### PR TITLE
jit: non-deopting polymorphic BinCmp + one-shot recompile (rubykon)

### DIFF
--- a/doc/HANDOFF.md
+++ b/doc/HANDOFF.md
@@ -1,0 +1,224 @@
+# HANDOFF — rubykon polymorphic-JIT work
+
+Branch: `jit-poly-bincmp` (commit `f11603ad`). Base: `master`.
+Date: 2026-05-16. Owner handing off → Claude Web continuation.
+
+> Rule: never push to `master`; this work stays on `jit-poly-bincmp`
+> and lands via PR. Verify branch before any commit (a merged PR may
+> auto-switch the checkout to `master`).
+
+---
+
+## 1. Problem
+
+ruby-bench `rubykon` runs ~1.5× slower than CRuby 4.0.1 `--yjit`.
+
+Measured (19×19 board, 100 iters, best of 10; clean release build):
+
+| Engine | best |
+|---|---|
+| CRuby 4.0.1 `--yjit` | ~367 ms |
+| monoruby | ~559 ms |
+| CRuby 4.0.1 interpreter | ~850 ms |
+
+Reproduction script: `/tmp/rubykon_run.rb` (requires
+`requires "rubykon"` from `/home/monochrome/yjit-bench/benchmarks/rubykon/lib`).
+Profiling build: `cargo build --release --features profile`
+(toolchain note in §6). `perf` does NOT work on this WSL2 kernel —
+use the `profile` feature's deopt-stats instead.
+
+## 2. Root cause (confirmed)
+
+`profile` deopt-stats: **>10M deoptimizations on a single `==`** in
+`MoveValidator#spot_unoccupied?`, millions more in `no_suicide_move?`,
+`gain_liberties_from_capture_of`, `candidate_eye_color`,
+`already_counted_as_liberty?`, etc. Recompile count is ~1–2, so these
+are pure per-call side-exits, not recompiles.
+
+Trigger: rubykon's board representation
+(`/home/monochrome/yjit-bench/benchmarks/rubykon/lib/rubykon/board.rb`):
+
+```ruby
+EMPTY = nil; BLACK = :black; WHITE = :white
+def spot_unoccupied?(id, board) = board[id] == Board::EMPTY   # i.e. == nil
+```
+
+`board[id]` is `nil` (empty point) or a `Symbol` (occupied). The `==`
+receiver class oscillates `NilClass`↔`Symbol`.
+
+monoruby's JIT compiles non-numeric `==` via
+`binary_cmp` → `BinaryOpType::Other` → `call_binary_method` →
+`compile_method_call`, which emits a **monomorphic receiver-class
+guard that plain-deopts on mismatch**. Because the board starts empty,
+the first ~20 calls see only `nil == nil`; the method is JIT-compiled
+monomorphic for `NilClass` at the call threshold, then deopts forever
+once `Symbol` appears. It is never recompiled.
+
+YJIT's `opt_eq` inlines immediate/special-const equality with a
+generic `send` fallback that stays in JIT code — it never side-exits
+on class variance, so it avoids this entirely.
+
+## 3. What is done (committed in `f11603ad`)
+
+POLY-flag **plumbing + diagnostics only**. Behavior is unchanged
+(flag recorded & surfaced, not yet used to alter codegen). Verified:
+comparison semantics match CRuby incl. polymorphic `== nil`; rubykon
+still ~559 ms; no regression.
+
+- **VM (`monoruby/src/codegen/vmgen.rs`)** — `vm_save_binary_class`
+  now compares the freshly observed `(lhs,rhs)` class pair against
+  the inline-cache-cached pair and, once the cache is populated
+  (cached lhs class ≠ 0), sets `opcode_sub = 1` (the POLY flag) on a
+  class mismatch. Mirrors the existing MethodCall mechanism in
+  `vmgen/method_call.rs` slow_path. New module const
+  `OPCODE_SUB: i64 = 7 - 16`. `get_class` only clobbers `rax`, so
+  `r8`/`r9` are safe scratch. This save routine is shared by the
+  generic path of **both** cmp (op 140..=146 / 150..=156) and
+  arithmetic binops (via `vm_generic_binop`), so the bit is recorded
+  for BinOp too.
+- **TraceIR (`monoruby/src/codegen/jitgen/trace_ir.rs`)** —
+  `TraceIr::BinCmp` / `BinCmpBr` carry `polymorphic: bool`
+  (`= pc.opcode_sub() == 1`). `cmp_fmt` prints a `POLY` prefix so
+  `dump_iseq` and profile deopt-stats show which cmp sites are
+  polymorphic. (MethodCall already printed `POLYMORPHIC`.)
+- **Compile glue (`compile.rs`, `compile/binary_op.rs`)** —
+  `binary_cmp` / `binary_cmp_br` take `polymorphic: bool`
+  (currently `let _ = polymorphic;` — threaded, not consumed).
+
+Verification done: a minimal repro (`/tmp/poly_repro.rb`) shows the
+`POLY` marker on `Object#spot ... POLY %2 = %1 == %2`. In the rubykon
+profile run, every 10M-deopt site now prints `POLY`, confirming the
+VM sets the bit — **but it is set lazily, after monomorphic
+compilation** (see §4).
+
+## 4. Key finding that shapes the remaining design
+
+The POLY bit is set by the VM **only after** it observes a second
+class. rubykon's hot sites are JIT-compiled monomorphic *before* that
+(empty board ⇒ only `nil == nil` for the first ≥20 calls). The
+recv-class guard then fails and **plain-deopts with no recompile**:
+
+`SideExit::Deoptimize` → `jitgen.rs::side_exit_with_label` =
+write-back regs, `r13 = pc`, `jmp fetch` (back to interpreter for the
+rest of that call). **There is no deopt counter and no recompile.**
+Recompilation only happens via the `RecompileDeopt` AsmInst →
+`jit_recompile_method` (`codegen/compiler.rs`), emitted only for
+compile-time-unresolvable reasons (`NotCached` / `MethodNotFound` /
+`IvarIdNotFound`) — never for a receiver-class guard miss.
+
+This is true for **both** MethodCall and BinCmp (they share
+`compile_method_call`). Neither recompiles on receiver-class
+polymorphism today; the MethodCall `_polymorphic` flag is likewise
+read but ignored (`compile.rs`, `_polymorphic: _`).
+
+⇒ Fixing rubykon needs **two** cooperating pieces:
+
+- **Part 3** — a polymorphic compilation that does **not** deopt on
+  class variance.
+- **Part B** — a one-shot recompile that flips a monomorphic-compiled
+  site to the Part 3 path once it has become polymorphic.
+
+## 5. Design decisions / tradeoffs (agreed direction)
+
+### Invariant that prevents infinite deopt→recompile→deopt
+
+> **Part 3 must emit code with no class-variance deopt.** Then Part B
+> is a *monotone, one-shot* monomorphic→polymorphic transition: after
+> recompile the site has no class guard left to fail, so it can never
+> re-trigger recompilation. Bounded ⇒ no infinite loop.
+
+Corollary: **decide and implement Part 3 before Part B.** If Part 3
+still deopts on class variance, Part B is unsafe and must not ship.
+
+### Part 3 options
+
+- **A — Polymorphic Inline Cache (PIC):** N-way class dispatch +
+  runtime resolve on miss (YJIT-style). Most general; needed
+  eventually for general MethodCall polymorphism. High complexity:
+  requires wiring the currently **dead** `send_not_cached`
+  (`asmir/compile/method_call.rs:20`, zero callers) and PIC state
+  management. Out of scope for the BinCmp-priority pass.
+- **B — Generic C-call:** call the same generic C helper the VM's
+  generic path uses (`cmp_<op>_values` — see the `vm_cmp_opt!` /
+  `vm_generic_binop` macros in `vmgen.rs`) with **no class guard**.
+  Inherently non-deopting (only the separate class-version / BOP
+  guards remain, which fire on real redefinition, not class
+  variance). Low risk. ~tens-of-ns per op, but a deopt is hundreds
+  of ns + re-JIT-entry, so still a large win. monoruby's JIT
+  currently has **no** generic-cmp C-call path, so this needs a new
+  AsmInst that calls a `BinaryOpFn`.
+- **C — Immediate fast-path + generic fallback (YJIT `opt_eq`):**
+  for `==`/`!=`, inline identity/value compare for immediates
+  (nil/Symbol/Integer/true/false) then C-fallback for heap objects.
+  rubykon's 10M deopts are *all* `==`/`!=` with immediate operands
+  (Symbol/nil/Integer), so this is fastest for the actual workload.
+
+**Recommended path:** B as the foundation (makes Part B safe and
+already removes the 10M deopts), then layer C onto `==`/`!=` as an
+optimization. A (PIC) deferred to a future general-MethodCall pass.
+Open sub-questions: `_opt` vs `_no_opt` C variant (use `_opt`, keeps
+the fixnum fast path); confirm `==` redefinition is absorbed inside
+the C helper's internal dispatch so only the class-version guard is
+needed; cover non-`==` cmp (`<`,`<=>`,…) with the B path too.
+
+This recommendation was presented; **user wants the Part 3 design
+nailed down before coding Part B**. No final A/B/C selection
+ratified yet — that is the first decision for the continuation.
+
+## 6. Environment gotchas
+
+- `/usr/bin/rustc` is an old 1.75 that shadows the rustup proxy and
+  breaks `cargo build`. Build with:
+  `RUSTC=$HOME/.rustup/toolchains/nightly-2025-10-15-x86_64-unknown-linux-gnu/bin/rustc PATH="$HOME/.rustup/toolchains/nightly-2025-10-15-x86_64-unknown-linux-gnu/bin:$PATH" cargo build --release [--features profile]`
+- `perf` is unusable on this WSL2 kernel. Use `--features profile`
+  deopt-stats (printed at process exit) for hot-spot analysis.
+- monoasm uses 64-bit register names even for 32-bit ops
+  (`movl r8, [mem]`, not `r8d`); `testq`/`cmpl` supported,
+  `testl`/`r8d` are not.
+- CRuby for comparison: `~/.rbenv/versions/4.0.1/bin/ruby [--yjit]`.
+
+## 7. Next steps (ordered)
+
+1. **Ratify Part 3 strategy** (A / B / B-then-C). Recommendation: B
+   foundation + C for `==`/`!=`.
+2. **Implement Part 3.** Add an AsmInst that calls the generic
+   `BinaryOpFn` C helper (no class guard, error-checked, result →
+   dst/acc); emit it from `binary_cmp`/`binary_cmp_br` (and later
+   `binary_op`) when `polymorphic && BinaryOpType::Other`. Keep the
+   class-version/BOP guards. Confirm no class-variance deopt remains.
+3. **Implement Part B.** Route the recv-class guard in
+   `compile_method_call` to a `RecompileDeopt` with a new
+   `RecompileReason` (e.g. `BecamePolymorphic`) **only** when the
+   originating site's POLY flag is set; otherwise keep plain deopt.
+   Gate so existing monomorphic sites are unaffected.
+4. **Measure** rubykon deopt counts (`--features profile`) and
+   best-of-10 wall time vs the ~559 ms / YJIT ~367 ms baseline.
+5. **Regression**: `bin/test` (or at least `cargo nextest` + the
+   comparison-semantics check in `/tmp/cmp_correctness.rb`).
+6. PR from `jit-poly-bincmp` → `master`.
+
+## 8. Key source pointers
+
+- `monoruby/src/codegen/vmgen.rs` — `vm_save_binary_class`
+  (POLY-set), `vm_cmp_opt!` / `vm_generic_binop` (generic C-call the
+  VM uses; Part 3 should reuse the same `*_values` fns).
+- `monoruby/src/codegen/vmgen/method_call.rs` — original MethodCall
+  POLY (`OPCODE_SUB`, `slow_path`).
+- `monoruby/src/codegen/jitgen/trace_ir.rs` — BinCmp/BinCmpBr decode
+  (op 140..=146 / 150..=156), `polymorphic` field, `cmp_fmt`.
+- `monoruby/src/codegen/jitgen/compile/binary_op.rs` —
+  `binary_cmp` / `binary_cmp_br` (Part 3 emission point).
+- `monoruby/src/codegen/jitgen/compile/method_call.rs` —
+  `compile_method_call` (shared recv-class guard, Part B point).
+- `monoruby/src/codegen/jitgen.rs` — `side_exit_with_label`
+  (plain deopt = jmp fetch, no recompile).
+- `monoruby/src/codegen/compiler.rs` — `gen_recompile`,
+  `recompile_method`, `jit_recompile_method`, `RecompileReason`.
+- `monoruby/src/codegen/jitgen/asmir/compile/method_call.rs:20` —
+  `send_not_cached` (dead code; the PIC building block for option A).
+- `monoruby/src/codegen/jitgen/asmir/compile.rs` — `AsmInst::Deopt`
+  vs `AsmInst::RecompileDeopt` lowering.
+
+Memory note: project memory `project_rubykon_polymorphic_jit.md`
+(index in MEMORY.md) tracks the same conclusions for cross-session
+recall.

