### PR TITLE
core/string: printf # flag for e/g/a, sign-magnitude negative b/o/x

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -6885,6 +6885,27 @@ mod tests {
     }
 
     #[test]
+    fn string_format_hash_and_neg_radix() {
+        // `#` flag forces a decimal point for e/E/g/G/a/A and keeps
+        // g/G trailing zeros; `%#f` keeps CRuby's Integer quirk.
+        run_test2(r###""%#.0e" % 100"###);
+        run_test2(r###""%#.0g" % 100"###);
+        run_test2(r###""%#g" % 123.4"###);
+        run_test2(r###""%#.0f" % 1"###);
+        run_test2(r###""%#.0f" % 1.0"###);
+        run_test2(r###""%#.0f" % 5"###);
+        run_test2(r###""%#a" % 16.0"###);
+        // `+`/space on negative b/o/x → sign-magnitude, not two's-complement.
+        run_test2(r###""%+b" % -10"###);
+        run_test2(r###""% o" % -10"###);
+        run_test2(r###""%+x" % -255"###);
+        run_test2(r###""%b" % -10"###);
+        run_test2(r###""%o" % -10"###);
+        run_test2(r###""%x" % -10"###);
+        run_test2(r###""%+8b" % -10"###);
+    }
+
+    #[test]
     fn string_format_g() {
         // %g and %G: shortest representation
         run_test2(r###""%g" % 100.0"###);

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -242,7 +242,21 @@ fn hex_digit_val(b: u8) -> u8 {
 /// Format a float using %g/%G rules:
 /// Use scientific notation if exponent < -4 or >= precision, otherwise fixed.
 /// Strip trailing zeros after decimal point (and the point itself if no digits remain).
-fn format_g(f: f64, precision: usize, uppercase: bool) -> String {
+/// For the `#` flag: ensure the mantissa contains a decimal point
+/// (CRuby keeps the point even when no fractional digits follow).
+/// Inserts `.` just before the exponent marker (`e`/`E`/`p`/`P`) or
+/// at the end if there is none. No-op if a `.` is already present.
+fn force_decimal_point(s: &str) -> String {
+    if s.contains('.') {
+        return s.to_string();
+    }
+    match s.find(['e', 'E', 'p', 'P']) {
+        Some(pos) => format!("{}.{}", &s[..pos], &s[pos..]),
+        None => format!("{}.", s),
+    }
+}
+
+fn format_g(f: f64, precision: usize, uppercase: bool, strip: bool) -> String {
     if f == 0.0 {
         return "0".to_string();
     }
@@ -266,7 +280,11 @@ fn format_g(f: f64, precision: usize, uppercase: bool) -> String {
             format!("{:.p$e}", f, p = sci_prec)
         };
         // Strip trailing zeros in the mantissa part (before 'e'/'E')
-        strip_trailing_zeros_scientific(&s)
+        if strip {
+            strip_trailing_zeros_scientific(&s)
+        } else {
+            s
+        }
     } else {
         // Use fixed notation
         // precision means total significant digits
@@ -276,7 +294,11 @@ fn format_g(f: f64, precision: usize, uppercase: bool) -> String {
             0
         };
         let s = format!("{:.p$}", f, p = fixed_prec);
-        strip_trailing_zeros_fixed(&s)
+        if strip {
+            strip_trailing_zeros_fixed(&s)
+        } else {
+            s
+        }
     }
 }
 
@@ -985,14 +1007,32 @@ impl Executor {
                     let ival = val.coerce_to_integer(self, globals)?;
                     match ival {
                         IntegerBase::Fixnum(v) if v < 0 => {
-                            let tc = format_neg_twos_complement(v, 2, ch == 'B');
-                            let prefix = if hash_flag {
-                                if ch == 'B' { "0B" } else { "0b" }
+                            if plus_flag || space_flag {
+                                // `+`/space disables two's-complement and
+                                // uses sign-magnitude (`-1010`).
+                                let digits = apply_int_precision(
+                                    &format!("{:b}", v.unsigned_abs()),
+                                    precision,
+                                );
+                                let prefix = if hash_flag {
+                                    if ch == 'B' { "0B" } else { "0b" }
+                                } else {
+                                    ""
+                                };
+                                format_int_with_prefix(
+                                    true, &digits, prefix, width, zero_flag, minus_flag,
+                                    plus_flag, space_flag,
+                                )
                             } else {
-                                ""
-                            };
-                            let body = format!("{}{}", prefix, tc);
-                            apply_width(&body, width, minus_flag, ' ')
+                                let tc = format_neg_twos_complement(v, 2, ch == 'B');
+                                let prefix = if hash_flag {
+                                    if ch == 'B' { "0B" } else { "0b" }
+                                } else {
+                                    ""
+                                };
+                                let body = format!("{}{}", prefix, tc);
+                                apply_width(&body, width, minus_flag, ' ')
+                            }
                         }
                         _ => {
                             let digits = match ival {
@@ -1017,8 +1057,20 @@ impl Executor {
                     let ival = val.coerce_to_integer(self, globals)?;
                     match ival {
                         IntegerBase::Fixnum(v) if v < 0 => {
-                            let tc = format_neg_twos_complement(v, 8, false);
-                            apply_width(&tc, width, minus_flag, ' ')
+                            if plus_flag || space_flag {
+                                let digits = apply_int_precision(
+                                    &format!("{:o}", v.unsigned_abs()),
+                                    precision,
+                                );
+                                let prefix = if hash_flag { "0" } else { "" };
+                                format_int_with_prefix(
+                                    true, &digits, prefix, width, zero_flag, minus_flag,
+                                    plus_flag, space_flag,
+                                )
+                            } else {
+                                let tc = format_neg_twos_complement(v, 8, false);
+                                apply_width(&tc, width, minus_flag, ' ')
+                            }
                         }
                         _ => {
                             let digits = match ival {
@@ -1042,14 +1094,34 @@ impl Executor {
                     let ival = val.coerce_to_integer(self, globals)?;
                     match ival {
                         IntegerBase::Fixnum(v) if v < 0 => {
-                            let tc = format_neg_twos_complement(v, 16, ch == 'X');
-                            let prefix = if hash_flag {
-                                if ch == 'X' { "0X" } else { "0x" }
+                            if plus_flag || space_flag {
+                                let digits = apply_int_precision(
+                                    &if ch == 'X' {
+                                        format!("{:X}", v.unsigned_abs())
+                                    } else {
+                                        format!("{:x}", v.unsigned_abs())
+                                    },
+                                    precision,
+                                );
+                                let prefix = if hash_flag {
+                                    if ch == 'X' { "0X" } else { "0x" }
+                                } else {
+                                    ""
+                                };
+                                format_int_with_prefix(
+                                    true, &digits, prefix, width, zero_flag, minus_flag,
+                                    plus_flag, space_flag,
+                                )
                             } else {
-                                ""
-                            };
-                            let body = format!("{}{}", prefix, tc);
-                            apply_width(&body, width, minus_flag, ' ')
+                                let tc = format_neg_twos_complement(v, 16, ch == 'X');
+                                let prefix = if hash_flag {
+                                    if ch == 'X' { "0X" } else { "0x" }
+                                } else {
+                                    ""
+                                };
+                                let body = format!("{}{}", prefix, tc);
+                                apply_width(&body, width, minus_flag, ' ')
+                            }
                         }
                         _ => {
                             let digits = match ival {
@@ -1092,6 +1164,13 @@ impl Executor {
                     } else {
                         format!("{:.p$}", f.abs(), p = prec)
                     };
+                    // CRuby quirk: `%#f` does NOT force a point for an
+                    // Integer argument (unlike `%#e`/`%#g`/`%#a`).
+                    let s = if hash_flag && f.is_finite() && !val.is_integer() {
+                        force_decimal_point(&s)
+                    } else {
+                        s
+                    };
                     format_float_with_flags(
                         &s, f, width, zero_flag, minus_flag, plus_flag, space_flag,
                     )
@@ -1108,6 +1187,11 @@ impl Executor {
                     } else {
                         normalize_sci_exponent(&format!("{:.p$e}", f.abs(), p = prec))
                     };
+                    let s = if hash_flag && f.is_finite() {
+                        force_decimal_point(&s)
+                    } else {
+                        s
+                    };
                     format_float_with_flags(
                         &s, f, width, zero_flag, minus_flag, plus_flag, space_flag,
                     )
@@ -1116,8 +1200,15 @@ impl Executor {
                     let f = val.coerce_to_float(self, globals)?;
                     let prec = precision.unwrap_or(6);
                     let prec = if prec == 0 { 1 } else { prec };
-                    let s = format_g(f.abs(), prec, ch == 'G');
+                    // The `#` flag keeps trailing zeros and forces a
+                    // decimal point.
+                    let s = format_g(f.abs(), prec, ch == 'G', !hash_flag);
                     let s = normalize_sci_exponent(&s);
+                    let s = if hash_flag && f.is_finite() {
+                        force_decimal_point(&s)
+                    } else {
+                        s
+                    };
                     format_float_with_flags(
                         &s, f, width, zero_flag, minus_flag, plus_flag, space_flag,
                     )
@@ -1125,6 +1216,11 @@ impl Executor {
                 'a' | 'A' => {
                     let f = val.coerce_to_float(self, globals)?;
                     let s = format_hex_float(f.abs(), precision, ch == 'A');
+                    let s = if hash_flag && f.is_finite() {
+                        force_decimal_point(&s)
+                    } else {
+                        s
+                    };
                     format_float_with_flags(
                         &s, f, width, zero_flag, minus_flag, plus_flag, space_flag,
                     )


### PR DESCRIPTION
## Summary

A low-risk, pure-Rust `core/string` / printf formatting batch (isolated to `executor/format.rs`, no new dependencies, deterministic, CRuby-verified, zero regressions).

- **`#` (alternate form) flag for floats** — now forces a decimal point for `e/E/g/G/a/A` even when no fractional digits follow, and keeps trailing zeros for `g/G`. `%#f` deliberately preserves CRuby's quirk of *not* forcing the point for an **Integer** argument (`"%#.0f" % 1 => "1"`, but `"%#.0f" % 1.0 => "1."`, `"%#.0e" % 100 => "1.e+02"`).
- **Negative `%b` / `%o` / `%x` with `+` or space flag** — now render sign-magnitude (`"%+b" % -10 => "-1010"`) instead of two's-complement (`"%b" % -10 => "..10110"` is unchanged and still correct), matching CRuby.

Result (unique-failure counts, before → after, **zero regressions**):

| Spec | Before | After |
|---|---|---|
| core/string `modulo_spec` | 34 | 26 |
| core/kernel `sprintf_spec` | 23 | 17 |
| core/kernel `printf_spec` | 17 | 11 |

Out of scope (separate unfixed case, noted in the commit): the `0`-flag two's-complement radix-1 padding (`"%08b" % -10`).

## Test plan

- [x] Every changed format verified directly against CRuby 4.0.2
- [x] Spec-format before/after diffs across modulo/sprintf/printf show **zero new failures**
- [x] New `string_format_hash_and_neg_radix` regression test passes under **both** the Prism and `MONORUBY_PARSER=ruruby` backends
- [x] `cargo test -p monoruby --lib` format/string suites green

## Note

The biggest remaining `core/string` lever is a separate VM-level bug (Proc/Lambda calls drop trailing keyword args instead of folding them into a `*rest` Hash; methods are unaffected). A design memo will be shared separately for discussion — it is intentionally **not** in this PR (VM-core, high regression risk).

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_