### PR TITLE
Parse `~` as an argument starter in command-style calls

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -2634,6 +2634,23 @@ mod tests {
     }
 
     #[test]
+    fn command_call_with_bitnot_arg() {
+        // `p ~x` / `foo ~x` — `~` is only ever a unary operator, so it
+        // must begin an argument in a parenless method call (matches
+        // CRuby's `p ~5 == -6`).
+        run_test("p ~5");
+        run_test("p ~5 + 3");
+        run_test("a = 10; p ~a");
+        run_test("a = 10; b = 20; p ~a + b");
+        run_test(
+            r#"
+            def foo(x); x; end
+            foo ~5
+            "#,
+        );
+    }
+
+    #[test]
     fn pow_unary_minus_rhs() {
         // `x ** -expr` where expr is a method call / identifier must parse
         // as `x ** (-expr)` (right-associative and tighter than outer `-`).

--- a/ruruby-parse/src/parser/arguments.rs
+++ b/ruruby-parse/src/parser/arguments.rs
@@ -208,9 +208,16 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
             match tok.kind {
                 TokenKind::LineTerm | TokenKind::Eof => false,
                 TokenKind::Punct(p) => match p {
-                    Punct::LParen | Punct::LBracket | Punct::Scope | Punct::Arrow | Punct::Not => {
-                        true
-                    }
+                    // Unambiguous argument-starting punctuators: `(`, `[`,
+                    // `::`, `->`, `!`, and `~`. `~` is only ever a unary
+                    // operator, so it always begins an argument (matches
+                    // CRuby's `foo ~x` parse).
+                    Punct::LParen
+                    | Punct::LBracket
+                    | Punct::Scope
+                    | Punct::Arrow
+                    | Punct::Not
+                    | Punct::BitNot => true,
                     Punct::Colon
                     | Punct::Plus
                     | Punct::Minus


### PR DESCRIPTION
## Summary

`p ~5`, `foo ~x`, and similar parenless method calls previously raised `SyntaxError` because the `is_command` heuristic in the parser didn't list `~` as an argument starter.

Unlike `+`/`-`/`*` which are also binary operators, `~` is unary-only — so it unconditionally begins an argument in this position. This matches CRuby (`p ~5 == -6`).

## Test plan

- [x] `cargo test --package monoruby --lib` — all 1162 tests pass
- [x] Manual comparison with CRuby for `p ~5`, `p ~5 + 3`, `p ~a`, `p ~a + b`, `foo ~5` — all match
- [x] Added regression test `command_call_with_bitnot_arg` covering the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)