### PR TITLE
Match CRuby for Range#to_s / Range#inspect (beginless/endless)

### DIFF
--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -1008,6 +1008,42 @@ mod tests {
     }
 
     #[test]
+    fn range_to_s_inspect() {
+        // `to_s` uses element `to_s` and elides nil endpoints.
+        run_tests(&[
+            "(1..5).to_s",
+            "(1...5).to_s",
+            "('a'..'z').to_s",
+            "(..5).to_s",
+            "(...5).to_s",
+            "(1..).to_s",
+            "(1...).to_s",
+            "(nil..nil).to_s",
+            "(nil...nil).to_s",
+        ]);
+        // `inspect` uses element `inspect`; nil endpoints elide one-sided
+        // but render as literal "nil" when both ends are nil.
+        run_tests(&[
+            "(1..5).inspect",
+            "(1...5).inspect",
+            "('a'..'z').inspect",
+            "(:a..:z).inspect",
+            "(..5).inspect",
+            "(1..).inspect",
+            "(nil..nil).inspect",
+            "(nil...nil).inspect",
+        ]);
+        // Ranges embedded in containers use `inspect` via the container.
+        run_tests(&[
+            "[1..5].inspect",
+            "[nil..5].inspect",
+            "[1..nil].inspect",
+            "[nil..nil].inspect",
+            r#"["a".."z"].inspect"#,
+        ]);
+    }
+
+    #[test]
     fn each() {
         run_test(
             r#"

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -521,6 +521,7 @@ impl RValue {
                 ObjTy::REGEXP => self.as_regex().inspect(),
                 ObjTy::MATCHDATA => self.as_match_data().inspect(),
                 ObjTy::HASH => self.hash_inspect(store, set),
+                ObjTy::RANGE => self.as_range().inspect(store, set),
                 _ => self.to_s(store),
             }
         }

--- a/monoruby/src/value/rvalue/range.rs
+++ b/monoruby/src/value/rvalue/range.rs
@@ -82,11 +82,37 @@ impl RangeInner {
     }
 
     pub(super) fn to_s(&self, store: &Store) -> String {
+        // Matches CRuby: renders each endpoint with `to_s`, so a nil
+        // endpoint (beginless/endless range) renders as an empty
+        // string. `(nil..5).to_s == "..5"`, `(nil..nil).to_s == ".."`.
         format!(
             "{}{}{}",
-            self.start.inspect(store),
+            self.start.to_s(store),
             if self.exclude_end() { "..." } else { ".." },
-            self.end.inspect(store),
+            self.end.to_s(store),
         )
+    }
+
+    pub(super) fn inspect(&self, store: &Store, set: &mut HashSet<u64>) -> String {
+        // Matches CRuby: renders each endpoint with `inspect`, but a
+        // single nil endpoint is elided (one-sided range). Only when
+        // BOTH endpoints are nil does the output keep the literal
+        // "nil..nil" so `(nil..nil).inspect` is distinguishable from
+        // `(..).to_s`.
+        let sep = if self.exclude_end() { "..." } else { ".." };
+        if self.start.is_nil() && self.end.is_nil() {
+            return format!("nil{sep}nil");
+        }
+        let start = if self.start.is_nil() {
+            String::new()
+        } else {
+            self.start.inspect_inner(store, set)
+        };
+        let end = if self.end.is_nil() {
+            String::new()
+        } else {
+            self.end.inspect_inner(store, set)
+        };
+        format!("{start}{sep}{end}")
     }
 }


### PR DESCRIPTION
## Summary

- `Range#to_s` called `inspect` on its endpoints, so `('a'..'z').to_s` produced `"\"a\"..\"z\""` and nil endpoints printed literally as `"nil"` — all wrong vs CRuby. Now uses element `to_s`, which elides nil endpoints naturally: `(nil..5).to_s == "..5"`, `(1..nil).to_s == "1.."`, `(nil..nil).to_s == ".."`, `('a'..'z').to_s == "a..z"`.
- `Range#inspect` fell through to `to_s`, so it wasn't using `inspect` on endpoints and didn't apply CRuby's quirk for both-nil. Now uses element `inspect`, elides a single nil endpoint, and keeps the literal `"nil..nil"` / `"nil...nil"` when both endpoints are nil. Wired an explicit `ObjTy::RANGE` arm into `Value::inspect_inner` so containers (`[1..5].inspect`, `p 1..5`) dispatch through the new method.

## Spec impact (`mspec core/range`)

- `core/range/to_s_spec.rb` + `core/range/inspect_spec.rb`: **7 examples, 0 failures, 0 errors** (previously failing).
- `core/range` overall: 202/467 → **206/469** passing.

## Test plan

- [x] `cargo nextest run --lib --release` — 1178/1178 passed (new `builtins::range::tests::range_to_s_inspect` covers `to_s`, `inspect`, and container embedding).
- [x] Byte-for-byte diff of CRuby vs monoruby over 40+ edge cases (endless, beginless, both-nil, Integer / String / Symbol endpoints, embedded in Array, `p`-style inspect) — identical.
- [x] `../mspec/bin/mspec core/range/{to_s,inspect}_spec.rb -t monoruby` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)