### PR TITLE
parser: trailing comma in block params injects auto-splat post arg

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -3989,4 +3989,27 @@ mod tests {
         run_test("{nil: 1, false: 2, true: 3}");
         run_test("{nil: 1}.keys");
     }
+
+    #[test]
+    fn hash_each_block_trailing_comma() {
+        // PR #361 follow-up: a trailing comma in a block parameter list
+        // (`|k,|`) injects a synthetic anonymous post param, bumping the
+        // total positional arity to >1 so a single Array argument from
+        // Hash#each (`[k, v]`) auto-splats. The block then sees only the
+        // key, matching CRuby's `core/hash/shared/each.rb`.
+        run_test(
+            r#"
+            ary = []
+            { "a" => 1, "b" => 2, "c" => 3 }.each { |k,| ary << k }
+            ary.sort
+            "#,
+        );
+        // Same for Array#each on a list of pairs.
+        run_test(r#"[[1, 2], [3, 4]].map { |k,| k }"#);
+        // |a, b,| (already 2 params) also auto-splats; trailing comma is
+        // a no-op for the destructuring count.
+        run_test(r#"[[1, 2, 3]].map { |a, b,| [a, b] }"#);
+        // No trailing comma → single param sees the whole array.
+        run_test(r#"[[1, 2]].map { |k| k }"#);
+    }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -817,7 +817,10 @@ impl Store {
                     args_names.push(name.map(IdentId::get_id_from_string));
                 }
                 ParamKind::Post(name) => {
-                    args_names.push(Some(IdentId::get_id_from_string(name)));
+                    // Anonymous post (`None`) is emitted for block-trailing
+                    // comma auto-splat (`|k,|`); it bumps the positional
+                    // arity but does NOT allocate a named local.
+                    args_names.push(name.map(IdentId::get_id_from_string));
                     post_num += 1;
                 }
                 ParamKind::Forwarding => {

--- a/ruruby-parse/src/node.rs
+++ b/ruruby-parse/src/node.rs
@@ -184,7 +184,13 @@ impl FormalParam {
     }
 
     pub(crate) fn post(name: String, loc: Loc) -> Self {
-        FormalParam::new(ParamKind::Post(name), loc)
+        FormalParam::new(ParamKind::Post(Some(name)), loc)
+    }
+
+    /// Anonymous post param, used to inject a trailing-comma auto-splat
+    /// hint into block / lambda parameter lists. Does not allocate a local.
+    pub(crate) fn post_discard(loc: Loc) -> Self {
+        FormalParam::new(ParamKind::Post(None), loc)
     }
 
     pub(crate) fn keyword(name: String, default: Option<Node>, loc: Loc) -> Self {
@@ -222,7 +228,7 @@ impl FormalParam {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParamKind {
     Param(String),
-    Post(String),
+    Post(Option<String>),
     Optional(String, Box<Node>), // name, default expr
     Rest(Option<String>),
     Keyword(String, Option<Box<Node>>), // name, default expr

--- a/ruruby-parse/src/parser.rs
+++ b/ruruby-parse/src/parser.rs
@@ -535,9 +535,18 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
 
     /// Parse formal parameters.
     /// required, optional = defaule, *rest, post_required, kw: default, **rest_kw, &block
+    ///
+    /// `is_block` is set by the caller to indicate that the parameter list
+    /// belongs to a block (`|...|`). In that case, a trailing comma after
+    /// a required parameter (`|k,|`) injects a synthetic anonymous post
+    /// parameter — bumping the positional arity to >1 so block auto-splat
+    /// of a single Array argument fires. Method `def` and lambda contexts
+    /// pass `false` and reject trailing commas via the usual SyntaxError
+    /// path of the surrounding parser.
     fn parse_formal_params(
         &mut self,
         terminator: impl Into<Option<Punct>>,
+        is_block: bool,
     ) -> Result<Vec<FormalParam>, LexerErr> {
         #[derive(Debug, Clone, PartialEq, PartialOrd)]
         enum Kind {
@@ -724,6 +733,21 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                         break;
                     }
                 }
+            }
+            // Trailing comma in a block parameter list (`|k,|`): when the
+            // next token is the terminator, treat the comma as an
+            // auto-splat hint by injecting an anonymous post parameter.
+            // Only valid while we're still parsing required positionals;
+            // `|*a,|` etc. fall through to the duplicate-rest error path
+            // matching CRuby.
+            if is_block
+                && state == Kind::Required
+                && let Some(term) = terminator
+                && self.peek_punct_no_term(term)
+            {
+                let trailing_loc = self.prev_loc();
+                args.push(FormalParam::post_discard(trailing_loc));
+                break;
             }
         }
         if let Some(term) = terminator {

--- a/ruruby-parse/src/parser/define.rs
+++ b/ruruby-parse/src/parser/define.rs
@@ -220,7 +220,9 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
         } else {
             None
         };
-        let args = self.parse_formal_params(term)?;
+        // Method definitions are NOT blocks: trailing commas in
+        // `def foo(a,)` remain a SyntaxError per CRuby.
+        let args = self.parse_formal_params(term, false)?;
         self.consume_term()?;
         Ok(args)
     }

--- a/ruruby-parse/src/parser/literals.rs
+++ b/ruruby-parse/src/parser/literals.rs
@@ -530,9 +530,11 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
         {
             vec![]
         } else if self.consume_punct(Punct::LParen)? {
-            self.parse_formal_params(Punct::RParen)?
+            // Lambda params (`->(...) {}`): not a block, no trailing-comma
+            // auto-splat injection.
+            self.parse_formal_params(Punct::RParen, false)?
         } else {
-            self.parse_formal_params(None)?
+            self.parse_formal_params(None, false)?
         };
         let body = if self.consume_punct(Punct::LBrace)? {
             let body = self.parse_comp_stmt()?;

--- a/ruruby-parse/src/parser/primary.rs
+++ b/ruruby-parse/src/parser/primary.rs
@@ -299,7 +299,8 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
         self.loop_stack.push(LoopKind::Block);
 
         let (params, _) = if self.consume_punct(Punct::BitOr)? {
-            (self.parse_formal_params(Punct::BitOr)?, true)
+            // Block params (`|...|`): trailing comma triggers auto-splat.
+            (self.parse_formal_params(Punct::BitOr, true)?, true)
         } else {
             self.consume_punct(Punct::LOr)?;
             (vec![], false)


### PR DESCRIPTION
## Summary

Block parameter lists with a trailing comma — `proc { |k,| ... }`, `do |k,| ... end` — now auto-splat a single Array argument the same way `|k, v|` does, matching CRuby. This was the missing piece for `core/hash/shared/each.rb`'s _"yields the key only to a block expecting `|key,|`"_ test.

## Mechanism

`parse_formal_params` gains an `is_block: bool` parameter. Block callsites (`primary.rs` for `|...|`) pass `true`; lambdas and method `def`s pass `false`.

After consuming a `,` in a block context, if the next token is the parameter terminator (`|`), the parser appends `FormalParam::post_discard(loc)`. This is a synthetic, anonymous post param — it bumps the function's total positional arity to >1 (so `single_arg_expand()` returns true and Hash#each's `[k, v]` Array auto-splats) but does NOT allocate a named local. `new_param` is skipped, just like `rest_discard`.

The injection is restricted to `Kind::Required` state, mirroring CRuby which rejects `|*a,|` and `|a, *b,|` as SyntaxError.

`ParamKind::Post(String)` becomes `ParamKind::Post(Option<String>)`, with the existing builder `FormalParam::post(name, loc)` wrapping with `Some(name)` and a new `FormalParam::post_discard(loc)` for the anonymous case. `globals/store.rs` propagates the option through `args_names` so the slot is reserved without binding a name.

## Files

- `ruruby-parse/src/node.rs` — `ParamKind::Post(Option<String>)`, new `FormalParam::post_discard`.
- `ruruby-parse/src/parser.rs` — `parse_formal_params(_, is_block)` with the trailing-comma branch.
- `ruruby-parse/src/parser/{primary,literals,define}.rs` — call sites pass `is_block` accordingly.
- `monoruby/src/globals/store.rs` — propagate `Option<String>` through `Post` to `args_names`.
- `monoruby/src/builtins/hash.rs` — new test `hash_each_block_trailing_comma`.

## Test plan

- [x] `cargo test --lib`: 1283 → 1284 passing (1 new test). 19 pre-existing failures unchanged.
- [x] `mspec run core/hash -t monoruby`: 34 → 32 issues (-2: `Hash#each` and `Hash#each_pair` _yields the key only to a block expecting `|key,|`_).
- [x] Hand-checked: `|k,|` from `Hash#each` and `Array#each`; `|a, b,|` (already-2-param) still works; `def foo(a,)` unchanged from prior parser behavior (this PR doesn't tighten method-def trailing-comma handling — that path explicitly passes `is_block=false`).

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_