### PR TITLE
core/time: Time.at :in keyword + #to_str coercion for month/utc_offset

### DIFF
--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -2640,6 +2640,18 @@ mod tests {
              Time.utc(2000, i, 1).month]
             "#,
         );
+        // #to_str returning a non-String falls through (TypeError);
+        // an offset via #to_int is accepted.
+        run_test_error(
+            r#"o = Object.new; def o.to_str; 99; end; Time.utc(2000, o, 1)"#,
+        );
+        run_test_error(
+            r#"o = Object.new; def o.to_str; :sym; end; Time.new(2000,1,1,0,0,0, o)"#,
+        );
+        run_test(
+            r#"o = Object.new; def o.to_int; 7*3600; end
+               Time.new(2000,1,1,0,0,0, o).utc_offset"#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -22,7 +22,9 @@ pub(super) fn init(globals: &mut Globals) {
     );
     globals.define_builtin_class_funcs_with(TIME_CLASS, "gm", &["utc"], time_gm, 1, 10, false);
     globals.define_builtin_class_func(TIME_CLASS, "now", time_now, 0);
-    globals.define_builtin_class_func_with(TIME_CLASS, "at", time_at, 1, 2, false);
+    globals.define_builtin_class_func_with_kw(
+        TIME_CLASS, "at", time_at, 1, 2, false, &["in"], false,
+    );
     globals.store[TIME_CLASS].set_alloc_func(time_alloc_func);
 
     globals.define_builtin_funcs(TIME_CLASS, "gmtime", &["utc"], gmtime, 0);
@@ -802,6 +804,16 @@ fn parse_utc_offset(
         return FixedOffset::east_opt(secs)
             .ok_or_else(|| MonorubyErr::argumenterr("utc_offset out of range"));
     }
