### PR TITLE
perf: drop per-builtin catch_unwind — optcarrot --opt +8-10%

### DIFF
--- a/monoruby/src/bin/irm/main.rs
+++ b/monoruby/src/bin/irm/main.rs
@@ -26,6 +26,7 @@ struct CommandLineArgs {
 
 fn main() {
     use clap::Parser;
+    install_panic_hook();
     let args = CommandLineArgs::parse();
 
     let mut rl = DefaultEditor::new().unwrap();

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -16,17 +16,14 @@ pub(super) extern "C" fn find_method(
     callid: CallSiteId,
     recv: Value,
 ) -> Option<FuncId> {
-    catch_panic_extern_c(vm, globals, "find_method", |vm, globals| {
-        if let Some(func_name) = globals[callid].name {
-            let is_func_call = globals[callid].is_func_call();
-            vm.find_method(globals, recv, func_name, is_func_call)
-        } else {
-            find_super(vm, globals)
-        }
-        .map_err(|err| vm.set_error(err))
-        .ok()
-    })
-    .unwrap_or(None)
+    if let Some(func_name) = globals[callid].name {
+        let is_func_call = globals[callid].is_func_call();
+        vm.find_method(globals, recv, func_name, is_func_call)
+    } else {
+        find_super(vm, globals)
+    }
+    .map_err(|err| vm.set_error(err))
+    .ok()
 }
 
 fn find_super(vm: &mut Executor, globals: &mut Globals) -> Result<FuncId> {

--- a/monoruby/src/codegen/vmgen/variables.rs
+++ b/monoruby/src/codegen/vmgen/variables.rs
@@ -6,31 +6,28 @@ extern "C" fn vm_get_constant(
     site_id: ConstSiteId,
     const_version: usize,
 ) -> Option<Value> {
-    crate::executor::catch_panic_extern_c(vm, globals, "vm_get_constant", |vm, globals| {
-        if let Some(cache) = &globals.store[site_id].cache {
-            let base_class = globals.store[site_id]
-                .base
-                .map(|base| unsafe { vm.get_slot(base) }.unwrap());
-            if cache.version == const_version && cache.base_class == base_class {
-                return Some(cache.value);
-            };
+    if let Some(cache) = &globals.store[site_id].cache {
+        let base_class = globals.store[site_id]
+            .base
+            .map(|base| unsafe { vm.get_slot(base) }.unwrap());
+        if cache.version == const_version && cache.base_class == base_class {
+            return Some(cache.value);
+        };
+    }
+    match vm.find_constant(globals, site_id) {
+        Ok((value, base_class)) => {
+            globals.store[site_id].cache = Some(ConstCache {
+                version: const_version,
+                base_class,
+                value,
+            });
+            Some(value)
         }
-        match vm.find_constant(globals, site_id) {
-            Ok((value, base_class)) => {
-                globals.store[site_id].cache = Some(ConstCache {
-                    version: const_version,
-                    base_class,
-                    value,
-                });
-                Some(value)
-            }
-            Err(err) => {
-                vm.set_error(err);
-                None
-            }
+        Err(err) => {
+            vm.set_error(err);
+            None
         }
-    })
-    .unwrap_or(None)
+    }
 }
 
 extern "C" fn vm_check_constant(
@@ -39,28 +36,25 @@ extern "C" fn vm_check_constant(
     site_id: ConstSiteId,
     const_version: usize,
 ) -> Option<Value> {
-    crate::executor::catch_panic_extern_c(vm, globals, "vm_check_constant", |vm, globals| {
-        if let Some(cache) = &globals.store[site_id].cache {
-            let base_class = globals.store[site_id]
-                .base
-                .map(|base| unsafe { vm.get_slot(base) }.unwrap());
-            if cache.version == const_version && cache.base_class == base_class {
-                return Some(cache.value);
-            };
+    if let Some(cache) = &globals.store[site_id].cache {
+        let base_class = globals.store[site_id]
+            .base
+            .map(|base| unsafe { vm.get_slot(base) }.unwrap());
+        if cache.version == const_version && cache.base_class == base_class {
+            return Some(cache.value);
+        };
+    }
+    match vm.find_constant(globals, site_id) {
+        Ok((value, base_class)) => {
+            globals.store[site_id].cache = Some(ConstCache {
+                version: const_version,
+                base_class,
+                value,
+            });
+            Some(value)
         }
-        match vm.find_constant(globals, site_id) {
-            Ok((value, base_class)) => {
-                globals.store[site_id].cache = Some(ConstCache {
-                    version: const_version,
-                    base_class,
-                    value,
-                });
-                Some(value)
-            }
-            Err(_) => Some(Value::nil()),
-        }
-    })
-    .unwrap_or(None)
+        Err(_) => Some(Value::nil()),
+    }
 }
 
 impl Codegen {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1,5 +1,3 @@
-use crate::codegen::runtime::_dump_stacktrace;
-
 use super::*;
 
 mod constants;
@@ -16,50 +14,27 @@ use crate::ast::{Loc, SourceInfoRef};
 pub type Result<T> = std::result::Result<T, MonorubyErr>;
 pub type BuiltinFn = extern "C" fn(&mut Executor, &mut Globals, Lfp, BytecodePtr) -> Option<Value>;
 
-/// Run `f` catching any Rust `panic!` that escapes it, and convert the
-/// panic into a `FatalError` stored on `vm`. Used at `extern "C"`
-/// boundaries so that a bug in the Rust implementation raises a
-/// Ruby-level FatalError (untrappable, propagates to the top) rather
-/// than aborting the whole process via non-unwinding abort.
+/// Install a process-wide panic hook that prepends a "monoruby internal
+/// error" banner to the default Rust panic message before the unwind
+/// reaches an `extern "C"` boundary and aborts the process. The hook is
+/// chained after the previous one, so the standard Rust panic message
+/// (file:line + message + backtrace hint) is still emitted.
 ///
-/// Returns `Some(r)` on normal completion, `None` if a panic was caught
-/// (in which case `vm.set_error(...)` has been called with a FatalError).
-pub fn catch_panic_extern_c<F, R>(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    site: &'static str,
-    f: F,
-) -> Option<R>
-where
-    F: FnOnce(&mut Executor, &mut Globals) -> R,
-{
-    let vm_ptr = vm as *mut Executor;
-    let globals_ptr = globals as *mut Globals;
-    let closure =
-        std::panic::AssertUnwindSafe(move || unsafe { f(&mut *vm_ptr, &mut *globals_ptr) });
-    match std::panic::catch_unwind(closure) {
-        Ok(r) => Some(r),
-        Err(payload) => {
-            let msg = if let Some(s) = payload.downcast_ref::<String>() {
-                s.clone()
-            } else if let Some(s) = payload.downcast_ref::<&'static str>() {
-                s.to_string()
-            } else {
-                format!("panic at {}", site)
-            };
-            // A mid-panic exception may already be set on `vm`; drop it in
-            // favor of the fatal diagnosis so that `set_error`'s invariant
-            // (exception slot is empty) holds.
-            vm.discard_error();
-            vm.set_error(MonorubyErr::fatal(format!(
-                "rust panic caught at extern \"C\" boundary in {}: {}",
-                site, msg
-            )));
-            _dump_stacktrace(vm, globals);
-            None
-        }
-    }
+/// We don't catch panics inside builtins anymore: they'd have to unwind
+/// back through JIT-assembled frames (which carry no unwind info), so
+/// the unwinder would abort anyway. A single hook here is the one place
+/// panics are surfaced — caller-visible diagnostics, then abort.
+pub fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        eprintln!("monoruby: Rust panic — this is a bug, please report it.");
+        prev(info);
+        eprintln!(
+            "monoruby: the panic will now propagate to an `extern \"C\"` boundary and abort the process."
+        );
+    }));
 }
+
 pub type BinaryOpFn = extern "C" fn(&mut Executor, &mut Globals, Value, Value) -> Option<Value>;
 pub type UnaryOpFn = extern "C" fn(&mut Executor, &mut Globals, Value) -> Option<Value>;
 

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) use bytecode::*;
 pub use bytecodegen::bytecode_compile_script;
 pub(crate) use codegen::jitgen::JitContext;
 pub use executor::Executor;
+pub use executor::install_panic_hook;
 pub use globals::OBJECT_CLASS;
 pub use globals::load_file;
 pub use globals::{Globals, MonorubyErr, MonorubyErrKind};

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -79,6 +79,7 @@ fn dump_ast(code: &str, path: &std::path::Path, kind: ParserKind, globals: &Glob
 
 fn main() {
     use clap::Parser;
+    install_panic_hook();
     let mut finish_flag = false;
     let args = CommandLineArgs::parse();
     let mut globals = Globals::new(args.warning, args.no_jit, args.disable_gems);

--- a/monoruby_attr/src/lib.rs
+++ b/monoruby_attr/src/lib.rs
@@ -19,21 +19,12 @@ pub fn monoruby_builtin(_attr: TokenStream, item: TokenStream) -> TokenStream {
             lfp: Lfp,
             pc: BytecodePtr,
         ) -> Option<Value> {
-            // Catch any Rust panic that escapes the inner function before
-            // it reaches the `extern "C"` boundary (where it would become
-            // a non-unwinding abort). On panic, a FatalError has already
-            // been set on `vm`; fall through to the error-handling branch.
-            let result = match catch_panic_extern_c(vm, globals, stringify!(#base_name), |vm, globals| {
-                #wrapped(vm, globals, lfp, pc)
-            }) {
-                Some(r) => r,
-                None => {
-                    // Panic caught; FatalError set. Reclaim it as Err so
-                    // the shared error-reporting path runs.
-                    Err(vm.take_error())
-                }
-            };
-            match result {
+            // A panic that escapes a builtin would have to unwind back
+            // through JIT-assembled frames that carry no unwind info, so
+            // the unwinder would abort anyway. Don't pay the per-call
+            // `catch_unwind` cost — instead, the process-wide panic hook
+            // installed at startup prints diagnostics before abort.
+            match #wrapped(vm, globals, lfp, pc) {
                 Ok(val) => Some(val),
                 Err(mut err) => {
                     if let MonorubyErrKind::MethodReturn(val, target_lfp) = err.kind() && lfp == *target_lfp {


### PR DESCRIPTION
## Summary

- Remove `catch_panic_extern_c` from the `#[monoruby_builtin]` wrapper (~300 builtins) and the three explicit call sites (`find_method`, `vm_get_constant`, `vm_check_constant`).
- Replace it with a single process-wide `install_panic_hook()` chained into the default Rust hook, called at startup from both binaries.
- Trade-off: a panic in a builtin now aborts the process (with the default Rust panic message + backtrace, prefixed by a monoruby banner) instead of becoming a recoverable Ruby `FatalError`. This reverts the ruby/spec category-level robustness added in d4898e2c, in exchange for the per-call cost.

## Why

Profiling `optcarrot --opt` against `master~300` (`fa71e1f1`) showed an ~11.5% regression. `perf` flagged `catch_panic_extern_c` (and its inlined copies of `__index` / `__even_` / `__rotate_` / `__index_assign`) eating ~4.9% combined, plus elevated per-builtin time for the hot path (`Integer#[]` 5×, `Array#rotate!` 2.5×, `Array#[]=` 2.6×).

A panic that escapes a builtin would have to unwind back through JIT-assembled frames that carry no DWARF/CFI info, so the unwinder aborts the process even with the catch in place — the per-call landing pads were not actually buying us recoverable panics on the JIT path.

## Measurements

`optcarrot --opt -f 3000`, Lan_Master.nes, 10 runs per build in the same shell session, trimmed mean (drop top/bottom):

| Build | fps | vs HEAD~300 | vs baseline |
|---|---:|---:|---:|
| HEAD~300 (`fa71e1f1`) | ~749 | — | — |
| HEAD (`db0e7ff8`) baseline | ~663 | −11.5% | — |
| **HEAD + this patch** | **~720** | **−3.9%** | **+8.6%** |

checksum unchanged (60838) across all configurations.

(`perf record -F 999 -g` overstated the regression to 12% / improvement to +89% — sampling-based callgraph interacts pathologically with the unwind landing pads, so the trimmed-mean wall-clock numbers above are the ones to read.)

## Test plan

- [x] `cargo build --release --features perf` — clean
- [x] `cargo test --release -p monoruby --lib` — 2042/2043 pass. The one failure (`io_popen_read_stdout`) is an `IO.popen` EFAULT under concurrent test load; passes when run alone, unrelated to this change.
- [x] optcarrot checksum identical
- [ ] `bin/test` full CI run (please run in CI; local run takes a while)
- [ ] Optional: rerun a subset of ruby/spec to confirm no regression beyond the category-robustness trade-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)