### PR TITLE
core: add to_proc fallback to generate_proc_inner so &Method works

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -6720,4 +6720,46 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn define_method_with_method_via_block_amp() {
+        // `&Method` as a block argument needs `Method#to_proc` to fire
+        // before `define_method` can install it. The bytecode for
+        // `&expr` (where `expr` isn't a Lambda / LocalVar) doesn't
+        // emit a `to_proc` call, so the runtime fallback in
+        // `Executor::generate_proc_inner` covers it. Surfaced by
+        // `core/time/fixtures/classes.rb:7`'s
+        // `define_method(:now, &Time.method(:now))` — without the
+        // fallback it raised `RuntimeError: not yet implemented:
+        // block handler unknown handler ...`.
+        run_test(
+            r#"
+            class Holder
+              class << self
+                define_method(:now, &Time.method(:now))
+              end
+            end
+            Holder.now.is_a?(Time)
+            "#,
+        );
+    }
+
+    #[test]
+    fn define_method_with_user_to_proc_via_block_amp() {
+        // Same fallback also accepts user-defined `to_proc`. The
+        // returned Proc determines the installed method body.
+        run_test(
+            r#"
+            class Coercible
+              def to_proc
+                proc { |x| x * 10 }
+              end
+            end
+            class Box
+              define_method(:scale, &Coercible.new)
+            end
+            Box.new.scale(7)
+            "#,
+        );
+    }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2013,8 +2013,8 @@ impl Executor {
 
 impl Executor {
     pub(crate) fn generate_proc(
-        &self,
-        globals: &Globals,
+        &mut self,
+        globals: &mut Globals,
         bh: BlockHandler,
         pc: BytecodePtr,
     ) -> Result<Proc> {
@@ -2024,9 +2024,20 @@ impl Executor {
     /// Build a long-lived `Proc` from a BlockHandler. The resulting
     /// Proc may outlive the current frame, so any on-stack outer lfp
     /// is moved to the heap here.
+    ///
+    /// `BlockHandler` can hold an arbitrary `Value` because the
+    /// bytecode for `&expr` (when `expr` isn't a Lambda / LocalVar)
+    /// pushes the raw expression result without a `to_proc`
+    /// conversion, and `set_frame_block` wraps it as-is. So in
+    /// addition to the proxy / Proc / Symbol fast paths, we fall
+    /// back to invoking `to_proc` on the value — covering Method
+    /// objects (`Method#to_proc` returns a Proc) and any user class
+    /// that implements `to_proc`. This mirrors `get_block_data`'s
+    /// fallback so `define_method(:m, &Time.method(:now))` and the
+    /// `&blk` proxy promotion behave consistently with `yield`.
     pub(crate) fn generate_proc_inner(
-        &self,
-        globals: &Globals,
+        &mut self,
+        globals: &mut Globals,
         cfp: Cfp,
         bh: BlockHandler,
         pc: BytecodePtr,
@@ -2043,6 +2054,15 @@ impl Executor {
             // call.
             let outer = outer.move_frame_to_heap();
             return Ok(Proc::from_outer(outer, fid, pc));
+        }
+        // `to_proc` fallback. If the value responds, use the resulting
+        // Proc; otherwise propagate the original "not yet implemented"
+        // diagnostic so unrecognised cases stay loud.
+        if let Some(result) =
+            self.invoke_method_if_exists(globals, IdentId::TO_PROC, bh.0, &[], None, None)?
+            && let Some(proc) = result.is_proc()
+        {
+            return Ok(proc);
         }
         Err(MonorubyErr::runtimeerr(format!(
             "not yet implemented: block handler {bh:?}"


### PR DESCRIPTION
## Summary

`Executor::generate_proc_inner` only accepted three BlockHandler shapes (proxy / Proc / Symbol). Anything else — most notably a `Method` value reaching the callee via the `define_method(:foo, &Time.method(:foo))` idiom — fell through to the cryptic `RuntimeError: not yet implemented: block handler unknown handler ...`.

Root cause is a **pipeline asymmetry**, not the BlockHandler design:

1. The bytecode for `&expr` (when `expr` isn't a `Lambda` / `LocalVar`) evaluates `expr` and pushes the raw result without emitting a `to_proc` call (`bytecodegen/method_call/arguments.rs:296-299`).
2. `set_frame_block` (`codegen/runtime/args.rs:67-71`) wraps that raw value with `BlockHandler::new(v)` — no conversion.
3. `Executor::get_block_data` (used for `yield`) handles this with a `to_proc` fallback at `executor.rs:1881-1885`. But `Executor::generate_proc_inner` (used by `define_method`, `Proc.new`, the `&blk` proxy promotion in JIT runtime, and 10 other callers) has no such fallback — that's the bug.

## Fix

Mirror `get_block_data`'s `to_proc` fallback in `generate_proc_inner`. Promote the signature from `&self, &Globals` to `&mut self, &mut Globals`; all 13 in-tree callers (12 builtins + JIT runtime `block_arg`) already hold `&mut`, so the cascade is a no-op.

The fallback only fires when the proxy / Proc / Symbol fast paths all miss, so existing BlockHandler shapes are untouched. If `to_proc` is undefined the original "not yet implemented" diagnostic still surfaces (now wrapped through `invoke_method_if_exists`, so missing methods become `NoMethodError` first — strictly more informative).

## Trade-offs (per discussion)

- **`to_proc` runs at callee-side rather than caller-side**: bactrace position for a `to_proc` exception lives one frame deeper than CRuby would emit. Side-effect-bearing `to_proc` implementations may fire multiple times if the callee accesses the block via both `yield` and `generate_proc`. `Method#to_proc` is pure so the practical effect is nil.
- **`define_method(:m, &method_obj)`** now installs a `to_proc`-wrapped Proc rather than a direct Method binding. CRuby's positional-arg form (`define_method(:m, method_obj)`) still uses the existing Method-direct fast path in `module.rs:1633-1657`.
- **Parallel paths**: `get_block_data` and `generate_proc_inner` now both contain the same fallback. Long-term we should extract a shared `resolve_block_target_with_to_proc` helper; deliberately deferred to keep this change minimal.

## Results

| | Before | After | Δ |
|---|---|---|---|
| `core/time` examples loaded | 525 | **770** | **+245** (six previously-unloadable spec files now load) |
| `core/time` passing | 197 | **233** | **+36 net** |
| `core/method` issues | 88 | 88 | unchanged |
| `core/module` issues | 106 | 106 | unchanged |
| `cargo test --release --lib --package monoruby` | 1920 ok | **1922 ok** | +2 unit tests, all green |

Only pre-existing failures (`string_inspect`, `symbol_inspect_unquoted`) remain in the cargo suite.

## Test plan

- [x] Original repro `class Foo; define_method(:now, &Time.method(:now)); end; Foo.new.now` works.
- [x] User-defined `to_proc` (`define_method(:scale, &Coercible.new)`) works.
- [x] `cargo test --release --lib --package monoruby 'builtins::module'` (+2 new tests, all green).
- [x] `cargo test --release --lib --package monoruby` (1922 / 1924, only pre-existing failures).
- [x] `mspec run core/time -t monoruby` (+36 net wins, no regressions among originally-passing examples).
- [x] `mspec run core/method`, `mspec run core/module` (unchanged — no regressions).
- [ ] Reviewer: full suite for any subtle regressions.

https://claude.ai/code/session_block_handler

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_