### PR TITLE
fix(jit): #480 deopt resume PC at loop-merge bridge

### DIFF
--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -1576,15 +1576,17 @@ mod tests {
     #[test]
     fn range_step_iteration() {
         // Iteration shape: inclusive vs exclusive end, integer vs
-        // float step. Kept on `run_test` (one CRuby invocation per
-        // case) rather than batched through `run_tests` because
-        // mixing several `to_a` calls in one wrapped block trips
-        // issue #480 under the test harness's lower
-        // `COUNT_LOOP_START_COMPILE` threshold.
-        run_test("(1..5).step(1).to_a");
-        run_test("(1...5).step(1).to_a");
-        run_test("(1..10).step(2).to_a");
-        run_test("(1.0..2.0).step(0.5).to_a");
+        // float step. Batched through `run_tests` so the float case
+        // JIT-compiles the inclusive-positive `while cur <= e` loop
+        // before the integer case enters it — see #480 (deopt resume
+        // PC at loop-merge bridge was past the fused BinCmp, so the
+        // VM resumed at the bare CondBr with a stale `%dst`).
+        run_tests(&[
+            "(1.0..2.0).step(0.5).to_a",
+            "(1..5).step(1).to_a",
+            "(1...5).step(1).to_a",
+            "(1..10).step(2).to_a",
+        ]);
     }
 
     #[test]

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -90,7 +90,13 @@ impl<'a> JitContext<'a> {
             #[cfg(feature = "jit-debug")]
             eprintln!("  target:  {:?}\n", target.slot_state());
 
-            self.gen_bridges_for_branches(&target, entries, bbid, pc + 1);
+            // `bridge` adds `+1` to the deopt resume PC so it lands on
+            // the first body instruction (skipping LoopStart, which
+            // would re-enter the JIT and infinite-loop). Pass `pc` (=
+            // LoopStart's PC) directly; an extra `+1` here would push
+            // the deopt resume past the fused BinCmp into the bare
+            // CondBr, which then reads a stale `%dst` — see #480.
+            self.gen_bridges_for_branches(&target, entries, bbid, pc);
             self.new_backedge(target.slot_state().clone(), bbid);
 
             Some(target)


### PR DESCRIPTION
Fixes #480.

## Summary

- Loop-entry merge in `JitContext::incoming_context` was passing `pc + 1` to `gen_bridges_for_branches`, but `SlotState::bridge` already adds `+1` to the deopt resume PC for its `S → Sf(Float)` / `G → Sf(Float)` / `S → S(class)` guards. The double `+1` pushed the resume PC past the loop body's first instruction.
- For a fused `BinCmpBr` at `LoopStart + 1`, the deopt landed on `LoopStart + 2` — the bare `CondBr opt=true` half of the fused pair. `%dst` was never written by the JIT, so the interpreter read a stale value and branched out of the loop on the first iteration. `(1..5).step(1).to_a` returned `[]` instead of `[1,2,3,4,5]` whenever the loop had been JIT-compiled with Float specialisation by a preceding float call.
- The backedge bridge in [`backedge_branches`](monoruby/src/codegen/jitgen/merge.rs) already passes plain `pc` and relies on `bridge`'s internal `+1`; the loop-entry path now agrees and both resume at `LoopStart + 1` (the first body instruction, skipping LoopStart to avoid re-entering the JIT and infinite-looping).
- Consolidated `range_step_iteration` into a single `run_tests` so the test wrapper trips the bug under the test-mode `COUNT_LOOP_START_COMPILE = 15` threshold. Without the fix the inclusive-int / step-2 cases return `[]`.

## Test plan

- [x] `cargo test -p monoruby --lib` — 2017/2017 pass
- [x] `cargo test -p monoruby --lib range::tests::range_step_iteration` — the consolidated regression test passes (fails on master)
- [x] Release build of the issue #480 reproducer returns `[[1, 2, 3, 4, 5], [1, 3, 5, 7, 9]]` with zero mismatches across 200 outer iterations
- [x] Float / loop JIT tests (`cargo test -p monoruby --lib float`, `… loop`) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)