### PR TITLE
core/arithmetic_sequence: phase 3 — AS#[] in Rust, Array#[aseq] direct-read

### DIFF
--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -991,18 +991,16 @@ class Enumerator
   # `kind_of?` are overridden to keep `is_a?(Enumerator)` truthy
   # for spec compatibility.
   #
-  # Phase 1 of the Rust-native migration moved storage off Ruby
-  # ivars onto a dedicated `RValue` variant
-  # (`ObjTy::ARITHMETIC_SEQUENCE`).  Phase 2 then moved every
-  # accessor and the `inspect` / `to_s` / `first` / `last`
-  # formatters into Rust builtins (registered in
-  # `src/builtins/enumerator.rs`), so this Ruby class body only
-  # needs to host the parts that still depend on Ruby semantics:
+  # The Rust-native migration (phases 1–3) moved storage onto a
+  # dedicated `RValue` variant (`ObjTy::ARITHMETIC_SEQUENCE`),
+  # promoted every accessor / formatter / slicer into Rust
+  # builtins (registered in `src/builtins/enumerator.rs`), and
+  # left only the parts that still depend on Ruby semantics
+  # in this class body:
   #   * `is_a?` / `kind_of?` — lie about `Enumerator` ancestry
-  #   * `each` — block-iteration kept in Ruby per design (Phase 2)
+  #   * `each` — block-iteration in Ruby (by design)
   #   * `to_a` / `entries` — thin `__each` wrapper
   #   * `size` — Numeric-type dispatch is easier in Ruby for now
-  #   * `[]` — stride-aware Array slicer (Rust-ified in Phase 3)
   class ArithmeticSequence
     include Enumerable
 
@@ -1077,117 +1075,6 @@ class Enumerator
         n_int -= 1 if overshoot
       end
       n_int + 1
