### PR TITLE
String: route mutation methods through cr-aware RStringInner API

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5509,11 +5509,12 @@ fn scrub_inner(inner: &RStringInner, repl: &RStringInner) -> Result<RStringInner
     let bytes = inner.as_bytes();
     let enc = inner.encoding();
     if inner.is_valid_encoding() {
-        // Already valid — copy through unchanged. `from_encoding`'s
-        // cr=Unknown is harmless here since the next access still
-        // takes the cached path of `inner` itself; this is the
-        // only branch that doesn't synthesise a fresh buffer.
-        return Ok(RStringInner::from_encoding(bytes, enc));
+        // Already valid — clone the receiver so the result inherits
+        // its cached cr instead of reverting to Unknown. Same alloc
+        // cost as `from_encoding(bytes, enc)` (both copy `bytes`),
+        // but preserves the SevenBit/Valid classification the caller
+        // had already paid for.
+        return Ok(inner.clone());
     }
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     match enc {
@@ -5551,7 +5552,8 @@ fn scrub_inner_with_block(
     let bytes = inner.as_bytes();
     let enc = inner.encoding();
     if inner.is_valid_encoding() {
-        return Ok(RStringInner::from_encoding(bytes, enc));
+        // Same cr-preservation rationale as `scrub_inner` above.
+        return Ok(inner.clone());
     }
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let data = vm.get_block_data(globals, bh)?;

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5470,6 +5470,10 @@ fn scrub_inner(inner: &RStringInner, repl: &RStringInner) -> Result<RStringInner
     let bytes = inner.as_bytes();
     let enc = inner.encoding();
     if inner.is_valid_encoding() {
+        // Already valid — copy through unchanged. `from_encoding`'s
+        // cr=Unknown is harmless here since the next access still
+        // takes the cached path of `inner` itself; this is the
+        // only branch that doesn't synthesise a fresh buffer.
         return Ok(RStringInner::from_encoding(bytes, enc));
     }
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
@@ -5486,7 +5490,11 @@ fn scrub_inner(inner: &RStringInner, repl: &RStringInner) -> Result<RStringInner
         }
         _ => out.extend_from_slice(bytes),
     }
-    Ok(RStringInner::from_encoding(&out, enc))
+    // Scrub by definition produces a fully valid byte sequence under
+    // `enc`, so we eagerly classify the result. Skipping this leaves
+    // cr=Unknown and the next operation that touches cr would walk
+    // the whole buffer again.
+    Ok(RStringInner::from_encoding_scanned(&out, enc))
 }
 
 /// Block-form scrub. For each "maximal subpart" of an ill-formed
@@ -5556,7 +5564,10 @@ fn scrub_inner_with_block(
         }
         _ => out.extend_from_slice(bytes),
     }
-    Ok(RStringInner::from_encoding(&out, enc))
+    // Same eagerness rationale as `scrub_inner` — block-driven
+    // replacements produce a final buffer that's expected to satisfy
+    // `enc`, so we cache the cr now.
+    Ok(RStringInner::from_encoding_scanned(&out, enc))
 }
 
 fn scrub_utf8(bytes: &[u8], repl: &[u8], out: &mut Vec<u8>) {

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3365,24 +3365,18 @@ fn bytesplice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         }
     }
 
-    // Check encoding compatibility
-    match (self_enc, str_enc) {
-        (Encoding::Utf8 | Encoding::UsAscii, Encoding::Ascii8) => {
-            if !replacement.is_ascii() && !self_.as_rstring_inner().as_bytes().is_ascii() {
-                return Err(MonorubyErr::runtimeerr(
-                    "incompatible character encodings: UTF-8 and ASCII-8BIT",
-                ));
-            }
-        }
-        (Encoding::Ascii8, Encoding::Utf8 | Encoding::UsAscii) => {
-            // OK
-        }
-        _ => {}
-    }
-
+    // Encoding-compatibility is delegated to `bytesplice_with`,
+    // which raises `Encoding::CompatibilityError` (matching CRuby)
+    // when the receiver and replacement disagree. The bytes were
+    // already extracted as a sub-slice, so we wrap them with the
+    // source string's encoding to preserve its semantics — the
+    // splice can promote the receiver's encoding (e.g. US-ASCII
+    // target + UTF-8 replacement → UTF-8 result, mirroring
+    // `String#+`).
+    let repl_inner = RStringInner::from_encoding_scanned(replacement, str_enc);
     self_
         .as_rstring_inner_mut()
-        .bytesplice(start, splice_len, replacement);
+        .bytesplice_with(start, splice_len, &repl_inner, &globals.store)?;
 
     Ok(self_)
 }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3406,7 +3406,19 @@ fn bytesplice(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     // splice can promote the receiver's encoding (e.g. US-ASCII
     // target + UTF-8 replacement → UTF-8 result, mirroring
     // `String#+`).
-    let repl_inner = RStringInner::from_encoding_scanned(replacement, str_enc);
+    //
+    // *Empty* replacements are special: `s.clear` (and
+    // `s.bytesplice(0, n, "")`) must not promote the receiver's
+    // encoding to the replacement's, since no source bytes are
+    // actually introduced. Tag the empty slice with the
+    // receiver's own encoding so `compatible_encoding`'s
+    // empty-other rule trivially returns `self_enc`.
+    let repl_enc = if replacement.is_empty() {
+        self_enc
+    } else {
+        str_enc
+    };
+    let repl_inner = RStringInner::from_encoding_scanned(replacement, repl_enc);
     self_
         .as_rstring_inner_mut()
         .bytesplice_with(start, splice_len, &repl_inner, &globals.store)?;

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1938,9 +1938,15 @@ fn chomp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     };
 
     let self_ = lfp.self_val();
+    let inner = self_.as_rstring_inner();
     let self_s = self_.expect_str(globals)?;
-    let res = chomp_sub(self_s, rs);
-    Ok(Value::string_from_str(res))
+    // `chomp_sub` returns a prefix of `self_s`; its length is the
+    // byte-end of the substring. `from_substring` propagates the
+    // parent's cached cr in O(1) on a single-byte trim.
+    let new_end = chomp_sub(self_s, rs).len();
+    Ok(Value::string_from_inner(RStringInner::from_substring(
+        inner, 0, new_end,
+    )))
 }
 
 ///
@@ -1965,12 +1971,14 @@ fn chomp_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     };
 
     let self_ = lfp.self_val();
+    let inner = self_.as_rstring_inner();
     let self_s = self_.expect_str(globals)?;
-    let res = chomp_sub(self_s, rs);
-    if res.len() == self_s.len() {
+    let new_end = chomp_sub(self_s, rs).len();
+    if new_end == self_s.len() {
         Ok(Value::nil())
     } else {
-        *lfp.self_val().as_rstring_inner_mut() = RStringInner::from_str(res);
+        let trimmed = RStringInner::from_substring(inner, 0, new_end);
+        lfp.self_val().replace_with_inner(trimmed);
         Ok(lfp.self_val())
     }
 }
@@ -1986,11 +1994,15 @@ const STRIP: &[char] = &[' ', '\n', '\t', '\x0d', '\x0c', '\x0b', '\x00'];
 #[monoruby_builtin]
 fn strip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let self_ = self_val
-        .expect_str(globals)?
-        .trim_end_matches(STRIP)
-        .trim_start_matches(STRIP);
-    Ok(Value::string_from_str(self_))
+    let inner = self_val.as_rstring_inner();
+    let s = self_val.expect_str(globals)?;
+    let after_rtrim = s.trim_end_matches(STRIP);
+    let new_end = after_rtrim.len();
+    let after_ltrim = after_rtrim.trim_start_matches(STRIP);
+    let new_start = new_end - after_ltrim.len();
+    Ok(Value::string_from_inner(RStringInner::from_substring(
+        inner, new_start, new_end,
+    )))
 }
 
 ///
@@ -2003,12 +2015,17 @@ fn strip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 fn strip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
+    let inner = self_val.as_rstring_inner();
     let orig = self_val.expect_str(globals)?;
-    let self_ = orig.trim_end_matches(STRIP).trim_start_matches(STRIP);
-    if self_.len() == orig.len() {
+    let after_rtrim = orig.trim_end_matches(STRIP);
+    let new_end = after_rtrim.len();
+    let after_ltrim = after_rtrim.trim_start_matches(STRIP);
+    let new_start = new_end - after_ltrim.len();
+    if new_end - new_start == orig.len() {
         return Ok(Value::nil());
     }
-    lfp.self_val().replace_str(self_);
+    let trimmed = RStringInner::from_substring(inner, new_start, new_end);
+    lfp.self_val().replace_with_inner(trimmed);
     Ok(lfp.self_val())
 }
 
@@ -2021,8 +2038,12 @@ fn strip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[monoruby_builtin]
 fn rstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let self_ = self_val.expect_str(globals)?.trim_end_matches(STRIP);
-    Ok(Value::string_from_str(self_))
+    let inner = self_val.as_rstring_inner();
+    let s = self_val.expect_str(globals)?;
+    let new_end = s.trim_end_matches(STRIP).len();
+    Ok(Value::string_from_inner(RStringInner::from_substring(
+        inner, 0, new_end,
+    )))
 }
 
 ///
@@ -2035,12 +2056,14 @@ fn rstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn rstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
+    let inner = self_val.as_rstring_inner();
     let orig = self_val.expect_str(globals)?;
-    let self_ = orig.trim_end_matches(STRIP);
-    if self_.len() == orig.len() {
+    let new_end = orig.trim_end_matches(STRIP).len();
+    if new_end == orig.len() {
         return Ok(Value::nil());
     }
-    lfp.self_val().replace_str(self_);
+    let trimmed = RStringInner::from_substring(inner, 0, new_end);
+    lfp.self_val().replace_with_inner(trimmed);
     Ok(lfp.self_val())
 }
 
@@ -2053,8 +2076,15 @@ fn rstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn lstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let self_ = self_val.expect_str(globals)?.trim_start_matches(STRIP);
-    Ok(Value::string_from_str(self_))
+    let inner = self_val.as_rstring_inner();
+    let s = self_val.expect_str(globals)?;
+    let trimmed = s.trim_start_matches(STRIP);
+    let new_start = s.len() - trimmed.len();
+    Ok(Value::string_from_inner(RStringInner::from_substring(
+        inner,
+        new_start,
+        s.len(),
+    )))
 }
 
 ///
@@ -2067,12 +2097,15 @@ fn lstrip(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn lstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let self_val = lfp.self_val();
+    let inner = self_val.as_rstring_inner();
     let orig = self_val.expect_str(globals)?;
-    let self_ = orig.trim_start_matches(STRIP);
-    if self_.len() == orig.len() {
+    let trimmed = orig.trim_start_matches(STRIP);
+    let new_start = orig.len() - trimmed.len();
+    if new_start == 0 {
         return Ok(Value::nil());
     }
-    lfp.self_val().replace_str(self_);
+    let result = RStringInner::from_substring(inner, new_start, orig.len());
+    lfp.self_val().replace_with_inner(result);
     Ok(lfp.self_val())
 }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -949,7 +949,7 @@ fn index_assign(
         // mock that should not receive `to_str` when the match fails.
         let (start, end) = locate_regex_match(vm, &re, &lfp.self_val(), arg1_opt, globals)?;
         let subst = arg_val.coerce_to_string(vm, globals)?;
-        replace_byte_range(lfp.self_val(), start, end, &subst);
+        replace_byte_range(globals, lfp.self_val(), start, end, &subst)?;
         return Ok(arg_val);
     }
 
@@ -968,7 +968,7 @@ fn index_assign(
             Some(p) => p,
             None => return Err(MonorubyErr::indexerr("string not matched")),
         };
-        replace_byte_range(lfp.self_val(), pos, pos + needle.len(), &subst);
+        replace_byte_range(globals, lfp.self_val(), pos, pos + needle.len(), &subst)?;
         return Ok(arg_val);
     }
 
@@ -1128,15 +1128,16 @@ fn locate_regex_match(
     }
 }
 
-fn replace_byte_range(mut self_val: Value, start: usize, end: usize, subst: &str) {
+fn replace_byte_range(
+    globals: &Globals,
+    mut self_val: Value,
+    start: usize,
+    end: usize,
+    subst: &str,
+) -> Result<()> {
+    let repl = RStringInner::from_str_scanned(subst);
     let inner = self_val.as_rstring_inner_mut();
-    let mut buf = inner.as_bytes().to_vec();
-    buf.splice(start..end, subst.as_bytes().iter().copied());
-    // Encoding-preserving construction is a separate concern; for
-    // now treat the result as UTF-8, which matches the rest of the
-    // string-builder paths in this file.
-    let s = String::from_utf8(buf).unwrap_or_default();
-    *inner = RStringInner::from_string(s);
+    inner.bytesplice_with(start, end - start, &repl, &globals.store)
 }
 
 ///

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2087,7 +2087,7 @@ fn lstrip_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn sub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     require_sub_block_or_replacement(&lfp, "sub")?;
     let (res, _) = sub_main(vm, globals, lfp.self_val(), lfp)?;
-    Ok(Value::string(res))
+    Ok(Value::string_from_inner(res))
 }
 
 ///
@@ -2103,7 +2103,7 @@ fn sub_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let (res, changed) = sub_main(vm, globals, self_, lfp)?;
-    self_.replace_string(res);
+    self_.replace_with_inner(res);
     let res = if changed { self_ } else { Value::nil() };
     Ok(res)
 }
@@ -2125,7 +2125,7 @@ fn sub_main(
     globals: &mut Globals,
     self_val: Value,
     lfp: Lfp,
-) -> Result<(String, bool)> {
+) -> Result<(RStringInner, bool)> {
     if let Some(arg1) = lfp.try_arg(1) {
         if lfp.block().is_some() {
             eprintln!("warning: default value argument supersedes block");
@@ -2199,7 +2199,7 @@ fn gsub(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
         );
     }
     let (res, _) = gsub_main(vm, globals, lfp.self_val(), lfp)?;
-    Ok(Value::string(res))
+    Ok(Value::string_from_inner(res))
 }
 
 ///
@@ -2223,7 +2223,7 @@ fn gsub_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) ->
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_ = lfp.self_val();
     let (res, changed) = gsub_main(vm, globals, self_, lfp)?;
-    self_.replace_string(res);
+    self_.replace_with_inner(res);
     let res = if changed { self_ } else { Value::nil() };
     Ok(res)
 }
@@ -2233,7 +2233,7 @@ fn gsub_main(
     globals: &mut Globals,
     self_val: Value,
     lfp: Lfp,
-) -> Result<(String, bool)> {
+) -> Result<(RStringInner, bool)> {
     if let Some(arg1) = lfp.try_arg(1) {
         if lfp.block().is_some() {
             eprintln!("warning: default value argument supersedes block");

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5827,9 +5827,13 @@ fn unicode_normalize_(
         _ => unreachable!(),
     };
     let old_len = lfp.self_val().as_rstring_inner().len();
+    // NFC/NFD/NFKC/NFKD output is well-formed UTF-8 by construction,
+    // so `from_string_scanned` lets the splice land in the Valid /
+    // SevenBit fast path without re-classifying afterwards.
+    let repl = RStringInner::from_string_scanned(result);
     lfp.self_val()
         .as_rstring_inner_mut()
-        .bytesplice(0, old_len, result.as_bytes());
+        .bytesplice_with(0, old_len, &repl, &globals.store)?;
     Ok(lfp.self_val())
 }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -4082,7 +4082,13 @@ fn upcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Upcase)?;
     let self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
-    Ok(Value::string(apply_case(s, CaseOp::Upcase, mode)))
+    // `apply_case` walks `chars()` and pushes whole scalars, so the
+    // output is well-formed UTF-8 by construction; pre-scan it so
+    // the cr lands as SevenBit/Valid up front and the next access
+    // doesn't have to walk the buffer again.
+    Ok(Value::string_from_inner(RStringInner::from_string_scanned(
+        apply_case(s, CaseOp::Upcase, mode),
+    )))
 }
 
 ///
@@ -4099,7 +4105,7 @@ fn upcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Upcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
-    self_val.replace_string(result);
+    self_val.replace_with_inner(RStringInner::from_string_scanned(result));
 
     Ok(if changed {
         lfp.self_val()
@@ -4119,7 +4125,9 @@ fn downcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Downcase)?;
     let self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
-    Ok(Value::string(apply_case(s, CaseOp::Downcase, mode)))
+    Ok(Value::string_from_inner(RStringInner::from_string_scanned(
+        apply_case(s, CaseOp::Downcase, mode),
+    )))
 }
 
 ///
@@ -4136,7 +4144,7 @@ fn downcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Downcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
-    self_val.replace_string(result);
+    self_val.replace_with_inner(RStringInner::from_string_scanned(result));
 
     Ok(if changed {
         lfp.self_val()
@@ -4161,7 +4169,9 @@ fn capitalize(
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Capitalize)?;
     let self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
-    Ok(Value::string(apply_case(s, CaseOp::Capitalize, mode)))
+    Ok(Value::string_from_inner(RStringInner::from_string_scanned(
+        apply_case(s, CaseOp::Capitalize, mode),
+    )))
 }
 
 ///
@@ -4183,7 +4193,7 @@ fn capitalize_(
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Capitalize, mode);
     let changed = &result != self_val.expect_str(globals)?;
-    self_val.replace_string(result);
+    self_val.replace_with_inner(RStringInner::from_string_scanned(result));
     Ok(if changed {
         lfp.self_val()
     } else {
@@ -4202,7 +4212,9 @@ fn swapcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Swapcase)?;
     let self_val = lfp.self_val();
     let s = self_val.expect_str(globals)?;
-    Ok(Value::string(apply_case(s, CaseOp::Swapcase, mode)))
+    Ok(Value::string_from_inner(RStringInner::from_string_scanned(
+        apply_case(s, CaseOp::Swapcase, mode),
+    )))
 }
 
 ///
@@ -4219,7 +4231,7 @@ fn swapcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Swapcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
-    self_val.replace_string(result);
+    self_val.replace_with_inner(RStringInner::from_string_scanned(result));
     Ok(if changed {
         lfp.self_val()
     } else {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -2183,6 +2183,15 @@ impl Value {
         unsafe { *self.rvalue_mut().as_rstring_mut() = RStringInner::from_string(replace) };
     }
 
+    /// Replace the underlying `RStringInner` with the supplied one.
+    /// Used by `sub!` / `gsub!` to land an already-built result
+    /// (with cached cr / encoding) without an extra String round-trip.
+    pub(crate) fn replace_with_inner(&mut self, inner: RStringInner) {
+        assert_eq!(ObjTy::STRING, self.rvalue().ty());
+        // SAFETY: The assert ensures this RValue contains a string.
+        unsafe { *self.rvalue_mut().as_rstring_mut() = inner };
+    }
+
     pub(crate) fn replace_str(&mut self, replace: &str) {
         assert_eq!(ObjTy::STRING, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue contains a string.

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -362,9 +362,9 @@ impl RegexpInner {
         re_val: Value,
         given: &str,
         replace: &str,
-    ) -> Result<(String, bool)> {
-        Self::with_coerced_regexp(vm, globals, re_val, |re, vm, _| {
-            re.replace_once(vm, given, replace)
+    ) -> Result<(RStringInner, bool)> {
+        Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
+            re.replace_once(vm, &globals.store, given, replace)
         })
         .map(|(s, c)| (s, c.is_some()))
     }
@@ -375,18 +375,19 @@ impl RegexpInner {
         re_val: Value,
         given: &str,
         bh: BlockHandler,
-    ) -> Result<(String, bool)> {
+    ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
             match re.captures(given, vm)? {
-                None => Ok((given.to_string(), false)),
+                None => Ok((RStringInner::from_str_scanned(given), false)),
                 Some(captures) => {
                     let m = captures.get(0).unwrap();
                     let (start, end, matched_str) = (m.start(), m.end(), m.as_str());
-                    let mut res = given.to_string();
+                    let mut res = RStringInner::from_str_scanned(given);
                     let matched = Value::string_from_str(matched_str);
                     let result = vm.invoke_block_once(globals, bh, &[matched])?;
                     let s = block_result_to_string(vm, globals, result)?;
-                    res.replace_range(start..end, &s);
+                    let rep_inner = RStringInner::from_string_scanned(s);
+                    res.bytesplice_with(start, end - start, &rep_inner, &globals.store)?;
                     Ok((res, true))
                 }
             }
@@ -400,9 +401,9 @@ impl RegexpInner {
         regexp: Value,
         given: &str,
         replace: &str,
-    ) -> Result<(String, bool)> {
-        Self::with_coerced_regexp(vm, globals, regexp, |re, vm, _| {
-            re.replace_repeat(vm, given, replace)
+    ) -> Result<(RStringInner, bool)> {
+        Self::with_coerced_regexp(vm, globals, regexp, |re, vm, globals| {
+            re.replace_repeat(vm, &globals.store, given, replace)
         })
     }
 
@@ -414,7 +415,7 @@ impl RegexpInner {
         given: &str,
         bh: BlockHandler,
         self_enc: Option<crate::value::Encoding>,
-    ) -> Result<(String, bool)> {
+    ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
             let mut range = vec![];
             let data = vm.get_block_data(globals, bh)?;
@@ -448,11 +449,12 @@ impl RegexpInner {
                 range.push((m.range(), replace));
             }
 
-            let mut res = given.to_string();
+            let mut res = RStringInner::from_str_scanned(given);
             let is_empty = range.is_empty();
 
-            for (range, replace) in range.into_iter().rev() {
-                res.replace_range(range, &replace);
+            for (r, replace) in range.into_iter().rev() {
+                let rep_inner = RStringInner::from_string_scanned(replace);
+                res.bytesplice_with(r.start, r.end - r.start, &rep_inner, &globals.store)?;
             }
 
             Ok((res, !is_empty))
@@ -469,17 +471,18 @@ impl RegexpInner {
         re_val: Value,
         given: &str,
         hash_val: Value,
-    ) -> Result<(String, bool)> {
+    ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
             match re.captures(given, vm)? {
-                None => Ok((given.to_string(), false)),
+                None => Ok((RStringInner::from_str_scanned(given), false)),
                 Some(captures) => {
                     let m = captures.get(0).unwrap();
                     let (start, end, matched_str) = (m.start(), m.end(), m.as_str());
-                    let mut res = given.to_string();
+                    let mut res = RStringInner::from_str_scanned(given);
                     let key = Value::string_from_str(matched_str);
                     let replacement = lookup_hash_replacement(vm, globals, hash_val, key)?;
-                    res.replace_range(start..end, &replacement);
+                    let rep_inner = RStringInner::from_string_scanned(replacement);
+                    res.bytesplice_with(start, end - start, &rep_inner, &globals.store)?;
                     Ok((res, true))
                 }
             }
@@ -493,7 +496,7 @@ impl RegexpInner {
         re_val: Value,
         given: &str,
         hash_val: Value,
-    ) -> Result<(String, bool)> {
+    ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
             let mut range = vec![];
 
@@ -510,11 +513,12 @@ impl RegexpInner {
                 range.push((m.range(), replacement));
             }
 
-            let mut res = given.to_string();
+            let mut res = RStringInner::from_str_scanned(given);
             let is_empty = range.is_empty();
 
-            for (range, replace) in range.into_iter().rev() {
-                res.replace_range(range, &replace);
+            for (r, replace) in range.into_iter().rev() {
+                let rep_inner = RStringInner::from_string_scanned(replace);
+                res.bytesplice_with(r.start, r.end - r.start, &rep_inner, &globals.store)?;
             }
 
             Ok((res, !is_empty))
@@ -602,13 +606,18 @@ impl RegexpInner {
     /// Replace all matches for `self` in `given` string with `replace`.
     ///
     /// ### return
-    /// (replaced:String, is_replaced?:bool)
+    /// `(replaced: RStringInner, is_replaced?: bool)`. The result
+    /// inherits the receiver-side encoding implicit in `given`
+    /// (always UTF-8 today, since the caller goes through
+    /// `expect_str`); cr is propagated through `bytesplice_with`
+    /// rather than re-classified after the fact.
     fn replace_repeat(
         &self,
         vm: &mut Executor,
+        store: &Store,
         given: &str,
         replace: &str,
-    ) -> Result<(String, bool)> {
+    ) -> Result<(RStringInner, bool)> {
         // Walk the haystack manually rather than relying on
         // `captures_iter`, which can skip the zero-width match that
         // sits between two non-empty matches (e.g.
@@ -642,10 +651,15 @@ impl RegexpInner {
                 next
             };
         }
-        let mut res = given.to_string();
+        let mut res = RStringInner::from_str_scanned(given);
         let is_empty = replacements.is_empty();
         for (r, rep) in replacements.into_iter().rev() {
-            res.replace_range(r, &rep);
+            // `r` is a UTF-8 byte range produced by Onigmo, so it
+            // sits on character boundaries; `rep` is the
+            // backref-expanded replacement, which inherits the
+            // splice substring's UTF-8 validity.
+            let rep_inner = RStringInner::from_string_scanned(rep);
+            res.bytesplice_with(r.start, r.end - r.start, &rep_inner, store)?;
         }
 
         if let Some(c) = last_captures {
@@ -787,21 +801,24 @@ impl RegexpInner {
 
     /// Replaces the leftmost-first match for `self` in `given` string with `replace`.
     ///
-    /// ### return
-    /// replaced:String
+    /// `(replaced: RStringInner, captures)`. See `replace_repeat`
+    /// for why we build the result via `bytesplice_with` rather
+    /// than `String::replace_range`.
     fn replace_once<'a>(
         &self,
         vm: &mut Executor,
+        store: &Store,
         given: &'a str,
         replace: &str,
-    ) -> Result<(String, Option<Captures<'a>>)> {
+    ) -> Result<(RStringInner, Option<Captures<'a>>)> {
         match self.captures(given, vm)? {
-            None => Ok((given.to_string(), None)),
+            None => Ok((RStringInner::from_str_scanned(given), None)),
             Some(captures) => {
-                let mut res = given.to_string();
+                let mut res = RStringInner::from_str_scanned(given);
                 let m = captures.get(0).unwrap();
                 let rep = self.expand_backref(replace, given, &captures);
-                res.replace_range(m.start()..m.end(), &rep);
+                let rep_inner = RStringInner::from_string_scanned(rep);
+                res.bytesplice_with(m.start(), m.end() - m.start(), &rep_inner, store)?;
                 Ok((res, Some(captures)))
             }
         }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -385,8 +385,7 @@ impl RegexpInner {
                     let mut res = RStringInner::from_str_scanned(given);
                     let matched = Value::string_from_str(matched_str);
                     let result = vm.invoke_block_once(globals, bh, &[matched])?;
-                    let s = block_result_to_string(vm, globals, result)?;
-                    let rep_inner = RStringInner::from_string_scanned(s);
+                    let rep_inner = block_result_to_inner(vm, globals, result)?;
                     res.bytesplice_with(start, end - start, &rep_inner, &globals.store)?;
                     Ok((res, true))
                 }
@@ -444,7 +443,7 @@ impl RegexpInner {
                         }
                     }
                 }
-                let replace = block_result_to_string(vm, globals, result)?;
+                let replace = block_result_to_inner(vm, globals, result)?;
 
                 range.push((m.range(), replace));
             }
@@ -452,8 +451,7 @@ impl RegexpInner {
             let mut res = RStringInner::from_str_scanned(given);
             let is_empty = range.is_empty();
 
-            for (r, replace) in range.into_iter().rev() {
-                let rep_inner = RStringInner::from_string_scanned(replace);
+            for (r, rep_inner) in range.into_iter().rev() {
                 res.bytesplice_with(r.start, r.end - r.start, &rep_inner, &globals.store)?;
             }
 
@@ -480,8 +478,7 @@ impl RegexpInner {
                     let (start, end, matched_str) = (m.start(), m.end(), m.as_str());
                     let mut res = RStringInner::from_str_scanned(given);
                     let key = Value::string_from_str(matched_str);
-                    let replacement = lookup_hash_replacement(vm, globals, hash_val, key)?;
-                    let rep_inner = RStringInner::from_string_scanned(replacement);
+                    let rep_inner = lookup_hash_replacement(vm, globals, hash_val, key)?;
                     res.bytesplice_with(start, end - start, &rep_inner, &globals.store)?;
                     Ok((res, true))
                 }
@@ -516,8 +513,7 @@ impl RegexpInner {
             let mut res = RStringInner::from_str_scanned(given);
             let is_empty = range.is_empty();
 
-            for (r, replace) in range.into_iter().rev() {
-                let rep_inner = RStringInner::from_string_scanned(replace);
+            for (r, rep_inner) in range.into_iter().rev() {
                 res.bytesplice_with(r.start, r.end - r.start, &rep_inner, &globals.store)?;
             }
 
@@ -825,23 +821,33 @@ impl RegexpInner {
     }
 }
 
-/// Coerce the result of a `String#sub`/`#gsub` block to a String,
-/// calling user-defined `to_s` so a mock returning a non-String
-/// from `to_s` is exercised. Falls back to monoruby's intrinsic
-/// `to_s` rendering when the object's `to_s` doesn't return a String.
-fn block_result_to_string(
+/// Coerce the result of a `String#sub`/`#gsub` block to an
+/// `RStringInner`, calling user-defined `to_s` so a mock returning
+/// a non-String from `to_s` is exercised. Falls back to monoruby's
+/// intrinsic `to_s` rendering when the object's `to_s` doesn't
+/// return a String. Returns the `RStringInner` directly so callers
+/// don't have to round-trip through `String` and re-classify.
+///
+/// Result encoding mirrors `block_result_to_string`'s pre-existing
+/// behaviour: `is_str()` validates the bytes are UTF-8 and surfaces
+/// `ArgumentError: invalid byte sequence in UTF-8` for non-UTF-8
+/// receivers. Callers (e.g. `replace_all_block`) layer their own
+/// `Encoding::CompatibilityError` checks on top.
+fn block_result_to_inner(
     vm: &mut Executor,
     globals: &mut Globals,
     v: Value,
-) -> Result<String> {
+) -> Result<RStringInner> {
     if let Some(s) = v.is_str() {
-        return Ok(s.to_string());
+        return Ok(RStringInner::from_str_scanned(s));
     }
     let coerced = vm.invoke_method_inner(globals, IdentId::TO_S, v, &[], None, None)?;
     if let Some(s) = coerced.is_str() {
-        Ok(s.to_string())
+        Ok(RStringInner::from_str_scanned(s))
     } else {
-        Ok(coerced.to_s(&globals.store))
+        // Intrinsic fallback produces `String`; pre-classify it
+        // so the splice that follows lands on a fast path.
+        Ok(RStringInner::from_string_scanned(coerced.to_s(&globals.store)))
     }
 }
 
@@ -856,19 +862,19 @@ fn lookup_hash_replacement(
     globals: &mut Globals,
     hash: Value,
     key: Value,
-) -> Result<String> {
+) -> Result<RStringInner> {
     let v =
         vm.invoke_method_inner(globals, IdentId::_INDEX, hash, &[key], None, None)?;
     if v.is_nil() {
-        Ok(String::new())
+        Ok(RStringInner::from_str_scanned(""))
     } else if let Some(s) = v.is_str() {
-        Ok(s.to_string())
+        Ok(RStringInner::from_str_scanned(s))
     } else {
         // CRuby coerces non-String hash values via `Object#to_s`.
-        let s = vm.invoke_method_inner(globals, IdentId::TO_S, v, &[], None, None)?;
-        match s.is_str() {
-            Some(s) => Ok(s.to_string()),
-            None => Ok(s.to_s(&globals.store)),
+        let coerced = vm.invoke_method_inner(globals, IdentId::TO_S, v, &[], None, None)?;
+        match coerced.is_str() {
+            Some(s) => Ok(RStringInner::from_str_scanned(s)),
+            None => Ok(RStringInner::from_string_scanned(coerced.to_s(&globals.store))),
         }
     }
 }

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1227,74 +1227,10 @@ impl RStringInner {
         RStringInner::from(SmallVec::from_vec(self.content.repeat(len)), self.ty, cr)
     }
 
-    /// Replace byte range `start..start+len` with `replacement` bytes.
-    /// After replacement, validates encoding consistency.
-    pub fn bytesplice(&mut self, start: usize, len: usize, replacement: &[u8]) {
-        let end = start + len;
-        let prev_cr = self.cr.get();
-        let prev_ty = self.ty;
-
-        // Test BEFORE we mutate: if the receiver is valid UTF-8 and both
-        // splice endpoints fall on character boundaries in the original
-        // buffer, then by UTF-8's prefix-free property the result will
-        // still be valid UTF-8 as long as `replacement` itself is valid
-        // UTF-8. This lets us skip the O(N) from_utf8 walk below.
-        let utf8_boundaries_ok = matches!(prev_ty, Encoding::Utf8)
-            && matches!(prev_cr, CodeRange::Valid | CodeRange::SevenBit)
-            && is_utf8_char_boundary(&self.content, start)
-            && is_utf8_char_boundary(&self.content, end);
-
-        self.splice_bytes(start, end, replacement);
-        // Fast path 1: if the receiver was already SevenBit and the
-        // spliced bytes are all ASCII, the SevenBit invariant survives
-        // and we can skip the O(n) from_utf8 walk below.
-        if matches!(prev_cr, CodeRange::SevenBit)
-            && prev_ty.is_ascii_compatible()
-            && replacement.iter().all(|&b| b < 0x80)
-        {
-            self.cr.set(CodeRange::SevenBit);
-            return;
-        }
-        // Fast path 2: UTF-8 receiver where the splice both starts and
-        // ends on character boundaries -- if `replacement` is valid
-        // UTF-8 the whole thing is still valid (prefix-free property of
-        // UTF-8). `from_utf8(replacement)` is O(|replacement|), which is
-        // typically << |content|.
-        if utf8_boundaries_ok && std::str::from_utf8(replacement).is_ok() {
-            // Promote SevenBit only when both sides are pure ASCII;
-            // any non-ASCII byte demotes to Valid.
-            let cr = if matches!(prev_cr, CodeRange::SevenBit)
-                && replacement.iter().all(|&b| b < 0x80)
-            {
-                CodeRange::SevenBit
-            } else {
-                CodeRange::Valid
-            };
-            self.cr.set(cr);
-            return;
-        }
-        // Slow path: re-classify the whole buffer. We used to set
-        // cr = Unknown here unconditionally, which forced the next
-        // bytesplice to re-walk the buffer too -- a stream of in-place
-        // splices on the same string thus ran in O(N²). Cache the
-        // classification result instead so subsequent calls hit the
-        // fast paths above.
-        let cr = self.ty.classify(&self.content);
-        if matches!(cr, CodeRange::Broken) && self.ty.is_utf8_compatible() {
-            // CRuby downgrades to ASCII-8BIT when UTF-8-tagged content
-            // becomes invalid; under that tag every byte is Valid.
-            self.ty = Encoding::Ascii8;
-            self.cr.set(CodeRange::Valid);
-        } else {
-            self.cr.set(cr);
-        }
-    }
-
     /// Mutate `self.content` in place: replace bytes `start..end` with
     /// `replacement`. Encoding tag and `cr` are *not* touched — the
     /// caller is responsible for re-classifying or otherwise updating
-    /// them. Pure data shuffling so it can be reused by the upcoming
-    /// `bytesplice_with(&RStringInner)` API.
+    /// them. The shared low-level shuffling used by `bytesplice_with`.
     fn splice_bytes(&mut self, start: usize, end: usize, replacement: &[u8]) {
         debug_assert!(start <= end);
         debug_assert!(end <= self.content.len());

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1315,6 +1315,97 @@ impl RStringInner {
         self.content[start..start + replacement.len()].copy_from_slice(replacement);
     }
 
+    /// Replace byte range `start..start+len` with the bytes of
+    /// `replacement`, taking the replacement's encoding and cached
+    /// code range into account. Returns
+    /// `Encoding::CompatibilityError` (rather than ignoring the
+    /// mismatch the way `bytesplice(&[u8])` does) when the receiver
+    /// and `replacement` carry incompatible encodings.
+    ///
+    /// The cached `code_range()` of `replacement` lets us short-cut
+    /// the post-mutation classification: when both sides are
+    /// SevenBit/Valid and the splice falls on UTF-8 character
+    /// boundaries we set the result cr in O(1) without re-walking
+    /// the whole buffer. Broken results on UTF-8-compatible
+    /// encodings demote to ASCII-8BIT, matching CRuby and
+    /// `bytesplice`.
+    pub fn bytesplice_with(
+        &mut self,
+        start: usize,
+        len: usize,
+        replacement: &RStringInner,
+        store: &Store,
+    ) -> Result<()> {
+        let result_enc = self
+            .compatible_encoding(replacement)
+            .ok_or_else(|| MonorubyErr::incompatible_encoding(store, self.ty, replacement.ty))?;
+
+        let end = start + len;
+        let prev_cr = self.cr.get();
+        let prev_ty = self.ty;
+        let repl_cr = replacement.code_range();
+        let repl_bytes = replacement.as_bytes();
+
+        // Test BEFORE we mutate: if the receiver is valid UTF-8 and
+        // both splice endpoints fall on character boundaries, the
+        // prefix-free property of UTF-8 lets the receiver-side stay
+        // valid as long as the replacement is itself valid (which
+        // its cached cr tells us in O(1)).
+        let utf8_boundaries_ok = matches!(prev_ty, Encoding::Utf8)
+            && matches!(prev_cr, CodeRange::Valid | CodeRange::SevenBit)
+            && is_utf8_char_boundary(&self.content, start)
+            && is_utf8_char_boundary(&self.content, end);
+
+        self.splice_bytes(start, end, repl_bytes);
+        self.ty = result_enc;
+
+        // Fast path 1: SevenBit + ASCII-compatible encoding +
+        // ASCII-only replacement (its cr already says SevenBit).
+        if matches!(prev_cr, CodeRange::SevenBit)
+            && matches!(repl_cr, CodeRange::SevenBit)
+            && result_enc.is_ascii_compatible()
+        {
+            self.cr.set(CodeRange::SevenBit);
+            return Ok(());
+        }
+        // Fast path 2: receiver and replacement are both well-formed
+        // UTF-8 (or pure ASCII) and the splice respects character
+        // boundaries — the result is well-formed UTF-8 too.
+        if utf8_boundaries_ok
+            && matches!(repl_cr, CodeRange::SevenBit | CodeRange::Valid)
+        {
+            self.cr.set(CodeRange::Valid);
+            return Ok(());
+        }
+        // Slow path: re-classify the whole buffer. Caching the
+        // result keeps a chain of in-place splices O(N) rather than
+        // O(N²).
+        let cr = self.ty.classify(&self.content);
+        if matches!(cr, CodeRange::Broken) && self.ty.is_utf8_compatible() {
+            // CRuby downgrades to ASCII-8BIT when UTF-8-tagged
+            // content becomes invalid; under that tag every byte is
+            // valid.
+            self.ty = Encoding::Ascii8;
+            self.cr.set(CodeRange::Valid);
+        } else {
+            self.cr.set(cr);
+        }
+        Ok(())
+    }
+
+    /// Build an empty `RStringInner` tagged with the given encoding
+    /// and pre-allocated for `cap` bytes. Empty content is always
+    /// SevenBit (the empty byte sequence is trivially ASCII), so
+    /// callers can append into the result without paying for an
+    /// initial classification.
+    pub fn with_encoding_capacity(encoding: Encoding, cap: usize) -> Self {
+        RStringInner::from(
+            SmallVec::with_capacity(cap),
+            encoding,
+            CodeRange::SevenBit,
+        )
+    }
+
     pub fn first_code(&self) -> Result<u32> {
         if self.len() == 0 {
             return Err(MonorubyErr::argumenterr("empty string"));
@@ -2002,5 +2093,107 @@ mod encoding_tests {
         let mut out = String::new();
         utf8_dump_with_lookahead(&mut out, "\u{1F600}".as_bytes());
         assert_eq!(out, "\\u{1F600}");
+    }
+
+    #[test]
+    fn with_encoding_capacity_starts_seven_bit() {
+        // The empty byte sequence is trivially ASCII, so a freshly
+        // allocated empty buffer should advertise SevenBit
+        // regardless of the declared encoding.
+        let s = RStringInner::with_encoding_capacity(Encoding::Sjis(0), 16);
+        assert_eq!(s.cr.get(), CodeRange::SevenBit);
+        assert_eq!(s.encoding(), Encoding::Sjis(0));
+        assert_eq!(s.as_bytes().len(), 0);
+
+        let s = RStringInner::with_encoding_capacity(Encoding::Utf16Le, 0);
+        assert_eq!(s.cr.get(), CodeRange::SevenBit);
+        assert_eq!(s.encoding(), Encoding::Utf16Le);
+    }
+
+    #[test]
+    fn bytesplice_with_seven_bit_combines_to_seven_bit() {
+        let mut globals = Globals::new_test();
+        let mut s = RStringInner::from_str_scanned("abcdef");
+        let repl = RStringInner::from_str_scanned("XY");
+        assert_eq!(s.code_range(), CodeRange::SevenBit);
+        assert_eq!(repl.code_range(), CodeRange::SevenBit);
+
+        s.bytesplice_with(2, 2, &repl, &globals.store).unwrap();
+        assert_eq!(s.as_bytes(), b"abXYef");
+        assert_eq!(s.cr.get(), CodeRange::SevenBit);
+        assert_eq!(s.encoding(), Encoding::Utf8);
+    }
+
+    #[test]
+    fn bytesplice_with_seven_bit_plus_valid_is_valid() {
+        let mut globals = Globals::new_test();
+        let mut s = RStringInner::from_str_scanned("abcdef");
+        let repl = RStringInner::from_str_scanned("あ"); // 3 bytes, Valid
+        assert_eq!(s.code_range(), CodeRange::SevenBit);
+        assert_eq!(repl.code_range(), CodeRange::Valid);
+
+        s.bytesplice_with(2, 2, &repl, &globals.store).unwrap();
+        assert_eq!(s.as_bytes(), "abあef".as_bytes());
+        // SevenBit + Valid on aligned UTF-8 boundaries → Valid in O(1).
+        assert_eq!(s.cr.get(), CodeRange::Valid);
+    }
+
+    #[test]
+    fn bytesplice_with_valid_plus_valid_keeps_valid() {
+        let mut globals = Globals::new_test();
+        let mut s = RStringInner::from_str_scanned("xあy");
+        let repl = RStringInner::from_str_scanned("いう");
+        assert_eq!(s.code_range(), CodeRange::Valid);
+        assert_eq!(repl.code_range(), CodeRange::Valid);
+
+        // Replace the middle 3 bytes ("あ") with the 6-byte replacement.
+        s.bytesplice_with(1, 3, &repl, &globals.store).unwrap();
+        assert_eq!(s.as_bytes(), "xいうy".as_bytes());
+        assert_eq!(s.cr.get(), CodeRange::Valid);
+    }
+
+    #[test]
+    fn bytesplice_with_us_ascii_and_utf8_combine() {
+        // Pure-ASCII Utf8 and UsAscii are compatible; CRuby keeps
+        // the receiver's encoding when both sides are SevenBit. The
+        // important guarantees here are (a) the call succeeds and
+        // (b) cr stays SevenBit, since both sides are pure ASCII
+        // and the result encoding is ASCII-compatible.
+        let mut globals = Globals::new_test();
+        let mut s = RStringInner::from_str_scanned("hi");
+        s.set_encoding(Encoding::UsAscii);
+        let repl = RStringInner::from_str_scanned("X");
+        assert_eq!(s.encoding(), Encoding::UsAscii);
+        assert_eq!(repl.encoding(), Encoding::Utf8);
+
+        s.bytesplice_with(0, 1, &repl, &globals.store).unwrap();
+        assert_eq!(s.as_bytes(), b"Xi");
+        assert!(s.encoding().is_ascii_compatible());
+        assert_eq!(s.cr.get(), CodeRange::SevenBit);
+    }
+
+    #[test]
+    fn bytesplice_with_incompatible_encodings_errors() {
+        // Sjis with a non-ASCII byte cannot be combined with a
+        // non-ASCII UTF-8 replacement.
+        let globals = Globals::new_test();
+        let mut s = RStringInner::from_encoding_scanned(b"\x82\xa0", Encoding::Sjis(0)); // "あ" in Sjis
+        let repl = RStringInner::from_str_scanned("え");
+        assert!(s.bytesplice_with(0, 0, &repl, &globals.store).is_err());
+    }
+
+    #[test]
+    fn bytesplice_with_breaks_utf8_boundary_demotes_to_ascii8() {
+        // Splicing into the middle of a multi-byte UTF-8 character
+        // produces broken bytes; under Utf8 tagging CRuby (and our
+        // implementation) demotes to ASCII-8BIT.
+        let mut globals = Globals::new_test();
+        let mut s = RStringInner::from_str_scanned("あ"); // 3 bytes
+        let repl = RStringInner::from_str_scanned("X");
+
+        // Replace byte 1 (middle of "あ") — boundary check fails.
+        s.bytesplice_with(1, 0, &repl, &globals.store).unwrap();
+        assert_eq!(s.encoding(), Encoding::Ascii8);
+        assert_eq!(s.cr.get(), CodeRange::Valid);
     }
 }

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1244,22 +1244,7 @@ impl RStringInner {
             && is_utf8_char_boundary(&self.content, start)
             && is_utf8_char_boundary(&self.content, end);
 
-        let new_len = self.content.len() - len + replacement.len();
-        if replacement.len() > len {
-            // Need to grow: extend first, then shift
-            let extra = replacement.len() - len;
-            self.content.resize(new_len, 0);
-            // Shift tail right
-            self.content.copy_within(end..new_len - extra, end + extra);
-        } else if replacement.len() < len {
-            // Shrink: shift tail left, then truncate
-            let shrink = len - replacement.len();
-            let old_len = self.content.len();
-            self.content.copy_within(end..old_len, end - shrink);
-            self.content.truncate(new_len);
-        }
-        // Copy replacement in
-        self.content[start..start + replacement.len()].copy_from_slice(replacement);
+        self.splice_bytes(start, end, replacement);
         // Fast path 1: if the receiver was already SevenBit and the
         // spliced bytes are all ASCII, the SevenBit invariant survives
         // and we can skip the O(n) from_utf8 walk below.
@@ -1303,6 +1288,31 @@ impl RStringInner {
         } else {
             self.cr.set(cr);
         }
+    }
+
+    /// Mutate `self.content` in place: replace bytes `start..end` with
+    /// `replacement`. Encoding tag and `cr` are *not* touched — the
+    /// caller is responsible for re-classifying or otherwise updating
+    /// them. Pure data shuffling so it can be reused by the upcoming
+    /// `bytesplice_with(&RStringInner)` API.
+    fn splice_bytes(&mut self, start: usize, end: usize, replacement: &[u8]) {
+        debug_assert!(start <= end);
+        debug_assert!(end <= self.content.len());
+        let len = end - start;
+        let new_len = self.content.len() - len + replacement.len();
+        if replacement.len() > len {
+            // Need to grow: extend first, then shift the tail right.
+            let extra = replacement.len() - len;
+            self.content.resize(new_len, 0);
+            self.content.copy_within(end..new_len - extra, end + extra);
+        } else if replacement.len() < len {
+            // Shrink: shift the tail left, then truncate.
+            let shrink = len - replacement.len();
+            let old_len = self.content.len();
+            self.content.copy_within(end..old_len, end - shrink);
+            self.content.truncate(new_len);
+        }
+        self.content[start..start + replacement.len()].copy_from_slice(replacement);
     }
 
     pub fn first_code(&self) -> Result<u32> {


### PR DESCRIPTION
## Summary

12-commit refactor of `String` mutation primitives so the receiver's encoding and cached `code_range` survive each operation. Replaces ad-hoc `String` / `Vec<u8>` round-trips with a cr-propagating API surface.

## API

**Added**
- `RStringInner::bytesplice_with(start, len, &RStringInner, &Store) -> Result<()>` — in-place splice that uses the replacement's cached `code_range` to skip the post-mutation classify walk; raises `Encoding::CompatibilityError` on incompatible encodings.
- `RStringInner::with_encoding_capacity(encoding, cap)` — empty buffer pre-tagged SevenBit.
- `Value::replace_with_inner(RStringInner)` — sibling to `replace_string` for `sub!` / `gsub!` / etc.
- 7 unit tests covering cr propagation, encoding promotion, and boundary breakage.

**Removed**
- `RStringInner::bytesplice(&[u8])` — no remaining Rust callers after the `String#bytesplice` builtin moves to `bytesplice_with`.

## Migrated

- `String#[]=` (`replace_byte_range`) — was forcing UTF-8 via `String::from_utf8` and silently corrupting non-UTF-8 receivers.
- `String#unicode_normalize!`
- `String#sub` / `#sub!` / `#gsub` / `#gsub!` — all 8 `Regexp::replace_*` helpers now return `(RStringInner, bool)` and splice via `bytesplice_with` instead of `String::replace_range`. `block_result_to_inner` / `lookup_hash_replacement` return `RStringInner` directly.
- `String#upcase` / `#downcase` / `#capitalize` / `#swapcase` and `!` variants.
- `String#chomp` / `#strip` / `#lstrip` / `#rstrip` and `!` variants — now use `RStringInner::from_substring`, so parent cr and encoding propagate.
- `String#bytesplice` — gains CRuby's encoding-promotion rule and raises `Encoding::CompatibilityError` (was `RuntimeError`); empty-replacement special-case preserves receiver encoding (`s.clear` regression fix).
- `String#scrub` — already-valid path uses `inner.clone()` so the parent cr survives; mutated path eager-classifies the output.

## Tests vs master baseline

- `cargo test -p monoruby --lib` — 1752 pass / 2 pre-existing fails (`string_inspect`, `symbol_inspect_unquoted`).
- `mspec run core/string -t monoruby` — 383 failures / 101 errors / 10481 expectations / 3984 examples. **7 net spec wins over master**:
  - `core/string/bytesplice_spec.rb`: 4f → 1f (encoding promotion).
  - `core/string/{strip,lstrip,rstrip,chomp}_spec.rb`: 9f → 5f (`from_substring` preserves encoding).

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM