### PR TITLE
Support String#split with no arguments

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3786,7 +3786,12 @@ mod tests {
         run_test(r##""   a \t  b \n  c".split(' ', -1)"##);
         run_test(r##""   a \t  b \n  c  ".split(' ', 0)"##);
         run_test(r##""   a \t  b \n  c  ".split(' ', 2)"##);
-        //run_test(r##""   a \t  b \n  c".split"##);
+        run_test(r##""   a \t  b \n  c".split"##);
+        run_test(r##""hello world".split"##);
+        run_test(r##""  hello  world  ".split"##);
+        run_test(r##""\t\n hello \t world \n".split"##);
+        run_test(r##""".split"##);
+        run_test(r##""   ".split"##);
         run_test(r##"'1-10,20'.split(/([-,])/)"##);
         run_test(r##"'hi there'.split(/\s*/).join(':')"##);
         run_test(r##"'hi there'.split(//).join(':')"##);


### PR DESCRIPTION
## Summary
- Change `String#split` min args from 1 to 0, defaulting to whitespace splitting when called without arguments (matching CRuby behavior)
- Add tests for no-argument `split` covering basic strings, multiple/leading/trailing whitespace, mixed whitespace characters, empty strings, and whitespace-only strings

## Test plan
- [x] `cargo test -p monoruby --lib split` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)