### PR TITLE
Regexp#match: return false for nil instead of raising TypeError

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -461,7 +461,11 @@ fn options(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resul
 fn match_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let regex = self_.is_regex().unwrap();
-    let given = lfp.arg(0).expect_symbol_or_string(globals)?.to_string();
+    let arg0 = lfp.arg(0);
+    if arg0.is_nil() {
+        return Ok(Value::bool(false));
+    }
+    let given = arg0.expect_symbol_or_string(globals)?.to_string();
     let char_pos = if let Some(pos) = lfp.try_arg(1) {
         match conv_index(pos.coerce_to_int_i64(vm, globals)?, given.chars().count()) {
             Some(pos) => pos,

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -992,6 +992,13 @@ mod tests {
     }
 
     #[test]
+    fn match_nil() {
+        run_test(r#"/foo/.match?(nil)"#);
+        run_test(r#"/foo/.match?(nil, 0)"#);
+        run_test(r#"//.match?(nil)"#);
+    }
+
+    #[test]
     fn r#match() {
         run_test(r##"/(.).(.)/.match("foobar", 3).captures"##);
         run_test(r##"/(.).(.)/.match("foobar", -3).captures"##);


### PR DESCRIPTION
## Summary
- CRuby returns `false` when `nil` is passed to `Regexp#match?`/`#match`. monoruby was coercing `nil` and raising `TypeError`.
- Add an explicit `nil` check before the coercion so the method returns `false` early.

## Test plan
- [ ] `cargo test`
- [ ] Smoke test: `/foo/.match?(nil) == false` (matches CRuby).