### PR TITLE
feat(startup): runtime probe for host Ruby's gem and load paths

### DIFF
--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -193,22 +193,44 @@ impl Globals {
         // the host gem roots. Done here, before `init_builtins`, because
         // monoruby's `ENV` hash is materialized from `std::env::vars()`
         // during builtin init and vendored rubygems reads GEM_PATH at
-        // require-time from that snapshot. Only set when the user hasn't
-        // supplied their own value.
-        if std::env::var_os("GEM_PATH").is_none() {
-            let gem_path_file = dirs::home_dir()
-                .unwrap()
-                .join(".monoruby")
-                .join("gem_path");
-            if let Ok(s) = std::fs::read_to_string(&gem_path_file) {
-                let s = s.trim();
-                if !s.is_empty() {
-                    // SAFETY: `Globals::new` runs single-threaded on the
-                    // main thread before any worker threads are spawned.
-                    unsafe {
-                        std::env::set_var("GEM_PATH", s);
-                    }
-                }
+        // require-time from that snapshot.
+        //
+        // Resolution chain (first non-empty wins):
+        //   1. MONORUBY_GEM_PATH env var  — explicit override
+        //   2. GEM_PATH env var           — CRuby convention, untouched
+        //   3. ~/.monoruby/gem_path file  — build.rs baked
+        //   4. Runtime probe              — invoke `ruby` once, cache to file
+        let monoruby_dir = dirs::home_dir().unwrap().join(".monoruby");
+        let gem_path_file = monoruby_dir.join("gem_path");
+        let library_path_file = monoruby_dir.join("library_path");
+
+        if let Some(p) = std::env::var_os("MONORUBY_GEM_PATH") {
+            // SAFETY: `Globals::new` runs single-threaded on the main
+            // thread before any worker threads are spawned.
+            unsafe { std::env::set_var("GEM_PATH", p) };
+        } else if std::env::var_os("GEM_PATH").is_none() {
+            let cached = std::fs::read_to_string(&gem_path_file)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            let from_probe = if cached.is_some() && !crate::ruby_probe::reprobe_requested() {
+                None
+            } else {
+                crate::ruby_probe::probe().map(|p| {
+                    // Cache both files so subsequent runs skip the
+                    // ~50ms `ruby` spawn. `library_path` may not have
+                    // been baked either (e.g. distributed binary), so
+                    // write it unconditionally when we just probed.
+                    let _ = std::fs::write(&gem_path_file, &p.gem_path);
+                    let _ = std::fs::write(&library_path_file, &p.library_path);
+                    p.gem_path
+                })
+            };
+            if let Some(s) = from_probe.or(cached)
+                && !s.is_empty()
+            {
+                // SAFETY: as above — single-threaded main-thread init.
+                unsafe { std::env::set_var("GEM_PATH", s) };
             }
         }
 
@@ -298,19 +320,23 @@ impl Globals {
             .set_ivar(main_object, IdentId::_NAME, Value::string_from_str("main"))
             .unwrap();
 
-        // load library path
-        let load_path = dirs::home_dir()
-            .unwrap()
-            .join(".monoruby")
-            .join("library_path");
-        let path_list = match std::fs::read_to_string(&load_path) {
-            Ok(s) => s,
-            Err(_) => {
-                eprintln!(
-                    "Warning: failed to read library path file: {:?}. Ruby may not be installed.",
-                    load_path
-                );
-                String::new()
+        // Load library path. Resolution chain mirrors the GEM_PATH
+        // chain above; the runtime probe that may have just populated
+        // `library_path_file` (via the GEM_PATH block) is the same
+        // ruby invocation, so by the time we get here the cache file
+        // is either already populated or unprobeable.
+        let path_list = if let Some(p) = std::env::var_os("MONORUBY_LOAD_PATH") {
+            p.to_string_lossy().into_owned()
+        } else {
+            match std::fs::read_to_string(&library_path_file) {
+                Ok(s) => s,
+                Err(_) => {
+                    eprintln!(
+                        "Warning: failed to read library path file: {:?}. Ruby may not be installed.",
+                        library_path_file
+                    );
+                    String::new()
+                }
             }
         };
         // prepend monoruby-specific lib directory so it can override CRuby stdlib files.

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -14,6 +14,7 @@ mod executor;
 mod globals;
 mod id_table;
 pub mod parser;
+mod ruby_probe;
 pub mod tests;
 mod value;
 

--- a/monoruby/src/ruby_probe.rs
+++ b/monoruby/src/ruby_probe.rs
@@ -1,0 +1,130 @@
+//! Runtime probe for a host `ruby` binary, used as a fallback when
+//! `build.rs` could not bake `~/.monoruby/library_path` and
+//! `~/.monoruby/gem_path` (e.g. distributed binaries, containers built
+//! without `ruby` in `PATH`).
+//!
+//! Order of precedence at startup:
+//!   1. `MONORUBY_GEM_PATH` / `MONORUBY_LOAD_PATH` env vars (explicit override)
+//!   2. `GEM_PATH` env var (CRuby convention)
+//!   3. `~/.monoruby/{gem_path,library_path}` files (build.rs baked)
+//!   4. Runtime probe — invoke `ruby` once, write the result back into
+//!      the same cache files so subsequent runs skip probing
+//!
+//! Probe results are cached in `~/.monoruby/{gem_path,library_path}` so
+//! the cost (~50ms for an interpreter spawn) is paid once per machine.
+//! Set `MONORUBY_REPROBE=1` to force a fresh probe.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Minimum host Ruby version accepted by the runtime probe.
+/// Mirrors `build.rs::MIN_RUBY_VERSION`: older Rubies ship gems
+/// whose `required_ruby_version` checks fail against monoruby's
+/// reported `RUBY_VERSION = "4.0.0"`, and their default-gem set
+/// drifts from the vendored stdlib snapshot.
+const MIN_RUBY_VERSION: (u32, u32) = (4, 0);
+
+fn ruby_version_ok(ruby_cmd: &str) -> bool {
+    let Ok(output) = Command::new(ruby_cmd)
+        .args(["-e", "puts RUBY_VERSION"])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let s = String::from_utf8_lossy(&output.stdout);
+    let mut parts = s.trim().split('.').map(|p| p.parse::<u32>().ok());
+    let major = parts.next().flatten();
+    let minor = parts.next().flatten();
+    match (major, minor) {
+        (Some(maj), Some(min)) => (maj, min) >= MIN_RUBY_VERSION,
+        _ => false,
+    }
+}
+
+/// Locate a `ruby` executable meeting `MIN_RUBY_VERSION`. Checks `PATH`
+/// first, then the well-known rbenv / rvm shim locations under `$HOME`.
+fn find_ruby() -> Option<String> {
+    if ruby_version_ok("ruby") {
+        return Some("ruby".to_string());
+    }
+    let home = std::env::var_os("HOME")?;
+    let candidates = [
+        PathBuf::from(&home).join(".rbenv/shims/ruby"),
+        PathBuf::from(&home).join(".rvm/bin/ruby"),
+    ];
+    for c in &candidates {
+        if let Some(s) = c.to_str()
+            && ruby_version_ok(s)
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+/// Honour `MONORUBY_REPROBE=1` to bypass cached `~/.monoruby/gem_path`
+/// and `~/.monoruby/library_path` and re-invoke `ruby`. Any other value
+/// (including unset) keeps the cache.
+pub fn reprobe_requested() -> bool {
+    matches!(std::env::var("MONORUBY_REPROBE").as_deref(), Ok("1"))
+}
+
+/// Probe result: `(library_path, gem_path)`.
+///
+/// - `library_path` — newline-separated list of `$LOAD_PATH` entries
+///   (stdlib + every installed gem's `lib/`).
+/// - `gem_path`     — colon-separated list of `Gem.paths.path` entries
+///   (the directories rubygems scans for `specifications/*.gemspec`).
+pub struct ProbedPaths {
+    pub library_path: String,
+    pub gem_path: String,
+}
+
+/// Invoke a host `ruby` and read back its `$LOAD_PATH` and
+/// `Gem.paths.path`. Returns `None` if no suitable ruby is found or
+/// the invocation fails — startup then proceeds with whatever was
+/// already configured (env vars / cached files / nothing).
+pub fn probe() -> Option<ProbedPaths> {
+    let ruby = find_ruby()?;
+
+    // $LOAD_PATH + every installed gem's require_paths (mirrors
+    // build.rs so cached files have identical shape regardless of
+    // whether they were populated at build or runtime).
+    let load_path_out = Command::new(&ruby).args(["-e", "puts($:)"]).output().ok()?;
+    if !load_path_out.status.success() {
+        return None;
+    }
+    let mut library_path = String::from_utf8(load_path_out.stdout).ok()?;
+    if let Ok(g) = Command::new(&ruby)
+        .args([
+            "-e",
+            "Gem::Specification.latest_specs(true).each{|s| \
+             s.require_paths.each{|p| d=File.join(s.full_gem_path,p); \
+             puts d if Dir.exist?(d)}}",
+        ])
+        .output()
+        && g.status.success()
+    {
+        if !library_path.ends_with('\n') {
+            library_path.push('\n');
+        }
+        library_path.push_str(&String::from_utf8_lossy(&g.stdout));
+    }
+
+    let gem_path_out = Command::new(&ruby)
+        .args(["-e", "print Gem.paths.path.join(':')"])
+        .output()
+        .ok()?;
+    if !gem_path_out.status.success() {
+        return None;
+    }
+    let gem_path = String::from_utf8(gem_path_out.stdout).ok()?.trim().to_string();
+
+    Some(ProbedPaths {
+        library_path,
+        gem_path,
+    })
+}


### PR DESCRIPTION
build.rs writes ~/.monoruby/{gem_path,library_path} by invoking
`ruby` at build time, but the cache stays empty if no Ruby >= 4.0
is present on the build host (CI image, distributed binary,
containers built without ruby). Add a runtime fallback so monoruby
can locate gem and stdlib directories at first start whenever a
suitable Ruby was installed *after* the build.

Resolution chain (first non-empty wins):
  1. MONORUBY_GEM_PATH / MONORUBY_LOAD_PATH env vars (explicit override)
  2. GEM_PATH env var (CRuby convention, untouched)
  3. ~/.monoruby/{gem_path,library_path} cached files (build.rs baked)
  4. Runtime probe — invoke `ruby` once via the same find_ruby logic
     build.rs uses (PATH, $HOME/.rbenv/shims/ruby, $HOME/.rvm/bin/ruby),
     write the result back into the cache files so subsequent runs
     skip the ~50ms spawn

The runtime probe enforces the same MIN_RUBY_VERSION = (4, 0) gate
as build.rs to avoid pulling in 3.x gems whose required_ruby_version
checks would conflict with monoruby reporting RUBY_VERSION = "4.0.0".
Set MONORUBY_REPROBE=1 to bypass the cache after installing new
gems or upgrading the host Ruby.

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp