### PR TITLE
ENV / Exception: ruby/spec compliance for assoc, merge!, replace, ==, set_backtrace, exception, etc.

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -487,7 +487,9 @@ ConditionVariable = Thread::ConditionVariable
 
 class Exception
   def backtrace_locations
-    backtrace.map do |frame|
+    bt = backtrace
+    return nil if bt.nil?
+    bt.map do |frame|
       Thread::Backtrace::Location.new(frame)
     end
   end

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -89,6 +89,15 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(EXCEPTION_CLASS, "backtrace", backtrace, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "set_backtrace", set_backtrace, 1);
     globals.define_builtin_func(EXCEPTION_CLASS, "cause", cause, 0);
+    globals.define_builtin_func(EXCEPTION_CLASS, "==", exception_eq, 1);
+    globals.define_builtin_func_with(
+        EXCEPTION_CLASS,
+        "exception",
+        exception_method,
+        0,
+        1,
+        false,
+    );
 }
 
 /// ### NoMethodError#receiver
@@ -215,38 +224,138 @@ fn message(_vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 ///
 /// - backtrace -> [String]
 ///
+/// Returns the backtrace explicitly set via `#set_backtrace` if any;
+/// otherwise the trace captured when the exception was raised.
+///
 /// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/backtrace.html]
 #[monoruby_builtin]
 fn backtrace(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let iter = self_
-        .is_exception()
-        .unwrap()
-        .trace_location(globals)
-        .into_iter()
-        .map(|s| Value::string(s));
-    Ok(Value::array_from_iter(iter))
+    if let Some(bt) = globals.store.get_ivar(self_, IdentId::get_id("/backtrace")) {
+        return Ok(bt);
+    }
+    let traces: Vec<String> = self_.is_exception().unwrap().trace_location(globals);
+    if traces.is_empty() {
+        // Exception was constructed (e.g. `Exception.new`) but never
+        // raised, so there is no backtrace to report.
+        return Ok(Value::nil());
+    }
+    Ok(Value::array_from_iter(
+        traces.into_iter().map(|s| Value::string(s)),
+    ))
 }
 
 /// ### Exception#set_backtrace
 /// - set_backtrace(backtrace) -> Array
 ///
+/// Stores `backtrace` so subsequent `#backtrace` calls return it. Per
+/// CRuby: a String is wrapped in a single-element array, nil clears
+/// the stored backtrace, an Array of Strings is used as-is.
+///
 /// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/set_backtrace.html]
 #[monoruby_builtin]
 fn set_backtrace(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     let arg = lfp.arg(0);
-    if arg.is_nil() {
-        Ok(Value::nil())
+    let stored = if arg.is_nil() {
+        Value::nil()
     } else if arg.is_str().is_some() {
-        Ok(Value::array1(arg))
+        Value::array1(arg)
+    } else if let Some(ary) = arg.try_array_ty() {
+        for elem in ary.iter() {
+            if elem.is_str().is_none() {
+                return Err(MonorubyErr::typeerr(
+                    "backtrace must be an Array of String",
+                ));
+            }
+        }
+        arg
     } else {
-        Ok(arg)
+        return Err(MonorubyErr::typeerr(
+            "backtrace must be an Array of String or a String",
+        ));
+    };
+    globals
+        .store
+        .set_ivar(lfp.self_val(), IdentId::get_id("/backtrace"), stored)?;
+    Ok(stored)
+}
+
+/// ### Exception#exception
+///
+/// - exception -> self
+/// - exception(message) -> Exception
+///
+/// With no arguments (or with `self` as the argument), returns `self`.
+/// Otherwise returns a copy of `self` with `message` as the new
+/// `#message`. The copy is created via `#dup` so that subclass-defined
+/// instance variables are preserved (e.g. `CustomArgumentError#val`).
+#[monoruby_builtin]
+fn exception_method(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_v = lfp.self_val();
+    let Some(arg) = lfp.try_arg(0) else {
+        return Ok(self_v);
+    };
+    if arg.id() == self_v.id() {
+        return Ok(self_v);
     }
+    let mut new_exc = self_v.dup();
+    let msg = arg.coerce_to_string(vm, globals)?;
+    new_exc.is_exception_mut().unwrap().set_message(msg);
+    Ok(new_exc)
+}
+
+/// ### Exception#==
+///
+/// - self == other -> bool
+///
+/// Returns true when `other` is an Exception with the same class,
+/// the same `#message`, and an equal `#backtrace` (per CRuby).
+#[monoruby_builtin]
+fn exception_eq(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_v = lfp.self_val();
+    let other = lfp.arg(0);
+    if self_v.id() == other.id() {
+        return Ok(Value::bool(true));
+    }
+    let self_ex = match self_v.is_exception() {
+        Some(e) => e,
+        None => return Ok(Value::bool(false)),
+    };
+    let other_ex = match other.is_exception() {
+        Some(e) => e,
+        None => return Ok(Value::bool(false)),
+    };
+    if self_v.class() != other.class() {
+        return Ok(Value::bool(false));
+    }
+    if self_ex.message() != other_ex.message() {
+        return Ok(Value::bool(false));
+    }
+    // Compare backtraces using #backtrace (so we go through the same
+    // path users see). Both nil or both equal arrays count as equal.
+    let bt_id = IdentId::get_id("backtrace");
+    let self_bt = vm
+        .invoke_method_if_exists(globals, bt_id, self_v, &[], None, None)?
+        .unwrap_or_default();
+    let other_bt = vm
+        .invoke_method_if_exists(globals, bt_id, other, &[], None, None)?
+        .unwrap_or_default();
+    Ok(Value::bool(vm.eq_values_bool(globals, self_bt, other_bt)?))
 }
 
 /// ### KeyError#receiver

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -222,10 +222,12 @@ fn message(_vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 ///
 /// ### Exception#backtrace
 ///
-/// - backtrace -> [String]
+/// - backtrace -> [String] | nil
 ///
-/// Returns the backtrace explicitly set via `#set_backtrace` if any;
-/// otherwise the trace captured when the exception was raised.
+/// Returns the backtrace explicitly stored via `#set_backtrace` if
+/// any; otherwise the trace captured when the exception was raised.
+/// Returns `nil` for an exception that has neither been raised nor had
+/// a backtrace assigned.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/backtrace.html]
 #[monoruby_builtin]
@@ -245,12 +247,15 @@ fn backtrace(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     ))
 }
 
-/// ### Exception#set_backtrace
-/// - set_backtrace(backtrace) -> Array
 ///
-/// Stores `backtrace` so subsequent `#backtrace` calls return it. Per
-/// CRuby: a String is wrapped in a single-element array, nil clears
-/// the stored backtrace, an Array of Strings is used as-is.
+/// ### Exception#set_backtrace
+///
+/// - set_backtrace(errinfo) -> Array
+///
+/// Stores *errinfo* so subsequent `#backtrace` calls return it.
+/// A String is wrapped in a single-element Array, `nil` clears the
+/// stored backtrace, and an Array of Strings is used as-is. Anything
+/// else raises `TypeError`.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/set_backtrace.html]
 #[monoruby_builtin]
@@ -285,15 +290,18 @@ fn set_backtrace(
     Ok(stored)
 }
 
+///
 /// ### Exception#exception
 ///
 /// - exception -> self
-/// - exception(message) -> Exception
+/// - exception(error_message) -> Exception
 ///
-/// With no arguments (or with `self` as the argument), returns `self`.
-/// Otherwise returns a copy of `self` with `message` as the new
-/// `#message`. The copy is created via `#dup` so that subclass-defined
-/// instance variables are preserved (e.g. `CustomArgumentError#val`).
+/// With no arguments (or with `self` as the argument) returns `self`.
+/// Otherwise returns a copy of `self` (via `#dup`, so subclass-defined
+/// instance variables such as `CustomArgumentError#val` are preserved)
+/// with *error_message* coerced through `#to_str` as the new `#message`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/exception.html]
 #[monoruby_builtin]
 fn exception_method(
     vm: &mut Executor,
@@ -314,12 +322,15 @@ fn exception_method(
     Ok(new_exc)
 }
 
+///
 /// ### Exception#==
 ///
 /// - self == other -> bool
 ///
-/// Returns true when `other` is an Exception with the same class,
-/// the same `#message`, and an equal `#backtrace` (per CRuby).
+/// Returns `true` when *other* is an Exception of the same class with
+/// the same `#message` and an equal `#backtrace`; otherwise `false`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/=3d=3d.html]
 #[monoruby_builtin]
 fn exception_eq(
     vm: &mut Executor,
@@ -592,5 +603,194 @@ mod tests {
             end
             "#,
         );
+    }
+
+    // -- Exception#== ------------------------------------------------------
+
+    /// Identity-equal exceptions are equal.
+    #[test]
+    fn exception_eq_same_object() {
+        run_test(
+            r#"
+            e = ArgumentError.new
+            e == e
+            "#,
+        );
+    }
+
+    /// Exceptions of the same class with the same nil message and no
+    /// backtrace are equal.
+    #[test]
+    fn exception_eq_same_class_no_message() {
+        run_test(r#"RuntimeError.new == RuntimeError.new"#);
+    }
+
+    /// Exceptions of the same class with the same explicit message are
+    /// equal.
+    #[test]
+    fn exception_eq_same_class_same_message() {
+        run_test(r#"TypeError.new("message") == TypeError.new("message")"#);
+    }
+
+    /// Different classes are not equal even with the same message.
+    #[test]
+    fn exception_eq_different_class() {
+        run_test(r#"RuntimeError.new("m") == TypeError.new("m")"#);
+    }
+
+    /// Different messages, same class — not equal.
+    #[test]
+    fn exception_eq_different_message() {
+        run_test(r#"RuntimeError.new("a") == RuntimeError.new("b")"#);
+    }
+
+    /// Identical user-set backtraces produce equal exceptions.
+    #[test]
+    fn exception_eq_with_same_backtrace() {
+        run_test(
+            r#"
+            one = TypeError.new("m"); one.set_backtrace(["here.rb:1"])
+            two = TypeError.new("m"); two.set_backtrace(["here.rb:1"])
+            one == two
+            "#,
+        );
+    }
+
+    /// Differing user-set backtraces make exceptions unequal.
+    #[test]
+    fn exception_eq_with_different_backtrace() {
+        run_test(
+            r#"
+            one = RuntimeError.new("m"); one.set_backtrace(["a.rb:1"])
+            two = RuntimeError.new("m"); two.set_backtrace(["b.rb:2"])
+            one == two
+            "#,
+        );
+    }
+
+    /// Comparing an exception against a non-Exception returns false
+    /// without raising.
+    #[test]
+    fn exception_eq_against_non_exception() {
+        run_test(r#"RuntimeError.new("m") == "m""#);
+    }
+
+    // -- Exception#exception ----------------------------------------------
+
+    /// `e.exception` with no argument returns self.
+    #[test]
+    fn exception_method_no_arg_returns_self() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e.exception.equal?(e)
+            "#,
+        );
+    }
+
+    /// `e.exception(self)` returns self.
+    #[test]
+    fn exception_method_self_arg_returns_self() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e.exception(e).equal?(e)
+            "#,
+        );
+    }
+
+    /// `e.exception("new")` returns a fresh same-class exception with
+    /// the new message.
+    #[test]
+    fn exception_method_with_new_message() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e2 = e.exception("new")
+            [e2.class, e2.message, e2.equal?(e)]
+            "#,
+        );
+    }
+
+    /// `e.exception("new")` is created via #dup so subclass-defined
+    /// instance variables (here `@val`) are preserved without
+    /// re-running #initialize.
+    #[test]
+    fn exception_method_preserves_subclass_ivars() {
+        run_test(
+            r#"
+            class MonoRubyExceptionTestErr < StandardError
+              attr_reader :val
+              def initialize(val)
+                @val = val
+              end
+            end
+            e  = MonoRubyExceptionTestErr.new(:boom)
+            e2 = e.exception("new message")
+            [e2.class, e2.message, e2.val]
+            "#,
+        );
+    }
+
+    // -- Exception#backtrace / set_backtrace -------------------------------
+
+    /// A fresh, never-raised exception has nil backtrace.
+    #[test]
+    fn backtrace_nil_when_unraised_and_unset() {
+        run_test(r#"Exception.new.backtrace"#);
+    }
+
+    /// `set_backtrace(nil)` clears any stored backtrace; subsequent
+    /// `backtrace` returns nil.
+    #[test]
+    fn set_backtrace_nil_clears() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e.set_backtrace(["x.rb:1"])
+            e.set_backtrace(nil)
+            e.backtrace
+            "#,
+        );
+    }
+
+    /// `set_backtrace(String)` stores it as a single-element array.
+    #[test]
+    fn set_backtrace_string_wrapped() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e.set_backtrace("here.rb:1")
+            e.backtrace
+            "#,
+        );
+    }
+
+    /// An Array of Strings is stored as-is and reflected in #backtrace.
+    #[test]
+    fn set_backtrace_array_roundtrip() {
+        run_test(
+            r#"
+            e = RuntimeError.new("m")
+            e.set_backtrace(["a.rb:1", "b.rb:2"])
+            e.backtrace
+            "#,
+        );
+    }
+
+    /// Bad inputs to set_backtrace raise TypeError.
+    #[test]
+    fn set_backtrace_typeerror() {
+        run_test_error(r#"RuntimeError.new.set_backtrace(:not_a_string)"#);
+        run_test_error(r#"RuntimeError.new.set_backtrace([1, 2])"#);
+        run_test_error(r#"RuntimeError.new.set_backtrace(["ok", nil])"#);
+        run_test_error(r#"RuntimeError.new.set_backtrace([["nested"]])"#);
+    }
+
+    /// `Exception#backtrace_locations` returns nil when backtrace is
+    /// nil (regression: previously raised NoMethodError on nil#map).
+    #[test]
+    fn backtrace_locations_nil_when_unset() {
+        run_test(r#"Exception.new.backtrace_locations"#);
     }
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1982,6 +1982,23 @@ fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 mod tests {
     use crate::tests::*;
 
+    /// Serializes ENV-mutating tests in this module. `setenv(3)` and
+    /// `unsetenv(3)` are not thread-safe (they manipulate the process-
+    /// wide `environ` array), so running ENV tests in parallel can race
+    /// and SIGSEGV. Tests that touch ENV take this lock for their full
+    /// body — including the `run_test_once` invocation, since CRuby
+    /// reads `environ` from the same process via `run_ruby` -> exec
+    /// before we mutate it back.
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Acquire the ENV test lock, recovering through poisoning so a
+    /// failing test never wedges every other ENV test that follows it.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
     #[test]
     fn test_hash() {
         run_test(
@@ -2294,6 +2311,7 @@ mod tests {
 
     #[test]
     fn env_fetch() {
+        let _g = env_lock();
         //run_test(r##"ENV["PWD"]"##);
         //run_test(r##"ENV.fetch("PWD")"##);
         run_test(r##"ENV.fetch("XZCDEWS", "ABC")"##);
@@ -2303,6 +2321,7 @@ mod tests {
 
     #[test]
     fn env_index_assign_updates_hash() {
+        let _g = env_lock();
         // Assignment is visible via ENV[]
         run_test_once(
             r##"
@@ -2316,6 +2335,7 @@ mod tests {
 
     #[test]
     fn env_index_assign_delete_via_nil() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_DEL"] = "x"
@@ -2328,6 +2348,7 @@ mod tests {
 
     #[test]
     fn env_delete_method() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_DEL2"] = "y"
@@ -2341,12 +2362,14 @@ mod tests {
 
     #[test]
     fn env_index_assign_type_errors() {
+        let _g = env_lock();
         run_test_error(r##"ENV[100] = "x""##);
         run_test_error(r##"ENV["MONORUBY_ENV_TEST_BAD"] = 100"##);
     }
 
     #[test]
     fn env_index_assign_embedded_nul() {
+        let _g = env_lock();
         run_test_error(r##"ENV["A\0B"] = "x""##);
         run_test_error(r##"ENV["MONORUBY_ENV_TEST_NUL"] = "a\0b""##);
     }
@@ -2356,6 +2379,7 @@ mod tests {
     /// previously broken.
     #[test]
     fn env_assign_propagates_to_libc_setenv() {
+        let _g = env_lock();
         use std::ffi::{CStr, CString};
         let key = "MONORUBY_ENV_TEST_LIBC_PROP";
         let c_key = CString::new(key).unwrap();
@@ -2382,6 +2406,7 @@ mod tests {
 
     #[test]
     fn env_delete_propagates_to_libc_unsetenv() {
+        let _g = env_lock();
         use std::ffi::CString;
         let key = "MONORUBY_ENV_TEST_LIBC_DEL";
         let c_key = CString::new(key).unwrap();
@@ -2402,6 +2427,7 @@ mod tests {
     /// `ENV.send(:[]=, key, value).should equal(value)` ruby/spec.
     #[test]
     fn env_index_assign_returns_value_identity() {
+        let _g = env_lock();
         run_test_once(
             r##"
             v = "MONORUBY_TEST_VAL"
@@ -2416,6 +2442,7 @@ mod tests {
     /// the value is non-nil.
     #[test]
     fn env_index_assign_einval_for_invalid_keys() {
+        let _g = env_lock();
         run_test_error(r##"ENV[""] = "x""##);
         run_test_error(r##"ENV["foo=bar"] = "x""##);
     }
@@ -2424,6 +2451,7 @@ mod tests {
     /// raise EINVAL) so library code can clear keys defensively.
     #[test]
     fn env_index_assign_invalid_key_with_nil_is_noop() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV[""]      = nil
@@ -2437,11 +2465,13 @@ mod tests {
 
     #[test]
     fn env_to_s_returns_literal_env() {
+        let _g = env_lock();
         run_test(r##"ENV.to_s"##);
     }
 
     #[test]
     fn env_rehash_returns_nil() {
+        let _g = env_lock();
         run_test(r##"ENV.rehash"##);
     }
 
@@ -2450,6 +2480,7 @@ mod tests {
     /// `ENV.to_h` and `ENV.to_hash` return a dup'd Hash, not ENV itself.
     #[test]
     fn env_to_h_returns_fresh_hash() {
+        let _g = env_lock();
         run_test(r##"ENV.to_h.equal?(ENV)"##);
         run_test(r##"ENV.to_hash.equal?(ENV)"##);
         run_test(r##"ENV.to_h.is_a?(Hash) && !ENV.to_h.equal?(ENV)"##);
@@ -2458,6 +2489,7 @@ mod tests {
     /// Block form transforms each pair into [k', v'].
     #[test]
     fn env_to_h_with_block() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_TOH"] = "1"
@@ -2472,6 +2504,7 @@ mod tests {
     /// Block must return a 2-element Array.
     #[test]
     fn env_to_h_block_size_error() {
+        let _g = env_lock();
         run_test_error(r##"ENV.to_h { |k, v| [k] }"##);
     }
 
@@ -2479,6 +2512,7 @@ mod tests {
 
     #[test]
     fn env_assoc_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_ASSOC"] = "yes"
@@ -2492,12 +2526,14 @@ mod tests {
     /// `ENV.assoc` raises TypeError for a non-coercible argument.
     #[test]
     fn env_assoc_typeerror() {
+        let _g = env_lock();
         run_test_error(r##"ENV.assoc(Object.new)"##);
     }
 
     /// `ENV.rassoc` returns nil (no TypeError) for a non-coercible value.
     #[test]
     fn env_rassoc_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_RASSOC"] = "uniq_value_1234"
@@ -2512,6 +2548,7 @@ mod tests {
 
     #[test]
     fn env_key_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"
@@ -2525,6 +2562,7 @@ mod tests {
 
     #[test]
     fn env_key_typeerror() {
+        let _g = env_lock();
         run_test_error(r##"ENV.key(Object.new)"##);
     }
 
@@ -2532,6 +2570,7 @@ mod tests {
 
     #[test]
     fn env_has_key_aliases() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_HK"] = "1"
@@ -2550,6 +2589,7 @@ mod tests {
 
     #[test]
     fn env_has_key_typeerror() {
+        let _g = env_lock();
         run_test_error(r##"ENV.has_key?(Object.new)"##);
         run_test_error(r##"ENV.include?(Object.new)"##);
     }
@@ -2560,6 +2600,7 @@ mod tests {
     /// returns nil (not TypeError) for a non-coercible argument.
     #[test]
     fn env_has_value_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_HV"] = "uniq_v_9999"
@@ -2579,6 +2620,7 @@ mod tests {
 
     #[test]
     fn env_merge_bang_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             r = ENV.merge!("MONORUBY_ENV_TEST_M1" => "1",
@@ -2595,6 +2637,7 @@ mod tests {
     /// Block-form `merge!` is invoked only on collisions.
     #[test]
     fn env_merge_bang_block() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_BLK"] = "old"
@@ -2613,6 +2656,7 @@ mod tests {
     /// `update` is an alias for `merge!`.
     #[test]
     fn env_update_alias() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV.update("MONORUBY_ENV_TEST_UP" => "u")
@@ -2626,6 +2670,7 @@ mod tests {
     /// A bad pair makes `merge!` raise without applying later good pairs.
     #[test]
     fn env_merge_bang_fails_fast() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_FF"] = "0"
@@ -2642,6 +2687,7 @@ mod tests {
 
     #[test]
     fn env_merge_bang_einval() {
+        let _g = env_lock();
         run_test_error(r##"ENV.merge!("foo=" => "bar")"##);
         run_test_error(r##"ENV.merge!("" => "bar")"##);
     }
@@ -2652,6 +2698,7 @@ mod tests {
     /// the input pairs (the "replaces ENV with a Hash" spec).
     #[test]
     fn env_replace_clears_originals() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_REPL_OLD"] = "old"
@@ -2672,21 +2719,25 @@ mod tests {
 
     /// When the bad pair comes first, `replace` raises before applying
     /// any pair — covering the "does not accept good data following an
-    /// error" spec (`ENV.to_hash` should equal the saved original).
+    /// error" spec. We assert per-key (not whole-hash equality) because
+    /// other parallel tests may legitimately mutate sibling ENV keys.
     #[test]
     fn env_replace_aborts_when_bad_pair_first() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_REPL2"] = "before"
-            saved = ENV.to_hash
+            ENV.delete("MONORUBY_ENV_TEST_REPL2_NEW")
             begin
               ENV.replace({Object.new => Object.new,
-                           "MONORUBY_ENV_TEST_REPL2" => "after"})
+                           "MONORUBY_ENV_TEST_REPL2_NEW" => "x",
+                           "MONORUBY_ENV_TEST_REPL2"     => "after"})
             rescue TypeError
             end
             v = [ENV["MONORUBY_ENV_TEST_REPL2"],
-                 ENV.to_hash == saved]
+                 ENV.key?("MONORUBY_ENV_TEST_REPL2_NEW")]
             ENV.delete("MONORUBY_ENV_TEST_REPL2")
+            ENV.delete("MONORUBY_ENV_TEST_REPL2_NEW")
             v
             "##,
         );
@@ -2694,12 +2745,14 @@ mod tests {
 
     #[test]
     fn env_replace_einval() {
+        let _g = env_lock();
         run_test_error(r##"ENV.replace("=" => "bar")"##);
         run_test_error(r##"ENV.replace("" => "bar")"##);
     }
 
     #[test]
     fn env_replace_typeerror_argument() {
+        let _g = env_lock();
         run_test_error(r##"ENV.replace(Object.new)"##);
     }
 
@@ -2707,6 +2760,7 @@ mod tests {
 
     #[test]
     fn env_values_at_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_VA1"] = "a"
@@ -2723,11 +2777,13 @@ mod tests {
 
     #[test]
     fn env_values_at_typeerror() {
+        let _g = env_lock();
         run_test_error(r##"ENV.values_at("PWD", Object.new)"##);
     }
 
     #[test]
     fn env_slice_basic() {
+        let _g = env_lock();
         run_test_once(
             r##"
             ENV["MONORUBY_ENV_TEST_SL1"] = "x"
@@ -2744,6 +2800,7 @@ mod tests {
 
     #[test]
     fn env_slice_typeerror() {
+        let _g = env_lock();
         run_test_error(r##"ENV.slice(Object.new)"##);
     }
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1285,15 +1285,21 @@ fn env_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(val)
 }
 
-/// ### ENV.to_hash / ENV.to_h
+///
+/// ### ENV.to_hash
+/// ### ENV.to_h
+///
+/// - to_hash -> Hash
+/// - to_h -> Hash
+/// - to_h {|name, value| block } -> Hash
 ///
 /// Returns a fresh `Hash` snapshot of the environment so callers can
-/// mutate it without affecting the live environment, matching CRuby's
-/// behaviour (`h.should_not equal ENV` per the ruby/spec suite).
+/// mutate it without affecting the live environment. When a block is
+/// given, the block must return a 2-element Array `[new_name, new_value]`;
+/// otherwise an `ArgumentError` (wrong size) or `TypeError` is raised.
 ///
-/// When a block is given, behaves like `Hash#to_h { |k, v| [k', v'] }`:
-/// the block must return a 2-element Array; otherwise raises ArgumentError
-/// (wrong size) or TypeError.
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/to_h.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/to_hash.html]
 #[monoruby_builtin]
 fn env_to_hash(
     vm: &mut Executor,
@@ -1343,16 +1349,23 @@ fn coerce_env_string(
     Ok(s)
 }
 
-/// ### ENV.[]=
-/// - self[key] = value
-/// - store(key, value) -> value
 ///
-/// Sets an environment variable. `value = nil` deletes the variable.
-/// Updates both the Ruby-visible hash and libc's `environ` via
-/// `setenv(3)` / `unsetenv(3)` so that FFI callers (e.g. `getenv(3)`)
-/// observe the change.
+/// ### ENV.[]=
+/// ### ENV.store
+///
+/// - self[name] = value -> value
+/// - store(name, value) -> value
+///
+/// Sets the environment variable named *name* to *value*. If *value*
+/// is `nil`, the variable is deleted. Updates both the Ruby-visible
+/// hash and libc's `environ` via `setenv(3)` / `unsetenv(3)` so that
+/// FFI callers (e.g. `getenv(3)`) observe the change. Raises
+/// `Errno::EINVAL` when *name* is empty or contains `'='`, and
+/// `TypeError` when *name* or *value* is not a String and does not
+/// respond to `#to_str`.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/=5b=5d=3d.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/store.html]
 #[monoruby_builtin]
 fn env_index_assign(
     vm: &mut Executor,
@@ -1430,12 +1443,16 @@ fn check_env_key_for_set(key: &str, store: &Store) -> Result<()> {
     Ok(())
 }
 
-/// ### ENV.delete
-/// - delete(key) -> String | nil
-/// - delete(key) {|key| ... } -> object
 ///
-/// Removes an environment variable from both the Ruby-visible hash and
-/// libc's `environ` (via `unsetenv(3)`).
+/// ### ENV.delete
+///
+/// - delete(name) -> String | nil
+/// - delete(name) {|name| block } -> object
+///
+/// Removes the environment variable named *name* from both the
+/// Ruby-visible hash and libc's `environ` (via `unsetenv(3)`).
+/// Returns the previous value, or the block's return value (if a
+/// block is given and the variable was not set), or `nil`.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/delete.html]
 #[monoruby_builtin]
@@ -1467,25 +1484,43 @@ fn env_delete(
     Ok(removed.unwrap_or_default())
 }
 
-/// ### ENV.to_s -> "ENV"
+///
+/// ### ENV.to_s
+///
+/// - to_s -> "ENV"
+///
+/// Returns the literal String `"ENV"`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/to_s.html]
 #[monoruby_builtin]
 fn env_to_s(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::string("ENV".to_string()))
 }
 
-/// ### ENV.rehash -> nil
 ///
-/// CRuby keeps ENV in libc's `environ`, so there is no Ruby-side hash
-/// to rehash; the method exists for API compatibility and returns nil.
+/// ### ENV.rehash
+///
+/// - rehash -> nil
+///
+/// Provided for compatibility with `Hash#rehash`. monoruby keeps ENV
+/// in libc's `environ`, so there is no Ruby-side bucket to rebuild;
+/// always returns `nil`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/rehash.html]
 #[monoruby_builtin]
 fn env_rehash(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::nil())
 }
 
-/// ### ENV.assoc(key) -> [key, value] | nil
 ///
-/// Coerces `key` with `#to_str` (raising `TypeError` if not coercible)
-/// and returns `[key, value]` if the key is set, nil otherwise.
+/// ### ENV.assoc
+///
+/// - assoc(name) -> [name, value] | nil
+///
+/// Coerces *name* with `#to_str` (raising `TypeError` if not coercible)
+/// and returns `[name, value]` if the variable is set, otherwise `nil`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/assoc.html]
 #[monoruby_builtin]
 fn env_assoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let key = coerce_env_string(lfp.arg(0), vm, globals)?;
@@ -1498,10 +1533,17 @@ fn env_assoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     }
 }
 
-/// ### ENV.rassoc(value) -> [key, value] | nil
 ///
-/// Coerces `value` with `#to_str`. If `value` does not respond to
-/// `#to_str`, returns nil (no TypeError, per spec).
+/// ### ENV.rassoc
+///
+/// - rassoc(value) -> [name, value] | nil
+///
+/// Coerces *value* with `#to_str` and returns `[name, value]` for the
+/// first variable whose value equals it, or `nil` if none does. If
+/// *value* does not respond to `#to_str`, returns `nil` (no
+/// `TypeError` is raised, per spec).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/rassoc.html]
 #[monoruby_builtin]
 fn env_rassoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let target = match try_coerce_env_string(lfp.arg(0), vm, globals)? {
@@ -1517,10 +1559,16 @@ fn env_rassoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     Ok(Value::nil())
 }
 
-/// ### ENV.key(value) -> key | nil
 ///
-/// Coerces `value` with `#to_str` (raising `TypeError` if not coercible)
-/// and returns the first key whose value equals `value`, or nil.
+/// ### ENV.key
+///
+/// - key(value) -> String | nil
+///
+/// Coerces *value* with `#to_str` (raising `TypeError` if not
+/// coercible) and returns the name of the first variable whose value
+/// equals it, or `nil` if none does.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/key.html]
 #[monoruby_builtin]
 fn env_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let target = Value::string(coerce_env_string(lfp.arg(0), vm, globals)?);
@@ -1533,11 +1581,24 @@ fn env_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(Value::nil())
 }
 
-/// ### ENV.has_key?(key) -> bool
-/// Aliased as `include?`, `key?`, `member?`.
 ///
-/// Coerces `key` with `#to_str` (raising `TypeError` on failure) and
-/// returns whether the key is set in the environment.
+/// ### ENV.has_key?
+/// ### ENV.include?
+/// ### ENV.key?
+/// ### ENV.member?
+///
+/// - has_key?(name) -> bool
+/// - include?(name) -> bool
+/// - key?(name) -> bool
+/// - member?(name) -> bool
+///
+/// Coerces *name* with `#to_str` (raising `TypeError` if not coercible)
+/// and returns whether the named variable is set in ENV.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/has_key=3f.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/include=3f.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/key=3f.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/member=3f.html]
 #[monoruby_builtin]
 fn env_has_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let key_v = Value::string(coerce_env_string(lfp.arg(0), vm, globals)?);
@@ -1545,11 +1606,19 @@ fn env_has_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
     Ok(Value::bool(hash.get(key_v, vm, globals)?.is_some()))
 }
 
-/// ### ENV.has_value?(value) -> bool | nil
-/// Aliased as `value?`.
 ///
-/// Coerces `value` with `#to_str`. If `value` is not coercible, returns
-/// nil (per spec — does *not* raise TypeError).
+/// ### ENV.has_value?
+/// ### ENV.value?
+///
+/// - has_value?(value) -> bool | nil
+/// - value?(value) -> bool | nil
+///
+/// Coerces *value* with `#to_str` and returns whether some variable in
+/// ENV has it as its value. If *value* does not respond to `#to_str`,
+/// returns `nil` (no `TypeError` is raised, per spec).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/has_value=3f.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/value=3f.html]
 #[monoruby_builtin]
 fn env_has_value(
     vm: &mut Executor,
@@ -1614,16 +1683,24 @@ fn env_unset_one(
     Ok(())
 }
 
-/// ### ENV.merge! / ENV.update
-/// - merge!(*hashes) -> ENV
-/// - merge!(*hashes) { |key, old_value, new_value| ... } -> ENV
 ///
-/// Iterates each hash argument; for each pair it coerces key & value
-/// with `#to_str` (TypeError if not coercible), validates the key
-/// (Errno::EINVAL if empty or contains '='), then sets the variable.
-/// If a block is given and the key already exists in ENV, the block
-/// is invoked with `(key, old_value, new_value)` and its return value
-/// is used as the new value.
+/// ### ENV.merge!
+/// ### ENV.update
+///
+/// - merge!(*others) -> ENV
+/// - merge!(*others) {|name, old_value, new_value| block } -> ENV
+/// - update(*others) -> ENV
+/// - update(*others) {|name, old_value, new_value| block } -> ENV
+///
+/// Iterates each hash argument; for each pair, *name* and *value* are
+/// coerced with `#to_str` (`TypeError` if not coercible), *name* is
+/// validated (`Errno::EINVAL` if empty or contains `'='`), then the
+/// variable is set. When a block is given and the variable already
+/// exists, the block is invoked with `(name, old_value, new_value)`
+/// and its return value is used as the new value. Returns ENV.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/merge=21.html]
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/update.html]
 #[monoruby_builtin]
 fn env_merge_bang(
     vm: &mut Executor,
@@ -1660,12 +1737,17 @@ fn env_merge_bang(
     Ok(lfp.self_val())
 }
 
-/// ### ENV.replace(other_hash) -> ENV
 ///
-/// Replaces the contents of ENV with `other_hash`. All keys / values
-/// are validated up front, so an invalid pair (TypeError or
-/// Errno::EINVAL) leaves ENV untouched — preserving the
-/// "does not accept good data preceding/following an error" semantics.
+/// ### ENV.replace
+///
+/// - replace(other_hash) -> ENV
+///
+/// Replaces the contents of ENV with *other_hash*. Every name / value
+/// pair is validated up front (`TypeError` for non-coercible objects,
+/// `Errno::EINVAL` for empty names or names containing `'='`), so an
+/// invalid pair leaves ENV untouched. Returns ENV.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/replace.html]
 #[monoruby_builtin]
 fn env_replace(
     vm: &mut Executor,
@@ -1707,10 +1789,16 @@ fn env_replace(
     Ok(lfp.self_val())
 }
 
-/// ### ENV.values_at(*keys) -> Array
 ///
-/// Returns an array of values for the given keys. Each key is coerced
-/// via `#to_str`, raising TypeError if not coercible.
+/// ### ENV.values_at
+///
+/// - values_at(*names) -> [String | nil]
+///
+/// Returns an Array of values for the given *names*. Each name is
+/// coerced via `#to_str` (`TypeError` if not coercible); a name that
+/// is not set produces `nil` in the resulting array.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/values_at.html]
 #[monoruby_builtin]
 fn env_values_at(
     vm: &mut Executor,
@@ -1729,12 +1817,18 @@ fn env_values_at(
     Ok(Value::array_from_vec(out))
 }
 
-/// ### ENV.slice(*keys) -> Hash
 ///
-/// Returns a Hash containing the values for keys that exist in ENV.
-/// Each key argument is coerced via `#to_str` exactly once (TypeError
-/// if not coercible); the resulting hash uses the *original* argument
-/// objects as keys, matching CRuby's spec behaviour.
+/// ### ENV.slice
+///
+/// - slice(*names) -> Hash
+///
+/// Returns a Hash containing the names that exist in ENV mapped to
+/// their values. Each name argument is coerced via `#to_str` exactly
+/// once (`TypeError` if not coercible); the resulting hash uses the
+/// *original* argument objects as keys (so a mock that responds to
+/// `#to_str` is preserved as a key in the result).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/slice.html]
 #[monoruby_builtin]
 fn env_slice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let args = lfp.arg(0).as_array();
@@ -2300,6 +2394,357 @@ mod tests {
         let _ = globals.run(src, std::path::Path::new("(test)"));
         let got = unsafe { libc::getenv(c_key.as_ptr()) };
         assert!(got.is_null(), "getenv should return NULL after ENV.delete");
+    }
+
+    // -- ENV.[]= validation ------------------------------------------------
+
+    /// Assigning a String value returns the *same* String object — the
+    /// `ENV.send(:[]=, key, value).should equal(value)` ruby/spec.
+    #[test]
+    fn env_index_assign_returns_value_identity() {
+        run_test_once(
+            r##"
+            v = "MONORUBY_TEST_VAL"
+            r = ENV.send(:[]=, "MONORUBY_ENV_TEST_ID", v)
+            ENV.send(:[]=, "MONORUBY_ENV_TEST_ID", nil)
+            r.equal?(v)
+            "##,
+        );
+    }
+
+    /// Empty key or a key containing '=' must raise Errno::EINVAL when
+    /// the value is non-nil.
+    #[test]
+    fn env_index_assign_einval_for_invalid_keys() {
+        run_test_error(r##"ENV[""] = "x""##);
+        run_test_error(r##"ENV["foo=bar"] = "x""##);
+    }
+
+    /// Per spec: `ENV[invalid_key] = nil` is a silent no-op (does *not*
+    /// raise EINVAL) so library code can clear keys defensively.
+    #[test]
+    fn env_index_assign_invalid_key_with_nil_is_noop() {
+        run_test_once(
+            r##"
+            ENV[""]      = nil
+            ENV["a=b"]   = nil
+            ENV.key?("") || ENV.key?("a=b")
+            "##,
+        );
+    }
+
+    // -- ENV.to_s / ENV.rehash --------------------------------------------
+
+    #[test]
+    fn env_to_s_returns_literal_env() {
+        run_test(r##"ENV.to_s"##);
+    }
+
+    #[test]
+    fn env_rehash_returns_nil() {
+        run_test(r##"ENV.rehash"##);
+    }
+
+    // -- ENV.to_hash / ENV.to_h -------------------------------------------
+
+    /// `ENV.to_h` and `ENV.to_hash` return a dup'd Hash, not ENV itself.
+    #[test]
+    fn env_to_h_returns_fresh_hash() {
+        run_test(r##"ENV.to_h.equal?(ENV)"##);
+        run_test(r##"ENV.to_hash.equal?(ENV)"##);
+        run_test(r##"ENV.to_h.is_a?(Hash) && !ENV.to_h.equal?(ENV)"##);
+    }
+
+    /// Block form transforms each pair into [k', v'].
+    #[test]
+    fn env_to_h_with_block() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_TOH"] = "1"
+            h = ENV.to_h { |k, v| [k.downcase, v + "!"] }
+            v = h["monoruby_env_test_toh"]
+            ENV.delete("MONORUBY_ENV_TEST_TOH")
+            v
+            "##,
+        );
+    }
+
+    /// Block must return a 2-element Array.
+    #[test]
+    fn env_to_h_block_size_error() {
+        run_test_error(r##"ENV.to_h { |k, v| [k] }"##);
+    }
+
+    // -- ENV.assoc / ENV.rassoc / ENV.key ---------------------------------
+
+    #[test]
+    fn env_assoc_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_ASSOC"] = "yes"
+            r = ENV.assoc("MONORUBY_ENV_TEST_ASSOC")
+            ENV.delete("MONORUBY_ENV_TEST_ASSOC")
+            [r, ENV.assoc("MONORUBY_ENV_TEST_ASSOC_NONE")]
+            "##,
+        );
+    }
+
+    /// `ENV.assoc` raises TypeError for a non-coercible argument.
+    #[test]
+    fn env_assoc_typeerror() {
+        run_test_error(r##"ENV.assoc(Object.new)"##);
+    }
+
+    /// `ENV.rassoc` returns nil (no TypeError) for a non-coercible value.
+    #[test]
+    fn env_rassoc_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_RASSOC"] = "uniq_value_1234"
+            r = ENV.rassoc("uniq_value_1234")
+            n = ENV.rassoc("__no_such_value__")
+            o = ENV.rassoc(Object.new)
+            ENV.delete("MONORUBY_ENV_TEST_RASSOC")
+            [r, n, o]
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_key_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"
+            r = ENV.key("uniq_value_5678")
+            n = ENV.key("__no_such_value__")
+            ENV.delete("MONORUBY_ENV_TEST_KEY")
+            [r, n]
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_key_typeerror() {
+        run_test_error(r##"ENV.key(Object.new)"##);
+    }
+
+    // -- ENV.has_key? / include? / key? / member? -------------------------
+
+    #[test]
+    fn env_has_key_aliases() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_HK"] = "1"
+            r = [
+              ENV.has_key?("MONORUBY_ENV_TEST_HK"),
+              ENV.include?("MONORUBY_ENV_TEST_HK"),
+              ENV.key?("MONORUBY_ENV_TEST_HK"),
+              ENV.member?("MONORUBY_ENV_TEST_HK"),
+              ENV.has_key?("MONORUBY_ENV_TEST_HK_NONE"),
+            ]
+            ENV.delete("MONORUBY_ENV_TEST_HK")
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_has_key_typeerror() {
+        run_test_error(r##"ENV.has_key?(Object.new)"##);
+        run_test_error(r##"ENV.include?(Object.new)"##);
+    }
+
+    // -- ENV.has_value? / value? ------------------------------------------
+
+    /// `ENV.has_value?` returns false for a missing String value, but
+    /// returns nil (not TypeError) for a non-coercible argument.
+    #[test]
+    fn env_has_value_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_HV"] = "uniq_v_9999"
+            r = [
+              ENV.has_value?("uniq_v_9999"),
+              ENV.value?("uniq_v_9999"),
+              ENV.has_value?("__no_such_value__"),
+              ENV.has_value?(Object.new),
+            ]
+            ENV.delete("MONORUBY_ENV_TEST_HV")
+            r
+            "##,
+        );
+    }
+
+    // -- ENV.merge! / ENV.update ------------------------------------------
+
+    #[test]
+    fn env_merge_bang_basic() {
+        run_test_once(
+            r##"
+            r = ENV.merge!("MONORUBY_ENV_TEST_M1" => "1",
+                           "MONORUBY_ENV_TEST_M2" => "2")
+            same = r.equal?(ENV)
+            v = [ENV["MONORUBY_ENV_TEST_M1"], ENV["MONORUBY_ENV_TEST_M2"]]
+            ENV.delete("MONORUBY_ENV_TEST_M1")
+            ENV.delete("MONORUBY_ENV_TEST_M2")
+            [same, v]
+            "##,
+        );
+    }
+
+    /// Block-form `merge!` is invoked only on collisions.
+    #[test]
+    fn env_merge_bang_block() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_BLK"] = "old"
+            ENV.merge!("MONORUBY_ENV_TEST_BLK" => "new",
+                       "MONORUBY_ENV_TEST_BLK_NEW" => "fresh") do
+              |k, old, new| "#{old}+#{new}"
+            end
+            r = [ENV["MONORUBY_ENV_TEST_BLK"], ENV["MONORUBY_ENV_TEST_BLK_NEW"]]
+            ENV.delete("MONORUBY_ENV_TEST_BLK")
+            ENV.delete("MONORUBY_ENV_TEST_BLK_NEW")
+            r
+            "##,
+        );
+    }
+
+    /// `update` is an alias for `merge!`.
+    #[test]
+    fn env_update_alias() {
+        run_test_once(
+            r##"
+            ENV.update("MONORUBY_ENV_TEST_UP" => "u")
+            v = ENV["MONORUBY_ENV_TEST_UP"]
+            ENV.delete("MONORUBY_ENV_TEST_UP")
+            v
+            "##,
+        );
+    }
+
+    /// A bad pair makes `merge!` raise without applying later good pairs.
+    #[test]
+    fn env_merge_bang_fails_fast() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_FF"] = "0"
+            begin
+              ENV.merge!({Object.new => "1", "MONORUBY_ENV_TEST_FF" => "2"})
+            rescue TypeError
+            end
+            v = ENV["MONORUBY_ENV_TEST_FF"]
+            ENV.delete("MONORUBY_ENV_TEST_FF")
+            v
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_merge_bang_einval() {
+        run_test_error(r##"ENV.merge!("foo=" => "bar")"##);
+        run_test_error(r##"ENV.merge!("" => "bar")"##);
+    }
+
+    // -- ENV.replace ------------------------------------------------------
+
+    /// Successful `replace` removes the original-only keys and adopts
+    /// the input pairs (the "replaces ENV with a Hash" spec).
+    #[test]
+    fn env_replace_clears_originals() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_REPL_OLD"] = "old"
+            saved = ENV.to_hash
+            r = ENV.replace({"MONORUBY_ENV_TEST_REPL_NEW" => "fresh"})
+            same = r.equal?(ENV)
+            v = [same,
+                 ENV.key?("MONORUBY_ENV_TEST_REPL_OLD"),
+                 ENV["MONORUBY_ENV_TEST_REPL_NEW"]]
+            # Restore so the test does not pollute the harness env.
+            ENV.replace(saved)
+            ENV.delete("MONORUBY_ENV_TEST_REPL_OLD")
+            ENV.delete("MONORUBY_ENV_TEST_REPL_NEW")
+            v
+            "##,
+        );
+    }
+
+    /// When the bad pair comes first, `replace` raises before applying
+    /// any pair — covering the "does not accept good data following an
+    /// error" spec (`ENV.to_hash` should equal the saved original).
+    #[test]
+    fn env_replace_aborts_when_bad_pair_first() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_REPL2"] = "before"
+            saved = ENV.to_hash
+            begin
+              ENV.replace({Object.new => Object.new,
+                           "MONORUBY_ENV_TEST_REPL2" => "after"})
+            rescue TypeError
+            end
+            v = [ENV["MONORUBY_ENV_TEST_REPL2"],
+                 ENV.to_hash == saved]
+            ENV.delete("MONORUBY_ENV_TEST_REPL2")
+            v
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_replace_einval() {
+        run_test_error(r##"ENV.replace("=" => "bar")"##);
+        run_test_error(r##"ENV.replace("" => "bar")"##);
+    }
+
+    #[test]
+    fn env_replace_typeerror_argument() {
+        run_test_error(r##"ENV.replace(Object.new)"##);
+    }
+
+    // -- ENV.values_at / ENV.slice ----------------------------------------
+
+    #[test]
+    fn env_values_at_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_VA1"] = "a"
+            ENV["MONORUBY_ENV_TEST_VA2"] = "b"
+            r = ENV.values_at("MONORUBY_ENV_TEST_VA1",
+                              "MONORUBY_ENV_TEST_VA_NONE",
+                              "MONORUBY_ENV_TEST_VA2")
+            ENV.delete("MONORUBY_ENV_TEST_VA1")
+            ENV.delete("MONORUBY_ENV_TEST_VA2")
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_values_at_typeerror() {
+        run_test_error(r##"ENV.values_at("PWD", Object.new)"##);
+    }
+
+    #[test]
+    fn env_slice_basic() {
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_SL1"] = "x"
+            ENV["MONORUBY_ENV_TEST_SL2"] = "y"
+            r = ENV.slice("MONORUBY_ENV_TEST_SL1",
+                          "MONORUBY_ENV_TEST_SL_NONE",
+                          "MONORUBY_ENV_TEST_SL2")
+            ENV.delete("MONORUBY_ENV_TEST_SL1")
+            ENV.delete("MONORUBY_ENV_TEST_SL2")
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn env_slice_typeerror() {
+        run_test_error(r##"ENV.slice(Object.new)"##);
     }
 
     #[test]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -108,6 +108,23 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_singleton_func(env, "store", env_index_assign, 2);
     globals.define_builtin_singleton_func(env, "delete", env_delete, 1);
     globals.define_builtin_singleton_func(env, "to_hash", env_to_hash, 0);
+    globals.define_builtin_singleton_func(env, "to_h", env_to_hash, 0);
+    globals.define_builtin_singleton_func(env, "to_s", env_to_s, 0);
+    globals.define_builtin_singleton_func(env, "rehash", env_rehash, 0);
+    globals.define_builtin_singleton_func(env, "assoc", env_assoc, 1);
+    globals.define_builtin_singleton_func(env, "rassoc", env_rassoc, 1);
+    globals.define_builtin_singleton_func(env, "key", env_key, 1);
+    for name in ["has_key?", "include?", "key?", "member?"] {
+        globals.define_builtin_singleton_func(env, name, env_has_key, 1);
+    }
+    for name in ["has_value?", "value?"] {
+        globals.define_builtin_singleton_func(env, name, env_has_value, 1);
+    }
+    globals.define_builtin_singleton_func_with(env, "merge!", env_merge_bang, 0, 0, true);
+    globals.define_builtin_singleton_func_with(env, "update", env_merge_bang, 0, 0, true);
+    globals.define_builtin_singleton_func(env, "replace", env_replace, 1);
+    globals.define_builtin_singleton_func_with(env, "values_at", env_values_at, 0, 0, true);
+    globals.define_builtin_singleton_func_with(env, "slice", env_slice, 0, 0, true);
 }
 
 ///
@@ -913,12 +930,18 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 /// ### Hash#reject
 ///
 /// - reject {|key, value| ... } -> Hash
-/// - [NOT SUPPORTED] reject -> Enumerator
+/// - reject -> Enumerator
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Hash/i/reject.html]
 #[monoruby_builtin]
-fn reject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let bh = lfp.expect_block()?;
+fn reject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let bh = match lfp.block() {
+        None => {
+            let id = IdentId::get_id("reject");
+            return vm.generate_enumerator(id, lfp.self_val(), lfp.iter().collect(), pc);
+        }
+        Some(block) => block,
+    };
     let h = lfp.self_val().dup();
     let p = vm.get_block_data(globals, bh)?;
     vm.temp_push(h);
@@ -1262,14 +1285,42 @@ fn env_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(val)
 }
 
+/// ### ENV.to_hash / ENV.to_h
+///
+/// Returns a fresh `Hash` snapshot of the environment so callers can
+/// mutate it without affecting the live environment, matching CRuby's
+/// behaviour (`h.should_not equal ENV` per the ruby/spec suite).
+///
+/// When a block is given, behaves like `Hash#to_h { |k, v| [k', v'] }`:
+/// the block must return a 2-element Array; otherwise raises ArgumentError
+/// (wrong size) or TypeError.
 #[monoruby_builtin]
 fn env_to_hash(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(lfp.self_val())
+    if let Some(bh) = lfp.block() {
+        let data = vm.get_block_data(globals, bh)?;
+        let hash = lfp.self_val().as_hash();
+        let pairs: Vec<(Value, Value)> = hash.iter().collect();
+        let mut new_map = RubyMap::default();
+        for (k, v) in pairs {
+            let result = vm.invoke_block(globals, &data, &[k, v])?;
+            let arr = result.expect_array_ty(globals)?;
+            if arr.len() != 2 {
+                return Err(MonorubyErr::argumenterr(format!(
+                    "element has wrong array length (expected 2, was {})",
+                    arr.len(),
+                )));
+            }
+            new_map.insert(arr[0], arr[1], vm, globals)?;
+        }
+        return Ok(Value::hash(new_map));
+    }
+    let inner = lfp.self_val().as_hashmap_inner().clone();
+    Ok(Value::hash_from_inner(inner))
 }
 
 /// Coerce a `Value` into an owned `String` for use as an environment variable
@@ -1317,6 +1368,10 @@ fn env_index_assign(
 
     if value_val.is_nil() {
         // Delete the variable from both the hash and libc's environ.
+        // Per CRuby, ENV[invalid_key] = nil is a silent no-op (it does
+        // *not* raise EINVAL), matching the spec
+        // "does nothing when the key is not a valid environment variable
+        //  key and the value is nil".
         let key_v = Value::string(key.clone());
         lfp.self_val().as_hash().remove(key_v, vm, globals)?;
         let c_key = std::ffi::CString::new(key.as_bytes())
@@ -1327,6 +1382,12 @@ fn env_index_assign(
             libc::unsetenv(c_key.as_ptr());
         }
         return Ok(Value::nil());
+    }
+
+    // Validate the key for setenv: empty string or '=' is rejected with
+    // Errno::EINVAL, matching CRuby and `setenv(3)`.
+    if let Err(e) = check_env_key_for_set(&key, &globals.store) {
+        return Err(e);
     }
 
     let value = coerce_env_string(value_val, vm, globals)?;
@@ -1346,7 +1407,27 @@ fn env_index_assign(
     lfp.self_val()
         .as_hash()
         .insert(key_v, val_v, vm, globals)?;
-    Ok(val_v)
+    // Per spec, ENV.[]= / ENV.store should return the *original* value
+    // argument (so that `equal?` on a String literal matches).
+    if value_val.is_str().is_some() {
+        Ok(value_val)
+    } else {
+        Ok(val_v)
+    }
+}
+
+/// Reject environment variable names that `setenv(3)` would refuse:
+/// empty strings, and names that contain a literal '=' character.
+fn check_env_key_for_set(key: &str, store: &Store) -> Result<()> {
+    if key.is_empty() || key.contains('=') {
+        let err = std::io::Error::from_raw_os_error(libc::EINVAL);
+        return Err(MonorubyErr::from_io_err(
+            store,
+            &err,
+            format!("Invalid argument - setenv({})", key),
+        ));
+    }
+    Ok(())
 }
 
 /// ### ENV.delete
@@ -1384,6 +1465,314 @@ fn env_delete(
         return vm.invoke_block_once(globals, bh, &[key_v]);
     }
     Ok(removed.unwrap_or_default())
+}
+
+/// ### ENV.to_s -> "ENV"
+#[monoruby_builtin]
+fn env_to_s(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::string("ENV".to_string()))
+}
+
+/// ### ENV.rehash -> nil
+///
+/// CRuby keeps ENV in libc's `environ`, so there is no Ruby-side hash
+/// to rehash; the method exists for API compatibility and returns nil.
+#[monoruby_builtin]
+fn env_rehash(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::nil())
+}
+
+/// ### ENV.assoc(key) -> [key, value] | nil
+///
+/// Coerces `key` with `#to_str` (raising `TypeError` if not coercible)
+/// and returns `[key, value]` if the key is set, nil otherwise.
+#[monoruby_builtin]
+fn env_assoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let key = coerce_env_string(lfp.arg(0), vm, globals)?;
+    let key_v = Value::string(key);
+    let hash = lfp.self_val().as_hash();
+    if let Some(v) = hash.get(key_v, vm, globals)? {
+        Ok(Value::array_from_vec(vec![key_v, v]))
+    } else {
+        Ok(Value::nil())
+    }
+}
+
+/// ### ENV.rassoc(value) -> [key, value] | nil
+///
+/// Coerces `value` with `#to_str`. If `value` does not respond to
+/// `#to_str`, returns nil (no TypeError, per spec).
+#[monoruby_builtin]
+fn env_rassoc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let target = match try_coerce_env_string(lfp.arg(0), vm, globals)? {
+        Some(s) => Value::string(s),
+        None => return Ok(Value::nil()),
+    };
+    let hash = lfp.self_val().as_hash();
+    for (k, v) in hash.iter() {
+        if vm.eq_values_bool(globals, target, v)? {
+            return Ok(Value::array_from_vec(vec![k, v]));
+        }
+    }
+    Ok(Value::nil())
+}
+
+/// ### ENV.key(value) -> key | nil
+///
+/// Coerces `value` with `#to_str` (raising `TypeError` if not coercible)
+/// and returns the first key whose value equals `value`, or nil.
+#[monoruby_builtin]
+fn env_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let target = Value::string(coerce_env_string(lfp.arg(0), vm, globals)?);
+    let hash = lfp.self_val().as_hash();
+    for (k, v) in hash.iter() {
+        if vm.eq_values_bool(globals, target, v)? {
+            return Ok(k);
+        }
+    }
+    Ok(Value::nil())
+}
+
+/// ### ENV.has_key?(key) -> bool
+/// Aliased as `include?`, `key?`, `member?`.
+///
+/// Coerces `key` with `#to_str` (raising `TypeError` on failure) and
+/// returns whether the key is set in the environment.
+#[monoruby_builtin]
+fn env_has_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let key_v = Value::string(coerce_env_string(lfp.arg(0), vm, globals)?);
+    let hash = lfp.self_val().as_hash();
+    Ok(Value::bool(hash.get(key_v, vm, globals)?.is_some()))
+}
+
+/// ### ENV.has_value?(value) -> bool | nil
+/// Aliased as `value?`.
+///
+/// Coerces `value` with `#to_str`. If `value` is not coercible, returns
+/// nil (per spec — does *not* raise TypeError).
+#[monoruby_builtin]
+fn env_has_value(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let target = match try_coerce_env_string(lfp.arg(0), vm, globals)? {
+        Some(s) => Value::string(s),
+        None => return Ok(Value::nil()),
+    };
+    let hash = lfp.self_val().as_hash();
+    for (_, v) in hash.iter() {
+        if vm.eq_values_bool(globals, target, v)? {
+            return Ok(Value::bool(true));
+        }
+    }
+    Ok(Value::bool(false))
+}
+
+/// Set or unset a single environment variable, propagating to libc's
+/// `environ` and updating the Ruby-visible hash. Used as a building
+/// block for `ENV.[]=`, `ENV.merge!`, `ENV.update`, `ENV.replace`.
+/// `key` must already have passed `check_env_key_for_set`.
+fn env_set_one(
+    self_val: Value,
+    key: &str,
+    value: &str,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Result<Value> {
+    let c_key = std::ffi::CString::new(key.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    let c_val = std::ffi::CString::new(value.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    // SAFETY: both pointers reference NUL-terminated C strings whose
+    // storage outlives this call. `setenv` copies its arguments.
+    unsafe {
+        libc::setenv(c_key.as_ptr(), c_val.as_ptr(), 1);
+    }
+    let key_v = Value::string(key.to_string());
+    let val_v = Value::string(value.to_string());
+    self_val.as_hash().insert(key_v, val_v, vm, globals)?;
+    Ok(val_v)
+}
+
+fn env_unset_one(
+    self_val: Value,
+    key: &str,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Result<()> {
+    let key_v = Value::string(key.to_string());
+    self_val.as_hash().remove(key_v, vm, globals)?;
+    let c_key = std::ffi::CString::new(key.as_bytes())
+        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+    // SAFETY: `c_key` is a NUL-terminated C string whose storage outlives
+    // this call. `unsetenv` is a no-op if the variable is not set.
+    unsafe {
+        libc::unsetenv(c_key.as_ptr());
+    }
+    Ok(())
+}
+
+/// ### ENV.merge! / ENV.update
+/// - merge!(*hashes) -> ENV
+/// - merge!(*hashes) { |key, old_value, new_value| ... } -> ENV
+///
+/// Iterates each hash argument; for each pair it coerces key & value
+/// with `#to_str` (TypeError if not coercible), validates the key
+/// (Errno::EINVAL if empty or contains '='), then sets the variable.
+/// If a block is given and the key already exists in ENV, the block
+/// is invoked with `(key, old_value, new_value)` and its return value
+/// is used as the new value.
+#[monoruby_builtin]
+fn env_merge_bang(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    let block_data = if let Some(bh) = lfp.block() {
+        Some(vm.get_block_data(globals, bh)?)
+    } else {
+        None
+    };
+    for arg in lfp.arg(0).as_array().iter() {
+        let other = arg.coerce_to_hash(vm, globals)?;
+        let pairs: Vec<(Value, Value)> = other.iter().collect();
+        for (k, v) in pairs {
+            let key = coerce_env_string(k, vm, globals)?;
+            check_env_key_for_set(&key, &globals.store)?;
+            let mut value = coerce_env_string(v, vm, globals)?;
+
+            if let Some(ref data) = block_data {
+                let key_v = Value::string(key.clone());
+                if let Some(old_v) = lfp.self_val().as_hash().get(key_v, vm, globals)? {
+                    let new_v = Value::string(value.clone());
+                    let result = vm.invoke_block(globals, data, &[key_v, old_v, new_v])?;
+                    value = coerce_env_string(result, vm, globals)?;
+                }
+            }
+
+            env_set_one(lfp.self_val(), &key, &value, vm, globals)?;
+        }
+    }
+    Ok(lfp.self_val())
+}
+
+/// ### ENV.replace(other_hash) -> ENV
+///
+/// Replaces the contents of ENV with `other_hash`. All keys / values
+/// are validated up front, so an invalid pair (TypeError or
+/// Errno::EINVAL) leaves ENV untouched — preserving the
+/// "does not accept good data preceding/following an error" semantics.
+#[monoruby_builtin]
+fn env_replace(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    let other = lfp.arg(0).coerce_to_hash(vm, globals)?;
+
+    // Phase 1: validate everything up front.
+    let mut new_pairs: Vec<(String, String)> = Vec::new();
+    for (k, v) in other.iter() {
+        let key = coerce_env_string(k, vm, globals)?;
+        check_env_key_for_set(&key, &globals.store)?;
+        let value = coerce_env_string(v, vm, globals)?;
+        new_pairs.push((key, value));
+    }
+
+    // Phase 2: drop every current variable from libc + the hash.
+    let cur_keys: Vec<String> = lfp
+        .self_val()
+        .as_hash()
+        .iter()
+        .filter_map(|(k, _)| k.is_str().map(|s| s.to_string()))
+        .collect();
+    for k in &cur_keys {
+        env_unset_one(lfp.self_val(), k, vm, globals)?;
+    }
+    // The `iter()` snapshot above is keyed by string content; a hash
+    // entry whose key happens not to be a String (in theory unreachable
+    // for ENV, but defensive) would be left behind without this clear.
+    lfp.self_val().as_hash().clear()?;
+
+    // Phase 3: insert the validated pairs.
+    for (key, value) in new_pairs {
+        env_set_one(lfp.self_val(), &key, &value, vm, globals)?;
+    }
+    Ok(lfp.self_val())
+}
+
+/// ### ENV.values_at(*keys) -> Array
+///
+/// Returns an array of values for the given keys. Each key is coerced
+/// via `#to_str`, raising TypeError if not coercible.
+#[monoruby_builtin]
+fn env_values_at(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let args = lfp.arg(0).as_array();
+    let hash = lfp.self_val().as_hash();
+    let mut out: Vec<Value> = Vec::with_capacity(args.len());
+    for k in args.iter() {
+        let key = coerce_env_string(*k, vm, globals)?;
+        let key_v = Value::string(key);
+        out.push(hash.get(key_v, vm, globals)?.unwrap_or_default());
+    }
+    Ok(Value::array_from_vec(out))
+}
+
+/// ### ENV.slice(*keys) -> Hash
+///
+/// Returns a Hash containing the values for keys that exist in ENV.
+/// Each key argument is coerced via `#to_str` exactly once (TypeError
+/// if not coercible); the resulting hash uses the *original* argument
+/// objects as keys, matching CRuby's spec behaviour.
+#[monoruby_builtin]
+fn env_slice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let args = lfp.arg(0).as_array();
+    let hash = lfp.self_val().as_hash();
+    let mut map = RubyMap::default();
+    for k in args.iter() {
+        let s = coerce_env_string(*k, vm, globals)?;
+        let s_v = Value::string(s);
+        if let Some(v) = hash.get(s_v, vm, globals)? {
+            map.insert(*k, v, vm, globals)?;
+        }
+    }
+    Ok(Value::hash(map))
+}
+
+/// Like `coerce_env_string`, but returns `Ok(None)` instead of raising
+/// `TypeError` when the value is neither a String nor responds to
+/// `#to_str`. Used by `ENV.rassoc` / `ENV.has_value?` per their specs.
+fn try_coerce_env_string(
+    v: Value,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Result<Option<String>> {
+    if v.is_str().is_some() {
+        let s = v.expect_string(&globals.store)?;
+        if s.as_bytes().contains(&0) {
+            return Err(MonorubyErr::argumenterr("bare \\0 in env"));
+        }
+        return Ok(Some(s));
+    }
+    if globals.check_method(v, IdentId::TO_STR).is_some() {
+        let s = v.coerce_to_str(vm, globals)?;
+        if s.as_bytes().contains(&0) {
+            return Err(MonorubyErr::argumenterr("bare \\0 in env"));
+        }
+        return Ok(Some(s));
+    }
+    Ok(None)
 }
 
 ///


### PR DESCRIPTION
## Summary

Improves `core/env` and `core/exception` ruby/spec pass rates by adding the singleton/instance methods CRuby ships and tightening their argument validation.

- `core/env`: 101 failures + 14 errors → 24 + 5 (≈75% reduction)
- `core/exception`: 83 + 88 → 63 + 86 (~13% reduction)

No regressions in `cargo test --release`: the 19 stable failures on this branch are identical to those on `origin/master` (CRuby 4.x format / locale differences pre-dating this branch).

## Changes by commit

1. **`Fix: ENV[]= and ENV.delete now propagate to libc environ`** — restores `ENV.[]=` / `ENV.store` / `ENV.delete` so they call `setenv(3)` / `unsetenv(3)`, matching CRuby. FFI callers (SDL, glibc, …) that read `getenv(3)` now observe Ruby-side ENV mutations.
2. **`ENV: ruby/spec compliance`** — adds the singleton methods needed by the spec suite:
   - `ENV.to_s` / `ENV.rehash`
   - `ENV.assoc` / `ENV.rassoc` / `ENV.key`
   - `ENV.has_key?` (+ `include?` / `key?` / `member?`) / `ENV.has_value?` (+ `value?`)
   - `ENV.merge!` / `ENV.update` / `ENV.replace` (with full-input validation and `Errno::EINVAL` for empty / `=`-bearing keys; supports the `{|k, old, new| ...}` block on collisions)
   - `ENV.values_at` / `ENV.slice`
   - `ENV.to_h` / `ENV.to_hash` now return a fresh `Hash` snapshot; `to_h` accepts the block form
   - `ENV.[]=` / `store` reject empty / `=`-bearing keys with `Errno::EINVAL`, and return the original value object so `equal?` succeeds
   - As a side effect, `Hash#reject` now returns an `Enumerator` when called without a block (matches `Hash#reject!` / `delete_if` and unblocks ENV.reject specs)
3. **`Exception: add #==, #exception, persist set_backtrace`**
   - `Exception#==` compares class + `#message` + `#backtrace` (was inheriting `Object#==`)
   - `Exception#exception(msg)` returns self / a `#dup`'d copy with new message (preserving subclass ivars)
   - `Exception#set_backtrace` persists its argument and validates input shape; `#backtrace` returns `nil` for never-raised, never-set exceptions
   - `Exception#backtrace_locations` returns `nil` (was crashing on `nil#map`) when no backtrace is set
4. **`ENV / Exception: unify doc comments to るびま format and add unit tests`** — every newly-added Ruby method now uses the project's standard doc-comment shape:
    ```
    ///
    /// ### Class#method
    ///
    /// - signature -> ReturnType
    ///
    /// description
    ///
    /// [https://docs.ruby-lang.org/ja/latest/method/...]
    ```
    Plus 29 new ENV unit tests and 17 new Exception unit tests (identity-preserving `[]=`, EINVAL validation, to_s/rehash, to_h dup + block, assoc/rassoc/key/has_key? coverage, merge!/update/replace incl. fail-fast + EINVAL, values_at/slice TypeError; `==` matrix, `exception` self/new/dup, set_backtrace shape errors, backtrace_locations nil regression guard).
5. **`Serialize ENV-mutating unit tests with a process-wide mutex`** — `setenv(3)` and `unsetenv(3)` are not thread-safe; with the larger ENV test population they raced under cargo's default parallel runner and occasionally SIGSEGV'd. Adds a `Mutex<()>` static and an `env_lock()` helper (recovers from poisoning) acquired at the top of every `env_*` test.

## Test plan

- [x] `cargo test --release -p monoruby --lib builtins::hash::tests::env_` — 37/37 pass
- [x] `cargo test --release -p monoruby --lib builtins::exception::tests` — 25/25 pass
- [x] `cargo test --release -p monoruby --lib` (full) — 1234 pass / 19 pre-existing fails (identical to `origin/master`)
- [x] `cargo test --release -p monoruby --lib -- --test-threads=1` — confirms no parallelism-only failures
- [x] `mspec run core/env -t monoruby` — 24 fail / 5 err (was 101 / 14)
- [x] `mspec run core/exception -t monoruby` — 63 fail / 86 err (was 83 / 88)
- [x] `mspec run core/hash -t monoruby` — same totals as master (no regression from `Hash#reject` Enumerator change)

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_