### PR TITLE
encoding: name-preserving ASCII-incompatible Encoding::Other (UTF-7/CP50220/1)

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -482,8 +482,8 @@ fn encoding_to_rs(enc: crate::value::Encoding) -> Option<&'static encoding_rs::E
         E::EucJp => b"euc-jp",
         E::Sjis(_) => b"shift_jis",
         E::Iso2022Jp => b"iso-2022-jp",
-        // Handled by callers as fast paths.
-        E::Utf32Le | E::Utf32Be | E::Ascii8 | E::UsAscii => return None,
+        // Handled by callers as fast paths / no native codec.
+        E::Utf32Le | E::Utf32Be | E::Ascii8 | E::UsAscii | E::Other(_) => return None,
     };
     encoding_rs::Encoding::for_label(label)
 }
@@ -1263,6 +1263,14 @@ pub(super) fn encoding_constant_name(enc: Encoding) -> &'static str {
         Encoding::Sjis(0) => "SHIFT_JIS",
         Encoding::Sjis(_) => "Windows_31J",
         Encoding::Iso2022Jp => "ISO_2022_JP",
+        // Name-preserving byte encodings: map the canonical display
+        // name back to its registered `Encoding::<CONST>` identifier.
+        Encoding::Other(i) => match i {
+            0 => "UTF_7",
+            1 => "CP50220",
+            2 => "CP50221",
+            _ => "ASCII_8BIT",
+        },
     }
 }
 
