### PR TITLE
Fix core/symbol failures: Symbol#inspect, #to_proc, chilled strings, \xNN literals

### DIFF
--- a/monoruby/builtins/symbol.rb
+++ b/monoruby/builtins/symbol.rb
@@ -84,11 +84,4 @@ class Symbol
   def match?(other, pos = 0)
     self.to_s.match?(other, pos)
   end
-
-  def to_proc
-    m = self
-    lambda do |recv, *args, &blk|
-      recv.public_send(m, *args, &blk)
-    end
-  end
 end

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -146,6 +146,8 @@ pub(super) fn init_encoding(globals: &mut Globals) {
     globals.define_builtin_func(enc.id(), "to_s", enc_to_s, 0);
     globals.define_builtin_func(enc.id(), "inspect", enc_inspect, 0);
     globals.define_builtin_func(enc.id(), "name", enc_to_s, 0);
+    globals.define_builtin_func(enc.id(), "ascii_compatible?", enc_ascii_compatible_p, 0);
+    globals.define_builtin_func(enc.id(), "dummy?", enc_dummy_p, 0);
 }
 
 // -------------------------------------------------------
@@ -664,6 +666,78 @@ fn enc_inspect(
         Some(v) => Ok(v),
         None => Ok(Value::string_from_str("#<Encoding:UTF-8>")),
     }
+}
+
+///
+/// ### Encoding#ascii_compatible?
+/// - ascii_compatible? -> bool
+///
+/// Returns true for encodings whose encoded forms are a superset of ASCII.
+///
+#[monoruby_builtin]
+fn enc_ascii_compatible_p(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let name = globals
+        .store
+        .get_ivar(self_, IdentId::_ENCODING)
+        .and_then(|v| v.is_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+    Ok(Value::bool(is_ascii_compatible_encoding(&name)))
+}
+
+///
+/// ### Encoding#dummy?
+/// - dummy? -> bool
+///
+#[monoruby_builtin]
+fn enc_dummy_p(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let name = globals
+        .store
+        .get_ivar(self_, IdentId::_ENCODING)
+        .and_then(|v| v.is_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+    Ok(Value::bool(is_dummy_encoding(&name)))
+}
+
+fn is_ascii_compatible_encoding(name: &str) -> bool {
+    !matches!(
+        name,
+        "UTF-16"
+            | "UTF-32"
+            | "UTF-16BE"
+            | "UTF-16LE"
+            | "UTF-32BE"
+            | "UTF-32LE"
+            | "ISO-2022-JP"
+            | "STATELESS-ISO-2022-JP"
+            | "CP50220"
+            | "CP50221"
+            | "UTF-7"
+    )
+}
+
+fn is_dummy_encoding(name: &str) -> bool {
+    matches!(
+        name,
+        "UTF-16"
+            | "UTF-32"
+            | "ISO-2022-JP"
+            | "STATELESS-ISO-2022-JP"
+            | "CP50220"
+            | "CP50221"
+            | "UTF-7"
+    )
 }
 
 #[cfg(test)]

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -875,4 +875,37 @@ mod tests {
         run_test_once("Encoding::CompatibilityError.is_a?(Class)");
         run_test_once("Encoding::CompatibilityError < EncodingError");
     }
+
+    #[test]
+    fn encoding_ascii_compatible_p() {
+        // ASCII-compatible encodings
+        run_test(r#"Encoding::UTF_8.ascii_compatible?"#);
+        run_test(r#"Encoding::US_ASCII.ascii_compatible?"#);
+        run_test(r#"Encoding::ASCII_8BIT.ascii_compatible?"#);
+        run_test(r#"Encoding::ISO_8859_1.ascii_compatible?"#);
+        run_test(r#"Encoding::Shift_JIS.ascii_compatible?"#);
+        run_test(r#"Encoding::EUC_JP.ascii_compatible?"#);
+        // Non-ASCII-compatible encodings
+        run_test(r#"Encoding::UTF_16.ascii_compatible?"#);
+        run_test(r#"Encoding::UTF_16BE.ascii_compatible?"#);
+        run_test(r#"Encoding::UTF_16LE.ascii_compatible?"#);
+        run_test(r#"Encoding::UTF_32.ascii_compatible?"#);
+        run_test(r#"Encoding::UTF_32BE.ascii_compatible?"#);
+        run_test(r#"Encoding::UTF_32LE.ascii_compatible?"#);
+    }
+
+    #[test]
+    fn encoding_dummy_p() {
+        // Non-dummy encodings
+        run_test(r#"Encoding::UTF_8.dummy?"#);
+        run_test(r#"Encoding::US_ASCII.dummy?"#);
+        run_test(r#"Encoding::ASCII_8BIT.dummy?"#);
+        run_test(r#"Encoding::UTF_16BE.dummy?"#);
+        run_test(r#"Encoding::UTF_16LE.dummy?"#);
+        run_test(r#"Encoding::Shift_JIS.dummy?"#);
+        // Dummy encodings (stateful / no-BOM UTF-16/32)
+        run_test(r#"Encoding::UTF_16.dummy?"#);
+        run_test(r#"Encoding::UTF_32.dummy?"#);
+        run_test(r#"Encoding::ISO_2022_JP.dummy?"#);
+    }
 }

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -216,7 +216,7 @@ pub(super) fn encode_(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     // Validate encoding arguments
     if let Some(arg0) = lfp.try_arg(0) {
         resolve_enc_arg(vm, globals, arg0)?;
@@ -290,7 +290,7 @@ pub(super) fn force_encoding(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let arg0 = lfp.arg(0);
     let enc = if let Some(s) = arg0.is_str() {
         Encoding::try_from_str(s)?

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -58,9 +58,7 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // Fast path for Symbol#to_proc procs: dispatch directly so that the
     // block passed to Proc#call is forwarded to the invoked method. The
     // regular invoke_proc/block_invoker path currently drops block handlers.
-    if let Some(body_fid) = super::symbol::symbol_to_proc_body_fid()
-        && proc.func_id() == body_fid
-    {
+    if proc.func_id() == SYMBOL_TO_PROC_BODY_FUNCID {
         let symbol = proc.outer_lfp().self_val();
         let symbol_id = symbol
             .try_symbol()

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -55,6 +55,42 @@ fn new(vm: &mut Executor, _: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<
 #[monoruby_builtin]
 fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let proc = Proc::new(lfp.self_val());
+    // Fast path for Symbol#to_proc procs: dispatch directly so that the
+    // block passed to Proc#call is forwarded to the invoked method. The
+    // regular invoke_proc/block_invoker path currently drops block handlers.
+    if let Some(body_fid) = super::symbol::symbol_to_proc_body_fid()
+        && proc.func_id() == body_fid
+    {
+        let symbol = proc.outer_lfp().self_val();
+        let symbol_id = symbol
+            .try_symbol()
+            .expect("symbol-to-proc outer self is not a Symbol");
+        let args_val = lfp.arg(0);
+        let args = args_val.as_array();
+        if args.is_empty() {
+            return Err(MonorubyErr::argumenterr("no receiver given"));
+        }
+        let recv = args[0];
+        let rest: Vec<Value> = args[1..].to_vec();
+        let class_id = recv.class();
+        if let Some(entry) = globals.check_method_for_class(class_id, symbol_id) {
+            match entry.visibility() {
+                Visibility::Private => {
+                    return Err(MonorubyErr::private_method_called(
+                        globals, symbol_id, recv,
+                    ));
+                }
+                Visibility::Protected => {
+                    return Err(MonorubyErr::protected_method_called(
+                        globals, symbol_id, recv,
+                    ));
+                }
+                _ => {}
+            }
+        }
+        let bh = lfp.block();
+        return vm.invoke_method_inner(globals, symbol_id, recv, &rest, bh, None);
+    }
     vm.invoke_proc(globals, &proc, &lfp.arg(0).as_array())
 }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -457,7 +457,7 @@ fn gt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=3c=3c.html]
 #[monoruby_builtin]
 fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     if let Some(other) = lfp.arg(0).is_rstring() {
         self_.as_rstring_inner_mut().extend(&other)?;
@@ -732,7 +732,7 @@ fn index_assign(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let (arg1, subst) = if let Some(arg2) = lfp.try_arg(2) {
         (Some(lfp.arg(1)), arg2.coerce_to_string(vm, globals)?)
     } else {
@@ -1093,7 +1093,7 @@ fn delete_prefix_(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_ = lfp.self_val();
     let string = self_.expect_str(globals)?;
     let arg = lfp.arg(0).coerce_to_str(vm, globals)?;
@@ -1354,7 +1354,7 @@ fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/slice=21.html]
 #[monoruby_builtin]
 fn slice_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     fn slice_sub(lfp: Lfp, mut lhs: String, r: std::ops::Range<usize>) -> Value {
         let res = Value::string_from_str(&lhs[r.clone()]);
         lhs.replace_range(r, "");
@@ -1527,7 +1527,7 @@ fn chomp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/chomp.html]
 #[monoruby_builtin]
 fn chomp_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let arg0 = lfp.try_arg(0);
     let rs_owned;
     let rs = if let Some(arg0) = &arg0 {
@@ -1576,8 +1576,8 @@ fn strip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/strip=21.html]
 #[monoruby_builtin]
-fn strip_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn strip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
     let orig = self_val.expect_str(globals)?;
     let self_ = orig.trim_end_matches(STRIP).trim_start_matches(STRIP);
@@ -1608,8 +1608,8 @@ fn rstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/rstrip=21.html]
 #[monoruby_builtin]
-fn rstrip_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn rstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
     let orig = self_val.expect_str(globals)?;
     let self_ = orig.trim_end_matches(STRIP);
@@ -1640,8 +1640,8 @@ fn lstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/lstrip=21.html]
 #[monoruby_builtin]
-fn lstrip_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn lstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
     let orig = self_val.expect_str(globals)?;
     let self_ = orig.trim_start_matches(STRIP);
@@ -1674,7 +1674,7 @@ fn sub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/sub=21.html]
 #[monoruby_builtin]
 fn sub_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let (res, changed) = sub_main(vm, globals, self_, lfp)?;
     self_.replace_string(res);
@@ -1734,7 +1734,7 @@ fn gsub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/gsub=21.html]
 #[monoruby_builtin]
 fn gsub_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let (res, changed) = gsub_main(vm, globals, self_, lfp)?;
     self_.replace_string(res);
@@ -2296,7 +2296,7 @@ fn getbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/setbyte.html]
 #[monoruby_builtin]
 fn setbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let byte_val = lfp.arg(1).coerce_to_int_i64(vm, globals)?;
     let s = self_.as_rstring_inner();
@@ -2444,7 +2444,7 @@ fn byteslice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/bytesplice.html]
 #[monoruby_builtin]
 fn bytesplice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let arg_count = if lfp.try_arg(4).is_some() {
         5
     } else if lfp.try_arg(3).is_some() {
@@ -3168,8 +3168,8 @@ fn upcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/upcase=21.html]
 #[monoruby_builtin]
-fn upcase_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn upcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?.to_uppercase();
     let changed = &s != self_val.expect_str(globals)?;
@@ -3202,8 +3202,8 @@ fn downcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/downcase=21.html]
 #[monoruby_builtin]
-fn downcase_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn downcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?.to_lowercase();
     let changed = &s != self_val.expect_str(globals)?;
@@ -3256,12 +3256,12 @@ fn capitalize(
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/capitalize=21.html]
 #[monoruby_builtin]
 fn capitalize_(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
@@ -3321,8 +3321,8 @@ fn swapcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/swapcase=21.html]
 #[monoruby_builtin]
-fn swapcase_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn swapcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
     let mut result = String::with_capacity(s.len());
@@ -3605,7 +3605,7 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/replace.html]
 #[monoruby_builtin]
 fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let s = lfp.arg(0).coerce_to_string(vm, globals)?;
     lfp.self_val().replace_str(&s);
     Ok(lfp.self_val())
@@ -3709,8 +3709,8 @@ fn next(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/next=21.html]
 #[monoruby_builtin]
-fn next_mut(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
+fn next_mut(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let recv = self_.expect_str(globals)?;
     let new_str = str_next(recv);

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3139,11 +3139,13 @@ fn parse_bigint(s: &str, radix: u32) -> BigInt {
 fn to_sym(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let inner = self_val.as_rstring_inner();
-    let id = if inner.encoding().is_utf8_compatible() {
-        let s = inner.check_utf8()?;
-        IdentId::get_id(s)
-    } else {
-        IdentId::get_id_from_bytes(inner.as_bytes().to_vec())
+    // Intern based on actual byte validity rather than the encoding tag:
+    // a UTF-8 labeled string may legitimately contain invalid byte
+    // sequences (e.g. `"\xA9"` from a source literal) and must round-trip
+    // through a Bytes-variant IdentName.
+    let id = match std::str::from_utf8(inner.as_bytes()) {
+        Ok(s) => IdentId::get_id(s),
+        Err(_) => IdentId::get_id_from_bytes(inner.as_bytes().to_vec()),
     };
     Ok(Value::symbol(id))
 }
@@ -5196,11 +5198,11 @@ mod tests {
 
     #[test]
     fn string_casecmp_p_invalid_utf8() {
-        // In monoruby, string literals with non-UTF-8 bytes are automatically
-        // assigned ASCII-8BIT encoding, so casecmp? performs byte comparison
-        // instead of raising ArgumentError as CRuby does.
-        run_test_no_result_check(r#""\xc3".casecmp?("\xc3")"#);
-        run_test_no_result_check(r#""\xc3".casecmp?("\xe3")"#);
+        // `"\xc3"` is a UTF-8 tagged string with an invalid byte sequence
+        // (matching CRuby's source-encoding semantics), so casecmp? raises
+        // ArgumentError just as CRuby does.
+        run_test_error(r#""\xc3".casecmp?("\xc3")"#);
+        run_test_error(r#""\xc3".casecmp?("\xe3")"#);
         run_test(r#""a".casecmp?("A")"#);
         run_test(r#""abc".casecmp?("ABC")"#);
     }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5220,6 +5220,34 @@ mod tests {
     }
 
     #[test]
+    fn string_xnn_literal_is_utf8() {
+        // Source-file `\xNN` escapes inherit the source (UTF-8) encoding
+        // regardless of whether the resulting bytes form valid UTF-8,
+        // matching CRuby.
+        run_test(r#""\xC3\xA9".encoding.name"#);
+        run_test(r#""\xC3\xA9".valid_encoding?"#);
+        run_test(r#""\xA9".encoding.name"#);
+        run_test(r#""\xA9".valid_encoding?"#);
+        run_test(r#""\xe3\x81\x82".encoding.name"#);
+        run_test(r#""\xe3\x81\x82".valid_encoding?"#);
+    }
+
+    #[test]
+    fn string_multibyte_char_boundary_check() {
+        // é (UTF-8 0xC3 0xA9) is a single character; start_with?/end_with?
+        // on a mid-character byte must return false even though the byte
+        // literally matches.
+        run_test(r#""\xC3\xA9".start_with?("\xC3")"#);
+        run_test(r#""\xC3\xA9".end_with?("\xA9")"#);
+        // 3-byte sequence for あ (UTF-8 0xE3 0x81 0x82)
+        run_test(r#""\xe3\x81\x82".end_with?("\x82")"#);
+        run_test(r#""\xe3\x81\x82".start_with?("\xe3")"#);
+        // Full-character match still succeeds.
+        run_test(r#""\xC3\xA9".start_with?("\xC3\xA9")"#);
+        run_test(r#""\xC3\xA9".end_with?("\xC3\xA9")"#);
+    }
+
+    #[test]
     fn string_index_at_end() {
         run_test(r#""blablabla".index("", 9)"#);
         run_test(r#""blablabla".index("", 10)"#);

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -28,12 +28,14 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 /// - to_s -> String
 ///
-/// Returns the name of the symbol as a string.
-/// ASCII-only symbols return a US-ASCII encoded string.
+/// Returns the name of the symbol as a string. ASCII-only symbols return a
+/// US-ASCII encoded string. The returned String is "chilled": it behaves as
+/// mutable but emits a one-shot deprecation warning on first mutation
+/// (matching CRuby's `rb_sym_to_s`).
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/to_s.html]
 #[monoruby_builtin]
-fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn sym_to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let sym = lfp.self_val().as_symbol();
     let ident_name = sym.get_ident_name_clone();
     let (bytes, enc) = match &ident_name {
@@ -48,61 +50,9 @@ fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
     let inner = RStringInner::from_encoding(bytes, enc);
-    let result = Value::string_from_inner(inner);
-    emit_to_s_chilled_warning(vm, globals, sym)?;
+    let mut result = Value::string_from_inner(inner);
+    result.set_chilled();
     Ok(result)
-}
-
-/// Emit the "string returned by :foo.to_s will be frozen in the future"
-/// deprecation warning when `Warning[:deprecated]` is enabled. This is
-/// approximate: CRuby fires the warning on mutation of the chilled string,
-/// but monoruby does not track chilled strings, so we fire it eagerly.
-fn emit_to_s_chilled_warning(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    sym: IdentId,
-) -> Result<()> {
-    // Check Warning[:deprecated]
-    let warning_val = match globals
-        .store
-        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Warning"))
-    {
-        Some(v) => v,
-        None => return Ok(()),
-    };
-    let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
-    let dep = vm.invoke_method_inner(
-        globals,
-        IdentId::get_id("[]"),
-        warning_val,
-        &[dep_sym],
-        None,
-        None,
-    )?;
-    if dep.is_nil() || dep == Value::bool(false) {
-        return Ok(());
-    }
-
-    let msg = format!(
-        "warning: string returned by {}.to_s will be frozen in the future\n",
-        inspect_symbol(sym)
-    );
-    let stderr = globals
-        .get_gvar(IdentId::get_id("$stderr"))
-        .unwrap_or(Value::nil());
-    if stderr.is_nil() {
-        return Ok(());
-    }
-    let msg_val = Value::string(msg);
-    vm.invoke_method_inner(
-        globals,
-        IdentId::get_id("write"),
-        stderr,
-        &[msg_val],
-        None,
-        None,
-    )?;
-    Ok(())
 }
 
 ///

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -1,21 +1,8 @@
 use super::*;
-use std::sync::OnceLock;
 
 //
 // Symbol class
 //
-
-///
-/// FuncId of the shared native body used by `Symbol#to_proc`.
-///
-/// Stored once at init so that `Proc#call` can detect symbol-to-proc procs
-/// for block-forwarding fast path.
-///
-static SYMBOL_TO_PROC_BODY_FID: OnceLock<FuncId> = OnceLock::new();
-
-pub(crate) fn symbol_to_proc_body_fid() -> Option<FuncId> {
-    SYMBOL_TO_PROC_BODY_FID.get().copied()
-}
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Symbol", SYMBOL_CLASS, None);
@@ -29,19 +16,6 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(SYMBOL_CLASS, "name", sym_name, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "inspect", sym_inspect, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "to_proc", sym_to_proc, 0);
-    // Register the shared body function used by Symbol#to_proc. It is
-    // installed on SYMBOL_CLASS with an internal name so that Proc dispatch
-    // can invoke it through the normal block-invoker path, but ordinary Ruby
-    // code has no reason to call it directly.
-    let body_fid = globals.define_builtin_func_with(
-        SYMBOL_CLASS,
-        "__monoruby_symbol_to_proc_body__",
-        symbol_to_proc_body,
-        1,
-        1,
-        true,
-    );
-    let _ = SYMBOL_TO_PROC_BODY_FID.set(body_fid);
     // Symbol.new is undefined (raises NoMethodError).
     let meta = globals.store.get_metaclass(SYMBOL_CLASS).id();
     globals
@@ -258,56 +232,10 @@ fn sym_to_proc(
     pc: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-    let body_fid = SYMBOL_TO_PROC_BODY_FID
-        .get()
-        .copied()
-        .expect("symbol_to_proc body function not initialized");
+    let body_fid = SYMBOL_TO_PROC_BODY_FUNCID;
     let outer_lfp = Lfp::heap_frame(self_val, globals[body_fid].meta());
     let proc = Proc::from_parts(outer_lfp, body_fid, pc);
     Ok(proc.into())
-}
-
-///
-/// Shared body for `Symbol#to_proc`-created procs.
-///
-/// Invoked via the block-invoker path (for `&:sym` usage in e.g. `map(&:to_s)`).
-/// `lfp.self_val()` carries the symbol (from the proc's outer_lfp), `arg(0)` is
-/// the receiver, and `arg(1)` is the rest array.
-///
-#[monoruby_builtin]
-fn symbol_to_proc_body(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let symbol_val = lfp.self_val();
-    let symbol = symbol_val
-        .try_symbol()
-        .expect("symbol_to_proc_body invoked with non-symbol self");
-    let recv = lfp.arg(0);
-    let rest_val = lfp.arg(1);
-    let rest_array = rest_val.as_array();
-    let rest: Vec<Value> = rest_array.iter().cloned().collect();
-    // public_send semantics: reject private and protected methods.
-    let class_id = recv.class();
-    if let Some(entry) = globals.check_method_for_class(class_id, symbol) {
-        match entry.visibility() {
-            Visibility::Private => {
-                return Err(MonorubyErr::private_method_called(
-                    globals, symbol, recv,
-                ));
-            }
-            Visibility::Protected => {
-                return Err(MonorubyErr::protected_method_called(
-                    globals, symbol, recv,
-                ));
-            }
-            _ => {}
-        }
-    }
-    let bh = lfp.block();
-    vm.invoke_method_inner(globals, symbol, recv, &rest, bh, None)
 }
 
 /// Test whether a symbol name can be rendered without quotes.

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -1,8 +1,21 @@
 use super::*;
+use std::sync::OnceLock;
 
 //
 // Symbol class
 //
+
+///
+/// FuncId of the shared native body used by `Symbol#to_proc`.
+///
+/// Stored once at init so that `Proc#call` can detect symbol-to-proc procs
+/// for block-forwarding fast path.
+///
+static SYMBOL_TO_PROC_BODY_FID: OnceLock<FuncId> = OnceLock::new();
+
+pub(crate) fn symbol_to_proc_body_fid() -> Option<FuncId> {
+    SYMBOL_TO_PROC_BODY_FID.get().copied()
+}
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Symbol", SYMBOL_CLASS, None);
@@ -14,6 +27,21 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(SYMBOL_CLASS, "!=", ne, 1);
     globals.define_builtin_func(SYMBOL_CLASS, "to_s", sym_to_s, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "name", sym_name, 0);
+    globals.define_builtin_func(SYMBOL_CLASS, "inspect", sym_inspect, 0);
+    globals.define_builtin_func(SYMBOL_CLASS, "to_proc", sym_to_proc, 0);
+    // Register the shared body function used by Symbol#to_proc. It is
+    // installed on SYMBOL_CLASS with an internal name so that Proc dispatch
+    // can invoke it through the normal block-invoker path, but ordinary Ruby
+    // code has no reason to call it directly.
+    let body_fid = globals.define_builtin_func_with(
+        SYMBOL_CLASS,
+        "__monoruby_symbol_to_proc_body__",
+        symbol_to_proc_body,
+        1,
+        1,
+        true,
+    );
+    let _ = SYMBOL_TO_PROC_BODY_FID.set(body_fid);
     // Symbol.new is undefined (raises NoMethodError).
     let meta = globals.store.get_metaclass(SYMBOL_CLASS).id();
     globals
@@ -31,8 +59,9 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/to_s.html]
 #[monoruby_builtin]
-fn sym_to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let sym = lfp.self_val().as_symbol();
+fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let sym = self_val.as_symbol();
     let ident_name = sym.get_ident_name_clone();
     let (bytes, enc) = match &ident_name {
         IdentName::Utf8(s) => {
@@ -46,7 +75,90 @@ fn sym_to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
     let inner = RStringInner::from_encoding(bytes, enc);
-    Ok(Value::string_from_inner(inner))
+    let result = Value::string_from_inner(inner);
+    emit_to_s_chilled_warning(vm, globals, self_val, &ident_name)?;
+    Ok(result)
+}
+
+/// Emit the "string returned by :foo.to_s will be frozen in the future"
+/// deprecation warning when `Warning[:deprecated]` is enabled. This is
+/// approximate: CRuby fires the warning on mutation of the chilled string,
+/// but monoruby does not track chilled strings, so we fire it eagerly.
+fn emit_to_s_chilled_warning(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    self_val: Value,
+    ident_name: &IdentName,
+) -> Result<()> {
+    // Check Warning[:deprecated]
+    let warning_val = match globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Warning"))
+    {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
+    let dep = vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("[]"),
+        warning_val,
+        &[dep_sym],
+        None,
+        None,
+    )?;
+    if dep.is_nil() || dep == Value::bool(false) {
+        return Ok(());
+    }
+
+    // Build the inspect form of self
+    let inspect = if is_simple_symbol(ident_name) {
+        let mut res = String::from(":");
+        match ident_name {
+            IdentName::Utf8(name) => res.push_str(name),
+            IdentName::Bytes(bytes) => res.push_str(&String::from_utf8_lossy(bytes)),
+        }
+        res
+    } else {
+        let (bytes, enc) = match ident_name {
+            IdentName::Utf8(s) => {
+                let enc = if s.is_ascii() {
+                    Encoding::UsAscii
+                } else {
+                    Encoding::Utf8
+                };
+                (s.as_bytes(), enc)
+            }
+            IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
+        };
+        let inner = RStringInner::from_encoding(bytes, enc);
+        let mut res = String::from(":\"");
+        res.push_str(&inner.inspect());
+        res.push('"');
+        res
+    };
+    let _ = self_val;
+
+    let msg = format!(
+        "warning: string returned by {}.to_s will be frozen in the future\n",
+        inspect
+    );
+    let stderr = globals
+        .get_gvar(IdentId::get_id("$stderr"))
+        .unwrap_or(Value::nil());
+    if stderr.is_nil() {
+        return Ok(());
+    }
+    let msg_val = Value::string(msg);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("write"),
+        stderr,
+        &[msg_val],
+        None,
+        None,
+    )?;
+    Ok(())
 }
 
 ///
@@ -81,6 +193,255 @@ fn sym_name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     v.set_frozen();
     globals.symbol_names.insert(sym, v);
     Ok(v)
+}
+
+///
+/// ### Symbol#inspect
+///
+/// - inspect -> String
+///
+/// Returns a string representation of the symbol as a symbol literal.
+/// Names that are not valid simple identifiers / operators / global-ivar-cvar
+/// forms are wrapped in `:"..."` with string-style escaping.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/inspect.html]
+#[monoruby_builtin]
+fn sym_inspect(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sym = lfp.self_val().as_symbol();
+    let ident_name = sym.get_ident_name_clone();
+    let s = if is_simple_symbol(&ident_name) {
+        let mut res = String::from(":");
+        match &ident_name {
+            IdentName::Utf8(name) => res.push_str(name),
+            IdentName::Bytes(bytes) => {
+                res.push_str(&String::from_utf8_lossy(bytes));
+            }
+        }
+        res
+    } else {
+        let (bytes, enc) = match &ident_name {
+            IdentName::Utf8(s) => {
+                let enc = if s.is_ascii() {
+                    Encoding::UsAscii
+                } else {
+                    Encoding::Utf8
+                };
+                (s.as_bytes(), enc)
+            }
+            IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
+        };
+        let inner = RStringInner::from_encoding(bytes, enc);
+        let mut res = String::from(":\"");
+        res.push_str(&inner.inspect());
+        res.push('"');
+        res
+    };
+    Ok(Value::string(s))
+}
+
+///
+/// ### Symbol#to_proc
+///
+/// - to_proc -> Proc
+///
+/// Returns a Proc object whose parameters are `[[:req], [:rest]]` and whose
+/// `source_location` is `nil`, matching CRuby's C-level implementation.
+/// When invoked with `(recv, *args, &blk)`, it calls `recv.public_send(self,
+/// *args, &blk)`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/to_proc.html]
+#[monoruby_builtin]
+fn sym_to_proc(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let body_fid = SYMBOL_TO_PROC_BODY_FID
+        .get()
+        .copied()
+        .expect("symbol_to_proc body function not initialized");
+    let outer_lfp = Lfp::heap_frame(self_val, globals[body_fid].meta());
+    let proc = Proc::from_parts(outer_lfp, body_fid, pc);
+    Ok(proc.into())
+}
+
+///
+/// Shared body for `Symbol#to_proc`-created procs.
+///
+/// Invoked via the block-invoker path (for `&:sym` usage in e.g. `map(&:to_s)`).
+/// `lfp.self_val()` carries the symbol (from the proc's outer_lfp), `arg(0)` is
+/// the receiver, and `arg(1)` is the rest array.
+///
+#[monoruby_builtin]
+fn symbol_to_proc_body(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let symbol_val = lfp.self_val();
+    let symbol = symbol_val
+        .try_symbol()
+        .expect("symbol_to_proc_body invoked with non-symbol self");
+    let recv = lfp.arg(0);
+    let rest_val = lfp.arg(1);
+    let rest_array = rest_val.as_array();
+    let rest: Vec<Value> = rest_array.iter().cloned().collect();
+    // public_send semantics: reject private and protected methods.
+    let class_id = recv.class();
+    if let Some(entry) = globals.check_method_for_class(class_id, symbol) {
+        match entry.visibility() {
+            Visibility::Private => {
+                return Err(MonorubyErr::private_method_called(
+                    globals, symbol, recv,
+                ));
+            }
+            Visibility::Protected => {
+                return Err(MonorubyErr::protected_method_called(
+                    globals, symbol, recv,
+                ));
+            }
+            _ => {}
+        }
+    }
+    let bh = lfp.block();
+    vm.invoke_method_inner(globals, symbol, recv, &rest, bh, None)
+}
+
+/// Test whether a symbol name can be rendered without quotes.
+fn is_simple_symbol(name: &IdentName) -> bool {
+    let s = match name.as_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    if s.is_empty() {
+        return false;
+    }
+    if is_operator_symbol(s) {
+        return true;
+    }
+    if let Some(rest) = s.strip_prefix("@@") {
+        return is_plain_identifier(rest);
+    }
+    if let Some(rest) = s.strip_prefix('@') {
+        return is_plain_identifier(rest);
+    }
+    if let Some(rest) = s.strip_prefix('$') {
+        return is_global_var_tail(rest);
+    }
+    is_method_identifier(s)
+}
+
+fn is_operator_symbol(s: &str) -> bool {
+    matches!(
+        s,
+        "|" | "^"
+            | "&"
+            | "<=>"
+            | "=="
+            | "==="
+            | "=~"
+            | ">"
+            | ">="
+            | "<"
+            | "<="
+            | "<<"
+            | ">>"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "%"
+            | "**"
+            | "~"
+            | "+@"
+            | "-@"
+            | "[]"
+            | "[]="
+            | "`"
+            | "!"
+            | "!="
+            | "!~"
+    )
+}
+
+fn is_ident_start_char(c: char) -> bool {
+    c == '_' || c.is_ascii_alphabetic() || (c as u32) >= 0x80
+}
+
+fn is_ident_cont_char(c: char) -> bool {
+    c == '_' || c.is_ascii_alphanumeric() || (c as u32) >= 0x80
+}
+
+fn is_plain_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_ident_start_char(c) => {}
+        _ => return false,
+    }
+    chars.all(is_ident_cont_char)
+}
+
+fn is_method_identifier(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let body_end = match bytes.last() {
+        Some(b'!') | Some(b'?') | Some(b'=') => bytes.len() - 1,
+        _ => bytes.len(),
+    };
+    if body_end == 0 {
+        return false;
+    }
+    is_plain_identifier(&s[..body_end])
+}
+
+fn is_global_var_tail(rest: &str) -> bool {
+    if rest.is_empty() {
+        return false;
+    }
+    // $1234: digits only
+    if rest.bytes().all(|b| b.is_ascii_digit()) {
+        return true;
+    }
+    // $-X: dash + exactly one identifier-ish char
+    if let Some(after_dash) = rest.strip_prefix('-') {
+        let mut chars = after_dash.chars();
+        if let (Some(c), None) = (chars.next(), chars.next()) {
+            return is_ident_cont_char(c);
+        }
+        return false;
+    }
+    // Single special char globals like $~, $*, $$, $?, $!, ...
+    if rest.len() == 1 {
+        let c = rest.as_bytes()[0];
+        if matches!(
+            c,
+            b'~' | b'*'
+                | b'$'
+                | b'?'
+                | b'!'
+                | b'@'
+                | b'/'
+                | b'\\'
+                | b';'
+                | b','
+                | b'.'
+                | b'<'
+                | b'>'
+                | b':'
+                | b'"'
+                | b'&'
+                | b'\''
+                | b'`'
+                | b'+'
+                | b'='
+        ) {
+            return true;
+        }
+    }
+    // $name: plain identifier, no !/?/= suffix allowed
+    is_plain_identifier(rest)
 }
 
 ///

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -34,8 +34,7 @@ pub(super) fn init(globals: &mut Globals) {
 /// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/to_s.html]
 #[monoruby_builtin]
 fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_val = lfp.self_val();
-    let sym = self_val.as_symbol();
+    let sym = lfp.self_val().as_symbol();
     let ident_name = sym.get_ident_name_clone();
     let (bytes, enc) = match &ident_name {
         IdentName::Utf8(s) => {
@@ -50,7 +49,7 @@ fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     };
     let inner = RStringInner::from_encoding(bytes, enc);
     let result = Value::string_from_inner(inner);
-    emit_to_s_chilled_warning(vm, globals, self_val, &ident_name)?;
+    emit_to_s_chilled_warning(vm, globals, sym)?;
     Ok(result)
 }
 
@@ -61,8 +60,7 @@ fn sym_to_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 fn emit_to_s_chilled_warning(
     vm: &mut Executor,
     globals: &mut Globals,
-    self_val: Value,
-    ident_name: &IdentName,
+    sym: IdentId,
 ) -> Result<()> {
     // Check Warning[:deprecated]
     let warning_val = match globals
@@ -85,37 +83,9 @@ fn emit_to_s_chilled_warning(
         return Ok(());
     }
 
-    // Build the inspect form of self
-    let inspect = if is_simple_symbol(ident_name) {
-        let mut res = String::from(":");
-        match ident_name {
-            IdentName::Utf8(name) => res.push_str(name),
-            IdentName::Bytes(bytes) => res.push_str(&String::from_utf8_lossy(bytes)),
-        }
-        res
-    } else {
-        let (bytes, enc) = match ident_name {
-            IdentName::Utf8(s) => {
-                let enc = if s.is_ascii() {
-                    Encoding::UsAscii
-                } else {
-                    Encoding::Utf8
-                };
-                (s.as_bytes(), enc)
-            }
-            IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
-        };
-        let inner = RStringInner::from_encoding(bytes, enc);
-        let mut res = String::from(":\"");
-        res.push_str(&inner.inspect());
-        res.push('"');
-        res
-    };
-    let _ = self_val;
-
     let msg = format!(
         "warning: string returned by {}.to_s will be frozen in the future\n",
-        inspect
+        inspect_symbol(sym)
     );
     let stderr = globals
         .get_gvar(IdentId::get_id("$stderr"))
@@ -182,35 +152,7 @@ fn sym_name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn sym_inspect(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let sym = lfp.self_val().as_symbol();
-    let ident_name = sym.get_ident_name_clone();
-    let s = if is_simple_symbol(&ident_name) {
-        let mut res = String::from(":");
-        match &ident_name {
-            IdentName::Utf8(name) => res.push_str(name),
-            IdentName::Bytes(bytes) => {
-                res.push_str(&String::from_utf8_lossy(bytes));
-            }
-        }
-        res
-    } else {
-        let (bytes, enc) = match &ident_name {
-            IdentName::Utf8(s) => {
-                let enc = if s.is_ascii() {
-                    Encoding::UsAscii
-                } else {
-                    Encoding::Utf8
-                };
-                (s.as_bytes(), enc)
-            }
-            IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
-        };
-        let inner = RStringInner::from_encoding(bytes, enc);
-        let mut res = String::from(":\"");
-        res.push_str(&inner.inspect());
-        res.push('"');
-        res
-    };
-    Ok(Value::string(s))
+    Ok(Value::string(inspect_symbol(sym)))
 }
 
 ///
@@ -236,140 +178,6 @@ fn sym_to_proc(
     let outer_lfp = Lfp::heap_frame(self_val, globals[body_fid].meta());
     let proc = Proc::from_parts(outer_lfp, body_fid, pc);
     Ok(proc.into())
-}
-
-/// Test whether a symbol name can be rendered without quotes.
-fn is_simple_symbol(name: &IdentName) -> bool {
-    let s = match name.as_str() {
-        Some(s) => s,
-        None => return false,
-    };
-    if s.is_empty() {
-        return false;
-    }
-    if is_operator_symbol(s) {
-        return true;
-    }
-    if let Some(rest) = s.strip_prefix("@@") {
-        return is_plain_identifier(rest);
-    }
-    if let Some(rest) = s.strip_prefix('@') {
-        return is_plain_identifier(rest);
-    }
-    if let Some(rest) = s.strip_prefix('$') {
-        return is_global_var_tail(rest);
-    }
-    is_method_identifier(s)
-}
-
-fn is_operator_symbol(s: &str) -> bool {
-    matches!(
-        s,
-        "|" | "^"
-            | "&"
-            | "<=>"
-            | "=="
-            | "==="
-            | "=~"
-            | ">"
-            | ">="
-            | "<"
-            | "<="
-            | "<<"
-            | ">>"
-            | "+"
-            | "-"
-            | "*"
-            | "/"
-            | "%"
-            | "**"
-            | "~"
-            | "+@"
-            | "-@"
-            | "[]"
-            | "[]="
-            | "`"
-            | "!"
-            | "!="
-            | "!~"
-    )
-}
-
-fn is_ident_start_char(c: char) -> bool {
-    c == '_' || c.is_ascii_alphabetic() || (c as u32) >= 0x80
-}
-
-fn is_ident_cont_char(c: char) -> bool {
-    c == '_' || c.is_ascii_alphanumeric() || (c as u32) >= 0x80
-}
-
-fn is_plain_identifier(s: &str) -> bool {
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(c) if is_ident_start_char(c) => {}
-        _ => return false,
-    }
-    chars.all(is_ident_cont_char)
-}
-
-fn is_method_identifier(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    let body_end = match bytes.last() {
-        Some(b'!') | Some(b'?') | Some(b'=') => bytes.len() - 1,
-        _ => bytes.len(),
-    };
-    if body_end == 0 {
-        return false;
-    }
-    is_plain_identifier(&s[..body_end])
-}
-
-fn is_global_var_tail(rest: &str) -> bool {
-    if rest.is_empty() {
-        return false;
-    }
-    // $1234: digits only
-    if rest.bytes().all(|b| b.is_ascii_digit()) {
-        return true;
-    }
-    // $-X: dash + exactly one identifier-ish char
-    if let Some(after_dash) = rest.strip_prefix('-') {
-        let mut chars = after_dash.chars();
-        if let (Some(c), None) = (chars.next(), chars.next()) {
-            return is_ident_cont_char(c);
-        }
-        return false;
-    }
-    // Single special char globals like $~, $*, $$, $?, $!, ...
-    if rest.len() == 1 {
-        let c = rest.as_bytes()[0];
-        if matches!(
-            c,
-            b'~' | b'*'
-                | b'$'
-                | b'?'
-                | b'!'
-                | b'@'
-                | b'/'
-                | b'\\'
-                | b';'
-                | b','
-                | b'.'
-                | b'<'
-                | b'>'
-                | b':'
-                | b'"'
-                | b'&'
-                | b'\''
-                | b'`'
-                | b'+'
-                | b'='
-        ) {
-            return true;
-        }
-    }
-    // $name: plain identifier, no !/?/= suffix allowed
-    is_plain_identifier(rest)
 }
 
 ///

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -334,4 +334,183 @@ mod tests {
         // Binary and UTF-8 symbols with same bytes are distinct
         run_test_no_result_check(r#""\xC3\xA3".to_sym != "\xC3\xA3".b.to_sym"#);
     }
+
+    #[test]
+    fn symbol_inspect_unquoted() {
+        // Plain identifiers
+        run_test(r#":hello.inspect"#);
+        run_test(r#":Fred.inspect"#);
+        run_test(r#":_abc.inspect"#);
+        run_test(r#":fred?.inspect"#);
+        run_test(r#":fred!.inspect"#);
+        run_test(r#":BAD!.inspect"#);
+        run_test(r#":_BAD!.inspect"#);
+        // Global / ivar / cvar
+        run_test(r#":$ruby.inspect"#);
+        run_test(r#":@ruby.inspect"#);
+        run_test(r#":@@ruby.inspect"#);
+        run_test(r#":$-w.inspect"#);
+        // Special single-char globals
+        run_test(r#":$+.inspect"#);
+        run_test(r#":$~.inspect"#);
+        run_test(r#":$?.inspect"#);
+        run_test(r#":$!.inspect"#);
+        // $digits
+        run_test(r#":$0.inspect"#);
+        run_test(r#":$1234.inspect"#);
+        // Operators
+        run_test(r#":+.inspect"#);
+        run_test(r#":-.inspect"#);
+        run_test(r#":*.inspect"#);
+        run_test(r#":**.inspect"#);
+        run_test(r#":+@.inspect"#);
+        run_test(r#":-@.inspect"#);
+        run_test(r#":<=>.inspect"#);
+        run_test(r#":==.inspect"#);
+        run_test(r#":===.inspect"#);
+        run_test(r#":=~.inspect"#);
+        run_test(r#":[].inspect"#);
+        run_test(r#":[]=.inspect"#);
+        run_test(r#":"<<".inspect"#);
+        run_test(r#":">>".inspect"#);
+        // Non-ASCII letters are valid identifier chars
+        run_test(r#":"ê".inspect"#);
+        run_test(r#":"日本語".inspect"#);
+    }
+
+    #[test]
+    fn symbol_inspect_quoted() {
+        // $ followed by non-simple content
+        run_test(r#":"$ruby!".inspect"#);
+        run_test(r#":"@ruby!".inspect"#);
+        run_test(r#":"@@ruby!".inspect"#);
+        run_test(r#":"$-ww".inspect"#);
+        run_test(r#":"$".inspect"#);
+        // Non-identifier, non-operator sequences
+        run_test(r#":"foo bar".inspect"#);
+        run_test(r#":"9".inspect"#);
+        run_test(r#":"*foo".inspect"#);
+        run_test(r#":"foo ".inspect"#);
+        run_test(r#":" foo".inspect"#);
+        run_test(r#":" ".inspect"#);
+        run_test(r#":"&&".inspect"#);
+        run_test(r#":"||".inspect"#);
+        run_test(r#":"|||".inspect"#);
+        run_test(r#":"++".inspect"#);
+        run_test(r#":":".inspect"#);
+        run_test(r#":"::".inspect"#);
+        run_test(r#":",".inspect"#);
+        run_test(r#":".".inspect"#);
+        run_test(r#":"..".inspect"#);
+        run_test(r#":"...".inspect"#);
+        run_test(r#":";".inspect"#);
+        run_test(r#":"=".inspect"#);
+        run_test(r#":"=>".inspect"#);
+        run_test(r#":"?".inspect"#);
+        run_test(r#":"@".inspect"#);
+        // Escaped characters inside quoted form
+        run_test(r#":"\"".inspect"#);
+        run_test(r#":"\"\"".inspect"#);
+        run_test(r#":"'".inspect"#);
+        // Binary symbol gets quoted with escape
+        run_test(r#""foo\xA4".b.to_sym.inspect"#);
+    }
+
+    #[test]
+    fn symbol_to_proc_metadata() {
+        // Arity is -2 (one required + rest)
+        run_test(r#":to_i.to_proc.arity"#);
+        // Parameters is [[:req], [:rest]] with no names (native builtin body)
+        run_test(r#":to_i.to_proc.parameters"#);
+        // Source location is nil (not an ISeq)
+        run_test(r#":to_i.to_proc.source_location"#);
+        // It is a lambda
+        run_test(r#":to_i.to_proc.lambda?"#);
+        // It is a Proc
+        run_test(r#":to_i.to_proc.is_a?(Proc)"#);
+    }
+
+    #[test]
+    fn symbol_to_proc_block_forwarding() {
+        // A block passed to Proc#call on a Symbol-derived proc must be
+        // forwarded to the underlying method.
+        run_test(
+            r#"
+            klass = Class.new do
+              def m
+                yield
+              end
+            end
+            :m.to_proc.call(klass.new) { :value }
+            "#,
+        );
+    }
+
+    #[test]
+    fn symbol_to_proc_no_receiver_raises() {
+        // Proc#call with no receiver argument raises ArgumentError.
+        run_test_error(r#":object_id.to_proc.call"#);
+    }
+
+    #[test]
+    fn symbol_to_s_chilled_basics() {
+        // Symbol#to_s returns a mutable string (chilled, not frozen).
+        run_test(r#":hello.to_s.frozen?"#);
+        // dup clears the chilled bit so mutation is silent.
+        run_test(r#"s = :hello.to_s.dup; s << "X"; s"#);
+        // Each call returns a fresh string instance.
+        run_test(r#":hello.to_s.equal?(:hello.to_s)"#);
+        // Mutation succeeds (warning or not) and the string changes.
+        run_test(
+            r#"
+            Warning[:deprecated] = false
+            s = :bad!.to_s
+            s.upcase!
+            s
+            "#,
+        );
+    }
+
+    #[test]
+    fn symbol_to_s_chilled_dup_silent() {
+        // With Warning[:deprecated]=true and a StringIO'd $stderr, dup'd
+        // chilled strings must not emit a warning on mutation.
+        run_test_once(
+            r#"
+            require 'stringio'
+            old_stderr = $stderr
+            old_dep = Warning[:deprecated]
+            begin
+              $stderr = StringIO.new
+              Warning[:deprecated] = true
+              :hello.to_s.dup << "X"
+              $stderr.string
+            ensure
+              $stderr = old_stderr
+              Warning[:deprecated] = old_dep
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn symbol_to_s_chilled_suppressed() {
+        // Warning[:deprecated]=false suppresses the mutation warning.
+        run_test_once(
+            r#"
+            require 'stringio'
+            old_stderr = $stderr
+            old_dep = Warning[:deprecated]
+            begin
+              $stderr = StringIO.new
+              Warning[:deprecated] = false
+              :bad!.to_s.upcase!
+              $stderr.string
+            ensure
+              $stderr = old_stderr
+              Warning[:deprecated] = old_dep
+            end
+            "#,
+        );
+    }
 }

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1087,7 +1087,10 @@ impl<'a> BytecodeGen<'a> {
     }
 
     fn emit_bytes(&mut self, dst: BcReg, b: Vec<u8>) {
-        self.emit_literal(dst, Value::bytes(b));
+        // `NodeKind::Bytes` comes from source literals containing `\xNN`
+        // escapes. Tag as UTF-8 so it inherits the source encoding like
+        // CRuby, rather than being forced to BINARY.
+        self.emit_literal(dst, Value::string_from_source_bytes(&b));
     }
 
     fn emit_array(&mut self, dst: BcReg, src: BcReg, len: usize, splat: Vec<usize>, loc: Loc) {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1507,7 +1507,7 @@ impl Executor {
         pc: BytecodePtr,
     ) -> Result<Value> {
         let outer_lfp = Lfp::dummy_heap_frame_with_self(obj);
-        let proc = Proc::from_parts(outer_lfp, FuncId::new(1), pc);
+        let proc = Proc::from_parts(outer_lfp, ENUM_YIELDER_FUNCID, pc);
         let e = Value::new_enumerator(obj, method, proc, args);
         Ok(e)
     }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -204,11 +204,11 @@ impl Globals {
             basic_object.get(),
         );
         assert_eq!(
-            FuncId::new(1),
+            ENUM_YIELDER_FUNCID,
             globals.define_builtin_func(OBJECT_CLASS, "", enum_yielder, 0)
         );
         assert_eq!(
-            FuncId::new(2),
+            YIELDER_FUNCID,
             globals.define_builtin_func_rest(OBJECT_CLASS, "", yielder)
         );
         assert_eq!(

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -211,6 +211,10 @@ impl Globals {
             FuncId::new(2),
             globals.define_builtin_func_rest(OBJECT_CLASS, "", yielder)
         );
+        assert_eq!(
+            SYMBOL_TO_PROC_BODY_FUNCID,
+            globals.define_builtin_func_with(OBJECT_CLASS, "", symbol_to_proc_body, 1, 1, true)
+        );
         globals.random.init_with_seed(None);
         crate::builtins::init_builtins(&mut globals);
         globals

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -362,7 +362,7 @@ impl MonorubyErr {
 
     pub(crate) fn wrong_number_of_arg_min(given: usize, min: usize) -> MonorubyErr {
         Self::argumenterr(format!(
-            "wrong number of arguments (given {given}, expeted {min}+)"
+            "wrong number of arguments (given {given}, expected {min}+)"
         ))
     }
 

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -316,6 +316,60 @@ fn yielder(vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     vm.yield_fiber(lfp.arg(0))
 }
 
+///
+/// Pre-assigned FuncId for the shared body of `Symbol#to_proc`.
+///
+/// Registered up-front in `Globals::new` (together with `enum_yielder` /
+/// `yielder`) so the FuncId is compile-time constant and can be used
+/// directly by `Symbol#to_proc` (to build a Proc) and by `Proc#call`
+/// (to detect symbol-to-proc procs for the block-forwarding fast path).
+///
+pub(crate) const SYMBOL_TO_PROC_BODY_FUNCID: FuncId = FuncId::new(3);
+
+///
+/// Shared body for procs returned by `Symbol#to_proc`.
+///
+/// Invoked via the block-invoker path (for `&:sym` usage in e.g.
+/// `map(&:to_s)`). `lfp.self_val()` carries the symbol (copied from the
+/// proc's outer_lfp), `arg(0)` is the receiver, and `arg(1)` is the rest
+/// array.
+///
+#[monoruby_builtin]
+pub(crate) fn symbol_to_proc_body(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let symbol_val = lfp.self_val();
+    let symbol = symbol_val
+        .try_symbol()
+        .expect("symbol_to_proc_body invoked with non-symbol self");
+    let recv = lfp.arg(0);
+    let rest_val = lfp.arg(1);
+    let rest_array = rest_val.as_array();
+    let rest: Vec<Value> = rest_array.iter().cloned().collect();
+    // public_send semantics: reject private and protected methods.
+    let class_id = recv.class();
+    if let Some(entry) = globals.check_method_for_class(class_id, symbol) {
+        match entry.visibility() {
+            Visibility::Private => {
+                return Err(MonorubyErr::private_method_called(
+                    globals, symbol, recv,
+                ));
+            }
+            Visibility::Protected => {
+                return Err(MonorubyErr::protected_method_called(
+                    globals, symbol, recv,
+                ));
+            }
+            _ => {}
+        }
+    }
+    let bh = lfp.block();
+    vm.invoke_method_inner(globals, symbol, recv, &rest, bh, None)
+}
+
 impl Funcs {
     pub(super) fn functions(&self) -> &[FuncInfo] {
         &self.info

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -295,26 +295,18 @@ impl alloc::GC<RValue> for Funcs {
     }
 }
 
-#[monoruby_builtin]
-fn enum_yielder(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let e = Enumerator::new(lfp.self_val());
-    let receiver = e.obj;
-    let method = e.method;
-    let args = &*e.args;
-    vm.invoke_method_inner(
-        globals,
-        method,
-        receiver,
-        args,
-        Some(BlockHandler::from_current(FuncId::new(2))),
-        None,
-    )
-}
+///
+/// Pre-assigned FuncId for `enum_yielder`, the proc body that drives
+/// Enumerator iteration by calling the backing method with a fresh yielder.
+///
+pub(crate) const ENUM_YIELDER_FUNCID: FuncId = FuncId::new(1);
 
-#[monoruby_builtin]
-fn yielder(vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    vm.yield_fiber(lfp.arg(0))
-}
+///
+/// Pre-assigned FuncId for `yielder`, the proc body invoked via a
+/// `BlockHandler::from_current` from `enum_yielder` to suspend the fiber
+/// with a value.
+///
+pub(crate) const YIELDER_FUNCID: FuncId = FuncId::new(2);
 
 ///
 /// Pre-assigned FuncId for the shared body of `Symbol#to_proc`.
@@ -325,6 +317,37 @@ fn yielder(vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 /// (to detect symbol-to-proc procs for the block-forwarding fast path).
 ///
 pub(crate) const SYMBOL_TO_PROC_BODY_FUNCID: FuncId = FuncId::new(3);
+
+#[monoruby_builtin]
+pub(crate) fn enum_yielder(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let e = Enumerator::new(lfp.self_val());
+    let receiver = e.obj;
+    let method = e.method;
+    let args = &*e.args;
+    vm.invoke_method_inner(
+        globals,
+        method,
+        receiver,
+        args,
+        Some(BlockHandler::from_current(YIELDER_FUNCID)),
+        None,
+    )
+}
+
+#[monoruby_builtin]
+pub(crate) fn yielder(
+    vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    vm.yield_fiber(lfp.arg(0))
+}
 
 ///
 /// Shared body for procs returned by `Symbol#to_proc`.

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -959,7 +959,7 @@ impl Value {
             RV::Float(f) => ruby_float_to_s(f),
             RV::Complex(_) => self.as_complex().debug(store),
             RV::Rational(r) => r.inspect(),
-            RV::Symbol(id) => format!(":{id}"),
+            RV::Symbol(id) => inspect_symbol(id),
             RV::String(s) => format!(r#""{}""#, s.inspect()),
             RV::Object(rvalue) => rvalue.debug(store),
         }
@@ -975,7 +975,7 @@ impl Value {
             RV::Float(f) => ruby_float_to_s(f),
             RV::Complex(_) => self.as_complex().debug(store),
             RV::Rational(r) => r.inspect(),
-            RV::Symbol(id) => format!(":{id}"),
+            RV::Symbol(id) => inspect_symbol(id),
             RV::String(s) => format!(r#""{}""#, s.inspect()),
             RV::Object(rvalue) => rvalue.debug(store),
         };
@@ -1037,6 +1037,177 @@ impl Value {
         }
         s
     }
+}
+
+///
+/// Render a symbol as its Ruby inspect form (`:name` or `:"escaped name"`).
+///
+/// Simple names — identifiers, operators, `$gv`/`@iv`/`@@cv` — are emitted
+/// without quotes. Anything else is wrapped in `:"..."` and escaped through
+/// `RStringInner::inspect`. This matches CRuby's `rb_sym_inspect` behavior and
+/// is shared between `Symbol#inspect`, `Value::debug`, and the
+/// `Symbol#to_s`-chilled-string deprecation warning.
+///
+pub(crate) fn inspect_symbol(id: IdentId) -> String {
+    let ident_name = id.get_ident_name_clone();
+    if is_simple_symbol(&ident_name) {
+        let mut res = String::from(":");
+        match &ident_name {
+            IdentName::Utf8(name) => res.push_str(name),
+            IdentName::Bytes(bytes) => res.push_str(&String::from_utf8_lossy(bytes)),
+        }
+        return res;
+    }
+    let (bytes, enc) = match &ident_name {
+        IdentName::Utf8(s) => {
+            let enc = if s.is_ascii() {
+                Encoding::UsAscii
+            } else {
+                Encoding::Utf8
+            };
+            (s.as_bytes(), enc)
+        }
+        IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
+    };
+    let inner = RStringInner::from_encoding(bytes, enc);
+    let mut res = String::from(":\"");
+    res.push_str(&inner.inspect());
+    res.push('"');
+    res
+}
+
+/// Test whether a symbol name can be rendered without surrounding quotes.
+fn is_simple_symbol(name: &IdentName) -> bool {
+    let s = match name.as_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    if s.is_empty() {
+        return false;
+    }
+    if is_operator_symbol(s) {
+        return true;
+    }
+    if let Some(rest) = s.strip_prefix("@@") {
+        return is_plain_identifier(rest);
+    }
+    if let Some(rest) = s.strip_prefix('@') {
+        return is_plain_identifier(rest);
+    }
+    if let Some(rest) = s.strip_prefix('$') {
+        return is_global_var_tail(rest);
+    }
+    is_method_identifier(s)
+}
+
+fn is_operator_symbol(s: &str) -> bool {
+    matches!(
+        s,
+        "|" | "^"
+            | "&"
+            | "<=>"
+            | "=="
+            | "==="
+            | "=~"
+            | ">"
+            | ">="
+            | "<"
+            | "<="
+            | "<<"
+            | ">>"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "%"
+            | "**"
+            | "~"
+            | "+@"
+            | "-@"
+            | "[]"
+            | "[]="
+            | "`"
+            | "!"
+            | "!="
+            | "!~"
+    )
+}
+
+fn is_ident_start_char(c: char) -> bool {
+    c == '_' || c.is_ascii_alphabetic() || (c as u32) >= 0x80
+}
+
+fn is_ident_cont_char(c: char) -> bool {
+    c == '_' || c.is_ascii_alphanumeric() || (c as u32) >= 0x80
+}
+
+fn is_plain_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_ident_start_char(c) => {}
+        _ => return false,
+    }
+    chars.all(is_ident_cont_char)
+}
+
+fn is_method_identifier(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let body_end = match bytes.last() {
+        Some(b'!') | Some(b'?') | Some(b'=') => bytes.len() - 1,
+        _ => bytes.len(),
+    };
+    if body_end == 0 {
+        return false;
+    }
+    is_plain_identifier(&s[..body_end])
+}
+
+fn is_global_var_tail(rest: &str) -> bool {
+    if rest.is_empty() {
+        return false;
+    }
+    // $1234: digits only
+    if rest.bytes().all(|b| b.is_ascii_digit()) {
+        return true;
+    }
+    // $-X: dash + exactly one identifier-ish char
+    if let Some(after_dash) = rest.strip_prefix('-') {
+        let mut chars = after_dash.chars();
+        if let (Some(c), None) = (chars.next(), chars.next()) {
+            return is_ident_cont_char(c);
+        }
+        return false;
+    }
+    // Single-character special globals like $~, $*, $$, $?, $!, ...
+    if rest.len() == 1 {
+        let c = rest.as_bytes()[0];
+        if matches!(
+            c,
+            b'~' | b'*'
+                | b'$'
+                | b'?'
+                | b'!'
+                | b'@'
+                | b'/'
+                | b'\\'
+                | b';'
+                | b','
+                | b'.'
+                | b'<'
+                | b'>'
+                | b':'
+                | b'"'
+                | b'&'
+                | b'\''
+                | b'`'
+                | b'+'
+                | b'='
+        ) {
+            return true;
+        }
+    }
+    // $name: plain identifier, no !/?/= suffix allowed
+    is_plain_identifier(rest)
 }
 
 fn coerce_to_rstring_inner(

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -479,6 +479,45 @@ impl Value {
         }
     }
 
+    ///
+    /// Returns true if `self` is a "chilled" String — a String returned by
+    /// `Symbol#to_s` that behaves mutable but should emit a one-shot
+    /// deprecation warning on first mutation.
+    ///
+    pub(crate) fn is_chilled(&self) -> bool {
+        match self.try_rvalue() {
+            Some(rv) => rv.is_chilled(),
+            None => false,
+        }
+    }
+
+    pub(crate) fn set_chilled(&mut self) {
+        self.rvalue_mut().set_chilled()
+    }
+
+    pub(crate) fn clear_chilled(&mut self) {
+        self.rvalue_mut().clear_chilled()
+    }
+
+    ///
+    /// Ensure `self` (a String) is mutable. If it is "chilled", emit a
+    /// one-shot deprecation warning (gated by `Warning[:deprecated]`), clear
+    /// the chilled flag, and proceed. If it is truly frozen, raise
+    /// `FrozenError`. Otherwise do nothing. Must only be called on String
+    /// receivers; behaves like `ensure_not_frozen` for non-chilled values.
+    ///
+    pub(crate) fn ensure_string_mutable(
+        &mut self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        if self.is_chilled() {
+            self.clear_chilled();
+            emit_chilled_string_mutation_warning(vm, globals, *self)?;
+        }
+        self.ensure_not_frozen(&globals.store)
+    }
+
     pub(crate) fn change_class(&mut self, new_class_id: ClassId) {
         if let Some(rv) = self.try_rvalue_mut() {
             rv.change_class(new_class_id);
@@ -1037,6 +1076,76 @@ impl Value {
         }
         s
     }
+}
+
+///
+/// Emit the CRuby-compatible deprecation warning for mutating a chilled
+/// string (one returned by `Symbol#to_s`). Gated by `Warning[:deprecated]`;
+/// writes to Ruby-level `$stderr` so that mspec's `complain` matcher can
+/// capture it. The chilled flag should be cleared on the caller *before*
+/// invoking this helper so that failing tests still leave the string in a
+/// consistent state.
+///
+pub(crate) fn emit_chilled_string_mutation_warning(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    self_val: Value,
+) -> Result<()> {
+    // Check Warning[:deprecated].
+    let warning_val = match globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Warning"))
+    {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
+    let dep = vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("[]"),
+        warning_val,
+        &[dep_sym],
+        None,
+        None,
+    )?;
+    if dep.is_nil() || dep == Value::bool(false) {
+        return Ok(());
+    }
+
+    // The current bytes of a chilled string still carry the original
+    // symbol name (monoruby only produces chilled strings from
+    // Symbol#to_s, and the flag is cleared on first mutation). Re-intern
+    // so the message shows the same form CRuby would have printed.
+    let sym = match self_val.is_rstring() {
+        Some(s) => {
+            let bytes = s.as_bytes();
+            match std::str::from_utf8(bytes) {
+                Ok(utf8) => IdentId::get_id(utf8),
+                Err(_) => IdentId::get_id_from_bytes(bytes.to_vec()),
+            }
+        }
+        None => return Ok(()),
+    };
+    let msg = format!(
+        "warning: string returned by {}.to_s will be frozen in the future\n",
+        inspect_symbol(sym)
+    );
+    let stderr = globals
+        .get_gvar(IdentId::get_id("$stderr"))
+        .unwrap_or(Value::nil());
+    if stderr.is_nil() {
+        return Ok(());
+    }
+    let msg_val = Value::string(msg);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("write"),
+        stderr,
+        &[msg_val],
+        None,
+        None,
+    )?;
+    Ok(())
 }
 
 ///

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -786,6 +786,19 @@ impl Value {
         RValue::new_bytes_from_slice(b).pack()
     }
 
+    ///
+    /// Build a String from a source-file byte literal (e.g. `"\xC3\xA9"`).
+    ///
+    /// The result is tagged as UTF-8, matching CRuby's source-encoding
+    /// semantics where string literals inherit the source file encoding
+    /// regardless of whether `\xNN` escapes produce valid UTF-8. The bytes
+    /// may be invalid UTF-8, in which case `#valid_encoding?` returns
+    /// false and byte-level operations still work.
+    ///
+    pub fn string_from_source_bytes(b: &[u8]) -> Self {
+        Self::string_from_inner(RStringInner::from_encoding(b, Encoding::Utf8))
+    }
+
     pub fn string_from_vec(b: Vec<u8>) -> Self {
         RValue::new_string_from_vec(b).pack()
     }
@@ -2480,7 +2493,7 @@ impl Value {
             NodeKind::Nil => Value::nil(),
             NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
             NodeKind::String(s) => Value::string_from_str(s),
-            NodeKind::Bytes(b) => Value::bytes_from_slice(b),
+            NodeKind::Bytes(b) => Value::string_from_source_bytes(b),
             NodeKind::Array(v, ..) => {
                 let iter = v.iter().map(|node| Self::from_ast_inner(node, vm, globals));
                 Value::array_from_iter(iter)
@@ -2602,7 +2615,7 @@ impl Value {
             NodeKind::Nil => Value::nil(),
             NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
             NodeKind::String(s) => Value::string_from_str(s),
-            NodeKind::Bytes(b) => Value::bytes_from_slice(b),
+            NodeKind::Bytes(b) => Value::string_from_source_bytes(b),
             NodeKind::Array(v, ..) => {
                 let iter = v.iter().map(|node| Self::from_const_ast(node));
                 Value::array_from_iter(iter)

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -741,6 +741,18 @@ impl RValue {
         self.header.set_frozen()
     }
 
+    pub(crate) fn is_chilled(&self) -> bool {
+        self.header.is_chilled()
+    }
+
+    pub(crate) fn set_chilled(&mut self) {
+        self.header.set_chilled()
+    }
+
+    pub(crate) fn clear_chilled(&mut self) {
+        self.header.clear_chilled()
+    }
+
     pub(crate) unsafe fn try_ty(&self) -> Option<ObjTy> {
         unsafe { self.header.meta.ty }
     }
@@ -914,8 +926,8 @@ impl RValue {
 
     pub(super) fn dup(&self) -> Self {
         let mut header = self.header;
-        // dup does not copy the frozen flag (clone does).
-        unsafe { header.meta.flag &= !0b10 };
+        // dup does not copy the frozen or chilled flag (clone does).
+        unsafe { header.meta.flag &= !0b110 };
         RValue {
             header,
             var_table: self.var_table.clone(),
@@ -1771,6 +1783,25 @@ impl Header {
 
     fn set_frozen(&mut self) {
         unsafe { self.meta.flag |= 0b10 }
+    }
+
+    ///
+    /// A "chilled" string behaves like a mutable String but emits a
+    /// deprecation warning (gated by `Warning[:deprecated]`) the first time
+    /// it is mutated. monoruby only produces chilled strings from
+    /// `Symbol#to_s`; the flag is cleared on first mutation so the warning
+    /// fires at most once per string. Currently only Strings are chilled.
+    ///
+    fn is_chilled(&self) -> bool {
+        unsafe { self.meta.flag & 0b100 != 0 }
+    }
+
+    fn set_chilled(&mut self) {
+        unsafe { self.meta.flag |= 0b100 }
+    }
+
+    fn clear_chilled(&mut self) {
+        unsafe { self.meta.flag &= !0b100 }
     }
 
     fn class(&self) -> ClassId {


### PR DESCRIPTION
## Summary

Knocks core/symbol down from **40 failures / 4 errors** to **3 failures / 1 error**:

- **Symbol#inspect** — add proper `:\"...\"` quoting for names that aren't simple identifiers / operators / `$gv`/`@iv`/`@@cv`, with string-style escaping.
- **Symbol#to_proc** — rewrite as a native Rust builtin backed by a pre-assigned `FuncId` (alongside `enum_yielder`/`yielder`). `#parameters == [[:req],[:rest]]`, `#source_location == nil`, `#arity == -2`, and `Proc#call` forwards its block to the invoked method via a fast-path in `Proc#call`.
- **Chilled strings for `Symbol#to_s`** — add a `CHILLED` bit (`0b100`) next to `FROZEN` in the `RValue` header. `Symbol#to_s` tags its result chilled instead of eagerly emitting the deprecation warning; `Value::ensure_string_mutable` fires the warning on first mutation (gated by `Warning[:deprecated]`), clears the bit, and then delegates to `ensure_not_frozen`. `dup` clears both bits, so dup'd chilled strings are silently mutable.
- **`\xNN` source literals tagged as UTF-8** — `"\xC3\xA9"` now reports `encoding == UTF-8` (matching CRuby's source-encoding semantics) so `start_with?`/`end_with?`'s existing UTF-8 char-boundary check kicks in. Invalid sequences like `"\xA9"` stay UTF-8-tagged but `valid_encoding?` correctly returns false.
- **`Encoding#ascii_compatible?` / `#dummy?`** — classify the common encodings (UTF-16/UTF-32 variants, ISO-2022-JP, etc.) so `inspect_spec.rb`'s non-ASCII-compat / dummy iteration no longer errors.
- **Cleanup** — pre-assigned FuncId constants named (`ENUM_YIELDER_FUNCID`, `YIELDER_FUNCID`, `SYMBOL_TO_PROC_BODY_FUNCID`), `inspect_symbol` helper lives in `value.rs` and is reused by `Value::debug`, and the typo `expeted` → `expected` in the wrong-arg-count error message is fixed.

## Commits

1. `c8481f5688` — Initial core/symbol fix: inspect quoting, to_proc Rust builtin, chilled warning (eager), Encoding helpers.
2. `c3458b3fc8` — Register symbol_to_proc body as a pre-assigned FuncId.
3. `38d8ea33df` — Name `ENUM_YIELDER_FUNCID` / `YIELDER_FUNCID` / `SYMBOL_TO_PROC_BODY_FUNCID`.
4. `e44e3a1fbc` — Move Symbol inspect logic to `value.rs` and wire it into `Value::debug`.
5. `cf629b9205` — Implement chilled strings for `Symbol#to_s`.
6. `52acfc4173` — Tag source-literal `\xNN` byte escapes as UTF-8.
7. `1c69dab7b8` — Add unit tests for the above.

## Remaining core/symbol failures

- `Symbol#end_with?` CompatibilityError between real EUC-JP / UTF-8 strings — needs a richer `Encoding` representation, out of scope.
- `Symbol#end_with?` UTF-16BE sub-assertion — monoruby's `Encoding` enum has no UTF-16 variant.
- `Symbol#inspect` non-ASCII-compat / dummy iteration — `Encoding.list` populated but `String#encode` is a stub, so the symbol inspect body still produces the wrong form.

All three require broadening monoruby's `Encoding` representation beyond `{Ascii8, Utf8, UsAscii}`, which is a significantly larger change.

## Test plan

- [x] `cargo test -p monoruby --lib` — **1011 passed** (12 new tests)
- [x] `mspec core/symbol -t monoruby` — **3 failures, 1 error** (from 40/4)
- [x] Spot-check regression on `core/string` mutation-heavy specs (upcase/downcase/concat/replace/force_encoding/append/casecmp/start_with/end_with): baseline 71 fails → this branch 69 fails
- [x] Smoke tests for chilled warning emission, dup-clearing, and `Warning[:deprecated] = false` suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)