### PR TITLE
Fix implicit type conversions (to_int, to_ary, to_hash, coerce)

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -166,7 +166,7 @@ class Array
         each { |x| yield x }
       end
     else
-      n = n.to_i
+      n = n.to_int
       n.times do
         each { |x| yield x }
       end
@@ -176,7 +176,7 @@ class Array
 
   def combination(n)
     return to_enum(:combination, n) unless block_given?
-    n = n.to_i
+    n = n.to_int
     len = self.size
     if n == 0
       yield []

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -310,6 +310,26 @@ class Numeric
     self < 0 ? -self : self
   end
   alias magnitude abs
+
+  def to_int
+    to_i
+  end
+
+  def ceil(ndigits = 0)
+    to_f.ceil(ndigits)
+  end
+
+  def floor(ndigits = 0)
+    to_f.floor(ndigits)
+  end
+
+  def round(ndigits = 0)
+    to_f.round(ndigits)
+  end
+
+  def truncate(ndigits = 0)
+    to_f.truncate(ndigits)
+  end
 end
 
 class Symbol

--- a/monoruby/builtins/integer.rb
+++ b/monoruby/builtins/integer.rb
@@ -143,14 +143,17 @@ class Integer
   end
 
   def allbits?(mask)
+    mask = mask.to_int
     (self & mask) == mask
   end
 
   def anybits?(mask)
+    mask = mask.to_int
     (self & mask) != 0
   end
 
   def nobits?(mask)
+    mask = mask.to_int
     (self & mask) == 0
   end
 
@@ -161,6 +164,8 @@ class Integer
       [other, self]
     elsif other.is_a?(Float)
       [other, self.to_f]
+    elsif defined?(Rational) && other.is_a?(Rational)
+      [other, Rational(self, 1)]
     elsif other.respond_to?(:to_f)
       [other.to_f, self.to_f]
     else

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -662,15 +662,12 @@ fn unshift(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/concat.html]
 #[monoruby_builtin]
