### PR TITLE
jit: inline Object#is_a? and stop poisoning callers with speculative Const returns

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -130,7 +130,6 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_private_builtin_func(kernel_class, "initialize_dup", initialize_clone, 1);
     globals.define_builtin_funcs_rest(kernel_class, "enum_for", &["to_enum"], to_enum);
     globals.define_builtin_func_rest(kernel_class, "extend", extend);
-    globals.define_builtin_func(kernel_class, "kind_of?", is_a, 1);
     globals.define_builtin_inline_func(
         kernel_class,
         "object_id",
@@ -156,7 +155,14 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "instance_variable_get", iv_get, 1);
     globals.define_builtin_func(kernel_class, "instance_variables", iv, 0);
     globals.define_builtin_func(kernel_class, "remove_instance_variable", iv_remove, 1);
-    globals.define_builtin_func(kernel_class, "is_a?", is_a, 1);
+    globals.define_builtin_inline_funcs(
+        kernel_class,
+        "is_a?",
+        &["kind_of?"],
+        is_a,
+        Box::new(kernel_is_a),
+        1,
+    );
     globals.define_builtin_inline_funcs_with_kw(
         kernel_class,
         "send",
@@ -2092,6 +2098,52 @@ fn is_a(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     ))
 }
 
+fn kernel_is_a(
+    state: &mut AbstractState,
+    _ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    let CallSiteInfo { args, dst, .. } = *callsite;
+    // Only fold when the argument is a concrete class/module value.
+    // Anything else (including a literal that isn't a class/module — which
+    // would raise TypeError) falls back to the regular dispatch.
+    let Some(target) = state.is_class_or_module_literal(args) else {
+        return false;
+    };
+    let target_id = target.id();
+    // Synthetic classes like BOOL_CLASS have no backing Module object —
+    // their superclass chain isn't meaningful for is_a? folding. Fall
+    // back to the regular dispatch in that case.
+    let Some(recv_module) = store[recv_class].try_get_module() else {
+        return false;
+    };
+    // The receiver-class guard + class_version guard upstream ensure
+    // recv_class is exact at this point, so the inheritance chain is
+    // fixed: walk recv_module's superclasses to compute the result at
+    // compile time.
+    let mut cur = Some(recv_module);
+    let mut result = false;
+    while let Some(m) = cur {
+        if m.id() == target_id {
+            result = true;
+            break;
+        }
+        cur = m.superclass();
+    }
+    if let Some(dst) = dst {
+        state.def_C(dst, Immediate::bool(result));
+    }
+    true
+}
+
 ///
 /// ### Kernel#enum_for
 ///
@@ -3460,6 +3512,26 @@ mod tests {
         end
         c = C.new
         [c.is_a?(S), c.is_a?(C)]"#,
+        );
+        // Walks include / superclass chain so JIT must consult ancestors.
+        run_test(
+            r#"
+            [5.is_a?(Integer), 5.is_a?(Numeric), 5.is_a?(Comparable),
+             5.is_a?(Object), 5.is_a?(Kernel), 5.is_a?(BasicObject),
+             5.is_a?(Float), 5.is_a?(String)]
+            "#,
+        );
+        // kind_of? alias resolves to the same inline.
+        run_test(r#"[5.kind_of?(Integer), 5.kind_of?(Float), "x".kind_of?(String)]"#);
+        // Make is_a? called from a hot method so the JIT compiles and
+        // fires the inline (run_test runs the snippet 25 times).
+        run_test(
+            r#"
+            def check(o); o.is_a?(Integer); end
+            r = []
+            1000.times { r << check(1) }
+            r.uniq
+            "#,
         );
     }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -342,7 +342,10 @@ impl<'a> JitContext<'a> {
         } else {
             JitArgumentInfo::default()
         };
