### PR TITLE
feat(exception): support raise cause: keyword

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -788,6 +788,87 @@ mod tests {
     }
 
     #[test]
+    fn explicit_cause() {
+        run_tests(&[
+            // `cause:` sets the cause explicitly.
+            r#"
+            c = StandardError.new("orig")
+            begin; raise "new", cause: c; rescue => e; e.cause.equal?(c); end
+            "#,
+            // `cause: nil` on a fresh exception ⇒ nil cause.
+            r#"begin; raise "x", cause: nil; rescue => e; e.cause.inspect; end"#,
+            // `cause:` overrides the implicit `$!` cause.
+            r#"
+            custom = StandardError.new("custom")
+            begin
+              raise "first"
+            rescue
+              begin; raise "second", cause: custom; rescue => e; e.cause.equal?(custom); end
+            end
+            "#,
+            // `cause: nil` inside a rescue suppresses implicit chaining.
+            r#"
+            begin
+              raise "first"
+            rescue
+              begin; raise "second", cause: nil; rescue => e; e.cause.inspect; end
+            end
+            "#,
+            // Exception class with message and explicit cause.
+            r#"
+            cm = StandardError.new("cm")
+            begin; raise ArgumentError, "am", cause: cm; rescue => e; [e.class.name, e.message, e.cause.equal?(cm)]; end
+            "#,
+            // A cause equal to the raised exception is ignored.
+            r#"
+            ce = StandardError.new("cause")
+            begin; raise ce, cause: ce; rescue => e; [e.equal?(ce), e.cause.inspect]; end
+            "#,
+            // `cause: nil` does not overwrite an existing cause.
+            r#"
+            e1 = nil; e2 = nil
+            begin
+              begin; raise "1"; rescue => e1; raise "2"; end
+            rescue => e2
+            end
+            begin; raise e2, cause: nil; rescue => e; e.cause.equal?(e1); end
+            "#,
+        ]);
+        // Non-exception cause ⇒ TypeError.
+        run_test(
+            r#"
+            begin; raise "m", cause: Object.new; rescue TypeError => e; e.message; end
+            "#,
+        );
+        // A circular cause ⇒ ArgumentError "circular causes".
+        run_test(
+            r#"
+            begin
+              begin
+                raise "Error 1"
+              rescue => e1
+                begin
+                  raise "Error 2"
+                rescue => e2
+                  begin
+                    raise "Error 3"
+                  rescue => e3
+                    raise(e1, cause: e3)
+                  end
+                end
+              end
+            rescue ArgumentError => e
+              e.message
+            end
+            "#,
+        );
+        // Only `cause:` with no positional argument ⇒ ArgumentError.
+        run_test(
+            r#"begin; raise(cause: nil); rescue ArgumentError => e; e.message; end"#,
+        );
+    }
+
+    #[test]
     fn message_calls_to_s() {
         run_tests(&[
             // Default: message == stored string.

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -565,9 +565,9 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     // raise/fail trampoline). CRuby: passing `cause:` with no
     // positional arguments raises `ArgumentError "only cause is given
     // with no arguments"`.
-    let has_cause = lfp.try_arg(3).is_some();
+    let cause_kwarg = lfp.try_arg(3);
     if lfp.try_arg(0).is_none() {
-        if has_cause {
+        if cause_kwarg.is_some() {
             return Err(MonorubyErr::argumenterr(
                 "only cause is given with no arguments",
             ));
@@ -586,13 +586,15 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 // A message override makes CRuby return a *new* exception
                 // (`exc.exception(msg)`), so identity is not preserved.
                 err.set_msg(arg1.coerce_to_str(vm, globals)?);
-                return Err(err);
+                return Err(apply_cause(globals, err, None, cause_kwarg)?);
             }
         }
-        return Err(err.with_original(lfp.arg(0)));
+        let raised = lfp.arg(0);
+        return Err(apply_cause(globals, err.with_original(raised), Some(raised), cause_kwarg)?);
     } else if let Some(klass) = lfp.arg(0).is_class() {
         if klass.id() == STOP_ITERATION_CLASS {
-            return Err(MonorubyErr::stopiterationerr("".to_string()));
+            let err = MonorubyErr::stopiterationerr("".to_string());
+            return Err(apply_cause(globals, err, None, cause_kwarg)?);
         } else if klass.is_exception() {
             let mut args = vec![];
             if let Some(arg1) = lfp.try_arg(1) {
@@ -603,10 +605,11 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             let ex =
                 vm.invoke_method_inner(globals, IdentId::NEW, klass.as_val(), &args, None, None)?;
             let err = MonorubyErr::new_from_exception(ex.is_exception().unwrap()).with_original(ex);
-            return Err(err);
+            return Err(apply_cause(globals, err, Some(ex), cause_kwarg)?);
         }
     } else if let Some(message) = lfp.arg(0).is_rstring() {
-        return Err(MonorubyErr::runtimeerr(message.to_str()?));
+        let err = MonorubyErr::runtimeerr(message.to_str()?);
+        return Err(apply_cause(globals, err, None, cause_kwarg)?);
     }
     // Duck-typed exception. CRuby drives `arg0.exception(msg)` (or
     // `arg0.exception` if no message was given); the result must be
@@ -625,11 +628,62 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         let result =
             vm.invoke_method_inner(globals, exception_id, lfp.arg(0), &args, None, None)?;
         match result.is_exception() {
-            Some(ex) => return Err(MonorubyErr::new_from_exception(ex).with_original(result)),
+            Some(ex) => {
+                let err = MonorubyErr::new_from_exception(ex).with_original(result);
+                return Err(apply_cause(globals, err, Some(result), cause_kwarg)?);
+            }
             None => return Err(MonorubyErr::typeerr("exception object expected")),
         }
     }
     Err(MonorubyErr::typeerr("exception class/object expected"))
+}
+
+/// Apply an explicit `cause:` keyword to a to-be-raised error. `raised`
+/// is the exception object being raised, when known (for identity and
+/// cycle checks). Returns the error to raise — either the original error
+/// tagged with the cause, or a validation error (`TypeError` for a
+/// non-exception cause, `ArgumentError` for a circular cause).
+fn apply_cause(
+    globals: &Globals,
+    mut err: MonorubyErr,
+    raised: Option<Value>,
+    cause_kwarg: Option<Value>,
+) -> Result<MonorubyErr> {
+    let Some(cause) = cause_kwarg else {
+        return Ok(err);
+    };
+    if !cause.is_nil() && cause.is_exception().is_none() {
+        return Err(MonorubyErr::typeerr("exception object expected"));
+    }
+    let cause = match raised {
+        // A cause equal to the raised exception itself is ignored.
+        Some(raised) if !cause.is_nil() && cause.id() == raised.id() => Value::nil(),
+        // Setting a cause whose chain already reaches the raised exception
+        // would create a cycle.
+        Some(raised)
+            if !cause.is_nil() && cause_chain_contains(globals, cause, raised) =>
+        {
+            return Err(MonorubyErr::argumenterr("circular causes"));
+        }
+        _ => cause,
+    };
+    err.explicit_cause = Some(cause);
+    Ok(err)
+}
+
+/// Whether `target` appears in the `#cause` chain reachable from `start`.
+fn cause_chain_contains(globals: &Globals, start: Value, target: Value) -> bool {
+    let cause_id = IdentId::get_id("/cause");
+    let mut cur = start;
+    loop {
+        if cur.id() == target.id() {
+            return true;
+        }
+        match globals.store.get_ivar(cur, cause_id) {
+            Some(next) if !next.is_nil() => cur = next,
+            _ => return false,
+        }
+    }
 }
 
 ///

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -809,6 +809,7 @@ impl Executor {
 
     pub(crate) fn take_ex_obj(&mut self, globals: &mut Globals) -> Value {
         let mut err = self.take_error();
+        let explicit_cause = err.explicit_cause;
         // Re-raise of an existing exception object (`raise exc`): return
         // that object so its identity and instance variables are
         // preserved. CRuby only assigns a backtrace if the exception
@@ -819,7 +820,7 @@ impl Executor {
                     ex.trace = err.take_trace();
                 }
             }
-            return self.chain_cause(globals, orig);
+            return self.chain_cause(globals, orig, explicit_cause);
         }
         let v = match err.kind() {
             MonorubyErrKind::Load(path) => {
@@ -873,16 +874,31 @@ impl Executor {
             }
             _ => Value::new_exception(err),
         };
-        self.chain_cause(globals, v)
+        self.chain_cause(globals, v, explicit_cause)
     }
 
-    /// Implicit cause chaining (CRuby `exc_setup_cause`): if an exception
-    /// is currently being handled (`$!`) and `v` is neither it nor
-    /// already given a cause, record `$!` as `v`'s cause. `take_ex_obj`
-    /// runs *before* the caller sets `$!` to the new exception, so `$!`
-    /// here is the enclosing handler's exception.
-    fn chain_cause(&mut self, globals: &mut Globals, v: Value) -> Value {
+    /// Record `v`'s cause. An explicit `cause:` keyword (`explicit_cause`,
+    /// `Some(nil)` for `cause: nil`) takes precedence and suppresses the
+    /// implicit chain. Otherwise, CRuby `exc_setup_cause`: if an exception
+    /// is currently being handled (`$!`) and `v` is neither it nor already
+    /// given a cause, record `$!` as `v`'s cause. `take_ex_obj` runs
+    /// *before* the caller sets `$!` to the new exception, so `$!` here is
+    /// the enclosing handler's exception.
+    fn chain_cause(
+        &mut self,
+        globals: &mut Globals,
+        v: Value,
+        explicit_cause: Option<Value>,
+    ) -> Value {
         let cause_id = IdentId::get_id("/cause");
+        if let Some(cause) = explicit_cause {
+            // `cause: nil` suppresses implicit chaining but keeps any cause
+            // the exception already has; a non-nil cause overwrites it.
+            if !cause.is_nil() {
+                let _ = globals.store.set_ivar(v, cause_id, cause);
+            }
+            return v;
+        }
         if globals.store.get_ivar(v, cause_id).is_none() {
             let active = globals
                 .get_gvar(IdentId::get_id("$!"))

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -15,6 +15,10 @@ pub struct MonorubyErr {
     /// materialising a fresh one, preserving the object's identity and
     /// its instance variables (CRuby `raise exc` re-raises `exc` itself).
     pub original: Option<Value>,
+    /// An explicitly given `cause:` keyword (`Some(nil)` for `cause: nil`).
+    /// When set, `take_ex_obj` records it as the exception's cause and
+    /// suppresses the implicit `$!` chaining.
+    pub explicit_cause: Option<Value>,
 }
 
 impl MonorubyErr {
@@ -24,6 +28,7 @@ impl MonorubyErr {
             message: message.to_string(),
             trace: vec![],
             original: None,
+            explicit_cause: None,
         }
     }
 
@@ -36,6 +41,7 @@ impl MonorubyErr {
             message: msg,
             trace,
             original: None,
+            explicit_cause: None,
         }
     }
 
@@ -59,6 +65,7 @@ impl MonorubyErr {
             message: msg,
             trace: vec![(Some((loc, sourceinfo)), func_id)],
             original: None,
+            explicit_cause: None,
         }
     }
 
@@ -76,6 +83,9 @@ impl MonorubyErr {
         use alloc::GC;
         if let Some(original) = &self.original {
             original.mark(alloc);
+        }
+        if let Some(cause) = &self.explicit_cause {
+            cause.mark(alloc);
         }
         match &self.kind {
             // Packed `Value::id()` of the receiver that triggered the


### PR DESCRIPTION
## Summary

`raise` now honours an explicit `cause:` keyword argument (previously it was only used to detect the "only cause is given with no arguments" error — the value was ignored).

```ruby
raise "new error", cause: some_exception   # sets #cause explicitly
raise "msg", cause: nil                     # suppresses implicit $! chaining
raise ArgumentError, "msg", cause: c        # class form with a cause
```

Behaviour, matching CRuby:
- **non-nil cause** → recorded as the exception's `#cause`, overriding the implicit `$!` chain.
- **`cause: nil`** → suppresses implicit chaining but does **not** overwrite a cause the exception already has (e.g. re-raising `e2` that already chained to `e1`).
- **non-Exception, non-nil cause** → `TypeError "exception object expected"`.
- **cause whose chain already reaches the raised exception** → `ArgumentError "circular causes"`.
- **cause equal to the raised exception itself** → ignored.

## Implementation

`MonorubyErr` gains an `explicit_cause: Option<Value>` field (`Some(nil)` for `cause: nil`), threaded through `Executor::take_ex_obj` → `chain_cause`, which applies the explicit cause and skips implicit `$!` chaining when one was given. The `raise` builtin validates the cause and runs the identity/cycle checks against the raised object — known for the exception-object, class, and duck-typed forms via the `original` tag added in #628. The new field is marked for GC alongside `original`.

## Impact on ruby/spec

`core/kernel/raise_spec`: **16 `cause:` examples now pass** (errors 21 → 7); failure count unchanged. Verified against master by diffing exact test names — no test that passed before regresses. `core/exception` totals unchanged (9F/2E on both).

The two remaining `cause`-tagged failures (`supports exception class with message, backtrace and cause`) now get past the cause handling and fail only on the unsupported **backtrace argument** to `raise` — a separate follow-up.

## Test plan

- [x] `cargo test --lib -p monoruby -- explicit_cause` ⇒ pass (prism + ruruby)
- [x] re-run under `--features gc-stress` ⇒ pass (covers the new GC mark)
- [x] `cargo test --lib -p monoruby -- builtins::exception builtins::kernel` ⇒ 110 pass
- [x] mspec raise_spec: 16 cause examples fixed, cause_spec 0F/0E, no regressions (name-level diff vs master)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBtRQ4j5NsUZTxqgcWBHZs)_