### PR TITLE
JIT: don't const-fold yield return when block has rescue/ensure

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -623,6 +623,19 @@ impl<'a> JitContext<'a> {
         let mut return_context = frame.detach_return_context();
         let return_state = return_context.remove(&pos);
         self.merge_return_context(return_context);
+        // If the iseq has rescue/ensure handlers, the abstract
+        // interpreter's BB graph doesn't include the rescue PCs as
+        // successors, so the computed return state only reflects the
+        // happy path. Letting Const-folding fire (or letting the
+        // Const ret survive into `def_rax2acc_return`) would
+        // overwrite the rescue path's actual return value with the
+        // happy-path constant. See issue #405.
+        let return_state = return_state.map(|mut s| {
+            if self.store[iseq_id].has_exception_handler() {
+                s.taint_for_unmodeled_rescue();
+            }
+            s
+        });
         if let Some(result) = &return_state {
             if let Some(v) = result.const_folded() {
                 #[cfg(feature = "jit-debug")]
@@ -949,5 +962,99 @@ impl AbstractState {
             ir.push(AsmInst::SetArguments { callid, callee_fid });
             ir.handle_error(error);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    /// Regression test for issue #405. After JIT compilation of a block
+    /// passed to `Array#map`, calls inside the block that raise and are
+    /// caught by an inner `rescue` used to silently take the happy path's
+    /// return value: the abstract interpreter never visited the rescue BB
+    /// (no incoming edge), so the block's return state collapsed to
+    /// `Const(<happy-path literal>)`, which `def_rax2acc_return` then wrote
+    /// directly into the destination slot — discarding the actual `rax`
+    /// produced by the rescue path.
+    ///
+    /// Each subtest below exercises a different "happy path" return shape
+    /// (literal symbol, `nil`, different class) and confirms the rescue
+    /// path's value reaches the caller after the JIT compiles the block.
+    #[test]
+    fn rescue_inside_map_block_returns_rescue_value() {
+        run_test(
+            r#"
+            def boom; raise "no"; end
+            def test; [1].map { begin; boom; :no_rescue; rescue; :rescued; end }; end
+            30.times { test }
+            test
+            "#,
+        );
+    }
+
+    #[test]
+    fn rescue_inside_map_block_with_nil_happy_path() {
+        run_test(
+            r#"
+            def boom; raise "no"; end
+            def test; [1].map { begin; boom; nil; rescue; :rescued; end }; end
+            30.times { test }
+            test
+            "#,
+        );
+    }
+
+    #[test]
+    fn rescue_inside_map_block_different_classes() {
+        // Happy path returns Symbol; rescue returns String. The pre-fix
+        // bug also baked in the Symbol's class, so even with a Value
+        // fallback we want to confirm the actual rescue String comes back.
+        run_test(
+            r#"
+            def boom; raise "no"; end
+            def test; [1].map { begin; boom; :sym_path; rescue; "string_path"; end }; end
+            30.times { test }
+            test
+            "#,
+        );
+    }
+
+    #[test]
+    fn rescue_inside_select_block_uses_rescue_value() {
+        // `select` keeps elements whose block returns truthy. Pre-fix the
+        // baked-in `true` from the happy path made `select` keep the
+        // element even though the rescue returned `false`.
+        run_test(
+            r#"
+            def boom; raise "no"; end
+            def test; [1].select { begin; boom; true; rescue; false; end }; end
+            30.times { test }
+            test
+            "#,
+        );
+    }
+
+    #[test]
+    fn rescue_inside_map_block_typeerror_dispatch() {
+        // The original surfacing case from PR #404: dispatching multiple
+        // values into a builtin that may raise TypeError, and rescuing the
+        // TypeError inside the .map block.
+        run_test(
+            r#"
+            def t(x)
+              [x].map do |v|
+                begin
+                  Signal.signame(v)
+                  :ok
+                rescue TypeError
+                  :typeerr
+                end
+              end
+            end
+            30.times { t("hello"); t(:HUP); t(nil); t(0) }
+            [t("hello"), t(:HUP), t(nil), t(0)]
+            "#,
+        );
     }
 }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -405,6 +405,16 @@ impl ReturnState {
         self.invariants.side_effect_guard = false;
     }
 
+    /// Forget what the abstract interpreter inferred about the return
+    /// value and side effects. Used when the iseq has rescue/ensure
+    /// handlers that the BB graph doesn't model — the actual return
+    /// could come from any rescue path the interpreter never visited
+    /// (see issue #405).
+    pub(in crate::codegen::jitgen) fn taint_for_unmodeled_rescue(&mut self) {
+        self.ret = ReturnValue::Value;
+        self.invariants.side_effect_guard = false;
+    }
+
     fn return_class(&self) -> Option<ClassId> {
         match self.ret {
             ReturnValue::Const(v) => Some(v.class()),
@@ -465,7 +475,13 @@ struct Invariants {
 
 impl Invariants {
     fn new_entry(cc: &JitContext) -> Self {
-        let side_effect_guard = cc.iseq().no_ensure();
+        // `rescue` is also a control-flow side effect: an exception
+        // raised in the protected range diverts control to the rescue
+        // body, which the abstract interpreter doesn't model (its BB
+        // graph has no edge into the rescue handler). Treat any
+        // exception handler — `rescue` or `ensure` — as breaking the
+        // side-effect guard. See issue #405.
+        let side_effect_guard = !cc.iseq().has_exception_handler();
         Self {
             class_version_guard: false,
             no_capture_guard: true,
@@ -483,7 +499,9 @@ impl Invariants {
     }
 
     fn new_specialized(cc: &JitContext) -> Self {
-        let side_effect_guard = cc.iseq().no_ensure();
+        // See `new_entry` for why we widen the guard from `no_ensure`
+        // to `!has_exception_handler` (issue #405).
+        let side_effect_guard = !cc.iseq().has_exception_handler();
         Self {
             class_version_guard: false,
             // specialized methods and blocks are always guarded frame capture.
@@ -496,5 +514,68 @@ impl Invariants {
         self.class_version_guard &= other.class_version_guard;
         self.no_capture_guard &= other.no_capture_guard;
         self.side_effect_guard &= other.side_effect_guard;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::Immediate;
+
+    /// `taint_for_unmodeled_rescue` must downgrade `Const`/`Class` to
+    /// `Value` so `def_rax2acc_return` falls into the `ReturnValue::Value`
+    /// branch and uses `rax`, AND clear `side_effect_guard` so the earlier
+    /// `const_folded()` short-circuit cannot fire either. Both halves are
+    /// load-bearing for the issue #405 fix.
+    #[test]
+    fn taint_for_unmodeled_rescue_drops_const_and_side_effect_guard() {
+        let mut s = ReturnState {
+            ret: ReturnValue::Const(Immediate::nil()),
+            invariants: Invariants {
+                class_version_guard: true,
+                no_capture_guard: true,
+                side_effect_guard: true,
+            },
+        };
+        // Pre-condition: const-folding would fire.
+        assert!(s.const_folded().is_some());
+        s.taint_for_unmodeled_rescue();
+        // Post-condition: ret is `Value` and const-folding is suppressed.
+        assert!(matches!(s.ret, ReturnValue::Value));
+        assert!(!s.invariants.side_effect_guard);
+        assert!(s.const_folded().is_none());
+    }
+
+    /// `Class(c)` is also unsafe — the rescue path may return a different
+    /// class — so it must be downgraded to `Value` too.
+    #[test]
+    fn taint_for_unmodeled_rescue_downgrades_class() {
+        let mut s = ReturnState {
+            ret: ReturnValue::Class(crate::SYMBOL_CLASS),
+            invariants: Invariants {
+                class_version_guard: true,
+                no_capture_guard: true,
+                side_effect_guard: true,
+            },
+        };
+        s.taint_for_unmodeled_rescue();
+        assert!(matches!(s.ret, ReturnValue::Value));
+    }
+
+    /// Already-tainted (`Value` ret with cleared side-effect guard) is a
+    /// fixed point — the helper is idempotent.
+    #[test]
+    fn taint_for_unmodeled_rescue_is_idempotent() {
+        let mut s = ReturnState {
+            ret: ReturnValue::Value,
+            invariants: Invariants {
+                class_version_guard: true,
+                no_capture_guard: true,
+                side_effect_guard: false,
+            },
+        };
+        s.taint_for_unmodeled_rescue();
+        assert!(matches!(s.ret, ReturnValue::Value));
+        assert!(!s.invariants.side_effect_guard);
     }
 }

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -414,8 +414,8 @@ impl ISeqInfo {
             .push(ExceptionMapEntry::new(range, rescue, ensure, err_reg));
     }
 
-    pub(crate) fn no_ensure(&self) -> bool {
-        self.exception_map.iter().all(|map| map.ensure_pc.is_none())
+    pub(crate) fn has_exception_handler(&self) -> bool {
+        !self.exception_map.is_empty()
     }
 
     #[cfg(feature = "emit-bc")]


### PR DESCRIPTION
Fixes #405.

## Root cause

`BasicBlockInfo::new` builds the BB graph from explicit branch instructions only — the exception_table's rescue PCs are never wired as successors. Rescue handlers therefore have zero predecessors and are unreachable from the abstract interpreter's BB walk.

For a block like

\`\`\`ruby
[1].map { begin; raise; :no_rescue; rescue; :rescued; end }
\`\`\`

the abstract interpreter sees only the happy path and concludes the block returns \`Const(:no_rescue)\`. \`def_rax2acc_return\` then writes that constant into the destination slot at the SpecializedYield call site — discarding the actual \`:rescued\` produced by the rescue path in \`rax\`. After ~20 iterations the JIT compiles the block and the caller silently observes the wrong value.

## Approach

Per the discussion in #405, properly modelling rescue/ensure edges in the BB graph is intricate (ensure interactions, multiple handlers, partial coverage of the protected range). The conservative fix here is to give up on the optimisation when the iseq has any exception handler.

### Changes

- **\`compile_specialized_func\`** taints the computed \`return_state\` via the new \`ReturnState::taint_for_unmodeled_rescue\` whenever the iseq has a non-empty exception_map. Taint forces \`ret = Value\` (so \`def_rax2acc_return\` reads \`rax\` instead of baking in the constant) and clears \`side_effect_guard\` (so the earlier \`const_folded()\` short-circuit cannot fire either).
- **\`Invariants::new_entry\` / \`new_specialized\`** seed \`side_effect_guard\` from \`!has_exception_handler()\` instead of \`no_ensure()\`. \`rescue\` is a control-flow side effect too, not just \`ensure\`. The narrower \`no_ensure\` helper is unused after this and is removed.
- **\`ISeqInfo::has_exception_handler\`** added — trivial \`!exception_map.is_empty()\` accessor (replaces \`no_ensure\` at all call sites).

## Tests

- 5 end-to-end regression tests in \`compile/method_call.rs\` cover the original repro plus shape variants:
  - \`rescue_inside_map_block_returns_rescue_value\` — the original repro.
  - \`rescue_inside_map_block_with_nil_happy_path\` — \`nil\` constant happy path.
  - \`rescue_inside_map_block_different_classes\` — Symbol vs String across paths.
  - \`rescue_inside_select_block_uses_rescue_value\` — \`select { ... rescue false }\`.
  - \`rescue_inside_map_block_typeerror_dispatch\` — the Signal.signame TypeError case from PR #404.
- 3 unit tests in \`state.rs\` lock down \`taint_for_unmodeled_rescue\`'s contract: drops \`Const\`, downgrades \`Class\`, idempotent on already-tainted state.

## Test plan

- [x] \`cargo test --release -p monoruby --lib --no-fail-fast\` → 1695/1695 pass, 0 failures.
- [x] \`cargo test --release -p monoruby --lib -- codegen::jitgen\` → 23/23 pass (15 pre-existing + 5 new e2e + 3 new unit).
- [x] Original repro from #405 — \`[1].map { begin; raise; :no_rescue; rescue; :rescued; end }\` returns \`[:rescued]\` consistently across all 20 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)