### PR TITLE
perf: speed up Kernel#respond_to? + restore trivial-method ConstReturn fold

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -260,7 +260,7 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             *self_val = (*arg.as_array()).clone();
             return Ok(self_val.into());
         }
-        let to_ary = IdentId::get_id("to_ary");
+        let to_ary = IdentId::TO_ARY;
         if let Some(func_id) = globals.check_method(arg, to_ary) {
             let result = vm.invoke_func_inner(globals, func_id, arg, &[], None, None)?;
             if result.is_array_ty() {
@@ -1443,7 +1443,7 @@ fn drop(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn zip(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ary = lfp.self_val().as_array();
     let self_len = self_ary.len();
-    let each_id = IdentId::get_id("each");
+    let each_id = IdentId::EACH;
     let to_enum_id = IdentId::get_id("to_enum");
     let next_id = IdentId::get_id("next");
 

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -202,7 +202,7 @@ pub(super) fn init_encoding(globals: &mut Globals) {
     {
         globals.set_constant_by_str(enc.id(), "ASCII", us_ascii);
     }
-    if let Some(utf8) = globals.store.get_constant_noautoload(enc.id(), IdentId::get_id("UTF_8")) {
+    if let Some(utf8) = globals.store.get_constant_noautoload(enc.id(), IdentId::UTF_8) {
         globals.set_constant_by_str(enc.id(), "CP65001", utf8);
     }
 
@@ -341,7 +341,7 @@ pub(super) fn str_encoding(
     }
     let enc = self_.as_rstring_inner().encoding();
     let enc_class = vm
-        .get_constant_checked(globals, OBJECT_CLASS, IdentId::get_id("Encoding"))?
+        .get_constant_checked(globals, OBJECT_CLASS, IdentId::ENCODING)?
         .expect_class(globals)?
         .id();
     let const_name = encoding_constant_name(enc);
@@ -480,7 +480,7 @@ fn enc_default_external(
     let enc_class = encoding_class(globals);
     let utf8 = globals
         .store
-        .get_constant_noautoload(enc_class, IdentId::get_id("UTF_8"))
+        .get_constant_noautoload(enc_class, IdentId::UTF_8)
         .unwrap_or(Value::nil());
     Ok(utf8)
 }
@@ -543,7 +543,7 @@ fn enc_list(
     let enc_class = encoding_class(globals);
     let utf8 = globals
         .store
-        .get_constant_noautoload(enc_class, IdentId::get_id("UTF_8"))
+        .get_constant_noautoload(enc_class, IdentId::UTF_8)
         .unwrap_or(Value::nil());
     let ascii = globals
         .store

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -140,7 +140,7 @@ fn nameerr_name(
     let self_val = lfp.self_val();
     let v = globals
         .store
-        .get_ivar(self_val, IdentId::get_id("/name"))
+        .get_ivar(self_val, IdentId::_NAME)
         .unwrap_or_default();
     Ok(v)
 }
@@ -176,7 +176,7 @@ fn nameerr_initialize(
             // `NameError#name` can return it as-is.
             globals
                 .store
-                .set_ivar(self_, IdentId::get_id("/name"), name)?;
+                .set_ivar(self_, IdentId::_NAME, name)?;
         }
     }
     Ok(Value::nil())

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1853,7 +1853,7 @@ fn value_to_timeval(
     if let Some(rv) = val.try_rvalue()
         && rv.ty() == ObjTy::TIME
     {
-        let to_f = IdentId::get_id("to_f");
+        let to_f = IdentId::TO_F;
         let f = vm.invoke_method_inner(globals, to_f, val, &[], None, None)?;
         if let Some(f) = f.try_float() {
             let secs = f.floor() as i64;

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -436,7 +436,7 @@ fn default_proc_assign(
     let proc_val = if arg.is_proc().is_some() {
         arg
     } else {
-        let to_proc_id = IdentId::get_id("to_proc");
+        let to_proc_id = IdentId::TO_PROC;
         let coerced =
             vm.invoke_method_if_exists(globals, to_proc_id, arg, &[], None, None)?;
         match coerced {
@@ -554,7 +554,7 @@ fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     if lhs.len() != rhs.len() {
         return Ok(Value::bool(false));
     }
-    let eql_id = IdentId::get_id("eql?");
+    let eql_id = IdentId::EQL_;
     crate::value::exec_recursive_paired(self_val.id(), rhs_v.id(), || {
         for (k, lhs_value) in lhs.iter() {
             let Some(rhs_value) = rhs.get(k, vm, globals)? else {
@@ -603,7 +603,7 @@ fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             const VAL_MIX: i64 = 0xc6bc279692b5c323u64 as i64;
             const KEY_OFFSET: i64 = 0x9e3779b97f4a7c15u64 as i64;
             let mut acc: i64 = (h.len() as i64).wrapping_mul(0x9ddfea08eb382d69u64 as i64);
-            let hash_id = IdentId::get_id("hash");
+            let hash_id = IdentId::HASH;
             for (k, v) in h.iter() {
                 let kh = vm
                     .invoke_method_inner(globals, hash_id, k, &[], None, None)?
@@ -939,7 +939,7 @@ fn map(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> R
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
         None => {
-            let id = IdentId::get_id("each");
+            let id = IdentId::EACH;
             return hash_to_sized_enum(vm, id, lfp, pc);
         }
         Some(block) => block,

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2304,20 +2304,12 @@ fn object_respond_to(
         // respond_to_missing?, so fall through.
     }
     // Method not visible. CRuby calls `recv.respond_to_missing?(name, include_all)`
-    // and coerces the result to bool. If `recv_class` still resolves to the
-    // default `Object#respond_to_missing?` (returns `false` unconditionally),
-    // fold the whole call to `false`. The class_version guard upstream
-    // catches any later override that would change the resolution.
-    //
-    // Note: we cannot rely on `ISeqHint::ConstReturn` for this — `hint()`
-    // currently only fires for empty bodies / explicit `return`, not for
-    // single-expression bodies wrapped in CompStmt (which is how the
-    // default `def respond_to_missing?(name, include_private = false); false; end`
-    // parses).
-    let default_fid = match store.default_respond_to_missing_fid() {
-        Some(fid) => fid,
-        None => return false,
-    };
+    // and coerces the result to bool. If `respond_to_missing?` resolves to
+    // an ISeq whose hint says it returns a constant (typical for the
+    // default `Object#respond_to_missing?` which is `def ...; false; end`
+    // and any user override that just returns a literal), fold the call
+    // to that value. The class_version guard upstream catches any later
+    // override that would change the resolution.
     let resolved = store
         .check_method_for_class_with_version(
             recv_class,
@@ -2325,8 +2317,11 @@ fn object_respond_to(
             ctx.class_version(),
         )
         .and_then(|e| e.func_id());
-    if resolved == Some(default_fid) {
-        state.def_C(dst, Immediate::bool(false));
+    if let Some(fid) = resolved
+        && let Some(iseq) = store[fid].is_iseq()
+        && let ISeqHint::ConstReturn(v) = store[iseq].hint
+    {
+        state.def_C(dst, Immediate::bool(v.as_bool()));
         return true;
     }
     false

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2300,9 +2300,35 @@ fn object_respond_to(
             state.def_C(dst, Immediate::bool(true));
             return true;
         }
+        // Found but private and !include_all: CRuby still consults
+        // respond_to_missing?, so fall through.
     }
-    // Method not found directly. Cannot JIT-inline because respond_to_missing?
-    // may be overridden and needs to be called at runtime.
+    // Method not visible. CRuby calls `recv.respond_to_missing?(name, include_all)`
+    // and coerces the result to bool. If `recv_class` still resolves to the
+    // default `Object#respond_to_missing?` (returns `false` unconditionally),
+    // fold the whole call to `false`. The class_version guard upstream
+    // catches any later override that would change the resolution.
+    //
+    // Note: we cannot rely on `ISeqHint::ConstReturn` for this — `hint()`
+    // currently only fires for empty bodies / explicit `return`, not for
+    // single-expression bodies wrapped in CompStmt (which is how the
+    // default `def respond_to_missing?(name, include_private = false); false; end`
+    // parses).
+    let default_fid = match store.default_respond_to_missing_fid() {
+        Some(fid) => fid,
+        None => return false,
+    };
+    let resolved = store
+        .check_method_for_class_with_version(
+            recv_class,
+            IdentId::RESPOND_TO_MISSING_,
+            ctx.class_version(),
+        )
+        .and_then(|e| e.func_id());
+    if resolved == Some(default_fid) {
+        state.def_C(dst, Immediate::bool(false));
+        return true;
+    }
     false
 }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2198,7 +2198,7 @@ fn initialize_clone(
     let self_val = lfp.self_val();
     vm.invoke_method_inner(
         globals,
-        IdentId::get_id("initialize_copy"),
+        IdentId::INITIALIZE_COPY,
         self_val,
         &[orig],
         None,
@@ -2241,7 +2241,7 @@ fn respond_to(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         return Ok(Value::bool(true));
     }
     // Call respond_to_missing?(name, include_all) as CRuby does.
-    let respond_to_missing = IdentId::get_id("respond_to_missing?");
+    let respond_to_missing = IdentId::RESPOND_TO_MISSING_;
     if let Some(fid) = globals.check_method(lfp.self_val(), respond_to_missing) {
         let result = vm.invoke_func_inner(
             globals,

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -47,7 +47,7 @@ fn allocate_undefined(
 ) -> Result<Value> {
     Err(MonorubyErr::method_not_found_for_class(
         &globals.store,
-        IdentId::get_id("allocate"),
+        IdentId::ALLOCATE,
         MATCHDATA_CLASS,
     ))
 }

--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -610,7 +610,7 @@ fn ldexp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             }
             _ => {
                 // Try to_int coercion
-                let to_int_id = IdentId::get_id("to_int");
+                let to_int_id = IdentId::TO_INT;
                 if let Some(fid) = globals.check_method(exp_val, to_int_id) {
                     let result = vm.invoke_func_inner(globals, fid, exp_val, &[], None, None)?;
                     match result.unpack() {

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -378,12 +378,12 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         if !rhs.im().is_zero() {
             return Ok(Value::nil());
         }
-        let cmp_id = IdentId::get_id("<=>");
+        let cmp_id = IdentId::_CMP;
         return vm.invoke_method_inner(globals, cmp_id, lhs_re, &[rhs.re().get()], None, None);
     }
     match other.unpack() {
         RV::Fixnum(_) | RV::BigInt(_) | RV::Float(_) => {
-            let cmp_id = IdentId::get_id("<=>");
+            let cmp_id = IdentId::_CMP;
             vm.invoke_method_inner(globals, cmp_id, lhs_re, &[other], None, None)
         }
         _ => Ok(Value::nil()),
@@ -546,7 +546,7 @@ fn complex_to_real(
 
 #[monoruby_builtin]
 fn to_f(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    complex_to_real(vm, globals, lfp, IdentId::get_id("to_f"), "Float")
+    complex_to_real(vm, globals, lfp, IdentId::TO_F, "Float")
 }
 
 #[monoruby_builtin]
@@ -590,7 +590,7 @@ fn to_r(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn neg_op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let c = self_val.as_complex();
-    let neg_id = IdentId::get_id("-@");
+    let neg_id = IdentId::_UMINUS;
     let re = vm.invoke_method_inner(globals, neg_id, c.re().get(), &[], None, None)?;
     let im = vm.invoke_method_inner(globals, neg_id, c.im().get(), &[], None, None)?;
     let re_r = Real::try_from(globals, re)?;

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -70,7 +70,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.store[FLOAT_CLASS].clear_alloc_func();
     // Float.new should raise NoMethodError (not TypeError from allocate)
     let float_meta = globals.store.get_metaclass(FLOAT_CLASS).id();
-    globals.add_empty_method(float_meta, IdentId::get_id("new"), Visibility::Undefined);
+    globals.add_empty_method(float_meta, IdentId::NEW, Visibility::Undefined);
 }
 
 ///
@@ -330,7 +330,7 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             {
                 if let Some(ary) = result.try_array_ty() {
                     if ary.len() == 2 {
-                        let cmp_id = IdentId::get_id("<=>");
+                        let cmp_id = IdentId::_CMP;
                         let res =
                             vm.invoke_method_inner(globals, cmp_id, ary[0], &[ary[1]], None, None)?;
                         return Ok(res);
@@ -901,7 +901,7 @@ fn quo(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     let rhs = lfp.arg(0);
     // Complex: delegate to Complex division
     if let Some(_) = rhs.try_complex() {
-        let div_id = IdentId::get_id("/");
+        let div_id = IdentId::_DIV;
         let complex_self = Value::complex(lhs, 0.0);
         return vm.invoke_method_inner(globals, div_id, complex_self, &[rhs], None, None);
     }
@@ -916,7 +916,7 @@ fn quo(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             {
                 if let Some(ary) = result.try_array_ty() {
                     if ary.len() == 2 {
-                        let div_id = IdentId::get_id("/");
+                        let div_id = IdentId::_DIV;
                         return vm.invoke_method_inner(
                             globals,
                             div_id,

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -685,7 +685,7 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
         }
         _ => {
             // Reverse dispatch: try rhs == lhs
-            let eq_id = IdentId::get_id("==");
+            let eq_id = IdentId::_EQ;
             let result = vm.invoke_method_inner(globals, eq_id, rhs, &[lhs], None, None)?;
             return Ok(Value::bool(result.as_bool()));
         }
@@ -736,7 +736,7 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 Ok(Some(result)) => {
                     if let Some(ary) = result.try_array_ty() {
                         if ary.len() == 2 {
-                            let cmp_id = IdentId::get_id("<=>");
+                            let cmp_id = IdentId::_CMP;
                             return vm.invoke_method_inner(
                                 globals,
                                 cmp_id,

--- a/monoruby/src/builtins/numeric/rational.rs
+++ b/monoruby/src/builtins/numeric/rational.rs
@@ -127,7 +127,7 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
         RV::Float(f) => Ok(Value::bool(lhs.to_f() == f)),
         _ => {
             // Reverse dispatch
-            let eq_id = IdentId::get_id("==");
+            let eq_id = IdentId::_EQ;
             let result =
                 vm.invoke_method_inner(globals, eq_id, rhs, &[lfp.self_val()], None, None)?;
             Ok(Value::bool(result.as_bool()))
@@ -194,7 +194,7 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 Ok(Some(result)) => {
                     if let Some(ary) = result.try_array_ty() {
                         if ary.len() == 2 {
-                            let cmp_id = IdentId::get_id("<=>");
+                            let cmp_id = IdentId::_CMP;
                             return vm.invoke_method_inner(globals, cmp_id, ary[0], &[ary[1]], None, None);
                         }
                     }
@@ -226,7 +226,7 @@ fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 vm.invoke_method_inner(globals, coerce_id, rhs, &[lfp.self_val()], None, None)?;
             if let Some(ary) = result.try_array_ty() {
                 if ary.len() == 2 {
-                    let add_id = IdentId::get_id("+");
+                    let add_id = IdentId::_ADD;
                     return vm.invoke_method_inner(globals, add_id, ary[0], &[ary[1]], None, None);
                 }
             }
@@ -257,7 +257,7 @@ fn sub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 vm.invoke_method_inner(globals, coerce_id, rhs, &[lfp.self_val()], None, None)?;
             if let Some(ary) = result.try_array_ty() {
                 if ary.len() == 2 {
-                    let sub_id = IdentId::get_id("-");
+                    let sub_id = IdentId::_SUB;
                     return vm.invoke_method_inner(globals, sub_id, ary[0], &[ary[1]], None, None);
                 }
             }
@@ -288,7 +288,7 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 vm.invoke_method_inner(globals, coerce_id, rhs, &[lfp.self_val()], None, None)?;
             if let Some(ary) = result.try_array_ty() {
                 if ary.len() == 2 {
-                    let mul_id = IdentId::get_id("*");
+                    let mul_id = IdentId::_MUL;
                     return vm.invoke_method_inner(globals, mul_id, ary[0], &[ary[1]], None, None);
                 }
             }
@@ -321,7 +321,7 @@ fn div(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 vm.invoke_method_inner(globals, coerce_id, rhs, &[lfp.self_val()], None, None)?;
             if let Some(ary) = result.try_array_ty() {
                 if ary.len() == 2 {
-                    let div_id = IdentId::get_id("/");
+                    let div_id = IdentId::_DIV;
                     return vm.invoke_method_inner(globals, div_id, ary[0], &[ary[1]], None, None);
                 }
             }
@@ -381,7 +381,7 @@ fn pow(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             let result = vm.invoke_method_inner(globals, coerce_id, rhs, &[lfp.self_val()], None, None)?;
             if let Some(ary) = result.try_array_ty() {
                 if ary.len() == 2 {
-                    let pow_id = IdentId::get_id("**");
+                    let pow_id = IdentId::_POW;
                     return vm.invoke_method_inner(globals, pow_id, ary[0], &[ary[1]], None, None);
                 }
             }

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -97,7 +97,7 @@ fn enum_to_vec(vm: &mut Executor, globals: &mut Globals, val: Value) -> Result<V
         return Ok(ary.iter().copied().collect());
     }
     // Check if it responds to each (is enumerable)
-    let each_id = IdentId::get_id("each");
+    let each_id = IdentId::EACH;
     if globals.check_method(val, each_id).is_none() {
         return Err(MonorubyErr::argumenterr(format!(
             "value must be enumerable"
@@ -298,7 +298,7 @@ fn delete_q(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let bh = match lfp.block() {
         None => {
-            let id = IdentId::get_id("each");
+            let id = IdentId::EACH;
             return vm.generate_enumerator(id, lfp.self_val(), lfp.iter().collect(), pc);
         }
         Some(block) => block,

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -19,7 +19,7 @@ pub(super) fn init(globals: &mut Globals) {
     // Symbol.new is undefined (raises NoMethodError).
     let meta = globals.store.get_metaclass(SYMBOL_CLASS).id();
     globals
-        .undef_method_for_class(meta, IdentId::get_id("new"))
+        .undef_method_for_class(meta, IdentId::NEW)
         .unwrap();
 }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -209,19 +209,26 @@ impl<'a> JitContext<'a> {
             FuncKind::Builtin { .. } => (func_id, None),
             FuncKind::Proc(proc) => (proc.func_id(), proc.outer_lfp()),
             FuncKind::ISeq(iseq) => {
-                // Check ISeq hint for trivial methods
-                match self.store[iseq].hint {
-                    ISeqHint::ConstReturn(v) => {
-                        state.def_C(dst, v);
-                        return Ok(CompileResult::Continue);
-                    }
-                    ISeqHint::SelfReturn => {
-                        if let Some(dst) = dst {
-                            state.copy_slot(ir, callsite.recv, dst);
+                // Check ISeq hint for trivial methods. Only fold when the
+                // call site's argument shape would actually dispatch (i.e.
+                // arity / splat / kw / block-arg checks would pass);
+                // otherwise CRuby raises ArgumentError and we must fall
+                // through to the normal path so the runtime can do the
+                // same.
+                if self.store.is_simple_call(func_id, callid) {
+                    match self.store[iseq].hint {
+                        ISeqHint::ConstReturn(v) => {
+                            state.def_C(dst, v);
+                            return Ok(CompileResult::Continue);
                         }
-                        return Ok(CompileResult::Continue);
+                        ISeqHint::SelfReturn => {
+                            if let Some(dst) = dst {
+                                state.copy_slot(ir, callsite.recv, dst);
+                            }
+                            return Ok(CompileResult::Continue);
+                        }
+                        ISeqHint::Normal => {}
                     }
-                    ISeqHint::Normal => {}
                 }
                 let specializable = self.store.is_simple_call(func_id, callid)
                     && (state.is_C(callsite.recv)

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -210,12 +210,21 @@ impl<'a> JitContext<'a> {
             FuncKind::Proc(proc) => (proc.func_id(), proc.outer_lfp()),
             FuncKind::ISeq(iseq) => {
                 // Check ISeq hint for trivial methods. Only fold when the
-                // call site's argument shape would actually dispatch (i.e.
-                // arity / splat / kw / block-arg checks would pass);
-                // otherwise CRuby raises ArgumentError and we must fall
-                // through to the normal path so the runtime can do the
-                // same.
-                if self.store.is_simple_call(func_id, callid) {
+                // call site's argument shape would actually dispatch
+                // without raising; otherwise CRuby raises ArgumentError
+                // and we must fall through to the normal path so the
+                // runtime can do the same.
+                //
+                // `is_simple_call` covers positional arity, splats, and
+                // the "callee has no kw + callsite passes kw" case, but
+                // it does NOT validate keyword matching when the callee
+                // accepts kwargs — required-kw-missing and unknown-kw
+                // would silently fold otherwise. Restrict folding to the
+                // "neither side touches kwargs" case to avoid that.
+                if self.store.is_simple_call(func_id, callid)
+                    && self.store[func_id].no_keyword()
+                    && !callsite.kw_may_exists()
+                {
                     match self.store[iseq].hint {
                         ISeqHint::ConstReturn(v) => {
                             state.def_C(dst, v);

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -619,7 +619,7 @@ impl Executor {
                 let v = Value::new_exception(err);
                 globals
                     .store
-                    .set_ivar(v, IdentId::get_id("/name"), Value::symbol(name))
+                    .set_ivar(v, IdentId::_NAME, Value::symbol(name))
                     .unwrap();
                 v
             }

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -924,8 +924,8 @@ impl Globals {
 /// exercises this for the alias path.
 fn is_always_private_method(name: IdentId) -> bool {
     name == IdentId::INITIALIZE
-        || name == IdentId::get_id("initialize_copy")
-        || name == IdentId::get_id("initialize_clone")
-        || name == IdentId::get_id("initialize_dup")
-        || name == IdentId::get_id("respond_to_missing?")
+        || name == IdentId::INITIALIZE_COPY
+        || name == IdentId::INITIALIZE_CLONE
+        || name == IdentId::INITIALIZE_DUP
+        || name == IdentId::RESPOND_TO_MISSING_
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -68,10 +68,6 @@ pub struct Store {
     optcase_info: Vec<OptCaseInfo>,
     /// inline info.
     pub(crate) inline_info: InlineTable,
-    /// `FuncId` of the default `Object#respond_to_missing?` (defined in
-    /// `startup.rb`). Memoised once at the first lookup so JIT inliners can
-    /// recognise an unmodified resolution and fold `respond_to?` to `false`.
-    default_respond_to_missing_fid: std::cell::Cell<Option<FuncId>>,
 }
 
 impl std::ops::Deref for Store {
@@ -184,34 +180,7 @@ impl Store {
             optcase_info: vec![],
             classes: ClassInfoTable::new(),
             inline_info: InlineTable::default(),
-            default_respond_to_missing_fid: std::cell::Cell::new(None),
         }
-    }
-
-    ///
-    /// `FuncId` of the default `Object#respond_to_missing?` (defined in
-    /// `startup.rb`).
-    ///
-    /// `startup.rb` is loaded after `Store::new`, so this is resolved
-    /// lazily on first call and memoised. Uses the version-agnostic
-    /// `search_method_by_class_id` directly — calling
-    /// `Globals::class_version()` from the JIT compile context would
-    /// re-borrow CODEGEN, and the resolved FuncId for an existing method
-    /// is stable regardless of the cache.
-    ///
-    /// Returns `None` only if `respond_to_missing?` has not been defined
-    /// on `Object` yet; callers should treat that as "cannot inline".
-    ///
-    pub(crate) fn default_respond_to_missing_fid(&self) -> Option<FuncId> {
-        if let Some(fid) = self.default_respond_to_missing_fid.get() {
-            return Some(fid);
-        }
-        let fid = self
-            .classes
-            .search_method_by_class_id(OBJECT_CLASS, IdentId::RESPOND_TO_MISSING_)?
-            .func_id()?;
-        self.default_respond_to_missing_fid.set(Some(fid));
-        Some(fid)
     }
 
     pub fn iseq(&self, func_id: FuncId) -> &ISeqInfo {

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -394,7 +394,7 @@ impl Store {
         };
         let compile_info = Store::handle_args(info, vec![])?;
         let fid = self.new_iseq_method(
-            Some(IdentId::get_id("/main")),
+            Some(IdentId::_MAIN),
             compile_info,
             Loc::default(),
             result.source_info,

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -68,6 +68,10 @@ pub struct Store {
     optcase_info: Vec<OptCaseInfo>,
     /// inline info.
     pub(crate) inline_info: InlineTable,
+    /// `FuncId` of the default `Object#respond_to_missing?` (defined in
+    /// `startup.rb`). Memoised once at the first lookup so JIT inliners can
+    /// recognise an unmodified resolution and fold `respond_to?` to `false`.
+    default_respond_to_missing_fid: std::cell::Cell<Option<FuncId>>,
 }
 
 impl std::ops::Deref for Store {
@@ -180,7 +184,34 @@ impl Store {
             optcase_info: vec![],
             classes: ClassInfoTable::new(),
             inline_info: InlineTable::default(),
+            default_respond_to_missing_fid: std::cell::Cell::new(None),
         }
+    }
+
+    ///
+    /// `FuncId` of the default `Object#respond_to_missing?` (defined in
+    /// `startup.rb`).
+    ///
+    /// `startup.rb` is loaded after `Store::new`, so this is resolved
+    /// lazily on first call and memoised. Uses the version-agnostic
+    /// `search_method_by_class_id` directly — calling
+    /// `Globals::class_version()` from the JIT compile context would
+    /// re-borrow CODEGEN, and the resolved FuncId for an existing method
+    /// is stable regardless of the cache.
+    ///
+    /// Returns `None` only if `respond_to_missing?` has not been defined
+    /// on `Object` yet; callers should treat that as "cannot inline".
+    ///
+    pub(crate) fn default_respond_to_missing_fid(&self) -> Option<FuncId> {
+        if let Some(fid) = self.default_respond_to_missing_fid.get() {
+            return Some(fid);
+        }
+        let fid = self
+            .classes
+            .search_method_by_class_id(OBJECT_CLASS, IdentId::RESPOND_TO_MISSING_)?
+            .func_id()?;
+        self.default_respond_to_missing_fid.set(Some(fid));
+        Some(fid)
     }
 
     pub fn iseq(&self, func_id: FuncId) -> &ISeqInfo {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1514,6 +1514,52 @@ impl<'pr> Lowerer<'pr> {
         })
     }
 
+    /// Lower a `StatementsNode`-shaped body to ruruby-parse's compact
+    /// shape:
+    ///
+    ///   - empty body  -> `CompStmt([])`
+    ///   - 1 statement -> bare expression (NO `CompStmt` wrapper)
+    ///   - N>=2        -> `CompStmt([s1, s2, ...])`
+    ///
+    /// Plain `lower_node(StatementsNode)` always wraps in `CompStmt`,
+    /// which (a) throws off class-body register arithmetic in
+    /// bytecodegen and (b) hides the inner kind from
+    /// `bytecodegen::hint()`, suppressing trivial-method
+    /// `ConstReturn` annotation. Both class-body and method-body
+    /// lowering route through here so the shape stays uniform with
+    /// ruruby-parse.
+    fn lower_compact_body(
+        &mut self,
+        body: Option<prism::Node<'pr>>,
+        fallback_loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        match body {
+            Some(b) => match b {
+                prism::Node::StatementsNode { .. } => {
+                    let stmts_node = b.as_statements_node().unwrap();
+                    let stmts_loc = location_to_loc(&stmts_node.location());
+                    let mut stmts = self.lower_statements_into_vec(&stmts_node)?;
+                    Ok(match stmts.len() {
+                        0 => Node {
+                            kind: NodeKind::CompStmt(vec![]),
+                            loc: stmts_loc,
+                        },
+                        1 => stmts.pop().unwrap(),
+                        _ => Node {
+                            kind: NodeKind::CompStmt(stmts),
+                            loc: stmts_loc,
+                        },
+                    })
+                }
+                _ => self.lower_node(&b),
+            },
+            None => Ok(Node {
+                kind: NodeKind::CompStmt(vec![]),
+                loc: fallback_loc,
+            }),
+        }
+    }
+
     /// Lower the body of a class / module / class-shovel definition,
     /// returning a fully-built `BlockInfo` with the body wrapped in
     /// the implicit `Begin { rescue: [], else_: None, ensure: None }`
@@ -1524,43 +1570,7 @@ impl<'pr> Lowerer<'pr> {
         loc: Loc,
     ) -> Result<BlockInfo, MonorubyErr> {
         let saved = std::mem::take(&mut self.lvars);
-        // ruruby's class / module body has a specific `Begin { body }`
-        // shape that bytecodegen depends on:
-        //   - empty body  -> `Begin { body: CompStmt([]) }`
-        //   - 1 statement -> `Begin { body: <bare expr> }` (NO CompStmt)
-        //   - N>=2        -> `Begin { body: CompStmt([s1, s2, ...]) }`
-        // Lowering through plain `lower_node(StatementsNode)` always
-        // wraps in `CompStmt`, even for single statements; that
-        // throws off bytecodegen's class-definition register
-        // arithmetic and panics later in `expand_array`. Use the
-        // statement-compact lowering instead so the shape matches.
-        let body_res = match body {
-            Some(b) => match b {
-                prism::Node::StatementsNode { .. } => {
-                    let stmts_node = b.as_statements_node().unwrap();
-                    let stmts_loc = location_to_loc(&stmts_node.location());
-                    match self.lower_statements_into_vec(&stmts_node) {
-                        Ok(mut stmts) => match stmts.len() {
-                            0 => Ok(Node {
-                                kind: NodeKind::CompStmt(vec![]),
-                                loc: stmts_loc,
-                            }),
-                            1 => Ok(stmts.pop().unwrap()),
-                            _ => Ok(Node {
-                                kind: NodeKind::CompStmt(stmts),
-                                loc: stmts_loc,
-                            }),
-                        },
-                        Err(e) => Err(e),
-                    }
-                }
-                _ => self.lower_node(&b),
-            },
-            None => Ok(Node {
-                kind: NodeKind::CompStmt(vec![]),
-                loc,
-            }),
-        };
+        let body_res = self.lower_compact_body(body, loc);
         match body_res {
             Ok(body_inner) => {
                 let body = Node {
@@ -2718,13 +2728,15 @@ impl<'pr> Lowerer<'pr> {
                     None => Vec::new(),
                 };
                 this.collect_locals(&node.locals())?;
-                let body_inner = match node.body() {
-                    Some(b) => this.lower_node(&b)?,
-                    None => Node {
-                        kind: NodeKind::Nil,
-                        loc,
-                    },
-                };
+                // Match ruruby-parse's method-body shape (also assumed by
+                // bytecodegen's `hint()`): a single-statement body is the
+                // bare expression, not a `CompStmt([expr])`. Plain
+                // `lower_node(StatementsNode)` always wraps in CompStmt,
+                // which makes `def foo; false; end` fall through `hint()`
+                // and miss the `ConstReturn(false)` annotation; without
+                // it the JIT can't fold trivial helpers like the default
+                // `Object#respond_to_missing?`.
+                let body_inner = this.lower_compact_body(node.body(), loc)?;
                 let body = Node {
                     kind: NodeKind::Begin {
                         body: Box::new(body_inner),

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1223,7 +1223,7 @@ pub(crate) fn emit_chilled_string_mutation_warning(
     let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
     let dep = vm.invoke_method_inner(
         globals,
-        IdentId::get_id("[]"),
+        IdentId::_INDEX,
         warning_val,
         &[dep_sym],
         None,
@@ -1325,7 +1325,7 @@ pub(crate) fn emit_deprecated_constant_warning(
     let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
     let dep = vm.invoke_method_inner(
         globals,
-        IdentId::get_id("[]"),
+        IdentId::_INDEX,
         warning_val,
         &[dep_sym],
         None,

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -841,7 +841,7 @@ fn lookup_hash_replacement(
     key: Value,
 ) -> Result<String> {
     let v =
-        vm.invoke_method_inner(globals, IdentId::get_id("[]"), hash, &[key], None, None)?;
+        vm.invoke_method_inner(globals, IdentId::_INDEX, hash, &[key], None, None)?;
     if v.is_nil() {
         Ok(String::new())
     } else if let Some(s) = v.is_str() {


### PR DESCRIPTION
## Summary

Cuts `respond_to?` ~41% on the ruby-bench/respond_to.rb microbench and restores trivial-method constant folding that had quietly stopped working when Prism became the default parser.

ruby-bench/respond_to.rb (12 calls × 500K loop, ms per iteration, after warmup):

| | min | median | mean |
|---|---|---|---|
| origin/master (caa9610b) | 335 | 362 | 392 |
| this branch (aff39461) | 218 | 232 | 231 |

Two motivating findings while looking at why the benchmark was slow:
- `IdentId::get_id("respond_to_missing?")` was being called per `respond_to?` miss, taking a global `RwLock::write()` despite a pre-interned `IdentId::RESPOND_TO_MISSING_` constant existing.
- The "method-not-visible" path of `Kernel#respond_to?` always invoked `Object#respond_to_missing?` through the full Ruby method-invocation machinery, even though the default implementation just returns `false`.

The first commit cleans up the pre-interned-constant misuse; the rest extend trivial-method folding so `respond_to_missing?` is recognised as a constant return at JIT time. Along the way I found and fixed two pre-existing JIT divergences from CRuby that would have masked further optimisation work.

## Commits (in order)

1. **`perf: replace IdentId::get_id literals with pre-interned constants`** (45 sites) — drops the global `RwLock::write()` from hot dispatch paths in numeric, hash, set, array, and exception code, and notably from the `respond_to?` fallback.

2. **`perf: JIT-inline Kernel#respond_to? when respond_to_missing? is unmodified`** — the inline-builtin codegen for `respond_to?` only handled the method-found case; the missing case fell through to a full builtin call. Cache the default `Object#respond_to_missing?` `FuncId` on `Store` and fold the call to `false` whenever per-class resolution still matches it. (Generalised by commit 6 below; commit 2 stands as a self-contained step in the bisect history.)

3. **`fix(jit): gate ConstReturn/SelfReturn folding on is_simple_call`** — pre-existing JIT bug discovered during this work: the `ISeqHint::ConstReturn` / `SelfReturn` early-return in `compile_method_call` skipped `set_arguments` entirely, so JIT-warmed wrong-arity call sites silently produced the folded value. Repro:
   ```ruby
   class A; def empty; end; end
   def call_wrong(a) = a.empty(1)
   50.times { begin; call_wrong(A.new); rescue ArgumentError; end }
   call_wrong(A.new)  # silently returns nil; CRuby raises ArgumentError
   ```

4. **`fix(jit): also gate ConstReturn fold on no-keyword paths`** — `is_simple_call` lets "callee has kw + callsite has kw" through on the assumption that runtime kw-matching catches required-kw-missing and unknown-kw, but ConstReturn folding skips that step too. Tighten to "no kwargs on either side". (A separate, deeper kw-matching bug on the regular JIT dispatch path is noted in the commit message but out of scope.)

5. **`parser/prism: lower method bodies in ruruby's compact statement shape`** — Prism wraps single-statement bodies in `CompStmt([expr])`, but `bytecodegen::hint()` was written for ruruby-parse's "single statement → bare expression" shape. With Prism the default since `caa9610b`, hint-driven trivial folding had silently regressed for everything except literal empty bodies. `lower_class_body` already handled this for class bodies via its own statement-compaction step; hoist that into a `lower_compact_body` helper and route `lower_def` through it too. Verified `def foo; false; end` and the default `Object#respond_to_missing?` now get `ISeqHint::ConstReturn` again.

6. **`refactor: detect respond_to_missing? const fold via ISeqHint, drop Store cache`** — with commit 5 in place, the dedicated `Store::default_respond_to_missing_fid` cache from commit 2 is unnecessary: just check the resolved `respond_to_missing?`'s ISeq hint. Generalises to user-defined trivial overrides (`def respond_to_missing?(*); true; end` etc.) and removes the cache plumbing.

## Test plan

- [x] `cargo test --release -p monoruby --lib` — 1706 passed
- [x] `cargo test --release -p monoruby --tests` — 22 crates, 2080 tests, 0 failed
- [x] arity smoke: `def empty; end` called with `(1, 2, 3)` raises `ArgumentError` after JIT warmup (would have silently returned nil before commit 3)
- [x] kwargs smoke: `def kwargs(b:); end` called with `(a: 1)` and `def reqkw(b:); end` called without args — `is_simple_call`-gated fold no longer silently folds. (The remaining "returned nil" on these paths is a separate pre-existing dispatch-path bug.)
- [x] respond_to.rb microbench: ~41% faster median, no behavior change
- [x] `IdentId::RESPOND_TO_MISSING_` and other pre-interned constants used in place of `IdentId::get_id(...)` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)