### PR TITLE
core/module: deprecate_constant + ruby2_keywords/define_method/attr fixes

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -315,15 +315,6 @@ class Hash
   end
 end
 
-class Module
-  def ruby2_keywords(*)
-    # no-op for compatibility
-  end
-
-  def deprecate_constant(*)
-    self
-  end
-end
 
 class File
   class Stat

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1530,12 +1530,12 @@ fn define_method_visibility(vm: &Executor, target: ClassId, name: IdentId) -> Vi
 /// `def`, `define_method`, and `alias_method` all consult this list.
 fn is_special_private_method_name(name: IdentId) -> bool {
     matches!(
-        name.get_name().as_str(),
-        "initialize"
-            | "initialize_copy"
-            | "initialize_clone"
-            | "initialize_dup"
-            | "respond_to_missing?"
+        name,
+        IdentId::INITIALIZE
+            | IdentId::INITIALIZE_COPY
+            | IdentId::INITIALIZE_CLONE
+            | IdentId::INITIALIZE_DUP
+            | IdentId::RESPOND_TO_MISSING_
     )
 }
 

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -196,6 +196,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(MODULE_CLASS, "included_modules", included_modules, 0);
     globals.define_builtin_func_rest(MODULE_CLASS, "public_constant", public_constant);
     globals.define_builtin_func_rest(MODULE_CLASS, "private_constant", private_constant);
+    globals.define_builtin_func_rest(MODULE_CLASS, "deprecate_constant", deprecate_constant);
+    globals.define_private_builtin_func_rest(MODULE_CLASS, "ruby2_keywords", ruby2_keywords);
     // `used_refinements` (both class and instance forms) is mocked in
     // Ruby — see `Module#used_refinements` / `Module.used_refinements`
     // in `builtins/startup.rb`. Both return `[]` since refinements
