### PR TITLE
Remove R15 accumulator register tracking from JIT state

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -314,7 +314,6 @@ pub(super) fn gen_class_new_inline(
         dst,
         ..
     } = *callsite;
-    state.writeback_acc(ir);
     state.load(ir, recv, GP::Rdi);
     state.write_back_recv_and_callargs(ir, callsite);
     let using_xmm = state.get_using_xmm();

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1733,7 +1733,6 @@ pub fn object_send(
     }
 
     state.write_back_recv_and_callargs(ir, callsite);
-    state.writeback_acc(ir);
     let using_xmm = state.get_using_xmm();
     let error = ir.new_error(state);
     let callid = callsite.id;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -113,16 +113,15 @@ pub(crate) fn rbp_local(reg: SlotId) -> i32 {
 }
 
 ///
-/// The struct holds information for writing back Value's in xmm registers or accumulator to the corresponding stack slots.
+/// The struct holds information for writing back Value's in xmm registers to the corresponding stack slots.
 ///
-/// Currently supports `literal`s, `xmm` registers and a `R15` register (as an accumulator).
+/// Currently supports `literal`s and `xmm` registers.
 ///
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct WriteBack {
     fpr: Vec<(FPReg, Vec<SlotId>)>,
     literal: Vec<(Immediate, SlotId)>,
     void: Vec<SlotId>,
-    r15: Option<SlotId>,
 }
 
 impl Hash for WriteBack {
@@ -138,9 +137,6 @@ impl Hash for WriteBack {
             slot.hash(state);
         }
         for slot in &self.void {
-            slot.hash(state);
-        }
-        if let Some(slot) = self.r15 {
             slot.hash(state);
         }
     }
@@ -161,9 +157,6 @@ impl std::fmt::Debug for WriteBack {
         for slot in &self.void {
             s.push_str(&format!(" nil->{:?}", slot));
         }
-        if let Some(slot) = self.r15 {
-            s.push_str(&format!(" R15->{:?}", slot));
-        }
         write!(f, "WriteBack({})", s)
     }
 }
@@ -172,15 +165,9 @@ impl WriteBack {
     fn new(
         fpr: Vec<(FPReg, Vec<SlotId>)>,
         literal: Vec<(Immediate, SlotId)>,
-        r15: Option<SlotId>,
         void: Vec<SlotId>,
     ) -> Self {
-        Self {
-            fpr,
-            literal,
-            r15,
-            void,
-        }
+        Self { fpr, literal, void }
     }
 }
 
@@ -731,11 +718,6 @@ impl JitModule {
         for slot in &wb.void {
             self.literal_to_stack(*slot, Value::nil());
         }
-        if let Some(slot) = wb.r15 {
-            monoasm! { self,
-                movq [rbp - (rbp_local(slot))], r15;
-            }
-        }
     }
 
     ///
