### PR TITLE
fix(kernel): Kernel#gets returns nil at EOF (not "")

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -424,13 +424,34 @@ fn puts(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/gets.html]
 #[monoruby_builtin]
-fn gets(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut buffer = String::new();
-    match std::io::stdin().read_line(&mut buffer) {
-        Ok(_) => {}
-        Err(_) => return Ok(Value::nil()),
+    let n = match std::io::stdin().read_line(&mut buffer) {
+        Ok(n) => n,
+        Err(_) => {
+            vm.set_last_read_line(Value::nil());
+            return Ok(Value::nil());
+        }
+    };
+    // `read_line` returns `Ok(0)` only at end-of-input. CRuby's
+    // `gets` then returns nil (and `while gets` terminates); returning
+    // the empty buffer string here would loop forever since "" is
+    // truthy.
+    if n == 0 {
+        vm.set_last_read_line(Value::nil());
+        return Ok(Value::nil());
     }
-    Ok(Value::string(buffer))
+    // Bump `$.` (input line number) and set `$_` (frame-local last
+    // read line), matching CRuby.
+    let lineno = globals
+        .get_gvar(IdentId::get_id("$."))
+        .and_then(|v| v.try_fixnum())
+        .unwrap_or(0)
+        + 1;
+    globals.set_gvar(IdentId::get_id("$."), Value::integer(lineno));
+    let s = Value::string(buffer);
+    vm.set_last_read_line(s);
+    Ok(s)
 }
 
 ///


### PR DESCRIPTION
## Summary

Top-level `Kernel#gets` ignored the byte count from
`std::io::stdin().read_line`, which returns `Ok(0)` with an empty
buffer at end-of-input. The code always wrapped the buffer in
`Value::string`, so at EOF it returned `""` — a *truthy* value — and
`while gets ... end` looped forever on piped / redirected stdin
instead of terminating. It also never maintained `$_` / `$.`.

## Fix

- Return `nil` when `read_line` reports `Ok(0)` (EOF), matching CRuby.
- Set `$_` (the frame-local last-read-line, now backed by the
  `LFP_SVAR` container) on each successful read; clear it to `nil` at
  EOF.
- Bump `$.` (input line number) on each successful read.

```
printf "a\nb\n" | monoruby -e '3.times { p [gets, $_, $.] }'
# before: ["a\n", ..1]  ["b\n", ..2]  ["", ..2]   # `while gets` never ends
# after:  ["a\n","a\n",1]  ["b\n","b\n",2]  [nil,nil,2]   # matches CRuby
```

## Test plan

- [x] `printf "a\nb\n" | monoruby -e '3.times { p [gets, $_, $.] }'`
      matches CRuby (`["a\n","a\n",1] / ["b\n","b\n",2] / [nil,nil,2]`)
- [x] `printf "x\ny\nz\n" | monoruby -e 'n=0; while gets; n+=1; end; p n'`
      → `3` (terminates; previously looped forever)
- [x] empty stdin → `gets` returns `nil` immediately
- [x] `cargo test --release -p monoruby --lib`: 1594 passed / 2 failed
      — the two failures (`string_inspect`, `symbol_inspect_unquoted`)
      already fail on `origin/master` (a `LANG`/encoding-dependent
      `String#inspect` diff) and are unrelated to this change

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_