### PR TITLE
feat(file): real File::Stat backed by stat(2)/lstat(2) (−84 E)

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -303,39 +303,92 @@ end
 
 
 class File
+  # File::Stat — the fields (@dev, @ino, @mode, @nlink, @uid, @gid,
+  # @rdev, @size, @blksize, @blocks, @atime, @mtime, @ctime) are
+  # populated from a real stat(2)/lstat(2) by the Rust constructor
+  # (`File.stat`, `File.lstat`, `File::Stat.new`). The accessors and
+  # mode-bit predicates below read those fields.
   class Stat
-    def initialize(path)
-      @path = path
-      @mode = File.exist?(path) ? 0o755 : 0
+    include Comparable
+
+    attr_reader :dev, :ino, :mode, :nlink, :uid, :gid, :rdev,
+                :size, :blksize, :blocks, :atime, :mtime, :ctime
+
+    S_IFMT   = 0o170000
+    S_IFSOCK = 0o140000
+    S_IFLNK  = 0o120000
+    S_IFREG  = 0o100000
+    S_IFBLK  = 0o060000
+    S_IFDIR  = 0o040000
+    S_IFCHR  = 0o020000
+    S_IFIFO  = 0o010000
+
+    def directory? ; (@mode & S_IFMT) == S_IFDIR  ; end
+    def file?      ; (@mode & S_IFMT) == S_IFREG  ; end
+    def symlink?   ; (@mode & S_IFMT) == S_IFLNK  ; end
+    def blockdev?  ; (@mode & S_IFMT) == S_IFBLK  ; end
+    def chardev?   ; (@mode & S_IFMT) == S_IFCHR  ; end
+    def pipe?      ; (@mode & S_IFMT) == S_IFIFO  ; end
+    def socket?    ; (@mode & S_IFMT) == S_IFSOCK ; end
+
+    def ftype
+      case @mode & S_IFMT
+      when S_IFREG  then "file"
+      when S_IFDIR  then "directory"
+      when S_IFCHR  then "characterSpecial"
+      when S_IFBLK  then "blockSpecial"
+      when S_IFIFO  then "fifo"
+      when S_IFLNK  then "link"
+      when S_IFSOCK then "socket"
+      else "unknown"
+      end
+    end
+
+    def setuid?  ; (@mode & 0o4000) != 0 ; end
+    def setgid?  ; (@mode & 0o2000) != 0 ; end
+    def sticky?  ; (@mode & 0o1000) != 0 ; end
+
+    def world_readable?
+      (@mode & 0o004) != 0 ? (@mode & 0o777) : nil
     end
 
     def world_writable?
-      (@mode & 0o002) != 0
+      (@mode & 0o002) != 0 ? (@mode & 0o777) : nil
     end
 
-    def sticky?
-      (@mode & 0o1000) != 0
+    def zero?     ; @size == 0 ; end
+    def size?     ; @size == 0 ? nil : @size ; end
+
+    def owned?    ; @uid == Process.euid ; end
+    def grpowned? ; @gid == Process.egid ; end
+
+    def readable?       ; (@mode & 0o400) != 0 ; end
+    def readable_real?  ; readable? ; end
+    def writable?       ; (@mode & 0o200) != 0 ; end
+    def writable_real?  ; writable? ; end
+    def executable?     ; (@mode & 0o100) != 0 ; end
+    def executable_real? ; executable? ; end
+
+    def dev_major  ; @dev >> 8 ; end
+    def dev_minor  ; @dev & 0xff ; end
+    def rdev_major ; @rdev >> 8 ; end
+    def rdev_minor ; @rdev & 0xff ; end
+
+    def birthtime
+      raise NotImplementedError, "birthtime() function is unimplemented"
     end
 
-    def directory?
-      File.directory?(@path)
+    def <=>(other)
+      return nil unless other.is_a?(File::Stat)
+      @mtime <=> other.mtime
     end
 
-    def file?
-      File.file?(@path)
+    def inspect
+      "#<File::Stat dev=0x#{@dev.to_s(16)}, ino=#{@ino}, mode=0#{@mode.to_s(8)}, " \
+      "nlink=#{@nlink}, uid=#{@uid}, gid=#{@gid}, rdev=0x#{@rdev.to_s(16)}, " \
+      "size=#{@size}, blksize=#{@blksize}, blocks=#{@blocks}, " \
+      "atime=#{@atime}, mtime=#{@mtime}, ctime=#{@ctime}>"
     end
-
-    def size
-      File.size(@path)
-    end
-  end
-
-  def self.stat(path)
-    Stat.new(path)
-  end
-
-  def self.lstat(path)
-    stat(path)
   end
 end
 

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -3446,4 +3446,25 @@ mod tests {
         run_test_error(r#"File.stat("/nonexistent_monoruby_stat_path_xyz")"#);
         run_test_error(r#"File::Stat.new("/nonexistent_monoruby_stat_path_xyz")"#);
     }
+
+    #[test]
+    fn file_instance_stat_method() {
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_test_instat_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "rubinius")
+              f = File.open(path)
+              begin
+                s = f.stat
+                [s.class.name, s.size, s.file?]
+              ensure
+                f.close
+              end
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -161,6 +161,19 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(file, "ctime", file_ctime, 1);
     globals.define_builtin_class_func(file, "birthtime", file_birthtime, 1);
 
+    // File::Stat — the class body (accessors / predicates) lives in
+    // `builtins/builtins.rb`; here we own construction. `File.stat`,
+    // `File.lstat`, and `File::Stat.new` all populate the fields from
+    // a real stat(2) / lstat(2), raising the matching Errno on
+    // failure. The instance ivars (@dev, @ino, …) are read by the
+    // Ruby accessors.
+    let object_class = globals.store.object_class();
+    let stat = globals.define_class("Stat", object_class, file).id();
+    globals.define_builtin_class_func(file, "stat", file_stat, 1);
+    globals.define_builtin_class_func(file, "lstat", file_lstat, 1);
+    globals.define_builtin_func(stat, "initialize", stat_initialize, 1);
+    globals.define_builtin_func(file, "stat", file_instance_stat, 0);
+
     globals.define_builtin_singleton_func(
         globals.get_load_path(),
         "resolve_feature_path",
@@ -2233,6 +2246,150 @@ fn file_birthtime(
     file_time_attr(vm, globals, lfp, |m| m.created())
 }
 
+/// Build a `Time` value from a (seconds, nanoseconds) pair via
+/// `Time.at(secs, nsec, :nanosecond)`.
+fn time_from_secs_nsec(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    secs: i64,
+    nsec: i64,
+) -> Result<Value> {
+    let time_class = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Time"))
+        .ok_or_else(|| MonorubyErr::runtimeerr("Time class not defined"))?;
+    let at = IdentId::get_id("at");
+    let unit = Value::symbol(IdentId::get_id("nanosecond"));
+    vm.invoke_method_inner(
+        globals,
+        at,
+        time_class,
+        &[Value::integer(secs), Value::integer(nsec), unit],
+        None,
+        None,
+    )
+}
+
+/// Populate a `File::Stat` instance's ivars from a `std::fs::Metadata`
+/// (which wraps a `struct stat`). The Ruby accessors in
+/// `builtins/builtins.rb` read these fields.
+fn fill_stat_ivars(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    mut obj: Value,
+    metadata: &std::fs::Metadata,
+) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    let pairs: &[(&str, i64)] = &[
+        ("@dev", metadata.dev() as i64),
+        ("@ino", metadata.ino() as i64),
+        ("@mode", metadata.mode() as i64),
+        ("@nlink", metadata.nlink() as i64),
+        ("@uid", metadata.uid() as i64),
+        ("@gid", metadata.gid() as i64),
+        ("@rdev", metadata.rdev() as i64),
+        ("@size", metadata.size() as i64),
+        ("@blksize", metadata.blksize() as i64),
+        ("@blocks", metadata.blocks() as i64),
+    ];
+    for (name, val) in pairs {
+        obj.set_instance_var(&mut globals.store, name, Value::integer(*val))?;
+    }
+    let atime = time_from_secs_nsec(vm, globals, metadata.atime(), metadata.atime_nsec())?;
+    let mtime = time_from_secs_nsec(vm, globals, metadata.mtime(), metadata.mtime_nsec())?;
+    let ctime = time_from_secs_nsec(vm, globals, metadata.ctime(), metadata.ctime_nsec())?;
+    obj.set_instance_var(&mut globals.store, "@atime", atime)?;
+    obj.set_instance_var(&mut globals.store, "@mtime", mtime)?;
+    obj.set_instance_var(&mut globals.store, "@ctime", ctime)?;
+    Ok(())
+}
+
+/// Build a fresh `File::Stat` object for `path`. When `follow` is
+/// true, symlinks are dereferenced (stat(2)); otherwise the link
+/// itself is described (lstat(2)).
+fn build_stat(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    path_val: Value,
+    follow: bool,
+) -> Result<Value> {
+    let path = to_path(vm, globals, path_val)?;
+    let path_str = path.to_string_lossy().to_string();
+    let metadata = if follow {
+        std::fs::metadata(&path)
+    } else {
+        std::fs::symlink_metadata(&path)
+    }
+    .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path_str))?;
+    let stat_class = vm
+        .get_qualified_constant(globals, OBJECT_CLASS, &["File", "Stat"])?
+        .as_class();
+    let obj = Value::object(stat_class.id());
+    fill_stat_ivars(vm, globals, obj, &metadata)?;
+    Ok(obj)
+}
+
+///
+/// ### File.stat
+/// - stat(path) -> File::Stat
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/s/stat.html]
+#[monoruby_builtin]
+fn file_stat(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    build_stat(vm, globals, lfp.arg(0), true)
+}
+
+///
+/// ### File.lstat
+/// - lstat(path) -> File::Stat
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/s/lstat.html]
+#[monoruby_builtin]
+fn file_lstat(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    build_stat(vm, globals, lfp.arg(0), false)
+}
+
+///
+/// ### File#stat
+/// - stat -> File::Stat
+///
+/// Instance method: stats the path the File was opened with.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/i/stat.html]
+#[monoruby_builtin]
+fn file_instance_stat(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let path = match lfp.self_val().as_io_inner().path() {
+        Some(p) => Value::string(p),
+        None => return Err(MonorubyErr::runtimeerr("File#stat: no path for this stream")),
+    };
+    build_stat(vm, globals, path, true)
+}
+
+///
+/// ### File::Stat.new
+/// - new(path) -> File::Stat
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File=3a=3aStat/s/new.html]
+#[monoruby_builtin]
+fn stat_initialize(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let path = to_path(vm, globals, lfp.arg(0))?;
+    let path_str = path.to_string_lossy().to_string();
+    let metadata = std::fs::metadata(&path)
+        .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_stat_new", &path_str))?;
+    fill_stat_ivars(vm, globals, lfp.self_val(), &metadata)?;
+    Ok(Value::nil())
+}
+
 ///
 /// ### File.identical?
 /// - identical?(file1, file2) -> bool
