### PR TITLE
io: track read/write access mode and enforce directional IOError

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -905,8 +905,9 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         // (logger/log_device.rb feature-detection code) where the caller
         // explicitly disclaims ownership of the borrowed fd.
         let (name, has_path, autoclose) = super::io::io_open_opts(vm, globals, lfp, 1..4, fd)?;
+        let (readable, writable) = super::io::fd_rw_mode(fd_i32);
         // SAFETY: fd has been validated as a valid file descriptor above.
-        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path);
+        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path, readable, writable);
         io_inner.set_autoclose(autoclose);
         let mut res = Value::new_io_with_class(io_inner, FILE_CLASS);
         if let Some(bh) = lfp.block() {
@@ -962,6 +963,12 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // Strip encoding suffix (e.g. ":UTF-8") and normalize the mode string:
     // remove 'b' (binary) flag since it has no effect on Unix.
     let mode_base = mode.split(':').next().unwrap().replace('b', "");
+    let (readable, writable) = match mode_base.as_str() {
+        "r" => (true, false),
+        "w" | "a" => (false, true),
+        "r+" | "+r" | "w+" | "+w" | "a+" | "+a" => (true, true),
+        _ => (true, false),
+    };
     let opt = match mode_base.as_str() {
         "r" => opt.read(true),
         "w" => opt.write(true).create(true).truncate(true),
@@ -988,7 +995,7 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             ));
         }
     };
-    let mut res = Value::new_file(file, path);
+    let mut res = Value::new_file(file, path, readable, writable);
     if let Some(bh) = lfp.block() {
         let r = vm.invoke_block_once(globals, bh, &[res]);
         // CRuby File.open(...) {|io| ... } closes the file at block exit.

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -3452,4 +3452,27 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn io_directional_mode_errors_streams() {
+        // ensure_readable: closed stream -> "closed stream".
+        run_test_error(
+            r#"
+            f = File.open("Cargo.toml")
+            f.close
+            f.lineno
+            "#,
+        );
+        // is_readable Stdout arm + ensure_readable "not opened for reading".
+        run_test_error(r#"$stdout.lineno"#);
+        run_test_error(r#"$stderr.lineno"#);
+        // ensure_writable Stdin arm -> "not opened for writing".
+        run_test_error(r#"$stdin.write("x")"#);
+        // fd_rw_mode through IO.pipe: read end is RO, write end is WO.
+        run_test_error(r#"r, w = IO.pipe; begin; w.gets; ensure; r.close; w.close; end"#);
+        run_test_error(r#"r, w = IO.pipe; begin; r.write("x"); ensure; r.close; w.close; end"#);
+        // is_readable / is_writable Popen arms.
+        run_test_error(r#"IO.popen("cat", "w") { |p| p.gets }"#);
+        run_test_error(r#"IO.popen("cat", "r") { |p| p.write("x") }"#);
+    }
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -105,7 +105,8 @@ fn io_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         // Pick up `:autoclose` and `:path` from the options Hash. See
         // `io_open_opts` for the rationale.
         let (name, has_path, autoclose) = io_open_opts(vm, globals, lfp, 1..3, fd)?;
-        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path);
+        let (readable, writable) = fd_rw_mode(fd_i32);
+        let io_inner = IoInner::from_raw_fd(fd_i32, name, has_path, readable, writable);
         io_inner.set_autoclose(autoclose);
         return Ok(Value::new_io(io_inner));
     }
@@ -151,6 +152,21 @@ pub(super) fn io_open_opts(
         }
     }
     Ok((name, has_path, autoclose))
+}
+
+/// Query a raw fd's access mode via `fcntl(F_GETFL)` and map `O_ACCMODE`
+/// to `(readable, writable)`. Falls back to `(true, true)` if the query
+/// fails so we never spuriously reject I/O on a valid fd.
+pub(super) fn fd_rw_mode(fd: i32) -> (bool, bool) {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        return (true, true);
+    }
+    match flags & libc::O_ACCMODE {
+        libc::O_RDONLY => (true, false),
+        libc::O_WRONLY => (false, true),
+        _ => (true, true),
+    }
 }
 
 /// Allocator for `IO` and its subclasses.
@@ -758,8 +774,20 @@ fn io_pipe(_vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr)
         let err = std::io::Error::last_os_error();
         return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "pipe(2)"));
     }
