### PR TITLE
core/module: define_method arity, undefined_instance_methods, set_temporary_name validation

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -134,6 +134,12 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_private_builtin_func(MODULE_CLASS, "extend_object", extend_object, 1);
     globals.define_builtin_func_rest(MODULE_CLASS, "prepend", prepend);
     globals.define_private_builtin_func(MODULE_CLASS, "prepend_features", prepend_features, 1);
+    globals.define_builtin_func(
+        MODULE_CLASS,
+        "undefined_instance_methods",
+        undefined_instance_methods,
+        0,
+    );
     globals.define_builtin_func(MODULE_CLASS, "instance_method", instance_method, 1);
     // `public_instance_method` is identical to `instance_method` except it
     // raises NameError when the resolved method is private or protected.
@@ -1437,7 +1443,12 @@ fn define_method(
     let name = lfp.arg(0).expect_symbol_or_string(globals)?;
     let func_id = if let Some(method) = lfp.try_arg(1) {
         if let Some(proc) = method.is_proc() {
-            globals.define_proc_method(proc)
+            let fid = globals.define_proc_method(proc);
+            // A method defined via `define_method` enforces strict arity
+            // (no destructuring of a single Array argument, ArgumentError
+            // on count mismatch), unlike the underlying Proc.
+            globals.store[fid].set_method_style();
+            fid
         } else if let Some(method) = method.is_method() {
             method.func_id()
         } else if let Some(umethod) = method.is_umethod() {
@@ -1451,7 +1462,9 @@ fn define_method(
         }
     } else if let Some(bh) = lfp.block() {
         let proc = vm.generate_proc(globals, bh, pc)?;
-        globals.define_proc_method(proc)
+        let fid = globals.define_proc_method(proc);
+        globals.store[fid].set_method_style();
+        fid
     } else {
         return Err(MonorubyErr::wrong_number_of_arg(2, 1));
     };
@@ -1479,6 +1492,27 @@ fn instance_methods(
     } else {
         globals.store.get_method_names_inherit(class_id, false)
     }))
+}
+
+///
+/// ### Module#undefined_instance_methods
+///
+/// - undefined_instance_methods -> [Symbol]
+///
+/// Returns the list of method names that have been undefined on this
+/// module/class itself via `undef_method`. Inherited undefs aren't
+/// included.
+#[monoruby_builtin]
+fn undefined_instance_methods(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let class_id = lfp.self_val().as_class_id();
+    Ok(Value::array_from_vec(
+        globals.store.get_undefined_instance_methods(class_id),
+    ))
 }
 
 ///
@@ -2336,6 +2370,24 @@ fn set_constants_visibility(globals: &mut Globals, lfp: Lfp, make_private: bool)
     Ok(lfp.self_val())
 }
 
