### PR TITLE
portal: landing page at gh-pages root linking to /spec/ dashboard

### DIFF
--- a/.github/portal/index.html
+++ b/.github/portal/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>monoruby</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --link: #1565c0;
+    --accent: #2e7d32;
+    --accent-dark: #1b5e20;
+    --border: #eaeaea;
+    --code-bg: #f5f5f5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif;
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 2em 1.5em 4em;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.6;
+  }
+  .cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75em;
+    margin: 2em 0 2.5em;
+  }
+  .cta a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.85em 1.5em;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1em;
+    text-decoration: none;
+    transition: transform 0.1s, background 0.1s;
+  }
+  .cta a:hover { transform: translateY(-1px); }
+  .cta .primary {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(46, 125, 50, 0.25);
+  }
+  .cta .primary:hover { background: var(--accent-dark); }
+  .cta .secondary {
+    background: #f0f0f0;
+    color: var(--fg);
+  }
+  .cta .secondary:hover { background: #e0e0e0; }
+  main h1 {
+    border-bottom: 2px solid var(--border);
+    padding-bottom: 0.3em;
+    margin-top: 0;
+  }
+  main h2 {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.3em;
+    margin-top: 2em;
+  }
+  main h3 { margin-top: 1.5em; }
+  a { color: var(--link); }
+  pre {
+    background: var(--code-bg);
+    padding: 1em;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  code {
+    background: var(--code-bg);
+    padding: 0.15em 0.35em;
+    border-radius: 3px;
+    font-size: 0.92em;
+  }
+  pre code { background: transparent; padding: 0; }
+  ul { padding-left: 1.5em; }
+  li { margin: 0.3em 0; }
+  img { max-width: 100%; height: auto; }
+  .loading { color: var(--muted); }
+</style>
+</head>
+<body>
+
+<nav class="cta">
+  <a class="primary" href="./spec/">ruby/spec compliance dashboard →</a>
+  <a class="secondary" href="https://github.com/sisshiki1969/monoruby">GitHub</a>
+</nav>
+
+<main id="readme"><p class="loading">Loading README…</p></main>
+
+<script>
+const README_URL =
+  "https://raw.githubusercontent.com/sisshiki1969/monoruby/master/README.md";
+const STOP_AT = /^## Prerequisites/m;
+
+(async () => {
+  const target = document.getElementById("readme");
+  try {
+    const res = await fetch(README_URL + "?t=" + Date.now());
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    const md = await res.text();
+    const trimmed = md.split(STOP_AT)[0];
+    target.innerHTML = marked.parse(trimmed, { breaks: false, gfm: true });
+  } catch (e) {
+    target.innerHTML =
+      '<p>Could not load README (' + e.message + '). ' +
+      'See the <a href="https://github.com/sisshiki1969/monoruby">repository</a>.</p>';
+  }
+})();
+</script>
+</body>
+</html>

--- a/.github/workflows/spec-core.yml
+++ b/.github/workflows/spec-core.yml
@@ -14,6 +14,7 @@ on:
       - 'Cargo.toml'
       - '.github/workflows/spec-core.yml'
       - '.github/spec-pages/**'
+      - '.github/portal/**'
 
 permissions:
   contents: write
@@ -172,11 +173,13 @@ jobs:
 
           cd "$GH_PAGES_DIR"
 
+          # One-time migration of legacy root layout into spec/
           if [ -d data ] && [ ! -d spec/data ]; then
             mkdir -p spec
             mv data spec/data
           fi
-          rm -f index.html latest.json
+          rm -rf data
+          rm -f latest.json
 
           mkdir -p spec/data
 
@@ -198,12 +201,13 @@ jobs:
             >> spec/data/history_total.csv
 
           cp "$GITHUB_WORKSPACE/.github/spec-pages/index.html" spec/index.html
+          cp "$GITHUB_WORKSPACE/.github/portal/index.html" index.html
 
           cat > spec/latest.json <<JSON
           {"schemaVersion":1,"label":"ruby/spec core","message":"${TOTAL_RATE}%","color":"blue","timestamp":"${TIMESTAMP}","commit":"${SHORT_SHA}","examples":${TOTAL_EX},"pass":${TOTAL_PASS},"failures":${TOTAL_FAIL},"errors":${TOTAL_ERR}}
           JSON
 
-          git add spec/
+          git add -A
           if git diff --cached --quiet; then
             echo "no changes to publish"
           else


### PR DESCRIPTION
## Summary

Adds a portal landing page at the gh-pages root so `https://sisshiki1969.github.io/monoruby/` is no longer occupied by stale spec data.

### What the portal looks like

- A nav with a prominent green button **"ruby/spec compliance dashboard →"** linking to `./spec/`, plus a secondary "GitHub" button.
- Below that, the README content rendered live: the top of the page fetches `README.md` from `master`, slices it at `## Prerequisites` (so we keep the title, badges, tagline, **Presentation**, and **Features** sections), and renders the markdown with `marked.js` from a CDN.
- Reading the README at view time means we don't have to redeploy the portal on every README edit.

Template lives at `.github/portal/index.html`; the spec-core workflow copies it to `gh-pages/index.html` alongside the existing `/spec/` publish.

### Cleanup of legacy root layout

#364 left `index.html`, `latest.json`, and an empty `data/` at the gh-pages root because `git add spec/` didn't stage the deletions. Switched to `git add -A` and added `rm -rf data` so the next publish removes them. Going forward the root will only contain the portal `index.html`, the migrated `spec/` tree, and whatever else lives there.

### Path filter

Added `.github/portal/**` so portal template edits trigger a republish.

## Test plan

- [ ] Open https://sisshiki1969.github.io/monoruby/ after merge: see the green CTA button at the top, README content below.
- [ ] Click the dashboard button → lands on https://sisshiki1969.github.io/monoruby/spec/.
- [ ] Confirm the gh-pages root no longer contains `data/` or `latest.json`.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_