### PR TITLE
Fix String#hash to return content-based hash

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5911,6 +5911,21 @@ mod tests {
     }
 
     #[test]
+    fn string_hash() {
+        // Hash values differ between monoruby and CRuby, so assert the
+        // Object#hash contract (equal content -> equal hash) instead.
+        run_tests(&[
+            r#""hello".hash == "hello".hash"#,
+            r#""b".hash == "b".hash"#,
+            r#"s1 = "hello"; s2 = "hel" + "lo"; s1.hash == s2.hash"#,
+            r#""".hash == "".hash"#,
+            r#""café".hash == "café".hash"#,
+            r#""a".hash == "b".hash"#,
+            r#""hello".hash.is_a?(Integer)"#,
+        ]);
+    }
+
+    #[test]
     fn string_inspect() {
         run_tests(&[
             // ASCII

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -23,6 +23,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(STRING_CLASS, "try_convert", string_try_convert, 1);
     globals.define_builtin_func(STRING_CLASS, "+", add, 1);
     globals.define_builtin_func(STRING_CLASS, "*", mul, 1);
+    globals.define_builtin_func(STRING_CLASS, "hash", hash, 0);
     globals.define_builtin_func(STRING_CLASS, "==", eq, 1);
     globals.define_builtin_func(STRING_CLASS, "===", eq, 1);
     globals.define_builtin_func(STRING_CLASS, "<=>", cmp, 1);
@@ -263,6 +264,18 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     }
     let res = Value::string_from_inner(inner.repeat(count));
     Ok(res)
+}
+
+///
+/// ### String#hash
+///
+/// - hash -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/String/i/hash.html]
+#[monoruby_builtin]
+fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let h = lfp.self_val().calculate_hash(vm, globals)?;
+    Ok(Value::integer_from_u64(h))
 }
 
 ///


### PR DESCRIPTION
## Summary
- Define `String#hash` explicitly, delegating to `Value::calculate_hash` (which routes through the existing content-based `RString::hash` used by `Hash`/`Set` internals).
- Previously `String` inherited `Kernel#hash`, returning object identity — two strings with equal content produced different hashes, violating Ruby's `Object#hash` contract.

Closes #318.

## Test plan
- [x] `p "b".hash` prints the same value on repeated calls
- [x] `"hello".hash == "hello".hash` returns `true`
- [x] `cargo test`