### PR TITLE
Change the type of BuiltinFn.

### DIFF
--- a/doc/method_args.md
+++ b/doc/method_args.md
@@ -12,29 +12,36 @@ caller から渡される実引数の数。
 
 ## Caller
 
-- Splat 引数を展開
-- 呼び出し先がブロックの場合、引数が１個の Array であれば展開。(vm_handle_arguments)
-- req, opt, rest引数を処理 (vm_handle_arguments)
-- 余ったreqは nil 、余ったoptは None で埋める（callee 側で引数の個数をチェック） (vm_handle_arguments)
-- keyword 引数の割り当て (vm_handle_arguments)
-- 実引数の個数 passed_args を callee へ渡す
-
-### Callerの最適化
-
-- arg_num >= reqopt_num かつ no_rest かつ no_keyword なら vm_handle_arguments を呼ばなくて済む。
+- Splat 引数を展開（set_arguments(), jit_set_arguments()）
+- 呼び出し先がブロックの場合(InitBlock)、引数が１個の Array であれば展開。(block_arg_expand()/single_arg_expand())
+- req, opt, rest, keyword引数を処理 (vm_handle_arguments())
+  - 余ったreqは nil 、余ったoptは None で埋める
+  - 引数の位置個数をチェックして不正ならエラーを返す
+  - keyword 引数の割り当て
+- 実引数の個数 passed_args を rdx に入れて callee へ渡す
 
 ## Callee
 
-### prologue での処理 (interpreter: INIT_METHOD/ INIT_BLOCK)
+### prologue での処理 (InitMethod / InitBlock)
 
-- [METHOD] passed_args < required, (reqopt_num < passed_args) && no_rest の場合はエラーを返す
-- block 引数の処理
-- 引数以外のスロットを nil で初期化。
-- 必要な情報： req_num, req_opt_num, block_pos, args_num
+- スタックの調整
+- block 引数がある場合はスロットへ入れる
+- 引数以外のローカル変数・一時変数スロットを nil で初期化。
 
 ### bytecode での処理 (bytecode.rs/compile_func())
 
 - 分割代入がある場合は分割されるスロットを再帰的に展開（余った子引数は nil で埋める）
