### PR TITLE
Fix panic in Proc#call with yield in detached context

### DIFF
--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -354,4 +354,44 @@ mod tests {
         "#,
         );
     }
+
+    #[test]
+    fn proc_yield_detached_context() {
+        // yield in Proc whose enclosing method was called with a block but has
+        // already returned should raise LocalJumpError, not panic.
+        run_test_error(
+            r#"
+        def make_proc
+          Proc.new { yield }
+        end
+        def get_proc_with_block
+          make_proc { 99 }
+        end
+        get_proc_with_block.call
+        "#,
+        );
+        // yield in Proc whose enclosing method was called without a block
+        run_test_error(
+            r#"
+        def make_proc
+          Proc.new { yield }
+        end
+        make_proc.call
+        "#,
+        );
+    }
+
+    #[test]
+    fn proc_yield_same_context() {
+        // yield in Proc called within the same method context should work
+        run_test(
+            r#"
+        def call_with_block
+          p = Proc.new { yield }
+          p.call
+        end
+        call_with_block { 42 }
+        "#,
+        );
+    }
 }

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -123,31 +123,49 @@ impl Executor {
         let bh = lfp.block()?;
         Some(match bh.0.try_fixnum() {
             Some(mut i) => {
-                i = Self::traverse_cfp(self, cfp, lfp, i);
+                i = Self::traverse_cfp(self, cfp, lfp, i)?;
                 BlockHandler::new(Value::integer(i))
             }
             None => bh,
         })
     }
 
-    // TODO: this does not support nexted fibers.
+    // TODO: this does not support nested fibers.
     pub fn prev_cfp(vm: &Executor, cfp: Cfp) -> (&Executor, Cfp) {
         match cfp.prev() {
             Some(prev) => (vm, prev),
             None => {
+                // SAFETY: parent_fiber is set when a fiber is resumed.
                 let vm = unsafe { vm.parent_fiber.unwrap().as_ref() };
                 (vm, vm.cfp())
             }
         }
     }
 
-    fn traverse_cfp(mut vm: &Executor, mut cfp: Cfp, lfp: Lfp, mut i: i64) -> i64 {
+    /// Try to get the previous CFP, returning `None` if there is no previous
+    /// frame and no parent fiber (i.e. the Proc's enclosing method has already
+    /// returned — "detached context").
+    fn try_prev_cfp(vm: &Executor, cfp: Cfp) -> Option<(&Executor, Cfp)> {
+        match cfp.prev() {
+            Some(prev) => Some((vm, prev)),
+            None => {
+                // SAFETY: parent_fiber is set when a fiber is resumed.
+                let parent = unsafe { vm.parent_fiber?.as_ref() };
+                Some((parent, parent.cfp()))
+            }
+        }
+    }
+
+    /// Traverse the CFP chain to find the target LFP.
+    /// Returns `None` if the CFP chain is exhausted before finding the target
+    /// (detached Proc context — the enclosing method has already returned).
+    fn traverse_cfp(mut vm: &Executor, mut cfp: Cfp, lfp: Lfp, mut i: i64) -> Option<i64> {
         loop {
             if cfp.lfp() == lfp {
-                return i;
+                return Some(i);
             }
             i += 1;
-            (vm, cfp) = Self::prev_cfp(vm, cfp);
+            (vm, cfp) = Self::try_prev_cfp(vm, cfp)?;
         }
     }
 }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -377,7 +377,7 @@ impl MonorubyErr {
     pub(crate) fn no_block_given() -> MonorubyErr {
         MonorubyErr::new(
             MonorubyErrKind::LocalJump,
-            "no block given (yield).".to_string(),
+            "no block given (yield)".to_string(),
         )
     }
 


### PR DESCRIPTION
## Summary

- Fix `unwrap()` panic (abort) in `get_block()` → `traverse_cfp()` → `prev_cfp()` when a Proc containing `yield` is called after its enclosing method has already returned (detached context)
- Introduce `try_prev_cfp()` that returns `Option` instead of panicking when the CFP chain is exhausted and no parent fiber exists
- Make `traverse_cfp()` return `Option<i64>` so `get_block()` safely returns `None` → triggers `LocalJumpError` matching CRuby behavior
- Fix error message: `"no block given (yield)."` → `"no block given (yield)"` (remove trailing period for CRuby compatibility)

### Reproduction

```ruby
def make_proc
  Proc.new { yield }
end
def get_proc_with_block
  make_proc { 99 }
end
get_proc_with_block.call  # => panic: unwrap() on None in prev_cfp
```

**Expected (CRuby):** `LocalJumpError: no block given (yield)`
**Before fix:** `thread panicked at 'called Option::unwrap() on a None value'` → abort
**After fix:** `LocalJumpError: no block given (yield)`

## Test plan

- [x] `proc_yield_detached_context` — yield in Proc from detached context raises `LocalJumpError`
- [x] `proc_yield_same_context` — yield in Proc within same method context still works correctly
- [x] All existing `builtins::proc` tests pass (15/15)

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH