### PR TITLE
jit: share more AsmInst lowering between x86-64 and aarch64 (constants, variables, allocation, FP transfer)

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -51,7 +51,10 @@ impl Codegen {
             | AsmInst::Deopt(..)
             | AsmInst::HandleError(..)
             | AsmInst::CheckStack { .. }
-            | AsmInst::ExecGc { .. } => {
+            | AsmInst::ExecGc { .. }
+            | AsmInst::GuardConstBaseClass { .. }
+            | AsmInst::GuardConstVersion { .. }
+            | AsmInst::StoreConstant { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -537,30 +540,6 @@ impl Codegen {
                 self.condbr_float(kind, branch_dest, brkind);
             }
 
-            AsmInst::GuardConstBaseClass { base_class, deopt } => {
-                let deopt = &labels[deopt];
-                let cached_base_class = self.jit.const_i64(base_class.id() as _);
-                monoasm! { &mut self.jit,
-                    cmpq rax, [rip + cached_base_class];  // rax: base_class
-                    jne  deopt;
-                }
-            }
-            AsmInst::GuardConstVersion {
-                const_version,
-                deopt,
-            } => {
-                let deopt = &labels[deopt];
-                self.guard_const_version(const_version, deopt);
-            }
-            AsmInst::StoreConstant {
-                id,
-                using_xmm,
-                error,
-            } => {
-                self.store_constant(id, using_xmm);
-                self.handle_error(&labels[error]);
-            }
-
             AsmInst::GenericBinOp {
                 lhs,
                 rhs,
@@ -1022,6 +1001,43 @@ impl Codegen {
         base: usize,
     ) -> bool {
         self.jit_execute_gc(&write_back, error, base);
+        true
+    }
+
+    /// Constant base-class guard: deopt if the accumulator (rax) is not the
+    /// cached base class.
+    pub(in crate::codegen::jitgen) fn emit_guard_const_base_class(
+        &mut self,
+        base_class: Value,
+        deopt: &DestLabel,
+    ) {
+        let cached_base_class = self.jit.const_i64(base_class.id() as _);
+        monoasm! { &mut self.jit,
+            cmpq rax, [rip + cached_base_class];  // rax: base_class
+            jne  deopt;
+        }
+    }
+
+    /// Constant version guard: deopt if the global constant version moved.
+    pub(in crate::codegen::jitgen) fn emit_guard_const_version(
+        &mut self,
+        const_version: usize,
+        deopt: &DestLabel,
+    ) {
+        self.guard_const_version(const_version, deopt);
+    }
+
+    /// Store the accumulator to a constant and bump the global constant
+    /// version. Always succeeds on x86 (the bool result exists for the aarch64
+    /// twin, which bails if any xmm is live).
+    pub(in crate::codegen::jitgen) fn emit_store_constant(
+        &mut self,
+        id: ConstSiteId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        self.store_constant(id, using_xmm);
+        self.handle_error(error);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -59,7 +59,14 @@ impl Codegen {
             | AsmInst::StoreGVar { .. }
             | AsmInst::LoadCVar { .. }
             | AsmInst::LoadDynVar { .. }
-            | AsmInst::StoreDynVar { .. } => {
+            | AsmInst::StoreDynVar { .. }
+            | AsmInst::CreateArray { .. }
+            | AsmInst::NewArray { .. }
+            | AsmInst::NewHash(..)
+            | AsmInst::NewRange { .. }
+            | AsmInst::ConcatStr { .. }
+            | AsmInst::ToA { .. }
+            | AsmInst::DeepCopyLit(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -234,8 +241,6 @@ impl Codegen {
             AsmInst::FprToStack(x, slots) => {
                 self.fpr_to_stack(x, &[slots], frame.base_stack_offset);
             }
-            AsmInst::DeepCopyLit(v, using_xmm) => self.deepcopy_literal(v, using_xmm),
-
             AsmInst::GuardArrayTy(r, deopt) => {
                 let deopt = &labels[deopt];
                 self.guard_array_ty(r, deopt)
@@ -569,22 +574,6 @@ impl Codegen {
             } => {
                 self.array_teq(lhs, rhs, using_xmm);
             }
-            AsmInst::NewArray { callid, using_xmm } => {
-                self.new_array(callid, using_xmm);
-            }
-            AsmInst::NewHash(args, len, using_xmm) => {
-                self.new_hash(args, len, using_xmm);
-            }
-            AsmInst::NewRange {
-                start,
-                end,
-                exclude_end,
-                using_xmm,
-            } => {
-                self.load_rdi(start);
-                self.load_rsi(end);
-                self.new_range(exclude_end, using_xmm);
-            }
 
             AsmInst::BlockArgProxy { ret, outer } => {
                 self.get_method_lfp(outer);
@@ -725,14 +714,6 @@ impl Codegen {
                 );
                 self.xmm_restore(using_xmm);
             }
-            AsmInst::CreateArray { src, len } => {
-                monoasm!( &mut self.jit,
-                    lea  rdi, [r14 - (conv(src))];
-                    movq rsi, (len);
-                    movq rax, (runtime::create_array);
-                    call rax;
-                );
-            }
             AsmInst::RestKw { rest_kw } => {
                 let data = self.jit.const_align8();
                 for (i, name) in rest_kw.into_iter() {
@@ -748,16 +729,6 @@ impl Codegen {
                     movq rax, (runtime::correct_rest_kw);
                     call rax;
                 );
-            }
-            AsmInst::ConcatStr {
-                arg,
-                len,
-                using_xmm,
-            } => {
-                self.concat_string(arg, len, using_xmm);
-            }
-            AsmInst::ToA { src, using_xmm } => {
-                self.to_a(src, using_xmm);
             }
             AsmInst::ConcatRegexp {
                 arg,
@@ -1078,6 +1049,84 @@ impl Codegen {
     /// dynamic (outer-frame) local <- src.
     pub(in crate::codegen::jitgen) fn emit_store_dyn_var(&mut self, dst: DynVar, src: GP) -> bool {
         self.store_dyn_var(dst, src);
+        true
+    }
+
+    // ---- runtime allocation primitives (x86-64) ---------------------------
+    // All build a heap object via a runtime call and always succeed (the bool
+    // result exists for the aarch64 twins, which bail on a live xmm / range
+    // overflow).
+
+    /// rax <- Array of the `len` slots starting at `src`.
+    pub(in crate::codegen::jitgen) fn emit_create_array(&mut self, src: SlotId, len: usize) -> bool {
+        monoasm!( &mut self.jit,
+            lea  rdi, [r14 - (conv(src))];
+            movq rsi, (len);
+            movq rax, (runtime::create_array);
+            call rax;
+        );
+        true
+    }
+
+    /// rax <- Array literal (splat-aware) via the call site.
+    pub(in crate::codegen::jitgen) fn emit_new_array(
+        &mut self,
+        callid: CallSiteId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.new_array(callid, using_xmm);
+        true
+    }
+
+    /// rax <- Hash literal from the `len` key/value slots at `args`.
+    pub(in crate::codegen::jitgen) fn emit_new_hash(
+        &mut self,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.new_hash(args, len, using_xmm);
+        true
+    }
+
+    /// rax <- Range(start, end, exclude_end).
+    pub(in crate::codegen::jitgen) fn emit_new_range(
+        &mut self,
+        start: SlotId,
+        end: SlotId,
+        exclude_end: bool,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.load_rdi(start);
+        self.load_rsi(end);
+        self.new_range(exclude_end, using_xmm);
+        true
+    }
+
+    /// rax <- the `len` slots at `arg` concatenated into a String.
+    pub(in crate::codegen::jitgen) fn emit_concat_str(
+        &mut self,
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.concat_string(arg, len, using_xmm);
+        true
+    }
+
+    /// rax <- `src` coerced to an Array (`Array(x)` / splat).
+    pub(in crate::codegen::jitgen) fn emit_to_a(&mut self, src: SlotId, using_xmm: UsingXmm) -> bool {
+        self.to_a(src, using_xmm);
+        true
+    }
+
+    /// rax <- a deep copy of literal `v` (fresh mutable object per evaluation).
+    pub(in crate::codegen::jitgen) fn emit_deep_copy_lit(
+        &mut self,
+        v: Value,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.deepcopy_literal(v, using_xmm);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -66,7 +66,13 @@ impl Codegen {
             | AsmInst::NewRange { .. }
             | AsmInst::ConcatStr { .. }
             | AsmInst::ToA { .. }
-            | AsmInst::DeepCopyLit(..) => {
+            | AsmInst::DeepCopyLit(..)
+            | AsmInst::FprMove(..)
+            | AsmInst::FprSwap(..)
+            | AsmInst::F64ToFpr(..)
+            | AsmInst::FixnumToFpr(..)
+            | AsmInst::FloatToFpr(..)
+            | AsmInst::FprToStack(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -158,12 +164,6 @@ impl Codegen {
                 );
             }
 
-            AsmInst::FprMove(src, dst) => {
-                self.emit_xmm_move(src, dst, frame.base_stack_offset);
-            }
-            AsmInst::FprSwap(l, r) => {
-                self.emit_fpr_swap(l, r, frame.base_stack_offset);
-            }
             AsmInst::FloatBinOp {
                 kind,
                 binary_xmm,
@@ -187,42 +187,6 @@ impl Codegen {
                 _ => unreachable!(),
             },
 
-            AsmInst::F64ToFpr(f, x) => {
-                let f_const = self.jit.const_f64(f);
-                match x.loc(frame.base_stack_offset) {
-                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                        movq xmm(p), [rip + f_const];
-                    ),
-                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                        movq xmm0, [rip + f_const];
-                        movq [rbp - (off)], xmm0;
-                    ),
-                }
-            }
-            AsmInst::FixnumToFpr(r, x) => {
-                let (work, spill_off) = match x.loc(frame.base_stack_offset) {
-                    FPRegLoc::Xmm(p) => (p, None),
-                    FPRegLoc::Spill(off) => (0u64, Some(off)),
-                };
-                self.integer_val_to_f64(r, work);
-                if let Some(off) = spill_off {
-                    monoasm!( &mut self.jit,
-                        movq [rbp - (off)], xmm(work);
-                    );
-                }
-            }
-            AsmInst::FloatToFpr(reg, x, deopt) => {
-                let (work, spill_off) = match x.loc(frame.base_stack_offset) {
-                    FPRegLoc::Xmm(p) => (p, None),
-                    FPRegLoc::Spill(off) => (0u64, Some(off)),
-                };
-                self.float_to_f64(reg, work, &labels[deopt]);
-                if let Some(off) = spill_off {
-                    monoasm!( &mut self.jit,
-                        movq [rbp - (off)], xmm(work);
-                    );
-                }
-            }
             AsmInst::I64ToBoth(i, r, x) => {
                 let f = self.jit.const_f64(i as f64);
                 monoasm! {&mut self.jit,
@@ -237,9 +201,6 @@ impl Codegen {
                         movq [rbp - (off)], xmm0;
                     ),
                 }
-            }
-            AsmInst::FprToStack(x, slots) => {
-                self.fpr_to_stack(x, &[slots], frame.base_stack_offset);
             }
             AsmInst::GuardArrayTy(r, deopt) => {
                 let deopt = &labels[deopt];
@@ -1475,9 +1436,16 @@ impl Codegen {
     /// combination and avoid the round-trip through xmm0 that the
     /// generic `expand_spills` wrapping would otherwise produce.
     ///
-    fn emit_xmm_move(&mut self, src: FPReg, dst: FPReg, base: usize) {
+    /// dst(f64) <- src. Spill-aware. Always succeeds on x86 (the bool result
+    /// exists for the aarch64 twin, which bails on an unlowerable FP register).
+    pub(in crate::codegen::jitgen) fn emit_fpr_move(
+        &mut self,
+        src: FPReg,
+        dst: FPReg,
+        base: usize,
+    ) -> bool {
         if src == dst {
-            return;
+            return true;
         }
         match (src.loc(base), dst.loc(base)) {
             (FPRegLoc::Xmm(s), FPRegLoc::Xmm(d)) => monoasm!( &mut self.jit,
@@ -1494,6 +1462,7 @@ impl Codegen {
                 movq [rbp - (d_off)], xmm0;
             ),
         }
+        true
     }
 
     ///
@@ -1501,9 +1470,14 @@ impl Codegen {
     /// the two memory slots through xmm0+xmm1 (avoiding rax/rcx so
     /// nothing in the surrounding code's GP state is disturbed).
     ///
-    fn emit_fpr_swap(&mut self, l: FPReg, r: FPReg, base: usize) {
+    pub(in crate::codegen::jitgen) fn emit_fpr_swap(
+        &mut self,
+        l: FPReg,
+        r: FPReg,
+        base: usize,
+    ) -> bool {
         if l == r {
-            return;
+            return true;
         }
         match (l.loc(base), r.loc(base)) {
             (FPRegLoc::Xmm(lp), FPRegLoc::Xmm(rp)) => monoasm!( &mut self.jit,
@@ -1528,5 +1502,64 @@ impl Codegen {
                 movq [rbp - (l_off)], xmm1;
             ),
         }
+        true
+    }
+
+    /// xmm(x) <- f64 constant `f`. Spill-aware.
+    pub(in crate::codegen::jitgen) fn emit_f64_to_fpr(&mut self, f: f64, x: FPReg, base: usize) -> bool {
+        let f_const = self.jit.const_f64(f);
+        match x.loc(base) {
+            FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                movq xmm(p), [rip + f_const];
+            ),
+            FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                movq xmm0, [rip + f_const];
+                movq [rbp - (off)], xmm0;
+            ),
+        }
+        true
+    }
+
+    /// xmm(x) <- the fixnum in GP `r`, converted to f64. Spill-aware.
+    pub(in crate::codegen::jitgen) fn emit_fixnum_to_fpr(&mut self, r: GP, x: FPReg, base: usize) -> bool {
+        let (work, spill_off) = match x.loc(base) {
+            FPRegLoc::Xmm(p) => (p, None),
+            FPRegLoc::Spill(off) => (0u64, Some(off)),
+        };
+        self.integer_val_to_f64(r, work);
+        if let Some(off) = spill_off {
+            monoasm!( &mut self.jit,
+                movq [rbp - (off)], xmm(work);
+            );
+        }
+        true
+    }
+
+    /// xmm(x) <- the Float Value in GP `reg`, decoded to f64; deopt if `reg` is
+    /// not a Float. Spill-aware.
+    pub(in crate::codegen::jitgen) fn emit_float_to_fpr(
+        &mut self,
+        reg: GP,
+        x: FPReg,
+        deopt: &DestLabel,
+        base: usize,
+    ) -> bool {
+        let (work, spill_off) = match x.loc(base) {
+            FPRegLoc::Xmm(p) => (p, None),
+            FPRegLoc::Spill(off) => (0u64, Some(off)),
+        };
+        self.float_to_f64(reg, work, deopt);
+        if let Some(off) = spill_off {
+            monoasm!( &mut self.jit,
+                movq [rbp - (off)], xmm(work);
+            );
+        }
+        true
+    }
+
+    /// [slot] <- box(xmm(x)) (flonum-encode or heap-allocate the f64).
+    pub(in crate::codegen::jitgen) fn emit_fpr_to_stack(&mut self, x: FPReg, slot: SlotId, base: usize) -> bool {
+        self.fpr_to_stack(x, &[slot], base);
+        true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -54,7 +54,12 @@ impl Codegen {
             | AsmInst::ExecGc { .. }
             | AsmInst::GuardConstBaseClass { .. }
             | AsmInst::GuardConstVersion { .. }
-            | AsmInst::StoreConstant { .. } => {
+            | AsmInst::StoreConstant { .. }
+            | AsmInst::LoadGVar { .. }
+            | AsmInst::StoreGVar { .. }
+            | AsmInst::LoadCVar { .. }
+            | AsmInst::LoadDynVar { .. }
+            | AsmInst::StoreDynVar { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -598,11 +603,9 @@ impl Codegen {
                 self.store_rax(ret);
             }
 
-            AsmInst::LoadDynVar { src } => self.load_dyn_var(src),
             AsmInst::LoadDynVarSpecialized { offset, reg } => {
                 self.load_dyn_var_specialized(offset.unwrap_concrete(), reg);
             }
-            AsmInst::StoreDynVar { dst, src } => self.store_dyn_var(dst, src),
             AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
                 self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
             }
@@ -640,9 +643,6 @@ impl Codegen {
                 self.guard_frozen(deopt);
             }
 
-            AsmInst::LoadCVar { name, using_xmm } => {
-                self.load_cvar(name, using_xmm);
-            }
             AsmInst::CheckCVar { name, using_xmm } => {
                 self.check_cvar(name, using_xmm);
             }
@@ -653,13 +653,6 @@ impl Codegen {
             } => {
                 self.store_cvar(name, src, using_xmm);
             }
-
-            AsmInst::LoadGVar { name, using_xmm } => self.load_gvar(name, using_xmm),
-            AsmInst::StoreGVar {
-                name,
-                src,
-                using_xmm,
-            } => self.store_gvar(name, src, using_xmm),
 
             AsmInst::ClassDef {
                 base,
@@ -1038,6 +1031,53 @@ impl Codegen {
     ) -> bool {
         self.store_constant(id, using_xmm);
         self.handle_error(error);
+        true
+    }
+
+    // ---- variable-access primitives (x86-64) ------------------------------
+    // All delegate to the existing helpers and always succeed (the bool result
+    // exists for the aarch64 twins, which bail on a live xmm / range overflow).
+
+    /// rax <- $gvar.
+    pub(in crate::codegen::jitgen) fn emit_load_gvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.load_gvar(name, using_xmm);
+        true
+    }
+
+    /// $gvar <- src.
+    pub(in crate::codegen::jitgen) fn emit_store_gvar(
+        &mut self,
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.store_gvar(name, src, using_xmm);
+        true
+    }
+
+    /// rax <- @@cvar.
+    pub(in crate::codegen::jitgen) fn emit_load_cvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.load_cvar(name, using_xmm);
+        true
+    }
+
+    /// rax <- dynamic (outer-frame) local.
+    pub(in crate::codegen::jitgen) fn emit_load_dyn_var(&mut self, src: DynVar) -> bool {
+        self.load_dyn_var(src);
+        true
+    }
+
+    /// dynamic (outer-frame) local <- src.
+    pub(in crate::codegen::jitgen) fn emit_store_dyn_var(&mut self, dst: DynVar, src: GP) -> bool {
+        self.store_dyn_var(dst, src);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -131,6 +131,23 @@ impl Codegen {
             }
             AsmInst::ToA { src, using_xmm } => return self.emit_to_a(src, using_xmm),
             AsmInst::DeepCopyLit(v, using_xmm) => return self.emit_deep_copy_lit(v, using_xmm),
+            // Floating-point register transfer/convert family (aarch64 bails if
+            // the FP pool register is not lowerable, hence the bool results).
+            // `base` is the spill base; deopt is a side-exit label.
+            AsmInst::FprMove(src, dst) => {
+                return self.emit_fpr_move(src, dst, frame.base_stack_offset);
+            }
+            AsmInst::FprSwap(l, r) => return self.emit_fpr_swap(l, r, frame.base_stack_offset),
+            AsmInst::F64ToFpr(f, x) => return self.emit_f64_to_fpr(f, x, frame.base_stack_offset),
+            AsmInst::FixnumToFpr(r, x) => {
+                return self.emit_fixnum_to_fpr(r, x, frame.base_stack_offset);
+            }
+            AsmInst::FloatToFpr(reg, x, deopt) => {
+                return self.emit_float_to_fpr(reg, x, &labels[deopt], frame.base_stack_offset);
+            }
+            AsmInst::FprToStack(x, slot) => {
+                return self.emit_fpr_to_stack(x, slot, frame.base_stack_offset);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -113,6 +113,24 @@ impl Codegen {
             AsmInst::LoadCVar { name, using_xmm } => return self.emit_load_cvar(name, using_xmm),
             AsmInst::LoadDynVar { src } => return self.emit_load_dyn_var(src),
             AsmInst::StoreDynVar { dst, src } => return self.emit_store_dyn_var(dst, src),
+            // Runtime allocation / C-call family: each builds a heap object via
+            // a runtime call (aarch64 bails on a live xmm / range overflow,
+            // hence the bool results).
+            AsmInst::CreateArray { src, len } => return self.emit_create_array(src, len),
+            AsmInst::NewArray { callid, using_xmm } => {
+                return self.emit_new_array(callid, using_xmm);
+            }
+            AsmInst::NewHash(args, len, using_xmm) => {
+                return self.emit_new_hash(args, len, using_xmm);
+            }
+            AsmInst::NewRange { start, end, exclude_end, using_xmm } => {
+                return self.emit_new_range(start, end, exclude_end, using_xmm);
+            }
+            AsmInst::ConcatStr { arg, len, using_xmm } => {
+                return self.emit_concat_str(arg, len, using_xmm);
+            }
+            AsmInst::ToA { src, using_xmm } => return self.emit_to_a(src, using_xmm),
+            AsmInst::DeepCopyLit(v, using_xmm) => return self.emit_deep_copy_lit(v, using_xmm),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -103,6 +103,16 @@ impl Codegen {
             AsmInst::StoreConstant { id, using_xmm, error } => {
                 return self.emit_store_constant(id, using_xmm, &labels[error]);
             }
+            // Variable access (aarch64 bails on a live xmm / range overflow,
+            // hence the bool results). gvar/cvar go via a runtime call; dynvar
+            // walks the outer-LFP chain.
+            AsmInst::LoadGVar { name, using_xmm } => return self.emit_load_gvar(name, using_xmm),
+            AsmInst::StoreGVar { name, src, using_xmm } => {
+                return self.emit_store_gvar(name, src, using_xmm);
+            }
+            AsmInst::LoadCVar { name, using_xmm } => return self.emit_load_cvar(name, using_xmm),
+            AsmInst::LoadDynVar { src } => return self.emit_load_dyn_var(src),
+            AsmInst::StoreDynVar { dst, src } => return self.emit_store_dyn_var(dst, src),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -88,6 +88,21 @@ impl Codegen {
             AsmInst::ExecGc { write_back, error } => {
                 return self.emit_exec_gc(write_back, &labels[error], frame.base_stack_offset);
             }
+            // Constant base-class guard: deopt if the constant's base class (in
+            // the accumulator) is not the cached one.
+            AsmInst::GuardConstBaseClass { base_class, deopt } => {
+                self.emit_guard_const_base_class(base_class, &labels[deopt]);
+            }
+            // Constant version guard: deopt if the global constant version moved
+            // since compilation.
+            AsmInst::GuardConstVersion { const_version, deopt } => {
+                self.emit_guard_const_version(const_version, &labels[deopt]);
+            }
+            // Store to a constant, bumping the global constant version (aarch64
+            // bails if any xmm is live, hence the bool result).
+            AsmInst::StoreConstant { id, using_xmm, error } => {
+                return self.emit_store_constant(id, using_xmm, &labels[error]);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1007,6 +1007,204 @@ impl Codegen {
         true
     }
 
+    // ---- runtime allocation primitives (aarch64) --------------------------
+    // Each builds a heap object via a runtime C call. All bail (`false`) on a
+    // live xmm (no FP save/restore yet) or an out-of-range frame offset.
+
+    /// rax <- Array built from the `len` slots starting at `src`.
+    /// create_array(ptr=&slot[src], len). No xmm save (matches x86).
+    pub(in crate::codegen::jitgen) fn emit_create_array(&mut self, src: SlotId, len: usize) -> bool {
+        let lfp = GP::R14.a64().0;
+        let off = src.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::create_array as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub x0, x(lfp), #(off);   // &slot[src]
+            mov x1, (len as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                   // result in x0
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- Array literal via gen_array(vm, globals, callid, &self).
+    pub(in crate::codegen::jitgen) fn emit_new_array(
+        &mut self,
+        callid: CallSiteId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let f = runtime::gen_array as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                       // vm
+            mov x1, x20;                       // globals
+            mov x2, (callid.get() as u64);     // callid
+            sub x3, x(lfp), #(LFP_SELF as u32); // &[lfp - LFP_SELF]
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- Hash literal via gen_hash(vm, globals, &slot[args], len).
+    pub(in crate::codegen::jitgen) fn emit_new_hash(
+        &mut self,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = args.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::gen_hash as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;              // vm
+            mov x1, x20;              // globals
+            sub x2, x(lfp), #(off);   // &slot[args]
+            mov x3, (len as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- Range via gen_range(start, end, vm, globals, exclude_end).
+    pub(in crate::codegen::jitgen) fn emit_new_range(
+        &mut self,
+        start: SlotId,
+        end: SlotId,
+        exclude_end: bool,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let soff = start.0 as u32 * 8 + LFP_SELF as u32;
+        let eoff = end.0 as u32 * 8 + LFP_SELF as u32;
+        if soff > 4095 || eoff > 4095 {
+            return false;
+        }
+        let f = runtime::gen_range as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(soff);
+            ldr x0, [x10];            // start value
+            sub x10, x(lfp), #(eoff);
+            ldr x1, [x10];            // end value
+            mov x2, x19;              // vm
+            mov x3, x20;              // globals
+            mov x4, (exclude_end as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- the `len` slots at `arg` concatenated into a String via
+    /// concatenate_string(vm, globals, &slot[arg], len). Result is Option<Value>
+    /// (followed by a HandleError in the IR).
+    pub(in crate::codegen::jitgen) fn emit_concat_str(
+        &mut self,
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = arg.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::concatenate_string as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;              // vm
+            mov x1, x20;              // globals
+            sub x2, x(lfp), #(off);   // &slot[arg]
+            mov x3, (len as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- `src` coerced to an Array: load slot `src`; if already an Array
+    /// keep it, otherwise call runtime::to_a(vm, globals, val). Mirrors x86 to_a.
+    pub(in crate::codegen::jitgen) fn emit_to_a(&mut self, src: SlotId, using_xmm: UsingXmm) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = src.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let toa = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off);
+            ldr x0, [x10];          // val (rax)
+        );
+        self.a64_guard_rvalue(GP::Rax.a64().0, ARRAY_CLASS, &toa); // not Array -> toa
+        monoasm_arm64!(&mut self.jit, b exit;); // already Array
+        let f = runtime::to_a as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            toa:
+            mov x2, x0;             // val
+            mov x0, x19;            // vm
+            mov x1, x20;            // globals
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                 // result in x0
+            ldr x30, [sp], #16;
+            exit:
+        );
+        true
+    }
+
+    /// rax <- a deep copy of literal `v` (a fresh mutable object per
+    /// evaluation). Mirrors x86 `deepcopy_literal`.
+    pub(in crate::codegen::jitgen) fn emit_deep_copy_lit(
+        &mut self,
+        v: Value,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let imm = v.id();
+        let f = Value::value_deep_copy as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, (imm);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;            // result in x0 (= rax)
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -1071,56 +1269,6 @@ impl Codegen {
                 );
                 true
             }
-            // to_a: load slot `src`; if it is already an Array, keep it in rax,
-            // otherwise call runtime::to_a(vm, globals, val). Mirrors x86 to_a.
-            AsmInst::ToA { src, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let off = src.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let toa = self.jit.label();
-                let exit = self.jit.label();
-                monoasm_arm64!(&mut self.jit,
-                    sub x10, x(lfp), #(off);
-                    ldr x0, [x10];          // val (rax)
-                );
-                self.a64_guard_rvalue(GP::Rax.a64().0, ARRAY_CLASS, &toa); // not Array -> toa
-                monoasm_arm64!(&mut self.jit, b exit;); // already Array
-                let f = runtime::to_a as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    toa:
-                    mov x2, x0;             // val
-                    mov x0, x19;            // vm
-                    mov x1, x20;            // globals
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;                 // result in x0
-                    ldr x30, [sp], #16;
-                    exit:
-                );
-                true
-            }
-            // rax <- deep copy of literal Value (so each evaluation yields a
-            // fresh mutable object). Runtime C call; bails if any xmm is live
-            // (no FP save/restore yet). Mirrors x86 `deepcopy_literal`.
-            AsmInst::DeepCopyLit(v, using_xmm) => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let imm = v.id();
-                let f = Value::value_deep_copy as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, (imm);
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;            // result in x0 (= rax)
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
             // Inline-cache class-version guard: deopt if the global class
             // version changed since compilation.
             AsmInst::GuardClassVersion { deopt, .. } => {
@@ -1155,114 +1303,6 @@ impl Codegen {
             AsmInst::RecompileDeopt { deopt, .. } => {
                 let deopt = labels[deopt].clone();
                 monoasm_arm64!(&mut self.jit, b deopt;);
-                true
-            }
-            // rax <- Array built from the `len` slots starting at `src`.
-            // create_array(ptr=&slot[src], len). No xmm save (matches x86).
-            AsmInst::CreateArray { src, len } => {
-                let off = src.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let f = runtime::create_array as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    sub x0, x(lfp), #(off);   // &slot[src]
-                    mov x1, (len as u64);
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;                   // result in x0
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // rax <- Array literal via gen_array(vm, globals, callid, &self).
-            AsmInst::NewArray { callid, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let f = runtime::gen_array as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;                       // vm
-                    mov x1, x20;                       // globals
-                    mov x2, (callid.get() as u64);     // callid
-                    sub x3, x(lfp), #(LFP_SELF as u32); // &[lfp - LFP_SELF]
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // rax <- Hash literal via gen_hash(vm, globals, &slot[args], len).
-            AsmInst::NewHash(args, len, using_xmm) => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let off = args.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let f = runtime::gen_hash as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;              // vm
-                    mov x1, x20;              // globals
-                    sub x2, x(lfp), #(off);   // &slot[args]
-                    mov x3, (len as u64);
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // rax <- concatenated string via concatenate_string(vm, globals,
-            // &slot[arg], len). Result is Option<Value> (followed by a
-            // HandleError in the IR). Bails if any xmm is live.
-            AsmInst::ConcatStr { arg, len, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let off = arg.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let f = runtime::concatenate_string as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;              // vm
-                    mov x1, x20;              // globals
-                    sub x2, x(lfp), #(off);   // &slot[arg]
-                    mov x3, (len as u64);
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // rax <- Range via gen_range(start, end, vm, globals, exclude_end).
-            AsmInst::NewRange { start, end, exclude_end, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let soff = start.0 as u32 * 8 + LFP_SELF as u32;
-                let eoff = end.0 as u32 * 8 + LFP_SELF as u32;
-                if soff > 4095 || eoff > 4095 {
-                    return false;
-                }
-                let f = runtime::gen_range as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    sub x10, x(lfp), #(soff);
-                    ldr x0, [x10];            // start value
-                    sub x10, x(lfp), #(eoff);
-                    ldr x1, [x10];            // end value
-                    mov x2, x19;              // vm
-                    mov x3, x20;              // globals
-                    mov x4, (exclude_end as u64);
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
-                );
                 true
             }
             // Method-call sequence: frame fields, arg massage, the call itself.

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -889,6 +889,124 @@ impl Codegen {
         true
     }
 
+    // ---- variable-access primitives (aarch64) -----------------------------
+    // gvar/cvar go through a runtime C call; dynvar walks the outer-LFP chain.
+    // All bail (`false`) on a live xmm / out-of-range offset (no FP save yet).
+
+    /// rax <- $gvar via runtime::get_global_var(vm, globals, name).
+    pub(in crate::codegen::jitgen) fn emit_load_gvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::get_global_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, (name.get() as u64); // name (IdentId)
+            str x30, [sp, #-16]!;         // save LR across the call
+            mov x9, (f);
+            blr x9;                       // result in x0 (= rax)
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// $gvar <- src via runtime::set_global_var(vm, globals, name, val).
+    pub(in crate::codegen::jitgen) fn emit_store_gvar(
+        &mut self,
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = src.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::set_global_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, (name.get() as u64); // name (IdentId)
+            sub x10, x(lfp), #(off);
+            ldr x3, [x10];                // val (from slot)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- @@cvar via runtime::get_class_var(vm, globals, name).
+    pub(in crate::codegen::jitgen) fn emit_load_cvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::get_class_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                  // vm
+            mov x1, x20;                  // globals
+            mov x2, (name.get() as u64); // name
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                       // result in x0
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// rax <- dynamic (outer-frame) local. Walk `outer` outer-LFP links
+    /// (LFP_OUTER == 0, so `[lfp]` is the next outer frame), then load the slot.
+    /// Mirrors x86 `load_dyn_var`.
+    pub(in crate::codegen::jitgen) fn emit_load_dyn_var(&mut self, src: DynVar) -> bool {
+        let lfp = GP::R14.a64().0;
+        let off = src.reg.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let rax = GP::Rax.a64().0;
+        self.a64_get_outer(src.outer, lfp, rax);
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(rax), #(off);
+            ldr x(rax), [x10];
+        );
+        true
+    }
+
+    /// dynamic (outer-frame) local <- src. Symmetric to `emit_load_dyn_var`.
+    pub(in crate::codegen::jitgen) fn emit_store_dyn_var(&mut self, dst: DynVar, src: GP) -> bool {
+        let lfp = GP::R14.a64().0;
+        let off = dst.reg.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        // walk to the outer LFP in `outer` (avoid clobbering `src`).
+        let outer = GP::Rcx.a64().0;
+        let s = src.a64().0;
+        if s == outer || s == 10 {
+            // src would be clobbered by the walk/scratch; bail (rare).
+            return false;
+        }
+        self.a64_get_outer(dst.outer, lfp, outer);
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(outer), #(off);
+            str x(s), [x10];
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -953,64 +1071,6 @@ impl Codegen {
                 );
                 true
             }
-            // rax <- dynamic (outer-frame) local. Walk `outer` outer-LFP links
-            // (LFP_OUTER == 0, so `[lfp]` is the next outer frame), then load
-            // the slot. Mirrors x86 `load_dyn_var` (`get_outer` + `movq rax,
-            // [rax - offset]`).
-            AsmInst::LoadDynVar { src } => {
-                let off = src.reg.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let rax = GP::Rax.a64().0;
-                self.a64_get_outer(src.outer, lfp, rax);
-                monoasm_arm64!(&mut self.jit,
-                    sub x10, x(rax), #(off);
-                    ldr x(rax), [x10];
-                );
-                true
-            }
-            // dynamic (outer-frame) local <- src. Symmetric to LoadDynVar.
-            AsmInst::StoreDynVar { dst, src } => {
-                let off = dst.reg.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                // walk to the outer LFP in x9 (avoid clobbering `src`).
-                let outer = GP::Rcx.a64().0;
-                let s = src.a64().0;
-                if s == outer || s == 10 {
-                    // src would be clobbered by the walk/scratch; bail (rare).
-                    return false;
-                }
-                self.a64_get_outer(dst.outer, lfp, outer);
-                monoasm_arm64!(&mut self.jit,
-                    sub x10, x(outer), #(off);
-                    str x(s), [x10];
-                );
-                true
-            }
-            // rax <- $gvar via runtime::get_global_var(vm, globals, name).
-            // EXEC (Executor) lives in x19, GLOBALS in x20 (= GP::R12). We have
-            // no FP save/restore yet, so bail if any xmm is live across the call.
-            // rax <- @@cvar via runtime::get_class_var(vm, globals, name).
-            AsmInst::LoadCVar { name, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let f = runtime::get_class_var as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;                  // vm
-                    mov x1, x20;                  // globals
-                    mov x2, (name.get() as u64); // name
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;                       // result in x0
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // Stack-overflow check at method entry: if sp <= executor.stack_limit
             // to_a: load slot `src`; if it is already an Array, keep it in rax,
             // otherwise call runtime::to_a(vm, globals, val). Mirrors x86 to_a.
             AsmInst::ToA { src, using_xmm } => {
@@ -1040,50 +1100,6 @@ impl Codegen {
                     blr x9;                 // result in x0
                     ldr x30, [sp], #16;
                     exit:
-                );
-                true
-            }
-            AsmInst::LoadGVar { name, using_xmm } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let f = runtime::get_global_var as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;                  // vm (Executor)
-                    mov x1, x20;                  // globals
-                    mov x2, (name.get() as u64); // name (IdentId)
-                    str x30, [sp, #-16]!;         // save LR across the call
-                    mov x9, (f);
-                    blr x9;                       // result in x0 (= rax)
-                    ldr x30, [sp], #16;
-                );
-                true
-            }
-            // $gvar <- src via runtime::set_global_var(vm, globals, name, val).
-            // Mirrors x86 store_gvar (the Option<Value> return is discarded).
-            AsmInst::StoreGVar {
-                name,
-                src,
-                using_xmm,
-            } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let off = src.0 as u32 * 8 + LFP_SELF as u32;
-                if off > 4095 {
-                    return false;
-                }
-                let f = runtime::set_global_var as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x0, x19;                  // vm (Executor)
-                    mov x1, x20;                  // globals
-                    mov x2, (name.get() as u64); // name (IdentId)
-                    sub x10, x(lfp), #(off);
-                    ldr x3, [x10];                // val (from slot)
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
                 );
                 true
             }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1205,6 +1205,130 @@ impl Codegen {
         true
     }
 
+    // ---- floating-point transfer primitives (aarch64) ---------------------
+    // FP pool registers map to D-registers via `a64_fpr` (None -> bail). All
+    // return bool; `base` is the spill base.
+
+    /// dst(f64) <- src.
+    pub(in crate::codegen::jitgen) fn emit_fpr_move(
+        &mut self,
+        src: FPReg,
+        dst: FPReg,
+        base: usize,
+    ) -> bool {
+        let (Some(s), Some(d)) = (self.a64_fpr(src, base), self.a64_fpr(dst, base)) else {
+            return false;
+        };
+        if s != d {
+            monoasm_arm64!(&mut self.jit, fmov d(d), d(s););
+        }
+        true
+    }
+
+    /// swap two FP registers (via scratch D0).
+    pub(in crate::codegen::jitgen) fn emit_fpr_swap(&mut self, l: FPReg, r: FPReg, base: usize) -> bool {
+        let (Some(a), Some(b)) = (self.a64_fpr(l, base), self.a64_fpr(r, base)) else {
+            return false;
+        };
+        if a != b {
+            monoasm_arm64!(&mut self.jit,
+                fmov d0, d(a);
+                fmov d(a), d(b);
+                fmov d(b), d0;
+            );
+        }
+        true
+    }
+
+    /// dst(f64) <- f64 constant `f`.
+    pub(in crate::codegen::jitgen) fn emit_f64_to_fpr(&mut self, f: f64, x: FPReg, base: usize) -> bool {
+        let Some(p) = self.a64_fpr(x, base) else {
+            return false;
+        };
+        let bits = f.to_bits();
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (bits);
+            fmov d(p), x9;
+        );
+        true
+    }
+
+    /// dst(f64) <- fixnum in GP `reg` (untag, signed int -> double).
+    pub(in crate::codegen::jitgen) fn emit_fixnum_to_fpr(&mut self, reg: GP, x: FPReg, base: usize) -> bool {
+        let Some(p) = self.a64_fpr(x, base) else {
+            return false;
+        };
+        let r = reg.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            asr x9, x(r), #(1);   // untag: value >> 1
+            scvtf d(p), x9;
+        );
+        true
+    }
+
+    /// dst(f64) <- Float Value in GP `reg`; deopt if `reg` is not a Float.
+    /// Mirrors x86 float_to_f64 / float_val_to_f64 (flonum decode + heap-Float
+    /// load). `and`/`ror` have no immediate form / the macro grew `ror`, so the
+    /// rotate uses `ror` and the mask uses shifts.
+    pub(in crate::codegen::jitgen) fn emit_float_to_fpr(
+        &mut self,
+        reg: GP,
+        x: FPReg,
+        deopt: &DestLabel,
+        base: usize,
+    ) -> bool {
+        let Some(p) = self.a64_fpr(x, base) else {
+            return false;
+        };
+        let deopt = deopt.clone();
+        let r = reg.a64().0;
+        let heap = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            tbnz x(r), #(0), deopt;   // fixnum -> deopt (expected a Float)
+            tbz x(r), #(1), heap;     // not flonum -> heap Float
+            // flonum: handle 0.0, else decode.
+            fmov d(p), xzr;
+            mov x9, (FLOAT_ZERO);
+            cmp x(r), x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+        monoasm_arm64!(&mut self.jit,
+            asr x9, x(r), #(63);      // sign: all-1s / all-0s
+            add x9, x9, #(2);         // 2 - signbit  (1 or 2)
+            lsr x10, x(r), #(2);
+            lsl x10, x10, #(2);       // reg & ~3
+            orr x10, x10, x9;
+            ror x10, x10, #(3);       // rotate_right 3
+            fmov d(p), x10;
+            b exit;
+            heap:
+        );
+        self.a64_guard_rvalue(r, FLOAT_CLASS, &deopt);
+        monoasm_arm64!(&mut self.jit,
+            ldr d(p), [x(r), #(RVALUE_OFFSET_KIND as u32)];
+            exit:
+        );
+        true
+    }
+
+    /// [slot] <- box(f64 in x): flonum-encode or heap-allocate.
+    pub(in crate::codegen::jitgen) fn emit_fpr_to_stack(&mut self, x: FPReg, slot: SlotId, base: usize) -> bool {
+        let Some(p) = self.a64_fpr(x, base) else {
+            return false;
+        };
+        let lfp = GP::R14.a64().0;
+        let f64_to_val = self.f64_to_val.clone();
+        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+        monoasm_arm64!(&mut self.jit,
+            fmov d0, d(p);
+            bl f64_to_val;          // x0 = Value(f64)
+            sub x10, x(lfp), #(off);
+            str x0, [x10];
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -1349,35 +1473,6 @@ impl Codegen {
                 true
             }
             // ---- floating point (four-arithmetic) ----
-            // dst <- src
-            AsmInst::FprMove(src, dst) => {
-                let base = frame.base_stack_offset;
-                let (Some(s), Some(d)) =
-                    (self.a64_fpr(src, base), self.a64_fpr(dst, base))
-                else {
-                    return false;
-                };
-                if s != d {
-                    monoasm_arm64!(&mut self.jit, fmov d(d), d(s););
-                }
-                true
-            }
-            // swap two FP registers (via scratch D0)
-            AsmInst::FprSwap(l, r) => {
-                let base = frame.base_stack_offset;
-                let (Some(a), Some(b)) = (self.a64_fpr(l, base), self.a64_fpr(r, base))
-                else {
-                    return false;
-                };
-                if a != b {
-                    monoasm_arm64!(&mut self.jit,
-                        fmov d0, d(a);
-                        fmov d(a), d(b);
-                        fmov d(b), d0;
-                    );
-                }
-                true
-            }
             // dst <- lhs <op> rhs  (D-register arithmetic)
             AsmInst::FloatBinOp {
                 kind,
@@ -1401,84 +1496,6 @@ impl Codegen {
                     BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
                     _ => return false,
                 }
-                true
-            }
-            // dst <- f64 constant
-            AsmInst::F64ToFpr(f, x) => {
-                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
-                    return false;
-                };
-                let bits = f.to_bits();
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (bits);
-                    fmov d(p), x9;
-                );
-                true
-            }
-            // dst(f64) <- fixnum in `reg` (untag, signed int -> double)
-            AsmInst::FixnumToFpr(reg, x) => {
-                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
-                    return false;
-                };
-                let r = reg.a64().0;
-                monoasm_arm64!(&mut self.jit,
-                    asr x9, x(r), #(1);   // untag: value >> 1
-                    scvtf d(p), x9;
-                );
-                true
-            }
-            // dst(f64) <- Float Value in `reg`; deopt if `reg` is not a Float.
-            // Mirrors x86 float_to_f64 / float_val_to_f64 (flonum decode +
-            // heap-Float load). `and`/`ror` have no immediate form / the macro
-            // grew `ror`, so the rotate uses `ror` and the mask uses shifts.
-            AsmInst::FloatToFpr(reg, x, deopt) => {
-                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
-                    return false;
-                };
-                let deopt = labels[deopt].clone();
-                let r = reg.a64().0;
-                let heap = self.jit.label();
-                let exit = self.jit.label();
-                monoasm_arm64!(&mut self.jit,
-                    tbnz x(r), #(0), deopt;   // fixnum -> deopt (expected a Float)
-                    tbz x(r), #(1), heap;     // not flonum -> heap Float
-                    // flonum: handle 0.0, else decode.
-                    fmov d(p), xzr;
-                    mov x9, (FLOAT_ZERO);
-                    cmp x(r), x9;
-                );
-                self.jit.bcond_label(monoasm::Cond::Eq, &exit);
-                monoasm_arm64!(&mut self.jit,
-                    asr x9, x(r), #(63);      // sign: all-1s / all-0s
-                    add x9, x9, #(2);         // 2 - signbit  (1 or 2)
-                    lsr x10, x(r), #(2);
-                    lsl x10, x10, #(2);       // reg & ~3
-                    orr x10, x10, x9;
-                    ror x10, x10, #(3);       // rotate_right 3
-                    fmov d(p), x10;
-                    b exit;
-                    heap:
-                );
-                self.a64_guard_rvalue(r, FLOAT_CLASS, &deopt);
-                monoasm_arm64!(&mut self.jit,
-                    ldr d(p), [x(r), #(RVALUE_OFFSET_KIND as u32)];
-                    exit:
-                );
-                true
-            }
-            // [slot] <- box(f64 in x): flonum-encode or heap-allocate.
-            AsmInst::FprToStack(x, slot) => {
-                let Some(p) = self.a64_fpr(x, frame.base_stack_offset) else {
-                    return false;
-                };
-                let f64_to_val = self.f64_to_val.clone();
-                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-                monoasm_arm64!(&mut self.jit,
-                    fmov d0, d(p);
-                    bl f64_to_val;          // x0 = Value(f64)
-                    sub x10, x(lfp), #(off);
-                    str x0, [x10];
-                );
                 true
             }
             // Save / restore live FP pool registers around a C-call.

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -814,6 +814,81 @@ impl Codegen {
         true
     }
 
+    /// Constant base-class guard: deopt if the accumulator (rax/x0) is not the
+    /// cached base class. Mirrors x86 `GuardConstBaseClass`.
+    pub(in crate::codegen::jitgen) fn emit_guard_const_base_class(
+        &mut self,
+        base_class: Value,
+        deopt: &DestLabel,
+    ) {
+        let deopt = deopt.clone();
+        let rax = GP::Rax.a64().0;
+        let cached = base_class.id() as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (cached);
+            cmp x(rax), x10;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+    }
+
+    /// Constant version guard: deopt if the global constant version moved since
+    /// compilation (`const_version` is the baked-in cached value). Mirrors x86
+    /// `guard_const_version`.
+    pub(in crate::codegen::jitgen) fn emit_guard_const_version(
+        &mut self,
+        const_version: usize,
+        deopt: &DestLabel,
+    ) {
+        let deopt = deopt.clone();
+        let gv_addr = self
+            .jit
+            .get_label_address(&self.const_version_label())
+            .as_ptr() as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (gv_addr);
+            ldr x9, [x9];
+            mov x10, (const_version as u64);
+            cmp x9, x10;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+    }
+
+    /// Store the accumulator to a constant via set_constant(vm, globals, id,
+    /// val), bumping the global constant version. Bails (`false`) if any xmm is
+    /// live (no FP save/restore yet). Mirrors x86 `store_constant` + error check.
+    pub(in crate::codegen::jitgen) fn emit_store_constant(
+        &mut self,
+        id: ConstSiteId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let error = error.clone();
+        let cv_addr = self
+            .jit
+            .get_label_address(&self.const_version_label())
+            .as_ptr() as u64;
+        let f = runtime::set_constant as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x3, x0;                 // val (was in rax)
+            mov x0, x19;                // vm
+            mov x1, x20;                // globals
+            mov x2, (id.0 as u64);      // ConstSiteId
+            mov x9, (cv_addr);
+            ldr x10, [x9];
+            add x10, x10, #(1u32);
+            str x10, [x9];              // bump global const version
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            cbz x0, error;              // None -> error
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -1054,66 +1129,6 @@ impl Codegen {
                     mov x9, (flag_addr);
                     ldr w9, [x9];
                     cbnz x9, deopt;   // any BOP redefined -> deopt
-                );
-                true
-            }
-            // Constant inline-cache guard: deopt if the global constant version
-            // moved since compilation (`const_version` is the baked-in cached
-            // value). Mirrors x86 guard_const_version.
-            AsmInst::GuardConstVersion { const_version, deopt } => {
-                let deopt = labels[deopt].clone();
-                let gv_addr = self
-                    .jit
-                    .get_label_address(&self.const_version_label())
-                    .as_ptr() as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (gv_addr);
-                    ldr x9, [x9];
-                    mov x10, (const_version as u64);
-                    cmp x9, x10;
-                );
-                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
-                true
-            }
-            // Guard that the constant's base class (in rax) matches the cached
-            // one. Mirrors x86 GuardConstBaseClass.
-            AsmInst::GuardConstBaseClass { base_class, deopt } => {
-                let deopt = labels[deopt].clone();
-                let rax = GP::Rax.a64().0;
-                let cached = base_class.id() as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x10, (cached);
-                    cmp x(rax), x10;
-                );
-                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
-                true
-            }
-            // Store to a constant via set_constant(vm, globals, id, val), bumping
-            // the global constant version. Bails if any xmm is live.
-            AsmInst::StoreConstant { id, using_xmm, error } => {
-                if using_xmm.iter().any(|b| *b) {
-                    return false;
-                }
-                let error = labels[error].clone();
-                let cv_addr = self
-                    .jit
-                    .get_label_address(&self.const_version_label())
-                    .as_ptr() as u64;
-                let f = runtime::set_constant as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x3, x0;                 // val (was in rax)
-                    mov x0, x19;                // vm
-                    mov x1, x20;                // globals
-                    mov x2, (id.0 as u64);      // ConstSiteId
-                    mov x9, (cv_addr);
-                    ldr x10, [x9];
-                    add x10, x10, #(1u32);
-                    str x10, [x9];              // bump global const version
-                    str x30, [sp, #-16]!;
-                    mov x9, (f);
-                    blr x9;
-                    ldr x30, [sp], #16;
-                    cbz x0, error;              // None -> error
                 );
                 true
             }


### PR DESCRIPTION
## Summary

Continues sharing the AsmIR→machine-code lowering between the x86-64 and aarch64 JIT backends, on top of #647. Moves four more instruction families (21 instructions) out of the two parallel per-arch matches and into the arch-neutral `compile_asmir` dispatcher, behind small per-arch **emission primitives**.

Each commit is behaviour-neutral and keeps both arches green; the series can be reviewed commit-by-commit.

## Commits

1. **slice 5 — constant family.** `GuardConstBaseClass`, `GuardConstVersion`, `StoreConstant` behind `emit_guard_const_base_class` / `emit_guard_const_version` / `emit_store_constant`. Shares the `labels[deopt]` / `labels[error]` side-exit lookup.

2. **slice 6 — variable access.** `LoadGVar`, `StoreGVar`, `LoadCVar`, `LoadDynVar`, `StoreDynVar` behind `emit_load_gvar` / `emit_store_gvar` / `emit_load_cvar` / `emit_load_dyn_var` / `emit_store_dyn_var`. (`CheckCVar`/`StoreCVar` and the `*Specialized` dyn-var variants stay per-arch — x86-only.)

3. **slice 7 — runtime allocation.** `CreateArray`, `NewArray`, `NewHash`, `NewRange`, `ConcatStr`, `ToA`, `DeepCopyLit` behind `emit_create_array` / `emit_new_array` / `emit_new_hash` / `emit_new_range` / `emit_concat_str` / `emit_to_a` / `emit_deep_copy_lit`.

4. **slice 8 — FP transfer/convert.** `FprMove`, `FprSwap`, `F64ToFpr`, `FixnumToFpr`, `FloatToFpr`, `FprToStack` behind `emit_fpr_move` / `emit_fpr_swap` / `emit_f64_to_fpr` / `emit_fixnum_to_fpr` / `emit_float_to_fpr` / `emit_fpr_to_stack`. On x86 the existing `emit_xmm_move`/`emit_fpr_swap` spill-aware helpers become the primitives directly.

## Design

Same pattern as #647: the arch-neutral dispatcher owns the match arm and the label/side-exit resolution, and calls a tiny per-arch primitive (`pub(in crate::codegen::jitgen)` method on `Codegen`). Most of these primitives return `bool` because the aarch64 path bails (live xmm with no FP save/restore yet, an out-of-range 12-bit frame offset, or an unlowerable FP pool register); the dispatcher propagates the bail so the method stays VM-interpreted. The x86 primitives delegate to the existing helpers and always succeed.

## Deliberately *not* shared here

- **`XmmSave` / `XmmRestore`** — FP save/restore around C-calls; left for a follow-up slice.
- **`CheckCVar` / `StoreCVar`**, the `*Specialized` variants, `FloatBinOp` / `FloatCmp` / `I64ToBoth` — x86-only or not-yet-uniform; stay per-arch.
- **`GuardClassVersion` / `CheckBOP` / `RecompileDeopt`** — semantics differ (recompile vs deopt; two-page cold layout), as in #647.

## Verification

Every commit:
- `cargo check` green on x86-64 and aarch64 — no new warnings.
- x86 `arith` test unchanged (the lone `defined` failure pre-exists on darwin).
- aarch64 run under qemu-user, byte-identical to CRuby and to x86, exercising each slice's instructions:
  - slice 5: constant define + hot-loop reads (`FOO + 1`, `C::PI * r * r`) → 43000, 6280.000000000054, hellohello, 0
  - slice 6: `$gvar` accumulator, `@@cvar` counter, closure outer-local capture, nested closures → 499500, 500, 5050, 20
  - slice 7: array/hash/range literals + splat, string interpolation, `[*x]`, fresh mutable literal → 500500, 10, 249500, 10, v=7/49, 300, 6, 5, 300
  - slice 8: float polynomial, Integer-in-float-context, Float-valued math, eight float locals (spill), tuple-swap → 167414750.0, 749250.0, 125.0, 1016000.0, 3.0

## Cumulative

With #647 (17 instructions) merged, this brings the arch-neutral `compile_asmir` dispatcher to 38 shared instructions.

https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT)_