### PR TITLE
fix(kwargs): non-Symbol keyword key raises ArgumentError instead of aborting

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -607,9 +607,23 @@ fn hash_splat_and_kw_rest(
         }
         if unused > 0 && globals[callee].kw_rest().is_none() {
             for (k, _) in h.iter() {
-                let sym = k.as_symbol();
-                if !globals[callee].kw_names().contains(&sym) {
-                    return Err(MonorubyErr::argumenterr(format!("unknown keyword: :{sym}")));
+                // A non-Symbol key (e.g. a String) can never name a
+                // keyword parameter, so it is always "unknown" here.
+                // CRuby reports it via the key's `inspect`
+                // (`unknown keyword: "b"`); a Symbol key uses `:name`.
+                match k.try_symbol() {
+                    Some(sym) if globals[callee].kw_names().contains(&sym) => {}
+                    Some(sym) => {
+                        return Err(MonorubyErr::argumenterr(format!(
+                            "unknown keyword: :{sym}"
+                        )));
+                    }
+                    None => {
+                        return Err(MonorubyErr::argumenterr(format!(
+                            "unknown keyword: {}",
+                            k.inspect(&globals.store)
+                        )));
+                    }
                 }
             }
         }
@@ -687,5 +701,18 @@ mod tests {
             B3.new.a(1, 2)
             "#,
         );
+    }
+
+    #[test]
+    fn kwarg_nonsymbol_key_no_panic() {
+        // A non-Symbol key passed where keyword params are expected
+        // (no **rest) is an "unknown keyword" reported via inspect;
+        // previously `as_symbol().unwrap()` aborted the process.
+        run_test_error(r#"def m(a:); a; end; m("a"=>1)"#);
+        run_test_error(r#"def m(a:); end; m(:a=>1, "b"=>2)"#);
+        run_test_error(r#"def m(a:); end; m(:a=>1, :c=>2)"#);
+        // **rest accepts non-Symbol keys verbatim.
+        run_test(r#"def m(**k); k; end; m("a"=>1, :b=>2)"#);
+        run_test(r#"def m(a:); a; end; m(a: 5)"#);
     }
 }


### PR DESCRIPTION
## Summary

Third of the `language`-panic sequence (#568, #569). Removes the
**process abort** on a non-Symbol keyword key.

A method expecting keyword parameters (no `**rest`) receiving a Hash
with a non-Symbol key (`m("a"=>1)`) hit `k.as_symbol().unwrap()` in the
unknown-keyword scan — a panic that at the `extern "C"` boundary
**aborts the whole process**, killing the rest of
`language/keyword_arguments_spec.rb`.

Now uses `try_symbol()`:
- Symbol key naming a parameter → accepted
- Symbol key not a parameter → `unknown keyword: :name`
- non-Symbol key → `unknown keyword: <inspect>` (CRuby format, e.g.
  `unknown keyword: "b"`)

`**rest` still accepts non-Symbol keys verbatim. Verified vs CRuby
4.0.4 (`m(:a=>1,"b"=>2)`→`unknown keyword: "b"`,
`m(:a=>1,:c=>2)`→`unknown keyword: :c`, `m("a"=>1,**)`→`{"a"=>1}`).

> **Out of scope:** monoruby has *no* required-keyword enforcement at
> all (`def m(a:); m()` doesn't raise `missing keyword: :a`). That's a
> separate pre-existing feature gap; this PR only removes the abort and
> makes the unknown-keyword path CRuby-faithful. So `m("a"=>1)` here
> reports `unknown keyword: "a"` where CRuby prefers `missing keyword:
> :a` — same `ArgumentError` class, different message.

### ruby/spec

| spec | before | after |
|---|---|---|
| `language/keyword_arguments_spec.rb` | **aborts (0 results)** | 23 examples, 6F, 3E |

`language/proc` unchanged. Other `language` panics handled in follow-up
PRs.

## Test plan

- [x] `cargo build` clean
- [x] new `codegen::runtime::args::tests::kwarg_nonsymbol_key_no_panic`
      (Symbol/non-Symbol unknown keys, `**rest`, valid kwarg) vs CRuby 4.0.4
- [x] clean-master comparison: spec aborts on master, runs fully here;
      `language/proc` unchanged, no `language` spec regressed

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ageMjsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_