### PR TITLE
encoding P2: per-encoding validity + scrub for EUC-JP / Shift_JIS

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -6152,7 +6152,14 @@ fn scrub_replacement(globals: &mut Globals, lfp: Lfp, self_enc: Encoding) -> Res
                 "replacement must be a valid byte sequence",
             ));
         }
-        if r_enc != self_enc && !(r_enc.is_utf8_compatible() && self_enc.is_utf8_compatible()) {
+        // An all-ASCII replacement is compatible with any
+        // ASCII-compatible target encoding (CRuby allows
+        // `s.scrub("?")` regardless of `s`'s encoding).
+        let repl_ascii_only = r_inner.as_bytes().iter().all(|b| *b < 0x80);
+        let compatible = r_enc == self_enc
+            || (r_enc.is_utf8_compatible() && self_enc.is_utf8_compatible())
+            || (repl_ascii_only && self_enc.is_ascii_compatible());
+        if !compatible {
             return Err(MonorubyErr::argumenterr(format!(
                 "incompatible character encodings: {} and {}",
                 self_enc.name(),
@@ -6192,6 +6199,27 @@ fn scrub_inner(inner: &RStringInner, repl: &RStringInner) -> Result<RStringInner
                     out.push(b);
                 } else {
                     out.extend_from_slice(repl.as_bytes());
+                }
+            }
+        }
+        Encoding::EucJp | Encoding::Sjis(_) => {
+            let char_w = if matches!(enc, Encoding::EucJp) {
+                eucjp_char_width
+            } else {
+                sjis_char_width
+            };
+            let mut i = 0;
+            while i < bytes.len() {
+                if let Some(w) = char_w(&bytes[i..]) {
+                    out.extend_from_slice(&bytes[i..i + w]);
+                    i += w;
+                } else {
+                    // An invalid byte that cannot begin a valid
+                    // character is its own ill-formed subpart
+                    // (CRuby replaces each independently, e.g.
+                    // SJIS `\xFF\xFE` -> two replacements).
+                    out.extend_from_slice(repl.as_bytes());
+                    i += 1;
                 }
             }
         }
@@ -10779,6 +10807,27 @@ mod tests {
             r#""漢A字".encode("Shift_JIS")[5]"#,
             r#""日本語".encode("EUC-JP")[0, 2].encode("UTF-8")"#,
             r#""日本語".encode("Shift_JIS")[1, 2].encode("UTF-8")"#,
+        ]);
+    }
+
+    #[test]
+    fn eucjp_sjis_validity_and_scrub() {
+        // P2: per-encoding validity + scrub for EUC-JP / Shift_JIS.
+        run_tests(&[
+            r#""あい".encode("EUC-JP").valid_encoding?"#,
+            r#""漢字".encode("Shift_JIS").valid_encoding?"#,
+            r#""abc".force_encoding("EUC-JP").valid_encoding?"#,
+            r#""\xFF\xFEok".dup.force_encoding("EUC-JP").valid_encoding?"#,
+            r#""a\x80b".dup.force_encoding("Shift_JIS").valid_encoding?"#,
+            r#""\x8F\xA2\xAF".dup.force_encoding("EUC-JP").valid_encoding?"#, // JIS X 0212
+            r#""a\x80b".dup.force_encoding("Shift_JIS").scrub("?")"#,
+            // valid JIS X 0208 left unchanged (compare by bytes to
+            // avoid String#inspect's non-UTF-8 rendering).
+            r#""a\xA1\xA1b".dup.force_encoding("EUC-JP").scrub("?").bytes"#,
+            // each lone invalid byte is its own replacement.
+            r#"("\x82\xA0\xFF\xFE".dup.force_encoding("Shift_JIS")).scrub("?").encode("UTF-8")"#,
+            // valid content is returned unchanged (scrub is a no-op).
+            r#""漢字".encode("EUC-JP").scrub.encode("UTF-8")"#,
         ]);
     }
 }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -29,7 +29,9 @@ pub use range::{RANGE_END_OFFSET, RANGE_EXCLUDE_END_OFFSET, RANGE_START_OFFSET, 
 pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
-pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner};
+pub use string::{
+    CharByteIter, CodeRange, Encoding, RString, RStringInner, eucjp_char_width, sjis_char_width,
+};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 
 mod arithmetic_sequence;

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -6,6 +6,46 @@ use std::cmp::Ordering;
 pub mod pack;
 mod printable;
 
+/// Width (in bytes) of the *valid* EUC-JP character starting at
+/// `b[0]`, or `None` if no valid character starts there. Encodes the
+/// onigenc EUC-JP rules: ASCII (1); `0x8E`+kana (2, JIS X 0201);
+/// `0x8F`+2 (3, JIS X 0212); `0xA1..=0xFE` pair (2, JIS X 0208).
+pub fn eucjp_char_width(b: &[u8]) -> Option<usize> {
+    let c0 = *b.first()?;
+    match c0 {
+        0x00..=0x7f => Some(1),
+        0x8e => match b.get(1) {
+            Some(0xa1..=0xdf) => Some(2),
+            _ => None,
+        },
+        0x8f => match (b.get(1), b.get(2)) {
+            (Some(0xa1..=0xfe), Some(0xa1..=0xfe)) => Some(3),
+            _ => None,
+        },
+        0xa1..=0xfe => match b.get(1) {
+            Some(0xa1..=0xfe) => Some(2),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Width of the *valid* Shift_JIS / CP932 character starting at
+/// `b[0]`, or `None`. ASCII & `0xA1..=0xDF` half-width kana are
+/// single byte; a `0x81..=0x9F | 0xE0..=0xFC` lead with a
+/// `0x40..=0x7E | 0x80..=0xFC` trail is a double-byte character.
+pub fn sjis_char_width(b: &[u8]) -> Option<usize> {
+    let c0 = *b.first()?;
+    match c0 {
+        0x00..=0x7f | 0xa1..=0xdf => Some(1),
+        0x81..=0x9f | 0xe0..=0xfc => match b.get(1) {
+            Some(0x40..=0x7e | 0x80..=0xfc) => Some(2),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 #[monoruby_object]
 pub struct RString(Value);
 
@@ -261,7 +301,21 @@ impl Encoding {
                     CodeRange::Broken
                 }
             }
-            Encoding::EucJp | Encoding::Sjis(_) => CodeRange::Valid,
+            Encoding::EucJp | Encoding::Sjis(_) => {
+                let char_w = if matches!(self, Encoding::EucJp) {
+                    eucjp_char_width
+                } else {
+                    sjis_char_width
+                };
+                let mut i = 0;
+                while i < bytes.len() {
+                    match char_w(&bytes[i..]) {
+                        Some(w) => i += w,
+                        None => return CodeRange::Broken,
+                    }
+                }
+                CodeRange::Valid
+            }
             // ISO-2022-JP: validate via encoding_rs's decoder so
             // truncated escape sequences / invalid JIS X 0208
             // codepoints aren't silently accepted as Valid. The


### PR DESCRIPTION
## Summary

**P2 of the per-encoding character-iteration layer** (design: `doc/encoding_char_iteration_design.md`).

`classify()` unconditionally returned `Valid` for EUC-JP / Shift_JIS, so `valid_encoding?` was always `true` and `scrub`/`scrub!` no-oped for those encodings.

- Add `eucjp_char_width` / `sjis_char_width` (onigenc validity rules: EUC-JP ASCII / `0x8E`+kana / `0x8F`+JIS X 0212 / JIS X 0208 pair; Shift_JIS ASCII / half-width kana / lead+trail double-byte).
- `classify()` walks these for EUC-JP / Shift_JIS — any byte that cannot begin a valid character ⇒ `Broken`. SevenBit / valid content is unchanged (**zero regression**).
- `scrub` / `scrub!` now replace each ill-formed byte for EUC-JP / Shift_JIS, matching CRuby (each lone invalid byte is replaced independently, e.g. SJIS `\xFF\xFE` → two replacements; verified `("\x82\xA0\xFF\xFE").force_encoding("Shift_JIS").scrub("?")` → `"あ??"`).
- Fixed `scrub` replacement-compatibility: an all-ASCII replacement is accepted for any ASCII-compatible target encoding, so `s.force_encoding("Shift_JIS").scrub("?")` no longer wrongly raises `Encoding::CompatibilityError`.

> **Stacks on #537 (P1).** Diff narrows automatically once #537 lands.

`core/string`+`core/encoding`+`core/symbol`: **zero regressions vs P1, 1 description fixed** (`String#force_encoding sets the encoding even if the String contents are invalid`).

Out of scope (documented follow-ups): block-form `scrub { }` for EUC-JP/SJIS, and the "longest valid-prefix" maximal-subpart rule for truncated multibyte (current per-byte rule matches CRuby for all tested vectors).

## Test plan

- [x] New `eucjp_sjis_validity_and_scrub` unit test (`valid_encoding?` for valid / truncated / lone-invalid / JIS X 0212; `scrub`/`scrub("?")`; no-op on valid) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/string`+`core/encoding`+`core/symbol` regression diff vs the P1 baseline: **zero regressions**, 1 fixed
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_