### PR TITLE
feat(date): Date#&gt;&gt;, #&lt;&lt;, next/prev_month/_year, julian?, deconstruct_keys (−37 E)

### DIFF
--- a/monoruby/stdlib/date_core.rb
+++ b/monoruby/stdlib/date_core.rb
@@ -151,6 +151,65 @@ class Date
   def eql?(other)
     self.class == other.class && self == other
   end
+
+  # Add `n` months. The result's day is clamped to the last valid
+  # day of the resulting month (e.g. Jan 31 >> 1 ⇒ Feb 28/29).
+  # Dispatches through `self.class.civil` so a DateTime receiver
+  # returns a DateTime (CRuby preserves the type).
+  def >>(n)
+    n = n.to_int
+    total = @year * 12 + (@month - 1) + n
+    y = total.div(12)
+    m = total.modulo(12) + 1
+    d = [@day, Date._days_in_month(y, m)].min
+    if self.is_a?(DateTime)
+      self.class.civil(y, m, d, @hour, @min, @sec, @offset)
+    else
+      self.class.civil(y, m, d)
+    end
+  end
+
+  # Subtract `n` months. `Date#<<(n)` is `Date#>>(-n)`.
+  def <<(n)
+    self >> -n.to_int
+  end
+
+  # Next-month / previous-month helpers; both delegate to `>>` so
+  # the end-of-month clamping is identical.
+  def next_month(n = 1) ; self >> n.to_int ; end
+  def prev_month(n = 1) ; self << n.to_int ; end
+
+  # Next-year / previous-year — multiply by 12 and reuse `>>`.
+  def next_year(n = 1)  ; self >> (n.to_int * 12) ; end
+  def prev_year(n = 1)  ; self << (n.to_int * 12) ; end
+
+  # CRuby: `Date#julian?` is true iff the date is interpreted in
+  # the Julian calendar. monoruby's Date is always Gregorian (the
+  # `sg` switchover argument is accepted for compatibility but
+  # never consulted), so this is always false. `gregorian?` is the
+  # mirror.
+  def julian?    ; false ; end
+  def gregorian? ; true  ; end
+
+  # Pattern-matching deconstructor (CRuby 3.2+):
+  # `keys=nil` ⇒ all four keys; otherwise only the matching ones.
+  def deconstruct_keys(keys)
+    all = { year: @year, month: @month, day: @day, yday: yday, wday: wday }
+    return all if keys.nil?
+    keys.each_with_object({}) { |k, h| h[k] = all[k] if all.key?(k) }
+  end
+
+  # Helper for `>>`/`<<`: number of days in the given (y, m) under
+  # the Gregorian calendar with the same leap-year rules as `leap?`.
+  def self._days_in_month(y, m)
+    days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    if m == 2
+      leap = (y % 4 == 0) && ((y % 100 != 0) || (y % 400 == 0))
+      leap ? 29 : 28
+    else
+      days[m - 1]
+    end
+  end
 end
 
 class DateTime < Date


### PR DESCRIPTION
## Summary

Six CRuby-shape additions to monoruby's pure-Ruby Date class. Pure additions to an existing class; no new class, no threading, no Refinements/ObjectSpace.

### `Date#>>(n)` / `Date#<<(n)`
Add / subtract `n` months. The result's day is clamped to the last valid day of the resulting month (e.g. `Date.civil(2024, 1, 31) >> 1` ⇒ `2024-02-29`). Dispatch through `self.class.civil` so a DateTime receiver returns a DateTime (CRuby contract).

### `Date#next_month(n=1)` / `Date#prev_month(n=1)` / `Date#next_year(n=1)` / `Date#prev_year(n=1)`
Sugar over `>>` / `<<`. `next_year` multiplies by 12.

### `Date#julian?` / `Date#gregorian?`
monoruby's Date is always Gregorian (the `sg` switchover argument is accepted for compatibility but never consulted), so `julian?` is always `false` and `gregorian?` always `true`.

### `Date#deconstruct_keys(keys)`
Pattern-matching deconstructor: `nil` ⇒ all five keys (year/month/day/yday/wday); otherwise only the matching ones.

### Helper
`Date._days_in_month(y, m)` computes leap-year-aware days-in-month using the same rules as `Date#leap?`.

## Impact on ruby/spec

| | examples | F | E |
|---|---:|---:|---:|
| `library/date` before  | 295 | 54  | 193 |
| `library/date` after   | 295 | 64  | **162** |
| `library/datetime` before | 192 | 117 | 42  |
| `library/datetime` after  | 192 | 119 | **36**  |

Combined E drops **−37** (193 → 162 + 42 → 36) with **+25** net passing examples. F goes up 12 because previously-blocked specs now reach their actual assertions.

## Verification

```text
Date.civil(2024, 1, 31) >> 1                  → Date 2024-02-29
Date.civil(2024, 1, 31) << 1                  → Date 2023-12-31
Date.civil(2024, 1, 31).next_month            → Date 2024-02-29
Date.civil(2024, 1, 31).prev_month(3)         → Date 2023-10-31
Date.civil(2024, 1, 31).deconstruct_keys(nil) →
              {year:2024, month:1, day:31, yday:31, wday:2}
DateTime.civil(2024,1,31,12,30,45) >> 1       → DateTime 2024-02-29T12:30:45
```

## Test plan

- [x] `cargo build --release -p monoruby` clean
- [x] Smoke (above) all return CRuby-shape results
- [x] `mspec library/date` E: 193 → 162 (−31); `library/datetime` E: 42 → 36 (−6)
- [x] No new panics in either group

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_