### PR TITLE
JIT: spill a victim xmm instead of panicking on "no xmm reg is vacant"

### DIFF
--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -695,7 +695,7 @@ fn math_sqrt(
     // On a negative argument we bail out to the interpreter, which will
     // re-execute the call via the regular builtin and raise DomainError.
     let deopt = ir.new_deopt(state);
-    let fret = dst.map(|dst| state.def_F(dst));
+    let fret = dst.map(|dst| state.def_F(ir, dst));
     ir.inline(move |r#gen, _, labels| {
         let deopt_label = &labels[deopt];
         let do_sqrt = r#gen.jit.label();

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -578,7 +578,7 @@ fn integer_tof(
     }
     let CallSiteInfo { dst, recv, .. } = *callsite;
     if let Some(ret) = dst {
-        let fret = state.def_F(ret).enc();
+        let fret = state.def_F(ir, ret).enc();
         state.load(ir, recv, GP::Rdi);
         ir.inline(move |r#gen, _, _| {
             monoasm! { &mut r#gen.jit,
@@ -1098,7 +1098,7 @@ fn integer_rem_float_rhs(
         // Result discarded; no work needed (rem_ff is pure).
         return true;
     };
-    let dst_xmm = state.def_F(dst);
+    let dst_xmm = state.def_F(ir, dst);
     let using_xmm = state.get_using_xmm();
     ir.inline(move |r#gen, _, _| r#gen.gen_int_rem_if(lhs_xmm, rhs_xmm, dst_xmm, using_xmm));
     true

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -349,7 +349,7 @@ impl<'a> JitContext<'a> {
                             }
                         }
                         let fsrc = state.load_xmm(ir, src);
-                        let dst = state.def_F(dst);
+                        let dst = state.def_F(ir, dst);
                         ir.xmm_move(fsrc, dst);
                         ir.push(AsmInst::XmmUnOp { kind, dst });
                     }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -497,7 +497,7 @@ impl AbstractFrame {
                 self.def_F_with_xmm(dst, lhs);
                 lhs
             } else {
-                self.def_F(dst)
+                self.def_F(ir, dst)
             }
         });
         (lhs, rhs, dst)

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -124,7 +124,7 @@ impl<'a> JitContext<'a> {
                         let src = state.load_xmm(ir, args);
                         state.discard(dst);
                         let using_xmm = state.get_using_xmm();
-                        let dst = state.def_F(dst);
+                        let dst = state.def_F(ir, dst);
                         ir.push(AsmInst::CFunc_F_F {
                             f: *f,
                             src,
@@ -152,7 +152,7 @@ impl<'a> JitContext<'a> {
                         let rhs = state.load_xmm(ir, args);
                         state.discard(dst);
                         let using_xmm = state.get_using_xmm();
-                        let dst = state.def_F(dst);
+                        let dst = state.def_F(ir, dst);
                         ir.push(AsmInst::CFunc_FF_F {
                             f: *f,
                             lhs,

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -127,7 +127,7 @@ impl AbstractState {
         });
         ir.lit2reg(*value, GP::Rax);
         if let Some(f) = value.try_float() {
-            let fdst = self.def_Sf_float(dst);
+            let fdst = self.def_Sf_float(ir, dst);
             ir.f64_to_xmm(f, fdst);
             ir.reg2stack(GP::Rax, dst);
         } else {

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -67,7 +67,9 @@ impl AbstractFrame {
                         // alias created by `copy_slot`). Rebind to a fresh
                         // xmm that no slot in the merge context uses, so
                         // each bridge can emit a single `xmm_move` instead.
-                        self.set_new_F(i);
+                        // No AsmIr here — if a Phase-2 spill would be needed,
+                        // fall back to keeping `F(l)` and let the bridge swap.
+                        let _ = self.try_set_new_F(i);
                     }
                 }
                 (LinkMode::F(_), LinkMode::C(r)) if r.is_float() => {}
@@ -90,8 +92,12 @@ impl AbstractFrame {
                         // Same reasoning as the F/F arm: register disagreement
                         // across branches would force bridge-time swaps that
                         // trample partner slots created by `copy_slot`'s
-                        // zero-cost alias. Rebind to a fresh xmm.
-                        self.set_new_Sf(i, guarded);
+                        // zero-cost alias. Rebind to a fresh xmm if possible;
+                        // otherwise keep the current Sf binding and let the
+                        // bridge handle the swap.
+                        if self.try_set_new_Sf(i, guarded).is_none() {
+                            self.set_Sf(i, x, guarded);
+                        }
                     }
                 }
                 (LinkMode::Sf(x, mut guarded), LinkMode::C(r)) if r.is_float() || r.is_fixnum() => {
@@ -99,16 +105,25 @@ impl AbstractFrame {
                     self.set_Sf(i, x, guarded)
                 }
                 (LinkMode::C(v), LinkMode::F(_)) if v.is_float() => {
-                    self.set_new_F(i);
+                    if self.try_set_new_F(i).is_none() {
+                        // Fall back to S — bridge will materialise from the
+                        // concrete literal on the C side and from xmm on the
+                        // F side.
+                        self.set_S_with_guard(i, Guarded::Float);
+                    }
                 }
                 (LinkMode::C(v), LinkMode::Sf(_, r)) if v.is_float() || v.is_fixnum() => {
                     let mut guarded = SfGuarded::from_concrete_value(v);
                     guarded.join(r);
-                    self.set_new_Sf(i, guarded);
+                    if self.try_set_new_Sf(i, guarded).is_none() {
+                        self.set_S_with_guard(i, guarded.into());
+                    }
                 }
                 (LinkMode::C(l), LinkMode::C(r)) if l == r => {}
                 (LinkMode::C(l), LinkMode::C(r)) if l.is_float() && r.is_float() => {
-                    self.set_new_F(i);
+                    if self.try_set_new_F(i).is_none() {
+                        self.set_S_with_guard(i, Guarded::Float);
+                    }
                 }
                 _ => {
                     let guarded = self.guarded(i).join(&other.guarded(i));

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -101,7 +101,7 @@ impl AbstractFrame {
                 // S -> Sf
                 ir.stack2reg(slot, GP::Rdi);
                 self.guard_fixnum(ir, slot, GP::Rdi);
-                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
+                let x = self.set_new_Sf(ir, slot, SfGuarded::Fixnum);
                 ir.fixnum2xmm(GP::Rdi, x);
                 x
             }
@@ -109,7 +109,7 @@ impl AbstractFrame {
                 // G -> Sf
                 ir.reg2stack(GP::R15, slot);
                 self.guard_fixnum(ir, slot, GP::R15);
-                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
+                let x = self.set_new_Sf(ir, slot, SfGuarded::Fixnum);
                 ir.fixnum2xmm(GP::R15, x);
                 x
             }
@@ -134,14 +134,14 @@ impl AbstractFrame {
             LinkMode::Sf(x, _) | LinkMode::F(x) => x,
             LinkMode::S(_) => {
                 // -> Sf
-                let x = self.set_new_Sf(slot, SfGuarded::Float);
+                let x = self.set_new_Sf(ir, slot, SfGuarded::Float);
                 ir.stack2reg(slot, GP::Rdi);
                 ir.float_to_xmm(GP::Rdi, x, deopt);
                 x
             }
             LinkMode::G(_) => {
                 // -> Sf
-                let x = self.set_new_Sf(slot, SfGuarded::Float);
+                let x = self.set_new_Sf(ir, slot, SfGuarded::Float);
                 ir.reg2stack(GP::R15, slot);
                 ir.float_to_xmm(GP::R15, x, deopt);
                 x
@@ -162,7 +162,7 @@ impl AbstractFrame {
             }
             RV::Fixnum(i) => {
                 // -> Sf
-                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
+                let x = self.set_new_Sf(ir, slot, SfGuarded::Fixnum);
                 ir.i64_to_stack_and_xmm(i, slot, x);
                 x
             }
@@ -173,7 +173,7 @@ impl AbstractFrame {
     }
 
     fn load_xmm_from_f64(&mut self, ir: &mut AsmIr, slot: SlotId, f: f64) -> Xmm {
-        let x = self.set_new_F(slot);
+        let x = self.set_new_F(ir, slot);
         ir.f64_to_xmm(f, x);
         x
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -112,7 +112,11 @@ impl SlotState {
             match self.mode(slot) {
                 LinkMode::S(_) => {
                     if as_f64 {
-                        self.set_new_Sf(slot, SfGuarded::Float);
+                        // Liveness-driven hint only — if no xmm is free without
+                        // a real spill, leave the slot on the stack and rely on
+                        // a lazy `load_xmm` later (which has access to AsmIr
+                        // and can spill if needed).
+                        let _ = self.try_set_new_Sf(slot, SfGuarded::Float);
                     }
                 }
                 LinkMode::C(_) => {}
@@ -195,18 +199,102 @@ impl SlotState {
     }
 
     ///
-    /// Allocate a new xmm register.
+    /// Try to allocate a new xmm register without emitting any asm.
     ///
-    /// ### Panics
-    /// If there is no vacant xmm register.
+    /// Phase 0: returns the first vacant xmm.
+    /// Phase 1: if no vacant xmm, finds an xmm whose linked slots are all `Sf`
+    ///          (stack already holds the value, xmm is just a read-only cache);
+    ///          demotes them all to `S` and returns the freed xmm. No asm is
+    ///          emitted because the stack already has the canonical value.
     ///
-    fn alloc_xmm(&mut self) -> Xmm {
-        for (flhs, xmm) in self.xmm.iter_mut().enumerate() {
+    /// Returns `None` if every xmm holds at least one `F` slot (would require
+    /// a real spill; use [`Self::alloc_xmm`] from a context that has access to
+    /// `AsmIr`).
+    ///
+    fn try_alloc_xmm_demote(&mut self) -> Option<Xmm> {
+        // Phase 0: a vacant xmm.
+        for (i, xmm) in self.xmm.iter().enumerate() {
             if xmm.is_empty() {
-                return Xmm(flhs as u16);
+                return Some(Xmm(i as u16));
             }
         }
-        panic!("no xmm reg is vacant.")
+        // Phase 1: an xmm whose linked slots are all `Sf` — demote them.
+        for i in 0..self.xmm.len() {
+            if self.xmm[i].is_empty() {
+                continue;
+            }
+            let all_sf = self.xmm[i]
+                .iter()
+                .all(|&s| matches!(self.mode(s), LinkMode::Sf(_, _)));
+            if !all_sf {
+                continue;
+            }
+            let to_demote: Vec<(SlotId, SfGuarded)> = self.xmm[i]
+                .iter()
+                .map(|&s| match self.mode(s) {
+                    LinkMode::Sf(_, g) => (s, g),
+                    _ => unreachable!(),
+                })
+                .collect();
+            self.xmm[i].clear();
+            for (s, g) in to_demote {
+                self.set_mode(s, LinkMode::S(g.into()));
+            }
+            return Some(Xmm(i as u16));
+        }
+        None
+    }
+
+    ///
+    /// Allocate a new xmm register, spilling a victim if necessary.
+    ///
+    /// Tries Phase 0 (vacant) and Phase 1 (Sf-only demote) first. If both fail,
+    /// picks a victim xmm with the fewest `F` slots (cheapest to spill), emits
+    /// `xmm2stack` for each `F` slot, demotes every linked slot to `S`, and
+    /// returns the freed xmm. Always succeeds.
+    ///
+    fn alloc_xmm(&mut self, ir: &mut AsmIr) -> Xmm {
+        if let Some(x) = self.try_alloc_xmm_demote() {
+            return x;
+        }
+        // Phase 2: pick the xmm with the fewest F slots to minimise emit cost.
+        let victim_idx = (0..self.xmm.len())
+            .min_by_key(|&i| {
+                self.xmm[i]
+                    .iter()
+                    .filter(|&&s| matches!(self.mode(s), LinkMode::F(_)))
+                    .count()
+            })
+            .expect("xmm vec is empty");
+        let xmm_v = Xmm(victim_idx as u16);
+        let slots: Vec<SlotId> = self.xmm[victim_idx].iter().copied().collect();
+        debug_assert!(!slots.is_empty());
+
+        // Emit xmm2stack for each F slot. Multiple F slots aliased to the
+        // same xmm hold the same f64 value; each still needs its own stack
+        // location populated (an asmir-side optimisation could batch these).
+        for &s in &slots {
+            if matches!(self.mode(s), LinkMode::F(_)) {
+                ir.xmm2stack(xmm_v, s);
+            }
+        }
+
+        let to_demote: Vec<(SlotId, Guarded)> = slots
+            .iter()
+            .map(|&s| {
+                let g = match self.mode(s) {
+                    LinkMode::F(_) => Guarded::Float,
+                    LinkMode::Sf(_, sg) => sg.into(),
+                    _ => unreachable!(),
+                };
+                (s, g)
+            })
+            .collect();
+        self.xmm[victim_idx].clear();
+        for (s, g) in to_demote {
+            self.set_mode(s, LinkMode::S(g));
+        }
+        xmm_v
     }
 
     ///
@@ -307,23 +395,45 @@ impl SlotState {
     }
 
     ///
-    /// C -> F
+    /// C -> F (may emit a victim spill if no xmm is free).
     ///
     #[allow(non_snake_case)]
-    pub(super) fn set_new_F(&mut self, slot: SlotId) -> Xmm {
-        let x = self.alloc_xmm();
+    pub(super) fn set_new_F(&mut self, ir: &mut AsmIr, slot: SlotId) -> Xmm {
+        let x = self.alloc_xmm(ir);
         self.set_F(slot, x);
         x
     }
 
     ///
-    /// C -> Sf
+    /// C -> F (no asm emit). Returns `None` when only Phase-2 spill could free
+    /// an xmm — caller should fall back (e.g. leave the slot as `S`).
     ///
     #[allow(non_snake_case)]
-    pub(super) fn set_new_Sf(&mut self, slot: SlotId, guarded: SfGuarded) -> Xmm {
-        let x = self.alloc_xmm();
+    pub(super) fn try_set_new_F(&mut self, slot: SlotId) -> Option<Xmm> {
+        let x = self.try_alloc_xmm_demote()?;
+        self.set_F(slot, x);
+        Some(x)
+    }
+
+    ///
+    /// C -> Sf (may emit a victim spill if no xmm is free).
+    ///
+    #[allow(non_snake_case)]
+    pub(super) fn set_new_Sf(&mut self, ir: &mut AsmIr, slot: SlotId, guarded: SfGuarded) -> Xmm {
+        let x = self.alloc_xmm(ir);
         self.set_Sf(slot, x, guarded);
         x
+    }
+
+    ///
+    /// C -> Sf (no asm emit). Returns `None` when only Phase-2 spill could free
+    /// an xmm.
+    ///
+    #[allow(non_snake_case)]
+    pub(super) fn try_set_new_Sf(&mut self, slot: SlotId, guarded: SfGuarded) -> Option<Xmm> {
+        let x = self.try_alloc_xmm_demote()?;
+        self.set_Sf(slot, x, guarded);
+        Some(x)
     }
 
     ///
@@ -356,11 +466,11 @@ impl SlotState {
     }
 
     ///
-    /// Link *slot* to a new xmm register.
+    /// Link *slot* to a new xmm register (may emit a victim spill).
     ///
     #[allow(non_snake_case)]
-    pub(crate) fn def_F(&mut self, slot: SlotId) -> Xmm {
-        let xmm = self.alloc_xmm();
+    pub(crate) fn def_F(&mut self, ir: &mut AsmIr, slot: SlotId) -> Xmm {
+        let xmm = self.alloc_xmm(ir);
         self.discard(slot);
         self.set_F(slot, xmm);
         xmm
@@ -374,19 +484,20 @@ impl SlotState {
     }
 
     ///
-    /// Link *slot* to both of the stack and a new xmm register.
+    /// Link *slot* to both of the stack and a new xmm register (may emit a
+    /// victim spill).
     ///
     #[allow(non_snake_case)]
-    fn def_Sf(&mut self, slot: SlotId, guarded: SfGuarded) -> Xmm {
-        let xmm = self.alloc_xmm();
+    fn def_Sf(&mut self, ir: &mut AsmIr, slot: SlotId, guarded: SfGuarded) -> Xmm {
+        let xmm = self.alloc_xmm(ir);
         self.discard(slot);
         self.set_Sf(slot, xmm, guarded);
         xmm
     }
 
     #[allow(non_snake_case)]
-    pub(crate) fn def_Sf_float(&mut self, slot: SlotId) -> Xmm {
-        self.def_Sf(slot, SfGuarded::Float)
+    pub(crate) fn def_Sf_float(&mut self, ir: &mut AsmIr, slot: SlotId) -> Xmm {
+        self.def_Sf(ir, slot, SfGuarded::Float)
     }
 
     ///
@@ -1273,7 +1384,7 @@ impl AbstractFrame {
                     ir.float_to_xmm(GP::Rax, x, deopt);
                     self.set_Sf_float(slot, x);
                 } else {
-                    let tmp = self.set_new_Sf(slot, SfGuarded::Float);
+                    let tmp = self.set_new_Sf(ir, slot, SfGuarded::Float);
                     ir.float_to_xmm(GP::Rax, tmp, deopt);
                     self.gen_xmm_swap(ir, x, tmp);
                 }
@@ -1285,7 +1396,7 @@ impl AbstractFrame {
                     ir.float_to_xmm(GP::R15, x, deopt);
                     self.set_Sf_float(slot, x);
                 } else {
-                    let tmp = self.set_new_Sf(slot, SfGuarded::Float);
+                    let tmp = self.set_new_Sf(ir, slot, SfGuarded::Float);
                     ir.float_to_xmm(GP::R15, tmp, deopt);
                     self.gen_xmm_swap(ir, x, tmp);
                 }


### PR DESCRIPTION
## Summary
- Float-heavy methods can pin all 14 xmm registers; `alloc_xmm` then panicked with `"no xmm reg is vacant."` and crashed the process via the cannot_unwind FFI boundary
- Replace the panic with a two-phase victim spill (classical register allocator pattern); existing stack slots are reused — no new frame slots are allocated
- Phase 1 (no asm emit) is reusable from contexts without `AsmIr`; Phase 2 emits `xmm2stack` for `F` slots and demotes everything to `S`

## Design
Two-tier allocator:

| Phase | Trigger | Behaviour |
|---|---|---|
| 0 | always | return any vacant xmm |
| 1 | no vacant xmm; some xmm has only `Sf` slots | demote them all to `S` (stack already canonical, xmm was a read-only cache); **no asm emit** |
| 2 | no vacant xmm; every xmm has at least one `F` slot | pick the xmm with the fewest `F` slots, emit `xmm2stack` for each, demote every linked slot to `S` |

`set_new_F` / `set_new_Sf` / `def_F` / `def_Sf` / `def_Sf_float` now take `&mut AsmIr` so they can drive Phase 2. `AbstractFrame::join` and `SlotState::use_float` operate on abstract state with no `AsmIr` available — they call the `try_set_new_*` variants (Phase 0+1 only) and fall back to `S` when only Phase 2 could free an xmm; the bridge materialises the value at branch reconciliation as usual.

The demote/spill is invisible to callers (they still get a valid `Xmm`), so no error-handling branches propagate through the JIT pipeline.

## Test plan
- [x] Lib test failure count unchanged from master baseline (91 pre-existing failures from system Ruby version mismatch)
- [x] Synthetic 30-local float stress test produces identical result to CRuby (`-2248753.679656`)
- [x] DOOM `licm_experiment.rb` (320×120 × 500 passes) runs to completion with results matching CRuby
- [x] Phase 1 demote confirmed firing extensively (verified via temporary trace, then removed)
- [x] No new `unsafe`, no `panic!`, no `unwrap()` on the hot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)