### PR TITLE
core/array: walk past singleton class in AS dispatch (#481 follow-up)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5269,6 +5269,31 @@ mod tests {
         ]);
     }
 
+    /// Regression: `Range#%` attaches a singleton method (`inspect`)
+    /// to its AS result, which makes `Value::class` return the
+    /// singleton's `ClassId`. The fast-path `is_arithmetic_sequence`
+    /// check must walk past the singleton (`real_class`) instead of
+    /// comparing against the cached AS class id verbatim — otherwise
+    /// the dispatch falls through to `coerce_to_int_i64` and raises
+    /// `TypeError: no implicit conversion of
+    /// Enumerator::ArithmeticSequence into Integer`. Same hazard
+    /// hits any AS the user decorates with `define_singleton_method`.
+    #[test]
+    fn slice_with_arithmetic_sequence_singleton_class() {
+        run_tests(&[
+            // Manually-attached singleton method on a plain AS.
+            r#"
+              aseq = (0..-1).step(2)
+              aseq.define_singleton_method(:foo) { :foo }
+              [10, 20, 30, 40, 50][aseq]
+            "#,
+            // `Range#%` already calls `define_singleton_method(:inspect)`
+            // internally, so this is the natural-occurring version of
+            // the case above.
+            "[10, 20, 30, 40, 50][(0..-1).%(2)]",
+        ]);
+    }
+
     #[test]
     fn pack() {
         run_test(r#"[*(0..100)].pack("C*")"#);

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -602,8 +602,14 @@ thread_local! {
 /// Mirrors the way Array's `[]` dispatch needs to recognise an AS
 /// index — without the per-call cost of walking the class chain and
 /// joining names into a string.
+///
+/// Uses `real_class` rather than `Value::class` so a singleton class
+/// attached to the AS (e.g. `Range#%` calls `define_singleton_method`
+/// to swap in a custom `inspect`) doesn't make the cached `ClassId`
+/// compare miss. Without this, `arr[(0..-1).%(2)]` fell through to
+/// the `to_int` path and raised `TypeError`.
 pub(crate) fn is_arithmetic_sequence(globals: &Globals, v: Value) -> bool {
-    let v_class = v.class();
+    let v_class = v.real_class(&globals.store).id();
     AS_CLASS_ID_CACHE.with(|cell| {
         if let Some(cached) = cell.get() {
             return v_class == cached;


### PR DESCRIPTION
## Summary

- The unit test `builtins::array::tests::slice_with_arithmetic_sequence` (added in #481) has been failing on every CI run since it landed.
- Root cause: `runtime::is_arithmetic_sequence` uses `Value::class()` (the *direct* class — which is the singleton class as soon as anyone has called `define_singleton_method`). The cached `Enumerator::ArithmeticSequence` `ClassId` compare misses, dispatch falls through to `coerce_to_int_i64`, and `Array#[]` raises `TypeError: no implicit conversion of Enumerator::ArithmeticSequence into Integer`.
- `Range#%` hits this naturally: [`monoruby/builtins/range.rb`](monoruby/builtins/range.rb) defines `%` as a thin wrapper around `step` and calls `define_singleton_method(:inspect)` on the result. So `[10,20,30,40,50][(0..-1).%(2)]` works through `step` but explodes through `%`.

## Fix

`real_class().id()` — same lookup `Object#class` already uses, which skips singleton + iclass links. Same one-`ClassId`-compare cost in the hot path; just one extra indirection through `real_class`.

## Regression test

New `slice_with_arithmetic_sequence_singleton_class` pins the `define_singleton_method`-then-index behaviour separately from the `Range#%` case, so a regression here can't masquerade as a `Range#%` quirk:

```ruby
aseq = (0..-1).step(2)
aseq.define_singleton_method(:foo) { :foo }
[10, 20, 30, 40, 50][aseq]   # before: TypeError, after: [10, 30, 50]
```

## Test plan

- [x] `cargo test -p monoruby --release --lib builtins::array::tests::slice_with_arithmetic_sequence`: passes
- [x] `cargo test -p monoruby --release --lib builtins::array::tests::slice_with_arithmetic_sequence_singleton_class`: passes (new)
- [x] `cargo test -p monoruby --release --lib`: 2017 pass / 0 fail
- [x] Manual: `Range#%` and `define_singleton_method`+AS both produce CRuby-matching slices

🤖 Generated with [Claude Code](https://claude.com/claude-code)