### PR TITLE
feat(io): IO#readpartial (−14 E)

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -40,6 +40,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(IO_CLASS, "pread", io_pread, 2, 3, false);
     globals.define_builtin_func(IO_CLASS, "pwrite", io_pwrite, 2);
     globals.define_builtin_func_with(IO_CLASS, "sysread", io_sysread, 1, 2, false);
+    globals.define_builtin_func_with(IO_CLASS, "readpartial", io_readpartial, 1, 2, false);
     globals.define_builtin_func_with_kw(
         IO_CLASS, "read_nonblock", io_read_nonblock, 1, 2, false, &["exception"], false,
     );
@@ -2335,6 +2336,63 @@ fn io_sysread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     }
 }
 
+///
+/// ### IO#readpartial
+/// - readpartial(maxlen, outbuf = nil) -> String | outbuf
+///
+/// Reads at most `maxlen` bytes, returning as soon as any data is
+/// available (blocking only when nothing is buffered yet). Raises
+/// `EOFError` at end of file. Reads through the buffered reader, so
+/// ungetc pushback and already-buffered bytes are honoured.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/readpartial.html]
+#[monoruby_builtin]
+fn io_readpartial(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if maxlen < 0 {
+        return Err(MonorubyErr::argumenterr("negative length"));
+    }
+    let buffer: Option<Value> = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => Some(v.coerce_to_rstring(vm, globals)?.as_val()),
+        _ => None,
+    };
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    if maxlen == 0 {
+        // CRuby's readpartial(0) clears and returns a supplied buffer.
+        return Ok(match buffer {
+            Some(mut v) => {
+                let enc = v.as_rstring_inner().encoding();
+                *v.as_rstring_inner_mut() = RStringInner::from_encoding(&[], enc);
+                v
+            }
+            None => Value::string_from_vec(vec![]),
+        });
+    }
+    let buf = lfp.self_val().as_io_inner_mut().readpartial(maxlen as usize)?;
+    if buf.is_empty() {
+        if let Some(mut v) = buffer {
+            let enc = v.as_rstring_inner().encoding();
+            *v.as_rstring_inner_mut() = RStringInner::from_encoding(&[], enc);
+        }
+        return Err(MonorubyErr::eoferr(&globals.store, "end of file reached"));
+    }
+    match buffer {
+        Some(mut v) => {
+            let enc = v.as_rstring_inner().encoding();
+            *v.as_rstring_inner_mut() = RStringInner::from_encoding(&buf, enc);
+            Ok(v)
+        }
+        None => Ok(Value::bytes(buf)),
+    }
+}
+
 /// Resolve a nested `IO::<name>` exception class id (for the
 /// `*WaitReadable` / `*WaitWritable` classes defined in startup.rb).
 fn io_wait_class(globals: &Globals, name: &str) -> Option<ClassId> {
@@ -4523,6 +4581,54 @@ mod tests {
             end
             "#,
         );
+    }
+
+    #[test]
+    fn io_readpartial_basic() {
+        run_test_no_result_check(
+            r#"
+            r, w = IO.pipe
+            w.write("foobar")
+            # reads at most maxlen, returning available data.
+            raise "1" unless r.read(1) == "f"
+            raise "2" unless r.readpartial(1) == "o"
+            # ungetc pushback combines with buffered data.
+            c = r.getc
+            r.ungetc(c)
+            raise "3" unless r.readpartial(3) == "oba"
+            raise "4" unless r.readpartial(3) == "r"
+            # maxlen 0 clears + returns the buffer.
+            buf = +"existing"
+            raise "5" unless r.readpartial(0, buf).equal?(buf) && buf.empty?
+            # into a buffer, then EOF raises (clearing the buffer).
+            w.write("hi"); w.close
+            out = +""
+            raise "6" unless r.readpartial(10, out).equal?(out) && out == "hi"
+            begin
+              r.readpartial(5, out)
+              raise "no eof"
+            rescue EOFError
+              raise "7" unless out.empty?
+            end
+            r.close
+            "#,
+        );
+        // negative length ⇒ ArgumentError; closed ⇒ IOError.
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            begin; r.readpartial(-1); ensure; r.close; w.close; end
+            "#,
+        );
+        run_test_error(
+            r#"
+            r, w = IO.pipe
+            r.close; w.close
+            r.readpartial(1)
+            "#,
+        );
+        // not opened for reading ⇒ IOError.
+        run_test_error(r#"$stdout.readpartial(1)"#);
     }
 
     #[test]

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -17,6 +17,26 @@ fn encode_wait_status(status: &std::process::ExitStatus) -> i32 {
     status.into_raw()
 }
 
