### PR TITLE
core/{time,range}: Time comparison + Range#minmax iteration (~6 spec wins)

### DIFF
--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -963,7 +963,67 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
             }
             Ok(Value::array_from_vec(vec![min_val, max_val]))
         } else {
-            Err(MonorubyErr::runtimeerr("not supported"))
+            // Non-numeric range with block: walk via `each`
+            // (which understands `succ` and works for Time /
+            // String / Symbol / mocked types) and apply the
+            // block as the comparator. Mirrors Enumerable#minmax.
+            let data = vm.get_block_data(globals, bh)?;
+            let mut min_val: Option<Value> = None;
+            let mut max_val: Option<Value> = None;
+            let arr = vm
+                .invoke_method_inner(
+                    globals,
+                    IdentId::get_id("to_a"),
+                    self_,
+                    &[],
+                    None,
+                    None,
+                )?
+                .as_array();
+            for v in arr.iter() {
+                let v = *v;
+                let mn = match min_val {
+                    Some(m) => m,
+                    None => {
+                        min_val = Some(v);
+                        max_val = Some(v);
+                        continue;
+                    }
+                };
+                let mx = max_val.unwrap();
+                let cmp_min = vm.invoke_block(globals, &data, &[v, mn])?;
+                if vm
+                    .invoke_method_inner(
+                        globals,
+                        IdentId::_LT,
+                        cmp_min,
+                        &[Value::integer(0)],
+                        None,
+                        None,
+                    )?
+                    .as_bool()
+                {
+                    min_val = Some(v);
+                }
+                let cmp_max = vm.invoke_block(globals, &data, &[v, mx])?;
+                if vm
+                    .invoke_method_inner(
+                        globals,
+                        IdentId::_GT,
+                        cmp_max,
+                        &[Value::integer(0)],
+                        None,
+                        None,
+                    )?
+                    .as_bool()
+                {
+                    max_val = Some(v);
+                }
+            }
+            Ok(Value::array_from_vec(vec![
+                min_val.unwrap_or_else(Value::nil),
+                max_val.unwrap_or_else(Value::nil),
+            ]))
         }
     } else {
         // No block: compute min and max directly
@@ -1000,8 +1060,34 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 } else {
                     return Err(MonorubyErr::typeerr("cannot exclude non Integer end value"));
                 }
-            } else {
+            } else if matches!(
+                start.unpack(),
+                RV::Fixnum(_) | RV::BigInt(_) | RV::Float(_)
+            ) {
+                // Numeric start with non-numeric end (the
+                // canonical case is `(0...Float::INFINITY)`):
+                // CRuby raises immediately rather than running
+                // an unbounded loop.
                 return Err(MonorubyErr::typeerr("cannot exclude non Integer end value"));
+            } else {
+                // Generic non-numeric exclusive range: iterate
+                // via `each` (uses `#succ`) and take the last
+                // yielded element. Mocked / user-defined types
+                // only need to respond to `<=>` / `succ`.
+                let arr = vm
+                    .invoke_method_inner(
+                        globals,
+                        IdentId::get_id("to_a"),
+                        self_,
+                        &[],
+                        None,
+                        None,
+                    )?
+                    .as_array();
+                if arr.is_empty() {
+                    return Ok(Value::array_from_vec(vec![Value::nil(), Value::nil()]));
+                }
+                arr[arr.len() - 1]
             }
         } else {
             end

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -47,6 +47,13 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(TIME_CLASS, "utc_offset", &["gmt_offset", "gmtoff"], utc_offset, 0);
     globals.define_builtin_func(TIME_CLASS, "-", sub, 1);
     globals.define_builtin_func(TIME_CLASS, "+", add, 1);
+    globals.define_builtin_func(TIME_CLASS, "<=>", cmp, 1);
+    globals.define_builtin_func(TIME_CLASS, "<", lt, 1);
+    globals.define_builtin_func(TIME_CLASS, "<=", le, 1);
+    globals.define_builtin_func(TIME_CLASS, ">", gt, 1);
+    globals.define_builtin_func(TIME_CLASS, ">=", ge, 1);
+    globals.define_builtin_func(TIME_CLASS, "==", eq, 1);
+    globals.define_builtin_func(TIME_CLASS, "eql?", eql, 1);
     globals.define_builtin_func(TIME_CLASS, "sunday?", sunday_q, 0);
     globals.define_builtin_func(TIME_CLASS, "monday?", monday_q, 0);
     globals.define_builtin_func(TIME_CLASS, "tuesday?", tuesday_q, 0);
@@ -1537,6 +1544,114 @@ fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 pub enum TimeInner {
     Local(DateTime<FixedOffset>),
     Utc(DateTime<Utc>),
+}
+
+impl PartialOrd for TimeInner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TimeInner {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Normalise both sides to UTC before comparing — `Local` and
+        // `Utc` variants both back onto the same `DateTime<Tz>` /
+        // `DateTime<Utc>` instants, just with a different display
+        // offset. CRuby compares Time by absolute instant.
+        let l = match self {
+            TimeInner::Local(t) => t.with_timezone(&Utc),
+            TimeInner::Utc(t) => *t,
+        };
+        let r = match other {
+            TimeInner::Local(t) => t.with_timezone(&Utc),
+            TimeInner::Utc(t) => *t,
+        };
+        l.cmp(&r)
+    }
+}
+
+/// Compare `self` against `other` for Time#<=>, Time#<, etc.
+/// Returns `None` when `other` isn't a Time (CRuby: `<=>` ⇒ nil,
+/// the relational operators ⇒ ArgumentError).
+fn time_cmp_opt(self_: Value, other: Value) -> Option<std::cmp::Ordering> {
+    let rv = other.try_rvalue()?;
+    if rv.ty() != ObjTy::TIME {
+        return None;
+    }
+    let lhs = self_.as_time();
+    let rhs = other.as_time();
+    Some(lhs.cmp(rhs))
+}
+
+/// `Time#<=>` — returns -1/0/1 against another Time, nil otherwise.
+#[monoruby_builtin]
+fn cmp(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match time_cmp_opt(lfp.self_val(), lfp.arg(0)) {
+        Some(std::cmp::Ordering::Less) => Value::integer(-1),
+        Some(std::cmp::Ordering::Equal) => Value::integer(0),
+        Some(std::cmp::Ordering::Greater) => Value::integer(1),
+        None => Value::nil(),
+    })
+}
+
+#[monoruby_builtin]
+fn lt(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match time_cmp_opt(lfp.self_val(), lfp.arg(0)) {
+        Some(ord) => Value::bool(ord == std::cmp::Ordering::Less),
+        None => return Err(MonorubyErr::argumenterr("comparison of Time with non-Time")),
+    })
+}
+
+#[monoruby_builtin]
+fn le(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match time_cmp_opt(lfp.self_val(), lfp.arg(0)) {
+        Some(ord) => Value::bool(ord != std::cmp::Ordering::Greater),
+        None => {
+            return Err(MonorubyErr::argumenterr("comparison of Time with non-Time"));
+        }
+    })
+}
+
+#[monoruby_builtin]
+fn gt(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match time_cmp_opt(lfp.self_val(), lfp.arg(0)) {
+        Some(ord) => Value::bool(ord == std::cmp::Ordering::Greater),
+        None => return Err(MonorubyErr::argumenterr("comparison of Time with non-Time")),
+    })
+}
+
+#[monoruby_builtin]
+fn ge(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match time_cmp_opt(lfp.self_val(), lfp.arg(0)) {
+        Some(ord) => Value::bool(ord != std::cmp::Ordering::Less),
+        None => {
+            return Err(MonorubyErr::argumenterr("comparison of Time with non-Time"));
+        }
+    })
+}
+
+#[monoruby_builtin]
+fn eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(
+        time_cmp_opt(lfp.self_val(), lfp.arg(0)) == Some(std::cmp::Ordering::Equal),
+    ))
+}
+
+#[monoruby_builtin]
+fn eql(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // `eql?` is stricter: only true for two Times *and* equal in
+    // both instant and offset. We approximate by comparing the
+    // tagged enum directly, which captures both pieces.
+    let other = lfp.arg(0);
+    let Some(rv) = other.try_rvalue() else {
+        return Ok(Value::bool(false));
+    };
+    if rv.ty() != ObjTy::TIME {
+        return Ok(Value::bool(false));
+    }
+    Ok(Value::bool(
+        lfp.self_val().as_time() == other.as_time(),
+    ))
 }
 
 impl std::ops::Sub<Self> for TimeInner {


### PR DESCRIPTION
## Summary
Two related Range-iteration gaps:

1. **Time comparison** — Time had no `<=>` / `<` / `<=` / `>` / `>=` / `==` / `eql?`, so `Time <=> Time` returned `nil`. `Range#each` (in `range.rb`) probes `start <=> end` and breaks immediately when the probe is nil — so `(t..t.succ).to_a` came back `[]`, and `include?` / `member?` with Time endpoints fell through to `cover?` returning false. Add `Ord`/`PartialOrd` on `TimeInner` (normalising both sides to UTC) and the seven comparison builtins. Only `<=>` returns nil for non-Time other; the relational ops raise ArgumentError as CRuby does.

2. **`Range#minmax` iteration** — two "not supported" / "cannot exclude non Integer end value" arms now fall back to iteration:
   - Block + non-fixnum range: walks `to_a` (which routes through Range#each's succ-based loop) and applies the block as comparator.
   - No-block + exclusive non-numeric range: returns `[start, last-yielded]` via `to_a`, but **only** when `start` isn't Numeric — `(0...Float::INFINITY)` keeps the TypeError instead of triggering an infinite iteration.

## Spec deltas
- `core/range`: **11 F + 4 E → 5 F + 1 E** (-9)
- `core/array`, `core/symbol`: unchanged.

## Test plan
- [x] `mspec run core/range -t monoruby`: 5 F / 1 E (was 11 / 4)
- [x] `mspec run core/range/minmax_spec.rb`: 0 F / 0 E (was 3 F / 3 E)
- [x] `mspec run core/range/each_spec.rb`: 0 F / 0 E (Time#succ subtest passes)
- [x] `cargo test -p monoruby --lib --release builtins::`: 1844 pass / 2 pre-existing fail (`string_inspect`, `symbol_inspect_unquoted` — P4 territory)
- [x] Manual smoke: `Time.utc(1970) <=> Time.utc(1971) == -1`, `(Time.utc(1970)..Time.utc(1970, 1, 1, 0, 0, 1)).to_a` returns both Times (with `def t.succ` singleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_