### PR TITLE
method: support Method/UnboundMethod objects from respond_to_missing?

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2503,11 +2503,40 @@ fn instance_of(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/method.html]
 #[monoruby_builtin]
-fn method(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn method(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
     let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let (func_id, _, owner) = globals.find_method_for_object(receiver, method_name)?;
-    Ok(Value::new_method(receiver, func_id, owner))
+    match globals.find_method_for_object(receiver, method_name) {
+        Ok((func_id, _, owner)) => Ok(Value::new_method(receiver, func_id, owner)),
+        Err(err) => {
+            // CRuby: if `receiver.respond_to_missing?(name, true)` is truthy,
+            // return a Method that proxies to `method_missing`.
+            if let Some(rtm_fid) =
+                globals.check_method(receiver, IdentId::RESPOND_TO_MISSING_)
+            {
+                let responds = vm.invoke_func_inner(
+                    globals,
+                    rtm_fid,
+                    receiver,
+                    &[Value::symbol(method_name), Value::bool(true)],
+                    None,
+                    None,
+                )?;
+                if responds.as_bool()
+                    && let Some(mm_fid) =
+                        globals.check_method(receiver, IdentId::METHOD_MISSING)
+                {
+                    return Ok(Value::new_method_missing_proxy(
+                        receiver,
+                        mm_fid,
+                        method_name,
+                        receiver.class(),
+                    ));
+                }
+            }
+            Err(err)
+        }
+    }
 }
 
 ///

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -50,7 +50,11 @@ fn method_eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     }
     let a = self_val.as_method();
     let b = other.as_method();
-    let eq = a.func_id() == b.func_id() && a.receiver().id() == b.receiver().id();
+    let eq = match (a.method_missing_name(), b.method_missing_name()) {
+        (Some(an), Some(bn)) => an == bn && a.receiver().id() == b.receiver().id(),
+        (None, None) => a.func_id() == b.func_id() && a.receiver().id() == b.receiver().id(),
+        _ => false,
+    };
     Ok(Value::bool(eq))
 }
 
@@ -70,7 +74,11 @@ fn umethod_eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     }
     let a = self_val.as_umethod();
     let b = other.as_umethod();
-    let eq = a.func_id() == b.func_id() && a.owner() == b.owner();
+    let eq = match (a.method_missing_name(), b.method_missing_name()) {
+        (Some(an), Some(bn)) => an == bn && a.owner() == b.owner(),
+        (None, None) => a.func_id() == b.func_id() && a.owner() == b.owner(),
+        _ => false,
+    };
     Ok(Value::bool(eq))
 }
 
@@ -89,6 +97,23 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let method = self_val.as_method();
     let func_id = method.func_id();
     let receiver = method.receiver();
+
+    if let Some(target) = method.method_missing_name() {
+        // Dispatch `receiver.method_missing(target, *args, &blk)` dynamically
+        // by name so that redefining `method_missing` after the Method was
+        // created is honored, and the real `target` method is never called
+        // even if it later comes to exist.
+        let mut args = vec![Value::symbol(target)];
+        args.extend(lfp.arg(0).as_array().iter().copied());
+        return vm.invoke_method_inner(
+            globals,
+            IdentId::METHOD_MISSING,
+            receiver,
+            &args,
+            lfp.block(),
+            None,
+        );
+    }
 
     vm.invoke_func_inner(
         globals,
@@ -110,6 +135,9 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn arity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_method();
+    if method.method_missing_name().is_some() {
+        return Ok(Value::integer(-1));
+    }
     let func_id = method.func_id();
     Ok(Value::integer(globals[func_id].arity()))
 }
@@ -124,6 +152,9 @@ fn arity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn uarity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_umethod();
+    if method.method_missing_name().is_some() {
+        return Ok(Value::integer(-1));
+    }
     let func_id = method.func_id();
     Ok(Value::integer(globals[func_id].arity()))
 }
