### PR TITLE
bench: switch to yjit-bench (full suite, failures included)

### DIFF
--- a/.github/bench-pages/index.html
+++ b/.github/bench-pages/index.html
@@ -20,6 +20,7 @@
   th, td { padding: 4px 8px; border-bottom: 1px solid #eee; text-align: right; }
   th:first-child, td:first-child { text-align: left; }
   thead th { border-bottom: 2px solid #888; }
+  td.err { color: #c62828; font-weight: 600; }
   a { color: #1565c0; }
   .empty { color: #888; padding: 1em 0; }
 </style>
@@ -27,9 +28,10 @@
 <body>
 <h1>monoruby × ruby <code>--yjit</code></h1>
 <div class="meta">
-  Per-benchmark relative speed against <code>ruby 4.0.1 --yjit</code> measured on every <code>master</code> push.
-  Source: <a href="latest.json">latest.json</a>, <a href="data/history.csv">history.csv</a>.
-  Back to <a href="../">portal</a>.
+  Per-benchmark relative speed against <code>ruby 4.0.1 --yjit</code>, measured on every <code>master</code> push with
+  <a href="https://github.com/Shopify/yjit-bench">Shopify/yjit-bench</a> (<code>--rss --harness=harness-warmup</code>).
+  Failed benchmarks are listed in red. Source: <a href="latest.json">latest.json</a>,
+  <a href="data/history.csv">history.csv</a>. Back to <a href="../">portal</a>.
 </div>
 
 <section>
@@ -40,9 +42,9 @@
     <thead>
       <tr>
         <th>Benchmark</th>
-        <th>monoruby (i/s)</th>
-        <th>YJIT (i/s)</th>
-        <th>monoruby / YJIT</th>
+        <th>monoruby (ms)</th>
+        <th>YJIT (ms)</th>
+        <th>YJIT / monoruby</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -66,28 +68,48 @@ async function loadJson(path) {
     empty.hidden = false;
     return;
   }
-  benches.sort((a, b) => b.ratio - a.ratio);
+
+  // Bar chart sort: ratio DESC, then errors at the bottom.
+  // ok = both implementations succeeded → use ratio
+  // monoruby_failed → push to bottom (ratio = 0)
+  // yjit_failed but monoruby ok → very high "ratio" (treat as ∞)
+  const sortKey = b => {
+    if (b.monoruby_failed) return -1; // bottom
+    if (b.yjit_failed)     return Infinity;
+    return b.ratio;
+  };
+  benches.sort((a, b) => sortKey(b) - sortKey(a));
 
   document.getElementById("latestMeta").textContent =
     "snapshot: " + data.timestamp + " @ " + data.commit;
 
-  const barColor = r =>
-    r >= 1.0 ? "#2e7d32" :
-    r >= 0.7 ? "#9ccc65" :
-    r >= 0.4 ? "#fdd835" :
-               "#c62828";
+  const okBars = benches.filter(b => !b.monoruby_failed);
+  const maxRatio = okBars.reduce((m, b) =>
+    (b.ratio && b.ratio > m) ? b.ratio : m, 1.5);
+  // Failed-monoruby bars get a small visible stub at the *negative* side
+  // so they're labeled and visible without distorting the ratio scale.
+  const FAIL_STUB = -Math.max(0.5, maxRatio * 0.05);
+
+  const barColor = b => {
+    if (b.monoruby_failed) return "#c62828";
+    const r = b.ratio || 0;
+    if (r >= 1.0) return "#2e7d32";
+    if (r >= 0.7) return "#9ccc65";
+    if (r >= 0.4) return "#fdd835";
+    return "#c62828";
+  };
 
   document.getElementById("latestBarWrap").style.height =
-    Math.max(280, benches.length * 32) + "px";
+    Math.max(280, benches.length * 26) + "px";
 
   new Chart(document.getElementById("latestBar"), {
     type: "bar",
     data: {
-      labels: benches.map(b => b.name),
+      labels: benches.map(b => b.name + (b.monoruby_failed ? " ✕" : "")),
       datasets: [{
-        label: "monoruby / YJIT",
-        data: benches.map(b => b.ratio),
-        backgroundColor: benches.map(b => barColor(b.ratio))
+        label: "YJIT / monoruby",
+        data: benches.map(b => b.monoruby_failed ? FAIL_STUB : (b.ratio || 0)),
+        backgroundColor: benches.map(barColor)
       }]
     },
     options: {
@@ -95,8 +117,9 @@ async function loadJson(path) {
       maintainAspectRatio: false,
       scales: {
         x: {
-          beginAtZero: true,
-          title: { display: true, text: "relative speed (× YJIT)" },
+          suggestedMin: FAIL_STUB,
+          suggestedMax: Math.max(2.0, maxRatio),
+          title: { display: true, text: "relative speed (× YJIT, higher = monoruby faster)" },
           grid: {
             color: ctx => ctx.tick.value === 1 ? "#1a1a1a" : "rgba(0,0,0,0.08)",
             lineWidth: ctx => ctx.tick.value === 1 ? 2 : 1
@@ -110,10 +133,19 @@ async function loadJson(path) {
           callbacks: {
             label: ctx => {
               const b = benches[ctx.dataIndex];
+              if (b.monoruby_failed) {
+                return [b.name + ": monoruby failed",
+                        b.yjit_failed ? "yjit also failed"
+                                      : "yjit: " + b.yjit_ms.toFixed(2) + " ms"];
+              }
+              if (b.yjit_failed) {
+                return [b.name + ": yjit failed",
+                        "monoruby: " + b.monoruby_ms.toFixed(2) + " ms"];
+              }
               return [
                 ctx.parsed.x.toFixed(2) + "× YJIT",
-                "monoruby: " + b.monoruby_ips.toFixed(2) + " i/s",
-                "yjit:     " + b.yjit_ips.toFixed(2) + " i/s"
+                "monoruby: " + b.monoruby_ms.toFixed(2) + " ms",
+                "yjit:     " + b.yjit_ms.toFixed(2) + " ms"
               ];
             }
           }
@@ -125,17 +157,18 @@ async function loadJson(path) {
   const tbody = document.querySelector("#latestTable tbody");
   for (const b of benches) {
     const tr = document.createElement("tr");
-    const cells = [
-      b.name,
-      b.monoruby_ips.toFixed(3),
-      b.yjit_ips.toFixed(3),
-      b.ratio.toFixed(3) + "x"
-    ];
-    for (const v of cells) {
+    const fmt = (v, fail) => {
       const td = document.createElement("td");
-      td.textContent = v;
-      tr.appendChild(td);
-    }
+      if (fail) { td.textContent = "ERROR"; td.className = "err"; }
+      else { td.textContent = v; }
+      return td;
+    };
+    const nameTd = document.createElement("td");
+    nameTd.textContent = b.name;
+    tr.appendChild(nameTd);
+    tr.appendChild(fmt(b.monoruby_ms != null ? b.monoruby_ms.toFixed(3) : "", b.monoruby_failed));
+    tr.appendChild(fmt(b.yjit_ms != null ? b.yjit_ms.toFixed(3) : "", b.yjit_failed));
+    tr.appendChild(fmt(b.ratio != null ? b.ratio.toFixed(3) + "x" : "", b.ratio == null));
     tbody.appendChild(tr);
   }
 })();

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,6 @@ on:
       - 'monoruby_attr/**'
       - 'rubymap/**'
       - 'Cargo.toml'
-      - 'benchmark/**'
       - '.github/workflows/bench.yml'
       - '.github/portal/**'
       - '.github/bench-pages/**'
@@ -21,7 +20,7 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 240
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -38,105 +37,146 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install system deps for yjit-bench
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libmagickwand-dev imagemagick libsqlite3-dev libpq-dev libyaml-dev
+
       - name: Install monoruby (release)
         run: RUSTFLAGS=-Cforce-frame-pointers cargo install --path monoruby --locked
 
-      - name: Install benchmark_driver
-        run: gem install --no-document benchmark_driver
+      - name: Clone yjit-bench (Shopify/yjit-bench)
+        run: git clone --depth 1 https://github.com/Shopify/yjit-bench.git ../ruby-bench
 
-      - name: Run benchmarks (monoruby vs ruby --yjit)
+      - name: bundle install yjit-bench
+        working-directory: ../ruby-bench
+        run: |
+          gem install --no-document bundler
+          bundle install || true
+
+      - name: Run yjit-bench (monoruby vs ruby --yjit)
         id: run
-        working-directory: benchmark
+        working-directory: ../ruby-bench
         shell: bash
         run: |
           set +e
           set -uo pipefail
 
           OUT="$GITHUB_WORKSPACE/bench-results"
-          mkdir -p "$OUT"
-          RAW="$OUT/raw.md"
+          mkdir -p "$OUT/data"
 
-          # Same set as bin/bench, minus app_aobench (slow) and bedcov for CI time.
-          BENCHMARKS=(
-            app_fib.yml
-            so_nbody.yml
-            so_mandelbrot.yml
-            bf.rb
-            plb2/nqueen.rb
-            plb2/sudoku.rb
-            plb2/matmul.rb
-          )
-
-          # Use full paths for both executables. benchmark-driver treats a
-          # bare name like "ruby" as a relative path (./ruby) and fails with
-          # ENOENT when run from the benchmark/ directory.
-          RUBY_BIN=$(command -v ruby)
-
-          benchmark-driver \
-            -o markdown \
-            "${BENCHMARKS[@]}" \
+          # Options follow bin/ruby-bench: --rss --harness=harness-warmup
+          # Plus --no-sudo / --no-pinning because GH-hosted runners lack the
+          # privileges and CPU layout assumptions yjit-bench's CPUConfig wants.
+          # We measure ALL benchmarks (no --headline, no --category) and let
+          # benchmarks that error under monoruby be recorded as failures.
+          ./run_benchmarks.rb \
+            --no-sudo \
+            --no-pinning \
+            --rss \
+            --harness=harness-warmup \
+            --out_path="$OUT/data" \
+            --out-name="$OUT/data/raw" \
             -e "monoruby::$HOME/.cargo/bin/monoruby" \
-            -e "yjit::$RUBY_BIN --yjit" \
-            | tee "$RAW"
+            -e "yjit::$(command -v ruby) --yjit" \
+            2>&1 | tee "$OUT/run.log"
 
-      - name: Aggregate results
-        id: agg
-        shell: bash
-        run: |
-          set +e
-          set -uo pipefail
-
-          OUT="$GITHUB_WORKSPACE/bench-results"
-          RAW="$OUT/raw.md"
+          # run_benchmarks.rb exits 1 when at least one benchmark failed.
+          # We always want to publish the partial result.
+          true
 
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           SHORT_SHA="${GITHUB_SHA:0:7}"
+          echo "timestamp=$TIMESTAMP" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
-          # Parse markdown table rows of the form
-          #   |name |monoruby |yjit |
-          # Skip the header row (|name) and the alignment row (|:---).
-          awk -F'|' -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" '
-          BEGIN {
-            printf "{\"timestamp\":\"%s\",\"commit\":\"%s\",\"benchmarks\":[", ts, sha
-            first=1
+      - name: Aggregate to portal JSON
+        env:
+          TIMESTAMP: ${{ steps.run.outputs.timestamp }}
+          SHORT_SHA: ${{ steps.run.outputs.short_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OUT="$GITHUB_WORKSPACE/bench-results"
+          RAW="$OUT/data/raw.json"
+
+          # Parse the run log for the "Failed benchmarks:" block so we can
+          # surface benchmarks that errored on every executable. Listed names
+          # become entries with both *_ms = nil.
+          ruby -rjson <<'RUBY' > "$OUT/portal.json"
+          out = ENV['GITHUB_WORKSPACE'] + '/bench-results'
+          raw = JSON.parse(File.read(out + '/data/raw.json'))
+          mr_data = raw.dig('raw_data', 'monoruby') || {}
+          yj_data = raw.dig('raw_data', 'yjit') || {}
+
+          median = ->(arr) {
+            return nil if arr.nil? || arr.empty?
+            s = arr.sort
+            n = s.size
+            n.odd? ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2.0
           }
-          /^\|name/ { next }
-          /^\|:/ { next }
-          /^\|/ {
-            name=$2; gsub(/^[ \t]+|[ \t]+$/,"",name)
-            mr=$3+0; yj=$4+0
-            if (yj > 0 && mr > 0) {
-              if (!first) printf ","
-              first=0
-              printf "{\"name\":\"%s\",\"monoruby_ips\":%.4f,\"yjit_ips\":%.4f,\"ratio\":%.4f}", \
-                     name, mr, yj, mr/yj
+
+          # Failures for each executable, parsed from run.log's
+          #   "Failed benchmarks:" section ("  <exe>: a, b, c").
+          failures = Hash.new { |h, k| h[k] = [] }
+          log = File.read(out + '/run.log') rescue ''
+          if (idx = log.index(/^Failed benchmarks:$/m))
+            log[idx..].each_line.drop(1).each do |line|
+              if line =~ /\A\s+(\S+):\s*(.+?)\s*\z/
+                failures[$1].concat($2.split(/,\s*/))
+              else
+                break
+              end
+            end
+          end
+
+          all_names = (mr_data.keys + yj_data.keys + failures.values.flatten).uniq.sort
+
+          benches = all_names.map do |name|
+            mr = mr_data[name]
+            yj = yj_data[name]
+            mr_med = mr ? median.call(mr['bench']) : nil
+            yj_med = yj ? median.call(yj['bench']) : nil
+            mr_ms = (mr_med && mr_med > 0) ? mr_med * 1000.0 : nil
+            yj_ms = (yj_med && yj_med > 0) ? yj_med * 1000.0 : nil
+            ratio = (mr_ms && yj_ms) ? yj_ms / mr_ms : nil
+            {
+              name: name,
+              monoruby_ms: mr_ms,
+              yjit_ms: yj_ms,
+              ratio: ratio,
+              monoruby_failed: mr_ms.nil?,
+              yjit_failed: yj_ms.nil?,
             }
-          }
-          END { print "]}" }
-          ' "$RAW" > "$OUT/latest.json"
+          end
 
-          cat "$OUT/latest.json"
+          puts JSON.generate(
+            timestamp: ENV['TIMESTAMP'],
+            commit: ENV['SHORT_SHA'],
+            benchmarks: benches,
+          )
+          RUBY
 
+          # Step Summary
           {
-            echo "## Benchmark vs YJIT"
+            echo "## Benchmark vs YJIT (yjit-bench)"
             echo ""
             echo "monoruby commit: \`$SHORT_SHA\`"
             echo ""
-            echo "| Benchmark | monoruby (i/s) | YJIT (i/s) | monoruby / YJIT |"
+            echo "| Benchmark | monoruby (ms) | YJIT (ms) | YJIT / monoruby |"
             echo "| --- | ---: | ---: | ---: |"
-            awk -F'|' '
-            /^\|name/ { next }
-            /^\|:/ { next }
-            /^\|/ {
-              name=$2; gsub(/^[ \t]+|[ \t]+$/,"",name)
-              mr=$3+0; yj=$4+0
-              if (yj > 0 && mr > 0)
-                printf "| %s | %.4f | %.4f | %.3fx |\n", name, mr, yj, mr/yj
-            }' "$RAW"
+            ruby -rjson <<'RUBY'
+            data = JSON.parse(File.read(ENV['GITHUB_WORKSPACE'] + '/bench-results/portal.json'))
+            data['benchmarks'].each do |b|
+              mr = b['monoruby_failed'] ? 'ERROR' : '%.3f' % b['monoruby_ms']
+              yj = b['yjit_failed']     ? 'ERROR' : '%.3f' % b['yjit_ms']
+              ratio = b['ratio'] ? '%.3fx' % b['ratio'] : '-'
+              puts "| #{b['name']} | #{mr} | #{yj} | #{ratio} |"
+            end
+          RUBY
           } >> "$GITHUB_STEP_SUMMARY"
-
-          echo "timestamp=$TIMESTAMP" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Upload results
         if: always()
@@ -150,8 +190,8 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TIMESTAMP: ${{ steps.agg.outputs.timestamp }}
-          SHORT_SHA: ${{ steps.agg.outputs.short_sha }}
+          TIMESTAMP: ${{ steps.run.outputs.timestamp }}
+          SHORT_SHA: ${{ steps.run.outputs.short_sha }}
         run: |
           set -euo pipefail
 
@@ -173,20 +213,22 @@ jobs:
           mkdir -p bench/data
 
           if [ ! -f bench/data/history.csv ]; then
-            echo "timestamp,commit,benchmark,monoruby_ips,yjit_ips,ratio" > bench/data/history.csv
+            echo "timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed" > bench/data/history.csv
           fi
 
-          awk -F'|' -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" '
-          /^\|name/ { next }
-          /^\|:/ { next }
-          /^\|/ {
-            name=$2; gsub(/^[ \t]+|[ \t]+$/,"",name)
-            mr=$3+0; yj=$4+0
-            if (yj > 0 && mr > 0)
-              printf "%s,%s,%s,%.4f,%.4f,%.4f\n", ts, sha, name, mr, yj, mr/yj
-          }' "$GITHUB_WORKSPACE/bench-results/raw.md" >> bench/data/history.csv
+          ruby -rjson <<'RUBY' >> bench/data/history.csv
+          data = JSON.parse(File.read(ENV['GITHUB_WORKSPACE'] + '/bench-results/portal.json'))
+          ts = ENV['TIMESTAMP']
+          sha = ENV['SHORT_SHA']
+          data['benchmarks'].each do |b|
+            mr = b['monoruby_failed'] ? '' : '%.4f' % b['monoruby_ms']
+            yj = b['yjit_failed']     ? '' : '%.4f' % b['yjit_ms']
+            ra = b['ratio'] ? '%.4f' % b['ratio'] : ''
+            puts [ts, sha, b['name'], mr, yj, ra, b['monoruby_failed'], b['yjit_failed']].join(',')
+          end
+          RUBY
 
-          cp "$GITHUB_WORKSPACE/bench-results/latest.json" bench/latest.json
+          cp "$GITHUB_WORKSPACE/bench-results/portal.json" bench/latest.json
           cp "$GITHUB_WORKSPACE/.github/bench-pages/index.html" bench/index.html
 
           git add -A


### PR DESCRIPTION
## Summary

Replace the local-`benchmark-driver` bench setup with the full **[Shopify/yjit-bench](https://github.com/Shopify/yjit-bench)** suite, matching the options used by `bin/ruby-bench`. Every benchmark in `yjit-bench` runs on every master push; benchmarks that error out under monoruby are still surfaced as red `ERROR` entries in the dashboard rather than being silently skipped.

### Workflow (`.github/workflows/bench.yml`)

```bash
./run_benchmarks.rb \
  --no-sudo \
  --no-pinning \
  --rss \
  --harness=harness-warmup \
  --out_path="$OUT/data" \
  --out-name="$OUT/data/raw" \
  -e "monoruby::$HOME/.cargo/bin/monoruby" \
  -e "yjit::$(command -v ruby) --yjit"
```

- `--no-sudo` / `--no-pinning` because GH-hosted runners don't have the CPU governor / address-space controls yjit-bench's `CPUConfig` wants.
- Pre-install `libmagickwand-dev`, `imagemagick`, `libsqlite3-dev`, `libpq-dev`, `libyaml-dev` so the gem builds for heavier benchmarks (rmagick, activerecord, hexapdf, …) work.
- `run_benchmarks.rb` exits 1 when any benchmark fails. monoruby will fail on a lot of the gem/Rails based suites — that's expected; we swallow the exit so the partial result still gets published.
- `timeout-minutes: 240` for headroom; the full set is much heavier than the prior 7-bench benchmark-driver run.

### Aggregator

An inline Ruby script reads yjit-bench's `data/raw.json`, takes the median of each warmed-up `bench` array (in seconds), converts to milliseconds, and emits a `bench/latest.json` shaped for the dashboard:

```json
{
  "timestamp": "...", "commit": "...",
  "benchmarks": [
    { "name": "fib",
      "monoruby_ms": 31.47, "yjit_ms": 209.21, "ratio": 6.65,
      "monoruby_failed": false, "yjit_failed": false },
    { "name": "lobsters",
      "monoruby_ms": null, "yjit_ms": 1234.5, "ratio": null,
      "monoruby_failed": true, "yjit_failed": false }
  ]
}
```

`ratio = yjit_ms / monoruby_ms` so values above `1.0` mean monoruby beat YJIT on that benchmark. Benchmarks that error in *both* runtimes are recovered from the `Failed benchmarks:` section of `run.log` so they still appear in the snapshot with both `*_failed = true`.

### Dashboard (`.github/bench-pages/index.html`)

- **Bar chart**: sorted by ratio descending, with monoruby-failed rows pushed to the bottom on a red negative-stub bar (✕ marker on the label) so they don't compress the live ratio scale.
- **Bar colors**: ≥1.0× green, ≥0.7× yellow-green, ≥0.4× yellow, else red. Monoruby failures are red regardless of YJIT's result.
- **Bold gridline at `x = 1.0`** marks parity with YJIT.
- **Tooltip** prints either raw ms for both runtimes or `"monoruby failed"` / `"yjit failed"` as appropriate.
- **Table** renders `"ERROR"` in red for failed cells; otherwise raw ms / ratio.

### History CSV

`bench/data/history.csv` schema gains failure flags:

```
timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed
```

So we can plot per-benchmark history and see when a benchmark started/stopped failing on monoruby. (The dashboard doesn't render that yet — separate PR.)

## Notes

- Reproduced locally on a single benchmark (`fib`) with `--no-sudo --no-pinning --rss --harness=harness-warmup` and the JSON path was correctly emitted with `monoruby_ms = 31.47, yjit_ms = 209.21, ratio = 6.65`.
- The full yjit-bench run on a shared runner is genuinely long (most benchmarks fail fast on monoruby for parser/gem reasons, but the few that succeed take 30+ seconds each on the warmup harness). Expect 30–90 minute jobs.

## Test plan

- [ ] After merge, manually `Run workflow` on `bench` and inspect the run summary's table — every yjit-bench benchmark should appear, with most monoruby cells reading `ERROR` and the ones that succeed showing reasonable ms / ratio.
- [ ] Open https://sisshiki1969.github.io/monoruby/bench/ — chart shows green bars at the top for the benchmarks where monoruby beats YJIT and red `✕` rows at the bottom for failures.
- [ ] Confirm `bench/data/history.csv` has rows for every benchmark with the new `monoruby_failed` / `yjit_failed` columns.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_