### PR TITLE
Support block arguments other than Proc.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2.2"
+          ruby-version: "3.3.0"
+      - run: |
+          gem environment paths
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly

--- a/a.rb
+++ b/a.rb
@@ -1,7 +1,4 @@
 class Foo
-  def to_proc
-    Proc.new {|v| p v}
-  end
 end
 
 [1,2,3].each(&Foo.new)

--- a/a.rb
+++ b/a.rb
@@ -1,16 +1,7 @@
-class C
-  def f(x)
-    x*100
+class Foo
+  def to_proc
+    Proc.new {|v| p v}
   end
 end
 
-c = C.new
-
-m = [*(0..15)]
-
-20000000.times do |x|
-  if x == 12
-    m = c.method(:f)
-  end
-  m[x]
-end
+[1,2,3].each(&Foo.new)

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -713,7 +713,7 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
             }
         }
         Some(bh) => {
-            let data = vm.get_block_data(globals, bh);
+            let data = vm.get_block_data(globals, bh)?;
             for v in iter {
                 let rhs = vm.invoke_block(globals, &data, &[v])?;
                 sum = executor::op::add_values(vm, globals, sum, rhs)
@@ -814,7 +814,7 @@ fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 #[monoruby_builtin]
 fn sort_by_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
-    let data = vm.get_block_data(globals, bh);
+    let data = vm.get_block_data(globals, bh)?;
     let f = |vm: &mut Executor,
              globals: &mut Globals,
              lhs: Value,
@@ -913,7 +913,7 @@ fn flat_map(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value>
 fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let ary: Array = lfp.self_val().into();
     if let Some(bh) = lfp.block() {
-        let data = vm.get_block_data(globals, bh);
+        let data = vm.get_block_data(globals, bh)?;
         for elem in ary.iter() {
             if !vm.invoke_block(globals, &data, &[*elem])?.as_bool() {
                 return Ok(Value::bool(false));
@@ -940,7 +940,7 @@ fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 fn detect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let ary: Array = lfp.self_val().into();
     let bh = lfp.expect_block()?;
-    let data = vm.get_block_data(globals, bh);
+    let data = vm.get_block_data(globals, bh)?;
     for elem in ary.iter() {
         if vm.invoke_block(globals, &data, &[*elem])?.as_bool() {
             return Ok(*elem);
@@ -1173,7 +1173,7 @@ fn uniq_inner(
     bh: BlockHandler,
 ) -> Result<bool> {
     let mut h = HashSet::default();
-    let data = vm.get_block_data(globals, bh);
+    let data = vm.get_block_data(globals, bh)?;
     ary.retain(|x| {
         let res = vm.invoke_block(globals, &data, &[*x])?;
         vm.temp_push(res);

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -713,7 +713,7 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
             }
         }
         Some(bh) => {
-            let data = globals.get_block_data(vm.cfp(), bh);
+            let data = vm.get_block_data(globals, bh);
             for v in iter {
                 let rhs = vm.invoke_block(globals, &data, &[v])?;
                 sum = executor::op::add_values(vm, globals, sum, rhs)
@@ -814,7 +814,7 @@ fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 #[monoruby_builtin]
 fn sort_by_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
-    let data = globals.get_block_data(vm.cfp(), bh);
+    let data = vm.get_block_data(globals, bh);
     let f = |vm: &mut Executor,
              globals: &mut Globals,
              lhs: Value,
@@ -913,7 +913,7 @@ fn flat_map(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value>
 fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let ary: Array = lfp.self_val().into();
     if let Some(bh) = lfp.block() {
-        let data = globals.get_block_data(vm.cfp(), bh);
+        let data = vm.get_block_data(globals, bh);
         for elem in ary.iter() {
             if !vm.invoke_block(globals, &data, &[*elem])?.as_bool() {
                 return Ok(Value::bool(false));
@@ -940,7 +940,7 @@ fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 fn detect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let ary: Array = lfp.self_val().into();
     let bh = lfp.expect_block()?;
-    let data = globals.get_block_data(vm.cfp(), bh);
+    let data = vm.get_block_data(globals, bh);
     for elem in ary.iter() {
         if vm.invoke_block(globals, &data, &[*elem])?.as_bool() {
             return Ok(*elem);
@@ -1173,7 +1173,7 @@ fn uniq_inner(
     bh: BlockHandler,
 ) -> Result<bool> {
     let mut h = HashSet::default();
-    let data = globals.get_block_data(vm.cfp(), bh);
+    let data = vm.get_block_data(globals, bh);
     ary.retain(|x| {
         let res = vm.invoke_block(globals, &data, &[*x])?;
         vm.temp_push(res);

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -14,7 +14,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func_with(CLASS_CLASS, "new", class_new, 0, 1, false);
     globals.define_builtin_inline_func_with(
         CLASS_CLASS,
-        &["new"],
+        "new",
         new,
         gen_class_new_object(),
         analysis::v_v_vv,

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -100,7 +100,7 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     }
     let self_val: Enumerator = lfp.self_val().into();
     let data = if let Some(bh) = lfp.block() {
-        vm.get_block_data(globals, bh)
+        vm.get_block_data(globals, bh)?
     } else {
         return Ok(self_val.into());
     };
@@ -164,7 +164,7 @@ fn with_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
 
     let id = IdentId::get_id("with_index");
     let data = if let Some(bh) = lfp.block() {
-        vm.get_block_data(globals, bh)
+        vm.get_block_data(globals, bh)?
     } else {
         return vm.generate_enumerator(id, lfp.self_val(), vec![]);
     };
@@ -260,7 +260,7 @@ fn generator_each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<
         }
     }
     let self_val: Generator = lfp.self_val().into();
-    let data = vm.get_block_data(globals, lfp.expect_block()?);
+    let data = vm.get_block_data(globals, lfp.expect_block()?)?;
     let internal = self_val.create_internal();
     vm.temp_push(internal.into());
     let res = each_inner(vm, globals, internal, &data);

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -100,7 +100,7 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     }
     let self_val: Enumerator = lfp.self_val().into();
     let data = if let Some(bh) = lfp.block() {
-        globals.get_block_data(vm.cfp(), bh)
+        vm.get_block_data(globals, bh)
     } else {
         return Ok(self_val.into());
     };
@@ -164,7 +164,7 @@ fn with_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
 
     let id = IdentId::get_id("with_index");
     let data = if let Some(bh) = lfp.block() {
-        globals.get_block_data(vm.cfp(), bh)
+        vm.get_block_data(globals, bh)
     } else {
         return vm.generate_enumerator(id, lfp.self_val(), vec![]);
     };
@@ -260,7 +260,7 @@ fn generator_each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<
         }
     }
     let self_val: Generator = lfp.self_val().into();
-    let data = globals.get_block_data(vm.cfp(), lfp.expect_block()?);
+    let data = vm.get_block_data(globals, lfp.expect_block()?);
     let internal = self_val.create_internal();
     vm.temp_push(internal.into());
     let res = each_inner(vm, globals, internal, &data);

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -9,7 +9,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(FIBER_CLASS, "new", fiber_new, 0);
     globals.define_builtin_class_inline_func_rest(
         FIBER_CLASS,
-        &["yield"],
+        "yield",
         fiber_yield,
         Box::new(fiber_yield_inline),
         analysis::v_v_vv,

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -163,7 +163,7 @@ fn values(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp) -> Result<Value>
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
     let ary = lfp.self_val();
-    let data = globals.get_block_data(vm.cfp(), bh);
+    let data = vm.get_block_data(globals, bh);
     for (k, v) in ary.as_hash().iter() {
         vm.invoke_block(globals, &data, &[k, v])?;
     }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -163,7 +163,7 @@ fn values(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp) -> Result<Value>
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
     let ary = lfp.self_val();
-    let data = vm.get_block_data(globals, bh);
+    let data = vm.get_block_data(globals, bh)?;
     for (k, v) in ary.as_hash().iter() {
         vm.invoke_block(globals, &data, &[k, v])?;
     }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -129,7 +129,7 @@ fn print(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 #[monoruby_builtin]
 fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
-    let data = vm.get_block_data(globals, bh);
+    let data = vm.get_block_data(globals, bh)?;
     loop {
         if let Err(err) = vm.invoke_block(globals, &data, &[]) {
             return if err.kind() == &MonorubyErrKind::StopIteration {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -129,7 +129,7 @@ fn print(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 #[monoruby_builtin]
 fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
     let bh = lfp.expect_block()?;
-    let data = globals.get_block_data(vm.cfp(), bh);
+    let data = vm.get_block_data(globals, bh);
     loop {
         if let Err(err) = vm.invoke_block(globals, &data, &[]) {
             return if err.kind() == &MonorubyErrKind::StopIteration {

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -7,7 +7,7 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Proc", PROC_CLASS);
     globals.define_builtin_class_func(PROC_CLASS, "new", new, 0);
-    globals.define_builtin_func_rest(PROC_CLASS, "call", call);
+    globals.define_builtin_funcs_rest(PROC_CLASS, "call", &["[]", "yield", "==="], call);
 }
 
 ///
@@ -29,11 +29,12 @@ fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
 ///
 /// ### Proc#call
 ///
-/// - [NOT SUPPORTED] self[*arg] -> ()
+/// - self[*arg] -> ()
 /// - call(*arg) -> ()
-/// - [NOT SUPPORTED] self === *arg -> ()
-/// - [NOT SUPPORTED] yield(*arg) -> ()
+/// - self === *arg -> ()
+/// - yield(*arg) -> ()
 ///
+/// TODO: we must support [] with >2 args.
 /// [https://docs.ruby-lang.org/ja/latest/method/Proc/i/=3d=3d=3d.html]
 #[monoruby_builtin]
 fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
@@ -72,6 +73,18 @@ mod test {
         a
         ",
         )
+    }
+
+    #[test]
+    fn proc1() {
+        run_test_with_prelude(
+            r#"
+        [p.call(3,4), p.yield(3,4), p[3,4], p.===(3,4)]
+        "#,
+            r#"
+        p = Proc.new {|x,y| x * y} 
+        "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -126,4 +126,21 @@ mod test {
         ",
         );
     }
+
+    #[test]
+    fn block_param() {
+        run_test_with_prelude(
+            r#"
+            $ans = []
+            [1, 2, 3].each(&Foo.new)
+        "#,
+            r#"
+            class Foo
+              def to_proc
+                Proc.new {|v| $ans << v * v}
+              end
+            end
+        "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -142,5 +142,24 @@ mod test {
             end
         "#,
         );
+        run_test_error(
+            r#"
+        class Foo
+            def to_proc
+                :xxx
+            end
+        end
+
+        [1,2,3].each(&Foo.new)
+        "#,
+        );
+        run_test_error(
+            r#"
+        class Foo
+        end
+
+        [1,2,3].each(&Foo.new)
+        "#,
+        );
     }
 }

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -110,7 +110,7 @@ fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
             }
 
             let iter = (start..end).map(Value::fixnum);
-            let data = vm.get_block_data(globals, bh);
+            let data = vm.get_block_data(globals, bh)?;
             for val in iter {
                 if !vm.invoke_block(globals, &data, &[val])?.as_bool() {
                     return Ok(Value::bool(false));

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -110,7 +110,7 @@ fn all_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
             }
 
             let iter = (start..end).map(Value::fixnum);
-            let data = globals.get_block_data(vm.cfp(), bh);
+            let data = vm.get_block_data(globals, bh);
             for val in iter {
                 if !vm.invoke_block(globals, &data, &[val])?.as_bool() {
                     return Ok(Value::bool(false));

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -956,7 +956,7 @@ fn scan_inner(
     block: BlockHandler,
     vec: &[Value],
 ) -> Result<()> {
-    let data = vm.get_block_data(globals, block);
+    let data = vm.get_block_data(globals, block)?;
     for arg in vec {
         match arg.try_array_ty() {
             Some(ary) => {

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -956,7 +956,7 @@ fn scan_inner(
     block: BlockHandler,
     vec: &[Value],
 ) -> Result<()> {
-    let data = globals.get_block_data(vm.cfp(), block);
+    let data = vm.get_block_data(globals, block);
     for arg in vec {
         match arg.try_array_ty() {
             Some(ary) => {

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -55,7 +55,7 @@ fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
 
     if let Some(bh) = lfp.block() {
         vm.push_class_context(class_id);
-        let data = globals.get_block_data(vm.cfp(), bh);
+        let data = vm.get_block_data(globals, bh);
         vm.invoke_block_with_self(globals, &data, new_struct, &[new_struct])?;
         vm.pop_class_context();
     };

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -34,9 +34,10 @@ fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
     } else {
         0
     };
-    globals.define_builtin_class_inline_func_rest(
+    globals.define_builtin_class_inline_funcs_rest(
         class_id,
-        &["[]", "new"],
+        "new",
+        &["[]"],
         new,
         Box::new(super::class::gen_class_new_object()),
         analysis::v_v_vv,

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -55,7 +55,7 @@ fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
 
     if let Some(bh) = lfp.block() {
         vm.push_class_context(class_id);
-        let data = vm.get_block_data(globals, bh);
+        let data = vm.get_block_data(globals, bh)?;
         vm.invoke_block_with_self(globals, &data, new_struct, &[new_struct])?;
         vm.pop_class_context();
     };

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -49,5 +49,10 @@ mod test {
         :to_i.to_proc["ff", 16]
         "#,
         );
+        run_test(
+            r#"
+        (1..3).collect(&:to_s)
+        "#,
+        );
     }
 }

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -36,4 +36,18 @@ mod test {
             &[":aaa", ":xxx", "nil", "3"],
         );
     }
+
+    #[test]
+    fn symbol_to_proc() {
+        run_test(
+            r#"
+        :to_i.to_proc.call("42")
+        "#,
+        );
+        run_test(
+            r#"
+        :to_i.to_proc["ff", 16]
+        "#,
+        );
+    }
 }

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -483,7 +483,11 @@ impl BytecodeGen {
                     _ => unreachable!(),
                 }
             }
-            BcIr::LoadDynVar { ret, src, outer } => {
+            BcIr::LoadDynVar {
+                dst: ret,
+                src,
+                outer,
+            } => {
                 let op1 = self.slot_id(&ret);
                 let op2 = self.slot_id(&src);
                 let op3 = outer as u16;

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -151,14 +151,7 @@ impl BytecodeGen {
                 let name = IdentId::get_id_from_string(ident);
                 if let Some(src) = self.refer_dynamic_local(outer, name) {
                     let src = src.into();
-                    self.emit(
-                        BcIr::LoadDynVar {
-                            ret: dst,
-                            src,
-                            outer,
-                        },
-                        loc,
-                    );
+                    self.emit(BcIr::LoadDynVar { dst, src, outer }, loc);
                 } else {
                     assert_eq!(Some(name), self.block_param);
                     self.emit(BcIr::BlockArg(dst, outer), loc);
@@ -423,7 +416,14 @@ impl BytecodeGen {
                 let lvar = IdentId::get_id_from_string(ident);
                 if let Some(src) = self.refer_dynamic_local(outer, lvar) {
                     let src = src.into();
-                    self.emit(BcIr::LoadDynVar { ret, src, outer }, loc);
+                    self.emit(
+                        BcIr::LoadDynVar {
+                            dst: ret,
+                            src,
+                            outer,
+                        },
+                        loc,
+                    );
                 } else {
                     assert_eq!(Some(lvar), self.outer_block_param_name(outer));
                     self.emit(BcIr::BlockArg(ret, outer), loc);

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -107,7 +107,7 @@ pub(super) enum BcIr {
     BlockArg(BcReg, usize),
     LoadDynVar {
         /// return register of the current frame.
-        ret: BcReg,
+        dst: BcReg,
         /// source register of the outer frame.
         src: BcReg,
         /// outer frame count.

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -487,7 +487,7 @@ impl Executor {
     ///
     /// To get BlockData, use get_block_data().
     ///  
-    /// let data = globals.get_block_data(cfp, block);
+    /// let data = vm.get_block_data(globals, block);
     ///
     pub(crate) fn invoke_block(
         &mut self,
@@ -534,7 +534,7 @@ impl Executor {
         bh: BlockHandler,
         args: &[Value],
     ) -> Result<Value> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         self.invoke_block(globals, &data, args)
     }
 
@@ -544,7 +544,7 @@ impl Executor {
         bh: BlockHandler,
         iter: impl Iterator<Item = Value>,
     ) -> Result<()> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         for val in iter {
             self.invoke_block(globals, &data, &[val])?;
         }
@@ -557,7 +557,7 @@ impl Executor {
         bh: BlockHandler,
         iter: impl Iterator<Item = Value>,
     ) -> Result<()> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         for (index, val) in iter.enumerate() {
             self.invoke_block(globals, &data, &[val, Value::integer(index as i64)])?;
         }
@@ -571,7 +571,7 @@ impl Executor {
         iter: impl Iterator<Item = Value>,
         size_hint: impl Into<Option<usize>>,
     ) -> Result<Value> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         let old = alloc::Allocator::<RValue>::set_enabled(false);
         self.temp_array_new(size_hint);
         for v in iter {
@@ -590,7 +590,7 @@ impl Executor {
         iter: impl Iterator<Item = Value>,
         size_hint: impl Into<Option<usize>>,
     ) -> Result<Value> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         let old = alloc::Allocator::<RValue>::set_enabled(false);
         self.temp_array_new(size_hint);
         for v in iter {
@@ -613,7 +613,7 @@ impl Executor {
         iter: impl Iterator<Item = Value>,
         mut res: Value,
     ) -> Result<Value> {
-        let data = globals.get_block_data(self.cfp(), bh);
+        let data = self.get_block_data(globals, bh);
         for elem in iter {
             res = self.invoke_block(globals, &data, &[res, elem])?;
         }
@@ -680,6 +680,37 @@ impl Executor {
             bh,
         )
     }
+}
+
+impl Executor {
+    ///
+    /// Generate *ProcInner* from 'bh'.
+    ///
+    pub(crate) fn get_block_data(&mut self, globals: &mut Globals, bh: BlockHandler) -> ProcInner {
+        let mut cfp = self.cfp();
+        if let Some((func_id, idx)) = bh.try_proxy() {
+            for _ in 0..idx {
+                cfp = cfp.prev().unwrap();
+            }
+            ProcInner::from(cfp.lfp(), func_id)
+        } else if let Some(proc) = bh.try_proc() {
+            proc.clone()
+        } else {
+            let proc = self
+                .invoke_method(globals, IdentId::TO_PROC, bh.get(), &[], None)
+                .unwrap();
+            proc.as_proc().clone()
+        }
+    }
+
+    ///
+    /// Generate *ProcInner* from a given block.
+    ///
+    pub(crate) fn get_yield_data(&mut self, globals: &mut Globals) -> Option<ProcInner> {
+        self.cfp()
+            .get_block()
+            .map(|bh| self.get_block_data(globals, bh))
+    }
 
     pub(crate) fn define_class(
         &mut self,
@@ -727,7 +758,7 @@ impl Executor {
         if bh.try_proxy().is_some() {
             let outer_lfp = self.cfp().prev().unwrap().lfp();
             outer_lfp.move_frame_to_heap();
-            let proc = Proc::new(globals.get_block_data(self.cfp(), bh));
+            let proc = Proc::new(self.get_block_data(globals, bh));
             Ok(proc)
         } else if bh.try_proc().is_some() {
             Ok(bh.0.into())
@@ -871,10 +902,6 @@ impl BlockHandler {
 
     pub fn try_proc(&self) -> Option<&ProcInner> {
         self.0.is_proc()
-    }
-
-    pub(crate) fn as_proc(&self) -> &ProcInner {
-        self.0.as_proc()
     }
 
     pub(crate) fn id(&self) -> u64 {

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -204,9 +204,10 @@ impl Globals {
         );
         assert_eq!(
             OBJECT_SEND_FUNCID,
-            globals.define_builtin_inline_func_with(
+            globals.define_builtin_inline_funcs_with(
                 OBJECT_CLASS,
-                &["send", "__send__"],
+                "send",
+                &["__send__"],
                 crate::builtins::send,
                 Box::new(crate::builtins::object_send),
                 analysis::v_v_vv,

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -160,15 +160,6 @@ impl MonorubyErr {
         MonorubyErr::new_with_loc(MonorubyErrKind::Unimplemented, msg, lhs.loc, sourceinfo)
     }
 
-    pub(crate) fn unsupported_block_param(lhs: &Node, sourceinfo: SourceInfoRef) -> MonorubyErr {
-        let msg = format!("unsupported block parameter type {:?}", lhs.kind);
-        eprintln!(
-            "{}",
-            ansi_term::Colour::Red.paint(format!("warning: {msg}"))
-        );
-        MonorubyErr::new_with_loc(MonorubyErrKind::Unimplemented, msg, lhs.loc, sourceinfo)
-    }
-
     pub(crate) fn unsupported_node(expr: Node, sourceinfo: SourceInfoRef) -> MonorubyErr {
         let msg = format!("unsupported nodekind {:?}", expr.kind);
         eprintln!(

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -535,6 +535,7 @@ pub enum TypeErrKind {
     CantConverFloat { val: Value },
     CantCoercedInteger { op: IdentId, val: Value },
     CantCoercedFloat { op: IdentId, val: Value },
+    WrongArgumentTypeProc { val: Value },
     Other,
 }
 
@@ -567,6 +568,12 @@ impl TypeErrKind {
             TypeErrKind::CantCoercedFloat { op, val } => {
                 format!(
                     "{op}: {} can't be coerced into Float",
+                    val.get_real_class_name(globals)
+                )
+            }
+            TypeErrKind::WrongArgumentTypeProc { val } => {
+                format!(
+                    "wrong argument type {} (expected Proc)",
                     val.get_real_class_name(globals)
                 )
             }

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -102,6 +102,7 @@ impl IdentId {
     pub const MICROSECOND: IdentId = id!(41);
     pub const NANOSECOND: IdentId = id!(42);
     pub const _MATCH: IdentId = id!(43);
+    pub const TO_PROC: IdentId = id!(44);
 }
 
 impl IdentId {
@@ -234,6 +235,7 @@ impl IdentifierTable {
         table.set_id("microsecond", IdentId::MICROSECOND);
         table.set_id("nanosecond", IdentId::NANOSECOND);
         table.set_id("=~", IdentId::_MATCH);
+        table.set_id("to_proc", IdentId::TO_PROC);
         table
     }
 

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -176,7 +176,7 @@ impl RegexpInner {
         ) -> Result<(String, bool)> {
             let mut range = vec![];
             let mut i = 0;
-            let data = vm.get_block_data(globals, bh);
+            let data = vm.get_block_data(globals, bh)?;
             loop {
                 let (start, end, matched_str) = match re.captures_from_pos(given, i) {
                     Ok(None) => break,

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -176,7 +176,7 @@ impl RegexpInner {
         ) -> Result<(String, bool)> {
             let mut range = vec![];
             let mut i = 0;
-            let data = globals.get_block_data(vm.cfp(), bh);
+            let data = vm.get_block_data(globals, bh);
             loop {
                 let (start, end, matched_str) = match re.captures_from_pos(given, i) {
                     Ok(None) => break,

--- a/monoruby/startup/startup.rb
+++ b/monoruby/startup/startup.rb
@@ -74,3 +74,11 @@ module Warning
     true
   end
 end
+
+class Symbol
+  def to_proc
+    Proc.new do |slf, *args|
+      slf.send(self, *args)
+    end
+  end
+end


### PR DESCRIPTION
Supports
```ruby
class Foo
  def to_proc
    Proc.new {|v| p v }
  end
end
[1, 2, 3].each(&Foo.new)

```