-    end
-
-    # `aseq[arr]` — extract the slice of `arr` whose indices are the
-    # terms of this sequence. Independent of Array's own `[]`
-    # implementation: Array#[] delegates here when its index argument
-    # is an ArithmeticSequence, instead of carrying AS-specific code.
-    #
-    # Mirrors CRuby's `rb_ary_subseq_step` behaviour:
-    #   * Resolve `begin` (nil → 0 for positive step, len-1 for
-    #     negative; negative ints rebased against `len`).
-    #   * Resolve `end` (nil → len-1 / 0; exclusive end ⇒ inner term).
-    #   * Walk by `step`, collecting elements whose index is in
-    #     `0...len`.
-    #   * `RangeError` when the explicit end (or begin for negative
-    #     step) is itself a term of the AS that lands outside the
-    #     array — see comments inline.
-    #   * Pure-`nil` return when `begin` is out of bounds for the
-    #     `step == ±1` cases that fall back to plain Range slicing
-    #     semantics.
-    def [](arr)
-      len = arr.length
-      raw_b = __b
-      raw_e = __e
-      s = __s
-      excl = __excl?
-      return [] if s == 0
-
-      if s > 0
-        # ---- positive step ----------------------------------------
-        b = raw_b.nil? ? 0 : raw_b
-        b += len if b < 0
-        # begin past the boundary: nil for stride 1 (matches plain
-        # `arr[N..]`), RangeError for larger strides — CRuby
-        # promotes the OOB to an error when the user explicitly
-        # asked for a non-trivial stride.
-        if !raw_b.nil? && b > len
-          if s > 1
-            raise RangeError,
-                  "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
-          end
-          return nil
-        end
-        # begin exactly at the boundary (== len): empty result.
-        return [] if b == len
-        return nil if b < 0
-
-        if raw_e.nil?
-          e = len - 1
-          end_is_term = false
-        else
-          e_res = raw_e
-          e_res += len if e_res < 0
-          # `end` is a term of the sequence iff stepping from begin
-          # lands exactly on it (and end is inclusive).
-          end_is_term = !excl && b >= 0 && (e_res - b) % s == 0
-          # CRuby raises when stride > 1 and the *user-supplied*
-          # end is itself a yielded value past the array.
-          if s > 1 && end_is_term && e_res >= len
-            raise RangeError,
-                  "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
-          end
-          e = excl ? e_res - 1 : e_res
-        end
-        e = len - 1 if e >= len
-        return [] if e < b
-        result = []
-        i = b
-        while i <= e
-          result << arr[i]
-          i += s
-        end
-        result
-      else
-        # ---- negative step ----------------------------------------
-        if raw_b.nil?
-          b = len - 1
-        else
-          b = raw_b
-          b += len if b < 0
-          # begin past the array's last index: clip to `len - 1`,
-          # but only if the gap is small enough — when
-          # `begin - (len - 1) > |step|` CRuby treats the request
-          # as out of range.
-          if b > len - 1
-            diff = b - (len - 1)
-            if s.abs > 1 && diff > s.abs
-              raise RangeError,
-                    "((#{raw_b.inspect}..#{raw_e.inspect}).step(#{s.inspect})) out of range"
-            end
-            b = len - 1
-          end
-          return nil if b < 0
-        end
-
-        if raw_e.nil?
-          e = 0
-        else
-          e_res = raw_e
-          e_res += len if e_res < 0
-          e = excl ? e_res + 1 : e_res
-        end
-        e = 0 if e < 0
-        return [] if b < e
-        result = []
-        i = b
-        while i >= e
-          result << arr[i]
-          i += s
-        end
-        result
-      end
     end
 
     private

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1069,24 +1069,18 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     } else {
         let idx = lfp.arg(0);
         // Non-fixnum, non-range index: delegate. The
-        // `Enumerator::ArithmeticSequence` case is handed off to
-        // `aseq.[](self)` — the slicing logic lives in
-        // `ArithmeticSequence#[]` (see `enumerable.rb`), keeping
-        // it independent of Array (the AS isn't an Array
-        // subclass; this code shouldn't carry its details).
+        // `Enumerator::ArithmeticSequence` case goes straight to
+        // the Rust slicer (`arithmetic_sequence_slice_array`) —
+        // no method dispatch through `aseq.[](self)`, since AS
+        // storage and slicing are both native now (Phase 3).
         // Anything else falls through to the existing `to_int`
         // coercion path.
         if idx.try_fixnum().is_none() && idx.is_range().is_none() {
-            let class_name =
-                globals.store.get_class_name(idx.real_class(&globals.store).id());
-            if class_name == "Enumerator::ArithmeticSequence" {
-                return vm.invoke_method_inner(
+            if idx.ty() == Some(ObjTy::ARITHMETIC_SEQUENCE) {
+                return enumerator::arithmetic_sequence_slice_array(
                     globals,
-                    IdentId::get_id("[]"),
                     idx,
-                    &[lfp.self_val()],
-                    None,
-                    None,
+                    lfp.self_val(),
                 );
             }
             let i = idx.coerce_to_int_i64(vm, globals)?;
@@ -5271,13 +5265,12 @@ mod tests {
 
     /// Regression: `Range#%` attaches a singleton method (`inspect`)
     /// to its AS result, which makes `Value::class` return the
-    /// singleton's `ClassId`. The fast-path `is_arithmetic_sequence`
-    /// check must walk past the singleton (`real_class`) instead of
-    /// comparing against the cached AS class id verbatim — otherwise
-    /// the dispatch falls through to `coerce_to_int_i64` and raises
-    /// `TypeError: no implicit conversion of
-    /// Enumerator::ArithmeticSequence into Integer`. Same hazard
-    /// hits any AS the user decorates with `define_singleton_method`.
+    /// singleton's `ClassId`. Phase 3 sidesteps that entirely by
+    /// switching the fast-path dispatch from class-id compare to a
+    /// native `ObjTy::ARITHMETIC_SEQUENCE` check (`Value::ty()`),
+    /// which is set on construction and is unaffected by singletons.
+    /// Test stays as a regression for the same shapes — anything
+    /// decorated with `define_singleton_method` must still resolve.
     #[test]
     fn slice_with_arithmetic_sequence_singleton_class() {
         run_tests(&[

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -118,6 +118,12 @@ pub(super) fn init(globals: &mut Globals) {
         1,
         false,
     );
+    globals.define_builtin_func(
+        ARITHMETIC_SEQUENCE_CLASS,
+        "[]",
+        arithmetic_sequence_index,
+        1,
+    );
     // Private aliases kept so the still-Ruby `size` / `[]` / `__each`
     // bodies in `enumerable.rb` can keep referring to the fields by
     // their internal shorthand. Phase 3 retires `[]` (and these along
@@ -259,6 +265,205 @@ fn arithmetic_sequence_first(
     } else {
         Ok(self_val.as_arithmetic_sequence_inner().begin())
     }
+}
+
+///
+/// ### Enumerator::ArithmeticSequence#[]
+///
+/// - `[](arr)` — stride-aware Array slice
+///
+/// Extracts the slice of `arr` whose indices are the terms of
+/// this sequence.  Independent of Array's own `[]`
+/// implementation: `Array#[]` delegates here when its index
+/// argument is an ArithmeticSequence.
+///
+/// Mirrors CRuby's `rb_ary_subseq_step` behaviour:
+///   * Resolve `begin` (nil → 0 for positive step, `len-1` for
+///     negative; negative ints rebased against `len`).
+///   * Resolve `end` (nil → `len-1` / `0`; exclusive end ⇒ inner term).
+///   * Walk by `step`, collecting elements whose index is in
+///     `0...len`.
+///   * `RangeError` when the explicit end (or begin for negative
+///     step) is itself a term of the AS that lands outside the
+///     array.
+///   * Pure-`nil` return when `begin` is out of bounds for the
+///     `step == ±1` cases that fall back to plain Range slicing
+///     semantics.
+#[monoruby_builtin]
+fn arithmetic_sequence_index(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    arithmetic_sequence_slice_array(globals, lfp.self_val(), lfp.arg(0))
+}
+
+/// Direct-read slice entry point for `Array#[aseq]` — used by
+/// both `builtins::array::index` (the bytecode/slow path) and
+/// `codegen::runtime::get_index` (the JIT inline path) so that
+/// neither needs a method dispatch through `aseq.[](arr)` to
+/// reach this logic.
+pub(crate) fn arithmetic_sequence_slice_array(
+    globals: &mut Globals,
+    aseq: Value,
+    arr: Value,
+) -> Result<Value> {
+    assert_eq!(aseq.ty(), Some(ObjTy::ARITHMETIC_SEQUENCE));
+    let inner = aseq.as_arithmetic_sequence_inner();
+    let raw_b = inner.begin();
+    let raw_e = inner.end();
+    let raw_s = inner.step();
+    let excl = inner.exclude_end();
+
+    let len = arr.as_array_inner().len() as i64;
+
+    // CRuby's Array#[aseq] only handles Integer-valued AS terms.
+    // Float / non-Integer step, begin, or end raises `TypeError`.
+    let s = match raw_s.try_fixnum() {
+        Some(v) => v,
+        None => return Err(as_slice_typeerr(globals, raw_s)),
+    };
+    if s == 0 {
+        return Ok(Value::array_empty());
+    }
+
+    let b_opt: Option<i64> = if raw_b.is_nil() {
+        None
+    } else {
+        match raw_b.try_fixnum() {
+            Some(v) => Some(v),
+            None => return Err(as_slice_typeerr(globals, raw_b)),
+        }
+    };
+    let e_opt: Option<i64> = if raw_e.is_nil() {
+        None
+    } else {
+        match raw_e.try_fixnum() {
+            Some(v) => Some(v),
+            None => return Err(as_slice_typeerr(globals, raw_e)),
+        }
+    };
+
+    if s > 0 {
+        // ---- positive step ------------------------------------
+        let mut b = b_opt.unwrap_or(0);
+        if b < 0 {
+            b += len;
+        }
+        if b_opt.is_some() && b > len {
+            if s > 1 {
+                return Err(as_slice_rangeerr(globals, raw_b, raw_e, raw_s));
+            }
+            return Ok(Value::nil());
+        }
+        if b == len {
+            return Ok(Value::array_empty());
+        }
+        if b < 0 {
+            return Ok(Value::nil());
+        }
+
+        let e = if let Some(raw_e_val) = e_opt {
+            let mut e_res = raw_e_val;
+            if e_res < 0 {
+                e_res += len;
+            }
+            let end_is_term = !excl && b >= 0 && (e_res - b).rem_euclid(s) == 0;
+            if s > 1 && end_is_term && e_res >= len {
+                return Err(as_slice_rangeerr(globals, raw_b, raw_e, raw_s));
+            }
+            let e = if excl { e_res - 1 } else { e_res };
+            if e >= len { len - 1 } else { e }
+        } else {
+            len - 1
+        };
+        if e < b {
+            return Ok(Value::array_empty());
+        }
+
+        let ary = arr.as_array_inner();
+        let mut result = Vec::new();
+        let mut i = b;
+        while i <= e {
+            result.push(ary[i as usize]);
+            i += s;
+        }
+        Ok(Value::array_from_vec(result))
+    } else {
+        // ---- negative step ------------------------------------
+        let mut b = if let Some(raw_b_val) = b_opt {
+            let mut b = raw_b_val;
+            if b < 0 {
+                b += len;
+            }
+            if b > len - 1 {
+                let diff = b - (len - 1);
+                if s.unsigned_abs() as i64 > 1 && diff > s.unsigned_abs() as i64 {
+                    return Err(as_slice_rangeerr(globals, raw_b, raw_e, raw_s));
+                }
+                b = len - 1;
+            }
+            if b < 0 {
+                return Ok(Value::nil());
+            }
+            b
+        } else {
+            len - 1
+        };
+
+        let e = if let Some(raw_e_val) = e_opt {
+            let mut e_res = raw_e_val;
+            if e_res < 0 {
+                e_res += len;
+            }
+            let e = if excl { e_res + 1 } else { e_res };
+            if e < 0 { 0 } else { e }
+        } else {
+            0
+        };
+        if b < e {
+            return Ok(Value::array_empty());
+        }
+
+        let ary = arr.as_array_inner();
+        let mut result = Vec::new();
+        while b >= e {
+            result.push(ary[b as usize]);
+            b += s;
+        }
+        Ok(Value::array_from_vec(result))
+    }
+}
+
+fn as_slice_typeerr(globals: &Globals, v: Value) -> MonorubyErr {
+    let class_name = globals
+        .store
+        .get_class_name(v.real_class(&globals.store).id());
+    MonorubyErr::typeerr(format!(
+        "no implicit conversion of {class_name} into Integer"
+    ))
+}
+
+fn as_slice_rangeerr(globals: &Globals, b: Value, e: Value, s: Value) -> MonorubyErr {
+    let store = &globals.store;
+    // Match CRuby: nil endpoints elide to empty string in the
+    // error message ("((11..).step(2))" rather than
+    // "((11..nil).step(2))"). The separator is always `..`,
+    // even for an exclusive-end AS — CRuby's error formatter
+    // does not distinguish the two here.
+    let b_s = if b.is_nil() {
+        String::new()
+    } else {
+        b.inspect(store)
+    };
+    let e_s = if e.is_nil() {
+        String::new()
+    } else {
+        e.inspect(store)
+    };
+    let s_s = s.inspect(store);
+    MonorubyErr::rangeerr(format!("(({b_s}..{e_s}).step({s_s})) out of range"))
 }
 
 ///

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -586,62 +586,6 @@ pub(super) struct ClassIdSlot {
     idx: ClassId,
 }
 
-thread_local! {
-    /// Cached `ClassId` of `Enumerator::ArithmeticSequence`. The
-    /// class is defined in Ruby (`monoruby/builtins/enumerable.rb`)
-    /// so its `ClassId` isn't known at compile time, but it's
-    /// stable across the lifetime of a `Globals` once the startup
-    /// files have loaded. We pay one constant lookup the first
-    /// time, then a plain `ClassId` compare from there.
-    static AS_CLASS_ID_CACHE: std::cell::Cell<Option<ClassId>> = const {
-        std::cell::Cell::new(None)
-    };
-}
-
-/// Fast check: is `v` an instance of `Enumerator::ArithmeticSequence`?
-/// Mirrors the way Array's `[]` dispatch needs to recognise an AS
-/// index — without the per-call cost of walking the class chain and
-/// joining names into a string.
-///
-/// Uses `real_class` rather than `Value::class` so a singleton class
-/// attached to the AS (e.g. `Range#%` calls `define_singleton_method`
-/// to swap in a custom `inspect`) doesn't make the cached `ClassId`
-/// compare miss. Without this, `arr[(0..-1).%(2)]` fell through to
-/// the `to_int` path and raised `TypeError`.
-pub(crate) fn is_arithmetic_sequence(globals: &Globals, v: Value) -> bool {
-    let v_class = v.real_class(&globals.store).id();
-    AS_CLASS_ID_CACHE.with(|cell| {
-        if let Some(cached) = cell.get() {
-            return v_class == cached;
-        }
-        // First-time lookup: resolve `Enumerator::ArithmeticSequence`
-        // via the constant table. Cache the resulting `ClassId` so
-        // subsequent calls bypass the lookup entirely.
-        let Some(enum_const) = globals
-            .store
-            .get_constant(OBJECT_CLASS, IdentId::get_id("Enumerator"))
-        else {
-            return false;
-        };
-        let enum_class_id = match enum_const.loaded_value() {
-            Some(val) if val.is_class_or_module().is_some() => val.as_class_id(),
-            _ => return false,
-        };
-        let Some(as_const) = globals
-            .store
-            .get_constant(enum_class_id, IdentId::get_id("ArithmeticSequence"))
-        else {
-            return false;
-        };
-        let as_class_id = match as_const.loaded_value() {
-            Some(val) if val.is_class_or_module().is_some() => val.as_class_id(),
-            _ => return false,
-        };
-        cell.set(Some(as_class_id));
-        v_class == as_class_id
-    })
-}
-
 ///
 /// Generic index operation.
 ///
@@ -670,21 +614,17 @@ pub(super) extern "C" fn get_index(
         ARRAY_CLASS => {
             // Non-fixnum, non-range index: ask the index to slice
             // the array itself. `Enumerator::ArithmeticSequence`
-            // defines `#[]` (in `enumerable.rb`) for this — the
-            // slicing logic lives on the AS, not parasitically in
-            // Array's `[]` path. Other types fall through to the
-            // existing `to_int` coercion. Mirrors `builtins/
-            // array.rs::index`, but `vm_index` / the JIT inline
-            // path land here, so both need the dispatch.
+            // goes straight to the Rust slicer
+            // (`arithmetic_sequence_slice_array`) — no method
+            // dispatch needed since Phase 3 moved AS slicing to
+            // Rust. Other types fall through to the existing
+            // `to_int` coercion. Mirrors `builtins/array.rs::index`,
+            // but `vm_index` / the JIT inline path land here, so
+            // both need the dispatch.
             let idx = if index.try_fixnum().is_none() && index.is_range().is_none() {
-                if is_arithmetic_sequence(globals, index) {
-                    return match vm.invoke_method_inner(
-                        globals,
-                        IdentId::_INDEX,
-                        index,
-                        &[base],
-                        None,
-                        None,
+                if index.ty() == Some(ObjTy::ARITHMETIC_SEQUENCE) {
+                    return match crate::builtins::enumerator::arithmetic_sequence_slice_array(
+                        globals, index, base,
                     ) {
                         Ok(val) => Some(val),
                         Err(err) => {


### PR DESCRIPTION
## Summary

Final phase of the AS Rust-native migration. Stacks on top of #487. Removes the last bit of Ruby in the AS slicing path: `def [](arr)` and the `Array#[]` → `aseq.[](self)` method-dispatch hop both go away, replaced by a single Rust function that reads the native `(begin, end, step, exclude_end?)` tuple and walks the array directly.

## What changes

- **`arithmetic_sequence_slice_array(globals, aseq, arr)`** — new `pub(crate)` entry point on `builtins::enumerator`. Mirrors CRuby's `rb_ary_subseq_step`:
  - positive / negative step paths
  - negative-index rebasing against `len`
  - `RangeError` "out of range" for stride > 1 with an OOB explicit endpoint
  - `nil` return for stride-1 OOB starts
  - `TypeError` for Float / non-Integer AS terms (matches CRuby's Array indexing contract)
- **`AS#[]`** becomes a registered Rust builtin (`arithmetic_sequence_index`) so user-facing `aseq[arr]` keeps working.
- **Both dispatch points** — `builtins::array::index` (slow-path) and `codegen::runtime::get_index` (JIT inline / `vm_index` path) — switch from `vm.invoke_method_inner(:'[]', aseq, &[base])` to a direct call into `arithmetic_sequence_slice_array`.
- **Drops `AS_CLASS_ID_CACHE` + `is_arithmetic_sequence`**. `Value::ty() == Some(ObjTy::ARITHMETIC_SEQUENCE)` now does the same job in one constant-time field read and is unaffected by singleton classes (the previous helper needed `real_class` to handle `Range#%` attaching a singleton `inspect`, which is no longer a concern).
- **`def [](arr)` is removed from `enumerable.rb`**. Private `__b` / `__e` / `__s` / `__excl?` readers stay because the still-Ruby `size` and `__each` use them.

## Error-message parity fix

CRuby elides `nil` endpoints in the "out of range" message (`((11..).step(2))` rather than `((11..nil).step(2))`). The original Ruby `[]` interpolated `raw_e.inspect` so it printed `"nil"` — a latent mismatch nobody had caught because the assertion never reached that exact string. Fixed in the Rust formatter (`as_slice_rangeerr`).

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib -- arithmetic` — 7/7 passing
- [x] `cargo test --lib -- builtins::array:: builtins::range:: builtins::enumerator::` — 191/194 passing; the 3 failures (`array_inspect`, `array_tos_recursive`, `fetch_values`) are pre-existing on master (Ruby 3.3 vs 4.0 env diffing).
- [x] Exhaustive matrix vs CRuby — positive/negative step, nil/explicit/negative endpoints, exclusive end, single-element, empty slices, singleton-class-decorated AS — `diff` says MATCH. Test rb:
  ```rb
  arr = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
  p arr[(0..).step(1)]; p arr[(0..).step(2)]; p arr[(-3..).step(1)]
  p arr[(9..0).step(-1)]; p arr[(8...2).step(-3)]; p arr[(0...0).step(1)]
  # ...etc — see commit message for the full set
  ```
- [x] RangeError message format matches CRuby exactly (`((11..).step(2)) out of range`).

https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4dV75UY6h5a44mSByCRfD)_