### PR TITLE
jit: fold heap constants (classes, modules, strings) into LinkMode::C

### DIFF
--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -121,7 +121,7 @@ pub(crate) fn rbp_local(reg: SlotId) -> i32 {
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct WriteBack {
     fpr: Vec<(FPReg, Vec<SlotId>)>,
-    literal: Vec<(Immediate, SlotId)>,
+    literal: Vec<(Value, SlotId)>,
     void: Vec<SlotId>,
     r15: Option<SlotId>,
 }
@@ -172,7 +172,7 @@ impl std::fmt::Debug for WriteBack {
 impl WriteBack {
     fn new(
         fpr: Vec<(FPReg, Vec<SlotId>)>,
-        literal: Vec<(Immediate, SlotId)>,
+        literal: Vec<(Value, SlotId)>,
         r15: Option<SlotId>,
         void: Vec<SlotId>,
     ) -> Self {
@@ -727,7 +727,7 @@ impl JitModule {
             self.fpr_to_stack(*xmm, v, base);
         }
         for (v, slot) in &wb.literal {
-            self.literal_to_stack(*slot, (*v).into());
+            self.literal_to_stack(*slot, *v);
         }
         for slot in &wb.void {
             self.literal_to_stack(*slot, Value::nil());
@@ -755,7 +755,7 @@ impl JitModule {
             self.fpr_to_stack2(*xmm, v, base);
         }
         for (v, slot) in &wb.literal {
-            self.literal_to_stack2(*slot, (*v).into());
+            self.literal_to_stack2(*slot, *v);
         }
         for slot in &wb.void {
             self.literal_to_stack2(*slot, Value::nil());

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -239,9 +239,22 @@ impl<'a> JitContext<'a> {
                         ISeqHint::Normal => {}
                     }
                 }
+                // Use `is_C_immediate` here, not `is_C`: heap-resident
+                // `LinkMode::C` (e.g. class constants newly folded by
+                // `load_constant`) would otherwise trigger specialization
+                // of methods like `Array.new`, whose body contains a
+                // polymorphic-on-`o` `__send__(:initialize, ...)`. The
+                // JIT picks up the inline cache's currently-cached
+                // receiver class, propagates it as `Guarded::Class(...)`
+                // onto `o`, and the trailing `o` becomes
+                // `ReturnValue::Class(...)` — overwriting the caller's
+                // dst slot with the wrong class. See the
+                // `attr_reader_in_different_class` regression for the
+                // observable failure.
                 let specializable = self.store.is_simple_call(func_id, callid)
-                    && (state.is_C(callsite.recv)
-                        || (pos_num != 0 && (args..args + pos_num).any(|i| state.is_C(i))));
+                    && (state.is_C_immediate(callsite.recv)
+                        || (pos_num != 0
+                            && (args..args + pos_num).any(|i| state.is_C_immediate(i))));
                 let iseq_block = block_fid.map(|fid| self.store[fid].is_iseq()).flatten();
 
                 if iseq_block.is_some() || (specializable && self.specialize_level() < 5)
@@ -585,7 +598,7 @@ impl<'a> JitContext<'a> {
 }
 
 pub(super) enum SpecializedCompileResult {
-    Const(Immediate),
+    Const(Value),
     Compiled {
         entry: JitLabel,
         return_state: Option<ReturnState>,

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -131,18 +131,26 @@ impl AbstractState {
             const_version: *version,
             deopt,
         });
-        if let Some(value) = value.is_immediate() {
-            self.def_C(dst, value);
-            return;
-        }
-        ir.lit2reg(*value, GP::Rax);
-        if let Some(f) = value.try_float() {
+        // Heap-allocated Float: keep the Sf optimization so subsequent
+        // float ops can read the f64 from xmm without re-extracting it
+        // from the RValue. Immediate flonums skip this path because
+        // `def_C` is already cheaper than emitting an `Sf` materialization.
+        if value.is_immediate().is_none()
+            && let Some(f) = value.try_float()
+        {
+            ir.lit2reg(*value, GP::Rax);
             let fdst = self.def_Sf_float(dst);
             ir.f64_to_fpr(f, fdst);
             ir.reg2stack(GP::Rax, dst);
-        } else {
-            self.def_reg2acc(ir, GP::Rax, dst);
+            return;
         }
+        // All other values (immediates, class objects, modules, strings,
+        // bignums, …) are folded into the abstract state as `LinkMode::C`.
+        // GC safety: the version guard above deopts on any redefinition,
+        // and `wb_literal` writes the value back to the stack slot before
+        // every GC safepoint, so a non-moving mark-and-sweep collector
+        // sees it through the normal stack scan.
+        self.def_C(dst, *value);
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -377,7 +377,7 @@ pub(super) struct ReturnState {
 #[derive(Debug, Clone, Copy)]
 enum ReturnValue {
     UD,
-    Const(Immediate),
+    Const(Value),
     Class(ClassId),
     Value,
 }
@@ -423,7 +423,7 @@ impl ReturnState {
         }
     }
 
-    pub(in crate::codegen::jitgen) fn const_folded(&self) -> Option<Immediate> {
+    pub(in crate::codegen::jitgen) fn const_folded(&self) -> Option<Value> {
         if !self.invariants.side_effect_guard {
             return None;
         }
@@ -520,7 +520,6 @@ impl Invariants {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::value::Immediate;
 
     /// `taint_for_unmodeled_rescue` must downgrade `Const`/`Class` to
     /// `Value` so `def_rax2acc_return` falls into the `ReturnValue::Value`
@@ -530,7 +529,7 @@ mod tests {
     #[test]
     fn taint_for_unmodeled_rescue_drops_const_and_side_effect_guard() {
         let mut s = ReturnState {
-            ret: ReturnValue::Const(Immediate::nil()),
+            ret: ReturnValue::Const(Value::nil()),
             invariants: Invariants {
                 class_version_guard: true,
                 no_capture_guard: true,

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -143,7 +143,7 @@ impl SfGuarded {
         }
     }
 
-    fn from_concrete_value(v: Immediate) -> Self {
+    fn from_concrete_value(v: Value) -> Self {
         if v.is_fixnum() {
             SfGuarded::Fixnum
         } else if v.is_float() {

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -26,7 +26,7 @@ impl AbstractFrame {
                 if dst == GP::R15 {
                     assert!(self.no_r15());
                 }
-                ir.lit2reg(v.into(), dst);
+                ir.lit2reg(v, dst);
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) => {
                 if dst == GP::R15 {
@@ -154,7 +154,10 @@ impl AbstractFrame {
     }
 
     #[allow(non_snake_case)]
-    fn load_xmm_from_C(&mut self, ir: &mut AsmIr, slot: SlotId, v: Immediate) -> FPReg {
+    fn load_xmm_from_C(&mut self, ir: &mut AsmIr, slot: SlotId, v: Value) -> FPReg {
+        // `LinkMode::C` may hold any Value; xmm loads only ever come from
+        // numeric literals (fixnum / float / heap Float), so anything else
+        // is a bug at the call site.
         match v.unpack() {
             RV::Float(f) => {
                 // -> F

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -57,7 +57,7 @@ impl SlotState {
     pub(super) fn new_method(cc: &JitContext) -> Self {
         let mut ctx = SlotState::new(cc, LinkMode::V);
         for i in cc.locals() {
-            ctx.set_mode(i, LinkMode::C(Immediate::nil()));
+            ctx.set_mode(i, LinkMode::C(Value::nil()));
         }
         for i in cc.args() {
             ctx.set_mode(i, LinkMode::default());
@@ -175,9 +175,19 @@ impl SlotState {
         self.guarded(slot).class()
     }
 
+    /// True only when *slot* is `LinkMode::C` with a packed immediate
+    /// value (fixnum, flonum, nil, true, false, symbol).
+    ///
+    /// Used to gate iseq specialization: passing a heap-resident
+    /// `LinkMode::C` (e.g. a class constant) through `from_caller` lets
+    /// the callee's body propagate Guarded class info inferred from
+    /// polymorphic inline caches back to the caller's dst slot — making
+    /// the caller believe the return type is whatever class happened to
+    /// win that cache last, which is unsound. Restricting specialization
+    /// to immediates preserves the pre-existing behavior.
     #[allow(non_snake_case)]
-    pub(in crate::codegen::jitgen) fn is_C(&self, slot: SlotId) -> bool {
-        self.mode(slot).is_C()
+    pub(in crate::codegen::jitgen) fn is_C_immediate(&self, slot: SlotId) -> bool {
+        matches!(self.mode(slot), LinkMode::C(v) if v.is_immediate().is_some())
     }
 }
 
@@ -543,11 +553,16 @@ impl SlotState {
     ///
     /// Link *slot* to a concrete value *v*.
     ///
+    /// `v` may be any `Value` (immediate or heap-resident). The pointer is kept
+    /// alive across GC safepoints via `wb_literal` writing it to its stack slot
+    /// before each GC checkpoint, and across constant redefinition via the
+    /// `GuardConstVersion` deopt check emitted by `load_constant`.
+    ///
     #[allow(non_snake_case)]
-    pub(crate) fn def_C(&mut self, slot: impl Into<Option<SlotId>>, v: Immediate) {
+    pub(crate) fn def_C(&mut self, slot: impl Into<Option<SlotId>>, v: impl Into<Value>) {
         if let Some(slot) = slot.into() {
             self.discard(slot);
-            self.set_mode(slot, LinkMode::C(v));
+            self.set_mode(slot, LinkMode::C(v.into()));
         }
     }
 
@@ -596,7 +611,7 @@ impl SlotState {
                 ir.fpr2stack(xmm, slot);
             }
             LinkMode::C(v) => {
-                ir.lit2stack(v.into(), slot);
+                ir.lit2stack(v, slot);
             }
             LinkMode::G(guarded) => {
                 // G -> S
@@ -628,7 +643,7 @@ impl SlotState {
                 ir.fpr2stack(xmm, slot);
             }
             LinkMode::C(v) => {
-                ir.lit2stack(v.into(), slot);
+                ir.lit2stack(v, slot);
             }
             LinkMode::G(_) => {
                 ir.acc2stack(slot);
@@ -657,7 +672,7 @@ impl SlotState {
 
     pub fn is_fixnum_literal(&self, slot: SlotId) -> Option<Fixnum> {
         if let LinkMode::C(v) = self.mode(slot) {
-            v.try_fixnum()
+            v.is_immediate()?.try_fixnum()
         } else {
             None
         }
@@ -665,7 +680,7 @@ impl SlotState {
 
     pub fn is_flonum_literal(&self, slot: SlotId) -> Option<Flonum> {
         if let LinkMode::C(v) = self.mode(slot) {
-            v.try_flonum()
+            v.is_immediate()?.try_flonum()
         } else {
             None
         }
@@ -1103,7 +1118,7 @@ impl AbstractFrame {
             .collect()
     }
 
-    fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Immediate, SlotId)> {
+    fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Value, SlotId)> {
         self.slots
             .iter()
             .enumerate()
@@ -1185,9 +1200,17 @@ pub(in crate::codegen::jitgen) enum LinkMode {
     ///
     Sf(FPReg, SfGuarded),
     ///
-    /// Concrete value (immediate / packed).
+    /// Concrete value.
     ///
-    C(Immediate),
+    /// `Value` may be any packed immediate (fixnum, flonum, nil, true,
+    /// false, symbol) or a pointer to a heap-allocated `RValue` (e.g. a
+    /// class object loaded from a constant). For heap values the pointer
+    /// is kept alive across GC by `wb_literal` writing it to the slot's
+    /// stack location before each GC safepoint, and across constant
+    /// redefinition by the `GuardConstVersion` deopt check at the load
+    /// site.
+    ///
+    C(Value),
 }
 
 impl LinkMode {
@@ -1200,7 +1223,7 @@ impl LinkMode {
     }
 
     fn nil() -> Self {
-        LinkMode::C(Immediate::nil())
+        LinkMode::C(Value::nil())
     }
 
     fn guarded(&self) -> Guarded {
@@ -1208,7 +1231,7 @@ impl LinkMode {
             LinkMode::S(guarded) | LinkMode::G(guarded) => *guarded,
             LinkMode::Sf(_, guarded) => (*guarded).into(),
             LinkMode::F(_) => Guarded::Float,
-            LinkMode::C(v) => Guarded::from_concrete_value((*v).into()),
+            LinkMode::C(v) => Guarded::from_concrete_value(*v),
             LinkMode::V => Guarded::Class(NIL_CLASS),
             _ => unreachable!("{:?}", self),
         }
@@ -1236,11 +1259,6 @@ impl LinkMode {
                 Guarded::Value => ReturnValue::Value,
             },
         }
-    }
-
-    #[allow(non_snake_case)]
-    fn is_C(&self) -> bool {
-        matches!(self, LinkMode::C(_))
     }
 
     pub(in crate::codegen::jitgen) fn from_caller(
@@ -1468,10 +1486,10 @@ impl AbstractFrame {
             }
             (LinkMode::C(l), LinkMode::Sf(r, _)) => {
                 self.set_Sf_float(slot, r);
-                let (v, f) = if let Some(f) = l.try_flonum() {
-                    (Value::float(f.get()), f.get())
+                let (v, f) = if let Some(f) = l.try_float() {
+                    (Value::float(f), f)
                 } else if let Some(i) = l.try_fixnum() {
-                    (Value::integer(i.get()), i.get() as f64)
+                    (Value::integer(i), i as f64)
                 } else {
                     unreachable!()
                 };
@@ -1480,9 +1498,9 @@ impl AbstractFrame {
             }
             (LinkMode::C(v), LinkMode::S(_)) => {
                 // C -> S
-                let guarded = Guarded::from_concrete_value(v.into());
+                let guarded = Guarded::from_concrete_value(v);
                 self.set_mode(slot, LinkMode::S(guarded));
-                ir.lit2stack(v.into(), slot);
+                ir.lit2stack(v, slot);
             }
             (LinkMode::None, LinkMode::None) => {}
             (LinkMode::MaybeNone, LinkMode::MaybeNone) => {}


### PR DESCRIPTION
## Summary

- Widen `LinkMode::C` from `Immediate` to `Value` so `load_constant` can fold heap-resident constants (Class objects, Modules, Strings, Bignums, Ranges, Regexps, …) into the abstract state instead of materializing them with `movabs imm64; mov` at every use.
- Heap-allocated `Float` keeps its existing `Sf` path so subsequent float arithmetic reads the f64 from xmm directly. Everything else flows through `def_C`.
- Fix a related JIT specialization bug surfaced by the change: heap class constants in `LinkMode::C` used to trigger iseq specialization, which let polymorphic inline-cache state inside the callee's body leak back to the caller's return type. A new `is_C_immediate` helper restricts the specialization trigger to packed immediates, preserving the pre-existing behaviour.

## Why this is safe

- **GC**: at every safepoint, `wb_literal` already writes back each `LinkMode::C` slot to the stack. The collector is non-moving mark-and-sweep, so the heap pointer embedded as a JIT literal stays valid after GC sees it via the stack scan.
- **Constant redefinition**: `GuardConstVersion` at the load site deopts the moment any constant changes, so a stale pointer can never be observed at runtime.
- **Class mutability**: a class object can have methods added/removed, but its identity (pointer) does not change — that's tracked separately by `class_version`.

## The specialization bug, in case anyone hits it again

`tests/method_call.rs::attr_reader_in_different_class` (specifically the `class S < Array; class C < S` variant) flipped `s.a..s.h` into the reverse order after JIT compiled. The chain was:

1. `S.new` now has `LinkMode::C(S_value)` for the receiver, so the call became `specializable`.
2. `Array.new` (the Ruby-defined `def self.new(...); o = allocate; o.__send__(:initialize, ...); o; end`) got specialized.
3. The `o.__send__` call site is shared across both `S.new` and `C.new` specializations, so its inline cache is polymorphic. The JIT happened to read one specific cached `recv_class` (here `C`) and `guard_class` upgraded `o` to `Guarded::Class(C)`.
4. The trailing `o` became `ReturnValue::Class(C)`, so back in the caller `state.class(s) == Some(C)` and `s.a` was compiled with `C`'s `IvarId` for `:a` (=7, the slot that actually held `@h` in `S`'s table).

Restricting specialization to immediate `LinkMode::C` keeps the previous trigger semantics; the underlying \"polymorphic IC leaks return class through `o`\" pattern can be addressed independently if specialization for class objects is desirable later.

## Test plan

- [x] `cargo nextest run` — 2662 passed, 17 skipped (process / copy_stream / aobench environment-specific)
- [x] `cargo test --test method_call attr_reader_in_different_class` — the regression case the fix targets
- [x] Manual smoke: class-constant access (`String`, `Array`, `Hash`, `Range`, `Regexp`, `Bignum`, heap `Float`) under tight JIT loop + GC pressure (1000 iters allocating per-iter garbage while reading a `Hash` constant); all match CRuby.
- [x] `bin/test` — *not run locally* (need maintainer's CI for the optcarrot diff and the full coverage path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)