### PR TITLE
encoding P3 (step 4): String#tr / #tr_s / #squeeze for EUC-JP / Shift_JIS

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -11314,6 +11314,17 @@ mod tests {
             r#""abc".encode("EUC-JP").squeeze!"#,            // no change -> nil
             r#"(y = "abcabc".encode("EUC-JP"); y.tr!("b", "B"); y.encode("UTF-8"))"#,
             r#""abc".encode("EUC-JP").tr!("z", "Z")"#,        // no change -> nil
+            // negated `from` with empty `to` deletes (incl. multibyte).
+            r#""aあbいcaab".encode("EUC-JP").tr("^a", "").encode("UTF-8")"#,
+            // tr_s! non-UTF-8: changed, then no-change -> nil.
+            r#"(z = "aabいc".encode("EUC-JP"); z.tr_s!("a", "X"); z.encode("UTF-8"))"#,
+            r#""abc".encode("EUC-JP").tr_s!("z", "Z")"#,
+            // squeeze with a non-ASCII set in a different encoding.
+            r#"begin; "aあ".encode("EUC-JP").squeeze("あ"); :no; rescue Encoding::CompatibilityError; :ce; end"#,
+            // Map replacement that is a no-op but still "matched".
+            r#""aaあ".encode("EUC-JP").tr("a", "a").encode("UTF-8")"#,
+            // tr! non-UTF-8 on Shift_JIS (changed).
+            r#"(q = "aabc".encode("Shift_JIS"); q.tr!("a", "A"); q.encode("UTF-8"))"#,
         ]);
     }
 


### PR DESCRIPTION
## Summary

**P3 step 4 of the per-encoding character-iteration layer** (design: `doc/encoding_char_iteration_design.md`).

`tr`/`tr!`/`tr_s`/`tr_s!`/`squeeze`/`squeeze!` called `expect_str`/`check_utf8` on the receiver, raising `ArgumentError` for EUC-JP / Shift_JIS strings with multibyte content.

- **`tr_translate_bytes`**: mirrors `tr_translate`'s CRuby semantics by **reusing `tr_build_map`/`TrMap`** (ranges, `^` negation, delete, later-duplicate-wins, `tr_s` squeeze) but walks the encoding-aware char iterator. Any multibyte character is treated as a single sentinel non-ASCII codepoint, so an ASCII-only `from`/`to` keeps it verbatim — or, for a negated `from`, replaces/deletes it (CRuby `tr("^a","_")`, `tr("a","")`, etc.).
- **`tr_args_ascii_ok`**: gates on ASCII-only specs; a non-ASCII spec in a *different* encoding raises `Encoding::CompatibilityError`; a same-encoding multibyte spec falls through (documented follow-up).
- **`squeeze`/`squeeze!`**: non-UTF-8 early path collapsing runs of identical *characters* via the iterator (reusing the `nonutf8_ascii_charsets`/`ascii_sets_contain` helpers from step 3).

> **Stacks on #541** (→ #540 → #539). Diff narrows as the stack lands.

No mspec *description* delta (these EUC-JP/SJIS slices aren't separately scored, same as P1), but removes an `ArgumentError` class for `tr`/`tr_s`/`squeeze` on EUC-JP/Shift_JIS, verified bit-for-bit vs CRuby 4.0.2.

This completes the char-set family. Remaining encoding follow-ups (documented in the design doc): same-encoding multibyte sets, `display_lossy()` split, ISO-2022-JP statefulness, block-form `scrub`.

## Test plan

- [x] New `eucjp_sjis_tr_squeeze` unit test (tr / ranges / `^` negation / tr-as-delete / tr_s / squeeze / `!` variants / no-change→nil / `Encoding::CompatibilityError`, EUC-JP & Shift_JIS) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/string`+`core/encoding`+`core/symbol` regression diff vs the P3-step-3 baseline: **zero regressions**
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_