### PR TITLE
enumerable: Enumerable#first arg validation/laziness + map/collect value forwarding

### DIFF
--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -136,8 +136,13 @@ module Enumerable
   def map
     return self.to_enum(:map) unless block_given?
     res = []
-    __gather_each do |x|
-      res << yield(x)
+    # The user block is called with the *original* values `each`
+    # yields (arity-adaptive), not the packed element: for
+    # `yield 1, 2` a `{ |e| }` block sees `1`, a `{ |a, b| }` block
+    # sees `1, 2` (matches CRuby `rb_yield_values2`). Internal
+    # packed-element callers use `__gather_each` directly instead.
+    self.each do |*vs|
+      res << yield(*vs)
     end
     res
   end
@@ -357,7 +362,9 @@ module Enumerable
       n = n.to_int unless n.is_a?(Integer)
       raise ArgumentError, "negative size (#{n})" if n < 0
       return [] if n == 0
-      self.map { |x| [yield(x), x] }.sort_by { |pair| pair[0] }.first(n).map { |pair| pair[1] }
+      pairs = []
+      __gather_each { |x| pairs << [yield(x), x] }
+      pairs.sort_by { |pair| pair[0] }.first(n).map { |pair| pair[1] }
     end
   end
 
@@ -500,7 +507,14 @@ module Enumerable
 
   def sort_by
     return self.to_enum(:sort_by) unless block_given?
-    map { |x| [yield(x), x] }.sort { |a, b| a[0] <=> b[0] }.map { |x| x[1] }
+    # Use the *packed* element (`__gather_each`) — `sort_by` treats a
+    # multi-value `yield` as a single Array element. (Public `map`
+    # forwards the raw values arity-adaptively, which is the wrong
+    # shape here.)
+    pairs = []
+    __gather_each { |x| pairs << [yield(x), x] }
+    pairs.sort! { |a, b| a[0] <=> b[0] }
+    pairs.map { |p| p[1] }
   end
 
   def max_by(n = nil)
@@ -525,7 +539,9 @@ module Enumerable
       n = n.to_int unless n.is_a?(Integer)
       raise ArgumentError, "negative size (#{n})" if n < 0
       return [] if n == 0
-      self.map { |x| [yield(x), x] }.sort_by { |pair| pair[0] }.last(n).reverse.map { |pair| pair[1] }
+      pairs = []
+      __gather_each { |x| pairs << [yield(x), x] }
+      pairs.sort_by { |pair| pair[0] }.last(n).reverse.map { |pair| pair[1] }
     end
   end
 

--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -561,18 +561,35 @@ module Enumerable
   end
   alias member? include?
 
-  def first(n = nil)
-    if n.nil?
-      __gather_each { |x| return x }
-      nil
-    else
-      res = []
-      __gather_each do |x|
-        break if res.size >= n
-        res << x
-      end
-      res
+  def first(*args)
+    if args.size > 1
+      raise ArgumentError,
+            "wrong number of arguments (given #{args.size}, expected 0..1)"
     end
+    if args.empty?
+      __gather_each { |x| return x }
+      return nil
+    end
+    n = args[0]
+    n = n.to_int if !n.is_a?(Integer) && n.respond_to?(:to_int)
+    unless n.is_a?(Integer)
+      raise TypeError, "no implicit conversion of #{n.class} into Integer"
+    end
+    raise ArgumentError, "negative array size" if n < 0
+    # CRuby converts the count with NUM2LONG; a Bignum that does not
+    # fit in a C long raises RangeError.
+    if n > 0x7fff_ffff_ffff_ffff
+      raise RangeError, "bignum too big to convert into `long'"
+    end
+    res = []
+    return res if n == 0
+    # Push-then-break so exactly `n` elements are consumed (the
+    # underlying `each` is not advanced past what is needed).
+    __gather_each do |x|
+      res << x
+      break if res.size >= n
+    end
+    res
   end
 
   def to_a(*args)

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -385,6 +385,30 @@ mod tests {
     }
 
     #[test]
