### PR TITLE
method/proc: CRuby-compatible anonymous param names in #parameters

### DIFF
--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -1166,6 +1166,41 @@ mod tests {
     }
 
     #[test]
+    fn method_parameters_anonymous_and_nokey() {
+        // Anonymous *, **, & report :*, :**, :&; `**nil` -> [[:nokey]];
+        // `...` -> [[:rest,:*],[:keyrest,:**],[:block,:&]]. Native
+        // rest stays [[:rest]] (no synthetic name).
+        run_test_with_prelude(
+            r##"
+            o = Object.new
+            def o.ab(&); end
+            [
+              C.new.method(:un_splat).parameters,
+              C.new.method(:un_kwrest).parameters,
+              C.new.method(:nokey).parameters,
+              C.new.method(:fwd).parameters,
+              C.instance_method(:fwd).parameters,
+              C.new.method(:under).parameters,
+              C.new.method(:named).parameters,
+              o.method(:ab).parameters,
+              "foo".method(:delete!).parameters,
+              "foo".method(:+).parameters,
+            ]
+            "##,
+            r##"
+            class C
+              def un_splat(*); end
+              def un_kwrest(**); end
+              def nokey(**nil); end
+              def fwd(...); end
+              def under(_, _, _ = 1, *_, _:, _: 2, **_, &_); end
+              def named(a, *rest, k:, **kw, &blk); end
+            end
+            "##,
+        );
+    }
+
+    #[test]
     fn umethod_arity_keyword_args() {
         run_test_with_prelude(
             r##"

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -182,7 +182,11 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
     let key_tag = Value::symbol(IdentId::get_id("key"));
     let keyreq_tag = Value::symbol(IdentId::get_id("keyreq"));
     let keyrest_tag = Value::symbol(IdentId::get_id("keyrest"));
+    let nokey_tag = Value::symbol(IdentId::get_id("nokey"));
     let block_tag = Value::symbol(IdentId::get_id("block"));
+    let star_sym = Value::symbol(IdentId::get_id("*"));
+    let dstar_sym = Value::symbol(IdentId::get_id("**"));
+    let amp_sym = Value::symbol(IdentId::get_id("&"));
     let mut result = vec![];
     let args_names = &params.args_names;
     let mut name_idx = 0;
@@ -212,10 +216,14 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
     // the runtime arg dispatcher to absorb extras under block style.
     if params.is_rest().is_some() {
         if !params.rest_is_implicit() {
-            let entry = if let Some(Some(name)) = args_names.get(name_idx) {
-                Value::array2(rest_tag, Value::symbol(*name))
-            } else {
-                Value::array1(rest_tag)
+            let entry = match args_names.get(name_idx) {
+                Some(Some(name)) => Value::array2(rest_tag, Value::symbol(*name)),
+                // A slot exists but is unnamed: Ruby-level anonymous
+                // `*` (incl. the rest synthesized by `...`). CRuby
+                // reports its name as `:*`.
+                Some(None) => Value::array2(rest_tag, star_sym),
+                // No slot at all: a native/builtin rest -> `[:rest]`.
+                None => Value::array1(rest_tag),
             };
             result.push(entry);
         }
@@ -241,17 +249,36 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
         result.push(Value::array2(tag, Value::symbol(*kw_name)));
     }
     // keyword rest
-    if params.kw_rest.is_some() {
-        let entry = if let Some(name) = params.kw_rest_name() {
-            Value::array2(keyrest_tag, Value::symbol(name))
+    if let Some(slot) = params.kw_rest {
+        if params.kw_rest_name() == Some(IdentId::get_id("nil")) {
+            // `**nil` is modeled by the parser as a kwrest literally
+            // named `nil` (impossible as a real identifier). CRuby
+            // reports it as the lone parameter `[[:nokey]]`.
+            result.push(Value::array1(nokey_tag));
         } else {
-            Value::array1(keyrest_tag)
-        };
-        result.push(entry);
+            let entry = match params.kw_rest_name() {
+                Some(name) => Value::array2(keyrest_tag, Value::symbol(name)),
+                // Distinguish a Ruby-level anonymous `**` (a slot
+                // exists, unnamed -> CRuby `:**`) from a native
+                // kwrest (no slot -> `[:keyrest]`).
+                None => match args_names.get(slot.0 as usize - 1) {
+                    Some(_) => Value::array2(keyrest_tag, dstar_sym),
+                    None => Value::array1(keyrest_tag),
+                },
+            };
+            result.push(entry);
+        }
     }
     // block param
     if let Some(block_name) = params.block_param {
-        result.push(Value::array2(block_tag, Value::symbol(block_name)));
+        // An empty name is the parser's marker for an anonymous `&`
+        // (and the block synthesized by `...`); CRuby reports `:&`.
+        let entry = if block_name == IdentId::get_id("") {
+            Value::array2(block_tag, amp_sym)
+        } else {
+            Value::array2(block_tag, Value::symbol(block_name))
+        };
+        result.push(entry);
     }
     Value::array_from_vec(result)
 }


### PR DESCRIPTION
## Summary

`Method#parameters` / `UnboundMethod#parameters` / `Proc#parameters` reported anonymous `*` / `**` / `&` as bare `[:rest]` / `[:keyrest]` / `[:block, :""]`, and `**nil` as `[:keyrest, :nil]`. Aligned with CRuby 4.0.1:

| input | before | after (CRuby) |
|---|---|---|
| `def m(*)` | `[[:rest]]` | `[[:rest, :*]]` |
| `def m(**)` | `[[:keyrest]]` | `[[:keyrest, :**]]` |
| `def m(&)` | `[[:block, :""]]` | `[[:block, :&]]` |
| `def m(**nil)` | `[[:keyrest, :nil]]` | `[[:nokey]]` |
| `def m(...)` | `[[:rest],[:keyrest],[:block,:""]]` | `[[:rest,:*],[:keyrest,:**],[:block,:&]]` |

A Ruby-level anonymous slot (an unnamed `args_names` entry) is distinguished from a native/builtin rest/kwrest (no slot), so core methods still report `[[:rest]]` and `attr_writer` `[[:req]]`. `Proc#parameters` shares the same builder and is verified byte-identical to CRuby for all anonymous forms.

Files: `builtins/proc.rs`, `builtins/method.rs` (regression test).

## Results

- core/method + core/unboundmethod **`parameters_spec`: 5 → 0 failures**.
- core/method: 16 → 11 failures (errors unchanged at 25); core/unboundmethod unchanged (6/9).
- Verified by direct diff vs system CRuby 4.0.1 for `Method`, `UnboundMethod`, and `Proc` parameters across anonymous `*`/`**`/`&`, `**nil`, `...`, `_`-named, named, and native (`String#delete!`, `String#+`) cases.

Out of scope (documented, not spec-tested, risk to kwarg binding): CRuby's required-before-optional keyword display reordering — consistent with the #508 note.

## Test plan

- [x] `cargo build` clean
- [x] New `method_parameters_anonymous_and_nokey` regression test passes vs CRuby; existing `method_parameters*` tests still pass
- [x] Full `cargo test`: 2054 pass; only the 2 pre-existing unrelated `string_inspect`/`symbol_inspect_unquoted` locale failures remain (fail on clean tree too)
- [x] `Proc#parameters` diffed vs CRuby — identical for anonymous forms (no shared-builder regression)
- [x] ruby/spec core/method, core/unboundmethod re-run; no regressions/new errors

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_