@@ -3246,5 +3403,47 @@ mod tests {
             end
             "#,
         );
+    }
+
+    #[test]
+    fn file_stat_fields_and_predicates() {
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_test_stat_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "rubinius")
+              s = File.stat(path)
+              [
+                s.class.name,
+                s.size,
+                s.file?,
+                s.directory?,
+                s.ino.is_a?(Integer),
+                s.mode.is_a?(Integer),
+                s.nlink.is_a?(Integer),
+                s.uid.is_a?(Integer),
+                s.gid.is_a?(Integer),
+                s.ftype,
+                s.zero?,
+                s.size?,
+                s.mtime.is_a?(Time),
+                s.blksize.is_a?(Integer),
+                s.blocks.is_a?(Integer),
+                File::Stat.new(path).file?,
+                File.lstat(path).file?,
+              ]
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        // Directory ftype / predicate.
+        run_test_once(r#"[File.stat("/tmp").directory?, File.stat("/tmp").ftype]"#);
+    }
+
+    #[test]
+    fn file_stat_missing_raises() {
+        run_test_error(r#"File.stat("/nonexistent_monoruby_stat_path_xyz")"#);
+        run_test_error(r#"File::Stat.new("/nonexistent_monoruby_stat_path_xyz")"#);
     }
 }


### PR DESCRIPTION
## Summary

The old `File::Stat` was a stub that faked `@mode = 0o755` and only exposed `directory?` / `file?` / `size` / `world_writable?` / `sticky?` by re-dispatching to `File.*`. Every other accessor (`ino`, `mode`, `dev`, `nlink`, `uid`, `gid`, `rdev`, `blksize`, `blocks`, `atime`, `mtime`, `ctime`, …) raised `NoMethodError`.

### Construction (Rust)
`File.stat` / `File.lstat` / `File::Stat.new` now run a real `std::fs::metadata` / `symlink_metadata` (i.e. stat(2) / lstat(2)), raise the matching `Errno` on failure, and populate the instance's fields from `MetadataExt` (`@dev`, `@ino`, `@mode`, `@nlink`, `@uid`, `@gid`, `@rdev`, `@size`, `@blksize`, `@blocks`, plus `@atime` / `@mtime` / `@ctime` as `Time` values built via `Time.at(secs, nsec, :nanosecond)`). `File#stat` stats the open stream's path. The `Stat` class is defined in Rust so construction owns the fields; the accessors live in Ruby.

### Accessors / predicates (Ruby)
`builtins/builtins.rb`'s `File::Stat` gains the full surface: attr-style readers, the `S_IF*` ftype/predicate family (`file?`, `directory?`, `symlink?`, `blockdev?`, `chardev?`, `pipe?`, `socket?`, `ftype`), permission bits (`setuid?`, `setgid?`, `sticky?`, `world_readable?`, `world_writable?`, `readable?`/`writable?`/`executable?` + `_real?`), `zero?`, `size?`, `owned?`, `grpowned?`, `dev_major`/`minor`, `rdev_major`/`minor`, `<=>` (Comparable on mtime), and `inspect`. `birthtime` raises `NotImplementedError`, matching CRuby on filesystems without birth time.

## Impact on ruby/spec

| suite            | E before | E after |
|------------------|---------:|--------:|
| core/file/stat   |       86 |   **2** |
| core/dir         |        8 |   **5** |

core/file/stat E drops 86 → 2 (the residual 2 are socket-file specs that need `UNIXServer`, which monoruby lacks). Passing expectations there climb 68 → 168.

## Test plan

- [x] `cargo test --lib -p monoruby -- file_stat` ⇒ 3 pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::file builtins::dir builtins::io` ⇒ 194 pass
- [x] `mspec core/file/stat` E: 86 → 2; `core/dir` E: 8 → 5
- [x] CRuby parity on fields / predicates for regular files & dirs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_