### PR TITLE
encoding P3 (step 2): String#split("") for EUC-JP / Shift_JIS

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1661,6 +1661,67 @@ fn is_utf8_char_boundary(bytes: &[u8], pos: usize) -> bool {
 #[monoruby_builtin]
 fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
+    // Non-UTF-8 receiver + empty String separator: split into
+    // characters via the encoding-aware iterator (the generic path
+    // below needs a `&str`, which would error for EUC-JP/Shift_JIS).
+    if let Some(recv) = self_.is_rstring_inner()
+        && !recv.encoding().is_utf8_compatible()
+        && let Some(a0) = lfp.try_arg(0)
+        && let Some(sep_inner) = a0.is_rstring_inner()
+        && sep_inner.as_bytes().is_empty()
+    {
+        let lim = if let Some(a1) = lfp.try_arg(1) {
+            a1.coerce_to_int_i64(vm, globals)?
+        } else {
+            0
+        };
+        let enc = recv.encoding();
+        let chars: Vec<RStringInner> = recv
+            .iter_char_bytes()
+            .map(|s| RStringInner::from_encoding(s, enc))
+            .collect();
+        let n = chars.len();
+        let mut v: Vec<Value> = if lim > 0 && (lim as usize) < n {
+            // `limit` fields: first `limit-1` chars, last field is
+            // the unsplit remainder.
+            let take = (lim as usize) - 1;
+            let mut bytes = Vec::new();
+            for c in &chars[take..] {
+                bytes.extend_from_slice(c.as_bytes());
+            }
+            let mut out: Vec<Value> = chars[..take]
+                .iter()
+                .map(|c| Value::string_from_inner(c.clone()))
+                .collect();
+            out.push(Value::string_from_inner(RStringInner::from_encoding(
+                &bytes, enc,
+            )));
+            out
+        } else {
+            chars
+                .into_iter()
+                .map(Value::string_from_inner)
+                .collect()
+        };
+        // Trailing empty field: only when limit is negative (CRuby
+        // keeps it; default/positive limit drops trailing empties,
+        // and an all-character split has none anyway).
+        if lim < 0 {
+            v.push(Value::string_from_inner(RStringInner::from_encoding(
+                b"", enc,
+            )));
+        }
+        return match lfp.block() {
+            Some(bh) => {
+                let ary = Value::array_from_vec(v);
+                vm.temp_push(ary);
+                vm.invoke_block_iter1(globals, bh, ary.as_array().iter().cloned())?;
+                vm.temp_pop();
+                Ok(lfp.self_val())
+            }
+            None => Ok(Value::array_from_vec(v)),
+        };
+    }
     let string = self_.expect_str(globals)?;
     let lim = if let Some(arg1) = lfp.try_arg(1) {
         arg1.coerce_to_int_i64(vm, globals)?
@@ -10892,6 +10953,21 @@ mod tests {
             r#"(x = "ABc".encode("EUC-JP"); x.upcase!; x.encode("UTF-8"))"#,
             r#""ABC".encode("EUC-JP").upcase!"#, // no change -> nil
             r#""漢字abc".encode("Shift_JIS").upcase.encode("UTF-8")"#,
+        ]);
+    }
+
+    #[test]
+    fn eucjp_sjis_split_empty_sep() {
+        // P3 (step 2): `split("")` splits an EUC-JP / Shift_JIS
+        // receiver into characters (was ArgumentError).
+        run_tests(&[
+            r#""aあbいc".encode("EUC-JP").split("").map { |x| x.encode("UTF-8") }"#,
+            r#""aあbいc".encode("EUC-JP").split("", 3).map { |x| x.encode("UTF-8") }"#,
+            r#""aあbいc".encode("EUC-JP").split("", -1).map { |x| x.encode("UTF-8") }"#,
+            r#""".encode("EUC-JP").split("")"#,
+            r#""漢A字".encode("Shift_JIS").split("").map { |x| x.encode("UTF-8") }"#,
+            r#"(r = []; "aあb".encode("EUC-JP").split("") { |c| r << c.encode("UTF-8") }; r)"#,
+            r#""aあbいc".encode("EUC-JP").split("", 1).map { |x| x.encode("UTF-8") }"#,
         ]);
     }
 }


### PR DESCRIPTION
## Summary

**P3 step 2 of the per-encoding character-iteration layer** (design: `doc/encoding_char_iteration_design.md`).

`String#split` calls `expect_str` up front, so splitting an EUC-JP / Shift_JIS string with an empty separator (split-into-characters) raised `ArgumentError`. Added an early branch — *before* `expect_str` — that, for a non-UTF-8 receiver with an empty `String` separator, splits via the (post-P0) encoding-aware `iter_char_bytes()` iterator, honouring:

- `limit` (first `limit-1` chars + unsplit remainder),
- the negative-limit trailing empty field,
- the block form,
- empty receiver → `[]`.

The existing UTF-8 path is untouched.

> **Stacks on #539 (P3 step 1).** Diff narrows automatically as the stack lands.

No mspec *description* delta (these EUC-JP/SJIS slices aren't separately scored, same as P1), but it removes an `ArgumentError` class for `split("")` on EUC-JP/Shift_JIS, verified bit-for-bit vs CRuby 4.0.2.

Out of scope (documented follow-ups): the char-set family (`tr`/`count`/`delete`/`squeeze`) and non-empty string-separator splitting for non-UTF-8 receivers.

## Test plan

- [x] New `eucjp_sjis_split_empty_sep` unit test (chars / limit / remainder / negative-limit / block / empty, EUC-JP & Shift_JIS) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/string`+`core/encoding`+`core/symbol` regression diff vs the P3-step-1 baseline: **zero regressions**
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_