### PR TITLE
Fix Numeric#step failures (Float coercion, infinity handling, Enumerator size)

### DIFF
--- a/monoruby/builtins/numeric.rb
+++ b/monoruby/builtins/numeric.rb
@@ -185,16 +185,86 @@ class Numeric
     step ||= 1
     raise ArgumentError, "step can't be 0" if step == 0
     return to_enum(:step, limit, step) unless block_given?
-    i = self
-    if step > 0
-      while (limit.nil? || i <= limit) && i.finite?
-        yield i
-        i += step
+
+    # Non-numeric `step` (e.g. `"foo"`) passes through `to_enum`
+    # unchanged -- matching CRuby, which only raises at iteration time
+    # -- but must fail loudly once we actually start iterating.
+    unless step.is_a?(Numeric)
+      raise ArgumentError, "step must be numeric"
+    end
+
+    use_float = self.is_a?(Float) ||
+                (!limit.nil? && limit.is_a?(Float)) ||
+                step.is_a?(Float)
+
+    if use_float
+      beg  = self.to_f
+      unit = step.to_f
+
+      # `unit` is +/- Infinity: at most one yield at `beg`, if the
+      # direction matches.
+      if unit.infinite?
+        if limit.nil?
+          yield beg
+        else
+          endv = limit.to_f
+          if unit > 0 ? beg <= endv : beg >= endv
+            yield beg
+          end
+        end
+        return self
+      end
+
+      if limit.nil?
+        # Unbounded: counted loop to avoid accumulated FP drift.
+        i = 0
+        loop do
+          yield beg + i * unit
+          i += 1
+        end
+      else
+        endv = limit.to_f
+        n = (endv - beg) / unit
+        if n.nan? || n < 0
+          # Direction mismatch or NaN: no yield.
+          return self
+        end
+        if n.infinite?
+          # `endv` is +/- Infinity in the iteration direction: yield
+          # forever, computing each value from the index to avoid
+          # cumulative rounding error.
+          i = 0
+          loop do
+            yield beg + i * unit
+            i += 1
+          end
+        end
+        # Tolerance mimicking CRuby's ruby_float_step:
+        #   err = (|beg| + |end| + |end-beg|) / |unit| * DBL_EPSILON
+        err = (beg.abs + endv.abs + (endv - beg).abs) / unit.abs * Float::EPSILON
+        err = 0.5 if err > 0.5
+        n = (n + err).floor
+        (0..n).each do |i|
+          d = beg + i * unit
+          # Clamp overshoot past the boundary (floating-point rounding).
+          if unit > 0 ? d > endv : d < endv
+            d = endv
+          end
+          yield d
+        end
       end
     else
-      while (limit.nil? || i >= limit) && i.finite?
-        yield i
-        i += step
+      i = self
+      if step > 0
+        while limit.nil? || i <= limit
+          yield i
+          i += step
+        end
+      else
+        while limit.nil? || i >= limit
+          yield i
+          i += step
+        end
       end
     end
     self

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -144,7 +144,73 @@ fn enumerator_size(
                 Ok(Value::nil())
             }
         }
+        "step" => {
+            // `to_enum(:step, limit, step)` from Numeric#step, so
+            // `inner.args == [limit, step]`.
+            let limit = inner.args.first().copied().unwrap_or(Value::nil());
+            let step_val = inner
+                .args
+                .get(1)
+                .copied()
+                .unwrap_or(Value::integer(1));
+            // Non-numeric step: iteration will raise, don't provide a size.
+            let step_f = match numeric_to_f64(step_val) {
+                Some(f) => f,
+                None => return Ok(Value::nil()),
+            };
+            if step_f == 0.0 {
+                return Ok(Value::nil());
+            }
+            if limit.is_nil() {
+                return Ok(Value::float(f64::INFINITY));
+            }
+            let limit_f = match numeric_to_f64(limit) {
+                Some(f) => f,
+                None => return Ok(Value::nil()),
+            };
+            let beg_f = match numeric_to_f64(inner.obj) {
+                Some(f) => f,
+                None => return Ok(Value::nil()),
+            };
+            if step_f.is_infinite() {
+                let yields = if step_f > 0.0 {
+                    beg_f <= limit_f
+                } else {
+                    beg_f >= limit_f
+                };
+                return Ok(Value::integer(if yields { 1 } else { 0 }));
+            }
+            if limit_f.is_infinite() {
+                let dir_match =
+                    (limit_f > 0.0 && step_f > 0.0) || (limit_f < 0.0 && step_f < 0.0);
+                return if dir_match {
+                    Ok(Value::float(f64::INFINITY))
+                } else {
+                    Ok(Value::integer(0))
+                };
+            }
+            let n = (limit_f - beg_f) / step_f;
+            if n.is_nan() || n < 0.0 {
+                return Ok(Value::integer(0));
+            }
+            let err = (beg_f.abs() + limit_f.abs() + (limit_f - beg_f).abs()) / step_f.abs()
+                * f64::EPSILON;
+            let err = err.min(0.5);
+            let count = (n + err).floor() as i64 + 1;
+            Ok(Value::integer(count))
+        }
         _ => Ok(Value::nil()),
