### PR TITLE
Add gosu gem stub so `require \"gosu\"` loads on monoruby

### DIFF
--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -739,15 +739,15 @@ module Gosu
       @_texture = nil
       @_renderer = nil  # the renderer the texture was created against
       @_owns_texture = true
+      @_rgba_blob = nil
 
       if source.is_a?(String)
         _load_from_path(source)
-      elsif source.respond_to?(:columns) && source.respond_to?(:rows)
-        # `Image::BlobHelper`-shaped object from `Image.from_blob`.
-        # Texture creation is deferred until first `#draw`.
-        @width  = @columns = source.columns.to_i
-        @height = @rows    = source.rows.to_i
-        @_blob_rgba = source.to_blob if source.respond_to?(:to_blob)
+      elsif source.respond_to?(:columns) && source.respond_to?(:rows) &&
+            source.respond_to?(:to_blob)
+        # `Image::BlobHelper`-shaped object: build a surface from raw RGBA.
+        _init_from_blob(source.to_blob.to_s,
+                        source.columns.to_i, source.rows.to_i)
       elsif source.nil?
         @width = @columns = 0
         @height = @rows   = 0
@@ -755,6 +755,15 @@ module Gosu
         @width = @columns = 0
         @height = @rows   = 0
       end
+    end
+
+    # Gosu 1.x convenience: `Image.from_blob(width, height, rgba_bytes)`.
+    # Matches the real gem's signature (width/height then blob).
+    def self.from_blob(columns, rows, blob)
+      img = allocate
+      img.send(:_init_blob_state)
+      img.send(:_init_from_blob, blob.to_s, columns.to_i, rows.to_i)
+      img
     end
 
     def self.from_text(text, height, opts = {})
@@ -838,7 +847,12 @@ module Gosu
 
     def draw_as_quad(*); end
     def draw_mod(*); end
-    def to_blob; "\0\0\0\0" * (width * height); end
+    # Raw RGBA bytes (4 bytes per pixel, row-major, top-to-bottom).
+    # Captured once from the source surface; subsequent draws don't
+    # affect the returned string.
+    def to_blob
+      @_rgba_blob || ("\0".b * (@width.to_i * @height.to_i * 4))
+    end
     def save(_path); end
     def insert(_img, _x, _y); self; end
     def subimage(_x, _y, _w, _h); Image.new; end
@@ -859,14 +873,89 @@ module Gosu
     public
 
     # Adopt an already-loaded SDL surface. Used by `Image.from_text` to
-    # feed a TTF-rendered surface into a fresh Image instance.
+    # feed a TTF-rendered surface into a fresh Image instance. Also
+    # extracts an RGBA snapshot for `#to_blob` before the surface is
+    # eventually uploaded to a texture (and freed).
     def _init_from_surface(surface)
       @width  = @columns = surface.get_int32(SDL2::SURFACE_W_OFFSET)
       @height = @rows    = surface.get_int32(SDL2::SURFACE_H_OFFSET)
+      @_rgba_blob = _surface_to_rgba(surface, @width, @height)
       @_pending_surface  = surface  # converted to texture on first draw
       @_texture = nil
       @_renderer = nil
       @_owns_texture = true
+    end
+
+    # Build a surface from raw RGBA bytes (Gosu blob layout: 4 bytes
+    # per pixel in memory order R, G, B, A).
+    def _init_from_blob(blob, w, h)
+      needed = w * h * 4
+      if blob.bytesize < needed
+        raise ArgumentError,
+              "blob too small: got #{blob.bytesize} bytes, need #{needed}"
+      end
+      surface = SDL2.create_rgb_surface_with_format(
+        0, w, h, 32, SDL2::PIXELFORMAT_ABGR8888)
+      if surface.null?
+        raise RuntimeError,
+              "SDL_CreateRGBSurfaceWithFormat failed: #{SDL2.get_error}"
+      end
+      pitch      = surface.get_int32(SDL2::SURFACE_PITCH_OFFSET)
+      pixels_ptr = surface.get_pointer(SDL2::SURFACE_PIXELS_OFFSET)
+      row_bytes  = w * 4
+      SDL2.lock_surface(surface)
+      if pitch == row_bytes
+        pixels_ptr.put_bytes(0, blob, 0, needed)
+      else
+        h.times do |y|
+          pixels_ptr.put_bytes(y * pitch, blob, y * row_bytes, row_bytes)
+        end
+      end
+      SDL2.unlock_surface(surface)
+      @width  = @columns = w
+      @height = @rows    = h
+      # Blob is already in RGBA; reuse it directly for to_blob.
+      @_rgba_blob        = blob.byteslice(0, needed).dup
+      @_pending_surface  = surface
+      @_texture = nil
+      @_renderer = nil
+      @_owns_texture = true
+    end
+
+    # Reset instance state used by allocate + _init_from_blob (bypassing
+    # the normal initialize path).
+    def _init_blob_state
+      @_texture = nil
+      @_renderer = nil
+      @_owns_texture = true
+      @_rgba_blob = nil
+    end
+
+    # Read an SDL_Surface's pixels into an RGBA8888 Ruby String. The
+    # surface is converted to `PIXELFORMAT_ABGR8888` first so we always
+    # get 4 bytes per pixel in R, G, B, A order.
+    def _surface_to_rgba(surface, w, h)
+      return "".b if w <= 0 || h <= 0
+      converted = SDL2.convert_surface_format(surface,
+                                              SDL2::PIXELFORMAT_ABGR8888,
+                                              0)
+      return "\0".b * (w * h * 4) if converted.null?
+      begin
+        SDL2.lock_surface(converted)
+        pitch      = converted.get_int32(SDL2::SURFACE_PITCH_OFFSET)
+        pixels_ptr = converted.get_pointer(SDL2::SURFACE_PIXELS_OFFSET)
+        row_bytes  = w * 4
+        if pitch == row_bytes
+          buf = pixels_ptr.get_bytes(0, row_bytes * h)
+        else
+          buf = "".b
+          h.times { |y| buf << pixels_ptr.get_bytes(y * pitch, row_bytes) }
+        end
+        SDL2.unlock_surface(converted)
+        buf
+      ensure
+        SDL2.free_surface(converted)
+      end
     end
 
     private

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -495,11 +495,14 @@ module Gosu
 
     def _lazy_sdl_init
       return if @@_sdl_inited
-      if SDL2.init(SDL2::INIT_VIDEO | SDL2::INIT_EVENTS) != 0
+      flags = SDL2::INIT_VIDEO | SDL2::INIT_EVENTS |
+              SDL2::INIT_JOYSTICK | SDL2::INIT_GAMECONTROLLER
+      if SDL2.init(flags) != 0
         raise RuntimeError, "SDL_Init failed: #{SDL2.get_error}"
       end
       @@_sdl_inited = true
       at_exit { SDL2.quit }
+      _enumerate_controllers
     end
 
     def _create_window
@@ -562,8 +565,93 @@ module Gosu
         when SDL2::EVENT_MOUSEBUTTONUP
           btn = @_event_buf.get_uint8(16)
           button_up(255 + btn)
+        when SDL2::EVENT_CONTROLLERDEVICEADDED
+          device_index = @_event_buf.get_int32(8)
+          _open_controller(device_index)
+        when SDL2::EVENT_CONTROLLERDEVICEREMOVED
+          instance_id = @_event_buf.get_int32(8)
+          _close_controller_by_instance(instance_id)
+        when SDL2::EVENT_CONTROLLERBUTTONDOWN
+          instance_id = @_event_buf.get_int32(8)
+          sdl_button  = @_event_buf.get_uint8(12)
+          gosu_id = _gosu_pad_button_id(instance_id, sdl_button)
+          button_down(gosu_id) if gosu_id
+        when SDL2::EVENT_CONTROLLERBUTTONUP
+          instance_id = @_event_buf.get_int32(8)
+          sdl_button  = @_event_buf.get_uint8(12)
+          gosu_id = _gosu_pad_button_id(instance_id, sdl_button)
+          button_up(gosu_id) if gosu_id
+        when SDL2::EVENT_CONTROLLERAXISMOTION
+          instance_id = @_event_buf.get_int32(8)
+          axis_idx    = @_event_buf.get_uint8(12)
+          raw         = @_event_buf.get_int16(16)
+          _set_controller_axis(instance_id, axis_idx, raw)
         end
       end
+    end
+
+    # --- Controller bookkeeping ---------------------------------------
+    # @@_controllers is a shared-across-windows hash of
+    #   SDL joystick instance_id => { slot: 0..3, handle: SDL_GameController*,
+    #                                 axes: Hash{0..5 => Float -1.0..1.0} }
+    # Slot 0..3 maps to Gosu's GP_N_BUTTON_X / GP_N_DPAD_* constants.
+    @@_controllers = {}
+    def self._controllers; @@_controllers; end
+
+    SDL_GAMEPAD_BUTTON_DPAD_UP    = 11
+    SDL_GAMEPAD_BUTTON_DPAD_DOWN  = 12
+    SDL_GAMEPAD_BUTTON_DPAD_LEFT  = 13
+    SDL_GAMEPAD_BUTTON_DPAD_RIGHT = 14
+
+    def _open_controller(device_index)
+      return unless SDL2.is_game_controller(device_index) != 0
+      handle = SDL2.game_controller_open(device_index)
+      return if handle.null?
+      joystick = SDL2.game_controller_get_joystick(handle)
+      instance_id = SDL2.joystick_instance_id(joystick)
+      # Assign the lowest free slot (0..3).
+      used_slots = @@_controllers.values.map { |e| e[:slot] }
+      slot = (0..3).find { |s| !used_slots.include?(s) }
+      return unless slot
+      @@_controllers[instance_id] = { slot: slot, handle: handle, axes: {} }
+      gamepad_connected(slot)
+    end
+
+    def _close_controller_by_instance(instance_id)
+      entry = @@_controllers.delete(instance_id)
+      return unless entry
+      SDL2.game_controller_close(entry[:handle]) if entry[:handle] && !entry[:handle].null?
+      gamepad_disconnected(entry[:slot])
+    end
+
+    def _gosu_pad_button_id(instance_id, sdl_button)
+      entry = @@_controllers[instance_id]
+      return nil unless entry
+      slot = entry[:slot]
+      case sdl_button
+      when SDL_GAMEPAD_BUTTON_DPAD_UP
+        case slot; when 0 then 291; when 1 then 311; when 2 then 331; when 3 then 351; end
+      when SDL_GAMEPAD_BUTTON_DPAD_DOWN
+        case slot; when 0 then 292; when 1 then 312; when 2 then 332; when 3 then 352; end
+      when SDL_GAMEPAD_BUTTON_DPAD_LEFT
+        case slot; when 0 then 289; when 1 then 309; when 2 then 329; when 3 then 349; end
+      when SDL_GAMEPAD_BUTTON_DPAD_RIGHT
+        case slot; when 0 then 290; when 1 then 310; when 2 then 330; when 3 then 350; end
+      else
+        # GP_<slot>_BUTTON_<sdl_button>, starting at 293 for slot 0, step 20.
+        293 + slot * 20 + sdl_button
+      end
+    end
+
+    def _set_controller_axis(instance_id, axis_idx, raw)
+      entry = @@_controllers[instance_id]
+      return unless entry
+      entry[:axes][axis_idx] = raw / 32767.0
+    end
+
+    def _enumerate_controllers
+      count = SDL2.num_joysticks
+      count.times { |i| _open_controller(i) }
     end
 
     public
@@ -1344,11 +1432,79 @@ module Gosu
     def screen_width(_window = nil); 1920; end
     def screen_height(_window = nil); 1080; end
 
-    def button_down?(_id); false; end
+    def button_down?(id)
+      id = id.to_i
+      # Keyboard scancodes occupy 0..256.
+      if id >= 0 && id < 256
+        state_ptr = SDL2.get_keyboard_state(nil)
+        return false if state_ptr.nil? || state_ptr.null?
+        return state_ptr.get_uint8(id) != 0
+      end
+      # Mouse buttons are encoded as 255 + SDL_BUTTON_*.
+      if id >= 256 && id <= 263
+        mask = SDL2.get_mouse_state(nil, nil)
+        sdl_btn = id - 255   # SDL_BUTTON_LEFT == 1
+        return (mask & (1 << (sdl_btn - 1))) != 0
+      end
+      # Game controller DPad buttons (GP_N_DPAD_LEFT/UP/DOWN/RIGHT) and
+      # GP_N_BUTTON_X -- look up live state on the controller instance.
+      Window._controllers.each_value do |entry|
+        slot = entry[:slot]
+        handle = entry[:handle]
+        next unless handle && !handle.null?
+        mapping = [
+          [293 + slot * 20 + 0,  0], [293 + slot * 20 + 1,  1],
+          [293 + slot * 20 + 2,  2], [293 + slot * 20 + 3,  3],
+          [293 + slot * 20 + 4,  4], [293 + slot * 20 + 5,  5],
+          [293 + slot * 20 + 6,  6], [293 + slot * 20 + 7,  7],
+          [293 + slot * 20 + 8,  8], [293 + slot * 20 + 9,  9],
+          [293 + slot * 20 + 10, 10],
+        ].find { |gid, _| gid == id }
+        if mapping
+          return SDL2.game_controller_get_button(handle, mapping[1]) != 0
+        end
+        dpad_btn =
+          case id
+          when 291, 311, 331, 351 then 11  # DPAD_UP
+          when 292, 312, 332, 352 then 12  # DPAD_DOWN
+          when 289, 309, 329, 349 then 13  # DPAD_LEFT
+          when 290, 310, 330, 350 then 14  # DPAD_RIGHT
+          end
+        if dpad_btn && (id - 289) / 20 == slot
+          return SDL2.game_controller_get_button(handle, dpad_btn) != 0
+        end
+      end
+      false
+    end
+
     def button_name(_id); nil; end
     def button_id_to_char(_id); nil; end
     def char_to_button_id(_c); nil; end
-    def axis(_id); 0.0; end
+
+    # Gosu axis IDs:
+    #   0/1: GP_LEFT_STICK_X/Y (any controller — we report controller 0)
+    #   2/3: GP_RIGHT_STICK_X/Y
+    #   4:   GP_LEFT_TRIGGER
+    #   5:   GP_RIGHT_TRIGGER
+    #   6..29: per-controller axis: 6 + 6*slot + (0..5)
+    def axis(id)
+      id = id.to_i
+      slot, axis_idx =
+        case id
+        when 0..5       then [nil, id]        # any controller
+        when 6..29      then [(id - 6) / 6, (id - 6) % 6]
+        else return 0.0
+        end
+      if slot.nil?
+        Window._controllers.each_value do |entry|
+          v = entry[:axes][axis_idx]
+          return v if v && v.abs > 0.01
+        end
+        return 0.0
+      end
+      entry = Window._controllers.values.find { |e| e[:slot] == slot }
+      entry && entry[:axes][axis_idx] || 0.0
+    end
 
     def default_font_name; "DejaVu Sans"; end
     def user_languages; []; end

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -608,8 +608,30 @@ module Gosu
       end
     end
 
-    def self.from_text(_text, _height, *_opts); new; end
-    def self.from_text_without_window(_text, _height, *_opts); new; end
+    def self.from_text(text, height, opts = {})
+      Gosu._lazy_ttf_init
+      path = (opts.is_a?(Hash) && opts[:font_name].is_a?(String) &&
+              File.file?(opts[:font_name])) ? opts[:font_name] : DEFAULT_FONT_PATH
+      font = SDL2_ttf.ttf_open_font(path, height.to_i)
+      if font.null?
+        raise RuntimeError,
+              "TTF_OpenFont failed: #{SDL2_ttf.ttf_get_error}"
+      end
+      # Render white; tint via `#draw`'s colour argument.
+      surface = SDL2_ttf.ttf_render_utf8_blended(font, text.to_s,
+                                                  0xffffffff)
+      SDL2_ttf.ttf_close_font(font)
+      if surface.null?
+        raise RuntimeError,
+              "TTF_RenderUTF8_Blended failed: #{SDL2_ttf.ttf_get_error}"
+      end
+      img = allocate
+      img._init_from_surface(surface)
+      img
+    end
+    def self.from_text_without_window(text, height, opts = {})
+      from_text(text, height, opts)
+    end
     def self.from_markup(_text, _height, *_opts); new; end
     def self.load_tiles(_source, _tile_w, _tile_h, *_opts); []; end
 
@@ -668,13 +690,23 @@ module Gosu
         raise RuntimeError,
               "IMG_Load(#{path.inspect}) failed: #{SDL2_image.img_get_error}"
       end
