### PR TITLE
Add method_missing fallback to invoke_method_inner

### DIFF
--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -886,8 +886,23 @@ impl Executor {
         bh: Option<BlockHandler>,
         kw_args: Option<Hashmap>,
     ) -> Result<Value> {
-        let func_id = self.find_method(globals, receiver, method, true)?;
-        self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args)
+        match self.find_method(globals, receiver, method, true) {
+            Ok(func_id) => self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args),
+            Err(original_err) => {
+                // Fall back to method_missing, matching CRuby behavior.
+                match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
+                    Ok(mm_func_id) => {
+                        let mut mm_args = Vec::with_capacity(args.len() + 1);
+                        mm_args.push(Value::symbol(method));
+                        mm_args.extend_from_slice(args);
+                        self.invoke_func_inner(
+                            globals, mm_func_id, receiver, &mm_args, bh, kw_args,
+                        )
+                    }
+                    Err(_) => Err(original_err),
+                }
+            }
+        }
     }
 
     pub(crate) fn invoke_eq(

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -1801,3 +1801,125 @@ fn comment_in_method_chain() {
         "##,
     );
 }
+
+#[test]
+fn method_missing_basic() {
+    run_test_with_prelude(
+        r#"
+        C.new.hello
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            "missing: #{name}"
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_args() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(1, 2, 3)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            [name, args]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_splat() {
+    run_test_with_prelude(
+        r#"
+        a = [2, 3]
+        C.new.foo(1, *a, 4)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args)
+            [name, args]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_kwargs() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(1, x: 10, y: 20)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args, **kwargs)
+            [name, args, kwargs]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_with_hash_splat() {
+    run_test_with_prelude(
+        r#"
+        h = {a: 1, b: 2}
+        C.new.bar(**h)
+        "#,
+        r#"
+        class C
+          def method_missing(name, *args, **kwargs)
+            [name, args, kwargs]
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_via_undef() {
+    run_test_with_prelude(
+        r#"
+        C.new.foo(10, 20)
+        "#,
+        r#"
+        class C
+          def foo(*args)
+            args
+          end
+          undef_method :foo
+          def method_missing(name, *args)
+            "undef caught: #{name} #{args}"
+          end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn method_missing_hook_via_singleton_class() {
+    run_test_once(
+        r#"
+        $result = []
+        class C
+          class << self
+            undef_method :singleton_method_added
+            def method_missing(name, *args)
+              $result << [name, args]
+              nil
+            end
+          end
+          def self.foo; end
+        end
+        $result
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary
- Add `method_missing` fallback in `invoke_method_inner`: when a method is not found, attempt to call `method_missing` with the method name symbol and original arguments, matching CRuby behavior
- Add 7 tests covering basic `method_missing`, argument passing, splat, kwargs, hash splat, `undef_method` fallback, and singleton class hook scenarios

## Test plan
- [x] `cargo test` passes
- [x] `method_missing` receives correct method name and arguments
- [x] Falls back to original error when `method_missing` is also not defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)