### PR TITLE
deps: drop libc transitive via ruby-prism fork bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,9 +1746,8 @@ dependencies = [
 [[package]]
 name = "ruby-prism"
 version = "1.9.0"
-source = "git+https://github.com/sisshiki1969/prism.git?rev=2ffc03f8ecda374a528d6ad870111fdbb48daaac#2ffc03f8ecda374a528d6ad870111fdbb48daaac"
+source = "git+https://github.com/sisshiki1969/prism.git?rev=28752c89d0da012d91794cf10bd5f8d7225cc32d#28752c89d0da012d91794cf10bd5f8d7225cc32d"
 dependencies = [
- "libc",
  "ruby-prism-sys",
  "serde",
  "serde_json",

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -48,7 +48,7 @@ monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = 
 monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "rc" }
 onigmo-regex = { git = "https://github.com/sisshiki1969/onigmo-regex.git" }
 ruruby-parse = { path = "../ruruby-parse" }
-ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", rev = "2ffc03f8ecda374a528d6ad870111fdbb48daaac" }
+ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", rev = "28752c89d0da012d91794cf10bd5f8d7225cc32d" }
 monoruby-attr = { path = "../monoruby_attr" }
 rubymap = { path = "../rubymap" }
 indexmap = "2.14.0"


### PR DESCRIPTION
## Summary
- Bump the `sisshiki1969/prism` `ruby-prism` rev to `28752c89d`, which removes the `libc` crate from the prism Rust wrapper.
- The fork's `Options::scopes` now keeps the staged `Vec<Scope>` in its own `scopes_storage` field and initializes each per-local `pm_string_t` as `PM_STRING_CONSTANT` (via `pm_string_constant_init`) pointing into the owned byte buffer, instead of `libc::malloc`'ing a copy and handing it to `pm_string_owned_init`. Prism's `pm_string_cleanup` is a no-op for `PM_STRING_CONSTANT`, so `pm_options_free` still safely tears down the `xcalloc`'d scope/locals arrays without touching our buffers.
- Net effect on monoruby: only the `ruby-prism` rev and `Cargo.lock` move.

## Test plan
- [x] `cargo build --release`
- [x] `cargo test -p monoruby --lib builtins::kernel` — 71 passed, 0 failed
- [x] Manual eval smoke test (`eval("x + y")`, scope-capturing eval, eval inside method) returns expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)