+    }
+}
+
+/// Best-effort cast of a numeric Value (Fixnum / Float / BigInt) to
+/// f64. Returns None for non-numeric values.
+fn numeric_to_f64(v: Value) -> Option<f64> {
+    match v.unpack() {
+        RV::Fixnum(i) => Some(i as f64),
+        RV::Float(f) => Some(f),
+        RV::BigInt(b) => b.to_f64(),
+        _ => None,
     }
 }
 

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -153,10 +153,15 @@ fn enumerator_size(
                 .get(1)
                 .copied()
                 .unwrap_or(Value::integer(1));
-            // Non-numeric step: iteration will raise, don't provide a size.
+            // Non-numeric step (e.g. `"1"`, `"foo"`) is accepted by the
+            // enumerator constructor, but asking for `.size` must raise
+            // the same error that iterating would raise -- matching
+            // CRuby.
             let step_f = match numeric_to_f64(step_val) {
                 Some(f) => f,
-                None => return Ok(Value::nil()),
+                None => {
+                    return Err(MonorubyErr::argumenterr("step must be numeric"));
+                }
             };
             if step_f == 0.0 {
                 return Ok(Value::nil());


### PR DESCRIPTION
## Summary

Fix `Numeric#step` errors and failures surfaced by `core/numeric` spec. This PR stacks on top of #328 (`claude/setup-dev-environment-HrlAW`).

| scope | before | after | delta |
|---|---:|---:|---:|
| `core/numeric/step_spec.rb` | 44 F / 2 E | **0 F / 2 E** | **-44 F** |
| `core/numeric` overall      | 50 F / 3 E | **6 F / 3 E** | -44 F |
| 10 sampled categories (proc, enumerable, array, hash, kernel, argf, symbol, integer, float, range) | — | unchanged | no regressions |

## Commits

### 1. `Numeric#step`: Float coercion, infinite-step/limit handling, Enumerator size (`99b606a7`)

Rewrite `Numeric#step` in `builtins/numeric.rb` against CRuby's `ruby_float_step` shape:

- Promote to Float when any of `self` / `limit` / `step` is Float.
- Counted iteration `d = beg + i * unit` instead of accumulation — avoids FP drift that made the accumulation form yield `3.5999999999999996` instead of `3.6`.
- Clamp the last yielded value to `limit` when FP rounding overshoots.
- Tolerance `err = (|beg| + |end| + |end-beg|) / |unit| * DBL_EPSILON` (capped at `0.5`) for the iteration count.
- `step = ±Infinity`: yield at most once, at `self`, if direction matches.
- `limit = ±Infinity` in the iteration direction: yield forever, computing each value from the index.
- Non-numeric `step` (e.g. `"foo"`): passes through `to_enum` without raising so the returned Enumerator is a valid Ruby object, but any actual iteration path (`each`, `to_a`, `.first`, `.size`, …) raises `ArgumentError`. This matches CRuby and incidentally fixes a hang — previously `step.to_f` silently collapsed `"foo"` to `0.0` and `(end-beg)/0.0 == INFINITY` drove an infinite loop under the new counted-iteration code.

Add a matching `"step"` arm to `Enumerator#size` in `builtins/enumerator.rs` so the Enumerator returned from the no-block path reports the right size:

| case | size |
|---|---|
| `nil` limit | `Float::INFINITY` |
| direction-matching infinite limit | `Float::INFINITY` |
| infinite step, direction matches | `1` |
| infinite step, direction does not match | `0` |
| finite case | `floor((end-beg)/step + err) + 1` |

### 2. `Enumerator#size`: raise `ArgumentError` when `:step` has non-numeric step (`c0c1875a`)

`to_enum(:step, limit, "foo").size` used to silently return `nil` while CRuby raises `ArgumentError`. The iteration path already raises — make `.size` behave consistently.

## Remaining numeric failures (not step-related, out of scope)

- `Numeric#quo` raising `TypeError`: 1 E
- `Numeric#remainder` mock-coerce assertions: 5 F
- `Numeric#singleton_method_added` wrong error class: 1 F
- `Enumerator::ArithmeticSequence` load-time error in the no-block describe blocks: 2 E (requires `Enumerator.new` to respect a subclass receiver, which is hardcoded in monoruby; separate task).

## Test plan

- [x] `cargo build` clean on nightly-2025-10-15
- [x] `core/numeric/step_spec.rb`: 44 F → 0 F
- [x] `core/numeric` overall: 50 F / 3 E → 6 F / 3 E
- [x] No regressions in proc / enumerable / array / hash / kernel / argf / symbol / integer / float / range
- [x] Minimal repros: `1.0.step(12.7, 1.3)` → `[..., 12.7]` (not `12.7000…001`); `1.step(to: ∞, by: ∞).size` → `1`; `1.step(5, "foo").size` → raises `ArgumentError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)