### PR TITLE
io: add IO#path/#to_path, #fsync/#fdatasync, #close_on_exec, #ungetc/#ungetbyte; auto-increment #lineno

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -72,7 +72,6 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_module_func(file_test, "writable_real?", writable_, 1);
 
     globals.define_builtin_func_rest(file, "write", write);
-    globals.define_builtin_funcs(file, "path", &["to_path"], path, 0);
     globals.define_builtin_func(file, "size", size, 0);
     globals.define_builtin_func(file, "flock", flock_, 1);
 
@@ -905,9 +904,9 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         // patterns like `File.new(io.fileno, autoclose: false, path: "")`
         // (logger/log_device.rb feature-detection code) where the caller
         // explicitly disclaims ownership of the borrowed fd.
-        let (name, autoclose) = super::io::io_open_opts(vm, globals, lfp, 1..4, fd)?;
+        let (name, has_path, autoclose) = super::io::io_open_opts(vm, globals, lfp, 1..4, fd)?;
         // SAFETY: fd has been validated as a valid file descriptor above.
-        let io_inner = IoInner::from_raw_fd(fd_i32, name);
+        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path);
         io_inner.set_autoclose(autoclose);
         let mut res = Value::new_io_with_class(io_inner, FILE_CLASS);
         if let Some(bh) = lfp.block() {
@@ -1495,22 +1494,6 @@ fn file_size_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             }
         }
         Err(_) => Ok(Value::nil()),
-    }
-}
-
-///
-/// ### File#path / File#to_path
-/// - path -> String
-/// - to_path -> String
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/File/i/path.html]
-#[monoruby_builtin]
-fn path(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_ = lfp.self_val();
-    let io = self_.as_io_inner();
-    match io.name() {
-        Some(name) => Ok(Value::string_from_str(name)),
-        None => Err(MonorubyErr::runtimeerr("path not available for this IO")),
     }
 }
 

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -52,6 +52,11 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(IO_CLASS, "sysseek", io_sysseek, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "lineno", io_lineno, 0);
     globals.define_builtin_func(IO_CLASS, "lineno=", io_lineno_set, 1);
+    globals.define_builtin_funcs(IO_CLASS, "path", &["to_path"], io_path, 0);
+    globals.define_builtin_func(IO_CLASS, "fsync", io_fsync, 0);
+    globals.define_builtin_func(IO_CLASS, "fdatasync", io_fdatasync, 0);
+    globals.define_builtin_func(IO_CLASS, "close_on_exec?", io_close_on_exec_, 0);
+    globals.define_builtin_func(IO_CLASS, "close_on_exec=", io_close_on_exec_set, 1);
     globals.define_builtin_class_func_with(IO_CLASS, "select", io_select, 1, 4, false);
     globals.define_builtin_class_func_with(IO_CLASS, "foreach", io_foreach, 1, 3, false);
     globals.define_builtin_class_func_with(IO_CLASS, "copy_stream", io_copy_stream, 2, 4, false);
@@ -97,8 +102,8 @@ fn io_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         }
         // Pick up `:autoclose` and `:path` from the options Hash. See
         // `io_open_opts` for the rationale.
-        let (name, autoclose) = io_open_opts(vm, globals, lfp, 1..3, fd)?;
-        let io_inner = IoInner::from_raw_fd(fd_i32, name);
+        let (name, has_path, autoclose) = io_open_opts(vm, globals, lfp, 1..3, fd)?;
+        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path);
         io_inner.set_autoclose(autoclose);
         return Ok(Value::new_io(io_inner));
     }
@@ -124,9 +129,10 @@ pub(super) fn io_open_opts(
     lfp: Lfp,
     range: std::ops::Range<usize>,
     fd: i64,
-) -> Result<(String, bool)> {
+) -> Result<(String, bool, bool)> {
     let mut autoclose = true;
     let mut name = format!("fd {}", fd);
+    let mut has_path = false;
     for i in range {
         if let Some(arg) = lfp.try_arg(i)
             && let Some(h) = arg.try_hash_ty()
@@ -138,10 +144,11 @@ pub(super) fn io_open_opts(
                 && !v.is_nil()
             {
                 name = v.coerce_to_string(vm, globals)?;
+                has_path = true;
             }
         }
     }
-    Ok((name, autoclose))
+    Ok((name, has_path, autoclose))
 }
 
 /// Allocator for `IO` and its subclasses.
