### PR TITLE
core/string: ASCII byte-level fast path for case mapping (12–16× faster, beats YJIT 2–15×)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1,4 +1,5 @@
 use num::{BigInt, Zero};
+use smallvec::SmallVec;
 
 use super::*;
 use jitgen::JitContext;
@@ -4286,6 +4287,57 @@ fn to_sym(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     Ok(Value::symbol(id))
 }
 
+/// Byte-level case mapping for ASCII-only receivers. Returns the
+/// transformed `RStringInner` when the input's code range is
+/// `SevenBit` and `mode` is not `Turkic` (Turkic upcases `i`→`İ` /
+/// downcases `I`→`ı`, both non-ASCII, so the byte transform isn't
+/// closed under Turkic semantics).
+///
+/// For ASCII content, `Full` / `Ascii` / `Fold` all collapse to the
+/// trivial bitwise `b ^ 0x20` for letters — `Fold`'s only non-trivial
+/// expansion is `ß` → `ss`, which can't appear here. The output is
+/// provably ASCII, so we tag the result with `cr = SevenBit`
+/// directly via `from_ascii_bytes` and skip the O(N) classification
+/// scan that `from_encoding_scanned` would do.
+///
+/// The transform loop intentionally has no loop-carried `changed`
+/// flag — that branchless byte-→byte map is the part the auto-
+/// vectoriser can turn into wide SIMD, so the bang variants compute
+/// changed-vs-unchanged with a single `memcmp` afterward instead.
+fn ascii_case_fast_path(
+    inner: &RStringInner,
+    op: CaseOp,
+    mode: CaseMode,
+) -> Option<RStringInner> {
+    if !inner.is_ascii_only() || matches!(mode, CaseMode::Turkic) {
+        return None;
+    }
+    let bytes = inner.as_bytes();
+    let out: SmallVec<[u8; STRING_INLINE_CAP]> = match op {
+        CaseOp::Upcase => bytes.iter().map(|b| b.to_ascii_uppercase()).collect(),
+        CaseOp::Downcase => bytes.iter().map(|b| b.to_ascii_lowercase()).collect(),
+        CaseOp::Swapcase => bytes
+            .iter()
+            .map(|&b| if b.is_ascii_alphabetic() { b ^ 0x20 } else { b })
+            .collect(),
+        CaseOp::Capitalize => {
+            // Run the downcase vector pass over every byte (so the
+            // body of the loop has no branch the auto-vectoriser has
+            // to disentangle), then patch the leading byte to its
+            // uppercase form. A hand-rolled "first vs rest" loop
+            // doesn't vectorise — that path costs ~4× more in this
+            // benchmark.
+            let mut v: SmallVec<[u8; STRING_INLINE_CAP]> =
+                bytes.iter().map(|b| b.to_ascii_lowercase()).collect();
+            if let Some(first) = v.first_mut() {
+                *first = first.to_ascii_uppercase();
+            }
+            v
+        }
+    };
+    Some(RStringInner::from_ascii_bytes(out, inner.encoding()))
+}
+
 ///
 /// ### String#upcase
 ///
@@ -4296,6 +4348,11 @@ fn to_sym(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 fn upcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Upcase)?;
     let self_val = lfp.self_val();
+    if let Some(inner) = self_val.is_rstring_inner() {
+        if let Some(fast) = ascii_case_fast_path(inner, CaseOp::Upcase, mode) {
+            return Ok(Value::string_from_inner(fast));
+        }
+    }
     let s = self_val.expect_str(globals)?;
     // `apply_case` walks `chars()` and pushes whole scalars, so the
     // output is well-formed UTF-8 by construction; pre-scan it so
@@ -4318,6 +4375,15 @@ fn upcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Upcase)?;
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
+    let fast = ascii_case_fast_path(self_val.as_rstring_inner(), CaseOp::Upcase, mode);
+    if let Some(result) = fast {
+        let changed = result.as_bytes() != self_val.as_rstring_inner().as_bytes();
+        if changed {
+            self_val.replace_with_inner(result);
+            return Ok(lfp.self_val());
+        }
+        return Ok(Value::nil());
+    }
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Upcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
@@ -4344,6 +4410,11 @@ fn upcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn downcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Downcase)?;
     let self_val = lfp.self_val();
