### PR TITLE
Implement Kernel.#format / Kernel.#sprintf

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -54,6 +54,8 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         0,
     );
     globals.define_builtin_module_func_rest(kernel_class, "p", p);
+    globals.define_builtin_module_func_rest(kernel_class, "format", format);
+    globals.define_builtin_module_func_rest(kernel_class, "sprintf", format);
     globals.define_builtin_module_func_with(kernel_class, "rand", rand, 0, 1, false);
     globals.define_builtin_module_func(kernel_class, "Integer", kernel_integer, 1);
     globals.define_builtin_module_func(kernel_class, "Float", kernel_float, 1);
@@ -410,6 +412,25 @@ fn p(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
         1 => lfp.arg(0).as_array()[0],
         _ => lfp.arg(0),
     })
+}
+
+///
+/// ### Kernel.#format
+///
+/// - format(format_string, *args) -> String
+/// - sprintf(format_string, *args) -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/format.html]
+#[monoruby_builtin]
+fn format(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let args = lfp.arg(0).as_array();
+    if args.is_empty() {
+        return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
+    }
+    let fmt = args[0].expect_string(&globals.store)?;
+    let arguments = &args[1..];
+    let result = globals.format_by_args(&fmt, arguments)?;
+    Ok(Value::string(result))
 }
 
 ///

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -335,3 +335,21 @@ fn string_format() {
     // multiple format specifiers
     run_test(r#""%d %f %s" % [1.5, 2.5, "x"]"#);
 }
+
+#[test]
+fn kernel_format() {
+    run_test(r#"format("%d", 42)"#);
+    run_test(r#"sprintf("%d", 42)"#);
+    run_test(r#"format("%s", "hello")"#);
+    run_test(r#"format("%05d", 42)"#);
+    run_test(r#"format("%x", 255)"#);
+    run_test(r#"format("%X", 255)"#);
+    run_test(r#"format("%b", 10)"#);
+    run_test(r#"format("%f", 3.14)"#);
+    run_test(r#"format("%.2f", 3.14159)"#);
+    run_test(r#"format("%c", 65)"#);
+    run_test(r#"format("%%")"#);
+    run_test(r#"format("%d %s %f", 1, "hello", 3.14)"#);
+    run_test(r#"format("Hello %s, you are %d years old", "Alice", 30)"#);
+    run_test(r#"format("%02d:%02d:%02d", 1, 2, 3)"#);
+}


### PR DESCRIPTION
## Summary
- Implement `Kernel.#format` and `Kernel.#sprintf` as module functions
- Reuse existing `format_by_args` logic from `String#%`
- Add tests covering `%d`, `%s`, `%f`, `%x`, `%X`, `%b`, `%c`, `%%`, width/precision specifiers, and multiple arguments

## Test plan
- [x] `cargo test --test literal kernel_format` passes
- [x] `cargo test` all existing tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)