### PR TITLE
core/comparable: fix clamp(range) regression on beginless/endless ranges (#467 follow-up)

### DIFF
--- a/monoruby/builtins/comparable.rb
+++ b/monoruby/builtins/comparable.rb
@@ -72,9 +72,13 @@ module Comparable
   def clamp(min_val = nil, max_val = nil)
     if min_val.is_a?(Range)
       range = min_val
-      min_val = range.first
-      max_val = range.last
-      # Exclude end not supported for clamp with range that has exclude_end
+      # Use `#begin` / `#end` (raw endpoint accessors) rather than
+      # `#first` / `#last`. The latter raise RangeError on
+      # beginless / endless ranges in Ruby 3.x+, but `clamp` is
+      # supposed to interpret a missing endpoint as "no bound on
+      # that side", matching CRuby's C-level implementation.
+      min_val = range.begin
+      max_val = range.end
       if max_val && range.exclude_end?
         raise ArgumentError, "cannot clamp with an exclusive range"
       end


### PR DESCRIPTION
## Summary

Fix-on-top for #467: 8 errors that surfaced in `core/comparable/clamp_spec.rb` once `Range#first` / `Range#last` started raising `RangeError` on beginless / endless ranges.

## Root cause

PR #467 made `Range#first` / `Range#last` raise `RangeError` on beginless / endless ranges, which is correct CRuby behaviour. But `Comparable#clamp(range)` (Ruby implementation in `monoruby/builtins/comparable.rb`) was reading the range endpoints with those very methods:

```ruby
def clamp(min_val = nil, max_val = nil)
  if min_val.is_a?(Range)
    range = min_val
    min_val = range.first   # ← RangeError on `..5` (beginless)
    max_val = range.last    # ← RangeError on `2..` (endless)
    ...
```

So `5.clamp(2..)` and `5.clamp(..10)` blew up at the read step instead of treating the missing side as "no bound on that side".

CRuby's C-level `clamp` reads `RANGE_BEG` / `RANGE_END` directly — the raw endpoint slots that expose `nil` for missing sides and never raise. The Ruby-level mirror is `Range#begin` / `Range#end`.

## Fix

Switch `Comparable#clamp(range)` from `range.first` / `range.last` to `range.begin` / `range.end`, with a comment explaining the rationale so a future contributor doesn't "fix" it back.

## Results

| Spec | Before #467 | After #467 (regression) | After this fix |
|------|-------------|-------------------------|----------------|
| `core/comparable` | 0 F + 0 E | 0 F + **8 E** | **0 F + 0 E** |
| `core/range` | unchanged | 11 F + 4 E | 11 F + 4 E (no change) |

8 affected examples in `core/comparable/clamp_spec.rb`:

- `with endless range returns minimum value of the range parameters if less than it`
- `with endless range always returns self if greater than minimum value of the range parameters`
- `with endless range works with exclusive range`
- `with beginless range returns maximum value of the range parameters if greater than it`
- `with beginless range always returns self if less than maximum value of the range parameters`
- `with beginless range raises an Argument error if the range parameter is exclusive`
- `with beginless-and-endless range always returns self`
- `with beginless-and-endless range works with exclusive range`

All pass after this change.

## Test plan

- [x] `mspec run core/comparable -t monoruby` — 54 / 54 pass (was 46 / 54 with #467)
- [x] `mspec run core/range -t monoruby` — unchanged (11 F + 4 E, all pre-existing in #467)
- [x] `cargo test --release --lib --package monoruby comparable` — 4 / 4 pass

Note: the patch lives in the `monoruby/builtins/*.rb` Ruby-side helper directory, which `build.rs` copies to `~/.monoruby/builtins/`. Running `cargo build` (or `touch monoruby/build.rs`) is needed to refresh the installed copy after edits.

https://claude.ai/code/session_clamp_fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_