### PR TITLE
bench: move chart to /bench/ subpage and fix empty-results parsing

### DIFF
--- a/.github/bench-pages/index.html
+++ b/.github/bench-pages/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>monoruby — Performance vs YJIT</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 2em;
+    max-width: 1100px;
+    color: #1a1a1a;
+  }
+  h1 { margin-bottom: 0.2em; }
+  .meta { color: #666; font-size: 0.9em; margin-bottom: 2em; }
+  section { margin-bottom: 3em; }
+  canvas { max-width: 100%; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.9em; }
+  th, td { padding: 4px 8px; border-bottom: 1px solid #eee; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { border-bottom: 2px solid #888; }
+  a { color: #1565c0; }
+  .empty { color: #888; padding: 1em 0; }
+</style>
+</head>
+<body>
+<h1>monoruby × ruby <code>--yjit</code></h1>
+<div class="meta">
+  Per-benchmark relative speed against <code>ruby 4.0.1 --yjit</code> measured on every <code>master</code> push.
+  Source: <a href="latest.json">latest.json</a>, <a href="data/history.csv">history.csv</a>.
+  Back to <a href="../">portal</a>.
+</div>
+
+<section>
+  <h2>Latest snapshot</h2>
+  <div id="latestMeta" class="meta"></div>
+  <div id="latestBarWrap" style="position: relative;"><canvas id="latestBar"></canvas></div>
+  <table id="latestTable">
+    <thead>
+      <tr>
+        <th>Benchmark</th>
+        <th>monoruby (i/s)</th>
+        <th>YJIT (i/s)</th>
+        <th>monoruby / YJIT</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <div id="empty" class="empty" hidden>No benchmark data yet. The next master push will populate this page.</div>
+</section>
+
+<script>
+async function loadJson(path) {
+  const res = await fetch(path + "?t=" + Date.now());
+  if (!res.ok) return null;
+  return await res.json();
+}
+
+(async () => {
+  const data = await loadJson("latest.json");
+  const empty = document.getElementById("empty");
+  const benches = (data && data.benchmarks) || [];
+
+  if (!benches.length) {
+    empty.hidden = false;
+    return;
+  }
+  benches.sort((a, b) => b.ratio - a.ratio);
+
+  document.getElementById("latestMeta").textContent =
+    "snapshot: " + data.timestamp + " @ " + data.commit;
+
+  const barColor = r =>
+    r >= 1.0 ? "#2e7d32" :
+    r >= 0.7 ? "#9ccc65" :
+    r >= 0.4 ? "#fdd835" :
+               "#c62828";
+
+  document.getElementById("latestBarWrap").style.height =
+    Math.max(280, benches.length * 32) + "px";
+
+  new Chart(document.getElementById("latestBar"), {
+    type: "bar",
+    data: {
+      labels: benches.map(b => b.name),
+      datasets: [{
+        label: "monoruby / YJIT",
+        data: benches.map(b => b.ratio),
+        backgroundColor: benches.map(b => barColor(b.ratio))
+      }]
+    },
+    options: {
+      indexAxis: "y",
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          beginAtZero: true,
+          title: { display: true, text: "relative speed (× YJIT)" },
+          grid: {
+            color: ctx => ctx.tick.value === 1 ? "#1a1a1a" : "rgba(0,0,0,0.08)",
+            lineWidth: ctx => ctx.tick.value === 1 ? 2 : 1
+          }
+        },
+        y: { ticks: { autoSkip: false, font: { size: 11 } } }
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: ctx => {
+              const b = benches[ctx.dataIndex];
+              return [
+                ctx.parsed.x.toFixed(2) + "× YJIT",
+                "monoruby: " + b.monoruby_ips.toFixed(2) + " i/s",
+                "yjit:     " + b.yjit_ips.toFixed(2) + " i/s"
+              ];
+            }
+          }
+        }
+      }
+    }
+  });
+
+  const tbody = document.querySelector("#latestTable tbody");
+  for (const b of benches) {
+    const tr = document.createElement("tr");
+    const cells = [
+      b.name,
+      b.monoruby_ips.toFixed(3),
+      b.yjit_ips.toFixed(3),
+      b.ratio.toFixed(3) + "x"
+    ];
+    for (const v of cells) {
+      const td = document.createElement("td");
+      td.textContent = v;
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+})();
+</script>
+</body>
+</html>

--- a/.github/portal/index.html
+++ b/.github/portal/index.html
@@ -5,7 +5,6 @@
 <title>monoruby</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <style>
   :root {
     --bg: #ffffff;
@@ -14,6 +13,8 @@
     --link: #1565c0;
     --accent: #2e7d32;
     --accent-dark: #1b5e20;
+    --accent-blue: #1565c0;
+    --accent-blue-dark: #0d47a1;
     --border: #eaeaea;
     --code-bg: #f5f5f5;
   }
@@ -51,6 +52,12 @@
     box-shadow: 0 2px 6px rgba(46, 125, 50, 0.25);
   }
   .cta .primary:hover { background: var(--accent-dark); }
+  .cta .primary-blue {
+    background: var(--accent-blue);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(21, 101, 192, 0.25);
+  }
+  .cta .primary-blue:hover { background: var(--accent-blue-dark); }
   .cta .secondary {
     background: #f0f0f0;
     color: var(--fg);
@@ -86,32 +93,15 @@
   li { margin: 0.3em 0; }
   img { max-width: 100%; height: auto; }
   .loading { color: var(--muted); }
-  section.bench { margin-bottom: 3em; }
-  section.bench h2 {
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0.3em;
-    margin: 0 0 0.4em;
-  }
-  section.bench .meta { font-size: 0.9em; color: var(--muted); margin: 0.2em 0 1em; }
-  #benchWrap { position: relative; }
 </style>
 </head>
 <body>
 
 <nav class="cta">
+  <a class="primary-blue" href="./bench/">Performance vs YJIT →</a>
   <a class="primary" href="./spec/">ruby/spec compliance dashboard →</a>
   <a class="secondary" href="https://github.com/sisshiki1969/monoruby">GitHub</a>
 </nav>
-
-<section class="bench" id="bench" hidden>
-  <h2>Performance vs YJIT</h2>
-  <p class="meta">
-    Relative speed (× <code>ruby 4.0.1 --yjit</code>). Higher is better;
-    bars beyond <code>1.0×</code> are faster than YJIT.
-  </p>
-  <div id="benchWrap"><canvas id="benchChart"></canvas></div>
-  <div id="benchMeta" class="meta"></div>
-</section>
 
 <main id="readme"><p class="loading">Loading README…</p></main>
 
@@ -132,75 +122,6 @@ const STOP_AT = /^## Prerequisites/m;
     target.innerHTML =
       '<p>Could not load README (' + e.message + '). ' +
       'See the <a href="https://github.com/sisshiki1969/monoruby">repository</a>.</p>';
-  }
-})();
-
-(async () => {
-  const section = document.getElementById("bench");
-  try {
-    const res = await fetch("bench/latest.json?t=" + Date.now());
-    if (!res.ok) return;
-    const data = await res.json();
-    const benches = (data.benchmarks || []).slice()
-      .sort((a, b) => b.ratio - a.ratio);
-    if (!benches.length) return;
-
-    section.hidden = false;
-
-    const wrap = document.getElementById("benchWrap");
-    wrap.style.height = Math.max(260, benches.length * 30) + "px";
-
-    const color = r => r >= 1.0 ? "#2e7d32"
-                     : r >= 0.7 ? "#9ccc65"
-                     : r >= 0.4 ? "#fdd835"
-                     :            "#c62828";
-
-    new Chart(document.getElementById("benchChart"), {
-      type: "bar",
-      data: {
-        labels: benches.map(b => b.name),
-        datasets: [{
-          label: "monoruby / YJIT",
-          data: benches.map(b => b.ratio),
-          backgroundColor: benches.map(b => color(b.ratio))
-        }]
-      },
-      options: {
-        indexAxis: "y",
-        maintainAspectRatio: false,
-        scales: {
-          x: {
-            beginAtZero: true,
-            title: { display: true, text: "relative speed (× YJIT)" },
-            grid: {
-              color: ctx => ctx.tick.value === 1 ? "#1a1a1a" : "rgba(0,0,0,0.08)",
-              lineWidth: ctx => ctx.tick.value === 1 ? 2 : 1
-            }
-          },
-          y: { ticks: { autoSkip: false, font: { size: 11 } } }
-        },
-        plugins: {
-          legend: { display: false },
-          tooltip: {
-            callbacks: {
-              label: ctx => {
-                const b = benches[ctx.dataIndex];
-                return [
-                  ctx.parsed.x.toFixed(2) + "× YJIT",
-                  "monoruby: " + b.monoruby_ips.toFixed(2) + " i/s",
-                  "yjit:     " + b.yjit_ips.toFixed(2) + " i/s"
-                ];
-              }
-            }
-          }
-        }
-      }
-    });
-
-    document.getElementById("benchMeta").textContent =
-      "snapshot: " + data.timestamp + " @ " + data.commit;
-  } catch (e) {
-    /* leave section hidden if data is unavailable */
   }
 })();
 </script>

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,7 @@ on:
       - 'benchmark/**'
       - '.github/workflows/bench.yml'
       - '.github/portal/**'
+      - '.github/bench-pages/**'
 
 permissions:
   contents: write
@@ -66,11 +67,16 @@ jobs:
             plb2/matmul.rb
           )
 
+          # Use full paths for both executables. benchmark-driver treats a
+          # bare name like "ruby" as a relative path (./ruby) and fails with
+          # ENOENT when run from the benchmark/ directory.
+          RUBY_BIN=$(command -v ruby)
+
           benchmark-driver \
             -o markdown \
             "${BENCHMARKS[@]}" \
             -e "monoruby::$HOME/.cargo/bin/monoruby" \
-            -e "yjit::ruby --yjit" \
+            -e "yjit::$RUBY_BIN --yjit" \
             | tee "$RAW"
 
       - name: Aggregate results
@@ -181,6 +187,7 @@ jobs:
           }' "$GITHUB_WORKSPACE/bench-results/raw.md" >> bench/data/history.csv
 
           cp "$GITHUB_WORKSPACE/bench-results/latest.json" bench/latest.json
+          cp "$GITHUB_WORKSPACE/.github/bench-pages/index.html" bench/index.html
 
           git add -A
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary

Two changes:

1. **Restructure**: per request, the bench chart leaves the portal and gets its own page at `https://sisshiki1969.github.io/monoruby/bench/`. The portal now shows three CTA buttons (bench, spec, GitHub) above the README and nothing else.
2. **Fix the empty-results bug** that left `bench/latest.json` containing `"benchmarks":[]` after #411.

### Why the chart was empty

The first run after #411 produced

```json
{"timestamp":"2026-05-06T12:01:05Z","commit":"1bf9ac7","benchmarks":[]}
```

I reproduced it locally. `benchmark-driver` treats the `path` half of `-e "name::path"` as a path argument and falls through to `popen` with `cwd + path` if it isn't absolute. Our workflow ran from `benchmark/`, so

```
-e "yjit::ruby --yjit"
```

made benchmark-driver try to spawn `./ruby --yjit` and the actual stack trace was:

```
popen': No such file or directory - /home/runner/work/monoruby/monoruby/benchmark/ruby (Errno::ENOENT)
```

The markdown formatter still emits a table, but the YJIT cell is blank, every row fails the `yj > 0` filter in awk, and the JSON ends up with an empty array.

Fix: resolve the system ruby with `command -v ruby` and pass the absolute path:

```yaml
RUBY_BIN=$(command -v ruby)
benchmark-driver \
  -o markdown \
  "${BENCHMARKS[@]}" \
  -e "monoruby::$HOME/.cargo/bin/monoruby" \
  -e "yjit::$RUBY_BIN --yjit" \
  | tee "$RAW"
```

Reproduction with the fix locally produced a normal table with both columns populated.

### New `/bench/` page

`.github/bench-pages/index.html` (parallel to `.github/spec-pages/index.html`):

- horizontal bar chart sorted by ratio descending, colored: ≥1.0× green, ≥0.7× yellow-green, ≥0.4× yellow, else red
- bold gridline at `x = 1.0` for parity with YJIT
- snapshot metadata (timestamp / commit) above the chart
- detailed per-benchmark numeric table below the chart (monoruby i/s, YJIT i/s, ratio)
- empty-state message until the first non-empty publish lands

The workflow's publish step now also `cp`s the template to `gh-pages/bench/index.html` and watches `.github/bench-pages/**` in the path filter.

### Portal cleanup

Drops the inline chart, drops the `chart.js` `<script>` (only `marked.js` remains), and adds a blue "Performance vs YJIT →" CTA next to the existing green "ruby/spec compliance dashboard →" button. README rendering below is unchanged.

## URLs after merge

- portal: https://sisshiki1969.github.io/monoruby/
- bench:  https://sisshiki1969.github.io/monoruby/bench/
- spec:   https://sisshiki1969.github.io/monoruby/spec/

## Test plan

- [ ] After merge, manually `Run workflow` on `bench` and verify `bench/latest.json` has a non-empty `benchmarks` array.
- [ ] Open `/bench/` and confirm the bar chart and table render with ratios.
- [ ] Open `/` and confirm the portal shows only the three CTAs above the README.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_