### PR TITLE
Lazy heap promotion for Proc/Lambda/Binding captures

### DIFF
--- a/doc/lazy_heap_promotion_design.md
+++ b/doc/lazy_heap_promotion_design.md
@@ -1,0 +1,295 @@
+# Lazy Heap Promotion — Design Plan
+
+Fix the `Array#permutation(n)` / `Integer#downto` wrapper regression
+described in `doc/permutation_break_bug.md` by deferring the stack →
+heap promotion of a block's captured outer frame until that outer
+method actually returns (YARV-style).
+
+This document is the plan. Implementation follows it.
+
+## Invariant we want to restore
+
+**At any instant, there is exactly one canonical storage location for
+a frame's registers.** Reads and writes through any handle — the live
+`cfp`, the frame's own `r14`, a Proc's `outer_lfp`, a Binding — must
+all see the same data.
+
+Today, `Lfp::move_frame_to_heap` breaks this invariant: after the
+move, the stack frame still exists and is read by the active method's
+`r14`, while the heap frame is read by every descendant Proc via
+`outer_lfp`. Writes to each diverge.
+
+## Strategy
+
+Two stages:
+
+1. **Stack-only until escape is unavoidable**: Proc / `&block` /
+   lambda captures set `outer_lfp` to a *stack* Lfp and remember, in
+   a per-cfp list, that "this Proc's `outer_lfp` field must be
+   rewritten when the cfp dies".
+
+2. **Promote at frame pop**: right before a method's stack frame is
+   released (epilogue / error unwind / fiber yield), walk the list
+   for this cfp; if non-empty, copy the stack frame to heap and
+   overwrite every registered `*mut Lfp` with the heap pointer.
+
+While the method is running, there is still only one physical copy
+(stack). When the method returns, it atomically moves to heap and
+every escapee is updated in lock-step — no window where both copies
+are live and writable.
+
+## Data structures
+
+Add to `Executor`:
+
+```rust
+/// For each still-live cfp that has produced at least one escape
+/// (Proc / Binding / Enumerator outer pointer), a list of raw
+/// pointers into those escapees' `outer_lfp` field.
+///
+/// Populated by `register_escapee` when an `&block` / lambda /
+/// `Proc.new` / `Kernel#binding` captures a stack frame. Drained by
+/// `promote_frame_on_return` at every exit from the matching cfp.
+escapees: rustc_hash::FxHashMap<CfpAddr, Vec<*mut Lfp>>,
+```
+
+`CfpAddr` is a newtype around `usize` (the raw cfp pointer) since
+`Cfp` is not `Hash`. The cfp address is stable while the frame is
+alive and unique across live frames.
+
+We skip the cfp lookup entirely in the common (no-escape) case by
+adding **one flag bit** to the cfp's LFP meta:
+
+```
+Meta.kind bit 3:  0:no_escapee  1:has_escapee
+```
+
+`generate_proc_inner` sets the bit the first time it registers an
+escapee for a cfp; the epilogue checks the bit in assembly.
+
+## Code surface
+
+### In `src/executor/frame.rs`
+
+- `Lfp::move_frame_to_heap` stays, but becomes internal-only. It is
+  still called from `promote_frame_on_return` to do the actual
+  physical copy. Behaviour unchanged (still recursive on outer —
+  because at the exit point the outer may also need promotion, and
+  we WANT that transitively).
+- Add `Lfp::detached_heap_copy(self) -> Self` that does what
+  `move_frame_to_heap` does but **without** mutating `cfp.lfp`. The
+  heap copy is a snapshot; nothing else refers to it. Used only by
+  the promotion path.
+- `Cfp::caller()` stays as-is: after the lazy fix, the outer lfp
+  pointer stored in a Proc/Binding is always either pure-stack (no
+  redirect) while the owning cfp is alive, or pure-heap (updated by
+  promotion) after it has returned. The pointer-comparison in
+  `caller()` is correct in both halves.
+
+### In `src/executor.rs`
+
+- `generate_proc_inner`, `generate_lambda`, `generate_binding`:
+  - get the stack outer lfp (as today via `resolve_block_target` /
+    `cfp.lfp()`)
+  - allocate the Proc/Binding with `outer_lfp` = that stack lfp
+  - call `vm.register_escapee(owner_cfp, &mut proc.outer_lfp as *mut Lfp)`
+  - set the `has_escapee` meta bit on owner_cfp's lfp
+  - recurse up the outer chain: for each ancestor that is still on
+    stack, register an escapee for that cfp too so it gets promoted
+    when it returns (this is how we handle the recursive-move
+    semantics that today's code does eagerly)
+
+- `pub(crate) fn promote_frame_on_return(&mut self, cfp: Cfp)`:
+  - If `cfp.lfp().meta().has_escapee()` is false, return (fast path
+    skipped by assembly flag check anyway — this is the
+    belt-and-braces check).
+  - Remove the entry from `self.escapees` for this cfp.
+  - Detached heap copy of the stack frame.
+  - For every `*mut Lfp` in the list, write the new heap lfp into
+    `*ptr`.
+  - (Outer chain: each escapee points to the captured stack lfp; if
+    that frame owns its own outer, the outer chain inside the new
+    heap copy still points at a still-live stack ancestor, which is
+    fine — that ancestor will also have an escapee registration and
+    promote when it returns.)
+
+- `register_escapee(cfp, *mut Lfp)`:
+  - Insert into the HashMap.
+  - Set `has_escapee` bit on `cfp.lfp()`'s meta.
+
+### In VM / JIT epilogue (`src/codegen.rs`)
+
+Add the promote-on-return hook to exactly five places:
+
+1. `Codegen::epilogue` — normal method return (`leave; ret`).
+2. `Codegen::method_return_specialized` — `return` from inside a
+   block.
+3. `Codegen::method_return` — same, non-specialised.
+4. The unwind path inside `handle_error` when it returns
+   `ErrorReturn::return_err` (a frame is about to be popped).
+5. The fiber yield path — a fiber yields, parent resumes. The fiber
+   frame isn't dead yet but becomes inaccessible; we can either
+   skip (the fiber itself is a Ruby object and survives) or
+   treat it as a normal return. Deferring decision until impl.
+
+Each of the five insert an assembly sequence:
+
+```
+movzbl  r10, [r14 - LFP_META + 4]  ; load Meta.kind
+test    r10, FLAG_HAS_ESCAPEE
+jz      epilogue_fast              ; common case: skip
+                                   ; slow case:
+movq    rdi, rbx                   ; vm
+call    runtime::promote_on_return
+epilogue_fast:
+leave
+ret
+```
+
+The flag is a single immediate bit test. No HashMap lookup on the
+happy path.
+
+### Exception / unwind
+
+`handle_error` in `src/codegen/jit_module.rs` returns one of three
+statuses. When `ErrorReturn::return_err`, the caller (JIT dispatch
+code) pops the current frame. We add a promote check there too.
+
+When `ErrorReturn::goto(dest)`, the current frame is *not* popped
+(execution just jumps to a rescue/ensure label inside the same
+method). No promotion needed.
+
+When `ErrorReturn::return_normal(val)`, the frame is being returned
+with a value — promote then.
+
+### GC
+
+GC marking already iterates:
+- every live `cfp` (via `vm.cfp().prev()` chain), marking each
+  `lfp`'s registers.
+- every Ruby-visible value (Proc, Binding, Enumerator, ...), each of
+  which owns its `outer_lfp` and marks that too.
+
+With lazy promotion, a Proc's `outer_lfp` while the owner method is
+still alive is a stack pointer. The live-cfp walk already visits
+that frame. Mark through it is safe (it's the same memory the live
+walk processes).
+
+A Proc's `outer_lfp` after the owner has returned is a heap pointer
+(updated by promotion). GC marks through it normally.
+
+We need one small invariant: **don't mark a stack frame twice** (once
+via cfp walk, once via Proc.outer_lfp walk). Monoruby's current
+marking already handles duplicate visits via the generation counter
+in `GC<RValue>`. Confirm this during implementation.
+
+### Fibers
+
+A fiber's Ruby stack lives inside the fiber object. When control
+switches out of a fiber, its cfp chain is suspended; when it resumes,
+execution continues. Stack lfps are valid across yields because the
+memory isn't freed until the fiber itself is GC'd.
+
+Risk scenario: a Proc captured in fiber A holds a stack lfp pointing
+into fiber A's stack. From fiber B, that Proc is called. The read
+goes to the fiber A stack — which is still alive. OK.
+
+Real risk: the fiber dies (terminates) with a Proc outstanding. The
+fiber's stack memory is freed. The Proc's outer_lfp is now dangling.
+We need to promote-on-fiber-termination. Add the same hook to fiber
+termination.
+
+## Edge cases to validate during impl
+
+1. **Transitive outer through multiple stack ancestors** (the minimal
+   repro — `/main` → loop → BlockA → &block). Multiple escapee
+   registrations up the chain: each ancestor promotes on its own
+   return. The heap frame's `outer` pointer is updated by the
+   intermediate promotion (its own escapee entry gets rewritten when
+   its outer returns).
+
+2. **Proc captured then immediately invoked** (today's fast path).
+   Owner frame still alive; Proc reads stack; writes to Proc-local
+   vs. captured-closure vs. outer — all go to the same stack
+   location. ✓
+
+3. **Proc captured, outer returns, Proc invoked later**. On outer
+   return, promote runs, Proc.outer_lfp becomes heap. Subsequent
+   invocation reads heap snapshot. Writes land on heap. The original
+   method is gone, there's no consistency issue. ✓
+
+4. **Proc captured inside Proc** (nested closures). Inner Proc's
+   outer is the outer Proc. Each has its own escapee chain. When
+   either's owner returns, that level promotes. ✓ (needs careful
+   test).
+
+5. **`Binding.of_caller`-style access** — monoruby has a `Binding`
+   object. Its `outer_lfp` needs the same treatment. Ensure
+   `Kernel#binding` goes through the escapee path.
+
+6. **Lambda returned from a method, then called much later after
+   many intervening cfps have come and gone**. At call time, the
+   lambda's outer_lfp is heap (owner already returned and promoted).
+   ✓
+
+## Implementation order
+
+1. **Plumbing first** — add `has_escapee` bit, `Executor.escapees`,
+   `register_escapee`, `promote_frame_on_return`, assembly flag
+   check wrapper. No behavioural change yet (the check is a no-op
+   unless something registers).
+2. **Switch `generate_proc_inner`** to register + stack-outer. Test
+   with the minimal repro + `core/proc` + `core/enumerator`.
+3. **Switch `generate_lambda` and `generate_binding`**. Test with
+   `core/proc` / `core/method` / the existing Binding tests.
+4. **Hook the error unwind path and fiber**. Test with
+   `core/exception` / `core/fiber`.
+5. **Remove the eager recursive move** inside `Lfp::move_frame_to_heap`.
+   At this point all promotion is driven by return hooks.
+6. **Full ruby/spec core regression**.
+
+Between each step, `core/numeric`, `core/array`, `core/proc`,
+`core/enumerator`, the minimal repro, and the specific partial
+permutation check must remain green / improve.
+
+## Risks & mitigations
+
+- **Assembly epilogue invasiveness**. Five sites, but each addition
+  is a few instructions gated by a flag test. Measured cost on the
+  no-escape path: one `test reg, imm` + one `jz`. Acceptable.
+- **GC double-mark**. Existing marking is idempotent — GC uses a
+  mark-bit / generation counter, so visiting the same RValue twice
+  is a no-op. We will still verify.
+- **Dangling escapee entries on panic / non-local exit**. If a
+  frame is popped in a path that doesn't reach our hook, escapee
+  entries stay in the HashMap keyed to freed cfp addresses. Next
+  allocation at the same address would misfire. Mitigate by
+  hooking every pop site (epilogue, error return, fiber
+  terminate); add a debug assertion that `escapees` is empty at VM
+  top-level exit.
+- **Stack address reuse**. Within a single deep recursion, the same
+  stack address can be reused across frames. But because we drain
+  the entry on pop (before the address is reused), the next
+  installation at that address has a fresh entry. ✓.
+- **Nested fibers**. Current monoruby is single-threaded with
+  cooperative fibers. A Proc from fiber A invoked while fiber B is
+  running accesses fiber A's stack; we need a way to detect "my
+  frame is currently on a *different* fiber's stack, which is
+  suspended". The existing `Executor::parent_fiber` chain handles
+  this for `caller()` traversal already; extend the promote path
+  similarly if needed.
+
+## What we are *not* fixing in this pass
+
+- The 2 `core/integer` `lazy-validation` errors (`1.upto("A").size`
+  raising at `.size` rather than at `upto` call time). They reappear
+  if the Ruby wrapper for `Integer#upto`/`#downto` is restored, and
+  the wrapper becomes safe to restore only *after* this plan lands.
+  Restoring the wrapper is a follow-up PR.
+- `Array#permutation`'s `permutation(n == size)` ↔ `permutation(n)`
+  Ruby-level algorithm refinements — orthogonal.
+- JIT-side cached frames (Side exits, etc.). The `r14` register is
+  loaded from `cfp.lfp()` when entering a frame and maintained in
+  register for the duration; no mid-method reload, which is what we
+  rely on. Verify no JIT op re-reads `lfp` expecting consistency
+  after an `&block` capture.

--- a/doc/permutation_break_bug.md
+++ b/doc/permutation_break_bug.md
@@ -1,0 +1,218 @@
+# `Array#permutation(n)` partial-case regression — root-cause report
+
+Branch for investigation: `claude/permutation-debug` (no code
+changes retained; this report lives on `claude/enumerator-size-master`
+as documentation only).
+
+## Symptom
+
+With a Ruby-level `Integer#downto` / `#upto` wrapper installed, i.e.:
+
+```ruby
+class Integer
+  def downto(limit, &block)
+    if block
+      __downto(limit, &block)       # Rust kernel
+    else
+      to_enum(:__downto, limit)
+    end
+  end
+end
+```
+
+partial permutations regress:
+
+```
+[1,2,3,4,5].permutation(3).to_a.size   # expected 60, got 21 (non-det)
+```
+
+Full permutations (`n == size`) are unaffected.
+
+## Minimal reproducer (no permutation involved)
+
+The bug is in the interaction between `&block` forwarding and `break`
+inside an enclosing loop block. Reducing it:
+
+```ruby
+outer_iter = 0
+loop do                          # BlockA — outer = /main
+  outer_iter += 1
+  break if outer_iter > 3        # <-- raises LocalJumpError on iter 4
+  2.downto(0) do |i|             # BlockB — outer = BlockA
+    break
+  end
+end
+```
+
+Expected: `outer_iter == 4`. Observed: `LocalJumpError: illegal break
+from block`. The error does **not** come from `break` inside BlockB
+(that one works correctly for iterations 1-3). It comes from the
+ordinary loop-exit `break` in BlockA on the fourth iteration.
+
+## Mechanism
+
+`break` inside a block is compiled to `BlockBreak`. At runtime it
+calls `err_block_break`
+(`monoruby/src/codegen/runtime.rs:1005`), which computes the break
+target by walking the caller chain:
+
+```rust
+let target_lfp = self.lfp().outer()?;         // lexical outer
+let mut cfp = *self;
+loop {
+    let cfp_prev = cfp.prev()?;               // walk prev-cfp
+    if cfp_prev.lfp() == target_lfp { … }     // match by lfp *pointer*
+    cfp = cfp_prev;
+}
+```
+
+It looks up a cfp on the stack whose *pointer* matches the block's
+outer lfp. If no cfp matches, `caller()` returns `None`, and
+`err_block_break` raises `LocalJumpError: illegal break from block`.
+
+## The actual bug: `Lfp::move_frame_to_heap` redirects the live cfp
+
+`monoruby/src/executor/frame.rs:330`:
+
+```rust
+pub fn move_frame_to_heap(self) -> Self {
+    if self.on_stack() {
+        unsafe {
+            let mut cfp = self.cfp();
+            …
+            let mut heap_lfp = Lfp::new(…);
+            heap_lfp.meta_mut().set_on_heap();
+            cfp.set_lfp(heap_lfp);                // <-- (A)
+            if let Some(outer_lfp) = heap_lfp.outer() {
+                let outer = outer_lfp.move_frame_to_heap();  // <-- (B)
+                heap_lfp.set_outer(Some(outer));
+            }
+            …
+            heap_lfp
+        }
+    } else { self }
+}
+```
+
+Two points:
+
+* (A) the move is **destructive**: the live cfp's lfp pointer is
+  mutated to point at the *heap* copy. The original stack frame
+  becomes orphaned but the cfp still sits on the call stack.
+* (B) the move is **recursive** up the outer chain. Moving BlockA's
+  frame also moves `/main`.
+
+`generate_proc_inner`
+(`monoruby/src/executor.rs`) calls this in the proxy arm via
+`outer.move_frame_to_heap()` — exactly what the `&block` forwarding
+path triggers, because `def downto(limit, &block)` captures the block
+as a Proc, and Procs must outlive their method, so their outer lfp has
+to live on the heap.
+
+So the sequence inside the reproducer is, per outer-loop iteration:
+
+1. Enter BlockA (new stack frame). BlockA.outer = /main (stack lfp).
+2. Evaluate `2.downto(0) { … }`. The block arg to `#downto` is
+   captured into a Proc via `&block`.
+3. `generate_proc_inner` calls
+   `cfp.lfp().move_frame_to_heap()` to make the Proc's outer safe.
+   That move:
+   * copies BlockA to heap, mutates `BlockA.cfp.lfp = heap_A`;
+   * recursively copies /main to heap, mutates
+     `main.cfp.lfp = heap_main_i` (a **fresh** heap allocation this
+     iteration).
+4. The Proc (wrapping BlockB) is passed into `__downto`; break inside
+   BlockB resolves against `my_downto`, fine.
+5. Next iteration: `loop` re-invokes BlockA with a fresh stack frame.
+   The invoker sets the new `BlockA.outer` from
+   `main.cfp.lfp`, which is `heap_main_i` from step 3.
+6. Go back to 2, and BlockA's outer is re-assigned to a **new**
+   `heap_main_{i+1}` after the next `move_frame_to_heap` call.
+
+The problem surfaces when BlockA runs `break` (step: `break if
+outer_iter > 3`):
+
+* BlockA.lfp.outer() = `heap_main_N` (whichever heap copy was active
+  when BlockA was last set up)
+* `main.cfp.lfp` currently = `heap_main_M`, where `M >= N`, but the
+  two can differ because the recursive move on every iteration
+  allocates a **fresh** heap copy and `cfp.set_lfp` overwrites the
+  pointer.
+
+`caller()` walks the prev-cfp chain looking for a cfp whose `lfp ==
+heap_main_N`, but the live `/main` cfp now stores `heap_main_M`. No
+match → `None` → `LocalJumpError`.
+
+The instrumented trace confirms this:
+
+```
+iter 1  self_lfp=…b678  outer=0x5569…e850   (moved)
+iter 2  self_lfp=…b678  outer=0x5569…e8d0   (different heap)
+iter 3  self_lfp=…b678  outer=0x5569…bdd0   (different heap, again)
+iter 4  self_lfp=…bc18  outer=0x7edf…c0a8   caller()=None → illegal
+```
+
+Each iteration produces a **different** outer lfp for BlockA. No
+stack cfp ever holds the exact pointer BlockA.outer points to at
+iteration 4's break.
+
+The same reproducer with a pure-Ruby downto that uses `yield`
+(no `&block`, no Proc creation, no `move_frame_to_heap`) keeps BlockA's
+outer stable across iterations and `break` works correctly.
+
+## Why full `permutation(n == size)` works
+
+The full-permutation branch in `builtins/array.rb` doesn't hit the
+same cfp-churn: its nested `(n - 1).downto(0) { … break … }` runs
+inside an `each`/method frame whose cfp prev chain gets lucky and
+finds a matching lfp before hitting the corrupted `/main`. The
+partial branch has an extra layer (the outer `loop { … }` wrapping
+the inner `downto` across many iterations), and it eventually loses
+the match.
+
+## Fix directions (ranked by risk)
+
+1. **Non-destructive heap promotion**. Keep the stack frame live and
+   back the Proc with a heap-allocated *snapshot* that is separate
+   from `cfp.lfp`. Stop mutating the live cfp's lfp pointer in
+   `move_frame_to_heap` while the frame is still executing. Promote
+   to heap only at frame exit (or copy once, and lock further moves
+   to be no-ops while the stack copy is still live). Low-risk once
+   we add an "on heap snapshot" bit so `cfp.lfp` can stay on stack
+   and `Proc.outer` points to the snapshot.
+2. **Stable lfp identity token**. Decouple `cfp.caller()`'s matching
+   from raw lfp pointers. Store a stable id (e.g. frame-creation
+   counter) in the frame header; use it for identity checks while
+   leaving the lfp pointer free to move. Higher-risk: many sites
+   compare lfp pointers directly.
+3. **Don't triple-move on repeat invocations**. `move_frame_to_heap`
+   already has an on-stack / on-heap fast path. But the *recursive*
+   move in step (B) re-allocates the outer heap copy every time
+   because the outer's `on_stack()` flips to `on_stack` again each
+   new frame invocation even if the outer's *identity* (via prev
+   chain) is unchanged. A narrower fix: don't recursively move the
+   outer if the prev-cfp chain already points to a valid heap frame
+   for that lfp.
+
+Any of the three unblocks the Ruby `Integer#upto` / `#downto`
+wrapper pattern — and, by extension, lets `Range#step`,
+`Enumerator::ArithmeticSequence` and other Ruby wrappers thread a
+size proc through `to_enum` without risking `LocalJumpError` in
+unrelated enclosing loops.
+
+## What was temporarily needed to reproduce
+
+* Rename Rust `upto` / `downto` registrations to `__upto` /
+  `__downto`.
+* Define Ruby wrappers in `builtins/integer.rb`:
+  ```ruby
+  def upto(limit, &block)
+    block ? __upto(limit, &block) : to_enum(:__upto, limit)
+  end
+  def downto(limit, &block)
+    block ? __downto(limit, &block) : to_enum(:__downto, limit)
+  end
+  ```
+
+All three changes are **not** in the tree after this investigation —
+the report is the deliverable.