-fn concat(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn concat(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ary = lfp.self_val().as_array();
     let mut ary: Array = Array::new_empty();
     for a in lfp.arg(0).as_array().iter().cloned() {
-        if let Some(a) = a.try_array_ty() {
-            ary.extend_from_slice(&a);
-        } else {
-            return Err(MonorubyErr::no_implicit_conversion(globals, a, ARRAY_CLASS));
-        }
+        let converted = a.coerce_to_array(vm, globals)?;
+        ary.extend_from_slice(&converted);
     }
     self_ary.extend_from_slice(&ary);
     Ok(self_ary.into())
@@ -811,8 +808,16 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 #[monoruby_builtin]
 fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs = lfp.self_val().as_array();
-    let rhs = if let Some(rhs) = lfp.arg(0).try_array_ty() {
+    let arg = lfp.arg(0);
+    let rhs = if let Some(rhs) = arg.try_array_ty() {
         rhs
+    } else if let Some(fid) = globals.check_method(arg, IdentId::TO_ARY) {
+        let v = vm.invoke_func_inner(globals, fid, arg, &[], None, None)?;
+        if let Some(ary) = v.try_array_ty() {
+            ary
+        } else {
+            return Ok(Value::nil());
+        }
     } else {
         return Ok(Value::nil());
     };
@@ -859,7 +864,7 @@ fn index(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/=5b=5d=3d.html]
 #[monoruby_builtin]
 fn index_assign(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -888,14 +893,12 @@ fn index_assign(
                 Ok(val)
             }
         } else {
-            Err(MonorubyErr::runtimeerr(format!(
-                "index {:?} is not supported yet.",
-                i.inspect(&globals.store)
-            )))
+            let idx = i.coerce_to_int(vm, globals)?;
+            ary.set_index(idx, val)
         }
     } else {
-        let mut i = lfp.arg(0).coerce_to_i64(globals)?;
-        let l = lfp.arg(1).coerce_to_i64(globals)?;
+        let mut i = lfp.arg(0).coerce_to_int(vm, globals)?;
+        let l = lfp.arg(1).coerce_to_int(vm, globals)?;
         if l < 0 {
             return Err(MonorubyErr::indexerr(format!("negative length ({})", l)));
         }
@@ -903,7 +906,7 @@ fn index_assign(
             i += ary.len() as i64;
             if i < 0 {
                 return Err(MonorubyErr::index_too_small(
-                    lfp.arg(0).coerce_to_i64(globals)?,
+                    lfp.arg(0).coerce_to_int(vm, globals)?,
                     0,
                 ));
             }
@@ -979,9 +982,9 @@ fn fill(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/drop.html]
 #[monoruby_builtin]
-fn drop(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn drop(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
-    let num = lfp.arg(0).coerce_to_i64(globals)?;
+    let num = lfp.arg(0).coerce_to_int(vm, globals)?;
     if num < 0 {
         return Err(MonorubyErr::argumenterr(format!(
             "Attempt to drop negative size. {}",
@@ -1112,12 +1115,12 @@ fn array_join(store: &Store, ary: Array, sep: &str) -> String {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/first.html]
 #[monoruby_builtin]
-fn first(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn first(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
     if lfp.try_arg(0).is_none() {
         Ok(ary.first().cloned().unwrap_or_default())
     } else {
-        let n = lfp.arg(0).coerce_to_i64(globals)?;
+        let n = lfp.arg(0).coerce_to_int(vm, globals)?;
         if n < 0 {
             return Err(MonorubyErr::argumenterr("must be positive."));
         }
@@ -1167,7 +1170,7 @@ fn last(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn fetch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
-    let index = lfp.arg(0).coerce_to_i64(globals)?;
+    let index = lfp.arg(0).coerce_to_int(vm, globals)?;
     let resolved = ary.get_array_index(index);
     if let Some(idx) = resolved {
         if let Some(val) = ary.get(idx) {
@@ -2169,7 +2172,27 @@ fn pack(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     rvalue::pack(globals, &ary, lfp.arg(0).expect_str(globals)?)
 }
 
+fn try_convert_to_array(
+    v: &Value,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Option<Array> {
+    if let Some(ary) = v.try_array_ty() {
+        return Some(ary);
+    }
+    if let Some(fid) = globals.check_method(*v, IdentId::TO_ARY) {
+        if let Ok(result) = vm.invoke_func_inner(globals, fid, *v, &[], None, None) {
+            if let Some(ary) = result.try_array_ty() {
+                return Some(ary);
+            }
+        }
+    }
+    None
+}
+
 fn flatten_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
     ary: &Array,
     res: &mut Vec<Value>,
     lv: Option<usize>,
@@ -2182,17 +2205,17 @@ fn flatten_inner(
     }
     seen.push(id);
     for v in ary.iter() {
-        if let Some(inner) = v.try_array_ty() {
+        if let Some(inner) = try_convert_to_array(v, vm, globals) {
             if let Some(lv) = lv {
                 if lv == 0 {
                     res.push(*v);
                 } else {
                     *changed = true;
-                    flatten_inner(&inner, res, Some(lv - 1), changed, seen)?;
+                    flatten_inner(vm, globals, &inner, res, Some(lv - 1), changed, seen)?;
                 }
             } else {
                 *changed = true;
-                flatten_inner(&inner, res, None, changed, seen)?;
+                flatten_inner(vm, globals, &inner, res, None, changed, seen)?;
             }
         } else {
             res.push(*v);
@@ -2209,13 +2232,13 @@ fn flatten_inner(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/flatten.html]
 #[monoruby_builtin]
-fn flatten(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn flatten(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
     let lv = if let Some(arg0) = lfp.try_arg(0) {
         if arg0.is_nil() {
             None
         } else {
-            match arg0.expect_integer(globals)? {
+            match arg0.coerce_to_int(vm, globals)? {
                 i if i >= 0 => Some(i as usize),
                 _ => None,
             }
@@ -2226,7 +2249,7 @@ fn flatten(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let mut res = vec![];
     let mut changed = false;
     let mut seen = vec![];
-    flatten_inner(&ary, &mut res, lv, &mut changed, &mut seen)?;
+    flatten_inner(vm, globals, &ary, &mut res, lv, &mut changed, &mut seen)?;
     Ok(Value::array_from_vec(res))
 }
 
@@ -2237,13 +2260,13 @@ fn flatten(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/flatten.html]
 #[monoruby_builtin]
-fn flatten_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn flatten_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut ary = lfp.self_val().as_array();
     let lv = if let Some(arg0) = lfp.try_arg(0) {
         if arg0.is_nil() {
             None
         } else {
-            match arg0.expect_integer(globals)? {
+            match arg0.coerce_to_int(vm, globals)? {
                 i if i >= 0 => Some(i as usize),
                 _ => None,
             }
@@ -2254,7 +2277,7 @@ fn flatten_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let mut res = vec![];
     let mut changed = false;
     let mut seen = vec![];
-    flatten_inner(&ary, &mut res, lv, &mut changed, &mut seen)?;
+    flatten_inner(vm, globals, &ary, &mut res, lv, &mut changed, &mut seen)?;
     ary.replace(res);
     Ok(if changed { ary.into() } else { Value::nil() })
 }
@@ -2325,9 +2348,9 @@ fn delete(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/delete_at.html]
 #[monoruby_builtin]
-fn delete_at(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn delete_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut ary = lfp.self_val().as_array();
-    let pos = lfp.arg(0).coerce_to_i64(globals)?;
+    let pos = lfp.arg(0).coerce_to_int(vm, globals)?;
     let pos = if pos < 0 {
         let pos = pos + ary.len() as i64;
         if pos < 0 {
@@ -2393,13 +2416,13 @@ fn find_index(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/insert.html]
 #[monoruby_builtin]
-fn insert(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn insert(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let val = lfp.arg(1).as_array();
     if val.len() == 0 {
         return Ok(lfp.self_val());
     }
     let mut ary = lfp.self_val().as_array();
-    let nth = lfp.arg(0).expect_integer(globals)?;
+    let nth = lfp.arg(0).coerce_to_int(vm, globals)?;
     let nth = if nth < 0 {
         let nth = nth + ary.len() as i64 + 1;
         if nth < 0 {
@@ -3683,5 +3706,58 @@ mod tests {
         run_test("[1,2,3,4,5].bsearch_index { |x| x >= 3 }");
         run_test("[1,2,3,4,5].bsearch_index { |x| x >= 6 }");
         run_test("[1,3,5,7,9].bsearch_index { |x| x <=> 5 }");
+    }
+
+    #[test]
+    fn implicit_type_conversions() {
+        // to_int conversions
+        run_test_with_prelude(
+            "[1,2,3,4,5].first(n)",
+            "class MyNum; def to_int; 3; end; end\nn = MyNum.new",
+        );
+        run_test_with_prelude(
+            "[1,2,3,4,5].drop(n)",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
+        run_test_with_prelude(
+            "[1,2,3,4,5].fetch(n)",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
+        run_test_with_prelude(
+            "[1,2,3,4,5].delete_at(n)",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
+        run_test_with_prelude(
+            "[[1,[2]],3].flatten(n)",
+            "class MyNum; def to_int; 1; end; end\nn = MyNum.new",
+        );
+        run_test_with_prelude(
+            "a = [1,2,3]; a.insert(n, 99); a",
+            "class MyNum; def to_int; 1; end; end\nn = MyNum.new",
+        );
+        // to_ary conversions
+        run_test_with_prelude(
+            "([1,2,3] <=> obj)",
+            "class MyAry; def to_ary; [1,2,3]; end; end\nobj = MyAry.new",
+        );
+        run_test_with_prelude(
+            "a = [1]; a.concat(obj); a",
+            "class MyAry; def to_ary; [4,5]; end; end\nobj = MyAry.new",
+        );
+        // to_int in []=
+        run_test_with_prelude(
+            "a = [1,2,3,4,5]; a[n] = 99; a",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
+        // cycle with to_int
+        run_test_with_prelude(
+            "res = []; [1,2].cycle(n) { |x| res << x }; res",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
+        // combination with to_int
+        run_test_with_prelude(
+            "res = []; [1,2,3].combination(n) { |c| res << c }; res",
+            "class MyNum; def to_int; 2; end; end\nn = MyNum.new",
+        );
     }
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -154,26 +154,26 @@ fn hash_bracket(
                 Ok(Value::hash_from_inner(inner))
             } else if let Some(ary) = arg.try_array_ty() {
                 // Single array argument: try to convert [[k,v], ...] to hash
-                let mut map = RubyMap::default();
-                for elem in ary.iter() {
-                    if let Some(pair) = elem.try_array_ty() {
-                        if pair.len() == 2 {
-                            map.insert(pair[0], pair[1], vm, globals)?;
-                        } else {
-                            return Err(MonorubyErr::argumenterr(format!(
-                                "invalid number of elements ({} for 1..2)",
-                                pair.len()
-                            )));
-                        }
-                    } else {
-                        return Err(MonorubyErr::argumenterr(
-                            "wrong number of arguments (odd number of arguments for Hash)"
-                                .to_string(),
-                        ));
+                hash_from_array_pairs(ary.iter().copied(), vm, globals)
+            } else {
+                // Try to_hash first
+                let to_hash_id = IdentId::get_id("to_hash");
+                if let Some(result) =
+                    vm.invoke_method_if_exists(globals, to_hash_id, arg, &[], None, None)?
+                {
+                    if result.try_hash_ty().is_some() {
+                        let inner = result.as_hashmap_inner().clone();
+                        return Ok(Value::hash_from_inner(inner));
                     }
                 }
-                Ok(Value::hash(map))
-            } else {
+                // Try to_ary
+                if let Some(result) =
+                    vm.invoke_method_if_exists(globals, IdentId::TO_ARY, arg, &[], None, None)?
+                {
+                    if let Some(ary) = result.try_array_ty() {
+                        return hash_from_array_pairs(ary.iter().copied(), vm, globals);
+                    }
+                }
                 Err(MonorubyErr::argumenterr(
                     "odd number of arguments for Hash".to_string(),
                 ))
@@ -192,6 +192,56 @@ fn hash_bracket(
             Ok(Value::hash(map))
         }
     }
+}
+
+/// Try to use a value as a Hash, calling `to_hash` if it doesn't have hash type.
+fn coerce_to_hash(vm: &mut Executor, globals: &mut Globals, arg: Value) -> Result<Value> {
+    if arg.try_hash_ty().is_some() {
+        return Ok(arg);
+    }
+    let to_hash_id = IdentId::get_id("to_hash");
+    if let Some(result) = vm.invoke_method_if_exists(globals, to_hash_id, arg, &[], None, None)? {
+        if result.try_hash_ty().is_some() {
+            return Ok(result);
+        }
+        return Err(MonorubyErr::typeerr(format!(
+            "can't convert {} to Hash ({}#to_hash gives {})",
+            arg.get_real_class_name(globals),
+            arg.get_real_class_name(globals),
+            result.get_real_class_name(globals),
+        )));
+    }
+    Err(MonorubyErr::no_implicit_conversion(
+        &globals.store,
+        arg,
+        HASH_CLASS,
+    ))
+}
+
+/// Helper to convert an iterator of values (expected to be [k,v] pairs) into a Hash.
+fn hash_from_array_pairs(
+    iter: impl Iterator<Item = Value>,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Result<Value> {
+    let mut map = RubyMap::default();
+    for elem in iter {
+        if let Some(pair) = elem.try_array_ty() {
+            if pair.len() == 2 {
+                map.insert(pair[0], pair[1], vm, globals)?;
+            } else {
+                return Err(MonorubyErr::argumenterr(format!(
+                    "invalid number of elements ({} for 1..2)",
+                    pair.len()
+                )));
+            }
+        } else {
+            return Err(MonorubyErr::argumenterr(
+                "wrong number of arguments (odd number of arguments for Hash)".to_string(),
+            ));
+        }
+    }
+    Ok(Value::hash(map))
 }
 
 ///
@@ -533,16 +583,9 @@ fn clear(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Hash/i/replace.html]
 #[monoruby_builtin]
-fn replace(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
-    let arg = lfp.arg(0);
-    if arg.try_hash_ty().is_none() {
-        return Err(MonorubyErr::no_implicit_conversion(
-            &globals.store,
-            arg,
-            HASH_CLASS,
-        ));
-    }
+    let arg = coerce_to_hash(vm, globals, lfp.arg(0))?;
     let h = self_.as_hashmap_inner_mut();
     *h = arg.as_hashmap_inner().clone();
 
@@ -1024,7 +1067,8 @@ fn merge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     lfp.expect_no_block()?;
     let mut h = lfp.self_val().dup().expect_hash_ty(globals)?;
     for arg in lfp.arg(0).as_array().iter() {
-        let other = arg.expect_hash_ty(globals)?;
+        let other_val = coerce_to_hash(vm, globals, *arg)?;
+        let other = other_val.expect_hash_ty(globals)?;
         for (k, v) in other.iter() {
             h.insert(k, v, vm, globals)?;
         }
@@ -1048,7 +1092,8 @@ fn merge_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     if let Some(block) = lfp.block() {
         let data = vm.get_block_data(globals, block)?;
         for arg in lfp.arg(0).as_array().iter() {
-            let other = arg.expect_hash_ty(globals)?;
+            let other_val = coerce_to_hash(vm, globals, *arg)?;
+            let other = other_val.expect_hash_ty(globals)?;
             for (k, other_v) in other.iter() {
                 if let Some(self_v) = h.get(k, vm, globals)? {
                     let v = vm.invoke_block(globals, &data, &[k, self_v, other_v])?;
@@ -1060,7 +1105,8 @@ fn merge_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         }
     } else {
         for arg in lfp.arg(0).as_array().iter() {
-            let other = arg.expect_hash_ty(globals)?;
+            let other_val = coerce_to_hash(vm, globals, *arg)?;
+            let other = other_val.expect_hash_ty(globals)?;
             for (k, v) in other.iter() {
                 h.insert(k, v, vm, globals)?;
             }

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -131,7 +131,7 @@ fn ne(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Float/i/=3c=3d=3e.html]
 #[monoruby_builtin]
-fn cmp(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs = lfp.self_val();
     let rhs = lfp.arg(0);
     let ord = match (lhs.try_float(), rhs.unpack()) {
@@ -139,7 +139,24 @@ fn cmp(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         (Some(lhs), RV::Fixnum(rhs)) => lhs.partial_cmp(&(rhs as f64)),
         (Some(lhs), RV::BigInt(rhs)) => lhs.partial_cmp(&rhs.to_f64().unwrap()),
         (Some(lhs), RV::Float(rhs)) => lhs.partial_cmp(&rhs),
-        _ => None,
+        _ => {
+            // Try coerce protocol for non-numeric types
+            let coerce_id = IdentId::get_id("coerce");
+            if let Some(result) =
+                vm.invoke_method_if_exists(globals, coerce_id, rhs, &[lhs], None, None)?
+            {
+                if let Some(ary) = result.try_array_ty() {
+                    if ary.len() == 2 {
+                        let cmp_id = IdentId::get_id("<=>");
+                        let res = vm.invoke_method_inner(
+                            globals, cmp_id, ary[0], &[ary[1]], None, None,
+                        )?;
+                        return Ok(res);
+                    }
+                }
+            }
+            None
+        }
     };
     Ok(match ord {
         Some(ord) => Value::from_ord(ord),

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -321,10 +321,10 @@ fn to_i(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 // Bitwise operations.
 
 macro_rules! binop {
-    ($op:ident) => {
+    ($op:ident, $op_str:expr) => {
         paste! {
             #[monoruby_builtin]
-            fn $op(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+            fn $op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
                 let lhs = lfp.self_val();
                 let rhs = lfp.arg(0);
                 match (lhs.unpack(), rhs.unpack()) {
@@ -333,6 +333,17 @@ macro_rules! binop {
                     (RV::BigInt(lhs), RV::Fixnum(rhs)) => Ok(Value::bigint(lhs.$op(BigInt::from(rhs)))),
                     (RV::BigInt(lhs), RV::BigInt(rhs)) => Ok(Value::bigint(lhs.$op(rhs))),
                     _ => {
+                        // Try coerce protocol
+                        let coerce_id = IdentId::get_id("coerce");
+                        if let Some(result) = vm.invoke_method_if_exists(globals, coerce_id, rhs, &[lhs], None, None)? {
+                            if let Some(ary) = result.try_array_ty() {
+                                if ary.len() == 2 {
+                                    let op_id = IdentId::get_id($op_str);
+                                    return vm.invoke_method_inner(globals, op_id, ary[0], &[ary[1]], None, None);
+                                }
+                            }
+                            return Err(MonorubyErr::typeerr("coerce must return [x, y]".to_string()));
+                        }
                         lfp.arg(0).coerce_to_i64(globals)?;
                         unreachable!();
                     }
@@ -340,13 +351,16 @@ macro_rules! binop {
             }
         }
     };
-    ($op1:ident, $($op2:ident),+) => {
-        binop!($op1);
-        binop!($($op2),+);
+    (($op1:ident, $op_str1:expr), $(($op2:ident, $op_str2:expr)),+) => {
+        binop!($op1, $op_str1);
+        binop!($(($op2, $op_str2)),+);
+    };
+    (($op1:ident, $op_str1:expr)) => {
+        binop!($op1, $op_str1);
     };
 }
 
-binop!(bitand, bitor, bitxor);
+binop!((bitand, "&"), (bitor, "|"), (bitxor, "^"));
 
 // Compare operations.
 


### PR DESCRIPTION
## Summary

Fix implicit type conversions to match CRuby behavior. Methods now call `to_int`, `to_ary`, `to_hash`, `coerce` on arguments instead of requiring exact types.

### Changes by class

**Array** (`array.rs`, `array.rb`):
- `first`, `drop`, `fetch`, `delete_at`, `flatten`, `insert`: use `coerce_to_int` (calls `to_int`)
- `<=>`, `concat`: use `coerce_to_array` (calls `to_ary`)
- `cycle`, `combination`: use `to_int` instead of `to_i`

**Hash** (`hash.rs`):
- `merge`, `merge!`, `replace`: try `to_hash` on argument
- `Hash.[]`: try `to_ary` / `to_hash` on single argument

**Integer** (`integer.rb`, `integer.rs`):
- `allbits?`, `anybits?`, `nobits?`: call `to_int` on mask
- `coerce`: handle Rational operands

**Float** (`float.rs`):
- Comparison methods handle `coerce` from other types

**Numeric** (`builtins.rb`):
- Add `to_int` (delegates to `to_i`)
- Add `ceil`, `floor`, `round`, `truncate` (delegate to `to_f`)

## Test plan
- [x] `cargo test` — 634 pass, 10 pre-existing failures
- [x] Array implicit conversion tests (to_int, to_ary)
- [x] Fixes 32+ array spec failures, 10+ hash spec failures, 5+ integer spec failures

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH