### PR TITLE
core: File/FileTest *_real? predicates; MatchData#deconstruct_keys semantics

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -61,6 +61,16 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(file, "writable?", writable_, 1);
     globals.define_builtin_module_func(file_test, "writable?", writable_, 1);
 
+    // `*_real?` test with the real uid/gid. In monoruby's typical
+    // single-user runtime real == effective, so they delegate to the
+    // effective-uid predicates (matches CRuby's result here).
+    globals.define_builtin_class_func(file, "executable_real?", executable_, 1);
+    globals.define_builtin_module_func(file_test, "executable_real?", executable_, 1);
+    globals.define_builtin_class_func(file, "readable_real?", readable_, 1);
+    globals.define_builtin_module_func(file_test, "readable_real?", readable_, 1);
+    globals.define_builtin_class_func(file, "writable_real?", writable_, 1);
+    globals.define_builtin_module_func(file_test, "writable_real?", writable_, 1);
+
     globals.define_builtin_func_rest(file, "write", write);
     globals.define_builtin_funcs(file, "path", &["to_path"], path, 0);
     globals.define_builtin_func(file, "size", size, 0);
@@ -2590,6 +2600,22 @@ mod tests {
             raise "expected nil for empty" unless s.nil?
             s = File.size?("/tmp/monoruby_nonexistent_file_xyz")
             raise "expected nil for nonexistent" unless s.nil?
+            File.delete(path)
+            "#,
+        );
+    }
+
+    #[test]
+    fn file_test_real_predicates() {
+        run_test_no_result_check(
+            r#"
+            path = "/tmp/monoruby_real_pred_#{Process.pid}"
+            File.write(path, "x")
+            raise unless FileTest.readable_real?(path) == true
+            raise unless FileTest.writable_real?(path) == true
+            raise unless File.readable_real?(path) == true
+            raise unless FileTest.executable_real?(path) == false
+            raise unless FileTest.readable_real?("/tmp/nope_#{Process.pid}_zzz") == false
             File.delete(path)
             "#,
         );

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -815,9 +815,14 @@ mod tests {
              m.deconstruct_keys([:f, :b, :x])]
             "##,
         );