--- a/doc/HANDOFF.md
+++ b/doc/HANDOFF.md
@@ -1,223 +1,308 @@
 # HANDOFF — rubykon polymorphic-JIT work
 
-Branch: `jit-poly-bincmp` (commit `f11603ad`). Base: `master`.
-Date: 2026-05-16. Owner handing off → Claude Web continuation.
+Branch: `claude/handoff-review-nyy4u`. Base: `master`.
+Last update: 2026-05-16. State: **Parts 3-B, B, C implemented &
+regression-verified. Remaining: rubykon perf measurement, then PR.**
 
-> Rule: never push to `master`; this work stays on `jit-poly-bincmp`
-> and lands via PR. Verify branch before any commit (a merged PR may
-> auto-switch the checkout to `master`).
+> Rule: never push to `master`; this work stays on
+> `claude/handoff-review-nyy4u` and lands via PR. Verify the branch
+> before any commit (a merged PR may auto-switch the checkout to
+> `master`).
 
 ---
 
-## 1. Problem
+## 0. Commits on this branch (over `master`)
+
+```
+0f0f087 jit: inline immediate fast path for polymorphic ==/!= (Part C)
+61b9a89 jit: fix Part B recompile target (use JIT entry position, not cmp pc)
+3bb3512 jit: one-shot recompile of monomorphic BinCmp on polymorphism (Part B)
+415208f jit: non-deopting polymorphic BinCmp via generic C-call (Part 3-B)
+256b461 doc: add HANDOFF.md for rubykon polymorphic-JIT work
+f11603a jit: record BinCmp/BinOp receiver polymorphism (POLY flag plumbing)
+```
+
+`f11603a` is the original POLY-flag plumbing/diagnostics (behavior
+unchanged). Everything from `415208f` on is the new behavior.
+
+---
+
+## 1. Problem (unchanged)
 
 ruby-bench `rubykon` runs ~1.5× slower than CRuby 4.0.1 `--yjit`.
 
-Measured (19×19 board, 100 iters, best of 10; clean release build):
-
-| Engine | best |
+| Engine | best (19×19, 100 iters, best of 10) |
 |---|---|
 | CRuby 4.0.1 `--yjit` | ~367 ms |
-| monoruby | ~559 ms |
+| monoruby (pre-this-work) | ~559 ms |
 | CRuby 4.0.1 interpreter | ~850 ms |
 
-Reproduction script: `/tmp/rubykon_run.rb` (requires
-`requires "rubykon"` from `/home/monochrome/yjit-bench/benchmarks/rubykon/lib`).
-Profiling build: `cargo build --release --features profile`
-(toolchain note in §6). `perf` does NOT work on this WSL2 kernel —
-use the `profile` feature's deopt-stats instead.
+Root cause (confirmed via `--features profile` deopt-stats):
+>10M deoptimizations on a single `==` in
+`MoveValidator#spot_unoccupied?` (`board[id] == Board::EMPTY`, i.e.
+`== nil`), plus millions more in `no_suicide_move?`,
+`gain_liberties_from_capture_of`, etc. The `==` receiver class
+oscillates `NilClass`↔`Symbol`. monoruby compiled these sites
+monomorphic (empty board ⇒ only `nil == nil` for the first ≥20
+calls), then the receiver-class guard plain-deopted forever with no
+recompile. See git history of this file / `f11603a` message for the
+full original analysis.
 
-## 2. Root cause (confirmed)
+---
 
-`profile` deopt-stats: **>10M deoptimizations on a single `==`** in
-`MoveValidator#spot_unoccupied?`, millions more in `no_suicide_move?`,
-`gain_liberties_from_capture_of`, `candidate_eye_color`,
-`already_counted_as_liberty?`, etc. Recompile count is ~1–2, so these
-are pure per-call side-exits, not recompiles.
+## 2. What was done (this branch)
 
-Trigger: rubykon's board representation
-(`/home/monochrome/yjit-bench/benchmarks/rubykon/lib/rubykon/board.rb`):
+The agreed plan (handoff §5, ratified by the user) was **B then C**:
+Part 3-B as the non-deopting foundation, Part B to flip
+monomorphic-compiled sites onto it, then Part C as the `==`/`!=`
+fast-path optimisation.
 
-```ruby
-EMPTY = nil; BLACK = :black; WHITE = :white
-def spot_unoccupied?(id, board) = board[id] == Board::EMPTY   # i.e. == nil
-```
+### Part 3-B — non-deopting polymorphic BinCmp (`415208f`)
 
-`board[id]` is `nil` (empty point) or a `Symbol` (occupied). The `==`
-receiver class oscillates `NilClass`↔`Symbol`.
+`monoruby/src/codegen/jitgen/compile/binary_op.rs`:
+`binary_cmp` / `binary_cmp_br`, in the
+`BinaryOpType::Other(Some(_), _)` arm, now branch on `polymorphic`:
 
-monoruby's JIT compiles non-numeric `==` via
-`binary_cmp` → `BinaryOpType::Other` → `call_binary_method` →
-`compile_method_call`, which emits a **monomorphic receiver-class
-guard that plain-deopts on mismatch**. Because the board starts empty,
-the first ~20 calls see only `nil == nil`; the method is JIT-compiled
-monomorphic for `NilClass` at the call threshold, then deopts forever
-once `Symbol` appears. It is never recompiled.
+- `polymorphic == true` → `emit_generic_cmp`: write back operands,
+  keep the **class-version** guard (it tracks the global
+  class-version counter, not the receiver class, so it never fires
+  on class variance — preserves the Part B monotone invariant),
+  then a generic `cmp_*_values` C-call with **no receiver-class
+  guard**, `handle_error`, then invalidate cached guards. Result →
+  acc/dst (or cond-br for the `_br` form).
+- `polymorphic == false` → unchanged `call_binary_method`
+  (monomorphic, recv-class-guarded), *but* now flagged for Part B
+  (see below).
 
-YJIT's `opt_eq` inlines immediate/special-const equality with a
-generic `send` fallback that stays in JIT code — it never side-exits
-on class variance, so it avoids this entirely.
+New plumbing: `AsmInst::GenericBinOp` + `AsmIr::generic_binop`
+(modelled on `ArrayTEq`), and a `CmpKind → BinaryOpFn` map
+(`cmp_generic_fn`, the same `cmp_eq_values`/… helpers the VM's
+generic path uses). Monomorphic sites are byte-for-byte unaffected.
 
-## 3. What is done (committed in `f11603ad`)
+### Part B — one-shot recompile on becoming polymorphic (`3bb3512`, fixed by `61b9a89`)
 
-POLY-flag **plumbing + diagnostics only**. Behavior is unchanged
-(flag recorded & surfaced, not yet used to alter codegen). Verified:
-comparison semantics match CRuby incl. polymorphic `== nil`; rubykon
-still ~559 ms; no regression.
+The POLY bit is set by the VM **after** monomorphic compilation, so
+Part 3-B alone never triggers for rubykon. Part B makes a
+monomorphic-compiled BinCmp site's **receiver-class-guard miss**
+recompile (once the miss counter is exhausted) instead of
+plain-deopting forever; the recompile re-runs `binary_cmp`, which by
+then sees `polymorphic == true` (the VM set POLY during the deopt
+fallbacks) and emits the Part 3-B path — which has **no recv-class
+guard**, so it can never re-trigger. Monotone, one-shot, bounded.
 
-- **VM (`monoruby/src/codegen/vmgen.rs`)** — `vm_save_binary_class`
-  now compares the freshly observed `(lhs,rhs)` class pair against
-  the inline-cache-cached pair and, once the cache is populated
-  (cached lhs class ≠ 0), sets `opcode_sub = 1` (the POLY flag) on a
-  class mismatch. Mirrors the existing MethodCall mechanism in
-  `vmgen/method_call.rs` slow_path. New module const
-  `OPCODE_SUB: i64 = 7 - 16`. `get_class` only clobbers `rax`, so
-  `r8`/`r9` are safe scratch. This save routine is shared by the
-  generic path of **both** cmp (op 140..=146 / 150..=156) and
-  arithmetic binops (via `vm_generic_binop`), so the bit is recorded
-  for BinOp too.
-- **TraceIR (`monoruby/src/codegen/jitgen/trace_ir.rs`)** —
-  `TraceIr::BinCmp` / `BinCmpBr` carry `polymorphic: bool`
-  (`= pc.opcode_sub() == 1`). `cmp_fmt` prints a `POLY` prefix so
-  `dump_iseq` and profile deopt-stats show which cmp sites are
-  polymorphic. (MethodCall already printed `POLYMORPHIC`.)
-- **Compile glue (`compile.rs`, `compile/binary_op.rs`)** —
-  `binary_cmp` / `binary_cmp_br` take `polymorphic: bool`
-  (currently `let _ = polymorphic;` — threaded, not consumed).
+Implementation:
+- `RecompileReason::BecamePolymorphic` (`executor.rs`).
+- `SideExit::RecompileDeoptimize(pc, wb, reason, position)`
+  (`asmir.rs`) + `AsmIr::new_recompile_deopt`. `binary_cmp`'s
+  non-polymorphic `Other` arm now calls `call_binary_method(…,
+  recompile_on_recv_miss = true)`; the bool is threaded through
+  `call_binary_method` → `compile_method_call`, where the
+  receiver-class guard's deopt becomes a `new_recompile_deopt`
+  instead of `new_deopt`. Every other caller passes `false`
+  (general MethodCall, arithmetic BinOp, index, ternary) — they keep
+  plain deopt, so no infinite-recompile risk for paths that have no
+  non-deopting alternative.
+- Side-exit codegen: `gen_recompile_deopt_with_label` →
+  `side_exit_with_label` with an optional
+  `(RecompileReason, position)`. The recompile (counter-gated,
+  `COUNT_DEOPT_RECOMPILE`, one-shot) is emitted **after** the deopt
+  write-back and **before** `jmp fetch`.
 
-Verification done: a minimal repro (`/tmp/poly_repro.rb`) shows the
-`POLY` marker on `Object#spot ... POLY %2 = %1 == %2`. In the rubykon
-profile run, every 10M-deopt site now prints `POLY`, confirming the
-VM sets the bit — **but it is set lazily, after monomorphic
-compilation** (see §4).
+Two bugs were found here and fixed before this state:
 
-## 4. Key finding that shapes the remaining design
+1. **GC use-after-free.** Initial version recompiled *before* the
+   deopt write-back, so a GC inside `jit_recompile_loop` freed Ruby
+   values still live only in registers → "Dead object" panic in
+   `cmp_eq_values`. Fix: write-back must precede the recompile call
+   (now structurally enforced by emitting the recompile inside
+   `side_exit_with_label` after `gen_write_back_for_deopt`).
+   Validated under `--features gc-stress`.
+2. **Wrong recompile target (`61b9a89`).** Passed the cmp-site `pc`
+   to `gen_recompile`, driving `jit_recompile_loop` at a
+   non-loop-header bytecode → `is_loop_begin(bb).unwrap()` panic
+   (e.g. `builtins::enumerator::tests::one_`). Fix: thread the JIT
+   **entry** position (`JitContext::position()` — `None` for a full
+   method/block JIT, `Some(loop-header pc)` for a loop JIT) into the
+   side exit, exactly as the existing `recompile_and_deopt` does.
+   `JitType::Specialized` recompiles via an idx, not a position, so
+   it is gated **out** of Part B (stays on plain deopt) — safe and
+   regression-free.
 
-The POLY bit is set by the VM **only after** it observes a second
-class. rubykon's hot sites are JIT-compiled monomorphic *before* that
-(empty board ⇒ only `nil == nil` for the first ≥20 calls). The
-recv-class guard then fails and **plain-deopts with no recompile**:
+### Part C — inline immediate fast path for `==`/`!=` (`0f0f087`)
 
-`SideExit::Deoptimize` → `jitgen.rs::side_exit_with_label` =
-write-back regs, `r13 = pc`, `jmp fetch` (back to interpreter for the
-rest of that call). **There is no deopt counter and no recompile.**
-Recompilation only happens via the `RecompileDeopt` AsmInst →
-`jit_recompile_method` (`codegen/compiler.rs`), emitted only for
-compile-time-unresolvable reasons (`NotCached` / `MethodNotFound` /
-`IvarIdNotFound`) — never for a receiver-class guard miss.
+YJIT-`opt_eq`-style. `emit_generic_cmp` now, for `CmpKind::Eq` /
+`CmpKind::Ne`, emits `AsmInst::OptEqCmp` instead of `GenericBinOp`
+(other cmp kinds keep the plain generic call). Lowering
+(`asmir/compile.rs::opt_eq_cmp`): with `rdx = lhs`, `rcx = rhs`, if
+**both** operands are non-heap, non-flonum immediates
+(`bits & 0b111 != 0` and `bits & 0b011 != 0b010` — i.e. Fixnum /
+nil / true / false / Symbol) the Ruby `==`/`!=` result is exactly
+bit (identity) equality and is produced inline (`xorq rax,rax;
+cmpq rdx,rcx; set_eq/set_ne`). Float (`-0.0`/`0.0`, `NaN`), heap
+(`String` content, custom `==`), `BigInt`, and mixed numeric all
+fall through to the same generic `cmp_*_values` C-call as Part 3-B
+(correct for them). No receiver-class guard. The slow-path tail
+reuses the exact `BinaryOpFn` calling convention; the fast path
+clobbers only `rax`.
 
