### PR TITLE
runtime: generalize signal handling, add Interrupt class

### DIFF
--- a/doc/signal_handling.md
+++ b/doc/signal_handling.md
@@ -1,0 +1,200 @@
+# Signal handling and hang prevention
+
+Plan for extending monoruby's runtime so that:
+
+1. Signals beyond SIGINT are caught and surfaced as Ruby exceptions.
+2. Common single-threaded-runtime hangs (mutex / sizedqueue, argf, file)
+   no longer terminate the test process.
+
+Tracked in this document; updated as items land.
+
+---
+
+## Current architecture (baseline)
+
+- A single AOT-generated asm stub is registered for `SIGINT` only in
+  [monoruby/src/codegen.rs:892](../monoruby/src/codegen.rs#L892).
+  The stub does:
+
+  ```asm
+  addl [rip + alloc_flag], 10   ; nudge GC poll
+  movl [rip + sigint_flag], 1   ; mark SIGINT pending
+  ret
+  ```
+
+- Polling happens only inside `execute_gc`
+  ([monoruby/src/executor.rs:2557](../monoruby/src/executor.rs#L2557)).
+  If the flag is set, the executor's error slot is filled with
+  `MonorubyErr::runtimeerr("Interrupt")` — a plain RuntimeError, **not**
+  a real `Interrupt`. `Interrupt` as a class does not exist yet
+  (`SignalException` does, in
+  [monoruby/src/builtins/exception.rs:42](../monoruby/src/builtins/exception.rs#L42)).
+- There is no `Signal.trap` / `Kernel#trap`. Only `Signal.list` and
+  `Signal.signame` exist.
+
+## A. Signal handling generalization
+
+### A1. Pending-signal bitmap
+
+Replace the single-purpose `sigint_flag: i32` with a 32-bit
+`pending_signals: i32` bitmap. Bit `n` corresponds to signal `n + 1`.
+Reads/writes use `OR` / `XCHG`, both async-signal-safe.
+
+### A2. Per-signal asm stubs
+
+Generalize `signal_handler` in
+[monoruby/src/codegen.rs:248](../monoruby/src/codegen.rs#L248) to a
+factory: for each supported signal, emit a tiny stub that sets its own
+bit and nudges `alloc_flag`. `Codegen::new` iterates the supported list
+and `sigaction`s each.
+
+### A3. Registered set
+
+The runtime *infrastructure* (bitmap, mapping table, async-safe stub
+emitter) supports any of the catchable POSIX signals. What is
+unconditionally installed at startup is a smaller set, because the
+CRuby default for most signals is "terminate the process", not "raise":
+
+| Signal                                                    | Default install | Mapped class                       |
+|-----------------------------------------------------------|-----------------|------------------------------------|
+| SIGINT                                                    | **yes**         | `Interrupt`                         |
+| SIGTERM, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT, SIGPIPE       | only via A7     | `SignalException` ("SIG…")          |
+| **Not catchable**: SIGKILL, SIGSTOP                       | —               | —                                   |
+| **Left to kernel**: SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT | —            | (core-dump on genuine bugs)         |
+
+Unconditionally catching SIGTERM/HUP/etc would break process-status
+tests that rely on `Process.kill("TERM", child); $?.signaled? == true`
+(CRuby's default is "kernel terminates the child", and `wait` reports
+the signal — not an exception). Once A7 (`Signal.trap`) is implemented,
+the runtime can `sigaction` the additional signals on first trap and
+deinstall on `:DEFAULT`. The mapping table is already pre-wired so A7
+only needs to flip the install bit.
+
+### A4. `Interrupt` class
+
+Add `Interrupt < SignalException` so the existing SIGINT path raises the
+right class. Currently it raises `RuntimeError` with the message
+`"Interrupt"`, which silently passes most user code but breaks
+`rescue Interrupt` and ruby/spec checks.
+
+### A5. Polling frequency
+
+Today only `execute_gc` polls. A tight CPU loop with no allocations
+never sees the flag. Candidates for additional poll sites:
+
+- Backward branch (loop iteration) in the VM dispatch table.
+- Method entry, sampled (e.g. once every 64 calls).
+
+Defer until measurements show the GC-only poll is insufficient.
+
+### A6. Signal → exception mapping table
+
+A small Rust const table drives the conversion at poll time:
+
+```rust
+static SIGNAL_TABLE: &[(c_int, &str, fn() -> MonorubyErr)] = &[
+    (SIGINT,  "INT",  || MonorubyErr::interrupt("Interrupt")),
+    (SIGTERM, "TERM", || MonorubyErr::signalexception("SIGTERM")),
+    // …
+];
+```
+
+The poller walks the bitmap, clears the bit, looks up the mapping, sets
+the error on the executor. Priority is bit order — lowest signo first.
+
+### A7. `Signal.trap` (deferred)
+
+Out of scope for the first cut. Sketch:
+
+- `Globals` carries `Vec<Option<Value>>` of length 32, indexed by signo.
+- Poll-time conversion checks the slot first; if a Proc is present,
+  invoke it; otherwise fall back to A6's default mapping.
+- `Signal.trap("INT") { ... }` writes the slot. `Signal.trap("INT", "DEFAULT")`
+  clears it. `Signal.trap("INT", "IGNORE")` installs a sentinel that swallows.
+
+---
+
+## B. Hang prevention
+
+### B1. `core/mutex`, `core/sizedqueue` (single-thread-incompatible)
+
+Root cause: `Thread.new` returns a Thread that never gets scheduled
+because monoruby is single-threaded, so `join` / `value` / mutex+CV
+patterns block forever.
+
+Two approaches, pick one:
+
+- **Run-block-synchronously**: `Thread.new { … }` runs the block on the
+  caller's stack to completion before returning the Thread. `join` /
+  `value` then return immediately. Closely matches what most tests
+  expect under cooperative concurrency. Risk: tests that depend on
+  *concurrent* visibility of mutated state will still fail, but at
+  least they won't hang.
+- **Eager ThreadError**: any blocking thread op (`Thread#join`,
+  `ConditionVariable#wait`, `Queue#pop` empty, …) raises
+  `ThreadError("can't block — monoruby is single-threaded")` immediately.
+  Safer, more honest; converts hangs to failures.
+
+Recommendation: start with eager ThreadError (cheaper, no semantic
+surprises). Revisit run-synchronously if too many tests would benefit.
+
+### B2. `core/argf`
+
+ARGF reads stdin when ARGV is empty. mspec may not redirect stdin;
+the parent shell may leave it open to the tty. Investigation needed:
+
+- Identify the spec file that hangs (the survey output stops at a
+  specific dotted position).
+- Determine whether the underlying issue is monoruby-specific
+  (`Kernel#gets` not returning nil at EOF when stdin is the terminal)
+  or a missing `<` redirect in the mspec invocation.
+
+No code change planned without that diagnosis.
+
+### B3. `core/file`
+
+Caused by a subprocess (`ruby_exe` in mspec) hitting the
+`Thread.pass called too many times` guard in
+[monoruby/builtins/startup.rb:452](../monoruby/builtins/startup.rb#L452).
+The subprocess aborts; the parent waits on its pipe forever.
+
+Pick one (or both):
+
+1. Lower or remove the guard. `Thread.pass` becomes a `sched_yield(2)`
+   wrapper — legitimate even single-threaded.
+2. Audit the call site that loops on `Thread.pass`. If it's busy-waiting
+   for something monoruby can't deliver under single-thread, raise
+   `ThreadError` eagerly instead of looping.
+
+### B+. Watchdog (safety net)
+
+Optional environment toggle `MONORUBY_HANG_WATCHDOG_SEC=N`. After N
+seconds of no bytecode progress, abort the process with a clear message.
+Default off. Catches unknown hangs in CI and converts them to errors
+instead of opaque timeouts.
+
+Implementation sketch: a SIGALRM-driven counter that decrements at every
+poll point; if it reaches zero, abort.
+
+---
+
+## Recommended order
+
+| # | Item                                                          | Size      | Outcome                                                                       |
+|---|---------------------------------------------------------------|-----------|-------------------------------------------------------------------------------|
+| 1 | A1–A4 + A6 (signal generalization + Interrupt class)          | ~150 LoC  | `core/signal` and `core/exception` stop killing the process                   |
+| 2 | B3 (`Thread.pass` guard revisit)                              | small     | `core/file` hang clears                                                       |
+| 3 | B1 (eager `ThreadError` on blocking thread ops)               | medium    | `core/mutex`, `core/sizedqueue` complete (with failures, not hangs)           |
+| 4 | B+ (watchdog)                                                 | small     | Safety net for the long tail                                                  |
+| 5 | A5 (extra poll points), B2 (argf), A7 (`Signal.trap`)         | as needed | Responsiveness, remaining argf hang, full user API                            |
+
+---
+
+## Status
+
+- [x] #1 Signal generalization infrastructure + `Interrupt` class
+  (default install limited to SIGINT — see A3 above)
+- [ ] #2 `Thread.pass` guard
+- [ ] #3 Eager `ThreadError`
+- [ ] #4 Watchdog
+- [ ] #5 Stretch items

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -905,4 +905,27 @@ mod tests {
     fn backtrace_locations_nil_when_unset() {
         run_test(r#"Exception.new.backtrace_locations"#);
     }
+
+    /// `Interrupt < SignalException` (A4 in doc/signal_handling.md): the
+    /// SIGINT path raises a real `Interrupt`, caught by
+    /// `rescue SignalException` and `rescue Exception`, with the
+    /// conventional default message. Only assertions that agree with
+    /// CRuby are checked here (SignalException's own superclass differs).
+    #[test]
+    fn interrupt_class_hierarchy() {
+        run_test(
+            r##"
+            [
+              Interrupt.superclass.name,
+              Interrupt < SignalException,
+              Interrupt < Exception,
+              Interrupt.new("boom").message,
+              Interrupt.new.message,
+              (begin; raise Interrupt, "interrupted"; rescue SignalException => e; "#{e.class}: #{e.message}"; end),
+              (begin; raise Interrupt; rescue SignalException => e; e.class.name; end),
+              (begin; raise Interrupt; rescue Exception => e; e.class.name; end),
+            ]
+            "##,
+        );
+    }
 }

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -39,7 +39,15 @@ pub(super) fn init(globals: &mut Globals) {
 
     globals.define_class("NoMemoryError", standarderr, OBJECT_CLASS);
     globals.define_class("SecurityError", standarderr, OBJECT_CLASS);
-    globals.define_class("SignalException", standarderr, OBJECT_CLASS);
+    let signal_exception = globals.define_builtin_exception_class(
+        "SignalException",
+        SIGNAL_EXCEPTION_CLASS,
+        standarderr,
+    );
+    // `Interrupt` is the Ruby class raised on SIGINT (Ctrl-C). It is a
+    // subclass of SignalException — `rescue SignalException` catches it
+    // but a bare `rescue` (StandardError) does not.
+    globals.define_builtin_exception_class("Interrupt", INTERRUPT_CLASS, signal_exception);
 
     let scripterr = globals.define_class("ScriptError", standarderr, OBJECT_CLASS);
     let loaderr = globals.define_builtin_exception_class("LoadError", LOAD_ERROR_CLASS, scripterr);

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -8,6 +8,7 @@ mod compiler;
 mod invoker;
 mod jit_module;
 pub mod jitgen;
+pub(crate) mod signal_table;
 mod patch;
 pub mod runtime;
 mod vmgen;
@@ -172,7 +173,11 @@ pub struct JitModule {
     class_version: DestLabel,
     const_version: DestLabel,
     alloc_flag: DestLabel,
-    sigint_flag: DestLabel,
+    /// 32-bit bitmap of pending Unix signals — bit `n` corresponds to
+    /// signal `n + 1` (so SIGINT = 2 ⇒ bit 1). Written async-safely from
+    /// the per-signal asm stubs in `signal_handler_for`; drained at
+    /// poll-time by `take_pending_signals`. See doc/signal_handling.md.
+    pending_signals: DestLabel,
     ///
     /// Raise error.
     ///
@@ -245,15 +250,26 @@ impl std::ops::DerefMut for JitModule {
 }
 
 impl JitModule {
-    pub(crate) fn signal_handler(
+    /// Emit a per-signal asm stub. Each stub OR-sets its own bit into
+    /// `pending_signals` and nudges `alloc_flag` so the next GC poll
+    /// in `execute_gc` notices the signal and converts it to a Ruby
+    /// exception. `signo` is the POSIX signal number (1..32).
+    ///
+    /// The handler runs in async-signal context; the only operations
+    /// performed are a memory OR and an ADD, both of which are
+    /// async-signal-safe on x86-64. No call into Rust.
+    pub(crate) fn signal_handler_for(
         &mut self,
         alloc_flag: DestLabel,
-        sigint_flag: DestLabel,
+        pending_signals: DestLabel,
+        signo: i32,
     ) -> CodePtr {
+        debug_assert!((1..=32).contains(&signo));
+        let bit: i32 = 1 << (signo - 1);
         let codeptr = self.jit.get_current_address();
         monoasm! { &mut self.jit,
             addl [rip + alloc_flag], 10;
-            movl [rip + sigint_flag], 1;
+            orl  [rip + pending_signals], (bit);
             ret;
         }
         codeptr
@@ -900,19 +916,27 @@ impl Codegen {
             jit_compile_time: std::time::Duration::default(),
         };
         codegen.construct_vm();
-        let signal_handler = codegen.signal_handler();
+        // Emit one stub per signal we want to surface as a Ruby
+        // exception. SIGSEGV/SIGBUS/SIGFPE/SIGILL/SIGABRT are deliberately
+        // not handled — those are genuine programming errors and should
+        // be left to the kernel's default core-dump path.
+        // See doc/signal_handling.md.
+        let signal_stubs: Vec<(i32, CodePtr)> = signal_table::POSIX_SIGNALS
+            .iter()
+            .map(|&signo| (signo, codegen.signal_handler_for(signo)))
+            .collect();
         codegen.jit.finalize();
 
         unsafe {
-            use libc::{SA_RESTART, SIGINT, sighandler_t};
-            let mut sa: libc::sigaction = std::mem::zeroed();
-
-            sa.sa_sigaction = signal_handler.as_ptr() as sighandler_t;
-            sa.sa_flags = SA_RESTART;
-            libc::sigemptyset(&mut sa.sa_mask);
-
-            if libc::sigaction(SIGINT, &sa, std::ptr::null_mut()) != 0 {
-                panic!("Failed to set signal handler.");
+            use libc::{SA_RESTART, sighandler_t};
+            for &(signo, codeptr) in &signal_stubs {
+                let mut sa: libc::sigaction = std::mem::zeroed();
+                sa.sa_sigaction = codeptr.as_ptr() as sighandler_t;
+                sa.sa_flags = SA_RESTART;
+                libc::sigemptyset(&mut sa.sa_mask);
+                if libc::sigaction(signo, &sa, std::ptr::null_mut()) != 0 {
+                    panic!("Failed to set signal handler for signo {signo}");
+                }
             }
         }
 
@@ -960,19 +984,32 @@ impl Codegen {
         CompilationUnitId(id)
     }
 
-    pub(crate) fn sigint_flag(&self) -> bool {
-        let ptr = self.jit.get_label_address(&self.sigint_flag).as_ptr() as *mut u32;
-        unsafe { *ptr != 0 }
+    /// Atomically read and clear the pending-signal bitmap. Returns the
+    /// signals that were pending at call time; the bitmap is left zero.
+    ///
+    /// Uses `xchg` semantics via a volatile read-then-zero. The asm
+    /// signal stub uses `or` to set bits, so a concurrent set racing
+    /// with this clear may be lost if the read happens between OR and
+    /// the bit's observation — acceptable: it gets picked up on the
+    /// next poll. Use of `*mut u32` is fine here because the signal
+    /// handler runs on the same thread as the poll.
+    pub(crate) fn take_pending_signals(&self) -> u32 {
+        let ptr = self
+            .jit
+            .get_label_address(&self.pending_signals)
+            .as_ptr() as *mut u32;
+        unsafe {
+            let v = std::ptr::read_volatile(ptr);
+            if v != 0 {
+                std::ptr::write_volatile(ptr, 0);
+            }
+            v
+        }
     }
 
-    pub(crate) fn unset_sigint_flag(&self) {
-        let ptr = self.jit.get_label_address(&self.sigint_flag).as_ptr() as *mut u32;
-        unsafe { *ptr = 0 }
-    }
-
-    pub(crate) fn signal_handler(&mut self) -> CodePtr {
+    pub(crate) fn signal_handler_for(&mut self, signo: i32) -> CodePtr {
         self.jit
-            .signal_handler(self.alloc_flag.clone(), self.sigint_flag.clone())
+            .signal_handler_for(self.alloc_flag.clone(), self.pending_signals.clone(), signo)
     }
 
     pub(crate) fn entry_raise(&self) -> DestLabel {

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -7,7 +7,7 @@ impl JitModule {
         let bop_redefined_flags = jit.data_i32(0);
         let const_version = jit.data_i64(1);
         let alloc_flag = jit.data_i32(if cfg!(feature = "gc-stress") { 1 } else { 0 });
-        let sigint_flag = jit.data_i32(0);
+        let pending_signals = jit.data_i32(0);
         let entry_raise = jit.label();
         let entry_panic = jit.label();
         let exec_gc = jit.label();
@@ -31,7 +31,7 @@ impl JitModule {
             class_version,
             const_version,
             alloc_flag,
-            sigint_flag,
+            pending_signals,
             entry_raise,
             exec_gc,
             f64_to_val,

--- a/monoruby/src/codegen/signal_table.rs
+++ b/monoruby/src/codegen/signal_table.rs
@@ -1,0 +1,55 @@
+//! POSIX signal → Ruby exception mapping.
+//!
+//! See doc/signal_handling.md for the full plan. This module is the
+//! single source of truth for:
+//!
+//! 1. Which signals monoruby installs an async-signal-safe handler for.
+//! 2. Which Ruby class / message each pending signal lowers to at the
+//!    next poll point.
+//!
+//! Deliberately omitted: SIGSEGV / SIGBUS / SIGFPE / SIGILL / SIGABRT.
+//! These are genuine runtime bugs (or explicit `abort`s); the kernel's
+//! default core-dump path is the right response, not a Ruby `rescue`.
+
+use crate::MonorubyErr;
+
+/// List of POSIX signals monoruby installs an async-signal handler
+/// for *by default*. Only SIGINT is here: every other signal's CRuby
+/// default action is *terminate the process* (or be signal-delivered
+/// up to `Process.wait`), not raise — installing an unconditional
+/// catch-and-convert would break `Process.kill("TERM", child); $?.signaled?`
+/// patterns that fork tests rely on. The remaining entries in
+/// `signo_to_error` are intentionally pre-wired so that A7
+/// (`Signal.trap`) only needs to register the handler at trap-time,
+/// not also teach the runtime a new mapping.
+///
+/// Order is delivery priority — lowest signo bit is consumed first.
+pub(crate) const POSIX_SIGNALS: &[i32] = &[libc::SIGINT];
+
+/// Convert a pending signo into the Ruby error the poll point should
+/// raise. Returns `None` for signals we do not handle (defensive: the
+/// asm stub only sets bits for signals we installed, so this should be
+/// unreachable in practice).
+pub(crate) fn signo_to_error(signo: i32) -> Option<MonorubyErr> {
+    let err = match signo {
+        libc::SIGINT => MonorubyErr::interrupt("Interrupt"),
+        libc::SIGTERM => MonorubyErr::signalexception("SIGTERM"),
+        libc::SIGHUP => MonorubyErr::signalexception("SIGHUP"),
+        libc::SIGUSR1 => MonorubyErr::signalexception("SIGUSR1"),
+        libc::SIGUSR2 => MonorubyErr::signalexception("SIGUSR2"),
+        libc::SIGQUIT => MonorubyErr::signalexception("SIGQUIT"),
+        libc::SIGPIPE => MonorubyErr::signalexception("SIGPIPE"),
+        _ => return None,
+    };
+    Some(err)
+}
+
+/// Drain the pending-signal bitmap into the first Ruby error to raise.
+/// Lowest-numbered pending signal wins.
+pub(crate) fn lowest_pending_to_error(bitmap: u32) -> Option<MonorubyErr> {
+    if bitmap == 0 {
+        return None;
+    }
+    let signo = bitmap.trailing_zeros() as i32 + 1;
+    signo_to_error(signo)
+}

--- a/monoruby/src/codegen/signal_table.rs
+++ b/monoruby/src/codegen/signal_table.rs
@@ -53,3 +53,90 @@ pub(crate) fn lowest_pending_to_error(bitmap: u32) -> Option<MonorubyErr> {
     let signo = bitmap.trailing_zeros() as i32 + 1;
     signo_to_error(signo)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MonorubyErrKind;
+    use crate::globals::{INTERRUPT_CLASS, SIGNAL_EXCEPTION_CLASS};
+
+    /// SIGINT maps to the dedicated `Interrupt` class with the
+    /// conventional "Interrupt" message (A4 in doc/signal_handling.md).
+    #[test]
+    fn sigint_maps_to_interrupt() {
+        let err = signo_to_error(libc::SIGINT).expect("SIGINT must map");
+        assert_eq!(err.kind(), &MonorubyErrKind::Other(INTERRUPT_CLASS));
+        assert_eq!(err.message(), "Interrupt");
+    }
+
+    /// Every pre-wired terminate-class signal maps to `SignalException`
+    /// with a "SIG…" message (A3 / A6 in doc/signal_handling.md). These
+    /// arms are unreachable through the default install set (SIGINT
+    /// only), so this is their only coverage until A7 (`Signal.trap`)
+    /// flips the install bit.
+    #[test]
+    fn terminate_signals_map_to_signalexception() {
+        for (signo, msg) in [
+            (libc::SIGTERM, "SIGTERM"),
+            (libc::SIGHUP, "SIGHUP"),
+            (libc::SIGUSR1, "SIGUSR1"),
+            (libc::SIGUSR2, "SIGUSR2"),
+            (libc::SIGQUIT, "SIGQUIT"),
+            (libc::SIGPIPE, "SIGPIPE"),
+        ] {
+            let err = signo_to_error(signo).unwrap_or_else(|| panic!("{msg} must map"));
+            assert_eq!(
+                err.kind(),
+                &MonorubyErrKind::Other(SIGNAL_EXCEPTION_CLASS),
+                "{msg} should lower to SignalException"
+            );
+            assert_eq!(err.message(), msg);
+        }
+    }
+
+    /// Signals deliberately left to the kernel (SIGSEGV, …) and any
+    /// other unmapped signo hit the defensive fall-through and return
+    /// `None`.
+    #[test]
+    fn unmapped_signo_returns_none() {
+        assert!(signo_to_error(libc::SIGSEGV).is_none());
+        assert!(signo_to_error(libc::SIGCHLD).is_none());
+    }
+
+    /// An empty bitmap drains to nothing.
+    #[test]
+    fn empty_bitmap_is_none() {
+        assert!(lowest_pending_to_error(0).is_none());
+    }
+
+    /// A single pending bit lowers to the matching error. Bit `n`
+    /// corresponds to signo `n + 1`, so SIGINT (signo 2) is bit 1.
+    #[test]
+    fn single_pending_bit_drains() {
+        let bit = 1u32 << (libc::SIGINT - 1) as u32;
+        let err = lowest_pending_to_error(bit).expect("SIGINT bit must drain");
+        assert_eq!(err.kind(), &MonorubyErrKind::Other(INTERRUPT_CLASS));
+    }
+
+    /// When several signals are pending the lowest signo wins (delivery
+    /// priority, per A6). SIGINT (2) beats SIGTERM (15).
+    #[test]
+    fn lowest_signo_wins() {
+        let bitmap = (1u32 << (libc::SIGINT - 1) as u32) | (1u32 << (libc::SIGTERM - 1) as u32);
+        let err = lowest_pending_to_error(bitmap).expect("must drain");
+        assert_eq!(
+            err.kind(),
+            &MonorubyErrKind::Other(INTERRUPT_CLASS),
+            "SIGINT must win over SIGTERM"
+        );
+    }
+
+    /// A pending bit for an unmapped signo (SIGTRAP, signo 5) drains to
+    /// `None` rather than panicking — exercises the `signo_to_error`
+    /// `None` passthrough inside `lowest_pending_to_error`.
+    #[test]
+    fn pending_unmapped_bit_is_none() {
+        let bit = 1u32 << (libc::SIGTRAP - 1) as u32;
+        assert!(lowest_pending_to_error(bit).is_none());
+    }
+}

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2630,9 +2630,15 @@ pub(crate) extern "C" fn execute_gc(
 ) -> Option<Value> {
     CODEGEN.with(|codegen| {
         let codegen = codegen.borrow_mut();
-        if codegen.sigint_flag() {
-            executor.set_error(MonorubyErr::runtimeerr("Interrupt"));
-            codegen.unset_sigint_flag();
+        // Drain the pending-signal bitmap. The lowest-numbered pending
+        // signal is consumed and lowered to a Ruby exception; any
+        // others observed in the same drain are dropped on the floor
+        // (signo collisions in a single poll window are extremely
+        // unlikely in practice and CRuby itself does not guarantee
+        // delivery of every signal). See doc/signal_handling.md.
+        let pending = codegen.take_pending_signals();
+        if let Some(err) = crate::codegen::signal_table::lowest_pending_to_error(pending) {
+            executor.set_error(err);
             None
         } else {
             Some(())

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -737,6 +737,14 @@ impl MonorubyErr {
         MonorubyErr::new(MonorubyErrKind::Runtime, msg)
     }
 
+    pub(crate) fn signalexception(msg: impl ToString) -> MonorubyErr {
+        MonorubyErr::new(MonorubyErrKind::Other(SIGNAL_EXCEPTION_CLASS), msg)
+    }
+
+    pub(crate) fn interrupt(msg: impl ToString) -> MonorubyErr {
+        MonorubyErr::new(MonorubyErrKind::Other(INTERRUPT_CLASS), msg)
+    }
+
     /// Construct a FatalError. Used when a Rust `panic!` is caught at an
     /// `extern "C"` boundary. FatalError propagates up through Ruby's
     /// `rescue` handlers without being caught.

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -73,6 +73,9 @@ pub const BOOL_CLASS: ClassId = ClassId::new(54);
 
 pub const ARITHMETIC_SEQUENCE_CLASS: ClassId = ClassId::new(55);
 
+pub const SIGNAL_EXCEPTION_CLASS: ClassId = ClassId::new(56);
+pub const INTERRUPT_CLASS: ClassId = ClassId::new(57);
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct ClassId(NonZeroU32);
@@ -137,6 +140,8 @@ impl std::fmt::Debug for ClassId {
             53 => write!(f, "FATAL_ERROR"),
             54 => write!(f, "BOOL"),
             55 => write!(f, "ARITHMETIC_SEQUENCE"),
+            56 => write!(f, "SIGNAL_EXCEPTION"),
+            57 => write!(f, "INTERRUPT"),
             n => write!(f, "ClassId({n})"),
         }
     }


### PR DESCRIPTION
## Summary

- Replace the SIGINT-specific `sigint_flag` with a 32-bit `pending_signals` bitmap and per-signal asm stub factory so any catchable POSIX signal can be lowered to a Ruby exception at the next poll point.
- Add `Interrupt < SignalException`. Previously SIGINT raised a bare `RuntimeError("Interrupt")`, which bypassed `rescue Interrupt`.
- Introduce `doc/signal_handling.md` documenting the full plan (this PR is item **#1**; #2–#5 stay open).

## Why default-install is still SIGINT-only

CRuby's default action for SIGTERM/HUP/USR1/USR2/QUIT/PIPE is *terminate the process*, not raise. An unconditional catch-and-convert breaks process-status tests that rely on
\`Process.kill("TERM", child); $?.signaled? == true\`. The infrastructure is fully wired (mapping table, async-safe stubs, bitmap drain) so item **A7 — `Signal.trap`** only has to flip the `sigaction` install bit at trap-time.

## Verification

- `cargo test -p monoruby --lib` — all 1564 tests pass, including the Process status / kill tests that initially regressed and drove the design decision above.
- Manual smoke test:
  - `Process.kill(\"INT\", Process.pid); loop {}` → caught as \`Interrupt\` ✔
  - `Process.kill(\"TERM\", Process.pid); loop {}` → kernel terminates, exit 143 ✔ (matches CRuby)

## What's next (tracked in [doc/signal_handling.md](doc/signal_handling.md))

- [ ] 2 `Thread.pass` guard revisit
- [ ] 3 Eager `ThreadError` on blocking thread ops
- [ ] 4 Hang watchdog
- [ ] 5 Stretch (extra poll points, `Signal.trap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)