### PR TITLE
Fix Module.new block not evaluating as module_eval

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -145,8 +145,7 @@ fn module_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     let module = globals.store.define_unnamed_module();
     let module_val = module.as_val();
     if let Some(bh) = lfp.block() {
-        let data = vm.get_block_data(globals, bh)?;
-        vm.invoke_block_with_self(globals, &data, module_val, &[module_val])?;
+        vm.module_eval(globals, module, bh)?;
     }
     Ok(module_val)
 }
@@ -2494,6 +2493,26 @@ mod tests {
         n = Module.new
         res << (m == n)
         res
+        "##,
+        );
+        run_test(
+            r##"
+        m = Module.new do
+          def foo; 42; end
+        end
+        Class.new { include m }.new.foo
+        "##,
+        );
+        run_test(
+            r##"
+        m1 = Module.new do
+          def foo; "m1"; end
+        end
+        m2 = Module.new do
+          include m1
+          def foo; super + "+m2"; end
+        end
+        Class.new { include m2 }.new.foo
         "##,
         );
     }


### PR DESCRIPTION
## Summary
- Fix `Module.new` block to use `module_eval` instead of `invoke_block_with_self`, so that methods defined in the block are properly added to the module (matching CRuby behavior)
- Add tests for `Module.new` with method definitions and module inclusion

## Test plan
- [x] Added test: `Module.new { def foo; 42; end }` correctly defines method on the module
- [x] Added test: nested `Module.new` with `include` and `super` works correctly
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)