### PR TITLE
Implement Binding#eval

### DIFF
--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -10,6 +10,16 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(BINDING_CLASS, "local_variables", local_variables, 0);
     globals.define_builtin_func(BINDING_CLASS, "source_location", source_location, 0);
     globals.define_builtin_func(BINDING_CLASS, "receiver", receiver, 0);
+    globals.define_builtin_funcs_with_effect(
+        BINDING_CLASS,
+        "eval",
+        &[],
+        eval,
+        1,
+        3,
+        false,
+        Effect::EVAL,
+    );
 }
 
 ///
@@ -62,6 +72,42 @@ fn source_location(
     let file_name = Value::string(iseq.sourceinfo.short_file_name().to_string());
     let line = Value::integer(iseq.sourceinfo.get_line(&iseq.loc) as i64);
     Ok(Value::array2(file_name, line))
+}
+
+///
+/// ### Binding#eval
+///
+/// - eval(expr, fname = "(eval)", lineno = 1) -> object
+///
+/// Evaluates `expr` in the binding's lexical context. Equivalent to
+/// `Kernel#eval(expr, self)` but without the binding-typecheck (and
+/// with the call-site location as the default `fname`, matching
+/// CRuby).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Binding/i/eval.html]
+#[monoruby_builtin]
+fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let expr = lfp.arg(0).coerce_to_string(vm, globals)?;
+    let cfp = vm.cfp();
+    let caller_cfp = cfp.prev().unwrap();
+    let fname = if let Some(f) = lfp.try_arg(1) {
+        f.coerce_to_str(vm, globals)?
+    } else {
+        let caller_loc = globals.store.get_caller_loc(caller_cfp, Some(pc));
+        format!("(eval at {})", caller_loc)
+    };
+    let lineno: i64 = if let Some(l) = lfp.try_arg(2) {
+        l.coerce_to_int_i64(vm, globals)?
+    } else {
+        1
+    };
+    // The receiver IS the binding — wrap it through `Binding::try_new`
+    // so the rest of the path is identical to `Kernel#eval`'s
+    // binding-form. The cast can't fail; `Module#define_builtin_func`
+    // guarantees `lfp.self_val()` matches `BINDING_CLASS`.
+    let binding = Binding::try_new(lfp.self_val()).expect("self is Binding");
+    globals.compile_script_binding(expr, fname, binding, lineno)?;
+    vm.invoke_binding(globals, binding.binding().unwrap())
 }
 
 #[monoruby_builtin]
@@ -230,6 +276,91 @@ mod tests {
         end
         b.source_location[1] == line
         "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_basic() {
+        // `Binding#eval(expr)` returns the expression's value, like
+        // `Kernel#eval(expr, self)` but with the binding-typecheck
+        // already satisfied.
+        run_test(
+            r#"
+            b = binding
+            b.eval("1 + 1")
+            "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_captures_locals() {
+        // Locals captured at the binding-creation site are visible.
+        run_test(
+            r#"
+            def get_binding
+              x = 100
+              binding
+            end
+            get_binding.eval("x + 1")
+            "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_mutates_outer_local() {
+        // Assignments inside the eval write through to the outer
+        // local that the binding captured.
+        run_test(
+            r#"
+            x = 1
+            binding.eval("x = 42")
+            x
+            "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_introduces_new_local() {
+        // A `=` in the eval that targets a name not present in the
+        // captured locals introduces it for subsequent evals on the
+        // same binding (eval-only scope, doesn't leak to the
+        // surrounding method).
+        run_test(
+            r#"
+            b = binding
+            b.eval("y = 7")
+            b.eval("y * 2")
+            "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_uses_explicit_filename_and_lineno() {
+        // The optional `fname` / `lineno` args drive the backtrace
+        // location so external tooling can attribute the error to
+        // the source string's origin. We compare only the
+        // `file:line:` prefix because monoruby and CRuby format the
+        // trailing label differently (`/main` vs `<main>`) — a
+        // pre-existing labelling quirk unrelated to Binding#eval.
+        run_test(
+            r#"
+            b = binding
+            begin
+              b.eval("missing_method", "myfile.rb", 42)
+            rescue NameError => e
+              e.backtrace.first[/\Amyfile\.rb:42:/]
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn binding_eval_method_arity_error() {
+        // Calling without args matches CRuby's arity range message.
+        run_test_error(
+            r#"
+            binding.eval
+            "#,
         );
     }
 }


### PR DESCRIPTION
## Summary

`Binding#eval(expr [, fname [, lineno]])` was missing from monoruby — calling it raised `NoMethodError: undefined method 'eval' for #<Binding>`. Wires the method to the existing `compile_script_binding` → `invoke_binding` flow that `Kernel#eval(expr, self)` already uses.

Cuts 1 failure from `core/module` ruby/spec (149 → 148), plus unblocks any user code that has been pinging the missing method.

## The gap

The internals to evaluate a string in a captured binding were already in place — `Kernel#eval(expr, binding)` works fine. But the equivalent method form on Binding itself was never registered, so:

```ruby
b = binding
b.eval("1 + 1")
# CRuby:    => 2
# monoruby: NoMethodError: undefined method 'eval' for #<Binding>  (before this PR)
```

## Implementation

`monoruby/src/builtins/binding.rs`:

- Register `eval` on `BINDING_CLASS` with arity `1..3` and `Effect::EVAL` (so the JIT side-effect inference treats it conservatively).
- The body coerces `expr` to a String, derives a default `fname` (`"(eval at file:line)"`) from the caller's PC via `Store::get_caller_loc` (matching CRuby's wording), reads `lineno` from `lfp.try_arg(2)`, then plugs the receiver into `Binding::try_new(lfp.self_val())` and dispatches through `compile_script_binding` + `invoke_binding`.
- The cast `Binding::try_new(lfp.self_val())` is `expect`'d to succeed because `define_builtin_func` guarantees the receiver matches `BINDING_CLASS`.

## Behaviour verified against CRuby 4.0.2

| Call | CRuby & monoruby |
|---|---|
| `binding.eval("1 + 1")` | `2` |
| `def gb; x = 100; binding; end; gb.eval("x + 1")` | `101` |
| `x = 1; binding.eval("x = 42"); x` | `42` |
| `binding.eval("missing", "f.rb", 42)` | `NameError` at `f.rb:42:in '<...>'` |
| `binding.eval` | `ArgumentError: wrong number of arguments (given 0, expected 1..3)` |
| `binding.eval(123)` | `TypeError: no implicit conversion of Integer into String` |

## Tests

6 new unit tests (`builtins::binding::tests::binding_eval_method_*`):

- `binding_eval_method_basic`
- `binding_eval_method_captures_locals`
- `binding_eval_method_mutates_outer_local`
- `binding_eval_method_introduces_new_local`
- `binding_eval_method_uses_explicit_filename_and_lineno`
- `binding_eval_method_arity_error`

The `fname/lineno` test asserts only the `file:line:` prefix because monoruby and CRuby format the trailing label differently (`/main` vs `<main>`) — a pre-existing labelling quirk unrelated to this change.

## Verification

- `cargo test --release --lib 'builtins::binding'` — **13/13 pass** (was 7, +6 new)
- `cargo test --release --lib 'builtins::module'` — 185/185 pass
- `cargo test --release --lib 'builtins::kernel'` — 78/78 pass
- `core/module` ruby/spec: **149 → 148** (the autoload spec that uses `TOPLEVEL_BINDING.eval("self")` now reaches its mock-require step instead of erroring on the missing method)
- `core/binding/*_spec.rb` files crash at fixture-load time on `refine` (pre-existing, present on master) — not affected here

## Test plan

- [x] `cargo test --release --lib 'builtins::binding'`
- [x] Manual smoke against CRuby for each behaviour case above
- [x] `core/module` ruby/spec full run

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_