### PR TITLE
Struct: inline member storage via SmallVec for 1-mov accessor JIT

### DIFF
--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -180,13 +180,14 @@ fn struct_initialize(
     // `method_added` is fired after each registration so user hooks
     // (e.g. `def self.method_added`) see the same `[:x, :x=, :y, :y=]`
     // sequence that `attr_reader`/`attr_writer` would have produced.
+    let inline = members.len() <= crate::value::STRUCT_INLINE_SLOTS;
     for (i, arg) in members.iter().enumerate() {
         let name = arg.expect_symbol_or_string(globals)?;
         let slot = i as u16;
-        globals.define_struct_reader(class_id, name, slot, Visibility::Public);
+        globals.define_struct_reader(class_id, name, slot, inline, Visibility::Public);
         vm.invoke_method_added(globals, class_id, name)?;
         let writer_name =
-            globals.define_struct_writer(class_id, name, slot, Visibility::Public);
+            globals.define_struct_writer(class_id, name, slot, inline, Visibility::Public);
         vm.invoke_method_added(globals, class_id, writer_name)?;
     }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1227,7 +1227,9 @@ pub(super) enum AsmInst {
         ivarid: IvarId,
     },
     ///
-    /// Load slot `slot_index` of a `Struct` subclass instance into r15.
+    /// Load slot `slot_index` of a `Struct` subclass instance whose
+    /// slot vector is INLINE in the RValue's `kind` union (i.e. the
+    /// class has at most `STRUCT_INLINE_SLOTS` members). Single mov.
     ///
     /// #### in
     /// - rdi: receiver (a Value pointing at an `ObjTy::STRUCT` RValue)
@@ -1235,29 +1237,52 @@ pub(super) enum AsmInst {
     /// #### out
     /// - r15: Value at slot `slot_index`
     ///
-    /// #### destroy
-    /// - rdi
-    ///
-    LoadStructSlot {
+    LoadStructSlotInline {
         slot_index: u16,
     },
     ///
-    /// Store *src* into slot `slot_index` of the `Struct` subclass
-    /// instance `rdi`. Caller is expected to have already emitted
-    /// the `GuardFrozen` so this only does the slot store + sets
-    /// rax to the stored value.
+    /// Load slot `slot_index` of a `Struct` subclass instance whose
+    /// slot vector is on the HEAP (`> STRUCT_INLINE_SLOTS` members).
+    /// Two movs: heap-pointer deref + slot index.
     ///
     /// #### in
-    /// - rdi: receiver (an `ObjTy::STRUCT` RValue)
-    /// - src: Value to store
-    ///
+    /// - rdi: receiver
     /// #### out
-    /// - rax: src (return value of the writer)
-    ///
+    /// - r15: Value
     /// #### destroy
     /// - rdi
     ///
-    StoreStructSlot {
+    LoadStructSlotHeap {
+        slot_index: u16,
+    },
+    ///
+    /// Store *src* into the inline slot `slot_index` of the `Struct`
+    /// subclass instance `rdi`. Caller must have emitted `GuardFrozen`.
+    ///
+    /// #### in
+    /// - rdi: receiver
+    /// - src: Value to store
+    /// #### out
+    /// - rax: src (return value of the writer)
+    ///
+    StoreStructSlotInline {
+        src: GP,
+        slot_index: u16,
+    },
+    ///
+    /// Store *src* into the heap-allocated slot `slot_index` of the
+    /// `Struct` subclass instance `rdi`. Caller must have emitted
+    /// `GuardFrozen`.
+    ///
+    /// #### in
+    /// - rdi: receiver
+    /// - src: Value to store
+    /// #### out
+    /// - rax: src
+    /// #### destroy
+    /// - rdi
+    ///
+    StoreStructSlotHeap {
         src: GP,
         slot_index: u16,
     },

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -607,9 +607,17 @@ impl Codegen {
                 is_object_ty,
             } => self.store_self_ivar_heap(src, ivarid, is_object_ty),
             AsmInst::StoreIVarInline { src, ivarid } => self.store_ivar_object_inline(src, ivarid),
-            AsmInst::LoadStructSlot { slot_index } => self.load_struct_slot(slot_index),
-            AsmInst::StoreStructSlot { src, slot_index } => {
-                self.store_struct_slot(src, slot_index)
+            AsmInst::LoadStructSlotInline { slot_index } => {
+                self.load_struct_slot_inline(slot_index)
+            }
+            AsmInst::LoadStructSlotHeap { slot_index } => {
+                self.load_struct_slot_heap(slot_index)
+            }
+            AsmInst::StoreStructSlotInline { src, slot_index } => {
+                self.store_struct_slot_inline(src, slot_index)
+            }
+            AsmInst::StoreStructSlotHeap { src, slot_index } => {
+                self.store_struct_slot_heap(src, slot_index)
             }
             AsmInst::GuardFrozen { deopt } => {
                 let deopt = &labels[deopt];

--- a/monoruby/src/codegen/jitgen/asmir/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/variables.rs
@@ -98,49 +98,72 @@ impl Codegen {
     }
 
     ///
-    /// Load slot `slot_index` of a `Struct` subclass instance into r15.
-    /// `rdi` holds the receiver `Value` (a heap pointer to the
-    /// `ObjTy::STRUCT` RValue). The `kind` union holds a
-    /// `Box<StructInner>`; deref it once, then index into the slot
-    /// pointer.
+    /// Load slot `slot_index` of a `Struct` instance whose slot
+    /// vector is **inline** in the RValue's union (i.e. the class has
+    /// `≤ STRUCT_INLINE_SLOTS` members). Single mov, no Box deref.
     ///
-    /// 3 movs total: nothing else (no length check, no nil substitution
-    /// needed — every slot is initialised to `Value::nil()` by
-    /// `struct_alloc_func` and never reset to a raw `0`).
+    /// Receiver class is already guarded by the call-site cache, so
+    /// the JIT picks this variant statically based on the class's
+    /// member count.
     ///
     /// #### in
     /// - rdi: &RValue (a STRUCT instance)
     /// #### out
     /// - r15: Value
-    /// #### destroy
-    /// - rdi
-    pub(super) fn load_struct_slot(&mut self, slot_index: u16) {
+    pub(super) fn load_struct_slot_inline(&mut self, slot_index: u16) {
         monoasm! {&mut self.jit,
-            movq rdi, [rdi + (RVALUE_OFFSET_KIND as i32)];        // Box<StructInner>
-            movq rdi, [rdi + (STRUCT_INNER_PTR_OFFSET as i32)];   // slot array
-            movq r15, [rdi + ((slot_index as i32) * 8)];          // the Value
+            movq r15, [rdi + ((slot_index as i32) * 8 + RVALUE_OFFSET_INLINE as i32)];
         }
     }
 
     ///
-    /// Store *src* into slot `slot_index` of the `Struct` subclass
-    /// instance `rdi`. Returns the stored value in `rax` (semantics of
-    /// a Ruby writer method).
-    ///
-    /// Caller is expected to have already emitted a `GuardFrozen` so
-    /// the frozen check is not duplicated here.
+    /// Load slot `slot_index` of a `Struct` instance whose slot
+    /// vector spilled to the **heap** (the class has more than
+    /// `STRUCT_INLINE_SLOTS` members). Two movs.
     ///
     /// #### in
-    /// - rdi: &RValue (a STRUCT instance)
+    /// - rdi: &RValue
+    /// #### out
+    /// - r15: Value
+    /// #### destroy
+    /// - rdi
+    pub(super) fn load_struct_slot_heap(&mut self, slot_index: u16) {
+        monoasm! {&mut self.jit,
+            movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
+            movq r15, [rdi + ((slot_index as i32) * 8)];
+        }
+    }
+
+    ///
+    /// Store *src* into inline slot `slot_index` of `rdi`. Single mov.
+    /// Caller must have emitted `GuardFrozen` already.
+    ///
+    /// #### in
+    /// - rdi: &RValue
+    /// - src: Value to store
+    /// #### out
+    /// - rax: src (return value of the writer)
+    pub(super) fn store_struct_slot_inline(&mut self, src: GP, slot_index: u16) {
+        monoasm! {&mut self.jit,
+            movq [rdi + ((slot_index as i32) * 8 + RVALUE_OFFSET_INLINE as i32)], R(src as _);
+            movq rax, R(src as _);
+        }
+    }
+
+    ///
+    /// Store *src* into heap slot `slot_index` of `rdi`. Two movs.
+    /// Caller must have emitted `GuardFrozen` already.
+    ///
+    /// #### in
+    /// - rdi: &RValue
     /// - src: Value to store
     /// #### out
     /// - rax: src
     /// #### destroy
     /// - rdi
-    pub(super) fn store_struct_slot(&mut self, src: GP, slot_index: u16) {
+    pub(super) fn store_struct_slot_heap(&mut self, src: GP, slot_index: u16) {
         monoasm! {&mut self.jit,
-            movq rdi, [rdi + (RVALUE_OFFSET_KIND as i32)];        // Box<StructInner>
-            movq rdi, [rdi + (STRUCT_INNER_PTR_OFFSET as i32)];   // slot array
+            movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
             movq [rdi + ((slot_index as i32) * 8)], R(src as _);
             movq rax, R(src as _);
         }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -200,11 +200,11 @@ impl<'a> JitContext<'a> {
             FuncKind::AttrWriter { ivar_name } => {
                 return Ok(self.attr_writer(state, ir, callid, recv_class, ivar_name));
             }
-            FuncKind::StructReader { slot_index } => {
-                return Ok(self.struct_slot_reader(state, ir, callid, slot_index));
+            FuncKind::StructReader { slot_index, inline } => {
+                return Ok(self.struct_slot_reader(state, ir, callid, slot_index, inline));
             }
-            FuncKind::StructWriter { slot_index } => {
-                return Ok(self.struct_slot_writer(state, ir, callid, slot_index));
+            FuncKind::StructWriter { slot_index, inline } => {
+                return Ok(self.struct_slot_writer(state, ir, callid, slot_index, inline));
             }
             FuncKind::Builtin { .. } => (func_id, None),
             FuncKind::Proc(proc) => (proc.func_id(), proc.outer_lfp()),
@@ -447,15 +447,18 @@ impl<'a> JitContext<'a> {
     }
 
     /// JIT inline a `Struct` member reader. Receiver class is already
-    /// guarded by the call-site cache, so we just emit the slot load
-    /// (3 movs). No recompile path required: the slot index is baked
-    /// into the [`FuncKind::StructReader`] itself.
+    /// guarded by the call-site cache; the JIT picks INLINE vs HEAP
+    /// statically based on the class's member count, so the emitted
+    /// code is exactly **1 mov** for the inline case (≤
+    /// `STRUCT_INLINE_SLOTS` members) and 2 movs for the heap case.
+    /// Mirrors how `attr_reader` distinguishes inline vs heap ivars.
     fn struct_slot_reader(
         &mut self,
         state: &mut AbstractState,
         ir: &mut AsmIr,
         callid: CallSiteId,
         slot_index: u16,
+        inline: bool,
     ) -> CompileResult {
         let callsite = &self.store[callid];
         let CallSiteInfo {
@@ -472,19 +475,25 @@ impl<'a> JitContext<'a> {
         state.load(ir, recv, GP::Rdi);
         state.discard(dst);
         state.writeback_acc(ir);
-        ir.push(AsmInst::LoadStructSlot { slot_index });
+        if inline {
+            ir.push(AsmInst::LoadStructSlotInline { slot_index });
+        } else {
+            ir.push(AsmInst::LoadStructSlotHeap { slot_index });
+        }
         state.def_reg2acc(ir, GP::R15, dst);
         CompileResult::Continue
     }
 
     /// JIT inline a `Struct` member writer. Mirrors `attr_writer` —
-    /// guard frozen, then emit the slot store directly.
+    /// guard frozen, then emit a 1-mov inline store or 2-mov heap
+    /// store based on the FuncKind's `inline` flag.
     fn struct_slot_writer(
         &mut self,
         state: &mut AbstractState,
         ir: &mut AsmIr,
         callid: CallSiteId,
         slot_index: u16,
+        inline: bool,
     ) -> CompileResult {
         let callsite = &self.store[callid];
         let CallSiteInfo {
@@ -502,7 +511,11 @@ impl<'a> JitContext<'a> {
         let deopt = ir.new_deopt(state);
         ir.guard_frozen(deopt);
         let src = state.load_or_reg(ir, args, GP::Rax);
-        ir.push(AsmInst::StoreStructSlot { src, slot_index });
+        if inline {
+            ir.push(AsmInst::StoreStructSlotInline { src, slot_index });
+        } else {
+            ir.push(AsmInst::StoreStructSlotHeap { src, slot_index });
+        }
         state.def_rax2acc(ir, dst);
         state.unset_side_effect_guard();
         CompileResult::Continue

--- a/monoruby/src/codegen/wrapper.rs
+++ b/monoruby/src/codegen/wrapper.rs
@@ -65,8 +65,12 @@ impl Codegen {
             FuncKind::Builtin { abs_address } => self.gen_native_func_wrapper(*abs_address),
             FuncKind::AttrReader { ivar_name } => self.gen_attr_reader(*ivar_name),
             FuncKind::AttrWriter { ivar_name } => self.gen_attr_writer(*ivar_name),
-            FuncKind::StructReader { slot_index } => self.gen_struct_reader(*slot_index),
-            FuncKind::StructWriter { slot_index } => self.gen_struct_writer(*slot_index),
+            FuncKind::StructReader { slot_index, inline } => {
+                self.gen_struct_reader(*slot_index, *inline)
+            }
+            FuncKind::StructWriter { slot_index, inline } => {
+                self.gen_struct_writer(*slot_index, *inline)
+            }
         };
         self.jit.finalize();
         entry
@@ -186,50 +190,49 @@ impl Codegen {
     }
 
     ///
-    /// Generate a `Struct` member reader. The slot index is hard-coded
-    /// at codegen time, so the wrapper is a fixed-cost three-load
-    /// sequence with no Rust call:
+    /// Generate a `Struct` member reader. With the slot vector now
+    /// stored as a `SmallVec<[Value; STRUCT_INLINE_SLOTS]>` directly
+    /// in the RValue's `kind` union (no Box), the inline case is a
+    /// **single mov** matching the inline-ivar `attr_reader` codegen.
+    /// The heap case dereferences `RVALUE_OFFSET_HEAP_PTR` once.
     ///
+    /// Inline:
     /// ```asm
-    ///   mov rdi, [r14 - LFP_SELF]              ; self (Value, heap ptr)
-    ///   mov rdi, [rdi + RVALUE_OFFSET_KIND]    ; Box<StructInner>
-    ///   mov rdi, [rdi + STRUCT_INNER_PTR_OFFSET]; slot array
-    ///   mov rax, [rdi + slot * 8]              ; the Value
+    ///   mov rdi, [r14 - LFP_SELF]
+    ///   mov rax, [rdi + RVALUE_OFFSET_INLINE + slot*8]
     ///   ret
     /// ```
-    ///
-    /// Receiver type is guaranteed by the dispatch path (the method
-    /// is only registered on `ObjTy::STRUCT` subclasses), so no class
-    /// guard is needed at this level.
-    fn gen_struct_reader(&mut self, slot_index: u16) {
-        monoasm!( &mut self.jit,
-            movq rdi, [r14 - (LFP_SELF)];
-            movq rdi, [rdi + (RVALUE_OFFSET_KIND as i32)];
-            movq rdi, [rdi + (STRUCT_INNER_PTR_OFFSET as i32)];
-            movq rax, [rdi + ((slot_index as i32) * 8)];
-            ret;
-        );
+    /// Heap:
+    /// ```asm
+    ///   mov rdi, [r14 - LFP_SELF]
+    ///   mov rdi, [rdi + RVALUE_OFFSET_HEAP_PTR]
+    ///   mov rax, [rdi + slot*8]
+    ///   ret
+    /// ```
+    fn gen_struct_reader(&mut self, slot_index: u16, inline: bool) {
+        if inline {
+            monoasm!( &mut self.jit,
+                movq rdi, [r14 - (LFP_SELF)];
+                movq rax, [rdi + ((slot_index as i32) * 8 + RVALUE_OFFSET_INLINE as i32)];
+                ret;
+            );
+        } else {
+            monoasm!( &mut self.jit,
+                movq rdi, [r14 - (LFP_SELF)];
+                movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
+                movq rax, [rdi + ((slot_index as i32) * 8)];
+                ret;
+            );
+        }
     }
 
     ///
     /// Generate a `Struct` member writer. Routes through a small
     /// runtime helper (`set_struct_slot_with_check`) to keep the
-    /// frozen check + error-flag plumbing in Rust:
-    ///
-    /// ```asm
-    ///   mov rdi, rbx                  ; &mut Executor
-    ///   mov rsi, r12                  ; &mut Globals
-    ///   mov rdx, [r14 - LFP_SELF]     ; self (Value)
-    ///   mov rcx, [r14 - LFP_ARG0]     ; the value to store
-    ///   mov r8, slot_index
-    ///   call set_struct_slot_with_check
-    ///   ret
-    /// ```
-    ///
-    /// On FrozenError the helper returns NULL and the caller picks up
-    /// the error via the existing extern-"C" None-means-error contract
-    /// (same as `set_instance_var_with_cache`).
-    fn gen_struct_writer(&mut self, slot_index: u16) {
+    /// frozen check + error-flag plumbing in Rust. The helper itself
+    /// figures out inline vs. heap from the receiver's `SmallVec`,
+    /// so the wrapper-level codegen is identical for both cases.
+    fn gen_struct_writer(&mut self, slot_index: u16, _inline: bool) {
         monoasm!( &mut self.jit,
             movq rdi, rbx;
             movq rsi, r12;

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -846,9 +846,10 @@ impl Globals {
         class_id: ClassId,
         member_name: IdentId,
         slot_index: u16,
+        inline: bool,
         visi: Visibility,
     ) -> IdentId {
-        let func_id = self.store.new_struct_reader(member_name, slot_index);
+        let func_id = self.store.new_struct_reader(member_name, slot_index, inline);
         self.gen_wrapper(func_id);
         self.add_method(class_id, member_name, func_id, visi);
         member_name
@@ -857,17 +858,20 @@ impl Globals {
     ///
     /// Define a `Struct` member writer (`s.x = v`) for *class_id*: a
     /// method named *member_name=* that stores into slot *slot_index*
-    /// of the receiver's `StructInner`.
+    /// of the receiver's `StructInner`. `inline` is `true` when the
+    /// class fits within `STRUCT_INLINE_SLOTS` members (so the slot
+    /// vector is not heap-allocated).
     ///
     pub(crate) fn define_struct_writer(
         &mut self,
         class_id: ClassId,
         member_name: IdentId,
         slot_index: u16,
+        inline: bool,
         visi: Visibility,
     ) -> IdentId {
         let writer_name = IdentId::add_assign_postfix(member_name);
-        let func_id = self.store.new_struct_writer(writer_name, slot_index);
+        let func_id = self.store.new_struct_writer(writer_name, slot_index, inline);
         self.gen_wrapper(func_id);
         self.add_method(class_id, writer_name, func_id, visi);
         writer_name

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -511,12 +511,22 @@ impl Store {
         self.functions.new_attr_writer(name, ivar_name)
     }
 
-    pub(super) fn new_struct_reader(&mut self, name: IdentId, slot_index: u16) -> FuncId {
-        self.functions.new_struct_reader(name, slot_index)
+    pub(super) fn new_struct_reader(
+        &mut self,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> FuncId {
+        self.functions.new_struct_reader(name, slot_index, inline)
     }
 
-    pub(super) fn new_struct_writer(&mut self, name: IdentId, slot_index: u16) -> FuncId {
-        self.functions.new_struct_writer(name, slot_index)
+    pub(super) fn new_struct_writer(
+        &mut self,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> FuncId {
+        self.functions.new_struct_writer(name, slot_index, inline)
     }
 
     pub(crate) fn new_callsite(

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -536,16 +536,26 @@ impl Funcs {
         id
     }
 
-    pub(super) fn new_struct_reader(&mut self, name: IdentId, slot_index: u16) -> FuncId {
+    pub(super) fn new_struct_reader(
+        &mut self,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> FuncId {
         let id = self.next_func_id();
-        let info = FuncInfo::new_struct_reader(id, name, slot_index);
+        let info = FuncInfo::new_struct_reader(id, name, slot_index, inline);
         self.info.push(info);
         id
     }
 
-    pub(super) fn new_struct_writer(&mut self, name: IdentId, slot_index: u16) -> FuncId {
+    pub(super) fn new_struct_writer(
+        &mut self,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> FuncId {
         let id = self.next_func_id();
-        let info = FuncInfo::new_struct_writer(id, name, slot_index);
+        let info = FuncInfo::new_struct_writer(id, name, slot_index, inline);
         self.info.push(info);
         id
     }
@@ -563,15 +573,15 @@ pub(crate) enum FuncKind {
     AttrReader { ivar_name: IdentId },
     AttrWriter { ivar_name: IdentId },
     /// `Struct` member reader. The slot index is fixed at class
-    /// definition time (the position in `/members`), so the JIT can
-    /// emit a direct `mov` from the per-instance slot vector — no
-    /// name lookup, no ivar id resolution. Mirrors the
-    /// `AttrReader { ivar_name }` pattern but for `ObjTy::STRUCT`
-    /// receivers.
-    StructReader { slot_index: u16 },
+    /// definition time (the position in `/members`); `inline` is
+    /// `true` when the class has at most `STRUCT_INLINE_SLOTS`
+    /// members (the slot vector lives directly in the RValue's
+    /// `kind` union, no heap allocation). The JIT and the wrapper
+    /// pick a 1-mov vs. 2-mov code variant accordingly.
+    StructReader { slot_index: u16, inline: bool },
     /// `Struct` member writer. Counterpart to `StructReader`; writes
     /// to slot `slot_index` of the per-instance `StructInner`.
-    StructWriter { slot_index: u16 },
+    StructWriter { slot_index: u16, inline: bool },
 }
 
 impl std::default::Default for FuncKind {
@@ -852,7 +862,12 @@ impl FuncInfo {
         )
     }
 
-    fn new_struct_reader(func_id: FuncId, name: IdentId, slot_index: u16) -> Self {
+    fn new_struct_reader(
+        func_id: FuncId,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> Self {
         // Same parameter shape as AttrReader (zero positional args,
         // simple), so wrapper / call dispatch infra can reuse the
         // attribute-reader code paths.
@@ -860,19 +875,24 @@ impl FuncInfo {
         let reg_num = params.total_args() + 1;
         Self::new(
             name,
-            FuncKind::StructReader { slot_index },
+            FuncKind::StructReader { slot_index, inline },
             FuncType::Method,
             Meta::native(func_id, reg_num, true),
             params,
         )
     }
 
-    fn new_struct_writer(func_id: FuncId, name: IdentId, slot_index: u16) -> Self {
+    fn new_struct_writer(
+        func_id: FuncId,
+        name: IdentId,
+        slot_index: u16,
+        inline: bool,
+    ) -> Self {
         let params = ParamsInfo::new_attr_writer();
         let reg_num = params.total_args() + 1;
         Self::new(
             name,
-            FuncKind::StructWriter { slot_index },
+            FuncKind::StructWriter { slot_index, inline },
             FuncType::Method,
             Meta::native(func_id, reg_num, true),
             params,

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -27,7 +27,7 @@ pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
 pub use string::{Encoding, RString, RStringInner};
-pub use struct_inner::{STRUCT_INNER_PTR_OFFSET, StructInner};
+pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 
 mod array;
 mod binding;
@@ -157,9 +157,13 @@ pub union ObjKind {
     binding: ManuallyDrop<BindingInner>,
     matchdata: ManuallyDrop<MatchDataInner>,
     rational: ManuallyDrop<Box<RationalInner>>,
-    /// Slot-array storage for `Struct` subclass instances. Boxed so the
-    /// union stays small even when the slot vector is large.
-    struct_inner: ManuallyDrop<Box<StructInner>>,
+    /// Slot-array storage for `Struct` subclass instances. Stored
+    /// directly (not boxed) so up to `STRUCT_INLINE_SLOTS` members
+    /// live inline in this union -- the JIT reuses the existing
+    /// `RVALUE_OFFSET_INLINE` / `RVALUE_OFFSET_HEAP_PTR` constants to
+    /// load slots without an extra Box deref. Same layout as
+    /// `ArrayInner`'s `SmallVec<[Value; 5]>`.
+    struct_inner: ManuallyDrop<StructInner>,
 }
 
 impl ObjKind {
@@ -954,7 +958,7 @@ impl RValue {
                             copy.set(i, v.deep_copy());
                         }
                         ObjKind {
-                            struct_inner: ManuallyDrop::new(Box::new(copy)),
+                            struct_inner: ManuallyDrop::new(copy),
                         }
                     }
                     _ => unreachable!("deep_copy()"),
@@ -1026,9 +1030,9 @@ impl RValue {
                             matchdata: self.kind.matchdata.clone(),
                         },
                         ObjTy::STRUCT => ObjKind {
-                            struct_inner: ManuallyDrop::new(Box::new(
-                                (**self.kind.struct_inner).clone(),
-                            )),
+                            struct_inner: ManuallyDrop::new(
+                                (*self.kind.struct_inner).clone(),
+                            ),
                         },
                         ty => unreachable!("{ty:?}"),
                     }
@@ -1100,9 +1104,9 @@ impl RValue {
                             matchdata: self.kind.matchdata.clone(),
                         },
                         ObjTy::STRUCT => ObjKind {
-                            struct_inner: ManuallyDrop::new(Box::new(
-                                (**self.kind.struct_inner).clone(),
-                            )),
+                            struct_inner: ManuallyDrop::new(
+                                (*self.kind.struct_inner).clone(),
+                            ),
                         },
                         ty => unreachable!("{ty:?}"),
                     }
@@ -1241,7 +1245,7 @@ impl RValue {
         RValue {
             header: Header::new(class_id, ObjTy::STRUCT),
             kind: ObjKind {
-                struct_inner: ManuallyDrop::new(Box::new(StructInner::new(len))),
+                struct_inner: ManuallyDrop::new(StructInner::new(len)),
             },
             var_table: None,
         }

--- a/monoruby/src/value/rvalue/struct_inner.rs
+++ b/monoruby/src/value/rvalue/struct_inner.rs
@@ -1,68 +1,35 @@
 use super::*;
+use smallvec::{SmallVec, smallvec};
 
-/// Inner storage for `Struct` subclass instances. Members are stored
-/// in a heap-allocated array of [`Value`]s, indexed by member position
-/// (matching the order of the class-level `/members` array).
+/// Number of slots stored INLINE in the [`StructInner`] (i.e. in the
+/// RValue's `kind` union, no heap allocation). Must equal
+/// [`ARRAY_INLINE_CAPA`] so the
+/// `RVALUE_OFFSET_INLINE` / `RVALUE_OFFSET_ARY_CAPA` / `RVALUE_OFFSET_HEAP_PTR`
+/// constants — computed by the vendored `smallvec` crate for
+/// `SmallVec<[u64; 5]>` — apply identically here. SmallVec layout
+/// depends only on the element-array size, and `Value` is the same
+/// size as `u64`, so the constants are interchangeable.
+pub const STRUCT_INLINE_SLOTS: usize = ARRAY_INLINE_CAPA;
+const _: () = assert!(STRUCT_INLINE_SLOTS == 5);
+
+/// Inner storage for `Struct` subclass instances. Slots live in a
+/// fixed-size [`SmallVec`] so up to [`STRUCT_INLINE_SLOTS`] members
+/// are stored inline (no heap allocation). Larger structs spill to
+/// the heap, with the same layout `ArrayInner` uses for arrays.
 ///
-/// The struct is `repr(C)` with an explicit field order so the JIT can
-/// load the slot pointer with a single `mov [rdi + STRUCT_PTR]` after
-/// dereferencing the `Box<StructInner>` from the RValue's `kind`.
-/// `STRUCT_PTR` is exposed as a const for codegen.
+/// Indexed by member position (matching `/members` order). All slots
+/// are initialised to `Value::nil()` by `struct_alloc_func`;
+/// `Struct#initialize` overwrites them positionally.
 ///
-/// Created at allocation time (`struct_alloc_func`) with all slots set
-/// to `nil`; `Struct#initialize` overwrites them positionally.
-#[repr(C)]
-pub struct StructInner {
-    /// Heap pointer to a `len`-element array of [`Value`]s. ALWAYS the
-    /// first field — the JIT relies on offset 0.
-    ptr: std::ptr::NonNull<Value>,
-    len: usize,
-}
-
-/// Byte offset of `StructInner.ptr` within `StructInner`. JIT uses
-/// this when emitting struct slot loads/stores.
-pub const STRUCT_INNER_PTR_OFFSET: usize = std::mem::offset_of!(StructInner, ptr);
-
-impl std::fmt::Debug for StructInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StructInner")
-            .field("len", &self.len)
-            .field("values", &self.values())
-            .finish()
-    }
-}
-
-impl Clone for StructInner {
-    fn clone(&self) -> Self {
-        let mut s = StructInner::new(self.len);
-        for (i, v) in self.values().iter().enumerate() {
-            s.set(i, *v);
-        }
-        s
-    }
-}
-
-impl PartialEq for StructInner {
-    fn eq(&self, other: &Self) -> bool {
-        self.values() == other.values()
-    }
-}
-
-impl Drop for StructInner {
-    fn drop(&mut self) {
-        // SAFETY: We allocated `self.ptr` via `Box::into_raw` (see
-        // `StructInner::new`) with the given `self.len`. Reconstruct
-        // the `Box<[Value]>` so it gets freed.
-        unsafe {
-            let slice = std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len);
-            drop(Box::from_raw(slice as *mut [Value]));
-        }
-    }
-}
+/// The struct is `repr(transparent)` over the SmallVec so the JIT can
+/// reuse the existing `RVALUE_OFFSET_*` constants.
+#[derive(Debug, Clone, PartialEq)]
+#[repr(transparent)]
+pub struct StructInner(SmallVec<[Value; STRUCT_INLINE_SLOTS]>);
 
 impl alloc::GC<RValue> for StructInner {
     fn mark(&self, alloc: &mut Allocator<RValue>) {
-        for v in self.values() {
+        for v in self.0.iter() {
             v.mark(alloc);
         }
     }
@@ -70,50 +37,38 @@ impl alloc::GC<RValue> for StructInner {
 
 impl StructInner {
     pub fn new(len: usize) -> Self {
-        // Allocate a `Box<[Value]>` of `len` nils, then leak it into a
-        // raw pointer we'll reclaim in `Drop`.
-        let boxed: Box<[Value]> = vec![Value::nil(); len].into_boxed_slice();
-        let raw: *mut [Value] = Box::into_raw(boxed);
-        // SAFETY: `Box::into_raw` returns a non-null pointer.
-        let ptr = unsafe {
-            std::ptr::NonNull::new_unchecked((raw as *mut Value).cast::<Value>())
-        };
-        StructInner { ptr, len }
+        StructInner(smallvec![Value::nil(); len])
     }
 
     pub fn len(&self) -> usize {
-        self.len
+        self.0.len()
     }
 
     pub fn get(&self, index: usize) -> Value {
-        assert!(index < self.len);
-        // SAFETY: bounds-checked above; the heap slice is alive for
-        // the lifetime of `self`.
-        unsafe { *self.ptr.as_ptr().add(index) }
+        self.0[index]
     }
 
     pub fn try_get(&self, index: usize) -> Option<Value> {
-        if index < self.len {
-            Some(self.get(index))
-        } else {
-            None
-        }
+        self.0.get(index).copied()
     }
 
     pub fn set(&mut self, index: usize, value: Value) {
-        assert!(index < self.len);
-        // SAFETY: bounds-checked above.
-        unsafe { *self.ptr.as_ptr().add(index) = value };
+        self.0[index] = value;
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, Value> {
-        self.values().iter()
+        self.0.iter()
     }
 
     pub fn values(&self) -> &[Value] {
-        // SAFETY: `ptr` is a valid pointer to `len` initialised
-        // [`Value`]s allocated by `StructInner::new`, alive for the
-        // lifetime of `self`.
-        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+        &self.0
+    }
+
+    /// True if the slot vector spilled to the heap (member count
+    /// exceeded [`STRUCT_INLINE_SLOTS`]). The JIT call-site path uses
+    /// this to decide between the inline and heap codegen variants
+    /// per receiver class.
+    pub fn is_heap(&self) -> bool {
+        self.0.spilled()
     }
 }


### PR DESCRIPTION
## Summary

Phase D follow-up to #368. Replaces the boxed `StructInner { ptr: NonNull<Value>, len: u32 }` with a `repr(transparent)` wrapper around `SmallVec<[Value; STRUCT_INLINE_SLOTS]>` (5 slots) stored **directly** in the `RValue` `kind` union — no `Box` indirection.

Reuses the existing `RVALUE_OFFSET_INLINE` / `RVALUE_OFFSET_HEAP_PTR` offsets (computed for `SmallVec<[u64; 5]>`, identical layout for `[Value; 5]` since `Value` is `u64`-sized), so the inline case becomes a **single `mov`** — exactly the same shape as inline-ivar `attr_reader`.

### Microbench (10M iterations, release build)

| | Before (PR #368) | After (this PR) | `attr_accessor` baseline |
|---|---:|---:|---:|
| Struct read  (`s.a; s.b`) | 539 ms | **368 ms** | 350 ms |
| Struct write (`s.a = 1`)  | 539 ms | **353 ms** | 377 ms |

Struct read is now within ~5% of `attr_reader`. Struct write is **faster** than `attr_writer` (the writer still routes through the FrozenError helper, so the gain is from the storage layout alone).

## Mechanism

### 1. `StructInner` is now a transparent SmallVec

```rust
pub const STRUCT_INLINE_SLOTS: usize = ARRAY_INLINE_CAPA; // = 5
const _: () = assert!(STRUCT_INLINE_SLOTS == 5);

#[repr(transparent)]
pub struct StructInner(SmallVec<[Value; STRUCT_INLINE_SLOTS]>);
```

The slot vector lives **inline** in the `RValue` for ≤5 members (the common case) and spills to the heap automatically for larger structs. No more `Box::into_raw` / `Box::from_raw`; `SmallVec`'s drop handles cleanup, and GC simply walks `iter()`.

### 2. Specialization is decided once, at class definition

`FuncKind` carries an `inline: bool` flag baked at class definition time:

```rust
StructReader { slot_index: u16, inline: bool },
StructWriter { slot_index: u16, inline: bool },
```

`struct_class.rs` computes `let inline = members.len() <= STRUCT_INLINE_SLOTS;` once per `Struct.new` and threads it through `define_struct_{reader,writer}`. No runtime member-count lookup — both the wrapper (non-JIT path) and the JIT call-site emit the right code statically.

### 3. AsmIR splits into four ops

| Variant | Codegen |
|---|---|
| `LoadStructSlotInline`  | `mov rax, [rdi + RVALUE_OFFSET_INLINE + slot*8]` (1 mov) |
| `LoadStructSlotHeap`    | deref `RVALUE_OFFSET_HEAP_PTR`, then `[rdi + slot*8]` (2 movs) |
| `StoreStructSlotInline` | symmetric write to inline slot |
| `StoreStructSlotHeap`   | symmetric write through heap ptr |

### 4. Wrapper codegen mirrors the JIT split

```asm
; gen_struct_reader, inline = true
mov rdi, [r14 - LFP_SELF]
mov rax, [rdi + RVALUE_OFFSET_INLINE + slot*8]
ret

; gen_struct_reader, inline = false
mov rdi, [r14 - LFP_SELF]
mov rdi, [rdi + RVALUE_OFFSET_HEAP_PTR]
mov rax, [rdi + slot*8]
ret
```

Writers still call `set_struct_slot_with_check` for the FrozenError path; the helper inspects the `SmallVec` itself to decide inline vs. heap, so the wrapper is identical for both cases.

## Files

- `monoruby/src/value/rvalue/struct_inner.rs` — rewrite as `repr(transparent)` SmallVec; export `STRUCT_INLINE_SLOTS`.
- `monoruby/src/value/rvalue.rs` — drop `Box` from the union field; rewire `dup`/`clone_value`/`deep_copy`.
- `monoruby/src/globals/store/function.rs` — add `inline: bool` to `FuncKind::StructReader/StructWriter` + factories.
- `monoruby/src/globals/{store,method}.rs` — propagate `inline` through `define_struct_{reader,writer}`.
- `monoruby/src/builtins/struct_class.rs` — compute `inline` from `members.len()` at class-def time.
- `monoruby/src/codegen/wrapper.rs` — `gen_struct_reader` branches on `inline` (1 mov vs 2 mov).
- `monoruby/src/codegen/jitgen/asmir.rs` — split into 4 inline/heap variants.
- `monoruby/src/codegen/jitgen/asmir/compile{,/variables}.rs` — dispatch + monoasm bodies for each variant.
- `monoruby/src/codegen/jitgen/compile/method_call.rs` — drop the runtime member-count helper; pull `inline` straight from `FuncKind`.

## Test plan

- [x] `cargo build --release -p monoruby` clean
- [x] `cargo test --release -p monoruby --lib` — 1310 passing, 19 baseline failures unchanged
- [x] All 32 `builtins::struct_class::tests::*` pass (`struct_slot_reader_jitted`, `struct_slot_writer_jitted`, `struct_writer_frozen_raises`, etc.)
- [x] Microbench: Struct read 0.37s vs attr_reader 0.35s (within 5%); Struct write 0.35s vs attr_writer 0.38s
- [x] Heap path verified with a 6-member struct (read/write, value round-trip)
- [x] Inline path verified at `STRUCT_INLINE_SLOTS` boundary (5 members)

Builds on #368.

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_