### PR TITLE
core: forward trailing kwargs from Proc#call to the block (VM fix)

### DIFF
--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -67,6 +67,20 @@ fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> R
 #[monoruby_builtin]
 fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let proc = Proc::new(lfp.self_val());
+    // `Proc#call` is declared with keyword-rest, so trailing keyword
+    // arguments land in the kw-rest slot (`arg(1)`, after the
+    // positional rest at `arg(0)`). Forward them to the block invoker
+    // so the *block's own* signature decides whether they bind to
+    // keyword parameters or fold into a trailing positional Hash
+    // (matches CRuby; previously these were dropped).
+    let kw = match lfp.try_arg(1) {
+        Some(v)
+            if v.ty() == Some(ObjTy::HASH) && !Hashmap::new(v).inner().is_empty() =>
+        {
+            Some(Hashmap::new(v))
+        }
+        _ => None,
+    };
     // Fast path for Symbol#to_proc procs: dispatch directly so that the
     // block passed to Proc#call is forwarded to the invoked method. The
     // regular invoke_proc/block_invoker path currently drops block handlers.
@@ -97,10 +111,10 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             }
         }
         let bh = lfp.block();
-        return vm.invoke_method_inner(globals, symbol_id, recv, &rest, bh, None);
+        return vm.invoke_method_inner(globals, symbol_id, recv, &rest, bh, kw);
     }
     let bh = lfp.block();
-    vm.invoke_proc_with_block(globals, &proc, &lfp.arg(0).as_array(), bh)
+    vm.invoke_proc_with_block(globals, &proc, &lfp.arg(0).as_array(), bh, kw)
 }
 
 ///
@@ -779,5 +793,34 @@ mod tests {
               forward(&:to_s)
             "#,
         );
+    }
+
+    #[test]
+    fn proc_call_forwards_trailing_kwargs() {
+        // Trailing keyword args passed to Proc#call/[]/=== are
+        // forwarded to the block; the block's own signature decides
+        // whether they bind to kw params or fold into a *rest Hash.
+        run_test(r#"->(fmt, *args){ args }.call("x", foo: 123)"#);
+        run_test(r#"->(*a){ a }.call(1, x: 2)"#);
+        run_test(r#"proc {|*a| a }.call(1, y: 3)"#);
+        run_test(r#"lambda {|*a| a }.call(2, z: 4)"#);
+        run_test(r#"->(a, k:){ [a, k] }.call(1, k: 2)"#);
+        run_test(r#"->(a, **kw){ [a, kw] }.call(1, x: 9)"#);
+        run_test(r#"->(*a){ a }.(7, q: 8)"#);
+        run_test(r#"(->(x){ x } === 4)"#);
+        run_test(r#"->(*a){ a }.call(**{})"#);
+        run_test(r#"->(a=0, *r){ [a, r] }.call(k: 1)"#);
+        run_test(r#"def fwd(&b); b.call(1, m: 2); end; fwd { |*a| a }"#);
+    }
+
+    #[test]
+    fn sprintf_named_unnamed_mix_is_error() {
+        run_test_error(r#""%d %<foo>d" % [1, {foo: 2}]"#);
+        run_test_error(r#""%d %{foo}" % [1, {foo: 2}]"#);
+        run_test_error(r#""%{a} %d" % {a: 1}"#);
+        run_test(r#""%<a>s %<b>s" % {a: 1, b: 2}"#);
+        run_test(r#""%{a} %{b}" % {a: 1, b: 2}"#);
+        run_test(r#""%s %s" % [1, 2]"#);
+        run_test(r#""%<a>d" % {a: 5}"#);
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1705,7 +1705,7 @@ impl Executor {
         proc: &ProcInner,
         args: &[Value],
     ) -> Result<Value> {
-        self.invoke_proc_with_block(globals, proc, args, None)
+        self.invoke_proc_with_block(globals, proc, args, None, None)
     }
 
     pub(crate) fn invoke_proc_with_block(
@@ -1714,6 +1714,7 @@ impl Executor {
         proc: &ProcInner,
         args: &[Value],
         bh: Option<BlockHandler>,
+        kw: Option<Hashmap>,
     ) -> Result<Value> {
         let proc = ProcData::from_proc(proc);
         // A proxy BlockHandler encodes its lexical scope as "walk N
@@ -1737,7 +1738,7 @@ impl Executor {
             block_val,
             args.as_ptr(),
             args.len(),
-            None,
+            kw,
         )
         .ok_or_else(|| {
             let err = self.take_error();

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -533,6 +533,9 @@ impl Executor {
         // string.
         let mut used_numbered = false;
         let mut used_unnumbered = false;
+        // A named reference (`%<n>` / `%{n}`) may not be mixed with
+        // numbered or unnumbered references in one format string.
+        let mut used_named = false;
         fn mark_numbered(
             n: usize,
             used_numbered: &mut bool,
@@ -907,6 +910,12 @@ impl Executor {
                 if named_val.is_some() {
                     return Err(MonorubyErr::argumenterr("named<name> after named{name}"));
                 }
+                if used_numbered || used_unnumbered {
+                    return Err(MonorubyErr::argumenterr(
+                        "named reference is mixed with numbered/unnumbered",
+                    ));
+                }
+                used_named = true;
                 let hash = get_named_hash(arguments, &mut named_hash_cache)
                     .ok_or_else(|| MonorubyErr::argumenterr("one hash required"))?;
                 let key_val = Value::symbol_from_str(&key);
@@ -921,6 +930,20 @@ impl Executor {
                 format_str += &apply_width(&s, width, minus_flag, ' ');
                 i = j + 1;
                 continue;
+            }
+            // Enforce CRuby's rule that named references cannot be
+            // mixed with numbered/unnumbered ones.
+            if named_val.is_some() {
+                if used_numbered || used_unnumbered {
+                    return Err(MonorubyErr::argumenterr(
+                        "named reference is mixed with numbered/unnumbered",
+                    ));
+                }
+                used_named = true;
+            } else if used_named {
+                return Err(MonorubyErr::argumenterr(
+                    "numbered/unnumbered reference is mixed with named",
+                ));
             }
             // Determine val: positional, named, or sequential
             let val = if let Some(v) = positional_arg {


### PR DESCRIPTION
## Summary

Implements **Option A** from the design memo: the VM-level fix for trailing keyword arguments being dropped on Proc/Lambda calls.

### Root cause
`Proc#call` (and its `[]` / `===` / `yield` aliases) is declared with keyword-rest, so trailing keyword arguments passed at the call site landed in *Proc#call's own* kw-rest slot and were silently discarded instead of reaching the block. (Methods were unaffected — they fold trailing kwargs into a `*rest` Hash correctly.)

### Fix
`Proc#call` now extracts the captured keyword hash and forwards it to the block invoker through a new `kw: Option<Hashmap>` parameter on `invoke_proc_with_block`. The **block's own signature** then decides what happens (this logic already existed in `invoker_arguments_inner`):

- `->(*a){ a }.call(1, k: 2)` → `[1, {k: 2}]` (folds into `*rest`)
- `->(a, k:){ [a,k] }.call(1, k: 2)` → `[1, 2]` (binds the `k:` parameter)
- `->(a, **kw){ }.call(1, x: 9)` → binds `**kw`
- Same for `proc{}`, `lambda{}`, `.()`, `===` (case/when), `yield`, and `&:sym`-to-proc.

This kwarg fix would otherwise expose a pre-existing format-engine gap as a pass→fail (the masking `one hash required` error vanished), so the printf argument-style guard is also extended: a **named** reference (`%<n>`/`%{n}`) mixed with numbered/unnumbered now raises `ArgumentError`, matching CRuby.

### Results (unique-failure counts vs master, **zero regressions**)

| Spec | Before | After |
|---|---|---|
| core/string `modulo_spec` | 26 | 19 |
| core/kernel `sprintf_spec` | 17 | 10 |
| core/kernel `printf_spec` | 11 | 5 |
| core/method | 14 | 13 |

No regressions in core/proc, core/method, core/lambda, core/enumerable, core/hash, language/{proc,block,keyword_arguments}.

Out of scope (separate **pre-existing** issues, not regressed): the `prc[1, 2, k: 3]` index-operator form (kwargs to `[]`-call bytecode), and the `0`-flag two's-complement radix-1 padding.

## Test plan

- [x] Verified against CRuby 4.0.2 across proc/lambda/method/`===`/`yield`/`&:sym` and explicit-kw / `**kw` / `**{}` cases
- [x] Spec-format before/after diffs (vs post-#516 master): zero new failures across the matrix above
- [x] New `proc_call_forwards_trailing_kwargs` and `sprintf_named_unnamed_mix_is_error` tests pass under **both** Prism and `MONORUBY_PARSER=ruruby`
- [x] `cargo test -p monoruby --lib` proc/method/format/enumerator/hash/kernel/array suites green (both backends)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_