### PR TITLE
encoding: Encoding::Converter.new replacement + same-encoding error

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -363,7 +363,19 @@ pub(super) fn init_encoding(globals: &mut Globals) {
     // 2..3 positional args: (src, dst, opts?). `opts` accepts an
     // Integer flag mask or an option Hash; both are tolerated and
     // ignored beyond construction-time validation.
-    globals.define_builtin_class_func_with(converter.id(), "new", converter_new, 2, 3, false);
+    // kw_rest=true so `Converter.new(src, dst, replace: …)` and
+    // `**opts` deliver the options as a trailing Hash (read via
+    // `get_options_hash_value`, like `String#encode`).
+    globals.define_builtin_class_func_with_kw(
+        converter.id(),
+        "new",
+        converter_new,
+        2,
+        3,
+        false,
+        &[],
+        true,
+    );
     globals.define_builtin_class_func(
         converter.id(),
         "asciicompat_encoding",
@@ -1606,8 +1618,34 @@ fn converter_new(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let src = resolve_dst_encoding(vm, globals, lfp.arg(0))?;
-    let dst = resolve_dst_encoding(vm, globals, lfp.arg(1))?;
+    // Resolve to canonical constant names *once* (so a `#to_str`
+    // mock argument is converted exactly once, per spec).
+    let src_name = encode_resolve_enc_arg(vm, globals, lfp.arg(0))?;
+    let dst_name = encode_resolve_enc_arg(vm, globals, lfp.arg(1))?;
+    let src = encoding_from_canonical_name(src_name).ok_or_else(|| {
+        MonorubyErr::converter_not_found_error(
+            &globals.store,
+            format!("code converter not found ({})", src_name),
+        )
+    })?;
+    let dst = encoding_from_canonical_name(dst_name).ok_or_else(|| {
+        MonorubyErr::converter_not_found_error(
+            &globals.store,
+            format!("code converter not found ({})", dst_name),
+        )
+    })?;
+    // CRuby raises `Encoding::ConverterNotFoundError` for identical
+    // source/destination encodings — there is no "X to X" transcoder.
+    // Compare the resolved canonical *names*, not the internal
+    // `Encoding`: monoruby folds aliases like `UTF8-MAC` onto
+    // `Utf8`, but CRuby treats them as distinct and DOES build a
+    // converter (`Converter.new(UTF_8, UTF8_MAC)` is valid).
+    if src_name == dst_name {
+        return Err(MonorubyErr::converter_not_found_error(
+            &globals.store,
+            format!("code converter not found ({} to {})", src.name(), dst.name()),
+        ));
+    }
     validate_converter_pair(src, dst, &globals.store)?;
     let class = lfp.self_val();
     let obj = Value::object(class.as_class_id());
@@ -1624,6 +1662,40 @@ fn converter_new(
         IdentId::get_id(CONVERTER_DST_IVAR),
         Value::string_from_str(dst.name()),
     );
+    // Options Hash (`replace:` kwargs / `**opts` / trailing Hash).
+    // With `kw_rest=true` the collected kwargs Hash is delivered in
+    // the slot after the positional args (index 3 here); a literal
+    // positional Hash lands at index 2. An Integer 3rd arg is a
+    // flags bitmask and carries no `replace:`. The encoding args at
+    // 0/1 are never Hashes, so scanning 2..=3 is unambiguous.
+    let opts_hash = (2..=3)
+        .filter_map(|i| lfp.try_arg(i))
+        .find_map(|v| v.try_hash_ty());
+    if let Some(hash) = opts_hash {
+        {
+            if let Some(rep) = find_hash_value_for_symbol(&hash, "replace") {
+                // `replace: nil` → keep the destination's default
+                // replacement (handled lazily by `#replacement`).
+                if !rep.is_nil() {
+                    // CRuby coerces via `#to_str`; a non-String
+                    // return or an object without `#to_str`
+                    // (true/false/Integer) raises TypeError.
+                    let s = if let Some(st) = rep.is_str() {
+                        st.to_string()
+                    } else {
+                        rep.coerce_to_string(vm, globals)?
+                    };
+                    let mut inner = crate::value::RStringInner::from_string_scanned(s);
+                    inner.set_encoding(dst);
+                    let _ = globals.store.set_ivar(
+                        obj,
+                        IdentId::get_id(CONVERTER_REPLACE_IVAR),
+                        Value::string_from_inner(inner),
+                    );
+                }
+            }
+        }
+    }
     Ok(obj)
 }
 

--- a/monoruby/src/builtins/encoding_tests.rs
+++ b/monoruby/src/builtins/encoding_tests.rs
@@ -320,6 +320,30 @@ mod tests {
     }
 
     #[test]
+    fn encoding_converter_new_replacement_and_same_encoding() {
+        // `Converter.new` option/argument handling, verified
+        // byte-exact against `LANG=C.UTF-8 ruby`.
+        run_tests(&[
+            // `replace:` String (incl. empty) sets the replacement.
+            r#"Encoding::Converter.new("us-ascii","utf-8", replace: "fubar").replacement"#,
+            r#"Encoding::Converter.new("us-ascii","utf-8", replace: "").replacement"#,
+            // nil → keep the destination default ("?" / "�").
+            r#"Encoding::Converter.new("us-ascii","binary", replace: nil).replacement"#,
+            r#"Encoding::Converter.new("us-ascii","utf-8", replace: nil).replacement"#,
+            // #to_str coercion for the replacement object.
+            r#"o = Object.new; def o.to_str; "X"; end; Encoding::Converter.new("us-ascii","utf-8", replace: o).replacement"#,
+            // Identical encodings raise ConverterNotFoundError…
+            r#"(Encoding::Converter.new("utf-8","utf-8") rescue $!.class.name)"#,
+            // …but alias-distinct pairs (UTF-8 vs UTF8-MAC) do not.
+            r#"Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_8_MAC).class.name"#,
+            // Non-String / non-#to_str replacement → TypeError.
+            r#"(Encoding::Converter.new("us-ascii","utf-8", replace: true) rescue $!.class.name)"#,
+            r#"(Encoding::Converter.new("us-ascii","utf-8", replace: 1) rescue $!.class.name)"#,
+            r#"b = Object.new; def b.to_str; 1; end; (Encoding::Converter.new("us-ascii","utf-8", replace: b) rescue $!.class.name)"#,
+        ]);
+    }
+
+    #[test]
     fn encoding_compatible_rb_enc_compatible() {
         // CRuby's `rb_enc_compatible` truth table (encoding.c),
         // verified byte-exact against `LANG=C.UTF-8 ruby`. Covers


### PR DESCRIPTION
## Summary

Phase B-1 of the `Encoding::Converter` work: `Converter.new` argument/option handling.

`Encoding::Converter.new` previously ignored its options argument entirely (no `replace:` support) and silently accepted identical source/destination encodings.

- Registered `Converter.new` with `kw_rest=true` so `replace:` kwargs / `**opts` / a trailing Hash are delivered (read from the slot after the positional args, like `String#encode`).
- **`replace:` honoured**: a String (incl. empty `""`) is used as-is; any other object is coerced via `#to_str` (a non-String return, or no `#to_str` — `true`/`false`/Integer — raises `TypeError`, per CRuby); `nil` keeps the destination's default replacement (`"?"` / `"�"`).
- **Identical encodings now raise `Encoding::ConverterNotFoundError`** (CRuby has no "X to X" converter). The check compares the resolved canonical *names*, not the internal `Encoding`: monoruby folds aliases like `UTF8-MAC` onto `Utf8`, but CRuby treats them as distinct and *does* build a converter (`Converter.new(UTF_8, UTF8_MAC)` is valid) — comparing the collapsed enum wrongly raised there. (This regressed `primitive_convert_spec` in an intermediate build; caught in the regression sweep and fixed before commit.) Encoding args are resolved once so a `#to_str` mock argument is converted exactly once.

## Results

`core/encoding/converter/new_spec.rb`: **11F/1E → 1F/1E** (10 fixed). The remaining 1F/1E is the single `**opts` + `#to_hash` example — that's the `**` double-splat calling `#to_hash` at the *call site* (a core-kwargs feature), out of Converter scope; deferred.

**Zero regressions, zero new errors** by category vs master:

| category | before | after |
|---|---|---|
| core/encoding | 66F/15E | 56F/15E |
| core/string | 212F/116E | 212F/116E |
| core/symbol | 0F/0E | 0F/0E |
| core/hash | 14F/6E | 14F/6E |
| core/array | 19F/8E | 19F/8E |

Verified byte-exact vs `LANG=C.UTF-8 ruby` (10 cases incl. empty / `#to_str` / nil-default / same-encoding / `UTF8-MAC`); both Prism and ruruby parsers green; CRuby-verified unit test added.

## Test plan

- [ ] `coverage` (nextest + benchmark diffs) green on CI
- [ ] `codecov/patch` / `codecov/project` (advisory)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_