### PR TITLE
spec-pages: relocate dashboard to /spec/ subpath and polish mobile/colors

### DIFF
--- a/.github/spec-pages/index.html
+++ b/.github/spec-pages/index.html
@@ -40,7 +40,7 @@
 <section>
   <h2>Latest snapshot</h2>
   <div id="latestMeta" class="meta"></div>
-  <canvas id="latestBar" height="320"></canvas>
+  <div id="latestBarWrap" style="position: relative;"><canvas id="latestBar"></canvas></div>
   <table id="latestTable">
     <thead>
       <tr><th>Category</th><th>Files</th><th>Examples</th><th>Pass</th><th>Failures</th><th>Errors</th><th>Pass rate</th></tr>
@@ -134,6 +134,15 @@ async function loadCsv(path) {
     document.getElementById('latestMeta').textContent =
       'snapshot: ' + latestTs + ' @ ' + latestSha;
 
+    const barColor = v => {
+      if (v >= 100) return '#2e7d32';
+      if (v >= 90)  return '#9ccc65';
+      if (v >= 70)  return '#fdd835';
+      return '#c62828';
+    };
+    document.getElementById('latestBarWrap').style.height =
+      Math.max(320, latest.length * 22) + 'px';
+
     new Chart(document.getElementById('latestBar'), {
       type: 'bar',
       data: {
@@ -141,17 +150,16 @@ async function loadCsv(path) {
         datasets: [{
           label: 'Pass rate (%)',
           data: latest.map(r => parseFloat(r.pass_rate)),
-          backgroundColor: latest.map(r => {
-            const v = parseFloat(r.pass_rate);
-            if (v >= 90) return '#2e7d32';
-            if (v >= 70) return '#f9a825';
-            return '#c62828';
-          })
+          backgroundColor: latest.map(r => barColor(parseFloat(r.pass_rate)))
         }]
       },
       options: {
         indexAxis: 'y',
-        scales: { x: { suggestedMin: 0, suggestedMax: 100 } },
+        maintainAspectRatio: false,
+        scales: {
+          x: { suggestedMin: 0, suggestedMax: 100 },
+          y: { ticks: { autoSkip: false, font: { size: 11 } } }
+        },
         plugins: { legend: { display: false } }
       }
     });

--- a/.github/workflows/spec-core.yml
+++ b/.github/workflows/spec-core.yml
@@ -171,32 +171,39 @@ jobs:
           fi
 
           cd "$GH_PAGES_DIR"
-          mkdir -p data
+
+          if [ -d data ] && [ ! -d spec/data ]; then
+            mkdir -p spec
+            mv data spec/data
+          fi
+          rm -f index.html latest.json
+
+          mkdir -p spec/data
 
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           SHORT_SHA="${GITHUB_SHA:0:7}"
 
-          if [ ! -f data/history.csv ]; then
-            echo "timestamp,commit,category,files,examples,pass,failures,errors,pass_rate" > data/history.csv
+          if [ ! -f spec/data/history.csv ]; then
+            echo "timestamp,commit,category,files,examples,pass,failures,errors,pass_rate" > spec/data/history.csv
           fi
-          if [ ! -f data/history_total.csv ]; then
-            echo "timestamp,commit,examples,pass,failures,errors,pass_rate" > data/history_total.csv
+          if [ ! -f spec/data/history_total.csv ]; then
+            echo "timestamp,commit,examples,pass,failures,errors,pass_rate" > spec/data/history_total.csv
           fi
 
           tail -n +2 "$GITHUB_WORKSPACE/spec-results/report.csv" \
             | awk -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" -F, 'BEGIN{OFS=","} {print ts,sha,$0}' \
-            >> data/history.csv
+            >> spec/data/history.csv
 
           echo "$TIMESTAMP,$SHORT_SHA,$TOTAL_EX,$TOTAL_PASS,$TOTAL_FAIL,$TOTAL_ERR,$TOTAL_RATE" \
-            >> data/history_total.csv
+            >> spec/data/history_total.csv
 
-          cp "$GITHUB_WORKSPACE/.github/spec-pages/index.html" index.html
+          cp "$GITHUB_WORKSPACE/.github/spec-pages/index.html" spec/index.html
 
-          cat > latest.json <<JSON
+          cat > spec/latest.json <<JSON
           {"schemaVersion":1,"label":"ruby/spec core","message":"${TOTAL_RATE}%","color":"blue","timestamp":"${TIMESTAMP}","commit":"${SHORT_SHA}","examples":${TOTAL_EX},"pass":${TOTAL_PASS},"failures":${TOTAL_FAIL},"errors":${TOTAL_ERR}}
           JSON
 
-          git add data/ index.html latest.json
+          git add spec/
           if git diff --cached --quiet; then
             echo "no changes to publish"
           else


### PR DESCRIPTION
## Summary

Two polish commits cherry-picked from `claude/setup-ruby-spec-ci-2cYTD` that didn't make it into #357.

### 1. Move dashboard under `/spec/` subpath

`gh-pages` root currently holds `index.html`, `data/`, `latest.json`, occupying the entire Pages site. This relocates everything under `/spec/` so the rest of `gh-pages` is free for other content.

- Workflow writes to `spec/data/history.csv`, `spec/data/history_total.csv`, `spec/index.html`, `spec/latest.json`.
- One-time migration: if `data/` exists at root and `spec/data/` does not, move it; remove root `index.html` and `latest.json`. After the next publish the root is clean.
- Dashboard URL becomes **https://sisshiki1969.github.io/monoruby/spec/**.
- Badge endpoint becomes `https://img.shields.io/endpoint?url=https://sisshiki1969.github.io/monoruby/spec/latest.json`.

### 2. Fix mobile axis-label thinning + adjust bar colors

Chart.js auto-skips tick labels when the canvas is too short. On phones the snapshot bar chart was hiding every other category name. Wrap the canvas in a div whose height scales with category count (`max(320, n * 22) px`), set `maintainAspectRatio: false`, force `y.ticks.autoSkip: false`, and shrink the tick font slightly.

Bar color thresholds:

| Pass rate | Color |
| --- | --- |
| 100%   | green        `#2e7d32` |
| ≥ 90%  | yellow-green `#9ccc65` |
| ≥ 70%  | yellow       `#fdd835` |
| else   | red          `#c62828` |

## Test plan

- [ ] After merge, next master push publishes to `gh-pages/spec/...`; root `index.html`, `latest.json`, `data/` are gone.
- [ ] Open https://sisshiki1969.github.io/monoruby/spec/ on a phone and confirm every category label is rendered.
- [ ] Spot-check colors: 100% rows green, low rows red.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_