### PR TITLE
feat(stringio,io): IO POSIX mode constants + StringIO methods (~100 E off library/stringio)

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -75,6 +75,22 @@ pub(super) fn init(globals: &mut Globals) {
     globals.set_constant_by_str(IO_CLASS, "READABLE", Value::integer(1));
     globals.set_constant_by_str(IO_CLASS, "PRIORITY", Value::integer(2));
     globals.set_constant_by_str(IO_CLASS, "WRITABLE", Value::integer(4));
+    // POSIX `open(2)` mode flags (used by File.open / IO#reopen mode
+    // forms and propagated to StringIO#reopen via ruby/spec). Values
+    // come from `libc::O_*`; they must compare with `File::WRONLY`
+    // etc. (File inherits IO so the same constants resolve).
+    globals.set_constant_by_str(IO_CLASS, "RDONLY", Value::integer(libc::O_RDONLY as i64));
+    globals.set_constant_by_str(IO_CLASS, "WRONLY", Value::integer(libc::O_WRONLY as i64));
+    globals.set_constant_by_str(IO_CLASS, "RDWR", Value::integer(libc::O_RDWR as i64));
+    globals.set_constant_by_str(IO_CLASS, "APPEND", Value::integer(libc::O_APPEND as i64));
+    globals.set_constant_by_str(IO_CLASS, "CREAT", Value::integer(libc::O_CREAT as i64));
+    globals.set_constant_by_str(IO_CLASS, "EXCL", Value::integer(libc::O_EXCL as i64));
+    globals.set_constant_by_str(IO_CLASS, "TRUNC", Value::integer(libc::O_TRUNC as i64));
+    globals.set_constant_by_str(IO_CLASS, "NOCTTY", Value::integer(libc::O_NOCTTY as i64));
+    globals.set_constant_by_str(IO_CLASS, "NONBLOCK", Value::integer(libc::O_NONBLOCK as i64));
+    globals.set_constant_by_str(IO_CLASS, "SYNC", Value::integer(libc::O_SYNC as i64));
+    // (IO::SEEK_SET / SEEK_CUR / SEEK_END are already defined elsewhere
+    //  in startup; do not re-define here.)
     let stdin = Value::new_io_stdin();
     globals.set_constant_by_str(OBJECT_CLASS, "STDIN", stdin);
     globals.set_gvar(IdentId::get_id("$stdin"), stdin);
@@ -4555,5 +4571,96 @@ mod tests {
         // is_readable / is_writable Popen arms.
         run_test_error(r#"IO.popen("cat", "w") { |p| p.gets }"#);
         run_test_error(r#"IO.popen("cat", "r") { |p| p.write("x") }"#);
+    }
+
+    #[test]
+    fn io_posix_open_constants() {
+        // POSIX open(2) flags resolve and are integers — File/IO mode
+        // forms (and StringIO#reopen) depend on these being defined.
+        run_test(
+            r##"
+            [IO::RDONLY, IO::WRONLY, IO::RDWR,
+             IO::APPEND, IO::CREAT, IO::EXCL, IO::TRUNC,
+             IO::NOCTTY, IO::NONBLOCK, IO::SYNC].map { |c| c.is_a?(Integer) }.uniq
+            "##,
+        );
+    }
+
+    #[test]
+    fn stringio_open_class_method() {
+        run_test_with_prelude(
+            r##"
+            res = []
+            ret = StringIO.open("hello") { |io| io.read }
+            res << ret
+            # Block-less form: returns a StringIO; caller must close.
+            io = StringIO.open("world", "r")
+            res << io.read
+            io.close
+            # Ensure-close even on raise.
+            begin
+              StringIO.open("x") { |io| raise "stop" }
+            rescue
+            end
+            res
+            "##,
+            r##"require "stringio""##,
+        );
+    }
+
+    #[test]
+    fn stringio_reopen() {
+        run_test_with_prelude(
+            r##"
+            res = []
+            a = StringIO.new("orig")
+            a.read(2)
+            # String form resets the backing string + position.
+            a.reopen("fresh")
+            res << [a.pos, a.read]
+            # StringIO form copies content from another StringIO.
+            b = StringIO.new("other")
+            a.reopen(b)
+            res << [a.pos, a.read]
+            res
+            "##,
+            r##"require "stringio""##,
+        );
+    }
+
+    #[test]
+    fn stringio_sysread_and_nonblock() {
+        run_test_with_prelude(
+            r##"
+            res = []
+            io = StringIO.new("abcdef")
+            res << io.sysread(3)
+            res << io.read_nonblock(2)
+            res << io.write_nonblock("X")
+            # write_nonblock returns the byte count (CRuby).
+            # negative length must raise ArgumentError on both.
+            begin; io.sysread(-1); rescue ArgumentError => e; res << :sys_neg_arg; end
+            begin; io.read_nonblock(-1); rescue ArgumentError => e; res << :rnb_neg_arg; end
+            # EOFError when reading past end of file.
+            r = StringIO.new("")
+            begin; r.sysread(1); rescue EOFError; res << :sys_eof; end
+            begin; r.read_nonblock(1); rescue EOFError; res << :rnb_eof; end
+            # exception: false at EOF -> nil instead of raising.
+            res << r.read_nonblock(1, exception: false)
+            res
+            "##,
+            r##"require "stringio""##,
+        );
+    }
+
+    #[test]
+    fn stringio_external_internal_encoding() {
+        run_test_with_prelude(
+            r##"
+            io = StringIO.new("hi")
+            [io.external_encoding == io.string.encoding, io.internal_encoding]
+            "##,
+            r##"require "stringio""##,
+        );
     }
 }

--- a/monoruby/stdlib/stringio.rb
+++ b/monoruby/stdlib/stringio.rb
@@ -7,6 +7,28 @@
 class StringIO
   include Enumerable
 
+  # ruby/spec asserts `StringIO::VERSION` is a String of digits and
+  # dots (it does not pin the value). Match CRuby's bundled gem
+  # shape; bump if/when monoruby tracks the upstream gem.
+  VERSION = "3.1.7"
+
+  # StringIO.open(string = "", mode = "r+") { |io| ... } -> obj
+  # StringIO.open(string = "", mode = "r+") -> stringio
+  #
+  # With a block, yields a freshly-built StringIO, ensures it is
+  # `close`d after the block returns (raising or not), and returns
+  # the block's value. Without a block, returns a StringIO -- in
+  # which case the caller is responsible for closing it.
+  def self.open(string = "", mode = "r+", &block)
+    io = new(string, mode)
+    return io unless block
+    begin
+      yield io
+    ensure
+      io.close unless io.closed?
+    end
+  end
+
   def initialize(string = "", mode = "r+")
     @string = string.is_a?(String) ? string : string.to_s
     @pos = 0
@@ -88,6 +110,51 @@ class StringIO
     else
       result
     end
+  end
+
+  # sysread(maxlen, outbuf = nil) -> string
+  #
+  # Like `read`, but raises `EOFError` at end-of-stream (CRuby
+  # treats sysread as "must return at least one byte or raise").
+  # StringIO has no real syscall layer; we just delegate to `read`
+  # and surface the EOF case as the exception.
+  def sysread(maxlen, outbuf = nil)
+    _check_readable
+    maxlen = maxlen.to_int if maxlen.respond_to?(:to_int) && !maxlen.is_a?(Integer)
+    raise ArgumentError, "negative length #{maxlen} given" if maxlen.is_a?(Integer) && maxlen < 0
+    raise EOFError, "end of file reached" if @pos >= @string.length && maxlen.to_i != 0
+    result = read(maxlen, outbuf)
+    raise EOFError, "end of file reached" if result.nil?
+    result
+  end
+  alias readpartial sysread
+
+  # read_nonblock(maxlen, outbuf = nil, exception: true) -> string | :wait_readable | nil
+  #
+  # StringIO has no non-blocking layer; the CRuby contract is that
+  # this acts like `sysread` (EOFError on end-of-stream). When
+  # `exception: false` is requested and we're at EOF, CRuby returns
+  # nil instead of raising — preserve that for codepaths that rely
+  # on the keyword form.
+  def read_nonblock(maxlen, outbuf = nil, exception: true)
+    _check_readable
+    maxlen = maxlen.to_int if maxlen.respond_to?(:to_int) && !maxlen.is_a?(Integer)
+    raise ArgumentError, "negative length #{maxlen} given" if maxlen.is_a?(Integer) && maxlen < 0
+    if @pos >= @string.length && maxlen.to_i != 0
+      return nil unless exception
+      raise EOFError, "end of file reached"
+    end
+    read(maxlen, outbuf)
+  end
+
+  # write_nonblock(string, exception: true) -> Integer
+  #
+  # StringIO writes never block; `write_nonblock` is just an alias
+  # for `write` with the same return shape (number of bytes
+  # written). The `exception:` keyword is accepted for API parity
+  # with `IO#write_nonblock` (it has no effect here).
+  def write_nonblock(string, exception: true)
+    write(string)
   end
 
   def getc
@@ -339,6 +406,57 @@ class StringIO
 
   def set_encoding(ext_enc, int_enc = nil, **opts)
     # No-op for now (single encoding)
+    self
+  end
+
+  # external_encoding -> Encoding
+  #
+  # CRuby's StringIO mirrors the encoding of the underlying String
+  # (the only encoding state a StringIO carries). monoruby's String
+  # already tracks an encoding, so just forward to it.
+  def external_encoding
+    @string.encoding
+  end
+
+  # internal_encoding -> nil
+  #
+  # CRuby StringIO has no separate internal encoding; the value is
+  # always nil unless `set_encoding(ext, int)` configured one. The
+  # current no-op `set_encoding` discards the int arg, so return nil.
+  def internal_encoding
+    nil
+  end
+
+  # reopen(other_stringio)             -> stringio
+  # reopen(string = "", mode = "r+")   -> stringio
+  #
+  # Re-attaches the StringIO to either another StringIO's content
+  # (single StringIO arg) or to a new backing string with an
+  # optional mode (CRuby semantics). The position counters are
+  # reset; the mode flags are re-parsed.
+  def reopen(*args)
+    if args.size == 1 && args[0].is_a?(StringIO)
+      other = args[0]
+      @string = other.string
+      @pos = 0
+      @lineno = 0
+      @closed_read = false
+      @closed_write = false
+      # Mirror the source's writability; CRuby's reopen(other)
+      # copies the mode state.
+      _parse_mode(other.closed_write? ? "r" : "r+")
+      return self
+    end
+    string = args[0] || ""
+    mode = args[1] || "r+"
+    raise TypeError, "no implicit conversion of #{string.class} into String" \
+      unless string.is_a?(String)
+    @string = string
+    @pos = 0
+    @lineno = 0
+    @closed_read = false
+    @closed_write = false
+    _parse_mode(mode)
     self
   end
 


### PR DESCRIPTION
## Summary

Two related-but-additive changes in existing classes (no new class, no concurrency, no Refinements/ObjectSpace) that knock ~100 errors off `library/stringio`.

### IO POSIX `open(2)` mode constants
`File::RDONLY` / `WRONLY` / `RDWR` / `APPEND` / `CREAT` / `EXCL` / `TRUNC` / `NOCTTY` / `NONBLOCK` / `SYNC`. (File inherits IO so the same constants resolve.) Values come from `libc::O_*`. ruby/spec uses them throughout `library/stringio/{open,reopen}_spec.rb`, `core/io`, `core/file`, etc. Their absence raised `NameError` at the `before :each` block, so every dependent example recorded as an `E` without reaching its actual assertion.

### StringIO methods (`monoruby/stdlib/stringio.rb`, pure Ruby)

| method | shape | note |
|---|---|---|
| `StringIO::VERSION` | `"3.1.7"` | ruby/spec asserts shape (digits + dots), not value |
| `StringIO.open(string="", mode="r+") { \|io\| ... }` | yields fresh IO, ensure-closes on return *and* on raise; block-less form returns the IO unmanaged |
| `StringIO#reopen` | `(other_stringio)` copies content + mirrors writability; `(string, mode)` resets backing string + parses mode; both reset `pos`/`lineno`/close flags |
| `StringIO#external_encoding` | delegate to `@string.encoding` (StringIO has no separate encoding state) |
| `StringIO#internal_encoding` | `nil` (CRuby contract until `set_encoding(ext, int)` configures one; our `set_encoding` is a no-op) |
| `StringIO#sysread` / `#readpartial` | `read`-like; raises `EOFError` at end-of-stream, `ArgumentError` on negative length |
| `StringIO#read_nonblock` | sysread semantics; `exception: false` ⇒ nil at EOF instead of raising |
| `StringIO#write_nonblock` | alias for `write` (no blocking layer) |

## Impact on `library/stringio` ruby/spec

| | examples | F | E |
|---|---:|---:|---:|
| before | 638 | 103 | 217 |
| after  | 663 | 144 | **115** |

E drops 217 → **115 (−102)** and passing examples climb 318 → 404 (**+86**). F goes up slightly (103 → 144) because more specs now reach their assertions and surface pre-existing semantic gaps (binary-encoding return shape, etc.) — those are explicitly out of scope for this PR and left for follow-ups.

Per-spec deltas (E only, was → now):

```
open                : 16 → 0
reopen              : 22 → 3
sysread             : 21 → 7
read_nonblock       : 17 → 2
write_nonblock      :  9 → 1
external_encoding   : 13 → 0
internal_encoding   :  - → 0
```

## Test plan

- [x] `cargo test --lib -p monoruby -- stringio_open_class_method stringio_reopen stringio_sysread_and_nonblock stringio_external_internal_encoding io_posix_open_constants` ⇒ 5/5 pass
- [x] Same under `MONORUBY_PARSER=ruruby` ⇒ 5/5 pass
- [x] Full `cargo test --lib -p monoruby` ⇒ no regressions
- [x] `mspec library/stringio` E count: 217 → 115; no new panics

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_