### PR TITLE
feat: frame-local $~ / $_ via LFP_SVAR slot (CRuby vm_svar semantics)

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -682,7 +682,7 @@ fn flush(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/gets.html]
 #[monoruby_builtin]
-fn gets(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn gets(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
     let line = self_.as_io_inner_mut().read_line()?;
     match line {
@@ -698,11 +698,13 @@ fn gets(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 .set_ivar(self_, IdentId::get_id("/lineno"), Value::integer(n))?;
             globals.set_gvar(IdentId::get_id("$."), Value::integer(n));
             let s = tagged_read_string(globals, self_, buf.into_bytes(), false);
-            globals.set_gvar(IdentId::get_id("$_"), s);
+            // `$_` is frame-local: set it on the calling Ruby scope's
+            // LEP (the builtin's own native frame is skipped).
+            vm.set_last_read_line(s);
             Ok(s)
         }
         None => {
-            globals.set_gvar(IdentId::get_id("$_"), Value::nil());
+            vm.set_last_read_line(Value::nil());
             Ok(Value::nil())
         }
     }

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1082,11 +1082,13 @@ fn regexp_timeout_set(
 #[monoruby_builtin]
 fn regexp_tilde(
     vm: &mut Executor,
-    globals: &mut Globals,
+    _globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let target = globals.get_gvar(IdentId::get_id("$_")).unwrap_or_default();
+    // `$_` is frame-local; read it from the calling scope's LEP
+    // (the `~` builtin's own native frame is skipped).
+    let target = vm.get_last_read_line();
     if target.is_nil() {
         vm.clear_capture_special_variables();
         return Ok(Value::nil());

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -437,6 +437,12 @@ impl JitModule {
         monoasm! { &mut self.jit,
             // set outer
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], rax;
+            // SVAR / CME are unused by block frames (they walk the
+            // outer chain to the LEP for `$~`); zero them so any stray
+            // reader sees a clean "absent" sentinel and so the GC
+            // doesn't follow uninitialised stack memory.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
     }
 
@@ -444,6 +450,11 @@ impl JitModule {
     fn set_method_outer(&mut self) {
         monoasm! { &mut self.jit,
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], 0;
+            // Method-introducing frame: own SVAR slot starts unset
+            // (zero = "no MatchData captured"). CME also zero for
+            // now — reserved for a future migration.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/method_call.rs
@@ -136,6 +136,8 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], rdi;
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], 0;
             movq rax, [rdi - (LFP_SELF)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF)], rax;
@@ -176,6 +178,12 @@ impl Codegen {
         monoasm! { &mut self.jit,
             movq rax, (meta.get());
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
+            // SVAR / CME slots — zero-fill so the GC mark walker
+            // never dereferences uninitialised stack memory. Lazy
+            // `$~` allocation rewrites SVAR on first MatchData; CME
+            // stays zero pending its own migration.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         }
         self.set_block(callsite.block_fid, callsite.block_arg);
         monoasm! { &mut self.jit,
@@ -209,6 +217,11 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], rdi;
             movq  rax, (meta.get());
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
+            // Yield builds a block frame — SVAR/CME are unused by
+            // block-style callees (they resolve via outer chain),
+            // but zero them so the GC mark walker stays sound.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], 0;
             movq rax, [rdi - (LFP_SELF)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF)], rax;
@@ -428,6 +441,10 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], 0;
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
+            // Zero SVAR/CME — method-introducing frame's lazy `$~`
+            // container is allocated on first MatchData write.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
         self.set_block(block_fid, block_arg);
         monoasm!( &mut self.jit,

--- a/monoruby/src/codegen/vmgen/method_call.rs
+++ b/monoruby/src/codegen/vmgen/method_call.rs
@@ -184,6 +184,11 @@ impl Codegen {
             // set meta
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
+            // SVAR / CME: zero-fill so the GC mark walker stays
+            // sound. Lazy `$~` allocation writes SVAR on first
+            // MatchData; CME stays zero pending its own migration.
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
+            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         }
         monoasm! { &mut self.jit,
             movzxw r9, [r13 + (POS_NUM)];

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -53,8 +53,25 @@ pub(crate) const LFP_META: i32 = 8;
 pub(crate) const LFP_REGNUM: i32 = LFP_META - META_REGNUM as i32;
 /// Meta::FuncId 4bytes
 pub(crate) const LFP_FUNCID: i32 = LFP_META + META_FUNCID as i32;
-pub(crate) const LFP_BLOCK: i32 = 16;
-pub(crate) const LFP_SELF: i32 = 24;
+/// Special variables (frame-local `$~`, planned `$_`).
+///
+/// CRuby's `vm_svar` lives on the LEP (= the method-introducing
+/// frame's local environment); blocks and `Proc.new`-style closures
+/// share their lexical parent's slot. monoruby mirrors this by
+/// resolving `$~` (and the BACK_REF / NTH_REF family derived from it)
+/// through the outer chain to the LEP's `LFP_SVAR`. Stored as a raw
+/// `u64`: `0` means "no MatchData captured yet" (faster than always
+/// allocating a SpecialVars container); any non-zero value is a
+/// MatchData `Value`.
+pub(crate) const LFP_SVAR: i32 = 16;
+/// Callable Method Entry — reserved for the upcoming CME slot. CRuby
+/// uses `cref_or_me` at the same position in `vm_svar`; monoruby keeps
+/// the slot separate so the SVAR migration above can land without
+/// blocking on the larger CME redesign. Initialised to `0`; no reads
+/// or writes wired up yet.
+pub(crate) const LFP_CME: i32 = 24;
+pub(crate) const LFP_BLOCK: i32 = 32;
+pub(crate) const LFP_SELF: i32 = 40;
 pub const LFP_ARG0: i32 = LFP_SELF + 8;
 
 pub(crate) const EXECUTOR_CFP: i64 = std::mem::offset_of!(Executor, cfp) as _;

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -60,9 +60,10 @@ pub(crate) const LFP_FUNCID: i32 = LFP_META + META_FUNCID as i32;
 /// share their lexical parent's slot. monoruby mirrors this by
 /// resolving `$~` (and the BACK_REF / NTH_REF family derived from it)
 /// through the outer chain to the LEP's `LFP_SVAR`. Stored as a raw
-/// `u64`: `0` means "no MatchData captured yet" (faster than always
-/// allocating a SpecialVars container); any non-zero value is a
-/// MatchData `Value`.
+/// `u64`: `0` means "no special variables set in this scope yet"
+/// (the lazy-allocation sentinel); any non-zero value is a 2-element
+/// `Array` `Value` container `[$~, $_]` (see `SVAR_BACKREF` /
+/// `SVAR_LASTLINE`).
 pub(crate) const LFP_SVAR: i32 = 16;
 /// Callable Method Entry — reserved for the upcoming CME slot. CRuby
 /// uses `cref_or_me` at the same position in `vm_svar`; monoruby keeps
@@ -73,6 +74,13 @@ pub(crate) const LFP_CME: i32 = 24;
 pub(crate) const LFP_BLOCK: i32 = 32;
 pub(crate) const LFP_SELF: i32 = 40;
 pub const LFP_ARG0: i32 = LFP_SELF + 8;
+
+/// Index of `$~` (the MatchData backref) inside the `LFP_SVAR`
+/// container Array.
+const SVAR_BACKREF: usize = 0;
+/// Index of `$_` (the last line read by `gets` / `readline`) inside
+/// the `LFP_SVAR` container Array.
+const SVAR_LASTLINE: usize = 1;
 
 pub(crate) const EXECUTOR_CFP: i64 = std::mem::offset_of!(Executor, cfp) as _;
 pub(crate) const EXECUTOR_RSP_SAVE: i64 = std::mem::offset_of!(Executor, rsp_save) as _;
@@ -2199,19 +2207,52 @@ impl Executor {
         Some(cfp.lfp().lep())
     }
 
-    /// Read the MatchData `Value` stashed on the current LEP's
-    /// `LFP_SVAR` slot. The slot only ever holds zero (the "unset"
-    /// sentinel) or a valid MatchData `Value`, so callers can safely
-    /// `.as_match_data()` the result.
-    pub(crate) fn current_match_data(&self) -> Option<Value> {
+    /// Read the svar container Array on the current LEP, if one has
+    /// been allocated. The slot starts as the zero sentinel (`None`)
+    /// and is lazily filled with a 2-element Array `[$~, $_]` the
+    /// first time either special variable is written.
+    fn svar_container(&self) -> Option<Value> {
         self.current_lep()?.svar()
     }
 
+    /// Get the svar container on the current LEP, allocating a fresh
+    /// `[nil, nil]` Array (and storing it in `LFP_SVAR`) if absent.
+    /// Returns `None` only outside Ruby execution (no LEP).
+    fn svar_container_create(&mut self) -> Option<Value> {
+        let lep = self.current_lep()?;
+        match lep.svar() {
+            Some(v) => Some(v),
+            None => {
+                let arr = Value::array_from_vec(vec![Value::nil(), Value::nil()]);
+                lep.set_svar_slot_value(arr);
+                Some(arr)
+            }
+        }
+    }
+
+    /// Read the MatchData `Value` (`$~`) from the current LEP's svar
+    /// container, or `None` when unset / nil.
+    pub(crate) fn current_match_data(&self) -> Option<Value> {
+        let c = self.svar_container()?;
+        let v = c.as_array()[SVAR_BACKREF];
+        if v.is_nil() { None } else { Some(v) }
+    }
+
+    /// Write `$~` (a MatchData `Value` or nil) into the current LEP's
+    /// svar container.
+    fn set_backref(&mut self, val: Value) {
+        if let Some(c) = self.svar_container_create() {
+            c.as_array()[SVAR_BACKREF] = val;
+        }
+    }
+
     pub(crate) fn clear_capture_special_variables(&mut self) {
-        // Bootstrap (e.g. `Executor::init` clearing stale state after
-        // startup.rb) runs with no CFP — nothing to clear yet.
-        if let Some(lep) = self.current_lep() {
-            lep.set_svar_slot_zero();
+        // CRuby's `$~ = nil` clears only the backref; `$_` is
+        // untouched. Skip silently before the first CFP exists
+        // (bootstrap), and don't bother allocating a container just
+        // to store nil.
+        if let Some(c) = self.svar_container() {
+            c.as_array()[SVAR_BACKREF] = Value::nil();
         }
         self.sp_match_regex = None;
     }
@@ -2225,7 +2266,7 @@ impl Executor {
     ///
     /// Build a `MatchData` from `captures` + `haystack` (plus the
     /// transient `sp_match_regex` stash) and store it as the current
-    /// scope's `$~` on the LEP's `LFP_SVAR` slot.
+    /// scope's `$~` on the LEP's svar container.
     ///
     pub(crate) fn save_capture_special_variables<'h>(
         &mut self,
@@ -2243,10 +2284,24 @@ impl Executor {
             md = md.with_regex(regex);
         }
         let md_val = RValue::new_match_data_from_inner(md).pack();
-        if let Some(lep) = self.current_lep() {
-            lep.set_svar_slot_value(md_val);
-        }
+        self.set_backref(md_val);
         self.sp_match_regex = None;
+    }
+
+    /// `$_` reader — the last line read by `gets` / `readline` in the
+    /// current scope (frame-local, like `$~`). `nil` when unset.
+    pub(crate) fn get_last_read_line(&self) -> Value {
+        match self.svar_container() {
+            Some(c) => c.as_array()[SVAR_LASTLINE],
+            None => Value::nil(),
+        }
+    }
+
+    /// `$_` writer.
+    pub(crate) fn set_last_read_line(&mut self, val: Value) {
+        if let Some(c) = self.svar_container_create() {
+            c.as_array()[SVAR_LASTLINE] = val;
+        }
     }
 
     /// `MatchData#[]` semantics for `$n` access (0 = full match,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -102,16 +102,14 @@ pub struct Executor {
     /// bare `private` / `public` / `protected`. CRuby's top-level
     /// default is `private`.
     toplevel_visibility: Visibility,
-    sp_last_match: Option<String>,   // $&        : Regexp.last_match(0)
-    sp_pre_match: Option<String>,    // $`        : Regexp.pre_match
-    sp_post_match: Option<String>,   // $'        : Regexp.post_match
-    sp_matches: Vec<Option<String>>, // $&, $1 ... $n : Regexp.last_match(n)
-    sp_match_positions: Vec<Option<(usize, usize)>>, // byte positions for MatchData
-    sp_match_haystack: Option<String>, // haystack for MatchData
-    /// The Regexp Value the most recent successful match was
-    /// performed against. Stashed here so `Regexp.last_match`
-    /// constructs a `MatchData` with `regex` populated, which the
-    /// `MatchData#[]` named-capture path needs.
+    /// In-flight Regexp stash: every `RegexpInner::captures_*` /
+    /// `find_*` entry point sets this to the Regexp `Value` it is
+    /// about to match, so the subsequent
+    /// `save_capture_special_variables` knows which Regexp to attach
+    /// to the constructed `MatchData` (named-capture lookup needs
+    /// it). Cleared once the MatchData is built and stored in the
+    /// LEP's `LFP_SVAR`. All other per-match state (`$~`, `$&`, `$'`,
+    /// `$\``, `$1`..`$N`) now lives frame-locally on the LEP.
     sp_match_regex: Option<Value>,
     temp_stack: Vec<Value>,
     require_level: usize,
@@ -138,12 +136,6 @@ impl std::default::Default for Executor {
             stack_limit: 0,
             lexical_class: vec![vec![]],
             toplevel_visibility: Visibility::Private,
-            sp_last_match: None,
-            sp_pre_match: None,
-            sp_post_match: None,
-            sp_matches: vec![],
-            sp_match_positions: vec![],
-            sp_match_haystack: None,
             sp_match_regex: None,
             temp_stack: vec![],
             require_level: 0,
@@ -371,22 +363,31 @@ impl Executor {
         self.parent_fiber
     }
 
+    /// `$&` — the last successful match (derived from the current
+    /// LEP's MatchData).
     pub fn sp_last_match(&self) -> Option<Value> {
-        self.sp_last_match
-            .as_ref()
-            .map(|s| Value::string_from_str(s))
+        let v = self.current_match_data()?;
+        let md = v.as_match_data();
+        let bytes = md.at(0)?;
+        Some(Value::string_from_str(&String::from_utf8_lossy(bytes)))
     }
 
+    /// `$\`` — the substring before the last match.
     pub fn sp_pre_match(&self) -> Option<Value> {
-        self.sp_pre_match
-            .as_ref()
-            .map(|s| Value::string_from_str(s))
+        let v = self.current_match_data()?;
+        let md = v.as_match_data();
+        let (start, _) = md.pos(0)?;
+        let bytes = &md.string().as_bytes()[..start];
+        Some(Value::string_from_str(&String::from_utf8_lossy(bytes)))
     }
 
+    /// `$'` — the substring after the last match.
     pub fn sp_post_match(&self) -> Option<Value> {
-        self.sp_post_match
-            .as_ref()
-            .map(|s| Value::string_from_str(s))
+        let v = self.current_match_data()?;
+        let md = v.as_match_data();
+        let (_, end) = md.pos(0)?;
+        let bytes = &md.string().as_bytes()[end..];
+        Some(Value::string_from_str(&String::from_utf8_lossy(bytes)))
     }
 }
 
@@ -2181,111 +2182,104 @@ impl Executor {
 // Handling special variables.
 
 impl Executor {
+    /// The LEP for the current `$~` / `$_` scope.
+    ///
+    /// Native (`#[monoruby_builtin]`) frames don't introduce an svar
+    /// scope — they mirror CRuby C-functions, whose `vm_push_frame`
+    /// reuses the caller's EP. Walk the dynamic CFP chain back past
+    /// any native frames to the Ruby caller, then `Lfp::lep` walks
+    /// that frame's lexical `outer` chain to the method frame (so a
+    /// match performed inside a block updates the enclosing method's
+    /// `$~`). Returns `None` outside Ruby execution (no CFP set).
+    fn current_lep(&self) -> Option<Lfp> {
+        let mut cfp = self.cfp?;
+        while cfp.lfp().meta().is_native() {
+            cfp = cfp.prev()?;
+        }
+        Some(cfp.lfp().lep())
+    }
+
+    /// Read the MatchData `Value` stashed on the current LEP's
+    /// `LFP_SVAR` slot. The slot only ever holds zero (the "unset"
+    /// sentinel) or a valid MatchData `Value`, so callers can safely
+    /// `.as_match_data()` the result.
+    pub(crate) fn current_match_data(&self) -> Option<Value> {
+        self.current_lep()?.svar()
+    }
+
     pub(crate) fn clear_capture_special_variables(&mut self) {
-        self.sp_last_match = None;
-        self.sp_pre_match = None;
-        self.sp_post_match = None;
-        self.sp_matches.clear();
-        self.sp_match_positions.clear();
-        self.sp_match_haystack = None;
+        // Bootstrap (e.g. `Executor::init` clearing stale state after
+        // startup.rb) runs with no CFP — nothing to clear yet.
+        if let Some(lep) = self.current_lep() {
+            lep.set_svar_slot_zero();
+        }
         self.sp_match_regex = None;
     }
 
     /// Stash the Regexp the next `save_capture_special_variables`
-    /// call should associate with the captures. Set by every
-    /// `RegexpInner::captures_*` / `find_*` entry point so
-    /// `Regexp.last_match` can later return a `MatchData` whose
-    /// `regexp` slot is populated (named-capture lookup needs it).
+    /// call should associate with the captures.
     pub(crate) fn set_match_regex(&mut self, regex: Value) {
         self.sp_match_regex = Some(regex);
     }
+
     ///
-    /// Save captured strings to special variables.
-    ///
-    /// - $n (n:0,1,2,3...) <- The string which matched with nth parenthesis in the last successful match.
-    ///
-    /// - $& <- The string which matched successfully at last.
-    ///
-    /// - $` <- The string before $&.
-    ///
-    /// - $' <- The string after $&.
+    /// Build a `MatchData` from `captures` + `haystack` (plus the
+    /// transient `sp_match_regex` stash) and store it as the current
+    /// scope's `$~` on the LEP's `LFP_SVAR` slot.
     ///
     pub(crate) fn save_capture_special_variables<'h>(
         &mut self,
         captures: &onigmo_regex::Captures<'h>,
         haystack: &str,
     ) {
-        // Onigmo's `Match::{as_str, post, to_string}` slice the
-        // haystack as `&str`, which panics (`panic_nounwind` ⇒
-        // extern "C" boundary abort) when a `/n` (binary) regexp
-        // returns byte offsets that land mid-UTF-8 of the source
-        // string. Slice on bytes and lossy-decode for the `String`
-        // fields, which preserves valid UTF-8 unchanged and avoids
-        // the abort for binary subjects.
-        let bytes = haystack.as_bytes();
-        match captures.get(0) {
-            Some(m) => {
-                let (s, e) = (m.start(), m.end());
-                self.sp_last_match =
-                    Some(String::from_utf8_lossy(&bytes[s..e]).into_owned());
-                self.sp_pre_match =
-                    Some(String::from_utf8_lossy(&bytes[..s]).into_owned());
-                self.sp_post_match =
-                    Some(String::from_utf8_lossy(&bytes[e..]).into_owned());
-            }
-            None => {
-                self.sp_last_match = None;
-                self.sp_pre_match = None;
-                self.sp_post_match = None;
-            }
-        };
-
-        self.sp_matches.clear();
-        self.sp_match_positions.clear();
-        self.sp_match_haystack = Some(haystack.to_string());
-        for m in captures.iter() {
-            self.sp_match_positions
-                .push(m.as_ref().map(|m| (m.start(), m.end())));
-            self.sp_matches.push(
-                m.map(|m| String::from_utf8_lossy(&bytes[m.start()..m.end()]).into_owned()),
-            );
-        }
-    }
-
-    pub(crate) fn get_special_matches(&self, mut nth: i64) -> Option<Value> {
-        // `MatchData#[]` (and therefore `Regexp.last_match(n)`)
-        // negative-indexes within `captures` only — `sp_matches[0]`
-        // (the full match) is *not* reachable through a negative
-        // index. For `(\w)(\w)(\w)` matched against "abc",
-        // `last_match(-3)` is "a" but `last_match(-4)` is nil even
-        // though `to_a` has 4 entries.
-        if nth < 0 {
-            let captures_len = self.sp_matches.len() as i64 - 1;
-            if -nth > captures_len {
-                return None;
-            }
-            nth += self.sp_matches.len() as i64;
-        }
-        if nth >= 0
-            && let Some(Some(s)) = self.sp_matches.get(nth as usize)
-        {
-            return Some(Value::string_from_str(s));
-        }
-        None
-    }
-
-    pub(crate) fn get_last_matchdata(&self) -> Value {
-        if self.sp_match_positions.is_empty() {
-            return Value::nil();
-        }
-        let haystack = self.sp_match_haystack.as_deref().unwrap_or("");
-        let mut md = MatchDataInner::new(haystack.to_string(), self.sp_match_positions.clone());
+        let positions: Vec<Option<(usize, usize)>> = captures
+            .iter()
+            .map(|m| m.as_ref().map(|m| (m.start(), m.end())))
+            .collect();
+        let mut md = MatchDataInner::new(haystack.to_string(), positions);
         if let Some(regex_val) = self.sp_match_regex
             && let Some(regex) = regex_val.is_regex()
         {
             md = md.with_regex(regex);
         }
-        RValue::new_match_data_from_inner(md).pack()
+        let md_val = RValue::new_match_data_from_inner(md).pack();
+        if let Some(lep) = self.current_lep() {
+            lep.set_svar_slot_value(md_val);
+        }
+        self.sp_match_regex = None;
+    }
+
+    /// `MatchData#[]` semantics for `$n` access (0 = full match,
+    /// 1..N = captures, negative = from the end of *captures only*).
+    pub(crate) fn get_special_matches(&self, mut nth: i64) -> Option<Value> {
+        let v = self.current_match_data()?;
+        let md = v.as_match_data();
+        let len = md.len();
+        if nth < 0 {
+            // Negative indices count back through captures (excluding
+            // $0). For `(\w)(\w)(\w)` matched against "abc",
+            // `last_match(-3)` is "a" but `last_match(-4)` is nil
+            // even though `to_a` has 4 entries.
+            let captures_len = len as i64 - 1;
+            if -nth > captures_len {
+                return None;
+            }
+            nth += len as i64;
+        }
+        if nth >= 0 {
+            let idx = nth as usize;
+            if idx < len {
+                let bytes = md.at(idx)?;
+                return Some(Value::string_from_str(&String::from_utf8_lossy(bytes)));
+            }
+        }
+        None
+    }
+
+    /// `$~` reader — returns the MatchData `Value` from the current
+    /// LEP, or `nil` if no match has been recorded in this scope.
+    pub(crate) fn get_last_matchdata(&self) -> Value {
+        self.current_match_data().unwrap_or_else(Value::nil)
     }
 }
 

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -251,6 +251,15 @@ impl alloc::GC<RValue> for Lfp {
         if let Some(v) = self.block() {
             v.0.mark(alloc)
         };
+        // Mark the LFP_SVAR slot if this frame owns one (LEP-style
+        // frames lazily allocate a container `Value` here on first
+        // `$~ = ...`; zero is the "unset" sentinel). Block-style
+        // frames keep zero — they read/write `$~` through their
+        // outer-chain LEP, which the recursive `outer.mark` below
+        // reaches separately.
+        if let Some(v) = self.svar_slot() {
+            v.mark(alloc);
+        }
         if let Some(outer) = self.outer() {
             outer.mark(alloc);
         }
@@ -305,6 +314,80 @@ impl Lfp {
     ///
     pub fn outer(self) -> Option<Lfp> {
         unsafe { *(self.0.as_ptr() as *mut Option<Lfp>) }
+    }
+
+    ///
+    /// Walk the outer chain up to the *Local Environment Pointer* —
+    /// the nearest method-introducing frame.
+    ///
+    /// CRuby's `vm_svar` lives on the LEP, and every frame-local
+    /// global (`$~`, `$_`, and the BACK_REF / NTH_REF family derived
+    /// from `$~`) reads/writes through it. The walking rule:
+    ///
+    /// * **Block-style** frames (block literal `{ }` / `do … end`
+    ///   and `Proc.new`) `share` their lexical parent's LEP — follow
+    ///   `outer` upward.
+    /// * **Method-style** frames (`def`, lambda, class/module body,
+    ///   toplevel script, `define_method`-installed Proc tagged
+    ///   `is_proc_method`) own their LEP — stop.
+    ///
+    /// The chain is guaranteed to terminate at a method-style frame
+    /// (the toplevel script body is method-style with no outer), so
+    /// this loop always returns a real LEP.
+    pub(crate) fn lep(self) -> Lfp {
+        let mut lfp = self;
+        loop {
+            let meta = lfp.meta();
+            if !meta.is_block_style() || meta.is_proc_method() {
+                return lfp;
+            }
+            match lfp.outer() {
+                Some(outer) => lfp = outer,
+                None => return lfp,
+            }
+        }
+    }
+
+    ///
+    /// Read this frame's `LFP_SVAR` slot **without** walking the
+    /// outer chain. Returns `None` when the slot still carries the
+    /// zero sentinel (no container allocated yet).
+    ///
+    /// Only the LEP's slot ever holds a meaningful value — block-
+    /// style frames keep zero here and resolve `$~` through
+    /// `Lfp::svar` / `Lfp::set_svar`. Use this raw accessor only for
+    /// the GC mark walker and for the LEP itself.
+    fn svar_slot(self) -> Option<Value> {
+        let raw = unsafe { *(self.sub(LFP_SVAR as _) as *const u64) };
+        if raw == 0 {
+            None
+        } else {
+            Some(Value::from_u64(raw))
+        }
+    }
+
+    fn set_svar_slot(self, val: Value) {
+        unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = val.id() }
+    }
+
+    ///
+    /// Read the **LEP's** `LFP_SVAR` slot — the `$~`/`$_` container
+    /// (or `None` if no container has been allocated yet).
+    ///
+    /// Walks the outer chain to the LEP first; calling on a block
+    /// frame transparently returns the enclosing method's slot.
+    pub(crate) fn svar(self) -> Option<Value> {
+        self.lep().svar_slot()
+    }
+
+    ///
+    /// Write `val` into the **LEP's** `LFP_SVAR` slot.
+    ///
+    /// Walks the outer chain to the LEP first, so a `$~ = …`
+    /// assignment from inside a block lands in the enclosing
+    /// method's slot — matching CRuby `vm_svar` semantics.
+    pub(crate) fn set_svar(self, val: Value) {
+        self.lep().set_svar_slot(val)
     }
 
     ///

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -370,24 +370,32 @@ impl Lfp {
         unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = val.id() }
     }
 
+    /// Write a MatchData `Value` directly into **this** frame's
+    /// `LFP_SVAR` slot (no outer-chain walk). The caller
+    /// (`Executor::current_lep`) has already resolved the LEP.
+    pub(crate) fn set_svar_slot_value(self, val: Value) {
+        self.set_svar_slot(val);
+    }
+
+    /// Write the zero "unset" sentinel directly into **this** frame's
+    /// `LFP_SVAR` slot (no outer-chain walk).
+    pub(crate) fn set_svar_slot_zero(self) {
+        unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = 0 }
+    }
+
     ///
     /// Read the **LEP's** `LFP_SVAR` slot — the `$~`/`$_` container
     /// (or `None` if no container has been allocated yet).
     ///
     /// Walks the outer chain to the LEP first; calling on a block
     /// frame transparently returns the enclosing method's slot.
+    ///
+    /// Note: this only follows the *lexical* `outer` chain, so it is
+    /// correct when called on a Ruby (iseq) frame. Native builtin
+    /// frames must first be skipped via the dynamic CFP chain — see
+    /// `Executor::current_lep`, which is the canonical entry point.
     pub(crate) fn svar(self) -> Option<Value> {
         self.lep().svar_slot()
-    }
-
-    ///
-    /// Write `val` into the **LEP's** `LFP_SVAR` slot.
-    ///
-    /// Walks the outer chain to the LEP first, so a `$~ = …`
-    /// assignment from inside a block lands in the enclosing
-    /// method's slot — matching CRuby `vm_svar` semantics.
-    pub(crate) fn set_svar(self, val: Value) {
-        self.lep().set_svar_slot(val)
     }
 
     ///

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -408,7 +408,7 @@ impl Lfp {
         unsafe {
             let mut cfp = self.cfp();
             let len = self.frame_bytes();
-            // `frame_bytes` is always a multiple of 8 (LFP_SELF=24 plus
+            // `frame_bytes` is always a multiple of 8 (LFP_SELF plus
             // 8*reg_num), so copy the frame as a `Box<[u64]>` — uniform
             // with `heap_frame`/`dummy_*` so the GC can reclaim every
             // promoted buffer with one `Box::from_raw(*mut [u64])`.
@@ -442,14 +442,19 @@ impl Lfp {
         let local_len = meta.reg_num() as usize - 1;
         meta.set_on_heap();
         let mut v = vec![Value::nil().id(); local_len];
-        // self
-        v.push(self_val.id());
-        // block
-        v.push(0);
-        // meta
-        v.push(meta.get());
-        // outer
-        v.push(0);
+        // The heap-allocated frame must mirror the stack layout
+        // exactly: lfp_addr (= base + len - 8) points at LFP_OUTER,
+        // and each LFP_xxx offset reads memory at lfp_addr - LFP_xxx.
+        // Push slots in **ascending memory order**, finishing with
+        // LFP_OUTER at the highest index = lfp_addr.
+        // Order: locals[0..N], self (LFP_SELF), block (LFP_BLOCK),
+        // cme (LFP_CME), svar (LFP_SVAR), meta (LFP_META), outer (LFP_OUTER).
+        v.push(self_val.id()); // -> LFP_SELF
+        v.push(0); //               -> LFP_BLOCK
+        v.push(0); //               -> LFP_CME (unused; zero sentinel)
+        v.push(0); //               -> LFP_SVAR (unused; zero sentinel)
+        v.push(meta.get()); //      -> LFP_META
+        v.push(0); //               -> LFP_OUTER (no outer)
         let v = v.into_boxed_slice();
         let n = v.len();
         let len = n * 8;
@@ -464,7 +469,22 @@ impl Lfp {
     }
 
     pub fn dummy_heap_frame_with_self(self_val: Value) -> Self {
-        let v: Box<[u64]> = vec![0, 0, self_val.id(), 0, 0, 0].into_boxed_slice();
+        // Same slot order as `heap_frame` (locals.., self, block, cme,
+        // svar, meta, outer) with zero locals. Eight u64 slots: 1 self
+        // + 5 zero header slots (block/cme/svar/meta/outer) padded out
+        // to two extra zeros so the LFP layout stays self-consistent
+        // with the new (post-SVAR/CME) header size.
+        let v: Box<[u64]> = vec![
+            0,                  // padding (matches the historical extra slot)
+            0,                  // padding
+            self_val.id(),      // LFP_SELF
+            0,                  // LFP_BLOCK
+            0,                  // LFP_CME
+            0,                  // LFP_SVAR
+            0,                  // LFP_META — set via `set_reg_num` below
+            0,                  // LFP_OUTER
+        ]
+        .into_boxed_slice();
         let n = v.len();
         let len = n * 8;
         unsafe {

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -370,17 +370,11 @@ impl Lfp {
         unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = val.id() }
     }
 
-    /// Write a MatchData `Value` directly into **this** frame's
-    /// `LFP_SVAR` slot (no outer-chain walk). The caller
+    /// Write the svar container `Value` directly into **this**
+    /// frame's `LFP_SVAR` slot (no outer-chain walk). The caller
     /// (`Executor::current_lep`) has already resolved the LEP.
     pub(crate) fn set_svar_slot_value(self, val: Value) {
         self.set_svar_slot(val);
-    }
-
-    /// Write the zero "unset" sentinel directly into **this** frame's
-    /// `LFP_SVAR` slot (no outer-chain walk).
-    pub(crate) fn set_svar_slot_zero(self) {
-        unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = 0 }
     }
 
     ///

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -355,6 +355,35 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     globals.define_hooked_variable(IdentId::get_id("$'"), get_post_match, None);
     globals.define_hooked_variable(IdentId::get_id("$`"), get_pre_match, None);
 
+    // `$_` (last line read by `gets` / `readline`) is frame-local in
+    // CRuby — it lives in `vm_svar.lastline` alongside `$~`. monoruby
+    // stores it in slot `SVAR_LASTLINE` of the LEP's container, so it
+    // routes through the same hooked-variable machinery rather than the
+    // process-global gvar table.
+    fn get_last_read_line(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        Some(vm.get_last_read_line())
+    }
+
+    fn set_last_read_line(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+        val: Value,
+    ) -> Result<()> {
+        vm.set_last_read_line(val);
+        Ok(())
+    }
+
+    globals.define_hooked_variable(
+        IdentId::get_id("$_"),
+        get_last_read_line,
+        Some(set_last_read_line),
+    );
+
     // $1 through $9 are the common case; higher-numbered matches are also
     // allowed by name — they all share the same getter which parses the
     // numeric suffix out of `name`.

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -220,7 +220,7 @@ impl Meta {
         (self.kind & 0b1_0000) != 0
     }
 
-    fn is_block_style(&self) -> bool {
+    pub(crate) fn is_block_style(&self) -> bool {
         (self.kind & 0b100) != 0
     }
 


### PR DESCRIPTION
## Summary

Make Ruby's frame-local special variables (`$~` and `$_`, plus the
BACK_REF / NTH_REF family derived from `$~`) actually frame-local, by
storing them on the method frame's LEP — matching CRuby's `vm_svar`
semantics — instead of process-global `Executor` state.

Before this PR `$~` / `$&` / `$'` / `$\`` / `$1`..`$N` lived in
per-`Executor` fields and `$_` in the global gvar table, so a regex
match inside a method leaked its `$~` to the caller. Now:

```ruby
def foo; "abc" =~ /(b)/; $~; end
foo   #=> #<MatchData "b" 1:"b">
$~    #=> nil          # foo's match no longer leaks out

"x" =~ /x/
[1].each { "yz" =~ /z/ }
$~    #=> #<MatchData "z">   # a block shares the enclosing LEP
```

## How

Four incremental commits:

1. **`feat(frame): reserve LFP_SVAR + LFP_CME slots`** — insert two
   8-byte slots between `LFP_META` and `LFP_BLOCK` (keeping the LFP
   header a multiple of 16 so the existing `rsp` alignment holds).
   `RSP_LOCAL_FRAME` / `RBP_LOCAL_FRAME` are intentionally **not**
   changed — they measure the distance from the caller's `rsp` /
   current `rbp` to `LFP_OUTER`, which stays put; only the lower
   slots shift down. `Lfp::heap_frame` / `dummy_heap_frame_with_self`
   grow their hand-built Vec to match the new offset table.

2. **`feat(frame): Lfp::lep / svar accessors + GC mark`** — `Lfp::lep`
   walks the lexical `outer` chain (block → enclosing method);
   `Lfp::svar` reads the slot; the GC mark visits it. `LFP_CME` is
   reserved for a future CME migration (no reads/writes yet).

3. **`feat(regexp): store $~ frame-locally`** — `Executor::current_lep`
   resolves the scope's LEP by walking the *dynamic* CFP chain past
   native (`#[monoruby_builtin]`) frames to the Ruby caller, then the
   *lexical* outer chain to the method. All `$~` reads/writes
   (including `Regexp.last_match`) route through it.

4. **`feat(special-vars): make $_ frame-local`** — `LFP_SVAR` now holds
   a lazily-allocated 2-element `Array` `[$~, $_]`; `$_` becomes a
   hooked variable; `IO#gets` / `Regexp#~` use the frame-local
   accessors.

`LFP_CME` is groundwork for an upcoming Callable Method Entry slot
(CRuby's `cref_or_me`) — reserved here so the layout change lands
once.

## Test plan

- [x] `$~` / `$&` / `$'` / `$\`` / `$1` / `Regexp.last_match(n)` and
      `$_` all match CRuby output
- [x] Frame-local semantics verified: method scope isolates `$~`/`$_`;
      blocks share the enclosing LEP; `gets` / `~` update the caller's
      scope
- [x] `cargo test --release -p monoruby --lib`: 1589 passed / 2 failed
      — the two failures (`string_inspect`, `symbol_inspect_unquoted`)
      already fail on `origin/master` (a `LANG`/encoding-dependent
      `String#inspect` diff) and are unrelated to this change
- [x] `regexp` / `match_data` suites green under
      `--features stress-spill-pool --features gc-stress`, exercising
      the GC mark of the `LFP_SVAR` Array container and its MatchData
      element
- [x] `bin/test` (run with `LANG=C.UTF-8`) full green on an earlier
      commit of this branch: nextest 2198/2198 ×2, all benchmark /
      optcarrot / mandel diffs identical

### Note

`monoruby -e 'while gets; …; end'` reading piped **stdin** loops at
EOF — that's a pre-existing `IO#read_line` EOF-detection issue
(`File#gets` is fine), orthogonal to this PR.

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_