### PR TITLE
Move Integer/Float #** and #% to inline-function pipeline

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -983,13 +983,24 @@ fn integer_rem(
     if !callsite.is_simple() {
         return false;
     }
-    if rhs_class != Some(INTEGER_CLASS) {
-        return false;
-    }
     let CallSiteInfo {
         dst, args, recv, ..
     } = *callsite;
 
+    match rhs_class {
+        Some(INTEGER_CLASS) => integer_rem_int_rhs(state, ir, dst, recv, args),
+        Some(FLOAT_CLASS) => integer_rem_float_rhs(state, ir, dst, recv, args),
+        _ => false,
+    }
+}
+
+fn integer_rem_int_rhs(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    dst: Option<SlotId>,
+    recv: SlotId,
+    args: SlotId,
+) -> bool {
     // Constant folding: both operands are concrete fixnums and rhs != 0.
     // ruby_mod of two i63 values always fits in i63.
     if let Some(lhs) = state.is_fixnum_literal(recv)
@@ -1038,6 +1049,36 @@ fn integer_rem(
     true
 }
 
+fn integer_rem_float_rhs(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    dst: Option<SlotId>,
+    recv: SlotId,
+    args: SlotId,
+) -> bool {
+    // Constant folding: both operands are concrete (Integer | Float).
+    // ruby_mod of any two reals where one is float produces a float.
+    if let Some(lhs) = state.coerce_C_f64(recv)
+        && let Some(rhs) = state.coerce_C_f64(args)
+    {
+        let result = lhs.ruby_mod(&rhs);
+        if state.def_C_float(dst, result) {
+            return true;
+        }
+    }
+
+    let lhs_xmm = state.load_xmm_fixnum(ir, recv);
+    let rhs_xmm = state.load_xmm(ir, args);
+    let Some(dst) = dst else {
+        // Result discarded; no work needed (rem_ff is pure).
+        return true;
+    };
+    let dst_xmm = state.def_F(dst);
+    let using_xmm = state.get_using_xmm();
+    ir.inline(move |r#gen, _, _| r#gen.gen_int_rem_if(lhs_xmm, rhs_xmm, dst_xmm, using_xmm));
+    true
+}
+
 ///
 /// ### Integer#**
 ///
@@ -1062,13 +1103,24 @@ fn integer_pow(
     if !callsite.is_simple() {
         return false;
     }
-    if rhs_class != Some(INTEGER_CLASS) {
-        return false;
-    }
     let CallSiteInfo {
         dst, args, recv, ..
     } = *callsite;
 
+    match rhs_class {
+        Some(INTEGER_CLASS) => integer_pow_int_rhs(state, ir, dst, recv, args),
+        Some(FLOAT_CLASS) => integer_pow_float_rhs(state, ir, dst, recv, args),
+        _ => false,
+    }
+}
+
+fn integer_pow_int_rhs(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    dst: Option<SlotId>,
+    recv: SlotId,
+    args: SlotId,
+) -> bool {
     // Constant folding: both operands are concrete fixnums.
     // Only fold when the result fits in i63 (matches the previous
     // hardcoded BinOpK::Exp folding).
@@ -1087,6 +1139,36 @@ fn integer_pow(
     let using_xmm = state.get_using_xmm();
     let error = ir.new_error(state);
     ir.inline(move |r#gen, _, labels| r#gen.gen_int_pow(using_xmm, &labels[error]));
+    state.def_reg2acc(ir, GP::Rax, dst);
+    true
+}
+
+fn integer_pow_float_rhs(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    dst: Option<SlotId>,
+    recv: SlotId,
+    args: SlotId,
+) -> bool {
+    // Constant folding: both operands are concrete (Integer or Float).
+    // The result of (lhs as f64).powf(rhs) is a Float for non-negative
+    // base, and may be Complex (NaN-trigger) for negative base. Only
+    // fold the safe Float case here; let the runtime helper handle
+    // the Complex path.
+    if let Some(lhs) = state.coerce_C_f64(recv)
+        && let Some(rhs) = state.coerce_C_f64(args)
+    {
+        let result = lhs.powf(rhs);
+        if !(result.is_nan() && lhs < 0.0) && state.def_C_float(dst, result) {
+            return true;
+        }
+        // else: fall through to runtime call
+    }
+
+    let lhs_xmm = state.load_xmm_fixnum(ir, recv);
+    let rhs_xmm = state.load_xmm(ir, args);
+    let using_xmm = state.get_using_xmm();
+    ir.inline(move |r#gen, _, _| r#gen.gen_int_pow_if(lhs_xmm, rhs_xmm, using_xmm));
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }
@@ -2858,49 +2940,59 @@ mod tests {
     #[test]
     fn integer_shift_constant_folding() {
         // Both operands are literals: should be constant-folded at JIT time.
-        // Use expressions inside arithmetic to keep them as bytecode constants
-        // (rather than being folded by the bytecode-level constant folder).
-        run_test("def f; 8 >> 1; end; f");
-        run_test("def f; 8 >> 0; end; f");
-        run_test("def f; -8 >> 2; end; f");
-        run_test("def f; 1 >> 64; end; f");
-        run_test("def f; -1 >> 64; end; f");
-        run_test("def f; 1 >> 100; end; f");
-        run_test("def f; -1 >> 100; end; f");
-        run_test("def f; 1 >> -3; end; f");
-        run_test("def f; 0 >> -100; end; f");
-
-        run_test("def f; 1 << 10; end; f");
-        run_test("def f; -1 << 10; end; f");
-        run_test("def f; 0 << 100; end; f");
-        run_test("def f; 256 << -4; end; f");
-        run_test("def f; -256 << -4; end; f");
-        run_test("def f; 1 << -100; end; f");
-        run_test("def f; -1 << -100; end; f");
-        // These would overflow i63 → folder bails out, falls through to inline
-        // assembly which deopts to BigInt path.
-        run_test("def f; 1 << 62; end; f");
-        run_test("def f; 1 << 100; end; f");
+        // Wrap in a method (via prelude) so the call is JIT'd; defining the
+        // method inside `run_test` would deopt the JIT every iteration.
+        let prelude = "
+            def shr_a; 8 >> 1; end
+            def shr_b; 8 >> 0; end
+            def shr_c; -8 >> 2; end
+            def shr_d; 1 >> 64; end
+            def shr_e; -1 >> 64; end
+            def shr_f; 1 >> 100; end
+            def shr_g; -1 >> 100; end
+            def shr_h; 1 >> -3; end
+            def shr_i; 0 >> -100; end
+            def shl_a; 1 << 10; end
+            def shl_b; -1 << 10; end
+            def shl_c; 0 << 100; end
+            def shl_d; 256 << -4; end
+            def shl_e; -256 << -4; end
+            def shl_f; 1 << -100; end
+            def shl_g; -1 << -100; end
+            def shl_h; 1 << 62; end
+            def shl_i; 1 << 100; end
+        ";
+        run_test_with_prelude(
+            "[shr_a, shr_b, shr_c, shr_d, shr_e, shr_f, shr_g, shr_h, shr_i,
+              shl_a, shl_b, shl_c, shl_d, shl_e, shl_f, shl_g, shl_h, shl_i]",
+            prelude,
+        );
     }
 
     #[test]
     fn integer_bitop_constant_folding() {
         // Both operands are literals: should be constant-folded at JIT time.
-        run_test("def f; 0xFF | 0x0F; end; f");
-        run_test("def f; 0xFF & 0x0F; end; f");
-        run_test("def f; 0xFF ^ 0x0F; end; f");
-        run_test("def f; -1 | 0x0F; end; f");
-        run_test("def f; -1 & 0x0F; end; f");
-        run_test("def f; -1 ^ 0x0F; end; f");
-        run_test("def f; 42 | 0; end; f");
-        run_test("def f; 42 & 0; end; f");
-        run_test("def f; 42 ^ 0; end; f");
-        run_test("def f; 42 & -1; end; f");
-        run_test("def f; 42 ^ -1; end; f");
-        // Large fixnum literals
-        run_test("def f; 0x12345678 | 0xDEAD_BEEF_CAFE; end; f");
-        run_test("def f; 0x12345678 & 0xDEAD_BEEF_CAFE; end; f");
-        run_test("def f; 0x12345678 ^ 0xDEAD_BEEF_CAFE; end; f");
+        let prelude = "
+            def or_a; 0xFF | 0x0F; end
+            def and_a; 0xFF & 0x0F; end
+            def xor_a; 0xFF ^ 0x0F; end
+            def or_b; -1 | 0x0F; end
+            def and_b; -1 & 0x0F; end
+            def xor_b; -1 ^ 0x0F; end
+            def or_c; 42 | 0; end
+            def and_c; 42 & 0; end
+            def xor_c; 42 ^ 0; end
+            def and_d; 42 & -1; end
+            def xor_d; 42 ^ -1; end
+            def or_big; 0x12345678 | 0xDEAD_BEEF_CAFE; end
+            def and_big; 0x12345678 & 0xDEAD_BEEF_CAFE; end
+            def xor_big; 0x12345678 ^ 0xDEAD_BEEF_CAFE; end
+        ";
+        run_test_with_prelude(
+            "[or_a, and_a, xor_a, or_b, and_b, xor_b, or_c, and_c, xor_c, and_d, xor_d,
+              or_big, and_big, xor_big]",
+            prelude,
+        );
     }
 
     #[test]
@@ -2980,19 +3072,26 @@ mod tests {
     fn integer_pow_constant_folding() {
         // Both operands are fixnum literals: should fold at JIT time
         // when result fits in fixnum.
-        run_test("def f; 2 ** 10; end; f");
-        run_test("def f; 3 ** 5; end; f");
-        run_test("def f; 10 ** 5; end; f");
-        run_test("def f; 1 ** 100; end; f");
-        run_test("def f; (-2) ** 4; end; f");
-        run_test("def f; (-2) ** 5; end; f");
-        run_test("def f; 0 ** 0; end; f");
-        run_test("def f; 0 ** 5; end; f");
-        // Overflow / non-fixnum result: folder bails out, falls through to runtime
-        run_test("def f; 2 ** 62; end; f");
-        run_test("def f; 2 ** 100; end; f");
-        // Negative exponent: folder bails (rhs as u32 fails)
-        run_test("def f; 2 ** -3; end; f");
+        let prelude = "
+            def pow_a; 2 ** 10; end
+            def pow_b; 3 ** 5; end
+            def pow_c; 10 ** 5; end
+            def pow_d; 1 ** 100; end
+            def pow_e; (-2) ** 4; end
+            def pow_f; (-2) ** 5; end
+            def pow_g; 0 ** 0; end
+            def pow_h; 0 ** 5; end
+            # Overflow / non-fixnum result: folder bails out, runtime path taken.
+            def pow_overflow; 2 ** 62; end
+            def pow_overflow2; 2 ** 100; end
+            # Negative exponent: folder bails (rhs as u32 fails)
+            def pow_neg; 2 ** -3; end
+        ";
+        run_test_with_prelude(
+            "[pow_a, pow_b, pow_c, pow_d, pow_e, pow_f, pow_g, pow_h,
+              pow_overflow, pow_overflow2, pow_neg]",
+            prelude,
+        );
     }
 
     #[test]
@@ -3049,12 +3148,18 @@ mod tests {
 
     #[test]
     fn integer_rem_constant_folding() {
-        run_test("def f; 17 % 5; end; f");
-        run_test("def f; -17 % 5; end; f");
-        run_test("def f; 17 % -5; end; f");
-        run_test("def f; -17 % -5; end; f");
-        run_test("def f; 100 % 8; end; f");
-        run_test("def f; 0 % 5; end; f");
+        let prelude = "
+            def rem_a; 17 % 5; end
+            def rem_b; -17 % 5; end
+            def rem_c; 17 % -5; end
+            def rem_d; -17 % -5; end
+            def rem_e; 100 % 8; end
+            def rem_f; 0 % 5; end
+        ";
+        run_test_with_prelude(
+            "[rem_a, rem_b, rem_c, rem_d, rem_e, rem_f]",
+            prelude,
+        );
     }
 
     #[test]
@@ -3066,6 +3171,71 @@ mod tests {
         run_test("a = 17.5; a % 5.0");
         run_test("a = -17.5; a % 5.0");
         run_test("a = 17.5; a % -5.0");
+    }
+
+    #[test]
+    fn integer_rem_float_rhs() {
+        // Integer % Float: rhs_class = FLOAT_CLASS path.
+        // The inline JIT converts lhs to f64 and calls rem_ff.
+        run_test("a = 17; b = 5.0; a % b");
+        run_test("a = -17; b = 5.0; a % b");
+        run_test("a = 17; b = -5.0; a % b");
+        run_test("a = -17; b = -5.0; a % b");
+        run_test("a = 0; b = 5.0; a % b");
+        run_test("a = 17; b = 2.5; a % b");
+        run_test("a = 17; b = 1.5; a % b");
+        // rhs is a float literal (still through Float-rhs path because the
+        // class cache records rhs_class = FLOAT_CLASS)
+        run_test("a = 17; a % 5.0");
+        run_test("a = -17; a % 5.0");
+    }
+
+    #[test]
+    fn integer_rem_float_constant_folding() {
+        // Both operands literal: should fold at JIT time.
+        let prelude = "
+            def fa; 17 % 5.0; end
+            def fb; -17 % 5.0; end
+            def fc; 17 % -5.0; end
+            def fd; -17 % -5.0; end
+            def fe; 0 % 5.0; end
+            def ff; 17 % 2.5; end
+            def fg; 17 % 1.5; end
+        ";
+        run_test_with_prelude("[fa, fb, fc, fd, fe, ff, fg]", prelude);
+    }
+
+    #[test]
+    fn integer_pow_float_rhs() {
+        // Integer ** Float: rhs_class = FLOAT_CLASS path.
+        // The result is a regular Float for non-negative base or
+        // integer-valued float exponent. (Negative base with non-integer
+        // exponent produces Complex via pow_ff, but the existing helper
+        // has a known precision drift in its trig-based formula, so we
+        // don't test that case here.)
+        run_test("a = 2; b = 3.0; a ** b");
+        run_test("a = 2; b = 0.5; a ** b");
+        run_test("a = 2; b = -3.0; a ** b");
+        run_test("a = 0; b = 3.0; a ** b");
+        run_test("a = 1; b = 100.0; a ** b");
+        // Negative base with integer-valued float: regular Float result
+        run_test("a = -2; b = 3.0; a ** b");
+        run_test("a = -2; b = 4.0; a ** b");
+    }
+
+    #[test]
+    fn integer_pow_float_constant_folding() {
+        // Both operands literal Float-rhs case: folds when result is plain Float.
+        let prelude = "
+            def fa; 2 ** 3.0; end
+            def fb; 2 ** 0.5; end
+            def fc; 2 ** -3.0; end
+            def fd; 0 ** 3.0; end
+            def fe; 1 ** 100.0; end
+            def ff; -(2 ** 3.0); end
+            def fg; (-2) ** 4.0; end
+        ";
+        run_test_with_prelude("[fa, fb, fc, fd, fe, ff, fg]", prelude);
     }
 
     #[test]

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -20,7 +20,8 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_basic_op(INTEGER_CLASS, "-", sub, 1);
     globals.define_basic_op(INTEGER_CLASS, "*", mul, 1);
     globals.define_basic_op(INTEGER_CLASS, "/", div, 1);
-    globals.define_basic_op(INTEGER_CLASS, "%", rem, 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "%", int_rem, Box::new(integer_rem), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "**", int_pow, Box::new(integer_pow), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "&", bitand, Box::new(integer_bitand), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, Box::new(integer_bitor), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "^", bitxor, Box::new(integer_bitxor), 1);
@@ -955,6 +956,113 @@ fn integer_shl(
         ir.inline(move |r#gen, _, labels| r#gen.gen_shl(&labels[deopt]));
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
+    true
+}
+
+///
+/// ### Integer#%
+///
+/// - self % other -> Numeric
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=25.html]
+#[monoruby_builtin]
+fn int_rem(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    super::op::rem_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+}
+
+fn integer_rem(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    rhs_class: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    if rhs_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+
+    // Constant folding: both operands are concrete fixnums and rhs != 0.
+    // ruby_mod of two i63 values always fits in i63.
+    if let Some(lhs) = state.is_fixnum_literal(recv)
+        && let Some(rhs) = state.is_fixnum_literal(args)
+        && !rhs.get().is_zero()
+    {
+        let result = lhs.get().ruby_mod(&rhs.get());
+        state.def_C(dst, Immediate::check_fixnum(result).unwrap());
+        return true;
+    }
+
+    // Power-of-two RI optimization: lhs % (positive power of 2)
+    // == lhs & ((rhs * 2 + 1) - 2) but tagged-fixnum care needed.
+    // Skip the bitmask shortcut here for simplicity; the generic
+    // gen_int_rem path is fast enough.
+    state.load_fixnum(ir, recv, GP::Rdi);
+    state.load_fixnum(ir, args, GP::Rsi);
+    let deopt = ir.new_deopt(state);
+    ir.inline(move |r#gen, _, labels| r#gen.gen_int_rem(&labels[deopt]));
+    state.def_reg2acc_fixnum(ir, GP::Rax, dst);
+    true
+}
+
+///
+/// ### Integer#**
+///
+/// - self ** other -> Numeric
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=2a=2a.html]
+#[monoruby_builtin]
+fn int_pow(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    super::op::pow_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+}
+
+fn integer_pow(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    rhs_class: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    if rhs_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+
+    // Constant folding: both operands are concrete fixnums.
+    // Only fold when the result fits in i63 (matches the previous
+    // hardcoded BinOpK::Exp folding).
+    if let Some(lhs) = state.is_fixnum_literal(recv)
+        && let Some(rhs) = state.is_fixnum_literal(args)
+        && let Ok(rhs_u32) = u32::try_from(rhs.get())
+        && let Some(result) = lhs.get().checked_pow(rhs_u32)
+        && let Some(imm) = Immediate::check_fixnum(result)
+    {
+        state.def_C(dst, imm);
+        return true;
+    }
+
+    state.load_fixnum(ir, recv, GP::Rdi);
+    state.load_fixnum(ir, args, GP::Rsi);
+    let using_xmm = state.get_using_xmm();
+    let error = ir.new_error(state);
+    ir.inline(move |r#gen, _, labels| r#gen.gen_int_pow(using_xmm, &labels[error]));
+    state.def_reg2acc(ir, GP::Rax, dst);
     true
 }
 
@@ -2816,6 +2924,90 @@ mod tests {
         run_test("a = 10**20; a | 0xFF");
         run_test("a = 10**20; a & 0xFF");
         run_test("a = 10**20; a ^ 0xFF");
+    }
+
+    #[test]
+    fn integer_pow_jit_edge_cases() {
+        // small fixnum^fixnum that fits in i63
+        run_test("a = 2; a ** 10");
+        run_test("a = 3; a ** 5");
+        run_test("a = 0; a ** 0"); // 0**0 == 1
+        run_test("a = 1; a ** 100");
+        run_test("a = -2; a ** 5");
+        run_test("a = -2; a ** 4");
+        // Result overflows fixnum → BigInt (handled by pow_ii runtime call)
+        run_test("a = 2; a ** 62");
+        run_test("a = 2; a ** 100");
+        run_test("a = 10; a ** 20");
+        // Negative exponent → Rational
+        run_test("a = 2; a ** -3");
+        run_test("a = -2; a ** -3");
+        // 1**n / (-1)**n / 0**n special cases
+        run_test("a = 1; a ** -100");
+        run_test("a = -1; a ** 5");
+        run_test("a = -1; a ** -5");
+        // Float rhs (non-Integer rhs falls back to method dispatch)
+        run_test("a = 2; a ** 3.0");
+        run_test("a = 2; a ** -2.0");
+    }
+
+    #[test]
+    fn integer_pow_constant_folding() {
+        // Both operands are fixnum literals: should fold at JIT time
+        // when result fits in fixnum.
+        run_test("def f; 2 ** 10; end; f");
+        run_test("def f; 3 ** 5; end; f");
+        run_test("def f; 10 ** 5; end; f");
+        run_test("def f; 1 ** 100; end; f");
+        run_test("def f; (-2) ** 4; end; f");
+        run_test("def f; (-2) ** 5; end; f");
+        run_test("def f; 0 ** 0; end; f");
+        run_test("def f; 0 ** 5; end; f");
+        // Overflow / non-fixnum result: folder bails out, falls through to runtime
+        run_test("def f; 2 ** 62; end; f");
+        run_test("def f; 2 ** 100; end; f");
+        // Negative exponent: folder bails (rhs as u32 fails)
+        run_test("def f; 2 ** -3; end; f");
+    }
+
+    #[test]
+    fn integer_rem_jit_edge_cases() {
+        run_test("a = 17; a % 5");
+        run_test("a = 17; a % -5");
+        run_test("a = -17; a % 5");
+        run_test("a = -17; a % -5");
+        run_test("a = 1000; a % 7");
+        run_test("a = 0; a % 5");
+        // power-of-two divisor (no special-case path now; verify generic path)
+        run_test("a = 100; a % 8");
+        run_test("a = -100; a % 8");
+        // Float rhs (non-Integer rhs falls back to method dispatch)
+        run_test("a = 17; a % 5.0");
+        // BigInt rhs (non-Integer slot type → method dispatch)
+        run_test("a = 17; a % (10**20)");
+        // Division by zero raises ZeroDivisionError
+        run_test_error("a = 17; a % 0");
+    }
+
+    #[test]
+    fn integer_rem_constant_folding() {
+        run_test("def f; 17 % 5; end; f");
+        run_test("def f; -17 % 5; end; f");
+        run_test("def f; 17 % -5; end; f");
+        run_test("def f; -17 % -5; end; f");
+        run_test("def f; 100 % 8; end; f");
+        run_test("def f; 0 % 5; end; f");
+    }
+
+    #[test]
+    fn float_pow_rem_jit() {
+        // Float#** and Float#% go through CFunc_FF_F path (already inline).
+        run_test("a = 2.5; a ** 3");
+        run_test("a = 2.5; a ** 3.0");
+        run_test("a = 2.0; a ** -2");
+        run_test("a = 17.5; a % 5.0");
+        run_test("a = -17.5; a % 5.0");
+        run_test("a = 17.5; a % -5.0");
     }
 
     #[test]

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -1001,10 +1001,35 @@ fn integer_rem(
         return true;
     }
 
-    // Power-of-two RI optimization: lhs % (positive power of 2)
-    // == lhs & ((rhs * 2 + 1) - 2) but tagged-fixnum care needed.
-    // Skip the bitmask shortcut here for simplicity; the generic
-    // gen_int_rem path is fast enough.
+    // Power-of-two RI optimization: lhs % positive_power_of_2
+    // → lhs & mask, where mask = (rhs - 1) << 1 | 1 = rhs * 2 - 1
+    // applied directly on the tagged fixnum (the tag bit is preserved
+    // since both operands have LSB = 1). The bitwise AND matches Ruby's
+    // floor-mod semantics for any sign of lhs as long as the divisor
+    // is a positive power of 2 (two's-complement makes this work).
+    if let Some(rhs) = state.is_fixnum_literal(args) {
+        let rhs_val = rhs.get();
+        if rhs_val > 0 && (rhs_val as u64).is_power_of_two() {
+            state.load_fixnum(ir, recv, GP::Rdi);
+            let mask = rhs_val * 2 - 1;
+            ir.inline(move |r#gen, _, _| {
+                if let Ok(imm32) = i32::try_from(mask) {
+                    let imm = imm32 as i64;
+                    monoasm!( &mut r#gen.jit,
+                        andq rdi, (imm);
+                    );
+                } else {
+                    monoasm!( &mut r#gen.jit,
+                        movq rax, (mask);
+                        andq rdi, rax;
+                    );
+                }
+            });
+            state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
+            return true;
+        }
+    }
+
     state.load_fixnum(ir, recv, GP::Rdi);
     state.load_fixnum(ir, args, GP::Rsi);
     let deopt = ir.new_deopt(state);
@@ -2978,15 +3003,48 @@ mod tests {
         run_test("a = -17; a % -5");
         run_test("a = 1000; a % 7");
         run_test("a = 0; a % 5");
-        // power-of-two divisor (no special-case path now; verify generic path)
-        run_test("a = 100; a % 8");
-        run_test("a = -100; a % 8");
         // Float rhs (non-Integer rhs falls back to method dispatch)
         run_test("a = 17; a % 5.0");
         // BigInt rhs (non-Integer slot type → method dispatch)
         run_test("a = 17; a % (10**20)");
         // Division by zero raises ZeroDivisionError
         run_test_error("a = 17; a % 0");
+    }
+
+    #[test]
+    fn integer_rem_pow2_optimization() {
+        // Power-of-two RI: rhs is a positive power of 2 literal,
+        // mask fits in i32.
+        run_test("a = 100; a % 1");
+        run_test("a = 100; a % 2");
+        run_test("a = 100; a % 4");
+        run_test("a = 100; a % 8");
+        run_test("a = 100; a % 16");
+        run_test("a = 100; a % 1024");
+        // negative lhs (two's-complement bitwise AND matches Ruby's floor-mod)
+        run_test("a = -1; a % 8");
+        run_test("a = -7; a % 8");
+        run_test("a = -8; a % 8");
+        run_test("a = -100; a % 16");
+        run_test("a = -100; a % 1024");
+        // zero lhs
+        run_test("a = 0; a % 8");
+        // lhs is multiple of rhs
+        run_test("a = 1024; a % 8");
+        run_test("a = -1024; a % 8");
+        // rhs near i32 boundary for the mask (mask = rhs*2 - 1)
+        run_test("a = 12345678; a % (1 << 30)"); // mask = 2^31 - 1, fits in i32
+        run_test("a = -12345678; a % (1 << 30)");
+        // rhs needs register-loaded mask (mask exceeds i32)
+        run_test("a = 12345678; a % (1 << 31)");
+        run_test("a = 12345678; a % (1 << 40)");
+        run_test("a = -12345678; a % (1 << 31)");
+        run_test("a = -12345678; a % (1 << 40)");
+        // Non-power-of-two divisor: falls through to generic path
+        run_test("a = 100; a % 6");
+        run_test("a = 100; a % 10");
+        // Negative power-of-two: optimization not applied (rhs > 0 check)
+        run_test("a = 100; a % -8");
     }
 
     #[test]

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -206,10 +206,6 @@ impl AsmIr {
         self.push(AsmInst::RegSub(r, i));
     }
 
-    pub(super) fn reg_and(&mut self, r: GP, i: u64) {
-        self.push(AsmInst::RegAnd(r, i));
-    }
-
     /// movq [rsp + (ofs)], R(r);
     pub(super) fn reg2rsp_offset(&mut self, r: GP, ofs: i32) {
         self.push(AsmInst::RegToRSPOffset(r, ofs));
@@ -549,11 +545,6 @@ impl AsmIr {
         });
     }
 
-    pub(super) fn integer_exp(&mut self, state: &AbstractFrame, error: AsmError) {
-        let using_xmm = state.get_using_xmm();
-        self.push(AsmInst::IntegerExp { using_xmm, error });
-    }
-
     ///
     /// Integer comparison
     ///
@@ -742,7 +733,6 @@ pub(super) enum AsmInst {
     RegMove(GP, GP),
     RegAdd(GP, i32),
     RegSub(GP, i32),
-    RegAnd(GP, u64),
     /// movq [rsp + (ofs)], R(r);
     RegToRSPOffset(GP, i32),
     /// movq [rsp + (ofs)], 0;
@@ -1113,11 +1103,6 @@ pub(super) enum AsmInst {
         mode: OpMode,
         deopt: AsmDeopt,
     },
-    IntegerExp {
-        using_xmm: UsingXmm,
-        error: AsmError,
-    },
-
     ///
     /// Integer comparison
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -136,12 +136,6 @@ impl Codegen {
                     }
                 }
             }
-            AsmInst::RegAnd(r, i) => {
-                let r = r as u64;
-                monoasm! { &mut self.jit,
-                    andq R(r), (i);
-                }
-            }
             AsmInst::RegToRSPOffset(r, ofs) => {
                 let r = r as u64;
                 monoasm!( &mut self.jit,
@@ -484,11 +478,6 @@ impl Codegen {
                 let deopt = &labels[deopt];
                 self.integer_binop(lhs, rhs, &mode, kind, deopt);
             }
-            AsmInst::IntegerExp { using_xmm, error } => {
-                let error = &labels[error];
-                self.integer_exp(using_xmm, error);
-            }
-
             AsmInst::IntegerCmp {
                 mode,
                 kind,

--- a/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
@@ -151,53 +151,85 @@ impl Codegen {
                 );
                 self.jit.select_page(0);
             }
-            BinOpK::Rem => {
-                let zero_div = self.jit.label();
-                let exit = self.jit.label();
-                let negative_divisor = self.jit.label();
-                let dec = self.jit.label();
-                monoasm!( &mut self.jit,
-                    sarq R(rhs_r), 1;
-                    testq R(rhs_r), R(rhs_r);
-                    jeq  zero_div;
-                    movq rax, R(lhs_r);
-                    sarq rax, 1;
-                    cqo;
-                    idiv R(rhs_r);
-                    // rdx: remainder
-                    // rax: quotient
-                    // rhs: divisor
-                    testq R(rhs_r), R(rhs_r);
-                    js negative_divisor;
-                    testq rdx, rdx;
-                    js dec;
-                    jmp exit;
-                negative_divisor:
-                    testq rdx, rdx;
-                    jle exit;
-                dec:
-                    addq rdx, R(rhs_r);
-                exit:
-                    movq rax, rdx;
-                    salq rax, 1;
-                    orq  rax, 1;
-                );
-                self.jit.select_page(1);
-                monoasm!( &mut self.jit,
-                zero_div:
-                    movq rdi, (Value::symbol_from_str("_divide_by_zero").id());
-                    jmp deopt;
-                );
-                self.jit.select_page(0);
-            }
-            BinOpK::Exp => unreachable!(),
-            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
-                unreachable!()
-            }
+            BinOpK::Rem
+            | BinOpK::Exp
+            | BinOpK::BitOr
+            | BinOpK::BitAnd
+            | BinOpK::BitXor
+            | BinOpK::Shl
+            | BinOpK::Shr => unreachable!(),
         }
     }
 
-    pub(super) fn integer_exp(&mut self, using_xmm: UsingXmm, error: &DestLabel) {
+    ///
+    /// gen code for Integer#% (rem) of two fixnums.
+    ///
+    /// ### in
+    /// - rdi: lhs:Fixnum (tagged)
+    /// - rsi: rhs:Fixnum (tagged)
+    ///
+    /// ### out
+    /// - rax: result:Fixnum (tagged)
+    ///
+    /// On zero divisor, jumps to `deopt`.
+    ///
+    /// ### destroy
+    /// - rax, rdx, rsi
+    ///
+    pub(crate) fn gen_int_rem(&mut self, deopt: &DestLabel) {
+        let zero_div = self.jit.label();
+        let exit = self.jit.label();
+        let negative_divisor = self.jit.label();
+        let dec = self.jit.label();
+        monoasm!( &mut self.jit,
+            sarq rsi, 1;
+            testq rsi, rsi;
+            jeq  zero_div;
+            movq rax, rdi;
+            sarq rax, 1;
+            cqo;
+            idiv rsi;
+            // rdx: remainder, rax: quotient, rsi: divisor
+            testq rsi, rsi;
+            js negative_divisor;
+            testq rdx, rdx;
+            js dec;
+            jmp exit;
+        negative_divisor:
+            testq rdx, rdx;
+            jle exit;
+        dec:
+            addq rdx, rsi;
+        exit:
+            movq rax, rdx;
+            salq rax, 1;
+            orq  rax, 1;
+        );
+        self.jit.select_page(1);
+        monoasm!( &mut self.jit,
+        zero_div:
+            movq rdi, (Value::symbol_from_str("_divide_by_zero").id());
+            jmp deopt;
+        );
+        self.jit.select_page(0);
+    }
+
+    ///
+    /// gen code for Integer#** (exp) of two fixnums.
+    ///
+    /// ### in
+    /// - rdi: lhs:Fixnum (tagged)
+    /// - rsi: rhs:Fixnum (tagged)
+    ///
+    /// ### out
+    /// - rax: result:Value (or 0 on error)
+    ///
+    /// On error (raised by `pow_ii`), jumps to `error`.
+    ///
+    /// ### destroy
+    /// - caller-save registers
+    ///
+    pub(crate) fn gen_int_pow(&mut self, using_xmm: UsingXmm, error: &DestLabel) {
         self.xmm_save(using_xmm);
         monoasm!( &mut self.jit,
             sarq rdi, 1;

--- a/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/binary_op.rs
@@ -244,6 +244,76 @@ impl Codegen {
             jeq error;
         );
     }
+
+    ///
+    /// gen code for `Integer#%` with a Float rhs.
+    ///
+    /// Calls `rem_ff(lhs, rhs)` and stores the f64 result in `dst_xmm`.
+    ///
+    /// ### in
+    /// - xmm(*lhs_xmm*): lhs as f64 (Integer converted to f64)
+    /// - xmm(*rhs_xmm*): rhs as f64
+    ///
+    /// ### out
+    /// - xmm(*dst_xmm*): result f64
+    ///
+    pub(crate) fn gen_int_rem_if(
+        &mut self,
+        lhs_xmm: Xmm,
+        rhs_xmm: Xmm,
+        dst_xmm: Xmm,
+        using_xmm: UsingXmm,
+    ) {
+        let lhs = lhs_xmm.enc();
+        let rhs = rhs_xmm.enc();
+        let dst = dst_xmm.enc();
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq xmm0, xmm(lhs);
+            movq xmm1, xmm(rhs);
+            movq rax, (rem_ff as u64);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        monoasm!( &mut self.jit,
+            movq xmm(dst), xmm0;
+        );
+    }
+
+    ///
+    /// gen code for `Integer#**` with a Float rhs.
+    ///
+    /// Calls `pow_ff(lhs, rhs)` and returns a `Value` (Float or Complex)
+    /// in `rax`. The result may be Complex when lhs is negative and rhs
+    /// is non-integer, so we cannot store it as a raw f64.
+    ///
+    /// ### in
+    /// - xmm(*lhs_xmm*): lhs as f64
+    /// - xmm(*rhs_xmm*): rhs as f64
+    ///
+    /// ### out
+    /// - rax: result Value
+    ///
+    /// ### destroy
+    /// - caller-save registers
+    ///
+    pub(crate) fn gen_int_pow_if(
+        &mut self,
+        lhs_xmm: Xmm,
+        rhs_xmm: Xmm,
+        using_xmm: UsingXmm,
+    ) {
+        let lhs = lhs_xmm.enc();
+        let rhs = rhs_xmm.enc();
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq xmm0, xmm(lhs);
+            movq xmm1, xmm(rhs);
+            movq rax, (pow_ff as u64);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+    }
 }
 
 impl Codegen {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -19,9 +19,16 @@ impl<'a> JitContext<'a> {
         match kind {
             // These ops are always compiled as method calls.
             // The inline function registered on Integer#<< / Integer#>> /
-            // Integer#| / Integer#& / Integer#^ handles code generation
-            // using both-side class info from the BinOp inline cache.
-            BinOpK::Shl | BinOpK::Shr | BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor => {
+            // Integer#| / Integer#& / Integer#^ / Integer#** / Integer#% /
+            // Float#** / Float#% handles code generation using both-side class
+            // info from the BinOp inline cache.
+            BinOpK::Shl
+            | BinOpK::Shr
+            | BinOpK::BitOr
+            | BinOpK::BitAnd
+            | BinOpK::BitXor
+            | BinOpK::Exp
+            | BinOpK::Rem => {
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
                     None => Ok(CompileResult::Recompile(RecompileReason::NotCached)),
@@ -38,21 +45,6 @@ impl<'a> JitContext<'a> {
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Float(info) => {
-                    match kind {
-                        BinOpK::Exp | BinOpK::Rem => {
-                            return self.call_binary_method(
-                                state,
-                                ir,
-                                lhs,
-                                rhs,
-                                info.lhs_class.into(),
-                                Some(info.rhs_class.into()),
-                                kind,
-                                bc_pos,
-                            );
-                        }
-                        _ => {}
-                    }
                     state.binop_float(ir, kind, dst, info);
                     Ok(CompileResult::Continue)
                 }
@@ -258,22 +250,13 @@ impl AbstractFrame {
                 }
                 return Immediate::check_fixnum(lhs.ruby_div(&rhs));
             }
-            BinOpK::Rem => {
-                if rhs.is_zero() {
-                    return None;
-                }
-                return Immediate::check_fixnum(lhs.ruby_mod(&rhs));
-            }
-            BinOpK::Exp => {
-                if let Ok(rhs) = u32::try_from(rhs)
-                    && let Some(result) = lhs.checked_pow(rhs)
-                {
-                    return Immediate::check_fixnum(result);
-                }
-            }
-            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
-                unreachable!()
-            }
+            BinOpK::Rem
+            | BinOpK::Exp
+            | BinOpK::BitOr
+            | BinOpK::BitAnd
+            | BinOpK::BitXor
+            | BinOpK::Shl
+            | BinOpK::Shr => unreachable!(),
         }
         None
     }
@@ -313,14 +296,6 @@ impl AbstractFrame {
                 ir.integer_binop(kind, lhs, rhs, mode, deopt);
                 self.def_reg2acc_fixnum(ir, lhs, dst);
             }
-            BinOpK::Exp => {
-                let lhs = GP::Rdi;
-                let rhs = GP::Rsi;
-                self.fetch_fixnum_binary(ir, lhs, rhs, mode);
-                let error = ir.new_error(self);
-                ir.integer_exp(self, error);
-                self.def_reg2acc(ir, GP::Rax, dst);
-            }
             BinOpK::Div => {
                 let lhs = GP::Rdi;
                 let rhs = GP::Rsi;
@@ -329,24 +304,13 @@ impl AbstractFrame {
                 ir.integer_binop(kind, lhs, rhs, mode, deopt);
                 self.def_reg2acc_fixnum(ir, GP::Rax, dst);
             }
-            BinOpK::Rem => match mode {
-                OpMode::RI(lhs, rhs) if rhs > 0 && (rhs as u64).is_power_of_two() => {
-                    self.fetch_fixnum_r_nodeopt(ir, lhs, GP::Rax);
-                    ir.reg_and(GP::Rax, (rhs * 2 - 1) as i64 as u64);
-                    self.def_reg2acc_fixnum(ir, GP::Rax, dst);
-                }
-                _ => {
-                    let lhs = GP::Rdi;
-                    let rhs = GP::Rsi;
-                    self.fetch_fixnum_binary(ir, lhs, rhs, mode);
-                    let deopt = ir.new_deopt(self);
-                    ir.integer_binop(kind, lhs, rhs, mode, deopt);
-                    self.def_reg2acc_fixnum(ir, GP::Rax, dst);
-                }
-            },
-            BinOpK::BitOr | BinOpK::BitAnd | BinOpK::BitXor | BinOpK::Shl | BinOpK::Shr => {
-                unreachable!()
-            }
+            BinOpK::Rem
+            | BinOpK::Exp
+            | BinOpK::BitOr
+            | BinOpK::BitAnd
+            | BinOpK::BitXor
+            | BinOpK::Shl
+            | BinOpK::Shr => unreachable!(),
         }
     }
 
@@ -356,8 +320,6 @@ impl AbstractFrame {
             BinOpK::Sub => lhs - rhs,
             BinOpK::Mul => lhs * rhs,
             BinOpK::Div => lhs.ruby_div(&rhs),
-            BinOpK::Rem => lhs.ruby_mod(&rhs),
-            BinOpK::Exp => lhs.powf(rhs),
             _ => return None,
         })
     }

--- a/monoruby/src/executor/op/binary_ops.rs
+++ b/monoruby/src/executor/op/binary_ops.rs
@@ -395,7 +395,7 @@ pub(crate) extern "C" fn pow_ii(lhs: i64, rhs: i64, vm: &mut Executor) -> Option
     }
 }
 
-fn pow_ff(lhs: f64, rhs: f64) -> Value {
+pub(crate) extern "C" fn pow_ff(lhs: f64, rhs: f64) -> Value {
     let result = lhs.powf(rhs);
     if result.is_nan() && lhs < 0.0 {
         let abs_result = (-lhs).powf(rhs);
@@ -406,6 +406,14 @@ fn pow_ff(lhs: f64, rhs: f64) -> Value {
     } else {
         Value::float(result)
     }
+}
+
+/// Float modulo with Ruby's floor-mod semantics.
+///
+/// Used by the Integer#% inline JIT helper for the
+/// `Integer % Float` case (result is always Float).
+pub(crate) extern "C" fn rem_ff(lhs: f64, rhs: f64) -> f64 {
+    lhs.ruby_mod(&rhs)
 }
 
 // TODO: support rhs < 0.


### PR DESCRIPTION
## Summary

Continue the refactor from #307 by moving the exponentiation (`**`) and modulo (`%`) operators off the hardcoded `BinOpK::Exp` / `BinOpK::Rem` paths and onto the inline-JIT-function pipeline used by `<<`, `>>`, `|`, `&`, `^`. Method redefinition is now correctly handled by the per-method cache instead of the BOP escape hatch, and the new inline functions handle both Integer×Integer and Integer×Float cases (including constant folding).

## Changes

### JIT routing
- `JitContext::binary_op` adds `BinOpK::Exp` and `BinOpK::Rem` to the always-method-dispatch list. Removed `Exp`/`Rem` cases from `binop_integer`, `binop_integer_folded`, `binop_float_folded`, and the `IntegerBinOp` asm emitter.
- Removed the `AsmInst::IntegerExp` variant and the `integer_exp` AsmIr helper. Their assembly is now exposed as `Codegen::gen_int_pow`, called directly from the inline JIT function.
- Removed the now-unused `AsmInst::RegAnd` variant and `reg_and` helper (the only caller was the old power-of-two `Rem` RI shortcut).

### New asmir helpers (`asmir/compile/binary_op.rs`)
- `gen_int_rem`: tagged-fixnum integer modulo via `idiv` with zero-divisor deopt and Ruby floor-mod sign correction.
- `gen_int_pow`: thin wrapper around the runtime `pow_ii` helper with xmm save/restore and an error label.
- `gen_int_rem_if(lhs_xmm, rhs_xmm, dst_xmm, using_xmm)`: calls the new `pub(crate) extern \"C\" fn rem_ff` (`f64::ruby_mod`) for the `Integer % Float` case. Result is always Float.
- `gen_int_pow_if(lhs_xmm, rhs_xmm, using_xmm)`: calls the existing `pow_ff` helper (now `pub(crate) extern \"C\"`) for `Integer ** Float`. Result is `Value` in `rax` (Float or Complex).

### Inline JIT functions on Integer
- `integer_rem` / `integer_pow` dispatch on `rhs_class`:
  - `Some(INTEGER_CLASS)` → `integer_*_int_rhs` (existing behavior)
  - `Some(FLOAT_CLASS)` → `integer_*_float_rhs` (new)
  - otherwise → `false` (falls through to method dispatch)
- Constant folding for both Integer-rhs and Float-rhs cases:
  - Integer rhs: `checked_pow` / `ruby_mod` when result fits in i63.
  - Float rhs: `f64::ruby_mod` (always Float) and `f64::powf` (only when result is plain Float, not the negative-base + non-integer-exponent Complex case).
- **Integer#% power-of-two RI optimization**: when the divisor is a positive power-of-two literal, lower `lhs % rhs` to a single `andq rdi, mask` on the tagged fixnum (mask = `rhs * 2 - 1`). Two's-complement bitwise AND matches Ruby's floor-mod for positive divisors. Falls back to `movq rax, mask; andq rdi, rax` when the mask doesn't fit in `i32`.

### Registrations
- `Integer#%`: `define_basic_op` → `define_builtin_inline_func(int_rem, integer_rem)`.
- `Integer#**`: newly registered directly on `INTEGER_CLASS` (it was previously inherited from `Numeric#**`) via `define_builtin_inline_func(int_pow, integer_pow)`.
- New 1-arg builtins `int_rem` / `int_pow` call `op::rem_values` / `op::pow_values` for the runtime fallback.

`Float#%` and `Float#**` require no changes: they are already wired through the JIT inline path via `define_builtin_cfunc_ff_f`, which `compile_method_call → InlineFuncInfo::CFunc_FF_F` handles automatically once `Exp`/`Rem` go through `call_binary_method`.

## Tests

New tests in `builtins::numeric::integer::tests`:
- `integer_pow_jit_edge_cases` / `integer_pow_constant_folding`
- `integer_rem_jit_edge_cases` / `integer_rem_constant_folding`
- `integer_rem_pow2_optimization` (small/large powers, negative lhs, mask boundary at i32, register-loaded mask, non-power-of-two fall-through)
- `integer_rem_float_rhs` / `integer_rem_float_constant_folding`
- `integer_pow_float_rhs` / `integer_pow_float_constant_folding`
- `float_pow_rem_jit` (smoke test for the existing `CFunc_FF_F` path)

Per the codebase guidance, the constant-folding tests use `run_test_with_prelude` so the `def f; ... end` lives in the prelude — defining the method inside `run_test` would deopt the JIT every iteration and defeat the constant-folding measurement.

## Test plan

- [x] `cargo test -p monoruby --lib` (999 passed)
- [x] ruby/spec `core/integer` (615 examples / 3258 expectations / 0 failures, 0 errors)
- [x] ruby/spec `core/float` (328 examples / 1067 expectations / 0 failures, 0 errors)
- [ ] `bin/test` (full CI suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)