### PR TITLE
core/range: Range#size, ==/eql?/hash, frozen, init checks, ===→Object (~43 spec wins)

### DIFF
--- a/monoruby/builtins/comparable.rb
+++ b/monoruby/builtins/comparable.rb
@@ -72,9 +72,13 @@ module Comparable
   def clamp(min_val = nil, max_val = nil)
     if min_val.is_a?(Range)
       range = min_val
-      min_val = range.first
-      max_val = range.last
-      # Exclude end not supported for clamp with range that has exclude_end
+      # Use `#begin` / `#end` (raw endpoint accessors) rather than
+      # `#first` / `#last`. The latter raise RangeError on
+      # beginless / endless ranges in Ruby 3.x+, but `clamp` is
+      # supposed to interpret a missing endpoint as "no bound on
+      # that side", matching CRuby's C-level implementation.
+      min_val = range.begin
+      max_val = range.end
       if max_val && range.exclude_end?
         raise ArgumentError, "cannot clamp with an exclusive range"
       end

--- a/monoruby/builtins/range.rb
+++ b/monoruby/builtins/range.rb
@@ -2,10 +2,22 @@ class Range
   include Enumerable
   
   def each
-    return self.to_enum(:each) unless block_given?
+    return self.to_enum(:each) { size rescue nil } unless block_given?
     i = self.begin
     raise TypeError, "can't iterate from NilClass" if i.nil?
     e = self.end
+    # CRuby probes `start <=> end` once before iterating non-numeric
+    # ranges so mocks that expect a single `<=>` call see it. Skip for
+    # endless or numeric (Integer/Float) starts where downstream paths
+    # already compare.
+    if !e.nil? && !i.is_a?(Numeric)
+      (i <=> e) rescue nil
+    end
+    # Reject elements that have no `succ`, even if the range is empty —
+    # CRuby validates this up front.
+    unless i.respond_to?(:succ)
+      raise TypeError, "can't iterate from #{i.class}"
+    end
     excl = self.exclude_end?
     if e.nil?
       loop do
@@ -13,13 +25,18 @@ class Range
         i = i.succ
       end
     else
-      # For String ranges, stop once succ extends past the end string's
-      # length -- monoruby's byte-wise #<=> keeps reporting -1 forever
-      # while CRuby's String#upto stops at the same-size boundary.
-      string_mode = i.is_a?(String) && e.is_a?(String)
-      end_len = e.length if string_mode
+      # For String / Symbol ranges, stop once succ extends past the end
+      # element's length — `:Z.succ == :AA` would otherwise loop past
+      # `:z` indefinitely. CRuby's String#upto applies the same
+      # same-length stopping rule.
+      seq_mode = (i.is_a?(String) && e.is_a?(String)) ||
+                 (i.is_a?(Symbol) && e.is_a?(Symbol))
+      end_len = (e.is_a?(Symbol) ? e.to_s.length : e.length) if seq_mode
       loop do
-        break if string_mode && i.length > end_len
+        if seq_mode
+          cur_len = i.is_a?(Symbol) ? i.to_s.length : i.length
+          break if cur_len > end_len
+        end
         c = (i <=> e)
         break if c.nil?
         if excl
@@ -721,10 +738,102 @@ class Range
 
   public
 
-  def to_set(klass = Set, *args, &block)
+  # Private initializer. The actual Range value is built by the Rust
+  # `Range.new` constructor (or by literal/marshal); this stub exists
+  # so spec hooks like `Range.allocate.send(:initialize, …)` see a
+  # method and to enforce CRuby's argument count, frozen-receiver, and
+  # comparability checks. We don't mutate the underlying RangeInner
+  # here — `Range.new` already populates it.
+  private def initialize(*args)
+    raise FrozenError, "can't modify frozen Range: #{inspect}" if frozen?
+    if args.length < 2 || args.length > 3
+      raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 2..3)"
+    end
+    a, b = args[0], args[1]
+    unless a.nil? || b.nil?
+      cmp = (a <=> b) rescue nil
+      raise ArgumentError, "bad value for range" if cmp.nil?
+    end
+    nil
+  end
+
+  # Override the Rust `to_a` so endpoints that lack a fast path (e.g.
+  # Symbol ranges, Float ranges, beginless) get routed through `each`,
+  # producing the proper TypeError / RangeError instead of the bare
+  # "not supported" runtime error.
+  def to_a
+    raise RangeError, "cannot convert endless range to an array" if self.end.nil?
+    res = []
+    each { |x| res << x }
+    res
+  end
+  alias entries to_a
+
+  def ==(other)
+    return false unless other.is_a?(Range)
+    return false unless self.exclude_end? == other.exclude_end?
+    self.begin == other.begin && self.end == other.end
+  end
+
+  def eql?(other)
+    return false unless other.is_a?(Range)
+    return false unless self.exclude_end? == other.exclude_end?
+    self.begin.eql?(other.begin) && self.end.eql?(other.end)
+  end
+
+  def hash
+    [self.begin, self.end, self.exclude_end?].hash
+  end
+
+  def to_set(*args, &block)
     if self.end.nil?
       raise RangeError, "cannot convert endless range to a set"
     end
-    klass.new(self, *args, &block)
+    if args.empty? && block.nil?
+      ::Set.new(self)
+    else
+      # Ruby 4.0 deprecates passing arguments to Enumerable#to_set; emit
+      # the same warning so callers see the migration notice. The first
+      # positional argument is still treated as the set class.
+      Kernel.warn("warning: passing arguments to Enumerable#to_set is deprecated")
+      klass = args.shift || ::Set
+      klass.new(self, *args, &block)
+    end
+  end
+
+  # Ruby 3.4 semantics: only Integer-bounded ranges (and Integer..±Infinity)
+  # are iterable; anything else either raises TypeError or returns nil.
+  def size
+    b = self.begin
+    e = self.end
+    excl = self.exclude_end?
+
+    raise TypeError, "can't iterate from NilClass" if b.nil?
+    raise TypeError, "can't iterate from Float" if b.is_a?(Float)
+
+    if e.nil?
+      return Float::INFINITY if b.is_a?(Integer)
+      return nil if b.respond_to?(:succ)
+      raise TypeError, "can't iterate from #{b.class}"
+    end
+
+    if b.is_a?(Integer)
+      if e.is_a?(Integer)
+        diff = e - b
+        return 0 if diff < 0
+        return excl ? diff : diff + 1
+      end
+      if e.is_a?(Float)
+        if e.infinite?
+          return e > 0 ? Float::INFINITY : 0
+        end
+        raise TypeError, "can't iterate from Float"
+      end
+      return nil if e.respond_to?(:succ)
+      raise TypeError, "can't iterate from #{e.class}"
+    end
+
+    return nil if b.respond_to?(:succ)
+    raise TypeError, "can't iterate from #{b.class}"
   end
 end

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -18,7 +18,11 @@ pub(super) fn init(globals: &mut Globals) {
     );
     globals.define_builtin_func(BASIC_OBJECT_CLASS, "==", eq, 1);
     globals.define_builtin_func(BASIC_OBJECT_CLASS, "equal?", eq, 1);
-    globals.define_builtin_func(BASIC_OBJECT_CLASS, "===", case_eq, 1);
+    // CRuby defines `===` on Kernel/Object, NOT on BasicObject. Keeping
+    // it on BasicObject would trap `===` for BasicObject subclasses (like
+    // mspec's `SpecPositiveOperatorMatcher`) instead of routing through
+    // `method_missing`, breaking the `actual.should === expected` idiom.
+    globals.define_builtin_func(OBJECT_CLASS, "===", case_eq, 1);
     globals.define_builtin_inline_func(BASIC_OBJECT_CLASS, "!", not_, Box::new(object_not), 0);
     globals.define_builtin_func(BASIC_OBJECT_CLASS, "!=", ne, 1);
     globals.define_builtin_funcs_with_effect(

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -40,9 +40,30 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Range/s/new.html]
 #[monoruby_builtin]
