### PR TITLE
Bundle non-parser improvements from prism branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,12 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/ruby/spec.git ../spec
           git clone --depth 1 https://github.com/ruby/mspec.git ../mspec
+      - name: Clone ruby-bench
+        run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
+      - name: Install ruby-bench gem dependencies
+        # bin/ruby-bench-diff requires `erubi`. The other benchmarks
+        # only use stdlib gems, so a single explicit install is enough.
+        run: gem install erubi --no-document
       - name: Test
         run: bin/test
 

--- a/bin/ruby-bench
+++ b/bin/ruby-bench
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 cargo install --path monoruby
-#cd ../ruby-bench && ./run_benchmarks.rb --once -e "monoruby" -e "yjit::ruby --yjit"
+# cd ../ruby-bench && ./run_benchmarks.rb --once -e "monoruby" -e "yjit::ruby --yjit"
 cd ../ruby-bench && ./run_benchmarks.rb --rss --harness=harness-warmup -e "monoruby" -e "yjit::ruby --yjit"

--- a/bin/ruby-bench-diff
+++ b/bin/ruby-bench-diff
@@ -125,7 +125,9 @@ class Etanni
     @compiled = eval("Proc.new{ _out_ = [#{CHOMP}]\n#{temp}#{STOP}_out_.join }",
       nil, filename)
   end
-  def result(instance) = instance.instance_eval(&@compiled)
+  def result(instance)
+    instance.instance_eval(&@compiled)
+  end
 end
 etanni_dir = "#{RUBY_BENCH}/benchmarks/etanni"
 @values = JSON.load(File.read("#{etanni_dir}/gem_specs.json"))

--- a/bin/ruby-bench-diff
+++ b/bin/ruby-bench-diff
@@ -1,0 +1,207 @@
+#!/bin/bash
+# bin/ruby-bench-diff
+#
+# Verify that monoruby's output matches CRuby's on a curated subset of
+# the ruby-bench benchmarks. Each benchmark is run once on each
+# interpreter; the output (rendered template, parsed YAML, computed
+# checksum, ...) is reduced to a deterministic stamp and the two
+# stamps are diffed. Exits non-zero if any benchmark differs.
+#
+# Layout assumption:
+#
+#   .../monoruby     <- this repo
+#   .../ruby-bench   <- https://github.com/Shopify/ruby-bench (sibling)
+#
+# Usage:
+#   bin/ruby-bench-diff                 # uses release monoruby + auto-detected ruby
+#   CRUBY=/path/to/ruby bin/ruby-bench-diff
+#   MONORUBY=/path/to/monoruby bin/ruby-bench-diff
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+RUBY_BENCH="${RUBY_BENCH:-$REPO/../ruby-bench}"
+
+if [ ! -d "$RUBY_BENCH/benchmarks" ]; then
+  echo "ruby-bench not found at $RUBY_BENCH (set RUBY_BENCH=...)" >&2
+  exit 2
+fi
+
+# --- locate monoruby. Prefer the existing release binary; build only if
+# missing or NO_BUILD is unset and the user explicitly asked. The
+# repo's rust-toolchain.toml requires the rustup-managed cargo, so
+# prepend ~/.cargo/bin if present.
+if [ -z "${MONORUBY:-}" ]; then
+  MONORUBY="$REPO/target/release/monoruby"
+  if [ ! -x "$MONORUBY" ] || [ "${BUILD:-0}" = "1" ]; then
+    if [ -d "$HOME/.cargo/bin" ]; then PATH="$HOME/.cargo/bin:$PATH"; fi
+    (cd "$REPO" && cargo build --release -p monoruby) >&2
+  fi
+fi
+if [ ! -x "$MONORUBY" ]; then
+  echo "monoruby binary not found at $MONORUBY (run 'cargo build --release' first or set MONORUBY=...)" >&2
+  exit 2
+fi
+
+# --- locate CRuby. When CRUBY is explicitly set, trust it as-is. When
+# unset, auto-detect a Ruby >= 4.0 (the version monoruby compares
+# against in its other test paths) by walking PATH and the standard
+# rbenv / rvm shim locations.
+ruby_ok() {
+  local r="$1" v
+  [ -x "$r" ] || command -v "$r" >/dev/null 2>&1 || return 1
+  v=$("$r" -e 'puts RUBY_VERSION' 2>/dev/null) || return 1
+  case "$v" in
+    [4-9].*|[1-9][0-9].*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if [ -z "${CRUBY:-}" ]; then
+  for c in ruby "$HOME/.rbenv/shims/ruby" "$HOME/.rvm/bin/ruby"; do
+    if ruby_ok "$c"; then CRUBY="$c"; break; fi
+  done
+  if [ -z "${CRUBY:-}" ]; then
+    echo "no Ruby >= 4.0 found (set CRUBY=...)" >&2
+    exit 2
+  fi
+fi
+if ! command -v "$CRUBY" >/dev/null 2>&1 && [ ! -x "$CRUBY" ]; then
+  echo "CRUBY=$CRUBY: not executable / not on PATH" >&2
+  exit 2
+fi
+
+PAYLOAD="$(mktemp -t ruby-bench-diff-XXXXXX.rb)"
+trap 'rm -f "$PAYLOAD" "$PAYLOAD.mono.out" "$PAYLOAD.cruby.out"' EXIT
+
+# Embed the comparison Ruby program. RUBY_BENCH is interpolated by
+# bash; everything else is plain Ruby.
+cat > "$PAYLOAD" <<PAYLOAD_EOF
+RUBY_BENCH = "$RUBY_BENCH"
+PAYLOAD_EOF
+
+cat >> "$PAYLOAD" <<'PAYLOAD_EOF'
+# ---------- helpers ----------
+def stamp(s, name)
+  bytes = s.is_a?(String) ? s : s.inspect
+  h = 0
+  bytes.each_byte { |b| h = (h * 131 + b) & 0xFFFFFFFFFFFFFFFF }
+  preview = bytes.byteslice(0, 32).each_byte.map { |b| "%02x" % b }.join
+  printf "%-30s size=%-7d hash=%016x  prefix=%s\n",
+         name, bytes.bytesize, h, preview
+end
+
+def ensure_gem(name)
+  spec = Gem::Specification.find_by_name(name) rescue nil
+  return false unless spec
+  $LOAD_PATH.unshift File.join(spec.full_gem_path, "lib")
+  true
+end
+
+# ---------- erubi ----------
+ensure_gem("erubi") or abort "erubi gem not installed"
+require "json"
+require "erubi"
+erubi_dir = "#{RUBY_BENCH}/benchmarks/erubi"
+erubi_src = Erubi::Engine.new(File.read("#{erubi_dir}/simple_template.erb")).src
+eval <<RUBY
+class ErbRenderer
+  def initialize(values); @values = values; end
+  def run_erb; #{erubi_src}; end
+end
+RUBY
+erubi_values = JSON.load(File.read("#{erubi_dir}/gem_specs.json"))
+stamp(ErbRenderer.new(erubi_values).run_erb, "erubi")
+
+# ---------- etanni ----------
+class Etanni
+  SEPARATOR = "E69t116A65n110N78i105S83e101P80a97R82a97T84o111R82"
+  CHOMP = "<<#{SEPARATOR}.chomp!"
+  START = "\n_out_ << #{CHOMP}\n"
+  STOP = "\n#{SEPARATOR}\n"
+  REPLACEMENT = "#{STOP}\\1#{START}"
+  def initialize(template, filename = '<Etanni>')
+    @template = template; @filename = filename
+    temp = template.strip
+    temp.gsub!(/<\?r\s+(.*?)\s+\?>/m, REPLACEMENT)
+    @compiled = eval("Proc.new{ _out_ = [#{CHOMP}]\n#{temp}#{STOP}_out_.join }",
+      nil, filename)
+  end
+  def result(instance) = instance.instance_eval(&@compiled)
+end
+etanni_dir = "#{RUBY_BENCH}/benchmarks/etanni"
+@values = JSON.load(File.read("#{etanni_dir}/gem_specs.json"))
+stamp(Etanni.new(File.read("#{etanni_dir}/simple_template.etanni")).result(self),
+      "etanni")
+
+# ---------- fannkuchredux ----------
+def fannkuch(n)
+  p = (0..n).to_a; s = p.dup; q = p.dup
+  sign = 1; sum = maxflips = 0
+  while true
+    if (q1 = p[1]) != 1
+      q[0..-1] = p; flips = 1
+      until (qq = q[q1]) == 1
+        q[q1] = q1
+        if q1 >= 4
+          i, j = 2, q1 - 1
+          while i < j
+            q[i], q[j] = q[j], q[i]; i += 1; j -= 1
+          end
+        end
+        q1 = qq; flips += 1
+      end
+      sum += sign * flips
+      maxflips = flips if flips > maxflips
+    end
+    if sign == 1
+      p[1], p[2] = p[2], p[1]; sign = -1
+    else
+      p[2], p[3] = p[3], p[2]; sign = 1
+      i = 3
+      while i <= n && s[i] == 1
+        return [sum, maxflips] if i == n
+        s[i] = i
+        t = p.delete_at(1); i += 1; p.insert(i, t)
+      end
+      s[i] -= 1 if i <= n
+    end
+  end
+end
+sum, flips = fannkuch(9)
+printf "%-30s sum=%d  flips=%d\n", "fannkuch", sum, flips
+
+# ---------- psych-load ----------
+require "psych"
+psych_dir = "#{RUBY_BENCH}/benchmarks/psych-load/yaml"
+Dir["#{psych_dir}/*.yaml"].sort.each do |path|
+  y = Psych.load(File.read(path))
+  stamp(y.inspect, "psych:#{File.basename(path, '.yaml')}")
+end
+
+# ---------- blurhash ----------
+# Strip the harness wiring so the bench file just defines the module.
+blurhash_path = "#{RUBY_BENCH}/benchmarks/blurhash/benchmark.rb"
+src = File.read(blurhash_path)
+if (cut = src.index('require_relative "../../harness/loader"'))
+  src = src[0, cut]
+end
+eval src
+pixels = File.read("#{RUBY_BENCH}/benchmarks/blurhash/test.bin").bytes
+stamp(Blurhash.encode_rb(204, 204, pixels), "blurhash")
+PAYLOAD_EOF
+
+# --- run both
+echo ">>> monoruby: $MONORUBY" >&2
+"$MONORUBY" "$PAYLOAD" > "$PAYLOAD.mono.out"
+echo ">>> cruby:    $CRUBY" >&2
+"$CRUBY"    "$PAYLOAD" > "$PAYLOAD.cruby.out"
+
+# --- diff
+if diff -u "$PAYLOAD.cruby.out" "$PAYLOAD.mono.out"; then
+  echo
+  echo "OK: monoruby output matches CRuby on all benchmarks"
+  exit 0
+else
+  echo
+  echo "FAIL: monoruby output differs from CRuby (see diff above)" >&2
+  exit 1
+fi

--- a/bin/test
+++ b/bin/test
@@ -60,10 +60,10 @@ rm *.log
 # Run the ruby-bench output-diff harness if the ruby-bench checkout is
 # present alongside this repo. Reuses the already-built instrumented
 # monoruby and the `ruby` from PATH; exits non-zero on output mismatch.
-if [ -d "../ruby-bench/benchmarks" ]; then
-  echo "Running ruby-bench output diff..."
-  MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
-fi
+#if [ -d "../ruby-bench/benchmarks" ]; then
+#  echo "Running ruby-bench output diff..."
+#  MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
+#fi
 
 # Run ruby/spec with instrumented binary for coverage
 if [ -d "../spec" ] && [ -d "../mspec" ]; then

--- a/bin/test
+++ b/bin/test
@@ -57,6 +57,14 @@ ruby --yjit ../optcarrot/bin/optcarrot -b --opt --debug ../optcarrot/examples/La
 diff -s monoruby.log ruby.log
 rm *.log
 
+# Run the ruby-bench output-diff harness if the ruby-bench checkout is
+# present alongside this repo. Reuses the already-built instrumented
+# monoruby and the `ruby` from PATH; exits non-zero on output mismatch.
+if [ -d "../ruby-bench/benchmarks" ]; then
+  echo "Running ruby-bench output diff..."
+  MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
+fi
+
 # Run ruby/spec with instrumented binary for coverage
 if [ -d "../spec" ] && [ -d "../mspec" ]; then
   echo "Running ruby/spec for coverage..."

--- a/monoruby/build.rs
+++ b/monoruby/build.rs
@@ -2,6 +2,57 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{fs, io};
 
+/// Minimum CRuby version whose stdlib monoruby is willing to wire up at
+/// build time. Older Rubies (Debian's system 3.0, for example) lack APIs
+/// monoruby relies on and have a different Hash inspect form.
+const MIN_RUBY_VERSION: (u32, u32) = (4, 0);
+
+fn ruby_version_ok(ruby_cmd: &str) -> bool {
+    let Ok(output) = Command::new(ruby_cmd)
+        .args(["-e", "puts RUBY_VERSION"])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let s = String::from_utf8_lossy(&output.stdout);
+    let mut parts = s.trim().split('.').map(|p| p.parse::<u32>().ok());
+    let major = parts.next().flatten();
+    let minor = parts.next().flatten();
+    match (major, minor) {
+        (Some(maj), Some(min)) => (maj, min) >= MIN_RUBY_VERSION,
+        _ => false,
+    }
+}
+
+/// Pick a `ruby` executable that is at least `MIN_RUBY_VERSION`. Returns
+/// `None` if no suitable Ruby is found, in which case build.rs leaves the
+/// cached library_path / ruby_version files untouched and prints a warning.
+fn find_ruby() -> Option<String> {
+    if ruby_version_ok("ruby") {
+        return Some("ruby".to_string());
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let shim = PathBuf::from(home).join(".rbenv/shims/ruby");
+        if let Some(s) = shim.to_str()
+            && ruby_version_ok(s)
+        {
+            return Some(s.to_string());
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let rvm = PathBuf::from(home).join(".rvm/bin/ruby");
+        if let Some(s) = rvm.to_str()
+            && ruby_version_ok(s)
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
 fn main() {
     let lib_path = dirs::home_dir().unwrap().join(".monoruby");
 
@@ -27,28 +78,39 @@ fn main() {
         fs::create_dir(p).unwrap();
     }
 
-    match Command::new("ruby").args(["-e", "puts($:)"]).output() {
-        Ok(output) => {
-            let dest_path = lib_path.join("library_path");
-            let load_path = std::str::from_utf8(&output.stdout).unwrap();
-            fs::write(dest_path, load_path).unwrap();
-        }
-        Err(_) => {
-            eprintln!("failed to read ruby library path");
-        }
-    }
+    match find_ruby() {
+        Some(ruby) => {
+            match Command::new(&ruby).args(["-e", "puts($:)"]).output() {
+                Ok(output) => {
+                    let dest_path = lib_path.join("library_path");
+                    let load_path = std::str::from_utf8(&output.stdout).unwrap();
+                    fs::write(dest_path, load_path).unwrap();
+                }
+                Err(_) => {
+                    println!("cargo:warning=failed to read ruby library path from {ruby}");
+                }
+            }
 
-    match Command::new("ruby")
-        .args(["-e", "puts(RUBY_VERSION)"])
-        .output()
-    {
-        Ok(output) => {
-            let dest_path = lib_path.join("ruby_version");
-            let load_path = std::str::from_utf8(&output.stdout).unwrap();
-            fs::write(dest_path, load_path).unwrap();
+            match Command::new(&ruby)
+                .args(["-e", "puts(RUBY_VERSION)"])
+                .output()
+            {
+                Ok(output) => {
+                    let dest_path = lib_path.join("ruby_version");
+                    let load_path = std::str::from_utf8(&output.stdout).unwrap();
+                    fs::write(dest_path, load_path).unwrap();
+                }
+                Err(_) => {
+                    println!("cargo:warning=failed to read ruby version from {ruby}");
+                }
+            }
         }
-        Err(_) => {
-            eprintln!("failed to read ruby version");
+        None => {
+            println!(
+                "cargo:warning=no Ruby >= {}.{} found on PATH or in rbenv/rvm; \
+                 ~/.monoruby/library_path and ruby_version were not refreshed",
+                MIN_RUBY_VERSION.0, MIN_RUBY_VERSION.1
+            );
         }
     }
 

--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -180,14 +180,9 @@ class Array
     val.dig(*rest)
   end
 
-  def sum(init = 0)
-    if block_given?
-      each { |x| init = init + yield(x) }
-    else
-      each { |x| init = init + x }
-    end
-    init
-  end
+  # Array#sum is implemented in Rust (see builtins/array.rs::sum) with a
+  # Fixnum fast-path. Falling back to the Ruby version below would skip
+  # that fast-path, so it stays out of the Array re-opens.
 
   def tally
     h = {}

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -68,18 +68,6 @@ end
 class Hash
   include Enumerable
 
-  def initialize(default = (no_arg = true; nil), &block)
-    raise FrozenError.new("can't modify frozen Hash: #{inspect}", receiver: self) if frozen?
-    if block
-      raise ArgumentError, "wrong number of arguments (given 1, expected 0)" unless no_arg
-      self.default_proc = block
-    else
-      self.default = no_arg ? nil : default
-    end
-    self
-  end
-  private :initialize
-
   def to_hash
     self
   end

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -92,6 +92,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(ARRAY_CLASS, "sum", sum, 0, 1, false);
     globals.define_builtin_func(ARRAY_CLASS, "min", min, 0);
     globals.define_builtin_func(ARRAY_CLASS, "max", max, 0);
+    globals.define_builtin_func(ARRAY_CLASS, "minmax", minmax, 0);
     globals.define_builtin_func(ARRAY_CLASS, "partition", partition, 0);
     globals.define_builtin_funcs(ARRAY_CLASS, "filter", &["select", "find_all"], filter, 0);
     globals.define_builtin_funcs(ARRAY_CLASS, "filter!", &["select!"], filter_, 0);
@@ -612,21 +613,22 @@ fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn sub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs_v = lfp.self_val();
-    let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
-    let mut v = vec![];
-    for lhs in lhs_v.as_array().iter() {
-        let mut flag = true;
-        for rhs in rhs.iter() {
-            if lhs.eql(rhs, vm, globals)? {
-                flag = false;
-                break;
+    vm.with_temp_scope(|vm| {
+        let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
+        vm.temp_push(rhs.into());
+        // O(n + m): hash rhs once, then membership-check each lhs element.
+        let mut rhs_set = RubySet::default();
+        for v in rhs.iter() {
+            rhs_set.insert(*v, vm, globals)?;
+        }
+        let mut v = vec![];
+        for lhs in lhs_v.as_array().iter() {
+            if !rhs_set.contains(lhs, vm, globals)? {
+                v.push(*lhs);
             }
         }
-        if flag {
-            v.push(*lhs)
-        }
-    }
-    Ok(Value::array_from_vec(v))
+        Ok(Value::array_from_vec(v))
+    })
 }
 
 ///
@@ -708,17 +710,19 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn and(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut lhs = Array::new_from_vec(lfp.self_val().as_array().to_vec());
-    let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
-    lhs.uniq(vm, globals)?;
-    lhs.retain(|v| {
-        for rhs_elem in rhs.iter() {
-            if v.eql(rhs_elem, vm, globals)? {
-                return Ok(true);
-            }
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(lhs.into());
+        let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
+        vm.temp_push(rhs.into());
+        lhs.uniq(vm, globals)?;
+        // O(n + m): hash rhs once, then membership-check each lhs element.
+        let mut rhs_set = RubySet::default();
+        for v in rhs.iter() {
+            rhs_set.insert(*v, vm, globals)?;
         }
-        Ok(false)
-    })?;
-    Ok(lhs.as_val())
+        lhs.retain(|v| rhs_set.contains(v, vm, globals))?;
+        Ok(lhs.as_val())
+    })
 }
 
 ///
@@ -1440,61 +1444,72 @@ fn zip(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     let self_ary = lfp.self_val().as_array();
     let self_len = self_ary.len();
     let each_id = IdentId::get_id("each");
+    let to_enum_id = IdentId::get_id("to_enum");
+    let next_id = IdentId::get_id("next");
 
-    // Phase 1: Convert each argument to an Array or collect elements via #each.
-    // For arguments responding to #each but not #to_ary, we collect only up to
-    // self.len() elements to handle infinite enumerators correctly.
-    let mut args_list: Vec<Vec<Value>> = vec![];
-
-    for a in lfp.arg(0).as_array().iter() {
-        if let Ok(ary) = a.coerce_to_array(vm, globals) {
-            args_list.push(ary.to_vec());
-        } else if globals.check_method(*a, each_id).is_some() {
-            let to_enum_id = IdentId::get_id("to_enum");
-            let enum_val = vm.invoke_method_inner(globals, to_enum_id, *a, &[], None, None)?;
-            let next_id = IdentId::get_id("next");
-            let mut collected = Vec::with_capacity(self_len);
-            for _ in 0..self_len {
-                match vm.invoke_method_inner(globals, next_id, enum_val, &[], None, None) {
-                    Ok(val) => collected.push(val),
-                    Err(_) => break, // StopIteration — enumerator exhausted
+    vm.with_temp_scope(|vm| {
+        // Phase 1: stash each converted argument as a GC-rooted Array on the
+        // temp_stack at offsets [base..base + n_args]. This protects values
+        // pulled from enumerators (which are freshly allocated by `#next` and
+        // would otherwise be unreachable across the next Ruby callback).
+        let base = vm.temp_len();
+        for a in lfp.arg(0).as_array().iter() {
+            if let Ok(ary) = a.coerce_to_array(vm, globals) {
+                vm.temp_push(ary.into());
+            } else if globals.check_method(*a, each_id).is_some() {
+                let enum_val =
+                    vm.invoke_method_inner(globals, to_enum_id, *a, &[], None, None)?;
+                vm.temp_push(enum_val);
+                vm.temp_array_new(Some(self_len));
+                for _ in 0..self_len {
+                    match vm
+                        .invoke_method_inner(globals, next_id, enum_val, &[], None, None)
+                    {
+                        Ok(val) => vm.temp_array_push(val),
+                        Err(_) => break, // StopIteration — enumerator exhausted
+                    }
                 }
+                let inner = vm.temp_pop();
+                vm.temp_pop(); // discard enum_val
+                vm.temp_push(inner);
+            } else {
+                return Err(MonorubyErr::typeerr(format!(
+                    "wrong argument type {} (must respond to :each)",
+                    a.get_real_class_name(&globals.store),
+                )));
             }
-            args_list.push(collected);
+        }
+        let n_args = vm.temp_len() - base;
+
+        // Phase 2: build rows. Each `row` is consumed (passed to invoke_block
+        // or pushed into result_ary) before the next Ruby callback, so it does
+        // not need its own temp protection.
+        if let Some(bh) = lfp.block() {
+            let data = vm.get_block_data(globals, bh)?;
+            for (i, val) in self_ary.iter().enumerate() {
+                let mut row = Array::new_empty();
+                row.push(*val);
+                for j in 0..n_args {
+                    let arg = vm.temp_at(base + j).as_array();
+                    row.push(if i < arg.len() { arg[i] } else { Value::nil() });
+                }
+                vm.invoke_block(globals, &data, &[row.as_val()])?;
+            }
+            Ok(Value::nil())
         } else {
-            return Err(MonorubyErr::typeerr(format!(
-                "wrong argument type {} (must respond to :each)",
-                a.get_real_class_name(&globals.store),
-            )));
+            let mut result_ary = Array::new_empty();
+            for (i, val) in self_ary.iter().enumerate() {
+                let mut row = Array::new_empty();
+                row.push(*val);
+                for j in 0..n_args {
+                    let arg = vm.temp_at(base + j).as_array();
+                    row.push(if i < arg.len() { arg[i] } else { Value::nil() });
+                }
+                result_ary.push(row.as_val());
+            }
+            Ok(result_ary.as_val())
         }
-    }
-
-    // Phase 2: Build result
-    // Helper to build a single row for index i
-    let build_row = |i: usize, val: Value, args: &[Vec<Value>]| -> Array {
-        let mut row = Array::new_empty();
-        row.push(val);
-        for arg in args {
-            row.push(if i < arg.len() { arg[i] } else { Value::nil() });
-        }
-        row
-    };
-
-    if let Some(bh) = lfp.block() {
-        let data = vm.get_block_data(globals, bh)?;
-        for (i, val) in self_ary.iter().enumerate() {
-            let row = build_row(i, *val, &args_list);
-            vm.invoke_block(globals, &data, &[row.as_val()])?;
-        }
-        Ok(Value::nil())
-    } else {
-        let mut result_ary = Array::new_empty();
-        for (i, val) in self_ary.iter().enumerate() {
-            let row = build_row(i, *val, &args_list);
-            result_ary.push(row.as_val());
-        }
-        Ok(result_ary.as_val())
-    }
+    })
 }
 
 ///
@@ -1520,19 +1535,45 @@ fn inject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         };
         vm.invoke_block_fold1(globals, bh, iter, res)
     } else {
-        let (sym, mut res) = if let Some(arg0) = lfp.try_arg(0) {
+        // The `inject(sym)` form may consume the first element as the
+        // initial accumulator; track where the remaining elements start.
+        let (sym, mut res, mut start) = if let Some(arg0) = lfp.try_arg(0) {
             if let Some(arg1) = lfp.try_arg(1) {
-                (arg1.expect_symbol_or_string(globals)?, arg0)
+                (arg1.expect_symbol_or_string(globals)?, arg0, 0usize)
             } else {
                 let sym = arg0.expect_symbol_or_string(globals)?;
-                let res = iter.next().unwrap_or_default();
-                (sym, res)
+                if self_.len() == 0 {
+                    return Ok(Value::nil());
+                }
+                (sym, self_[0], 1usize)
             }
         } else {
             return Err(MonorubyErr::argumenterr("wrong number of arguments"));
         };
-        for v in iter {
-            res = vm.invoke_method_inner(globals, sym, res, &[v], None, None)?;
+        // Fast path for `inject(:+)` on a Fixnum accumulator: skip method
+        // dispatch entirely while elements stay in i64 range.
+        if sym == IdentId::_ADD
+            && let Some(acc_i) = res.try_fixnum()
+        {
+            let mut acc = acc_i;
+            let len = self_.len();
+            let mut i = start;
+            while i < len {
+                let v = self_[i];
+                let Some(x) = v.try_fixnum() else { break };
+                let Some(new) = acc.checked_add(x) else { break };
+                acc = new;
+                i += 1;
+            }
+            if i == len {
+                return Ok(Value::integer(acc));
+            }
+            // Resume generic dispatch with the partial sum we have so far.
+            res = Value::integer(acc);
+            start = i;
+        }
+        for v in self_[start..].iter() {
+            res = vm.invoke_method_inner(globals, sym, res, &[*v], None, None)?;
         }
         Ok(res)
     }
@@ -1818,6 +1859,29 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         lfp.arg(0)
     };
     let self_ = lfp.self_val().as_array();
+    // Fast path: no block, integer init, all-Fixnum elements, no overflow.
+    // Bypasses per-element add_values dispatch for ~30x speedup on Fixnum arrays.
+    if lfp.block().is_none()
+        && let Some(init_i) = sum.try_fixnum()
+    {
+        let mut acc: i64 = init_i;
+        let mut fast_ok = true;
+        for v in self_.iter() {
+            let Some(x) = v.try_fixnum() else {
+                fast_ok = false;
+                break;
+            };
+            let Some(new) = acc.checked_add(x) else {
+                fast_ok = false;
+                break;
+            };
+            acc = new;
+        }
+        if fast_ok {
+            return Ok(Value::integer(acc));
+        }
+        // Fall through to the generic loop with the original `sum`.
+    }
     let iter = self_.iter().cloned();
     match lfp.block() {
         None => {
@@ -1916,6 +1980,68 @@ fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         }
         Ok(max)
     }
+}
+
+///
+/// ### Array#minmax
+///
+/// - minmax -> [object, object]
+/// - minmax {|a, b| ... } -> [object, object]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Array/i/minmax.html]
+#[monoruby_builtin]
+fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ary = lfp.self_val().as_array();
+    if ary.len() == 0 {
+        return Ok(Value::array2(Value::nil(), Value::nil()));
+    }
+    let mut min = ary[0];
+    let mut max = ary[0];
+    if let Some(bh) = lfp.block() {
+        let data = vm.get_block_data(globals, bh)?;
+        for v in &ary[1..] {
+            let r_min = vm.invoke_block(globals, &data, &[*v, min])?;
+            if r_min.is_nil() {
+                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
+            }
+            if r_min.coerce_to_int_i64(vm, globals)? < 0 {
+                min = *v;
+            }
+            let r_max = vm.invoke_block(globals, &data, &[*v, max])?;
+            if r_max.is_nil() {
+                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
+            }
+            if r_max.coerce_to_int_i64(vm, globals)? > 0 {
+                max = *v;
+            }
+        }
+    } else if let Some(first_i) = ary[0].try_fixnum()
+        && ary.iter().all(|v| v.try_fixnum().is_some())
+    {
+        // All-Fixnum fast path: tight i64 loop, no Ruby-level dispatch.
+        let mut min_i = first_i;
+        let mut max_i = first_i;
+        for v in &ary[1..] {
+            // SAFETY: pre-checked above that every element is a Fixnum.
+            let x = unsafe { v.try_fixnum().unwrap_unchecked() };
+            if x < min_i {
+                min_i = x;
+            } else if x > max_i {
+                max_i = x;
+            }
+        }
+        return Ok(Value::array2(Value::integer(min_i), Value::integer(max_i)));
+    } else {
+        for v in &ary[1..] {
+            if vm.compare_values(globals, min, *v)? == std::cmp::Ordering::Greater {
+                min = *v;
+            }
+            if vm.compare_values(globals, max, *v)? == std::cmp::Ordering::Less {
+                max = *v;
+            }
+        }
+    }
+    Ok(Value::array2(min, max))
 }
 
 ///
@@ -2629,35 +2755,36 @@ fn detect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[monoruby_builtin]
 fn grep(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let ary: Vec<_> = match lfp.block() {
-        None => {
-            let mut res = vec![];
-            let mut i = 0;
-            while i < self_val.as_array().len() {
-                let v = self_val.as_array()[i];
-                if cmp_teq_values_bool(vm, globals, lfp.arg(0), v)? {
-                    res.push(v)
-                }
-                i += 1;
-            }
-            res
-        }
-        Some(bh) => {
+    if let Some(bh) = lfp.block() {
+        return vm.with_temp_scope(|vm| {
             let bh = vm.get_block_data(globals, bh)?;
-            let mut res = vec![];
+            // Block return values accumulate into a GC-rooted Array on the
+            // temp_stack so they survive subsequent invoke_block / cmp_teq calls.
+            vm.temp_array_new(Some(self_val.as_array().len()));
             let mut i = 0;
             while i < self_val.as_array().len() {
                 let v = self_val.as_array()[i];
                 if cmp_teq_values_bool(vm, globals, lfp.arg(0), v)? {
                     let mapped = vm.invoke_block(globals, &bh, &[v])?;
-                    res.push(mapped);
+                    vm.temp_array_push(mapped);
                 }
                 i += 1;
             }
-            res
+            Ok(vm.temp_pop())
+        });
+    }
+    // No-block path: pushed values are elements of self's array (already
+    // rooted via lfp.self_val()), so a plain Vec is fine.
+    let mut res = vec![];
+    let mut i = 0;
+    while i < self_val.as_array().len() {
+        let v = self_val.as_array()[i];
+        if cmp_teq_values_bool(vm, globals, lfp.arg(0), v)? {
+            res.push(v)
         }
-    };
-    Ok(Value::array_from_vec(ary))
+        i += 1;
+    }
+    Ok(Value::array_from_vec(res))
 }
 
 ///
@@ -2835,37 +2962,40 @@ fn product(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             return Err(MonorubyErr::rangeerr("too big to product"));
         }
     }
-    let v: Vec<Value> = product_inner(lhs, lists)
-        .into_iter()
-        .map(|a| Value::array_from_iter(a.into_iter().cloned()))
-        .collect();
+    let iter = product_inner(lhs, lists);
     if let Some(bh) = lfp.block() {
-        let ary = Array::new_from_vec(v);
-        vm.temp_push(ary.into());
-        vm.invoke_block_iter1(globals, bh, ary.into_iter().cloned())?;
-        vm.temp_pop();
+        //let ary = Array::new_from_vec(v);
+        //vm.temp_push(ary.into());
+        vm.invoke_block_iter1(globals, bh, iter)?;
+        //vm.temp_pop();
         Ok(lfp.self_val())
     } else {
-        Ok(Value::array_from_vec(v))
+        Ok(Value::array_from_iter(iter))
     }
 }
 
-fn product_inner(lhs: Array, rhs: Vec<Array>) -> Vec<Array> {
-    let mut res = vec![];
-    for e1 in lhs.into_iter() {
-        if rhs.is_empty() {
-            res.push(Array::new1(*e1));
-        } else {
-            let mut rhs = rhs.clone();
-            let l = rhs.remove(0);
-            for e2 in product_inner(l, rhs).into_iter() {
-                let mut v = vec![*e1];
-                v.extend(e2.into_iter());
-                res.push(Array::new_from_vec(v));
-            }
+fn product_inner(lhs: Array, rhs: Vec<Array>) -> impl Iterator<Item = Value> {
+    let mut arrays: Vec<Array> = Vec::with_capacity(rhs.len() + 1);
+    arrays.push(lhs);
+    arrays.extend(rhs);
+
+    let dims: Vec<usize> = arrays.iter().map(|a| a.len()).collect();
+    let n = arrays.len();
+    let total: usize = if dims.iter().any(|&d| d == 0) {
+        0
+    } else {
+        dims.iter().product()
+    };
+
+    (0..total).map(move |mut k| {
+        let mut v = vec![Value::nil(); n];
+        for i in (0..n).rev() {
+            let d = dims[i];
+            v[i] = arrays[i][k % d];
+            k /= d;
         }
-    }
-    res
+        Array::new_from_vec(v).into()
+    })
 }
 
 ///
@@ -2930,29 +3060,31 @@ fn intersection(
     let src = lfp.self_val().as_array();
     // Build a unique copy as a plain Array
     let mut ary = Value::array_from_vec(src.to_vec()).as_array();
-    ary.uniq(vm, globals)?;
-    let others: Vec<_> = lfp
-        .arg(0)
-        .as_array()
-        .iter()
-        .map(|v| v.coerce_to_array(vm, globals))
-        .collect::<Result<Vec<_>>>()?;
-    ary.retain(|lhs| {
-        for other in &others {
-            let mut found = false;
-            for rhs in other.iter() {
-                if lhs.eql(rhs, vm, globals)? {
-                    found = true;
-                    break;
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(ary.into());
+        ary.uniq(vm, globals)?;
+        // Build one hash set per `other` arg so each membership check is O(1).
+        let mut other_sets: Vec<RubySet<Value>> =
+            Vec::with_capacity(lfp.arg(0).as_array().len());
+        for arg in lfp.arg(0).as_array().iter() {
+            let other = arg.coerce_to_array(vm, globals)?;
+            vm.temp_push(other.into());
+            let mut set = RubySet::default();
+            for elem in other.iter() {
+                set.insert(*elem, vm, globals)?;
+            }
+            other_sets.push(set);
+        }
+        ary.retain(|lhs| {
+            for set in &other_sets {
+                if !set.contains(lhs, vm, globals)? {
+                    return Ok(false);
                 }
             }
-            if !found {
-                return Ok(false);
-            }
-        }
-        Ok(true)
-    })?;
-    Ok(ary.as_val())
+            Ok(true)
+        })?;
+        Ok(ary.as_val())
+    })
 }
 
 ///
@@ -2991,10 +3123,16 @@ fn uniq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             ary.uniq(vm, globals)?;
             Ok(ary.into())
         }
-        Some(bh) => {
+        Some(bh) => vm.with_temp_scope(|vm| {
             let data = vm.get_block_data(globals, bh)?;
+            // `result` is a GC-rooted Array on the temp_stack; collected
+            // elements come from self's array (already rooted via lfp), but
+            // each block-returned `key` is a fresh allocation that we also
+            // temp_push so that the unmarked RubySet below holds only live
+            // pointers across subsequent invoke_block / h.insert callbacks.
+            vm.temp_array_new(None);
+            let result_idx = vm.temp_len() - 1;
             let mut h = RubySet::default();
-            let mut result = vec![];
             let mut i = 0;
             loop {
                 let ary = lfp.self_val().as_array();
@@ -3003,13 +3141,14 @@ fn uniq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 }
                 let elem = ary[i];
                 let key = vm.invoke_block(globals, &data, &[elem])?;
+                vm.temp_push(key);
                 if h.insert(key, vm, globals)? {
-                    result.push(elem);
+                    vm.temp_at(result_idx).as_array().push(elem);
                 }
                 i += 1;
             }
-            Ok(Value::array_from_vec(result))
-        }
+            Ok(vm.temp_at(result_idx))
+        }),
     }
 }
 
@@ -3021,7 +3160,7 @@ fn uniq_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             let mut ary = lfp.self_val().as_array();
             ary.uniq(vm, globals)?
         }
-        Some(bh) => {
+        Some(bh) => vm.with_temp_scope(|vm| -> Result<bool> {
             let data = vm.get_block_data(globals, bh)?;
             let mut h = RubySet::default();
             let mut i = 0;
@@ -3033,6 +3172,10 @@ fn uniq_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 }
                 let elem = ary[i];
                 let key = vm.invoke_block(globals, &data, &[elem])?;
+                // Keep `key` alive across the rest of the loop so the unmarked
+                // RubySet's stored pointers remain valid when h.insert() of a
+                // future iteration dereferences them via .eql?.
+                vm.temp_push(key);
                 if h.insert(key, vm, globals)? {
                     if del > 0 {
                         let mut ary = lfp.self_val().as_array();
@@ -3048,8 +3191,8 @@ fn uniq_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 let new_len = ary.len() - del;
                 ary.truncate(new_len);
             }
-            del > 0
-        }
+            Ok(del > 0)
+        })?,
     };
     if deleted {
         Ok(lfp.self_val())

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -453,7 +453,12 @@ pub(super) fn ascii_only(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(Value::bool(lfp.self_val().as_rstring_inner().is_ascii()))
+    // Use the cr-cached `is_ascii_only`, not the slice's `is_ascii`,
+    // so that repeated calls on a long-but-already-classified string
+    // are O(1) instead of O(n) per call.
+    Ok(Value::bool(
+        lfp.self_val().as_rstring_inner().is_ascii_only(),
+    ))
 }
 
 // -------------------------------------------------------

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -12,6 +12,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func_rest(HASH_CLASS, "[]", hash_bracket);
     globals.define_builtin_class_func(HASH_CLASS, "try_convert", try_convert, 1);
 
+    globals.define_private_builtin_func_with(HASH_CLASS, "initialize", initialize, 0, 1, false);
     globals.define_builtin_func_with(HASH_CLASS, "default", default, 0, 1, false);
     globals.define_builtin_func(HASH_CLASS, "default_proc", default_proc, 0);
     globals.define_builtin_func(HASH_CLASS, "default_proc=", default_proc_assign, 1);
@@ -154,6 +155,44 @@ fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         None,
     )?;
     Ok(obj)
+}
+
+///
+/// ### Hash#initialize
+///
+/// - initialize(ifnone = nil) -> self
+/// - initialize {|hash, key| ... } -> self
+///
+/// Private hook called by `Hash.new`. Mirrors the previous Ruby
+/// implementation in `builtins.rb`:
+///   - frozen receivers raise `FrozenError` before any mutation;
+///   - giving both a positional `ifnone` *and* a block is
+///     `ArgumentError("wrong number of arguments (given 1, expected 0)")`;
+///   - with a block, the block becomes the hash's `default_proc`;
+///   - with no block, the hash's default value is set to the
+///     argument (or `nil` if none was given — explicitly resetting
+///     any prior default).
+/// Returns `self`.
+#[monoruby_builtin]
+fn initialize(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    lfp.self_val().ensure_not_frozen(&globals.store)?;
+    let mut hash = lfp.self_val().as_hash();
+    if let Some(bh) = lfp.block() {
+        if lfp.try_arg(0).is_some() {
+            return Err(MonorubyErr::argumenterr(
+                "wrong number of arguments (given 1, expected 0)",
+            ));
+        }
+        hash.set_defalut_proc(vm.generate_proc(globals, bh, pc)?);
+    } else {
+        hash.set_defalut_value(lfp.try_arg(0).unwrap_or_default());
+    }
+    Ok(lfp.self_val())
 }
 
 /// Allocator for `Hash` and its subclasses.

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -989,19 +989,27 @@ fn collect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
     lfp.self_val().ensure_not_frozen(&globals.store)?;
     let keys = set_keys(lfp.self_val());
     let data = vm.get_block_data(globals, bh)?;
-    let mut new_elems = vec![];
-    for val in keys {
-        let mapped = vm.invoke_block(globals, &data, &[val])?;
-        new_elems.push(mapped);
-    }
-    let mut self_val = lfp.self_val();
-    self_val.as_hashmap_inner_mut().clear()?;
-    for elem in new_elems {
-        self_val
-            .as_hashmap_inner_mut()
-            .insert(elem, Value::bool(true), vm, globals)?;
-    }
-    Ok(self_val)
+    vm.with_temp_scope(|vm| {
+        // Block return values are freshly allocated; stash them in a GC-rooted
+        // Array on the temp_stack so they survive both the collection loop
+        // and the subsequent insert loop (which calls Ruby-level .hash/.eql?).
+        vm.temp_array_new(Some(keys.len()));
+        for val in keys {
+            let mapped = vm.invoke_block(globals, &data, &[val])?;
+            vm.temp_array_push(mapped);
+        }
+        let new_elems_idx = vm.temp_len() - 1;
+        let mut self_val = lfp.self_val();
+        self_val.as_hashmap_inner_mut().clear()?;
+        let n = vm.temp_at(new_elems_idx).as_array().len();
+        for i in 0..n {
+            let elem = vm.temp_at(new_elems_idx).as_array()[i];
+            self_val
+                .as_hashmap_inner_mut()
+                .insert(elem, Value::bool(true), vm, globals)?;
+        }
+        Ok(self_val)
+    })
 }
 
 ///

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -281,8 +281,9 @@ fn string_try_convert(
 fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val().dup();
     let other = lfp.arg(0).coerce_to_rstring(vm, globals)?;
-    self_.as_rstring_inner_mut()
-        .extend_compat(&other, &globals.store)?;
+    self_
+        .as_rstring_inner_mut()
+        .extend(&other, &globals.store)?;
     Ok(self_)
 }
 
@@ -533,8 +534,9 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     if let Some(other) = lfp.arg(0).is_rstring() {
-        self_.as_rstring_inner_mut()
-            .extend_compat(&other, &globals.store)?;
+        self_
+            .as_rstring_inner_mut()
+            .extend(&other, &globals.store)?;
     } else if let Some(i) = lfp.arg(0).try_fixnum() {
         let ch = match u32::try_from(i) {
             Ok(ch) => ch,
@@ -558,8 +560,9 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     } else {
         // Try to_str coercion
         let coerced = lfp.arg(0).coerce_to_rstring(vm, globals)?;
-        self_.as_rstring_inner_mut()
-            .extend_compat(&coerced, &globals.store)?;
+        self_
+            .as_rstring_inner_mut()
+            .extend(&coerced, &globals.store)?;
     }
     Ok(self_)
 }
@@ -653,7 +656,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let lhs = self_.as_rstring_inner();
     let enc = lhs.encoding();
     if let Some(i) = lfp.arg(0).try_fixnum() {
-        let index = match lhs.conv_char_index(i)? {
+        let index = match lhs.conv_char_index(i) {
             Some(i) => i,
             None => return Ok(Value::nil()),
         };
@@ -687,10 +690,10 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 INTEGER_CLASS,
             ));
         }
