### PR TITLE
runtime: hang prevention — Thread.pass sched_yield (B3) + opt-in watchdog (B+)

### DIFF
--- a/doc/signal_handling.md
+++ b/doc/signal_handling.md
@@ -151,20 +151,23 @@ the parent shell may leave it open to the tty. Investigation needed:
 
 No code change planned without that diagnosis.
 
-### B3. `core/file`
+### B3. `core/file` — **done**
 
 Caused by a subprocess (`ruby_exe` in mspec) hitting the
-`Thread.pass called too many times` guard in
-[monoruby/builtins/startup.rb:452](../monoruby/builtins/startup.rb#L452).
-The subprocess aborts; the parent waits on its pipe forever.
+`Thread.pass called too many times` guard. The pure-Ruby `Thread.pass`
+counted its calls and raised `ThreadError` after 1000, so the subprocess
+aborted and the parent waited on its pipe forever.
 
-Pick one (or both):
+Resolved via option 1: the artificial guard is gone and `Thread.pass`
+is now a native `sched_yield(2)` wrapper
+([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs),
+`std::thread::yield_now()`). It returns nil and never raises — a cheap,
+legitimate no-op when nothing else is runnable. `Thread` is created in
+Rust (subclass of `Object`) and reopened by the pure-Ruby class in
+`startup.rb`, matching how `Dir` / `File` / `IO` are split.
 
-1. Lower or remove the guard. `Thread.pass` becomes a `sched_yield(2)`
-   wrapper — legitimate even single-threaded.
-2. Audit the call site that loops on `Thread.pass`. If it's busy-waiting
-   for something monoruby can't deliver under single-thread, raise
-   `ThreadError` eagerly instead of looping.
+Option 2 (raising `ThreadError` eagerly at genuinely-blocking call sites)
+is tracked separately as B1 / #3.
 
 ### B+. Watchdog (safety net)
 
@@ -194,7 +197,8 @@ poll point; if it reaches zero, abort.
 
 - [x] #1 Signal generalization infrastructure + `Interrupt` class
   (default install limited to SIGINT — see A3 above)
-- [ ] #2 `Thread.pass` guard
+- [x] #2 `Thread.pass` guard removed; now a native `sched_yield(2)`
+  wrapper ([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs))
 - [ ] #3 Eager `ThreadError`
 - [ ] #4 Watchdog
 - [ ] #5 Stretch items

--- a/doc/signal_handling.md
+++ b/doc/signal_handling.md
@@ -169,15 +169,39 @@ Rust (subclass of `Object`) and reopened by the pure-Ruby class in
 Option 2 (raising `ThreadError` eagerly at genuinely-blocking call sites)
 is tracked separately as B1 / #3.
 
-### B+. Watchdog (safety net)
+### B+. Watchdog (safety net) — **done**
 
 Optional environment toggle `MONORUBY_HANG_WATCHDOG_SEC=N`. After N
-seconds of no bytecode progress, abort the process with a clear message.
-Default off. Catches unknown hangs in CI and converts them to errors
-instead of opaque timeouts.
+seconds of no interpreter progress, abort the process with a clear
+message. Default off. Catches unknown hangs in CI and converts them to
+errors instead of opaque timeouts.
 
-Implementation sketch: a SIGALRM-driven counter that decrements at every
-poll point; if it reaches zero, abort.
+Implemented in
+[monoruby/src/watchdog.rs](../monoruby/src/watchdog.rs):
+
+- `init` (called once from `Globals::new`) reads the env var; when
+  `N > 0` it installs a `SIGALRM` handler and a 1 Hz `setitimer`. Unset
+  / `<= 0` ⇒ no syscalls installed, fully disabled.
+- A `COUNTDOWN` (seconds) is reset to `N` at the VM poll point
+  (`execute_gc`, via `watchdog::poll`) — i.e. "progress was made".
+- The `SIGALRM` handler decrements `COUNTDOWN` once per second and, on
+  reaching zero, `write(2)`s a message and `_exit(134)`s. The abort
+  decision lives in the handler, *not* the poll point, because a genuine
+  hang never reaches the poll point. The handler touches only an atomic,
+  `write` and `_exit`, all async-signal-safe.
+
+**Limitation:** the only poll point today is the allocation-driven GC
+poll, so the watchdog catches hangs that make *no* heap allocations
+(tight non-allocating loops, `sleep`/`Thread.pass`-until-flag spins —
+the common single-thread hang shapes). A spin loop that keeps
+allocating resets the countdown and is *not* caught. Adding the A5
+backward-branch poll point would close that gap; until then a watchdog
+budget should be set comfortably above the slowest legitimate
+allocating example.
+
+Coverage: [monoruby/tests/watchdog.rs](../monoruby/tests/watchdog.rs)
+(fires on a non-allocating hang; silent when unset; no false-fire when
+the program finishes within budget).
 
 ---
 
@@ -200,5 +224,6 @@ poll point; if it reaches zero, abort.
 - [x] #2 `Thread.pass` guard removed; now a native `sched_yield(2)`
   wrapper ([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs))
 - [ ] #3 Eager `ThreadError`
-- [ ] #4 Watchdog
+- [x] #4 Watchdog — `MONORUBY_HANG_WATCHDOG_SEC=N`, SIGALRM-driven,
+  default off ([monoruby/src/watchdog.rs](../monoruby/src/watchdog.rs))
 - [ ] #5 Stretch items

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -595,17 +595,9 @@ class Thread
     @@current
   end
 
-  @@pass_count = 0
-  def self.pass
-    # monoruby is single-threaded. Thread.pass is a no-op, but if called
-    # repeatedly (e.g., `Thread.pass until condition`), the condition will
-    # never change. Raise after a safety limit to prevent infinite loops.
-    @@pass_count += 1
-    if @@pass_count > 1000
-      @@pass_count = 0
-      raise ThreadError, "Thread.pass called too many times (monoruby is single-threaded)"
-    end
-  end
+  # Thread.pass is a native sched_yield(2) wrapper (see builtins/thread.rs).
+  # Genuine single-thread blocking is surfaced at the blocking call sites,
+  # not by an artificial Thread.pass call-count guard.
 
   def initialize(*args, &block)
     @block = block

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -41,6 +41,7 @@ mod set;
 mod string;
 pub(crate) mod struct_class;
 mod symbol;
+mod thread;
 mod time;
 mod true_class;
 
@@ -92,6 +93,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     marshal::init(globals);
     math::init(globals);
     process::init(globals);
+    thread::init(globals);
     gc::init(globals);
     random::init(globals);
     symbol::init(globals);

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+//
+// Thread class
+//
+// monoruby runs Ruby code on a single OS thread. The bulk of `Thread`
+// lives in monoruby/builtins/startup.rb as plain Ruby — `Thread.new`
+// defers its block and runs it lazily on `#value` / `#join`. Only the
+// pieces that need a real syscall live here; the Ruby side reopens this
+// class.
+
+pub(super) fn init(globals: &mut Globals) {
+    let klass = globals.define_class_under_obj("Thread").id();
+    globals.define_builtin_class_func(klass, "pass", pass, 0);
+}
+
+///
+/// ### Thread.pass
+///
+/// - pass -> nil
+///
+/// Give the OS scheduler a hint that the current thread is willing to
+/// yield the CPU. monoruby has only one runnable OS thread, so there is
+/// no in-process thread to switch to; this lowers to `sched_yield(2)`
+/// (via `std::thread::yield_now`), which is a cheap, legitimate no-op
+/// when nothing else is runnable. Always returns nil.
+///
+/// Previously `Thread.pass` was a pure-Ruby counter that raised
+/// `ThreadError` after 1000 calls to break `Thread.pass until cond`
+/// busy-waits. That guard aborted innocent subprocesses (e.g. mspec's
+/// `ruby_exe`) and hung the parent on its pipe; see
+/// doc/signal_handling.md (B3). Genuine single-thread blocking is
+/// surfaced at the blocking call sites instead (B1).
+///
+/// [https://docs.ruby-lang.org/en/master/Thread.html#method-c-pass]
+#[monoruby_builtin]
+fn pass(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    std::thread::yield_now();
+    Ok(Value::nil())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn thread_pass_returns_nil() {
+        run_test("Thread.pass");
+        run_test("Thread.pass.nil?");
+    }
+
+    #[test]
+    fn thread_pass_does_not_raise_when_called_repeatedly() {
+        // The old pure-Ruby guard raised ThreadError after 1000 calls.
+        // A real sched_yield wrapper never raises (B3 in
+        // doc/signal_handling.md).
+        run_test_once(
+            r#"
+            2000.times { Thread.pass }
+            :ok
+            "#,
+        );
+    }
+}

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2644,6 +2644,10 @@ pub(crate) extern "C" fn execute_gc(
     mut executor: &mut Executor,
     globals: &mut Globals,
 ) -> Option<Value> {
+    // Reaching the poll point counts as interpreter progress: reset the
+    // hang watchdog's countdown (no-op unless armed). See
+    // doc/signal_handling.md B+.
+    crate::watchdog::poll();
     CODEGEN.with(|codegen| {
         let codegen = codegen.borrow_mut();
         // Drain the pending-signal bitmap. The lowest-numbered pending

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -184,6 +184,10 @@ impl Globals {
 
         WARNING.store(warning, std::sync::atomic::Ordering::Relaxed);
 
+        // Arm the optional hang watchdog (no-op unless
+        // MONORUBY_HANG_WATCHDOG_SEC is set). See doc/signal_handling.md B+.
+        crate::watchdog::init();
+
         // Propagate the host CRuby's gem-root directories to the vendored
         // rubygems via GEM_PATH so `Gem::Specification.find_by_name` can
         // discover host-installed gems (e.g. those added by `gem install`).

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 mod ruby_probe;
 pub mod tests;
 mod value;
+mod watchdog;
 
 pub(crate) use crate::codegen::runtime::ProcData;
 pub(crate) use bytecode::*;

--- a/monoruby/src/watchdog.rs
+++ b/monoruby/src/watchdog.rs
@@ -1,0 +1,106 @@
+//! Optional hang watchdog (doc/signal_handling.md B+).
+//!
+//! monoruby runs Ruby on a single OS thread with no preemptive
+//! scheduler, so some inherently-concurrent programs — and a handful of
+//! single-thread-incompatible specs — can spin or block with no way to
+//! make forward progress. When `MONORUBY_HANG_WATCHDOG_SEC=N` (N > 0)
+//! is set, this module arms a `SIGALRM`-driven watchdog that aborts the
+//! process after N seconds without the interpreter reaching a poll
+//! point, turning an opaque CI timeout into a clear, fast failure.
+//!
+//! Mechanism:
+//! - [`init`] reads the env var once and, if armed, installs a `SIGALRM`
+//!   handler plus a 1 Hz interval timer (`setitimer`).
+//! - [`poll`] is called from the VM poll point (`execute_gc`); it resets
+//!   the countdown to the full budget — i.e. "progress was made".
+//! - The `SIGALRM` handler decrements the countdown once per second and,
+//!   when it reaches zero, writes a message and `_exit`s. The abort
+//!   decision lives in the handler — not at the poll point — because a
+//!   genuine hang never reaches the poll point.
+//!
+//! Disabled by default (env var unset or `<= 0`): [`init`] installs
+//! nothing and [`poll`] is a single relaxed atomic load.
+
+use std::sync::atomic::{AtomicI32, Ordering};
+
+/// Configured budget in seconds (`0` = disabled). Set once by [`init`].
+static BUDGET: AtomicI32 = AtomicI32::new(0);
+
+/// Seconds remaining before the watchdog fires. Reset to [`BUDGET`] at
+/// every poll point; decremented once per second by the `SIGALRM`
+/// handler; aborts when it reaches zero.
+static COUNTDOWN: AtomicI32 = AtomicI32::new(0);
+
+/// Arm the watchdog from `MONORUBY_HANG_WATCHDOG_SEC`, at most once per
+/// process. A no-op when the variable is unset, unparsable, or `<= 0`.
+pub(crate) fn init() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(arm_from_env);
+}
+
+fn arm_from_env() {
+    let secs = match std::env::var("MONORUBY_HANG_WATCHDOG_SEC") {
+        Ok(s) => s.trim().parse::<i32>().unwrap_or(0),
+        Err(_) => 0,
+    };
+    if secs <= 0 {
+        return;
+    }
+    BUDGET.store(secs, Ordering::Relaxed);
+    COUNTDOWN.store(secs, Ordering::Relaxed);
+
+    // SAFETY: textbook libc signal/timer setup. The handler is
+    // async-signal-safe (only atomic ops, `write(2)` and `_exit(2)`),
+    // and we install it before arming the timer so it can never observe
+    // an uninitialised state.
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = handler as *const () as usize;
+        sa.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&mut sa.sa_mask);
+        if libc::sigaction(libc::SIGALRM, &sa, std::ptr::null_mut()) != 0 {
+            return;
+        }
+        let it = libc::itimerval {
+            it_interval: libc::timeval {
+                tv_sec: 1,
+                tv_usec: 0,
+            },
+            it_value: libc::timeval {
+                tv_sec: 1,
+                tv_usec: 0,
+            },
+        };
+        libc::setitimer(libc::ITIMER_REAL, &it, std::ptr::null_mut());
+    }
+
+    eprintln!("monoruby: hang watchdog armed (MONORUBY_HANG_WATCHDOG_SEC={secs})");
+}
+
+/// Record interpreter progress. Called from the VM poll point; resets
+/// the countdown so the watchdog only fires after a full [`BUDGET`]
+/// seconds with no poll point reached. Cheap (one relaxed load) and a
+/// no-op when the watchdog is disarmed.
+#[inline]
+pub(crate) fn poll() {
+    let budget = BUDGET.load(Ordering::Relaxed);
+    if budget > 0 {
+        COUNTDOWN.store(budget, Ordering::Relaxed);
+    }
+}
+
+/// `SIGALRM` handler. Async-signal-safe: only atomic ops, `write(2)`
+/// and `_exit(2)`.
+extern "C" fn handler(_signo: libc::c_int) {
+    // `fetch_sub` returns the previous value: still > 1 means there is
+    // budget left after this tick, so keep waiting.
+    if COUNTDOWN.fetch_sub(1, Ordering::Relaxed) > 1 {
+        return;
+    }
+    const MSG: &[u8] = b"\nmonoruby: hang watchdog fired - no interpreter progress within MONORUBY_HANG_WATCHDOG_SEC; aborting\n";
+    // SAFETY: `write` and `_exit` are async-signal-safe; `MSG` is static.
+    unsafe {
+        libc::write(2, MSG.as_ptr() as *const libc::c_void, MSG.len());
+        libc::_exit(134);
+    }
+}

--- a/monoruby/tests/watchdog.rs
+++ b/monoruby/tests/watchdog.rs
@@ -1,0 +1,87 @@
+//! Integration coverage for the optional hang watchdog
+//! (doc/signal_handling.md B+).
+//!
+//! The watchdog aborts the *process* via `_exit` from a signal handler,
+//! so it can only be exercised by spawning the real binary — not through
+//! the in-process `run_test` harness.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn monoruby() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+}
+
+/// A non-allocating infinite loop never reaches the GC poll point, so an
+/// armed watchdog must fire and abort the process — converting a hang
+/// into a fast, deterministic failure rather than an opaque timeout.
+#[test]
+fn watchdog_aborts_non_allocating_hang() {
+    let start = Instant::now();
+    let output = monoruby()
+        .args(["-e", "i = 0; while true; i += 1; end"])
+        .env("MONORUBY_HANG_WATCHDOG_SEC", "1")
+        .output()
+        .expect("failed to spawn monoruby");
+    let elapsed = start.elapsed();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The SIGALRM handler ends the process with `_exit(134)`.
+    assert_eq!(
+        output.status.code(),
+        Some(134),
+        "expected watchdog _exit(134), got {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(
+        stderr.contains("hang watchdog fired"),
+        "expected watchdog message on stderr, got: {stderr}"
+    );
+    // Budget is 1s; allow generous slack for CI scheduling but ensure it
+    // fired promptly rather than spinning indefinitely.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "watchdog took too long to fire: {elapsed:?}"
+    );
+}
+
+/// Disabled by default: with the env var unset the watchdog installs
+/// nothing, so a terminating program runs to completion silently.
+#[test]
+fn watchdog_disabled_by_default() {
+    let output = monoruby()
+        .args(["-e", "x = 0; 1000.times { |k| x += k }; puts x"])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(
+        output.status.success(),
+        "expected clean exit, got {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("watchdog"),
+        "watchdog must stay silent when unset, stderr: {stderr}"
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "499500");
+}
+
+/// Armed, but the program finishes within budget: the watchdog must not
+/// fire and the process exits normally.
+#[test]
+fn watchdog_armed_but_program_finishes_in_time() {
+    let output = monoruby()
+        .args(["-e", "x = 0; 1000.times { |k| x += k }; puts x"])
+        .env("MONORUBY_HANG_WATCHDOG_SEC", "5")
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(
+        output.status.success(),
+        "expected clean exit, got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "499500");
+}


### PR DESCRIPTION
Continues `doc/signal_handling.md` after PR #590 (signal generalization + `Interrupt`, merged). Implements two of the hang-prevention items.

## B3 — `Thread.pass` → native `sched_yield(2)`
`Thread.pass` was a pure-Ruby counter that raised `ThreadError` after 1000 calls to break `Thread.pass until cond` busy-waits. That guard aborted innocent subprocesses (mspec's `ruby_exe`) and hung the parent on its pipe — the root cause of the `core/file` hang.

- Replaced with a native `sched_yield(2)` wrapper (`std::thread::yield_now`) that returns nil and never raises.
- `Thread` is now created in Rust (subclass of `Object`) and reopened by the pure-Ruby class in `startup.rb`, matching how `Dir`/`File`/`IO` are split.

> Note: this commit was originally part of PR #590's branch but was orphaned when #590 was squash-merged at an earlier head; reapplied here.

## B+ — optional hang watchdog (`MONORUBY_HANG_WATCHDOG_SEC`)
Opt-in safety net that converts opaque CI timeouts into clear, fast failures.

- `MONORUBY_HANG_WATCHDOG_SEC=N` (N>0) ⇒ `Globals::new` installs a `SIGALRM` handler + 1 Hz `setitimer`.
- A countdown is reset to N at the VM poll point (`execute_gc`); the `SIGALRM` handler decrements it once per second and, at zero, writes a message and `_exit(134)`s. The abort decision lives in the handler — a genuine hang never reaches the poll point. Handler is async-signal-safe (atomic + `write` + `_exit`).
- **Default off**: unset/≤0 installs nothing and `poll()` is a single relaxed atomic load.
- **Limitation**: the only poll point today is the allocation-driven GC poll, so it catches non-allocating hangs (tight loops, `sleep`/`Thread.pass`-until-flag spins — the common shapes). An allocating spin resets the countdown and is not caught; the A5 backward-branch poll point would close that gap.

## Tests
- `tests/watchdog.rs` (subprocess): fires on a non-allocating hang (`_exit(134)` + message), silent when unset, no false-fire when the program finishes in time.
- Full lib suite: 1632 passed, 0 failed. New `builtins::thread` unit tests pass.

## Doc
`doc/signal_handling.md`: B3 and B+ marked done with implementation notes; status checklist updated (#2, #4). Remaining: #3 (eager `ThreadError`), #5 (A5 extra poll points, B2 argf, A7 `Signal.trap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)