-      begin
-        @width  = @columns = surface.get_int32(SDL2::SURFACE_W_OFFSET)
-        @height = @rows    = surface.get_int32(SDL2::SURFACE_H_OFFSET)
-      ensure
-        @_pending_surface = surface  # turned into a texture on first draw
-      end
+      _init_from_surface(surface)
     end
+
+    public
+
+    # Adopt an already-loaded SDL surface. Used by `Image.from_text` to
+    # feed a TTF-rendered surface into a fresh Image instance.
+    def _init_from_surface(surface)
+      @width  = @columns = surface.get_int32(SDL2::SURFACE_W_OFFSET)
+      @height = @rows    = surface.get_int32(SDL2::SURFACE_H_OFFSET)
+      @_pending_surface  = surface  # converted to texture on first draw
+      @_texture = nil
+      @_renderer = nil
+      @_owns_texture = true
+    end
+
+    private
 
     def _ensure_texture
       win = Gosu._current_window
@@ -730,22 +762,136 @@ module Gosu
     end
   end
 
+  # ---------------------------------------------------------------------
+  # Fonts: lazy SDL2_ttf init.
+  # ---------------------------------------------------------------------
+  @@_ttf_inited = false
+  def self._lazy_ttf_init
+    return if @@_ttf_inited
+    if SDL2_ttf.ttf_init != 0
+      raise RuntimeError, "TTF_Init failed: #{SDL2_ttf.ttf_get_error}"
+    end
+    @@_ttf_inited = true
+    at_exit { SDL2_ttf.ttf_quit }
+  end
+
+  # Default font path; falls back to a well-known DejaVu file present
+  # on most Linux distros. Can be overridden with `Gosu::DEFAULT_FONT_PATH`.
+  DEFAULT_FONT_PATH =
+    (ENV["GOSU_DEFAULT_FONT"].to_s.empty? ?
+       "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf" :
+       ENV["GOSU_DEFAULT_FONT"]).freeze
+
   class Font
     attr_accessor :name, :height
 
     def initialize(height, *opts)
+      Gosu._lazy_ttf_init
       @height = height.to_i
-      @name = opts.first.is_a?(Hash) ? (opts.first[:name] || "") : ""
+      @_options = opts.first.is_a?(Hash) ? opts.first : {}
+      @name = @_options[:name] || ""
+      path = _resolve_font_path(@name)
+      @_ttf_font = SDL2_ttf.ttf_open_font(path, @height)
+      if @_ttf_font.null?
+        raise RuntimeError,
+              "TTF_OpenFont(#{path.inspect}, #{@height}) failed: #{SDL2_ttf.ttf_get_error}"
+      end
+      # Cache textures per (text, color, renderer) so redraws are cheap.
+      @_cache = {}
     end
 
-    def draw_text(*); end
-    def draw_text_rel(*); end
-    def draw_markup(*); end
-    def draw_markup_rel(*); end
-    def text_width(text, *_opts); text.to_s.length * (@height / 2); end
-    def markup_width(text, *_opts); text_width(text); end
+    # draw_text(text, x, y, z = 0, scale_x = 1, scale_y = 1,
+    #           color = WHITE, mode = :default)
+    def draw_text(text, x, y, _z = 0, scale_x = 1.0, scale_y = 1.0,
+                  color = 0xffffffff, _mode = :default)
+      tex, w, h = _texture_for(text.to_s, color)
+      return unless tex
+      ren = Gosu._current_window&._sdl_renderer
+      return unless ren
+      dst = SDL2::Rect.new
+      dst[:x] = x.to_i
+      dst[:y] = y.to_i
+      dst[:w] = (w * scale_x).to_i
+      dst[:h] = (h * scale_y).to_i
+      SDL2.render_copy(ren, tex, nil, dst.pointer)
+    end
+
+    # draw_text_rel(text, x, y, z, rel_x, rel_y, scale_x, scale_y,
+    #               color, mode) -- relative anchor.
+    def draw_text_rel(text, x, y, z = 0, rel_x = 0.0, rel_y = 0.0,
+                      scale_x = 1.0, scale_y = 1.0,
+                      color = 0xffffffff, mode = :default)
+      w = text_width(text) * scale_x
+      h = @height * scale_y
+      draw_text(text, x - w * rel_x, y - h * rel_y, z,
+                scale_x, scale_y, color, mode)
+    end
+
+    def draw_markup(*args)
+      draw_text(*args)
+    end
+
+    def draw_markup_rel(*args)
+      draw_text_rel(*args)
+    end
+
+    def text_width(text, scale_x = 1.0)
+      return 0 if text.to_s.empty?
+      w_ptr = FFI::MemoryPointer.new(:int)
+      h_ptr = FFI::MemoryPointer.new(:int)
+      SDL2_ttf.ttf_size_utf8(@_ttf_font, text.to_s, w_ptr, h_ptr)
+      (w_ptr.get_int32(0) * scale_x).to_i
+    end
+
+    def markup_width(text, *opts); text_width(text, *opts); end
+
     def set_image(_codepoint, _image); end
     def []=(*); end
+
+    private
+
+    def _resolve_font_path(name)
+      return name if name.is_a?(String) && File.file?(name)
+      DEFAULT_FONT_PATH
+    end
+
+    # Returns [SDL_Texture*, width, height] or nil if the renderer is
+    # not yet available (e.g. Font.text_width before Window#show).
+    def _texture_for(text, color)
+      return [nil, 0, 0] if text.empty?
+      ren = Gosu._current_window&._sdl_renderer
+      return [nil, 0, 0] unless ren
+
+      argb = _color_to_argb(color)
+      key = [text, argb, ren.address]
+      if (entry = @_cache[key])
+        return entry
+      end
+
+      r = (argb >> 16) & 0xff
+      g = (argb >>  8) & 0xff
+      b =  argb        & 0xff
+      a = (argb >> 24) & 0xff
+      # SDL_Color packed little-endian: r | g<<8 | b<<16 | a<<24.
+      packed = r | (g << 8) | (b << 16) | (a << 24)
+      surface = SDL2_ttf.ttf_render_utf8_blended(@_ttf_font, text, packed)
+      return [nil, 0, 0] if surface.null?
+      w = surface.get_int32(SDL2::SURFACE_W_OFFSET)
+      h = surface.get_int32(SDL2::SURFACE_H_OFFSET)
+      tex = SDL2.create_texture_from_surface(ren, surface)
+      SDL2.free_surface(surface)
+      return [nil, 0, 0] if tex.null?
+      SDL2.set_texture_blend_mode(tex, 1)  # BLEND
+      @_cache[key] = [tex, w, h]
+    end
+
+    def _color_to_argb(color)
+      if color.is_a?(Color)
+        color.to_i
+      else
+        color.to_i & 0xffffffff
+      end
+    end
   end
 
   # ---------------------------------------------------------------------

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -641,12 +641,24 @@ module Gosu
              color = nil, _mode = :default)
       return unless _ensure_texture
       _apply_color_mod(color)
-      dst = SDL2::Rect.new
-      dst[:x] = x.to_i
-      dst[:y] = y.to_i
-      dst[:w] = (@width * scale_x).to_i
-      dst[:h] = (@height * scale_y).to_i
-      SDL2.render_copy(@_renderer, @_texture, nil, dst.pointer)
+      tx, ty, msx, msy, angle = Gosu._decompose
+      px, py = Gosu._apply_point(x, y)
+      w = (@width  * scale_x * msx).to_f
+      h = (@height * scale_y * msy).to_f
+      dst = SDL2::FRect.new
+      dst[:x] = px.to_f
+      dst[:y] = py.to_f
+      dst[:w] = w
+      dst[:h] = h
+      if angle == 0.0
+        SDL2.render_copy_f(@_renderer, @_texture, nil, dst.pointer)
+      else
+        center = SDL2::FPoint.new
+        center[:x] = 0.0
+        center[:y] = 0.0
+        SDL2.render_copy_ex_f(@_renderer, @_texture, nil, dst.pointer,
+                            angle, center.pointer, SDL2::SDL_FLIP_NONE)
+      end
     end
 
     # Image#draw_rot(x, y, z, angle, center_x = 0.5, center_y = 0.5,
@@ -658,18 +670,20 @@ module Gosu
                  color = nil, _mode = :default)
       return unless _ensure_texture
       _apply_color_mod(color)
-      w = (@width  * scale_x).to_i
-      h = (@height * scale_y).to_i
-      dst = SDL2::Rect.new
-      dst[:x] = (x - w * center_x).to_i
-      dst[:y] = (y - h * center_y).to_i
+      _, _, msx, msy, extra_angle = Gosu._decompose
+      px, py = Gosu._apply_point(x, y)
+      w = (@width  * scale_x * msx).to_f
+      h = (@height * scale_y * msy).to_f
+      dst = SDL2::FRect.new
+      dst[:x] = (px - w * center_x).to_f
+      dst[:y] = (py - h * center_y).to_f
       dst[:w] = w
       dst[:h] = h
-      center = SDL2::Point.new
-      center[:x] = (w * center_x).to_i
-      center[:y] = (h * center_y).to_i
-      SDL2.render_copy_ex(@_renderer, @_texture, nil, dst.pointer,
-                          angle.to_f, center.pointer,
+      center = SDL2::FPoint.new
+      center[:x] = (w * center_x).to_f
+      center[:y] = (h * center_y).to_f
+      SDL2.render_copy_ex_f(@_renderer, @_texture, nil, dst.pointer,
+                          angle.to_f + extra_angle, center.pointer,
                           SDL2::SDL_FLIP_NONE)
     end
 
@@ -1081,6 +1095,62 @@ module Gosu
   def self._current_window; @@_current_window; end
   def self._current_window=(w); @@_current_window = w; end
 
+  # ---------------------------------------------------------------------
+  # Transform stack
+  # ---------------------------------------------------------------------
+  # Each entry is a 6-element Array [a, b, c, d, tx, ty] representing
+  # the affine matrix
+  #     | a c tx |
+  #     | b d ty |
+  #     | 0 0  1 |
+  # so a world point (x, y) maps to (a*x + c*y + tx, b*x + d*y + ty).
+  IDENTITY_MATRIX = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0].freeze
+  @@_mat_stack = [IDENTITY_MATRIX]
+
+  def self._mat; @@_mat_stack.last; end
+  def self._mat_mul(m1, m2)
+    a1, b1, c1, d1, tx1, ty1 = m1
+    a2, b2, c2, d2, tx2, ty2 = m2
+    [a1 * a2 + c1 * b2,
+     b1 * a2 + d1 * b2,
+     a1 * c2 + c1 * d2,
+     b1 * c2 + d1 * d2,
+     a1 * tx2 + c1 * ty2 + tx1,
+     b1 * tx2 + d1 * ty2 + ty1]
+  end
+
+  def self._apply_point(x, y)
+    m = _mat
+    # Fast path for the (very common) identity case — the JIT's float
+    # register allocator thrashes hot inlining `a*x + c*y + tx` etc.
+    return [x.to_f, y.to_f] if m.equal?(IDENTITY_MATRIX)
+    a, b, c, d, tx, ty = m
+    [a * x + c * y + tx, b * x + d * y + ty]
+  end
+
+  # Decompose the current affine into (tx, ty, scale_x, scale_y,
+  # angle_in_degrees) suitable for SDL_RenderCopyEx. Assumes no shear.
+  def self._decompose
+    m = _mat
+    return [0.0, 0.0, 1.0, 1.0, 0.0] if m.equal?(IDENTITY_MATRIX)
+    a, b, c, d, tx, ty = m
+    sx = Math.sqrt(a * a + b * b)
+    sy = Math.sqrt(c * c + d * d)
+    # Fix sign of sy via the determinant, so a pure Y-flip stays a flip.
+    sy = -sy if (a * d - b * c) < 0
+    angle = Math.atan2(b, a) * 180.0 / Math::PI
+    [tx, ty, sx, sy, angle]
+  end
+
+  def self._push_matrix(m)
+    @@_mat_stack.push(_mat_mul(_mat, m))
+    begin
+      yield if block_given?
+    ensure
+      @@_mat_stack.pop
+    end
+  end
+
   class << self
     # Split an ARGB / Color into 4 bytes for SDL colour calls.
     def _split_color(color)
@@ -1093,40 +1163,163 @@ module Gosu
     end
     private :_split_color
 
+    # -------- Transform block helpers (Gosu.translate / rotate / scale /
+    # transform). Each yields under the resulting matrix then pops on
+    # exit. --------
+    def translate(dx, dy, &block)
+      _push_matrix([1.0, 0.0, 0.0, 1.0, dx.to_f, dy.to_f], &block)
+    end
+
+    def scale(sx, sy = nil, around_x = 0.0, around_y = 0.0, &block)
+      sy ||= sx
+      m = [sx.to_f, 0.0, 0.0, sy.to_f, 0.0, 0.0]
+      if around_x != 0 || around_y != 0
+        m = _mat_mul([1.0, 0.0, 0.0, 1.0, around_x.to_f, around_y.to_f], m)
+        m = _mat_mul(m, [1.0, 0.0, 0.0, 1.0, -around_x.to_f, -around_y.to_f])
+      end
+      _push_matrix(m, &block)
+    end
+
+    def rotate(degrees, around_x = 0.0, around_y = 0.0, &block)
+      rad = degrees.to_f * Math::PI / 180.0
+      cos_r = Math.cos(rad)
+      sin_r = Math.sin(rad)
+      m = [cos_r, sin_r, -sin_r, cos_r, 0.0, 0.0]
+      if around_x != 0 || around_y != 0
+        m = _mat_mul([1.0, 0.0, 0.0, 1.0, around_x.to_f, around_y.to_f], m)
+        m = _mat_mul(m, [1.0, 0.0, 0.0, 1.0, -around_x.to_f, -around_y.to_f])
+      end
+      _push_matrix(m, &block)
+    end
+
+    def transform(a, b, c, d, tx, ty, &block)
+      _push_matrix([a.to_f, b.to_f, c.to_f, d.to_f, tx.to_f, ty.to_f], &block)
+    end
+
+    # Build a 2-triangle (4-vertex) SDL_RenderGeometry draw from four
+    # transformed corner points of colour `rgba`.
+    def _render_quad(ren, corners, rgba)
+      r, g, b, a = rgba
+      verts = FFI::MemoryPointer.new(:uint8, 20 * 4)
+      corners.each_with_index do |(px, py), i|
+        off = i * 20
+        verts.put_float32(off, px)
+        verts.put_float32(off + 4, py)
+        verts.put_uint8(off + 8,  r)
+        verts.put_uint8(off + 9,  g)
+        verts.put_uint8(off + 10, b)
+        verts.put_uint8(off + 11, a)
+        verts.put_float32(off + 12, 0.0)
+        verts.put_float32(off + 16, 0.0)
+      end
+      idx = FFI::MemoryPointer.new(:int32, 6)
+      [0, 1, 2, 0, 2, 3].each_with_index { |v, i| idx.put_int32(i * 4, v) }
+      SDL2.render_geometry(ren, nil, verts, 4, idx, 6)
+    end
+    private :_render_quad
+
+    def _identity_transform?
+      _mat == [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+    end
+    private :_identity_transform?
+
     def draw_rect(x, y, w, h, color, _z = 0, _mode = :default)
       ren = (_current_window && _current_window._sdl_renderer)
       return unless ren
-      r, g, b, a = _split_color(color)
+      rgba = _split_color(color)
       SDL2.set_draw_blend_mode(ren, 1) # SDL_BLENDMODE_BLEND
-      SDL2.set_draw_color(ren, r, g, b, a)
-      rect = SDL2::Rect.new
-      rect[:x] = x.to_i
-      rect[:y] = y.to_i
-      rect[:w] = w.to_i
-      rect[:h] = h.to_i
-      SDL2.render_fill_rect(ren, rect.pointer)
+      SDL2.set_draw_color(ren, *rgba)
+
+      if _identity_transform?
+        frect = SDL2::FRect.new
+        frect[:x] = x.to_f
+        frect[:y] = y.to_f
+        frect[:w] = w.to_f
+        frect[:h] = h.to_f
+        SDL2.render_fill_rect_f(ren, frect.pointer)
+      else
+        corners = [
+          _apply_point(x,     y    ),
+          _apply_point(x + w, y    ),
+          _apply_point(x + w, y + h),
+          _apply_point(x,     y + h),
+        ]
+        _render_quad(ren, corners, rgba)
+      end
     end
 
     def draw_line(x1, y1, c1, x2, y2, _c2 = nil, _z = 0, _mode = :default)
       ren = (_current_window && _current_window._sdl_renderer)
       return unless ren
-      r, g, b, a = _split_color(c1)
+      rgba = _split_color(c1)
       SDL2.set_draw_blend_mode(ren, 1)
-      SDL2.set_draw_color(ren, r, g, b, a)
-      SDL2.render_draw_line(ren, x1.to_i, y1.to_i, x2.to_i, y2.to_i)
+      SDL2.set_draw_color(ren, *rgba)
+      px1, py1 = _apply_point(x1, y1)
+      px2, py2 = _apply_point(x2, y2)
+      SDL2.render_draw_line_f(ren, px1, py1, px2, py2)
     end
 
-    def draw_triangle(*); end
-    def draw_quad(*); end
+    # draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, z=0, mode=:default)
+    def draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, _z = 0, _mode = :default)
+      ren = (_current_window && _current_window._sdl_renderer)
+      return unless ren
+      verts = FFI::MemoryPointer.new(:uint8, 20 * 3)
+      [[x1, y1, c1], [x2, y2, c2], [x3, y3, c3]].each_with_index do |(px, py, col), i|
+        tx, ty = _apply_point(px, py)
+        r, g, b, a = _split_color(col)
+        off = i * 20
+        verts.put_float32(off,       tx)
+        verts.put_float32(off + 4,   ty)
+        verts.put_uint8(off + 8,   r)
+        verts.put_uint8(off + 9,   g)
+        verts.put_uint8(off + 10,  b)
+        verts.put_uint8(off + 11,  a)
+        verts.put_float32(off + 12,  0.0)
+        verts.put_float32(off + 16,  0.0)
+      end
+      SDL2.render_geometry(ren, nil, verts, 3, nil, 0)
+    end
+
+    # draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4,
+    #           z=0, mode=:default)  -- Gosu's vertex order is
+    # top-left, top-right, bottom-left, bottom-right. Render as two
+    # triangles (v0,v1,v2) and (v2,v1,v3).
+    def draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4,
+                  _z = 0, _mode = :default)
+      ren = (_current_window && _current_window._sdl_renderer)
+      return unless ren
+      verts = FFI::MemoryPointer.new(:uint8, 20 * 4)
+      [[x1, y1, c1], [x2, y2, c2], [x3, y3, c3], [x4, y4, c4]].each_with_index do |(px, py, col), i|
+        tx, ty = _apply_point(px, py)
+        r, g, b, a = _split_color(col)
+        off = i * 20
+        verts.put_float32(off,       tx)
+        verts.put_float32(off + 4,   ty)
+        verts.put_uint8(off + 8,   r)
+        verts.put_uint8(off + 9,   g)
+        verts.put_uint8(off + 10,  b)
+        verts.put_uint8(off + 11,  a)
+        verts.put_float32(off + 12,  0.0)
+        verts.put_float32(off + 16,  0.0)
+      end
+      idx = FFI::MemoryPointer.new(:int32, 6)
+      [0, 1, 2, 2, 1, 3].each_with_index { |v, i| idx.put_int32(i * 4, v) }
+      SDL2.render_geometry(ren, nil, verts, 4, idx, 6)
+    end
+
     def flush; end
     def record(_w, _h); yield if block_given?; nil; end
 
     def clip_to(x, y, w, h)
       ren = (_current_window && _current_window._sdl_renderer)
       if ren
