### PR TITLE
Jit-compile for loops

### DIFF
--- a/app_fib_float.rb
+++ b/app_fib_float.rb
@@ -6,4 +6,4 @@ def fib(x)
   end
 end;
 
-puts fib 35.0
+puts fib 40.0

--- a/src/executor/bytecodegen.rs
+++ b/src/executor/bytecodegen.rs
@@ -25,7 +25,7 @@ impl std::ops::Add<InstId> for BcPcBase {
 
 impl BcPcBase {
     pub(super) fn new(func: &NormalFuncInfo) -> Self {
-        BcPcBase(&func.bytecode()[0] as *const _)
+        BcPcBase(func.bytecode_top())
     }
 }
 
@@ -34,7 +34,7 @@ impl BcPcBase {
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct BcPc(*const Bc);
+pub struct BcPc(pub(crate) *const Bc);
 
 impl std::ops::Sub<BcPcBase> for BcPc {
     type Output = usize;
@@ -1297,7 +1297,7 @@ impl IrContext {
         let mut locs = vec![];
         for (idx, (inst, loc)) in self.ir.iter().enumerate() {
             let op = match inst {
-                BcIr::LoopStart => BcOp1::LoopStart.to_bc(),
+                BcIr::LoopStart => BcOp1::LoopStart(0).to_bc(),
                 BcIr::LoopEnd => BcOp1::LoopEnd.to_bc(),
                 BcIr::Br(dst) => {
                     let dst = self.labels[*dst].unwrap().0 as i32;

--- a/src/executor/compiler/jitgen.rs
+++ b/src/executor/compiler/jitgen.rs
@@ -1,5 +1,4 @@
 use monoasm_macro::monoasm;
-use paste::paste;
 
 use super::*;
 
@@ -8,83 +7,25 @@ impl Codegen {
         &mut self,
         func: &NormalFuncInfo,
         store: &FnStore,
+        position: Option<usize>,
     ) -> DestLabel {
-        macro_rules! cmp {
-            ($lhs:ident, $rhs:ident, $ret:ident, $op:ident) => {{
-                paste! {
-                    let generic = self.jit.label();
-                    self.load_binary_args($lhs, $rhs);
-                    self.guard_rdi_rsi_fixnum(generic);
-                    self.[<cmp_ $op>](generic);
-                    monoasm! { self.jit,
-                        movq [rbp - (conv($ret))], rax;
-                    };
-                }
-            }};
-        }
-
-        macro_rules! cmp_ri {
-            ($lhs:ident, $rhs:ident, $ret:ident, $op:ident) => {{
-                paste! {
-                    let generic = self.jit.label();
-                    monoasm!(self.jit,
-                        movq rdi, [rbp - (conv($lhs))];
-                        movq rsi, (Value::new_integer($rhs as i64).get());
-                    );
-                    self.guard_rdi_fixnum(generic);
-                    self.[<cmp_ $op>](generic);
-                    monoasm! { self.jit,
-                        movq [rbp - (conv($ret))], rax;
-                    }
-                }
-            }};
-        }
-
-        macro_rules! cmp_o {
-            ($lhs:ident, $rhs:ident, $dest:ident, $op:ident, $cond: expr) => {{
-                paste! {
-                    let generic = self.jit.label();
-                    self.load_binary_args($lhs, $rhs);
-                    self.guard_rdi_rsi_fixnum(generic);
-                    self.[<cmp_opt_ $op>]($dest, generic, $cond);
-                }
-            }};
-        }
-
-        macro_rules! cmp_o_ri {
-            ($lhs:ident, $rhs:ident, $dest:ident, $op:ident, $cond: expr) => {{
-                paste! {
-                    let generic = self.jit.label();
-                    monoasm!(self.jit,
-                        movq rdi, [rbp - (conv($lhs))];
-                        movq rsi, (Value::new_integer($rhs as i64).get());
-                    );
-                    self.guard_rdi_fixnum(generic);
-                    self.[<cmp_opt_ $op>]($dest, generic, $cond);
-                }
-            }};
-        }
-
-        macro_rules! bin_ops {
-            ($op:ident, $ret:ident, $lhs:ident, $rhs:ident) => {{
-                paste! {
-                    let generic = self.jit.label();
-                    let exit = self.jit.label();
-                    self.guard_rdi_rsi_fixnum(generic);
-                    self.[<generic_ $op>](generic, exit, $ret);
-                }
-            }};
-        }
+        let start_pos = position.unwrap_or_default();
 
         #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
         {
             eprintln!(
-                "--> start compile: {} {:?}",
+                "--> start {} compile: {} {:?} position={}",
+                if position.is_some() {
+                    "partial"
+                } else {
+                    "whole"
+                },
                 match func.name() {
                     Some(name) => name,
                     None => "<unnamed>",
                 },
-                func.id
+                func.id,
+                start_pos
             );
         }
         #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
@@ -92,13 +33,18 @@ impl Codegen {
 
         let entry = self.jit.label();
         let mut labels = vec![];
-        for _ in func.bytecode() {
+        for _ in &func.bytecode()[start_pos..] {
             labels.push(self.jit.label());
         }
         self.jit.bind_label(entry);
-        self.prologue(func.total_reg_num());
+
+        if position.is_none() {
+            self.prologue(func.total_reg_num());
+        }
+
         let mut skip = false;
-        for (idx, op) in func.bytecode().iter().enumerate() {
+        let mut loop_count = 0;
+        for (idx, op) in func.bytecode()[start_pos..].iter().enumerate() {
             if skip {
                 skip = false;
                 continue;
@@ -106,7 +52,26 @@ impl Codegen {
             self.jit.bind_label(labels[idx]);
             let ops = BcOp1::from_bc(*op);
             match ops {
-                BcOp1::LoopStart | BcOp1::LoopEnd => {}
+                BcOp1::LoopStart(_) => {
+                    loop_count += 1;
+                }
+                BcOp1::LoopEnd => {
+                    assert_ne!(0, loop_count);
+                    loop_count -= 1;
+                    if position.is_some() && loop_count == 0 {
+                        let fetch = self.vm_fetch;
+                        let pc = func.get_bytecode_address(start_pos + idx + 1);
+
+                        #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
+                        eprintln!("    return pc:[{}] {:?}", start_pos + idx + 1, pc);
+
+                        monoasm!(self.jit,
+                            movq r13, (pc.0);
+                            jmp fetch;
+                        );
+                        break;
+                    }
+                }
                 BcOp1::Integer(ret, i) => {
                     let i = Value::int32(i).get();
                     monoasm!(self.jit,
@@ -254,11 +219,19 @@ impl Codegen {
                         BinOpK::Div => {
                             self.generic_op(ret, div_values as _);
                         }
-                        BinOpK::BitOr => bin_ops!(bit_or, ret, lhs, rhs),
-                        BinOpK::BitAnd => bin_ops!(bit_and, ret, lhs, rhs),
-                        BinOpK::BitXor => bin_ops!(bit_xor, ret, lhs, rhs),
-                        BinOpK::Shr => bin_ops!(shr, ret, lhs, rhs),
-                        BinOpK::Shl => bin_ops!(shl, ret, lhs, rhs),
+                        _ => {
+                            let generic = self.jit.label();
+                            let exit = self.jit.label();
+                            self.guard_rdi_rsi_fixnum(generic);
+                            match kind {
+                                BinOpK::BitOr => self.generic_bit_or(generic, exit, ret),
+                                BinOpK::BitAnd => self.generic_bit_and(generic, exit, ret),
+                                BinOpK::BitXor => self.generic_bit_xor(generic, exit, ret),
+                                BinOpK::Shr => self.generic_shr(generic, exit, ret),
+                                BinOpK::Shl => self.generic_shl(generic, exit, ret),
+                                _ => unimplemented!(),
+                            }
+                        }
                     }
                 }
 
@@ -341,28 +314,43 @@ impl Codegen {
                     }
                 }
 
-                BcOp1::Cmp(kind, ret, lhs, rhs, false) => match kind {
-                    CmpKind::Eq => cmp!(lhs, rhs, ret, eq),
-                    CmpKind::Ne => cmp!(lhs, rhs, ret, ne),
-                    CmpKind::Ge => cmp!(lhs, rhs, ret, ge),
-                    CmpKind::Gt => cmp!(lhs, rhs, ret, gt),
-                    CmpKind::Le => cmp!(lhs, rhs, ret, le),
-                    CmpKind::Lt => cmp!(lhs, rhs, ret, lt),
-                    _ => unimplemented!(),
-                },
+                BcOp1::Cmp(kind, ret, lhs, rhs, false) => {
+                    let generic = self.jit.label();
+                    self.load_binary_args(lhs, rhs);
+                    self.guard_rdi_rsi_fixnum(generic);
+                    match kind {
+                        CmpKind::Eq => self.cmp_eq(generic),
+                        CmpKind::Ne => self.cmp_ne(generic),
+                        CmpKind::Ge => self.cmp_ge(generic),
+                        CmpKind::Gt => self.cmp_gt(generic),
+                        CmpKind::Le => self.cmp_le(generic),
+                        CmpKind::Lt => self.cmp_lt(generic),
+                        _ => unimplemented!(),
+                    }
+                    self.store_rax(ret);
+                }
                 BcOp1::Cmp(_, _, _, _, true) | BcOp1::Cmpri(_, _, _, _, true) => {
                     assert!(self.opt_buf.is_none());
                     self.opt_buf = Some(ops);
                 }
-                BcOp1::Cmpri(kind, ret, lhs, rhs, false) => match kind {
-                    CmpKind::Eq => cmp_ri!(lhs, rhs, ret, eq),
-                    CmpKind::Ne => cmp_ri!(lhs, rhs, ret, ne),
-                    CmpKind::Ge => cmp_ri!(lhs, rhs, ret, ge),
-                    CmpKind::Gt => cmp_ri!(lhs, rhs, ret, gt),
-                    CmpKind::Le => cmp_ri!(lhs, rhs, ret, le),
-                    CmpKind::Lt => cmp_ri!(lhs, rhs, ret, lt),
-                    _ => unimplemented!(),
-                },
+                BcOp1::Cmpri(kind, ret, lhs, rhs, false) => {
+                    let generic = self.jit.label();
+                    monoasm!(self.jit,
+                        movq rdi, [rbp - (conv(lhs))];
+                        movq rsi, (Value::new_integer(rhs as i64).get());
+                    );
+                    self.guard_rdi_fixnum(generic);
+                    match kind {
+                        CmpKind::Eq => self.cmp_eq(generic),
+                        CmpKind::Ne => self.cmp_ne(generic),
+                        CmpKind::Ge => self.cmp_ge(generic),
+                        CmpKind::Gt => self.cmp_gt(generic),
+                        CmpKind::Le => self.cmp_le(generic),
+                        CmpKind::Lt => self.cmp_lt(generic),
+                        _ => unimplemented!(),
+                    }
+                    self.store_rax(ret);
+                }
                 BcOp1::Mov(dst, src) => {
                     monoasm!(self.jit,
                       movq rax, [rbp - (conv(src))];
@@ -441,54 +429,65 @@ impl Codegen {
                 }
                 BcOp1::CondBr(_, disp, true) => {
                     let dest = labels[(idx as i32 + 1 + disp) as usize];
-                    match std::mem::take(&mut self.opt_buf).unwrap() {
-                        BcOp1::Cmp(kind, _ret, lhs, rhs, true) => match kind {
-                            CmpKind::Eq => cmp_o!(lhs, rhs, dest, eq, true),
-                            CmpKind::Ne => cmp_o!(lhs, rhs, dest, ne, true),
-                            CmpKind::Ge => cmp_o!(lhs, rhs, dest, ge, true),
-                            CmpKind::Gt => cmp_o!(lhs, rhs, dest, gt, true),
-                            CmpKind::Le => cmp_o!(lhs, rhs, dest, le, true),
-                            CmpKind::Lt => cmp_o!(lhs, rhs, dest, lt, true),
-                            _ => unimplemented!(),
-                        },
-                        BcOp1::Cmpri(kind, _ret, lhs, rhs, true) => match kind {
-                            CmpKind::Eq => cmp_o_ri!(lhs, rhs, dest, eq, true),
-                            CmpKind::Ne => cmp_o_ri!(lhs, rhs, dest, ne, true),
-                            CmpKind::Ge => cmp_o_ri!(lhs, rhs, dest, ge, true),
-                            CmpKind::Gt => cmp_o_ri!(lhs, rhs, dest, gt, true),
-                            CmpKind::Le => cmp_o_ri!(lhs, rhs, dest, le, true),
-                            CmpKind::Lt => cmp_o_ri!(lhs, rhs, dest, lt, true),
-                            _ => unimplemented!(),
-                        },
+                    let generic = self.jit.label();
+                    let kind = match std::mem::take(&mut self.opt_buf).unwrap() {
+                        BcOp1::Cmp(kind, _ret, lhs, rhs, true) => {
+                            self.load_binary_args(lhs, rhs);
+                            self.guard_rdi_rsi_fixnum(generic);
+                            kind
+                        }
+                        BcOp1::Cmpri(kind, _ret, lhs, rhs, true) => {
+                            monoasm!(self.jit,
+                                movq rdi, [rbp - (conv(lhs))];
+                                movq rsi, (Value::new_integer(rhs as i64).get());
+                            );
+                            self.guard_rdi_fixnum(generic);
+                            kind
+                        }
                         _ => unreachable!(),
+                    };
+                    match kind {
+                        CmpKind::Eq => self.cmp_opt_eq(dest, generic, true),
+                        CmpKind::Ne => self.cmp_opt_ne(dest, generic, true),
+                        CmpKind::Ge => self.cmp_opt_ge(dest, generic, true),
+                        CmpKind::Gt => self.cmp_opt_gt(dest, generic, true),
+                        CmpKind::Le => self.cmp_opt_le(dest, generic, true),
+                        CmpKind::Lt => self.cmp_opt_lt(dest, generic, true),
+                        _ => unimplemented!(),
                     }
                 }
                 BcOp1::CondNotBr(_, disp, true) => {
                     let dest = labels[(idx as i32 + 1 + disp) as usize];
-                    match std::mem::take(&mut self.opt_buf).unwrap() {
-                        BcOp1::Cmp(kind, _ret, lhs, rhs, true) => match kind {
-                            CmpKind::Eq => cmp_o!(lhs, rhs, dest, eq, false),
-                            CmpKind::Ne => cmp_o!(lhs, rhs, dest, ne, false),
-                            CmpKind::Ge => cmp_o!(lhs, rhs, dest, ge, false),
-                            CmpKind::Gt => cmp_o!(lhs, rhs, dest, gt, false),
-                            CmpKind::Le => cmp_o!(lhs, rhs, dest, le, false),
-                            CmpKind::Lt => cmp_o!(lhs, rhs, dest, lt, false),
-                            _ => unimplemented!(),
-                        },
-                        BcOp1::Cmpri(kind, _ret, lhs, rhs, true) => match kind {
-                            CmpKind::Eq => cmp_o_ri!(lhs, rhs, dest, eq, false),
-                            CmpKind::Ne => cmp_o_ri!(lhs, rhs, dest, ne, false),
-                            CmpKind::Ge => cmp_o_ri!(lhs, rhs, dest, ge, false),
-                            CmpKind::Gt => cmp_o_ri!(lhs, rhs, dest, gt, false),
-                            CmpKind::Le => cmp_o_ri!(lhs, rhs, dest, le, false),
-                            CmpKind::Lt => cmp_o_ri!(lhs, rhs, dest, lt, false),
-                            _ => unimplemented!(),
-                        },
+                    let generic = self.jit.label();
+                    let kind = match std::mem::take(&mut self.opt_buf).unwrap() {
+                        BcOp1::Cmp(kind, _ret, lhs, rhs, true) => {
+                            self.load_binary_args(lhs, rhs);
+                            self.guard_rdi_rsi_fixnum(generic);
+                            kind
+                        }
+                        BcOp1::Cmpri(kind, _ret, lhs, rhs, true) => {
+                            monoasm!(self.jit,
+                                movq rdi, [rbp - (conv(lhs))];
+                                movq rsi, (Value::new_integer(rhs as i64).get());
+                            );
+                            self.guard_rdi_fixnum(generic);
+                            kind
+                        }
                         _ => unreachable!(),
+                    };
+                    match kind {
+                        CmpKind::Eq => self.cmp_opt_eq(dest, generic, false),
+                        CmpKind::Ne => self.cmp_opt_ne(dest, generic, false),
+                        CmpKind::Ge => self.cmp_opt_ge(dest, generic, false),
+                        CmpKind::Gt => self.cmp_opt_gt(dest, generic, false),
+                        CmpKind::Le => self.cmp_opt_le(dest, generic, false),
+                        CmpKind::Lt => self.cmp_opt_lt(dest, generic, false),
+                        _ => unimplemented!(),
                     }
                 }
             }
         }
+
         self.jit.finalize();
 
         #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
@@ -518,8 +517,7 @@ impl Codegen {
         monoasm!(self.jit,
             pushq rbp;
             movq rbp, rsp;
-            movq rax, (regs);
-            subq rax, 1;
+            movq rax, (regs - 1);
             subq rax, rdi;
             jeq  loop_exit;
             lea  rcx, [rsp - ((regs as i32) * 8 + 16)];

--- a/src/executor/compiler/vmgen.rs
+++ b/src/executor/compiler/vmgen.rs
@@ -207,6 +207,8 @@ impl Codegen {
         self.dispatch[11] = self.vm_store_const();
         self.dispatch[12] = self.vm_condbr(branch);
         self.dispatch[13] = self.vm_condnotbr(branch);
+        self.dispatch[14] = self.vm_loop_start();
+        self.dispatch[15] = self.vm_loop_end();
 
         self.dispatch[129] = self.vm_neg();
         self.dispatch[134] = self.vm_eqrr();
@@ -581,6 +583,23 @@ impl Codegen {
         );
         self.jit.select(0);
 
+        label
+    }
+
+    fn vm_loop_start(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        monoasm! { self.jit,
+            addl [r13 - 8], 1;
+        };
+        self.fetch_and_dispatch();
+        label
+    }
+
+    fn vm_loop_end(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        monoasm! { self.jit,
+        };
+        self.fetch_and_dispatch();
         label
     }
 

--- a/src/executor/globals/functions.rs
+++ b/src/executor/globals/functions.rs
@@ -674,6 +674,8 @@ impl NormalFuncInfo {
                     0 => eprintln!("_ = concat(%{}; {})", args, len),
                     ret => eprintln!("%{:?} = concat(%{}; {})", ret, args, len),
                 },
+                BcOp1::LoopStart => eprintln!("loop_start counter={}", Bc2::from_bc_counter(*inst)),
+                BcOp1::LoopEnd => eprintln!("loop_end"),
             }
         }
         eprintln!("------------------------------------");

--- a/src/executor/globals/functions.rs
+++ b/src/executor/globals/functions.rs
@@ -225,7 +225,7 @@ impl FnStore {
 
         let regs = info.total_reg_num();
         std::mem::swap(&mut info, self[func_id].as_normal_mut());
-        self[func_id].data.pc = BcPcBase::new(self[func_id].as_normal()) + 0;
+        self[func_id].data.pc = self[func_id].as_normal().get_bytecode_address(0);
         self[func_id].data.set_reg_num(regs as i64);
         Ok(())
     }
@@ -479,9 +479,14 @@ impl NormalFuncInfo {
         info
     }
 
-    /// set bytecode..
+    /// set bytecode.
     pub(crate) fn set_bytecode(&mut self, bc: Vec<Bc>) {
         self.bytecode = bc.into_boxed_slice();
+    }
+
+    /// get bytecode address.
+    pub(crate) fn get_bytecode_address(&self, index: usize) -> BcPc {
+        BcPcBase::new(self) + index
     }
 
     /// get a number of registers.
@@ -489,8 +494,8 @@ impl NormalFuncInfo {
         1 + self.locals.len() + self.temp_num as usize
     }
 
-    /// get bytecode.
-    #[cfg(feature = "emit-asm")]
+    /// get name.
+    #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
     pub(crate) fn name(&self) -> &Option<String> {
         &self.name
     }
@@ -498,6 +503,11 @@ impl NormalFuncInfo {
     /// get bytecode.
     pub(crate) fn bytecode(&self) -> &[Bc] {
         &self.bytecode
+    }
+
+    /// get bytecode address.
+    pub(crate) fn bytecode_top(&self) -> *const Bc {
+        self.bytecode.as_ptr()
     }
 
     /// get the next register id.
@@ -674,7 +684,11 @@ impl NormalFuncInfo {
                     0 => eprintln!("_ = concat(%{}; {})", args, len),
                     ret => eprintln!("%{:?} = concat(%{}; {})", ret, args, len),
                 },
-                BcOp1::LoopStart => eprintln!("loop_start counter={}", Bc2::from_bc_counter(*inst)),
+                BcOp1::LoopStart(count) => eprintln!(
+                    "loop_start counter={} jit-addr={:016x}",
+                    count,
+                    Bc2::from_jit_addr(*inst)
+                ),
                 BcOp1::LoopEnd => eprintln!("loop_end"),
             }
         }

--- a/src/executor/inst.rs
+++ b/src/executor/inst.rs
@@ -60,6 +60,8 @@ pub(super) enum BcIr {
     InlineCache,
     MethodDef(IdentId, FuncId),
     ConcatStr(Option<BcReg>, BcTemp, usize), // (ret, args, args_len)
+    LoopStart,
+    LoopEnd,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -109,6 +111,10 @@ impl Bc2 {
     pub(crate) fn from_bc_classid(bcop: Bc) -> ClassId {
         ClassId::new(bcop.op2.0 as u32)
     }
+
+    pub(crate) fn from_bc_counter(bcop: Bc) -> u32 {
+        bcop.op2.0 as u32
+    }
 }
 
 ///
@@ -154,6 +160,8 @@ pub(super) enum BcOp1 {
     MethodDef(MethodDefId),
     /// concatenate strings(ret, args, args_len)
     ConcatStr(u16, u16, u16),
+    LoopStart,
+    LoopEnd,
 }
 
 fn enc_wl(opcode: u16, op1: u16, op2: u32) -> u64 {
@@ -210,6 +218,8 @@ impl BcOp1 {
             Symbol(op1, op2) => enc_wl(9, *op1, op2.get()),
             LoadConst(op1, op2) => enc_wl(10, *op1, op2.get()),
             StoreConst(op1, op2) => enc_wl(11, *op1, op2.get()),
+            LoopStart => enc_l(14, 0),
+            LoopEnd => enc_l(15, 0),
 
             Neg(op1, op2) => enc_ww(129, *op1, *op2),
             BinOp(kind, op1, op2, op3) => {
@@ -270,6 +280,8 @@ impl BcOp1 {
                 11 => Self::StoreConst(op1, IdentId::from(op2)),
                 12 => Self::CondBr(op1, op2 as i32, true),
                 13 => Self::CondNotBr(op1, op2 as i32, true),
+                14 => Self::LoopStart,
+                15 => Self::LoopEnd,
                 _ => unreachable!(),
             }
         } else {

--- a/src/executor/interp.rs
+++ b/src/executor/interp.rs
@@ -16,9 +16,9 @@ impl Interp {
     }
 
     /// Execute top level method.
-    pub fn eval_toplevel(globals: &mut Globals, jit_flag: bool) -> Result<Value> {
+    pub fn eval_toplevel(globals: &mut Globals, aot_flag: bool) -> Result<Value> {
         let mut eval = Self::new();
-        if !jit_flag {
+        if !aot_flag {
             eval.codegen.precompile(&mut globals.func)
         };
         let main_id = globals.get_main_func();

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
     }
 }
 
-fn exec(code: &str, jit: bool, warning: u8, path: &std::path::Path) {
+fn exec(code: &str, aot_flag: bool, warning: u8, path: &std::path::Path) {
     let mut globals = Globals::new(warning);
     match globals.compile_script(code.to_string(), path) {
         Ok(_) => {}
@@ -104,10 +104,10 @@ fn exec(code: &str, jit: bool, warning: u8, path: &std::path::Path) {
         }
     };
 
-    match Interp::eval_toplevel(&mut globals, jit) {
+    match Interp::eval_toplevel(&mut globals, aot_flag) {
         Ok(_val) => {
             #[cfg(debug_assertions)]
-            eprintln!("jit({:?}) {:?}", jit, _val)
+            eprintln!("jit({:?}) {:?}", aot_flag, _val)
         }
         Err(err) => {
             eprintln!("{:?}", err.kind);
@@ -116,8 +116,8 @@ fn exec(code: &str, jit: bool, warning: u8, path: &std::path::Path) {
     };
 }
 
-fn repl_exec(code: &str, jit_flag: bool, warning: u8) -> Result<(), MonorubyErr> {
-    if !jit_flag {
+fn repl_exec(code: &str, aot_flag: bool, warning: u8) -> Result<(), MonorubyErr> {
+    if !aot_flag {
         let mut globals = Globals::new(warning);
         match globals.compile_script(code.to_string(), std::path::Path::new("REPL")) {
             Ok(_) => {}
@@ -158,9 +158,9 @@ fn repl_exec(code: &str, jit_flag: bool, warning: u8) -> Result<(), MonorubyErr>
     }
 }
 
-fn run_repl(code: &str, all_codes: &mut Vec<String>, jit_flag: bool, warning: u8) {
+fn run_repl(code: &str, all_codes: &mut Vec<String>, aot_flag: bool, warning: u8) {
     all_codes.push(code.to_string());
-    if let Err(_) = repl_exec(&all_codes.join(";"), jit_flag, warning) {
+    if let Err(_) = repl_exec(&all_codes.join(";"), aot_flag, warning) {
         all_codes.pop();
     };
 }
@@ -206,7 +206,7 @@ pub fn run_test_main(globals: &mut Globals, code: &str) -> Value {
     eprintln!("jit: {:?}", jit_val);
 
     assert!(Value::eq(interp_val, jit_val));
-    interp_val
+    jit_val
 }
 
 pub fn run_test_error(code: &str) {

--- a/tarai.rb
+++ b/tarai.rb
@@ -6,4 +6,4 @@ def tarai(x,y,z)
   end
 end
 
-puts tarai(12, 6, 4)
+puts tarai(16, 6, 4)

--- a/tarai_float.rb
+++ b/tarai_float.rb
@@ -6,4 +6,4 @@ def tarai(x,y,z)
   end
 end
 
-puts tarai(12.0, 6.0, 4.0)
+puts tarai(16.0, 6.0, 4.0)

--- a/test.rb
+++ b/test.rb
@@ -1,9 +1,15 @@
-def f(x)
-  if x < 2
-      dump
-      1
-  else
-      x*f(x-1)
-  end
+def f
+  1
 end
-f(5)
+a = 0
+i = 0
+while i < 1000000
+  a = a + f()
+  if i == 500
+    def f
+      0
+    end
+  end
+  i = i + 1
+end
+a 


### PR DESCRIPTION
Enable JIT compilation of loops.

New bytecode instructions, LoopStart and LoopEnd are introduced.
These instructions are markers for VM, and VM counts how many times the loop was executed, and write the count into the bytecode.
When the loop counts reached to a preset number, the JIT compiler is invoked by VM, and just jump to a generated machine code.