-        let (entry, return_state) = match self.compile_specialized_func(
+        let SpecializedCompileResult {
+            entry,
+            return_state,
+        } = self.compile_specialized_func(
             state,
             iseq,
             self_class,
@@ -350,16 +353,7 @@ impl<'a> JitContext<'a> {
             args_info,
             Some(outer),
             callid,
-        )? {
-            SpecializedCompileResult::Const(v) => {
-                state.def_C(dst, v);
-                return Ok(CompileResult::Continue);
-            }
-            SpecializedCompileResult::Compiled {
-                entry,
-                return_state,
-            } => (entry, return_state),
-        };
+        )?;
         state.exec_gc(ir, true);
         let using_xmm = state.get_using_xmm();
         // stack pointer adjustment
@@ -571,7 +565,10 @@ impl<'a> JitContext<'a> {
         } else {
             Some(self.label())
         };
-        let (entry, result) = match self.compile_specialized_func(
+        let SpecializedCompileResult {
+            entry,
+            return_state,
+        } = self.compile_specialized_func(
             state,
             iseq,
             recv_class,
@@ -579,30 +576,18 @@ impl<'a> JitContext<'a> {
             args_info,
             None,
             callid,
-        )? {
-            SpecializedCompileResult::Const(v) => {
-                state.def_C(dst, v);
-                return Ok(CompileResult::Continue);
-            }
-            SpecializedCompileResult::Compiled {
-                entry,
-                return_state: result,
-            } => (entry, result),
-        };
+        )?;
         let evict = ir.new_evict();
         state.send_specialized(ir, &self.store, callid, fid, entry, patch_point, evict);
-        let res = state.def_rax2acc_return(ir, dst, result);
+        let res = state.def_rax2acc_return(ir, dst, return_state);
         state.immediate_evict(ir, evict);
         return Ok(res);
     }
 }
 
