### PR TITLE
core/module: class_eval arity msg, method_defined? on Module, redef warning qualified name, ruby2_keywords skip warnings

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -52,14 +52,19 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_rest(MODULE_CLASS, "attr_writer", attr_writer);
     globals.define_builtin_func(MODULE_CLASS, "autoload", autoload, 2);
     globals.define_builtin_func_with(MODULE_CLASS, "autoload?", autoload_query, 1, 2, false);
+    // Registered as a rest-arg builtin so that the dispatch layer
+    // doesn't pre-format the arity error with monoruby's default
+    // "expected 0..3"; the function does its own arity check below
+    // and produces the CRuby-compatible "expected 1..3" message that
+    // ruby/spec asserts on.
     globals.define_builtin_funcs_with_effect(
         MODULE_CLASS,
         "class_eval",
         &["module_eval"],
         class_eval,
         0,
-        3,
-        false,
+        0,
+        true,
         Effect::EVAL,
     );
     globals.define_builtin_funcs_with_effect(
@@ -729,35 +734,37 @@ fn class_eval(
     pc: BytecodePtr,
 ) -> Result<Value> {
     let module = lfp.self_val().as_class();
+    let args = lfp.arg(0).as_array();
+    let supplied = args.len();
 
     // CRuby: `class_eval` accepts at most 3 args (expr, fname, lineno);
-    // anything more is an ArgumentError, even before classifying the
-    // string-vs-block dispatch. The arity is also reported as 0..3 to
-    // match the spec's regex.
-    let supplied = lfp.args_count(3);
+    // anything more is an ArgumentError. The reported range is `1..3`
+    // because the string form requires the expression argument; the
+    // no-arg block form is a separate dispatch and never reaches this
+    // arity check.
     if supplied > 3 {
         return Err(MonorubyErr::argumenterr(format!(
-            "wrong number of arguments (given {supplied}, expected 0..3)"
+            "wrong number of arguments (given {supplied}, expected 1..3)"
         )));
     }
 
     if let Some(bh) = lfp.block() {
-        if lfp.try_arg(0).is_some() {
+        if supplied != 0 {
             return Err(MonorubyErr::wrong_number_of_arg(0, supplied));
         }
         vm.module_eval(globals, module, bh)
-    } else if let Some(arg0) = lfp.try_arg(0) {
-        let expr = arg0.coerce_to_string(vm, globals)?;
+    } else if supplied >= 1 {
+        let expr = args[0].coerce_to_string(vm, globals)?;
         let cfp = vm.cfp();
         let caller_cfp = cfp.prev().unwrap();
-        let path = if let Some(arg1) = lfp.try_arg(1) {
-            arg1.coerce_to_str(vm, globals)?
+        let path = if supplied >= 2 {
+            args[1].coerce_to_str(vm, globals)?
         } else {
             let caller_loc = globals.store.get_caller_loc(caller_cfp, Some(pc));
             format!("(eval at {})", caller_loc)
         };
-        let lineno: i64 = if let Some(arg2) = lfp.try_arg(2) {
-            arg2.coerce_to_int_i64(vm, globals)?
+        let lineno: i64 = if supplied >= 3 {
+            args[2].coerce_to_int_i64(vm, globals)?
         } else {
             1
         };
@@ -1178,12 +1185,11 @@ fn const_set(
     let val = lfp.arg(1);
     // Warn (via Ruby's `$stderr` so mspec's `complain` matcher captures it)
     // when overwriting an existing same-name constant on the receiver,
-    // matching CRuby's redefinition warning.
+    // matching CRuby's redefinition warning. The qualified name uses
+    // the full ancestor chain so reflective tests can match
+    // `/.+::Name/`.
     if globals.store.get_constant_noautoload(module, name).is_some() {
-        let parent_name = globals.store[module]
-            .get_name()
-            .unwrap_or_default()
-            .to_string();
+        let parent_name = globals.store.qualified_name(module);
         let qual = if parent_name.is_empty() {
             name.get_name().to_string()
         } else {
@@ -2492,7 +2498,7 @@ fn deprecate_constant(
 /// correctly.
 #[monoruby_builtin]
 fn ruby2_keywords(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -2505,16 +2511,50 @@ fn ruby2_keywords(
         // string"). We don't honour `to_str` here — CRuby's
         // `ruby2_keywords` is also strict about Symbol/String only.
         let name = arg.expect_symbol_or_string(globals)?;
-        if globals.store[class_id].has_own_method(name) {
-            continue;
+        if !globals.store[class_id].has_own_method(name) {
+            return Err(MonorubyErr::nameerr(format!(
+                "undefined method '{}' for class '{}'",
+                name,
+                class_id.get_name(&globals.store)
+            )));
         }
-        return Err(MonorubyErr::nameerr(format!(
-            "undefined method '{}' for class '{}'",
-            name,
-            class_id.get_name(&globals.store)
-        )));
+        // Even though we don't track the ruby2_keywords flag, we still
+        // emit the CRuby compatibility warning when the target method
+        // signature is incompatible (i.e. the method has no positional
+        // splat, has explicit keywords, or has a keyword splat — none
+        // of which can be marked ruby2_keywords by CRuby either). The
+        // message format mirrors CRuby's "Skipping set of
+        // ruby2_keywords flag for <name> (...)".
+        if let Ok((func_id, _, _)) = globals.store.find_method_for_class(class_id, name)
+            && let Some(reason) = ruby2_keywords_skip_reason(globals, func_id)
+        {
+            let msg = format!(
+                "Skipping set of ruby2_keywords flag for {name} ({reason})",
+            );
+            crate::value::emit_verbose_warning(vm, globals, &msg)?;
+        }
     }
     Ok(Value::nil())
+}
+
+/// Returns a human-readable reason string when the method signature
+/// can't be marked ruby2_keywords, matching CRuby's wording.
+fn ruby2_keywords_skip_reason(globals: &Globals, func_id: FuncId) -> Option<&'static str> {
+    let info = &globals[func_id];
+    if !info.no_keyword() {
+        // Has explicit keyword params or `**kw`.
+        return Some("method accepts keywords or method accepts keyword splat");
+    }
+    if !info.is_rest() {
+        // No `*args` to absorb the trailing kwsplat.
+        return Some("method does not accept argument splat");
+    }
+    if info.post_num() > 0 {
+        // `*a, b` — post-rest required positional makes the trailing
+        // kwhash undecidable.
+        return Some("method accepts argument splat with post-rest required arguments");
+    }
+    None
 }
 
 /// True when `s` parses as `(::)?CONST(::CONST)*` where each `CONST`
@@ -5130,7 +5170,7 @@ mod tests {
     fn class_eval_too_many_args_raises() {
         // `Module#class_eval` takes at most 3 args (expr, fname, lineno);
         // passing 4 raises ArgumentError ("wrong number of arguments
-        // (given 4, expected 0..3)").
+        // (given 4, expected 1..3)").
         run_test_error(
             r#"
             Class.new.class_eval("nil", "f", 1, :extra)
@@ -5595,6 +5635,182 @@ mod tests {
             r2 = c.send(:attr, :bar, false)
             r1 + r2
             "#,
+        );
+    }
+
+    #[test]
+    fn class_eval_too_many_args_message_uses_1_to_3_range() {
+        // CRuby's `Module#class_eval` reports `expected 1..3` (not
+        // `0..3`) for the string form's arity error, since the no-arg
+        // block dispatch is a different path.
+        run_test_error(
+            r#"
+            Class.new.class_eval("nil", "f", 1, :extra)
+            "#,
+        );
+    }
+
+    #[test]
+    fn module_eval_too_many_args_uses_1_to_3_range() {
+        run_test_error(
+            r#"
+            Class.new.module_eval("nil", "f", 1, :extra)
+            "#,
+        );
+    }
+
+    #[test]
+    fn method_defined_module_does_not_search_object_or_kernel() {
+        // CRuby: `Module#method_defined?` on a plain Module receiver
+        // does NOT walk into `Object`/`Kernel`, even though monoruby's
+        // class store wires every Module's superclass through `Object`
+        // for dispatch reasons. So `:hash` (a Kernel method) shouldn't
+        // surface here.
+        run_test(
+            r#"
+            Module.new.method_defined?(:hash)
+            "#,
+        );
+    }
+
+    #[test]
+    fn method_defined_class_still_finds_inherited() {
+        // Class receivers continue to walk into Object/Kernel — verify
+        // we didn't break the common case.
+        run_test(
+            r#"
+            Class.new.method_defined?(:hash)
+            "#,
+        );
+    }
+
+    #[test]
+    fn module_eval_redef_warning_uses_qualified_name() {
+        // The "warning: already initialized constant ..." message must
+        // be qualified with the receiver's name even when the
+        // assignment happens through `module_eval` against an
+        // anonymous module — the regex
+        // `/already initialized constant .+::TEST/` from
+        // `core/module/const_added_spec.rb` requires a parent
+        // qualifier, even if it's the anonymous-module render.
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              mod = Module.new
+              mod.module_eval("TEST = 1; TEST = 2")
+            ensure
+              $stderr = old_stderr
+            end
+            captured =~ /already initialized constant .+::TEST/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn const_set_redef_warning_uses_qualified_name() {
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              m = Module.new
+              m.const_set(:X, 1)
+              m.const_set(:X, 2)
+            ensure
+              $stderr = old_stderr
+            end
+            captured =~ /already initialized constant .+::X/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_warns_when_method_has_no_splat() {
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              c = Class.new { def foo(a, b, c); end }
+              c.send(:ruby2_keywords, :foo)
+            ensure
+              $stderr = old_stderr
+            end
+            captured =~ /Skipping set of ruby2_keywords flag for foo/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_warns_when_method_has_explicit_keyword() {
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              c = Class.new { def foo(*a, b:); end }
+              c.send(:ruby2_keywords, :foo)
+            ensure
+              $stderr = old_stderr
+            end
+            captured =~ /Skipping set of ruby2_keywords flag for foo/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_warns_when_method_has_post_argument() {
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              c = Class.new { def foo(*a, b); end }
+              c.send(:ruby2_keywords, :foo)
+            ensure
+              $stderr = old_stderr
+            end
+            captured =~ /Skipping set of ruby2_keywords flag for foo/ ? :ok : captured
+            "##,
+        );
+    }
+
+    #[test]
+    fn ruby2_keywords_silent_for_compatible_signature() {
+        // `def foo(*args)` is the canonical compatible shape — must
+        // not warn.
+        run_test(
+            r##"
+            old_stderr = $stderr
+            captured = String.new
+            $stderr = Class.new {
+              define_method(:write) { |s| captured << s; s.size }
+            }.new
+            begin
+              c = Class.new { def foo(*args); end }
+              c.send(:ruby2_keywords, :foo)
+            ensure
+              $stderr = old_stderr
+            end
+            captured.empty?
+            "##,
         );
     }
 }

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -117,10 +117,7 @@ fn struct_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             .get_constant_noautoload(parent_class, n)
             .is_some();
         if prev {
-            let parent_name = globals.store[parent_class]
-                .get_name()
-                .unwrap_or_default()
-                .to_string();
+            let parent_name = globals.store.qualified_name(parent_class);
             let qual = if parent_name.is_empty() {
                 n.get_name().to_string()
             } else {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -823,10 +823,10 @@ impl Executor {
             .get_constant_noautoload(parent, name)
             .is_some()
         {
-            let parent_name = globals.store[parent]
-                .get_name()
-                .unwrap_or_default()
-                .to_string();
+            // Use the full qualified path (`Foo::Bar::Leaf`) instead of
+            // just the immediate parent's leaf name. Anonymous parents
+            // render as `#<Module:0x..>::Leaf`; `Object` renders bare.
+            let parent_name = globals.store.qualified_name(parent);
             let qual = if parent_name.is_empty() {
                 name.get_name().to_string()
             } else {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -601,6 +601,31 @@ impl ClassInfoTable {
         class_obj
     }
 
+    /// Build the fully qualified `A::B::Leaf` name for *class_id*.
+    /// Returns an empty string for anonymous classes whose `name` slot
+    /// is `None` (the caller must decide how to render those — for the
+    /// "already initialized constant" warning we fall back to the bare
+    /// constant name). This is `ClassInfoTable`-local so call sites
+    /// inside `set_constant` can use it without going through `Store`.
+    pub(crate) fn qualified_name(&self, class_id: ClassId) -> String {
+        if class_id == OBJECT_CLASS {
+            return String::new();
+        }
+        if self[class_id].name.is_none() {
+            // Anonymous owner: render its inspect form.
+            let class_obj = self[class_id].get_module().as_val();
+            let kind = if class_obj.ty() == Some(ObjTy::MODULE) {
+                "Module"
+            } else {
+                "Class"
+            };
+            return format!("#<{kind}:0x{:016x}>", class_obj.id());
+        }
+        let mut parts = self.get_parents(class_id);
+        parts.reverse();
+        parts.join("::")
+    }
+
     pub(crate) fn get_parents(&self, mut class: ClassId) -> Vec<String> {
         let mut parents = vec![self[class].name.clone().unwrap()];
         while let Some(parent) = self[class].parent {
@@ -1458,11 +1483,27 @@ impl Store {
         func_name: IdentId,
         inherit: bool,
     ) -> Option<Visibility> {
-        Some(if inherit {
-            self.check_method_for_class(class_id, func_name)?.visibility
-        } else {
-            self.classes.get_method(class_id, func_name)?.1
-        })
+        if !inherit {
+            return Some(self.classes.get_method(class_id, func_name)?.1);
+        }
+        // For a Module receiver (not a Class), the lookup must NOT walk
+        // into `Object`/`Kernel` even though monoruby's class store
+        // wires every Module's superclass chain through `Object` for
+        // method-dispatch reasons. CRuby returns false for things like
+        // `Module.new.method_defined?(:hash)`, since the lookup is
+        // restricted to the module itself plus any modules it includes
+        // via iclass entries. `Store::ancestors` already implements
+        // that "stop at the first real Class" rule, so reuse it here.
+        let module = self.classes[class_id].get_module();
+        if module.as_val().ty() == Some(ObjTy::CLASS) {
+            return Some(self.check_method_for_class(class_id, func_name)?.visibility);
+        }
+        for ancestor in self.ancestors(class_id) {
+            if let Some((_, visi, _)) = self.classes.get_method(ancestor.id(), func_name) {
+                return Some(visi);
+            }
+        }
+        None
     }
 
     ///

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -102,6 +102,7 @@ impl ConstState {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_loaded(&self) -> bool {
         matches!(self.kind, ConstStateKind::Loaded(_))
     }
@@ -271,12 +272,14 @@ impl ClassInfoTable {
             new_state.visibility = vis;
         }
         new_state.deprecated = prev_deprecated;
-        let prev = self[class_id].constants.insert(name, new_state);
-        if prev.as_ref().is_some_and(|s| s.is_loaded())
-            && WARNING.load(std::sync::atomic::Ordering::Relaxed) >= 1
-        {
-            eprintln!("warning: already initialized constant {name}")
-        }
+        // The "already initialized constant" warning for user-level
+        // redefinitions is emitted by the upstream call sites
+        // (`Executor::set_constant` for literal assignments,
+        // `Module#const_set` for the reflective form, `Struct.new`'s
+        // class-binding) so that the message goes through Ruby's
+        // `$stderr.write` and uses the proper qualified path. We
+        // intentionally do *not* re-emit here.
+        let _prev = self[class_id].constants.insert(name, new_state);
         if let Some(klass) = val.is_class_or_module() {
             if self[klass.id()].get_name().is_none() {
                 self[klass.id()].set_parent(class_id);


### PR DESCRIPTION
## Summary

Four small, isolated `core/module` fixes that together cut **8 failures** from ruby/spec (194 → 186).

### 1. `Module#class_eval` / `Module#module_eval` arity error message (2 fixes)

CRuby reports `expected 1..3` (not `0..3`) when too many args are passed to the string form, because the no-arg block dispatch is a separate path. Re-registered as a rest-arg builtin and rebuilt the body to read from the rest array, so the dispatch layer no longer pre-formats with monoruby's default range.

### 2. `Module#method_defined?` on a Module receiver (1 fix)

`Module.new.method_defined?(:hash)` was returning `true` because monoruby's class store wires every Module's superclass through `Object` for dispatch reasons, so the lookup walked into `Kernel`. Now the query restricts itself to the receiver plus its included iclasses (reusing `Store::ancestors`' "stop at first real Class" rule) when the receiver is a plain Module. Class receivers continue to walk into Object/Kernel.

### 3. "already initialized constant" warning uses qualified name (1 fix)

The `complain` matcher regex `/.+::TEST/` requires a parent qualifier. The three callers — `Executor::set_constant` (literal `=`), `Module#const_set`, and `Struct.new`'s constant binding — now use a new `ClassInfoTable::qualified_name` helper so anonymous parents render as `#<Module:0x..>::Leaf` and named ones as the full chain. Also removed a duplicate `eprintln!` warning that was firing alongside the proper `$stderr.write` paths.

### 4. `Module#ruby2_keywords` "Skipping set of ruby2_keywords flag" warnings (4 fixes)

Even though monoruby still doesn't track per-Hash ruby2_keywords markers, the compatibility warning now fires for the four method-signature shapes CRuby refuses to mark:

- no rest argument (`def foo(a, b, c)`)
- explicit keyword param (`def foo(*a, b:)`)
- keyword splat (`def foo(*a, **b)`)
- post-rest required positional (`def foo(*a, b)`)

Wording mirrors CRuby's `rb_warn`.

## Verification

- `cargo test --release --lib 'builtins::module'` — **152/152 pass** (was 142, +10 new tests covering each fix)
- `cargo test --release --test method_call` — 63/63 pass
- `cargo test --release --test class_chain` — 2/2 pass
- `core/module` ruby/spec: 194 → 186 failures+errors, no new regressions

## Test plan

- [x] Run `cargo test --release --lib 'builtins::module'`
- [x] Run `cargo test --release --test method_call --test class_chain`
- [x] Run `core/module` ruby/spec against monoruby
- [x] Manually verify each fix with `monoruby -e ...`

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_