### PR TITLE
core/module: fix Module#prepend chain ordering, dup, super, and propagation

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1533,6 +1533,13 @@ fn define_method(
     }
     let class_id = self_val.as_class_id();
     let name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    // For proc-based define_method, the runtime LFP has the *block*'s
+    // FuncId (the wrapper jumps directly to the block code, only
+    // tagging the meta with `PROC_METHOD_MASK`). For `super` to work
+    // we need that block FuncId itself to (a) have a `name` we can
+    // look up and (b) have its owner_class registered so
+    // `check_super`'s walk recognises the method's home class.
+    let block_fid_to_decorate: Option<FuncId>;
     let func_id = if let Some(method) = lfp.try_arg(1) {
         if let Some(proc) = method.is_proc() {
             let fid = globals.define_proc_method(proc);
@@ -1540,12 +1547,16 @@ fn define_method(
             // (no destructuring of a single Array argument, ArgumentError
             // on count mismatch), unlike the underlying Proc.
             globals.store[fid].set_method_style();
+            globals.store[fid].set_name(name);
+            block_fid_to_decorate = Some(proc.func_id());
             fid
         } else if let Some(method) = method.is_method() {
             validate_bind_target(globals, method.owner(), class_id)?;
+            block_fid_to_decorate = None;
             method.func_id()
         } else if let Some(umethod) = method.is_umethod() {
             validate_bind_target(globals, umethod.owner(), class_id)?;
+            block_fid_to_decorate = None;
             umethod.func_id()
         } else {
             return Err(MonorubyErr::wrong_argument_type(
@@ -1558,6 +1569,8 @@ fn define_method(
         let proc = vm.generate_proc(globals, bh, pc)?;
         let fid = globals.define_proc_method(proc);
         globals.store[fid].set_method_style();
+        globals.store[fid].set_name(name);
+        block_fid_to_decorate = Some(proc.func_id());
         fid
     } else {
         return Err(MonorubyErr::wrong_number_of_arg(2, 1));
@@ -1575,6 +1588,33 @@ fn define_method(
         vm.add_singleton_method(globals, class_id, name, func_id, Visibility::Public)?;
     } else {
         vm.add_method(globals, class_id, name, func_id, visibility)?;
+    }
+    // For proc-based define_method: also decorate the block iseq's
+    // FuncInfo with the installed name and owner so `find_super`
+    // (which looks at the runtime LFP's block FuncId, not the
+    // proc-method wrapper FuncId) can resolve correctly.
+    if let Some(block_fid) = block_fid_to_decorate {
+        if globals.store[block_fid].name().is_none() {
+            globals.store[block_fid].set_name(name);
+        }
+        // `set_owner_class` appends — but only push when this owner
+        // isn't already recorded, to avoid an unbounded grow on
+        // repeated re-registration of the same proc under the same
+        // class (e.g. `define_method` inside a hot loop).
+        if !globals.store[block_fid]
+            .owner_class()
+            .contains(&class_id)
+        {
+            globals.store[block_fid].set_owner_class(class_id);
+        }
+        // Tag the block's static Meta with the proc-method bit.
+        // The dynamic OR in `gen_wrapper` only fires for the
+        // unspecialised dispatch path; JIT-specialised calls copy
+        // this static Meta verbatim into LFP_META, so without this
+        // bit `Lfp::outermost` would walk past the method boundary
+        // once JIT compilation kicks in (manifested as
+        // `undefined method '/main'` from `super`).
+        globals.store[block_fid].set_proc_method();
     }
     Ok(Value::symbol(name))
 }
@@ -1899,6 +1939,15 @@ fn prepend_features(
     base.as_val().ensure_not_frozen(&globals.store)?;
     let prepend_module = lfp.self_val().as_class();
     base.prepend_module(prepend_module)?;
+    // CRuby propagates a `Module#prepend` to every class that has
+    // already mixed in `base` — without this, an existing
+    // `subclass.include(base)` silently shadows the new prepend
+    // because subclass's chain still points at the un-modified
+    // include-iclass. Walk the class store and splice an iclass for
+    // `prepend_module` in above each iclass that wraps `base`.
+    globals
+        .store
+        .propagate_prepend_to_subclasses(base.id(), prepend_module);
     Ok(lfp.self_val())
 }
 
@@ -4020,6 +4069,81 @@ mod tests {
         end
         $res
         "##,
+        );
+    }
+
+    #[test]
+    fn prepend_chain_order() {
+        // Multiple prepends layer in CRuby's expected order: the
+        // *most recently prepended* iclass sits closest to the class.
+        // ruby/spec `core/module/prepend_spec.rb` "prepends multiple
+        // modules in the right order".
+        run_test(
+            r##"
+            m1 = Module.new { def chain; super << :m1; end }
+            m2 = Module.new { def chain; super << :m2; end; prepend(m1) }
+            c  = Class.new  { def chain; [:c]; end; prepend(m2) }
+            c.new.chain
+            "##,
+        );
+    }
+
+    #[test]
+    fn prepend_propagates_to_subclass_chain() {
+        // A class that already includes a module observes a later
+        // prepend on that module — `b.include(a); a.prepend(m)` must
+        // splice `m` into `b`'s chain. ruby/spec
+        // `core/module/prepend_spec.rb` "adds the module in the
+        // subclass chains" + "modifies the ancestor chain".
+        run_test(
+            r##"
+            m = Module.new { def chain; super << :m; end }
+            a = Module.new
+            b = Class.new   { def chain; [:b]; end }
+            b.include(a)
+            a.prepend(m)
+            [b.ancestors.take(4).map { |x| x.equal?(m) ? :m : x.equal?(a) ? :a : x.equal?(b) ? :b : x.name },
+             b.new.chain]
+            "##,
+        );
+    }
+
+    #[test]
+    fn prepend_dup_class() {
+        // Duping a class that has prepended modules must keep the
+        // prepended module reachable via the dup, and the dup must
+        // still be a Class (so `c.dup.new` works). ruby/spec
+        // `core/module/prepend_spec.rb` "keeps the module in the chain
+        // when dupping the class".
+        run_test(
+            r##"
+            m = Module.new { def hello; :from_m; end }
+            c = Class.new { prepend m }
+            d = c.dup
+            [d.is_a?(Class), d.new.kind_of?(m), d.new.hello]
+            "##,
+        );
+    }
+
+    #[test]
+    fn prepend_define_method_super() {
+        // `define_method` inside a class with a prepended module:
+        // `super` from the proc body must resolve through the
+        // surrounding class's super, not the enclosing toplevel
+        // block. ruby/spec `core/module/prepend_spec.rb` "does not
+        // interfere with a define_method super in the original class".
+        run_test(
+            r##"
+            base = Class.new { def foo(ary); ary << 1; end }
+            child = Class.new(base) {
+              define_method(:foo) { |ary| ary << 2; super(ary) }
+            }
+            mod = Module.new { def foo(ary); ary << 3; super(ary); end }
+            child.prepend(mod)
+            ary = []
+            child.new.foo(ary)
+            ary
+            "##,
         );
     }
 

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -269,12 +269,24 @@ impl Lfp {
     ///
     /// Get the outermost LFP and the depth.
     ///
+    /// A frame tagged with `is_proc_method` (the `define_method`-installed
+    /// proc body) is its own outermost — even though it has an `outer`
+    /// pointer for closure variable access, semantically it's a method
+    /// boundary. Stopping there lets `method_func_id` return the actual
+    /// method's `FuncId` instead of the enclosing toplevel/class iseq's,
+    /// so `super` inside `define_method { ... }` looks up the right name.
     pub(crate) fn outermost(&self) -> (Lfp, usize) {
         let mut lfp = *self;
         let mut depth = 0;
+        if lfp.meta().is_proc_method() {
+            return (lfp, depth);
+        }
         while let Some(outer) = lfp.outer() {
             lfp = outer;
             depth += 1;
+            if lfp.meta().is_proc_method() {
+                break;
+            }
         }
         (lfp, depth)
     }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -216,10 +216,23 @@ impl Store {
         // purposes, so the naive walk would include
         // `[M, Object, Kernel, BasicObject]`. Stop the walk when leaving
         // the iclass-included region under a non-class receiver.
+        //
+        // For prepend support we follow CRuby's rule: a class/module that
+        // has an `origin` pointer (i.e. has been the target of a
+        // `prepend`) is *not* rendered at its head position; instead it
+        // shows up where its origin iclass sits in the chain. Iclass
+        // entries are rendered as the underlying module/class that they
+        // wrap so `[Klass, Module, Klass]` becomes `[Module, Klass]` —
+        // matching CRuby's `[m, c, Object, ...]` output.
         let start = self[class_id].get_module();
         let receiver_is_class = start.as_val().ty() == Some(ObjTy::CLASS);
         let mut class = start;
-        let mut v = vec![class];
+        let mut v = Vec::new();
+        // Decide whether to push the head node: skip if it has an
+        // origin (its content surfaces via the origin iclass later).
+        if !class.has_origin() {
+            v.push(class);
+        }
         while let Some(super_class) = class.superclass() {
             // For a Module receiver, stop walking once we leave the
             // mixed-in iclass chain — i.e. once the next ancestor is the
@@ -233,7 +246,18 @@ impl Store {
             {
                 break;
             }
-            v.push(super_class);
+            // Render this node. For an iclass, render the wrapped
+            // module/class (look up by class_id) so a prepended class
+            // doesn't surface as a `Module` value. For a real
+            // class/module, push it directly — but if it has an origin
+            // it's already shadowed by its origin iclass and should be
+            // skipped (matching CRuby's `p == RCLASS_ORIGIN(p)` test).
+            if super_class.is_iclass() {
+                let underlying = self[super_class.id()].get_module();
+                v.push(underlying);
+            } else if !super_class.has_origin() {
+                v.push(super_class);
+            }
             class = super_class;
         }
         v

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -975,6 +975,101 @@ impl ClassInfoTable {
         result
     }
 
+    /// After `base.prepend_module(prepend_module)` runs (modifying
+    /// `base`'s own chain), splice an iclass for `prepend_module` into
+    /// every other class/module whose chain already contains an iclass
+    /// that wraps `base`. This mirrors CRuby's
+    /// `rb_prepend_module` → subclass-iteration propagation step (class.c
+    /// ~L2070 in 4.0.2). Without it, a pattern like
+    ///
+    /// ```text
+    /// b.include(a)   # b -> IA -> ...
+    /// a.prepend(m)   # only a's own chain changes
+    /// ```
+    ///
+    /// silently shadows `m` from `b`'s view because `b`'s chain still
+    /// points at the un-modified `IA`.
+    ///
+    /// Implementation: brute-force scan the class table. For each
+    /// class/module C ≠ `base_id`, walk C's superclass chain. If we
+    /// encounter an iclass whose `class_id == base_id` and
+    /// `prepend_module` is not already in the prepend region above it,
+    /// insert a new iclass for `prepend_module` immediately above that
+    /// iclass.
+    pub(crate) fn propagate_prepend_to_subclasses(
+        &mut self,
+        base_id: ClassId,
+        prepend_module: Module,
+    ) {
+        let prepend_id = prepend_module.id();
+        // Snapshot which class objects exist now — `prepend_module`
+        // might create new iclasses below as a side effect, but we only
+        // want to update *pre-existing* subclasses, not iclasses we add.
+        let candidates: Vec<Module> = self
+            .table
+            .iter()
+            .filter_map(|info| info.object)
+            .filter(|m| {
+                // Skip iclasses (we walk via super through them) and
+                // singleton classes (they carry their own metaclass
+                // semantics; CRuby's propagation skips them too).
+                !m.is_iclass() && m.is_singleton().is_none() && m.id() != base_id
+            })
+            .collect();
+
+        for module in candidates {
+            // Find the iclass node `IA` (wrapping base_id) in module's
+            // chain, walking head→super. We need a `&mut` reference to
+            // the predecessor of IA so we can re-link it through a new
+            // prepend iclass. Track predecessor in `prev`.
+            let mut prev = module;
+            let mut cur = match module.superclass() {
+                Some(s) => s,
+                None => continue,
+            };
+            // Track whether we've seen `prepend_id` in the prepend
+            // region of `module` above `IA` — if so, skip insertion to
+            // avoid duplicate iclasses. (The prepend region of a class
+            // with origin sits between head and origin; for a class
+            // without origin, the whole chain.)
+            let module_origin = module.origin();
+            let mut already_present = false;
+            let target_iclass = loop {
+                if cur.is_iclass() && cur.id() == prepend_id {
+                    already_present = true;
+                }
+                if cur.is_iclass() && cur.id() == base_id {
+                    break Some(cur);
+                }
+                if let Some(o) = module_origin
+                    && cur.as_val() == o.as_val()
+                {
+                    // Reached `module`'s origin without finding IA;
+                    // base isn't in `module`'s prepend-side chain, so
+                    // there is nothing to propagate to here.
+                    break None;
+                }
+                match cur.superclass() {
+                    Some(next) => {
+                        prev = cur;
+                        cur = next;
+                    }
+                    None => break None,
+                }
+            };
+            let Some(target) = target_iclass else { continue };
+            if already_present {
+                continue;
+            }
+            // Insert a fresh iclass for `prepend_module` between `prev`
+            // and `target`. `prev.superclass = new_iclass`,
+            // `new_iclass.superclass = target`.
+            let new_iclass = Value::iclass(prepend_id, Some(target)).as_class();
+            let mut prev_mut = prev;
+            prev_mut.set_superclass(Some(new_iclass));
+        }
+    }
+
     pub(crate) fn get_private_method_names(&self, class_id: ClassId) -> Vec<Value> {
         self[class_id]
             .methods
@@ -1203,7 +1298,7 @@ impl ClassInfoTable {
     /// producing an anonymous duplicate usable for `include`.
     pub(crate) fn duplicate_module(&mut self, original_class: ClassId) -> Module {
         let orig = &self[original_class];
-        let superclass = self.get_module(original_class).superclass();
+        let orig_module = self.get_module(original_class);
         let is_module = orig.instance_ty.is_none();
         let instance_ty = orig.instance_ty;
         // Snapshot data we need to copy before borrowing mut.
@@ -1213,11 +1308,41 @@ impl ClassInfoTable {
         let class_variables = orig.class_variables.clone();
         let alloc_func = orig.alloc_func;
 
+        // The original may have prepended modules. In that case its
+        // `superclass` chain looks like: head -> IM_p1 -> IM_p2 -> ...
+        // -> origin -> real_super. Cloning `superclass` directly would
+        // make the dup share the original's prepend iclasses (bad: the
+        // dup's content would still surface via the original's origin).
+        // Instead, take the dup's *real* super (the part below the
+        // origin) and re-prepend each module on the dup so it gets its
+        // own iclass set.
+        let (real_super, prepended_module_ids): (Option<Module>, Vec<ClassId>) = {
+            if let Some(origin) = orig_module.origin() {
+                // Collect prepended module ids in chain order: walk
+                // head.super through origin, gathering iclasses.
+                let mut ids = Vec::new();
+                let mut cur = orig_module.superclass();
+                while let Some(node) = cur {
+                    if node.id() == origin.id() && node.is_iclass() {
+                        // reached origin iclass — stop
+                        break;
+                    }
+                    if node.is_iclass() {
+                        ids.push(node.id());
+                    }
+                    cur = node.superclass();
+                }
+                (origin.superclass(), ids)
+            } else {
+                (orig_module.superclass(), Vec::new())
+            }
+        };
+
         let new_id = self.add_class();
         let class_obj = if is_module {
-            Value::module_empty(new_id, superclass)
+            Value::module_empty(new_id, real_super)
         } else {
-            Value::class_empty(new_id, superclass)
+            Value::class_empty(new_id, real_super)
         };
         let info = &mut self[new_id];
         info.object = Some(class_obj.as_class());
@@ -1233,8 +1358,23 @@ impl ClassInfoTable {
         // Duplicate the singleton class too: CRuby's Module#initialize_copy
         // clones the singleton class so `def self.foo` and `extend`-ed modules
         // on the original are reachable through the dup.
+        //
+        // NOTE: must happen *before* re-prepending modules below — the
+        // metaclass's super is built from the dup's superclass at the
+        // moment `get_metaclass` runs. If we prepended first, the
+        // dup's super would already be a prepend iclass, throwing the
+        // metaclass chain off (and breaking `is_a?(Class)`).
         let orig_meta = self.get_metaclass(original_class);
         let new_meta = self.get_metaclass(new_id);
+
+        // Re-prepend the original's prepended modules, in reverse so
+        // the resulting chain order matches the original (the iclass
+        // closest to head was the last to be prepended).
+        let mut new_module = class_obj.as_class();
+        for mod_id in prepended_module_ids.into_iter().rev() {
+            let m = self.get_module(mod_id);
+            let _ = new_module.prepend_module(m);
+        }
 
         // Copy singleton-class method/constant/cvar tables.
         let orig_meta_info = &self[orig_meta.id()];

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -228,6 +228,16 @@ impl Meta {
         self.kind &= !0b100
     }
 
+    /// Set the static `is_proc_method` bit. The runtime wrapper for a
+    /// `FuncKind::Proc` already OR's `PROC_METHOD_MASK` into the LFP at
+    /// call time, but JIT-specialised call sites bypass that wrapper
+    /// and copy the underlying block iseq's static Meta directly. Pre-
+    /// setting the bit here ensures `Lfp::outermost` can detect a
+    /// `define_method` proc body in either call path.
+    fn set_proc_method(&mut self) {
+        self.kind |= 0b0010_0000
+    }
+
     /// True when this frame is a define_method proc-method entry;
     /// `handle_error` treats it as the target for `MethodReturn`.
     pub(crate) fn is_proc_method(&self) -> bool {
@@ -907,6 +917,15 @@ impl FuncInfo {
         self.ext.name
     }
 
+    /// Override the function's reported name. Used by `Module#define_method`
+    /// to label a proc-method with its installed method name (otherwise the
+    /// FuncInfo's name remains the placeholder `"proc"`, which makes
+    /// `find_super` look up the wrong identifier and surface a misleading
+    /// `NoMethodError`).
+    pub(crate) fn set_name(&mut self, name: IdentId) {
+        self.ext.name = Some(name);
+    }
+
     ///
     /// Whether this function is a method.
     ///
@@ -934,7 +953,7 @@ impl FuncInfo {
         &self.ext.owner
     }
 
-    pub(super) fn set_owner_class(&mut self, class: ClassId) {
+    pub(crate) fn set_owner_class(&mut self, class: ClassId) {
         self.ext.owner.push(class);
     }
 
@@ -951,6 +970,14 @@ impl FuncInfo {
 
     pub(crate) fn set_method_style(&mut self) {
         self.data.meta.set_method_style();
+    }
+
+    /// Mark the underlying iseq's static Meta as a `define_method`
+    /// proc-method body. See `Meta::set_proc_method` — this is what
+    /// makes `Lfp::outermost` (and thus `super`) detect the method
+    /// boundary even when the JIT inlines the call.
+    pub(crate) fn set_proc_method(&mut self) {
+        self.data.meta.set_proc_method();
     }
 
     ///

--- a/monoruby/src/value/rvalue/module.rs
+++ b/monoruby/src/value/rvalue/module.rs
@@ -39,7 +39,15 @@ impl Module {
     ///
     /// class_version is incremented.
     ///
-    pub(crate) fn include_module(&mut self, mut module: Module) -> Result<()> {
+    pub(crate) fn include_module(&mut self, module: Module) -> Result<()> {
+        self.include_or_prepend_module(module, false)
+    }
+
+    fn include_or_prepend_module(
+        &mut self,
+        mut module: Module,
+        for_prepend: bool,
+    ) -> Result<()> {
         if self.check_cyclic(module) {
             return Err(MonorubyErr::argumenterr("cyclic include detected"));
         }
@@ -49,9 +57,36 @@ impl Module {
         // against `self`'s ancestor chain. Invalidate the constant
         // cache so cached lookups re-walk the new chain.
         Globals::const_version_inc();
+        // If the module being included/prepended has its own origin
+        // (i.e. one or more modules were prepended into it), the head
+        // node represents the prepend-most position — its method table
+        // is intentionally empty in CRuby; the module's actual content
+        // lives at the origin iclass. Skip the head and start the walk
+        // at the first iclass of its prepend chain so the resulting
+        // chain order matches CRuby's: prepended modules first, the
+        // module itself last.
+        if module.has_origin() {
+            if let Some(superclass) = module.superclass()
+                && superclass.is_iclass()
+            {
+                module = superclass;
+            } else {
+                return Ok(());
+            }
+        }
         let mut base = *self;
         loop {
-            if !module.is_ancestor_of(*self) {
+            // For prepend: only treat the module as already-an-ancestor
+            // if it's in the prepend region (between head and origin).
+            // CRuby intentionally lets you prepend a module that's also
+            // included down the chain — both iclass entries appear in
+            // ancestors, and method dispatch sees the prepend first.
+            let already_present = if for_prepend {
+                module.is_ancestor_of_before_origin(*self)
+            } else {
+                module.is_ancestor_of(*self)
+            };
+            if !already_present {
                 base.include(module);
             }
             base = base.superclass().unwrap();
@@ -64,6 +99,35 @@ impl Module {
             }
         }
         Ok(())
+    }
+
+    /// Like `is_ancestor_of`, but only checks the prepend region of
+    /// `class` (the chain segment between `class`'s head and its
+    /// origin iclass). Used by `prepend_module` to avoid duplicate
+    /// inserts in the prepend region while still allowing the same
+    /// module to surface again via an existing include further down
+    /// the chain.
+    ///
+    /// Returns true iff `self` (a module) is reachable from `class`
+    /// via super-walk, stopping at `class`'s origin iclass (exclusive).
+    fn is_ancestor_of_before_origin(self, class: Module) -> bool {
+        let origin = class.origin();
+        let mut cur = class;
+        while let Some(superclass) = cur.superclass() {
+            if let Some(o) = origin
+                && superclass.as_val() == o.as_val()
+            {
+                // Reached the origin iclass — stop. Anything past this
+                // point is either `class`'s own methods (origin) or
+                // included modules below origin.
+                return false;
+            }
+            if superclass.id() == self.id() {
+                return true;
+            }
+            cur = superclass;
+        }
+        false
     }
 
     fn include(&mut self, module: Module) {
@@ -117,7 +181,7 @@ impl Module {
             self.superclass = Some(origin);
             self.origin = Some(origin);
         }
-        self.include_module(module)
+        self.include_or_prepend_module(module, true)
     }
 
     pub fn get_real_class(&self) -> Module {


### PR DESCRIPTION
## Summary

Address several gaps in `Module#prepend` behaviour that surfaced in `core/module/prepend_spec.rb`. Touches the include/prepend chain construction, `dup`, `define_method`+`super`, and chain propagation to existing subclasses.

### Fixes implemented (8/8 actionable)

1. **Multi-prepend order** — `include_module`/`prepend_module` skip a module's head node when it already has an origin, so `c.prepend(m2_with_m1_prepended)` produces `[m1, m2, c, ...]` instead of `[m2, m1, c, ...]`.

2. **Subclass chain shape** — `Store::ancestors` skips a class shadowed by its origin iclass and renders iclass entries as the wrapped class. `parent.prepend(mod)` now surfaces in `child.ancestors`.

3. **Already-included absorption** — `is_ancestor_of_before_origin` only checks the prepend region (between head and origin), so `B.prepend(M)` succeeds when `M` already exists via a parent class's `include`.

4 & 5. **`dup` chain preservation** — `duplicate_module` rebuilds the prepend chain with a fresh origin iclass, and runs `get_metaclass` *before* re-prepending so the dup's singleton chain stays correct (was `Module → Object`, now `Class → Object`). `c.dup.new` works.

6. **`define_method` + `super`** — proc-form `define_method` now sets the installed method's name + owner_class on the underlying block iseq and tags it with `PROC_METHOD_MASK`. `Lfp::outermost` early-exits at proc-method LFPs so `super` in `define_method { ... }` resolves through the host class. Works under both VM and JIT-specialised dispatch.

7 & 8. **Re-prepend / chain propagation** — new `Store::propagate_prepend_to_subclasses` walks the class table after a successful `Module#prepend` and splices a new iclass into every other class/module already mixing in the target.

## Results

- `core/module/prepend_spec.rb`: **9 → 1** (8/8 actionable fixed; remaining is a refinement `TypeError`, intentionally out of scope).
- `core/module` overall: **149 → 141** (8 fewer).
- `cargo test --release --lib --package monoruby`: 1822 passed, 2 pre-existing failures (`string_inspect`, `symbol_inspect_unquoted`) on master, unrelated to this change.
- 4 new unit tests in `builtins::module`.

### Files touched (+400/-9)
- `monoruby/src/builtins/module.rs` — `define_method` decoration, `prepend_features` propagation hook, 4 new unit tests
- `monoruby/src/executor/frame.rs` — `outermost` proc-method early-exit
- `monoruby/src/globals/store.rs` — ancestors rewrite
- `monoruby/src/globals/store/class.rs` — `duplicate_module` reorder + prepend-chain replication, `propagate_prepend_to_subclasses`
- `monoruby/src/globals/store/function.rs` — `set_name` / `set_proc_method` / `pub(crate) set_owner_class`
- `monoruby/src/value/rvalue/module.rs` — `include_or_prepend_module` skip-head-with-origin, `is_ancestor_of_before_origin`

## Test plan

- [x] `cargo test --release --lib --package monoruby` (1822 passed; 2 pre-existing failures only)
- [x] `mspec run core/module/prepend_spec.rb -t monoruby` (9 → 1)
- [x] `mspec run core/module -t monoruby` (149 → 141)
- [x] `mspec run core/module/{ancestors,include}_spec.rb`, `core/class/dup_spec.rb` — no regressions
- [ ] Reviewer: confirm no regressions on full test suite

https://claude.ai/code/session_prepend_chain

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_