### PR TITLE
feat(kernel): raise honors cause: kwarg and #exception duck-type (−7 E)

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -579,14 +579,8 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 args.push(arg1);
             }
         }
-        let result = vm.invoke_method_inner(
-            globals,
-            exception_id,
-            lfp.arg(0),
-            &args,
-            None,
-            None,
-        )?;
+        let result =
+            vm.invoke_method_inner(globals, exception_id, lfp.arg(0), &args, None, None)?;
         match result.is_exception() {
             Some(ex) => return Err(MonorubyErr::new_from_exception(ex)),
             None => return Err(MonorubyErr::typeerr("exception object expected")),
@@ -5566,6 +5560,9 @@ mod tests {
         );
         // `fail` aliases `raise` — the cause-only path applies too.
         run_test_error(r#"fail(cause: nil)"#);
+        // Bare `raise` with no current exception ⇒ RuntimeError
+        // (the `$!`-reraise fallthrough).
+        run_test_error(r#"raise"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -44,8 +44,29 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         Effect::CAPTURE | Effect::BINDING,
     );
     globals.define_builtin_module_func(kernel_class, "loop", loop_, 0);
-    globals.define_builtin_module_func_with(kernel_class, "raise", raise, 0, 3, false);
-    globals.define_builtin_module_func_with(kernel_class, "fail", raise, 0, 2, false);
+    globals.define_builtin_module_func_with_kw(
+        kernel_class,
+        "raise",
+        raise,
+        0,
+        3,
+        false,
+        &["cause"],
+        false,
+    );
+    // CRuby aliases `fail` to the same `rb_f_raise` callback (variadic).
+    // Use the identical signature so `cause:` ends up at the same
+    // `lfp.try_arg(3)` slot in the shared trampoline.
+    globals.define_builtin_module_func_with_kw(
+        kernel_class,
+        "fail",
+        raise,
+        0,
+        3,
+        false,
+        &["cause"],
+        false,
+    );
     globals.define_builtin_module_inline_func(
         kernel_class,
         "block_given?",
@@ -500,7 +521,17 @@ fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/fail.html]
 #[monoruby_builtin]
 fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // `cause:` kwarg is at slot 3 (positional_max=3 for the shared
+    // raise/fail trampoline). CRuby: passing `cause:` with no
+    // positional arguments raises `ArgumentError "only cause is given
+    // with no arguments"`.
+    let has_cause = lfp.try_arg(3).is_some();
     if lfp.try_arg(0).is_none() {
+        if has_cause {
+            return Err(MonorubyErr::argumenterr(
+                "only cause is given with no arguments",
+            ));
+        }
         let ex = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
         if let Some(ex) = ex.is_exception() {
             return Err(MonorubyErr::new_from_exception(ex));
@@ -533,6 +564,33 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         }
     } else if let Some(message) = lfp.arg(0).is_rstring() {
         return Err(MonorubyErr::runtimeerr(message.to_str()?));
+    }
+    // Duck-typed exception. CRuby drives `arg0.exception(msg)` (or
+    // `arg0.exception` if no message was given); the result must be
+    // an Exception instance — anything else is `TypeError "exception
+    // object expected"` (note: distinct from the
+    // "exception class/object expected" emitted when arg0 doesn't
+    // even respond to `#exception`).
+    let exception_id = IdentId::get_id("exception");
+    if globals.check_method(lfp.arg(0), exception_id).is_some() {
+        let mut args = vec![];
+        if let Some(arg1) = lfp.try_arg(1) {
+            if arg1.try_hash_ty().is_none() {
+                args.push(arg1);
+            }
+        }
+        let result = vm.invoke_method_inner(
+            globals,
+            exception_id,
+            lfp.arg(0),
+            &args,
+            None,
+            None,
+        )?;
+        match result.is_exception() {
+            Some(ex) => return Err(MonorubyErr::new_from_exception(ex)),
+            None => return Err(MonorubyErr::typeerr("exception object expected")),
+        }
     }
     Err(MonorubyErr::typeerr("exception class/object expected"))
 }
@@ -5464,6 +5522,50 @@ mod tests {
     fn kernel_raise_class() {
         run_test_error("raise ArgumentError");
         run_test_error(r#"raise TypeError, "custom""#);
+    }
+
+    /// `raise(cause:)` with no positional args ⇒ ArgumentError,
+    /// `raise(obj)` where `obj.exception` returns an Exception ⇒
+    /// raise that, and `obj.exception` returning a non-Exception ⇒
+    /// `TypeError "exception object expected"`.
+    #[test]
+    fn kernel_raise_cause_and_duck() {
+        run_test(
+            r##"
+            results = []
+            # cause: only ⇒ ArgumentError "only cause is given with no arguments"
+            begin
+              raise(cause: nil)
+            rescue ArgumentError => e
+              results << [e.class.name, e.message]
+            end
+            # obj.exception(msg) returning an Exception
+            obj = Object.new
+            def obj.exception(msg); StandardError.new(msg); end
+            begin
+              raise obj, "hi"
+            rescue => e
+              results << [e.class.name, e.message]
+            end
+            # obj.exception returning non-Exception ⇒ TypeError "exception object expected"
+            bad = Object.new
+            def bad.exception; Array; end
+            begin
+              raise bad
+            rescue TypeError => e
+              results << [e.class.name, e.message]
+            end
+            # Plain object with no #exception ⇒ TypeError "exception class/object expected"
+            begin
+              raise 42
+            rescue TypeError => e
+              results << [e.class.name, e.message]
+            end
+            results
+            "##,
+        );
+        // `fail` aliases `raise` — the cause-only path applies too.
+        run_test_error(r#"fail(cause: nil)"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CRuby's `Kernel#raise` (and its alias `#fail`):
1. Accepts any object that responds to `#exception` by calling `obj.exception(msg)` and using the returned Exception.
2. Raises `TypeError "exception object expected"` — distinct from the existing `"exception class/object expected"` — when that `#exception` method returns a non-Exception.
3. Raises `ArgumentError "only cause is given with no arguments"` when called with no positional args but a `cause:` keyword.

monoruby was treating the `cause:` keyword as a positional hash (no kwarg metadata on the builtin registration), so any `raise(cause: ...)` fell through to the bare `"exception class/object expected"` arm. It also lacked the `#exception` duck-typing path entirely.

### Changes
- Switch the `raise` / `fail` registration from `define_builtin_module_func_with` to `_with_kw` with `&["cause"]`. Both aliases share the same trampoline so they use the same positional max (3) and the kwarg slot lands at `lfp.try_arg(3)`.
- In the shared body, fast-path the `cause:`-only case to `ArgumentError`.
- After the existing Exception / Class / String dispatch, probe arg0 for a `#exception` method and drive `arg0.exception(msg)` (or `arg0.exception` if no message) — matching CRuby's `rb_make_exception` duck-type path.

## Impact on `core/kernel` ruby/spec

|        | examples |   F |   E |
|--------|---------:|----:|----:|
| before |     2821 | 278 | 191 |
| after  |     2821 | 277 | **184** |

E drops 191 → **184 (−7)**; F −1; passing assertions +8. The 7 `"exception class/object expected"` cluster across `raise` / `fail` / `cause:` specs is resolved.

## Test plan

- [x] `cargo test --lib -p monoruby -- kernel_raise` ⇒ 2 pass
- [x] Same under `MONORUBY_PARSER=ruruby` ⇒ 2 pass
- [x] `mspec core/kernel` E: 191 → 184 (−7); no other regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_