### PR TITLE
fix(spec-panics): eliminate 7 ruby/spec process aborts

### DIFF
--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -23,6 +23,16 @@ pub(super) fn init(globals: &mut Globals) {
         ENUMERATOR_CLASS,
         ObjTy::ARITHMETIC_SEQUENCE,
     );
+    // CRuby: `Enumerator::ArithmeticSequence.allocate` raises
+    // `TypeError: allocator undefined for ...` and `.new` raises
+    // `NoMethodError`. Without this the default object allocator
+    // produces an `ObjTy::OBJECT` instance whose class is
+    // ArithmeticSequence; any subsequent ArithmeticSequence builtin
+    // (e.g. `inspect`) then hits `as_arithmetic_sequence_inner`'s
+    // type assertion and aborts the process (non-unwinding builtin).
+    globals.store[ARITHMETIC_SEQUENCE_CLASS].clear_alloc_func();
+    let meta = globals.store.get_metaclass(ARITHMETIC_SEQUENCE_CLASS).id();
+    globals.undef_method_for_class(meta, IdentId::NEW).unwrap();
     globals.define_builtin_class_func(
         ARITHMETIC_SEQUENCE_CLASS,
         "__build",

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -154,6 +154,34 @@ mod tests {
     }
 
     #[test]
+    fn fiber_resume_self_or_ancestor() {
+        // Resuming the currently-running fiber, or a still-active
+        // ancestor on the resume chain, must raise `FiberError` (was
+        // SIGSEGV from native-stack switching into a live frame).
+        // CRuby:
+        //   self-resume      ⇒ "attempt to resume the current fiber"
+        //   ancestor-resume  ⇒ "attempt to resume a resumed fiber (double resume)"
+        run_test_error(
+            r#"
+            f = nil
+            f = Fiber.new { f.resume }
+            f.resume
+        "#,
+        );
+        run_test_error(
+            r#"
+            outer = nil
+            inner = nil
+            outer = Fiber.new {
+              inner = Fiber.new { outer.resume }
+              inner.resume
+            }
+            outer.resume
+        "#,
+        );
+    }
+
+    #[test]
     fn fiber() {
         run_test(
             r##"

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -157,7 +157,7 @@ fn deconstruct_keys_md(
             }
         }
         match last.and_then(|i| m.at(i + 1)) {
-            Some(s) => Value::string_from_str(s),
+            Some(s) => Value::string_from_vec(s.to_vec()),
             None => Value::nil(),
         }
     };
@@ -313,7 +313,9 @@ fn pre_match(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     let self_ = lfp.self_val();
     let m = self_.as_match_data();
     match m.pos(0) {
-        Some((start, _)) => Ok(Value::string_from_str(&m.string()[..start])),
+        Some((start, _)) => Ok(Value::string_from_vec(
+            m.string().as_bytes()[..start].to_vec(),
+        )),
         None => Ok(Value::string_from_str("")),
     }
 }
@@ -331,7 +333,9 @@ fn post_match(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     let self_ = lfp.self_val();
     let m = self_.as_match_data();
     match m.pos(0) {
-        Some((_, end)) => Ok(Value::string_from_str(&m.string()[end..])),
+        Some((_, end)) => Ok(Value::string_from_vec(
+            m.string().as_bytes()[end..].to_vec(),
+        )),
         None => Ok(Value::string_from_str("")),
     }
 }
@@ -391,7 +395,7 @@ fn last_matched_named<'a>(
     m: &'a crate::value::rvalue::MatchDataInner,
     capture_names: &[String],
     name: &str,
-) -> Option<&'a str> {
+) -> Option<&'a [u8]> {
     let mut result = None;
     for (i, n) in capture_names.iter().enumerate() {
         if n == name
@@ -436,7 +440,11 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
             let s = start as usize;
             let e = (s + slice_len as usize).min(m.len());
             for i in s..e {
-                res.push(m.at(i).map(Value::string_from_str).unwrap_or_default());
+                res.push(
+                    m.at(i)
+                        .map(|b| Value::string_from_vec(b.to_vec()))
+                        .unwrap_or_default(),
+                );
             }
             // Pad with nil for positions past the end.
             let requested = (start + slice_len) as usize;
@@ -467,7 +475,7 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                 })?;
             res.push(
                 m.at(i)
-                    .map(Value::string_from_str)
+                    .map(|b| Value::string_from_vec(b.to_vec()))
                     .unwrap_or_else(Value::nil),
             );
             continue;
