### PR TITLE
feat(stringio): StringIO#set_encoding_by_bom (−18 E, spec fully green)

### DIFF
--- a/monoruby/stdlib/stringio.rb
+++ b/monoruby/stdlib/stringio.rb
@@ -409,6 +409,57 @@ class StringIO
     self
   end
 
+  # set_encoding_by_bom -> Encoding | nil
+  #
+  # Inspect the bytes at the current position for one of the
+  # documented BOM (byte-order mark) sequences. On a match: slice
+  # the BOM off the backing string, reset `@pos` to 0 (avoids
+  # char-vs-byte position drift after the encoding changes), force
+  # the new encoding, and return the `Encoding`. Otherwise
+  # (incomplete BOM, no BOM, or not opened for reading) leave the
+  # state untouched and return `nil`.
+  #
+  # CRuby checks longest BOM first (UTF-32LE must precede
+  # UTF-16LE because both start with `\xFF\xFE`).
+  def set_encoding_by_bom
+    # CRuby raises FrozenError on a frozen StringIO *before* the
+    # readable-state check (the spec asserts the error class even
+    # when the underlying state would otherwise return nil).
+    raise FrozenError, "can't modify frozen StringIO" if frozen?
+    # CRuby returns `nil` (not IOError) when the StringIO was
+    # opened write-only; probe the close flag directly instead of
+    # going through `_check_readable`.
+    return nil if @closed_read
+    bytes = @string.bytes
+    return nil if bytes.empty?
+    bom_len, enc =
+      if bytes[0] == 0xEF
+        return nil unless bytes.length >= 3 && bytes[1] == 0xBB && bytes[2] == 0xBF
+        [3, Encoding::UTF_8]
+      elsif bytes[0] == 0x00
+        return nil unless bytes.length >= 4 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF
+        [4, Encoding::UTF_32BE]
+      elsif bytes[0] == 0xFF && bytes.length >= 2 && bytes[1] == 0xFE
+        if bytes.length >= 4 && bytes[2] == 0x00 && bytes[3] == 0x00
+          [4, Encoding::UTF_32LE]
+        else
+          [2, Encoding::UTF_16LE]
+        end
+      elsif bytes[0] == 0xFE
+        return nil unless bytes.length >= 2 && bytes[1] == 0xFF
+        [2, Encoding::UTF_16BE]
+      else
+        return nil
+      end
+    # Slice BOM off the backing string and reset @pos. Using a
+    # byte-level slice on an ASCII-8BIT string keeps the bytes
+    # exact; we then force the new encoding on the remaining bytes.
+    @string = bytes[bom_len..].pack("C*")
+    @string.force_encoding(enc)
+    @pos = 0
+    enc
+  end
+
   # external_encoding -> Encoding
   #
   # CRuby's StringIO mirrors the encoding of the underlying String


### PR DESCRIPTION
## Summary

CRuby's `StringIO#set_encoding_by_bom` inspects the bytes at the current position for a BOM (byte-order mark) and, on a match, sets the backing string's encoding to the matching `Encoding::*`, advances past the BOM, and returns the encoding. On miss / incomplete / write-only / empty IO it returns `nil` without mutating state. Frozen IO ⇒ `FrozenError`.

monoruby was missing the method entirely, so 18 errors in `library/stringio/set_encoding_by_bom_spec.rb` (all `before :each` NoMethodErrors) blocked downstream assertions.

### Algorithm

Longest BOM first — UTF-32LE precedes UTF-16LE because both start with `\xFF\xFE`:

| Encoding | BOM bytes |
|---|---|
| UTF-8 | `EF BB BF` |
| UTF-32BE | `00 00 FE FF` |
| UTF-32LE | `FF FE 00 00` |
| UTF-16LE | `FF FE` |
| UTF-16BE | `FE FF` |

Match → slice the BOM off `@string`, reset `@pos = 0` (avoids char-vs-byte position drift after `force_encoding`), apply the new encoding, return the `Encoding`. Otherwise return `nil` with state untouched.

### Frozen + state-precondition order

CRuby raises `FrozenError` *before* the readable-state check, so even a frozen write-only IO surfaces the freeze, not `nil`. Mirror that ordering.

## Impact on `library/stringio` ruby/spec

| | examples | F | E |
|---|---:|---:|---:|
| `set_encoding_by_bom_spec` before | 18 | 0 | 18 |
| `set_encoding_by_bom_spec` after  | 18 | 0 | **0**  |
| `library/stringio` total before | 663 | 144 | 115 |
| `library/stringio` total after  | 663 | 144 | **97** |

E drops 115 → **97 (−18)**; the per-method spec is fully green.

## Test plan

- [x] `cargo build --release -p monoruby` clean
- [x] All 5 BOM variants round-trip (smoke verified)
- [x] Incomplete BOM ⇒ nil with bytes preserved (smoke verified)
- [x] Frozen IO ⇒ FrozenError (spec passes)
- [x] `mspec library/stringio/set_encoding_by_bom_spec.rb` ⇒ 18 ex / 0F / 0E (full green)
- [x] No new panics

https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_