### PR TITLE
core/errno: auto-populate Errno::E* from libc, fix Errno::ENETDOWN NameError

### DIFF
--- a/monoruby/builtins/error.rb
+++ b/monoruby/builtins/error.rb
@@ -1,238 +1,50 @@
+# `Errno::E*` exception classes and their `Errno` constants are populated
+# by Rust-side `errno::init` (see monoruby/src/builtins/errno.rs), which
+# walks the host's `libc::E*` table at startup so any errno present on the
+# system (`Errno::ENETDOWN`, `Errno::EPROTOTYPE`, …) is reachable.
+# We only attach a per-class `initialize` here so `Errno::E*.new(arg)`
+# yields CRuby's "<strerror> - <arg>" message format.
 class Errno
   class ENOENT < SystemCallError
-    Errno = 2
     def initialize(msg = nil)
       super(msg ? "No such file or directory - #{msg}" : "No such file or directory")
     end
   end
 
   class EEXIST < SystemCallError
-    Errno = 17
     def initialize(msg = nil)
       super(msg ? "File exists - #{msg}" : "File exists")
     end
   end
 
   class EACCES < SystemCallError
-    Errno = 13
     def initialize(msg = nil)
       super(msg ? "Permission denied - #{msg}" : "Permission denied")
     end
   end
 
-  class EPERM < SystemCallError
-    Errno = 1
-  end
-
-  class ESRCH < SystemCallError
-    Errno = 3
-  end
-
-  class EINTR < SystemCallError
-    Errno = 4
-  end
-
-  class EIO < SystemCallError
-    Errno = 5
-  end
-
-  class ENXIO < SystemCallError
-    Errno = 6
-  end
-
-  class E2BIG < SystemCallError
-    Errno = 7
-  end
-
-  class ENOEXEC < SystemCallError
-    Errno = 8
-  end
-
-  class EBADF < SystemCallError
-    Errno = 9
-  end
-
-  class ECHILD < SystemCallError
-    Errno = 10
-  end
-
-  class EAGAIN < SystemCallError
-    Errno = 11
-  end
-
-  # EWOULDBLOCK is an alias for EAGAIN on Linux.
-  EWOULDBLOCK = EAGAIN
-
-  class ENOMEM < SystemCallError
-    Errno = 12
-  end
-
-  class EFAULT < SystemCallError
-    Errno = 14
-  end
-
-  class EBUSY < SystemCallError
-    Errno = 16
-  end
-
-  class EXDEV < SystemCallError
-    Errno = 18
-  end
-
-  class ENODEV < SystemCallError
-    Errno = 19
-  end
-
-  class ENOTDIR < SystemCallError
-    Errno = 20
-  end
-
-  class EISDIR < SystemCallError
-    Errno = 21
-  end
-
-  class EINVAL < SystemCallError
-    Errno = 22
-  end
-
-  class ENFILE < SystemCallError
-    Errno = 23
-  end
-
-  class EMFILE < SystemCallError
-    Errno = 24
-  end
-
-  class ENOTTY < SystemCallError
-    Errno = 25
-  end
-
-  class EFBIG < SystemCallError
-    Errno = 27
-  end
-
-  class ENOSPC < SystemCallError
-    Errno = 28
-  end
-
-  class ESPIPE < SystemCallError
-    Errno = 29
-  end
-
-  class EROFS < SystemCallError
-    Errno = 30
-  end
-
-  class EMLINK < SystemCallError
-    Errno = 31
-  end
-
-  class EPIPE < SystemCallError
-    Errno = 32
-  end
-
-  class EDOM < SystemCallError
-    Errno = 33
-  end
-
-  class ERANGE < SystemCallError
-    Errno = 34
-  end
-
-  class EDEADLK < SystemCallError
-    Errno = 35
-  end
-
-  class ENAMETOOLONG < SystemCallError
-    Errno = 36
-  end
-
-  class ENOLCK < SystemCallError
-    Errno = 37
-  end
-
-  class ENOSYS < SystemCallError
-    Errno = 38
-  end
-
   class ENOTEMPTY < SystemCallError
-    Errno = 39
     def initialize(msg = nil)
       super(msg ? "Directory not empty - #{msg}" : "Directory not empty")
     end
   end
 
-  class ELOOP < SystemCallError
-    Errno = 40
-  end
-
-  class EPROTO < SystemCallError
-    Errno = 71
-  end
-
-  class ENOTSUP < SystemCallError
-    Errno = 95
-  end
-
-  class EADDRINUSE < SystemCallError
-    Errno = 98
-  end
-
-  class EADDRNOTAVAIL < SystemCallError
-    Errno = 99
-  end
-
-  class ENETUNREACH < SystemCallError
-    Errno = 101
-  end
-
-  class ECONNABORTED < SystemCallError
-    Errno = 103
-  end
-
   class ECONNRESET < SystemCallError
-    Errno = 104
     def initialize(msg = nil)
       super(msg ? "Connection reset by peer - #{msg}" : "Connection reset by peer")
     end
   end
 
-  class ENOBUFS < SystemCallError
-    Errno = 105
-  end
-
-  class EISCONN < SystemCallError
-    Errno = 106
-  end
-
-  class ENOTCONN < SystemCallError
-    Errno = 107
-  end
-
   class ETIMEDOUT < SystemCallError
-    Errno = 110
     def initialize(msg = nil)
       super(msg ? "Connection timed out - #{msg}" : "Connection timed out")
     end
   end
 
   class ECONNREFUSED < SystemCallError
-    Errno = 111
     def initialize(msg = nil)
       super(msg ? "Connection refused - #{msg}" : "Connection refused")
     end
-  end
-
-  class EHOSTUNREACH < SystemCallError
-    Errno = 113
-  end
-
-  class EALREADY < SystemCallError
-    Errno = 114
-  end
-
-  class EINPROGRESS < SystemCallError
-    Errno = 115
   end
 
   class EISDIR < SystemCallError

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -6,6 +6,7 @@ mod bool_class;
 mod class;
 mod dir;
 mod encoding;
+pub(crate) mod errno;
 #[cfg(test)]
 mod encoding_tests;
 pub(crate) mod enumerator;
@@ -68,6 +69,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
 
     let kernel = kernel::init(globals);
     exception::init(globals);
+    errno::init(globals);
     numeric::init(globals);
     string::init(globals);
     array::init(globals);

