### PR TITLE
fix(defined?): handle &&/||/and/or and =~/!~ instead of aborting

### DIFF
--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -81,6 +81,13 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::Begin { body: box n, .. }
             | NodeKind::UnOp(_, box n) => self.check_defined(n, nil_label, ret, false)?,
             NodeKind::BinOp(op, box l, box r) => {
+                // `&&` / `||` (and `and`/`or`) are not method calls:
+                // CRuby `defined?(a && b)` is always "expression" and
+                // the operands are *not* checked. Keep the "expression"
+                // string set by `gen_defined` and never jump to nil.
+                if matches!(op, BinOp::LAnd | BinOp::LOr) {
+                    return Ok(());
+                }
                 if top {
                     let body_start = self.new_label();
                     let body_end = self.new_label();
@@ -109,7 +116,11 @@ impl<'a> BytecodeGen<'a> {
                             CmpKind::Ge => IdentId::_GE,
                             CmpKind::TEq => IdentId::_TEQ,
                         },
-                        _ => unimplemented!(),
+                        BinOp::Match => IdentId::_MATCH,
+                        BinOp::Unmatch => IdentId::_UNMATCH,
+                        // LAnd/LOr handled above; all BinOp variants are
+                        // now covered.
+                        BinOp::LAnd | BinOp::LOr => unreachable!(),
                     };
                     self.emit(BytecodeInst::DefinedMethod { ret, recv, name }, node.loc);
                     self.exception_table.push(ExceptionEntry {
@@ -327,6 +338,8 @@ fn defined_str(node: &Node) -> &'static str {
         NodeKind::GlobalVar(..) => "global-variable",
         NodeKind::ClassVar(..) => "class-variable",
         NodeKind::Const { .. } => "constant",
+        // `&&` / `||` are expressions, not method calls.
+        NodeKind::BinOp(BinOp::LAnd | BinOp::LOr, ..) => "expression",
         NodeKind::BinOp(..)
         | NodeKind::FuncCall { .. }
         | NodeKind::MethodCall { .. }
@@ -339,5 +352,27 @@ fn defined_str(node: &Node) -> &'static str {
             None => "nil",
         },
         NodeKind::DiscardLhs => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn defined_logical_and_match_ops() {
+        // `&&` / `||` / `and` / `or` are expressions (operands not
+        // checked); `=~` / `!~` are method calls. Previously these
+        // panicked (`unimplemented!`) and aborted the process.
+        run_test(r#"a = 1; b = 2; defined?(a && b)"#);
+        run_test(r#"defined?(1 || 2)"#);
+        run_test(r#"a = 1; defined?(a and 2)"#);
+        run_test(r#"defined?(1 or 2)"#);
+        run_test(r#"defined?(undef_x && 1)"#);
+        run_test(r#"defined?(undef_x || undef_y)"#);
+        run_test(r#"defined?("x" =~ /x/)"#);
+        run_test(r#"defined?(1 =~ 2).inspect"#);
+        run_test(r#"defined?(1 !~ 2)"#);
+        run_test(r#"defined?(undef_x =~ /a/).inspect"#);
     }
 }


### PR DESCRIPTION
## Summary

First of a sequence of fixes for the `ruby/spec` `language` panics
(investigated previously). This one removes the **process abort** in
`defined?`.

`defined?(<l> <op> <r>)` where `op` was `&&`/`||`/`and`/`or`
(`LAnd`/`LOr`) or `=~`/`!~` (`Match`/`Unmatch`) hit `unimplemented!()`
in `bytecodegen/defined.rs`, which — at the `extern "C"` builtin
boundary — is a **non-unwinding panic that aborts the whole process**,
killing every subsequent example in `language/defined_spec.rb` (and any
file using these forms).

- `&&` / `||` / `and` / `or` → classified as `"expression"`; operands
  are *not* checked (CRuby: `defined?(a && b)` is always `"expression"`,
  even with undefined operands).
- `=~` / `!~` → treated as method calls like the other operators,
  mapped to `IdentId::_MATCH` / `IdentId::_UNMATCH`.

Verified against CRuby 4.0.4:
`defined?(a && b)`→`"expression"`, `defined?("x" =~ /x/)`→`"method"`,
`defined?(1 =~ 2)`→`nil`, `defined?(1 !~ 2)`→`"method"`,
`defined?(undef_x && 1)`→`"expression"`.

### ruby/spec

| spec | before | after |
|---|---|---|
| `language/defined_spec.rb` | **aborts (0 results)** | 255 examples, 42F, 0E |

`language/and`, `language/or`, `language/not` unchanged (0F). Other
`language` panics (`precedence`/`if`/`case`/`method` etc.) are
**separate, pre-existing** causes handled in follow-up PRs.

## Test plan

- [x] `cargo build` clean
- [x] full `cargo test --lib`: 1549 passed; the only 2 failures are the
      pre-existing sandbox-locale artifacts (`string_inspect`,
      `symbol_inspect_unquoted`) documented in
      `doc/refine_encoding_plan.md`, unrelated to this change
- [x] new `bytecodegen::defined::tests::defined_logical_and_match_ops`
      validates all forms against CRuby 4.0.4
- [x] clean-master comparison: `defined_spec.rb` aborts on master, runs
      fully here; no `language` spec regressed

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_