+        tx, ty = _apply_point(x, y)
+        _, _, sx, sy, _ = _decompose
         rect = SDL2::Rect.new
-        rect[:x] = x.to_i; rect[:y] = y.to_i
-        rect[:w] = w.to_i; rect[:h] = h.to_i
+        rect[:x] = tx.to_i
+        rect[:y] = ty.to_i
+        rect[:w] = (w * sx).to_i
+        rect[:h] = (h * sy).to_i
         SDL2.render_set_clip_rect(ren, rect.pointer)
         begin
           yield if block_given?
@@ -1137,11 +1330,6 @@ module Gosu
         yield if block_given?
       end
     end
-
-    def translate(*); yield if block_given?; end
-    def rotate(*); yield if block_given?; end
-    def scale(*); yield if block_given?; end
-    def transform(*); yield if block_given?; end
 
     def fps; 60; end
     def milliseconds

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -587,12 +587,24 @@ module Gosu
     attr_reader :width, :height, :columns, :rows
 
     def initialize(source = nil, *_opts)
-      if source.respond_to?(:columns) && source.respond_to?(:rows)
+      @_texture = nil
+      @_renderer = nil  # the renderer the texture was created against
+      @_owns_texture = true
+
+      if source.is_a?(String)
+        _load_from_path(source)
+      elsif source.respond_to?(:columns) && source.respond_to?(:rows)
+        # `Image::BlobHelper`-shaped object from `Image.from_blob`.
+        # Texture creation is deferred until first `#draw`.
         @width  = @columns = source.columns.to_i
         @height = @rows    = source.rows.to_i
+        @_blob_rgba = source.to_blob if source.respond_to?(:to_blob)
+      elsif source.nil?
+        @width = @columns = 0
+        @height = @rows   = 0
       else
-        @width  = @columns = 0
-        @height = @rows    = 0
+        @width = @columns = 0
+        @height = @rows   = 0
       end
     end
 
@@ -601,8 +613,44 @@ module Gosu
     def self.from_markup(_text, _height, *_opts); new; end
     def self.load_tiles(_source, _tile_w, _tile_h, *_opts); []; end
 
-    def draw(*); end
-    def draw_rot(*); end
+    # Image#draw(x, y, z, scale_x = 1, scale_y = 1, color = WHITE,
+    #            mode = :default)
+    def draw(x, y, _z = 0, scale_x = 1.0, scale_y = 1.0,
+             color = nil, _mode = :default)
+      return unless _ensure_texture
+      _apply_color_mod(color)
+      dst = SDL2::Rect.new
+      dst[:x] = x.to_i
+      dst[:y] = y.to_i
+      dst[:w] = (@width * scale_x).to_i
+      dst[:h] = (@height * scale_y).to_i
+      SDL2.render_copy(@_renderer, @_texture, nil, dst.pointer)
+    end
+
+    # Image#draw_rot(x, y, z, angle, center_x = 0.5, center_y = 0.5,
+    #                scale_x = 1, scale_y = 1, color = WHITE,
+    #                mode = :default)
+    def draw_rot(x, y, _z = 0, angle = 0,
+                 center_x = 0.5, center_y = 0.5,
+                 scale_x = 1.0, scale_y = 1.0,
+                 color = nil, _mode = :default)
+      return unless _ensure_texture
+      _apply_color_mod(color)
+      w = (@width  * scale_x).to_i
+      h = (@height * scale_y).to_i
+      dst = SDL2::Rect.new
+      dst[:x] = (x - w * center_x).to_i
+      dst[:y] = (y - h * center_y).to_i
+      dst[:w] = w
+      dst[:h] = h
+      center = SDL2::Point.new
+      center[:x] = (w * center_x).to_i
+      center[:y] = (h * center_y).to_i
+      SDL2.render_copy_ex(@_renderer, @_texture, nil, dst.pointer,
+                          angle.to_f, center.pointer,
+                          SDL2::SDL_FLIP_NONE)
+    end
+
     def draw_as_quad(*); end
     def draw_mod(*); end
     def to_blob; "\0\0\0\0" * (width * height); end
@@ -610,6 +658,76 @@ module Gosu
     def insert(_img, _x, _y); self; end
     def subimage(_x, _y, _w, _h); Image.new; end
     def gl_tex_info; nil; end
+
+    private
+
+    def _load_from_path(path)
+      @_image_path = path
+      surface = SDL2_image.img_load(path)
+      if surface.null?
+        raise RuntimeError,
+              "IMG_Load(#{path.inspect}) failed: #{SDL2_image.img_get_error}"
+      end
+      begin
+        @width  = @columns = surface.get_int32(SDL2::SURFACE_W_OFFSET)
+        @height = @rows    = surface.get_int32(SDL2::SURFACE_H_OFFSET)
+      ensure
+        @_pending_surface = surface  # turned into a texture on first draw
+      end
+    end
+
+    def _ensure_texture
+      win = Gosu._current_window
+      ren = win && win._sdl_renderer
+      return false unless ren
+
+      # If we already have a texture for THIS renderer, reuse it.
+      return true if @_texture && @_renderer == ren
+
+      _destroy_texture
+      surface = @_pending_surface
+      surface = nil unless surface && !surface.null?
+
+      if surface
+        @_texture = SDL2.create_texture_from_surface(ren, surface)
+        SDL2.free_surface(surface)
+        @_pending_surface = nil
+      else
+        return false
+      end
+      if @_texture.null?
+        @_texture = nil
+        return false
+      end
+      SDL2.set_texture_blend_mode(@_texture, 1)  # SDL_BLENDMODE_BLEND
+      @_renderer = ren
+      true
+    end
+
+    def _apply_color_mod(color)
+      return unless @_texture
+      if color.is_a?(Color)
+        SDL2.set_texture_color_mod(@_texture, color.red, color.green, color.blue)
+        SDL2.set_texture_alpha_mod(@_texture, color.alpha)
+      elsif color.is_a?(Integer)
+        SDL2.set_texture_color_mod(@_texture,
+                                    (color >> 16) & 0xff,
+                                    (color >>  8) & 0xff,
+                                    color         & 0xff)
+        SDL2.set_texture_alpha_mod(@_texture, (color >> 24) & 0xff)
+      else
+        SDL2.set_texture_color_mod(@_texture, 255, 255, 255)
+        SDL2.set_texture_alpha_mod(@_texture, 255)
+      end
+    end
+
+    def _destroy_texture
+      if @_texture && !@_texture.null?
+        SDL2.destroy_texture(@_texture)
+      end
+      @_texture = nil
+      @_renderer = nil
+    end
   end
 
   class Font
@@ -630,38 +748,155 @@ module Gosu
     def []=(*); end
   end
 
+  # ---------------------------------------------------------------------
+  # Audio: lazy SDL2_mixer init shared by Sample / Song.
+  # ---------------------------------------------------------------------
+  @@_mixer_inited = false
+  def self._lazy_mixer_init
+    return if @@_mixer_inited
+    if SDL2.init_sub_system(SDL2::INIT_AUDIO) != 0
+      raise RuntimeError, "SDL_InitSubSystem(AUDIO) failed: #{SDL2.get_error}"
+    end
+    if SDL2_mixer.mix_open_audio(SDL2_mixer::DEFAULT_FREQUENCY,
+                                 SDL2_mixer::AUDIO_S16LSB,
+                                 SDL2_mixer::DEFAULT_CHANNELS,
+                                 SDL2_mixer::DEFAULT_CHUNKSIZE) != 0
+      raise RuntimeError,
+            "Mix_OpenAudio failed: #{SDL2_mixer.mix_get_error}"
+    end
+    SDL2_mixer.mix_allocate_channels(16)
+    @@_mixer_inited = true
+    at_exit do
+      SDL2_mixer.mix_close_audio
+    end
+  end
+
   class Sample
-    def initialize(_path); end
-    def play(_vol = 1.0, _speed = 1.0, _looping = false); Channel.new; end
-    def play_pan(_pan = 0.0, _vol = 1.0, _speed = 1.0, _looping = false)
-      Channel.new
+    def initialize(path)
+      Gosu._lazy_mixer_init
+      @_chunk = SDL2_mixer.mix_load_wav(path.to_s)
+      if @_chunk.null?
+        raise RuntimeError,
+              "Mix_LoadWAV(#{path.inspect}) failed: #{SDL2_mixer.mix_get_error}"
+      end
+    end
+
+    def play(volume = 1.0, _speed = 1.0, looping = false)
+      ch = SDL2_mixer.mix_play_channel(-1, @_chunk, looping ? -1 : 0)
+      if ch >= 0
+        SDL2_mixer.mix_volume(ch, (volume.to_f.clamp(0.0, 1.0) * 128).to_i)
+        Channel.new(ch)
+      else
+        Channel.new(-1)
+      end
+    end
+
+    def play_pan(pan = 0.0, volume = 1.0, speed = 1.0, looping = false)
+      ch = play(volume, speed, looping)
+      ch.pan = pan if ch && ch.respond_to?(:pan=)
+      ch
     end
   end
 
   class Song
-    def initialize(_path); end
-    def self.current_song; nil; end
+    @@_current = nil
+    def self.current_song; @@_current; end
     def self.update; end
-    def play(_looping = false); end
-    def pause; end
-    def paused?; false; end
-    def stop; end
-    def playing?; false; end
-    def volume; 1.0; end
-    def volume=(_); end
+
+    def initialize(path)
+      Gosu._lazy_mixer_init
+      @_music = SDL2_mixer.mix_load_mus(path.to_s)
+      if @_music.null?
+        raise RuntimeError,
+              "Mix_LoadMUS(#{path.inspect}) failed: #{SDL2_mixer.mix_get_error}"
+      end
+      @_volume = 1.0
+    end
+
+    def play(looping = false)
+      SDL2_mixer.mix_volume_music((@_volume.clamp(0.0, 1.0) * 128).to_i)
+      SDL2_mixer.mix_play_music(@_music, looping ? -1 : 1)
+      @@_current = self
+    end
+
+    def pause
+      SDL2_mixer.mix_pause_music
+    end
+
+    def paused?
+      SDL2_mixer.mix_paused_music != 0
+    end
+
+    def stop
+      SDL2_mixer.mix_halt_music
+      @@_current = nil if @@_current.equal?(self)
+    end
+
+    def playing?
+      @@_current.equal?(self) && SDL2_mixer.mix_playing_music != 0
+    end
+
+    def volume; @_volume; end
+    def volume=(v)
+      @_volume = v.to_f
+      SDL2_mixer.mix_volume_music((@_volume.clamp(0.0, 1.0) * 128).to_i) if playing?
+    end
   end
 
   class Channel
+    attr_reader :_channel_id
+
+    def initialize(channel_id = -1)
+      @_channel_id = channel_id
+      @_pan = 0.0
+      @_volume = 1.0
+    end
+
     def current_channel; self; end
-    def playing?; false; end
-    def paused?; false; end
-    def pause; end
-    def resume; end
-    def stop; end
-    def volume; 1.0; end
-    def volume=(_); end
-    def pan; 0.0; end
-    def pan=(_); end
+
+    def playing?
+      @_channel_id >= 0 && SDL2_mixer.mix_playing(@_channel_id) != 0
+    end
+
+    def paused?
+      @_channel_id >= 0 && SDL2_mixer.mix_paused(@_channel_id) != 0
+    end
+
+    def pause
+      SDL2_mixer.mix_pause(@_channel_id) if @_channel_id >= 0
+    end
+
+    def resume
+      SDL2_mixer.mix_resume(@_channel_id) if @_channel_id >= 0
+    end
+
+    def stop
+      SDL2_mixer.mix_halt_channel(@_channel_id) if @_channel_id >= 0
+    end
+
+    def volume; @_volume; end
+    def volume=(v)
+      @_volume = v.to_f
+      if @_channel_id >= 0
+        SDL2_mixer.mix_volume(@_channel_id, (@_volume.clamp(0.0, 1.0) * 128).to_i)
+      end
+    end
+
+    def pan; @_pan; end
+    def pan=(p)
+      @_pan = p.to_f.clamp(-1.0, 1.0)
+      if @_channel_id >= 0
+        # SDL_mixer pan: 0..255 left, 0..255 right.
+        if @_pan <= 0
+          left = 255
+          right = (255 * (1.0 + @_pan)).to_i
+        else
+          left = (255 * (1.0 - @_pan)).to_i
+          right = 255
+        end
+        SDL2_mixer.mix_set_panning(@_channel_id, left, right)
+      end
+    end
   end
 
   class TextInput

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -401,7 +401,8 @@ module Gosu
   # ---------------------------------------------------------------------
   class Window
     attr_accessor :caption, :width, :height, :mouse_x, :mouse_y,
-                  :update_interval, :text_input
+                  :update_interval
+    attr_reader :text_input
 
     def initialize(width, height, fullscreen_or_flags = 0,
                    update_interval = 16.666666)
@@ -462,6 +463,20 @@ module Gosu
     def caption=(title)
       @caption = title.to_s
       SDL2.set_window_title(@_sdl_window, @caption) if @_sdl_window
+    end
+
+    # Enable/disable SDL text input alongside storing the TextInput.
+    # When a TextInput is attached, SDL will emit SDL_TEXTINPUT events
+    # which _pump_events routes into TextInput#insert_text.
+    def text_input=(input)
+      @text_input = input
+      if @@_sdl_inited
+        if input
+          SDL2.start_text_input
+        else
+          SDL2.stop_text_input
+        end
+      end
     end
 
     def fullscreen?; @fullscreen; end
@@ -532,6 +547,7 @@ module Gosu
       end
       SDL2.set_draw_color(@_sdl_renderer, 0, 0, 0, 255)
       SDL2.render_clear(@_sdl_renderer)
