### PR TITLE
feat(marshal): 'c' / 'm' / 'M' (Class/Module references) (−33 E)

### DIFF
--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -1618,6 +1618,21 @@ mod tests {
             Marshal.load("\x04\x08c\x12MMissingClass")
             "##,
         );
+        // 'm' naming a missing constant ⇒ ArgumentError. Same shape
+        // as the 'c' case, just under the module reader.
+        run_test_error(
+            r##"
+            # 'm' + length(13 ⇒ marshal_int 0x12) + "MMissingModul"
+            Marshal.load("\x04\x08m\x12MMissingModul")
+            "##,
+        );
+        // 'M' (TYPE_MODULE_OLD) naming a missing constant ⇒ ArgumentError.
+        run_test_error(
+            r##"
+            # 'M' + length(13 ⇒ marshal_int 0x12) + "MMissingThing"
+            Marshal.load("\x04\x08M\x12MMissingThing")
+            "##,
+        );
         // Dump of an anonymous class ⇒ TypeError.
         run_test_error(
             r##"

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -311,6 +311,17 @@ impl<'a> MarshalReader<'a> {
             // the declared members don't match the class's actual
             // member list.
             b'S' => self.read_struct(vm, globals),
+            // 'c' (TYPE_CLASS) — `length(varint) + name-bytes`.
+            // Resolves to the named class. CRuby raises ArgumentError
+            // when the constant is missing and TypeError when it
+            // resolves to a module instead of a class.
+            b'c' => self.read_class_ref(globals),
+            // 'm' (TYPE_MODULE) — same shape as 'c' but the constant
+            // must resolve to a *module*. (Class ⇒ TypeError.)
+            b'm' => self.read_module_ref(globals),
+            // 'M' (TYPE_MODULE_OLD) — legacy tag that accepts either
+            // a class or a module (Ruby 1.8 wrote this for both).
+            b'M' => self.read_class_or_module_ref(globals),
             _ => Err(MonorubyErr::argumenterr(format!(
                 "unsupported marshal type tag: 0x{:02x} ('{}')",
                 tag,
@@ -772,6 +783,61 @@ impl<'a> MarshalReader<'a> {
         self.objects[obj_idx] = instance;
         Ok(instance)
     }
+
+    /// Read a 'c' (TYPE_CLASS) or 'm' (TYPE_MODULE) payload: a
+    /// length-prefixed UTF-8 name string.
+    fn read_class_or_module_name(&mut self) -> Result<String> {
+        let len = self.read_fixnum()? as usize;
+        let bytes = self.read_bytes(len)?;
+        std::str::from_utf8(bytes)
+            .map(|s| s.to_string())
+            .map_err(|_| MonorubyErr::argumenterr("invalid class/module name in marshal data"))
+    }
+
+    /// Read a 'c' (TYPE_CLASS) reference. The payload names a class
+    /// by its qualified path; the constant must exist and must be a
+    /// class (not a module). Mirrors CRuby's `r_object0` TYPE_CLASS
+    /// branch (`ArgumentError` on missing constant, `TypeError` if
+    /// the resolved constant is a Module).
+    fn read_class_ref(&mut self, globals: &mut Globals) -> Result<Value> {
+        let name = self.read_class_or_module_name()?;
+        let module = resolve_class_path(globals, &name).ok_or_else(|| {
+            MonorubyErr::argumenterr(format!("undefined class/module {}", name))
+        })?;
+        if module.as_val().ty() == Some(ObjTy::MODULE) {
+            return Err(MonorubyErr::typeerr(format!("{} does not refer to class", name)));
+        }
+        let val = module.as_val();
+        self.objects.push(val);
+        Ok(val)
+    }
+
+    /// Read a 'm' (TYPE_MODULE) reference — mirror of `read_class_ref`
+    /// but rejects Class with `TypeError`.
+    fn read_module_ref(&mut self, globals: &mut Globals) -> Result<Value> {
+        let name = self.read_class_or_module_name()?;
+        let module = resolve_class_path(globals, &name).ok_or_else(|| {
+            MonorubyErr::argumenterr(format!("undefined class/module {}", name))
+        })?;
+        if module.as_val().ty() != Some(ObjTy::MODULE) {
+            return Err(MonorubyErr::typeerr(format!("{} does not refer to module", name)));
+        }
+        let val = module.as_val();
+        self.objects.push(val);
+        Ok(val)
+    }
+
+    /// Read a 'M' (TYPE_MODULE_OLD) reference — legacy CRuby 1.8 tag
+    /// that accepts either a class or a module.
+    fn read_class_or_module_ref(&mut self, globals: &mut Globals) -> Result<Value> {
+        let name = self.read_class_or_module_name()?;
+        let module = resolve_class_path(globals, &name).ok_or_else(|| {
+            MonorubyErr::argumenterr(format!("undefined class/module {}", name))
+        })?;
+        let val = module.as_val();
+        self.objects.push(val);
+        Ok(val)
+    }
 }
 
 /// Walk a `::`-separated constant path starting at `Object`.
@@ -1138,6 +1204,27 @@ fn marshal_dump_value(
                             marshal_dump_value(buf, *elem, globals, symbols, in_progress)?;
                         }
                     }
+                    Some(ObjTy::CLASS) | Some(ObjTy::MODULE) => {
+                        // Class ⇒ 'c', Module ⇒ 'm', payload is the
+                        // qualified name as a length-prefixed string.
+                        // CRuby raises TypeError on anonymous classes;
+                        // monoruby renders them as `#<Class:0x...>`,
+                        // which is not a constant path.
+                        let is_module = obj.ty() == Some(ObjTy::MODULE);
+                        let class_id = obj.as_class_id();
+                        let class_name = globals.get_class_name(class_id);
+                        if class_name.starts_with("#<") {
+                            return Err(MonorubyErr::typeerr(format!(
+                                "can't dump anonymous {}",
+                                if is_module { "module" } else { "class" }
+                            )));
+                        }
+                        let tag = if is_module { b'm' } else { b'c' };
+                        let name_bytes = class_name.as_bytes();
+                        buf.push(tag);
+                        marshal_write_fixnum(buf, name_bytes.len() as i32);
+                        buf.extend_from_slice(name_bytes);
+                    }
                     Some(ObjTy::RANGE) => {
                         // Serialize Range as a generic 'o' object with the
                         // three ivars CRuby uses: @begin, @end, @excl.
@@ -1475,6 +1562,72 @@ mod tests {
             s = MStructInherited.new("a", "b")
             t = Marshal.load(Marshal.dump(s))
             [t.class.name, t.p, t.q]
+            "##,
+        );
+    }
+
+    /// 'c' (TYPE_CLASS), 'm' (TYPE_MODULE) and 'M' (TYPE_MODULE_OLD)
+    /// references: round-trip yields the same object (`.equal?`) and
+    /// the tag/type mismatch arms both raise `TypeError`.
+    #[test]
+    fn marshal_class_and_module() {
+        // Round-trip a class via 'c'.
+        run_test(
+            r##"
+            bytes = Marshal.dump(String)
+            t = Marshal.load(bytes)
+            [t.equal?(String), bytes.bytes[2].chr]
+            "##,
+        );
+        // Round-trip a module via 'm'.
+        run_test(
+            r##"
+            bytes = Marshal.dump(Enumerable)
+            t = Marshal.load(bytes)
+            [t.equal?(Enumerable), bytes.bytes[2].chr]
+            "##,
+        );
+        // 'M' (TYPE_MODULE_OLD) accepts both classes and modules.
+        // Hand-crafted bytes since CRuby no longer emits this tag.
+        run_test(
+            r##"
+            # 'M' + length(6 ⇒ marshal_int 0x0b) + "String"
+            class_bytes  = "\x04\x08M\x0bString"
+            # 'M' + length(10 ⇒ marshal_int 0x0f) + "Enumerable"
+            module_bytes = "\x04\x08M\x0fEnumerable"
+            [Marshal.load(class_bytes).equal?(String),
+             Marshal.load(module_bytes).equal?(Enumerable)]
+            "##,
+        );
+        // 'c' naming a Module ⇒ TypeError.
+        run_test_error(
+            r##"
+            Marshal.load(Marshal.dump(Enumerable).sub("m", "c"))
+            "##,
+        );
+        // 'm' naming a Class ⇒ TypeError.
+        run_test_error(
+            r##"
+            Marshal.load(Marshal.dump(String).sub("c", "m"))
+            "##,
+        );
+        // 'c' naming a constant that does not exist ⇒ ArgumentError.
+        run_test_error(
+            r##"
+            # 'c' + length(13 ⇒ marshal_int 0x12) + "MMissingClass"
+            Marshal.load("\x04\x08c\x12MMissingClass")
+            "##,
+        );
+        // Dump of an anonymous class ⇒ TypeError.
+        run_test_error(
+            r##"
+            Marshal.dump(Class.new)
+            "##,
+        );
+        // Dump of an anonymous module ⇒ TypeError.
+        run_test_error(
+            r##"
+            Marshal.dump(Module.new)
             "##,
         );
     }


### PR DESCRIPTION
## Summary

CRuby's marshal format for a *bare* class or module reference:

```
'c' + length(varint) + name-bytes   # TYPE_CLASS
'm' + length(varint) + name-bytes   # TYPE_MODULE
'M' + length(varint) + name-bytes   # TYPE_MODULE_OLD (legacy)
```

The first two enforce a kind check on load (`'c'` requires a Class, `'m'` requires a Module; mismatch ⇒ `TypeError`). `'M'` is the Ruby 1.8 tag that accepts either — CRuby no longer emits it but still loads it.

monoruby previously dropped all three into the generic "unsupported marshal type tag" arm. Both the load and dump paths are now wired.

### Load
Each handler reads a length-prefixed UTF-8 name string, resolves it via the existing `resolve_class_path` helper (qualified paths like `Foo::Bar` walk segment-by-segment off `Object`), and runs the kind check before returning the resolved class/module. Missing constants raise `ArgumentError`, kind mismatches raise `TypeError`, matching CRuby's `r_object0` arms.

### Dump
`ObjTy::CLASS` / `ObjTy::MODULE` join the dispatch in `marshal_dump_value`: pick `'c'` or `'m'` based on the type, write the qualified class path (from `get_class_name`) as a length-prefixed string. Anonymous classes/modules (which `get_class_name` renders as `#<Class:0x...>`) raise `TypeError`, matching CRuby's "can't dump anonymous class/module".

Byte-exact match with CRuby's `Marshal.dump(String)`, `Marshal.dump(Enumerable)`, and round-trip via `.equal?`.

## Impact on `core/marshal` ruby/spec

|        | examples |   F |   E |
|--------|---------:|----:|----:|
| before |      717 | 143 | 167 |
| after  |      717 | 148 | **134** |

E drops 167 → **134 (−33)**; passing assertions +43 (680 → 723). F goes up 5 because previously-aborted reads now reach their downstream assertions. All `'c'`, `'m'`, `'M'` clusters (14 E combined) are gone, plus 19 downstream specs that previously errored on the `'U'` round-trip path because the embedded class reference couldn't load. Only `'d'` (TYPE_DATA, 4 E) remains in the tag-error cluster.

## Test plan

- [x] `cargo test --lib -p monoruby -- marshal::tests::marshal_class_and_module` ⇒ pass
- [x] All 19 marshal lib tests pass under both prism and ruruby
- [x] `mspec core/marshal` E: 167 → 134 (−33); no other regressions
- [x] CRuby byte-for-byte match on `Marshal.dump(String)` and `Marshal.dump(Enumerable)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_