### PR TITLE
fix(visibility): bare private/public at top level no longer aborts

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -3057,6 +3057,30 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn bare_visibility_no_cref_no_panic() {
+        // Bare `private`/`public` at the top level — where the
+        // lexical-class frame carries no Cref — previously aborted the
+        // process at `set_context_visibility().unwrap()`. It must now
+        // toggle the top-level default visibility (CRuby: top level
+        // starts `private`).
+        run_test(
+            r#"
+            def pa; end
+            public
+            def pb; end
+            private
+            def pc; end
+            [Object.public_instance_methods(false).include?(:pb),
+             Object.private_instance_methods(false).include?(:pa),
+             Object.private_instance_methods(false).include?(:pc)]
+            "#,
+        );
+        // bare modifier at top level returns nil and does not abort
+        run_test(r#"def t; end; (private).inspect"#);
+        run_test(r#"def t; end; (public).inspect"#);
+    }
+
+    #[test]
     fn toplevel_private_public() {
         // Top-level `private`/`public`/`protected` target Object, and
         // Object's own private instance methods surface in

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -80,6 +80,11 @@ pub struct Executor {
     stack_limit: usize,
     /// lexical class stack.
     lexical_class: Vec<Vec<Cref>>,
+    /// Default method visibility for the top level (and any context
+    /// whose lexical-class frame carries no `Cref`), toggled by a
+    /// bare `private` / `public` / `protected`. CRuby's top-level
+    /// default is `private`.
+    toplevel_visibility: Visibility,
     sp_last_match: Option<String>,   // $&        : Regexp.last_match(0)
     sp_pre_match: Option<String>,    // $`        : Regexp.pre_match
     sp_post_match: Option<String>,   // $'        : Regexp.post_match
@@ -115,6 +120,7 @@ impl std::default::Default for Executor {
             parent_fiber: None,
             stack_limit: 0,
             lexical_class: vec![vec![]],
+            toplevel_visibility: Visibility::Private,
             sp_last_match: None,
             sp_pre_match: None,
             sp_post_match: None,
@@ -651,7 +657,7 @@ impl Executor {
             .unwrap()
             .last()
             .cloned()
-            .unwrap_or_else(|| Cref::new(OBJECT_CLASS, false, Visibility::Private))
+            .unwrap_or_else(|| Cref::new(OBJECT_CLASS, false, self.toplevel_visibility))
     }
 
     pub fn context_class_id(&self) -> ClassId {
@@ -726,16 +732,19 @@ impl Executor {
             .unwrap()
             .last()
             .map(|cref| cref.visibility)
-            .unwrap_or(Visibility::Private)
+            .unwrap_or(self.toplevel_visibility)
     }
 
+    /// Set the current default method visibility (bare `private` /
+    /// `public` / `protected`). When the current lexical-class frame
+    /// carries no `Cref` (top level, or a method body whose frame is
+    /// empty) there is nothing to write to, so the toggle is recorded
+    /// in `toplevel_visibility` instead of panicking.
     pub(crate) fn set_context_visibility(&mut self, visi: Visibility) {
-        self.lexical_class
-            .last_mut()
-            .unwrap()
-            .last_mut()
-            .unwrap()
-            .visibility = visi;
+        match self.lexical_class.last_mut().and_then(|f| f.last_mut()) {
+            Some(cref) => cref.visibility = visi,
+            None => self.toplevel_visibility = visi,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fourth of the `language`-panic sequence (#568/#569/#570). Removes the
**process abort** in bare `private`/`public`/`protected` at the top
level.

`set_context_visibility` did
`lexical_class.last_mut().unwrap().last_mut().unwrap()`. At the top
level the lexical-class frame carries **no `Cref`**, so the inner
`unwrap()` is `None` → a non-unwinding panic at the `extern "C"`
boundary that **aborts the whole process**, killing the rest of
`language/def_spec.rb` (which calls top-level `public`).

Added a `toplevel_visibility` field (default `Private`, matching
CRuby's top-level default):
- `set_context_visibility` writes there when no `Cref` is present
  (instead of `unwrap()`-panicking).
- `context_visibility` and the synthetic top-level
  `get_class_context` `Cref` read it, so top-level `public`/`private`
  correctly toggle subsequent top-level `def` visibility (previously
  hard-coded `Private`).

Verified vs CRuby 4.0.4: `def pa; public; def pb; private; def pc` →
`pb` public, `pa`/`pc` private; `(private).inspect` → `"nil"`.

### ruby/spec

`language/def_spec.rb` no longer aborts at this panic — it now
progresses past it (a *separate, unrelated* `def_spec.rb:215`
`FatalError` remains, tracked for a later fix). `language/private`
0F/0E; `language/class`, `core/main/{private,public}` **unchanged**
(no #567 regression).

## Test plan

- [x] `cargo build` clean
- [x] full `cargo test --lib`: 1549 passed; only the 2 pre-existing
      sandbox-locale artifacts (`string_inspect`,
      `symbol_inspect_unquoted`) fail, unrelated
- [x] new `builtins::module::tests::bare_visibility_no_cref_no_panic`
      (top-level public/private toggle + `(private).inspect`) vs CRuby 4.0.4
- [x] clean-master comparison: `def_spec.rb` aborts on master, runs
      further here; no visibility spec regressed

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_