### PR TITLE
symbol: per-(bytes, encoding) interner identity (fixes A1 side-map collision + flake)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -4791,27 +4791,29 @@ fn parse_bigint(s: &str, radix: u32) -> BigInt {
 fn to_sym(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let inner = self_val.as_rstring_inner();
-    // Intern based on actual byte validity rather than the encoding tag:
-    // a UTF-8 labeled string may legitimately contain invalid byte
-    // sequences (e.g. `"\xA9"` from a source literal) and must round-trip
-    // through a Bytes-variant IdentName.
-    let id = match std::str::from_utf8(inner.as_bytes()) {
-        Ok(s) => IdentId::get_id(s),
-        Err(_) => IdentId::get_id_from_bytes(inner.as_bytes().to_vec()),
+    use crate::value::Encoding as E;
+    let src = inner.encoding();
+    // CRuby symbol-encoding rule: ASCII-only content in an
+    // ASCII-compatible encoding collapses to US-ASCII (so e.g.
+    // `"a".force_encoding("KOI8-R").to_sym == :a`); otherwise the
+    // source encoding is significant and discriminates identity.
+    let canon = if inner.as_bytes().is_ascii() && src.is_ascii_compatible() {
+        E::UsAscii
+    } else {
+        src
     };
-    // Preserve the source encoding when `Symbol#to_s` cannot
-    // re-derive it from the bytes alone (UTF-16/32, EUC-JP, …).
-    // US-ASCII / UTF-8 / ASCII-8BIT are reconstructed correctly by
-    // the default derivation, so they need no side-map entry.
-    let enc = inner.encoding();
-    if !matches!(
-        enc,
-        crate::value::Encoding::UsAscii
-            | crate::value::Encoding::Utf8
-            | crate::value::Encoding::Ascii8
-    ) {
-        id.set_symbol_encoding(enc);
-    }
+    // US-ASCII / UTF-8 names dedup by string/bytes and have their
+    // encoding re-derived by `Symbol#to_s` (US-ASCII vs UTF-8); other
+    // encodings are byte-interned keyed by `(bytes, encoding)` so the
+    // symbol carries (and round-trips) its distinct identity.
+    let id = if matches!(canon, E::UsAscii | E::Utf8) {
+        match std::str::from_utf8(inner.as_bytes()) {
+            Ok(s) => IdentId::get_id(s),
+            Err(_) => IdentId::get_id_from_bytes(inner.as_bytes().to_vec(), E::Ascii8),
+        }
+    } else {
+        IdentId::get_id_from_bytes(inner.as_bytes().to_vec(), canon)
+    };
     Ok(Value::symbol(id))
 }
 

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -587,4 +587,26 @@ mod tests {
             r#":café.encoding.name"#,
         ]);
     }
+
+    #[test]
+    fn symbol_per_bytes_encoding_identity() {
+        // Symbols are interned per (bytes, encoding): same bytes under
+        // different (ASCII-incompatible / non-UTF-8) encodings are
+        // distinct symbols; ASCII content in an ASCII-compatible
+        // encoding collapses to the US-ASCII symbol.
+        run_tests(&[
+            r#""あ".encode("UTF-16LE").to_sym == "あ".encode("UTF-16BE").to_sym"#,
+            r#""あ".encode("UTF-16LE").to_sym.equal?("あ".encode("UTF-16LE").to_sym)"#,
+            r#"["abcd".force_encoding("UTF-7").to_sym.inspect,
+               "abcd".force_encoding("CP50221").to_sym.inspect,
+               "abcd".force_encoding("UTF-7").to_sym ==
+                 "abcd".force_encoding("CP50221").to_sym]"#,
+            r#""a".force_encoding("KOI8-R").to_sym == :a"#,
+            r#""a".force_encoding("UTF-7").to_sym == :a"#,
+            r#""foo".encode("UTF-16LE").to_sym == :foo"#,
+            r#":café.encoding.name"#,
+            r#":foo == :foo"#,
+            r#":hello.upcase"#,
+        ]);
+    }
 }

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -589,6 +589,39 @@ mod tests {
     }
 
     #[test]
