### PR TITLE
Fix IO.popen close deadlock and stdout broken pipe panic

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -419,6 +419,7 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         cmd
     };
 
+    command.stdin(Stdio::null());
     command.stdout(Stdio::piped());
     command.stderr(Stdio::inherit());
 
@@ -565,6 +566,41 @@ mod tests {
         end
         res
         "##,
+        );
+    }
+
+    #[test]
+    fn popen_close() {
+        // Verify IO.popen + close doesn't deadlock when child writes to stdout.
+        run_test_no_result_check(
+            r#"
+            io = IO.popen("echo hello")
+            s = io.read
+            io.close
+            s
+            "#,
+        );
+    }
+
+    #[test]
+    fn popen_close_without_read() {
+        // Closing without reading should not hang (child gets SIGPIPE).
+        run_test_no_result_check(
+            r#"
+            io = IO.popen("echo hello")
+            io.close
+            "#,
+        );
+    }
+
+    #[test]
+    fn popen_block() {
+        // IO.popen with block should auto-close.
+        run_test_no_result_check(
+            r#"
+            result = IO.popen("echo hello") {|io| io.read }
+            result
+            "#,
         );
     }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -307,10 +307,10 @@ fn puts(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     }
 
     for v in collector {
-        globals.print_value(v);
-        globals.write_stdout(b"\n");
+        globals.print_value(v)?;
+        globals.write_stdout(b"\n")?;
     }
-    globals.flush_stdout();
+    globals.flush_stdout()?;
     Ok(Value::nil())
 }
 
@@ -339,7 +339,7 @@ fn gets(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn print(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     for v in lfp.arg(0).as_array().iter().cloned() {
-        globals.print_value(v);
+        globals.print_value(v)?;
     }
     Ok(Value::nil())
 }
@@ -477,8 +477,8 @@ fn p(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
         buf += &inspected.to_s(&globals.store);
         buf += "\n";
     }
-    globals.write_stdout(buf.as_bytes());
-    globals.flush_stdout();
+    globals.write_stdout(buf.as_bytes())?;
+    globals.flush_stdout()?;
     Ok(match len {
         0 => Value::nil(),
         1 => lfp.arg(0).as_array()[0],

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -272,7 +272,7 @@ impl Globals {
         let mut executor = Executor::init(self, &program_name)?;
         executor.init_stack_limit(self);
         let res = executor.exec_script(self, code, path);
-        self.flush_stdout();
+        let _ = self.flush_stdout();
         #[cfg(any(feature = "profile", feature = "jit-log"))]
         self.show_stats();
         #[cfg(feature = "gc-log")]
@@ -384,22 +384,26 @@ impl Globals {
         })
     }
 
-    pub fn flush_stdout(&mut self) {
-        self.stdout.flush().unwrap();
+    pub fn flush_stdout(&mut self) -> Result<()> {
+        self.stdout
+            .flush()
+            .map_err(|e| MonorubyErr::runtimeerr(format!("flush: {}", e)))
     }
 
-    pub fn write_stdout(&mut self, bytes: &[u8]) {
-        self.stdout.write_all(bytes).unwrap();
+    pub fn write_stdout(&mut self, bytes: &[u8]) -> Result<()> {
+        self.stdout
+            .write_all(bytes)
+            .map_err(|e| MonorubyErr::runtimeerr(format!("write: {}", e)))
     }
 
-    pub fn print_value(&mut self, val: Value) {
+    pub fn print_value(&mut self, val: Value) -> Result<()> {
         if let Some(s) = val.is_rstring() {
             self.stdout.write_all(&s)
         } else {
             let v = val.to_s(&self.store).into_bytes();
             self.stdout.write_all(&v)
         }
-        .unwrap();
+        .map_err(|e| MonorubyErr::runtimeerr(format!("write: {}", e)))
     }
 
     // Handling global variable

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -76,8 +76,13 @@ impl IoInner {
             return Err(MonorubyErr::runtimeerr("closed stream"));
         }
         if let Self::Popen(popen) = self {
-            // Wait for child process to finish before closing.
             let popen = Rc::get_mut(popen).unwrap();
+            // Drop the stdout reader and take child's stdout to close the
+            // pipe's read end. This causes the child to get SIGPIPE when it
+            // writes, preventing a deadlock where the parent waits on the
+            // child while the child blocks on write.
+            popen.reader = None;
+            popen.child.stdout.take();
             let _ = popen.child.wait();
         }
         // Replace self with Closed, dropping the File and letting it close the fd naturally.


### PR DESCRIPTION
## Summary
- **IO.popen deadlock fix**: Set child stdin to `Stdio::null()` and drop stdout reader + `child.stdout.take()` before `wait()` in `IO#close`, so the child gets SIGPIPE instead of blocking on write
- **Stdout broken pipe fix**: Change `write_stdout`/`flush_stdout`/`print_value` to return `Result` instead of panicking on write errors (e.g. broken pipe). Propagate errors in `puts`/`print`/`p` builtins
- Add 3 tests for IO.popen close scenarios

### Root cause
When `IO#close` was called on a popen'd IO, it called `child.wait()` while the child's stdout pipe was still open. If the child was writing to stdout, it would block waiting for the parent to read — but the parent was blocked on `wait()`. Additionally, if the child got a broken pipe, monoruby panicked on the `.unwrap()` in `write_stdout`.

## Test plan
- [x] `cargo test` — 582 pass, 10 pre-existing failures
- [x] `popen_close`, `popen_close_without_read`, `popen_block` tests pass
- [x] `core/io/close_spec.rb` completes without hanging (was HANG before)

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH