### PR TITLE
Improve Set spec compliance and add Hash iteration guard

### DIFF
--- a/monoruby/builtins/set.rb
+++ b/monoruby/builtins/set.rb
@@ -2,15 +2,25 @@ class Set
   include Enumerable
 
   def initialize(enum = nil, &block)
-    @hash = {}
-    if enum
+    if enum.nil?
+      # empty set
+    elsif enum.respond_to?(:each_entry)
+      if block
+        enum.each_entry { |o| add(block.call(o)) }
+      else
+        enum.each_entry { |o| add(o) }
+      end
+    elsif enum.respond_to?(:each)
       if block
         enum.each { |o| add(block.call(o)) }
       else
         enum.each { |o| add(o) }
       end
+    else
+      raise ArgumentError, "value must be enumerable"
     end
   end
+  private :initialize
 
   def to_set
     self

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -207,13 +207,14 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         block_data: &ProcData,
         self_val: Enumerator,
     ) -> Result<Value> {
+        let mut res = Value::nil();
         loop {
-            let v = internal.enum_yield_values(vm, globals, self_val, Value::nil())?;
+            let v = internal.enum_yield_values(vm, globals, self_val, res)?;
             if internal.is_terminated() {
                 return Ok(v);
             }
             let a = v.as_array();
-            vm.invoke_block(globals, block_data, &[a.peel()])?;
+            res = vm.invoke_block(globals, block_data, &[a.peel()])?;
         }
     }
     let self_val: Enumerator = match Enumerator::try_new(lfp.self_val()) {

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2070,4 +2070,59 @@ mod tests {
             "class C; def to_hash; {a: 1, b: 2}; end; end; o = C.new",
         );
     }
+
+    #[test]
+    fn hash_iter_guard_new_key_raises() {
+        // Adding a brand-new key during iteration must raise RuntimeError.
+        run_test_error("h = {a: 1, b: 2}; h.each { h[:c] = 3 }");
+        run_test_error("h = {a: 1}; h.each_key { h[:new] = 0 }");
+        run_test_error("h = {a: 1}; h.each_value { h[:new] = 0 }");
+    }
+
+    #[test]
+    fn hash_iter_guard_existing_key_allowed() {
+        // Updating an already-present key during iteration is allowed,
+        // matching CRuby semantics.
+        run_test("h = {a: 1, b: 2}; h.each { |k, v| h[k] = v * 10 }; h.to_a.sort");
+    }
+
+    #[test]
+    fn hash_iter_guard_delete_allowed() {
+        // Hash#delete during iteration does NOT raise (CRuby-compatible).
+        // Exact visitation order is implementation-defined, so just check
+        // that the call succeeds and returns the pre-delete value.
+        run_test(
+            "h = {a: 1}; \
+             seen = nil; \
+             h.each { |k, v| seen = h.delete(k) }; \
+             [seen, h.empty?]",
+        );
+    }
+
+    #[test]
+    fn hash_iter_guard_clear_raises() {
+        run_test_error("h = {a: 1, b: 2}; h.each { h.clear }");
+    }
+
+    #[test]
+    fn hash_iter_guard_nested_iteration() {
+        // Nested iteration increments iter_lev twice and decrements back to 0;
+        // after all iterations complete, mutation is allowed again.
+        run_test(
+            "h = {a: 1, b: 2}; \
+             h.each { |k1, _| h.each { |k2, _| _ = [k1, k2] } }; \
+             h[:c] = 3; h.keys.sort",
+        );
+    }
+
+    #[test]
+    fn hash_iter_guard_released_after_block_exception() {
+        // If the each block raises, the iter_lev guard is still decremented
+        // (RAII Drop) so subsequent mutations succeed.
+        run_test(
+            "h = {a: 1}; \
+             begin; h.each { raise 'stop' }; rescue; end; \
+             h[:b] = 2; h.keys.sort",
+        );
+    }
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -578,7 +578,7 @@ extern "C" fn hashindex(
 #[monoruby_builtin]
 fn clear(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     lfp.self_val().ensure_not_frozen(&globals.store)?;
-    lfp.self_val().as_hash().clear();
+    lfp.self_val().as_hash().clear()?;
     Ok(lfp.self_val())
 }
 
@@ -705,6 +705,7 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     };
     let hash = lfp.self_val().as_hash();
     let data = vm.get_block_data(globals, bh)?;
+    let _iter_guard = hash.iter_guard();
     for (k, v) in hash.iter() {
         vm.invoke_block(globals, &data, &[Value::array2(k, v)])?;
     }
@@ -733,6 +734,7 @@ fn each_value(
         Some(block) => block,
     };
     let hash = lfp.self_val().as_hash();
+    let _iter_guard = hash.iter_guard();
     let iter = hash.iter().map(|(_, v)| v);
     vm.invoke_block_iter1(globals, bh, iter)?;
     Ok(lfp.self_val())
@@ -755,6 +757,7 @@ fn each_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
         Some(block) => block,
     };
     let hash = lfp.self_val().as_hash();
+    let _iter_guard = hash.iter_guard();
     let iter = hash.iter().map(|(k, _)| k);
     vm.invoke_block_iter1(globals, bh, iter)?;
     Ok(lfp.self_val())
@@ -809,9 +812,14 @@ fn select_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
     };
     let data = vm.get_block_data(globals, bh)?;
     let mut remove = vec![];
-    for (k, v) in lfp.self_val().as_hash().iter() {
-        if !vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
-            remove.push(k);
+    let self_val = lfp.self_val();
+    let hash = self_val.as_hash();
+    {
+        let _iter_guard = hash.iter_guard();
+        for (k, v) in hash.iter() {
+            if !vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
+                remove.push(k);
+            }
         }
     }
     let changed = !remove.is_empty();
@@ -945,9 +953,14 @@ fn delete_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
     };
     let data = vm.get_block_data(globals, bh)?;
     let mut remove = vec![];
-    for (k, v) in lfp.self_val().as_hash().iter() {
-        if vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
-            remove.push(k);
+    let self_val = lfp.self_val();
+    let hash = self_val.as_hash();
+    {
+        let _iter_guard = hash.iter_guard();
+        for (k, v) in hash.iter() {
+            if vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
+                remove.push(k);
+            }
         }
     }
     let mut h = lfp.self_val().as_hash();
@@ -976,9 +989,14 @@ fn reject_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
     };
     let data = vm.get_block_data(globals, bh)?;
     let mut remove = vec![];
-    for (k, v) in lfp.self_val().as_hash().iter() {
-        if vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
-            remove.push(k);
+    let self_val = lfp.self_val();
+    let hash = self_val.as_hash();
+    {
+        let _iter_guard = hash.iter_guard();
+        for (k, v) in hash.iter() {
+            if vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
+                remove.push(k);
+            }
         }
     }
     let changed = !remove.is_empty();
@@ -1348,9 +1366,14 @@ fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
     };
     let data = vm.get_block_data(globals, bh)?;
     let mut remove = vec![];
-    for (k, v) in lfp.self_val().as_hash().iter() {
-        if !vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
-            remove.push(k);
+    let self_val = lfp.self_val();
+    let hash = self_val.as_hash();
+    {
+        let _iter_guard = hash.iter_guard();
+        for (k, v) in hash.iter() {
+            if !vm.invoke_block(globals, &data, &[k, v])?.as_bool() {
+                remove.push(k);
+            }
         }
     }
     let mut h = lfp.self_val().as_hash();

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -16,6 +16,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(METHOD_CLASS, "owner", owner, 0);
     globals.define_builtin_func(METHOD_CLASS, "unbind", unbind, 0);
     globals.define_builtin_func(METHOD_CLASS, "parameters", parameters, 0);
+    globals.define_builtin_funcs(METHOD_CLASS, "==", &["eql?"], method_eq, 1);
 
     globals.define_builtin_class_under_obj("UnboundMethod", UMETHOD_CLASS, ObjTy::METHOD);
     globals.define_builtin_class_func(UMETHOD_CLASS, "allocate", super::class::undef_allocate, 0);
@@ -25,6 +26,47 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(UMETHOD_CLASS, "name", uname, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "owner", uowner, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "parameters", uparameters, 0);
+    globals.define_builtin_funcs(UMETHOD_CLASS, "==", &["eql?"], umethod_eq, 1);
+}
+
+///
+/// ### Method#==
+///
+/// - self == other -> bool
+/// - eql?(other) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/=3d=3d.html]
+#[monoruby_builtin]
+fn method_eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let other = lfp.arg(0);
+    if self_val.class() != other.class() {
+        return Ok(Value::bool(false));
+    }
+    let a = self_val.as_method();
+    let b = other.as_method();
+    let eq = a.func_id() == b.func_id() && a.receiver().id() == b.receiver().id();
+    Ok(Value::bool(eq))
+}
+
+///
+/// ### UnboundMethod#==
+///
+/// - self == other -> bool
+/// - eql?(other) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/=3d=3d.html]
+#[monoruby_builtin]
+fn umethod_eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let other = lfp.arg(0);
+    if self_val.class() != other.class() {
+        return Ok(Value::bool(false));
+    }
+    let a = self_val.as_umethod();
+    let b = other.as_umethod();
+    let eq = a.func_id() == b.func_id() && a.owner() == b.owner();
+    Ok(Value::bool(eq))
 }
 
 ///
@@ -35,7 +77,7 @@ pub(super) fn init(globals: &mut Globals) {
 /// - call(*args) { ... } -> object
 /// - self === *args -> object
 ///
-/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/=3d=3d=3d.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/call.html]
 #[monoruby_builtin]
 fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -72,6 +114,7 @@ fn arity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// - arity -> Integer
 ///
+/// [https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/arity.html]
 #[monoruby_builtin]
 fn uarity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -86,7 +129,7 @@ fn uarity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// - to_proc -> Proc
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Method/i/to_proc.html]
-/// TODO: support keyword arguments
+// TODO: support keyword arguments
 #[monoruby_builtin]
 fn to_proc(_: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
@@ -107,7 +150,7 @@ fn to_proc(_: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
 /// - bind(obj) -> Method
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/bind.html]
-/// TODO: we must reject invalid objects for *obj*
+// TODO: we must reject invalid objects for *obj*
 #[monoruby_builtin]
 fn bind(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -618,4 +618,76 @@ mod tests {
             "##,
         );
     }
+
+    #[test]
+    fn method_eq_alias() {
+        // Aliased methods share the same FuncId, so Method#== returns true.
+        run_test_with_prelude(
+            r##"
+            f = Foo.new
+            [f.method(:bar) == f.method(:baz),
+             f.method(:bar).eql?(f.method(:baz)),
+             f.method(:bar) == f.method(:other)]
+            "##,
+            r##"
+            class Foo
+              def bar; 1; end
+              alias_method :baz, :bar
+              def other; 2; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn method_eq_different_receiver() {
+        // Same method name on two instances → different receiver → not equal.
+        run_test_with_prelude(
+            r##"
+            f1 = Foo.new
+            f2 = Foo.new
+            [f1.method(:bar) == f1.method(:bar),
+             f1.method(:bar) == f2.method(:bar)]
+            "##,
+            r##"
+            class Foo
+              def bar; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn method_eq_non_method() {
+        // Comparing with a non-Method returns false, not an error.
+        run_test_with_prelude(
+            r##"
+            Foo.new.method(:bar) == 42
+            "##,
+            r##"
+            class Foo
+              def bar; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn umethod_eq_alias() {
+        // UnboundMethod#== compares FuncId + owner.
+        run_test_with_prelude(
+            r##"
+            [Foo.instance_method(:bar) == Foo.instance_method(:baz),
+             Foo.instance_method(:bar).eql?(Foo.instance_method(:baz)),
+             Foo.instance_method(:bar) == Foo.instance_method(:other)]
+            "##,
+            r##"
+            class Foo
+              def bar; 1; end
+              alias_method :baz, :bar
+              def other; 2; end
+            end
+            "##,
+        );
+    }
 }

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1602,4 +1602,120 @@ mod tests {
         run_test("Set[1, 2, 3].freeze.reject!.class.to_s");
         run_test("Set[1, 2, 3].freeze.collect!.class.to_s");
     }
+
+    #[test]
+    fn set_divide_arity2() {
+        // Symmetric relation: elements within abs-difference of 1 group together.
+        run_test(
+            "Set[1, 3, 4, 6, 9, 10, 11].divide {|x, y| (x - y).abs == 1 }\
+             .map {|s| s.to_a.sort }.sort",
+        );
+        // SCC with a symmetric relation: (a+b).even? on {1,2,3,4} groups
+        // odd {1,3} and even {2,4}.
+        run_test(
+            "Set[1, 2, 3, 4].divide {|a, b| (a + b).even? }\
+             .map {|s| s.to_a.sort }.sort",
+        );
+    }
+
+    #[test]
+    fn set_initialize_private() {
+        run_test("Set.private_instance_methods(false).include?(:initialize)");
+    }
+
+    #[test]
+    fn set_initialize_uses_each_entry_when_available() {
+        // If the argument responds to #each_entry, Set.new uses it
+        // (rather than #each or #to_a).
+        run_test_with_prelude(
+            "$trace = []; s = Set.new(E.new([10, 20, 30])); [$trace.sort, s.to_a.sort]",
+            r#"
+            class E
+              def initialize(a); @a = a; end
+              def each_entry; @a.each { |x| $trace << x; yield x }; end
+              def each; raise "should not be called"; end
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_initialize_falls_back_to_each() {
+        run_test_with_prelude(
+            "s = Set.new(E.new([1, 2, 2, 3])); s.to_a.sort",
+            r#"
+            class E
+              def initialize(a); @a = a; end
+              def each; @a.each { |x| yield x }; end
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_initialize_non_enumerable_raises() {
+        run_test_error("Set.new(42)");
+    }
+
+    #[test]
+    fn set_inspect_to_s_alias_equal_method() {
+        // Both names resolve to the same underlying Method.
+        run_test("Set.instance_method(:to_s) == Set.instance_method(:inspect)");
+        run_test("Set[].method(:to_s) == Set[].method(:inspect)");
+    }
+
+    #[test]
+    fn set_case_equality_alias() {
+        // Set#=== is an alias for #include? / #member?.
+        run_test("Set.instance_method(:===) == Set.instance_method(:include?)");
+        run_test("Set.instance_method(:===) == Set.instance_method(:member?)");
+    }
+
+    #[test]
+    fn set_iteration_mutation_raises() {
+        // Adding a new element during iteration should raise RuntimeError.
+        run_test_error(
+            "s = Set[:a, :b, :c]; s.each { |x| s << :new if x == :a }",
+        );
+        // merge during iteration raises.
+        run_test_error(
+            "s = Set[1]; s.each { s.merge([99]) }",
+        );
+        // replace during iteration raises (clear inside).
+        run_test_error(
+            "s = Set[1, 2]; s.each { s.replace([9]) }",
+        );
+    }
+
+    #[test]
+    fn set_iteration_delete_allowed() {
+        // Removing an element during iteration is permitted (CRuby-compatible).
+        run_test(
+            "s = Set[1, 2, 3]; s.each { |x| s.delete(x) if x == 2 }; s.to_a.sort",
+        );
+    }
+
+    #[test]
+    fn set_hash_static() {
+        // Same content → same hash, regardless of insertion order.
+        run_test("Set[].hash == Set[].hash");
+        run_test("Set[1, 2, 3].hash == Set[1, 2, 3].hash");
+        run_test("Set[:a, \"b\", \"c\"].hash == Set[\"c\", \"b\", :a].hash");
+        run_test("Set[].hash != Set[1, 2, 3].hash");
+    }
+
+    #[test]
+    fn set_enumerator_forwards_block_result() {
+        // select!/reject! without a block return an Enumerator whose #each
+        // drives the backing method; the user block's truthiness must reach
+        // the filter logic.
+        run_test(
+            "s = Set[\"one\", \"two\", \"three\"]; \
+             s.select!.each { |x| x.size != 3 }; s.to_a",
+        );
+        run_test(
+            "s = Set[\"one\", \"two\", \"three\"]; \
+             s.reject!.each { |x| x.size == 3 }; s.to_a",
+        );
+    }
 }

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1309,22 +1309,25 @@ fn reset(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 /// [https://docs.ruby-lang.org/ja/latest/method/Set/i/hash.html]
 #[monoruby_builtin]
 fn set_hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    use crate::RubyHash;
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
+    use std::hash::Hasher;
+    // Hash every element through `Value::ruby_hash`, which is content-based
+    // (e.g. strings hash by bytes, not by object identity). Combine with
+    // XOR so the result is order-independent — two Sets with the same
+    // members always hash equal regardless of insertion order.
+    //
+    // `DefaultHasher::new()` uses fixed keys, so the result is stable
+    // across processes with the same element hashes.
     let keys = set_keys(lfp.self_val());
-    // XOR all element hashes for order-independence
-    let mut combined: u64 = 0;
-    let hash_id = IdentId::get_id("hash");
+    // Seed mixed in to distinguish an empty Set from other empty
+    // aggregates that XOR-combine to 0.
+    let mut combined: u64 = 0x5e7_5e7_5e7_5e7;
     for k in keys {
-        let h = vm.invoke_method_inner(globals, hash_id, k, &[], None, None)?;
-        if let Some(i) = h.try_fixnum() {
-            combined ^= i as u64;
-        }
+        let mut hasher = DefaultHasher::new();
+        k.ruby_hash(&mut hasher, vm, globals)?;
+        combined ^= hasher.finish();
     }
-    // Mix with Set class identity
-    let mut hasher = DefaultHasher::new();
-    "Set".hash(&mut hasher);
-    combined ^= hasher.finish();
     Ok(Value::integer(combined as i64))
 }
 

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -23,7 +23,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(SET_CLASS, "delete?", delete_q, 1);
     globals.define_builtin_func(SET_CLASS, "each", each, 0);
     globals.define_builtin_func(SET_CLASS, "to_a", to_a, 0);
-    // inspect/to_s handled by RValue::hash_inspect (value/rvalue.rs) for cycle detection
+    // inspect/to_s dispatch to RValue::hash_inspect (value/rvalue.rs) via a shared
+    // FuncId so that `Set#to_s` and `Set#inspect` compare equal as Method objects.
+    globals.define_builtin_funcs(SET_CLASS, "inspect", &["to_s"], set_inspect, 0);
     globals.define_builtin_funcs_with_kw(SET_CLASS, "dup", &["clone"], dup, 0, 1, false, &[], false);
     globals.define_builtin_func_rest(SET_CLASS, "merge", merge);
     globals.define_builtin_func(SET_CLASS, "subtract", subtract, 1);
@@ -106,7 +108,43 @@ fn enum_to_vec(vm: &mut Executor, globals: &mut Globals, val: Value) -> Result<V
     Ok(ary.iter().copied().collect())
 }
 
+///
+/// ### Set.new
+///
+/// - new(enum = nil) -> Set
+/// - new(enum) {|o| ... } -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/s/new.html]
+///
+/// Explicit class method so that `Set.new` goes through `Set.allocate`
+/// (producing a Hash-backed instance) and then calls the Ruby-level
+/// `initialize`. Without this override, the default `Class#new` inline
+/// fast path allocates a plain Object instead of a Hash-backed Set.
+#[monoruby_builtin]
+fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _pc: BytecodePtr) -> Result<Value> {
+    let obj =
+        vm.invoke_method_inner(globals, IdentId::ALLOCATE, lfp.self_val(), &[], None, None)?;
+    let args: Vec<Value> = match lfp.try_arg(0) {
+        Some(v) => vec![v],
+        None => vec![],
+    };
+    vm.invoke_method_inner(
+        globals,
+        IdentId::INITIALIZE,
+        obj,
+        &args,
+        lfp.block(),
+        None,
+    )?;
+    Ok(obj)
+}
+
+///
 /// ### Set.allocate
+///
+/// - allocate -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
 #[monoruby_builtin]
 fn allocate(
     _vm: &mut Executor,
@@ -121,43 +159,13 @@ fn allocate(
 ///
 /// ### Set.[]
 ///
-/// - Set[*ary -> Set
+/// - Set[*ary] -> Set
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Set/s/=5b=5d.html]
 #[monoruby_builtin]
 fn set_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let args = lfp.arg(0).as_array();
     set_from_iter(args.iter().copied(), vm, globals)
-}
-
-///
-/// ### Set.new
-///
-/// - new(enum = nil) -> Set
-/// - new(enum) {|o| block } -> Set
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Set/s/new.html]
-#[monoruby_builtin]
-fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _pc: BytecodePtr) -> Result<Value> {
-    let enum_val = lfp.try_arg(0);
-    match enum_val {
-        Some(val) if !val.is_nil() => {
-            let elems = enum_to_vec(vm, globals, val)?;
-            if let Some(bh) = lfp.block() {
-                let data = vm.get_block_data(globals, bh)?;
-                let mut set = new_empty_set();
-                for elem in elems {
-                    let mapped = vm.invoke_block(globals, &data, &[elem])?;
-                    set.as_hashmap_inner_mut()
-                        .insert(mapped, Value::bool(true), vm, globals)?;
-                }
-                Ok(set)
-            } else {
-                set_from_iter(elems.into_iter(), vm, globals)
-            }
-        }
-        _ => Ok(new_empty_set()),
-    }
 }
 
 ///
@@ -179,11 +187,11 @@ fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 }
 
 ///
-/// ### Set#<<
+/// ### Set#add?
 ///
 /// - add?(o) -> self | nil
 ///
-/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=3c=3c.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/add=3f.html]
 #[monoruby_builtin]
 fn add_q(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let val = lfp.arg(0);
@@ -203,7 +211,7 @@ fn add_q(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// ### Set#===
 ///
-/// - include?(o) -> bool[permalink][rdoc][edit]
+/// - include?(o) -> bool
 /// - member?(o) -> bool
 /// - self === o -> bool
 ///
@@ -251,7 +259,7 @@ fn empty_(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 fn clear(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
-    self_val.as_hashmap_inner_mut().clear();
+    self_val.as_hashmap_inner_mut().clear()?;
     Ok(self_val)
 }
 
@@ -292,6 +300,10 @@ fn delete_q(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// ### Set#each
 ///
+/// - each {|o| ... } -> self
+/// - each -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/each.html]
 #[monoruby_builtin]
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -302,8 +314,10 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
         Some(block) => block,
     };
     let self_val = lfp.self_val();
-    let keys = self_val.as_hashmap_inner().keys();
+    let inner = self_val.as_hashmap_inner();
+    let keys = inner.keys();
     let data = vm.get_block_data(globals, bh)?;
+    let _iter_guard = inner.iter_guard();
     for val in keys {
         vm.invoke_block(globals, &data, &[val])?;
     }
@@ -313,6 +327,9 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
 ///
 /// ### Set#to_a
 ///
+/// - to_a -> Array
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/to_a.html]
 #[monoruby_builtin]
 fn to_a(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let keys = set_keys(lfp.self_val());
@@ -320,15 +337,35 @@ fn to_a(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 }
 
 ///
-/// ### Set#inspect / Set#to_s
+/// ### Set#inspect
 ///
-/// Handled by RValue::hash_inspect (in value/rvalue.rs) which detects
-/// whether the HASH-typed object is a Set or Hash by checking the class ID,
-/// and uses the shared HashSet-based cycle detection from Value::inspect_inner.
+/// - inspect -> String
+/// - to_s -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/inspect.html]
+///
+/// Delegates to the shared `Value::inspect` path (which dispatches to
+/// `RValue::hash_inspect` for HASH-typed values and handles cycle
+/// detection). Registered as an alias pair so the two method names
+/// share a single `FuncId` and compare equal as `Method` objects.
+#[monoruby_builtin]
+fn set_inspect(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let s = lfp.self_val().inspect(&globals.store);
+    Ok(Value::string(s))
+}
 
 ///
-/// ### Set#dup / Set#clone
+/// ### Set#dup
 ///
+/// - dup -> Set
+/// - clone -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/dup.html]
 #[monoruby_builtin]
 fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let keys = set_keys(lfp.self_val());
@@ -338,6 +375,9 @@ fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 ///
 /// ### Set#merge
 ///
+/// - merge(*enums) -> self
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/merge.html]
 #[monoruby_builtin]
 fn merge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
@@ -357,6 +397,9 @@ fn merge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// ### Set#subtract
 ///
+/// - subtract(enum) -> self
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/subtract.html]
 #[monoruby_builtin]
 fn subtract(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
@@ -371,12 +414,15 @@ fn subtract(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// ### Set#replace
 ///
+/// - replace(enum) -> self
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/replace.html]
 #[monoruby_builtin]
 fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
     let elems = enum_to_vec(vm, globals, lfp.arg(0))?;
-    self_val.as_hashmap_inner_mut().clear();
+    self_val.as_hashmap_inner_mut().clear()?;
     for elem in elems {
         self_val
             .as_hashmap_inner_mut()
@@ -386,8 +432,12 @@ fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 }
 
 ///
-/// ### Set#& / Set#intersection
+/// ### Set#&
 ///
+/// - self & enum -> Set
+/// - intersection(enum) -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=26.html]
 #[monoruby_builtin]
 fn intersection(
     vm: &mut Executor,
@@ -418,8 +468,13 @@ fn intersection(
 }
 
 ///
-/// ### Set#| / Set#+ / Set#union
+/// ### Set#|
 ///
+/// - self | enum -> Set
+/// - self + enum -> Set
+/// - union(enum) -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=7c.html]
 #[monoruby_builtin]
 fn union_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_keys = set_keys(lfp.self_val());
@@ -439,8 +494,12 @@ fn union_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 }
 
 ///
-/// ### Set#- / Set#difference
+/// ### Set#-
 ///
+/// - self - enum -> Set
+/// - difference(enum) -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=2d.html]
 #[monoruby_builtin]
 fn difference(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -467,6 +526,9 @@ fn difference(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 ///
 /// ### Set#^
 ///
+/// - self ^ enum -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=5e.html]
 #[monoruby_builtin]
 fn symmetric_difference(
     vm: &mut Executor,
@@ -505,6 +567,10 @@ fn symmetric_difference(
 ///
 /// ### Set#==
 ///
+/// - self == set -> bool
+/// - eql?(set) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=3d=3d.html]
 #[monoruby_builtin]
 fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let other = lfp.arg(0);
@@ -528,8 +594,12 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 }
 
 ///
-/// ### Set#subset? / Set#<=
+/// ### Set#subset?
 ///
+/// - subset?(set) -> bool
+/// - self <= set -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=3c=3d.html]
 #[monoruby_builtin]
 fn subset_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -551,8 +621,12 @@ fn subset_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 }
 
 ///
-/// ### Set#superset? / Set#>=
+/// ### Set#superset?
 ///
+/// - superset?(set) -> bool
+/// - self >= set -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=3e=3d.html]
 #[monoruby_builtin]
 fn superset_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -574,8 +648,12 @@ fn superset_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 }
 
 ///
-/// ### Set#proper_subset? / Set#<
+/// ### Set#proper_subset?
 ///
+/// - proper_subset?(set) -> bool
+/// - self < set -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/proper_subset=3f.html]
 #[monoruby_builtin]
 fn proper_subset_(
     vm: &mut Executor,
@@ -602,8 +680,12 @@ fn proper_subset_(
 }
 
 ///
-/// ### Set#proper_superset? / Set#>
+/// ### Set#proper_superset?
 ///
+/// - proper_superset?(set) -> bool
+/// - self > set -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/proper_superset=3f.html]
 #[monoruby_builtin]
 fn proper_superset_(
     vm: &mut Executor,
@@ -632,6 +714,9 @@ fn proper_superset_(
 ///
 /// ### Set#<=>
 ///
+/// - self <=> set -> -1 | 0 | 1 | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/=3c=3d=3e.html]
 #[monoruby_builtin]
 fn spaceship(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let other = lfp.arg(0);
@@ -672,6 +757,9 @@ fn spaceship(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// ### Set#disjoint?
 ///
+/// - disjoint?(enum) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/disjoint=3f.html]
 #[monoruby_builtin]
 fn disjoint_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -711,6 +799,9 @@ fn disjoint_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// ### Set#intersect?
 ///
+/// - intersect?(enum) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/intersect=3f.html]
 #[monoruby_builtin]
 fn intersect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -750,6 +841,10 @@ fn intersect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 ///
 /// ### Set#delete_if
 ///
+/// - delete_if {|o| ... } -> self
+/// - delete_if -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/delete_if.html]
 #[monoruby_builtin]
 fn delete_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -779,6 +874,10 @@ fn delete_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
 ///
 /// ### Set#keep_if
 ///
+/// - keep_if {|o| ... } -> self
+/// - keep_if -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/keep_if.html]
 #[monoruby_builtin]
 fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -806,8 +905,14 @@ fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 }
 
 ///
-/// ### Set#select! / Set#filter!
+/// ### Set#select!
 ///
+/// - select! {|o| ... } -> self | nil
+/// - filter! {|o| ... } -> self | nil
+/// - select! -> Enumerator
+/// - filter! -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/select=21.html]
 #[monoruby_builtin]
 fn select_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -840,6 +945,10 @@ fn select_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 ///
 /// ### Set#reject!
 ///
+/// - reject! {|o| ... } -> self | nil
+/// - reject! -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/reject=21.html]
 #[monoruby_builtin]
 fn reject_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -870,8 +979,14 @@ fn reject_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 }
 
 ///
-/// ### Set#collect! / Set#map!
+/// ### Set#collect!
 ///
+/// - collect! {|o| ... } -> self
+/// - map! {|o| ... } -> self
+/// - collect! -> Enumerator
+/// - map! -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/collect=21.html]
 #[monoruby_builtin]
 fn collect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -890,7 +1005,7 @@ fn collect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
         new_elems.push(mapped);
     }
     let mut self_val = lfp.self_val();
-    self_val.as_hashmap_inner_mut().clear();
+    self_val.as_hashmap_inner_mut().clear()?;
     for elem in new_elems {
         self_val
             .as_hashmap_inner_mut()
@@ -902,6 +1017,9 @@ fn collect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
 ///
 /// ### Set#flatten
 ///
+/// - flatten -> Set
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/flatten.html]
 #[monoruby_builtin]
 fn flatten(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -941,6 +1059,9 @@ fn flatten_set_into(
 ///
 /// ### Set#flatten!
 ///
+/// - flatten! -> self | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/flatten=21.html]
 #[monoruby_builtin]
 fn flatten_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
@@ -956,7 +1077,7 @@ fn flatten_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     flatten_set_into(&mut result, self_val, vm, globals, &mut seen)?;
     // Replace self's contents
     let mut self_val = lfp.self_val();
-    self_val.as_hashmap_inner_mut().clear();
+    self_val.as_hashmap_inner_mut().clear()?;
     let new_keys = set_keys(result);
     for k in new_keys {
         self_val
@@ -966,7 +1087,12 @@ fn flatten_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     Ok(self_val)
 }
 
+///
 /// ### Set#join
+///
+/// - join(sep = "") -> String
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/join.html]
 #[monoruby_builtin]
 fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let sep = if let Some(s) = lfp.try_arg(0) {
@@ -994,7 +1120,13 @@ fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     Ok(Value::string(result))
 }
 
+///
 /// ### Set#classify
+///
+/// - classify {|o| ... } -> Hash
+/// - classify -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/classify.html]
 #[monoruby_builtin]
 fn classify(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -1022,7 +1154,14 @@ fn classify(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
     Ok(result_hash)
 }
 
+///
 /// ### Set#divide
+///
+/// - divide {|o| ... } -> Set
+/// - divide {|o1, o2| ... } -> Set
+/// - divide -> Enumerator
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/divide.html]
 #[monoruby_builtin]
 fn divide(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
@@ -1041,40 +1180,87 @@ fn divide(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
     } else {
         1
     };
-    if arity == 2 || arity == -1 || arity < -2 || arity > 2 {
-        // Arity-2 mode: union-find based divide
-        // Group elements where block(a, b) returns true
+    if arity == 2 {
+        // Arity-2 mode: group elements by strongly-connected components
+        // of the directed graph with edge i->j iff block(keys[i], keys[j])
+        // returns truthy. Block is called for every ordered pair (i, j)
+        // where i != j.
         let n = keys.len();
-        let mut parent: Vec<usize> = (0..n).collect();
-        fn find(parent: &mut Vec<usize>, i: usize) -> usize {
-            if parent[i] != i {
-                parent[i] = find(parent, parent[i]);
-            }
-            parent[i]
-        }
-        fn union(parent: &mut Vec<usize>, i: usize, j: usize) {
-            let ri = find(parent, i);
-            let rj = find(parent, j);
-            if ri != rj {
-                parent[ri] = rj;
-            }
-        }
+        let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
         for i in 0..n {
-            for j in (i + 1)..n {
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
                 let result = vm.invoke_block(globals, &data, &[keys[i], keys[j]])?;
                 if result.as_bool() {
-                    union(&mut parent, i, j);
+                    adj[i].push(j);
                 }
             }
         }
-        // Group by root
-        let mut groups: std::collections::HashMap<usize, Vec<Value>> = std::collections::HashMap::new();
-        for i in 0..n {
-            let root = find(&mut parent, i);
-            groups.entry(root).or_default().push(keys[i]);
+        // Tarjan's SCC
+        let mut index_counter: usize = 0;
+        let mut stack: Vec<usize> = Vec::new();
+        let mut on_stack: Vec<bool> = vec![false; n];
+        let mut idx: Vec<Option<usize>> = vec![None; n];
+        let mut low: Vec<usize> = vec![0; n];
+        let mut sccs: Vec<Vec<usize>> = Vec::new();
+        // Iterative Tarjan to avoid stack overflow on large sets.
+        enum Step { Enter(usize), Resume(usize, usize) }
+        for start in 0..n {
+            if idx[start].is_some() {
+                continue;
+            }
+            let mut work: Vec<Step> = vec![Step::Enter(start)];
+            while let Some(step) = work.pop() {
+                match step {
+                    Step::Enter(v) => {
+                        idx[v] = Some(index_counter);
+                        low[v] = index_counter;
+                        index_counter += 1;
+                        stack.push(v);
+                        on_stack[v] = true;
+                        work.push(Step::Resume(v, 0));
+                    }
+                    Step::Resume(v, i) => {
+                        if i < adj[v].len() {
+                            let w = adj[v][i];
+                            work.push(Step::Resume(v, i + 1));
+                            if idx[w].is_none() {
+                                work.push(Step::Enter(w));
+                            } else if on_stack[w] {
+                                if let Some(wi) = idx[w] {
+                                    if wi < low[v] {
+                                        low[v] = wi;
+                                    }
+                                }
+                            }
+                        } else {
+                            // Propagate low from children that have returned.
+                            for &w in &adj[v] {
+                                if on_stack[w] && low[w] < low[v] {
+                                    low[v] = low[w];
+                                }
+                            }
+                            if Some(low[v]) == idx[v] {
+                                let mut comp = Vec::new();
+                                while let Some(w) = stack.pop() {
+                                    on_stack[w] = false;
+                                    comp.push(w);
+                                    if w == v {
+                                        break;
+                                    }
+                                }
+                                sccs.push(comp);
+                            }
+                        }
+                    }
+                }
+            }
         }
         let mut result_set = new_empty_set();
-        for (_root, elems) in groups {
+        for comp in sccs {
+            let elems: Vec<Value> = comp.into_iter().map(|i| keys[i]).collect();
             let subset = set_from_iter(elems.into_iter(), vm, globals)?;
             result_set.as_hashmap_inner_mut().insert(subset, Value::bool(true), vm, globals)?;
         }
@@ -1102,7 +1288,12 @@ fn divide(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
     }
 }
 
+///
 /// ### Set#reset
+///
+/// - reset -> self
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/reset.html]
 #[monoruby_builtin]
 fn reset(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // In CRuby, reset rebuilds the internal hash. For us, it's a no-op since
@@ -1110,7 +1301,12 @@ fn reset(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(lfp.self_val())
 }
 
+///
 /// ### Set#hash
+///
+/// - hash -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Set/i/hash.html]
 #[monoruby_builtin]
 fn set_hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use std::collections::hash_map::DefaultHasher;

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -44,10 +44,31 @@ impl std::default::Default for HashDefault {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct HashmapInner {
     default: HashDefault,
     content: HashContent,
+    /// Active iteration count on this hash. Incremented while a block-based
+    /// traversal (each, each_pair, each_key, etc.) is in progress and
+    /// decremented when it finishes. Mutating operations consult this via
+    /// [`Self::check_iter`] and raise `RuntimeError` when non-zero.
+    ///
+    /// Corresponds to CRuby's `RHASH_ITER_LEV`. Wrapped in `Cell` so that
+    /// a traversal holding a shared borrow of the hash (for iteration) can
+    /// still record its presence here.
+    iter_lev: std::cell::Cell<u32>,
+}
+
+impl Clone for HashmapInner {
+    /// Clones the default and content but resets `iter_lev` to 0 — a fresh
+    /// copy is not being iterated, regardless of the original's state.
+    fn clone(&self) -> Self {
+        HashmapInner {
+            default: self.default.clone(),
+            content: self.content.clone(),
+            iter_lev: std::cell::Cell::new(0),
+        }
+    }
 }
 
 impl RubyEql<Executor, Globals, MonorubyErr> for HashmapInner {
@@ -88,6 +109,7 @@ impl HashmapInner {
         HashmapInner {
             default: HashDefault::default(),
             content: HashContent::new(map),
+            iter_lev: std::cell::Cell::new(0),
         }
     }
 
@@ -95,6 +117,7 @@ impl HashmapInner {
         HashmapInner {
             default: HashDefault::Value(default),
             content: HashContent::new(map),
+            iter_lev: std::cell::Cell::new(0),
         }
     }
 
@@ -102,6 +125,7 @@ impl HashmapInner {
         HashmapInner {
             default: HashDefault::Proc(default_proc),
             content: HashContent::new(map),
+            iter_lev: std::cell::Cell::new(0),
         }
     }
 
@@ -127,6 +151,30 @@ impl HashmapInner {
 
     pub fn set_defalut_proc(&mut self, default_proc: Proc) {
         self.default = HashDefault::Proc(default_proc);
+    }
+
+    /// Raise `RuntimeError` if a traversal is currently in progress on
+    /// this hash. Called from mutating entry points that change the set
+    /// of keys (delete, clear, shift, compare_by_identity). Updating the
+    /// value of an already-present key does *not* go through this check —
+    /// matching CRuby, where `h.each { h[existing] = v }` is allowed but
+    /// `h.each { h[new] = v }` or `h.each { h.delete(k) }` raises.
+    pub fn check_iter(&self) -> Result<()> {
+        if self.iter_lev.get() > 0 {
+            Err(MonorubyErr::runtimeerr(
+                "can't modify hash during iteration",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Start a traversal: returns an RAII guard that decrements `iter_lev`
+    /// when dropped. Takes `&self` (not `&mut`) so the hash can be iterated
+    /// concurrently with the guard being alive.
+    pub fn iter_guard(&self) -> IterGuard<'_> {
+        self.iter_lev.set(self.iter_lev.get() + 1);
+        IterGuard { inner: self }
     }
 
     fn id(&self) -> HashId {
@@ -157,10 +205,52 @@ impl HashmapInner {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Option<Value>> {
+        // Removing a key during iteration is explicitly allowed — CRuby
+        // behaves the same way (see ruby/spec core/hash/delete_spec.rb
+        // "allows removing a key while iterating").
         Ok(match &mut self.content {
             HashContent::Map(map) => map.shift_remove(&k, vm, globals)?,
             HashContent::IdentMap(map) => map.shift_remove(&IdentKey(k), vm, globals)?,
         })
+    }
+
+    pub fn insert(
+        &mut self,
+        k: Value,
+        v: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        if self.iter_lev.get() > 0 && !self.content.contains_key(k, vm, globals)? {
+            return Err(MonorubyErr::runtimeerr(
+                "can't add a new key into hash during iteration",
+            ));
+        }
+        self.content.insert(k, v, vm, globals)
+    }
+
+    pub fn clear(&mut self) -> Result<()> {
+        self.check_iter()?;
+        self.content.clear();
+        Ok(())
+    }
+
+    pub fn shift(
+        &mut self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<(Value, Value)>> {
+        self.check_iter()?;
+        self.content.shift(vm, globals)
+    }
+
+    pub fn compare_by_identity(
+        &mut self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        self.check_iter()?;
+        self.content.compare_by_identity(vm, globals)
     }
 
     /*pub fn entry_and_modify<F>(&mut self, k: Value, f: F)
@@ -240,6 +330,20 @@ impl HashmapInner {
                 format! {"{{{}}}", result}
             }
         }
+    }
+}
+
+/// RAII guard returned from [`HashmapInner::iter_guard`].
+///
+/// While alive it represents a single layer of active iteration; dropping it
+/// (normal return or unwinding via `Result::Err`) decrements `iter_lev`.
+pub struct IterGuard<'a> {
+    inner: &'a HashmapInner,
+}
+
+impl Drop for IterGuard<'_> {
+    fn drop(&mut self) {
+        self.inner.iter_lev.set(self.inner.iter_lev.get() - 1);
     }
 }
 


### PR DESCRIPTION
## Summary

Improves `core/set` ruby/spec compliance from **19 failures + 4 errors → 1 failure + 2 errors** (15 issues resolved), and introduces a CRuby-compatible iteration guard for `Hash`.

## Changes

### Set
- **`Set#initialize`**: go through `Set.allocate` + a private Ruby-level `initialize` that dispatches to `#each_entry` then `#each` on the provided enumerable. No longer calls `#to_a`, matching the ruby/spec expectation (and the Mock-based tests).
- **`Set#divide`**: only `arity == 2` takes the pair-mode path; pair mode rewritten as iterative Tarjan SCC over the directed graph with edge `i → j` iff `block(keys[i], keys[j])` is truthy, evaluating every ordered pair `i != j`.
- **`Set#inspect` / `Set#to_s`**: registered as an alias pair (shared `FuncId`) so `Method#==` reports them equal.

### Method / UnboundMethod
- **`Method#==` / `#eql?`**: equal iff same `FuncId` and same receiver — aliases of the same underlying method now compare equal.
- **`UnboundMethod#==` / `#eql?`**: equal iff same `FuncId` and same owner.

### Enumerator
- **`Enumerator#each`**: forwards the user block's return value back into the backing fiber. Previously the block result was discarded, so `select!`/`reject!` driven through an Enumerator saw `nil` as every block result.

### Hash iteration guard (CRuby `RHASH_ITER_LEV` equivalent)
- `HashmapInner` gains `iter_lev: Cell<u32>` and an `IterGuard<'_>` RAII helper (`Drop` decrements, so even panicking blocks can't leak the counter).
- `insert` raises `RuntimeError(\"can't add a new key into hash during iteration\")` **only when the key is new** (existing-key updates remain allowed, matching CRuby).
- `clear` / `shift` / `compare_by_identity` raise `RuntimeError(\"can't modify hash during iteration\")`.
- `remove` deliberately does **not** check — CRuby allows `h.delete(k)` during iteration (see `core/hash/delete_spec.rb` \"allows removing a key while iterating\").
- `Hash` `each` / `each_key` / `each_value` / `select!` / `delete_if` / `reject!` / `keep_if`, and `Set#each` all take the guard before looping.
- `Clone` is implemented by hand so a freshly cloned hash starts at `iter_lev = 0`.

### Doc comments
- `method.rs` and `set.rs` Ruby-method doc comments unified to the rdoc/るりま style used in `array.rs` (signature list + docs.ruby-lang.org URL).

## Test plan
- [x] `cargo test --release -p monoruby --lib` — 1068 / 1068 passing
- [x] `cargo test --release -p monoruby --test set` — 20 / 20 passing
- [x] `core/set` mspec: 162 examples, 1 failure + 2 errors (down from 19+4)
  - remaining: `Set#hash is static` (separate issue), arity-2 divide Enumerator (monoruby Enumerator infra limitation), `compare_by_identity_spec.rb` parse error (issue #316)
- [x] `core/hash` mspec: no regressions, `Hash#delete` during iteration now green

## Notes
- `Hash#[]=` is not inlined, so the JIT hot path also flows through `HashmapInner::insert` and picks up the guard automatically.
- The remaining `Set#divide` enumerator failure is a monoruby Enumerator infrastructure limitation (block arity doesn't reach the backing method when re-invoked via the yielder), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)