+/// True when `s` parses as `(::)?CONST(::CONST)*` where each `CONST`
+/// matches `[A-Z][A-Za-z0-9_]*`. Used by `set_temporary_name` to reject
+/// names that would shadow real constant lookups.
+fn is_constant_path(s: &str) -> bool {
+    let body = s.strip_prefix("::").unwrap_or(s);
+    if body.is_empty() {
+        return false;
+    }
+    body.split("::").all(|seg| {
+        let mut chars = seg.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_uppercase() => {}
+            _ => return false,
+        }
+        chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    })
+}
+
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/set_temporary_name.html]
 #[monoruby_builtin]
 fn set_temporary_name(
@@ -2346,11 +2398,29 @@ fn set_temporary_name(
 ) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
     let name_val = lfp.arg(0);
+    // CRuby refuses to rename a module that already has a permanent
+    // (constant-bound) name; the check runs before nil/string handling
+    // so even `set_temporary_name(nil)` on `Object` raises.
+    if globals.store[class_id].is_name_permanent() {
+        return Err(MonorubyErr::runtimeerr("can't change permanent name"));
+    }
     if name_val.is_nil() {
         globals.store[class_id].clear_name();
     } else {
         let name = name_val.coerce_to_string(vm, globals)?;
-        globals.store[class_id].set_name(name);
+        if name.is_empty() {
+            return Err(MonorubyErr::argumenterr("empty class/module name"));
+        }
+        // Reject anything that *looks* like a syntactically valid
+        // constant or constant path so introspection tools that resolve
+        // `A::B` aren't confused. We accept anything that wouldn't
+        // round-trip as a constant ("a::B", "A::b", "A::B::", "Template['x']").
+        if is_constant_path(&name) {
+            return Err(MonorubyErr::argumenterr(
+                "the temporary name must not be a constant path to avoid confusion",
+            ));
+        }
+        globals.store[class_id].set_temporary_name(name);
     }
     Ok(lfp.self_val())
 }

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -4990,4 +4990,234 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn define_method_strict_arity_too_few() {
+        // A method defined from a Proc/block enforces method-style
+        // arity, so calling with fewer args than the block declares
+        // raises ArgumentError instead of filling missing params with
+        // nil (the proc-style behaviour).
+        run_test_error(
+            r#"
+            class C
+              define_method(:m) { |a, b| [a, b] }
+            end
+            C.new.m(1)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_strict_arity_too_many() {
+        // Likewise, extra arguments are rejected.
+        run_test_error(
+            r#"
+            class C
+              define_method(:m) { |a| a }
+            end
+            C.new.m(1, 2)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_no_destructure_single_array() {
+        // Block-style auto-destructuring of a single Array argument
+        // must not happen for define_method bodies — the array is
+        // passed through as one value.
+        run_test(
+            r#"
+            class C
+              define_method(:m) { |a| a }
+            end
+            C.new.m([1, 2])
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_rest_arity() {
+        // Rest params on a method-style body still accept any extra
+        // positional args without ArgumentError.
+        run_test(
+            r#"
+            class C
+              define_method(:m) { |a, b, *c| [a, b, c] }
+            end
+            C.new.m(1, 2, 3, 4)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_proc_unaffected() {
+        // The original Proc passed to define_method keeps its
+        // block-style behaviour when invoked directly — only the
+        // wrapper installed as a method becomes strict. Calling the
+        // original proc with one arg fills `b` with nil; the method
+        // would raise ArgumentError instead (covered by
+        // `define_method_strict_arity_too_few`).
+        run_test(
+            r#"
+            p = Proc.new { |a, b| [a, b] }
+            Class.new do
+              define_method(:m, p)
+            end
+            p.call(1)
+            "#,
+        );
+    }
+
+    #[test]
+    fn undefined_instance_methods_returns_undef_names() {
+        // `undef_method` marks the slot Undefined; the new builtin
+        // surfaces those names.
+        run_test(
+            r#"
+            class P
+              def foo; end
+              def bar; end
+              undef_method :foo
+            end
+            P.undefined_instance_methods.sort
+            "#,
+        );
+    }
+
+    #[test]
+    fn undefined_instance_methods_empty_when_none() {
+        run_test(
+            r#"
+            class C
+              def foo; end
+            end
+            C.undefined_instance_methods
+            "#,
+        );
+    }
+
+    #[test]
+    fn undefined_instance_methods_only_self() {
+        // Inherited undefs are NOT included — only entries on the
+        // class's own method table count.
+        run_test(
+            r#"
+            class P
+              def foo; end
+              undef_method :foo
+            end
+            class C < P
+            end
+            C.undefined_instance_methods
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_empty_string_raises() {
+        run_test_error(
+            r#"
+            Module.new.set_temporary_name("")
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_constant_name_raises() {
+        run_test_error(
+            r#"
+            Module.new.set_temporary_name("Object")
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_constant_path_raises() {
+        run_test_error(
+            r#"
+            Module.new.set_temporary_name("A::B")
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_leading_colons_raises() {
+        run_test_error(
+            r#"
+            Module.new.set_temporary_name("::A")
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_permanent_module_raises() {
+        // Built-in / constant-bound classes are permanent and refuse
+        // a temporary rename.
+        run_test_error(
+            r#"
+            Object.set_temporary_name("fake")
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_accepts_non_constant_strings() {
+        // Strings that don't parse as a constant or constant path are
+        // accepted: lowercase initial, embedded non-identifier
+        // characters, lowercase second segment, trailing `::`, etc.
+        run_test(
+            r#"
+            m = Module.new
+            results = []
+            results << m.set_temporary_name("name").name
+            results << m.set_temporary_name("Template['foo.rb']").name
+            results << m.set_temporary_name("a::B").name
+            results << m.set_temporary_name("A::b").name
+            results << m.set_temporary_name("A::B::").name
+            results << m.set_temporary_name("A=").name
+            results
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_bare_leaf_for_anonymous_parent() {
+        // When the parent chain contains an anonymous module, an
+        // explicit `set_temporary_name` call on a leaf still returns
+        // the bare name (no `#<Module:0x..>::leaf` rendering).
+        run_test(
+            r#"
+            m = Module.new
+            module m::N; end
+            m::N.set_temporary_name("fake_name")
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_anonymous_nested_module_is_not_permanent() {
+        // A module assigned through an anonymous parent isn't itself
+        // permanent: `set_temporary_name` succeeds on it.
+        run_test(
+            r#"
+            m = Module.new
+            module m::N; end
+            m::N.set_temporary_name("ok")
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_nil_clears_name() {
+        run_test(
+            r#"
+            m = Module.new
+            m.set_temporary_name("temp")
+            m.set_temporary_name(nil)
+            m.name
+            "#,
+        );
+    }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -268,7 +268,13 @@ impl Store {
     pub(crate) fn get_class_name(&self, class: ClassId) -> String {
         let class_obj = self.classes[class].get_module();
         match self.classes[class].get_name() {
-            Some(_) => {
+            Some(name) => {
+                // A name set explicitly via `Module#set_temporary_name`
+                // overrides parent-chain rendering — CRuby returns the
+                // bare leaf string, not `#<Module:0x..>::leaf`.
+                if self.classes[class].is_name_explicit_temporary() {
+                    return name.to_string();
+                }
                 let v: Vec<_> = self.classes.get_parents(class).into_iter().rev().collect();
                 v.join("::")
             }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -215,6 +215,21 @@ pub struct ClassInfo {
     ///
     name_value: Option<Value>,
     ///
+    /// True when `name` was assigned via constant binding (a "permanent
+    /// name"). False for anonymous modules and for modules whose name
+    /// was set via `Module#set_temporary_name`. Used to enforce
+    /// `set_temporary_name`'s restriction that permanent names cannot
+    /// be replaced.
+    ///
+    name_permanent: bool,
+    ///
+    /// True when `name` was assigned via `Module#set_temporary_name`.
+    /// In that case `Module#name` returns the leaf string verbatim
+    /// instead of prefixing it with the (possibly anonymous) parent
+    /// chain — matching CRuby's behavior.
+    ///
+    name_explicit_temporary: bool,
+    ///
     /// the parent class of this class.
     ///
     parent: Option<ClassId>,
@@ -330,6 +345,8 @@ impl ClassInfo {
         Self {
             name: None,
             name_value: None,
+            name_permanent: false,
+            name_explicit_temporary: false,
             parent: None,
             object: None,
             methods: HashMap::default(),
@@ -346,6 +363,8 @@ impl ClassInfo {
         Self {
             name: None,
             name_value: None,
+            name_permanent: false,
+            name_explicit_temporary: false,
             parent: None,
             object: None,
             methods: HashMap::default(),
@@ -399,11 +418,38 @@ impl ClassInfo {
         // Invalidate any cached frozen name Value so the next call to
         // `Module#name` rebuilds it from the current `name`.
         self.name_value = None;
+        self.name_permanent = true;
+        self.name_explicit_temporary = false;
+    }
+
+    /// Set a non-permanent (temporary) name. Distinguished from
+    /// `set_name` so `set_temporary_name` round-trips correctly and a
+    /// later constant assignment can still promote the module to a
+    /// permanent name.
+    pub(crate) fn set_temporary_name(&mut self, name: String) {
+        self.name = Some(name);
+        self.name_value = None;
+        self.name_permanent = false;
+        self.name_explicit_temporary = true;
     }
 
     pub(crate) fn clear_name(&mut self) {
         self.name = None;
         self.name_value = None;
+        self.name_permanent = false;
+        self.name_explicit_temporary = false;
+    }
+
+    pub(crate) fn is_name_explicit_temporary(&self) -> bool {
+        self.name_explicit_temporary
+    }
+
+    pub(crate) fn is_name_permanent(&self) -> bool {
+        self.name_permanent
+    }
+
+    pub(crate) fn set_name_permanent(&mut self, permanent: bool) {
+        self.name_permanent = permanent;
     }
 
     pub(crate) fn get_name(&self) -> Option<&str> {
@@ -827,6 +873,23 @@ impl ClassInfoTable {
             .collect()
     }
 
+    /// Names of methods explicitly undefined on *class_id* itself (via
+    /// `undef_method`), regardless of whether the name was originally
+    /// defined here or only inherited.
+    pub(crate) fn get_undefined_instance_methods(&self, class_id: ClassId) -> Vec<Value> {
+        self[class_id]
+            .methods
+            .iter()
+            .filter_map(|(name, entry)| {
+                if matches!(entry.visibility, Visibility::Undefined) {
+                    Some(Value::symbol(*name))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     ///
     /// Get public and protected method names in the class of *class_id* and its ancesters.
     ///
@@ -1005,8 +1068,17 @@ impl ClassInfoTable {
         } else {
             None
         };
+        // A class/module is "permanently" named only if its leaf name was
+        // assigned and the surrounding lexical parent is itself
+        // permanent (so the full qualified name is reachable from a
+        // top-level constant). `Object` itself counts as permanent.
+        let parent_permanent = match parent {
+            Some(p) => p == OBJECT_CLASS || self[p].is_name_permanent(),
+            None => false,
+        };
         self[class_id].object = Some(class_obj.as_class());
         self[class_id].name = name.map(|id| id.to_string());
+        self[class_id].name_permanent = name.is_some() && parent_permanent;
         self[class_id].parent = parent;
         self[class_id].instance_ty = instance_ty;
         self[class_id].alloc_func = inherited_alloc;

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -266,6 +266,14 @@ impl ClassInfoTable {
                 // ancestors are rendered using their inspect form during the
                 // walk (see `get_parents`).
                 self[klass.id()].set_name(name.to_string());
+                // The new module is permanently named only if its parent
+                // is itself permanent (so the full chain back to a
+                // top-level constant is reachable). Otherwise the leaf
+                // name is "borrowed" through an anonymous ancestor and
+                // CRuby still allows `set_temporary_name` on it.
+                let parent_permanent =
+                    class_id == OBJECT_CLASS || self[class_id].is_name_permanent();
+                self[klass.id()].set_name_permanent(parent_permanent);
             }
         }
     }


### PR DESCRIPTION
## Summary

Reduces `core/module` ruby/spec failures from **238 (107 FAIL + 131 ERROR)** to **210 (81 + 129)** — about 12% fewer issues — across three independent fixes.

## Changes

### `Module#define_method` — strict arity for Proc/block bodies

When a Proc or block is wrapped as a method via `define_method`, the resulting method now follows method-style arity:
- raises `ArgumentError` on argument count mismatch
- does not destructure a single `Array` argument

Implemented by calling `set_method_style()` on the wrapper `FuncId` returned by `define_proc_method`, so the runtime arg-handling code (`codegen/runtime/args.rs`) takes the strict path. The underlying Proc still behaves as a block when used elsewhere.

**Fixes ~16 spec failures.**

### `Module#undefined_instance_methods` — new builtin

Returns the names of methods explicitly removed via `undef_method` on this class itself (no inheritance walk). Reuses the existing `Visibility::Undefined` state in the method table.

```ruby
class P
  def foo; end
  undef_method :foo
end
P.undefined_instance_methods  # => [:foo]
```

**Fixes 4 spec errors.**

### `Module#set_temporary_name` — validation + permanence tracking

Validates input and rejects names that would shadow real constant lookups:
- empty string → `ArgumentError("empty class/module name")`
- constant name / constant path (`/\A(::)?[A-Z]\w*(::[A-Z]\w*)*\z/`) → `ArgumentError("the temporary name must not be a constant path…")`
- permanent (constant-bound) module → `RuntimeError("can't change permanent name")`

Adds `name_permanent` and `name_explicit_temporary` flags on `ClassInfo` so:
- Built-in classes and constant-bound classes are permanent.
- `module m::N; end` with anonymous `m` produces a non-permanent `N` (so `set_temporary_name` is allowed on it).
- After `set_temporary_name`, `Module#name` returns the bare leaf string instead of prefixing with the anonymous parent's `#<Module:0x..>` rendering.

**Fixes 6 spec failures.**

## Verification

- `cargo test --release --lib 'builtins::module'` — 110/110 pass
- `cargo test --release --test method_call` — 63/63 pass
- `cargo test --release --test class_chain` — 2/2 pass
- `core/module` ruby/spec: 238 → 210 issues (no new regressions in the suite)

Pre-existing failures in `string_inspect` / `symbol_inspect` unit tests are unrelated to this PR (Ruby 4.0 changed `String#inspect` to escape non-ASCII by default).

## Test plan

- [x] Run `cargo test --release --lib`
- [x] Run `core/module` ruby/spec against monoruby
- [x] Manual smoke tests for each new behavior

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_