### PR TITLE
core/module: distinguish lexical-scope cref from runtime-only definee push (~22 spec failures)

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -771,7 +771,12 @@ fn class_eval(
 
         let fid = globals.compile_script_eval(expr, path, caller_cfp, Some(module.id()), lineno)?;
         let proc = ProcData::new(caller_cfp.lfp(), fid);
-        vm.push_class_context(module.id());
+        // class_eval "..." string form: runtime-only push, just like
+        // the block form. The compiled eval body itself receives the
+        // module as its lexical context via `compile_script_eval`'s
+        // 4th argument, so `module Foo; end` / `X = ...` inside the
+        // string still see `module` as the lexical owner.
+        vm.push_runtime_class_context(module.id());
         let res = vm.invoke_block_with_self(globals, &proc, module.get(), &[]);
         vm.pop_class_context();
         res
@@ -802,7 +807,10 @@ fn class_exec(
     let bh = lfp.expect_block()?;
     let data = vm.get_block_data(globals, bh)?;
     let args = lfp.arg(0).as_array();
-    vm.push_class_context(module.id());
+    // class_exec(&block) is a runtime-only push: `def` inside lands
+    // on the receiver, but `module Foo; end` / `X = ...` use the
+    // block's captured lexical scope (matches CRuby).
+    vm.push_runtime_class_context(module.id());
     let res = vm.invoke_block_with_self(globals, &data, module.get(), &args);
     vm.pop_class_context();
     res
@@ -5912,6 +5920,91 @@ mod tests {
             module m::N; end
             ModuleSpecs5::Mod5 = m
             m::N.set_temporary_name("nope")
+            "#,
+        );
+    }
+
+    #[test]
+    fn class_exec_module_def_uses_lexical_scope() {
+        // CRuby: `module Inner` inside `A.class_exec { ... }` creates
+        // toplevel `::Inner`, NOT `A::Inner`, because `class_exec`
+        // changes only the receiver (for `def`), not the lexical
+        // scope.
+        run_test(
+            r#"
+            class ClassExecLexA; end
+            ClassExecLexA.class_exec {
+              module ClassExecLexInner; end
+            }
+            [
+              Object.constants.include?(:ClassExecLexInner),
+              ClassExecLexA.constants.include?(:ClassExecLexInner),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn module_eval_block_module_def_uses_lexical_scope() {
+        // Same rule for `module_eval(&block)` — the block-form's body
+        // doesn't change lexical scope for `module Foo; end`.
+        run_test(
+            r#"
+            class ModEvalBlockA; end
+            ModEvalBlockA.module_eval {
+              module ModEvalBlockInner; end
+            }
+            [
+              Object.constants.include?(:ModEvalBlockInner),
+              ModEvalBlockA.constants.include?(:ModEvalBlockInner),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn instance_exec_module_def_uses_lexical_scope() {
+        run_test(
+            r#"
+            class InstanceExecA; end
+            InstanceExecA.new.instance_exec {
+              module InstanceExecInner; end
+            }
+            [
+              Object.constants.include?(:InstanceExecInner),
+              InstanceExecA.constants.include?(:InstanceExecInner),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn class_keyword_still_pushes_lexical_scope() {
+        // Negative control: `class Outer; class Inner; end; end`
+        // must still nest Inner under Outer (the keyword form is a
+        // real lexical push).
+        run_test(
+            r#"
+            class ClassKwOuter
+              class ClassKwInner; end
+            end
+            ClassKwOuter::ClassKwInner.name
+            "#,
+        );
+    }
+
+    #[test]
+    fn class_exec_def_still_lands_on_receiver() {
+        // The receiver-as-default-definee semantics for `def` must
+        // be preserved — `def` inside `class_exec` still adds to the
+        // receiver class.
+        run_test(
+            r#"
+            klass = Class.new
+            klass.class_exec do
+              def hi; :hi; end
+            end
+            klass.new.hi
             "#,
         );
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -482,6 +482,18 @@ impl Executor {
             .push(Cref::new(class_id, false, Visibility::Public));
     }
 
+    /// Runtime-only push used by `class_eval` / `module_eval` /
+    /// `class_exec` (block forms). The pushed cref drives `def`'s
+    /// default definee but is **not** a real lexical scope, so
+    /// `module Foo; end` / `X = ...` inside the block fall through
+    /// to the iseq's captured lexical context.
+    pub(crate) fn push_runtime_class_context(&mut self, class_id: ClassId) {
+        self.lexical_class
+            .last_mut()
+            .unwrap()
+            .push(Cref::new_runtime(class_id, Visibility::Public));
+    }
+
     pub(crate) fn push_instance_eval_context(&mut self, receiver: Value) {
         self.lexical_class
             .last_mut()
@@ -521,6 +533,35 @@ impl Executor {
                 DefinitionContext::Receiver(val) => val.class(),
             })
             .unwrap_or(OBJECT_CLASS)
+    }
+
+    /// Lexical parent for `module Foo; end` / `class Foo; end` /
+    /// `X = ...`. Walks the runtime cref stack (top-down) and returns
+    /// the first entry tagged as a lexical push — i.e. one introduced
+    /// by the `class`/`module` keyword or a `Kernel#load` wrap, but
+    /// **not** one introduced by `class_exec` / `module_eval` /
+    /// `instance_exec` (those push only to drive `def`'s default
+    /// definee). If no lexical entry is on the stack, falls back to
+    /// the current iseq's captured lexical context — the block-form
+    /// case where the runtime push doesn't reflect a lexical change.
+    pub(crate) fn lexical_context_class_id(&self, globals: &Globals) -> ClassId {
+        // Walk only the *current* require/load frame (`lexical_class`
+        // is a `Vec<Vec<Cref>>`; each outer entry is one require
+        // boundary, each inner one a class/module/eval push). We must
+        // not descend into the enclosing require's frame because that
+        // would leak the requirer's lexical scope into the loaded
+        // file.
+        if let Some(crefs) = self.lexical_class.last() {
+            for cref in crefs.iter().rev() {
+                if cref.is_lexical
+                    && let DefinitionContext::Class(class_id) = cref.context
+                {
+                    return class_id;
+                }
+            }
+        }
+        self.definition_func_id(globals)
+            .lexical_class(&globals.store)
     }
 
     /// Returns the lexical class nesting at the current point of execution,
@@ -1406,7 +1447,10 @@ impl Executor {
         bh: BlockHandler,
     ) -> Result<Value> {
         let data = self.get_block_data(globals, bh)?;
-        self.push_class_context(module.id());
+        // module_eval { ... }: runtime-only push so that an enclosed
+        // `def` lands on the receiver, but `module Foo; end` /
+        // `X = ...` use the block's captured lexical scope.
+        self.push_runtime_class_context(module.id());
         let res = self.invoke_block_with_self(globals, &data, module.get(), &[module.get()]);
         self.pop_class_context();
         res
@@ -1723,7 +1767,15 @@ impl Executor {
     ) -> Result<Value> {
         let parent = match base {
             Some(base) => base.expect_class_or_module(&globals.store)?.id(),
-            None => self.context_class_id(),
+            // Use the lexical parent, not the runtime class-context
+            // stack. The two diverge inside `class_eval` /
+            // `module_eval` / `class_exec` / `instance_exec` blocks:
+            // the runtime stack is pushed to the receiver (so that an
+            // enclosed `def` lands on the receiver), but `module Foo;
+            // end` / `class Foo; end` inside such a block must use
+            // the block's captured lexical scope. CRuby's
+            // `rb_vm_get_cref` / `rb_const_set` does the same.
+            None => self.lexical_context_class_id(globals),
         };
         // Capture the call-site location *before* we create / look up
         // the class so we can attach it to the constant if this is the
@@ -2107,6 +2159,13 @@ struct Cref {
     pub(crate) context: DefinitionContext,
     pub(crate) module_function: bool,
     pub(crate) visibility: Visibility,
+    /// True when this cref was introduced by a `class`/`module`
+    /// keyword (or `Kernel#load(path, true)` wrap) — i.e. when it
+    /// represents a real lexical scope, not just a runtime override
+    /// for `def`'s default definee. `class_eval` / `module_eval` /
+    /// `class_exec` / `instance_eval` / `instance_exec` push with
+    /// `is_lexical = false`.
+    pub(crate) is_lexical: bool,
 }
 
 impl Cref {
@@ -2115,6 +2174,16 @@ impl Cref {
             context: DefinitionContext::Class(class_id),
             module_function,
             visibility,
+            is_lexical: true,
+        }
+    }
+
+    fn new_runtime(class_id: ClassId, visibility: Visibility) -> Self {
+        Self {
+            context: DefinitionContext::Class(class_id),
+            module_function: false,
+            visibility,
+            is_lexical: false,
         }
     }
 
@@ -2123,6 +2192,7 @@ impl Cref {
             context: DefinitionContext::Receiver(receiver),
             module_function: false,
             visibility,
+            is_lexical: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Distinguishes the two distinct uses of monoruby's `lexical_class` runtime stack — **real lexical scope** (from `class`/`module` keywords) vs. **method-definee override** (from `class_exec` / `module_eval` / `instance_exec`) — by tagging each cref with an `is_lexical` flag. `module Foo; end` / `class Foo; end` / `X = ...` now consult only the lexical entries, matching CRuby semantics.

Cuts **~22 failures** from `core/module` ruby/spec (194 → 172).

## Background

For a block executed via `class_exec` / `module_eval` / `instance_exec`:

```ruby
class A; end
A.class_exec {
  def foo; end       # → lands on A (receiver-class)
  module Inner; end  # CRuby: toplevel ::Inner; monoruby was: A::Inner
  C = 100            # CRuby: toplevel ::C;     monoruby was: A::C
}
```

monoruby was generating `A::Inner` because `define_class` (the `module`/`class` keyword) read its parent from `Executor::context_class_id` — the same stack that `class_exec` had pushed the receiver onto.

mspec runs every `it` block via `MSpecEnv.instance_exec(&block)`, so `module ModuleSpecs; ... end` inside a spec was creating `MSpecEnv::ModuleSpecs` instead of opening `::ModuleSpecs`. That accounted for ~22 spec failures across `core/module/`.

## Changes

### 1. `Cref` gains `is_lexical: bool`

- `Cref::new` (used by the `class`/`module` keyword and `Kernel#load(path, true)` wrap) sets `is_lexical = true`.
- `Cref::new_runtime` (**new**, used by `class_eval` / `module_eval` / `class_exec`) sets `is_lexical = false`.
- `Cref::new_instance_eval` (used by `instance_exec` / `instance_eval`) sets `is_lexical = false`.

### 2. New runtime push helper

`Executor::push_runtime_class_context` pushes a non-lexical cref. `class_eval` (string + block forms), `class_exec`, `module_eval` were switched over.

### 3. Lexical-only lookup helper

`Executor::lexical_context_class_id` (**new**) walks the **current require/load frame** of `lexical_class` from top and returns the first `is_lexical = true` entry, falling back to the current iseq's captured `lexical_context.last()` (or `OBJECT_CLASS`). Crucially does NOT descend across require boundaries — the requirer's lexical scope can't leak into the loaded file (this avoided regressions in rubygems boot).

### 4. `define_class` consults the new helper

`Executor::define_class` for the `base = None` branch reads from `lexical_context_class_id` instead of `context_class_id`. `def`'s default-definee path is unchanged (still `context_class_id`), so the receiver-class semantics for `def` inside `class_exec` is preserved.

## Verification

- `cargo test --release --lib 'builtins::module'` — **157/157 pass** (was 152, +5 new tests covering `class_exec`/`module_eval`/`instance_exec` lexical scope, the `class` keyword regression sentry, and `def` inside `class_exec`)
- `cargo test --release --lib` — 1714/1716 pass (the 2 failures are pre-existing inspect-format issues already present on master)
- `cargo test --release --test method_call --test class_chain --test require --test enumerable --test variables --test yield` — all pass (98/98 across these)
- `core/module` ruby/spec: 67+127=**194 → 60+112=172**, 22 fewer issues, no new regressions

## Test plan

- [x] Run `cargo test --release --lib 'builtins::module'`
- [x] Run integration tests for require/method_call/class_chain/enumerable/variables/yield
- [x] Run full `core/module` ruby/spec
- [x] Manual smoke tests for each scope-affecting builtin

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_