### PR TITLE
String: Phase 2 — Encoding::CompatibilityError from + / &lt;&lt; / gsub / sub / []=

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1051,6 +1051,55 @@ mod tests {
     }
 
     #[test]
+    fn string_concat_raises_compat_error() {
+        // Two distinct broken sides cannot be concatenated.
+        run_test_error(
+            r#""\xff".force_encoding("UTF-8") + "\xff".force_encoding("ASCII-8BIT")"#,
+        );
+        run_test_error(
+            r#"
+              s = "\xff".force_encoding("UTF-8")
+              s << "\xff".force_encoding("ASCII-8BIT")
+            "#,
+        );
+    }
+
+    #[test]
+    fn string_concat_empty_adopts_other_encoding() {
+        // Empty side adopts the other side's encoding (matters for
+        // non-ASCII-compatible encodings).
+        run_test(
+            r#"("".force_encoding("UTF-16LE") + "abc").encoding == Encoding::UTF_8"#,
+        );
+        run_test(
+            r#"
+              s = "".force_encoding("UTF-16LE")
+              s << "abc"
+              s.encoding == Encoding::UTF_8
+            "#,
+        );
+    }
+
+    #[test]
+    fn gsub_raises_compat_error_on_replacement() {
+        // Receiver is UTF-8 with non-ASCII content, replacement is
+        // an ASCII-8BIT broken byte → CompatibilityError.
+        run_test_error(
+            r#""é".gsub(/é/, "\xff".force_encoding("ASCII-8BIT"))"#,
+        );
+    }
+
+    #[test]
+    fn index_assign_raises_compat_error_on_replacement() {
+        run_test_error(
+            r#"
+              s = "é"
+              s[0] = "\xff".force_encoding("ASCII-8BIT")
+            "#,
+        );
+    }
+
+    #[test]
     fn encoding_default_external() {
         run_test_no_result_check(
             r#"

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -237,7 +237,8 @@ fn string_try_convert(
 fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val().dup();
     let other = lfp.arg(0).coerce_to_rstring(vm, globals)?;
-    self_.as_rstring_inner_mut().extend(&other)?;
+    self_.as_rstring_inner_mut()
+        .extend_compat(&other, &globals.store)?;
     Ok(self_)
 }
 
@@ -488,7 +489,8 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     if let Some(other) = lfp.arg(0).is_rstring() {
-        self_.as_rstring_inner_mut().extend(&other)?;
+        self_.as_rstring_inner_mut()
+            .extend_compat(&other, &globals.store)?;
     } else if let Some(i) = lfp.arg(0).try_fixnum() {
         let ch = match u32::try_from(i) {
             Ok(ch) => ch,
@@ -512,7 +514,8 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     } else {
         // Try to_str coercion
         let coerced = lfp.arg(0).coerce_to_rstring(vm, globals)?;
-        self_.as_rstring_inner_mut().extend(&coerced)?;
+        self_.as_rstring_inner_mut()
+            .extend_compat(&coerced, &globals.store)?;
     }
     Ok(self_)
 }
@@ -760,6 +763,16 @@ fn index_assign(
     _: BytecodePtr,
 ) -> Result<Value> {
     lfp.self_val().ensure_string_mutable(vm, globals)?;
+    // The replacement String's encoding must be compatible with the
+    // receiver before any of the index-resolution work runs. CRuby
+    // raises `Encoding::CompatibilityError` here, ahead of the
+    // index/range/regex match-or-error.
+    let replacement_val = if lfp.try_arg(2).is_some() {
+        lfp.arg(2)
+    } else {
+        lfp.arg(1)
+    };
+    check_replacement_encoding_compat(globals, lfp.self_val(), replacement_val)?;
     let arg0_val = lfp.arg(0);
     let arg1_opt = lfp.try_arg(2).map(|_| lfp.arg(1));
     let arg_val = if arg1_opt.is_some() {
@@ -1883,6 +1896,7 @@ fn sub_main(
         if arg1.try_hash_ty().is_some() {
             RegexpInner::replace_one_hash(vm, globals, lfp.arg(0), given, arg1)
         } else {
+            check_replacement_encoding_compat(globals, self_val, arg1)?;
             let replace = arg1.coerce_to_str(vm, globals)?;
             RegexpInner::replace_one(vm, globals, lfp.arg(0), given, &replace)
         }
@@ -1895,6 +1909,35 @@ fn sub_main(
             }
         }
     }
+}
+
+/// Raise `Encoding::CompatibilityError` if `self_val` (the receiver
+/// of `gsub`/`sub`) and `replacement` (the explicit replacement
+/// String) have incompatible encodings. The block-form callers
+/// don't go through this — block return values are coerced
+/// per-iteration and CRuby ties the result encoding to whichever
+/// chunk first introduces a non-7-bit byte.
+fn check_replacement_encoding_compat(
+    globals: &Globals,
+    self_val: Value,
+    replacement: Value,
+) -> Result<()> {
+    let lhs = match self_val.is_rstring_inner() {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+    let rhs = match replacement.is_rstring_inner() {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+    if lhs.compatible_encoding(rhs).is_some() {
+        return Ok(());
+    }
+    Err(MonorubyErr::incompatible_encoding(
+        &globals.store,
+        lhs.encoding(),
+        rhs.encoding(),
+    ))
 }
 
 ///
@@ -1961,6 +2004,7 @@ fn gsub_main(
         if arg1.try_hash_ty().is_some() {
             RegexpInner::replace_all_hash(vm, globals, lfp.arg(0), given, arg1)
         } else {
+            check_replacement_encoding_compat(globals, self_val, arg1)?;
             let replace = arg1.coerce_to_str(vm, globals)?;
             RegexpInner::replace_all(vm, globals, lfp.arg(0), given, &replace)
         }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -484,6 +484,30 @@ impl MonorubyErr {
         MonorubyErr::typeerr(format!("{} is not a regexp nor a string", val.to_s(store)))
     }
 
+    /// Build an `Encoding::CompatibilityError` with the CRuby-format
+    /// "incompatible character encodings: A and B" message. Falls
+    /// back to `RuntimeError` if `Encoding::CompatibilityError`
+    /// hasn't been registered yet (e.g. very early in startup).
+    pub(crate) fn incompatible_encoding(
+        store: &Store,
+        a: crate::value::Encoding,
+        b: crate::value::Encoding,
+    ) -> MonorubyErr {
+        let msg = format!("incompatible character encodings: {} and {}", a.name(), b.name());
+        if let Some(enc_const) = store.get_constant_noautoload(OBJECT_CLASS, IdentId::ENCODING) {
+            if let Some(compat_const) = store.get_constant_noautoload(
+                enc_const.as_class_id(),
+                IdentId::get_id("CompatibilityError"),
+            ) {
+                return MonorubyErr::new(
+                    MonorubyErrKind::Other(compat_const.as_class_id()),
+                    msg,
+                );
+            }
+        }
+        MonorubyErr::runtimeerr(msg)
+    }
+
     pub fn cant_convert_error_ary(store: &Store, v: Value, result: Value) -> MonorubyErr {
         Self::cant_convert_error(store, v, result, "Array", IdentId::TO_ARY)
     }

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -541,6 +541,47 @@ impl RStringInner {
         matches!(self.code_range(), CodeRange::SevenBit | CodeRange::Valid)
     }
 
+    /// Negotiate the result encoding for an operation that combines
+    /// `self` and `other` (string concatenation, replacement, …).
+    /// Returns `None` if the two encodings are not compatible —
+    /// callers should raise `Encoding::CompatibilityError`.
+    pub fn compatible_encoding(&self, other: &Self) -> Option<Encoding> {
+        // CRuby's `rb_enc_compatible` empty-side rules:
+        //   - both empty → self's encoding (left wins).
+        //   - empty self, 7-bit other AND self is ASCII-compatible
+        //     → self's encoding (`"".encode("UTF-8") << "hello".force_encoding(BINARY)"`
+        //     keeps UTF-8).
+        //   - otherwise (one side empty) → the non-empty side's
+        //     encoding wins (matters for ASCII-incompatible enc on
+        //     the empty side, e.g.
+        //     `"".force_encoding("UTF-16LE") + "abc"` → UTF-8).
+        if self.content.is_empty() {
+            if other.content.is_empty() {
+                return Some(self.encoding());
+            }
+            if matches!(other.code_range(), CodeRange::SevenBit)
+                && self.encoding().is_ascii_compatible()
+            {
+                return Some(self.encoding());
+            }
+            return Some(other.encoding());
+        }
+        if other.content.is_empty() {
+            if matches!(self.code_range(), CodeRange::SevenBit)
+                && other.encoding().is_ascii_compatible()
+            {
+                return Some(other.encoding());
+            }
+            return Some(self.encoding());
+        }
+        Encoding::compatible(
+            self.encoding(),
+            self.code_range(),
+            other.encoding(),
+            other.code_range(),
+        )
+    }
+
     pub fn check_utf8(&self) -> Result<&str> {
         match std::str::from_utf8(self) {
             Ok(s) => Ok(s),
@@ -702,35 +743,46 @@ impl RStringInner {
         if other.is_empty() {
             return Ok(());
         }
-        let self_ascii_only = self.content.is_ascii();
-        let other_ascii_only = other.content.is_ascii();
-        match (self.ty, other.ty) {
-            (Encoding::Utf8 | Encoding::UsAscii, Encoding::Ascii8) => {
-                if other_ascii_only {
-                    // ASCII-8BIT with only ASCII bytes is compatible with UTF-8
-                } else if self_ascii_only {
-                    // self is UTF-8 but ASCII-only, other is binary non-ASCII => downgrade
-                    self.ty = Encoding::Ascii8;
-                } else {
-                    // both have non-ASCII bytes => incompatible
-                    return Err(MonorubyErr::runtimeerr(
-                        "incompatible character encodings: UTF-8 and ASCII-8BIT",
-                    ));
-                }
+        let result_enc = match self.compatible_encoding(other) {
+            Some(enc) => enc,
+            None => {
+                // Caller does not have access to `Store`, so raise a
+                // generic runtime error that matches CRuby's
+                // wording. Callers that have access to `Store` can
+                // build a proper `Encoding::CompatibilityError` via
+                // `MonorubyErr::incompatible_encoding`; see
+                // `String#<<` / `String#concat` /
+                // `Array#join`-style sites.
+                return Err(MonorubyErr::runtimeerr(format!(
+                    "incompatible character encodings: {} and {}",
+                    self.ty.name(),
+                    other.ty.name(),
+                )));
             }
-            (Encoding::Ascii8, Encoding::Utf8 | Encoding::UsAscii) => {
-                if self_ascii_only && !other_ascii_only {
-                    // self is binary but ASCII-only, other has non-ASCII UTF-8 => upgrade
-                    self.ty = Encoding::Utf8;
-                }
-                // otherwise keep ASCII-8BIT
-            }
-            _ => {}
-        }
-        self.content.extend_from_slice(other);
+        };
+        self.content.extend_from_slice(&other.content);
+        self.ty = result_enc;
         // The cached classification doesn't survive mutation: appending
         // bytes can flip SevenBit → Valid/Broken, or two Broken halves
         // can combine into a Valid character.
+        self.cr.set(CodeRange::Unknown);
+        Ok(())
+    }
+
+    /// Append `other`'s bytes to `self`, raising
+    /// `Encoding::CompatibilityError` (rather than `RuntimeError`)
+    /// on incompatible encodings. Used by call sites that have
+    /// access to `Store` — preferred for new code; the older
+    /// `extend()` is kept for the call sites that don't.
+    pub fn extend_compat(&mut self, other: &Self, store: &Store) -> Result<()> {
+        if other.is_empty() {
+            return Ok(());
+        }
+        let result_enc = self.compatible_encoding(other).ok_or_else(|| {
+            MonorubyErr::incompatible_encoding(store, self.ty, other.ty)
+        })?;
+        self.content.extend_from_slice(&other.content);
+        self.ty = result_enc;
         self.cr.set(CodeRange::Unknown);
         Ok(())
     }


### PR DESCRIPTION
## Summary

Phase 2 of the encoding-aware string overhaul. Stacked on PR #382 (Phase 1). With the data model in place, wire the "raise `Encoding::CompatibilityError` when operands are not encoding-compatible" rule into the operations CRuby exercises.

> **Note**: this PR's base is `claude/string-encoding-phase1`. After Phase 1 lands on `master`, this PR's base should be retargeted.

## What this changes

### `String#+` / `String#<<` / `String#concat`

`String#+` and `String#<<` switch their `RStringInner::extend` call to a new `extend_compat(other, store)` that builds an `Encoding::CompatibilityError` via the new `MonorubyErr::incompatible_encoding` helper. The legacy `extend` keeps a `RuntimeError` fallback for callers that don't have access to `Store`. `String#concat` is implemented in Ruby and dispatches through `<<`, so it picks up the new error automatically.

### `String#gsub` / `#sub` (and `!`)

At the pattern-and-replacement-string entry, a `check_replacement_encoding_compat` runs on the receiver / replacement pair before delegating to the replace-engine.

The block-form and Hash-form callers are intentionally untouched — CRuby's spec ties those errors to within block-return / hash-value coercion, which is a separate Phase 3 concern.

### `String#[]=`

`check_replacement_encoding_compat` runs ahead of index/range/regex resolution, so the spec's "checks the encoding before any of the index work" assertions hold.

### Compat-table refinements

- `RStringInner::compatible_encoding` now special-cases the empty string: an empty side defers to the non-empty side's encoding unconditionally. CRuby's `rb_enc_check` does this so that `"".force_encoding("UTF-16LE") + "abc"` yields `"abc"` (UTF-8) rather than failing the "ASCII-incompatible meets ASCII-only" rule.

## Tests

- `string_concat_raises_compat_error` — `+` and `<<` both raise.
- `string_concat_empty_adopts_other_encoding` — pins the empty-side rule.
- `gsub_raises_compat_error_on_replacement`.
- `index_assign_raises_compat_error_on_replacement`.

## ruby/spec deltas vs master

| spec | master | this PR | Δ |
|---|---:|---:|---:|
| 6 targeted specs (+/<</concat/gsub/sub/[]=) | 90F + 41E | 69F + 36E | **−26** |
| core/string overall | 617F + 577E | 595F + 571E | **−28** |

## Out of scope (Phase 3+)

- Encoding-aware char iteration (`size` / `each_char` / `slice` for non-UTF-8 encodings).
- Block-form `gsub`/`sub` return-encoding negotiation (compat error from inside the block).
- Actual `String#encode` byte-level transcoding.

## Test plan

- [x] `cargo test --lib` (1476 pass / 20 fail — same baseline as master, +4 new tests pass)
- [x] `mspec run` on the 6 targeted specs — 131 → 105 issues
- [x] `mspec run core/string` — 1194 → 1166 (−28)
- [ ] CI

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_