### PR TITLE
ruby/spec fixes: range, array, hash, io compatibility + encoding handoff plan

### DIFF
--- a/doc/refine_encoding_plan.md
+++ b/doc/refine_encoding_plan.md
@@ -1,0 +1,261 @@
+# Encoding subsystem refinement — handoff plan
+
+Status: **handoff document** for a future session. No encoding code has
+been changed yet; this captures the diagnosis, concrete code pointers,
+a phased plan, and verification commands so the work can resume cold.
+
+Reference CRuby in this environment: **4.0.4** (mspec oracle). Target
+binary for spec runs: `target/release/monoruby`.
+
+---
+
+## 1. Why this work exists
+
+A ruby/spec survey of `core/{symbol,range,hash,set,array}` showed that a
+large, recurring share of the *remaining* failures across **symbol,
+string, hash, array** trace back to **one root cause: monoruby's
+non-UTF / multibyte encoding support is incomplete**. It manifests four
+ways:
+
+1. **`Encoding.list` is almost empty.** It returns only
+   `[UTF-8, ASCII-8BIT]` (see §3), so any spec that does
+   `Encoding.list.select(&:dummy?)` / `.reject(&:ascii_compatible?)`
+   iterates an empty list. mspec then reports *"No behavior expectation
+   was found"* and counts the example as a **failure** even though the
+   tested method (`Symbol#inspect`, `String#inspect`, …) may be fine.
+2. **Missing transcoders.** e.g. `UTF-8 → UTF-32LE` raises
+   `Encoding::ConverterNotFoundError`; several `casecmp`/`encode`
+   paths depend on it.
+3. **Cross-encoding compatibility rules are too eager.** e.g.
+   `ASCII-8BIT` vs `UTF-16BE` raises `Encoding::CompatibilityError`
+   where CRuby decides compatibility by content.
+4. **`inspect` escaping** for non-ASCII / non-UTF / dummy-encoding
+   strings & symbols (`:"\x61\x62"`, `\uXXXX`) is not exercised /
+   not correct because (1) prevents the specs from running and the
+   default-external-encoding rules aren't applied.
+
+This is the continuation of the **"encoding P0–P3"** line of work
+already on `master` (see §6).
+
+---
+
+## 2. Concrete remaining failures attributable to encoding
+
+Numbers are from the re-baseline against a fresh `master` build
+(commit `7c1137b` era; rerun to refresh — see §7).
+
+### core/symbol — 2 failures, 3 errors (330 examples) — **100% encoding**
+- ERROR `Symbol#casecmp with Symbol returns 0 for empty strings in different encodings` → `ConverterNotFoundError: UTF-8 to UTF-32LE`
+- ERROR `Symbol#casecmp? returns true for empty symbols in different encodings` → same
+- ERROR `Symbol#end_with? checks that we are starting to match at the head of a character` → `CompatibilityError: ASCII-8BIT and UTF-16BE`
+- FAIL `Symbol#inspect quotes symbols in non-ASCII-compatible encodings` (inspect_spec.rb:118) → empty-loop artifact: `Encoding.list.reject(&:ascii_compatible?).reject(&:dummy?)` is empty
+- FAIL `Symbol#inspect quotes and escapes symbols in dummy encodings` (inspect_spec.rb:125) → empty-loop artifact: `Encoding.list.select(&:dummy?)` is empty
+
+### core/hash & core/array — encoding-attributable subset
+- `Hash#inspect`/`#to_s` and `Array#inspect`/`#to_s` "can be evaled" /
+  "not default external encoding": ~6 (hash) + ~4 (array) examples want
+  symbol-key quoting and `\uXXXX` escaping under a non-ASCII default
+  external encoding. Same inspect/encoding root cause.
+
+### Not encoding (do NOT chase here)
+- hash/array mock `#hash`/`#eql?` dispatch (deferred item 5),
+  `Set#divide` enumerator arity (deferred item 2), `Array#pack`
+  formats, `fill` arg validation. Tracked separately.
+
+Expected payoff of this work: clears the 5 `core/symbol` items and a
+chunk (~10) of hash/array inspect failures in one coherent effort.
+
+---
+
+## 3. Codebase map (file:line as of writing — re-grep before editing)
+
+All paths under `monoruby/`.
+
+| What | Where |
+| --- | --- |
+| Encoding builtins (class, predicates, transcode, encode) | `src/builtins/encoding.rs` (~3.1k lines) |
+| `Encoding.list` — **returns only `[UTF-8, ASCII-8BIT]`** | `src/builtins/encoding.rs` `fn enc_list` ~line 2492 |
+| `Encoding.find` | `fn enc_find` ~2510 |
+| Registered constant names (UTF_16LE/BE, UTF_32*, SJIS, EUC…) | encoding.rs ~line 58–165 (`canonical_encoding_name`, constant list) |
+| `Encoding#ascii_compatible?` / `#dummy?` builtins | `fn enc_ascii_compatible_p` ~3077, `fn enc_dummy_p` ~3097 |
+| CRuby "dummy" name set | `fn is_cruby_dummy_name` ~3048 (UTF_7/16/32, ISO-2022-JP, CESU-8…) |
+| Transcoder entry point | `fn transcode_bytes_with_opts` ~531 (uses `encoding_rs`; has ASCII fast paths; raises ConverterNotFound for unhandled pairs) |
+| `String#encode` plumbing | `fn encode` ~934 (calls `transcode_bytes_with_opts`) |
+| `Encoding::Converter` (stub) | encoding.rs ~321 (validates pairs; runtime `convert`/`primitive_convert` partly implemented — see encoding_tests.rs) |
+| `Encoding` value type / per-encoding props | `src/value.rs` (`crate::value::Encoding`, `is_ascii_compatible`, width/validity) |
+| Per-encoding char iteration (P0–P3) | `src/value/rvalue/string.rs`; design doc `doc/encoding_char_iteration_design.md` |
+| `Symbol#inspect` / `String#inspect` escaping | `src/builtins/symbol.rs`, `src/builtins/string.rs` (search `inspect`), and `Value::inspect` |
+| Symbol cross-encoding ops (casecmp/end_with?) | `monoruby/builtins/symbol.rb` (e.g. `:42` end_with? at symbol.rb:42) + symbol.rs |
+| Dummy-encoding `#inspect` form `#<Encoding:NAME (dummy)>` | encoding.rs ~3040 |
+| Existing design docs | `doc/encoding_char_iteration_design.md`, `doc/string_api_design.md` |
+
+> Build note: Ruby-side files under `monoruby/builtins/*.rb` are copied
+> to `~/.monoruby/` by `build.rs` **only on build**. After editing them
+> run `touch monoruby/build.rs && cargo build --release`.
+
+---
+
+## 4. Phased plan (each phase: implement → mspec verify → commit)
+
+### Phase A — Register the full encoding table in `Encoding.list`
+**Goal:** make `Encoding.list` return the encodings monoruby already
+has constants for (UTF-8, ASCII-8BIT, US-ASCII, the ISO-8859 family,
+Windows-125x, Shift_JIS, EUC-JP, UTF-16{,LE,BE}, UTF-32{,LE,BE}, and
+the CRuby "dummy" set from `is_cruby_dummy_name`).
+
+- Rewrite `enc_list` (encoding.rs ~2492) to enumerate every registered
+  `Encoding::*` constant (it currently hard-returns 2). The constant
+  list already exists near encoding.rs ~58–165 — reuse it as the
+  single source of truth.
+- Ensure each listed object answers `name`, `ascii_compatible?`,
+  `dummy?` consistently (predicates already exist; verify they cover
+  UTF-16/32 ⇒ not ascii_compatible, and `is_cruby_dummy_name` ⇒
+  dummy?).
+- **Expected:** the 2 `core/symbol` inspect "failures" start *running*
+  their bodies. They will then pass **iff** `Symbol#inspect` already
+  emits `:"foo"` for non-ascii-compat and `:"\x61\x62\x63\x64"` for
+  dummy encodings (verify; if not, small fix in Phase D).
+- Verify: `core/symbol`, `core/encoding`, `core/string` (regression —
+  many specs introspect `Encoding.list`; watch for new failures from
+  specs that now iterate a bigger list).
+
+### Phase B — Transcoders for UTF-16/UTF-32 (both endians)
+**Goal:** kill `ConverterNotFoundError: UTF-8 to UTF-32LE` (and the
+symmetric/sibling pairs).
+
+- In `transcode_bytes_with_opts` (encoding.rs ~531) add the UTF-8 ↔
+  UTF-16{LE,BE} and UTF-8 ↔ UTF-32{LE,BE} pairs. `encoding_rs` handles
+  UTF-16; UTF-32 likely needs a small hand-rolled codec (4-byte
+  units, BOM/endianness, surrogate validation, `Undefined`/`Invalid`
+  → `Encoding::UndefinedConversionError`/`InvalidByteSequenceError`
+  consistent with the existing error helpers).
+- Route `Encoding::Converter` and `String#encode` through the same
+  path (they already call `transcode_bytes_with_opts`).
+- Verify: `core/symbol/casecmp_spec.rb`, `casecmp_query_spec.rb`,
+  `core/string/encode_spec.rb`, `core/encoding/converter` (regression).
+
+### Phase C — Cross-encoding compatibility rules
+**Goal:** fix `CompatibilityError: ASCII-8BIT and UTF-16BE` in
+`Symbol#end_with?` (and the shared String compatibility predicate).
+
+- Find the compatibility check (search `CompatibilityError` /
+  `Encoding.compatible?` in encoding.rs + string.rs). Implement CRuby's
+  `rb_enc_compatible` semantics: two strings are compatible if equal
+  encodings; if one is ASCII-only its encoding "yields"; ASCII-8BIT
+  with only ASCII bytes is compatible with any ASCII-compatible
+  encoding; otherwise incompatible. The current code raises too
+  eagerly for the empty/ASCII-only operands the specs use.
+- Verify: `core/symbol/end_with_spec.rb`, `core/string/{end_with,
+  start_with,concat,plus}_spec.rb` (regression).
+
+### Phase D — inspect escaping under non-ASCII default external
+**Goal:** the hash/array (and symbol) inspect "can be evaled" /
+"not default external encoding" examples.
+
+- Make `Symbol#inspect` / `String#inspect` / `Array#inspect` /
+  `Hash#inspect` escape non-ASCII as `\uXXXX` (or `\xNN` for
+  non-UTF/dummy) when the relevant default-external rule applies, and
+  quote symbol keys that need quoting (`:"!":` vs `!:`). Centralize in
+  `Value::inspect` if possible so all four share one implementation.
+- NB: a separate local artifact exists where the *sandbox* CRuby
+  (4.0.4 with unset `LANG`) escapes non-ASCII in `inspect`; that makes
+  `builtins::string::tests::string_inspect` /
+  `symbol_inspect_unquoted` fail under `cargo test` locally but pass
+  on CI. Do **not** "fix" monoruby to match the broken-locale oracle;
+  match CRuby-with-UTF-8-locale (what CI uses). Validate with `LANG=
+  C.UTF-8 ruby` vs `monoruby`.
+- Verify: `core/symbol/inspect_spec.rb`, `core/string/inspect_spec.rb`,
+  `core/hash/{to_s,inspect}_spec.rb`, `core/array/{inspect,to_s}_spec.rb`.
+
+### Phase E — full regression sweep
+Run the five categories plus `core/string` and `core/encoding`
+end-to-end; confirm net failures strictly decrease and no new
+errors/regressions. Commit per phase with the before/after tallies in
+the message (matches the project's commit-message convention).
+
+---
+
+## 5. Verification commands
+
+```sh
+# build (Ruby-side builtins need the touch)
+touch monoruby/build.rs && cargo build --release
+
+# one category, summary only
+cd ../spec && timeout 300 ../mspec/bin/mspec run core/symbol \
+  -t /home/user/monoruby/target/release/monoruby --format dotted | tail -3
+
+# one spec file with failure detail
+cd ../spec && ../mspec/bin/mspec run core/symbol/inspect_spec.rb \
+  -t /home/user/monoruby/target/release/monoruby 2>&1 | grep -A6 'FAILED\|ERROR'
+
+# big categories: batch to avoid timeouts
+cd ../spec && find core/array -name '*_spec.rb' | xargs -n 40 sh -c \
+  'timeout 240 ../mspec/bin/mspec "$@" -t /home/user/monoruby/target/release/monoruby --format dotted 2>&1 | tail -1' _
+```
+
+Also run the in-tree harness for regressions:
+`cargo test -p monoruby --lib builtins::encoding::tests builtins::string::tests`
+(and with `MONORUBY_PARSER=ruruby`). Use `--test-threads=1`; parallel
+runs are flaky in this sandbox (pre-existing, env-related).
+
+---
+
+## 6. Prior art on `master` (do not duplicate)
+
+`git log --oneline -- monoruby/src/builtins/encoding.rs monoruby/src/value/rvalue/string.rs`:
+- `encoding P2: per-encoding validity + scrub for EUC-JP / Shift_JIS (#538)`
+- `encoding P1: char-index String#[] / #slice for EUC-JP / Shift_JIS (#537)`
+- `encoding: per-encoding char-iteration design + P0 (EUC-JP/Shift_JIS width) (#536)`
+- design: `doc/encoding_char_iteration_design.md`
+
+This plan is the **"P4: full encoding table + UTF-16/32 transcode +
+compat rules + inspect"** continuation.
+
+---
+
+## 7. Baseline snapshot & branch state for continuity
+
+Spec tallies captured this session (rerun §5 to refresh — `master`
+moves):
+
+| category | failures | errors | notes |
+| --- | --- | --- | --- |
+| core/symbol | 2 | 3 | **all encoding** (this plan) |
+| core/range | 0 | 0 | fixed this session (committed) |
+| core/set | 1 | 1 | item 2 deferred (Enumerator arity) |
+| core/hash | 24 | 4 | after subclass-default fix; ~6 inspect = this plan |
+| core/array | 23 | 8 | after defensive-copy fix; ~4 inspect = this plan |
+
+Related spec-fix work committed on branch
+`claude/spec-fixes-1-5` (off `master`), independent of this plan:
+1. `range: iterate single ASCII-char String/Symbol endpoints by codepoint`
+3. `array: defensive-copy combination/repeated_combination; lazy permutation enumerator`
+4. `hash: honour subclass #default in Hash#[]; Hash#slice bypasses subclass #[]`
+
+Two items were **deferred as architectural** (separate from encoding,
+noted here only so the next session has the full map):
+- **Item 2 — `Set#divide` enumerator arity:** monoruby's generic
+  Enumerator inserts a yielder proc, so predicate-consuming methods
+  (`divide`/`classify`) can't see the user block's arity. Needs the
+  Enumerator to propagate the downstream block arity to the driven
+  method. 1–2 specs.
+- **Item 5 — Ruby-level `#hash`/`#eql?` dispatch in the native hash
+  table:** `Value::ruby_hash` already dispatches to Ruby `#hash` for
+  generic objects, but object-key lookups in the vendored `rubymap`
+  (`rubymap/src/{map,set}.rs`, traits in `ruby_traits`) don't
+  consistently route through Ruby `#hash`/`#eql?`, so mock specs
+  (`Hash#[] compares key via hash`, `Hash#==` via `eql?`) and
+  nested-`Set` equality fail. Core data-structure change, broad
+  regression surface — do it on its own branch with full regression.
+
+---
+
+## 8. Suggested order & rationale
+
+A → B → C → D → E. Phase A is the highest-leverage, lowest-risk step
+(it unblocks the empty-loop "failures" across symbol/string/hash/array
+and is mostly enumerating data monoruby already has). B and C are
+contained codec/predicate work. D is the broadest (touches four
+`inspect`s) — centralize it. Keep each phase a separate, spec-verified
+commit so the handoff stays bisectable.

--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -266,16 +266,19 @@ class Array
       }
     end
     n = n.to_int
