### PR TITLE
bench-pages: add per-benchmark history line chart

### DIFF
--- a/.github/bench-pages/index.html
+++ b/.github/bench-pages/index.html
@@ -26,6 +26,9 @@
   thead th { border-bottom: 2px solid #888; }
   a { color: #1565c0; }
   .empty { color: #888; padding: 1em 0; }
+  .controls { display: flex; flex-wrap: wrap; gap: 1.5em; align-items: center; margin: 0.5em 0 1em; font-size: 0.9em; }
+  .controls select { font-size: 1em; padding: 0.2em 0.4em; }
+  .control-yratio { color: #555; }
 </style>
 </head>
 <body>
@@ -55,6 +58,23 @@
     <tbody></tbody>
   </table>
   <div id="empty" class="empty" hidden>No benchmark data yet. The next master push will populate this page.</div>
+</section>
+
+<section>
+  <h2>Per-benchmark history</h2>
+  <p class="meta">
+    monoruby and YJIT time (ms) per master commit. Lower is better.
+    Successful rows only — failure entries are skipped on this chart.
+  </p>
+  <div class="controls">
+    <label>Benchmark: <select id="historySelect"></select></label>
+    <label class="control-yratio">
+      <input type="checkbox" id="historyYRatio">
+      show YJIT / monoruby ratio instead of raw ms
+    </label>
+  </div>
+  <div id="historyWrap" style="position: relative; height: 360px;"><canvas id="historyChart"></canvas></div>
+  <div id="historyEmpty" class="empty" hidden>No history yet for this benchmark.</div>
 </section>
 
 <script>
@@ -220,6 +240,160 @@ async function loadJson(path) {
     tr.appendChild(reasonCell(b.yjit_failed     ? (b.yjit_reason     || "failed") : ""));
     tbody.appendChild(tr);
   }
+})();
+
+// ---------------------------------------------------------------------
+// Per-benchmark history line chart.
+// ---------------------------------------------------------------------
+
+function parseCsvRow(line) {
+  const out = [];
+  let cur = "", inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuotes) {
+      if (c === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (c === '"') { inQuotes = false; }
+      else { cur += c; }
+    } else if (c === '"' && cur === "") {
+      inQuotes = true;
+    } else if (c === ",") {
+      out.push(cur); cur = "";
+    } else {
+      cur += c;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function parseCsv(text) {
+  const lines = text.replace(/\r/g, "").trim().split("\n");
+  if (lines.length < 2) return [];
+  const headers = parseCsvRow(lines[0]);
+  return lines.slice(1).map(line => {
+    const fields = parseCsvRow(line);
+    const obj = {};
+    headers.forEach((h, i) => obj[h] = fields[i]);
+    return obj;
+  });
+}
+
+(async () => {
+  const res = await fetch("data/history.csv?t=" + Date.now());
+  if (!res.ok) return;
+  const rows = parseCsv(await res.text())
+    .map(r => ({
+      timestamp:    r.timestamp,
+      commit:       r.commit,
+      benchmark:    r.benchmark,
+      monoruby_ms:  r.monoruby_ms === "" ? null : parseFloat(r.monoruby_ms),
+      yjit_ms:      r.yjit_ms     === "" ? null : parseFloat(r.yjit_ms),
+      ratio:        r.ratio       === "" ? null : parseFloat(r.ratio),
+    }))
+    .filter(r => r.benchmark);
+
+  const benchNames = [...new Set(rows.map(r => r.benchmark))].sort();
+  if (!benchNames.length) return;
+
+  const sel = document.getElementById("historySelect");
+  for (const name of benchNames) {
+    const opt = document.createElement("option");
+    opt.value = name; opt.textContent = name;
+    sel.appendChild(opt);
+  }
+
+  // Sync the selection with the URL hash so a link can deep-link to a
+  // specific benchmark, and so reloads remember the user's choice.
+  const initial = decodeURIComponent((location.hash || "").replace(/^#bench=/, ""));
+  if (benchNames.includes(initial)) sel.value = initial;
+  else sel.value = benchNames[0];
+
+  const yRatioCheckbox = document.getElementById("historyYRatio");
+  const empty = document.getElementById("historyEmpty");
+
+  let chart;
+  function draw() {
+    const name = sel.value;
+    const showRatio = yRatioCheckbox.checked;
+    const points = rows
+      .filter(r => r.benchmark === name && r.monoruby_ms != null && r.yjit_ms != null)
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+    empty.hidden = points.length > 0;
+
+    const labels = points.map(p => p.timestamp);
+    const commits = points.map(p => p.commit);
+
+    const datasets = showRatio
+      ? [{
+          label: "YJIT / monoruby",
+          data: points.map(p => p.ratio),
+          borderColor: "#2e7d32",
+          backgroundColor: "rgba(46,125,50,0.15)",
+          tension: 0.15,
+          fill: true,
+          pointRadius: 3,
+        }]
+      : [
+          {
+            label: "monoruby (ms)",
+            data: points.map(p => p.monoruby_ms),
+            borderColor: "#1565c0",
+            backgroundColor: "rgba(21,101,192,0.10)",
+            tension: 0.15,
+            fill: false,
+            pointRadius: 3,
+          },
+          {
+            label: "YJIT (ms)",
+            data: points.map(p => p.yjit_ms),
+            borderColor: "#ef6c00",
+            backgroundColor: "rgba(239,108,0,0.10)",
+            tension: 0.15,
+            fill: false,
+            pointRadius: 3,
+          },
+        ];
+
+    const yTitle = showRatio
+      ? "relative speed (× YJIT, higher = monoruby faster)"
+      : "time (ms, lower is better)";
+
+    const cfg = {
+      type: "line",
+      data: { labels, datasets },
+      options: {
+        maintainAspectRatio: false,
+        scales: {
+          x: { ticks: { autoSkip: true, maxTicksLimit: 12 } },
+          y: { beginAtZero: true, title: { display: true, text: yTitle } },
+        },
+        plugins: {
+          legend: { display: true, position: "top", align: "end" },
+          tooltip: {
+            callbacks: {
+              title: items => {
+                const idx = items[0].dataIndex;
+                return labels[idx] + "  @  " + (commits[idx] || "?");
+              },
+            },
+          },
+        },
+      },
+    };
+
+    if (chart) chart.destroy();
+    chart = new Chart(document.getElementById("historyChart"), cfg);
+  }
+
+  sel.addEventListener("change", () => {
+    history.replaceState(null, "", "#bench=" + encodeURIComponent(sel.value));
+    draw();
+  });
+  yRatioCheckbox.addEventListener("change", draw);
+
+  draw();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

`bench/data/history.csv` already accumulates one row per benchmark per master commit (timestamp, commit, monoruby_ms, yjit_ms, ratio, …), but the dashboard only ever showed the latest snapshot. Add a new **Per-benchmark history** section below the snapshot that plots that history.

### UI

- **Dropdown** to pick any benchmark (sorted alphabetically). Selection is mirrored to `#bench=<name>` in the URL hash so links can deep-link, e.g. `…/bench/#bench=fib`.
- **Two lines by default**: monoruby (ms) in blue, YJIT (ms) in orange. Lower is better.
- **Checkbox toggle** "show YJIT / monoruby ratio instead of raw ms" — switches to a single green line on the ratio axis (higher is better). Useful when runner-side noise dominates raw timings and you just want the relative trend.
- **Tooltip** on each point shows the timestamp plus the commit SHA: `2026-05-07T03:21:09Z  @  abc1234`.
- **Empty-state message** if the selected benchmark has no successful rows (e.g. it has only ever failed).

### Implementation notes

- Pure client-side: only `bench-pages/index.html` changes, no workflow changes. Uses the existing `data/history.csv`.
- Small inline CSV parser that respects the quoted `monoruby_reason` / `yjit_reason` cells the publish step writes (`"timeout (400s)"`, `"signal 9 (exit 137)"`, …). Sanity-checked against synthetic rows.
- Lines are sorted by ISO timestamp string compare (works for `YYYY-MM-DDTHH:MM:SSZ`).
- Reuses Chart.js v4 that's already loaded for the snapshot bar.

### Skipped for this PR

- A "show all benchmarks on one chart" view — felt too noisy with 60+ benchmarks.
- A second y-axis combining ms and ratio — checkbox toggle is simpler and easier to read.
- Time-axis tick formatting (Chart.js auto-handles it well enough for sparse data; can revisit once we have thicker history).

## Test plan

- [ ] After merge, next master push (or `Run workflow`) refreshes `bench/index.html` on `gh-pages`.
- [ ] Open `https://sisshiki1969.github.io/monoruby/bench/`:
  - New "Per-benchmark history" section below the snapshot.
  - Dropdown shows every benchmark name.
  - Default chart shows two lines (monoruby and YJIT ms) over the commit timestamps in history.
  - Toggling "show YJIT / monoruby ratio instead of raw ms" swaps to a single green ratio line.
  - Selecting a different benchmark redraws and updates `#bench=…` in the URL.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_