### PR TITLE
encoding P1: char-index String#[] / #slice for EUC-JP / Shift_JIS

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -10760,4 +10760,25 @@ mod tests {
             r#""".encode("EUC-JP").length"#,
         ]);
     }
+
+    #[test]
+    fn eucjp_sjis_char_indexing() {
+        // `String#[]` / `#slice` must index EUC-JP / Shift_JIS by
+        // *character*, not byte (P1: get_range walks the encoding
+        // iterator for variable-width encodings).
+        run_tests(&[
+            r#""あいうえお".encode("EUC-JP")[1].encode("UTF-8")"#,
+            r#""あいうえお".encode("EUC-JP")[1, 2].encode("UTF-8")"#,
+            r#""あいうえお".encode("EUC-JP")[1..3].encode("UTF-8")"#,
+            r#""あいうえお".encode("EUC-JP")[-2].encode("UTF-8")"#,
+            r#""あいうえお".encode("EUC-JP").slice(2, 2).encode("UTF-8")"#,
+            r#""漢A字".encode("Shift_JIS")[0].encode("UTF-8")"#,
+            r#""漢A字".encode("Shift_JIS")[1].encode("UTF-8")"#,
+            r#""漢A字".encode("Shift_JIS")[2].encode("UTF-8")"#,
+            r#""漢A字".encode("Shift_JIS")[1..].encode("UTF-8")"#,
+            r#""漢A字".encode("Shift_JIS")[5]"#,
+            r#""日本語".encode("EUC-JP")[0, 2].encode("UTF-8")"#,
+            r#""日本語".encode("Shift_JIS")[1, 2].encode("UTF-8")"#,
+        ]);
+    }
 }

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1292,10 +1292,14 @@ impl RStringInner {
             Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => Some(1),
             Encoding::Utf16Le | Encoding::Utf16Be => Some(2),
             Encoding::Utf32Le | Encoding::Utf32Be => Some(4),
-            // EUC-JP / Shift_JIS / ISO-2022-JP currently iterate
-            // byte-wise too, so a fixed-1-byte shortcut is fine.
-            Encoding::EucJp | Encoding::Sjis(_) | Encoding::Iso2022Jp => Some(1),
-            Encoding::Utf8 => None,
+            // ISO-2022-JP still iterates byte-wise (stateful decode
+            // deferred), so the fixed-1-byte shortcut matches its
+            // iterator.
+            Encoding::Iso2022Jp => Some(1),
+            // EUC-JP / Shift_JIS are variable-width: walk the
+            // (now encoding-aware) char iterator so `String#[]` /
+            // `#slice` index by characters, not bytes.
+            Encoding::EucJp | Encoding::Sjis(_) | Encoding::Utf8 => None,
         };
         if let Some(u) = unit {
             let total = self.content.len();


### PR DESCRIPTION
## Summary

**P1 of the per-encoding character-iteration layer** (design: `doc/encoding_char_iteration_design.md`, added in #536).

`RStringInner::get_range` short-circuited EUC-JP / Shift_JIS to a fixed **1-byte unit**, so `String#[]` / `#slice` / range slicing indexed those *variable-width* encodings **by byte**, silently returning corrupt substrings (e.g. `"日本語".encode("EUC-JP")[0,2]` returned half of one character). Now that P0 made `iter_char_bytes` decode their character widths, EUC-JP / Shift_JIS go through the encoding-aware iterator walk (UTF-8 already did). ISO-2022-JP keeps the 1-byte shortcut (stateful decode deferred, consistent with its iterator).

> **Stacks on #536 (P0).** Until #536 merges this PR's diff also shows the P0 commit; it narrows automatically once #536 lands.

No mspec *description* delta in these categories (these slices aren't separately scored), but the change removes a latent byte-corruption class in `String#[]`/`#slice` for EUC-JP/Shift_JIS and is the prerequisite for P2 (chars/each_char/reverse/scrub call-site migration).

## Test plan

- [x] New `eucjp_sjis_char_indexing` unit test (`[]`, `[i,len]`, ranges, endless, out-of-range, `slice`) — verified bit-for-bit vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/string`+`core/encoding`+`core/symbol` regression diff vs the P0 baseline: **zero regressions**
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_