### PR TITLE
impl BytecodeInst::ToA.

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -845,6 +845,10 @@ impl BytecodeGen {
         }
     }
 
+    fn emit_toa(&mut self, dst: BcReg, src: BcReg, loc: Loc) {
+        self.emit(BytecodeInst::ToA { dst, src }, loc);
+    }
+
     fn emit_br(&mut self, jmp_pos: Label) {
         self.add_merge(jmp_pos);
         self.emit(BytecodeInst::Br(jmp_pos), Loc::default());
@@ -1348,7 +1352,9 @@ impl BytecodeGen {
         let len = args.len();
         for (i, arg) in args.into_iter().enumerate() {
             if let NodeKind::Splat(box expr) = arg.kind {
-                self.push_expr(expr)?;
+                let loc = arg.loc;
+                let temp = self.push_expr(expr)?;
+                self.emit_toa(temp.into(), temp.into(), loc);
                 splat_pos.push(i);
             } else {
                 self.push_expr(arg)?;

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -561,6 +561,11 @@ impl BytecodeGen {
                 let op2 = self.slot_id(&args);
                 Bytecode::from(enc_www(174, op1.0, op2.0, len))
             }
+            BytecodeInst::ToA { dst, src } => {
+                let op1 = self.slot_id(&dst);
+                let op2 = self.slot_id(&src);
+                Bytecode::from(enc_ww(175, op1.0, op2.0))
+            }
             BytecodeInst::Mov(dst, src) => {
                 let op1 = self.slot_id(&dst);
                 let op2 = self.slot_id(&src);

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -163,6 +163,10 @@ pub(super) enum BytecodeInst {
     BinOp(BinOpK, Option<BcReg>, BinopMode), // kind, ret, (lhs, rhs)
     Cmp(CmpKind, Option<BcReg>, BinopMode, bool), // kind, dst, (lhs, rhs), optimizable
     Mov(BcReg, BcReg),                       // dst, offset
+    ToA {
+        dst: BcReg,
+        src: BcReg,
+    },
     CheckLocal(BcReg, Label),
     Br(Label),
     CondBr(BcReg, Label, bool, BrKind),

--- a/monoruby/src/compiler/jitgen/asmir.rs
+++ b/monoruby/src/compiler/jitgen/asmir.rs
@@ -309,6 +309,11 @@ impl AsmIr {
         self.push(AsmInst::LoadSVar { id, using_xmm });
     }
 
+    pub(super) fn to_a(&mut self, bb: &BBContext, src: SlotId) {
+        let using_xmm = bb.get_using_xmm();
+        self.push(AsmInst::ToA { src, using_xmm });
+    }
+
     pub(super) fn concat_str(&mut self, bb: &BBContext, arg: SlotId, len: u16) {
         let using_xmm = bb.get_using_xmm();
         self.push(AsmInst::ConcatStr {
@@ -1149,6 +1154,10 @@ pub(super) enum AsmInst {
         start: SlotId,
         end: SlotId,
         exclude_end: bool,
+        using_xmm: UsingXmm,
+    },
+    ToA {
+        src: SlotId,
         using_xmm: UsingXmm,
     },
     ConcatStr {

--- a/monoruby/src/compiler/jitgen/asmir/compile.rs
+++ b/monoruby/src/compiler/jitgen/asmir/compile.rs
@@ -707,6 +707,9 @@ impl Codegen {
             } => {
                 self.concat_string(arg, len, using_xmm);
             }
+            AsmInst::ToA { src, using_xmm } => {
+                self.to_a(src, using_xmm);
+            }
             AsmInst::ConcatRegexp {
                 arg,
                 len,
@@ -865,6 +868,18 @@ impl Codegen {
             lea rdx, [r14 - (conv(arg))];
             movq rcx, (len);
             movq rax, (runtime::concatenate_string);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+    }
+
+    fn to_a(&mut self, src: SlotId, using_xmm: UsingXmm) {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rdx, [r14 - (conv(src))];
+            movq rax, (runtime::to_a);
             call rax;
         );
         self.xmm_restore(using_xmm);

--- a/monoruby/src/compiler/jitgen/compile.rs
+++ b/monoruby/src/compiler/jitgen/compile.rs
@@ -550,6 +550,13 @@ impl JitContext {
                     return CompileResult::Recompile;
                 }
             }
+            TraceIr::ToA { dst, src } => {
+                let error = ir.new_error(bbctx);
+                bbctx.write_back_slot(ir, src);
+                ir.to_a(bbctx, src);
+                ir.handle_error(error);
+                bbctx.rax2acc(ir, dst);
+            }
             TraceIr::Mov(dst, src) => {
                 bbctx.copy_slot(ir, src, dst);
             }

--- a/monoruby/src/compiler/jitgen/trace_ir.rs
+++ b/monoruby/src/compiler/jitgen/trace_ir.rs
@@ -235,6 +235,11 @@ pub(crate) enum TraceIr {
     Raise(SlotId),
     /// ensure_end
     EnsureEnd,
+    /// toa{%src, %dst}
+    ToA {
+        dst: SlotId,
+        src: SlotId,
+    },
     /// move(%dst, %src)
     Mov(SlotId, SlotId),
     /// initialize_method
@@ -679,7 +684,8 @@ impl TraceIr {
             TraceIr::BlockBreak(reg) => format!("break {:?}", reg),
             TraceIr::Raise(reg) => format!("raise {:?}", reg),
             TraceIr::EnsureEnd => format!("ensure_end"),
-            TraceIr::Mov(dst, src) => format!("{:?} = {:?}", dst, src),
+            TraceIr::ToA { dst, src } => format!("{dst:?} = {src:?}.to_a"),
+            TraceIr::Mov(dst, src) => format!("{dst:?} = {src:?}"),
             TraceIr::MethodCall {
                 polymorphic,
                 callid,

--- a/monoruby/src/compiler/runtime.rs
+++ b/monoruby/src/compiler/runtime.rs
@@ -159,11 +159,8 @@ pub(super) extern "C" fn gen_array(
             let mut ary = Array::new_empty();
             for (i, v) in iter.enumerate() {
                 if globals.store[callid].splat_pos.contains(&i) {
-                    if let Some(a) = v.try_array_ty() {
-                        ary.extend_from_slice(&a);
-                    } else {
-                        unreachable!("splat arguments must be Array.");
-                    }
+                    let a = v.try_array_ty().expect("splat arguments must be Array.");
+                    ary.extend_from_slice(&a);
                 } else {
                     ary.push(v);
                 }

--- a/monoruby/src/compiler/runtime.rs
+++ b/monoruby/src/compiler/runtime.rs
@@ -157,22 +157,12 @@ pub(super) extern "C" fn gen_array(
             Some(Value::array_from_iter(iter))
         } else {
             let mut ary = Array::new_empty();
-            let to_a = IdentId::get_id("to_a");
             for (i, v) in iter.enumerate() {
                 if globals.store[callid].splat_pos.contains(&i) {
-                    if let Some(fid) = globals.check_method(v, to_a) {
-                        let a = vm.invoke_func(globals, fid, v, &[], None)?;
-                        if let Some(a) = a.try_array_ty() {
-                            ary.extend_from_slice(&a);
-                        } else {
-                            vm.set_error(MonorubyErr::typeerr(
-                                "`to_a' method should return Array.",
-                                TypeErrKind::Other,
-                            ));
-                            return None;
-                        }
+                    if let Some(a) = v.try_array_ty() {
+                        ary.extend_from_slice(&a);
                     } else {
-                        ary.push(v);
+                        unreachable!("splat arguments must be Array.");
                     }
                 } else {
                     ary.push(v);
@@ -737,6 +727,29 @@ pub(super) extern "C" fn raise_err(vm: &mut Executor, err_val: Value) {
     match err_val.is_exception() {
         Some(ex) => vm.set_error(MonorubyErr::new_from_exception(ex)),
         None => unimplemented!(),
+    }
+}
+
+pub(super) extern "C" fn to_a(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: Value,
+) -> Option<Value> {
+    if let Some(func_id) = globals.check_method(src, IdentId::TO_A) {
+        let ary = vm.invoke_func(globals, func_id, src, &[], None)?;
+        if ary.is_array_ty() {
+            Some(ary)
+        } else {
+            let src_class = src.class().get_name_id(&globals.store);
+            let res_class = ary.class().get_name_id(&globals.store);
+            vm.set_error(MonorubyErr::typeerr(
+                format!("can't convert {src_class} to Array ({src_class}#to_a gives {res_class})"),
+                TypeErrKind::Other,
+            ));
+            None
+        }
+    } else {
+        Some(Value::array1(src))
     }
 }
 

--- a/monoruby/src/compiler/runtime/args.rs
+++ b/monoruby/src/compiler/runtime/args.rs
@@ -241,11 +241,8 @@ fn positional(
         for i in 0..pos_num {
             let v = unsafe { *src.sub(i) };
             if splat_pos.contains(&i) {
-                if let Some(ary) = v.try_array_ty() {
-                    push_ary(&mut arg_num, &mut rest, max_pos, dst, &ary, no_push);
-                } else {
-                    unreachable!("splat arguments must be an array");
-                };
+                let ary = v.try_array_ty().expect("splat arguments must be an array");
+                push_ary(&mut arg_num, &mut rest, max_pos, dst, &ary, no_push);
             } else {
                 push(&mut arg_num, &mut rest, max_pos, dst, v, no_push);
             }

--- a/monoruby/src/compiler/runtime/args.rs
+++ b/monoruby/src/compiler/runtime/args.rs
@@ -137,9 +137,13 @@ pub(crate) fn set_frame_block(caller: &CallSiteInfo, callee_lfp: Lfp, caller_lfp
     let bh = if let Some(block_fid) = block_fid {
         let bh = BlockHandler::from_caller(block_fid);
         Some(bh)
+    } else if let Some(block_arg) = block_arg {
+        match caller_lfp.register(block_arg.0 as usize) {
+            Some(v) => Some(BlockHandler::new(v)),
+            None => None,
+        }
     } else {
-        block_arg
-            .map(|block_arg| BlockHandler::new(caller_lfp.register(block_arg.0 as usize).unwrap()))
+        None
     };
     callee_lfp.set_block(bh);
 }
@@ -239,12 +243,8 @@ fn positional(
             if splat_pos.contains(&i) {
                 if let Some(ary) = v.try_array_ty() {
                     push_ary(&mut arg_num, &mut rest, max_pos, dst, &ary, no_push);
-                } else if let Some(_range) = v.is_range() {
-                    unimplemented!()
-                } else if let Some(_hash) = v.is_hash() {
-                    unimplemented!()
                 } else {
-                    push(&mut arg_num, &mut rest, max_pos, dst, v, no_push);
+                    unreachable!("splat arguments must be an array");
                 };
             } else {
                 push(&mut arg_num, &mut rest, max_pos, dst, v, no_push);

--- a/monoruby/src/compiler/vmgen.rs
+++ b/monoruby/src/compiler/vmgen.rs
@@ -220,6 +220,24 @@ impl Codegen {
         };
         self.fetch_and_dispatch();
 
+        //BcOp::ToA
+        let toa = self.jit.get_current_address();
+        let raise = self.entry_raise();
+        self.fetch3();
+        self.vm_get_slot_addr(GP::R15);
+        self.vm_get_slot_value(GP::Rdi);
+        monoasm! { &mut self.jit,
+            movq rdx, rdi;
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::to_a);
+            call rax;
+            testq rax, rax;
+            je  raise;
+            movq [r15], rax;
+        };
+        self.fetch_and_dispatch();
+
         //BcOp::Mov
         let mov = self.jit.get_current_address();
         self.fetch3();
@@ -356,6 +374,7 @@ impl Codegen {
         self.dispatch[172] = self.vm_init();
         self.dispatch[173] = self.vm_alias_method();
         self.dispatch[174] = self.vm_hash();
+        self.dispatch[175] = toa;
         self.dispatch[176] = mov;
         self.dispatch[177] = self.vm_range(false);
         self.dispatch[178] = self.vm_range(true);

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -933,6 +933,10 @@ impl ISeqInfo {
                     args: SlotId::new(op2_w2),
                     len: op3_w3,
                 },
+                175 => TraceIr::ToA {
+                    dst: SlotId::new(op1_w1),
+                    src: SlotId::new(op2_w2),
+                },
                 176 => TraceIr::Mov(SlotId::new(op1_w1), SlotId::new(op2_w2)),
                 177..=178 => TraceIr::Range {
                     dst: SlotId::new(op1_w1),

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -253,6 +253,26 @@ fn splat() {
         end
         "#,
     );
+    run_test_error(
+        r##"
+    class C
+        def to_a
+            1
+        end
+    end
+    [*C.new]
+    "##,
+    );
+    run_test_error(
+        r##"
+    class C
+        def to_a
+            1
+        end
+    end
+    puts *C.new
+    "##,
+    );
 }
 
 #[test]


### PR DESCRIPTION
- impl. BytecodeInst::ToA for splat operators.
