### PR TITLE
Refactor Class#new/allocate through alloc_func and JIT-inline

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -22,13 +22,7 @@ pub(super) fn init(globals: &mut Globals) {
     //    0,
     //    true,
     //);
-    globals.define_builtin_class_inline_func(
-        ARRAY_CLASS,
-        "allocate",
-        allocate,
-        Box::new(array_allocate),
-        0,
-    );
+    globals.store[ARRAY_CLASS].set_alloc_func(array_alloc_func);
     globals.define_private_builtin_func_with(ARRAY_CLASS, "initialize", initialize, 0, 2, false);
     globals.define_builtin_inline_funcs(
         ARRAY_CLASS,
@@ -187,49 +181,8 @@ fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     Ok(obj)
 }
 
-///
-/// ### Array#allocate
-/// - allocate -> object
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class = lfp.self_val().as_class_id();
-    let obj = Value::array_empty_with_class(class);
-    Ok(obj)
-}
-
-fn array_allocate(
-    state: &mut AbstractState,
-    ir: &mut AsmIr,
-    _: &JitContext,
-    store: &Store,
-    callid: CallSiteId,
-    _: ClassId,
-    _: Option<ClassId>,
-) -> bool {
-    let callsite = &store[callid];
-    if !callsite.is_simple() {
-        return false;
-    }
-    let dst = callsite.dst;
-    state.load(ir, callsite.recv, GP::Rdi);
-    let using_xmm = state.get_using_xmm();
-    ir.xmm_save(using_xmm);
-    ir.inline(move |r#gen, _, _| {
-        monoasm! { &mut r#gen.jit,
-            movq rax, (allocate_array);
-            call rax;
-        }
-    });
-    ir.xmm_restore(using_xmm);
-
-    state.def_reg2acc(ir, GP::Rax, dst);
-    true
-}
-
-extern "C" fn allocate_array(class_val: Value) -> Value {
-    let class_id = class_val.as_class_id();
+/// Allocator for `Array` and its subclasses.
+pub(crate) extern "C" fn array_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
     Value::array_empty_with_class(class_id)
 }
 

--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Binding", BINDING_CLASS, ObjTy::BINDING);
-    globals.define_builtin_class_func(BINDING_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[BINDING_CLASS].clear_alloc_func();
     globals.define_builtin_func(BINDING_CLASS, "local_variables", local_variables, 0);
     globals.define_builtin_func(BINDING_CLASS, "source_location", source_location, 0);
 }

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -4,8 +4,13 @@ use super::*;
 // Class class
 //
 
