### PR TITLE
fix(env): ENV.merge! deletes the key when its value is nil

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2058,6 +2058,25 @@ fn env_merge_bang(
         let pairs: Vec<(Value, Value)> = other.iter().collect();
         for (k, v) in pairs {
             let key = coerce_env_string(k, vm, globals)?;
+            // CRuby: a `nil` value in the merged hash deletes the
+            // variable instead of coercing-then-setting. yjit-bench's
+            // `harness-common.rb` relies on this exact form:
+            // `ENV.merge!("GEM_HOME" => nil, "GEM_PATH" => nil)`.
+            // Without this branch monoruby raises
+            // `TypeError: no implicit conversion of NilClass into String`
+            // in `coerce_env_string`, breaking every benchmark.
+            if v.is_nil() {
+                let key_v = Value::string(key.clone());
+                lfp.self_val().as_hash().remove(key_v, vm, globals)?;
+                if let Ok(c_key) = std::ffi::CString::new(key.as_bytes()) {
+                    // SAFETY: NUL-terminated C string; `unsetenv` is
+                    // thread-safe on Linux.
+                    unsafe {
+                        libc::unsetenv(c_key.as_ptr());
+                    }
+                }
+                continue;
+            }
             check_env_key_for_set(&key, &globals.store)?;
             let mut value = coerce_env_string(v, vm, globals)?;
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2948,6 +2948,31 @@ mod tests {
         );
     }
 
+    /// A `nil` value in the merged hash deletes the key from ENV and
+    /// libc's `environ` (matching CRuby and `ENV[k] = nil`). yjit-bench
+    /// relies on `ENV.merge!("GEM_HOME" => nil, "GEM_PATH" => nil)`
+    /// at every benchmark's harness top — without this branch every
+    /// monoruby benchmark aborted at load with TypeError.
+    #[test]
+    fn env_merge_bang_nil_deletes() {
+        let _g = env_lock();
+        run_test_once(
+            r##"
+            ENV["MONORUBY_ENV_TEST_MN1"] = "v1"
+            ENV["MONORUBY_ENV_TEST_MN2"] = "v2"
+            before = [ENV["MONORUBY_ENV_TEST_MN1"], ENV["MONORUBY_ENV_TEST_MN2"]]
+            ENV.merge!("MONORUBY_ENV_TEST_MN1" => nil,
+                       "MONORUBY_ENV_TEST_MN2" => nil,
+                       "MONORUBY_ENV_TEST_MN3" => "new")
+            after = [ENV["MONORUBY_ENV_TEST_MN1"],
+                     ENV["MONORUBY_ENV_TEST_MN2"],
+                     ENV["MONORUBY_ENV_TEST_MN3"]]
+            ENV.delete("MONORUBY_ENV_TEST_MN3")
+            [before, after]
+            "##,
+        );
+    }
+
     /// `update` is an alias for `merge!`.
     #[test]
     fn env_update_alias() {


### PR DESCRIPTION
## Summary

The `bench vs YJIT` workflow on master post-#579 records `monoruby_failed: true / "exit 1"` for the **entire** benchmark matrix — every monoruby column on the bench dashboard is empty since commit `20efe6d`:

```
2026-05-20T01:01:55Z,6e8cfe0,fib,26.5096,29.6150,1.1171,false,false,,
2026-05-20T01:54:38Z,20efe6d,fib,       ,27.7653,       ,true,false,"exit 1",   ← #579 lands
2026-05-20T03:17:39Z,f224635,fib,       ,27.7742,       ,true,false,"exit 1",
```

The workflow exits 0 (it's expected to publish even on partial failures), but every per-benchmark result is `exit 1`. YJIT is unaffected.

### Root cause

yjit-bench's `harness/harness-common.rb` is the first file every benchmark loads, and its very first executable line is

```ruby
ENV.merge!("GEM_HOME" => nil, "GEM_PATH" => nil) # avoid installing gems to chruby-ed Ruby
```

CRuby specifies that any nil value handed to ENV — via `[]=`, `store`, **or `merge!`** — deletes the variable from both the Hash mirror and libc's `environ`. monoruby's `env_index_assign` already implements that delete branch for `ENV[k]=nil`, but `env_merge_bang` unconditionally pushes the value through `coerce_env_string`:

```rust
for (k, v) in pairs {
    let key = coerce_env_string(k, vm, globals)?;
    check_env_key_for_set(&key, &globals.store)?;
    let mut value = coerce_env_string(v, vm, globals)?;   // ← nil ⇒ TypeError
    …
}
```

`coerce_env_string(nil, …)` raises `TypeError: no implicit conversion of NilClass into String`, so the harness raises at line 7 and every benchmark exits 1 before reaching the measured code.

### Fix

Inside the per-pair loop in `env_merge_bang`, mirror the `nil ⇒ delete` branch that `env_index_assign` already has: if `v.is_nil()`, `remove` the key from the hash, call `libc::unsetenv`, and `continue`. Non-nil values keep going through the existing validate-and-set path. `env_replace` is intentionally **not** changed (per its existing comment, CRuby's `ENV.replace(hash)` is a strict all-or-nothing type check; nil there is still a TypeError).

### Verification

```
$ monoruby -e 'ENV["X"]="1"; ENV.merge!("X" => nil); p ENV["X"]'
nil

$ cd ../ruby-bench  &&  for b in fib nbody binarytrees nqueens 30k_ifelse setivar; do
    monoruby benchmarks/$b/*.rb benchmarks/$b.rb 2>&1 | tail -1
  done
Average of last 199, non-warmup iters: 46ms   # fib
Average of last 469, non-warmup iters: 20ms   # nbody
Average of last  10, non-warmup iters: 426ms  # binarytrees
Average of last 324, non-warmup iters: 29ms   # nqueens
Average of last  10, non-warmup iters: 411ms  # 30k_ifelse
Average of last 1356, non-warmup iters: 7ms   # setivar
```

All six selected benchmarks (a mix of the smallest, harness-heavy, and warmup-heavy cases) run to completion with real measurements. The next scheduled `bench vs YJIT` run after merge should repopulate the dashboard.

## Test plan

- [x] `ENV.merge!(k => nil)` deletes `k` (matches CRuby)
- [x] Six representative yjit-bench benchmarks (`fib`, `nbody`, `binarytrees`, `nqueens`, `30k_ifelse`, `setivar`) all `exit 0`
- [x] `cargo build --release -p monoruby` clean
- [ ] Next `bench vs YJIT` workflow run shows non-null `monoruby_ms` across the matrix

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_