### PR TITLE
Add missing Numeric methods and fix Proc#call block forwarding

### DIFF
--- a/monoruby/builtins/numeric.rb
+++ b/monoruby/builtins/numeric.rb
@@ -1,4 +1,15 @@
 class Numeric
+  include Comparable
+
+  def +@
+    self
+  end
+
+  def -@
+    a, b = coerce(0)
+    a - b
+  end
+
   def positive?
     self > 0
   end
@@ -11,6 +22,128 @@ class Numeric
     self < 0 ? -self : self
   end
   alias magnitude abs
+
+  def abs2
+    self * self
+  end
+
+  def zero?
+    self == 0
+  end
+
+  def nonzero?
+    zero? ? nil : self
+  end
+
+  def finite?
+    true
+  end
+
+  def infinite?
+    nil
+  end
+
+  def integer?
+    false
+  end
+
+  def real?
+    true
+  end
+
+  def real
+    self
+  end
+
+  def imag
+    0
+  end
+  alias imaginary imag
+
+  def conj
+    self
+  end
+  alias conjugate conj
+
+  def rect
+    [self, 0]
+  end
+  alias rectangular rect
+
+  def polar
+    [abs, arg]
+  end
+
+  def i
+    Complex(0, self)
+  end
+
+  def numerator
+    to_r.numerator
+  end
+
+  def denominator
+    to_r.denominator
+  end
+
+  def quo(other)
+    Rational(self) / other
+  end
+
+  def fdiv(other)
+    to_f / other
+  end
+
+  def div(other)
+    raise ZeroDivisionError, "divided by 0" if other == 0
+    (self / other).floor
+  end
+
+  def modulo(other)
+    self - other * div(other)
+  end
+  alias % modulo
+
+  def remainder(other)
+    mod = self % other
+    if mod != 0 && ((self < 0 && other > 0) || (self > 0 && other < 0))
+      mod - other
+    else
+      mod
+    end
+  end
+
+  def eql?(other)
+    self.class == other.class && self == other
+  end
+
+  def divmod(other)
+    [div(other), modulo(other)]
+  end
+
+  def coerce(other)
+    if self.class == other.class
+      [other, self]
+    else
+      if other.nil? || other.equal?(true) || other.equal?(false) || other.is_a?(Symbol)
+        raise TypeError, "#{other.class} can't be coerced into #{self.class}"
+      end
+      begin
+        [Float(other), Float(self)]
+      rescue TypeError
+        raise TypeError, "#{other.class} can't be coerced into #{self.class}"
+      end
+    end
+  end
+
+  def clone(freeze: true)
+    raise ArgumentError, "can't unfreeze #{self.class}" if freeze == false
+    self
+  end
+
+  def dup
+    self
+  end
 
   def to_int
     to_i
@@ -41,8 +174,14 @@ class Numeric
   end
 
   def step(limit = nil, step = nil, by: nil, to: nil)
-    limit = to if to
-    step = by if by
+    if !to.nil? && !limit.nil?
+      raise ArgumentError, "wrong number of arguments (given 2, expected 0..1)"
+    end
+    if !by.nil? && !step.nil?
+      raise ArgumentError, "wrong number of arguments (given 2, expected 0..1)"
+    end
+    limit = to unless to.nil?
+    step = by unless by.nil?
     step ||= 1
     raise ArgumentError, "step can't be 0" if step == 0
     return to_enum(:step, limit, step) unless block_given?

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -702,22 +702,14 @@ class Data
   end
 end unless defined?(::Data)
 
-class Numeric
-  include Comparable
-
-  def +@
-    self
-  end
-end
-
 require_relative 'enumerable'
+require_relative 'numeric'
 require_relative 'integer'
 require_relative 'range'
 require_relative 'array'
 require_relative 'rational'
 require_relative 'complex'
 require_relative 'float'
-require_relative 'numeric'
 require_relative 'string'
 require_relative 'symbol'
 require_relative 'error'

