### PR TITLE
fix(exception): Exception#message dispatches to #to_s

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -281,10 +281,10 @@ fn store_exception_kwargs(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/message.html]
 #[monoruby_builtin]
-fn message(_vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_ = lfp.self_val();
-    let ex = self_.is_exception().unwrap();
-    Ok(Value::string(ex.message().to_string()))
+fn message(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // CRuby's `Exception#message` is `self.to_s`, so a subclass that
+    // overrides `#to_s` changes the reported message too.
+    vm.invoke_method_inner(globals, IdentId::TO_S, lfp.self_val(), &[], None, None)
 }
 
 ///
@@ -698,6 +698,24 @@ mod tests {
             end
             "#,
         );
+    }
+
+    #[test]
+    fn message_calls_to_s() {
+        run_tests(&[
+            // Default: message == stored string.
+            r#"RuntimeError.new("hi").message"#,
+            // No-arg: message == class name.
+            r#"RuntimeError.new.message"#,
+            // A subclass overriding #to_s changes #message (CRuby:
+            // `Exception#message` is `self.to_s`).
+            r#"
+            class MsgToS < StandardError
+              def to_s; "from to_s"; end
+            end
+            MsgToS.new("orig").message
+            "#,
+        ]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CRuby's `Exception#message` is defined as `self.to_s`, so a subclass that overrides `#to_s` changes the reported message. monoruby returned the stored message string directly, ignoring a `#to_s` override.

Route `#message` through `self.to_s` (the default Exception `to_s` already returns the stored message, so standard exceptions are unchanged).

## Impact on `core/exception/message_spec`

The "calls #to_s on self" example now passes (1 F → 0).

## Test plan

- [x] `cargo test --lib -p monoruby -- message_calls_to_s` ⇒ pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::exception` ⇒ 16 pass
- [x] `mspec core/exception/message_spec` ⇒ 0 F / 0 E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_