### PR TITLE
encoding: correct dummy classification + bare UTF-16/UTF-32 as dummy

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1269,6 +1269,8 @@ pub(super) fn encoding_constant_name(enc: Encoding) -> &'static str {
             0 => "UTF_7",
             1 => "CP50220",
             2 => "CP50221",
+            3 => "UTF_16",
+            4 => "UTF_32",
             _ => "ASCII_8BIT",
         },
     }
@@ -3354,17 +3356,20 @@ fn enc_inspect(
 /// match to match CRuby observed behaviour.
 fn is_cruby_dummy_name(name: &str) -> bool {
     let normalized = name.to_uppercase().replace('-', "_");
+    // CRuby's actual dummy-encoding set (Emacs-Mule / CESU-8 /
+    // stateless-ISO-2022-JP are *not* dummy in CRuby — they are
+    // ASCII-compatible).
     matches!(
         normalized.as_str(),
         "UTF_7"
             | "UTF_16"
             | "UTF_32"
-            | "EMACS_MULE"
             | "CP50220"
             | "CP50221"
             | "ISO_2022_JP"
-            | "STATELESS_ISO_2022_JP"
-            | "CESU_8"
+            | "ISO_2022_JP_2"
+            | "ISO_2022_JP_KDDI"
+            | "IBM037"
     )
 }
 
@@ -3420,7 +3425,6 @@ fn is_ascii_compatible_encoding(name: &str) -> bool {
             | "UTF-32BE"
             | "UTF-32LE"
             | "ISO-2022-JP"
-            | "STATELESS-ISO-2022-JP"
             | "CP50220"
             | "CP50221"
             | "UTF-7"
@@ -4467,6 +4471,33 @@ mod tests {
             // Emacs-Mule / CESU-8 stay ASCII-compatible (unchanged)
             r#""abcd".dup.force_encoding("Emacs-Mule").inspect"#,
             r#""abcd".dup.force_encoding("CESU-8").inspect"#,
+        ]);
+    }
+
+    #[test]
+    fn dummy_encoding_classification() {
+        run_tests(&[
+            // CRuby dummy set: dummy => not ASCII-compatible; the
+            // ASCII-only-content `to_sym` is byte-escaped + quoted.
+            r#"Encoding.list.select(&:dummy?).all? { |e| !e.ascii_compatible? }"#,
+            r#"Encoding.list.select(&:dummy?).map { |e|
+                 "abcd".dup.force_encoding(e).to_sym.inspect
+               }.uniq"#,
+            // Emacs-Mule / CESU-8 / stateless-ISO-2022-JP are NOT dummy
+            // and ARE ASCII-compatible (CRuby).
+            r#"[Encoding::CESU_8.dummy?, Encoding::Emacs_Mule.dummy?,
+                Encoding::STATELESS_ISO_2022_JP.dummy?]"#,
+            r#"[Encoding::CESU_8.ascii_compatible?,
+                Encoding::Emacs_Mule.ascii_compatible?,
+                Encoding::STATELESS_ISO_2022_JP.ascii_compatible?]"#,
+            r#""abcd".dup.force_encoding("Emacs-Mule").to_sym.inspect"#,
+            r#""abcd".dup.force_encoding("CESU-8").to_sym.inspect"#,
+            // bare UTF-16/UTF-32 are dummy (distinct from the LE codecs)
+            r#"[Encoding::UTF_16.dummy?, Encoding::UTF_16LE.dummy?]"#,
+            r#""abcd".dup.force_encoding("UTF-16").to_sym.inspect"#,
+            r#""abcd".dup.force_encoding("UTF-32").to_sym.inspect"#,
+            r#"Encoding.find("UTF-16").name"#,
+            r#""x".encode("UTF-16LE").bytes.size"#,
         ]);
     }
 

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1887,7 +1887,11 @@ mod encoding_tests {
             Encoding::try_from_str("UTF-16BE").unwrap(),
             Encoding::Utf16Be
         );