@@ -486,7 +494,11 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         if idx >= m.len() {
             res.push(Value::nil());
         } else {
-            res.push(m.at(idx).map(Value::string_from_str).unwrap_or_default());
+            res.push(
+                m.at(idx)
+                    .map(|b| Value::string_from_vec(b.to_vec()))
+                    .unwrap_or_default(),
+            );
         }
     }
     Ok(Value::array_from_vec(res))
@@ -505,7 +517,7 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 fn deconstruct(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::array_from_iter(
         lfp.self_val().as_match_data().captures().skip(1).map(|s| {
-            s.map(Value::string_from_str).unwrap_or_default()
+            s.map(|b| Value::string_from_vec(b.to_vec())).unwrap_or_default()
         }),
     ))
 }
@@ -535,14 +547,18 @@ fn match_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         if idx >= m.len() {
             return Ok(Value::nil());
         }
-        Ok(m.at(idx).map(Value::string_from_str).unwrap_or_default())
+        Ok(m.at(idx)
+            .map(|b| Value::string_from_vec(b.to_vec()))
+            .unwrap_or_default())
     } else if let Some(sym) = arg.try_symbol_or_string() {
         if let Some(i) = m
             .regexp()
             .map(|r| r.get_group_members(&format!("{sym}")))
             .and_then(|g| g.last().copied())
         {
-            Ok(m.at(i as usize).map(Value::string_from_str).unwrap_or_default())
+            Ok(m.at(i as usize)
+                .map(|b| Value::string_from_vec(b.to_vec()))
+                .unwrap_or_default())
         } else {
             Err(MonorubyErr::indexerr(format!(
                 "undefined group name reference: {sym}"
@@ -599,7 +615,9 @@ fn match_length(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodeP
         return Ok(Value::nil());
     }
     match m.at(idx) {
-        Some(s) => Ok(Value::integer(s.chars().count() as i64)),
+        Some(s) => Ok(Value::integer(
+            String::from_utf8_lossy(s).chars().count() as i64,
+        )),
         None => Ok(Value::nil()),
     }
 }
@@ -615,7 +633,7 @@ fn captures(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
     Ok(Value::array_from_iter(
         lfp.self_val().as_match_data().captures().skip(1).map(|s| {
             if let Some(s) = s {
-                Value::string_from_str(s)
+                Value::string_from_vec(s.to_vec())
             } else {
                 Value::nil()
             }
@@ -633,7 +651,7 @@ fn to_a(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<V
     Ok(Value::array_from_iter(
         lfp.self_val().as_match_data().captures().map(|s| {
             if let Some(s) = s {
-                Value::string_from_str(s)
+                Value::string_from_vec(s.to_vec())
             } else {
                 Value::nil()
             }
@@ -682,7 +700,7 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             return Ok(Value::nil());
         }
         Ok(m.at(idx as usize)
-            .map(|s| Value::string_from_str(s))
+            .map(|s| Value::string_from_vec(s.to_vec()))
             .unwrap_or_default())
     } else if let Some(range) = lfp.arg(0).is_range() {
         // `[start..end]` / `[start...]` / `[..end]` slicing.
@@ -707,7 +725,7 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let mut result = Value::nil();
         for i in members {
             if let Some(s) = m.at(i as usize) {
-                result = Value::string_from_str(s);
+                result = Value::string_from_vec(s.to_vec());
             }
         }
         Ok(result)
@@ -738,7 +756,7 @@ fn slice_match_data(
     for i in s..e {
         out.push(
             m.at(i)
-                .map(|v| Value::string_from_str(v))
+                .map(|v| Value::string_from_vec(v.to_vec()))
                 .unwrap_or_default(),
         );
     }
@@ -855,7 +873,7 @@ fn named_captures(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
             Value::string_from_str(name)
         };
         let val = last_matched_named(&m, &names, name)
-            .map(Value::string_from_str)
+            .map(|b| Value::string_from_vec(b.to_vec()))
             .unwrap_or_default();
         map.insert(key, val, vm, globals)?;
     }

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -897,6 +897,26 @@ mod tests {
     }
 
     #[test]
+    fn match_data_binary_n_byte_safe() {
+        // `/n` regex matches per *byte*. On a haystack whose bytes
+        // are not valid UTF-8 char boundaries (e.g. a single high
+        // byte under ASCII-8BIT), `MatchDataInner::at` previously
+        // sliced `&str` and aborted (`panic_nounwind` across the
+        // builtin's extern "C" boundary). The byte-slice path must
+        // return the matched bytes intact.
+        run_tests(&[
+            r##"/./n.match("\xC3\xA9".dup.force_encoding(Encoding::ASCII_8BIT)).to_a"##,
+            r##"/./n.match("\xC3\xA9".dup.force_encoding(Encoding::ASCII_8BIT))[0]"##,
+            r##"/./n.match("\xC3\xA9".dup.force_encoding(Encoding::ASCII_8BIT)).pre_match"##,
+            r##"/./n.match("\xC3\xA9".dup.force_encoding(Encoding::ASCII_8BIT)).post_match"##,
+            // Sanity: ASCII haystack still works through the same path.
+            r##"/(\w)(\w)/.match("abc").to_a"##,
+            r##"/(\w)(\w)/.match("abc")[0..]"##,
+            r##"/(\w)(\w)/.match("abc").pre_match + /(\w)/.match("abc").post_match"##,
+        ]);
+    }
+
+    #[test]
     fn match_data_deconstruct_keys() {
         run_test(
             r##"

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -615,6 +615,15 @@ impl<'a> BytecodeGen<'a> {
             let local = local.into();
             let next = self.new_label();
             self.emit_check_local(local, next);
+            // The parameter is in scope (as `nil`) while its own
+            // default expression runs: CRuby `-> (a = a) { a }` is
+            // `nil`, `-> (a = a + 1) {}` raises NoMethodError. The opt
+            // slot is `None` ("not given") for `CheckLocal`; once we
+            // fall through (not given) initialize it to `nil` so a
+            // self-reference reads `nil` instead of the uninitialized
+            // sentinel (which made the proc invoker return an
+            // error-less `None` and abort).
+            self.emit_nil(local);
             self.gen_store_expr(local, initializer)?;
             self.apply_label(next);
         }
@@ -1718,5 +1727,26 @@ impl UnOpK {
             3 => UnOpK::Not,
             _ => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn optional_param_self_reference() {
+        // An optional parameter is in scope (as `nil`) while its own
+        // default expression is evaluated. `->(a = a) { a }` yields
+        // `nil`; `->(a = a + 1) {}` raises NoMethodError on nil.
+        // Previously the slot held the "not given" sentinel, so a
+        // self-reference made the proc invoker return an error-less
+        // `None` and abort the process.
+        run_test(r#"->(a = a) { a }.call"#);
+        run_test(r#"->(x, y = x) { [x, y] }.call(5)"#);
+        run_test(r#"->(a = 1, b = a) { [a, b] }.call"#);
+        run_test_error(r#"->(a = a + 1) { a }.call"#);
+        run_test(r#"def m(a = a); a; end; m"#);
+        run_test(r#"def f(x, y = x, z = y + 1); [x, y, z]; end; f(3)"#);
     }
 }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1316,3 +1316,44 @@ impl<'a> BytecodeGen<'a> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn undef_dynamic_name() {
+        // `undef :"#{expr}"` (interpolated symbol) is lowered to an
+        // implicit-self `undef_method(<expr>)` call. Previously the
+        // non-`Symbol` branch hit `unimplemented!()` in the
+        // `NodeKind::UndefMethod` codegen and aborted.
+        run_test(
+            r##"
+            c = Class.new do
+              def m; 1; end
+              undef :"#{'m'}"
+            end
+            c.new.respond_to?(:m)
+        "##,
+        );
+        run_test(
+            r##"
+            c = Class.new do
+              def foo; 'x'; end
+              undef :"#{'fo' + 'o'}"
+            end
+            c.new.respond_to?(:foo)
+        "##,
+        );
+        // Non-literal interpolation (call .to_s on a Symbol).
+        run_test(
+            r##"
+            c = Class.new do
+              def bar; end
+              undef :"#{:bar.to_s}"
+            end
+            c.new.respond_to?(:bar)
+        "##,
+        );
+    }
+}

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -764,15 +764,28 @@ impl<'a> BytecodeGen<'a> {
                 //return Ok(());
             }
             NodeKind::UndefMethod(box undef) => {
-                match undef.kind {
-                    NodeKind::Symbol(undef) => {
-                        let temp = self.temp;
-                        let undef = IdentId::get_id_from_string(undef);
-                        self.temp = temp;
-                        self.emit(BytecodeInst::UndefMethod { undef }, loc);
-                    }
-                    _ => unimplemented!(),
-                };
+                if let NodeKind::Symbol(name) = &undef.kind {
+                    let temp = self.temp;
+                    let undef = IdentId::get_id(name);
+                    self.temp = temp;
+                    self.emit(BytecodeInst::UndefMethod { undef }, loc);
+                } else {
+                    // Dynamic name, e.g. `undef :"#{expr}"`. The static
+                    // `UndefMethod` instruction bakes in an `IdentId`, so
+                    // lower this to an implicit-self `undef_method(<expr>)`
+                    // call (Module#undef_method coerces String/Symbol),
+                    // matching CRuby. `undef` evaluates to nil, so discard
+                    // the call result and push nil like the static path.
+                    let arglist = ArgList::from_args(vec![undef]);
+                    self.gen_method_call(
+                        IdentId::get_id("undef_method"),
+                        None,
+                        arglist,
+                        false,
+                        UseMode2::NotUse,
+                        loc,
+                    )?;
+                }
                 self.push_nil();
             }
             NodeKind::Defined(box node) => {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2190,15 +2190,23 @@ impl Executor {
         captures: &onigmo_regex::Captures<'h>,
         haystack: &str,
     ) {
+        // Onigmo's `Match::{as_str, post, to_string}` slice the
+        // haystack as `&str`, which panics (`panic_nounwind` ⇒
+        // extern "C" boundary abort) when a `/n` (binary) regexp
+        // returns byte offsets that land mid-UTF-8 of the source
+        // string. Slice on bytes and lossy-decode for the `String`
+        // fields, which preserves valid UTF-8 unchanged and avoids
+        // the abort for binary subjects.
+        let bytes = haystack.as_bytes();
         match captures.get(0) {
             Some(m) => {
-                let matched = m.as_str();
-                let post = m.post();
-                // `haystack = pre ++ matched ++ post`
-                let pre_len = haystack.len() - matched.len() - post.len();
-                self.sp_last_match = Some(matched.to_string());
-                self.sp_pre_match = Some(haystack[..pre_len].to_string());
-                self.sp_post_match = Some(post.to_string());
+                let (s, e) = (m.start(), m.end());
+                self.sp_last_match =
+                    Some(String::from_utf8_lossy(&bytes[s..e]).into_owned());
+                self.sp_pre_match =
+                    Some(String::from_utf8_lossy(&bytes[..s]).into_owned());
+                self.sp_post_match =
+                    Some(String::from_utf8_lossy(&bytes[e..]).into_owned());
             }
             None => {
                 self.sp_last_match = None;
@@ -2213,7 +2221,9 @@ impl Executor {
         for m in captures.iter() {
             self.sp_match_positions
                 .push(m.as_ref().map(|m| (m.start(), m.end())));
-            self.sp_matches.push(m.map(|m| m.to_string()));
+            self.sp_matches.push(
+                m.map(|m| String::from_utf8_lossy(&bytes[m.start()..m.end()]).into_owned()),
+            );
         }
     }
 

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -374,7 +374,17 @@ impl ClassInfoTable {
         // `$stderr.write` and uses the proper qualified path. We
         // intentionally do *not* re-emit here.
         let _prev = self[class_id].constants.insert(name, new_state);
-        if let Some(klass) = val.is_class_or_module() {
+        // Auto-naming: only for *non-singleton* anonymous classes/modules.
+        // CRuby never names a singleton class from constant assignment
+        // (`class << o; CONST = self; end` ⇒ `o.singleton_class.name == nil`).
+        // Without this guard `CONST = self` set inside `class << o`
+        // would store `target.parent = target` (the singleton class is
+        // both the constant's owner and value), turning the parent
+        // chain into a self-loop and hanging `get_parents`
+        // (`#to_s`/`#inspect`/error formatting → OOM).
+        if let Some(klass) = val.is_class_or_module()
+            && klass.is_singleton().is_none()
+        {
             // The new owner is "permanent" iff its parent's chain is
             // already reachable from a top-level constant. `Object`
             // counts as permanent at the root.

--- a/monoruby/src/value/rvalue/fiber.rs
+++ b/monoruby/src/value/rvalue/fiber.rs
@@ -71,6 +71,27 @@ impl FiberInner {
 impl Fiber {
     pub fn resume(&mut self, vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
         let arg0 = lfp.arg(0).as_array();
+        // The "running" state is not representable via `rsp_save`
+        // (a live fiber still reads as `Suspended`), so resuming the
+        // currently-executing fiber — or an ancestor still on the
+        // active resume chain — would do a native stack switch into a
+        // frame that is already live and corrupt the stack (SIGSEGV).
+        // CRuby raises FiberError instead.
+        let target = (&*self.handle) as *const Executor;
+        if target == (vm as *const Executor) {
+            return Err(MonorubyErr::fibererr(
+                "attempt to resume the current fiber".to_string(),
+            ));
+        }
+        let mut cur = vm.parent_fiber();
+        while let Some(p) = cur {
+            if (p.as_ptr() as *const Executor) == target {
+                return Err(MonorubyErr::fibererr(
+                    "attempt to resume a resumed fiber (double resume)".to_string(),
+                ));
+            }
+            cur = unsafe { p.as_ref().parent_fiber() };
+        }
         match self.state() {
             FiberState::Created => self.invoke_fiber(vm, globals, &[lfp.arg(0)]),
             FiberState::Suspended => self.resume_fiber(vm, arg0.peel()),

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -63,26 +63,36 @@ impl MatchDataInner {
         self.matches[pos]
     }
 
-    pub fn at(&self, pos: usize) -> Option<&str> {
-        self.matches[pos].map(|(start, end)| &self.heystack[start..end])
+    /// Matched bytes for capture `pos`. Slices the haystack on
+    /// **byte** boundaries (always safe) — required for binary
+    /// (`/n`) regexps whose onigmo byte offsets land mid-UTF-8 of
+    /// the underlying Rust `String`. Returning `&str` here would
+    /// panic in `core::str::slice_error_fail` on a non-char boundary
+    /// (which is a `panic_nounwind` ⇒ process abort across the
+    /// `#[monoruby_builtin]` extern "C" boundary).
+    pub fn at(&self, pos: usize) -> Option<&[u8]> {
+        self.matches[pos].map(|(start, end)| &self.heystack.as_bytes()[start..end])
     }
 
     pub fn len(&self) -> usize {
         self.matches.len()
     }
 
-    pub fn captures(&self) -> impl Iterator<Item = Option<&str>> {
+    pub fn captures(&self) -> impl Iterator<Item = Option<&[u8]>> {
         self.matches
             .iter()
-            .map(|m| m.map(|(start, end)| &self.heystack[start..end]))
+            .map(|m| m.map(|(start, end)| &self.heystack.as_bytes()[start..end]))
     }
 
     pub fn to_s(&self) -> String {
-        self.at(0).unwrap().to_string()
+        String::from_utf8_lossy(self.at(0).unwrap()).into_owned()
     }
 
     pub fn inspect(&self) -> String {
-        let mut s = format!("#<MatchData \"{}\"", self.at(0).unwrap());
+        let mut s = format!(
+            "#<MatchData \"{}\"",
+            String::from_utf8_lossy(self.at(0).unwrap())
+        );
         let names = self
             .regexp()
             .and_then(|r| r.capture_names().ok())
@@ -94,7 +104,7 @@ impl MatchDataInner {
                 s.push_str(&format!(" {}:", names[i - 1]));
             }
             if let Some(capture) = self.at(i) {
-                s.push_str(&format!("\"{capture}\""));
+                s.push_str(&format!("\"{}\"", String::from_utf8_lossy(capture)));
             } else {
                 s.push_str(&format!("nil"));
             }

--- a/ruruby-parse/src/parser.rs
+++ b/ruruby-parse/src/parser.rs
@@ -654,13 +654,6 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                 };
                 if reserved_kw.is_none() && self.consume_punct(Punct::Assign)? {
                     // Optional param
-                    let default = if let Some(Punct::BitOr) = terminator {
-                        let node = self.parse_primary()?;
-                        node
-                    } else {
-                        self.parse_arg(false)?
-                    };
-                    loc = loc.merge(self.prev_loc());
                     match state {
                         Kind::Required => state = Kind::Optional,
                         Kind::Optional => {}
@@ -671,7 +664,20 @@ impl<'a, OuterContext: LocalsContext> Parser<'a, OuterContext> {
                             ));
                         }
                     };
+                    // The parameter is in scope (as `nil`) while its own
+                    // default expression is parsed, matching CRuby:
+                    // `->(a = a) { a }` is `nil`, `->(a = a + 1) {}`
+                    // raises NoMethodError. Register the name *before*
+                    // parsing the default so a self-reference resolves to
+                    // the local var instead of a method call on `self`.
                     self.new_param(&name, loc)?;
+                    let default = if let Some(Punct::BitOr) = terminator {
+                        let node = self.parse_primary()?;
+                        node
+                    } else {
+                        self.parse_arg(false)?
+                    };
+                    loc = loc.merge(self.prev_loc());
                     args.push(FormalParam::optional(name, default, loc));
                 } else if self.consume_punct_no_term(Punct::Colon)? {
                     // Keyword param


### PR DESCRIPTION
## Summary

Driven from a `ruby/spec` panic-fix loop on a freshly built Ruby 4.0.4 env. Started from a 131-group baseline (`core/` + `language/`) and worked the list down to **0 panics**:

| # | Group | Signal | Root cause | Commit |
|---|---|---|---|---|
| 1 | `core/enumerator` | SIGABRT | `Enumerator::ArithmeticSequence.new`/`.allocate` produced an `ObjTy::OBJECT` whose class was ArithmeticSequence; the first `as_arithmetic_sequence_inner` (e.g. on `inspect`) failed its type assertion across an extern "C" boundary | 2b78fc8 |
| 2 | `core/fiber` | SIGSEGV | resuming a fiber that is itself / an ancestor of the current execution context corrupted the native stack | 0e0766a |
| 3 | `language/lambda` | SIGABRT | self-referential optional default `->(a=a){a}` — `take_error().unwrap()` on a `None` error slot across an extern "C" boundary (**cherry-picked from #577**) | 22fab47 + bcf3419 |
| 4 | `language/undef` | rust panic | `undef :"#{expr}"` (interpolated symbol) hit `unimplemented!()` in `bytecodegen` — `BytecodeInst::UndefMethod` bakes in an `IdentId`, so only `NodeKind::Symbol` was handled | d5fe23c |
| 5 | `language/singleton_class` | SIGKILL (OOM) | `class << o; CONST = self; end` made the constant auto-namer write `S.parent = S` (target *is* the owning singleton class), so `get_parents` looped forever inside the next `to_s`/`inspect`/error-format call | 861df6f |
| 6 | `language/metaclass` | SIGKILL (OOM) | same singleton-auto-naming self-loop | 861df6f |
| 7 | `language/regexp` | SIGABRT | `/n` (binary) regexps return byte offsets that land mid-UTF-8 in the Rust `String` haystack; `MatchDataInner::at`/`captures` and `Executor::save_capture_special_variables` were slicing as `&str` (`panic_nounwind` ⇒ abort) | 48161be |

### Per-fix shape

1. **ArithmeticSequence** (`builtins/arithmetic_sequence.rs`) — mirror the Symbol pattern: `clear_alloc_func()` so `.allocate` ⇒ `TypeError: allocator undefined`, and `undef_method_for_class(meta, IdentId::NEW)` so `.new` ⇒ `NoMethodError`. Matches CRuby 4.0.4.
2. **Fiber** (`value/rvalue/fiber.rs`) — raise `FiberError` before touching native stack state when the target fiber is self or an ancestor.
3. **Lambda self-ref** — exact #577 commits cherry-picked. If #577 lands first these become no-ops on rebase.
4. **`undef` dynamic name** (`bytecodegen/expression.rs`) — for non-`Symbol` argument, lower to an implicit-self `undef_method(<expr>)` call (`Module#undef_method` coerces String/Symbol); `undef` still evaluates to nil. Static-symbol path untouched.
5. **Singleton auto-naming** (`globals/store/class/constants.rs`) — guard the auto-namer with `klass.is_singleton().is_none()`. CRuby never names a singleton class via constant assignment (`o.singleton_class.name == nil`); the constant insert itself is unaffected.
6. **(same fix as 5).**
7. **MatchData / capture-save byte-safety** (`value/rvalue/match_data.rs`, `builtins/match_data.rs`, `executor.rs`) — change `MatchDataInner::at`/`captures` to return `Option<&[u8]>` via `heystack.as_bytes()[..]`; builtins build the result `Value` with `string_from_vec` so `from_vec_scanned` picks the right encoding (ASCII-8BIT for the non-UTF-8 bytes, matching CRuby's `/n` result). `to_s`/`inspect` switch to `String::from_utf8_lossy` for display. `save_capture_special_variables` was calling `m.as_str()`/`m.post()`/`&haystack[..pre_len]` — compute pre/match/post via `(start, end)` on bytes and lossy-decode for the `sp_*: Option<String>` fields (the richer `MatchData` byte path is what `.to_a` / `.captures` etc. actually go through).

### Verification

`ruby/spec` against the release binary (UTF-8 locale, CRuby 4.0.4 reference):

```
groups: 131 | clean: 126 | panics: 0 | timeouts: 5
```

The 5 `TIMEOUT`s (`core/argf`, `core/file`, `core/io`, `core/mutex`, `core/sizedqueue`) are the pre-existing blocking-IO / sync-primitive hangs called out in `CLAUDE.md` (single-threaded runtime). **Not panics.**

Per-target spot checks (before ⇒ after):

- `/./n.match("\xC3\xA9").to_a` ⇒ `["\xC3"]` (was SIGABRT)
- `class << o; CONST = self; end; o.singleton_class.to_s` ⇒ `#<Class:#<Object:…>>` (was hang/OOM)
- `language/singleton_class_spec.rb`: 53 ex, 9 F, **0 E** in 0.012 s (was rc=137)
- `language/metaclass_spec.rb`: 21 ex, 1 F, 1 E (was rc=137)
- `language/undef_spec.rb`: 8 ex, **0 F, 0 E** (was rust panic)
- `language/regexp` (11 files, 257 ex): rc=1 (was rc=134 abort; remaining F/E are encoding-correctness mismatches, not panics)
- `Enumerator::ArithmeticSequence.{new,allocate}` raise the CRuby-shape `NoMethodError` / `TypeError`

### Notes

- **Overlap with #577**: 22fab47 + bcf3419 are exact cherry-picks of that PR's two commits. If #577 lands first, `git rebase origin/master` will drop them cleanly.
- The `MatchData` API change (`at`/`captures` ⇒ `&[u8]`) is local to `MatchDataInner`; every external caller is updated in this PR (no consumers outside `monoruby/src/builtins/match_data.rs`).
- Remaining `F`/`E` in the formerly-panicking groups are correctness mismatches (encoding handling, dup-vs-clone singleton-class semantics, etc.) — explicitly out of scope for this PR (panic-elimination only).

## Test plan

- [x] `ruby/spec` full re-scan (131 groups): 0 panics
- [x] Each fix verified on the original aborting spec / minimal repro
- [x] `cargo build --release -p monoruby` clean
- [x] No regression in `core/` (was 1 panic, now 0)

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_