### PR TITLE
encoding: stateful default_external + Symbol source-encoding preservation (P4 B2/A1)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -523,6 +523,7 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     crate::value::exec_recursive(
         self_val.id(),
         || {
+            let escape = crate::builtins::encoding::inspect_escape_nonascii(globals);
             let ary = self_val.as_array();
             if ary.len() == 0 {
                 return Ok(Value::string_from_inner(RStringInner::from_encoding(
@@ -573,7 +574,14 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                 }
             }
             s.push(']');
-            Ok(Value::string(s))
+            if escape {
+                Ok(Value::string_from_inner(RStringInner::from_encoding(
+                    crate::value::escape_nonascii_to_u(&s).as_bytes(),
+                    Encoding::UsAscii,
+                )))
+            } else {
+                Ok(Value::string(s))
+            }
         },
         Value::string("[...]".to_string()),
     )

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1361,6 +1361,11 @@ fn enc_default_external(
     _lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    if let Some(v) = globals.get_gvar(IdentId::get_id("$DEFAULT_EXTERNAL")) {
+        if !v.is_nil() {
+            return Ok(v);
+        }
+    }
     let enc_class = encoding_class(globals);
     let utf8 = globals
         .store
@@ -1376,13 +1381,43 @@ fn enc_default_external(
 /// [https://docs.ruby-lang.org/ja/latest/method/Encoding/s/default_external=3d.html]
 #[monoruby_builtin]
 fn enc_set_default_external(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    // Stub: accept the argument but do nothing
-    Ok(lfp.arg(0))
+    let val = lfp.arg(0);
+    if val.is_nil() {
+        return Err(MonorubyErr::argumenterr(
+            "default external can not be nil",
+        ));
+    }
+    // A String argument is resolved through `Encoding.find`.
+    let enc_val = if val.is_str().is_some() {
+        let find_id = IdentId::get_id("find");
+        let enc_class_val = lfp.self_val();
+        vm.invoke_method_inner(globals, find_id, enc_class_val, &[val], None, None)?
+    } else {
+        val
+    };
+    globals.set_gvar(IdentId::get_id("$DEFAULT_EXTERNAL"), enc_val);
+    Ok(enc_val)
+}
+
+/// CRuby renders container (`Array`/`Hash`) `#inspect` with non-ASCII
+/// escaped as `\uXXXX` and a US-ASCII result string whenever
+/// `Encoding.default_external` is not UTF-8 (when it is UTF-8 — the
+/// default — non-ASCII is shown literally, the existing behaviour).
+pub(crate) fn inspect_escape_nonascii(globals: &mut Globals) -> bool {
+    match globals.get_gvar(IdentId::get_id("$DEFAULT_EXTERNAL")) {
+        Some(v) if !v.is_nil() => globals
+            .store
+            .get_ivar(v, IdentId::_ENCODING)
+            .and_then(|s| s.is_str().map(|s| s.to_string()))
+            .map(|n| n != "UTF-8")
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 ///
@@ -3594,6 +3629,43 @@ mod tests {
             raise "should be Encoding" unless enc.is_a?(Encoding)
             "#,
         );
+    }
+
+    #[test]
+    fn inspect_under_default_external() {
+        // `Encoding.default_external` is now stateful (get/set via a
+        // gvar). Container #inspect escapes non-ASCII as \uXXXX and
+        // tags the result US-ASCII unless default_external is UTF-8.
+        run_tests(&[
+            // round-trips get/set
+            r#"o = Encoding.default_external
+               Encoding.default_external = Encoding::US_ASCII
+               r = Encoding.default_external.name
+               Encoding.default_external = o
+               r"#,
+            // non-UTF-8 default_external => escaped + US-ASCII result
+            r#"o = Encoding.default_external
+               Encoding.default_external = Encoding::US_ASCII
+               r = [{ "あ": 1 }.inspect, ["café"].inspect,
+                    [1, 2].inspect.encoding.name,
+                    { a: 1 }.inspect]
+               Encoding.default_external = o
+               r"#,
+            r#"o = Encoding.default_external
+               Encoding.default_external = Encoding.find('UTF-32')
+               r = [["jp".encode("EUC-JP"), "utf8"].inspect,
+                    ["jp".encode("EUC-JP"), "utf8"].inspect.encoding.name,
+                    { あ: 1 }.to_s]
+               Encoding.default_external = o
+               r"#,
+            // UTF-8 default_external => unchanged (bare, UTF-8 result)
+            r#"o = Encoding.default_external
+               Encoding.default_external = Encoding::UTF_8
+               r = [{ あ: 1 }.inspect, ["café"].inspect,
+                    ["café"].inspect.encoding.name]
+               Encoding.default_external = o
+               r"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1146,9 +1146,20 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     crate::value::exec_recursive(
         self_val.id(),
         || {
+            let escape = crate::builtins::encoding::inspect_escape_nonascii(globals);
+            let mk = |s: String| {
+                if escape {
+                    Value::string_from_inner(RStringInner::from_encoding(
+                        crate::value::escape_nonascii_to_u(&s).as_bytes(),
+                        Encoding::UsAscii,
+                    ))
+                } else {
+                    Value::string(s)
+                }
+            };
             let hash = self_val.as_hash();
             if hash.len() == 0 {
-                return Ok(Value::string("{}".to_string()));
+                return Ok(mk("{}".to_string()));
             }
             let mut s = String::from("{");
             let mut first = true;
@@ -1163,7 +1174,7 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                     // identifier symbols; operators / `=`-setters /
                     // `@`/`$` / quoted names use `"name":` (stricter
                     // than `Symbol#inspect`).
-                    let key_str = crate::value::symbol_hash_label(sym);
+                    let key_str = crate::value::symbol_hash_label(sym, escape);
                     s.push_str(&format!("{key_str}: {v_str}"));
                 } else {
                     let k_str = inspect_value_for_hash(vm, globals, k)?;
@@ -1171,7 +1182,7 @@ fn inspect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                 }
             }
             s.push('}');
-            Ok(Value::string(s))
+            Ok(mk(s))
         },
         Value::string("{...}".to_string()),
     )

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -4798,6 +4798,19 @@ fn to_sym(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         Ok(s) => IdentId::get_id(s),
         Err(_) => IdentId::get_id_from_bytes(inner.as_bytes().to_vec()),
     };
+    // Preserve the source encoding when `Symbol#to_s` cannot
+    // re-derive it from the bytes alone (UTF-16/32, EUC-JP, …).
+    // US-ASCII / UTF-8 / ASCII-8BIT are reconstructed correctly by
+    // the default derivation, so they need no side-map entry.
+    let enc = inner.encoding();
+    if !matches!(
+        enc,
+        crate::value::Encoding::UsAscii
+            | crate::value::Encoding::Utf8
+            | crate::value::Encoding::Ascii8
+    ) {
+        id.set_symbol_encoding(enc);
+    }
     Ok(Value::symbol(id))
 }
 

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -38,7 +38,7 @@ pub(super) fn init(globals: &mut Globals) {
 fn sym_to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let sym = lfp.self_val().as_symbol();
     let ident_name = sym.get_ident_name_clone();
-    let (bytes, enc) = match &ident_name {
+    let (bytes, default_enc) = match &ident_name {
         IdentName::Utf8(s) => {
             let enc = if s.is_ascii() {
                 Encoding::UsAscii
@@ -49,6 +49,9 @@ fn sym_to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
         }
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
+    // A recorded source encoding (set by `String#to_sym` for
+    // UTF-16/32 etc.) overrides the byte-derived default.
+    let enc = sym.symbol_encoding().unwrap_or(default_enc);
     let inner = RStringInner::from_encoding(bytes, enc);
     let mut result = Value::string_from_inner(inner);
     result.set_chilled();
@@ -71,7 +74,7 @@ fn sym_name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         return Ok(v);
     }
     let ident_name = sym.get_ident_name_clone();
-    let (bytes, enc) = match &ident_name {
+    let (bytes, default_enc) = match &ident_name {
         IdentName::Utf8(s) => {
             let enc = if s.is_ascii() {
                 Encoding::UsAscii
@@ -82,6 +85,7 @@ fn sym_name(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         }
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
+    let enc = sym.symbol_encoding().unwrap_or(default_enc);
     let inner = RStringInner::from_encoding(bytes, enc);
     let mut v = Value::string_from_inner(inner);
     v.set_frozen();
@@ -561,5 +565,26 @@ mod tests {
             end
             "#,
         );
+    }
+
+    #[test]
+    fn symbol_preserves_source_encoding() {
+        // `String#to_sym` records a non-default source encoding
+        // (UTF-16/32) so Symbol#{to_s,name,encoding,inspect,end_with?}
+        // round-trip it. ASCII / UTF-8 keep the default derivation.
+        run_tests(&[
+            r#""foo".encode("UTF-16LE").to_sym.encoding.name"#,
+            r#""foo".encode("UTF-16LE").to_sym.inspect"#,
+            r#""foo".encode("UTF-16LE").to_sym.to_s.encoding.name"#,
+            r#""foo".encode("UTF-16LE").to_sym.name.encoding.name"#,
+            r#""abç".encode("UTF-16BE").to_sym.inspect"#,
+            r#""x".encode("UTF-32LE").to_sym.encoding.name"#,
+            r#"s = "\xd8\x00\xdc\x00".dup.force_encoding("UTF-16BE").to_sym
+               s.end_with?("\xdc\x00".dup.force_encoding("UTF-16BE"))"#,
+            r#""abcd".encode("UTF-16BE").to_sym.end_with?("cd".encode("UTF-16BE"))"#,
+            // ASCII / UTF-8 unchanged
+            r#""abc".to_sym.encoding.name"#,
+            r#":café.encoding.name"#,
+        ]);
     }
 }

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -305,6 +305,22 @@ impl IdentId {
     }
 
     ///
+    /// Record the source-string encoding a symbol was created from
+    /// (only when it differs from the default `Symbol#to_s`
+    /// derivation). Called by `String#to_sym`.
+    ///
+    pub(crate) fn set_symbol_encoding(self, enc: crate::value::Encoding) {
+        ID.write().unwrap().enc_map.insert(self, enc);
+    }
+
+    ///
+    /// The recorded source encoding for this symbol, if any.
+    ///
+    pub(crate) fn symbol_encoding(self) -> Option<crate::value::Encoding> {
+        ID.read().unwrap().enc_map.get(&self).copied()
+    }
+
+    ///
     /// Compare *self* to *other* by raw bytes.
     ///
     pub fn compare(&self, other: &Self) -> std::cmp::Ordering {
@@ -354,6 +370,13 @@ pub struct IdentifierTable {
     rev_table_bytes: HashMap<Vec<u8>, IdentId>,
     /// Forward table: IdentId -> IdentName.
     table: Vec<IdentName>,
+    /// Sparse side-map: the source-string encoding a symbol was
+    /// created from, when it is *not* the one `Symbol#to_s` would
+    /// derive by default (i.e. not US-ASCII / UTF-8 / ASCII-8BIT).
+    /// Only `String#to_sym` populates it; method/ivar/constant
+    /// interning never touches it, so symbol identity and dispatch
+    /// are unaffected.
+    enc_map: HashMap<IdentId, crate::value::Encoding>,
 }
 
 impl IdentifierTable {
@@ -362,6 +385,7 @@ impl IdentifierTable {
             rev_table: HashMap::default(),
             rev_table_bytes: HashMap::default(),
             table: vec![IdentName::Utf8(String::new()); 100],
+            enc_map: HashMap::default(),
         };
         table.set_id("initialize", IdentId::INITIALIZE);
         table.set_id("Object", IdentId::OBJECT);

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1519,7 +1519,7 @@ pub(crate) fn inspect_symbol(id: IdentId) -> String {
         }
         return res;
     }
-    let (bytes, enc) = match &ident_name {
+    let (bytes, default_enc) = match &ident_name {
         IdentName::Utf8(s) => {
             let enc = if s.is_ascii() {
                 Encoding::UsAscii
@@ -1530,6 +1530,7 @@ pub(crate) fn inspect_symbol(id: IdentId) -> String {
         }
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
+    let enc = id.symbol_encoding().unwrap_or(default_enc);
     let inner = RStringInner::from_encoding(bytes, enc);
     let mut res = String::from(":\"");
     res.push_str(&inner.inspect());
@@ -1587,7 +1588,7 @@ pub(crate) fn symbol_hash_label(id: IdentId, escape: bool) -> String {
             return s.to_string();
         }
     }
-    let (bytes, enc): (&[u8], Encoding) = match &name {
+    let (bytes, default_enc): (&[u8], Encoding) = match &name {
         IdentName::Utf8(s) => (
             s.as_bytes(),
             if s.is_ascii() {
@@ -1598,6 +1599,7 @@ pub(crate) fn symbol_hash_label(id: IdentId, escape: bool) -> String {
         ),
         IdentName::Bytes(b) => (b.as_slice(), Encoding::Ascii8),
     };
+    let enc = id.symbol_encoding().unwrap_or(default_enc);
     let inner = RStringInner::from_encoding(bytes, enc);
     format!("\"{}\"", inner.inspect())
 }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1577,10 +1577,13 @@ pub(crate) fn escape_unicode_noncompat_component(inner: &RStringInner) -> Option
 /// the quoted `"name":` form. This is *stricter* than
 /// `Symbol#inspect`'s `is_simple_symbol` (which leaves operators
 /// unquoted), so it needs its own predicate.
-pub(crate) fn symbol_hash_label(id: IdentId) -> String {
+pub(crate) fn symbol_hash_label(id: IdentId, escape: bool) -> String {
     let name = id.get_ident_name_clone();
     if let Some(s) = name.as_str() {
-        if is_label_symbol(s) {
+        // Under `escape` mode (non-UTF-8 `default_external`) a name
+        // with non-ASCII can't be a bare label — it must be quoted so
+        // the caller's `\u` pass can escape it.
+        if is_label_symbol(s) && !(escape && !s.is_ascii()) {
             return s.to_string();
         }
     }
@@ -1597,6 +1600,29 @@ pub(crate) fn symbol_hash_label(id: IdentId) -> String {
     };
     let inner = RStringInner::from_encoding(bytes, enc);
     format!("\"{}\"", inner.inspect())
+}
+
+/// Replace every non-ASCII character with `\uXXXX` / `\u{XXXXX}`,
+/// leaving ASCII bytes untouched. Used by container `#inspect` when
+/// `Encoding.default_external` is not UTF-8.
+pub(crate) fn escape_nonascii_to_u(s: &str) -> String {
+    if s.is_ascii() {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if ch.is_ascii() {
+            out.push(ch);
+        } else {
+            let cp = ch as u32;
+            if cp <= 0xFFFF {
+                out.push_str(&format!("\\u{:04X}", cp));
+            } else {
+                out.push_str(&format!("\\u{{{:X}}}", cp));
+            }
+        }
+    }
+    out
 }
 
 /// `true` iff `s` is a plain-identifier symbol name (with an optional

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -320,7 +320,7 @@ impl HashmapInner {
                     let k_inspect = k.inspect_inner(store, set);
                     let v_inspect = v.inspect_inner(store, set);
                     let s = if let Some(k) = k.try_symbol() {
-                        format!("{}: {v_inspect}", crate::value::symbol_hash_label(k))
+                        format!("{}: {v_inspect}", crate::value::symbol_hash_label(k, false))
                     } else {
                         format!("{k_inspect} => {v_inspect}")
                     };


### PR DESCRIPTION
## Summary

Two encoding-refinement commits, rebased on current `master` (`aa786ef9`).

| Commit | Phase | Effect |
|---|---|---|
| `674b3bb7` | **B2** | stateful `Encoding.default_external` + container-inspect threading |
| `421efebf` | **A1** | `String#to_sym` preserves source encoding (UTF-16/32) |

### B2 — stateful `Encoding.default_external`

Was hardcoded UTF-8 with a no-op setter. Now stored/read via the `$DEFAULT_EXTERNAL` gvar (mirrors the existing `$DEFAULT_INTERNAL` precedent; `IO#external_encoding` is independently hardcoded, so this is decoupled and low-risk). When `default_external` is not UTF-8, `Array`/`Hash` `#inspect`/`#to_s` escape non-ASCII as `\uXXXX` and tag the result `US-ASCII`; otherwise behaviour is unchanged. **`core/array/{inspect,to_s}_spec.rb` 1F → 0F.**

### A1 — Symbol source-encoding preservation

The global interner stored only `Utf8`/`Bytes`, so a symbol made from a UTF-16/32 string was re-tagged US-ASCII/ASCII-8BIT by `Symbol#to_s` (broke `#encoding`/`#inspect`; `#end_with?` raised a spurious `CompatibilityError`). Added a **sparse side-map** `HashMap<IdentId, Encoding>` in the `IdentifierTable`; `String#to_sym` records the source encoding only when it is not US-ASCII/UTF-8/ASCII-8BIT (others reconstruct correctly by default). `Symbol#{to_s,name}`, `inspect_symbol`, `symbol_hash_label` consult it. **Method/ivar/constant interning never touches the side-map — symbol identity and dispatch are unaffected (no interner re-keying).** `core/symbol/end_with_spec.rb` **1E → 0**; `inspect_spec.rb` **2F → 1F**; `core/symbol` **2F/1E → 1F/0E**.

### Net result

- By-name pre/post diff vs `master`: **zero true regressions**; **6 true fixes** (B2: 2 Array US-ASCII; A1: `String#{to_sym,intern}` UTF-16LE, `Symbol#end_with?` head-of-char, `Symbol#inspect` non-ASCII-compatible)
- Byte-exact vs `LANG=C.UTF-8 ruby`; Prism **and** ruruby parsers green; CRuby-verified unit tests added per phase

### Known / out of scope (documented in commit messages)

- **Dummy-encoding symbol inspect** (`"abcd".force_encoding("UTF-7").to_sym.inspect`): `force_encoding` maps UTF-7/CESU-8/Emacs-Mule to ASCII-8BIT/UTF-8 (no Encoding-enum variants), losing the dummy name before `to_sym`. Needs a separate encoding-model expansion.
- **Hash `can be evaled when default_external is changed`** (B2): the ASCII/UTF-8 assertions now pass, which unmasks a pre-existing parser limitation (`eval` of a Shift_JIS source) — same example flips `FAILED → ERROR`, not a new regression.
- Pre-existing broken-locale cargo artifacts (`string_inspect`, `symbol_inspect_unquoted`) fail locally but pass on CI; untouched, per the handoff.
- `codecov/patch` is advisory (project coverage **+0.01%**, build+tests green); residual uncovered lines are defensive/edge paths — consistent with prior merged PRs in this series.

## Test plan

- [x] `core/array/{inspect,to_s}_spec.rb` 0/0; `core/symbol` 1F/0E (was 2F/1E)
- [x] By-name pre/post diff on core/{symbol,string,hash,array}: zero true regressions
- [x] CRuby byte-exact: default_external = US-ASCII/UTF-32/UTF-8 (Array/Hash); UTF-16/32 symbol encoding/to_s/name/inspect/end_with?
- [x] Prism + ruruby; `builtins::{encoding,hash,array,symbol}` cargo suites green (only the documented pre-existing broken-locale artifacts)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1