-fn range_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn range_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let exclude_end = lfp.try_arg(2).map(|v| v.as_bool()).unwrap_or(false);
-    globals.generate_range(lfp.arg(0), lfp.arg(1), exclude_end)
+    let class_id = lfp.self_val().as_class_id();
+    let start = lfp.arg(0);
+    let end = lfp.arg(1);
+    // Explicit `Range.new` is strict: CRuby probes `start <=> end` once,
+    // propagates any raised exception, and turns a `nil` result into
+    // `ArgumentError`. We do the same. Range *literals* are more lax
+    // (see `gen_range`) so monoruby's incomplete user-type comparators
+    // don't reject hand-written ranges.
+    if !start.is_nil() && !end.is_nil() {
+        let cmp = vm.compare_values_inner(globals, start, end)?;
+        if cmp.is_none() {
+            return Err(MonorubyErr::argumenterr("bad value for range"));
+        }
+    }
+    if class_id != RANGE_CLASS {
+        // Subclass of Range: build directly with the subclass's class id
+        // and leave it unfrozen (CRuby only freezes direct Range
+        // instances).
+        Ok(Value::range_with_class(start, end, exclude_end, class_id))
+    } else {
+        Ok(Value::range(start, end, exclude_end))
+    }
 }
 
 /// Allocator for `Range` and its subclasses.
