### PR TITLE
set: propagate user-block arity to Set#divide via its no-block Enumerator

### DIFF
--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -175,9 +175,19 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         return Ok(self_val.into());
     };
 
+    // Record the user block's arity so a predicate-consuming method
+    // driven through its no-block enumerator (e.g. `Set#divide`, which
+    // only receives the internal yielder proc as its block) can pick
+    // the right mode from the real arity.
+    let blk_arity = data
+        .func_id()
+        .map(|fid| globals[fid].arity())
+        .unwrap_or(-1);
     let internal = Fiber::from(self_val.proc);
     vm.temp_push(internal.into());
+    globals.push_enum_block_arity(blk_arity);
     let res = each_inner(vm, globals, internal, &data, self_val);
+    globals.pop_enum_block_arity();
     vm.temp_pop();
     res
 }

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1218,8 +1218,16 @@ fn divide(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
     let data = vm.get_block_data(globals, bh)?;
     let keys = set_keys(lfp.self_val());
 
-    // Check block arity to determine mode
-    let arity = if let Some(fid) = data.func_id() {
+    // Check block arity to determine mode.
+    //
+    // When `divide` is driven through its own no-block Enumerator
+    // (`set.divide` then `.each { |a, b| ... }`), the block it receives
+    // is the internal enumerator yielder proc, not the user's block, so
+    // its declared arity is meaningless here. `Enumerator#each` records
+    // the real user-block arity on `Globals`; use that instead.
+    let arity = if data.func_id() == Some(crate::globals::YIELDER_FUNCID) {
+        globals.current_enum_block_arity().unwrap_or(1)
+    } else if let Some(fid) = data.func_id() {
         globals[fid].arity()
     } else {
         1

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1659,4 +1659,50 @@ mod tests {
             r#"(s=Set.new; s.compare_by_identity?)"#,
         ]);
     }
+
+    #[test]
+    fn divide_enumerator_arity() {
+        // Arity-2 via the no-block Enumerator: graph/SCC grouping.
+        run_test(
+            r#"Set[1,2,3,4].divide.each { |a, b| (a + b).even? } == Set[Set[1, 3], Set[2, 4]]"#,
+        );
+        // Arity-1 via the no-block Enumerator: classify grouping.
+        run_test(r#"Set[1,2,3,4].divide.each { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#);
+        // No block -> Enumerator.
+        run_test(r#"Set[1,2,3,4].divide.is_a?(Enumerator)"#);
+        // Direct (non-enumerator) arity-2 / arity-1 still correct.
+        run_test(
+            r#"Set[1,3,4,6,9,10,11].divide { |x, y| (x - y).abs == 1 }.map { |s| s.to_a.sort }.sort"#,
+        );
+        run_test(r#"Set[1,2,3,4].divide { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#);
+    }
+
+    #[test]
+    fn object_keys_use_ruby_hash_eql() {
+        // Set#hash is order-independent and a Set works as a
+        // content-based Hash/Set key (object keys dispatch to Ruby
+        // #hash / #eql?).
+        run_tests(&[
+            r#"Set[1,3].hash == Set[3,1].hash"#,
+            r#"Set[Set[3,1],Set[4,2]] == Set[Set[1,3],Set[2,4]]"#,
+            r#"{Set[1,3] => :x}[Set[3,1]]"#,
+            r#"Set[Set[1,2]].include?(Set[2,1])"#,
+            r#"{[1,2] => :a}[[1,2]]"#,
+            r#"({}[Object.new]).nil?"#,
+        ]);
+        // A user object's #hash / #eql? are consulted on Hash lookup.
+        run_test(
+            r#"
+            class K
+              def initialize(n); @n = n; end
+              def hash; @n.hash; end
+              def eql?(o); o.is_a?(K) && o.instance_variable_get(:@n) == @n; end
+            end
+            h = {}
+            h[K.new(1)] = :a
+            h[K.new(2)] = :b
+            [h[K.new(1)], h[K.new(2)], h[K.new(3)]]
+            "#,
+        );
+    }
 }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -118,6 +118,13 @@ pub struct Globals {
     pub(crate) symbol_names: HashMap<IdentId, Value>,
     /// address of invokers.
     pub(crate) invokers: Invokers,
+    /// Stack of the *user* block arities for the `Enumerator`s
+    /// currently being driven via `Enumerator#each`. A predicate-
+    /// consuming method (e.g. `Set#divide`) driven through its
+    /// no-block enumerator only sees the internal yielder proc as its
+    /// block, so it reads the real arity from here instead. A stack
+    /// supports nested enumerators.
+    pub(crate) enum_block_arity: Vec<i64>,
     /// stats for deoptimization
     #[cfg(feature = "profile")]
     deopt_stats: HashMap<(FuncId, bytecodegen::BcIndex), usize>,
@@ -150,6 +157,24 @@ impl alloc::GC<RValue> for Globals {
         self.store.mark(alloc);
         self.gvars.mark_values(|v| v.mark(alloc));
         self.symbol_names.values().for_each(|v| v.mark(alloc));
+    }
+}
+
+impl Globals {
+    /// Record the arity of the user block driving the current
+    /// `Enumerator#each`, so a predicate-consuming method invoked
+    /// through its no-block enumerator (which only sees the yielder
+    /// proc) can recover the real arity.
+    pub(crate) fn push_enum_block_arity(&mut self, arity: i64) {
+        self.enum_block_arity.push(arity);
+    }
+
+    pub(crate) fn pop_enum_block_arity(&mut self) {
+        self.enum_block_arity.pop();
+    }
+
+    pub(crate) fn current_enum_block_arity(&self) -> Option<i64> {
+        self.enum_block_arity.last().copied()
     }
 }
 
@@ -189,6 +214,7 @@ impl Globals {
             loaded_features,
             symbol_names: HashMap::default(),
             invokers,
+            enum_block_arity: Vec::new(),
             #[cfg(feature = "profile")]
             deopt_stats: HashMap::default(),
             #[cfg(feature = "profile")]


### PR DESCRIPTION
## Summary

`Set#divide` chooses arity-1 (classify) vs arity-2 (graph/SCC) mode
from its block's arity. When driven through its own **no-block
Enumerator** (`set.divide` then `.each { |a, b| ... }`), monoruby's
generic Enumerator passes the driven method the internal *yielder*
proc, not the user's block — so the declared arity was meaningless
and `divide` mis-moded (raising `TypeError: NilClass can't be coerced
into Integer`; a naive "yielder ⇒ arity-2" hack instead regressed the
arity-1 enumerator case).

## Fix

Plumb the real arity instead of guessing. The driven method runs in a
fiber (separate `Executor`) but **`Globals` is shared across the fiber
boundary**, so:

- `Enumerator#each` records the user block's arity on a `Globals`
  stack (nested enumerators supported) around the fiber drive.
- `Set#divide`, when its block is the enumerator yielder
  (`YIELDER_FUNCID`), reads the arity from there instead of the
  meaningless yielder arity.

What looked architectural turned out to be 46 lines, no Enumerator
redesign.

## Verification (vs CRuby 4.0)

- `divide.each { |a| ... }` (arity-1 enum) — **no regression**
- `divide.each { |a, b| ... }` (arity-2 enum) — now produces the
  correct SCC grouping
- direct `divide { |x| ... }` / `divide { |x, y| ... }` — unchanged
- `core/set/divide_spec`: **1F/1E → 1F/0E** (the `TypeError` error is
  eliminated). The remaining failure is the nested-`Set` `==`
  assertion, fixed orthogonally by the Ruby `#hash`/`#eql?` dispatch
  work in **#551** — together they take divide_spec to **0F/0E**.
- `core/set` overall: 1F/0E, no regression.
- Full release test suite: **1516 passed**; only the 2 pre-existing
  local-CRuby-locale inspect artifacts fail (unrelated; pass on CI).

## Test plan

- [x] CI green
- [x] `mspec core/set` no regressions; divide_spec error eliminated
- [x] (with #551 merged) `mspec core/set/divide_spec.rb` → 0F/0E

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_