### PR TITLE
Fix panics caused by non-UTF-8 byte sequences

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1195,7 +1195,7 @@ fn dlopen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 lib
             )));
         }
-        let message = { unsafe { std::ffi::CStr::from_ptr(err).to_str().unwrap().to_string() } };
+        let message = { unsafe { std::ffi::CStr::from_ptr(err).to_string_lossy().into_owned() } };
         let path = match lib {
             Some(lib) => lib.to_string_lossy().to_string(),
             None => "".to_string(),

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -459,7 +459,7 @@ impl Executor {
         let err = self.take_error();
         match err.kind() {
             MonorubyErrKind::Load(path) => {
-                let path = Value::string_from_str(path.as_os_str().to_str().unwrap());
+                let path = Value::string_from_str(&path.as_os_str().to_string_lossy());
                 let v = Value::new_exception(err);
                 globals
                     .store

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -775,7 +775,7 @@ impl Value {
         let s = match self.unpack() {
             RV::Nil => "".to_string(),
             RV::Symbol(id) => id.to_string(),
-            RV::String(s) => s.to_str().unwrap().to_string(),
+            RV::String(s) => String::from_utf8_lossy(s.as_bytes()).into_owned(),
             _ => self.debug(store),
         };
         s
@@ -2037,7 +2037,7 @@ impl<'a> std::fmt::Debug for RV<'a> {
             RV::Float(n) => write!(f, "{}", dtoa::Buffer::new().format(*n),),
             RV::Complex(c) => write!(f, "{:?}", c),
             RV::Symbol(id) => write!(f, ":{}", id),
-            RV::String(s) => write!(f, "\"{}\"", s.to_str().unwrap()),
+            RV::String(s) => write!(f, "\"{}\"", String::from_utf8_lossy(s.as_bytes())),
             RV::Object(rvalue) => write!(f, "{rvalue:?}"),
         }
     }
@@ -2054,7 +2054,7 @@ impl<'a> std::fmt::Display for RV<'a> {
             RV::Float(n) => write!(f, "{}", dtoa::Buffer::new().format(*n),),
             RV::Complex(c) => write!(f, "{}", c),
             RV::Symbol(id) => write!(f, ":{}", id),
-            RV::String(s) => write!(f, "\"{}\"", s.to_str().unwrap()),
+            RV::String(s) => write!(f, "\"{}\"", String::from_utf8_lossy(s.as_bytes())),
             RV::Object(rvalue) => write!(f, "{rvalue:?}"),
         }
     }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -383,7 +383,7 @@ impl std::fmt::Debug for RValue {
                             ObjTy::OBJECT => format!("{:?}", self.kind.object),
                             ObjTy::BIGNUM => format!("{:?}", self.kind.bignum),
                             ObjTy::FLOAT => format!("{:?}", self.kind.float),
-                            ObjTy::STRING => format!("{}", self.kind.string.to_str().unwrap()),
+                            ObjTy::STRING => format!("{}", String::from_utf8_lossy(self.kind.string.as_bytes())),
                             ObjTy::TIME => format!("{:?}", self.kind.time),
                             ObjTy::ARRAY => format!("{:?}", self.kind.array),
                             ObjTy::RANGE => format!("{:?}", self.kind.range),

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -127,22 +127,11 @@ impl RStringInner {
                 }
                 res
             }
-            Encoding::Utf8 => match std::str::from_utf8(self) {
-                Ok(s) => {
-                    let mut res = String::with_capacity(self.len());
-                    for c in s.chars() {
-                        utf8_escape(&mut res, c);
-                    }
-                    res
-                }
-                Err(err) => {
-                    let s = String::from_utf8_lossy(self).to_string();
-                    panic!("invalid byte sequence: {s} {err}");
-                    //Err(MonorubyErr::runtimeerr(format!(
-                    //    "invalid byte sequence: {s}",
-                    //)))
-                }
-            },
+            Encoding::Utf8 => {
+                let mut res = String::with_capacity(self.len());
+                utf8_escape_bytes(&mut res, self.as_bytes(), utf8_escape);
+                res
+            }
         }
     }
 
@@ -155,22 +144,11 @@ impl RStringInner {
                 }
                 res
             }
-            Encoding::Utf8 => match std::str::from_utf8(self) {
-                Ok(s) => {
-                    let mut res = String::with_capacity(self.len());
-                    for c in s.chars() {
-                        utf8_inspect(&mut res, c);
-                    }
-                    res
-                }
-                Err(err) => {
-                    let s = String::from_utf8_lossy(self).to_string();
-                    panic!("invalid byte sequence: {s} {err}");
-                    //Err(MonorubyErr::runtimeerr(format!(
-                    //    "invalid byte sequence: {s}",
-                    //)))
-                }
-            },
+            Encoding::Utf8 => {
+                let mut res = String::with_capacity(self.len());
+                utf8_escape_bytes(&mut res, self.as_bytes(), utf8_inspect);
+                res
+            }
         }
     }
 
@@ -223,6 +201,40 @@ fn ascii_escape(s: &mut String, ch: u8) {
         }
     };
     s.push_str(str);
+}
+
+/// Process a byte slice as UTF-8, applying `escape_fn` to valid characters
+/// and escaping invalid bytes as `\xHH`. This avoids panicking on non-UTF-8
+/// byte sequences in UTF-8 encoded strings.
+fn utf8_escape_bytes(res: &mut String, bytes: &[u8], escape_fn: fn(&mut String, char)) {
+    let mut i = 0;
+    while i < bytes.len() {
+        match std::str::from_utf8(&bytes[i..]) {
+            Ok(valid) => {
+                for c in valid.chars() {
+                    escape_fn(res, c);
+                }
+                break;
+            }
+            Err(err) => {
+                let valid_up_to = err.valid_up_to();
+                // Process valid UTF-8 prefix
+                if valid_up_to > 0 {
+                    // SAFETY: from_utf8 confirmed these bytes are valid UTF-8.
+                    let valid_str = unsafe { std::str::from_utf8_unchecked(&bytes[i..i + valid_up_to]) };
+                    for c in valid_str.chars() {
+                        escape_fn(res, c);
+                    }
+                }
+                // Escape the invalid byte(s)
+                let error_len = err.error_len().unwrap_or(bytes.len() - i - valid_up_to);
+                for b in &bytes[i + valid_up_to..i + valid_up_to + error_len] {
+                    res.push_str(&format!("\\x{:0>2X}", b));
+                }
+                i += valid_up_to + error_len;
+            }
+        }
+    }
 }
 
 impl RStringInner {
@@ -368,21 +380,32 @@ impl RStringInner {
                     index..index + len
                 }
             }
-            Encoding::Utf8 => {
-                let s = self.check_utf8().unwrap();
-                let mut start = 0;
-                let mut end = 0;
-                for (char_i, (byte_i, _)) in s.char_indices().enumerate() {
-                    if char_i == index {
-                        start = byte_i;
-                        end = s.len();
+            Encoding::Utf8 => match std::str::from_utf8(self) {
+                Ok(s) => {
+                    let mut start = 0;
+                    let mut end = 0;
+                    for (char_i, (byte_i, _)) in s.char_indices().enumerate() {
+                        if char_i == index {
+                            start = byte_i;
+                            end = s.len();
+                        }
+                        if char_i == index + len {
+                            end = byte_i;
+                            break;
+                        }
                     }
-                    if char_i == index + len {
-                        end = byte_i;
-                        break;
+                    start..end
+                }
+                Err(_) => {
+                    // Fall back to byte-based indexing for invalid UTF-8
+                    if self.len() <= index {
+                        0..0
+                    } else if self.len() <= index + len {
+                        index..self.len()
+                    } else {
+                        index..index + len
                     }
                 }
-                start..end
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `panic!()` and `unwrap()` calls with graceful handling of invalid UTF-8 in string display, debug, and inspect paths
- Invalid bytes are now escaped as `\xHH` (matching CRuby behavior) instead of panicking
- Affected paths: `RStringInner::dump()/inspect()`, `Value::debug_tos()`, `RV/RValue` Display/Debug impls, `RStringInner::get_range()`, `Executor::take_ex_obj()`, `kernel.rs` dlopen

## Test plan
- [ ] `cargo test` passes
- [ ] Strings containing non-UTF-8 bytes (e.g. `"\xff"`) can be displayed/inspected without panicking
- [ ] Output matches CRuby behavior for escaped byte sequences

https://claude.ai/code/session_017koxPGVjAFpiFYMBCRAkDN