### PR TITLE
Impl. attribute accessor

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cargo build --release
-cd benchmark && benchmark-driver quick_sort.yaml vm_ivar.yaml app_fib.rb tarai.rb  --rbenv '3.2.0-dev; 3.2.0-dev --yjit; 3.2.0-dev --mjit' -e ../target/release/monoruby --repeat-count 3
+cd benchmark && benchmark-driver quick_sort.yaml vm_ivar.yaml vm_attr_ivar.yaml vm_attr_ivar_set.yaml app_fib.rb tarai.rb  --rbenv '3.2.0-dev; 3.2.0-dev --yjit; 3.2.0-dev --mjit' -e ../target/release/monoruby --repeat-count 3

--- a/benchmark/vm_attr_ivar.yaml
+++ b/benchmark/vm_attr_ivar.yaml
@@ -1,0 +1,14 @@
+prelude: |
+  class C
+    attr_reader :a, :b
+    def initialize
+      @a = nil
+      @b = nil
+    end
+  end
+  obj = C.new
+benchmark:
+  vm_attr_ivar: |
+    j = obj.a
+    k = obj.b
+loop_count: 30000000

--- a/benchmark/vm_attr_ivar_set.yaml
+++ b/benchmark/vm_attr_ivar_set.yaml
@@ -1,0 +1,14 @@
+prelude: |
+  class C
+    attr_accessor :a, :b
+    def initialize
+      @a = nil
+      @b = nil
+    end
+  end
+  obj = C.new
+benchmark:
+  vm_attr_ivar_set: |
+    obj.a = 1
+    obj.b = 2
+loop_count: 30000000

--- a/ivar.sh
+++ b/ivar.sh
@@ -1,2 +1,2 @@
 cargo build --release
-benchmark-driver benchmark/vm_ivar.yaml benchmark/vm_attr_ivar.yaml --rbenv '3.2.0-dev; 3.2.0-dev --yjit' -e 'target/release/monoruby' -e 'target/release/monoruby --no-jit' --repeat-count 3
+benchmark-driver benchmark/vm_ivar.yaml benchmark/vm_attr_ivar.yaml benchmark/vm_attr_ivar_set.yaml --rbenv '3.2.0-dev; 3.2.0-dev --yjit' -e 'target/release/monoruby' -e 'target/release/monoruby --no-jit' --repeat-count 3

--- a/ivar.sh
+++ b/ivar.sh
@@ -1,2 +1,2 @@
 cargo build --release
-benchmark-driver vm_ivar.yaml --rbenv '3.2.0-dev; 3.2.0-dev --yjit' -e 'target/release/monoruby' -e 'target/release/monoruby --no-jit' --repeat-count 3
+benchmark-driver benchmark/vm_ivar.yaml benchmark/vm_attr_ivar.yaml --rbenv '3.2.0-dev; 3.2.0-dev --yjit' -e 'target/release/monoruby' -e 'target/release/monoruby --no-jit' --repeat-count 3

--- a/src/executor/bytecodegen.rs
+++ b/src/executor/bytecodegen.rs
@@ -877,7 +877,7 @@ impl IrContext {
                     }
                     let temp = info.temp;
                     let lhs = self.eval_lvalue(ctx, info, id_store, &lhs)?;
-                    let src = self.push_expr(ctx, info, id_store, rhs)?;
+                    let src = self.gen_expr_reg(ctx, info, id_store, rhs)?;
                     self.gen_assign(src, lhs, loc);
                     info.temp = temp;
                     let res = info.push().into();

