### PR TITLE
Get `monoruby doom/bin/doom` past startup (FFI macros, File.writable?, put_bytes)

### DIFF
--- a/monoruby/gem/ffi_c.rb
+++ b/monoruby/gem/ffi_c.rb
@@ -268,7 +268,9 @@ module FFI
     end
 
     def put_bytes(offset, str, start = 0, length = str.bytesize - start)
-      FFI.___write_bytes(@address + offset, str[start, length])
+      # Slice by bytes, not characters: callers (e.g. SDL_LockSurface +
+      # blob upload) pass binary data that may not be valid UTF-8.
+      FFI.___write_bytes(@address + offset, str.byteslice(start, length))
     end
 
     def put_string(offset, str)

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -67,6 +67,10 @@ module Gosu
     attach_function :get_ticks,        :SDL_GetTicks,         [], :uint32
     attach_function :delay,            :SDL_Delay,            [:uint32], :void
 
+    # SDL_RWops factory used to feed Mix_LoadWAV_RW (see SDL2_mixer below) —
+    # `Mix_LoadWAV` is a header-only macro and not a real exported symbol.
+    attach_function :rw_from_file,     :SDL_RWFromFile,       [:string, :string], :pointer
+
     # --- Window / Renderer ---------------------------------------------
     attach_function :create_window,       :SDL_CreateWindow,
       [:string, :int, :int, :int, :int, :uint32], :pointer
@@ -279,10 +283,26 @@ module Gosu
     attach_function :mix_close_audio,    :Mix_CloseAudio,     [], :void
     attach_function :mix_allocate_channels, :Mix_AllocateChannels, [:int], :int
 
-    attach_function :mix_load_wav,       :Mix_LoadWAV,        [:string], :pointer
+    # `Mix_LoadWAV` in SDL_mixer.h is `#define`d as
+    # `Mix_LoadWAV_RW(SDL_RWFromFile(file,"rb"),1)` — only `Mix_LoadWAV_RW`
+    # is an actual exported symbol. Bind that and wrap it in `mix_load_wav`.
+    attach_function :mix_load_wav_rw,    :Mix_LoadWAV_RW,     [:pointer, :int], :pointer
+
+    def self.mix_load_wav(path)
+      rw = Gosu::SDL2.rw_from_file(path, "rb")
+      return rw if rw.null?
+      mix_load_wav_rw(rw, 1)
+    end
     attach_function :mix_free_chunk,     :Mix_FreeChunk,      [:pointer], :void
-    attach_function :mix_play_channel,   :Mix_PlayChannel,
-      [:int, :pointer, :int], :int
+    # `Mix_PlayChannel` in SDL_mixer.h is `#define`d as
+    # `Mix_PlayChannelTimed(channel,chunk,loops,-1)` — only the *Timed*
+    # variant is actually exported. Bind that and wrap.
+    attach_function :mix_play_channel_timed, :Mix_PlayChannelTimed,
+      [:int, :pointer, :int, :int], :int
+
+    def self.mix_play_channel(channel, chunk, loops)
+      mix_play_channel_timed(channel, chunk, loops, -1)
+    end
     attach_function :mix_volume,         :Mix_Volume,         [:int, :int], :int
     attach_function :mix_volume_chunk,   :Mix_VolumeChunk,    [:pointer, :int], :int
     attach_function :mix_halt_channel,   :Mix_HaltChannel,    [:int], :int

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -47,6 +47,12 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(file, "executable?", executable_, 1);
     globals.define_builtin_module_func(file_test, "executable?", executable_, 1);
 
+    globals.define_builtin_class_func(file, "readable?", readable_, 1);
+    globals.define_builtin_module_func(file_test, "readable?", readable_, 1);
+
+    globals.define_builtin_class_func(file, "writable?", writable_, 1);
+    globals.define_builtin_module_func(file_test, "writable?", writable_, 1);
+
     globals.define_builtin_func_rest(file, "write", write);
     globals.define_builtin_funcs(file, "path", &["to_path"], path, 0);
     globals.define_builtin_func(file, "size", size, 0);
@@ -486,6 +492,36 @@ fn executable_(
         Err(_) => false,
     };
     Ok(Value::bool(b))
+}
+
+fn access_path(vm: &mut Executor, globals: &mut Globals, val: Value, mode: i32) -> Result<bool> {
+    use std::os::unix::ffi::OsStrExt;
+    let path = to_path(vm, globals, val)?;
+    let c = match std::ffi::CString::new(path.as_os_str().as_bytes()) {
+        Ok(c) => c,
+        Err(_) => return Ok(false),
+    };
+    Ok(unsafe { libc::access(c.as_ptr(), mode) } == 0)
+}
+
+///
+/// ### File.readable?
+/// - readable?(path) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/s/readable=3f.html]
+#[monoruby_builtin]
+fn readable_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(access_path(vm, globals, lfp.arg(0), libc::R_OK)?))
+}
+
+///
+/// ### File.writable?
+/// - writable?(path) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/s/writable=3f.html]
+#[monoruby_builtin]
+fn writable_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(access_path(vm, globals, lfp.arg(0), libc::W_OK)?))
 }
 
 ///
@@ -1260,6 +1296,16 @@ mod tests {
         run_test(r##"File.executable?("../LICENSE-MIT")"##);
         run_test(r##"File.executable?("nonexistent_file_xyz")"##);
         run_test(r##"FileTest.executable?("/bin/sh")"##);
+    }
+
+    #[test]
+    fn readable_writable() {
+        run_test(r##"File.readable?("/bin/sh")"##);
+        run_test(r##"File.readable?("nonexistent_file_xyz")"##);
+        run_test(r##"FileTest.readable?("/bin/sh")"##);
+        run_test(r##"File.writable?("/tmp")"##);
+        run_test(r##"File.writable?("nonexistent_file_xyz")"##);
+        run_test(r##"FileTest.writable?("/tmp")"##);
     }
 
     #[test]


### PR DESCRIPTION
Three independent issues blocked the [Doom Ruby port](https://github.com/RReverser/doom) from launching under monoruby. Fixing all three lets `monoruby /path/to/doom/bin/doom` reach the live game window.

## 1. Gosu SDL2_mixer bindings hit C macros, not exported symbols

`Mix_LoadWAV(file)` and `Mix_PlayChannel(c,chunk,loops)` in `SDL_mixer.h` are
```c
#define Mix_LoadWAV(file)               Mix_LoadWAV_RW(SDL_RWFromFile(file,"rb"),1)
#define Mix_PlayChannel(c,chunk,loops)  Mix_PlayChannelTimed(c,chunk,loops,-1)
```
Only the `_RW` / `Timed` variants are real exports — `nm -D libSDL2_mixer-2.0.so.0` confirms `Mix_LoadWAV` and `Mix_PlayChannel` are not present. `attach_function` therefore raised `FFI::NotFoundError` at `require 'gosu'` time.

Bind the real symbols and wrap them in Ruby helpers; add an `SDL_RWFromFile` binding to the SDL2 module to feed `Mix_LoadWAV_RW`.

## 2. `File.writable?` / `File.readable?` missing

`Dir.tmpdir` (used by Doom's `SoundManager#initialize`) calls `File.writable?(dir)`. monoruby only had `File.executable?`. Add both `readable?` / `writable?` on `File` and `FileTest` using `libc::access(2)` for proper effective-UID checks.

## 3. `FFI::AbstractMemory#put_bytes` slices by characters, not bytes

Doom uploads RGBA framebuffer blobs via `Image.from_blob`, which goes through `put_bytes(0, blob, 0, w*h*4)`. The shim did `str[start, length]` — for a UTF-8-tagged binary string that either raises `invalid byte sequence in UTF-8` or, with `Array#join`-built strings (which is exactly what Doom uses), corrupts glibc's heap and aborts:
```
monoruby: malloc.c:4118: _int_malloc: Assertion `chunk_main_arena (fwd)' failed.
```

Switch to `str.byteslice(start, length)`.

## Test plan

- [x] Added `readable_writable` regression test
- [x] Targeted: `cargo test --release -p monoruby --lib builtins::file::` (32 passed)
- [x] Full library suite passes (one pre-existing flaky `Dir.glob` test from parallel cwd interference, unrelated)
- [x] `monoruby /home/monochrome/doom/bin/doom` now reaches the running game window (no errors after `Starting game window...`); previously aborted at `require 'gosu'` (#1), then `Dir.tmpdir` (#2), then heap corruption in `Image.from_blob` (#3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)