### PR TITLE
encoding P3 (step 5): String#index / #rindex for EUC-JP / Shift_JIS

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5296,6 +5296,12 @@ fn tr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
             inner.encoding(),
         )));
     }
+    if tr_args_ascii_ok(globals, &inner, lfp.arg(0), lfp.arg(1))? {
+        let (b, _) = tr_translate_bytes(&inner, &from, &to, false)?;
+        return Ok(Value::string_from_inner(
+            RStringInner::from_encoding_scanned(&b, inner.encoding()),
+        ));
+    }
     let rec = self_.expect_str(globals)?;
     let (res, _) = tr_translate(rec, &from, &to, false)?;
     Ok(Value::string_from_str_with_encoding_of(&res, self_))
@@ -5320,6 +5326,15 @@ fn tr_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         }
         let enc = self_.as_rstring_inner().encoding();
         self_.replace_with_inner(RStringInner::from_ascii_bytes(bytes, enc));
+        return Ok(self_);
+    }
+    if tr_args_ascii_ok(globals, &self_.as_rstring_inner(), lfp.arg(0), lfp.arg(1))? {
+        let enc = self_.as_rstring_inner().encoding();
+        let (b, changed) = tr_translate_bytes(&self_.as_rstring_inner(), &from, &to, false)?;
+        if !changed {
+            return Ok(Value::nil());
+        }
+        self_.replace_with_inner(RStringInner::from_encoding_scanned(&b, enc));
         return Ok(self_);
     }
     let rec = self_.expect_str(globals)?.to_string();
@@ -5353,6 +5368,12 @@ fn tr_s(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             inner.encoding(),
         )));
     }
+    if tr_args_ascii_ok(globals, &inner, lfp.arg(0), lfp.arg(1))? {
+        let (b, _) = tr_translate_bytes(&inner, &from, &to, true)?;
+        return Ok(Value::string_from_inner(
+            RStringInner::from_encoding_scanned(&b, inner.encoding()),
+        ));
+    }
     let rec = self_.expect_str(globals)?;
     let (res, _) = tr_translate(rec, &from, &to, true)?;
     Ok(Value::string_from_str_with_encoding_of(&res, self_))
@@ -5377,6 +5398,15 @@ fn tr_s_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         }
         let enc = self_.as_rstring_inner().encoding();
         self_.replace_with_inner(RStringInner::from_ascii_bytes(bytes, enc));
+        return Ok(self_);
+    }
+    if tr_args_ascii_ok(globals, &self_.as_rstring_inner(), lfp.arg(0), lfp.arg(1))? {
+        let enc = self_.as_rstring_inner().encoding();
+        let (b, changed) = tr_translate_bytes(&self_.as_rstring_inner(), &from, &to, true)?;
+        if !changed {
+            return Ok(Value::nil());
+        }
+        self_.replace_with_inner(RStringInner::from_encoding_scanned(&b, enc));
         return Ok(self_);
     }
     let rec = self_.expect_str(globals)?.to_string();
@@ -5605,6 +5635,115 @@ enum TrMap {
     },
 }
 
+/// Gate for the non-UTF-8 `tr` / `tr_s` path. `Ok(true)` ⇒ receiver
+/// is non-UTF-8 and both spec args are ASCII-only (safe). `Err` ⇒ a
+/// spec arg is non-ASCII in a *different* encoding
+/// (Encoding::CompatibilityError). `Ok(false)` ⇒ caller keeps the
+/// existing path (UTF-8 receiver, or a same-encoding multibyte spec —
+/// documented follow-up).
+fn tr_args_ascii_ok(
+    globals: &Globals,
+    recv: &RStringInner,
+    a: Value,
+    b: Value,
+) -> Result<bool> {
+    if recv.encoding().is_utf8_compatible() {
+        return Ok(false);
+    }
+    for v in [a, b] {
+        if let Some(s) = v.is_rstring_inner()
+            && s.as_bytes().iter().any(|x| *x >= 0x80)
+        {
+            return if s.encoding() != recv.encoding() {
+                Err(MonorubyErr::incompatible_encoding(
+                    &globals.store,
+                    recv.encoding(),
+                    s.encoding(),
+                ))
+            } else {
+                Ok(false)
+            };
+        }
+    }
+    Ok(true)
+}
+
+/// `tr_translate` over a non-UTF-8 receiver: walk the encoding-aware
+/// char iterator. Any multibyte character is treated as a single
+/// sentinel non-ASCII codepoint (`\u{FFFF}`) so an ASCII-only
+/// `from`/`to` spec yields exactly CRuby's behaviour (kept verbatim
+/// unless a negated set replaces/deletes it). `from`/`to` must be
+/// ASCII-only (the caller gates via `tr_args_ascii_ok`).
+fn tr_translate_bytes(
+    inner: &RStringInner,
+    from: &str,
+    to: &str,
+    squeeze: bool,
+) -> Result<(SmallVec<[u8; STRING_INLINE_CAP]>, bool)> {
+    let map = tr_build_map(from, to)?;
+    let mut out: SmallVec<[u8; STRING_INLINE_CAP]> =
+        SmallVec::with_capacity(inner.as_bytes().len());
+    let mut changed = false;
+    let mut last_translated: Option<char> = None;
+    for ch in inner.iter_char_bytes() {
+        let key = if ch.len() == 1 && ch[0] < 0x80 {
+            ch[0] as char
+        } else {
+            '\u{FFFF}'
+        };
+        enum Out {
+            Keep,
+            Drop,
+            Repl(char),
+        }
+        let outcome = match &map {
+            TrMap::Map(m) => match m.get(&key) {
+                Some(r) => Out::Repl(*r),
+                None => Out::Keep,
+            },
+            TrMap::Delete { chars, negated } => {
+                let in_set = chars.contains(&key);
+                if if *negated { !in_set } else { in_set } {
+                    Out::Drop
+                } else {
+                    Out::Keep
+                }
+            }
+            TrMap::Negated {
+                from_set,
+                replacement,
+            } => {
+                if from_set.contains(&key) {
+                    Out::Keep
+                } else {
+                    Out::Repl(*replacement)
+                }
+            }
+        };
+        match outcome {
+            Out::Drop => {
+                changed = true;
+                last_translated = None;
+            }
+            // Translated to `r` (ASCII for a gated ASCII-only spec).
+            Out::Repl(r) => {
+                changed = true;
+                if !(squeeze && Some(r) == last_translated) {
+                    let mut buf = [0u8; 4];
+                    out.extend_from_slice(r.encode_utf8(&mut buf).as_bytes());
+                }
+                last_translated = Some(r);
+            }
+            // Kept verbatim (copy the original char bytes).
+            Out::Keep => {
+                out.extend_from_slice(ch);
+                last_translated = None;
+            }
+        }
+    }
+    Ok((out, changed))
+}
+
 /// Run a `tr` translation. Returns `(result, changed)` so callers can
 /// distinguish "no-op → return nil" for the bang variants.
 /// `squeeze` collapses consecutive identical *output* characters that