+
+```text
+        +--------------+
+        |   +----------+----+
+  a , ( b , c ) , d    |    |
+  |     |   |     |    |    |
+  v     +-+-+     v    v    v
+  0       1       2    3    4
+
+```
+
 - opt引数がある場合は実引数が引き渡されていなければ初期化
 
 ```text

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -16,8 +16,8 @@ pub use globals::*;
 use inst::*;
 use op::*;
 
-type Result<T> = std::result::Result<T, MonorubyErr>;
-pub type BuiltinFn = extern "C" fn(&mut Executor, &mut Globals, LFP, Arg, usize) -> Option<Value>;
+pub type Result<T> = std::result::Result<T, MonorubyErr>;
+pub type BuiltinFn = fn(&mut Executor, &mut Globals, LFP, Arg, usize) -> Result<Value>;
 
 const BP_PREV_CFP: i64 = 8;
 const BP_LFP: i64 = 16;
@@ -321,7 +321,7 @@ impl Executor {
     ///
     /// Find Constant in current class context.
     ///
-    fn find_constant(&self, globals: &mut Globals, site_id: ConstSiteId) -> Option<Value> {
+    fn find_constant(&self, globals: &mut Globals, site_id: ConstSiteId) -> Result<Value> {
         let current_func = self.method_func_id();
         globals.find_constant(site_id, current_func)
     }
@@ -360,15 +360,18 @@ impl Executor {
         globals: &mut Globals,
         data: BlockData,
         args: &[Value],
-    ) -> Option<Value> {
-        (globals.codegen.block_invoker)(
+    ) -> Result<Value> {
+        match (globals.codegen.block_invoker)(
             self,
             globals,
             &data as _,
             Value::nil(),
             args.as_ptr(),
             args.len(),
-        )
+        ) {
+            Some(val) => Ok(val),
+            None => Err(globals.take_error().unwrap()),
+        }
     }
 
     pub fn invoke_block_iter1(
@@ -376,12 +379,12 @@ impl Executor {
         globals: &mut Globals,
         block_handler: BlockHandler,
         iter: impl Iterator<Item = Value>,
-    ) -> Option<()> {
+    ) -> Result<()> {
         let block_data = self.get_block_data(globals, block_handler);
         for val in iter {
             self.invoke_block(globals, block_data.clone(), &[val])?;
         }
-        Some(())
+        Ok(())
     }
 
     ///
@@ -392,7 +395,7 @@ impl Executor {
         globals: &mut Globals,
         block_data: &BlockData,
         args: &[Value],
-    ) -> Option<Value> {
+    ) -> Result<Value> {
         (globals.codegen.block_invoker)(
             self,
             globals,
@@ -401,6 +404,7 @@ impl Executor {
             args.as_ptr(),
             args.len(),
         )
+        .ok_or_else(|| globals.take_error().unwrap())
     }
 
     fn invoke_method2_if_exists(
@@ -410,11 +414,11 @@ impl Executor {
         receiver: Value,
         args: Arg,
         len: usize,
-    ) -> Option<Value> {
+    ) -> Result<Value> {
         if let Some(func_id) = globals.check_method(receiver, method) {
             self.invoke_func2(globals, func_id, receiver, args, len)
         } else {
-            Some(Value::nil())
+            Ok(Value::nil())
         }
     }
 
@@ -428,9 +432,46 @@ impl Executor {
         receiver: Value,
         args: Arg,
         len: usize,
-    ) -> Option<Value> {
+    ) -> Result<Value> {
         let data = globals.compile_on_demand(func_id) as *const _;
         (globals.codegen.method_invoker2)(self, globals, data, receiver, args, len)
+            .ok_or_else(|| globals.take_error().unwrap())
+    }
+
+    fn define_class(
+        &mut self,
+        globals: &mut Globals,
+        name: IdentId,
+        superclass: Option<Value>,
+        is_module: u32,
+    ) -> Result<Value> {
+        let parent = self.context_class_id();
+        let self_val = match globals.get_constant(parent, name) {
+            Some(val) => {
+                val.expect_class_or_module(globals)?;
+                if let Some(superclass) = superclass {
+                    assert!(is_module != 1);
+                    let superclass_id = superclass.expect_class(globals)?;
+                    if Some(superclass_id) != val.as_class().superclass_id() {
+                        return Err(MonorubyErr::superclass_mismatch(name));
+                    }
+                }
+                val.as_class()
+            }
+            None => {
+                let superclass = match superclass {
+                    Some(superclass) => {
+                        assert!(is_module != 1);
+                        superclass.expect_class(globals)?;
+                        superclass.as_class()
+                    }
+                    None => OBJECT_CLASS.get_obj(globals),
+                };
+                globals.define_class(name, Some(superclass), parent, is_module == 1)
+            }
+        };
+        self.push_class_context(self_val.class_id());
+        Ok(self_val.as_val())
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -647,9 +647,6 @@ impl BcPc {
             TraceIr::InitMethod(info) => {
                 format!("init_method {info:?}")
             }
-            TraceIr::InitBlock(info) => {
-                format!("init_block {info:?}")
-            }
             TraceIr::CheckLocal(local, disp) => {
                 format!("check_local({:?}) =>:{:05}", local, i as i32 + 1 + disp)
             }

--- a/src/executor/builtins/class.rs
+++ b/src/executor/builtins/class.rs
@@ -16,14 +16,14 @@ pub(super) fn init(globals: &mut Globals) {
 /// - [NOT SUPPORTED] new(superclass = Object) {|klass| ... } -> Class
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Class/s/new.html]
-extern "C" fn class_new(
+fn class_new(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
-    globals.check_number_of_arguments(len, 0..=1)?;
+) -> Result<Value> {
+    Globals::check_number_of_arguments(len, 0..=1)?;
     let superclass = if len == 0 {
         None
     } else {
@@ -31,7 +31,7 @@ extern "C" fn class_new(
         Some(arg[0].as_class())
     };
     let obj = globals.new_unnamed_class(superclass);
-    Some(obj)
+    Ok(obj)
 }
 
 /// ### Class#new
@@ -40,47 +40,41 @@ extern "C" fn class_new(
 /// [https://docs.ruby-lang.org/ja/latest/method/Class/i/new.html]
 ///
 /// !! We must call Object#initialize.
-extern "C" fn new(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: LFP,
-    arg: Arg,
-    len: usize,
-) -> Option<Value> {
+fn new(vm: &mut Executor, globals: &mut Globals, lfp: LFP, arg: Arg, len: usize) -> Result<Value> {
     let obj = allocate(vm, globals, lfp, arg, 0)?;
     vm.invoke_method2_if_exists(globals, IdentId::INITIALIZE, obj, arg, dbg!(len))?;
-    Some(obj)
+    Ok(obj)
 }
 
 /// ### Class#superclass
 /// - superclass -> Class | nil
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Class/i/superclass.html]
-extern "C" fn superclass(
+fn superclass(
     _vm: &mut Executor,
     _globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class = lfp.self_val().as_class();
-    Some(class.superclass_value().unwrap_or_default())
+    Ok(class.superclass_value().unwrap_or_default())
 }
 
 /// ### Class#allocate
 /// - allocate -> object
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
-extern "C" fn allocate(
+fn allocate(
     _vm: &mut Executor,
     _globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class_id = lfp.self_val().as_class().class_id();
     let obj = Value::new_object(class_id);
-    Some(obj)
+    Ok(obj)
 }
 
 #[cfg(test)]

--- a/src/executor/builtins/float.rs
+++ b/src/executor/builtins/float.rs
@@ -9,25 +9,25 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(FLOAT_CLASS, "to_f", tof, 0);
 }
 
-extern "C" fn tof(
+fn tof(
     _vm: &mut Executor,
     _globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
-    Some(lfp.self_val())
+) -> Result<Value> {
+    Ok(lfp.self_val())
 }
 
-extern "C" fn toi(
+fn toi(
     _vm: &mut Executor,
     _globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     match lfp.self_val().unpack() {
-        RV::Float(f) => Some(Value::new_integer(f.trunc() as i64)),
+        RV::Float(f) => Ok(Value::new_integer(f.trunc() as i64)),
         _ => unreachable!(),
     }
 }

--- a/src/executor/builtins/io.rs
+++ b/src/executor/builtins/io.rs
@@ -10,24 +10,24 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_CLASS, "sync=", assign_sync, 1);
 }
 
-extern "C" fn sync(
+fn sync(
     _vm: &mut Executor,
     _globals: &mut Globals,
     _lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
-    Some(Value::bool(false))
+) -> Result<Value> {
+    Ok(Value::bool(false))
 }
 
-extern "C" fn assign_sync(
+fn assign_sync(
     _vm: &mut Executor,
     _globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
-    Some(arg[0])
+) -> Result<Value> {
+    Ok(arg[0])
 }
 
 #[cfg(test)]

--- a/src/executor/builtins/math.rs
+++ b/src/executor/builtins/math.rs
@@ -16,72 +16,69 @@ pub(super) fn init(globals: &mut Globals, class_id: ClassId) {
 /// - sqrt(x) -> Float
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/sqrt.html]
-extern "C" fn sqrt(
+fn sqrt(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let arg0 = arg[0];
     let f = match arg0.unpack() {
         RV::Float(f) => f,
         RV::Integer(i) => i as f64,
         RV::BigInt(b) => b.to_f64().unwrap(),
         _ => {
-            globals.err_cant_conert_into_float(arg0);
-            return None;
+            return Err(MonorubyErr::cant_convert_into_float(globals, arg0));
         }
     };
-    Some(Value::new_float(f.sqrt()))
+    Ok(Value::new_float(f.sqrt()))
 }
 
 /// ### Math.#sin
 /// - sin(x) -> Float
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/sin.html]
-extern "C" fn sin(
+fn sin(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let arg0 = arg[0];
     let f = match arg0.unpack() {
         RV::Float(f) => f,
         RV::Integer(i) => i as f64,
         RV::BigInt(b) => b.to_f64().unwrap(),
         _ => {
-            globals.err_cant_conert_into_float(arg0);
-            return None;
+            return Err(MonorubyErr::cant_convert_into_float(globals, arg0));
         }
     };
-    Some(Value::new_float(f.sin()))
+    Ok(Value::new_float(f.sin()))
 }
 
 /// ### Math.#cos
 /// - cos(x) -> Float
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/cos.html]
-extern "C" fn cos(
+fn cos(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let arg0 = arg[0];
     let f = match arg0.unpack() {
         RV::Float(f) => f,
         RV::Integer(i) => i as f64,
         RV::BigInt(b) => b.to_f64().unwrap(),
         _ => {
-            globals.err_cant_conert_into_float(arg0);
-            return None;
+            return Err(MonorubyErr::cant_convert_into_float(globals, arg0));
         }
     };
-    Some(Value::new_float(f.cos()))
+    Ok(Value::new_float(f.cos()))
 }
 
 #[cfg(test)]

--- a/src/executor/builtins/module.rs
+++ b/src/executor/builtins/module.rs
@@ -24,69 +24,69 @@ pub(super) fn init(globals: &mut Globals) {
 /// - self == obj -> bool
 ///
 /// []
-extern "C" fn eq(
+fn eq(
     _vm: &mut Executor,
     _globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let rhs = match arg[0].is_class_or_module() {
         Some(class) => class,
-        None => return Some(Value::bool(false)),
+        None => return Ok(Value::bool(false)),
     };
     let lhs = lfp.self_val().as_class().class_id();
-    Some(Value::bool(lhs == rhs))
+    Ok(Value::bool(lhs == rhs))
 }
 
 /// ### Module#===
 /// - self === obj -> bool
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/=3d=3d=3d.html]
-extern "C" fn teq(
+fn teq(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class = lfp.self_val().as_class().class_id();
-    Some(Value::bool(arg[0].is_kind_of(globals, class)))
+    Ok(Value::bool(arg[0].is_kind_of(globals, class)))
 }
 
 /// ### Module#to_s
 /// - to_s -> String
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/to_s.html]
-extern "C" fn tos(
+fn tos(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class_name = lfp.self_val().as_class().class_id().get_name(globals);
     let res = Value::new_string(class_name);
-    Some(res)
+    Ok(res)
 }
 
 /// ### Module#constants
 /// - constants(inherit = true) -> [Symbol]
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/constants.html]
-extern "C" fn constants(
+fn constants(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class_id = lfp.self_val().as_class().class_id();
     let iter = globals
         .get_constant_names(class_id)
         .into_iter()
         .map(Value::new_symbol);
-    Some(Value::new_array_from_iter(iter))
+    Ok(Value::new_array_from_iter(iter))
 }
 
 /// ### Module#instance_methods
@@ -97,32 +97,32 @@ extern "C" fn constants(
 /// !! Currently, this method returns only the methods that is defined in *self*.
 ///
 /// TODO: support inherited_too.
-extern "C" fn instance_methods(
+fn instance_methods(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let class_id = lfp.self_val().as_class().class_id();
     let iter = globals
         .get_method_names(class_id)
         .into_iter()
         .map(Value::new_symbol);
-    Some(Value::new_array_from_iter(iter))
+    Ok(Value::new_array_from_iter(iter))
 }
 
 /// ### Module#attr_reader
 /// - attr_reader(*name) -> [Symbol]
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/attr_reader.html]
-extern "C" fn attr_reader(
+fn attr_reader(
     vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let mut ary = ArrayInner::new();
     let class_id = lfp.self_val().as_class().class_id();
     let visi = vm.context_visibility();
@@ -131,20 +131,20 @@ extern "C" fn attr_reader(
         let method_name = globals.define_attr_reader(class_id, arg_name, visi);
         ary.push(Value::new_symbol(method_name));
     }
-    Some(Value::new_array(ary))
+    Ok(Value::new_array(ary))
 }
 
 /// ### Module#attr_writer
 /// - attr_writer(*name) -> [Symbol]
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/attr_writer.html]
-extern "C" fn attr_writer(
+fn attr_writer(
     vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let mut ary = ArrayInner::new();
     let class_id = lfp.self_val().as_class().class_id();
     let visi = vm.context_visibility();
@@ -153,20 +153,20 @@ extern "C" fn attr_writer(
         let method_name = globals.define_attr_writer(class_id, arg_name, visi);
         ary.push(Value::new_symbol(method_name));
     }
-    Some(Value::new_array(ary))
+    Ok(Value::new_array(ary))
 }
 
 /// ### Module#attr_accessor
 /// - attr_accessor(*name) -> [Symbol]
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/attr_accessor.html]
-extern "C" fn attr_accessor(
+fn attr_accessor(
     vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let mut ary = ArrayInner::new();
     let class_id = lfp.self_val().as_class().class_id();
     let visi = vm.context_visibility();
@@ -177,23 +177,23 @@ extern "C" fn attr_accessor(
         let method_name = globals.define_attr_writer(class_id, arg_name, visi);
         ary.push(Value::new_symbol(method_name));
     }
-    Some(Value::new_array(ary))
+    Ok(Value::new_array(ary))
 }
 
 /// ### Module#module_function
 /// - module_function(*name) -> self
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/module_function.html]
-extern "C" fn module_function(
+fn module_function(
     vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     if len == 0 {
         vm.set_module_function();
-        Some(Value::nil())
+        Ok(Value::nil())
     } else {
         let class_id = lfp.self_val().as_class().class_id();
         let visi = vm.context_visibility();
@@ -205,7 +205,7 @@ extern "C" fn module_function(
             globals.add_singleton_method(class_id, name, func_id, visi);
         }
         let res = Value::new_array_from_iter(arg.iter(len));
-        Some(res)
+        Ok(res)
     }
 }
 
@@ -213,21 +213,21 @@ extern "C" fn module_function(
 /// - include(*mod) -> self
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/include.html]
-extern "C" fn include(
+fn include(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let self_ = lfp.self_val();
-    globals.check_min_number_of_arguments(len, 1)?;
+    Globals::check_min_number_of_arguments(len, 1)?;
     let class = self_.as_class();
     for v in arg.rev(len) {
         v.expect_module(globals)?;
         globals.include_module(class, v.as_class());
     }
-    Some(self_)
+    Ok(self_)
 }
 
 /// ### Module#private
@@ -235,13 +235,13 @@ extern "C" fn include(
 /// - private(names) -> self
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/private.html]
-extern "C" fn private(
+fn private(
     executor: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     change_visi(
         executor,
         globals,
@@ -257,13 +257,13 @@ extern "C" fn private(
 /// - protected(names) -> self
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/protected.html]
-extern "C" fn protected(
+fn protected(
     executor: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     change_visi(
         executor,
         globals,
@@ -279,13 +279,13 @@ extern "C" fn protected(
 /// - public(names) -> self
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/public.html]
-extern "C" fn public(
+fn public(
     executor: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     change_visi(
         executor,
         globals,
@@ -303,10 +303,10 @@ fn change_visi(
     arg: Arg,
     len: usize,
     visi: Visibility,
-) -> Option<Value> {
+) -> Result<Value> {
     if len == 0 {
         executor.set_context_visibility(visi);
-        return Some(Value::nil());
+        return Ok(Value::nil());
     }
     let class_id = self_val.as_class().class_id();
     let mut names = vec![];
@@ -316,7 +316,7 @@ fn change_visi(
                 names.push(v.expect_symbol_or_string(globals)?);
             }
             globals.change_method_visibility_for_class(class_id, &names, visi);
-            return Some(arg[0]);
+            return Ok(arg[0]);
         }
     }
     for v in arg.iter(len) {
@@ -324,7 +324,7 @@ fn change_visi(
     }
     globals.change_method_visibility_for_class(class_id, &names, visi);
     let res = Value::new_array_from_iter(arg.iter(len));
-    Some(res)
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/src/executor/builtins/process.rs
+++ b/src/executor/builtins/process.rs
@@ -22,16 +22,15 @@ pub(super) fn init(globals: &mut Globals, class_id: ClassId) {
 /// - times -> Process::Tms
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Process/m/times.html]
-extern "C" fn times(
+fn times(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let tms_class = globals
-        .get_qualified_constant(&["Process", "Tms"])
-        .unwrap()
+        .get_qualified_constant(&["Process", "Tms"])?
         .as_class();
     let mut val = Value::new_object(tms_class.class_id());
     let mut self_rusage = rusage::Rusage::default();
@@ -40,25 +39,25 @@ extern "C" fn times(
         globals,
         "@utime",
         Value::new_float(self_rusage.ru_utime.get_f64()),
-    );
+    )?;
     val.set_instance_var(
         globals,
         "@stime",
         Value::new_float(self_rusage.ru_stime.get_f64()),
-    );
+    )?;
     let mut child_rusage = rusage::Rusage::default();
     rusage::getrusage(rusage::RusageWho::Children, &mut child_rusage);
     val.set_instance_var(
         globals,
         "@cutime",
         Value::new_float(child_rusage.ru_utime.get_f64()),
-    );
+    )?;
     val.set_instance_var(
         globals,
         "@cstime",
         Value::new_float(child_rusage.ru_stime.get_f64()),
-    );
-    Some(val)
+    )?;
+    Ok(val)
 }
 
 ///
@@ -67,14 +66,14 @@ extern "C" fn times(
 /// - pid -> Integer
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Process/m/pid.html]
-extern "C" fn pid(
+fn pid(
     _vm: &mut Executor,
     _globals: &mut Globals,
     _lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
-    Some(Value::new_integer(std::process::id() as i64))
+) -> Result<Value> {
+    Ok(Value::new_integer(std::process::id() as i64))
 }
 
 ///
@@ -83,17 +82,17 @@ extern "C" fn pid(
 /// - clock_gettime(clock_id, unit=:float_second) -> Float | Integer
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Process/m/clock_gettime.html]
-extern "C" fn clock_gettime(
+fn clock_gettime(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let mut tp = TimeSpec::default();
     let clk_id = arg[0].coerce_to_fixnum(globals)? as i32;
     clock_gettime::clock_gettime(clk_id, &mut tp);
-    Some(Value::new_float(tp.to_f64()))
+    Ok(Value::new_float(tp.to_f64()))
 }
 
 #[cfg(test)]

--- a/src/executor/builtins/random.rs
+++ b/src/executor/builtins/random.rs
@@ -15,14 +15,14 @@ pub(super) fn init(globals: &mut Globals, class: ClassId) {
 /// - srand(number) -> Integer
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Random/s/srand.html]
-extern "C" fn srand(
+fn srand(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
-    globals.check_number_of_arguments(len, 0..=1)?;
+) -> Result<Value> {
+    Globals::check_number_of_arguments(len, 0..=1)?;
     let old_seed = BigInt::from_bytes_le(num::bigint::Sign::Plus, &globals.random.seed);
     let new_seed = if len == 0 {
         None
@@ -33,7 +33,7 @@ extern "C" fn srand(
         }
     };
     globals.random.init_with_seed(new_seed);
-    Some(Value::new_bigint(old_seed))
+    Ok(Value::new_bigint(old_seed))
 }
 
 // ### Random.rand
@@ -42,13 +42,13 @@ extern "C" fn srand(
 /// - rand(range) -> Integer | Float
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Random/s/rand.html]
-extern "C" fn rand(
+fn rand(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     _arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let f = globals.random.gen();
-    Some(Value::new_float(f))
+    Ok(Value::new_float(f))
 }

--- a/src/executor/builtins/regexp.rs
+++ b/src/executor/builtins/regexp.rs
@@ -20,18 +20,18 @@ pub(crate) fn init(globals: &mut Globals) {
 /// - compile(string, option=nil, code=nil) -> Regexp
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/compile.html]
-extern "C" fn regexp_new(
+fn regexp_new(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let arg0 = arg[0];
     let string = arg0.expect_string(globals)?;
     let regexp = RegexpInner::from_string(globals, string)?;
     let val = Value::new_regexp(regexp);
-    Some(val)
+    Ok(val)
 }
 
 /// ### Regexp.new
@@ -39,17 +39,17 @@ extern "C" fn regexp_new(
 /// - quote(string) -> String
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/escape.html]
-extern "C" fn regexp_escape(
+fn regexp_escape(
     _vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let arg0 = arg[0];
     let string = arg0.expect_string(globals)?;
     let val = Value::new_string(regex::escape(&string));
-    Some(val)
+    Ok(val)
 }
 
 /// ### Regexp.last_match
@@ -57,19 +57,19 @@ extern "C" fn regexp_escape(
 /// - last_match(nth) -> String | nil
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/last_match.html]
-extern "C" fn regexp_last_match(
+fn regexp_last_match(
     vm: &mut Executor,
     globals: &mut Globals,
     _lfp: LFP,
     arg: Arg,
     len: usize,
-) -> Option<Value> {
-    globals.check_number_of_arguments(len, 0..=1)?;
+) -> Result<Value> {
+    Globals::check_number_of_arguments(len, 0..=1)?;
     if len == 0 {
-        Some(vm.get_last_matchdata())
+        Ok(vm.get_last_matchdata())
     } else {
         let nth = arg[0].coerce_to_fixnum(globals)?;
-        Some(vm.get_special_matches(nth))
+        Ok(vm.get_special_matches(nth))
     }
 }
 
@@ -77,13 +77,13 @@ extern "C" fn regexp_last_match(
 /// - self =~ string -> Integer | nil
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/i/=3d=7e.html]
-extern "C" fn regexp_match(
+fn regexp_match(
     vm: &mut Executor,
     globals: &mut Globals,
     lfp: LFP,
     arg: Arg,
     _len: usize,
-) -> Option<Value> {
+) -> Result<Value> {
     let self_ = lfp.self_val();
     let regex = self_.is_regex().unwrap();
     let given = arg[0].expect_string(globals)?;
@@ -91,7 +91,7 @@ extern "C" fn regexp_match(
         Some(mat) => Value::new_integer(mat.start() as i64),
         None => Value::nil(),
     };
-    Some(res)
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/src/executor/compiler.rs
+++ b/src/executor/compiler.rs
@@ -111,7 +111,7 @@ pub struct Codegen {
     ///
     /// ### in
     /// - rdx: actual number of arguments
-    /// - r13: pc (InitBlock/InitMethod)
+    /// - r13: pc (InitMethod)
     ///
     #[allow(dead_code)]
     wrong_argument: DestLabel,

--- a/src/executor/compiler.rs
+++ b/src/executor/compiler.rs
@@ -613,9 +613,6 @@ impl Codegen {
             je   l1;
             // rax <- op
             movzxb rax, [rsi + 6];
-            // method-style
-            //cmpb rax, (170u8 as i8);
-            //je   l1;
             // block-style?
             cmpb rax, (172u8 as i8);
             jne  l1;

--- a/src/executor/compiler/jitgen.rs
+++ b/src/executor/compiler/jitgen.rs
@@ -903,7 +903,6 @@ impl Codegen {
                 .push((cc.bb_pos + ofs, self.jit.get_current() - cc.start_codepos));
             match pc.get_ir(fnstore) {
                 TraceIr::InitMethod { .. } => {}
-                TraceIr::InitBlock { .. } => {}
                 TraceIr::LoopStart(_) => {
                     cc.loop_count += 1;
                 }

--- a/src/executor/compiler/jitgen/analysis.rs
+++ b/src/executor/compiler/jitgen/analysis.rs
@@ -137,7 +137,6 @@ impl LoopAnalysis {
             let idx = bb_pos + ofs;
             match self.pc.get_ir(fnstore) {
                 TraceIr::InitMethod { .. } => {}
-                TraceIr::InitBlock { .. } => {}
                 TraceIr::AliasMethod { .. } => {}
                 TraceIr::MethodDef { .. } => {}
                 TraceIr::SingletonMethodDef { .. } => {}

--- a/src/executor/compiler/jitgen/init_method.rs
+++ b/src/executor/compiler/jitgen/init_method.rs
@@ -7,7 +7,7 @@ impl Codegen {
             movq rbp, rsp;
         );
         match pc.get_ir(fnstore) {
-            TraceIr::InitMethod(fn_info) | TraceIr::InitBlock(fn_info) => {
+            TraceIr::InitMethod(fn_info) => {
                 self.setup_stack(fn_info.stack_offset);
                 self.init_func(&fn_info);
             }

--- a/src/executor/compiler/jitgen/method_call.rs
+++ b/src/executor/compiler/jitgen/method_call.rs
@@ -508,7 +508,8 @@ impl Codegen {
             subq rsp, (stack_offset);
             movq rdi, rbx;  // &mut Interp
             movq rsi, r12;  // &mut Globals
-            movq rax, (abs_address);
+            movq r9, (abs_address);
+            movq rax, (crate::executor::compiler::wrapper::wrapper);
             call rax;
             addq rsp, (stack_offset);
         );

--- a/src/executor/compiler/wrapper.rs
+++ b/src/executor/compiler/wrapper.rs
@@ -114,7 +114,7 @@ impl Codegen {
             subq rsp, rax;
             lea  rcx, [r14 - (LBP_ARG0)];     // rcx <- *const arg[0]
             // we should overwrite reg_num because the func itself does not know actual number of arguments.
-            movw [r14 - (LBP_META_REGNUM)], rdi;
+            movw [r14 - (LBP_META_REGNUM)], rdx;
 
             movq rdi, rbx;
             movq rsi, r12;

--- a/src/executor/compiler/wrapper.rs
+++ b/src/executor/compiler/wrapper.rs
@@ -119,8 +119,8 @@ impl Codegen {
             movq rdi, rbx;
             movq rsi, r12;
             movq rdx, r14;    // rdx <- lfp
-            movq rax, (abs_address);
-            // fn(&mut Interp, &mut Globals, LFP, *const Value, len:usize)
+            movq r9, (abs_address);
+            movq rax, (wrapper);
             call rax;
 
             leave;
@@ -198,5 +198,22 @@ impl Codegen {
             ret;
         );
         label
+    }
+}
+
+pub extern "C" fn wrapper(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: LFP,
+    arg: Arg,
+    len: usize,
+    f: BuiltinFn,
+) -> Option<Value> {
+    match f(vm, globals, lfp, arg, len) {
+        Ok(val) => Some(val),
+        Err(err) => {
+            globals.set_error(err);
+            None
+        }
     }
 }

--- a/src/executor/globals/class.rs
+++ b/src/executor/globals/class.rs
@@ -373,13 +373,12 @@ impl Globals {
         &mut self,
         class: ClassId,
         func_name: IdentId,
-    ) -> Option<MethodTableEntry> {
+    ) -> Result<MethodTableEntry> {
         match self.check_method_for_class(class, func_name) {
-            Some(entry) => Some(entry),
-            None => {
-                self.err_method_not_found_for_class(func_name, class);
-                None
-            }
+            Some(entry) => Ok(entry),
+            None => Err(MonorubyErr::method_not_found_for_class(
+                self, func_name, class,
+            )),
         }
     }
 

--- a/src/executor/globals/class/instance_var.rs
+++ b/src/executor/globals/class/instance_var.rs
@@ -57,18 +57,17 @@ impl Globals {
     ///
     /// Set *val* to the instance variable with *name* which belongs to *base*.
     ///
-    pub(crate) fn set_ivar(&mut self, mut base: Value, name: IdentId, val: Value) -> Option<()> {
+    pub(crate) fn set_ivar(&mut self, mut base: Value, name: IdentId, val: Value) -> Result<()> {
         let class_id = base.class();
         let rval = match base.try_rvalue_mut() {
             Some(rval) => rval,
             None => {
-                self.err_cant_modify_frozen(base);
-                return None;
+                return Err(MonorubyErr::cant_modify_frozen(self, base));
             }
         };
         let id = self.get_ivar_id(class_id, name);
         rval.set_var(id, val);
-        Some(())
+        Ok(())
     }
 }
 
@@ -130,7 +129,7 @@ fn test_ivar() {
     assert_eq!(None, globals.get_ivar(obj, IdentId::INITIALIZE));
     assert!(globals
         .set_ivar(obj, IdentId::INITIALIZE, Value::fixnum(42))
-        .is_some());
+        .is_ok());
     assert_eq!(
         Some(Value::fixnum(42)),
         globals.get_ivar(obj, IdentId::INITIALIZE)

--- a/src/executor/globals/method.rs
+++ b/src/executor/globals/method.rs
@@ -141,17 +141,14 @@ impl Globals {
         obj: Value,
         new_name: IdentId,
         old_name: IdentId,
-    ) -> Option<()> {
+    ) -> Result<()> {
         let class_id = obj.class();
         let entry = match self.check_method_for_class(class_id, old_name) {
             Some(func) => func,
-            None => {
-                self.err_method_not_found(old_name, obj);
-                return None;
-            }
+            None => return Err(MonorubyErr::method_not_found(self, old_name, obj)),
         };
         self.add_method(obj.class(), new_name, entry.func_id(), entry.visibility);
-        Some(())
+        Ok(())
     }
 
     ///
@@ -162,9 +159,9 @@ impl Globals {
         class_id: ClassId,
         new_name: IdentId,
         old_name: IdentId,
-    ) -> Option<()> {
+    ) -> Result<()> {
         let entry = self.find_method_entry_for_class(class_id, old_name)?;
         self.add_method(class_id, new_name, entry.func_id(), entry.visibility);
-        Some(())
+        Ok(())
     }
 }

--- a/src/executor/inst.rs
+++ b/src/executor/inst.rs
@@ -463,8 +463,6 @@ pub(super) enum TraceIr {
     Mov(SlotId, SlotId),
     /// initialize_method
     InitMethod(FnInitInfo),
-    /// initialize_block
-    InitBlock(FnInitInfo),
     //                0       4       8       12      16
     //                +-------+-------+-------+-------+
     // MethodCall     |   |ret|identid| class |version|
@@ -831,7 +829,7 @@ impl TraceIr {
                     stack_offset: op3 as usize,
                 }),
                 171 => Self::ExpandArray(SlotId::new(op1), SlotId::new(op2), op3),
-                172 => Self::InitBlock(FnInitInfo {
+                172 => Self::InitMethod(FnInitInfo {
                     reg_num: op1 as usize,
                     arg_num: pc.u16(3) as usize,
                     block_pos: pc.u16(1) as usize,

--- a/src/executor/op.rs
+++ b/src/executor/op.rs
@@ -510,9 +510,14 @@ pub extern "C" fn vm_get_constant(
     if *cached_version == const_version {
         return *val;
     };
-    let res = executor.find_constant(globals, site_id);
-    if res.is_some() {
-        globals.func[site_id].cache = (const_version, res)
+    match executor.find_constant(globals, site_id) {
+        Ok(val) => {
+            globals.func[site_id].cache = (const_version, Some(val));
+            Some(val)
+        }
+        Err(err) => {
+            globals.set_error(err);
+            None
+        }
     }
-    res
 }


### PR DESCRIPTION
OLD: extern "C" fn(&mut Executor, &mut Globals, LFP, Arg, usize) -> Option<Value>
NEW: fn(&mut Executor, &mut Globals, LFP, Arg, usize) -> Result<Value>

The built-in function can now be written using Rust ABI rather than C ABI, and return Result<Value, MonorubyErr>.
This change allows us to write them more simply.