### PR TITLE
Track nested {} / <> balance in %r{} regex percent-literals

### DIFF
--- a/ruruby-parse/src/parser/lexer.rs
+++ b/ruruby-parse/src/parser/lexer.rs
@@ -1222,12 +1222,15 @@ impl<'a> Lexer<'a> {
                     outer_level += 1;
                     body.push(ch);
                 }
-                ch if ch == term && char_class.is_empty() => {
-                    if track_outer && outer_level > 0 {
-                        outer_level -= 1;
-                        body.push(ch);
-                        continue;
+                ch if track_outer && ch == term => {
+                    if outer_level == 0 {
+                        let postfix = self.check_postfix();
+                        return Ok(RegexInterpolateState::Finished { body, postfix });
                     }
+                    outer_level -= 1;
+                    body.push(ch);
+                }
+                ch if ch == term && char_class.is_empty() => {
                     let postfix = self.check_postfix();
                     return Ok(RegexInterpolateState::Finished { body, postfix });
                 }

--- a/ruruby-parse/src/parser/lexer.rs
+++ b/ruruby-parse/src/parser/lexer.rs
@@ -58,7 +58,7 @@ enum InterpolateState {
 #[derive(Debug, Clone, PartialEq)]
 enum RegexInterpolateState {
     Finished { body: String, postfix: String },
-    Interpolation(RubyString, Vec<ParenKind>), // (string, char_level)
+    Interpolation(RubyString, Vec<ParenKind>, usize), // (string, char_level, outer_delim_level)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1186,30 +1186,48 @@ impl<'a> Lexer<'a> {
     /// return TokenKind::Regex or TokenKind::OpenRegex.
     pub(crate) fn get_regexp(
         &mut self,
+        open: Option<char>,
         term: char,
         char_class: Vec<ParenKind>,
+        outer_level: usize,
     ) -> Result<Token, LexerErr> {
-        match self.read_regexp_sub(term, char_class)? {
+        match self.read_regexp_sub(open, term, char_class, outer_level)? {
             RegexInterpolateState::Finished { body, postfix } => {
                 Ok(self.new_regexlit(body, postfix))
             }
-            RegexInterpolateState::Interpolation(s, char_class) => {
-                Ok(self.new_open_reg(s.into_string()?, char_class))
+            RegexInterpolateState::Interpolation(s, char_class, outer_level) => {
+                Ok(self.new_open_reg(s.into_string()?, char_class, outer_level))
             }
         }
     }
 
     /// Scan as regular expression.
+    ///
+    /// `open` is the paired opening delimiter for percent-literals whose open/close
+    /// characters are not already meaningful in regex syntax (e.g. `{` for `%r{...}`,
+    /// `<` for `%r<...>`). It is ignored for delimiters handled by the existing
+    /// char_class tracking (`(`, `[`).
     fn read_regexp_sub(
         &mut self,
+        open: Option<char>,
         term: char,
         mut char_class: Vec<ParenKind>,
+        mut outer_level: usize,
     ) -> Result<RegexInterpolateState, LexerErr> {
         let mut body = "".to_string();
-        //let mut char_class = 0;
+        let track_outer = matches!(open, Some('{') | Some('<'));
         loop {
             match self.get()? {
+                ch if track_outer && Some(ch) == open => {
+                    outer_level += 1;
+                    body.push(ch);
+                }
                 ch if ch == term && char_class.is_empty() => {
+                    if track_outer && outer_level > 0 {
+                        outer_level -= 1;
+                        body.push(ch);
+                        continue;
+                    }
                     let postfix = self.check_postfix();
                     return Ok(RegexInterpolateState::Finished { body, postfix });
                 }
@@ -1288,6 +1306,7 @@ impl<'a> Lexer<'a> {
                         return Ok(RegexInterpolateState::Interpolation(
                             body.into(),
                             char_class,
+                            outer_level,
                         ));
                     }
                     _ => body.push('#'),
@@ -1768,8 +1787,8 @@ impl<'a> Lexer<'a> {
         Token::new_open_string(s, delimiter, level, self.cur_loc())
     }
 
-    fn new_open_reg(&self, s: String, char_class: Vec<ParenKind>) -> Token {
-        Token::new_open_reg(s, char_class, self.cur_loc())
+    fn new_open_reg(&self, s: String, char_class: Vec<ParenKind>, outer_level: usize) -> Token {
+        Token::new_open_reg(s, char_class, outer_level, self.cur_loc())
     }
 
     fn new_open_command(&self, s: String, delimiter: Option<char>, level: usize) -> Token {

--- a/ruruby-parse/src/parser/literals.rs
+++ b/ruruby-parse/src/parser/literals.rs
@@ -231,8 +231,9 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
             'r' => {
                 let mut nodes = vec![];
                 let mut char_class = vec![];
+                let mut outer_level = 0usize;
                 loop {
-                    let tok = self.lexer.get_regexp(term, char_class)?;
+                    let tok = self.lexer.get_regexp(open, term, char_class, outer_level)?;
                     let loc = tok.loc();
                     match tok.kind {
                         TokenKind::Regex { body, postfix } => {
@@ -242,11 +243,12 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                             let loc = Loc(start, self.lexer.current_pos());
                             return Ok(Node::new_regexp(nodes, postfix, loc));
                         }
-                        TokenKind::OpenRegex(s, char_class_new) => {
+                        TokenKind::OpenRegex(s, char_class_new, outer_level_new) => {
                             if !s.is_empty() {
                                 nodes.push(Node::new_string(s.into(), loc));
                             }
                             char_class = char_class_new;
+                            outer_level = outer_level_new;
                             self.parse_template(&mut nodes)?;
                         }
                         _ => unreachable!(),
@@ -496,22 +498,24 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
         let start_loc = self.prev_loc();
         let mut nodes = vec![];
         let mut char_class = vec![];
+        let mut outer_level = 0usize;
         loop {
-            let tok = self.lexer.get_regexp(term, char_class)?;
+            let tok = self.lexer.get_regexp(None, term, char_class, outer_level)?;
             let loc = tok.loc();
             match tok.kind {
                 TokenKind::Regex { body, postfix } => {
                     nodes.push(Node::new_string(body.into(), loc));
                     return Ok(Node::new_regexp(nodes, postfix, start_loc.merge(loc)));
                 }
-                TokenKind::OpenRegex(s, char_class_new) => {
+                TokenKind::OpenRegex(s, char_class_new, outer_level_new) => {
                     nodes.push(Node::new_string(s.into(), loc));
                     char_class = char_class_new;
+                    outer_level = outer_level_new;
                     self.parse_template(&mut nodes)?;
                 }
                 _ => unreachable!(),
             }
-        }
+}
     }
 
     pub(super) fn parse_lambda_literal(&mut self) -> Result<Node, LexerErr> {

--- a/ruruby-parse/src/token.rs
+++ b/ruruby-parse/src/token.rs
@@ -56,7 +56,7 @@ pub(crate) enum TokenKind {
     Reserved(Reserved),
     Punct(Punct),
     OpenString(String, Option<char>, usize), // (content, delimiter, paren_level)
-    OpenRegex(String, Vec<ParenKind>),
+    OpenRegex(String, Vec<ParenKind>, usize),
     OpenCommand(String, Option<char>, usize),
     LineTerm,
 }
@@ -273,8 +273,13 @@ impl Token {
         Annot::new(TokenKind::OpenCommand(s.into(), delimiter, level), loc)
     }
 
-    pub(crate) fn new_open_reg(s: impl Into<String>, char_class: Vec<ParenKind>, loc: Loc) -> Self {
-        Annot::new(TokenKind::OpenRegex(s.into(), char_class), loc)
+    pub(crate) fn new_open_reg(
+        s: impl Into<String>,
+        char_class: Vec<ParenKind>,
+        outer_level: usize,
+        loc: Loc,
+    ) -> Self {
+        Annot::new(TokenKind::OpenRegex(s.into(), char_class, outer_level), loc)
     }
 
     pub(crate) fn new_punct(punct: Punct, loc: Loc) -> Self {


### PR DESCRIPTION
## Summary

- The regex lexer terminated at the first closing delimiter even when it was nested inside a `{N,M}` quantifier, so `%r{\A[-0-9a-z_+/]{43}={0,2}\z}i` (seen in `bundler/checksum.rb`) failed to parse as `Expect FatArrow Got Punct(Comma)`.
- `(` and `[` delimiters were already balanced via the regex char-class tracking, but `{` and `<` had no nesting logic.
- Thread an optional `open` delimiter and an `outer_level` counter through `get_regexp` / `read_regexp_sub` / `TokenKind::OpenRegex`, preserving level across `#{}` interpolations.
- Decouple the outer-delimiter balance from regex char-class state — CRuby balances percent-literal delimiters purely at the lexer level — so `{N,M}` inside `(...)` / `[...]` (e.g. `%r{(?:[A-Fa-f\d]{4})}` in `json/ext/parser.rb`) also works.

## Test plan

- [x] `cargo test --release` — 2009 passed / 0 failed
- [x] Manual reproducers all parse correctly:
  - `%r{foo{0,2}bar}`, `%r{\A[-0-9a-z_+/]{43}={0,2}\z}i`, `%r{nest{a{b}c}d}`
  - `%r{(?:\\[\\bfnrt"/]|(?:\\u(?:[A-Fa-f\d]{4}))+|\\[\x20-\xff])}n`
  - `%r<…>i`, `%r(foo(bar)baz)`, `/foo{0,2}bar/` (existing cases still work)
  - `%r{pre{1,2}#{:x}post{3,}}` (interpolation across nested braces)
- [x] Unblocks `ruby-bench lee` (and any other benchmark requiring `Bundler.setup`) getting past `bundler/checksum.rb` / `json/ext/parser.rb` parse errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)