+      SDL2.start_text_input if @text_input
     end
 
     # SDL_Event field offsets we care about (x86_64 / little-endian):
@@ -552,10 +568,18 @@ module Gosu
           close
         when SDL2::EVENT_KEYDOWN
           scancode = @_event_buf.get_int32(16)
+          next if @text_input && _text_input_consume_keydown(scancode)
           button_down(scancode)
         when SDL2::EVENT_KEYUP
           scancode = @_event_buf.get_int32(16)
+          next if @text_input && _text_input_editing_key?(scancode)
           button_up(scancode)
+        when SDL2::EVENT_TEXTINPUT
+          if @text_input
+            # SDL_TextInputEvent.text is a NUL-terminated UTF-8 char[32] at offset 12.
+            s = @_event_buf.get_string(12)
+            @text_input.insert_text(s) unless s.empty?
+          end
         when SDL2::EVENT_MOUSEMOTION
           @mouse_x = @_event_buf.get_int32(20).to_f
           @mouse_y = @_event_buf.get_int32(24).to_f
@@ -652,6 +676,43 @@ module Gosu
     def _enumerate_controllers
       count = SDL2.num_joysticks
       count.times { |i| _open_controller(i) }
+    end
+
+    # --- Text input editing keys --------------------------------------
+    # When a TextInput is attached, these keys are consumed by the
+    # text input widget instead of firing button_down / button_up.
+    def _text_input_editing_key?(scancode)
+      case scancode
+      when KB_BACKSPACE, KB_DELETE, KB_LEFT, KB_RIGHT, KB_HOME, KB_END
+        true
+      else
+        false
+      end
+    end
+
+    def _text_input_consume_keydown(scancode)
+      t = @text_input
+      case scancode
+      when KB_BACKSPACE
+        t.delete_backward
+      when KB_DELETE
+        t.delete_forward
+      when KB_LEFT
+        t.caret_pos = t.caret_pos - 1 if t.caret_pos > 0
+        t.selection_start = t.caret_pos
+      when KB_RIGHT
+        t.caret_pos = t.caret_pos + 1 if t.caret_pos < t.text.length
+        t.selection_start = t.caret_pos
+      when KB_HOME
+        t.caret_pos = 0
+        t.selection_start = 0
+      when KB_END
+        t.caret_pos = t.text.length
+        t.selection_start = t.caret_pos
+      else
+        return false
+      end
+      true
     end
 
     public
@@ -1148,18 +1209,68 @@ module Gosu
   end
 
   class TextInput
-    attr_accessor :text, :caret_pos, :selection_start, :filter
+    attr_accessor :filter
+    attr_reader :text, :caret_pos, :selection_start
 
     def initialize
-      @text = ""
+      @text = String.new(encoding: Encoding::UTF_8) rescue +""
       @caret_pos = 0
       @selection_start = 0
       @filter = nil
     end
 
-    def delete_forward; end
-    def delete_backward; end
-    def insert_text(_); end
+    def text=(new_text)
+      @text = new_text.dup.to_s
+      @caret_pos = @text.length
+      @selection_start = @caret_pos
+    end
+
+    def caret_pos=(pos)
+      @caret_pos = pos.to_i.clamp(0, @text.length)
+    end
+
+    def selection_start=(pos)
+      @selection_start = pos.to_i.clamp(0, @text.length)
+    end
+
+    # Insert `new_text`, optionally running it through `@filter` first.
+    # Replaces any selection between `caret_pos` and `selection_start`.
+    def insert_text(new_text)
+      s = new_text.to_s
+      s = @filter.call(s) if @filter
+      return if s.empty?
+      _replace_selection(s)
+      nil
+    end
+
+    def delete_backward
+      if @caret_pos != @selection_start
+        _replace_selection("")
+      elsif @caret_pos > 0
+        @text = @text[0, @caret_pos - 1].to_s +
+                @text[@caret_pos, @text.length - @caret_pos].to_s
+        @caret_pos -= 1
+        @selection_start = @caret_pos
+      end
+    end
+
+    def delete_forward
+      if @caret_pos != @selection_start
+        _replace_selection("")
+      elsif @caret_pos < @text.length
+        @text = @text[0, @caret_pos].to_s +
+                @text[@caret_pos + 1, @text.length - @caret_pos - 1].to_s
+      end
+    end
+
+    private
+
+    def _replace_selection(str)
+      lo, hi = [@caret_pos, @selection_start].sort
+      @text = @text[0, lo].to_s + str + @text[hi, @text.length - hi].to_s
+      @caret_pos = lo + str.length
+      @selection_start = @caret_pos
+    end
   end
 
   class GLTexInfo

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -1,0 +1,634 @@
+# gosu.rb -- monoruby replacement for the `gosu` gem's C extension
+# (gosu.so).
+#
+# Provides enough Gosu API surface that
+#
+#   require "gosu"
+#
+# succeeds and a typical `Gosu::Window` subclass can be instantiated
+# without error. Rendering, audio, and input are stubbed out:
+# callbacks such as `Gosu::Window#show` return immediately without
+# running a real frame loop, and primitives such as `Gosu::Image.new`
+# accept any path but never produce pixels. Real gameplay / drawing
+# is not supported -- this is a compatibility shim so that Ruby code
+# using Gosu at least loads, parses, and fails gracefully instead of
+# raising `LoadError` on `require`.
+#
+# The pure-Ruby parts of the gem (swig_patches.rb, patches.rb,
+# compat.rb) are shipped here under `monoruby/gem/gosu/` and required
+# at the bottom of this file; they add the CamelCase button aliases
+# (`KbLeft`, `Gp0Button0`, ...), deprecation helpers, and `Numeric`
+# angle-conversion extensions, matching the real gem's public API.
+
+module Gosu
+  GP_0_BUTTON_0 = 293
+  GP_0_BUTTON_1 = 294
+  GP_0_BUTTON_10 = 303
+  GP_0_BUTTON_11 = 304
+  GP_0_BUTTON_12 = 305
+  GP_0_BUTTON_13 = 306
+  GP_0_BUTTON_14 = 307
+  GP_0_BUTTON_15 = 308
+  GP_0_BUTTON_2 = 295
+  GP_0_BUTTON_3 = 296
+  GP_0_BUTTON_4 = 297
+  GP_0_BUTTON_5 = 298
+  GP_0_BUTTON_6 = 299
+  GP_0_BUTTON_7 = 300
+  GP_0_BUTTON_8 = 301
+  GP_0_BUTTON_9 = 302
+  GP_0_DOWN = 376
+  GP_0_DPAD_DOWN = 292
+  GP_0_DPAD_LEFT = 289
+  GP_0_DPAD_RIGHT = 290
+  GP_0_DPAD_UP = 291
+  GP_0_LEFT = 373
+  GP_0_LEFT_STICK_X_AXIS = 6
+  GP_0_LEFT_STICK_Y_AXIS = 7
+  GP_0_LEFT_TRIGGER_AXIS = 10
+  GP_0_RIGHT = 374
+  GP_0_RIGHT_STICK_X_AXIS = 8
+  GP_0_RIGHT_STICK_Y_AXIS = 9
+  GP_0_RIGHT_TRIGGER_AXIS = 11
+  GP_0_UP = 375
+  GP_1_BUTTON_0 = 313
+  GP_1_BUTTON_1 = 314
+  GP_1_BUTTON_10 = 323
+  GP_1_BUTTON_11 = 324
+  GP_1_BUTTON_12 = 325
+  GP_1_BUTTON_13 = 326
+  GP_1_BUTTON_14 = 327
+  GP_1_BUTTON_15 = 328
+  GP_1_BUTTON_2 = 315
+  GP_1_BUTTON_3 = 316
+  GP_1_BUTTON_4 = 317
+  GP_1_BUTTON_5 = 318
+  GP_1_BUTTON_6 = 319
+  GP_1_BUTTON_7 = 320
+  GP_1_BUTTON_8 = 321
+  GP_1_BUTTON_9 = 322
+  GP_1_DOWN = 380
+  GP_1_DPAD_DOWN = 312
+  GP_1_DPAD_LEFT = 309
+  GP_1_DPAD_RIGHT = 310
+  GP_1_DPAD_UP = 311
+  GP_1_LEFT = 377
+  GP_1_LEFT_STICK_X_AXIS = 12
+  GP_1_LEFT_STICK_Y_AXIS = 13
+  GP_1_LEFT_TRIGGER_AXIS = 16
+  GP_1_RIGHT = 378
+  GP_1_RIGHT_STICK_X_AXIS = 14
+  GP_1_RIGHT_STICK_Y_AXIS = 15
+  GP_1_RIGHT_TRIGGER_AXIS = 17
+  GP_1_UP = 379
+  GP_2_BUTTON_0 = 333
+  GP_2_BUTTON_1 = 334
+  GP_2_BUTTON_10 = 343
+  GP_2_BUTTON_11 = 344
+  GP_2_BUTTON_12 = 345
+  GP_2_BUTTON_13 = 346
+  GP_2_BUTTON_14 = 347
+  GP_2_BUTTON_15 = 348
+  GP_2_BUTTON_2 = 335
+  GP_2_BUTTON_3 = 336
+  GP_2_BUTTON_4 = 337
+  GP_2_BUTTON_5 = 338
+  GP_2_BUTTON_6 = 339
+  GP_2_BUTTON_7 = 340
+  GP_2_BUTTON_8 = 341
+  GP_2_BUTTON_9 = 342
+  GP_2_DOWN = 384
+  GP_2_DPAD_DOWN = 332
+  GP_2_DPAD_LEFT = 329
+  GP_2_DPAD_RIGHT = 330
+  GP_2_DPAD_UP = 331
+  GP_2_LEFT = 381
+  GP_2_LEFT_STICK_X_AXIS = 18
+  GP_2_LEFT_STICK_Y_AXIS = 19
+  GP_2_LEFT_TRIGGER_AXIS = 22
+  GP_2_RIGHT = 382
+  GP_2_RIGHT_STICK_X_AXIS = 20
+  GP_2_RIGHT_STICK_Y_AXIS = 21
+  GP_2_RIGHT_TRIGGER_AXIS = 23
+  GP_2_UP = 383
+  GP_3_BUTTON_0 = 353
+  GP_3_BUTTON_1 = 354
+  GP_3_BUTTON_10 = 363
+  GP_3_BUTTON_11 = 364
+  GP_3_BUTTON_12 = 365
+  GP_3_BUTTON_13 = 366
+  GP_3_BUTTON_14 = 367
+  GP_3_BUTTON_15 = 368
+  GP_3_BUTTON_2 = 355
+  GP_3_BUTTON_3 = 356
+  GP_3_BUTTON_4 = 357
+  GP_3_BUTTON_5 = 358
+  GP_3_BUTTON_6 = 359
+  GP_3_BUTTON_7 = 360
+  GP_3_BUTTON_8 = 361
+  GP_3_BUTTON_9 = 362
+  GP_3_DOWN = 388
+  GP_3_DPAD_DOWN = 352
+  GP_3_DPAD_LEFT = 349
+  GP_3_DPAD_RIGHT = 350
+  GP_3_DPAD_UP = 351
+  GP_3_LEFT = 385
+  GP_3_LEFT_STICK_X_AXIS = 24
+  GP_3_LEFT_STICK_Y_AXIS = 25
+  GP_3_LEFT_TRIGGER_AXIS = 28
+  GP_3_RIGHT = 386
+  GP_3_RIGHT_STICK_X_AXIS = 26
+  GP_3_RIGHT_STICK_Y_AXIS = 27
+  GP_3_RIGHT_TRIGGER_AXIS = 29
+  GP_3_UP = 387
+  GP_BUTTON_0 = 273
+  GP_BUTTON_1 = 274
+  GP_BUTTON_10 = 283
+  GP_BUTTON_11 = 284
+  GP_BUTTON_12 = 285
+  GP_BUTTON_13 = 286
+  GP_BUTTON_14 = 287
+  GP_BUTTON_15 = 288
+  GP_BUTTON_2 = 275
+  GP_BUTTON_3 = 276
+  GP_BUTTON_4 = 277
+  GP_BUTTON_5 = 278
+  GP_BUTTON_6 = 279
+  GP_BUTTON_7 = 280
+  GP_BUTTON_8 = 281
+  GP_BUTTON_9 = 282
+  GP_DOWN = 372
+  GP_DPAD_DOWN = 272
+  GP_DPAD_LEFT = 269
+  GP_DPAD_RIGHT = 270
+  GP_DPAD_UP = 271
+  GP_LEFT = 369
+  GP_LEFT_STICK_X_AXIS = 0
+  GP_LEFT_STICK_Y_AXIS = 1
+  GP_LEFT_TRIGGER_AXIS = 4
+  GP_RIGHT = 370
+  GP_RIGHT_STICK_X_AXIS = 2
+  GP_RIGHT_STICK_Y_AXIS = 3
+  GP_RIGHT_TRIGGER_AXIS = 5
+  GP_UP = 371
+  KB_0 = 39
+  KB_1 = 30
+  KB_2 = 31
+  KB_3 = 32
+  KB_4 = 33
+  KB_5 = 34
+  KB_6 = 35
+  KB_7 = 36
+  KB_8 = 37
+  KB_9 = 38
+  KB_A = 4
+  KB_APOSTROPHE = 52
+  KB_B = 5
+  KB_BACKSLASH = 49
+  KB_BACKSPACE = 42
+  KB_BACKTICK = 53
+  KB_C = 6
+  KB_CAPS_LOCK = 57
+  KB_COMMA = 54
+  KB_D = 7
+  KB_DELETE = 76
+  KB_DOWN = 81
+  KB_E = 8
+  KB_END = 77
+  KB_ENTER = 88
+  KB_EQUALS = 46
+  KB_ESCAPE = 41
+  KB_F = 9
+  KB_F1 = 58
+  KB_F10 = 67
+  KB_F11 = 68
+  KB_F12 = 69
+  KB_F2 = 59
+  KB_F3 = 60
+  KB_F4 = 61
+  KB_F5 = 62
+  KB_F6 = 63
+  KB_F7 = 64
+  KB_F8 = 65
+  KB_F9 = 66
+  KB_G = 10
+  KB_H = 11
+  KB_HOME = 74
+  KB_I = 12
+  KB_INSERT = 73
+  KB_ISO = 100
+  KB_J = 13
+  KB_K = 14
+  KB_L = 15
+  KB_LEFT = 80
+  KB_LEFT_ALT = 226
+  KB_LEFT_BRACKET = 47
+  KB_LEFT_CONTROL = 224
+  KB_LEFT_META = 227
+  KB_LEFT_SHIFT = 225
+  KB_M = 16
+  KB_MINUS = 45
+  KB_N = 17
+  KB_NUMPAD_0 = 98
+  KB_NUMPAD_1 = 89
+  KB_NUMPAD_2 = 90
+  KB_NUMPAD_3 = 91
+  KB_NUMPAD_4 = 92
+  KB_NUMPAD_5 = 93
+  KB_NUMPAD_6 = 94
+  KB_NUMPAD_7 = 95
+  KB_NUMPAD_8 = 96
+  KB_NUMPAD_9 = 97
+  KB_NUMPAD_DELETE = 99
+  KB_NUMPAD_DIVIDE = 84
+  KB_NUMPAD_MINUS = 86
+  KB_NUMPAD_MULTIPLY = 85
+  KB_NUMPAD_PLUS = 87
+  KB_O = 18
+  KB_P = 19
+  KB_PAGE_DOWN = 78
+  KB_PAGE_UP = 75
+  KB_PAUSE = 72
+  KB_PERIOD = 55
+  KB_PRINT_SCREEN = 70
+  KB_Q = 20
+  KB_R = 21
+  KB_RETURN = 40
+  KB_RIGHT = 79
+  KB_RIGHT_ALT = 230
+  KB_RIGHT_BRACKET = 48
+  KB_RIGHT_CONTROL = 228
+  KB_RIGHT_META = 231
+  KB_RIGHT_SHIFT = 229
+  KB_S = 22
+  KB_SCROLL_LOCK = 71
+  KB_SEMICOLON = 51
+  KB_SLASH = 56
+  KB_SPACE = 44
+  KB_T = 23
+  KB_TAB = 43
+  KB_U = 24
+  KB_UP = 82
+  KB_V = 25
+  KB_W = 26
+  KB_X = 27
+  KB_Y = 28
+  KB_Z = 29
+  LICENSES = "This software may utilize code from the following third-party libraries:\n\nGosu, https://www.libgosu.org, MIT License, https://opensource.org/licenses/MIT\nSDL 2, https://www.libsdl.org, MIT License, https://opensource.org/licenses/MIT\nlibsndfile, http://www.mega-nerd.com/libsndfile, GNU LGPL 3, https://www.gnu.org/copyleft/lesser.html\nmpg123, https://mpg123.de, GNU LGPL 3, https://www.gnu.org/copyleft/lesser.html\n"
+  MAJOR_VERSION = 1
+  MAX_TEXTURE_SIZE = 1024
+  MINOR_VERSION = 4
+  MS_LEFT = 256
+  MS_MIDDLE = 257
+  MS_OTHER_0 = 261
+  MS_OTHER_1 = 262
+  MS_OTHER_2 = 263
+  MS_OTHER_3 = 264
+  MS_OTHER_4 = 265
+  MS_OTHER_5 = 266
+  MS_OTHER_6 = 267
+  MS_OTHER_7 = 268
+  MS_RIGHT = 258
+  MS_WHEEL_DOWN = 260
+  MS_WHEEL_UP = 259
+  POINT_VERSION = 6
+  VERSION = "1.4.6"
+
+  # ---------------------------------------------------------------------
+  # Gosu::Color -- 32-bit ARGB colour value.
+  # ---------------------------------------------------------------------
+  class Color
+    attr_accessor :alpha, :red, :green, :blue
+
+    def initialize(*args)
+      case args.size
+      when 1
+        argb_packed = args[0].to_i
+        @alpha = (argb_packed >> 24) & 0xff
+        @red   = (argb_packed >> 16) & 0xff
+        @green = (argb_packed >>  8) & 0xff
+        @blue  =  argb_packed        & 0xff
+      when 3
+        @alpha = 255
+        @red, @green, @blue = args.map(&:to_i)
+      when 4
+        @alpha, @red, @green, @blue = args.map(&:to_i)
+      else
+        raise ArgumentError,
+              "wrong number of arguments (given #{args.size}, expected 1, 3 or 4)"
+      end
+    end
+
+    def self.rgb(r, g, b)
+      new(255, r, g, b)
+    end
+
+    def self.rgba(r, g, b, a)
+      new(a, r, g, b)
+    end
+
+    def self.argb(a_or_packed, r = nil, g = nil, b = nil)
+      r.nil? ? new(a_or_packed) : new(a_or_packed, r, g, b)
+    end
+
+    def self.from_hsv(h, s, v)
+      new(255, *_hsv_to_rgb(h, s, v))
+    end
+
+    def self.from_ahsv(a, h, s, v)
+      new(a, *_hsv_to_rgb(h, s, v))
+    end
+
+    def self._hsv_to_rgb(h, s, v)
+      h = h.to_f % 360.0
+      s = s.to_f.clamp(0.0, 1.0)
+      v = v.to_f.clamp(0.0, 1.0)
+      c = v * s
+      x = c * (1 - ((h / 60.0) % 2 - 1).abs)
+      m = v - c
+      r1, g1, b1 =
+        case (h / 60).to_i
+        when 0 then [c, x, 0]
+        when 1 then [x, c, 0]
+        when 2 then [0, c, x]
+        when 3 then [0, x, c]
+        when 4 then [x, 0, c]
+        else        [c, 0, x]
+        end
+      [((r1 + m) * 255).round, ((g1 + m) * 255).round, ((b1 + m) * 255).round]
+    end
+
+    def hue; 0.0; end
+    def saturation; 0.0; end
+    def value; 0.0; end
+    def hue=(_); end
+    def saturation=(_); end
+    def value=(_); end
+
+    def to_i
+      (@alpha << 24) | (@red << 16) | (@green << 8) | @blue
+    end
+    alias_method :argb, :to_i
+
+    def bgr
+      (@blue << 16) | (@green << 8) | @red
+    end
+
+    def abgr
+      (@alpha << 24) | (@blue << 16) | (@green << 8) | @red
+    end
+
+    # GL (little-endian RGBA) layout matches ABGR byte order.
+    alias_method :gl, :abgr
+
+    def dup
+      Color.new(@alpha, @red, @green, @blue)
+    end
+
+    def ==(other)
+      other.is_a?(Color) &&
+        @alpha == other.alpha && @red == other.red &&
+        @green == other.green && @blue == other.blue
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Window -- stubbed game window. `show` is a no-op so programs that
+  # just construct the window and call `show` exit immediately instead
+  # of hanging.
+  # ---------------------------------------------------------------------
+  class Window
+    attr_accessor :caption, :width, :height, :mouse_x, :mouse_y,
+                  :update_interval, :text_input
+
+    def initialize(width, height, fullscreen_or_flags = 0,
+                   update_interval = 16.666666)
+      @width  = width
+      @height = height
+      @caption = ""
+      @mouse_x = 0.0
+      @mouse_y = 0.0
+      @update_interval = update_interval
+      @text_input = nil
+      @fullscreen = fullscreen_or_flags != 0
+      @resizable = false
+      @borderless = false
+    end
+
+    def show; self; end
+    def close; end
+    def close!; end
+    def tick; false; end
+
+    def fullscreen?; @fullscreen; end
+    def fullscreen=(v); @fullscreen = !!v; end
+    def resizable?; @resizable; end
+    def resizable=(v); @resizable = !!v; end
+    def borderless?; @borderless; end
+    def borderless=(v); @borderless = !!v; end
+
+    # Callbacks default to no-op so subclasses override only what they
+    # actually use.
+    def update; end
+    def draw; end
+    def needs_redraw?; true; end
+    def needs_cursor?; false; end
+    def button_down(_id); end
+    def button_up(_id); end
+    def gain_focus; end
+    def lose_focus; end
+    def gamepad_connected(_index); end
+    def gamepad_disconnected(_index); end
+    def drop(_filename); end
+
+    def minimize; end
+    def restore; end
+    def minimized?; false; end
+
+    def set_mouse_position(_x, _y); end
+
+    def self.button_id_to_char(_id); nil; end
+    def self.char_to_button_id(_c); nil; end
+  end
+
+  # ---------------------------------------------------------------------
+  # Image / Font / Sample / Song / Channel / TextInput / SampleInstance /
+  # GLTexInfo -- stubs that accept the CRuby constructors and expose the
+  # documented accessors.
+  # ---------------------------------------------------------------------
+  class Image
+    attr_reader :width, :height, :columns, :rows
+
+    def initialize(source = nil, *_opts)
+      if source.respond_to?(:columns) && source.respond_to?(:rows)
+        @width  = @columns = source.columns.to_i
+        @height = @rows    = source.rows.to_i
+      else
+        @width  = @columns = 0
+        @height = @rows    = 0
+      end
+    end
+
+    def self.from_text(_text, _height, *_opts); new; end
+    def self.from_text_without_window(_text, _height, *_opts); new; end
+    def self.from_markup(_text, _height, *_opts); new; end
+    def self.load_tiles(_source, _tile_w, _tile_h, *_opts); []; end
+
+    def draw(*); end
+    def draw_rot(*); end
+    def draw_as_quad(*); end
+    def draw_mod(*); end
+    def to_blob; "\0\0\0\0" * (width * height); end
+    def save(_path); end
+    def insert(_img, _x, _y); self; end
+    def subimage(_x, _y, _w, _h); Image.new; end
+    def gl_tex_info; nil; end
+  end
+
+  class Font
+    attr_accessor :name, :height
+
+    def initialize(height, *opts)
+      @height = height.to_i
+      @name = opts.first.is_a?(Hash) ? (opts.first[:name] || "") : ""
+    end
+
+    def draw_text(*); end
+    def draw_text_rel(*); end
+    def draw_markup(*); end
+    def draw_markup_rel(*); end
+    def text_width(text, *_opts); text.to_s.length * (@height / 2); end
+    def markup_width(text, *_opts); text_width(text); end
+    def set_image(_codepoint, _image); end
+    def []=(*); end
+  end
+
+  class Sample
+    def initialize(_path); end
+    def play(_vol = 1.0, _speed = 1.0, _looping = false); Channel.new; end
+    def play_pan(_pan = 0.0, _vol = 1.0, _speed = 1.0, _looping = false)
+      Channel.new
+    end
+  end
+
+  class Song
+    def initialize(_path); end
+    def self.current_song; nil; end
+    def self.update; end
+    def play(_looping = false); end
+    def pause; end
+    def paused?; false; end
+    def stop; end
+    def playing?; false; end
+    def volume; 1.0; end
+    def volume=(_); end
+  end
+
+  class Channel
+    def current_channel; self; end
+    def playing?; false; end
+    def paused?; false; end
+    def pause; end
+    def resume; end
+    def stop; end
+    def volume; 1.0; end
+    def volume=(_); end
+    def pan; 0.0; end
+    def pan=(_); end
+  end
+
+  class TextInput
+    attr_accessor :text, :caret_pos, :selection_start, :filter
+
+    def initialize
+      @text = ""
+      @caret_pos = 0
+      @selection_start = 0
+      @filter = nil
+    end
+
+    def delete_forward; end
+    def delete_backward; end
+    def insert_text(_); end
+  end
+
+  class GLTexInfo
+    attr_accessor :tex_name, :left, :right, :top, :bottom
+
+    def initialize
+      @tex_name = 0
+      @left = 0.0
+      @right = 1.0
+      @top = 0.0
+      @bottom = 1.0
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Module-level helpers.
+  # ---------------------------------------------------------------------
+  class << self
+    def draw_line(*); end
+    def draw_triangle(*); end
+    def draw_quad(*); end
+    def draw_rect(*); end
+    def flush; end
+    def record(_w, _h); yield if block_given?; nil; end
+    def clip_to(*); yield if block_given?; end
+    def translate(*); yield if block_given?; end
+    def rotate(*); yield if block_given?; end
+    def scale(*); yield if block_given?; end
+    def transform(*); yield if block_given?; end
+
+    def fps; 60; end
+    def milliseconds; (Time.now.to_f * 1000).to_i; end
+    def random(a, b); a + rand * (b - a); end
+
+    def available_width(_window = nil); 1920; end
+    def available_height(_window = nil); 1080; end
+    def screen_width(_window = nil); 1920; end
+    def screen_height(_window = nil); 1080; end
+
+    def button_down?(_id); false; end
+    def button_name(_id); nil; end
+    def button_id_to_char(_id); nil; end
+    def char_to_button_id(_c); nil; end
+    def axis(_id); 0.0; end
+
+    def default_font_name; "DejaVu Sans"; end
+    def user_languages; []; end
+
+    def degrees_to_radians(d); d * Math::PI / 180.0; end
+    def radians_to_degrees(r); r * 180.0 / Math::PI; end
+    def offset_x(angle, distance)
+      Math.sin(degrees_to_radians(angle)) * distance
+    end
+    def offset_y(angle, distance)
+      -Math.cos(degrees_to_radians(angle)) * distance
+    end
+    def distance(x1, y1, x2, y2)
+      Math.sqrt((x1 - x2)**2 + (y1 - y2)**2)
+    end
+    def angle(x1, y1, x2, y2)
+      radians_to_degrees(Math.atan2(x2 - x1, y1 - y2)) % 360
+    end
+    def angle_diff(a, b)
+      ((b - a + 180) % 360) - 180
+    end
+
+    def clipboard; ""; end
+    def clipboard=(_); end
+    def enable_undocumented_retrofication; end
+
+    def disown_Window(_window); end
+    def disown_TextInput(_input); end
+  end
+end
+
+# Pure-Ruby helpers shipped with the gem (copied under gem/gosu/).
+# They add deprecation helpers, Color constants, CamelCase aliases for
+# the KB_*/MS_*/GP_* button constants, and Numeric angle-conversion
+# helpers.
+require "gosu/swig_patches"
+require "gosu/patches"
+require "gosu/compat"

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -20,6 +20,8 @@
 # (`KbLeft`, `Gp0Button0`, ...), deprecation helpers, and `Numeric`
 # angle-conversion extensions, matching the real gem's public API.
 
