### PR TITLE
Fix yjit-bench gem resolution (Category A) and add Digest library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +392,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -610,6 +648,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1151,6 +1199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1282,7 @@ dependencies = [
  "indexmap",
  "libc",
  "libffi",
+ "md-5",
  "monoasm",
  "monoasm_macro",
  "monoruby-attr",
@@ -1237,6 +1296,8 @@ dependencies = [
  "rubymap",
  "ruruby-parse",
  "rustyline",
+ "sha1",
+ "sha2",
  "signal-hook",
  "smallvec 1.10.0",
  "tempfile",
@@ -1993,6 +2054,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2495,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/doc/yjit_bench_errors.md
+++ b/doc/yjit_bench_errors.md
@@ -34,9 +34,32 @@ setivar_young, splay, str_concat, structaref, structaset, sudoku, throw
 
 ## 失敗カテゴリと原因
 
-### Category A: bundler / gem 解決エラー (環境依存・monoruby 本体のバグではない)
+### Category A: bundler / gem 解決エラー
 
-**症状:** `bundler/definition.rb:702: ... GemNotFound: Could not find <gem> ...`
+> **2026-05-21 更新 — 解決済み。** ホストに Ruby 4.0+ を入れた後も残った
+> 本質的原因は、ベンダリング rbconfig.rb が `ENABLE_SHARED="no"` を持ち
+> `Gem.extension_api_version` が `<api>-static` を返すこと。これがホストの
+> gem 拡張ディレクトリ (`.../extensions/<plat>/<api>/`、`-static` 無し) と
+> 食い違い、rubygems/bundler が **全 C 拡張 gem を「拡張が未ビルド」と判定
+> してスキップ**するため、`Gemfile.lock` が json/cgi 等の C 拡張 gem を
+> pin していると `materialize` が `GemNotFound` で落ちていた。
+> 修正 (この PR):
+> 1. `search_lib` が monoruby 自前スタブ専用ルート `~/.monoruby/stub`
+>    (`stdlib/` + `gem/`) を `$LOAD_PATH` より前に固定 → gem activation の
+>    `$LOAD_PATH.unshift` による並べ替えに免疫化 (json/psych 等のスタブが
+>    確実に勝つ)。vendored bundler/rubygems は固定しない (コード版と spec 版
+>    の連動を壊し `CorruptBundlerInstallError` を招くため)。
+> 2. ホスト gem 解決時は `RbConfig::CONFIG['ENABLE_SHARED']='yes'` に上書き
+>    し `-static` を外す → bundler がホスト C 拡張 gem を受理。
+> 3. json スタブに `JSON::VERSION` を追加。
+>
+> 結果、gem/bundler 解決でブロックされるベンチは無くなった (psych-load 等が
+> 完走)。残る失敗は個別ライブラリ未実装 (digest=rack/graphql/mail/hexapdf,
+> openssl cipher=erubi-rails, unicode-display_width=rubocop) や、Ractor 専用
+> harness を default loader で直接起動した際の引数不整合 (json_parse_*; CRuby
+> でも同一行で落ちる) で、いずれも gem 解決とは別問題。
+
+**当初の症状 (ホスト 3.3.6 時点):** `bundler/definition.rb:702: ... GemNotFound: Could not find <gem> ...`
 
 **根本原因:** monoruby の `build.rs` は CRuby **4.0 以上** が `PATH` に
 無いと以下の 3 ファイルを生成しない (Warning: failed to read library

--- a/doc/yjit_bench_errors.md
+++ b/doc/yjit_bench_errors.md
@@ -1,0 +1,260 @@
+# yjit-bench Error Investigation
+
+monoruby を `https://github.com/Shopify/yjit-bench` の全ベンチマークに
+対して `target/release/monoruby <benchmark.rb>` 形式で実行し、エラー
+終了したものをカテゴリ別に分類した。
+
+- monoruby: branch `claude/investigate-yjit-bench-errors-TiRVg`, `cargo build --release`
+- yjit-bench: master (cloned at `/home/user/yjit-bench`)
+- host: x86-64 Linux, system Ruby = **3.3.6** (rbenv), Ruby 4.0+ は未インストール
+- benchmark 実行時の harness 環境変数: `WARMUP_ITRS=1 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=1`, タイムアウト 60s
+
+## Summary
+
+| Result | 件数 |
+|---|---|
+| 成功 (`rc=0`) | 40 |
+| 失敗 (`rc=1`) | 30 |
+| タイムアウト (`rc=124`) | 3 |
+| **合計** | **73** |
+
+### 成功したベンチマーク (40)
+
+純粋な Ruby のみで `harness/loader.rb` のみを require する単体スクリプトはほぼすべて完走した。
+gem 依存があってもベンダリングされていれば動く。
+
+```
+30k_ifelse, 30k_methods, attr_accessor, binarytrees, blurhash, cfunc_itself, etanni,
+fannkuchredux, fib, gcbench, getivar, getivar-module, gvl_release_acquire, keyword_args,
+knucleotide, loops-times, matmul, nbody, nqueens, object-new, object-new-initialize,
+object-new-no-escape, optcarrot, protoboeuf, protoboeuf-encode, respond_to, ruby-xor,
+rubykon, send_bmethod, send_cfunc_block, send_rubyfunc_block, setivar, setivar_object,
+setivar_young, splay, str_concat, structaref, structaset, sudoku, throw
+```
+
+## 失敗カテゴリと原因
+
+### Category A: bundler / gem 解決エラー (環境依存・monoruby 本体のバグではない)
+
+**症状:** `bundler/definition.rb:702: ... GemNotFound: Could not find <gem> ...`
+
+**根本原因:** monoruby の `build.rs` は CRuby **4.0 以上** が `PATH` に
+無いと以下の 3 ファイルを生成しない (Warning: failed to read library
+path file を出す):
+
+- `~/.monoruby/library_path` ($LOAD_PATH 用)
+- `~/.monoruby/gem_path` (GEM_PATH 用)
+- `~/.monoruby/ruby_version`
+
+`build.rs` の `MIN_RUBY_VERSION = (4, 0)` (`monoruby/build.rs:7`) でガード
+されているため、ホスト Ruby が 3.x だとファイルが書かれず、monoruby は
+GEM_PATH = 空・RUBY_VERSION = "4.0.0" (defaults) で起動する。
+ベンチマークの `use_gemfile`
+(`yjit-bench/harness/harness-common.rb:62`) が `Bundler.setup` を
+呼ぶと、ロックファイルに書かれた gem を `~/.monoruby/lib/<gem>` でも
+GEM_PATH でも見つけられず `GemNotFound` で落ちる。
+
+`GEM_PATH=/opt/rbenv/versions/3.3.6/lib/ruby/gems/3.3.0` を手で渡しても
+今度はベンダリングされた rubygems が Ruby 3.3 用ビルドの gem を弾く
+(`Gem::MissingSpecVersionError`, "Could not find 'json' (= 2.19.1) - did
+find: [json-2.19.1, ...]")。これはホスト Ruby のメジャー版と monoruby
+が報告する `RUBY_VERSION` の不一致による required_ruby_version 検査
+失敗で、本質的にビルド環境の前提 (Ruby 4.0+) が満たされていないこと
+が原因。
+
+該当 (27 件):
+
+```
+activerecord, addressable-equality, addressable-getters, addressable-join,
+addressable-merge, addressable-new, addressable-normalize, addressable-parse,
+addressable-setters, addressable-to-s, chunky-png, erubi, erubi-rails, fluentd,
+graphql, graphql-native, hexapdf, json_parse_float, json_parse_string, lee, mail,
+psych-load, rack, railsbench, rubocop, ruby-lsp, tinygql
+```
+
+→ Ruby 4.0+ をホストにインストールして `cargo build` を再実行すれば
+解消が期待される (`build.rs` が `gem_path` と `library_path` を生成する)。
+
+### Category B: `bundle install` 実行待ちのタイムアウト
+
+**症状:** stdout に `Fetching <gem>` / `Installing <gem>` が大量に並び、
+60s 制限を超えて kill された (`rc=124`)。
+
+`use_gemfile` は最初に `bundle check 2> /dev/null || bundle install` を
+shell で実行する。`bundle check` が失敗するとネットワークから gem を
+取りに行くため非常に時間がかかる。完了したとしても **Category A** に
+帰着する (vendored bundler / gems が解決できない)。
+
+該当 (3 件): `lobsters`, `sequel`, `shipit`
+
+### Category C: Git source 解決失敗
+
+**症状:** `bundler/source/git.rb:233: ... is not yet checked out. Run 'bundle install' first. (GitError)`
+
+Gemfile に `gem "liquid", git: "https://github.com/Shopify/liquid.git", ref: "..."`
+のような git ソースがあり、ベンダリング bundler が `git clone` 済み
+ディレクトリを必要とする。事前に `bundle install` が走れなかったため失敗。
+
+該当 (3 件): `liquid-c`, `liquid-compile`, `liquid-render`
+
+### Category D: monoruby の実装ギャップ — Ractor 未サポート
+
+**症状:** `NameError: uninitialized constant Ractor`
+
+monoruby は **設計上シングルスレッドで Ractor は未実装**。`yjit-bench`
+側の Ractor 専用ベンチは harness で `Ractor.make_shareable` を呼ぶ前に
+`defined?(Ractor.make_shareable)` でガードしているので大抵動くが、
+`knucleotide-ractor` はベンチ本体が直接 `Ractor.make_shareable(...)`
+を呼ぶため落ちる。
+
+```
+/home/user/yjit-bench/benchmarks/knucleotide-ractor/benchmark.rb:56:
+  TEST_SEQUENCE = Ractor.make_shareable(generate_test_sequence(100_000))
+                  ^^^^^^
+```
+
+該当 (1 件): `knucleotide-ractor`
+
+> `gvl_release_acquire`, `json_parse_float`, `json_parse_string` は
+> `harness-ractor` を使う設計だが、`harness/loader.rb` 経由なら
+> `make_shareable` は `obj` を返す noop に置き換わるので Ractor 自体は
+> 呼ばれない。
+
+### Category E: monoruby の実装バグ — StringScanner ストブが String を受け付けない
+
+**症状:** `NoMethodError: undefined method 'source' for {`
+
+`/root/.monoruby/lib/strscan.rb` は StringScanner を pure Ruby で再実装
+したスタブだが、`_match_at_pos` が引数を **Regexp 前提** で扱っている:
+
+```ruby
+# /root/.monoruby/lib/strscan.rb:214
+def _match_at_pos(pattern, advance, return_string)
+  ...
+  m = rest_str.match(Regexp.new("\\A(?:#{pattern.source})", pattern.options))
+                                          ^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^
+```
+
+CRuby の StringScanner は `scan("{")` / `skip("{")` のように **String** を
+渡すと文字列リテラルとしてマッチする (`scan_str_until`)。
+`ruby-json/benchmark.rb:68` は `skip("{")` を使うため即座に落ちる。
+
+最小再現:
+
+```ruby
+require "strscan"
+StringScanner.new("{x}").skip("{")
+# => undefined method 'source' for { (NoMethodError)
+```
+
+修正方針: `_match_at_pos` / `_match_forward` の入口で
+`pattern.is_a?(String)` なら `Regexp.escape(pattern)` で正規表現化
+する分岐を追加する。
+
+該当 (1 件): `ruby-json`
+
+### Category F: Category A の派生 (Git source + bundler 内部エラー)
+
+**症状:** rubyboy は Gemfile に git source (RubyBoy 本体) があり、また
+gem も不足。`bundler/lazy_specification.rb` → `materialize_for_installation`
+の経路で internal な NoMethodError が出る。
+ホストに Ruby 4.0 + 該当 gem が揃って初めて切り分けできる。
+
+該当 (1 件): `rubyboy`
+
+---
+
+## Category A の派生で見つかったその他の monoruby ギャップ
+
+GEM_PATH を手で設定して bundler をバイパスし `chunky-png` を実行すると、
+次の monoruby 側の不足が表面化した:
+
+**Zlib モジュールの定数不足:** `NameError: uninitialized constant Zlib::NO_COMPRESSION`
+
+`monoruby/stdlib/zlib.rb` には `VERSION`, `ZLIB_VERSION`, `CRC_TABLE`
+しか定義がなく、CRuby が持つ以下の標準定数が欠落している:
+
+- `Zlib::NO_COMPRESSION` (= 0)
+- `Zlib::BEST_SPEED` (= 1)
+- `Zlib::DEFAULT_COMPRESSION` (= -1)
+- `Zlib::BEST_COMPRESSION` (= 9)
+- 他に `Zlib::DEFLATED`, `Zlib::FILTERED`, `Zlib::HUFFMAN_ONLY`, ...
+
+`chunky-png` を Category A 修正後に動かすには別途これらの追加が必要。
+(本件は今回の調査対象から派生したついでの発見なので別 PR にする想定。)
+
+---
+
+## 失敗一覧と分類
+
+| benchmark | rc | category |
+|---|---|---|
+| activerecord | 1 | A |
+| addressable-equality | 1 | A |
+| addressable-getters | 1 | A |
+| addressable-join | 1 | A |
+| addressable-merge | 1 | A |
+| addressable-new | 1 | A |
+| addressable-normalize | 1 | A |
+| addressable-parse | 1 | A |
+| addressable-setters | 1 | A |
+| addressable-to-s | 1 | A |
+| chunky-png | 1 | A (+ Zlib 定数欠落) |
+| erubi | 1 | A |
+| erubi-rails | 1 | A |
+| fluentd | 1 | A |
+| graphql | 1 | A |
+| graphql-native | 1 | A |
+| hexapdf | 1 | A |
+| json_parse_float | 1 | A |
+| json_parse_string | 1 | A |
+| knucleotide-ractor | 1 | **D: Ractor 未実装** |
+| lee | 1 | A |
+| liquid-c | 1 | C |
+| liquid-compile | 1 | C |
+| liquid-render | 1 | C |
+| lobsters | 124 | B |
+| mail | 1 | A |
+| psych-load | 1 | A |
+| rack | 1 | A |
+| railsbench | 1 | A |
+| rubocop | 1 | A |
+| ruby-json | 1 | **E: StringScanner スタブのバグ** |
+| ruby-lsp | 1 | A |
+| rubyboy | 1 | F (Category A 派生) |
+| sequel | 124 | B |
+| shipit | 124 | B |
+| tinygql | 1 | A |
+
+## 再現コマンド
+
+```sh
+# 1. monoruby build
+cd /home/user/monoruby
+cargo build --release
+
+# 2. yjit-bench clone (浅い)
+cd /home/user
+git clone --depth 1 https://github.com/Shopify/yjit-bench.git
+
+# 3. ベンチを 1 本ずつ実行 (例)
+WARMUP_ITRS=1 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=1 \
+  /home/user/monoruby/target/release/monoruby \
+  /home/user/yjit-bench/benchmarks/ruby-json/benchmark.rb
+```
+
+`/tmp/run_all_benchmarks.sh` に一括実行用のスクリプトを置いた
+(成果物は `/tmp/yjit-bench-results/<name>.{out,err}` に保存される)。
+
+## monoruby 側で取り組む価値があるもの
+
+Category A/B/C/F は基本的にホスト環境を Ruby 4.0+ + gem 一式に揃え
+直せば前進する。一方 Category D/E は monoruby 自身の不足:
+
+1. **`ruby-json`**: `~/.monoruby/lib/strscan.rb` (= `monoruby/stdlib/strscan.rb`)
+   の `_match_at_pos` / `_match_forward` に String→Regexp 変換を追加。
+   工数小・効果大 (CRuby 互換性向上)。
+2. **`chunky-png` 派生**: `monoruby/stdlib/zlib.rb` に CRuby 互換の
+   圧縮レベル定数を追加。
+3. **`knucleotide-ractor`**: Ractor 未実装は monoruby の設計上の制約
+   なので、yjit-bench 側でスキップ扱いにするのが現実的。

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -79,6 +79,9 @@ unicode-segmentation = "1.13.2"
 signal-hook = "0.4.4"
 divrem = "1.0.0"
 libffi = "5.1.0"
+md-5 = "0.10"
+sha1 = "0.10"
+sha2 = "0.10"
 
 [build-dependencies]
 dirs = "6.0.0"

--- a/monoruby/build.rs
+++ b/monoruby/build.rs
@@ -58,17 +58,29 @@ fn main() {
 
     let lib_dir = lib_path.join("lib");
     let builtins_dir = lib_path.join("builtins");
+    // `stub` holds *only* monoruby's own C-extension replacement stubs
+    // (the `stdlib/` and `gem/` trees). The require resolver
+    // (`search_lib`) pins this directory ahead of `$LOAD_PATH` so those
+    // stubs win even after rubygems/bundler activates a host gem and
+    // unshifts its lib dir to the front of `$LOAD_PATH`. It deliberately
+    // excludes the vendored CRuby snapshot (bundler / rubygems), whose
+    // code version must stay in lockstep with the activated gem spec.
+    let stub_dir = lib_path.join("stub");
     // Order matters: the checked-in CRuby stdlib snapshot is laid down
     // first, then monoruby's own builtins/stdlib/gem stubs overwrite any
     // name clash so monoruby's host-independent implementations of
     // C-extension-backed libraries stay authoritative. No `ruby` is
     // invoked here — the snapshot is produced offline by
-    // bin/vendor-ruby-stdlib, so the build works without CRuby.
+    // bin/vendor-ruby-stdlib, so the build works without CRuby. The
+    // `stdlib/` and `gem/` trees are additionally laid down into `stub`
+    // (the pinned resolution root; see `search_lib`).
     let sources = [
         (PathBuf::from("vendor/ruby-stdlib"), lib_dir.clone()),
         (PathBuf::from("builtins"), builtins_dir.clone()),
         (PathBuf::from("stdlib"), lib_dir.clone()),
         (PathBuf::from("gem"), lib_dir.clone()),
+        (PathBuf::from("stdlib"), stub_dir.clone()),
+        (PathBuf::from("gem"), stub_dir.clone()),
     ];
 
     // Re-run when the installed sources change so edits to the vendored
@@ -87,7 +99,7 @@ fn main() {
     if !lib_path.exists() {
         fs::create_dir(&lib_path).unwrap();
     }
-    for p in [&lib_dir, &builtins_dir] {
+    for p in [&lib_dir, &builtins_dir, &stub_dir] {
         if p.exists() {
             fs::remove_dir_all(p).unwrap();
         }

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -54,6 +54,17 @@ if host_rubylibprefix && !host_rubylibprefix.empty? && ruby_api_version && !ruby
   RbConfig::CONFIG['vendordir']      = "#{host_rubylibprefix}/vendor_ruby"
   # libdir is one level above rubylibprefix (rubylibprefix == libdir/ruby).
   RbConfig::CONFIG['libdir']         = File.dirname(host_rubylibprefix)
+  # The vendored rbconfig.rb hard-codes ENABLE_SHARED="no" (monoruby is a
+  # static binary), which makes Gem.extension_api_version append "-static".
+  # That mismatches the host's gem extension layout
+  # (".../extensions/<plat>/<api>/" without "-static"), so rubygems/bundler
+  # judge every host C-extension gem as having unbuilt extensions and skip
+  # it — a Gemfile.lock pinning json/cgi/… then fails with GemNotFound.
+  # When we are resolving against a host CRuby's gems, report "yes" so the
+  # api version matches and those gems resolve. monoruby still can't run
+  # their native .so, but require.rs pins its own pure-Ruby stubs ahead of
+  # $LOAD_PATH for the libraries it replaces, so they load the stub.
+  RbConfig::CONFIG['ENABLE_SHARED']  = 'yes'
 end
 
 class BasicObject

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -5,6 +5,7 @@ mod array;
 mod binding;
 mod bool_class;
 mod class;
+mod digest;
 mod dir;
 pub(crate) mod encoding;
 pub(crate) mod errno;
@@ -99,6 +100,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     match_data::init(globals);
     set::init(globals);
     json::init(globals);
+    digest::init(globals);
     main_object::init(globals);
     globals.object_class().include_module(kernel).unwrap();
 }

--- a/monoruby/src/builtins/digest.rs
+++ b/monoruby/src/builtins/digest.rs
@@ -1,0 +1,77 @@
+use super::*;
+use md5::Md5;
+use sha1::Sha1;
+use sha2::{Digest, Sha256, Sha384, Sha512};
+
+//
+// Digest module — native one-shot hashing backend.
+//
+// The Ruby side (stdlib/digest*.rb) implements the full `Digest::*` class
+// API (`update` / `<<` / `reset` / `digest` / `hexdigest` / …) by buffering
+// the input and calling this single native helper to finalize. Streaming
+// over a buffer is equivalent to one-shot hashing of the concatenated data,
+// so no native per-instance state is needed.
+//
+
+pub(super) fn init(globals: &mut Globals) {
+    globals.define_builtin_class_func(STRING_CLASS, "__digest", digest_hash, 2);
+}
+
+/// String.__digest(algorithm, data) -> binary String
+///
+/// `algorithm` is "md5" / "sha1" / "sha256" / "sha384" / "sha512".
+/// Returns the raw (ASCII-8BIT) digest of `data`.
+#[monoruby_builtin]
+fn digest_hash(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let algo = lfp.arg(0).expect_string(&globals.store)?;
+    let data_v = lfp.arg(1);
+    let data = data_v.expect_bytes(&globals.store)?;
+    let out: Vec<u8> = match algo.as_str() {
+        "md5" => Md5::digest(data).to_vec(),
+        "sha1" => Sha1::digest(data).to_vec(),
+        "sha256" => Sha256::digest(data).to_vec(),
+        "sha384" => Sha384::digest(data).to_vec(),
+        "sha512" => Sha512::digest(data).to_vec(),
+        other => {
+            return Err(MonorubyErr::argumenterr(format!(
+                "unsupported digest algorithm: {other}"
+            )));
+        }
+    };
+    Ok(Value::bytes(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn digest() {
+        run_tests(&[
+            r#"require 'digest'; Digest::MD5.hexdigest("The quick brown fox jumps over the lazy dog")"#,
+            r#"require 'digest'; Digest::MD5.hexdigest("")"#,
+            r#"require 'digest/md5'; Digest::MD5.hexdigest("abc")"#,
+            r#"require 'digest/sha1'; Digest::SHA1.hexdigest("abc")"#,
+            r#"require 'digest/sha2'; Digest::SHA256.hexdigest("abc")"#,
+            r#"require 'digest/sha2'; Digest::SHA384.hexdigest("abc")"#,
+            r#"require 'digest/sha2'; Digest::SHA512.hexdigest("abc")"#,
+            // const_missing autoload (SHA256 referenced via Digest:: only)
+            r#"require 'digest'; Digest.const_get(:SHA256).hexdigest("abc")"#,
+            // streaming via update / <<
+            r#"require 'digest'; Digest::SHA256.new.update("ab").update("c").hexdigest"#,
+            r#"require 'digest'; d = Digest::MD5.new; d << "a"; d << "bc"; d.hexdigest"#,
+            // binary digest length, base64, metadata
+            r#"require 'digest'; Digest::SHA256.digest("abc").length"#,
+            r#"require 'digest'; Digest::MD5.base64digest("abc")"#,
+            r#"require 'digest'; Digest::SHA512.new.digest_length"#,
+            r#"require 'digest'; Digest::SHA1.new.block_length"#,
+            // SHA2 bit-length wrapper
+            r#"require 'digest/sha2'; Digest::SHA2.new(512).update("abc").hexdigest"#,
+        ]);
+    }
+}

--- a/monoruby/src/globals/require.rs
+++ b/monoruby/src/globals/require.rs
@@ -95,40 +95,58 @@ impl Globals {
     }
 
     pub(crate) fn search_lib(&mut self, file_name: &std::path::Path) -> Option<PathBuf> {
-        // Priority: ~/.monoruby/lib/<name>.rb overrides both $LOAD_PATH
-        // and native .so extensions. The files installed there by
-        // build.rs (from stdlib/ and gem/) are stubs that replace native
-        // extensions monoruby cannot load. They must take precedence,
-        // otherwise CRuby's stdlib wrappers (which themselves require
-        // more things monoruby cannot handle) would be loaded first and
-        // fail.
-        if file_name.extension().is_none() {
-            let mut fallback = dirs::home_dir().unwrap().join(".monoruby").join(file_name);
-            fallback.set_extension("rb");
-            if fallback.exists() {
-                return Some(fallback);
-            }
-        }
-        for lib in self.load_path.as_array().iter() {
-            let lib = match lib.is_str() {
-                Some(s) => s,
-                None => continue,
-            };
-            let mut lib = std::path::PathBuf::from(lib).join(file_name);
+        // Probe a single directory for `file_name`, applying the usual
+        // extension rules: an explicit extension must match exactly;
+        // otherwise try `.rb` then `.so`.
+        fn probe(dir: &std::path::Path, file_name: &std::path::Path) -> Option<PathBuf> {
+            let mut lib = dir.join(file_name);
             if lib.extension().is_some() {
-                if lib.exists() {
-                    return Some(lib);
-                } else {
-                    continue;
-                }
+                return lib.exists().then_some(lib);
             }
             lib.set_extension("rb");
             if lib.exists() {
                 return Some(lib);
             }
             lib.set_extension("so");
-            if lib.exists() {
-                return Some(lib);
+            lib.exists().then_some(lib)
+        }
+
+        // Pin monoruby's own C-extension replacement stubs ahead of
+        // `$LOAD_PATH`. `~/.monoruby/stub` holds exactly the files
+        // monoruby ships in `stdlib/` and `gem/` (json, psych, strscan,
+        // stringio, zlib, …) — pure-Ruby replacements for libraries
+        // monoruby cannot load as native `.so`. They must win even after
+        // rubygems/bundler `activate`s a host gem and unshifts its lib
+        // dir to the front of `$LOAD_PATH`; checking them here, outside
+        // the (mutable) `$LOAD_PATH` loop, makes the precedence immune to
+        // that reordering. Without this, a host C-extension gem (now
+        // accepted, since `Gem.extension_api_version` no longer appends
+        // `-static`) would shadow the stub and then fail to load its
+        // native `.so`.
+        //
+        // Only this stub root is pinned — NOT the vendored CRuby stdlib
+        // snapshot in `~/.monoruby/lib`. That snapshot includes bundler /
+        // rubygems, whose loaded *code* version must stay in lockstep
+        // with the activated gem *spec* version (bundler raises
+        // `CorruptBundlerInstallError` otherwise). Pinning the vendored
+        // bundler ahead of the host one would force vendored code while
+        // the host spec stays activated, splitting the two. So the
+        // vendored snapshot keeps resolving through `$LOAD_PATH` (where it
+        // is merely first), letting host activation shadow it consistently.
+        let stub_root = dirs::home_dir().unwrap().join(".monoruby").join("stub");
+        for dir in [stub_root.clone(), stub_root.join("x86_64-linux")] {
+            if let Some(p) = probe(&dir, file_name) {
+                return Some(p);
+            }
+        }
+
+        for lib in self.load_path.as_array().iter() {
+            let lib = match lib.is_str() {
+                Some(s) => s,
+                None => continue,
+            };
+            if let Some(p) = probe(std::path::Path::new(lib), file_name) {
+                return Some(p);
             }
         }
         None

--- a/monoruby/stdlib/digest.rb
+++ b/monoruby/stdlib/digest.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+#
+# Digest implementation for monoruby.
+#
+# The hashing itself is performed natively by `String.__digest`
+# (see src/builtins/digest.rs). Each algorithm class buffers the input
+# it receives and finalizes by calling that one-shot helper — hashing the
+# concatenation of all updates is equivalent to streaming, so no native
+# per-instance state is needed.
+
+module Digest
+  VERSION = '3.2.0'
+
+  # Autoload algorithm classes on first reference, mirroring CRuby:
+  #   Digest::SHA256 / SHA384 / SHA512  -> digest/sha2
+  #   Digest::MD5 / SHA1 / ...          -> digest/<name>
+  def self.const_missing(name)
+    case name
+    when :SHA256, :SHA384, :SHA512
+      require 'digest/sha2'
+    else
+      require "digest/#{name.to_s.downcase}"
+    end
+    if const_defined?(name, false)
+      const_get(name, false)
+    else
+      raise NameError, "uninitialized constant Digest::#{name}"
+    end
+  end
+
+  # Class-level (one-shot) API shared by every algorithm.
+  class Class
+    def self.digest(str, *args)
+      new(*args).update(str).digest!
+    end
+
+    def self.hexdigest(str, *args)
+      new(*args).update(str).hexdigest!
+    end
+
+    def self.base64digest(str, *args)
+      [digest(str, *args)].pack('m0')
+    end
+
+    def self.file(name, *args)
+      new(*args).file(name)
+    end
+  end
+
+  # Instance-level API. Subclasses set ALGORITHM / DIGEST_LENGTH /
+  # BLOCK_LENGTH (or override the corresponding methods).
+  module Instance
+    def update(str)
+      @buffer << str.b
+      self
+    end
+    alias << update
+
+    def reset
+      @buffer = ''.b
+      self
+    end
+
+    # The raw digest of the accumulated data, computed natively.
+    def finish
+      String.__digest(self.class::ALGORITHM, @buffer)
+    end
+    private :finish
+
+    def digest(str = nil)
+      return finish if str.nil?
+      reset
+      update(str)
+      value = finish
+      reset
+      value
+    end
+
+    def digest!
+      value = finish
+      reset
+      value
+    end
+
+    def hexdigest(str = nil)
+      digest(str).unpack1('H*')
+    end
+    alias to_s hexdigest
+
+    def hexdigest!
+      digest!.unpack1('H*')
+    end
+
+    def base64digest(str = nil)
+      [digest(str)].pack('m0')
+    end
+
+    def base64digest!
+      [digest!].pack('m0')
+    end
+
+    def file(name)
+      update(File.binread(name))
+    end
+
+    def digest_length
+      self.class::DIGEST_LENGTH
+    end
+    alias length digest_length
+    alias size digest_length
+
+    def block_length
+      self.class::BLOCK_LENGTH
+    end
+
+    def ==(other)
+      case other
+      when Digest::Instance
+        digest == other.digest
+      when String
+        to_s == other
+      else
+        false
+      end
+    end
+
+    def inspect
+      "#<#{self.class.name}: #{hexdigest}>"
+    end
+  end
+
+  # Base class for the buffered algorithm implementations.
+  class Base < Digest::Class
+    include Instance
+
+    def initialize
+      @buffer = ''.b
+    end
+
+    def initialize_copy(other)
+      @buffer = other.instance_variable_get(:@buffer).dup
+    end
+  end
+end

--- a/monoruby/stdlib/digest/md5.rb
+++ b/monoruby/stdlib/digest/md5.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'digest'
+
+module Digest
+  class MD5 < Base
+    ALGORITHM = 'md5'
+    DIGEST_LENGTH = 16
+    BLOCK_LENGTH = 64
+  end
+end

--- a/monoruby/stdlib/digest/sha1.rb
+++ b/monoruby/stdlib/digest/sha1.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'digest'
+
+module Digest
+  class SHA1 < Base
+    ALGORITHM = 'sha1'
+    DIGEST_LENGTH = 20
+    BLOCK_LENGTH = 64
+  end
+end

--- a/monoruby/stdlib/digest/sha2.rb
+++ b/monoruby/stdlib/digest/sha2.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'digest'
+
+module Digest
+  class SHA256 < Base
+    ALGORITHM = 'sha256'
+    DIGEST_LENGTH = 32
+    BLOCK_LENGTH = 64
+  end
+
+  class SHA384 < Base
+    ALGORITHM = 'sha384'
+    DIGEST_LENGTH = 48
+    BLOCK_LENGTH = 128
+  end
+
+  class SHA512 < Base
+    ALGORITHM = 'sha512'
+    DIGEST_LENGTH = 64
+    BLOCK_LENGTH = 128
+  end
+
+  # Digest::SHA2.new(bitlen) — CRuby's bit-length-parameterized wrapper
+  # (defaults to 256). Delegates to the fixed-width algorithm above.
+  class SHA2 < Base
+    def initialize(bitlen = 256)
+      @algorithm, @digest_length, @block_length =
+        case bitlen
+        when 256 then ['sha256', 32, 64]
+        when 384 then ['sha384', 48, 128]
+        when 512 then ['sha512', 64, 128]
+        else raise ArgumentError, "unsupported bit length: #{bitlen.inspect}"
+        end
+      @bitlen = bitlen
+      super()
+    end
+
+    def finish
+      String.__digest(@algorithm, @buffer)
+    end
+    private :finish
+
+    def digest_length
+      @digest_length
+    end
+    alias length digest_length
+    alias size digest_length
+
+    def block_length
+      @block_length
+    end
+
+    def inspect
+      "#<#{self.class.name}:#{@bitlen}: #{hexdigest}>"
+    end
+  end
+end

--- a/monoruby/stdlib/json.rb
+++ b/monoruby/stdlib/json.rb
@@ -8,6 +8,12 @@
 require 'strscan'
 
 module JSON
+  VERSION = '2.13.2'
+  VERSION_ARRAY = VERSION.split('.').map { |x| x.to_i }
+  VERSION_MAJOR = VERSION_ARRAY[0]
+  VERSION_MINOR = VERSION_ARRAY[1]
+  VERSION_BUILD = VERSION_ARRAY[2]
+
   class JSONError < StandardError; end
   class ParserError < JSONError; end
   class GeneratorError < JSONError; end


### PR DESCRIPTION
## Summary

Investigated yjit-bench failures and resolved the largest cluster (gem/bundler
resolution, "Category A"), then implemented the `digest` library that several
benchmarks need.

### 1. Stub precedence vs. host C-extension gems (`require.rs`, `build.rs`, `startup.rb`)

A load-bearing bug conflated two concerns: the vendored `rbconfig.rb` reports
`ENABLE_SHARED="no"`, so `Gem.extension_api_version` returned `<api>-static`.
That mismatched the host gem extension layout, making rubygems/bundler treat
**every host C-extension gem as having unbuilt extensions and skip it** — so a
`Gemfile.lock` pinning json/cgi/… failed `materialize` with `GemNotFound`,
while the rejection happened to let monoruby's own stubs win.

Decoupled the two layers:

- `search_lib` now pins a dedicated stub root `~/.monoruby/stub` (only the
  `stdlib/` + `gem/` trees) ahead of `$LOAD_PATH`, so monoruby's pure-Ruby
  replacements (json, psych, strscan, …) win even after rubygems/bundler
  `activate` a host gem and unshift its lib dir to the front of `$LOAD_PATH`.
  The vendored CRuby snapshot (bundler/rubygems) is deliberately **not**
  pinned — its loaded code version must stay in lockstep with the activated
  gem spec, else bundler raises `CorruptBundlerInstallError`.
- When resolving against a host CRuby's gems, override `ENABLE_SHARED="yes"`
  so `extension_api_version` drops `-static` and bundler accepts host C-ext
  gems.
- Added `JSON::VERSION` to the json stub.

Result: gem/bundler resolution no longer blocks any benchmark. `psych-load`,
`rack`, `graphql`, and the addressable/erubi/lee/tinygql/chunky-png family run.

### 2. `digest` library (`builtins/digest.rs`, `stdlib/digest*.rb`)

monoruby had no `digest`, so any gem doing `require 'digest'` failed.

- Native one-shot backend `String.__digest(algo, data)` via RustCrypto
  `md-5`/`sha1`/`sha2`.
- Ruby `Digest::*` classes buffer input and finalize via the native helper
  (streaming over a buffer equals one-shot hashing of the concatenation, so no
  native per-instance state). Covers MD5/SHA1/SHA256/SHA384/SHA512, the class
  and instance APIs, `const_missing` autoload, and the `SHA2` bit-length
  wrapper. Output matches CRuby exactly.

### Residual (separate, pre-existing gaps — out of scope here)

`mail` (splat in index-assignment LHS), `hexapdf` (nil `[]`), `erubi-rails`
(`openssl` cipher), `rubocop` (`unicode-display_width`), and the Ractor-harness
arg artifact in `json_parse_*` (which fails identically on CRuby when run via
the default loader).

## Test plan

- [x] `cargo test --release -p monoruby --lib` → **1609 passed / 0 failed**
      (new `digest` lib test compares output against CRuby)
- [x] digest output verified byte-for-byte against CRuby (MD5/SHA1/SHA2*,
      streaming, base64, metadata)
- [x] yjit-bench: `psych-load`, `rack`, `graphql`, `addressable`, `erubi`,
      `lee`, `tinygql`, `chunky-png` run; control benchmarks
      (optcarrot/fib/nbody/…) show no regression

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_