### PR TITLE
Improve Ruby spec compliance: method hooks, Kernel refactor, builtins

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -43,7 +43,7 @@ pub use monoasm::*;
 pub use monoasm_macro::*;
 use monoruby_attr::monoruby_builtin;
 use num::ToPrimitive;
-pub(crate) use object::{object_send, send};
+pub(crate) use kernel::{object_send, send};
 pub use time::TimeInner;
 
 //

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -153,7 +153,7 @@ pub(super) fn init(globals: &mut Globals) {
 fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class = lfp.self_val().as_class_id();
     let obj = Value::array_empty_with_class(class);
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
         obj,

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -36,6 +36,19 @@ pub(super) fn init(globals: &mut Globals) {
         true,
     );
     globals.define_builtin_func(CLASS_CLASS, "superclass", superclass, 0);
+    // hook method (no-op by default)
+    globals.define_private_builtin_func(CLASS_CLASS, "inherited", class_noop_hook, 1);
+}
+
+/// No-op hook for Class#inherited.
+#[monoruby_builtin]
+fn class_noop_hook(
+    _: &mut Executor,
+    _: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::nil())
 }
 
 /// ### Class.new
@@ -58,7 +71,7 @@ fn class_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     if let Some(block) = lfp.block() {
         vm.module_eval(globals, m, block)?;
     }
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INHERITED,
         superclass_val,
@@ -100,7 +113,7 @@ pub(super) fn new(
     let obj =
         vm.invoke_method_inner(globals, IdentId::ALLOCATE, lfp.self_val(), &[], None, None)?;
 
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
         obj,

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -60,6 +60,7 @@ pub(super) fn init(globals: &mut Globals) {
     let nameerr =
         globals.define_builtin_exception_class("NameError", NAME_ERROR_CLASS, standarderr);
     globals.define_builtin_exception_class("NoMethodError", NO_METHOD_ERROR_CLASS, nameerr);
+    globals.define_builtin_func(NO_METHOD_ERROR_CLASS, "receiver", nomethoderr_receiver, 0);
 
     let runtimeerr =
         globals.define_builtin_exception_class("RuntimeError", RUNTIME_ERROR_CLASS, standarderr);
@@ -79,6 +80,22 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(EXCEPTION_CLASS, "message", message, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "backtrace", backtrace, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "set_backtrace", set_backtrace, 1);
+}
+
+/// ### NoMethodError#receiver
+#[monoruby_builtin]
+fn nomethoderr_receiver(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let v = globals
+        .store
+        .get_ivar(self_val, IdentId::get_id("/receiver"))
+        .unwrap_or_default();
+    Ok(v)
 }
 
 /// ### Exception.allocate
@@ -110,7 +127,7 @@ fn exception_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
     let class_id = lfp.self_val().expect_class(globals)?.id();
     let obj = Value::new_exception_from("".to_string(), class_id);
 
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
         obj,
@@ -152,7 +169,7 @@ fn initialize(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
 fn message(_vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let ex = self_.is_exception().unwrap();
-    Ok(Value::string(ex.get_error_message()))
+    Ok(Value::string(ex.message().to_string()))
 }
 
 ///

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -115,6 +115,74 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     //globals.define_builtin_inline_func(kernel_class, "____max", max, Box::new(inline_max), 2);
     //globals.define_builtin_inline_func(kernel_class, "____min", min, Box::new(inline_min), 2);
 
+    // Kernel methods (matching CRuby: these are defined on Kernel, not Object)
+    globals.define_builtin_func(kernel_class, "class", class, 0);
+    globals.define_builtin_func(kernel_class, "hash", hash, 0);
+    globals.define_builtin_func(kernel_class, "eql?", eql_, 1);
+    globals.define_builtin_funcs(kernel_class, "dup", &["clone"], dup, 0);
+    globals.define_private_builtin_func(kernel_class, "initialize_copy", initialize_copy, 1);
+    globals.define_private_builtin_func(kernel_class, "initialize_clone", initialize_clone, 1);
+    globals.define_private_builtin_func(kernel_class, "initialize_dup", initialize_clone, 1);
+    globals.define_builtin_funcs_rest(kernel_class, "enum_for", &["to_enum"], to_enum);
+    globals.define_builtin_func_rest(kernel_class, "extend", extend);
+    globals.define_builtin_func(kernel_class, "kind_of?", is_a, 1);
+    globals.define_builtin_inline_func(
+        kernel_class,
+        "object_id",
+        super::object::object_id,
+        Box::new(super::object::object_object_id),
+        0,
+    );
+    globals.define_builtin_inline_func_with(
+        kernel_class,
+        "respond_to?",
+        respond_to,
+        Box::new(object_respond_to),
+        1,
+        2,
+        false,
+    );
+    globals.define_builtin_func(kernel_class, "singleton_class", singleton_class, 0);
+    globals.define_builtin_func(kernel_class, "to_s", to_s, 0);
+    globals.define_builtin_func(kernel_class, "inspect", inspect, 0);
+    globals.define_builtin_func(kernel_class, "instance_of?", instance_of, 1);
+    globals.define_builtin_func(kernel_class, "instance_variable_defined?", iv_defined, 1);
+    globals.define_builtin_func(kernel_class, "instance_variable_set", iv_set, 2);
+    globals.define_builtin_func(kernel_class, "instance_variable_get", iv_get, 1);
+    globals.define_builtin_func(kernel_class, "instance_variables", iv, 0);
+    globals.define_builtin_func(kernel_class, "remove_instance_variable", iv_remove, 1);
+    globals.define_builtin_func(kernel_class, "is_a?", is_a, 1);
+    globals.define_builtin_inline_funcs_with_kw(
+        kernel_class,
+        "send",
+        &["__send__", "public_send"],
+        crate::builtins::send,
+        Box::new(crate::builtins::object_send),
+        0,
+        0,
+        true,
+        &[],
+        true,
+    );
+    globals.define_builtin_func(kernel_class, "method", method, 1);
+    globals.define_builtin_func_with(
+        kernel_class,
+        "define_singleton_method",
+        define_singleton_method,
+        1,
+        2,
+        false,
+    );
+    globals.define_builtin_func_with(kernel_class, "methods", methods, 0, 1, false);
+    globals.define_builtin_func_with(
+        kernel_class,
+        "singleton_methods",
+        singleton_methods,
+        0,
+        1,
+        false,
+    );
+
     klass
 }
 
@@ -769,7 +837,7 @@ fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         vm.invoke_binding(globals, binding.binding().unwrap())
     } else {
         let caller_cfp = cfp.prev().unwrap();
-        let fid = globals.compile_script_eval(expr, "(eval)", caller_cfp)?;
+        let fid = globals.compile_script_eval(expr, "(eval)", caller_cfp, None)?;
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         vm.invoke_block(globals, &proc, &[])
     }
@@ -1428,6 +1496,540 @@ fn inline_min(
     true
 }*/
 
+///
+/// Object#send
+///
+/// - send(name, *args) -> object
+/// - send(name, *args) { .... } -> object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/send.html]
+#[monoruby_builtin]
+pub(crate) fn send(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let ary = lfp.arg(0).as_array();
+    if ary.len() < 1 {
+        return Err(MonorubyErr::wrong_number_of_arg_min(ary.len(), 1));
+    }
+    let method = ary[0].expect_symbol_or_string(globals)?;
+    vm.invoke_method_inner(
+        globals,
+        method,
+        lfp.self_val(),
+        &ary[1..],
+        lfp.block(),
+        if let Some(kw) = lfp.try_arg(1)
+            && let Some(kw) = kw.try_hash_ty()
+            && !kw.is_empty()
+        {
+            Some(kw)
+        } else {
+            None
+        },
+    )
+}
+
+pub fn object_send(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+) -> bool {
+    let callsite = &store[callid];
+    let no_splat = !callsite.object_send_single_splat();
+    if !callsite.is_simple() && no_splat {
+        return false;
+    }
+
+    state.write_back_recv_and_callargs(ir, callsite);
+    state.writeback_acc(ir);
+    let using_xmm = state.get_using_xmm();
+    let error = ir.new_error(state);
+    let callid = callsite.id;
+    ir.inline(move |r#gen, store, labels| {
+        let error = &labels[error];
+        r#gen.object_send_inline(callid, store, using_xmm, &error, no_splat);
+    });
+    state.def_reg2acc(ir, GP::Rax, callsite.dst);
+    true
+}
+
+///
+/// ### Kernel#extend
+/// - extend(*modules) -> self
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/extend.html]
+#[monoruby_builtin]
+fn extend(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let args = lfp.arg(0).as_array();
+    if args.len() == 0 {
+        return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
+    }
+    let self_val = lfp.self_val();
+    for v in args.iter().cloned().rev() {
+        vm.invoke_method_inner(globals, IdentId::EXTEND_OBJECT, v, &[self_val], None, None)?;
+        vm.invoke_method_inner(globals, IdentId::EXTENDED, v, &[self_val], None, None)?;
+    }
+    Ok(lfp.self_val())
+}
+
+///
+/// ### Kernel#is_a?
+///
+/// - is_a?(mod) -> bool
+/// - kind_of?(mod) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/is_a=3f.html]
+#[monoruby_builtin]
+fn is_a(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.arg(0).expect_class_or_module(&globals.store)?.id();
+    Ok(Value::bool(
+        lfp.self_val().is_kind_of(&globals.store, class),
+    ))
+}
+
+///
+/// ### Kernel#enum_for
+///
+/// - to_enum(method = :each, *args) -> Enumerator
+/// - enum_for(method = :each, *args) -> Enumerator
+/// - [NOT SUPPORTED] to_enum(method = :each,  *args) {|*args| ... } -> Enumerator
+/// - [NOT SUPPORTED] enum_for(method = :each, *args) {|*args| ... } -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/enum_for.html]
+#[monoruby_builtin]
+fn to_enum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    lfp.expect_no_block()?;
+    let args = lfp.arg(0).as_array();
+    let (method, args) = if args.is_empty() {
+        (IdentId::EACH, vec![])
+    } else {
+        (
+            args[0].expect_symbol_or_string(globals)?,
+            args[1..].to_vec(),
+        )
+    };
+    vm.generate_enumerator(method, lfp.self_val(), args, pc)
+}
+
+///
+/// ### Kernel#dup
+///
+/// - dup -> object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/clone.html]
+#[monoruby_builtin]
+fn dup(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(lfp.self_val().dup())
+}
+
+/// ### Kernel#define_singleton_method
+///
+/// - define_singleton_method(name, method) -> Symbol
+/// - define_singleton_method(name) { ... } -> Symbol
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/define_singleton_method.html]
+#[monoruby_builtin]
+fn define_singleton_method(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let class_id = globals.store.get_singleton(self_val)?.id();
+    let name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let func_id = if let Some(method) = lfp.try_arg(1) {
+        if let Some(proc) = method.is_proc() {
+            globals.define_proc_method(proc)
+        } else if let Some(method) = method.is_method() {
+            method.func_id()
+        } else if let Some(method) = method.is_umethod() {
+            method.func_id()
+        } else {
+            return Err(MonorubyErr::wrong_argument_type(
+                globals,
+                method,
+                "Proc/Method/UnboundMethod",
+            ));
+        }
+    } else if let Some(bh) = lfp.block() {
+        let proc = vm.generate_proc(bh, pc)?;
+        globals.define_proc_method(proc)
+    } else {
+        return Err(MonorubyErr::wrong_number_of_arg(2, 1));
+    };
+    globals.add_public_method(class_id, name, func_id);
+    Ok(Value::symbol(name))
+}
+
+/// ### Kernel#initialize_copy
+///
+/// - initialize_copy(obj) -> object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/initialize_copy.html]
+#[monoruby_builtin]
+fn initialize_copy(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let orig = lfp.arg(0);
+    let self_val = lfp.self_val();
+    if orig.id() == self_val.id() {
+        return Ok(self_val);
+    }
+    if self_val.real_class(globals).id() != orig.real_class(globals).id()
+        || self_val.ty() != orig.ty()
+    {
+        return Err(MonorubyErr::typeerr(format!(
+            "initialize_copy should take same class object self:{} original:{}",
+            self_val.class().get_name(globals),
+            orig.class().get_name(globals)
+        )));
+    }
+    Ok(self_val)
+}
+
+/// ### Kernel#initialize_clone
+///
+/// - initialize_clone(obj) -> object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/initialize_clone.html]
+#[monoruby_builtin]
+fn initialize_clone(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let orig = lfp.arg(0);
+    let self_val = lfp.self_val();
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("initialize_copy"),
+        self_val,
+        &[orig],
+        None,
+        None,
+    )
+}
+
+///
+/// ### Kernel#to_s
+///
+/// - to_s -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/to_s.html]
+#[monoruby_builtin]
+fn to_s(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = lfp.self_val().to_s(&globals.store);
+    Ok(Value::string(s))
+}
+
+///
+/// ### Kernel#respond_to?
+///
+/// - respond_to?(name, include_all = false) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/respond_to=3f.html]
+#[monoruby_builtin]
+fn respond_to(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let include_all = if let Some(arg1) = lfp.try_arg(1) {
+        arg1.as_bool()
+    } else {
+        false
+    };
+    Ok(Value::bool(if include_all {
+        globals.check_method(lfp.self_val(), name).is_some()
+    } else {
+        globals.check_public_method(lfp.self_val(), name).is_some()
+    }))
+}
+
+fn object_respond_to(
+    state: &mut AbstractState,
+    _: &mut AsmIr,
+    ctx: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, pos_num, ..
+    } = *callsite;
+    let dst = if let Some(dst) = dst {
+        dst
+    } else {
+        return false;
+    };
+    let include_all = if pos_num != 1 {
+        if state.is_truthy(args + 1usize) {
+            true
+        } else if state.is_falsy(args + 1usize) {
+            false
+        } else {
+            return false;
+        }
+    } else {
+        false
+    };
+    let method_name = if let Some(name) = state.is_symbol_literal(args) {
+        name
+    } else {
+        return false;
+    };
+    let b = if let Some(entry) =
+        store.check_method_for_class_with_version(recv_class, method_name, ctx.class_version())
+    {
+        include_all || entry.is_public()
+    } else {
+        false
+    };
+    state.def_C(dst, Value::bool(b));
+    true
+}
+
+///
+/// ### Kernel#inspect
+///
+/// - inspect -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/inspect.html]
+#[monoruby_builtin]
+fn inspect(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = lfp.self_val().inspect(&globals.store);
+    Ok(Value::string(s))
+}
+
+///
+/// ### Kernel#class
+///
+/// - class -> Class
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/class.html]
+#[monoruby_builtin]
+fn class(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(lfp.self_val().real_class(&globals.store).as_val())
+}
+
+///
+/// ### Kernel#hash
+///
+/// - hash -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/hash.html]
+#[monoruby_builtin]
+fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::integer(lfp.self_val().id() as _))
+}
+
+///
+/// ### Kernel#eql?
+///
+/// - eql?(other) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/eql=3f.html]
+#[monoruby_builtin]
+fn eql_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(lfp.self_val().id() == lfp.arg(0).id()))
+}
+
+///
+/// ### Kernel#instance_of?
+///
+/// - instance_of?(klass) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_of=3f.html]
+#[monoruby_builtin]
+fn instance_of(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let b = lfp.self_val().real_class(&globals.store).id()
+        == lfp.arg(0).expect_class_or_module(&globals.store)?.id();
+    Ok(Value::bool(b))
+}
+
+///
+/// ### Kernel#method
+///
+/// - method(name) -> Method
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/method.html]
+#[monoruby_builtin]
+fn method(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let receiver = lfp.self_val();
+    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let (func_id, _, owner) = globals.find_method_for_object(receiver, method_name)?;
+    Ok(Value::new_method(receiver, func_id, owner))
+}
+
+///
+/// ### Kernel#singleton_class
+///
+/// - singleton_class -> Class
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/singleton_class.html]
+#[monoruby_builtin]
+fn singleton_class(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().get_singleton(&mut globals.store)
+}
+
+///
+/// ### Kernel#methods
+///
+/// - methods(include_inherited = true) -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/methods.html]
+#[monoruby_builtin]
+fn methods(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let inherited_too = lfp.try_arg(0).is_none() || lfp.arg(0).as_bool();
+    Ok(Value::array_from_vec(if !inherited_too {
+        let class_id = match globals.store.has_singleton(lfp.self_val()) {
+            Some(module) => module.id(),
+            None => return Ok(Value::array_empty()),
+        };
+        globals.store.get_method_names(class_id)
+    } else {
+        let class_id = lfp.self_val().class();
+        globals.store.get_method_names_inherit(class_id, true)
+    }))
+}
+
+///
+/// ### Kernel#singleton_methods
+///
+/// - singleton_methods(inherited_too = true) -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/singleton_methods.html]
+#[monoruby_builtin]
+fn singleton_methods(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let class_id = match globals.store.has_singleton(lfp.self_val()) {
+        Some(module) => module.id(),
+        None => return Ok(Value::array_empty()),
+    };
+    let inherited_too = lfp.try_arg(0).is_none() || lfp.arg(0).as_bool();
+    Ok(Value::array_from_vec(if !inherited_too {
+        globals.store.get_method_names(class_id)
+    } else {
+        globals.store.get_method_names_inherit(class_id, true)
+    }))
+}
+
+///
+/// ### Kernel#instance_variable_defined?
+///
+/// - instance_variable_defined?(var) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_defined=3f.html]
+#[monoruby_builtin]
+fn iv_defined(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let id = match lfp.arg(0).unpack() {
+        RV::Symbol(sym) => sym,
+        RV::String(s) => IdentId::get_id(s.check_utf8()?),
+        _ => return Err(MonorubyErr::is_not_symbol_nor_string(globals, lfp.arg(0))),
+    };
+    let b = globals.store.get_ivar(lfp.self_val(), id).is_some();
+    Ok(Value::bool(b))
+}
+
+///
+/// ### Kernel#instance_variable_set
+///
+/// - instance_variable_set(var, value) -> Object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_set.html]
+#[monoruby_builtin]
+fn iv_set(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let val = lfp.arg(1);
+    globals.store.set_ivar(lfp.self_val(), id, val)?;
+    Ok(val)
+}
+
+///
+/// ### Kernel#instance_variable_get
+///
+/// - instance_variable_get(var) -> Object | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_get.html]
+#[monoruby_builtin]
+fn iv_get(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let v = globals
+        .store
+        .get_ivar(lfp.self_val(), id)
+        .unwrap_or_default();
+    Ok(v)
+}
+
+///
+/// ### Kernel#instance_variables
+///
+/// - instance_variables -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variables.html]
+#[monoruby_builtin]
+fn iv(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let iter = globals
+        .store
+        .get_ivars(lfp.self_val())
+        .into_iter()
+        .map(|(id, _)| Value::symbol(id));
+    Ok(Value::array_from_iter(iter))
+}
+
+///
+/// ### Kernel#remove_instance_variable
+///
+/// - remove_instance_variable(name) -> Object
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/remove_instance_variable.html]
+#[monoruby_builtin]
+fn iv_remove(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
+    match globals.store.remove_ivar(lfp.self_val(), id) {
+        Some(val) => Ok(val),
+        None => Err(MonorubyErr::nameerr(format!(
+            "instance variable {id} not defined"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
@@ -1751,6 +2353,736 @@ mod tests {
         end
         p PFoo.new
         "##,
+        );
+    }
+
+    #[test]
+    fn test_builtin() {
+        run_test2(":sym.class.to_s");
+        run_test2("5.class.to_s");
+        run_test2("5.7.class.to_s");
+        run_test2("'windows'.class.to_s");
+        run_test2("puts 100");
+        run_test2("print '100'");
+        run_test2("p");
+        run_test2("p 1");
+        run_test2("p 1,2");
+        run_test2("p 1,2,3");
+        run_test2("nil.respond_to?(:foo)");
+        run_test2("nil.inspect");
+        run_test2("Time.singleton_class.to_s");
+        run_test2(r#"File.write("/tmp/foo", "woo")"#);
+    }
+
+    #[test]
+    fn object_id() {
+        run_test_with_prelude(
+            r##"
+            [id == a.object_id, a.__id__ == a.object_id]
+            "##,
+            r##"
+            a = [1,2,3]
+            id = a.object_id
+            "##,
+        );
+        run_test_with_prelude(
+            r##"
+            [id == a.object_id, a.__id__ == a.object_id]
+            "##,
+            r##"
+            a = 1356
+            id = a.object_id
+            "##,
+        );
+        run_test_with_prelude(
+            r##"
+            [id == a.object_id, a.__id__ == a.object_id]
+            "##,
+            r##"
+            a = -49.52
+            id = a.object_id
+            "##,
+        );
+    }
+
+    #[test]
+    fn remove_instance_variable() {
+        run_test2(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+                @b = 2
+              end
+            end
+            f = Foo.new
+            f.remove_instance_variable(:@a)
+            "#,
+        );
+        run_test2(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+                @b = 2
+              end
+            end
+            f = Foo.new
+            f.remove_instance_variable(:@a)
+            f.instance_variables
+            "#,
+        );
+        run_test2(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+                @b = 2
+              end
+            end
+            f = Foo.new
+            f.remove_instance_variable("@a")
+            f.instance_variables
+            "#,
+        );
+        run_test2(
+            r#"
+            module M
+              @x = 42
+              remove_instance_variable(:@x)
+            end
+            "#,
+        );
+        run_test_error(
+            r#"
+            obj = Object.new
+            obj.remove_instance_variable(:@nonexistent)
+            "#,
+        );
+    }
+
+    #[test]
+    fn extend() {
+        run_test_with_prelude(
+            r#"
+        res = []
+        obj = Object.new
+        obj.extend Foo, Bar
+        res << obj.a #=> "ok Foo"
+        res << obj.b #=> "ok Bar"
+        res << Klass.new.a #=> "ok Foo"
+        res << Klass.b     #=> "ok Bar"
+        res
+        "#,
+            r#"
+        module Foo
+          def a
+            'ok Foo'
+          end
+        end
+
+        module Bar
+          def b
+            'ok Bar'
+          end
+        end
+
+        class Klass
+          include Foo
+          extend Bar
+        end
+        "#,
+        );
+    }
+
+    #[test]
+    fn dup() {
+        run_test("1.dup");
+        run_test("1.5.dup");
+        run_test("'Ruby'.dup");
+        run_test(":Ruby.dup");
+        run_test("[1,2,3].dup");
+        run_test("{a:1,b:2}.dup");
+        run_test("(1..3).dup");
+    }
+
+    #[test]
+    fn block_given_kernel() {
+        run_test_with_prelude(
+            r##"
+            [check, check {}]
+        "##,
+            r##"
+        def check
+            if block_given?
+                "Block is given."
+            else
+                "Block isn't given."
+            end
+        end
+        "##,
+        );
+    }
+
+    #[test]
+    fn test_object() {
+        run_test2(r#"a=Object.new; a.instance_variable_set("@i", 42)"#);
+        run_test2(r#"a=Object.new; a.instance_variable_get(:@i)"#);
+        run_test2(
+            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@i)"#,
+        );
+        run_test2(
+            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@j)"#,
+        );
+        run_test2(
+            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_get(:@i)"#,
+        );
+        // TDDO: Object#instace_variables must return Array of Symbols,
+        // ordered by the time of definition of the instance variables.
+        run_test2(
+            r#"
+            a=Object.new;
+            a.instance_variable_set("@b", 1);
+            a.instance_variable_set("@e", 4);
+            a.instance_variable_set("@c", 2);
+            a.instance_variable_set("@j", 9);
+            a.instance_variable_set("@d", 3);
+            a.instance_variable_set("@a", 0);
+            a.instance_variable_set("@g", 6);
+            a.instance_variable_set("@l", 11);
+            a.instance_variable_set("@h", 7);
+            a.instance_variable_set("@i", 8);
+            a.instance_variable_set("@f", 5);
+            a.instance_variable_set("@k", 10);
+            a.instance_variables.sort
+            "#,
+        );
+    }
+
+    #[test]
+    fn respond_to() {
+        run_test_with_prelude(
+            r#"
+        list = [F.new, D.new]
+        res = []
+        list.each{|it| res << it.hello if it.respond_to?(:hello)}
+        list.each{|it| res << it.hello if it.respond_to?(:hello, false)}
+        list.each{|it| it.instance_eval("res << hello if it.respond_to?(:hello, true)")}
+        res
+        "#,
+            r#"
+        class F
+          def hello
+            "Bonjour"
+          end
+        end
+
+        class D
+          private
+          def hello
+            "Guten Tag"
+          end
+        end
+        "#,
+        );
+    }
+
+    #[test]
+    fn kernel_integer() {
+        run_test2(r#"Integer(-2435)"#);
+        run_test2(r#"Integer("2435")"#);
+        run_test_error(r#"Integer("2435.78")"#);
+        run_test_error(r#"Integer([4])"#);
+        run_test2(r#"Integer(-2435766756886769978978435)"#);
+        run_test2(r#"Integer(2435.4556787)"#);
+    }
+
+    #[test]
+    fn object_instance_of() {
+        run_test2(r#"5.instance_of?(Integer)"#);
+        run_test2(r#"5.instance_of?(Float)"#);
+        run_test2(r#":ruby.instance_of?(Symbol)"#);
+        run_test2(r#":ruby.instance_of?(Object)"#);
+        run_test2(
+            r#"
+        class C < Object
+        end
+        class S < C
+        end
+
+        obj = S.new
+        [obj.instance_of?(S), obj.instance_of?(C)]
+        "#,
+        );
+        run_test_error(r#"5.instance_of?(7)"#);
+    }
+
+    #[test]
+    fn object_isa() {
+        run_test("4.is_a? Integer");
+        run_test("4.5.is_a? Integer");
+        run_test("'Ruby'.is_a? Integer");
+        run_test("4.5.is_a? Float");
+        run_test("'Ruby'.is_a? Float");
+        run_test(
+            r#"
+        class C
+        end
+        C.new.is_a? C"#,
+        );
+        run_test(
+            r#"
+        class S
+        end
+        class C < S
+        end
+        c = C.new
+        [c.is_a?(S), c.is_a?(C)]"#,
+        );
+    }
+
+    #[test]
+    fn object_nil() {
+        run_test("4.nil?");
+        run_test("4.5.nil?");
+        run_test("nil.nil?");
+        run_test("true.nil?");
+        run_test("false.nil?");
+        run_test("[].nil?");
+    }
+
+    #[test]
+    fn kernel_system() {
+        run_test(r#"system "ls""#);
+        run_test(r#"system "jkjkjk""#);
+        run_test(r#"system "*""#);
+        run_test(r#"`pwd`"#);
+        run_test(r#"`*`"#);
+        run_test_error(r#"``"#);
+    }
+
+    #[test]
+    fn to_enum() {
+        run_test(
+            r#"
+        e = [1,2,3,4,5].to_enum
+        e.next
+        "#,
+        );
+    }
+
+    #[test]
+    fn send() {
+        run_test(
+            r#"
+        "ruby".send(:sub, /./, "R")
+        "#,
+        );
+        run_test(
+            r#"
+        class Foo
+            def foo() "foo" end
+            def bar() "bar" end
+            def baz() "baz" end
+        end
+        methods = {1 => :foo, 2 => :bar, 3 => :baz}
+        f = Foo.new
+        [f.send(methods[1]), f.send(methods[2]), f.send(methods[3])]
+        "#,
+        );
+        run_test_with_prelude(
+            r#"
+            o.send(:f){ 3 }
+            "#,
+            r#"
+            class C
+                def f
+                    yield
+                end
+            end
+            o = C.new
+            "#,
+        );
+    }
+
+    #[test]
+    fn object_send() {
+        run_test_with_prelude(
+            r##"
+        o = C.new
+        [o.send(:foo), o.send("foo"), o.send(:bar, 20), o.send(*[:foo]), o.send(*["bar", 100])]
+        "##,
+            r##"
+        class C
+            def foo
+                1
+            end
+            def bar(x)
+                x
+            end
+        end
+        "##,
+        );
+        run_test_error(
+            r##"
+        class C
+            def foo
+                1
+            end
+        end
+        C.new.send
+        "##,
+        );
+        run_test_error(
+            r##"
+        class C
+            def foo
+                1
+            end
+        end
+        C.new.send(200, 100)
+        "##,
+        );
+        run_test_error(
+            r##"
+        class C
+            def foo
+                1
+            end
+        end
+        C.new.send(:foo, 100)
+        "##,
+        );
+        run_test_error(
+            r##"
+        class C
+            def foo
+                1
+            end
+        end
+        C.new.send(*[])
+        "##,
+        );
+        run_test_error(
+            r##"
+          class C
+            def b(x, y, z)
+              puts "x=#{[x, y, z]}"
+            end
+          end
+
+          o = C.new
+          30.times do |x|
+            if x == 28 then
+              eval('class C; def b(x); puts "x=#{x}" ;end; end')
+            end
+            o.send(:b, x, 2, 3)
+          end
+            "##,
+        );
+    }
+
+    #[test]
+    fn public_send() {
+        run_test(
+            r##"
+        class C
+          def foo; "foo"; end
+        end
+        C.new.public_send(:foo)
+        "##,
+        );
+        run_test(
+            r##"
+        class C
+          def bar(x); x * 2; end
+        end
+        C.new.public_send(:bar, 21)
+        "##,
+        );
+        run_test(
+            r##"
+        class C
+          def baz; yield + 1; end
+        end
+        C.new.public_send(:baz) { 41 }
+        "##,
+        );
+    }
+
+    #[test]
+    fn methods() {
+        run_test_with_prelude(
+            r##"
+        [
+          obj.singleton_methods(false).sort,
+          (obj.singleton_methods(true) - obj2.singleton_methods(true)).sort,
+          obj.methods(false).sort,
+          (obj.methods(true) - obj2.methods(true)).sort,
+          Foo.singleton_methods(false).sort,
+          (Foo.singleton_methods(true) - Foo2.singleton_methods(true)).sort
+        ]
+        "##,
+            r##"
+        Parent = Class.new
+
+        class <<Parent
+          private;   def private_class_parent() end
+          protected; def protected_class_parent() end
+          public;    def public_class_parent() end
+        end
+
+        Foo = Class.new(Parent)
+        Foo2 = Class.new()
+
+        class <<Foo
+          private;   def private_class_foo() end
+          protected; def protected_class_foo() end
+          public;    def public_class_foo() end
+        end
+
+        module Bar
+          private;   def private_bar()   end
+          protected; def protected_bar() end
+          public;    def public_bar()    end
+        end
+
+        obj = Foo.new
+        obj2 = Foo.new
+
+        class << obj
+          include Bar
+          private;   def private_self()   end
+          protected; def protected_self() end
+          public;    def public_self()    end
+        end
+        "##,
+        );
+    }
+
+    #[test]
+    fn define_singleton_method() {
+        // with block
+        run_test(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method(:greet) { "hello" }
+            obj.greet
+            "#,
+        );
+        // with block taking arguments
+        run_test(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method(:add) { |a, b| a + b }
+            obj.add(3, 4)
+            "#,
+        );
+        // returns symbol
+        run_test(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method(:foo) { 42 }
+            "#,
+        );
+        // with string name
+        run_test(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method("bar") { "baz" }
+            obj.bar
+            "#,
+        );
+        // with Proc
+        run_test(
+            r#"
+            obj = Object.new
+            pr = Proc.new { |x| x * 2 }
+            obj.define_singleton_method(:double, pr)
+            obj.double(5)
+            "#,
+        );
+        // with Method
+        run_test(
+            r#"
+            class Foo
+              def hello
+                "hello from Foo"
+              end
+            end
+            obj = Foo.new
+            obj.define_singleton_method(:greet, obj.method(:hello))
+            obj.greet
+            "#,
+        );
+        // with UnboundMethod
+        run_test(
+            r#"
+            class Foo
+              def hi
+                "hi"
+              end
+            end
+            obj = Foo.new
+            obj.define_singleton_method(:greet, Foo.instance_method(:hi))
+            obj.greet
+            "#,
+        );
+        // does not affect other instances
+        run_test(
+            r#"
+            a = Object.new
+            b = Object.new
+            a.define_singleton_method(:only_a) { "only a" }
+            [a.only_a, b.respond_to?(:only_a)]
+            "#,
+        );
+        // error: no block and no method given
+        run_test_error(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method(:foo)
+            "#,
+        );
+        // error: wrong argument type
+        run_test_error(
+            r#"
+            obj = Object.new
+            obj.define_singleton_method(:foo, 42)
+            "#,
+        );
+    }
+
+    #[test]
+    fn initialize_copy() {
+        // initialize_copy with same object returns self
+        run_test(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+              end
+            end
+            obj = Foo.new
+            obj.send(:initialize_copy, obj).equal?(obj)
+            "#,
+        );
+        // initialize_copy with same class succeeds
+        run_test(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+              end
+            end
+            a = Foo.new
+            b = Foo.new
+            b.send(:initialize_copy, a).equal?(b)
+            "#,
+        );
+        // initialize_copy with different class raises TypeError
+        run_test_error(
+            r#"
+            class Foo; end
+            class Bar; end
+            a = Foo.new
+            b = Bar.new
+            a.send(:initialize_copy, b)
+            "#,
+        );
+    }
+
+    #[test]
+    fn initialize_clone() {
+        // initialize_clone delegates to initialize_copy
+        run_test(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+              end
+            end
+            a = Foo.new
+            b = Foo.new
+            b.send(:initialize_clone, a).equal?(b)
+            "#,
+        );
+        // initialize_clone with different class raises TypeError via initialize_copy
+        run_test_error(
+            r#"
+            class Foo; end
+            class Bar; end
+            a = Foo.new
+            b = Bar.new
+            a.send(:initialize_clone, b)
+            "#,
+        );
+        // overridden initialize_clone is called
+        run_test(
+            r#"
+            $called = []
+            class Foo
+              def initialize_clone(orig)
+                $called << :initialize_clone
+                super
+              end
+              def initialize_copy(orig)
+                $called << :initialize_copy
+                super
+              end
+            end
+            a = Foo.new
+            b = Foo.new
+            b.send(:initialize_clone, a)
+            $called
+            "#,
+        );
+    }
+
+    #[test]
+    fn initialize_dup() {
+        // initialize_dup delegates to initialize_copy
+        run_test(
+            r#"
+            class Foo
+              def initialize
+                @a = 1
+              end
+            end
+            a = Foo.new
+            b = Foo.new
+            b.send(:initialize_dup, a).equal?(b)
+            "#,
+        );
+        // initialize_dup with different class raises TypeError via initialize_copy
+        run_test_error(
+            r#"
+            class Foo; end
+            class Bar; end
+            a = Foo.new
+            b = Bar.new
+            a.send(:initialize_dup, b)
+            "#,
+        );
+        // overridden initialize_dup is called
+        run_test(
+            r#"
+            $called = []
+            class Foo
+              def initialize_dup(orig)
+                $called << :initialize_dup
+                super
+              end
+              def initialize_copy(orig)
+                $called << :initialize_copy
+                super
+              end
+            end
+            a = Foo.new
+            b = Foo.new
+            b.send(:initialize_dup, a)
+            $called
+            "#,
         );
     }
 }

--- a/monoruby/src/builtins/main_object.rs
+++ b/monoruby/src/builtins/main_object.rs
@@ -85,7 +85,7 @@ fn main_define_method(
     };
     let _ = func_id;
     let receiver = globals.store[class_id].get_module().into();
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::METHOD_ADDED,
         receiver,

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -8,11 +8,13 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Method", METHOD_CLASS, ObjTy::METHOD);
     globals.define_builtin_class_func(METHOD_CLASS, "allocate", super::class::undef_allocate, 0);
     globals.define_builtin_funcs_rest(METHOD_CLASS, "call", &["[]", "==="], call);
+    globals.define_builtin_func(METHOD_CLASS, "arity", arity, 0);
     globals.define_builtin_func(METHOD_CLASS, "to_proc", to_proc, 0);
     globals.define_builtin_func(METHOD_CLASS, "source_location", source_location, 0);
 
     globals.define_builtin_class_under_obj("UnboundMethod", UMETHOD_CLASS, ObjTy::METHOD);
     globals.define_builtin_class_func(UMETHOD_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.define_builtin_func(UMETHOD_CLASS, "arity", uarity, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "bind", bind, 1);
     globals.define_builtin_func(UMETHOD_CLASS, "source_location", usource_location, 0);
 }
@@ -41,6 +43,33 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         lfp.block(),
         None,
     )
+}
+
+///
+/// ### Method#arity
+///
+/// - arity -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/arity.html]
+#[monoruby_builtin]
+fn arity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_method();
+    let func_id = method.func_id();
+    Ok(Value::integer(globals[func_id].arity()))
+}
+
+///
+/// ### UnboundMethod#arity
+///
+/// - arity -> Integer
+///
+#[monoruby_builtin]
+fn uarity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_umethod();
+    let func_id = method.func_id();
+    Ok(Value::integer(globals[func_id].arity()))
 }
 
 ///

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -105,6 +105,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_rest(MODULE_CLASS, "private_class_method", private_class_method);
     globals.define_builtin_func(MODULE_CLASS, "class_variable_set", class_variable_set, 2);
     globals.define_builtin_func(MODULE_CLASS, "class_variable_get", class_variable_get, 1);
+    globals.define_builtin_func(MODULE_CLASS, "class_variables", class_variables, 0);
     globals.define_builtin_funcs(MODULE_CLASS, "to_s", &["inspect"], tos, 0);
     globals.define_builtin_func(MODULE_CLASS, "name", name, 0);
     globals.define_builtin_func(MODULE_CLASS, "set_temporary_name", set_temporary_name, 1);
@@ -113,6 +114,25 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_private_builtin_func_rest(MODULE_CLASS, "private", private);
     globals.define_private_builtin_func_rest(MODULE_CLASS, "protected", protected);
     globals.define_private_builtin_func_rest(MODULE_CLASS, "public", public);
+    // hook methods (no-op by default)
+    globals.define_private_builtin_func(MODULE_CLASS, "method_added", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "method_removed", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "method_undefined", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "included", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "prepended", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "extended", module_noop_hook, 1);
+    globals.define_private_builtin_func(MODULE_CLASS, "const_added", module_noop_hook, 1);
+}
+
+/// No-op hook for method_added/removed/undefined, included/prepended/extended, const_added.
+#[monoruby_builtin]
+fn module_noop_hook(
+    _: &mut Executor,
+    _: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::nil())
 }
 
 /// ### Module.new
@@ -338,7 +358,7 @@ fn class_eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             "(eval)".into()
         };
 
-        let fid = globals.compile_script_eval(expr, path, caller_cfp)?;
+        let fid = globals.compile_script_eval(expr, path, caller_cfp, Some(module.id()))?;
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         vm.push_class_context(module.id());
         let res = vm.invoke_block_with_self(globals, &proc, module.get(), &[]);
@@ -414,7 +434,7 @@ fn const_set(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let val = lfp.arg(1);
     globals.set_constant(module, name, val);
     let receiver = globals.store[module].get_module().into();
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::CONST_ADDED,
         receiver,
@@ -608,7 +628,7 @@ fn include(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let self_ = lfp.self_val();
     for v in args.iter().cloned().rev() {
         vm.invoke_method_inner(globals, IdentId::APPEND_FEATURES, v, &[self_], None, None)?;
-        vm.invoke_method_if_exists(globals, IdentId::INCLUDED, v, &[self_], None, None)?;
+        vm.invoke_method_inner(globals, IdentId::INCLUDED, v, &[self_], None, None)?;
     }
     Ok(lfp.self_val())
 }
@@ -671,7 +691,7 @@ fn prepend(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             None,
             None,
         )?;
-        vm.invoke_method_if_exists(globals, IdentId::PREPENDED, v, &[self_], None, None)?;
+        vm.invoke_method_inner(globals, IdentId::PREPENDED, v, &[self_], None, None)?;
     }
     Ok(lfp.self_val())
 }
@@ -944,6 +964,25 @@ fn class_variable_get(
     globals.get_class_variable(module, name).map(|(_, v)| v)
 }
 
+///
+/// ### Module#class_variables
+///
+/// - class_variables -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Module/i/class_variables.html]
+#[monoruby_builtin]
+fn class_variables(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let class_id = lfp.self_val().as_class_id();
+    let names = globals.store.get_class_variable_names(class_id);
+    let ary: Vec<Value> = names.into_iter().map(Value::symbol).collect();
+    Ok(Value::array_from_vec(ary))
+}
+
 /// ### Module#set_temporary_name
 /// - set_temporary_name(name) -> self
 ///
@@ -991,7 +1030,7 @@ fn module_function(
             let name = v.expect_symbol_or_string(globals)?;
             let func_id = globals.find_method_for_class(class_id, name)?.0;
             globals.add_singleton_method(class_id, name, func_id, visi);
-            vm.invoke_method_if_exists(
+            vm.invoke_method_inner(
                 globals,
                 IdentId::SINGLETON_METHOD_ADDED,
                 receiver,
@@ -1347,6 +1386,15 @@ mod tests {
         "#,
             r#"
         class C
+        end
+        "#,
+        );
+        // constant lookup in class_eval with string
+        run_test_with_prelude(
+            r#"C.class_eval("X")"#,
+            r#"
+        class C
+          X = 99
         end
         "#,
         );

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -2,7 +2,7 @@ use super::*;
 use jitgen::JitContext;
 
 //
-// Object class
+// BasicObject class and Object class
 //
 
 pub(super) fn init(globals: &mut Globals) {
@@ -58,74 +58,25 @@ pub(super) fn init(globals: &mut Globals) {
         "method_missing",
         bo_method_missing,
     );
+    globals.define_private_builtin_func(
+        BASIC_OBJECT_CLASS,
+        "singleton_method_added",
+        bo_noop_hook,
+        1,
+    );
+    globals.define_private_builtin_func(
+        BASIC_OBJECT_CLASS,
+        "singleton_method_removed",
+        bo_noop_hook,
+        1,
+    );
+    globals.define_private_builtin_func(
+        BASIC_OBJECT_CLASS,
+        "singleton_method_undefined",
+        bo_noop_hook,
+        1,
+    );
 
-    // Object methods
-    globals.define_builtin_func(OBJECT_CLASS, "class", class, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "hash", hash, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "eql?", eql_, 1);
-    globals.define_builtin_funcs(OBJECT_CLASS, "dup", &["clone"], dup, 0);
-    globals.define_private_builtin_func(OBJECT_CLASS, "initialize_copy", initialize_copy, 1);
-    globals.define_private_builtin_func(OBJECT_CLASS, "initialize_clone", initialize_clone, 1);
-    globals.define_private_builtin_func(OBJECT_CLASS, "initialize_dup", initialize_clone, 1);
-    globals.define_builtin_funcs_rest(OBJECT_CLASS, "enum_for", &["to_enum"], to_enum);
-    globals.define_builtin_func_rest(OBJECT_CLASS, "extend", extend);
-    globals.define_builtin_func(OBJECT_CLASS, "kind_of?", is_a, 1);
-    globals.define_builtin_inline_func(
-        OBJECT_CLASS,
-        "object_id",
-        object_id,
-        Box::new(object_object_id),
-        0,
-    );
-    globals.define_builtin_inline_func_with(
-        OBJECT_CLASS,
-        "respond_to?",
-        respond_to,
-        Box::new(object_respond_to),
-        1,
-        2,
-        false,
-    );
-    globals.define_builtin_func(OBJECT_CLASS, "singleton_class", singleton_class, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "to_s", to_s, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "inspect", inspect, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "instance_of?", instance_of, 1);
-    globals.define_builtin_func(OBJECT_CLASS, "instance_variable_defined?", iv_defined, 1);
-    globals.define_builtin_func(OBJECT_CLASS, "instance_variable_set", iv_set, 2);
-    globals.define_builtin_func(OBJECT_CLASS, "instance_variable_get", iv_get, 1);
-    globals.define_builtin_func(OBJECT_CLASS, "instance_variables", iv, 0);
-    globals.define_builtin_func(OBJECT_CLASS, "remove_instance_variable", iv_remove, 1);
-    globals.define_builtin_func(OBJECT_CLASS, "is_a?", is_a, 1);
-    globals.define_builtin_inline_funcs_with_kw(
-        OBJECT_CLASS,
-        "send",
-        &["__send__", "public_send"],
-        crate::builtins::send,
-        Box::new(crate::builtins::object_send),
-        0,
-        0,
-        true,
-        &[],
-        true,
-    );
-    globals.define_builtin_func(OBJECT_CLASS, "method", method, 1);
-    globals.define_builtin_func_with(
-        OBJECT_CLASS,
-        "define_singleton_method",
-        define_singleton_method,
-        1,
-        2,
-        false,
-    );
-    globals.define_builtin_func_with(OBJECT_CLASS, "methods", methods, 0, 1, false);
-    globals.define_builtin_func_with(
-        OBJECT_CLASS,
-        "singleton_methods",
-        singleton_methods,
-        0,
-        1,
-        false,
-    );
 }
 
 ///
@@ -133,6 +84,12 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 #[monoruby_builtin]
 fn bo_initialize(_: &mut Executor, _: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::nil())
+}
+
+/// No-op hook for singleton_method_added/removed/undefined on BasicObject.
+#[monoruby_builtin]
+fn bo_noop_hook(_: &mut Executor, _: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::nil())
 }
 
@@ -218,17 +175,17 @@ fn ne(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 }
 
 ///
-/// ### Object#object_id
+/// ### BasicObject#__id__
 ///
 /// - object_id -> Integer
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/object_id.html]
 #[monoruby_builtin]
-fn object_id(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+pub(super) fn object_id(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::integer(lfp.self_val().id() as i64))
 }
 
-fn object_object_id(
+pub(super) fn object_object_id(
     state: &mut AbstractState,
     ir: &mut AsmIr,
     _: &JitContext,
@@ -256,89 +213,7 @@ fn object_object_id(
 }
 
 ///
-/// Object#send
-///
-/// - send(name, *args) -> object
-/// - send(name, *args) { .... } -> object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/send.html]
-#[monoruby_builtin]
-pub(crate) fn send(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let ary = lfp.arg(0).as_array();
-    if ary.len() < 1 {
-        return Err(MonorubyErr::wrong_number_of_arg_min(ary.len(), 1));
-    }
-    let method = ary[0].expect_symbol_or_string(globals)?;
-    vm.invoke_method_inner(
-        globals,
-        method,
-        lfp.self_val(),
-        &ary[1..],
-        lfp.block(),
-        if let Some(kw) = lfp.try_arg(1)
-            && let Some(kw) = kw.try_hash_ty()
-            && !kw.is_empty()
-        {
-            Some(kw)
-        } else {
-            None
-        },
-    )
-}
-
-pub fn object_send(
-    state: &mut AbstractState,
-    ir: &mut AsmIr,
-    _: &JitContext,
-    store: &Store,
-    callid: CallSiteId,
-    _: ClassId,
-) -> bool {
-    let callsite = &store[callid];
-    let no_splat = !callsite.object_send_single_splat();
-    if !callsite.is_simple() && no_splat {
-        return false;
-    }
-
-    state.write_back_recv_and_callargs(ir, callsite);
-    state.writeback_acc(ir);
-    let using_xmm = state.get_using_xmm();
-    let error = ir.new_error(state);
-    let callid = callsite.id;
-    ir.inline(move |r#gen, store, labels| {
-        let error = &labels[error];
-        r#gen.object_send_inline(callid, store, using_xmm, &error, no_splat);
-    });
-    state.def_reg2acc(ir, GP::Rax, callsite.dst);
-    true
-}
-
-///
-/// ### Object#extend
-/// - extend(*modules) -> self
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/extend.html]
-#[monoruby_builtin]
-fn extend(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let args = lfp.arg(0).as_array();
-    if args.len() == 0 {
-        return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
-    }
-    let self_val = lfp.self_val();
-    for v in args.iter().cloned().rev() {
-        vm.invoke_method_inner(globals, IdentId::EXTEND_OBJECT, v, &[self_val], None, None)?;
-        vm.invoke_method_if_exists(globals, IdentId::EXTENDED, v, &[self_val], None, None)?;
-    }
-    Ok(lfp.self_val())
-}
-
-///
-/// ### Object.new
+/// Object.new
 ///
 /// - new -> Object
 ///
@@ -347,7 +222,7 @@ fn extend(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 fn object_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class = lfp.self_val().as_class_id();
     let obj = Value::object(class);
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
         obj,
@@ -356,327 +231,6 @@ fn object_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         None,
     )?;
     Ok(obj)
-}
-
-///
-/// ### Object#is_a?
-///
-/// - is_a?(mod) -> bool
-/// - kind_of?(mod) -> bool
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/is_a=3f.html]
-#[monoruby_builtin]
-fn is_a(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class = lfp.arg(0).expect_class_or_module(&globals.store)?.id();
-    Ok(Value::bool(
-        lfp.self_val().is_kind_of(&globals.store, class),
-    ))
-}
-
-///
-/// ### Object#enum_for
-///
-/// - to_enum(method = :each, *args) -> Enumerator
-/// - enum_for(method = :each, *args) -> Enumerator
-/// - [NOT SUPPORTED] to_enum(method = :each,  *args) {|*args| ... } -> Enumerator
-/// - [NOT SUPPORTED] enum_for(method = :each, *args) {|*args| ... } -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/enum_for.html]
-#[monoruby_builtin]
-fn to_enum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    lfp.expect_no_block()?;
-    let args = lfp.arg(0).as_array();
-    let (method, args) = if args.is_empty() {
-        (IdentId::EACH, vec![])
-    } else {
-        (
-            args[0].expect_symbol_or_string(globals)?,
-            args[1..].to_vec(),
-        )
-    };
-    vm.generate_enumerator(method, lfp.self_val(), args, pc)
-}
-
-///
-/// ### Object#dup
-///
-/// - dup -> object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/clone.html]
-#[monoruby_builtin]
-fn dup(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(lfp.self_val().dup())
-}
-
-/// ### Object#define_singleton_method
-///
-/// - define_singleton_method(name, method) -> Symbol
-/// - define_singleton_method(name) { ... } -> Symbol
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/define_singleton_method.html]
-#[monoruby_builtin]
-fn define_singleton_method(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    pc: BytecodePtr,
-) -> Result<Value> {
-    let self_val = lfp.self_val();
-    let class_id = globals.store.get_singleton(self_val)?.id();
-    let name = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let func_id = if let Some(method) = lfp.try_arg(1) {
-        if let Some(proc) = method.is_proc() {
-            globals.define_proc_method(proc)
-        } else if let Some(method) = method.is_method() {
-            method.func_id()
-        } else if let Some(method) = method.is_umethod() {
-            method.func_id()
-        } else {
-            return Err(MonorubyErr::wrong_argument_type(
-                globals,
-                method,
-                "Proc/Method/UnboundMethod",
-            ));
-        }
-    } else if let Some(bh) = lfp.block() {
-        let proc = vm.generate_proc(bh, pc)?;
-        globals.define_proc_method(proc)
-    } else {
-        return Err(MonorubyErr::wrong_number_of_arg(2, 1));
-    };
-    globals.add_public_method(class_id, name, func_id);
-    Ok(Value::symbol(name))
-}
-
-/// ### Object#initialize_copy
-///
-/// - initialize_copy(obj) -> object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/initialize_copy.html]
-#[monoruby_builtin]
-fn initialize_copy(
-    _: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let orig = lfp.arg(0);
-    let self_val = lfp.self_val();
-    if orig.id() == self_val.id() {
-        return Ok(self_val);
-    }
-    if self_val.real_class(globals).id() != orig.real_class(globals).id()
-        || self_val.ty() != orig.ty()
-    {
-        return Err(MonorubyErr::typeerr(format!(
-            "initialize_copy should take same class object self:{} original:{}",
-            self_val.class().get_name(globals),
-            orig.class().get_name(globals)
-        )));
-    }
-    Ok(self_val)
-}
-
-/// ### Object#initialize_clone
-///
-/// - initialize_clone(obj) -> object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/initialize_clone.html]
-#[monoruby_builtin]
-fn initialize_clone(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let orig = lfp.arg(0);
-    let self_val = lfp.self_val();
-    vm.invoke_method_inner(
-        globals,
-        IdentId::get_id("initialize_copy"),
-        self_val,
-        &[orig],
-        None,
-        None,
-    )
-}
-
-///
-/// ### Object#to_s
-///
-/// - to_s -> String
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/to_s.html]
-#[monoruby_builtin]
-fn to_s(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let s = lfp.self_val().to_s(&globals.store);
-    Ok(Value::string(s))
-}
-
-///
-/// ### Object#respond_to?
-///
-/// - respond_to?(name, include_all = false) -> bool
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/respond_to=3f.html]
-#[monoruby_builtin]
-fn respond_to(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let name = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let include_all = if let Some(arg1) = lfp.try_arg(1) {
-        arg1.as_bool()
-    } else {
-        false
-    };
-    Ok(Value::bool(if include_all {
-        globals.check_method(lfp.self_val(), name).is_some()
-    } else {
-        globals.check_public_method(lfp.self_val(), name).is_some()
-    }))
-}
-
-fn object_respond_to(
-    state: &mut AbstractState,
-    _: &mut AsmIr,
-    ctx: &JitContext,
-    store: &Store,
-    callid: CallSiteId,
-    recv_class: ClassId,
-) -> bool {
-    let callsite = &store[callid];
-    if !callsite.is_simple() {
-        return false;
-    }
-    let CallSiteInfo {
-        dst, args, pos_num, ..
-    } = *callsite;
-    let dst = if let Some(dst) = dst {
-        dst
-    } else {
-        return false;
-    };
-    let include_all = if pos_num != 1 {
-        if state.is_truthy(args + 1usize) {
-            true
-        } else if state.is_falsy(args + 1usize) {
-            false
-        } else {
-            return false;
-        }
-    } else {
-        false
-    };
-    let method_name = if let Some(name) = state.is_symbol_literal(args) {
-        name
-    } else {
-        return false;
-    };
-    let b = if let Some(entry) =
-        store.check_method_for_class_with_version(recv_class, method_name, ctx.class_version())
-    {
-        include_all || entry.is_public()
-    } else {
-        false
-    };
-    state.def_C(dst, Value::bool(b));
-    true
-}
-
-///
-/// ### Object#inspect
-///
-/// - inspect -> String
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/inspect.html]
-#[monoruby_builtin]
-fn inspect(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let s = lfp.self_val().inspect(&globals.store);
-    Ok(Value::string(s))
-}
-
-///
-/// ### Object#class
-///
-/// - class -> Class
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/class.html]
-#[monoruby_builtin]
-fn class(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(lfp.self_val().real_class(&globals.store).as_val())
-}
-
-///
-/// ### Object#hash
-///
-/// - hash -> Integer
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/hash.html]
-#[monoruby_builtin]
-fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(Value::integer(lfp.self_val().id() as _))
-}
-
-///
-/// ### Object#eql?
-///
-/// - eql?(other) -> bool
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/eql=3f.html]
-#[monoruby_builtin]
-fn eql_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(Value::bool(lfp.self_val().id() == lfp.arg(0).id()))
-}
-
-///
-/// ### Object#instance_of?
-///
-/// - instance_of?(klass) -> bool
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_of=3f.html]
-#[monoruby_builtin]
-fn instance_of(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let b = lfp.self_val().real_class(&globals.store).id()
-        == lfp.arg(0).expect_class_or_module(&globals.store)?.id();
-    Ok(Value::bool(b))
-}
-
-///
-/// ### Object#method
-///
-/// - method(name) -> Method
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/method.html]
-#[monoruby_builtin]
-fn method(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let receiver = lfp.self_val();
-    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let (func_id, _, owner) = globals.find_method_for_object(receiver, method_name)?;
-    Ok(Value::new_method(receiver, func_id, owner))
-}
-
-///
-/// ### Object#singleton_class
-///
-/// - singleton_class -> Class
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/singleton_class.html]
-#[monoruby_builtin]
-fn singleton_class(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    lfp.self_val().get_singleton(&mut globals.store)
 }
 
 ///