-    len = self.size
+    # Defensive copy: CRuby snapshots the receiver before iterating,
+    # so mutations from the block don't change the generated combos.
+    pool = self.dup
+    len = pool.size
     if n == 0
       yield []
     elsif n == 1
-      each { |x| yield [x] }
+      pool.each { |x| yield [x] }
     elsif n > 0 && n <= len
       # iterative combination generation
       indices = (0...n).to_a
       loop do
-        yield indices.map { |i| self[i] }
+        yield indices.map { |i| pool[i] }
         # find rightmost index that can be incremented
         i = n - 1
         i -= 1 while i >= 0 && indices[i] == len - n + i
@@ -329,12 +332,17 @@ class Array
     mode == :find_min ? low < size ? low : nil : nil
   end
 
-  def permutation(n = self.size)
+  def permutation(n = nil)
     unless block_given?
+      # When called with no argument the Enumerator must use the
+      # receiver's size *at iteration time*, not freeze it now — CRuby
+      # reflects later mutations (`a.permutation; a << x; enum.to_a`).
+      # Replay with no arg so `self.size` is recomputed; with an
+      # explicit `n` the Enumerator is built with that fixed length.
       # Descending factorial size = n * (n-1) * ... * (n-k+1).
-      # 0 for k < 0 or k > size; 1 for k == 0.
-      return to_enum(:permutation, n) {
-        k = n.is_a?(Integer) ? n : n.to_int
+      enum_args = n.nil? ? [] : [n]
+      return to_enum(:permutation, *enum_args) {
+        k = n.nil? ? self.size : (n.is_a?(Integer) ? n : n.to_int)
         len = self.size
         if k < 0 || k > len
           0
@@ -347,7 +355,7 @@ class Array
         end
       }
     end
-    n = n.to_int
+    n = n.nil? ? self.size : n.to_int
     if n == 0
       yield []
       return self
@@ -575,15 +583,17 @@ class Array
       }
     end
     n = n.to_int
