### PR TITLE
JIT: load recv before allocating dst in integer_tof (fixes NaN on aliased slot)

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -578,8 +578,17 @@ fn integer_tof(
     }
     let CallSiteInfo { dst, recv, .. } = *callsite;
     if let Some(ret) = dst {
-        let fret = state.def_F(ir, ret).enc();
+        // Load `recv` BEFORE allocating `ret`'s xmm. When `ret == recv`
+        // (a common slot-reuse pattern, e.g. `496.to_f` or chained
+        // `v.x.to_f`), `def_F(ir, ret)` discards `recv`'s existing
+        // binding and sets the slot to `F(fresh_xmm)`. A subsequent
+        // `state.load(ir, recv, ..)` then sees the slot in `F` mode
+        // and emits an `xmm2stack` write-back of the *uninitialised*
+        // fresh xmm — so `rdi` ends up holding boxed-NaN garbage, the
+        // `sarq` / `cvtsi2sdq` below produce NaN, and the caller sees
+        // `496.to_f #=> NaN`.
         state.load(ir, recv, GP::Rdi);
+        let fret = state.def_F(ir, ret).enc();
         ir.inline(move |r#gen, _, _| {
             monoasm! { &mut r#gen.jit,
                 sarq  rdi, 1;
@@ -1939,6 +1948,38 @@ fn format_bigint_base(n: &BigInt, base: u32) -> String {
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    /// Regression test for `integer_tof`: when the to_f result aliases the
+    /// receiver slot (very common — e.g. `496.to_f` or chained
+    /// `v.x.to_f` where the bytecodegen reuses the slot), the inline
+    /// allocator used to discard the receiver's binding before reading it
+    /// and produced NaN.
+    ///
+    /// Discovered while running the `khasinski/doom` Ruby port under
+    /// monoruby — the renderer's `draw_seg_range` does many
+    /// `seg_v1.x.to_f` / `seg_v1.y.to_f` calls and the chained form
+    /// returned NaN, corrupting all downstream wall-texture mapping.
+    #[test]
+    fn integer_tof_jit_inline_aliased_dst() {
+        run_test(
+            r##"
+        class V
+          attr_reader :x
+          def initialize(x); @x = x; end
+        end
+        v = V.new(496)
+        # Chained: `v.x.to_f`. bytecodegen tends to reuse the slot
+        # receiving `v.x`'s return as the dst of `to_f`, so dst aliases recv.
+        def chained(v); v.x.to_f; end
+        # Literal Integer: same shape -- the LOAD_CONST result and the to_f
+        # destination land in the same slot.
+        def literal; 496.to_f; end
+        # Warm the JIT, then check.
+        3000.times { chained(v); literal }
+        [chained(v), literal]
+        "##,
+        );
+    }
 
     #[test]
     fn times() {


### PR DESCRIPTION
## What

Fix `Integer#to_f`'s JIT inline returning NaN when the destination slot
aliases the receiver slot (a very common shape: a literal integer
`.to_f` or a chained `.x.to_f`).

## Root cause

`integer_tof` had:

```rust
let fret = state.def_F(ir, ret).enc();   // 1) discard recv's binding, alloc fresh xmm
state.load(ir, recv, GP::Rdi);            // 2) read recv  --  but recv's mode just changed!
```

Bytecodegen frequently routes both `recv` and `ret` through the same
slot (literal `496.to_f`; chained `v.x.to_f`). When that happens:

1. `def_F(ret)` discards the slot's existing mode and assigns
   `F(fresh_xmm)`. The fresh xmm is *uninitialised*.
2. `state.load(ir, recv, Rdi)` then sees the slot in `F` mode and
   takes the `F → Sf` path, which emits `xmm2stack(fresh_xmm, slot)`.
   That converts the uninitialised xmm via `f64_to_val` and stores
   the boxed-NaN garbage into rdi.
3. The inline `sarq rdi, 1; cvtsi2sdq xmm(fret), rdi` then produces
   NaN.

So `496.to_f` returns NaN under JIT.

## Reproducer

```ruby
def f1(v); v.x.to_f; end   # chained
def f4   ; 496.to_f; end   # literal
3000.times { f1(v); f4 }
p [f1(v), f4]
# JIT before:  [NaN, NaN]
# JIT after:   [496.0, 496.0]
```

## The fix

Swap the order: load `recv` *before* allocating `ret`'s xmm. Then
`recv`'s mode is still its original (`S` / `Sf` / `C` / etc.) when
`load` runs, and it reads the right value into rdi. The subsequent
`def_F(ret)` is free to discard the slot — it is no longer needed.

Receiver is in rdi (a GP register), not an xmm, so the xmm
allocator's behaviour is irrelevant; nothing else needs to change.

## In-game impact

Found while running the `khasinski/doom` Ruby port under monoruby.
`Renderer#draw_seg_range` does a lot of `seg_v1.x.to_f` /
`seg_v1.y.to_f` to compute `px`, `py`, `tex_e`, `tex_f` for the
wall-texture mapping math; under JIT all of those went to NaN, so
distant walls rendered with totally wrong texture columns.

After this patch, a 50-frame-warmed JIT render of E1M1 is
**byte-identical to the interpreter** (`diff = 0/76800 px`). Same
pose I used in #358 (`x=504, y=-3239, z=41 (eye), angle=180`):

**Before** (wall textures corrupted by NaN-derived `tex_col`):

<img width="720" height="540" alt="after" src="https://github.com/user-attachments/assets/32d0feda-eb6e-4beb-9329-53b513580c0a" />


**After** (clean walls):

<img width="720" height="540" alt="after_tof" src="https://github.com/user-attachments/assets/70fb51a2-0271-4b4c-b9be-9b4ccb715cc5" />


## Test

`integer_tof_jit_inline_aliased_dst` in
`builtins/numeric/integer.rs`. Fails before, passes after.

This is independent of #358 (which fixed the xmm-aliasing bug in
`load_binary_xmm`-style paths). Together they get monoruby's JIT to
render Doom byte-for-byte identically to the interpreter.
