### PR TITLE
Fix unqualified constant assignment to use lexical scope (cref)

### DIFF
--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -401,4 +401,25 @@ mod tests {
         "##,
         );
     }
+
+    #[test]
+    fn struct_block_constant_lexical_scope() {
+        // CRuby semantics: a constant assigned inside the `Struct.new ... do
+        // ... end` block goes to the *lexical* scope (top-level here), not to
+        // the new Struct subclass. Methods defined in the same block resolve
+        // the constant via the same lexical chain.
+        run_test_with_prelude(
+            r##"
+            [S.new(0).flag, S.constants, Object.constants.include?(:FLAGS)]
+            "##,
+            r##"
+            S = Struct.new(:x) do
+              FLAGS = { foo: 1 }
+              def flag
+                FLAGS[:foo]
+              end
+            end
+            "##,
+        );
+    }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -705,7 +705,15 @@ impl Executor {
         } else if toplevel {
             OBJECT_CLASS
         } else if prefix.is_empty() {
-            self.context_class_id()
+            // CRuby semantics: an unqualified `X = …` assigns into the
+            // *lexical* class — the cref captured at parse time — not the
+            // runtime class context. The two diverge inside `class_eval` /
+            // `module_eval` / `instance_eval` blocks (and `Struct.new(...) do
+            // ... end`, which uses `module_eval` internally), where the
+            // runtime context is the receiver but the lexical scope is the
+            // block's enclosing scope. Mirror `find_constant` / `def`'s use
+            // of the iseq-recorded lexical context.
+            self.definition_func_id(globals).lexical_class(&globals.store)
         } else {
             let parent = prefix.remove(0);
             let current_func = self.method_func_id();


### PR DESCRIPTION
## Summary

`Executor::set_constant` resolved unqualified `X = ...` against the runtime lexical_class stack (`context_class_id()`), but constant *lookup* uses the iseq-recorded `lexical_context`. The two diverge inside `class_eval`/`module_eval`/`instance_eval` blocks — including `Struct.new(...) do ... end`, which calls `module_eval` internally — where the runtime context is the receiver but the lexical scope is the block's enclosing scope.

CRuby (and the cref model) puts the assignment in the lexical scope. The discrepancy meant code like the following raised `uninitialized constant FLAGS (NameError)` on monoruby:

```ruby
S = Struct.new(:x) do
  FLAGS = { foo: 1 }
  def flag = FLAGS[:foo]
end
S.new(0).flag  #=> 1 in CRuby; NameError in monoruby
```

`FLAGS` ended up on `S`, while the method's lexical scope stayed at top-level, so lookup never found it.

## Fix

Use `definition_func_id().lexical_class(&globals.store)` for the assignment target, so the assignment and lookup share one cref-equivalent (mirroring how `define_method` already chooses its lexical class).

## Behavior table

| case | expected | before | after |
|---|---|---|---|
| `class C; X=1; end` | `C` | `C` ✓ | `C` ✓ |
| top-level `X=1` | `Object` | `Object` ✓ | `Object` ✓ |
| `Struct.new(:x){ X=1 }` (top-level) | `Object` | **`S` ✗** | `Object` ✓ |
| `class C; D.class_eval{ X=1 }; end` | `C` | **`D` ✗** | `C` ✓ |
| String `class_eval "X=1"` | receiver | receiver ✓ | receiver ✓ |

## Test plan

- [x] Added `struct_block_constant_lexical_scope` regression test
- [x] Full library test suite: `cargo test --release -p monoruby --lib` (1209 passed, 0 failed)
- [x] Targeted: `builtins::struct_class::`, `builtins::module::`, `builtins::class::`, `builtins::object::` (104 passed)
- [x] Real-world repro (https://github.com/RReverser/doom Ruby port benchmark) no longer hits the original `FLAGS` NameError

🤖 Generated with [Claude Code](https://claude.com/claude-code)