+require "gosu/sdl2"
+
 module Gosu
   GP_0_BUTTON_0 = 293
   GP_0_BUTTON_1 = 294
@@ -393,9 +395,9 @@ module Gosu
   end
 
   # ---------------------------------------------------------------------
-  # Window -- stubbed game window. `show` is a no-op so programs that
-  # just construct the window and call `show` exit immediately instead
-  # of hanging.
+  # Window -- real SDL2-backed game window. `show` runs an event loop
+  # that pumps SDL events, calls `update` / `draw`, and renders to the
+  # window until `close` is called (or the user closes the window).
   # ---------------------------------------------------------------------
   class Window
     attr_accessor :caption, :width, :height, :mouse_x, :mouse_y,
@@ -413,12 +415,54 @@ module Gosu
       @fullscreen = fullscreen_or_flags != 0
       @resizable = false
       @borderless = false
+      @_sdl_window = nil
+      @_sdl_renderer = nil
+      @_closing = false
+      @_event_buf = FFI::MemoryPointer.new(:uint8, SDL2::EVENT_SIZE)
     end
 
-    def show; self; end
-    def close; end
-    def close!; end
+    def show
+      _lazy_sdl_init
+      _create_window unless @_sdl_window
+      Gosu._current_window = self
+      last_tick = SDL2.get_ticks
+      until @_closing
+        _pump_events
+        now = SDL2.get_ticks
+        if now - last_tick >= @update_interval
+          update
+          last_tick = now
+        end
+        draw
+        SDL2.render_present(@_sdl_renderer)
+        SDL2.delay(1)
+      end
+      close!
+      self
+    end
+
+    def close
+      @_closing = true
+    end
+
+    def close!
+      if @_sdl_renderer
+        SDL2.destroy_renderer(@_sdl_renderer)
+        @_sdl_renderer = nil
+      end
+      if @_sdl_window
+        SDL2.destroy_window(@_sdl_window)
+        @_sdl_window = nil
+      end
+      Gosu._current_window = nil if Gosu._current_window == self
+    end
+
     def tick; false; end
+
+    def caption=(title)
+      @caption = title.to_s
+      SDL2.set_window_title(@_sdl_window, @caption) if @_sdl_window
+    end
 
     def fullscreen?; @fullscreen; end
     def fullscreen=(v); @fullscreen = !!v; end
@@ -426,6 +470,10 @@ module Gosu
     def resizable=(v); @resizable = !!v; end
     def borderless?; @borderless; end
     def borderless=(v); @borderless = !!v; end
+
+    # Internal: exposed so `Gosu.draw_rect` / `Gosu.draw_line` can reach
+    # the SDL renderer attached to the currently-showing window.
+    def _sdl_renderer; @_sdl_renderer; end
 
     # Callbacks default to no-op so subclasses override only what they
     # actually use.
@@ -440,6 +488,85 @@ module Gosu
     def gamepad_connected(_index); end
     def gamepad_disconnected(_index); end
     def drop(_filename); end
+
+    private
+
+    @@_sdl_inited = false
+
+    def _lazy_sdl_init
+      return if @@_sdl_inited
+      if SDL2.init(SDL2::INIT_VIDEO | SDL2::INIT_EVENTS) != 0
+        raise RuntimeError, "SDL_Init failed: #{SDL2.get_error}"
+      end
+      @@_sdl_inited = true
+      at_exit { SDL2.quit }
+    end
+
+    def _create_window
+      flags = SDL2::WINDOW_SHOWN
+      flags |= SDL2::WINDOW_FULLSCREEN_DESKTOP if @fullscreen
+      flags |= SDL2::WINDOW_RESIZABLE          if @resizable
+      flags |= SDL2::WINDOW_BORDERLESS         if @borderless
+      @_sdl_window = SDL2.create_window(
+        @caption.empty? ? "Gosu" : @caption,
+        SDL2::WINDOWPOS_CENTERED, SDL2::WINDOWPOS_CENTERED,
+        @width, @height, flags
+      )
+      if @_sdl_window.null?
+        raise RuntimeError, "SDL_CreateWindow failed: #{SDL2.get_error}"
+      end
+      @_sdl_renderer = SDL2.create_renderer(
+        @_sdl_window, -1,
+        SDL2::RENDERER_ACCELERATED | SDL2::RENDERER_PRESENTVSYNC
+      )
+      if @_sdl_renderer.null?
+        # Fall back to software renderer (e.g. under SDL_VIDEODRIVER=dummy).
+        @_sdl_renderer = SDL2.create_renderer(@_sdl_window, -1,
+                                              SDL2::RENDERER_SOFTWARE)
+      end
+      if @_sdl_renderer.null?
+        raise RuntimeError, "SDL_CreateRenderer failed: #{SDL2.get_error}"
+      end
+      SDL2.set_draw_color(@_sdl_renderer, 0, 0, 0, 255)
+      SDL2.render_clear(@_sdl_renderer)
+    end
+
+    # SDL_Event field offsets we care about (x86_64 / little-endian):
+    #   event.type             uint32 @ 0
+    #   SDL_KeyboardEvent:
+    #     .keysym.scancode     int32  @ 16
+    #   SDL_MouseMotionEvent:
+    #     .x                   int32  @ 20
+    #     .y                   int32  @ 24
+    #   SDL_MouseButtonEvent:
+    #     .button              uint8  @ 16
+    # All other fields are ignored for now.
+    def _pump_events
+      while SDL2.poll_event(@_event_buf) != 0
+        type = @_event_buf.get_uint32(0)
+        case type
+        when SDL2::EVENT_QUIT
+          close
+        when SDL2::EVENT_KEYDOWN
+          scancode = @_event_buf.get_int32(16)
+          button_down(scancode)
+        when SDL2::EVENT_KEYUP
+          scancode = @_event_buf.get_int32(16)
+          button_up(scancode)
+        when SDL2::EVENT_MOUSEMOTION
+          @mouse_x = @_event_buf.get_int32(20).to_f
+          @mouse_y = @_event_buf.get_int32(24).to_f
+        when SDL2::EVENT_MOUSEBUTTONDOWN
+          btn = @_event_buf.get_uint8(16)
+          button_down(255 + btn)
+        when SDL2::EVENT_MOUSEBUTTONUP
+          btn = @_event_buf.get_uint8(16)
+          button_up(255 + btn)
+        end
+      end
+    end
+
+    public
 
     def minimize; end
     def restore; end
