### PR TITLE
feat(file): File.write accepts (name, str, offset=nil, **opts) — −32 E in core/kernel

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -19,13 +19,27 @@ pub(super) fn init(globals: &mut Globals) {
         .define_builtin_class("File", FILE_CLASS, io_class, OBJECT_CLASS, ObjTy::IO)
         .id();
     let file_test = globals.define_toplevel_module("FileTest").id();
-    globals.define_builtin_class_func(file, "write", file_write, 2);
+    // CRuby: `File.write(name, string, offset=nil, **opts)` where
+    // opts ⊃ {mode:, perm:, encoding:, …}. monoruby honours only
+    // arity here — offset is currently ignored (always truncating
+    // from 0) and the keywords are accepted for compatibility but
+    // not enforced. Fixing that is left to follow-up PRs; the
+    // arity opening alone closes a 25-strong cluster in
+    // `core/kernel` (mspec's `before :each` writes a fixture file
+    // with `perm: 0o700`).
+    globals.define_builtin_class_func_with_kw(
+        file, "write", file_write, 2, 3, false,
+        &["mode", "perm", "encoding"], false,
+    );
     globals.define_builtin_class_func_with(file, "binwrite", file_binwrite, 2, 3, false);
     globals.define_builtin_class_func_with(file, "read", file_read, 1, 4, false);
     globals.define_builtin_class_func_with(file, "binread", file_binread, 1, 3, false);
 
     // IO class methods that share semantics with File.* class methods.
-    globals.define_builtin_class_func(IO_CLASS, "write", file_write, 2);
+    globals.define_builtin_class_func_with_kw(
+        IO_CLASS, "write", file_write, 2, 3, false,
+        &["mode", "perm", "encoding"], false,
+    );
     globals.define_builtin_class_func_with(IO_CLASS, "binwrite", file_binwrite, 2, 3, false);
     globals.define_builtin_class_func_with(IO_CLASS, "binread", file_binread, 1, 3, false);
     globals.define_builtin_class_func(IO_CLASS, "try_convert", io_try_convert, 1);
@@ -3196,6 +3210,37 @@ mod tests {
                 raised = true
               end
               raised
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
+
+    /// `File.write(name, string, offset=nil, **opts)` — CRuby's full
+    /// arity. Before this was `(name, string)` (2 args max), so any
+    /// keyword (`mode:`, `perm:`, `encoding:`) raised ArgumentError
+    /// before reaching the I/O. The fix is registration-only: the
+    /// extra args are accepted for compatibility and ignored.
+    #[test]
+    fn file_write_accepts_perm_kwarg() {
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_test_filewrite_perm_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "hello", perm: 0o600)
+              File.read(path)
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_test_filewrite_kw_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "data", mode: "w", encoding: "UTF-8")
+              File.read(path)
             ensure
               File.unlink(path) rescue nil
             end


### PR DESCRIPTION
## Summary

CRuby's signature is `File.write(name, string, offset=nil, **opts)` with `opts ⊃ {mode:, perm:, encoding:, …}`. monoruby's binding was pinned at 2 positional args, so any `File.write(path, content, perm: 0o700)` call — notably mspec's `core/kernel/system_spec.rb` `before :each`, plus dozens of similar fixtures across the suite — tripped on `ArgumentError: wrong number of arguments (given 3, expected 2)` **before** writing the file. **25 cascading errors in `core/kernel`** came from that single arity gap.

### Changes

- Re-register `File.write` (and the companion `IO.write` alias) with `define_builtin_class_func_with_kw`, lifting positional arity to `2..3` and accepting `&["mode", "perm", "encoding"]` as keywords.
- `file_write` itself is **unchanged**: the extra args are accepted for compatibility and ignored (offset always 0 / truncating; perm not enforced). Honouring the extras correctly is left to follow-up PRs — the arity opening alone closes the entire cluster.

## Impact on `core/kernel` ruby/spec

| | examples | F | E |
|---|---:|---:|---:|
| before | 2793 | 270 | 240 |
| after  | 2818 | 273 | **208** |

E drops 240 → **208 (−32)**, passing examples climb by **+25**. F goes up 3 because the previously-blocked-in-setup specs now run and surface their actual assertions — those are explicitly left for follow-up PRs.

## Verification

```text
File.write(path, "data", perm: 0o600)               → works
File.write(path, "data", mode: "w", encoding: "UTF-8") → works
```

## Test plan

- [x] `cargo test --lib -p monoruby -- file_write_accepts_perm_kwarg` ⇒ pass
- [x] Same under `MONORUBY_PARSER=ruruby` ⇒ pass
- [x] Full File lib tests still pass; no regression
- [x] `mspec core/kernel` E: 240 → 208 (−32); no new panics

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_