### PR TITLE
core/ffi+fiddle: nested struct/array fields, CRuby type-code convention, String VOIDP write-back

### DIFF
--- a/monoruby/gem/ffi_c.rb
+++ b/monoruby/gem/ffi_c.rb
@@ -13,28 +13,38 @@ module FFI
   # VERSION is set by the ffi gem's lib/ffi/version.rb
 
   # =========================================================================
-  # Type codes – integer constants matching the Rust backend (builtins/ffi.rs)
+  # Type codes – integer constants matching the Rust backend
+  # (src/builtins/fiddle.rs). They follow CRuby's Fiddle convention so that
+  # `-Fiddle::TYPE_INT` (used by opengl-bindings2 and friends) means
+  # "unsigned int". Keep these in sync with stdlib/fiddle.rb.
   # =========================================================================
   TYPE_VOID       =  0
-  TYPE_VOIDP      = -1
-  TYPE_CHAR       = -2
-  TYPE_UCHAR      = -3
-  TYPE_SHORT      = -4
-  TYPE_USHORT     = -5
-  TYPE_INT        = -6
-  TYPE_UINT       = -7
-  TYPE_LONG       = -8
-  TYPE_ULONG      = -9
-  TYPE_LONG_LONG  = -10
-  TYPE_ULONG_LONG = -11
-  TYPE_FLOAT      = -12
-  TYPE_DOUBLE     = -13
-  TYPE_BOOL       = -14
-  TYPE_INTPTR_T   = -15
-  TYPE_UINTPTR_T  = -16
-  TYPE_PTRDIFF_T  = -17
-  TYPE_SIZE_T     = -18
-  TYPE_SSIZE_T    = -19
+  TYPE_VOIDP      =  1
+  TYPE_CHAR       =  2
+  TYPE_SHORT      =  3
+  TYPE_INT        =  4
+  TYPE_LONG       =  5
+  TYPE_LONG_LONG  =  6
+  TYPE_FLOAT      =  7
+  TYPE_DOUBLE     =  8
+
+  # Unsigned variants — CRuby convention is to negate the signed code.
+  TYPE_UCHAR      = -TYPE_CHAR
+  TYPE_USHORT     = -TYPE_SHORT
+  TYPE_UINT       = -TYPE_INT
+  TYPE_ULONG      = -TYPE_LONG
+  TYPE_ULONG_LONG = -TYPE_LONG_LONG
+
+  # Platform aliases (8 bytes on x86-64 Linux).
+  TYPE_INTPTR_T   = TYPE_LONG
+  TYPE_UINTPTR_T  = TYPE_ULONG
+  TYPE_PTRDIFF_T  = TYPE_LONG
+  TYPE_SIZE_T     = TYPE_ULONG
+  TYPE_SSIZE_T    = TYPE_LONG
+
+  # Picked an unused positive value for TYPE_BOOL — CRuby's Fiddle 1.1
+  # doesn't expose one, but FFI's `:bool` argument routes through Fiddle.
+  TYPE_BOOL       =  9
 
   # =========================================================================
   # FFI::Platform – minimal constants needed before the gem's platform.rb
@@ -141,6 +151,33 @@ module FFI
       end
     end
 
+    # Type::Struct – wraps an FFI::Struct subclass so it can appear as a field
+    # type in another struct's layout. Mirrors the C-extension class.
+    class Struct < Type
+      attr_reader :struct_class
+
+      def initialize(struct_class)
+        @struct_class = struct_class
+        super("struct(#{struct_class.name})",
+              struct_class.size,
+              struct_class.respond_to?(:alignment) ? struct_class.alignment : 8)
+      end
+    end
+
+    # Type::Array – inline fixed-length array of `elem_type` repeated `length`
+    # times. Used for layout entries like `:filters, [:pointer, 10]`.
+    class Array < Type
+      attr_reader :elem_type, :length
+
+      def initialize(elem_type, length)
+        @elem_type = elem_type
+        @length    = length
+        super("array(#{elem_type.name}, #{length})",
+              elem_type.size * length,
+              elem_type.alignment)
+      end
+    end
+
     # Map from ffi gem symbol names to Type objects
     NAMES = {
       void:       VOID,
@@ -170,9 +207,21 @@ module FFI
       NAMES[name] or raise TypeError, "unknown FFI type: #{name.inspect}"
     end
 
-    # Resolve a type descriptor to an FFI::Type
+    # Resolve a type descriptor to an FFI::Type. Mirrors the lookup the
+    # ffi gem's `find_field_type` does (struct.rb), so Symbol, Struct
+    # subclass, `Struct.by_value` (StructByValue), and `[type, count]`
+    # array literals all work.
     def self.find(type, type_map = nil)
       return type if type.is_a?(FFI::Type)
+      if type.is_a?(FFI::StructByValue)
+        return FFI::Type::Struct.new(type.struct_class)
+      end
+      if type.is_a?(::Class) && type < FFI::Struct
+        return FFI::Type::Struct.new(type)
+      end
+      if type.is_a?(::Array)
+        return FFI::Type::Array.new(find(type[0], type_map), type[1])
+      end
       if type_map
         mapped = type_map[type]
         return find(mapped, nil) if mapped
@@ -790,6 +839,12 @@ module FFI
 
       # Define layout via DSL: layout :x, :int32, :y, :int32
       def layout(*spec)
+        # No-arg call is the accessor form. The gem's Struct.layout (loaded
+        # later) does the same; mirroring it here keeps things sane in case
+        # this stub is the active definition (e.g. while the gem's
+        # `ffi/struct` hasn't been required yet).
+        return @layout if spec.empty?
+
         fields = []
         offset = 0
         max_align = 1
@@ -888,24 +943,99 @@ module FFI
     private
 
     def read_field(field)
-      FFI.___read(@address + field.offset, field.type.type_code)
+      type = field.type
+      addr = @address + field.offset
+      case type
+      when FFI::Type::Struct
+        # Inline struct field: return a Struct instance pointing into our
+        # backing memory. Borrowed (not owned) so the parent owns the
+        # lifetime.
+        sub = type.struct_class.allocate
+        sub.instance_variable_set(:@address, addr)
+        sub.instance_variable_set(:@size,    type.size)
+        sub.instance_variable_set(:@owned,   false)
+        sub
+      when FFI::Type::Array
+        # Inline fixed-length array field: return an Array of the field's
+        # element type read element-by-element.
+        elem  = type.elem_type
+        ecode = elem.type_code
+        esize = elem.size
+        Array.new(type.length) { |i| FFI.___read(addr + i * esize, ecode) }
+      else
+        FFI.___read(addr, type.type_code)
+      end
     end
 
     def write_field(field, value)
-      if value.nil? && field.type.type_code == FFI::TYPE_VOIDP
-        value = 0
-      elsif value.is_a?(FFI::Pointer)
-        value = value.address
-      elsif value.respond_to?(:to_ptr)
-        value = value.to_ptr.address
+      type = field.type
+      addr = @address + field.offset
+      case type
+      when FFI::Type::Struct
+        # Copy the source struct's bytes into our slot. Source must be the
+        # same struct class (or a subclass).
+        unless value.is_a?(type.struct_class)
+          raise TypeError,
+            "wrong value type (expected #{type.struct_class})"
+        end
+        FFI.___write_bytes(addr, FFI.___read_bytes(value.instance_variable_get(:@address), type.size))
+      when FFI::Type::Array
+        ary = value.to_ary
+        elem  = type.elem_type
+        ecode = elem.type_code
+        esize = elem.size
+        ary.first(type.length).each_with_index do |v, i|
+          FFI.___write(addr + i * esize, ecode, v)
+        end
+      else
+        if value.nil? && type.type_code == FFI::TYPE_VOIDP
+          value = 0
+        elsif value.is_a?(FFI::Pointer)
+          value = value.address
+        elsif value.respond_to?(:to_ptr)
+          value = value.to_ptr.address
+        end
+        FFI.___write(addr, type.type_code, value)
       end
-      FFI.___write(@address + field.offset, field.type.type_code, value)
     end
+  end
+
+  # =========================================================================
+  # FFI::StructByValue – pass-a-struct-by-value marker.
+  #
+  # The C extension uses this to wrap an FFI::Struct subclass when a function
+  # signature passes the struct by value. monoruby doesn't yet support
+  # passing structs by value to native code, so this is a stub that records
+  # the struct class and exposes the same `struct_class`/`size` accessors the
+  # gem's `Struct.val` / `Struct.by_value` callers expect.
+  # =========================================================================
+  class StructByValue
+    attr_reader :struct_class
+
+    def initialize(struct_class)
+      unless struct_class.is_a?(::Class) && struct_class < FFI::Struct
+        raise TypeError, 'wrong type (expected subclass of FFI::Struct)'
+      end
+      @struct_class = struct_class
+    end
+
+    def size
+      @struct_class.size
+    end
+
+    def alignment
+      @struct_class.respond_to?(:alignment) ? @struct_class.alignment : 8
+    end
+    alias align alignment
   end
 
   class Union < Struct
     class << self
       def layout(*spec)
+        # No-arg call is the accessor form (matches the gem's
+        # Struct.layout). The DSL form passes an even-sized spec.
+        return @layout if spec.empty?
+
         fields = []
         max_size  = 0
         max_align = 1
@@ -998,4 +1128,41 @@ module FFI
   end
 
   class NotFoundError < LoadError; end
+
+  # =========================================================================
+  # Patch the gem's Struct.find_field_type so it can convert a
+  # FFI::StructByValue (returned by `OtherStruct.by_value`) into an inline
+  # Type::Struct field. The C extension does this implicitly when building a
+  # layout; the gem's pure-Ruby `find_field_type` doesn't, since it expects
+  # the C extension to handle that case.
+  #
+  # Prepended onto Struct's singleton so it survives the gem re-opening
+  # `class Struct` later in the load (`require 'ffi/struct'`).
+  # =========================================================================
+  class Struct
+    module FindFieldTypePatch
+      def find_field_type(type, mod = enclosing_module)
+        if type.is_a?(FFI::StructByValue)
+          return FFI::Type::Struct.new(type.struct_class)
+        end
+        super
+      end
+    end
+    singleton_class.prepend(FindFieldTypePatch)
+  end
+
+  # Same idea for `FFI.find_type` (used by `Library#attach_function` to
+  # resolve parameter / return types). The gem's pure-Ruby implementation
+  # raises `TypeError: unable to resolve type` on a StructByValue, since
+  # passing structs by value is C-extension territory. monoruby doesn't
+  # support true by-value calls yet, so we conservatively fall back to
+  # passing the struct as a pointer — matching what the gem already does
+  # for a bare `Class < Struct`.
+  module FindTypePatch
+    def find_type(name, type_map = nil)
+      return FFI::Type::POINTER if name.is_a?(FFI::StructByValue)
+      super
+    end
+  end
+  singleton_class.prepend(FindTypePatch)
 end

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -5,29 +5,35 @@ use jitgen::JitContext;
 use libffi::middle::{Arg, Cif, CodePtr, Type};
 
 // ---------------------------------------------------------------------------
-// Fiddle type codes  (must match startup/fiddle.rb and startup/ffi_c.rb)
+// Fiddle type codes  (must match stdlib/fiddle.rb and gem/ffi_c.rb)
+//
+// We use CRuby's Fiddle convention: each canonical type has a small positive
+// integer code, and the unsigned variant is its negation. opengl-bindings2
+// and other CRuby-targeted gems write `-Fiddle::TYPE_INT` to mean
+// "unsigned int", so we need the same convention.
+//
+// Platform aliases (INTPTR_T / SIZE_T / SSIZE_T / PTRDIFF_T / UINTPTR_T)
+// alias to LONG / ULONG on x86-64 Linux; they are not separate Rust
+// constants because match arms would collide.
 // ---------------------------------------------------------------------------
-const TYPE_VOID: i64 = 0;
-const TYPE_VOIDP: i64 = -1;
-const TYPE_CHAR: i64 = -2;
-const TYPE_UCHAR: i64 = -3;
-const TYPE_SHORT: i64 = -4;
-const TYPE_USHORT: i64 = -5;
-const TYPE_INT: i64 = -6;
-const TYPE_UINT: i64 = -7;
-const TYPE_LONG: i64 = -8;
-const TYPE_ULONG: i64 = -9;
-const TYPE_LONG_LONG: i64 = -10;
-const TYPE_ULONG_LONG: i64 = -11;
-const TYPE_FLOAT: i64 = -12;
-const TYPE_DOUBLE: i64 = -13;
-const TYPE_BOOL: i64 = -14;
-// Platform-specific aliases (all 8 bytes on x86-64)
-const TYPE_INTPTR_T: i64 = -15;
-const TYPE_UINTPTR_T: i64 = -16;
-const TYPE_PTRDIFF_T: i64 = -17;
-const TYPE_SIZE_T: i64 = -18;
-const TYPE_SSIZE_T: i64 = -19;
+const TYPE_VOID:       i64 =  0;
+const TYPE_VOIDP:      i64 =  1;
+const TYPE_CHAR:       i64 =  2;
+const TYPE_UCHAR:      i64 = -2;
+const TYPE_SHORT:      i64 =  3;
+const TYPE_USHORT:     i64 = -3;
+const TYPE_INT:        i64 =  4;
+const TYPE_UINT:       i64 = -4;
+const TYPE_LONG:       i64 =  5;
+const TYPE_ULONG:      i64 = -5;
+const TYPE_LONG_LONG:  i64 =  6;
+const TYPE_ULONG_LONG: i64 = -6;
+const TYPE_FLOAT:      i64 =  7;
+const TYPE_DOUBLE:     i64 =  8;
+// CRuby's Fiddle (1.1) doesn't expose TYPE_BOOL; we keep it for FFI's
+// `:bool` arg and treat it like a 32-bit int, matching libffi's `bool` ABI
+// on x86-64. Picked an unused value (9) to avoid clashes.
+const TYPE_BOOL:       i64 =  9;
 
 // ---------------------------------------------------------------------------
 // Argument storage (keeps values alive while libffi call is running)
@@ -108,18 +114,19 @@ impl CArg {
 // ---------------------------------------------------------------------------
 
 fn type_code_to_ret_ffi_type(ty: i64) -> Result<Type> {
+    // INTPTR_T / PTRDIFF_T / SSIZE_T alias TYPE_LONG (positive 5);
+    // UINTPTR_T / SIZE_T alias TYPE_ULONG (negative -5). Those alias paths
+    // hit the LONG/ULONG arms automatically without separate constants.
     match ty {
         TYPE_VOID => Ok(Type::void()),
-        TYPE_VOIDP | TYPE_UINTPTR_T | TYPE_SIZE_T => Ok(Type::pointer()),
+        TYPE_VOIDP => Ok(Type::pointer()),
         TYPE_CHAR => Ok(Type::i8()),
         TYPE_UCHAR => Ok(Type::u8()),
         TYPE_SHORT => Ok(Type::i16()),
         TYPE_USHORT => Ok(Type::u16()),
         TYPE_INT | TYPE_BOOL => Ok(Type::i32()),
         TYPE_UINT => Ok(Type::u32()),
-        TYPE_LONG | TYPE_LONG_LONG | TYPE_INTPTR_T | TYPE_PTRDIFF_T | TYPE_SSIZE_T => {
-            Ok(Type::i64())
-        }
+        TYPE_LONG | TYPE_LONG_LONG => Ok(Type::i64()),
         TYPE_ULONG | TYPE_ULONG_LONG => Ok(Type::u64()),
         TYPE_FLOAT => Ok(Type::f32()),
         TYPE_DOUBLE => Ok(Type::f64()),
@@ -135,6 +142,8 @@ fn type_code_to_ret_ffi_type(ty: i64) -> Result<Type> {
 /// For `TYPE_VOIDP`, a Ruby String value is accepted: its raw byte-buffer
 /// pointer is passed to the C function.  An Integer is treated as an address.
 fn value_to_carg(globals: &mut Globals, val: Value, ty: i64) -> Result<CArg> {
+    // Same alias note as type_code_to_ret_ffi_type: INTPTR_T family
+    // collapses to LONG/ULONG codes in CRuby's convention.
     match ty {
         TYPE_VOID => Ok(CArg::I64(0)), // should not appear as argument
         TYPE_CHAR => Ok(CArg::I8(val.expect_integer(globals)? as i8)),
@@ -143,12 +152,8 @@ fn value_to_carg(globals: &mut Globals, val: Value, ty: i64) -> Result<CArg> {
         TYPE_USHORT => Ok(CArg::U16(val.expect_integer(globals)? as u16)),
         TYPE_INT | TYPE_BOOL => Ok(CArg::I32(val.expect_integer(globals)? as i32)),
         TYPE_UINT => Ok(CArg::U32(val.expect_integer(globals)? as u32)),
-        TYPE_LONG | TYPE_LONG_LONG | TYPE_INTPTR_T | TYPE_PTRDIFF_T | TYPE_SSIZE_T => {
-            Ok(CArg::I64(val.expect_integer(globals)?))
-        }
-        TYPE_ULONG | TYPE_ULONG_LONG | TYPE_UINTPTR_T | TYPE_SIZE_T => {
-            Ok(CArg::U64(val.expect_integer(globals)? as u64))
-        }
+        TYPE_LONG | TYPE_LONG_LONG => Ok(CArg::I64(val.expect_integer(globals)?)),
+        TYPE_ULONG | TYPE_ULONG_LONG => Ok(CArg::U64(val.expect_integer(globals)? as u64)),
         TYPE_VOIDP => {
             // Accept: nil → NULL, Integer → address, String → raw bytes ptr
             match val.unpack() {
@@ -255,11 +260,11 @@ fn fiddle_call_inner(
             let v: u32 = unsafe { cif.call(func, &ffi_args) };
             Value::integer(v as i64)
         }
-        TYPE_LONG | TYPE_LONG_LONG | TYPE_INTPTR_T | TYPE_PTRDIFF_T | TYPE_SSIZE_T => {
+        TYPE_LONG | TYPE_LONG_LONG => {
             let v: i64 = unsafe { cif.call(func, &ffi_args) };
             Value::integer(v)
         }
-        TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG | TYPE_UINTPTR_T | TYPE_SIZE_T => {
+        TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG => {
             let v: u64 = unsafe { cif.call(func, &ffi_args) };
             Value::integer(v as i64)
         }
@@ -341,10 +346,10 @@ fn fiddle_read(
             TYPE_USHORT => Value::integer(*(ptr as *const u16) as i64),
             TYPE_INT | TYPE_BOOL => Value::integer(*(ptr as *const i32) as i64),
             TYPE_UINT => Value::integer(*(ptr as *const u32) as i64),
-            TYPE_LONG | TYPE_LONG_LONG | TYPE_INTPTR_T | TYPE_PTRDIFF_T | TYPE_SSIZE_T => {
+            TYPE_LONG | TYPE_LONG_LONG => {
                 Value::integer(*(ptr as *const i64))
             }
-            TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG | TYPE_UINTPTR_T | TYPE_SIZE_T => {
+            TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG => {
                 Value::integer(*(ptr as *const u64) as i64)
             }
             TYPE_FLOAT => Value::float(*(ptr as *const f32) as f64),
@@ -385,10 +390,10 @@ fn fiddle_write(
             TYPE_USHORT => *(ptr as *mut u16) = val.expect_integer(globals)? as u16,
             TYPE_INT | TYPE_BOOL => *(ptr as *mut i32) = val.expect_integer(globals)? as i32,
             TYPE_UINT => *(ptr as *mut u32) = val.expect_integer(globals)? as u32,
-            TYPE_LONG | TYPE_LONG_LONG | TYPE_INTPTR_T | TYPE_PTRDIFF_T | TYPE_SSIZE_T => {
+            TYPE_LONG | TYPE_LONG_LONG => {
                 *(ptr as *mut i64) = val.expect_integer(globals)?;
             }
-            TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG | TYPE_UINTPTR_T | TYPE_SIZE_T => {
+            TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG => {
                 *(ptr as *mut u64) = val.expect_integer(globals)? as u64;
             }
             TYPE_FLOAT => *(ptr as *mut f32) = val.coerce_to_f64_no_convert(globals)? as f32,
@@ -722,13 +727,15 @@ mod tests {
     // surfaces as a monoruby-side exception and fails the test.
     //
     // Type codes match the constants defined at the top of this file
-    // (kept in sync with `startup/ffi_c.rb`).
+    // (kept in sync with `gem/ffi_c.rb` and `stdlib/fiddle.rb`).
+    // CRuby's Fiddle convention: positive=signed, negation=unsigned.
+    // SIZE_T is an alias of ULONG (= -LONG = -5) on x86-64.
     const TYPE_PRELUDE: &str = r#"
-        TY_VOIDP = -1
-        TY_INT   = -6
-        TY_LLONG = -10
-        TY_DOUBLE = -13
-        TY_SIZE_T = -18
+        TY_VOIDP  = 1
+        TY_INT    = 4
+        TY_LLONG  = 6
+        TY_DOUBLE = 8
+        TY_SIZE_T = -5
         LIBC = FFI.___dlopen("libc.so.6")
         LIBM = FFI.___dlopen("libm.so.6") || FFI.___dlopen("libc.so.6")
     "#;
@@ -866,11 +873,11 @@ mod tests {
     fn fiddle_read_write_inline_jit() {
         run_test_no_result_check(&format!(
             r#"{TYPE_PRELUDE}
-            TY_CHAR   = -2
-            TY_UCHAR  = -3
-            TY_SHORT  = -4
-            TY_USHORT = -5
-            TY_UINT   = -7
+            TY_CHAR   = 2
+            TY_UCHAR  = -2
+            TY_SHORT  = 3
+            TY_USHORT = -3
+            TY_UINT   = -4
             ptr = FFI.___malloc(16)
             raise "malloc returned NULL" if ptr == 0
             begin

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -54,26 +54,9 @@ enum CArg {
     U64(u64),
     F32(f32),
     F64(f64),
-    /// Ruby String passed as a C `char*`. Owns a heap buffer with an
-    /// appended NUL terminator (Ruby strings are not NUL-terminated) and
-    /// caches its pointer as a u64 so `as_libffi_arg` can reference a
-    /// stable location. Moving the `CArg` is safe because the `Vec<u8>`
-    /// move leaves the heap allocation in place.
-    CStr {
-        _buf: Vec<u8>,
-        ptr: u64,
-    },
 }
 
 impl CArg {
-    fn from_bytes_nul_terminated(bytes: &[u8]) -> Self {
-        let mut buf = Vec::with_capacity(bytes.len() + 1);
-        buf.extend_from_slice(bytes);
-        buf.push(0);
-        let ptr = buf.as_ptr() as u64;
-        CArg::CStr { _buf: buf, ptr }
-    }
-
     /// Return a libffi Arg pointing into this CArg.
     /// SAFETY: `self` must not be moved or dropped while the Arg is in use.
     fn as_libffi_arg(&'_ self) -> Arg<'_> {
@@ -88,7 +71,6 @@ impl CArg {
             CArg::U64(v) => Arg::new(v),
             CArg::F32(v) => Arg::new(v),
             CArg::F64(v) => Arg::new(v),
-            CArg::CStr { ptr, .. } => Arg::new(ptr),
         }
     }
 
@@ -104,7 +86,6 @@ impl CArg {
             CArg::U64(_) => Type::u64(),
             CArg::F32(_) => Type::f32(),
             CArg::F64(_) => Type::f64(),
-            CArg::CStr { .. } => Type::pointer(),
         }
     }
 }
@@ -139,9 +120,17 @@ fn type_code_to_ret_ffi_type(ty: i64) -> Result<Type> {
 
 /// Convert a Ruby Value and a Fiddle type code into a `CArg`.
 ///
-/// For `TYPE_VOIDP`, a Ruby String value is accepted: its raw byte-buffer
-/// pointer is passed to the C function.  An Integer is treated as an address.
-fn value_to_carg(globals: &mut Globals, val: Value, ty: i64) -> Result<CArg> {
+/// For `TYPE_VOIDP`, a Ruby String value is accepted: a pointer to its
+/// actual byte buffer is passed to the C function. We mutate the String
+/// to ensure a trailing NUL in spare capacity (so `strlen`-style reads
+/// stop at `len`) but the visible content is unchanged. Writes the C
+/// function makes within `[0, len)` are visible to subsequent Ruby reads
+/// — this is required for callers like `glGenTextures(1, buf)` and
+/// `memcpy(buf, src, n)` that fill `buf` in place.
+///
+/// `mut val` is taken by value (Value is Copy) so we can freely take an
+/// `&mut` to its underlying RValue without disturbing the caller.
+fn value_to_carg(globals: &mut Globals, mut val: Value, ty: i64) -> Result<CArg> {
     // Same alias note as type_code_to_ret_ffi_type: INTPTR_T family
     // collapses to LONG/ULONG codes in CRuby's convention.
     match ty {
@@ -161,14 +150,16 @@ fn value_to_carg(globals: &mut Globals, val: Value, ty: i64) -> Result<CArg> {
                 RV::BigInt(b) => Ok(CArg::U64(num::ToPrimitive::to_u64(b).unwrap_or(0))),
                 RV::Nil => Ok(CArg::U64(0)),
                 RV::String(_) => {
-                    // Ruby strings are not NUL-terminated, so passing
-                    // `as_ptr()` directly to a C function expecting a
-                    // `char*` (e.g. `SDL_SetWindowTitle`, `strlen`)
-                    // causes a read past the end of the string buffer.
-                    // Copy into a NUL-terminated buffer owned by the
-                    // CArg for the duration of the libffi call.
-                    let inner = val.as_rstring_inner();
-                    Ok(CArg::from_bytes_nul_terminated(inner.as_bytes()))
+                    // Hand the C function the actual String buffer (so
+                    // it can write back into Ruby-visible memory) but
+                    // first ensure a trailing NUL in spare capacity
+                    // (read-only callers like strlen need it). The
+                    // String stays alive via the args slice in
+                    // fiddle_call_inner, so the pointer is valid for
+                    // the duration of the call.
+                    let inner = val.as_rstring_inner_mut();
+                    let ptr = inner.nul_terminated_buf_ptr();
+                    Ok(CArg::U64(ptr as u64))
                 }
                 _ => {
                     // Other objects (e.g. FFI::Pointer): coerce via to_i

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -181,6 +181,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         true,
     );
     globals.define_builtin_func(kernel_class, "method", method, 1);
+    globals.define_builtin_func(kernel_class, "singleton_method", singleton_method, 1);
     globals.define_builtin_func_with(
         kernel_class,
         "define_singleton_method",
@@ -2454,6 +2455,38 @@ fn method(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let receiver = lfp.self_val();
     let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
     let (func_id, _, owner) = globals.find_method_for_object(receiver, method_name)?;
+    Ok(Value::new_method(receiver, func_id, owner))
+}
+
+///
+/// ### Kernel#singleton_method
+///
+/// - singleton_method(name) -> Method
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/singleton_method.html]
+#[monoruby_builtin]
+fn singleton_method(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let receiver = lfp.self_val();
+    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let class_id = match globals.store.has_singleton(receiver) {
+        Some(module) => module.id(),
+        None => {
+            return Err(MonorubyErr::nameerr_with_name(
+                format!(
+                    "undefined singleton method `{}' for `{}'",
+                    method_name,
+                    receiver.inspect(&globals.store)
+                ),
+                method_name,
+            ));
+        }
+    };
+    let (func_id, _, owner) = globals.store.find_method_for_class(class_id, method_name)?;
     Ok(Value::new_method(receiver, func_id, owner))
 }
 

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1072,6 +1072,34 @@ impl RStringInner {
         &self.content
     }
 
+    /// Make the buffer C-string compatible without changing the visible
+    /// Ruby content: ensure capacity ≥ `len + 1` and write a NUL byte at
+    /// `content[len]` (in spare capacity, *not* part of `as_bytes`).
+    /// Returns a raw pointer to the start of the buffer.
+    ///
+    /// Used by the Fiddle / FFI bridge so a Ruby String passed where
+    /// C expects `char*` / `void*` can be:
+    ///   * read by `strlen`-style C code (the trailing NUL stops the scan
+    ///     at `len`), and
+    ///   * written into by `memcpy`-style C code (writes within the first
+    ///     `len` bytes are visible to subsequent Ruby reads of the same
+    ///     String, because we expose the actual backing buffer instead of
+    ///     a copy).
+    ///
+    /// SAFETY: The pointer is valid until the next mutation of `self`
+    /// (which may reallocate). `as_bytes`, `len`, `hash`, and equality
+    /// of `self` are unchanged — the NUL lives in spare capacity.
+    pub fn nul_terminated_buf_ptr(&mut self) -> *mut u8 {
+        let len = self.content.len();
+        if self.content.capacity() <= len {
+            self.content.reserve(1);
+        }
+        // SAFETY: capacity > len after the reserve above, so the byte at
+        // offset `len` is owned spare capacity that we can write to.
+        unsafe { self.content.as_mut_ptr().add(len).write(0) };
+        self.content.as_mut_ptr()
+    }
+
     pub fn set_byte(&mut self, index: usize, byte: u8) {
         self.content[index] = byte;
         // Phase 1 lets a UTF-8-tagged buffer hold invalid bytes,

--- a/monoruby/stdlib/fiddle.rb
+++ b/monoruby/stdlib/fiddle.rb
@@ -12,29 +12,44 @@
 module Fiddle
   # ---------------------------------------------------------------------------
   # Fiddle::Types — authoritative type-code constants.
-  # The ffi gem will mirror these as Fiddle::TYPE_* after loading.
+  #
+  # Uses CRuby's Fiddle convention: each canonical type has a small positive
+  # integer code, and the unsigned variant is its arithmetic negation. Code
+  # written for CRuby (e.g. opengl-bindings2) commonly writes
+  # `-Fiddle::TYPE_INT` to mean "unsigned int", which only works under this
+  # convention. The Rust backend (src/builtins/fiddle.rs) decodes the same
+  # values.
   # ---------------------------------------------------------------------------
   module Types
     VOID       =  0
-    VOIDP      = -1
-    CHAR       = -2
-    UCHAR      = -3
-    SHORT      = -4
-    USHORT     = -5
-    INT        = -6
-    UINT       = -7
-    LONG       = -8
-    ULONG      = -9
-    LONG_LONG  = -10
-    ULONG_LONG = -11
-    FLOAT      = -12
-    DOUBLE     = -13
-    BOOL       = -14
-    INTPTR_T   = -15
-    UINTPTR_T  = -16
-    PTRDIFF_T  = -17
-    SIZE_T     = -18
-    SSIZE_T    = -19
+    VOIDP      =  1
+    CHAR       =  2
+    SHORT      =  3
+    INT        =  4
+    LONG       =  5
+    LONG_LONG  =  6
+    FLOAT      =  7
+    DOUBLE     =  8
+
+    # Unsigned variants: the negation of the corresponding signed code.
+    UCHAR      = -CHAR
+    USHORT     = -SHORT
+    UINT       = -INT
+    ULONG      = -LONG
+    ULONG_LONG = -LONG_LONG
+
+    # Platform aliases — on x86-64 Linux these all resolve to LONG/ULONG
+    # (8-byte) so the Rust backend's match arms collapse cleanly.
+    INTPTR_T   = LONG
+    UINTPTR_T  = ULONG
+    PTRDIFF_T  = LONG
+    SIZE_T     = ULONG
+    SSIZE_T    = LONG
+
+    # CRuby's Fiddle (1.1) doesn't expose TYPE_BOOL but FFI's `:bool`
+    # arg goes through Fiddle. Picked an unused positive value (9) so it
+    # doesn't clash with the canonical signed/unsigned codes above.
+    BOOL       =  9
   end
 
   # ---------------------------------------------------------------------------
@@ -48,6 +63,25 @@ module Fiddle
   WINDOWS = false
 
   # ---------------------------------------------------------------------------
+  # ALIGN_* — C type alignments for x86-64 Linux. fiddle/pack.rb relies on
+  # them. SIZEOF_* counterparts come from src/builtins/fiddle.rs.
+  # ---------------------------------------------------------------------------
+  ALIGN_VOIDP         = 8
+  ALIGN_CHAR          = 1
+  ALIGN_SHORT         = 2
+  ALIGN_INT           = 4
+  ALIGN_LONG          = 8
+  ALIGN_LONG_LONG     = 8
+  ALIGN_FLOAT         = 4
+  ALIGN_DOUBLE        = 8
+  ALIGN_BOOL          = 1
+  ALIGN_INTPTR_T      = 8
+  ALIGN_UINTPTR_T     = 8
+  ALIGN_PTRDIFF_T     = 8
+  ALIGN_SIZE_T        = 8
+  ALIGN_SSIZE_T       = 8
+
+  # ---------------------------------------------------------------------------
   # Errors
   # ---------------------------------------------------------------------------
   class Error < StandardError; end
@@ -57,7 +91,10 @@ module Fiddle
   # Fiddle::Pointer – wraps a raw memory address
   # ---------------------------------------------------------------------------
   class Pointer
-    attr_reader :size
+    # CRuby's Fiddle::Pointer exposes `size` both for read and write —
+    # fiddle/struct.rb's CStructEntity does `undef_method :size=` which
+    # requires the writer to exist. We follow the same shape.
+    attr_accessor :size
 
     def initialize(addr, size = 0)
       @ptr  = addr.respond_to?(:to_i) ? addr.to_i : 0


### PR DESCRIPTION
## Summary

Three intertwined changes that together let the FFI / Fiddle stack behind quake-rb (sdl2-bindings + opengl-bindings2 + sdl2-mixer + fiddle/import) load and run on monoruby.

### 1. FFI: nested struct / array fields, missing helpers, layout fixes
[`monoruby/gem/ffi_c.rb`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/gem/ffi_c.rb)

Define classes the gem expects from `ffi_c.so` but that monoruby's pure-Ruby replacement was missing:

- `FFI::Type::Struct` (inline nested struct), `FFI::Type::Array` (inline `[type, count]` array), `FFI::StructByValue` (`Struct.by_value` return value).
- Extend `FFI::Type.find` to accept Struct subclass / `[type, count]` literal / StructByValue.
- Prepend-patch the gem's `Struct.find_field_type` and `FFI.find_type` so `StructByValue` resolves to an inline `Type::Struct` (or `Type::POINTER` for `attach_function`) after `ffi/struct.rb` loads.
- Make `Struct#read_field` / `write_field` handle `Type::Struct` (return / copy a borrowed sub-struct) and `Type::Array` (read / write each element).
- Guard `Union.layout` and `Struct.layout` no-arg calls so they act as accessors instead of recreating an empty layout — the original `Union.layout(...)` was being called twice (DSL form + accessor form) and the accessor form was overwriting fields with an empty list.

### 2. Fiddle / FFI type codes match CRuby's convention
[`monoruby/gem/ffi_c.rb`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/gem/ffi_c.rb), [`monoruby/stdlib/fiddle.rb`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/stdlib/fiddle.rb), [`monoruby/src/builtins/fiddle.rs`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/src/builtins/fiddle.rs)

Switch from monoruby's previous all-negative scheme to CRuby's: positive integer codes for canonical signed types, the arithmetic negation for unsigned. opengl-bindings2 (and other CRuby-targeted gems) write `-Fiddle::TYPE_INT` to mean "unsigned int", which only works under that convention. Without this, `glClear`, `glDrawArrays`, … hit `Fiddle: unsupported argument type code 6`.

Also drop the Rust-side INTPTR_T / SIZE_T / PTRDIFF_T / SSIZE_T / UINTPTR_T constants — they collapse to LONG / ULONG on x86-64 and would clash in match arms. Fiddle ALIGN_* constants added in stdlib for fiddle/pack.rb. `Fiddle::Pointer#size` switched to `attr_accessor` so fiddle/struct.rb's `undef_method :size=` succeeds.

### 3. String → VOIDP must hand C the real buffer (write-back)
[`monoruby/src/value/rvalue/string.rs`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/src/value/rvalue/string.rs), [`monoruby/src/builtins/fiddle.rs`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/src/builtins/fiddle.rs)

Before this PR `value_to_carg` copied a String into a fresh NUL-terminated `Vec<u8>` for any VOIDP argument. That kept strlen-style read paths safe (PR #337's fix) but quietly broke every C function that *writes* into its caller's buffer — `glGenTextures(1, buf)`, `glReadPixels(...)`, `memcpy(dest, src, n)`, … — because the writes landed in the throw-away copy and the original Ruby String stayed unchanged. Visible symptom in quake: every texture upload bound to id 0, world rendered wrong.

Fix: hand C the String's actual backing buffer. To stay strlen-safe we mutate the buffer to write a NUL into spare capacity (reserving one byte if needed); this is invisible to Ruby (`as_bytes` / `len` / `hash` / equality unchanged) but lets read-only C code stop scanning at `len`. Writes the C function makes within `[0, len)` are now visible to subsequent Ruby reads of the same String, matching CRuby's Fiddle semantics.

### Misc
- Add `Object#singleton_method` ([`src/builtins/kernel.rs`](https://github.com/sisshiki1969/monoruby/blob/claude/ffi-type-array-struct/monoruby/src/builtins/kernel.rs)) — opengl-bindings2's load_lib calls it to alias `glu*` methods.

## Test plan

- [x] `cargo test --release --lib -p monoruby` — 1846 / 1846 pass
- [x] `cargo test --release --lib -p monoruby fiddle::` — 8 / 8 pass (covers the strlen / two-string regression from #337)
- [x] `cargo test --release --test require` — 12 / 12 pass
- [x] Manual: quake-rb (sdl2-bindings + opengl-bindings2 + sdl2-mixer) loads, opens an SDL window, uploads textures, and enters its render / event loop without errors

## Out of scope (filed separately in my notes)

- Constant lookup for `Foo::Bar` falls back to `::Bar` (Object) when `Bar` is missing under `Foo`; CRuby raises NameError. This was the *root cause* that surfaced the original `FFI::Type::Array` symptom (which silently resolved to `::Array`). The new FFI classes mask it for this code path; the underlying lookup bug is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)