### PR TITLE
feat(io): IO#read_nonblock / #write_nonblock + idempotent #close (−40 E)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1173,6 +1173,21 @@ class IO
   SEEK_CUR = 1
   SEEK_END = 2
 
+  # Mix-ins tagging the exceptions raised by `*_nonblock` when the
+  # operation would block. The concrete classes subclass the matching
+  # Errno (on Linux EAGAIN == EWOULDBLOCK) and include these so
+  # `rescue IO::WaitReadable` / `rescue IO::WaitWritable` work.
+  module WaitReadable; end
+  module WaitWritable; end
+  class EAGAINWaitReadable < Errno::EAGAIN
+    include IO::WaitReadable
+  end
+  class EAGAINWaitWritable < Errno::EAGAIN
+    include IO::WaitWritable
+  end
+  EWOULDBLOCKWaitReadable = EAGAINWaitReadable
+  EWOULDBLOCKWaitWritable = EAGAINWaitWritable
+
   def sync
     raise IOError, "closed stream" if closed?
     false

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -4679,6 +4679,116 @@ mod tests {
     }
 
     #[test]
+    fn io_read_write_nonblock_buffer_pushback_full() {
+        // read_nonblock with an output buffer (data + maxlen 0 + EOF arms),
+        // ungetc pushback, write_nonblock to_s coercion, and the
+        // would-block paths on a saturated pipe.
+        run_test_no_result_check(
+            r#"
+            r, w = IO.pipe
+            w.write("foobar")
+            buf = +"xxxx"
+            r.read_nonblock(3, buf)                 # fills buf with "foo"
+            raise "buf #{buf.inspect}" unless buf == "foo" && r.read_nonblock(3, buf).equal?(buf) && buf == "bar"
+            # maxlen 0 with buffer returns the buffer untouched.
+            raise "zero" unless r.read_nonblock(0, buf).equal?(buf)
+            # ungetc pushback drained by read_nonblock.
+            w.write("Z")
+            c = r.read_nonblock(1)                   # "Z"
+            r.ungetc(c)
+            raise "pushback" unless r.read_nonblock(5) == "Z"
+            w.close
+            # EOF with a buffer clears it then returns nil (exception: false).
+            raise "eofbuf" unless r.read_nonblock(5, buf, exception: false).nil? && buf.empty?
+            r.close
+            "#,
+        );
+        // write_nonblock #to_s-coerces a non-String, and the saturated
+        // pipe yields :wait_writable / IO::WaitWritable.
+        run_test_no_result_check(
+            r#"
+            r, w = IO.pipe
+            n = w.write_nonblock(12345)             # to_s ⇒ "12345"
+            raise "to_s #{n}" unless n == 5
+            blocked = false
+            10000.times do
+              break (blocked = true) if w.write_nonblock("a" * 10000, exception: false) == :wait_writable
+            end
+            raise "no block" unless blocked
+            ok = false
+            begin
+              loop { w.write_nonblock("a" * 10000) }
+            rescue IO::WaitWritable => e
+              ok = e.is_a?(Errno::EAGAIN)
+            end
+            raise "no wait-writable raise" unless ok
+            r.close; w.close
+            "#,
+        );
+        // read_nonblock on a regular File exercises the seek-sync path.
+        run_test_no_result_check(
+            r#"
+            path = "/tmp/monoruby_io_rnb_file_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "abcdef")
+              f = File.open(path, "r")
+              f.read(2)                              # buffered read
+              raise "file rnb" unless f.read_nonblock(2) == "cd"
+              f.close
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+        // write_nonblock / read_nonblock on closed streams ⇒ IOError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            r.close; w.close
+            w.write_nonblock("x")
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_nonblock_error_arms() {
+        // read_nonblock on a closed stream ⇒ IOError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            r.close; w.close
+            r.read_nonblock(1)
+            "#,
+        );
+        // read_nonblock on a non-readable stream ($stdout) ⇒ IOError.
+        run_test_error(r#"$stdout.read_nonblock(1)"#);
+        // write_nonblock on a non-writable stream (pipe read end) ⇒ IOError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            begin
+              r.write_nonblock("x")
+            ensure
+              r.close; w.close
+            end
+            "#,
+        );
+        // write_nonblock to a pipe whose read end is closed ⇒ Errno::EPIPE
+        // (the hard-error arm; SIGPIPE is ignored by the runtime).
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            r.close
+            begin
+              w.write_nonblock("x")
+            ensure
+              w.close
+            end
+            "#,
+        );
+    }
+
+    #[test]
     fn io_read_nonblock_negative_and_eof() {
         // Negative length ⇒ ArgumentError.
         run_test_error(

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -40,6 +40,12 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(IO_CLASS, "pread", io_pread, 2, 3, false);
     globals.define_builtin_func(IO_CLASS, "pwrite", io_pwrite, 2);
     globals.define_builtin_func_with(IO_CLASS, "sysread", io_sysread, 1, 2, false);
+    globals.define_builtin_func_with_kw(
+        IO_CLASS, "read_nonblock", io_read_nonblock, 1, 2, false, &["exception"], false,
+    );
+    globals.define_builtin_func_with_kw(
+        IO_CLASS, "write_nonblock", io_write_nonblock, 1, 1, false, &["exception"], false,
+    );
     globals.define_builtin_func_with(IO_CLASS, "readlines", io_readlines, 0, 2, false);
     globals.define_builtin_func(IO_CLASS, "binmode", io_binmode, 0);
     globals.define_builtin_func(IO_CLASS, "binmode?", io_binmode_, 0);
@@ -734,6 +740,11 @@ fn isatty(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/close.html]
 #[monoruby_builtin]
 fn close(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // CRuby's `IO#close` is idempotent — closing an already-closed
+    // stream is a no-op that returns nil (no IOError).
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Ok(Value::nil());
+    }
     let popen_result = lfp.self_val().as_io_inner_mut().close()?;
     if let Some((exit_status, pid)) = popen_result {
         // Set $? (Process::Status) via Process::Status.new(exitstatus, pid)
@@ -2321,6 +2332,147 @@ fn io_sysread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             Ok(v)
         }
         None => Ok(Value::bytes(buf)),
+    }
+}
+
+/// Resolve a nested `IO::<name>` exception class id (for the
+/// `*WaitReadable` / `*WaitWritable` classes defined in startup.rb).
+fn io_wait_class(globals: &Globals, name: &str) -> Option<ClassId> {
+    let io = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("IO"))?
+        .is_class_or_module()?;
+    globals
+        .store
+        .get_constant(io.id(), IdentId::get_id(name))?
+        .loaded_value()?
+        .is_class_or_module()
+        .map(|m| m.id())
+}
+
+///
+/// ### IO#read_nonblock
+/// - read_nonblock(maxlen, outbuf = nil, exception: true) -> String | outbuf | :wait_readable | nil
+///
+/// A single non-blocking read. When the read would block: raises
+/// `IO::EAGAINWaitReadable` (default) or returns `:wait_readable`
+/// (`exception: false`). At end of file: raises `EOFError` (default)
+/// or returns `nil`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/read_nonblock.html]
+#[monoruby_builtin]
+fn io_read_nonblock(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if maxlen < 0 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "negative length {} given",
+            maxlen
+        )));
+    }
+    let buffer: Option<Value> = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => Some(v.coerce_to_rstring(vm, globals)?.as_val()),
+        _ => None,
+    };
+    // `exception:` keyword is at slot 2 (positional max 2).
+    let exception = lfp.try_arg(2).map_or(true, |v| v.as_bool());
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    if maxlen == 0 {
+        return Ok(match buffer {
+            Some(v) => v,
+            None => Value::string_from_vec(vec![]),
+        });
+    }
+    let outcome = lfp
+        .self_val()
+        .as_io_inner_mut()
+        .read_nonblock(maxlen as usize, &globals.store)?;
+    match outcome {
+        NonblockRead::Data(buf) => match buffer {
+            Some(mut v) => {
+                let enc = v.as_rstring_inner().encoding();
+                *v.as_rstring_inner_mut() = RStringInner::from_encoding(&buf, enc);
+                Ok(v)
+            }
+            None => Ok(Value::bytes(buf)),
+        },
+        NonblockRead::Eof => {
+            // CRuby empties a supplied buffer before signalling EOF.
+            if let Some(mut v) = buffer {
+                let enc = v.as_rstring_inner().encoding();
+                *v.as_rstring_inner_mut() = RStringInner::from_encoding(&[], enc);
+            }
+            if exception {
+                Err(MonorubyErr::eoferr(&globals.store, "end of file reached"))
+            } else {
+                Ok(Value::nil())
+            }
+        }
+        NonblockRead::WouldBlock => {
+            if exception {
+                let cid = io_wait_class(globals, "EAGAINWaitReadable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitReadable not defined"))?;
+                Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - read would block".to_string(),
+                ))
+            } else {
+                Ok(Value::symbol(IdentId::get_id("wait_readable")))
+            }
+        }
+    }
+}
+
+///
+/// ### IO#write_nonblock
+/// - write_nonblock(string, exception: true) -> Integer | :wait_writable
+///
+/// A single non-blocking write; returns the number of bytes written.
+/// When the write would block: raises `IO::EAGAINWaitWritable`
+/// (default) or returns `:wait_writable` (`exception: false`).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/write_nonblock.html]
+#[monoruby_builtin]
+fn io_write_nonblock(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let bytes = if let Some(b) = lfp.arg(0).try_bytes() {
+        b.to_vec()
+    } else {
+        vm.to_s(globals, lfp.arg(0))?.into_bytes()
+    };
+    // `exception:` keyword is at slot 1 (positional max 1).
+    let exception = lfp.try_arg(1).map_or(true, |v| v.as_bool());
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    let outcome = lfp
+        .self_val()
+        .as_io_inner_mut()
+        .write_nonblock(&bytes, &globals.store)?;
+    match outcome {
+        NonblockWrite::Written(n) => Ok(Value::integer(n as i64)),
+        NonblockWrite::WouldBlock => {
+            if exception {
+                let cid = io_wait_class(globals, "EAGAINWaitWritable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitWritable not defined"))?;
+                Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - write would block".to_string(),
+                ))
+            } else {
+                Ok(Value::symbol(IdentId::get_id("wait_writable")))
+            }
+        }
     }
 }
 
