### PR TITLE
feat(exception): preserve object identity on re-raise

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -709,6 +709,75 @@ mod tests {
     }
 
     #[test]
+    fn reraise_preserves_identity() {
+        // `raise exc` re-raises the same object: identity and instance
+        // variables survive being caught.
+        run_test(
+            r#"
+            class MyErr < StandardError
+              attr_accessor :data
+            end
+            e = MyErr.new("boom")
+            e.data = 42
+            begin
+              raise e
+            rescue MyErr => x
+              [x.equal?(e), x.data, x.message]
+            end
+            "#,
+        );
+        // `raise ClassWithCustomState` keeps the freshly-built instance.
+        run_test(
+            r#"
+            class Built < StandardError
+              def initialize(n); super("n=#{n}"); @n = n; end
+              attr_reader :n
+            end
+            begin
+              raise Built.new(7)
+            rescue => e
+              [e.n, e.message]
+            end
+            "#,
+        );
+        // Re-raise does not overwrite an existing backtrace.
+        run_test(
+            r#"
+            first = nil
+            begin; raise "a"; rescue => first; end
+            bt = first.backtrace
+            begin; raise first; rescue => second; end
+            [second.equal?(first), second.backtrace == bt]
+            "#,
+        );
+        // A re-raised object is its successor's implicit cause by identity.
+        run_test(
+            r#"
+            cause = RuntimeError.new("cause")
+            begin
+              raise cause
+            rescue
+              begin
+                1 / 0
+              rescue ZeroDivisionError => z
+                z.cause.equal?(cause)
+              end
+            end
+            "#,
+        );
+        // Re-raising the active exception itself records no self-cause.
+        run_test(
+            r#"
+            begin
+              raise RuntimeError, "x"
+            rescue RuntimeError => e
+              begin; raise e; rescue => f; [f.equal?(e), f.cause.inspect]; end
+            end
+            "#,
+        );
+    }
+
+    #[test]
     fn message_calls_to_s() {
         run_tests(&[
             // Default: message == stored string.

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -775,6 +775,16 @@ mod tests {
             end
             "#,
         );
+        // Bare `raise` re-raises `$!` by identity, with no self-cause.
+        run_test(
+            r#"
+            begin
+              raise "x"
+            rescue => e
+              begin; raise; rescue => f; [f.equal?(e), f.cause.inspect]; end
+            end
+            "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -573,8 +573,8 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             ));
         }
         let ex = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
-        if let Some(ex) = ex.is_exception() {
-            return Err(MonorubyErr::new_from_exception(ex));
+        if let Some(inner) = ex.is_exception() {
+            return Err(MonorubyErr::new_from_exception(inner).with_original(ex));
         } else {
             return Err(MonorubyErr::runtimeerr(""));
         }
@@ -583,10 +583,13 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         let mut err = MonorubyErr::new_from_exception(ex);
         if let Some(arg1) = lfp.try_arg(1) {
             if arg1.try_hash_ty().is_none() {
+                // A message override makes CRuby return a *new* exception
+                // (`exc.exception(msg)`), so identity is not preserved.
                 err.set_msg(arg1.coerce_to_str(vm, globals)?);
+                return Err(err);
             }
         }
-        return Err(err);
+        return Err(err.with_original(lfp.arg(0)));
     } else if let Some(klass) = lfp.arg(0).is_class() {
         if klass.id() == STOP_ITERATION_CLASS {
             return Err(MonorubyErr::stopiterationerr("".to_string()));
@@ -599,7 +602,7 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             }
             let ex =
                 vm.invoke_method_inner(globals, IdentId::NEW, klass.as_val(), &args, None, None)?;
-            let err = MonorubyErr::new_from_exception(ex.is_exception().unwrap());
+            let err = MonorubyErr::new_from_exception(ex.is_exception().unwrap()).with_original(ex);
             return Err(err);
         }
     } else if let Some(message) = lfp.arg(0).is_rstring() {
@@ -622,7 +625,7 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         let result =
             vm.invoke_method_inner(globals, exception_id, lfp.arg(0), &args, None, None)?;
         match result.is_exception() {
-            Some(ex) => return Err(MonorubyErr::new_from_exception(ex)),
+            Some(ex) => return Err(MonorubyErr::new_from_exception(ex).with_original(result)),
             None => return Err(MonorubyErr::typeerr("exception object expected")),
         }
     }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1223,7 +1223,7 @@ pub(super) extern "C" fn check_err(vm: &mut Executor) -> usize {
 
 pub(super) extern "C" fn raise_err(vm: &mut Executor, err_val: Value) {
     match err_val.is_exception() {
-        Some(ex) => vm.set_error(MonorubyErr::new_from_exception(ex)),
+        Some(ex) => vm.set_error(MonorubyErr::new_from_exception(ex).with_original(err_val)),
         None => unimplemented!(),
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -808,7 +808,19 @@ impl Executor {
     }
 
     pub(crate) fn take_ex_obj(&mut self, globals: &mut Globals) -> Value {
-        let err = self.take_error();
+        let mut err = self.take_error();
+        // Re-raise of an existing exception object (`raise exc`): return
+        // that object so its identity and instance variables are
+        // preserved. CRuby only assigns a backtrace if the exception
+        // doesn't have one yet, so fill the trace in only when empty.
+        if let Some(mut orig) = err.original {
+            if let Some(ex) = orig.is_exception_mut() {
+                if ex.trace.is_empty() {
+                    ex.trace = err.take_trace();
+                }
+            }
+            return self.chain_cause(globals, orig);
+        }
         let v = match err.kind() {
             MonorubyErrKind::Load(path) => {
                 let path = Value::string_from_str(&path.as_os_str().to_string_lossy());
@@ -861,12 +873,15 @@ impl Executor {
             }
             _ => Value::new_exception(err),
         };
-        // Implicit cause chaining (CRuby `exc_setup_cause`): if an
-        // exception is currently being handled (`$!`) and the freshly
-        // materialised one is neither it nor already given a cause,
-        // record `$!` as the cause. `take_ex_obj` runs *before* the
-        // caller sets `$!` to the new exception, so `$!` here is the
-        // enclosing handler's exception.
+        self.chain_cause(globals, v)
+    }
+
+    /// Implicit cause chaining (CRuby `exc_setup_cause`): if an exception
+    /// is currently being handled (`$!`) and `v` is neither it nor
+    /// already given a cause, record `$!` as `v`'s cause. `take_ex_obj`
+    /// runs *before* the caller sets `$!` to the new exception, so `$!`
+    /// here is the enclosing handler's exception.
+    fn chain_cause(&mut self, globals: &mut Globals, v: Value) -> Value {
         let cause_id = IdentId::get_id("/cause");
         if globals.store.get_ivar(v, cause_id).is_none() {
             let active = globals

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -10,6 +10,11 @@ pub struct MonorubyErr {
     pub kind: MonorubyErrKind,
     pub message: String,
     pub trace: Vec<(Option<(Loc, SourceInfoRef)>, Option<FuncId>)>,
+    /// When re-raising an existing exception object, the original
+    /// `Value`. `Executor::take_ex_obj` returns this object instead of
+    /// materialising a fresh one, preserving the object's identity and
+    /// its instance variables (CRuby `raise exc` re-raises `exc` itself).
+    pub original: Option<Value>,
 }
 
 impl MonorubyErr {
@@ -18,6 +23,7 @@ impl MonorubyErr {
             kind,
             message: message.to_string(),
             trace: vec![],
+            original: None,
         }
     }
 
@@ -29,7 +35,15 @@ impl MonorubyErr {
             kind,
             message: msg,
             trace,
+            original: None,
         }
+    }
+
+    /// Tag this error with the original exception object so its identity
+    /// and instance variables survive being caught (see `original`).
+    pub(crate) fn with_original(mut self, original: Value) -> Self {
+        self.original = Some(original);
+        self
     }
 
     pub(crate) fn new_with_loc(
@@ -44,6 +58,7 @@ impl MonorubyErr {
             kind,
             message: msg,
             trace: vec![(Some((loc, sourceinfo)), func_id)],
+            original: None,
         }
     }
 
@@ -59,6 +74,9 @@ impl MonorubyErr {
     ///
     pub(crate) fn mark(&self, alloc: &mut alloc::Allocator<crate::value::RValue>) {
         use alloc::GC;
+        if let Some(original) = &self.original {
+            original.mark(alloc);
+        }
         match &self.kind {
             // Packed `Value::id()` of the receiver that triggered the
             // NoMethodError (set by `MonorubyErr::no_method_for_*`).


### PR DESCRIPTION
## Summary

`raise exc` should re-raise the **same** exception object. monoruby copied the exception's data into a fresh object inside `Executor::take_ex_obj`, so a re-raised exception lost its identity (`equal?` was `false`) and any custom instance variables.

```ruby
class MyErr < StandardError; attr_accessor :data; end
e = MyErr.new("boom"); e.data = 42
begin; raise e; rescue MyErr => x
  p x.data       # was nil, now 42
  p x.equal?(e)  # was false, now true
end
```

`MonorubyErr` gains an `original: Option<Value>` tag, set on every re-raise path:
- `Kernel#raise` with no args (re-raise `$!`)
- `raise <exception_object>` (without a message override — a message makes CRuby build a new object via `exc.exception(msg)`, so identity is intentionally not preserved there)
- `raise <class>[, msg]` (preserves the freshly built instance, so a custom `initialize` survives)
- duck-typed `obj.exception`
- the internal `Raise` bytecode op (`runtime::raise_err`) used to re-raise when no rescue clause matches

`take_ex_obj` returns the tagged object instead of materialising a new one, and `MonorubyErr::mark` keeps it alive for GC while the error is in flight. A backtrace is assigned only when the object doesn't already have one, matching CRuby's "don't overwrite a re-raised backtrace" behaviour.

This also fixes implicit cause-by-identity: a re-raised exception is now correctly recorded as its successor's `#cause`, and re-raising the active exception itself records no self-cause.

## Impact on ruby/spec

| spec                        | before     | after     |
|-----------------------------|-----------:|----------:|
| core/exception/cause_spec   | 2 E        | 0         |
| core/exception/exception_spec | 1 F      | 0         |
| core/kernel/raise_spec      | 14 F / 23 E | 8 F / 21 E |

No regressions across `core/exception` (verified per-file against master; `hierarchy_spec` hangs on both, pre-existing). The residual raise_spec failures are the explicit `cause:` keyword plumbing and hash-message handling — separate follow-ups.

## Test plan

- [x] `cargo test --lib -p monoruby -- reraise_preserves_identity` ⇒ pass (prism + ruruby)
- [x] `cargo test --lib -p monoruby -- builtins::exception builtins::kernel` ⇒ 109 pass (both parsers)
- [x] re-run under `--features gc-stress` ⇒ pass (confirms the new GC mark)
- [x] mspec: cause_spec 2E→0, exception_spec 1F→0, raise_spec −6F −2E, no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_