### PR TITLE
autoload: state machine + non-triggering defined? / const_defined? + source location

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -445,7 +445,7 @@ fn alias_method(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_val = lfp.self_val();
+    let self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
     let class_id = self_val.as_class_id();
     let new_name = lfp.arg(0).coerce_to_symbol_or_string(vm, globals)?;
@@ -1143,7 +1143,7 @@ fn const_set(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_val = lfp.self_val();
+    let self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
     let name = lfp.arg(0).coerce_to_symbol_or_string(vm, globals)?;
     let name_str = name.get_name();
@@ -1607,7 +1607,7 @@ fn extend_object(
     _: BytecodePtr,
 ) -> Result<Value> {
     require_module_receiver(globals, lfp.self_val(), "extend_object")?;
-    let mut obj = lfp.arg(0);
+    let obj = lfp.arg(0);
     // Refuse to extend a frozen object — CRuby raises `RuntimeError`
     // (a FrozenError, which is a RuntimeError subclass) before
     // mutating anything.
@@ -1797,7 +1797,7 @@ fn undef_method(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_val = lfp.self_val();
+    let self_val = lfp.self_val();
     let class_id = self_val.as_class_id();
     let names = lfp.arg(0).as_array();
     // Coerce all names *before* the frozen check so that a non-name
@@ -1834,7 +1834,7 @@ fn remove_method(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_val = lfp.self_val();
+    let self_val = lfp.self_val();
     let class_id = self_val.as_class_id();
     let names = lfp.arg(0).as_array();
     let resolved: Vec<IdentId> = names
@@ -2081,7 +2081,7 @@ fn class_variable_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_val = lfp.self_val();
+    let self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
     let class_id = self_val.as_class_id();
     let name = coerce_to_class_var_name(vm, globals, lfp.arg(0))?;

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -640,9 +640,18 @@ fn autoload_query(
     loop {
         if let Some(state) = globals.store.get_constant(module.id(), name) {
             match &state.kind {
-                ConstStateKind::Autoload(path) => {
-                    return Ok(Value::string(path.to_string_lossy().into_owned()));
-                }
+                ConstStateKind::Autoload(entry) => match entry.state {
+                    // CRuby 3.0+: while the autoload's own require is
+                    // in flight, `autoload?` returns nil (the load is
+                    // already in progress, so there's nothing left to
+                    // schedule).
+                    AutoloadState::Loading => return Ok(Value::nil()),
+                    AutoloadState::Idle => {
+                        return Ok(Value::string(
+                            entry.feature.to_string_lossy().into_owned(),
+                        ));
+                    }
+                },
                 ConstStateKind::Loaded(_) => return Ok(Value::nil()),
             }
         }
@@ -818,8 +827,14 @@ fn const_defined(
 ) -> Result<Value> {
     let module = lfp.self_val().as_class();
     let inherit = lfp.try_arg(1).is_none() || lfp.arg(1).as_bool();
-    let found = lookup_constant_path(vm, globals, module, lfp.arg(0), inherit)?;
-    Ok(Value::bool(found.is_some()))
+    // CRuby's `Module#const_defined?` does not trigger autoload for
+    // the final segment (since Ruby 2.0 — `rb_const_defined` calls
+    // `rb_const_defined_0` with `autoload_load = FALSE`). The
+    // intermediate qualifiers in a path string like `"A::B::C"` are
+    // still resolved through the regular triggering lookup so we can
+    // walk into the right class.
+    let found = probe_constant_path(vm, globals, module, lfp.arg(0), inherit)?;
+    Ok(Value::bool(found))
 }
 
 ///
@@ -1005,6 +1020,104 @@ fn lookup_constant_path(
         }
     }
     Ok(None)
+}
+
+/// Like `lookup_constant_path` but probes the *final* segment without
+/// firing autoload — used by `Module#const_defined?` which (since
+/// Ruby 2.0) reports an autoload-registered constant as defined
+/// without invoking `require`. Intermediate qualifiers still trigger
+/// autoload, since we need the actual class object to walk further.
+fn probe_constant_path(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    receiver: Module,
+    name_arg: Value,
+    inherit: bool,
+) -> Result<bool> {
+    let (path, was_symbol) = if let Some(sym) = name_arg.try_symbol() {
+        (sym.get_name().to_string(), true)
+    } else if let Some(s) = name_arg.is_str() {
+        (s.to_string(), false)
+    } else if let Some(func_id) = globals.check_method(name_arg, IdentId::TO_STR) {
+        let result = vm.invoke_func_inner(globals, func_id, name_arg, &[], None, None)?;
+        if let Some(s) = result.is_str() {
+            (s.to_string(), false)
+        } else {
+            return Err(MonorubyErr::typeerr(format!(
+                "no implicit conversion of {} into String",
+                name_arg.get_real_class_name(&globals.store)
+            )));
+        }
+    } else {
+        return Err(MonorubyErr::typeerr(format!(
+            "no implicit conversion of {} into String",
+            name_arg.get_real_class_name(&globals.store)
+        )));
+    };
+
+    let (start_at_object, segs): (bool, Vec<&str>) = if was_symbol {
+        if path.contains("::") {
+            return Err(MonorubyErr::nameerr(format!(
+                "wrong constant name {path}"
+            )));
+        }
+        (false, vec![path.as_str()])
+    } else if let Some(rest) = path.strip_prefix("::") {
+        (true, rest.split("::").collect())
+    } else {
+        (false, path.split("::").collect())
+    };
+
+    if segs.iter().any(|s| !is_valid_const_name(s)) {
+        return Err(MonorubyErr::nameerr(format!(
+            "wrong constant name {path}"
+        )));
+    }
+
+    let mut current = if start_at_object {
+        globals.store[OBJECT_CLASS].get_module()
+    } else {
+        receiver
+    };
+    let last_idx = segs.len() - 1;
+    for (i, seg) in segs.iter().enumerate() {
+        let id = IdentId::get_id(seg);
+        if i == last_idx {
+            // Final segment: non-triggering probe. For the receiver
+            // (i == 0) honour `inherit`; for nested resolved classes
+            // (i > 0) restrict to direct lookup, matching the
+            // triggering variant.
+            return Ok(if i == 0 && inherit {
+                Executor::probe_constant_superclass(globals, current, id)
+            } else {
+                Executor::probe_constant_at(globals, current.id(), id)
+            });
+        }
+        // Intermediate segment: resolve via the triggering path so
+        // we can walk into the named class. A miss short-circuits
+        // to "not defined".
+        let val = if i == 0 && inherit {
+            match vm.get_constant_superclass_with_class(globals, current, id) {
+                Ok((v, _)) => Some(v),
+                Err(_) => None,
+            }
+        } else if globals.store[current.id()].has_own_constant(id) {
+            match vm.get_constant_checked(globals, current.id(), id) {
+                Ok(v) => Some(v),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+        match val {
+            Some(v) => match v.is_class_or_module() {
+                Some(m) => current = m,
+                None => return Ok(false),
+            },
+            None => return Ok(false),
+        }
+    }
+    Ok(false)
 }
 
 ///

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -586,7 +586,7 @@ fn attr_writer(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/autoload.html]
 #[monoruby_builtin]
-fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let const_name = lfp.arg(0).expect_symbol_or_string(globals)?;
     validate_constant_name(const_name)?;
     let feature = lfp.arg(1).coerce_to_path_rstring(vm, globals)?;
@@ -602,6 +602,16 @@ fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     globals
         .store
         .set_constant_autoload(class_id, const_name, feature);
+    // Record the autoload call-site as the constant's source
+    // location so `Module#const_source_location(:Foo)` returns the
+    // `autoload` line until the load actually happens — once the
+    // loaded file assigns the constant, that assignment overwrites
+    // this entry via `Executor::set_constant`'s recording.
+    if let Some(caller) = vm.cfp().prev()
+        && let Some((file, line)) = caller_source_location_with_pc(globals, caller, pc)
+    {
+        globals.store[class_id].record_constant_location(const_name, file, line);
+    }
     if was_autoload {
         let receiver = globals.store[class_id].get_module().into();
         vm.invoke_method_inner(

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -932,7 +932,13 @@ pub(super) extern "C" fn defined_const(
     reg: *mut Value,
     site_id: ConstSiteId,
 ) {
-    if vm.find_constant(globals, site_id).is_err() {
+    // CRuby's `defined?` probes the constant table without firing
+    // autoload for the final segment (`rb_const_defined` calls
+    // `rb_const_defined_0` with `autoload_load = FALSE`). Mirror that
+    // via `probe_constant`: intermediate qualifiers are resolved
+    // normally so we can walk into the right class, but the leaf
+    // does not trigger `require`.
+    if !vm.probe_constant(globals, site_id) {
         unsafe { *reg = Value::nil() }
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -690,18 +690,28 @@ impl Executor {
         };
         for constant in prefix {
             // Each intermediate `Foo::Bar::...::Name` lookup is a qualified
-            // access; enforce visibility for it as well.
-            let (val, defining) = self.get_constant_superclass_with_class(
-                globals,
-                globals[parent].get_module(),
-                constant,
-            )?;
-            check_constant_visibility(globals, defining, constant)?;
+            // access; enforce visibility for it as well. CRuby's
+            // `rb_public_const_get` checks visibility *before* firing
+            // autoload, so a `private_constant` registered on an
+            // autoload entry rejects the access without ever invoking
+            // `require`. Probe the ancestor chain non-triggering to
+            // find the defining class, check visibility, then resolve
+            // (triggering) only if visibility passes.
+            let module = globals[parent].get_module();
+            if let Some(defining) =
+                Self::probe_constant_superclass_with_class(globals, module, constant)
+            {
+                check_constant_visibility(globals, defining, constant)?;
+            }
+            let (val, _) =
+                self.get_constant_superclass_with_class(globals, module, constant)?;
             parent = val.expect_class_or_module(&globals.store)?.id();
         }
-        let (v, defining) =
-            self.get_constant_superclass_with_class(globals, globals[parent].get_module(), name)?;
-        check_constant_visibility(globals, defining, name)?;
+        let module = globals[parent].get_module();
+        if let Some(defining) = Self::probe_constant_superclass_with_class(globals, module, name) {
+            check_constant_visibility(globals, defining, name)?;
+        }
+        let (v, _) = self.get_constant_superclass_with_class(globals, module, name)?;
         Ok((v, base))
     }
 

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -47,33 +47,66 @@ impl Executor {
         class_id: ClassId,
         name: IdentId,
     ) -> Result<Option<Value>> {
-        match globals.get_constant(class_id, name) {
+        let feature = match globals.get_constant(class_id, name) {
             None => return Ok(None),
             Some(state) => match &state.kind {
                 ConstStateKind::Loaded(v) => return Ok(Some(*v)),
-                ConstStateKind::Autoload(file_name) => {
-                    let file_name = file_name.clone();
-                    globals.remove_constant(class_id, name);
-                    let _level = self.inc_require_level();
-
-                    #[cfg(feature = "dump-require")]
-                    eprintln!("{} > Autoload:{:?}", "  ".repeat(_level), name);
-
-                    let res = self.require(globals, &file_name, false);
-
-                    #[cfg(feature = "dump-require")]
-                    eprintln!("{} < Autoload:{:?}", "  ".repeat(_level), name);
-
-                    self.dec_require_level();
-                    res?;
-                }
+                ConstStateKind::Autoload(entry) => match entry.state {
+                    // Same-thread re-entry while the autoload's own
+                    // require is in flight: behave as "not yet
+                    // defined" without re-triggering, matching CRuby's
+                    // recursion guard. The caller will surface
+                    // NameError or const_missing.
+                    AutoloadState::Loading => return Ok(None),
+                    AutoloadState::Idle => entry.feature.clone(),
+                },
             },
         };
+
+        // Mark the slot Loading for the duration of the require so a
+        // recursive reference from inside the file we're about to
+        // load is rejected by the branch above.
+        globals
+            .store
+            .set_autoload_state(class_id, name, AutoloadState::Loading);
+
+        let _level = self.inc_require_level();
+
+        #[cfg(feature = "dump-require")]
+        eprintln!("{} > Autoload:{:?}", "  ".repeat(_level), name);
+
+        let res = self.require(globals, &feature, false);
+
+        #[cfg(feature = "dump-require")]
+        eprintln!("{} < Autoload:{:?}", "  ".repeat(_level), name);
+
+        self.dec_require_level();
+
+        if let Err(e) = res {
+            // require failed (LoadError, syntax error, …). Revert
+            // the slot to Idle so a future reference may retry,
+            // matching CRuby's behaviour of leaving the autoload
+            // registration intact across a failed load.
+            globals
+                .store
+                .set_autoload_state(class_id, name, AutoloadState::Idle);
+            return Err(e);
+        }
+
+        // require returned successfully. Either the file defined the
+        // constant (slot is now Loaded — typically via `set_constant`
+        // or a `class`/`module` keyword) or it didn't (slot is still
+        // Autoload + Loading). The "still Autoload" case means CRuby
+        // would surface NameError; drop the entry so subsequent
+        // references see "missing" rather than re-entering require.
         match globals.get_constant(class_id, name) {
             None => Ok(None),
             Some(state) => match &state.kind {
                 ConstStateKind::Loaded(v) => Ok(Some(*v)),
-                ConstStateKind::Autoload(_) => Ok(None),
+                ConstStateKind::Autoload(_) => {
+                    globals.remove_constant(class_id, name);
+                    Ok(None)
+                }
             },
         }
     }
@@ -207,6 +240,182 @@ impl Executor {
             }
         }
         Err(MonorubyErr::uninitialized_constant(name))
+    }
+
+    /// Non-triggering probe of a constant directly on `class_id` —
+    /// returns true if a value exists or an autoload is registered
+    /// (Idle), false for missing entries and for entries currently
+    /// `Loading` on this thread (same-thread recursion sees the slot
+    /// as not-yet-defined). Mirrors CRuby's `rb_const_defined_at`
+    /// with `autoload_load = FALSE`.
+    pub(crate) fn probe_constant_at(
+        globals: &Globals,
+        class_id: ClassId,
+        name: IdentId,
+    ) -> bool {
+        match globals.store.get_constant(class_id, name) {
+            None => false,
+            Some(state) => match &state.kind {
+                ConstStateKind::Loaded(_) => true,
+                ConstStateKind::Autoload(entry) => match entry.state {
+                    AutoloadState::Idle => true,
+                    AutoloadState::Loading => false,
+                },
+            },
+        }
+    }
+
+    /// Non-triggering walk of the ancestor chain of `module`. Used by
+    /// `defined?` / `Module#const_defined?` for the final lookup
+    /// segment so that autoload-registered constants register as
+    /// "defined" without invoking `require`.
+    pub(crate) fn probe_constant_superclass(
+        globals: &Globals,
+        mut module: Module,
+        name: IdentId,
+    ) -> bool {
+        loop {
+            if Self::probe_constant_at(globals, module.id(), name) {
+                return true;
+            }
+            match module.superclass() {
+                Some(superclass) => module = superclass,
+                None => return false,
+            }
+        }
+    }
+
+    /// Non-triggering walk of the ancestor chain that also returns the
+    /// defining class so a caller can enforce visibility (private
+    /// constants are still considered defined, but qualified-access
+    /// callers may want to raise `NameError: private constant` —
+    /// matching `find_constant`'s behaviour but without firing
+    /// autoload).
+    pub(crate) fn probe_constant_superclass_with_class(
+        globals: &Globals,
+        mut module: Module,
+        name: IdentId,
+    ) -> Option<ClassId> {
+        loop {
+            if Self::probe_constant_at(globals, module.id(), name) {
+                return Some(module.id());
+            }
+            match module.superclass() {
+                Some(superclass) => module = superclass,
+                None => return None,
+            }
+        }
+    }
+
+    /// Non-triggering search of the *lexical* scope chain (innermost
+    /// first). Used by `defined?(Foo)` for unqualified references.
+    fn probe_lexical_stack(
+        &self,
+        globals: &Globals,
+        name: IdentId,
+        current_func: FuncId,
+    ) -> bool {
+        let iseq = match globals.store[current_func].is_iseq() {
+            Some(iseq) => iseq,
+            None => return false,
+        };
+        for module in globals.store[iseq].lexical_context.iter().rev().copied() {
+            if Self::probe_constant_at(globals, module, name) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Resolve a `ConstSiteId` for `defined?` semantics: intermediate
+    /// segments are looked up with autoload triggering (CRuby resolves
+    /// them via the regular `getconstant` path), but the *final*
+    /// segment is probed without firing the autoload. Returns true if
+    /// the constant is reachable.
+    ///
+    /// Errors from intermediate-segment resolution are swallowed —
+    /// `defined?` reports `nil`, never propagates.
+    pub(crate) fn probe_constant(
+        &mut self,
+        globals: &mut Globals,
+        site_id: ConstSiteId,
+    ) -> bool {
+        let ConstSiteInfo {
+            name,
+            toplevel,
+            mut prefix,
+            base,
+            ..
+        } = globals.store[site_id].clone();
+        // SAFETY: `base` slot was populated by the bytecode compiler.
+        let base = base.map(|base| unsafe { self.get_slot(base) }.unwrap());
+        let current_func = self.method_func_id();
+        let parent = if let Some(base) = base {
+            match base.is_class_or_module() {
+                Some(m) => m.id(),
+                None => return false,
+            }
+        } else if toplevel {
+            OBJECT_CLASS
+        } else if prefix.is_empty() {
+            // Single-segment unqualified reference: walk lexical
+            // contexts (innermost first), then the enclosing class's
+            // ancestor chain — all non-triggering.
+            let frame_func = self.cfp().lfp().func_id();
+            if frame_func != current_func && self.probe_lexical_stack(globals, name, frame_func) {
+                return true;
+            }
+            if self.probe_lexical_stack(globals, name, current_func) {
+                return true;
+            }
+            let lexical_class = if frame_func != current_func {
+                let fc = frame_func.lexical_class(&globals.store);
+                if fc != OBJECT_CLASS {
+                    fc
+                } else {
+                    current_func.lexical_class(&globals.store)
+                }
+            } else {
+                current_func.lexical_class(&globals.store)
+            };
+            let module = globals.store[lexical_class].get_module();
+            if Self::probe_constant_superclass(globals, module, name) {
+                return true;
+            }
+            // BasicObject subclasses fall through to Object.
+            if lexical_class == BASIC_OBJECT_CLASS
+                && Self::probe_constant_at(globals, OBJECT_CLASS, name)
+            {
+                return true;
+            }
+            return false;
+        } else {
+            // Resolve the leading qualifier with the normal triggering
+            // path; we need the actual class to walk further.
+            let parent = prefix.remove(0);
+            match self.search_constant_checked(globals, parent, current_func) {
+                Ok(v) => match v.is_class_or_module() {
+                    Some(m) => m.id(),
+                    None => return false,
+                },
+                Err(_) => return false,
+            }
+        };
+        let mut parent = parent;
+        for constant in prefix {
+            match self.get_constant_superclass_with_class(
+                globals,
+                globals.store[parent].get_module(),
+                constant,
+            ) {
+                Ok((val, _)) => match val.is_class_or_module() {
+                    Some(m) => parent = m.id(),
+                    None => return false,
+                },
+                Err(_) => return false,
+            }
+        }
+        Self::probe_constant_superclass(globals, globals.store[parent].get_module(), name)
     }
 
     fn search_lexical_stack(

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -1,25 +1,6 @@
 use super::*;
 
 impl Executor {
-    pub(crate) fn const_get(
-        &mut self,
-        globals: &mut Globals,
-        module: Module,
-        name: IdentId,
-        inherit: bool,
-    ) -> Result<Value> {
-        // Note: `Module#const_get` is a reflection API and (since Ruby 3.0+)
-        // intentionally does *not* enforce constant visibility — private
-        // constants are readable through `const_get`. Visibility is only
-        // checked for syntactic qualified access (`Foo::Bar`, `::Bar`,
-        // `obj::Bar`) in `Executor::find_constant`.
-        if inherit {
-            self.get_constant_superclass_checked(globals, module, name)
-        } else {
-            self.get_constant_checked(globals, module.id(), name)
-        }
-    }
-
     pub(crate) fn get_qualified_constant(
         &mut self,
         globals: &mut Globals,
@@ -123,18 +104,6 @@ impl Executor {
         name: IdentId,
     ) -> Result<Value> {
         match self.get_constant(globals, class_id, name)? {
-            Some(v) => Ok(v),
-            None => Err(MonorubyErr::uninitialized_constant(name)),
-        }
-    }
-
-    pub(crate) fn get_constant_superclass_checked(
-        &mut self,
-        globals: &mut Globals,
-        module: Module,
-        name: IdentId,
-    ) -> Result<Value> {
-        match self.get_constant_superclass(globals, module, name)? {
             Some(v) => Ok(v),
             None => Err(MonorubyErr::uninitialized_constant(name)),
         }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -232,7 +232,45 @@ pub(crate) struct ConstState {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ConstStateKind {
     Loaded(Value),
-    Autoload(std::path::PathBuf),
+    Autoload(AutoloadEntry),
+}
+
+/// Per-constant autoload registration plus its load-state. Mirrors
+/// CRuby's `autoload_const` + `autoload_data`: the `feature` is the
+/// path to require, and `state` tracks whether a load is in progress
+/// or has been declared "done without defining the constant" so that
+/// subsequent references don't keep retrying.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct AutoloadEntry {
+    pub feature: std::path::PathBuf,
+    pub state: AutoloadState,
+}
+
+/// Load state for an autoload-registered constant.
+///
+/// `Idle` is the initial state right after `Module#autoload`. The next
+/// triggering reference flips to `Loading` for the duration of the
+/// `require`. monoruby is single-threaded so the flag is just a
+/// recursion guard — a same-(only)-thread re-reference must not
+/// re-enter `require`. After the require returns successfully but the
+/// constant is *still* registered as autoload (i.e. the file did not
+/// define it), the entry is removed entirely so that subsequent
+/// references raise `NameError` rather than retrying. If `require`
+/// itself raises (e.g. `LoadError`), the state is reverted to `Idle`
+/// so a future reference may try again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoloadState {
+    Idle,
+    Loading,
+}
+
+impl AutoloadEntry {
+    pub(crate) fn new(feature: std::path::PathBuf) -> Self {
+        Self {
+            feature,
+            state: AutoloadState::Idle,
+        }
+    }
 }
 
 impl ConstState {
@@ -245,7 +283,7 @@ impl ConstState {
 
     pub(crate) fn autoload(path: std::path::PathBuf) -> Self {
         Self {
-            kind: ConstStateKind::Autoload(path),
+            kind: ConstStateKind::Autoload(AutoloadEntry::new(path)),
             visibility: ConstVisibility::Public,
         }
     }
@@ -263,6 +301,20 @@ impl ConstState {
 
     pub(crate) fn is_autoload(&self) -> bool {
         matches!(self.kind, ConstStateKind::Autoload(_))
+    }
+
+    /// True if this slot is an autoload registration that is currently
+    /// being loaded on this thread. Used to suppress re-triggering
+    /// `require` from inside the autoload's own load chain (CRuby's
+    /// same-thread recursion guard).
+    pub(crate) fn is_autoload_loading(&self) -> bool {
+        matches!(
+            self.kind,
+            ConstStateKind::Autoload(AutoloadEntry {
+                state: AutoloadState::Loading,
+                ..
+            })
+        )
     }
 
     pub(crate) fn is_private(&self) -> bool {
@@ -593,7 +645,7 @@ impl ClassInfo {
     pub(in crate::globals) fn remove_constant(&mut self, name: IdentId) -> Option<Value> {
         let removed = self.constants.remove(&name).map(|state| match state.kind {
             ConstStateKind::Loaded(v) => v,
-            ConstStateKind::Autoload(..) => Value::nil(),
+            ConstStateKind::Autoload(_) => Value::nil(),
         });
         if removed.is_some() {
             self.constant_locations.remove(&name);

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -4,6 +4,7 @@ use super::*;
 
 mod constants;
 mod instance_var;
+pub(crate) use constants::*;
 pub(crate) use instance_var::*;
 
 pub const BASIC_OBJECT_CLASS: ClassId = ClassId::new(1);
@@ -197,122 +198,6 @@ impl ClassId {
                 Some(base) => format!("#<Class:{}>", base.to_s(store)),
             },
         }
-    }
-}
-
-/// Visibility of a constant. Constants are public by default;
-/// `Module#private_constant` makes them private. Visibility is stored
-/// alongside the constant's value/autoload-path inside `ConstState`, so it
-/// persists across an autoload-to-loaded transition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) enum ConstVisibility {
-    #[default]
-    Public,
-    Private,
-}
-
-impl ConstVisibility {
-    pub(crate) fn is_private(self) -> bool {
-        matches!(self, ConstVisibility::Private)
-    }
-}
-
-/// State of a constant slot in a `ClassInfo`'s constant table.
-///
-/// `kind` distinguishes a fully loaded constant from a registered autoload,
-/// and `visibility` records whether the constant is public or private. The
-/// two are kept independent so that toggling visibility on an autoload entry
-/// is preserved when the autoload is later triggered.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ConstState {
-    pub kind: ConstStateKind,
-    pub visibility: ConstVisibility,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum ConstStateKind {
-    Loaded(Value),
-    Autoload(AutoloadEntry),
-}
-
-/// Per-constant autoload registration plus its load-state. Mirrors
-/// CRuby's `autoload_const` + `autoload_data`: the `feature` is the
-/// path to require, and `state` tracks whether a load is in progress
-/// or has been declared "done without defining the constant" so that
-/// subsequent references don't keep retrying.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct AutoloadEntry {
-    pub feature: std::path::PathBuf,
-    pub state: AutoloadState,
-}
-
-/// Load state for an autoload-registered constant.
-///
-/// `Idle` is the initial state right after `Module#autoload`. The next
-/// triggering reference flips to `Loading` for the duration of the
-/// `require`. monoruby is single-threaded so the flag is just a
-/// recursion guard — a same-(only)-thread re-reference must not
-/// re-enter `require`. After the require returns successfully but the
-/// constant is *still* registered as autoload (i.e. the file did not
-/// define it), the entry is removed entirely so that subsequent
-/// references raise `NameError` rather than retrying. If `require`
-/// itself raises (e.g. `LoadError`), the state is reverted to `Idle`
-/// so a future reference may try again.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum AutoloadState {
-    Idle,
-    Loading,
-}
-
-impl AutoloadEntry {
-    pub(crate) fn new(feature: std::path::PathBuf) -> Self {
-        Self {
-            feature,
-            state: AutoloadState::Idle,
-        }
-    }
-}
-
-impl ConstState {
-    pub(crate) fn loaded(value: Value) -> Self {
-        Self {
-            kind: ConstStateKind::Loaded(value),
-            visibility: ConstVisibility::Public,
-        }
-    }
-
-    pub(crate) fn autoload(path: std::path::PathBuf) -> Self {
-        Self {
-            kind: ConstStateKind::Autoload(AutoloadEntry::new(path)),
-            visibility: ConstVisibility::Public,
-        }
-    }
-
-    pub(crate) fn loaded_value(&self) -> Option<Value> {
-        match self.kind {
-            ConstStateKind::Loaded(v) => Some(v),
-            ConstStateKind::Autoload(_) => None,
-        }
-    }
-
-    pub(crate) fn is_loaded(&self) -> bool {
-        matches!(self.kind, ConstStateKind::Loaded(_))
-    }
-
-    pub(crate) fn is_autoload(&self) -> bool {
-        matches!(self.kind, ConstStateKind::Autoload(_))
-    }
-
-    pub(crate) fn is_private(&self) -> bool {
-        self.visibility.is_private()
-    }
-
-    pub(crate) fn set_private(&mut self) {
-        self.visibility = ConstVisibility::Private;
-    }
-
-    pub(crate) fn set_public(&mut self) {
-        self.visibility = ConstVisibility::Public;
     }
 }
 

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -303,20 +303,6 @@ impl ConstState {
         matches!(self.kind, ConstStateKind::Autoload(_))
     }
 
-    /// True if this slot is an autoload registration that is currently
-    /// being loaded on this thread. Used to suppress re-triggering
-    /// `require` from inside the autoload's own load chain (CRuby's
-    /// same-thread recursion guard).
-    pub(crate) fn is_autoload_loading(&self) -> bool {
-        matches!(
-            self.kind,
-            ConstStateKind::Autoload(AutoloadEntry {
-                state: AutoloadState::Loading,
-                ..
-            })
-        )
-    }
-
     pub(crate) fn is_private(&self) -> bool {
         self.visibility.is_private()
     }

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -31,15 +31,35 @@ impl ClassInfoTable {
                 // (matches CRuby behavior).
                 ConstStateKind::Loaded(_) => {}
                 // Re-registering autoload updates the path; visibility is
-                // preserved.
-                ConstStateKind::Autoload(path) => {
-                    *path = file_name.into();
+                // preserved. CRuby leaves an in-progress load alone here
+                // and only swaps the feature, so we mirror that by keeping
+                // the existing `state` untouched.
+                ConstStateKind::Autoload(entry) => {
+                    entry.feature = file_name.into();
                 }
             },
             None => {
                 self[class_id]
                     .constants
                     .insert(name, ConstState::autoload(file_name.into()));
+            }
+        }
+    }
+
+    /// Transition an Autoload entry's `state`. Used by the const-lookup
+    /// path to mark a slot `Loading` for the duration of the `require`,
+    /// and to revert it on `require` failure. No-op if the slot is gone
+    /// or has been replaced by a Loaded value (e.g. the require defined
+    /// the constant via `set_constant`).
+    pub(crate) fn set_autoload_state(
+        &mut self,
+        class_id: ClassId,
+        name: IdentId,
+        state: AutoloadState,
+    ) {
+        if let Some(slot) = self[class_id].constants.get_mut(&name) {
+            if let ConstStateKind::Autoload(entry) = &mut slot.kind {
+                entry.state = state;
             }
         }
     }

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -1,5 +1,121 @@
 use super::*;
 
+/// Visibility of a constant. Constants are public by default;
+/// `Module#private_constant` makes them private. Visibility is stored
+/// alongside the constant's value/autoload-path inside `ConstState`, so it
+/// persists across an autoload-to-loaded transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum ConstVisibility {
+    #[default]
+    Public,
+    Private,
+}
+
+impl ConstVisibility {
+    pub(crate) fn is_private(self) -> bool {
+        matches!(self, ConstVisibility::Private)
+    }
+}
+
+/// State of a constant slot in a `ClassInfo`'s constant table.
+///
+/// `kind` distinguishes a fully loaded constant from a registered autoload,
+/// and `visibility` records whether the constant is public or private. The
+/// two are kept independent so that toggling visibility on an autoload entry
+/// is preserved when the autoload is later triggered.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ConstState {
+    pub kind: ConstStateKind,
+    pub visibility: ConstVisibility,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ConstStateKind {
+    Loaded(Value),
+    Autoload(AutoloadEntry),
+}
+
+/// Per-constant autoload registration plus its load-state. Mirrors
+/// CRuby's `autoload_const` + `autoload_data`: the `feature` is the
+/// path to require, and `state` tracks whether a load is in progress
+/// or has been declared "done without defining the constant" so that
+/// subsequent references don't keep retrying.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct AutoloadEntry {
+    pub feature: std::path::PathBuf,
+    pub state: AutoloadState,
+}
+
+/// Load state for an autoload-registered constant.
+///
+/// `Idle` is the initial state right after `Module#autoload`. The next
+/// triggering reference flips to `Loading` for the duration of the
+/// `require`. monoruby is single-threaded so the flag is just a
+/// recursion guard — a same-(only)-thread re-reference must not
+/// re-enter `require`. After the require returns successfully but the
+/// constant is *still* registered as autoload (i.e. the file did not
+/// define it), the entry is removed entirely so that subsequent
+/// references raise `NameError` rather than retrying. If `require`
+/// itself raises (e.g. `LoadError`), the state is reverted to `Idle`
+/// so a future reference may try again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoloadState {
+    Idle,
+    Loading,
+}
+
+impl AutoloadEntry {
+    pub(crate) fn new(feature: std::path::PathBuf) -> Self {
+        Self {
+            feature,
+            state: AutoloadState::Idle,
+        }
+    }
+}
+
+impl ConstState {
+    pub(crate) fn loaded(value: Value) -> Self {
+        Self {
+            kind: ConstStateKind::Loaded(value),
+            visibility: ConstVisibility::Public,
+        }
+    }
+
+    pub(crate) fn autoload(path: std::path::PathBuf) -> Self {
+        Self {
+            kind: ConstStateKind::Autoload(AutoloadEntry::new(path)),
+            visibility: ConstVisibility::Public,
+        }
+    }
+
+    pub(crate) fn loaded_value(&self) -> Option<Value> {
+        match self.kind {
+            ConstStateKind::Loaded(v) => Some(v),
+            ConstStateKind::Autoload(_) => None,
+        }
+    }
+
+    pub(crate) fn is_loaded(&self) -> bool {
+        matches!(self.kind, ConstStateKind::Loaded(_))
+    }
+
+    pub(crate) fn is_autoload(&self) -> bool {
+        matches!(self.kind, ConstStateKind::Autoload(_))
+    }
+
+    pub(crate) fn is_private(&self) -> bool {
+        self.visibility.is_private()
+    }
+
+    pub(crate) fn set_private(&mut self) {
+        self.visibility = ConstVisibility::Private;
+    }
+
+    pub(crate) fn set_public(&mut self) {
+        self.visibility = ConstVisibility::Public;
+    }
+}
+
 /// Walk up the singleton chain until we hit a non-singleton or until
 /// the attached object stops being a class/module. Used by class-var
 /// access so that `class C; class << self; @@x = …; end; end` lands

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -2054,6 +2054,7 @@ impl Value {
 
     /// Read-only access to the slot array of a `Struct` subclass
     /// instance. Asserts the receiver is a STRUCT-typed RValue.
+    #[allow(dead_code)]
     pub(crate) fn as_struct(&self) -> &StructInner {
         assert_eq!(ObjTy::STRUCT, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue is a Struct instance.

--- a/monoruby/tests/require.rs
+++ b/monoruby/tests/require.rs
@@ -159,3 +159,54 @@ fn autoload_loaderror_keeps_registration() {
         "#,
     );
 }
+
+// `Module#const_source_location(:X)` for an autoload-registered
+// constant returns the location of the `autoload` call itself, until
+// the load actually fires and overwrites the entry. Use a fresh
+// Module each iteration so 25 reruns don't accumulate.
+#[test]
+fn autoload_const_source_location() {
+    run_test(
+        r#"
+        m = Module.new
+        m.autoload :Lazy, "/no/such/file"
+        loc = m.const_source_location(:Lazy)
+        # The location's line number depends on this script's layout
+        # in the test harness; just assert the shape and that the
+        # path entry is a String. (CRuby reports `(eval at …)` for
+        # the path here, so we only check structural properties.)
+        [loc.is_a?(Array), loc[0].is_a?(String), loc[1].is_a?(Integer)]
+        "#,
+    );
+}
+
+// `private_constant` registered on an autoload entry must carry
+// through the load: after the file assigns the constant, qualified
+// access from outside still raises `NameError: private constant
+// referenced`.
+#[test]
+fn autoload_private_constant_carries_through_load() {
+    run_test_once(
+        r#"
+        # `c.rb` defines `Foo::Bar = 20`. Register it as an autoload
+        # under `Foo` and immediately mark it private. After the
+        # implicit load triggered below, Bar must still be private.
+        module Foo
+          autoload :Bar, File.expand_path("c")
+          private_constant :Bar
+        end
+        # Inside `Foo`'s lexical scope, `Bar` is reachable (private
+        # constants are reachable from their own class). Outside,
+        # qualified access raises NameError.
+        outer = begin
+          Foo::Bar
+          :reachable
+        rescue NameError => e
+          e.message =~ /private/ ? :private : :other_name
+        end
+        # Sanity check: confirm the autoload was consumed (Bar is now
+        # an Integer 20) and that visibility carried through.
+        [outer, Foo.const_defined?(:Bar), Foo.autoload?(:Bar)]
+        "#,
+    );
+}

--- a/monoruby/tests/require.rs
+++ b/monoruby/tests/require.rs
@@ -60,3 +60,102 @@ fn module_autoload() {
         "#,
     );
 }
+
+// `Module#const_defined?` reports an autoload-registered constant as
+// defined without firing the `require`. Pointing the registration at
+// a non-existent path proves that the load isn't triggered: if it
+// were, we'd see a LoadError.
+#[test]
+fn const_defined_does_not_trigger_autoload() {
+    run_test(
+        r#"
+        m = Module.new
+        m.autoload :Foo, "/no/such/path/at/all"
+        [m.const_defined?(:Foo), m.autoload?(:Foo)]
+        "#,
+    );
+}
+
+// Same idea via `defined?(Foo::Bar)`: the leaf segment must not
+// trigger autoload. The intermediate qualifier `M` is loaded already
+// (it's just the receiver), so only the leaf probe matters.
+#[test]
+fn defined_does_not_trigger_autoload() {
+    run_test(
+        r#"
+        module AutoloadProbe
+          autoload :Bar, "/nonexistent/probe/file"
+        end
+        defined?(AutoloadProbe::Bar)
+        "#,
+    );
+}
+
+// `Module#autoload?` continues to return the registered path until
+// the autoload is actually consumed. Probing via `const_defined?`
+// must not consume it.
+#[test]
+fn const_defined_preserves_autoload_query() {
+    run_test(
+        r#"
+        m = Module.new
+        m.autoload :Lazy, "/nope"
+        a = m.autoload?(:Lazy)
+        b = m.const_defined?(:Lazy)
+        c = m.autoload?(:Lazy)
+        [a, b, c]
+        "#,
+    );
+}
+
+// Once the autoload-registered constant is *actually* referenced,
+// the `require` runs and the constant binds to the value the file
+// defined. After that, `autoload?` reports nil and `const_defined?`
+// is still true.
+#[test]
+fn autoload_triggers_on_reference() {
+    run_test(
+        r#"
+        class AutoLazy
+          autoload :D, File.expand_path("a")
+        end
+        before = AutoLazy.autoload?(:D)
+        # Touching the constant fires the require. The fixture
+        # `a.rb` defines `class C; D = __FILE__; end`; we don't
+        # bind it on `AutoLazy` (the require runs at top level),
+        # so we just verify the registration was consumed.
+        AutoLazy.const_defined?(:D)
+        # Touching for real:
+        begin
+          AutoLazy::D
+        rescue NameError
+          # expected — `a.rb` defines C::D, not AutoLazy::D, so
+          # after the require the autoload entry is dropped.
+        end
+        after_query = AutoLazy.autoload?(:D)
+        # `before` is the path string; `after_query` is nil.
+        [before.is_a?(String), after_query]
+        "#,
+    );
+}
+
+// LoadError during the autoload's `require` keeps the registration
+// alive so a future reference (after fixing the path) can retry.
+#[test]
+fn autoload_loaderror_keeps_registration() {
+    run_test(
+        r#"
+        class AutoRetry
+          autoload :Foo, "/definitely/not/a/file"
+        end
+        first = begin
+          AutoRetry::Foo
+        rescue LoadError
+          :load_error
+        end
+        # Registration must still be there — `autoload?` returns
+        # the (still-registered) path.
+        [first, AutoRetry.autoload?(:Foo)]
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

CRuby's autoload state machine implemented in three layers, replacing the previous "remove-entry-then-require" sketch with a proper `Idle → Loading → done` flow.

### Step 1 — autoload entry carries a load state

`ConstStateKind::Autoload(PathBuf)` becomes `AutoloadEntry { feature, state }`. `state` is `Idle` / `Loading` and serves as a same-thread recursion guard: while the autoload's own `require` is in flight, a re-reference must not re-enter `require` — it surfaces as "not yet defined" so the caller raises `NameError` or invokes `const_missing`.

`Executor::get_constant` is rewritten as a small state machine:

```
Idle → Loading → require → { Loaded by file   → return value
                           | still Autoload   → drop, NameError
                           | require raised   → Idle (retry next time) }
```

Two long-standing CRuby divergences fall out:

1. `LoadError` during autoload no longer permanently consumes the registration. Previously the entry was deleted before `require` even started.
2. Same-file recursion (`bar.rb` referencing the constant the autoload is for) now resolves consistently to "not yet defined" instead of triggering a second require pass.

### Step 2 — non-triggering probe for `defined?` / `Module#const_defined?`

Both APIs in CRuby use `rb_const_defined_0` with `autoload_load = FALSE`: an autoload-registered constant reports as defined *without* invoking `require`. New helpers `Executor::probe_constant_at`, `probe_constant_superclass`, `probe_lexical_stack`, and the top-level `probe_constant` resolve intermediate qualifiers through the regular triggering path (so `Foo::Bar`'s `Foo` still autoloads) but probe the leaf segment without firing autoload. Wired into `runtime::defined_const` and a new `probe_constant_path` used by `Module#const_defined?`.

`Module#autoload?` now returns `nil` while a load is in flight, matching CRuby ≥ 3.0.

### Step 4 — source_location + pre-trigger visibility check

`Module#autoload(:Foo, "f")` records the call site as `:Foo`'s source location, so `Module#const_source_location(:Foo)` returns the `autoload` line until the loaded file actually assigns the constant (which then overwrites the location via `Executor::set_constant`'s existing recording).

`Executor::find_constant` performs the visibility check **before** firing the autoload trigger — CRuby's `rb_public_const_get` walks the chain non-triggering, raises `NameError: private constant referenced` on a hit, and only fires `require` when visibility passes. Previously monoruby triggered first and refused after the fact, observable via `Module#autoload?` (CRuby reports the path; monoruby reported nil because the autoload had already been consumed).

## Tests

`tests/require.rs` gains 7 cases covering the state-machine: non-triggering `const_defined?` / `defined?`, `autoload?` query around a probe, end-to-end trigger-and-consume, `LoadError` keeping the registration alive, autoload `const_source_location`, and `private_constant` carrying through load.

## ruby/spec deltas

| spec | master | this PR | Δ |
|---|---:|---:|---:|
| core/module overall | 114F + 129E | 104F + 129E | −10F |
| autoload + const_defined + const_source_location + private_constant | 25F + 29E (computed) | 13F + 29E | −12F |

Errors unchanged.

## Test plan

- [x] `cargo build`
- [x] `cargo test --test require` (12/12 pass — 7 new + 5 existing)
- [x] `cargo test --lib` (1474 pass / 19 fail — same baseline as master)
- [x] `mspec run core/module` — 105F → 104F vs master 114F
- [ ] CI

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_