### PR TITLE
Optimize class guards for *self*.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git#2215e811fe30d152eb6575529598fad1270558bf"
+source = "git+https://github.com/sisshiki1969/monoasm.git#9dc93f8696275f02b7164e1ee7b2d6d3087676fb"
 dependencies = [
  "libc",
  "monoasm_macro",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git#2215e811fe30d152eb6575529598fad1270558bf"
+source = "git+https://github.com/sisshiki1969/monoasm.git#9dc93f8696275f02b7164e1ee7b2d6d3087676fb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -837,9 +837,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git#fc947194d6ac0b9fe44704752f14e79d733213c2"
+source = "git+https://github.com/sisshiki1969/monoasm.git#2215e811fe30d152eb6575529598fad1270558bf"
 dependencies = [
  "libc",
  "monoasm_macro",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git#fc947194d6ac0b9fe44704752f14e79d733213c2"
+source = "git+https://github.com/sisshiki1969/monoasm.git#2215e811fe30d152eb6575529598fad1270558bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1041,9 +1041,9 @@ checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1508,21 +1508,17 @@ extern "C" fn exec_jit_compile_patch(
         .is_none());
     globals.exec_jit_compile_method(func_id, self_value, entry_label);
 
-    let codegen = &mut globals.codegen;
-    let guard = codegen.jit.get_label_address(guard);
-    let patch_point = codegen.jit.get_label_address(entry);
-    let offset = guard - patch_point - 5;
-    unsafe { *(patch_point.as_ptr().add(1) as *mut [u8; 4]) = (offset as i32).to_ne_bytes() };
+    globals.codegen.jit.apply_jmp_patch(entry, guard);
 }
 
 extern "C" fn exec_jit_recompile_method(globals: &mut Globals, func_id: FuncId, self_value: Value) {
     let entry_label = globals.codegen.jit.label();
     globals.exec_jit_compile_method(func_id, self_value, entry_label);
-    let codeptr = globals.codegen.jit.get_label_address(entry_label);
     let patch_point = globals[func_id].get_jit_code(self_value.class()).unwrap();
-    let patch_point = globals.codegen.jit.get_label_address(patch_point);
-    let offset = codeptr - patch_point - 5;
-    unsafe { *(patch_point.as_ptr().add(1) as *mut [u8; 4]) = (offset as i32).to_ne_bytes() };
+    globals
+        .codegen
+        .jit
+        .apply_jmp_patch(patch_point, entry_label);
 }
 
 ///

--- a/monoruby/src/executor/compiler.rs
+++ b/monoruby/src/executor/compiler.rs
@@ -240,24 +240,26 @@ impl Codegen {
             pushq r15;
             pushq rbp;
             subq rsp, 8;
-
+        }
+        self.set_lfp();
+        monoasm! { &mut self.jit,
             movq rbx, rdi;  // rdi: &mut Interp
             movq r12, rsi;  // rsi: &mut Globals
             movq r13, rdx;
             // set meta func_id
             movq rax, [r13 + (FUNCDATA_OFFSET_META)];  // r13: *const FuncData
-            movq [rsp - (16 + LBP_META)], rax;
+            movq [r14 - (LBP_META)], rax;
             // set block
-            movq [rsp - (16 + LBP_BLOCK)], 0;
-            movq [rsp - (16 + LBP_OUTER)], 0;
-            movq [rsp - (16 + BP_PREV_CFP)], 0;
-            lea  rax, [rsp - (16 + BP_PREV_CFP)];
+            movq [r14 - (LBP_BLOCK)], 0;
+            movq [r14 - (LBP_OUTER)], 0;
+            movq [r14 - (BP_PREV_CFP)], 0;
+            lea  rax, [r14 - (BP_PREV_CFP)];
             movq [rbx], rax;
         };
         let l1 = self.jit.label();
         let l2 = self.jit.label();
         monoasm! { &mut self.jit,
-            lea  rax, [rsp - (16 + LBP_ARG0)];
+            lea  rax, [r14 - (LBP_ARG0)];
             movzxw rdi, [r13 + (FUNCDATA_OFFSET_REGNUM)];
         l1:
             subq rdi, 1;
@@ -267,7 +269,6 @@ impl Codegen {
             jmp  l1;
         l2:
         };
-        self.set_lfp();
         monoasm! { &mut self.jit,
             movq [rbx + 8], r14;
             //
@@ -290,7 +291,7 @@ impl Codegen {
             //
             // set self
             movq rax, (main_object.get());
-            movq [rsp - (16 + LBP_SELF)], rax;
+            movq [r14 - (LBP_SELF)], rax;
             movq rax, [r13 + (FUNCDATA_OFFSET_CODEPTR)];
             // set pc
             movq r13, [r13 + (FUNCDATA_OFFSET_PC)];
@@ -397,7 +398,7 @@ impl Codegen {
         monoasm!( &mut self.jit,
             // set lfp
             lea  r14, [rsp - 16];
-            movq [rsp - (16 + BP_LFP)], r14;
+            movq [r14 - (BP_LFP)], r14;
         );
     }
 
@@ -507,6 +508,29 @@ impl Codegen {
             leave;
             ret;
         );
+    }
+
+    pub(super) fn class_guard_stub(
+        &mut self,
+        self_class: ClassId,
+        patch_point: DestLabel,
+        entry: DestLabel,
+        guard: DestLabel,
+    ) {
+        let old = self.jit.get_page();
+        self.jit.select_page(1);
+
+        let vm_entry = self.vm_entry;
+        monoasm!( &mut self.jit,
+        guard:
+            movq rdi, [r14 - (LBP_SELF)];
+        );
+        self.guard_class(self_class, vm_entry);
+        monoasm! { &mut self.jit,
+        patch_point:
+            jmp entry;
+        }
+        self.jit.select_page(old);
     }
 
     ///

--- a/monoruby/src/executor/compiler.rs
+++ b/monoruby/src/executor/compiler.rs
@@ -1,4 +1,3 @@
-use monoasm::*;
 use monoasm_macro::monoasm;
 use paste::paste;
 
@@ -98,7 +97,7 @@ pub struct Codegen {
     alloc_flag: DestLabel,
     const_version: DestLabel,
     entry_panic: DestLabel,
-    vm_entry: DestLabel,
+    pub(super) vm_entry: DestLabel,
     vm_fetch: DestLabel,
     ///
     /// Raise error.

--- a/monoruby/src/executor/compiler/jitgen.rs
+++ b/monoruby/src/executor/compiler/jitgen.rs
@@ -381,7 +381,6 @@ impl Codegen {
         #[cfg(any(feature = "emit-asm", feature = "log-jit"))]
         let now = std::time::Instant::now();
 
-        //self.jit.align16();
         let entry = self.jit.label();
         self.jit.bind_label(entry);
         store[func_id].add_jit_code(self_value.class(), entry);
@@ -396,19 +395,16 @@ impl Codegen {
             ctx.loop_exit.insert(*loop_start, (*loop_end, exit));
         }
 
-        let pc = if let Some(pc) = position {
-            pc
-        } else {
+        /*monoasm!( &mut self.jit,
+            movq rdi, [r14 - (LBP_SELF)];
+        );
+        self.guard_class(self_value.class(), self.vm_entry);*/
+
+        if position.is_none() {
             // generate prologue and class guard of *self* for a method
             let pc = func.get_top_pc();
             self.prologue(pc);
-            pc
         };
-        let side_exit = self.gen_side_deopt_without_writeback(pc + 1);
-        monoasm!( &mut self.jit,
-            movq rdi, [r14 - (LBP_SELF)];
-        );
-        self.guard_class(self_value.class(), side_exit);
 
         ctx.branch_map.insert(
             start_pos,
@@ -1402,11 +1398,11 @@ impl Codegen {
     /// ### in
     /// - rdi: deopt-reason:Value
     ///
-    fn gen_side_deopt_without_writeback(&mut self, pc: BcPc) -> DestLabel {
+    /*fn gen_side_deopt_without_writeback(&mut self, pc: BcPc) -> DestLabel {
         let entry = self.jit.label();
         self.gen_side_deopt_with_label(pc, None, entry);
         entry
-    }
+    }*/
 
     fn gen_side_deopt_with_label(&mut self, pc: BcPc, ctx: Option<&BBContext>, entry: DestLabel) {
         assert_eq!(0, self.jit.get_page());

--- a/monoruby/src/executor/compiler/jitgen.rs
+++ b/monoruby/src/executor/compiler/jitgen.rs
@@ -1271,12 +1271,12 @@ impl Codegen {
         let counter = self.jit.const_i32(5);
         let deopt = self.gen_side_deopt(pc, ctx);
         monoasm!( &mut self.jit,
+            xorq rdi, rdi;
             cmpl [rip + counter], 0;
             jlt deopt;
             jeq recompile;
-        dec:
+            dec:
             subl [rip + counter], 1;
-            xorq rdi, rdi;
             jmp deopt;
         );
         self.jit.select_page(1);
@@ -1299,6 +1299,7 @@ impl Codegen {
             );
         }
         monoasm!( &mut self.jit,
+            xorq rdi, rdi;
             jmp dec;
         );
         self.jit.select_page(0);

--- a/monoruby/src/executor/compiler/jitgen/guard.rs
+++ b/monoruby/src/executor/compiler/jitgen/guard.rs
@@ -10,7 +10,7 @@ impl Codegen {
     /// ### in
     /// - rdi: Value
     ///
-    pub(super) fn guard_class(&mut self, class_id: ClassId, side_exit: DestLabel) {
+    pub(in crate::executor) fn guard_class(&mut self, class_id: ClassId, side_exit: DestLabel) {
         match class_id {
             INTEGER_CLASS => {
                 monoasm!( &mut self.jit,

--- a/monoruby/src/executor/compiler/jitgen/method_call.rs
+++ b/monoruby/src/executor/compiler/jitgen/method_call.rs
@@ -701,18 +701,17 @@ impl Codegen {
             _ => {}
         }
         monoasm!( &mut self.jit,
-            movq rdx, rdi;
             // set meta.
             movq rax, (func_data.meta.get());
             movq [rsp - (16 + LBP_META)], rax;
             // set pc.
             movq r13, (func_data.pc().get_u64());
         );
-        /*match store[callee_func_id].get_jit_code(recv_classid) {
+        match store[callee_func_id].get_jit_code(recv_classid) {
             Some(dest) => self.call_label(dest),
             None => self.call_codeptr(func_data.codeptr.unwrap()),
-        };*/
-        self.call_codeptr(func_data.codeptr.unwrap());
+        };
+        //self.call_codeptr(func_data.codeptr.unwrap());
         self.xmm_restore(&xmm_using);
         self.jit_handle_error(ctx, pc);
         if !ret.is_zero() {

--- a/monoruby/src/executor/compiler/vmgen/init_method.rs
+++ b/monoruby/src/executor/compiler/vmgen/init_method.rs
@@ -24,7 +24,6 @@ impl Codegen {
     /// - r15 <- reg
     /// - rdi <- pos
     /// - rsi <- ofs
-    /// - rdx <- passed args
     ///
     pub(super) fn vm_init(&mut self) -> CodePtr {
         let label = self.jit.get_current_address();
@@ -86,41 +85,4 @@ impl Codegen {
         l1:
         };
     }
-
-    /*
-    /// Expand arg0 if the number of args is 1 and arg0 is Array and pos_num > 1.
-    ///
-    /// in
-    /// rdi: pos_num
-    /// rdx: number of args passed from caller
-    /// out
-    /// rdx: number of args
-    /// destroy
-    /// rax
-    fn expand_arg0(&mut self) {
-        let l1 = self.jit.label();
-        monoasm! { &mut self.jit,
-            // if passed_arg == 1 && arg0 isArray && pos_num >= 2 then expand arg0.
-            cmpl rdx, 1;
-            jne  l1;
-            cmpl rdi, 2;
-            jlt  l1;
-            movq rax, [r14 - (LBP_ARG0)];
-            testq rax, 0b111;
-            jnz  l1;
-            cmpl [rax + 4], (ARRAY_CLASS.0);
-            jne  l1;
-            pushq rdi;
-            pushq rsi;
-            movzxw rdx, [r13 - 8];
-            movq rdi, rax;
-            lea  rsi, [r14 - (LBP_ARG0)];
-            movq rax, (block_expand_array);
-            call rax;
-            movq rdx, rax;
-            popq rsi;
-            popq rdi;
-        l1:
-        }
-    }*/
 }

--- a/monoruby/src/executor/compiler/wrapper.rs
+++ b/monoruby/src/executor/compiler/wrapper.rs
@@ -40,12 +40,9 @@ impl Codegen {
             // save arg len.
             pushq rdi;
             movq rdi, r12;
-            movq rax, (exec_jit_compile);
+            movq rcx, (entry.to_usize());
+            movq rax, (exec_jit_compile_patch);
             call rax;
-            lea rdi, [rip + entry];
-            addq rdi, 5;
-            subq rax, rdi;
-            movl [rdi - 4], rax;
             // restore arg len to rdx.
             popq rdx;
             addq rsp, 1024;

--- a/monoruby/src/executor/compiler/wrapper.rs
+++ b/monoruby/src/executor/compiler/wrapper.rs
@@ -139,7 +139,7 @@ impl Codegen {
         let label = self.jit.get_current_address();
         let cache = self.jit.const_i64(-1);
         monoasm!( &mut self.jit,
-            movq rdi, [rsp - (8 + LBP_SELF)];  // self: Value
+            movq rdi, [r14 - (LBP_SELF)];  // self: Value
             movq rsi, (ivar_name.get()); // name: IdentId
             movq rdx, r12; // &mut Globals
             lea  rcx, [rip + cache];
@@ -175,9 +175,9 @@ impl Codegen {
         monoasm!( &mut self.jit,
             movq rdi, rbx; //&mut Executor
             movq rsi, r12; //&mut Globals
-            movq rdx, [rsp - (8 + LBP_SELF)];  // self: Value
+            movq rdx, [r14 - (LBP_SELF)];  // self: Value
             movq rcx, (ivar_name.get()); // name: IdentId
-            movq r8, [rsp - (8 + LBP_ARG0)];  //val: Value
+            movq r8, [r14 - (LBP_ARG0)];  //val: Value
             lea  r9, [rip + cache];
             movq rax, (set_instance_var_with_cache);
             subq rsp, 8;
@@ -188,21 +188,3 @@ impl Codegen {
         label
     }
 }
-
-/*#[allow(improper_ctypes_definitions)]
-pub extern "C" fn wrapper(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: LFP,
-    arg: Arg,
-    len: usize,
-    f: BuiltinFn,
-) -> Option<Value> {
-    match f(vm, globals, lfp, arg, len) {
-        Ok(val) => Some(val),
-        Err(err) => {
-            vm.set_error(err);
-            None
-        }
-    }
-}*/

--- a/monoruby/src/executor/compiler/wrapper.rs
+++ b/monoruby/src/executor/compiler/wrapper.rs
@@ -33,19 +33,14 @@ impl Codegen {
         next:
             subl [rip + counter], 1;
             jne vm_entry;
-            movq rdi, rdx;
-            movl rsi, [rsp - (8 + LBP_META_FUNCID)];
-            movq rdx, [rsp - (8 + LBP_SELF)];
-            subq rsp, 1024;
-            // save arg len.
-            pushq rdi;
             movq rdi, r12;
+            movl rsi, [r14 - (LBP_META_FUNCID)];
+            movq rdx, [r14 - (LBP_SELF)];
             movq rcx, (entry.to_usize());
+            subq rsp, 1032;
             movq rax, (exec_jit_compile_patch);
             call rax;
-            // restore arg len to rdx.
-            popq rdx;
-            addq rsp, 1024;
+            addq rsp, 1032;
             jmp entry;
         );
         codeptr

--- a/monoruby/src/executor/globals.rs
+++ b/monoruby/src/executor/globals.rs
@@ -501,6 +501,7 @@ impl Globals {
         }
         self.dumped_bc = self.store.func_len();
     }
+
     #[cfg(any(feature = "emit-asm"))]
     pub(crate) fn dump_disas(&mut self, sourcemap: Vec<(BcIndex, usize)>, func_id: FuncId) {
         let (start, code_end, end) = self.codegen.jit.code_block.last().unwrap();

--- a/monoruby/src/executor/globals/store/function.rs
+++ b/monoruby/src/executor/globals/store/function.rs
@@ -421,8 +421,12 @@ impl FuncInfo {
         }
     }
 
-    pub(crate) fn add_jit_code(&mut self, self_class: ClassId, entry: DestLabel) {
-        self.jit_entry.insert(self_class, entry);
+    pub(crate) fn add_jit_code(
+        &mut self,
+        self_class: ClassId,
+        entry: DestLabel,
+    ) -> Option<DestLabel> {
+        self.jit_entry.insert(self_class, entry)
     }
 
     pub(crate) fn get_jit_code(&self, self_class: ClassId) -> Option<DestLabel> {

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -2462,4 +2462,44 @@ mod test {
             "#,
         );
     }
+
+    #[test]
+    fn polymorphic_call2() {
+        run_test_with_prelude(
+            r#"
+            $res = []
+            for i in 0...x.size
+              $res << x[i].g
+            end
+            $res
+            "#,
+            r#"
+            class S
+              def g
+                x = 0
+                for i in 0..10
+                  x += @x
+                end
+                x
+              end
+            end
+
+            class A < S
+              def initialize
+                @x = 1
+                @y = 2
+              end
+            end
+
+            class B < S
+              def initialize
+                @y = 10
+                @x = 20
+              end
+            end
+
+            x = [A.new, B.new, A.new, B.new, A.new, B.new, B.new, A.new, B.new, A.new, B.new]
+            "#,
+        );
+    }
 }


### PR DESCRIPTION
In both of method JIT and loop JIT, compiler assumes that *self*'s class is a certain class. This allows to omit class guards for instance variable access and receiver check in function-like method call.
Furthermore, when JIT'ed function is called by a JIT'ed function, we can remove *self*'s class guards completely.