@@ -733,8 +740,8 @@ fn io_pipe(_vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr)
         let err = std::io::Error::last_os_error();
         return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "pipe(2)"));
     }
-    let read_io = Value::new_io(IoInner::from_raw_fd(fds[0], "pipe".to_string()));
-    let write_io = Value::new_io(IoInner::from_raw_fd(fds[1], "pipe".to_string()));
+    let read_io = Value::new_io(IoInner::from_raw_fd(fds[0], "pipe".to_string(), false));
+    let write_io = Value::new_io(IoInner::from_raw_fd(fds[1], "pipe".to_string(), false));
     Ok(Value::array2(read_io, write_io))
 }
 
@@ -1347,6 +1354,83 @@ fn io_lineno_set(
         Value::integer(n),
     )?;
     Ok(Value::integer(n))
+}
+
+///
+/// ### IO#path / IO#to_path
+/// - path -> String | nil
+/// - to_path -> String | nil
+///
+/// Returns the path associated with the IO, the pseudo-path for the
+/// standard streams (`<STDIN>` etc.), or `nil` for pipes/`popen`/raw fds
+/// without an explicit `path:` and for closed streams.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/path.html]
+#[monoruby_builtin]
+fn io_path(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(match lfp.self_val().as_io_inner().path() {
+        Some(p) => Value::string(p),
+        None => Value::nil(),
+    })
+}
+
+///
+/// ### IO#fsync
+/// - fsync -> 0
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/fsync.html]
+#[monoruby_builtin]
+fn io_fsync(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ret = lfp.self_val().as_io_inner_mut().fsync(false)?;
+    Ok(Value::integer(ret as i64))
+}
+
+///
+/// ### IO#fdatasync
+/// - fdatasync -> 0
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/fdatasync.html]
+#[monoruby_builtin]
+fn io_fdatasync(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let ret = lfp.self_val().as_io_inner_mut().fsync(true)?;
+    Ok(Value::integer(ret as i64))
+}
+
+///
+/// ### IO#close_on_exec?
+/// - close_on_exec? -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/close_on_exec=3f.html]
+#[monoruby_builtin]
+fn io_close_on_exec_(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(Value::bool(lfp.self_val().as_io_inner().close_on_exec()?))
+}
+
+///
+/// ### IO#close_on_exec=
+/// - close_on_exec = bool -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/close_on_exec=3d.html]
+#[monoruby_builtin]
+fn io_close_on_exec_set(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let v = lfp.arg(0);
+    lfp.self_val().as_io_inner().set_close_on_exec(v.as_bool())?;
+    Ok(v)
 }
 
 /// ### IO#write
