### PR TITLE
JIT: bridge F -> Sf(_, FixnumOrFloat) at branch merge

### DIFF
--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1354,14 +1354,20 @@ impl AbstractFrame {
                     }
                 }
             }
-            (LinkMode::F(l), LinkMode::Sf(r, SfGuarded::Float)) => {
+            (
+                LinkMode::F(l),
+                LinkMode::Sf(r, guarded @ (SfGuarded::Float | SfGuarded::FixnumOrFloat)),
+            ) => {
+                // F means the xmm holds a float; writing back produces a
+                // Value::float, which satisfies both the Float and the
+                // FixnumOrFloat guards.
                 ir.xmm2stack(l, slot);
                 if l == r {
                     // F(l) -> Sf(l)
-                    self.set_Sf_float(slot, l);
+                    self.set_Sf(slot, l, guarded);
                 } else {
                     // F(l) -> Sf(r)
-                    self.to_sf(ir, slot, l, r, SfGuarded::Float);
+                    self.to_sf(ir, slot, l, r, guarded);
                 }
             }
             (LinkMode::F(_) | LinkMode::G(_), LinkMode::S(_)) => {


### PR DESCRIPTION
## Summary

- Fix a panic in `AbstractFrame::bridge` (`codegen/jitgen/state/slot.rs`) when the joined target state widens an `Sf` slot's guard to `FixnumOrFloat` while the source branch holds the slot in `F(_)`.
- Reproduces in `monoruby ../doom/bin/doom`: after the renderer starts and the player presses a key, the JIT compiles a function with mixed fixnum/float arithmetic across branches, and the bridge falls through to `unreachable!`:
  ```
  thread 'main' panicked at slot.rs:1444:17:
  internal error: entered unreachable code:
    %14 F(Xmm(8))->Sf(Xmm(8), FixnumOrFloat) { ... }
  ```

## Why the state arises

`SfGuarded::join` widens `Float ⊔ Fixnum` to `FixnumOrFloat` (`state/join.rs`). When one branch enters a merge as `F(x)` (treated as `Sf(_, Float)` for the join) and another as `Sf(_, Fixnum)`, the merged slot becomes `Sf(_, FixnumOrFloat)`. The bridge then has to transition the `F(_)` side into that merged state, but the existing `match` only listed `SfGuarded::Float`.

## Fix

`F(l)` already holds a float in xmm, so `xmm2stack` writes a `Value::float` that satisfies both `Float` and `FixnumOrFloat`. Extend the pattern to accept either variant and propagate the target's guard through `set_Sf` / `to_sf` rather than hard-coding `Float`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --lib codegen::jitgen::state` (3 passed, including the existing `test_join*` regressions)
- [ ] Local replay of `monoruby ../doom/bin/doom` past the prior panic point (manual; requires a display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)