### PR TITLE
prism: switch to one-shot Options::scopes API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "ruby-prism"
 version = "1.9.0"
-source = "git+https://github.com/sisshiki1969/prism.git?rev=f96247fca4d213ff596e635737d05fc93aa300f7#f96247fca4d213ff596e635737d05fc93aa300f7"
+source = "git+https://github.com/sisshiki1969/prism.git?rev=2ffc03f8ecda374a528d6ad870111fdbb48daaac#2ffc03f8ecda374a528d6ad870111fdbb48daaac"
 dependencies = [
  "libc",
  "ruby-prism-sys",

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -48,7 +48,7 @@ monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = 
 monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "rc" }
 onigmo-regex = { git = "https://github.com/sisshiki1969/onigmo-regex.git" }
 ruruby-parse = { path = "../ruruby-parse" }
-ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", rev = "f96247fca4d213ff596e635737d05fc93aa300f7" }
+ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", rev = "2ffc03f8ecda374a528d6ad870111fdbb48daaac" }
 monoruby-attr = { path = "../monoruby_attr" }
 rubymap = { path = "../rubymap" }
 indexmap = "2.10.0"

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -76,7 +76,8 @@ fn build_prism_options(
     // (`lineno - 1`) at the call sites in `globals.rs`, so the
     // wire-format we want is `line_offset + 1`.
     let line = line_offset.saturating_add(1).clamp(1, i32::MAX as i64) as i32;
-    let mut opts = prism::Options::new().line(line);
+
+    let mut scopes: Vec<prism::Scope> = Vec::new();
 
     if let Some(ctx) = extern_context {
         // Walk outermost -> innermost.
@@ -86,7 +87,7 @@ fn build_prism_options(
             if let Some(blk_id) = block_param {
                 names.push(blk_id.get_name());
             }
-            opts.add_scope(names, 0);
+            scopes.push(prism::Scope::new(names));
         }
     }
 
@@ -108,12 +109,12 @@ fn build_prism_options(
     //   scope, and we don't append a separate empty placeholder.
     if let Some(coll) = binding_locals {
         let names: Vec<String> = coll.table().iter().cloned().collect();
-        opts.add_scope(names, 0);
+        scopes.push(prism::Scope::new(names));
     } else {
-        opts.add_scope(Vec::<&[u8]>::new(), 0);
+        scopes.push(prism::Scope::new(Vec::<&[u8]>::new()));
     }
 
-    opts
+    prism::Options::new().line(line).scopes(scopes)
 }
 
 /// Result of lowering the `block` slot on a Prism call/super node.


### PR DESCRIPTION
## Summary

Switches the eval/binding parse path to the new one-shot \`Options::scopes(Vec<Scope>)\` API in the \`sisshiki1969/prism\` fork (commit \`2ffc03f8\`).

The old builder called \`opts.add_scope(locals, forwarding)\` once per surrounding-locals frame, which re-grew the scope array via \`libc::realloc\` on every call. The new API takes the whole chain as a typed \`Vec<prism::Scope>\` and converts it in one allocation pass on the Prism side (single \`pm_options_scopes_init\` xcalloc + per-scope \`pm_options_scope_init\` + \`pm_string_owned_init\` loop).

Call site in \`build_prism_options\` builds a local \`Vec<prism::Scope>\` instead of mutating an \`Options\` in-place, then chains \`.scopes(scopes)\` at the end.

Bumps the \`ruby-prism\` git dependency rev to \`2ffc03f8ecda374a528d6ad870111fdbb48daaac\`.

## Test plan

- [x] \`cargo build -p monoruby\`
- [x] \`MONORUBY_PARSER=prism cargo test -p monoruby --test variables --test method_call --test rescue\` (63 + 35 + 13 pass)
- [ ] CI: full \`bin/test\` run on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)