### PR TITLE
core/parser: honour `# encoding:` magic comments + \u-escape force-UTF-8 (~727 spec wins)

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1094,20 +1094,51 @@ impl<'a> BytecodeGen<'a> {
         self.emit_literal(dst, Value::complex(0, f));
     }
 
+    /// Resolve the file's `# encoding: NAME` magic comment to an
+    /// `Encoding`. Falls back to UTF-8 — Ruby 2.0+'s default source
+    /// encoding — when the source has no magic comment or the name
+    /// isn't recognised. Used by `emit_string` / `emit_bytes` and the
+    /// const-AST literal builder so every literal in this file gets
+    /// the right tag at bytecode-emission time.
+    pub(crate) fn source_encoding(&self) -> crate::value::Encoding {
+        match self.sourceinfo.source_encoding.as_deref() {
+            Some(name) => crate::value::Encoding::try_from_str(name)
+                .unwrap_or(crate::value::Encoding::Utf8),
+            None => crate::value::Encoding::Utf8,
+        }
+    }
+
     fn emit_string(&mut self, dst: BcReg, s: String) {
         // String literals become long-lived templates: `Literal`
         // dispatch `deep_copy`s the template into a fresh RValue on
         // every execution, and the clone preserves the template's
         // `cr`. Pre-classify here so each clone gets `cr` for free
         // instead of re-running classify on first use.
-        self.emit_literal(dst, Value::string_scanned(s));
+        let enc = self.source_encoding();
+        self.emit_literal(dst, Value::string_from_source_str(&s, enc));
     }
 
     fn emit_bytes(&mut self, dst: BcReg, b: Vec<u8>) {
         // `NodeKind::Bytes` comes from source literals containing `\xNN`
-        // escapes. Tag as UTF-8 so it inherits the source encoding like
-        // CRuby, rather than being forced to BINARY.
-        self.emit_literal(dst, Value::string_from_source_bytes(&b));
+        // escapes. Tag with the file's `# encoding:` magic-comment value
+        // (defaulting to UTF-8 — Ruby's default source encoding since
+        // 2.0). The bytes are passed through verbatim; if they're
+        // invalid under the declared encoding `valid_encoding?` returns
+        // false but byte-level operations still work, matching CRuby.
+        let enc = self.source_encoding();
+        self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
+    }
+
+    /// Emit a string literal whose encoding was *forced* by prism —
+    /// e.g. a `\u` escape inside a `# encoding: binary` source forces
+    /// the literal to UTF-8 in CRuby. `enc_name` is the static
+    /// override the lowerer extracted from prism's flags
+    /// (`"UTF-8"` / `"ASCII-8BIT"`); falls back to UTF-8 if monoruby
+    /// doesn't recognise the alias (shouldn't happen for these two).
+    fn emit_encoded_string(&mut self, dst: BcReg, b: Vec<u8>, enc_name: &'static str) {
+        let enc = crate::value::Encoding::try_from_str(enc_name)
+            .unwrap_or(crate::value::Encoding::Utf8);
+        self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
     }
 
     fn emit_array(&mut self, dst: BcReg, src: BcReg, len: usize, splat: Vec<usize>, loc: Loc) {

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -286,6 +286,7 @@ fn defined_str(node: &Node) -> &'static str {
         | NodeKind::Symbol(_)
         | NodeKind::String(_)
         | NodeKind::Bytes(_)
+        | NodeKind::EncodedString(..)
         | NodeKind::InterporatedString(_)
         | NodeKind::RegExp(..)
         | NodeKind::Range { .. }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -100,11 +100,12 @@ impl<'a> BytecodeGen<'a> {
             NodeKind::RImaginary(n, d) => self.emit_rimaginary(dst, &n, &d),
             NodeKind::String(s) => self.emit_string(dst, s),
             NodeKind::Bytes(b) => self.emit_bytes(dst, b),
+            NodeKind::EncodedString(b, enc) => self.emit_encoded_string(dst, b, enc),
             NodeKind::Array(nodes, false) => self.gen_array(dst, nodes, loc)?,
             NodeKind::Hash(nodes, splat) => self.gen_hash(dst, nodes, splat, loc)?,
             NodeKind::RegExp(nodes, op, false) => self.gen_regexp(dst, nodes, op, loc)?,
             NodeKind::Array(_, true) | NodeKind::Range { is_const: true, .. } => {
-                let val = Value::from_const_ast(&rhs);
+                let val = Value::from_const_ast(&rhs, self.source_encoding());
                 self.emit_literal(dst, val);
             }
             NodeKind::RegExp(nodes, op, true) => {
@@ -329,7 +330,8 @@ impl<'a> BytecodeGen<'a> {
                 | NodeKind::Imaginary(_)
                 | NodeKind::Rational(..)
                 | NodeKind::RImaginary(..)
-                | NodeKind::String(_) => return Ok(()),
+                | NodeKind::String(_)
+                | NodeKind::EncodedString(..) => return Ok(()),
                 _ => {}
             }
         }
@@ -349,6 +351,7 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::RImaginary(..)
             | NodeKind::String(_)
             | NodeKind::Bytes(_)
+            | NodeKind::EncodedString(..)
             | NodeKind::Array(..)
             | NodeKind::Hash(..)
             | NodeKind::Range { .. }

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -271,6 +271,7 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::Bool(_)
             | NodeKind::String(_)
             | NodeKind::Bytes(_)
+            | NodeKind::EncodedString(..)
             | NodeKind::Symbol(_)
             | NodeKind::Ident(_)
             | NodeKind::InstanceVar(_)

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -4038,16 +4038,43 @@ $1
     // -> the resulting `String` literal's `encoding` tag at runtime.
     //
     // These tests pin the end-to-end behaviour by running short scripts
-    // through `Globals::run` and reading back `String#encoding.to_s`.
-    // Going through the live runtime keeps the test honest: it would
-    // notice if any layer (parser, bytecodegen, value constructors) lost
-    // the encoding on the way through.
+    // through the full parse → bytecode → eval pipeline and reading back
+    // `String#encoding.to_s`. Going through the live runtime keeps the
+    // test honest: it would notice if any layer (parser, bytecodegen,
+    // value constructors) lost the encoding on the way through.
+    //
+    // We force the prism backend explicitly rather than going through
+    // `Globals::run` (which routes via `MONORUBY_PARSER`): magic-comment
+    // handling is prism-only, and `bin/test` runs the suite a second
+    // time with `MONORUBY_PARSER=ruruby` for coverage of the legacy
+    // backend — every test in this module is prism-specific by design.
+
+    /// Drive a short Ruby script through the prism backend explicitly,
+    /// returning the final `Value` and the `Globals` it ran against.
+    /// Callers inspect the value with the returned `Globals` (needed
+    /// for `Value::inspect`).
+    fn run_prism_source(source: &str) -> (crate::Globals, crate::Value) {
+        let path = std::path::Path::new("(test)");
+        let mut globals = crate::Globals::new_test();
+        let parsed = crate::parser::parse_program_with(
+            crate::parser::Backend::Prism,
+            source.to_owned(),
+            path,
+        )
+        .expect("parse_program_with(Prism)");
+        let fid = crate::bytecodegen::bytecode_compile_script(&mut globals, parsed)
+            .expect("bytecode_compile_script");
+        let mut executor = crate::executor::Executor::init(&mut globals, "(test)")
+            .expect("Executor::init");
+        executor.init_stack_limit(&mut globals);
+        let val = executor
+            .eval_toplevel(&mut globals, fid)
+            .expect("eval_toplevel");
+        (globals, val)
+    }
 
     fn run_encoding_query(source: &str) -> String {
-        let mut globals = crate::Globals::new_test();
-        let val = globals
-            .run(source.to_owned(), std::path::Path::new("(test)"))
-            .expect("script should run");
+        let (globals, val) = run_prism_source(source);
         val.inspect(&globals.store)
             .trim_matches('"')
             .to_owned()
@@ -4102,13 +4129,8 @@ $1
     /// shape of every `core/array/pack/*_spec.rb` assertion.
     #[test]
     fn magic_comment_pack_output_eq_binary_literal() {
-        let mut globals = crate::Globals::new_test();
-        let val = globals
-            .run(
-                "# encoding: binary\n[\"1\"].pack(\"B\") == \"\\x80\"\n".to_owned(),
-                std::path::Path::new("(test)"),
-            )
-            .expect("script should run");
+        let (_globals, val) =
+            run_prism_source("# encoding: binary\n[\"1\"].pack(\"B\") == \"\\x80\"\n");
         assert!(val.as_bool(), "pack output should equal binary literal");
     }
 

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -135,16 +135,28 @@ fn try_prism_inner(
     line_offset: i64,
 ) -> Result<ParseResult, MonorubyErr> {
     let path_display = path.display().to_string();
-    let source_info: SourceInfoRef = std::rc::Rc::new(ruruby_parse::SourceInfo::new_eval(
-        path,
-        code.to_owned(),
-        line_offset,
-    ));
 
     let result = match options.as_ref() {
         Some(opts) => prism::parse_with_options(code.as_bytes(), opts),
         None => prism::parse(code.as_bytes()),
     };
+
+    // Pull `# encoding: NAME` / `# coding: NAME` (also Emacs-style
+    // `# -*- coding: NAME -*-`) out of the magic comment list before
+    // we touch any string literals. Prism normalises all of these
+    // into one entry per key=value pair, so we just look for the
+    // canonical key. If both are present (rare), the first wins —
+    // matching CRuby's "first magic comment line" semantics.
+    let source_encoding: Option<String> = result
+        .magic_comments()
+        .find(|c| matches!(c.key(), b"encoding" | b"coding"))
+        .and_then(|c| std::str::from_utf8(c.value()).ok().map(str::to_owned));
+
+    let source_info: SourceInfoRef = std::rc::Rc::new(
+        ruruby_parse::SourceInfo::new_eval(path, code.to_owned(), line_offset)
+            .with_source_encoding(source_encoding),
+    );
+
     if let Some(diag) = result.errors().next() {
         let loc = location_to_loc(&diag.location());
         return Err(MonorubyErr::parse(ruruby_parse::ParseErr {
@@ -1248,6 +1260,26 @@ impl<'pr> Lowerer<'pr> {
     fn lower_string(&self, node: &StringNode<'pr>) -> Node {
         let bytes: &[u8] = node.unescaped();
         let loc = location_to_loc(&node.location());
+        // CRuby upgrades a non-UTF-8 source's literal to UTF-8 the
+        // moment it contains a `\u` escape (the bytes the escape
+        // produces are valid UTF-8, so they no longer fit the source
+        // encoding). Prism flags this via
+        // `PM_STRING_FLAGS_FORCED_UTF8_ENCODING`; surface it as the
+        // dedicated `EncodedString` variant so bytecodegen tags the
+        // literal UTF-8 regardless of the file's `# encoding:`.
+        // Likewise `forced_binary` (rare) overrides to ASCII-8BIT.
+        if node.is_forced_utf8_encoding() {
+            return Node {
+                kind: NodeKind::EncodedString(bytes.to_vec(), "UTF-8"),
+                loc,
+            };
+        }
+        if node.is_forced_binary_encoding() {
+            return Node {
+                kind: NodeKind::EncodedString(bytes.to_vec(), "ASCII-8BIT"),
+                loc,
+            };
+        }
         match std::str::from_utf8(bytes) {
             Ok(s) => Node {
                 kind: NodeKind::String(s.to_owned()),
@@ -3420,6 +3452,7 @@ fn is_constant_literal(kind: &NodeKind) -> bool {
             | NodeKind::RImaginary(_, _)
             | NodeKind::String(_)
             | NodeKind::Bytes(_)
+            | NodeKind::EncodedString(..)
             | NodeKind::Symbol(_)
     )
 }
@@ -3996,5 +4029,133 @@ $1
                 "CallNode",
             ],
         );
+    }
+
+    // ----- # encoding: / # coding: magic-comment handling -----------------
+    //
+    // Source encoding flows: prism's `magic_comments()` -> SourceInfo's
+    // `source_encoding` field -> bytecodegen's `emit_string` / `emit_bytes`
+    // -> the resulting `String` literal's `encoding` tag at runtime.
+    //
+    // These tests pin the end-to-end behaviour by running short scripts
+    // through `Globals::run` and reading back `String#encoding.to_s`.
+    // Going through the live runtime keeps the test honest: it would
+    // notice if any layer (parser, bytecodegen, value constructors) lost
+    // the encoding on the way through.
+
+    fn run_encoding_query(source: &str) -> String {
+        let mut globals = crate::Globals::new_test();
+        let val = globals
+            .run(source.to_owned(), std::path::Path::new("(test)"))
+            .expect("script should run");
+        val.inspect(&globals.store)
+            .trim_matches('"')
+            .to_owned()
+    }
+
+    /// `# encoding: binary` makes every string literal in the file
+    /// ASCII-8BIT. Without honouring the comment, `pack`-style spec
+    /// files (which all open with `# encoding: binary`) compare a
+    /// pack output (ASCII-8BIT) against a literal we'd tagged UTF-8
+    /// and the encoding-aware `String#==` returns false.
+    #[test]
+    fn magic_comment_encoding_binary_tags_literal_ascii8bit() {
+        let enc = run_encoding_query("# encoding: binary\n\"hello\".encoding.to_s\n");
+        assert_eq!(enc, "ASCII-8BIT");
+    }
+
+    /// `# coding: NAME` is the legacy form prism still emits.
+    #[test]
+    fn magic_comment_coding_alias_resolves() {
+        let enc = run_encoding_query("# coding: us-ascii\n\"abc\".encoding.to_s\n");
+        assert_eq!(enc, "US-ASCII");
+    }
+
+    /// Emacs-style `# -*- coding: NAME -*-` — prism normalises the
+    /// `-*-` decoration away and surfaces the same `coding` key.
+    #[test]
+    fn magic_comment_emacs_style_resolves() {
+        let enc = run_encoding_query("# -*- coding: shift_jis -*-\n\"abc\".encoding.to_s\n");
+        assert_eq!(enc, "Shift_JIS");
+    }
+
+    /// No magic comment -> UTF-8 (Ruby 2.0+ default source encoding).
+    #[test]
+    fn magic_comment_default_is_utf8() {
+        let enc = run_encoding_query("\"abc\".encoding.to_s\n");
+        assert_eq!(enc, "UTF-8");
+    }
+
+    /// `\xNN` byte escapes in a `# encoding: binary` source come out
+    /// of the lowerer as `NodeKind::Bytes` (their bytes don't UTF-8
+    /// decode). The bytecodegen must still tag those as ASCII-8BIT,
+    /// not silently UTF-8.
+    #[test]
+    fn magic_comment_binary_byte_literal_is_ascii8bit() {
+        let enc = run_encoding_query("# encoding: binary\n\"\\x80\".encoding.to_s\n");
+        assert_eq!(enc, "ASCII-8BIT");
+    }
+
+    /// The proximate fix for PR #462: pack output (ASCII-8BIT) and a
+    /// `# encoding: binary` literal with the same bytes must compare
+    /// equal under the encoding-aware `String#==`. This is the exact
+    /// shape of every `core/array/pack/*_spec.rb` assertion.
+    #[test]
+    fn magic_comment_pack_output_eq_binary_literal() {
+        let mut globals = crate::Globals::new_test();
+        let val = globals
+            .run(
+                "# encoding: binary\n[\"1\"].pack(\"B\") == \"\\x80\"\n".to_owned(),
+                std::path::Path::new("(test)"),
+            )
+            .expect("script should run");
+        assert!(val.as_bool(), "pack output should equal binary literal");
+    }
+
+    /// Sanity check on the parser layer in isolation: prism reports
+    /// the magic comment, and `parse_program` stashes its value on
+    /// the `SourceInfo` for downstream consumers.
+    #[test]
+    fn parse_program_extracts_source_encoding_from_magic_comment() {
+        let result = parse_program(
+            "# encoding: binary\nx = 1\n".to_owned(),
+            PathBuf::from("test.rb"),
+        )
+        .expect("parse_program");
+        assert_eq!(
+            result.source_info.source_encoding.as_deref(),
+            Some("binary")
+        );
+
+        let result =
+            parse_program("x = 1\n".to_owned(), PathBuf::from("test.rb")).expect("parse_program");
+        assert_eq!(result.source_info.source_encoding, None);
+    }
+
+    /// CRuby promotes a string literal to UTF-8 the moment it contains
+    /// a `\u` escape, even when the source file declares a non-UTF-8
+    /// encoding. Prism flags this case via
+    /// `PM_STRING_FLAGS_FORCED_UTF8_ENCODING`; the lowerer must lower
+    /// it as `EncodedString("UTF-8")` so bytecodegen tags the result
+    /// UTF-8 instead of inheriting the file's `# encoding: binary`.
+    /// Tested cases: `\u` in binary source, `\u` in shift_jis source,
+    /// and the negative — a plain ASCII literal in binary source
+    /// stays ASCII-8BIT (no spurious upgrade).
+    #[test]
+    fn magic_comment_unicode_escape_forces_utf8_in_binary_source() {
+        let enc = run_encoding_query("# encoding: binary\n\"\\u{9819}\".encoding.to_s\n");
+        assert_eq!(enc, "UTF-8");
+    }
+
+    #[test]
+    fn magic_comment_unicode_escape_forces_utf8_in_shift_jis_source() {
+        let enc = run_encoding_query("# encoding: shift_jis\n\"\\u{1234}\".encoding.to_s\n");
+        assert_eq!(enc, "UTF-8");
+    }
+
+    #[test]
+    fn magic_comment_no_unicode_escape_keeps_source_encoding() {
+        let enc = run_encoding_query("# encoding: binary\n\"abc\".encoding.to_s\n");
+        assert_eq!(enc, "ASCII-8BIT");
     }
 }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -936,18 +936,36 @@ impl Value {
     ///
     /// Build a String from a source-file byte literal (e.g. `"\xC3\xA9"`).
     ///
-    /// The result is tagged as UTF-8, matching CRuby's source-encoding
-    /// semantics where string literals inherit the source file encoding
-    /// regardless of whether `\xNN` escapes produce valid UTF-8. The bytes
-    /// may be invalid UTF-8, in which case `#valid_encoding?` returns
-    /// false and byte-level operations still work.
+    /// `enc` is the encoding declared by the source file's `# encoding:`
+    /// magic comment (defaulting to UTF-8 when the source has no magic
+    /// comment, per Ruby 2.0+ semantics). The bytes are *not* re-validated
+    /// against `enc` — invalid byte sequences survive verbatim, so e.g.
+    /// `"\x80"` in a `# encoding: utf-8` file is tagged UTF-8 but
+    /// `valid_encoding?` returns false, exactly like CRuby.
     ///
-    pub fn string_from_source_bytes(b: &[u8]) -> Self {
+    pub fn string_from_source_bytes(b: &[u8], enc: Encoding) -> Self {
         // Source-byte literals are bytecode-time templates that get
         // `deep_copy`-cloned at every literal-load. Pre-classify so
         // the cr is fixed on the template; clones inherit it for free
         // instead of each one re-running the encoding check.
-        Self::string_from_inner(RStringInner::from_encoding_scanned(b, Encoding::Utf8))
+        Self::string_from_inner(RStringInner::from_encoding_scanned(b, enc))
+    }
+
+    ///
+    /// Build a String literal carrying the file's declared source
+    /// encoding. The Prism lowerer hands us a Rust `String` (i.e. valid
+    /// UTF-8 bytes) when the literal's bytes happened to UTF-8-decode,
+    /// but the *declared* source encoding may still be e.g. binary or
+    /// US-ASCII — so we honour `enc` rather than always tagging UTF-8.
+    /// Pre-scanned so deep_copy clones inherit `cr` for free.
+    ///
+    pub fn string_from_source_str(s: &str, enc: Encoding) -> Self {
+        if matches!(enc, Encoding::Utf8) {
+            // Hot path: the common case (no magic comment) reuses the
+            // existing UTF-8 scanned constructor verbatim.
+            return Self::string_scanned(s.to_owned());
+        }
+        Self::string_from_inner(RStringInner::from_encoding_scanned(s.as_bytes(), enc))
     }
 
     pub fn string_from_vec(b: Vec<u8>) -> Self {
@@ -2327,16 +2345,21 @@ impl Value {
 impl Value {
     pub(crate) fn from_ast(node: &Node, globals: &mut Globals) -> Value {
         let mut vm = Executor::default();
-        Self::from_ast_inner(node, &mut vm, globals)
+        Self::from_ast_inner(node, &mut vm, globals, Encoding::Utf8)
     }
 
-    fn from_ast_inner(node: &Node, vm: &mut Executor, globals: &mut Globals) -> Value {
+    fn from_ast_inner(
+        node: &Node,
+        vm: &mut Executor,
+        globals: &mut Globals,
+        src_enc: Encoding,
+    ) -> Value {
         use crate::ast::NReal;
 
         match &node.kind {
             NodeKind::CompStmt(stmts) => {
                 assert_eq!(1, stmts.len(), "multiple statements {stmts:?}");
-                Self::from_ast_inner(&stmts[0], vm, globals)
+                Self::from_ast_inner(&stmts[0], vm, globals, src_enc)
             }
             NodeKind::Integer(num) => Value::integer(*num),
             NodeKind::Bignum(num) => Value::bigint(num.clone()),
@@ -2354,10 +2377,16 @@ impl Value {
             NodeKind::Bool(b) => Value::bool(*b),
             NodeKind::Nil => Value::nil(),
             NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
-            NodeKind::String(s) => Value::string_from_str(s),
-            NodeKind::Bytes(b) => Value::string_from_source_bytes(b),
+            NodeKind::String(s) => Value::string_from_source_str(s, src_enc),
+            NodeKind::Bytes(b) => Value::string_from_source_bytes(b, src_enc),
+            NodeKind::EncodedString(b, name) => {
+                let enc = Encoding::try_from_str(name).unwrap_or(Encoding::Utf8);
+                Value::string_from_source_bytes(b, enc)
+            }
             NodeKind::Array(v, ..) => {
-                let iter = v.iter().map(|node| Self::from_ast_inner(node, vm, globals));
+                let iter = v
+                    .iter()
+                    .map(|node| Self::from_ast_inner(node, vm, globals, src_enc));
                 Value::array_from_iter(iter)
             }
             NodeKind::Const {
@@ -2400,12 +2429,12 @@ impl Value {
                 ..
             } => {
                 let start = if let Some(start) = start {
-                    Self::from_ast_inner(start, vm, globals)
+                    Self::from_ast_inner(start, vm, globals, src_enc)
                 } else {
                     Value::nil()
                 };
                 let end = if let Some(end) = end {
-                    Self::from_ast_inner(end, vm, globals)
+                    Self::from_ast_inner(end, vm, globals, src_enc)
                 } else {
                     Value::nil()
                 };
@@ -2414,8 +2443,8 @@ impl Value {
             NodeKind::Hash(v, _splat) => {
                 let mut map = RubyMap::default();
                 for (k, v) in v.iter() {
-                    let k = Self::from_ast_inner(k, vm, globals);
-                    let v = Self::from_ast_inner(v, vm, globals);
+                    let k = Self::from_ast_inner(k, vm, globals, src_enc);
+                    let v = Self::from_ast_inner(v, vm, globals, src_enc);
                     map.insert(k, v, vm, globals).unwrap();
                 }
                 Value::hash(map)
@@ -2435,7 +2464,7 @@ impl Value {
                 }
             }
             NodeKind::BinOp(crate::ast::BinOp::Add, box lhs, box rhs) => {
-                let lhs = Self::from_ast_inner(lhs, vm, globals);
+                let lhs = Self::from_ast_inner(lhs, vm, globals, src_enc);
                 if let NodeKind::Imaginary(im) = &rhs.kind {
                     Value::complex(Real::try_from(globals, lhs).unwrap(), im.clone())
                 } else {
@@ -2443,7 +2472,7 @@ impl Value {
                 }
             }
             NodeKind::BinOp(crate::ast::BinOp::Sub, box lhs, box rhs) => {
-                let lhs = Self::from_ast_inner(lhs, vm, globals);
+                let lhs = Self::from_ast_inner(lhs, vm, globals, src_enc);
                 if let NodeKind::Imaginary(im) = &rhs.kind {
                     Value::complex(
                         Real::try_from(globals, lhs).unwrap(),
@@ -2457,7 +2486,7 @@ impl Value {
         }
     }
 
-    pub(crate) fn from_const_ast(node: &Node) -> Value {
+    pub(crate) fn from_const_ast(node: &Node, src_enc: Encoding) -> Value {
         use crate::ast::NReal;
         match &node.kind {
             NodeKind::Integer(num) => Value::integer(*num),
@@ -2476,10 +2505,14 @@ impl Value {
             NodeKind::Bool(b) => Value::bool(*b),
             NodeKind::Nil => Value::nil(),
             NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
-            NodeKind::String(s) => Value::string_from_str(s),
-            NodeKind::Bytes(b) => Value::string_from_source_bytes(b),
+            NodeKind::String(s) => Value::string_from_source_str(s, src_enc),
+            NodeKind::Bytes(b) => Value::string_from_source_bytes(b, src_enc),
+            NodeKind::EncodedString(b, name) => {
+                let enc = Encoding::try_from_str(name).unwrap_or(Encoding::Utf8);
+                Value::string_from_source_bytes(b, enc)
+            }
             NodeKind::Array(v, ..) => {
-                let iter = v.iter().map(|node| Self::from_const_ast(node));
+                let iter = v.iter().map(|node| Self::from_const_ast(node, src_enc));
                 Value::array_from_iter(iter)
             }
             NodeKind::Range {
@@ -2489,12 +2522,12 @@ impl Value {
                 ..
             } => {
                 let start = if let Some(start) = start {
-                    Self::from_const_ast(start)
+                    Self::from_const_ast(start, src_enc)
                 } else {
                     Value::nil()
                 };
                 let end = if let Some(end) = end {
-                    Self::from_const_ast(end)
+                    Self::from_const_ast(end, src_enc)
                 } else {
                     Value::nil()
                 };

--- a/ruruby-parse/src/node.rs
+++ b/ruruby-parse/src/node.rs
@@ -16,6 +16,21 @@ pub enum NodeKind {
     Bool(bool),
     String(String),
     Bytes(Vec<u8>),
+    /// String literal whose encoding is *forced* to a specific value
+    /// regardless of the source file's `# encoding:` directive.
+    ///
+    /// CRuby upgrades a non-UTF-8 source's string literal to UTF-8
+    /// when it contains a `\u` escape (the bytes the escape produces
+    /// are valid UTF-8, so the literal is no longer representable in
+    /// the source encoding). Prism surfaces this via the
+    /// `PM_STRING_FLAGS_FORCED_UTF8_ENCODING` flag on `StringNode`.
+    /// The lowerer emits this variant only when prism flags the
+    /// literal — the common case stays on `String` / `Bytes`.
+    ///
+    /// `(content_bytes, encoding_name)` — encoding name is one of
+    /// `"UTF-8"` or `"ASCII-8BIT"`, lowercased aliases also accepted
+    /// by the consumer.
+    EncodedString(Vec<u8>, &'static str),
     InterporatedString(Vec<Node>),
     Command(Box<Node>),
     Symbol(String),

--- a/ruruby-parse/src/source_info.rs
+++ b/ruruby-parse/src/source_info.rs
@@ -41,6 +41,13 @@ pub struct SourceInfo {
     pub code: String,
     /// line number offset for eval (0-based: e.g. lineno=1 means offset=0, lineno=42 means offset=41).
     pub line_offset: i64,
+    /// Source encoding declared by a magic comment
+    /// (`# encoding: NAME` / `# coding: NAME`). `None` means no
+    /// magic comment was present, in which case callers should
+    /// default to UTF-8 (Ruby's default source encoding since 2.0).
+    /// Stored verbatim as written in the source so consumers can
+    /// resolve aliases through their own normaliser.
+    pub source_encoding: Option<String>,
 }
 
 impl Default for SourceInfo {
@@ -62,6 +69,7 @@ impl SourceInfo {
             path: path.into(),
             code,
             line_offset: 0,
+            source_encoding: None,
         }
     }
 
@@ -78,7 +86,16 @@ impl SourceInfo {
             path: path.into(),
             code,
             line_offset,
+            source_encoding: None,
         }
+    }
+
+    /// Return a copy of this `SourceInfo` with `source_encoding` set
+    /// to `enc`. Used by parsers to attach the magic-comment-derived
+    /// source encoding after the source has already been wrapped.
+    pub fn with_source_encoding(mut self, enc: Option<String>) -> Self {
+        self.source_encoding = enc;
+        self
     }
 
     pub fn get_line(&self, loc: &Loc) -> i64 {


### PR DESCRIPTION
## Summary

- #462 made `String#==` encoding-aware (content-equal AND encoding-compatible) — the right CRuby semantics — but exposed a pre-existing bug: monoruby's parser was tagging every string literal as UTF-8 regardless of the source file's `# encoding:` directive.
- Result: every `core/array/pack/*_spec.rb` (which all open with `# encoding: binary`) compared a pack output (ASCII-8BIT) against a literal we mis-tagged UTF-8 → the new `==` correctly returned false → 730+ Array#pack examples regressed.
- This PR fixes the root cause by wiring source encoding through the parser → bytecodegen → literal-Value pipeline, instead of reverting #462's encoding-aware `==`.

## Pipeline

- `ruruby-parse::SourceInfo` grows `source_encoding: Option<String>`. Existing constructors keep it `None`; `with_source_encoding` attaches it post-construction.
- `prism_backend::try_prism_inner` reads `result.magic_comments()`, picks the first `encoding` / `coding` entry (matching CRuby's "first magic comment wins" rule). Emacs-style `# -*- coding: NAME -*-` is normalised by prism to the same key.
- `BytecodeGen::source_encoding()` resolves the stamped string through `Encoding::try_from_str`, defaulting to UTF-8 (Ruby 2.0+). `emit_string` / `emit_bytes` use it; `Value::from_const_ast` is threaded through too for frozen-array / const-range elements.

## `\u` escape force-UTF-8

CRuby upgrades a non-UTF-8 source's literal to UTF-8 the moment it contains a `\u` escape. Prism flags this via `PM_STRING_FLAGS_FORCED_UTF8_ENCODING`. New `NodeKind::EncodedString(Vec<u8>, &'static str)` variant carries an explicit override; `lower_string` emits it only when prism flags the literal, so the common case stays on `String` / `Bytes`.

## Coverage matrix (now matches CRuby exactly)

| source            | literal       | encoding   |
| ----------------- | ------------- | ---------- |
| (default) / utf-8 | `"abc"`       | UTF-8      |
| (default) / utf-8 | `"\xff"`      | UTF-8 inv  |
| binary            | `"abc"`       | ASCII-8BIT |
| binary            | `"\x80"`      | ASCII-8BIT |
| binary            | `"\u{9819}"`  | UTF-8      |
| us-ascii          | `"abc"`       | US-ASCII   |
| us-ascii          | `"\u{1234}"`  | UTF-8      |
| shift_jis (Emacs) | `"abc"`       | Shift_JIS  |

## Spec deltas (vs current master HEAD)

- `core/array`:  812 F + 28 E → 85 F + 29 E  (**−726 F+E**)
- `core/string`: 283 F + 149 E → 282 F + 145 E  (**−5 F+E**)

## Test plan

- [x] `cargo test -p monoruby --release --lib`: 1975 pass / 0 fail (+10 new in `parser::prism_backend::tests::magic_comment_*`).
- [x] `cargo test -p ruruby-parse --release`: all pass.
- [x] `mspec run core/array -t monoruby`: 85 F / 29 E (was 812 / 28).
- [x] `mspec run core/string -t monoruby`: 282 F / 145 E (was 283 / 149).
- [x] Manual smoke test: `# encoding: binary`, `# coding: us-ascii`, `# -*- coding: shift_jis -*-`, and `\u` escapes in non-UTF-8 sources all match CRuby output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)