### PR TITLE
core/regexp: Regexp.linear_time? classification + Regexp#options uninitialized guard

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -829,6 +829,9 @@ fn source(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result
 fn options(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let regexp = self_.is_regex().unwrap();
+    if !regexp.initialized() {
+        return Err(MonorubyErr::typeerr("uninitialized Regexp"));
+    }
     Ok(Value::integer(regexp.option() as i64))
 }
 
@@ -970,13 +973,36 @@ fn regexp_try_convert(
 /// - linear_time?(re) -> bool
 /// - linear_time?(string, options=0) -> bool
 ///
-/// monoruby's regex engine (Onigmo) classifies linear-time vs.
-/// possibly-exponential matchers conservatively. CRuby treats the
-/// vast majority of patterns as linear-time. We don't expose
-/// Onigmo's internal classifier, so return `true` for any pattern
-/// that compiles — the spec only checks for boolean shape.
+/// monoruby's regex engine (Onigmo) does not expose its internal
+/// linear-time classifier. CRuby's `linear_time?` is `false` for
+/// patterns that defeat the linear matcher — backreferences
+/// (`\1`..`\9`, `\k<…>`/`\k'…'`) and subexpression calls (`\g<…>`) —
+/// and `true` otherwise (look-around, atomic groups and possessive
+/// quantifiers all match in linear time). We apply that same
+/// syntactic test, which matches CRuby 4.0.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/linear_time=3f.html]
+fn pattern_is_linear_time(src: &str) -> bool {
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            // `\1`..`\9` (backref), `\k` (named backref) and `\g`
+            // (subexpression call) force backtracking; every other
+            // escape is linear-time.
+            if let Some(&n) = bytes.get(i + 1) {
+                if (n.is_ascii_digit() && n != b'0') || n == b'k' || n == b'g' {
+                    return false;
+                }
+            }
+            i += 2; // skip the escaped character
+            continue;
+        }
+        i += 1;
+    }
+    true
+}
+
 #[monoruby_builtin]
 fn regexp_linear_time_p(
     vm: &mut Executor,
@@ -985,10 +1011,13 @@ fn regexp_linear_time_p(
     _: BytecodePtr,
 ) -> Result<Value> {
     let arg = lfp.arg(0);
-    // If a Regexp is given, options on the second arg are ignored
-    // by CRuby (with a warning); we just accept and ignore.
-    if arg.is_regex().is_some() {
-        return Ok(Value::bool(true));
+    // If a Regexp is given, options on the second arg are ignored by
+    // CRuby (with a warning).
+    if let Some(re) = arg.is_regex() {
+        if lfp.try_arg(1).is_some() {
+            warn_flags_ignored(vm, globals);
+        }
+        return Ok(Value::bool(pattern_is_linear_time(re.as_str())));
     }
     // Otherwise, compile the source to validate the pattern. The
     // option arg may be Integer/String/nil/Boolean — we only need
@@ -1009,8 +1038,8 @@ fn regexp_linear_time_p(
     } else {
         0
     };
-    let _ = RegexpInner::with_option(s, opt)?;
-    Ok(Value::bool(true))
+    let _ = RegexpInner::with_option(s.clone(), opt)?;
+    Ok(Value::bool(pattern_is_linear_time(&s)))
 }
 
 ///
@@ -1551,6 +1580,27 @@ mod tests {
         run_test(r#"Regexp.linear_time?(/abc/)"#);
         run_test(r#"Regexp.linear_time?("abc")"#);
         run_test(r#"Regexp.linear_time?("abc", Regexp::IGNORECASE)"#);
+        // Backreferences are not linear-time; look-around / atomic /
+        // possessive / subexpression-call patterns still are.
+        run_tests(&[
+            r#"Regexp.linear_time?(/(a)\1/)"#,
+            r#"Regexp.linear_time?("(a)\\1")"#,
+            r#"Regexp.linear_time?(/a*(?:(?=a*)a)*b/)"#,
+            r#"Regexp.linear_time?(/a*(?:(?<=a)a*)*b/)"#,
+            r#"Regexp.linear_time?(/.(?<=(a))/)"#,
+            r#"Regexp.linear_time?(/(?<a>a){0}\g<a>/)"#,
+            r#"Regexp.linear_time?(/[\x80-\xff]/n)"#,
+        ]);
+        // Flags are ignored (with a warning) for a Regexp argument.
+        run_test_no_result_check(
+            r#"Regexp.linear_time?(/a/, Regexp::IGNORECASE)"#,
+        );
+    }
+
+    #[test]
+    fn regexp_options_uninitialized() {
+        // `Regexp.allocate` is uninitialized -> `#options` is a TypeError.
+        run_test_error(r#"Regexp.allocate.options"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`Regexp.linear_time?`**: previously returned `true` for any compilable pattern. Now applies CRuby 4.0's syntactic classification — `false` for patterns that defeat the linear matcher (backreferences `\1`..`\9` / `\k<…>`, and subexpression calls `\g<…>`), `true` otherwise (look-around, atomic groups and possessive quantifiers remain linear). A Regexp argument given a flags argument now emits the `warning: flags ignored` warning (reusing the existing `warn_flags_ignored` helper).
- **`Regexp#options`**: on an uninitialized Regexp (`Regexp.allocate`) now raises `TypeError`, mirroring the existing `Regexp#match` uninitialized guard.

`core/regexp`: **34F/6E → 31F/6E** (3 spec descriptions fixed).

The remaining `core/regexp` failures are encoding-model bound (US-ASCII/BINARY/Shift_JIS/UTF-16 source tagging, ASCII-incompatible detection, `FIXEDENCODING`, invalid-encoding byte handling) — a deeper structural area, out of scope for this localized fix.

## Test plan

- [x] New/extended unit tests `regexp_linear_time_p` (backref / `\g` / look-around / atomic / binary, all verified vs CRuby 4.0.2) and `regexp_options_uninitialized`
- [x] Pass under both Prism and ruruby parsers
- [x] `core/regexp` regression diff vs `origin/master`: **zero regressions**, 3 descriptions fixed
- [x] `core/regexp/linear_time_spec.rb` 0F (the CRuby-version-divergent "subexpr call is linear" case is version-guarded in mspec; behavior aligned to CRuby 4.0.2)
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_