### PR TITLE
Add Marshal.dump implementation for basic types

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -16,6 +16,7 @@ mod io;
 mod kernel;
 mod main_object;
 mod match_data;
+mod marshal;
 mod math;
 mod method;
 mod module;
@@ -72,6 +73,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     file::init(globals);
     fiddle::init(globals);
     ffi::init(globals);
+    marshal::init(globals);
     math::init(globals);
     process::init(globals);
     random::init(globals);

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+//
+// Marshal module
+//
+
+pub(super) fn init(globals: &mut Globals) {
+    let klass = globals.define_toplevel_module("Marshal").id();
+    globals.define_builtin_module_func(klass, "dump", dump, 1);
+}
+
+/// ### Marshal.dump
+/// - dump(obj) -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Marshal/m/dump.html]
+#[monoruby_builtin]
+fn dump(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _pc: BytecodePtr) -> Result<Value> {
+    let obj = lfp.arg(0);
+    let mut buf: Vec<u8> = Vec::new();
+    // Marshal version header
+    buf.push(0x04);
+    buf.push(0x08);
+    marshal_dump_value(&mut buf, obj, globals)?;
+    Ok(Value::bytes(buf))
+}
+
+fn marshal_dump_value(buf: &mut Vec<u8>, obj: Value, globals: &Globals) -> Result<()> {
+    match obj.unpack() {
+        RV::Nil => {
+            buf.push(b'0'); // 0x30
+            Ok(())
+        }
+        RV::Bool(true) => {
+            buf.push(b'T'); // 0x54
+            Ok(())
+        }
+        RV::Bool(false) => {
+            buf.push(b'F'); // 0x46
+            Ok(())
+        }
+        _ => Err(MonorubyErr::typeerr(format!(
+            "no _dump_data is defined for class {}",
+            globals.get_class_name(obj.class())
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn marshal_dump_nil() {
+        run_test("Marshal.dump(nil)");
+    }
+
+    #[test]
+    fn marshal_dump_true() {
+        run_test("Marshal.dump(true)");
+    }
+
+    #[test]
+    fn marshal_dump_false() {
+        run_test("Marshal.dump(false)");
+    }
+}


### PR DESCRIPTION
## Summary
Implement the `Marshal.dump` method for the Ruby Marshal module, enabling serialization of basic Ruby objects (nil, true, false) to their binary representation.

## Key Changes
- Added new `marshal.rs` module implementing the Marshal builtin module
- Implemented `Marshal.dump(obj)` method that serializes objects to binary format with proper Marshal version header (0x04 0x08)
- Added serialization support for basic types:
  - `nil` → `0x30` (character '0')
  - `true` → `0x54` (character 'T')
  - `false` → `0x46` (character 'F')
- Returns serialized data as a `Value::bytes` object
- Raises `TypeError` for unsupported types with descriptive error message
- Added comprehensive test coverage for all three basic types
- Integrated marshal module initialization into the builtins system

## Implementation Details
- The serialization format follows Ruby's Marshal protocol with the standard version header bytes
- Error handling provides clear feedback when attempting to serialize unsupported object types
- The implementation is extensible for future support of additional types

https://claude.ai/code/session_01EH6oX9BBMxmegPtvpyEG7F