@@ -716,162 +270,38 @@ fn instance_eval(
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-
     vm.push_instance_eval_context(self_val);
-    let res = if let Some(bh) = lfp.block() {
+    let res = instance_eval_inner(vm, globals, lfp, self_val);
+    vm.pop_class_context();
+    res
+}
+
+fn instance_eval_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    self_val: Value,
+) -> Result<Value> {
+    if let Some(bh) = lfp.block() {
         if lfp.try_arg(0).is_some() {
             return Err(MonorubyErr::wrong_number_of_arg(0, lfp.args_count(3)));
         }
         let data = vm.get_block_data(globals, bh)?;
         vm.invoke_block_with_self(globals, &data, self_val, &[self_val])
     } else if let Some(arg0) = lfp.try_arg(0) {
-        let expr = arg0.expect_string(globals)?;
+        let expr = arg0.coerce_to_str(vm, globals)?;
         let cfp = vm.cfp();
         let caller_cfp = cfp.prev().unwrap();
         let path = if let Some(arg1) = lfp.try_arg(1) {
-            arg1.expect_string(globals)?
+            arg1.coerce_to_str(vm, globals)?
         } else {
             "(eval)".into()
         };
-
-        let fid = globals.compile_script_eval(expr, path, caller_cfp)?;
+        let fid = globals.compile_script_eval(expr, path, caller_cfp, Some(self_val.class()))?;
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         vm.invoke_block_with_self(globals, &proc, self_val, &[])
     } else {
         Err(MonorubyErr::wrong_number_of_arg_range(0, 1..=3))
-    };
-    vm.pop_class_context();
-    res
-}
-
-///
-/// ### Object#methods
-///
-/// - methods(include_inherited = true) -> [Symbol]
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/methods.html]
-#[monoruby_builtin]
-fn methods(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let inherited_too = lfp.try_arg(0).is_none() || lfp.arg(0).as_bool();
-    Ok(Value::array_from_vec(if !inherited_too {
-        let class_id = match globals.store.has_singleton(lfp.self_val()) {
-            Some(module) => module.id(),
-            None => return Ok(Value::array_empty()),
-        };
-        globals.store.get_method_names(class_id)
-    } else {
-        let class_id = lfp.self_val().class();
-        globals.store.get_method_names_inherit(class_id, true)
-    }))
-}
-
-///
-/// ### Object#singleton_methods
-///
-/// - singleton_methods(inherited_too = true) -> [Symbol]
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/singleton_methods.html]
-#[monoruby_builtin]
-fn singleton_methods(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let class_id = match globals.store.has_singleton(lfp.self_val()) {
-        Some(module) => module.id(),
-        None => return Ok(Value::array_empty()),
-    };
-    let inherited_too = lfp.try_arg(0).is_none() || lfp.arg(0).as_bool();
-    Ok(Value::array_from_vec(if !inherited_too {
-        globals.store.get_method_names(class_id)
-    } else {
-        globals.store.get_method_names_inherit(class_id, true)
-    }))
-}
-
-///
-/// ### Object#instance_variable_defined?
-///
-/// - instance_variable_defined?(var) -> bool
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_defined=3f.html]
-#[monoruby_builtin]
-fn iv_defined(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let id = match lfp.arg(0).unpack() {
-        RV::Symbol(sym) => sym,
-        RV::String(s) => IdentId::get_id(s.check_utf8()?),
-        _ => return Err(MonorubyErr::is_not_symbol_nor_string(globals, lfp.arg(0))),
-    };
-    let b = globals.store.get_ivar(lfp.self_val(), id).is_some();
-    Ok(Value::bool(b))
-}
-
-///
-/// ### Object#instance_variable_set
-///
-/// - instance_variable_set(var, value) -> Object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_set.html]
-#[monoruby_builtin]
-fn iv_set(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let val = lfp.arg(1);
-    globals.store.set_ivar(lfp.self_val(), id, val)?;
-    Ok(val)
-}
-
-///
-/// ### Object#instance_variable_get
-///
-/// - instance_variable_get(var) -> Object | nil
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_get.html]
-#[monoruby_builtin]
-fn iv_get(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let v = globals
-        .store
-        .get_ivar(lfp.self_val(), id)
-        .unwrap_or_default();
-    Ok(v)
-}
-
-///
-/// ### Object#instance_variables
-///
-/// - instance_variables -> [Symbol]
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variables.html]
-#[monoruby_builtin]
-fn iv(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let iter = globals
-        .store
-        .get_ivars(lfp.self_val())
-        .into_iter()
-        .map(|(id, _)| Value::symbol(id));
-    Ok(Value::array_from_iter(iter))
-}
-
-///
-/// ### Object#remove_instance_variable
-///
-/// - remove_instance_variable(name) -> Object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/remove_instance_variable.html]
-#[monoruby_builtin]
-fn iv_remove(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = lfp.arg(0).expect_symbol_or_string(globals)?;
-    match globals.store.remove_ivar(lfp.self_val(), id) {
-        Some(val) => Ok(val),
-        None => Err(MonorubyErr::nameerr(format!(
-            "instance variable {id} not defined"
-        ))),
     }
 }
 
