### PR TITLE
feat(io): IO#sysread (−16 E)

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -39,6 +39,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(IO_CLASS, "syswrite", io_syswrite, 1, 1, false);
     globals.define_builtin_func_with(IO_CLASS, "pread", io_pread, 2, 3, false);
     globals.define_builtin_func(IO_CLASS, "pwrite", io_pwrite, 2);
+    globals.define_builtin_func_with(IO_CLASS, "sysread", io_sysread, 1, 2, false);
     globals.define_builtin_func_with(IO_CLASS, "readlines", io_readlines, 0, 2, false);
     globals.define_builtin_func(IO_CLASS, "binmode", io_binmode, 0);
     globals.define_builtin_func(IO_CLASS, "binmode?", io_binmode_, 0);
@@ -2273,6 +2274,56 @@ fn io_pwrite(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(Value::integer(n as i64))
 }
 
+///
+/// ### IO#sysread
+/// - sysread(maxlen) -> String
+/// - sysread(maxlen, outbuf) -> outbuf
+///
+/// Low-level read of up to `maxlen` bytes via a single underlying
+/// read. Raises `EOFError` at end of file.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/sysread.html]
+#[monoruby_builtin]
+fn io_sysread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if maxlen < 0 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "negative length {} given",
+            maxlen
+        )));
+    }
+    let buffer: Option<Value> = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => Some(v.coerce_to_rstring(vm, globals)?.as_val()),
+        _ => None,
+    };
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    if maxlen == 0 {
+        // CRuby returns "" — and leaves a supplied buffer untouched.
+        return Ok(match buffer {
+            Some(v) => v,
+            None => Value::string_from_vec(vec![]),
+        });
+    }
+    let buf = lfp.self_val().as_io_inner_mut().sysread(maxlen as usize)?;
+    if buf.is_empty() {
+        if let Some(mut v) = buffer {
+            let enc = v.as_rstring_inner().encoding();
+            *v.as_rstring_inner_mut() = RStringInner::from_encoding(&[], enc);
+        }
+        return Err(MonorubyErr::eoferr(&globals.store, "end of file reached"));
+    }
+    match buffer {
+        Some(mut v) => {
+            let enc = v.as_rstring_inner().encoding();
+            *v.as_rstring_inner_mut() = RStringInner::from_encoding(&buf, enc);
+            Ok(v)
+        }
+        None => Ok(Value::bytes(buf)),
+    }
+}
+
 /// Helper: extract raw fd from a Value that is an IO (or responds to to_io).
 fn value_to_fd(globals: &Globals, v: Value) -> Result<i32> {
     if let Some(rv) = v.try_rvalue() {
@@ -4317,6 +4368,70 @@ mod tests {
             ensure
               f.close
               File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_sysread_basic() {
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_io_sysread_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "012345678901234567890123456789\nabcdef")
+              f = File.open(path, "r+")
+              res = []
+              res << f.sysread(15)            # "012345678901234"
+              res << f.sysread(5)             # "56789" (position advanced)
+              buf = +"ABCDE"
+              res << f.sysread(6, buf).equal?(buf)  # true
+              res << buf                      # bytes 20..25
+              res << f.sysread(0)             # "" immediately
+              f.close
+              res
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_sysread_eof_and_pipe() {
+        // Smaller string from a pipe when fewer bytes are available.
+        run_test_once(
+            r#"
+            r, w = IO.pipe
+            w.write("ab")
+            out = r.sysread(3)
+            r.close; w.close
+            out
+            "#,
+        );
+        // EOFError past end of file.
+        run_test_error(
+            r#"
+            path = "/tmp/monoruby_io_sysread_eof_#{Process.pid}_#{rand(100000)}"
+            File.write(path, "abc")
+            f = File.open(path, "r")
+            begin
+              f.seek(0, IO::SEEK_END)
+              f.sysread(1)
+            ensure
+              f.close
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        // Negative length ⇒ ArgumentError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            begin
+              r.sysread(-1)
+            ensure
+              r.close; w.close
             end
             "#,
         );

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -4438,6 +4438,64 @@ mod tests {
     }
 
     #[test]
+    fn io_sysread_popen_pushback_and_errors() {
+        // Popen reader arm: read from a child's stdout (monoruby-only;
+        // the popen harness output isn't comparable via run_test). The
+        // Ruby code asserts the result itself.
+        run_test_no_result_check(
+            r#"
+            io = IO.popen("printf hello")
+            out = io.sysread(5)
+            io.close
+            raise "popen sysread: #{out.inspect}" unless out == "hello"
+            "#,
+        );
+        // ungetc pushback is drained before the underlying read.
+        run_test_no_result_check(
+            r#"
+            path = "/tmp/monoruby_io_sysread_pb_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "abcdef")
+              f = File.open(path, "r")
+              c = f.getc          # "a"
+              f.ungetc(c)         # push "a" back
+              out = f.sysread(3)  # drains pushback then reads
+              f.close
+              raise "pushback sysread: #{out.inspect}" unless out == "abc"
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        // sysread on a write-only stream ⇒ IOError (not opened for reading).
+        run_test_error(
+            r#"
+            path = "/tmp/monoruby_io_sysread_wo_#{Process.pid}_#{rand(100000)}"
+            begin
+              f = File.open(path, "w")
+              begin
+                f.sysread(1)
+              ensure
+                f.close
+              end
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        // sysread on $stdout ⇒ IOError (not opened for reading).
+        run_test_error(r#"$stdout.sysread(1)"#);
+        // sysread on a closed stream ⇒ IOError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            r.close; w.close
+            r.sysread(1)
+            "#,
+        );
+    }
+
+    #[test]
     fn io_select_immediate_timeout_pipe() {
         // A freshly-created pipe with no data buffered should report no
         // ready descriptors when polled with a zero-second timeout.

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -437,6 +437,78 @@ impl IoInner {
         }
     }
 
+    /// Low-level read used by `IO#sysread`: read up to `maxlen` bytes
+    /// with a single underlying read, bypassing the buffered reader.
+    ///
+    /// For a `File`, the `BufReader` is first seeked to its logical
+    /// position — which discards its internal buffer — so the
+    /// subsequent direct read on the underlying file starts at the
+    /// right offset and leaves the `BufReader` consistent for any
+    /// later buffered reads. Any ungetc pushback is drained first.
+    /// Returns an empty `Vec` only at end of file (the caller raises
+    /// `EOFError`).
+    pub fn sysread(&mut self, maxlen: usize) -> Result<Vec<u8>> {
+        use std::io::{Read, Seek, SeekFrom};
+        let mut out = if self.pushback_len() > 0 {
+            self.take_pushback(Some(maxlen))
+        } else {
+            vec![]
+        };
+        if out.len() >= maxlen {
+            return Ok(out);
+        }
+        let need = maxlen - out.len();
+        let chunk = match self {
+            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Stdout | Self::Stderr => {
+                return Err(MonorubyErr::ioerr("not opened for reading"));
+            }
+            Self::Stdin => {
+                let mut buf = vec![0u8; need];
+                let n = std::io::stdin()
+                    .read(&mut buf)
+                    .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
+                buf.truncate(n);
+                buf
+            }
+            Self::File(file) => {
+                if !file.readable {
+                    return Err(MonorubyErr::ioerr("not opened for reading"));
+                }
+                let reader = &mut *Rc::get_mut(file).unwrap().reader;
+                // Sync the underlying fd to the logical position and
+                // discard the BufReader buffer. Best-effort: pipe /
+                // socket fds (also stored as `File`) are not seekable
+                // (`ESPIPE`), in which case the single direct read
+                // below simply returns whatever is available.
+                let _ = reader.seek(SeekFrom::Current(0));
+                let mut buf = vec![0u8; need];
+                let n = reader
+                    .get_mut()
+                    .read(&mut buf)
+                    .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
+                buf.truncate(n);
+                buf
+            }
+            Self::Popen(popen) => {
+                let popen = Rc::get_mut(popen).unwrap();
+                let reader = popen
+                    .reader
+                    .as_mut()
+                    .ok_or_else(|| MonorubyErr::ioerr("not opened for reading"))?;
+                let mut buf = vec![0u8; need];
+                let n = reader
+                    .get_mut()
+                    .read(&mut buf)
+                    .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
+                buf.truncate(n);
+                buf
+            }
+        };
+        out.extend(chunk);
+        Ok(out)
+    }
+
     pub fn read_line(&mut self) -> Result<Option<String>> {
         if self.pushback_len() > 0 {
             let cell = self.pushback_cell().unwrap();


### PR DESCRIPTION
## Summary

`IO#sysread` was undefined. Add it as a low-level read of up to `maxlen` bytes via a single underlying read.

### `IoInner::sysread`
- drains any ungetc pushback first;
- for a `File`, seeks the `BufReader` to its logical position (which discards the internal buffer) so the subsequent direct read on the underlying file starts at the right offset and leaves the reader consistent for later buffered reads. The seek is best-effort — pipe/socket fds (also stored as `File`) aren't seekable, in which case the single read just returns whatever is available;
- `Stdin` / `Popen` read directly from the underlying stream;
- returns an empty `Vec` only at EOF.

### `IO#sysread(maxlen, outbuf = nil)`
- coerces `maxlen` via `#to_int`; negative ⇒ ArgumentError;
- `maxlen == 0` returns `""` immediately, leaving a supplied buffer untouched;
- raises `EOFError` (clearing the output buffer first) at EOF;
- with a buffer, coerces via `#to_str`, fills it in place preserving its encoding, and returns it.

## Impact on `core/io/sysread_spec`

E 17 → 0, F 0 → 1. The single remaining failure is "raises an error when called after buffered reads": CRuby distinguishes `IO#read(n)` (buffer drained) from `IO#readline` (buffer pending) to decide whether sysread raises `IOError`, but monoruby routes both through a `BufReader` whose pending state is identical, so the distinction can't be reproduced. The companion spec "reads normally ... after a buffered `IO#read`" passes.

## Test plan

- [x] `cargo test --lib -p monoruby -- io_sysread` ⇒ 3 pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::io` ⇒ 97 pass
- [x] `mspec core/io/sysread_spec` E: 17 → 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_