### PR TITLE
String#start_with?/#end_with? character-boundary check (P4 phase C)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1532,10 +1532,8 @@ fn start_with(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         check_encoding_compat(self_enc, self_bytes, &arg_inner, globals)?;
         let arg_bytes = arg_inner.as_bytes();
         if self_bytes.starts_with(arg_bytes) {
-            if self_enc.is_utf8_compatible() && arg_bytes.len() < self_bytes.len() {
-                if !is_utf8_char_boundary(self_bytes, arg_bytes.len()) {
-                    continue;
-                }
+            if !enc_char_boundary(self_enc, self_bytes, arg_bytes.len()) {
+                continue;
             }
             return Ok(Value::bool(true));
         }
@@ -1566,11 +1564,9 @@ fn end_with(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         check_encoding_compat(self_enc, self_bytes, &arg_inner, globals)?;
         let arg_bytes = arg_inner.as_bytes();
         if self_bytes.ends_with(arg_bytes) {
-            if self_enc.is_utf8_compatible() && arg_bytes.len() < self_bytes.len() {
-                let boundary = self_bytes.len() - arg_bytes.len();
-                if !is_utf8_char_boundary(self_bytes, boundary) {
-                    continue;
-                }
+            let boundary = self_bytes.len() - arg_bytes.len();
+            if !enc_char_boundary(self_enc, self_bytes, boundary) {
+                continue;
             }
             return Ok(Value::bool(true));
         }
@@ -1720,6 +1716,35 @@ fn is_utf8_char_boundary(bytes: &[u8], pos: usize) -> bool {
     }
     // A byte is NOT at a character boundary if it's a continuation byte (10xxxxxx)
     (bytes[pos] & 0xC0) != 0x80
+}
+
+/// True iff byte offset `pos` is the head of a character in `enc`.
+/// Used so `start_with?` / `end_with?` only accept a prefix/suffix
+/// that aligns to a character (CRuby: a match must start at a char
+/// head). UTF-16 is surrogate-aware — a low surrogate (the 2nd half
+/// of an astral character) is not a head. Encodings other than
+/// UTF-8/16/32 keep the previous "no boundary constraint" behaviour.
+fn enc_char_boundary(enc: crate::value::Encoding, bytes: &[u8], pos: usize) -> bool {
+    use crate::value::Encoding as E;
+    if pos == 0 || pos >= bytes.len() {
+        return true;
+    }
+    match enc {
+        E::Utf8 => is_utf8_char_boundary(bytes, pos),
+        E::Utf16Le | E::Utf16Be => {
+            if pos % 2 != 0 || pos + 1 >= bytes.len() {
+                return pos % 2 == 0;
+            }
+            let u = if matches!(enc, E::Utf16Be) {
+                u16::from_be_bytes([bytes[pos], bytes[pos + 1]])
+            } else {
+                u16::from_le_bytes([bytes[pos], bytes[pos + 1]])
+            };
+            !(0xDC00..=0xDFFF).contains(&u)
+        }
+        E::Utf32Le | E::Utf32Be => pos % 4 == 0,
+        _ => true,
+    }
 }
 
 ///
@@ -11391,6 +11416,28 @@ mod tests {
             r#""aあbいcb".encode("EUC-JP").rpartition("b").map { |x| x.encode("UTF-8") }"#,
             r#"begin; "aあbいc".encode("EUC-JP").rpartition("い"); :no; rescue Encoding::CompatibilityError; :ce; end"#,
             r#"begin; ("ab".encode("EUC-JP"))[5] = "x"; :no; rescue IndexError; :ie; end"#,
+        ]);
+    }
+
+    #[test]
+    fn start_end_with_char_boundary_by_encoding() {
+        run_tests(&[
+            // UTF-8: a suffix/prefix that splits a multibyte char does
+            // not match (must align to a character head).
+            r#""\xC3\xA9".end_with?("\xA9")"#,
+            r#""\xe3\x81\x82".end_with?("\x82")"#,
+            r#""café".end_with?("é")"#,
+            r#""café".start_with?("c")"#,
+            // UTF-16BE: a surrogate pair is ONE 4-byte character, so a
+            // 2-byte suffix landing inside it must not match; an
+            // aligned suffix does.
+            r#"s = "\xd8\x00\xdc\x00".dup.force_encoding("UTF-16BE")
+               s.end_with?("\xdc\x00".dup.force_encoding("UTF-16BE"))"#,
+            r#"s = "\xd8\x00\xdc\x00".dup.force_encoding("UTF-16BE")
+               s.end_with?("\x00\xdc\x00".dup.force_encoding("UTF-16BE"))"#,
+            r#""abcd".encode("UTF-16BE").end_with?("cd".encode("UTF-16BE"))"#,
+            r#""abcd".encode("UTF-16LE").start_with?("ab".encode("UTF-16LE"))"#,
+            r#""abcd".encode("UTF-32BE").end_with?("d".encode("UTF-32BE"))"#,
         ]);
     }
 }


### PR DESCRIPTION
## Summary

Single focused commit (`2f5f8a79`) completing the actionable part of encoding-refinement **phase C**.

`String#start_with?` / `#end_with?` only enforced CRuby's "a match must begin at a character head" rule for ASCII-compatible (UTF-8) receivers — every other encoding skipped the check. So a 2-byte suffix landing **inside** a 4-byte UTF-16 surrogate-pair character matched incorrectly:

```ruby
"\xd8\x00\xdc\x00".dup.force_encoding("UTF-16BE").end_with?(
  "\xdc\x00".dup.force_encoding("UTF-16BE"))   # was true, CRuby => false
```

Added `enc_char_boundary`, a surrogate-aware boundary predicate:

- **UTF-8** — continuation-byte rule (existing logic)
- **UTF-16 LE/BE** — even offset and the code unit there is not a low surrogate (`0xDC00..=0xDFFF`), so the second half of an astral character is not a head
- **UTF-32 LE/BE** — 4-byte aligned
- other encodings — keep the previous "no constraint" behaviour (no change)

Both methods now consult it for **every** encoding (the `is_utf8_compatible()` gate is removed).

## Result

- `core/string/end_with_spec.rb`: **1 failure → 0**
- `core/string` vs `master`: by-name pre/post diff → **zero true regressions, 1 true fix** (229F/116E)
- `core/string/start_with_spec.rb` still 0; Prism **and** ruruby parsers green
- CRuby-verified unit test `start_end_with_char_boundary_by_encoding` added

## Out of scope (documented in the commit message)

The sibling `core/symbol/end_with_spec.rb` error (`ASCII-8BIT and UTF-16BE`) is a *different* root cause: symbols don't preserve their source encoding (the interner stores only `Utf8`/`Bytes`), so `Symbol#to_s` re-tags as ASCII-8BIT. Fixing that needs a cross-cutting `id_table` change and is intentionally deferred.

## Test plan

- [x] `core/string/end_with_spec.rb` 0/0; `start_with_spec.rb` 0/0
- [x] UTF-16 surrogate-pair / UTF-32 alignment cases byte-exact vs `LANG=C.UTF-8 ruby`
- [x] Pre/post name diff on `core/string`: zero true regressions
- [x] Prism + ruruby parsers; full `builtins::string` cargo suite green (only the pre-existing broken-locale `string_inspect` artifact, which passes on CI)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_