### PR TITLE
inspect & sprintf correctness: U+00A0, Hash key quoting, non-ASCII-compat components, positional stars (P4 B4/B3/B1/C1)

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -6,7 +6,7 @@ mod binding;
 mod bool_class;
 mod class;
 mod dir;
-mod encoding;
+pub(crate) mod encoding;
 pub(crate) mod errno;
 #[cfg(test)]
 mod encoding_tests;

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -540,19 +540,31 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                 // If #inspect returned a String, use it directly.
                 // Otherwise, call Ruby #to_s on the result.
                 if let Some(str_inner) = inspected.is_rstring_inner() {
-                    let bytes = str_inner.as_bytes();
-                    match std::str::from_utf8(bytes) {
-                        Ok(utf8) => s.push_str(utf8),
-                        Err(_) => s.push_str(&inspected.to_s(&globals.store)),
+                    if let Some(esc) =
+                        crate::value::escape_unicode_noncompat_component(str_inner)
+                    {
+                        s.push_str(&esc);
+                    } else {
+                        let bytes = str_inner.as_bytes();
+                        match std::str::from_utf8(bytes) {
+                            Ok(utf8) => s.push_str(utf8),
+                            Err(_) => s.push_str(&inspected.to_s(&globals.store)),
+                        }
                     }
                 } else {
                     let to_s_result =
                         vm.invoke_method_inner(globals, IdentId::TO_S, inspected, &[], None, None)?;
                     if let Some(str_inner) = to_s_result.is_rstring_inner() {
-                        let bytes = str_inner.as_bytes();
-                        match std::str::from_utf8(bytes) {
-                            Ok(utf8) => s.push_str(utf8),
-                            Err(_) => s.push_str(&to_s_result.to_s(&globals.store)),
+                        if let Some(esc) =
+                            crate::value::escape_unicode_noncompat_component(str_inner)
+                        {
+                            s.push_str(&esc);
+                        } else {
+                            let bytes = str_inner.as_bytes();
+                            match std::str::from_utf8(bytes) {
+                                Ok(utf8) => s.push_str(utf8),
+                                Err(_) => s.push_str(&to_s_result.to_s(&globals.store)),
+                            }
                         }
                     } else {
                         // If #to_s also doesn't return a String, use default representation
@@ -5988,6 +6000,35 @@ mod tests {
             // empty array
             "[].min {|a,b| a <=> b}",
             "[].max {|a,b| a <=> b}",
+        ]);
+    }
+
+    #[test]
+    fn inspect_noncompat_component_escaped() {
+        // When a component's #inspect returns a UTF-16/UTF-32 string,
+        // Array#inspect / Hash#inspect must not splice the raw bytes
+        // (or raise) — ASCII stays, non-ASCII becomes \uXXXX.
+        run_tests(&[
+            r#"
+            o = Object.new
+            def o.inspect; "abあc".encode("UTF-16BE"); end
+            [o].inspect
+            "#,
+            r#"
+            o = Object.new
+            def o.inspect; "x\u{1F600}y".encode("UTF-32LE"); end
+            [1, o].inspect
+            "#,
+            r#"
+            o = Object.new
+            def o.inspect; "kあ".encode("UTF-16LE"); end
+            { a: o }.inspect
+            "#,
+            r#"
+            o = Object.new
+            def o.inspect; "v".encode("UTF-16BE"); end
+            { 1 => o }.to_s
+            "#,
         ]);
     }
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1159,19 +1159,11 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                 first = false;
                 let v_str = inspect_value_for_hash(vm, globals, v)?;
                 if let Some(sym) = k.try_symbol() {
-                    // Use the symbol's #inspect form ("name" / ":\"foo\"") to
-                    // decide whether the shorthand `name:` is valid. If the
-                    // canonical inspect quotes the symbol, mirror that here
-                    // and write `"name":`; otherwise use bare `name:`.
-                    let sym_inspect = crate::value::inspect_symbol(sym);
-                    let key_str = if let Some(rest) = sym_inspect.strip_prefix(":\"") {
-                        // `:\"...\"` -> `"..."`
-                        let inner = rest.strip_suffix('"').unwrap_or(rest);
-                        format!("\"{inner}\"")
-                    } else {
-                        // `:name` -> `name`
-                        sym_inspect.trim_start_matches(':').to_string()
-                    };
+                    // Hash short form: bare `name:` only for plain-
+                    // identifier symbols; operators / `=`-setters /
+                    // `@`/`$` / quoted names use `"name":` (stricter
+                    // than `Symbol#inspect`).
+                    let key_str = crate::value::symbol_hash_label(sym);
                     s.push_str(&format!("{key_str}: {v_str}"));
                 } else {
                     let k_str = inspect_value_for_hash(vm, globals, k)?;
@@ -3775,6 +3767,28 @@ mod tests {
             end
             "#,
         );
+    }
+
+    #[test]
+    fn hash_inspect_symbol_key_label_quoting() {
+        // Hash short form: bare `name:` only for plain-identifier
+        // symbols (optional single trailing ?/!); operators,
+        // `=`-setters, `@`/`$`-prefixed, digit-leading, embedded
+        // spaces/dashes, and the empty symbol use `"name":`.
+        // (Non-ASCII-identifier keys like `:"あ"` are bare on CI but
+        // would false-fail here against the sandbox's broken-locale
+        // CRuby — covered by `core/hash/inspect_spec.rb` instead.)
+        run_tests(&[
+            r#"
+            h = {}
+            [:a, :A, :_x, :foo?, :foo!, :"foo=", :"0", :"!", :"+",
+             :"a b", :"a-b", :"", :x1, :CONST, :"1abc",
+             :"@iv", :"$g", :"==", :"[]", :"[]="].each { |s| h[s] = 1 }
+            h.inspect
+            "#,
+            r#"{ a: 1, "b c": 2, "+": 3 }.to_s"#,
+            r#"{ foo?: 1, bar!: 2, "baz=": 3 }.inspect"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -3798,6 +3798,10 @@ mod tests {
             "#,
             r#"{ a: 1, "b c": 2, "+": 3 }.to_s"#,
             r#"{ foo?: 1, bar!: 2, "baz=": 3 }.inspect"#,
+            // Symbol key whose name is invalid UTF-8 (interned as
+            // bytes): quoted, per-byte `\xNN` form.
+            r#"{ "\xff".b.to_sym => 1 }.inspect"#,
+            r#"{ "\xe3\x81".b.to_sym => 2, ok: 3 }.to_s"#,
         ]);
     }
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1187,11 +1187,21 @@ fn inspect_value_for_hash(
     v: Value,
 ) -> Result<String> {
     let inspected = vm.invoke_method_inner(globals, IdentId::INSPECT, v, &[], None, None)?;
+    if let Some(inner) = inspected.is_rstring_inner() {
+        if let Some(esc) = crate::value::escape_unicode_noncompat_component(inner) {
+            return Ok(esc);
+        }
+    }
     if let Some(s) = inspected.is_str() {
         return Ok(s.to_string());
     }
     let to_s_result =
         vm.invoke_method_inner(globals, IdentId::TO_S, inspected, &[], None, None)?;
+    if let Some(inner) = to_s_result.is_rstring_inner() {
+        if let Some(esc) = crate::value::escape_unicode_noncompat_component(inner) {
+            return Ok(esc);
+        }
+    }
     if let Some(s) = to_s_result.is_str() {
         Ok(s.to_string())
     } else {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -5187,6 +5187,18 @@ mod tests {
             r#"sprintf("%<foo>x", foo: 255)"#,
             r#"sprintf("%<foo>f", foo: 3.14)"#,
             r#"sprintf("%<foo>s", foo: "hello")"#,
+            // Positional `*N$` width / `.*N$` precision stars, mixed
+            // with a positional value reference.
+            r#""%*1$.*2$3$d" % [10, 5, 1]"#,
+            r#""%*1$.*2$3$d" % [-10, 5, 1]"#,
+            r#""%-*1$.*2$3$d" % [10, 5, 1]"#,
+            r#""%-*1$.*2$3$d" % [-10, 5, 1]"#,
+            r#""%*1$.*2$3$d" % [10, -5, 1]"#,
+            r#""%2$*1$d" % [5, 42]"#,
+            r#""%1$*2$d" % [42, 5]"#,
+            // Negative `.*` precision is ignored (sequential form).
+            r#""%.*s" % [-1, "abc"]"#,
+            r#""%10.*d" % [-3, 7]"#,
         ]);
     }
 

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -842,7 +842,9 @@ impl Executor {
                     ch = fchars[i];
                 }
             }
-            // Precision
+            // Precision: `.N`, `.*` (sequential), or `.*N$`
+            // (positional). A negative `.*` precision is ignored
+            // (treated as no precision), matching CRuby.
             let mut precision = None;
             if ch == '.' {
                 i += 1;
@@ -852,25 +854,36 @@ impl Executor {
                     ));
                 }
                 ch = fchars[i];