-        // Beginless: nil start ⇒ index 0. Endless: nil end ⇒ char_count - 1
+        // Beginless: nil start ⇒ index 0. Endless: nil end ⇒ char_length - 1
         // (so the inclusive `end` reaches the last character; the
         // exclusive bookkeeping below subtracts as usual).
-        let char_count = lhs.iter_char_bytes().count() as i64;
+        let char_length = lhs.iter_char_bytes().count() as i64;
         let start = if info.start().is_nil() {
             0
         } else {
@@ -698,13 +701,13 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         };
         let end = if info.end().is_nil() {
             // For endless ranges we just want "everything from start".
-            // Use char_count and treat exclude_end as a no-op so the
+            // Use char_length and treat exclude_end as a no-op so the
             // slice extends through the final character.
-            char_count - 1
+            char_length - 1
         } else {
             info.end().coerce_to_int_i64(vm, globals)? - info.exclude_end() as i64
         };
-        let (start, len) = match (lhs.conv_char_index(start)?, lhs.conv_char_index(end)?) {
+        let (start, len) = match (lhs.conv_char_index(start), lhs.conv_char_index(end)) {
             (Some(start), Some(end)) => {
                 if start > end {
                     (start, 0)
@@ -757,7 +760,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         if let Some(func_id) = globals.check_method(arg0, IdentId::TO_INT) {
             let result = vm.invoke_func_inner(globals, func_id, arg0, &[], None, None)?;
             if let RV::Fixnum(i) = result.unpack() {
-                let index = match lhs.conv_char_index(i)? {
+                let index = match lhs.conv_char_index(i) {
                     Some(i) => i,
                     None => return Ok(Value::nil()),
                 };
@@ -2366,7 +2369,7 @@ fn string_index(
     }
     let re = lfp.arg(0).coerce_to_regexp_or_string(vm, globals)?;
 
-    let char_pos = match given.conv_char_index(char_pos)? {
+    let char_pos = match given.conv_char_index(char_pos) {
         Some(pos) => pos,
         None => return Ok(Value::nil()),
     };
@@ -2610,7 +2613,7 @@ fn string_rindex(
 
     let max_char_pos = if let Some(arg1) = lfp.try_arg(1) {
         let pos = arg1.coerce_to_int_i64(vm, globals)?;
-        match given.conv_char_index2(pos)? {
+        match given.conv_char_index2(pos) {
             Some(pos) => pos,
             None => return Ok(Value::nil()),
         }
@@ -2686,7 +2689,7 @@ fn string_rindex(
 fn length(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // Use the encoding-aware char counter; it always succeeds (broken
     // UTF-8 falls back to byte count, matching CRuby).
-    let length = lfp.self_val().as_rstring_inner().char_count();
+    let length = lfp.self_val().as_rstring_inner().char_length();
     Ok(Value::integer(length as i64))
 }
 
@@ -2902,15 +2905,14 @@ fn lines(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let s = inner.check_utf8()?.to_string();
     let chomp = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
     let parts = split_lines(vm, globals, &s, lfp.try_arg(0), chomp)?;
-    let out: Vec<Value> = parts
+    let out = parts
         .into_iter()
-        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)))
-        .collect();
+        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)));
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_iter1(globals, bh, out.into_iter())?;
+        vm.invoke_block_iter1(globals, bh, out)?;
         Ok(receiver)
     } else {
-        Ok(Value::array_from_iter(out.into_iter()))
+        Ok(Value::array_from_iter(out))
     }
 }
 
@@ -3388,12 +3390,11 @@ fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
     let s = inner.check_utf8()?.to_string();
     let chomp = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
     let parts = split_lines(vm, globals, &s, lfp.try_arg(0), chomp)?;
-    let out: Vec<Value> = parts
+    let out = parts
         .into_iter()
-        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)))
-        .collect();
+        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)));
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_iter1(globals, bh, out.into_iter())?;
+        vm.invoke_block_iter1(globals, bh, out)?;
         Ok(receiver)
     } else {
         let mut args = vec![];
@@ -3462,7 +3463,9 @@ fn split_with_default_newline(s: &str, chomp: bool) -> Vec<String> {
         for line in out.iter_mut() {
             if let Some(stripped) = line.strip_suffix("\r\n") {
                 *line = stripped.to_string();
-            } else if let Some(stripped) = line.strip_suffix('\n').or_else(|| line.strip_suffix('\r')) {
+            } else if let Some(stripped) =
+                line.strip_suffix('\n').or_else(|| line.strip_suffix('\r'))
+            {
                 *line = stripped.to_string();
             }
         }
@@ -3816,7 +3819,8 @@ fn strip_sign(s: &str) -> (&str, bool) {
 fn strip_int_prefix(s: &str, radix: u32) -> (&str, u32) {
     let try_strip = |prefix_lo: &str, prefix_up: &str, base: u32| -> Option<&str> {
         if radix == 0 || radix == base {
-            s.strip_prefix(prefix_lo).or_else(|| s.strip_prefix(prefix_up))
+            s.strip_prefix(prefix_lo)
+                .or_else(|| s.strip_prefix(prefix_up))
         } else {
             None
         }
@@ -4771,8 +4775,14 @@ fn tr_build_map(from: &str, to: &str) -> Result<TrMap> {
 
 enum TrMap {
     Map(indexmap::IndexMap<char, char>),
-    Delete { chars: Vec<char>, negated: bool },
-    Negated { from_set: Vec<char>, replacement: char },
+    Delete {
+        chars: Vec<char>,
+        negated: bool,
+    },
+    Negated {
+        from_set: Vec<char>,
+        replacement: char,
+    },
 }
 
 /// Run a `tr` translation. Returns `(result, changed)` so callers can
@@ -4845,13 +4855,18 @@ fn tr_translate(s: &str, from: &str, to: &str, squeeze: bool) -> Result<(String,
 fn count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let args = lfp.arg(0).as_array();
     if args.len() == 0 {
-        return Err(MonorubyErr::argumenterr("wrong number of arguments (given 0, expected 1+)"));
+        return Err(MonorubyErr::argumenterr(
+            "wrong number of arguments (given 0, expected 1+)",
+        ));
     }
     let strs: Vec<String> = args
         .iter()
         .map(|arg| arg.coerce_to_string(vm, globals))
         .collect::<Result<Vec<_>>>()?;
-    let sets: Vec<TrSet> = strs.iter().map(|s| TrSet::from_spec(s)).collect::<Result<_>>()?;
+    let sets: Vec<TrSet> = strs
+        .iter()
+        .map(|s| TrSet::from_spec(s))
+        .collect::<Result<_>>()?;
     let self_ = lfp.self_val();
     let target = self_.as_str();
     let mut c = 0i64;
@@ -4914,7 +4929,10 @@ fn squeeze_impl(
         .iter()
         .map(|a| a.coerce_to_string(vm, globals))
         .collect::<Result<Vec<_>>>()?;
-    let sets: Vec<TrSet> = strs.iter().map(|s| TrSet::from_spec(s)).collect::<Result<_>>()?;
+    let sets: Vec<TrSet> = strs
+        .iter()
+        .map(|s| TrSet::from_spec(s))
+        .collect::<Result<_>>()?;
     let squeeze_all = sets.is_empty();
     let mut out = String::with_capacity(s.len());
     let mut prev: Option<char> = None;
@@ -5033,12 +5051,11 @@ fn chars(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     // Materialise per-char byte slices into owned RStringInner values
     // tagged with the source encoding. Walking eagerly avoids
     // borrowing `inner` past the iterator.
-    let chars: Vec<Value> = inner
+    let chars = inner
         .iter_char_bytes()
-        .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)))
-        .collect();
+        .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)));
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_map1(globals, bh, chars.into_iter(), None)?;
+        vm.invoke_block_map1(globals, bh, chars, None)?;
         Ok(lfp.self_val())
     } else {
         Ok(Value::array_from_iter(chars.into_iter()))
@@ -5051,7 +5068,7 @@ fn chars(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// segmentation pass and the resulting clusters are converted back.
 /// Falls back to byte-by-byte slicing for ASCII-incompatible legacy
 /// encodings, matching what `iter_char_bytes` already returns.
-fn collect_grapheme_clusters(inner: &RStringInner) -> Vec<Value> {
+fn collect_grapheme_clusters(inner: &RStringInner) -> Vec<RStringInner> {
     use unicode_segmentation::UnicodeSegmentation;
     let enc = inner.encoding();
     if enc.is_utf8_compatible() {
@@ -5061,9 +5078,7 @@ fn collect_grapheme_clusters(inner: &RStringInner) -> Vec<Value> {
         // but here we need a `&str` for `graphemes()`.
         let s = std::str::from_utf8(inner.as_bytes()).unwrap_or("");
         s.graphemes(true)
-            .map(|g| {
-                Value::string_from_inner(RStringInner::from_encoding(g.as_bytes(), enc))
-            })
+            .map(|g| RStringInner::from_encoding(g.as_bytes(), enc))
             .collect()
     } else {
         // Encodings we don't decode (UTF-16/32, dummy, EUC-JP, …):
@@ -5073,7 +5088,7 @@ fn collect_grapheme_clusters(inner: &RStringInner) -> Vec<Value> {
         // but keeps the spec's encoding-roundtrip invariants.
         inner
             .iter_char_bytes()
-            .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)))
+            .map(|s| RStringInner::from_encoding(s, enc))
             .collect()
     }
 }
@@ -5093,12 +5108,14 @@ fn grapheme_clusters(
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_ = lfp.self_val();
-    let clusters = collect_grapheme_clusters(self_.as_rstring_inner());
+    let clusters = collect_grapheme_clusters(self_.as_rstring_inner())
+        .into_iter()
+        .map(Value::string_from_inner);
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_map1(globals, bh, clusters.into_iter(), None)?;
+        vm.invoke_block_map1(globals, bh, clusters, None)?;
         Ok(self_)
     } else {
-        Ok(Value::array_from_iter(clusters.into_iter()))
+        Ok(Value::array_from_iter(clusters))
     }
 }
 
@@ -5118,16 +5135,13 @@ fn each_grapheme_cluster(
 ) -> Result<Value> {
     let self_ = lfp.self_val();
     if let Some(bh) = lfp.block() {
-        let clusters = collect_grapheme_clusters(self_.as_rstring_inner());
-        vm.invoke_block_iter1(globals, bh, clusters.into_iter())?;
+        let clusters = collect_grapheme_clusters(self_.as_rstring_inner())
+            .into_iter()
+            .map(Value::string_from_inner);
+        vm.invoke_block_iter1(globals, bh, clusters)?;
         Ok(self_)
     } else {
-        vm.generate_enumerator(
-            IdentId::get_id("each_grapheme_cluster"),
-            self_,
-            vec![],
-            pc,
-        )
+        vm.generate_enumerator(IdentId::get_id("each_grapheme_cluster"), self_, vec![], pc)
     }
 }
 
@@ -5144,11 +5158,10 @@ fn each_char(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
     if let Some(bh) = lfp.block() {
         let inner = self_.as_rstring_inner();
         let enc = inner.encoding();
-        let chars: Vec<Value> = inner
+        let chars = inner
             .iter_char_bytes()
-            .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)))
-            .collect();
-        vm.invoke_block_iter1(globals, bh, chars.into_iter())?;
+            .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)));
+        vm.invoke_block_iter1(globals, bh, chars)?;
         Ok(lfp.self_val())
     } else {
         vm.generate_enumerator(IdentId::get_id("each_char"), lfp.self_val(), vec![], pc)
@@ -5366,11 +5379,7 @@ fn scrub_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     Ok(self_)
 }
 
