### PR TITLE
Module: 5 small clusters (cmp, cvar metaclass, visibility, method_added, const warn)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -89,6 +89,31 @@ class Regexp
 end
 
 class Module
+  # Partial ordering on the include / inherit graph, matching CRuby's
+  # `rb_mod_cmp`:
+  #
+  # | relationship                                    | result |
+  # | ----------------------------------------------- | ------ |
+  # | `self` is `other`                               | `0`    |
+  # | `self` is a subclass of, or includes, `other`   | `-1`   |
+  # | `other` is a subclass of, or includes, `self`   | `+1`   |
+  # | unrelated                                       | `nil`  |
+  # | `other` is not a Module / Class                 | `nil`  |
+  #
+  # Defined on Module so `<` / `>` / `<=` / `>=` (provided by
+  # `Comparable` in CRuby; we synthesise them) all reduce to this.
+  def <=>(other)
+    return nil unless other.is_a?(Module)
+    return 0 if equal?(other)
+    if ancestors.include?(other)
+      -1
+    elsif other.ancestors.include?(self)
+      +1
+    else
+      nil
+    end
+  end
+
   private
   def extended(mod)
   end

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1417,10 +1417,15 @@ fn public_instance_methods(
 ) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
     let inherited_too = lfp.try_arg(0).is_none() || lfp.arg(0).as_bool();
+    // CRuby distinguishes `public_instance_methods` (public only) from
+    // `instance_methods` (public + protected). The shared helpers
+    // `get_method_names` / `get_method_names_inherit` cover the
+    // public+protected case used by `instance_methods`; here we want
+    // the strict public-only flavor.
     Ok(Value::array_from_vec(if !inherited_too {
-        globals.store.get_method_names(class_id)
+        globals.store.get_public_method_names(class_id)
     } else {
-        globals.store.get_method_names_inherit(class_id, false)
+        globals.store.get_public_method_names_inherit(class_id)
     }))
 }
 
@@ -2060,7 +2065,12 @@ fn class_variables(
     let inherit = lfp.try_arg(0).map(|v| v.as_bool()).unwrap_or(true);
     let mut seen = HashSet::default();
     let mut names: Vec<IdentId> = Vec::new();
-    let mut module = Some(globals.store[class_id].get_module());
+    // CRuby: a class variable defined on a singleton class is shared
+    // with the attached class — `class C; class << self; @@x = …; end;
+    // C.class_variables.include?(:@@x)`. Start the walk on the
+    // attached non-singleton class so `class_variables` sees those.
+    let start_id = singleton_attached_class_for_id(globals, class_id);
+    let mut module = Some(globals.store[start_id].get_module());
     while let Some(m) = module {
         for name in globals.store.get_class_variable_names(m.id()) {
             if seen.insert(name) {
@@ -2075,6 +2085,23 @@ fn class_variables(
     Ok(Value::array_from_vec(
         names.into_iter().map(Value::symbol).collect(),
     ))
+}
+
+/// Mirror of the same-named helper in `class/constants.rs`, exposed
+/// to the builtin layer. Walks up the singleton chain until the
+/// receiver is non-singleton (or the attached object isn't a
+/// class/module).
+fn singleton_attached_class_for_id(globals: &Globals, mut class_id: ClassId) -> ClassId {
+    loop {
+        let module = globals.store[class_id].get_module();
+        match module.is_singleton() {
+            Some(attached) => match attached.is_class_or_module() {
+                Some(m) => class_id = m.id(),
+                None => return class_id,
+            },
+            None => return class_id,
+        }
+    }
 }
 
 /// ### Module#set_temporary_name
@@ -2300,7 +2327,21 @@ fn change_visi(
     }
     let (res, names) = extract_names(globals, arg)?;
     let class_id = self_val.as_class_id();
+    // CRuby fires `method_added` only when `private` / `protected` /
+    // `public` adds a *new* entry to the receiver's method table —
+    // i.e. when the method was inherited rather than defined locally.
+    // Capture which names were missing locally before the call so we
+    // can fire after `change_method_visibility_for_class` runs.
+    let was_missing_locally: Vec<bool> = names
+        .iter()
+        .map(|n| !globals.store[class_id].has_own_method(*n))
+        .collect();
     globals.change_method_visibility_for_class(class_id, &names, visi)?;
+    for (name, was_missing) in names.iter().zip(was_missing_locally) {
+        if was_missing && globals.store[class_id].has_own_method(*name) {
+            vm.invoke_method_added(globals, class_id, *name)?;
+        }
+    }
     Ok(res)
 }
 

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -906,8 +906,17 @@ pub(super) extern "C" fn alias_method(
             return None;
         }
     };
-    let func_id = vm.cfp().lfp().func_id();
-    let class_id = func_id.lexical_class(globals);
+    // Target the *runtime* class context (`module_eval` /
+    // `class_eval` push it onto a stack) rather than the iseq's
+    // *lexical* class — the iseq is captured at compile time, so a
+    // block created at top level and run inside
+    // `Module.new do … end` still has Object as its lexical class.
+    // `alias` should target the module that's currently being
+    // defined, matching CRuby's `cref->klass`.
+    let class_id = vm.context_class_id();
+    // `Executor::alias_method_for_class` already fires the
+    // `method_added` hook, so the alias-keyword path matches
+    // `Module#alias_method`'s behaviour for it.
     match vm.alias_method_for_class(globals, class_id, new, old) {
         Ok(_) => Some(Value::nil()),
         Err(err) => {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -749,6 +749,33 @@ impl Executor {
                 .expect_class_or_module(&globals.store)?
                 .id();
         }
+        // Re-initialization warning, matching CRuby's
+        // `rb_const_set_visibility`: the same wording (and same `$stderr`
+        // delivery) used by `Module#const_set` so mspec's `complain`
+        // matcher catches both code-paths.
+        if globals.store.get_constant_noautoload(parent, name).is_some() {
+            let parent_name = globals.store[parent]
+                .get_name()
+                .unwrap_or_default()
+                .to_string();
+            let qual = if parent_name.is_empty() {
+                name.get_name().to_string()
+            } else {
+                format!("{parent_name}::{}", name.get_name())
+            };
+            let msg = format!("warning: already initialized constant {qual}\n");
+            let stderr_id = IdentId::get_id("$stderr");
+            let stderr = globals.get_gvar(stderr_id).unwrap_or(Value::nil());
+            let write_id = IdentId::get_id("write");
+            let _ = self.invoke_method_inner(
+                globals,
+                write_id,
+                stderr,
+                &[Value::string(msg)],
+                None,
+                None,
+            );
+        }
         globals.set_constant(parent, name, val);
         if let Some((file, line)) = source_loc {
             globals.store[parent].record_constant_location(name, file, line);

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -511,6 +511,16 @@ impl ClassInfo {
         self.constants.contains_key(&name)
     }
 
+    /// Returns true if a method entry for `name` exists directly on
+    /// this class/module's method table (not inherited). Used by
+    /// visibility-modifier code to decide whether `private :foo` /
+    /// `public :foo` constitutes adding the method to the table
+    /// (which fires `method_added`) or merely flipping the visibility
+    /// of an already-local entry (which doesn't).
+    pub(crate) fn has_own_method(&self, name: IdentId) -> bool {
+        self.methods.contains_key(&name)
+    }
+
     /// Returns true if the constant `name` defined on this class/module is
     /// marked as private. Constants are public by default. Returns false if
     /// the constant is not defined on this class.
@@ -787,6 +797,64 @@ impl ClassInfoTable {
             .collect()
     }
 
+    /// Public-only method names on the class itself (no inheritance).
+    /// Used by `Module#public_instance_methods(false)`. CRuby
+    /// distinguishes public from protected for this query — protected
+    /// methods belong to `protected_instance_methods`, not
+    /// `public_instance_methods`.
+    pub(crate) fn get_public_method_names(&self, class_id: ClassId) -> Vec<Value> {
+        self[class_id]
+            .methods
+            .iter()
+            .filter_map(|(name, entry)| {
+                if entry.is_public() {
+                    Some(Value::symbol(*name))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Public-only walk of the ancestor chain. Closer-ancestor wins
+    /// the visibility race so a `private`/`protected` modifier on a
+    /// nearer module doesn't surface as public via a deeper public
+    /// definition.
+    pub(crate) fn get_public_method_names_inherit(&self, class_id: ClassId) -> Vec<Value> {
+        let mut names = HashSet::default();
+        let mut module = self.get_module(class_id);
+        let mut exclude = HashSet::default();
+        loop {
+            for (name, entry) in &self[module.id()].methods {
+                if exclude.contains(name) || names.contains(name) {
+                    continue;
+                }
+                match entry.visibility {
+                    Visibility::Undefined | Visibility::Private | Visibility::Protected => {
+                        exclude.insert(*name);
+                    }
+                    Visibility::Public => {
+                        if entry.func_id().is_some() {
+                            names.insert(*name);
+                        } else {
+                            exclude.insert(*name);
+                        }
+                    }
+                }
+            }
+            match module.superclass() {
+                Some(superclass) => {
+                    if superclass.id() == OBJECT_CLASS {
+                        break;
+                    }
+                    module = superclass;
+                }
+                None => break,
+            }
+        }
+        names.into_iter().map(|sym| Value::symbol(sym)).collect()
+    }
+
     ///
     /// Get private method names in the class of *class_id*.
     ///  
@@ -850,12 +918,20 @@ impl ClassInfoTable {
         loop {
             if !only_singleton || module.is_singleton().is_some() || module.is_iclass() {
                 for (name, entry) in &self[module.id()].methods {
+                    // Closer ancestor wins: skip names already resolved
+                    // here. This is what makes `private :foo` on Kernel
+                    // not surface `:foo` as private through Object —
+                    // Object's own public entry has already classified
+                    // it.
+                    if exclude.contains(name) || names.contains(name) {
+                        continue;
+                    }
                     if matches!(
                         entry.visibility,
                         Visibility::Undefined | Visibility::Private
                     ) {
                         exclude.insert(*name);
-                    } else if entry.is_public_protected() && !exclude.contains(name) {
+                    } else if entry.is_public_protected() {
                         names.insert(*name);
                     }
                 }
@@ -882,10 +958,27 @@ impl ClassInfoTable {
         let mut exclude = HashSet::default();
         loop {
             for (name, entry) in &self[module.id()].methods {
+                // Earlier entries in the lookup chain take precedence
+                // for visibility queries: once a name has been resolved
+                // (here or in `Undefined`), don't let a later, deeper
+                // ancestor's different visibility shadow it. This is
+                // why `Object.private_instance_methods` does NOT
+                // include a method that's public on Object even if
+                // `Kernel` (a deeper iclass entry) has marked it
+                // private — Object's own entry wins.
+                if exclude.contains(name) || names.contains(name) {
+                    // Already resolved by a closer ancestor.
+                    continue;
+                }
                 if matches!(entry.visibility, Visibility::Undefined) {
                     exclude.insert(*name);
-                } else if entry.is_private() && !exclude.contains(name) {
+                } else if entry.is_private() {
                     names.insert(*name);
+                } else {
+                    // Public/protected at this level; don't report it
+                    // as private even if a deeper ancestor has a
+                    // private modifier.
+                    exclude.insert(*name);
                 }
             }
             match module.superclass() {
@@ -927,13 +1020,20 @@ impl ClassInfoTable {
         let mut exclude = HashSet::default();
         loop {
             for (name, entry) in &self[module.id()].methods {
+                // Closer ancestor wins (see private/public siblings).
+                if exclude.contains(name) || names.contains(name) {
+                    continue;
+                }
                 if matches!(entry.visibility, Visibility::Undefined) {
                     exclude.insert(*name);
                 } else if entry.func_id().is_some()
                     && entry.visibility() == Visibility::Protected
-                    && !exclude.contains(name)
                 {
                     names.insert(*name);
+                } else {
+                    // Public/private classification at this depth ends
+                    // the lookup for `name`.
+                    exclude.insert(*name);
                 }
             }
             match module.superclass() {
@@ -1452,14 +1552,39 @@ impl Store {
             // `func_id` is `None`, which `is_private` / `is_public` and
             // friends treat as "no method present" — so the spec's
             // `m.private_instance_methods.include?(:foo)` would be false.
-            let (func_id, _, _) = self.find_method_for_class(class_id, *name)?;
+            let (func_id, inherited_vis, _) = self.find_method_for_class(class_id, *name)?;
             match self.classes[class_id].methods.get_mut(name) {
                 Some(entry) => {
                     entry.visibility = visibility;
                     Globals::class_version_inc();
                 }
                 None => {
-                    self.add_method_inner(class_id, *name, func_id, visibility, false);
+                    // Optimization (matches CRuby `set_method_visibility`):
+                    // if the inherited method already has the requested
+                    // visibility, don't bother adding a local copy. The
+                    // ruby/spec
+                    // `"with argument does not clone method from the
+                    // ancestor when setting to the same visibility in a
+                    // child"` exercises this.
+                    if inherited_vis == visibility {
+                        continue;
+                    }
+                    // Insert a *visibility-modifier* entry that shares
+                    // `func_id` with the inherited method but does NOT
+                    // change the func's owner_class — otherwise asking
+                    // `Object.public_instance_methods` would surface
+                    // `Module.new { public :foo }`'s shadow because the
+                    // func itself would now claim Module as owner.
+                    self.insert_method(
+                        class_id,
+                        *name,
+                        MethodTableEntry {
+                            owner: class_id,
+                            func_id: Some(func_id),
+                            visibility,
+                            is_basic_op: false,
+                        },
+                    );
                 }
             };
         }

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -1,5 +1,23 @@
 use super::*;
 
+/// Walk up the singleton chain until we hit a non-singleton or until
+/// the attached object stops being a class/module. Used by class-var
+/// access so that `class C; class << self; @@x = …; end; end` lands
+/// on `C`'s class-var table rather than the singleton's, matching
+/// CRuby's `rb_cvar_set` /`rb_cvar_get`.
+fn singleton_attached_class(classes: &ClassInfoTable, mut class_id: ClassId) -> ClassId {
+    loop {
+        let module = classes.get_module(class_id);
+        match module.is_singleton() {
+            Some(attached) => match attached.is_class_or_module() {
+                Some(m) => class_id = m.id(),
+                None => return class_id,
+            },
+            None => return class_id,
+        }
+    }
+}
+
 impl ClassInfoTable {
     pub(crate) fn set_constant_autoload(
         &mut self,
@@ -124,7 +142,15 @@ impl Globals {
     }
 
     pub(crate) fn set_class_variable(&mut self, class_id: ClassId, name: IdentId, val: Value) {
-        self.store.classes[class_id].set_cvar(name, val);
+        // Class variable assignments in a singleton class scope
+        // (`class << self; @@x = …; end`) target the attached object's
+        // class — when the attached is a Class/Module, the cvar lands
+        // on it directly. CRuby's `rb_cvar_set` calls
+        // `rb_singleton_class_attached`-aware logic; we replicate by
+        // walking until the target is non-singleton (or the attached
+        // is no longer a class/module).
+        let target = singleton_attached_class(&self.store.classes, class_id);
+        self.store.classes[target].set_cvar(name, val);
     }
 
     pub(crate) fn get_class_variable(
@@ -132,7 +158,9 @@ impl Globals {
         parent: Module,
         name: IdentId,
     ) -> Result<(Module, Value)> {
-        let mut module = parent;
+        let start_id = singleton_attached_class(&self.store.classes, parent.id());
+        let start = self.store.classes[start_id].get_module();
+        let mut module = start;
         let mut res: Option<(Module, Value)> = None;
         loop {
             if let Some(v) = self.store.classes[module.id()].get_cvar(name) {


### PR DESCRIPTION
## Summary

Targets the small clusters identified in the most recent core/module analysis: ⑤ class-var metaclass scope, ⑥ visibility on inherited methods, ⑨ `method_added` timing, ⑪ `Module#<=>`, ⑬ `const_source_location` redefinition warning. Drops `core/module` from **130F + 132E → 115F + 129E** (about 18 cleared).

## ⑪ `Module#<=>`

Defined in `builtins/startup.rb`. Returns -1 / 0 / +1 / nil based on the include/inherit graph:

| relationship | result |
| --- | :-: |
| `self` is `other` | `0` |
| `self` is a subclass of, or includes, `other` | `-1` |
| `other` is a subclass of, or includes, `self` | `+1` |
| unrelated, or non-Module argument | `nil` |

## ⑤ Class variables in singleton scope

`class C; class << self; @@x = …; end; end` now records on `C`'s cvar table, matching CRuby's `rb_cvar_set`. New `singleton_attached_class` helper walks up the singleton chain until the receiver is non-singleton (or until the attached object stops being a class/module). Threaded through:

- `set_class_variable` / `get_class_variable` (in `class/constants.rs`)
- `Module#class_variables` (mirror walk so metaclass cvars surface)

## ⑥ `Module#private`/`protected`/`public` on inherited methods

The visibility-modifier path for an inherited method now inserts a *visibility shadow* entry on the receiver (sharing the inherited `func_id`) rather than calling the generic `add_method_inner` which would mutate the func's `owner_class`. Without this, marking an Object method private from a Module would later cause Object itself to report it as that visibility because the func's owner had moved.

`change_method_visibility_for_class` skips work when the inherited visibility already matches (matches the `same-visibility no-op` spec).

**Closer-ancestor wins** in `get_private_method_names_inherit`, `get_method_names_inherit`, `get_protected_method_names_inherit`: a name resolved at a shallow ancestor short-circuits the deeper ones, so `Object.private_instance_methods` no longer surfaces a `:foo` that's only marked private on Kernel.

New `get_public_method_names` / `get_public_method_names_inherit` (public-only, not public+protected). `Module#public_instance_methods` switched over so protected methods don't leak into the public list.

## ⑨ `Module#method_added` timing

- `private` / `protected` / `public` with method names now fires `method_added` on the receiver, but **only** when the call adds a new local entry — i.e. the method was inherited rather than already-present. Captures `has_own_method` before+after to decide. Matches the spec's `"is called when using #private in a subclass"` and `"is not called when a method changes visibility"` simultaneously.
- `runtime::alias_method` (the `alias` keyword) now uses the *runtime* class context (`Executor::context_class_id`) rather than the iseq's *lexical* class. The lexical class is captured at compile time, so an `alias` keyword inside `Module.new do … end` was targeting the enclosing scope's class instead of the new module — fixes a regression where `alias` inside a `Module.new` block didn't even add the new method.
- Routes through `Executor::alias_method_for_class`, which already fires `method_added`, so the alias-keyword path now matches `Module#alias_method`.

## ⑬ `Module#const_source_location` redefinition warning

Static `Module::CONST = …` reassignment now emits the `already initialized constant <Qualified>` warning to Ruby `$stderr`, matching the path `Module#const_set` already had. The spec `"with dynamically assigned constants returns path to the updated value of a constant"` exercises this `complain` match.

## Misc

- `ClassInfo::has_own_method` helper for the visibility/method_added decision.

## Test plan

- [x] `cargo build --release -p monoruby` clean
- [x] `cargo test --release -p monoruby --lib` — 1474 pass / 19 baseline failures unchanged
- [x] All 110 `builtins::module::tests::*` pass
- [x] `mspec run core/module -t monoruby` — 115F + 129E (was 130 + 132; **−18**)
- [x] Specs flipped to all-green: `core/module/comparison_spec.rb`, `core/module/class_variable_get_spec.rb`, `core/module/class_variable_defined_spec.rb` (modulo one unrelated cvar-overtaken edge case)

The remaining failures cluster around the architecturally hard items: refinements (~57), autoload state machine (~49), `define_method` UnboundMethod/Method semantics (~41), ruby2_keywords, eval-string caller-cref propagation, prepend chain post-`dup` reattachment.

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_