### PR TITLE
Support safe navigation operator.

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -786,6 +786,11 @@ impl BytecodeGen {
         );
     }
 
+    fn emit_nilbr(&mut self, cond: BcReg, jmp_pos: Label) {
+        self.add_merge(jmp_pos);
+        self.emit(BcIr::NilBr(cond, jmp_pos), Loc::default());
+    }
+
     fn emit_check_local(&mut self, local: BcReg, else_pos: Label) {
         self.add_merge(else_pos);
         self.emit(BcIr::CheckLocal(local, else_pos), Loc::default());

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -149,6 +149,16 @@ impl BytecodeGen {
                 );
                 Bc::from(op)
             }
+            BcIr::NilBr(reg, dst) => {
+                // 37
+                let dst = self[dst].to_usize();
+                incoming.push(idx, dst);
+                incoming.push(idx, idx + 1);
+                let op1 = self.slot_id(&reg);
+                let op2 = dst as isize - idx as isize - 1;
+                let op = enc_wl(37, op1.0, op2 as u32);
+                Bc::from(op)
+            }
             BcIr::CheckLocal(local, dst) => {
                 // 20
                 let op1 = self.slot_id(&local);

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -90,6 +90,7 @@ impl BytecodeGen {
                         IdentId::_INDEX,
                         Some(base),
                         arglist,
+                        false,
                         UseMode2::Store(dst),
                         loc,
                     )?;
@@ -191,18 +192,25 @@ impl BytecodeGen {
                 box receiver,
                 method,
                 arglist,
-                safe_nav: false,
+                safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                self.gen_method_call(method, Some(receiver), arglist, UseMode2::Store(dst), loc)?;
+                self.gen_method_call(
+                    method,
+                    Some(receiver),
+                    arglist,
+                    safe_nav,
+                    UseMode2::Store(dst),
+                    loc,
+                )?;
             }
             NodeKind::FuncCall {
                 method,
                 arglist,
-                safe_nav: false,
+                safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                self.gen_method_call(method, None, arglist, UseMode2::Store(dst), loc)?;
+                self.gen_method_call(method, None, arglist, safe_nav, UseMode2::Store(dst), loc)?;
             }
             NodeKind::Return(box val) => {
                 if self.is_block() {
@@ -325,7 +333,14 @@ impl BytecodeGen {
                     self.gen_index(None, base, index.remove(0), loc)?;
                 } else if index.len() == 2 {
                     let arglist = ArgList::from_args(index);
-                    self.gen_method_call(IdentId::_INDEX, Some(base), arglist, use_mode, loc)?;
+                    self.gen_method_call(
+                        IdentId::_INDEX,
+                        Some(base),
+                        arglist,
+                        false,
+                        use_mode,
+                        loc,
+                    )?;
                     return Ok(());
                 } else {
                     return Err(MonorubyErr::unsupported_feature(
@@ -434,18 +449,25 @@ impl BytecodeGen {
                 box receiver,
                 method,
                 arglist,
-                safe_nav: false,
+                safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                return self.gen_method_call(method, Some(receiver), arglist, use_mode, loc);
+                return self.gen_method_call(
+                    method,
+                    Some(receiver),
+                    arglist,
+                    safe_nav,
+                    use_mode,
+                    loc,
+                );
             }
             NodeKind::FuncCall {
                 method,
                 arglist,
-                safe_nav: false,
+                safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                return self.gen_method_call(method, None, arglist, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, safe_nav, use_mode, loc);
             }
             NodeKind::Super(arglist) => {
                 return self.gen_super(arglist, use_mode, loc);
@@ -453,7 +475,7 @@ impl BytecodeGen {
             NodeKind::Command(box expr) => {
                 let arglist = ArgList::from_args(vec![expr]);
                 let method = IdentId::get_id("`");
-                return self.gen_method_call(method, None, arglist, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, false, use_mode, loc);
             }
             NodeKind::Yield(arglist) => {
                 return self.gen_yield(arglist, use_mode, loc);
@@ -461,7 +483,7 @@ impl BytecodeGen {
             NodeKind::Ident(method) => {
                 let arglist = ArgList::default();
                 let method = IdentId::get_id_from_string(method);
-                return self.gen_method_call(method, None, arglist, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, false, use_mode, loc);
             }
             NodeKind::If {
                 box cond,

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -145,6 +145,8 @@ pub(super) enum BcIr {
     CheckLocal(BcReg, Label),
     Br(Label),
     CondBr(BcReg, Label, bool, BrKind),
+    /// when *BcReg* is nil, goto *Label*.
+    NilBr(BcReg, Label),
     OptCase {
         // a register for cond and ret.
         reg: BcReg,

--- a/monoruby/src/compiler/jitgen.rs
+++ b/monoruby/src/compiler/jitgen.rs
@@ -826,6 +826,13 @@ impl JitContext {
                 self.ir.inst.push(AsmInst::CondBr(brkind, branch_dest));
                 self.new_branch(func, bb_pos, dest_idx, bb.clone(), branch_dest);
             }
+            TraceIr::NilBr(cond_, disp) => {
+                let dest_idx = bb_pos + 1 + disp;
+                let branch_dest = self.asm_label();
+                self.ir.fetch_to_reg(bb, cond_, GP::Rax);
+                self.ir.inst.push(AsmInst::NilBr(branch_dest));
+                self.new_branch(func, bb_pos, dest_idx, bb.clone(), branch_dest);
+            }
             TraceIr::CondBr(_, _, true, _) => {}
             TraceIr::CheckLocal(local, disp) => {
                 let dest_idx = bb_pos + 1 + disp;

--- a/monoruby/src/compiler/jitgen/analysis.rs
+++ b/monoruby/src/compiler/jitgen/analysis.rs
@@ -423,6 +423,10 @@ impl JitContext {
                     info.r#use(cond_);
                     return (ExitType::Continue, info);
                 }
+                TraceIr::NilBr(cond_, _) => {
+                    info.r#use(cond_);
+                    return (ExitType::Continue, info);
+                }
                 TraceIr::CheckLocal(src, _) => {
                     info.r#use(src);
                     return (ExitType::Continue, info);

--- a/monoruby/src/compiler/jitgen/asmir.rs
+++ b/monoruby/src/compiler/jitgen/asmir.rs
@@ -982,6 +982,7 @@ pub(super) enum AsmInst {
     EnsureEnd,
     Br(AsmLabel),
     CondBr(BrKind, AsmLabel),
+    NilBr(AsmLabel),
     CheckLocal(AsmLabel),
     ///
     /// Conditional branch

--- a/monoruby/src/compiler/jitgen/asmir/compile.rs
+++ b/monoruby/src/compiler/jitgen/asmir/compile.rs
@@ -237,6 +237,13 @@ impl Codegen {
                     BrKind::BrIfNot => monoasm!( &mut self.jit, jeq dest;),
                 }
             }
+            AsmInst::NilBr(dest) => {
+                let dest = ctx[dest];
+                monoasm!( &mut self.jit,
+                    cmpq rax, (NIL_VALUE);
+                    jeq  dest;
+                );
+            }
             AsmInst::CheckLocal(branch_dest) => {
                 let branch_dest = ctx[branch_dest];
                 monoasm!( &mut self.jit,

--- a/monoruby/src/compiler/jitgen/trace_ir.rs
+++ b/monoruby/src/compiler/jitgen/trace_ir.rs
@@ -10,6 +10,8 @@ pub(crate) enum TraceIr {
     Br(i32),
     /// conditional branch(%reg, dest, optimizable)  : branch when reg was true.
     CondBr(SlotId, i32, bool, BrKind),
+    /// conditional branch(%reg, dest)  : branch when reg is nil.
+    NilBr(SlotId, i32),
     /// check local var(%reg, dest)  : branch when reg was None.
     OptCase {
         cond: SlotId,

--- a/monoruby/src/compiler/vmgen.rs
+++ b/monoruby/src/compiler/vmgen.rs
@@ -259,6 +259,7 @@ impl Codegen {
         self.dispatch[34] = self.vm_yield();
         self.dispatch[35] = self.vm_array();
         self.dispatch[36] = self.vm_optcase(branch);
+        self.dispatch[37] = self.vm_nilbr(branch);
 
         self.dispatch[64] = self.vm_defined_yield();
         self.dispatch[65] = self.vm_defined_const();
@@ -1317,6 +1318,18 @@ impl Codegen {
             orq r15, 0x10;
             cmpq r15, (FALSE_VALUE);
             jne branch;
+        };
+        self.fetch_and_dispatch();
+        label
+    }
+
+    fn vm_nilbr(&mut self, branch: DestLabel) -> CodePtr {
+        let label = self.jit.get_current_address();
+        self.fetch2();
+        self.vm_get_slot_value(GP::R15);
+        monoasm! { &mut self.jit,
+            cmpq r15, (NIL_VALUE);
+            je branch;
         };
         self.fetch_and_dispatch();
         label

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1277,6 +1277,7 @@ impl BcPc {
                     cond: SlotId::new(op1),
                     optid: OptCaseId::from(op2),
                 },
+                37 => TraceIr::NilBr(SlotId::new(op1), op2 as i32),
                 _ => unreachable!("{:016x}", op),
             }
         } else {

--- a/monoruby/src/globals/dump.rs
+++ b/monoruby/src/globals/dump.rs
@@ -235,6 +235,9 @@ impl Globals {
                     i as i32 + 1 + disp
                 )
             }
+            TraceIr::NilBr(reg, disp) => {
+                format!("nilbr {:?} =>:{:05}", reg, i as i32 + 1 + disp)
+            }
             TraceIr::OptCase { cond: dst, optid } => {
                 format!("opt_case {:?}->({:?})", dst, self.store[optid])
             }

--- a/monoruby/src/tests/method_call.rs
+++ b/monoruby/src/tests/method_call.rs
@@ -565,4 +565,18 @@ mod test {
         "#,
         );
     }
+
+    #[test]
+    fn safe_nav_operator() {
+        run_test(
+            r#"
+        a = [1,2,3,nil] * 5
+        x = []
+        for e in a
+          x << e&.nil?
+        end
+        x
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
test code
```ruby
nil&.nil?
```
bytecode
```
+:00000 [01] init_method reg:2 arg:0 req:0 opt:0 rest:false stack_offset:5
 :00001 [02] %1 = nil
 :00002 [02] nilbr %1 =>:00006
+:00003 [02] %1 = %1.nil?()                       [-]
 :00005 [02] br =>:00007
+:00006 [02] %1 = nil
+:00007 [01] ret %1
```