### PR TITLE
Enumerator#size: carry a real size slot on EnumeratorInner

### DIFF
--- a/monoruby/builtins/numeric.rb
+++ b/monoruby/builtins/numeric.rb
@@ -184,7 +184,11 @@ class Numeric
     step = by unless by.nil?
     step ||= 1
     raise ArgumentError, "step can't be 0" if step == 0
-    return to_enum(:step, limit, step) unless block_given?
+    unless block_given?
+      # Attach a size-computing block so `to_enum(:step).size` reports
+      # the correct value without iterating.  The block runs lazily.
+      return to_enum(:step, limit, step) { __step_size(limit, step) }
+    end
 
     # Non-numeric `step` (e.g. `"foo"`) passes through `to_enum`
     # unchanged -- matching CRuby, which only raises at iteration time
@@ -268,5 +272,40 @@ class Numeric
       end
     end
     self
+  end
+
+  private
+
+  # Compute the size that `step(limit, step)` will yield, without
+  # actually iterating. Invoked lazily via the size block attached to
+  # `to_enum(:step, ...)`. Returns:
+  #   - `Float::INFINITY` when iteration is unbounded in the step's
+  #     direction (`limit == nil` or limit = +/-INFINITY aligned with
+  #     step's sign),
+  #   - `1` / `0` for infinite step, depending on whether the first
+  #     yield occurs,
+  #   - `floor((limit - self)/step + err) + 1` otherwise,
+  #   - raises `ArgumentError` for a non-numeric step, matching
+  #     `.each`'s behavior.
+  def __step_size(limit, step)
+    unless step.is_a?(Numeric)
+      raise ArgumentError, "step must be numeric"
+    end
+    return Float::INFINITY if limit.nil?
+    beg  = self.to_f
+    unit = step.to_f
+    endv = limit.to_f
+    if unit.infinite?
+      return (unit > 0 ? (beg <= endv ? 1 : 0) : (beg >= endv ? 1 : 0))
+    end
+    if endv.infinite?
+      dir = (endv > 0 && unit > 0) || (endv < 0 && unit < 0)
+      return dir ? Float::INFINITY : 0
+    end
+    n = (endv - beg) / unit
+    return 0 if n.nan? || n < 0
+    err = (beg.abs + endv.abs + (endv - beg).abs) / unit.abs * Float::EPSILON
+    err = 0.5 if err > 0.5
+    (n + err).floor + 1
   end
 end

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -60,8 +60,8 @@ pub(super) fn init(globals: &mut Globals) {
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerator/i/size.html]
 #[monoruby_builtin]
 fn enumerator_size(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
@@ -70,6 +70,14 @@ fn enumerator_size(
         return Ok(Value::nil());
     }
     let inner = e.as_enumerator_inner();
+    // Explicit size attached via `to_enum(...) { size }` / Enumerator.new(size).
+    // Proc values are evaluated lazily, matching CRuby.
+    if let Some(stored) = inner.size() {
+        if let Some(proc) = stored.is_proc() {
+            return vm.invoke_proc(globals, &proc, &[]);
+        }
+        return Ok(stored);
+    }
     let method_name = inner.method.get_name();
     match method_name.as_str() {
         "upto" => {
@@ -81,7 +89,7 @@ fn enumerator_size(
                 } else {
                     return Err(MonorubyErr::argumenterr(format!(
                         "comparison of Integer with {} failed: coercion was not possible",
-                        stop_val.get_real_class_name(&_globals.store)
+                        stop_val.get_real_class_name(&globals.store)
                     )));
                 };
                 let size = if stop >= start { stop - start + 1 } else { 0 };
@@ -99,7 +107,7 @@ fn enumerator_size(
                 } else {
                     return Err(MonorubyErr::argumenterr(format!(
                         "comparison of Integer with {} failed: coercion was not possible",
-                        stop_val.get_real_class_name(&_globals.store)
+                        stop_val.get_real_class_name(&globals.store)
                     )));
                 };
                 let size = if start >= stop { start - stop + 1 } else { 0 };
@@ -144,85 +152,18 @@ fn enumerator_size(
                 Ok(Value::nil())
             }
         }
-        "step" => {
-            // `to_enum(:step, limit, step)` from Numeric#step, so
-            // `inner.args == [limit, step]`.
-            let limit = inner.args.first().copied().unwrap_or(Value::nil());
-            let step_val = inner
-                .args
-                .get(1)
-                .copied()
-                .unwrap_or(Value::integer(1));
-            // Non-numeric step (e.g. `"1"`, `"foo"`) is accepted by the
-            // enumerator constructor, but asking for `.size` must raise
-            // the same error that iterating would raise -- matching
-            // CRuby.
-            let step_f = match numeric_to_f64(step_val) {
-                Some(f) => f,
-                None => {
-                    return Err(MonorubyErr::argumenterr("step must be numeric"));
-                }
-            };
-            if step_f == 0.0 {
-                return Ok(Value::nil());
-            }
-            if limit.is_nil() {
-                return Ok(Value::float(f64::INFINITY));
-            }
-            let limit_f = match numeric_to_f64(limit) {
-                Some(f) => f,
-                None => return Ok(Value::nil()),
-            };
-            let beg_f = match numeric_to_f64(inner.obj) {
-                Some(f) => f,
-                None => return Ok(Value::nil()),
-            };
-            if step_f.is_infinite() {
-                let yields = if step_f > 0.0 {
-                    beg_f <= limit_f
-                } else {
-                    beg_f >= limit_f
-                };
-                return Ok(Value::integer(if yields { 1 } else { 0 }));
-            }
-            if limit_f.is_infinite() {
-                let dir_match =
-                    (limit_f > 0.0 && step_f > 0.0) || (limit_f < 0.0 && step_f < 0.0);
-                return if dir_match {
-                    Ok(Value::float(f64::INFINITY))
-                } else {
-                    Ok(Value::integer(0))
-                };
-            }
-            let n = (limit_f - beg_f) / step_f;
-            if n.is_nan() || n < 0.0 {
-                return Ok(Value::integer(0));
-            }
-            let err = (beg_f.abs() + limit_f.abs() + (limit_f - beg_f).abs()) / step_f.abs()
-                * f64::EPSILON;
-            let err = err.min(0.5);
-            let count = (n + err).floor() as i64 + 1;
-            Ok(Value::integer(count))
-        }
+        // `"step"` used to have a dedicated arm here; it is now computed
+        // by `Numeric#__step_size`, attached via the size block of
+        // `to_enum(:step, limit, step) { ... }` and returned from the
+        // `inner.size()` fast-path above.
         _ => Ok(Value::nil()),
-    }
-}
-
-/// Best-effort cast of a numeric Value (Fixnum / Float / BigInt) to
-/// f64. Returns None for non-numeric values.
-fn numeric_to_f64(v: Value) -> Option<f64> {
-    match v.unpack() {
-        RV::Fixnum(i) => Some(i as f64),
-        RV::Float(f) => Some(f),
-        RV::BigInt(b) => b.to_f64(),
-        _ => None,
     }
 }
 
 ///
 /// ### Enumerator.new
 ///
