### PR TITLE
Copy lib/ directory to ~/.monoruby/lib during build

### DIFF
--- a/monoruby/build.rs
+++ b/monoruby/build.rs
@@ -39,6 +39,10 @@ fn main() {
             std::path::PathBuf::from("builtins"),
             lib_path.join("builtins"),
         ),
+        (
+            std::path::PathBuf::from("lib"),
+            lib_path.join("lib"),
+        ),
     ];
 
     while let Some((from_dir, to_dir)) = directories.pop() {


### PR DESCRIPTION
The monoruby lib/ directory contains override files (e.g. forwardable/impl.rb) that replace CRuby stdlib files depending on RubyVM::InstructionSequence. The build script was not copying this directory, so the overrides were never deployed and forwardable failed with "uninitialized constant RubyVM".

https://claude.ai/code/session_01Af7pqCyzaSmEKVN6qRaKRp