### PR TITLE
Invoke const_missing on failed constant lookup

### DIFF
--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -757,14 +757,14 @@ impl Executor {
             {
                 check_constant_visibility(globals, defining, constant)?;
             }
-            let (val, _) = self.get_constant_superclass_with_class(globals, module, constant)?;
+            let val = self.get_qualified_constant_with_missing(globals, module, constant)?;
             parent = val.expect_class_or_module(&globals.store)?.id();
         }
         let module = globals[parent].get_module();
         if let Some(defining) = Self::probe_constant_superclass_with_class(globals, module, name) {
             check_constant_visibility(globals, defining, name)?;
         }
-        let (v, _) = self.get_constant_superclass_with_class(globals, module, name)?;
+        let v = self.get_qualified_constant_with_missing(globals, module, name)?;
         Ok((v, base))
     }
 

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -186,6 +186,18 @@ impl Executor {
         if let Some(v) = self.get_constant_superclass(globals, module, name)? {
             return Ok(v);
         }
+        self.invoke_const_missing(globals, module, name)
+    }
+
+    /// Invoke `module.const_missing(name)` and rewrap a NameError so its
+    /// `name` attribute is preserved across `raise ex_obj` (which otherwise
+    /// rebuilds the error and drops the constructor-set name).
+    fn invoke_const_missing(
+        &mut self,
+        globals: &mut Globals,
+        module: Module,
+        name: IdentId,
+    ) -> Result<Value> {
         match self.invoke_method_inner(
             globals,
             IdentId::get_id("const_missing"),
@@ -253,20 +265,7 @@ impl Executor {
         // resolve the reference. The default `Module#const_missing` raises
         // NameError, preserving the previous behaviour for classes without
         // a custom hook.
-        match self.invoke_method_inner(
-            globals,
-            IdentId::get_id("const_missing"),
-            module.as_val(),
-            &[Value::symbol(name)],
-            None,
-            None,
-        ) {
-            Ok(v) => Ok(v),
-            Err(e) if matches!(e.kind, MonorubyErrKind::Name(_)) => {
-                Err(MonorubyErr::nameerr_with_name(e.message, name))
-            }
-            Err(e) => Err(e),
-        }
+        self.invoke_const_missing(globals, module, name)
     }
 
     /// Non-triggering probe of a constant directly on `class_id` —

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -174,6 +174,34 @@ impl Executor {
         Err(MonorubyErr::uninitialized_constant(name))
     }
 
+    /// Walk the ancestor chain of *module* to find *name*; if missing, fall
+    /// back to `module.const_missing(name)` so user-defined hooks fire for
+    /// qualified `Foo::Bar` access (matching CRuby's `rb_const_get`).
+    pub(crate) fn get_qualified_constant_with_missing(
+        &mut self,
+        globals: &mut Globals,
+        module: Module,
+        name: IdentId,
+    ) -> Result<Value> {
+        if let Some(v) = self.get_constant_superclass(globals, module, name)? {
+            return Ok(v);
+        }
+        match self.invoke_method_inner(
+            globals,
+            IdentId::get_id("const_missing"),
+            module.as_val(),
+            &[Value::symbol(name)],
+            None,
+            None,
+        ) {
+            Ok(v) => Ok(v),
+            Err(e) if matches!(e.kind, MonorubyErrKind::Name(_)) => {
+                Err(MonorubyErr::nameerr_with_name(e.message, name))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     pub(super) fn search_constant_checked(
         &mut self,
         globals: &mut Globals,
@@ -219,7 +247,26 @@ impl Executor {
                 }
             }
         }
-        Err(MonorubyErr::uninitialized_constant(name))
+        // CRuby invokes `const_missing` on the innermost lexical class when
+        // unqualified constant lookup fails; user-defined hooks (e.g.
+        // `Delegator.const_missing` delegating to `::Object.const_get`) can
+        // resolve the reference. The default `Module#const_missing` raises
+        // NameError, preserving the previous behaviour for classes without
+        // a custom hook.
+        match self.invoke_method_inner(
+            globals,
+            IdentId::get_id("const_missing"),
+            module.as_val(),
+            &[Value::symbol(name)],
+            None,
+            None,
+        ) {
+            Ok(v) => Ok(v),
+            Err(e) if matches!(e.kind, MonorubyErrKind::Name(_)) => {
+                Err(MonorubyErr::nameerr_with_name(e.message, name))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Non-triggering probe of a constant directly on `class_id` —


### PR DESCRIPTION
## Summary

- CRuby's `rb_const_get` falls through to `const_missing` on the innermost lexical class (unqualified) or on the receiver (qualified `Foo::Bar`) before raising NameError. monoruby was raising directly, so user-defined hooks like `Delegator.const_missing` (defined in `delegate.rb` to delegate to `::Object.const_get`) never fired.
- This surfaced as `require "active_record"` failing on `class Delegator; include ActiveSupport::Tryable; end` — `Delegator < BasicObject` has no `Object` in its ancestor chain, so without `const_missing` the unqualified `ActiveSupport` reference goes unresolved.
- Wire the fallback in two places:
  - `search_constant_checked` (unqualified): after the lexical-stack and ancestor-chain walks miss, invoke `const_missing` on the innermost lexical class. The default `Module#const_missing` raises NameError, so behaviour is unchanged for classes without a custom hook.
  - `find_constant` qualified path: route both intermediate `Foo::Bar` and final-segment lookups through a new `get_qualified_constant_with_missing` helper that falls back to `module.const_missing(name)` on a miss. `Module#const_get`'s `lookup_constant_path` keeps using the bare ancestor walk so its own top-level `const_missing` invocation isn't doubled.
- NameError raised from a custom `const_missing` is rewrapped with `nameerr_with_name(name)` so `e.name` survives the `raise ex_obj` round-trip, matching the existing `Module#const_get` fallback.

## Test plan

- [x] `class Foo < BasicObject; def self.const_missing(n); ::Object.const_get(n); end; end; class Foo; Module; end` now resolves `Module` (previously NameError); CRuby parity confirmed.
- [x] `Foo::Bar` triggers `Foo.const_missing(:Bar)` when `Bar` is missing; CRuby parity confirmed.
- [x] Chained `MultiSeg::Bar::Baz` (where `Bar` and `Baz` both go through `const_missing`) matches CRuby.
- [x] Without a custom `const_missing`, the missing-constant case still raises NameError with the same wording as before / as CRuby (e.g. `class Foo; TOP_CONST; end` where `TOP_CONST` isn't reachable).
- [x] autoload-defined constants still resolve.
- [x] `cargo nextest run -E 'test(/const/) | test(/module/) | test(/autoload/) | test(/class/)'`: `337 passed, 29 failed, 1952 skipped` — identical totals before and after the change (the 29 failures are pre-existing on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)