@@ -3085,6 +3169,65 @@ mod tests {
             f = File.open("Cargo.toml")
             f.close
             f.gets
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_path_to_path() {
+        run_test(r#"File.open("Cargo.toml") { |f| f.path }"#);
+        run_test(r#"File.open("Cargo.toml") { |f| f.to_path }"#);
+        run_test(r#"$stdin.path"#);
+        run_test(r#"$stdout.path"#);
+        run_test(r#"$stderr.path"#);
+        run_test(r#"r, w = IO.pipe; v = [r.path, w.path]; r.close; w.close; v"#);
+        run_test(
+            r#"File.open("Cargo.toml") { |f| IO.new(f.fileno, path: "X", autoclose: false).path }"#,
+        );
+        run_test(
+            r#"File.open("Cargo.toml") { |f| IO.new(f.fileno, autoclose: false).path }"#,
+        );
+    }
+
+    #[test]
+    fn io_fsync_fdatasync() {
+        run_test_once(
+            r#"
+            path = "/tmp/mr_fsync_test.txt"
+            r = File.open(path, "w") { |f| f.write("payload"); [f.fsync, f.fdatasync] }
+            File.unlink(path)
+            r
+            "#,
+        );
+        run_test_error(
+            r#"
+            f = File.open("Cargo.toml")
+            f.close
+            f.fsync
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_close_on_exec() {
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              before = f.close_on_exec?
+              f.close_on_exec = false
+              a = f.close_on_exec?
+              f.close_on_exec = true
+              b = f.close_on_exec?
+              f.close_on_exec = nil
+              [before, a, b, f.close_on_exec?]
+            end
+            "#,
+        );
+        run_test_error(
+            r#"
+            f = File.open("Cargo.toml")
+            f.close
+            f.close_on_exec?
             "#,
         );
     }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -300,14 +300,30 @@ fn flush(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/gets.html]
 #[monoruby_builtin]
-fn gets(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn gets(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    Ok(if let Some(buf) = io.read_line()? {
-        Value::string(buf)
-    } else {
-        Value::nil()
-    })
+    let line = self_.as_io_inner_mut().read_line()?;
+    match line {
+        Some(buf) => {
+            let cur = globals
+                .store
+                .get_ivar(self_, IdentId::get_id("/lineno"))
+                .and_then(|v| v.try_fixnum())
+                .unwrap_or(0);
+            let n = cur + 1;
+            globals
+                .store
+                .set_ivar(self_, IdentId::get_id("/lineno"), Value::integer(n))?;
+            globals.set_gvar(IdentId::get_id("$."), Value::integer(n));
+            let s = Value::string(buf);
+            globals.set_gvar(IdentId::get_id("$_"), s);
+            Ok(s)
+        }
+        None => {
+            globals.set_gvar(IdentId::get_id("$_"), Value::nil());
+            Ok(Value::nil())
+        }
+    }
 }
 
 ///
@@ -1168,6 +1184,9 @@ fn io_rewind(
         .as_io_inner_mut()
         .seek(0, 0)
         .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, ""))?;
+    globals
+        .store
+        .set_ivar(self_, IdentId::get_id("/lineno"), Value::integer(0))?;
     Ok(Value::integer(0))
 }
 
@@ -1376,9 +1395,9 @@ fn io_sysseek(
 /// ### IO#lineno
 /// - lineno -> Integer
 ///
-/// Returns the value last assigned via `lineno=`, or 0 if it was never
-/// assigned. monoruby does not auto-increment `lineno` on `gets`/`readline`
-/// the way CRuby does — only the explicit setter is honored.
+/// Returns the current line number: incremented by each `gets`/`readline`
+/// (and the default-separator `each_line`), reset to 0 by `rewind`, and
+/// overridable via `lineno=`.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/lineno.html]
 #[monoruby_builtin]
@@ -1411,6 +1430,11 @@ fn io_lineno_set(
 ) -> Result<Value> {
     ensure_io_open(lfp.self_val())?;
     let n = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if n > i32::MAX as i64 || n < i32::MIN as i64 {
+        return Err(MonorubyErr::rangeerr(format!(
+            "integer {n} too big to convert to `int'"
+        )));
+    }
     globals.store.set_ivar(
         lfp.self_val(),
         IdentId::get_id("/lineno"),
@@ -3352,5 +3376,31 @@ mod tests {
             f.ungetc(100)
             "#,
         );
+    }
+
+    #[test]
+    fn io_lineno_autoincrement() {
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              a = f.lineno
+              f.gets; f.gets
+              b = f.lineno
+              line = f.gets
+              [a, b, f.lineno, $. , $_ == line, f.readline ? f.lineno : nil]
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              f.gets; f.gets
+              n = f.lineno
+              f.rewind
+              [n, f.lineno, f.gets.nil?]
+            end
+            "#,
+        );
+        run_test_error(r#"File.open("Cargo.toml") { |f| f.lineno = 4294967296 }"#);
     }
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -49,6 +49,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(IO_CLASS, "eof?", &["eof"], io_eof_, 0);
     globals.define_builtin_func(IO_CLASS, "getbyte", io_getbyte, 0);
     globals.define_builtin_func(IO_CLASS, "getc", io_getc, 0);
+    globals.define_builtin_func(IO_CLASS, "ungetc", io_ungetc, 1);
+    globals.define_builtin_func(IO_CLASS, "ungetbyte", io_ungetbyte, 1);
     globals.define_builtin_func_with(IO_CLASS, "sysseek", io_sysseek, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "lineno", io_lineno, 0);
     globals.define_builtin_func(IO_CLASS, "lineno=", io_lineno_set, 1);
@@ -1115,10 +1117,11 @@ fn io_pos(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     ensure_io_open(lfp.self_val())?;
     let mut self_ = lfp.self_val();
     let io = self_.as_io_inner_mut();
+    let pb = io.pushback_len() as i64;
     let pos = io
         .seek(0, 1)
         .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, ""))?;
-    Ok(Value::integer(pos as i64))
+    Ok(Value::integer((pos as i64 - pb).max(0)))
 }
 
 ///
@@ -1187,6 +1190,9 @@ fn io_eof_(
 ) -> Result<Value> {
     let mut self_ = lfp.self_val();
     let io = self_.as_io_inner_mut();
+    if io.pushback_len() > 0 {
+        return Ok(Value::bool(false));
+    }
     // Read 1 byte; if empty, we're at EOF. Then push it back via seek(-1).
     let buf = io.read(Some(1))?;
     if buf.is_empty() {
@@ -1278,6 +1284,63 @@ fn io_getc(
     } else {
         Ok(Value::string_from_vec(buf))
     }
+}
+
+///
+/// ### IO#ungetbyte
+/// - ungetbyte(string or integer) -> nil
+///
+/// Pushes bytes back so the next read returns them first. An Integer is
+/// reduced modulo 256 (never raises RangeError); `nil` is a no-op.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/ungetbyte.html]
+#[monoruby_builtin]
+fn io_ungetbyte(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let arg = lfp.arg(0);
+    if arg.is_nil() {
+        return Ok(Value::nil());
+    }
+    let bytes = if arg.is_integer() {
+        vec![(arg.coerce_to_pack_u64(vm, globals)? & 0xff) as u8]
+    } else {
+        arg.coerce_to_string(vm, globals)?.into_bytes()
+    };
+    lfp.self_val().as_io_inner_mut().unget(&bytes)?;
+    Ok(Value::nil())
+}
+
+///
+/// ### IO#ungetc
+/// - ungetc(string or integer) -> nil
+///
+/// Pushes a character back so the next read returns it first. An Integer
+/// is interpreted as a codepoint.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/ungetc.html]
+#[monoruby_builtin]
+fn io_ungetc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg = lfp.arg(0);
+    if arg.is_nil() {
+        return Err(MonorubyErr::typeerr(
+            "no implicit conversion of nil into Integer",
+        ));
+    }
+    let bytes = if arg.is_integer() {
+        let cp = (arg.coerce_to_pack_u64(vm, globals)? & 0xffff_ffff) as u32;
+        match char::from_u32(cp) {
+            Some(c) => c.to_string().into_bytes(),
+            None => vec![cp as u8],
+        }
+    } else {
+        arg.coerce_to_string(vm, globals)?.into_bytes()
+    };
+    lfp.self_val().as_io_inner_mut().unget(&bytes)?;
+    Ok(Value::nil())
 }
 
 ///
@@ -3228,6 +3291,65 @@ mod tests {
             f = File.open("Cargo.toml")
             f.close
             f.close_on_exec?
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_ungetbyte() {
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              f.getbyte
+              r = f.ungetbyte("cat")
+              [r, f.getbyte, f.getbyte, f.getbyte, f.getbyte]
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              [f.ungetbyte(nil), f.ungetbyte(4095), f.getbyte,
+               f.ungetbyte(0x4f7574206f6620636861722072616e67ff), f.getbyte]
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_ungetc() {
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              c = f.getc
+              r = f.ungetc(c)
+              p = f.pos
+              [r, p, f.getc, f.eof?]
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            File.open("Cargo.toml") do |f|
+              f.read
+              f.ungetc(100)
+              [f.eof?, f.getc]
+            end
+            "#,
+        );
+        run_test(r#"File.open("Cargo.toml") { |f| f.ungetc(100) }"#);
+    }
+
+    #[test]
+    fn io_ungetc_errors() {
+        run_test_error(r#"$stdout.ungetc(100)"#);
+        run_test_error(r#"$stdout.ungetbyte(42)"#);
+        run_test_error(r#"File.open("Cargo.toml") { |f| f.getc; f.ungetc(nil) }"#);
+        run_test_error(
+            r#"
+            f = File.open("Cargo.toml")
+            f.close
+            f.ungetc(100)
             "#,
         );
     }

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     io::{BufRead, IsTerminal, Read, Seek, SeekFrom, Write},
     mem::ManuallyDrop,
     os::fd::{AsRawFd, FromRawFd, IntoRawFd},
@@ -33,6 +33,10 @@ pub struct FileDescriptor {
     /// (see `logger/log_device.rb#fixup_mode`) where the original IO is
     /// expected to relinquish ownership of the fd to the new wrapper.
     autoclose: Cell<bool>,
+    /// Bytes pushed back via `IO#ungetc` / `IO#ungetbyte`, served before
+    /// the underlying reader on the next read. Stored in read order (front
+    /// = next byte out); each unget splices its bytes at the front.
+    pushback: RefCell<Vec<u8>>,
 }
 
 impl Drop for FileDescriptor {
@@ -58,6 +62,8 @@ pub struct PopenDescriptor {
     child: std::process::Child,
     pub(crate) reader: Option<std::io::BufReader<std::process::ChildStdout>>,
     pub(crate) writer: Option<std::process::ChildStdin>,
+    /// See `FileDescriptor::pushback`.
+    pushback: RefCell<Vec<u8>>,
 }
 
 #[derive(Debug)]
@@ -165,6 +171,7 @@ impl IoInner {
             name,
             has_path: true,
             autoclose: Cell::new(true),
+            pushback: RefCell::new(Vec::new()),
         }))
     }
 
@@ -175,6 +182,7 @@ impl IoInner {
             child,
             reader,
             writer,
+            pushback: RefCell::new(Vec::new()),
         }))
     }
 
@@ -193,6 +201,7 @@ impl IoInner {
             name,
             has_path,
             autoclose: Cell::new(true),
+            pushback: RefCell::new(Vec::new()),
         }))
     }
 
@@ -231,7 +240,81 @@ impl IoInner {
         }
     }
 
+    /// Bytes currently sitting in the `ungetc`/`ungetbyte` pushback buffer.
+    pub fn pushback_len(&self) -> usize {
+        match self {
+            Self::File(f) => f.pushback.borrow().len(),
+            Self::Popen(p) => p.pushback.borrow().len(),
+            _ => 0,
+        }
+    }
+
+    fn pushback_cell(&self) -> Option<&RefCell<Vec<u8>>> {
+        match self {
+            Self::File(f) => Some(&f.pushback),
+            Self::Popen(p) => Some(&p.pushback),
+            _ => None,
+        }
+    }
+
+    /// Push `bytes` back so the next read returns them first. CRuby raises
+    /// `IOError` on closed streams and on streams not opened for reading
+    /// (`STDOUT`/`STDERR`). Each call splices at the front, so successive
+    /// ungets behave LIFO while a single multi-byte unget preserves order.
+    pub fn unget(&mut self, bytes: &[u8]) -> Result<()> {
+        match self {
+            Self::Closed => Err(MonorubyErr::ioerr("closed stream")),
+            Self::Stdin | Self::Stdout | Self::Stderr => {
+                Err(MonorubyErr::ioerr("not opened for reading"))
+            }
+            Self::File(_) | Self::Popen(_) => {
+                let cell = self.pushback_cell().unwrap();
+                let mut pb = cell.borrow_mut();
+                pb.splice(0..0, bytes.iter().copied());
+                Ok(())
+            }
+        }
+    }
+
+    /// Take up to `max` bytes (all if `None`) from the front of the
+    /// pushback buffer.
+    fn take_pushback(&mut self, max: Option<usize>) -> Vec<u8> {
+        let cell = match self.pushback_cell() {
+            Some(c) => c,
+            None => return vec![],
+        };
+        let mut pb = cell.borrow_mut();
+        let n = match max {
+            Some(m) => m.min(pb.len()),
+            None => pb.len(),
+        };
+        pb.drain(..n).collect()
+    }
+
     pub fn read(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
+        if self.pushback_len() > 0 {
+            match length {
+                Some(0) => return Ok(vec![]),
+                Some(n) if n <= self.pushback_len() => {
+                    return Ok(self.take_pushback(Some(n)));
+                }
+                Some(n) => {
+                    let mut out = self.take_pushback(None);
+                    let need = n - out.len();
+                    out.extend_from_slice(&self.read_underlying(Some(need))?);
+                    return Ok(out);
+                }
+                None => {
+                    let mut out = self.take_pushback(None);
+                    out.extend_from_slice(&self.read_underlying(None)?);
+                    return Ok(out);
+                }
+            }
+        }
+        self.read_underlying(length)
+    }
+
+    fn read_underlying(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
         match self {
             Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin => {
@@ -293,6 +376,29 @@ impl IoInner {
     }
 
     pub fn read_line(&mut self) -> Result<Option<String>> {
+        if self.pushback_len() > 0 {
+            let cell = self.pushback_cell().unwrap();
+            let nl = cell.borrow().iter().position(|&b| b == b'\n');
+            match nl {
+                Some(idx) => {
+                    let line = self.take_pushback(Some(idx + 1));
+                    return Ok(Some(String::from_utf8_lossy(&line).into_owned()));
+                }
+                None => {
+                    let mut line = self.take_pushback(None);
+                    match self.read_line_underlying()? {
+                        Some(rest) => line.extend_from_slice(rest.as_bytes()),
+                        None if line.is_empty() => return Ok(None),
+                        None => {}
+                    }
+                    return Ok(Some(String::from_utf8_lossy(&line).into_owned()));
+                }
+            }
+        }
+        self.read_line_underlying()
+    }
+
+    fn read_line_underlying(&mut self) -> Result<Option<String>> {
         match self {
             Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin => {

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -21,6 +21,11 @@ fn encode_wait_status(status: &std::process::ExitStatus) -> i32 {
 pub struct FileDescriptor {
     reader: ManuallyDrop<std::io::BufReader<std::fs::File>>,
     name: String,
+    /// Whether `name` is a real filesystem path (surfaced via `IO#path`).
+    /// `false` for placeholder names like `fd 3`/`pipe` created from a raw
+    /// fd without an explicit `path:` option — CRuby's `IO#path` is `nil`
+    /// in that case.
+    has_path: bool,
     /// CRuby's `IO#autoclose=` semantics. When `true` (the default), the
     /// underlying fd is closed when this `FileDescriptor` is dropped. When
     /// `false`, ownership is released via `into_raw_fd` so the fd is *not*
@@ -158,6 +163,7 @@ impl IoInner {
         Self::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
+            has_path: true,
             autoclose: Cell::new(true),
         }))
     }
@@ -179,12 +185,13 @@ impl IoInner {
         }
     }
 
-    pub(crate) fn from_raw_fd(fd: i32, name: String) -> Self {
+    pub(crate) fn from_raw_fd(fd: i32, name: String, has_path: bool) -> Self {
         // SAFETY: fd is a valid file descriptor obtained from pipe().
         let file = unsafe { std::fs::File::from_raw_fd(fd) };
         Self::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
+            has_path,
             autoclose: Cell::new(true),
         }))
     }
@@ -386,6 +393,74 @@ impl IoInner {
             Self::File(file) => Some(&file.name),
             _ => None,
         }
+    }
+
+    /// CRuby `IO#path` / `IO#to_path`. Returns the pseudo-path for the
+    /// standard streams, the real filesystem path for file-backed IO (and
+    /// raw-fd IO opened with an explicit `path:`), and `nil` for pipes,
+    /// `popen`, raw fds without a path, and closed streams.
+    pub fn path(&self) -> Option<String> {
+        match self {
+            Self::Stdin => Some("<STDIN>".to_string()),
+            Self::Stdout => Some("<STDOUT>".to_string()),
+            Self::Stderr => Some("<STDERR>".to_string()),
+            Self::File(file) if file.has_path => Some(file.name.clone()),
+            Self::File(_) | Self::Popen(_) | Self::Closed => None,
+        }
+    }
+
+    /// CRuby `IO#fsync` / `IO#fdatasync`. Flushes user-space buffers, then
+    /// asks the kernel to flush to permanent storage. `data_only` selects
+    /// `fdatasync(2)` (skip metadata) over `fsync(2)`. Returns `0` on
+    /// success (matching CRuby), `IOError` on a closed stream.
+    pub fn fsync(&mut self, data_only: bool) -> Result<i32> {
+        self.flush()?;
+        let fd = self.fileno()?;
+        let ret = unsafe {
+            if data_only {
+                libc::fdatasync(fd)
+            } else {
+                libc::fsync(fd)
+            }
+        };
+        if ret == -1 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::ioerr(err.to_string()));
+        }
+        Ok(0)
+    }
+
+    /// CRuby `IO#close_on_exec?`. Reads the `FD_CLOEXEC` flag via
+    /// `fcntl(F_GETFD)`. `IOError` on a closed stream.
+    pub fn close_on_exec(&self) -> Result<bool> {
+        let fd = self.fileno()?;
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags == -1 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::ioerr(err.to_string()));
+        }
+        Ok(flags & libc::FD_CLOEXEC != 0)
+    }
+
+    /// CRuby `IO#close_on_exec=`. Sets/clears `FD_CLOEXEC` via
+    /// `fcntl(F_GETFD)`/`fcntl(F_SETFD)`. `IOError` on a closed stream.
+    pub fn set_close_on_exec(&self, value: bool) -> Result<()> {
+        let fd = self.fileno()?;
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags == -1 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::ioerr(err.to_string()));
+        }
+        let new_flags = if value {
+            flags | libc::FD_CLOEXEC
+        } else {
+            flags & !libc::FD_CLOEXEC
+        };
+        if unsafe { libc::fcntl(fd, libc::F_SETFD, new_flags) } == -1 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::ioerr(err.to_string()));
+        }
+        Ok(())
     }
 
     /// Set the autoclose flag for a File IO. No-op for stdio/pipe/popen/closed