@@ -5784,6 +5923,24 @@ fn squeeze_compute(
         .collect::<Result<_>>()?;
     let squeeze_all = sets.is_empty();
     let inner = self_val.as_rstring_inner();
+
+    // Non-UTF-8 receiver: collapse runs of identical *characters*
+    // via the encoding-aware iterator.
+    if let Some(sets2) = nonutf8_ascii_charsets(globals, &inner, args)? {
+        let squeeze_all2 = sets2.is_empty();
+        let mut out: SmallVec<[u8; STRING_INLINE_CAP]> =
+            SmallVec::with_capacity(inner.as_bytes().len());
+        let mut prev: Option<SmallVec<[u8; 4]>> = None;
+        for ch in inner.iter_char_bytes() {
+            let in_set = squeeze_all2 || ascii_sets_contain(&sets2, ch);
+            if in_set && prev.as_deref() == Some(ch) {
+                continue;
+            }
+            out.extend_from_slice(ch);
+            prev = Some(SmallVec::from_slice(ch));
+        }
+        return Ok(RStringInner::from_encoding_scanned(&out, inner.encoding()));
+    }
 
     // ASCII fast path: branchless byte-test against the intersection,
     // no allocation when nothing collapses (we still allocate when
@@ -11067,6 +11224,29 @@ mod tests {
             r#""abcabc".encode("EUC-JP").delete("b").encode("UTF-8")"#,
             r#"(s = "abcあ".encode("EUC-JP"); s.delete!("b"); s.encode("UTF-8"))"#,
             r#""ac".encode("EUC-JP").delete!("z")"#, // no change -> nil
+        ]);
+    }
+
+    #[test]
+    fn eucjp_sjis_tr_squeeze() {
+        // P3 (step 4): `tr`/`tr_s`/`squeeze` over a non-UTF-8 receiver
+        // with ASCII-only specs (multibyte kept verbatim unless a
+        // negated `from` replaces/deletes it).
+        run_tests(&[
+            r#""aあbいcaabあ".encode("EUC-JP").squeeze.encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").squeeze("a").encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").tr("abc", "xyz").encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").tr("a-c", "A-C").encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").tr("^a", "_").encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").tr("a", "").encode("UTF-8")"#,
+            r#""aあbいcaabあ".encode("EUC-JP").tr_s("a", "X").encode("UTF-8")"#,
+            r#"begin; "aあ".encode("EUC-JP").tr("あ", "x"); :no; rescue Encoding::CompatibilityError; :ce; end"#,
+            r#""AABBＸＸ".encode("Shift_JIS").squeeze.encode("UTF-8")"#,
+            r#""abcabc".encode("Shift_JIS").tr("ac", "AC").encode("UTF-8")"#,
+            r#"(x = "aabc".encode("EUC-JP"); x.squeeze!; x.encode("UTF-8"))"#,
+            r#""abc".encode("EUC-JP").squeeze!"#,            // no change -> nil
+            r#"(y = "abcabc".encode("EUC-JP"); y.tr!("b", "B"); y.encode("UTF-8"))"#,
+            r#""abc".encode("EUC-JP").tr!("z", "Z")"#,        // no change -> nil
         ]);
     }
 }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2691,6 +2691,22 @@ fn string_index(
     let given = self_.is_rstring().unwrap();
     if let Some(arg_inner) = lfp.arg(0).is_rstring_inner() {
         check_string_encoding_compat(&given, &arg_inner, globals)?;
+        // Non-UTF-8 receiver + String needle: encoding-aware byte
+        // search at character boundaries (the regex path below needs
+        // valid UTF-8).
+        if !given.encoding().is_utf8_compatible() {
+            let from = match given.conv_char_index(char_pos) {
+                Some(p) => p,
+                None => return Ok(Value::nil()),
+            };
+            let needle = arg_inner.as_bytes().to_vec();
+            return Ok(
+                match nonutf8_substring_index(&given, &needle, from, false) {
+                    Some(cp) => Value::integer(cp as i64),
+                    None => Value::nil(),
+                },
+            );
+        }
     }
     let re = lfp.arg(0).coerce_to_regexp_or_string(vm, globals)?;
 
@@ -3023,6 +3039,46 @@ fn string_rindex(
 /// matches right-to-left and is bytewise correct because it works on
 /// `&str`: candidate positions inside a multibyte char's interior are
 /// skipped by `str::Searcher`'s boundary check.
+/// Character index of `needle`'s bytes within a non-UTF-8 receiver,
+/// constrained to character boundaries (so an ASCII needle never
+/// matches a Shift_JIS trail byte). `rev=false` ⇒ first match at or
+/// after `anchor`; `rev=true` ⇒ last match at or before `anchor`.
+/// The caller has already passed `check_string_encoding_compat`, so
+/// `needle` is ASCII or same-encoding bytes.
+fn nonutf8_substring_index(
+    inner: &RStringInner,
+    needle: &[u8],
+    anchor: usize,
+    rev: bool,
+) -> Option<usize> {
+    let bytes = inner.as_bytes();
+    let mut bounds: Vec<usize> = Vec::new();
+    let mut off = 0usize;
+    for ch in inner.iter_char_bytes() {
+        bounds.push(off);
+        off += ch.len();
+    }
+    let char_len = bounds.len();
+    if needle.is_empty() {
+        return if rev {
+            Some(anchor.min(char_len))
+        } else if anchor <= char_len {
+            Some(anchor)
+        } else {
+            None
+        };
+    }
+    let hit = |cp: usize| {
+        let bp = bounds[cp];
+        bytes[bp..].starts_with(needle)
+    };
+    if rev {
+        (0..char_len.min(anchor + 1)).rev().find(|&cp| hit(cp))
+    } else {
+        (anchor..char_len).find(|&cp| hit(cp))
+    }
+}
+
 fn string_rindex_string(
     vm: &mut Executor,
     globals: &mut Globals,
@@ -3052,6 +3108,17 @@ fn string_rindex_string(
     // Empty needle: `rindex("", k)` == k, capped at char_len.
     if needle_bytes.is_empty() {
         return Ok(Value::integer(max_char_pos as i64));
+    }
+
+    // Non-UTF-8 receiver: encoding-aware reverse byte search at
+    // character boundaries.
+    if !given.encoding().is_utf8_compatible() {
+        return Ok(
+            match nonutf8_substring_index(given, needle_bytes, max_char_pos, true) {
+                Some(cp) => Value::integer(cp as i64),
+                None => Value::nil(),
+            },
+        );
     }
 
     // The regex path requires valid UTF-8; preserve that contract for
@@ -11247,6 +11314,30 @@ mod tests {
             r#""abc".encode("EUC-JP").squeeze!"#,            // no change -> nil
             r#"(y = "abcabc".encode("EUC-JP"); y.tr!("b", "B"); y.encode("UTF-8"))"#,
             r#""abc".encode("EUC-JP").tr!("z", "Z")"#,        // no change -> nil
+        ]);
+    }
+
+    #[test]
+    fn eucjp_sjis_index_rindex() {
+        // P3 (step 5): `index`/`rindex` with a String needle over a
+        // non-UTF-8 receiver — character index, matches constrained to
+        // character boundaries; incompatible needle encoding raises.
+        run_tests(&[
+            r#""aあbいcあb".encode("EUC-JP").index("b")"#,
+            r#""aあbいcあb".encode("EUC-JP").index("b", 4)"#,
+            r#""aあbいcあb".encode("EUC-JP").index("z")"#,
+            r#""aあbいcあb".encode("EUC-JP").rindex("b")"#,
+            r#""aあbいcあb".encode("EUC-JP").rindex("b", 3)"#,
+            r#""aあbいcあb".encode("EUC-JP").index("")"#,
+            r#""aあbいcあb".encode("EUC-JP").index("", 99)"#,
+            r#""aあbいcあb".encode("EUC-JP").rindex("")"#,
+            r#"begin; "aあ".encode("EUC-JP").index("い"); :no; rescue Encoding::CompatibilityError; :ce; end"#,
+            r#"begin; "aあ".encode("EUC-JP").rindex("い"); :no; rescue Encoding::CompatibilityError; :ce; end"#,
+            // Shift_JIS: 'z' (0x7A) must not match a trail byte.
+            r#""X漢Yz漢Y".encode("Shift_JIS").index("Y")"#,
+            r#""X漢Yz漢Y".encode("Shift_JIS").rindex("Y")"#,
+            r#""X漢Yz漢Y".encode("Shift_JIS").index("z")"#,
+            r#""abcabc".encode("EUC-JP").index("bc", 2)"#,
         ]);
     }
 }


### PR DESCRIPTION
## Summary

**P3 step 5 of the per-encoding character-iteration layer** (design: `doc/encoding_char_iteration_design.md`).

`index` (regex path) and `rindex` (string fast path) both called `check_utf8()` on the receiver, raising `ArgumentError` for EUC-JP / Shift_JIS strings with multibyte content.

Added `nonutf8_substring_index`: an encoding-aware byte search that only accepts matches starting on a **character boundary** (walked via `iter_char_bytes`), so an ASCII needle never matches a Shift_JIS trail byte in `0x40..=0x7E`. Used by both `String#index` and `String#rindex` for a String needle on a non-UTF-8 receiver — forward / reverse, character-position offsets, and empty needle. The existing `check_string_encoding_compat` still raises `Encoding::CompatibilityError` for an incompatible needle encoding.

> **Stacks on #542** (→ #541 → #540/#539, merged). Diff narrows as the stack lands.

This is foundational — `partition`/`rpartition`/`insert`/`slice!` build on character indexing. Regexp needles on a non-UTF-8 receiver remain a documented follow-up (Onigmo multi-encoding, design item ⑦).

No mspec *description* delta (these EUC-JP/SJIS slices aren't separately scored, same as P1), but removes an `ArgumentError` class for `index`/`rindex` on EUC-JP/Shift_JIS, verified bit-for-bit vs CRuby 4.0.2.

## Test plan

- [x] New `eucjp_sjis_index_rindex` unit test (index / rindex / offsets / empty needle / Shift_JIS char-boundary safety / `Encoding::CompatibilityError`, EUC-JP & Shift_JIS) — verified vs CRuby 4.0.2 via `run_tests`
- [x] Passes under both Prism and ruruby parsers
- [x] `core/string`+`core/encoding`+`core/symbol` regression diff vs the P3-step-4 baseline: **zero regressions**
- [x] Full `cargo test`: only the pre-existing, unrelated `string_inspect` / `symbol_inspect_unquoted` failures (present on clean master; local CRuby-4.0.2 artifacts, CI uses 3.4.x)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_