+    // An object that responds to `#to_str` (but is not itself numeric)
+    // is coerced to a String offset like `"+05:00"`.
+    if !v.is_integer()
+        && let Some(fid) = globals.check_method(v, IdentId::TO_STR)
+    {
+        let s = vm.invoke_func_inner(globals, fid, v, &[], None, None)?;
+        if let Some(s) = s.is_str() {
+            return parse_utc_offset_string(s);
+        }
+    }
     let secs = match i32::try_from(v.coerce_to_int_i64(vm, globals)?) {
         Ok(s) => s,
         Err(_) => {
@@ -906,8 +918,16 @@ fn time_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let total_ns = nsecs + usec_ns;
     let dt = DateTime::from_timestamp(secs, total_ns)
         .ok_or_else(|| MonorubyErr::argumenterr("out of Time range"))?;
-    let local: DateTime<Local> = dt.into();
-    let time_info = TimeInner::Local(local.into());
+    // `Time.at(t, in: offset)` — keyword UTC offset.
+    let time_info = if let Some(off) = lfp.try_arg(2)
+        && !off.is_nil()
+    {
+        let fixed = parse_utc_offset(vm, globals, off)?;
+        TimeInner::Local(dt.with_timezone(&fixed))
+    } else {
+        let local: DateTime<Local> = dt.into();
+        TimeInner::Local(local.into())
+    };
     Ok(Value::new_time(time_info))
 }
 
@@ -1126,14 +1146,27 @@ fn time_arg_to_i64(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result
 /// `"dec"` → 12, etc. Names that don't match still fall through to the
 /// numeric parse so `"12"` works.
 fn time_month_to_i64(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<i64> {
-    if let Some(s) = v.is_str() {
+    let parse_str = |s: &str| -> Result<i64> {
         let trimmed = s.trim();
         if let Some(n) = month_name_to_num(trimmed) {
             return Ok(n);
         }
-        return trimmed.parse::<i64>().map_err(|_| {
+        trimmed.parse::<i64>().map_err(|_| {
             MonorubyErr::argumenterr(format!("argument out of range: {:?}", trimmed))
-        });
+        })
+    };
+    if let Some(s) = v.is_str() {
+        return parse_str(s);
+    }
+    // A non-numeric object that responds to `#to_str` is coerced to a
+    // String first (CRuby allows a month name via `#to_str`).
+    if !v.is_integer()
+        && let Some(fid) = globals.check_method(v, IdentId::TO_STR)
+    {
+        let r = vm.invoke_func_inner(globals, fid, v, &[], None, None)?;
+        if let Some(s) = r.is_str() {
+            return parse_str(s);
+        }
     }
     v.coerce_to_int_i64(vm, globals)
 }
@@ -2576,6 +2609,35 @@ mod tests {
             r#"
             t = Time.new(2013, 3, 17, 12, 0, 0, "+09:00:00")
             t.utc_offset
+            "#,
+        );
+    }
+
+    #[test]
+    fn time_at_in_keyword() {
+        run_test(
+            r#"
+            t = 1_700_000_000
+            a = Time.at(t, in: "+05:00")
+            b = Time.at(t, in: "-09:00:01")
+            c = Time.at(t, in: 5*3600)
+            d = Time.at(t, in: "UTC")
+            [a.utc_offset, a.to_i, b.utc_offset, c.utc_offset, d.utc_offset,
+             Time.at(t).to_i, Time.at(t, 500).usec]
+            "#,
+        );
+    }
+
+    #[test]
+    fn time_arg_to_str_coercion() {
+        run_test(
+            r#"
+            m = Object.new; def m.to_str; "feb"; end
+            s = Object.new; def s.to_str; "+05:00"; end
+            i = Object.new; def i.to_int; 3; end
+            [Time.utc(2000, m, 1).month,
+             Time.new(2000, 1, 1, 0, 0, 0, s).utc_offset,
+             Time.utc(2000, i, 1).month]
             "#,
         );
     }


### PR DESCRIPTION
## Summary

Survey of the candidate categories: **core/struct (0F/0E) and core/range (1F/0E) are fully mature** — skipped. **core/time (133F/136E)** is the high-failure target; its biggest tractable cluster is argument handling, fixed here.

- **`Time.at(t, in: offset)`** — the `in:` keyword was never declared, so it folded into the positional args as a Hash → `TypeError: no implicit conversion of Hash into Integer` (the single largest core/time error cluster, ~17 in `at_spec`). Now registered as a keyword, parsed via `parse_utc_offset`, and applied as a fixed-offset zone (String `"+05:00"`/`"-09:00:01"`/`"UTC"`, Integer seconds, etc.).
- **`#to_str` coercion** for `Time.new`/`Time.utc` month and the `utc_offset` argument — a non-numeric object responding to `#to_str` is now coerced first (CRuby allows a month name or an offset string like `"+05:00"` through `#to_str`). `#to_int` already worked; the `#to_r`-only path correctly errors in both monoruby and CRuby.

### Results (vs master, **zero regressions**)

| Spec | FAILED+ERROR occurrences |
|---|---|
| core/time (all) | 538 → 498 |
| core/time/at_spec | 62 → 54 |
| core/time/new_spec | 150 → 142 |
| core/time/utc_spec | 20 → 16 |

(Unique-description count moves less — many of these descriptions are shared `shared/` specs — but ~40 fewer failure/error occurrences overall, all examples now passing or progressing further with no new failures.)

## Test plan

- [x] Verified vs CRuby 4.0.2: `Time.at` with `in:` String/Integer/`"UTC"`/`-HH:MM:SS`, no-`in`, with usec; month/offset via `#to_str` and `#to_int` mocks (and the `#to_r`-only mock erroring, matching CRuby)
- [x] Spec-format before/after diffs (core/time, at/new/utc): zero new failures
- [x] New `time_at_in_keyword` / `time_arg_to_str_coercion` tests pass under **both** Prism and `MONORUBY_PARSER=ruruby`; `cargo test -p monoruby --lib builtins::time` green (both backends)

## Note

`Time.new`/`Time.now` also accept an `in:` keyword in CRuby; that path (the shared 0..7-arg `time_now` handler) is larger and left for a follow-up. core/struct & core/range need no work. core/io did not produce a summary (likely a partial crash/hang) and warrants separate triage.

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_