### PR TITLE
feat(signal): Signal.trap / Kernel#trap (core/signal 35→47)

### DIFF
--- a/doc/signal_handling.md
+++ b/doc/signal_handling.md
@@ -1,229 +1,176 @@
 # Signal handling and hang prevention
 
-Plan for extending monoruby's runtime so that:
+monoruby runs on a single OS thread with a register-based VM and an
+x86-64 JIT. Two consequences shaped this subsystem:
 
-1. Signals beyond SIGINT are caught and surfaced as Ruby exceptions.
-2. Common single-threaded-runtime hangs (mutex / sizedqueue, argf, file)
-   no longer terminate the test process.
+1. POSIX signals must be turned into Ruby-level behaviour (exceptions or
+   `Signal.trap` handlers) **without** running Ruby code in
+   async-signal context.
+2. Several single-threaded-runtime situations would otherwise hang the
+   process — and, in CI, the test runner — instead of failing.
 
-Tracked in this document; updated as items land.
+This document describes **what is implemented today** and **what is
+planned next**.
 
 ---
 
-## Current architecture (baseline)
+## Current implementation
 
-- A single AOT-generated asm stub is registered for `SIGINT` only in
-  [monoruby/src/codegen.rs:892](../monoruby/src/codegen.rs#L892).
-  The stub does:
+### Signal capture pipeline
+
+Signals are never serviced inside the OS handler. A tiny
+async-signal-safe asm stub only *records* the signal; the real work
+happens at the next interpreter *poll point*.
+
+- **Pending-signal bitmap.** `JitModule` holds a 32-bit
+  `pending_signals` label — bit `n` corresponds to signal `n + 1` (so
+  `SIGINT` = 2 ⇒ bit 1). Writes are an async-safe `OR`; the poll point
+  reads-and-clears.
+  ([monoruby/src/codegen.rs](../monoruby/src/codegen.rs))
+- **Per-signal asm stubs.** `JitModule::signal_handler_for(signo)` emits,
+  for each signal:
 
   ```asm
-  addl [rip + alloc_flag], 10   ; nudge GC poll
-  movl [rip + sigint_flag], 1   ; mark SIGINT pending
+  addl [rip + alloc_flag], 10        ; force the next allocation to hit the GC poll
+  orl  [rip + pending_signals], bit  ; mark this signal pending (async-safe OR)
   ret
   ```
 
-- Polling happens only inside `execute_gc`
-  ([monoruby/src/executor.rs:2557](../monoruby/src/executor.rs#L2557)).
-  If the flag is set, the executor's error slot is filled with
-  `MonorubyErr::runtimeerr("Interrupt")` — a plain RuntimeError, **not**
-  a real `Interrupt`. `Interrupt` as a class does not exist yet
-  (`SignalException` does, in
-  [monoruby/src/builtins/exception.rs:42](../monoruby/src/builtins/exception.rs#L42)).
-- There is no `Signal.trap` / `Kernel#trap`. Only `Signal.list` and
-  `Signal.signame` exist.
+  A stub is pre-generated at `Codegen::new` for **every** signal in
+  `signal_table::TRAPPABLE_SIGNALS`, but only the default-install set
+  (`POSIX_SIGNALS`, currently just `SIGINT`) is `sigaction(2)`'d at
+  startup. The rest are armed on demand by `Signal.trap`, so trapping
+  never has to JIT-emit code into a live buffer.
+- **Poll point.** `execute_gc` (the allocation-driven GC poll) drains the
+  bitmap via `signal_table::lowest_pending_signo` and dispatches the
+  lowest-numbered pending signal. This is currently the **only** poll
+  point. ([monoruby/src/executor.rs](../monoruby/src/executor.rs))
 
-## A. Signal handling generalization
+### Signal → exception mapping
 
-### A1. Pending-signal bitmap
+When no user handler is installed, `signal_table::signo_to_error` maps a
+signo to the Ruby error raised at the poll point:
 
-Replace the single-purpose `sigint_flag: i32` with a 32-bit
-`pending_signals: i32` bitmap. Bit `n` corresponds to signal `n + 1`.
-Reads/writes use `OR` / `XCHG`, both async-signal-safe.
+| Signal                                            | Mapped class                  |
+|---------------------------------------------------|-------------------------------|
+| `SIGINT`                                          | `Interrupt` (real class)      |
+| `SIGTERM`/`SIGHUP`/`SIGUSR1`/`SIGUSR2`/`SIGQUIT`/`SIGPIPE` | `SignalException` ("SIG…")     |
 
-### A2. Per-signal asm stubs
+`Interrupt < SignalException` is a real class
+([monoruby/src/builtins/exception.rs](../monoruby/src/builtins/exception.rs)),
+so `rescue Interrupt` works. Only `SIGINT` is installed by default:
+CRuby's default action for the others is *terminate the process*, and
+unconditionally catching them would break
+`Process.kill("TERM", child); $?.signaled?` patterns that fork tests
+rely on.
 
-Generalize `signal_handler` in
-[monoruby/src/codegen.rs:248](../monoruby/src/codegen.rs#L248) to a
-factory: for each supported signal, emit a tiny stub that sets its own
-bit and nudges `alloc_flag`. `Codegen::new` iterates the supported list
-and `sigaction`s each.
+### `Signal.trap` / `Kernel#trap`
 
-### A3. Registered set
+`Signal.trap(sig, command = nil, &block)` and the private `Kernel#trap`
+([monoruby/src/builtins/process.rs](../monoruby/src/builtins/process.rs),
+`signal_trap`).
 
-The runtime *infrastructure* (bitmap, mapping table, async-safe stub
-emitter) supports any of the catchable POSIX signals. What is
-unconditionally installed at startup is a smaller set, because the
-CRuby default for most signals is "terminate the process", not "raise":
+- **Per-signo disposition table.** `Globals::signal_handlers:
+  Vec<SignalDisposition>`, with `Handler` objects marked as GC roots in
+  `Globals::mark`. `SignalDisposition`
+  ([monoruby/src/codegen/signal_table.rs](../monoruby/src/codegen/signal_table.rs))
+  is one of:
 
-| Signal                                                    | Default install | Mapped class                       |
-|-----------------------------------------------------------|-----------------|------------------------------------|
-| SIGINT                                                    | **yes**         | `Interrupt`                         |
-| SIGTERM, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT, SIGPIPE       | only via A7     | `SignalException` ("SIG…")          |
-| **Not catchable**: SIGKILL, SIGSTOP                       | —               | —                                   |
-| **Left to kernel**: SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT | —            | (core-dump on genuine bugs)         |
+  | variant                 | OS disposition                       | reported back as              |
+  |-------------------------|--------------------------------------|-------------------------------|
+  | `Default`               | re-arm stub (if default-installed) else `SIG_DFL` | `"DEFAULT"`        |
+  | `SystemDefault`         | `SIG_DFL`                            | `"SYSTEM_DEFAULT"`            |
+  | `Ignore { from_nil }`   | `SIG_IGN`                            | `nil` (set via `nil`) / `"IGNORE"` |
+  | `Handler(Value)`        | the pre-generated stub               | the callable (by identity)    |
 
-Unconditionally catching SIGTERM/HUP/etc would break process-status
-tests that rely on `Process.kill("TERM", child); $?.signaled? == true`
-(CRuby's default is "kernel terminates the child", and `wait` reports
-the signal — not an exception). Once A7 (`Signal.trap`) is implemented,
-the runtime can `sigaction` the additional signals on first trap and
-deinstall on `:DEFAULT`. The mapping table is already pre-wired so A7
-only needs to flip the install bit.
+  The initial state is `Default` for the default-installed set (`SIGINT`)
+  and `SystemDefault` for every other signal — matching CRuby's initial
+  `"DEFAULT"` vs `"SYSTEM_DEFAULT"` reports.
+- **Install.** `trap` only `sigaction(2)`s the pre-generated stub:
+  `install_signal_stub` / `_ignore` / `_default` / `_system_default`
+  flip the OS disposition to stub / `SIG_IGN` / re-arm-or-`SIG_DFL` /
+  `SIG_DFL`.
+- **Dispatch.** At the poll point a `Handler` is invoked via
+  `#call(signo)`, so a `Proc`, `Method`, or any callable works; a
+  non-callable raises `NoMethodError` at delivery, per CRuby. `Ignore`
+  drops; `Default` / `SystemDefault` fall back to the exception mapping.
+- **CRuby-compatible parsing & errors:**
+  - **Signal arg:** Integer (validated; `#to_int` is never called),
+    String / `#to_str`-able, or Symbol — otherwise
+    `ArgumentError: bad signal type <Class>`. Out-of-range Integer ⇒
+    `invalid signal number (N)`; unknown name ⇒
+    `unsupported signal 'SIG…'`.
+  - **Reserved:** `SIGKILL` / `SIGSTOP` ⇒
+    `ArgumentError: Signal already used by VM or OS` (CRuby may raise
+    `Errno::EINVAL`; the spec accepts either);
+    `SIGSEGV` / `SIGBUS` / `SIGILL` / `SIGFPE` / `SIGVTALRM` ⇒
+    `can't trap reserved signal: SIG…`. The fault signals are left to the
+    kernel's core-dump path on purpose.
+  - **Command:** `"DEFAULT"`/`"SIG_DFL"`, `"SYSTEM_DEFAULT"`,
+    `"IGNORE"`/`"SIG_IGN"`/`""`/`nil`, or any callable.
 
-### A4. `Interrupt` class
+**ruby/spec `core/signal`: 47 / 52** (`list` 4/4, `signame` 6/6,
+`trap` 37/42).
 
-Add `Interrupt < SignalException` so the existing SIGINT path raises the
-right class. Currently it raises `RuntimeError` with the message
-`"Interrupt"`, which silently passes most user code but breaks
-`rescue Interrupt` and ruby/spec checks.
+Coverage: registration / return-value / error semantics as `process.rs`
+unit tests; signal *delivery* (Proc/Method/callable handlers,
+non-callable `NoMethodError`, signo argument, IGNORE swallows, DEFAULT
+re-terminates, SIGINT ⇒ Interrupt) as subprocess-isolated tests in
+[monoruby/tests/signal_trap.rs](../monoruby/tests/signal_trap.rs).
+Delivery cannot be tested in-process: sending a process-wide signal is
+unsafe under cargo's parallel test threads.
 
-### A5. Polling frequency
+### Hang prevention
 
-Today only `execute_gc` polls. A tight CPU loop with no allocations
-never sees the flag. Candidates for additional poll sites:
-
-- Backward branch (loop iteration) in the VM dispatch table.
-- Method entry, sampled (e.g. once every 64 calls).
-
-Defer until measurements show the GC-only poll is insufficient.
-
-### A6. Signal → exception mapping table
-
-A small Rust const table drives the conversion at poll time:
-
-```rust
-static SIGNAL_TABLE: &[(c_int, &str, fn() -> MonorubyErr)] = &[
-    (SIGINT,  "INT",  || MonorubyErr::interrupt("Interrupt")),
-    (SIGTERM, "TERM", || MonorubyErr::signalexception("SIGTERM")),
-    // …
-];
-```
-
-The poller walks the bitmap, clears the bit, looks up the mapping, sets
-the error on the executor. Priority is bit order — lowest signo first.
-
-### A7. `Signal.trap` (deferred)
-
-Out of scope for the first cut. Sketch:
-
-- `Globals` carries `Vec<Option<Value>>` of length 32, indexed by signo.
-- Poll-time conversion checks the slot first; if a Proc is present,
-  invoke it; otherwise fall back to A6's default mapping.
-- `Signal.trap("INT") { ... }` writes the slot. `Signal.trap("INT", "DEFAULT")`
-  clears it. `Signal.trap("INT", "IGNORE")` installs a sentinel that swallows.
-
----
-
-## B. Hang prevention
-
-### B1. `core/mutex`, `core/sizedqueue` (single-thread-incompatible)
-
-Root cause: `Thread.new` returns a Thread that never gets scheduled
-because monoruby is single-threaded, so `join` / `value` / mutex+CV
-patterns block forever.
-
-Two approaches, pick one:
-
-- **Run-block-synchronously**: `Thread.new { … }` runs the block on the
-  caller's stack to completion before returning the Thread. `join` /
-  `value` then return immediately. Closely matches what most tests
-  expect under cooperative concurrency. Risk: tests that depend on
-  *concurrent* visibility of mutated state will still fail, but at
-  least they won't hang.
-- **Eager ThreadError**: any blocking thread op (`Thread#join`,
-  `ConditionVariable#wait`, `Queue#pop` empty, …) raises
-  `ThreadError("can't block — monoruby is single-threaded")` immediately.
-  Safer, more honest; converts hangs to failures.
-
-Recommendation: start with eager ThreadError (cheaper, no semantic
-surprises). Revisit run-synchronously if too many tests would benefit.
-
-### B2. `core/argf`
-
-ARGF reads stdin when ARGV is empty. mspec may not redirect stdin;
-the parent shell may leave it open to the tty. Investigation needed:
-
-- Identify the spec file that hangs (the survey output stops at a
-  specific dotted position).
-- Determine whether the underlying issue is monoruby-specific
-  (`Kernel#gets` not returning nil at EOF when stdin is the terminal)
-  or a missing `<` redirect in the mspec invocation.
-
-No code change planned without that diagnosis.
-
-### B3. `core/file` — **done**
-
-Caused by a subprocess (`ruby_exe` in mspec) hitting the
-`Thread.pass called too many times` guard. The pure-Ruby `Thread.pass`
-counted its calls and raised `ThreadError` after 1000, so the subprocess
-aborted and the parent waited on its pipe forever.
-
-Resolved via option 1: the artificial guard is gone and `Thread.pass`
-is now a native `sched_yield(2)` wrapper
-([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs),
-`std::thread::yield_now()`). It returns nil and never raises — a cheap,
-legitimate no-op when nothing else is runnable. `Thread` is created in
-Rust (subclass of `Object`) and reopened by the pure-Ruby class in
-`startup.rb`, matching how `Dir` / `File` / `IO` are split.
-
-Option 2 (raising `ThreadError` eagerly at genuinely-blocking call sites)
-is tracked separately as B1 / #3.
-
-### B+. Watchdog (safety net) — **done**
-
-Optional environment toggle `MONORUBY_HANG_WATCHDOG_SEC=N`. After N
-seconds of no interpreter progress, abort the process with a clear
-message. Default off. Catches unknown hangs in CI and converts them to
-errors instead of opaque timeouts.
-
-Implemented in
-[monoruby/src/watchdog.rs](../monoruby/src/watchdog.rs):
-
-- `init` (called once from `Globals::new`) reads the env var; when
-  `N > 0` it installs a `SIGALRM` handler and a 1 Hz `setitimer`. Unset
-  / `<= 0` ⇒ no syscalls installed, fully disabled.
-- A `COUNTDOWN` (seconds) is reset to `N` at the VM poll point
-  (`execute_gc`, via `watchdog::poll`) — i.e. "progress was made".
-- The `SIGALRM` handler decrements `COUNTDOWN` once per second and, on
-  reaching zero, `write(2)`s a message and `_exit(134)`s. The abort
-  decision lives in the handler, *not* the poll point, because a genuine
-  hang never reaches the poll point. The handler touches only an atomic,
-  `write` and `_exit`, all async-signal-safe.
-
-**Limitation:** the only poll point today is the allocation-driven GC
-poll, so the watchdog catches hangs that make *no* heap allocations
-(tight non-allocating loops, `sleep`/`Thread.pass`-until-flag spins —
-the common single-thread hang shapes). A spin loop that keeps
-allocating resets the countdown and is *not* caught. Adding the A5
-backward-branch poll point would close that gap; until then a watchdog
-budget should be set comfortably above the slowest legitimate
-allocating example.
-
-Coverage: [monoruby/tests/watchdog.rs](../monoruby/tests/watchdog.rs)
-(fires on a non-allocating hang; silent when unset; no false-fire when
-the program finishes within budget).
+- **`Thread.pass` is a native `sched_yield(2)`**
+  ([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs),
+  `std::thread::yield_now()`) — returns `nil`, never raises. It replaced
+  an artificial "called too many times" guard that aborted `ruby_exe`
+  subprocesses and hung `core/file`. `Thread` is a Rust class reopened by
+  the pure-Ruby class in `startup.rb` (like `Dir` / `File` / `IO`).
+- **Optional hang watchdog**
+  ([monoruby/src/watchdog.rs](../monoruby/src/watchdog.rs)) —
+  `MONORUBY_HANG_WATCHDOG_SEC=N`, default off. A `SIGALRM` + 1 Hz
+  `setitimer` handler decrements a countdown that the poll point resets
+  ("progress was made"); on reaching zero it `write(2)`s a message and
+  `_exit(134)`s, turning an opaque CI timeout into a fast, labelled
+  failure. The handler touches only an atomic, `write`, and `_exit` (all
+  async-signal-safe). Because the GC poll is the only poll point, it
+  catches hangs that make *no* allocations (the common single-thread
+  shapes); an allocating spin resets the countdown and is not caught.
+  Coverage: [monoruby/tests/watchdog.rs](../monoruby/tests/watchdog.rs).
 
 ---
 
-## Recommended order
+## Future plans
 
-| # | Item                                                          | Size      | Outcome                                                                       |
-|---|---------------------------------------------------------------|-----------|-------------------------------------------------------------------------------|
-| 1 | A1–A4 + A6 (signal generalization + Interrupt class)          | ~150 LoC  | `core/signal` and `core/exception` stop killing the process                   |
-| 2 | B3 (`Thread.pass` guard revisit)                              | small     | `core/file` hang clears                                                       |
-| 3 | B1 (eager `ThreadError` on blocking thread ops)               | medium    | `core/mutex`, `core/sizedqueue` complete (with failures, not hangs)           |
-| 4 | B+ (watchdog)                                                 | small     | Safety net for the long tail                                                  |
-| 5 | A5 (extra poll points), B2 (argf), A7 (`Signal.trap`)         | as needed | Responsiveness, remaining argf hang, full user API                            |
+### Signal handling
 
----
+- **More poll points.** The GC poll is the only one today, so a signal
+  delivered during a tight *non-allocating* loop is seen only once the
+  loop allocates — affecting both `Signal.trap` responsiveness and the
+  watchdog. A backward-branch (loop-iteration) poll in the VM dispatch,
+  and possibly a sampled method-entry poll, would close this gap.
+  Deferred until measurements show the GC-only poll is insufficient.
+- **Remaining `core/signal` examples (5):**
+  - `:EXIT` pseudo-signal — `Signal.trap(:EXIT, …)` must run before
+    `at_exit` handlers; needs at-exit integration.
+  - Creating a new `Thread` from inside a handler — blocked on the
+    single-threaded `Thread` model.
+  - `SIGPIPE` `"SYSTEM_DEFAULT"` — CRuby ignores `SIGPIPE` by default
+    (write errors surface as `Errno::EPIPE`) and reports the initial
+    handler as `nil`; monoruby currently leaves it at `SIG_DFL`.
 
-## Status
+### Hang prevention
 
-- [x] #1 Signal generalization infrastructure + `Interrupt` class
-  (default install limited to SIGINT — see A3 above)
-- [x] #2 `Thread.pass` guard removed; now a native `sched_yield(2)`
-  wrapper ([monoruby/src/builtins/thread.rs](../monoruby/src/builtins/thread.rs))
-- [ ] #3 Eager `ThreadError`
-- [x] #4 Watchdog — `MONORUBY_HANG_WATCHDOG_SEC=N`, SIGALRM-driven,
-  default off ([monoruby/src/watchdog.rs](../monoruby/src/watchdog.rs))
-- [ ] #5 Stretch items
+- **Eager `ThreadError` on blocking thread ops.** `Thread#join` /
+  `value`, `ConditionVariable#wait`, empty `Queue#pop`, etc. cannot make
+  progress on a single thread, so they should raise `ThreadError`
+  immediately rather than block forever — converting the remaining
+  `core/mutex` / `core/sizedqueue` hangs into honest failures. (An
+  alternative, running `Thread.new` synchronously on the caller's stack,
+  is recorded but not chosen.)
+- **`core/argf` hang.** ARGF reads stdin when ARGV is empty; the hang
+  needs diagnosis (monoruby `Kernel#gets` not returning `nil` at tty EOF
+  vs a missing `<` redirect in the mspec invocation) before any code
+  change.

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -589,12 +589,6 @@ class Fiber
   end
 end
 
-class Signal
-  def self.trap(signal, command = nil, &block)
-    # No-op for now.
-  end
-end
-
 class Thread
   # monoruby is single-threaded. Thread.new does NOT execute blocks
   # concurrently. Only Thread.current (the main thread) is meaningful.

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -137,6 +137,14 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_module_func_rest(kernel_class, "spawn", spawn);
     globals.define_builtin_module_func(kernel_class, "`", command, 1);
     globals.define_builtin_module_func(kernel_class, "fork", fork, 0);
+    globals.define_builtin_module_func_with(
+        kernel_class,
+        "trap",
+        crate::builtins::process::signal_trap,
+        1,
+        2,
+        false,
+    );
     globals.define_builtin_module_func_with(kernel_class, "sleep", sleep, 0, 1, false);
     globals.define_builtin_module_func_with(kernel_class, "abort", abort, 0, 1, false);
     globals.define_builtin_module_func_with(kernel_class, "exit", exit, 0, 1, false);

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1,6 +1,7 @@
 use num::ToPrimitive;
 
 use super::*;
+use crate::codegen::signal_table;
 
 use self::clock_gettime::TimeSpec;
 
@@ -99,6 +100,7 @@ pub(super) fn init(globals: &mut Globals) {
     let signal = globals.define_toplevel_module("Signal").id();
     globals.define_builtin_module_func(signal, "list", signal_list, 0);
     globals.define_builtin_module_func(signal, "signame", signal_signame, 1);
+    globals.define_builtin_module_func_with(signal, "trap", signal_trap, 1, 2, false);
 }
 
 ///
@@ -881,6 +883,149 @@ fn signal_signame(
     })
 }
 
+/// Parse a `Signal.trap` signal argument into a signo. Mirrors CRuby:
+/// an Integer must be a valid signal number; a String or `#to_str`-able
+/// object names a signal (with/without "SIG"); a Symbol names a signal;
+/// anything else is `ArgumentError: bad signal type <Class>`. `#to_int`
+/// is deliberately never called.
+fn trap_signo(vm: &mut Executor, globals: &mut Globals, arg: Value) -> Result<i32> {
+    if let Some(i) = arg.try_fixnum() {
+        let signo = i as i32;
+        if signal_number_to_name(i).is_none() {
+            return Err(MonorubyErr::argumenterr(format!(
+                "invalid signal number ({i})"
+            )));
+        }
+        return Ok(signo);
+    }
+    let name = if let Some(sym) = arg.try_symbol() {
+        sym.get_name().to_string()
+    } else if let Some(s) = arg.is_str() {
+        s.to_string()
+    } else if globals.store.check_method(arg, IdentId::TO_STR).is_some() {
+        arg.coerce_to_str(vm, globals)?
+    } else {
+        return Err(MonorubyErr::argumenterr(format!(
+            "bad signal type {}",
+            arg.get_real_class_name(&globals.store)
+        )));
+    };
+    signal_name_to_number(&name).ok_or_else(|| {
+        MonorubyErr::argumenterr(format!(
+            "unsupported signal 'SIG{}'",
+            name.trim_start_matches("SIG")
+        ))
+    })
+}
+
+/// Map a `command` argument to a trap disposition. Mirrors CRuby's
+/// `trap_handler`: `nil` and "IGNORE"/"SIG_IGN"/"" set `SIG_IGN`;
+/// "DEFAULT"/"SIG_DFL" restore monoruby's default; "SYSTEM_DEFAULT"
+/// forces the OS default; any other object is taken as a callable handler
+/// (its `#call` is invoked at delivery — non-callables raise then).
+fn command_disposition(cmd: Value) -> Result<signal_table::SignalDisposition> {
+    use signal_table::SignalDisposition;
+    if cmd.is_nil() {
+        return Ok(SignalDisposition::Ignore { from_nil: true });
+    }
+    let name = if let Some(s) = cmd.is_str() {
+        Some(s.to_string())
+    } else {
+        cmd.try_symbol().map(|sym| sym.get_name().to_string())
+    };
+    match name.as_deref() {
+        Some("" | "SIG_IGN" | "IGNORE") => Ok(SignalDisposition::Ignore { from_nil: false }),
+        Some("SIG_DFL" | "DEFAULT") => Ok(SignalDisposition::Default),
+        Some("SYSTEM_DEFAULT") => Ok(SignalDisposition::SystemDefault),
+        Some(other) => Err(MonorubyErr::argumenterr(format!("unsupported command `{other}'"))),
+        // Not a String/Symbol command: treat as a callable handler.
+        None => Ok(SignalDisposition::Handler(cmd)),
+    }
+}
+
+/// The Ruby-visible value `Signal.trap` returns for the *previous*
+/// disposition.
+fn disposition_to_value(disp: signal_table::SignalDisposition) -> Value {
+    use signal_table::SignalDisposition;
+    match disp {
+        SignalDisposition::Default => Value::string_from_str("DEFAULT"),
+        SignalDisposition::SystemDefault => Value::string_from_str("SYSTEM_DEFAULT"),
+        SignalDisposition::Ignore { from_nil: true } => Value::nil(),
+        SignalDisposition::Ignore { from_nil: false } => Value::string_from_str("IGNORE"),
+        SignalDisposition::Handler(v) => v,
+    }
+}
+
+///
+/// ### Signal.trap
+///
+/// - trap(signal, command) -> object
+/// - trap(signal) { ... } -> object
+///
+/// Install a handler for `signal` (Integer, Symbol or String). `command`
+/// may be any callable (`Proc`, `Method`, …), or one of "DEFAULT"/
+/// "SIG_DFL", "IGNORE"/"SIG_IGN"/"" (or nil), or "SYSTEM_DEFAULT". A
+/// block, if given, is the handler. Returns the previous handler.
+///
+/// The handler does not run in async-signal context: the asm stub only
+/// records the pending signal, and `#call` is invoked at the next
+/// interpreter poll point. See doc/signal_handling.md A7.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Signal/m/trap.html]
+#[monoruby_builtin]
+pub(super) fn signal_trap(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let signo = trap_signo(vm, globals, lfp.arg(0))?;
+    if signal_table::is_uncatchable(signo) {
+        // KILL / STOP: the kernel forbids catching these.
+        return Err(MonorubyErr::argumenterr("Signal already used by VM or OS"));
+    }
+    if !signal_table::is_trappable(signo) {
+        // Ruby-reserved (SEGV/BUS/ILL/FPE/VTALRM, …) and the EXIT
+        // pseudo-signal land here.
+        let name = signal_number_to_name(signo as i64).unwrap_or("");
+        return Err(MonorubyErr::argumenterr(format!(
+            "can't trap reserved signal: SIG{name}"
+        )));
+    }
+
+    use signal_table::SignalDisposition;
+    // An explicit command argument takes precedence over a block.
+    let new_disp = if let Some(cmd) = lfp.try_arg(1) {
+        command_disposition(cmd)?
+    } else if let Some(bh) = lfp.block() {
+        SignalDisposition::Handler(vm.generate_proc(globals, bh, pc)?.into())
+    } else {
+        return Err(MonorubyErr::argumenterr(
+            "tried to create Proc object without a block",
+        ));
+    };
+
+    // Apply the OS-level disposition before recording it; if the syscall
+    // fails the table is left untouched. The stub for `signo` was
+    // pre-generated at Codegen::new, so this is just a sigaction(2).
+    let installed = crate::codegen::CODEGEN.with(|codegen| {
+        let codegen = codegen.borrow();
+        match new_disp {
+            SignalDisposition::Handler(_) => codegen.install_signal_stub(signo),
+            SignalDisposition::Ignore { .. } => codegen.install_signal_ignore(signo),
+            SignalDisposition::Default => codegen.install_signal_default(signo),
+            SignalDisposition::SystemDefault => codegen.install_signal_system_default(signo),
+        }
+    });
+    if !installed {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "sigaction"));
+    }
+
+    let prev = globals.set_signal_disposition(signo, new_disp);
+    Ok(disposition_to_value(prev))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
@@ -967,6 +1112,57 @@ mod tests {
             [h.is_a?(Hash), h["INT"], h["KILL"], h["EXIT"]]
             "#,
         );
+    }
+
+    #[test]
+    fn signal_trap_return_values() {
+        // First trap returns the previous handler "DEFAULT"; re-trapping
+        // returns the previously installed Proc; setting then reading a
+        // string command round-trips ("IGNORE"). USR2 is reset to
+        // DEFAULT first so each warm-up iteration starts identically.
+        run_test(
+            r#"
+            Signal.trap("USR2", "DEFAULT")
+            a = Signal.trap("USR2") { }
+            b = Signal.trap("USR2", "IGNORE")
+            c = Signal.trap("USR2", "DEFAULT")
+            [a, b.is_a?(Proc), c]
+            "#,
+        );
+    }
+
+    #[test]
+    fn signal_trap_return_values_commands() {
+        // nil command reports the previous handler as nil; an explicit
+        // callable is returned by identity; "SYSTEM_DEFAULT" round-trips
+        // distinctly from "DEFAULT".
+        run_test(
+            r#"
+            Signal.trap("USR2", "DEFAULT")
+            h = ->{}
+            a = Signal.trap("USR2", h)
+            b = Signal.trap("USR2", nil)
+            c = Signal.trap("USR2", "SYSTEM_DEFAULT")
+            d = Signal.trap("USR2", "DEFAULT")
+            [a, b.equal?(h), c, d]
+            "#,
+        );
+    }
+
+    // Signal *delivery* (self-kill → handler runs) is covered by the
+    // subprocess-isolated integration tests in tests/signal_trap.rs:
+    // sending a process-wide signal is unsafe under cargo's parallel
+    // in-process test threads.
+
+    #[test]
+    fn signal_trap_unsupported_signal() {
+        run_test_error(r#"Signal.trap("NO_SUCH_SIGNAL") { }"#);
+    }
+
+    #[test]
+    fn signal_trap_reserved_signal() {
+        // SIGKILL / SIGSTOP cannot be trapped.
+        run_test_error("Signal.trap(:KILL) { }");
     }
 
     #[test]

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -796,6 +796,11 @@ struct CompilationUnitInfo {
 ///
 pub struct Codegen {
     pub(crate) jit: JitModule,
+    /// Pre-generated async-signal-safe asm stub for every signal in
+    /// `signal_table::TRAPPABLE_SIGNALS`, keyed by signo. Generated once
+    /// at `Codegen::new`; `Signal.trap` looks up the stub here and
+    /// `sigaction(2)`s it at trap time. See doc/signal_handling.md A7.
+    signal_stubs: HashMap<i32, CodePtr>,
     class_version_addr: *mut u32,
     const_version_addr: *mut u64,
 
@@ -888,6 +893,7 @@ impl Codegen {
 
         let mut codegen = Self {
             jit,
+            signal_stubs: HashMap::default(),
             class_version_addr,
             const_version_addr,
             compilation_unit: Vec::new(),
@@ -916,27 +922,25 @@ impl Codegen {
             jit_compile_time: std::time::Duration::default(),
         };
         codegen.construct_vm();
-        // Emit one stub per signal we want to surface as a Ruby
-        // exception. SIGSEGV/SIGBUS/SIGFPE/SIGILL/SIGABRT are deliberately
-        // not handled — those are genuine programming errors and should
-        // be left to the kernel's default core-dump path.
-        // See doc/signal_handling.md.
-        let signal_stubs: Vec<(i32, CodePtr)> = signal_table::POSIX_SIGNALS
-            .iter()
-            .map(|&signo| (signo, codegen.signal_handler_for(signo)))
-            .collect();
+        // Pre-generate an async-signal-safe stub for every signal we
+        // permit trapping (signal_table::TRAPPABLE_SIGNALS). Doing it all
+        // up front means `Signal.trap` only has to sigaction(2) at trap
+        // time — no JIT codegen on a live buffer. SIGSEGV/SIGBUS/SIGFPE/
+        // SIGILL/SIGABRT are deliberately absent: those are genuine
+        // programming errors and are left to the kernel's core-dump path.
+        // See doc/signal_handling.md A2/A7.
+        for &signo in signal_table::TRAPPABLE_SIGNALS {
+            let codeptr = codegen.signal_handler_for(signo);
+            codegen.signal_stubs.insert(signo, codeptr);
+        }
         codegen.jit.finalize();
 
-        unsafe {
-            use libc::{SA_RESTART, sighandler_t};
-            for &(signo, codeptr) in &signal_stubs {
-                let mut sa: libc::sigaction = std::mem::zeroed();
-                sa.sa_sigaction = codeptr.as_ptr() as sighandler_t;
-                sa.sa_flags = SA_RESTART;
-                libc::sigemptyset(&mut sa.sa_mask);
-                if libc::sigaction(signo, &sa, std::ptr::null_mut()) != 0 {
-                    panic!("Failed to set signal handler for signo {signo}");
-                }
+        // Only the default-install set (POSIX_SIGNALS, i.e. SIGINT) is
+        // armed now. The rest stay at their OS default until a user
+        // `Signal.trap` wires the pre-generated stub in. See A3.
+        for &signo in signal_table::POSIX_SIGNALS {
+            if !codegen.install_signal_stub(signo) {
+                panic!("Failed to set signal handler for signo {signo}");
             }
         }
 
@@ -1010,6 +1014,63 @@ impl Codegen {
     pub(crate) fn signal_handler_for(&mut self, signo: i32) -> CodePtr {
         self.jit
             .signal_handler_for(self.alloc_flag.clone(), self.pending_signals.clone(), signo)
+    }
+
+    /// `sigaction(2)` `signo` to `handler` with `flags`. Returns true on
+    /// success. The handler must be either one of the libc `SIG_*`
+    /// sentinels or a pointer to a stub from `signal_stubs`.
+    unsafe fn sigaction_to(signo: i32, handler: libc::sighandler_t, flags: i32) -> bool {
+        // SAFETY: caller passes a valid signo and a handler that is
+        // either a libc sentinel or a stable code pointer into the JIT
+        // buffer (which lives for the process lifetime).
+        unsafe {
+            let mut sa: libc::sigaction = std::mem::zeroed();
+            sa.sa_sigaction = handler;
+            sa.sa_flags = flags;
+            libc::sigemptyset(&mut sa.sa_mask);
+            libc::sigaction(signo, &sa, std::ptr::null_mut()) == 0
+        }
+    }
+
+    /// Arm `signo` with its pre-generated async-signal-safe stub so the
+    /// next poll point observes the pending bit. Returns false if no
+    /// stub was generated for `signo` (i.e. it is not trappable) or the
+    /// syscall failed.
+    pub(crate) fn install_signal_stub(&self, signo: i32) -> bool {
+        let Some(codeptr) = self.signal_stubs.get(&signo) else {
+            return false;
+        };
+        // SAFETY: codeptr is a stable pointer into the finalized JIT
+        // buffer; SA_RESTART matches the startup install.
+        unsafe { Self::sigaction_to(signo, codeptr.as_ptr() as libc::sighandler_t, libc::SA_RESTART) }
+    }
+
+    /// Set `signo` to `SIG_IGN` (silently discard).
+    pub(crate) fn install_signal_ignore(&self, signo: i32) -> bool {
+        // SAFETY: SIG_IGN is a valid disposition for any catchable signal.
+        unsafe { Self::sigaction_to(signo, libc::SIG_IGN, 0) }
+    }
+
+    /// Restore `signo` to monoruby's default disposition: re-arm the stub
+    /// for default-installed signals (so SIGINT keeps raising `Interrupt`),
+    /// otherwise revert to the kernel `SIG_DFL`.
+    pub(crate) fn install_signal_default(&self, signo: i32) -> bool {
+        if signal_table::is_default_installed(signo) {
+            self.install_signal_stub(signo)
+        } else {
+            // SAFETY: SIG_DFL is always a valid disposition.
+            unsafe { Self::sigaction_to(signo, libc::SIG_DFL, 0) }
+        }
+    }
+
+    /// Set `signo` to the OS default disposition (`SIG_DFL`)
+    /// unconditionally — the `"SYSTEM_DEFAULT"` trap command. Unlike
+    /// `install_signal_default`, this does *not* re-arm monoruby's stub
+    /// for the default-installed set: the caller explicitly wants the
+    /// kernel's behaviour.
+    pub(crate) fn install_signal_system_default(&self, signo: i32) -> bool {
+        // SAFETY: SIG_DFL is always a valid disposition.
+        unsafe { Self::sigaction_to(signo, libc::SIG_DFL, 0) }
     }
 
     pub(crate) fn entry_raise(&self) -> DestLabel {

--- a/monoruby/src/codegen/signal_table.rs
+++ b/monoruby/src/codegen/signal_table.rs
@@ -11,7 +11,7 @@
 //! These are genuine runtime bugs (or explicit `abort`s); the kernel's
 //! default core-dump path is the right response, not a Ruby `rescue`.
 
-use crate::MonorubyErr;
+use crate::{MonorubyErr, Value};
 
 /// List of POSIX signals monoruby installs an async-signal handler
 /// for *by default*. Only SIGINT is here: every other signal's CRuby
@@ -25,6 +25,94 @@ use crate::MonorubyErr;
 ///
 /// Order is delivery priority — lowest signo bit is consumed first.
 pub(crate) const POSIX_SIGNALS: &[i32] = &[libc::SIGINT];
+
+/// Signals `Signal.trap` is allowed to install a handler for. An
+/// async-signal-safe asm stub is pre-generated for each of these at
+/// `Codegen::new` time (see codegen.rs), so trapping at runtime only
+/// has to `sigaction(2)` the existing stub — no JIT codegen on a live
+/// buffer.
+///
+/// Deliberately excluded:
+/// - SIGKILL / SIGSTOP — uncatchable by the kernel.
+/// - SIGILL / SIGTRAP / SIGABRT / SIGBUS / SIGFPE / SIGSEGV — genuine
+///   faults; the kernel core-dump path is the right response (see the
+///   module header). CRuby also forbids trapping most of these.
+/// Deliberately excluded:
+/// - SIGKILL / SIGSTOP — uncatchable by the kernel (see `is_uncatchable`).
+/// - SIGILL / SIGTRAP / SIGABRT / SIGBUS / SIGFPE / SIGSEGV — genuine
+///   faults; the kernel core-dump path is the right response. CRuby also
+///   forbids trapping SEGV/BUS/FPE/ILL (and SIGVTALRM, which it uses
+///   internally) with `ArgumentError: can't trap reserved signal`.
+pub(crate) const TRAPPABLE_SIGNALS: &[i32] = &[
+    libc::SIGHUP,
+    libc::SIGINT,
+    libc::SIGQUIT,
+    libc::SIGUSR1,
+    libc::SIGUSR2,
+    libc::SIGPIPE,
+    libc::SIGALRM,
+    libc::SIGTERM,
+    libc::SIGCHLD,
+    libc::SIGCONT,
+    libc::SIGTSTP,
+    libc::SIGTTIN,
+    libc::SIGTTOU,
+    libc::SIGURG,
+    libc::SIGXCPU,
+    libc::SIGXFSZ,
+    libc::SIGPROF,
+    libc::SIGWINCH,
+    libc::SIGIO,
+    libc::SIGPWR,
+    libc::SIGSYS,
+];
+
+/// Whether `signo` may be trapped via `Signal.trap` / `Kernel#trap`.
+pub(crate) fn is_trappable(signo: i32) -> bool {
+    TRAPPABLE_SIGNALS.contains(&signo)
+}
+
+/// Signals the kernel does not allow catching at all. CRuby surfaces a
+/// trap attempt on these as `Errno::EINVAL` ("Invalid argument") or an
+/// `ArgumentError` ("Signal already used by VM or OS"); we use the
+/// latter.
+pub(crate) fn is_uncatchable(signo: i32) -> bool {
+    signo == libc::SIGKILL || signo == libc::SIGSTOP
+}
+
+/// Whether `signo` is part of the default-install set (its async stub is
+/// `sigaction`'d at startup). On `Signal.trap(sig, "DEFAULT")` such a
+/// signal keeps monoruby's runtime default (e.g. SIGINT ⇒ raise
+/// `Interrupt`) rather than reverting to the kernel's `SIG_DFL`.
+pub(crate) fn is_default_installed(signo: i32) -> bool {
+    POSIX_SIGNALS.contains(&signo)
+}
+
+/// What should happen when a trapped signal is observed at the next
+/// poll point, and what the *next* `Signal.trap` reports as the previous
+/// handler. Stored per-signo in `Globals` (see globals.rs) and set by
+/// `Signal.trap`.
+#[derive(Clone, Copy)]
+pub(crate) enum SignalDisposition {
+    /// monoruby's runtime default: lower to the `signo_to_error`
+    /// exception for default-installed signals (SIGINT ⇒ Interrupt),
+    /// otherwise the OS `SIG_DFL` applies and the bit is never set.
+    /// Reported back to Ruby as `"DEFAULT"`.
+    Default,
+    /// The OS default disposition (`SIG_DFL`). Reported as
+    /// `"SYSTEM_DEFAULT"`. This is the initial state of every signal
+    /// except the default-installed set.
+    SystemDefault,
+    /// Swallow the signal (`SIG_IGN` at the OS level, so the pending bit
+    /// is normally never set — the poll arm is a defensive drop).
+    /// `from_nil` records whether it was requested via `nil` (reported
+    /// back as `nil`) or via "IGNORE"/"SIG_IGN" (reported as `"IGNORE"`).
+    Ignore { from_nil: bool },
+    /// Invoke this Ruby object (passed the signo) via `#call` at the poll
+    /// point. May be a `Proc`, `Method`, or any callable — non-callables
+    /// raise `NoMethodError` at delivery, matching CRuby.
+    Handler(Value),
+}
 
 /// Convert a pending signo into the Ruby error the poll point should
 /// raise. Returns `None` for signals we do not handle (defensive: the
@@ -44,14 +132,17 @@ pub(crate) fn signo_to_error(signo: i32) -> Option<MonorubyErr> {
     Some(err)
 }
 
-/// Drain the pending-signal bitmap into the first Ruby error to raise.
-/// Lowest-numbered pending signal wins.
-pub(crate) fn lowest_pending_to_error(bitmap: u32) -> Option<MonorubyErr> {
+/// The lowest-numbered pending signo in `bitmap`, or `None` if no bits
+/// are set. Bit `n` corresponds to signo `n + 1` (so SIGINT = 2 ⇒ bit
+/// 1). Lowest-numbered wins, matching A6 delivery priority. The poll
+/// point looks the signo up in the per-signal trap table before deciding
+/// whether to run a handler, ignore it, or fall back to `signo_to_error`.
+pub(crate) fn lowest_pending_signo(bitmap: u32) -> Option<i32> {
     if bitmap == 0 {
-        return None;
+        None
+    } else {
+        Some(bitmap.trailing_zeros() as i32 + 1)
     }
-    let signo = bitmap.trailing_zeros() as i32 + 1;
-    signo_to_error(signo)
 }
 
 #[cfg(test)]
@@ -103,18 +194,21 @@ mod tests {
         assert!(signo_to_error(libc::SIGCHLD).is_none());
     }
 
-    /// An empty bitmap drains to nothing.
+    /// An empty bitmap drains to no signo.
     #[test]
     fn empty_bitmap_is_none() {
-        assert!(lowest_pending_to_error(0).is_none());
+        assert!(lowest_pending_signo(0).is_none());
     }
 
-    /// A single pending bit lowers to the matching error. Bit `n`
-    /// corresponds to signo `n + 1`, so SIGINT (signo 2) is bit 1.
+    /// A single pending bit drains to its signo, which maps to the
+    /// matching error. Bit `n` corresponds to signo `n + 1`, so SIGINT
+    /// (signo 2) is bit 1.
     #[test]
     fn single_pending_bit_drains() {
         let bit = 1u32 << (libc::SIGINT - 1) as u32;
-        let err = lowest_pending_to_error(bit).expect("SIGINT bit must drain");
+        let signo = lowest_pending_signo(bit).expect("SIGINT bit must drain");
+        assert_eq!(signo, libc::SIGINT);
+        let err = signo_to_error(signo).expect("SIGINT must map");
         assert_eq!(err.kind(), &MonorubyErrKind::Other(INTERRUPT_CLASS));
     }
 
@@ -123,20 +217,18 @@ mod tests {
     #[test]
     fn lowest_signo_wins() {
         let bitmap = (1u32 << (libc::SIGINT - 1) as u32) | (1u32 << (libc::SIGTERM - 1) as u32);
-        let err = lowest_pending_to_error(bitmap).expect("must drain");
-        assert_eq!(
-            err.kind(),
-            &MonorubyErrKind::Other(INTERRUPT_CLASS),
-            "SIGINT must win over SIGTERM"
-        );
+        let signo = lowest_pending_signo(bitmap).expect("must drain");
+        assert_eq!(signo, libc::SIGINT, "SIGINT must win over SIGTERM");
     }
 
     /// A pending bit for an unmapped signo (SIGTRAP, signo 5) drains to
-    /// `None` rather than panicking — exercises the `signo_to_error`
-    /// `None` passthrough inside `lowest_pending_to_error`.
+    /// its signo but `signo_to_error` returns `None` — the poll point
+    /// then drops it (Default disposition, no mapping).
     #[test]
     fn pending_unmapped_bit_is_none() {
         let bit = 1u32 << (libc::SIGTRAP - 1) as u32;
-        assert!(lowest_pending_to_error(bit).is_none());
+        let signo = lowest_pending_signo(bit).expect("bit must drain to a signo");
+        assert_eq!(signo, libc::SIGTRAP);
+        assert!(signo_to_error(signo).is_none());
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2679,22 +2679,43 @@ pub(crate) extern "C" fn execute_gc(
     // hang watchdog's countdown (no-op unless armed). See
     // doc/signal_handling.md B+.
     crate::watchdog::poll();
-    CODEGEN.with(|codegen| {
-        let codegen = codegen.borrow_mut();
-        // Drain the pending-signal bitmap. The lowest-numbered pending
-        // signal is consumed and lowered to a Ruby exception; any
-        // others observed in the same drain are dropped on the floor
-        // (signo collisions in a single poll window are extremely
-        // unlikely in practice and CRuby itself does not guarantee
-        // delivery of every signal). See doc/signal_handling.md.
-        let pending = codegen.take_pending_signals();
-        if let Some(err) = crate::codegen::signal_table::lowest_pending_to_error(pending) {
-            executor.set_error(err);
-            None
-        } else {
-            Some(())
+    // Drain the pending-signal bitmap. The lowest-numbered pending signal
+    // is consumed; any others observed in the same drain are dropped on
+    // the floor (signo collisions in a single poll window are extremely
+    // unlikely, and CRuby itself does not guarantee delivery of every
+    // coalesced signal). The CODEGEN borrow is released before
+    // dispatching so a trap handler (which JIT-compiles, GCs, …) can
+    // re-enter freely. See doc/signal_handling.md A6/A7.
+    let pending = CODEGEN.with(|codegen| codegen.borrow().take_pending_signals());
+    if let Some(signo) = crate::codegen::signal_table::lowest_pending_signo(pending) {
+        use crate::codegen::signal_table::{self, SignalDisposition};
+        match globals.signal_disposition(signo) {
+            // A user `Signal.trap` handler: invoke its `#call` at this
+            // safepoint, passing the signo. The handler (Proc / Method /
+            // any callable) stays a GC root via the trap table; a
+            // non-callable raises NoMethodError here, matching CRuby.
+            SignalDisposition::Handler(handler) => {
+                let arg = Value::integer(signo as i64);
+                let call = IdentId::get_id("call");
+                if let Err(err) =
+                    executor.invoke_method_inner(globals, call, handler, &[arg], None, None)
+                {
+                    executor.set_error(err);
+                    return None;
+                }
+            }
+            // Defensive: a SIG_IGN'd signal normally never sets its bit.
+            SignalDisposition::Ignore { .. } => {}
+            // No user handler: lower to the default exception (e.g.
+            // SIGINT ⇒ Interrupt). Unmapped signals drain to nothing.
+            SignalDisposition::Default | SignalDisposition::SystemDefault => {
+                if let Some(err) = signal_table::signo_to_error(signo) {
+                    executor.set_error(err);
+                    return None;
+                }
+            }
         }
-    })?;
+    }
     // Get root Executor.
     while let Some(mut parent) = executor.parent_fiber {
         // SAFETY: parent_fiber is guaranteed to be a valid pointer to an Executor

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -125,6 +125,12 @@ pub struct Globals {
     /// block, so it reads the real arity from here instead. A stack
     /// supports nested enumerators.
     pub(crate) enum_block_arity: Vec<i64>,
+    /// Per-signal trap disposition, indexed by signo (1..=32; index 0 is
+    /// unused). Written by `Signal.trap` / `Kernel#trap` and consulted
+    /// at the poll point (`execute_gc`) to decide whether a pending
+    /// signal runs a Ruby `Proc`, is ignored, or lowers to the default
+    /// exception. See doc/signal_handling.md A7.
+    pub(crate) signal_handlers: Vec<crate::codegen::signal_table::SignalDisposition>,
     /// stats for deoptimization
     #[cfg(feature = "profile")]
     deopt_stats: HashMap<(FuncId, bytecodegen::BcIndex), usize>,
@@ -157,6 +163,13 @@ impl alloc::GC<RValue> for Globals {
         self.store.mark(alloc);
         self.gvars.mark_values(|v| v.mark(alloc));
         self.symbol_names.values().for_each(|v| v.mark(alloc));
+        // Trap handler Procs are GC roots: they are reachable only from
+        // this table, yet may be invoked at any future poll point.
+        for disp in &self.signal_handlers {
+            if let crate::codegen::signal_table::SignalDisposition::Handler(v) = disp {
+                v.mark(alloc);
+            }
+        }
     }
 }
 
@@ -175,6 +188,28 @@ impl Globals {
 
     pub(crate) fn current_enum_block_arity(&self) -> Option<i64> {
         self.enum_block_arity.last().copied()
+    }
+
+    /// The current trap disposition for `signo`. Out-of-range signos
+    /// (defensive) report `Default`.
+    pub(crate) fn signal_disposition(
+        &self,
+        signo: i32,
+    ) -> crate::codegen::signal_table::SignalDisposition {
+        self.signal_handlers
+            .get(signo as usize)
+            .copied()
+            .unwrap_or(crate::codegen::signal_table::SignalDisposition::Default)
+    }
+
+    /// Install a new trap disposition for `signo`, returning the previous
+    /// one. Caller is responsible for the matching `sigaction(2)` change.
+    pub(crate) fn set_signal_disposition(
+        &mut self,
+        signo: i32,
+        disp: crate::codegen::signal_table::SignalDisposition,
+    ) -> crate::codegen::signal_table::SignalDisposition {
+        std::mem::replace(&mut self.signal_handlers[signo as usize], disp)
     }
 }
 
@@ -303,6 +338,18 @@ impl Globals {
             random: Box::new(Prng::new()),
             loaded_features,
             symbol_names: HashMap::default(),
+            // signo runs 1..=32; index by signo directly (slot 0 unused).
+            // Every signal starts at the OS default ("SYSTEM_DEFAULT"),
+            // except the default-installed set (SIGINT), whose runtime
+            // default is "DEFAULT" (raise Interrupt). See A7.
+            signal_handlers: {
+                use crate::codegen::signal_table::{self, SignalDisposition};
+                let mut v = vec![SignalDisposition::SystemDefault; 33];
+                for &signo in signal_table::POSIX_SIGNALS {
+                    v[signo as usize] = SignalDisposition::Default;
+                }
+                v
+            },
             invokers,
             enum_block_arity: Vec::new(),
             #[cfg(feature = "profile")]

--- a/monoruby/tests/signal_trap.rs
+++ b/monoruby/tests/signal_trap.rs
@@ -1,0 +1,179 @@
+//! Integration coverage for `Signal.trap` / `Kernel#trap`
+//! (doc/signal_handling.md A7).
+//!
+//! These exercise actual signal *delivery*: a script traps a signal,
+//! `Process.kill`s its own pid, and the handler runs at the next poll
+//! point. Sending a process-wide signal is unsafe under cargo's parallel
+//! in-process test threads (a stray delivery could hit a thread whose
+//! disposition for that signal is still the default), so — like the
+//! watchdog tests — they spawn the real binary for full isolation.
+
+use std::os::unix::process::ExitStatusExt;
+use std::process::Command;
+
+fn monoruby() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+}
+
+/// A trapped, self-delivered SIGUSR1 runs the Ruby handler at the next
+/// poll point. The allocation loop guarantees the GC poll fires.
+#[test]
+fn trap_handler_runs_on_self_signal() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"$ran = false
+               Signal.trap("USR1") { $ran = true }
+               Process.kill("USR1", Process.pid)
+               10000.times { Object.new }
+               puts $ran"#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected clean exit, got {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "true");
+}
+
+/// The handler is passed the signal number (SIGUSR1 == 10 on Linux).
+#[test]
+fn trap_handler_receives_signo() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"Signal.trap("USR1") { |signo| puts signo }
+               Process.kill("USR1", Process.pid)
+               10000.times { Object.new }"#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(output.status.success(), "status: {:?}", output.status);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "10" // SIGUSR1 on x86-64 Linux
+    );
+}
+
+/// "IGNORE" installs SIG_IGN: the self-delivered signal neither runs a
+/// handler nor terminates the process.
+#[test]
+fn trap_ignore_swallows_signal() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"trap("USR1", "IGNORE")
+               Process.kill("USR1", Process.pid)
+               10000.times { Object.new }
+               puts "alive""#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(output.status.success(), "status: {:?}", output.status);
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "alive");
+}
+
+/// Restoring "DEFAULT" on a non-default-installed signal reverts the OS
+/// disposition to SIG_DFL, so a subsequent SIGUSR1 terminates the
+/// process (the kernel default for SIGUSR1) instead of running anything.
+#[test]
+fn trap_default_restores_termination() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"Signal.trap("USR1") { }
+               Signal.trap("USR1", "DEFAULT")
+               Process.kill("USR1", Process.pid)
+               puts "alive""#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(
+        !output.status.success(),
+        "expected termination by SIGUSR1, got success"
+    );
+    assert_eq!(
+        output.status.signal(),
+        Some(10), // SIGUSR1 on x86-64 Linux
+        "expected death by SIGUSR1, status: {:?}",
+        output.status
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+}
+
+/// A handler may be any callable, not just a `Proc`: a `Method` object
+/// is accepted and `#call`'d (with the signo) at delivery.
+#[test]
+fn trap_method_handler_runs() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"$got = nil
+               def handler(signo); $got = signo; end
+               Signal.trap("USR1", method(:handler))
+               Process.kill("USR1", Process.pid)
+               10000.times { Object.new }
+               puts $got"#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(output.status.success(), "status: {:?}", output.status);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "10" // SIGUSR1 on x86-64 Linux
+    );
+}
+
+/// A non-callable handler raises `NoMethodError` at the point of
+/// delivery (when the runtime tries `handler.call(signo)`), matching
+/// CRuby — not at trap-registration time.
+#[test]
+fn trap_non_callable_raises_at_delivery() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"Signal.trap("USR1", Object.new)
+               Process.kill("USR1", Process.pid)
+               begin
+                 10000.times { Object.new }
+                 puts "no error"
+               rescue NoMethodError
+                 puts "nomethod"
+               end"#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(output.status.success(), "status: {:?}", output.status);
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "nomethod");
+}
+
+/// SIGINT delivered to a `rescue Interrupt` block lowers to a real
+/// `Interrupt` (the runtime default, unchanged by this work).
+#[test]
+fn sigint_default_raises_interrupt() {
+    let output = monoruby()
+        .args([
+            "-e",
+            r#"begin
+                 Process.kill("INT", Process.pid)
+                 10000.times { Object.new }
+                 puts "no interrupt"
+               rescue Interrupt
+                 puts "interrupt"
+               end"#,
+        ])
+        .output()
+        .expect("failed to spawn monoruby");
+
+    assert!(output.status.success(), "status: {:?}", output.status);
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "interrupt");
+}


### PR DESCRIPTION
## Summary

Implements **A7** from `doc/signal_handling.md`: a real `Signal.trap` /
`Kernel#trap`, built on the existing pending-signal bitmap + GC-poll
pipeline. Previously `Signal.trap` was a no-op Ruby stub in `startup.rb`.

`ruby/spec core/signal`: **35 → 47 / 52** (`list` 4/4, `signame` 6/6,
`trap` 25 → 37/42).

## What's in it

- **Per-signo disposition table** in `Globals`
  (`Default` / `SystemDefault` / `Ignore{from_nil}` / `Handler`), with
  `Handler` objects marked as GC roots. Initial state: `DEFAULT` for
  `SIGINT`, `SYSTEM_DEFAULT` otherwise (matches CRuby).
- **Pre-generated async-signal-safe stubs** for every trappable signal at
  `Codegen::new`; `trap` only `sigaction(2)`s an existing stub — no JIT
  codegen on a live buffer. New `install_signal_{stub,ignore,default,system_default}`.
- **Poll-time dispatch** (`execute_gc`) invokes a handler via
  `#call(signo)`, so a `Proc`, `Method`, or any callable works; a
  non-callable raises `NoMethodError` at delivery, matching CRuby.
- **CRuby-compatible parsing & errors:** `bad signal type <Class>`,
  `invalid signal number (N)`, `unsupported signal 'SIG…'`,
  reserved-signal split (`KILL`/`STOP` → "Signal already used by VM or
  OS" vs `SEGV`/`BUS`/`ILL`/`FPE`/`VTALRM` → "can't trap reserved
  signal"), and `DEFAULT` / `SYSTEM_DEFAULT` / `IGNORE` / `nil` return
  values.
- Rewrites `doc/signal_handling.md` into a **current implementation +
  future plans** structure.

## Remaining `core/signal` gaps (out of scope, see doc)

`:EXIT` pseudo-signal (at-exit), running a `Thread` from a handler
(single-threaded runtime), and `SIGPIPE`'s special ignore-by-default
disposition.

## Tests

- `process.rs` unit tests — registration / return values / errors.
- Subprocess-isolated `tests/signal_trap.rs` — delivery (Proc/Method/
  callable handlers, non-callable `NoMethodError`, signo arg, IGNORE
  swallows, DEFAULT re-terminates, SIGINT ⇒ Interrupt). Delivery can't be
  tested in-process: a process-wide signal is unsafe under cargo's
  parallel test threads.
- Full `cargo test --lib` suite green (1642 passing); no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)