@@ -182,6 +213,9 @@ fn source_location(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_method();
+    if method.method_missing_name().is_some() {
+        return Ok(Value::nil());
+    }
     let func_id = method.func_id();
     if let Some(iseq) = globals.store[func_id].is_iseq() {
         let iseq_info = &globals.store[iseq];
@@ -208,6 +242,9 @@ fn usource_location(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_umethod();
+    if method.method_missing_name().is_some() {
+        return Ok(Value::nil());
+    }
     let func_id = method.func_id();
     if let Some(iseq) = globals.store[func_id].is_iseq() {
         let iseq_info = &globals.store[iseq];
@@ -229,6 +266,9 @@ fn usource_location(
 fn name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_method();
+    if let Some(target) = method.method_missing_name() {
+        return Ok(Value::symbol(target));
+    }
     let func_id = method.func_id();
     let id = globals[func_id].name().unwrap();
     Ok(Value::symbol(id))
@@ -270,6 +310,13 @@ fn owner(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn unbind(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_method();
+    if let Some(target) = method.method_missing_name() {
+        return Ok(Value::new_unbound_method_missing_proxy(
+            method.func_id(),
+            target,
+            method.owner(),
+        ));
+    }
     Ok(Value::new_unbound_method(method.func_id(), method.owner()))
 }
 
@@ -283,6 +330,9 @@ fn unbind(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result
 fn uname(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_umethod();
+    if let Some(target) = method.method_missing_name() {
+        return Ok(Value::symbol(target));
+    }
     let func_id = method.func_id();
     let id = globals[func_id].name().unwrap();
     Ok(Value::symbol(id))
@@ -311,6 +361,10 @@ fn uowner(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 fn parameters(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_method();
+    if method.method_missing_name().is_some() {
+        let rest = Value::array1(Value::symbol(IdentId::get_id("rest")));
+        return Ok(Value::array1(rest));
+    }
     Ok(super::proc::build_parameters(
         globals,
         method.func_id(),
@@ -328,6 +382,10 @@ fn parameters(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 fn uparameters(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let method = self_val.as_umethod();
+    if method.method_missing_name().is_some() {
+        let rest = Value::array1(Value::symbol(IdentId::get_id("rest")));
+        return Ok(Value::array1(rest));
+    }
     Ok(super::proc::build_parameters(
         globals,
         method.func_id(),
@@ -929,6 +987,124 @@ mod tests {
               def b(x: 1); end
               def c(x, y:, **k); end
               def d(x = 1, *y, z:, **r); end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn respond_to_missing_method() {
+        run_test_with_prelude(
+            r##"
+            obj = Foo.new
+            m = obj.method(:dynamic)
+            [
+              m.call(1, 2),
+              m[3],
+              (m === 4),
+              m.arity,
+              m.parameters,
+              m.name,
+              m.receiver == obj,
+              m.owner,
+              m.source_location,
+              m.call { |x| x * 10 },
+            ]
+            "##,
+            r##"
+            class Foo
+              def respond_to_missing?(name, include_all)
+                name == :dynamic
+              end
+              def method_missing(name, *args, &blk)
+                if blk
+                  blk.call(7)
+                else
+                  [name, args]
+                end
+              end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn respond_to_missing_eq() {
+        run_test_with_prelude(
+            r##"
+            a = Foo.new
+            b = Foo.new
+            [
+              a.method(:x) == a.method(:x),
+              a.method(:x).eql?(a.method(:x)),
+              a.method(:x) == a.method(:y),
+              a.method(:x) == b.method(:x),
+              a.method(:x) == 5,
+            ]
+            "##,
+            r##"
+            class Foo
+              def respond_to_missing?(name, ia); true; end
+              def method_missing(name, *a); name; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn respond_to_missing_false_raises() {
+        run_test_error(
+            r##"
+            class Foo
+              def respond_to_missing?(name, ia); false; end
+            end
+            Foo.new.method(:nope)
+            "##,
+        );
+        run_test_error(
+            r##"
+            class Bar; end
+            Bar.new.method(:nope)
+            "##,
+        );
+    }
+
+    #[test]
+    fn respond_to_missing_unbind() {
+        run_test_with_prelude(
+            r##"
+            um = Foo.new.method(:dyn).unbind
+            [
+              um.is_a?(UnboundMethod),
+              um.arity,
+              um.name,
+              um.parameters,
+              um.source_location,
+              um == Foo.new.method(:dyn).unbind,
+              um == Foo.new.method(:other).unbind,
+            ]
+            "##,
+            r##"
+            class Foo
+              def respond_to_missing?(name, ia); true; end
+              def method_missing(name, *a); name; end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn respond_to_missing_respond_to() {
+        run_test_with_prelude(
+            r##"
+            obj = Foo.new
+            [obj.respond_to?(:dynamic), obj.respond_to?(:other)]
+            "##,
+            r##"
+            class Foo
+              def respond_to_missing?(name, ia)
+                name == :dynamic
+              end
             end
             "##,
         );

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -745,8 +745,19 @@ pub(super) extern "C" fn get_index(
         }*/
         METHOD_CLASS => {
             let method = base.as_method();
-            let func_id = method.func_id();
             let receiver = method.receiver();
+            if let Some(target) = method.method_missing_name() {
+                return vm.invoke_method(
+                    globals,
+                    IdentId::METHOD_MISSING,
+                    true,
+                    receiver,
+                    &[Value::symbol(target), index],
+                    None,
+                    None,
+                );
+            }
+            let func_id = method.func_id();
             return vm.invoke_func(globals, func_id, receiver, &[index], None, None);
         }
         _ => {}

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1140,8 +1140,25 @@ impl Value {
         RValue::new_method(receiver, func_id, owner).pack()
     }
 
+    pub fn new_method_missing_proxy(
+        receiver: Value,
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        RValue::new_method_missing_proxy(receiver, mm_func_id, target, owner).pack()
+    }
+
     pub fn new_unbound_method(func_id: FuncId, owner: ClassId) -> Self {
         RValue::new_unbound_method(func_id, owner).pack()
+    }
+
+    pub fn new_unbound_method_missing_proxy(
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        RValue::new_unbound_method_missing_proxy(mm_func_id, target, owner).pack()
     }
 
     pub(crate) fn new_fiber(proc: Proc) -> Self {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -340,6 +340,27 @@ impl ObjKind {
         }
     }
 
+    fn method_missing_proxy(
+        receiver: Value,
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        Self {
+            method: ManuallyDrop::new(MethodInner::new_method_missing(
+                receiver, mm_func_id, target, owner,
+            )),
+        }
+    }
+
+    fn unbound_method_missing_proxy(mm_func_id: FuncId, target: IdentId, owner: ClassId) -> Self {
+        Self {
+            umethod: ManuallyDrop::new(UMethodInner::new_method_missing(
+                mm_func_id, target, owner,
+            )),
+        }
+    }
+
     fn unbound_method(func_id: FuncId, owner: ClassId) -> Self {
         Self {
             umethod: ManuallyDrop::new(UMethodInner::new(func_id, owner)),
@@ -1548,10 +1569,35 @@ impl RValue {
         }
     }
 
+    pub(super) fn new_method_missing_proxy(
+        receiver: Value,
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        RValue {
+            header: Header::new(METHOD_CLASS, ObjTy::METHOD),
+            kind: ObjKind::method_missing_proxy(receiver, mm_func_id, target, owner),
+            var_table: None,
+        }
+    }
+
     pub(super) fn new_unbound_method(func_id: FuncId, owner: ClassId) -> Self {
         RValue {
             header: Header::new(UMETHOD_CLASS, ObjTy::UMETHOD),
             kind: ObjKind::unbound_method(func_id, owner),
+            var_table: None,
+        }
+    }
+
+    pub(super) fn new_unbound_method_missing_proxy(
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        RValue {
+            header: Header::new(UMETHOD_CLASS, ObjTy::UMETHOD),
+            kind: ObjKind::unbound_method_missing_proxy(mm_func_id, target, owner),
             var_table: None,
         }
     }

--- a/monoruby/src/value/rvalue/method.rs
+++ b/monoruby/src/value/rvalue/method.rs
@@ -6,6 +6,11 @@ pub struct MethodInner {
     receiver: Value,
     func_id: FuncId,
     owner: ClassId,
+    /// `Some(sym)` marks this Method as a `method_missing` proxy created
+    /// via `respond_to_missing?` for the target name `sym`. In that case
+    /// `func_id` is the resolved `method_missing` function and calling the
+    /// Method dispatches `receiver.method_missing(sym, ...)`.
+    mm_name: Option<IdentId>,
 }
 
 impl alloc::GC<RValue> for MethodInner {
@@ -20,6 +25,21 @@ impl MethodInner {
             receiver,
             func_id,
             owner,
+            mm_name: None,
+        }
+    }
+
+    pub fn new_method_missing(
+        receiver: Value,
+        mm_func_id: FuncId,
+        target: IdentId,
+        owner: ClassId,
+    ) -> Self {
+        Self {
+            receiver,
+            func_id: mm_func_id,
+            owner,
+            mm_name: Some(target),
         }
     }
 
@@ -33,6 +53,13 @@ impl MethodInner {
 
     pub fn owner(&self) -> ClassId {
         self.owner
+    }
+
+    ///
+    /// If this Method is a `method_missing` proxy, return the target name.
+    ///
+    pub fn method_missing_name(&self) -> Option<IdentId> {
+        self.mm_name
     }
 
     pub fn debug(&self, store: &Store) -> String {
@@ -57,11 +84,26 @@ impl MethodInner {
 pub struct UMethodInner {
     func_id: FuncId,
     owner: ClassId,
+    /// `Some(sym)` marks this UnboundMethod as a `method_missing` proxy
+    /// (created via `Method#unbind` on a `respond_to_missing?` Method).
+    mm_name: Option<IdentId>,
 }
 
 impl UMethodInner {
     pub fn new(func_id: FuncId, owner: ClassId) -> Self {
-        Self { func_id, owner }
+        Self {
+            func_id,
+            owner,
+            mm_name: None,
+        }
+    }
+
+    pub fn new_method_missing(mm_func_id: FuncId, target: IdentId, owner: ClassId) -> Self {
+        Self {
+            func_id: mm_func_id,
+            owner,
+            mm_name: Some(target),
+        }
     }
 
     pub fn func_id(&self) -> FuncId {
@@ -70,6 +112,13 @@ impl UMethodInner {
 
     pub fn owner(&self) -> ClassId {
         self.owner
+    }
+
+    ///
+    /// If this UnboundMethod is a `method_missing` proxy, return the target name.
+    ///
+    pub fn method_missing_name(&self) -> Option<IdentId> {
+        self.mm_name
     }
 
     pub fn debug(&self, store: &Store) -> String {


### PR DESCRIPTION
## Summary

When `obj.method(:foo)` is called and `obj` has no real `foo` but `obj.respond_to_missing?(:foo, true)` is truthy, CRuby returns a `Method` that is a `method_missing` proxy. monoruby previously raised `NoMethodError`. This implements the proxy to match CRuby 4.0.1, fixing the largest remaining `core/method` / `core/unboundmethod` error cluster (~20 cases).

## Design

- `MethodInner` / `UMethodInner` gain a `mm_name: Option<IdentId>` tag; `Some(sym)` marks a `method_missing` proxy for target `sym`.
- `Kernel#method`: on lookup failure, consult `respond_to_missing?(name, true)`; if truthy build a proxy, else re-raise the original error.
- `Method#call`/`[]`/`===` dispatch `receiver.method_missing(name, *args, &blk)` **dynamically by name** (`invoke_method_inner`), so later `method_missing` redefinition is honored and the real method is never called even if it later exists.
- Proxy-aware: `arity` (→ -1), `parameters` (→ `[[:rest]]`), `name`, `receiver`, `owner`, `source_location` (→ nil), `==`/`eql?`, `unbind`, and the `UnboundMethod` equivalents; plus the `METHOD_CLASS` fast-path in `codegen/runtime.rs::get_index` for `m[x]`.
- `Kernel#respond_to?` already consulted `respond_to_missing?`; unchanged.

Files: `value/rvalue/method.rs`, `value/rvalue.rs`, `value.rs`, `builtins/kernel.rs`, `builtins/method.rs`, `codegen/runtime.rs`.

## Results

- `core/method`: errors **47 → 25**; all `respond_to_missing?` `call`/`===`/`[]` sub-cases (18) now pass.
- `core/unboundmethod`: errors **10 → 9**; `UnboundMethod#arity ... respond_to_missing?` now passes.
- Remaining `respond_to_missing?`-tagged failures/errors in both suites: **0**. The unrelated raised failure counts (inspect/to_s, `super_method`) are pre-existing, out-of-scope examples that now *run* instead of erroring early.
- Verified by direct diff vs system CRuby: `call`/`[]`/`===`, blocks, `arity`/`parameters`/`name`/`receiver`/`owner`/`source_location`/`==`/`respond_to?` all match. (`method(:undefined)` raising `NoMethodError` vs CRuby `NameError` is a pre-existing monoruby-wide behavior, out of scope; `NoMethodError < NameError` so `rescue NameError` is unaffected.)

## Test plan

- [x] `cargo build` clean; cherry-pick conflict (vs merged #508 tests) resolved keeping both test sets
- [x] 5 new `respond_to_missing_*` regression tests pass; #508 keyword tests still pass
- [x] No regressions in `builtins::method` / `builtins::kernel` / `value` cargo tests
- [x] ruby/spec `core/method` & `core/unboundmethod` re-run

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_