### PR TITLE
fix(string): String#&lt;&lt; / #concat raise RangeError on Bignum codepoint (−2 E)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -649,6 +649,12 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         self_
             .as_rstring_inner_mut()
             .extend(&other, &globals.store)?;
+    } else if lfp.arg(0).try_fixnum().is_none() && lfp.arg(0).is_integer() {
+        // `String#<<` / `#concat` treat any Integer as a codepoint; a
+        // Bignum can never be a valid codepoint, so it is always out
+        // of char range (CRuby: `RangeError "bignum out of char
+        // range"`).
+        return Err(MonorubyErr::rangeerr("bignum out of char range"));
     } else if let Some(i) = lfp.arg(0).try_fixnum() {
         let ch = match u32::try_from(i) {
             Ok(ch) => ch,
@@ -7341,6 +7347,14 @@ mod tests {
             [s, s.encoding == Encoding::UTF_8]
         "##,
         ]);
+        // Integer codepoint out of range ⇒ RangeError. Both the
+        // negative fixnum and the (always-out-of-range) Bignum forms,
+        // for `<<` and the `concat`/`append` aliases that delegate to it.
+        run_test_error(r##""a" << -1"##);
+        run_test_error(r##""".concat(-200)"##);
+        run_test_error(r##""".concat(-(2 ** 64))"##);
+        run_test_error(r##""" << (2 ** 70)"##);
+        run_test_error(r##""".append(2 ** 80)"##);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`String#<<` (and the `#concat` / `#append` aliases that delegate to it) treat an Integer argument as a codepoint. A Bignum is never a valid codepoint, but monoruby fell through to the `#to_str` coercion arm and raised `TypeError "no implicit conversion of Integer into String"` instead of CRuby's `RangeError "bignum out of char range"`.

Add a Bignum branch before the `to_str` fallback: any Integer that isn't a Fixnum is out of char range.

## Impact on `core/string`

The shared `concat`/`<<` example "raises RangeError if the argument is negative" (which checks `-200` and `-bignum_value`) now passes for both `<<` and `concat` (−2 E).

## Test plan

- [x] `cargo test --lib -p monoruby -- string_shl_encoding` ⇒ pass (both prism and ruruby)
- [x] `mspec core/string/{append,concat}_spec` ⇒ 0 errors (5 pre-existing encoding F unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_