### PR TITLE
Fix GC crash and enforce type safety for JIT constant slots

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -212,11 +212,11 @@ fn kernel_nil(
     let CallSiteInfo { recv, dst, .. } = *callsite;
     if state.is_nil(recv) {
         if let Some(dst) = dst {
-            state.def_C(dst, Value::bool(true));
+            state.def_C(dst, Immediate::bool(true));
         }
     } else if state.is_not_nil(recv) {
         if let Some(dst) = dst {
-            state.def_C(dst, Value::bool(false));
+            state.def_C(dst, Immediate::bool(false));
         }
     } else {
         state.load(ir, recv, GP::Rdi);
@@ -263,7 +263,7 @@ fn kernel_block_given(
         && let Some(b) = store[callid].block_given()
     {
         if let Some(dst) = dst {
-            state.def_C(dst, Value::bool(b));
+            state.def_C(dst, Immediate::bool(b));
         }
     } else {
         ir.inline(|r#gen, _, _| {
@@ -1817,7 +1817,7 @@ fn object_respond_to(
     } else {
         false
     };
-    state.def_C(dst, Value::bool(b));
+    state.def_C(dst, Immediate::bool(b));
     true
 }
 

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -248,9 +248,9 @@ fn integer_succ(
     }
     let CallSiteInfo { dst, recv, .. } = *callsite;
     if let Some(i) = state.is_fixnum_literal(recv)
-        && Value::is_i63(i + 1)
+        && Value::is_i63(i.get() + 1)
     {
-        state.def_C(dst, Value::integer(i + 1));
+        state.def_C(dst, Immediate::check_fixnum(i.get() + 1).unwrap());
         return true;
     }
 
@@ -506,7 +506,7 @@ fn integer_shl(
     } else if let Some(lhs) = state.is_fixnum_literal(recv) {
         state.load_fixnum(ir, args, GP::Rcx);
         let deopt = ir.new_deopt(state);
-        ir.inline(move |r#gen, _, labels| r#gen.gen_shl_lhs_imm(lhs, &labels[deopt]));
+        ir.inline(move |r#gen, _, labels| r#gen.gen_shl_lhs_imm(lhs.get(), &labels[deopt]));
     } else {
         state.load_fixnum(ir, args, GP::Rcx);
         let deopt = ir.new_deopt(state);

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -139,11 +139,11 @@ fn object_not(
     let CallSiteInfo { recv, dst, .. } = *callsite;
     if state.is_truthy(recv) {
         if let Some(dst) = dst {
-            state.def_C(dst, Value::bool(false));
+            state.def_C(dst, Immediate::bool(false));
         }
     } else if state.is_falsy(recv) {
         if let Some(dst) = dst {
-            state.def_C(dst, Value::bool(true));
+            state.def_C(dst, Immediate::bool(true));
         }
     } else {
         state.load(ir, recv, GP::Rdi);

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -87,8 +87,7 @@ fn range_begin(
     }
     let dst = callsite.dst;
     if let Some(range) = state.is_range_literal(callsite.recv) {
-        let start = range.start();
-        if start.is_frozen_literal() {
+        if let Some(start) = range.start().is_immediate() {
             state.def_C(dst, start);
             return true;
         }
@@ -129,8 +128,7 @@ fn range_end(
     }
     let dst = callsite.dst;
     if let Some(range) = state.is_range_literal(callsite.recv) {
-        let end = range.end();
-        if end.is_frozen_literal() {
+        if let Some(end) = range.end().is_immediate() {
             state.def_C(dst, end);
             return true;
         }
@@ -170,7 +168,7 @@ fn range_exclude_end(
     let dst = callsite.dst;
     if let Some(range) = state.is_range_literal(callsite.recv) {
         let exclude_end = range.exclude_end();
-        state.def_C(dst, Value::bool(exclude_end));
+        state.def_C(dst, Immediate::bool(exclude_end));
         return true;
     }
     state.load(ir, callsite.recv, GP::Rdi);

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -120,7 +120,7 @@ pub(crate) fn rbp_local(reg: SlotId) -> i32 {
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct WriteBack {
     xmm: Vec<(Xmm, Vec<SlotId>)>,
-    literal: Vec<(Value, SlotId)>,
+    literal: Vec<(Immediate, SlotId)>,
     void: Vec<SlotId>,
     r15: Option<SlotId>,
 }
@@ -171,7 +171,7 @@ impl std::fmt::Debug for WriteBack {
 impl WriteBack {
     fn new(
         xmm: Vec<(Xmm, Vec<SlotId>)>,
-        literal: Vec<(Value, SlotId)>,
+        literal: Vec<(Immediate, SlotId)>,
         r15: Option<SlotId>,
         void: Vec<SlotId>,
     ) -> Self {
@@ -676,7 +676,7 @@ impl JitModule {
             self.xmm_to_stack(*xmm, v);
         }
         for (v, slot) in &wb.literal {
-            self.literal_to_stack(*slot, *v);
+            self.literal_to_stack(*slot, (*v).into());
         }
         for slot in &wb.void {
             self.literal_to_stack(*slot, Value::nil());
@@ -704,7 +704,7 @@ impl JitModule {
             self.xmm_to_stack2(*xmm, v);
         }
         for (v, slot) in &wb.literal {
-            self.literal_to_stack2(*slot, *v);
+            self.literal_to_stack2(*slot, (*v).into());
         }
         for slot in &wb.void {
             self.literal_to_stack2(*slot, Value::nil());

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -166,8 +166,8 @@ impl<'a> JitContext<'a> {
                 }
             }
             TraceIr::FrozenLiteral(dst, val) => {
-                if val.is_frozen_literal() {
-                    state.def_C(dst, val);
+                if let Some(imm) = val.is_immediate() {
+                    state.def_C(dst, imm);
                 } else {
                     state.discard(dst);
                     ir.lit2reg(val, GP::Rax);
@@ -301,10 +301,11 @@ impl<'a> JitContext<'a> {
                     }
                     Some(INTEGER_CLASS) => {
                         if let Some(src) = state.is_fixnum_literal(src) {
+                            let i = src.get();
                             match kind {
                                 UnOpK::Neg => {
-                                    if let Some(res) = src.checked_neg()
-                                        && let Some(res) = Value::check_fixnum(res)
+                                    if let Some(res) = i.checked_neg()
+                                        && let Some(res) = Immediate::check_fixnum(res)
                                     {
                                         state.def_C(dst, res);
                                         return Ok(CompileResult::Continue);
@@ -314,7 +315,8 @@ impl<'a> JitContext<'a> {
                                     return Ok(CompileResult::Continue);
                                 }
                                 UnOpK::BitNot => {
-                                    state.def_C(dst, Value::integer(!src));
+                                    // Bitwise NOT of an i63 value always fits in i63
+                                    state.def_C(dst, Immediate::check_fixnum(!i).unwrap());
                                     return Ok(CompileResult::Continue);
                                 }
                                 UnOpK::Not => unreachable!(),
@@ -338,15 +340,14 @@ impl<'a> JitContext<'a> {
                         state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
                     }
                     Some(FLOAT_CLASS) if kind != UnOpK::BitNot && kind != UnOpK::Not => {
-                        if let Some(f) = state.is_float_literal(src) {
+                        if let Some(f) = state.is_flonum_literal(src) {
+                            let f = f.get();
                             let res = match kind {
                                 UnOpK::Neg => -f,
                                 UnOpK::Pos => f,
                                 UnOpK::BitNot | UnOpK::Not => unreachable!(),
                             };
-                            let v = Value::float(res);
-                            if v.is_packed_value() {
-                                state.def_C(dst, v);
+                            if state.def_C_float(dst, res) {
                                 return Ok(CompileResult::Continue);
                             }
                         }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -143,22 +143,22 @@ impl AbstractFrame {
         T: PartialEq + PartialOrd,
     {
         let b = cmp(kind, lhs, rhs);
-        self.def_C(dst, Value::bool(b));
+        self.def_C(dst, Immediate::bool(b));
     }
 
     fn check_concrete_i64(&self, mode: OpMode) -> Option<(i64, i64)> {
         match mode {
             OpMode::RR(lhs, rhs) => {
-                let lhs = self.is_fixnum_literal(lhs)?;
-                let rhs = self.is_fixnum_literal(rhs)?;
+                let lhs = self.is_fixnum_literal(lhs)?.get();
+                let rhs = self.is_fixnum_literal(rhs)?.get();
                 Some((lhs, rhs))
             }
             OpMode::RI(lhs, rhs) => {
-                let lhs = self.is_fixnum_literal(lhs)?;
+                let lhs = self.is_fixnum_literal(lhs)?.get();
                 Some((lhs, rhs as i64))
             }
             OpMode::IR(lhs, rhs) => {
-                let rhs = self.is_fixnum_literal(rhs)?;
+                let rhs = self.is_fixnum_literal(rhs)?.get();
                 Some((lhs as i64, rhs))
             }
         }
@@ -208,50 +208,51 @@ impl AbstractFrame {
         None
     }
 
-    fn binop_integer_folded(&mut self, kind: BinOpK, lhs: i64, rhs: i64) -> Option<Value> {
+    fn binop_integer_folded(&mut self, kind: BinOpK, lhs: i64, rhs: i64) -> Option<Immediate> {
         match kind {
             BinOpK::Add => {
                 if let Some(result) = lhs.checked_add(rhs) {
-                    return Value::check_fixnum(result);
+                    return Immediate::check_fixnum(result);
                 }
             }
             BinOpK::Sub => {
                 if let Some(result) = lhs.checked_sub(rhs) {
-                    return Value::check_fixnum(result);
+                    return Immediate::check_fixnum(result);
                 }
             }
             BinOpK::Mul => {
                 if let Some(result) = lhs.checked_mul(rhs) {
-                    return Value::check_fixnum(result);
+                    return Immediate::check_fixnum(result);
                 }
             }
             BinOpK::Div => {
                 if rhs.is_zero() {
                     return None;
                 }
-                return Value::check_fixnum(lhs.ruby_div(&rhs));
+                return Immediate::check_fixnum(lhs.ruby_div(&rhs));
             }
             BinOpK::Rem => {
                 if rhs.is_zero() {
                     return None;
                 }
-                return Value::check_fixnum(lhs.ruby_mod(&rhs));
+                return Immediate::check_fixnum(lhs.ruby_mod(&rhs));
             }
             BinOpK::Exp => {
                 if let Ok(rhs) = u32::try_from(rhs)
                     && let Some(result) = lhs.checked_pow(rhs)
                 {
-                    return Value::check_fixnum(result);
+                    return Immediate::check_fixnum(result);
                 }
             }
             BinOpK::BitOr => {
-                return Some(Value::integer(lhs | rhs));
+                // Bitwise ops on two i63 values always produce i63 results
+                return Immediate::check_fixnum(lhs | rhs);
             }
             BinOpK::BitAnd => {
-                return Some(Value::integer(lhs & rhs));
+                return Immediate::check_fixnum(lhs & rhs);
             }
             BinOpK::BitXor => {
-                return Some(Value::integer(lhs ^ rhs));
+                return Immediate::check_fixnum(lhs ^ rhs);
             }
         }
         None
@@ -341,14 +342,9 @@ impl AbstractFrame {
     fn binop_float(&mut self, ir: &mut AsmIr, kind: BinOpK, dst: Option<SlotId>, info: FBinOpInfo) {
         if let Some((lhs, rhs)) = self.check_binary_C_f64(info.lhs, info.rhs)
             && let Some(result) = self.binop_float_folded(kind, lhs, rhs)
+            && self.def_C_float(dst, result)
         {
-            // Only constant-fold if the result can be represented as a flonum (packed value).
-            // Heap-allocated Floats (NaN, Infinity) cannot be safely embedded as constants
-            // in JIT code because their pointers are not registered as GC roots.
-            if Value::float(result).is_packed_value() {
-                self.def_C_float(dst, result);
-                return;
-            }
+            return;
         };
 
         let (lhs, rhs, dst) = self.load_binary_ret_xmm(ir, dst, info);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -97,10 +97,12 @@ impl<'a> JitContext<'a> {
                     let CallSiteInfo { args, dst, .. } = *callsite;
                     if let Some(args) = state.coerce_C_f64(args) {
                         let res = f(args);
-                        if let Some(dst) = dst {
-                            state.def_C_float(dst, res);
+                        if match dst {
+                            Some(dst) => state.def_C_float(dst, res),
+                            None => true,
+                        } {
+                            return Ok(CompileResult::Continue);
                         }
-                        return Ok(CompileResult::Continue);
                     }
                     if let Some(dst) = dst {
                         let src = state.load_xmm(ir, args);
@@ -122,10 +124,12 @@ impl<'a> JitContext<'a> {
                     } = *callsite;
                     if let Some((lhs, rhs)) = state.check_binary_C_f64(recv, args) {
                         let res = f(lhs, rhs);
-                        if let Some(dst) = dst {
-                            state.def_C_float(dst, res);
+                        if match dst {
+                            Some(dst) => state.def_C_float(dst, res),
+                            None => true,
+                        } {
+                            return Ok(CompileResult::Continue);
                         }
-                        return Ok(CompileResult::Continue);
                     }
                     if let Some(dst) = dst {
                         let lhs = state.load_xmm(ir, recv);
@@ -172,7 +176,7 @@ impl<'a> JitContext<'a> {
             }
             FuncKind::Builtin { .. } => (func_id, None),
             FuncKind::Const(v) => {
-                state.def_C(dst, v.into());
+                state.def_C(dst, v);
                 return Ok(CompileResult::Continue);
             }
             FuncKind::Proc(proc) => (proc.func_id(), Some(proc.outer_lfp())),
@@ -446,7 +450,7 @@ impl<'a> JitContext<'a> {
 }
 
 pub(super) enum SpecializedCompileResult {
-    Const(Value),
+    Const(Immediate),
     Compiled {
         entry: JitLabel,
         return_state: Option<ReturnState>,

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -371,7 +371,7 @@ pub(super) struct ReturnState {
 #[derive(Debug, Clone, Copy)]
 enum ReturnValue {
     UD,
-    Const(Value),
+    Const(Immediate),
     Class(ClassId),
     Value,
 }
@@ -407,17 +407,11 @@ impl ReturnState {
         }
     }
 
-    pub(in crate::codegen::jitgen) fn const_folded(&self) -> Option<Value> {
+    pub(in crate::codegen::jitgen) fn const_folded(&self) -> Option<Immediate> {
         if !self.invariants.side_effect_guard {
             return None;
         }
         if let ReturnValue::Const(v) = self.ret {
-            // Do not constant-fold heap-allocated objects (e.g., NaN, Infinity as heap Floats).
-            // Their pointers would be embedded directly in JIT code without being registered
-            // as GC roots, causing them to be collected and leading to use-after-free crashes.
-            if !v.is_packed_value() {
-                return None;
-            }
             return Some(v);
         }
         None

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -108,7 +108,7 @@ impl SfGuarded {
         }
     }
 
-    fn from_concrete_value(v: Value) -> Self {
+    fn from_concrete_value(v: Immediate) -> Self {
         if v.is_fixnum() {
             SfGuarded::Fixnum
         } else if v.is_float() {

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -26,7 +26,7 @@ impl AbstractFrame {
                 if dst == GP::R15 {
                     assert!(self.no_r15());
                 }
-                ir.lit2reg(v, dst);
+                ir.lit2reg(v.into(), dst);
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) => {
                 if dst == GP::R15 {
@@ -154,7 +154,7 @@ impl AbstractFrame {
     }
 
     #[allow(non_snake_case)]
-    fn load_xmm_from_C(&mut self, ir: &mut AsmIr, slot: SlotId, v: Value) -> Xmm {
+    fn load_xmm_from_C(&mut self, ir: &mut AsmIr, slot: SlotId, v: Immediate) -> Xmm {
         match v.unpack() {
             RV::Float(f) => {
                 // -> F

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -49,7 +49,7 @@ impl SlotState {
     pub(super) fn new_method(cc: &JitContext) -> Self {
         let mut ctx = SlotState::new(cc, LinkMode::V);
         for i in cc.locals() {
-            ctx.set_mode(i, LinkMode::C(Value::nil()));
+            ctx.set_mode(i, LinkMode::C(Immediate::nil()));
         }
         for i in cc.args() {
             ctx.set_mode(i, LinkMode::default());
@@ -393,16 +393,20 @@ impl SlotState {
     /// Link *slot* to a concrete flonum value *i*.
     ///
     #[allow(non_snake_case)]
-    pub(crate) fn def_C_float(&mut self, slot: impl Into<Option<SlotId>>, f: f64) {
-        self.def_C(slot, Value::float(f));
+    pub(crate) fn def_C_float(&mut self, slot: impl Into<Option<SlotId>>, f: f64) -> bool {
+        if let Some(imm) = Immediate::flonum(f) {
+            self.def_C(slot, imm);
+            true
+        } else {
+            false
+        }
     }
 
     ///
     /// Link *slot* to a concrete value *v*.
     ///
     #[allow(non_snake_case)]
-    pub(crate) fn def_C(&mut self, slot: impl Into<Option<SlotId>>, v: Value) {
-        assert!(v.is_frozen_literal(), "{:?}", v);
+    pub(crate) fn def_C(&mut self, slot: impl Into<Option<SlotId>>, v: Immediate) {
         if let Some(slot) = slot.into() {
             self.discard(slot);
             self.set_mode(slot, LinkMode::C(v));
@@ -454,7 +458,7 @@ impl SlotState {
                 ir.xmm2stack(xmm, slot);
             }
             LinkMode::C(v) => {
-                ir.lit2stack(v, slot);
+                ir.lit2stack(v.into(), slot);
             }
             LinkMode::G(guarded) => {
                 // G -> S
@@ -486,7 +490,7 @@ impl SlotState {
                 ir.xmm2stack(xmm, slot);
             }
             LinkMode::C(v) => {
-                ir.lit2stack(v, slot);
+                ir.lit2stack(v.into(), slot);
             }
             LinkMode::G(_) => {
                 ir.acc2stack(slot);
@@ -513,7 +517,7 @@ impl SlotState {
         }
     }
 
-    pub fn is_fixnum_literal(&self, slot: SlotId) -> Option<i64> {
+    pub fn is_fixnum_literal(&self, slot: SlotId) -> Option<Fixnum> {
         if let LinkMode::C(v) = self.mode(slot) {
             v.try_fixnum()
         } else {
@@ -521,9 +525,9 @@ impl SlotState {
         }
     }
 
-    pub fn is_float_literal(&self, slot: SlotId) -> Option<f64> {
+    pub fn is_flonum_literal(&self, slot: SlotId) -> Option<Flonum> {
         if let LinkMode::C(v) = self.mode(slot) {
-            v.try_float()
+            v.try_flonum()
         } else {
             None
         }
@@ -551,30 +555,18 @@ impl SlotState {
     }
 
     pub fn is_u16(&self, slot: SlotId) -> Option<u16> {
-        if let LinkMode::C(v) = self.mode(slot) {
-            let i = v.try_fixnum()?;
-            u16::try_from(i).ok()
-        } else {
-            None
-        }
+        let i = self.is_fixnum_literal(slot)?.get();
+        u16::try_from(i).ok()
     }
 
     pub fn is_i16_literal(&self, slot: SlotId) -> Option<i16> {
-        if let LinkMode::C(v) = self.mode(slot) {
-            let i = v.try_fixnum()?;
-            i16::try_from(i).ok()
-        } else {
-            None
-        }
+        let i = self.is_fixnum_literal(slot)?.get();
+        i16::try_from(i).ok()
     }
 
     pub fn is_u8_literal(&self, slot: SlotId) -> Option<u8> {
-        if let LinkMode::C(v) = self.mode(slot) {
-            let i = v.try_fixnum()?;
-            u8::try_from(i).ok()
-        } else {
-            None
-        }
+        let i = self.is_fixnum_literal(slot)?.get();
+        u8::try_from(i).ok()
     }
 
     pub fn is_array_ty(&self, store: &Store, slot: SlotId) -> bool {
@@ -963,7 +955,7 @@ impl AbstractFrame {
             .collect()
     }
 
-    fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Value, SlotId)> {
+    fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Immediate, SlotId)> {
         self.slots
             .iter()
             .enumerate()
@@ -1045,11 +1037,9 @@ pub(in crate::codegen::jitgen) enum LinkMode {
     ///
     Sf(Xmm, SfGuarded),
     ///
-    /// Concrete value.
+    /// Concrete value (immediate / packed).
     ///
-    /// The `Value` must be a packed value or Float or Range object.
-    ///
-    C(Value),
+    C(Immediate),
 }
 
 impl LinkMode {
@@ -1062,7 +1052,7 @@ impl LinkMode {
     }
 
     fn nil() -> Self {
-        LinkMode::C(Value::nil())
+        LinkMode::C(Immediate::nil())
     }
 
     fn guarded(&self) -> Guarded {
@@ -1070,7 +1060,7 @@ impl LinkMode {
             LinkMode::S(guarded) | LinkMode::G(guarded) => *guarded,
             LinkMode::Sf(_, guarded) => (*guarded).into(),
             LinkMode::F(_) => Guarded::Float,
-            LinkMode::C(v) => Guarded::from_concrete_value(*v),
+            LinkMode::C(v) => Guarded::from_concrete_value((*v).into()),
             LinkMode::V => Guarded::Class(NIL_CLASS),
             _ => unreachable!("{:?}", self),
         }
@@ -1321,10 +1311,10 @@ impl AbstractFrame {
             }
             (LinkMode::C(l), LinkMode::Sf(r, _)) => {
                 self.set_Sf_float(slot, r);
-                let (v, f) = if let Some(f) = l.try_float() {
-                    (Value::float(f), f)
+                let (v, f) = if let Some(f) = l.try_flonum() {
+                    (Value::float(f.get()), f.get())
                 } else if let Some(i) = l.try_fixnum() {
-                    (Value::integer(i), i as f64)
+                    (Value::integer(i.get()), i.get() as f64)
                 } else {
                     unreachable!()
                 };
@@ -1333,9 +1323,9 @@ impl AbstractFrame {
             }
             (LinkMode::C(v), LinkMode::S(_)) => {
                 // C -> S
-                let guarded = Guarded::from_concrete_value(v);
+                let guarded = Guarded::from_concrete_value(v.into());
                 self.set_mode(slot, LinkMode::S(guarded));
-                ir.lit2stack(v, slot);
+                ir.lit2stack(v.into(), slot);
             }
             (LinkMode::None, LinkMode::None) => {}
             (LinkMode::MaybeNone, LinkMode::MaybeNone) => {}

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -858,6 +858,15 @@ impl Value {
         self.0.get() & 0b0111 != 0
     }
 
+    /// Return `Some(Immediate)` if `self` is a packed (immediate) value.
+    pub fn is_immediate(&self) -> Option<Immediate> {
+        if self.is_packed_value() {
+            Some(Immediate(self.0))
+        } else {
+            None
+        }
+    }
+
     ///
     /// Check if `self` is an immediate, Float or Range object.
     ///
@@ -1856,13 +1865,6 @@ impl AsRef<Value> for Immediate {
     }
 }
 
-impl From<Value> for Immediate {
-    fn from(value: Value) -> Self {
-        assert!(value.is_packed_value());
-        Self(value.0)
-    }
-}
-
 impl Debug for Immediate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let v: Value = (*self).into();
@@ -1917,6 +1919,60 @@ impl Immediate {
         } else {
             None
         }
+    }
+
+    pub fn try_fixnum(self) -> Option<Fixnum> {
+        let i = (*self).try_fixnum()?;
+        Some(Fixnum(i))
+    }
+
+    pub fn try_flonum(self) -> Option<Flonum> {
+        let f = (*self).try_float()?;
+        Some(Flonum(f))
+    }
+}
+
+/// A Value that is guaranteed to be a Fixnum (i63 integer).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Fixnum(i64);
+
+impl Fixnum {
+    pub fn get(&self) -> i64 {
+        self.0
+    }
+}
+
+impl From<Fixnum> for Immediate {
+    fn from(f: Fixnum) -> Self {
+        Immediate::fixnum(f.0)
+    }
+}
+
+impl From<Fixnum> for Value {
+    fn from(f: Fixnum) -> Self {
+        Value::fixnum(f.0)
+    }
+}
+
+/// A Value that is guaranteed to be a Flonum (inline-encoded f64).
+#[derive(Clone, Copy, PartialEq)]
+pub struct Flonum(f64);
+
+impl Flonum {
+    pub fn get(&self) -> f64 {
+        self.0
+    }
+}
+
+impl From<Flonum> for Immediate {
+    fn from(f: Flonum) -> Self {
+        Immediate::flonum(f.0).unwrap()
+    }
+}
+
+impl From<Flonum> for Value {
+    fn from(f: Flonum) -> Self {
+        Value::float(f.0)
     }
 }
 


### PR DESCRIPTION
## Summary
- **Fix GC crash**: Prevent JIT from constant-folding heap-allocated Floats (e.g. NaN, Infinity) whose pointers would be embedded in JIT code without GC root registration, causing use-after-free crashes
- **Enforce type safety for `def_C`**: Replace `Value` with `Immediate` in `LinkMode::C` and `def_C()` so only packed/immediate values can be stored in constant slots — enforced at compile time rather than via runtime assert
- **Introduce `Fixnum`/`Flonum` newtypes**: `is_fixnum_literal()` returns `Option<Fixnum>`, `is_flonum_literal()` returns `Option<Flonum>`, guaranteeing value validity through the type system
- **Add `Value::is_immediate()`**: Safe conversion from `Value` to `Option<Immediate>`, replacing the `is_packed_value()` + `From<Value>` pattern

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)