### PR TITLE
feat(process): spawn + thread-free Open3 (unblocks git-source gems)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -367,6 +367,15 @@ class Process
   CLOCK_BOOTTIME = 7
   CLOCK_REALTIME_ALARM = 8
   CLOCK_BOOTTIME_ALARM = 9
+
+  # Reap child `pid` and return a thread whose #value waits for it and yields
+  # the resulting Process::Status. monoruby's Thread is cooperative (the block
+  # runs at #value/#join time), which matches Open3's "drain the pipes first,
+  # then read the exit status" ordering.
+  def self.detach(pid)
+    Thread.new { Process.wait2(pid)[1] }
+  end
+
   class Tms
     attr_accessor :utime, :stime, :cutime, :cstime
   end

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2150,6 +2150,16 @@ pub(super) fn spawn(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytec
     if pid == 0 {
         // ===== child =====
         unsafe {
+            // Restore default signal dispositions before exec. monoruby
+            // ignores SIGPIPE (and installs other handlers); a freshly
+            // exec'd program expects the defaults, e.g. so a command in a
+            // pipeline dies on SIGPIPE instead of seeing EPIPE and printing
+            // a "Broken pipe" error. Mirrors CRuby's spawn.
+            for sig in 1..32 {
+                if sig != libc::SIGKILL && sig != libc::SIGSTOP {
+                    libc::signal(sig, libc::SIG_DFL);
+                }
+            }
             for &(child_fd, src_fd) in &redirects {
                 if src_fd != child_fd {
                     libc::dup2(src_fd, child_fd);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -134,6 +134,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     );
     globals.define_builtin_module_func_with(kernel_class, "system", system, 1, 1, true);
     globals.define_builtin_module_func_rest(kernel_class, "exec", exec);
+    globals.define_builtin_module_func_rest(kernel_class, "spawn", spawn);
     globals.define_builtin_module_func(kernel_class, "`", command, 1);
     globals.define_builtin_module_func(kernel_class, "fork", fork, 0);
     globals.define_builtin_module_func_with(kernel_class, "sleep", sleep, 0, 1, false);
@@ -2059,6 +2060,113 @@ fn fork(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         // Parent process
         Ok(Value::integer(pid as i64))
     }
+}
+
+///
+/// ### Kernel.#spawn
+///
+/// - spawn(command... [, options]) -> Integer
+///
+/// Launches an external command in a new child process and returns its PID
+/// immediately (unlike `system`, it does not wait). Honours the `:in` /
+/// `:out` / `:err` redirect options (each an IO or fd Integer) — the form
+/// `Open3` uses to wire up pipes, which is what lets bundler fetch git-source
+/// gems via `Open3.capture3("git", ...)`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/spawn.html]
+#[monoruby_builtin]
+pub(super) fn spawn(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    use std::ffi::CString;
+    let null_byte = || MonorubyErr::argumenterr("string contains null byte");
+
+    let mut items: Vec<Value> = lfp.arg(0).as_array().iter().copied().collect();
+
+    // Trailing options Hash: honour :in / :out / :err fd redirections,
+    // recorded as (child_fd, source_fd) pairs.
+    let mut redirects: Vec<(i32, i32)> = vec![];
+    if let Some(last) = items.last() {
+        if let Some(h) = last.try_hash_ty() {
+            for (name, child_fd) in [("in", 0i32), ("out", 1), ("err", 2)] {
+                if let Some(v) = h.get(Value::symbol(IdentId::get_id(name)), vm, globals)? {
+                    let src = if let Some(i) = v.try_fixnum() {
+                        i as i32
+                    } else if v.ty() == Some(ObjTy::IO) {
+                        v.as_io_inner().fileno()?
+                    } else {
+                        return Err(MonorubyErr::argumenterr(format!(
+                            "spawn: unsupported redirect value for :{name}"
+                        )));
+                    };
+                    redirects.push((child_fd, src));
+                }
+            }
+            items.pop();
+        }
+    }
+
+    let str_args: Vec<String> = items
+        .iter()
+        .map(|v| v.coerce_to_string(vm, globals))
+        .collect::<Result<Vec<_>>>()?;
+    if str_args.is_empty() {
+        return Err(MonorubyErr::argumenterr(
+            "wrong number of arguments (given 0, expected 1+)",
+        ));
+    }
+
+    // Build argv as CStrings up front so the child needs no allocation.
+    let argv: Vec<CString> = if str_args.len() == 1 {
+        // Single string ⇒ shell-style split (mirrors `system` / `exec`).
+        let (program, sh_args) = prepare_command_arg(&str_args[0]);
+        let mut v = vec![CString::new(program).map_err(|_| null_byte())?];
+        for a in sh_args {
+            v.push(CString::new(a).map_err(|_| null_byte())?);
+        }
+        v
+    } else {
+        str_args
+            .iter()
+            .map(|s| CString::new(s.as_str()).map_err(|_| null_byte()))
+            .collect::<Result<Vec<_>>>()?
+    };
+    let mut argv_ptrs: Vec<*const libc::c_char> = argv.iter().map(|a| a.as_ptr()).collect();
+    argv_ptrs.push(std::ptr::null());
+    let max_fd = match unsafe { libc::sysconf(libc::_SC_OPEN_MAX) } {
+        n if n > 0 => n as i32,
+        _ => 1024,
+    };
+
+    // SAFETY: monoruby has no real OS threads (Thread is cooperative), so
+    // fork() leaves the child single-threaded and consistent. The child only
+    // performs async-signal-safe libc calls (dup2/close/execvp) before
+    // replacing itself; every allocation above happened in the parent.
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        return Err(MonorubyErr::runtimeerr(format!(
+            "spawn failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if pid == 0 {
+        // ===== child =====
+        unsafe {
+            for &(child_fd, src_fd) in &redirects {
+                if src_fd != child_fd {
+                    libc::dup2(src_fd, child_fd);
+                }
+            }
+            // IO.pipe fds are not close-on-exec, so close every other
+            // descriptor (>= 3); otherwise a leaked write end keeps the pipe
+            // open and the reader never sees EOF when the child exits.
+            for fd in 3..max_fd {
+                libc::close(fd);
+            }
+            libc::execvp(argv[0].as_ptr(), argv_ptrs.as_ptr());
+            libc::_exit(127);
+        }
+    }
+    // ===== parent =====
+    Ok(Value::integer(pid as i64))
 }
 
 ///

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -90,6 +90,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_module_func_with(klass, "exit", crate::builtins::kernel::exit, 0, 1, false);
     globals.define_builtin_module_func_with(klass, "abort", crate::builtins::kernel::abort, 0, 1, false);
     globals.define_builtin_module_func_rest(klass, "exec", crate::builtins::kernel::exec);
+    globals.define_builtin_module_func_rest(klass, "spawn", crate::builtins::kernel::spawn);
 
     // Process::Status class — methods defined in Ruby (startup.rb)
     globals.define_class("Status", object_class, klass);
@@ -909,6 +910,23 @@ mod tests {
     #[test]
     fn process_euid() {
         run_test("Process.euid");
+    }
+
+    #[test]
+    fn process_spawn_detach() {
+        // spawn returns a pid; detach(pid).value yields the Process::Status.
+        run_test("Process.detach(spawn(\"true\")).value.success?");
+        run_test("Process.detach(spawn(\"false\")).value.exitstatus");
+        run_test("st = Process.detach(spawn(\"sh\", \"-c\", \"exit 3\")).value; st.exitstatus");
+    }
+
+    #[test]
+    fn open3_capture_via_spawn() {
+        // Open3 wires :in/:out/:err pipes through spawn; capture3/capture2
+        // drain them — the path bundler uses to run git for git-source gems.
+        run_test(r#"require "open3"; out, _, st = Open3.capture3("printf", "hello"); [out, st.success?]"#);
+        run_test(r#"require "open3"; out, err, st = Open3.capture3("sh", "-c", "echo O; echo E 1>&2; exit 2"); [out, err, st.exitstatus]"#);
+        run_test(r#"require "open3"; Open3.capture2("echo", "hi").first"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -927,6 +927,28 @@ mod tests {
         run_test(r#"require "open3"; out, _, st = Open3.capture3("printf", "hello"); [out, st.success?]"#);
         run_test(r#"require "open3"; out, err, st = Open3.capture3("sh", "-c", "echo O; echo E 1>&2; exit 2"); [out, err, st.exitstatus]"#);
         run_test(r#"require "open3"; Open3.capture2("echo", "hi").first"#);
+        run_test(r#"require "open3"; Open3.capture3("cat", stdin_data: "piped").first"#);
+        // capture2e merges stdout+stderr onto one pipe.
+        run_test(r#"require "open3"; oe, st = Open3.capture2e("sh", "-c", "echo a; echo b 1>&2"); [oe.split("\n").sort, st.success?]"#);
+    }
+
+    #[test]
+    fn open3_no_deadlock_on_large_output() {
+        // The reason Open3 is reimplemented thread-free (IO.select) in
+        // monoruby: a child writing more than a pipe buffer (~64KB) on BOTH
+        // stdout and stderr would deadlock the cooperative-Thread approach.
+        run_test(
+            r#"require "open3"
+            out, err, st = Open3.capture3("sh", "-c", "yes A | head -c 200000; yes B | head -c 200000 1>&2")
+            [out.bytesize, err.bytesize, st.success?]"#,
+        );
+        // Large stdin streamed while large stdout is read back concurrently.
+        run_test(
+            r#"require "open3"
+            data = "x" * 300000
+            out, _, st = Open3.capture3("cat", stdin_data: data)
+            [out.bytesize, out == data, st.success?]"#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -921,6 +921,14 @@ mod tests {
     }
 
     #[test]
+    fn spawn_argument_errors() {
+        // A redirect value that is neither an IO nor an fd Integer.
+        run_test_error(r#"spawn("true", out: :nope)"#);
+        // No command given at all.
+        run_test_error("spawn()");
+    }
+
+    #[test]
     fn open3_capture_via_spawn() {
         // Open3 wires :in/:out/:err pipes through spawn; capture3/capture2
         // drain them — the path bundler uses to run git for git-source gems.

--- a/monoruby/stdlib/open3.rb
+++ b/monoruby/stdlib/open3.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+#
+# Thread-free Open3 for monoruby.
+#
+# CRuby's Open3.capture* drain the child's stdout and stderr in separate
+# threads so neither pipe can fill its buffer (~64KB) and block the child
+# while the parent is busy reading the other stream. monoruby's Thread is
+# cooperative — a `Thread.new { ... }` block does not run concurrently, it
+# runs when `#value`/`#join` is called — so that pattern deadlocks once a
+# child emits more than a pipe buffer on one stream.
+#
+# This implementation multiplexes all the pipes with IO.select instead, so
+# no real threads are needed. `spawn` and `Process.detach` are provided
+# natively (see the process builtin / startup.rb).
+
+module Open3
+  def popen3(*cmd, &block)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    in_r, in_w = IO.pipe
+    out_r, out_w = IO.pipe
+    err_r, err_w = IO.pipe
+    opts[:in] = in_r
+    opts[:out] = out_w
+    opts[:err] = err_w
+    in_w.sync = true
+    popen_run(cmd, opts, [in_r, out_w, err_w], [in_w, out_r, err_r], &block)
+  end
+  module_function :popen3
+
+  def popen2(*cmd, &block)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    in_r, in_w = IO.pipe
+    out_r, out_w = IO.pipe
+    opts[:in] = in_r
+    opts[:out] = out_w
+    in_w.sync = true
+    popen_run(cmd, opts, [in_r, out_w], [in_w, out_r], &block)
+  end
+  module_function :popen2
+
+  def popen2e(*cmd, &block)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    in_r, in_w = IO.pipe
+    out_r, out_w = IO.pipe
+    opts[:in] = in_r
+    # Send both stdout and stderr of the child to the same pipe.
+    opts[:out] = out_w
+    opts[:err] = out_w
+    in_w.sync = true
+    popen_run(cmd, opts, [in_r, out_w], [in_w, out_r], &block)
+  end
+  module_function :popen2e
+
+  def popen_run(cmd, opts, child_io, parent_io)
+    pid = spawn(*cmd, opts)
+    wait_thr = Process.detach(pid)
+    child_io.each { |io| io.close unless io.closed? }
+    result = [*parent_io, wait_thr]
+    if defined?(yield)
+      begin
+        return yield(*result)
+      ensure
+        parent_io.each { |io| io.close unless io.closed? }
+        wait_thr.join
+      end
+    end
+    result
+  end
+  module_function :popen_run
+
+  def capture3(*cmd)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    stdin_data = opts.delete(:stdin_data) || ''
+    binmode = opts.delete(:binmode)
+    popen3(*cmd, opts) do |i, o, e, t|
+      if binmode
+        i.binmode
+        o.binmode
+        e.binmode
+      end
+      bufs = __drain(i, stdin_data, [o, e])
+      [bufs[o], bufs[e], t.value]
+    end
+  end
+  module_function :capture3
+
+  def capture2(*cmd)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    stdin_data = opts.delete(:stdin_data) || ''
+    binmode = opts.delete(:binmode)
+    popen2(*cmd, opts) do |i, o, t|
+      if binmode
+        i.binmode
+        o.binmode
+      end
+      bufs = __drain(i, stdin_data, [o])
+      [bufs[o], t.value]
+    end
+  end
+  module_function :capture2
+
+  def capture2e(*cmd)
+    opts = (Hash === cmd.last) ? cmd.pop.dup : {}
+    stdin_data = opts.delete(:stdin_data) || ''
+    binmode = opts.delete(:binmode)
+    popen2e(*cmd, opts) do |i, oe, t|
+      if binmode
+        i.binmode
+        oe.binmode
+      end
+      bufs = __drain(i, stdin_data, [oe])
+      [bufs[oe], t.value]
+    end
+  end
+  module_function :capture2e
+
+  # Feed `stdin_data` into `wr` while reading every IO in `readers` to EOF,
+  # all multiplexed through a single IO.select loop so no pipe can deadlock.
+  # Returns a Hash mapping each reader IO to its collected String.
+  def __drain(wr, stdin_data, readers)
+    chunks = {}
+    readers.each { |io| chunks[io] = [] }
+    pending = readers.dup
+    data = (stdin_data || '').b
+    if wr && data.empty?
+      wr.close
+      wr = nil
+    end
+    until pending.empty? && wr.nil?
+      rs, ws, = IO.select(pending.empty? ? nil : pending, wr ? [wr] : nil)
+      rs&.each do |io|
+        begin
+          chunks[io] << io.read_nonblock(65536)
+        rescue EOFError
+          pending.delete(io)
+          io.close unless io.closed?
+        rescue IO::WaitReadable
+        end
+      end
+      if ws && !ws.empty? && wr
+        begin
+          n = wr.write_nonblock(data)
+          data = data.byteslice(n..-1) || ''.b
+          if data.empty?
+            wr.close
+            wr = nil
+          end
+        rescue IO::WaitWritable
+        rescue Errno::EPIPE
+          wr.close unless wr.closed?
+          wr = nil
+        end
+      end
+    end
+    result = {}
+    chunks.each { |io, parts| result[io] = parts.join }
+    result
+  end
+  module_function :__drain
+end


### PR DESCRIPTION
## Summary

Implements `spawn` + a thread-free `Open3`, which lets bundler fetch
git-source gems (e.g. the `rubyboy` benchmark). Previously `require "open3"`
→ `Open3.capture3("git", ...)` failed with `undefined method 'spawn' for
Open3`.

### 1. `Kernel#spawn` / `Process.spawn` + `Process.detach`

- Native `spawn` (`kernel.rs`): fork + dup2 + execvp. Honours the
  `:in`/`:out`/`:err` redirect options Open3 passes (each an IO or fd
  Integer), returns the child PID without waiting. argv is built in the
  parent; the child resets signal dispositions to default (monoruby ignores
  SIGPIPE — an exec'd program expects the defaults), then closes all fds ≥ 3
  (IO.pipe fds are not close-on-exec) so the reader sees EOF when the child
  exits.
- `Process.detach` (Ruby, `startup.rb`): `Thread.new { Process.wait2(pid)[1] }`.
  monoruby's Thread is cooperative, so the wait runs at `#value` time —
  matching Open3's "drain the pipes, then read the status" ordering.

### 2. Thread-free `Open3` (`stdlib/open3.rb`)

CRuby's `Open3.capture*` drain stdout and stderr in separate threads so
neither pipe deadlocks. monoruby's Thread is cooperative (the block runs at
`#value`/`#join`, not concurrently), so that approach deadlocks once a child
emits more than a pipe buffer (~64KB) on one stream while the parent reads
the other. This reimplements `popen3`/`popen2`/`popen2e` and
`capture3`/`capture2`/`capture2e` to multiplex all pipes through a single
`IO.select` loop (reading every reader and writing `stdin_data`
concurrently), so no real threads are needed.

## Test plan

- [x] `cargo test --release -p monoruby --lib` → **1632 passed / 0 failed**
      (new `process_spawn_detach`, `open3_capture_via_spawn`,
      `open3_no_deadlock_on_large_output` compare against CRuby)
- [x] Output matches CRuby for capture2/capture2e/capture3, `stdin_data`,
      and the deadlock scenario (1 MB on stdout **and** stderr at once;
      2 MB stdin streamed while stdout is read back)
- [x] Real `git clone` → `rev-parse` driven through `Open3.capture3`
      (the bundler git-source path) succeeds
- [x] `rubyboy` benchmark runs (rc=0); no benchmark regressions

NOTE: spawn currently ignores options other than `:in`/`:out`/`:err`
(e.g. `:chdir`, env hash); bundler's git path doesn't use them.

https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRTBeAMesniEnbcrdGtJp)_