### PR TITLE
parser: lower Prism's ImplicitRestNode (`|a,|`) to a dedicated ParamKind

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -6008,4 +6008,99 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn define_method_trailing_comma_arity_is_one() {
+        // CRuby's `|a,|` reports `arity = 1` (not 2) for both proc
+        // and method/lambda forms — the trailing comma is a hint to
+        // the runtime, not a "second required arg".
+        run_test(
+            r#"
+            class C; define_method(:m) { |a,| a }; end
+            C.new.method(:m).arity
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_trailing_comma_parameters() {
+        // `Method#parameters` should report the trailing-comma rest
+        // as absent — only the explicit positionals appear.
+        run_test(
+            r#"
+            class C; define_method(:m) { |a,| a }; end
+            C.new.method(:m).parameters
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_trailing_comma_strict_arity_rejects_extras() {
+        // The method form is strict: passing extras raises
+        // ArgumentError even though the block-form proc would absorb
+        // them.
+        run_test_error(
+            r#"
+            class C; define_method(:m) { |a,| a }; end
+            C.new.m(1, 2)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_trailing_comma_no_destructure() {
+        // `m([1, 2])` returns `[1, 2]` whole — trailing-comma in
+        // method form does NOT auto-splat a single Array argument.
+        run_test(
+            r#"
+            class C; define_method(:m) { |a,| a }; end
+            C.new.m([1, 2])
+            "#,
+        );
+    }
+
+    #[test]
+    fn proc_trailing_comma_block_form_auto_splats() {
+        // The block form: `proc { |a,| a }.call([1, 2])` returns 1
+        // because the trailing comma's "block-style implicit rest"
+        // makes the caller treat a single Array as auto-splat.
+        run_test(
+            r#"
+            proc { |a,| a }.call([1, 2])
+            "#,
+        );
+    }
+
+    #[test]
+    fn proc_trailing_comma_block_form_absorbs_extras() {
+        // Without strict-arity (block form), extras are absorbed.
+        run_test(
+            r#"
+            proc { |a,| a }.call(1, 2, 3)
+            "#,
+        );
+    }
+
+    #[test]
+    fn lambda_trailing_comma_arity_is_one() {
+        // The `lambda` form is method-style strict but reports the
+        // same arity = 1 as proc.
+        run_test(
+            r#"
+            lambda { |a,| a }.arity
+            "#,
+        );
+    }
+
+    #[test]
+    fn explicit_anonymous_rest_arity_negative() {
+        // Sanity: an *explicit* anonymous rest still flips arity to
+        // the negative form (`-2`).
+        run_test(
+            r#"
+            class C; define_method(:m) { |a, *| a }; end
+            C.new.method(:m).arity
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -205,14 +205,19 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
         result.push(entry);
         name_idx += 1;
     }
-    // rest param
+    // rest param — but skip the implicit trailing-comma rest (`|a,|`)
+    // since CRuby's `Method#parameters` reports `[[:req, :a]]`, not
+    // `[[:req, :a], [:rest]]`. The slot still exists internally for
+    // the runtime arg dispatcher to absorb extras under block style.
     if params.is_rest().is_some() {
-        let entry = if let Some(Some(name)) = args_names.get(name_idx) {
-            Value::array2(rest_tag, Value::symbol(*name))
-        } else {
-            Value::array1(rest_tag)
-        };
-        result.push(entry);
+        if !params.rest_is_implicit() {
+            let entry = if let Some(Some(name)) = args_names.get(name_idx) {
+                Value::array2(rest_tag, Value::symbol(*name))
+            } else {
+                Value::array1(rest_tag)
+            };
+            result.push(entry);
+        }
         name_idx += 1;
     }
     // post params (required after rest)

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -299,7 +299,12 @@ fn fill_positional_args(
     let min_args = callee.min_positional_args();
     let max_args = callee.max_positional_args();
     let is_block_style = callee.is_block_style();
-    if !is_block_style && (buf_len < min_args || (buf_len > max_args && !callee.is_rest())) {
+    // For the method-style strict check, an *implicit* (trailing-
+    // comma) rest doesn't accept extras — CRuby's
+    // `define_method(:m) { |a,| }; m(1, 2)` raises ArgumentError.
+    // Only an *explicit* `*rest`/`*` lifts the upper bound.
+    if !is_block_style && (buf_len < min_args || (buf_len > max_args && !callee.is_explicit_rest()))
+    {
         return Err(MonorubyErr::wrong_number_of_arg_range(
             buf_len,
             min_args..=max_args,

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -863,6 +863,7 @@ impl Store {
         let mut optional_num = 0;
         let mut post_num = 0;
         let mut rest = None;
+        let mut rest_is_implicit = false;
         let mut kw_rest_param = None;
         let mut block_param = None;
         let mut for_param_info = vec![];
@@ -897,10 +898,21 @@ impl Store {
                     rest = Some(args_names.len());
                     args_names.push(name.map(IdentId::get_id_from_string));
                 }
+                ParamKind::ImplicitRest => {
+                    // `|a,|` — synthetic anonymous rest emitted for a
+                    // block-param trailing comma. Allocates a slot
+                    // (so block dispatch can use it as a regular rest)
+                    // but flags `rest_is_implicit` so arity / strict
+                    // checks treat it as absent. Semantically it's
+                    // equivalent to `|a, *|` for proc/block but to
+                    // `|a|` for `define_method` / lambda. See
+                    // `ParamsInfo::is_explicit_rest`.
+                    assert_eq!(rest, None);
+                    rest = Some(args_names.len());
+                    rest_is_implicit = true;
+                    args_names.push(None);
+                }
                 ParamKind::Post(name) => {
-                    // Anonymous post (`None`) is emitted for block-trailing
-                    // comma auto-splat (`|k,|`); it bumps the positional
-                    // arity but does NOT allocate a named local.
                     args_names.push(name.map(IdentId::get_id_from_string));
                     post_num += 1;
                 }
@@ -944,6 +956,7 @@ impl Store {
             required_num,
             optional_num,
             rest,
+            rest_is_implicit,
             post_num,
             args_names,
             keyword_names,

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1005,6 +1005,13 @@ impl FuncInfo {
         self.ext.params.is_rest().is_some()
     }
 
+    /// True only when the rest slot is an explicit `*name` / `*`.
+    /// `|a,|` (Prism's `ImplicitRestNode`) returns false here even
+    /// though `is_rest()` is true — see `ParamsInfo::is_explicit_rest`.
+    pub(crate) fn is_explicit_rest(&self) -> bool {
+        self.ext.params.is_explicit_rest().is_some()
+    }
+
     pub(crate) fn rest_pos(&self) -> Option<u16> {
         self.ext.params.is_rest()
     }
@@ -1042,12 +1049,16 @@ impl FuncInfo {
     ///
     /// Calculate Ruby arity for this function.
     ///
-    /// - No optional/rest: arity = required + post
-    /// - Optional or rest: arity = -(required + post + 1)
+    /// - No optional / explicit rest: arity = required + post
+    /// - Optional or explicit rest: arity = -(required + post + 1)
+    ///
+    /// An *implicit* trailing-comma rest (`|a,|`) doesn't shift
+    /// arity to the negative form — CRuby reports `arity = 1` for
+    /// `|a,|` while `|a, *|` reports `-2`, and `|a, *r|` likewise.
     ///
     pub(crate) fn arity(&self) -> i64 {
         let min = self.min_positional_args() as i64;
-        if self.opt_num() > 0 || self.is_rest() {
+        if self.opt_num() > 0 || self.is_explicit_rest() {
             -(min + 1)
         } else {
             min

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -584,6 +584,15 @@ pub(crate) struct ParamsInfo {
     optional_num: usize,
     /// rest
     rest: Option<usize>,
+    /// True when `rest` was introduced by a trailing comma (Prism's
+    /// `ImplicitRestNode`, e.g. `|a,|`) rather than an explicit
+    /// `*name` / `*`. An implicit rest behaves like a normal rest at
+    /// block dispatch (extras absorbed, total positional bumped so
+    /// `single_arg_expand` still triggers single-Array auto-splat),
+    /// but does *not* count toward `arity` / strict-arity checks —
+    /// `define_method(:m) { |a,| }; m.arity` is `1`, `m(1, 2)` raises
+    /// `ArgumentError`, matching CRuby.
+    rest_is_implicit: bool,
     /// post
     post_num: usize,
     // for param, req(incl. destruct slot), opt, rest, keyword, kw_rest, destructed local, block
@@ -599,6 +608,7 @@ impl ParamsInfo {
         required_num: usize,
         optional_num: usize,
         rest: Option<usize>,
+        rest_is_implicit: bool,
         post_num: usize,
         args_names: Vec<Option<IdentId>>,
         keyword_names: Vec<IdentId>,
@@ -610,6 +620,7 @@ impl ParamsInfo {
             required_num,
             optional_num,
             rest,
+            rest_is_implicit,
             post_num,
             args_names,
             kw_names: keyword_names,
@@ -628,6 +639,7 @@ impl ParamsInfo {
             required_num: 1,
             optional_num: 0,
             rest: None,
+            rest_is_implicit: false,
             post_num: 0,
             args_names: vec![],
             kw_names: vec![],
@@ -655,6 +667,7 @@ impl ParamsInfo {
             } else {
                 None
             },
+            rest_is_implicit: false,
             post_num: 0,
             args_names: vec![],
             kw_names,
@@ -699,6 +712,24 @@ impl ParamsInfo {
     ///
     pub fn is_rest(&self) -> Option<u16> {
         self.rest.map(|i| i as u16)
+    }
+
+    /// Like `is_rest`, but only returns the position when `rest` is
+    /// an explicit `*name` / `*`. The trailing-comma `|a,|` form is
+    /// not counted — used by arity reporting and the method-style
+    /// strict-arity check so `|a,|` reports `arity = 1` and rejects
+    /// extras at `define_method` call time, while still letting block
+    /// dispatch absorb extras (via the regular `is_rest` path).
+    pub fn is_explicit_rest(&self) -> Option<u16> {
+        if self.rest_is_implicit {
+            None
+        } else {
+            self.is_rest()
+        }
+    }
+
+    pub fn rest_is_implicit(&self) -> bool {
+        self.rest_is_implicit
     }
 
     #[allow(dead_code)]

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -3043,15 +3043,17 @@ impl<'pr> Lowerer<'pr> {
                     });
                 }
                 prism::Node::ImplicitRestNode { .. } => {
-                    // `|k, v,|` — trailing comma in block params
-                    // forces destructure of a single yielded array
-                    // argument (block-arg auto-splat). ruruby
-                    // models the trailing comma as a single
-                    // anonymous `Post(None)` entry that bumps the
-                    // positional arity but allocates no local; we
-                    // do the same.
+                    // `|a,|` — trailing comma in block params. Acts
+                    // like an anonymous rest *only* under block
+                    // dispatch (extras absorbed, single Array
+                    // auto-splat fires); under method-style dispatch
+                    // (`define_method`) it's invisible — `arity` is
+                    // unchanged and extras raise `ArgumentError`.
+                    // `ParamKind::ImplicitRest` carries that two-faced
+                    // semantic; it lowers to a `rest`-slot in
+                    // `ParamsInfo` with `rest_is_implicit = true`.
                     out.push(ruruby_parse::FormalParam {
-                        kind: ParamKind::Post(None),
+                        kind: ParamKind::ImplicitRest,
                         loc: location_to_loc(&rest.location()),
                     });
                 }

--- a/ruruby-parse/src/node.rs
+++ b/ruruby-parse/src/node.rs
@@ -189,8 +189,12 @@ impl FormalParam {
 
     /// Anonymous post param, used to inject a trailing-comma auto-splat
     /// hint into block / lambda parameter lists. Does not allocate a local.
+    /// Lowers `|a,|`-style trailing commas to `ParamKind::ImplicitRest`
+    /// so the rest-slot only counts toward block-style auto-splat /
+    /// extras absorption, not toward `arity` or method-style strict
+    /// checks.
     pub(crate) fn post_discard(loc: Loc) -> Self {
-        FormalParam::new(ParamKind::Post(None), loc)
+        FormalParam::new(ParamKind::ImplicitRest, loc)
     }
 
     pub(crate) fn keyword(name: String, default: Option<Node>, loc: Loc) -> Self {
@@ -231,6 +235,13 @@ pub enum ParamKind {
     Post(Option<String>),
     Optional(String, Box<Node>), // name, default expr
     Rest(Option<String>),
+    /// Trailing-comma rest (`|a,|`): a Prism `ImplicitRestNode`.
+    /// Acts like an anonymous rest only when the body is invoked
+    /// block-style (proc/yield) — extras are absorbed and a single
+    /// Array argument auto-splats. In method-style (`define_method`)
+    /// it disappears: arity counts the required params alone, and
+    /// passing extras raises `ArgumentError`. Carries no local slot.
+    ImplicitRest,
     Keyword(String, Option<Box<Node>>), // name, default expr
     KWRest(Option<String>),
     Block(Option<String>),


### PR DESCRIPTION
## Summary

Lower Prism's `ImplicitRestNode` (`|a,|`) to a dedicated `ParamKind::ImplicitRest` and a `ParamsInfo::rest_is_implicit` flag, so the trailing-comma rest behaves as CRuby specifies: `arity = 1`, `Method#parameters == [[:req, :a]]`, block-form auto-splats single-Array, method-form rejects extras with `ArgumentError`.

Cuts 4 failures from `core/module` ruby/spec (172 → 168).

## The bug

Prism produces `requireds: [a], rest: ImplicitRestNode, posts: []` for `|a,|`. monoruby was lowering `ImplicitRestNode` to `ParamKind::Post(None)`, which bumped the arity to 2 and made:

```ruby
class C; define_method(:m) { |a,| a }; end
C.new.m(1)
# => ArgumentError: wrong number of arguments (given 1, expected 2)  ← bug
```

CRuby reports `arity = 1` and accepts a single argument. The trailing comma is a hint to the runtime (absorb extras under block-style; auto-splat single Array) that should NOT inflate the arity / `Method#parameters` view.

## Why simple alternatives don't work

| Lowering           | arity (want 1) | `m([1,2])` for method (want `[1,2]`) | `m(1,2)` for method (want ArgErr) |
|--------------------|:-:|:-:|:-:|
| `Post(None)` (current) | 2 ✗ | `[1,2]` ✓ | `expected 2` ✗ |
| `Rest(None)` (anonymous)| -2 ✗ | `1` (auto-splat) ✗ | absorbs ✗ |
| `Req` only (drop)       | 1 ✓ | `[1,2]` ✓ | ArgErr ✓ but proc-form `m(1,2)` errors too ✗ |

## Solution: a 3-state rest representation

`ParamsInfo::rest: Option<usize>` now has a parallel `rest_is_implicit: bool` flag:
- **No rest**: `rest = None`
- **Explicit rest** (`*name` / `*`): `rest = Some(pos)`, `rest_is_implicit = false`
- **Implicit rest** (`|a,|`): `rest = Some(pos)`, `rest_is_implicit = true`

Two new accessors split the consumers:
- `is_rest()` — true for both forms; used by **block dispatch** to absorb extras and by `single_arg_expand` for auto-splat.
- `is_explicit_rest()` — true only for the explicit form; used by **arity** computation and the **method-style strict-arity** check.

## Changes

| File | Change |
|---|---|
| `ruruby-parse/src/node.rs` | Add `ParamKind::ImplicitRest`. `FormalParam::post_discard` lowers to it. |
| `monoruby/src/parser/prism_backend.rs` | Map Prism's `ImplicitRestNode` (block-param) to `ParamKind::ImplicitRest`. |
| `monoruby/src/globals/store/iseq.rs` | Add `rest_is_implicit` field + `is_explicit_rest()` / `rest_is_implicit()` accessors on `ParamsInfo`. |
| `monoruby/src/globals/store.rs` | Handle `ParamKind::ImplicitRest` in `handle_args` (rest slot, anonymous, flag). |
| `monoruby/src/globals/store/function.rs` | `arity()` uses `is_explicit_rest`; new `is_explicit_rest()` shortcut on `FuncInfo`. |
| `monoruby/src/codegen/runtime/args.rs` | Method-style strict-arity check uses `is_explicit_rest()`. |
| `monoruby/src/builtins/proc.rs` | `Method#parameters` / `Proc#parameters` skip the implicit rest. |

## Behaviour after the fix (matches CRuby)

```
|a,|   arity=1, params=[[:req, :a]]
|a, *| arity=-2, params=[[:req, :a], [:rest]]
|a|    arity=1, params=[[:req, :a]]

define_method(:m) { |a,| a }; m(1)       → 1
define_method(:m) { |a,| a }; m([1, 2])  → [1, 2]   (no destructure)
define_method(:m) { |a,| a }; m(1, 2)    → ArgumentError (strict)
proc { |a,| a }.call([1, 2])             → 1        (auto-splat)
proc { |a,| a }.call(1, 2)               → 1        (extras absorbed)
```

## Verification

- `cargo test --release --lib 'builtins::module'` — **171/171 pass** (was 163, +8 new tests covering arity/parameters/strict/auto-splat for proc, lambda, and `define_method` forms).
- `cargo test --release --lib` — 1752/1754 (the 2 failures are pre-existing inspect format issues unrelated to this change).
- `cargo test --release --test method_call --test class_chain --test require --test enumerable --test variables --test yield` — all pass (98/98).
- `core/module` ruby/spec: **172 → 168 (4 fewer failures)** — the 3 specific `Module#define_method passed { |a,| }` tests + 1 ripple — no regressions.

## Test plan

- [x] `cargo test --release --lib`
- [x] Run integration tests
- [x] Run `core/module` ruby/spec
- [x] Manual smoke tests for proc/lambda/define_method `|a,|` semantics

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_