--- a/doc/permutation_break_bug.md
+++ b/doc/permutation_break_bug.md
@@ -200,6 +200,75 @@ wrapper pattern — and, by extension, lets `Range#step`,
 size proc through `to_enum` without risking `LocalJumpError` in
 unrelated enclosing loops.
 
+## Why a "check-before-copy" patch is not enough (experiment log)
+
+An obvious-looking tweak: **"before copying the frame, see if it's
+already on the heap and skip the copy if so."** The existing code
+already does this at the first level (`if self.on_stack()`), and we
+tried extending it to detect a stale stack `Lfp` pointer whose cfp
+had been previously redirected, plus a matching extension in
+`Cfp::caller()` so that the pointer comparison succeeded when the
+block's `outer_lfp` still named the original stack slot:
+
+```rust
+// move_frame_to_heap entry:
+let cfp = self.cfp();
+if cfp.lfp().as_ptr() != self.as_ptr() {
+    return cfp.lfp();         // stack slot was already redirected
+}
+```
+
+```rust
+// Cfp::caller(): normalise the target through its owning cfp
+if target_lfp.on_stack() {
+    let owner_cfp = unsafe { Cfp::new(target_lfp.as_ptr().add(16) as _) };
+    let live = owner_cfp.lfp();
+    if live.as_ptr() != target_lfp.as_ptr() {
+        target_lfp = live;
+    }
+}
+```
+
+With both patches applied, the reproducer *no longer* raised
+`LocalJumpError`:
+
+* `[1,2,3,4,5].permutation(3).to_a.size` returned **60** (correct),
+* the minimal-repro loop actually ran 4 iterations.
+
+**But the loop counter came out wrong** (`1` instead of `4`). Reason:
+`BlockA` writes `outer_iter` through `outer_lfp` -> heap `/main`
+copy, while `/main` itself continues executing with `r14` pointing
+at the *stack* `/main`. The frame's locals exist in two places that
+diverge.
+
+So the patch turns the `LocalJumpError` into a silent correctness
+bug. The architectural invariant that `move_frame_to_heap` was
+written against is "once we have promoted the frame to heap, nobody
+still reads through the stack copy" — and that's violated as soon as
+you recursively promote an outer frame that is still actively
+executing (a `/main` that is still waiting for `Kernel#loop` to
+return). A fix localised to `move_frame_to_heap` / `caller()` can
+only paper over one symptom at a time.
+
+The real fix has to address the invariant:
+
+1. **Don't promote an outer that is still live.** Defer the heap
+   promotion until the outer actually returns (or the Proc is
+   first invoked past the outer's return). Until then, hold the
+   Proc's `outer_lfp` as a "tag" that resolves to the current stack
+   slot on demand. This is the YARV approach.
+2. **Alias the stack and heap copies.** Either treat the stack slot
+   as a cache of the heap (write-through) or vice versa. Expensive
+   in the register-based VM but avoids the active-frame issue.
+3. **Avoid the round-trip in user code.** Keep `Integer#upto` /
+   `#downto` in Rust, accept the lazy-validation spec regression,
+   and document the pattern "Ruby wrapper -> `&block` -> Rust
+   builtin" as unsafe until (1) or (2) lands.
+
+The check-before-copy idea was a good question to validate — it
+falsifies itself in ~20 minutes because the counter test is a
+single-line change and catches the write/read split immediately.
+
 ## What was temporarily needed to reproduce
 
 * Rename Rust `upto` / `downto` registrations to `__upto` /

--- a/monoruby/builtins/integer.rb
+++ b/monoruby/builtins/integer.rb
@@ -28,6 +28,25 @@ class Integer
     self
   end
 
+  alias __upto upto
+  alias __downto downto
+
+  def upto(limit, &block)
+    if block
+      __upto(limit, &block)
+    else
+      to_enum(:__upto, limit) { self <= limit ? limit - self + 1 : 0 }
+    end
+  end
+
+  def downto(limit, &block)
+    if block
+      __downto(limit, &block)
+    else
+      to_enum(:__downto, limit) { self >= limit ? self - limit + 1 : 0 }
+    end
+  end
+
   def negative?
     self < 0
   end

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -332,13 +332,18 @@ impl JitModule {
     }
 
     ///
-    /// Test whether the current local frame is on the heap ("captured").
+    /// Test whether the current local frame is "captured" — either
+    /// already promoted to heap (bit 7) or still on the stack with
+    /// pending escapees from lazy heap promotion (bit 3). In either
+    /// case the frame should opt out of loop-JIT compilation, since
+    /// captured frames violate the JIT's stack-layout assumptions for
+    /// register-cached locals.
     ///
-    /// if the frame is on the heap, jump to *label*.
+    /// if the frame is captured, jump to *label*.
     ///
     fn branch_if_captured(&mut self, label: &DestLabel) {
         monoasm! { &mut self.jit,
-            testb [r14 - (LFP_META - META_KIND)], (0b1000_0000_u8 as i8);
+            testb [r14 - (LFP_META - META_KIND)], (0b1000_1000_u8 as i8);
             jnz label;
         }
     }
@@ -1016,7 +1021,22 @@ impl Codegen {
     }
 
     fn epilogue(&mut self) {
+        // Lazy heap promotion hook: if the current frame's `has_escapee`
+        // bit is set, promote it to heap and rewrite registered escapee
+        // slots before the stack frame is released. The fast path (no
+        // escapee) is gated by the inline flag check so the cost on
+        // ordinary returns is one byte test + one branch.
+        let no_escapee = self.jit.label();
         monoasm!( &mut self.jit,
+            // Meta is at [r14 - LFP_META]; kind byte is at offset
+            // META_KIND inside Meta. LFP_META(8) - META_KIND(7) = 1.
+            testb [r14 - 1], (0b0000_1000_u8 as i8);
+            jz   no_escapee;
+            movq rdi, rbx;
+            movq rsi, rax;
+            movq rax, (runtime::lazy_promote_check);
+            call rax;
+        no_escapee:
             leave;
             ret;
         );

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -112,6 +112,17 @@ pub(super) extern "C" fn get_yield_data(vm: &mut Executor, globals: &mut Globals
     }
 }
 
+/// Lazy heap promotion: called from the JIT/VM epilogue when the
+/// `has_escapee` bit is set on the current frame's Meta. Copies the
+/// frame to heap and rewrites every registered escapee `outer_lfp`
+/// slot. The return value (`retval` in `rsi`) is passed through in rax
+/// so the caller can keep its return value across the call.
+pub(super) extern "C" fn lazy_promote_check(vm: &mut Executor, retval: u64) -> u64 {
+    let cfp = vm.cfp();
+    vm.promote_frame_on_return(cfp);
+    retval
+}
+
 pub(super) extern "C" fn block_arg(
     vm: &mut Executor,
     globals: &mut Globals,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -112,6 +112,11 @@ pub struct Executor {
     require_level: usize,
     /// error information.
     exception: Option<MonorubyErr>,
+    /// Lazy heap promotion: per-still-live-cfp list of raw pointers into
+    /// captured Procs/Bindings' `outer_lfp` field (and into heap-promoted
+    /// frames' own outer slot). Drained by `promote_frame_on_return` when
+    /// the matching cfp pops; entries get rewritten with the heap pointer.
+    escapees: std::collections::HashMap<usize, Vec<*mut Lfp>>,
 }
 
 impl std::default::Default for Executor {
@@ -131,6 +136,7 @@ impl std::default::Default for Executor {
             temp_stack: vec![],
             require_level: 0,
             exception: None,
+            escapees: std::collections::HashMap::new(),
         }
     }
 }
@@ -1662,19 +1668,75 @@ impl Executor {
 
 impl Executor {
     pub(crate) fn generate_proc(
-        &self,
+        &mut self,
         globals: &Globals,
         bh: BlockHandler,
         pc: BytecodePtr,
     ) -> Result<Proc> {
-        self.generate_proc_inner(globals, self.cfp(), bh, pc)
+        let cfp = self.cfp();
+        self.generate_proc_inner(globals, cfp, bh, pc)
     }
 
-    /// Build a long-lived `Proc` from a BlockHandler. The resulting
-    /// Proc may outlive the current frame, so any on-stack outer lfp
-    /// is moved to the heap here.
+    /// Lazy heap promotion plumbing.
+    ///
+    /// Register an escapee: a raw pointer to the `outer_lfp` slot of a
+    /// captured Proc/Binding (or to the `outer` slot of an
+    /// already-promoted heap frame).  The slot currently holds a stack
+    /// `Lfp` belonging to *cfp*'s frame.  When that cfp returns,
+    /// `promote_frame_on_return` will copy the frame to the heap and
+    /// rewrite *slot_ptr* with the heap pointer.
+    pub(crate) fn register_escapee(&mut self, cfp: Cfp, slot_ptr: *mut Lfp) {
+        debug_assert!(cfp.lfp().on_stack());
+        let key = cfp.as_ptr() as usize;
+        self.escapees.entry(key).or_default().push(slot_ptr);
+        let mut lfp = cfp.lfp();
+        unsafe { lfp.meta_mut_for_escapee().set_has_escapee() };
+    }
+
+    /// Called at every site that pops a still-live stack frame
+    /// (epilogue, method_return, block_break, error unwind, fiber
+    /// terminate). If the frame had any registered escapees, copy it to
+    /// heap and overwrite each escapee slot with the heap pointer.
+    pub(crate) fn promote_frame_on_return(&mut self, cfp: Cfp) {
+        if !cfp.lfp().meta().has_escapee() {
+            return;
+        }
+        let key = cfp.as_ptr() as usize;
+        let entries = match self.escapees.remove(&key) {
+            Some(v) => v,
+            None => return,
+        };
+        if entries.is_empty() {
+            return;
+        }
+        let stack_lfp = cfp.lfp();
+        // Detached snapshot: copies the frame to heap without mutating
+        // cfp.lfp and without recursively promoting outers. Outers stay
+        // on stack until they hit their own return hook.
+        let heap_lfp = stack_lfp.detached_heap_copy();
+        for slot in entries {
+            unsafe { *slot = heap_lfp };
+        }
+        // If the heap frame's outer is still on stack, register the
+        // heap frame's own `outer` slot as an escapee of that ancestor
+        // cfp so the chain gets rewritten transitively when the
+        // ancestor returns.
+        if let Some(outer) = heap_lfp.outer()
+            && outer.on_stack()
+        {
+            let outer_cfp = unsafe { outer.cfp_unchecked() };
+            let outer_slot = heap_lfp.outer_slot_ptr();
+            self.register_escapee(outer_cfp, outer_slot);
+        }
+    }
+
+    /// Build a long-lived `Proc` from a BlockHandler. With lazy heap
+    /// promotion, the captured outer frame is left on the stack while
+    /// it is still live; the Proc's `outer_lfp` slot is registered as
+    /// an escapee of that frame's cfp so it gets rewritten with the
+    /// heap pointer at frame return.
     pub(crate) fn generate_proc_inner(
-        &self,
+        &mut self,
         globals: &Globals,
         cfp: Cfp,
         bh: BlockHandler,
@@ -1686,12 +1748,13 @@ impl Executor {
             return Ok(proc);
         }
         if let Some((outer, fid)) = self.resolve_block_target(globals, cfp, bh) {
-            // move_frame_to_heap is a no-op when `outer` is already on
-            // the heap (Symbol case). For the proxy case it promotes
-            // the stack frame so the Proc can be used past the current
-            // call.
-            let outer = outer.move_frame_to_heap();
-            return Ok(Proc::from_outer(outer, fid, pc));
+            let mut proc = Proc::from_outer(outer, fid, pc);
+            if outer.on_stack() {
+                let owner_cfp = unsafe { outer.cfp_unchecked() };
+                let slot = proc.outer_lfp_slot_ptr();
+                self.register_escapee(owner_cfp, slot);
+            }
+            return Ok(proc);
         }
         Err(MonorubyErr::runtimeerr(format!(
             "not yet implemented: block handler {bh:?}"
@@ -1699,13 +1762,25 @@ impl Executor {
     }
 
     pub(crate) fn generate_lambda(&mut self, func_id: FuncId, pc: BytecodePtr) -> Proc {
-        let outer_lfp = self.cfp().lfp().move_frame_to_heap();
-        Proc::from_outer(outer_lfp, func_id, pc)
+        let outer_lfp = self.cfp().lfp();
+        let mut proc = Proc::from_outer(outer_lfp, func_id, pc);
+        if outer_lfp.on_stack() {
+            let owner_cfp = unsafe { outer_lfp.cfp_unchecked() };
+            let slot = proc.outer_lfp_slot_ptr();
+            self.register_escapee(owner_cfp, slot);
+        }
+        proc
     }
 
     pub(crate) fn generate_binding(&mut self, pc: BytecodePtr) -> Binding {
         let lfp = self.cfp().prev().unwrap().lfp();
-        Binding::from_outer(lfp, pc)
+        let mut binding = Binding::from_outer(lfp, pc);
+        if lfp.on_stack() {
+            let owner_cfp = unsafe { lfp.cfp_unchecked() };
+            let slot = binding.outer_lfp_slot_ptr();
+            self.register_escapee(owner_cfp, slot);
+        }
+        binding
     }
 
     ///

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -21,10 +21,17 @@ impl Cfp {
         Cfp(std::ptr::NonNull::new(ptr as *mut Option<Cfp>).unwrap())
     }
 
+    /// Public alias of `new` for cross-module construction in
+    /// lazy-promotion helpers. SAFETY contract is identical: *ptr* must
+    /// point at a valid Cfp slot.
+    pub(crate) unsafe fn new_pub(ptr: *mut u8) -> Self {
+        unsafe { Self::new(ptr) }
+    }
+
     ///
     /// Get inner raw pointer.
     ///
-    fn as_ptr(&self) -> *const Option<Cfp> {
+    pub(crate) fn as_ptr(&self) -> *const Option<Cfp> {
         self.0.as_ptr()
     }
 
@@ -348,6 +355,35 @@ impl Lfp {
         }
     }
 
+    /// Lazy heap promotion: produce a heap snapshot of `self` (which
+    /// must be on the stack) **without** mutating `cfp.lfp` and
+    /// **without** recursively promoting the outer chain.
+    ///
+    /// The caller is responsible for:
+    ///  - rewriting registered escapee slots to point at the returned
+    ///    heap lfp;
+    ///  - if the returned heap lfp's outer is still on stack,
+    ///    registering the heap lfp's `outer` slot as an escapee of the
+    ///    appropriate ancestor cfp so it gets promoted transitively.
+    ///
+    /// The has_escapee flag bit is cleared on the (about-to-die) stack
+    /// frame's meta — a sanity hygiene step; the stack frame is being
+    /// released either way.
+    pub fn detached_heap_copy(self) -> Self {
+        debug_assert!(self.on_stack());
+        unsafe {
+            let len = self.frame_bytes();
+            let v = self.frame_ref().to_vec().into_boxed_slice();
+            let mut heap_lfp = Lfp::new((Box::into_raw(v) as *mut u64 as usize + len - 8) as _);
+            heap_lfp.meta_mut().set_on_heap();
+            // The stack copy's meta still has `has_escapee` set; the
+            // copy we made inherits it. Clear it on the heap copy so a
+            // future capture pointing here re-registers cleanly.
+            heap_lfp.meta_mut().clear_has_escapee();
+            heap_lfp
+        }
+    }
+
     pub fn heap_frame(self_val: Value, mut meta: Meta) -> Self {
         let local_len = meta.reg_num() as usize - 1;
         meta.set_on_heap();
@@ -390,6 +426,32 @@ impl Lfp {
 
     fn meta_mut(&mut self) -> &mut Meta {
         unsafe { &mut *(self.sub(LFP_META as _) as *mut Meta) }
+    }
+
+    /// Mutable reference to Meta from outside the frame module
+    /// (used by lazy heap promotion to set the has_escapee flag).
+    ///
+    /// ### safety
+    /// The Lfp must point at a valid live frame (stack or heap).
+    pub(crate) unsafe fn meta_mut_for_escapee(&mut self) -> &mut Meta {
+        self.meta_mut()
+    }
+
+    /// Get CFP without requiring the frame to be on stack.
+    /// Caller asserts the lfp is on stack — this avoids the panic in
+    /// `cfp()` so callers in lazy-promotion paths can use it.
+    ///
+    /// ### safety
+    /// `self` must point at a stack frame (Lfp+16 must be a valid Cfp slot).
+    pub(crate) unsafe fn cfp_unchecked(&self) -> Cfp {
+        unsafe { Cfp::new_pub(self.as_ptr().add(16) as _) }
+    }
+
+    /// Raw pointer to this Lfp's outer slot. Used by lazy promotion
+    /// to register a heap frame's outer field as an escapee of an
+    /// ancestor cfp so the chain promotes transitively.
+    pub(crate) fn outer_slot_ptr(self) -> *mut Lfp {
+        self.0.as_ptr() as *mut Lfp
     }
 
     ///

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -121,6 +121,8 @@ pub struct Meta {
     mode: u8,
     /// bit 7:  0:on_stack 1:on_heap
     /// bit 4:  1:simple (no optional, no rest, no keyword, no block)
+    /// bit 3:  1:has_escapee (lazy promotion: this frame has captured Procs/Bindings
+    ///         awaiting heap promotion at frame return)
     /// bit 2:  0:method_style arg 1:block_style arg
     /// bit 1:  0:Ruby 1:native
     kind: u8,
@@ -226,6 +228,20 @@ impl Meta {
 
     pub fn set_on_heap(&mut self) {
         self.kind |= 0b1000_0000;
+    }
+
+    /// True if this frame has at least one captured Proc/Binding/lambda
+    /// awaiting heap promotion at frame return (lazy promotion).
+    pub fn has_escapee(&self) -> bool {
+        (self.kind & 0b1000) != 0
+    }
+
+    pub fn set_has_escapee(&mut self) {
+        self.kind |= 0b1000;
+    }
+
+    pub fn clear_has_escapee(&mut self) {
+        self.kind &= !0b1000;
     }
 
     ///

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1477,8 +1477,10 @@ impl RValue {
     }
 
     pub(super) fn new_binding(outer_lfp: Lfp, call_site_pc: Option<BytecodePtr>) -> Self {
-        let outer_lfp = outer_lfp.move_frame_to_heap();
-        assert!(!outer_lfp.on_stack());
+        // Lazy heap promotion: store the outer lfp as-is. If it points
+        // at a still-live stack frame, the caller (Executor) must
+        // register this Binding's outer slot as an escapee so the
+        // pointer gets rewritten when that frame returns.
         RValue {
             header: Header::new(BINDING_CLASS, ObjTy::BINDING),
             kind: ObjKind::binding(outer_lfp, call_site_pc),

--- a/monoruby/src/value/rvalue/binding.rs
+++ b/monoruby/src/value/rvalue/binding.rs
@@ -24,6 +24,12 @@ impl Binding {
     pub(crate) fn from_outer(outer_lfp: Lfp, call_site_pc: BytecodePtr) -> Self {
         Binding(Value::new_binding(outer_lfp, Some(call_site_pc)))
     }
+
+    /// Raw pointer to this Binding's `outer_lfp` slot. Used by lazy
+    /// heap promotion to register the slot as an escapee.
+    pub(crate) fn outer_lfp_slot_ptr(&mut self) -> *mut Lfp {
+        &mut self.outer_lfp as *mut Lfp
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/monoruby/src/value/rvalue/proc.rs
+++ b/monoruby/src/value/rvalue/proc.rs
@@ -25,6 +25,18 @@ impl Proc {
             pc,
         )))
     }
+
+    /// Raw pointer to this Proc's `outer_lfp` slot inside the heap-allocated
+    /// RValue. Used by lazy heap promotion to register the slot as an
+    /// escapee so it gets rewritten when the captured stack frame is
+    /// promoted.
+    ///
+    /// Reads/writes 8 bytes — `Option<Lfp>` and `Lfp` share the same
+    /// representation (NonNull niche), so writing a non-null `Lfp`
+    /// through this pointer leaves the field as `Some(new)`.
+    pub(crate) fn outer_lfp_slot_ptr(&mut self) -> *mut Lfp {
+        &mut self.outer_lfp as *mut Option<Lfp> as *mut Lfp
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Fix the `Array#permutation(n)` partial-case regression and restore the
`Integer#upto` / `#downto` Ruby wrapper pattern by defer-promoting
captured stack frames until the owning cfp actually returns
(YARV-style), rather than copying to heap eagerly at capture time.

Stacks on top of #331.

## Root cause recap

`Lfp::move_frame_to_heap` was **destructive + recursive** at every
`&block` / `proc { }` / `lambda { }` / `binding` capture:

* mutated the live cfp's `lfp` slot to point at the heap copy;
* recursively promoted outer frames.

For a long-lived method (e.g. `/main`) that is captured once per
iteration of an enclosing loop, each iteration freshly allocated a
**new** heap copy for `/main`, and each `BlockA` captured a stale
pointer to the previous iteration's heap. `err_block_break` walks the
prev-cfp chain comparing lfp pointers by value — the mismatch turned
an ordinary `break` into `LocalJumpError: illegal break from block`.

See `doc/permutation_break_bug.md` and
`doc/lazy_heap_promotion_design.md` for the full analysis.

## Design

Per `doc/lazy_heap_promotion_design.md`:

1. **Capture stays on stack**. `generate_proc_inner` / `generate_lambda`
   / `new_binding` no longer call `move_frame_to_heap`. They store the
   stack lfp in the new `Proc.outer_lfp` / `Binding.outer_lfp` and
   *register* that slot as an **escapee** of the owning cfp.
2. **Flag bit**: `Meta.kind` bit 3 is `has_escapee` — set when a cfp
   accumulates any escapees.
3. **Promote on return**: every site that pops a still-live stack
   frame (JIT `epilogue`, which is shared with VM `Ret`, `MethodRet`,
   and `Break`) emits an inline fast-path check:
   ```
   testb [r14 - 1], 0b0000_1000
   jz   no_escapee
   ; slow path:
   movq rdi, rbx ; vm
   movq rsi, rax ; preserve return value
   call lazy_promote_check
   no_escapee:
   leave
   ret
   ```
   `lazy_promote_check` detaches a heap snapshot of the frame
   (non-recursive, doesn't mutate `cfp.lfp`), rewrites every registered
   escapee slot to the heap pointer, and transitively registers the
   heap copy's own outer slot with the ancestor cfp so outer chains
   promote only as each ancestor actually returns.

## JIT interaction

`branch_if_captured` — the existing JIT loop-compile opt-out —
previously only tested bit 7 (`on_heap`). Under eager-move that
implicitly kept long-lived + captured methods out of the loop JIT,
because they were always promoted to heap at capture. Lazy keeps them
on stack, so the gate is extended to also test bit 3 (`has_escapee`):

```
testb [r14 - 1], 0b1000_1000
jnz  skip_jit_compile
```

One extra instruction per loop-start; no behavioural change on the
no-capture path.

## Verification

* Minimal repro (`loop { 2.downto(0) { break } }`): no longer raises;
  `outer_iter == 4` as expected.
* `Array#permutation(n).to_a.size` for `[1,2,3,4,5]`: 20 / 60 / 120 for
  n = 2 / 3 / 5.
* `core/integer/upto_spec` + `core/integer/downto_spec`: **18 examples,
  34 expectations, 0 failures, 0 errors** (was 2 lazy-validation errors
  before; the Ruby wrapper is now safe to restore).
* `core/proc` and `core/array/permutation_spec` unchanged relative to
  baseline.
* `cargo test --lib`: 1154 pass / 21 fail — all 21 are pre-existing
  Ruby-4-format / stdlib differences from the base branch; no proc /
  closure / binding / fiber tests regressed.
* A targeted closure test (`proc { a = 1 }` capturing /main's local,
  invoked via `foo; a.inspect`, looped 200×) passes 200/200 through
  JIT warmup under both no-jit and JIT builds.

## Follow-ups (not in this PR)

* Clean up `move_frame_to_heap` (now only used by internal fallback) —
  can be deleted once all callers switch to `detached_heap_copy`.
* Error-unwind (`handle_error` / fiber terminate) paths — current
  implementation hits promotion via the shared `epilogue()`, but the
  error path has additional pops that don't route through epilogue in
  every case. The minimal repro and the regression tests exercise the
  happy path only; a more thorough audit can follow.
* `Array#permutation` spec: 5 unrelated failures remain (empty-array
  edge cases, not touched here).

## Test plan

- [x] `cargo build --release` (JIT) + `cargo build --release --features no-jit`
- [x] `cargo test --release --lib` — 21 failures, identical to baseline
- [x] Minimal break-through-loop repro: green
- [x] Array#permutation partial/full: green
- [x] Integer#upto + #downto specs: green (was 2 errors)
- [x] Long-lived `proc` capture smoke (200×): green through JIT warmup

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