### PR TITLE
jit: gate speculative-Const demotion on iseq's actual deopt presence

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -64,6 +64,12 @@ pub(crate) struct AsmIr {
     codegen_mode: bool,
     inst: Vec<AsmInst>,
     side_exit: Vec<SideExit>,
+    /// Set when this IR has emitted at least one deopt-able side exit
+    /// (via [`Self::new_deopt`] / [`Self::new_deopt_with_pc`]). Read by
+    /// the enclosing frame to taint any `ReturnValue::Const` it would
+    /// otherwise propagate to its caller — see
+    /// `JitStackFrame::had_deopt`.
+    had_deopt: bool,
 }
 
 impl std::ops::Index<AsmEvict> for AsmIr {
@@ -96,7 +102,12 @@ impl AsmIr {
             codegen_mode: ctx.codegen_mode(),
             inst: vec![],
             side_exit: vec![],
+            had_deopt: false,
         }
+    }
+
+    pub(super) fn had_deopt(&self) -> bool {
+        self.had_deopt
     }
 
     pub(super) fn push(&mut self, inst: AsmInst) {
@@ -117,14 +128,23 @@ impl AsmIr {
         self.inst.is_empty()
     }
 
-    pub(super) fn save(&mut self) -> (usize, usize, bool) {
-        (self.inst.len(), self.side_exit.len(), self.codegen_mode)
+    pub(super) fn save(&mut self) -> (usize, usize, bool, bool) {
+        (
+            self.inst.len(),
+            self.side_exit.len(),
+            self.codegen_mode,
+            self.had_deopt,
+        )
     }
 
-    pub(super) fn restore(&mut self, (inst, side_exit, codegen_mode): (usize, usize, bool)) {
+    pub(super) fn restore(
+        &mut self,
+        (inst, side_exit, codegen_mode, had_deopt): (usize, usize, bool, bool),
+    ) {
         self.inst.truncate(inst);
         self.side_exit.truncate(side_exit);
         self.codegen_mode = codegen_mode;
+        self.had_deopt = had_deopt;
     }
 
     pub(crate) fn new_evict(&mut self) -> AsmEvict {
@@ -134,6 +154,7 @@ impl AsmIr {
 
     pub(crate) fn new_deopt_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmDeopt {
         let i = self.new_label(SideExit::Deoptimize(pc, state.get_write_back()));
+        self.had_deopt = true;
         AsmDeopt(i)
     }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -637,15 +637,24 @@ impl<'a> JitContext<'a> {
         let mut return_context = frame.detach_return_context();
         let return_state = return_context.remove(&pos);
         self.merge_return_context(return_context);
-        // If the iseq has rescue/ensure handlers, the abstract
-        // interpreter's BB graph doesn't include the rescue PCs as
-        // successors, so the computed return state only reflects the
-        // happy path. Letting the Const ret survive into
-        // `def_rax2acc_return` would overwrite the rescue path's
-        // actual return value with the happy-path constant. See
-        // issue #405.
+        // Capture before `frame.asm_info` is moved below.
+        let frame_had_deopt = frame.had_deopt;
+        // Two unmodeled-path conditions taint the return state so the
+        // caller doesn't propagate a speculative `Const` past us:
+        //
+        // 1. `has_exception_handler`: the BB graph doesn't include
+        //    rescue/ensure successors, so the computed return state
+        //    only reflects the happy path. See issue #405.
+        //
+        // 2. `frame_had_deopt`: any deopt-able side exit emitted
+        //    during this iseq's compile means the runtime can resume
+        //    in the interpreter from the deopt PC and produce a
+        //    different rax than the abstract interpreter's
+        //    speculation predicted (e.g. `Array#assoc`'s block doing
+        //    `return elem` after the recv-class guard fails). See
+        //    PR #505.
         let return_state = return_state.map(|mut s| {
-            if self.store[iseq_id].has_exception_handler() {
+            if self.store[iseq_id].has_exception_handler() || frame_had_deopt {
                 s.taint_for_unmodeled_rescue();
             }
             s
@@ -673,6 +682,15 @@ impl<'a> JitContext<'a> {
             info: frame.asm_info,
             patch_point,
         });
+        // Propagate the deopt fact one level up: if this inlined
+        // sub-iseq could deopt, the caller's compiled body also
+        // contains that deopt-able path, so the caller's own
+        // return-state taint check needs to see it. We are always
+        // inside the caller's frame here (specialized_compile pushed
+        // and popped the sub-frame internally).
+        if frame_had_deopt {
+            self.current_frame_mut().had_deopt = true;
+        }
         Ok(SpecializedCompileResult {
             entry,
             return_state,

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -406,6 +406,21 @@ pub(super) struct JitStackFrame {
     /// hints into concrete byte offsets.
     ///
     specialized_id: SpecializedId,
+
+    ///
+    /// True iff any deopt-able side exit was emitted during this
+    /// frame's compilation, including from inlined sub-iseqs whose
+    /// compile-time deopt fact has been propagated up. Used by
+    /// `compile_specialized_func` to taint a `ReturnValue::Const`
+    /// before it leaks to the caller — see
+    /// `ReturnState::taint_for_unmodeled_rescue` for the dual case.
+    ///
+    /// Aggregated from `AsmIr::had_deopt()` at every
+    /// `push_ir`/`add_inline_bridge`/`add_outline_bridge`, and
+    /// propagated from inlined sub-iseqs in
+    /// `compile_specialized_func`.
+    ///
+    pub(super) had_deopt: bool,
 }
 
 impl std::fmt::Debug for JitStackFrame {
@@ -490,6 +505,7 @@ impl JitStackFrame {
             base_stack_offset: stack_offset,
             // Sentinel — overwritten by [`JitContext::push_frame`].
             specialized_id: SpecializedId(usize::MAX),
+            had_deopt: false,
         }
     }
 
@@ -512,6 +528,7 @@ impl JitStackFrame {
             // walks over a snapshot of the stack and never reaches
             // the codegen resolve pass, so id reuse is safe.
             specialized_id: self.specialized_id,
+            had_deopt: self.had_deopt,
         }
     }
 
@@ -696,7 +713,7 @@ impl<'a> JitContext<'a> {
         self.stack_frame.last().unwrap()
     }
 
-    fn current_frame_mut(&mut self) -> &mut JitStackFrame {
+    pub(super) fn current_frame_mut(&mut self) -> &mut JitStackFrame {
         self.stack_frame.last_mut().unwrap()
     }
 
@@ -1307,7 +1324,9 @@ impl<'a> JitContext<'a> {
     }
 
     pub(super) fn push_ir(&mut self, bb: Option<BasicBlockId>, ir: AsmIr) {
-        self.current_frame_mut().ir.push((bb, ir));
+        let frame = self.current_frame_mut();
+        frame.had_deopt |= ir.had_deopt();
+        frame.ir.push((bb, ir));
     }
 
     pub(super) fn add_inline_bridge(
@@ -1316,14 +1335,14 @@ impl<'a> JitContext<'a> {
         ir: AsmIr,
         dest_bb: Option<BasicBlockId>,
     ) {
-        self.current_frame_mut()
-            .inline_bridges
-            .insert(src_bb, (ir, dest_bb));
+        let frame = self.current_frame_mut();
+        frame.had_deopt |= ir.had_deopt();
+        frame.inline_bridges.insert(src_bb, (ir, dest_bb));
     }
 
     pub(super) fn add_outline_bridge(&mut self, ir: AsmIr, dest: JitLabel, bbid: BasicBlockId) {
-        self.current_frame_mut()
-            .outline_bridges
-            .push((ir, dest, bbid));
+        let frame = self.current_frame_mut();
+        frame.had_deopt |= ir.had_deopt();
+        frame.outline_bridges.push((ir, dest, bbid));
     }
 }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -277,20 +277,15 @@ impl AbstractFrame {
                     ir.push(AsmInst::Unreachable);
                     return CompileResult::Cease;
                 }
-                // Treat `Const` returns from inlined iseqs the same as
-                // `Value`: take rax as the source of truth. The
-                // analyzed-as-constant return was inferred from the
-                // happy speculation path inside the callee; if any deopt
-                // along that path fires at runtime, the non-local
-                // return / interp epilogue writes the actual value to
-                // rax (see `Array#assoc` for a concrete example), and
-                // folding the static constant here would poison the
-                // caller into emitting code that overwrites rax with the
-                // stale literal. The callee already wrote the constant
-                // to rax on its happy path, so demoting to `def_rax2acc`
-                // costs only a `mov` while staying correct under deopt.
-                ReturnValue::Const(_) => {
-                    self.def_rax2acc(ir, dst);
+                // Reaching this arm means `compile_specialized_func`
+                // confirmed the callee's body is genuinely deopt-free
+                // (and has no rescue/ensure). Speculative `Const`
+                // returns are tainted to `Value` upstream by
+                // `taint_for_unmodeled_rescue`, so what arrives here is
+                // a true compile-time constant — safe to fold into the
+                // caller's abstract state.
+                ReturnValue::Const(v) => {
+                    self.def_C(dst, v);
                 }
                 ReturnValue::Class(class) => {
                     self.def_reg2acc_class(ir, GP::Rax, dst, class);
@@ -418,10 +413,22 @@ impl ReturnState {
     }
 
     /// Forget what the abstract interpreter inferred about the return
-    /// value and side effects. Used when the iseq has rescue/ensure
-    /// handlers that the BB graph doesn't model — the actual return
-    /// could come from any rescue path the interpreter never visited
-    /// (see issue #405).
+    /// value and side effects. Used whenever the iseq has control-flow
+    /// paths the BB graph doesn't model, so the actual return at
+    /// runtime can differ from what the analysis computed.
+    ///
+    /// Two cases trigger this taint today:
+    ///
+    /// 1. **rescue/ensure handlers** — the BB graph has no edge into
+    ///    them, so the analysis only sees the happy path (issue #405).
+    ///
+    /// 2. **deopt-able guards** — speculation can fail at runtime, in
+    ///    which case the interpreter resumes from the deopt PC and
+    ///    runs the bytecode (including paths the JIT eliminated as
+    ///    dead). The rax it leaves behind may differ from the static
+    ///    `Const` the analyzer derived on the happy path — see
+    ///    `Array#assoc` / PR #505. The trigger is
+    ///    `JitStackFrame::had_deopt`.
     pub(in crate::codegen::jitgen) fn taint_for_unmodeled_rescue(&mut self) {
         self.ret = ReturnValue::Value;
         self.invariants.side_effect_guard = false;


### PR DESCRIPTION
## Summary

Follow-up to #505. PR #505 unconditionally demoted every `ReturnValue::Const(v)` reaching `def_rax2acc_return` to `def_rax2acc(rax)` to stop leaking speculation-derived constants into callers. That's correct but over-conservative: a genuinely pure iseq (e.g. `def f; 5; end`) emits no deopt-able guards at all, so its `Const` return is reliable and can still be folded into the caller's abstract state.

This PR tracks whether each iseq's compile actually emitted a deopt, taints only when it did, and restores `def_C` in the `Const` arm so pure-function folding works again.

- `AsmIr` carries a `had_deopt` flag, set in `new_deopt[_with_pc]` and preserved across `save`/`restore` (so the inline-asm rollback path doesn't accidentally remember a deopt that was rolled back).
- `JitStackFrame` carries an aggregated `had_deopt`, ORed in by `push_ir` / `add_inline_bridge` / `add_outline_bridge`, and propagated one frame up by `compile_specialized_func` so an inlined sub-iseq's deopt taints the surrounding iseq too.
- `compile_specialized_func` taints the return state via the existing `taint_for_unmodeled_rescue` whenever the frame had a deopt — in addition to the `has_exception_handler` case from issue #405.
- `def_rax2acc_return`'s `Const` arm goes back to `self.def_C(dst, v)`. By the time control reaches it the taint logic above has already downgraded any speculative Const to `Value`, so what's left is genuine compile-time constants.
- `taint_for_unmodeled_rescue`'s doc comment is updated to describe both trigger conditions (rescue/ensure and deopt). The body is unchanged and existing unit tests still cover the state-transition invariants.

## Verification

- `def pure; 42; end; def use_pure; pure + 1; end` — JIT-compiled `use_pure` emits `movabs rax, 0x57` (`Fixnum 43`), i.e. the entire `pure() + 1` folds to a literal at compile time.
- `Array#assoc` / `Array#rassoc` polymorphic-block tests keep passing — the speculative-deopt → non-local-return path from PR #505 is still correct.
- `cargo nextest run --lib`: **2289 / 2289 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)