### PR TITLE
Move shift and bitwise ops to inline-function pipeline with constant folding

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -812,7 +812,9 @@ fn kernel_rational(
                     return Err(MonorubyErr::rangeerr("can't convert NaN into Rational"));
                 }
                 if f.is_infinite() {
-                    return Err(MonorubyErr::rangeerr("can't convert Infinity into Rational"));
+                    return Err(MonorubyErr::rangeerr(
+                        "can't convert Infinity into Rational",
+                    ));
                 }
                 Ok(Value::rational_from_inner(RationalInner::from_f64(f)))
             }
@@ -835,11 +837,7 @@ fn kernel_rational(
 }
 
 /// Convert a Value to RationalInner for Kernel#Rational two-arg form.
-fn val_to_rational(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    v: Value,
-) -> Result<RationalInner> {
+fn val_to_rational(_: &mut Executor, globals: &mut Globals, v: Value) -> Result<RationalInner> {
     if let Some(r) = v.try_rational() {
         return Ok(r.clone());
     }
@@ -1720,7 +1718,9 @@ fn public_send(
     if let Some(entry) = globals.check_method_for_class(class_id, method) {
         match entry.visibility() {
             Visibility::Private => {
-                return Err(MonorubyErr::private_method_called(globals, method, receiver));
+                return Err(MonorubyErr::private_method_called(
+                    globals, method, receiver,
+                ));
             }
             Visibility::Protected => {
                 return Err(MonorubyErr::protected_method_called(

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -912,13 +912,11 @@ fn integer_bitop_inline(
     if let Some(rhs) = state.is_fixnum_literal(args) {
         // recv op <fixnum literal>
         state.load(ir, recv, GP::Rdi);
-        let imm = Value::integer(rhs.get()).id() as i64;
-        emit_bitop_imm(ir, imm, emit_imm, emit_rr);
+        emit_bitop_imm(ir, rhs, emit_imm, emit_rr);
     } else if let Some(lhs) = state.is_fixnum_literal(recv) {
         // <fixnum literal> op args (commutative — swap to use immediate form)
         state.load_fixnum(ir, args, GP::Rdi);
-        let imm = Value::integer(lhs.get()).id() as i64;
-        emit_bitop_imm(ir, imm, emit_imm, emit_rr);
+        emit_bitop_imm(ir, lhs, emit_imm, emit_rr);
     } else {
         state.load(ir, recv, GP::Rdi);
         state.load_fixnum(ir, args, GP::Rsi);
@@ -928,23 +926,26 @@ fn integer_bitop_inline(
     true
 }
 
-/// Emit a bitwise op with a literal rhs in `imm` (tagged fixnum form, in rdi).
+/// Emit a bitwise op with a literal `imm` rhs (lhs already in rdi as a tagged
+/// fixnum).
 ///
-/// If `imm` fits in `i32`, emit the immediate form directly. Otherwise load
-/// the full 64-bit immediate into rsi via `movabsq` and emit the register
-/// form.
+/// `imm` is converted to its tagged-fixnum `Value` form. If the tagged
+/// representation fits in `i32`, emit the immediate form directly via
+/// `emit_imm`. Otherwise load the full 64-bit tagged value into rsi and
+/// emit the register form via `emit_rr`.
 fn emit_bitop_imm(
     ir: &mut AsmIr,
-    imm: i64,
+    imm: Fixnum,
     emit_imm: impl Fn(&mut Codegen, i64) + Copy + 'static,
     emit_rr: impl Fn(&mut Codegen) + Copy + 'static,
 ) {
-    if i32::try_from(imm).is_ok() {
-        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
+    let tagged = Value::from(imm).id() as i64;
+    if i32::try_from(tagged).is_ok() {
+        ir.inline(move |r#gen, _, _| emit_imm(r#gen, tagged));
     } else {
         ir.inline(move |r#gen, _, _| {
             monoasm!( &mut r#gen.jit,
-                movq rsi, (imm);
+                movq rsi, (tagged);
             );
             emit_rr(r#gen);
         });

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -756,6 +756,67 @@ fn shr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     super::op::shr_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
 }
 
+/// Constant-fold `lhs >> rhs` for two i63 fixnums.
+///
+/// Returns `Some(result)` if the result fits in an i63 fixnum and matches
+/// `safe_int_shr` / `safe_int_shl` semantics. Returns `None` if folding
+/// would require BigInt allocation or would error at runtime.
+fn fold_shr(lhs: i64, rhs: i64) -> Option<i64> {
+    if rhs >= 0 {
+        // right shift never grows; always fits in i63.
+        let r = if rhs >= 64 {
+            if lhs >= 0 { 0 } else { -1 }
+        } else {
+            lhs >> rhs
+        };
+        Some(r)
+    } else {
+        // n >> -k == n << k
+        let k = (-rhs) as u64;
+        fold_shl_pos(lhs, k)
+    }
+}
+
+/// Constant-fold `lhs << rhs` for two i63 fixnums.
+///
+/// Returns `Some(result)` if the result fits in an i63 fixnum. Returns
+/// `None` if the result would overflow into a BigInt or if `rhs` is too
+/// large for a runtime-safe shift (matching `safe_int_shl` semantics).
+fn fold_shl(lhs: i64, rhs: i64) -> Option<i64> {
+    if rhs >= 0 {
+        let k = rhs as u64;
+        fold_shl_pos(lhs, k)
+    } else {
+        // n << -k == n >> k; right shift always fits.
+        let k = (-rhs) as u64;
+        let r = if k >= 64 {
+            if lhs >= 0 { 0 } else { -1 }
+        } else {
+            lhs >> k
+        };
+        Some(r)
+    }
+}
+
+/// Helper: fold `lhs << k` (k >= 0). Returns `None` if the result would
+/// overflow i63 (and thus require BigInt) or fail at runtime.
+fn fold_shl_pos(lhs: i64, k: u64) -> Option<i64> {
+    if lhs == 0 {
+        return Some(0);
+    }
+    if k >= 63 {
+        // Would overflow i63 for any non-zero lhs, or be a runtime error
+        // when k > u32::MAX (handled by safe_int_shl as RangeError).
+        return None;
+    }
+    let result = lhs.checked_shl(k as u32)?;
+    if Value::is_i63(result) {
+        Some(result)
+    } else {
+        None
+    }
+}
+
 fn integer_shr(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -775,6 +836,16 @@ fn integer_shr(
     let CallSiteInfo {
         dst, args, recv, ..
     } = *callsite;
+
+    // Constant folding: both operands are concrete fixnums.
+    if let Some(lhs) = state.is_fixnum_literal(recv)
+        && let Some(rhs) = state.is_fixnum_literal(args)
+        && let Some(folded) = fold_shr(lhs.get(), rhs.get())
+    {
+        state.def_C(dst, Immediate::check_fixnum(folded).unwrap());
+        return true;
+    }
+
     state.load(ir, recv, GP::Rdi);
     if let Some(rhs) = state.is_fixnum_literal(args) {
         let rhs = rhs.get();
@@ -842,6 +913,15 @@ fn integer_shl(
         dst, args, recv, ..
     } = *callsite;
 
+    // Constant folding: both operands are concrete fixnums.
+    if let Some(lhs) = state.is_fixnum_literal(recv)
+        && let Some(rhs) = state.is_fixnum_literal(args)
+        && let Some(folded) = fold_shl(lhs.get(), rhs.get())
+    {
+        state.def_C(dst, Immediate::check_fixnum(folded).unwrap());
+        return true;
+    }
+
     state.load(ir, recv, GP::Rdi);
     if let Some(rhs) = state.is_fixnum_literal(args) {
         let rhs = rhs.get();
@@ -886,6 +966,8 @@ fn integer_shl(
 /// Returns false if rhs is not Integer or the call site is not simple,
 /// falling back to the regular method dispatch path.
 ///
+/// `fold` performs the operation on two i64 fixnum values for constant
+/// folding. Bitwise ops on two i63 fixnums always produce an i63 result.
 /// `emit_imm` generates `<op>q rdi, imm` (rdi: tagged fixnum lhs, imm: tagged
 /// fixnum rhs that fits in `i32`).
 /// `emit_rr` generates `<op>q rdi, rsi` (both tagged fixnums in rdi/rsi).
@@ -895,6 +977,7 @@ fn integer_bitop_inline(
     store: &Store,
     callid: CallSiteId,
     rhs_class: Option<ClassId>,
+    fold: impl Fn(i64, i64) -> i64,
     emit_imm: impl Fn(&mut Codegen, i64) + Copy + 'static,
     emit_rr: impl Fn(&mut Codegen) + Copy + 'static,
 ) -> bool {
@@ -909,11 +992,22 @@ fn integer_bitop_inline(
         dst, args, recv, ..
     } = *callsite;
 
-    if let Some(rhs) = state.is_fixnum_literal(args) {
+    let lhs_lit = state.is_fixnum_literal(recv);
+    let rhs_lit = state.is_fixnum_literal(args);
+
+    if let (Some(lhs), Some(rhs)) = (lhs_lit, rhs_lit) {
+        // constant folding: both operands are concrete fixnums.
+        // Bitwise ops on two i63 values always produce an i63 result.
+        let result = fold(lhs.get(), rhs.get());
+        state.def_C(dst, Immediate::check_fixnum(result).unwrap());
+        return true;
+    }
+
+    if let Some(rhs) = rhs_lit {
         // recv op <fixnum literal>
         state.load(ir, recv, GP::Rdi);
         emit_bitop_imm(ir, rhs, emit_imm, emit_rr);
-    } else if let Some(lhs) = state.is_fixnum_literal(recv) {
+    } else if let Some(lhs) = lhs_lit {
         // <fixnum literal> op args (commutative — swap to use immediate form)
         state.load_fixnum(ir, args, GP::Rdi);
         emit_bitop_imm(ir, lhs, emit_imm, emit_rr);
@@ -967,6 +1061,7 @@ fn integer_bitor(
         store,
         callid,
         rhs_class,
+        |a, b| a | b,
         |r#gen, imm| {
             monoasm!( &mut r#gen.jit,
                 orq rdi, (imm);
@@ -995,6 +1090,7 @@ fn integer_bitand(
         store,
         callid,
         rhs_class,
+        |a, b| a & b,
         |r#gen, imm| {
             monoasm!( &mut r#gen.jit,
                 andq rdi, (imm);
@@ -1026,6 +1122,7 @@ fn integer_bitxor(
         store,
         callid,
         rhs_class,
+        |a, b| a ^ b,
         |r#gen, imm| {
             monoasm!( &mut r#gen.jit,
                 xorq rdi, (imm - 1);
@@ -2623,6 +2720,54 @@ mod tests {
         // zero lhs
         run_test("a = 0; a << 10");
         run_test("a = 0; a << -10");
+    }
+
+    #[test]
+    fn integer_shift_constant_folding() {
+        // Both operands are literals: should be constant-folded at JIT time.
+        // Use expressions inside arithmetic to keep them as bytecode constants
+        // (rather than being folded by the bytecode-level constant folder).
+        run_test("def f; 8 >> 1; end; f");
+        run_test("def f; 8 >> 0; end; f");
+        run_test("def f; -8 >> 2; end; f");
+        run_test("def f; 1 >> 64; end; f");
+        run_test("def f; -1 >> 64; end; f");
+        run_test("def f; 1 >> 100; end; f");
+        run_test("def f; -1 >> 100; end; f");
+        run_test("def f; 1 >> -3; end; f");
+        run_test("def f; 0 >> -100; end; f");
+
+        run_test("def f; 1 << 10; end; f");
+        run_test("def f; -1 << 10; end; f");
+        run_test("def f; 0 << 100; end; f");
+        run_test("def f; 256 << -4; end; f");
+        run_test("def f; -256 << -4; end; f");
+        run_test("def f; 1 << -100; end; f");
+        run_test("def f; -1 << -100; end; f");
+        // These would overflow i63 → folder bails out, falls through to inline
+        // assembly which deopts to BigInt path.
+        run_test("def f; 1 << 62; end; f");
+        run_test("def f; 1 << 100; end; f");
+    }
+
+    #[test]
+    fn integer_bitop_constant_folding() {
+        // Both operands are literals: should be constant-folded at JIT time.
+        run_test("def f; 0xFF | 0x0F; end; f");
+        run_test("def f; 0xFF & 0x0F; end; f");
+        run_test("def f; 0xFF ^ 0x0F; end; f");
+        run_test("def f; -1 | 0x0F; end; f");
+        run_test("def f; -1 & 0x0F; end; f");
+        run_test("def f; -1 ^ 0x0F; end; f");
+        run_test("def f; 42 | 0; end; f");
+        run_test("def f; 42 & 0; end; f");
+        run_test("def f; 42 ^ 0; end; f");
+        run_test("def f; 42 & -1; end; f");
+        run_test("def f; 42 ^ -1; end; f");
+        // Large fixnum literals
+        run_test("def f; 0x12345678 | 0xDEAD_BEEF_CAFE; end; f");
+        run_test("def f; 0x12345678 & 0xDEAD_BEEF_CAFE; end; f");
+        run_test("def f; 0x12345678 ^ 0xDEAD_BEEF_CAFE; end; f");
     }
 
     #[test]

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -21,9 +21,9 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_basic_op(INTEGER_CLASS, "*", mul, 1);
     globals.define_basic_op(INTEGER_CLASS, "/", div, 1);
     globals.define_basic_op(INTEGER_CLASS, "%", rem, 1);
-    globals.define_basic_op(INTEGER_CLASS, "&", bitand, 1);
-    globals.define_basic_op(INTEGER_CLASS, "|", bitor, 1);
-    globals.define_basic_op(INTEGER_CLASS, "^", bitxor, 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "&", bitand, Box::new(integer_bitand), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, Box::new(integer_bitor), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "^", bitxor, Box::new(integer_bitxor), 1);
     globals.define_builtin_func(INTEGER_CLASS, "divmod", divmod, 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, ">>", shr, Box::new(integer_shr), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "<<", shl, Box::new(integer_shl), 1);
@@ -876,6 +876,143 @@ fn integer_shl(
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true
+}
+
+///
+/// Common helper for inline JIT compilation of Integer#| / Integer#& / Integer#^.
+///
+/// Loads operands into registers (or detects literal rhs/lhs for immediate
+/// encoding) and emits the corresponding bitwise instruction. Returns false
+/// if rhs is not Integer or the call site is not simple, falling back to
+/// the regular method dispatch path.
+///
+/// `emit_imm` generates `<op>q rdi, imm` (rdi: tagged fixnum lhs).
+/// `emit_rr` generates `<op>q rdi, rsi` (both tagged fixnums in rdi/rsi).
+fn integer_bitop_inline(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    store: &Store,
+    callid: CallSiteId,
+    rhs_class: Option<ClassId>,
+    emit_imm: impl FnOnce(&mut Codegen, i64) + 'static,
+    emit_rr: impl FnOnce(&mut Codegen) + 'static,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    if rhs_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+
+    if let Some(rhs) = state.is_i16_literal(args) {
+        // recv op <i16 literal>
+        state.load(ir, recv, GP::Rdi);
+        let imm = Value::i32(rhs as i32).id() as i64;
+        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
+    } else if let Some(lhs) = state.is_i16_literal(recv) {
+        // <i16 literal> op args (commutative — swap to use immediate form)
+        state.load_fixnum(ir, args, GP::Rdi);
+        let imm = Value::i32(lhs as i32).id() as i64;
+        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
+    } else {
+        state.load(ir, recv, GP::Rdi);
+        state.load_fixnum(ir, args, GP::Rsi);
+        ir.inline(move |r#gen, _, _| emit_rr(r#gen));
+    }
+    state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
+    true
+}
+
+fn integer_bitor(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    rhs_class: Option<ClassId>,
+) -> bool {
+    integer_bitop_inline(
+        state,
+        ir,
+        store,
+        callid,
+        rhs_class,
+        |r#gen, imm| {
+            monoasm!( &mut r#gen.jit,
+                orq rdi, (imm);
+            );
+        },
+        |r#gen| {
+            monoasm!( &mut r#gen.jit,
+                orq rdi, rsi;
+            );
+        },
+    )
+}
+
+fn integer_bitand(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    rhs_class: Option<ClassId>,
+) -> bool {
+    integer_bitop_inline(
+        state,
+        ir,
+        store,
+        callid,
+        rhs_class,
+        |r#gen, imm| {
+            monoasm!( &mut r#gen.jit,
+                andq rdi, (imm);
+            );
+        },
+        |r#gen| {
+            monoasm!( &mut r#gen.jit,
+                andq rdi, rsi;
+            );
+        },
+    )
+}
+
+fn integer_bitxor(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    rhs_class: Option<ClassId>,
+) -> bool {
+    // XOR of two tagged fixnums (both LSB=1) yields LSB=0, so we need to
+    // restore the tag bit. For the immediate path we instead strip the tag
+    // bit from the immediate (`imm - 1`) so the result keeps lhs's tag.
+    integer_bitop_inline(
+        state,
+        ir,
+        store,
+        callid,
+        rhs_class,
+        |r#gen, imm| {
+            monoasm!( &mut r#gen.jit,
+                xorq rdi, (imm - 1);
+            );
+        },
+        |r#gen| {
+            monoasm!( &mut r#gen.jit,
+                xorq rdi, rsi;
+                addq rdi, 1;
+            );
+        },
+    )
 }
 
 ///
@@ -2461,6 +2598,43 @@ mod tests {
         // zero lhs
         run_test("a = 0; a << 10");
         run_test("a = 0; a << -10");
+    }
+
+    #[test]
+    fn integer_bitop_jit_edge_cases() {
+        // immediate rhs
+        run_test("a = 0xFF; a | 0x0F");
+        run_test("a = 0xFF; a & 0x0F");
+        run_test("a = 0xFF; a ^ 0x0F");
+        // immediate lhs (commutative)
+        run_test("a = 0x0F; 0xFF | a");
+        run_test("a = 0x0F; 0xFF & a");
+        run_test("a = 0x0F; 0xFF ^ a");
+        // both register
+        run_test("a = 0xFF; b = 0x0F; a | b");
+        run_test("a = 0xFF; b = 0x0F; a & b");
+        run_test("a = 0xFF; b = 0x0F; a ^ b");
+        // negative values (sign bit interaction with tag)
+        run_test("a = -1; a | 0x0F");
+        run_test("a = -1; a & 0x0F");
+        run_test("a = -1; a ^ 0x0F");
+        run_test("a = -1; b = 5; a | b");
+        run_test("a = -1; b = 5; a & b");
+        run_test("a = -1; b = 5; a ^ b");
+        // identity / zero
+        run_test("a = 42; a | 0");
+        run_test("a = 42; a & 0");
+        run_test("a = 42; a ^ 0");
+        run_test("a = 42; a & -1");
+        run_test("a = 42; a ^ -1");
+        // self
+        run_test("a = 42; a | a");
+        run_test("a = 42; a & a");
+        run_test("a = 42; a ^ a");
+        // BigInt fallback (uses generic method dispatch)
+        run_test("a = 10**20; a | 0xFF");
+        run_test("a = 10**20; a & 0xFF");
+        run_test("a = 10**20; a ^ 0xFF");
     }
 
     #[test]

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -881,12 +881,13 @@ fn integer_shl(
 ///
 /// Common helper for inline JIT compilation of Integer#| / Integer#& / Integer#^.
 ///
-/// Loads operands into registers (or detects literal rhs/lhs for immediate
-/// encoding) and emits the corresponding bitwise instruction. Returns false
-/// if rhs is not Integer or the call site is not simple, falling back to
-/// the regular method dispatch path.
+/// Loads operands into registers (or detects a literal fixnum operand for
+/// immediate encoding) and emits the corresponding bitwise instruction.
+/// Returns false if rhs is not Integer or the call site is not simple,
+/// falling back to the regular method dispatch path.
 ///
-/// `emit_imm` generates `<op>q rdi, imm` (rdi: tagged fixnum lhs).
+/// `emit_imm` generates `<op>q rdi, imm` (rdi: tagged fixnum lhs, imm: tagged
+/// fixnum rhs that fits in `i32`).
 /// `emit_rr` generates `<op>q rdi, rsi` (both tagged fixnums in rdi/rsi).
 fn integer_bitop_inline(
     state: &mut AbstractState,
@@ -894,8 +895,8 @@ fn integer_bitop_inline(
     store: &Store,
     callid: CallSiteId,
     rhs_class: Option<ClassId>,
-    emit_imm: impl FnOnce(&mut Codegen, i64) + 'static,
-    emit_rr: impl FnOnce(&mut Codegen) + 'static,
+    emit_imm: impl Fn(&mut Codegen, i64) + Copy + 'static,
+    emit_rr: impl Fn(&mut Codegen) + Copy + 'static,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {
@@ -908,16 +909,16 @@ fn integer_bitop_inline(
         dst, args, recv, ..
     } = *callsite;
 
-    if let Some(rhs) = state.is_i16_literal(args) {
-        // recv op <i16 literal>
+    if let Some(rhs) = state.is_fixnum_literal(args) {
+        // recv op <fixnum literal>
         state.load(ir, recv, GP::Rdi);
-        let imm = Value::i32(rhs as i32).id() as i64;
-        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
-    } else if let Some(lhs) = state.is_i16_literal(recv) {
-        // <i16 literal> op args (commutative — swap to use immediate form)
+        let imm = Value::integer(rhs.get()).id() as i64;
+        emit_bitop_imm(ir, imm, emit_imm, emit_rr);
+    } else if let Some(lhs) = state.is_fixnum_literal(recv) {
+        // <fixnum literal> op args (commutative — swap to use immediate form)
         state.load_fixnum(ir, args, GP::Rdi);
-        let imm = Value::i32(lhs as i32).id() as i64;
-        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
+        let imm = Value::integer(lhs.get()).id() as i64;
+        emit_bitop_imm(ir, imm, emit_imm, emit_rr);
     } else {
         state.load(ir, recv, GP::Rdi);
         state.load_fixnum(ir, args, GP::Rsi);
@@ -925,6 +926,29 @@ fn integer_bitop_inline(
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true
+}
+
+/// Emit a bitwise op with a literal rhs in `imm` (tagged fixnum form, in rdi).
+///
+/// If `imm` fits in `i32`, emit the immediate form directly. Otherwise load
+/// the full 64-bit immediate into rsi via `movabsq` and emit the register
+/// form.
+fn emit_bitop_imm(
+    ir: &mut AsmIr,
+    imm: i64,
+    emit_imm: impl Fn(&mut Codegen, i64) + Copy + 'static,
+    emit_rr: impl Fn(&mut Codegen) + Copy + 'static,
+) {
+    if i32::try_from(imm).is_ok() {
+        ir.inline(move |r#gen, _, _| emit_imm(r#gen, imm));
+    } else {
+        ir.inline(move |r#gen, _, _| {
+            monoasm!( &mut r#gen.jit,
+                movq rsi, (imm);
+            );
+            emit_rr(r#gen);
+        });
+    }
 }
 
 fn integer_bitor(
@@ -2602,7 +2626,7 @@ mod tests {
 
     #[test]
     fn integer_bitop_jit_edge_cases() {
-        // immediate rhs
+        // immediate rhs (small, tagged form fits in i32)
         run_test("a = 0xFF; a | 0x0F");
         run_test("a = 0xFF; a & 0x0F");
         run_test("a = 0xFF; a ^ 0x0F");
@@ -2614,6 +2638,14 @@ mod tests {
         run_test("a = 0xFF; b = 0x0F; a | b");
         run_test("a = 0xFF; b = 0x0F; a & b");
         run_test("a = 0xFF; b = 0x0F; a ^ b");
+        // large fixnum literal (tagged form does NOT fit in i32 → register-loaded path)
+        run_test("a = 0x12345678; a | 0xDEADBEEF_CAFE");
+        run_test("a = 0x12345678; a & 0xDEADBEEF_CAFE");
+        run_test("a = 0x12345678; a ^ 0xDEADBEEF_CAFE");
+        // commutative form with large literal
+        run_test("a = 0x12345678; 0xDEADBEEF_CAFE | a");
+        run_test("a = 0x12345678; 0xDEADBEEF_CAFE & a");
+        run_test("a = 0x12345678; 0xDEADBEEF_CAFE ^ a");
         // negative values (sign bit interaction with tag)
         run_test("a = -1; a | 0x0F");
         run_test("a = -1; a & 0x0F");
@@ -2621,6 +2653,9 @@ mod tests {
         run_test("a = -1; b = 5; a | b");
         run_test("a = -1; b = 5; a & b");
         run_test("a = -1; b = 5; a ^ b");
+        // negative large literal
+        run_test("a = -1; a & 0xDEADBEEF_CAFE");
+        run_test("a = -1; a ^ 0xDEADBEEF_CAFE");
         // identity / zero
         run_test("a = 42; a | 0");
         run_test("a = 42; a & 0");

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -763,18 +763,45 @@ fn integer_shr(
     store: &Store,
     callid: CallSiteId,
     _: ClassId,
-    _: Option<ClassId>,
+    rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {
+        return false;
+    }
+    if rhs_class != Some(INTEGER_CLASS) {
         return false;
     }
     let CallSiteInfo {
         dst, args, recv, ..
     } = *callsite;
     state.load(ir, recv, GP::Rdi);
-    if let Some(rhs) = state.is_u8_literal(args) {
-        ir.inline(move |r#gen, _, _| r#gen.gen_shr_imm(rhs));
+    if let Some(rhs) = state.is_fixnum_literal(args) {
+        let rhs = rhs.get();
+        if rhs >= 0 {
+            // n >> k (k >= 0): right shift
+            ir.inline(move |r#gen, _, _| r#gen.gen_shr_imm(rhs.min(64) as u8));
+        } else {
+            // n >> -k: equivalent to n << k
+            let k = (-rhs) as u64;
+            if k < 64 {
+                let deopt = ir.new_deopt(state);
+                ir.inline(move |r#gen, _, labels| {
+                    r#gen.gen_shl_rhs_imm(k as u8, &labels[deopt])
+                });
+            } else {
+                // shift too large for inline, deopt
+                let deopt = ir.new_deopt(state);
+                ir.inline(move |r#gen, _, labels| {
+                    let deopt = &labels[deopt];
+                    monoasm!( &mut r#gen.jit,
+                        cmpq rdi, (Value::i32(0).id());
+                        jne deopt;
+                        movq rdi, (Value::i32(0).id());
+                    );
+                });
+            }
+        }
     } else {
         state.load_fixnum(ir, args, GP::Rcx);
         let deopt = ir.new_deopt(state);
@@ -802,10 +829,13 @@ fn integer_shl(
     store: &Store,
     callid: CallSiteId,
     _: ClassId,
-    _: Option<ClassId>,
+    rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {
+        return false;
+    }
+    if rhs_class != Some(INTEGER_CLASS) {
         return false;
     }
     let CallSiteInfo {
@@ -813,11 +843,28 @@ fn integer_shl(
     } = *callsite;
 
     state.load(ir, recv, GP::Rdi);
-    if let Some(rhs) = state.is_u8_literal(args)
-        && rhs < 64
-    {
-        let deopt = ir.new_deopt(state);
-        ir.inline(move |r#gen, _, labels| r#gen.gen_shl_rhs_imm(rhs, &labels[deopt]));
+    if let Some(rhs) = state.is_fixnum_literal(args) {
+        let rhs = rhs.get();
+        if rhs >= 0 && rhs < 64 {
+            // n << k (0 <= k < 64): left shift
+            let deopt = ir.new_deopt(state);
+            ir.inline(move |r#gen, _, labels| r#gen.gen_shl_rhs_imm(rhs as u8, &labels[deopt]));
+        } else if rhs < 0 {
+            // n << -k: equivalent to n >> k
+            let k = (-rhs) as u64;
+            ir.inline(move |r#gen, _, _| r#gen.gen_shr_imm(k.min(64) as u8));
+        } else {
+            // rhs >= 64: deopt (overflow for non-zero lhs)
+            let deopt = ir.new_deopt(state);
+            ir.inline(move |r#gen, _, labels| {
+                let deopt = &labels[deopt];
+                monoasm!( &mut r#gen.jit,
+                    cmpq rdi, (Value::i32(0).id());
+                    jne deopt;
+                    movq rdi, (Value::i32(0).id());
+                );
+            });
+        }
     } else if let Some(lhs) = state.is_fixnum_literal(recv) {
         state.load_fixnum(ir, args, GP::Rcx);
         let deopt = ir.new_deopt(state);
@@ -2368,6 +2415,25 @@ mod tests {
     }
 
     #[test]
+    fn integer_shr_jit_edge_cases() {
+        // negative constant rhs (>> -k == << k)
+        run_test("a = 1; a >> -3");
+        run_test("a = 5; a >> -10");
+        run_test("a = -1; a >> -3");
+        // large negative rhs (overflow → deopt to BigInt)
+        run_test("a = 0; a >> -100");
+        run_test("a = 1; a >> -100");
+        // large positive rhs
+        run_test("a = 100; a >> 64");
+        run_test("a = 100; a >> 100");
+        run_test("a = -1; a >> 64");
+        run_test("a = -1; a >> 100");
+        // zero lhs
+        run_test("a = 0; a >> 10");
+        run_test("a = 0; a >> -10");
+    }
+
+    #[test]
     fn integer_shl_extended() {
         run_tests(&[
             "1 << 10",
@@ -2375,6 +2441,26 @@ mod tests {
             // BigInt shift
             "(10**20) << 10",
         ]);
+    }
+
+    #[test]
+    fn integer_shl_jit_edge_cases() {
+        // negative constant rhs (<< -k == >> k)
+        run_test("a = 256; a << -4");
+        run_test("a = -256; a << -4");
+        run_test("a = 1; a << -100");
+        run_test("a = -1; a << -100");
+        // large positive rhs (overflow → deopt to BigInt)
+        run_test("a = 0; a << 100");
+        run_test("a = 1; a << 100");
+        // large negative rhs
+        run_test("a = 100; a << -64");
+        run_test("a = 100; a << -100");
+        run_test("a = -1; a << -64");
+        run_test("a = -1; a << -100");
+        // zero lhs
+        run_test("a = 0; a << 10");
+        run_test("a = 0; a << -10");
     }
 
     #[test]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -168,10 +168,6 @@ pub(super) fn init(globals: &mut Globals) {
     super::encoding::init_encoding(globals);
 }
 
-fn encoding_class(globals: &Globals) -> ClassId {
-    super::encoding::encoding_class(globals)
-}
-
 ///
 /// ### String.new
 ///
@@ -4578,10 +4574,14 @@ mod tests {
         run_test_no_result_check(r#""\xC3\xA9".end_with?("\xA9")"#);
         run_test_no_result_check(r#""\xe3\x81\x82".end_with?("\x82")"#);
         // Explicit UTF-8 string with force_encoding: boundary check works
-        run_test_once(r#""\xC3\xA9".force_encoding("UTF-8").end_with?("\xA9".force_encoding("UTF-8"))"#);
+        run_test_once(
+            r#""\xC3\xA9".force_encoding("UTF-8").end_with?("\xA9".force_encoding("UTF-8"))"#,
+        );
         // start_with? UTF-8 character boundary check
         run_test_no_result_check(r#""\xC3\xA9".start_with?("\xC3")"#);
-        run_test_once(r#""\xC3\xA9".force_encoding("UTF-8").start_with?("\xC3".force_encoding("UTF-8"))"#);
+        run_test_once(
+            r#""\xC3\xA9".force_encoding("UTF-8").start_with?("\xC3".force_encoding("UTF-8"))"#,
+        );
         // start_with? with Regexp sets/clears $~
         run_test(r#""test-123".start_with?(/test/); $~[0]"#);
         run_test(r#""test-123".start_with?(/xxx/); $~"#);

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1624,6 +1624,8 @@ pub(crate) enum BinOpK {
     BitXor = 6,
     Rem = 7,
     Exp = 8,
+    Shl = 9,
+    Shr = 10,
 }
 
 impl std::fmt::Display for BinOpK {
@@ -1638,6 +1640,8 @@ impl std::fmt::Display for BinOpK {
             BinOpK::BitXor => "^",
             BinOpK::Rem => "%",
             BinOpK::Exp => "**",
+            BinOpK::Shl => "<<",
+            BinOpK::Shr => ">>",
         };
         write!(f, "{}", s)
     }
@@ -1655,23 +1659,11 @@ impl BinOpK {
             6 => BinOpK::BitXor,
             7 => BinOpK::Rem,
             8 => BinOpK::Exp,
+            9 => BinOpK::Shl,
+            10 => BinOpK::Shr,
             _ => unreachable!(),
         }
     }
-
-    /*pub(crate) fn generic_func(&self) -> BinaryOpFn {
-        match self {
-            BinOpK::Add => add_values,
-            BinOpK::Sub => sub_values,
-            BinOpK::Mul => mul_values,
-            BinOpK::Div => div_values,
-            BinOpK::BitOr => bitor_values,
-            BinOpK::BitAnd => bitand_values,
-            BinOpK::BitXor => bitxor_values,
-            BinOpK::Rem => rem_values,
-            BinOpK::Exp => pow_values,
-        }
-    }*/
 }
 
 ///

--- a/monoruby/src/bytecodegen/binary.rs
+++ b/monoruby/src/bytecodegen/binary.rs
@@ -21,8 +21,8 @@ impl<'a> BytecodeGen<'a> {
             BinOp::BitOr => self.gen_bitor(use_mode, lhs, rhs, loc),
             BinOp::BitAnd => self.gen_bitand(use_mode, lhs, rhs, loc),
             BinOp::BitXor => self.gen_bitxor(use_mode, lhs, rhs, loc),
-            BinOp::Shr => self.gen_binop_method(IdentId::_SHR, lhs, rhs, use_mode, loc),
-            BinOp::Shl => self.gen_binop_method(IdentId::_SHL, lhs, rhs, use_mode, loc),
+            BinOp::Shr => self.gen_shr(use_mode, lhs, rhs, loc),
+            BinOp::Shl => self.gen_shl(use_mode, lhs, rhs, loc),
             BinOp::Match => self.gen_binop_method(IdentId::_MATCH, lhs, rhs, use_mode, loc),
             BinOp::Unmatch => self.gen_binop_method(IdentId::_UNMATCH, lhs, rhs, use_mode, loc),
             BinOp::Compare => self.gen_binop_method(IdentId::_CMP, lhs, rhs, use_mode, loc),
@@ -176,7 +176,9 @@ impl<'a> BytecodeGen<'a> {
         (bitand, BitAnd),
         (bitxor, BitXor),
         (exp, Exp),
-        (rem, Rem)
+        (rem, Rem),
+        (shl, Shl),
+        (shr, Shr)
     );
 
     ///

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -571,7 +571,7 @@ impl<'a> BytecodeGen<'a> {
                 let op3 = self.slot_id(&src);
                 Bytecode::from(enc_www(149, op1.0, op2, op3.0))
             }
-            BytecodeInst::InitMethod(fn_info) => Bytecode::from(enc_www_fn_info(170, &fn_info)),
+            BytecodeInst::InitMethod(fn_info) => Bytecode::from(enc_www_fn_info(172, &fn_info)),
             BytecodeInst::ExpandArray(src, dst, len, rest_pos) => {
                 let op1 = self.slot_id(&src);
                 let op2 = self.slot_id(&dst);
@@ -580,28 +580,28 @@ impl<'a> BytecodeGen<'a> {
                 } else {
                     0
                 };
-                Bytecode::from_u16(enc_www(171, op1.0, op2.0, len), rest)
+                Bytecode::from_u16(enc_www(173, op1.0, op2.0, len), rest)
             }
-            BytecodeInst::UndefMethod { undef } => Bytecode::from(enc_wl(172, 0, undef.get())),
+            BytecodeInst::UndefMethod { undef } => Bytecode::from(enc_wl(174, 0, undef.get())),
             BytecodeInst::AliasMethod { new, old } => {
                 let op1 = self.slot_id(&new);
                 let op2 = self.slot_id(&old);
-                Bytecode::from(enc_ww(173, op1.0, op2.0))
+                Bytecode::from(enc_ww(175, op1.0, op2.0))
             }
             BytecodeInst::Hash { ret, args, len } => {
                 let op1 = self.slot_id(&ret);
                 let op2 = self.slot_id(&args);
-                Bytecode::from(enc_www(174, op1.0, op2.0, len))
+                Bytecode::from(enc_www(176, op1.0, op2.0, len))
             }
             BytecodeInst::ToA { dst, src } => {
                 let op1 = self.slot_id(&dst);
                 let op2 = self.slot_id(&src);
-                Bytecode::from(enc_ww(175, op1.0, op2.0))
+                Bytecode::from(enc_ww(177, op1.0, op2.0))
             }
             BytecodeInst::Mov(dst, src) => {
                 let op1 = self.slot_id(&dst);
                 let op2 = self.slot_id(&src);
-                Bytecode::from(enc_ww(176, op1.0, op2.0))
+                Bytecode::from(enc_ww(178, op1.0, op2.0))
             }
             BytecodeInst::Range {
                 ret,
@@ -612,12 +612,12 @@ impl<'a> BytecodeGen<'a> {
                 let op1 = self.slot_id(&ret);
                 let op2 = self.slot_id(&start);
                 let op3 = self.slot_id(&end);
-                Bytecode::from(enc_www(177 + u16::from(exclude_end), op1.0, op2.0, op3.0))
+                Bytecode::from(enc_www(179 + u16::from(exclude_end), op1.0, op2.0, op3.0))
             }
             BytecodeInst::ConcatStr(ret, arg, len) => {
                 let op1 = ret.map_or(SlotId::self_(), |ret| self.slot_id(&ret));
                 let op2 = self.slot_id(&BcReg::from(arg));
-                Bytecode::from(enc_www(179, op1.0, op2.0, len as u16))
+                Bytecode::from(enc_www(181, op1.0, op2.0, len as u16))
             }
         };
         Ok(bc)

--- a/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
@@ -228,6 +228,7 @@ impl Codegen {
                     );
                 }
             },
+            BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
@@ -191,44 +191,9 @@ impl Codegen {
                 self.jit.select_page(0);
             }
             BinOpK::Exp => unreachable!(),
-            BinOpK::BitOr => match mode {
-                OpMode::RR(_, _) => {
-                    monoasm!( &mut self.jit,
-                        orq R(lhs as u64), R(rhs as u64);
-                    );
-                }
-                OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                    monoasm!( &mut self.jit,
-                        orq R(lhs as u64), (Value::i32(*i as i32).id());
-                    );
-                }
-            },
-            BinOpK::BitAnd => match mode {
-                OpMode::RR(_, _) => {
-                    monoasm!( &mut self.jit,
-                        andq R(lhs as u64), R(rhs as u64);
-                    );
-                }
-                OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                    monoasm!( &mut self.jit,
-                        andq R(lhs as u64), (Value::i32(*i as i32).id());
-                    );
-                }
-            },
-            BinOpK::BitXor => match mode {
-                OpMode::RR(_, _) => {
-                    monoasm!( &mut self.jit,
-                        xorq R(lhs as u64), R(rhs as u64);
-                        addq R(lhs as u64), 1;
-                    );
-                }
-                OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                    monoasm!( &mut self.jit,
-                        xorq R(lhs as u64), (Value::i32(*i as i32).id() - 1);
-                    );
-                }
-            },
-            BinOpK::Shl | BinOpK::Shr => unreachable!(),
+            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
+                unreachable!()
+            }
         }
     }
 

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -17,10 +17,11 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match kind {
-            // Shl/Shr are always compiled as method calls.
-            // The inline function registered on Integer#<< / Integer#>> handles
-            // code generation using both-side class info from the BinOp inline cache.
-            BinOpK::Shl | BinOpK::Shr => {
+            // These ops are always compiled as method calls.
+            // The inline function registered on Integer#<< / Integer#>> /
+            // Integer#| / Integer#& / Integer#^ handles code generation
+            // using both-side class info from the BinOp inline cache.
+            BinOpK::Shl | BinOpK::Shr | BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor => {
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
                     None => Ok(CompileResult::Recompile(RecompileReason::NotCached)),
@@ -270,17 +271,9 @@ impl AbstractFrame {
                     return Immediate::check_fixnum(result);
                 }
             }
-            BinOpK::BitOr => {
-                // Bitwise ops on two i63 values always produce i63 results
-                return Immediate::check_fixnum(lhs | rhs);
+            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
+                unreachable!()
             }
-            BinOpK::BitAnd => {
-                return Immediate::check_fixnum(lhs & rhs);
-            }
-            BinOpK::BitXor => {
-                return Immediate::check_fixnum(lhs ^ rhs);
-            }
-            BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
         None
     }
@@ -304,7 +297,7 @@ impl AbstractFrame {
         };
 
         match kind {
-            BinOpK::Add | BinOpK::Mul | BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor => {
+            BinOpK::Add | BinOpK::Mul => {
                 let lhs = GP::Rdi;
                 let rhs = GP::Rsi;
                 self.fetch_fixnum_comm(ir, lhs, rhs, mode);
@@ -351,7 +344,9 @@ impl AbstractFrame {
                     self.def_reg2acc_fixnum(ir, GP::Rax, dst);
                 }
             },
-            BinOpK::Shl | BinOpK::Shr => unreachable!(),
+            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
+                unreachable!()
+            }
         }
     }
 

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -16,36 +16,54 @@ impl<'a> JitContext<'a> {
         ic: Option<(ClassId, ClassId)>,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
-        match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) => {
-                state.binop_integer(ir, kind, dst, mode);
-                Ok(CompileResult::Continue)
-            }
-            BinaryOpType::Float(info) => {
-                match kind {
-                    BinOpK::Exp | BinOpK::Rem => {
-                        return self.call_binary_method(
-                            state,
-                            ir,
-                            lhs,
-                            rhs,
-                            info.lhs_class.into(),
-                            Some(info.rhs_class.into()),
-                            kind,
-                            bc_pos,
-                        );
+        match kind {
+            // Shl/Shr are always compiled as method calls.
+            // The inline function registered on Integer#<< / Integer#>> handles
+            // code generation using both-side class info from the BinOp inline cache.
+            BinOpK::Shl | BinOpK::Shr => {
+                let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
+                match lhs_class {
+                    None => Ok(CompileResult::Recompile(RecompileReason::NotCached)),
+                    Some(lhs_class) => {
+                        self.call_binary_method(
+                            state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos,
+                        )
                     }
-                    _ => {}
                 }
-                state.binop_float(ir, kind, dst, info);
-                Ok(CompileResult::Continue)
             }
-            BinaryOpType::Other(None, _) => {
-                Ok(CompileResult::Recompile(RecompileReason::NotCached))
-            }
-            BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
-            }
+            _ => match state.binop_type(lhs, rhs, ic) {
+                BinaryOpType::Integer(mode) => {
+                    state.binop_integer(ir, kind, dst, mode);
+                    Ok(CompileResult::Continue)
+                }
+                BinaryOpType::Float(info) => {
+                    match kind {
+                        BinOpK::Exp | BinOpK::Rem => {
+                            return self.call_binary_method(
+                                state,
+                                ir,
+                                lhs,
+                                rhs,
+                                info.lhs_class.into(),
+                                Some(info.rhs_class.into()),
+                                kind,
+                                bc_pos,
+                            );
+                        }
+                        _ => {}
+                    }
+                    state.binop_float(ir, kind, dst, info);
+                    Ok(CompileResult::Continue)
+                }
+                BinaryOpType::Other(None, _) => {
+                    Ok(CompileResult::Recompile(RecompileReason::NotCached))
+                }
+                BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                    self.call_binary_method(
+                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos,
+                    )
+                }
+            },
         }
     }
 
@@ -262,6 +280,7 @@ impl AbstractFrame {
             BinOpK::BitXor => {
                 return Immediate::check_fixnum(lhs ^ rhs);
             }
+            BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
         None
     }
@@ -332,6 +351,7 @@ impl AbstractFrame {
                     self.def_reg2acc_fixnum(ir, GP::Rax, dst);
                 }
             },
+            BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
     }
 

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -564,10 +564,10 @@ impl SlotState {
         i16::try_from(i).ok()
     }
 
-    pub fn is_u8_literal(&self, slot: SlotId) -> Option<u8> {
-        let i = self.is_fixnum_literal(slot)?.get();
-        u8::try_from(i).ok()
-    }
+    //pub fn is_u8_literal(&self, slot: SlotId) -> Option<u8> {
+    //    let i = self.is_fixnum_literal(slot)?.get();
+    //    u8::try_from(i).ok()
+    //}
 
     pub fn is_array_ty(&self, store: &Store, slot: SlotId) -> bool {
         let b = if let Guarded::Class(class) = self.guarded(slot) {

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -617,7 +617,7 @@ impl TraceIr {
                         ic,
                     }
                 }
-                160..=168 => {
+                160..=170 => {
                     let kind = BinOpK::from(opcode - 160);
                     let dst = SlotId::from(op1_w1);
                     let lhs = SlotId::new(op2_w2);
@@ -638,47 +638,47 @@ impl TraceIr {
                     }
                 }
 
-                170 => TraceIr::InitMethod(FnInitInfo {
+                172 => TraceIr::InitMethod(FnInitInfo {
                     reg_num: op1_w1 as usize,
                     arg_num: op2_w2 as usize,
                     stack_offset: op3_w3 as usize,
                 }),
-                171 => TraceIr::ExpandArray {
+                173 => TraceIr::ExpandArray {
                     src: SlotId::new(op1_w1),
                     dst: (SlotId::new(op2_w2), op3_w3, {
                         let rest = op2 as u16;
                         if rest == 0 { None } else { Some(rest - 1) }
                     }),
                 },
-                172 => {
+                174 => {
                     let undef = IdentId::from(dec_wl(op1).1);
                     TraceIr::UndefMethod { undef }
                 }
-                173 => TraceIr::AliasMethod {
+                175 => TraceIr::AliasMethod {
                     new: SlotId::new(op1_w1),
                     old: SlotId::new(op2_w2),
                 },
-                174 => TraceIr::Hash {
+                176 => TraceIr::Hash {
                     dst: SlotId::new(op1_w1),
                     args: SlotId::new(op2_w2),
                     len: op3_w3,
                 },
-                175 => TraceIr::ToA {
+                177 => TraceIr::ToA {
                     dst: SlotId::new(op1_w1),
                     src: SlotId::new(op2_w2),
                 },
-                176 => TraceIr::Mov(SlotId::new(op1_w1), SlotId::new(op2_w2)),
-                177..=178 => TraceIr::Range {
+                178 => TraceIr::Mov(SlotId::new(op1_w1), SlotId::new(op2_w2)),
+                179..=180 => TraceIr::Range {
                     dst: SlotId::new(op1_w1),
                     start: SlotId::new(op2_w2),
                     end: SlotId::new(op3_w3),
-                    exclude_end: match opcode - 177 {
+                    exclude_end: match opcode - 179 {
                         0 => false,
                         1 => true,
                         _ => unreachable!(),
                     },
                 },
-                179 => TraceIr::ConcatStr(SlotId::from(op1_w1), SlotId::new(op2_w2), op3_w3),
+                181 => TraceIr::ConcatStr(SlotId::from(op1_w1), SlotId::new(op2_w2), op3_w3),
                 _ => unreachable!("{:016x}", op1),
             }
         }

--- a/monoruby/src/codegen/vmgen.rs
+++ b/monoruby/src/codegen/vmgen.rs
@@ -225,6 +225,8 @@ impl Codegen {
         let mul_rr = self.vm_binops(mul_values);
         let rem_rr = self.vm_binops(rem_values);
         let pow_rr = self.vm_binops(pow_values);
+        let shl_rr = self.vm_binops(shl_values);
+        let shr_rr = self.vm_binops(shr_values);
         let vm_send_simple = self.vm_send(true);
         let vm_send = self.vm_send(false);
 
@@ -323,17 +325,19 @@ impl Codegen {
         self.dispatch[166] = xor_rr;
         self.dispatch[167] = rem_rr;
         self.dispatch[168] = pow_rr;
+        self.dispatch[169] = shl_rr;
+        self.dispatch[170] = shr_rr;
 
-        self.dispatch[170] = self.vm_init();
-        self.dispatch[171] = self.vm_expand_array();
-        self.dispatch[172] = self.vm_undef_method();
-        self.dispatch[173] = self.vm_alias_method();
-        self.dispatch[174] = self.vm_hash();
-        self.dispatch[175] = toa;
-        self.dispatch[176] = mov;
-        self.dispatch[177] = self.vm_range(false);
-        self.dispatch[178] = self.vm_range(true);
-        self.dispatch[179] = self.vm_concat();
+        self.dispatch[172] = self.vm_init();
+        self.dispatch[173] = self.vm_expand_array();
+        self.dispatch[174] = self.vm_undef_method();
+        self.dispatch[175] = self.vm_alias_method();
+        self.dispatch[176] = self.vm_hash();
+        self.dispatch[177] = toa;
+        self.dispatch[178] = mov;
+        self.dispatch[179] = self.vm_range(false);
+        self.dispatch[180] = self.vm_range(true);
+        self.dispatch[181] = self.vm_concat();
     }
 
     ///
@@ -372,6 +376,8 @@ impl Codegen {
         self.dispatch[166] = self.vm_binops(bitxor_values_no_opt);
         self.dispatch[167] = self.vm_binops(rem_values_no_opt);
         self.dispatch[168] = self.vm_binops(pow_values_no_opt);
+        self.dispatch[169] = self.vm_binops(shl_values_no_opt);
+        self.dispatch[170] = self.vm_binops(shr_values_no_opt);
 
         self.jit.finalize();
     }

--- a/monoruby/src/codegen/vmgen.rs
+++ b/monoruby/src/codegen/vmgen.rs
@@ -218,9 +218,9 @@ impl Codegen {
 
         let add_rr = self.vm_binops_opt(Self::int_add, add_values);
         let sub_rr = self.vm_binops_opt(Self::int_sub, sub_values);
-        let or_rr = self.vm_binops_opt(Self::int_or, bitor_values);
-        let and_rr = self.vm_binops_opt(Self::int_and, bitand_values);
-        let xor_rr = self.vm_binops_opt(Self::int_xor, bitxor_values);
+        let or_rr = self.vm_binops(bitor_values);
+        let and_rr = self.vm_binops(bitand_values);
+        let xor_rr = self.vm_binops(bitxor_values);
         let div_rr = self.vm_binops(div_values);
         let mul_rr = self.vm_binops(mul_values);
         let rem_rr = self.vm_binops(rem_values);
@@ -1208,28 +1208,6 @@ impl Codegen {
             subq rax, rsi;
             jo generic;
             addb rax, 1;
-        };
-    }
-
-    fn int_or(&mut self, _generic: DestLabel) {
-        monoasm! { &mut self.jit,
-            movq rax, rdi;
-            orq rax, rsi;
-        };
-    }
-
-    fn int_and(&mut self, _generic: DestLabel) {
-        monoasm! { &mut self.jit,
-            movq rax, rdi;
-            andq rax, rsi;
-        };
-    }
-
-    fn int_xor(&mut self, _generic: DestLabel) {
-        monoasm! { &mut self.jit,
-            movq rax, rdi;
-            xorq rax, rsi;
-            orb rax, 1;
         };
     }
 

--- a/monoruby/src/executor/op/binary_ops.rs
+++ b/monoruby/src/executor/op/binary_ops.rs
@@ -340,7 +340,9 @@ binop_values_no_opt!(
     (pow, IdentId::_POW),
     (bitor, IdentId::_BOR),
     (bitand, IdentId::_BAND),
-    (bitxor, IdentId::_BXOR)
+    (bitxor, IdentId::_BXOR),
+    (shl, IdentId::_SHL),
+    (shr, IdentId::_SHR)
 );
 
 /// Maximum result size in bits for integer exponentiation (16 GB on 64-bit).
@@ -678,7 +680,10 @@ fn safe_int_shr(lhs: i64, rhs: u64) -> Value {
     if rhs >= 64 {
         Value::integer(if lhs >= 0 { 0 } else { -1 })
     } else {
-        int_shr(lhs, rhs as u32)
+        Value::integer(
+            lhs.checked_shr(rhs as u32)
+                .unwrap_or(if lhs >= 0 { 0 } else { -1 }),
+        )
     }
 }
 
@@ -691,7 +696,11 @@ fn safe_int_shl(lhs: i64, rhs: u64, vm: &mut Executor) -> Option<Value> {
             None
         }
     } else {
-        Some(int_shl(lhs, rhs as u32))
+        let rhs = rhs as u32;
+        Some(match lhs.checked_shl(rhs) {
+            Some(res) if lhs.is_positive() == res.is_positive() => Value::integer(res),
+            _ => bigint_shl(&BigInt::from(lhs), rhs),
+        })
     }
 }
 
@@ -699,7 +708,7 @@ fn safe_bigint_shr(lhs: &BigInt, rhs: u64) -> Value {
     if rhs > u32::MAX as u64 {
         Value::integer(if lhs.is_negative() { -1 } else { 0 })
     } else {
-        bigint_shr(lhs, rhs as u32)
+        Value::bigint(lhs.shr(rhs as u32))
     }
 }
 
@@ -712,27 +721,8 @@ fn safe_bigint_shl(lhs: &BigInt, rhs: u64, vm: &mut Executor) -> Option<Value> {
             None
         }
     } else {
-        Some(bigint_shl(lhs, rhs as u32))
+        Some(Value::bigint(lhs.shl(rhs as u32)))
     }
-}
-
-fn int_shr(lhs: i64, rhs: u32) -> Value {
-    Value::integer(
-        lhs.checked_shr(rhs)
-            .unwrap_or(if lhs >= 0 { 0 } else { -1 }),
-    )
-}
-
-fn int_shl(lhs: i64, rhs: u32) -> Value {
-    match lhs.checked_shl(rhs) {
-        // Work around
-        Some(res) if lhs.is_positive() == res.is_positive() => Value::integer(res),
-        _ => bigint_shl(&BigInt::from(lhs), rhs),
-    }
-}
-
-fn bigint_shr(lhs: &BigInt, rhs: u32) -> Value {
-    Value::bigint(lhs.shr(rhs))
 }
 
 fn bigint_shl(lhs: &BigInt, rhs: u32) -> Value {

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -145,6 +145,8 @@ impl From<BinOpK> for IdentId {
             BinOpK::BitXor => IdentId::_BXOR,
             BinOpK::Rem => IdentId::_REM,
             BinOpK::Exp => IdentId::_POW,
+            BinOpK::Shl => IdentId::_SHL,
+            BinOpK::Shr => IdentId::_SHR,
         }
     }
 }


### PR DESCRIPTION
## Summary

Refactor `Integer#<<` `#>>` `#|` `#&` `#^` so the JIT compiles them through the regular method-resolution path with inline-function code generation, rather than via hard-coded `BinOpK` handling. This makes redefinition correct (handled by the per-method cache, not the BOP escape hatch) while still emitting tight inline assembly when both operands are integers.

## Changes

### Bytecode pipeline
- Add `BinOpK::Shl` (9) and `BinOpK::Shr` (10) so shift operators get a dedicated `TraceIr::BinOp` (with `(lhs_class, rhs_class)` inline cache) instead of being lowered to a `MethodCall`. Opcodes 170–179 shifted to 172–181 to make room.
- VM dispatch for `<<` `>>` `|` `&` `^` now uses the non-BOP path (`vm_binops(*_values)`); the unused `int_or` / `int_and` / `int_xor` helpers are removed.

### JIT compilation
- `JitContext::binary_op` routes `Shl/Shr/BitOr/BitAnd/BitXor` through `call_binary_method`, dispatching to the inline JIT function attached to `Integer#<<` etc.
- Removed the hard-coded BitOr/BitAnd/BitXor and Shl/Shr cases from `binop_integer` / `binop_integer_folded` and from the `IntegerBinOp` assembly emitter.

### Inline JIT functions on `Integer`
- `integer_shl` / `integer_shr`: bail to method dispatch if `rhs_class != Integer`. Handle constant `i64` rhs (positive, negative ⇒ converse direction, and overflow ⇒ deopt). Negative-rhs and large-rhs cases mirror `safe_int_shl` / `safe_int_shr` semantics.
- `integer_bitor` / `integer_bitand` / `integer_bitxor`: bail if `rhs_class != Integer`. For literal fixnum operands (either side, commutative), emit immediate-form `orq/andq/xorq rdi, imm32` when the tagged form fits in `i32`; otherwise load via `movq rsi, imm64` and use the register form.
- Common helper `integer_bitop_inline` factors out the literal-detection and code-emission logic.
- `emit_bitop_imm` takes a `Fixnum` directly and converts via `Value::from(imm).id()`.

### Constant folding
- All five inline functions fold the operation at JIT time when both operands are concrete fixnum literals, using `def_C` to bind the destination slot directly. Shift folding is delegated to `fold_shr` / `fold_shl` / `fold_shl_pos`, which mirror runtime semantics and bail (returning `None`) on BigInt-promoting or runtime-error cases so the inline-asm path takes over.

### Cleanup
- Inline `int_shr` / `int_shl` / `bigint_shr` into their sole callers in `binary_ops.rs`.
- Drop the now-dead `is_u8_literal` helper.

### Tests
Added JIT edge-case and constant-folding tests under `builtins::numeric::integer::tests`:
- `integer_shr_jit_edge_cases`, `integer_shl_jit_edge_cases`
- `integer_bitop_jit_edge_cases`
- `integer_shift_constant_folding`, `integer_bitop_constant_folding`

## Test plan

- [x] `cargo test -p monoruby --lib` (989 passed)
- [x] `cargo build`
- [ ] `bin/test` (full CI suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)