### PR TITLE
core/encoding: render Encoding::* subclass names with their qualified path

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -206,30 +206,38 @@ pub(super) fn init_encoding(globals: &mut Globals) {
         globals.set_constant_by_str(enc.id(), "CP65001", utf8);
     }
 
-    // Encoding::CompatibilityError < EncodingError < StandardError
+    // Encoding::CompatibilityError < EncodingError < StandardError.
+    // The fourth `define_class` argument is the *lexical parent* —
+    // pass `enc.id()` so `Module#name` walks back through `Encoding`
+    // and renders `"Encoding::CompatibilityError"`. (Passing
+    // `OBJECT_CLASS` would still register the class as the
+    // `Encoding::CompatibilityError` *constant*, but its `parent`
+    // field would point at `Object`, and `set_constant` only
+    // re-parents anonymous / non-permanent classes — so the bare
+    // leaf `"CompatibilityError"` would leak through.)
     let enc_error_val = globals
         .store
         .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("EncodingError"))
         .unwrap();
     let enc_error_module = enc_error_val.expect_class(globals).unwrap();
-    let compat_error = globals.define_class("CompatibilityError", enc_error_module, OBJECT_CLASS);
+    let compat_error = globals.define_class("CompatibilityError", enc_error_module, enc.id());
     globals.set_constant_by_str(enc.id(), "CompatibilityError", compat_error.get());
     // Encoding::ConverterNotFoundError < EncodingError. Stubbed so
     // specs that reference the constant (e.g.
     // `String#encode` expectations) don't fail with NameError before
     // we get to the actual encode behaviour.
     let conv_not_found =
-        globals.define_class("ConverterNotFoundError", enc_error_module, OBJECT_CLASS);
+        globals.define_class("ConverterNotFoundError", enc_error_module, enc.id());
     globals.set_constant_by_str(enc.id(), "ConverterNotFoundError", conv_not_found.get());
     // Encoding::UndefinedConversionError < EncodingError. Same
     // motivation — referenced by `String#encode` specs.
     let undef_conv =
-        globals.define_class("UndefinedConversionError", enc_error_module, OBJECT_CLASS);
+        globals.define_class("UndefinedConversionError", enc_error_module, enc.id());
     globals.set_constant_by_str(enc.id(), "UndefinedConversionError", undef_conv.get());
     // Encoding::InvalidByteSequenceError < EncodingError. Same
     // motivation.
     let invalid_byte =
-        globals.define_class("InvalidByteSequenceError", enc_error_module, OBJECT_CLASS);
+        globals.define_class("InvalidByteSequenceError", enc_error_module, enc.id());
     globals.set_constant_by_str(enc.id(), "InvalidByteSequenceError", invalid_byte.get());
 
     // Encoding class methods
@@ -242,7 +250,14 @@ pub(super) fn init_encoding(globals: &mut Globals) {
     // dst)` validates that monoruby can transcode the pair (mostly
     // used in spec setup expectations). The runtime `convert` /
     // `primitive_convert` API is not exposed yet.
-    let converter = globals.define_class("Converter", None, OBJECT_CLASS);
+    // Inherit from `Object` explicitly so `Encoding::Converter#class`
+    // and the Kernel methods inherited via Object (`is_a?`,
+    // `inspect`, …) work on Converter instances. Passing `None`
+    // produces a class with no superclass, which monoruby renders
+    // as an empty string for `Converter.superclass` (CRuby shows
+    // `Object`).
+    let object_class = globals.store.object_class();
+    let converter = globals.define_class("Converter", object_class, enc.id());
     globals.set_constant_by_str(enc.id(), "Converter", converter.get());
     globals.define_builtin_class_func(converter.id(), "new", converter_new, 2);
     globals.define_builtin_class_func(enc.id(), "list", enc_list, 0);

--- a/monoruby/src/builtins/encoding_tests.rs
+++ b/monoruby/src/builtins/encoding_tests.rs
@@ -233,36 +233,19 @@ mod tests {
 
     #[test]
     fn encode_unknown_encoding_raises_converter_not_found() {
-        // Catch by class so the assertion doesn't depend on the
-        // namespace-qualification of `e.class.name` — monoruby's
-        // `Module#name` for classes opened inside `class Encoding ...
-        // end` (in `startup.rb`) sometimes returns the bare leaf
-        // string (`"ConverterNotFoundError"`) rather than the
-        // fully-qualified form (`"Encoding::ConverterNotFoundError"`),
-        // depending on parent-chain bookkeeping. The `is-a` check
-        // (CRuby and monoruby both implement it via the class
-        // hierarchy, not the name string) is stable regardless.
-        run_test_no_result_check(
-            r#"
-              begin
-                "abc".encode("xyz")
-                raise "expected ConverterNotFoundError"
-              rescue Encoding::ConverterNotFoundError
-                # ok
-              end
-            "#,
+        run_test(
+            r#"begin; "abc".encode("xyz"); rescue => e; e.class.name; end"#,
         );
     }
 
     #[test]
     fn encode_unmappable_to_us_ascii_raises_undefined_conversion() {
-        run_test_no_result_check(
+        run_test(
             r#"
               begin
                 "\xE3\x81\x82".force_encoding("UTF-8").encode("US-ASCII")
-                raise "expected UndefinedConversionError"
-              rescue Encoding::UndefinedConversionError
-                # ok
+              rescue => e
+                e.class.name
               end
             "#,
         );
@@ -271,13 +254,48 @@ mod tests {
     #[test]
     fn encode_unmappable_to_iso8859_1_raises_undefined_conversion() {
         // U+3042 (HIRAGANA A) isn't representable in Latin-1.
-        run_test_no_result_check(
+        run_test(
             r#"
               begin
                 "\xE3\x81\x82".force_encoding("UTF-8").encode("ISO-8859-1")
-                raise "expected UndefinedConversionError"
-              rescue Encoding::UndefinedConversionError
-                # ok
+              rescue => e
+                e.class.name
+              end
+            "#,
+        );
+    }
+
+    #[test]
+    fn encoding_subclass_names_are_qualified() {
+        // Regression test for a `Module#name` bug where the five
+        // `Encoding::*` classes registered by `init_encoding` in
+        // Rust rendered as bare leaf strings
+        // (`"CompatibilityError"` instead of
+        // `"Encoding::CompatibilityError"`).
+        //
+        // The Rust call sites passed `OBJECT_CLASS` as the
+        // lexical-parent argument to `define_class`, so the class
+        // had `parent = Object`. `set_constant`'s re-parenting
+        // logic only fires for anonymous / non-permanent targets
+        // (it deliberately doesn't touch already-named classes —
+        // CRuby's `M::X = Foo` doesn't rename `Foo`), so the
+        // qualified path never got reattached after the
+        // `set_constant_by_str(enc.id(), …)` call. Pass `enc.id()`
+        // as the parent and `Module#name` walks back to `Encoding`
+        // correctly.
+        run_test(r#"Encoding::CompatibilityError.name"#);
+        run_test(r#"Encoding::ConverterNotFoundError.name"#);
+        run_test(r#"Encoding::UndefinedConversionError.name"#);
+        run_test(r#"Encoding::InvalidByteSequenceError.name"#);
+        run_test(r#"Encoding::Converter.name"#);
+        // The end-to-end `rescue => e; e.class.name` path that
+        // PR #443's CI run flagged as failing.
+        run_test(
+            r#"
+              begin
+                "\xE3\x81\x82".force_encoding("UTF-8").encode("ISO-8859-1")
+              rescue Encoding::UndefinedConversionError => e
+                e.class.name
               end
             "#,
         );


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where `Module#name` for the
Rust-registered `Encoding::*` subclasses returned bare leaf
strings:

```ruby
# Before
Encoding::CompatibilityError.name
# => "CompatibilityError"          # ✗ should include `Encoding::`
Encoding::UndefinedConversionError.name
# => "UndefinedConversionError"    # ✗
Encoding::Converter.superclass
# => nil                           # ✗ should be Object

# After
Encoding::CompatibilityError.name
# => "Encoding::CompatibilityError"
Encoding::Converter.superclass
# => Object
```

Surfaced by PR #443's new encoding tests, which the merge
worked around by catching `rescue ClassName` instead of
comparing `e.class.name`. This PR fixes the underlying issue
and reverts the workaround.

## Root cause

The Rust call sites in `init_encoding` looked like:

```rust
let compat_error = globals.define_class(
    "CompatibilityError", enc_error_module, OBJECT_CLASS);
globals.set_constant_by_str(
    enc.id(), "CompatibilityError", compat_error.get());
```

The fourth `define_class` argument is the *lexical parent* —
the field `Module#name` walks back through to assemble the
qualified path. We passed `OBJECT_CLASS`, so
`generate_class_obj` set `parent = Object`. The
`set_constant_by_str(enc.id(), …)` that followed correctly
registered the value as the `Encoding::CompatibilityError`
constant, but `set_constant`'s re-parenting clause only fires
for anonymous / non-permanent targets:

```rust
if target_was_anon { /* set_parent */ }
else if target_was_non_permanent && parent_permanent { /* set_parent */ }
```

`CompatibilityError` already had a permanent name (because the
Rust-side parent `Object` is itself permanent), so **neither
arm ran**. The class kept `parent = Object`, and `get_parents`
walked from `CompatibilityError` straight to `OBJECT_CLASS` —
the `Encoding` link was never traversed.

## Fix

Pass `enc.id()` (the `Encoding` class id) as the lexical parent
in every `define_class` call inside `init_encoding`. The new
class's `parent` field is then set correctly the first time
through `generate_class_obj`, no re-parenting required.

While there, give `Encoding::Converter` an explicit `Object`
superclass — the previous `define_class("Converter", None, …)`
produced a class with no superclass, so `Converter.superclass`
rendered as `nil` in monoruby (CRuby shows `Object`).

## Tests

- New regression test `encoding_subclass_names_are_qualified`
  covers all five classes plus the end-to-end `rescue => e;
  e.class.name` path.
- The three tests that PR #443 had switched to `rescue
  ClassName` are restored to the direct `e.class.name`
  comparison they were originally written as.

```
$ cargo test -p monoruby --lib
1818 pass / 2 pre-existing fails (unrelated)

$ cargo nextest run --features stress-spill-pool --features gc-stress \
    -p monoruby --lib builtins::encoding_tests
33 passed

$ MONORUBY_PARSER=ruruby cargo nextest run \
    --features stress-spill-pool --features gc-stress \
    -p monoruby --lib builtins::encoding_tests
33 passed

$ mspec run core/string/encode -t monoruby
38 failures / 65 errors (unchanged from master)
```

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_