### PR TITLE
Implement Range#min, #max, #count, #minmax to fix endless range hangs

### DIFF
--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -32,6 +32,10 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(RANGE_CLASS, "collect", &["map"], map, 0);
     globals.define_builtin_funcs(RANGE_CLASS, "collect_concat", &["flat_map"], flat_map, 0);
     globals.define_builtin_funcs(RANGE_CLASS, "entries", &["to_a"], toa, 0);
+    globals.define_builtin_func(RANGE_CLASS, "min", min, 0);
+    globals.define_builtin_func(RANGE_CLASS, "max", max, 0);
+    globals.define_builtin_func(RANGE_CLASS, "count", count, 0);
+    globals.define_builtin_func(RANGE_CLASS, "minmax", minmax, 0);
 }
 
 ///
@@ -557,17 +561,315 @@ fn toa(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         && let Some(end) = range.end().is_str()
     {
         let mut start = start.to_string();
+        let end = end.to_string();
         let mut v = vec![];
-        while start != end {
+        while start < end {
             v.push(Value::string_from_str(&start));
             start = builtins::string::str_next(&start);
         }
-        if !range.exclude_end() {
+        if !range.exclude_end() && start == end {
             v.push(Value::string_from_str(&start));
         }
         Ok(Value::array_from_vec(v))
     } else {
         Err(MonorubyErr::runtimeerr("not supported"))
+    }
+}
+
+///
+/// ### Range#min
+///
+/// - min -> object | nil
+/// - min {|a, b| ... } -> object | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Range/i/min.html]
+#[monoruby_builtin]
+fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let range = self_.as_range();
+    let start = range.start();
+    let end = range.end();
+
+    if let Some(bh) = lfp.block() {
+        // With block: raise RangeError for endless ranges, then delegate to iteration
+        if end.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the minimum of endless range",
+            ));
+        }
+        if start.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the minimum of beginless range",
+            ));
+        }
+        // Iterate the range and find min using the block
+        if let Some((s, e)) = range.try_fixnum() {
+            if e <= s {
+                return Ok(Value::nil());
+            }
+            let data = vm.get_block_data(globals, bh)?;
+            let mut min_val = Value::integer(s);
+            for i in (s + 1)..e {
+                let val = Value::integer(i);
+                let cmp = vm.invoke_block(globals, &data, &[val, min_val])?;
+                // CRuby calls < on the block result
+                let is_less = vm
+                    .invoke_method_inner(globals, IdentId::_LT, cmp, &[Value::integer(0)], None, None)?
+                    .as_bool();
+                if is_less {
+                    min_val = val;
+                }
+            }
+            Ok(min_val)
+        } else {
+            Err(MonorubyErr::runtimeerr("not supported"))
+        }
+    } else {
+        // No block
+        if start.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the minimum of beginless range",
+            ));
+        }
+        // Check for empty range
+        if !end.is_nil() {
+            let cmp = vm.compare_values_inner(globals, start, end)?;
+            match cmp {
+                Some(std::cmp::Ordering::Greater) => return Ok(Value::nil()),
+                Some(std::cmp::Ordering::Equal) => {
+                    if range.exclude_end() {
+                        return Ok(Value::nil());
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(start)
+    }
+}
+
+///
+/// ### Range#max
+///
+/// - max -> object | nil
+/// - max {|a, b| ... } -> object | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Range/i/max.html]
+#[monoruby_builtin]
+fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let range = self_.as_range();
+    let start = range.start();
+    let end = range.end();
+
+    if let Some(bh) = lfp.block() {
+        // With block: raise RangeError for endless/beginless ranges, then iterate
+        if end.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the maximum of endless range",
+            ));
+        }
+        if start.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the maximum of beginless range",
+            ));
+        }
+        if let Some((s, e)) = range.try_fixnum() {
+            if e <= s {
+                return Ok(Value::nil());
+            }
+            let data = vm.get_block_data(globals, bh)?;
+            let mut max_val = Value::integer(s);
+            for i in (s + 1)..e {
+                let val = Value::integer(i);
+                let cmp = vm.invoke_block(globals, &data, &[val, max_val])?;
+                // CRuby calls > on the block result
+                let is_greater = vm
+                    .invoke_method_inner(globals, IdentId::_GT, cmp, &[Value::integer(0)], None, None)?
+                    .as_bool();
+                if is_greater {
+                    max_val = val;
+                }
+            }
+            Ok(max_val)
+        } else {
+            Err(MonorubyErr::runtimeerr("not supported"))
+        }
+    } else {
+        // No block
+        if end.is_nil() {
+            return Err(MonorubyErr::rangeerr(
+                "cannot get the maximum of endless range",
+            ));
+        }
+
+        // Check for empty range
+        if !start.is_nil() {
+            let cmp = vm.compare_values_inner(globals, start, end)?;
+            match cmp {
+                Some(std::cmp::Ordering::Greater) => return Ok(Value::nil()),
+                Some(std::cmp::Ordering::Equal) => {
+                    if range.exclude_end() {
+                        return Ok(Value::nil());
+                    }
+                    return Ok(end);
+                }
+                _ => {}
+            }
+        }
+
+        if range.exclude_end() {
+            // For exclusive ranges, need integer end
+            if let Some(i) = end.try_fixnum() {
+                if start.is_nil() {
+                    // beginless exclusive: check if end is integer
+                    return Ok(Value::integer(i - 1));
+                }
+                return Ok(Value::integer(i - 1));
+            } else if let RV::BigInt(b) = end.unpack() {
+                return Ok(Value::bigint(b - 1));
+            } else {
+                return Err(MonorubyErr::typeerr(
+                    "cannot exclude non Integer end value",
+                ));
+            }
+        }
+
+        Ok(end)
+    }
+}
+
+///
+/// ### Range#count
+///
+/// - count -> Integer | Float::INFINITY
+/// - count(item) -> Integer
+/// - count {|item| ... } -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Range/i/count.html]
+#[monoruby_builtin]
+fn count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let range = self_.as_range();
+    let start = range.start();
+    let end = range.end();
+
+    if lfp.block().is_some() {
+        // With block: delegate to Enumerable iteration
+        if let Some((s, e)) = range.try_fixnum() {
+            let bh = lfp.expect_block()?;
+            let data = vm.get_block_data(globals, bh)?;
+            let mut count: i64 = 0;
+            for i in s..e {
+                let val = Value::integer(i);
+                if vm.invoke_block(globals, &data, &[val])?.as_bool() {
+                    count += 1;
+                }
+            }
+            Ok(Value::integer(count))
+        } else {
+            Err(MonorubyErr::runtimeerr("not supported"))
+        }
+    } else {
+        // No block, no args
+        if start.is_nil() || end.is_nil() {
+            return Ok(Value::float(f64::INFINITY));
+        }
+        // For integer ranges, calculate directly
+        if let Some((s, e)) = range.try_fixnum() {
+            let count = if e > s { e - s } else { 0 };
+            Ok(Value::integer(count))
+        } else {
+            // For non-integer finite ranges, fall back to iteration
+            Err(MonorubyErr::runtimeerr("not supported"))
+        }
+    }
+}
+
+///
+/// ### Range#minmax
+///
+/// - minmax -> [object, object]
+/// - minmax {|a, b| ... } -> [object, object]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Range/i/minmax.html]
+#[monoruby_builtin]
+fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let range = self_.as_range();
+    let start = range.start();
+    let end = range.end();
+
+    if start.is_nil() {
+        return Err(MonorubyErr::rangeerr(
+            "cannot get the minimum of beginless range",
+        ));
+    }
+    if end.is_nil() {
+        return Err(MonorubyErr::rangeerr(
+            "cannot get the maximum of endless range",
+        ));
+    }
+
+    if let Some(bh) = lfp.block() {
+        // With block: iterate
+        if let Some((s, e)) = range.try_fixnum() {
+            if e <= s {
+                return Ok(Value::array_from_vec(vec![Value::nil(), Value::nil()]));
+            }
+            let data = vm.get_block_data(globals, bh)?;
+            let mut min_val = Value::integer(s);
+            let mut max_val = Value::integer(s);
+            for i in (s + 1)..e {
+                let val = Value::integer(i);
+                let cmp_min = vm.invoke_block(globals, &data, &[val, min_val])?;
+                let ord = vm.compare_values(globals, cmp_min, Value::integer(0))?;
+                if ord == std::cmp::Ordering::Less {
+                    min_val = val;
+                }
+                let cmp_max = vm.invoke_block(globals, &data, &[val, max_val])?;
+                let ord = vm.compare_values(globals, cmp_max, Value::integer(0))?;
+                if ord == std::cmp::Ordering::Greater {
+                    max_val = val;
+                }
+            }
+            Ok(Value::array_from_vec(vec![min_val, max_val]))
+        } else {
+            Err(MonorubyErr::runtimeerr("not supported"))
+        }
+    } else {
+        // No block: compute min and max directly
+        // Check for empty range
+        let cmp = vm.compare_values_inner(globals, start, end)?;
+        match cmp {
+            Some(std::cmp::Ordering::Greater) => {
+                return Ok(Value::array_from_vec(vec![Value::nil(), Value::nil()]));
+            }
+            Some(std::cmp::Ordering::Equal) => {
+                if range.exclude_end() {
+                    return Ok(Value::array_from_vec(vec![Value::nil(), Value::nil()]));
+                }
+                return Ok(Value::array_from_vec(vec![start, end]));
+            }
+            _ => {}
+        }
+
+        // Get max value
+        let max_val = if range.exclude_end() {
+            if let Some(i) = end.try_fixnum() {
+                Value::integer(i - 1)
+            } else if let RV::BigInt(b) = end.unpack() {
+                Value::bigint(b - 1)
+            } else {
+                return Err(MonorubyErr::typeerr(
+                    "cannot exclude non Integer end value",
+                ));
+            }
+        } else {
+            end
+        };
+
+        Ok(Value::array_from_vec(vec![start, max_val]))
     }
 }
 


### PR DESCRIPTION
## Summary
- Implement `Range#min`, `Range#max`, `Range#count`, and `Range#minmax` methods
- Fix hangs when calling these methods on endless/beginless ranges (raises `RangeError` instead)
- Handle block arguments and edge cases (empty ranges, exclusive end)

## Test plan
- [ ] `cargo test` passes with no new failures
- [ ] Verify `(1..).min` raises `RangeError` instead of hanging
- [ ] Verify `(1..5).min`, `(1..5).max`, `(1..5).count`, `(1..5).minmax` return correct results

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH