### PR TITLE
core/matchdata: duplicate-named-capture resolution; #== / #eql?

### DIFF
--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -34,6 +34,33 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(MATCHDATA_CLASS, "byteend", byteend, 1);
     globals.define_builtin_func(MATCHDATA_CLASS, "byteoffset", byteoffset, 1);
     globals.define_builtin_func_with(MATCHDATA_CLASS, "deconstruct_keys", deconstruct_keys_md, 1, 1, false);
+    globals.define_builtin_funcs(MATCHDATA_CLASS, "==", &["eql?"], eq, 1);
+}
+
+///
+/// ### MatchData#== / #eql?
+///
+/// Two MatchData are equal iff their target strings, patterns, and all
+/// match positions are equal.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/=3d=3d.html]
+#[monoruby_builtin]
+fn eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let other = lfp.arg(0);
+    if !matches!(other.unpack(), RV::Object(rv) if rv.ty() == ObjTy::MATCHDATA) {
+        return Ok(Value::bool(false));
+    }
+    let a = self_.as_match_data();
+    let b = other.as_match_data();
+    let src_eq = a.string() == b.string();
+    let re_eq = match (a.regexp(), b.regexp()) {
+        (Some(x), Some(y)) => x.as_str() == y.as_str(),
+        (None, None) => true,
+        _ => false,
+    };
+    let pos_eq = a.len() == b.len() && (0..a.len()).all(|i| a.pos(i) == b.pos(i));
+    Ok(Value::bool(src_eq && re_eq && pos_eq))
 }
 
 /// Stand-in for the undefined `MatchData.allocate`. Raises NoMethodError
@@ -345,9 +372,35 @@ fn names(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<
     let self_ = lfp.self_val();
     let m = self_.as_match_data();
     let names = m.regexp().and_then(|r| r.capture_names().ok()).unwrap_or_default();
+    // A name shared by several groups appears only once (== Regexp#names).
+    let mut seen: Vec<&str> = Vec::with_capacity(names.len());
+    for n in &names {
+        if !seen.iter().any(|s| *s == n.as_str()) {
+            seen.push(n);
+        }
+    }
     Ok(Value::array_from_iter(
-        names.iter().map(|n| Value::string_from_str(n)),
+        seen.into_iter().map(Value::string_from_str),
     ))
+}
+
+/// The value of named capture `name`: the *last* group sharing that
+/// name whose capture actually participated in the match (CRuby
+/// "latest matched capture"); `None` if the name never matched.
+fn last_matched_named<'a>(
+    m: &'a crate::value::rvalue::MatchDataInner,
+    capture_names: &[String],
+    name: &str,
+) -> Option<&'a str> {
+    let mut result = None;
+    for (i, n) in capture_names.iter().enumerate() {
+        if n == name
+            && let Some(s) = m.at(i + 1)
+        {
+            result = Some(s);
+        }
+    }
+    result
 }
 
 ///
@@ -640,21 +693,24 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         };
         Ok(slice_match_data(&m, start, slice_len))
     } else if let Some(sym) = lfp.arg(0).try_symbol_or_string() {
-        if let Some(i) = m
+        let members = m
             .regexp()
             .map(|r| r.get_group_members(&format!("{sym}")))
-            .and_then(|g| g.last().copied())
-        {
-            if let Some(s) = m.at(i as usize) {
-                Ok(Value::string_from_str(s))
-            } else {
-                Ok(Value::nil())
-            }
-        } else {
-            Err(MonorubyErr::indexerr(format!(
+            .unwrap_or_default();
+        if members.is_empty() {
+            return Err(MonorubyErr::indexerr(format!(
                 "undefined group name reference: {sym}"
-            )))
+            )));
         }
+        // Among groups sharing this name, return the last one that
+        // actually matched (CRuby semantics); nil if none matched.
+        let mut result = Value::nil();
+        for i in members {
+            if let Some(s) = m.at(i as usize) {
+                result = Value::string_from_str(s);
+            }
+        }
+        Ok(result)
     } else {
         Err(MonorubyErr::typeerr(format!(
             "no implicit conversion of {} into Integer",
@@ -779,11 +835,27 @@ fn named_captures(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         .regexp()
         .and_then(|r| r.capture_names().ok())
         .unwrap_or_default();
+    // `named_captures(symbolize_names: true)` -> Symbol keys.
+    let symbolize = lfp
+        .try_arg(0)
+        .and_then(|h| h.try_hash_ty())
+        .and_then(|h| h.get(Value::symbol_from_str("symbolize_names"), vm, globals).ok().flatten())
+        .map(|v| v.as_bool())
+        .unwrap_or(false);
     let mut map = RubyMap::default();
-    for (i, name) in names.iter().enumerate() {
-        let key = Value::string_from_str(name);
-        let val = m.at(i + 1)
-            .map(|s| Value::string_from_str(s))
+    let mut done: Vec<&str> = Vec::with_capacity(names.len());
+    for name in &names {
+        if done.iter().any(|s| *s == name.as_str()) {
+            continue;
+        }
+        done.push(name);
+        let key = if symbolize {
+            Value::symbol_from_str(name)
+        } else {
+            Value::string_from_str(name)
+        };
+        let val = last_matched_named(&m, &names, name)
+            .map(Value::string_from_str)
             .unwrap_or_default();
         map.insert(key, val, vm, globals)?;
     }
@@ -823,6 +895,23 @@ mod tests {
         run_test_error(r##"/(?<f>x)(?<g>y)/.match("xy").deconstruct_keys(['s', :g])"##);
         // Array longer than named captures -> {} (early return, no type check).
         run_test(r##"/(?<f>x)/.match("x").deconstruct_keys(['s', :f])"##);
+    }
+
+    #[test]
+    fn match_data_dup_names_eq() {
+        run_tests(&[
+            r##"/(?<hay>hay)(?<dot>\.)(?<hay>hay)/.match("hay.hay").names"##,
+            r##"/\A(?<a>.)(?<b>.)(?<b>.)(?<a>.)?\z/.match("012").named_captures"##,
+            r##"/(?<a>.)(?<b>.)?/.match("0").named_captures(symbolize_names: true)"##,
+            r##"/(?<a>.)(?<b>.)?/.match("02").named_captures(symbolize_names: false)"##,
+            r##"/(?<f>foo)|(?<f>bar)/.match("bar")[:f]"##,
+            r##"/(?<f>foo)|(?<f>bar)/.match("foo")[:f]"##,
+            r##"(/(?<a>x)/.match("x")["nope"] rescue $!.class)"##,
+            r##"/(a)(b)/.match("ab") == /(a)(b)/.match("ab")"##,
+            r##"/(a)(b)/.match("ab").eql?(/(a)(b)/.match("ab"))"##,
+            r##"/(a)(b)/.match("ab") == /(a)(b)/.match("xab")"##,
+            r##"/(a)/.match("a") == "a""##,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -2060,4 +2060,29 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn regexp_to_s_option_group_folding() {
+        // A whole-pattern-spanning `(?flags:...)` / `(?:...)` wrapper
+        // folds into the outer option block (CRuby `rb_reg_to_s`).
+        run_tests(&[
+            r#"/(?i:nothing outside this group)/.to_s"#,
+            r#"/(?i:.)/.to_s"#,
+            r#"/(?mmmmix-miiiix:)/.to_s"#,
+            r#"/(?:.)/.to_s"#,
+            // No folding when the group does not span the whole pattern.
+            r#"/(?ix:foo)(?m:bar)/.to_s"#,
+            r#"/(?ix:foo)bar/m.to_s"#,
+            r#"/whatever(?:0d)/ix.to_s"#,
+            r#"/(?=5)/.to_s"#,
+            r#"/(?!5)/.to_s"#,
+            // Plain option rendering still correct.
+            r#"/abc/mxi.to_s"#,
+            r#"/abc/i.to_s"#,
+            r#"/abc/.to_s"#,
+            r#"/(a)(b)/.to_s"#,
+            // Char class containing parens must not confuse the scan.
+            r#"/(?i:[()])/.to_s"#,
+        ]);
+    }
 }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -638,9 +638,73 @@ impl RegexpInner {
 
     pub fn tos(&self) -> String {
         let option = self.option();
-        let m = option & onigmo_regex::ONIG_OPTION_MULTILINE != 0;
-        let i = option & onigmo_regex::ONIG_OPTION_IGNORECASE != 0;
-        let x = option & onigmo_regex::ONIG_OPTION_EXTEND != 0;
+        let mut m = option & onigmo_regex::ONIG_OPTION_MULTILINE != 0;
+        let mut i = option & onigmo_regex::ONIG_OPTION_IGNORECASE != 0;
+        let mut x = option & onigmo_regex::ONIG_OPTION_EXTEND != 0;
+        // CRuby `rb_reg_to_s`: while the whole pattern is a single
+        // wrapping option group `(?on-off:body)` (or `(?:body)`), fold
+        // its flags into the displayed options and recurse on `body`.
+        let mut src = self.as_str().to_string();
+        loop {
+            let b = src.as_bytes();
+            if b.len() < 4 || b[0] != b'(' || b[1] != b'?' {
+                break;
+            }
+            let mut p = 2;
+            let (mut on_m, mut on_i, mut on_x) = (false, false, false);
+            while p < b.len() {
+                match b[p] {
+                    b'm' => on_m = true,
+                    b'i' => on_i = true,
+                    b'x' => on_x = true,
+                    _ => break,
+                }
+                p += 1;
+            }
+            let (mut off_m, mut off_i, mut off_x) = (false, false, false);
+            if p < b.len() && b[p] == b'-' {
+                p += 1;
+                while p < b.len() {
+                    match b[p] {
+                        b'm' => off_m = true,
+                        b'i' => off_i = true,
+                        b'x' => off_x = true,
+                        _ => break,
+                    }
+                    p += 1;
+                }
+            }
+            // Must be an option group (`...:`), not `(?=`, `(?<`, `(?#`,
+            // `(?>`, a named or capturing group, etc.
+            if p >= b.len() || b[p] != b':' {
+                break;
+            }
+            // The opening paren must match the final character, i.e. the
+            // group spans the entire pattern.
+            if regexp_matching_close(b, 0) != Some(b.len() - 1) {
+                break;
+            }
+            // CRuby applies the `on` set then the `off` set.
+            if on_m {
+                m = true;
+            }
+            if on_i {
+                i = true;
+            }
+            if on_x {
+                x = true;
+            }
+            if off_m {
+                m = false;
+            }
+            if off_i {
+                i = false;
+            }
+            if off_x {
+                x = false;
+            }
+            src = src[p + 1..src.len() - 1].to_string();
+        }
         format!(
             "(?{}{}{}{}{}{}{}:{})",
             if m { "m" } else { "" },
@@ -650,7 +714,7 @@ impl RegexpInner {
             if !m { "m" } else { "" },
             if !i { "i" } else { "" },
             if !x { "x" } else { "" },
-            self.as_str()
+            src
         )
     }
 
@@ -661,6 +725,38 @@ impl RegexpInner {
             self.option_string()
         )
     }
+}
+
+/// Index of the `)` matching the `(` at `open`, or `None` if
+/// unbalanced. Skips backslash escapes and `[...]` character classes
+/// (where `(`/`)` are literal).
+fn regexp_matching_close(b: &[u8], open: usize) -> Option<usize> {
+    if open >= b.len() || b[open] != b'(' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut k = open;
+    let mut in_class = false;
+    while k < b.len() {
+        match b[k] {
+            b'\\' => {
+                k += 2;
+                continue;
+            }
+            b'[' if !in_class => in_class = true,
+            b']' if in_class => in_class = false,
+            b'(' if !in_class => depth += 1,
+            b')' if !in_class => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(k);
+                }
+            }
+            _ => {}
+        }
+        k += 1;
+    }
+    None
 }
 
 /// Escape forward slashes that aren't already escaped, leaving every


### PR DESCRIPTION
## Summary

- **`MatchData#names`** returns each capture name only once (now `== Regexp#names`).
- **`MatchData#named_captures`** resolves a name shared by several groups to the *last group that actually matched* (CRuby "latest matched capture"), not the textually-last group; it also honours the `symbolize_names:` keyword (Symbol keys when truthy).
- **`MatchData#[Symbol]`** likewise returns the matched group among duplicate names (nil if none matched), instead of blindly the last one.
- **Added `MatchData#==` / `#eql?`**: equal iff the other is a `MatchData` with the same target string, pattern source, and all match positions (previously fell back to `Object` identity, so equal matches compared unequal).

`core/matchdata`: **16F/0E → 9F/0E** — 7 spec descriptions fixed.

The remaining `core/matchdata` failures are encoding-model bound (EUC-JP/ISO-8859-1/UTF-8 tagging of captures and `pre_match`/`post_match`) and the frozen-shared `#string` identity — deeper and out of scope for this localized change.

## Test plan

- [x] New `match_data_dup_names_eq` unit test (unique names, latest-matched named_captures, `symbolize_names:`, `[Symbol]` duplicate resolution, `==`/`eql?`, non-MatchData operand) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/matchdata` regression diff vs `origin/master`: **zero regressions**, 7 descriptions fixed
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_