-/// - new([NOT SUPPORTED] size=nil) {|y| ... } -> Enumerator
+/// - new(size=nil) {|y| ... } -> Enumerator
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerator/s/new.html]
 #[monoruby_builtin]
@@ -235,7 +176,11 @@ fn enumerator_new(
     let bh = lfp.expect_block()?;
     let proc = vm.generate_proc(globals, bh, pc)?;
     let obj = Value::new_generator(proc);
-    vm.generate_enumerator(IdentId::EACH, obj, vec![], pc)
+    // Optional size argument: nil (default) / Integer / Float /
+    // Float::INFINITY / Proc. Stored verbatim; Enumerator#size resolves
+    // Proc values lazily.
+    let size = lfp.try_arg(0).filter(|v| !v.is_nil());
+    vm.generate_enumerator_with_size(IdentId::EACH, obj, vec![], pc, size)
 }
 
 ///

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1868,7 +1868,15 @@ fn is_a(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/enum_for.html]
 #[monoruby_builtin]
 fn to_enum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    lfp.expect_no_block()?;
+    // When a block is supplied, it becomes the size proc:
+    //   `to_enum(:step, limit, step) { step_size }`
+    // CRuby evaluates this lazily when `.size` is called on the
+    // returned Enumerator.
+    let size = if let Some(bh) = lfp.block() {
+        Some(vm.generate_proc(globals, bh, pc)?.as_val())
+    } else {
+        None
+    };
     let args = lfp.arg(0).as_array();
     let (method, args) = if args.is_empty() {
         (IdentId::EACH, vec![])
@@ -1878,7 +1886,7 @@ fn to_enum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
             args[1..].to_vec(),
         )
     };
-    vm.generate_enumerator(method, lfp.self_val(), args, pc)
+    vm.generate_enumerator_with_size(method, lfp.self_val(), args, pc, size)
 }
 
 ///

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1726,9 +1726,20 @@ impl Executor {
         args: Vec<Value>,
         pc: BytecodePtr,
     ) -> Result<Value> {
+        self.generate_enumerator_with_size(method, obj, args, pc, None)
+    }
+
+    pub(crate) fn generate_enumerator_with_size(
+        &mut self,
+        method: IdentId,
+        obj: Value,
+        args: Vec<Value>,
+        pc: BytecodePtr,
+        size: Option<Value>,
+    ) -> Result<Value> {
         let outer_lfp = Lfp::dummy_heap_frame_with_self(obj);
         let proc = Proc::from_outer(outer_lfp, ENUM_YIELDER_FUNCID, pc);
-        let e = Value::new_enumerator(obj, method, proc, args);
+        let e = Value::new_enumerator(obj, method, proc, args, size);
         Ok(e)
     }
 }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -957,8 +957,9 @@ impl Value {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        size: Option<Value>,
     ) -> Self {
-        RValue::new_enumerator(obj, method, proc, args).pack()
+        RValue::new_enumerator(obj, method, proc, args, size).pack()
     }
 
     pub(crate) fn new_generator(proc: Proc) -> Self {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -148,7 +148,7 @@ pub union ObjKind {
     method: ManuallyDrop<MethodInner>,
     umethod: ManuallyDrop<UMethodInner>,
     fiber: ManuallyDrop<FiberInner>,
-    enumerator: ManuallyDrop<EnumeratorInner>,
+    enumerator: ManuallyDrop<Box<EnumeratorInner>>,
     generator: ManuallyDrop<GeneratorInner>,
     binding: ManuallyDrop<BindingInner>,
     matchdata: ManuallyDrop<MatchDataInner>,
@@ -328,9 +328,17 @@ impl ObjKind {
         }
     }
 
-    fn enumerator(obj: Value, method: IdentId, proc: Proc, args: Vec<Value>) -> Self {
+    fn enumerator(
+        obj: Value,
+        method: IdentId,
+        proc: Proc,
+        args: Vec<Value>,
+        size: Option<Value>,
+    ) -> Self {
         Self {
-            enumerator: ManuallyDrop::new(EnumeratorInner::new(obj, method, proc, args)),
+            enumerator: ManuallyDrop::new(Box::new(EnumeratorInner::new(
+                obj, method, proc, args, size,
+            ))),
         }
     }
 
@@ -1451,10 +1459,11 @@ impl RValue {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        size: Option<Value>,
     ) -> Self {
         RValue {
             header: Header::new(ENUMERATOR_CLASS, ObjTy::ENUMERATOR),
-            kind: ObjKind::enumerator(obj, method, proc, args),
+            kind: ObjKind::enumerator(obj, method, proc, args, size),
             var_table: None,
         }
     }

--- a/monoruby/src/value/rvalue/enumerator.rs
+++ b/monoruby/src/value/rvalue/enumerator.rs
@@ -11,6 +11,11 @@ pub struct EnumeratorInner {
     pub proc: Proc,
     pub args: Box<Vec<Value>>,
     buffer: Option<Array>,
+    /// Optional size associated with the Enumerator:
+    ///   - `None`                → unknown / fall back to method-name dispatch
+    ///   - `Some(v)` with `Proc` → evaluated lazily when `#size` is called
+    ///   - `Some(v)` otherwise   → Integer / Float returned as-is
+    size: Option<Value>,
 }
 
 impl alloc::GC<RValue> for EnumeratorInner {
@@ -24,11 +29,20 @@ impl alloc::GC<RValue> for EnumeratorInner {
         if let Some(buf) = self.buffer {
             buf.mark(alloc)
         }
+        if let Some(size) = self.size {
+            size.mark(alloc);
+        }
     }
 }
 
 impl EnumeratorInner {
-    pub(crate) fn new(obj: Value, method: IdentId, proc: Proc, args: Vec<Value>) -> Self {
+    pub(crate) fn new(
+        obj: Value,
+        method: IdentId,
+        proc: Proc,
+        args: Vec<Value>,
+        size: Option<Value>,
+    ) -> Self {
         Self {
             obj,
             method,
@@ -36,7 +50,13 @@ impl EnumeratorInner {
             proc,
             args: Box::new(args),
             buffer: None,
+            size,
         }
+    }
+
+    /// Raw accessor for the stored size value (before proc resolution).
+    pub fn size(&self) -> Option<Value> {
+        self.size
     }
 }
 


### PR DESCRIPTION
## Summary

Replace `Enumerator#size`'s hardcoded method-name switch with a proper `size` slot on `EnumeratorInner`, and thread it through `Kernel#to_enum { ... }` and `Enumerator.new(size) { ... }`.

Stacks on top of #329 (merged into `claude/setup-dev-environment-HrlAW`).

## Motivation

`Enumerator#size` previously only worked for a handful of built-in Ruby methods (`upto` / `downto` / `times` / `cycle`, plus the `step` arm added in #329). `Kernel#to_enum` actively rejected any block, so there was no generic way to attach a size to an arbitrary Enumerator. CRuby supports:

```ruby
to_enum(:step, limit, step) { step_size }   # size block, evaluated lazily
Enumerator.new(size) { |y| ... }            # constant or Proc
```

monoruby now supports both.

## Changes

### Rust

- **`EnumeratorInner`**: new field `size: Option<Value>`.
  - `None` = unknown (fall back to the method-name switch).
  - `Some(v)` with a `Proc` = evaluated lazily on `#size`.
  - `Some(v)` otherwise (Integer / Float / `Float::INFINITY`) = returned as-is.
- **`ObjKind::enumerator`** changed from `ManuallyDrop<EnumeratorInner>` to `ManuallyDrop<Box<EnumeratorInner>>` — adding the 8-byte size field pushed the inner past the 48-byte union budget. This matches the pattern already used for `ExceptionInner` / `RationalInner`.
- **GC `mark`** marks the new size value too.
- **New `Executor::generate_enumerator_with_size`** carries the size through; the existing `generate_enumerator` stays as a no-size wrapper so all existing call sites compile unchanged.
- **`Kernel#to_enum` / `#enum_for`**: drop the blanket `expect_no_block()`. If a block is passed, it's converted to a Proc and stored as the size.
- **`Enumerator.new(size) { |y| ... }`**: the previously-ignored `size` positional arg is now honored.
- **`Enumerator#size`**: check the stored size first (resolving a Proc lazily); fall back to the existing method-name switch for `upto` / `downto` / `times` / `cycle`.
- **Remove** the ad-hoc `"step"` arm and the now-unused `numeric_to_f64` helper — size for step is now produced by the size block attached in Ruby.

### Ruby

- **`Numeric#step`** now attaches a size block:
  ```ruby
  to_enum(:step, limit, step) { __step_size(limit, step) }
  ```
- **`Numeric#__step_size`** (private) computes:
  - `Float::INFINITY` for unbounded iteration (nil limit, or `±Float::INFINITY` limit aligned with step sign)
  - `1` / `0` for infinite step depending on whether the first yield occurs
  - `floor((end - beg)/step + err) + 1` for the finite case (same `DBL_EPSILON` tolerance as the iteration loop)
  - raises `ArgumentError` for a non-numeric step, matching `.each`

## Verification

- `cargo build` clean on nightly-2025-10-15.
- `core/numeric/step_spec.rb`: **0 F**; `core/numeric` overall **6 F / 3 E** — identical to the pre-refactor numbers.
- No regressions in proc / enumerable / array / hash / kernel / argf / symbol / integer / float / range.
- Smoke tests for the new path:
  ```ruby
  1.step(by: 42).size                            # => Infinity
  1.step(to: Float::INFINITY, by: INF).size      # => 1
  Enumerator.new(5)   { |y| 3.times { |i| y << i } }.size  # => 5
  Enumerator.new     { |y| y << 1 }.size          # => nil
  ```

## Test plan

- [x] `cargo build` / `cargo install --path monoruby --force`
- [x] `core/numeric`: 6 F / 3 E (same as #329 final state)
- [x] 10 categories regression check
- [ ] Ideas for follow-ups: migrate `upto` / `downto` / `times` / `cycle` to attach their size at construction (removing the method-name switch entirely); `Array#each.size` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)