### PR TITLE
core/array: attach size hint to no-block Enumerator (~28 spec wins)

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -60,7 +60,7 @@ class Array
   end
 
   def each
-    return self.to_enum(:each) unless block_given?
+    return self.to_enum(:each) { self.size } unless block_given?
     i = 0
     while i < self.size
       yield self[i]
@@ -70,7 +70,7 @@ class Array
   end
 
   def reverse_each
-    return self.to_enum(:reverse_each) unless block_given?
+    return self.to_enum(:reverse_each) { self.size } unless block_given?
     len = self.size
     if len == 0
       return self
@@ -84,7 +84,7 @@ class Array
   end
 
   def each_with_index
-    return self.to_enum(:each_with_index) unless block_given?
+    return self.to_enum(:each_with_index) { self.size } unless block_given?
     i = 0
     while i < self.size
       yield self[i], i
@@ -94,7 +94,7 @@ class Array
   end
 
   def map!
-    return self.to_enum(:map!) unless block_given?
+    return self.to_enum(:map!) { self.size } unless block_given?
     raise FrozenError, "can't modify frozen #{self.class}: #{self.inspect}" if frozen?
     i = 0
     while i < self.size
@@ -106,7 +106,7 @@ class Array
   alias collect! map!
 
   def map
-    return self.to_enum(:map) unless block_given?
+    return self.to_enum(:map) { self.size } unless block_given?
     res = Array.new(self.size)
     i = 0
     while i < self.size
@@ -193,7 +193,7 @@ class Array
   end
 
   def filter_map
-    return to_enum(:filter_map) unless block_given?
+    return to_enum(:filter_map) { self.size } unless block_given?
     res = []
     each do |x|
       y = yield(x)
@@ -245,7 +245,26 @@ class Array
   end
 
   def combination(n)
-    return to_enum(:combination, n) unless block_given?
+    unless block_given?
+      # Lazily compute the binomial coefficient C(self.size, k) the
+      # same way CRuby's enumerator does: 0 for k < 0 or k > size, 1
+      # for k == 0, otherwise the multiplicative form so we never
+      # build the full factorial.
+      return to_enum(:combination, n) {
+        k = n.is_a?(Integer) ? n : n.to_int
+        len = self.size
+        if k < 0 || k > len
+          0
+        elsif k == 0
+          1
+        else
+          k = len - k if k > len - k
+          v = 1
+          1.upto(k) { |i| v = v * (len - k + i) / i }
+          v
+        end
+      }
+    end
     n = n.to_int
     len = self.size
     if n == 0
@@ -311,7 +330,23 @@ class Array
   end
 
   def permutation(n = self.size)
-    return to_enum(:permutation, n) unless block_given?
+    unless block_given?
+      # Descending factorial size = n * (n-1) * ... * (n-k+1).
+      # 0 for k < 0 or k > size; 1 for k == 0.
+      return to_enum(:permutation, n) {
+        k = n.is_a?(Integer) ? n : n.to_int
+        len = self.size
+        if k < 0 || k > len
+          0
+        elsif k == 0
+          1
+        else
+          v = 1
+          k.times { |i| v *= (len - i) }
+          v
+        end
+      }
+    end
     n = n.to_int
     if n == 0
       yield []
@@ -467,7 +502,7 @@ class Array
   end
 
   def each_index
-    return self.to_enum(:each_index) unless block_given?
+    return self.to_enum(:each_index) { self.size } unless block_given?
     i = 0
     while i < self.size
       yield i
@@ -477,7 +512,20 @@ class Array
   end
 
   def repeated_permutation(n)
-    return to_enum(:repeated_permutation, n) unless block_given?
+    unless block_given?
+      # size**n; 0 when n < 0 (no permutations); 1 when n == 0
+      # (the empty permutation), even for an empty receiver.
+      return to_enum(:repeated_permutation, n) {
+        k = n.is_a?(Integer) ? n : n.to_int
+        if k < 0
+          0
+        elsif k == 0
+          1
+        else
+          self.size ** k
+        end
+      }
+    end
     n = n.to_int
     copy = self.dup
     len = copy.size
@@ -506,7 +554,26 @@ class Array
   end
 
   def repeated_combination(n)
-    return to_enum(:repeated_combination, n) unless block_given?
+    unless block_given?
+      # C(size + k - 1, k); 0 for k < 0; 1 for k == 0; the full
+      # multiplicative form to avoid factorials of large arrays.
+      return to_enum(:repeated_combination, n) {
+        k = n.is_a?(Integer) ? n : n.to_int
+        len = self.size
+        if k < 0
+          0
+        elsif k == 0
+          1
+        elsif len == 0
+          0
+        else
+          # C(len + k - 1, k) using the multiplicative form.
+          v = 1
+          1.upto(k) { |i| v = v * (len + k - i) / i }
+          v
+        end
+      }
+    end
     n = n.to_int
     len = self.size
     if n == 0

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2213,8 +2213,24 @@ fn sort_by_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
             Ok(ary.into())
         })
     } else {
-        vm.generate_enumerator(IdentId::get_id("sort_by!"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("sort_by!"), pc)
     }
+}
+
+/// Build an `Enumerator` for an `Array` iterator that has the same size
+/// as the receiver: every method here yields exactly `self.length`
+/// elements (`each`, `select`, `reject`, `sort_by`, …), so we attach
+/// that as the size hint so `enum.size` returns the right value
+/// without running the iteration. Mirrors the size proc CRuby ships
+/// with each builtin's no-block branch.
+fn array_enumerator(
+    vm: &mut Executor,
+    self_val: Value,
+    method: IdentId,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let size = Value::integer(self_val.as_array().len() as i64);
+    vm.generate_enumerator_with_size(method, self_val, vec![], pc, Some(size))
 }
 
 fn sort_by_collect_pairs(
@@ -2285,7 +2301,7 @@ fn sort_by(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
             Ok(Value::array_from_vec(sorted_elems))
         })
     } else {
-        vm.generate_enumerator(IdentId::get_id("sort_by"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("sort_by"), pc)
     }
 }
 
@@ -2314,7 +2330,7 @@ fn filter(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
         }
         Ok(Value::array_from_vec(res))
     } else {
-        vm.generate_enumerator(IdentId::get_id("filter"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("filter"), pc)
     }
 }
 
@@ -2408,7 +2424,7 @@ fn filter_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
             Value::nil()
         })
     } else {
-        vm.generate_enumerator(IdentId::get_id("filter!"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("filter!"), pc)
     }
 }
 
@@ -2427,7 +2443,7 @@ fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
         retain_with_block(vm, globals, lfp.self_val(), &data, false)?;
         Ok(lfp.self_val())
     } else {
-        vm.generate_enumerator(IdentId::get_id("keep_if"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("keep_if"), pc)
     }
 }
 
@@ -2454,7 +2470,7 @@ fn reject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
         }
         Ok(Value::array_from_vec(res))
     } else {
-        vm.generate_enumerator(IdentId::get_id("reject"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("reject"), pc)
     }
 }
 
@@ -2477,7 +2493,7 @@ fn reject_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
             Value::nil()
         })
     } else {
-        vm.generate_enumerator(IdentId::get_id("reject!"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("reject!"), pc)
     }
 }
 
@@ -2496,7 +2512,7 @@ fn delete_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
         retain_with_block(vm, globals, lfp.self_val(), &data, true)?;
         Ok(lfp.self_val())
     } else {
-        vm.generate_enumerator(IdentId::get_id("delete_if"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("delete_if"), pc)
     }
 }
 
@@ -2523,7 +2539,7 @@ fn group_by(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
             Ok(h_val)
         })
     } else {
-        vm.generate_enumerator(IdentId::get_id("group_by"), lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("group_by"), pc)
     }
 }
 
@@ -3564,8 +3580,7 @@ fn find_index(
         }
         Ok(Value::nil())
     } else {
-        let id = IdentId::get_id("find_index");
-        vm.generate_enumerator(id, lfp.self_val(), vec![], pc)
+        array_enumerator(vm, lfp.self_val(), IdentId::get_id("find_index"), pc)
     }
 }
 


### PR DESCRIPTION
## Summary
- Every `Array#each / map / select / combination / permutation / ...` Enumerator returned `nil` for `.size` because both `array.rb` (`to_enum(:method)`) and `array.rs` (`generate_enumerator(...)`) skipped the size hint. CRuby attaches one for every iterator with a known yield count; `core/array` mspec leans on it heavily.
- `array.rs`: tiny `array_enumerator(vm, self, method, pc)` helper that wraps `generate_enumerator_with_size` with `self.length`. Routes the 9 active no-block branches (`filter`/`select`/`find_all`, `filter!`/`select!`, `keep_if`, `reject`, `reject!`, `delete_if`, `sort_by`, `sort_by!`, `group_by`, `find_index`) through it.
- `array.rb`: pass `{ self.size }` to `to_enum(...)` in `each / each_index / each_with_index / reverse_each / map / map! / collect / collect! / filter_map`. For `combination / permutation / repeated_*`, attach the proper binomial / descending-factorial / power formula (lazy, in the size block) — defaults to `0` for `k < 0` or `k > size`, `1` for `k == 0`.

## Spec deltas
- `core/array`: **85 F + 29 E → 57 F + 29 E** (-28 failures, no regressions)

## Test plan
- [x] `cargo test -p monoruby --lib --release builtins::array`: 131 pass / 0 fail
- [x] `cargo test -p monoruby --lib --release builtins::enumerator`: 17 pass / 0 fail
- [x] `mspec run core/array -t monoruby`: 57 F / 29 E (was 85 / 29)
- [x] Smoke test: `[1,2,3,4].each.size` → 4, `[1,2,3,4].combination(2).size` → 6, `[].permutation(0).size` → 1, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_