### PR TITLE
fix(regexp): Regexp.escape / .quote work on broken strings (−4 E)

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -311,22 +311,23 @@ fn regexp_escape(
 ) -> Result<Value> {
     let arg0 = lfp.arg(0);
     // CRuby accepts both String and Symbol; for a Symbol we use its
-    // textual form. Other types still go through `to_str`.
-    let (string, src_enc) = if let Some(s) = arg0.is_str() {
-        let enc = arg0
-            .is_rstring_inner()
-            .map(|r| r.encoding())
-            .unwrap_or(crate::value::Encoding::Utf8);
-        (s.to_string(), enc)
+    // textual form. Other types still go through `to_str`. Work on
+    // raw bytes so "broken" strings (invalid byte sequences for
+    // their encoding) escape byte-wise instead of raising.
+    let (bytes, src_enc) = if let Some(r) = arg0.is_rstring_inner() {
+        (r.as_bytes().to_vec(), r.encoding())
     } else if let Some(sym) = arg0.try_symbol() {
-        (sym.to_string(), crate::value::Encoding::Utf8)
+        (
+            sym.to_string().into_bytes(),
+            crate::value::Encoding::Utf8,
+        )
     } else {
         (
-            arg0.coerce_to_str(vm, globals)?,
+            arg0.coerce_to_str(vm, globals)?.into_bytes(),
             crate::value::Encoding::Utf8,
         )
     };
-    let escaped = RegexpInner::escape(&string);
+    let escaped = RegexpInner::escape_bytes(&bytes);
     // CRuby tags the result US-ASCII when it contains only ASCII
     // bytes (otherwise it inherits the source's encoding). The
     // escape itself only adds ASCII metacharacters, so the result
@@ -338,7 +339,7 @@ fn regexp_escape(
     };
     Ok(Value::string_from_inner(
         crate::value::rvalue::RStringInner::from_encoding_scanned(
-            escaped.as_bytes(),
+            &escaped,
             result_enc,
         ),
     ))
@@ -1830,5 +1831,27 @@ mod tests {
             // Char class containing parens must not confuse the scan.
             r#"/(?i:[()])/.to_s"#,
         ]);
+    }
+
+    #[test]
+    fn regexp_escape_quote() {
+        run_tests(&[
+            // Metacharacters escaped; whitespace controls rewritten.
+            r#"Regexp.escape("a b.c*[d]{e}(f)|g-h^i$j+k?l#m")"#,
+            r#"Regexp.escape("\n\t\r\f\v")"#,
+            // Symbol argument.
+            r#"Regexp.quote(:"a.b")"#,
+            // ASCII-only result is tagged US-ASCII.
+            r#"Regexp.escape("abc").encoding.name"#,
+        ]);
+        // Broken (invalid-UTF-8) strings escape byte-wise instead of
+        // raising — the invalid byte passes through verbatim.
+        run_test(
+            r##"
+            s = "a\xffb".force_encoding("UTF-8")
+            e = Regexp.escape(s)
+            [e.bytes, e.encoding.name]
+            "##,
+        );
     }
 }

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1853,5 +1853,15 @@ mod tests {
             [e.bytes, e.encoding.name]
             "##,
         );
+        // A non-String/Symbol arg is coerced via #to_str.
+        run_test(
+            r##"
+            o = Object.new
+            def o.to_str; "a.b"; end
+            Regexp.escape(o)
+            "##,
+        );
+        // An arg that can't be coerced ⇒ TypeError.
+        run_test_error(r#"Regexp.escape(5)"#);
     }
 }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -155,16 +155,32 @@ impl RegexpInner {
     /// but skips whitespace, so we layer the whitespace handling on
     /// top.
     pub fn escape(text: &str) -> String {
-        let pre = regex::escape(text);
-        let mut out = String::with_capacity(pre.len());
-        for ch in pre.chars() {
-            match ch {
-                ' ' => out.push_str("\\ "),
-                '\t' => out.push_str("\\t"),
-                '\n' => out.push_str("\\n"),
-                '\r' => out.push_str("\\r"),
-                '\x0c' => out.push_str("\\f"),
-                '\x0b' => out.push_str("\\v"),
+        // SAFETY: `escape_bytes` only inserts ASCII backslashes
+        // before ASCII metacharacters and passes every other byte
+        // through unchanged, so a valid-UTF-8 input stays valid.
+        String::from_utf8(Self::escape_bytes(text.as_bytes())).unwrap()
+    }
+
+    /// Byte-wise `Regexp.escape` / `Regexp.quote`, mirroring CRuby's
+    /// `rb_reg_quote`. Escapes the regex metacharacters with a
+    /// backslash, rewrites the ASCII whitespace controls to their
+    /// `\n` / `\t` … forms, and passes every other byte through
+    /// verbatim — including bytes that don't form valid UTF-8, so it
+    /// works on "broken" strings.
+    pub fn escape_bytes(bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(bytes.len());
+        for &b in bytes {
+            match b {
+                b'[' | b']' | b'{' | b'}' | b'(' | b')' | b'|' | b'-' | b'*' | b'.'
+                | b'\\' | b'?' | b'+' | b'^' | b'$' | b'#' | b' ' => {
+                    out.push(b'\\');
+                    out.push(b);
+                }
+                b'\n' => out.extend_from_slice(b"\\n"),
+                b'\r' => out.extend_from_slice(b"\\r"),
+                b'\x0c' => out.extend_from_slice(b"\\f"),
+                b'\x0b' => out.extend_from_slice(b"\\v"),
+                b'\t' => out.extend_from_slice(b"\\t"),
                 other => out.push(other),
             }
         }


### PR DESCRIPTION
## Summary

`Regexp.escape` (and its `.quote` alias) converted the argument to a Rust `&str` first, which raised `RuntimeError "invalid byte sequence"` for a String whose bytes aren't valid for its declared encoding. CRuby escapes byte-wise and passes invalid bytes through verbatim.

Add `RegexpInner::escape_bytes`, a byte-wise port of CRuby's `rb_reg_quote`: backslash-escape the regex metacharacters (`[ ] { } ( ) | - * . \ ? + ^ $ #` and space), rewrite the ASCII whitespace controls (`\n \r \f \v \t`), and pass every other byte — including invalid-UTF-8 bytes — straight through. `RegexpInner::escape` now delegates to it. `regexp_escape` reads the raw bytes (preserving the source encoding) instead of going through `to_string`.

## Impact on `core/regexp`

`escape_spec` / `quote_spec` go fully green; the "works for broken strings" examples (−4 E across escape + quote) now pass. Byte-exact CRuby parity on metacharacter escaping verified.

## Test plan

- [x] `cargo test --lib -p monoruby -- regexp_escape_quote` ⇒ pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- regexp` ⇒ 40 pass
- [x] `mspec core/regexp/{escape,quote}_spec` ⇒ 0 F / 0 E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_