### PR TITLE
core/arithmetic_sequence: phase 1 — native RValue backing for AS

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -2,11 +2,6 @@ require_relative 'monitor'
 
 class Enumerator
   include Enumerable
-
-  # Placeholder for CRuby's Enumerator::ArithmeticSequence. We treat it as
-  # an alias of Enumerator so `Numeric#step` / `Range#step` can report the
-  # conventional class without a dedicated implementation.
-  ArithmeticSequence = self unless defined?(ArithmeticSequence)
 end
 
 class CallerLocation

--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -990,37 +990,38 @@ class Enumerator
   # for Enumerators built from a real iterator), so `is_a?` /
   # `kind_of?` are overridden to keep `is_a?(Enumerator)` truthy
   # for spec compatibility.
+  #
+  # Phase 1 of the Rust-native migration: storage moved off Ruby
+  # ivars onto a dedicated `RValue` variant
+  # (`ObjTy::ARITHMETIC_SEQUENCE`).  `__build` and the private
+  # `__b` / `__e` / `__s` / `__excl?` readers are Rust builtins
+  # that operate on those fields directly; the rest of this class
+  # is still Ruby, but reaches the fields through those readers
+  # instead of `@begin` / `@end` / `@step` / `@exclude_end`.
   class ArithmeticSequence
     include Enumerable
 
-    # Bypass the standard `Enumerator#new(&block)` requirement so
-    # `Range#step` can stamp begin/end/step/exclude_end? on a fresh
-    # instance without going through the Fiber path.
-    def self.__build(b, e, step, exclude_end)
-      o = allocate
-      o.__send__(:__init, b, e, step, exclude_end)
-      o
+    def begin
+      __b
     end
 
-    def __init(b, e, step, exclude_end)
-      @begin = b
-      @end = e
-      @step = step
-      @exclude_end = exclude_end ? true : false
+    def end
+      __e
     end
-    private :__init
 
-    attr_reader :begin, :end, :step
+    def step
+      __s
+    end
+
+    def exclude_end?
+      __excl?
+    end
 
     # `first` follows Enumerator#first: with no arg returns the
     # first yielded value (== `begin` for a non-empty AS); with
     # `n` returns the first `n` yielded values.
     def first(n = nil)
-      n.nil? ? @begin : take(n)
-    end
-
-    def exclude_end?
-      @exclude_end
+      n.nil? ? __b : take(n)
     end
 
     def is_a?(klass)
@@ -1036,10 +1037,11 @@ class Enumerator
     # `inspect` separately to hit the second form; this default is
     # the `step` form.
     def inspect
-      lo = @begin.nil? ? "" : @begin.inspect
-      hi = @end.nil?  ? "" : @end.inspect
-      sep = @exclude_end ? "..." : ".."
-      step_part = @step.nil? ? "" : @step.inspect
+      b, e, s, excl = __b, __e, __s, __excl?
+      lo = b.nil? ? "" : b.inspect
+      hi = e.nil? ? "" : e.inspect
+      sep = excl ? "..." : ".."
+      step_part = s.nil? ? "" : s.inspect
       "((#{lo}#{sep}#{hi}).step(#{step_part}))"
     end
     alias to_s inspect
@@ -1064,9 +1066,10 @@ class Enumerator
     # `ArgumentError` when the step isn't `Numeric` (CRuby checks
     # this lazily on `.size`).
     def size
-      b = @begin
-      e = @end
-      s = @step
+      b = __b
+      e = __e
+      s = __s
+      excl = __excl?
       raise ArgumentError, "step must be numeric" unless s.is_a?(Numeric)
       raise ArgumentError, "step can't be 0" if s == 0
       if b.nil?
@@ -1082,9 +1085,9 @@ class Enumerator
       # (the `begin`, if it satisfies the bound), so size is 1 or 0.
       if s.is_a?(Float) && s.infinite?
         if s > 0
-          return @exclude_end ? (b < e ? 1 : 0) : (b <= e ? 1 : 0)
+          return excl ? (b < e ? 1 : 0) : (b <= e ? 1 : 0)
         else
