### PR TITLE
Fix regex literal parsing with unescaped braces (#316)

### DIFF
--- a/ruruby-parse/src/lib.rs
+++ b/ruruby-parse/src/lib.rs
@@ -142,4 +142,27 @@ mod test {
         .unwrap();
         eprintln!("{:?}", res)
     }
+
+    /// Regression test for issue #316: regex literals with unescaped `{`/`}`
+    /// in contexts Onigmo accepts (inside `[...]` or as literal braces inside
+    /// groups) must parse successfully.
+    #[test]
+    fn regex_brace_in_char_class() {
+        use crate::parser::*;
+        let sources = [
+            r#"p /a(\[|: {)[\]}]b/"#,
+            r#"p /can't modify frozen Set: (#<)?Set(\[|: {)[\]}]>?/"#,
+            r#"p /[{}]/"#,
+            r#"p /a{1,2}/"#,
+            r#"p /({)/"#,
+            r#"p /(})/"#,
+        ];
+        for src in sources {
+            Parser::<DummyContext>::parse_program(
+                src.to_string(),
+                std::path::PathBuf::from("path"),
+            )
+            .unwrap_or_else(|e| panic!("failed to parse {src:?}: {e:?}"));
+        }
+    }
 }

--- a/ruruby-parse/src/parser/lexer.rs
+++ b/ruruby-parse/src/parser/lexer.rs
@@ -1235,17 +1235,6 @@ impl<'a> Lexer<'a> {
                         return Err(self.error_unexpected(self.pos - 1));
                     };
                 }
-                '{' if char_class.last() != Some(&ParenKind::Bracket) => {
-                    char_class.push(ParenKind::Brace);
-                    body.push('{');
-                }
-                '}' if char_class.last() != Some(&ParenKind::Bracket) => {
-                    if let Some(ParenKind::Brace) = char_class.pop() {
-                        body.push('}');
-                    } else {
-                        return Err(self.error_unexpected(self.pos - 1));
-                    };
-                }
                 '\\' => {
                     let ch = self.get()?;
                     match ch {


### PR DESCRIPTION
## Summary
- The regex lexer in `ruruby-parse` tracked `{`/`}` for balance, which caused `)` to fail when a literal `{` appeared inside a group (e.g. `/a(\[|: {)[\]}]b/`).
- Ruby/Onigmo treat `{` and `}` as literal characters outside valid `{n,m}` quantifiers, and regex termination only depends on `[...]` tracking. Brace tracking is removed.
- Fixes #316.

## Test plan
- [x] `cargo test -p ruruby-parse` passes, including the new `regex_brace_in_char_class` regression test covering the issue repro and the original `core/set/compare_by_identity_spec.rb` line.
- [x] Manual check: `p /a(\[|: {)[\]}]b/` and `p /can't modify frozen Set: (#<)?Set(\[|: {)[\]}]>?/` now produce output matching CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)