### PR TITLE
bench: stop the patch step from interpolating #{output_path} too early

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,7 +61,9 @@ jobs:
           file = "lib/benchmark_runner/cli.rb"
           src = File.read(file)
           unless src.include?("failures.json")
-            insert = "      File.write(\"#{output_path}.failures.json\", JSON.generate(bench_failures))\n\n"
+            # Single-quoted Ruby string so #{output_path} is preserved
+            # verbatim; it'll be interpolated inside cli.rb at run time.
+            insert = '      File.write("#{output_path}.failures.json", JSON.generate(bench_failures))' + "\n\n"
             patched = src.sub(/(^      # Save the output in a text file)/) { insert + $1 }
             raise "could not locate insertion point" if patched == src
             File.write(file, patched)


### PR DESCRIPTION
## What broke

#417's patch step in `bench.yml` ran a Ruby heredoc whose body contained:

```ruby
insert = "      File.write(\"#{output_path}.failures.json\", ...)\n\n"
```

The heredoc opener was `<<'RUBY'` so the **shell** doesn't interpolate, but the body is still ordinary Ruby and the **outer double-quoted string is interpolated by Ruby itself** when the heredoc executes. There's no `output_path` local at that scope, so the step blew up immediately on every run:

```
-:4:in '<main>': undefined local variable or method 'output_path' for main (NameError)
Error: Process completed with exit code 1.
```

…and the workflow died before any benchmark could start. I caught and fixed this locally before pushing #417 but somehow committed the broken version. Apologies.

## Fix

Use a single-quoted Ruby string for that literal so the `#{output_path}` token is preserved verbatim and ends up inside `yjit-bench`'s `cli.rb`, where it interpolates correctly against the `output_path` local that exists at the insertion point.

```diff
-            insert = "      File.write(\"#{output_path}.failures.json\", JSON.generate(bench_failures))\n\n"
+            # Single-quoted Ruby string so #{output_path} is preserved
+            # verbatim; it'll be interpolated inside cli.rb at run time.
+            insert = '      File.write("#{output_path}.failures.json", JSON.generate(bench_failures))' + "\n\n"
```

## Verified

On a fresh clone of `Shopify/yjit-bench`:

```sh
$ ruby - <<'RUBY'
... (the corrected patch script) ...
RUBY
patched: writes <output_path>.failures.json

$ grep "failures.json" lib/benchmark_runner/cli.rb
      File.write("#{output_path}.failures.json", JSON.generate(bench_failures))
```

Exit 0 from the patch step; `cli.rb` line 127 contains the correct verbatim interpolation token.

## Test plan

- [ ] After merge, `Run workflow` on `bench` and confirm the **Patch yjit-bench…** step succeeds.
- [ ] Run completes and produces `bench-results/data/raw.failures.json` alongside the regular outputs.
- [ ] Dashboard at https://sisshiki1969.github.io/monoruby/bench/ surfaces failure reasons (timeout / SIGSEGV / etc.) for any benchmark that errored.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_