### PR TITLE
core/io: implement IO#autoclose= so File.new(fd, autoclose: false) is safe

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -881,9 +881,15 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 &format!("fd {}", fd),
             ));
         }
-        let name = format!("fd {}", fd);
+        // Scan trailing args for an options Hash and pick up `:path`
+        // (display name) and `:autoclose` (fd ownership) — required by
+        // patterns like `File.new(io.fileno, autoclose: false, path: "")`
+        // (logger/log_device.rb feature-detection code) where the caller
+        // explicitly disclaims ownership of the borrowed fd.
+        let (name, autoclose) = super::io::io_open_opts(vm, globals, lfp, 1..4, fd)?;
         // SAFETY: fd has been validated as a valid file descriptor above.
         let io_inner = IoInner::from_raw_fd(fd_i32, name);
+        io_inner.set_autoclose(autoclose);
         let mut res = Value::new_io_with_class(io_inner, FILE_CLASS);
         if let Some(bh) = lfp.block() {
             let r = vm.invoke_block_once(globals, bh, &[res]);

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -86,7 +86,7 @@ pub(super) fn init(globals: &mut Globals) {
 }
 
 #[monoruby_builtin]
-fn io_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn io_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // IO.new(fd [, mode [, opt]]) -> creates an IO object from an integer file descriptor.
     if let Some(fd) = lfp.arg(0).try_fixnum() {
         let fd_i32 = fd as i32;
@@ -99,13 +99,53 @@ fn io_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                 &format!("fd {}", fd),
             ));
         }
-        let name = format!("fd {}", fd);
+        // Pick up `:autoclose` and `:path` from the options Hash. See
+        // `io_open_opts` for the rationale.
+        let (name, autoclose) = io_open_opts(vm, globals, lfp, 1..3, fd)?;
         let io_inner = IoInner::from_raw_fd(fd_i32, name);
+        io_inner.set_autoclose(autoclose);
         return Ok(Value::new_io(io_inner));
     }
     Err(MonorubyErr::argumenterr(
         "IO.new requires an integer file descriptor",
     ))
+}
+
+/// Parse the trailing options Hash for `IO.new(fd, ...)` / `File.new(fd, ...)`,
+/// returning `(display_name, autoclose)`.
+///
+/// CRuby accepts `:path` (display name surfaced via `IO#path`) and `:autoclose`
+/// (whether the wrapping IO closes the fd on close/GC). The latter is
+/// load-bearing: `File.new(other.fileno, autoclose: false, path: ...)` (used
+/// in `logger/log_device.rb`'s feature detection and `fixup_mode`) hands a
+/// borrowed fd to a new wrapper while keeping the original IO responsible
+/// for closing it. Without honoring `:autoclose` we end up with two owners
+/// for the same fd, triggering `IO Safety violation: owned file descriptor
+/// already closed` on drop.
+pub(super) fn io_open_opts(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    range: std::ops::Range<usize>,
+    fd: i64,
+) -> Result<(String, bool)> {
+    let mut autoclose = true;
+    let mut name = format!("fd {}", fd);
+    for i in range {
+        if let Some(arg) = lfp.try_arg(i)
+            && let Some(h) = arg.try_hash_ty()
+        {
+            if let Some(v) = h.get(Value::symbol(IdentId::get_id("autoclose")), vm, globals)? {
+                autoclose = v.as_bool();
+            }
+            if let Some(v) = h.get(Value::symbol(IdentId::get_id("path")), vm, globals)?
+                && !v.is_nil()
+            {
+                name = v.coerce_to_string(vm, globals)?;
+            }
+        }
+    }
+    Ok((name, autoclose))
 }
 
 /// Allocator for `IO` and its subclasses.
@@ -1021,8 +1061,11 @@ fn io_binmode_(
 /// ### IO#autoclose=
 /// - autoclose=(bool) -> bool
 ///
-/// Tracking the autoclose flag is not currently supported; this acts as a
-/// no-op and returns the argument coerced to a Boolean.
+/// Set the autoclose flag. When `false`, the fd is NOT closed when the IO
+/// is closed or garbage-collected — the caller is then responsible for the
+/// fd's lifetime. Required by the `File.new(other.fileno, ...)` pattern
+/// (e.g. `logger/log_device.rb#fixup_mode`) where the original IO must
+/// relinquish ownership of the fd to the new wrapper.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/autoclose=3d.html]
 #[monoruby_builtin]
@@ -1032,25 +1075,28 @@ fn io_autoclose_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(Value::bool(lfp.arg(0).as_bool()))
+    let value = lfp.arg(0).as_bool();
+    lfp.self_val().as_io_inner().set_autoclose(value);
+    Ok(Value::bool(value))
 }
 
 ///
 /// ### IO#autoclose?
 /// - autoclose? -> bool
 ///
-/// Always returns `true` — monoruby's IO does not currently track the
-/// autoclose flag.
+/// Returns the current autoclose flag. Defaults to `true`; only changes via
+/// `IO#autoclose=`. Stdio / popen / closed IOs always report `true` because
+/// their fd lifetime is not owned by the IO object.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/autoclose=3f.html]
 #[monoruby_builtin]
 fn io_autoclose_(
     _vm: &mut Executor,
     _globals: &mut Globals,
-    _lfp: Lfp,
+    lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(Value::bool(true))
+    Ok(Value::bool(lfp.self_val().as_io_inner().is_autoclose()))
 }
 
 ///
@@ -2605,6 +2651,41 @@ mod tests {
               [f.binmode.equal?(f), f.binmode?, f.autoclose?, (f.autoclose = false)]
             ensure
               f.close
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_autoclose_round_trip() {
+        // The flag must actually be tracked, not silently coerced. The
+        // `File.new(other.fileno, autoclose: false)` pattern from
+        // `logger/log_device.rb` aborts with "IO Safety violation" on GC if
+        // the new wrapper still claims ownership of the borrowed fd.
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              before = f.autoclose?
+              f.autoclose = false
+              after = f.autoclose?
+              [before, after, f.autoclose?]
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_new_with_autoclose_false() {
+        // `File.new(integer_fd, autoclose: false, path: ...)` must parse the
+        // options Hash so the wrapper does not double-close the borrowed fd.
+        // This is the crash-on-GC pattern from `logger/log_device.rb`.
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              g = File.new(f.fileno, autoclose: false, path: "borrowed")
+              ac = g.autoclose?
+              g.close
+              ac
             end
             "#,
         );

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -1,6 +1,8 @@
 use std::{
+    cell::Cell,
     io::{BufRead, IsTerminal, Read, Seek, SeekFrom, Write},
-    os::fd::{AsRawFd, FromRawFd},
+    mem::ManuallyDrop,
+    os::fd::{AsRawFd, FromRawFd, IntoRawFd},
     os::unix::process::ExitStatusExt,
     rc::Rc,
 };
@@ -17,8 +19,33 @@ fn encode_wait_status(status: &std::process::ExitStatus) -> i32 {
 
 #[derive(Debug)]
 pub struct FileDescriptor {
-    reader: std::io::BufReader<std::fs::File>,
+    reader: ManuallyDrop<std::io::BufReader<std::fs::File>>,
     name: String,
+    /// CRuby's `IO#autoclose=` semantics. When `true` (the default), the
+    /// underlying fd is closed when this `FileDescriptor` is dropped. When
+    /// `false`, ownership is released via `into_raw_fd` so the fd is *not*
+    /// closed — required for the `File.new(other_io.fileno, ...)` pattern
+    /// (see `logger/log_device.rb#fixup_mode`) where the original IO is
+    /// expected to relinquish ownership of the fd to the new wrapper.
+    autoclose: Cell<bool>,
+}
+
+impl Drop for FileDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: `reader` is wrapped in `ManuallyDrop` and is only taken
+        // here, exactly once, in `Drop`. After this, `self.reader` must not
+        // be accessed.
+        let reader = unsafe { ManuallyDrop::take(&mut self.reader) };
+        if self.autoclose.get() {
+            // Normal case: dropping the `BufReader<File>` closes the fd via
+            // `OwnedFd::drop`.
+            drop(reader);
+        } else {
+            // Borrowed-fd case: release ownership without closing. Some
+            // other Ruby IO is responsible for the fd's lifetime.
+            let _fd = reader.into_inner().into_raw_fd();
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -129,8 +156,9 @@ impl IoInner {
 
     pub(super) fn file(file: std::fs::File, name: String) -> Self {
         Self::File(Rc::new(FileDescriptor {
-            reader: std::io::BufReader::new(file),
+            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
+            autoclose: Cell::new(true),
         }))
     }
 
@@ -155,8 +183,9 @@ impl IoInner {
         // SAFETY: fd is a valid file descriptor obtained from pipe().
         let file = unsafe { std::fs::File::from_raw_fd(fd) };
         Self::File(Rc::new(FileDescriptor {
-            reader: std::io::BufReader::new(file),
+            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
+            autoclose: Cell::new(true),
         }))
     }
 
@@ -217,7 +246,11 @@ impl IoInner {
             Self::Stdout => Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => Err(MonorubyErr::argumenterr("can't read from $stderr")),
             Self::File(file) => {
-                let file = &mut Rc::get_mut(file).unwrap().reader;
+                // `&mut *...reader` peels the ManuallyDrop wrapper to yield
+                // `&mut BufReader<File>`, which is needed because `Read::bytes`
+                // takes `self` by value and would otherwise try to move out of
+                // the ManuallyDrop.
+                let file = &mut *Rc::get_mut(file).unwrap().reader;
                 if let Some(length) = length {
                     let buf = match file.bytes().take(length).collect() {
                         Ok(buf) => buf,
@@ -265,7 +298,7 @@ impl IoInner {
             Self::Stdout => Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => Err(MonorubyErr::argumenterr("can't read from $stderr")),
             Self::File(file) => {
-                let file = &mut Rc::get_mut(file).unwrap().reader;
+                let file = &mut *Rc::get_mut(file).unwrap().reader;
                 let mut buf = String::new();
                 let size = file
                     .read_line(&mut buf)
@@ -352,6 +385,23 @@ impl IoInner {
         match self {
             Self::File(file) => Some(&file.name),
             _ => None,
+        }
+    }
+
+    /// Set the autoclose flag for a File IO. No-op for stdio/pipe/popen/closed
+    /// because their fd lifetime is not owned by this `IoInner`.
+    pub fn set_autoclose(&self, value: bool) {
+        if let Self::File(file) = self {
+            file.autoclose.set(value);
+        }
+    }
+
+    /// Read the autoclose flag. Always `true` for variants whose fd is owned
+    /// elsewhere (stdio inherits the process fd, popen owns its own ends).
+    pub fn is_autoclose(&self) -> bool {
+        match self {
+            Self::File(file) => file.autoclose.get(),
+            _ => true,
         }
     }
 }


### PR DESCRIPTION
## Summary

- `require \"active_record\"` aborted with \`fatal runtime error: IO Safety violation: owned file descriptor already closed\` whenever GC ran between fd reuses (reliable under \`--features gc-stress\`, intermittent in release).
- Root cause: \`IO#autoclose=\` was a no-op and \`File.new(integer_fd, ...)\` ignored the trailing options Hash, so \`logger/log_device.rb#fixup_mode\` produced two \`OwnedFd\`s for the same fd. The second drop's \`fcntl(F_GETFD)\` debug guard saw \`EBADF\` and aborted.
- Track the flag on \`FileDescriptor\` (\`Cell<bool>\`, default \`true\`), wrap \`reader\` in \`ManuallyDrop\`, and in \`Drop\` route through \`into_raw_fd\` to release ownership without closing when \`autoclose == false\`. Wire \`IO#autoclose=\` / \`IO#autoclose?\` to the real flag and parse \`:autoclose\` / \`:path\` from the options Hash in both \`IO.new(fd, ...)\` and \`File.new(fd, ...)\`.

## Failure trace (before)

\`\`\`
openat(...rails.rb...)            = 3
fcntl(3, F_GETFD)                 = 0x1     ← original OwnedFd debug-check before close
close(3)                          = 0       ← fd closed
...
fcntl(3, F_GETFD)                 = -1 EBADF ← second OwnedFd thinks it owns fd 3
fatal runtime error: IO Safety violation: owned file descriptor already closed, aborting
\`\`\`

The offender is the \`logger/log_device.rb\` autoclose dance:
\`\`\`ruby
dev.autoclose = false                                      # was a no-op in monoruby
old_dev = dev
dev = File.new(dev.fileno, mode: MODE, path: dev.path)     # silently took ownership
old_dev.close                                              # actually closed the fd
# dev is now a stale OwnedFd → aborts when GC drops it
\`\`\`

## Why \`Cell<bool>\`

\`IoInner::File\` wraps \`Rc<FileDescriptor>\`, and \`set_autoclose\` is reachable via \`&IoInner\` (e.g. from \`as_io_inner()\`), so plain \`bool\` would not compile and \`Rc::get_mut\` cannot be relied on once the Rc is shared. \`bool: Copy\` makes \`Cell\` strictly cheaper than \`RefCell\` (no dynamic borrow check, no panic risk).

## Test plan

- [x] \`cargo build --features gc-stress\` + \`require \"active_record\"\` × 3 — no abort, all \`exit 0\`
- [x] \`cargo build --release\` + \`require \"active_record\"\` — \`exit 0\`
- [x] \`cargo nextest run\` — 2566 / 2566 pass
- [x] new \`io_autoclose_round_trip\` and \`io_new_with_autoclose_false\` regression tests
- [x] existing \`io_binmode_and_autoclose\` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)