+/// Pull up to `need` bytes from a buffered reader for `readpartial`.
+/// When `no_block` is set (ungetc pushback already produced data),
+/// only the bytes already sitting in the internal buffer are taken;
+/// otherwise `fill_buf` may block once to fetch more.
+fn read_partial_chunk<T: Read>(
+    reader: &mut std::io::BufReader<T>,
+    need: usize,
+    no_block: bool,
+) -> Result<Vec<u8>> {
+    let avail: &[u8] = if no_block {
+        reader.buffer()
+    } else {
+        reader.fill_buf().map_err(|e| MonorubyErr::ioerr(e.to_string()))?
+    };
+    let n = avail.len().min(need);
+    let chunk = avail[..n].to_vec();
+    reader.consume(n);
+    Ok(chunk)
+}
+
 #[derive(Debug)]
 pub struct FileDescriptor {
     reader: ManuallyDrop<std::io::BufReader<std::fs::File>>,
@@ -600,6 +620,61 @@ impl IoInner {
                 _ => Err(MonorubyErr::from_io_err(store, &err, "write_nonblock".to_string())),
             }
         }
+    }
+
+    /// `IO#readpartial` core: return up to `maxlen` bytes, blocking
+    /// only when no data is buffered or available yet. Unlike
+    /// `sysread` this reads *through* the `BufReader` (so already-
+    /// buffered bytes are returned) and unlike `read` it never blocks
+    /// to fill the whole `maxlen`. An empty result signals EOF.
+    pub fn readpartial(&mut self, maxlen: usize) -> Result<Vec<u8>> {
+        // Drain ungetc pushback first. When pushback supplied any
+        // bytes, we must not block for more — only append bytes that
+        // are *already* buffered (CRuby returns the available data).
+        let had_pushback = self.pushback_len() > 0;
+        let mut out = if had_pushback {
+            self.take_pushback(Some(maxlen))
+        } else {
+            vec![]
+        };
+        if out.len() >= maxlen {
+            return Ok(out);
+        }
+        let need = maxlen - out.len();
+        match self {
+            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Stdout | Self::Stderr => {
+                return Err(MonorubyErr::ioerr("not opened for reading"));
+            }
+            Self::Stdin => {
+                if !had_pushback {
+                    let mut buf = vec![0u8; need];
+                    let n = std::io::stdin()
+                        .read(&mut buf)
+                        .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
+                    buf.truncate(n);
+                    out.extend(buf);
+                }
+            }
+            Self::File(file) => {
+                if !file.readable {
+                    return Err(MonorubyErr::ioerr("not opened for reading"));
+                }
+                let reader = &mut *Rc::get_mut(file).unwrap().reader;
+                let chunk = read_partial_chunk(reader, need, had_pushback)?;
+                out.extend(chunk);
+            }
+            Self::Popen(popen) => {
+                let popen = Rc::get_mut(popen).unwrap();
+                let reader = popen
+                    .reader
+                    .as_mut()
+                    .ok_or_else(|| MonorubyErr::ioerr("not opened for reading"))?;
+                let chunk = read_partial_chunk(reader, need, had_pushback)?;
+                out.extend(chunk);
+            }
+        }
+        Ok(out)
     }
 
     pub fn read_line(&mut self) -> Result<Option<String>> {


### PR DESCRIPTION
## Summary

`IO#readpartial` was undefined. Add it: read at most `maxlen` bytes, returning as soon as any data is available and blocking only when nothing is buffered yet — distinct from `read` (which blocks to fill the whole length) and `sysread` (which bypasses the buffer).

### `IoInner::readpartial`
- drains ungetc pushback first; when pushback supplied data, only bytes *already* in the `BufReader` are appended (no blocking), so `ungetc` + `readpartial` returns the combined available data;
- otherwise `fill_buf` may block once to fetch data, then takes up to `maxlen` bytes via `consume`;
- reads through the buffered reader (File / Popen), so buffered and pushed-back bytes are honoured;
- an empty result signals EOF.

The shared `read_partial_chunk` helper is generic over the `BufReader`'s inner reader.

### `IO#readpartial(maxlen, outbuf = nil)`
- coerces `maxlen` via `#to_int`; negative ⇒ ArgumentError;
- `maxlen == 0` clears and returns a supplied buffer (CRuby);
- raises `EOFError` (clearing a supplied buffer first) at EOF;
- with a buffer, fills it in place preserving its encoding.

## Impact on `core/io/readpartial_spec`

E 14 → 0, F 0 → 1. The single remaining failure needs the character-conversion-on-ungetc `IOError` (an encoding-converter edge), out of scope.

## Test plan

- [x] `cargo test --lib -p monoruby -- io_readpartial_basic` ⇒ pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::io` ⇒ 105 pass
- [x] `mspec core/io/readpartial_spec` E: 14 → 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_