-    len = self.size
+    # Defensive copy (see #combination): ignore block mutations.
+    pool = self.dup
+    len = pool.size
     if n == 0
       yield []
     elsif n == 1
-      each { |x| yield [x] }
+      pool.each { |x| yield [x] }
     elsif len > 0 && n > 0
       indices = [0] * n
       loop do
-        yield indices.map { |i| self[i] }
+        yield indices.map { |i| pool[i] }
         # Increment
         i = n - 1
         while i >= 0

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -142,7 +142,10 @@ class Hash
   def slice(*keys)
     h = {}
     h.compare_by_identity if compare_by_identity?
-    keys.each { |k| h[k] = self[k] if key?(k) }
+    # CRuby's Hash#slice uses the internal element reference, not a
+    # subclass-overridden #[], so bind the base Hash#[].
+    aref = ::Hash.instance_method(:[])
+    keys.each { |k| h[k] = aref.bind(self).call(k) if key?(k) }
     h
   end
 

--- a/monoruby/builtins/range.rb
+++ b/monoruby/builtins/range.rb
@@ -31,6 +31,27 @@ class Range
       # same-length stopping rule.
       seq_mode = (i.is_a?(String) && e.is_a?(String)) ||
                  (i.is_a?(Symbol) && e.is_a?(Symbol))