@@ -567,21 +694,80 @@ module Gosu
   # ---------------------------------------------------------------------
   # Module-level helpers.
   # ---------------------------------------------------------------------
+  # The window that is currently running `#show`. `draw_rect` etc. reach
+  # through it to the SDL renderer.
+  @@_current_window = nil
+  def self._current_window; @@_current_window; end
+  def self._current_window=(w); @@_current_window = w; end
+
   class << self
-    def draw_line(*); end
+    # Split an ARGB / Color into 4 bytes for SDL colour calls.
+    def _split_color(color)
+      if color.is_a?(Color)
+        [color.red, color.green, color.blue, color.alpha]
+      else
+        argb = color.to_i
+        [(argb >> 16) & 0xff, (argb >> 8) & 0xff, argb & 0xff, (argb >> 24) & 0xff]
+      end
+    end
+    private :_split_color
+
+    def draw_rect(x, y, w, h, color, _z = 0, _mode = :default)
+      ren = (_current_window && _current_window._sdl_renderer)
+      return unless ren
+      r, g, b, a = _split_color(color)
+      SDL2.set_draw_blend_mode(ren, 1) # SDL_BLENDMODE_BLEND
+      SDL2.set_draw_color(ren, r, g, b, a)
+      rect = SDL2::Rect.new
+      rect[:x] = x.to_i
+      rect[:y] = y.to_i
+      rect[:w] = w.to_i
+      rect[:h] = h.to_i
+      SDL2.render_fill_rect(ren, rect.pointer)
+    end
+
+    def draw_line(x1, y1, c1, x2, y2, _c2 = nil, _z = 0, _mode = :default)
+      ren = (_current_window && _current_window._sdl_renderer)
+      return unless ren
+      r, g, b, a = _split_color(c1)
+      SDL2.set_draw_blend_mode(ren, 1)
+      SDL2.set_draw_color(ren, r, g, b, a)
+      SDL2.render_draw_line(ren, x1.to_i, y1.to_i, x2.to_i, y2.to_i)
+    end
+
     def draw_triangle(*); end
     def draw_quad(*); end
-    def draw_rect(*); end
     def flush; end
     def record(_w, _h); yield if block_given?; nil; end
-    def clip_to(*); yield if block_given?; end
+
+    def clip_to(x, y, w, h)
+      ren = (_current_window && _current_window._sdl_renderer)
+      if ren
+        rect = SDL2::Rect.new
+        rect[:x] = x.to_i; rect[:y] = y.to_i
+        rect[:w] = w.to_i; rect[:h] = h.to_i
+        SDL2.render_set_clip_rect(ren, rect.pointer)
+        begin
+          yield if block_given?
+        ensure
+          SDL2.render_set_clip_rect(ren, nil)
+        end
+      else
+        yield if block_given?
+      end
+    end
+
     def translate(*); yield if block_given?; end
     def rotate(*); yield if block_given?; end
     def scale(*); yield if block_given?; end
     def transform(*); yield if block_given?; end
 
     def fps; 60; end
-    def milliseconds; (Time.now.to_f * 1000).to_i; end
+    def milliseconds
+      SDL2.get_ticks
+    rescue
+      (Time.now.to_f * 1000).to_i
+    end
     def random(a, b); a + rand * (b - a); end
 
     def available_width(_window = nil); 1920; end

--- a/monoruby/gem/gosu/compat.rb
+++ b/monoruby/gem/gosu/compat.rb
@@ -1,0 +1,196 @@
+# This whole file is about backward compatibility.
+
+# Define some helpers to deprecate code.
+module Gosu
+  DEPRECATION_STACKTRACE_LINES = 1
+
+  # Adapted from RubyGems, but without the date part.
+  def self.deprecate(klass, name, repl)
+    klass.class_eval {
+      old = "_deprecated_#{name}"
+      alias_method old, name
+      define_method(name) do |*args, &block|
+        Gosu.deprecation_message(self, name, repl)
+        send old, *args, &block
+      end
+    }
+  end
+
+  def self.deprecation_message(klass_or_full_message, name = nil, repl = nil)
+    @@_deprecations_shown ||= {}
+
+    msg = if klass_or_full_message.is_a?(String) and name.nil? and repl.nil?
+      [ "DEPRECATION WARNING: #{klass_or_full_message},
+        \n#Called from #{caller[1, DEPRECATION_STACKTRACE_LINES]}"
+      ]
+    else
+      # Class method deprecation warnings result in something like this:
+      # #<Class:Gosu::Window>::button_id_to_char is deprecated
+      # Remove the instance-inspect stuff to make it look a bit better:
+      if klass_or_full_message.kind_of?(Module)
+        target = "#{klass_or_full_message.to_s.gsub(/#<Class:(.*)>/, '\1')}::"
+      else
+        "#{klass_or_full_message.class}#"
+      end
+      [ "DEPRECATION WARNING: #{target}#{name} is deprecated",
+        repl == :none ? " with no replacement." : "; use #{repl} instead.",
+        "\n#{target}#{name} called from #{Gosu.deprecation_caller.join("\n")}",
+      ]
+    end
+    return if @@_deprecations_shown.has_key?(msg[0])
+    @@_deprecations_shown[msg[0]] = true
+
+    warn "#{msg.join}."
+  end
+
+  # This method removes the deprecation methods themselves from the stacktrace.
+  def self.deprecation_caller
+    caller.delete_if { |trace_line| trace_line =~ /(deprecat|const_missing)/ }
+      .first(DEPRECATION_STACKTRACE_LINES)
+  end
+end
+
+# These were useful for working with Direct3D and the Win32 API a long time ago,
+# there was never a real reason to have them available in Ruby.
+Gosu.deprecate Gosu::Color, :bgr, :none
+Gosu.deprecate Gosu::Color, :abgr, :none
+
+# No need to pass a Window to Image.
+class Gosu::Image
+  alias_method :initialize_without_window, :initialize
+
+  def initialize(*args)
+    if args[0].is_a? Gosu::Window
+      Gosu.deprecation_message("Passing a Window to Image#initialize has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html ")
+      if args.size == 7
+        initialize_without_window args[1], tileable: args[2], rect: args[3..-1]
+      else
+        initialize_without_window args[1], tileable: args[2]
+      end
+    else
+      initialize_without_window(*args)
+    end
+  end
+
+  class << self
+    alias_method :from_text_without_window, :from_text
+  end
+
+  def self.from_text(*args)
+    if args.size == 4
+      Gosu.deprecation_message("Passing a Window to Image.from_text has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html ")
+      from_text_without_window(args[1], args[3], font: args[2])
+    elsif args.size == 7
+      Gosu.deprecation_message("Passing a Window to Image.from_text has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html ")
+      from_text_without_window(args[1], args[3],
+                               font: args[2], spacing: args[4], width: args[5],
+                               align: args[6])
+    else
+      from_text_without_window(*args)
+    end
+  end
+end
+
+# No need to pass a Window to Sample.
+class Gosu::Sample
+  alias_method :initialize_without_window, :initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+# No need to pass a Window to Song.
+class Gosu::Song
+  alias_method :initialize_without_window, :initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+class Gosu::Font
+  alias_method :draw, :draw_markup
+  Gosu.deprecate Gosu::Font, :draw, "Font#draw_text or Font#draw_markup"
+
+  alias_method :draw_rel, :draw_markup_rel
+  Gosu.deprecate Gosu::Font, :draw_rel, "Font#draw_text_rel or Font#draw_markup_rel"
+
+  def draw_rot(markup, x, y, z, angle, scale_x = 1, scale_y = 1, c = 0xff_ffffff, mode = :default)
+    Gosu.rotate(angle, x, y) { draw_markup(markup, x, y, z, scale_x, scale_y, c, mode) }
+  end
+
+  Gosu.deprecate Gosu::Font, :draw_rot, "Font#draw with Gosu.rotate"
+end
+
+# Moved some Window methods to the Gosu module.
+class Gosu::Window
+  # Class methods that have been turned into module methods.
+  class << self
+    def button_id_to_char(id)
+      Gosu.button_id_to_char(id)
+    end
+
+    def char_to_button_id(ch)
+      Gosu.char_to_button_id(ch)
+    end
+  end
+
+  # Instance methods that have been turned into module methods.
+  %w(draw_line draw_triangle draw_quad draw_rect
+     flush gl clip_to record
+     transform translate rotate scale
+     button_id_to_char char_to_button_id button_down?).each do |method|
+    define_method(method.to_sym) do |*args, &block|
+      Gosu.send method, *args, &block
+    end
+  end
+
+  Gosu.deprecate Gosu::Window, :set_mouse_position, "Window#mouse_x= and Window#mouse_y="
+end
+
+# Constants
+module Gosu
+  # This was renamed because it's not actually a "copyright notice".
+  # (https://en.wikipedia.org/wiki/Copyright_notice)
+  GOSU_COPYRIGHT_NOTICE = LICENSES
+  deprecate_constant :GOSU_COPYRIGHT_NOTICE
+
+  module Button; end
+
+  # Channel was called SampleInstance before Gosu 0.13.0.
+  SampleInstance = Channel
+  deprecate_constant :SampleInstance
+
+  # Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
+  Gosu.constants.grep(/^KB_|MS_|GP_/).each do |new_name|
+    old_name = case new_name
+      when :KB_ISO then "KbISO"
+      when :KB_NUMPAD_PLUS then "KbNumpadAdd"
+      when :KB_NUMPAD_MINUS then "KbNumpadSubtract"
+      when :KB_EQUALS then "KbEqual"
+      when :KB_LEFT_BRACKET then "KbBracketLeft"
+      when :KB_RIGHT_BRACKET then "KbBracketRight"
+      else new_name.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
+      end
+    Gosu.const_set old_name, Gosu.const_get(new_name)
+    deprecate_constant old_name
+
+    # Also import old-style constants into Gosu::Button.
+    Gosu::Button.const_set old_name, Gosu.const_get(new_name)
+  end
+
+  deprecate_constant :Button
+
+  def self.language
+    @language_cache ||= (user_languages.first || "en_US")
+  end
+end

--- a/monoruby/gem/gosu/patches.rb
+++ b/monoruby/gem/gosu/patches.rb
@@ -1,0 +1,66 @@
+# Extend Numeric with simple angle conversion methods,
+# for easier integration with Chipmunk.
+class ::Numeric
+  def degrees_to_radians
+    self * Math::PI / 180.0
+  end
+
+  def radians_to_degrees
+    self * 180.0 / Math::PI
+  end
+
+  def gosu_to_radians
+    (self - 90) * Math::PI / 180.0
+  end
+
+  def radians_to_gosu
+    self * 180.0 / Math::PI + 90
+  end
+end
+
+class Gosu::Image
+  BlobHelper = Struct.new(:columns, :rows, :to_blob)
+  
+  def self.from_blob(width, height, rgba = "\0\0\0\0" * (width * height))
+    self.new(BlobHelper.new(width, height, rgba))
+  end
+end
+
+# Color constants.
+# This is cleaner than having SWIG define them.
+module Gosu
+  class ImmutableColor < Color
+    private :alpha=, :red=, :green=, :blue=, :hue=, :saturation=, :value=
+  end
+
+  class Color
+    NONE    = Gosu::ImmutableColor.new(0x00_000000)
+    BLACK   = Gosu::ImmutableColor.new(0xff_000000)
+    GRAY    = Gosu::ImmutableColor.new(0xff_808080)
+    WHITE   = Gosu::ImmutableColor.new(0xff_ffffff)
+    AQUA    = Gosu::ImmutableColor.new(0xff_00ffff)
+    RED     = Gosu::ImmutableColor.new(0xff_ff0000)
+    GREEN   = Gosu::ImmutableColor.new(0xff_00ff00)
+    BLUE    = Gosu::ImmutableColor.new(0xff_0000ff)
+    YELLOW  = Gosu::ImmutableColor.new(0xff_ffff00)
+    FUCHSIA = Gosu::ImmutableColor.new(0xff_ff00ff)
+    CYAN    = Gosu::ImmutableColor.new(0xff_00ffff)
+
+    alias_method :hash, :gl
+    def eql?(other)
+      gl == other.gl
+    end
+  end
+end
+
+class Gosu::Window
+  # Call Thread.pass every tick, which may or may not be necessary for friendly co-existence with
+  # Ruby's Thread class.
+
+  alias_method :_tick, :tick
+
+  def tick
+    Thread.pass
+    _tick
+  end
+end

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -1,0 +1,108 @@
+# SDL2 FFI bindings used by Gosu::Window / Gosu.draw_* to drive a real
+# window + event loop under monoruby. Only the subset of libSDL2-2.0
+# actually needed is bound; we avoid pulling in SDL2_image / SDL2_ttf
+# / SDL2_mixer until image / font / audio support is added.
+#
+# The bindings are intentionally Ruby-style (snake_case) because
+# monoruby's constant vs method lookup rules clash with uppercase
+# `SDL_*` names; module callers do `Gosu::SDL2.init(...)` rather than
+# `SDL2::SDL_Init(...)`.
+
+require "ffi"
+
+module Gosu
+  module SDL2
+    extend FFI::Library
+    ffi_lib "libSDL2-2.0.so.0"
+
+    # --- SDL_Init flags -------------------------------------------------
+    INIT_TIMER          = 0x00000001
+    INIT_AUDIO          = 0x00000010
+    INIT_VIDEO          = 0x00000020
+    INIT_JOYSTICK       = 0x00000200
+    INIT_HAPTIC         = 0x00001000
+    INIT_GAMECONTROLLER = 0x00002000
+    INIT_EVENTS         = 0x00004000
+    INIT_EVERYTHING     = INIT_TIMER | INIT_AUDIO | INIT_VIDEO |
+                          INIT_EVENTS | INIT_JOYSTICK | INIT_HAPTIC |
+                          INIT_GAMECONTROLLER
+
+    # --- Window flags ---------------------------------------------------
+    WINDOW_FULLSCREEN         = 0x00000001
+    WINDOW_OPENGL             = 0x00000002
+    WINDOW_SHOWN              = 0x00000004
+    WINDOW_HIDDEN             = 0x00000008
+    WINDOW_BORDERLESS         = 0x00000010
+    WINDOW_RESIZABLE          = 0x00000020
+    WINDOW_FULLSCREEN_DESKTOP = 0x00001001
+    WINDOWPOS_CENTERED        = 0x2FFF0000
+
+    # --- Renderer flags -------------------------------------------------
+    RENDERER_SOFTWARE     = 0x00000001
+    RENDERER_ACCELERATED  = 0x00000002
+    RENDERER_PRESENTVSYNC = 0x00000004
+    RENDERER_TARGETTEXTURE = 0x00000008
+
+    # --- Event types ----------------------------------------------------
+    EVENT_QUIT          = 0x100
+    EVENT_WINDOW        = 0x200
+    EVENT_KEYDOWN       = 0x300
+    EVENT_KEYUP         = 0x301
+    EVENT_MOUSEMOTION   = 0x400
+    EVENT_MOUSEBUTTONDOWN = 0x401
+    EVENT_MOUSEBUTTONUP   = 0x402
+    EVENT_MOUSEWHEEL      = 0x403
+    EVENT_CONTROLLERBUTTONDOWN = 0x650
+    EVENT_CONTROLLERBUTTONUP   = 0x651
+    EVENT_TEXTINPUT = 0x303
+
+    # --- Core -----------------------------------------------------------
+    attach_function :init,             :SDL_Init,             [:uint32], :int
+    attach_function :init_sub_system,  :SDL_InitSubSystem,    [:uint32], :int
+    attach_function :quit,             :SDL_Quit,             [], :void
+    attach_function :get_error,        :SDL_GetError,         [], :string
+    attach_function :get_ticks,        :SDL_GetTicks,         [], :uint32
+    attach_function :delay,            :SDL_Delay,            [:uint32], :void
+
+    # --- Window / Renderer ---------------------------------------------
+    attach_function :create_window,       :SDL_CreateWindow,
+      [:string, :int, :int, :int, :int, :uint32], :pointer
+    attach_function :destroy_window,      :SDL_DestroyWindow,    [:pointer], :void
+    attach_function :set_window_title,    :SDL_SetWindowTitle,   [:pointer, :string], :void
+    attach_function :set_window_size,     :SDL_SetWindowSize,    [:pointer, :int, :int], :void
+    attach_function :create_renderer,     :SDL_CreateRenderer,
+      [:pointer, :int, :uint32], :pointer
+    attach_function :destroy_renderer,    :SDL_DestroyRenderer,  [:pointer], :void
+    attach_function :set_draw_color,      :SDL_SetRenderDrawColor,
+      [:pointer, :uint8, :uint8, :uint8, :uint8], :int
+    attach_function :set_draw_blend_mode, :SDL_SetRenderDrawBlendMode,
+      [:pointer, :int], :int
+    attach_function :render_clear,        :SDL_RenderClear,      [:pointer], :int
+    attach_function :render_present,      :SDL_RenderPresent,    [:pointer], :void
+    attach_function :render_fill_rect,    :SDL_RenderFillRect,   [:pointer, :pointer], :int
+    attach_function :render_draw_line,    :SDL_RenderDrawLine,
+      [:pointer, :int, :int, :int, :int], :int
+    attach_function :render_draw_point,   :SDL_RenderDrawPoint,  [:pointer, :int, :int], :int
+    attach_function :render_set_clip_rect,:SDL_RenderSetClipRect,[:pointer, :pointer], :int
+
+    # --- Event pump -----------------------------------------------------
+    # SDL_Event is a 56-byte union on x86_64. We stash it in a
+    # MemoryPointer and pull fields out by byte offset (see
+    # Gosu::Window#_pump_events below) rather than mapping the full
+    # union, which keeps this binding small and avoids FFI::Union
+    # quirks.
+    EVENT_SIZE = 56
+    attach_function :poll_event,  :SDL_PollEvent,  [:pointer], :int
+    attach_function :wait_event,  :SDL_WaitEvent,  [:pointer], :int
+    attach_function :get_mouse_state, :SDL_GetMouseState, [:pointer, :pointer], :uint32
+    attach_function :get_keyboard_state, :SDL_GetKeyboardState, [:pointer], :pointer
+
+    # --- Small helper: a 4-int Rect we reuse for draw_rect / clip_to ---
+    class Rect < FFI::Struct
+      layout :x, :int32,
+             :y, :int32,
+             :w, :int32,
+             :h, :int32
+    end
+  end
+end

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -141,6 +141,43 @@ module Gosu
       layout :x, :int32,
              :y, :int32
     end