-                let mut prec = 0usize;
                 if ch == '*' {
-                    mark_unnumbered(used_numbered, &mut used_unnumbered, arg_no)?;
-                    if arguments.len() <= arg_no {
-                        return Err(MonorubyErr::argumenterr("too few arguments"));
-                    }
-                    let p = arguments[arg_no].coerce_to_integer(self, globals)?;
-                    arg_no += 1;
-                    match p {
+                    i += 1; // skip '*'
+                    let prec_val = if let Some(num) =
+                        try_positional(&fchars, flen, &mut i)
+                    {
+                        mark_numbered(num, &mut used_numbered, used_unnumbered, arg_no)?;
+                        if num == 0 || num > arguments.len() {
+                            return Err(MonorubyErr::argumenterr("too few arguments"));
+                        }
+                        arguments[num - 1]
+                    } else {
+                        mark_unnumbered(used_numbered, &mut used_unnumbered, arg_no)?;
+                        if arguments.len() <= arg_no {
+                            return Err(MonorubyErr::argumenterr("too few arguments"));
+                        }
+                        let v = arguments[arg_no];
+                        arg_no += 1;
+                        v
+                    };
+                    match prec_val.coerce_to_integer(self, globals)? {
                         IntegerBase::Fixnum(v) => {
                             if v >= 0 {
-                                prec = v as usize;
+                                precision = Some(v as usize);
                             }
+                            // negative precision: ignored (stays None)
                         }
                         IntegerBase::BigInt(_) => {
                             return Err(MonorubyErr::argumenterr("precision too big"));
                         }
                     }
-                    i += 1;
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
                             "Invalid termination of format string",
@@ -878,6 +891,7 @@ impl Executor {
                     }
                     ch = fchars[i];
                 } else {
+                    let mut prec = 0usize;
                     while ch.is_ascii_digit() {
                         prec = prec
                             .checked_mul(10)
@@ -891,8 +905,25 @@ impl Executor {
                         }
                         ch = fchars[i];
                     }
+                    precision = Some(prec);
                 }
-                precision = Some(prec);
+            }
+            // A `N$` positional *value* reference may follow the width
+            // / precision (e.g. `%*1$.*2$3$d`).
+            if positional_arg.is_none() && named_val.is_none() {
+                if let Some(num) = try_positional(&fchars, flen, &mut i) {
+                    mark_numbered(num, &mut used_numbered, used_unnumbered, arg_no)?;
+                    if num == 0 || num > arguments.len() {
+                        return Err(MonorubyErr::argumenterr("too few arguments"));
+                    }
+                    positional_arg = Some(arguments[num - 1]);
+                    if i >= flen {
+                        return Err(MonorubyErr::argumenterr(
+                            "Invalid termination of format string",
+                        ));
+                    }
+                    ch = fchars[i];
+                }
             }
             // `<name>` may appear between precision and the type char.
             if ch == '<' {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1537,6 +1537,39 @@ pub(crate) fn inspect_symbol(id: IdentId) -> String {
     res
 }
 
+/// When a container (`Array`/`Hash`) `#inspect` concatenates a
+/// component whose `#inspect` returned a string in a non-ASCII-
+/// compatible Unicode encoding (UTF-16/UTF-32), CRuby does not raise
+/// and does not splice the raw bytes — it keeps ASCII bytes verbatim
+/// and renders every non-ASCII codepoint as `\uXXXX` / `\u{XXXXX}`.
+/// Returns `Some(rendered)` for those encodings, `None` otherwise (so
+/// the caller keeps its existing path).
+pub(crate) fn escape_unicode_noncompat_component(inner: &RStringInner) -> Option<String> {
+    use crate::value::Encoding as E;
+    let enc = inner.encoding();
+    if !matches!(
+        enc,
+        E::Utf16Le | E::Utf16Be | E::Utf32Le | E::Utf32Be
+    ) {
+        return None;
+    }
+    let (decoded, _) = crate::builtins::encoding::decode_utf16_32(inner.as_bytes(), enc);
+    let mut out = String::with_capacity(decoded.len());
+    for ch in decoded.chars() {
+        if ch.is_ascii() {
+            out.push(ch);
+        } else {
+            let cp = ch as u32;
+            if cp <= 0xFFFF {
+                out.push_str(&format!("\\u{:04X}", cp));
+            } else {
+                out.push_str(&format!("\\u{{{:X}}}", cp));
+            }
+        }
+    }
+    Some(out)
+}
+
 /// Hash short-form key label for a symbol. CRuby renders `{ sym: v }`
 /// where `sym` is the bare name only if it is a plain identifier
 /// (optionally with a single trailing `?`/`!`); operators, `=`-suffix

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1537,6 +1537,52 @@ pub(crate) fn inspect_symbol(id: IdentId) -> String {
     res
 }
 
+/// Hash short-form key label for a symbol. CRuby renders `{ sym: v }`
+/// where `sym` is the bare name only if it is a plain identifier
+/// (optionally with a single trailing `?`/`!`); operators, `=`-suffix
+/// setters, `@`/`$`-prefixed names, digit-leading or empty names use
+/// the quoted `"name":` form. This is *stricter* than
+/// `Symbol#inspect`'s `is_simple_symbol` (which leaves operators
+/// unquoted), so it needs its own predicate.
+pub(crate) fn symbol_hash_label(id: IdentId) -> String {
+    let name = id.get_ident_name_clone();
+    if let Some(s) = name.as_str() {
+        if is_label_symbol(s) {
+            return s.to_string();
+        }
+    }
+    let (bytes, enc): (&[u8], Encoding) = match &name {
+        IdentName::Utf8(s) => (
+            s.as_bytes(),
+            if s.is_ascii() {
+                Encoding::UsAscii
+            } else {
+                Encoding::Utf8
+            },
+        ),
+        IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
+    };
+    let inner = RStringInner::from_encoding(bytes, enc);
+    format!("\"{}\"", inner.inspect())
+}
+
+/// `true` iff `s` is a plain-identifier symbol name (with an optional
+/// single trailing `?`/`!`) — the names CRuby renders bare as a Hash
+/// short-form key.
+fn is_label_symbol(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let body = match s.as_bytes().last() {
+        Some(b'!') | Some(b'?') => &s[..s.len() - 1],
+        _ => s,
+    };
+    if body.is_empty() {
+        return false;
+    }
+    is_plain_identifier(body)
+}
+
 /// Test whether a symbol name can be rendered without surrounding quotes.
 fn is_simple_symbol(name: &IdentName) -> bool {
     let s = match name.as_str() {

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -320,7 +320,7 @@ impl HashmapInner {
                     let k_inspect = k.inspect_inner(store, set);
                     let v_inspect = v.inspect_inner(store, set);
                     let s = if let Some(k) = k.try_symbol() {
-                        format!("{k}: {v_inspect}")
+                        format!("{}: {v_inspect}", crate::value::symbol_hash_label(k))
                     } else {
                         format!("{k_inspect} => {v_inspect}")
                     };

--- a/monoruby/src/value/rvalue/string/printable.rs
+++ b/monoruby/src/value/rvalue/string/printable.rs
@@ -50,6 +50,13 @@ pub(super) fn is_printable(x: char) -> bool {
     } else if x < 127 {
         // ASCII fast path
         true
+    } else if x == 0xA0 || x == 0xAD {
+        // CRuby's `rb_enc_isprint` (Onigmo) treats NBSP (U+00A0) and
+        // SOFT HYPHEN (U+00AD) as printable, so `String#inspect` shows
+        // them literally. The Rust core table (this module's source)
+        // classifies them as White_Space / Default_Ignorable instead;
+        // override here since this fn is inspect-only.
+        true
     } else if x < 0x10000 {
         check(lower, SINGLETONS0U, SINGLETONS0L, NORMAL0)
     } else if x < 0x20000 {


### PR DESCRIPTION
## Summary

Focused, independently-verified CRuby-correctness commits (encoding-refinement plan, phases **B4 / B3 / B1 / C1**), rebased on current `master`.

| Commit | Area | Effect |
|---|---|---|
| `99f0574b` | `String#inspect` | treat U+00A0 / U+00AD as printable |
| `88f9e20b` | `Hash#inspect` | CRuby symbol-key label quoting |
| `89e5f5b2` | `Array`/`Hash#inspect` | escape non-ASCII-compat components |
| `d7acdea5` | test | cover invalid-UTF-8 symbol-key path |
| `36674e80` | sprintf | positional `*N$` / `.*N$` width/precision stars |

### Details

- **B4** — `String#inspect` showed NBSP (U+00A0) / SOFT HYPHEN (U+00AD) escaped; CRuby's `rb_enc_isprint` classifies them printable. Inspect-only override. `core/string/inspect_spec.rb`: 1 → 0.
- **B3** — Hash short form derived `name:` vs `"name":` from `Symbol#inspect` (operators left unquoted). Added `symbol_hash_label`/`is_label_symbol` — bare only for a plain-identifier name with optional single trailing `?`/`!`. `core/hash` 26/4 → 22/4.
- **B1** — container `#inspect` spliced raw bytes for a component string in a non-ASCII-compatible Unicode encoding (UTF-16/32); now keeps ASCII verbatim and renders non-ASCII as `\uXXXX`/`\u{XXXXX}` (no raise). `core/hash` 22/4 → 20/4, `core/array` 25/8 → 21/8.
- **C1** — `%*N$` worked but `.*N$` (positional precision star) raised `unnumbered(1) mixed with numbered`; a negative `.*` precision was stored as `Some(0)`; a positional value ref after precision (`%*1$.*2$3$d`) wasn't parsed. Now: `.*N$` numbered path, negative `.*` precision ignored, post-precision positional value parsed. `core/string/modulo_spec.rb` **5F/4E → 5F/1E**.

### Net result

- `core/string`: inspect_spec 1→0; modulo 5/4→5/1
- `core/hash`: **26F/4E → 20F/4E**
- `core/array`: **25F/8E → 21F/8E**
- Cumulative, by-name pre/post diff on core/{string,hash,array,symbol}: **zero true regressions**
- Both Prism **and** ruruby parsers green; per-area CRuby-verified unit tests added (byte-exact vs `LANG=C.UTF-8 ruby`)
- Rebased cleanly onto `master` (`e272c98a`, PR #551)

### CI note

`codecov/patch` is advisory and red (project coverage **+0.01%**, build+tests green). The residual uncovered diff lines are monoruby-specific defensive inspect fallbacks (CRuby-incomparable) and the B4 `printable` line (only mspec-coverable due to the documented broken-locale `string_inspect` artifact). Consistent with prior merged PRs in this series.

### Out of scope (documented in commit messages)

- **B2** — `default_external`-dependent inspect: needs making `Encoding.default_external` stateful (broad IO/transcode blast radius); deferred.
- Non-ASCII-identifier Hash keys (`:"あ"`) verified via `core/hash/inspect_spec.rb`, not cargo (broken-locale artifact).

## Test plan

- [x] `core/string` inspect_spec 0, modulo 5/1; `core/hash` 20/4; `core/array` 21/8
- [x] By-name pre/post diff: zero true regressions
- [x] CRuby byte-exact (`LANG=C.UTF-8 ruby`): U+00A0/AD range, symbol-key label matrix, UTF-16/32 component escaping, positional star width/precision/value matrix
- [x] Prism + ruruby; full `builtins::{hash,array}` + format/sprintf cargo suites green (only the pre-existing broken-locale `string_inspect` artifact, which passes on CI)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1