### PR TITLE
main / Binding: spec coverage for core/main

### DIFF
--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -9,6 +9,20 @@ pub(super) fn init(globals: &mut Globals) {
     globals.store[BINDING_CLASS].clear_alloc_func();
     globals.define_builtin_func(BINDING_CLASS, "local_variables", local_variables, 0);
     globals.define_builtin_func(BINDING_CLASS, "source_location", source_location, 0);
+    globals.define_builtin_func(BINDING_CLASS, "receiver", receiver, 0);
+}
+
+///
+/// ### Binding#receiver
+///
+/// - receiver -> Object
+///
+/// Returns the receiver (`self`) of the frame the binding captured.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Binding/i/receiver.html]
+#[monoruby_builtin]
+fn receiver(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(lfp.self_val().as_binding_inner().self_val())
 }
 
 #[monoruby_builtin]

--- a/monoruby/src/builtins/main_object.rs
+++ b/monoruby/src/builtins/main_object.rs
@@ -7,6 +7,37 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     let main = globals.main_object;
     globals.define_builtin_singleton_func_with(main, "include", include, 0, 0, true);
+    // CRuby exposes `public` / `private` (and `protected`) as
+    // singleton methods of `main` that delegate to the Object class
+    // — the receiver of top-level `def`. Names are coerced via
+    // Symbol/String, an Array argument is accepted, and the result is
+    // the original argument value (per spec parity with `Module#public`).
+    globals.define_builtin_singleton_func_with(main, "public", main_public, 0, 0, true);
+    globals.define_builtin_singleton_func_with(main, "private", main_private, 0, 0, true);
+    // Refinements aren't supported by monoruby; `using` is provided
+    // as a stub that argument-checks (ArgumentError on no-args,
+    // TypeError on non-Module) and otherwise no-ops.
+    globals.define_builtin_singleton_func(main, "using", main_using, 1);
+    // CRuby's main object responds to a private `ruby2_keywords`
+    // (no-op). monoruby doesn't propagate keyword splat metadata, so
+    // we register a private no-op method that swallows its args.
+    let main_singleton_id = globals.store.get_singleton(main).unwrap().id();
+    let func_id = globals.define_builtin_func_with(
+        main_singleton_id,
+        "ruby2_keywords",
+        main_ruby2_keywords,
+        0,
+        0,
+        true,
+    );
+    globals
+        .change_method_visibility_for_class(
+            main_singleton_id,
+            &[IdentId::get_id("ruby2_keywords")],
+            Visibility::Private,
+        )
+        .unwrap();
+    let _ = func_id;
     let singleton_class_id = globals.store.get_singleton(main).unwrap().id();
     globals.define_builtin_funcs_with_effect(
         singleton_class_id,
@@ -37,6 +68,78 @@ fn include(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         class.include_module(v.expect_module(globals)?)?;
     }
     Ok(class.as_val())
+}
+
+///
+/// ### main#public
+///
+/// - public(*name) -> *name
+/// - public(names) -> names
+///
+/// Set the visibility of named methods to public on Object (the
+/// implicit receiver of top-level `def`). Mirrors CRuby's main-object
+/// `public` so `public :foo` at the top level reopens Object.
+#[monoruby_builtin]
+fn main_public(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg = lfp.arg(0).as_array();
+    let object = globals.store.object_class().as_val();
+    super::module::change_visi(vm, globals, object, arg, Visibility::Public)
+}
+
+///
+/// ### main#private
+///
+/// - private(*name) -> *name
+/// - private(names) -> names
+///
+/// Counterpart of `main#public` — sets named methods on Object to
+/// private. With no argument, raises (top-level visibility-default
+/// switching is handled by the parser, not this method).
+#[monoruby_builtin]
+fn main_private(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg = lfp.arg(0).as_array();
+    let object = globals.store.object_class().as_val();
+    super::module::change_visi(vm, globals, object, arg, Visibility::Private)
+}
+
+///
+/// ### main.using
+///
+/// - using(mod) -> self
+///
+/// Stub for refinement support. monoruby does not implement
+/// refinements, so this validates the argument (must be a Module)
+/// and otherwise no-ops. `using` with no argument raises ArgumentError
+/// via the standard arity check.
+#[monoruby_builtin]
+fn main_using(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg = lfp.arg(0);
+    if arg.is_class_or_module().is_none() {
+        return Err(MonorubyErr::typeerr(format!(
+            "wrong argument type {} (expected Module)",
+            arg.get_real_class_name(globals)
+        )));
+    }
+    Ok(lfp.self_val())
+}
+
+///
+/// ### main.ruby2_keywords
+///
+/// - ruby2_keywords(*method_names) -> nil
+///
+/// CRuby uses this to flag a method as a ruby2_keywords-style
+/// keyword-passthrough method. monoruby doesn't propagate keyword
+/// splat metadata, so this is a private no-op — the spec only asserts
+/// that `main` responds to a private `ruby2_keywords` method.
+#[monoruby_builtin]
+fn main_ruby2_keywords(
+    _: &mut Executor,
+    _: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::nil())
 }
 
 ///
@@ -75,7 +178,9 @@ fn main_define_method(
     } else {
         return Err(MonorubyErr::wrong_number_of_arg(2, 1));
     };
-    vm.add_private_method(globals, class_id, name, func_id)?;
+    // Top-level `define_method` adds a *public* method on Object,
+    // unlike top-level `def` which is private. Matches CRuby.
+    vm.add_public_method(globals, class_id, name, func_id)?;
     Ok(Value::symbol(name))
 }
 
