### PR TITLE
core/method: account for keyword args in arity and parameters

### DIFF
--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -864,6 +864,77 @@ mod tests {
     }
 
     #[test]
+    fn method_arity_keyword_args() {
+        // Keyword arguments participate in Method#arity exactly as
+        // CRuby: a required keyword folds into one mandatory argument,
+        // a purely-optional keyword set folds into one optional
+        // argument (negative form). Compared against system CRuby.
+        run_test(
+            r##"
+            def a; end
+            def b(x); end
+            def c(x:); end
+            def d(x:, y:); end
+            def e(x, y:); end
+            def f(x, y:, &l); end
+            def g(x, y, z:, w: 1, **k, &l); end
+            def h(x: 1, y: 2); end
+            def i(x: 1, y: 2, **k); end
+            def j(x=1, y: 2); end
+            def k(x=1, *y, z:, w: 2, **r, &l); end
+            def l(p, q=1, *r, s:, t: 2, **u, &v); end
+            %i[a b c d e f g h i j k l].map { |n| method(n).arity }
+            "##,
+        );
+    }
+
+    #[test]
+    fn method_parameters_keyword_kinds() {
+        // Required keywords report :keyreq, optional ones :key, and a
+        // named **kwrest carries its name. (Keyword display ordering
+        // for source-interleaved req/opt keywords still differs from
+        // CRuby and is intentionally not asserted here.)
+        run_test(
+            r##"
+            def m(a, b = 1, c:, d: 2, **rest, &blk); end
+            method(:m).parameters
+            "##,
+        );
+        run_test(
+            r##"
+            def only_req_kw(a:, b:); end
+            method(:only_req_kw).parameters
+            "##,
+        );
+        run_test(
+            r##"
+            def kwrest_named(**opts); end
+            method(:kwrest_named).parameters
+            "##,
+        );
+    }
+
+    #[test]
+    fn umethod_arity_keyword_args() {
+        run_test_with_prelude(
+            r##"
+            [Foo.instance_method(:a).arity,
+             Foo.instance_method(:b).arity,
+             Foo.instance_method(:c).arity,
+             Foo.instance_method(:d).arity]
+            "##,
+            r##"
+            class Foo
+              def a(x:); end
+              def b(x: 1); end
+              def c(x, y:, **k); end
+              def d(x = 1, *y, z:, **r); end
+            end
+            "##,
+        );
+    }
+
+    #[test]
     fn umethod_bind_call_basic() {
         run_test(
             r##"

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -180,6 +180,7 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
     let opt_tag = Value::symbol(IdentId::get_id("opt"));
     let rest_tag = Value::symbol(IdentId::get_id("rest"));
     let key_tag = Value::symbol(IdentId::get_id("key"));
+    let keyreq_tag = Value::symbol(IdentId::get_id("keyreq"));
     let keyrest_tag = Value::symbol(IdentId::get_id("keyrest"));
     let block_tag = Value::symbol(IdentId::get_id("block"));
     let mut result = vec![];
@@ -231,12 +232,22 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
         name_idx += 1;
     }
     // keyword params
-    for kw_name in &params.kw_names {
-        result.push(Value::array2(key_tag, Value::symbol(*kw_name)));
+    for (i, kw_name) in params.kw_names.iter().enumerate() {
+        let tag = if params.kw_is_required(i) {
+            keyreq_tag
+        } else {
+            key_tag
+        };
+        result.push(Value::array2(tag, Value::symbol(*kw_name)));
     }
     // keyword rest
     if params.kw_rest.is_some() {
-        result.push(Value::array1(keyrest_tag));
+        let entry = if let Some(name) = params.kw_rest_name() {
+            Value::array2(keyrest_tag, Value::symbol(name))
+        } else {
+            Value::array1(keyrest_tag)
+        };
+        result.push(entry);
     }
     // block param
     if let Some(block_name) = params.block_param {

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -976,6 +976,10 @@ impl Store {
             .map(|(src, dst, len)| DestructureInfo::new(src, args_names.len() + dst, len))
             .collect();
         args_names.append(&mut destruct_args);
+        let kw_required: Vec<bool> = keyword_initializers
+            .iter()
+            .map(|init| init.is_none())
+            .collect();
         let params_info = ParamsInfo::new(
             required_num,
             optional_num,
@@ -984,6 +988,7 @@ impl Store {
             post_num,
             args_names,
             keyword_names,
+            kw_required,
             kw_rest_param,
             block_param,
             forwarding,

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1083,12 +1083,35 @@ impl FuncInfo {
     /// arity to the negative form — CRuby reports `arity = 1` for
     /// `|a,|` while `|a, *|` reports `-2`, and `|a, *r|` likewise.
     ///
+    /// Keyword arguments are folded into a single extra argument
+    /// (per the Ruby docs): mandatory if any keyword is required,
+    /// optional otherwise. A required keyword therefore adds 1 to the
+    /// required count without making the signature variable, while a
+    /// set of purely-optional keywords (or `**kwrest`) with no required
+    /// keyword behaves like one optional argument and forces the
+    /// negative form.
+    ///
     pub(crate) fn arity(&self) -> i64 {
-        let min = self.min_positional_args() as i64;
-        if self.opt_num() > 0 || self.is_explicit_rest() {
-            -(min + 1)
+        let p = &self.ext.params;
+        let req = self.min_positional_args() as i64;
+        let has_required_kw = p.required_kw_num() > 0;
+        let req_count = req + has_required_kw as i64;
+        // Non-lambda procs/blocks only go negative for an explicit rest
+        // or an optional positional; purely-optional keywords (or
+        // `**kwrest`) are ignored. Lambdas, named methods and
+        // `define_method` additionally fold a no-required-keyword set
+        // into one optional argument (CRuby `Method#arity`).
+        let variable = if self.is_block_style() {
+            self.opt_num() > 0 || self.is_explicit_rest()
         } else {
-            min
+            self.opt_num() > 0
+                || self.is_explicit_rest()
+                || (p.has_keyword() && !has_required_kw)
+        };
+        if variable {
+            -(req_count + 1)
+        } else {
+            req_count
         }
     }
 

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -598,6 +598,11 @@ pub(crate) struct ParamsInfo {
     // for param, req(incl. destruct slot), opt, rest, keyword, kw_rest, destructed local, block
     pub args_names: Vec<Option<IdentId>>,
     pub kw_names: Vec<IdentId>,
+    /// Parallel to `kw_names`: `true` for a required keyword (`a:` with
+    /// no default), `false` for an optional one (`a: default`). May be
+    /// shorter than `kw_names` (e.g. native methods) — treat a missing
+    /// entry as optional via `kw_is_required`.
+    pub kw_required: Vec<bool>,
     pub kw_rest: Option<SlotId>,
     pub block_param: Option<IdentId>,
     forwarding: bool,
@@ -612,6 +617,7 @@ impl ParamsInfo {
         post_num: usize,
         args_names: Vec<Option<IdentId>>,
         keyword_names: Vec<IdentId>,
+        kw_required: Vec<bool>,
         kw_rest: Option<SlotId>,
         block_param: Option<IdentId>,
         forwarding: bool,
@@ -624,6 +630,7 @@ impl ParamsInfo {
             post_num,
             args_names,
             kw_names: keyword_names,
+            kw_required,
             kw_rest,
             block_param,
             forwarding,
@@ -643,6 +650,7 @@ impl ParamsInfo {
             post_num: 0,
             args_names: vec![],
             kw_names: vec![],
+            kw_required: vec![],
             kw_rest: None,
             block_param: None,
             forwarding: false,
@@ -670,6 +678,7 @@ impl ParamsInfo {
             rest_is_implicit: false,
             post_num: 0,
             args_names: vec![],
+            kw_required: vec![false; kw_num],
             kw_names,
             kw_rest: if kw_rest {
                 Some(SlotId::new((1 + p + kw_num) as u16))
@@ -707,6 +716,39 @@ impl ParamsInfo {
     ///
     pub(crate) fn post_num(&self) -> usize {
         self.post_num
+    }
+
+    ///
+    /// The number of required (no-default) keyword arguments.
+    ///
+    pub(crate) fn required_kw_num(&self) -> usize {
+        self.kw_required.iter().filter(|b| **b).count()
+    }
+
+    ///
+    /// Whether the keyword at `idx` in `kw_names` is required.
+    ///
+    pub(crate) fn kw_is_required(&self, idx: usize) -> bool {
+        self.kw_required.get(idx).copied().unwrap_or(false)
+    }
+
+    ///
+    /// Whether this function accepts any keyword argument or `**kwrest`.
+    ///
+    pub(crate) fn has_keyword(&self) -> bool {
+        !self.kw_names.is_empty() || self.kw_rest.is_some()
+    }
+
+    ///
+    /// The name of the `**kwrest` parameter, if it has one. Anonymous
+    /// `**` (and the synthetic kwrest of `...`) return `None`.
+    ///
+    pub(crate) fn kw_rest_name(&self) -> Option<IdentId> {
+        let slot = self.kw_rest?;
+        self.args_names
+            .get(slot.0 as usize - 1)
+            .copied()
+            .flatten()
     }
 
     ///


### PR DESCRIPTION
## Summary

`Method#arity` / `UnboundMethod#arity` ignored keyword arguments entirely, and `Proc#parameters` / `Method#parameters` never reported `:keyreq` or a named `**kwrest`. This aligns both with CRuby 4.0.1.

- Track per-keyword required-ness in `ParamsInfo` (`kw_required: Vec<bool>`).
- `FuncInfo::arity()` now applies CRuby's rule: a required keyword folds into one **mandatory** argument; a no-required-keyword set (incl. `**kwrest`) folds into one **optional** argument for lambdas/named methods/`define_method`. Non-lambda procs keep their distinct rule (only an explicit rest / optional positional forces the negative form), so **`Proc#arity` is not regressed**.
- `build_parameters` emits `:keyreq` for required keywords and a named `**k` as `[:keyrest, :k]`.
- Added 3 regression tests (`method_arity_keyword_args`, `method_parameters_keyword_kinds`, `umethod_arity_keyword_args`).

## Results

- `core/method`: **41 → 31** failures (10 fixed)
- `core/unboundmethod`: **14 → 7** failures (7 fixed)
- 17 ruby/spec examples fixed total; arity values verified identical to CRuby across all 21 signature patterns.
- Full cargo suite: 2043/2045 pass. The 2 remaining failures (`string_inspect`, `symbol_inspect_unquoted`) are a pre-existing `café`/`é` locale issue, confirmed failing on a clean tree and unrelated to this change.

Out of scope (parser / other subsystems): anonymous `*`/`**`/`&` naming (`:*`/`:**`/`:&`), `**nil` → `:nokey`, source-interleaved keyword display ordering, and unimplemented `Method#<<`/`#>>`/`#curry`/`#super_method`.

## Test plan

- [x] `cargo build` clean
- [x] New regression tests pass (`method_arity_keyword_args`, `method_parameters_keyword_kinds`, `umethod_arity_keyword_args`)
- [x] Full `cargo test` — no new failures vs. clean tree
- [x] `ruby/spec` core/method & core/unboundmethod re-run, no regressions/new errors
- [x] Direct diff vs system CRuby on 21 arity/parameters signatures

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_