### PR TITLE
feat(kernel): print with no args writes $_ (frame-local last line)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -916,10 +916,10 @@ module Kernel
     nil
   end
 
-  def print(*args)
-    $stdout.print(*args)
-    nil
-  end
+  # `Kernel#print` is a native builtin (see builtins/kernel.rs): it
+  # delegates to `$stdout.print` but additionally writes `$_` when
+  # called with no arguments, which a pure-Ruby definition can't do
+  # because `$_` is frame-local (it would read print's own nil slot).
 
   def p(*args)
     if args.size == 1

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -15,7 +15,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "!~", not_match, 1);
     //globals.define_builtin_module_func_rest(kernel_class, "puts", puts);
     globals.define_builtin_module_func(kernel_class, "gets", gets, 0);
-    //globals.define_builtin_module_func_rest(kernel_class, "print", print);
+    globals.define_builtin_module_func_rest(kernel_class, "print", print);
     globals.define_builtin_module_func_with_effect(
         kernel_class,
         "proc",
@@ -461,9 +461,28 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/print.html]
 #[monoruby_builtin]
-fn print(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    for v in lfp.arg(0).as_array().iter().cloned() {
-        globals.print_value(v)?;
+fn print(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let args = lfp.arg(0).as_array();
+    // Delegate to `$stdout.print` so output-stream reassignment is
+    // honoured (and so the `IO#print` write path stays the single
+    // source of truth), reading `$stdout` dynamically each call.
+    let stdout = globals
+        .get_gvar(IdentId::get_id("$stdout"))
+        .unwrap_or_default();
+    let print_id = IdentId::get_id("print");
+    if args.len() == 0 {
+        // `print` with no arguments writes `$_` (the caller's
+        // frame-local last-read line). A `nil` `$_` prints nothing.
+        // `vm.get_last_read_line` resolves the LEP past this native
+        // frame, so it sees the Ruby caller's `$_`, not print's own.
+        let lastline = vm.get_last_read_line();
+        if lastline.is_nil() {
+            return Ok(Value::nil());
+        }
+        vm.invoke_method_inner(globals, print_id, stdout, &[lastline], None, None)?;
+    } else {
+        let argvec: Vec<Value> = args.iter().cloned().collect();
+        vm.invoke_method_inner(globals, print_id, stdout, &argvec, None, None)?;
     }
     Ok(Value::nil())
 }


### PR DESCRIPTION
## Summary

CRuby's `print` with no arguments writes `$_` (the last line read by
`gets` / `readline`); a `nil` `$_` prints nothing. monoruby's
top-level `print` was a pure-Ruby `Kernel#print` in startup.rb
(`$stdout.print(*args)`), which **can't** implement this: `$_` is
frame-local (PR #608), so reading it inside the Ruby method sees
print's own (nil) slot rather than the caller's.

## How

Reimplement `Kernel#print` as a native builtin that:

- reads `$_` via `vm.get_last_read_line` when called with no args —
  `Executor::current_lep` resolves past the native frame to the Ruby
  caller's LEP, so it sees the caller's `$_`;
- delegates to `$stdout.print` (looked up dynamically each call) for
  the actual write, so output-stream reassignment is still honoured
  and `IO#print` stays the single write path.

```
printf "data\n" | monoruby -e 'gets; print'   # => data   (was: nothing)
monoruby -e 'print'                            # => (nothing; $_ is nil)
monoruby -e 'print "a","b"'                    # => ab      (unchanged)
```

The pure-Ruby `Kernel#print` is removed from startup.rb (replaced by a
comment pointing at the native impl).

## Scope

CRuby defines the other implicit-`$_` helpers (`sub` / `gsub` /
`chomp` / `chop`) **only under the `-n` / `-p` command-line flags**
(they raise `NoMethodError` otherwise). Those need separate CLI-flag
support (arg parsing + program wrapping), so this PR covers only the
always-on `print`-with-no-args case; `-n` / `-p` is left as follow-up.

## Test plan

- [x] `printf "data\n" | monoruby -e 'gets; print'` → `data`
- [x] `monoruby -e 'print'` (no `$_`) → prints nothing
- [x] `monoruby -e 'print "a","b","c"'` → `abc` (unchanged)
- [x] `$stdout = StringIO.new; print "x"` captured by the StringIO
      (reassignment honoured)
- [x] `cargo test --release -p monoruby --lib`: 1597 passed / 2 failed
      — the two failures (`string_inspect`, `symbol_inspect_unquoted`)
      already fail on `origin/master` (a `LANG`/encoding-dependent
      `String#inspect` diff) and are unrelated
- [x] `print` suite 9/9; `kernel` suite 93/93 under
      `--features stress-spill-pool --features gc-stress`

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_