-          return @exclude_end ? (b > e ? 1 : 0) : (b >= e ? 1 : 0)
+          return excl ? (b > e ? 1 : 0) : (b >= e ? 1 : 0)
         end
       end
       diff = e - b
@@ -1100,7 +1103,7 @@ class Enumerator
       # above). Avoid `Float::INFINITY.floor` (FloatDomainError).
       return Float::INFINITY if n.infinite?
       n_int = n.floor
-      if @exclude_end
+      if excl
         last = b + n_int * s
         overshoot = s > 0 ? last >= e : last <= e
         n_int -= 1 if overshoot
@@ -1132,21 +1135,24 @@ class Enumerator
     #     semantics.
     def [](arr)
       len = arr.length
-      s = @step
+      raw_b = __b
+      raw_e = __e
+      s = __s
+      excl = __excl?
       return [] if s == 0
 
       if s > 0
         # ---- positive step ----------------------------------------
-        b = @begin.nil? ? 0 : @begin
+        b = raw_b.nil? ? 0 : raw_b
         b += len if b < 0
         # begin past the boundary: nil for stride 1 (matches plain
         # `arr[N..]`), RangeError for larger strides — CRuby
         # promotes the OOB to an error when the user explicitly
         # asked for a non-trivial stride.
-        if !@begin.nil? && b > len
+        if !raw_b.nil? && b > len
           if s > 1
             raise RangeError,
-                  "((#{@begin.inspect}..#{@end.inspect}).step(#{s.inspect})) out of range"
+                  "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
           end
           return nil
         end
@@ -1154,22 +1160,22 @@ class Enumerator
         return [] if b == len
         return nil if b < 0
 
-        if @end.nil?
+        if raw_e.nil?
           e = len - 1
           end_is_term = false
         else
-          e_res = @end
+          e_res = raw_e
           e_res += len if e_res < 0
           # `end` is a term of the sequence iff stepping from begin
           # lands exactly on it (and end is inclusive).
-          end_is_term = !@exclude_end && b >= 0 && (e_res - b) % s == 0
+          end_is_term = !excl && b >= 0 && (e_res - b) % s == 0
           # CRuby raises when stride > 1 and the *user-supplied*
           # end is itself a yielded value past the array.
           if s > 1 && end_is_term && e_res >= len
             raise RangeError,
-                  "((#{@begin.inspect}..#{@end.inspect}).step(#{s.inspect})) out of range"
+                  "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
           end
-          e = @exclude_end ? e_res - 1 : e_res
+          e = excl ? e_res - 1 : e_res
         end
         e = len - 1 if e >= len
         return [] if e < b
@@ -1182,10 +1188,10 @@ class Enumerator
         result
       else
         # ---- negative step ----------------------------------------
-        if @begin.nil?
+        if raw_b.nil?
           b = len - 1
         else
-          b = @begin
+          b = raw_b
           b += len if b < 0
           # begin past the array's last index: clip to `len - 1`,
           # but only if the gap is small enough — when
@@ -1195,19 +1201,19 @@ class Enumerator
             diff = b - (len - 1)
             if s.abs > 1 && diff > s.abs
               raise RangeError,
-                    "((#{@begin.inspect}..#{@end.inspect}).step(#{s.inspect})) out of range"
+                    "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
             end
             b = len - 1
           end
           return nil if b < 0
         end
 
-        if @end.nil?
+        if raw_e.nil?
           e = 0
         else
-          e_res = @end
+          e_res = raw_e
           e_res += len if e_res < 0
-          e = @exclude_end ? e_res + 1 : e_res
+          e = excl ? e_res + 1 : e_res
         end
         e = 0 if e < 0
         return [] if b < e
@@ -1224,9 +1230,10 @@ class Enumerator
     private
 
     def __each
-      b = @begin
-      e = @end
-      s = @step
+      b = __b
+      e = __e
+      s = __s
+      excl = __excl?
       raise TypeError, "step can't be 0" if s == 0
       raise ArgumentError, "#each for beginless arithmetic sequences is meaningless" if b.nil?
       cur = b
@@ -1236,7 +1243,7 @@ class Enumerator
           cur += s
         end
       elsif s > 0
