### PR TITLE
core/module: isolate Kernel#eval's cref so module_function/private don't leak

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1281,7 +1281,14 @@ fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     } else {
         let fid = globals.compile_script_eval(expr, fname, caller_cfp, None, lineno)?;
         let proc = ProcData::new(caller_cfp.lfp(), fid);
-        vm.invoke_block(globals, &proc, &[])
+        // Isolate the eval's cref so toggles like `module_function`,
+        // `private`, … set inside the eval'd source don't leak to
+        // the surrounding class/module body. Mirrors CRuby's
+        // `rb_vm_cref_dup_without_refinements`.
+        let pushed = vm.push_eval_cref();
+        let res = vm.invoke_block(globals, &proc, &[]);
+        vm.pop_eval_cref(pushed);
+        res
     }
 }
 

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -6376,4 +6376,59 @@ mod tests {
             "#,
         );
     }
+
+    // -- module_function eval-boundary isolation --------------------------
+
+    #[test]
+    fn module_function_inside_eval_does_not_leak_outside() {
+        // CRuby: `eval "module_function"` mutates the eval's *own*
+        // cref copy, so `def test1` outside the eval is a regular
+        // instance method (not a module function). Without the
+        // cref-dup before `Kernel#eval`'s block invocation, the
+        // toggle would leak through to the surrounding module body.
+        run_test(
+            r#"
+            m = Module.new do
+              eval "module_function"
+              def test1; end
+            end
+            m.respond_to?(:test1)
+            "#,
+        );
+    }
+
+    #[test]
+    fn module_function_inside_eval_works_for_local_defs() {
+        // Counterpart to the boundary test: when `module_function`
+        // *and* the `def`s live inside the same eval, the toggle
+        // does apply (as expected).
+        run_test(
+            r##"
+            m = Module.new do
+              eval <<-CODE
+                module_function
+                def test1; end
+                def test2; end
+              CODE
+            end
+            [m.respond_to?(:test1), m.respond_to?(:test2)]
+            "##,
+        );
+    }
+
+    #[test]
+    fn private_inside_eval_does_not_leak_outside() {
+        // Same isolation rule applies to `private` (no args). A
+        // `private` toggled inside an eval must not turn the outer
+        // module body's subsequent `def` into a private method.
+        run_test(
+            r#"
+            c = Class.new do
+              eval "private"
+              def public_after_eval; :ok; end
+            end
+            c.public_method_defined?(:public_after_eval)
+            "#,
+        );
+    }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -501,6 +501,37 @@ impl Executor {
             .push(Cref::new_instance_eval(receiver, Visibility::Public));
     }
 
+    /// Push a duplicate of the current top cref. Used by `Kernel#eval`
+    /// (no-binding form) so that flag mutations inside the eval'd
+    /// code (`module_function`, `private`, …) stay scoped to the
+    /// eval body and don't leak to the surrounding module/class.
+    /// CRuby's `rb_vm_cref_dup_without_refinements` does the same.
+    /// Returns `true` when a cref was actually pushed; the matching
+    /// `pop_eval_cref(true)` then balances it. At the top level —
+    /// where `lexical_class.last()` is an empty frame — there's no
+    /// cref to dup so we return `false` and the pop is a no-op.
+    pub(crate) fn push_eval_cref(&mut self) -> bool {
+        if let Some(crefs) = self.lexical_class.last_mut()
+            && let Some(top) = crefs.last().copied()
+        {
+            crefs.push(top);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Pop the cref pushed by `push_eval_cref`. Pass through the
+    /// boolean returned by the matching push so a top-level eval
+    /// (no top cref to dup) skips the pop too.
+    pub(crate) fn pop_eval_cref(&mut self, was_pushed: bool) {
+        if was_pushed
+            && let Some(crefs) = self.lexical_class.last_mut()
+        {
+            crefs.pop();
+        }
+    }
+
     pub(crate) fn pop_class_context(&mut self) {
         self.lexical_class.last_mut().unwrap().pop();
     }


### PR DESCRIPTION
## Summary

Isolate `Kernel#eval`'s cref so toggles (`module_function`, `private`, …) set inside the eval'd source don't leak to the surrounding class/module body. Mirrors CRuby's `rb_vm_cref_dup_without_refinements`.

Cuts 4 failures from `core/module` ruby/spec (153 → 149); the direct `module_function_spec.rb` failure list goes from 1 → 0.

## The bug

```ruby
m = Module.new do
  eval "module_function"   # CRuby: scoped to the eval; monoruby: leaks
  def test1; end           # CRuby: regular method; monoruby: module function
end

m.respond_to?(:test1)
# CRuby:    false ✓
# monoruby: true  ✗ (before this PR)
```

monoruby's `Kernel#eval` (no-binding branch) invoked the eval'd proc against the caller's existing `lexical_class` stack. `module_function`'s `set_module_function` modifies `lexical_class.last().last()` — which was the *outer* module body's cref, since `eval` made no private copy. `def test1` running afterward saw the toggle as on.

CRuby's `rb_vm_cref_dup_without_refinements` duplicates the cref for the eval body so flag mutations stay scoped.

## Changes

- **`Executor::push_eval_cref` / `pop_eval_cref`** *(new)*: duplicate-and-push the current top cref onto the active require/load frame, balanced by a paired pop. The push returns a `bool` so the matching pop can no-op for a top-level `eval` (no cref to dup).
- **`Kernel#eval`** (no-binding branch): wrap the `invoke_block` call with `push_eval_cref` / `pop_eval_cref`. Toggles set inside the eval are confined to the duplicated cref.

The binding form (`eval(expr, binding)`) is unaffected — bindings already carry their own captured cref, so isolation is moot.

## Verification

- `cargo test --release --lib 'builtins::module'` — **185/185 pass** (was 182, +3 new tests)
- `cargo test --release --lib` — 1782/1784 pass (the 2 pre-existing inspect-format failures are unrelated and present on master)
- Integration tests: `method_call` (64), `class_chain` (2), `require` (12), `enumerable` (4), `variables` (13), `yield` (4) — all pass
- `core/kernel/eval_spec.rb` — same dot pattern as master (no new regressions; pre-existing `BEGIN { ... }` parser crash unrelated)
- `core/module` ruby/spec: **153 → 149 failures+errors** (-4)

## Test plan

- [x] `cargo test --release --lib 'builtins::module'`
- [x] `cargo test --release --test {method_call,class_chain,require,enumerable,variables,yield}`
- [x] Run `core/module/module_function_spec.rb`
- [x] Run full `core/module` ruby/spec
- [x] Manual smoke test for `eval "module_function"` boundary, `eval "private"` boundary, and the in-eval `module_function` + in-eval `def` counterpart

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_