### PR TITLE
core/arithmetic_sequence: phase 2 — accessors + inspect in Rust

### DIFF
--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -991,38 +991,20 @@ class Enumerator
   # `kind_of?` are overridden to keep `is_a?(Enumerator)` truthy
   # for spec compatibility.
   #
-  # Phase 1 of the Rust-native migration: storage moved off Ruby
+  # Phase 1 of the Rust-native migration moved storage off Ruby
   # ivars onto a dedicated `RValue` variant
-  # (`ObjTy::ARITHMETIC_SEQUENCE`).  `__build` and the private
-  # `__b` / `__e` / `__s` / `__excl?` readers are Rust builtins
-  # that operate on those fields directly; the rest of this class
-  # is still Ruby, but reaches the fields through those readers
-  # instead of `@begin` / `@end` / `@step` / `@exclude_end`.
+  # (`ObjTy::ARITHMETIC_SEQUENCE`).  Phase 2 then moved every
+  # accessor and the `inspect` / `to_s` / `first` / `last`
+  # formatters into Rust builtins (registered in
+  # `src/builtins/enumerator.rs`), so this Ruby class body only
+  # needs to host the parts that still depend on Ruby semantics:
+  #   * `is_a?` / `kind_of?` — lie about `Enumerator` ancestry
+  #   * `each` — block-iteration kept in Ruby per design (Phase 2)
+  #   * `to_a` / `entries` — thin `__each` wrapper
+  #   * `size` — Numeric-type dispatch is easier in Ruby for now
+  #   * `[]` — stride-aware Array slicer (Rust-ified in Phase 3)
   class ArithmeticSequence
     include Enumerable
-
-    def begin
-      __b
-    end
-
-    def end
-      __e
-    end
-
-    def step
-      __s
-    end
-
-    def exclude_end?
-      __excl?
-    end
-
-    # `first` follows Enumerator#first: with no arg returns the
-    # first yielded value (== `begin` for a non-empty AS); with
-    # `n` returns the first `n` yielded values.
-    def first(n = nil)
-      n.nil? ? __b : take(n)
-    end
 
     def is_a?(klass)
       return true if klass == Enumerator::ArithmeticSequence
@@ -1031,20 +1013,6 @@ class Enumerator
       super
     end
     alias kind_of? is_a?
-
-    # CRuby format: `((begin..end).step(step))` — or `%(step)` when
-    # the sequence was produced via `Range#%`. `Range#%` overrides
-    # `inspect` separately to hit the second form; this default is
-    # the `step` form.
-    def inspect
-      b, e, s, excl = __b, __e, __s, __excl?
-      lo = b.nil? ? "" : b.inspect
-      hi = e.nil? ? "" : e.inspect
-      sep = excl ? "..." : ".."
-      step_part = s.nil? ? "" : s.inspect
-      "((#{lo}#{sep}#{hi}).step(#{step_part}))"
-    end
-    alias to_s inspect
 
     def each(&block)
       return self.to_enum(:each) { size } unless block
@@ -1109,11 +1077,6 @@ class Enumerator
         n_int -= 1 if overshoot
       end
       n_int + 1
-    end
-
-    def last(n = nil)
-      arr = to_a
-      n.nil? ? arr.last : arr.last(n)
     end
 
     # `aseq[arr]` — extract the slice of `arr` whose indices are the

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -51,11 +51,13 @@ pub(super) fn init(globals: &mut Globals) {
     );
     globals.define_builtin_func_rest(GENERATOR_CLASS, "each", generator_each);
 
-    // `Enumerator::ArithmeticSequence` — Phase 1: native storage
-    // backs a Ruby class. The higher-level behaviour
-    // (`size`/`each`/`[]`/...) still lives in `enumerable.rb` and
-    // reaches the native `(begin, end, step, exclude_end?)` tuple
-    // through the private readers defined below.
+    // `Enumerator::ArithmeticSequence` — Phase 2: accessors and
+    // formatters are Rust builtins reading directly from the
+    // `ObjTy::ARITHMETIC_SEQUENCE` native fields. Higher-level
+    // behaviour that requires Enumerable-style iteration (`size`,
+    // `each`, `to_a`, `[]`) still lives in `enumerable.rb` and
+    // reaches the fields through the private `__b`/`__e`/`__s`/
+    // `__excl?` readers, which Phase 3 will retire alongside `[]`.
     globals.define_builtin_class(
         "ArithmeticSequence",
         ARITHMETIC_SEQUENCE_CLASS,
@@ -69,6 +71,57 @@ pub(super) fn init(globals: &mut Globals) {
         arithmetic_sequence_build,
         4,
     );
+    globals.define_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "begin",
+        arithmetic_sequence_read_begin,
+        0,
+    );
+    globals.define_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "end",
+        arithmetic_sequence_read_end,
+        0,
+    );
+    globals.define_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "step",
+        arithmetic_sequence_read_step,
+        0,
+    );
+    globals.define_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "exclude_end?",
+        arithmetic_sequence_read_exclude_end,
+        0,
+    );
+    globals.define_builtin_funcs(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "inspect",
+        &["to_s"],
+        arithmetic_sequence_inspect,
+        0,
+    );
+    globals.define_builtin_func_with(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "first",
+        arithmetic_sequence_first,
+        0,
+        1,
+        false,
+    );
+    globals.define_builtin_func_with(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "last",
+        arithmetic_sequence_last,
+        0,
+        1,
+        false,
+    );
+    // Private aliases kept so the still-Ruby `size` / `[]` / `__each`
+    // bodies in `enumerable.rb` can keep referring to the fields by
+    // their internal shorthand. Phase 3 retires `[]` (and these along
+    // with it).
     globals.define_private_builtin_func(
         ARITHMETIC_SEQUENCE_CLASS,
         "__b",
@@ -156,6 +209,91 @@ fn arithmetic_sequence_read_exclude_end(
     Ok(Value::bool(
         lfp.self_val().as_arithmetic_sequence_inner().exclude_end(),
     ))
+}
+
+///
+/// ### Enumerator::ArithmeticSequence#inspect / #to_s
+///
+/// Returns the CRuby format string `((begin..end).step(step))`,
+/// using `...` for an exclusive end and eliding `nil` endpoints.
+/// Goes through `RValue::inspect`, so `p [aseq]` formats the AS
+/// in place too.
+#[monoruby_builtin]
+fn arithmetic_sequence_inspect(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::string(lfp.self_val().inspect(&globals.store)))
+}
+
+///
+/// ### Enumerator::ArithmeticSequence#first
+///
+/// - first -> object
+/// - first(n) -> Array
+///
+/// With no argument returns `begin` (the first term, or `nil`
+/// when the sequence is beginless — beginless `first` does not
+/// raise here, mirroring CRuby's behaviour for AS). With an `n`
+/// argument materialises the first `n` terms by dispatching to
+/// `Enumerable#take(n)`, which in turn drives `#each`.
+#[monoruby_builtin]
+fn arithmetic_sequence_first(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    if let Some(n) = lfp.try_arg(0) {
+        vm.invoke_method_inner(
+            globals,
+            IdentId::get_id("take"),
+            self_val,
+            &[n],
+            None,
+            None,
+        )
+    } else {
+        Ok(self_val.as_arithmetic_sequence_inner().begin())
+    }
+}
+
+///
+/// ### Enumerator::ArithmeticSequence#last
+///
+/// - last -> object
+/// - last(n) -> Array
+///
+/// Materialises the sequence via `#to_a` and delegates to
+/// `Array#last`. (CRuby resolves `last` analytically for AS,
+/// but the simple-and-correct dispatch through `to_a` is enough
+/// to stop spec failures; an analytic Rust path can land later
+/// without changing this method's contract.)
+#[monoruby_builtin]
+fn arithmetic_sequence_last(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let arr = vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("to_a"),
+        self_val,
+        &[],
+        None,
+        None,
+    )?;
+    let last_id = IdentId::get_id("last");
+    if let Some(n) = lfp.try_arg(0) {
+        vm.invoke_method_inner(globals, last_id, arr, &[n], None, None)
+    } else {
+        vm.invoke_method_inner(globals, last_id, arr, &[], None, None)
+    }
 }
 
 ///

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -520,6 +520,10 @@ impl RValue {
                 // OBJECT — `Struct#inspect` (Rust builtin) is what users
                 // see; this is just for internal diagnostics.
                 ObjTy::STRUCT => self.object_debug(store),
+                ObjTy::ARITHMETIC_SEQUENCE => {
+                    let mut set = HashSet::new();
+                    self.as_arithmetic_sequence().inspect(store, &mut set)
+                }
                 _ => format!("{:016x}", self.id()),
             }
         }
@@ -546,6 +550,10 @@ impl RValue {
                 ObjTy::BINDING => self.object_tos(store),
                 ObjTy::UMETHOD => self.as_umethod().to_s(store),
                 ObjTy::MATCHDATA => self.as_match_data().to_s(),
+                ObjTy::ARITHMETIC_SEQUENCE => {
+                    let mut set = HashSet::new();
+                    self.as_arithmetic_sequence().inspect(store, &mut set)
+                }
                 _ => self.debug(store),
             }
         }
@@ -565,6 +573,7 @@ impl RValue {
                 ObjTy::MATCHDATA => self.as_match_data().inspect(),
                 ObjTy::HASH => self.hash_inspect(store, set),
                 ObjTy::RANGE => self.as_range().inspect(store, set),
+                ObjTy::ARITHMETIC_SEQUENCE => self.as_arithmetic_sequence().inspect(store, set),
                 _ => self.to_s(store),
             }
         }

--- a/monoruby/src/value/rvalue/arithmetic_sequence.rs
+++ b/monoruby/src/value/rvalue/arithmetic_sequence.rs
@@ -51,4 +51,29 @@ impl ArithmeticSequenceInner {
     pub fn exclude_end(&self) -> bool {
         self.exclude_end != 0
     }
+
+    /// CRuby format: `((begin..end).step(step))` — or `((begin...end).step(step))`
+    /// for exclusive end. `nil` endpoints are elided to the empty string
+    /// (so `(0..).step(2)` prints as `((0..).step(2))`, not
+    /// `((0..nil).step(2))`). `step.inspect` is used directly so a Float
+    /// step prints as `0.5` rather than `(1/2)`.
+    pub(super) fn inspect(&self, store: &Store, set: &mut HashSet<u64>) -> String {
+        let sep = if self.exclude_end() { "..." } else { ".." };
+        let lo = if self.begin.is_nil() {
+            String::new()
+        } else {
+            self.begin.inspect_inner(store, set)
+        };
+        let hi = if self.end.is_nil() {
+            String::new()
+        } else {
+            self.end.inspect_inner(store, set)
+        };
+        let step_part = if self.step.is_nil() {
+            String::new()
+        } else {
+            self.step.inspect_inner(store, set)
+        };
+        format!("(({lo}{sep}{hi}).step({step_part}))")
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the AS Rust-native migration. Stacks on top of #486.

Phase 1 put `Enumerator::ArithmeticSequence` on a native `ObjTy::ARITHMETIC_SEQUENCE` but left every high-level method in `enumerable.rb`, reaching the fields through `__b` / `__e` / `__s` / `__excl?` private readers. Phase 2 promotes the accessors and the user-facing formatters into Rust builtins on `ARITHMETIC_SEQUENCE_CLASS`.

## What changes

- `begin` / `end` / `step` / `exclude_end?` are now Rust builtins — direct field reads, no `def begin; __b end` thunk on the way.
- `inspect` / `to_s` are computed by `ArithmeticSequenceInner::inspect` (mirroring `RangeInner::inspect`):
  - nil endpoints elide to empty strings
  - exclusive end produces `...`
  - child values go through `inspect_inner` so floats keep their literal form
  - **also wired into `RValue::inspect` / `to_s` / `debug`**, so `p [aseq]` and similar nested formatters reach the AS output without a per-call method dispatch
- `first` and `last` are Rust builtins that VM-dispatch to `take(n)` / `to_a.last(n)` for the n-argument case and return `begin` / a materialised last directly otherwise. Same observable behaviour as the Ruby `n.nil? ? __b : take(n)` it replaces.
- `__b` / `__e` / `__s` / `__excl?` private readers stay registered (still-Ruby `size`, `[]`, `__each` reference them) — Phase 3 will retire `[]` and these together.

## What stays in Ruby

- `size` — Numeric-class dispatch (Float infinity vs Integer arithmetic, NaN guarding, exclusive-end overshoot). A correct Rust port needs full VM dispatch for `+`/`-`/`*`/`<` against arbitrary numeric types; left for a follow-up so the Phase 2 diff stays mechanical.
- `each` — block iteration in Ruby per the design decision (user-confirmed in the planning thread).
- `to_a` / `entries` — thin `__each` wrappers.
- `[]` — lands in Phase 3.
- `is_a?` / `kind_of?` — Enumerator/Enumerable ancestry lie.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib -- arithmetic` — 7/7 passing
- [x] `cargo test --lib -- builtins::range:: builtins::enumerator:: builtins::numeric::integer:: builtins::array::` — 303/306 passing; the 3 failures (`array_inspect`, `array_tos_recursive`, `fetch_values`) are pre-existing on master (Ruby 3.3 vs 4.0 env diffing — confirmed by stashing the PR's changes and re-running)
- [x] Runtime smoke test vs CRuby for the rewritten methods:
  - `(1..10).step(2)`'s `begin`/`end`/`step`/`exclude_end?`/`inspect`/`to_s`/`first`/`first(n)`/`last`/`last(n)`/`size`/`class` all match exactly
  - `p [(0..).step(2), (1...10).step(3)]` matches exactly (exercises the `RValue::inspect` dispatch)
  - `aseq.define_singleton_method(:foo)` still resolves
  - `Range#%`'s custom `inspect` override (per-instance singleton `define_singleton_method(:inspect)`) keeps working

https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD)_