### PR TITLE
core/module: dynamic name resolution — promote non-permanent names on constant rebind

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2609,6 +2609,10 @@ fn set_temporary_name(
         }
         globals.store[class_id].set_temporary_name(name);
     }
+    // The receiver's leaf changed; any descendant that renders its
+    // own `Module#name` through us has a stale frozen-string cache.
+    // Invalidate so the next call rebuilds with the new chain.
+    globals.store.invalidate_descendant_name_caches(class_id);
     Ok(lfp.self_val())
 }
 
@@ -5811,6 +5815,104 @@ mod tests {
             end
             captured.empty?
             "##,
+        );
+    }
+
+    #[test]
+    fn name_constant_rebind_promotes_existing_named_module() {
+        // `m::N` was created with `module m::N; end`, so it already has
+        // a leaf name "N" but with an anonymous parent. Binding it to
+        // a permanent constant must replace the anon parent with the
+        // new owner, so `Module#name` renders the full path.
+        run_test(
+            r#"
+            module ModuleSpecs2; module Anonymous2; end; end
+            m = Module.new
+            module m::N; end
+            ModuleSpecs2::Anonymous2::WasAnnon2 = m::N
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn name_anonymous_parent_promotion_propagates_to_descendant() {
+        // Promoting `m` to a permanent constant should also flip its
+        // descendant `m::N` to permanent — the qualified rendering
+        // walks through `m`'s new permanent name.
+        run_test(
+            r#"
+            module ModuleSpecs3; end
+            m = Module.new
+            module m::N; end
+            ModuleSpecs3::Mod3 = m
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn name_promotion_discards_temporary_on_descendant() {
+        // A descendant that explicitly chose a temporary name (via
+        // `set_temporary_name`) gets the constant-bound leaf restored
+        // when an ancestor is promoted to permanent.
+        run_test(
+            r#"
+            module ModuleSpecs4; end
+            m = Module.new
+            module m::N; end
+            m::N.set_temporary_name("fake")
+            ModuleSpecs4::Mod4 = m
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_propagates_to_nested_module_render() {
+        // When the receiver's leaf name changes via
+        // `set_temporary_name`, descendants' cached qualified names
+        // must be invalidated so the next call rebuilds with the new
+        // leaf.
+        run_test(
+            r#"
+            m = Module.new
+            m::N = Module.new
+            m::N.name # warm the cache with the anon-parent rendering
+            m.set_temporary_name "m"
+            m::N.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn name_promotion_does_not_replace_already_permanent() {
+        // Once a module has a permanent constant binding, a *second*
+        // binding under a different parent must not silently move it.
+        run_test(
+            r#"
+            module ModuleSpecsP1; end
+            module ModuleSpecsP2; end
+            module ModuleSpecsP1::Inner; end
+            ModuleSpecsP2::Alias = ModuleSpecsP1::Inner
+            ModuleSpecsP1::Inner.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn set_temporary_name_on_descendant_after_promotion_is_rejected() {
+        // After `M = m` promotes m::N, calling `set_temporary_name`
+        // on m::N must raise `RuntimeError("can't change permanent
+        // name")` — the promotion really did make it permanent.
+        run_test_error(
+            r#"
+            module ModuleSpecs5; end
+            m = Module.new
+            module m::N; end
+            ModuleSpecs5::Mod5 = m
+            m::N.set_temporary_name("nope")
+            "#,
         );
     }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -988,6 +988,14 @@ impl ClassInfoTable {
         }
     }
 
+    /// Number of slots in the class table, including the unused
+    /// `ClassId(0)` slot at index 0. Used by sweep-style operations
+    /// that need to iterate every live class (e.g. propagating a
+    /// rebind across descendants for `Module#name`).
+    pub(crate) fn classinfo_len(&self) -> usize {
+        self.table.len()
+    }
+
     fn add_class(&mut self) -> ClassId {
         let id = self.table.len();
         self.table.push(ClassInfo::new());

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -413,6 +413,13 @@ impl ClassInfo {
         self.parent = Some(parent);
     }
 
+    /// Lexical parent (`Outer` in `Outer::Inner`), if any. Used by
+    /// the descendant-walk in `propagate_permanent_name` and by
+    /// `get_parents` to assemble a fully-qualified name.
+    pub(crate) fn parent_id(&self) -> Option<ClassId> {
+        self.parent
+    }
+
     pub(crate) fn set_name(&mut self, name: String) {
         self.name = Some(name);
         // Invalidate any cached frozen name Value so the next call to
@@ -450,6 +457,23 @@ impl ClassInfo {
 
     pub(crate) fn set_name_permanent(&mut self, permanent: bool) {
         self.name_permanent = permanent;
+    }
+
+    /// Drop the "set via `Module#set_temporary_name`" marker. Used
+    /// when an enclosing anonymous ancestor gets a permanent name and
+    /// thereby promotes this descendant: the previously-explicit
+    /// temporary leaf must yield to the qualified parent-chain
+    /// rendering.
+    pub(crate) fn clear_explicit_temporary(&mut self) {
+        self.name_explicit_temporary = false;
+    }
+
+    /// Force `Module#name` to recompute its frozen-string return next
+    /// time it's called, instead of returning the cached value. Needed
+    /// when something external to `set_name` mutates the rendered
+    /// path — e.g. when a parent's permanence flips.
+    pub(crate) fn invalidate_cached_name_value(&mut self) {
+        self.name_value = None;
     }
 
     pub(crate) fn get_name(&self) -> Option<&str> {

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -281,23 +281,141 @@ impl ClassInfoTable {
         // intentionally do *not* re-emit here.
         let _prev = self[class_id].constants.insert(name, new_state);
         if let Some(klass) = val.is_class_or_module() {
-            if self[klass.id()].get_name().is_none() {
-                self[klass.id()].set_parent(class_id);
-                // Store the leaf name only; `get_parents` walks the parent
-                // chain at lookup time and joins the segments. Anonymous
-                // ancestors are rendered using their inspect form during the
-                // walk (see `get_parents`).
-                self[klass.id()].set_name(name.to_string());
-                // The new module is permanently named only if its parent
-                // is itself permanent (so the full chain back to a
-                // top-level constant is reachable). Otherwise the leaf
-                // name is "borrowed" through an anonymous ancestor and
-                // CRuby still allows `set_temporary_name` on it.
-                let parent_permanent =
-                    class_id == OBJECT_CLASS || self[class_id].is_name_permanent();
-                self[klass.id()].set_name_permanent(parent_permanent);
+            // The new owner is "permanent" iff its parent's chain is
+            // already reachable from a top-level constant. `Object`
+            // counts as permanent at the root.
+            let parent_permanent =
+                class_id == OBJECT_CLASS || self[class_id].is_name_permanent();
+            let target = klass.id();
+            let target_was_anon = self[target].get_name().is_none();
+            let target_was_non_permanent = !self[target].is_name_permanent();
+            if target_was_anon {
+                // First-time naming: install the leaf name and parent.
+                self[target].set_parent(class_id);
+                // Store the leaf name only; `get_parents` walks the
+                // parent chain at lookup time and joins the segments.
+                // Anonymous ancestors are rendered using their inspect
+                // form during the walk (see `get_parents`).
+                self[target].set_name(name.to_string());
+                self[target].set_name_permanent(parent_permanent);
+            } else if target_was_non_permanent && parent_permanent {
+                // Promotion: an existing non-permanent name (anonymous
+                // parent or `set_temporary_name`) gets replaced when
+                // the module is bound under a permanent parent.
+                // Discard any explicit-temporary marker so future
+                // `Module#name` calls render the parent chain. Mirrors
+                // CRuby's `rb_set_class_path` re-binding behaviour.
+                self[target].set_parent(class_id);
+                self[target].set_name(name.to_string());
+                self[target].set_name_permanent(true);
+            }
+            // Whenever the target's permanence may have flipped, walk
+            // its descendants and promote any of *their* non-permanent
+            // names too — `module m::N; end; M = m` must promote both
+            // `m` and `m::N`.
+            if self[target].is_name_permanent() {
+                self.propagate_permanent_name(target);
             }
         }
+    }
+
+    /// Walk the (parent, child) graph rooted at `root` and promote any
+    /// descendant whose own name was non-permanent up to permanent,
+    /// clearing the `name_explicit_temporary` flag in the process. The
+    /// descendants' leaf names are kept as-is — only the rendered
+    /// fully-qualified path changes (recomputed lazily via
+    /// `get_parents`).
+    fn propagate_permanent_name(&mut self, root: ClassId) {
+        // Collect descendants iteratively. Walking the full class
+        // table is acceptable because re-binding is rare; this avoids
+        // maintaining a child-list per `ClassInfo`.
+        let mut stack = vec![root];
+        let mut to_promote: Vec<(ClassId, ClassId)> = Vec::new();
+        while let Some(parent) = stack.pop() {
+            // The class table is `ClassId`-indexed, so `table[idx]`
+            // corresponds to `ClassId(idx)`; index 0 is unused
+            // (`ClassId` is `NonZeroU32`).
+            for idx in 1..self.classinfo_len() {
+                let id = ClassId::new(idx as u32);
+                if id == root {
+                    continue;
+                }
+                if self[id].parent_id() != Some(parent) {
+                    continue;
+                }
+                if self[id].get_name().is_none() {
+                    // No own name — nothing to promote, and it can't
+                    // have permanent named descendants either (a
+                    // permanent name is propagated through named
+                    // ancestors only).
+                    continue;
+                }
+                if !self[id].is_name_permanent() {
+                    to_promote.push((id, parent));
+                }
+                stack.push(id);
+            }
+        }
+        for (id, parent) in to_promote {
+            // If `set_temporary_name` had overridden the leaf, find
+            // the original constant-bound leaf name on the parent and
+            // restore it. Otherwise keep the existing leaf — it's
+            // already the constant-bound one.
+            if self[id].is_name_explicit_temporary()
+                && let Some(original) = self.find_constant_binding(parent, id)
+            {
+                self[id].set_name(original.get_name().to_string());
+            }
+            self[id].set_name_permanent(true);
+            // Drop the explicit-temporary flag too, otherwise
+            // `get_class_name` would still short-circuit to the bare
+            // leaf and skip the parent-chain rendering.
+            self[id].clear_explicit_temporary();
+            self[id].invalidate_cached_name_value();
+        }
+        // Also invalidate the root's cached name Value: it may have
+        // been previously rendered as anonymous.
+        self[root].invalidate_cached_name_value();
+    }
+
+    /// Drop the cached frozen-`String` returned by `Module#name` for
+    /// every descendant of `root` whose lexical chain runs through
+    /// `root`. Used when the qualified rendering may change without
+    /// the descendant's own leaf having been rewritten — e.g. after
+    /// `set_temporary_name` on `root`.
+    pub(crate) fn invalidate_descendant_name_caches(&mut self, root: ClassId) {
+        let mut stack = vec![root];
+        while let Some(parent) = stack.pop() {
+            for idx in 1..self.classinfo_len() {
+                let id = ClassId::new(idx as u32);
+                if id == root {
+                    continue;
+                }
+                if self[id].parent_id() != Some(parent) {
+                    continue;
+                }
+                self[id].invalidate_cached_name_value();
+                stack.push(id);
+            }
+        }
+        self[root].invalidate_cached_name_value();
+    }
+
+    /// Walk `parent`'s constant table looking for an entry whose
+    /// loaded value is the class/module `child`. Returns the binding
+    /// `IdentId` if found, used by `propagate_permanent_name` to
+    /// restore the constant-bound leaf name when a temporary is
+    /// overridden.
+    fn find_constant_binding(&self, parent: ClassId, child: ClassId) -> Option<IdentId> {
+        for (name, state) in self[parent].constants.iter() {
+            if let ConstStateKind::Loaded(v) = state.kind
+                && let Some(m) = v.is_class_or_module()
+                && m.id() == child
+            {
+                return Some(*name);
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

Implements CRuby-compatible **dynamic name resolution** for `Module#name`: binding a module to a constant under a permanent ancestor now promotes its (and its descendants') name from the anonymous-render form to the qualified path. Cuts 2 failures from `core/module` ruby/spec (and matches CRuby's `rb_set_class_path` semantics).

## Background — current monoruby model

`ClassInfo` stores a **leaf** `name` plus a `parent` `ClassId`; the fully-qualified `Module#name` is rebuilt on demand by walking the parent chain (`get_parents` / `get_class_name`). Two flags gate that walk:

- `name_permanent` — set when the leaf was reached from a top-level constant.
- `name_explicit_temporary` — set when assigned via `Module#set_temporary_name`, which causes `Module#name` to return the bare leaf instead of the qualified chain.

Before this PR, `ClassInfoTable::set_constant` only installed a leaf name when the target was **completely anonymous** (`get_name().is_none()`). That made the following CRuby-compatible behaviours fail:

```ruby
m = Module.new                    # anon m
module m::N; end                  # m::N: leaf "N", parent m, non-permanent
ModuleSpecs::Anonymous::WasAnnon = m::N
m::N.name
# CRuby:    "ModuleSpecs::Anonymous::WasAnnon"
# monoruby: "#<Module:0x..>::N"   (skipped the rebind)
```

```ruby
m = Module.new
module m::N; end
m::N.set_temporary_name "fake"
ModuleSpecs::M = m
m::N.name
# CRuby:    "ModuleSpecs::M::N"   (temporary discarded, original leaf restored)
# monoruby: "fake"
```

## Changes

### 1. `set_constant`: promotion path

In `monoruby/src/globals/store/class/constants.rs`, `set_constant` now handles three cases instead of two:
- target `name == None` → install leaf + parent (unchanged)
- target has a **non-permanent** name **and** the new parent is permanent → **rebind**: replace leaf + parent, flip `name_permanent = true` (new)
- already permanent → no-op (unchanged)

### 2. Descendant sweep: `propagate_permanent_name`

After a (re)binding promotes the target, walk its descendants via the class-table-wide parent chain and:
- promote each descendant's `name_permanent` from `false` to `true`,
- if the descendant's leaf was overridden by `set_temporary_name`, restore the original leaf by looking it up in the new permanent parent's constants table (`find_constant_binding`),
- invalidate cached `Module#name` frozen-string values along the way.

### 3. `set_temporary_name`: descendant cache invalidation

`Module#set_temporary_name` now invalidates the cached `Module#name` frozen-string on every descendant (`invalidate_descendant_name_caches`) so a stale render (e.g. with the previous anon prefix) doesn't survive a subsequent `m.set_temporary_name "m"`.

### Helpers added

| Helper | Purpose |
|---|---|
| `ClassInfoTable::propagate_permanent_name` | Descendant sweep + promotion |
| `ClassInfoTable::find_constant_binding` | Locate the original leaf on the new parent |
| `ClassInfoTable::invalidate_descendant_name_caches` | Drop cached frozen-strings through the chain |
| `ClassInfo::clear_explicit_temporary` | Drop the temp marker during promotion |
| `ClassInfo::invalidate_cached_name_value` | Force `Module#name` to recompute |
| `ClassInfo::parent_id` | Public read accessor used by the sweep |
| `ClassInfoTable::classinfo_len` | Table size for the iterative walk |

## Verification

- `cargo test --release --lib 'builtins::module'` — **148/148 pass** (was 142, +6 new tests covering promotion, descendant propagation, cache invalidation, and the negative case)
- `cargo test --release --test method_call --test class_chain` — 65/65 pass
- `core/module` ruby/spec: 194 → 192 failures+errors (2 fewer)

## Remaining failures (out of scope)

Two related failures persist but are unrelated to the name machinery:

- `Module#name is set after it is removed from a constant` — leaks `MSpecEnv::` prefix because mspec's `instance_exec` block lexical scope is mishandled in monoruby. Separate bug.
- `Module#set_temporary_name also updates a name of a nested module` (the `set_temporary_name(nil)` half) — needs CRuby's "ancestor cleared → descendant becomes nil" rule, a distinct behaviour.

## Test plan

- [x] Run `cargo test --release --lib 'builtins::module'`
- [x] Run `cargo test --release --test method_call --test class_chain`
- [x] Run `core/module/name_spec.rb` and `set_temporary_name_spec.rb` against monoruby
- [x] Run full `core/module` ruby/spec — no regressions

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_