### PR TITLE
Make is_str() return None for non-UTF-8 strings instead of panicking

### DIFF
--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1568,15 +1568,23 @@ impl Value {
     pub(crate) fn as_str(&self) -> &str {
         assert_eq!(ObjTy::STRING, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue contains a string.
-        unsafe { self.rvalue().as_str() }
+        // Panics if the string contains invalid UTF-8. Prefer expect_str()
+        // for user-facing code paths.
+        unsafe {
+            self.rvalue()
+                .as_str()
+                .expect("as_str called on non-UTF-8 string")
+        }
     }
 
     pub(crate) fn is_str(&self) -> Option<&str> {
         let rv = self.try_rvalue()?;
         // SAFETY: The type check ensures this RValue contains a string.
+        // Returns None if the value is not a String OR if it contains
+        // invalid UTF-8 byte sequences.
         unsafe {
             match rv.ty() {
-                ObjTy::STRING => Some(rv.as_str()),
+                ObjTy::STRING => rv.as_str(),
                 _ => None,
             }
         }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1449,10 +1449,10 @@ impl RValue {
         unsafe { &mut self.kind.string }
     }
 
-    pub(super) unsafe fn as_str(&self) -> &str {
-        // SAFETY: Caller must ensure this RValue contains a STRING type with valid UTF-8.
-        // Accessing the string union field and calling check_utf8() is valid for STRING types.
-        unsafe { self.kind.string.check_utf8().unwrap() }
+    pub(super) unsafe fn as_str(&self) -> Option<&str> {
+        // SAFETY: Caller must ensure this RValue contains a STRING type.
+        // Returns None if the string contains invalid UTF-8.
+        unsafe { self.kind.string.check_utf8().ok() }
     }
 
     /*pub(crate) fn as_string_mut(&mut self) -> &mut InnerVec {


### PR DESCRIPTION
## Summary
- Change `RValue::as_str()` return type from `&str` to `Option<&str>`, returning `None` for invalid UTF-8 instead of panicking
- Change `Value::is_str()` to propagate `None` for non-UTF-8 strings instead of calling `.unwrap()` which would panic
- Improve `Value::as_str()` panic message to be more descriptive

This is the root cause fix that complements PRs #209-#212. Those PRs added `expect_str()` / error handling at individual call sites, but `is_str()` itself still had an `.unwrap()` that could panic on non-UTF-8 byte sequences (e.g. `"\xFF"` from binary I/O). With this change, any code path using `is_str()` is safe by default.

## Test plan
- [x] `cargo test` — 568 pass, 10 pre-existing failures, no regressions
- [x] No new panics in ruby/spec testing

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH