### PR TITLE
core/{random,time}: add easy missing methods and accept richer args

### DIFF
--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -8,8 +8,12 @@ pub(super) fn init(globals: &mut Globals) {
     let klass = globals.define_class_under_obj("Random").id();
     globals.define_builtin_class_func_with(klass, "srand", random_srand, 0, 1, false);
     globals.define_builtin_class_func_with(klass, "rand", random_rand, 0, 1, false);
+    globals.define_builtin_class_func_with(klass, "random_number", random_rand, 0, 1, false);
     globals.define_builtin_class_func(klass, "urandom", urandom, 1);
+    globals.define_builtin_class_func(klass, "bytes", random_bytes, 1);
+    globals.define_builtin_class_func(klass, "new_seed", new_seed, 0);
     globals.define_builtin_func_with(klass, "rand", rand, 0, 1, false);
+    globals.define_builtin_func(klass, "bytes", instance_bytes, 1);
 }
 
 ///
@@ -57,19 +61,20 @@ fn random_srand(
 /// ### Random.rand
 ///
 /// - rand -> Float
-/// - [NOT SUPPORTED] rand(max) -> Integer | Float
+/// - rand(max) -> Integer | Float
 /// - [NOT SUPPORTED] rand(range) -> Integer | Float
+///
+/// Also bound as `Random.random_number`.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Random/s/rand.html]
 #[monoruby_builtin]
 fn random_rand(
     _vm: &mut Executor,
     globals: &mut Globals,
-    _lfp: Lfp,
+    lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let f = globals.random_gen();
-    Ok(Value::float(f))
+    rand_with_arg(globals, lfp.try_arg(0))
 }
 
 ///
@@ -82,42 +87,109 @@ fn random_rand(
 /// [https://docs.ruby-lang.org/ja/latest/method/Random/i/rand.html]
 #[monoruby_builtin]
 fn rand(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    if let Some(arg) = lfp.try_arg(0) {
-        if let Some(max) = arg.try_fixnum() {
-            if max <= 0 {
-                return Err(MonorubyErr::argumenterr(format!(
-                    "invalid argument - {}",
-                    max
-                )));
-            }
-            let f: f64 = globals.random_gen();
-            Ok(Value::integer((f * max as f64) as i64))
-        } else if let Some(max) = arg.try_float() {
-            if max < 0.0 {
-                return Err(MonorubyErr::argumenterr(format!(
-                    "invalid argument - {}",
-                    max
-                )));
-            }
-            let f: f64 = globals.random_gen();
-            if max == 0.0 {
-                Ok(Value::float(f))
-            } else {
-                Ok(Value::float(f * max))
-            }
-        } else if let Some(_) = arg.is_range() {
-            return Err(MonorubyErr::runtimeerr(
-                "Range argument is not supported in Random#rand",
-            ));
-        } else {
-            return Err(MonorubyErr::runtimeerr(
-                "the argument is not supported in Random#rand",
-            ));
+    rand_with_arg(globals, lfp.try_arg(0))
+}
+
+/// Shared implementation for `Random.rand`, `Random.random_number`,
+/// and `Random#rand`. monoruby's per-instance state is not yet
+/// distinct from the global PRNG, so all three currently share it.
+fn rand_with_arg(globals: &mut Globals, arg: Option<Value>) -> Result<Value> {
+    let arg = match arg {
+        Some(v) => v,
+        None => return Ok(Value::float(globals.random_gen())),
+    };
+    if let Some(max) = arg.try_fixnum() {
+        if max <= 0 {
+            return Err(MonorubyErr::argumenterr(format!(
+                "invalid argument - {}",
+                max
+            )));
         }
-    } else {
         let f: f64 = globals.random_gen();
-        Ok(Value::float(f))
+        Ok(Value::integer((f * max as f64) as i64))
+    } else if let Some(max) = arg.try_float() {
+        if max < 0.0 {
+            return Err(MonorubyErr::argumenterr(format!(
+                "invalid argument - {}",
+                max
+            )));
+        }
+        let f: f64 = globals.random_gen();
+        if max == 0.0 {
+            Ok(Value::float(f))
+        } else {
+            Ok(Value::float(f * max))
+        }
+    } else if arg.is_range().is_some() {
+        Err(MonorubyErr::runtimeerr(
+            "Range argument is not supported in Random#rand",
+        ))
+    } else {
+        Err(MonorubyErr::runtimeerr(
+            "the argument is not supported in Random#rand",
+        ))
     }
+}
+
+///
+/// ### Random.bytes
+///
+/// - bytes(size) -> String
+///
+/// Returns a binary string of `size` random bytes drawn from the
+/// global PRNG. Equivalent to monoruby's `Random.urandom` but uses
+/// the seeded global PRNG (for reproducibility under `Random.srand`)
+/// rather than the OS entropy source.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Random/s/bytes.html]
+#[monoruby_builtin]
+fn random_bytes(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    random_bytes_inner(vm, globals, lfp.arg(0))
+}
+
+///
+/// ### Random#bytes
+///
+/// - bytes(size) -> String
+///
+/// Per-instance state is not yet distinct from `Random.bytes`; both
+/// currently draw from the global PRNG.
+#[monoruby_builtin]
+fn instance_bytes(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    random_bytes_inner(vm, globals, lfp.arg(0))
+}
+
+///
+/// ### Random.new_seed
+///
+/// - new_seed -> Integer
+///
+/// Returns a fresh, non-deterministic integer suitable as a seed for
+/// `Random.new`. Drawn from OS entropy so it is unaffected by
+/// `Kernel#srand` / `Random.srand`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Random/s/new_seed.html]
+#[monoruby_builtin]
+fn new_seed(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mut buf = [0u8; 16];
+    if let Err(e) = getrandom::fill(&mut buf) {
+        return Err(MonorubyErr::runtimeerr(format!(
+            "Random.new_seed: {}",
+            e
+        )));
+    }
+    let bytes = num::BigInt::from_bytes_le(num::bigint::Sign::Plus, &buf);
+    Ok(Value::bigint(bytes))
 }
 
 ///
@@ -126,12 +198,16 @@ fn rand(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// - urandom(size) -> String
 #[monoruby_builtin]
 fn urandom(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let size = if let Some(size) = lfp.arg(0).try_fixnum() {
+    random_bytes_inner(vm, globals, lfp.arg(0))
+}
+
+fn random_bytes_inner(vm: &mut Executor, globals: &mut Globals, size_arg: Value) -> Result<Value> {
+    let size = if let Some(size) = size_arg.try_fixnum() {
         size
-    } else if let Some(size) = lfp.arg(0).try_float() {
+    } else if let Some(size) = size_arg.try_float() {
         size.round() as i64
     } else {
-        lfp.arg(0).coerce_to_int_i64(vm, globals)?
+        size_arg.coerce_to_int_i64(vm, globals)?
     };
     if size == 0 {
         return Ok(Value::bytes(vec![]));
@@ -215,6 +291,60 @@ mod tests {
         Random.srand(42)
         results = 10.times.map { Random.rand }
         results.all? { |x| x.is_a?(Float) && x >= 0.0 && x < 1.0 } && results.uniq.size == results.size
+        "#,
+        );
+        // Class-form `Random.rand(n)` honors the int max — used to be ignored.
+        run_test(
+            r#"
+        Random.srand(42)
+        a = Random.rand(100)
+        a.is_a?(Integer) && a >= 0 && a < 100
+        "#,
+        );
+    }
+
+    #[test]
+    fn random_random_number() {
+        run_test(
+            r#"
+        Random.srand(42)
+        a = Random.random_number
+        b = Random.random_number(50)
+        a.is_a?(Float) && a >= 0.0 && a < 1.0 && b.is_a?(Integer) && b >= 0 && b < 50
+        "#,
+        );
+    }
+
+    #[test]
+    fn random_class_bytes() {
+        run_test(
+            r#"
+        s = Random.bytes(8)
+        [s.is_a?(String), s.bytesize, s.encoding == Encoding::BINARY]
+        "#,
+        );
+        run_test_error("Random.bytes(-1)");
+    }
+
+    #[test]
+    fn random_instance_bytes() {
+        run_test(
+            r#"
+        s = Random.new.bytes(15)
+        [s.is_a?(String), s.bytesize]
+        "#,
+        );
+    }
+
+    #[test]
+    fn random_new_seed() {
+        // `Random.new_seed` returns an Integer (Bignum) and varies
+        // between calls.
+        run_test(
+            r#"
+        a = Random.new_seed
+        b = Random.new_seed
+        [a.is_a?(Integer), b.is_a?(Integer), a != b]
         "#,
         );
     }

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -17,10 +17,10 @@ pub(super) fn init(globals: &mut Globals) {
         &["mktime"],
         time_local,
         1,
-        7,
+        10,
         false,
     );
-    globals.define_builtin_class_funcs_with(TIME_CLASS, "gm", &["utc"], time_gm, 1, 7, false);
+    globals.define_builtin_class_funcs_with(TIME_CLASS, "gm", &["utc"], time_gm, 1, 10, false);
     globals.define_builtin_class_func(TIME_CLASS, "now", time_now, 0);
     globals.define_builtin_class_func_with(TIME_CLASS, "at", time_at, 1, 2, false);
     globals.store[TIME_CLASS].set_alloc_func(time_alloc_func);
@@ -562,70 +562,86 @@ fn time_gm(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 }
 
 fn from_args(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Option<NaiveDateTime>> {
-    let year = if let Ok(i) = i32::try_from(lfp.arg(0).coerce_to_int_i64(vm, globals)?) {
-        i
+    // Reorder args when the 10-arg C-style form is used:
+    // `Time.gm(sec, min, hour, mday, mon, year, wday, yday, isdst, tz)`.
+    // The trailing four args (wday, yday, isdst, tz) are intentionally
+    // ignored — CRuby treats them as advisory.
+    let arg_count = (0..10).filter(|i| lfp.try_arg(*i).is_some()).count();
+    let (year_arg, mon_arg, day_arg, hour_arg, min_arg, sec_arg, usec_arg) = if arg_count == 10 {
+        (
+            lfp.try_arg(5),
+            lfp.try_arg(4),
+            lfp.try_arg(3),
+            lfp.try_arg(2),
+            lfp.try_arg(1),
+            lfp.try_arg(0),
+            None,
+        )
+    } else if arg_count >= 8 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "wrong number of arguments (given {}, expected 1..7)",
+            arg_count
+        )));
     } else {
-        return Ok(None);
+        (
+            lfp.try_arg(0),
+            lfp.try_arg(1),
+            lfp.try_arg(2),
+            lfp.try_arg(3),
+            lfp.try_arg(4),
+            lfp.try_arg(5),
+            lfp.try_arg(6),
+        )
     };
-    let mon = if let Some(mon) = lfp.try_arg(1) {
-        let i = mon.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        1
+
+    let year = match year_arg {
+        Some(v) => match i32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        None => return Err(MonorubyErr::typeerr("no implicit conversion of nil into Integer")),
     };
-    let day = if let Some(day) = lfp.try_arg(2) {
-        let i = day.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        1
+    let mon = match mon_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_month_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 1,
     };
-    let hour = if let Some(hour) = lfp.try_arg(3) {
-        let i = hour.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        0
+    let day = match day_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 1,
     };
-    let min = if let Some(min) = lfp.try_arg(4) {
-        let i = min.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        0
+    let hour = match hour_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 0,
     };
-    let sec = if let Some(sec) = lfp.try_arg(5) {
-        let i = sec.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        0
+    let min = match min_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 0,
     };
-    let usec = if let Some(usec) = lfp.try_arg(6) {
-        let i = usec.coerce_to_int_i64(vm, globals)?;
-        if let Ok(i) = u32::try_from(i) {
-            i
-        } else {
-            return Ok(None);
-        }
-    } else {
-        0
+    let sec = match sec_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 0,
+    };
+    let usec = match usec_arg {
+        Some(v) if !v.is_nil() => match u32::try_from(time_arg_to_i64(vm, globals, v)?) {
+            Ok(i) => i,
+            Err(_) => return Ok(None),
+        },
+        _ => 0,
     };
     Ok(Some(NaiveDateTime::new(
         NaiveDate::from_ymd_opt(year, mon, day)
@@ -633,6 +649,52 @@ fn from_args(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Optio
         NaiveTime::from_hms_micro_opt(hour, min, sec, usec)
             .ok_or_else(|| MonorubyErr::argumenterr("argument out of range."))?,
     )))
+}
+
+/// Coerce a `Time.gm` / `Time.local` numeric argument to `i64`.
+/// Accepts Integer / Float / `to_int`-respondent objects (delegated
+/// to `coerce_to_int_i64`) as well as numeric Strings — CRuby parses
+/// `"2000"` / `"08"` as base-10 integers here. Surrounding whitespace
+/// is stripped (matching `String#to_i`).
+fn time_arg_to_i64(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<i64> {
+    if let Some(s) = v.is_str() {
+        let trimmed = s.trim();
+        return trimmed.parse::<i64>().map_err(|_| {
+            MonorubyErr::argumenterr(format!("argument out of range: {:?}", trimmed))
+        });
+    }
+    v.coerce_to_int_i64(vm, globals)
+}
+
+/// Coerce the `mon` argument to an `i64` month number. Same rules as
+/// `time_arg_to_i64` plus a short-name lookup: `"jan"`/`"Jan"` → 1,
+/// `"dec"` → 12, etc. Names that don't match still fall through to the
+/// numeric parse so `"12"` works.
+fn time_month_to_i64(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<i64> {
+    if let Some(s) = v.is_str() {
+        let trimmed = s.trim();
+        if let Some(n) = month_name_to_num(trimmed) {
+            return Ok(n);
+        }
+        return trimmed.parse::<i64>().map_err(|_| {
+            MonorubyErr::argumenterr(format!("argument out of range: {:?}", trimmed))
+        });
+    }
+    v.coerce_to_int_i64(vm, globals)
+}
+
+fn month_name_to_num(s: &str) -> Option<i64> {
+    const NAMES: [&str; 12] = [
+        "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+    ];
+    if s.len() != 3 {
+        return None;
+    }
+    let lower = s.to_ascii_lowercase();
+    NAMES
+        .iter()
+        .position(|n| *n == lower.as_str())
+        .map(|i| (i + 1) as i64)
 }
 
 fn generate_time<Tz: TimeZone>(vm: &mut Executor, globals: &mut Globals, tz: Tz, lfp: Lfp) -> Result<DateTime<Tz>> {
@@ -1242,6 +1304,34 @@ mod tests {
     #[test]
     fn time_zone() {
         run_test("Time.utc(2000).zone");
+    }
+
+    #[test]
+    fn time_gm_string_args() {
+        // String args parse as base-10 numerals, mirroring CRuby.
+        run_test(r#"Time.gm("2000", "12", "1", "5", "8", "8").inspect"#);
+        // Short month-name lookup ("jan" → 1, "Dec" → 12, …).
+        run_test(r#"Time.gm(2000, "jan").inspect"#);
+        run_test(r#"Time.gm(2000, "dec").inspect"#);
+    }
+
+    #[test]
+    fn time_gm_c_style_10_args() {
+        // 10-arg form: (sec, min, hour, mday, mon, year, wday, yday, isdst, tz).
+        // Trailing wday/yday/isdst/tz are ignored.
+        run_test(
+            r#"Time.gm(1, 15, 20, 1, 1, 2000, :ignored, :ignored, :ignored, :ignored).inspect"#,
+        );
+        // Float-form 10-arg (numeric to_int truncation).
+        run_test(
+            r#"Time.gm(1.0, 15.0, 20.0, 1.0, 1.0, 2000.0, nil, nil, false, nil).inspect"#,
+        );
+    }
+
+    #[test]
+    fn time_gm_nil_defaults() {
+        // Trailing nil month/day/etc default to 1/0.
+        run_test("Time.gm(2000, nil, nil, nil, nil, nil).inspect");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two unrelated low-cost improvements grouped together; both surfaced in ruby/spec.

### `core/random`

- **Fix `Random.rand(n)`** (class form) — it was ignoring its argument and always returning a Float. Now shares a helper with `Random#rand` and the new `Random.random_number`, so all three honour Integer / Float bounds identically.
- **Add `Random.random_number(n)`** — alias-equivalent of `Random.rand` with the same arity (0..1).
- **Add `Random.bytes(size)` and `Random#bytes(size)`** — return `size` random bytes in a binary-encoded String, drawn from the global PRNG. (Per-instance state is still shared with the global PRNG; that's a separate, larger refactor — flagged explicitly in the rustdoc.)
- **Add `Random.new_seed`** — returns a fresh 128-bit non-deterministic Integer drawn from OS entropy, suitable as a `Random.new` seed.

ruby/spec `core/random`: **87 examples, 10 failures + 45 errors → 10 failures + 28 errors (+17 wins)**. Remaining issues need either Range-as-arg support, per-instance PRNG state, or Bignum `rand(huge)` — all bigger scope.

### `core/time`

- **Extend `Time.gm` / `utc` / `local` / `mktime` arity from 1..7 to 1..10** so the C-style form `Time.gm(sec, min, hour, mday, mon, year, wday, yday, isdst, tz)` is accepted. Args 7..10 (wday/yday/isdst/tz) are read but ignored, matching CRuby's advisory treatment.
- **`from_args` now parses Strings as base-10 numerals** (`Time.gm("2000", "12", "1")` works), accepts trailing `nil`s as defaults, and recognises short month names for the `mon` argument (`"jan"`/`"Jan"` → 1, `"dec"` → 12, …). Arity 8/9 fall through to the standard "wrong number of arguments" path; arity 10 is the C-style reorder.

ruby/spec `core/time`: **525 examples, 232 failures + 100 errors → 288 failures + 40 errors**. 60 of the previous errors now run successfully through `from_args`; 56 still fail on deeper time/timezone behaviour unrelated to argument coercion. Net 4 specs flipped to passing. The conversion error → failure makes the codepath reachable, which is necessary groundwork for the larger Time fixes.

## Test plan

- [x] `cargo test --release --lib --package monoruby` (1903 passed; only the two pre-existing failures unchanged)
- [x] `cargo test --release --lib --package monoruby 'builtins::random'` (8 / 8)
- [x] `cargo test --release --lib --package monoruby 'builtins::time'` (25 / 25)
- [x] `mspec run core/random -t monoruby` (55 issues → 38 issues, +17)
- [x] `mspec run core/time -t monoruby` (332 issues → 328 issues, +4)
- [ ] Reviewer: full suite for any subtle regressions

https://claude.ai/code/session_random_time

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_