### PR TITLE
core/kernel: comma-separated ivars and instance_variables_to_inspect

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2929,8 +2929,62 @@ fn object_respond_to(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/inspect.html]
 #[monoruby_builtin]
-fn inspect(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let s = lfp.self_val().inspect(&globals.store);
+fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    // Only plain objects participate in the ivar / hook formatting;
+    // every other kind (immediates, internally `/name`-tagged objects,
+    // and types with their own `inspect`) keeps the default rendering.
+    if self_val.ty() != Some(ObjTy::OBJECT)
+        || globals
+            .store
+            .get_ivar(self_val, IdentId::_NAME)
+            .is_some()
+    {
+        let s = self_val.inspect(&globals.store);
+        return Ok(Value::string(s));
+    }
+
+    // CRuby consults the (private) `instance_variables_to_inspect`
+    // hook: an Array selects/orders the ivars to show, `nil` shows
+    // all, anything else is a TypeError.
+    let hook = IdentId::get_id("instance_variables_to_inspect");
+    let selection = vm.invoke_method_if_exists(globals, hook, self_val, &[], None, None)?;
+
+    let all_ivars = globals.store.get_ivars(self_val);
+    let chosen: Vec<(IdentId, Value)> = match selection {
+        None => all_ivars,
+        Some(v) if v.is_nil() => all_ivars,
+        Some(v) => match v.try_array_ty() {
+            Some(arr) => arr
+                .iter()
+                .filter_map(|e| e.try_symbol())
+                .filter_map(|nm| {
+                    all_ivars
+                        .iter()
+                        .find(|(n, _)| *n == nm)
+                        .map(|(n, val)| (*n, *val))
+                })
+                .collect(),
+            None => {
+                let cls = globals
+                    .store
+                    .get_class_name(v.real_class(&globals.store).id());
+                return Err(MonorubyErr::typeerr(format!(
+                    "Expected #instance_variables_to_inspect to return an Array or nil, but it returned {cls}"
+                )));
+            }
+        },
+    };
+
+    let class_name = globals
+        .store
+        .get_class_name(self_val.real_class(&globals.store).id());
+    let mut s = format!("#<{}:0x{:016x}", class_name, self_val.id());
+    for (i, (name, val)) in chosen.iter().enumerate() {
+        s += if i == 0 { " " } else { ", " };
+        s += &format!("{name}={}", val.inspect(&globals.store));
+    }
+    s += ">";
     Ok(Value::string(s))
 }
 
@@ -5213,5 +5267,43 @@ mod tests {
     fn kernel_uncaught_throw() {
         // Throwing a tag with no matching catch raises an error.
         run_test_error("throw :nope");
+    }
+
+    #[test]
+    fn kernel_inspect_ivars_and_hook() {
+        // Comma-separated ivars; the `instance_variables_to_inspect`
+        // hook selects (Array) / shows-all (nil); addresses normalized.
+        run_test(
+            r#"
+            o = Object.new
+            o.instance_eval { @host="h"; @user="u"; @password="p" }
+            a = o.inspect.sub(/0x[0-9a-f]+/, '0xX')
+            o2 = Object.new
+            o2.instance_eval { @host="h"; @user="u"; @password="p" }
+            o2.singleton_class.class_eval { private def instance_variables_to_inspect = %i[@host @user @nope] }
+            b = o2.inspect.sub(/0x[0-9a-f]+/, '0xX')
+            o3 = Object.new
+            o3.instance_eval { @a=1 }
+            o3.singleton_class.class_eval { private def instance_variables_to_inspect = [] }
+            c = o3.inspect.sub(/0x[0-9a-f]+/, '0xX')
+            o4 = Object.new
+            o4.instance_eval { @x=1; @y=2 }
+            o4.singleton_class.class_eval { private def instance_variables_to_inspect = nil }
+            d = o4.inspect.sub(/0x[0-9a-f]+/, '0xX')
+            [a, b, c, d]
+            "#,
+        );
+    }
+
+    #[test]
+    fn kernel_inspect_hook_type_error() {
+        run_test_error(
+            r#"
+            o = Object.new
+            o.instance_eval { @a=1 }
+            o.singleton_class.class_eval { private def instance_variables_to_inspect = {} }
+            o.inspect
+            "#,
+        );
     }
 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -5273,6 +5273,8 @@ mod tests {
     fn kernel_inspect_ivars_and_hook() {
         // Comma-separated ivars; the `instance_variables_to_inspect`
         // hook selects (Array) / shows-all (nil); addresses normalized.
+        // Classic `def...end` only (the ruruby parser used by `bin/test`
+        // has no endless-method support).
         run_test(
             r#"
             o = Object.new
@@ -5280,15 +5282,24 @@ mod tests {
             a = o.inspect.sub(/0x[0-9a-f]+/, '0xX')
             o2 = Object.new
             o2.instance_eval { @host="h"; @user="u"; @password="p" }
-            o2.singleton_class.class_eval { private def instance_variables_to_inspect = %i[@host @user @nope] }
+            o2.singleton_class.class_eval do
+              def instance_variables_to_inspect; [:@host, :@user, :@nope]; end
+              private :instance_variables_to_inspect
+            end
             b = o2.inspect.sub(/0x[0-9a-f]+/, '0xX')
             o3 = Object.new
             o3.instance_eval { @a=1 }
-            o3.singleton_class.class_eval { private def instance_variables_to_inspect = [] }
+            o3.singleton_class.class_eval do
+              def instance_variables_to_inspect; []; end
+              private :instance_variables_to_inspect
+            end
             c = o3.inspect.sub(/0x[0-9a-f]+/, '0xX')
             o4 = Object.new
             o4.instance_eval { @x=1; @y=2 }
-            o4.singleton_class.class_eval { private def instance_variables_to_inspect = nil }
+            o4.singleton_class.class_eval do
+              def instance_variables_to_inspect; nil; end
+              private :instance_variables_to_inspect
+            end
             d = o4.inspect.sub(/0x[0-9a-f]+/, '0xX')
             [a, b, c, d]
             "#,
@@ -5301,7 +5312,10 @@ mod tests {
             r#"
             o = Object.new
             o.instance_eval { @a=1 }
-            o.singleton_class.class_eval { private def instance_variables_to_inspect = {} }
+            o.singleton_class.class_eval do
+              def instance_variables_to_inspect; {}; end
+              private :instance_variables_to_inspect
+            end
             o.inspect
             "#,
         );

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -643,8 +643,9 @@ impl RValue {
             name.to_s(store)
         } else {
             let mut s = String::new();
-            for (id, v) in self.get_ivars(store).into_iter() {
-                s += &format!(" {id}={}", v.inspect_inner(store, set));
+            for (i, (id, v)) in self.get_ivars(store).into_iter().enumerate() {
+                s += if i == 0 { " " } else { ", " };
+                s += &format!("{id}={}", v.inspect_inner(store, set));
             }
             format!(
                 "#<{}:0x{:016x}{s}>",


### PR DESCRIPTION
## Summary

`Kernel#inspect` joined instance variables with a bare space (`#<C:0x.. @a=1 @b=2>`) and ignored CRuby 4.0's private `instance_variables_to_inspect` hook.

- Object inspect now uses CRuby's `, ` separator. Fixed in the shared `RValue::object_inspect`, so nested / `p` output matches too.
- `Kernel#inspect` consults `instance_variables_to_inspect` when defined: an **Array** selects and orders the shown ivars (missing names skipped), **nil** shows all, any other return raises `TypeError: Expected #instance_variables_to_inspect to return an Array or nil, but it returned <Class>`.

Files: `builtins/kernel.rs`, `value/rvalue.rs`.

## Results

- core/kernel **`inspect_spec` + `to_s_spec`: 3 → 0 failures**.
- Verified byte-identical to system CRuby 4.0.1 across: default ivars, hook returning Array (with a non-existent name), `[]`, `nil`, non-Array (TypeError), and nested/`p` output.
- core/basicobject: 0 failures. Full `cargo test`: 2070 pass; only the 2 pre-existing unrelated `string_inspect`/`symbol_inspect_unquoted` locale failures remain (fail on clean tree too).
- The remaining `core/kernel/p`/`print` spec gaps are pre-existing and unrelated (`IO#reopen` unimplemented, `$_` handling) — not touched by this change.

## Test plan

- [x] `cargo build` clean
- [x] 2 new regression tests (`kernel_inspect_ivars_and_hook`, `kernel_inspect_hook_type_error`) pass vs CRuby
- [x] Full `cargo test`: no new failures vs clean tree
- [x] ruby/spec core/kernel inspect_spec/to_s_spec → 0 failures; p/pp/print/puts and basicobject spot-checked, no regressions from this change
- [x] Direct diff vs CRuby for hook Array/nil/TypeError and nested object inspect

https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVMRCXaa3sSdLYMn9MeqSM)_