### PR TITLE
deps: consume prism via git submodule, auto-populate vendor via rake

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,20 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+        with:
+          # `vendor/prism` is a submodule; the `ruby-prism-sys` build
+          # script `bundle exec rake cargo:build`s against its source
+          # tree to regenerate `vendor/prism-{ver}/`.
+          submodules: recursive
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "4.0.1"
+          bundler-cache: false
+      - name: Install prism Gemfile deps
+        # ruby-prism-sys's build.rs invokes `bundle exec rake cargo:build`
+        # in the submodule.
+        run: bundle install --gemfile=vendor/prism/Gemfile
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/prism"]
+	path = vendor/prism
+	url = https://github.com/sisshiki1969/prism.git
+	branch = monoruby

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,8 +496,26 @@ The repository vendors several dependencies as local paths rather than crates.io
 - `hashbrown/` — local fork
 - `rust-smallvec/` — local fork with const-generics feature
 - `ruruby-parse/` — developed in tandem with monoruby
+- `vendor/prism/` — **git submodule**, branch `monoruby` of `sisshiki1969/prism`. The Rust wrapper crates `ruby-prism` and `ruby-prism-sys` are consumed as path deps from inside this submodule.
 
 When modifying these, be aware changes affect the whole workspace.
+
+### Working with the prism submodule
+
+After cloning monoruby:
+
+```sh
+git submodule update --init --recursive
+```
+
+The `ruby-prism-sys` build script (`vendor/prism/rust/ruby-prism-sys/build/vendored.rs`) invokes `bundle exec rake cargo:build` against `vendor/prism/` to regenerate `vendor/prism/rust/ruby-prism{-sys,}/vendor/prism-{ver}/` (which is `.gitignore`'d in the prism repo). Prerequisites:
+
+```sh
+# One-time, in the prism submodule
+(cd vendor/prism && bundle install)
+```
+
+The auto-populate is gated on `vendor/{src,include}` existence under each prism rust crate, so it only runs once per checkout. Wipe `vendor/prism/rust/ruby-prism-sys/vendor/` to force a fresh `rake cargo:build` after editing prism sources.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,9 +1746,7 @@ dependencies = [
 [[package]]
 name = "ruby-prism"
 version = "1.9.0"
-source = "git+https://github.com/sisshiki1969/prism.git?rev=2ffc03f8ecda374a528d6ad870111fdbb48daaac#2ffc03f8ecda374a528d6ad870111fdbb48daaac"
 dependencies = [
- "libc",
  "ruby-prism-sys",
  "serde",
  "serde_json",
@@ -1757,8 +1755,6 @@ dependencies = [
 [[package]]
 name = "ruby-prism-sys"
 version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f85fd9571455bdca2b3bf0b2f543cd13ac39d5de0026a8eb2deb94ffd264f00"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,3 @@ resolver = "2"
 
 [profile.dev]
 opt-level = 1
-
-# `sisshiki1969/prism` only carries the Rust-wrapper changes; the
-# `ruby-prism-sys` crate inside the fork has the same source as
-# upstream, but its `vendor/prism-{ver}/` C-source dir is `.gitignore`'d
-# (rake builds it locally before publishing) and so doesn't exist in
-# the fork tree. Pull `ruby-prism-sys` from crates.io instead — that
-# tarball ships the populated vendor dir and is bit-identical to what
-# the fork would produce.
-[patch."https://github.com/sisshiki1969/prism.git"]
-ruby-prism-sys = "1.9.0"

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -48,7 +48,7 @@ monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = 
 monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "rc" }
 onigmo-regex = { git = "https://github.com/sisshiki1969/onigmo-regex.git" }
 ruruby-parse = { path = "../ruruby-parse" }
-ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", rev = "2ffc03f8ecda374a528d6ad870111fdbb48daaac" }
+ruby-prism = { path = "../vendor/prism/rust/ruby-prism" }
 monoruby-attr = { path = "../monoruby_attr" }
 rubymap = { path = "../rubymap" }
 indexmap = "2.14.0"


### PR DESCRIPTION
## Summary
- Add `vendor/prism/` as a git submodule pinned to `sisshiki1969/prism` branch `monoruby`. The `monoruby` branch's latest commit:
  - drops the `libc` dep from `ruby-prism` (covered by #421);
  - auto-populates `vendor/prism-{ver}/` from `ruby-prism-sys/build/vendored.rs` by shelling out to `bundle exec rake cargo:build` against the submodule's source tree;
  - removes the previously-committed `rust/ruby-prism/vendor/prism-1.9.0/config.json` shim, which is now regenerated by the same build script.
- Switch `monoruby/Cargo.toml` to `ruby-prism = { path = "../vendor/prism/rust/ruby-prism" }`.
- Drop the workspace-level `[patch."https://github.com/sisshiki1969/prism.git"] ruby-prism-sys = "1.9.0"` shim — `ruby-prism-sys` is now pulled in-tree from `vendor/prism/rust/ruby-prism-sys`.
- CI checks out submodules recursively and runs `bundle install --gemfile=vendor/prism/Gemfile` so the rake invocation has its gem deps.
- CLAUDE.md documents the new submodule + setup.

Supersedes #421 (the rev-bump approach is no longer needed once we consume by submodule).

## Test plan
- [x] `cargo build --release` (clean state — wiped `vendor/prism/rust/ruby-prism{-sys,}/vendor/` first; build script invokes `rake cargo:build` and populates them)
- [x] `cargo test -p monoruby --lib builtins::kernel` — 71 passed, 0 failed
- [x] Verified the deletion of the committed `config.json` is harmless: rake regenerates it.
- [ ] Confirm CI green (submodule checkout + `bundle install` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)