### PR TITLE
Implement Thread#initialize with synchronous block execution

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -162,6 +162,45 @@ class Thread
   def self.current
     @@current
   end
+
+  def initialize(*args, &block)
+    @value = nil
+    @exception = nil
+    @alive = true
+    if block
+      begin
+        @value = block.call(*args)
+      rescue Exception => e
+        @exception = e
+      end
+      @alive = false
+    end
+  end
+
+  def value
+    raise @exception if @exception
+    @value
+  end
+
+  def join(limit = nil)
+    raise @exception if @exception
+    self
+  end
+
+  def alive?
+    @alive
+  end
+
+  def status
+    if @exception
+      nil
+    elsif @alive
+      "run"
+    else
+      false
+    end
+  end
+
   def [](key)
     @keys ||= {}
     @keys[key]


### PR DESCRIPTION
## Summary
- Implement `Thread#initialize` to execute the block synchronously (pseudo-threading)
- Store block result in `@value` and exceptions in `@exception`
- Add `Thread#value`, `#join`, `#alive?`, `#status` methods
- Previously, `Thread.new { ... }` completely ignored the block because only `Object#initialize` was called

### Limitation
monoruby does not support true multi-threading. `Thread.new` executes the block synchronously before returning. Tests that rely on concurrent execution (e.g. `Thread.pass until ready` + `sleep`) will still hang.

## Test plan
- [x] `cargo test` — 582 pass, 10 pre-existing failures
- [x] `ruby_exe("Thread.new { exit! 21 }.join; sleep")` patterns in ruby/spec now work correctly

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH