### PR TITLE
prism: lower ImplicitNode for Ruby 3.1+ shorthand keyword args

### DIFF
--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1174,6 +1174,10 @@ impl<'pr> Lowerer<'pr> {
                     loc,
                 }
             }
+            prism::Node::ImplicitNode { .. } => {
+                let implicit = node.as_implicit_node().unwrap();
+                return self.lower_node(&implicit.value());
+            }
             other => return Err(self.unsupported("expression", other)),
         })
     }
@@ -3566,6 +3570,7 @@ fn node_kind_name(node: &prism::Node<'_>) -> &'static str {
         ItLocalVariableReadNode { .. } => "ItLocalVariableReadNode",
         ItParametersNode { .. } => "ItParametersNode",
         NumberedParametersNode { .. } => "NumberedParametersNode",
+        ImplicitNode { .. } => "ImplicitNode",
         ImplicitRestNode { .. } => "ImplicitRestNode",
         FlipFlopNode { .. } => "FlipFlopNode",
         SourceFileNode { .. } => "SourceFileNode",

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -279,6 +279,66 @@ fn keyword_rest() {
     run_test_error("def f(**a, **b); end");
 }
 
+// Ruby 3.1+ shorthand keyword argument syntax: `foo(handled:)` is
+// equivalent to `foo(handled: handled)`. Prism wraps the implicit value
+// in an `ImplicitNode` that the lowerer must unwrap.
+#[test]
+fn keyword_shorthand() {
+    run_test_with_prelude(
+        r#"
+        handled = 42
+        f(handled:)
+        "#,
+        r#"
+        def f(handled:)
+          handled
+        end
+        "#,
+    );
+    run_test_with_prelude(
+        r#"
+        a = 1
+        b = 2
+        f(a:, b:)
+        "#,
+        r#"
+        def f(a:, b:)
+          [a, b]
+        end
+        "#,
+    );
+    run_test_with_prelude(
+        r#"
+        x = 10
+        z = 30
+        f(1, x:, y: 20, z:)
+        "#,
+        r#"
+        def f(p, x:, y:, z:)
+          [p, x, y, z]
+        end
+        "#,
+    );
+    // Shorthand referencing a method, not a local variable.
+    run_test_with_prelude(
+        r#"
+        f(name:)
+        "#,
+        r#"
+        def name; "ruby"; end
+        def f(name:); name; end
+        "#,
+    );
+    // Hash literal: `{x:, y:}` desugars to `{x: x, y: y}`.
+    run_test(
+        r#"
+        x = "hello"
+        y = 99
+        {x:, y:}
+        "#,
+    );
+}
+
 #[test]
 fn keyword_to_hash() {
     run_test_with_prelude(


### PR DESCRIPTION
## Summary
- Ruby 3.1 introduced shorthand keyword argument syntax: `foo(handled:)` is equivalent to `foo(handled: handled)`.
- Prism wraps the implicit value in an `ImplicitNode`. Lower it by delegating to the wrapped value.
- Adds the variant to `node_kind_name` so any further unsupported uses produce a descriptive error.

## Test plan
- [x] `cargo test`
- [x] Confirm a snippet using shorthand keyword args (e.g. `def foo(handled:); foo(handled:); end`) parses.