-pub(super) enum SpecializedCompileResult {
-    Const(Value),
-    Compiled {
-        entry: JitLabel,
-        return_state: Option<ReturnState>,
-    },
+pub(super) struct SpecializedCompileResult {
+    pub entry: JitLabel,
+    pub return_state: Option<ReturnState>,
 }
 
 impl<'a> JitContext<'a> {
@@ -655,29 +640,25 @@ impl<'a> JitContext<'a> {
         // If the iseq has rescue/ensure handlers, the abstract
         // interpreter's BB graph doesn't include the rescue PCs as
         // successors, so the computed return state only reflects the
-        // happy path. Letting Const-folding fire (or letting the
-        // Const ret survive into `def_rax2acc_return`) would
-        // overwrite the rescue path's actual return value with the
-        // happy-path constant. See issue #405.
+        // happy path. Letting the Const ret survive into
+        // `def_rax2acc_return` would overwrite the rescue path's
+        // actual return value with the happy-path constant. See
+        // issue #405.
         let return_state = return_state.map(|mut s| {
             if self.store[iseq_id].has_exception_handler() {
                 s.taint_for_unmodeled_rescue();
             }
             s
         });
-        if let Some(result) = &return_state {
-            if let Some(v) = result.const_folded() {
-                #[cfg(feature = "jit-debug")]
-                if self.codegen_mode() {
-                    eprintln!(
-                        "const folded: {} {:?}",
-                        self.store.func_description(self.store[iseq_id].func_id()),
-                        result
-                    );
-                }
-                return Ok(SpecializedCompileResult::Const(v));
-            }
-        }
+        // Even when the specialized body has been fully const-folded,
+        // we keep the call site: the asm still contains the
+        // speculation's deopt-able guards and the non-local-return
+        // jump targets that a deopt'd interp may use. Skipping the
+        // call site (the previous `SpecializedCompileResult::Const`
+        // shortcut) made those runtime paths unreachable — which
+        // broke e.g. `Array#assoc`, whose block's `return elem`
+        // depends on the deopt path to set rax for the non-local
+        // return.
         #[cfg(feature = "jit-debug")]
         if self.codegen_mode() {
             eprintln!(
@@ -692,7 +673,7 @@ impl<'a> JitContext<'a> {
             info: frame.asm_info,
             patch_point,
         });
-        Ok(SpecializedCompileResult::Compiled {
+        Ok(SpecializedCompileResult {
             entry,
             return_state,
         })

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -277,8 +277,20 @@ impl AbstractFrame {
                     ir.push(AsmInst::Unreachable);
                     return CompileResult::Cease;
                 }
-                ReturnValue::Const(v) => {
-                    self.def_C(dst, v);
+                // Treat `Const` returns from inlined iseqs the same as
+                // `Value`: take rax as the source of truth. The
+                // analyzed-as-constant return was inferred from the
+                // happy speculation path inside the callee; if any deopt
+                // along that path fires at runtime, the non-local
+                // return / interp epilogue writes the actual value to
+                // rax (see `Array#assoc` for a concrete example), and
+                // folding the static constant here would poison the
+                // caller into emitting code that overwrites rax with the
+                // stale literal. The callee already wrote the constant
+                // to rax on its happy path, so demoting to `def_rax2acc`
+                // costs only a `mov` while staying correct under deopt.
+                ReturnValue::Const(_) => {
+                    self.def_rax2acc(ir, dst);
                 }
                 ReturnValue::Class(class) => {
                     self.def_reg2acc_class(ir, GP::Rax, dst, class);
@@ -423,6 +435,7 @@ impl ReturnState {
         }
     }
 
+    #[allow(dead_code)] // retained for `taint_for_unmodeled_rescue` tests
     pub(in crate::codegen::jitgen) fn const_folded(&self) -> Option<Value> {
         if !self.invariants.side_effect_guard {
             return None;

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -694,6 +694,14 @@ impl SlotState {
         }
     }
 
+    pub fn is_class_or_module_literal(&self, slot: SlotId) -> Option<Module> {
+        if let LinkMode::C(v) = self.mode(slot) {
+            v.is_class_or_module()
+        } else {
+            None
+        }
+    }
+
     #[allow(non_snake_case)]
     pub fn coerce_C_f64(&self, slot: SlotId) -> Option<f64> {
         if let LinkMode::C(v) = self.mode(slot) {


### PR DESCRIPTION
## Summary

- Adds an inline gen for `Kernel#is_a?` / `kind_of?` that constant-folds the result at compile time when the argument is a known class/module `Value`. Falls back to normal dispatch for synthetic classes (`BOOL_CLASS` et al.) with no backing `Module`.
- Fixes two interacting bugs in the specialized-iseq return path that surfaced while wiring up the inline:
  1. `compile_specialized_func` had a `SpecializedCompileResult::Const` shortcut that skipped registering the iseq's entry asm entirely when the body const-folded. That made the speculation's deopt path and the deopt → interp → non-local return mechanism unreachable at runtime. Always register the entry; route `Const`-returning iseqs through `send_specialized` / `SpecializedYield` + `def_rax2acc_return`.
  2. `def_rax2acc_return` for `ReturnValue::Const(v)` did `def_C(dst, v)`, baking the speculation's happy-path constant into the caller's abstract state. If the callee deopts and the VM produces a different return value in rax (e.g. `Array#assoc`'s block doing `return elem` for `[3, 4]`), the caller had already emitted code that ignored or overwrote rax with the stale literal. Demote `Const` to `def_rax2acc` so the caller treats rax as the source of truth.

The end-to-end symptom of (1)+(2) was `Array#assoc` returning `nil` for an array that actually contained the matching pair under specialized inlining: the JIT inlined `assoc` into the caller, observed the block as "always returns nil under String-specialized speculation", folded that nil up to the caller's return slot, and ignored the rax that the interp had set after deopt via non-local return.

## Follow-up

The `Const → Value` demotion in `def_rax2acc_return` is currently unconditional, which also gives up the legitimate Const propagation for iseqs that truly are deopt-free (no guards, no speculation — think `def f; 5; end`). A cleaner follow-up is to thread a "this iseq emitted at least one deopt" flag through `ReturnState` (analogous to `taint_for_unmodeled_rescue` for issue #405) and gate the demotion on it.

## Test plan

- [x] `cargo nextest run --lib` — 2289 / 2289 passed
- [x] `Object#check; o.is_a?(Integer); end; 1000.times { check(1) }` — JIT emits a single `movabs rax, TRUE_VALUE` for the inlined is_a?
- [x] `Array#assoc` / `Array#rassoc` polymorphic-block tests pass (they were the trigger for finding bug 2)
- [x] `FalseClass#class_name` / `TrueClass#class_name` no longer panic on `Option::unwrap()` (BOOL_CLASS has no backing Module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)