### PR TITLE
core: implement Exception#detailed_message; fix Warning module

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -181,13 +181,19 @@ class Module
 end
 
 module Warning
-  @categories = { deprecated: false, experimental: true, performance: false }
+  @categories = {
+    deprecated: false, experimental: true, performance: false,
+    strict_unused_block: false,
+  }
 
-  def self.warn(*x)
+  def self.categories
+    @categories.keys
   end
 
   def self.[](category)
-    category = category.to_sym if category.is_a?(String)
+    unless category.is_a?(Symbol)
+      raise TypeError, "wrong argument type #{category.class} (expected Symbol)"
+    end
     unless @categories.key?(category)
       raise ArgumentError, "unknown category: #{category}"
     end
@@ -195,12 +201,20 @@ module Warning
   end
 
   def self.[]=(category, value)
-    category = category.to_sym if category.is_a?(String)
+    unless category.is_a?(Symbol)
+      raise TypeError, "wrong argument type #{category.class} (expected Symbol)"
+    end
     unless @categories.key?(category)
       raise ArgumentError, "unknown category: #{category}"
     end
     @categories[category] = value ? true : false
   end
+
+  def warn(msg, category: nil)
+    $stderr.write(msg)
+    nil
+  end
+  extend self
 end
 
 class Process
@@ -581,6 +595,28 @@ class Exception
       end
     else
       msg + "\n"
+    end
+  end
+
+  # CRuby `Exception#detailed_message(highlight: false, **)`:
+  # decorate the message with the class name; empty-message and
+  # anonymous-class cases have special forms.
+  def detailed_message(highlight: false, **)
+    msg = message.to_s
+    cls = self.class
+    if msg.empty?
+      base = instance_of?(::RuntimeError) ? "unhandled exception" : (cls.name || cls.to_s)
+      return highlight ? "\e[1;4m#{base}\e[m" : base
+    end
+    nl = msg.index("\n")
+    first = nl ? msg[0...nl] : msg
+    rest = nl ? msg[nl..] : ""
+    if cls.name.nil?
+      highlight ? "\e[1m#{first}\e[m#{rest}" : "#{first}#{rest}"
+    elsif highlight
+      "\e[1m#{first} (\e[1;4m#{cls}\e[m\e[1m)\e[m#{rest}"
+    else
+      "#{first} (#{cls})#{rest}"
     end
   end
 end

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -752,6 +752,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detailed_message() {
+        run_test(
+            r#"
+            [RuntimeError.new("boom").detailed_message,
+             RuntimeError.new("").detailed_message,
+             ArgumentError.new("").detailed_message,
+             RuntimeError.new("x").detailed_message(highlight: true),
+             ArgumentError.new("bad").detailed_message(highlight: true),
+             RuntimeError.new("a\nb").detailed_message,
+             Class.new(StandardError).new("m").detailed_message,
+             RuntimeError.new("").detailed_message(highlight: true),
+             ArgumentError.new("z").detailed_message(foo: 1)]
+            "#,
+        );
+    }
+
+    #[test]
+    fn warning_module() {
+        run_test(r#"Warning.categories.sort"#);
+        run_test(r#"Warning[:strict_unused_block]"#);
+        run_test(r#"Warning.singleton_class.ancestors.include?(Warning)"#);
+        run_test_error(r#"Warning[42]"#);
+        run_test_error(r#"Warning["noop"]"#);
+        run_test_error(r#"Warning[:nope]"#);
+        run_test_error(r#"Warning[:deprecated] = "x"; Warning[1] = false"#);
+    }
+
     // -- Exception#== ------------------------------------------------------
 
     /// Identity-equal exceptions are equal.


### PR DESCRIPTION
## Summary

Survey: **core/exception** has scattered clusters (plus `signal_*` specs that hang under monoruby's single-threaded runtime — skipped); **core/warning** is 10F/5E. This PR fixes the two clean missing-method clusters:

- **`Exception#detailed_message(highlight: false, **)`** — was entirely missing (9 errors in `detailed_message_spec`). Implements CRuby's rules: `"<msg> (<Class>)"`; empty message → `"unhandled exception"` for a `RuntimeError` instance else the class name; anonymous class → bare message; multi-line message decorates only the first line; `highlight: true` adds the ANSI escape wrapping; extra keywords ignored.
- **`Warning`** — add `Warning.categories` and the `:strict_unused_block` category; `Warning.[]`/`[]=` now raise `TypeError` for a non-Symbol category and `ArgumentError` for an unknown one (matching CRuby — previously a String was silently coerced); `Warning.warn` writes the message to `$stderr` and returns `nil`, defined as an instance method with `extend self` so it "complains", has `Warning` as the method owner, and appears in `singleton_class.ancestors`.

### Results (vs master, **zero regressions**)

| Spec | failure/error occurrences |
|---|---|
| core/warning | 15 → 6 (10F/5E → 6F/0E) |
| core/exception/detailed_message_spec | 9 errors → 0 (1F remains: full_message-uses-detailed_message, out of scope) |

`full_message`'s failing-description set is unchanged (one example flips ERROR→FAILED on the *same* description now that `detailed_message` exists; verified identical description set, no example regressed). Other exception specs (message, backtrace, no_method_error) untouched and unchanged.

## Test plan

- [x] Verified vs CRuby 4.0.2: `detailed_message` across boom/empty/anonymous/multiline/highlight/RuntimeError-vs-other/extra-kwargs; `Warning.categories`, `Warning[:strict_unused_block]`, non-Symbol→TypeError, unknown→ArgumentError, `extend self` ancestors
- [x] Sequential before/after measurement (startup.rb is a shared install — both binaries can't run simultaneously); per-description diff for full_message confirms zero regressions
- [x] New `detailed_message` / `warning_module` tests pass under **both** Prism and `MONORUBY_PARSER=ruruby`; `cargo test -p monoruby --lib builtins::exception` green

## Note

Out of scope (separate, deeper): `NoMethodError#args` / `:receiver` keyword, `NameError#receiver` (needs the raise sites to populate the receiver), `SystemCallError`/Errno, `full_message` delegating to `detailed_message`, and the `signal_*` specs (single-threaded runtime).

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_