+      # CRuby's String#upto special-cases single ASCII-character
+      # endpoints: it walks by codepoint, not by #succ, so
+      # `("A".."z")` yields the punctuation between `Z` and `a`
+      # (bytes 65..122 = 58 elements) and `(:A..:z)` the symbol
+      # equivalent. #succ would instead stop at `Z`/`z`.
+      if seq_mode
+        __bs = i.is_a?(Symbol) ? i.to_s : i
+        __es = e.is_a?(Symbol) ? e.to_s : e
+        if __bs.length == 1 && __es.length == 1 &&
+           __bs.ord < 128 && __es.ord < 128
+          __sym = i.is_a?(Symbol)
+          __last = excl ? __es.ord - 1 : __es.ord
+          __c = __bs.ord
+          while __c <= __last
+            ch = __c.chr
+            yield(__sym ? ch.to_sym : ch)
+            __c += 1
+          end
+          return self
+        end
+      end
       end_len = (e.is_a?(Symbol) ? e.to_s.length : e.length) if seq_mode
       loop do
         if seq_mode

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1082,6 +1082,95 @@ class IO
     self
   end
 
+  def each_line(*args)
+    raise IOError, "closed stream" if closed?
+    # `chomp:` arrives as a trailing options Hash (the only Hash arg
+    # #each_line ever takes). Pop it so it round-trips through
+    # `to_enum` as a positional Hash too.
+    chomp = false
+    if args.last.is_a?(Hash)
+      chomp = args.pop[:chomp] ? true : false
+    end
+    unless block_given?
+      return to_enum(:each_line, *args, { chomp: chomp }) { nil }
+    end
+    # Fast, proven path: default record separator, no chomp — delegate
+    # to the native `\n`-separated reader (#gets).
+    if args.empty? && !chomp
+      while (line = gets)
+        yield line
+      end
+      return self
+    end
+    # Argument-aware path: (sep), (limit), (sep, limit), chomp:.
+    # CRuby's default separator is `$/` (whose own default is "\n").
+    # monoruby leaves `$/` nil unless the user set it, so fall back to
+    # "\n" for the implicit case while still honouring an explicit
+    # `nil` (slurp) / "" (paragraph) / String passed by the caller.
+    sep = $/.nil? ? "\n" : $/
+    limit = nil
+    unless args.empty?
+      a0 = args[0]
+      if a0.nil? || a0.is_a?(String)
+        sep = a0
+        limit = args[1]
+      else
+        limit = a0
+      end
+    end
+    limit = limit.to_int if limit && !limit.is_a?(Integer)
+    limit = nil if limit && limit <= 0
+
+    if sep.nil?
+      buf = +""
+      while (c = getc)
+        buf << c
+        break if limit && buf.bytesize >= limit
+      end
+      yield buf unless buf.empty?
+      return self
+    end
+
+    paragraph = (sep == "")
+    match = paragraph ? "\n\n" : sep
+    loop do
+      buf = +""
+      if paragraph
+        # Skip the blank lines between paragraphs.
+        c = nil
+        while (c = getc) && c == "\n"; end
+        break if c.nil?
+        buf << c
+      end
+      eof = false
+      loop do
+        c = getc
+        if c.nil?
+          eof = true
+          break
+        end
+        buf << c
+        break if limit && buf.bytesize >= limit
+        break if buf.end_with?(match)
+      end
+      break if buf.empty?
+      out = buf
+      if chomp
+        out = if paragraph
+                buf.sub(/\n+\z/, "")
+              elsif buf.end_with?(sep)
+                buf[0, buf.length - sep.length]
+              else
+                buf
+              end
+      end
+      yield out
+      break if eof
+    end
+    self
+  end
+  alias each each_line
+
   def internal_encoding
     nil
   end

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1035,6 +1035,53 @@ class IO
     false
   end
 