-        if @exclude_end
+        if excl
           while cur < e
             yield cur
             cur += s
@@ -1248,7 +1255,7 @@ class Enumerator
           end
         end
       else
-        if @exclude_end
+        if excl
           while cur > e
             yield cur
             cur += s

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -50,6 +50,112 @@ pub(super) fn init(globals: &mut Globals) {
         Effect::CAPTURE,
     );
     globals.define_builtin_func_rest(GENERATOR_CLASS, "each", generator_each);
+
+    // `Enumerator::ArithmeticSequence` — Phase 1: native storage
+    // backs a Ruby class. The higher-level behaviour
+    // (`size`/`each`/`[]`/...) still lives in `enumerable.rb` and
+    // reaches the native `(begin, end, step, exclude_end?)` tuple
+    // through the private readers defined below.
+    globals.define_builtin_class(
+        "ArithmeticSequence",
+        ARITHMETIC_SEQUENCE_CLASS,
+        object_class,
+        ENUMERATOR_CLASS,
+        ObjTy::ARITHMETIC_SEQUENCE,
+    );
+    globals.define_builtin_class_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "__build",
+        arithmetic_sequence_build,
+        4,
+    );
+    globals.define_private_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "__b",
+        arithmetic_sequence_read_begin,
+        0,
+    );
+    globals.define_private_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "__e",
+        arithmetic_sequence_read_end,
+        0,
+    );
+    globals.define_private_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "__s",
+        arithmetic_sequence_read_step,
+        0,
+    );
+    globals.define_private_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "__excl?",
+        arithmetic_sequence_read_exclude_end,
+        0,
+    );
+}
+
+///
+/// ### Enumerator::ArithmeticSequence.__build
+///
+/// Internal allocator used by `Numeric#step` / `Range#step` /
+/// `Range#%`. Mirrors the original Ruby-side
+/// `allocate` + `__init` dance — bypasses `Enumerator#new`'s
+/// block requirement and stamps the native tuple directly.
+#[monoruby_builtin]
+fn arithmetic_sequence_build(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let begin = lfp.arg(0);
+    let end = lfp.arg(1);
+    let step = lfp.arg(2);
+    let exclude_end = lfp.arg(3).as_bool();
+    Ok(Value::arithmetic_sequence(begin, end, step, exclude_end))
+}
+
+#[monoruby_builtin]
+fn arithmetic_sequence_read_begin(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(lfp.self_val().as_arithmetic_sequence_inner().begin())
+}
+
+#[monoruby_builtin]
+fn arithmetic_sequence_read_end(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(lfp.self_val().as_arithmetic_sequence_inner().end())
+}
+
+#[monoruby_builtin]
+fn arithmetic_sequence_read_step(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(lfp.self_val().as_arithmetic_sequence_inner().step())
+}
+
+#[monoruby_builtin]
+fn arithmetic_sequence_read_exclude_end(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::bool(
+        lfp.self_val().as_arithmetic_sequence_inner().exclude_end(),
+    ))
 }
 
 ///

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -71,6 +71,8 @@ pub const FATAL_ERROR_CLASS: ClassId = ClassId::new(53);
 /// and `false` does not deopt on every flip.
 pub const BOOL_CLASS: ClassId = ClassId::new(54);
 
+pub const ARITHMETIC_SEQUENCE_CLASS: ClassId = ClassId::new(55);
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct ClassId(NonZeroU32);
@@ -134,6 +136,7 @@ impl std::fmt::Debug for ClassId {
             52 => write!(f, "RATIONAL"),
             53 => write!(f, "FATAL_ERROR"),
             54 => write!(f, "BOOL"),
+            55 => write!(f, "ARITHMETIC_SEQUENCE"),
             n => write!(f, "ClassId({n})"),
         }
     }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1071,6 +1071,10 @@ impl Value {
         v
     }
 