--- a/monoruby/src/builtins/numeric.rs
+++ b/monoruby/src/builtins/numeric.rs
@@ -22,7 +22,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(NUMERIC_CLASS, "/", div, 1);
     globals.define_builtin_funcs(NUMERIC_CLASS, "%", &["module"], rem, 1);
     globals.define_builtin_func(NUMERIC_CLASS, "**", pow, 1);
-    globals.define_builtin_func(NUMERIC_CLASS, "-@", neg, 0);
+    globals.define_builtin_func(INTEGER_CLASS, "-@", neg, 0);
+    globals.define_builtin_func(FLOAT_CLASS, "-@", neg, 0);
+    globals.define_builtin_func(COMPLEX_CLASS, "-@", neg, 0);
     globals.define_builtin_func(NUMERIC_CLASS, "~", bitnot, 0);
     globals.define_builtin_funcs(NUMERIC_CLASS, "angle", &["arg", "phase"], angle, 0);
 }

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -99,7 +99,8 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let bh = lfp.block();
         return vm.invoke_method_inner(globals, symbol_id, recv, &rest, bh, None);
     }
-    vm.invoke_proc(globals, &proc, &lfp.arg(0).as_array())
+    let bh = lfp.block();
+    vm.invoke_proc_with_block(globals, &proc, &lfp.arg(0).as_array(), bh)
 }
 
 ///

--- a/monoruby/src/codegen/invoker.rs
+++ b/monoruby/src/codegen/invoker.rs
@@ -437,8 +437,8 @@ impl JitModule {
     fn invoker_frame_setup(&mut self, invoke_block: bool, specify_self: bool) {
         if invoke_block {
             monoasm! { &mut self.jit,
-                // set block
-                movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], 0;
+                // set block (rcx holds optional block handler passed from caller)
+                movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], rcx;
                 movq rax, [rdx + (PROCDATA_OUTER)];        // rax <- outer_lfp
                 movl rdx, [rdx + (PROCDATA_FUNCID)];    // rdx <- FuncId
             };

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1352,12 +1352,26 @@ impl Executor {
         proc: &ProcInner,
         args: &[Value],
     ) -> Result<Value> {
+        self.invoke_proc_with_block(globals, proc, args, None)
+    }
+
+    pub(crate) fn invoke_proc_with_block(
+        &mut self,
+        globals: &mut Globals,
+        proc: &ProcInner,
+        args: &[Value],
+        bh: Option<BlockHandler>,
+    ) -> Result<Value> {
         let proc = ProcData::from_proc(proc);
+        let block_val = match bh {
+            Some(handler) => handler.get(),
+            None => Value::nil(),
+        };
         (globals.invokers.block)(
             self,
             globals,
             &proc,
-            Value::nil(),
+            block_val,
             args.as_ptr(),
             args.len(),
             None,


### PR DESCRIPTION
## Summary
- Implement ~20 missing Numeric base class methods (abs2, zero?, nonzero?, coerce, conj, real, imag, rect, polar, quo, fdiv, div, divmod, remainder, eql?, clone, dup, finite?, infinite?, integer?, real?, i)
- Fix a bug where `&block` parameters in lambdas/procs were always nil — Proc#call now forwards its block through the invoker chain
- Move Numeric#-@ Rust registration from NUMERIC_CLASS to Integer/Float/Complex, with a Ruby-level coerce-based fallback on Numeric
- Move Numeric class definition from startup.rb into numeric.rb

## Test plan
- [x] `cargo test -p monoruby --lib` — all 1163 tests pass
- [x] `mspec run core/numeric` (excluding step_spec) — 130 examples, 533 expectations, 6 failures (pre-existing mock/coerce protocol issues), 1 error (pre-existing)
- [x] Verified negation works for Integer, Float, Complex, Rational
- [x] Verified lambda `&block` parameter passing works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)