### PR TITLE
parser: keep keyword args on recv[k => v] index calls

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -3598,6 +3598,30 @@ mod tests {
     }
 
     #[test]
+    fn hash_bracket_kwarg_form() {
+        // `Recv[k => v]` / `Recv[**h]` — the trailing keywords form an
+        // implicit positional Hash; previously dropped. This `[]`-call
+        // lowering is Prism-only (ruruby-parse lowers it differently).
+        if parser_is_ruruby() {
+            return;
+        }
+        run_test(r#"Hash[5 => 6]"#);
+        run_test(r#"Hash["a" => 1, "b" => 2]"#);
+        run_test(r#"h = {9 => 9}; Hash[**h]"#);
+        run_test(
+            r#"
+            klass = Class.new(Hash) { def to_hash; {trap: 1}; end }
+            a = klass[5 => 6]
+            [a.class.ancestors.include?(Hash), {5 => 6} == a,
+             {3 => 4}.merge(klass[1 => 2])]
+            "#,
+        );
+        // Proc#[] with kwargs forwards to the block (like #call).
+        run_test(r#"->(*a){ a }[1, k: 2]"#);
+        run_test(r#"->(a, k:){ [a, k] }[1, k: 9]"#);
+    }
+
+    #[test]
     fn hash_bracket_array_form() {
         // 1-element arrays become `key => nil`.
         run_test("Hash[[[:a]]]");

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -3332,10 +3332,32 @@ impl<'pr> Lowerer<'pr> {
             && method == "[]"
         {
             let base = self.lower_node(recv)?;
+            // `recv[k => v]` / `recv[**h]`: the `NodeKind::Index`
+            // fast path is positional-only and would drop the
+            // keyword/`**` portion. Keep it as a real `[]` method
+            // call so the *callee* decides what to do with the
+            // keywords (e.g. `Hash.[]` folds them into a trailing
+            // Hash; `Proc#[]` forwards them to the block).
+            if kw_args.is_empty() && hash_splat.is_empty() {
+                return Ok(Node {
+                    kind: NodeKind::Index {
+                        base: Box::new(base),
+                        index: args,
+                    },
+                    loc,
+                });
+            }
+            let mut arglist = ruruby_parse::ArgList::default();
+            arglist.args = args;
+            arglist.kw_args = kw_args;
+            arglist.hash_splat = hash_splat;
+            arglist.splat = has_splat;
             return Ok(Node {
-                kind: NodeKind::Index {
-                    base: Box::new(base),
-                    index: args,
+                kind: NodeKind::MethodCall {
+                    receiver: Box::new(base),
+                    method: "[]".to_string(),
+                    arglist: Box::new(arglist),
+                    safe_nav: false,
                 },
                 loc,
             });


### PR DESCRIPTION
## Summary

Survey of `core/array` (27F/8E) and `core/hash` (34F/4E) showed both are already mature — no large root-cause cluster. The one notable cluster ("Hash does not call `to_hash` on hash subclasses", ~5) traced to a real cross-cutting bug, which this PR fixes:

**`recv[k => v]` / `recv[**h]` dropped the keyword portion.** The `[]`-call was collapsed to a positional-only `NodeKind::Index`, so:
- `Hash[5 => 6]` → `{}` (and `Hash.[](5 => 6)` likewise)
- `MyHash[k => v]` → empty subclass hash → cascaded into the Hash-subclass `==`/`merge` specs
- `prc[1, k: 2]` → kwargs lost (the item explicitly deferred from #517)

### Fix
When a `[]` call has keyword / `**` arguments, lower it to a real `[]` `MethodCall` (preserving `kw_args`/`hash_splat`) instead of the fast-path `Index` node. The **callee** then decides, exactly as for a normal call:
- `Hash.[]` (no keyword-rest) folds them into a trailing positional Hash → `Hash[5 => 6]` ⇒ `{5 => 6}`
- `Proc#[]` forwards them to the block (via the #517 mechanism) → `->(a, k:){ }[1, k: 9]` binds `k`

The common no-keyword `recv[i]` / `recv[i, j]` fast path is unchanged (zero overhead, zero risk there).

### Results (unique-failure counts vs master, **zero regressions**)

| Spec | Before | After |
|---|---|---|
| core/hash | 27 | 24 |
| core/array | 32 | 31 |
| core/method | 14 | 13 |
| core/string | 239 | 239 (unchanged — string indexing safe) |

No regressions in core/proc, language/{proc,block,keyword_arguments}, sprintf.

## Test plan

- [x] Verified vs CRuby 4.0.2: `Hash[k=>v]`, `Hash.[]`, string keys, `**h`, subclass + `to_hash`-trap, `Proc#[]` with `*a` and explicit `k:`, plus plain array/string/`a[i,j]` indexing (unchanged)
- [x] Spec-format before/after diffs across hash/array/proc/string/method/language: zero new failures
- [x] New `hash_bracket_kwarg_form` test passes (gated to Prism — ruruby-parse lowers `[]` differently); `cargo test -p monoruby --lib` hash/array/proc/string/method green under **both** backends

## Note

`core/array`/`core/hash` are otherwise mature; remaining failures there are scattered one-offs with no shared root cause. Recommend the next survey target be a less-mature, higher-failure category.

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_