### PR TITLE
encoding: Converter#primitive_errinfo non-error tuples are [state, nil×4]

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1857,6 +1857,22 @@ fn converter_convert(
         opts.replace = Some(s.to_string());
     }
     let out = transcode_bytes_with_opts(&bytes, src, dst, &opts, &globals.store)?;
+    // A successful `convert` leaves the converter "drained":
+    // `primitive_errinfo` reports `[:source_buffer_empty, nil×4]`
+    // (overwriting any stale tuple from a prior `primitive_convert`).
+    let errinfo = Value::array_from_iter(
+        [
+            Value::symbol_from_str("source_buffer_empty"),
+            Value::nil(),
+            Value::nil(),
+            Value::nil(),
+            Value::nil(),
+        ]
+        .into_iter(),
+    );
+    let _ = globals
+        .store
+        .set_ivar(recv, IdentId::get_id(CONVERTER_ERRINFO_IVAR), errinfo);
     Ok(Value::string_from_inner(
         crate::value::RStringInner::from_encoding_scanned(&out, dst),
     ))
@@ -2381,16 +2397,41 @@ fn converter_primitive_convert(
     dst_arg.replace_with_inner(new_dst);
 
     // Stash the errinfo tuple for `Encoding::Converter#primitive_errinfo`.
-    let errinfo = Value::array_from_iter(
-        [
-            Value::symbol_from_str(result.symbol_name()),
-            Value::string_from_str(src_enc.name()),
-            Value::string_from_str(dst_enc.name()),
-            Value::string_from_str(""),
-            Value::string_from_str(""),
-        ]
-        .into_iter(),
+    // CRuby's non-error results (`:source_buffer_empty`, `:finished`,
+    // `:destination_buffer_full`) carry only the state symbol — the
+    // four trailing fields are `nil`. Error results keep the
+    // src/dst names; the precise erroneous / read-again byte runs
+    // (and the transcoding-path leg encodings) are a separate
+    // follow-up — left as empty strings here, unchanged.
+    let is_error = matches!(
+        result,
+        StreamConvertResult::InvalidByteSequence
+            | StreamConvertResult::UndefinedConversion
+            | StreamConvertResult::IncompleteInput
     );
+    let errinfo = if is_error {
+        Value::array_from_iter(
+            [
+                Value::symbol_from_str(result.symbol_name()),
+                Value::string_from_str(src_enc.name()),
+                Value::string_from_str(dst_enc.name()),
+                Value::string_from_str(""),
+                Value::string_from_str(""),
+            ]
+            .into_iter(),
+        )
+    } else {
+        Value::array_from_iter(
+            [
+                Value::symbol_from_str(result.symbol_name()),
+                Value::nil(),
+                Value::nil(),
+                Value::nil(),
+                Value::nil(),
+            ]
+            .into_iter(),
+        )
+    };
     let _ = globals.store.set_ivar(
         recv,
         IdentId::get_id(CONVERTER_ERRINFO_IVAR),
@@ -2426,13 +2467,15 @@ fn converter_primitive_errinfo(
     {
         return Ok(v);
     }
+    // No `primitive_convert` has run yet — CRuby's "nothing
+    // pending" form is `[:source_buffer_empty, nil, nil, nil, nil]`.
     Ok(Value::array_from_iter(
         [
             Value::symbol_from_str("source_buffer_empty"),
-            Value::string_from_str(""),
-            Value::string_from_str(""),
-            Value::string_from_str(""),
-            Value::string_from_str(""),
+            Value::nil(),
+            Value::nil(),
+            Value::nil(),
+            Value::nil(),
         ]
         .into_iter(),
     ))
@@ -4544,22 +4587,17 @@ mod tests {
 
     #[test]
     fn primitive_errinfo_reflects_last_primitive_convert() {
-        // `primitive_errinfo` returns the 5-tuple
-        // `[result, src_enc_name, dst_enc_name, error_bytes, readagain_bytes]`
-        // of the most recent `primitive_convert`. The exact
-        // `error_bytes` / `readagain_bytes` diverge from CRuby
-        // (monoruby stores empty strings), so check structure rather
-        // than full equality.
+        // CRuby's `primitive_errinfo` for a non-error result
+        // (`:source_buffer_empty` / `:finished` /
+        // `:destination_buffer_full`) is `[state, nil, nil, nil,
+        // nil]` — only the state symbol; the four trailing fields
+        // are nil. (Verified byte-exact vs `LANG=C.UTF-8 ruby`.)
         run_test_no_result_check(
             r#"
               ec = Encoding::Converter.new("UTF-8", "ISO-8859-1")
               ec.primitive_convert("hello", "")
               info = ec.primitive_errinfo
-              raise unless info.is_a?(Array)
-              raise unless info.length == 5
-              raise unless info[0] == :finished
-              raise unless info[1] == "UTF-8"
-              raise unless info[2] == "ISO-8859-1"
+              raise unless info == [:finished, nil, nil, nil, nil]
             "#,
         );
     }

--- a/monoruby/src/builtins/encoding_tests.rs
+++ b/monoruby/src/builtins/encoding_tests.rs
@@ -320,6 +320,42 @@ mod tests {
     }
 
     #[test]
+    fn encoding_converter_primitive_errinfo_non_error_states() {
+        // CRuby's `primitive_errinfo` non-error tuple is
+        // `[state, nil, nil, nil, nil]` — verified byte-exact
+        // against `LANG=C.UTF-8 ruby`.
+        run_tests(&[
+            // No conversion attempted yet.
+            r#"Encoding::Converter.new('ascii','utf-8').primitive_errinfo"#,
+            // After a `:finished` primitive_convert.
+            r#"
+              ec = Encoding::Converter.new('ascii','utf-8')
+              ec.primitive_convert("a".dup,"".dup)
+              ec.primitive_errinfo
+            "#,
+            // After a successful `#convert`.
+            r#"
+              ec = Encoding::Converter.new('ascii','utf-8')
+              ec.convert("a".dup.force_encoding('ascii'))
+              ec.primitive_errinfo
+            "#,
+            // After `:destination_buffer_full`.
+            r#"
+              ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
+              ec.primitive_convert("\u{9999}", "".dup, 0, 0, partial_input: false)
+              ec.primitive_errinfo
+            "#,
+            // Last result wins: error then success → success tuple.
+            r#"
+              ec = Encoding::Converter.new("utf-8", "iso-8859-1")
+              ec.primitive_convert("\xf1abcd".dup,"".dup)
+              ec.primitive_convert("glark".dup.force_encoding('utf-8'),"".dup)
+              ec.primitive_errinfo
+            "#,
+        ]);
+    }
+
+    #[test]
     fn encoding_converter_new_replacement_and_same_encoding() {
         // `Converter.new` option/argument handling, verified
         // byte-exact against `LANG=C.UTF-8 ruby`.


### PR DESCRIPTION
## Summary

Continues the `Encoding::Converter` line: `#primitive_errinfo` non-error tuples.

`Encoding::Converter#primitive_errinfo` always returned a tuple filled with the src/dst encoding names and empty strings. CRuby's **non-error** results (`:source_buffer_empty`, `:finished`, `:destination_buffer_full`) carry only the state symbol — the four trailing fields are `nil`.

- `primitive_convert` now stashes `[state, nil, nil, nil, nil]` for non-error results (src/dst names retained for error results).
- The "no conversion yet" default is `[:source_buffer_empty, nil, nil, nil, nil]`.
- A successful `#convert` resets errinfo to the drained `[:source_buffer_empty, nil×4]` form, overwriting any stale tuple from a prior `primitive_convert`.

**Deferred (separate follow-up):** the error-state results (`:undefined_conversion` / `:invalid_byte_sequence` / `:incomplete_input`) need the precise erroneous & read-again byte runs plus CRuby's two-leg transcoding-path encodings (e.g. `:incomplete_input` EUC-JP→ISO-8859-1 reports dst `"UTF-8"`, the intermediate). That requires surfacing byte ranges from `stream_convert` and a path-element model — left unchanged here.

## Results

`core/encoding/converter/primitive_errinfo_spec.rb`: **9F/1E → 4F/1E** (5 fixed: no-conversion / `:finished` / post-`#convert` / `:destination_buffer_full` / last-result-wins). The remaining 4F/1E are the deferred error-detail cases.

**Zero regressions, zero new errors** by category vs master:

| category | before | after |
|---|---|---|
| core/encoding | 56F/15E | 51F/15E |
| core/string | 212F/116E | 212F/116E |
| core/symbol | 0F/0E | 0F/0E |

Verified byte-exact vs `LANG=C.UTF-8 ruby` (5 cases); both Prism and ruruby parsers green. Updated the pre-existing `primitive_errinfo_reflects_last_primitive_convert` unit test (it asserted the old CRuby-incorrect tuple) and added a CRuby-verified test.

## Test plan

- [ ] `coverage` (nextest + benchmark diffs) green on CI
- [ ] `codecov/patch` / `codecov/project` (advisory)

https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWApQXcmpMQBz6ZBavkYH1)_