### PR TITLE
Null-terminate strings passed to FFI as char*

### DIFF
--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -47,9 +47,23 @@ enum CArg {
     U64(u64),
     F32(f32),
     F64(f64),
+    /// Ruby String passed as a C `char*`. Owns a heap buffer with an
+    /// appended NUL terminator (Ruby strings are not NUL-terminated) and
+    /// caches its pointer as a u64 so `as_libffi_arg` can reference a
+    /// stable location. Moving the `CArg` is safe because the `Vec<u8>`
+    /// move leaves the heap allocation in place.
+    CStr { _buf: Vec<u8>, ptr: u64 },
 }
 
 impl CArg {
+    fn from_bytes_nul_terminated(bytes: &[u8]) -> Self {
+        let mut buf = Vec::with_capacity(bytes.len() + 1);
+        buf.extend_from_slice(bytes);
+        buf.push(0);
+        let ptr = buf.as_ptr() as u64;
+        CArg::CStr { _buf: buf, ptr }
+    }
+
     /// Return a libffi Arg pointing into this CArg.
     /// SAFETY: `self` must not be moved or dropped while the Arg is in use.
     fn as_libffi_arg(&'_ self) -> Arg<'_> {
@@ -64,6 +78,7 @@ impl CArg {
             CArg::U64(v) => Arg::new(v),
             CArg::F32(v) => Arg::new(v),
             CArg::F64(v) => Arg::new(v),
+            CArg::CStr { ptr, .. } => Arg::new(ptr),
         }
     }
 
@@ -79,6 +94,7 @@ impl CArg {
             CArg::U64(_) => Type::u64(),
             CArg::F32(_) => Type::f32(),
             CArg::F64(_) => Type::f64(),
+            CArg::CStr { .. } => Type::pointer(),
         }
     }
 }