-This is true for **both** MethodCall and BinCmp (they share
-`compile_method_call`). Neither recompiles on receiver-class
-polymorphism today; the MethodCall `_polymorphic` flag is likewise
-read but ignored (`compile.rs`, `_polymorphic: _`).
+This is a pure optimisation layered on a correct Part 3-B; its
+*benefit* needs the rubykon measurement (below), but its
+*correctness* is exhaustively tested.
 
-⇒ Fixing rubykon needs **two** cooperating pieces:
+---
 
-- **Part 3** — a polymorphic compilation that does **not** deopt on
-  class variance.
-- **Part B** — a one-shot recompile that flips a monomorphic-compiled
-  site to the Part 3 path once it has become polymorphic.
+## 3. Verification done (in this container)
 
-## 5. Design decisions / tradeoffs (agreed direction)
+- **Correctness vs CRuby 4.0.4** (see §4 for the Ruby build): a
+  large polymorphic-cmp matrix — `==`/`!=`/`<`/`<=>`/`===`, branch
+  form, NilClass↔Symbol↔custom↔Integer oscillation, custom `==` /
+  `<=>` with `Comparable`, exception propagation through the C
+  helper, `coerce`/`Rational`, `BigInt`, Float `NaN`/`-0.0`/`0.0`,
+  String content equality, `Integer == Float` — all match exactly,
+  run >300× (well past the JIT thresholds, so the
+  monomorphic→polymorphic→recompile→Part 3-B/C path is exercised).
+  Repro scripts: `/tmp/poly_cmp.rb`, `/tmp/poly_edge.rb`,
+  `/tmp/partc.rb`, `/tmp/mixed.rb` (regenerate as needed; they are
+  not committed).
+- **gc-stress**: `cargo build --features gc-stress`; the transition
+  tests + a heavy mixed workload pass with correct results (this is
+  what caught and now guards the Part B GC-ordering bug).
+- **Full lib suite**: `2053 passed / 0 failed` against Ruby 4.0.4
+  (with `LANG=C.UTF-8`). Integration suites (`arith`, `comparable`,
+  `case`, `bang_operator`, `method_call`, `enumerable`) all green.
+- No new warnings; `cargo build` clean. (One-off `rust-lld`
+  "undefined hidden symbol" link errors seen mid-session were
+  stale-incremental-cache corruption from flipping the `gc-stress`
+  feature + a `build.rs` rerun — resolved by `cargo clean`, **not** a
+  code issue.)
 
-### Invariant that prevents infinite deopt→recompile→deopt
+> The 31 lib failures originally seen were entirely the wrong
+> reference Ruby (3.3.6) + a non-UTF-8 locale; 29 vanished under
+> Ruby 4.0.4 and the last 2 (`string_inspect`,
+> `symbol_inspect_unquoted`) under `LANG=C.UTF-8`. None were
+> related to this work.
 
-> **Part 3 must emit code with no class-variance deopt.** Then Part B
-> is a *monotone, one-shot* monomorphic→polymorphic transition: after
-> recompile the site has no class guard left to fail, so it can never
-> re-trigger recompilation. Bounded ⇒ no infinite loop.
+---
 
-Corollary: **decide and implement Part 3 before Part B.** If Part 3
-still deopts on class variance, Part B is unsafe and must not ship.
+## 4. Environment notes (this container)
 
-### Part 3 options
-
-- **A — Polymorphic Inline Cache (PIC):** N-way class dispatch +
-  runtime resolve on miss (YJIT-style). Most general; needed
-  eventually for general MethodCall polymorphism. High complexity:
-  requires wiring the currently **dead** `send_not_cached`
-  (`asmir/compile/method_call.rs:20`, zero callers) and PIC state
-  management. Out of scope for the BinCmp-priority pass.
-- **B — Generic C-call:** call the same generic C helper the VM's
-  generic path uses (`cmp_<op>_values` — see the `vm_cmp_opt!` /
-  `vm_generic_binop` macros in `vmgen.rs`) with **no class guard**.
-  Inherently non-deopting (only the separate class-version / BOP
-  guards remain, which fire on real redefinition, not class
-  variance). Low risk. ~tens-of-ns per op, but a deopt is hundreds
-  of ns + re-JIT-entry, so still a large win. monoruby's JIT
-  currently has **no** generic-cmp C-call path, so this needs a new
-  AsmInst that calls a `BinaryOpFn`.
-- **C — Immediate fast-path + generic fallback (YJIT `opt_eq`):**
-  for `==`/`!=`, inline identity/value compare for immediates
-  (nil/Symbol/Integer/true/false) then C-fallback for heap objects.
-  rubykon's 10M deopts are *all* `==`/`!=` with immediate operands
-  (Symbol/nil/Integer), so this is fastest for the actual workload.
-
-**Recommended path:** B as the foundation (makes Part B safe and
-already removes the 10M deopts), then layer C onto `==`/`!=` as an
-optimization. A (PIC) deferred to a future general-MethodCall pass.
-Open sub-questions: `_opt` vs `_no_opt` C variant (use `_opt`, keeps
-the fixnum fast path); confirm `==` redefinition is absorbed inside
-the C helper's internal dispatch so only the class-version guard is
-needed; cover non-`==` cmp (`<`,`<=>`,…) with the B path too.
-
-This recommendation was presented; **user wants the Part 3 design
-nailed down before coding Part B**. No final A/B/C selection
-ratified yet — that is the first decision for the continuation.
-
-## 6. Environment gotchas
-
-- `/usr/bin/rustc` is an old 1.75 that shadows the rustup proxy and
-  breaks `cargo build`. Build with:
-  `RUSTC=$HOME/.rustup/toolchains/nightly-2025-10-15-x86_64-unknown-linux-gnu/bin/rustc PATH="$HOME/.rustup/toolchains/nightly-2025-10-15-x86_64-unknown-linux-gnu/bin:$PATH" cargo build --release [--features profile]`
-- `perf` is unusable on this WSL2 kernel. Use `--features profile`
-  deopt-stats (printed at process exit) for hot-spot analysis.
+- **Ruby 4.0.4 built from source.** `ruby/ruby` tag `v4.0.4` →
+  `~/.ruby-4.0` (`./autogen.sh && ./configure
+  --prefix=$HOME/.ruby-4.0 --disable-install-doc && make -j4 &&
+  make install`). Bundled gems were **skipped** (emptied
+  `gems/bundled_gems`) because the network policy blocks
+  `cache.ruby-lang.org` (the gem mirror — 403 `host_not_allowed`);
+  `rubygems.org` *is* reachable. Core interpreter + default gems
+  are intact. `gem install bigdecimal` done (for
+  `tests/bigdecimal.rs`, since bigdecimal is a bundled gem in 4.0).
+- `/usr/local/bin/{ruby,gem,bundle}` were symlinks to
+  `/opt/ruby-3.3.6/…`; repointed to `/root/.ruby-4.0/bin/…`. The
+  project's `build.rs` and `monoruby/src/tests.rs` both enforce
+  `MIN_RUBY_VERSION = (4, 0)` and resolve `ruby` from PATH; with
+  this repoint `ruby --version` → `4.0.4`, `~/.monoruby/ruby_version`
+  → `4.0.4`, and `monoruby -e 'puts RUBY_VERSION'` → `4.0.4`.
+- `~/.bashrc` exports `LANG=C.UTF-8 LC_ALL=C.UTF-8` so the
+  reference Ruby's `inspect` output (US-ASCII default external
+  encoding otherwise) matches monoruby's UTF-8.
+- This container has **no rubykon benchmark** and is **not** the
+  perf-measurement environment. `perf` is unusable on the original
+  WSL2 kernel; use `--features profile` deopt-stats (printed at
+  process exit) for hot-spot analysis there.
 - monoasm uses 64-bit register names even for 32-bit ops
   (`movl r8, [mem]`, not `r8d`); `testq`/`cmpl` supported,
-  `testl`/`r8d` are not.
-- CRuby for comparison: `~/.rbenv/versions/4.0.1/bin/ruby [--yjit]`.
+  `testl`/`r8d` are not. `0b…` immediates work in `monoasm!`.
 
-## 7. Next steps (ordered)
+---
 
-1. **Ratify Part 3 strategy** (A / B / B-then-C). Recommendation: B
-   foundation + C for `==`/`!=`.
-2. **Implement Part 3.** Add an AsmInst that calls the generic
-   `BinaryOpFn` C helper (no class guard, error-checked, result →
-   dst/acc); emit it from `binary_cmp`/`binary_cmp_br` (and later
-   `binary_op`) when `polymorphic && BinaryOpType::Other`. Keep the
-   class-version/BOP guards. Confirm no class-variance deopt remains.
-3. **Implement Part B.** Route the recv-class guard in
-   `compile_method_call` to a `RecompileDeopt` with a new
-   `RecompileReason` (e.g. `BecamePolymorphic`) **only** when the
-   originating site's POLY flag is set; otherwise keep plain deopt.
-   Gate so existing monomorphic sites are unaffected.
-4. **Measure** rubykon deopt counts (`--features profile`) and
-   best-of-10 wall time vs the ~559 ms / YJIT ~367 ms baseline.
-5. **Regression**: `bin/test` (or at least `cargo nextest` + the
-   comparison-semantics check in `/tmp/cmp_correctness.rb`).
-6. PR from `jit-poly-bincmp` → `master`.
+## 5. Remaining work (ordered) — for the benchmark environment
 
-## 8. Key source pointers
+The implementation and correctness are done. What is left needs the
+rubykon benchmark + profiling, which this container does not have.
 
-- `monoruby/src/codegen/vmgen.rs` — `vm_save_binary_class`
-  (POLY-set), `vm_cmp_opt!` / `vm_generic_binop` (generic C-call the
-  VM uses; Part 3 should reuse the same `*_values` fns).
-- `monoruby/src/codegen/vmgen/method_call.rs` — original MethodCall
-  POLY (`OPCODE_SUB`, `slow_path`).
-- `monoruby/src/codegen/jitgen/trace_ir.rs` — BinCmp/BinCmpBr decode
-  (op 140..=146 / 150..=156), `polymorphic` field, `cmp_fmt`.
+1. **Measure rubykon** with a clean release build of this branch:
+   - deopt counts via `cargo build --release --features profile`
+     (deopt-stats printed at exit). Expectation: the >10M
+     `spot_unoccupied?` / `no_suicide_move?` `==` deopts collapse to
+     ~0 (Part B recompiles the site once; Part 3-B/C then has no
+     recv-class guard to miss).
+   - best-of-10 wall time (19×19, 100 iters) vs the ~559 ms
+     baseline and CRuby 4.0.1 `--yjit` ~367 ms.
+   - Reproduction: the original owner's `/tmp/rubykon_run.rb`
+     (`require "rubykon"` from
+     `…/yjit-bench/benchmarks/rubykon/lib`).
+2. **If a perf regression or wrong result appears in rubykon**
+   specifically (not reproduced by the §3 correctness tests), the
+   first suspects are: Part C's immediate-tag check (verify against
+   `value.rs` tag table), and the Part B counter
+   (`COUNT_DEOPT_RECOMPILE`) interacting with the loop vs method JIT
+   at that site (check `--features deopt`/`jit-log`).
+3. **Optional further opt** only if measurement shows `==`/`!=`
+   slow-path still hot: extend Part 3-B/C to `binary_op`
+   (arithmetic) the same way (`binary_op` does not yet take a
+   `polymorphic` arg; the POLY bit is already recorded for BinOp by
+   the VM per `f11603a`).
+4. **Regression** in the benchmark env: `bin/test` (full
+   test + coverage + benchmark diff + optcarrot). In a Ruby-4.0+
+   env this should be clean; mirror the §3 results.
+5. **PR** `claude/handoff-review-nyy4u` → `master`. Summarise Parts
+   3-B / B / C, the monotone-recompile safety invariant, and the
+   rubykon before/after numbers from step 1.
+
+---
+
+## 6. Design invariant (must hold — re-check if extending)
+
+> Part 3 (the polymorphic path) emits **no class-variance deopt**.
+> Therefore Part B is a *monotone, one-shot* monomorphic→polymorphic
+> transition: after recompile the site has no receiver-class guard
+> left to fail, so it can never re-trigger recompilation. Bounded ⇒
+> no infinite deopt→recompile loop.
+
+Corollary, if you extend Part B to any new site (e.g. arithmetic
+`binary_op`): only set `recompile_on_recv_miss = true` for sites
+that have a non-deopting polymorphic alternative compiled when
+`polymorphic == true`. Otherwise the recompile re-emits the same
+guarded code and loops. The class-version guard is intentionally
+**kept** on the generic path — it guards the global class-version
+counter, not the receiver class, so it only fires on a real
+`==`/`<=>` redefinition (rare, also monotone), never on class
+variance.
+
+---
+
+## 7. Key source pointers (current)
+
 - `monoruby/src/codegen/jitgen/compile/binary_op.rs` —
