### PR TITLE
Fix Class spec failures: allocate, dup, defined?, Class#new

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -74,9 +74,6 @@ fn class_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         .as_val();
     let m = globals.store.define_unnamed_class(superclass);
     let obj = m.as_val();
-    if let Some(block) = lfp.block() {
-        vm.module_eval(globals, m, block)?;
-    }
     vm.invoke_method_inner(
         globals,
         IdentId::INHERITED,
@@ -85,6 +82,9 @@ fn class_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         None,
         None,
     )?;
+    if let Some(block) = lfp.block() {
+        vm.module_eval(globals, m, block)?;
+    }
     Ok(obj)
 }
 
@@ -189,8 +189,48 @@ pub(super) fn new(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let obj =
-        vm.invoke_method_inner(globals, IdentId::ALLOCATE, lfp.self_val(), &[], None, None)?;
+    // CRuby's Class#new uses an internal allocator (a C-level alloc_func) and
+    // does NOT dispatch to a user-defined `allocate` method. monoruby has no
+    // separate alloc_func table, so emulate this by looking up `allocate`
+    // starting at the class's metaclass superclass — skipping any user
+    // override on the receiver class's own singleton class.
+    let self_val = lfp.self_val();
+    let meta_id = self_val.class();
+    // First check the normal lookup. If the resolved `allocate` is a native
+    // (built-in) function we use it as-is — that covers registered class-level
+    // allocators such as Hash's allocate or Complex's `undef_allocate`.
+    // If it's a Ruby-level override (`def self.allocate`) on the receiver
+    // class's own metaclass, skip past it and search from the metaclass's
+    // superclass so we use the inherited built-in allocator, matching CRuby's
+    // C-level alloc_func behavior.
+    let alloc_fid = globals
+        .store
+        .check_method_for_class(meta_id, IdentId::ALLOCATE)
+        .and_then(|e| e.func_id());
+    let alloc_fid = match alloc_fid {
+        Some(fid)
+            if !matches!(
+                globals.store[fid].kind,
+                crate::globals::FuncKind::ISeq(_) | crate::globals::FuncKind::Proc(_)
+            ) =>
+        {
+            Some(fid)
+        }
+        _ => {
+            let meta = globals.store[meta_id].get_module();
+            let search_from = meta.superclass().map(|m| m.id()).unwrap_or(meta_id);
+            globals
+                .store
+                .check_method_for_class(search_from, IdentId::ALLOCATE)
+                .and_then(|e| e.func_id())
+        }
+    };
+    let obj = match alloc_fid {
+        Some(fid) => vm.invoke_func_inner(globals, fid, self_val, &[], None, None)?,
+        None => {
+            vm.invoke_method_inner(globals, IdentId::ALLOCATE, self_val, &[], None, None)?
+        }
+    };
 
     vm.invoke_method_inner(
         globals,
@@ -217,14 +257,22 @@ pub(super) fn new(
 #[monoruby_builtin]
 fn superclass(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let class = lfp.self_val().as_class();
     match class.get_real_superclass() {
         Some(class) => Ok(class.into()),
-        None => Ok(Value::nil()),
+        None => {
+            // Distinguish uninitialized classes (from Class.allocate) from BasicObject.
+            // An uninitialized class has neither a name nor a superclass.
+            let info = &globals.store[class.id()];
+            if info.get_name().is_none() && class.superclass().is_none() && class.id() != BASIC_OBJECT_CLASS {
+                return Err(MonorubyErr::typeerr("uninitialized class"));
+            }
+            Ok(Value::nil())
+        }
     }
 }
 
@@ -517,6 +565,128 @@ mod tests {
         Class.new(A)
         $res
         "##,
+        );
+    }
+
+    #[test]
+    fn class_new_block_runs_after_inherited_hook() {
+        // `Class.new(sup) { block }` must fire `inherited` before yielding the block.
+        run_test(
+            r##"
+        $res = []
+        class D
+          def self.inherited(sub)
+            $res << "inherited:#{self}"
+          end
+        end
+        k = Class.new(D) { $res << "block" }
+        $res
+        "##,
+        );
+    }
+
+    #[test]
+    fn class_allocate_superclass_raises() {
+        // Uninitialized class (from Class.allocate) must raise TypeError on #superclass.
+        run_test_error("Class.allocate.superclass");
+        // But BasicObject#superclass must still return nil (not raise).
+        run_test("BasicObject.superclass.inspect");
+    }
+
+    #[test]
+    fn class_new_bypasses_user_allocate() {
+        // User-level `def self.allocate` must NOT be called by Class#new
+        // (CRuby uses an internal C-level allocator).
+        run_test(
+            r#"
+        klass = Class.new do
+          def self.allocate
+            raise "allocate should not be called"
+          end
+        end
+        instance = klass.new
+        [instance.is_a?(klass), instance.class == klass]
+        "#,
+        );
+        // But `klass.allocate` called directly still dispatches to user override.
+        run_test_error(
+            r#"
+        klass = Class.new do
+          def self.allocate
+            raise "boom"
+          end
+        end
+        klass.allocate
+        "#,
+        );
+        // Built-in undef_allocate (e.g. Complex) must still prevent instantiation.
+        run_test_error("Complex.new(1)");
+        run_test_error("Rational.new(1)");
+    }
+
+    #[test]
+    fn class_dup_preserves_singleton_class() {
+        // `def self.foo` on the original must survive `.dup`.
+        run_test(
+            r#"
+        klass = Class.new do
+          def hello; "hello"; end
+          def self.message; "text"; end
+        end
+        d = klass.dup
+        [d.new.hello, d.message]
+        "#,
+        );
+        // `extend`-ed module must remain in the dup's singleton-class ancestor chain.
+        run_test(
+            r#"
+        mod = Module.new do
+          def greet; "hi"; end
+        end
+        klass = Class.new
+        klass.extend(mod)
+        d = klass.dup
+        d.greet
+        "#,
+        );
+        // Superclass singleton methods are still inherited through the dup.
+        run_test(
+            r#"
+        sup = Class.new do
+          def self.message; "text"; end
+          def hello; "hello"; end
+        end
+        klass = Class.new(sup)
+        d = klass.dup
+        [d.new.hello, d.message]
+        "#,
+        );
+    }
+
+    #[test]
+    fn defined_scoped_const_via_self() {
+        // `defined?(self::C)` must resolve the constant against the parent
+        // expression (here: self, the receiver in the inherited hook).
+        run_test(
+            r##"
+        $res = []
+        parent = Class.new do
+          def self.inherited(subclass)
+            $res << defined?(self::C)
+            $res << const_defined?(:C)
+            $res << constants
+          end
+        end
+        class parent::C < parent; end
+        $res
+        "##,
+        );
+        // `defined?` returns nil when the scoped constant is missing.
+        run_test(
+            r#"
+        m = Module.new
+        defined?(m::NOPE).inspect
+        "#,
         );
     }
 

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -1132,66 +1132,64 @@ mod tests {
         }
         run_tests(&test);
 
-        // Beginless ranges (nil..end)
-        run_test(r#"(nil..5).include?(3)"#);
-        run_test(r#"(nil..5).include?(5)"#);
-        run_test(r#"(nil..5).include?(6)"#);
-        run_test(r#"(nil...5).include?(5)"#);
-        run_test(r#"(nil..5.0).include?(3.0)"#);
-        run_test(r#"(nil..5).include?(:a)"#);
-        // exclude-end beginless
-        run_test(r#"(nil...5).include?(4)"#);
-        run_test(r#"(nil...5.0).include?(5.0)"#);
-        // beginless with float endpoint and integer value
-        run_test(r#"(nil..5.0).include?(3)"#);
-        run_test(r#"(nil..5.0).include?(5)"#);
-        // beginless via ===
-        run_test(r#"(nil..5) === 3"#);
-        run_test(r#"(nil..5) === 6"#);
-        run_test(r#"(nil...5) === 5"#);
-
-        // Endless ranges (beg..nil)
-        run_test(r#"(1..nil).include?(3)"#);
-        run_test(r#"(1..nil).include?(0)"#);
-        run_test(r#"(1.0..nil).include?(3.0)"#);
-        run_test(r#"(1..nil).include?(:a)"#);
-        // endless with float endpoint and integer value
-        run_test(r#"(1.0..nil).include?(2)"#);
-        run_test(r#"(1.0..nil).include?(0)"#);
-        // endless via ===
-        run_test(r#"(1..nil) === 3"#);
-        run_test(r#"(1..nil) === 0"#);
-        run_test(r#"(1.0..nil) === 3.0"#);
-
-        // Both-nil ranges (nil..nil) — numeric values are always included
-        run_test(r#"(nil..nil).include?(0)"#);
-        run_test(r#"(nil..nil).include?(42)"#);
-        run_test(r#"(nil..nil).include?(3.14)"#);
-        // (nil..nil).include?(:a) raises TypeError in CRuby; monoruby returns false
-        // (nil..nil) === :a  returns true in CRuby (cover? semantics); monoruby returns false
-        // These divergences are not tested here.
-        run_test(r#"(nil..nil) === 0"#);
-
-        // String ranges
-        run_test(r#"("a".."z").include?("a")"#);
-        run_test(r#"("a".."z").include?("m")"#);
-        run_test(r#"("a".."z").include?("z")"#);
-        run_test(r#"("a"..."z").include?("z")"#);
-        run_test(r#"("a".."z").include?("A")"#);
-        run_test(r#"("a".."z").include?(1)"#);
-        // string ranges via ===
-        run_test(r#"("a".."z") === "a""#);
-        run_test(r#"("a".."z") === "m""#);
-        run_test(r#"("a".."z") === "z""#);
-        run_test(r#"("a"..."z") === "z""#);
-        run_test(r#"("a".."z") === 1"#);
-
-        // member? is an alias for include?
-        run_test(r#"(1..5).member?(3)"#);
-        run_test(r#"(1..5).member?(6)"#);
-        run_test(r#"("a".."z").member?("m")"#);
-        run_test(r#"(nil..5).member?(3)"#);
-        run_test(r#"(1..nil).member?(3)"#);
+        run_tests(&[
+            // Beginless ranges (nil..end)
+            r#"(nil..5).include?(3)"#,
+            r#"(nil..5).include?(5)"#,
+            r#"(nil..5).include?(6)"#,
+            r#"(nil...5).include?(5)"#,
+            r#"(nil..5.0).include?(3.0)"#,
+            r#"(nil..5).include?(:a)"#,
+            // exclude-end beginless
+            r#"(nil...5).include?(4)"#,
+            r#"(nil...5.0).include?(5.0)"#,
+            // beginless with float endpoint and integer value
+            r#"(nil..5.0).include?(3)"#,
+            r#"(nil..5.0).include?(5)"#,
+            // beginless via ===
+            r#"(nil..5) === 3"#,
+            r#"(nil..5) === 6"#,
+            r#"(nil...5) === 5"#,
+            // Endless ranges (beg..nil)
+            r#"(1..nil).include?(3)"#,
+            r#"(1..nil).include?(0)"#,
+            r#"(1.0..nil).include?(3.0)"#,
+            r#"(1..nil).include?(:a)"#,
+            // endless with float endpoint and integer value
+            r#"(1.0..nil).include?(2)"#,
+            r#"(1.0..nil).include?(0)"#,
+            // endless via ===
+            r#"(1..nil) === 3"#,
+            r#"(1..nil) === 0"#,
+            r#"(1.0..nil) === 3.0"#,
+            // Both-nil ranges (nil..nil) — numeric values are always included
+            r#"(nil..nil).include?(0)"#,
+            r#"(nil..nil).include?(42)"#,
+            r#"(nil..nil).include?(3.14)"#,
+            // (nil..nil).include?(:a) raises TypeError in CRuby; monoruby returns false
+            // (nil..nil) === :a  returns true in CRuby (cover? semantics); monoruby returns false
+            // These divergences are not tested here.
+            r#"(nil..nil) === 0"#,
+            // String ranges
+            r#"("a".."z").include?("a")"#,
+            r#"("a".."z").include?("m")"#,
+            r#"("a".."z").include?("z")"#,
+            r#"("a"..."z").include?("z")"#,
+            r#"("a".."z").include?("A")"#,
+            r#"("a".."z").include?(1)"#,
+            // string ranges via ===
+            r#"("a".."z") === "a""#,
+            r#"("a".."z") === "m""#,
+            r#"("a".."z") === "z""#,
+            r#"("a"..."z") === "z""#,
+            r#"("a".."z") === 1"#,
+            // member? is an alias for include?
+            r#"(1..5).member?(3)"#,
+            r#"(1..5).member?(6)"#,
+            r#"("a".."z").member?("m")"#,
+            r#"(nil..5).member?(3)"#,
+            r#"(1..nil).member?(3)"#,
+        ]);
     }
 
     /// Test that beginless/endless ranges with non-numeric, non-nil endpoints raise TypeError.

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -4699,44 +4699,43 @@ mod tests {
 
     #[test]
     fn with() {
-        run_test(r##""string".start_with?("str")"##);
-        run_test(r##""string".start_with?("ing")"##);
-        run_test(r##""string".start_with?("jng", "hng", "ing")"##);
-        run_test_error(r##""string".start_with?("jng", 3, "ing")"##);
-        // Regexp argument
-        run_test(r##""string".start_with?(/str/)"##);
-        run_test(r##""string".start_with?(/ing/)"##);
-        run_test(r##""hello".delete_prefix("hel")"##);
-        run_test(r##""hello".delete_prefix("her")"##);
-        run_test(r##"s = "hello"; [s.delete_prefix!("hel"), s]"##);
-        run_test(r##"s = "hello"; [s.delete_prefix!("her"), s]"##);
-        run_test(r##""string".end_with?("str")"##);
-        run_test(r##""string".end_with?("ing")"##);
-        run_test(r##""string".end_with?("jng", "hng", "ing")"##);
-        run_test_error(r##""string".end_with?("jng", 3, "ing")"##);
-        // end_with? UTF-8 character boundary check
-        // monoruby assigns BINARY encoding to \xNN literals (CRuby keeps UTF-8),
-        // so results differ. Use run_test_no_result_check.
-        run_test_no_result_check(r#""\xC3\xA9".end_with?("\xA9")"#);
-        run_test_no_result_check(r#""\xe3\x81\x82".end_with?("\x82")"#);
-        // Explicit UTF-8 string with force_encoding: boundary check works
-        run_test(r#""\xC3\xA9".force_encoding("UTF-8").end_with?("\xA9".force_encoding("UTF-8"))"#);
-        // start_with? UTF-8 character boundary check
-        run_test_no_result_check(r#""\xC3\xA9".start_with?("\xC3")"#);
-        run_test(
+        run_tests(&[
+            r##""string".start_with?("str")"##,
+            r##""string".start_with?("ing")"##,
+            r##""string".start_with?("jng", "hng", "ing")"##,
+            // Regexp argument
+            r##""string".start_with?(/str/)"##,
+            r##""string".start_with?(/ing/)"##,
+            r##""hello".delete_prefix("hel")"##,
+            r##""hello".delete_prefix("her")"##,
+            r##"s = "hello"; [s.delete_prefix!("hel"), s]"##,
+            r##"s = "hello"; [s.delete_prefix!("her"), s]"##,
+            r##""string".end_with?("str")"##,
+            r##""string".end_with?("ing")"##,
+            r##""string".end_with?("jng", "hng", "ing")"##,
+            // Explicit UTF-8 string with force_encoding: boundary check works
+            r#""\xC3\xA9".force_encoding("UTF-8").end_with?("\xA9".force_encoding("UTF-8"))"#,
             r#""\xC3\xA9".force_encoding("UTF-8").start_with?("\xC3".force_encoding("UTF-8"))"#,
-        );
-        // start_with? with Regexp sets/clears $~
-        run_test(r#""test-123".start_with?(/test/); $~[0]"#);
-        run_test(r#""test-123".start_with?(/xxx/); $~"#);
+            // start_with? with Regexp sets/clears $~
+            r#""test-123".start_with?(/test/); $~[0]"#,
+            r#""test-123".start_with?(/xxx/); $~"#,
+            // Binary string start_with?/end_with?
+            r#""\xC3".b.start_with?("\xC3".b)"#,
+            r#""\xC3".b.end_with?("\xC3".b)"#,
+            r##""string".include?("str")"##,
+            r##""string".include?("ing")"##,
+            r##""string".include?("ingi")"##,
+            // start_with? UTF-8 character boundary check
+            r#""\xC3\xA9".start_with?("\xC3")"#,
+            // end_with? UTF-8 character boundary check
+            r#""\xC3\xA9".end_with?("\xA9")"#,
+            r#""\xe3\x81\x82".end_with?("\x82")"#,
+        ]);
+
+        run_test_error(r##""string".start_with?("jng", 3, "ing")"##);
+        run_test_error(r##""string".end_with?("jng", 3, "ing")"##);
         // end_with? with Regexp raises TypeError
         run_test_error(r#""hello".end_with?(/lo/)"#);
-        // Binary string start_with?/end_with?
-        run_test(r#""\xC3".b.start_with?("\xC3".b)"#);
-        run_test(r#""\xC3".b.end_with?("\xC3".b)"#);
-        run_test(r##""string".include?("str")"##);
-        run_test(r##""string".include?("ing")"##);
-        run_test(r##""string".include?("ingi")"##);
     }
 
     #[test]

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -201,105 +201,111 @@ mod tests {
 
     #[test]
     fn symbol_match() {
-        run_test(r#":hello.match?(/ell/)"#);
-        run_test(r#":hello.match?(/xyz/)"#);
-        run_test(r#":hello.match?(/\A[a-z]+\z/)"#);
+        run_tests(&[
+            r#":hello.match?(/ell/)"#,
+            r#":hello.match?(/xyz/)"#,
+            r#":hello.match?(/\A[a-z]+\z/)"#,
+        ]);
     }
 
     #[test]
     fn symbol_methods() {
-        run_test(r#":hello.upcase"#);
-        run_test(r#":hello.downcase"#);
-        run_test(r#":hello.capitalize"#);
-        run_test(r#":hElLo.swapcase"#);
-        run_test(r#":hello.size"#);
-        run_test(r#":hello.length"#);
-        run_test(r#":hello.empty?"#);
-        run_test(r#":"".empty?"#);
-        run_test(r#":hello.start_with?("he")"#);
-        run_test(r#":hello.end_with?("lo")"#);
-        run_test(r#":hello.succ"#);
-        run_test(r#":hello.next"#);
-        run_test(r#":hello.id2name"#);
-        run_test(r#":hello.name"#);
-        run_test(r#":hello.name.frozen?"#);
-        run_test(r#":hello.intern"#);
-        run_test(r#":hello.to_sym"#);
-        run_test(r#":hello =~ /ell/"#);
-        run_test(r#":hello[1]"#);
-        run_test(r#":hello[1,3]"#);
-        run_test(r#":abc.casecmp(:ABC)"#);
-        run_test(r#":abc.casecmp(:abd)"#);
-        run_test(r#":abc.casecmp?(:ABC)"#);
-        run_test(r#":abc.casecmp("abc")"#);
+        run_tests(&[
+            r#":hello.upcase"#,
+            r#":hello.downcase"#,
+            r#":hello.capitalize"#,
+            r#":hElLo.swapcase"#,
+            r#":hello.size"#,
+            r#":hello.length"#,
+            r#":hello.empty?"#,
+            r#":"".empty?"#,
+            r#":hello.start_with?("he")"#,
+            r#":hello.end_with?("lo")"#,
+            r#":hello.succ"#,
+            r#":hello.next"#,
+            r#":hello.id2name"#,
+            r#":hello.name"#,
+            r#":hello.name.frozen?"#,
+            r#":hello.intern"#,
+            r#":hello.to_sym"#,
+            r#":hello =~ /ell/"#,
+            r#":hello[1]"#,
+            r#":hello[1,3]"#,
+            r#":abc.casecmp(:ABC)"#,
+            r#":abc.casecmp(:abd)"#,
+            r#":abc.casecmp?(:ABC)"#,
+            r#":abc.casecmp("abc")"#,
+        ]);
     }
 
     #[test]
     fn symbol_all_symbols() {
-        run_test(r#"Symbol.all_symbols.is_a?(Array)"#);
-        run_test(r#"Symbol.all_symbols.all? { |s| s.is_a?(Symbol) }"#);
-        run_test(r#"Symbol.all_symbols.include?(:to_s)"#);
+        run_tests(&[
+            r#"Symbol.all_symbols.is_a?(Array)"#,
+            r#"Symbol.all_symbols.all? { |s| s.is_a?(Symbol) }"#,
+            r#"Symbol.all_symbols.include?(:to_s)"#,
+        ]);
     }
 
     #[test]
     fn symbol_to_proc() {
-        run_test(
-            r#"
-        :to_i.to_proc.call("42")
-        "#,
-        );
-        run_test(
-            r#"
-        :to_i.to_proc["ff", 16]
-        "#,
-        );
-        run_test(
-            r#"
-        (1..3).collect(&:to_s)
-        "#,
-        );
+        run_tests(&[
+            r#":to_i.to_proc.call("42")"#,
+            r#":to_i.to_proc["ff", 16]"#,
+            r#"(1..3).collect(&:to_s)"#,
+        ]);
     }
 
     #[test]
     fn symbol_to_s_encoding() {
-        run_test(r#":hello.to_s.encoding.to_s"#);
-        run_test(r#":"日本語".to_s.encoding.to_s"#);
+        run_tests(&[
+            r#":hello.to_s.encoding.to_s"#,
+            r#":"日本語".to_s.encoding.to_s"#,
+        ]);
     }
 
     #[test]
     fn symbol_match_with_matchdata() {
-        run_test(r#":hello.match(/ell/).class"#);
-        run_test(r#":hello.match(/ell/)[0]"#);
-        run_test(r#":hello.match(/xyz/)"#);
+        run_tests(&[
+            r#":hello.match(/ell/).class"#,
+            r#":hello.match(/ell/)[0]"#,
+            r#":hello.match(/xyz/)"#,
+        ]);
     }
 
     #[test]
     fn symbol_to_proc_public_send() {
         // to_proc should use public_send and forward blocks
-        run_test(r#"[1, 2, 3].map(&:to_s)"#);
-        run_test(r#"["a", "b", "c"].map(&:upcase)"#);
+        run_tests(&[
+            r#"[1, 2, 3].map(&:to_s)"#,
+            r#"["a", "b", "c"].map(&:upcase)"#,
+        ]);
     }
 
     #[test]
     fn symbol_comparable() {
         // Comparable methods derived from <=>
-        run_test(r#":abc < :abd"#);
-        run_test(r#":abd > :abc"#);
-        run_test(r#":abc >= :abc"#);
-        run_test(r#":abc <= :abc"#);
-        run_test(r#":bbb.between?(:aaa, :ccc)"#);
-        run_test(r#":aaa.between?(:bbb, :ccc)"#);
-        run_test(r#":ddd.clamp(:bbb, :ccc)"#);
-        run_test(r#":aaa.clamp(:bbb, :ccc)"#);
-        run_test(r#":bbb.clamp(:aaa, :ccc)"#);
+        run_tests(&[
+            r#":abc < :abd"#,
+            r#":abd > :abc"#,
+            r#":abc >= :abc"#,
+            r#":abc <= :abc"#,
+            r#":bbb.between?(:aaa, :ccc)"#,
+            r#":aaa.between?(:bbb, :ccc)"#,
+            r#":ddd.clamp(:bbb, :ccc)"#,
+            r#":aaa.clamp(:bbb, :ccc)"#,
+            r#":bbb.clamp(:aaa, :ccc)"#,
+        ]);
     }
 
     #[test]
     fn symbol_name_identity() {
         // Symbol#name returns the same frozen String object each time
-        run_test(r#":hello.name.equal?(:hello.name)"#);
-        run_test(r#":hello.name.frozen?"#);
-        run_test(r#":world.name.equal?(:world.name)"#);
+        run_tests(&[
+            r#":hello.name.equal?(:hello.name)"#,
+            r#":hello.name.frozen?"#,
+            r#":world.name.equal?(:world.name)"#,
+        ]);
     }
 
     #[test]
@@ -311,123 +317,133 @@ mod tests {
 
     #[test]
     fn symbol_global_var_literal() {
-        // :$name symbol literals
-        run_test(r#":$ruby"#);
-        run_test(r#":$0"#);
-        run_test(r#":$~"#);
-        run_test(r#":$&"#);
-        run_test(r#":$'"#);
-        run_test(r#":$+"#);
-        // :$-w style
-        run_test(r#":$-w"#);
-        // :@name and :@@name
-        run_test(r#":@ruby"#);
-        run_test(r#":@@ruby"#);
+        run_tests(&[
+            // :$name symbol literals
+            r#":$ruby"#,
+            r#":$0"#,
+            r#":$~"#,
+            r#":$&"#,
+            r#":$'"#,
+            r#":$+"#,
+            // :$-w style
+            r#":$-w"#,
+            // :@name and :@@name
+            r#":@ruby"#,
+            r#":@@ruby"#,
+        ]);
     }
 
     #[test]
     fn symbol_binary() {
         // Binary (ASCII-8BIT) string can be converted to symbol and back
-        run_test(r#""\xC3".b.to_sym.to_s.encoding.to_s"#);
-        run_test(r#""\xC3".b.to_sym.to_s == "\xC3".b"#);
-        run_test(r#""\xC3".b.to_sym == "\xC3".b.to_sym"#);
+        run_tests(&[
+            r#""\xC3".b.to_sym.to_s.encoding.to_s"#,
+            r#""\xC3".b.to_sym.to_s == "\xC3".b"#,
+            r#""\xC3".b.to_sym == "\xC3".b.to_sym"#,
+        ]);
         // Binary and UTF-8 symbols with same bytes are distinct
         run_test_no_result_check(r#""\xC3\xA3".to_sym != "\xC3\xA3".b.to_sym"#);
     }
 
     #[test]
     fn symbol_inspect_unquoted() {
-        // Plain identifiers
-        run_test(r#":hello.inspect"#);
-        run_test(r#":Fred.inspect"#);
-        run_test(r#":_abc.inspect"#);
-        run_test(r#":fred?.inspect"#);
-        run_test(r#":fred!.inspect"#);
-        run_test(r#":BAD!.inspect"#);
-        run_test(r#":_BAD!.inspect"#);
-        // Global / ivar / cvar
-        run_test(r#":$ruby.inspect"#);
-        run_test(r#":@ruby.inspect"#);
-        run_test(r#":@@ruby.inspect"#);
-        run_test(r#":$-w.inspect"#);
-        // Special single-char globals
-        run_test(r#":$+.inspect"#);
-        run_test(r#":$~.inspect"#);
-        run_test(r#":$?.inspect"#);
-        run_test(r#":$!.inspect"#);
-        // $digits
-        run_test(r#":$0.inspect"#);
-        run_test(r#":$1234.inspect"#);
-        // Operators
-        run_test(r#":+.inspect"#);
-        run_test(r#":-.inspect"#);
-        run_test(r#":*.inspect"#);
-        run_test(r#":**.inspect"#);
-        run_test(r#":+@.inspect"#);
-        run_test(r#":-@.inspect"#);
-        run_test(r#":<=>.inspect"#);
-        run_test(r#":==.inspect"#);
-        run_test(r#":===.inspect"#);
-        run_test(r#":=~.inspect"#);
-        run_test(r#":[].inspect"#);
-        run_test(r#":[]=.inspect"#);
-        run_test(r#":"<<".inspect"#);
-        run_test(r#":">>".inspect"#);
-        // Non-ASCII letters are valid identifier chars
-        run_test(r#":"ê".inspect"#);
-        run_test(r#":"日本語".inspect"#);
+        run_tests(&[
+            // Plain identifiers
+            r#":hello.inspect"#,
+            r#":Fred.inspect"#,
+            r#":_abc.inspect"#,
+            r#":fred?.inspect"#,
+            r#":fred!.inspect"#,
+            r#":BAD!.inspect"#,
+            r#":_BAD!.inspect"#,
+            // Global / ivar / cvar
+            r#":$ruby.inspect"#,
+            r#":@ruby.inspect"#,
+            r#":@@ruby.inspect"#,
+            r#":$-w.inspect"#,
+            // Special single-char globals
+            r#":$+.inspect"#,
+            r#":$~.inspect"#,
+            r#":$?.inspect"#,
+            r#":$!.inspect"#,
+            // $digits
+            r#":$0.inspect"#,
+            r#":$1234.inspect"#,
+            // Operators
+            r#":+.inspect"#,
+            r#":-.inspect"#,
+            r#":*.inspect"#,
+            r#":**.inspect"#,
+            r#":+@.inspect"#,
+            r#":-@.inspect"#,
+            r#":<=>.inspect"#,
+            r#":==.inspect"#,
+            r#":===.inspect"#,
+            r#":=~.inspect"#,
+            r#":[].inspect"#,
+            r#":[]=.inspect"#,
+            r#":"<<".inspect"#,
+            r#":">>".inspect"#,
+            // Non-ASCII letters are valid identifier chars
+            r#":"ê".inspect"#,
+            r#":"日本語".inspect"#,
+        ]);
     }
 
     #[test]
     fn symbol_inspect_quoted() {
-        // $ followed by non-simple content
-        run_test(r#":"$ruby!".inspect"#);
-        run_test(r#":"@ruby!".inspect"#);
-        run_test(r#":"@@ruby!".inspect"#);
-        run_test(r#":"$-ww".inspect"#);
-        run_test(r#":"$".inspect"#);
-        // Non-identifier, non-operator sequences
-        run_test(r#":"foo bar".inspect"#);
-        run_test(r#":"9".inspect"#);
-        run_test(r#":"*foo".inspect"#);
-        run_test(r#":"foo ".inspect"#);
-        run_test(r#":" foo".inspect"#);
-        run_test(r#":" ".inspect"#);
-        run_test(r#":"&&".inspect"#);
-        run_test(r#":"||".inspect"#);
-        run_test(r#":"|||".inspect"#);
-        run_test(r#":"++".inspect"#);
-        run_test(r#":":".inspect"#);
-        run_test(r#":"::".inspect"#);
-        run_test(r#":",".inspect"#);
-        run_test(r#":".".inspect"#);
-        run_test(r#":"..".inspect"#);
-        run_test(r#":"...".inspect"#);
-        run_test(r#":";".inspect"#);
-        run_test(r#":"=".inspect"#);
-        run_test(r#":"=>".inspect"#);
-        run_test(r#":"?".inspect"#);
-        run_test(r#":"@".inspect"#);
-        // Escaped characters inside quoted form
-        run_test(r#":"\"".inspect"#);
-        run_test(r#":"\"\"".inspect"#);
-        run_test(r#":"'".inspect"#);
-        // Binary symbol gets quoted with escape
-        run_test(r#""foo\xA4".b.to_sym.inspect"#);
+        run_tests(&[
+            // $ followed by non-simple content
+            r#":"$ruby!".inspect"#,
+            r#":"@ruby!".inspect"#,
+            r#":"@@ruby!".inspect"#,
+            r#":"$-ww".inspect"#,
+            r#":"$".inspect"#,
+            // Non-identifier, non-operator sequences
+            r#":"foo bar".inspect"#,
+            r#":"9".inspect"#,
+            r#":"*foo".inspect"#,
+            r#":"foo ".inspect"#,
+            r#":" foo".inspect"#,
+            r#":" ".inspect"#,
+            r#":"&&".inspect"#,
+            r#":"||".inspect"#,
+            r#":"|||".inspect"#,
+            r#":"++".inspect"#,
+            r#":":".inspect"#,
+            r#":"::".inspect"#,
+            r#":",".inspect"#,
+            r#":".".inspect"#,
+            r#":"..".inspect"#,
+            r#":"...".inspect"#,
+            r#":";".inspect"#,
+            r#":"=".inspect"#,
+            r#":"=>".inspect"#,
+            r#":"?".inspect"#,
+            r#":"@".inspect"#,
+            // Escaped characters inside quoted form
+            r#":"\"".inspect"#,
+            r#":"\"\"".inspect"#,
+            r#":"'".inspect"#,
+            // Binary symbol gets quoted with escape
+            r#""foo\xA4".b.to_sym.inspect"#,
+        ]);
     }
 
     #[test]
     fn symbol_to_proc_metadata() {
-        // Arity is -2 (one required + rest)
-        run_test(r#":to_i.to_proc.arity"#);
-        // Parameters is [[:req], [:rest]] with no names (native builtin body)
-        run_test(r#":to_i.to_proc.parameters"#);
-        // Source location is nil (not an ISeq)
-        run_test(r#":to_i.to_proc.source_location"#);
-        // It is a lambda
-        run_test(r#":to_i.to_proc.lambda?"#);
-        // It is a Proc
-        run_test(r#":to_i.to_proc.is_a?(Proc)"#);
+        run_tests(&[
+            // Arity is -2 (one required + rest)
+            r#":to_i.to_proc.arity"#,
+            // Parameters is [[:req], [:rest]] with no names (native builtin body)
+            r#":to_i.to_proc.parameters"#,
+            // Source location is nil (not an ISeq)
+            r#":to_i.to_proc.source_location"#,
+            // It is a lambda
+            r#":to_i.to_proc.lambda?"#,
+            // It is a Proc
+            r#":to_i.to_proc.is_a?(Proc)"#,
+        ]);
     }
 
     #[test]
@@ -454,21 +470,21 @@ mod tests {
 
     #[test]
     fn symbol_to_s_chilled_basics() {
-        // Symbol#to_s returns a mutable string (chilled, not frozen).
-        run_test(r#":hello.to_s.frozen?"#);
-        // dup clears the chilled bit so mutation is silent.
-        run_test(r#"s = :hello.to_s.dup; s << "X"; s"#);
-        // Each call returns a fresh string instance.
-        run_test(r#":hello.to_s.equal?(:hello.to_s)"#);
-        // Mutation succeeds (warning or not) and the string changes.
-        run_test(
+        run_tests(&[
+            // Symbol#to_s returns a mutable string (chilled, not frozen).
+            r#":hello.to_s.frozen?"#,
+            // dup clears the chilled bit so mutation is silent.
+            r#"s = :hello.to_s.dup; s << "X"; s"#,
+            // Each call returns a fresh string instance.
+            r#":hello.to_s.equal?(:hello.to_s)"#,
+            // Mutation succeeds (warning or not) and the string changes.
             r#"
             Warning[:deprecated] = false
             s = :bad!.to_s
             s.upcase!
             s
             "#,
-        );
+        ]);
     }
 
     #[test]

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -216,7 +216,7 @@ impl<'a> BytecodeGen<'a> {
             }
             NodeKind::Const {
                 toplevel,
-                parent: _,
+                parent,
                 prefix,
                 name,
             } => {
@@ -225,9 +225,27 @@ impl<'a> BytecodeGen<'a> {
                     .into_iter()
                     .map(IdentId::get_id_from_string)
                     .collect();
+                let base = if let Some(box parent) = parent {
+                    // Evaluate the parent expression; if it raises, defined? yields nil.
+                    let body_start = self.new_label();
+                    let body_end = self.new_label();
+                    self.apply_label(body_start);
+                    let base = self.gen_temp_expr(parent)?;
+                    self.apply_label(body_end);
+                    self.exception_table.push(ExceptionEntry {
+                        range: body_start..body_end,
+                        rescue: Some(nil_label),
+                        ensure: None,
+                        err_reg: None,
+                    });
+                    Some(base)
+                } else {
+                    None
+                };
                 self.emit(
                     BytecodeInst::DefinedConst {
                         ret,
+                        base,
                         toplevel,
                         prefix,
                         name,

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -512,13 +512,15 @@ impl<'a> BytecodeGen<'a> {
             }
             BytecodeInst::DefinedConst {
                 ret,
+                base,
                 toplevel,
                 prefix,
                 name,
             } => {
                 // 65
                 let op1 = self.slot_id(&ret);
-                let op2 = self.store.new_constsite(None, name, prefix, toplevel);
+                let base = base.map(|base| self.slot_id(&base));
+                let op2 = self.store.new_constsite(base, name, prefix, toplevel);
                 Bytecode::from_u32(enc_www(65, op1.0, 0, 0), op2.0)
             }
             BytecodeInst::DefinedMethod { ret, recv, name } => {

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -233,6 +233,7 @@ pub(super) enum BytecodeInst {
     },
     DefinedConst {
         ret: BcReg,
+        base: Option<BcReg>,
         toplevel: bool,
         prefix: Vec<IdentId>,
         name: IdentId,

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -988,7 +988,43 @@ impl ClassInfoTable {
         info.constants = constants;
         info.constant_locations = constant_locations;
         info.class_variables = class_variables;
-        self.get_metaclass(new_id);
+
+        // Duplicate the singleton class too: CRuby's Module#initialize_copy
+        // clones the singleton class so `def self.foo` and `extend`-ed modules
+        // on the original are reachable through the dup.
+        let orig_meta = self.get_metaclass(original_class);
+        let new_meta = self.get_metaclass(new_id);
+
+        // Copy singleton-class method/constant/cvar tables.
+        let orig_meta_info = &self[orig_meta.id()];
+        let m_methods = orig_meta_info.methods.clone();
+        let m_constants = orig_meta_info.constants.clone();
+        let m_constant_locations = orig_meta_info.constant_locations.clone();
+        let m_class_variables = orig_meta_info.class_variables.clone();
+        let new_meta_info = &mut self[new_meta.id()];
+        new_meta_info.methods = m_methods;
+        new_meta_info.constants = m_constants;
+        new_meta_info.constant_locations = m_constant_locations;
+        new_meta_info.class_variables = m_class_variables;
+
+        // Replicate `extend`-ed modules (iclasses hanging off the original
+        // metaclass's superclass chain) on the new metaclass in the same
+        // order. `include_module` prepends, so walk the original chain from
+        // nearest to furthest and re-include in reverse.
+        let mut included: Vec<ClassId> = vec![];
+        let mut cur = orig_meta.superclass();
+        while let Some(sc) = cur
+            && sc.is_iclass()
+        {
+            included.push(sc.id());
+            cur = sc.superclass();
+        }
+        let mut new_meta = new_meta;
+        for mod_id in included.into_iter().rev() {
+            let module = self.get_module(mod_id);
+            let _ = new_meta.include_module(module);
+        }
+
         class_obj.as_class()
     }
 


### PR DESCRIPTION
## Summary
- Fix `Class#allocate` to properly preserve superclass
- Fix `dup` on singleton classes
- Fix `defined?(self::C)` resolution
- Fix `Class#new` behavior
- Collapse sequential `run_test()` calls into `run_tests()` in tests

## Test plan
- [x] `cargo test`
- [x] ruby/spec core/class passes improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)