+/// Returns the JIT inliner for `Class#new`. The inliner reads the receiver
+/// class's `alloc_func` from `ClassInfo` at JIT-compile time, embeds the raw
+/// function pointer into the generated code, and calls it directly (ABI:
+/// `extern "C" fn(ClassId, &mut Globals) -> Value`), matching the slow-path
+/// `call_alloc_func` helper.
 pub fn gen_class_new_object() -> Box<InlineGen> {
-    Box::new(gen_class_new(allocate_object))
+    Box::new(gen_class_new_inline)
 }
 
 pub(super) fn init(globals: &mut Globals) {
@@ -19,13 +24,12 @@ pub(super) fn init(globals: &mut Globals) {
     // instance methods. The default `Class#allocate` consults the receiver
     // class's `ClassInfo.alloc_func`, raising TypeError when None.
     globals.define_builtin_func(CLASS_CLASS, "allocate", allocate, 0);
-    // NOTE: Phase B disables the JIT inline for `Class#new` to keep the
-    // semantics correct while we migrate per-class allocators. Phase C will
-    // restore an inline that calls `ClassInfo.alloc_func` directly.
-    globals.define_builtin_func_with_kw(
+    globals.define_builtin_inline_funcs_with_kw(
         CLASS_CLASS,
         "new",
+        &[],
         new,
+        gen_class_new_object(),
         0,
         0,
         true,
@@ -254,100 +258,13 @@ pub(crate) fn call_alloc_func(globals: &mut Globals, class_id: ClassId) -> Resul
     }
 }
 
-pub(super) fn gen_class_new(
-    f: extern "C" fn(Value) -> Value,
-) -> impl Fn(
-    &mut AbstractState,
-    &mut AsmIr,
-    &JitContext,
-    &Store,
-    CallSiteId,
-    ClassId,
-    Option<ClassId>,
-) -> bool {
-    move |state: &mut AbstractState,
-          ir: &mut AsmIr,
-          _: &JitContext,
-          store: &Store,
-          callid: CallSiteId,
-          _: ClassId,
-          _: Option<ClassId>| {
-        let callsite = &store[callid];
-        if !callsite.is_simple() {
-            return false;
-        }
-        let CallSiteInfo {
-            recv,
-            args,
-            pos_num,
-            dst,
-            ..
-        } = *callsite;
-        state.writeback_acc(ir);
-        state.load(ir, recv, GP::Rdi);
-        state.write_back_recv_and_callargs(ir, callsite);
-        let using_xmm = state.get_using_xmm();
-        let error = ir.new_error(state);
-        ir.xmm_save(using_xmm);
-        ir.inline(move |r#gen, _, _| {
-            let cached_version = r#gen.jit.data_i32(-1);
-            let cached_funcid = r#gen.jit.data_i32(-1);
-            let class_version = r#gen.class_version_label();
-            let slow_path = r#gen.jit.label();
-            let checked = r#gen.jit.label();
-            let initialize = r#gen.jit.label();
-            let exit = r#gen.jit.label();
-            monoasm!( &mut r#gen.jit,
-                movq rax, (f);
-                call rax;
-                movq r15, rax; // r15 <- new instance
-                movl rax, [rip + class_version];
-                cmpl rax, [rip + cached_version];
-                jne  slow_path;
-                movl rax, [rip + cached_funcid];
-            checked:
-                testq rax, rax;
-                jne  initialize;
-            exit:
-                movq rax, r15;
-            );
-
-            r#gen.jit.select_page(1);
-            monoasm!( &mut r#gen.jit,
-            initialize:
-                movq rdi, rbx;
-                movq rsi, r12;
-                movq rdx, rax;
-                movq rcx, r15;
-                lea r8, [r14 - (crate::executor::jitgen::conv(args))];
-                movl r9, (pos_num);
-                // TODO: Currently inline call does not support calling with block or keyword arguments.
-                movq rax, (r#gen.method_invoker2);
-                call rax;
-                testq rax, rax;
-                jne  exit;
-                xorq r15, r15;
-                jmp  exit;
-            slow_path:
-                movq rdi, r12;
-                movq rsi, r15;
-                movq rax, (check_initializer);
-                call rax;
-                movl [rip + cached_funcid], rax;
-                movl rdi, [rip + class_version];
-                movl [rip + cached_version], rdi;
-                jmp  checked;
-            );
-            r#gen.jit.select_page(0);
-        });
-        ir.xmm_restore(using_xmm);
-        ir.handle_error(error);
-        state.def_rax2acc(ir, dst);
-        true
-    }
-}
-
-fn inline_allocate(
+/// JIT inliner for `Class#new`. Resolves the receiver class's `alloc_func`
+/// at compile time and emits a direct C call, then falls through to the
+/// usual cached-`initialize` dispatch used by the previous implementation.
+///
+/// Bails to the slow path (Rust `new`, which raises `TypeError`) when the
+/// class has no allocator, mirroring `call_alloc_func`.
+pub(super) fn gen_class_new_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
     _: &JitContext,
@@ -360,40 +277,91 @@ fn inline_allocate(
     if !callsite.is_simple() {
         return false;
     }
-    let CallSiteInfo { recv, dst, .. } = *callsite;
+    // When `Class#new` is called on a class object, the receiver's class is
+    // that class's singleton (metaclass). Unwrap it to the attached class
+    // so we read the right `alloc_func`.
     let mut self_module = store[self_class].get_module();
     if let Some(origin) = self_module.is_singleton() {
         self_module = origin.as_class();
     }
+    let class_id = self_module.id();
+
+    let alloc_func = match store[class_id].alloc_func() {
+        Some(f) => f,
+        None => return false,
+    };
+
+    let CallSiteInfo {
+        recv,
+        args,
+        pos_num,
+        dst,
+        ..
+    } = *callsite;
+    state.writeback_acc(ir);
     state.load(ir, recv, GP::Rdi);
     state.write_back_recv_and_callargs(ir, callsite);
     let using_xmm = state.get_using_xmm();
+    let error = ir.new_error(state);
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _| {
+        let cached_version = r#gen.jit.data_i32(-1);
+        let cached_funcid = r#gen.jit.data_i32(-1);
+        let class_version = r#gen.class_version_label();
+        let slow_path = r#gen.jit.label();
+        let checked = r#gen.jit.label();
+        let initialize = r#gen.jit.label();
+        let exit = r#gen.jit.label();
         monoasm!( &mut r#gen.jit,
-            movl rsi, (self_module.id().u32());
-            movq rax, (allocate_object2);
+            // alloc_func(class_id, &mut Globals) -> Value
+            movl rdi, (class_id.u32());
+            movq rsi, r12;
+            movq rax, (alloc_func);
             call rax;
+            movq r15, rax; // r15 <- new instance
+            movl rax, [rip + class_version];
+            cmpl rax, [rip + cached_version];
+            jne  slow_path;
+            movl rax, [rip + cached_funcid];
+        checked:
+            testq rax, rax;
+            jne  initialize;
+        exit:
+            movq rax, r15;
         );
+
+        r#gen.jit.select_page(1);
+        monoasm!( &mut r#gen.jit,
+        initialize:
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rdx, rax;
+            movq rcx, r15;
+            lea r8, [r14 - (crate::executor::jitgen::conv(args))];
+            movl r9, (pos_num);
+            // TODO: Currently inline call does not support calling with block or keyword arguments.
+            movq rax, (r#gen.method_invoker2);
+            call rax;
+            testq rax, rax;
+            jne  exit;
+            xorq r15, r15;
+            jmp  exit;
+        slow_path:
+            movq rdi, r12;
+            movq rsi, r15;
+            movq rax, (check_initializer);
+            call rax;
+            movl [rip + cached_funcid], rax;
+            movl rdi, [rip + class_version];
+            movl [rip + cached_version], rdi;
+            jmp  checked;
+        );
+        r#gen.jit.select_page(0);
     });
     ir.xmm_restore(using_xmm);
-    state.def_reg2acc_class(ir, GP::Rax, dst, self_module.id());
+    ir.handle_error(error);
+    state.def_rax2acc(ir, dst);
     true
-}
-
-extern "C" fn allocate_object(class_val: Value) -> Value {
-    let class_id = class_val.as_class_id();
-    Value::object(class_id)
-}
-
-extern "C" fn allocate_object2(class_val: Value, self_class: ClassId) -> Value {
-    let class_id = class_val.as_class_id();
-    debug_assert_eq!(class_id, self_class);
-    //eprintln!(
-    //    "allocate_object: class_id={:?}, self_class={:?}",
-    //    class_id, self_class
-    //);
-    Value::object(self_class)
 }
 
 extern "C" fn check_initializer(globals: &mut Globals, receiver: Value) -> Option<FuncId> {

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -9,26 +9,23 @@ pub fn gen_class_new_object() -> Box<InlineGen> {
 }
 
 pub(super) fn init(globals: &mut Globals) {
+    // Class.allocate / Class#new on a class object both produce a fresh,
+    // uninitialized Class. Install that as Class's alloc_func so it flows
+    // through the unified `Class#allocate` path.
+    globals.store[CLASS_CLASS].set_alloc_func(class_alloc_func);
     // class methods
     globals.define_builtin_class_func_with(CLASS_CLASS, "new", class_new, 0, 1, false);
-    // Override allocate on Class's singleton class so that Class.allocate
-    // creates a proper (uninitialized) Class object instead of a plain object.
-    globals.define_builtin_class_func(CLASS_CLASS, "allocate", class_allocate, 0);
 
-    // instance methods
-    globals.define_builtin_inline_func(
-        CLASS_CLASS,
-        "allocate",
-        allocate,
-        Box::new(inline_allocate),
-        0,
-    );
-    globals.define_builtin_inline_funcs_with_kw(
+    // instance methods. The default `Class#allocate` consults the receiver
+    // class's `ClassInfo.alloc_func`, raising TypeError when None.
+    globals.define_builtin_func(CLASS_CLASS, "allocate", allocate, 0);
+    // NOTE: Phase B disables the JIT inline for `Class#new` to keep the
+    // semantics correct while we migrate per-class allocators. Phase C will
+    // restore an inline that calls `ClassInfo.alloc_func` directly.
+    globals.define_builtin_func_with_kw(
         CLASS_CLASS,
         "new",
-        &[],
         new,
-        gen_class_new_object(),
         0,
         0,
         true,
@@ -88,20 +85,11 @@ fn class_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(obj)
 }
 
-/// ### Class.allocate
-/// - allocate -> Class
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
-#[monoruby_builtin]
-fn class_allocate(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    lfp.expect_no_block()?;
-    let obj = globals.store.allocate_uninit_class();
-    Ok(obj.as_val())
+/// Allocator installed on `Class` itself. Produces a new uninitialized
+/// `Class` value (no name, no superclass), used by both `Class.allocate`
+/// and the bootstrap path of `Class.new`.
+pub(crate) extern "C" fn class_alloc_func(_class_id: ClassId, globals: &mut Globals) -> Value {
+    globals.store.allocate_uninit_class().as_val()
 }
 
 /// Validate a value used as a superclass for `Class.new`/`Class#initialize`.
@@ -189,48 +177,12 @@ pub(super) fn new(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    // CRuby's Class#new uses an internal allocator (a C-level alloc_func) and
-    // does NOT dispatch to a user-defined `allocate` method. monoruby has no
-    // separate alloc_func table, so emulate this by looking up `allocate`
-    // starting at the class's metaclass superclass — skipping any user
-    // override on the receiver class's own singleton class.
+    // Class#new dispatches to the receiver's C-level allocator (`alloc_func`),
+    // bypassing any user-defined Ruby `def self.allocate`. Matches CRuby's
+    // `rb_class_alloc` semantics.
     let self_val = lfp.self_val();
-    let meta_id = self_val.class();
-    // First check the normal lookup. If the resolved `allocate` is a native
-    // (built-in) function we use it as-is — that covers registered class-level
-    // allocators such as Hash's allocate or Complex's `undef_allocate`.
-    // If it's a Ruby-level override (`def self.allocate`) on the receiver
-    // class's own metaclass, skip past it and search from the metaclass's
-    // superclass so we use the inherited built-in allocator, matching CRuby's
-    // C-level alloc_func behavior.
-    let alloc_fid = globals
-        .store
-        .check_method_for_class(meta_id, IdentId::ALLOCATE)
-        .and_then(|e| e.func_id());
-    let alloc_fid = match alloc_fid {
-        Some(fid)
-            if !matches!(
-                globals.store[fid].kind,
-                crate::globals::FuncKind::ISeq(_) | crate::globals::FuncKind::Proc(_)
-            ) =>
-        {
-            Some(fid)
-        }
-        _ => {
-            let meta = globals.store[meta_id].get_module();
-            let search_from = meta.superclass().map(|m| m.id()).unwrap_or(meta_id);
-            globals
-                .store
-                .check_method_for_class(search_from, IdentId::ALLOCATE)
-                .and_then(|e| e.func_id())
-        }
-    };
-    let obj = match alloc_fid {
-        Some(fid) => vm.invoke_func_inner(globals, fid, self_val, &[], None, None)?,
-        None => {
-            vm.invoke_method_inner(globals, IdentId::ALLOCATE, self_val, &[], None, None)?
-        }
-    };
+    let class_id = self_val.as_class_id();
+    let obj = call_alloc_func(globals, class_id)?;
 
     vm.invoke_method_inner(
         globals,
@@ -279,37 +231,27 @@ fn superclass(
 /// ### Class#allocate
 /// - allocate -> object
 ///
+/// Default `allocate` for every class. Looks up `ClassInfo.alloc_func` on
+/// the receiver class and invokes it. Raises TypeError when the class has
+/// no allocator (None).
+///
 /// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
 #[monoruby_builtin]
 fn allocate(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
-    match class_id {
-        TRUE_CLASS | FALSE_CLASS | NIL_CLASS | SYMBOL_CLASS => {
-            return Err(MonorubyErr::typeerr(&format!(
-                "allocator undefined for {}",
-                class_id.get_name(globals)
-            )));
-        }
-        _ => {}
-    }
-    let obj = Value::object(class_id);
-    Ok(obj)
+    call_alloc_func(globals, class_id)
 }
 
-/// allocate that raises "allocator undefined for ClassName".
-/// Used for classes that cannot be instantiated (TrueClass, FalseClass, NilClass, Symbol, Integer, Float).
-#[monoruby_builtin]
-pub(super) fn undef_allocate(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Err(MonorubyErr::typeerr(&format!(
-        "allocator undefined for {}",
-        class_id.get_name(globals)
-    )))
+/// Look up the receiver class's `alloc_func` and invoke it; raise the
+/// standard "allocator undefined" TypeError when None.
+pub(crate) fn call_alloc_func(globals: &mut Globals, class_id: ClassId) -> Result<Value> {
+    match globals.store[class_id].alloc_func() {
+        Some(f) => Ok(f(class_id, globals)),
+        None => Err(MonorubyErr::typeerr(format!(
+            "allocator undefined for {}",
+            class_id.get_name(globals)
+        ))),
+    }
 }
 
 pub(super) fn gen_class_new(

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -17,7 +17,7 @@ pub(super) fn init(globals: &mut Globals) {
         true,
     );
 
-    globals.define_builtin_class_func(EXCEPTION_CLASS, "allocate", allocate, 0);
+    globals.store[EXCEPTION_CLASS].set_alloc_func(exception_alloc_func);
 
     let standarderr = globals.define_class("StandardError", exception_class, OBJECT_CLASS);
 
@@ -101,14 +101,12 @@ fn nomethoderr_receiver(
     Ok(v)
 }
 
-/// ### Exception.allocate
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
+/// Allocator for `Exception` and its subclasses. The exception is created
+/// with its message set to the class name (matching CRuby:
+/// `Exception.allocate.message # => "Exception"`).
+pub(crate) extern "C" fn exception_alloc_func(class_id: ClassId, globals: &mut Globals) -> Value {
     let name = class_id.get_name(globals);
-    Ok(Value::new_exception_from_with_class(
-        name, class_id, class_id,
-    ))
+    Value::new_exception_from_with_class(name, class_id, class_id)
 }
 
 ///

--- a/monoruby/src/builtins/false_class.rs
+++ b/monoruby/src/builtins/false_class.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("FalseClass", FALSE_CLASS, None);
-    globals.define_builtin_class_func(FALSE_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[FALSE_CLASS].clear_alloc_func();
 }
 
 #[cfg(test)]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -7,7 +7,7 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Hash", HASH_CLASS, ObjTy::HASH);
     globals.define_builtin_class_func_with_effect(HASH_CLASS, "new", new, 0, 2, Effect::CAPTURE);
-    globals.define_builtin_class_func(HASH_CLASS, "allocate", allocate, 0);
+    globals.store[HASH_CLASS].set_alloc_func(hash_alloc_func);
     globals.define_builtin_class_func_rest(HASH_CLASS, "[]", hash_bracket);
     globals.define_builtin_class_func(HASH_CLASS, "try_convert", try_convert, 1);
 
@@ -126,14 +126,9 @@ fn new(vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     Ok(obj)
 }
 
-/// ### Hash.allocate
-/// - allocate -> Hash
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Ok(Value::hash_with_class_and_default(class_id, Value::nil()))
+/// Allocator for `Hash` and its subclasses.
+pub(crate) extern "C" fn hash_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::hash_with_class_and_default(class_id, Value::nil())
 }
 
 ///

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("IO", IO_CLASS, ObjTy::IO);
     globals.define_builtin_class_func_with(IO_CLASS, "new", io_new, 1, 3, false);
-    globals.define_builtin_class_func(IO_CLASS, "allocate", allocate, 0);
+    globals.store[IO_CLASS].set_alloc_func(io_alloc_func);
     globals.define_builtin_func(IO_CLASS, "<<", shl, 1);
     globals.define_builtin_func_with(IO_CLASS, "puts", puts, 0, 0, true);
     globals.define_builtin_func_with(IO_CLASS, "print", print, 0, 0, true);
@@ -76,11 +76,9 @@ fn io_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Err(MonorubyErr::argumenterr("IO.new requires an integer file descriptor"))
 }
 
-/// ### IO.allocate
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Ok(Value::new_io_with_class(IoInner::Closed, class_id))
+/// Allocator for `IO` and its subclasses.
+pub(crate) extern "C" fn io_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::new_io_with_class(IoInner::Closed, class_id)
 }
 
 ///

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("MatchData", MATCHDATA_CLASS, ObjTy::MATCHDATA);
-    globals.define_builtin_class_func(MATCHDATA_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[MATCHDATA_CLASS].clear_alloc_func();
     globals.define_builtin_func(MATCHDATA_CLASS, "captures", captures, 0);
     globals.define_builtin_func(MATCHDATA_CLASS, "to_a", to_a, 0);
     globals.define_builtin_func_with(MATCHDATA_CLASS, "[]", index, 1, 2, false);

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Method", METHOD_CLASS, ObjTy::METHOD);
-    globals.define_builtin_class_func(METHOD_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[METHOD_CLASS].clear_alloc_func();
     globals.define_builtin_funcs_rest(METHOD_CLASS, "call", &["[]", "==="], call);
     globals.define_builtin_func(METHOD_CLASS, "arity", arity, 0);
     globals.define_builtin_func(METHOD_CLASS, "to_proc", to_proc, 0);
@@ -19,7 +19,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(METHOD_CLASS, "==", &["eql?"], method_eq, 1);
 
     globals.define_builtin_class_under_obj("UnboundMethod", UMETHOD_CLASS, ObjTy::METHOD);
-    globals.define_builtin_class_func(UMETHOD_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[UMETHOD_CLASS].clear_alloc_func();
     globals.define_builtin_func(UMETHOD_CLASS, "arity", uarity, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "bind", bind, 1);
     globals.define_builtin_func(UMETHOD_CLASS, "source_location", usource_location, 0);

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -5,6 +5,10 @@ use super::*;
 //
 
 pub(super) fn init(globals: &mut Globals) {
+    // Module.allocate raises (CRuby behavior); Module.new uses an internal
+    // allocator inside `module_new`, not Class#new. Class subclasses Module
+    // and reinstalls its own alloc_func in `class.rs::init`.
+    globals.store[MODULE_CLASS].clear_alloc_func();
     // class methods
     globals.define_builtin_class_func_with_kw(
         MODULE_CLASS,

--- a/monoruby/src/builtins/nil_class.rs
+++ b/monoruby/src/builtins/nil_class.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("NilClass", NIL_CLASS, None);
-    globals.define_builtin_class_func(NIL_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[NIL_CLASS].clear_alloc_func();
 }
 
 #[cfg(test)]

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -28,7 +28,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     );
     globals.define_builtin_funcs(COMPLEX_CLASS, "abs", &["magnitude"], abs, 0);
     globals.define_builtin_funcs(COMPLEX_CLASS, "rect", &["rectangular"], rect, 0);
-    globals.define_builtin_class_func(COMPLEX_CLASS, "allocate", super::super::class::undef_allocate, 0);
+    globals.store[COMPLEX_CLASS].clear_alloc_func();
     globals.define_builtin_func(COMPLEX_CLASS, "eql?", eql_, 1);
     globals.define_builtin_func(COMPLEX_CLASS, "coerce", coerce, 1);
 }

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -55,7 +55,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_funcs(FLOAT_CLASS, "to_s", &["inspect"], float_to_s, 0);
     globals.define_builtin_func(FLOAT_CLASS, "to_r", float_to_r, 0);
     globals.define_builtin_func_with(FLOAT_CLASS, "rationalize", float_rationalize, 0, 1, false);
-    globals.define_builtin_class_func(FLOAT_CLASS, "allocate", super::super::class::undef_allocate, 0);
+    globals.store[FLOAT_CLASS].clear_alloc_func();
     // Float.new should raise NoMethodError (not TypeError from allocate)
     let float_meta = globals.store.get_metaclass(FLOAT_CLASS).id();
     globals.add_empty_method(float_meta, IdentId::get_id("new"), Visibility::Undefined);

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -9,6 +9,7 @@ use std::ops::{BitAnd, BitOr, BitXor};
 
 pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_class("Integer", INTEGER_CLASS, numeric, OBJECT_CLASS, None);
+    globals.store[INTEGER_CLASS].clear_alloc_func();
     globals.define_builtin_func_with(INTEGER_CLASS, "chr", chr, 0, 1, false);
     //globals.define_builtin_inline_func(INTEGER_CLASS, "succ", succ, Box::new(integer_succ), 0);
     //globals.define_builtin_func(INTEGER_CLASS, "times", times, 0);

--- a/monoruby/src/builtins/numeric/rational.rs
+++ b/monoruby/src/builtins/numeric/rational.rs
@@ -42,7 +42,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         RATIONAL_CLASS, "round", rat_round, 0, 1, false, &["half"], false,
     );
     globals.define_builtin_class_func(RATIONAL_CLASS, "__allocate", allocate, 2);
-    globals.define_builtin_class_func(RATIONAL_CLASS, "allocate", super::super::class::undef_allocate, 0);
+    globals.store[RATIONAL_CLASS].clear_alloc_func();
 }
 
 /// Rational.__allocate(num, den) — internal constructor from Ruby

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -7,7 +7,7 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Proc", PROC_CLASS, ObjTy::PROC);
     globals.define_builtin_class_func_with_effect(PROC_CLASS, "new", new, 0, 0, Effect::CAPTURE);
-    globals.define_builtin_class_func(PROC_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[PROC_CLASS].clear_alloc_func();
     globals.define_builtin_funcs_with_kw(
         PROC_CLASS,
         "call",

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -7,7 +7,7 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Range", RANGE_CLASS, ObjTy::RANGE);
     globals.define_builtin_class_func_with(RANGE_CLASS, "new", range_new, 2, 3, false);
-    globals.define_builtin_class_func(RANGE_CLASS, "allocate", allocate, 0);
+    globals.store[RANGE_CLASS].set_alloc_func(range_alloc_func);
     globals.define_builtin_inline_func(RANGE_CLASS, "begin", begin, Box::new(range_begin), 0);
     globals.define_builtin_func_with(RANGE_CLASS, "first", first, 0, 1, false);
     globals.define_builtin_inline_func(RANGE_CLASS, "end", end, Box::new(range_end), 0);
@@ -45,16 +45,9 @@ fn range_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     globals.generate_range(lfp.arg(0), lfp.arg(1), exclude_end)
 }
 
-/// ### Range.allocate
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Ok(Value::range_with_class(
-        Value::nil(),
-        Value::nil(),
-        false,
-        class_id,
-    ))
+/// Allocator for `Range` and its subclasses.
+pub(crate) extern "C" fn range_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::range_with_class(Value::nil(), Value::nil(), false, class_id)
 }
 
 ///

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -31,17 +31,16 @@ pub(crate) fn init(globals: &mut Globals) {
     globals.define_builtin_func(REGEXP_CLASS, "options", options, 0);
     globals.define_builtin_func_with(REGEXP_CLASS, "match?", match_, 1, 2, false);
     globals.define_builtin_func_with(REGEXP_CLASS, "match", rmatch, 1, 2, false);
-    globals.define_builtin_class_func(REGEXP_CLASS, "allocate", allocate, 0);
+    globals.store[REGEXP_CLASS].set_alloc_func(regexp_alloc_func);
 }
 
 // Class methods
 
-/// ### Regexp.allocate
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    let regexp = RegexpInner::with_option("", 0)?;
-    Ok(Value::regexp_with_class(regexp, class_id))
+/// Allocator for `Regexp` and its subclasses. An empty pattern with no
+/// options cannot fail to compile, so unwrap is safe.
+pub(crate) extern "C" fn regexp_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    let regexp = RegexpInner::with_option("", 0).expect("empty regexp compile cannot fail");
+    Value::regexp_with_class(regexp, class_id)
 }
 
 ///

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -10,7 +10,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Set", SET_CLASS, ObjTy::HASH);
     globals.define_builtin_class_func_rest(SET_CLASS, "[]", set_index);
     globals.define_builtin_class_func_with(SET_CLASS, "new", new, 0, 1, false);
-    globals.define_builtin_class_func(SET_CLASS, "allocate", allocate, 0);
+    globals.store[SET_CLASS].set_alloc_func(set_alloc_func);
 
     globals.define_builtin_func(SET_CLASS, "<<", add, 1);
     globals.define_builtin_func(SET_CLASS, "add", add, 1);
@@ -139,21 +139,11 @@ fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _pc: BytecodePtr) -> 
     Ok(obj)
 }
 
-///
-/// ### Set.allocate
-///
-/// - allocate -> Set
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Class/i/allocate.html]
-#[monoruby_builtin]
-fn allocate(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Ok(Value::hash_with_class_and_default(class_id, Value::nil()))
+/// Allocator for `Set` and its subclasses. Set uses the same underlying hash
+/// storage as `Hash`, so the allocator hands back an empty hash typed with
+/// the given class id.
+pub(crate) extern "C" fn set_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::hash_with_class_and_default(class_id, Value::nil())
 }
 
 ///

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -19,7 +19,7 @@ pub(super) fn init(globals: &mut Globals) {
         &["encoding", "capacity"],
         false,
     );
-    globals.define_builtin_class_func(STRING_CLASS, "allocate", allocate, 0);
+    globals.store[STRING_CLASS].set_alloc_func(string_alloc_func);
     globals.define_builtin_class_func(STRING_CLASS, "try_convert", string_try_convert, 1);
     globals.define_builtin_func(STRING_CLASS, "+", add, 1);
     globals.define_builtin_func(STRING_CLASS, "*", mul, 1);
@@ -202,11 +202,10 @@ fn string_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     Ok(Value::string(s))
 }
 
-/// ### String.allocate
-#[monoruby_builtin]
-fn allocate(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    Ok(Value::string_with_class("", class_id))
+/// Allocator for `String` and its subclasses. Installed on `STRING_CLASS`'s
+/// `ClassInfo.alloc_func`; invoked by `Class#new` and `Class#allocate`.
+pub(crate) extern "C" fn string_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::string_with_class("", class_id)
 }
 
 ///

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -2,7 +2,10 @@ use super::*;
 
 pub(crate) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Struct", STRUCT_CLASS, ObjTy::CLASS);
-    globals.define_builtin_class_func(STRUCT_CLASS, "allocate", allocate, 0);
+    // Struct itself is not allocatable (`Struct.allocate` and `Struct.new(1)`
+    // both raise). Subclasses created via `Struct.new(:a, :b, ...)` get the
+    // default allocator installed in `define_struct_class`.
+    globals.store[STRUCT_CLASS].clear_alloc_func();
     globals.define_builtin_class_func_rest(STRUCT_CLASS, "new", struct_new);
     globals.define_builtin_class_func_rest(STRUCT_CLASS, "initialize", struct_initialize);
 
@@ -11,17 +14,6 @@ pub(crate) fn init(globals: &mut Globals) {
     globals.define_builtin_func(STRUCT_CLASS, "members", members, 0);
     globals.define_builtin_funcs(STRUCT_CLASS, "==", &["eql?"], eq, 1);
     globals.define_builtin_func(STRUCT_CLASS, "!=", ne, 1);
-}
-
-/// Struct.allocate raises "allocator undefined" for the base Struct class,
-/// but allows allocate on Struct subclasses (e.g. Customer = Struct.new(:name)).
-#[monoruby_builtin]
-fn allocate(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
-    if class_id == STRUCT_CLASS {
-        return Err(MonorubyErr::typeerr("allocator undefined for Struct"));
-    }
-    Ok(Value::object(class_id))
 }
 
 ///

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Symbol", SYMBOL_CLASS, None);
-    globals.define_builtin_class_func(SYMBOL_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[SYMBOL_CLASS].clear_alloc_func();
     globals.define_builtin_class_func(SYMBOL_CLASS, "all_symbols", all_symbols, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "<=>", cmp, 1);
     globals.define_builtin_func(SYMBOL_CLASS, "===", eq, 1);

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -23,7 +23,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_funcs_with(TIME_CLASS, "gm", &["utc"], time_gm, 1, 7, false);
     globals.define_builtin_class_func(TIME_CLASS, "now", time_now, 0);
     globals.define_builtin_class_func_with(TIME_CLASS, "at", time_at, 1, 2, false);
-    globals.define_builtin_class_func(TIME_CLASS, "allocate", allocate, 0);
+    globals.store[TIME_CLASS].set_alloc_func(time_alloc_func);
 
     globals.define_builtin_funcs(TIME_CLASS, "gmtime", &["utc"], gmtime, 0);
     globals.define_builtin_funcs(TIME_CLASS, "gmt?", &["utc?"], gmt_, 0);
@@ -92,17 +92,10 @@ fn time_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(Value::new_time(time_info))
 }
 
-/// ### Time.allocate
-#[monoruby_builtin]
-fn allocate(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
+/// Allocator for `Time` and its subclasses.
+pub(crate) extern "C" fn time_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
     let time_info = TimeInner::Utc(DateTime::<Utc>::default());
-    Ok(Value::new_time_with_class(time_info, class_id))
+    Value::new_time_with_class(time_info, class_id)
 }
 
 ///

--- a/monoruby/src/builtins/true_class.rs
+++ b/monoruby/src/builtins/true_class.rs
@@ -6,7 +6,7 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("TrueClass", TRUE_CLASS, None);
-    globals.define_builtin_class_func(TRUE_CLASS, "allocate", super::class::undef_allocate, 0);
+    globals.store[TRUE_CLASS].clear_alloc_func();
 }
 
 #[cfg(test)]

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -200,6 +200,12 @@ impl Globals {
             ObjTy::OBJECT,
         );
         object_class.set_superclass(Some(basic_object));
+        // Seed the root of the alloc_func inheritance chain with the default
+        // generic allocator. `generate_class_obj` copies this field from the
+        // superclass at class-creation time, so every subsequent class picks
+        // it up automatically unless a builtin overrides it.
+        globals.store[BASIC_OBJECT_CLASS].set_alloc_func(default_alloc_func);
+        globals.store[OBJECT_CLASS].set_alloc_func(default_alloc_func);
         globals.set_constant(
             BASIC_OBJECT_CLASS,
             IdentId::get_id("BasicObject"),

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -325,14 +325,19 @@ pub struct ClassInfo {
     alloc_func: Option<AllocFunc>,
 }
 
-/// C-level allocator function pointer. Given a class id, returns a freshly
-/// allocated (uninitialized) instance of that class.
-pub type AllocFunc = extern "C" fn(ClassId) -> Value;
+/// C-level allocator function pointer. Given a class id (and a globals
+/// handle, used by a few allocators that need e.g. the class name), returns
+/// a freshly allocated (uninitialized) instance of that class.
+///
+/// The second parameter is always passed (matching a fixed calling
+/// convention so the JIT can install a single call sequence), but many
+/// allocators ignore it.
+pub type AllocFunc = extern "C" fn(ClassId, &mut crate::Globals) -> Value;
 
 /// Default allocator used by `BasicObject` and inherited by any class that
 /// does not override it. Produces a plain `RValue::Object` tagged with the
 /// given class id.
-pub extern "C" fn default_alloc_func(class_id: ClassId) -> Value {
+pub extern "C" fn default_alloc_func(class_id: ClassId, _: &mut crate::Globals) -> Value {
     Value::object(class_id)
 }
 
@@ -1015,6 +1020,7 @@ impl ClassInfoTable {
         let constants = orig.constants.clone();
         let constant_locations = orig.constant_locations.clone();
         let class_variables = orig.class_variables.clone();
+        let alloc_func = orig.alloc_func;
 
         let new_id = self.add_class();
         let class_obj = if is_module {
@@ -1031,6 +1037,7 @@ impl ClassInfoTable {
         info.constants = constants;
         info.constant_locations = constant_locations;
         info.class_variables = class_variables;
+        info.alloc_func = alloc_func;
 
         // Duplicate the singleton class too: CRuby's Module#initialize_copy
         // clones the singleton class so `def self.foo` and `extend`-ed modules
@@ -1081,7 +1088,12 @@ impl ClassInfoTable {
         } else {
             None
         };
-        self.define_class_inner(name, superclass, parent, false, Some(ObjTy::OBJECT))
+        let m = self.define_class_inner(name, superclass, parent, false, Some(ObjTy::OBJECT));
+        // Struct itself has no alloc_func, so a class created with `<` Struct
+        // would inherit None. `Struct.new(...)` however produces instantiable
+        // classes — install the default allocator explicitly.
+        self[m.id()].set_alloc_func(default_alloc_func);
+        m
     }
 
     fn define_class_inner(

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -316,6 +316,24 @@ pub struct ClassInfo {
     /// None for modules.
     ///
     instance_ty: Option<ObjTy>,
+    ///
+    /// C-level allocator (CRuby's `rb_alloc_func_t` equivalent). Invoked by
+    /// `Class#new` and the default `Class#allocate` to produce an
+    /// uninitialized instance. Inherited from the superclass at class
+    /// definition time; `None` means "allocator undefined" (raise TypeError).
+    ///
+    alloc_func: Option<AllocFunc>,
+}
+
+/// C-level allocator function pointer. Given a class id, returns a freshly
+/// allocated (uninitialized) instance of that class.
+pub type AllocFunc = extern "C" fn(ClassId) -> Value;
+
+/// Default allocator used by `BasicObject` and inherited by any class that
+/// does not override it. Produces a plain `RValue::Object` tagged with the
+/// given class id.
+pub extern "C" fn default_alloc_func(class_id: ClassId) -> Value {
+    Value::object(class_id)
 }
 
 impl alloc::GC<RValue> for ClassInfo {
@@ -350,6 +368,7 @@ impl ClassInfo {
             class_variables: None,
             ivar_names: indexmap::IndexMap::default(),
             instance_ty: None,
+            alloc_func: None,
         }
     }
 
@@ -365,7 +384,20 @@ impl ClassInfo {
             class_variables: None,
             ivar_names: self.ivar_names.clone(),
             instance_ty: self.instance_ty,
+            alloc_func: self.alloc_func,
         }
+    }
+
+    pub(crate) fn alloc_func(&self) -> Option<AllocFunc> {
+        self.alloc_func
+    }
+
+    pub(crate) fn set_alloc_func(&mut self, f: AllocFunc) {
+        self.alloc_func = Some(f);
+    }
+
+    pub(crate) fn clear_alloc_func(&mut self) {
+        self.alloc_func = None;
     }
 
     pub(crate) fn get_module(&self) -> Module {
@@ -886,10 +918,21 @@ impl ClassInfoTable {
         } else {
             Value::class_empty(class_id, superclass)
         };
+        // Inherit `alloc_func` from the superclass. Modules have no alloc_func.
+        // Builtin classes that need a custom allocator will overwrite this
+        // later via `ClassInfo::set_alloc_func`.
+        let inherited_alloc = if is_module {
+            None
+        } else if let Some(sc) = superclass {
+            self[sc.id()].alloc_func
+        } else {
+            None
+        };
         self[class_id].object = Some(class_obj.as_class());
         self[class_id].name = name.map(|id| id.to_string());
         self[class_id].parent = parent;
         self[class_id].instance_ty = instance_ty;
+        self[class_id].alloc_func = inherited_alloc;
         if let Some(name) = name {
             self.set_constant(parent.unwrap(), name, class_obj);
         }


### PR DESCRIPTION
## Summary
Refactor `Class#new` / `Class#allocate` to dispatch through a per-class `alloc_func` function pointer, then JIT-inline the allocation path. 3 commits, +239 / −353 across 26 files.

- **Phase A** (`c40c7d63`): Add `alloc_func: Option<extern "C" fn(...) -> Value>` field to `ClassInfo` with inheritance plumbing (`globals.rs`, `globals/store/class.rs`).
- **Phase B** (`6d6e76a6`): Route `Class#new` and `Class#allocate` through `ClassInfo.alloc_func`. Built-in classes with custom allocators (Array, Hash, String, Range, Set, Regexp, Time, Struct, Exception, IO, Method, MatchData, Proc, Binding, Complex, Float, Integer, Rational, Symbol, NilClass, TrueClass, FalseClass, Module) now register an `alloc_func` instead of overriding `new` / `allocate` individually. Removes the duplicated per-class `new`/`allocate` boilerplate in `class.rs` and slims the per-class wrappers.
- **Phase C** (`419f779f`): JIT-inline `Class#new` to emit a direct C call to the receiver class's `alloc_func`, followed by the normal `initialize` dispatch — skipping the generic `new` built-in for known classes.

## Test plan
- [ ] `cargo test`
- [ ] `bin/spec` — especially `core/class`, `core/module`, `core/kernel` (allocate / new)
- [ ] `bin/bench` — no regression on object-allocation-heavy benchmarks (expect small win from Phase C inlining)
- [ ] `cargo build --features emit-asm` sanity-check on inlined `Class#new` sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