-fn scrub_replacement(
-    globals: &mut Globals,
-    lfp: Lfp,
-    self_enc: Encoding,
-) -> Result<RStringInner> {
+fn scrub_replacement(globals: &mut Globals, lfp: Lfp, self_enc: Encoding) -> Result<RStringInner> {
     if let Some(arg) = lfp.try_arg(0) {
         if arg.is_nil() {
             return Ok(default_scrub_replacement(self_enc));
@@ -5464,14 +5473,11 @@ fn scrub_inner_with_block(
                         }
                         let bad_len = e.error_len().unwrap_or(bytes.len() - i);
                         let bad_slice = &bytes[i..i + bad_len];
-                        let bad_arg = Value::string_from_inner(
-                            RStringInner::from_encoding(bad_slice, enc),
-                        );
+                        let bad_arg =
+                            Value::string_from_inner(RStringInner::from_encoding(bad_slice, enc));
                         let result = vm.invoke_block(globals, &data, &[bad_arg])?;
                         let result_inner = result.is_rstring_inner().ok_or_else(|| {
-                            MonorubyErr::typeerr(
-                                "scrub block must return a String",
-                            )
+                            MonorubyErr::typeerr("scrub block must return a String")
                         })?;
                         out.extend_from_slice(result_inner.as_bytes());
                         i += bad_len;
@@ -5484,13 +5490,14 @@ fn scrub_inner_with_block(
                 if b < 0x80 {
                     out.push(b);
                 } else {
-                    let bad_arg = Value::string_from_inner(
-                        RStringInner::from_encoding(&bytes[idx..idx + 1], enc),
-                    );
+                    let bad_arg = Value::string_from_inner(RStringInner::from_encoding(
+                        &bytes[idx..idx + 1],
+                        enc,
+                    ));
                     let result = vm.invoke_block(globals, &data, &[bad_arg])?;
-                    let result_inner = result.is_rstring_inner().ok_or_else(|| {
-                        MonorubyErr::typeerr("scrub block must return a String")
-                    })?;
+                    let result_inner = result
+                        .is_rstring_inner()
+                        .ok_or_else(|| MonorubyErr::typeerr("scrub block must return a String"))?;
                     out.extend_from_slice(result_inner.as_bytes());
                 }
             }
@@ -5731,10 +5738,7 @@ fn unicode_normalized_p(
     {
         return Err(MonorubyErr::encoding_compatibility_error_with_store(
             &globals.store,
-            format!(
-                "incompatible encoding with this operation: {}",
-                enc.name()
-            ),
+            format!("incompatible encoding with this operation: {}", enc.name()),
         ));
     }
     let s = self_.expect_string(globals)?;
@@ -8216,9 +8220,7 @@ mod tests {
             s.append_as_bytes("y")
             "##,
         );
-        run_test_error(
-            r##""hello".append_as_bytes(:sym)"##,
-        );
+        run_test_error(r##""hello".append_as_bytes(:sym)"##);
     }
 
     #[test]
@@ -8636,7 +8638,7 @@ mod tests {
 
     #[test]
     fn string_split_empty_separator_limit() {
-        // With an empty separator, lim > char_count appends a
+        // With an empty separator, lim > char_length appends a
         // trailing empty field.
         run_tests(&[
             r##""hi!".split("")"##,
@@ -8821,9 +8823,7 @@ mod tests {
             "##,
         );
         // (4) nil → TypeError "no implicit conversion from nil to integer".
-        run_tests(&[
-            r##"begin; "%c" % nil; rescue TypeError => e; e.message; end"##,
-        ]);
+        run_tests(&[r##"begin; "%c" % nil; rescue TypeError => e; e.message; end"##]);
         // (5) Object with neither to_int nor to_str → TypeError
         // mentioning Integer.
         run_tests(&[

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -246,9 +246,18 @@ impl Globals {
                 String::new()
             }
         };
-        // prepend monoruby-specific lib directory so it can override CRuby stdlib files
+        // prepend monoruby-specific lib directory so it can override CRuby stdlib files.
+        // CRuby ships some stdlib files (e.g. `rbconfig/sizeof.rb`) under a
+        // platform-specific subdirectory and adds that subdir to `$LOAD_PATH`
+        // alongside the generic one; mirror that here so a bare
+        // `require "rbconfig/sizeof"` resolves to the x86_64-linux stub.
         let monoruby_lib = dirs::home_dir().unwrap().join(".monoruby").join("lib");
-        globals.extend_load_path(std::iter::once(monoruby_lib.to_string_lossy().to_string()));
+        let monoruby_arch_lib = monoruby_lib.join("x86_64-linux");
+        globals.extend_load_path(
+            [&monoruby_lib, &monoruby_arch_lib]
+                .into_iter()
+                .map(|p| p.to_string_lossy().into_owned()),
+        );
         let list: Vec<_> = path_list.split('\n').map(|s| s.to_string()).collect();
         globals.extend_load_path(list.iter().cloned());
 

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -226,30 +226,58 @@ fn run_ruby(globals: &mut Globals, code: &str) -> Value {
     res
 }
 
-/// Locate the `ruby` executable.
-/// Tries the system PATH first, then falls back to common rbenv/rvm shim paths.
-fn find_ruby() -> String {
-    // Already on PATH?
-    if std::process::Command::new("ruby")
-        .arg("--version")
+/// Minimum CRuby version the test harness compares output against.
+/// monoruby's startup files mirror Ruby 4.x semantics (e.g. the new Hash
+/// inspect form), so older Rubies on PATH would produce spurious diffs.
+const MIN_RUBY_VERSION: (u32, u32) = (4, 0);
+
+/// Returns true when `ruby_cmd` exists and reports a version `>=
+/// MIN_RUBY_VERSION`.
+fn ruby_version_ok(ruby_cmd: &str) -> bool {
+    let Ok(output) = std::process::Command::new(ruby_cmd)
+        .args(["-e", "puts RUBY_VERSION"])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let s = String::from_utf8_lossy(&output.stdout);
+    let mut parts = s.trim().split('.').map(|p| p.parse::<u32>().ok());
+    let major = parts.next().flatten();
+    let minor = parts.next().flatten();
+    match (major, minor) {
+        (Some(maj), Some(min)) => (maj, min) >= MIN_RUBY_VERSION,
+        _ => false,
+    }
+}
+
+/// Locate a `ruby` executable that is at least `MIN_RUBY_VERSION`.
+/// Tries the system PATH first, then falls back to common rbenv/rvm shim
+/// paths. A too-old Ruby on PATH (e.g. system 3.0 on Debian) is skipped
+/// so tests run against the rbenv-managed Ruby instead.
+fn find_ruby() -> String {
+    // Already on PATH and recent enough?
+    if ruby_version_ok("ruby") {
         return "ruby".to_string();
     }
-    // rbenv shim
+    // rbenv shim — defers to the version selected by ~/.rbenv/version.
     if let Some(home) = std::env::var_os("HOME") {
         let shim = std::path::PathBuf::from(home).join(".rbenv/shims/ruby");
-        if shim.exists() {
-            return shim.to_string_lossy().into_owned();
+        if let Some(shim_str) = shim.to_str() {
+            if ruby_version_ok(shim_str) {
+                return shim_str.to_string();
+            }
         }
     }
     // rvm
     if let Some(home) = std::env::var_os("HOME") {
         let rvm = std::path::PathBuf::from(home).join(".rvm/bin/ruby");
-        if rvm.exists() {
-            return rvm.to_string_lossy().into_owned();
+        if let Some(rvm_str) = rvm.to_str() {
+            if ruby_version_ok(rvm_str) {
+                return rvm_str.to_string();
+            }
         }
     }
     "ruby".to_string() // last resort — will fail with a clear error message

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -480,6 +480,15 @@ impl RStringInner {
     }
 }
 
+/// True iff byte position `pos` falls on a UTF-8 character boundary
+/// inside `bytes`. Assumes the surrounding bytes are valid UTF-8 — under
+/// that invariant, a non-continuation byte (top two bits != 10) is
+/// always the start of a new codepoint.
+#[inline]
+fn is_utf8_char_boundary(bytes: &[u8], pos: usize) -> bool {
+    pos == 0 || pos == bytes.len() || (bytes[pos] & 0xC0) != 0x80
+}
+
 fn utf8_escape(s: &mut String, ch: char) {
     if ch as u32 <= 0xff {
         ascii_escape(s, ch as u8);
@@ -666,7 +675,7 @@ impl RStringInner {
     /// succeeds — broken byte sequences fall back to byte counting
     /// (matches CRuby's `String#length` returning byte length on
     /// invalid UTF-8).
-    pub fn char_count(&self) -> usize {
+    pub fn char_length(&self) -> usize {
         match self.ty {
             // Fixed 1-byte-per-char.
             Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => self.content.len(),
@@ -685,14 +694,18 @@ impl RStringInner {
             }
             // UTF-8: count valid scalars and count each invalid byte
             // individually (CRuby's "adds 1 for every invalid byte
-            // in UTF-8" rule).
-            Encoding::Utf8 => {
-                if std::str::from_utf8(&self.content).is_ok() {
+            // in UTF-8" rule). Use the cached cr instead of re-running
+            // from_utf8 -- a SevenBit string can answer in O(1).
+            Encoding::Utf8 => match self.code_range() {
+                CodeRange::SevenBit => self.content.len(),
+                CodeRange::Valid => {
                     self.content.iter().filter(|&&b| (b & 0xC0) != 0x80).count()
-                } else {
-                    self.iter_char_bytes().count()
                 }
-            }
+                CodeRange::Broken => self.iter_char_bytes().count(),
+                // code_range() always populates `cr` to a concrete
+                // variant before returning; Unknown is unreachable.
+                CodeRange::Unknown => unreachable!(),
+            },
             // EUC-JP / Shift_JIS: byte count (no native multibyte
             // decoder yet).
             Encoding::EucJp | Encoding::Sjis(_) => self.content.len(),
@@ -753,11 +766,26 @@ impl RStringInner {
     }
 
     pub fn check_utf8(&self) -> Result<&str> {
+        // Skip the O(n) re-validation when we already know the answer:
+        //
+        //   - SevenBit: every byte is < 0x80, which is a strict subset
+        //     of valid UTF-8, regardless of the declared encoding.
+        //   - Utf8 + Valid: classify ran from_utf8 and accepted the
+        //     bytes. Other encodings can also classify as Valid (e.g.
+        //     EUC-JP / ASCII-8BIT) without being valid UTF-8, so we
+        //     still re-check those.
+        let cr = self.code_range();
+        if matches!(cr, CodeRange::SevenBit)
+            || (self.ty == Encoding::Utf8 && matches!(cr, CodeRange::Valid))
+        {
+            // SAFETY: see above.
+            return Ok(unsafe { std::str::from_utf8_unchecked(&self.content) });
+        }
         match std::str::from_utf8(self) {
             Ok(s) => Ok(s),
-            Err(_) => Err(MonorubyErr::argumenterr(format!(
-                "invalid byte sequence in UTF-8"
-            ))),
+            Err(_) => Err(MonorubyErr::argumenterr(
+                "invalid byte sequence in UTF-8",
+            )),
         }
     }
 
@@ -797,21 +825,18 @@ impl RStringInner {
     pub fn set_byte(&mut self, index: usize, byte: u8) {
         self.content[index] = byte;
         // Phase 1 lets a UTF-8-tagged buffer hold invalid bytes,
-        // so we no longer downgrade the encoding tag here. The
-        // cached classification is invalidated and will be
-        // re-computed on the next access (`valid_encoding?` will
-        // see the byte and report Broken).
-        self.cr.set(CodeRange::Unknown);
-    }
-
-    ///
-    /// Get the length in char of the string `self`.
-    ///
-    pub fn char_length(&self) -> Result<usize> {
-        // Always-succeeding char counter: broken UTF-8 falls back to
-        // counting each invalid byte as one character (matches
-        // CRuby's `String#length` rule).
-        Ok(self.char_count())
+        // so we no longer downgrade the encoding tag here.
+        //
+        // Most setbyte calls poke ASCII bytes into already-SevenBit
+        // strings; we can preserve the cached classification for that
+        // common case to avoid an O(N) re-classify on the next
+        // `valid_encoding?` / encoding-compat check. Anything else
+        // falls back to lazy re-classify.
+        let new_cr = match (self.cr.get(), byte) {
+            (CodeRange::SevenBit, b) if b < 0x80 => CodeRange::SevenBit,
+            _ => CodeRange::Unknown,
+        };
+        self.cr.set(new_cr);
     }
 
     ///
@@ -819,18 +844,18 @@ impl RStringInner {
     ///
     /// Return None if `i` is out of range.
     ///
-    pub fn conv_char_index(&self, char_pos: i64) -> Result<Option<usize>> {
-        let len = self.char_length()?;
+    pub fn conv_char_index(&self, char_pos: i64) -> Option<usize> {
+        let len = self.char_length();
         if char_pos >= 0 {
             if char_pos <= len as i64 {
-                Ok(Some(char_pos as usize))
+                Some(char_pos as usize)
             } else {
-                Ok(None)
+                None
             }
         } else {
             match len as i64 + char_pos {
-                n if n < 0 => Ok(None),
-                n => Ok(Some(n as usize)),
+                n if n < 0 => None,
+                n => Some(n as usize),
             }
         }
     }
@@ -840,17 +865,17 @@ impl RStringInner {
     ///
     /// Return None if `i` is negative.
     ///
-    pub fn conv_char_index2(&self, char_pos: i64) -> Result<Option<usize>> {
-        let len = self.char_length()?;
+    pub fn conv_char_index2(&self, char_pos: i64) -> Option<usize> {
+        let len = self.char_length();
         if len == 0 && char_pos == -1 {
-            return Ok(Some(0));
+            return Some(0);
         }
         if char_pos >= 0 {
-            Ok(Some(char_pos as usize))
+            Some(char_pos as usize)
         } else {
             match len as i64 + char_pos {
-                n if n < 0 => Ok(None),
-                n => Ok(Some(n as usize)),
+                n if n < 0 => None,
+                n => Some(n as usize),
             }
         }
     }
@@ -917,40 +942,10 @@ impl RStringInner {
         match start_byte {
             // `index` past the end but exactly equal to char count
             // is the "append point" — empty range at end.
-            None if index == self.char_count() => self.content.len()..self.content.len(),
+            None if index == self.char_length() => self.content.len()..self.content.len(),
             None => 0..0,
             Some(s) => s..end_byte,
         }
-    }
-
-    pub fn extend(&mut self, other: &Self) -> Result<()> {
-        if other.is_empty() {
-            return Ok(());
-        }
-        let result_enc = match self.compatible_encoding(other) {
-            Some(enc) => enc,
-            None => {
-                // Caller does not have access to `Store`, so raise a
-                // generic runtime error that matches CRuby's
-                // wording. Callers that have access to `Store` can
-                // build a proper `Encoding::CompatibilityError` via
-                // `MonorubyErr::incompatible_encoding`; see
-                // `String#<<` / `String#concat` /
-                // `Array#join`-style sites.
-                return Err(MonorubyErr::runtimeerr(format!(
-                    "incompatible character encodings: {} and {}",
-                    self.ty.name(),
-                    other.ty.name(),
-                )));
-            }
-        };
-        self.content.extend_from_slice(&other.content);
-        self.ty = result_enc;
-        // The cached classification doesn't survive mutation: appending
-        // bytes can flip SevenBit → Valid/Broken, or two Broken halves
-        // can combine into a Valid character.
-        self.cr.set(CodeRange::Unknown);
-        Ok(())
     }
 
     /// Append `other`'s bytes to `self`, raising
@@ -958,16 +953,39 @@ impl RStringInner {
     /// on incompatible encodings. Used by call sites that have
     /// access to `Store` — preferred for new code; the older
     /// `extend()` is kept for the call sites that don't.
-    pub fn extend_compat(&mut self, other: &Self, store: &Store) -> Result<()> {
+    pub fn extend(&mut self, other: &Self, store: &Store) -> Result<()> {
         if other.is_empty() {
             return Ok(());
         }
         let result_enc = self
             .compatible_encoding(other)
             .ok_or_else(|| MonorubyErr::incompatible_encoding(store, self.ty, other.ty))?;
+        // Snapshot (possibly cached) classifications BEFORE extending the
+        // buffer and fold them into a combined cr in O(1). Previously every
+        // append wiped self.cr to Unknown, which forced the *next*
+        // extend's compatible_encoding() call to re-classify the
+        // entire growing buffer -- turning N appends from O(N) into O(N²).
+        // (See String#<< micro-bench: a 100k-iter `s << "abcde"` loop took
+        // ~5.7s before this change vs 5.6ms in CRuby.)
+        let new_cr = match (self.cr.get(), other.cr.get()) {
+            (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
+            (
+                CodeRange::SevenBit | CodeRange::Valid,
+                CodeRange::SevenBit | CodeRange::Valid,
+            ) => {
+                // compatible_encoding already verified the encodings agree,
+                // so two well-formed pieces concatenate to a well-formed
+                // whole. (Multi-byte boundaries can only collide at the
+                // junction if one side was already Broken.)
+                CodeRange::Valid
+            }
+            // Either side is Broken or its cr was never computed --
+            // fall back to lazy re-classify on the next access.
+            _ => CodeRange::Unknown,
+        };
         self.content.extend_from_slice(&other.content);
         self.ty = result_enc;
-        self.cr.set(CodeRange::Unknown);
+        self.cr.set(new_cr);
         Ok(())
     }
 
@@ -978,8 +996,29 @@ impl RStringInner {
                 slice
             )));
         }
+        // We just verified `slice` validates under self.ty when
+        // utf8-compatible, so its cr is at worst Valid; if every byte is
+        // < 0x80 it's still SevenBit. Combine with self.cr in O(1) so
+        // repeated callers (e.g. String#<< with single-char Integer args
+        // or per-codepoint encode loops) don't degenerate to O(N²) when
+        // self.code_range() is later queried.
+        let slice_cr = if slice.iter().all(|&b| b < 0x80) {
+            CodeRange::SevenBit
+        } else if self.ty.is_utf8_compatible() {
+            CodeRange::Valid
+        } else {
+            CodeRange::Unknown
+        };
+        let new_cr = match (self.cr.get(), slice_cr) {
+            (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
+            (
+                CodeRange::SevenBit | CodeRange::Valid,
+                CodeRange::SevenBit | CodeRange::Valid,
+            ) => CodeRange::Valid,
+            _ => CodeRange::Unknown,
+        };
         self.content.extend_from_slice(slice);
-        self.cr.set(CodeRange::Unknown);
+        self.cr.set(new_cr);
         Ok(())
     }
 
@@ -1001,6 +1040,19 @@ impl RStringInner {
     /// After replacement, validates encoding consistency.
     pub fn bytesplice(&mut self, start: usize, len: usize, replacement: &[u8]) {
         let end = start + len;
+        let prev_cr = self.cr.get();
+        let prev_ty = self.ty;
+
+        // Test BEFORE we mutate: if the receiver is valid UTF-8 and both
+        // splice endpoints fall on character boundaries in the original
+        // buffer, then by UTF-8's prefix-free property the result will
+        // still be valid UTF-8 as long as `replacement` itself is valid
+        // UTF-8. This lets us skip the O(N) from_utf8 walk below.
+        let utf8_boundaries_ok = matches!(prev_ty, Encoding::Utf8)
+            && matches!(prev_cr, CodeRange::Valid | CodeRange::SevenBit)
+            && is_utf8_char_boundary(&self.content, start)
+            && is_utf8_char_boundary(&self.content, end);
+
         let new_len = self.content.len() - len + replacement.len();
         if replacement.len() > len {
             // Need to grow: extend first, then shift
@@ -1017,15 +1069,49 @@ impl RStringInner {
         }
         // Copy replacement in
         self.content[start..start + replacement.len()].copy_from_slice(replacement);
-        // Re-check encoding
-        if self.ty.is_utf8_compatible() {
-            if std::str::from_utf8(&self.content).is_err() {
-                self.ty = Encoding::Ascii8;
-            }
-        } else if self.content.is_ascii() || std::str::from_utf8(&self.content).is_ok() {
-            // Keep Ascii8
+        // Fast path 1: if the receiver was already SevenBit and the
+        // spliced bytes are all ASCII, the SevenBit invariant survives
+        // and we can skip the O(n) from_utf8 walk below.
+        if matches!(prev_cr, CodeRange::SevenBit)
+            && prev_ty.is_ascii_compatible()
+            && replacement.iter().all(|&b| b < 0x80)
+        {
+            self.cr.set(CodeRange::SevenBit);
+            return;
         }
-        self.cr.set(CodeRange::Unknown);
+        // Fast path 2: UTF-8 receiver where the splice both starts and
+        // ends on character boundaries -- if `replacement` is valid
+        // UTF-8 the whole thing is still valid (prefix-free property of
+        // UTF-8). `from_utf8(replacement)` is O(|replacement|), which is
+        // typically << |content|.
+        if utf8_boundaries_ok && std::str::from_utf8(replacement).is_ok() {
+            // Promote SevenBit only when both sides are pure ASCII;
+            // any non-ASCII byte demotes to Valid.
+            let cr = if matches!(prev_cr, CodeRange::SevenBit)
+                && replacement.iter().all(|&b| b < 0x80)
+            {
+                CodeRange::SevenBit
+            } else {
+                CodeRange::Valid
+            };
+            self.cr.set(cr);
+            return;
+        }
+        // Slow path: re-classify the whole buffer. We used to set
+        // cr = Unknown here unconditionally, which forced the next
+        // bytesplice to re-walk the buffer too -- a stream of in-place
+        // splices on the same string thus ran in O(N²). Cache the
+        // classification result instead so subsequent calls hit the
+        // fast paths above.
+        let cr = self.ty.classify(&self.content);
+        if matches!(cr, CodeRange::Broken) && self.ty.is_utf8_compatible() {
+            // CRuby downgrades to ASCII-8BIT when UTF-8-tagged content
+            // becomes invalid; under that tag every byte is Valid.
+            self.ty = Encoding::Ascii8;
+            self.cr.set(CodeRange::Valid);
+        } else {
+            self.cr.set(cr);
+        }
     }
 
     pub fn first_code(&self) -> Result<u32> {
@@ -1238,18 +1324,6 @@ mod encoding_tests {
         assert_eq!(s.code_range(), CodeRange::Broken);
     }
 
-    #[test]
-    fn extend_invalidates_cache_for_new_bytes() {
-        let mut a = RStringInner::from_encoding(&[0xC3], Encoding::Utf8);
-        // 0xC3 alone is a truncated 2-byte UTF-8 scalar → Broken.
-        assert_eq!(a.code_range(), CodeRange::Broken);
-        let b = RStringInner::from_encoding(&[0xA9], Encoding::Utf8);
-        assert_eq!(b.code_range(), CodeRange::Broken);
-        a.extend(&b).unwrap();
-        // Two broken halves combine into U+00E9 (é) — Valid.
-        assert_eq!(a.code_range(), CodeRange::Valid);
-        assert!(a.is_valid_encoding());
-    }
 
     #[test]
     fn encoding_compatible_same_encoding() {
@@ -1363,31 +1437,6 @@ mod encoding_tests {
         let utf16 = RStringInner::from_encoding(&[0x00, 0xD8], Encoding::Utf16Le);
         // 0x00 stays ASCII-printable; 0xD8 escapes.
         assert_eq!(utf16.to_str().unwrap().as_ref(), "\x00\\xD8");
-    }
-
-    #[test]
-    fn extend_errors_on_incompatible_encodings() {
-        // UTF-8 (with non-ASCII content) + UTF-16LE → no compatible
-        // encoding → RuntimeError mentioning both encoding names.
-        let mut a = RStringInner::from_encoding("あ".as_bytes(), Encoding::Utf8);
-        let b = RStringInner::from_encoding(&[0x61, 0x00], Encoding::Utf16Le);
-        let err = a.extend(&b).unwrap_err();
-        let msg = err.message();
-        assert!(msg.contains("incompatible character encodings"), "{msg}");
-        assert!(msg.contains("UTF-8"), "{msg}");
-        assert!(msg.contains("UTF-16LE"), "{msg}");
-    }
-
-    #[test]
-    fn extend_compatible_seven_bit_and_other() {
-        // Pure-ASCII operand is compatible with any ASCII-compatible
-        // encoding (Shift_JIS in this case) — append succeeds and the
-        // result keeps the receiver's encoding.
-        let mut a = RStringInner::from_encoding(b"\x82\xa0", Encoding::Sjis(0));
-        let b = RStringInner::from_str("xy");
-        a.extend(&b).unwrap();
-        assert_eq!(a.encoding(), Encoding::Sjis(0));
-        assert_eq!(a.as_bytes(), b"\x82\xa0xy");
     }
 
     #[test]

--- a/monoruby/stdlib/psych.rb
+++ b/monoruby/stdlib/psych.rb
@@ -122,7 +122,15 @@ module Psych
     end
 
     def indent_of(line)
-      line ? (line =~ /\S/ || line.size) : -1
+      return -1 if line.nil?
+      i = 0
+      len = line.size
+      while i < len
+        b = line.getbyte(i)
+        break unless b == 0x20 || b == 0x09
+        i += 1
+      end
+      i
     end
 
     def parse_value(parent_indent)
@@ -173,14 +181,49 @@ module Psych
     end
 
     def block_mapping_line?(line)
-      s = line.strip
-      return false if s.start_with?("- ")
-      return false if s.start_with?("#")
-      if s =~ /\A(?:["'].*?["']|[^:#]*?)\s*:\s/
-        return true
+      # Find the first non-leading-whitespace byte without allocating.
+      bytes = line.bytes
+      len = bytes.size
+      i = 0
+      while i < len && (bytes[i] == 0x20 || bytes[i] == 0x09)
+        i += 1
       end
-      if s =~ /\A(?:["'].*?["']|[^:#]*?)\s*:\z/
-        return true
+      return false if i == len
+      first = bytes[i]
+      return false if first == 0x23 # '#'
+      return false if first == 0x2D && i + 1 < len && bytes[i + 1] == 0x20 # "- "
+      # A block-mapping line is a key followed by ':' that is either
+      # at end of line or followed by whitespace. Strings escape the
+      # match (so we have to skip past balanced "..." or '...').
+      while i < len
+        b = bytes[i]
+        case b
+        when 0x22 # '"'
+          i += 1
+          while i < len && bytes[i] != 0x22
+            i += 1
+          end
+          i += 1 # past closing "
+        when 0x27 # "'"
+          i += 1
+          while i < len && bytes[i] != 0x27
+            i += 1
+          end
+          i += 1 # past closing '
+        when 0x23 # '#'  inline comment ⇒ no mapping
+          return false
+        when 0x3A # ':'
+          # ':' followed by whitespace or end-of-line is a mapping
+          # separator. Anything else (e.g. ::, :foo) is not.
+          if i + 1 == len
+            return true
+          end
+          nx = bytes[i + 1]
+          return true if nx == 0x20 || nx == 0x09
+          i += 1
+        else
+          i += 1
+        end
       end
       false
     end
@@ -209,7 +252,9 @@ module Psych
 
         key = resolve_scalar(key)
 
-        if rest.nil? || rest.empty?
+        if rest.nil? || rest.empty? || rest.start_with?("#")
+          # `key: # comment` carries no inline value; the value is on
+          # the following indented line(s).
           value = parse_value(ind)
         elsif rest.start_with?("*")
           alias_name = rest[1..-1].strip
@@ -231,11 +276,24 @@ module Psych
           value = parse_flow_mapping(rest)
         elsif rest.start_with?("[")
           value = parse_flow_sequence(rest)
-        elsif rest == "|" || rest == "|-" || rest == "|+"
-          value = parse_literal_block(ind, rest)
-        elsif rest == ">" || rest == ">-" || rest == ">+"
-          value = parse_folded_block(ind, rest)
+        elsif rest =~ /\A([|>])(\d*)([+-]?)\z/
+          block_type = $1
+          explicit_n = $2.empty? ? nil : $2.to_i
+          chomp = $3 # "" (clip), "-" (strip), or "+" (keep)
+          if block_type == "|"
+            value = parse_literal_block(ind, explicit_n, chomp)
+          else
+            value = parse_folded_block(ind, explicit_n, chomp)
+          end
         else
+          # YAML allows "..." / '...' values to span multiple lines; the
+          # closing quote may be on a later line. Pull continuation
+          # lines into `rest` (folding line breaks into single spaces
+          # per YAML 1.1) before handing off to resolve_scalar.
+          if (rest.start_with?('"') || rest.start_with?("'")) &&
+             !quoted_string_terminated?(rest, rest.getbyte(0))
+            rest = consume_multiline_quoted(rest)
+          end
           value = resolve_scalar(rest)
         end
 
@@ -312,12 +370,14 @@ module Psych
     end
 
     def split_mapping_key(stripped)
+      # For quoted keys, keep the quotes so that resolve_scalar
+      # treats `"1"` as the string "1" rather than the integer 1.
       if stripped.start_with?('"')
-        if stripped =~ /\A"((?:[^"\\]|\\.)*)"\s*:\s*(.*)\z/
+        if stripped =~ /\A("(?:[^"\\]|\\.)*")\s*:\s*(.*)\z/
           return [$1, $2]
         end
       elsif stripped.start_with?("'")
-        if stripped =~ /\A'([^']*)'\s*:\s*(.*)\z/
+        if stripped =~ /\A('[^']*')\s*:\s*(.*)\z/
           return [$1, $2]
         end
       end
@@ -330,30 +390,55 @@ module Psych
       [stripped, nil]
     end
 
-    def parse_literal_block(parent_indent, chomp)
-      lines = []
-      while @pos < @lines.size
-        line = @lines[@pos]
-        if line.strip.empty?
-          lines << ""
-          @pos += 1
+    # True iff the quoted scalar `s` (which starts with `quote`) has a
+    # matching unescaped closing `quote` on the same line. Mirrors
+    # YAML 1.1 escapes: `\` consumes the next byte inside `"..."` and
+    # `''` is the in-string escape for `'` inside `'...'`.
+    def quoted_string_terminated?(s, quote)
+      return false if s.bytesize < 2
+      i = 1
+      len = s.bytesize
+      while i < len
+        c = s.getbyte(i)
+        if c == quote
+          if quote == 0x27 && i + 1 < len && s.getbyte(i + 1) == 0x27
+            i += 2
+            next
+          end
+          return true
+        end
+        if quote == 0x22 && c == 0x5C # backslash escape inside "..."
+          i += 2
           next
         end
-        ind = indent_of(line)
-        break if ind <= parent_indent
-        lines << line[parent_indent + 2..-1].to_s
-        @pos += 1
+        i += 1
       end
-      result = lines.join("\n")
-      case chomp
-      when "|"  then result + "\n"
-      when "|-" then result
-      when "|+" then result + "\n"
-      else result + "\n"
-      end
+      false
     end
 
-    def parse_folded_block(parent_indent, chomp)
+    # `rest` starts with `"` / `'` whose closing quote is on a later
+    # line. Pull continuation lines into a single buffer, folding the
+    # joining line break into a single space (YAML 1.1 rule for
+    # double/single-quoted multi-line scalars on contiguous non-blank
+    # lines), and advance @pos past the consumed lines.
+    def consume_multiline_quoted(rest)
+      quote = rest.getbyte(0)
+      buf = rest.dup
+      while @pos < @lines.size
+        nxt = @lines[@pos]
+        @pos += 1
+        buf = buf.rstrip + " " + nxt.lstrip
+        break if quoted_string_terminated?(buf, quote)
+      end
+      buf
+    end
+
+    # `chomp` is one of "" (clip — single trailing newline), "-"
+    # (strip — no trailing newline), "+" (keep — preserve all
+    # trailing newlines). `explicit_indent`, when given, fixes the
+    # content indent at parent_indent + explicit_indent (e.g. `|2-`).
+    def parse_literal_block(parent_indent, explicit_indent, chomp)
+      content_indent = explicit_indent ? parent_indent + explicit_indent : parent_indent + 2
       lines = []
       while @pos < @lines.size
         line = @lines[@pos]
@@ -364,15 +449,56 @@ module Psych
         end
         ind = indent_of(line)
         break if ind <= parent_indent
-        lines << line[parent_indent + 2..-1].to_s
+        lines << line[content_indent..-1].to_s
         @pos += 1
       end
-      result = lines.join(" ").gsub("  ", " ")
+      # Pop trailing empty lines (the chomp indicator decides what to
+      # do with them).
+      trailing = 0
+      while !lines.empty? && lines.last.empty?
+        lines.pop
+        trailing += 1
+      end
+      body = lines.join("\n")
+      apply_chomp(body, trailing, chomp)
+    end
+
+    def parse_folded_block(parent_indent, explicit_indent, chomp)
+      content_indent = explicit_indent ? parent_indent + explicit_indent : parent_indent + 2
+      lines = []
+      while @pos < @lines.size
+        line = @lines[@pos]
+        if line.strip.empty?
+          lines << ""
+          @pos += 1
+          next
+        end
+        ind = indent_of(line)
+        break if ind <= parent_indent
+        lines << line[content_indent..-1].to_s
+        @pos += 1
+      end
+      trailing = 0
+      while !lines.empty? && lines.last.empty?
+        lines.pop
+        trailing += 1
+      end
+      # Folded: line breaks fold to a single space (collapsing any
+      # double-spaces that arise from joining).
+      body = lines.join(" ").gsub("  ", " ")
+      apply_chomp(body, trailing, chomp)
+    end
+
+    # Block-scalar chomp indicator:
+    #   ""  (clip)  -> exactly one trailing newline
+    #   "-" (strip) -> no trailing newlines
+    #   "+" (keep)  -> the original trailing-empty-line count, plus the
+    #                   final block-end newline
+    def apply_chomp(body, trailing, chomp)
       case chomp
-      when ">"  then result + "\n"
-      when ">-" then result
-      when ">+" then result + "\n"
-      else result + "\n"
+      when "-" then body
+      when "+" then body + ("\n" * (trailing + 1))
+      else          body + "\n"
       end
     end
 
@@ -402,36 +528,77 @@ module Psych
     def resolve_scalar(str)
       return nil if str.nil?
       str = str.strip
-      str = $1 if str =~ /\A(.*?)\s+#.*\z/ && !str.start_with?('"') && !str.start_with?("'")
+      return nil if str.empty?
 
-      if str =~ /\A\*(\S+)\z/
-        return @anchors[$1]
+      # Most YAML scalars are plain strings. Dispatch on the first
+      # byte to skip the per-call regex/case scan whenever possible.
+      first = str.getbyte(0)
+      # Cheap leading-comment trim, but only for unquoted plain
+      # scalars (quoted strings may legally contain " #").
+      if first != 0x22 && first != 0x27 && (idx = str.index(" #"))
+        str = str[0, idx].rstrip
+        return nil if str.empty?
+        first = str.getbyte(0)
       end
 
-      case str
-      when "", "~", "null", "Null", "NULL"
-        nil
-      when "true", "True", "TRUE"
-        true
-      when "false", "False", "FALSE"
-        false
-      when /\A-?\d+\z/
-        str.to_i
-      when /\A-?\d+\.\d+(?:[eE][+-]?\d+)?\z/
-        str.to_f
-      when /\A"(.*)"\z/
-        $1.gsub('\\n', "\n").gsub('\\t', "\t").gsub('\\"', '"').gsub('\\\\', '\\')
-      when /\A'(.*)'\z/
-        $1
-      else
-        str
+      case first
+      when 0x22 # "..."  double-quoted
+        if str.end_with?('"') && str.size >= 2
+          inner = str[1..-2]
+          # Cheap path: no escape sequences ⇒ return as-is.
+          if inner.include?("\\")
+            return inner.gsub('\\n', "\n").gsub('\\t', "\t")
+                        .gsub('\\"', '"').gsub('\\\\', '\\')
+          end
+          return inner
+        end
+      when 0x27 # '...'  single-quoted
+        return str[1..-2] if str.end_with?("'") && str.size >= 2
+      when 0x2A # '*'    alias
+        return @anchors[str[1..-1]] if str.size > 1 && !str.include?(" ")
+      when 0x7E # '~'
+        return nil if str.size == 1
+      when 0x6E # 'n'
+        return nil if str == "null"
+      when 0x4E # 'N'
+        return nil if str == "Null" || str == "NULL"
+      when 0x74 # 't'
+        return true if str == "true"
+      when 0x54 # 'T'
+        return true if str == "True" || str == "TRUE"
+      when 0x66 # 'f'
+        return false if str == "false"
+      when 0x46 # 'F'
+        return false if str == "False" || str == "FALSE"
       end
+
+      # Numbers: only worth a regex when the leading byte could
+      # plausibly start one.
+      if first == 0x2D || (first >= 0x30 && first <= 0x39) # '-' or '0'..'9'
+        if str =~ /\A-?\d+\z/
+          return str.to_i
+        elsif str =~ /\A-?\d+\.\d+(?:[eE][+-]?\d+)?\z/
+          return str.to_f
+        end
+      end
+
+      str
     end
 
     def skip_blanks_and_comments
       while @pos < @lines.size
         line = @lines[@pos]
-        if line.strip.empty? || line.strip.start_with?("#")
+        # Avoid two strip allocations per line (the old code stripped
+        # twice). Walk leading whitespace inline; lines that only have
+        # whitespace, or whose first non-space byte is '#', are skipped.
+        i = 0
+        len = line.size
+        while i < len
+          b = line.getbyte(i)
+          break unless b == 0x20 || b == 0x09
+          i += 1
+        end
+        if i == len || line.getbyte(i) == 0x23 # '#'
           @pos += 1
         else
           break


### PR DESCRIPTION
## Summary

Cherry-picks the runtime/builtins/benchmark improvements that accumulated on the `prism` topic branch but are independent of the Prism parser work, so they can land on master without waiting for the parser switch.

### Runtime / builtins
- hash: port `Hash#initialize` from Ruby to Rust
- Add Fixnum fast path for `Array#sum` and `Array#inject(:+)`
- Speed up `Array#&`, `#-`, `#intersection`, `#minmax`
- Fix GC mark-leak bugs in Array/Set methods
- Fix O(n²) `String#<<` by caching code range across appends
- Use cached CodeRange to skip O(n) string scans
- Use UTF-8 prefix-free property to skip bytesplice revalidation
- Remove dead `RStringInner::extend` and unwrap unused `Result`
- Rename `extend_compat -> extend`, `char_count -> char_length`
- Speed up monoruby's pure-Ruby Psych YAML parser

### Tooling
- `require`: add `x86_64-linux` subdir to default `$LOAD_PATH`
- Skip too-old Ruby on PATH; pick rbenv >= 4.0 instead
- Add `bin/ruby-bench-diff` and extend Psych for full discourse parse
- Run `bin/ruby-bench-diff` in `bin/test` and on CI

### Excluded (kept on the prism branch)
Every `prism:` / `prism phase` commit, every change under `monoruby/src/parser/`, the `monoruby::ast` boundary, `vendor/ruby-prism/`, and the `Fix.` commits whose hunks straddled prism-only files (`fatal_with_loc`, parser-driven CI tweaks).

## Test plan

- [x] `cargo build -p monoruby`
- [x] `cargo test -p monoruby --test variables --test method_call --test rescue` (63 + 35 + 13 pass)
- [ ] CI: full `bin/test` run on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)