### PR TITLE
fix: drop MatchData inner on GC sweep to prevent memory leak

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [master, prism]
+    branches: [master]
   pull_request:
     branches: [master]
 

--- a/bin/test
+++ b/bin/test
@@ -58,10 +58,10 @@ rm *.log
 # Run the ruby-bench output-diff harness if the ruby-bench checkout is
 # present alongside this repo. Reuses the already-built instrumented
 # monoruby and the `ruby` from PATH; exits non-zero on output mismatch.
-#if [ -d "../ruby-bench/benchmarks" ]; then
-#  echo "Running ruby-bench output diff..."
-#  MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
-#fi
+if [ -d "../ruby-bench/benchmarks" ]; then
+  echo "Running ruby-bench output diff..."
+  MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
+fi
 
 # Run ruby/spec with instrumented binary for coverage
 if [ -d "../spec" ] && [ -d "../mspec" ]; then

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -722,6 +722,7 @@ impl alloc::GCBox for RValue {
                 ObjTy::IO => ManuallyDrop::drop(&mut self.kind.io),
                 ObjTy::RATIONAL => ManuallyDrop::drop(&mut self.kind.rational),
                 ObjTy::STRUCT => ManuallyDrop::drop(&mut self.kind.struct_inner),
+                ObjTy::MATCHDATA => ManuallyDrop::drop(&mut self.kind.matchdata),
                 _ => {}
             }
             self.set_next_none();


### PR DESCRIPTION
## Summary

- `RValue::free()` was missing an arm for `ObjTy::MATCHDATA`, so the `ManuallyDrop<MatchDataInner>` was never dropped during GC sweep. Each `String#match` (and any path that produces a `MatchData`) leaked the heystack `String` and the captures `Box<Vec<...>>`.
- For workloads that match large strings — e.g. tinygql parsing 80 KB GraphQL documents via `StringScanner`, which calls `String#match` with `rest_str = @str.byteslice(@pos..-1)` per token — RSS grew several hundred MB per parse and OOM-killed within a few iterations of `run_benchmarks.rb --once tinygql -e "monoruby"`.
- Adds `ObjTy::MATCHDATA => ManuallyDrop::drop(&mut self.kind.matchdata)` to the sweep match. `COMPLEX` / `METHOD` / `UMETHOD` / `PROC` / `RANGE` also fall through to `_ => {}` but their inners only hold Copy-style fields (`Value` / `FuncId` / `ClassId` / `Lfp` / `BytecodePtr`) with no owned heap, so no drop arm is needed for them.
- Bundles two unrelated working-tree tweaks: dropping the `prism` CI trigger (already merged into master) and re-enabling `bin/ruby-bench-diff` in `bin/test`.

## Test plan

- [x] `"abc".match(re)` x100k x3 with `GC.start`: 24 → 42 → 59 → 76 MB before, 32 → 32 → 32 MB flat after.
- [x] `ruby-bench --once tinygql -e monoruby`: previously OOM-killed (exit 137) right after `itr: time` on the first iteration; now completes in 24s at 871 MiB RSS.
- [x] `cargo nextest run --release` — 2322 / 2322 pass.
- [x] `gc-stress` build: `MatchData` captures / `to_s` / `pre_match` / `post_match` survive 1000 iterations and held-in-array + `GC.start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)