+  # CRuby raises EOFError (not RuntimeError) at end of stream for the
+  # `read*` family; #getbyte/#getc return nil at EOF.
+  def readbyte
+    raise IOError, "closed stream" if closed?
+    b = getbyte
+    raise EOFError, "end of file reached" if b.nil?
+    b
+  end
+
+  def readchar
+    raise IOError, "closed stream" if closed?
+    c = getc
+    raise EOFError, "end of file reached" if c.nil?
+    c
+  end
+
+  def readline(*args)
+    line = gets(*args)
+    raise EOFError, "end of file reached" if line.nil?
+    line
+  end
+
+  def each_byte
+    raise IOError, "closed stream" if closed?
+    return to_enum(:each_byte) { nil } unless block_given?
+    while (b = getbyte)
+      yield b
+    end
+    self
+  end
+
+  def each_char
+    raise IOError, "closed stream" if closed?
+    return to_enum(:each_char) { nil } unless block_given?
+    while (c = getc)
+      yield c
+    end
+    self
+  end
+
+  def each_codepoint
+    raise IOError, "closed stream" if closed?
+    return to_enum(:each_codepoint) { nil } unless block_given?
+    each_char { |c| yield c.ord }
+    self
+  end
+
   def internal_encoding
     nil
   end

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1031,6 +1031,7 @@ class IO
   SEEK_END = 2
 
   def sync
