### PR TITLE
core/regexp: fold whole-pattern option group in Regexp#to_s

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -2060,4 +2060,29 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn regexp_to_s_option_group_folding() {
+        // A whole-pattern-spanning `(?flags:...)` / `(?:...)` wrapper
+        // folds into the outer option block (CRuby `rb_reg_to_s`).
+        run_tests(&[
+            r#"/(?i:nothing outside this group)/.to_s"#,
+            r#"/(?i:.)/.to_s"#,
+            r#"/(?mmmmix-miiiix:)/.to_s"#,
+            r#"/(?:.)/.to_s"#,
+            // No folding when the group does not span the whole pattern.
+            r#"/(?ix:foo)(?m:bar)/.to_s"#,
+            r#"/(?ix:foo)bar/m.to_s"#,
+            r#"/whatever(?:0d)/ix.to_s"#,
+            r#"/(?=5)/.to_s"#,
+            r#"/(?!5)/.to_s"#,
+            // Plain option rendering still correct.
+            r#"/abc/mxi.to_s"#,
+            r#"/abc/i.to_s"#,
+            r#"/abc/.to_s"#,
+            r#"/(a)(b)/.to_s"#,
+            // Char class containing parens must not confuse the scan.
+            r#"/(?i:[()])/.to_s"#,
+        ]);
+    }
 }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -638,9 +638,73 @@ impl RegexpInner {
 
     pub fn tos(&self) -> String {
         let option = self.option();
-        let m = option & onigmo_regex::ONIG_OPTION_MULTILINE != 0;
-        let i = option & onigmo_regex::ONIG_OPTION_IGNORECASE != 0;
-        let x = option & onigmo_regex::ONIG_OPTION_EXTEND != 0;
+        let mut m = option & onigmo_regex::ONIG_OPTION_MULTILINE != 0;
+        let mut i = option & onigmo_regex::ONIG_OPTION_IGNORECASE != 0;
+        let mut x = option & onigmo_regex::ONIG_OPTION_EXTEND != 0;
+        // CRuby `rb_reg_to_s`: while the whole pattern is a single
+        // wrapping option group `(?on-off:body)` (or `(?:body)`), fold
+        // its flags into the displayed options and recurse on `body`.
+        let mut src = self.as_str().to_string();
+        loop {
+            let b = src.as_bytes();
+            if b.len() < 4 || b[0] != b'(' || b[1] != b'?' {
+                break;
+            }
+            let mut p = 2;
+            let (mut on_m, mut on_i, mut on_x) = (false, false, false);
+            while p < b.len() {
+                match b[p] {
+                    b'm' => on_m = true,
+                    b'i' => on_i = true,
+                    b'x' => on_x = true,
+                    _ => break,
+                }
+                p += 1;
+            }
+            let (mut off_m, mut off_i, mut off_x) = (false, false, false);
+            if p < b.len() && b[p] == b'-' {
+                p += 1;
+                while p < b.len() {
+                    match b[p] {
+                        b'm' => off_m = true,
+                        b'i' => off_i = true,
+                        b'x' => off_x = true,
+                        _ => break,
+                    }
+                    p += 1;
+                }
+            }
+            // Must be an option group (`...:`), not `(?=`, `(?<`, `(?#`,
+            // `(?>`, a named or capturing group, etc.
+            if p >= b.len() || b[p] != b':' {
+                break;
+            }
+            // The opening paren must match the final character, i.e. the
+            // group spans the entire pattern.
+            if regexp_matching_close(b, 0) != Some(b.len() - 1) {
+                break;
+            }
+            // CRuby applies the `on` set then the `off` set.
+            if on_m {
+                m = true;
+            }
+            if on_i {
+                i = true;
+            }
+            if on_x {
+                x = true;
+            }
+            if off_m {
+                m = false;
+            }
+            if off_i {
+                i = false;
+            }
+            if off_x {
+                x = false;
+            }
+            src = src[p + 1..src.len() - 1].to_string();
+        }
         format!(
             "(?{}{}{}{}{}{}{}:{})",
             if m { "m" } else { "" },
@@ -650,7 +714,7 @@ impl RegexpInner {
             if !m { "m" } else { "" },
             if !i { "i" } else { "" },
             if !x { "x" } else { "" },
-            self.as_str()
+            src
         )
     }
 
@@ -661,6 +725,38 @@ impl RegexpInner {
             self.option_string()
         )
     }
+}
+
+/// Index of the `)` matching the `(` at `open`, or `None` if
+/// unbalanced. Skips backslash escapes and `[...]` character classes
+/// (where `(`/`)` are literal).
+fn regexp_matching_close(b: &[u8], open: usize) -> Option<usize> {
+    if open >= b.len() || b[open] != b'(' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut k = open;
+    let mut in_class = false;
+    while k < b.len() {
+        match b[k] {
+            b'\\' => {
+                k += 2;
+                continue;
+            }
+            b'[' if !in_class => in_class = true,
+            b']' if in_class => in_class = false,
+            b'(' if !in_class => depth += 1,
+            b')' if !in_class => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(k);
+                }
+            }
+            _ => {}
+        }
+        k += 1;
+    }
+    None
 }
 
 /// Escape forward slashes that aren't already escaped, leaving every


### PR DESCRIPTION
## Summary

CRuby's `rb_reg_to_s`: when the entire pattern is a single wrapping option group `(?on-off:body)` (or `(?:body)`), its inline flags fold into the displayed `(?...:...)` option block and the body is unwrapped (recursively). monoruby previously always nested it, e.g. `/(?i:.)/.to_s` → `"(?-mix:(?i:.))"` instead of CRuby's `"(?i-mx:.)"`.

The wrapper is folded **only** when its opening paren matches the final character (spans the whole pattern); a paren scanner that skips backslash escapes and `[...]` character classes verifies this, so `/(?ix:foo)(?m:bar)/`, `/(?ix:foo)bar/m`, and lookahead groups are left untouched. Abusive repeated flags (`/(?mmmmix-miiiix:)/` → `"(?-mix:)"`) are handled.

`core/regexp`: **31F/6E → 28F/6E** (`Regexp#to_s` 3F → 0F).

The remaining `core/regexp` failures are encoding-model bound (US-ASCII/BINARY tagging, ASCII-incompatible unions, broken-string escape, `FIXEDENCODING`) and out of scope for this localized change.

## Test plan

- [x] New `regexp_to_s_option_group_folding` unit test (folding, non-spanning groups, lookahead, char-class with parens, plain options) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/regexp` regression diff vs `origin/master`: **zero regressions**, exactly 3 `Regexp#to_s` descriptions fixed
- [x] `core/regexp/to_s_spec.rb`: 0 failures
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_