### PR TITLE
fix(stdlib): StringScanner String args + Zlib constants

### DIFF
--- a/monoruby/stdlib/strscan.rb
+++ b/monoruby/stdlib/strscan.rb
@@ -206,6 +206,10 @@ class StringScanner
   private
 
   def _match_at_pos(pattern, advance, return_string)
+    # CRuby's StringScanner (C extension) treats String pattern arguments as
+    # literal byte sequences (memcmp-style), not as Regexps. Convert via
+    # Regexp.escape so metacharacters in the String are matched literally.
+    pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
     @prev_pos = @pos
     rest_str = @str.byteslice(@pos..-1)
     return nil if rest_str.nil?
@@ -224,6 +228,10 @@ class StringScanner
   end
 
   def _match_forward(pattern, advance, return_string)
+    # CRuby's StringScanner (C extension) treats String pattern arguments as
+    # literal byte sequences (memcmp-style), not as Regexps. Convert via
+    # Regexp.escape so metacharacters in the String are matched literally.
+    pattern = Regexp.new(Regexp.escape(pattern)) if pattern.is_a?(String)
     @prev_pos = @pos
     rest_str = @str.byteslice(@pos..-1)
     return nil if rest_str.nil?

--- a/monoruby/stdlib/zlib.rb
+++ b/monoruby/stdlib/zlib.rb
@@ -9,6 +9,54 @@ module Zlib
   VERSION = "3.1.0"
   ZLIB_VERSION = "1.3"
 
+  # Compression levels (zlib.h Z_NO_COMPRESSION ... Z_BEST_COMPRESSION).
+  NO_COMPRESSION      = 0
+  BEST_SPEED          = 1
+  DEFAULT_COMPRESSION = -1
+  BEST_COMPRESSION    = 9
+
+  # Compression strategies (zlib.h Z_FILTERED ... Z_DEFAULT_STRATEGY).
+  FILTERED         = 1
+  HUFFMAN_ONLY     = 2
+  RLE              = 3
+  FIXED            = 4
+  DEFAULT_STRATEGY = 0
+
+  # Flush values (zlib.h Z_NO_FLUSH ... Z_FINISH).
+  NO_FLUSH    = 0
+  SYNC_FLUSH  = 2
+  FULL_FLUSH  = 3
+  FINISH      = 4
+
+  # Window bits and memory level (zlib.h MAX_WBITS, DEF_MEM_LEVEL, MAX_MEM_LEVEL).
+  MAX_WBITS     = 15
+  DEF_MEM_LEVEL = 8
+  MAX_MEM_LEVEL = 9
+
+  # Data type hints (zlib.h Z_BINARY ... Z_UNKNOWN).
+  BINARY  = 0
+  TEXT    = 1
+  ASCII   = 1
+  UNKNOWN = 2
+
+  # gzip OS codes (RFC 1952 §2.3.1).
+  OS_MSDOS   = 0
+  OS_AMIGA   = 1
+  OS_VMS     = 2
+  OS_UNIX    = 3
+  OS_VMCMS   = 4
+  OS_ATARI   = 5
+  OS_OS2     = 6
+  OS_MACOS   = 7
+  OS_ZSYSTEM = 8
+  OS_CPM     = 9
+  OS_TOPS20  = 10
+  OS_WIN32   = 11
+  OS_QDOS    = 12
+  OS_RISCOS  = 13
+  OS_UNKNOWN = 255
+  OS_CODE    = OS_UNIX
+
   class Error < StandardError; end
   class StreamError < Error; end
   class DataError < Error; end
@@ -16,6 +64,8 @@ module Zlib
   class VersionError < Error; end
   class MemError < Error; end
   class NeedDict < Error; end
+  class StreamEnd < Error; end
+  class InProgressError < Error; end
 
   # Standard CRC-32 (polynomial 0xEDB88320), computed lazily.
   CRC_TABLE = begin


### PR DESCRIPTION
## Summary

Two independent pure-Ruby stdlib stub fixes surfaced while investigating
yjit-bench failures on monoruby. Both close gaps where the pure-Ruby
re-implementations diverge from CRuby's C extension contract.

### 1. `StringScanner` accepts `String` pattern args (`monoruby/stdlib/strscan.rb`)

CRuby's `StringScanner` (`ext/strscan/strscan.c`) treats a `String`
pattern argument as a literal byte sequence (`memcmp`-style match),
not as a `Regexp`. The pure-Ruby stub was calling `pattern.source`
unconditionally and crashing with `NoMethodError: undefined method
'source' for "{":String` on any `scan("...")` / `skip("...")` /
`match?("...")` / `check("...")` and the `_until` variants.

Fix: at the entry of `_match_at_pos` and `_match_forward`, convert
`String` arguments via `Regexp.new(Regexp.escape(pattern))` so
metacharacters in the literal string are matched literally, matching
CRuby's semantics.

Reproduced and verified to fix `yjit-bench/benchmarks/ruby-json/benchmark.rb`,
which calls `scanner.skip("{")` on JSON input.

### 2. `Zlib` constants and exception classes (`monoruby/stdlib/zlib.rb`)

CRuby's `Zlib` (`ext/zlib/zlib.c`) defines ~36 integer constants from
`zlib.h` via `rb_define_const` (compression levels, strategies, flush
modes, window/memory parameters, gzip OS codes, data-type hints) plus
the `StreamEnd` / `InProgressError` exception classes. The pure-Ruby
stub only exposed `VERSION`, `ZLIB_VERSION` and `CRC_TABLE`, so any gem
referencing e.g. `Zlib::NO_COMPRESSION` raised `NameError`.

Reproduced on `chunky-png` (`to_blob(:no_compression)` →
`png_encoding.rb:113: uninitialized constant Zlib::NO_COMPRESSION`).
With this PR the same call returns a valid PNG blob.

All constant values were dumped from CRuby 3.3.6 (matches the upstream
zlib.h numbering) and are documented inline with their `zlib.h` /
RFC 1952 origin.

## Test plan

- [x] `cargo build --release` clean on `nightly-2025-10-15`
- [x] Minimal `StringScanner` repros (`scan("{")`, `skip("{")`,
      metacharacter check `scan(".")` on `"a.b.c"`) match CRuby
- [x] `Regexp` pattern path still works (no regression in non-String case)
- [x] All 36 `Zlib` constants compared programmatically against
      CRuby 3.3.6 — all match
- [x] `Zlib::StreamEnd` / `Zlib::InProgressError` subclass `Zlib::Error`
      (matches CRuby ancestry)
- [x] `yjit-bench/benchmarks/ruby-json/benchmark.rb` runs to completion
- [x] `chunky-png` `image.to_blob(:no_compression)` returns a blob
- [x] `cargo test --release -p monoruby --test require` — 14/14 pass

No StringScanner- or Zlib-specific integration tests exist under
`monoruby/tests/`; none were added since both fixes target pure-Ruby
stub files that are exercised end-to-end via the benchmarks above.

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_