@@ -145,6 +166,11 @@ fn range_end(
 fn first(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let range = self_.as_range();
+    if range.start().is_nil() {
+        return Err(MonorubyErr::rangeerr(
+            "cannot get the first element of beginless range",
+        ));
+    }
     if let Some(n_val) = lfp.try_arg(0) {
         let n = n_val.coerce_to_int_i64(vm, globals)?;
         if n < 0 {
@@ -173,6 +199,11 @@ fn first(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 fn last(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let range = self_.as_range();
+    if range.end().is_nil() {
+        return Err(MonorubyErr::rangeerr(
+            "cannot get the last element of endless range",
+        ));
+    }
     if let Some(n_val) = lfp.try_arg(0) {
         let n = n_val.coerce_to_int_i64(vm, globals)?;
         if n < 0 {
@@ -793,12 +824,7 @@ fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         if range.exclude_end() {
             // For exclusive ranges, need integer end or string end
             if let Some(i) = end.try_fixnum() {
-                // For beginless exclusive integer ranges, raise TypeError
-                if start.is_nil() {
-                    return Err(MonorubyErr::typeerr(
-                        "cannot exclude end value with non Integer begin value",
-                    ));
-                }
+                // Ruby 4.0+: beginless exclusive Integer ranges return end - 1.
                 return Ok(Value::integer(i - 1));
             } else if let RV::BigInt(b) = end.unpack() {
                 return Ok(Value::bigint(b - 1));

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -273,13 +273,28 @@ pub(super) extern "C" fn gen_range(
     globals: &mut Globals,
     exclude_end: bool,
 ) -> Option<Value> {
-    match globals.generate_range(start, end, exclude_end) {
-        Ok(val) => Some(val),
-        Err(err) => {
-            vm.set_error(err);
-            None
+    // Validate with `<=>` only when the endpoints are different classes
+    // — same-class endpoints are always allowed (matches CRuby for
+    // user-defined types, and avoids false positives when monoruby's
+    // own `<=>` is incomplete e.g. on Time). Different-class endpoints
+    // like `9155.."s"` still need to be rejected (`<=>` returns nil).
+    if !start.is_nil()
+        && !end.is_nil()
+        && start.real_class(&globals.store).id() != end.real_class(&globals.store).id()
+    {
+        match vm.compare_values_inner(globals, start, end) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                vm.set_error(MonorubyErr::argumenterr("bad value for range"));
+                return None;
+            }
+            Err(err) => {
+                vm.set_error(err);
+                return None;
+            }
         }
     }
+    Some(Value::range(start, end, exclude_end))
 }
 
 pub(super) extern "C" fn concatenate_string(

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1047,7 +1047,10 @@ impl Value {
     }
 
     pub fn range(start: Value, end: Value, exclude_end: bool) -> Self {
-        RValue::new_range(start, end, exclude_end).pack()
+        // Range objects are frozen since Ruby 3.0.
+        let mut v = RValue::new_range(start, end, exclude_end).pack();
+        v.set_frozen();
+        v
     }
 
     pub fn range_with_class(
@@ -1056,6 +1059,10 @@ impl Value {
         exclude_end: bool,
         class_id: ClassId,
     ) -> Self {
+        // Not frozen: this constructor is used by `Range.allocate` and by
+        // the allocator for `Range` subclasses. CRuby only freezes direct
+        // `Range` instances (literal, `Range.new`, marshal load) — those
+        // go through `Value::range`.
         RValue::new_range_with_class(start, end, exclude_end, class_id).pack()
     }
 


### PR DESCRIPTION
## Summary

A batch of `core/range` ruby/spec wins. Touches a handful of cross-cutting Range pieces plus one `BasicObject` quirk that was breaking mspec matchers.

| Spec | Before | After | Δ |
|------|--------|-------|---|
| `core/range` | 37 F + 21 E | 11 F + 4 E | **−43** |
| `core/marshal` | 113 F + 308 E | 101 F + 308 E | **−12** |
| `core/array` | 812 F + 32 E | 812 F + 28 E | **−4** |
| `cargo nextest` | 2331 pass | 2331 pass | 0 |

### Range additions

- **`Range#size`** (Ruby) — Integer/Integer ranges count, `Integer..±Float::INFINITY` returns `Infinity` / `0`, non-iterable Float-bounded ranges raise `TypeError` per Ruby 3.4, non-numeric `succ`-able ranges (`'a'..'z'`, `:a..:z`) return `nil`.
- **`Range#==` / `Range#eql?` / `Range#hash`** (Ruby) — previously fell through to `BasicObject` identity, so two literal-equal ranges compared `false` and any Hash-key use was broken.
- **`Range#first` / `Range#last`** — raise `RangeError` on beginless/endless instead of returning `nil`.
- **`Range#max`** — beginless exclusive Integer ranges return `end - 1` (Ruby 4.0+) instead of raising `TypeError`.
- **`Range#each`** — probe `<=>` once on non-numeric ranges so mocks expecting a single `<=>` call see it; raise `TypeError` up front when start has no `#succ`; extend the same-length stop rule from `String` to `Symbol` so `(:A..:z).to_a` doesn't run away through `:Z` → `:AA` → ….
- **`Range#to_a`** (Ruby override) — drop the bare "not supported" runtime errors; route Symbol / Float / beginless / endless through `each` so they raise the proper `TypeError` / `RangeError`. `entries` becomes an alias.
- **`Range#initialize`** (private, Ruby) — enforce 2..3 arity, `FrozenError` on a frozen receiver, `ArgumentError` on a `nil` `<=>` result. Validates the spec contract without trying to mutate the underlying `RangeInner` (still populated by `Range.new`).
- **`Range#to_set`** — emit the Ruby 4.0 `Enumerable#to_set is deprecated` warning when called with positional arguments or a block.

### Range constructor / freezing

- `Value::range` now sets `frozen` — covers literals, marshal load, and `Range.new` on `Range` itself. `Value::range_with_class` (used by `Range.allocate` and subclass allocators) stays unfrozen, matching CRuby's "only direct `Range` instances are frozen" rule.
- `Range.new` now probes `start <=> end` and raises `ArgumentError` on `nil`/propagates exceptions, matching CRuby. Subclass `new` builds with the subclass's `class_id` and skips freezing.
- `gen_range` (literal/JIT path) validates cross-type endpoints with `<=>` so `9155.."s"` still raises `ArgumentError`, but skips the probe when both endpoints share a class — avoids false positives on monoruby's incomplete user-type comparators (e.g. `Time#<=>` currently returns `nil` for unequal times, which would otherwise reject `(t1..t2)` literals).

### `BasicObject#===` → `Object#===`

CRuby places `===` on `Kernel`/`Object`, NOT on `BasicObject`. Keeping it on `BasicObject` trapped `===` for matchers that subclass `BasicObject` (mspec's `SpecPositiveOperatorMatcher`) instead of routing through `method_missing`, which silently collapsed `obj.should === val` into `obj == val`.

## Test plan

- [x] `cargo nextest run --release -p monoruby` — 2331 / 2331 pass
- [x] `core/range` — 58 failing tests → 15 (−43)
- [x] `core/marshal`, `core/array` no regressions; small wins (Range frozen propagated to marshal)
- [x] `core/basicobject`, `core/comparable`, `core/symbol`, `core/numeric/coerce` unchanged

## Out of scope (remaining `core/range` failures, ~15)

- `Range#each` / `include?` / `member?` with `Time` endpoints — needs `Time#succ` and a working `Time#<=>` for unequal times.
- `Range#min` / `Range#max` / `Range#minmax` block forms — CRuby calls both `>` and `<` on the block result; current impl only calls one direction.
- `Range#%` returning `Enumerator::ArithmeticSequence` — needs the new class.
- `(:A..:z).to_a.size == 58` — needs CRuby-faithful `Symbol#succ` (jumps `Z` → `[` → `\` → `]` … → `z`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)