+        // No named captures -> empty hash.
+        run_test(r##"/(foo)(bar)/.match("foobar").deconstruct_keys(nil)"##);
         run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys(1)"##);
         run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys("asd")"##);
-        run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys(['s', :f])"##);
+        // Non-Symbol key with array length == named-capture count -> TypeError.
+        run_test_error(r##"/(?<f>x)(?<g>y)/.match("xy").deconstruct_keys(['s', :g])"##);
+        // Array longer than named captures -> {} (early return, no type check).
+        run_test(r##"/(?<f>x)/.match("x").deconstruct_keys(['s', :f])"##);
     }
 
     #[test]
@@ -935,22 +940,6 @@ mod tests {
         run_test(r##"/(foo)(bar)(BAZ)?/.match("foobar").byteoffset(3)"##);
         // multibyte: UTF-8, byte offsets differ from char offsets
         run_test(r##"/い/.match("あぃい").byteoffset(0)"##);
-    }
-
-    #[test]
-    fn match_data_deconstruct_keys() {
-        run_test(
-            r##"/(?<a>foo)(?<b>bar)/.match("foobar").deconstruct_keys(nil)"##,
-        );
-        run_test(
-            r##"/(?<a>foo)(?<b>bar)/.match("foobar").deconstruct_keys([:a])"##,
-        );
-        run_test(
-            r##"/(?<a>foo)(?<b>bar)/.match("foobar").deconstruct_keys([:a, :missing, :b])"##,
-        );
-        // No named captures → empty hash
-        run_test(r##"/(foo)(bar)/.match("foobar").deconstruct_keys(nil)"##);
-        run_test_error(r##"/(?<a>x)/.match("x").deconstruct_keys(1)"##);
     }
 
     #[test]

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -142,20 +142,28 @@ fn deconstruct_keys_md(
         }
     } else if arg.is_array_ty() {
         let arr = arg.as_array();
-        // CRuby: if any requested symbol isn't a named capture, return `{}`.
+        // CRuby: more requested keys than named captures -> `{}`.
+        if arr.len() > names.len() {
+            return Ok(Value::hash(RubyMap::default()));
+        }
         for key in arr.iter() {
             let Some(sym) = key.try_symbol() else {
-                return Ok(Value::hash(RubyMap::default()));
+                return Err(MonorubyErr::typeerr(format!(
+                    "wrong argument type {} (expected Symbol)",
+                    key.get_real_class_name(globals)
+                )));
             };
             let name = sym.get_name();
+            // Stop at the first key with no corresponding named
+            // capture, returning what was collected so far.
             if !names.iter().any(|n| *n == name) {
-                return Ok(Value::hash(RubyMap::default()));
+                break;
             }
             map.insert(*key, val_for(&name), vm, globals)?;
         }
     } else {
         return Err(MonorubyErr::typeerr(format!(
-            "wrong argument type {} (expected Array or nil)",
+            "wrong argument type {} (expected Array)",
             arg.get_real_class_name(globals)
         )));
     }
@@ -795,6 +803,21 @@ mod tests {
         run_test(r##"/(?<a>foo)(?<b>bar)(?<a>BAZ)?/.match("foobarbaz").inspect"##);
 
         run_test(r##"/(foo)(bar)(BAZ)?/.match("foobarbaz").captures"##);
+    }
+
+    #[test]
+    fn match_data_deconstruct_keys() {
+        run_test(
+            r##"
+            m = /(?<f>foo)(?<b>bar)(?<c>baz)/.match("foobarbaz")
+            [m.deconstruct_keys(nil), m.deconstruct_keys([:f]),
+             m.deconstruct_keys([]), m.deconstruct_keys([:f, :a, :b]),
+             m.deconstruct_keys([:f, :b, :x])]
+            "##,
+        );
+        run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys(1)"##);
+        run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys("asd")"##);
+        run_test_error(r##"/(?<f>x)/.match("x").deconstruct_keys(['s', :f])"##);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two small, self-contained core fixes from the remaining-failures survey (filetest → matchdata).

### core/filetest (17F/17E → 14F/4E)
`File`/`FileTest.{readable,writable,executable}_real?` were missing entirely (13 errors). Added, delegating to the effective-uid predicates — in monoruby's single-user runtime real == effective uid/gid, which matches CRuby's result here. (Remaining failures are `Process.uid`/`groups`-dependent and `#to_path` mock-count cases — separate.)

### core/matchdata (18F/1E → 16F/0E)
`MatchData#deconstruct_keys` corrected to CRuby semantics:
- non-Array/non-nil argument → `TypeError "wrong argument type X (expected Array)"` (was `"...(expected Array or nil)"`)
- a non-Symbol key → `TypeError "...(expected Symbol)"` (was silently `{}`)
- a key with no corresponding named capture **stops iteration and returns the partial hash** (was `{}` for the whole call)
- more requested keys than named captures → `{}`

(Remaining matchdata failures — capture encoding, `==`, `named_captures`/`names`, frozen results — are separate mini-clusters.)

## Test plan

- [x] Verified vs CRuby 4.0.2: `*_real?` predicates (existing/missing files); `deconstruct_keys` with nil / subset / `[]` / first-missing / too-many / Integer / String / non-Symbol-key
- [x] Spec-format before/after diffs (core/filetest, core/matchdata): **zero regressions**; 5 + 3 unique descriptions fixed
- [x] New `file_test_real_predicates` / `match_data_deconstruct_keys` tests pass under **both** Prism and `MONORUBY_PARSER=ruruby`; `cargo test -p monoruby --lib builtins::file builtins::match_data` green

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_