### PR TITLE
aarch64 JIT: support Float four-arithmetic compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#a5c4c398c210607fc4cd9cf944371114e84eda70"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#19108d9059e799005c1e5ab9e269dfcc8fe8dead"
 dependencies = [
  "chrono",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#a5c4c398c210607fc4cd9cf944371114e84eda70"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#19108d9059e799005c1e5ab9e269dfcc8fe8dead"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1748,7 +1748,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2023,7 +2023,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/monoruby/src/codegen/arch/aarch64/codegen.rs
+++ b/monoruby/src/codegen/arch/aarch64/codegen.rs
@@ -90,6 +90,67 @@ impl Codegen {
         );
     }
 
+    /// `f64_to_val`: convert the f64 in `D0` to a boxed `Value` in `X0` —
+    /// flonum-encode when the exponent is in range, else heap-allocate a
+    /// `Float`. Mirrors x86 `gen_f64_to_val`. Called via `bl` from `FprToStack`.
+    ///
+    /// `and`/`orr` have no immediate form and there is no `ror` in the
+    /// `monoasm_arm64!` macro, so the bit-twiddling uses shift + register-logical
+    /// ops (rotate = `lsl`/`lsr`/`orr`; clear-low-2 = `lsr #2; lsl #2`).
+    pub(in crate::codegen) fn a64_gen_f64_to_val(&mut self, label: &DestLabel) {
+        let normal = self.jit.label();
+        let heap = self.jit.label();
+        self.jit.bind_label(label.clone());
+        monoasm_arm64!(&mut self.jit,
+            fcmp d0, #0.0;           // compare D0 with zero
+        );
+        self.jit.bcond_label(Cond::Ne, &normal); // != 0.0 (or NaN) -> normal
+        monoasm_arm64!(&mut self.jit,
+            mov x0, (FLOAT_ZERO);
+            ret;
+            normal:
+            fmov x0, d0;             // x0 = bits(d0)
+            lsr x1, x0, #(60);
+            add x1, x1, #(1);
+            mov x9, (6);
+            and x1, x1, x9;
+            cmp x1, #(4);
+        );
+        self.jit.bcond_label(Cond::Ne, &heap); // exponent out of flonum range -> heap
+        monoasm_arm64!(&mut self.jit,
+            // flonum-encode: rol 3, clear low 2 bits, set bit1 (0b10).
+            rol x0, x0, #(3);
+            lsr x0, x0, #(2);
+            lsl x0, x0, #(2);        // clear low 2 bits (and -4)
+            mov x9, (2);
+            orr x0, x0, x9;          // set 0b10
+            ret;
+            heap:
+            // Heap-allocate. Save the caller-saved FP pool (D2-D7); D8-D15 are
+            // AAPCS64 callee-saved and preserved by float_heap. D0 still holds
+            // the f64 argument that float_heap reads.
+            str x30, [sp, #(-16)]!;
+            sub sp, sp, #(48);
+            str d2, [sp];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            mov x9, (Value::float_heap as *const () as u64);
+            blr x9;                  // x0 = Value::float_heap(d0)
+            ldr d2, [sp];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            add sp, sp, #(48);
+            ldr x30, [sp], #(16);
+            ret;
+        );
+    }
+
     /// VM-side GC/signal poll. If `alloc_flag >= 8` (the signal handler nudges
     /// it by 10), call `exec_gc` which drains pending signals + runs GC. The
     /// hot path is two loads, a compare, and a fall-through branch.

--- a/monoruby/src/codegen/arch/aarch64/jit_module.rs
+++ b/monoruby/src/codegen/arch/aarch64/jit_module.rs
@@ -161,7 +161,10 @@ impl JitModule {
         // exec_gc is bound by `construct_vm` (real handler defers to
         // entry_raise on a poll-time error).
         let _ = gc;
-        j.a64_brk_stub_diag(&f64v, 0xffff04); // f64_to_val
+        // f64_to_val is bound later in `construct_vm` (a Codegen context):
+        // `a64_gen_f64_to_val` is an `impl Codegen` helper and nothing in `new`
+        // references the label yet, so leaving it unbound here is fine.
+        let _ = &f64v;
         // vm_stack_overflow is bound by `construct_vm` (the real handler
         // needs entry_raise, which isn't emitted until then).
         let _ = ovf;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1783,8 +1783,26 @@ impl Codegen {
         p
     }
 
+    /// Record the runtime operand classes into the BinOp inline cache so the
+    /// JIT can type the site (e.g. classify a Float `+`): `[PC+8]` = classid1,
+    /// `[PC+12]` = classid2. Mirrors x86 `vm_save_binary_class` (sans the
+    /// polymorphic-flag bookkeeping for now). Operands are the Values in X13
+    /// (lhs) / X14 (rhs); `get_class` reads X0 only, so X13/X14 survive.
+    pub(in crate::codegen) fn a64_save_binary_class(&mut self) {
+        let get_class = self.get_class.clone();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x13;
+            bl get_class;             // x0 = class(lhs)
+            str w0, [x(PC.0), #(8)];  // classid1
+            mov x0, x14;
+            bl get_class;             // x0 = class(rhs)
+            str w0, [x(PC.0), #(12)]; // classid2
+        );
+    }
+
     pub(in crate::codegen) fn a64_generic_binop(&mut self, func: BinaryOpFn) {
         let raise = self.entry_raise.clone();
+        self.a64_save_binary_class();
         monoasm_arm64!(&mut self.jit,
             mov x2, x13;  // lhs
             mov x3, x14;  // rhs

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -11,6 +11,9 @@ impl Codegen {
         self.a64_gen_entry_raise();
         self.a64_gen_stack_overflow();
         self.a64_gen_exec_gc();
+        // f64_to_val helper (D0 f64 -> X0 boxed Value), used by `FprToStack`.
+        let f64_to_val = self.f64_to_val.clone();
+        self.a64_gen_f64_to_val(&f64_to_val);
         let vm_entry = self.jit.label();
         let entry_fetch = self.jit.label();
         // vm_entry: establish the frame pointer (x86: `pushq rbp; movq rbp,rsp`).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -601,6 +601,23 @@ impl Codegen {
         }
     }
 
+    /// Physical D-register index for a pool-resident `FPReg`, or `None` (bail →
+    /// the method stays VM-interpreted) otherwise.
+    ///
+    /// Capped to the caller-saved D2-D7: under AAPCS64 D8-D15 are callee-saved
+    /// (unlike x86-64 SysV where every xmm is caller-saved), and the aarch64
+    /// invoker / JIT prologue does not yet preserve them. Restricting the JIT'd
+    /// FP pool to caller-saved registers keeps the ABI sound without that
+    /// prologue work; methods needing >6 live floats (or any spill) just don't
+    /// JIT yet. `f64_to_val`'s heap path and `XmmSave` are consistent with this
+    /// (they only ever touch D2-D7).
+    fn a64_fpr(&self, x: FPReg, base: usize) -> Option<u32> {
+        match x.loc(base) {
+            FPRegLoc::Xmm(p) if p <= 7 => Some(p as u32),
+            _ => None,
+        }
+    }
+
     /// Lower one `AsmInst`. Returns `false` for any not-yet-ported variant.
     pub(super) fn compile_asmir(
         &mut self,
@@ -1259,6 +1276,176 @@ impl Codegen {
                 self.a64_cmp_integer(&mode, lhs, rhs);
                 let cond = a64_cond_for_cmp(kind, brkind);
                 self.jit.bcond_label(cond, &branch_dest);
+                true
+            }
+            // ---- floating point (four-arithmetic) ----
+            // dst <- src
+            AsmInst::FprMove(src, dst) => {
+                let base = frame.base_stack_offset;
+                let (Some(s), Some(d)) =
+                    (self.a64_fpr(src, base), self.a64_fpr(dst, base))
+                else {
+                    return false;
+                };
+                if s != d {
+                    monoasm_arm64!(&mut self.jit, fmov d(d), d(s););
+                }
+                true
+            }
+            // swap two FP registers (via scratch D0)
+            AsmInst::FprSwap(l, r) => {
+                let base = frame.base_stack_offset;
+                let (Some(a), Some(b)) = (self.a64_fpr(l, base), self.a64_fpr(r, base))
+                else {
+                    return false;
+                };
+                if a != b {
+                    monoasm_arm64!(&mut self.jit,
+                        fmov d0, d(a);
+                        fmov d(a), d(b);
+                        fmov d(b), d0;
+                    );
+                }
+                true
+            }
+            // dst <- lhs <op> rhs  (D-register arithmetic)
+            AsmInst::FloatBinOp {
+                kind,
+                binary_xmm,
+                dst,
+            } => {
+                let base = frame.base_stack_offset;
+                let (l, r) = binary_xmm;
+                let (Some(ld), Some(rd), Some(dd)) = (
+                    self.a64_fpr(l, base),
+                    self.a64_fpr(r, base),
+                    self.a64_fpr(dst, base),
+                ) else {
+                    return false;
+                };
+                // aarch64 FP 3-op writes rd, reads rn/rm — no aliasing hazard.
+                match kind {
+                    BinOpK::Add => monoasm_arm64!(&mut self.jit, fadd d(dd), d(ld), d(rd);),
+                    BinOpK::Sub => monoasm_arm64!(&mut self.jit, fsub d(dd), d(ld), d(rd);),
+                    BinOpK::Mul => monoasm_arm64!(&mut self.jit, fmul d(dd), d(ld), d(rd);),
+                    BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
+                    _ => return false,
+                }
+                true
+            }
+            // dst <- f64 constant
+            AsmInst::F64ToFpr(f, x) => {
+                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
+                    return false;
+                };
+                let bits = f.to_bits();
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (bits);
+                    fmov d(p), x9;
+                );
+                true
+            }
+            // dst(f64) <- fixnum in `reg` (untag, signed int -> double)
+            AsmInst::FixnumToFpr(reg, x) => {
+                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
+                    return false;
+                };
+                let r = reg.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    asr x9, x(r), #(1);   // untag: value >> 1
+                    scvtf d(p), x9;
+                );
+                true
+            }
+            // dst(f64) <- Float Value in `reg`; deopt if `reg` is not a Float.
+            // Mirrors x86 float_to_f64 / float_val_to_f64 (flonum decode +
+            // heap-Float load). `and`/`ror` have no immediate form / the macro
+            // grew `ror`, so the rotate uses `ror` and the mask uses shifts.
+            AsmInst::FloatToFpr(reg, x, deopt) => {
+                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
+                    return false;
+                };
+                let deopt = labels[deopt].clone();
+                let r = reg.a64().0;
+                let heap = self.jit.label();
+                let exit = self.jit.label();
+                monoasm_arm64!(&mut self.jit,
+                    tbnz x(r), #(0), deopt;   // fixnum -> deopt (expected a Float)
+                    tbz x(r), #(1), heap;     // not flonum -> heap Float
+                    // flonum: handle 0.0, else decode.
+                    fmov d(p), xzr;
+                    mov x9, (FLOAT_ZERO);
+                    cmp x(r), x9;
+                );
+                self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+                monoasm_arm64!(&mut self.jit,
+                    asr x9, x(r), #(63);      // sign: all-1s / all-0s
+                    add x9, x9, #(2);         // 2 - signbit  (1 or 2)
+                    lsr x10, x(r), #(2);
+                    lsl x10, x10, #(2);       // reg & ~3
+                    orr x10, x10, x9;
+                    ror x10, x10, #(3);       // rotate_right 3
+                    fmov d(p), x10;
+                    b exit;
+                    heap:
+                );
+                self.a64_guard_rvalue(r, FLOAT_CLASS, &deopt);
+                monoasm_arm64!(&mut self.jit,
+                    ldr d(p), [x(r), #(RVALUE_OFFSET_KIND as u32)];
+                    exit:
+                );
+                true
+            }
+            // [slot] <- box(f64 in x): flonum-encode or heap-allocate.
+            AsmInst::FprToStack(x, slot) => {
+                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
+                    return false;
+                };
+                let f64_to_val = self.f64_to_val.clone();
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                monoasm_arm64!(&mut self.jit,
+                    fmov d0, d(p);
+                    bl f64_to_val;          // x0 = Value(f64)
+                    sub x10, x(lfp), #(off);
+                    str x0, [x10];
+                );
+                true
+            }
+            // Save / restore live FP pool registers around a C-call.
+            AsmInst::XmmSave(using_xmm, cont) => {
+                if using_xmm.not_any() && !cont {
+                    return true;
+                }
+                let sp_offset =
+                    (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
+                monoasm_arm64!(&mut self.jit, sub sp, sp, #(sp_offset););
+                let mut i = 0u32;
+                for (xi, b) in using_xmm.iter().enumerate() {
+                    if *b {
+                        let pr = xi as u32 + 2;
+                        let ofs = 8 * i;
+                        monoasm_arm64!(&mut self.jit, str d(pr), [sp, #(ofs)];);
+                        i += 1;
+                    }
+                }
+                true
+            }
+            AsmInst::XmmRestore(using_xmm, cont) => {
+                if using_xmm.not_any() && !cont {
+                    return true;
+                }
+                let sp_offset =
+                    (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
+                let mut i = 0u32;
+                for (xi, b) in using_xmm.iter().enumerate() {
+                    if *b {
+                        let pr = xi as u32 + 2;
+                        let ofs = 8 * i;
+                        monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
+                        i += 1;
+                    }
+                }
+                monoasm_arm64!(&mut self.jit, add sp, sp, #(sp_offset););
                 true
             }
             // Phase 3b: more AsmInst lowerings land here, one category at a time.


### PR DESCRIPTION
## Summary

Lower the floating-point `AsmInst`s on aarch64 so methods/loops doing Float `+ - * /` JIT-compile instead of bailing to the VM. The front-end (TraceIR→AsmIR) was already shared; this adds the aarch64 emission. Follows up the jitgen port (#645) — Float was the last big `big.rb` blocker.

## What's lowered

- **FloatBinOp** → `fadd`/`fsub`/`fmul`/`fdiv` (D-registers; aarch64's FP 3-op writes `rd` and reads `rn`/`rm`, so `dst` may alias an operand with no hazard).
- **FloatToFpr** (`Value`→f64): flonum-decode (rotate via monoasm's new `ror`) + heap-`Float` load, deopting if the value is not a Float. **FixnumToFpr**: untag + `scvtf`. **F64ToFpr**: materialize the f64 bits + `fmov`.
- **FprToStack**: box via a new `a64_gen_f64_to_val` helper — flonum-encode when the exponent is in range, else `Value::float_heap` (the helper saves the caller-saved FP pool around the C-call). **FprMove**/**FprSwap**, **XmmSave**/**XmmRestore**.

## ABI note (why the FP pool is capped to D2–D7)

Under AAPCS64 **D8–D15 are callee-saved** (unlike x86-64 SysV, where every xmm is caller-saved), and the aarch64 invoker / JIT prologue does not preserve them yet. So the JIT'd FP pool is restricted to the caller-saved **D2–D7**; methods needing >6 live floats (or any spill) stay VM-interpreted. `f64_to_val`'s heap path and `XmmSave` only ever touch D2–D7, so this is self-consistent. Lifting the cap later just needs the prologue to save/restore D8–D15.

Bumps `monoasm` to the rev that adds `ror`/`rol`.

## Testing (arm64-darwin)

- Float `+,-,*,/` accumulators, mixed int/float (`add(2, 1.5)`), method args, and heap-magnitude values (`1e300 * 10^30 → Infinity`) — all byte-identical to CRuby.
- `cargo nextest run -p monoruby --lib`: **1631 passed / 0 failed**; `arith` 59/0; `redefine` 4/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: VM operand-class recording (prerequisite)

Added a second commit — `aarch64 VM: record BinOp operand classes`. The lowering above was necessary but **not sufficient**: the aarch64 VM was not recording binop operand classes into the inline cache (unlike x86's `vm_save_binary_class`), so at JIT time `binop_type` saw an empty cache and classified a Float `a + b` (whose operand classes aren't known statically, unlike fixnum fast-paths) as `Other(None) → Recompile`. With no recompile-on-miss on aarch64, `FloatBinOp` was never reached and float arithmetic always fell back to the VM.

The generic binop handler now writes the runtime operand classes to `[PC+8]`/`[PC+12]` via `get_class`. With the cache populated the site types as `(Float, Float) → Float → FloatBinOp`, so float `+,-,*,/` methods/loops now genuinely JIT (verified with DIAG instrumentation that `FloatBinOp` is reached).

Re-verified: `cargo nextest run -p monoruby --lib` **1631/0**, full `--test arith` **59/59**, `--test redefine` 4/0.
