### PR TITLE
fix(binding): clone/dup of a Binding no longer aborts

### DIFF
--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -314,6 +314,32 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn binding_dup_clone() {
+        // Cloning a Binding RValue previously hit
+        // `unreachable!("BINDING")` and aborted (ERB dups `binding`).
+        run_test(
+            r#"
+            x = 41
+            b = binding
+            b2 = b.dup
+            b3 = b.clone
+            [b2.class.name, b2.eval("x"), b3.eval("x + 1"),
+             b2.local_variable_get(:x)]
+            "#,
+        );
+        run_test(
+            r#"
+            def m
+              y = 7
+              binding
+            end
+            b = m.dup
+            [b.eval("y"), b.class == Binding]
+            "#,
+        );
+    }
+
+    #[test]
     fn binding_new() {
         run_test(
             r#"

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1133,6 +1133,9 @@ impl RValue {
                                 (*self.kind.arithmetic_sequence).clone(),
                             ),
                         },
+                        ObjTy::BINDING => ObjKind {
+                            binding: ManuallyDrop::new((*self.kind.binding).clone()),
+                        },
                         ty => unreachable!("{ty:?}"),
                     }
                 } else {
@@ -1209,6 +1212,9 @@ impl RValue {
                             arithmetic_sequence: ManuallyDrop::new(
                                 (*self.kind.arithmetic_sequence).clone(),
                             ),
+                        },
+                        ObjTy::BINDING => ObjKind {
+                            binding: ManuallyDrop::new((*self.kind.binding).clone()),
                         },
                         ty => unreachable!("{ty:?}"),
                     }


### PR DESCRIPTION
## Summary

Fifth panic-removal (companion to #568/#569/#570/#571). The RValue
deep-copy match had no `ObjTy::BINDING` arm, so cloning a `Binding`
hit `unreachable!("{ty:?}")` — a non-unwinding panic at the
`extern "C"` boundary that **aborts the whole process**, killing the
`library/erb/*` specs (ERB `dup`s `binding`).

Added `ObjTy::BINDING => ObjKind { binding: ManuallyDrop::new(
(*self.kind.binding).clone()) }` (the `BindingInner` is already
`#[derive(Clone)]`), mirroring the existing `STRUCT` /
`ARITHMETIC_SEQUENCE` `ManuallyDrop` arms, at both copy sites.

Verified vs CRuby 4.0.4: `b = binding; b.dup.eval("x")` /
`b.clone.local_variable_get(:x)` work; `m.dup.eval("y")` for a
binding captured in a method body works.

### ruby/spec (clean-master → now)

| spec | before | after |
|---|---|---|
| `library/erb/new` | **aborts** | 13 examples, 0F, 7E |
| `library/erb/result` | **aborts** | 5 examples, **0F, 0E** |

## Test plan

- [x] `cargo build` clean
- [x] full `cargo test --lib`: only the 2 pre-existing sandbox-locale
      artifacts (`string_inspect`, `symbol_inspect_unquoted`) fail,
      unrelated
- [x] new `builtins::binding::tests::binding_dup_clone` (dup/clone
      `eval`, `local_variable_get`, method-captured binding) vs CRuby 4.0.4
- [x] clean-master comparison: `erb/new`/`erb/result` abort on master,
      run here; no regression

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_