+    pub fn arithmetic_sequence(begin: Value, end: Value, step: Value, exclude_end: bool) -> Self {
+        RValue::new_arithmetic_sequence(begin, end, step, exclude_end).pack()
+    }
+
     pub fn range_with_class(
         start: Value,
         end: Value,
@@ -2316,6 +2320,12 @@ impl Value {
         assert_eq!(ObjTy::ENUMERATOR, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue contains an enumerator.
         unsafe { self.rvalue_mut().as_enumerator_mut() }
+    }
+
+    pub fn as_arithmetic_sequence_inner(&self) -> &ArithmeticSequenceInner {
+        assert_eq!(ObjTy::ARITHMETIC_SEQUENCE, self.rvalue().ty());
+        // SAFETY: The assert ensures this RValue contains an arithmetic sequence.
+        unsafe { self.rvalue().as_arithmetic_sequence() }
     }
 
     pub fn as_generator_inner(&self) -> &GeneratorInner {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -9,6 +9,9 @@ use std::mem::ManuallyDrop;
 
 use crate::ast::{Loc, SourceInfoRef};
 
+pub use arithmetic_sequence::{
+    AS_BEGIN_OFFSET, AS_END_OFFSET, AS_EXCLUDE_END_OFFSET, AS_STEP_OFFSET, ArithmeticSequenceInner,
+};
 pub use array::*;
 pub use binding::*;
 pub use complex::ComplexInner;
@@ -29,6 +32,7 @@ pub(crate) use string::pack::*;
 pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 
+mod arithmetic_sequence;
 mod array;
 mod binding;
 mod complex;
@@ -93,6 +97,7 @@ impl std::fmt::Debug for ObjTy {
                 22 => "MATCHDATA",
                 23 => "RATIONAL",
                 24 => "STRUCT",
+                25 => "ARITHMETIC_SEQUENCE",
                 _ => return write!(f, "INVALID({ty})"),
             }
         )
@@ -130,6 +135,7 @@ impl ObjTy {
     pub const MATCHDATA: Self = Self(std::num::NonZeroU8::new(22).unwrap());
     pub const RATIONAL: Self = Self(std::num::NonZeroU8::new(23).unwrap());
     pub const STRUCT: Self = Self(std::num::NonZeroU8::new(24).unwrap());
+    pub const ARITHMETIC_SEQUENCE: Self = Self(std::num::NonZeroU8::new(25).unwrap());
 }
 
 #[repr(C)]
@@ -164,6 +170,7 @@ pub union ObjKind {
     /// load slots without an extra Box deref. Same layout as
     /// `ArrayInner`'s `SmallVec<[Value; 5]>`.
     struct_inner: ManuallyDrop<StructInner>,
+    arithmetic_sequence: ManuallyDrop<ArithmeticSequenceInner>,
 }
 
 impl ObjKind {
@@ -388,6 +395,17 @@ impl ObjKind {
             rational: ManuallyDrop::new(Box::new(inner)),
         }
     }
+
+    fn arithmetic_sequence(begin: Value, end: Value, step: Value, exclude_end: bool) -> Self {
+        Self {
+            arithmetic_sequence: ManuallyDrop::new(ArithmeticSequenceInner::new(
+                begin,
+                end,
+                step,
+                exclude_end,
+            )),
+        }
+    }
 }
 
 /// Heap-allocated objects.
@@ -449,6 +467,9 @@ impl std::fmt::Debug for RValue {
                             ObjTy::UMETHOD => format!("{:?}", self.kind.umethod),
                             ObjTy::MATCHDATA => format!("{:?}", self.kind.matchdata),
                             ObjTy::STRUCT => format!("{:?}", self.kind.struct_inner),
+                            ObjTy::ARITHMETIC_SEQUENCE => {
+                                format!("{:?}", self.kind.arithmetic_sequence)
+                            }
                             _ => unreachable!(),
                         }
                     })
@@ -691,6 +712,7 @@ impl alloc::GC<RValue> for RValue {
                 ObjTy::UMETHOD => {}
                 ObjTy::MATCHDATA => self.as_matchdata().mark(alloc),
                 ObjTy::STRUCT => self.as_struct_inner().mark(alloc),
+                ObjTy::ARITHMETIC_SEQUENCE => self.as_arithmetic_sequence().mark(alloc),
                 _ => unreachable!("mark {:016x} {:?}", self.id(), self.ty()),
             }
         }
@@ -729,6 +751,9 @@ impl alloc::GCBox for RValue {
                 ObjTy::RATIONAL => ManuallyDrop::drop(&mut self.kind.rational),
                 ObjTy::STRUCT => ManuallyDrop::drop(&mut self.kind.struct_inner),
                 ObjTy::MATCHDATA => ManuallyDrop::drop(&mut self.kind.matchdata),
+                ObjTy::ARITHMETIC_SEQUENCE => {
+                    ManuallyDrop::drop(&mut self.kind.arithmetic_sequence)
+                }
                 _ => {}
             }
             self.set_next_none();
@@ -941,6 +966,15 @@ impl RValue {
                             lhs.exclude_end(),
                         )
                     }
+                    ObjTy::ARITHMETIC_SEQUENCE => {
+                        let lhs = self.as_arithmetic_sequence();
+                        ObjKind::arithmetic_sequence(
+                            lhs.begin().deep_copy(),
+                            lhs.end().deep_copy(),
+                            lhs.step().deep_copy(),
+                            lhs.exclude_end(),
+                        )
+                    }
                     /*ObjTy::HASH => {
                         let mut map = RubyMap::default();
                         let hash = self.as_hashmap();
@@ -1039,6 +1073,11 @@ impl RValue {
                         ObjTy::STRUCT => ObjKind {
                             struct_inner: ManuallyDrop::new((*self.kind.struct_inner).clone()),
                         },
+                        ObjTy::ARITHMETIC_SEQUENCE => ObjKind {
+                            arithmetic_sequence: ManuallyDrop::new(
+                                (*self.kind.arithmetic_sequence).clone(),
+                            ),
+                        },
                         ty => unreachable!("{ty:?}"),
                     }
                 } else {
@@ -1110,6 +1149,11 @@ impl RValue {
                         },
                         ObjTy::STRUCT => ObjKind {
                             struct_inner: ManuallyDrop::new((*self.kind.struct_inner).clone()),
+                        },
+                        ObjTy::ARITHMETIC_SEQUENCE => ObjKind {
+                            arithmetic_sequence: ManuallyDrop::new(
+                                (*self.kind.arithmetic_sequence).clone(),
+                            ),
                         },
                         ty => unreachable!("{ty:?}"),
                     }
@@ -1542,6 +1586,19 @@ impl RValue {
         }
     }
 
+    pub(super) fn new_arithmetic_sequence(
+        begin: Value,
+        end: Value,
+        step: Value,
+        exclude_end: bool,
+    ) -> Self {
+        RValue {
+            header: Header::new(ARITHMETIC_SEQUENCE_CLASS, ObjTy::ARITHMETIC_SEQUENCE),
+            kind: ObjKind::arithmetic_sequence(begin, end, step, exclude_end),
+            var_table: None,
+        }
+    }
+
     pub(super) fn new_binding(outer_lfp: Lfp, call_site_pc: Option<BytecodePtr>) -> Self {
         let outer_lfp = outer_lfp.move_frame_to_heap();
         assert!(!outer_lfp.on_stack());
@@ -1814,6 +1871,10 @@ impl RValue {
 
     pub(super) unsafe fn as_generator_mut(&mut self) -> &mut GeneratorInner {
         unsafe { &mut self.kind.generator }
+    }
+
+    pub(super) unsafe fn as_arithmetic_sequence(&self) -> &ArithmeticSequenceInner {
+        unsafe { &self.kind.arithmetic_sequence }
     }
 
     pub(super) unsafe fn as_binding(&self) -> &BindingInner {

--- a/monoruby/src/value/rvalue/arithmetic_sequence.rs
+++ b/monoruby/src/value/rvalue/arithmetic_sequence.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+pub const AS_BEGIN_OFFSET: usize =
+    RVALUE_OFFSET_KIND + std::mem::offset_of!(ArithmeticSequenceInner, begin);
+pub const AS_END_OFFSET: usize =
+    RVALUE_OFFSET_KIND + std::mem::offset_of!(ArithmeticSequenceInner, end);
+pub const AS_STEP_OFFSET: usize =
+    RVALUE_OFFSET_KIND + std::mem::offset_of!(ArithmeticSequenceInner, step);
+pub const AS_EXCLUDE_END_OFFSET: usize =
+    RVALUE_OFFSET_KIND + std::mem::offset_of!(ArithmeticSequenceInner, exclude_end);
+
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct ArithmeticSequenceInner {
+    begin: Value,
+    end: Value,
+    step: Value,
+    exclude_end: u32,
+}
+
+impl GC<RValue> for ArithmeticSequenceInner {
+    fn mark(&self, alloc: &mut Allocator<RValue>) {
+        self.begin.mark(alloc);
+        self.end.mark(alloc);
+        self.step.mark(alloc);
+    }
+}
+
+impl ArithmeticSequenceInner {
+    pub fn new(begin: Value, end: Value, step: Value, exclude_end: bool) -> Self {
+        ArithmeticSequenceInner {
+            begin,
+            end,
+            step,
+            exclude_end: if exclude_end { 1 } else { 0 },
+        }
+    }
+
+    pub fn begin(&self) -> Value {
+        self.begin
+    }
+
+    pub fn end(&self) -> Value {
+        self.end
+    }
+
+    pub fn step(&self) -> Value {
+        self.step
+    }
+
+    pub fn exclude_end(&self) -> bool {
+        self.exclude_end != 0
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of a three-phase migration moving `Enumerator::ArithmeticSequence` from a pure-Ruby class (added in #472) onto a Rust-native `RValue` variant. This phase is **storage-only**: behaviour is unchanged and the Ruby class body keeps owning `size` / `each` / `[]` / `inspect`. Subsequent phases will lift accessors and the slice operator into Rust now that the fields are reachable without going through `instance_variable_get`.

Supersedes the now-closed #485 (which got polluted with Phase 2 on the same branch). Phase 2 is stacked on top as a separate PR.

## What changes

- New `ObjTy::ARITHMETIC_SEQUENCE` (`= 25`) and `ARITHMETIC_SEQUENCE_CLASS` (`= 55`), with a dedicated `ArithmeticSequenceInner { begin, end, step, exclude_end }` (`monoruby/src/value/rvalue/arithmetic_sequence.rs`). Sized inline at 32 bytes — fits in `ObjKind` without a `Box`.
- `Enumerator::ArithmeticSequence` is now registered as a builtin class in `enumerator.rs::init` (mirroring `Generator`), with `__build(b, e, step, exclude_end)` returning a fresh AS `RValue` via `Value::arithmetic_sequence(...)`. Replaces the old `allocate` + private `__init` dance.
- Private Rust-side readers `__b` / `__e` / `__s` / `__excl?` expose the native fields.
- `enumerable.rb`'s AS class keeps its higher-level methods but rewrites every `@begin` / `@end` / `@step` / `@exclude_end` reference to the matching reader. The public `begin` / `end` / `step` / `exclude_end?` are now thin wrappers around `__b` / `__e` / `__s` / `__excl?`.
- Superclass stays `Object` so the Ruby `class Enumerator::ArithmeticSequence` reopen keeps working without a superclass mismatch (the `is_a?(Enumerator)` lie still lives in the Ruby override).
- Removes the stale placeholder `ArithmeticSequence = self unless defined?(ArithmeticSequence)` in `builtins.rb` — the constant is now defined in Rust before any Ruby file loads, so the guard always skipped.

## Why split this up

Phase 1 leaves the higher-level methods in Ruby so the diff is mechanical and the unit-test coverage from #472 / #477 (range / numeric / array) shields against any regression. Once the storage is native, Phase 2 (accessors → Rust) and Phase 3 (`AS#[]` → Rust, `Array#[aseq]` direct-read) only touch one method at a time — much easier to review and bisect.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib -- arithmetic` — 7/7 passing (covers the AS-targeted regression tests added in #472 / #477 / #481)
- [x] `cargo test --lib -- builtins::range:: builtins::enumerator:: builtins::numeric::integer::` — 161/161 passing
- [x] Failures elsewhere in `cargo test --lib` are environmental (Ruby 3.3 vs 4.0 output diffing); identical set on `master` — none introduced by this PR

https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD)_