### PR TITLE
String: Phase 3 — encoding-aware char iteration (length / chars / each_char / slice)

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1100,6 +1100,36 @@ mod tests {
     }
 
     #[test]
+    fn length_for_dummy_encodings() {
+        // UTF-16: count code units (surrogate pairs count as 2).
+        run_test(r#""ab".force_encoding("UTF-16LE").length"#);
+        run_test(r#""abc".force_encoding("UTF-16LE").length"#); // 1.5 + 1 (broken trailing)
+        // UTF-32: 1 char per 4 bytes.
+        run_test(r#""abcd".force_encoding("UTF-32LE").length"#);
+        // ISO-8859-N: 1 byte per char.
+        run_test(r#""\xff\xfe".force_encoding("ISO-8859-1").length"#);
+    }
+
+    #[test]
+    fn length_for_broken_utf8() {
+        // Broken UTF-8: each invalid byte counts as one char.
+        run_test(r#""\xF4\x90\x80\x80".length"#);
+        run_test(r#""a\xF4\x90\x80\x80b".length"#);
+        run_test(r#""é\xF4\x90\x80\x80è".length"#);
+    }
+
+    #[test]
+    fn chars_preserves_encoding() {
+        // Each yielded character carries the source encoding.
+        run_test(
+            r#""abc".force_encoding("ASCII-8BIT").chars.all? { |c| c.encoding == Encoding::ASCII_8BIT }"#,
+        );
+        run_test(
+            r#""ab".force_encoding("ISO-8859-1").chars.map(&:encoding) == [Encoding::ISO_8859_1, Encoding::ISO_8859_1]"#,
+        );
+    }
+
+    #[test]
     fn encoding_default_external() {
         run_test_no_result_check(
             r#"

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2488,7 +2488,9 @@ fn string_rindex(
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/length.html]
 #[monoruby_builtin]
 fn length(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let length = lfp.self_val().as_rstring_inner().char_length()?;
+    // Use the encoding-aware char counter; it always succeeds (broken
+    // UTF-8 falls back to byte count, matching CRuby).
+    let length = lfp.self_val().as_rstring_inner().char_count();
     Ok(Value::integer(length as i64))
 }
 
@@ -4215,13 +4217,20 @@ fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn chars(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let recv = self_.expect_str(globals)?;
-    let iter = recv.chars().map(|c| Value::string(c.to_string()));
+    let inner = self_.as_rstring_inner();
+    let enc = inner.encoding();
+    // Materialise per-char byte slices into owned RStringInner values
+    // tagged with the source encoding. Walking eagerly avoids
+    // borrowing `inner` past the iterator.
+    let chars: Vec<Value> = inner
+        .iter_char_bytes()
+        .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)))
+        .collect();
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_map1(globals, bh, iter, None)?;
+        vm.invoke_block_map1(globals, bh, chars.into_iter(), None)?;
         Ok(lfp.self_val())
     } else {
-        Ok(Value::array_from_iter(iter))
+        Ok(Value::array_from_iter(chars.into_iter()))
     }
 }
 
@@ -4235,10 +4244,14 @@ fn chars(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn each_char(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let recv = self_.expect_str(globals)?;
     if let Some(bh) = lfp.block() {
-        let iter = recv.chars().map(|c| Value::string(c.to_string()));
-        vm.invoke_block_iter1(globals, bh, iter)?;
+        let inner = self_.as_rstring_inner();
+        let enc = inner.encoding();
+        let chars: Vec<Value> = inner
+            .iter_char_bytes()
+            .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)))
+            .collect();
+        vm.invoke_block_iter1(globals, bh, chars.into_iter())?;
         Ok(lfp.self_val())
     } else {
         vm.generate_enumerator(IdentId::get_id("each_char"), lfp.self_val(), vec![], pc)

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -26,7 +26,7 @@ pub use range::{RANGE_END_OFFSET, RANGE_EXCLUDE_END_OFFSET, RANGE_START_OFFSET, 
 pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
-pub use string::{CodeRange, Encoding, RString, RStringInner};
+pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 
 mod array;

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -9,6 +9,69 @@ mod printable;
 #[monoruby_object]
 pub struct RString(Value);
 
+/// Iterator yielding one character's worth of bytes per call,
+/// honouring the declared encoding. For UTF-8, walks valid UTF-8
+/// scalars; broken byte sequences advance one byte at a time so the
+/// iterator always terminates. Non-UTF-8 encodings use the
+/// fixed-code-unit width (1 for Ascii8/UsAscii/Iso8859, 2 for
+/// UTF-16, 4 for UTF-32) — multibyte ASCII-compatible families
+/// (EUC-JP, Shift_JIS) currently iterate byte-wise.
+pub struct CharByteIter<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    encoding: Encoding,
+}
+
+impl<'a> Iterator for CharByteIter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<&'a [u8]> {
+        if self.pos >= self.bytes.len() {
+            return None;
+        }
+        let width = match self.encoding {
+            Encoding::Ascii8
+            | Encoding::UsAscii
+            | Encoding::Iso8859(_)
+            | Encoding::EucJp
+            | Encoding::Sjis(_) => 1,
+            Encoding::Utf16Le | Encoding::Utf16Be => 2,
+            Encoding::Utf32Le | Encoding::Utf32Be => 4,
+            Encoding::Utf8 => {
+                let b = self.bytes[self.pos];
+                if b < 0x80 {
+                    1
+                } else if b < 0xC0 {
+                    1 // continuation byte at scalar boundary => broken; consume one
+                } else {
+                    let needed = if b < 0xE0 {
+                        2
+                    } else if b < 0xF0 {
+                        3
+                    } else {
+                        4
+                    };
+                    let end = (self.pos + needed).min(self.bytes.len());
+                    // Validate the candidate scalar; on failure, fall
+                    // back to one byte (CRuby's "adds 1 for every
+                    // invalid byte in UTF-8" rule).
+                    if end - self.pos == needed
+                        && std::str::from_utf8(&self.bytes[self.pos..end]).is_ok()
+                    {
+                        needed
+                    } else {
+                        1
+                    }
+                }
+            }
+        };
+        let end = (self.pos + width).min(self.bytes.len());
+        let slice = &self.bytes[self.pos..end];
+        self.pos = end;
+        Some(slice)
+    }
+}
+
 /// Cached classification of an `RStringInner`'s byte content relative
 /// to its declared `encoding`. CRuby's `enum ruby_coderange_type`
 /// equivalent — keeps `valid_encoding?` / `ascii_only?` /
@@ -541,6 +604,58 @@ impl RStringInner {
         matches!(self.code_range(), CodeRange::SevenBit | CodeRange::Valid)
     }
 
+    /// Number of characters under the declared encoding. Always
+    /// succeeds — broken byte sequences fall back to byte counting
+    /// (matches CRuby's `String#length` returning byte length on
+    /// invalid UTF-8).
+    pub fn char_count(&self) -> usize {
+        match self.ty {
+            // Fixed 1-byte-per-char.
+            Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => self.content.len(),
+            // UTF-16 / UTF-32 with one extra unit per broken trailing
+            // byte. CRuby's `String#length` for these reports the
+            // number of *complete* code units plus one per stray byte
+            // ("adds 1 (and not 2) for a incomplete surrogate in
+            // UTF-16").
+            Encoding::Utf16Le | Encoding::Utf16Be => {
+                let len = self.content.len();
+                len / 2 + len % 2
+            }
+            Encoding::Utf32Le | Encoding::Utf32Be => {
+                let len = self.content.len();
+                len / 4 + (len % 4 > 0) as usize
+            }
+            // UTF-8: count valid scalars and count each invalid byte
+            // individually (CRuby's "adds 1 for every invalid byte
+            // in UTF-8" rule).
+            Encoding::Utf8 => {
+                if std::str::from_utf8(&self.content).is_ok() {
+                    self.content
+                        .iter()
+                        .filter(|&&b| (b & 0xC0) != 0x80)
+                        .count()
+                } else {
+                    self.iter_char_bytes().count()
+                }
+            }
+            // EUC-JP / Shift_JIS: byte count (no native multibyte
+            // decoder yet).
+            Encoding::EucJp | Encoding::Sjis(_) => self.content.len(),
+        }
+    }
+
+    /// Iterate the string's characters as byte-slice views into
+    /// `self`. The yielded slices reference `self.content`. Used by
+    /// `String#chars` / `#each_char` / `#slice` to be encoding-aware
+    /// without converting through a `&str`.
+    pub fn iter_char_bytes(&self) -> CharByteIter<'_> {
+        CharByteIter {
+            bytes: &self.content,
+            pos: 0,
+            encoding: self.ty,
+        }
+    }
+
     /// Negotiate the result encoding for an operation that combines
     /// `self` and `other` (string concatenation, replacement, …).
     /// Returns `None` if the two encodings are not compatible —
@@ -638,16 +753,10 @@ impl RStringInner {
     /// Get the length in char of the string `self`.
     ///
     pub fn char_length(&self) -> Result<usize> {
-        let len = if self.ty.is_utf8_compatible() {
-            self.check_utf8()?.chars().count()
-        } else {
-            // Non-UTF-8 encodings: report byte length until per-encoding
-            // char-iteration is implemented (matches CRuby for
-            // ASCII-8BIT and is the conservative answer for the dummy
-            // encodings monoruby doesn't decode).
-            self.content.len()
-        };
-        Ok(len)
+        // Always-succeeding char counter: broken UTF-8 falls back to
+        // counting each invalid byte as one character (matches
+        // CRuby's `String#length` rule).
+        Ok(self.char_count())
     }
 
     ///
@@ -711,31 +820,51 @@ impl RStringInner {
     }
 
     pub fn get_range(&self, index: usize, len: usize) -> std::ops::Range<usize> {
-        if self.ty.is_utf8_compatible() {
-            if let Ok(s) = std::str::from_utf8(self) {
-                let mut start = 0;
-                let mut end = 0;
-                for (char_i, (byte_i, _)) in s.char_indices().enumerate() {
-                    if char_i == index {
-                        start = byte_i;
-                        end = s.len();
-                    }
-                    if char_i == index + len {
-                        end = byte_i;
-                        break;
-                    }
+        // Walk the encoding-aware char iterator, accumulating the
+        // byte offsets of chars `index` through `index+len`. Falls
+        // back to byte indexing for fixed-1-byte encodings (which
+        // is what `iter_char_bytes` would do anyway, but we
+        // shortcut it for performance).
+        let unit = match self.ty {
+            Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => Some(1),
+            Encoding::Utf16Le | Encoding::Utf16Be => Some(2),
+            Encoding::Utf32Le | Encoding::Utf32Be => Some(4),
+            // EUC-JP / Shift_JIS currently iterate byte-wise too, so
+            // a fixed-1-byte shortcut is fine.
+            Encoding::EucJp | Encoding::Sjis(_) => Some(1),
+            Encoding::Utf8 => None,
+        };
+        if let Some(u) = unit {
+            let total = self.content.len();
+            let start_byte = (index * u).min(total);
+            let end_byte = ((index + len) * u).min(total);
+            return start_byte..end_byte;
+        }
+        // UTF-8 path: walk per scalar (or per broken byte) so
+        // `String#[char_index]` indexes by *characters*, not bytes.
+        let mut start_byte: Option<usize> = None;
+        let mut end_byte = self.content.len();
+        let mut byte_pos = 0usize;
+        for (i, c) in self.iter_char_bytes().enumerate() {
+            if i == index {
+                start_byte = Some(byte_pos);
+                if len == 0 {
+                    end_byte = byte_pos;
+                    break;
                 }
-                return start..end;
+            }
+            byte_pos += c.len();
+            if start_byte.is_some() && i + 1 == index + len {
+                end_byte = byte_pos;
+                break;
             }
         }
-        // Byte-based indexing fallback (Ascii8 / dummy encodings /
-        // broken UTF-8).
-        if self.len() <= index {
-            0..0
-        } else if self.len() <= index + len {
-            index..self.len()
-        } else {
-            index..index + len
+        match start_byte {
+            // `index` past the end but exactly equal to char count
+            // is the "append point" — empty range at end.
+            None if index == self.char_count() => self.content.len()..self.content.len(),
+            None => 0..0,
+            Some(s) => s..end_byte,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 3 of the encoding-aware string overhaul. Stacked on PR #383 (Phase 2). With CompatibilityError raising in place, add encoding-aware character iteration so `String#length` / `#size` / `#chars` / `#each_char` / `#[]` / `#slice` return CRuby-correct values for non-UTF-8 encodings.

> **Note**: this PR's base is `claude/string-encoding-phase2`. After Phase 2 lands, this PR's base should be retargeted.

## RStringInner additions

- `char_count() -> usize` — always-succeeding character count for the declared encoding. Replaces the old `char_length()` strict path with CRuby's "adds 1 for every invalid UTF-8 byte" rule (`"\xF4\x90\x80\x80".length == 4`, `"é\xF4\x90\x80\x80è".length == 6`). UTF-16 / UTF-32 count code units (surrogate pairs as 2; broken trailing bytes as 1).

- `iter_char_bytes() -> CharByteIter<'_>` — iterates byte-slice views for one character at a time. The new public `CharByteIter` knows fixed-width encodings (Ascii8 / UsAscii / Iso8859=1, UTF-16=2, UTF-32=4) and parses UTF-8 with a validity check, falling back to one-byte advances for broken sequences.

## Behaviour changes

- `String#length` / `#size` switch from `char_length()` to `char_count()`.
- `String#chars` / `#each_char` yield per-character `RStringInner` values tagged with the source encoding.
- `get_range` (used by `String#[]` / `#slice`) is rewritten to index by *characters* per encoding. Fixed-width encodings get a shortcut; UTF-8 walks the iterator. `len = 0` and `index == char_count()` edge cases are now correct (`"abcd"[2, 0] == ""` rather than `"cd"`).
- `compatible_encoding`'s empty-side rule is tightened to match CRuby's `rb_enc_compatible`:
  - empty self + 7-bit other → self's encoding
  - empty self + non-7-bit other → other's encoding
  - both empty → self's encoding

The Phase 2 unconditional empty-defers rule was overshooting and broke the existing `string_shl_encoding` left-wins assertions.

## Tests

- `length_for_dummy_encodings` — UTF-16LE / UTF-32LE / ISO-8859-1 char counts, including broken-trailing-byte rules.
- `length_for_broken_utf8` — pins the per-byte-counts-as-one rule.
- `chars_preserves_encoding` — `chars` keeps source encoding on each yielded char.

## ruby/spec deltas vs master (cumulative with Phases 1 + 2)

| spec | master | this PR | Δ |
|---|---:|---:|---:|
| length / size shared (subset) | 4F + 4E | 4F + 2E | −2E |
| chars / each_char | 10F + 4E | 8F + 4E | −2F |
| slice / element_reference | 17F + 26E | 12F + 22E | −9 |
| core/string overall | 617F + 577E | 597F + 566E | **−31** |

The remaining `length`/`size` failures on UTF-32 / SHIFT_JIS encoding-preserved counts depend on `String#encode` actually transcoding (Phase 4). The remaining `chars` failures are parser-level (octal escapes are re-encoded into UTF-8 in monoruby's parser instead of preserving raw bytes).

## Out of scope (Phase 4)

- `String#encode` real byte-level transcoding (UTF-8 ↔ UTF-16, etc.).
- EUC-JP / Shift_JIS multibyte-aware char iteration.
- Block-form `gsub`/`sub` return-encoding negotiation.

## Test plan

- [x] `cargo test --lib` (1480 pass / 20 fail — same baseline as master, +3 new tests pass)
- [x] `mspec run core/string` — 1194 → 1163 (−31)
- [ ] CI

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_