@@ -758,11 +740,6 @@ impl JitModule {
         }
         for slot in &wb.void {
             self.literal_to_stack2(*slot, Value::nil());
-        }
-        if let Some(slot) = wb.r15 {
-            monoasm! { self,
-                movq [r14 - (conv(slot))], r15;
-            }
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -272,10 +272,6 @@ impl AsmIr {
         self.push(AsmInst::LitToReg(v, reg));
     }
 
-    pub fn acc2stack(&mut self, reg: SlotId) {
-        self.push(AsmInst::AccToStack(reg));
-    }
-
     ///
     /// Convert Fixnum to f64.
     ///
@@ -758,13 +754,10 @@ pub(super) enum AsmInst {
     BcIndex(BcIndex),
     Label(JitLabel),
     Unreachable,
-    /// move reg to stack
+    /// move reg to stack via r14 (heap-aware: writes to the live frame
+    /// even when the surrounding frame has been promoted to heap during
+    /// a method call's lifetime).
     RegToStack(GP, SlotId),
-    /// move acc to stack
-    AccToStack(SlotId),
-
-    /// move reg to acc
-    RegToAcc(GP),
 
     /// move reg to stack
     StackToReg(SlotId, GP),
@@ -1637,8 +1630,6 @@ impl AsmInst {
     #[allow(dead_code)]
     pub fn dump(&self, store: &Store) -> String {
         match self {
-            Self::AccToStack(slot) => format!("{:?} = R15", slot),
-            Self::RegToAcc(gpr) => format!("R15 = {:?}", gpr),
             Self::RegToStack(gpr, slot) => format!("{:?} = {:?}", slot, gpr),
             Self::StackToReg(slot, gpr) => format!("{:?} = {:?}", gpr, slot),
             Self::LitToReg(val, gpr) => format!("{:?} = {}", gpr, val.debug(store)),

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -95,21 +95,10 @@ impl Codegen {
                 let label = frame.resolve_label(&mut self.jit, label);
                 self.jit.bind_label(label);
             }
-            AsmInst::AccToStack(slot) => {
-                self.store_r15(slot);
-            }
-            AsmInst::RegToAcc(r) => {
-                if r != GP::R15 {
-                    let r = r as u64;
-                    monoasm!( &mut self.jit,
-                        movq r15, R(r);
-                    );
-                }
-            }
             AsmInst::RegToStack(r, slot) => {
                 let r = r as u64;
                 monoasm!( &mut self.jit,
-                    movq [rbp - (rbp_local(slot))], R(r);
+                    movq [r14 - (conv(slot))], R(r);
                 );
             }
             AsmInst::StackToReg(slot, r) => {

--- a/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
+++ b/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
@@ -73,14 +73,6 @@ impl<'a> JitContext<'a> {
                 }
             }
         }
-        if let Some(backedge) = &mut backedge {
-            for i in backedge.all_regs() {
-                if let LinkMode::G(_) = backedge.mode(i) {
-                    let g = backedge.guarded(i);
-                    backedge.set_S_with_guard(i, g);
-                }
-            }
-        }
         #[cfg(feature = "jit-debug")]
         eprintln!(
             "analyse_end: {loop_start:?}->{loop_end:?} {}",

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -340,7 +340,6 @@ impl<'a> JitContext<'a> {
         state.discard(dst);
         state.clear_above_next_sp();
         let error = ir.new_error(state);
-        state.writeback_acc(ir);
         let evict = ir.new_evict();
         let meta = self.store[callee_fid].meta();
         ir.push(AsmInst::SetupYieldFrame { meta, outer });
@@ -374,7 +373,6 @@ impl<'a> JitContext<'a> {
         assert!(callsite.block_arg.is_none());
         state.load(ir, recv, GP::Rdi);
         state.discard(dst);
-        state.writeback_acc(ir);
         if recv_class.is_always_frozen() {
             if dst.is_some() {
                 ir.lit2reg(Value::nil(), GP::Rax);
@@ -474,7 +472,6 @@ impl<'a> JitContext<'a> {
         assert!(callsite.block_arg.is_none());
         state.load(ir, recv, GP::Rdi);
         state.discard(dst);
-        state.writeback_acc(ir);
         if inline {
             ir.push(AsmInst::LoadStructSlotInline { slot_index });
         } else {
@@ -714,7 +711,6 @@ impl AbstractState {
         self.discard(dst);
         self.clear_above_next_sp();
         let error = ir.new_error(self);
-        self.writeback_acc(ir);
         let meta = store[callee_fid].meta();
         ir.push(AsmInst::SetupMethodFrame {
             meta,
@@ -758,7 +754,6 @@ impl AbstractState {
         self.discard(store[callid].dst);
         self.clear_above_next_sp();
         let error = ir.new_error(self);
-        self.writeback_acc(ir);
         let meta = store[callee_fid].meta();
         ir.push(AsmInst::SetupMethodFrame {
             meta,
@@ -779,7 +774,6 @@ impl AbstractState {
         let callinfo = &store[callid];
         let dst = callinfo.dst;
         self.write_back_recv_and_callargs(ir, &callinfo);
-        self.writeback_acc(ir);
         let using_xmm = self.get_using_xmm();
         let error = ir.new_error(self);
         let evict = ir.new_evict();

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -11,7 +11,6 @@ impl<'a> JitContext<'a> {
     ) {
         assert!(!self_class.is_always_frozen());
         state.discard(dst);
-        state.writeback_acc(ir);
         ir.self2reg(GP::Rdi);
         let is_object_ty = self.self_ty() == Some(ObjTy::OBJECT);
         if is_object_ty && ivarid.is_inline() {

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -259,8 +259,9 @@ impl AbstractFrame {
         guarded: slot::Guarded,
     ) {
         if let Some(dst) = dst.into() {
-            self.def_G(ir, dst, guarded);
-            ir.push(AsmInst::RegToAcc(src));
+            self.discard(dst);
+            ir.reg2stack(src, dst);
+            self.set_S_with_guard(dst, guarded);
         }
     }
 

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -14,28 +14,16 @@ impl AbstractFrame {
         self.use_as_value(slot);
         match self.mode(slot) {
             LinkMode::F(fpr) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
                 // F -> Sf
                 ir.fpr2stack(fpr, slot);
                 ir.reg_move(GP::Rax, dst);
                 self.set_Sf_float(slot, fpr);
             }
             LinkMode::C(v) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
                 ir.lit2reg(v.into(), dst);
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
                 ir.stack2reg(slot, dst);
-            }
-            LinkMode::G(_) => {
-                ir.reg_move(GP::R15, dst);
             }
             LinkMode::MaybeNone => {
                 ir.stack2reg(slot, dst);
@@ -105,14 +93,6 @@ impl AbstractFrame {
                 ir.fixnum2fpr(GP::Rdi, x);
                 x
             }
-            LinkMode::G(_) => {
-                // G -> Sf
-                ir.reg2stack(GP::R15, slot);
-                self.guard_fixnum(ir, slot, GP::R15);
-                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                ir.fixnum2fpr(GP::R15, x);
-                x
-            }
             LinkMode::C(v) => self.load_xmm_from_C(ir, slot, v),
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("load_xmm_fixnum() {:?}", self.mode(slot));
@@ -137,13 +117,6 @@ impl AbstractFrame {
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
                 ir.stack2reg(slot, GP::Rdi);
                 ir.float_to_fpr(GP::Rdi, x, deopt);
-                x
-            }
-            LinkMode::G(_) => {
-                // -> Sf
-                let x = self.set_new_Sf(slot, SfGuarded::Float);
-                ir.reg2stack(GP::R15, slot);
-                ir.float_to_fpr(GP::R15, x, deopt);
                 x
             }
             LinkMode::C(v) => self.load_xmm_from_C(ir, slot, v),
@@ -195,16 +168,8 @@ impl AbstractFrame {
         slot: SlotId,
         ofs: i32,
     ) {
-        match self.mode(slot) {
-            LinkMode::G(_) => {
-                self.use_as_value(slot);
-                ir.reg2rsp_offset(GP::R15, ofs);
-            }
-            _ => {
-                self.load(ir, slot, GP::Rax);
-                ir.reg2rsp_offset(GP::Rax, ofs);
-            }
-        }
+        self.load(ir, slot, GP::Rax);
+        ir.reg2rsp_offset(GP::Rax, ofs);
     }
 
     pub(in crate::codegen::jitgen) fn fetch_rest_for_callee(

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -10,7 +10,6 @@ pub(crate) struct SlotState {
     /// xmm2..xmm15; indices >= 14 are spilled (live on stack — at use
     /// time the codegen swaps them with a scratch xmm).
     vfpr: Vec<Vec<SlotId>>,
-    r15: Option<SlotId>,
     local_num: usize,
     /// xmm registers that must not be reused by `alloc_xmm` /
     /// `try_alloc_xmm_demote`. Used by callers that have just produced
@@ -42,7 +41,6 @@ impl SlotState {
             slots: vec![default; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
             vfpr: (0..PHYS_XMM_POOL).map(|_| vec![]).collect(),
-            r15: None,
             local_num,
             pinned_vfpr: Vec::new(),
         };
@@ -97,10 +95,6 @@ impl SlotState {
         self.slots.len()
     }
 
-    pub(super) fn no_r15(&self) -> bool {
-        self.r15.is_none()
-    }
-
     pub(super) fn equiv(&self, other: &Self) -> bool {
         assert_eq!(self.slots.len(), other.slots.len());
         self.slots
@@ -134,7 +128,7 @@ impl SlotState {
                         self.set_Sf(slot, x, SfGuarded::Float);
                     }
                 }
-                LinkMode::G(_) | LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
+                LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                     unreachable!("use_float {:?}", self.mode(slot));
                 }
             };
@@ -332,10 +326,6 @@ impl SlotState {
             LinkMode::Sf(xmm, _) | LinkMode::F(xmm) => {
                 assert!(self.xmm(xmm).contains(&slot));
                 self.xmm_remove(slot, xmm);
-            }
-            LinkMode::G(_) => {
-                assert_eq!(self.r15, Some(slot));
-                self.r15 = None;
             }
             LinkMode::C(_) => {}
             LinkMode::S(_) => {}
@@ -552,23 +542,6 @@ impl SlotState {
     }
 
     ///
-    /// Link *slot* to the accumulator.
-    ///
-    #[allow(non_snake_case)]
-    pub(crate) fn def_G(
-        &mut self,
-        ir: &mut AsmIr,
-        slot: impl Into<Option<SlotId>>,
-        guarded: Guarded,
-    ) {
-        if let Some(slot) = slot.into() {
-            self.discard(slot);
-            self.writeback_acc(ir);
-            self.set_mode(slot, LinkMode::G(guarded));
-            self.r15 = Some(slot);
-        }
-    }
-
     // APIs for 'use'
 
     /// used as f64 with no conversion
@@ -598,13 +571,6 @@ impl SlotState {
             LinkMode::C(v) => {
                 ir.lit2stack(v.into(), slot);
             }
-            LinkMode::G(guarded) => {
-                // G -> S
-                ir.acc2stack(slot);
-                assert_eq!(self.r15, Some(slot));
-                self.r15 = None;
-                self.set_mode(slot, LinkMode::S(guarded));
-            }
             LinkMode::Sf(_, _) | LinkMode::S(_) | LinkMode::MaybeNone => {}
             LinkMode::V | LinkMode::None => {
                 eprintln!("{:?}", self);
@@ -629,9 +595,6 @@ impl SlotState {
             }
             LinkMode::C(v) => {
                 ir.lit2stack(v.into(), slot);
-            }
-            LinkMode::G(_) => {
-                ir.acc2stack(slot);
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) => {}
             LinkMode::V => {
@@ -817,41 +780,16 @@ impl SlotState {
         }
     }
 
-    pub(super) fn on_reg(&self, slot: SlotId) -> Option<GP> {
-        if self.is_r15(slot) {
-            Some(GP::R15)
-        } else {
-            None
-        }
+    pub(super) fn on_reg(&self, _slot: SlotId) -> Option<GP> {
+        None
     }
 
-    pub(in crate::codegen::jitgen) fn on_reg_or(&self, slot: SlotId, optb: GP) -> GP {
-        if self.is_r15(slot) { GP::R15 } else { optb }
-    }
-
-    ///
-    ///
-    /// Write back acc(`r15``) to the stack slot.
-    ///
-    /// The slot is set to LinkMode::Stack.
-    ///
-    pub(crate) fn writeback_acc(&mut self, ir: &mut AsmIr) {
-        if let Some(slot) = self.r15 {
-            let guarded = self.guarded(slot);
-            self.set_mode(slot, LinkMode::S(guarded));
-            self.r15 = None;
-            ir.acc2stack(slot);
-        }
-        assert!(!self.slots.iter().any(|link| matches!(link, LinkMode::G(_))));
-        assert!(self.r15.is_none());
+    pub(in crate::codegen::jitgen) fn on_reg_or(&self, _slot: SlotId, optb: GP) -> GP {
+        optb
     }
 
     fn is_xmm_vacant(&self, xmm: FPReg) -> bool {
         self.xmm(xmm).is_empty()
-    }
-
-    fn is_r15(&self, slot: SlotId) -> bool {
-        self.r15 == Some(slot)
     }
 }
 
@@ -890,11 +828,6 @@ impl SlotState {
             LinkMode::C(v) => {
                 self.def_C(dst, v);
             }
-            LinkMode::G(guarded) => {
-                ir.reg2stack(GP::R15, src);
-                self.set_S_with_guard(src, guarded);
-                self.def_G(ir, dst, guarded)
-            }
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("copy_slot() {:?} {:?}: {:?}", src, self.mode(src), self);
             }
@@ -925,7 +858,7 @@ impl AbstractFrame {
         }
         let class_guarded = Guarded::from_class(class);
         match &mut self.slots[slot.0 as usize] {
-            LinkMode::S(guarded) | LinkMode::G(guarded) => {
+            LinkMode::S(guarded) => {
                 if class_guarded == *guarded {
                     return;
                 } else if *guarded == Guarded::Value {
@@ -1003,18 +936,14 @@ impl AbstractFrame {
     pub(super) fn get_gc_write_back(&self) -> WriteBack {
         let literal = self.wb_literal(|_| true);
         let void = self.wb_void();
-        WriteBack::new(vec![], literal, self.r15, void)
+        WriteBack::new(vec![], literal, void)
     }
 
     pub(crate) fn get_write_back(&self) -> WriteBack {
         let f = |_| true;
         let xmm = self.wb_xmm(f);
         let literal = self.wb_literal(f);
-        let r15 = match self.r15 {
-            Some(slot) if f(slot) => Some(slot),
-            _ => None,
-        };
-        WriteBack::new(xmm, literal, r15, vec![])
+        WriteBack::new(xmm, literal, vec![])
     }
 
     fn xmm_swap(&mut self, l: FPReg, r: FPReg) {
@@ -1073,7 +1002,6 @@ impl AbstractFrame {
             }
             LinkMode::S(_)
             | LinkMode::C(_)
-            | LinkMode::G(_)
             | LinkMode::V
             | LinkMode::MaybeNone
             | LinkMode::None => {}
@@ -1171,10 +1099,6 @@ pub(in crate::codegen::jitgen) enum LinkMode {
     ///
     S(Guarded),
     ///
-    /// On the general-purpose register (r15).
-    ///
-    G(Guarded),
-    ///
     /// On the floating point register (xmm).
     ///
     /// mutation of the corresponding FPR lazily affects the stack slot.
@@ -1205,7 +1129,7 @@ impl LinkMode {
 
     fn guarded(&self) -> Guarded {
         match self {
-            LinkMode::S(guarded) | LinkMode::G(guarded) => *guarded,
+            LinkMode::S(guarded) => *guarded,
             LinkMode::Sf(_, guarded) => (*guarded).into(),
             LinkMode::F(_) => Guarded::Float,
             LinkMode::C(v) => Guarded::from_concrete_value((*v).into()),
@@ -1410,7 +1334,7 @@ impl AbstractFrame {
                     self.to_sf(ir, slot, l, r, guarded);
                 }
             }
-            (LinkMode::F(_) | LinkMode::G(_), LinkMode::S(_)) => {
+            (LinkMode::F(_), LinkMode::S(_)) => {
                 self.write_back_slot(ir, slot);
             }
             (LinkMode::Sf(l, _), LinkMode::Sf(r, guarded)) => {
@@ -1432,18 +1356,6 @@ impl AbstractFrame {
                 } else {
                     let tmp = self.set_new_Sf(slot, SfGuarded::Float);
                     ir.float_to_fpr(GP::Rax, tmp, deopt);
-                    self.gen_xmm_swap(ir, x, tmp);
-                }
-            }
-            (LinkMode::G(_), LinkMode::Sf(x, SfGuarded::Float)) => {
-                // G -> Sf
-                let deopt = ir.new_deopt_with_pc(&self, pc + 1);
-                if self.is_xmm_vacant(x) {
-                    ir.float_to_fpr(GP::R15, x, deopt);
-                    self.set_Sf_float(slot, x);
-                } else {
-                    let tmp = self.set_new_Sf(slot, SfGuarded::Float);
-                    ir.float_to_fpr(GP::R15, tmp, deopt);
                     self.gen_xmm_swap(ir, x, tmp);
                 }
             }


### PR DESCRIPTION
This PR removes the R15 general-purpose register accumulator tracking from the JIT code generation state management. The R15 register was previously used as an accumulator to hold values temporarily, but this functionality is being removed in favor of simpler stack-based value management.

## Key Changes

- **Removed R15 accumulator state tracking**: Deleted the `r15: Option<SlotId>` field from `SlotState` and all associated methods (`no_r15()`, `is_r15()`, `on_reg()`, `on_reg_or()`, `writeback_acc()`)

- **Removed `LinkMode::G` variant**: Eliminated the `G(Guarded)` link mode that tracked values stored in the R15 register, simplifying the value location tracking to only stack, constant, and XMM register locations

- **Simplified value handling**: Replaced R15-based value passing with direct stack operations:
  - `def_G()` method removed; callers now use `def_S()` with stack-based storage
  - `acc2stack()` and `reg2acc()` AsmIr instructions removed
  - `RegToStack` instruction now uses R14-based addressing (heap-aware frame access) instead of RBP-based

- **Updated WriteBack struct**: Removed `r15: Option<SlotId>` field and related writeback logic for the accumulator register

- **Cleaned up method call sites**: Removed `writeback_acc()` calls from method call compilation, class instantiation, and variable access code paths

## Implementation Details

The changes maintain correctness by ensuring values that would have been in R15 are now properly stored on the stack. The `RegToStack` instruction was updated to use `[r14 - offset]` addressing instead of `[rbp - offset]`, which provides heap-aware frame access for cases where the frame has been promoted during method calls.

This simplification reduces the complexity of the JIT state machine while maintaining the same functionality through stack-based value management.

https://claude.ai/code/session_01SRrCAdBwQ5RbixCCtNwYtD