### PR TITLE
hash/set: dispatch Ruby #hash/#eql? for object keys; Set#hash for Set keys

### DIFF
--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -317,7 +317,16 @@ impl RubyHash<Executor, Globals, MonorubyErr> for Value {
                     ObjTy::BIGNUM => lhs.as_bignum().hash(state),
                     ObjTy::FLOAT => lhs.as_float().to_bits().hash(state),
                     ObjTy::STRING => lhs.as_rstring().hash(state),
-                    ObjTy::ARRAY | ObjTy::HASH => {
+                    // Only a *true* Array / Hash uses the native
+                    // structural hash. `Set` is `ObjTy::HASH` with class
+                    // `Set` and a Ruby-level, order-independent
+                    // `Set#hash` (and a Hash subclass may override
+                    // `#hash`); those fall through to the Ruby `#hash`
+                    // dispatch in the `_` arm so e.g. `Set[1,3]` and
+                    // `Set[3,1]` hash equal and compare as set members.
+                    ObjTy::ARRAY | ObjTy::HASH
+                        if lhs.ty() == ObjTy::ARRAY || lhs.class() == HASH_CLASS =>
+                    {
                         let id = self.id();
                         let is_recursive =
                             HASH_RECURSION_GUARD.with(|guard| !guard.borrow_mut().insert(id));

--- a/rubymap/src/map.rs
+++ b/rubymap/src/map.rs
@@ -759,13 +759,17 @@ where
     where
         Q: ?Sized + RubyHash<E, G, R> + Equivalent<K, E, G, R>,
     {
-        Ok(match self.as_entries() {
-            [] => None,
-            [x] => key.equivalent(&x.key, e, g)?.then_some(0),
-            _ => {
-                let hash = self.hash(key, e, g)?;
-                self.core.get_index_of(hash, key, e, g)?
-            }
+        // CRuby's `Hash#[]` always hashes the query key (when the hash
+        // is non-empty) and only consults `#eql?` on a hash collision.
+        // A single-entry fast path that compared via `#eql?` without
+        // hashing diverged from that: object keys never received
+        // `#hash`, and `#eql?` was called even for differing hashes
+        // (and Set-of-Sets membership / mock-count specs failed).
+        Ok(if self.as_entries().is_empty() {
+            None
+        } else {
+            let hash = self.hash(key, e, g)?;
+            self.core.get_index_of(hash, key, e, g)?
         })
     }
 


### PR DESCRIPTION
## Summary

Makes monoruby's native `Hash`/`Set` use a key's Ruby `#hash` / `#eql?`
the way CRuby does. What looked architectural turned out to be two
localized bugs (21-line fix; no trait-crate restructuring needed).

### Root causes & fixes

1. **`rubymap::RubyMap::get_index_of` single-entry fast path**
   compared via `#eql?` *without hashing the query key*. CRuby always
   hashes the query key when the map is non-empty and only consults
   `#eql?` on a hash collision. Removed the fast path (empty map still
   skips hashing, matching CRuby). `RubyMap::insert` indexes entries
   from the first one, so the fast path was a pure (incorrect)
   optimization. `RubySet` delegates to `RubyMap`, so Set is fixed too.

2. **`Value::ruby_hash` structurally hashed every `ObjTy::HASH`**,
   including `Set` (which is `ObjTy::HASH`, class `Set`, with a
   Ruby-level order-independent `Set#hash`). Guarded the structural
   fast path to *true* `Array`/`Hash` (`class == HASH_CLASS`); `Set`
   and Hash subclasses overriding `#hash` fall through to the Ruby
   `#hash` dispatch — so `Set[1,3]` and `Set[3,1]` hash equal and
   compare as set members.

### Verification (core data structure — full regression run)

- Verified vs CRuby 4.0: nested-`Set` `==`, `Set`/`Array`/`String`
  keys, `Hash#[]` hash-then-`eql?` ordering, empty-map no-hash — all match.
- Full release test suite: **1516 passed**; the only 2 failures are
  the pre-existing local-CRuby-locale inspect artifacts
  (`string_inspect`, `symbol_inspect_unquoted`) — unrelated, pass on CI.
- `core/hash`: master baseline **24F/4E → 20F/4E** (mock dispatch
  specs `element_reference`, `equal_value` now 0F/0E).
- `core/set`: **0F/1E** unchanged (residual = deferred `Set#divide`
  enumerator-arity error); nested-Set membership fixed; no regressions.

## Test plan

- [ ] CI green
- [ ] `mspec core/hash core/set` no new failures vs base
- [ ] full `bin/test` suite green (modulo the known locale artifacts)

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_