### PR TITLE
Use from_encoding_scanned for eager code-range classification

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -666,7 +666,7 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             &mut out,
             &mut enc,
         )?;
-        Ok(Value::string_from_inner(RStringInner::from_encoding(
+        Ok(Value::string_from_inner(RStringInner::from_encoding_scanned(
             &out, enc,
         )))
     } else if let Ok(s) = arg.coerce_to_str(vm, globals) {
@@ -686,7 +686,7 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             &mut out,
             &mut enc,
         )?;
-        Ok(Value::string_from_inner(RStringInner::from_encoding(
+        Ok(Value::string_from_inner(RStringInner::from_encoding_scanned(
             &out, enc,
         )))
     } else {
@@ -1623,7 +1623,11 @@ fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         &mut result,
         &mut enc,
     )?;
-    let inner = RStringInner::from_encoding(&result, enc);
+    // Eager-classify so the join's result has its cr cached.
+    // `Encoding::classify` is cheap relative to the byte concat we
+    // just did, and avoids forcing every subsequent code-range
+    // query on the joined string to re-walk the buffer.
+    let inner = RStringInner::from_encoding_scanned(&result, enc);
     Ok(Value::string_from_inner(inner))
 }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5417,17 +5417,14 @@ fn undump(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let self_ = lfp.self_val();
     let s = self_.expect_str(globals)?;
     let bytes = parse_undump(s)?;
-    // The dumped form is always ASCII-compatible. If the resulting
-    // bytes happen to be valid UTF-8, return UTF-8; otherwise return
-    // the bytes tagged as US-ASCII (so encoding survives the round
-    // trip and `valid_encoding?` reports correctly).
-    let enc = if std::str::from_utf8(&bytes).is_ok() {
-        Encoding::Utf8
-    } else {
-        Encoding::Utf8
-    };
-    Ok(Value::string_from_inner(RStringInner::from_encoding(
-        &bytes, enc,
+    // The dumped form is always ASCII-compatible and we tag the
+    // result as UTF-8. `from_encoding_scanned` classifies the
+    // bytes once at construction so subsequent cr queries are
+    // O(1); skipping the eager scan would force every later
+    // operation to re-walk the buffer through `Encoding::classify`.
+    Ok(Value::string_from_inner(RStringInner::from_encoding_scanned(
+        &bytes,
+        Encoding::Utf8,
     )))
 }
 


### PR DESCRIPTION
## Summary
Replace `from_encoding` with `from_encoding_scanned` in string construction to eagerly classify code ranges, improving performance of subsequent code-range queries by caching the result instead of re-walking the buffer on each access.

## Changes
- **string.rs (undump)**: Switched to `from_encoding_scanned` and simplified the encoding logic. The dumped form is always tagged as UTF-8, and eager classification avoids repeated buffer scans during `valid_encoding?` checks.

- **array.rs (mul)**: Updated two string construction sites in the array multiplication operation to use `from_encoding_scanned` for consistent eager classification.

- **array.rs (join)**: Changed to `from_encoding_scanned` with added documentation explaining that eager classification caches the code-range result, avoiding expensive re-walks of the buffer on subsequent queries.

## Implementation Details
The `from_encoding_scanned` method performs an upfront `Encoding::classify` pass on the byte buffer, storing the result so that future code-range (cr) queries are O(1) instead of requiring a full buffer traversal. This is particularly beneficial after concatenation operations where the buffer has just been constructed and will likely be queried multiple times.

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM