### PR TITLE
Fix implicit type conversions: to_int, to_str, to_f across builtins

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -249,11 +249,11 @@ fn system_exit_status(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: By
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/SystemExit/s/new.html]
 #[monoruby_builtin]
-fn system_exit_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn system_exit_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class_id = lfp.self_val().expect_class(globals)?.id();
     let name = class_id.get_name(&globals.store);
     let (status, msg) = if let Some(arg0) = lfp.try_arg(0) {
-        let status = arg0.expect_integer(globals)?;
+        let status = arg0.coerce_to_int(vm, globals)?;
         if let Some(arg1) = lfp.try_arg(1) {
             (status, arg1.expect_string(globals)?)
         } else {

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -141,12 +141,12 @@ fn file_read(
 fn binread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let filename = to_path(vm, globals, lfp.arg(0))?;
     let length = if let Some(arg1) = lfp.try_arg(1) {
-        Some(arg1.coerce_to_i64(globals)?)
+        Some(arg1.coerce_to_int(vm, globals)?)
     } else {
         None
     };
     let offset = if let Some(arg2) = lfp.try_arg(2) {
-        Some(arg2.coerce_to_i64(globals)?)
+        Some(arg2.coerce_to_int(vm, globals)?)
     } else {
         None
     };
@@ -571,9 +571,9 @@ fn resolve_feature_path(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/umask.html]
 #[monoruby_builtin]
-fn umask(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn umask(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     if let Some(arg0) = lfp.try_arg(0) {
-        let mask = arg0.coerce_to_i64(globals)? as u32;
+        let mask = arg0.coerce_to_int(vm, globals)? as u32;
         // SAFETY: umask is a POSIX system call that is safe to call.
         let old = unsafe { libc::umask(mask as libc::mode_t) };
         Ok(Value::integer(old as i64))
@@ -594,7 +594,7 @@ fn umask(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/fnmatch.html]
 #[monoruby_builtin]
 fn fnmatch(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -602,7 +602,7 @@ fn fnmatch(
     let pattern = lfp.arg(0).expect_string(globals)?;
     let path_str = lfp.arg(1).expect_string(globals)?;
     let flags = if let Some(arg2) = lfp.try_arg(2) {
-        arg2.coerce_to_i64(globals)? as u32
+        arg2.coerce_to_int(vm, globals)? as u32
     } else {
         0
     };

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -258,13 +258,13 @@ fn assign_sync(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/read.html
 #[monoruby_builtin]
-fn read(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let length = match lfp.try_arg(0) {
         Some(v) => {
             if v.is_nil() {
                 None
             } else {
-                let length = v.expect_integer(globals)?;
+                let length = v.coerce_to_int(vm, globals)?;
                 if length < 0 {
                     return Err(MonorubyErr::argumenterr("negative length"));
                 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -518,7 +518,7 @@ fn caller(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let mut cfp = vm.cfp();
     let mut v = Vec::new();
     let level = if let Some(arg0) = lfp.try_arg(0) {
-        arg0.coerce_to_i64(globals)? as usize + 1
+        arg0.coerce_to_int(vm, globals)? as usize + 1
     } else {
         2
     };
@@ -599,13 +599,13 @@ fn instance_ty(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/rand.html]
 #[monoruby_builtin]
-fn rand(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let i = if let Some(arg0) = lfp.try_arg(0) {
         if let Some(range) = arg0.is_range() {
             let start = range.start();
             let end = range.end();
-            let start = start.expect_integer(globals)?;
-            let end = end.expect_integer(globals)?;
+            let start = start.coerce_to_int(vm, globals)?;
+            let end = end.coerce_to_int(vm, globals)?;
             if start > end {
                 return Ok(Value::nil());
             }
@@ -613,7 +613,7 @@ fn rand(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 (rand::random::<f64>() * (end - start) as f64 + start as f64) as i64,
             ));
         }
-        arg0.coerce_to_i64(globals)?
+        arg0.coerce_to_int(vm, globals)?
     } else {
         0i64
     };
@@ -1195,7 +1195,7 @@ fn dlopen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     // see: https://github.com/ruby/fiddle/blob/2b3747e919df5d044c835cbbb27ebf9e27df74f9/ext/fiddle/handle.c#L136
     let arg0 = lfp.arg(0);
     let flags = if let Some(arg1) = lfp.try_arg(1) {
-        match i32::try_from(arg1.expect_integer(globals)?) {
+        match i32::try_from(arg1.coerce_to_int(vm, globals)?) {
             Ok(f) => f,
             Err(_) => return Err(MonorubyErr::argumenterr("Illegale flag value.")),
         }

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -89,10 +89,10 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/begin.html]
 #[monoruby_builtin]
-fn match_begin(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn match_begin(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let m = self_.as_match_data();
-    let idx = lfp.arg(0).coerce_to_i64(globals)? as usize;
+    let idx = lfp.arg(0).coerce_to_int(vm, globals)? as usize;
     if idx >= m.len() {
         return Err(MonorubyErr::indexerr(format!(
             "index {idx} out of matches"
@@ -116,10 +116,10 @@ fn match_begin(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/end.html]
 #[monoruby_builtin]
-fn match_end(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn match_end(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let m = self_.as_match_data();
-    let idx = lfp.arg(0).coerce_to_i64(globals)? as usize;
+    let idx = lfp.arg(0).coerce_to_int(vm, globals)? as usize;
     if idx >= m.len() {
         return Err(MonorubyErr::indexerr(format!(
             "index {idx} out of matches"

--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -59,13 +59,27 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_module_func(klass, "frexp", frexp, 1);
 }
 
-/// Convert a Value to f64, raising an error if not numeric.
-fn coerce_to_f64(globals: &mut Globals, v: Value) -> Result<f64> {
+/// Convert a Value to f64, trying `to_f` if the value is not directly numeric.
+fn coerce_to_f64(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<f64> {
     match v.unpack() {
         RV::Float(f) => Ok(f),
         RV::Fixnum(i) => Ok(i as f64),
         RV::BigInt(b) => Ok(b.to_f64().unwrap()),
-        _ => Err(MonorubyErr::cant_convert_into_float(globals, v)),
+        _ => {
+            // Only try to_f for non-String types (CRuby only calls to_f on Numeric subclasses)
+            if v.is_str().is_none()
+                && let Some(fid) = globals.check_method(v, IdentId::TO_F)
+            {
+                let result = vm.invoke_func_inner(globals, fid, v, &[], None, None)?;
+                match result.unpack() {
+                    RV::Float(f) => Ok(f),
+                    RV::Fixnum(i) => Ok(i as f64),
+                    _ => Err(MonorubyErr::cant_convert_into_float(globals, v)),
+                }
+            } else {
+                Err(MonorubyErr::cant_convert_into_float(globals, v))
+            }
+        }
     }
 }
 
@@ -74,8 +88,8 @@ fn coerce_to_f64(globals: &mut Globals, v: Value) -> Result<f64> {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/sqrt.html]
 #[monoruby_builtin]
-fn sqrt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn sqrt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.sqrt()))
 }
 
@@ -84,8 +98,8 @@ fn sqrt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/sin.html]
 #[monoruby_builtin]
-fn sin(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn sin(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.sin()))
 }
 
@@ -94,8 +108,8 @@ fn sin(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/cos.html]
 #[monoruby_builtin]
-fn cos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn cos(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.cos()))
 }
 
@@ -104,8 +118,8 @@ fn cos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/tan.html]
 #[monoruby_builtin]
-fn tan(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn tan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.tan()))
 }
 
@@ -115,15 +129,15 @@ fn tan(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/log.html]
 #[monoruby_builtin]
-fn log(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn log(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f.is_sign_negative() {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"log\"",
         ));
     }
     let result = if let Some(base) = lfp.try_arg(1) {
-        let b = coerce_to_f64(globals, base)?;
+        let b = coerce_to_f64(vm, globals, base)?;
         f.log(b)
     } else {
         f.ln()
@@ -136,8 +150,8 @@ fn log(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/log2.html]
 #[monoruby_builtin]
-fn log2(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn log2(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f.is_sign_negative() {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"log2\"",
@@ -151,8 +165,8 @@ fn log2(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/log10.html]
 #[monoruby_builtin]
-fn log10(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn log10(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f.is_sign_negative() {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - log10",
@@ -166,8 +180,8 @@ fn log10(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/exp.html]
 #[monoruby_builtin]
-fn exp(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn exp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.exp()))
 }
 
@@ -176,8 +190,8 @@ fn exp(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/asin.html]
 #[monoruby_builtin]
-fn asin(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn asin(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f < -1.0 || f > 1.0 {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"asin\"",
@@ -191,8 +205,8 @@ fn asin(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/acos.html]
 #[monoruby_builtin]
-fn acos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn acos(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f < -1.0 || f > 1.0 {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"acos\"",
@@ -206,8 +220,8 @@ fn acos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/atan.html]
 #[monoruby_builtin]
-fn atan(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn atan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.atan()))
 }
 
@@ -216,9 +230,9 @@ fn atan(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/atan2.html]
 #[monoruby_builtin]
-fn atan2(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let y = coerce_to_f64(globals, lfp.arg(0))?;
-    let x = coerce_to_f64(globals, lfp.arg(1))?;
+fn atan2(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let y = coerce_to_f64(vm, globals, lfp.arg(0))?;
+    let x = coerce_to_f64(vm, globals, lfp.arg(1))?;
     Ok(Value::float(y.atan2(x)))
 }
 
@@ -227,8 +241,8 @@ fn atan2(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/sinh.html]
 #[monoruby_builtin]
-fn sinh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn sinh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.sinh()))
 }
 
@@ -237,8 +251,8 @@ fn sinh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/cosh.html]
 #[monoruby_builtin]
-fn cosh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn cosh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.cosh()))
 }
 
@@ -247,8 +261,8 @@ fn cosh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/tanh.html]
 #[monoruby_builtin]
-fn tanh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn tanh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.tanh()))
 }
 
@@ -257,8 +271,8 @@ fn tanh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/asinh.html]
 #[monoruby_builtin]
-fn asinh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn asinh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.asinh()))
 }
 
@@ -267,8 +281,8 @@ fn asinh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/acosh.html]
 #[monoruby_builtin]
-fn acosh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn acosh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f < 1.0 {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"acosh\"",
@@ -282,8 +296,8 @@ fn acosh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/atanh.html]
 #[monoruby_builtin]
-fn atanh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn atanh(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f <= -1.0 || f >= 1.0 {
         if f == -1.0 || f == 1.0 {
             // Returns -Infinity or Infinity
@@ -303,8 +317,8 @@ fn atanh(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/erf.html]
 #[monoruby_builtin]
-fn erf(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn erf(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     // SAFETY: erf is a standard C math function with no safety concerns.
     Ok(Value::float(unsafe { c_erf(f) }))
 }
@@ -314,8 +328,8 @@ fn erf(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/erfc.html]
 #[monoruby_builtin]
-fn erfc(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn erfc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     // SAFETY: erfc is a standard C math function with no safety concerns.
     Ok(Value::float(unsafe { c_erfc(f) }))
 }
@@ -325,8 +339,8 @@ fn erfc(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/gamma.html]
 #[monoruby_builtin]
-fn gamma(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn gamma(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     if f < 0.0 && f == f.floor() {
         return Err(MonorubyErr::rangeerr(
             "Numerical argument is out of domain - \"tgamma\"",
@@ -341,8 +355,8 @@ fn gamma(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/lgamma.html]
 #[monoruby_builtin]
-fn lgamma(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn lgamma(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     // SAFETY: lgamma_r is a standard C math function; sign is a valid pointer to a local variable.
     let mut sign: c_int = 0;
     let result = unsafe { c_lgamma_r(f, &mut sign) };
@@ -357,8 +371,8 @@ fn lgamma(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/cbrt.html]
 #[monoruby_builtin]
-fn cbrt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn cbrt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     Ok(Value::float(f.cbrt()))
 }
 
@@ -367,9 +381,9 @@ fn cbrt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/hypot.html]
 #[monoruby_builtin]
-fn hypot(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let x = coerce_to_f64(globals, lfp.arg(0))?;
-    let y = coerce_to_f64(globals, lfp.arg(1))?;
+fn hypot(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let x = coerce_to_f64(vm, globals, lfp.arg(0))?;
+    let y = coerce_to_f64(vm, globals, lfp.arg(1))?;
     Ok(Value::float(x.hypot(y)))
 }
 
@@ -378,8 +392,8 @@ fn hypot(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/ldexp.html]
 #[monoruby_builtin]
-fn ldexp(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let x = coerce_to_f64(globals, lfp.arg(0))?;
+fn ldexp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let x = coerce_to_f64(vm, globals, lfp.arg(0))?;
     let exp = match lfp.arg(1).unpack() {
         RV::Fixnum(i) => i as i32,
         RV::Float(f) => f as i32,
@@ -397,8 +411,8 @@ fn ldexp(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Math/m/frexp.html]
 #[monoruby_builtin]
-fn frexp(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let f = coerce_to_f64(globals, lfp.arg(0))?;
+fn frexp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let f = coerce_to_f64(vm, globals, lfp.arg(0))?;
     // SAFETY: frexp is a standard C math function; exp_val is a valid pointer to a local variable.
     let mut exp_val: c_int = 0;
     let frac = unsafe { c_frexp(f, &mut exp_val) };
@@ -534,6 +548,40 @@ mod tests {
         end
         C.new.f
         "#,
+        );
+    }
+
+    #[test]
+    fn implicit_to_f() {
+        run_test(
+            r#"
+            class MyNum < Numeric
+              def to_f
+                2.0
+              end
+            end
+            Math.sqrt(MyNum.new)
+            "#,
+        );
+        run_test(
+            r#"
+            class MyNum2 < Numeric
+              def to_f
+                1.0
+              end
+            end
+            Math.sin(MyNum2.new)
+            "#,
+        );
+        run_test(
+            r#"
+            class MyNum3 < Numeric
+              def to_f
+                0.5
+              end
+            end
+            Math.cos(MyNum3.new)
+            "#,
         );
     }
 }

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -149,7 +149,7 @@ fn process_exit_bang(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Process/m/clock_gettime.html]
 #[monoruby_builtin]
-fn clock_gettime(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn clock_gettime(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let unit = if let Some(arg1) = lfp.try_arg(1) {
         match arg1.try_symbol() {
             Some(id) => id,
@@ -164,7 +164,7 @@ fn clock_gettime(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         IdentId::FLOAT_SECOND
     };
     let mut tp = TimeSpec::default();
-    let clk_id = lfp.arg(0).coerce_to_i64(globals)? as i32;
+    let clk_id = lfp.arg(0).coerce_to_int(vm, globals)? as i32;
     if let Err(errno) = clock_gettime::clock_gettime(clk_id, &mut tp) {
         return Err(MonorubyErr::runtimeerr(format!(
             "clock_gettime failed: errno {}",

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -56,9 +56,9 @@ fn allocate(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/compile.html]
 #[monoruby_builtin]
-fn regexp_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let arg0 = lfp.arg(0);
-    let string = arg0.expect_string(globals)?;
+    let string = arg0.coerce_to_string(vm, globals)?;
     let option = if let Some(option) = lfp.try_arg(1) {
         if let Some(option) = option.try_fixnum() {
             option as i32 as u32
@@ -89,10 +89,10 @@ fn regexp_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/escape.html]
 #[monoruby_builtin]
-fn regexp_escape(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn regexp_escape(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let arg0 = lfp.arg(0);
-    let string = arg0.expect_str(globals)?;
-    let val = Value::string(RegexpInner::escape(string));
+    let string = arg0.coerce_to_str(vm, globals)?;
+    let val = Value::string(RegexpInner::escape(&string));
     Ok(val)
 }
 
@@ -137,7 +137,7 @@ fn regexp_union(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
 #[monoruby_builtin]
 fn regexp_last_match(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     if let Some(arg0) = lfp.try_arg(0) {
-        let nth = arg0.coerce_to_i64(globals)?;
+        let nth = arg0.coerce_to_int(vm, globals)?;
         Ok(vm.get_special_matches(nth))
     } else {
         Ok(vm.get_last_matchdata())
@@ -236,7 +236,7 @@ fn match_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let given_val = lfp.arg(0);
     let given = given_val.expect_str(globals)?;
     let char_pos = if let Some(pos) = lfp.try_arg(1) {
-        match conv_index(pos.expect_integer(globals)?, given.chars().count()) {
+        match conv_index(pos.coerce_to_int(vm, globals)?, given.chars().count()) {
             Some(pos) => pos,
             None => return Ok(Value::bool(false)),
         }
@@ -265,7 +265,7 @@ fn rmatch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let heystack_val = lfp.arg(0);
     let heystack = heystack_val.expect_str(globals)?;
     let char_pos = if let Some(pos) = lfp.try_arg(1) {
-        match conv_index(pos.expect_integer(globals)?, heystack.chars().count()) {
+        match conv_index(pos.coerce_to_int(vm, globals)?, heystack.chars().count()) {
             Some(pos) => pos,
             None => return Ok(Value::bool(false)),
         }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -282,8 +282,8 @@ fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=2a.html]
 #[monoruby_builtin]
-fn mul(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let count = match lfp.arg(0).coerce_to_i64(globals)? {
+fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let count = match lfp.arg(0).coerce_to_int(vm, globals)? {
         i if i < 0 => return Err(MonorubyErr::negative_argument()),
         i => i as usize,
     };
@@ -597,7 +597,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             None => return Ok(Value::nil()),
         };
         if let Some(arg1) = lfp.try_arg(1) {
-            let len = match arg1.coerce_to_i64(globals)? {
+            let len = match arg1.coerce_to_int(vm, globals)? {
                 0 => return Ok(Value::string_from_str("")),
                 i if i < 0 => return Ok(Value::nil()),
                 i => i as usize,
@@ -618,8 +618,8 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         }
     } else if let Some(info) = lfp.arg(0).is_range() {
         let (start, end) = (
-            info.start().expect_integer(globals)?,
-            info.end().expect_integer(globals)? - info.exclude_end() as i64,
+            info.start().coerce_to_int(vm, globals)?,
+            info.end().coerce_to_int(vm, globals)? - info.exclude_end() as i64,
         );
         let (start, len) = match (lhs.conv_char_index(start)?, lhs.conv_char_index(end)?) {
             (Some(start), Some(end)) => {
@@ -637,7 +637,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         )))
     } else if let Some(re) = lfp.arg(0).is_regex() {
         let nth = if let Some(i) = lfp.try_arg(1) {
-            i.coerce_to_i64(globals)?
+            i.coerce_to_int(vm, globals)?
         } else {
             0
         };
@@ -688,7 +688,7 @@ fn string_match_index(
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=5b=5d=3d.html]
 #[monoruby_builtin]
 fn index_assign(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -712,7 +712,7 @@ fn index_assign(
         };
         let len = if let Some(arg1) = arg1 {
             // self[nth, len] = val
-            match arg1.expect_integer(globals)? {
+            match arg1.coerce_to_int(vm, globals)? {
                 i if i < 0 => return Err(MonorubyErr::indexerr("negative length.")),
                 i => i as usize,
             }
@@ -886,7 +886,7 @@ pub fn str_next(self_: &str) -> String {
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/start_with=3f.html]
 #[monoruby_builtin]
 fn start_with(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -894,8 +894,9 @@ fn start_with(
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
     let arg0 = lfp.arg(0).as_array();
-    for a in arg0.iter().map(|v| v.expect_str(globals)) {
-        if string.starts_with(a?) {
+    for v in arg0.iter() {
+        let a = v.coerce_to_str(vm, globals)?;
+        if string.starts_with(a.as_str()) {
             return Ok(Value::bool(true));
         }
     }
@@ -909,11 +910,11 @@ fn start_with(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/include=3f.html]
 #[monoruby_builtin]
-fn include_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn include_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
-    let substr = lfp.arg(0);
-    let b = string.contains(substr.expect_str(globals)?);
+    let substr_s = lfp.arg(0).coerce_to_str(vm, globals)?;
+    let b = string.contains(substr_s.as_str());
     Ok(Value::bool(b))
 }
 
@@ -925,16 +926,15 @@ fn include_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/delete_prefix=21.html]
 #[monoruby_builtin]
 fn delete_prefix_(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
-    let arg0 = lfp.arg(0);
-    let arg = arg0.expect_str(globals)?;
-    if let Some(stripped) = string.strip_prefix(arg) {
+    let arg = lfp.arg(0).coerce_to_str(vm, globals)?;
+    if let Some(stripped) = string.strip_prefix(arg.as_str()) {
         lfp.self_val().replace_str(stripped);
         Ok(lfp.self_val())
     } else {
@@ -950,16 +950,15 @@ fn delete_prefix_(
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/delete_prefix.html]
 #[monoruby_builtin]
 fn delete_prefix(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
-    let arg0 = lfp.arg(0);
-    let arg = arg0.expect_str(globals)?;
-    if let Some(stripped) = string.strip_prefix(arg) {
+    let arg = lfp.arg(0).coerce_to_str(vm, globals)?;
+    if let Some(stripped) = string.strip_prefix(arg.as_str()) {
         Ok(Value::string_from_str(stripped))
     } else {
         Ok(Value::string_from_str(string))
@@ -973,12 +972,13 @@ fn delete_prefix(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/end_with=3f.html]
 #[monoruby_builtin]
-fn end_with(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn end_with(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
     let arg0 = lfp.arg(0).as_array();
-    for a in arg0.iter().map(|v| v.expect_str(globals)) {
-        if string.ends_with(a?) {
+    for v in arg0.iter() {
+        let a = v.coerce_to_str(vm, globals)?;
+        if string.ends_with(a.as_str()) {
             return Ok(Value::bool(true));
         }
     }
@@ -999,7 +999,7 @@ fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
     let lim = if let Some(arg1) = lfp.try_arg(1) {
-        arg1.coerce_to_i64(globals)?
+        arg1.coerce_to_int(vm, globals)?
     } else {
         0
     };
@@ -1153,7 +1153,7 @@ fn slice_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
             None => return Ok(Value::nil()),
         };
         if let Some(arg1) = lfp.try_arg(1) {
-            let len = match arg1.coerce_to_i64(globals)? {
+            let len = match arg1.coerce_to_int(vm, globals)? {
                 i if i < 0 => return Ok(Value::nil()),
                 i => i as usize,
             };
@@ -1170,8 +1170,8 @@ fn slice_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     } else if let Some(info) = lfp.arg(0).is_range() {
         let len = lhs.chars().count();
         let (start, end) = (
-            info.start().expect_integer(globals)?,
-            info.end().expect_integer(globals)? - info.exclude_end() as i64,
+            info.start().coerce_to_int(vm, globals)?,
+            info.end().coerce_to_int(vm, globals)? - info.exclude_end() as i64,
         );
         let (start, len) = match (
             conv_index(start, len),
@@ -1198,7 +1198,7 @@ fn slice_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         let nth = if lfp.try_arg(1).is_none() {
             0
         } else {
-            lfp.arg(1).coerce_to_i64(globals)?
+            lfp.arg(1).coerce_to_int(vm, globals)?
         };
         match info.captures(&lhs, vm)? {
             None => Ok(Value::nil()),
@@ -1439,8 +1439,8 @@ fn sub_main(
             eprintln!("warning: default value argument supersedes block");
         }
         let given = self_val.expect_str(globals)?;
-        let replace = arg1.expect_str(globals)?;
-        RegexpInner::replace_one(vm, lfp.arg(0), given, replace)
+        let replace = arg1.coerce_to_str(vm, globals)?;
+        RegexpInner::replace_one(vm, lfp.arg(0), given, &replace)
     } else {
         match lfp.block() {
             None => Err(MonorubyErr::runtimeerr("Currently, not supported.")),
@@ -1494,8 +1494,8 @@ fn gsub_main(
             eprintln!("warning: default value argument supersedes block");
         }
         let given = self_val.expect_str(globals)?;
-        let replace = arg1.expect_str(globals)?;
-        RegexpInner::replace_all(vm, lfp.arg(0), given, replace)
+        let replace = arg1.coerce_to_str(vm, globals)?;
+        RegexpInner::replace_all(vm, lfp.arg(0), given, &replace)
     } else {
         match lfp.block() {
             None => Err(MonorubyErr::runtimeerr("Currently, not supported.")),
@@ -1596,7 +1596,7 @@ fn string_match(
     _: BytecodePtr,
 ) -> Result<Value> {
     let pos = if let Some(arg1) = lfp.try_arg(1) {
-        match arg1.coerce_to_i64(globals)? {
+        match arg1.coerce_to_int(vm, globals)? {
             pos if pos >= 0 => pos as usize,
             _ => return Ok(Value::nil()),
         }
@@ -1624,7 +1624,7 @@ fn string_match_(
     _: BytecodePtr,
 ) -> Result<Value> {
     let pos = if let Some(arg1) = lfp.try_arg(1) {
-        match arg1.coerce_to_i64(globals)? {
+        match arg1.coerce_to_int(vm, globals)? {
             pos if pos >= 0 => pos as usize,
             _ => return Ok(Value::nil()),
         }
@@ -1653,7 +1653,7 @@ fn string_index(
     _: BytecodePtr,
 ) -> Result<Value> {
     let char_pos = if let Some(arg1) = lfp.try_arg(1) {
-        arg1.coerce_to_i64(globals)?
+        arg1.coerce_to_int(vm, globals)?
     } else {
         0
     };
@@ -1709,7 +1709,7 @@ fn string_rindex(
     let char_len = s.chars().count();
 
     let max_char_pos = if let Some(arg1) = lfp.try_arg(1) {
-        let pos = arg1.coerce_to_i64(globals)?;
+        let pos = arg1.coerce_to_int(vm, globals)?;
         match given.conv_char_index2(pos)? {
             Some(pos) => pos,
             None => return Ok(Value::nil()),
@@ -1866,7 +1866,7 @@ fn gen_pad(padding: &str, len: usize) -> String {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/ljust.html]
 #[monoruby_builtin]
-fn ljust(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn ljust(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let arg1 = lfp.try_arg(1);
     let padding = if let Some(arg1) = &arg1 {
         arg1.expect_str(globals)?
@@ -1878,7 +1878,7 @@ fn ljust(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     };
     let self_ = lfp.self_val();
     let lhs = self_.as_str();
-    let width = lfp.arg(0).coerce_to_i64(globals)?;
+    let width = lfp.arg(0).coerce_to_int(vm, globals)?;
     let str_len = lhs.chars().count();
     if width <= 0 || width as usize <= str_len {
         return Ok(Value::string(lhs.to_string()));
@@ -1894,7 +1894,7 @@ fn ljust(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/rjust.html]
 #[monoruby_builtin]
-fn rjust(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn rjust(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let arg1 = lfp.try_arg(1);
     let padding = if let Some(arg1) = &arg1 {
         arg1.expect_str(globals)?
@@ -1906,7 +1906,7 @@ fn rjust(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     };
     let self_ = lfp.self_val();
     let lhs = self_.as_str();
-    let width = lfp.arg(0).coerce_to_i64(globals)?;
+    let width = lfp.arg(0).coerce_to_int(vm, globals)?;
     let str_len = lhs.chars().count();
     if width <= 0 || width as usize <= str_len {
         return Ok(Value::string(lhs.to_string()));
@@ -1962,11 +1962,11 @@ fn bytes(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/getbyte.html]
 #[monoruby_builtin]
-fn getbyte(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn getbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
     let s = receiver.as_rstring_inner();
     let len = s.len() as i64;
-    let mut idx = lfp.arg(0).expect_integer(globals)?;
+    let mut idx = lfp.arg(0).coerce_to_int(vm, globals)?;
     if idx < 0 {
         idx += len;
     }
@@ -1984,19 +1984,19 @@ fn getbyte(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/setbyte.html]
 #[monoruby_builtin]
-fn setbyte(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn setbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
-    let byte_val = lfp.arg(1).expect_integer(globals)?;
+    let byte_val = lfp.arg(1).coerce_to_int(vm, globals)?;
     let s = self_.as_rstring_inner();
     let len = s.len() as i64;
-    let mut idx = lfp.arg(0).expect_integer(globals)?;
+    let mut idx = lfp.arg(0).coerce_to_int(vm, globals)?;
     if idx < 0 {
         idx += len;
     }
     if idx < 0 || idx >= len {
         return Err(MonorubyErr::indexerr(format!(
             "index {} out of string",
-            lfp.arg(0).expect_integer(globals)?
+            lfp.arg(0).coerce_to_int(vm, globals)?
         )));
     }
     self_
@@ -2014,7 +2014,7 @@ fn setbyte(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/byteslice.html]
 #[monoruby_builtin]
-fn byteslice(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn byteslice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let s = self_.as_rstring_inner();
     let byte_len = s.len();
@@ -2034,8 +2034,8 @@ fn byteslice(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     };
 
     if let Some(range) = lfp.arg(0).is_range() {
-        let start = range.start().expect_integer(globals)?;
-        let end = range.end().expect_integer(globals)?;
+        let start = range.start().coerce_to_int(vm, globals)?;
+        let end = range.end().coerce_to_int(vm, globals)?;
         let start = match {
             if start >= 0 {
                 if (start as usize) <= byte_len {
@@ -2081,10 +2081,10 @@ fn byteslice(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             enc,
         )))
     } else {
-        let i = lfp.arg(0).expect_integer(globals)?;
+        let i = lfp.arg(0).coerce_to_int(vm, globals)?;
         if let Some(arg1) = lfp.try_arg(1) {
             // byteslice(nth, len)
-            let len = arg1.coerce_to_i64(globals)?;
+            let len = arg1.coerce_to_int(vm, globals)?;
             if len < 0 {
                 return Ok(Value::nil());
             }
@@ -2132,7 +2132,7 @@ fn byteslice(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/bytesplice.html]
 #[monoruby_builtin]
 fn bytesplice(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -2158,8 +2158,8 @@ fn bytesplice(
 
     // Parse target range (index, length) from the first args
     let (start, splice_len) = if let Some(range) = lfp.arg(0).is_range() {
-        let rstart = range.start().expect_integer(globals)?;
-        let rend = range.end().expect_integer(globals)?;
+        let rstart = range.start().coerce_to_int(vm, globals)?;
+        let rend = range.end().coerce_to_int(vm, globals)?;
         let start = conv_byte_index_for_splice(rstart, byte_len)?;
         let end = if rend >= 0 {
             let e = if range.exclude_end() {
@@ -2191,8 +2191,8 @@ fn bytesplice(
                 "wrong argument type Integer (expected Range)",
             ));
         }
-        let idx = lfp.arg(0).expect_integer(globals)?;
-        let len = lfp.arg(1).expect_integer(globals)?;
+        let idx = lfp.arg(0).coerce_to_int(vm, globals)?;
+        let len = lfp.arg(1).coerce_to_int(vm, globals)?;
         if len < 0 {
             return Err(MonorubyErr::indexerr(format!("negative length {}", len)));
         }
@@ -2222,8 +2222,8 @@ fn bytesplice(
             let src_range = src_range.is_range().ok_or_else(|| {
                 MonorubyErr::typeerr("wrong argument type Integer (expected Range)")
             })?;
-            let src_start = src_range.start().expect_integer(globals)?;
-            let src_end = src_range.end().expect_integer(globals)?;
+            let src_start = src_range.start().coerce_to_int(vm, globals)?;
+            let src_end = src_range.end().coerce_to_int(vm, globals)?;
             let src_start = conv_byte_index_for_splice(src_start, str_byte_len)?;
             let src_end_val = if src_end >= 0 {
                 let e = if src_range.exclude_end() {
@@ -2252,8 +2252,8 @@ fn bytesplice(
             }
         } else {
             // bytesplice(idx, len, str, str_idx, str_len)
-            let src_idx = lfp.arg(str_arg_idx + 1).expect_integer(globals)?;
-            let src_len = lfp.arg(str_arg_idx + 2).expect_integer(globals)?;
+            let src_idx = lfp.arg(str_arg_idx + 1).coerce_to_int(vm, globals)?;
+            let src_len = lfp.arg(str_arg_idx + 2).coerce_to_int(vm, globals)?;
             if src_len < 0 {
                 return Err(MonorubyErr::indexerr(format!(
                     "negative length {}",
@@ -2428,11 +2428,11 @@ fn to_f(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/to_i.html]
 #[monoruby_builtin]
-fn to_i(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn to_i(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let s = self_.expect_str(globals)?;
     let radix = if let Some(arg0) = lfp.try_arg(0) {
-        match arg0.expect_integer(globals)? {
+        match arg0.coerce_to_int(vm, globals)? {
             n if !(2..=36).contains(&n) => {
                 return Err(MonorubyErr::argumenterr(format!("invalid radix {n}")));
             }
@@ -3070,9 +3070,9 @@ fn count(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/sum.html]
 #[monoruby_builtin]
-fn sum(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let bits = if let Some(arg0) = lfp.try_arg(0) {
-        arg0.coerce_to_i64(globals)?
+        arg0.coerce_to_int(vm, globals)?
     } else {
         16
     };
@@ -3144,7 +3144,7 @@ fn each_char(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/center.html]
 #[monoruby_builtin]
-fn center(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn center(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let arg1 = lfp.try_arg(1);
     let padding = if let Some(arg) = &arg1 {
         arg.expect_str(globals)?
@@ -3155,7 +3155,7 @@ fn center(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         return Err(MonorubyErr::argumenterr("Zero width padding."));
     };
     let lhs = lfp.self_val();
-    let width = lfp.arg(0).coerce_to_i64(globals)?;
+    let width = lfp.arg(0).coerce_to_int(vm, globals)?;
     let str_len = lhs.as_str().chars().count();
     if width <= 0 || width as usize <= str_len {
         return Ok(lhs.dup());
@@ -3229,9 +3229,9 @@ fn b(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Valu
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/unpack.html]
 #[monoruby_builtin]
-fn unpack(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn unpack(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let offset = unpack_offset(globals, lfp, self_.as_rstring_inner().len())?;
+    let offset = unpack_offset(vm, globals, lfp, self_.as_rstring_inner().len())?;
     rvalue::unpack(
         &self_.as_rstring_inner()[offset..],
         lfp.arg(0).expect_str(globals)?,
@@ -3247,9 +3247,9 @@ fn unpack(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/unpack1.html]
 #[monoruby_builtin]
-fn unpack1(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn unpack1(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let offset = unpack_offset(globals, lfp, self_.as_rstring_inner().len())?;
+    let offset = unpack_offset(vm, globals, lfp, self_.as_rstring_inner().len())?;
     rvalue::unpack(
         &self_.as_rstring_inner()[offset..],
         lfp.arg(0).expect_str(globals)?,
@@ -3257,10 +3257,10 @@ fn unpack1(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     )
 }
 
-fn unpack_offset(globals: &Globals, lfp: Lfp, len: usize) -> Result<usize> {
+fn unpack_offset(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, len: usize) -> Result<usize> {
     match lfp.try_arg(1) {
         Some(v) => {
-            let offset = v.expect_integer(globals)?;
+            let offset = v.coerce_to_int(vm, globals)?;
             if offset < 0 || offset as usize > len {
                 Err(MonorubyErr::argumenterr("offset outside of string"))
             } else {
@@ -4901,6 +4901,92 @@ mod tests {
         run_test_once(
             r#"
             Encoding.compatible?("a", "b").nil?.!
+            "#,
+        );
+    }
+
+    #[test]
+    fn implicit_to_str_include() {
+        run_test(
+            r#"
+            class MyStr
+              def to_str
+                "world"
+              end
+            end
+            "hello world".include?(MyStr.new)
+            "#,
+        );
+    }
+
+    #[test]
+    fn implicit_to_str_start_with() {
+        run_test(
+            r#"
+            class MyStr
+              def to_str
+                "hel"
+              end
+            end
+            "hello".start_with?(MyStr.new)
+            "#,
+        );
+    }
+
+    #[test]
+    fn implicit_to_str_end_with() {
+        run_test(
+            r#"
+            class MyStr
+              def to_str
+                "llo"
+              end
+            end
+            "hello".end_with?(MyStr.new)
+            "#,
+        );
+    }
+
+    #[test]
+    fn to_int_conversion() {
+        run_test(
+            r#"
+            class MyInt
+              def to_int
+                3
+              end
+            end
+            "abc" * MyInt.new
+            "#,
+        );
+        run_test(
+            r#"
+            class MyInt
+              def to_int
+                10
+              end
+            end
+            "hello".ljust(MyInt.new, ".")
+            "#,
+        );
+        run_test(
+            r#"
+            class MyInt
+              def to_int
+                10
+              end
+            end
+            "hello".center(MyInt.new, ".")
+            "#,
+        );
+        run_test(
+            r#"
+            class MyInt
+              def to_int
+                1
+              end
+            end
+            "hello".getbyte(MyInt.new)
             "#,
         );
     }

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -56,18 +56,18 @@ fn time_now(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePt
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Time/s/at.html]
 #[monoruby_builtin]
-fn time_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn time_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let secs_val = lfp.arg(0);
     let (secs, nsecs) = if let Some(f) = secs_val.try_float() {
         let s = f.floor() as i64;
         let ns = ((f - f.floor()) * 1_000_000_000.0) as u32;
         (s, ns)
     } else {
-        let s = secs_val.coerce_to_i64(globals)?;
+        let s = secs_val.coerce_to_int(vm, globals)?;
         (s, 0u32)
     };
     let usec_ns = if let Some(arg1) = lfp.try_arg(1) {
-        let u = arg1.coerce_to_i64(globals)?;
+        let u = arg1.coerce_to_int(vm, globals)?;
         (u * 1000) as u32
     } else {
         0

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -181,6 +181,7 @@ impl IdentId {
     pub const SINGLETON_METHOD_REMOVED: IdentId = id!(72);
     pub const SINGLETON_METHOD_UNDEFINED: IdentId = id!(73);
     pub const TO_INT: IdentId = id!(74);
+    pub const TO_F: IdentId = id!(75);
 }
 
 impl IdentId {
@@ -351,6 +352,7 @@ impl IdentifierTable {
         table.set_id("singleton_method_removed", IdentId::SINGLETON_METHOD_REMOVED);
         table.set_id("singleton_method_undefined", IdentId::SINGLETON_METHOD_UNDEFINED);
         table.set_id("to_int", IdentId::TO_INT);
+        table.set_id("to_f", IdentId::TO_F);
         table
     }
 


### PR DESCRIPTION
## Summary

Fix implicit type conversions across 11 builtin files. Methods now call `to_int`, `to_str`, `to_f` on arguments instead of requiring exact types, matching CRuby behavior.

### to_int (Integer conversion via `coerce_to_int`)
- **String**: `*`, `[]`, `[]=`, `slice!`, `split`, `match`, `index`, `rindex`, `ljust`, `rjust`, `center`, `getbyte`, `setbyte`, `byteslice`, `to_i`, `sum`, `unpack`
- **Regexp**: `match`, `match?`, `last_match`
- **Kernel**: `caller`, `rand`
- **IO**: `read`
- **MatchData**: `begin`, `end`
- **SystemExit**: `new`
- **Process**: `clock_gettime`
- **File**: `binread`, `umask`, `fnmatch`
- **Time**: `at`

### to_str (String conversion via `coerce_to_str`)
- **String**: `include?`, `start_with?`, `end_with?`, `delete_prefix`, `delete_prefix!`, `sub`, `gsub`
- **Regexp**: `new`, `escape`

### to_f (Float conversion for Numeric subclasses)
- **Math**: All 25+ functions (`sin`, `cos`, `sqrt`, `log`, `exp`, etc.)
- Rejects String arguments (CRuby only calls `to_f` on Numeric subclasses)
- Added `IdentId::TO_F` constant

## Test plan
- [x] `cargo test` — 639 pass, 10 pre-existing failures
- [x] Tests added: `to_int_conversion` (String#*, ljust, center, getbyte), `implicit_to_str_*` (include?, start_with?, end_with?), `implicit_to_f` (Math with Numeric subclass)

https://claude.ai/code/session_01HbA7ZLRg3dKsSa7mLGM6GH