@@ -162,6 +267,107 @@ mod tests {
             define_method(:calc2, um)
             calc2(7)
         "#,
+        );
+    }
+
+    #[test]
+    fn define_method_creates_public_method() {
+        // Top-level `define_method` adds a *public* method on Object
+        // (top-level `def` would be private). Matches CRuby.
+        run_test(
+            r#"
+            define_method(:boom) { :bam }
+            Object.method_defined?(:boom)
+            "#,
+        );
+        run_test(
+            r#"
+            define_method(:boom2) { :bam2 }
+            Object.private_method_defined?(:boom2)
+            "#,
+        );
+    }
+
+    #[test]
+    fn main_public() {
+        // Single Symbol arg flips a top-level def to public.
+        run_test(
+            r#"
+            def foo; end
+            public :foo
+            Object.private_method_defined?(:foo)
+            "#,
+        );
+        // Multiple args.
+        run_test(
+            r#"
+            def foo; end
+            def bar; end
+            public :foo, :bar
+            [Object.private_method_defined?(:foo),
+             Object.private_method_defined?(:bar)]
+            "#,
+        );
+        // Single Array arg.
+        run_test(
+            r#"
+            def foo; end
+            def bar; end
+            public [:foo, :bar]
+            [Object.private_method_defined?(:foo),
+             Object.private_method_defined?(:bar)]
+            "#,
+        );
+    }
+
+    #[test]
+    fn main_private() {
+        // public method -> private.
+        run_test(
+            r#"
+            def foo; end
+            public :foo
+            private :foo
+            Object.private_method_defined?(:foo)
+            "#,
+        );
+        // Multiple args + Array form.
+        run_test(
+            r#"
+            def foo; end
+            def bar; end
+            public :foo, :bar
+            private [:foo, :bar]
+            [Object.private_method_defined?(:foo),
+             Object.private_method_defined?(:bar)]
+            "#,
+        );
+        // Unknown name -> NameError.
+        run_test_error(r#"private :main_undefined_method_xyz"#);
+    }
+
+    #[test]
+    fn main_using_argchecks() {
+        // No-arg form raises (arity).
+        run_test_error(r#"using"#);
+        // Non-Module arg -> TypeError.
+        run_test_error(r#"using "foo""#);
+        // Module arg accepted (no-op).
+        run_test(r#"using Math; :ok"#);
+    }
+
+    #[test]
+    fn binding_receiver() {
+        // Binding#receiver returns self at the binding's frame.
+        run_test(r#"binding.receiver == self"#);
+        run_test(r#"TOPLEVEL_BINDING.receiver.equal?(self)"#);
+        run_test(
+            r#"
+            class Foo
+              def bind; binding; end
+            end
+            Foo.new.bind.receiver.is_a?(Foo)
+            "#,
         );
     }
 }

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2437,7 +2437,7 @@ fn public(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     change_visi(vm, globals, lfp.self_val(), arg, Visibility::Public)
 }
 
-fn change_visi(
+pub(super) fn change_visi(
     vm: &mut Executor,
     globals: &mut Globals,
     self_val: Value,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -895,17 +895,6 @@ impl Executor {
         self.add_method(globals, class_id, name, func_id, Visibility::Public)
     }
 
-    /// Register a private method and invoke the method_added hook.
-    pub(crate) fn add_private_method(
-        &mut self,
-        globals: &mut Globals,
-        class_id: ClassId,
-        name: IdentId,
-        func_id: FuncId,
-    ) -> Result<()> {
-        self.add_method(globals, class_id, name, func_id, Visibility::Private)
-    }
-
     /// Register a method with the given visibility and invoke the method_added hook.
     pub(crate) fn add_method(
         &mut self,


### PR DESCRIPTION
## Summary

Make `core/main` spec files loadable and pass most of the simple-target tests in them. Aligned to Ruby 4.0.2.

### Additions

- **`main#public(*names)` / `main#private(*names)`** — delegate to the Object class (the implicit receiver of top-level `def`), reusing `module::change_visi`. Accept Symbol / String / Array forms and return the argument value.
- **`main#using(mod)`** — argument-validating stub (raises TypeError on non-Module, no-arg form raises via arity). monoruby has no refinements; the method otherwise no-ops.
- **`main.ruby2_keywords`** — private no-op singleton method. `main.private_methods.include?(:ruby2_keywords)` is now true (CRuby parity; monoruby doesn't propagate keyword-splat metadata).
- **`main#define_method`** now adds a *public* method on Object (top-level `def` is private, but `define_method` at the top level is not — CRuby semantics).
- **`Binding#receiver`** — returns `self` at the captured frame.

`module::change_visi` is now `pub(super)` so `main_object` can reuse the visibility-flipping logic.

### Spec deltas (`core/main`, Ruby 4.0.2)

| | examples | failures | errors |
|---|---:|---:|---:|
| master    | 1  | 0 | 6 |
| this PR   | 27 | 7 | 7 |

All 6 load-time errors gone — `fixtures/classes.rb` calls `public :name` / `private :name` at the top level, which previously prevented every spec file in `core/main` from loading.

The 14 residual issues cluster around (a) `private_methods(true)` not walking past Object [deferred — fixing the cut-off cascades through other tests], (b) refinements (`main.using` semantics), and (c) `define_method` plus `eval` interactions.

## Test plan

- [x] `cargo test --release --lib main_object binding` — 19/19 passing
- [x] `cargo test --release --lib` — full suite, no new regressions (3 pre-existing failures stay the same: `dir::glob`, `string_inspect`, `symbol_inspect_unquoted`)
- [x] `mspec run core/main -t monoruby --format dotted` against the master baseline (Ruby 4.0.2)
- [ ] CI green

https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ7zGdpAm9fc1tG6iBZtFZ)_