### PR TITLE
fix(symbol): set $~ on caller for Symbol#=~ / match / [] / start_with?

### DIFF
--- a/monoruby/builtins/symbol.rb
+++ b/monoruby/builtins/symbol.rb
@@ -1,10 +1,9 @@
 class Symbol
   include Comparable
 
-  def [](*args)
-    to_s.[](*args)
-  end
-  alias slice []
+  # `[]` / `slice`, `=~`, `match`, `start_with?` are native (see
+  # builtins/symbol.rs): they must set the frame-local `$~` on the
+  # *caller's* LEP, which a pure-Ruby `to_s`-delegation can't do.
 
   def size
     to_s.size
@@ -34,10 +33,6 @@ class Symbol
     to_s.swapcase.to_sym
   end
 
-  def start_with?(*args)
-    to_s.start_with?(*args)
-  end
-
   def end_with?(*args)
     to_s.end_with?(*args)
   end
@@ -63,10 +58,6 @@ class Symbol
     self
   end
 
-  def =~(other)
-    to_s =~ other
-  end
-
   def casecmp(other)
     return nil unless other.is_a?(Symbol)
     to_s.casecmp(other.to_s)
@@ -75,10 +66,6 @@ class Symbol
   def casecmp?(other)
     return nil unless other.is_a?(Symbol)
     to_s.casecmp?(other.to_s)
-  end
-
-  def match(other, *args, &block)
-    self.to_s.match(other, *args, &block)
   end
 
   def match?(other, pos = 0)

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -16,6 +16,18 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(SYMBOL_CLASS, "name", sym_name, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "inspect", sym_inspect, 0);
     globals.define_builtin_func(SYMBOL_CLASS, "to_proc", sym_to_proc, 0);
+    // Regexp-matching delegations. These are native (not the pure-Ruby
+    // `to_s.=~` forms in builtins/symbol.rb) specifically so that `$~`
+    // and the BACK_REF / NTH_REF family land on the *caller's* LEP.
+    // `$~` is frame-local; a Ruby-level `def =~(o); to_s =~ o; end`
+    // would set it on the Symbol method's own (discarded) frame, so the
+    // caller would never see it (CRuby keeps these as C functions for
+    // the same reason). `current_lep` skips native frames, so delegating
+    // to the `String#…` builtin from here writes `$~` to the caller.
+    globals.define_builtin_func(SYMBOL_CLASS, "=~", sym_match_op, 1);
+    globals.define_builtin_funcs_with(SYMBOL_CLASS, "[]", &["slice"], sym_aref, 1, 2, false);
+    globals.define_builtin_func_with(SYMBOL_CLASS, "match", sym_match, 1, 2, false);
+    globals.define_builtin_func_rest(SYMBOL_CLASS, "start_with?", sym_start_with);
     // Symbol.new is undefined (raises NoMethodError).
     let meta = globals.store.get_metaclass(SYMBOL_CLASS).id();
     globals