+    fn chilled_symbol_to_s_mutation_reinterns_by_encoding() {
+        // Mutating a `Symbol#to_s` chilled string emits the
+        // "will be frozen" deprecation (gated on Warning[:deprecated])
+        // after re-interning the symbol. Exercises all three
+        // re-intern branches of `emit_chilled_string_mutation_warning`
+        // (ASCII via get_id, non-ASCII-compat via get_id_from_bytes,
+        // invalid-UTF-8 via the Ascii8 fallback). Execute-only: the
+        // message text/stream differs from CRuby's, so no comparison.
+        run_test_no_result_check(
+            r#"
+            Warning[:deprecated] = true
+            cap = Object.new
+            def cap.write(*a) (@b ||= +""); @b << a.join; end
+            def cap.b; @b || ""; end
+            old = $stderr
+            $stderr = cap
+            begin
+              a = :hello.to_s;                       a << "x"
+              b = "foo".encode("UTF-16LE").to_sym.to_s; b.upcase!
+              c = "\xA9".to_sym.to_s;                c << "z"
+            ensure
+              $stderr = old
+            end
+            msg = cap.b
+            raise "ascii branch"   unless msg.include?("string returned by :hello.to_s")
+            raise "utf16 branch"   unless msg.include?(%q{:"foo".to_s})
+            raise "binary branch"  unless msg.include?(%q{:"\xA9".to_s})
+            :ok
+            "#,
+        );
+    }
+
+    #[test]
     fn symbol_per_bytes_encoding_identity() {
         // Symbols are interned per (bytes, encoding): same bytes under
         // different (ASCII-incompatible / non-UTF-8) encodings are

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -286,8 +286,13 @@ impl IdentId {
     ///
     /// Get *IdentId* from raw bytes (binary/ASCII-8BIT).
     ///
-    pub fn get_id_from_bytes(bytes: Vec<u8>) -> IdentId {
-        ID.write().unwrap().get_id_from_bytes(bytes)
+    /// `enc` discriminates the symbol: same bytes interned under a
+    /// different (ASCII-incompatible / non-UTF-8) encoding produce a
+    /// distinct `IdentId`, matching CRuby's per-(bytes, encoding)
+    /// symbol identity. The encoding is recorded so
+    /// `Symbol#{to_s,name,encoding,inspect}` round-trip it.
+    pub fn get_id_from_bytes(bytes: Vec<u8>, enc: crate::value::Encoding) -> IdentId {
+        ID.write().unwrap().get_id_from_bytes(bytes, enc)
     }
 
     ///
@@ -302,15 +307,6 @@ impl IdentId {
     ///
     pub fn get_ident_name_clone(&self) -> IdentName {
         ID.read().unwrap().get_ident_name(*self).clone()
-    }
-
-    ///
-    /// Record the source-string encoding a symbol was created from
-    /// (only when it differs from the default `Symbol#to_s`
-    /// derivation). Called by `String#to_sym`.
-    ///
-    pub(crate) fn set_symbol_encoding(self, enc: crate::value::Encoding) {
-        ID.write().unwrap().enc_map.insert(self, enc);
     }
 
     ///
@@ -366,16 +362,17 @@ impl IdentId {
 pub struct IdentifierTable {
     /// Reverse lookup for UTF-8 names.
     rev_table: HashMap<String, IdentId>,
-    /// Reverse lookup for binary names.
-    rev_table_bytes: HashMap<Vec<u8>, IdentId>,
+    /// Reverse lookup for binary names, keyed by `(bytes, encoding)`
+    /// so the same bytes under different (ASCII-incompatible /
+    /// non-UTF-8) encodings are distinct symbols.
+    rev_table_bytes: HashMap<(Vec<u8>, crate::value::Encoding), IdentId>,
     /// Forward table: IdentId -> IdentName.
     table: Vec<IdentName>,
-    /// Sparse side-map: the source-string encoding a symbol was
-    /// created from, when it is *not* the one `Symbol#to_s` would
-    /// derive by default (i.e. not US-ASCII / UTF-8 / ASCII-8BIT).
-    /// Only `String#to_sym` populates it; method/ivar/constant
-    /// interning never touches it, so symbol identity and dispatch
-    /// are unaffected.
+    /// The source encoding each byte-interned symbol carries, set
+    /// atomically by `get_id_from_bytes` at intern time. Collision-
+    /// free now that the byte table is keyed by `(bytes, encoding)`.
+    /// String/identifier interning never touches it, so method /
+    /// ivar / constant dispatch is unaffected.
     enc_map: HashMap<IdentId, crate::value::Encoding>,
 }
 
@@ -500,13 +497,16 @@ impl IdentifierTable {
         }
     }
 
-    fn get_id_from_bytes(&mut self, bytes: Vec<u8>) -> IdentId {
-        match self.rev_table_bytes.get(&bytes) {
+    fn get_id_from_bytes(&mut self, bytes: Vec<u8>, enc: crate::value::Encoding) -> IdentId {
+        let key = (bytes, enc);
+        match self.rev_table_bytes.get(&key) {
             Some(id) => *id,
             None => {
                 let id = IdentId::from(self.table.len() as u32 + 1);
-                self.rev_table_bytes.insert(bytes.clone(), id);
+                let (bytes, enc) = key;
+                self.rev_table_bytes.insert((bytes.clone(), enc), id);
                 self.table.push(IdentName::Bytes(bytes));
+                self.enc_map.insert(id, enc);
                 id
             }
         }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1391,9 +1391,19 @@ pub(crate) fn emit_chilled_string_mutation_warning(
     let sym = match self_val.is_rstring() {
         Some(s) => {
             let bytes = s.as_bytes();
-            match std::str::from_utf8(bytes) {
-                Ok(utf8) => IdentId::get_id(utf8),
-                Err(_) => IdentId::get_id_from_bytes(bytes.to_vec()),
+            let src = s.encoding();
+            let canon = if bytes.is_ascii() && src.is_ascii_compatible() {
+                Encoding::UsAscii
+            } else {
+                src
+            };
+            if matches!(canon, Encoding::UsAscii | Encoding::Utf8) {
+                match std::str::from_utf8(bytes) {
+                    Ok(utf8) => IdentId::get_id(utf8),
+                    Err(_) => IdentId::get_id_from_bytes(bytes.to_vec(), Encoding::Ascii8),
+                }
+            } else {
+                IdentId::get_id_from_bytes(bytes.to_vec(), canon)
             }
         }
         None => return Ok(()),

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -152,7 +152,7 @@ pub enum CodeRange {
     Broken,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum Encoding {
     /// Binary / ASCII-8BIT.


### PR DESCRIPTION
## Summary

One commit (`821fe344`) replacing the A1 symbol-encoding *side-map* with proper per-`(bytes, encoding)` interner identity. Rebased on current `master` (`36731080`).

### Problem

A1 (#555) recorded a symbol's source encoding in a process-global side-map keyed by `IdentId`. Byte-interned symbols were keyed by **bytes alone**, so the same bytes under different encodings collided on one `IdentId` and the side-map became last-writer-wins — CRuby gives them **distinct identity**. This also surfaced as cross-test flakiness under single-process parallel `cargo test`.

### Change

- `IdentifierTable::rev_table_bytes` → `HashMap<(Vec<u8>, Encoding), IdentId>`; `get_id_from_bytes(bytes, enc)` allocates a distinct `IdentId` per encoding and records `enc_map` atomically at intern time (collision-free).
- `String#to_sym`/`#intern` (+ the chilled-string re-intern) compute the canonical symbol encoding: ASCII-only content in an ASCII-compatible encoding collapses to US-ASCII (`"a".force_encoding("KOI8-R").to_sym == :a`); US-ASCII/UTF-8 names keep string-interning (shared with method/constant/ivar identifiers — **dispatch unaffected**); other encodings are byte-keyed so the symbol carries & round-trips its identity.
- `IdentId` / `Value::symbol` packing and the `IdentName` type are **unchanged** (`RValue` stays exactly 64 bytes; no ripple to trait impls). The A1 `set_symbol_encoding` shim is removed (now intrinsic).

### Result

- By-name pre/post mspec diff vs `master`: **zero true regressions, 4 true fixes** (`String#{to_sym,intern}` "ignores existing symbols with different encoding" / "returns a binary Symbol for a binary String with non US-ASCII characters").
- **Resolves the A1 cross-test `cargo test` flake**: under a full parallel run, `symbol_methods` / `symbol_preserves_source_encoding` are now stable (only the documented broken-locale `string_inspect` / `symbol_inspect_unquoted` artifacts remain — green on CI).
- Byte-exact vs `LANG=C.UTF-8 ruby`: distinct identity for `"あ".encode("UTF-16LE/BE").to_sym`, UTF-7 vs CP50221, US-ASCII collapse; `:café`/`:foo`/method names unchanged.
- Both Prism **and** ruruby parsers green; CRuby-verified unit test added; rebased cleanly onto `master` (`36731080`, PR #561).

### Out of scope (documented in commit message)

`Symbol#inspect quotes and escapes symbols in dummy encodings` stays red — blocked by `is_cruby_dummy_name` over-including Emacs-Mule/CESU-8/stateless-ISO-2022-JP and by the bare UTF-16/UTF-32 dummy forms mapping to the real LE codecs (Phase-B-sensitive), both separate from the collision fixed here. `codecov/patch`/`project` are advisory (project coverage stable, build+tests green) — consistent with prior merged PRs.

## Test plan

- [x] By-name pre/post diff on core/{symbol,string,encoding,hash,array,enumerable}: zero true regressions, 4 fixes
- [x] CRuby byte-exact for per-(bytes,encoding) identity, US-ASCII collapse, method/constant/symbol-name invariance
- [x] Full parallel `cargo test` symbol/string/encoding: 261 passed, only the 2 known broken-locale artifacts (flake resolved)
- [x] Prism + ruruby parsers; CRuby-verified `symbol_per_bytes_encoding_identity` unit test added
- [x] `RValue` size unchanged (64 bytes) — startup verified

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_