+    raise IOError, "closed stream" if closed?
     false
   end
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -753,8 +753,25 @@ fn index_assign(
 #[monoruby_builtin]
 fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let key = lfp.arg(0);
-    let h = Hashmap::new(lfp.self_val());
-    h.index(vm, globals, key)
+    let self_val = lfp.self_val();
+    let h = Hashmap::new(self_val);
+    if let Some(v) = h.get(key, vm, globals)? {
+        Ok(v)
+    } else {
+        // CRuby's `Hash#[]` invokes the `default` *method* on a miss
+        // (rb_funcall id_default), so Hash subclasses overriding
+        // `#default` are honoured. The default `Hash#default` builtin
+        // returns the stored value / runs the default proc, so plain
+        // hashes behave exactly as before.
+        vm.invoke_method_inner(
+            globals,
+            IdentId::get_id("default"),
+            self_val,
+            &[key],
+            None,
+            None,
+        )
+    }
 }
 
 fn hash_index(

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -26,8 +26,6 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_CLASS, "sync=", assign_sync, 1);
     globals.define_builtin_func_with(IO_CLASS, "seek", seek, 1, 2, false);
     globals.define_builtin_func_with(IO_CLASS, "read", read, 0, 2, false);
-    globals.define_builtin_func_with(IO_CLASS, "readline", readline, 0, 2, false);
-    globals.define_builtin_funcs(IO_CLASS, "each", &["each_line"], each_line, 0);
     globals.define_builtin_class_func_with(IO_CLASS, "read", io_class_read, 1, 4, false);
     globals.define_builtin_class_func_with(IO_CLASS, "readlines", io_class_readlines, 1, 3, false);
     globals.define_builtin_class_func_with(IO_CLASS, "sysopen", io_sysopen, 1, 3, false);
@@ -50,9 +48,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_CLASS, "rewind", io_rewind, 0);
     globals.define_builtin_funcs(IO_CLASS, "eof?", &["eof"], io_eof_, 0);
     globals.define_builtin_func(IO_CLASS, "getbyte", io_getbyte, 0);
-    globals.define_builtin_func(IO_CLASS, "readbyte", io_readbyte, 0);
     globals.define_builtin_func(IO_CLASS, "getc", io_getc, 0);
-    globals.define_builtin_func(IO_CLASS, "readchar", io_readchar, 0);
     globals.define_builtin_func_with(IO_CLASS, "sysseek", io_sysseek, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "lineno", io_lineno, 0);
     globals.define_builtin_func(IO_CLASS, "lineno=", io_lineno_set, 1);
@@ -490,58 +486,6 @@ fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         return Ok(Value::nil());
     }
     Ok(Value::string_from_vec(buf))
-}
-
-///
-/// ### IO#readline
-///
-/// - readline([NOT SUPPORTED] rs = $/, [NOT SUPPORTED] chomp: false) -> String
-/// - readline([NOT SUPPORTED] limit, [NOT SUPPORTED] chomp: false) -> String
-/// - readline([NOT SUPPORTED] rs, [NOT SUPPORTED] limit, [NOT SUPPORTED] chomp: false) -> String
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/readline.html]
-#[monoruby_builtin]
-fn readline(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let s = match lfp.self_val().as_io_inner_mut().read_line()? {
-        Some(s) => s,
-        None => return Err(MonorubyErr::runtimeerr("end of file reached")),
-    };
-    Ok(Value::string(s))
-}
-
-///
-/// ### IO#each
-///
-/// - each(rs = $/, chomp: false) {|line| ... } -> self
-/// - each(limit, chomp: false) {|line| ... } -> self
-/// - each(rs, limit, chomp: false) {|line| ... } -> self
-/// - each(rs = $/, chomp: false) -> Enumerator
-/// - each(limit, chomp: false) -> Enumerator
-/// - each(rs, limit, chomp: false) -> Enumerator
-///
-/// - each_line(rs = $/, chomp: false) {|line| ... } -> self
-/// - each_line(limit, chomp: false) {|line| ... } -> self
-/// - each_line(rs, limit, chomp: false) {|line| ... } -> self
-/// - each_line(rs = $/, chomp: false) -> Enumerator
-/// - each_line(limit, chomp: false) -> Enumerator
-/// - each_line(rs, limit, chomp: false) -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/each.html]
-#[monoruby_builtin]
-fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    if let Some(bh) = lfp.block() {
-        let p = vm.get_block_data(globals, bh)?;
-        while let Some(s) = io.read_line()? {
-            vm.invoke_block(globals, &p, &[Value::string(s)])?;
-        }
-    } else {
-        return Err(MonorubyErr::runtimeerr(
-            "IO#each_line without block is not yet supported",
-        ));
-    };
-    Ok(lfp.self_val())
 }
 
 ///
