### PR TITLE
spec-pages: clamp per-category pass rate at 0 in time-series chart

### DIFF
--- a/.github/spec-pages/index.html
+++ b/.github/spec-pages/index.html
@@ -107,7 +107,7 @@ async function loadCsv(path) {
         labels: rows.map(r => r.timestamp),
         datasets: [{
           label: cat + ' pass rate (%)',
-          data: rows.map(r => parseFloat(r.pass_rate)),
+          data: rows.map(r => Math.max(0, parseFloat(r.pass_rate))),
           borderColor: '#1565c0',
           backgroundColor: 'rgba(21,101,192,0.15)',
           tension: 0.15,


### PR DESCRIPTION
## Summary

In the **Per-category pass rate over time** chart on the spec dashboard, clamp `pass_rate` to `>= 0` when reading the CSV.

Older history rows (written before the workflow's pass-count clamp landed in #357) can have `pass_rate < 0` because at the time `pass = examples - failures - errors` could go negative when one example raised multiple errors. New rows are already clamped at write time, but the existing `spec/data/history.csv` keeps the old rows; this prevents the line chart from dipping below the X axis for those categories.

```diff
- data: rows.map(r => parseFloat(r.pass_rate)),
+ data: rows.map(r => Math.max(0, parseFloat(r.pass_rate))),
```

## Test plan

- [ ] On the next publish, open https://sisshiki1969.github.io/monoruby/spec/, pick a category that previously dipped below 0, and confirm the line stays at 0 instead.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_