### PR TITLE
Fix String#<< encoding compatibility with CRuby

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -343,12 +343,21 @@ fn shl(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             Err(_) => return Err(MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0))),
         };
         let bytes = self_.as_rstring_inner_mut();
-        if let Ok(ch) = u8::try_from(ch) {
-            bytes.extend_from_slice_checked(&[ch])?;
+        if bytes.encoding() == Encoding::Utf8 {
+            let c = char::from_u32(ch).ok_or_else(|| {
+                MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0))
+            })?;
+            let mut buf = [0u8; 4];
+            let encoded = c.encode_utf8(&mut buf);
+            bytes.extend_from_slice_checked(encoded.as_bytes())?;
         } else {
-            bytes.extend_from_slice_checked(&ch.to_ne_bytes())?;
+            // ASCII-8BIT: append raw byte(s)
+            if let Ok(b) = u8::try_from(ch) {
+                bytes.extend_from_slice_checked(&[b])?;
+            } else {
+                return Err(MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0)));
+            }
         }
-        bytes.check_utf8()?;
     } else {
         return Err(MonorubyErr::no_implicit_conversion(
             globals,
@@ -2805,6 +2814,105 @@ mod tests {
             a
         "##,
         );*/
+    }
+
+    #[test]
+    fn string_shl_encoding() {
+        // UTF-8 << ASCII-8BIT (ASCII chars only) => keeps UTF-8
+        run_test(
+            r##"
+            s = "hello".encode("UTF-8")
+            s << "world".force_encoding("ASCII-8BIT")
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
+        // UTF-8 << ASCII-8BIT (non-ASCII) => downgrades to ASCII-8BIT
+        run_test(
+            r##"
+            s = "hello".encode("UTF-8")
+            s << "\x80".force_encoding("ASCII-8BIT")
+            s.encoding == Encoding::ASCII_8BIT
+        "##,
+        );
+        // ASCII-8BIT (ASCII only) << UTF-8 (non-ASCII) => upgrades to UTF-8
+        run_test(
+            r##"
+            s = "hello".force_encoding("ASCII-8BIT")
+            s << "こんにちは"
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
+        // UTF-8 (non-ASCII) << ASCII-8BIT (non-ASCII) => Encoding::CompatibilityError
+        run_test_error(
+            r##"
+            s = "こんにちは"
+            s << "\x80".force_encoding("ASCII-8BIT")
+        "##,
+        );
+        // ASCII-8BIT << UTF-8 (ASCII only) => keeps ASCII-8BIT
+        run_test(
+            r##"
+            s = "hello".force_encoding("ASCII-8BIT")
+            s << "world".encode("UTF-8")
+            [s, s.encoding == Encoding::ASCII_8BIT]
+        "##,
+        );
+        // empty UTF-8 << ASCII-8BIT (ASCII only) => keeps UTF-8
+        run_test(
+            r##"
+            s = "".encode("UTF-8")
+            s << "hello".force_encoding("ASCII-8BIT")
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
+        // empty UTF-8 << ASCII-8BIT (non-ASCII) => downgrades to ASCII-8BIT
+        run_test(
+            r##"
+            s = "".encode("UTF-8")
+            s << "\x80".force_encoding("ASCII-8BIT")
+            s.encoding == Encoding::ASCII_8BIT
+        "##,
+        );
+        // empty ASCII-8BIT << UTF-8 (ASCII only) => keeps ASCII-8BIT
+        run_test(
+            r##"
+            s = "".force_encoding("ASCII-8BIT")
+            s << "hello".encode("UTF-8")
+            [s, s.encoding == Encoding::ASCII_8BIT]
+        "##,
+        );
+        // empty ASCII-8BIT << UTF-8 (non-ASCII) => upgrades to UTF-8
+        run_test(
+            r##"
+            s = "".force_encoding("ASCII-8BIT")
+            s << "こんにちは"
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
+        // Integer argument: UTF-8 string << Unicode codepoint
+        run_test(
+            r##"
+            s = "hello"
+            s << 0x3042
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
+        // Integer argument: ASCII-8BIT << 0x80
+        run_test(
+            r##"
+            s = "hello".force_encoding("ASCII-8BIT")
+            s << 0x80
+            [s.bytes.to_a, s.encoding == Encoding::ASCII_8BIT]
+        "##,
+        );
+        // Integer argument: ASCII char
+        run_test(
+            r##"
+            s = "hello"
+            s << 33
+            [s, s.encoding == Encoding::UTF_8]
+        "##,
+        );
     }
 
     #[test]

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -388,20 +388,36 @@ impl RStringInner {
     }
 
     pub fn extend(&mut self, other: &Self) -> Result<()> {
-        if self.is_empty() {
-            self.content.extend_from_slice(other);
-            self.ty = other.ty;
+        if other.is_empty() {
             return Ok(());
         }
-        if self.ty == other.ty || other.is_ascii() {
-            self.content.extend_from_slice(other);
-            Ok(())
-        } else {
-            Err(MonorubyErr::runtimeerr(format!(
-                "incompatible character encodings: {:?} and {:?}",
-                self.ty, other.ty
-            )))
+        let self_ascii_only = self.content.is_ascii();
+        let other_ascii_only = other.content.is_ascii();
+        match (self.ty, other.ty) {
+            (Encoding::Utf8, Encoding::Ascii8) => {
+                if other_ascii_only {
+                    // ASCII-8BIT with only ASCII bytes is compatible with UTF-8
+                } else if self_ascii_only {
+                    // self is UTF-8 but ASCII-only, other is binary non-ASCII => downgrade
+                    self.ty = Encoding::Ascii8;
+                } else {
+                    // both have non-ASCII bytes => incompatible
+                    return Err(MonorubyErr::runtimeerr(
+                        "incompatible character encodings: UTF-8 and ASCII-8BIT",
+                    ));
+                }
+            }
+            (Encoding::Ascii8, Encoding::Utf8) => {
+                if self_ascii_only && !other_ascii_only {
+                    // self is binary but ASCII-only, other has non-ASCII UTF-8 => upgrade
+                    self.ty = Encoding::Utf8;
+                }
+                // otherwise keep ASCII-8BIT
+            }
+            _ => {}
         }
+        self.content.extend_from_slice(other);
+        Ok(())
     }
 
     pub fn extend_from_slice_checked(&mut self, slice: &[u8]) -> Result<()> {


### PR DESCRIPTION
## Summary
- Implement CRuby's ASCII-compatibility rules for `String#<<` when self and other have different encodings
- Fix `extend()` to properly handle encoding negotiation: upgrade ASCII-8BIT to UTF-8 when self is ASCII-only, raise error when both sides have non-ASCII bytes with incompatible encodings
- Fix integer argument handling to encode Unicode codepoints as UTF-8 instead of appending raw native-endian bytes
- Allow ASCII-8BIT strings to accept non-ASCII byte values via `<<`

## Test plan
- [x] Added `string_shl_encoding` test with 12 cases covering all encoding combinations
- [x] All 58 string builtin tests pass
- [x] All monoruby lib and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)