### PR TITLE
core/data: proper Data.define members/inspect/with; fix Struct subclass members panic

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -995,7 +995,31 @@ require_relative 'comparable'
 # reference `Data.define`.
 class Data
   def self.define(*members, &block)
+    members = members.map { |m| m.is_a?(String) ? m.to_sym : m }
     klass = ::Struct.new(*members)
+    # CRuby renders `Data` instances as `#<data ...>` rather than
+    # `#<struct ...>`. Reuse Struct's (correct) inspect — which already
+    # handles qualified/anonymous class names and bypasses an overridden
+    # `#name` — and only relabel the prefix.
+    klass.class_eval do
+      def inspect
+        ::Struct.instance_method(:inspect).bind(self).call.sub(/\A#<struct/, '#<data')
+      end
+      alias_method :to_s, :inspect
+
+      # Returns a copy with the given members replaced. Does not go
+      # through `self.class.new` (CRuby allocates + initializes directly).
+      def with(**kw)
+        return self if kw.empty?
+        kw = kw.map { |k, v| [k.is_a?(String) ? k.to_sym : k, v] }.to_h
+        ms = self.class.members
+        merged = to_h.merge(kw)
+        copy = self.class.allocate
+        copy.send(:initialize, *ms.map { |m| merged[m] })
+        copy.freeze
+        copy
+      end
+    end
     klass.class_eval(&block) if block
     klass
   end

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -250,11 +250,11 @@ fn struct_members(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let members = globals
-        .store
-        .get_ivar(lfp.self_val(), IdentId::get_id("/members"))
-        .unwrap();
-    Ok(members)
+    // `self` is the struct class itself. A class produced via
+    // `Class.new(SomeStruct)` stores `/members` on its ancestor, so walk
+    // the superclass chain rather than assuming the ivar is local.
+    let members = get_members(globals, lfp.self_val().as_class())?;
+    Ok(members.into())
 }
 
 #[monoruby_builtin]
@@ -682,12 +682,11 @@ fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 
 #[monoruby_builtin]
 fn members(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let class_obj = lfp.self_val().get_class_obj(globals).as_val();
-    let members = globals
-        .store
-        .get_ivar(class_obj, IdentId::get_id("/members"))
-        .unwrap();
-    Ok(members)
+    // Walk the superclass chain: an instance of a `Class.new(SomeStruct)`
+    // subclass has `/members` defined on the ancestor, not its own class.
+    let class_obj = lfp.self_val().get_class_obj(globals);
+    let members = get_members(globals, class_obj)?;
+    Ok(members.into())
 }
 
 ///
@@ -1679,5 +1678,37 @@ mod tests {
             S.new("a", "b", c: "c")
             "#,
         );
+    }
+
+    #[test]
+    fn struct_members_via_anonymous_subclass() {
+        // Regression: `Class.new(SomeStruct)` stores `/members` on the
+        // ancestor; class- and instance-level `members` must walk the
+        // superclass chain instead of panicking on a missing ivar.
+        run_tests(&[
+            r#"S = Struct.new(:a, :b); Class.new(S).members"#,
+            r#"S = Struct.new(:a, :b); Class.new(S).new(1, 2).members"#,
+            r#"D = Data.define(:x, :y); Class.new(D).members"#,
+            r#"D = Data.define(:x, :y); Class.new(D).new(1, 2).members"#,
+        ]);
+    }
+
+    #[test]
+    fn data_define_and_inspect() {
+        run_tests(&[
+            // String / mixed members are coerced to symbols.
+            r#"Data.define("title", :year, "genre").members"#,
+            r#"Data.define.members"#,
+            // Instances render as `#<data ...>` (named and anonymous),
+            // reusing Struct's name/anonymity handling.
+            r#"M = Data.define(:amount, :unit); M.new(42, "km").inspect"#,
+            r#"M = Data.define(:amount, :unit); M.new(42, "km").to_s"#,
+            r#"Data.define(:a).new("").inspect"#,
+            // #with returns an updated copy and is frozen.
+            r#"M = Data.define(:amount, :unit); m = M.new(42, "km"); m.with(amount: 4).to_h"#,
+            r#"M = Data.define(:amount, :unit); m = M.new(42, "km"); m.with.equal?(m)"#,
+            r#"M = Data.define(:amount, :unit); M.new(1, "m").with("amount" => 9).to_h"#,
+            r#"M = Data.define(:amount, :unit); M.new(1, "m").with(amount: 9).frozen?"#,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

**`startup.rb` (`Data.define`):**
- Coerce String members to symbols — `Data.define("title", :year)` now works (previously `Struct.new("title")` raised `NameError: identifier title needs to be constant`).
- Render instances as `#<data ...>` instead of `#<struct ...>`, by reusing Struct's inspect (which already handles qualified/anonymous class names and bypasses an overridden `#name`) and only relabelling the prefix.
- Add `Data#with`: allocates + initializes directly (not via `self.class.new`, matching CRuby's "does not depend on Data.new"), accepts String keyword keys, returns `self` when given no arguments, result is frozen.

**`struct_class.rs` (pre-existing panic fix):**
- `Struct#members` (both class- and instance-level) called `.unwrap()` on a missing `/members` ivar for `Class.new(SomeStruct)` subclasses, **aborting the process with a non-unwinding panic** (the ivar lives on the ancestor). Now walks the superclass chain via the existing `get_members` helper. This bug exists on master independent of Data and is exercised by the `Data#with` "does not depend on the Data.new method" spec.

`core/data`: **24F/8E → 13F/0E** (19 examples improved). Remaining failures are deeper: keyword-only `initialize` dispatch (ArgumentError messages, frozen-on-empty, positional→keyword conversion for an overridden `initialize`) and recursion-guarded inspect (`...`) — coherently out of scope for this focused PR.

`core/struct`: 0F/0E, unchanged.

## Test plan

- [x] New unit tests `struct_members_via_anonymous_subclass` and `data_define_and_inspect` (verified vs CRuby 4.0.2 via `run_tests`)
- [x] Pass under both Prism and ruruby parsers
- [x] `core/data` + `core/struct` regression diff vs `origin/master` (sequential install for the shared startup.rb): **zero genuine regressions** — the only changed line is `Data#with calls #initialize` going ERROR→FAILED (same example: `with` previously didn't exist), 20 descriptions fixed
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_