@@ -886,156 +316,6 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin() {
-        run_test2(":sym.class.to_s");
-        run_test2("5.class.to_s");
-        run_test2("5.7.class.to_s");
-        run_test2("'windows'.class.to_s");
-        run_test2("puts 100");
-        run_test2("print '100'");
-        run_test2("p");
-        run_test2("p 1");
-        run_test2("p 1,2");
-        run_test2("p 1,2,3");
-        run_test2("nil.respond_to?(:foo)");
-        run_test2("nil.inspect");
-        run_test2("Time.singleton_class.to_s");
-        run_test2(r#"File.write("/tmp/foo", "woo")"#);
-    }
-
-    #[test]
-    fn object_id() {
-        run_test_with_prelude(
-            r##"
-            [id == a.object_id, a.__id__ == a.object_id]
-            "##,
-            r##"
-            a = [1,2,3]
-            id = a.object_id
-            "##,
-        );
-        run_test_with_prelude(
-            r##"
-            [id == a.object_id, a.__id__ == a.object_id]
-            "##,
-            r##"
-            a = 1356
-            id = a.object_id
-            "##,
-        );
-        run_test_with_prelude(
-            r##"
-            [id == a.object_id, a.__id__ == a.object_id]
-            "##,
-            r##"
-            a = -49.52
-            id = a.object_id
-            "##,
-        );
-    }
-
-    #[test]
-    fn remove_instance_variable() {
-        run_test2(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-                @b = 2
-              end
-            end
-            f = Foo.new
-            f.remove_instance_variable(:@a)
-            "#,
-        );
-        run_test2(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-                @b = 2
-              end
-            end
-            f = Foo.new
-            f.remove_instance_variable(:@a)
-            f.instance_variables
-            "#,
-        );
-        run_test2(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-                @b = 2
-              end
-            end
-            f = Foo.new
-            f.remove_instance_variable("@a")
-            f.instance_variables
-            "#,
-        );
-        run_test2(
-            r#"
-            module M
-              @x = 42
-              remove_instance_variable(:@x)
-            end
-            "#,
-        );
-        run_test_error(
-            r#"
-            obj = Object.new
-            obj.remove_instance_variable(:@nonexistent)
-            "#,
-        );
-    }
-
-    #[test]
-    fn extend() {
-        run_test_with_prelude(
-            r#"
-        res = []
-        obj = Object.new
-        obj.extend Foo, Bar
-        res << obj.a #=> "ok Foo"
-        res << obj.b #=> "ok Bar"
-        res << Klass.new.a #=> "ok Foo"
-        res << Klass.b     #=> "ok Bar"
-        res
-        "#,
-            r#"
-        module Foo
-          def a
-            'ok Foo'
-          end
-        end
-
-        module Bar
-          def b
-            'ok Bar'
-          end
-        end
-
-        class Klass
-          include Foo
-          extend Bar
-        end
-        "#,
-        );
-    }
-
-    #[test]
-    fn dup() {
-        run_test("1.dup");
-        run_test("1.5.dup");
-        run_test("'Ruby'.dup");
-        run_test(":Ruby.dup");
-        run_test("[1,2,3].dup");
-        run_test("{a:1,b:2}.dup");
-        run_test("(1..3).dup");
-    }
-
-    #[test]
     fn equal() {
         run_test(r##"100.equal?(100)"##);
         run_test(r##"100.equal?(100.0)"##);
@@ -1046,117 +326,6 @@ mod tests {
         b = a
         a.equal?(b)"##,
         );
-    }
-
-    #[test]
-    fn block_given() {
-        run_test_with_prelude(
-            r##"
-            [check, check {}]
-        "##,
-            r##"
-        def check
-            if block_given?
-                "Block is given."
-            else
-                "Block isn't given."
-            end
-        end
-        "##,
-        );
-    }
-
-    #[test]
-    fn test_object() {
-        run_test2(r#"a=Object.new; a.instance_variable_set("@i", 42)"#);
-        run_test2(r#"a=Object.new; a.instance_variable_get(:@i)"#);
-        run_test2(
-            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@i)"#,
-        );
-        run_test2(
-            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@j)"#,
-        );
-        run_test2(
-            r#"a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_get(:@i)"#,
-        );
-        // TDDO: Object#instace_variables must return Array of Symbols,
-        // ordered by the time of definition of the instance variables.
-        run_test2(
-            r#"
-            a=Object.new;
-            a.instance_variable_set("@b", 1);
-            a.instance_variable_set("@e", 4);
-            a.instance_variable_set("@c", 2);
-            a.instance_variable_set("@j", 9);
-            a.instance_variable_set("@d", 3);
-            a.instance_variable_set("@a", 0);
-            a.instance_variable_set("@g", 6);
-            a.instance_variable_set("@l", 11);
-            a.instance_variable_set("@h", 7);
-            a.instance_variable_set("@i", 8);
-            a.instance_variable_set("@f", 5);
-            a.instance_variable_set("@k", 10);
-            a.instance_variables.sort
-            "#,
-        );
-    }
-
-    #[test]
-    fn respond_to() {
-        run_test_with_prelude(
-            r#"
-        list = [F.new, D.new]
-        res = []
-        list.each{|it| res << it.hello if it.respond_to?(:hello)}
-        list.each{|it| res << it.hello if it.respond_to?(:hello, false)}
-        list.each{|it| it.instance_eval("res << hello if it.respond_to?(:hello, true)")}
-        res
-        "#,
-            r#"
-        class F
-          def hello
-            "Bonjour"
-          end
-        end
-
-        class D
-          private
-          def hello
-            "Guten Tag"
-          end
-        end
-        "#,
-        );
-    }
-
-    #[test]
-    fn kernel_integer() {
-        run_test2(r#"Integer(-2435)"#);
-        run_test2(r#"Integer("2435")"#);
-        run_test_error(r#"Integer("2435.78")"#);
-        run_test_error(r#"Integer([4])"#);
-        run_test2(r#"Integer(-2435766756886769978978435)"#);
-        run_test2(r#"Integer(2435.4556787)"#);
-    }
-
-    #[test]
-    fn object_instance_of() {
-        run_test2(r#"5.instance_of?(Integer)"#);
-        run_test2(r#"5.instance_of?(Float)"#);
-        run_test2(r#":ruby.instance_of?(Symbol)"#);
-        run_test2(r#":ruby.instance_of?(Object)"#);
-        run_test2(
-            r#"
-        class C < Object
-        end
-        class S < C
-        end
-
-        obj = S.new
-        [obj.instance_of?(S), obj.instance_of?(C)]
-        "#,
-        );
-        run_test_error(r#"5.instance_of?(7)"#);
     }
 
     #[test]
@@ -1179,6 +348,30 @@ mod tests {
             'secret'
           end
         end
+        "#,
+        );
+        // constant lookup in instance_eval with string
+        run_test_with_prelude(
+            r#"
+        some = Foo.new
+        some.instance_eval("BAR")
+        "#,
+            r#"
+        class Foo
+          BAR = 42
+        end
+        "#,
+        );
+        // constant lookup in instance_eval with string (caller's lexical scope)
+        run_test(
+            r#"
+        class A
+          X = 100
+          def test
+            instance_eval("X")
+          end
+        end
+        A.new.test
         "#,
         );
     }
@@ -1228,470 +421,50 @@ mod tests {
     }
 
     #[test]
-    fn object_isa() {
-        run_test("4.is_a? Integer");
-        run_test("4.5.is_a? Integer");
-        run_test("'Ruby'.is_a? Integer");
-        run_test("4.5.is_a? Float");
-        run_test("'Ruby'.is_a? Float");
+    fn initialize() {
+        // default initialize returns the new object
+        run_test("Object.new.class");
+        run_test("Object.new.is_a?(Object)");
+        // custom initialize sets instance variables
         run_test(
             r#"
-        class C
-        end
-        C.new.is_a? C"#,
-        );
-        run_test(
-            r#"
-        class S
-        end
-        class C < S
-        end
-        c = C.new
-        [c.is_a?(S), c.is_a?(C)]"#,
-        );
-    }
-
-    #[test]
-    fn object_nil() {
-        run_test("4.nil?");
-        run_test("4.5.nil?");
-        run_test("nil.nil?");
-        run_test("true.nil?");
-        run_test("false.nil?");
-        run_test("[].nil?");
-    }
-
-    #[test]
-    fn kernel_system() {
-        run_test(r#"system "ls""#);
-        run_test(r#"system "jkjkjk""#);
-        run_test(r#"system "*""#);
-        run_test(r#"`pwd`"#);
-        run_test(r#"`*`"#);
-        run_test_error(r#"``"#);
-    }
-
-    #[test]
-    fn to_enum() {
-        run_test(
-            r#"
-        e = [1,2,3,4,5].to_enum
-        e.next
-        "#,
-        );
-    }
-
-    #[test]
-    fn send() {
-        run_test(
-            r#"
-        "ruby".send(:sub, /./, "R")
-        "#,
-        );
-        run_test(
-            r#"
-        class Foo
-            def foo() "foo" end
-            def bar() "bar" end
-            def baz() "baz" end
-        end
-        methods = {1 => :foo, 2 => :bar, 3 => :baz}
-        f = Foo.new
-        [f.send(methods[1]), f.send(methods[2]), f.send(methods[3])]
-        "#,
-        );
-        run_test_with_prelude(
-            r#"
-            o.send(:f){ 3 }
+            class Foo
+              def initialize(x)
+                @x = x
+              end
+              def x; @x; end
+            end
+            Foo.new(42).x
             "#,
+        );
+        // super in initialize
+        run_test(
+            r#"
+            class A
+              def initialize
+                @a = 1
+              end
+            end
+            class B < A
+              def initialize
+                super
+                @b = 2
+              end
+              def vals; [@a, @b]; end
+            end
+            B.new.vals
+            "#,
+        );
+        // initialize with block
+        run_test(
             r#"
             class C
-                def f
-                    yield
-                end
-            end
-            o = C.new
-            "#,
-        );
-    }
-
-    #[test]
-    fn object_send() {
-        run_test_with_prelude(
-            r##"
-        o = C.new
-        [o.send(:foo), o.send("foo"), o.send(:bar, 20), o.send(*[:foo]), o.send(*["bar", 100])]
-        "##,
-            r##"
-        class C
-            def foo
-                1
-            end
-            def bar(x)
-                x
-            end
-        end
-        "##,
-        );
-        run_test_error(
-            r##"
-        class C
-            def foo
-                1
-            end
-        end
-        C.new.send
-        "##,
-        );
-        run_test_error(
-            r##"
-        class C
-            def foo
-                1
-            end
-        end
-        C.new.send(200, 100)
-        "##,
-        );
-        run_test_error(
-            r##"
-        class C
-            def foo
-                1
-            end
-        end
-        C.new.send(:foo, 100)
-        "##,
-        );
-        run_test_error(
-            r##"
-        class C
-            def foo
-                1
-            end
-        end
-        C.new.send(*[])
-        "##,
-        );
-        run_test_error(
-            r##"
-          class C
-            def b(x, y, z)
-              puts "x=#{[x, y, z]}"
-            end
-          end
-          
-          o = C.new
-          30.times do |x|
-            if x == 28 then
-              eval('class C; def b(x); puts "x=#{x}" ;end; end')
-            end
-            o.send(:b, x, 2, 3)
-          end 
-            "##,
-        );
-    }
-
-    #[test]
-    fn public_send() {
-        run_test(
-            r##"
-        class C
-          def foo; "foo"; end
-        end
-        C.new.public_send(:foo)
-        "##,
-        );
-        run_test(
-            r##"
-        class C
-          def bar(x); x * 2; end
-        end
-        C.new.public_send(:bar, 21)
-        "##,
-        );
-        run_test(
-            r##"
-        class C
-          def baz; yield + 1; end
-        end
-        C.new.public_send(:baz) { 41 }
-        "##,
-        );
-    }
-
-    #[test]
-    fn methods() {
-        run_test_with_prelude(
-            r##"
-        [
-          obj.singleton_methods(false).sort,
-          (obj.singleton_methods(true) - obj2.singleton_methods(true)).sort,
-          obj.methods(false).sort,
-          (obj.methods(true) - obj2.methods(true)).sort,
-          Foo.singleton_methods(false).sort,
-          (Foo.singleton_methods(true) - Foo2.singleton_methods(true)).sort
-        ]
-        "##,
-            r##"
-        Parent = Class.new
-
-        class <<Parent
-          private;   def private_class_parent() end
-          protected; def protected_class_parent() end
-          public;    def public_class_parent() end
-        end
-
-        Foo = Class.new(Parent)
-        Foo2 = Class.new()
-
-        class <<Foo
-          private;   def private_class_foo() end
-          protected; def protected_class_foo() end
-          public;    def public_class_foo() end
-        end
-
-        module Bar
-          private;   def private_bar()   end
-          protected; def protected_bar() end
-          public;    def public_bar()    end
-        end
-
-        obj = Foo.new
-        obj2 = Foo.new
-
-        class << obj
-          include Bar
-          private;   def private_self()   end
-          protected; def protected_self() end
-          public;    def public_self()    end
-        end
-        "##,
-        );
-    }
-
-    #[test]
-    fn define_singleton_method() {
-        // with block
-        run_test(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method(:greet) { "hello" }
-            obj.greet
-            "#,
-        );
-        // with block taking arguments
-        run_test(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method(:add) { |a, b| a + b }
-            obj.add(3, 4)
-            "#,
-        );
-        // returns symbol
-        run_test(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method(:foo) { 42 }
-            "#,
-        );
-        // with string name
-        run_test(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method("bar") { "baz" }
-            obj.bar
-            "#,
-        );
-        // with Proc
-        run_test(
-            r#"
-            obj = Object.new
-            pr = Proc.new { |x| x * 2 }
-            obj.define_singleton_method(:double, pr)
-            obj.double(5)
-            "#,
-        );
-        // with Method
-        run_test(
-            r#"
-            class Foo
-              def hello
-                "hello from Foo"
+              def initialize(&blk)
+                @v = blk.call
               end
+              def v; @v; end
             end
-            obj = Foo.new
-            obj.define_singleton_method(:greet, obj.method(:hello))
-            obj.greet
-            "#,
-        );
-        // with UnboundMethod
-        run_test(
-            r#"
-            class Foo
-              def hi
-                "hi"
-              end
-            end
-            obj = Foo.new
-            obj.define_singleton_method(:greet, Foo.instance_method(:hi))
-            obj.greet
-            "#,
-        );
-        // does not affect other instances
-        run_test(
-            r#"
-            a = Object.new
-            b = Object.new
-            a.define_singleton_method(:only_a) { "only a" }
-            [a.only_a, b.respond_to?(:only_a)]
-            "#,
-        );
-        // error: no block and no method given
-        run_test_error(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method(:foo)
-            "#,
-        );
-        // error: wrong argument type
-        run_test_error(
-            r#"
-            obj = Object.new
-            obj.define_singleton_method(:foo, 42)
-            "#,
-        );
-    }
-
-    #[test]
-    fn initialize_copy() {
-        // initialize_copy with same object returns self
-        run_test(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-              end
-            end
-            obj = Foo.new
-            obj.send(:initialize_copy, obj).equal?(obj)
-            "#,
-        );
-        // initialize_copy with same class succeeds
-        run_test(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-              end
-            end
-            a = Foo.new
-            b = Foo.new
-            b.send(:initialize_copy, a).equal?(b)
-            "#,
-        );
-        // initialize_copy with different class raises TypeError
-        run_test_error(
-            r#"
-            class Foo; end
-            class Bar; end
-            a = Foo.new
-            b = Bar.new
-            a.send(:initialize_copy, b)
-            "#,
-        );
-    }
-
-    #[test]
-    fn initialize_clone() {
-        // initialize_clone delegates to initialize_copy
-        run_test(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-              end
-            end
-            a = Foo.new
-            b = Foo.new
-            b.send(:initialize_clone, a).equal?(b)
-            "#,
-        );
-        // initialize_clone with different class raises TypeError via initialize_copy
-        run_test_error(
-            r#"
-            class Foo; end
-            class Bar; end
-            a = Foo.new
-            b = Bar.new
-            a.send(:initialize_clone, b)
-            "#,
-        );
-        // overridden initialize_clone is called
-        run_test(
-            r#"
-            $called = []
-            class Foo
-              def initialize_clone(orig)
-                $called << :initialize_clone
-                super
-              end
-              def initialize_copy(orig)
-                $called << :initialize_copy
-                super
-              end
-            end
-            a = Foo.new
-            b = Foo.new
-            b.send(:initialize_clone, a)
-            $called
-            "#,
-        );
-    }
-
-    #[test]
-    fn initialize_dup() {
-        // initialize_dup delegates to initialize_copy
-        run_test(
-            r#"
-            class Foo
-              def initialize
-                @a = 1
-              end
-            end
-            a = Foo.new
-            b = Foo.new
-            b.send(:initialize_dup, a).equal?(b)
-            "#,
-        );
-        // initialize_dup with different class raises TypeError via initialize_copy
-        run_test_error(
-            r#"
-            class Foo; end
-            class Bar; end
-            a = Foo.new
-            b = Bar.new
-            a.send(:initialize_dup, b)
-            "#,
-        );
-        // overridden initialize_dup is called
-        run_test(
-            r#"
-            $called = []
-            class Foo
-              def initialize_dup(orig)
-                $called << :initialize_dup
-                super
-              end
-              def initialize_copy(orig)
-                $called << :initialize_copy
-                super
-              end
-            end
-            a = Foo.new
-            b = Foo.new
-            b.send(:initialize_dup, a)
-            $called
+            C.new { 99 }.v
             "#,
         );
     }
@@ -1836,55 +609,6 @@ mod tests {
               end
             end
             Foo.new.baz
-            "#,
-        );
-    }
-
-    #[test]
-    fn initialize() {
-        // default initialize returns the new object
-        run_test("Object.new.class");
-        run_test("Object.new.is_a?(Object)");
-        // custom initialize sets instance variables
-        run_test(
-            r#"
-            class Foo
-              def initialize(x)
-                @x = x
-              end
-              def x; @x; end
-            end
-            Foo.new(42).x
-            "#,
-        );
-        // super in initialize
-        run_test(
-            r#"
-            class A
-              def initialize
-                @a = 1
-              end
-            end
-            class B < A
-              def initialize
-                super
-                @b = 2
-              end
-              def vals; [@a, @b]; end
-            end
-            B.new.vals
-            "#,
-        );
-        // initialize with block
-        run_test(
-            r#"
-            class C
-              def initialize(&blk)
-                @v = blk.call
-              end
-              def v; @v; end
-            end
-            C.new { 99 }.v
             "#,
         );
     }

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -50,7 +50,7 @@ fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         .define_struct_class(name, lfp.self_val().as_class())
         .as_val();
 
-    vm.invoke_method_if_exists(
+    vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
         new_struct,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -474,6 +474,19 @@ impl Executor {
                     .unwrap();
                 v
             }
+            MonorubyErrKind::NotMethod(Some(receiver)) => {
+                let receiver = *receiver;
+                let v = Value::new_exception(err);
+                globals
+                    .store
+                    .set_ivar(
+                        v,
+                        IdentId::get_id("/receiver"),
+                        Value::from_u64(receiver),
+                    )
+                    .unwrap();
+                v
+            }
             _ => Value::new_exception(err),
         }
     }
@@ -626,7 +639,7 @@ impl Executor {
         }
         globals.set_constant(parent, name, val);
         let receiver = globals.store[parent].get_module().into();
-        self.invoke_method_if_exists(
+        self.invoke_method_inner(
             globals,
             IdentId::CONST_ADDED,
             receiver,
@@ -696,7 +709,7 @@ impl Executor {
         } else {
             (IdentId::METHOD_ADDED, module.into())
         };
-        self.invoke_method_if_exists(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
+        self.invoke_method_inner(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
         Ok(())
     }
 
@@ -713,7 +726,7 @@ impl Executor {
         } else {
             (IdentId::METHOD_REMOVED, module.into())
         };
-        self.invoke_method_if_exists(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
+        self.invoke_method_inner(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
         Ok(())
     }
 
@@ -730,7 +743,7 @@ impl Executor {
         } else {
             (IdentId::METHOD_UNDEFINED, module.into())
         };
-        self.invoke_method_if_exists(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
+        self.invoke_method_inner(globals, hook, receiver, &[Value::symbol(name)], None, None)?;
         Ok(())
     }
 
@@ -766,7 +779,7 @@ impl Executor {
         if cref.module_function {
             let module = globals.store[class_id].get_module();
             let receiver: Value = module.into();
-            self.invoke_method_if_exists(
+            self.invoke_method_inner(
                 globals,
                 IdentId::SINGLETON_METHOD_ADDED,
                 receiver,
@@ -873,8 +886,23 @@ impl Executor {
         bh: Option<BlockHandler>,
         kw_args: Option<Hashmap>,
     ) -> Result<Value> {
-        let func_id = self.find_method(globals, receiver, method, true)?;
-        self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args)
+        match self.find_method(globals, receiver, method, true) {
+            Ok(func_id) => self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args),
+            Err(original_err) => {
+                // Fall back to method_missing, matching CRuby behavior.
+                match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
+                    Ok(mm_func_id) => {
+                        let mut mm_args = Vec::with_capacity(args.len() + 1);
+                        mm_args.push(Value::symbol(method));
+                        mm_args.extend_from_slice(args);
+                        self.invoke_func_inner(
+                            globals, mm_func_id, receiver, &mm_args, bh, kw_args,
+                        )
+                    }
+                    Err(_) => Err(original_err),
+                }
+            }
+        }
     }
 
     pub(crate) fn invoke_eq(
@@ -1309,7 +1337,7 @@ impl Executor {
                 } else {
                     let new_class =
                         globals.define_class_with_identid(name, Some(superclass), parent);
-                    self.invoke_method_if_exists(
+                    self.invoke_method_inner(
                         globals,
                         IdentId::INHERITED,
                         superclass.as_val(),

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -104,10 +104,6 @@ impl Executor {
                 },
             };
         }
-        if let Some(v) = self.get_constant(globals, OBJECT_CLASS, name)? {
-            // for BasicObject class
-            return Ok(v);
-        }
         Err(MonorubyErr::uninitialized_constant(name))
     }
 
@@ -117,12 +113,32 @@ impl Executor {
         name: IdentId,
         current_func: FuncId,
     ) -> Result<Value> {
+        // Search the current frame's lexical_context first (covers string
+        // eval where the eval's ISeqInfo has the receiver's class set).
+        let frame_func = self.cfp().lfp().func_id();
+        if frame_func != current_func {
+            if let Some(v) = self.search_lexical_stack(globals, name, frame_func)? {
+                return Ok(v);
+            }
+        }
+        // Then search the enclosing method's lexical_context.
         if let Some(v) = self.search_lexical_stack(globals, name, current_func)? {
             return Ok(v);
         }
-        let module = current_func.lexical_class(globals);
-        let module = globals[module].get_module();
-
+        // For superclass fallback, prefer the frame's lexical class if the
+        // frame has its own lexical_context (i.e. string eval), otherwise
+        // use the enclosing method's lexical class.
+        let lexical_class = if frame_func != current_func {
+            let fc = frame_func.lexical_class(globals);
+            if fc != OBJECT_CLASS {
+                fc
+            } else {
+                current_func.lexical_class(globals)
+            }
+        } else {
+            current_func.lexical_class(globals)
+        };
+        let module = globals[lexical_class].get_module();
         self.get_constant_superclass_checked(globals, module, name)
     }
 

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -300,6 +300,7 @@ impl Globals {
         code: String,
         path: impl Into<PathBuf>,
         caller_cfp: Cfp,
+        receiver_class: Option<ClassId>,
     ) -> Result<FuncId> {
         let outer_fid = caller_cfp.lfp().func_id();
         let outer = self.store[outer_fid].as_iseq();
@@ -307,11 +308,16 @@ impl Globals {
 
         match Parser::parse_program_eval(code, path.into(), Some(&external_context)) {
             Ok(result) => {
-                let res =
-                    bytecodegen::bytecode_compile_eval(self, result, outer, Loc::default(), None);
+                let fid =
+                    bytecodegen::bytecode_compile_eval(self, result, outer, Loc::default(), None)?;
+                if let Some(class_id) = receiver_class {
+                    if let Some(info) = self.store.iseq_mut(fid) {
+                        info.lexical_context.push(class_id);
+                    }
+                }
                 #[cfg(feature = "emit-bc")]
                 self.dump_bc();
-                res
+                Ok(fid)
             }
             Err(err) => Err(MonorubyErr::parse(err)),
         }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -124,7 +124,7 @@ impl MonorubyErr {
     pub fn class_name(&self, store: &Store) -> String {
         match &self.kind {
             MonorubyErrKind::Exception => "Exception",
-            MonorubyErrKind::NotMethod => "NoMethodError",
+            MonorubyErrKind::NotMethod(_) => "NoMethodError",
             MonorubyErrKind::Arguments => "ArgumentError",
             MonorubyErrKind::Syntax => "SyntaxError",
             MonorubyErrKind::Unimplemented => "RuntimeError",
@@ -153,7 +153,7 @@ impl MonorubyErr {
     pub fn class_id(&self) -> ClassId {
         match &self.kind {
             MonorubyErrKind::Exception => EXCEPTION_CLASS,
-            MonorubyErrKind::NotMethod => NO_METHOD_ERROR_CLASS,
+            MonorubyErrKind::NotMethod(_) => NO_METHOD_ERROR_CLASS,
             MonorubyErrKind::Arguments => ARGUMENTS_ERROR_CLASS,
             MonorubyErrKind::Syntax => SYNTAX_ERROR_CLASS,
             MonorubyErrKind::Unimplemented => UNIMPLEMENTED_ERROR_CLASS,
@@ -292,7 +292,7 @@ impl MonorubyErr {
 
     pub(crate) fn method_not_found(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod,
+            MonorubyErrKind::NotMethod(Some(obj.id())),
             format!(
                 "undefined method `{name}' for {}",
                 obj.get_real_class_name(store)
@@ -306,7 +306,7 @@ impl MonorubyErr {
         class: ClassId,
     ) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod,
+            MonorubyErrKind::NotMethod(None),
             format!(
                 "undefined method `{name}' for {}",
                 store.get_class_name(class)
@@ -316,7 +316,7 @@ impl MonorubyErr {
 
     pub(crate) fn private_method_called(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod,
+            MonorubyErrKind::NotMethod(Some(obj.id())),
             format!(
                 "private method `{name}' called for {}:{}",
                 obj.to_s(store),
@@ -331,7 +331,7 @@ impl MonorubyErr {
         obj: Value,
     ) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod,
+            MonorubyErrKind::NotMethod(Some(obj.id())),
             format!(
                 "protected method `{name}' called for {}:{}",
                 obj.to_s(store),
@@ -559,7 +559,7 @@ impl MonorubyErr {
         MonorubyErr::frozenerr(format!(
             "can't modify frozen {}: {}",
             val.get_real_class_name(store),
-            val.to_s(store),
+            val.inspect(store),
         ))
     }
 
@@ -597,7 +597,7 @@ impl MonorubyErr {
 #[derive(Debug, Clone, PartialEq)]
 pub enum MonorubyErrKind {
     Exception,
-    NotMethod,
+    NotMethod(Option<u64>),
     Arguments,
     Syntax,
     Unimplemented,
@@ -625,7 +625,7 @@ impl MonorubyErrKind {
     pub fn from_class_id(class_id: ClassId) -> Self {
         match class_id {
             EXCEPTION_CLASS => MonorubyErrKind::Exception,
-            NO_METHOD_ERROR_CLASS => MonorubyErrKind::NotMethod,
+            NO_METHOD_ERROR_CLASS => MonorubyErrKind::NotMethod(None),
             ARGUMENTS_ERROR_CLASS => MonorubyErrKind::Arguments,
             SYNTAX_ERROR_CLASS => MonorubyErrKind::Syntax,
             UNIMPLEMENTED_ERROR_CLASS => MonorubyErrKind::Unimplemented,

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -323,6 +323,13 @@ impl ClassInfo {
         self.class_variables.as_ref()?.get(&name).cloned()
     }
 
+    fn cvar_names(&self) -> Vec<IdentId> {
+        match &self.class_variables {
+            Some(cv) => cv.keys().cloned().collect(),
+            None => vec![],
+        }
+    }
+
     ///
     /// Remove a constant with *name* in the class of *class_id*.
     ///
@@ -785,6 +792,10 @@ impl ClassInfoTable {
 }
 
 impl Store {
+    pub(crate) fn get_class_variable_names(&self, class_id: ClassId) -> Vec<IdentId> {
+        self[class_id].cvar_names()
+    }
+
     ///
     /// Add a new public method *func* with *name* to the class of *class_id*.
     ///

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -851,6 +851,21 @@ impl FuncInfo {
         self.ext.params.total_positional_args()
     }
 
+    ///
+    /// Calculate Ruby arity for this function.
+    ///
+    /// - No optional/rest: arity = required + post
+    /// - Optional or rest: arity = -(required + post + 1)
+    ///
+    pub(crate) fn arity(&self) -> i64 {
+        let min = self.min_positional_args() as i64;
+        if self.opt_num() > 0 || self.is_rest() {
+            -(min + 1)
+        } else {
+            min
+        }
+    }
+
     /*pub(crate) fn discard_excess_positional_args(&self) -> bool {
         self.is_block_style() && !self.is_rest()
     }*/

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -820,29 +820,34 @@ impl Value {
     }
 }
 
-fn search_method(
+fn coerce_to_rstring_inner(
     vm: &mut Executor,
     globals: &mut Globals,
-    methods: &[IdentId],
     recv: Value,
+    methods: &[IdentId],
 ) -> Result<RString> {
     if let Some(s) = recv.is_rstring() {
         return Ok(s);
     }
     for &method in methods {
         if let Some(func_id) = globals.check_method(recv, method) {
-            let v = vm.invoke_func_inner(globals, func_id, recv, &[], None, None)?;
-            if let Some(s) = v.is_rstring() {
+            let result = vm.invoke_func_inner(globals, func_id, recv, &[], None, None)?;
+            if let Some(s) = result.is_rstring() {
                 return Ok(s);
             }
-            break;
+            return Err(MonorubyErr::typeerr(format!(
+                "can't convert {} into String ({}#{} gives {})",
+                recv.get_real_class_name(&globals.store),
+                recv.get_real_class_name(&globals.store),
+                method,
+                result.get_real_class_name(&globals.store),
+            )));
         }
     }
-    Err(MonorubyErr::no_implicit_conversion(
-        globals,
-        recv,
-        STRING_CLASS,
-    ))
+    Err(MonorubyErr::typeerr(format!(
+        "no implicit conversion of {} into String",
+        recv.get_real_class_name(&globals.store)
+    )))
 }
 
 impl Value {
@@ -1428,7 +1433,7 @@ impl Value {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<RString> {
-        search_method(vm, globals, &[IdentId::TO_STR], *self)
+        coerce_to_rstring_inner(vm, globals, *self, &[IdentId::TO_STR])
     }
 
     pub(crate) fn coerce_to_string(
@@ -1439,12 +1444,20 @@ impl Value {
         Ok(self.coerce_to_rstring(vm, globals)?.to_str()?.to_string())
     }
 
+    pub(crate) fn coerce_to_str(
+        &self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<String> {
+        self.coerce_to_string(vm, globals)
+    }
+
     pub(crate) fn coerce_to_path_rstring(
         &self,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<RString> {
-        search_method(vm, globals, &[IdentId::TO_STR, IdentId::TO_PATH], *self)
+        coerce_to_rstring_inner(vm, globals, *self, &[IdentId::TO_STR, IdentId::TO_PATH])
     }
 
     pub(crate) fn expect_regexp_or_string(&self, store: &Store) -> Result<Regexp> {

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -1801,3 +1801,125 @@ fn comment_in_method_chain() {
         "##,
     );
 }
+
+#[test]
+fn method_missing_basic() {
+    run_test_with_prelude(
+        r#"
+        C.new.hello
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            "missing: #{name}"
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_args() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(1, 2, 3)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            [name, args]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_splat() {
+    run_test_with_prelude(
+        r#"
+        a = [2, 3]
+        C.new.foo(1, *a, 4)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            [name, args]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_kwargs() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(1, x: 10, y: 20)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args, **kwargs)
+            [name, args, kwargs]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_hash_splat() {
+    run_test_with_prelude(
+        r#"
+        h = {a: 1, b: 2}
+        C.new.bar(**h)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args, **kwargs)
+            [name, args, kwargs]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_via_undef() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(10, 20)
+        "#,
+        r#"
+        class C
+          def foo(*args)
+            args
+          end
+          undef_method :foo
+          def method_missing(name, *args)
+            "undef caught: #{name} #{args}"
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_hook_via_singleton_class() {
+    run_test_once(
+        r#"
+        $result = []
+        class C
+          class << self
+            undef_method :singleton_method_added
+            def method_missing(name, *args)
+              $result << [name, args]
+              nil
+            end
+          end
+          def self.foo; end
+        end
+        $result
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary
- **Kernel/Object refactor**: Move method implementations from `Object` to `Kernel` module to match CRuby's method resolution hierarchy
- **Method hooks**: Implement `method_missing` fallback with argument passing, `singleton_method_added/removed/undefined` hooks, and consolidate `method_added/removed/undefined` callbacks into Executor helpers
- **New builtins**: Add `Method#arity`, `NoMethodError#receiver`, `Module#class_variables`, improve `Exception#message`, add `to_str` coercion for `instance_eval`
- **Bug fixes**: Fix `!=` dispatch, protected method check, frozen singleton, constant lookup in `instance_eval`/`class_eval`, singleton class creation rejection for Integer/Float/Symbol/Range/Complex, panics in `Module#to_s`/`clock_gettime`/Regexp captures
- **BasicObject**: Define as constant on itself, improve spec compliance
- **Tests**: Add comprehensive tests for method_call, public_instance_methods, class_variable_get/set, and more

## Test plan
- [ ] `cargo test` passes
- [ ] Verify method_missing argument passing works correctly
- [ ] Verify Kernel methods are accessible through expected resolution chain
- [ ] Verify singleton method hooks fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)