@@ -494,6 +496,20 @@ fn attr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     };
 
     if let Some(writable) = legacy_writable {
+        // CRuby emits "boolean argument is obsoleted" when $VERBOSE is
+        // true (i.e. ruby -W2). $VERBOSE defaults to nil/false; only
+        // `true` triggers the warning, matching CRuby's `rb_warning`
+        // gating used here.
+        if globals
+            .get_gvar(IdentId::get_id("$VERBOSE"))
+            .is_some_and(|v| v == Value::bool(true))
+        {
+            crate::value::emit_verbose_warning(
+                vm,
+                globals,
+                "boolean argument is obsoleted",
+            )?;
+        }
         let arg_name = args[0].coerce_to_symbol_or_string(vm, globals)?;
         let method_name = vm.define_attr_reader(globals, class_id, arg_name, visi)?;
         ary.push(Value::symbol(method_name));
@@ -1404,6 +1420,18 @@ fn remove_const(
 ) -> Result<Value> {
     let name = lfp.arg(0).coerce_to_symbol_or_string(vm, globals)?;
     let module = lfp.self_val().as_class().id();
+    // CRuby 3.4+ emits the deprecation warning when removing a
+    // deprecated constant (matches `remove_const` reading the slot
+    // before deleting it). The message uses the receiver's full
+    // qualified name even for anonymous modules.
+    if globals
+        .store
+        .get_constant(module, name)
+        .is_some_and(|s| s.is_deprecated())
+    {
+        let qualified = format!("{}::{}", module.get_name(&globals.store), name);
+        crate::value::emit_deprecated_constant_warning(vm, globals, &qualified)?;
+    }
     globals
         .remove_constant(module, name)
         .ok_or(MonorubyErr::uninitialized_constant(name))
@@ -1439,7 +1467,11 @@ fn define_method(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    let class_id = lfp.self_val().as_class_id();
+    let self_val = lfp.self_val();
+    if self_val.is_frozen() {
+        return Err(MonorubyErr::cant_modify_frozen(&globals.store, self_val));
+    }
+    let class_id = self_val.as_class_id();
     let name = lfp.arg(0).expect_symbol_or_string(globals)?;
     let func_id = if let Some(method) = lfp.try_arg(1) {
         if let Some(proc) = method.is_proc() {
@@ -1468,8 +1500,43 @@ fn define_method(
     } else {
         return Err(MonorubyErr::wrong_number_of_arg(2, 1));
     };
-    vm.add_public_method(globals, class_id, name, func_id)?;
+    let visibility = define_method_visibility(vm, class_id, name);
+    vm.add_method(globals, class_id, name, func_id, visibility)?;
     Ok(Value::symbol(name))
+}
+
+/// Compute the visibility for a `define_method` call.
+///
+/// `:initialize` (and the other "special private" names) is forced
+/// private to match `def initialize`. Otherwise CRuby uses the current
+/// lexical visibility *only* when `define_method` is called from inside
+/// the target module's own body — i.e. when the lexical class equals
+/// the receiver. Cross-class `klass.send(:define_method, ...)` always
+/// installs a public method, regardless of any `private`/`protected`
+/// in the calling scope.
+fn define_method_visibility(vm: &Executor, target: ClassId, name: IdentId) -> Visibility {
+    if is_special_private_method_name(name) {
+        return Visibility::Private;
+    }
+    if vm.context_class_id() == target {
+        vm.context_visibility()
+    } else {
+        Visibility::Public
+    }
+}
+
+/// Names that CRuby always installs as private even when called from a
+/// public scope: the `initialize` family plus `respond_to_missing?`.
+/// `def`, `define_method`, and `alias_method` all consult this list.
+fn is_special_private_method_name(name: IdentId) -> bool {
+    matches!(
+        name.get_name().as_str(),
+        "initialize"
+            | "initialize_copy"
+            | "initialize_clone"
+            | "initialize_dup"
+            | "respond_to_missing?"
+    )
 }
 
 ///
@@ -2368,6 +2435,86 @@ fn set_constants_visibility(globals: &mut Globals, lfp: Lfp, make_private: bool)
         }
     }
     Ok(lfp.self_val())
+}
+
+///
+/// ### Module#deprecate_constant
+///
+/// - deprecate_constant(*name) -> self
+///
+/// Marks each named constant as deprecated. Subsequent reads of those
+/// constants emit a `warning: constant ...::Name is deprecated` warning
+/// (subject to `Warning[:deprecated]`). Each name must be a constant
+/// defined directly on the receiver; otherwise `NameError` is raised.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Module/i/deprecate_constant.html]
+#[monoruby_builtin]
+fn deprecate_constant(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let class_id = lfp.self_val().as_class_id();
+    let args = lfp.arg(0).as_array();
+    // Validate every name first so a partial failure does not leave the
+    // class in an inconsistent state — matching CRuby and the behaviour
+    // of `private_constant` / `public_constant`.
+    let mut names = Vec::with_capacity(args.len());
+    for arg in args.iter() {
+        let name = arg.expect_symbol_or_string(globals)?;
+        if !globals.store[class_id].has_own_constant(name) {
+            return Err(MonorubyErr::nameerr(format!(
+                "constant {}::{} not defined",
+                class_id.get_name(&globals.store),
+                name
+            )));
+        }
+        names.push(name);
+    }
+    for name in names {
+        globals.store[class_id].set_constant_deprecated(name);
+    }
+    Ok(lfp.self_val())
+}
+
+///
+/// ### Module#ruby2_keywords
+///
+/// - ruby2_keywords(*method_names) -> nil
+///
+/// monoruby does not implement the ruby2_keywords flag mechanism, so
+/// the marking itself is a no-op. We still validate the arguments —
+/// each must coerce to a Symbol/String (TypeError otherwise) and
+/// reference a method defined directly on the receiver (NameError
+/// otherwise) — so that callers relying on the validation contract
+/// (e.g. specs in `core/module/ruby2_keywords_spec.rb`) behave
+/// correctly.
+#[monoruby_builtin]
+fn ruby2_keywords(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let class_id = lfp.self_val().as_class_id();
+    let args = lfp.arg(0).as_array();
+    for arg in args.iter() {
+        // expect_symbol_or_string accepts Symbol and String (and rejects
+        // anything else with TypeError "<obj> is not a symbol nor a
+        // string"). We don't honour `to_str` here — CRuby's
+        // `ruby2_keywords` is also strict about Symbol/String only.
+        let name = arg.expect_symbol_or_string(globals)?;
+        if globals.store[class_id].has_own_method(name) {
+            continue;
+        }
+        return Err(MonorubyErr::nameerr(format!(
+            "undefined method '{}' for class '{}'",
+            name,
+            class_id.get_name(&globals.store)
+        )));
+    }
+    Ok(Value::nil())
 }
 
 /// True when `s` parses as `(::)?CONST(::CONST)*` where each `CONST`
@@ -5217,6 +5364,236 @@ mod tests {
             m.set_temporary_name("temp")
             m.set_temporary_name(nil)
             m.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_returns_self() {
+        run_test(
+            r#"
+            m = Module.new
+            m.const_set(:X, 1)
+            m.deprecate_constant(:X).equal?(m)
+            "#,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_undefined_name_raises() {
+        run_test_error(
+            r#"
+            Module.new.deprecate_constant(:UNDEFINED)
+            "#,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_emits_warning_when_warning_deprecated_true() {
+        // The warning should reach $stderr.write. We capture stderr by
+        // pointing $stderr at a String-with-write stub and asserting on
+        // the captured message.
+        run_test(
+            r##"
+            old_dep = Warning[:deprecated]
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              Warning[:deprecated] = true
+              m = Module.new
+              m.const_set(:X, 1)
+              m.deprecate_constant(:X)
+              m::X
+            ensure
+              Warning[:deprecated] = old_dep
+              $stderr = old_stderr
+            end
+            captured =~ /warning: constant .+::X is deprecated/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_silent_when_warning_deprecated_false() {
+        run_test(
+            r##"
+            old_dep = Warning[:deprecated]
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              Warning[:deprecated] = false
+              m = Module.new
+              m.const_set(:X, 1)
+              m.deprecate_constant(:X)
+              m::X
+            ensure
+              Warning[:deprecated] = old_dep
+              $stderr = old_stderr
+            end
+            captured.empty?
+            "##,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_accepts_multiple_names_as_strings_and_symbols() {
+        run_test(
+            r#"
+            m = Module.new
+            m.const_set(:X, 1)
+            m.const_set(:Y, 2)
+            m.deprecate_constant("X", :Y)
+            [m::X, m::Y]
+            "#,
+        );
+    }
+
+    #[test]
+    fn deprecate_constant_warns_when_removed() {
+        // CRuby ≥3.4: `remove_const` on a deprecated constant fires
+        // the deprecation warning before the slot is deleted.
+        run_test(
+            r##"
+            old_dep = Warning[:deprecated]
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              Warning[:deprecated] = true
+              m = Module.new
+              m.const_set(:X, 1)
+              m.deprecate_constant(:X)
+              m.module_eval { remove_const :X }
+            ensure
+              Warning[:deprecated] = old_dep
+              $stderr = old_stderr
+            end
+            captured =~ /warning: constant .+::X is deprecated/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_undefined_method_raises_nameerror() {
+        run_test_error(
+            r#"
+            Class.new { ruby2_keywords :missing_method }
+            "#,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_non_symbol_string_raises_typeerror() {
+        run_test_error(
+            r#"
+            Class.new { ruby2_keywords Object.new }
+            "#,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_accepts_symbol_for_existing_method() {
+        // No-op call returning nil; should not raise.
+        run_test(
+            r#"
+            c = Class.new { def foo(*a); a; end; ruby2_keywords :foo }
+            c.new.foo(1, 2)
+            "#,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_accepts_string_for_existing_method() {
+        run_test(
+            r#"
+            c = Class.new { def foo(*a); a; end; ruby2_keywords "foo" }
+            c.new.foo(1, 2)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_visibility_inherits_from_class_body() {
+        // Inside the class body the current visibility wins.
+        run_test(
+            r#"
+            klass = Class.new do
+              define_method(:bar) { :bar }
+              private
+              define_method(:baz) { :baz }
+            end
+            [klass.public_method_defined?(:bar), klass.private_method_defined?(:baz)]
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_visibility_default_public_when_cross_class() {
+        // Calling via `send` from a different class always installs
+        // public, even if the *caller's* lexical visibility is private.
+        run_test(
+            r#"
+            klass = Class.new
+            Class.new do
+              klass.send(:define_method, :bar) { :bar }
+              private
+              klass.send(:define_method, :baz) { :baz }
+            end
+            [
+              klass.public_method_defined?(:bar),
+              klass.public_method_defined?(:baz),
+              klass.private_method_defined?(:baz),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_initialize_is_private() {
+        // Even called from a public scope, `:initialize` is private.
+        run_test(
+            r#"
+            klass = Class.new do
+              define_method(:initialize) { }
+            end
+            [
+              klass.private_method_defined?(:initialize),
+              klass.public_method_defined?(:initialize),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_on_frozen_module_raises_frozenerror() {
+        run_test_error(
+            r#"
+            Class.new { freeze; define_method(:foo) {} }
+            "#,
+        );
+    }
+
+    #[test]
+    fn attr_boolean_argument_returns_method_names() {
+        // The legacy `attr name, true|false` form returns the list of
+        // installed reader/writer names. Stronger CRuby-vs-monoruby
+        // comparison of the emitted-warning text is covered by the
+        // `core/module/attr_spec.rb` ruby/spec suite (which uses
+        // mspec's `complain` matcher).
+        run_test(
+            r#"
+            c = Class.new
+            r1 = c.send(:attr, :foo, true)
+            r2 = c.send(:attr, :bar, false)
+            r1 + r2
             "#,
         );
     }

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -31,7 +31,18 @@ impl Executor {
         let feature = match globals.get_constant(class_id, name) {
             None => return Ok(None),
             Some(state) => match &state.kind {
-                ConstStateKind::Loaded(v) => return Ok(Some(*v)),
+                ConstStateKind::Loaded(v) => {
+                    let v = *v;
+                    let deprecated = state.is_deprecated();
+                    if deprecated {
+                        let qualified =
+                            format!("{}::{}", class_id.get_name(&globals.store), name);
+                        crate::value::emit_deprecated_constant_warning(
+                            self, globals, &qualified,
+                        )?;
+                    }
+                    return Ok(Some(v));
+                }
                 ConstStateKind::Autoload(entry) => match entry.state {
                     // Same-thread re-entry while the autoload's own
                     // require is in flight: behave as "not yet

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -515,6 +515,15 @@ impl ClassInfo {
         }
     }
 
+    /// Marks the constant `name` as deprecated so that subsequent reads
+    /// trigger a "constant ... is deprecated" warning. Caller must
+    /// verify that `name` exists.
+    pub(crate) fn set_constant_deprecated(&mut self, name: IdentId) {
+        if let Some(state) = self.constants.get_mut(&name) {
+            state.set_deprecated();
+        }
+    }
+
     pub(crate) fn instance_ty(&self) -> Option<ObjTy> {
         self.instance_ty
     }

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -27,6 +27,11 @@ impl ConstVisibility {
 pub(crate) struct ConstState {
     pub kind: ConstStateKind,
     pub visibility: ConstVisibility,
+    /// Set by `Module#deprecate_constant`. When true, every read of
+    /// the constant emits a `warning: constant <Name> is deprecated`
+    /// message via `Kernel#warn` (so it honours `Warning[:deprecated]`
+    /// and any custom `Warning.warn` override).
+    pub deprecated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -78,6 +83,7 @@ impl ConstState {
         Self {
             kind: ConstStateKind::Loaded(value),
             visibility: ConstVisibility::Public,
+            deprecated: false,
         }
     }
 
@@ -85,6 +91,7 @@ impl ConstState {
         Self {
             kind: ConstStateKind::Autoload(AutoloadEntry::new(path)),
             visibility: ConstVisibility::Public,
+            deprecated: false,
         }
     }
 
@@ -113,6 +120,14 @@ impl ConstState {
 
     pub(crate) fn set_public(&mut self) {
         self.visibility = ConstVisibility::Public;
+    }
+
+    pub(crate) fn is_deprecated(&self) -> bool {
+        self.deprecated
+    }
+
+    pub(crate) fn set_deprecated(&mut self) {
+        self.deprecated = true;
     }
 }
 
@@ -241,17 +256,21 @@ impl ClassInfoTable {
         name: IdentId,
         val: Value,
     ) {
-        // Preserve the previous visibility if we're overwriting an existing
-        // entry, so that `M::X = 1; private_constant :X; M::X = 2` keeps :X
-        // private. New entries default to public via `ConstState::loaded`.
-        let prev_visibility = self[class_id]
+        // Preserve the previous visibility / deprecation flags if we're
+        // overwriting an existing entry, so that `M::X = 1;
+        // private_constant :X; M::X = 2` keeps :X private (and likewise
+        // for `deprecate_constant`). New entries default to public and
+        // non-deprecated via `ConstState::loaded`.
+        let (prev_visibility, prev_deprecated) = self[class_id]
             .constants
             .get(&name)
-            .map(|s| s.visibility);
+            .map(|s| (Some(s.visibility), s.deprecated))
+            .unwrap_or((None, false));
         let mut new_state = ConstState::loaded(val);
         if let Some(vis) = prev_visibility {
             new_state.visibility = vis;
         }
+        new_state.deprecated = prev_deprecated;
         let prev = self[class_id].constants.insert(name, new_state);
         if prev.as_ref().is_some_and(|s| s.is_loaded())
             && WARNING.load(std::sync::atomic::Ordering::Relaxed) >= 1

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -247,6 +247,10 @@ impl IdentId {
     pub const SINGLETON_METHOD_UNDEFINED: IdentId = id!(73);
     pub const TO_INT: IdentId = id!(74);
     pub const TO_F: IdentId = id!(75);
+    pub const INITIALIZE_COPY: IdentId = id!(76);
+    pub const INITIALIZE_CLONE: IdentId = id!(77);
+    pub const INITIALIZE_DUP: IdentId = id!(78);
+    pub const RESPOND_TO_MISSING_: IdentId = id!(79);
 }
 
 impl IdentId {
@@ -437,6 +441,10 @@ impl IdentifierTable {
         table.set_id("singleton_method_undefined", IdentId::SINGLETON_METHOD_UNDEFINED);
         table.set_id("to_int", IdentId::TO_INT);
         table.set_id("to_f", IdentId::TO_F);
+        table.set_id("initialize_copy", IdentId::INITIALIZE_COPY);
+        table.set_id("initialize_clone", IdentId::INITIALIZE_CLONE);
+        table.set_id("initialize_dup", IdentId::INITIALIZE_DUP);
+        table.set_id("respond_to_missing?", IdentId::RESPOND_TO_MISSING_);
         table
     }
 

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1249,6 +1249,91 @@ pub(crate) fn emit_chilled_string_mutation_warning(
 }
 
 ///
+/// Emit a `warning: <msg>` line on Ruby-level `$stderr`. Used by
+/// builtins that need to surface verbose-only warnings (e.g.
+/// `Module#attr` with a boolean argument). The caller is responsible
+/// for the `$VERBOSE`/`Warning[:...]` gating; this helper just formats
+/// the message and writes it through `$stderr.write` so mspec's
+/// `should complain` matcher catches the output.
+///
+pub(crate) fn emit_verbose_warning(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    msg: &str,
+) -> Result<()> {
+    let stderr = globals
+        .get_gvar(IdentId::get_id("$stderr"))
+        .unwrap_or(Value::nil());
+    if stderr.is_nil() {
+        return Ok(());
+    }
+    let line = format!("warning: {msg}\n");
+    let msg_val = Value::string(line);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("write"),
+        stderr,
+        &[msg_val],
+        None,
+        None,
+    )?;
+    Ok(())
+}
+
+///
+/// Emit the CRuby-compatible "constant ... is deprecated" warning when
+/// reading a constant marked via `Module#deprecate_constant`. Gated by
+/// `Warning[:deprecated]`; writes to Ruby-level `$stderr` so mspec's
+/// `should complain` matcher captures it. `qualified_name` is the full
+/// `OwnerName::ConstantName` path that CRuby includes in the message.
+///
+pub(crate) fn emit_deprecated_constant_warning(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    qualified_name: &str,
+) -> Result<()> {
+    // Check Warning[:deprecated]. If the Warning module isn't loaded
+    // yet (during bootstrap) we silently skip — CRuby behaves the same.
+    let warning_val = match globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Warning"))
+    {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
+    let dep = vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("[]"),
+        warning_val,
+        &[dep_sym],
+        None,
+        None,
+    )?;
+    if dep.is_nil() || dep == Value::bool(false) {
+        return Ok(());
+    }
+
+    let msg = format!("warning: constant {qualified_name} is deprecated\n");
+    let stderr = globals
+        .get_gvar(IdentId::get_id("$stderr"))
+        .unwrap_or(Value::nil());
+    if stderr.is_nil() {
+        return Ok(());
+    }
+    let msg_val = Value::string(msg);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("write"),
+        stderr,
+        &[msg_val],
+        None,
+        None,
+    )?;
+    Ok(())
+}
+
+///
 /// Render a symbol as its Ruby inspect form (`:name` or `:"escaped name"`).
 ///
 /// Simple names — identifiers, operators, `$gv`/`@iv`/`@@cv` — are emitted


### PR DESCRIPTION
## Summary

Five small, independent fixes that together reduce `core/module` ruby/spec failures from **210 (81 FAIL + 129 ERROR)** to **196 (67 + 129)** — 14 fewer issues with no regressions.

### 1. `Module#deprecate_constant` — full implementation (5 fixes)

- Adds a `deprecated: bool` slot to `ConstState`, preserved across constant re-assignment (mirroring the existing visibility flag).
- Replaces the no-op Ruby stub with a Rust builtin that validates each argument and raises `NameError` for undefined names.
- Hooks `Executor::get_constant` and `Module#remove_const` to emit `warning: constant <Owner>::<Name> is deprecated` via `$stderr.write`, gated by `Warning[:deprecated]`. New helper `value::emit_deprecated_constant_warning` follows the same pattern as the existing chilled-string deprecation helper.

### 2. `Module#ruby2_keywords` — argument validation (2 fixes)

The flag mechanism itself remains unimplemented (monoruby doesn't track per-Hash ruby2_keywords markers), but the no-op stub now raises:
- `TypeError` for non-Symbol/String arguments
- `NameError` for method names that don't exist on the receiver

### 3. `Module#define_method` — visibility inheritance (4 fixes)

- When called from inside the receiver's own lexical body, the new method picks up the current `private`/`protected`/`public` modifier instead of always being public.
- Cross-class `klass.send(:define_method, ...)` still installs `Public` (matches CRuby's rule about cross-module dispatch).
- `:initialize`, `:initialize_copy`, `:initialize_clone`, `:initialize_dup`, `respond_to_missing?` are forced `Private` regardless of the calling context — CRuby's "special private names" rule.

### 4. `Module#define_method` — FrozenError on frozen receiver (1 fix)

`define_method` now raises `FrozenError` when the receiver is frozen, matching the contract for module-mutating methods.

### 5. `Module#attr` — boolean argument warning (1 fix)

When the legacy `attr name, true|false` form is used and `$VERBOSE == true`, emits `warning: boolean argument is obsoleted`. New helper `value::emit_verbose_warning` for the `$VERBOSE`-gated channel.

## Verification

- `cargo test --release --lib 'builtins::module'` — **142/142 pass** (was 127, +15 new tests covering each fix)
- `cargo test --release --test method_call` — 63/63 pass
- `cargo test --release --test class_chain` — 2/2 pass
- `core/module` ruby/spec: 210 → 196 failures+errors (no new regressions)

## Test plan

- [x] Run `cargo test --release --lib 'builtins::module'`
- [x] Run `core/module` ruby/spec against monoruby
- [x] Verify each Quick win individually with `mspec run <file> -t monoruby`

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_