### PR TITLE
ruby/spec: Struct iteration accessors + Method/UnboundMethod basics

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -814,6 +814,7 @@ require_relative 'string'
 require_relative 'symbol'
 require_relative 'error'
 require_relative 'set'
+require_relative 'struct'
 require_relative 'builtins'
 require_relative 'pathname_builtins'
 

--- a/monoruby/builtins/struct.rb
+++ b/monoruby/builtins/struct.rb
@@ -1,0 +1,194 @@
+class Struct
+  include Enumerable
+
+  # Number of attributes.
+  def size
+    members.size
+  end
+  alias length size
+
+  # Yield each value.
+  # Returns self when a block is given, an Enumerator (sized to size)
+  # otherwise.
+  def each
+    return to_enum(:each) { size } unless block_given?
+    members.each { |m| yield instance_variable_get("@#{m}") }
+    self
+  end
+
+  # Yield [name, value] for each member.
+  def each_pair
+    return to_enum(:each_pair) { size } unless block_given?
+    members.each { |m| yield m, instance_variable_get("@#{m}") }
+    self
+  end
+
+  # Array of values, in member order.
+  def to_a
+    members.map { |m| instance_variable_get("@#{m}") }
+  end
+  alias values to_a
+  alias deconstruct to_a
+
+  # Hash of {member => value}. Block form mirrors Hash#to_h.
+  def to_h
+    return Hash[each_pair.to_a] unless block_given?
+    h = {}
+    each_pair do |k, v|
+      pair = yield k, v
+      pair = pair.to_ary if !pair.is_a?(Array) && pair.respond_to?(:to_ary)
+      raise TypeError, "wrong element type #{pair.class} (expected Array)" unless pair.is_a?(Array)
+      raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" unless pair.size == 2
+      h[pair[0]] = pair[1]
+    end
+    h
+  end
+
+  # Index access: by Integer, Symbol, or String. Negative indices count
+  # from the end (matching CRuby's `rb_struct_aref`).
+  def [](key)
+    if key.is_a?(Integer)
+      i = key
+      i += size if i < 0
+      raise IndexError, "offset #{key} too small for struct (size:#{size})" if i < 0
+      raise IndexError, "offset #{key} too large for struct (size:#{size})" if i >= size
+      instance_variable_get("@#{members[i]}")
+    elsif key.is_a?(Symbol) || key.is_a?(String)
+      sym = key.to_sym
+      raise NameError, "no member '#{key}' in struct" unless members.include?(sym)
+      instance_variable_get("@#{sym}")
+    else
+      raise TypeError, "no implicit conversion of #{key.class} into Integer"
+    end
+  end
+
+  def []=(key, value)
+    raise FrozenError.new("can't modify frozen #{self.class}: #{inspect}", receiver: self) if frozen?
+    if key.is_a?(Integer)
+      i = key
+      i += size if i < 0
+      raise IndexError, "offset #{key} too small for struct (size:#{size})" if i < 0
+      raise IndexError, "offset #{key} too large for struct (size:#{size})" if i >= size
+      instance_variable_set("@#{members[i]}", value)
+    elsif key.is_a?(Symbol) || key.is_a?(String)
+      sym = key.to_sym
+      raise NameError, "no member '#{key}' in struct" unless members.include?(sym)
+      instance_variable_set("@#{sym}", value)
+    else
+      raise TypeError, "no implicit conversion of #{key.class} into Integer"
+    end
+  end
+
+  def values_at(*indices)
+    result = []
+    indices.each do |idx|
+      if idx.is_a?(Range)
+        first = idx.begin
+        last = idx.end
+        first = 0 if first.nil?
+        last = size - 1 if last.nil?
+        first += size if first < 0
+        raise RangeError, "#{idx} out of range" if first < 0
+        last += size if last < 0
+        last -= 1 if idx.exclude_end?
+        (first..last).each do |i|
+          result << (i < size ? instance_variable_get("@#{members[i]}") : nil)
+        end
+      else
+        i = if idx.is_a?(Integer)
+              idx
+            elsif idx.respond_to?(:to_int)
+              c = idx.to_int
+              raise TypeError, "no implicit conversion of #{idx.class} into Integer" unless c.is_a?(Integer)
+              c
+            else
+              raise TypeError, "no implicit conversion of #{idx.class} into Integer"
+            end
+        adj = i
+        adj += size if adj < 0
+        if adj < 0
+          raise IndexError, "offset #{i} too small for struct(size:#{size})"
+        elsif adj >= size
+          raise IndexError, "offset #{i} too large for struct(size:#{size})"
+        end
+        result << instance_variable_get("@#{members[adj]}")
+      end
+    end
+    result
+  end
+
+  def dig(key, *rest)
+    raise ArgumentError, "wrong number of arguments (given 0, expected 1+)" if key.nil? && rest.empty?
+    val =
+      if key.is_a?(Integer)
+        idx = key
+        idx += size if idx < 0
+        if idx < 0 || idx >= size
+          nil
+        else
+          instance_variable_get("@#{members[idx]}")
+        end
+      elsif key.is_a?(Symbol) || key.is_a?(String)
+        sym = key.to_sym
+        members.include?(sym) ? instance_variable_get("@#{sym}") : nil
+      else
+        # Mirror Struct#[] coercion path; unsupported types raise TypeError.
+        self[key]
+      end
+    return val if rest.empty? || val.nil?
+    raise TypeError, "#{val.class} does not have #dig method" unless val.respond_to?(:dig)
+    val.dig(*rest)
+  end
+
+  def deconstruct_keys(keys)
+    return to_h if keys.nil?
+    raise TypeError, "wrong argument type #{keys.class} (expected Array or nil)" unless keys.is_a?(Array)
+    # CRuby drops the partial result entirely when the number of requested
+    # keys exceeds the struct size.
+    return {} if keys.size > size
+    h = {}
+    keys.each do |k|
+      if k.is_a?(Symbol) || k.is_a?(String)
+        sym = k.to_sym
+        return h unless members.include?(sym)
+        # Preserve the caller-supplied key (Symbol stays Symbol, String
+        # stays String) per CRuby `rb_struct_deconstruct_keys`.
+        h[k] = instance_variable_get("@#{sym}")
+      else
+        i = if k.is_a?(Integer)
+              k
+            elsif k.respond_to?(:to_int)
+              c = k.to_int
+              raise TypeError, "can't convert #{k.class} into Integer (#{k.class}#to_int gives #{c.class})" unless c.is_a?(Integer)
+              c
+            else
+              raise TypeError, "no implicit conversion of #{k.class} into Integer"
+            end
+        idx = i
+        idx += size if idx < 0
+        return h if idx < 0 || idx >= size
+        # Position numbers are returned AS the original key in the output.
+        h[k] = instance_variable_get("@#{members[idx]}")
+      end
+    end
+    h
+  end
+
+  # Order-dependent hash (unlike Hash#hash). Includes the class so
+  # different Struct subclasses with the same content do not collide.
+  def hash
+    acc = self.class.hash
+    each do |v|
+      acc = ((acc * 0x100000001b3) ^ v.hash) & 0x7fffffffffffffff
+    end
+    acc
+  end
+
+  # Filter / select: Enumerable's version returns Array; Struct's spec
+  # also expects an Array (not a Struct).
+  def select(&block)
+    return to_enum(:select) { size } unless block
+    to_a.select(&block)
+  end
+  alias filter select
+end

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -12,20 +12,25 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(METHOD_CLASS, "to_proc", to_proc, 0);
     globals.define_builtin_func(METHOD_CLASS, "source_location", source_location, 0);
     globals.define_builtin_func(METHOD_CLASS, "name", name, 0);
+    globals.define_builtin_func(METHOD_CLASS, "original_name", original_name, 0);
     globals.define_builtin_func(METHOD_CLASS, "receiver", receiver, 0);
     globals.define_builtin_func(METHOD_CLASS, "owner", owner, 0);
     globals.define_builtin_func(METHOD_CLASS, "unbind", unbind, 0);
     globals.define_builtin_func(METHOD_CLASS, "parameters", parameters, 0);
+    globals.define_builtin_func(METHOD_CLASS, "hash", method_hash, 0);
     globals.define_builtin_funcs(METHOD_CLASS, "==", &["eql?"], method_eq, 1);
 
     globals.define_builtin_class_under_obj("UnboundMethod", UMETHOD_CLASS, ObjTy::METHOD);
     globals.store[UMETHOD_CLASS].clear_alloc_func();
     globals.define_builtin_func(UMETHOD_CLASS, "arity", uarity, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "bind", bind, 1);
+    globals.define_builtin_func_rest(UMETHOD_CLASS, "bind_call", bind_call);
     globals.define_builtin_func(UMETHOD_CLASS, "source_location", usource_location, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "name", uname, 0);
+    globals.define_builtin_func(UMETHOD_CLASS, "original_name", uoriginal_name, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "owner", uowner, 0);
     globals.define_builtin_func(UMETHOD_CLASS, "parameters", uparameters, 0);
+    globals.define_builtin_func(UMETHOD_CLASS, "hash", umethod_hash, 0);
     globals.define_builtin_funcs(UMETHOD_CLASS, "==", &["eql?"], umethod_eq, 1);
 }
 
@@ -328,6 +333,118 @@ fn uparameters(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         method.func_id(),
         true,
     ))
+}
+
+///
+/// ### Method#original_name
+///
+/// - original_name -> Symbol
+///
+/// Returns the underlying function's stored name. Currently identical to
+/// `Method#name` because monoruby's `MethodInner` does not yet record a
+/// separate "lookup name" -- after `alias_method :b, :a`, both names
+/// resolve to the same `FuncInfo` so `m.original_name == m.name`. The
+/// method is here so that callers depending on its existence don't blow
+/// up with NoMethodError; full alias-aware behavior is a follow-up.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/original_name.html]
+#[monoruby_builtin]
+fn original_name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_method();
+    let id = globals[method.func_id()].name().unwrap();
+    Ok(Value::symbol(id))
+}
+
+/// ### UnboundMethod#original_name -- see `Method#original_name`.
+#[monoruby_builtin]
+fn uoriginal_name(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_umethod();
+    let id = globals[method.func_id()].name().unwrap();
+    Ok(Value::symbol(id))
+}
+
+///
+/// ### Method#hash
+///
+/// - hash -> Integer
+///
+/// Order-of-magnitude consistent with `Method#==`/`#eql?`: two methods
+/// that compare equal (same `func_id` and same receiver identity) hash
+/// equal. Combines `func_id` and the receiver's object id with a non-
+/// commutative mix.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Method/i/hash.html]
+#[monoruby_builtin]
+fn method_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_method();
+    let fid: i64 = method.func_id().get() as i64;
+    let recv: i64 = method.receiver().id() as i64;
+    let h = fid
+        .wrapping_mul(0x100000001b3i64)
+        .wrapping_add(recv.rotate_left(13));
+    // Mask sign bit so we always return a non-negative Fixnum-friendly value.
+    Ok(Value::integer(h & 0x7fff_ffff_ffff_ffff))
+}
+
+///
+/// ### UnboundMethod#hash
+///
+/// Symmetric to `Method#hash`: same `func_id` + same `owner` -> same hash.
+#[monoruby_builtin]
+fn umethod_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_umethod();
+    let fid: i64 = method.func_id().get() as i64;
+    let owner_id: i64 = method.owner().u32() as i64;
+    let h = fid
+        .wrapping_mul(0x100000001b3i64)
+        .wrapping_add(owner_id.rotate_left(13));
+    Ok(Value::integer(h & 0x7fff_ffff_ffff_ffff))
+}
+
+///
+/// ### UnboundMethod#bind_call
+///
+/// - bind_call(recv, *args, &block) -> object
+///
+/// Equivalent to `bind(recv).call(*args, &block)` but in one step
+/// (matches CRuby's `rb_method_bind_call`). Avoids materialising an
+/// intermediate Method object.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/bind_call.html]
+#[monoruby_builtin]
+fn bind_call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let method = self_val.as_umethod();
+    let mut args: Vec<Value> = lfp.arg(0).as_array().iter().copied().collect();
+    if args.is_empty() {
+        return Err(MonorubyErr::argumenterr(
+            "wrong number of arguments (given 0, expected 1+)",
+        ));
+    }
+    let receiver = args.remove(0);
+    // The receiver must be kind_of? the owner module of the original
+    // method; otherwise CRuby raises TypeError. We rely on
+    // `invoke_func_inner` raising the appropriate error if the func is
+    // applied to an incompatible receiver class -- the spec covers both
+    // success and the error path through `bind_call` directly.
+    let _ = method.owner();
+    vm.invoke_func_inner(
+        globals,
+        method.func_id(),
+        receiver,
+        &args,
+        lfp.block(),
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -690,6 +807,89 @@ mod tests {
               alias_method :baz, :bar
               def other; 2; end
             end
+            "##,
+        );
+    }
+
+    #[test]
+    fn method_hash_consistent_with_eq() {
+        // Methods that compare equal must hash equal.
+        run_test_with_prelude(
+            r##"
+            a = Foo.new.method(:bar)
+            b = a # same Method object
+            [a == b, a.hash == b.hash]
+            "##,
+            r##"
+            class Foo
+              def bar; 42; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn umethod_hash_consistent_with_eq() {
+        run_test_with_prelude(
+            r##"
+            a = Foo.instance_method(:bar)
+            b = Foo.instance_method(:baz)
+            c = Foo.instance_method(:other)
+            [a == b, a.hash == b.hash, a == c]
+            "##,
+            r##"
+            class Foo
+              def bar; 1; end
+              alias_method :baz, :bar
+              def other; 2; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn method_original_name() {
+        // `original_name` is currently equivalent to `name` (alias-aware
+        // tracking is a follow-up); here we just assert the method is
+        // callable and returns the function's stored name as a Symbol.
+        run_test(
+            r##"
+            class Foo
+              def bar; 1; end
+            end
+            m = Foo.new.method(:bar)
+            [m.original_name, m.original_name.is_a?(Symbol)]
+            "##,
+        );
+    }
+
+    #[test]
+    fn umethod_bind_call_basic() {
+        run_test(
+            r##"
+            class Foo
+              def hello(x); "hi #{x}"; end
+            end
+            m = Foo.instance_method(:hello)
+            m.bind_call(Foo.new, "world")
+            "##,
+        );
+        // Forwarding a block.
+        run_test(
+            r##"
+            class Foo
+              def with_block; yield 7; end
+            end
+            Foo.instance_method(:with_block).bind_call(Foo.new) { |n| n * 2 }
+            "##,
+        );
+        // bind_call with no receiver argument is an ArgumentError.
+        run_test_error(
+            r##"
+            class Foo
+              def x; end
+            end
+            Foo.instance_method(:x).bind_call
             "##,
         );
     }

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -22,6 +22,13 @@ pub(crate) fn init(globals: &mut Globals) {
     globals.define_builtin_func(STRUCT_CLASS, "members", members, 0);
     globals.define_builtin_funcs(STRUCT_CLASS, "==", &["eql?"], eq, 1);
     globals.define_builtin_func(STRUCT_CLASS, "!=", ne, 1);
+    // `Struct.keyword_init?` returns true/false/nil to describe how the
+    // struct was created. monoruby's Struct.new currently ignores the
+    // `keyword_init:` option entirely, so this is a stub that always
+    // returns nil — sufficient to satisfy callers that just check the
+    // method exists / is callable, e.g. `klass.keyword_init?`.
+    let struct_meta = globals.store.get_metaclass(STRUCT_CLASS).id();
+    globals.define_builtin_func(struct_meta, "keyword_init?", keyword_init_p, 0);
 }
 
 ///
@@ -32,23 +39,76 @@ pub(crate) fn init(globals: &mut Globals) {
 /// [https://docs.ruby-lang.org/ja/latest/method/Struct/s/=5b=5d.html]
 #[monoruby_builtin]
 fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let args = lfp.arg(0).as_array();
-    let (args, name) = if let Some(arg0) = args.first()
-        && let Some(s) = arg0.is_str()
+    let mut args: Vec<Value> = lfp.arg(0).as_array().iter().copied().collect();
+
+    // Strip a trailing `keyword_init:` Hash argument before classifying the
+    // first positional. monoruby's `Struct.new` doesn't declare kwargs in
+    // its signature, so kwargs land as a positional Hash; we extract
+    // `keyword_init:` here and remember it as `/keyword_init`.
+    let keyword_init_arg = if let Some(last) = args.last()
+        && let Some(h) = last.try_hash_ty()
     {
-        if s.starts_with(|c: char| c.is_ascii_uppercase()) {
-            (args[1..].to_vec(), Some(IdentId::get_id(s)))
+        let key = Value::symbol_from_str("keyword_init");
+        if let Ok(Some(v)) = h.get(key, vm, globals)
+            && h.len() == 1
+        {
+            args.pop();
+            Some(v)
         } else {
-            return Err(MonorubyErr::identifier_must_be_constant(s));
+            None
         }
     } else {
-        (args.to_vec(), None)
+        None
+    };
+
+    // First-arg classification:
+    // * `nil` -> anonymous struct (consume the arg).
+    // * String starting with uppercase -> named struct constant.
+    // * Object with #to_str returning an uppercase-starting String -> ditto.
+    // * Anything else -> first positional becomes a member name.
+    let name = if let Some(arg0) = args.first().copied() {
+        if arg0.is_nil() {
+            args.remove(0);
+            None
+        } else if let Some(s) = arg0.is_str() {
+            if s.starts_with(|c: char| c.is_ascii_uppercase()) {
+                let n = IdentId::get_id(s);
+                args.remove(0);
+                Some(n)
+            } else {
+                return Err(MonorubyErr::identifier_must_be_constant(s));
+            }
+        } else if arg0.try_symbol().is_none()
+            && let Some(coerced) =
+                vm.invoke_method_if_exists(globals, IdentId::TO_STR, arg0, &[], None, None)?
+            && coerced.is_str().is_some()
+        {
+            let s = coerced.as_str();
+            if s.starts_with(|c: char| c.is_ascii_uppercase()) {
+                let n = IdentId::get_id(&s);
+                args.remove(0);
+                Some(n)
+            } else {
+                return Err(MonorubyErr::identifier_must_be_constant(&s));
+            }
+        } else {
+            None
+        }
+    } else {
+        None
     };
 
     let new_struct = globals
         .store
         .define_struct_class(name, lfp.self_val().as_class())
         .as_val();
+
+    if let Some(v) = keyword_init_arg {
+        globals
+            .store
+            .set_ivar(new_struct, IdentId::get_id("/keyword_init"), v)
+            .unwrap();
+    }
 
     vm.invoke_method_inner(
         globals,
@@ -96,6 +156,19 @@ fn struct_initialize(
     globals.define_builtin_func(class_id, "!=", ne, 1);
 
     let members = ArrayInner::from_iter(args.iter().cloned());
+
+    // Reject duplicate member names (matches CRuby's
+    // `rb_struct_define_without_accessor`).
+    let mut seen: Vec<IdentId> = Vec::with_capacity(members.len());
+    for arg in members.iter() {
+        let name = arg.expect_symbol_or_string(globals)?;
+        if seen.contains(&name) {
+            return Err(MonorubyErr::argumenterr(format!(
+                "duplicate member: {name:?}"
+            )));
+        }
+        seen.push(name);
+    }
 
     for arg in members.iter() {
         let name = arg.expect_symbol_or_string(globals)?;
@@ -159,46 +232,84 @@ fn initialize(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let len = lfp.arg(0).as_array().len();
+    let args = lfp.arg(0).as_array();
     let self_val = lfp.self_val();
     let members = get_members(globals, self_val.get_class_obj(globals))?;
-    if members.len() < len {
+    if members.len() < args.len() {
         return Err(MonorubyErr::argumenterr("Struct size differs."));
     };
-    for (i, val) in lfp.arg(0).as_array().iter().enumerate() {
-        let id = members[i].try_symbol().unwrap();
+    // Each member becomes an ivar. Missing positional args are stored
+    // *explicitly* as nil so that `instance_variables` lists every
+    // member -- matching CRuby's "uninitialized members default to nil"
+    // behavior.
+    for (i, member) in members.iter().enumerate() {
+        let id = member.try_symbol().unwrap();
         let ivar_name = IdentId::add_ivar_prefix(id);
-        globals.store.set_ivar(self_val, ivar_name, *val)?;
+        let val = args.get(i).copied().unwrap_or(Value::nil());
+        globals.store.set_ivar(self_val, ivar_name, val)?;
     }
     Ok(Value::nil())
 }
 
 #[monoruby_builtin]
 fn inspect(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut inspect = "#<struct ".to_string();
     let self_val = lfp.self_val();
     let class_id = self_val.class();
     let struct_class = globals.store[class_id].get_module();
-    if let Some(name) = globals.store[class_id].get_name() {
-        inspect += &format!("{name}");
+    // Class name: fully qualified path (`M::S`), bypassing any user-
+    // defined `#name` so e.g. `def self.name; "x"; end` cannot affect
+    // inspect. CRuby's `rb_struct_inspect` uses `rb_class_real`-derived
+    // path for the same reason. Anonymous classes (and any ancestor in
+    // the path that's anonymous) are detected via `get_name() == None`
+    // — in that case render `#<struct member=...>` with no class name.
+    let class_name = if globals.store[class_id].get_name().is_some()
+        && let Some(qualified) = qualified_real_class_name(globals, class_id)
+    {
+        Some(qualified)
+    } else {
+        None
     };
-    let name = get_members(globals, struct_class)?;
 
-    if name.len() != 0 {
-        for x in name.iter() {
-            let name = x.try_symbol().unwrap();
-            let ivar_name = IdentId::add_ivar_prefix(name);
-            let val = match globals.store.get_ivar(self_val, ivar_name) {
-                Some(v) => v.inspect(&globals.store),
-                None => "nil".to_string(),
-            };
-            inspect += &format!(" {:?}={},", name, val);
-        }
-        inspect.pop();
+    let mut inspect = String::from("#<struct");
+    if let Some(name) = &class_name {
+        inspect.push(' ');
+        inspect.push_str(name);
     }
-    inspect += ">";
+
+    let members = get_members(globals, struct_class)?;
+    let mut first = true;
+    for m in members.iter() {
+        let name = m.try_symbol().unwrap();
+        let ivar_name = IdentId::add_ivar_prefix(name);
+        let val = match globals.store.get_ivar(self_val, ivar_name) {
+            Some(v) => v.inspect(&globals.store),
+            None => "nil".to_string(),
+        };
+        inspect.push_str(if first { " " } else { ", " });
+        first = false;
+        inspect.push_str(&format!("{name:?}={val}"));
+    }
+    inspect.push('>');
 
     Ok(Value::string(inspect))
+}
+
+/// Returns the fully-qualified class name (`M::S`) by walking the
+/// parent chain. Returns `None` if any ancestor (including the class
+/// itself) is anonymous, matching CRuby's "drop class label entirely
+/// if any segment is anonymous" rule for `Struct#inspect`.
+fn qualified_real_class_name(globals: &Globals, class_id: ClassId) -> Option<String> {
+    let parents = globals.store.get_parents(class_id);
+    if parents.iter().any(|s| s.starts_with("#<")) {
+        // `get_parents` renders anonymous segments as `#<Class:...>`.
+        return None;
+    }
+    let v: Vec<String> = parents.into_iter().rev().collect();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v.join("::"))
+    }
 }
 
 ///
@@ -264,6 +375,29 @@ fn members(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         .get_ivar(class_obj, IdentId::get_id("/members"))
         .unwrap();
     Ok(members)
+}
+
+///
+/// Struct.keyword_init? -> true | false | nil
+///
+/// Whether the struct was created with `keyword_init: true`. monoruby's
+/// `Struct.new` does not currently parse a `keyword_init:` kwarg, so the
+/// stored flag is never set and this always returns `nil` — matching
+/// CRuby's "no flag specified" return value.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Struct/s/keyword_init=3f.html]
+#[monoruby_builtin]
+fn keyword_init_p(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let v = globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/keyword_init"))
+        .unwrap_or(Value::nil());
+    Ok(v)
 }
 
 #[cfg(test)]
@@ -471,5 +605,137 @@ mod tests {
             end
             "##,
         );
+    }
+
+    // ----- Tests for the iteration / accessor / introspection sweep -----
+
+    #[test]
+    fn struct_iteration_methods() {
+        // PR for core/method/struct sweep: Struct gains a Ruby-side
+        // implementation of Enumerable-friendly accessors.
+        let prelude = r#"
+        S = Struct.new(:a, :b, :c)
+        s = S.new(10, 20, 30)
+        "#;
+        run_test_with_prelude(r#"s.size"#, prelude);
+        run_test_with_prelude(r#"s.length"#, prelude);
+        run_test_with_prelude(r#"s.to_a"#, prelude);
+        run_test_with_prelude(r#"s.values"#, prelude);
+        run_test_with_prelude(r#"s.deconstruct"#, prelude);
+        run_test_with_prelude(r#"s.to_h"#, prelude);
+        run_test_with_prelude(r#"s.each.to_a"#, prelude);
+        run_test_with_prelude(r#"s.each_pair.to_a"#, prelude);
+    }
+
+    #[test]
+    fn struct_index_access() {
+        let prelude = r#"
+        S = Struct.new(:a, :b, :c)
+        s = S.new(10, 20, 30)
+        "#;
+        run_test_with_prelude(r#"[s[0], s[1], s[2]]"#, prelude);
+        run_test_with_prelude(r#"[s[:a], s[:b], s[:c]]"#, prelude);
+        run_test_with_prelude(r#"[s["a"], s["b"], s["c"]]"#, prelude);
+        run_test_with_prelude(r#"[s[-1], s[-3]]"#, prelude);
+        run_test_with_prelude(
+            r#"
+            t = S.new(10, 20, 30)
+            t[0] = 100
+            t[:b] = 200
+            t.to_a
+            "#,
+            prelude,
+        );
+        // Out-of-range index raises IndexError; unknown member raises NameError.
+        run_test_error(r#"S = Struct.new(:a); S.new(1)[5]"#);
+        run_test_error(r#"S = Struct.new(:a); S.new(1)[:nope]"#);
+    }
+
+    #[test]
+    fn struct_values_at() {
+        let prelude = r#"
+        S = Struct.new(:a, :b, :c)
+        s = S.new(10, 20, 30)
+        "#;
+        run_test_with_prelude(r#"s.values_at(0, 2)"#, prelude);
+        run_test_with_prelude(r#"s.values_at(0..2)"#, prelude);
+        run_test_with_prelude(r#"s.values_at(0..3)"#, prelude);
+        run_test_with_prelude(r#"s.values_at"#, prelude);
+        run_test_error(r#"S = Struct.new(:a, :b); S.new.values_at(3)"#);
+        run_test_error(r#"S = Struct.new(:a, :b); S.new.values_at(-3)"#);
+        run_test_error(r#"S = Struct.new(:a, :b); S.new.values_at("x")"#);
+    }
+
+    #[test]
+    fn struct_dig_traversal() {
+        let prelude = r#"
+        Inner = Struct.new(:b)
+        Outer = Struct.new(:a)
+        o = Outer.new(Inner.new({k: 1}))
+        "#;
+        run_test_with_prelude(r#"o.dig(:a, :b, :k)"#, prelude);
+        // Unknown key returns nil (not NameError) when used via dig.
+        run_test_with_prelude(r#"o.dig(:nope, 0)"#, prelude);
+        // Intermediate nil short-circuits.
+        run_test_with_prelude(r#"o.dig(:a, :b, :missing, 0)"#, prelude);
+    }
+
+    #[test]
+    fn struct_deconstruct_keys_basic() {
+        let prelude = r#"
+        S = Struct.new(:x, :y, :z)
+        s = S.new(1, 2, 3)
+        "#;
+        run_test_with_prelude(r#"s.deconstruct_keys([:x, :y])"#, prelude);
+        run_test_with_prelude(r#"s.deconstruct_keys(["x", "y"])"#, prelude);
+        run_test_with_prelude(r#"s.deconstruct_keys([0, 1])"#, prelude);
+        run_test_with_prelude(r#"s.deconstruct_keys([0, :x])"#, prelude);
+        run_test_with_prelude(r#"s.deconstruct_keys(nil)"#, prelude);
+        // More keys requested than struct has -> empty hash.
+        run_test_with_prelude(r#"s.deconstruct_keys([:x, :y, :z, :w])"#, prelude);
+    }
+
+    #[test]
+    fn struct_inspect_qualified_name() {
+        // Nested struct uses fully-qualified module path; anonymous
+        // structs render without a class label.
+        run_test(
+            r#"
+            module M
+              N = Struct.new(:a, :b)
+            end
+            M::N.new(1, 2).inspect
+            "#,
+        );
+        run_test(r#"Struct.new(:x).new("hello").inspect"#);
+    }
+
+    #[test]
+    fn struct_initialize_explicit_nil() {
+        // Members not provided to `new` are explicitly set to nil so they
+        // appear in `instance_variables` (matching CRuby's behavior of
+        // initializing all member slots).
+        run_test(
+            r#"
+            S = Struct.new(:a, :b, :c)
+            s = S.new(1)
+            [s.a, s.b, s.c]
+            "#,
+        );
+    }
+
+    #[test]
+    fn struct_duplicate_member_raises() {
+        run_test_error(r#"Struct.new(:a, :b, :a)"#);
+    }
+
+    #[test]
+    fn struct_keyword_init_q() {
+        // `keyword_init?` is defined on each Struct subclass. monoruby's
+        // implementation currently always returns nil because we don't
+        // yet track the `keyword_init:` arg passed to `Struct.new`; the
+        // test asserts the method exists and returns nil (matching CRuby
+        // for the no-`keyword_init:` form).
+        run_test(r#"Struct.new(:a, :b).keyword_init?"#);
     }
 }


### PR DESCRIPTION
## Summary

Sweep of the easier failures across `core/struct`, `core/method`, and `core/unboundmethod`. Adds the missing surface that the existing implementations were silently lacking, plus a handful of bug fixes uncovered along the way.

**Result on the three covered categories**

| Category | Before | After | Δ |
|----------|-------:|------:|--:|
| core/method | 91 | 86 | -5 |
| core/unboundmethod | 31 | 20 | -11 |
| core/struct | 123 | 24 | -99 |
| **Total** | **245** | **130** | **-115 (~47%)** |

## Struct (`monoruby/builtins/struct.rb` — new file, registered from `startup.rb`)

- `include Enumerable`.
- `each`, `each_pair`, `to_a`, `values`, `deconstruct`, `to_h` (with block + `to_ary` coercion), `size`, `length`, `select`/`filter`.
- `[]`/`[]=` accept Integer (negative wrap), Symbol, String; raise `IndexError` / `NameError` / `TypeError` per CRuby wording.
- `values_at` accepts Integers and Ranges, fills past-end with `nil` for ranges, raises `IndexError` (`"offset N too small/large for struct(size:S)"`) for out-of-range indices, raises `TypeError` for unsupported types.
- `dig` returns `nil` for missing keys instead of raising, short-circuits on intermediate `nil`, raises `TypeError` when the next step doesn't respond to `#dig`.
- `deconstruct_keys` preserves caller-supplied keys (Symbol / String / Integer) verbatim in the result hash, returns `{}` when more keys are requested than the struct has, supports `nil` for "all", and coerces non-int/string/sym keys via `#to_int`.
- `hash` mixes per-element via a non-commutative wrapping product.

## Struct (Rust, `struct_class.rs`)

- `inspect`/`to_s` use the *fully-qualified* class path (`M::S`) and drop the class label entirely if any segment is anonymous. Override of `#name` cannot affect inspect output. Anonymous structs no longer emit a stray double space.
- `Struct.new` accepts a `nil` first argument as "anonymous"; honours `#to_str` on the first arg for the constant-name path; strips a trailing `keyword_init:` Hash kwarg before classifying positionals (so `Struct.new(:a, keyword_init: true)` no longer fails fixture loading with `"Hash is not a symbol nor a string"`).
- `Struct#initialize` now sets every member ivar *explicitly* to `nil` when not provided, so `instance_variables` lists all members.
- Member duplication raises `ArgumentError` matching CRuby.
- `Struct.keyword_init?` class method (returns the stored flag, `nil` by default).

## Method / UnboundMethod (`method.rs`)

- `Method#hash` and `UnboundMethod#hash` derive an order-of-magnitude-consistent hash from `func_id` plus the receiver/owner, so two methods that compare `==`/`eql?` also hash equal — required by Ruby's container contract.
- `Method#original_name` and `UnboundMethod#original_name` return the underlying function's stored name (Symbol). Alias-aware tracking is a follow-up; the method existing at all unblocks several specs.
- `UnboundMethod#bind_call(recv, *args, &block)` invokes the function on `recv` directly, equivalent to `bind(recv).call(...)`.

## Test plan

- [x] `cargo test --lib`: 1284 → **1297 passing** (13 new tests). 19 pre-existing failures unchanged.
- [x] `mspec run core/method core/unboundmethod core/struct -t monoruby`: 245 → 130 issues (-115).
- [x] Hand-checked: `Struct.new(:a, keyword_init: true).new(a: 1)` raises NoMethodError on `:a=` (expected — kw_init full impl is a follow-up); `Struct.new(:a, :a)` raises ArgumentError; `Struct.new(:x).new("hello").inspect` renders without leading space.

## Known follow-ups (not in this PR)

- `Struct.new(keyword_init: true)` end-to-end (the tag is stored, but `initialize` doesn't yet read it for kwarg-only construction).
- `Struct#instance_variables` returns C-level slots — currently uses Ruby ivars; `instance_variables` consequently lists `[:@a, :@b, ...]` instead of `[]` per CRuby.
- Recursive `Struct#==` / `#eql?` / `#hash` recursion guard.
- `Method#name` after `alias_method` (needs a separate "lookup name" field on `MethodInner`).
- `Method#<<`, `#>>`, `#curry`, `#super_method`.
- `Method`/`UnboundMethod` `respond_to_missing?` virtual methods.

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_