### PR TITLE
Fix yield to traverse Fiber boundaries when resolving blocks

### DIFF
--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -78,10 +78,10 @@ impl ProcData {
         }
     }
 
-    pub(crate) fn from_proxy(executor: &Executor, proxy: (FuncId, u16)) -> Self {
+    pub(crate) fn from_proxy(mut executor: &Executor, proxy: (FuncId, u16)) -> Self {
         let mut cfp = executor.cfp();
         for _ in 0..proxy.1 {
-            cfp = cfp.prev().unwrap();
+            (executor, cfp) = Executor::prev_cfp(executor, cfp);
         }
         ProcData {
             outer: Some(cfp.lfp()),
@@ -102,7 +102,7 @@ impl ProcData {
 /// - rdx: FuncId
 ///
 pub(super) extern "C" fn get_yield_data(vm: &mut Executor, globals: &mut Globals) -> ProcData {
-    let bh = match vm.cfp().get_block() {
+    let bh = match vm.get_block() {
         Some(data) => data,
         None => {
             vm.set_error(MonorubyErr::no_block_given());

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -931,9 +931,8 @@ impl Executor {
                         let mut mm_args = Vec::with_capacity(args.len() + 1);
                         mm_args.push(Value::symbol(method));
                         mm_args.extend_from_slice(args);
-                        return self.invoke_func(
-                            globals, mm_func_id, receiver, &mm_args, bh, kw_args,
-                        );
+                        return self
+                            .invoke_func(globals, mm_func_id, receiver, &mm_args, bh, kw_args);
                     }
                     Err(_) => {
                         self.set_error(original_err);
@@ -1437,13 +1436,14 @@ impl Executor {
 }
 
 impl Executor {
-    pub(crate) fn generate_proc(&mut self, bh: BlockHandler, pc: BytecodePtr) -> Result<Proc> {
+    pub(crate) fn generate_proc(&self, bh: BlockHandler, pc: BytecodePtr) -> Result<Proc> {
         if let Some((fid, outer)) = bh.try_proxy() {
             // Walk back through the call frame chain to the block's outer scope,
             // using the proxy's depth index.
             let mut cfp = self.cfp();
+            let mut vm = self;
             for _ in 0..outer {
-                cfp = cfp.prev().unwrap();
+                (vm, cfp) = Self::prev_cfp(vm, cfp);
             }
             // Move the correct outer frame (and its lexical chain) to the heap,
             // so the proc can safely reference it after the current scope exits.

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -99,28 +99,6 @@ impl Cfp {
     }
 
     ///
-    /// Get *BlockHandler* of a current method / classdef.
-    ///
-    pub fn get_block(&self) -> Option<BlockHandler> {
-        let lfp = self.outermost_lfp();
-
-        lfp.block().map(|bh| match bh.0.try_fixnum() {
-            Some(mut i) => {
-                let mut cfp = *self;
-                loop {
-                    if cfp.lfp() == lfp {
-                        break;
-                    }
-                    i += 1;
-                    cfp = cfp.prev().unwrap();
-                }
-                BlockHandler::new(Value::integer(i))
-            }
-            None => bh,
-        })
-    }
-
-    ///
     /// Get *FuncId* of a current position in the source code.
     ///
     pub fn get_source_pos(&self) -> FuncId {
@@ -132,6 +110,45 @@ impl Cfp {
             cfp = inner_cfp.prev();
         }
         unreachable!("get_source_pos: non-native method not found.")
+    }
+}
+
+impl Executor {
+    ///
+    /// Get *BlockHandler* of a current method / classdef.
+    ///
+    pub fn get_block(&self) -> Option<BlockHandler> {
+        let cfp = self.cfp();
+        let lfp = cfp.outermost_lfp();
+        let bh = lfp.block()?;
+        Some(match bh.0.try_fixnum() {
+            Some(mut i) => {
+                i = Self::traverse_cfp(self, cfp, lfp, i);
+                BlockHandler::new(Value::integer(i))
+            }
+            None => bh,
+        })
+    }
+
+    // TODO: this does not support nexted fibers.
+    pub fn prev_cfp(vm: &Executor, cfp: Cfp) -> (&Executor, Cfp) {
+        match cfp.prev() {
+            Some(prev) => (vm, prev),
+            None => {
+                let vm = unsafe { vm.parent_fiber.unwrap().as_ref() };
+                (vm, vm.cfp())
+            }
+        }
+    }
+
+    fn traverse_cfp(mut vm: &Executor, mut cfp: Cfp, lfp: Lfp, mut i: i64) -> i64 {
+        loop {
+            if cfp.lfp() == lfp {
+                return i;
+            }
+            i += 1;
+            (vm, cfp) = Self::prev_cfp(vm, cfp);
+        }
     }
 }
 

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -1168,60 +1168,6 @@ fn test_constant_in_method() {
 }
 
 #[test]
-fn test_yield_in_block() {
-    run_test(
-        "
-        class C
-          def f
-            x = 0
-            7.times { x += yield }
-            x
-          end
-        end
-
-        a = 42
-        c = C.new
-
-        c.f { a }
-        ",
-    );
-    run_test(
-        "
-        class C
-          def f
-            x = 0
-            10.times { x += yield }
-            x
-          end
-        end
-
-        @a = 42
-        c = C.new
-
-        c.f { @a }
-        ",
-    );
-}
-
-#[test]
-fn test_yield_in_loop() {
-    run_test_with_prelude(
-        r#"
-        m{}
-        "#,
-        r#"
-        def m
-            i = 0
-            while i<30
-              i += 1
-              yield
-            end
-        end
-        "#,
-    );
-}
-
-#[test]
 fn test_for_each() {
     run_test(
         r#"

--- a/monoruby/tests/yield.rs
+++ b/monoruby/tests/yield.rs
@@ -1,0 +1,83 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn test_yield_in_block() {
+    run_test(
+        "
+        class C
+          def f
+            x = 0
+            7.times { x += yield }
+            x
+          end
+        end
+
+        a = 42
+        c = C.new
+
+        c.f { a }
+        ",
+    );
+    run_test(
+        "
+        class C
+          def f
+            x = 0
+            10.times { x += yield }
+            x
+          end
+        end
+
+        @a = 42
+        c = C.new
+
+        c.f { @a }
+        ",
+    );
+}
+
+#[test]
+fn test_yield_in_loop() {
+    run_test_with_prelude(
+        r#"
+        m{}
+        "#,
+        r#"
+        def m
+            i = 0
+            while i<30
+              i += 1
+              yield
+            end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn test_yield_over_fiber() {
+    run_test_with_prelude(
+        r#"
+        method_with_block { |x| puts x }
+        "#,
+        r#"
+        def method_with_block
+          Fiber.new {
+            [1,2].each { |x| yield x }  # yield が Fiber 境界を越える
+          }.resume
+        end
+        "#,
+    );
+    run_test_with_prelude(
+        r#"
+        foo { puts "hello" }
+        "#,
+        r#"
+        def foo(&blk)
+            Fiber.new { blk.call }
+            .resume
+        end
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary
- `yield` inside a Fiber would panic because `cfp.prev()` returns `None` at the Fiber boundary
- Added `Executor::prev_cfp` which falls back to the parent Fiber's executor, allowing block handler resolution (`get_block`, `from_proxy`, `generate_proc`) to cross Fiber boundaries
- Moved yield-related tests from `arith.rs` into a dedicated `tests/yield.rs`, and added a new `test_yield_over_fiber` test

## Test plan
- [x] `test_yield_over_fiber`: yield across Fiber boundary with `each` and with `&blk`
- [x] Existing `test_yield_in_block` and `test_yield_in_loop` tests moved to `yield.rs`
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)