### PR TITLE
Fix String method panics on invalid UTF-8 byte sequences

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -352,10 +352,14 @@ fn casecmp(
 ) -> Result<Value> {
     let lhs = lfp.self_val();
     let rhs = lfp.arg(0);
-    if let Some(rhs_str) = rhs.is_str() {
-        let lhs_lower = lhs.as_str().to_lowercase();
-        let rhs_lower = rhs_str.to_lowercase();
-        Ok(Value::from_ord(lhs_lower.cmp(&rhs_lower)))
+    if let Some(rhs_inner) = rhs.is_rstring_inner() {
+        let lhs_inner = lhs.as_rstring_inner();
+        // ASCII case-insensitive byte comparison (matches CRuby behavior)
+        let ord = lhs_inner
+            .iter()
+            .map(|b| b.to_ascii_lowercase())
+            .cmp(rhs_inner.iter().map(|b| b.to_ascii_lowercase()));
+        Ok(Value::from_ord(ord))
     } else {
         Ok(Value::nil())
     }
@@ -376,8 +380,12 @@ fn casecmp_p(
 ) -> Result<Value> {
     let lhs = lfp.self_val();
     let rhs = lfp.arg(0);
-    if let Some(rhs_str) = rhs.is_str() {
-        let lhs_lower = lhs.as_str().to_lowercase();
+    if let Some(rhs_inner) = rhs.is_rstring_inner() {
+        let lhs_inner = lhs.as_rstring_inner();
+        // CRuby's casecmp? does Unicode case folding; raises on invalid UTF-8
+        let lhs_str = lhs_inner.check_utf8()?;
+        let rhs_str = rhs_inner.check_utf8()?;
+        let lhs_lower = lhs_str.to_lowercase();
         let rhs_lower = rhs_str.to_lowercase();
         Ok(Value::bool(lhs_lower == rhs_lower))
     } else {
@@ -973,7 +981,8 @@ fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         0
     };
     let arg0 = lfp.try_arg(0).unwrap_or(Value::string_from_str(" "));
-    if let Some(sep) = arg0.is_str() {
+    if let Some(sep_inner) = arg0.is_rstring_inner() {
+        let sep = sep_inner.check_utf8()?;
         let v: Vec<Value> = if sep == " " {
             match lim {
                 lim if lim < 0 => {
@@ -1635,6 +1644,16 @@ fn string_index(
     };
 
     let s = given.check_utf8()?;
+    let char_len = s.chars().count();
+    if char_pos == char_len {
+        // At end of string, only empty-width matches are possible
+        return match re.captures("", vm)? {
+            Some(captures) if captures.get(0).unwrap().range().is_empty() => {
+                Ok(Value::integer(char_pos as i64))
+            }
+            _ => Ok(Value::nil()),
+        };
+    }
     let byte_pos = s.char_indices().nth(char_pos).unwrap().0;
     match re.captures_from_pos(s, byte_pos, vm)? {
         None => Ok(Value::nil()),
@@ -1662,17 +1681,19 @@ fn string_rindex(
     let self_ = lfp.self_val();
     let given = self_.is_rstring().unwrap();
     let re = lfp.arg(0).expect_regexp_or_string(globals)?;
-    let max_char_pos = if let Some(arg1) = lfp.try_arg(1) {
-        arg1.coerce_to_i64(globals)?
-    } else {
-        -1
-    };
-    let max_char_pos = match given.conv_char_index2(max_char_pos)? {
-        Some(pos) => pos,
-        None => return Ok(Value::nil()),
-    };
 
     let s = given.check_utf8()?;
+    let char_len = s.chars().count();
+
+    let max_char_pos = if let Some(arg1) = lfp.try_arg(1) {
+        let pos = arg1.coerce_to_i64(globals)?;
+        match given.conv_char_index2(pos)? {
+            Some(pos) => pos,
+            None => return Ok(Value::nil()),
+        }
+    } else {
+        char_len
+    };
 
     let mut last_byte_pos = match re.captures_from_pos(s, 0, vm)? {
         None => {
@@ -1681,7 +1702,6 @@ fn string_rindex(
         Some(captures) => captures.get(0).unwrap().start(),
     };
 
-    // Option<(char_pos:usize, byte_pos:usize)>
     let mut last_char_pos = if last_byte_pos == 0 { Some(0) } else { None };
     for (char_pos, (byte_pos, _)) in s.char_indices().enumerate() {
         if last_byte_pos == byte_pos {
@@ -1712,7 +1732,24 @@ fn string_rindex(
             }
         }
     }
-    Ok(Value::integer(last_char_pos.unwrap() as i64))
+    // Handle match at end of string (e.g. zero-width match past last char_indices entry)
+    // Check if the pattern can match empty at the end of string
+    if char_len <= max_char_pos {
+        if last_byte_pos == s.len() {
+            last_char_pos = Some(char_len);
+        } else if last_byte_pos < s.len() {
+            // Try to find a zero-width match at the end of string
+            if let Ok(Some(captures)) = re.captures("", vm) {
+                if captures.get(0).unwrap().range().is_empty() {
+                    last_char_pos = Some(char_len);
+                }
+            }
+        }
+    }
+    Ok(match last_char_pos {
+        Some(pos) => Value::integer(pos as i64),
+        None => Value::nil(),
+    })
 }
 
 ///
@@ -2370,7 +2407,7 @@ fn to_f(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn to_i(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let s = self_.as_str();
+    let s = self_.expect_str(globals)?;
     let radix = if let Some(arg0) = lfp.try_arg(0) {
         match arg0.expect_integer(globals)? {
             n if !(2..=36).contains(&n) => {
@@ -2576,9 +2613,9 @@ fn to_sym(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/upcase.html]
 #[monoruby_builtin]
-fn upcase(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn upcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let s = self_val.as_str().to_uppercase();
+    let s = self_val.expect_str(globals)?.to_uppercase();
     Ok(Value::string(s))
 }
 
@@ -2589,10 +2626,10 @@ fn upcase(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/upcase=21.html]
 #[monoruby_builtin]
-fn upcase_(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn upcase_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
-    let s = self_val.as_str().to_uppercase();
-    let changed = &s != self_val.as_str();
+    let s = self_val.expect_str(globals)?.to_uppercase();
+    let changed = &s != self_val.expect_str(globals)?;
     self_val.replace_string(s);
 
     Ok(if changed {
@@ -2609,9 +2646,9 @@ fn upcase_(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/downcase.html]
 #[monoruby_builtin]
-fn downcase(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn downcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let s = self_val.as_str().to_lowercase();
+    let s = self_val.expect_str(globals)?.to_lowercase();
     Ok(Value::string(s))
 }
 
@@ -2624,13 +2661,13 @@ fn downcase(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 #[monoruby_builtin]
 fn downcase_(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let mut self_val = lfp.self_val();
-    let s = self_val.as_str().to_lowercase();
-    let changed = &s != self_val.as_str();
+    let s = self_val.expect_str(globals)?.to_lowercase();
+    let changed = &s != self_val.expect_str(globals)?;
     self_val.replace_string(s);
 
     Ok(if changed {
@@ -2649,12 +2686,12 @@ fn downcase_(
 #[monoruby_builtin]
 fn capitalize(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-    let s = self_val.as_str();
+    let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
     let mut first = true;
     for c in s.chars() {
@@ -2681,12 +2718,12 @@ fn capitalize(
 #[monoruby_builtin]
 fn capitalize_(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let mut self_val = lfp.self_val();
-    let s = self_val.as_str();
+    let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
     let mut first = true;
     for c in s.chars() {
@@ -2701,7 +2738,7 @@ fn capitalize_(
             }
         }
     }
-    let changed = &result != self_val.as_str();
+    let changed = &result != self_val.expect_str(globals)?;
     self_val.replace_string(result);
     Ok(if changed {
         lfp.self_val()
@@ -2719,12 +2756,12 @@ fn capitalize_(
 #[monoruby_builtin]
 fn swapcase(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-    let s = self_val.as_str();
+    let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
     for c in s.chars() {
         if c.is_uppercase() {
@@ -2751,12 +2788,12 @@ fn swapcase(
 #[monoruby_builtin]
 fn swapcase_(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let mut self_val = lfp.self_val();
-    let s = self_val.as_str();
+    let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
     for c in s.chars() {
         if c.is_uppercase() {
@@ -2771,7 +2808,7 @@ fn swapcase_(
             result.push(c);
         }
     }
-    let changed = &result != self_val.as_str();
+    let changed = &result != self_val.expect_str(globals)?;
     self_val.replace_string(result);
     Ok(if changed {
         lfp.self_val()
@@ -4537,5 +4574,43 @@ mod tests {
         run_test(r#"s = "hello world"; s.bytesplice(0..4, "ABCDE", 0..-100); s"#);
         // str_range with negative start out of range => RangeError
         run_test_error(r#"s = "hello"; s.bytesplice(0..4, "AB", -100..-1)"#);
+    }
+
+    #[test]
+    fn string_casecmp_invalid_utf8() {
+        run_test(r#""\xc3".casecmp("\xe3")"#);
+        run_test(r#""\xc3".casecmp("\xc3")"#);
+        run_test(r#""a".casecmp("A")"#);
+        run_test(r#""abc".casecmp("ABC")"#);
+    }
+
+    #[test]
+    fn string_casecmp_p_invalid_utf8() {
+        // CRuby's casecmp? raises ArgumentError on invalid UTF-8
+        run_test_error(r#""\xc3".casecmp?("\xc3")"#);
+        run_test_error(r#""\xc3".casecmp?("\xe3")"#);
+        run_test(r#""a".casecmp?("A")"#);
+        run_test(r#""abc".casecmp?("ABC")"#);
+    }
+
+    #[test]
+    fn string_index_at_end() {
+        run_test(r#""blablabla".index("", 9)"#);
+        run_test(r#""blablabla".index("", 10)"#);
+        run_test(r#""abc".index("", 3)"#);
+        run_test(r#""abc".index("", 0)"#);
+    }
+
+    #[test]
+    fn string_rindex_zero_width() {
+        run_test(r#""blablabla".rindex(/.{0}/)"#);
+        run_test(r#""blablabla".rindex(/.*/)"#);
+        run_test(r#""hello".rindex(/.{0}/)"#);
+    }
+
+    #[test]
+    fn string_split_invalid_utf8() {
+        run_test_error(r#""\xDF".force_encoding("UTF-8").split"#);
+        run_test_error(r#""\xDF".force_encoding("UTF-8").split(":")"#);
     }
 }

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -253,9 +253,8 @@ impl RStringInner {
     pub fn check_utf8(&self) -> Result<&str> {
         match std::str::from_utf8(self) {
             Ok(s) => Ok(s),
-            Err(_) => Err(MonorubyErr::runtimeerr(format!(
-                "invalid byte sequence. {:?}",
-                self.to_str()
+            Err(_) => Err(MonorubyErr::argumenterr(format!(
+                "invalid byte sequence in UTF-8"
             ))),
         }
     }


### PR DESCRIPTION
## Summary

- Fix panics (abort) in 11 String methods when operating on strings with invalid UTF-8 bytes (e.g. created via `force_encoding("UTF-8")`)
- All methods now raise `ArgumentError("invalid byte sequence in UTF-8")` matching CRuby behavior
- Fix `casecmp` to use byte-level ASCII comparison (no UTF-8 decoding needed)
- Fix `index`/`rindex` boundary edge cases causing `unwrap()` on `None`
- Change `check_utf8` error from `RuntimeError` to `ArgumentError` for CRuby compatibility

### Affected methods
`casecmp`, `casecmp?`, `index`, `rindex`, `split`, `to_i`, `upcase`/`upcase!`, `downcase`/`downcase!`, `capitalize`/`capitalize!`, `swapcase`/`swapcase!`

### Root cause
These methods called `as_str()` or `is_str()` which internally invoke `check_utf8().unwrap()`, panicking on invalid UTF-8.

## Test plan

- [x] Tests for `casecmp`/`casecmp?` with invalid UTF-8
- [x] Tests for `index` at string end position
- [x] Tests for `rindex` with zero-width patterns
- [x] Tests for `split` with invalid UTF-8
- [x] All results compared against CRuby via `run_test`/`run_test_error`
- [x] 568 existing tests pass (10 pre-existing failures unchanged)

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH