### PR TITLE
test(digest): cover the unsupported-algorithm error branch

### DIFF
--- a/monoruby/src/builtins/digest.rs
+++ b/monoruby/src/builtins/digest.rs
@@ -74,4 +74,9 @@ mod tests {
             r#"require 'digest/sha2'; Digest::SHA2.new(512).update("abc").hexdigest"#,
         ]);
     }
+
+    #[test]
+    fn digest_unsupported_algorithm() {
+        run_test_error(r#"String.__digest("bogus", "data")"#);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #623. Adds a unit test covering `String.__digest`'s
unsupported-algorithm error branch — the one patch line the Codecov report
flagged as uncovered in `digest.rs`.

## Test plan

- [x] `cargo test --release -p monoruby --lib digest` → both `digest` and
      `digest_unsupported_algorithm` pass

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_