### PR TITLE
Fix define_method return semantics and Symbol#to_proc-as-method

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1995,6 +1995,33 @@ mod tests {
     }
 
     #[test]
+    fn define_method_return() {
+        // `return` inside a `define_method` block acts like a lambda-style
+        // method return: it exits the method created by `define_method`,
+        // not the block's lexical enclosing scope.
+        run_test(
+            r#"
+            k = Class.new { define_method(:m) { return 42 } }
+            k.new.m
+            "#,
+        );
+        // Multiple return values via `return a, b` — wraps as an Array.
+        run_test(
+            r#"
+            k = Class.new { define_method(:m) { |a, b| return a, b } }
+            k.new.m(10, 20)
+            "#,
+        );
+        // `return` from a nested block still targets the proc-method frame.
+        run_test(
+            r#"
+            k = Class.new { define_method(:m) { [1, 2, 3].each { |x| return x if x == 2 }; :no_return } }
+            k.new.m
+            "#,
+        );
+    }
+
+    #[test]
     fn define_method_in_eval() {
         // `def` inside string class_eval inherits the receiver's lexical
         // context so that constants defined in C are visible.

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -274,6 +274,20 @@ mod tests {
     }
 
     #[test]
+    fn symbol_to_proc_via_define_method() {
+        // Regression: `define_method` wrapping a Symbol#to_proc must
+        // resolve the symbol from the proc's outer_lfp, not from the
+        // method receiver which is not a Symbol.
+        run_test(
+            r#"
+            symbol_proc = :+.to_proc
+            klass = Class.new { define_method :foo, &symbol_proc }
+            klass.new.foo(1, 2)
+            "#,
+        );
+    }
+
+    #[test]
     fn symbol_to_proc_public_send() {
         // to_proc should use public_send and forward blocks
         run_tests(&[

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -352,7 +352,12 @@ pub(super) extern "C" fn handle_error(
             if let MonorubyErrKind::MethodReturn(val, target_lfp) = vm.exception().unwrap().kind() {
                 return if let Some((_, Some(ensure), _)) = info.get_exception_dest(pc) {
                     ErrorReturn::goto(bc_base + ensure)
-                } else if lfp == *target_lfp {
+                } else if lfp == *target_lfp || meta.is_proc_method() {
+                    // Stop unwinding either at the matching target LFP
+                    // or at a `define_method` proc-method boundary, so
+                    // that `return` inside a wrapped block exits the
+                    // method rather than escaping to the block's
+                    // lexical enclosing scope.
                     let val = *val;
                     vm.take_error();
                     ErrorReturn::return_normal(val)

--- a/monoruby/src/codegen/wrapper.rs
+++ b/monoruby/src/codegen/wrapper.rs
@@ -49,8 +49,13 @@ impl Codegen {
                     // set outer
                     movq [r14 - (LFP_OUTER)], rax;
                     // use given self
-                    // set meta
+                    // set meta; tag with the proc-method bit so that
+                    // `handle_error` absorbs `MethodReturn` at this
+                    // frame (define_method's `return` acts like a
+                    // lambda-style method return).
                     movq rax, [r15 + (FUNCDATA_META)];
+                    movq rdi, (Meta::PROC_METHOD_MASK);
+                    orq  rax, rdi;
                     movq [r14 - (LFP_META)], rax;
                     // set pc
                     movq r13, [r15 + (FUNCDATA_PC)];

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -120,6 +120,10 @@ pub struct Meta {
     reg_num: u16,
     mode: u8,
     /// bit 7:  0:on_stack 1:on_heap
+    /// bit 5:  1:proc-method frame (ISeq body wrapped as a method via
+    ///         `Module#define_method`; a set `MethodReturn` must be
+    ///         absorbed at this frame so `return` has lambda-like
+    ///         method-return semantics)
     /// bit 4:  1:simple (no optional, no rest, no keyword, no block)
     /// bit 3:  1:invalidated (stack LFP whose content has been copied
     ///         to heap via `move_frame_to_heap`; subsequent readers
@@ -174,6 +178,11 @@ impl Meta {
         unsafe { std::mem::transmute(*self) }
     }
 
+    /// u64 bit mask for the `is_proc_method` flag (bit 5 of the `kind`
+    /// byte). Used by the `define_method` wrapper to tag the proc body's
+    /// `LFP_META` so that `handle_error` can recognize the frame.
+    pub(crate) const PROC_METHOD_MASK: u64 = 1 << 61;
+
     fn vm_method(func_id: FuncId, reg_num: u16, is_block_style: bool, is_simple: bool) -> Self {
         Self::new(func_id, reg_num, is_simple, false, is_block_style)
     }
@@ -217,6 +226,12 @@ impl Meta {
 
     fn set_method_style(&mut self) {
         self.kind &= !0b100
+    }
+
+    /// True when this frame is a define_method proc-method entry;
+    /// `handle_error` treats it as the target for `MethodReturn`.
+    pub(crate) fn is_proc_method(&self) -> bool {
+        (self.kind & 0b0010_0000) != 0
     }
 
     pub fn is_native(&self) -> bool {
@@ -368,9 +383,13 @@ pub(crate) fn yielder(
 /// Shared body for procs returned by `Symbol#to_proc`.
 ///
 /// Invoked via the block-invoker path (for `&:sym` usage in e.g.
-/// `map(&:to_s)`). `lfp.self_val()` carries the symbol (copied from the
-/// proc's outer_lfp), `arg(0)` is the receiver, and `arg(1)` is the rest
-/// array.
+/// `map(&:to_s)`) and via the proc-method wrapper path when the proc
+/// is installed with `define_method(:foo, &sym.to_proc)`. The symbol
+/// lives on the proc's `outer_lfp` (set up by `sym_to_proc`); reading
+/// it there rather than from `lfp.self_val()` works for both paths —
+/// the block invoker copies `outer_lfp.self` into the inner frame's
+/// self, but `define_method`'s wrapper keeps the receiver as self.
+/// `arg(0)` is the receiver, and `arg(1)` is the rest array.
 ///
 #[monoruby_builtin]
 pub(crate) fn symbol_to_proc_body(
@@ -379,10 +398,13 @@ pub(crate) fn symbol_to_proc_body(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let symbol_val = lfp.self_val();
+    let symbol_val = lfp
+        .outer()
+        .expect("symbol_to_proc_body called without outer_lfp")
+        .self_val();
     let symbol = symbol_val
         .try_symbol()
-        .expect("symbol_to_proc_body invoked with non-symbol self");
+        .expect("symbol_to_proc_body invoked with non-symbol outer self");
     let recv = lfp.arg(0);
     let rest_val = lfp.arg(1);
     let rest_array = rest_val.as_array();


### PR DESCRIPTION
## Summary

- `return` inside a block passed to `define_method` now exits the wrapped method (lambda-style) rather than silently terminating the whole process. Achieved by tagging proc-method frames with a new `Meta::kind` bit (bit 5); the `FuncKind::Proc` wrapper ORs the mask into `LFP_META` on entry, and `handle_error` absorbs `MethodReturn` at that boundary.
- `Symbol#to_proc` installed via `define_method` no longer panics with `symbol_to_proc_body invoked with non-symbol self`. `symbol_to_proc_body` now reads the symbol from `lfp.outer().self_val()` (the proc's outer_lfp always carries the symbol in every invocation path: `Proc#call` fast-path, block invoker, and the new proc-method wrapper), instead of `lfp.self_val()` which only held it when the block invoker copied outer.self into the inner frame.

## Spec impact (`mspec core/*`)

- `core/module/define_method_spec.rb` was previously crashing monoruby silently after the first example, killing the entire `module` batch (20 files / ~20 examples lost). It now runs to completion (88 examples, 33 failures, 12 errors — none crash).
- Across all core subcategories: overall pass rate 57.32% → 57.41%, total passes 12,627 → 12,808 (+181), perfect categories 9 → 10 (`numeric` newly 100%), crash/timeout batches 1 → **0**.

## Test plan

- [x] `cargo nextest run --lib --release` — 1177/1177 passed (includes two new regression tests: `builtins::module::tests::define_method_return` and `builtins::symbol::tests::symbol_to_proc_via_define_method`)
- [x] `../mspec/bin/mspec core/module/define_method_spec.rb -t monoruby` runs to completion
- [x] Full `bin/spec`-equivalent batch run with no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)