@@ -132,6 +144,85 @@ fn sym_to_proc(
     let outer_lfp = Lfp::heap_frame(self_val, globals[body_fid].meta());
     let proc = Proc::from_outer(outer_lfp, body_fid, pc);
     Ok(proc.into())
+}
+
+/// Convert the receiver Symbol to its `String` `Value` by invoking
+/// `to_s` (a frozen-name string), for delegating String-method calls.
+fn sym_self_string(vm: &mut Executor, globals: &mut Globals, self_val: Value) -> Result<Value> {
+    vm.invoke_method_inner(globals, IdentId::get_id("to_s"), self_val, &[], None, None)
+}
+
+///
+/// ### Symbol#=~
+///
+/// - self =~ other -> Integer | nil
+///
+/// Delegates to `to_s =~ other`; native so `$~` is set on the caller.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/=3d=7e.html]
+#[monoruby_builtin]
+fn sym_match_op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = sym_self_string(vm, globals, lfp.self_val())?;
+    vm.invoke_method_inner(globals, IdentId::_MATCH, s, &[lfp.arg(0)], None, None)
+}
+
+///
+/// ### Symbol#[] / Symbol#slice
+///
+/// - self[*args] -> String | nil
+///
+/// Delegates to `to_s[*args]`; native so a Regexp index sets `$~` on
+/// the caller.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/=5b=5d.html]
+#[monoruby_builtin]
+fn sym_aref(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = sym_self_string(vm, globals, lfp.self_val())?;
+    let mut args: Vec<Value> = vec![lfp.arg(0)];
+    if let Some(a1) = lfp.try_arg(1) {
+        args.push(a1);
+    }
+    vm.invoke_method_inner(globals, IdentId::get_id("[]"), s, &args, None, None)
+}
+
+///
+/// ### Symbol#match
+///
+/// - match(pattern, pos = 0) -> MatchData | nil
+/// - match(pattern, pos = 0) { |m| ... } -> object | nil
+///
+/// Delegates to `to_s.match(...)`; native so `$~` is set on the caller.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/match.html]
+#[monoruby_builtin]
+fn sym_match(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = sym_self_string(vm, globals, lfp.self_val())?;
+    let mut args: Vec<Value> = vec![lfp.arg(0)];
+    if let Some(pos) = lfp.try_arg(1) {
+        args.push(pos);
+    }
+    vm.invoke_method_inner(globals, IdentId::get_id("match"), s, &args, lfp.block(), None)
+}
+
+///
+/// ### Symbol#start_with?
+///
+/// - start_with?(*prefixes) -> bool
+///
+/// Delegates to `to_s.start_with?(*prefixes)`; native so a Regexp
+/// prefix sets `$~` on the caller.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Symbol/i/start_with=3f.html]
+#[monoruby_builtin]
+fn sym_start_with(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let s = sym_self_string(vm, globals, lfp.self_val())?;
+    let args: Vec<Value> = lfp.arg(0).as_array().iter().cloned().collect();
+    vm.invoke_method_inner(globals, IdentId::get_id("start_with?"), s, &args, None, None)
 }
 
 ///


### PR DESCRIPTION
## Summary

`core/symbol` (ruby/spec) regressed after `$~` became frame-local
(#608): the last-match pseudo-variables (`$~`, `$&`, `$1`..) and
`Regexp.last_match` were no longer set by `Symbol#=~`, `#match`,
`#[]` / `#slice`, and `#start_with?` — 7 spec failures/errors.

## Root cause

These were pure-Ruby delegations in `builtins/symbol.rb`:

```ruby
def =~(other); to_s =~ other; end
def match(o, *a, &b); to_s.match(o, *a, &b); end
def [](*args); to_s.[](*args); end   # alias slice
def start_with?(*args); to_s.start_with?(*args); end
```

With frame-local `$~`, the inner `String#=~` sets `$~` on the **Symbol
method's own LEP**, which is discarded on return — so the caller never
sees it. (`String#…` works because it's native; CRuby keeps the Symbol
forms as C functions for exactly this reason.)

`bin/test`'s ruby/spec subset (`basicobject true false nil integer
float comparable math builtin_constants class numeric rational struct`)
does **not** include `core/symbol`, so CI didn't catch the regression.

## Fix

Reimplement the four match-setting methods as native builtins in
`builtins/symbol.rs` that delegate to the `String#…` builtin via
`invoke_method_inner`. `Executor::current_lep` skips native frames, so
the inner String match writes `$~` to the Ruby caller's LEP — matching
CRuby. `match?` / `end_with?` stay pure-Ruby (they don't set `$~`).

## Test plan

- [x] `:abc =~ /(a)/`, `:abc.match(/(b)/)`, `:hello[/l(l)/]`,
      `:hello.slice(/(l)/)`, `:hello.start_with?(/h(.)/)` set
      `$~` / `$1` matching CRuby; non-regex `:hello[1,2]` → `"el"`
      unchanged
- [x] `core/symbol`: 330 examples, **0 failures, 0 errors** (was 3
      failures + 4 errors)
- [x] `cargo test --release -p monoruby --lib`: 1600 passed / 2 failed
      — the two failures (`string_inspect`, `symbol_inspect_unquoted`)
      already fail on `origin/master` (LANG/encoding-dependent) and are
      unrelated

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_