@@ -4401,6 +4409,30 @@ mod tests {
             // Regexp pairs use the declared encoding of the source.
             r#"Encoding.compatible?(/abc/, /def/).to_s"#,
             r#"Encoding.compatible?("abc", /def/).to_s"#,
+        ]);
+    }
+
+    #[test]
+    fn other_dummy_encodings_name_preserved() {
+        // UTF-7 / CP50220 / CP50221: name-preserved, ASCII-
+        // incompatible — `#inspect` escapes every byte, symbols are
+        // quoted, and the encoding round-trips through force_encoding.
+        run_tests(&[
+            r#""abcd".dup.force_encoding("UTF-7").encoding.name"#,
+            r#""abcd".dup.force_encoding("UTF-7").inspect"#,
+            r#""abcd".dup.force_encoding("CP50220").inspect"#,
+            r#""abcd".dup.force_encoding("CP50221").encoding.name"#,
+            r#""a\"b".dup.force_encoding("UTF-7").inspect"#,
+            r#"Encoding.find("UTF-7").name"#,
+            r#"Encoding.find("CP50220").name"#,
+            r#""abc".dup.force_encoding("UTF-7").to_sym.inspect"#,
+            r#""abc".dup.force_encoding("UTF-7").to_sym.encoding.name"#,
+            // ascii_compatible? false => Encoding.compatible? rules
+            r#"Encoding.compatible?(Encoding::UTF_7, Encoding::UTF_7) == Encoding::UTF_7"#,
+            r#"Encoding.compatible?("x".dup.force_encoding("UTF-7"), "y").inspect"#,
+            // Emacs-Mule / CESU-8 stay ASCII-compatible (unchanged)
+            r#""abcd".dup.force_encoding("Emacs-Mule").inspect"#,
+            r#""abcd".dup.force_encoding("CESU-8").inspect"#,
         ]);
     }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -478,6 +478,7 @@ fn encoding_ordinal(enc: Encoding) -> i32 {
         Encoding::Sjis(_) => 8,
         Encoding::Iso8859(n) => 100 + n as i32,
         Encoding::Iso2022Jp => 200,
+        Encoding::Other(_) => 300,
     }
 }
 

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1511,7 +1511,13 @@ pub(crate) fn emit_deprecated_constant_warning(
 ///
 pub(crate) fn inspect_symbol(id: IdentId) -> String {
     let ident_name = id.get_ident_name_clone();
-    if is_simple_symbol(&ident_name) {
+    // A symbol whose recorded source encoding is ASCII-incompatible
+    // (UTF-16/32, ISO-2022-JP, UTF-7, …) is always quoted and
+    // byte-escaped, never rendered bare.
+    let ascii_incompat_enc = id
+        .symbol_encoding()
+        .is_some_and(|e| !e.is_ascii_compatible());
+    if !ascii_incompat_enc && is_simple_symbol(&ident_name) {
         let mut res = String::from(":");
         match &ident_name {
             IdentName::Utf8(name) => res.push_str(name),

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -73,6 +73,7 @@ impl<'a> Iterator for CharByteIter<'a> {
             Encoding::Ascii8
             | Encoding::UsAscii
             | Encoding::Iso8859(_)
+            | Encoding::Other(_)
             // ISO-2022-JP groups bytes 1-at-a-time at the codepoint
             // iterator level — the actual char-vs-ESC-sequence
             // chunking happens further up via `encoding_rs`. This
@@ -184,7 +185,22 @@ pub enum Encoding {
     /// either `'B'` or part of a JIS X 0208 codepoint depending
     /// on the surrounding ESC state.
     Iso2022Jp,
+    /// A byte-oriented encoding monoruby has no native codec for but
+    /// must still name-preserve and treat as ASCII-incompatible
+    /// (CRuby's stateful / dummy encodings: UTF-7, CP50220/1,
+    /// ISO-2022-JP-2/KDDI, the BOM-form UTF-16/UTF-32, IBM037, …).
+    /// The payload indexes [`OTHER_ENC_NAMES`] (kept `u8` so the enum
+    /// stays small — `RValue` must remain exactly 64 bytes).
+    /// Transcoding and per-char iteration behave like ASCII-8BIT (raw
+    /// bytes); only `#name`, `#inspect` and ASCII-incompatibility
+    /// differ.
+    Other(u8),
 }
+
+/// Canonical names for [`Encoding::Other`] variants (stateful /
+/// dummy byte encodings monoruby has no native codec for). The
+/// index is the `Encoding::Other` payload.
+pub(crate) const OTHER_ENC_NAMES: &[&str] = &["UTF-7", "CP50220", "CP50221"];
 
 impl Encoding {
     /// True if the encoding is a strict superset of US-ASCII for
@@ -194,7 +210,12 @@ impl Encoding {
     pub fn is_ascii_compatible(self) -> bool {
         !matches!(
             self,
-            Self::Utf16Le | Self::Utf16Be | Self::Utf32Le | Self::Utf32Be | Self::Iso2022Jp
+            Self::Utf16Le
+                | Self::Utf16Be
+                | Self::Utf32Le
+                | Self::Utf32Be
+                | Self::Iso2022Jp
+                | Self::Other(_)
         )
     }
 
@@ -217,6 +238,7 @@ impl Encoding {
     /// hyphenated forms users see in `Encoding#to_s`.
     pub fn name(self) -> &'static str {
         match self {
+            Encoding::Other(i) => OTHER_ENC_NAMES[i as usize],
             Encoding::Ascii8 => "ASCII-8BIT",
             Encoding::Utf8 => "UTF-8",
             Encoding::UsAscii => "US-ASCII",
@@ -283,6 +305,8 @@ impl Encoding {
                 Err(_) => CodeRange::Broken,
             },
             Encoding::Ascii8 => CodeRange::Valid, // every byte is "valid"
+            // No native codec: raw bytes, every sequence "valid".
+            Encoding::Other(_) => CodeRange::Valid,
             Encoding::Iso8859(_) => CodeRange::Valid, // every byte 0..256 represents a glyph
             // For encodings we don't decode natively, treat any
             // sequence as Valid unless its byte count contradicts
@@ -350,6 +374,13 @@ impl Encoding {
             "UTF_8" | "UTF8" | "CP65001" | "UTF8_MAC" | "UTF_8_MAC" | "CESU_8" | "CESU8" => {
                 Ok(Encoding::Utf8)
             }
+
+            // ASCII-incompatible stateful / dummy byte encodings with
+            // no native codec: name-preserved, `#inspect` escapes
+            // every byte, symbols are quoted (CRuby semantics).
+            "UTF_7" => Ok(Encoding::Other(0)),
+            "CP50220" => Ok(Encoding::Other(1)),
+            "CP50221" => Ok(Encoding::Other(2)),
             "ASCII_8BIT" | "BINARY" => Ok(Encoding::Ascii8),
             "US_ASCII" | "ASCII" | "ANSI_X3_4_1968" | "646" => Ok(Encoding::UsAscii),
             "LOCALE" | "EXTERNAL" | "FILESYSTEM" => Ok(Encoding::Utf8),
@@ -402,7 +433,7 @@ impl Encoding {
             | "IBM865" | "CP865" | "IBM866" | "CP866" | "IBM869" | "CP869" | "KOI8_R"
             | "KOI8_U" | "GB2312" | "EUC_CN" | "GBK" | "CP936" | "GB18030" | "BIG5"
             | "BIG5_HKSCS" | "BIG5_UAO" | "EUC_KR" | "EUCKR" | "CP949" | "EUC_TW" | "EUCTW"
-            | "TIS_620" | "TIS620" | "UTF_7" | "EMACS_MULE" | "CP50220" | "CP50221" | "GB12345"
+            | "TIS_620" | "TIS620" | "EMACS_MULE" | "GB12345"
             | "MACCYRILLIC" | "MACGREEK" | "MACICELAND" | "MACROMAN" | "MACROMANIA" | "MACTHAI"
             | "MACTURKISH" | "MACUKRAINE" => Ok(Encoding::Ascii8),
 
@@ -612,8 +643,18 @@ impl RStringInner {
                 }
                 res
             }
-            // US-ASCII, ASCII-8BIT, ISO-8859-N, ISO-2022-JP (dummy):
-            // pure per-byte — ASCII rules for < 0x80, `\xHH` otherwise.
+            // ASCII-incompatible stateful / no-codec byte encodings
+            // (ISO-2022-JP, UTF-7, CP50220/1, …): CRuby escapes
+            // *every* byte as `\xHH`, even printable ASCII.
+            Encoding::Iso2022Jp | Encoding::Other(_) => {
+                let mut res = String::with_capacity(self.len() * 4);
+                for b in self.as_bytes() {
+                    res.push_str(&format!("\\x{:0>2X}", b));
+                }
+                res
+            }
+            // US-ASCII, ASCII-8BIT, ISO-8859-N: pure per-byte —
+            // ASCII rules for < 0x80, `\xHH` otherwise.
             _ => {
                 let mut res = String::with_capacity(self.len());
                 for c in self.as_bytes() {
@@ -959,7 +1000,10 @@ impl RStringInner {
     pub fn char_length(&self) -> usize {
         match self.ty {
             // Fixed 1-byte-per-char.
-            Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => self.content.len(),
+            Encoding::Ascii8
+            | Encoding::UsAscii
+            | Encoding::Iso8859(_)
+            | Encoding::Other(_) => self.content.len(),
             // UTF-16 / UTF-32 with one extra unit per broken trailing
             // byte. CRuby's `String#length` for these reports the
             // number of *complete* code units plus one per stray byte
@@ -1341,7 +1385,9 @@ impl RStringInner {
             CodeRange::Valid => match parent.encoding() {
                 // Single-byte encodings: every byte position is a
                 // character boundary; Valid trivially propagates.
-                Encoding::Ascii8 | Encoding::Iso8859(_) => CodeRange::Valid,
+                Encoding::Ascii8 | Encoding::Iso8859(_) | Encoding::Other(_) => {
+                    CodeRange::Valid
+                }
                 // UTF-8: the cut points must land on character
                 // boundaries (a non-continuation byte or one-past-the-
                 // end). When both endpoints align, the byte sequence
@@ -1530,7 +1576,10 @@ impl RStringInner {
         // is what `iter_char_bytes` would do anyway, but we
         // shortcut it for performance).
         let unit = match self.ty {
-            Encoding::Ascii8 | Encoding::UsAscii | Encoding::Iso8859(_) => Some(1),
+            Encoding::Ascii8
+            | Encoding::UsAscii
+            | Encoding::Iso8859(_)
+            | Encoding::Other(_) => Some(1),
             Encoding::Utf16Le | Encoding::Utf16Be => Some(2),
             Encoding::Utf32Le | Encoding::Utf32Be => Some(4),
             // ISO-2022-JP still iterates byte-wise (stateful decode


### PR DESCRIPTION
## Summary

One commit (`c4a9d727`) adding a name-preserving, ASCII-incompatible encoding representation for the no-native-codec stateful/dummy byte encodings **UTF-7 / CP50220 / CP50221**.

These were folded into `ASCII-8BIT` by `try_from_str`, losing the name and (wrongly) becoming ASCII-compatible.

### Changes

- New compact `Encoding::Other(u8)` variant — payload indexes a static `OTHER_ENC_NAMES` table, so the enum stays small and **`RValue` is still exactly 64 bytes** (an `&'static str` payload bloated it and tripped the allocator size assertion — verified and avoided).
- `#name` / `force_encoding` round-trip preserved (`force_encoding(e).encoding == e`, `Encoding.find` round-trips).
- ASCII-incompatible: `String#inspect` escapes **every** byte as `\xHH` (matching CRuby for these and the existing ISO-2022-JP); `Symbol#inspect` quotes them.
- Transcoding / per-char iteration behave like `ASCII-8BIT` (no codec).
- Emacs-Mule / CESU-8 / stateless-ISO-2022-JP intentionally **stay ASCII-compatible** (CRuby treats them so — `:abcd` / US-ASCII), unchanged.

### Result

- By-name pre/post diff vs `master`: **zero true regressions, 8 true fixes** — all in `Encoding.compatible?` (dummy / ASCII-incompatible operands now negotiate correctly).
- Byte-exact vs `LANG=C.UTF-8 ruby` for `force_encoding` + `String#inspect` / `Symbol#inspect` / `#encoding` of UTF-7/CP50220/CP50221 (and Emacs-Mule/CESU-8 unchanged).
- Both Prism **and** ruruby parsers green; `builtins::{encoding,symbol,string}` + `value::rvalue::string` cargo suites green (only the pre-existing broken-locale `symbol_inspect_unquoted` artifact, which passes on CI).

### Out of scope (documented in commit message)

`Symbol#inspect quotes and escapes symbols in dummy encodings` iterates many encodings over the **same bytes**; the A1 symbol-encoding side-map is keyed by `IdentId`, so same-bytes/different-encoding symbols collide (CRuby gives them distinct identity). Fully greening it needs a per-`(bytes, encoding)` interner re-key (high-risk) plus reclassifying the bare UTF-16/UTF-32 dummy forms (Phase-B-sensitive). Deferred.

`codecov/patch` is advisory (project coverage stable/up, build+tests green) — consistent with prior merged PRs in this series.

## Test plan

- [x] CRuby byte-exact: UTF-7/CP50220/CP50221 force_encoding + String/Symbol inspect + #encoding + round-trip; Emacs-Mule/CESU-8 unchanged
- [x] By-name pre/post diff on core/{string,symbol,encoding}: zero true regressions, 8 `Encoding.compatible?` fixes
- [x] Prism + ruruby; touched-module cargo suites green
- [x] `RValue` size assertion holds (64 bytes) — startup verified

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_