### PR TITLE
feat(fiber): storage / scheduler / blocking? (−34 E in core/fiber)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -454,6 +454,93 @@ class Fiber
     # the current fiber across resume/yield).
     @@main_fiber ||= Fiber.new {}
   end
+
+  # --- Fiber-local storage (CRuby 3.2+) --------------------------------
+  #
+  # `Fiber.current.storage` is a Hash whose keys must be Symbols. The
+  # `Fiber.[key]` / `Fiber.[]=key, val` class-method sugar reads/writes
+  # the *current* fiber's storage. Pure-Ruby implementation here —
+  # monoruby tracks an `@storage` ivar per Fiber, lazily materialised.
+
+  # Returns the storage Hash. CRuby returns `nil` until `[]=` /
+  # `storage=` materialises one (no lazy init on bare read), so do
+  # not auto-create here.
+  def storage
+    @storage
+  end
+
+  # Assigns the storage Hash. `nil` clears it. Non-Hash raises
+  # TypeError; non-Symbol keys raise TypeError.
+  def storage=(hash)
+    if hash.nil?
+      @storage = nil
+      return nil
+    end
+    raise TypeError, "no implicit conversion of #{hash.class} into Hash" \
+      unless hash.is_a?(Hash)
+    hash.each_key do |k|
+      raise TypeError, "wrong argument type #{k.class} (expected Symbol)" \
+        unless k.is_a?(Symbol)
+    end
+    @storage = hash
+  end
+
+  # Class-method sugar over `Fiber.current` storage. Symbol-keyed.
+  # `Fiber[:k]` on a fiber with no storage returns nil (CRuby).
+  def self.[](key)
+    raise TypeError, "wrong argument type #{key.class} (expected Symbol)" \
+      unless key.is_a?(Symbol)
+    s = current.storage
+    s ? s[key] : nil
+  end
+
+  # `Fiber[:k] = v` materialises an empty storage on first write.
+  def self.[]=(key, value)
+    raise TypeError, "wrong argument type #{key.class} (expected Symbol)" \
+      unless key.is_a?(Symbol)
+    cur = current
+    cur.storage = {} if cur.storage.nil?
+    cur.storage[key] = value
+  end
+
+  # --- Scheduler -------------------------------------------------------
+  #
+  # monoruby has no fiber scheduler, so `set_scheduler` is effectively
+  # a no-op store. CRuby allows `nil` to clear the scheduler, so accept
+  # that too. `scheduler` returns whatever was set (default nil).
+
+  @@scheduler = nil
+
+  def self.scheduler
+    @@scheduler
+  end
+
+  def self.set_scheduler(scheduler)
+    @@scheduler = scheduler
+  end
+
+  def self.current_scheduler
+    # CRuby: nil when the current fiber is blocking. monoruby fibers
+    # are always blocking, so this is always nil.
+    nil
+  end
+
+  # --- Blocking / non-blocking ----------------------------------------
+  #
+  # CRuby contracts (3.2+):
+  #   `Fiber.blocking?`         returns `1` when the *current* fiber
+  #                             is blocking, `false` otherwise.
+  #   `Fiber#blocking?`         instance form: `true` / `false`.
+  # monoruby has no non-blocking fibers, so the class form is `1`
+  # and the instance form is `true`.
+
+  def self.blocking?
+    1
+  end
+
+  def blocking?
+    true
+  end
 end
 
 class Signal

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -248,4 +248,59 @@ mod tests {
     fn thread_pass() {
         run_test("Thread.pass.nil?");
     }
+
+    /// Fiber-local storage class-method sugar (`Fiber[:k]` /
+    /// `Fiber[:k] = v`) and the Symbol-keyed contract.
+    #[test]
+    fn fiber_storage_class_sugar() {
+        run_test(
+            r##"
+            Fiber[:a] = 1
+            Fiber[:b] = "x"
+            [Fiber.current.storage, Fiber[:a], Fiber[:missing]]
+            "##,
+        );
+        run_test_error(r##"Fiber["str_key"] = 1"##);
+        run_test_error(r##"Fiber["str_key"]"##);
+    }
+
+    /// `Fiber#storage=` replaces / clears; non-Hash raises.
+    #[test]
+    fn fiber_storage_assign() {
+        run_test(
+            r##"
+            f = Fiber.current
+            f.storage = {c: 3}
+            r = f.storage
+            f.storage = nil
+            [r, f.storage]
+            "##,
+        );
+        run_test_error(r##"Fiber.current.storage = 1"##);
+    }
+
+    /// `Fiber.set_scheduler(nil)` / `Fiber.scheduler` round-trip;
+    /// `Fiber.current_scheduler` stays nil because monoruby fibers
+    /// are always blocking; `Fiber.blocking?` / `Fiber#blocking?`
+    /// return `1`.
+    ///
+    /// Only `nil` is round-tripped here because CRuby's
+    /// `set_scheduler` validates the scheduler interface
+    /// (`#block`, `#kernel_sleep`, …), which monoruby's stub does
+    /// not enforce. Interface validation is intentional follow-up.
+    #[test]
+    fn fiber_scheduler_blocking() {
+        run_test_once(
+            r##"
+            res = []
+            res << Fiber.scheduler
+            res << Fiber.set_scheduler(nil)
+            res << Fiber.scheduler
+            res << Fiber.current_scheduler
+            res << Fiber.blocking?
+            res << Fiber.current.blocking?
+            res
+            "##,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Pure-Ruby additions to `startup.rb`'s `Fiber` block plus a focused unit-test addition in `builtins/fiber.rs`. No native fiber-internals changes; no threading; no Refinements/ObjectSpace.

### `Fiber#storage` / `Fiber#storage=`
Per-fiber Hash. `storage` returns `@storage` *as is* — CRuby contract is that it stays `nil` until materialised, so no lazy auto-create on bare read. `storage=` validates Hash-ness and Symbol-only keys before assigning; `nil` clears.

### `Fiber.[]` / `Fiber.[]=`
Class-method sugar over `Fiber.current`'s storage. Symbol-keyed (`TypeError` otherwise). `Fiber[:k]` returns `nil` when no storage exists yet; `Fiber[:k] = v` materialises an empty Hash on first write.

### `Fiber.set_scheduler` / `Fiber.scheduler` / `Fiber.current_scheduler`
monoruby has no fiber scheduler, so `set_scheduler` is a stash and `current_scheduler` is always `nil` (all fibers are blocking). CRuby validates the scheduler interface (`#block`, `#kernel_sleep`, …) inside `set_scheduler`; this PR accepts `nil` and any object verbatim — interface validation is intentionally left for a follow-up.

### `Fiber.blocking?` / `Fiber#blocking?`
CRuby's contract is **asymmetric**:
- `Fiber.blocking?`  →  `1` (current is blocking) or `false`
- `Fiber#blocking?`  →  `true` or `false`

monoruby fibers are always blocking, so the class form returns `1` and the instance form returns `true`. The two arms are distinct on purpose to match `ruby -e` byte-for-byte.

## Impact on `core/fiber` ruby/spec

| | examples | F | E |
|---|---:|---:|---:|
| before | 173 | 24 | 125 |
| after  | 173 | 32 | **91** |

E drops 125 → **91 (−34)**, passing examples climb by **+26**. F goes up because previously-hidden semantic gaps (`Fiber#raise`, transfer / scheduling edge cases) now surface as real failures — those are explicitly left for follow-up PRs.

## Test plan

- [x] `cargo test --lib -p monoruby -- fiber_storage_class_sugar fiber_storage_assign fiber_scheduler_blocking` ⇒ 3/3 pass
- [x] Same under `MONORUBY_PARSER=ruruby` ⇒ 3/3 pass
- [x] Full `cargo test --lib -p monoruby` ⇒ no regressions
- [x] `mspec core/fiber` E: 125 → 91; F: 24 → 32; no new panics

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_