### PR TITLE
JIT: rebind F/F and Sf/F merge disagreements to a fresh xmm

### DIFF
--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -57,7 +57,19 @@ impl AbstractFrame {
                 (_, LinkMode::V) => {
                     self.discard(i);
                 }
-                (LinkMode::F(_), LinkMode::F(_)) => {}
+                (LinkMode::F(l), LinkMode::F(r)) => {
+                    if l != r {
+                        // Registers differ across branches. Keeping `F(l)`
+                        // here would force the `F(r)` side's bridge to swap
+                        // `l <-> r`, which displaces any other slot bound to
+                        // `l` in that source state (a common occurrence when
+                        // the `F(l)` side reached the merge via the zero-cost
+                        // alias created by `copy_slot`). Rebind to a fresh
+                        // xmm that no slot in the merge context uses, so
+                        // each bridge can emit a single `xmm_move` instead.
+                        self.set_new_F(i);
+                    }
+                }
                 (LinkMode::F(_), LinkMode::C(r)) if r.is_float() => {}
                 (LinkMode::F(x), LinkMode::Sf(_, _))
                 | (LinkMode::Sf(x, _), LinkMode::Sf(_, _) | LinkMode::F(_)) => {
@@ -66,13 +78,21 @@ impl AbstractFrame {
                         LinkMode::Sf(_, guarded) => guarded,
                         _ => unreachable!(),
                     };
-                    let other = match other.mode(i) {
-                        LinkMode::F(_) => SfGuarded::Float,
-                        LinkMode::Sf(_, guarded) => guarded,
+                    let (other_xmm, other_g) = match other.mode(i) {
+                        LinkMode::F(y) => (y, SfGuarded::Float),
+                        LinkMode::Sf(y, guarded) => (y, guarded),
                         _ => unreachable!(),
                     };
-                    guarded.join(other);
-                    self.set_Sf(i, x, guarded);
+                    guarded.join(other_g);
+                    if x == other_xmm {
+                        self.set_Sf(i, x, guarded);
+                    } else {
+                        // Same reasoning as the F/F arm: register disagreement
+                        // across branches would force bridge-time swaps that
+                        // trample partner slots created by `copy_slot`'s
+                        // zero-cost alias. Rebind to a fresh xmm.
+                        self.set_new_Sf(i, guarded);
+                    }
                 }
                 (LinkMode::Sf(x, mut guarded), LinkMode::C(r)) if r.is_float() || r.is_fixnum() => {
                     guarded.join(SfGuarded::from_concrete_value(r));

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1384,4 +1384,61 @@ mod tests {
         "###,
         );
     }
+
+    /// Merging `F(l)` and `F(r)` with `l != r` used to keep `self`'s
+    /// register even though the other entry's value lived elsewhere; the
+    /// subsequent per-slot swap then displaced a partner slot sharing the
+    /// register from a `copy_slot` alias. Regression test: before the fix
+    /// the loop returned `[-1.0, -1.0, -1.0, -1.0, -1.0]` after JIT warm-up.
+    #[test]
+    fn test_join_float_register_disagreement() {
+        run_test(
+            r###"
+        def test
+          res = []
+          i = 0
+          endv = 1.0
+          while i <= 4
+            a = -1.0 + i * 0.5
+            if a > endv
+              a = endv
+            end
+            res << a
+            i += 1
+          end
+          res
+        end
+        test
+        "###,
+        );
+    }
+
+    /// Same regression, but with the assigned-value differing from both the
+    /// `endv` register and the computed register -- exercises the fresh-xmm
+    /// rebind path when neither `l` nor `r` is safe to keep.
+    #[test]
+    fn test_join_float_register_three_way() {
+        run_test(
+            r###"
+        def test
+          res = []
+          i = 0
+          lo  = -2.0
+          hi  =  2.0
+          while i < 5
+            a = -1.0 + i * 0.5
+            if a > hi
+              a = hi
+            elsif a < lo
+              a = lo
+            end
+            res << a
+            i += 1
+          end
+          res
+        end
+        test
+        "###,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fix a JIT miscompile where Float-valued slots could end up holding a stale
value after a control-flow merge.

### Root cause

`copy_slot` implements Float slot rename as a zero-cost alias: the
destination slot inherits the source slot's xmm register, so two
distinct slots share one register. That is sound as long as every path
reaching a subsequent merge made the same rename.

At the merge point, `join` for two `F(l)` / `F(r)` entries (and the
related `F` / `Sf` combined arm) silently kept `self`'s register when
the two entries disagreed (`l != r`). The merge target therefore had
two different slots bound to the same xmm — one still aliased from the
rename path, one still in its own register on the other path. `bridge`
tried to reconcile the other branch with per-slot swaps, but the swap
for the aliased slot displaces its partner, and the next per-slot
bridge undoes it — the algorithm oscillates and the final register
assignment is wrong.

### Symptom

After JIT warm-up, a loop like

```ruby
d = beg + i * unit
if d > endv
  d = endv
end
```

kept `d` stuck at its initial value. Before this fix, `monoruby/builtins/range.rb`'s
`Range#step` Float path needed a source-level workaround (commit `a986be22`)
to avoid the pattern.

### Fix

When `join` sees register disagreement in either the `F/F` arm or the
combined `F/Sf | Sf/F | Sf/Sf` arm, rebind the slot to a **fresh xmm**
via `set_new_F` / `set_new_Sf`. Each source branch's bridge then emits
a single `xmm_move` into the fresh register — no swap, no stack round-
trip, and partner slots sharing either `l` or `r` are left untouched.

Cost: one extra `xmm_move` per merge point where register allocation
disagrees. The common `l == r` case stays a no-op.

### Tests

Two regression tests in `jitgen::state::slot::tests`:

- `test_join_float_register_disagreement` — F/F pattern.
- `test_join_float_register_three_way` — three-way pattern that also
  exercises the combined Sf/F arm.

### Verification

- `cargo test --release --lib`: clean apart from four pre-existing
  failures (`file::open`, `string::string_inspect`,
  `symbol::symbol_inspect_unquoted`, flaky `dir::glob` in parallel),
  none related.
- Emit-asm inspection on the reproducer shows BB3 now does `movq xmm5,
  xmm2` (fresh xmm) and BB4 consumes `xmm5` — the hot path stays in
  registers.
- `core/range/{step,bsearch,overlap,reverse_each}_spec` all unchanged
  (pre-existing Mock-protocol failures only).

## Test plan

- [x] `cargo test --release --lib`
- [x] `/tmp/jit_repro.rb` (minimal repro) passes under JIT and --no-jit
- [x] Inspect emit-asm to confirm register-only reconciliation
- [ ] CI

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_