@@ -136,9 +152,14 @@ fn value_to_carg(globals: &mut Globals, val: Value, ty: i64) -> Result<CArg> {
                 RV::BigInt(b) => Ok(CArg::U64(num::ToPrimitive::to_u64(b).unwrap_or(0))),
                 RV::Nil => Ok(CArg::U64(0)),
                 RV::String(_) => {
-                    // String: pass raw content pointer (GC cannot run here)
-                    let ptr = val.as_rstring_inner().as_ptr() as u64;
-                    Ok(CArg::U64(ptr))
+                    // Ruby strings are not NUL-terminated, so passing
+                    // `as_ptr()` directly to a C function expecting a
+                    // `char*` (e.g. `SDL_SetWindowTitle`, `strlen`)
+                    // causes a read past the end of the string buffer.
+                    // Copy into a NUL-terminated buffer owned by the
+                    // CArg for the duration of the libffi call.
+                    let inner = val.as_rstring_inner();
+                    Ok(CArg::from_bytes_nul_terminated(inner.as_bytes()))
                 }
                 _ => {
                     // Other objects (e.g. FFI::Pointer): coerce via to_i

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -480,3 +480,167 @@ pub(super) fn init(globals: &mut Globals) {
         globals.set_constant_by_str(fiddle, name, Value::integer(size));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    // The harness's reference Ruby runs with `--disable-gem`, so the
+    // ffi gem is unavailable to compare against. These tests instead
+    // drive the low-level builtins registered in `ffi.rs`
+    // (`FFI.___dlopen`/`___dlsym`/`___call`/`___read`/`___write`/…) and
+    // embed their own `raise` assertions — a misbehaving primitive
+    // surfaces as a monoruby-side exception and fails the test.
+    //
+    // Type codes match the constants defined at the top of this file
+    // (kept in sync with `startup/ffi_c.rb`).
+    const TYPE_PRELUDE: &str = r#"
+        TY_VOIDP = -1
+        TY_INT   = -6
+        TY_LLONG = -10
+        TY_DOUBLE = -13
+        TY_SIZE_T = -18
+        LIBC = FFI.___dlopen("libc.so.6")
+        LIBM = FFI.___dlopen("libm.so.6") || FFI.___dlopen("libc.so.6")
+    "#;
+
+    // Regression for https://github.com/sisshiki1969/monoruby/pull/337:
+    // Ruby strings must be NUL-terminated before being handed to C via
+    // a `TYPE_VOIDP` argument. Without the fix, `strlen` read past the
+    // end of the string buffer and returned a length that depended on
+    // whatever garbage followed in memory — the cause of the garbled
+    // optcarrot window title.
+    #[test]
+    fn fiddle_string_is_nul_terminated() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            strlen = FFI.___dlsym(LIBC, "strlen")
+            call = ->(s) {{ FFI.___call(strlen, [s], [TY_VOIDP], TY_SIZE_T) }}
+            raise unless call.call("")               == 0
+            raise unless call.call("hello")          == 5
+            raise unless call.call("hello_optcarrot") == 15
+            # Short strings placed back-to-back used to leak neighbouring
+            # bytes through strlen before the fix; loop many times so at
+            # least one iteration trips any non-zero byte left over in
+            # the small-string inline buffer.
+            50.times do |i|
+              s = "t_#{{i}}"
+              actual = call.call(s)
+              raise "strlen=#{{actual}} bytesize=#{{s.bytesize}}" unless actual == s.bytesize
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // Two `:string` arguments forwarded in one call — exercises the
+    // CArg storage path that keeps multiple NUL-terminated buffers
+    // alive at once.
+    #[test]
+    fn fiddle_two_string_args() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            strcmp = FFI.___dlsym(LIBC, "strcmp")
+            call = ->(a, b) {{ FFI.___call(strcmp, [a, b], [TY_VOIDP, TY_VOIDP], TY_INT) }}
+            raise unless call.call("abc", "abc") == 0
+            raise unless call.call("abc", "abd")  < 0
+            raise unless call.call("abd", "abc")  > 0
+            20.times do |i|
+              raise unless call.call("k_#{{i}}", "k_#{{i}}") == 0
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // Integer args/returns of varying widths.
+    #[test]
+    fn fiddle_integer_roundtrip() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            abs   = FFI.___dlsym(LIBC, "abs")
+            llabs = FFI.___dlsym(LIBC, "llabs")
+            raise unless FFI.___call(abs,   [-42], [TY_INT],   TY_INT)   == 42
+            raise unless FFI.___call(abs,   [ 42], [TY_INT],   TY_INT)   == 42
+            raise unless FFI.___call(llabs, [-1_000_000_000_000], [TY_LLONG], TY_LLONG) == 1_000_000_000_000
+            raise unless FFI.___call(llabs, [ 1_000_000_000_000], [TY_LLONG], TY_LLONG) == 1_000_000_000_000
+            :ok
+            "#
+        ));
+    }
+
+    // Double args/returns via libm's `sqrt` and `floor`.
+    #[test]
+    fn fiddle_double_args() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            sqrt  = FFI.___dlsym(LIBM, "sqrt")
+            floor = FFI.___dlsym(LIBM, "floor")
+            raise unless FFI.___call(sqrt,  [0.0], [TY_DOUBLE], TY_DOUBLE) == 0.0
+            raise unless (FFI.___call(sqrt, [2.0], [TY_DOUBLE], TY_DOUBLE) - Math.sqrt(2.0)).abs < 1e-12
+            raise unless FFI.___call(floor, [3.7],  [TY_DOUBLE], TY_DOUBLE) == 3.0
+            raise unless FFI.___call(floor, [-0.5], [TY_DOUBLE], TY_DOUBLE) == -1.0
+            :ok
+            "#
+        ));
+    }
+
+    // Typed memory read/write at a heap address via ___malloc / ___write
+    // / ___read / ___free — exercises the numeric argument path for
+    // int and double without involving the ffi gem.
+    #[test]
+    fn fiddle_read_write_roundtrip() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            ptr = FFI.___malloc(16)
+            raise "malloc returned NULL" if ptr == 0
+            begin
+              FFI.___write(ptr, TY_INT, 0x41424344)
+              raise unless FFI.___read(ptr, TY_INT) == 0x41424344
+              FFI.___write(ptr, TY_DOUBLE, 3.14)
+              raise unless FFI.___read(ptr, TY_DOUBLE) == 3.14
+            ensure
+              FFI.___free(ptr)
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // `___read_string` stops at the first NUL byte; `___read_bytes`
+    // takes an explicit length. Verifying both on the same buffer keeps
+    // the string-read path in sync with the NUL-termination behaviour
+    // of the write path.
+    #[test]
+    fn fiddle_read_string_and_bytes() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            ptr = FFI.___malloc(32)
+            raise if ptr == 0
+            begin
+              FFI.___write_bytes(ptr, "hello\0world\0junk")
+              raise unless FFI.___read_string(ptr)    == "hello"
+              raise unless FFI.___read_bytes(ptr, 11) == "hello\0world"
+            ensure
+              FFI.___free(ptr)
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // Passing `nil` as `TYPE_VOIDP` resolves to a NULL pointer.
+    // `memcpy(NULL, NULL, 0)` is well-defined on glibc — the zero
+    // length short-circuits before any dereference.
+    #[test]
+    fn fiddle_null_pointer_arg() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            memcpy = FFI.___dlsym(LIBC, "memcpy")
+            res = FFI.___call(memcpy, [nil, nil, 0], [TY_VOIDP, TY_VOIDP, TY_SIZE_T], TY_VOIDP)
+            raise unless res == 0
+            :ok
+            "#
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Ruby strings in monoruby are not NUL-terminated (`RStringInner` is a `SmallVec<[u8; _]>`), but `Fiddle.___call` was forwarding the raw `as_ptr()` to C. Any C function expecting a `char*` (e.g. `SDL_SetWindowTitle`, `strlen`) would read past the end of the Ruby buffer until it happened to find a zero byte, producing garbage at the tail — the stray characters at the end of optcarrot's window title that the user reported.

- Add a `CArg::CStr` variant that owns a heap buffer with an appended NUL and caches its pointer as a u64. Moving the `CArg` into the argv `Vec` does not invalidate the pointer because `Vec<u8>`'s heap allocation stays in place.
- Route the `TYPE_VOIDP` / `RV::String` branch in `value_to_carg` through `CArg::from_bytes_nul_terminated`.

## Test plan

- [x] `cargo nextest run --lib --release` — 1178/1178 passed
- [x] Repro before the fix (strlen via FFI ≠ `String#bytesize`):
  ```ruby
  require 'ffi'
  module LC; extend FFI::Library; ffi_lib 'c'
    attach_function :strlen, [:string], :size_t
  end
  50.times { |i| s = "t_#{i}".dup; raise unless LC.strlen(s) == s.bytesize }
  ```
  Before: dozens of MISMATCH lines. After: all lengths match.
- [x] Affects any FFI gem user passing `:string` args — the direct cause of the optcarrot window-title trailing-garbage report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)