@@ -4491,6 +4643,78 @@ mod tests {
             r, w = IO.pipe
             r.close; w.close
             r.sysread(1)
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_read_write_nonblock() {
+        run_test_no_result_check(
+            r#"
+            r, w = IO.pipe
+            res = []
+            # No data: exception: false ⇒ :wait_readable.
+            res << r.read_nonblock(5, exception: false)
+            # No data: default ⇒ IO::WaitReadable (is_a? Errno::EAGAIN).
+            begin
+              r.read_nonblock(5)
+            rescue IO::WaitReadable => e
+              res << [:rescued, e.is_a?(Errno::EAGAIN)]
+            end
+            # write_nonblock returns bytes written; read sees them.
+            res << w.write_nonblock("hello")
+            res << r.read_nonblock(4)          # "hell"
+            res << r.read_nonblock(10)         # "o"
+            res << r.read_nonblock(0)          # "" immediately
+            w.close
+            begin
+              r.read_nonblock(10)
+            rescue EOFError
+              res << :eof
+            end
+            r.close
+            raise "unexpected: #{res.inspect}" unless res == [:wait_readable, [:rescued, true], 5, "hell", "o", "", :eof]
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_read_nonblock_negative_and_eof() {
+        // Negative length ⇒ ArgumentError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            begin
+              r.read_nonblock(-1)
+            ensure
+              r.close; w.close
+            end
+            "#,
+        );
+        // EOF with exception: false ⇒ nil.
+        run_test_no_result_check(
+            r#"
+            r, w = IO.pipe
+            w.write("ab"); w.close
+            r.read_nonblock(5)                 # "ab"
+            v = r.read_nonblock(5, exception: false)
+            r.close
+            raise "expected nil, got #{v.inspect}" unless v.nil?
+            "#,
+        );
+    }
+
+    #[test]
+    fn io_close_is_idempotent() {
+        // CRuby: closing an already-closed stream is a no-op (no IOError).
+        run_test_once(
+            r#"
+            r, w = IO.pipe
+            w.close
+            w.close
+            r.close
+            r.close
+            "ok"
             "#,
         );
     }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -19,7 +19,7 @@ pub use enumerator::*;
 pub use exception::ExceptionInner;
 pub use fiber::*;
 pub use hash::*;
-pub use io::IoInner;
+pub use io::{IoInner, NonblockRead, NonblockWrite};
 pub use ivar_table::*;
 pub use match_data::MatchDataInner;
 pub use method::*;

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -528,12 +528,7 @@ impl IoInner {
         // SAFETY: fd is a valid descriptor for the lifetime of this IO.
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
-            if flags < 0 {
-                return Err(MonorubyErr::ioerr(
-                    std::io::Error::last_os_error().to_string(),
-                ));
-            }
-            if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            if flags < 0 || libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
                 return Err(MonorubyErr::ioerr(
                     std::io::Error::last_os_error().to_string(),
                 ));

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -81,6 +81,19 @@ pub enum IoInner {
     Closed,
 }
 
+/// Outcome of a non-blocking `IO#read_nonblock`.
+pub enum NonblockRead {
+    Data(Vec<u8>),
+    WouldBlock,
+    Eof,
+}
+
+/// Outcome of a non-blocking `IO#write_nonblock`.
+pub enum NonblockWrite {
+    Written(usize),
+    WouldBlock,
+}
+
 impl std::clone::Clone for IoInner {
     fn clone(&self) -> Self {
         match self {
@@ -507,6 +520,91 @@ impl IoInner {
         };
         out.extend(chunk);
         Ok(out)
+    }
+
+    /// Set `O_NONBLOCK` on the underlying fd (idempotent).
+    fn set_nonblock(&self) -> Result<()> {
+        let fd = self.fileno()?;
+        // SAFETY: fd is a valid descriptor for the lifetime of this IO.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            if flags < 0 {
+                return Err(MonorubyErr::ioerr(
+                    std::io::Error::last_os_error().to_string(),
+                ));
+            }
+            if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+                return Err(MonorubyErr::ioerr(
+                    std::io::Error::last_os_error().to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// `IO#read_nonblock` core: a single non-blocking read of up to
+    /// `maxlen` bytes. Drains ungetc pushback first; otherwise sets
+    /// `O_NONBLOCK` and issues one raw `read(2)`. Reports `WouldBlock`
+    /// on `EAGAIN`/`EWOULDBLOCK` and `Eof` on a 0-byte read.
+    pub fn read_nonblock(&mut self, maxlen: usize, store: &Store) -> Result<NonblockRead> {
+        if self.pushback_len() > 0 {
+            return Ok(NonblockRead::Data(self.take_pushback(Some(maxlen))));
+        }
+        if !self.is_readable() {
+            return Err(MonorubyErr::ioerr("not opened for reading"));
+        }
+        // Best-effort: sync a seekable File's BufReader to its logical
+        // position (discarding its buffer) so the raw read below is at
+        // the right offset; pipes/sockets aren't seekable and skip it.
+        if let Self::File(file) = self {
+            let reader = &mut *Rc::get_mut(file).unwrap().reader;
+            let _ = reader.seek(SeekFrom::Current(0));
+        }
+        let fd = self.fileno()?;
+        self.set_nonblock()?;
+        let mut buf = vec![0u8; maxlen];
+        // SAFETY: fd is valid; buf has `maxlen` bytes of capacity.
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, maxlen) };
+        if n > 0 {
+            buf.truncate(n as usize);
+            Ok(NonblockRead::Data(buf))
+        } else if n == 0 {
+            Ok(NonblockRead::Eof)
+        } else {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(e) if e == libc::EAGAIN || e == libc::EWOULDBLOCK => {
+                    Ok(NonblockRead::WouldBlock)
+                }
+                _ => Err(MonorubyErr::from_io_err(store, &err, "read_nonblock".to_string())),
+            }
+        }
+    }
+
+    /// `IO#write_nonblock` core: a single non-blocking `write(2)`.
+    /// Reports `WouldBlock` on `EAGAIN`/`EWOULDBLOCK`; a hard error
+    /// (e.g. `EPIPE`) is surfaced as the matching `Errno` exception.
+    pub fn write_nonblock(&mut self, bytes: &[u8], store: &Store) -> Result<NonblockWrite> {
+        if !self.is_writable() {
+            return Err(MonorubyErr::ioerr("not opened for writing"));
+        }
+        let fd = self.fileno()?;
+        self.set_nonblock()?;
+        // SAFETY: fd is valid; bytes is a valid buffer of `bytes.len()`.
+        let n = unsafe {
+            libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len())
+        };
+        if n >= 0 {
+            Ok(NonblockWrite::Written(n as usize))
+        } else {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(e) if e == libc::EAGAIN || e == libc::EWOULDBLOCK => {
+                    Ok(NonblockWrite::WouldBlock)
+                }
+                _ => Err(MonorubyErr::from_io_err(store, &err, "write_nonblock".to_string())),
+            }
+        }
     }
 
     pub fn read_line(&mut self) -> Result<Option<String>> {


### PR DESCRIPTION
## Summary

`IO#read_nonblock` and `IO#write_nonblock` were undefined.

### Class hierarchy (startup.rb)
Add the `IO::WaitReadable` / `IO::WaitWritable` mix-in modules and the `IO::EAGAINWaitReadable` / `IO::EAGAINWaitWritable` exception classes (subclassing `Errno::EAGAIN` and including the matching module), plus the `EWOULDBLOCK*` aliases (EAGAIN == EWOULDBLOCK on Linux). This makes `rescue IO::WaitReadable` / `rescue Errno::EAGAIN` both work on the raised object.

### Non-blocking core (`IoInner`)
`set_nonblock` flips `O_NONBLOCK` on the fd; `read_nonblock` / `write_nonblock` issue a single raw `read(2)`/`write(2)` and report `WouldBlock` on `EAGAIN`/`EWOULDBLOCK`, `Eof` on a 0-byte read, or the matching `Errno` (e.g. `EPIPE`) on a hard error. `read_nonblock` drains ungetc pushback first and best-effort syncs a seekable File's `BufReader` (so the raw read is at the right offset).

### Builtins
- `read_nonblock(maxlen, buf = nil, exception: true)`: `WouldBlock` ⇒ raise `IO::EAGAINWaitReadable` or return `:wait_readable`; `Eof` ⇒ raise `EOFError` (clearing a supplied buffer first) or return `nil`; `maxlen == 0` ⇒ `""`.
- `write_nonblock(string, exception: true)`: returns bytes written; `WouldBlock` ⇒ raise `IO::EAGAINWaitWritable` or `:wait_writable`.

### `IO#close` idempotency
CRuby's `IO#close` is a no-op on an already-closed stream; monoruby raised `IOError "closed stream"`. Return `nil` early when closed — this also unblocks specs (and `after :each` blocks) that close twice.

## Impact on `core/io` ruby/spec

| spec                 | E before | E after |
|----------------------|---------:|--------:|
| read_nonblock_spec   |       18 |       2 |
| write_nonblock_spec  |       30 |       1 |

The residual errors need the `io/nonblock` library (`IO#nonblock?`) and a buffered-write-position edge, both out of scope.

## Test plan

- [x] `cargo test --lib -p monoruby -- io_read_write_nonblock io_read_nonblock_negative_and_eof io_close_is_idempotent` ⇒ pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::io` ⇒ 103 pass
- [x] `mspec core/io/{read,write}_nonblock_spec`: E 48 → 3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_