### PR TITLE
JIT: pin in-flight xmm operands to prevent alloc_xmm aliasing

### DIFF
--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -349,7 +349,9 @@ impl<'a> JitContext<'a> {
                             }
                         }
                         let fsrc = state.load_xmm(ir, src);
+                        state.pin_xmm(fsrc);
                         let dst = state.def_F(ir, dst);
+                        state.unpin_xmm(fsrc);
                         ir.xmm_move(fsrc, dst);
                         ir.push(AsmInst::XmmUnOp { kind, dst });
                     }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -475,10 +475,18 @@ impl AbstractFrame {
             ..
         } = info;
         if lhs != rhs {
-            (
-                self.fetch_float_assume(ir, lhs, lhs_class),
-                self.fetch_float_assume(ir, rhs, rhs_class),
-            )
+            // Loading lhs may set an `Sf` mode on its xmm. Without pinning,
+            // the next allocator call (when loading rhs) can demote that
+            // same xmm via Phase-1 of `try_alloc_xmm_demote` and hand it
+            // back as the rhs xmm — so the consumer would compare /
+            // arithmetic the value with itself. Pin lhs across the rhs
+            // load to force the allocator to pick a different physical
+            // register.
+            let lhs_xmm = self.fetch_float_assume(ir, lhs, lhs_class);
+            self.pin_xmm(lhs_xmm);
+            let rhs_xmm = self.fetch_float_assume(ir, rhs, rhs_class);
+            self.unpin_xmm(lhs_xmm);
+            (lhs_xmm, rhs_xmm)
         } else {
             let lhs = self.fetch_float_assume(ir, lhs, lhs_class);
             (lhs, lhs)
@@ -492,6 +500,11 @@ impl AbstractFrame {
         info: FBinOpInfo,
     ) -> (Xmm, Xmm, Option<Xmm>) {
         let (lhs, rhs) = self.load_binary_xmm(ir, info);
+        // Pin both operands while allocating the destination — `def_F` calls
+        // `alloc_xmm`, which can otherwise pick `lhs` or `rhs` as the spill
+        // victim and alias dst onto an operand the consumer still needs.
+        self.pin_xmm(lhs);
+        self.pin_xmm(rhs);
         let dst = dst.map(|dst| {
             if dst == info.lhs {
                 self.def_F_with_xmm(dst, lhs);
@@ -500,6 +513,8 @@ impl AbstractFrame {
                 self.def_F(ir, dst)
             }
         });
+        self.unpin_xmm(rhs);
+        self.unpin_xmm(lhs);
         (lhs, rhs, dst)
     }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -122,9 +122,11 @@ impl<'a> JitContext<'a> {
                     }
                     if let Some(dst) = dst {
                         let src = state.load_xmm(ir, args);
+                        state.pin_xmm(src);
                         state.discard(dst);
                         let using_xmm = state.get_using_xmm();
                         let dst = state.def_F(ir, dst);
+                        state.unpin_xmm(src);
                         ir.push(AsmInst::CFunc_F_F {
                             f: *f,
                             src,
@@ -148,11 +150,19 @@ impl<'a> JitContext<'a> {
                         }
                     }
                     if let Some(dst) = dst {
+                        // Pin lhs across rhs load and dst alloc; otherwise the
+                        // allocator can pick lhs's xmm as spill victim and the
+                        // consuming CFunc gets aliased operands. Same for rhs
+                        // across the dst alloc.
                         let lhs = state.load_xmm(ir, recv);
+                        state.pin_xmm(lhs);
                         let rhs = state.load_xmm(ir, args);
+                        state.pin_xmm(rhs);
                         state.discard(dst);
                         let using_xmm = state.get_using_xmm();
                         let dst = state.def_F(ir, dst);
+                        state.unpin_xmm(rhs);
+                        state.unpin_xmm(lhs);
                         ir.push(AsmInst::CFunc_FF_F {
                             f: *f,
                             lhs,

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -10,6 +10,14 @@ pub(crate) struct SlotState {
     xmm: [Vec<SlotId>; 14],
     r15: Option<SlotId>,
     local_num: usize,
+    /// xmm registers that must not be reused by `alloc_xmm` /
+    /// `try_alloc_xmm_demote`. Used by callers that have just produced
+    /// an xmm-resident value but have not yet emitted the consuming
+    /// instruction — without this, a subsequent allocation can pick
+    /// that same xmm as a spill victim (e.g. demote its `Sf` slot to
+    /// `S`) and hand the same physical register back, so the consumer
+    /// ends up reading both operands from the same register.
+    pinned_xmm: Vec<Xmm>,
 }
 
 impl std::fmt::Debug for SlotState {
@@ -37,6 +45,7 @@ impl SlotState {
             },
             r15: None,
             local_num,
+            pinned_xmm: Vec::new(),
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
         ctx
@@ -198,6 +207,25 @@ impl SlotState {
         self.xmm[xmm.0 as usize].retain(|e| *e != slot);
     }
 
+    /// Mark *xmm* off-limits for subsequent `alloc_xmm` /
+    /// `try_alloc_xmm_demote` calls until [`Self::unpin_xmm`] is invoked.
+    /// Use this when an xmm has just been produced (loaded or written) and
+    /// is needed by an upcoming instruction in the same compile step —
+    /// without the pin, a later allocation in the same step can choose the
+    /// freshly-loaded xmm as a spill victim and reuse it for an unrelated
+    /// value.
+    pub(in crate::codegen::jitgen) fn pin_xmm(&mut self, xmm: Xmm) {
+        if !self.pinned_xmm.contains(&xmm) {
+            self.pinned_xmm.push(xmm);
+        }
+    }
+
+    pub(in crate::codegen::jitgen) fn unpin_xmm(&mut self, xmm: Xmm) {
+        if let Some(pos) = self.pinned_xmm.iter().position(|x| *x == xmm) {
+            self.pinned_xmm.swap_remove(pos);
+        }
+    }
+
     ///
     /// Try to allocate a new xmm register without emitting any asm.
     ///
@@ -212,14 +240,21 @@ impl SlotState {
     /// `AsmIr`).
     ///
     fn try_alloc_xmm_demote(&mut self) -> Option<Xmm> {
+        let pinned = &self.pinned_xmm;
         // Phase 0: a vacant xmm.
         for (i, xmm) in self.xmm.iter().enumerate() {
+            if pinned.contains(&Xmm(i as u16)) {
+                continue;
+            }
             if xmm.is_empty() {
                 return Some(Xmm(i as u16));
             }
         }
         // Phase 1: an xmm whose linked slots are all `Sf` — demote them.
         for i in 0..self.xmm.len() {
+            if self.pinned_xmm.contains(&Xmm(i as u16)) {
+                continue;
+            }
             if self.xmm[i].is_empty() {
                 continue;
             }
@@ -259,13 +294,14 @@ impl SlotState {
         }
         // Phase 2: pick the xmm with the fewest F slots to minimise emit cost.
         let victim_idx = (0..self.xmm.len())
+            .filter(|&i| !self.pinned_xmm.contains(&Xmm(i as u16)))
             .min_by_key(|&i| {
                 self.xmm[i]
                     .iter()
                     .filter(|&&s| matches!(self.mode(s), LinkMode::F(_)))
                     .count()
             })
-            .expect("xmm vec is empty");
+            .expect("xmm vec is empty (every xmm is pinned)");
         let xmm_v = Xmm(victim_idx as u16);
         let slots: Vec<SlotId> = self.xmm[victim_idx].iter().copied().collect();
         debug_assert!(!slots.is_empty());
@@ -1526,6 +1562,41 @@ mod tests {
           res
         end
         test
+        "###,
+        );
+    }
+
+    /// Regression test for the `alloc_xmm` aliasing bug. When `load_binary_xmm`
+    /// loaded `lhs` into xmm `A` and then loaded `rhs`, Phase-1 of
+    /// `try_alloc_xmm_demote` could demote `A`'s `Sf` slot back to `S` and hand
+    /// `A` back as the rhs xmm. The consuming `ucomisd xmm A, xmm A` then
+    /// always reported equal, so `d2 > 0` evaluated false even when
+    /// `d2 = 100.0` and the ternary fell through to `Float::INFINITY`. The
+    /// trigger needs ~14 simultaneously-live floats so all xmms are occupied
+    /// when the second operand is loaded.
+    ///
+    /// Discovered while running the `khasinski/doom` Ruby port under
+    /// monoruby — the renderer's sprite-vs-wall clip uses exactly this
+    /// shape and sprites would draw through walls until the fix.
+    #[test]
+    fn test_alloc_xmm_aliasing_under_pressure() {
+        run_test(
+            r###"
+        def f(d1, d2, x, y, s, c, p)
+          px = x - 100.0
+          py = y - 100.0
+          w  = 160
+          c1 = c * p - s * w
+          c2 = s * p + c * w
+          ta = py * s  + px * c
+          tb = py * c1 - px * c2
+          s1 = d1 > 0 ? p / d1 : Float::INFINITY
+          s2 = d2 > 0 ? p / d2 : Float::INFINITY
+          [s1, s2, ta, tb, px, py]
+        end
+        # Warm the JIT, then probe.
+        1500.times { f(50.0, 100.0, 1024.0, -1024.0, 0.5, 0.866, 160.0) }
+        f(50.0, 100.0, 1024.0, -1024.0, 0.5, 0.866, 160.0)
         "###,
         );
     }


### PR DESCRIPTION
## What

Fix an `alloc_xmm` aliasing bug that produced wrong results from binary
float operations under high xmm pressure (~14 simultaneously-live floats).

## Root cause

`load_binary_xmm` loaded `lhs` into xmm `A`, leaving `A` linked to the
slot in `Sf` mode. When loading `rhs` then ran out of vacant xmms,
Phase 1 of `try_alloc_xmm_demote` happily picked `A` as a victim
(its only inhabitant was an `Sf` slot it considered "demotable"),
returned `A` as the freed register, and reused it for the rhs.
The resulting `(lhs_xmm, rhs_xmm)` tuple aliased the same physical
register, so the consuming `ucomisd xmm A, xmm A` (or `mulsd` /
`subsd`) compared the value with itself.

A reduced reproducer that triggered this from `khasinski/doom`:

```ruby
def f(d1, d2, x, y, s, c, p)
  px = x - 100.0
  py = y - 100.0
  w  = 160
  c1 = c * p - s * w
  c2 = s * p + c * w
  ta = py * s  + px * c
  tb = py * c1 - px * c2
  s1 = d1 > 0 ? p / d1 : Float::INFINITY
  s2 = d2 > 0 ? p / d2 : Float::INFINITY
  [s1, s2, ta, tb, px, py]
end
1500.times { f(50.0, 100.0, 1024.0, -1024.0, 0.5, 0.866, 160.0) }
f(50.0, 100.0, 1024.0, -1024.0, 0.5, 0.866, 160.0)
# expected: [3.2, 1.6, ...]
# JIT before fix: [3.2, Infinity, ...]   # `d2 > 0` evaluated false
```

This is the same `alloc_xmm` machinery that was previously hardened in
#348 (xmm-spill instead of panicking) and #353 (`F -> Sf(_, FixnumOrFloat)`
bridge); both addressed correctness on the producer side. This patch
addresses correctness on the consumer side: an in-flight xmm must not
be victimised by a sibling allocation in the same op.

## The fix

`SlotState` grows a small `pinned_xmm: Vec<Xmm>` set. `try_alloc_xmm_demote`
and Phase 2 of `alloc_xmm` skip pinned registers. Callers that hold a
just-loaded xmm across another allocation (binary loads, the xmm-binop
destination allocation, unary float ops, the `CFunc_F_F` /
`CFunc_FF_F` inlined paths) pin during the at-risk window and
unpin immediately afterward. The pin is purely a runtime
allocator hint; there is no change to the LinkMode state machine.

Four sites pinned:

- `load_binary_xmm` — pin lhs across rhs load
- `load_binary_ret_xmm` — pin lhs and rhs across dst alloc
- unary float op (`compile.rs`) — pin src across dst alloc
- `CFunc_F_F` / `CFunc_FF_F` (`method_call.rs`) — pin src and rhs across dst alloc

## Test

`test_alloc_xmm_aliasing_under_pressure` in
`codegen/jitgen/state/slot.rs` — minimised from the doom repro above,
fails before this change, passes after.

## In-game impact

Found while running the `khasinski/doom` Ruby port under monoruby.
The renderer's sprite-vs-wall clip in `Renderer#draw_seg_range`
hits this code shape (many simultaneously-live floats around a
ternary-with-`Float::INFINITY`), so sprites drew through walls.

Headless render of E1M1 at pose `(x=504, y=-3239, z=41, angle=180)`,
50-frame JIT warmup:

**Before** (imp visible through the back wall):

<img width="720" height="540" alt="before" src="https://github.com/user-attachments/assets/d5837c9b-c252-41e4-9046-f4ba2095b23d" />

**After** (imp correctly occluded):

<img width="720" height="540" alt="after" src="https://github.com/user-attachments/assets/77ac55cd-87ec-4076-b763-d728d790022e" />



(Doom still has a separate JIT'd wall-texture artefact that is
not addressed here; it lives somewhere else in `draw_seg_range`'s
outer body and reproduces deterministically with method-level
bisection ending at that one method. Will file a separate issue
with the framebuffer-hash repro harness once narrowed.)