--- a/monoruby/src/builtins/errno.rs
+++ b/monoruby/src/builtins/errno.rs
@@ -1,0 +1,280 @@
+use super::*;
+
+//
+// `Errno::E*` exception classes.
+//
+// CRuby builds the `Errno` module dynamically at boot from the system's
+// `<errno.h>`, so any errno present on the host (`Errno::ENETDOWN`,
+// `Errno::EPROTOTYPE`, …) is reachable. monoruby is x86_64 Linux only, so
+// we mirror that by walking `libc::E*` at startup and creating
+// `Errno::E* < SystemCallError` for each, with the matching `Errno = N`
+// constant. Aliases that share an errno number (`EWOULDBLOCK == EAGAIN`,
+// `EDEADLOCK == EDEADLK`, `EOPNOTSUPP == ENOTSUP` on Linux) are exposed as
+// constant aliases so `Errno::EWOULDBLOCK == Errno::EAGAIN` holds.
+//
+// The hand-rolled `monoruby/builtins/error.rb` previously listed only a
+// subset of these and triggered `NameError` for anything unlisted; bundler
+// 4's `fetcher/downloader.rb` references `Errno::ENETDOWN`, which crashed
+// `require "active_record"` (see issue history).
+
+/// Linux x86_64 errno → exception class name table.
+///
+/// Keep this list in sync with the canonical `Errno.constants` set CRuby
+/// produces on Linux x86_64 (entries with a non-zero `Errno` constant).
+const ERRNO_TABLE: &[(&str, i32)] = &[
+    ("EPERM", libc::EPERM),
+    ("ENOENT", libc::ENOENT),
+    ("ESRCH", libc::ESRCH),
+    ("EINTR", libc::EINTR),
+    ("EIO", libc::EIO),
+    ("ENXIO", libc::ENXIO),
+    ("E2BIG", libc::E2BIG),
+    ("ENOEXEC", libc::ENOEXEC),
+    ("EBADF", libc::EBADF),
+    ("ECHILD", libc::ECHILD),
+    ("EAGAIN", libc::EAGAIN),
+    ("ENOMEM", libc::ENOMEM),
+    ("EACCES", libc::EACCES),
+    ("EFAULT", libc::EFAULT),
+    ("ENOTBLK", libc::ENOTBLK),
+    ("EBUSY", libc::EBUSY),
+    ("EEXIST", libc::EEXIST),
+    ("EXDEV", libc::EXDEV),
+    ("ENODEV", libc::ENODEV),
+    ("ENOTDIR", libc::ENOTDIR),
+    ("EISDIR", libc::EISDIR),
+    ("EINVAL", libc::EINVAL),
+    ("ENFILE", libc::ENFILE),
+    ("EMFILE", libc::EMFILE),
+    ("ENOTTY", libc::ENOTTY),
+    ("ETXTBSY", libc::ETXTBSY),
+    ("EFBIG", libc::EFBIG),
+    ("ENOSPC", libc::ENOSPC),
+    ("ESPIPE", libc::ESPIPE),
+    ("EROFS", libc::EROFS),
+    ("EMLINK", libc::EMLINK),
+    ("EPIPE", libc::EPIPE),
+    ("EDOM", libc::EDOM),
+    ("ERANGE", libc::ERANGE),
+    ("EDEADLK", libc::EDEADLK),
+    ("ENAMETOOLONG", libc::ENAMETOOLONG),
+    ("ENOLCK", libc::ENOLCK),
+    ("ENOSYS", libc::ENOSYS),
+    ("ENOTEMPTY", libc::ENOTEMPTY),
+    ("ELOOP", libc::ELOOP),
+    ("ENOMSG", libc::ENOMSG),
+    ("EIDRM", libc::EIDRM),
+    ("ECHRNG", libc::ECHRNG),
+    ("EL2NSYNC", libc::EL2NSYNC),
+    ("EL3HLT", libc::EL3HLT),
+    ("EL3RST", libc::EL3RST),
+    ("ELNRNG", libc::ELNRNG),
+    ("EUNATCH", libc::EUNATCH),
+    ("ENOCSI", libc::ENOCSI),
+    ("EL2HLT", libc::EL2HLT),
+    ("EBADE", libc::EBADE),
+    ("EBADR", libc::EBADR),
+    ("EXFULL", libc::EXFULL),
+    ("ENOANO", libc::ENOANO),
+    ("EBADRQC", libc::EBADRQC),
+    ("EBADSLT", libc::EBADSLT),
+    ("EBFONT", libc::EBFONT),
+    ("ENOSTR", libc::ENOSTR),
+    ("ENODATA", libc::ENODATA),
+    ("ETIME", libc::ETIME),
+    ("ENOSR", libc::ENOSR),
+    ("ENONET", libc::ENONET),
+    ("ENOPKG", libc::ENOPKG),
+    ("EREMOTE", libc::EREMOTE),
+    ("ENOLINK", libc::ENOLINK),
+    ("EADV", libc::EADV),
+    ("ESRMNT", libc::ESRMNT),
+    ("ECOMM", libc::ECOMM),
+    ("EPROTO", libc::EPROTO),
+    ("EMULTIHOP", libc::EMULTIHOP),
+    ("EDOTDOT", libc::EDOTDOT),
+    ("EBADMSG", libc::EBADMSG),
+    ("EOVERFLOW", libc::EOVERFLOW),
+    ("ENOTUNIQ", libc::ENOTUNIQ),
+    ("EBADFD", libc::EBADFD),
+    ("EREMCHG", libc::EREMCHG),
+    ("ELIBACC", libc::ELIBACC),
+    ("ELIBBAD", libc::ELIBBAD),
+    ("ELIBSCN", libc::ELIBSCN),
+    ("ELIBMAX", libc::ELIBMAX),
+    ("ELIBEXEC", libc::ELIBEXEC),
+    ("EILSEQ", libc::EILSEQ),
+    ("ERESTART", libc::ERESTART),
+    ("ESTRPIPE", libc::ESTRPIPE),
+    ("EUSERS", libc::EUSERS),
+    ("ENOTSOCK", libc::ENOTSOCK),
+    ("EDESTADDRREQ", libc::EDESTADDRREQ),
+    ("EMSGSIZE", libc::EMSGSIZE),
+    ("EPROTOTYPE", libc::EPROTOTYPE),
+    ("ENOPROTOOPT", libc::ENOPROTOOPT),
+    ("EPROTONOSUPPORT", libc::EPROTONOSUPPORT),
+    ("ESOCKTNOSUPPORT", libc::ESOCKTNOSUPPORT),
+    ("ENOTSUP", libc::ENOTSUP),
+    ("EPFNOSUPPORT", libc::EPFNOSUPPORT),
+    ("EAFNOSUPPORT", libc::EAFNOSUPPORT),
+    ("EADDRINUSE", libc::EADDRINUSE),
+    ("EADDRNOTAVAIL", libc::EADDRNOTAVAIL),
+    ("ENETDOWN", libc::ENETDOWN),
+    ("ENETUNREACH", libc::ENETUNREACH),
+    ("ENETRESET", libc::ENETRESET),
+    ("ECONNABORTED", libc::ECONNABORTED),
+    ("ECONNRESET", libc::ECONNRESET),
+    ("ENOBUFS", libc::ENOBUFS),
+    ("EISCONN", libc::EISCONN),
+    ("ENOTCONN", libc::ENOTCONN),
+    ("ESHUTDOWN", libc::ESHUTDOWN),
+    ("ETOOMANYREFS", libc::ETOOMANYREFS),
+    ("ETIMEDOUT", libc::ETIMEDOUT),
+    ("ECONNREFUSED", libc::ECONNREFUSED),
+    ("EHOSTDOWN", libc::EHOSTDOWN),
+    ("EHOSTUNREACH", libc::EHOSTUNREACH),
+    ("EALREADY", libc::EALREADY),
+    ("EINPROGRESS", libc::EINPROGRESS),
+    ("ESTALE", libc::ESTALE),
+    ("EUCLEAN", libc::EUCLEAN),
+    ("ENOTNAM", libc::ENOTNAM),
+    ("ENAVAIL", libc::ENAVAIL),
+    ("EISNAM", libc::EISNAM),
+    ("EREMOTEIO", libc::EREMOTEIO),
+    ("EDQUOT", libc::EDQUOT),
+    ("ENOMEDIUM", libc::ENOMEDIUM),
+    ("EMEDIUMTYPE", libc::EMEDIUMTYPE),
+    ("ECANCELED", libc::ECANCELED),
+    ("ENOKEY", libc::ENOKEY),
+    ("EKEYEXPIRED", libc::EKEYEXPIRED),
+    ("EKEYREVOKED", libc::EKEYREVOKED),
+    ("EKEYREJECTED", libc::EKEYREJECTED),
+    ("EOWNERDEAD", libc::EOWNERDEAD),
+    ("ENOTRECOVERABLE", libc::ENOTRECOVERABLE),
+    ("ERFKILL", libc::ERFKILL),
+    ("EHWPOISON", libc::EHWPOISON),
+];
+
+/// Constant aliases (alias_name → canonical_name): on Linux these errno
+/// numbers collide, and CRuby exposes both names as the same class object.
+const ERRNO_ALIASES: &[(&str, &str)] = &[
+    ("EWOULDBLOCK", "EAGAIN"),
+    ("EDEADLOCK", "EDEADLK"),
+    ("EOPNOTSUPP", "ENOTSUP"),
+];
+
+pub(super) fn init(globals: &mut Globals) {
+    let object = globals.object_class();
+    let syscall_err = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("SystemCallError"))
+        .expect("SystemCallError must be defined before errno::init");
+    let syscall_err_module = syscall_err.expect_class(globals).unwrap();
+
+    // `Errno` is a plain class containing the per-errno exception classes,
+    // matching CRuby (which exposes it as a module — we use a class here for
+    // continuity with the existing `monoruby/builtins/error.rb`, which the
+    // Ruby side reopens after this).
+    let errno = globals.define_class("Errno", object, OBJECT_CLASS);
+    let errno_id = errno.id();
+
+    for (name, num) in ERRNO_TABLE {
+        let cls = globals.define_class(name, syscall_err_module, errno_id);
+        globals.set_constant_by_str(cls.id(), "Errno", Value::integer(*num as i64));
+    }
+    for (alias, canonical) in ERRNO_ALIASES {
+        let target = globals
+            .store
+            .get_constant_noautoload(errno_id, IdentId::get_id(canonical))
+            .unwrap_or_else(|| panic!("Errno alias target {canonical} not defined"));
+        globals.set_constant_by_str(errno_id, alias, target);
+    }
+}
+
+/// Look up the canonical Ruby `Errno` class name (e.g. `"ENETDOWN"`) for a
+/// raw OS errno number. Returns `None` for unknown values.
+pub(crate) fn errno_to_name(errno: i32) -> Option<&'static str> {
+    ERRNO_TABLE
+        .iter()
+        .find_map(|(name, n)| if *n == errno { Some(*name) } else { None })
+}
+
+/// Get the system's `strerror` text for an errno number. Falls back to
+/// `"Unknown error <N>"` if `strerror` returns NULL.
+///
+/// Single-threaded use only: monoruby's runtime is single-threaded so the
+/// non-`_r` form is safe; the returned string is copied immediately.
+pub(crate) fn strerror(errno: i32) -> String {
+    // SAFETY: `libc::strerror` returns a pointer to a static or
+    // thread-local buffer that's valid until the next `strerror` call on
+    // the same thread; we copy it out via `to_string_lossy` before
+    // returning. monoruby is single-threaded so there are no cross-thread
+    // races on the buffer.
+    unsafe {
+        let ptr = libc::strerror(errno);
+        if ptr.is_null() {
+            format!("Unknown error {errno}")
+        } else {
+            std::ffi::CStr::from_ptr(ptr)
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn errno_classes_dynamically_registered() {
+        // bundler 4's `fetcher/downloader.rb` references `Errno::ENETDOWN`
+        // (and friends). They must resolve and carry the right `Errno`
+        // constant, with the canonical Linux x86_64 numbers.
+        run_test(
+            r#"
+            [
+              Errno::ENETDOWN.ancestors.include?(SystemCallError),
+              Errno::ENETDOWN::Errno,           # 100
+              Errno::EPROTOTYPE::Errno,         # 91
+              Errno::EAFNOSUPPORT::Errno,       # 97
+              Errno::EHOSTDOWN::Errno,          # 112
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn errno_aliases_share_class() {
+        // CRuby exposes `EWOULDBLOCK == EAGAIN` etc. as the same class
+        // object; they must be `equal?`, not just `==`, so existence-of-
+        // class checks (`HTTP_RETRYABLE_ERRORS.include?`) work right.
+        run_test(
+            r#"
+            [
+              Errno::EWOULDBLOCK.equal?(Errno::EAGAIN),
+              Errno::EDEADLOCK.equal?(Errno::EDEADLK),
+              Errno::EOPNOTSUPP.equal?(Errno::ENOTSUP),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn errno_message_format() {
+        // `Errno::E*.new(arg)` should yield CRuby's "<strerror> - <arg>"
+        // shape. The descriptive prefix comes from the per-class
+        // `initialize` overrides in `monoruby/builtins/error.rb` (which
+        // mirrors CRuby's hard-coded strings, not the host's strerror,
+        // for portability of test output).
+        run_test(
+            r#"
+            [
+              Errno::ENOENT.new("foo").message,
+              Errno::EACCES.new("bar").message,
+              Errno::EEXIST.new.message,
+            ]
+            "#,
+        );
+    }
+}

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -923,73 +923,20 @@ impl MonorubyErrKind {
     }
 }
 
-/// Return a human-readable description for an `std::io::Error`, matching CRuby's Errno messages.
-pub(crate) fn errno_description(err: &std::io::Error) -> &'static str {
+/// Return a human-readable description for an `std::io::Error`, matching
+/// CRuby's `Errno` messages (sourced from `strerror`). Returns
+/// `"Unknown error"` for non-OS errors.
+pub(crate) fn errno_description(err: &std::io::Error) -> String {
     match err.raw_os_error() {
-        Some(1) => "Operation not permitted",
-        Some(2) => "No such file or directory",
-        Some(5) => "Input/output error",
-        Some(9) => "Bad file descriptor",
-        Some(12) => "Cannot allocate memory",
-        Some(13) => "Permission denied",
-        Some(17) => "File exists",
-        Some(20) => "Not a directory",
-        Some(21) => "Is a directory",
-        Some(22) => "Invalid argument",
-        Some(28) => "No space left on device",
-        Some(30) => "Read-only file system",
-        Some(32) => "Broken pipe",
-        Some(36) => "File name too long",
-        Some(39) => "Directory not empty",
-        _ => "Unknown error",
+        Some(errno) => crate::builtins::errno::strerror(errno),
+        None => "Unknown error".to_string(),
     }
 }
 
-/// Map a raw OS errno number to the corresponding Ruby Errno class name.
-///
-/// Returns `None` for unknown errno values.
+/// Map a raw OS errno number to the corresponding Ruby `Errno::E*` class
+/// name. Delegates to the canonical table populated by `errno::init`.
 fn errno_to_name(errno: i32) -> Option<&'static str> {
-    match errno {
-        1 => Some("EPERM"),
-        2 => Some("ENOENT"),
-        3 => Some("ESRCH"),
-        4 => Some("EINTR"),
-        5 => Some("EIO"),
-        6 => Some("ENXIO"),
-        7 => Some("E2BIG"),
-        8 => Some("ENOEXEC"),
-        9 => Some("EBADF"),
-        10 => Some("ECHILD"),
-        11 => Some("EAGAIN"),
-        12 => Some("ENOMEM"),
-        13 => Some("EACCES"),
-        14 => Some("EFAULT"),
-        16 => Some("EBUSY"),
-        17 => Some("EEXIST"),
-        18 => Some("EXDEV"),
-        19 => Some("ENODEV"),
-        20 => Some("ENOTDIR"),
-        21 => Some("EISDIR"),
-        22 => Some("EINVAL"),
-        23 => Some("ENFILE"),
-        24 => Some("EMFILE"),
-        25 => Some("ENOTTY"),
-        27 => Some("EFBIG"),
-        28 => Some("ENOSPC"),
-        29 => Some("ESPIPE"),
-        30 => Some("EROFS"),
-        31 => Some("EMLINK"),
-        32 => Some("EPIPE"),
-        33 => Some("EDOM"),
-        34 => Some("ERANGE"),
-        35 => Some("EDEADLK"),
-        36 => Some("ENAMETOOLONG"),
-        37 => Some("ENOLCK"),
-        38 => Some("ENOSYS"),
-        39 => Some("ENOTEMPTY"),
-        40 => Some("ELOOP"),
-        _ => None,
-    }
+    crate::builtins::errno::errno_to_name(errno)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- \`require \"active_record\"\` (and any path that loads bundler 4) crashed with \`uninitialized constant Errno::ENETDOWN (NameError)\` from \`bundler/fetcher/downloader.rb:9\` because the previous \`Errno\` table was hand-rolled in \`monoruby/builtins/error.rb\` and only listed ~40 errno classes.
- Replace the hand-curated list with a libc-backed table: \`monoruby/src/builtins/errno.rs\` registers \`class Errno::E* < SystemCallError\` plus the matching \`Errno = N\` constant for every \`libc::E*\` on Linux x86_64, and exposes constant aliases for collisions (\`EWOULDBLOCK == EAGAIN\`, \`EDEADLOCK == EDEADLK\`, \`EOPNOTSUPP == ENOTSUP\`).
- Mirror CRuby's behaviour: any errno present on the host is now reachable as \`Errno::E*\`. Removes 3-way drift between \`error.rb\`, \`errno_to_name\`, and \`errno_description\`.

## Failure trace (before)

\`\`\`
/.../bundler-4.0.0/lib/bundler/fetcher/downloader.rb:9:in 'Downloader':
  uninitialized constant Errno::ENETDOWN (NameError)
        Errno::ENETDOWN,
        ^^^^^^^^^^^^^^^
\`\`\`

## What changed

- **\`monoruby/src/builtins/errno.rs\` (new)** — \`ERRNO_TABLE\` (libc::E* → name), \`ERRNO_ALIASES\`, \`init(globals)\` that builds the classes and constants at boot, plus \`errno_to_name\` / \`strerror\` helpers.
- **\`monoruby/src/builtins.rs\`** — declare the module and call \`errno::init\` right after \`exception::init\` (so \`SystemCallError\` exists).
- **\`monoruby/src/globals/error.rs\`** — \`errno_to_name\` and \`errno_description\` delegate to the new module instead of carrying their own truncated tables. \`errno_description\` now returns \`String\` (sourced from \`libc::strerror\`) instead of a hand-typed \`&'static str\`.
- **\`monoruby/builtins/error.rb\`** — drop the hand-rolled class declarations and \`Errno = N\` assignments; keep only the per-class \`initialize\` overrides that produce CRuby-shaped \`\"<desc> - <arg>\"\` messages. Ruby reopens the classes Rust created, so the overrides still attach to the right objects.

## Test plan

- [x] \`/.../monoruby -e 'p Errno::ENETDOWN; p Errno::ENETDOWN::Errno'\` → \`Errno::ENETDOWN\` / \`100\`
- [x] \`/.../monoruby -e 'require \"active_record\"; p :ok'\` → \`:ok\`
- [x] \`Errno::EWOULDBLOCK.equal?(Errno::EAGAIN)\` and the other two aliases are true
- [x] \`Errno::ENOENT.new(\"foo\").message\` still returns \`\"No such file or directory - foo\"\` (initialize override preserved)
- [x] \`cargo nextest run\` — 2568 / 2568 pass on master base
- [x] new \`errno_classes_dynamically_registered\`, \`errno_aliases_share_class\`, \`errno_message_format\` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)