### PR TITLE
core: top-level private/public target Object; obj.private_methods includes Object

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3247,7 +3247,9 @@ fn private_methods(
     Ok(Value::array_from_vec(if !inherited_too {
         globals.store.get_private_method_names_direct(class_id)
     } else {
-        globals.store.get_private_method_names_inherit(class_id)
+        globals
+            .store
+            .get_private_method_names_inherit_incl_object(class_id)
     }))
 }
 
@@ -3269,7 +3271,9 @@ fn protected_methods(
     Ok(Value::array_from_vec(if !inherited_too {
         globals.store.get_protected_method_names_direct(class_id)
     } else {
-        globals.store.get_protected_method_names_inherit(class_id)
+        globals
+            .store
+            .get_protected_method_names_inherit_incl_object(class_id)
     }))
 }
 

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -3087,6 +3087,31 @@ mod tests {
     }
 
     #[test]
+    fn toplevel_protected_and_direct() {
+        // obj.protected_methods(true) includes Object's own protected
+        // instance methods (incl_object walk); the `(false)` direct
+        // variants; and Kernel's instance view must not bleed Object's.
+        run_test(
+            r#"
+            class Object
+              def tp1; 1; end
+              protected :tp1
+              def tp2; 2; end
+            end
+            Object.send(:private, :tp2)
+            r = []
+            r << Object.protected_instance_methods(false).include?(:tp1)
+            r << Object.protected_methods(true).include?(:tp1)
+            r << Object.new.protected_methods(true).include?(:tp1)
+            r << Object.private_methods(false).include?(:tp2)
+            r << Object.protected_methods(false).include?(:tp1)
+            r << Kernel.protected_instance_methods(true).include?(:tp1)
+            r
+            "#,
+        );
+    }
+
+    #[test]
     fn test_teq() {
         run_tests(&[
             "Integer === 4",

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -3005,7 +3005,15 @@ pub(super) fn change_visi(
         return Ok(Value::nil());
     }
     let (res, names) = extract_names(globals, arg)?;
-    let class_id = self_val.as_class_id();
+    // At top level `self` is the `main` object (an Object instance, not
+    // a Module); CRuby's default definee there is `Object`, so e.g.
+    // `private :m` makes `Object#m` private. Fall back to OBJECT_CLASS
+    // for any non-module receiver.
+    let class_id = if self_val.is_class().is_some() || self_val.is_module().is_some() {
+        self_val.as_class_id()
+    } else {
+        OBJECT_CLASS
+    };
     // CRuby fires `method_added` only when `private` / `protected` /
     // `public` adds a *new* entry to the receiver's method table —
     // i.e. when the method was inherited rather than defined locally.
@@ -3047,6 +3055,36 @@ fn extract_names(store: &Store, arg: Array) -> Result<(Value, Vec<IdentId>)> {
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn toplevel_private_public() {
+        // Top-level `private`/`public`/`protected` target Object, and
+        // Object's own private instance methods surface in
+        // `Object.private_methods(true)` (CRuby semantics).
+        run_test(
+            r#"
+            def mp1; 1; end
+            def mp2; 2; end
+            def mp3; 3; end
+            private :mp1
+            private :mp2, :mp3
+            r = []
+            r << Object.private_instance_methods(false).include?(:mp1)
+            r << Object.private_methods(true).include?(:mp1)
+            r << Object.private_methods(true).include?(:mp2)
+            r << Object.private_methods(true).include?(:mp3)
+            public :mp1
+            r << Object.private_methods(true).include?(:mp1)
+            # array argument form + return value
+            r << (private([:mp2, :mp3]))
+            r << (private :mp1)
+            # Kernel's instance-method list must NOT bleed in Object's
+            r << Kernel.public_instance_methods(true).include?(:mp1)
+            r
+            "#,
+        );
+        run_test_error(r#"private :no_such_toplevel_method_xyz"#);
+    }
 
     #[test]
     fn test_teq() {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -909,10 +909,23 @@ impl ClassInfoTable {
 
     /// Stop predicate for `(true)` / inherited variants — process every
     /// ancestor up to but excluding `OBJECT_CLASS`.
+    /// Stop predicate for the `*_instance_methods(true)` family: stop
+    /// once the next ancestor would be `Object` (or there is none), so a
+    /// module such as `Kernel` reports only its own instance methods and
+    /// does not bleed in `Object`'s (monoruby links `Kernel`'s internal
+    /// superclass to `Object` for lookup).
     fn stop_before_object(module: Module) -> bool {
         module
             .superclass()
             .is_none_or(|superclass| superclass.id() == OBJECT_CLASS)
+    }
+
+    /// Stop predicate for the receiver-level `obj.{private,public,
+    /// protected}_methods(true)` accessors: walk up to and *including*
+    /// `Object`'s own method table (where toplevel `def`s / `private :m`
+    /// land), then stop before `Kernel` / `BasicObject` builtin noise.
+    fn stop_at_object(module: Module) -> bool {
+        module.id() == OBJECT_CLASS || module.superclass().is_none()
     }
 
     /// Stop predicate for `(false)` / direct variants — process the
@@ -1168,6 +1181,24 @@ impl ClassInfoTable {
     ///
     pub(crate) fn get_private_method_names_inherit(&self, class_id: ClassId) -> Vec<Value> {
         self.walk_method_names(class_id, MethodTableEntry::is_private, Self::stop_before_object)
+    }
+
+    /// `obj.private_methods(true)`: like the above but also includes
+    /// `Object`'s own private instance methods (toplevel `private :m`),
+    /// which CRuby reports.
+    pub(crate) fn get_private_method_names_inherit_incl_object(
+        &self,
+        class_id: ClassId,
+    ) -> Vec<Value> {
+        self.walk_method_names(class_id, MethodTableEntry::is_private, Self::stop_at_object)
+    }
+
+    /// `obj.protected_methods(true)` counterpart of the above.
+    pub(crate) fn get_protected_method_names_inherit_incl_object(
+        &self,
+        class_id: ClassId,
+    ) -> Vec<Value> {
+        self.walk_method_names(class_id, Self::is_protected, Self::stop_at_object)
     }
 
     ///


### PR DESCRIPTION
## Summary

Scouted `core/main` (per request to look around argf/main). The
tractable, contained win was **`main#private`** (3 failures, same root
cause; `core/main/{public,to_s,ruby2_keywords}` already green, `using`
needs refinements, `include` is a niche load-wrapper case).

Two coupled fixes:

1. **`change_visi`**: at top level `self` is the `main` object (an
   Object instance, *not* a Module), so `self_val.as_class_id()`
   mis-resolved and `private :m` / `public :m` / `protected :m` were
   silent no-ops. A non-Module receiver now resolves to `OBJECT_CLASS`
   — CRuby's default definee at top level — so the visibility actually
   changes on `Object`'s instance methods.

2. **`*_methods(true)` ancestor-walk split**: the previous single
   `stop_before_object` stopped one module too early, dropping
   `Object`'s own (top-level-defined) methods whenever Object was an
   ancestor. The `*_instance_methods` family keeps `stop_before_object`
   (so `Kernel.public_instance_methods` doesn't bleed in Object's
   methods — monoruby links `Kernel`'s internal superclass to Object),
   while the receiver-level `obj.private_methods` /
   `obj.protected_methods` use a new `stop_at_object` that walks up to
   and including Object's own table, matching CRuby.

### ruby/spec (clean-master baseline → now), zero regressions

| spec | before | after |
|---|---|---|
| `core/main` | 5F / 7E | **2F / 7E**  (`main#private` 3F → 0F) |
| `core/kernel` | 270F / 240E | **269F / 240E** |

`core/module` (incl. the `Module#alias_method` /
`Kernel.public_instance_methods` case that an interim single-stop
attempt regressed — now fixed by the split), `core/method`,
`core/basicobject` all **unchanged** vs a freshly built clean-`master`
binary; per-spec failure diffs confirm no example regressed.

## Test plan

- [x] `cargo build` clean
- [x] `builtins::module` 195/195 and `builtins::kernel` 87/87 unit
      modules green; new `toplevel_private_public` validates top-level
      `private`/`public`, array-arg form, return value,
      `Object.private_methods(true)` membership, the `Kernel`
      non-bleed, and the undefined-name `NameError` against CRuby 4.0.4
- [x] clean-master ruby/spec sweep (`main`/`kernel`/`module`/`method`/
      `basicobject`) with per-spec failure diff — no regression

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_