+    if let Some(inner) = self_val.is_rstring_inner() {
+        if let Some(fast) = ascii_case_fast_path(inner, CaseOp::Downcase, mode) {
+            return Ok(Value::string_from_inner(fast));
+        }
+    }
     let s = self_val.expect_str(globals)?;
     Ok(Value::string_from_str_with_encoding_of(
         &apply_case(s, CaseOp::Downcase, mode),
@@ -4362,6 +4433,15 @@ fn downcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Downcase)?;
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
+    let fast = ascii_case_fast_path(self_val.as_rstring_inner(), CaseOp::Downcase, mode);
+    if let Some(result) = fast {
+        let changed = result.as_bytes() != self_val.as_rstring_inner().as_bytes();
+        if changed {
+            self_val.replace_with_inner(result);
+            return Ok(lfp.self_val());
+        }
+        return Ok(Value::nil());
+    }
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Downcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
@@ -4393,6 +4473,11 @@ fn capitalize(
 ) -> Result<Value> {
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Capitalize)?;
     let self_val = lfp.self_val();
+    if let Some(inner) = self_val.is_rstring_inner() {
+        if let Some(fast) = ascii_case_fast_path(inner, CaseOp::Capitalize, mode) {
+            return Ok(Value::string_from_inner(fast));
+        }
+    }
     let s = self_val.expect_str(globals)?;
     Ok(Value::string_from_str_with_encoding_of(
         &apply_case(s, CaseOp::Capitalize, mode),
@@ -4416,6 +4501,15 @@ fn capitalize_(
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Capitalize)?;
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
+    let fast = ascii_case_fast_path(self_val.as_rstring_inner(), CaseOp::Capitalize, mode);
+    if let Some(result) = fast {
+        let changed = result.as_bytes() != self_val.as_rstring_inner().as_bytes();
+        if changed {
+            self_val.replace_with_inner(result);
+            return Ok(lfp.self_val());
+        }
+        return Ok(Value::nil());
+    }
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Capitalize, mode);
     let changed = &result != self_val.expect_str(globals)?;
@@ -4441,6 +4535,11 @@ fn capitalize_(
 fn swapcase(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Swapcase)?;
     let self_val = lfp.self_val();
+    if let Some(inner) = self_val.is_rstring_inner() {
+        if let Some(fast) = ascii_case_fast_path(inner, CaseOp::Swapcase, mode) {
+            return Ok(Value::string_from_inner(fast));
+        }
+    }
     let s = self_val.expect_str(globals)?;
     Ok(Value::string_from_str_with_encoding_of(
         &apply_case(s, CaseOp::Swapcase, mode),
@@ -4459,6 +4558,15 @@ fn swapcase_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let mode = parse_case_options(globals, lfp.arg(0).as_array(), CaseOp::Swapcase)?;
     lfp.self_val().ensure_string_mutable(vm, globals)?;
     let mut self_val = lfp.self_val();
+    let fast = ascii_case_fast_path(self_val.as_rstring_inner(), CaseOp::Swapcase, mode);
+    if let Some(result) = fast {
+        let changed = result.as_bytes() != self_val.as_rstring_inner().as_bytes();
+        if changed {
+            self_val.replace_with_inner(result);
+            return Ok(lfp.self_val());
+        }
+        return Ok(Value::nil());
+    }
     let s = self_val.expect_str(globals)?;
     let result = apply_case(s, CaseOp::Swapcase, mode);
     let changed = &result != self_val.expect_str(globals)?;
@@ -9629,6 +9737,75 @@ mod tests {
     }
 
     // ----- S2: encoding propagation through string-producing ops -----
+
+    #[test]
+    fn case_fast_path_basic() {
+        // ASCII-only inputs cover the byte-level fast path; the slow
+        // path is exercised via the UTF-8 / Turkic tests below.
+        run_test(r#""Hello, World!".upcase"#);
+        run_test(r#""Hello, World!".downcase"#);
+        run_test(r#""Hello, World!".swapcase"#);
+        run_test(r#""hello world".capitalize"#);
+        run_test(r#""".upcase"#);
+        run_test(r#""".downcase"#);
+        run_test(r#""".capitalize"#);
+        run_test(r#""".swapcase"#);
+        // Mixed letters / digits / punctuation — non-letters pass through.
+        run_test(r#""a1b2 c3!".upcase"#);
+        run_test(r#""A1B2 C3!".downcase"#);
+    }
+
+    #[test]
+    fn case_fast_path_turkic_falls_back() {
+        // Turkic mode on ASCII can still produce non-ASCII output
+        // (`i` → `İ`, `I` → `ı`), so the fast path must punt.
+        run_test(r#""istanbul".upcase(:turkic)"#);
+        run_test(r#""ISTANBUL".downcase(:turkic)"#);
+    }
+
+    #[test]
+    fn case_fast_path_utf8_slow_path() {
+        // Non-ASCII receivers always hit the slow path.
+        run_test(r#""Café".upcase"#);
+        run_test(r#""CAFÉ".downcase"#);
+        run_test(r#""ß".downcase(:fold)"#);
+    }
+
+    #[test]
+    fn case_bang_fast_path_changed_vs_nil() {
+        // CRuby contract: bang variants return self on change, nil on no-op.
+        run_test(
+            r#"
+              s = "hello".dup
+              [s.upcase!, s, s.upcase!]
+            "#,
+        );
+        run_test(
+            r#"
+              s = "HELLO".dup
+              [s.downcase!, s, s.downcase!]
+            "#,
+        );
+        run_test(
+            r#"
+              s = "Hello".dup
+              [s.swapcase!, s]
+            "#,
+        );
+        run_test(
+            r#"
+              s = "hello".dup
+              [s.capitalize!, s, s.capitalize!]
+            "#,
+        );
+        // Pure non-letters: no change → nil from the bang variant.
+        run_test(
+            r#"
+              s = "1234!".dup
+              [s.upcase!, s]
+            "#,
+        );
+    }
 
     #[test]
     fn case_methods_preserve_encoding() {

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -977,6 +977,25 @@ impl RStringInner {
         )
     }
 
+    /// O(1): build a string whose bytes the caller guarantees are
+    /// all 7-bit ASCII (< 0x80), recording `cr = SevenBit` directly
+    /// and skipping the classification scan. The caller is
+    /// responsible for the invariant — in debug builds this is
+    /// checked. Used by byte-level fast paths (case mapping, etc.)
+    /// where the transform's output is provably ASCII whenever the
+    /// input was.
+    pub fn from_ascii_bytes(bytes: SmallVec<[u8; STRING_INLINE_CAP]>, encoding: Encoding) -> Self {
+        debug_assert!(
+            bytes.iter().all(|b| *b < 0x80),
+            "from_ascii_bytes: caller passed a byte >= 0x80"
+        );
+        debug_assert!(
+            encoding.is_ascii_compatible(),
+            "from_ascii_bytes: encoding must be ASCII-compatible"
+        );
+        RStringInner::from(bytes, encoding, CodeRange::SevenBit)
+    }
+
     /// Build a substring of `parent` covering the byte range
     /// `start..end`, inheriting the parent's encoding and propagating
     /// the cached code range when the parent's classification implies


### PR DESCRIPTION
## Summary

`String#upcase` / `#downcase` / `#swapcase` / `#capitalize` (plus the bang variants) previously walked `chars()` and called `char::to_uppercase` / `char::to_lowercase` per scalar — full Unicode machinery even for pure-ASCII receivers, which is the dominant shape.

Split off a byte-level fast path that runs when:

- the receiver's code range is `SevenBit` (every byte < 0x80), AND
- `mode` is not `Turkic` (the Turkic mappings `i`→`İ` / `I`→`ı` leave ASCII, so the byte transform isn't closed under them).

For ASCII input, `Full` / `Ascii` / `Fold` all collapse to the trivial bitwise `b ^ 0x20` on letters — `Fold`'s only non-trivial expansion is `ß` → `ss`, which can't appear in SevenBit content. The output is provably ASCII, so we tag the result with `cr = SevenBit` directly via a new `RStringInner::from_ascii_bytes` constructor and skip the O(N) classification scan that `from_encoding_scanned` would otherwise pay.

### Two micro-decisions worth flagging for review

1. **No loop-carried `changed` flag.** An earlier draft computed `changed` inside the transform (`changed |= u != b`) so the bang variants could skip the comparison. That loop-carried bool kept the auto-vectoriser from SIMD-widening the byte map and cost ~4× on the benchmark. The bang variants now do a single `memcmp` after the transform instead, which the compiler vectorises freely.
2. **Capitalize is "downcase all, then patch byte 0".** A hand-rolled "first vs rest" loop didn't vectorise — running the downcase pass over every byte (no branch in the body) and then upcasing the leading byte is ~4× faster, and the patched byte never needs a separate scan because the transform is closed under ASCII.

## Benchmarks (i/s, higher is better) — 560-byte ASCII haystack

| op | before | after | YJIT 4.0.1 | speedup |
|---|---:|---:|---:|---:|
| `upcase`     | 184k | **2.90M** | 1.43M | **15.8×** before; **2.03×** YJIT |
| `downcase`   | 202k | **2.97M** | 1.43M | **14.7×** before; **2.07×** YJIT |
| `swapcase`   | 222k | **2.58M** | 0.17M | 11.6× before; **14.8×** YJIT |
| `capitalize` | 198k | **2.41M** | 0.18M | 12.2× before; **13.2×** YJIT |

Non-ASCII receivers (`"café".upcase`) and Turkic mode still go through the existing `chars()` + `char::to_*` slow path — completely untouched.

## Test plan

- [x] `cargo test --release --lib -p monoruby builtins::string::` — 223 string tests pass (219 baseline + 4 new tests covering: ASCII fast path basics, Turkic fallback, UTF-8 slow path, bang `changed`-vs-`nil` invariant).
- [x] Existing `case_methods_preserve_encoding` covers encoding propagation (`US-ASCII`, `ASCII-8BIT`) through the fast path.
- [x] Smoke-tested vs CRuby 4.0.1: `"".upcase`, `"a1b2!".upcase`, `"istanbul".upcase(:turkic)`, `"ß".downcase(:fold)`, frozen-receiver `upcase!` — identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)