-        assert_eq!(Encoding::try_from_str("UTF-32").unwrap(), Encoding::Utf32Le);
+        // Bare `UTF-16` / `UTF-32` are CRuby's BOM-based *dummy*
+        // encodings — distinct ASCII-incompatible `Other` variants,
+        // not the real LE codecs.
+        assert_eq!(Encoding::try_from_str("UTF-16").unwrap(), Encoding::Other(3));
+        assert_eq!(Encoding::try_from_str("UTF-32").unwrap(), Encoding::Other(4));
         // Japanese.
         assert_eq!(Encoding::try_from_str("EUC-JP").unwrap(), Encoding::EucJp);
         assert_eq!(

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -200,7 +200,8 @@ pub enum Encoding {
 /// Canonical names for [`Encoding::Other`] variants (stateful /
 /// dummy byte encodings monoruby has no native codec for). The
 /// index is the `Encoding::Other` payload.
-pub(crate) const OTHER_ENC_NAMES: &[&str] = &["UTF-7", "CP50220", "CP50221"];
+pub(crate) const OTHER_ENC_NAMES: &[&str] =
+    &["UTF-7", "CP50220", "CP50221", "UTF-16", "UTF-32"];
 
 impl Encoding {
     /// True if the encoding is a strict superset of US-ASCII for
@@ -385,9 +386,14 @@ impl Encoding {
             "US_ASCII" | "ASCII" | "ANSI_X3_4_1968" | "646" => Ok(Encoding::UsAscii),
             "LOCALE" | "EXTERNAL" | "FILESYSTEM" => Ok(Encoding::Utf8),
 
-            "UTF_16" | "UTF_16LE" => Ok(Encoding::Utf16Le),
+            // Bare `UTF-16` / `UTF-32` are CRuby's BOM-based *dummy*
+            // encodings, distinct from the real `UTF-16LE` / … codecs:
+            // ASCII-incompatible, byte-oriented, name-preserved.
+            "UTF_16" => Ok(Encoding::Other(3)),
+            "UTF_32" => Ok(Encoding::Other(4)),
+            "UTF_16LE" => Ok(Encoding::Utf16Le),
             "UTF_16BE" => Ok(Encoding::Utf16Be),
-            "UTF_32" | "UTF_32LE" => Ok(Encoding::Utf32Le),
+            "UTF_32LE" => Ok(Encoding::Utf32Le),
             "UTF_32BE" => Ok(Encoding::Utf32Be),
 
             "ISO_8859_1" | "ISO8859_1" | "LATIN1" => Ok(Encoding::Iso8859(1)),


### PR DESCRIPTION
## Summary

One commit (`d52dad7a`) correcting monoruby's dummy-encoding classification to match CRuby and reclassifying the bare `UTF-16`/`UTF-32` BOM dummy encodings. Rebased on current `master` (`5473d892`). Builds on the per-`(bytes, encoding)` interner identity from #562 (collision-free).

### (a) Dummy classification

`is_cruby_dummy_name` mis-matched CRuby's set — it flagged **Emacs-Mule / CESU-8 / stateless-ISO-2022-JP** as dummy (CRuby treats them as ASCII-compatible, non-dummy) and omitted IBM037 / ISO-2022-JP-2 / ISO-2022-JP-KDDI. Aligned it with CRuby. Also removed `"STATELESS-ISO-2022-JP"` from `is_ascii_compatible_encoding` (CRuby: it *is* ASCII-compatible) — without this the corrected dummy set left it ASCII-incompatible + non-dummy, which would regress `Symbol#inspect quotes symbols in non-ASCII-compatible encodings` (caught and fixed).

### (b) Bare UTF-16 / UTF-32

Bare `UTF-16`/`UTF-32` are CRuby's BOM-based **dummy** encodings, distinct from the real `UTF-16LE`/`UTF-32LE` codecs. `try_from_str` collapsed them onto the LE codecs, so a symbol force-encoded to bare UTF-16 was *decoded* instead of byte-escaped. They now map to name-preserving ASCII-incompatible `Encoding::Other` variants; `UTF-16LE`/`BE`/`UTF-32LE`/`BE` keep their real codecs **unchanged**. No spec/test uses bare `encode("UTF-16")` (the BOM transcoder is unimplemented and unaffected — the niche stays `ConverterNotFoundError` as before), so the Phase-B risk did **not** materialize (verified by the regression diff).

### Result

By-name pre/post mspec diff vs `master`: **zero true regressions, 9 true fixes**:

- `Symbol#inspect quotes and escapes symbols in dummy encodings` (the original target)
- `Encoding#ascii_compatible? is always false for dummy encodings`
- `Encoding#dummy? implies not #ascii_compatible?`
- `String#{chars,each_char,grapheme_clusters,each_grapheme_cluster}` for dummy encodings (4)
- `String#{codepoints,each_codepoint}` for dummy UTF-16/UTF-32 (2)

`core/symbol/inspect_spec.rb` fully green (0F/0E). Byte-exact vs `LANG=C.UTF-8 ruby` (dummy set, `ascii_compatible?`, `force_encoding` round-trip, `to_sym.inspect`). Both Prism **and** ruruby parsers green; CRuby-verified unit test added. `codecov/*` is advisory (real build+tests green) — consistent with prior merged PRs.

## Test plan

- [x] `core/symbol/inspect_spec.rb` 0/0
- [x] By-name pre/post diff on core/{symbol,string,encoding,hash,array,enumerable}: zero true regressions, 9 fixes
- [x] CRuby byte-exact: dummy set, `Encoding#{dummy?,ascii_compatible?}`, force_encoding round-trip, `to_sym.inspect`; `UTF-16LE` codec unchanged
- [x] Prism + ruruby; cargo encoding/symbol green (only the documented broken-locale `symbol_inspect_unquoted` artifact)
- [x] Rebased cleanly onto `master` (`5473d892`, PR #563); post-rebase specs/cargo re-verified

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_