### PR TITLE
fix(bytecodegen): optional param is in scope (as nil) within its own default

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -615,6 +615,15 @@ impl<'a> BytecodeGen<'a> {
             let local = local.into();
             let next = self.new_label();
             self.emit_check_local(local, next);
+            // The parameter is in scope (as `nil`) while its own
+            // default expression runs: CRuby `-> (a = a) { a }` is
+            // `nil`, `-> (a = a + 1) {}` raises NoMethodError. The opt
+            // slot is `None` ("not given") for `CheckLocal`; once we
+            // fall through (not given) initialize it to `nil` so a
+            // self-reference reads `nil` instead of the uninitialized
+            // sentinel (which made the proc invoker return an
+            // error-less `None` and abort).
+            self.emit_nil(local);
             self.gen_store_expr(local, initializer)?;
             self.apply_label(next);
         }
@@ -1718,5 +1727,26 @@ impl UnOpK {
             3 => UnOpK::Not,
             _ => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn optional_param_self_reference() {
+        // An optional parameter is in scope (as `nil`) while its own
+        // default expression is evaluated. `->(a = a) { a }` yields
+        // `nil`; `->(a = a + 1) {}` raises NoMethodError on nil.
+        // Previously the slot held the "not given" sentinel, so a
+        // self-reference made the proc invoker return an error-less
+        // `None` and abort the process.
+        run_test(r#"->(a = a) { a }.call"#);
+        run_test(r#"->(x, y = x) { [x, y] }.call(5)"#);
+        run_test(r#"->(a = 1, b = a) { [a, b] }.call"#);
+        run_test_error(r#"->(a = a + 1) { a }.call"#);
+        run_test(r#"def m(a = a); a; end; m"#);
+        run_test(r#"def f(x, y = x, z = y + 1); [x, y, z]; end; f(3)"#);
     }
 }

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -658,13 +658,21 @@ mod tests {
         // promote and reclaim many frames. Result must be
         // byte-identical to CRuby (reclamation never frees a
         // still-reachable frame).
-        run_test_once(
+        // ruruby-parse has no endless-method-def (`def f(x) = expr`,
+        // Ruby 3.0); under `MONORUBY_PARSER=ruruby` use the equivalent
+        // `def f(x); expr; end` form (same promoted-frame GC path).
+        let mk = if parser_is_ruruby() {
+            "def mk(n); ->{ n += 1 }; end"
+        } else {
+            "def mk(n) = ->{ n += 1 }"
+        };
+        run_test_once(&format!(
             r#"
-            def mk(n) = ->{ n += 1 }
-            fs = (1..150).map { |i| mk(i) }
-            fs.map { |f| f.call + f.call }.sum
-            "#,
-        );
+            {mk}
+            fs = (1..150).map {{ |i| mk(i) }}
+            fs.map {{ |f| f.call + f.call }}.sum
+            "#
+        ));
         run_test_once(
             r#"
             r = []
@@ -677,11 +685,16 @@ mod tests {
             r.sum
             "#,
         );
-        run_test_once(
+        let outer = if parser_is_ruruby() {
+            "def outer(n); ->{ ->{ n } }; end"
+        } else {
+            "def outer(n) = ->{ ->{ n } }"
+        };
+        run_test_once(&format!(
             r#"
-            def outer(n) = ->{ ->{ n } }
-            (1..80).map { |i| outer(i).call.call }.sum
-            "#,
-        );
+            {outer}
+            (1..80).map {{ |i| outer(i).call.call }}.sum
+            "#
+        ));
     }
 }

--- a/ruruby-parse/src/parser.rs
+++ b/ruruby-parse/src/parser.rs
@@ -654,13 +654,6 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                 };
                 if reserved_kw.is_none() && self.consume_punct(Punct::Assign)? {
                     // Optional param
-                    let default = if let Some(Punct::BitOr) = terminator {
-                        let node = self.parse_primary()?;
-                        node
-                    } else {
-                        self.parse_arg(false)?
-                    };
-                    loc = loc.merge(self.prev_loc());
                     match state {
                         Kind::Required => state = Kind::Optional,
                         Kind::Optional => {}
@@ -671,7 +664,20 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                             ));
                         }
                     };
+                    // The parameter is in scope (as `nil`) while its own
+                    // default expression is parsed, matching CRuby:
+                    // `->(a = a) { a }` is `nil`, `->(a = a + 1) {}`
+                    // raises NoMethodError. Register the name *before*
+                    // parsing the default so a self-reference resolves to
+                    // the local var instead of a method call on `self`.
                     self.new_param(&name, loc)?;
+                    let default = if let Some(Punct::BitOr) = terminator {
+                        let node = self.parse_primary()?;
+                        node
+                    } else {
+                        self.parse_arg(false)?
+                    };
+                    loc = loc.merge(self.prev_loc());
                     args.push(FormalParam::optional(name, default, loc));
                 } else if self.consume_punct_no_term(Punct::Colon)? {
                     // Keyword param


### PR DESCRIPTION
## Summary

A self-referential optional parameter default such as `->(a = a) { a }`
aborted the whole process at `executor.rs` `take_error().unwrap()`.

Root cause: the optional-arg prologue in `bytecodegen.rs` leaves the slot
holding the "not given" `None` sentinel while it evaluates the default
expression. A self-reference (`a` inside `a = a`) therefore read the
sentinel instead of `nil`, which made the proc invoker return an
error-less `None`, and the subsequent `take_error()` panicked
(non-unwinding `#[monoruby_builtin]`/extern "C" boundary → process abort,
killing every later example in a spec file).

CRuby semantics: an optional parameter **is in scope (as `nil`)** while
its own default runs — `->(a = a) { a }` → `nil`,
`->(a = a + 1) {}` → `NoMethodError` on `nil`.

Fix: after the `CheckLocal` fall-through (parameter not given) and before
evaluating the default, initialize the slot to `nil`.

## Validation

- New regression test `bytecodegen::tests::optional_param_self_reference`
  (runs each case 25× and diffs against CRuby 4.0.4):
  `->(a=a){a}`→nil, `->(x,y=x).call(5)`→[5,5], `->(a=1,b=a)`→[1,1],
  `->(a=a+1)`→error, `def m(a=a)`→nil, `def f(x,y=x,z=y+1);f(3)`→[3,3,4].
- Full `cargo test --lib -p monoruby --test-threads=1`: **1559 passed**,
  only the 2 known pre-existing locale artifacts fail (zero regression).
- Regression test also green under `--features gc-stress`.
- `language/lambda` spec no longer aborts (was a process abort).

## Test plan

- [x] `cargo test --lib -p monoruby optional_param_self_reference`
- [x] full single-threaded lib suite — zero regressions
- [x] gc-stress sanity

https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xauk3yKxZT8aYG72ZpsU6U)_