+    fn enumerable_first_arg_validation() {
+        run_tests(&[
+            // no arg / explicit count
+            r#"(1..5).first"#,
+            r#"(1..5).first(0)"#,
+            r#"(1..5).first(3)"#,
+            r#"(1..5).first(100)"#,
+            // #to_int coercion
+            r#"o = Object.new; def o.to_int; 2; end; (10..20).first(o)"#,
+            // negative -> ArgumentError; explicit nil / non-numeric -> TypeError
+            r#"begin; (1..3).first(-1); rescue ArgumentError; :ae; end"#,
+            r#"begin; (1..3).first(nil); rescue TypeError; :te; end"#,
+            r#"begin; (1..3).first("a"); rescue TypeError; :te; end"#,
+            r#"begin; [].first(2 ** 70); rescue RangeError; :re; end"#,
+            r#"begin; (1..3).first(1, 2); rescue ArgumentError; :ae; end"#,
+            // laziness: consumes only what is needed
+            r#"
+            e = Enumerator.new { |y| y << 1; y << 2; raise "boom"; y << 3 }
+            e.first(2)
+            "#,
+        ]);
+    }
+
+    #[test]
     fn enumerator2() {
         run_test_no_result_check(
             r##"


### PR DESCRIPTION
## Summary

Two `Enumerable` correctness commits, rebased on current `master` (`ac394e3b`). Both are pure-Ruby changes in `monoruby/builtins/enumerable.rb`.

| Commit | Effect |
|---|---|
| `a02220f7` | `Enumerable#first` argument validation + laziness |
| `f3d820ac` | `Enumerable#map`/`#collect` forward original yielded values |

### `Enumerable#first` (`a02220f7`)

`first(n)` did no argument checking and broke laziness. Now mirrors CRuby (and `Enumerable#take`):

- `def first(*args)` distinguishes no-arg (single element) from an explicit `nil`
- count is `#to_int`-coerced → `TypeError` if not Integer-convertible (incl. explicit `nil` / `String` / non-numeric)
- negative count → `ArgumentError`; a Bignum that wouldn't fit a C long → `RangeError`; `> 1` args → `ArgumentError`
- push-then-break so exactly `n` elements are consumed (the underlying `#each` is not advanced past what is needed)

`core/enumerable/first_spec.rb` + `take_spec.rb`: **0F/0E** (25 examples).

### `Enumerable#map`/`#collect` (`f3d820ac`)

Called the user block with the *packed* element, so `YieldsMulti#each` (`yield 1, 2`) gave `map { |e| e }` → `[[1,2],..]` instead of CRuby's `[1,3,6]`. Now iterates `self.each { |*vs| res << yield(*vs) }`, forwarding the raw yielded values so the **block's arity** decides (CRuby `rb_yield_values2`). `sort_by` / `min_by(n)` / `max_by(n)` internally relied on the old packed-`map` shape; they now collect via `__gather_each` directly (packed-element semantics preserved, independent of public `map`).

### Net result

- core/enumerable **91F/21E → 84F/19E**
- By-name pre/post mspec diff vs `master`: **zero true regressions, 8 true fixes** (`Enumerable#first` ×5: RangeError-on-Bignum / negative→ArgumentError / non-numeric→TypeError / `#to_int` / laziness; `Enumerable#{map,collect}` gathers-initial-args; `Enumerable#sort_by` calls-#each)
- Both Prism **and** ruruby parsers green; CRuby byte-exact and JIT-stable (30× warmup); CRuby-verified unit test added

### Known / out of scope (documented in commit messages)

- Deeper `map` sub-problems left untouched: "reports the same arity as the given block" (block-arity forwarding into `#each`), Hash strict-arity-method cases, "calls #each on sub-classes", `Enumerator#size`.
- Under a **single-process parallel `cargo test`** the `symbol_*` tests can flake: the A1 symbol-encoding side-map (merged in #555) is a process-global interner table where same-bytes/different-encoding symbols collide — a documented A1 limitation. This map change only perturbs the test schedule; it is **not a deterministic regression** (mspec name-diff clean, isolated runs pass, JIT-stable). CI's per-test-process `nextest` isolation does not hit it — same pattern as the existing `string_inspect` / `symbol_inspect_unquoted` broken-locale artifacts (local-only, green on CI).
- `codecov/patch` is advisory (project coverage stable/up, build+tests green) — consistent with prior merged PRs in this series.

## Test plan

- [x] `core/enumerable/{first,take}_spec.rb` 0/0; map/sort_by clusters improved
- [x] By-name pre/post diff on core/{enumerable,array,hash,range,struct}: zero true regressions, 8 fixes
- [x] CRuby byte-exact (`LANG=C.UTF-8 ruby`) for first arg-validation/laziness and map/collect/sort_by/min_by/max_by; 30× JIT warmup stable
- [x] Prism + ruruby parsers; CRuby-verified `enumerable_first_arg_validation` unit test added
- [x] Rebased cleanly onto `master` (`ac394e3b`, PR #559); post-rebase specs/cargo re-verified

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_