--- a/src/executor/compiler/jitgen.rs
+++ b/src/executor/compiler/jitgen.rs
@@ -702,10 +702,8 @@ impl Codegen {
     fn jit_load_ivar(&mut self, id: IdentId, ret: SlotId, xmm_using: UsingXmm) {
         self.xmm_save(&xmm_using);
         monoasm!(self.jit,
-          movq rdx, [rbp - 16];  // base: Value
-          movq rcx, (id.get());  // id: IdentId
-          movq rdi, rbx;  // &mut Interp
-          movq rsi, r12;  // &mut Globals
+          movq rdi, [rbp - 16];  // base: Value
+          movq rsi, (id.get());  // id: IdentId
           movq rax, (get_instance_var);
           call rax;
         );
@@ -716,11 +714,9 @@ impl Codegen {
     fn jit_store_ivar(&mut self, id: IdentId, src: SlotId, xmm_using: UsingXmm) {
         self.xmm_save(&xmm_using);
         monoasm!(self.jit,
-          movq rdx, [rbp - 16];  // base: Value
-          movq rcx, (id.get());  // id: IdentId
-          movq r8, [rbp - (conv(src))];   // val: Value
-          movq rdi, rbx;  // &mut Interp
-          movq rsi, r12;  // &mut Globals
+          movq rdi, [rbp - 16];  // base: Value
+          movq rsi, (id.get());  // id: IdentId
+          movq rdx, [rbp - (conv(src))];   // val: Value
           movq rax, (set_instance_var);
           call rax;
         );

--- a/src/executor/compiler/vmgen.rs
+++ b/src/executor/compiler/vmgen.rs
@@ -893,10 +893,8 @@ impl Codegen {
         let label = self.jit.get_current_address();
         self.vm_get_addr_r15();
         monoasm! { self.jit,
-            movq rdx, [rbp - 16];  // base: Value
-            movq rcx, rdi; // name: IdentId
-            movq rdi, rbx;  // &mut Interp
-            movq rsi, r12;  // &mut Globals
+            movq rsi, rdi; // name: IdentId
+            movq rdi, [rbp - 16];  // base: Value
             movq rax, (get_instance_var);
             call rax;
         };
@@ -909,11 +907,9 @@ impl Codegen {
         let label = self.jit.get_current_address();
         self.vm_get_addr_r15();
         monoasm! { self.jit,
-            movq rdx, [rbp - 16];  // base: Value
-            movq rcx, rdi;  // name: IdentId
-            movq r8, [r15];     // val: Value
-            movq rdi, rbx;  // &mut Interp
-            movq rsi, r12;  // &mut Globals
+            movq rsi, rdi;  // name: IdentId
+            movq rdi, [rbp - 16];  // base: Value
+            movq rdx, [r15];     // val: Value
             movq rax, (set_instance_var);
             call rax;
         };

--- a/src/executor/globals.rs
+++ b/src/executor/globals.rs
@@ -469,12 +469,23 @@ impl Globals {
     ///
     /// Define attribute reader for *class_id* and *ivar_name*.
     ///
-    pub fn define_attr_reader(&mut self, class_id: ClassId, ivar_name: String) -> FuncId {
+    pub fn define_attr_reader(&mut self, class_id: ClassId, ivar_name: String) -> IdentId {
         let ivar_id = self.get_ident_id(&format!("@{}", ivar_name));
         let method_name = self.get_ident_id(&ivar_name);
         let func_id = self.func.add_attr_reader(ivar_name, ivar_id);
         self.class.add_method(class_id, method_name, func_id);
-        func_id
+        method_name
+    }
+
+    ///
+    /// Define attribute writer for *class_id* and *ivar_name*.
+    ///
+    pub fn define_attr_writer(&mut self, class_id: ClassId, ivar_name: String) -> IdentId {
+        let ivar_id = self.get_ident_id(&format!("@{}", ivar_name));
+        let method_name = self.get_ident_id(&format!("{}=", ivar_name));
+        let func_id = self.func.add_attr_writer(ivar_name, ivar_id);
+        self.class.add_method(class_id, method_name, func_id);
+        method_name
     }
 
     pub fn compile_script(&mut self, code: String, path: impl Into<PathBuf>) -> Result<FuncId> {

--- a/src/executor/globals.rs
+++ b/src/executor/globals.rs
@@ -105,6 +105,16 @@ impl Globals {
     }
 
     ///
+    /// Set TypeError with message "*name* is not a class".
+    ///
+    pub fn err_is_not_symbol_nor_string(&mut self, val: Value) {
+        self.set_error(MonorubyErr::typeerr(format!(
+            "{} is not a symbol nor a string",
+            self.val_tos(val)
+        )));
+    }
+
+    ///
     /// Set IndexError with message "index *actual* too small for array; minimum: *minimum*".
     ///
     pub fn err_index_too_small(&mut self, actual: i64, minimum: i64) {
@@ -453,6 +463,17 @@ impl Globals {
         let func_id = self.func.add_builtin_func(name.to_string(), address, arity);
         let name_id = self.get_ident_id(name);
         self.class.add_method(class_id, name_id, func_id);
+        func_id
+    }
+
+    ///
+    /// Define attribute reader for *class_id* and *ivar_name*.
+    ///
+    pub fn define_attr_reader(&mut self, class_id: ClassId, ivar_name: String) -> FuncId {
+        let ivar_id = self.get_ident_id(&format!("@{}", ivar_name));
+        let method_name = self.get_ident_id(&ivar_name);
+        let func_id = self.func.add_attr_reader(ivar_name, ivar_id);
+        self.class.add_method(class_id, method_name, func_id);
         func_id
     }
 

--- a/src/executor/globals/functions.rs
+++ b/src/executor/globals/functions.rs
@@ -77,6 +77,12 @@ impl Funcs {
         self.0.push(FuncInfo::new_attr_reader(id, name, ivar_name));
         id
     }
+
+    fn add_attr_writer(&mut self, name: String, ivar_name: IdentId) -> FuncId {
+        let id = self.next_func_id();
+        self.0.push(FuncInfo::new_attr_writer(id, name, ivar_name));
+        id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -226,6 +232,10 @@ impl FnStore {
     pub(super) fn add_attr_reader(&mut self, name: String, ivar_name: IdentId) -> FuncId {
         self.functions.add_attr_reader(name, ivar_name)
     }
+
+    pub(super) fn add_attr_writer(&mut self, name: String, ivar_name: IdentId) -> FuncId {
+        self.functions.add_attr_writer(name, ivar_name)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -233,6 +243,7 @@ pub(crate) enum FuncKind {
     Normal(RubyFuncInfo),
     Builtin { abs_address: u64 },
     AttrReader { ivar_name: IdentId },
+    AttrWriter { ivar_name: IdentId },
 }
 
 impl std::default::Default for FuncKind {
@@ -446,6 +457,19 @@ impl FuncInfo {
                 meta: Meta::native(func_id, 0),
             },
             kind: FuncKind::AttrReader { ivar_name },
+        }
+    }
+
+    fn new_attr_writer(func_id: FuncId, name: String, ivar_name: IdentId) -> Self {
+        Self {
+            name: Some(name),
+            arity: 1,
+            data: FuncData {
+                codeptr: None,
+                pc: BcPc::default(),
+                meta: Meta::native(func_id, 1),
+            },
+            kind: FuncKind::AttrWriter { ivar_name },
         }
     }
 

--- a/src/executor/inst.rs
+++ b/src/executor/inst.rs
@@ -94,7 +94,7 @@ pub(super) enum BcIr {
     Ret(BcReg),
     Mov(BcReg, BcReg),                  // dst, offset
     MethodCall(Option<BcReg>, IdentId), // (ret, id)
-    MethodArgs(BcReg, BcTemp, usize),   // (recv, args, args_len)
+    MethodArgs(BcReg, BcReg, usize),    // (recv, args, args_len)
     InlineCache,
     MethodDef(IdentId, FuncId),
     ClassDef(Option<BcReg>, IdentId, FuncId),

--- a/test.rb
+++ b/test.rb
@@ -1,8 +1,10 @@
 class A
-  class B
-    def f
-      42
-    end
+  attr_reader "v"
+  def f(x)
+    @v=x
   end
 end
-puts A::B.new.f
+a = A.new
+a.f(42)
+#puts A.instance_methods
+puts a.v


### PR DESCRIPTION
Implement attribute accessor.

- Support Module#attr_accessor, Module#attr_reader, Module#attr_writer.
- Benchmark
```
                      3.2.0-dev   3.2.0-dev --yjit   3.2.0-dev --mjit  ../target/release/monoruby 
             vm_ivar   164.809M           163.787M           233.520M                    182.145M i/s -     30.000M times in 0.182029s 0.183165s 0.128468s 0.164704s
        vm_attr_ivar    61.475M            60.603M            70.191M                    124.755M i/s -     30.000M times in 0.488004s 0.495022s 0.427406s 0.240470s
    vm_attr_ivar_set    66.998M            65.070M            77.188M                     77.255M i/s -     30.000M times in 0.447774s 0.461042s 0.388659s 0.388322s
```