-    let read_io = Value::new_io(IoInner::from_raw_fd(fds[0], "pipe".to_string(), false));
-    let write_io = Value::new_io(IoInner::from_raw_fd(fds[1], "pipe".to_string(), false));
+    let read_io = Value::new_io(IoInner::from_raw_fd(
+        fds[0],
+        "pipe".to_string(),
+        false,
+        true,
+        false,
+    ));
+    let write_io = Value::new_io(IoInner::from_raw_fd(
+        fds[1],
+        "pipe".to_string(),
+        false,
+        false,
+        true,
+    ));
     Ok(Value::array2(read_io, write_io))
 }
 
@@ -1407,7 +1435,7 @@ fn io_lineno(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    ensure_io_open(lfp.self_val())?;
+    lfp.self_val().as_io_inner().ensure_readable()?;
     let stored = globals
         .store
         .get_ivar(lfp.self_val(), IdentId::get_id("/lineno"));
@@ -1428,7 +1456,7 @@ fn io_lineno_set(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    ensure_io_open(lfp.self_val())?;
+    lfp.self_val().as_io_inner().ensure_readable()?;
     let n = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
     if n > i32::MAX as i64 || n < i32::MIN as i64 {
         return Err(MonorubyErr::rangeerr(format!(
@@ -3402,5 +3430,26 @@ mod tests {
             "#,
         );
         run_test_error(r#"File.open("Cargo.toml") { |f| f.lineno = 4294967296 }"#);
+    }
+
+    #[test]
+    fn io_directional_mode_errors() {
+        // Read ops on a write-only stream raise IOError.
+        run_test_error(r#"File.open("/tmp/mr_mode_w.txt", "w") { |f| f.read }"#);
+        run_test_error(r#"File.open("/tmp/mr_mode_w.txt", "w") { |f| f.gets }"#);
+        run_test_error(r#"File.open("/tmp/mr_mode_w.txt", "w") { |f| f.lineno }"#);
+        run_test_error(r#"File.open("/tmp/mr_mode_w.txt", "w") { |f| f.lineno = 1 }"#);
+        run_test_error(r#"File.open("/tmp/mr_mode_w.txt", "w") { |f| f.ungetc(65) }"#);
+        // Write op on a read-only stream raises IOError.
+        run_test_error(r#"File.open("Cargo.toml", "r") { |f| f.write("x") }"#);
+        // Read/write modes still work both ways.
+        run_test(
+            r#"
+            path = "/tmp/mr_mode_rw.txt"
+            r = File.open(path, "w+") { |f| f.write("hello"); f.rewind; f.read }
+            File.unlink(path)
+            r
+            "#,
+        );
     }
 }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1097,8 +1097,13 @@ impl Value {
         RValue::new_io_stderr().pack()
     }
 
-    pub(crate) fn new_file(file: std::fs::File, name: String) -> Self {
-        RValue::new_file(file, name).pack()
+    pub(crate) fn new_file(
+        file: std::fs::File,
+        name: String,
+        readable: bool,
+        writable: bool,
+    ) -> Self {
+        RValue::new_file(file, name, readable, writable).pack()
     }
 
     pub fn range(start: Value, end: Value, exclude_end: bool) -> Self {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1549,8 +1549,13 @@ impl RValue {
         Self::new_io(IoInner::stderr())
     }
 
-    pub(super) fn new_file(file: std::fs::File, name: String) -> Self {
-        let inner = IoInner::file(file, name);
+    pub(super) fn new_file(
+        file: std::fs::File,
+        name: String,
+        readable: bool,
+        writable: bool,
+    ) -> Self {
+        let inner = IoInner::file(file, name, readable, writable);
         RValue {
             header: Header::new(FILE_CLASS, ObjTy::IO),
             kind: ObjKind::io(inner),

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -263,9 +263,8 @@ impl IoInner {
     }
 
     pub fn write(&mut self, data: &[u8]) -> Result<()> {
+        self.ensure_writable()?;
         match self {
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
-            Self::Stdin => Err(MonorubyErr::argumenterr("can't write to $stdin")),
             Self::Stdout => match std::io::stdout().write(data) {
                 Ok(_) => Ok(()),
                 Err(e) => Err(MonorubyErr::rangeerr(e.to_string())),
@@ -275,9 +274,6 @@ impl IoInner {
                 Err(e) => Err(MonorubyErr::rangeerr(e.to_string())),
             },
             Self::File(file) => {
-                if !file.writable {
-                    return Err(MonorubyErr::ioerr("not opened for writing"));
-                }
                 let _ = Rc::get_mut(file)
                     .unwrap()
                     .reader
@@ -288,15 +284,15 @@ impl IoInner {
             }
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
-                if let Some(ref mut writer) = popen.writer {
-                    writer
-                        .write(data)
-                        .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
-                    Ok(())
-                } else {
-                    Err(MonorubyErr::ioerr("not opened for writing"))
-                }
+                // `ensure_writable` guaranteed the writer is present.
+                let writer = popen.writer.as_mut().unwrap();
+                writer
+                    .write(data)
+                    .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
+                Ok(())
             }
+            // `ensure_writable` already rejected non-writable streams.
+            Self::Stdin | Self::Closed => unreachable!(),
         }
     }
 

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -26,6 +26,11 @@ pub struct FileDescriptor {
     /// fd without an explicit `path:` option — CRuby's `IO#path` is `nil`
     /// in that case.
     has_path: bool,
+    /// Access mode the descriptor was opened with. Read operations on a
+    /// non-`readable` descriptor and write operations on a non-`writable`
+    /// one raise `IOError`, matching CRuby.
+    readable: bool,
+    writable: bool,
     /// CRuby's `IO#autoclose=` semantics. When `true` (the default), the
     /// underlying fd is closed when this `FileDescriptor` is dropped. When
     /// `false`, ownership is released via `into_raw_fd` so the fd is *not*
@@ -127,6 +132,48 @@ impl IoInner {
         matches!(self, Self::Closed)
     }
 
+    /// Whether the stream may be read from.
+    pub fn is_readable(&self) -> bool {
+        match self {
+            Self::Stdin => true,
+            Self::Stdout | Self::Stderr | Self::Closed => false,
+            Self::File(f) => f.readable,
+            Self::Popen(p) => p.reader.is_some(),
+        }
+    }
+
+    /// Whether the stream may be written to.
+    pub fn is_writable(&self) -> bool {
+        match self {
+            Self::Stdout | Self::Stderr => true,
+            Self::Stdin | Self::Closed => false,
+            Self::File(f) => f.writable,
+            Self::Popen(p) => p.writer.is_some(),
+        }
+    }
+
+    /// `IOError` unless the stream is open for reading.
+    pub fn ensure_readable(&self) -> Result<()> {
+        if self.is_closed() {
+            return Err(MonorubyErr::ioerr("closed stream"));
+        }
+        if !self.is_readable() {
+            return Err(MonorubyErr::ioerr("not opened for reading"));
+        }
+        Ok(())
+    }
+
+    /// `IOError` unless the stream is open for writing.
+    pub fn ensure_writable(&self) -> Result<()> {
+        if self.is_closed() {
+            return Err(MonorubyErr::ioerr("closed stream"));
+        }
+        if !self.is_writable() {
+            return Err(MonorubyErr::ioerr("not opened for writing"));
+        }
+        Ok(())
+    }
+
     /// Close the IO. Returns `(raw_wait_status, pid)` for Popen, `None`
     /// otherwise. `raw_wait_status` is the POSIX `wait(2)` status word, so
     /// callers (and `Process::Status`) can distinguish exit code, signal
@@ -165,11 +212,13 @@ impl IoInner {
         Self::Stderr
     }
 
-    pub(super) fn file(file: std::fs::File, name: String) -> Self {
+    pub(super) fn file(file: std::fs::File, name: String, readable: bool, writable: bool) -> Self {
         Self::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
             has_path: true,
+            readable,
+            writable,
             autoclose: Cell::new(true),
             pushback: RefCell::new(Vec::new()),
         }))
@@ -193,13 +242,21 @@ impl IoInner {
         }
     }
 
-    pub(crate) fn from_raw_fd(fd: i32, name: String, has_path: bool) -> Self {
+    pub(crate) fn from_raw_fd(
+        fd: i32,
+        name: String,
+        has_path: bool,
+        readable: bool,
+        writable: bool,
+    ) -> Self {
         // SAFETY: fd is a valid file descriptor obtained from pipe().
         let file = unsafe { std::fs::File::from_raw_fd(fd) };
         Self::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(std::io::BufReader::new(file)),
             name,
             has_path,
+            readable,
+            writable,
             autoclose: Cell::new(true),
             pushback: RefCell::new(Vec::new()),
         }))
@@ -218,6 +275,9 @@ impl IoInner {
                 Err(e) => Err(MonorubyErr::rangeerr(e.to_string())),
             },
             Self::File(file) => {
+                if !file.writable {
+                    return Err(MonorubyErr::ioerr("not opened for writing"));
+                }
                 let _ = Rc::get_mut(file)
                     .unwrap()
                     .reader
@@ -265,6 +325,9 @@ impl IoInner {
         match self {
             Self::Closed => Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin | Self::Stdout | Self::Stderr => {
+                Err(MonorubyErr::ioerr("not opened for reading"))
+            }
+            Self::File(f) if !f.readable => {
                 Err(MonorubyErr::ioerr("not opened for reading"))
             }
             Self::File(_) | Self::Popen(_) => {
@@ -336,6 +399,9 @@ impl IoInner {
             Self::Stdout => Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => Err(MonorubyErr::argumenterr("can't read from $stderr")),
             Self::File(file) => {
+                if !file.readable {
+                    return Err(MonorubyErr::ioerr("not opened for reading"));
+                }
                 // `&mut *...reader` peels the ManuallyDrop wrapper to yield
                 // `&mut BufReader<File>`, which is needed because `Read::bytes`
                 // takes `self` by value and would otherwise try to move out of
@@ -411,6 +477,9 @@ impl IoInner {
             Self::Stdout => Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => Err(MonorubyErr::argumenterr("can't read from $stderr")),
             Self::File(file) => {
+                if !file.readable {
+                    return Err(MonorubyErr::ioerr("not opened for reading"));
+                }
                 let file = &mut *Rc::get_mut(file).unwrap().reader;
                 let mut buf = String::new();
                 let size = file


### PR DESCRIPTION
## Summary

Adds read/write access-mode tracking to `IoInner`, fixing CRuby's
directional `IOError` semantics. Verified against a freshly built
clean-`master` ruby/spec baseline with **zero regressions** (+10 examples).

- `FileDescriptor` records `readable`/`writable`, derived from
  `File.open`'s mode string and from `fcntl(F_GETFL)` for raw-fd /
  `File.new(fd)` / pipe ends (read end RO, write end WO).
- Read operations (`read`/`gets`/`getc`/`getbyte`/`eof?`/`lineno`/
  `lineno=`/`ungetc`) on a non-readable stream and `write` on a
  non-writable stream now raise `IOError` ("not opened for reading" /
  "not opened for writing"); closed → "closed stream".
- `IO#lineno`/`#lineno=` switched from a bare open-check to the readable
  check, so write-only streams correctly raise.

### ruby/spec (clean-master baseline → now), no regressions

| spec | before | after |
|---|---|---|
| `core/io/lineno` | 4F | **0F/0E (fully passing)** |
| `core/io/gets` | 8E | 6E |
| `core/io/eof` | 3E | 2E |
| `core/io/write` | 18E | 17E |
| `core/io/readlines` | 17E | 15E |

All other touched specs (`read`/`readline`/`foreach`/`new`/`open`/
`pwrite`/`syswrite`/`ungetc`/`ungetbyte`/`file truncate`) unchanged.

## Test plan

- [x] `cargo build` clean
- [x] io unit-test module green (80/80), incl. new
      `io_directional_mode_errors` regression test (both parsers)
- [x] file unit-test module green (68/68)
- [x] ruby/spec deltas measured vs a freshly built clean-`master` binary;
      no spec regressed

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_