### PR TITLE
Fix do...end block attachment on Foo::BAR in method args

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2032,4 +2032,59 @@ mod tests {
             "##,
         );
     }
+
+    #[test]
+    fn scope_const_with_do_block() {
+        run_test(
+            r##"
+        module Foo
+          BAR = 42
+        end
+        def baz(x)
+          [x, block_given?]
+        end
+        baz Foo::BAR do end
+        "##,
+        );
+        run_test(
+            r##"
+        module Foo
+          BAR = 42
+        end
+        def baz(x)
+          x + yield
+        end
+        baz Foo::BAR do 10 end
+        "##,
+        );
+        run_test(
+            r##"
+        module A
+          module B
+            C = 99
+          end
+        end
+        def f(x)
+          [x, block_given?]
+        end
+        f A::B::C do end
+        "##,
+        );
+        run_test(
+            r##"
+        module Foo
+          def self.bar; yield; end
+        end
+        Foo::bar { 55 }
+        "##,
+        );
+        run_test(
+            r##"
+        module Foo
+          def self.Bar; yield; end
+        end
+        Foo::Bar { 77 }
+        "##,
+        );
+    }
 }

--- a/ruruby-parse/src/parser/expression.rs
+++ b/ruruby-parse/src/parser/expression.rs
@@ -572,7 +572,14 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                 if let TokenKind::Const(_) = self.peek()?.kind {
                     let loc = node.loc;
                     let name = self.expect_const()?;
-                    if let Some(arglist) = self.parse_arguments(true)? {
+                    // Suppress `do...end` blocks for `Foo::BAR do end` — in CRuby,
+                    // `do...end` does not attach to a constant-style method call.
+                    // Only `{ }` blocks attach (e.g. `Foo::BAR { }`).
+                    let old = self.suppress_do_block;
+                    self.suppress_do_block = true;
+                    let arglist = self.parse_arguments(true)?;
+                    self.suppress_do_block = old;
+                    if let Some(arglist) = arglist {
                         // Foo::Bar()
                         Node::new_mcall(node, name, arglist, false, self.prev_loc())
                     } else if let NodeKind::Const {


### PR DESCRIPTION
## Summary
- `baz Foo::BAR do end` was incorrectly parsed as `baz(Foo.BAR { })` instead of `baz(Foo::BAR) { }` — the `do...end` block was being attached to `BAR` as a method call instead of to the outer `baz`
- Fix by setting `suppress_do_block = true` when parsing arguments after `::CONST` in the parser, matching CRuby behavior where `do...end` does not attach to constant-style scope resolution
- Brace blocks (`Foo::Bar { }`) still correctly attach as method calls

## Test plan
- [x] Added `scope_const_with_do_block` test covering:
  - `baz Foo::BAR do end` — block belongs to outer call
  - `baz Foo::BAR do 10 end` — block yield works with outer call
  - `f A::B::C do end` — nested constants
  - `Foo::bar { }` / `Foo::Bar { }` — brace blocks still attach correctly
- [x] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)