### PR TITLE
feat(exception): implicit cause chaining from $! (−1 E, −1 F)

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -727,6 +727,46 @@ mod tests {
     }
 
     #[test]
+    fn implicit_cause_chaining() {
+        // An exception raised while handling another records that
+        // exception as its #cause.
+        run_test(
+            r#"
+            begin
+              begin
+                raise "the cause"
+              rescue
+                raise "the consequence"
+              end
+            rescue => e
+              [e.message, e.cause&.message]
+            end
+            "#,
+        );
+        // VM-raised error (1/0) during a rescue is chained too.
+        run_test(
+            r#"
+            begin
+              raise "user"
+            rescue
+              begin
+                1 / 0
+              rescue ZeroDivisionError => z
+                [z.class.name, z.cause&.message]
+              end
+            end
+            "#,
+        );
+        // No spurious chaining once a rescue has completed.
+        run_test(
+            r#"
+            begin; raise "a"; rescue; end
+            begin; raise "b"; rescue => e; e.cause.inspect; end
+            "#,
+        );
+    }
+
+    #[test]
     fn nomethoderror_receiver() {
         run_test(
             r#"

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -809,7 +809,7 @@ impl Executor {
 
     pub(crate) fn take_ex_obj(&mut self, globals: &mut Globals) -> Value {
         let err = self.take_error();
-        match err.kind() {
+        let v = match err.kind() {
             MonorubyErrKind::Load(path) => {
                 let path = Value::string_from_str(&path.as_os_str().to_string_lossy());
                 let v = Value::new_exception(err);
@@ -860,7 +860,23 @@ impl Executor {
                 v
             }
             _ => Value::new_exception(err),
+        };
+        // Implicit cause chaining (CRuby `exc_setup_cause`): if an
+        // exception is currently being handled (`$!`) and the freshly
+        // materialised one is neither it nor already given a cause,
+        // record `$!` as the cause. `take_ex_obj` runs *before* the
+        // caller sets `$!` to the new exception, so `$!` here is the
+        // enclosing handler's exception.
+        let cause_id = IdentId::get_id("/cause");
+        if globals.store.get_ivar(v, cause_id).is_none() {
+            let active = globals
+                .get_gvar(IdentId::get_id("$!"))
+                .unwrap_or_default();
+            if !active.is_nil() && active.id() != v.id() {
+                let _ = globals.store.set_ivar(v, cause_id, active);
+            }
         }
+        v
     }
 
     pub(crate) fn err_divide_by_zero(&mut self) {


### PR DESCRIPTION
## Summary

When an exception is raised while another is being handled, CRuby records the handled exception (`$!`) as the new one's `#cause`. monoruby left `#cause` nil unless an explicit `cause:` was given.

`Executor::take_ex_obj` materialises the exception object when a handler catches it — and runs *before* the caller assigns `$!` to the new exception — so at that point `$!` still holds the enclosing handler's exception. Record it as the new exception's `/cause` ivar when (a) the exception has no cause yet and (b) `$!` is set and isn't the exception itself. VM-raised errors (e.g. `1 / 0`) flow through the same path, so they're chained too.

`$!` is cleared when a rescue completes, so sequential independent rescues do not chain spuriously.

## Impact on ruby/spec

| spec                       | before | after |
|----------------------------|-------:|------:|
| core/exception/cause_spec  |  3 E   | 2 E   |
| core/kernel/raise_spec     | 15 F   | 14 F  |

The residual cause failures need exception-object identity preservation on re-raise (`raise e` re-materialises rather than re-using `e`) and the explicit `cause:` keyword plumbing — both larger follow-ups.

## Test plan

- [x] `cargo test --lib -p monoruby -- implicit_cause_chaining` ⇒ pass (both prism and ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::exception` ⇒ pass
- [x] `mspec` cause_spec 3→2 E, raise_spec 15→14 F, no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_