### PR DESCRIPTION
## Summary

Three independent, well-scoped `core/io` improvements, each verified against a
clean-`master` ruby/spec baseline with **zero regressions** (≈ +43 examples
total). All read-hot paths (`read`/`gets`/`getc`/`getbyte`/`eof`/`pos`/
`readline`/`readlines`/`readchar`) confirmed unchanged.

- **`IO#path`/`#to_path`, `#fsync`/`#fdatasync`, `#close_on_exec?`/`=`**
  - `path`/`to_path` moved to `IO` (File inherits): pseudo-paths for the
    standard streams, real path for file-backed IO and raw fds opened with an
    explicit `path:`, `nil` for pipes/`popen`/raw fds without a path. A
    `has_path` flag on `FileDescriptor` distinguishes `IO.new(fd)` (→ `nil`)
    from `IO.new(fd, path:)`.
  - `fsync`/`fdatasync`: flush user buffers then `fsync(2)`/`fdatasync(2)`,
    return `0`; `IOError` on closed.
  - `close_on_exec?`/`=`: `fcntl(F_GETFD/F_SETFD)` `FD_CLOEXEC`; `IOError` on
    closed.
  - spec: fsync 2E→0, path 1E→pass, close_on_exec 9E→1E.

- **`IO#ungetc`/`#ungetbyte`** — per-IO pushback buffer (File/Popen) consumed
  before the underlying reader by `read`/`read_line`, with `eof?`/`pos`
  accounting for it. `ungetbyte` reduces an Integer mod 256 (never
  `RangeError`), `nil` is a no-op; `ungetc` interprets an Integer as a
  codepoint; both accept strings/`#to_str`. Closed/non-readable streams →
  `IOError`; `ungetc(nil)` → `TypeError`.
  - spec: ungetbyte 6/6, ungetc 12/14 (remaining: external-encoding interp,
    missing `#sysread`).

- **`IO#lineno` auto-increment + `$.`/`$_`** — `gets` increments the per-IO
  line counter, sets `$.` and `$_` (`nil` at EOF); `rewind` resets it;
  `readline`/default-separator `each_line` inherit via `gets`. `lineno=`
  raises `RangeError` outside C-int range.
  - spec: lineno 8F→4F, gets 31F→22F, readline 7F→6F (residual lineno
    failures need read/write-mode tracking, out of scope here).

## Test plan

- [x] `cargo build` clean
- [x] io unit-test module green (78/78), incl. new regression tests for
      each batch (both prism + ruruby parsers)
- [x] ruby/spec deltas measured against a freshly built clean-`master`
      binary; no regressions in any touched spec
      (`read`/`gets`/`getc`/`eof`/`pos`/`readline`/`readlines`/`readchar`/
      `new`/`open`/`pipe`/`popen`/`autoclose`/`fileno`/`file path|to_path`)

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_