-  `binary_cmp` / `binary_cmp_br` (Part 3 emission point).
+  `binary_cmp` / `binary_cmp_br` (polymorphic dispatch),
+  `emit_generic_cmp` (Part 3-B/C emission), `cmp_generic_fn`
+  (`CmpKind → BinaryOpFn`).
 - `monoruby/src/codegen/jitgen/compile/method_call.rs` —
-  `compile_method_call` (shared recv-class guard, Part B point).
+  `compile_method_call` (`recompile_on_recv_miss`; recv-class guard
+  → `new_recompile_deopt` vs `new_deopt`; `JitType::Specialized`
+  gated out). `guard_class_version` is now `pub(super)`.
+- `monoruby/src/codegen/jitgen/compile.rs` — `call_binary_method`
+  (threads `recompile_on_recv_miss`), `recompile_and_deopt`
+  (pre-existing `AsmInst::RecompileDeopt` path; mirrored for the
+  `position`/`JitType` handling).
+- `monoruby/src/codegen/jitgen/asmir.rs` —
+  `AsmInst::GenericBinOp` / `OptEqCmp`, `AsmIr::generic_binop` /
+  `opt_eq_cmp` / `new_recompile_deopt`;
+  `SideExit::RecompileDeoptimize`; `gen_asm` side-exit loop.
+- `monoruby/src/codegen/jitgen/asmir/compile.rs` —
+  `generic_binop` (Part 3-B slow path) and `opt_eq_cmp` (Part C
+  fast path + slow fallback) lowering.
 - `monoruby/src/codegen/jitgen.rs` — `side_exit_with_label`
-  (plain deopt = jmp fetch, no recompile).
-- `monoruby/src/codegen/compiler.rs` — `gen_recompile`,
-  `recompile_method`, `jit_recompile_method`, `RecompileReason`.
-- `monoruby/src/codegen/jitgen/asmir/compile/method_call.rs:20` —
-  `send_not_cached` (dead code; the PIC building block for option A).
-- `monoruby/src/codegen/jitgen/asmir/compile.rs` — `AsmInst::Deopt`
-  vs `AsmInst::RecompileDeopt` lowering.
+  (now takes `recompile: Option<(RecompileReason,
+  Option<BytecodePtr>)>`; recompile emitted **after** write-back,
+  **before** `jmp fetch`), `gen_recompile_deopt_with_label`.
+- `monoruby/src/codegen/jitgen/deoptimize.rs` —
+  `recompile_and_deopt` (the pre-existing counter+recompile the
+  Part B side exit's design mirrors).
+- `monoruby/src/executor.rs` — `RecompileReason::BecamePolymorphic`.
+- `monoruby/src/executor/op.rs` — `cmp_{eq,ne,lt,le,gt,ge,teq}_values`
+  (the generic `BinaryOpFn`s; same ones the VM's generic path uses).
+- `monoruby/src/codegen/vmgen.rs` — `vm_save_binary_class`
+  (sets the POLY bit; original mechanism unchanged).
 
 Memory note: project memory `project_rubykon_polymorphic_jit.md`
 (index in MEMORY.md) tracks the same conclusions for cross-session

--- a/doc/HANDOFF.md
+++ b/doc/HANDOFF.md
@@ -1,8 +1,11 @@
 # HANDOFF — rubykon polymorphic-JIT work
 
 Branch: `claude/handoff-review-nyy4u`. Base: `master`.
-Last update: 2026-05-16. State: **Parts 3-B, B, C implemented &
-regression-verified. Remaining: rubykon perf measurement, then PR.**
+Last update: 2026-05-16. State: **Parts 3-B, B, C implemented,
+regression-verified, AND rubykon-measured (§3a): the targeted
+`[Symbol][NilClass]` `== nil` deopt storm collapses millions → 10
+(+1 recompile), ~7% best wall-time. Remaining: scoped-out follow-ups
+(§5 items 1–3) + PR.**
 
 > Rule: never push to `master`; this work stays on
 > `claude/handoff-review-nyy4u` and lands via PR. Verify the branch
@@ -176,6 +179,49 @@ This is a pure optimisation layered on a correct Part 3-B; its
   feature + a `build.rs` rerun — resolved by `cargo clean`, **not** a
   code issue.)
 
+### 3a. rubykon measured (this container, 2026-05-16)
+
+`ruby/ruby-bench` cloned at `/home/user/ruby-bench` (it mirrors
+yjit-bench — identical refs — so `benchmarks/rubykon/lib` is the
+exact lib the original analysis used). Pure Ruby, loads under
+monoruby & CRuby 4.0.4. Self-contained runner `/tmp/rubykon_run.rb`
+(19×19, `ITERATIONS=100`, best-of-10; env: `RUBYKON_ITERS/RUNS/LIB`)
+— mirrors yjit-bench `benchmark.rb`, no YJIT/CSV harness so it runs
+identically under both.
+
+> Absolute ms are NOT comparable to the original handoff numbers
+> (different machine). What matters is same-machine relative.
+
+Wall time, best-of-10, 19×19/100, this container:
+
+| build | best | avg |
+|---|---|---|
+| baseline `256b461` (no 3-B/B/C) | 793.6 ms | 805.0 ms |
+| **this branch (3-B/B/C)** | **738.9 ms** | **767.1 ms** |
+| CRuby 4.0.4 `--yjit` | 471.6 ms | 503.1 ms |
+| CRuby 4.0.4 interp | 1047.0 ms | 1091.0 ms |
+
+⇒ Parts 3-B/B/C: **~7% best / ~5% avg faster** than baseline. Real
+but modest (see §5 for why).
+
+Deopt counts (`--features profile`, 2 runs × 100 iters), the
+decisive evidence — **baseline → this branch**, per site:
+
+| site (`POLY … == …`) | baseline | branch |
+|---|---:|---:|
+| `MoveValidator#spot_unoccupied?` `[Symbol][NilClass]` | 1,390,933 | **10** |
+| `block in no_suicide_move?` `[Symbol][NilClass]` | 418,415 | **10** |
+| `EyeDetector#candidate_eye_color` `[Symbol][NilClass]` | 145,612 | **10** |
+| `block in candidate_eye_color` `[NilClass][Symbol]` | 31,721 | ~0 |
+| `Group#already_counted_as_liberty?` `[Integer][NilClass]` | 137,805 | 50,550 |
+
+Each fixed site shows exactly **one `BecamePolymorphic` recompile**
+then runs deopt-free. The targeted `[Symbol][NilClass]` `== nil`
+pattern is reduced **5–6 orders of magnitude (millions → 10)** —
+Part B's monotone one-shot transition is confirmed working exactly
+as designed. (Baseline at 2×100 iters ≈ the original ">10M" at the
+full 10-run measurement — consistent.)
+
 > The 31 lib failures originally seen were entirely the wrong
 > reference Ruby (3.3.6) + a non-UTF-8 locale; 29 vanished under
 > Ruby 4.0.4 and the last 2 (`string_inspect`,
@@ -204,49 +250,71 @@ This is a pure optimisation layered on a correct Part 3-B; its
 - `~/.bashrc` exports `LANG=C.UTF-8 LC_ALL=C.UTF-8` so the
   reference Ruby's `inspect` output (US-ASCII default external
   encoding otherwise) matches monoruby's UTF-8.
-- This container has **no rubykon benchmark** and is **not** the
-  perf-measurement environment. `perf` is unusable on the original
-  WSL2 kernel; use `--features profile` deopt-stats (printed at
-  process exit) for hot-spot analysis there.
+- rubykon **is** now available here: `ruby/ruby-bench` cloned at
+  `/home/user/ruby-bench` (sibling of the repo). Runner
+  `/tmp/rubykon_run.rb`. Measurement done — see §3a. `perf` is
+  unusable; use `--features profile` deopt-stats (printed at process
+  exit) for hot-spot analysis.
 - monoasm uses 64-bit register names even for 32-bit ops
   (`movl r8, [mem]`, not `r8d`); `testq`/`cmpl` supported,
   `testl`/`r8d` are not. `0b…` immediates work in `monoasm!`.
 
 ---
 
-## 5. Remaining work (ordered) — for the benchmark environment
+## 5. Remaining work (ordered)
 
-The implementation and correctness are done. What is left needs the
-rubykon benchmark + profiling, which this container does not have.
+Implementation, correctness, and rubykon measurement are **done**
+(§3, §3a). Parts 3-B/B/C fully solve the *targeted* problem (the
+`[Symbol][NilClass]` `== nil` deopt storm: millions → 10 + one
+recompile). The ~7% (not larger) wall-time gain is explained by the
+deopt-stats: rubykon's *remaining* hot deopts are other
+polymorphism classes the ratified **B-then-C / BinCmp-`Other`**
+scope deliberately did **not** cover. To close more of the gap vs
+CRuby `--yjit` (which inlines all of these via `opt_eq` + a
+send-PIC):
 
-1. **Measure rubykon** with a clean release build of this branch:
-   - deopt counts via `cargo build --release --features profile`
-     (deopt-stats printed at exit). Expectation: the >10M
-     `spot_unoccupied?` / `no_suicide_move?` `==` deopts collapse to
-     ~0 (Part B recompiles the site once; Part 3-B/C then has no
-     recv-class guard to miss).
-   - best-of-10 wall time (19×19, 100 iters) vs the ~559 ms
-     baseline and CRuby 4.0.1 `--yjit` ~367 ms.
-   - Reproduction: the original owner's `/tmp/rubykon_run.rb`
-     (`require "rubykon"` from
-     `…/yjit-bench/benchmarks/rubykon/lib`).
-2. **If a perf regression or wrong result appears in rubykon**
-   specifically (not reproduced by the §3 correctness tests), the
-   first suspects are: Part C's immediate-tag check (verify against
-   `value.rs` tag table), and the Part B counter
-   (`COUNT_DEOPT_RECOMPILE`) interacting with the loop vs method JIT
-   at that site (check `--features deopt`/`jit-log`).
-3. **Optional further opt** only if measurement shows `==`/`!=`
-   slow-path still hot: extend Part 3-B/C to `binary_op`
-   (arithmetic) the same way (`binary_op` does not yet take a
-   `polymorphic` arg; the POLY bit is already recorded for BinOp by
-   the VM per `f11603a`).
-4. **Regression** in the benchmark env: `bin/test` (full
-   test + coverage + benchmark diff + optcarrot). In a Ruby-4.0+
-   env this should be clean; mirror the §3 results.
+1. **Integer/Float-arm polymorphism** (biggest remaining cmp item).
+   `Group#already_counted_as_liberty?` `%3 == %2 [Integer][NilClass]`
+   still deopts ~50K (down from 138K). Cause: with an `Integer` in
+   the IC, `state.binop_type` returns `BinaryOpType::Integer`, so
+   `binary_cmp` takes the **numeric fast-path arm** (integer type
+   guard) — Parts 3-B/B/C only divert the `Other` arm. Fix idea:
+   when `polymorphic`, route the `Integer`/`Float` arms of
+   `binary_cmp`/`binary_cmp_br` to `emit_generic_cmp` too (the
+   opt_eq fast path already handles Fixnum==Fixnum inline; the
+   generic C-call handles Integer==Float/nil correctly). Re-check
+   the §6 invariant (the numeric arms' type guards must not remain
+   as class-variance deopts after recompile).
+2. **Arithmetic `binary_op` polymorphism.** `GameScorer#score_board`
+   / `score_empty_cutting_point` `%6 + %7 [Integer][Integer]` deopt
+   ~35K total (occasional nil). `binary_op` has no `polymorphic`
+   arg yet; the VM already records the POLY bit for BinOp
+   (`f11603a`). Mirror Part 3-B/B for `binary_op` (generic
+   `*_values` C-call, recompile-on-recv-miss). Same invariant check.
+3. **Polymorphic method-call PIC (handoff option A).** `.nil?`
+   (`Game.pass?`, `Enumerable#inject`), `.root?`
+   (`Node#backpropagate`) deopt as `POLYMORPHIC … FuncId` — general
+   MethodCall receiver polymorphism. Needs the N-way PIC / the
+   currently-dead `send_not_cached`
+   (`asmir/compile/method_call.rs`). Largest scope; deferred by the
+   original handoff. CRuby `--yjit` gets these via its send PIC,
+   which is much of its remaining lead.
+4. **Regression** in a benchmark env with optcarrot present:
+   `bin/test` (full test + coverage + benchmark diff + optcarrot).
+   §3 already shows lib `2053/0` + integration green under Ruby
+   4.0.4; mirror that.
 5. **PR** `claude/handoff-review-nyy4u` → `master`. Summarise Parts
-   3-B / B / C, the monotone-recompile safety invariant, and the
-   rubykon before/after numbers from step 1.
+   3-B / B / C, the monotone-recompile safety invariant (§6), and
+   the §3a before/after deopt + wall-time numbers. Be explicit that
+   it solves the `[Symbol][NilClass]` `==` storm and that items
+   1–3 above are the scoped-out follow-ups for the rest of the
+   rubykon↔YJIT gap.
+
+If a *wrong result* (not perf) ever shows in rubykon but not in the
+§3 correctness matrix, first suspects: Part C's immediate-tag check
+vs the `value.rs` tag table, and the Part B counter
+(`COUNT_DEOPT_RECOMPILE`) loop-vs-method-JIT interaction
+(`--features deopt`/`jit-log`).
 
 ---
 

--- a/doc/HANDOFF.md
+++ b/doc/HANDOFF.md
@@ -4,8 +4,10 @@ Branch: `claude/handoff-review-nyy4u`. Base: `master`.
 Last update: 2026-05-16. State: **Parts 3-B, B, C implemented,
 regression-verified, AND rubykon-measured (§3a): the targeted
 `[Symbol][NilClass]` `== nil` deopt storm collapses millions → 10
-(+1 recompile), ~7% best wall-time. Remaining: scoped-out follow-ups
-(§5 items 1–3) + PR.**
+(+1 recompile), ~7% best wall-time. One follow-up ("§5 item 1") was
+tried, measured, and reverted — it disproved its own premise and
+revealed the next bottleneck is class-version churn, not BinCmp
+polymorphism (§5a/§5b). Remaining: §5b investigation + PR (§5c).**
 
 > Rule: never push to `master`; this work stays on
 > `claude/handoff-review-nyy4u` and lands via PR. Verify the branch
@@ -266,31 +268,68 @@ full 10-run measurement — consistent.)
 Implementation, correctness, and rubykon measurement are **done**
 (§3, §3a). Parts 3-B/B/C fully solve the *targeted* problem (the
 `[Symbol][NilClass]` `== nil` deopt storm: millions → 10 + one
-recompile). The ~7% (not larger) wall-time gain is explained by the
-deopt-stats: rubykon's *remaining* hot deopts are other
-polymorphism classes the ratified **B-then-C / BinCmp-`Other`**
-scope deliberately did **not** cover. To close more of the gap vs
-CRuby `--yjit` (which inlines all of these via `opt_eq` + a
-send-PIC):
+recompile). The ~7% (not larger) wall-time gain is explained below.
 
-1. **Integer/Float-arm polymorphism** (biggest remaining cmp item).
-   `Group#already_counted_as_liberty?` `%3 == %2 [Integer][NilClass]`
-   still deopts ~50K (down from 138K). Cause: with an `Integer` in
-   the IC, `state.binop_type` returns `BinaryOpType::Integer`, so
-   `binary_cmp` takes the **numeric fast-path arm** (integer type
-   guard) — Parts 3-B/B/C only divert the `Other` arm. Fix idea:
-   when `polymorphic`, route the `Integer`/`Float` arms of
-   `binary_cmp`/`binary_cmp_br` to `emit_generic_cmp` too (the
-   opt_eq fast path already handles Fixnum==Fixnum inline; the
-   generic C-call handles Integer==Float/nil correctly). Re-check
-   the §6 invariant (the numeric arms' type guards must not remain
-   as class-variance deopts after recompile).
+### 5a. Investigated & rejected — "§5 item 1" (commit reverted)
+
+A first follow-up hypothesis was that
+`Group#already_counted_as_liberty?` (`%3 == %2`, ~50K residual
+deopts, the single largest remaining cmp deopt) deopted because
+`binop_type` returned `BinaryOpType::Integer` so `binary_cmp` took
+the numeric fast-path arm (integer type guard) instead of the
+`Other`/generic arm. A change routing the polymorphic
+`Integer`/`Float` arms to `emit_generic_cmp` was implemented
+(`bf91ecc`), correctness-verified, **measured, and reverted**
+(`bbdb8df`).
+
+**Why reverted — the hypothesis was wrong.** With the change the
+site *still* deopted ~50K (`50,550 → 49,833`); only the recorded
+operand-class label moved (`[Integer][NilClass]` →
+`[NilClass][NilClass]`). With the numeric/recv-class guards removed
+by `emit_generic_cmp`, the *only* deopt-capable instruction left on
+that path is `guard_class_version` (Part C's opt_eq fast path has
+no deopt; `handle_error` only fires on a C-call error, which
+`nil == nil` never hits). So **`already_counted_as_liberty?`'s
+~50K deopts are class-version-guard misses, i.e. class-version
+*churn*, not receiver/numeric polymorphism at all.** The change
+gave no deopt reduction and a slight wall-time *regression* (best
+738.9 → 755.0 ms — the per-call opt_eq tag-check overhead on the
+hot `Integer == Integer` path, with no offsetting deopt saving).
+Per "don't ship changes that don't earn their cost", it was
+reverted. The branch is back to the validated Parts 3-B/B/C state.
+
+> Lesson for the next continuation: confirm the *actual*
+> deopt-causing instruction (it is recorded at the cmp pc but may be
+> a guard `emit_generic_cmp`/the numeric arm inserted, not the cmp
+> itself) before optimising. `--features deopt` prints the deopt
+> reason symbol (`__version_guard`, `_bop_guard`, the operand value,
+> …) — use it to disambiguate.
+
+### 5b. The real remaining rubykon gap vs CRuby `--yjit`
+
+From §3a deopt-stats, what still dominates (none in the ratified
+B-then-C / BinCmp-`Other` scope):
+
+1. **Class-version churn.** `already_counted_as_liberty?` ~50K
+   class-version-guard deopts. Something in rubykon's MCTS hot path
+   keeps bumping the global class-version counter (suspects:
+   per-node `MCTS::Node`/`Root` object/singleton creation,
+   `define_method`, frozen/`extend`, or an inline-cache
+   invalidation feeding the class-version bump). Investigate with
+   `--features deopt` (confirm reason `__version_guard`) and
+   `--features profile` recompile stats; the fix is to stop the
+   churn (or make the class-version guard at a hot site
+   recompile-once like Part B rather than deopt-per-iter), **not**
+   more BinCmp polymorphism work. This is the highest-value next
+   item and is a *different subsystem* from Parts 3-B/B/C.
 2. **Arithmetic `binary_op` polymorphism.** `GameScorer#score_board`
    / `score_empty_cutting_point` `%6 + %7 [Integer][Integer]` deopt
-   ~35K total (occasional nil). `binary_op` has no `polymorphic`
-   arg yet; the VM already records the POLY bit for BinOp
-   (`f11603a`). Mirror Part 3-B/B for `binary_op` (generic
-   `*_values` C-call, recompile-on-recv-miss). Same invariant check.
+   ~35K total (occasional non-Integer). `binary_op` has no
+   `polymorphic` arg yet; the VM already records the POLY bit for
+   BinOp (`f11603a`). Mirror Part 3-B/B for `binary_op` (generic
+   `*_values` C-call, recompile-on-recv-miss, §6 invariant). NOTE:
+   given 5a, first confirm via `--features deopt` that these are
+   actually operand-type guards and not class-version churn too.
 3. **Polymorphic method-call PIC (handoff option A).** `.nil?`
    (`Game.pass?`, `Enumerable#inject`), `.root?`
    (`Node#backpropagate`) deopt as `POLYMORPHIC … FuncId` — general
@@ -299,16 +338,20 @@ send-PIC):
    (`asmir/compile/method_call.rs`). Largest scope; deferred by the
    original handoff. CRuby `--yjit` gets these via its send PIC,
    which is much of its remaining lead.
+
+### 5c. Ship the verified work
+
 4. **Regression** in a benchmark env with optcarrot present:
    `bin/test` (full test + coverage + benchmark diff + optcarrot).
    §3 already shows lib `2053/0` + integration green under Ruby
    4.0.4; mirror that.
 5. **PR** `claude/handoff-review-nyy4u` → `master`. Summarise Parts
-   3-B / B / C, the monotone-recompile safety invariant (§6), and
-   the §3a before/after deopt + wall-time numbers. Be explicit that
-   it solves the `[Symbol][NilClass]` `==` storm and that items
-   1–3 above are the scoped-out follow-ups for the rest of the
-   rubykon↔YJIT gap.
+   3-B / B / C, the monotone-recompile safety invariant (§6), the
+   §3a before/after deopt + wall-time numbers, and explicitly that
+   it solves the `[Symbol][NilClass]` `==` storm. List 5b items as
+   scoped-out follow-ups. The reverted 5a commit pair (`bf91ecc` +
+   `bbdb8df`) can stay in history or be dropped via interactive
+   rebase before the PR — either is fine; nothing depends on it.
 
 If a *wrong result* (not perf) ever shows in rubykon but not in the
 §3 correctness matrix, first suspects: Part C's immediate-tag check

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -816,11 +816,20 @@ impl Codegen {
         pc: BytecodePtr,
         wb: &WriteBack,
         reason: RecompileReason,
+        position: Option<BytecodePtr>,
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
-        self.side_exit_with_label(pc, wb, entry, false, Some(reason), loop_jit_spill_bytes, base)
+        self.side_exit_with_label(
+            pc,
+            wb,
+            entry,
+            false,
+            Some((reason, position)),
+            loop_jit_spill_bytes,
+            base,
+        )
     }
 
     ///
@@ -849,7 +858,7 @@ impl Codegen {
         wb: &WriteBack,
         entry: DestLabel,
         _is_evict: bool,
-        recompile: Option<RecompileReason>,
+        recompile: Option<(RecompileReason, Option<BytecodePtr>)>,
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
@@ -898,7 +907,7 @@ impl Codegen {
         // the generic op a few times first (so the VM has set the
         // site's POLY bit) before we recompile; once exhausted it
         // never recompiles again (monotone / one-shot).
-        if let Some(reason) = recompile {
+        if let Some((reason, position)) = recompile {
             let recompile_lbl = self.jit.label();
             let skip = self.jit.label();
             let counter = self.jit.data_i32(COUNT_DEOPT_RECOMPILE);
@@ -908,7 +917,7 @@ impl Codegen {
                 subl [rip + counter], 1;
                 jne  skip;
             );
-            self.gen_recompile(Some(pc), recompile_lbl, reason, None);
+            self.gen_recompile(position, recompile_lbl, reason, None);
             monoasm!( &mut self.jit,
             skip:
             );

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -799,7 +799,28 @@ impl Codegen {
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
-        self.side_exit_with_label(pc, wb, entry, false, loop_jit_spill_bytes, base)
+        self.side_exit_with_label(pc, wb, entry, false, None, loop_jit_spill_bytes, base)
+    }
+
+    ///
+    /// Like `gen_deopt_with_label`, but after the deopt write-back
+    /// (so all live Ruby values are on the LFP and GC-safe) and
+    /// before falling back to the interpreter, recompile the
+    /// method/loop with *reason* once a small miss counter is
+    /// exhausted. Used for the receiver-class guard of
+    /// monomorphic-compiled BinCmp sites so they flip to the
+    /// non-deopting polymorphic path (Part B).
+    ///
+    fn gen_recompile_deopt_with_label(
+        &mut self,
+        pc: BytecodePtr,
+        wb: &WriteBack,
+        reason: RecompileReason,
+        entry: DestLabel,
+        loop_jit_spill_bytes: usize,
+        base: usize,
+    ) {
+        self.side_exit_with_label(pc, wb, entry, false, Some(reason), loop_jit_spill_bytes, base)
     }
 
     ///
@@ -813,7 +834,7 @@ impl Codegen {
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
-        self.side_exit_with_label(pc, wb, entry, true, loop_jit_spill_bytes, base)
+        self.side_exit_with_label(pc, wb, entry, true, None, loop_jit_spill_bytes, base)
     }
 
     ///
@@ -828,6 +849,7 @@ impl Codegen {
         wb: &WriteBack,
         entry: DestLabel,
         _is_evict: bool,
+        recompile: Option<RecompileReason>,
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
@@ -867,6 +889,28 @@ impl Codegen {
                 movq rdx, r13;
                 movq rax, (crate::globals::log_deoptimize);
                 call rax;
+            );
+        }
+        // Part B: counter-gated, one-shot recompile. Emitted AFTER
+        // the write-back above (LFP holds all live Ruby values, so a
+        // GC inside `jit_recompile_loop` is safe) and BEFORE the
+        // interpreter fallback. The counter lets the interpreter run
+        // the generic op a few times first (so the VM has set the
+        // site's POLY bit) before we recompile; once exhausted it
+        // never recompiles again (monotone / one-shot).
+        if let Some(reason) = recompile {
+            let recompile_lbl = self.jit.label();
+            let skip = self.jit.label();
+            let counter = self.jit.data_i32(COUNT_DEOPT_RECOMPILE);
+            monoasm!( &mut self.jit,
+                cmpl [rip + counter], 0;
+                jle  skip;
+                subl [rip + counter], 1;
+                jne  skip;
+            );
+            self.gen_recompile(Some(pc), recompile_lbl, reason, None);
+            monoasm!( &mut self.jit,
+            skip:
             );
         }
         let fetch = self.vm_fetch();

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -505,6 +505,32 @@ impl AsmIr {
         });
     }
 
+    ///
+    /// `==` / `!=` with a YJIT-`opt_eq`-style inline fast path: when
+    /// both operands are non-heap, non-flonum immediates (Fixnum /
+    /// nil / true / false / Symbol) the result is exactly bit
+    /// equality; anything else (Float, heap, mixed numeric, custom
+    /// `==`) falls back to the generic `cmp_*_values` C-call. No
+    /// receiver-class guard (Part C, layered on Part 3-B).
+    ///
+    pub(super) fn opt_eq_cmp(
+        &mut self,
+        state: &AbstractFrame,
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
+        func: crate::executor::BinaryOpFn,
+    ) {
+        let using_xmm = state.get_using_xmm();
+        self.push(AsmInst::OptEqCmp {
+            lhs,
+            rhs,
+            kind,
+            func,
+            using_xmm,
+        });
+    }
+
     pub(super) fn undef_method(&mut self, state: &AbstractFrame, undef: IdentId) {
         let using_xmm = state.get_using_xmm();
         let error = self.new_error(state);
@@ -1290,6 +1316,20 @@ pub(super) enum AsmInst {
     GenericBinOp {
         lhs: SlotId,
         rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    },
+
+    ///
+    /// `==` / `!=` with an inline immediate fast path (YJIT
+    /// `opt_eq` style), generic `cmp_*_values` C-call fallback.
+    /// *kind* is `CmpKind::Eq` or `CmpKind::Ne`. Result `Value`
+    /// (fast path) or `Option<Value>` (slow path) in rax.
+    ///
+    OptEqCmp {
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
         func: crate::executor::BinaryOpFn,
         using_xmm: UsingXmm,
     },

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -163,6 +163,27 @@ impl AsmIr {
         self.new_deopt_with_pc(state, pc)
     }
 
+    ///
+    /// Like `new_deopt`, but the side exit recompiles the method/loop
+    /// after a few misses (reason *reason*) before continuing to fall
+    /// back to the interpreter. Used for the receiver-class guard of
+    /// monomorphic-compiled BinCmp sites (Part B).
+    ///
+    pub(crate) fn new_recompile_deopt(
+        &mut self,
+        state: &AbstractFrame,
+        reason: RecompileReason,
+    ) -> AsmDeopt {
+        let pc = state.pc();
+        let i = self.new_label(SideExit::RecompileDeoptimize(
+            pc,
+            state.get_write_back(),
+            reason,
+        ));
+        self.had_deopt = true;
+        AsmDeopt(i)
+    }
+
     pub(crate) fn new_error_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmError {
         let i = self.new_label(SideExit::Error(pc, state.get_write_back()));
         AsmError(i)
@@ -1768,6 +1789,15 @@ impl AsmInst {
 pub enum SideExit {
     Evict(Option<(BytecodePtr, WriteBack)>),
     Deoptimize(BytecodePtr, WriteBack),
+    ///
+    /// A deopt that, after a small number of misses, recompiles the
+    /// whole method/loop with the given reason instead of falling
+    /// back to the interpreter forever. Used as the
+    /// receiver-class-guard miss target for monomorphic-compiled
+    /// BinCmp sites so they flip to the non-deopting polymorphic
+    /// path once the VM has observed class variance (Part B).
+    ///
+    RecompileDeoptimize(BytecodePtr, WriteBack, RecompileReason),
     Error(BytecodePtr, WriteBack),
 }
 
@@ -1811,6 +1841,18 @@ impl Codegen {
                         deopt_table.insert(t, label.clone());
                         label
                     }
+                }
+                SideExit::RecompileDeoptimize(pc, wb, reason) => {
+                    let label = self.jit.label();
+                    self.gen_recompile_deopt_with_label(
+                        pc,
+                        &wb,
+                        reason,
+                        label.clone(),
+                        loop_jit_spill_bytes,
+                        base,
+                    );
+                    label
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -169,16 +169,22 @@ impl AsmIr {
     /// back to the interpreter. Used for the receiver-class guard of
     /// monomorphic-compiled BinCmp sites (Part B).
     ///
+    /// *position* is the JIT entry position (`None` for a full
+    /// method/block JIT, `Some(loop-header pc)` for a loop JIT) — the
+    /// recompile target, NOT the deopt site `pc`.
+    ///
     pub(crate) fn new_recompile_deopt(
         &mut self,
         state: &AbstractFrame,
         reason: RecompileReason,
+        position: Option<BytecodePtr>,
     ) -> AsmDeopt {
         let pc = state.pc();
         let i = self.new_label(SideExit::RecompileDeoptimize(
             pc,
             state.get_write_back(),
             reason,
+            position,
         ));
         self.had_deopt = true;
         AsmDeopt(i)
@@ -1797,7 +1803,7 @@ pub enum SideExit {
     /// BinCmp sites so they flip to the non-deopting polymorphic
     /// path once the VM has observed class variance (Part B).
     ///
-    RecompileDeoptimize(BytecodePtr, WriteBack, RecompileReason),
+    RecompileDeoptimize(BytecodePtr, WriteBack, RecompileReason, Option<BytecodePtr>),
     Error(BytecodePtr, WriteBack),
 }
 
@@ -1842,12 +1848,13 @@ impl Codegen {
                         label
                     }
                 }
-                SideExit::RecompileDeoptimize(pc, wb, reason) => {
+                SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
                     let label = self.jit.label();
                     self.gen_recompile_deopt_with_label(
                         pc,
                         &wb,
                         reason,
+                        position,
                         label.clone(),
                         loop_jit_spill_bytes,
                         base,

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -462,6 +462,22 @@ impl AsmIr {
         });
     }
 
+    pub(super) fn generic_binop(
+        &mut self,
+        state: &AbstractFrame,
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+    ) {
+        let using_xmm = state.get_using_xmm();
+        self.push(AsmInst::GenericBinOp {
+            lhs,
+            rhs,
+            func,
+            using_xmm,
+        });
+    }
+
     pub(super) fn undef_method(&mut self, state: &AbstractFrame, undef: IdentId) {
         let using_xmm = state.get_using_xmm();
         let error = self.new_error(state);
@@ -1230,6 +1246,27 @@ pub(super) enum AsmInst {
         brkind: BrKind,
         branch_dest: JitLabel,
     },
+    ///
+    /// Generic binary operation through a `BinaryOpFn` C helper.
+    ///
+    /// Calls `func(vm, globals, lhs, rhs) -> Option<Value>`; the
+    /// result (or 0 = error) is left in rax. Emits **no**
+    /// receiver-class guard, so the site never deopts on receiver
+    /// class variance — used for polymorphic BinCmp/BinOp.
+    ///
+    /// ### out
+    /// - rax: result `Option<Value>`
+    ///
+    /// ### destroy
+    /// - caller save registers
+    ///
+    GenericBinOp {
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    },
+
     ///
     /// Compare `lhs and `rhs` with "===" and return the result in rax.
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -603,6 +603,15 @@ impl Codegen {
             } => {
                 self.generic_binop(lhs, rhs, func, using_xmm);
             }
+            AsmInst::OptEqCmp {
+                lhs,
+                rhs,
+                kind,
+                func,
+                using_xmm,
+            } => {
+                self.opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
+            }
             AsmInst::ArrayTEq {
                 lhs,
                 rhs,
@@ -1012,6 +1021,75 @@ impl Codegen {
             call rax;
         );
         self.xmm_restore(using_xmm);
+    }
+
+    ///
+    /// `==` / `!=` with an inline immediate fast path.
+    ///
+    /// `rdx = lhs`, `rcx = rhs`. If BOTH are non-heap, non-flonum
+    /// immediates (Fixnum / nil / true / false / Symbol) the Ruby
+    /// `==`/`!=` result is exactly bit (identity) equality, so it is
+    /// produced inline. Float (`-0.0`/`0.0`, `NaN`), heap (`String`
+    /// content, custom `==`), `BigInt`, and mixed numeric all fall
+    /// through to the generic `cmp_*_values` C-call, which is
+    /// correct for them. No receiver-class guard.
+    ///
+    /// ### out
+    /// - rax: bool `Value` (fast path) or `Option<Value>` (slow)
+    ///
+    fn opt_eq_cmp(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) {
+        self.load_rdx(lhs);
+        self.load_rcx(rhs);
+        let slow = self.jit.label();
+        let done = self.jit.label();
+        // Heap iff (bits & 0b111) == 0; Flonum iff (bits & 0b011) == 0b010.
+        // Either operand heap/flonum -> generic C-call.
+        monoasm!( &mut self.jit,
+            movq rax, rdx;
+            andq rax, 0b111;
+            jz   slow;
+            movq rax, rdx;
+            andq rax, 0b011;
+            cmpq rax, 0b010;
+            jeq  slow;
+            movq rax, rcx;
+            andq rax, 0b111;
+            jz   slow;
+            movq rax, rcx;
+            andq rax, 0b011;
+            cmpq rax, 0b010;
+            jeq  slow;
+            // both identity-comparable immediates: result = bit-eq
+            xorq rax, rax;
+            cmpq rdx, rcx;
+        );
+        match kind {
+            CmpKind::Eq => self.set_eq(),
+            CmpKind::Ne => self.set_ne(),
+            _ => unreachable!("opt_eq_cmp only handles Eq/Ne"),
+        }
+        monoasm!( &mut self.jit,
+            jmp  done;
+        slow:
+        );
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (func);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        monoasm!( &mut self.jit,
+        done:
+        );
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -595,6 +595,14 @@ impl Codegen {
                 self.handle_error(&labels[error]);
             }
 
+            AsmInst::GenericBinOp {
+                lhs,
+                rhs,
+                func,
+                using_xmm,
+            } => {
+                self.generic_binop(lhs, rhs, func, using_xmm);
+            }
             AsmInst::ArrayTEq {
                 lhs,
                 rhs,
@@ -976,6 +984,31 @@ impl Codegen {
             movq rdi, rbx;
             movq rsi, r12;
             movq rax, (runtime::array_teq);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+    }
+
+    ///
+    /// Call a generic `BinaryOpFn` C helper with no receiver-class
+    /// guard. Mirrors the VM's `call_binop` calling convention
+    /// (rdi=&Executor, rsi=&Globals, rdx=lhs, rcx=rhs); result
+    /// `Option<Value>` in rax.
+    ///
+    fn generic_binop(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) {
+        self.xmm_save(using_xmm);
+        self.load_rdx(lhs);
+        self.load_rcx(rhs);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (func);
             call rax;
         );
         self.xmm_restore(using_xmm);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -389,7 +389,20 @@ impl<'a> JitContext<'a> {
                 lhs,
                 rhs,
                 ic,
-            } => return self.binary_cmp(state, ir, kind, dst, lhs, rhs, ic, bc_pos),
+                polymorphic,
+            } => {
+                return self.binary_cmp(
+                    state,
+                    ir,
+                    kind,
+                    dst,
+                    lhs,
+                    rhs,
+                    ic,
+                    polymorphic,
+                    bc_pos,
+                )
+            }
             TraceIr::BinCmpBr {
                 kind,
                 _dst: _,
@@ -398,9 +411,21 @@ impl<'a> JitContext<'a> {
                 disp,
                 brkind,
                 ic,
+                polymorphic,
             } => {
                 let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
-                return self.binary_cmp_br(state, ir, kind, lhs, rhs, dest_bb, brkind, ic, bc_pos);
+                return self.binary_cmp_br(
+                    state,
+                    ir,
+                    kind,
+                    lhs,
+                    rhs,
+                    dest_bb,
+                    brkind,
+                    ic,
+                    polymorphic,
+                    bc_pos,
+                );
             }
             TraceIr::Index {
                 _dst: _,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -802,7 +802,7 @@ impl<'a> JitContext<'a> {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, recv);
             assert_eq!(self.store[callid].pos_num, 0);
-            self.compile_method_call(state, ir, recv_class, None, func_id, callid)
+            self.compile_method_call(state, ir, recv_class, None, func_id, callid, false)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::MethodNotFound))
         }
@@ -818,13 +818,22 @@ impl<'a> JitContext<'a> {
         rhs_class: Option<ClassId>,
         name: impl Into<IdentId>,
         bc_pos: BcIndex,
+        recompile_on_recv_miss: bool,
     ) -> JitResult<CompileResult> {
         if let Some(fid) = self.jit_check_method(lhs_class, name.into()) {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, lhs);
             assert_eq!(self.store[callid].args, rhs);
             assert_eq!(self.store[callid].pos_num, 1);
-            self.compile_method_call(state, ir, lhs_class, rhs_class, fid, callid)
+            self.compile_method_call(
+                state,
+                ir,
+                lhs_class,
+                rhs_class,
+                fid,
+                callid,
+                recompile_on_recv_miss,
+            )
         } else {
             Ok(CompileResult::Recompile(RecompileReason::MethodNotFound))
         }
@@ -848,7 +857,7 @@ impl<'a> JitContext<'a> {
             assert_eq!(self.store[callid].args, idx);
             assert_eq!(self.store[callid].args + 1usize, src);
             assert_eq!(self.store[callid].pos_num, 2);
-            self.compile_method_call(state, ir, recv_class, idx_class, fid, callid)
+            self.compile_method_call(state, ir, recv_class, idx_class, fid, callid, false)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::MethodNotFound))
         }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -120,7 +120,15 @@ impl<'a> JitContext<'a> {
         state.write_back_slots(ir, &[lhs, rhs]);
         self.guard_class_version(state, ir, true);
         let error = ir.new_error(state);
-        ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind));
+        // Part C: `==`/`!=` get an inline immediate fast path with a
+        // generic C-call fallback; other cmp kinds use the plain
+        // generic C-call (Part 3-B).
+        match kind {
+            CmpKind::Eq | CmpKind::Ne => {
+                ir.opt_eq_cmp(state, lhs, rhs, kind, cmp_generic_fn(kind))
+            }
+            _ => ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind)),
+        }
         ir.handle_error(error);
         // The C helper can run arbitrary Ruby (user-defined `==`,
         // `coerce`); invalidate cached guards so subsequent

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -69,31 +69,36 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) => {
+            BinaryOpType::Integer(mode) if !polymorphic => {
                 state.gen_cmp_integer(ir, kind, dst, mode);
                 Ok(CompileResult::Continue)
             }
-            BinaryOpType::Float(info) => {
+            BinaryOpType::Float(info) if !polymorphic => {
                 state.gen_cmp_float(ir, dst, info, kind);
                 Ok(CompileResult::Continue)
             }
             BinaryOpType::Other(None, _) => {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
-            BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
-                    state.def_rax2acc(ir, dst);
-                    Ok(CompileResult::Continue)
-                } else {
-                    // Monomorphic compile (POLY not yet set). Make the
-                    // recv-class guard recompile-on-miss so the site
-                    // flips to the generic path once the VM observes
-                    // class variance (Part B).
-                    self.call_binary_method(
-                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
-                    )
-                }
+            BinaryOpType::Other(Some(lhs_class), rhs_class) if !polymorphic => {
+                // Monomorphic compile (POLY not yet set). Make the
+                // recv-class guard recompile-on-miss so the site
+                // flips to the generic path once the VM observes
+                // class variance (Part B).
+                self.call_binary_method(
+                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
+                )
+            }
+            // Polymorphic & cached (Integer / Float / Other(Some)):
+            // never specialize on a numeric/class fast path — each
+            // would deopt on class variance, defeating Part B's
+            // monotone invariant. The generic path is non-deopting;
+            // Part C keeps Fixnum/nil/true/false/Symbol inline, so
+            // an Integer↔nil site stays fast without the deopt.
+            _ => {
+                self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                state.def_rax2acc(ir, dst);
+                Ok(CompileResult::Continue)
             }
         }
     }
@@ -152,7 +157,7 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) => {
+            BinaryOpType::Integer(mode) if !polymorphic => {
                 if let Some(result) = state.check_concrete_i64_cmpbr(mode, kind, brkind, dest_bb) {
                     return Ok(result);
                 }
@@ -162,7 +167,7 @@ impl<'a> JitContext<'a> {
                 self.new_side_branch(src_idx, dest_bb, state.clone(), dest);
                 Ok(CompileResult::Continue)
             }
-            BinaryOpType::Float(info) => {
+            BinaryOpType::Float(info) if !polymorphic => {
                 if let Some(result) =
                     state.check_concrete_f64_cmpbr(lhs, rhs, kind, brkind, dest_bb)
                 {
@@ -178,13 +183,7 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(None, _) => {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
-            BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
-                    let src_idx = bc_pos + 1;
-                    self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
-                    return Ok(CompileResult::Continue);
-                }
+            BinaryOpType::Other(Some(lhs_class), rhs_class) if !polymorphic => {
                 // Monomorphic compile (POLY not yet set): recompile
                 // on recv-class-guard miss so the site flips to the
                 // generic path once class variance is observed.
@@ -198,6 +197,14 @@ impl<'a> JitContext<'a> {
                     self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
                 }
                 Ok(res)
+            }
+            // Polymorphic & cached: non-deopting generic compare +
+            // conditional branch (see `binary_cmp`).
+            _ => {
+                self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                let src_idx = bc_pos + 1;
+                self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
+                Ok(CompileResult::Continue)
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -65,6 +65,7 @@ impl<'a> JitContext<'a> {
         lhs: SlotId,
         rhs: SlotId,
         ic: Option<(ClassId, ClassId)>,
+        polymorphic: bool,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
@@ -80,6 +81,7 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                let _ = polymorphic;
                 self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
             }
         }
@@ -95,8 +97,10 @@ impl<'a> JitContext<'a> {
         dest_bb: BasicBlockId,
         brkind: BrKind,
         ic: Option<(ClassId, ClassId)>,
+        polymorphic: bool,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
+        let _ = polymorphic;
         match state.binop_type(lhs, rhs, ic) {
             BinaryOpType::Integer(mode) => {
                 if let Some(result) = state.check_concrete_i64_cmpbr(mode, kind, brkind, dest_bb) {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -33,7 +33,7 @@ impl<'a> JitContext<'a> {
                 match lhs_class {
                     None => Ok(CompileResult::Recompile(RecompileReason::NotCached)),
                     Some(lhs_class) => self.call_binary_method(
-                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos,
+                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
                     ),
                 }
             }
@@ -49,9 +49,9 @@ impl<'a> JitContext<'a> {
                 BinaryOpType::Other(None, _) => {
                     Ok(CompileResult::Recompile(RecompileReason::NotCached))
                 }
-                BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                    self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
-                }
+                BinaryOpType::Other(Some(lhs_class), rhs_class) => self.call_binary_method(
+                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
+                ),
             },
         }
     }
@@ -86,7 +86,13 @@ impl<'a> JitContext<'a> {
                     state.def_rax2acc(ir, dst);
                     Ok(CompileResult::Continue)
                 } else {
-                    self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
+                    // Monomorphic compile (POLY not yet set). Make the
+                    // recv-class guard recompile-on-miss so the site
+                    // flips to the generic path once the VM observes
+                    // class variance (Part B).
+                    self.call_binary_method(
+                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
+                    )
                 }
             }
         }
@@ -171,8 +177,12 @@ impl<'a> JitContext<'a> {
                     self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
                     return Ok(CompileResult::Continue);
                 }
-                let res = self
-                    .call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)?;
+                // Monomorphic compile (POLY not yet set): recompile
+                // on recv-class-guard miss so the site flips to the
+                // generic path once class variance is observed.
+                let res = self.call_binary_method(
+                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
+                )?;
                 if let CompileResult::Continue = res {
                     let src_idx = bc_pos + 1;
                     state.unset_class_version_guard();

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -81,10 +81,47 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                let _ = polymorphic;
-                self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
+                if polymorphic {
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    state.def_rax2acc(ir, dst);
+                    Ok(CompileResult::Continue)
+                } else {
+                    self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)
+                }
             }
         }
+    }
+
+    ///
+    /// Emit a non-deopting polymorphic comparison: a generic
+    /// `cmp_*_values` C-call with **no receiver-class guard**, so the
+    /// site never side-exits on receiver class variance (the rubykon
+    /// `== nil` vs `== Symbol` pattern). The class-version guard is
+    /// kept (it tracks the global class-version counter, not the
+    /// receiver class, so it only fires on a real `==`/`<=>`
+    /// redefinition — never on class variance, which preserves the
+    /// Part B monotone-recompile invariant). Result `Option<Value>`
+    /// is left in rax.
+    ///
+    fn emit_generic_cmp(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        kind: CmpKind,
+        lhs: SlotId,
+        rhs: SlotId,
+    ) {
+        state.write_back_slots(ir, &[lhs, rhs]);
+        self.guard_class_version(state, ir, true);
+        let error = ir.new_error(state);
+        ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind));
+        ir.handle_error(error);
+        // The C helper can run arbitrary Ruby (user-defined `==`,
+        // `coerce`); invalidate cached guards so subsequent
+        // instructions re-establish them.
+        state.unset_class_version_guard();
+        state.unset_const_version_guard();
+        state.unset_side_effect_guard();
     }
 
     pub(super) fn binary_cmp_br(
@@ -100,7 +137,6 @@ impl<'a> JitContext<'a> {
         polymorphic: bool,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
-        let _ = polymorphic;
         match state.binop_type(lhs, rhs, ic) {
             BinaryOpType::Integer(mode) => {
                 if let Some(result) = state.check_concrete_i64_cmpbr(mode, kind, brkind, dest_bb) {
@@ -129,6 +165,12 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                if polymorphic {
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    let src_idx = bc_pos + 1;
+                    self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
+                    return Ok(CompileResult::Continue);
+                }
                 let res = self
                     .call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos)?;
                 if let CompileResult::Continue = res {
@@ -140,6 +182,26 @@ impl<'a> JitContext<'a> {
                 Ok(res)
             }
         }
+    }
+}
+
+///
+/// The generic `Option<Value>`-returning C comparison helper for
+/// *kind* — the same `cmp_*_values` functions the VM's generic
+/// binop path calls. These dispatch the fixnum/float fast paths
+/// internally and fall back to live method lookup for heap objects,
+/// so they never require a receiver-class guard.
+///
+fn cmp_generic_fn(kind: CmpKind) -> crate::executor::BinaryOpFn {
+    use crate::executor::op;
+    match kind {
+        CmpKind::Eq => op::cmp_eq_values,
+        CmpKind::Ne => op::cmp_ne_values,
+        CmpKind::Lt => op::cmp_lt_values,
+        CmpKind::Le => op::cmp_le_values,
+        CmpKind::Gt => op::cmp_gt_values,
+        CmpKind::Ge => op::cmp_ge_values,
+        CmpKind::TEq => op::cmp_teq_values,
     }
 }
 

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -69,36 +69,31 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) if !polymorphic => {
+            BinaryOpType::Integer(mode) => {
                 state.gen_cmp_integer(ir, kind, dst, mode);
                 Ok(CompileResult::Continue)
             }
-            BinaryOpType::Float(info) if !polymorphic => {
+            BinaryOpType::Float(info) => {
                 state.gen_cmp_float(ir, dst, info, kind);
                 Ok(CompileResult::Continue)
             }
             BinaryOpType::Other(None, _) => {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
-            BinaryOpType::Other(Some(lhs_class), rhs_class) if !polymorphic => {
-                // Monomorphic compile (POLY not yet set). Make the
-                // recv-class guard recompile-on-miss so the site
-                // flips to the generic path once the VM observes
-                // class variance (Part B).
-                self.call_binary_method(
-                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
-                )
-            }
-            // Polymorphic & cached (Integer / Float / Other(Some)):
-            // never specialize on a numeric/class fast path — each
-            // would deopt on class variance, defeating Part B's
-            // monotone invariant. The generic path is non-deopting;
-            // Part C keeps Fixnum/nil/true/false/Symbol inline, so
-            // an Integer↔nil site stays fast without the deopt.
-            _ => {
-                self.emit_generic_cmp(state, ir, kind, lhs, rhs);
-                state.def_rax2acc(ir, dst);
-                Ok(CompileResult::Continue)
+            BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                if polymorphic {
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    state.def_rax2acc(ir, dst);
+                    Ok(CompileResult::Continue)
+                } else {
+                    // Monomorphic compile (POLY not yet set). Make the
+                    // recv-class guard recompile-on-miss so the site
+                    // flips to the generic path once the VM observes
+                    // class variance (Part B).
+                    self.call_binary_method(
+                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, true,
+                    )
+                }
             }
         }
     }
@@ -157,7 +152,7 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) if !polymorphic => {
+            BinaryOpType::Integer(mode) => {
                 if let Some(result) = state.check_concrete_i64_cmpbr(mode, kind, brkind, dest_bb) {
                     return Ok(result);
                 }
@@ -167,7 +162,7 @@ impl<'a> JitContext<'a> {
                 self.new_side_branch(src_idx, dest_bb, state.clone(), dest);
                 Ok(CompileResult::Continue)
             }
-            BinaryOpType::Float(info) if !polymorphic => {
+            BinaryOpType::Float(info) => {
                 if let Some(result) =
                     state.check_concrete_f64_cmpbr(lhs, rhs, kind, brkind, dest_bb)
                 {
@@ -183,7 +178,13 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(None, _) => {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
-            BinaryOpType::Other(Some(lhs_class), rhs_class) if !polymorphic => {
+            BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                if polymorphic {
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    let src_idx = bc_pos + 1;
+                    self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
+                    return Ok(CompileResult::Continue);
+                }
                 // Monomorphic compile (POLY not yet set): recompile
                 // on recv-class-guard miss so the site flips to the
                 // generic path once class variance is observed.
@@ -197,14 +198,6 @@ impl<'a> JitContext<'a> {
                     self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
                 }
                 Ok(res)
-            }
-            // Polymorphic & cached: non-deopting generic compare +
-            // conditional branch (see `binary_cmp`).
-            _ => {
-                self.emit_generic_cmp(state, ir, kind, lhs, rhs);
-                let src_idx = bc_pos + 1;
-                self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
-                Ok(CompileResult::Continue)
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -21,6 +21,7 @@ impl<'a> JitContext<'a> {
                 idx_class,
                 IdentId::_INDEX,
                 bc_pos,
+                false,
             );
         }
         return Ok(CompileResult::Recompile(RecompileReason::NotCached));

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -292,7 +292,12 @@ impl<'a> JitContext<'a> {
     /// ### destroy
     /// - rax
     ///
-    fn guard_class_version(&self, state: &mut AbstractState, ir: &mut AsmIr, with_recovery: bool) {
+    pub(super) fn guard_class_version(
+        &self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        with_recovery: bool,
+    ) {
         if state.class_version_guard() {
             return;
         }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -46,7 +46,7 @@ impl<'a> JitContext<'a> {
                 return Ok(CompileResult::Recompile(RecompileReason::NotCached));
             }
         };
-        self.compile_method_call(state, ir, recv_class, None, func_id, callid)
+        self.compile_method_call(state, ir, recv_class, None, func_id, callid, false)
     }
 
     ///
@@ -60,6 +60,11 @@ impl<'a> JitContext<'a> {
         arg_class: Option<ClassId>,
         func_id: FuncId,
         callid: CallSiteId,
+        // When the receiver-class guard misses, recompile (so the
+        // site flips to the non-deopting polymorphic path) instead
+        // of plain-deopting forever. Only set for monomorphic-
+        // compiled BinCmp sites, which have such a path (Part B).
+        recompile_on_recv_miss: bool,
     ) -> JitResult<CompileResult> {
         let callsite = &self.store[callid];
         self.inline_method_cache
@@ -94,7 +99,11 @@ impl<'a> JitContext<'a> {
 
         // receiver class guard
         if state.class(recv) != Some(recv_class) {
-            let deopt = ir.new_deopt(state);
+            let deopt = if recompile_on_recv_miss {
+                ir.new_recompile_deopt(state, RecompileReason::BecamePolymorphic)
+            } else {
+                ir.new_deopt(state)
+            };
             state.load(ir, recv, GP::Rdi);
             state.guard_class(ir, recv, GP::Rdi, recv_class, deopt);
         }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -99,8 +99,16 @@ impl<'a> JitContext<'a> {
 
         // receiver class guard
         if state.class(recv) != Some(recv_class) {
-            let deopt = if recompile_on_recv_miss {
-                ir.new_recompile_deopt(state, RecompileReason::BecamePolymorphic)
+            // Specialized JIT recompiles via an idx, not a position;
+            // keep it on the plain deopt path (no Part B there).
+            let use_recompile = recompile_on_recv_miss
+                && !matches!(self.jit_type(), JitType::Specialized { .. });
+            let deopt = if use_recompile {
+                ir.new_recompile_deopt(
+                    state,
+                    RecompileReason::BecamePolymorphic,
+                    self.position(),
+                )
             } else {
                 ir.new_deopt(state)
             };

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -151,6 +151,7 @@ pub(crate) enum TraceIr {
         lhs: SlotId,
         rhs: SlotId,
         ic: Option<(ClassId, ClassId)>,
+        polymorphic: bool,
     },
     BinCmpBr {
         kind: crate::ast::CmpKind,
@@ -160,6 +161,7 @@ pub(crate) enum TraceIr {
         disp: i32,
         brkind: BrKind,
         ic: Option<(ClassId, ClassId)>,
+        polymorphic: bool,
     },
     ArrayTEq {
         lhs: SlotId,
@@ -566,6 +568,7 @@ impl TraceIr {
                         lhs,
                         rhs,
                         ic,
+                        polymorphic: pc.opcode_sub() == 1,
                     }
                 }
 
@@ -607,6 +610,7 @@ impl TraceIr {
                         disp,
                         brkind,
                         ic,
+                        polymorphic: pc.opcode_sub() == 1,
                     }
                 }
                 160..=170 => {
@@ -724,10 +728,12 @@ impl TraceIr {
             rhs: SlotId,
             class: impl Into<Option<(ClassId, ClassId)>>,
             optimizable: bool,
+            polymorphic: bool,
         ) -> String {
             let class: Option<(ClassId, ClassId)> = class.into();
             let s = format!(
-                "{}{} = {:?} {:?} {:?}",
+                "{}{}{} = {:?} {:?} {:?}",
+                if polymorphic { "POLY " } else { "" },
                 optstr(optimizable),
                 ret_str(dst),
                 lhs,
@@ -937,15 +943,17 @@ impl TraceIr {
                 lhs,
                 rhs,
                 ic,
-            } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), false),
+                polymorphic,
+            } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), false, polymorphic),
             TraceIr::BinCmpBr {
                 kind,
                 _dst: dst,
                 lhs,
                 rhs,
                 ic,
+                polymorphic,
                 ..
-            } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), true),
+            } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), true, polymorphic),
 
             TraceIr::ArrayTEq { lhs, rhs } => {
                 format!("{lhs:?} = *{lhs:?} === {rhs:?}")

--- a/monoruby/src/codegen/vmgen.rs
+++ b/monoruby/src/codegen/vmgen.rs
@@ -7,6 +7,13 @@ pub mod init_method;
 mod method_call;
 mod variables;
 
+/// Byte offset (relative to `r13`, which points at the *next* bytecode)
+/// of the current instruction's `opcode_sub` byte. Mirrors the constant
+/// of the same name in `method_call.rs`; writing `1` here marks the
+/// call site polymorphic so the JIT can read it back via
+/// `BytecodePtr::opcode_sub()`.
+const OPCODE_SUB: i64 = 7 - 16;
+
 macro_rules! vm_cmp_opt {
   ($op:ident) => {
       paste! {
@@ -528,14 +535,36 @@ impl Codegen {
     ///
     fn vm_save_binary_class(&mut self) {
         let get_class = self.get_class.clone();
+        let skip = self.jit.label();
+        let set_poly = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
+            // r8 <- cached lhs class (0 if the inline cache is empty)
+            movl  r8, [r13 - 8];
             movl  [r13 - 8], rax;
             xchgq rdi, rsi;
             //movq  rdi, rsi;
             call  get_class;
+            // r9 <- cached rhs class
+            movl  r9, [r13 - 4];
             movl  [r13 - 4], rax;
             xchgq rdi, rsi;
+            // Polymorphic detection: once the cache is populated
+            // (cached lhs class != 0), if either operand's class
+            // differs from what was cached, mark this binop/cmp site
+            // polymorphic via opcode_sub so the JIT emits a
+            // non-deoptimizing dispatch instead of a monomorphic
+            // class guard.
+            testq r8, r8;
+            jeq   skip;
+            cmpl  r8, [r13 - 8];
+            jne   set_poly;
+            cmpl  r9, [r13 - 4];
+            jne   set_poly;
+            jmp   skip;
+        set_poly:
+            movb  [r13 + (OPCODE_SUB)], 1;
+        skip:
         };
     }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2443,6 +2443,12 @@ pub enum RecompileReason {
     MethodNotFound = 1,
     IvarIdNotFound = 2,
     ClassVersionGuardFailed = 3,
+    /// A monomorphic-compiled BinCmp site's receiver-class guard
+    /// missed after the VM flagged the site polymorphic (POLY bit).
+    /// Recompiling lets `binary_cmp` re-emit it on the non-deopting
+    /// generic-C-call path. Monotone & one-shot: the recompiled site
+    /// has no receiver-class guard, so it can never re-trigger.
+    BecamePolymorphic = 4,
 }
 
 struct Root<'a, 'b> {


### PR DESCRIPTION
## Summary

Fixes the rubykon deopt storm: a `==`/`!=` site whose receiver class
oscillates (e.g. `board[id] == nil`, `NilClass`↔`Symbol`) was JIT-compiled
monomorphic and then **plain-deopted forever with no recompile** (>1M
deopts on a single `==` in `MoveValidator#spot_unoccupied?` alone).

Three cooperating parts (design ratified as "B then C"):

- **Part 3-B** (`415208f`) — when a `BinCmp`/`BinCmpBr` `Other` site is
  flagged polymorphic (the existing POLY bit), emit a generic
  `cmp_*_values` C-call with **no receiver-class guard** instead of the
  monomorphic guarded method call. Non-deopting on class variance; the
  class-version guard is kept (global counter, not receiver class).
- **Part B** (`3bb3512`, fixed by `61b9a89`) — a monomorphic-compiled
  site's receiver-class-guard miss now does a **counter-gated, one-shot
  recompile** (`RecompileReason::BecamePolymorphic`) instead of
  plain-deopting; the recompile re-emits it on the Part 3-B path, which
  has no recv-class guard, so it can never re-trigger. New
  `SideExit::RecompileDeoptimize`; the recompile is emitted **after** the
  deopt write-back (GC-safe) and **before** the interpreter fallback.
  `JitType::Specialized` is gated out (recompiles via idx, not position).
- **Part C** (`0f0f087`) — YJIT-`opt_eq`-style inline immediate fast path
  for `==`/`!=`: when both operands are non-heap, non-flonum immediates
  (Fixnum/nil/true/false/Symbol) the result is bit equality, inline;
  Float/heap/BigInt/mixed fall back to the same generic C-call.

### Safety invariant

Part 3-B emits **no class-variance deopt**, so Part B is a *monotone,
one-shot* monomorphic→polymorphic transition (after recompile there is no
recv-class guard left to fail) — bounded, no infinite deopt↔recompile
loop. Two bugs were found and fixed during bring-up: a GC use-after-free
(recompile must follow the write-back) and a wrong recompile target
(must use the JIT entry position, not the cmp pc).

## Measured (rubykon, same machine, 19×19/100)

Targeted `[Symbol][NilClass]` `== nil` sites, deopt count
(baseline `256b461` → this branch):

| site | before | after |
|---|--:|--:|
| `MoveValidator#spot_unoccupied?` | 1,390,933 | **10** |
| `block in no_suicide_move?` | 418,415 | **10** |
| `EyeDetector#candidate_eye_color` | 145,612 | **10** |

Each fixed site shows exactly one `BecamePolymorphic` recompile then runs
deopt-free (5–6 orders of magnitude reduction). Wall time best-of-10:
793.6 ms → **738.9 ms** (~7% best / ~5% avg). CRuby 4.0.4 `--yjit` is
471.6 ms on the same box; the residual gap is class-version churn,
arithmetic-`binop` and method-call polymorphism — all out of this PR's
ratified BinCmp-`Other` scope and documented as follow-ups in
`doc/HANDOFF.md` §5b.

> `doc/HANDOFF.md` carries the full design, the measurement, the
> rejected follow-up ("§5 item 1", commits `bf91ecc`+`bbdb8df` — a
> revert pair kept as honest history; nothing depends on it), and the
> prioritised next steps.

## Test plan

- [x] Correctness vs CRuby 4.0.4: exhaustive polymorphic-cmp matrix
  (`==`/`!=`/`<`/`<=>`/`===`, branch form, NilClass↔Symbol↔custom↔
  Integer, custom `==`/`<=>`, exceptions, `coerce`/`Rational`, `BigInt`,
  Float `NaN`/`-0.0`, String content, `Integer==Float`) — all match,
  run past JIT thresholds so the recompile→Part 3-B/C path is exercised.
- [x] `--features gc-stress`: transition + heavy mixed workload, correct.
- [x] Full lib suite `2053 passed / 0 failed`; integration (`arith`,
  `comparable`, `case`, `bang_operator`, `method_call`, `enumerable`)
  all green — under Ruby 4.0.4.
- [ ] `bin/test` in a benchmark env with optcarrot present (not
  available in the dev container).

> Note: the branch is based on `efb8c79`; `master` has since advanced,
> so a rebase / conflict resolution (likely `executor.rs`, `vmgen.rs`,
> `trace_ir.rs`) is expected before merge. GitHub's three-dot diff shows
> only this branch's changes.

https://claude.ai/code/session_01NJQRXqLXJWd4Wur26tKzM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJQRXqLXJWd4Wur26tKzM4)_