@@ -1272,30 +1216,6 @@ fn io_getbyte(
     }
 }
 
-///
-/// ### IO#readbyte
-/// - readbyte -> Integer
-///
-/// Like `IO#getbyte` but raises `EOFError` at end of stream.
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/readbyte.html]
-#[monoruby_builtin]
-fn io_readbyte(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    let buf = io.read(Some(1))?;
-    if buf.is_empty() {
-        Err(MonorubyErr::runtimeerr("end of file reached"))
-    } else {
-        Ok(Value::integer(buf[0] as i64))
-    }
-}
-
 /// Read a single UTF-8 character (1-4 bytes) from the IO. Returns the bytes
 /// of the character, an empty Vec on EOF, or the first byte if the byte
 /// sequence is not valid UTF-8 (matching CRuby's invalid-byte behavior in
@@ -1348,30 +1268,6 @@ fn io_getc(
     let buf = read_one_char(io)?;
     if buf.is_empty() {
         Ok(Value::nil())
-    } else {
-        Ok(Value::string_from_vec(buf))
-    }
-}
-
-///
-/// ### IO#readchar
-/// - readchar -> String
-///
-/// Like `IO#getc` but raises `EOFError` at end of stream.
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/readchar.html]
-#[monoruby_builtin]
-fn io_readchar(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    let buf = read_one_char(io)?;
-    if buf.is_empty() {
-        Err(MonorubyErr::runtimeerr("end of file reached"))
     } else {
         Ok(Value::string_from_vec(buf))
     }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -314,6 +314,7 @@ fn gets(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/isatty.html]
 #[monoruby_builtin]
 fn isatty(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     Ok(Value::bool(lfp.self_val().as_io_inner_mut().isatty()))
 }
 
@@ -414,6 +415,7 @@ fn assign_sync(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     Ok(lfp.arg(0))
 }
 
@@ -429,6 +431,7 @@ fn assign_sync(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/seek.html]
 #[monoruby_builtin]
 fn seek(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let offset = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
     let whence = match lfp.try_arg(1) {
         None => 0i32,
@@ -957,6 +960,7 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/pid.html]
 #[monoruby_builtin]
 fn io_pid(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let self_ = lfp.self_val();
     match self_.as_io_inner().pid() {
         Some(pid) => Ok(Value::integer(pid as i64)),
@@ -1036,6 +1040,7 @@ fn io_binmode(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     Ok(lfp.self_val())
 }
 
@@ -1051,9 +1056,10 @@ fn io_binmode(
 fn io_binmode_(
     _vm: &mut Executor,
     _globals: &mut Globals,
-    _lfp: Lfp,
+    lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     Ok(Value::bool(true))
 }
 
@@ -1075,6 +1081,7 @@ fn io_autoclose_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let value = lfp.arg(0).as_bool();
     lfp.self_val().as_io_inner().set_autoclose(value);
     Ok(Value::bool(value))
@@ -1096,6 +1103,7 @@ fn io_autoclose_(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     Ok(Value::bool(lfp.self_val().as_io_inner().is_autoclose()))
 }
 
@@ -1116,6 +1124,7 @@ fn io_advise(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let arg0 = lfp.arg(0);
     let sym = arg0.try_symbol().ok_or_else(|| {
         MonorubyErr::typeerr(format!(
@@ -1152,6 +1161,7 @@ fn io_advise(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/pos.html]
 #[monoruby_builtin]
 fn io_pos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let mut self_ = lfp.self_val();
     let io = self_.as_io_inner_mut();
     let pos = io
@@ -1174,6 +1184,7 @@ fn io_pos_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let n = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
     let mut self_ = lfp.self_val();
     self_
@@ -1197,6 +1208,7 @@ fn io_rewind(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let mut self_ = lfp.self_val();
     self_
         .as_io_inner_mut()
@@ -1379,6 +1391,7 @@ fn io_sysseek(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let offset = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
     let whence = match lfp.try_arg(1) {
         None => 0i32,
@@ -1409,6 +1422,7 @@ fn io_lineno(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let stored = globals
         .store
         .get_ivar(lfp.self_val(), IdentId::get_id("/lineno"));
@@ -1429,6 +1443,7 @@ fn io_lineno_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
     let n = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
     globals.store.set_ivar(
         lfp.self_val(),
@@ -1788,6 +1803,20 @@ fn parse_wait_timeout(
         ms as i32
     };
     Ok(capped)
+}
+
+/// Raise `IOError: closed stream` if the receiver IO is closed.
+///
+/// Shared guard for the query / positioning methods CRuby rejects on a
+/// closed stream (`#pos`, `#pos=`, `#seek`, `#rewind`, `#sysseek`,
+/// `#lineno`, `#lineno=`, `#pid`, `#tty?`, `#binmode`, `#binmode?`,
+/// `#autoclose?`, `#autoclose=`, `#advise`, `#sync=`). Without this the
+/// underlying syscalls fail with `Errno::EBADF` or silently return.
+fn ensure_io_open(self_val: Value) -> Result<()> {
+    if self_val.as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    Ok(())
 }
 
 /// Wait on a single fd via `poll(2)` with the given `events` mask (mixing


### PR DESCRIPTION
## Summary

Targeted ruby/spec compatibility fixes across `core/{range,array,hash,io}`,
plus a handoff design doc for the larger encoding-subsystem work. Every
change was verified against CRuby 4.0.4 via mspec with **no regressions**.
core/io was treated carefully — monoruby has no multithreading model, so
only non-blocking/non-threaded methods were touched, and all spec runs
were per-file `timeout`-guarded (the two known single-thread hangers,
`copy_stream_spec`/`select_spec`, were excluded).

## Commits

1. **range: iterate single ASCII-char String/Symbol endpoints by codepoint**
   CRuby's `String#upto` special-cases single-char ASCII endpoints (walk by
   codepoint, not `#succ`), so `("A".."z")`/`(:A..:z)` = 58 elements.
   `core/range`: 1 failure → **0F/0E (466 examples)**.

2. **array: defensive-copy combination/repeated_combination; lazy permutation enumerator**
   `#combination`/`#repeated_combination` block forms snapshot the receiver;
   no-arg `#permutation` Enumerator recomputes size at iteration.
   `core/array`: 25 → 23 failures (combinatoric specs 0F/0E).

3. **hash: honour subclass #default in Hash#[]; Hash#slice bypasses subclass #[]**
   `Hash#[]` invokes the `default` *method* on a miss (subclass overrides
   honoured); `Hash#slice` binds base `Hash#[]`. `core/hash`: 26 → 24 failures.

4. **doc: encoding subsystem refinement handoff plan** (`doc/refine_encoding_plan.md`)
   Phased A–E plan + code pointers for the larger encoding work
   (`Encoding.list` only returns `[UTF-8, ASCII-8BIT]`; missing UTF-16/32
   transcoders; cross-encoding compat; inspect escaping). No code change.

5. **io: raise IOError on closed stream for positioning/query methods**
   Shared `ensure_io_open` guard for `#pos/#seek/#rewind/#sysseek/#lineno/
   #pid/#tty?/#binmode?/#autoclose?/#advise/#sync=` etc. Purely additive
   (only fires on a closed fd). pos/tell/seek/pid/isatty/tty/autoclose → 0F/0E.

6. **io: EOFError for readbyte/readchar/readline; add each_byte/char/codepoint**
   EOF now raises `EOFError` (was RuntimeError); `#each_byte/#each_char/
   #each_codepoint` added (were NoMethodError). readbyte/each_byte → 0F/0E.

7. **io: IO#each_line/#each accept sep/limit/chomp: and yield an Enumerator**
   Was arity-0 (any arg → ArgumentError) and no Enumerator. Now handles
   (sep)/(limit)/(sep,limit)/`chomp:`/nil-slurp/""-paragraph; default
   separator falls back to `"\n"` when `$/` is nil. Default no-arg path
   still delegates to the native reader (no regression). Verified
   bit-for-bit vs CRuby; `core/io` each_line/each: ~all-erroring (21
   errors) → 9F/1E with 32 expectations now evaluated.

## Out of scope (documented, not attempted here)

- Encoding pipeline (~230 io + symbol/hash/array inspect) → see
  `doc/refine_encoding_plan.md`.
- `IO` concurrency: `read_nonblock`/`write_nonblock`/`select`/blocking
  pipe & popen child sync — monoruby has no threading model.
- `Set#divide` enumerator arity and native-hash Ruby-`#hash`/`#eql?`
  dispatch — architectural, noted in the handoff doc.

## Test plan

- [x] CI green
- [ ] `mspec core/range` 0F/0E
- [ ] `mspec core/array core/hash` no new failures vs base
- [ ] `mspec` per-file (timeout-guarded) for the touched core/io specs:
      pos/tell/seek/pid/isatty/tty/autoclose/readbyte/each_byte 0F/0E;
      each_line/each, readchar/readline no regressions

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_