+
+    # --- Float point / rect / vertex used by transformed drawing ---
+    class FPoint < FFI::Struct
+      layout :x, :float,
+             :y, :float
+    end
+
+    class FRect < FFI::Struct
+      layout :x, :float,
+             :y, :float,
+             :w, :float,
+             :h, :float
+    end
+
+    # SDL_Vertex: { SDL_FPoint position; SDL_Color color; SDL_FPoint tex_coord; }
+    # 20 bytes total (2 floats + 4 bytes + 2 floats).
+    class Vertex < FFI::Struct
+      layout :pos_x,  :float,
+             :pos_y,  :float,
+             :r,      :uint8,
+             :g,      :uint8,
+             :b,      :uint8,
+             :a,      :uint8,
+             :uv_x,   :float,
+             :uv_y,   :float
+    end
+
+    attach_function :render_draw_line_f,    :SDL_RenderDrawLineF,
+      [:pointer, :float, :float, :float, :float], :int
+    attach_function :render_fill_rect_f,    :SDL_RenderFillRectF,
+      [:pointer, :pointer], :int
+    attach_function :render_copy_f,         :SDL_RenderCopyF,
+      [:pointer, :pointer, :pointer, :pointer], :int
+    attach_function :render_copy_ex_f,      :SDL_RenderCopyExF,
+      [:pointer, :pointer, :pointer, :pointer, :double, :pointer, :int], :int
+    attach_function :render_geometry,       :SDL_RenderGeometry,
+      [:pointer, :pointer, :pointer, :int, :pointer, :int], :int
   end
 
   # ----------------------------------------------------------------------

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -52,9 +52,12 @@ module Gosu
     EVENT_MOUSEBUTTONDOWN = 0x401
     EVENT_MOUSEBUTTONUP   = 0x402
     EVENT_MOUSEWHEEL      = 0x403
-    EVENT_CONTROLLERBUTTONDOWN = 0x650
-    EVENT_CONTROLLERBUTTONUP   = 0x651
-    EVENT_TEXTINPUT = 0x303
+    EVENT_CONTROLLERAXISMOTION    = 0x650
+    EVENT_CONTROLLERBUTTONDOWN    = 0x651
+    EVENT_CONTROLLERBUTTONUP      = 0x652
+    EVENT_CONTROLLERDEVICEADDED   = 0x653
+    EVENT_CONTROLLERDEVICEREMOVED = 0x654
+    EVENT_TEXTINPUT               = 0x303
 
     # --- Core -----------------------------------------------------------
     attach_function :init,             :SDL_Init,             [:uint32], :int
@@ -178,6 +181,28 @@ module Gosu
       [:pointer, :pointer, :pointer, :pointer, :double, :pointer, :int], :int
     attach_function :render_geometry,       :SDL_RenderGeometry,
       [:pointer, :pointer, :pointer, :int, :pointer, :int], :int
+
+    # --- Game controller / joystick ------------------------------------
+    # `SDL_NumJoysticks` gives the total attached joystick count;
+    # `SDL_IsGameController(index)` tells whether a given slot has a
+    # GameController mapping (so it can be opened via
+    # `SDL_GameControllerOpen`). Buttons 0..14 map to SDL's standard
+    # layout (A, B, X, Y, Back, Guide, Start, LStick, RStick,
+    # LShoulder, RShoulder, DPadUp, DPadDown, DPadLeft, DPadRight);
+    # axes 0..5 cover the two analog sticks and the two triggers.
+    attach_function :num_joysticks,             :SDL_NumJoysticks,        [], :int
+    attach_function :is_game_controller,        :SDL_IsGameController,    [:int], :int
+    attach_function :game_controller_open,      :SDL_GameControllerOpen,  [:int], :pointer
+    attach_function :game_controller_close,     :SDL_GameControllerClose, [:pointer], :void
+    attach_function :game_controller_get_attached, :SDL_GameControllerGetAttached,
+      [:pointer], :int
+    attach_function :game_controller_get_button, :SDL_GameControllerGetButton,
+      [:pointer, :int], :uint8
+    attach_function :game_controller_get_axis,   :SDL_GameControllerGetAxis,
+      [:pointer, :int], :int16
+    attach_function :game_controller_get_joystick, :SDL_GameControllerGetJoystick,
+      [:pointer], :pointer
+    attach_function :joystick_instance_id,       :SDL_JoystickInstanceID,  [:pointer], :int32
   end
 
   # ----------------------------------------------------------------------

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -97,6 +97,19 @@ module Gosu
       [:pointer], :void
     attach_function :create_texture_from_surface, :SDL_CreateTextureFromSurface,
       [:pointer, :pointer], :pointer
+    attach_function :create_rgb_surface_with_format,
+      :SDL_CreateRGBSurfaceWithFormat,
+      [:uint32, :int, :int, :int, :uint32], :pointer
+    attach_function :convert_surface_format,  :SDL_ConvertSurfaceFormat,
+      [:pointer, :uint32, :uint32], :pointer
+    attach_function :lock_surface,            :SDL_LockSurface,
+      [:pointer], :int
+    attach_function :unlock_surface,          :SDL_UnlockSurface,
+      [:pointer], :void
+
+    # SDL_PIXELFORMAT_ABGR8888: four bytes in memory order R, G, B, A.
+    # This matches Gosu's to_blob / from_blob convention.
+    PIXELFORMAT_ABGR8888 = 0x16762004
     attach_function :destroy_texture,         :SDL_DestroyTexture,
       [:pointer], :void
     attach_function :query_texture,           :SDL_QueryTexture,
@@ -115,9 +128,10 @@ module Gosu
     # SDL_Surface starts with `Uint32 flags; SDL_PixelFormat *format;
     # int w; int h; int pitch;` — we only need w/h/pitch, which sit at
     # offsets 16/20/24 on x86_64.
-    SURFACE_W_OFFSET     = 16
-    SURFACE_H_OFFSET     = 20
-    SURFACE_PITCH_OFFSET = 24
+    SURFACE_W_OFFSET      = 16
+    SURFACE_H_OFFSET      = 20
+    SURFACE_PITCH_OFFSET  = 24
+    SURFACE_PIXELS_OFFSET = 32
 
     # --- Event pump -----------------------------------------------------
     # SDL_Event is a 56-byte union on x86_64. We stash it in a

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -227,4 +227,40 @@ module Gosu
       Gosu::SDL2.get_error
     end
   end
+
+  # ----------------------------------------------------------------------
+  # SDL2_ttf bindings -- loaded lazily on first `Gosu::Font.new` /
+  # `Gosu::Image.from_text`. `TTF_Init` is called once per process and
+  # cleaned up in `at_exit`.
+  # ----------------------------------------------------------------------
+  module SDL2_ttf
+    extend FFI::Library
+    ffi_lib "libSDL2_ttf-2.0.so.0"
+
+    # SDL_Color in big-endian order: r, g, b, a.
+    class Color < FFI::Struct
+      layout :r, :uint8,
+             :g, :uint8,
+             :b, :uint8,
+             :a, :uint8
+    end
+
+    attach_function :ttf_init,              :TTF_Init,              [], :int
+    attach_function :ttf_quit,              :TTF_Quit,              [], :void
+    attach_function :ttf_open_font,         :TTF_OpenFont,          [:string, :int], :pointer
+    attach_function :ttf_close_font,        :TTF_CloseFont,         [:pointer], :void
+    attach_function :ttf_render_utf8_blended, :TTF_RenderUTF8_Blended,
+      [:pointer, :string, :uint32], :pointer
+    # NOTE: SDL_Color is a 4-byte struct that libTTF expects by value.
+    # FFI's `:uint32` ABI-matches the little-endian byte layout
+    # `r | (g<<8) | (b<<16) | (a<<24)`.
+    attach_function :ttf_size_utf8,         :TTF_SizeUTF8,
+      [:pointer, :string, :pointer, :pointer], :int
+    attach_function :ttf_font_height,       :TTF_FontHeight,        [:pointer], :int
+    attach_function :ttf_font_ascent,       :TTF_FontAscent,        [:pointer], :int
+
+    def self.ttf_get_error
+      Gosu::SDL2.get_error
+    end
+  end
 end

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -203,6 +203,11 @@ module Gosu
     attach_function :game_controller_get_joystick, :SDL_GameControllerGetJoystick,
       [:pointer], :pointer
     attach_function :joystick_instance_id,       :SDL_JoystickInstanceID,  [:pointer], :int32
+
+    # --- Text input -----------------------------------------------------
+    attach_function :start_text_input,  :SDL_StartTextInput,  [], :void
+    attach_function :stop_text_input,   :SDL_StopTextInput,   [], :void
+    attach_function :is_text_input_active, :SDL_IsTextInputActive, [], :int
   end
 
   # ----------------------------------------------------------------------

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -85,6 +85,37 @@ module Gosu
     attach_function :render_draw_point,   :SDL_RenderDrawPoint,  [:pointer, :int, :int], :int
     attach_function :render_set_clip_rect,:SDL_RenderSetClipRect,[:pointer, :pointer], :int
 
+    # --- Surface / Texture ---------------------------------------------
+    SDL_FLIP_NONE       = 0x00000000
+    SDL_FLIP_HORIZONTAL = 0x00000001
+    SDL_FLIP_VERTICAL   = 0x00000002
+
+    attach_function :free_surface,            :SDL_FreeSurface,
+      [:pointer], :void
+    attach_function :create_texture_from_surface, :SDL_CreateTextureFromSurface,
+      [:pointer, :pointer], :pointer
+    attach_function :destroy_texture,         :SDL_DestroyTexture,
+      [:pointer], :void
+    attach_function :query_texture,           :SDL_QueryTexture,
+      [:pointer, :pointer, :pointer, :pointer, :pointer], :int
+    attach_function :set_texture_color_mod,   :SDL_SetTextureColorMod,
+      [:pointer, :uint8, :uint8, :uint8], :int
+    attach_function :set_texture_alpha_mod,   :SDL_SetTextureAlphaMod,
+      [:pointer, :uint8], :int
+    attach_function :set_texture_blend_mode,  :SDL_SetTextureBlendMode,
+      [:pointer, :int], :int
+    attach_function :render_copy,             :SDL_RenderCopy,
+      [:pointer, :pointer, :pointer, :pointer], :int
+    attach_function :render_copy_ex,          :SDL_RenderCopyEx,
+      [:pointer, :pointer, :pointer, :pointer, :double, :pointer, :int], :int
+
+    # SDL_Surface starts with `Uint32 flags; SDL_PixelFormat *format;
+    # int w; int h; int pitch;` — we only need w/h/pitch, which sit at
+    # offsets 16/20/24 on x86_64.
+    SURFACE_W_OFFSET     = 16
+    SURFACE_H_OFFSET     = 20
+    SURFACE_PITCH_OFFSET = 24
+
     # --- Event pump -----------------------------------------------------
     # SDL_Event is a 56-byte union on x86_64. We stash it in a
     # MemoryPointer and pull fields out by byte offset (see
@@ -103,6 +134,97 @@ module Gosu
              :y, :int32,
              :w, :int32,
              :h, :int32
+    end
+
+    # --- 2-int Point used by SDL_RenderCopyEx for the rotation center ---
+    class Point < FFI::Struct
+      layout :x, :int32,
+             :y, :int32
+    end
+  end
+
+  # ----------------------------------------------------------------------
+  # SDL2_image bindings -- loaded lazily on first `Gosu::Image.new(path)`
+  # so monoruby installs without libSDL2_image present can still
+  # `require "gosu"`.
+  # ----------------------------------------------------------------------
+  module SDL2_image
+    extend FFI::Library
+    ffi_lib "libSDL2_image-2.0.so.0"
+
+    INIT_JPG  = 0x01
+    INIT_PNG  = 0x02
+    INIT_TIF  = 0x04
+    INIT_WEBP = 0x08
+    INIT_DEFAULT = INIT_JPG | INIT_PNG | INIT_TIF | INIT_WEBP
+
+    attach_function :img_init,  :IMG_Init,    [:int], :int
+    attach_function :img_quit,  :IMG_Quit,    [], :void
+    attach_function :img_load,  :IMG_Load,    [:string], :pointer
+
+    # SDL2_image 2.x routes errors through SDL_GetError (it's a #define
+    # in SDL_image.h), so use the core SDL function rather than a
+    # non-existent IMG_GetError symbol.
+    def self.img_get_error
+      Gosu::SDL2.get_error
+    end
+  end
+
+  # ----------------------------------------------------------------------
+  # SDL2_mixer bindings -- loaded lazily on first
+  # `Gosu::Sample.new` / `Gosu::Song.new`. Audio init happens on demand
+  # so windowed-only programs don't open an audio device.
+  # ----------------------------------------------------------------------
+  module SDL2_mixer
+    extend FFI::Library
+    ffi_lib "libSDL2_mixer-2.0.so.0"
+
+    INIT_FLAC = 0x01
+    INIT_MOD  = 0x02
+    INIT_MP3  = 0x08
+    INIT_OGG  = 0x10
+    INIT_MID  = 0x20
+    INIT_OPUS = 0x40
+
+    DEFAULT_FREQUENCY = 44100
+    AUDIO_S16LSB      = 0x8010
+    DEFAULT_CHANNELS  = 2
+    DEFAULT_CHUNKSIZE = 1024
+
+    attach_function :mix_init,           :Mix_Init,           [:int], :int
+    attach_function :mix_quit,           :Mix_Quit,           [], :void
+    attach_function :mix_open_audio,     :Mix_OpenAudio,
+      [:int, :uint16, :int, :int], :int
+    attach_function :mix_close_audio,    :Mix_CloseAudio,     [], :void
+    attach_function :mix_allocate_channels, :Mix_AllocateChannels, [:int], :int
+
+    attach_function :mix_load_wav,       :Mix_LoadWAV,        [:string], :pointer
+    attach_function :mix_free_chunk,     :Mix_FreeChunk,      [:pointer], :void
+    attach_function :mix_play_channel,   :Mix_PlayChannel,
+      [:int, :pointer, :int], :int
+    attach_function :mix_volume,         :Mix_Volume,         [:int, :int], :int
+    attach_function :mix_volume_chunk,   :Mix_VolumeChunk,    [:pointer, :int], :int
+    attach_function :mix_halt_channel,   :Mix_HaltChannel,    [:int], :int
+    attach_function :mix_pause,          :Mix_Pause,          [:int], :void
+    attach_function :mix_resume,         :Mix_Resume,         [:int], :void
+    attach_function :mix_paused,         :Mix_Paused,         [:int], :int
+    attach_function :mix_playing,        :Mix_Playing,        [:int], :int
+    attach_function :mix_set_panning,    :Mix_SetPanning,
+      [:int, :uint8, :uint8], :int
+
+    attach_function :mix_load_mus,       :Mix_LoadMUS,        [:string], :pointer
+    attach_function :mix_free_music,     :Mix_FreeMusic,      [:pointer], :void
+    attach_function :mix_play_music,     :Mix_PlayMusic,      [:pointer, :int], :int
+    attach_function :mix_halt_music,     :Mix_HaltMusic,      [], :int
+    attach_function :mix_pause_music,    :Mix_PauseMusic,     [], :void
+    attach_function :mix_resume_music,   :Mix_ResumeMusic,    [], :void
+    attach_function :mix_paused_music,   :Mix_PausedMusic,    [], :int
+    attach_function :mix_playing_music,  :Mix_PlayingMusic,   [], :int
+    attach_function :mix_volume_music,   :Mix_VolumeMusic,    [:int], :int
+
+    # Errors flow through SDL_GetError (Mix_GetError is a #define).
+    def self.mix_get_error
+      Gosu::SDL2.get_error
     end
   end
 end

