### PR TITLE
ci: stop spec-core dying on categories with zero summary lines

### DIFF
--- a/.github/workflows/spec-core.yml
+++ b/.github/workflows/spec-core.yml
@@ -51,6 +51,12 @@ jobs:
         working-directory: ../spec
         shell: bash
         run: |
+          # GitHub Actions' default `shell: bash` is `bash --noprofile --norc
+          # -eo pipefail`. We rely on grep-no-match returning non-zero (a
+          # category with zero summary lines is normal -- e.g. when every
+          # batch hits the 60s timeout), and on `[ test ] && cmd` patterns
+          # below; both would terminate the step under -e. Disable it.
+          set +e
           set -uo pipefail
           OUT="$GITHUB_WORKSPACE/spec-results"
           mkdir -p "$OUT/logs"


### PR DESCRIPTION
## Summary

The `spec-core` workflow has been failing on every master push since #357 was merged: step 8 (`Run core specs per subcategory`) exits 1, so the `Publish history to gh-pages` step is skipped and gh-pages stops getting updated. Latest example: [run #10](https://github.com/sisshiki1969/monoruby/actions/runs/25034374399) for #361.

## Root cause

GitHub Actions' default `shell: bash` is `bash --noprofile --norc -eo pipefail`. The script's own `set -uo pipefail` doesn't strip the `-e` the runner already enabled, so it actually runs under `set -euo pipefail`.

Inside that, `sum_field` chains `parse_log | grep -oE | grep -oE | awk`. When a category's log has zero summary lines (the `N files, M examples, K expectations, F failures, E errors, T tagged` line), the inner greps exit 1 and `pipefail` propagates it. `EX=$(sum_field ...)` then exits 1, and bash's `-e` terminates the step right there.

`core/mutex` and `core/sizedqueue` are the trigger: every 10-file batch hits the 60s `timeout`, the `-f s` formatter never reaches the summary line, and `parse_log` returns empty. `mutex` comes first alphabetically, so it kills the script before the rest of the loop runs.

This was masked locally because invoking `bash -c '...'` directly doesn't enable `-e`; the script ran end to end without complaint there.

## Fix

Add explicit `set +e` at the top of the run step. The script was always written assuming no `-e` (uses `|| true`, `[ test ] && cmd`, tolerant `sum_field`), so this just lines reality up with intent. Categories with zero summary lines now correctly report 0 examples and the loop continues.

## Test plan

- [ ] Confirm the next `spec-core` run on master succeeds (step 8 green, step 11 publishes a row to `gh-pages/data/history*.csv`).
- [ ] Confirm `core/mutex` and `core/sizedqueue` show up in the report with `examples=0` instead of crashing the step.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_