--- a/monoruby/gem/gosu/swig_patches.rb
+++ b/monoruby/gem/gosu/swig_patches.rb
@@ -1,0 +1,110 @@
+# Exceptions in Window callbacks often get lost, this is especially annoying in draw/update.
+# It is not clear whether this is a SWIG issue or if some stack frame is not exception
+# compatible, but I just call protected_update etc. in the Ruby wrapper so I can add this
+# custom debugging help:
+class Gosu::Window
+  alias_method :initialize_with_bitmask, :initialize
+
+  def initialize(width, height, *args)
+    $gosu_gl_blocks = nil
+
+    if args.first.is_a? Hash
+      flags = 0
+      flags |= 1 if args.first[:fullscreen]
+      flags |= 2 if args.first[:resizable]
+      flags |= 4 if args.first[:borderless]
+      initialize_with_bitmask(width, height, flags, args.first[:update_interval] || 16.666666)
+    else
+      initialize_with_bitmask(width, height, args[0] ? 1 : 0, args[1] || 16.666666)
+    end
+  end
+
+  %w(update draw needs_redraw? needs_cursor?
+     gain_focus lose_focus button_down button_up
+     gamepad_connected gamepad_disconnected drop).each do |callback|
+    define_method("protected_#{callback}") do |*args|
+      begin
+        # If there has been an exception, don't do anything as to not make matters worse.
+        # Conveniently turn the return value into a boolean result (for needs_cursor? etc).
+        defined?(@_exception) ? false : !!send(callback, *args)
+      rescue Exception => e
+        # Exit the message loop naturally, then re-throw during the next tick.
+        @_exception = e
+        close!
+        false
+      end
+    end
+  end
+
+  def protected_draw_2
+    protected_draw
+    $gosu_gl_blocks_2 = $gosu_gl_blocks
+    $gosu_gl_blocks = nil
+  end
+
+  alias_method :show_internal, :show
+  def show
+    show_internal
+    # Try to format the message nicely, without any useless patching that we are
+    # doing here.
+    if defined? @_exception
+      if @_exception.backtrace.is_a? Array and not @_exception.backtrace.frozen?
+        @_exception.backtrace.reject! { |line| line.include? "lib/gosu/swig_patches.rb" }
+      end
+      raise @_exception
+    end
+  end
+
+  alias_method :tick_internal, :tick
+  def tick
+    value = tick_internal
+    # Try to format the message nicely, without any useless patching that we are
+    # doing here.
+    if defined? @_exception
+      if @_exception.backtrace.is_a? Array and not @_exception.backtrace.frozen?
+        @_exception.backtrace.reject! { |line| line.include? "lib/gosu/swig_patches.rb" }
+      end
+      raise @_exception
+    end
+
+    value
+  end
+end
+
+module Gosu
+  # Keep a reference to these blocks that is only cleared after Window#draw.
+  # Otherwise, the GC might free these blocks while Gosu is still rendering.
+  def self.gl(z = nil, &block)
+    $gosu_gl_blocks ||= []
+    $gosu_gl_blocks << block
+    if z.nil?
+      unsafe_gl(&block)
+    else
+      unsafe_gl(z, &block)
+    end
+  end
+end
+
+# SWIG somehow maps the instance method "argb" as an overload of the class
+# method of the same name.
+class Gosu::Color
+  alias_method :initialize_without_argb, :initialize
+
+  # The (a,r,g,b) constructor overload was dropped in C++ to reduce ambiguity,
+  # adding it via %extend in gosu.i does not work, so patch it here.
+  def initialize(*args)
+    if args.size == 4
+      initialize_without_argb(args[1], args[2], args[3])
+      self.alpha = args[0]
+    else
+      initialize_without_argb(*args)
+    end
+  end
+
+  alias_method :argb, :to_i
+end
+
+# SWIG will not let me rename my method to '[]=', so use alias_method here.
+class Gosu::Font
+  alias_method :[]=, :set_image
+end

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -104,6 +104,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.set_constant_by_str(OBJECT_CLASS, "ENV", env);
     globals.define_builtin_singleton_func_with(env, "fetch", fetch, 1, 2, false);
     globals.define_builtin_singleton_func(env, "[]", env_index, 1);
+    globals.define_builtin_singleton_func(env, "[]=", env_index_assign, 2);
+    globals.define_builtin_singleton_func(env, "store", env_index_assign, 2);
+    globals.define_builtin_singleton_func(env, "delete", env_delete, 1);
     globals.define_builtin_singleton_func(env, "to_hash", env_to_hash, 0);
 }
 
@@ -1269,6 +1272,120 @@ fn env_to_hash(
     Ok(lfp.self_val())
 }
 
+/// Coerce a `Value` into an owned `String` for use as an environment variable
+/// name or value. Non-String values that do not respond to `to_str` raise a
+/// `TypeError`; strings that contain an embedded NUL byte raise an
+/// `ArgumentError`, matching CRuby's `ENV` semantics.
+fn coerce_env_string(
+    v: Value,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Result<String> {
+    let s = if v.is_str().is_some() {
+        v.expect_string(&globals.store)?
+    } else {
+        v.coerce_to_str(vm, globals)?
+    };
+    if s.as_bytes().contains(&0) {
+        return Err(MonorubyErr::argumenterr("bare \\0 in env"));
+    }
+    Ok(s)
+}
+
+/// ### ENV.[]=
+/// - self[key] = value
+/// - store(key, value) -> value
+///
+/// Sets an environment variable. `value = nil` deletes the variable.
+/// Updates both the Ruby-visible hash and libc's `environ` via
+/// `setenv(3)` / `unsetenv(3)` so that FFI callers (e.g. `getenv(3)`)
+/// observe the change.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/=5b=5d=3d.html]
+#[monoruby_builtin]
+fn env_index_assign(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    let key_val = lfp.arg(0);
+    let value_val = lfp.arg(1);
+
+    let key = coerce_env_string(key_val, vm, globals)?;
+
+    if value_val.is_nil() {
+        // Delete the variable from both the hash and libc's environ.
+        let key_v = Value::string(key.clone());
+        lfp.self_val().as_hash().remove(key_v, vm, globals)?;
+        let c_key = std::ffi::CString::new(key.as_bytes())
+            .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+        // SAFETY: `c_key` is a NUL-terminated C string whose storage
+        // outlives this call. `unsetenv` is thread-safe on Linux.
+        unsafe {
+            libc::unsetenv(c_key.as_ptr());
+        }
+        return Ok(Value::nil());
+    }
+
+    let value = coerce_env_string(value_val, vm, globals)?;
+
+    let c_key = std::ffi::CString::new(key.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    let c_val = std::ffi::CString::new(value.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    // SAFETY: both pointers reference NUL-terminated C strings whose
+    // storage outlives this call. `setenv` copies its arguments.
+    unsafe {
+        libc::setenv(c_key.as_ptr(), c_val.as_ptr(), 1);
+    }
+
+    let key_v = Value::string(key);
+    let val_v = Value::string(value);
+    lfp.self_val()
+        .as_hash()
+        .insert(key_v, val_v, vm, globals)?;
+    Ok(val_v)
+}
+
+/// ### ENV.delete
+/// - delete(key) -> String | nil
+/// - delete(key) {|key| ... } -> object
+///
+/// Removes an environment variable from both the Ruby-visible hash and
+/// libc's `environ` (via `unsetenv(3)`).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/delete.html]
+#[monoruby_builtin]
+fn env_delete(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    let key_val = lfp.arg(0);
+    let key = coerce_env_string(key_val, vm, globals)?;
+    let key_v = Value::string(key.clone());
+    let removed = lfp.self_val().as_hash().remove(key_v, vm, globals)?;
+
+    let c_key = std::ffi::CString::new(key.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    // SAFETY: `c_key` is a NUL-terminated C string whose storage outlives
+    // this call. `unsetenv` is a no-op if the variable is not set.
+    unsafe {
+        libc::unsetenv(c_key.as_ptr());
+    }
+
+    if removed.is_none()
+        && let Some(bh) = lfp.block()
+    {
+        return vm.invoke_block_once(globals, bh, &[key_v]);
+    }
+    Ok(removed.unwrap_or_default())
+}
+
 ///
 /// ### Hash#fetch
 ///
@@ -1699,6 +1816,101 @@ mod tests {
         run_test(r##"ENV.fetch("XZCDEWS", "ABC")"##);
         run_test(r##"ENV.fetch("XZCDEWS") {|key| key + "先生"}"##);
         run_test_error(r##"ENV[100]"##);
+    }
+
+    #[test]
+    fn env_index_assign_updates_hash() {
+        // Assignment is visible via ENV[]
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_BASIC"] = "hello"
+            v = ENV["MONORUBY_ENV_TEST_BASIC"]
+            ENV["MONORUBY_ENV_TEST_BASIC"] = nil
+            [v, ENV["MONORUBY_ENV_TEST_BASIC"]]
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_index_assign_delete_via_nil() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_DEL"] = "x"
+            before = ENV["MONORUBY_ENV_TEST_DEL"]
+            ENV["MONORUBY_ENV_TEST_DEL"] = nil
+            [before, ENV["MONORUBY_ENV_TEST_DEL"]]
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_delete_method() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_DEL2"] = "y"
+            a = ENV.delete("MONORUBY_ENV_TEST_DEL2")
+            b = ENV.delete("MONORUBY_ENV_TEST_DEL2")
+            c = ENV.delete("MONORUBY_ENV_TEST_DEL2") {|k| k + "!missing"}
+            [a, b, c]
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_index_assign_type_errors() {
+        run_test_error(r##"ENV[100] = "x""##);
+        run_test_error(r##"ENV["MONORUBY_ENV_TEST_BAD"] = 100"##);
+    }
+
+    #[test]
+    fn env_index_assign_embedded_nul() {
+        run_test_error(r##"ENV["A\0B"] = "x""##);
+        run_test_error(r##"ENV["MONORUBY_ENV_TEST_NUL"] = "a\0b""##);
+    }
+
+    /// Verify that `ENV[]=` propagates to libc's `environ`, so that FFI
+    /// callers of `getenv(3)` observe the value. This is what was
+    /// previously broken.
+    #[test]
+    fn env_assign_propagates_to_libc_setenv() {
+        use std::ffi::{CStr, CString};
+        let key = "MONORUBY_ENV_TEST_LIBC_PROP";
+        let c_key = CString::new(key).unwrap();
+        // Make sure the variable is not present before the test runs.
+        unsafe { libc::unsetenv(c_key.as_ptr()) };
+
+        // Run a short Ruby script that sets the variable via `ENV[]=`.
+        let mut globals = crate::Globals::new_test();
+        let src = format!(r#"ENV["{key}"] = "hello""#);
+        let _ = globals.run(src, std::path::Path::new("(test)"));
+
+        // libc `getenv` should now see "hello".
+        let got = unsafe { libc::getenv(c_key.as_ptr()) };
+        assert!(!got.is_null(), "getenv returned NULL after ENV[]=");
+        let s = unsafe { CStr::from_ptr(got) }.to_str().unwrap();
+        assert_eq!(s, "hello");
+
+        // ENV[] = nil should remove it from libc as well.
+        let src = format!(r#"ENV["{key}"] = nil"#);
+        let _ = globals.run(src, std::path::Path::new("(test)"));
+        let got = unsafe { libc::getenv(c_key.as_ptr()) };
+        assert!(got.is_null(), "getenv should return NULL after ENV[]=nil");
+    }
+
+    #[test]
+    fn env_delete_propagates_to_libc_unsetenv() {
+        use std::ffi::CString;
+        let key = "MONORUBY_ENV_TEST_LIBC_DEL";
+        let c_key = CString::new(key).unwrap();
+        unsafe { libc::unsetenv(c_key.as_ptr()) };
+
+        let mut globals = crate::Globals::new_test();
+        let src = format!(
+            r#"ENV["{key}"] = "bye"; ENV.delete("{key}")"#
+        );
+        let _ = globals.run(src, std::path::Path::new("(test)"));
+        let got = unsafe { libc::getenv(c_key.as_ptr()) };
+        assert!(got.is_null(), "getenv should return NULL after ENV.delete");
     }
 
     #[test]


### PR DESCRIPTION
The `gosu` gem ships a C extension (`gosu.so`) that monoruby cannot
load. Replace it with a pure-Ruby shim under `monoruby/gem/gosu.rb`
plus vendored copies of the gem's pure-Ruby helpers so programs
using the gem at least load, parse, and build their classes without
raising `LoadError`.

Scope:

- Provides the full public API surface of gosu 1.4.6:
  - `Gosu` module with every `KB_*` / `MS_*` / `GP_*` button
    constant, `VERSION`, `POINT_VERSION`, `MAJOR/MINOR_VERSION`,
    `MAX_TEXTURE_SIZE`, and `LICENSES`.
  - Classes: `Color` (with HSV helpers, `to_i`/`argb`/`abgr`/`gl`,
    and `rgb`/`rgba`/`argb`/`from_hsv`/`from_ahsv` factories),
    `Window` (accessors, fullscreen/resizable/borderless flags,
    all documented callbacks as no-ops), `Image`, `Font`, `Sample`,
    `Song`, `Channel`, `TextInput`, `GLTexInfo`.
  - Module methods: drawing primitives, transforms, fps/timing,
    distance/angle math, button/axis queries, language/clipboard
    helpers, and the `disown_*` stubs expected by swig_patches.
- Ships the gem's pure-Ruby helpers verbatim under
  `monoruby/gem/gosu/{swig_patches,patches,compat}.rb` so calls
  like `Gosu::Color::WHITE`, `Gosu::KbSpace`, `42.degrees_to_radians`,
  and `Gosu.deprecate` all work out of the box. The only edits
  vs upstream are two `define_method name do ... end` sites
  rewritten as `define_method(name) do ... end` (monoruby's
  parser binds `do` to the method chain `name.to_sym` otherwise).
- `Window#show` is a no-op so programs that `MyGame.new.show`
  return immediately rather than hanging without a real event
  loop. Drawing / audio / input are all no-ops.

Smoke test:

    require "gosu"
    class G < Gosu::Window
      def initialize
        super(320, 240); self.caption = "Hi"
      end
    end
    g = G.new
    p [g.width, g.height, g.caption, Gosu::KbSpace,
       Gosu::Color::WHITE.red]
    g.show  # returns immediately

Everything parses, constructs, and runs to completion. This is a
compatibility shim only -- running an actual Gosu game (with a
window, audio, input) still needs a real SDL2-backed backend;
that's out of scope for this change.

`cargo test --release --lib` unchanged (1184 pass; 3 pre-existing
Ruby-version-specific / flaky failures).