### PR TITLE
jit: share floating-point AsmInst lowering between x86-64 and aarch64 (FP save/restore, integer & float arithmetic, unary, comparison)

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -74,7 +74,11 @@ impl Codegen {
             | AsmInst::FloatToFpr(..)
             | AsmInst::FprToStack(..)
             | AsmInst::XmmSave(..)
-            | AsmInst::XmmRestore(..) => {
+            | AsmInst::XmmRestore(..)
+            | AsmInst::IntegerBinOp { .. }
+            | AsmInst::IntegerCmp { .. }
+            | AsmInst::IntegerCmpBr { .. }
+            | AsmInst::FloatBinOp { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -166,11 +170,6 @@ impl Codegen {
                 );
             }
 
-            AsmInst::FloatBinOp {
-                kind,
-                binary_xmm,
-                dst,
-            } => self.float_binop(kind, dst, binary_xmm, frame.base_stack_offset),
             AsmInst::FloatUnOp { kind, dst } => match kind {
                 UnOpK::Neg => {
                     let imm = self.jit.const_i64(0x8000_0000_0000_0000u64 as i64);
@@ -464,34 +463,6 @@ impl Codegen {
                 }
             }
 
-            AsmInst::IntegerBinOp {
-                kind,
-                lhs,
-                rhs,
-                mode,
-                deopt,
-            } => {
-                let deopt = &labels[deopt];
-                self.integer_binop(lhs, rhs, &mode, kind, deopt);
-            }
-            AsmInst::IntegerCmp {
-                mode,
-                kind,
-                lhs,
-                rhs,
-            } => self.integer_cmp(kind, mode, lhs, rhs),
-            AsmInst::IntegerCmpBr {
-                mode,
-                kind,
-                lhs,
-                rhs,
-                brkind,
-                branch_dest,
-            } => {
-                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
-                self.cmp_integer(&mode, lhs, rhs);
-                self.condbr_int(kind, branch_dest, brkind);
-            }
             AsmInst::FloatCmp { kind, lhs, rhs } => {
                 monoasm! { &mut self.jit,
                     xorq rax, rax;
@@ -1573,6 +1544,59 @@ impl Codegen {
     /// Restore the live FP pool registers after a C-call.
     pub(in crate::codegen::jitgen) fn emit_xmm_restore(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
         self.xmm_restore_with_cont(using_xmm, cont);
+        true
+    }
+
+    /// Integer binary op fast path (guarded; deopts to `deopt` on overflow /
+    /// type miss). Always succeeds on x86 (the bool mirrors the aarch64 twin).
+    pub(in crate::codegen::jitgen) fn emit_integer_binop(
+        &mut self,
+        lhs: GP,
+        rhs: GP,
+        mode: OpMode,
+        kind: BinOpK,
+        deopt: DestLabel,
+    ) -> bool {
+        self.integer_binop(lhs, rhs, &mode, kind, &deopt);
+        true
+    }
+
+    /// Integer comparison; result Value lands in the accumulator.
+    pub(in crate::codegen::jitgen) fn emit_integer_cmp(
+        &mut self,
+        kind: CmpKind,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+    ) -> bool {
+        self.integer_cmp(kind, mode, lhs, rhs);
+        true
+    }
+
+    /// Fused integer compare + conditional branch to `branch_dest`.
+    pub(in crate::codegen::jitgen) fn emit_integer_cmp_br(
+        &mut self,
+        kind: CmpKind,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+        brkind: BrKind,
+        branch_dest: DestLabel,
+    ) -> bool {
+        self.cmp_integer(&mode, lhs, rhs);
+        self.condbr_int(kind, branch_dest, brkind);
+        true
+    }
+
+    /// Float (four-arithmetic) binary op: dst <- lhs <op> rhs in FP registers.
+    pub(in crate::codegen::jitgen) fn emit_float_binop(
+        &mut self,
+        kind: BinOpK,
+        binary_xmm: (FPReg, FPReg),
+        dst: FPReg,
+        base: usize,
+    ) -> bool {
+        self.float_binop(kind, dst, binary_xmm, base);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -80,7 +80,9 @@ impl Codegen {
             | AsmInst::IntegerCmpBr { .. }
             | AsmInst::FloatBinOp { .. }
             | AsmInst::FloatUnOp { .. }
-            | AsmInst::I64ToBoth(..) => {
+            | AsmInst::I64ToBoth(..)
+            | AsmInst::FloatCmp { .. }
+            | AsmInst::FloatCmpBr { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -430,25 +432,6 @@ impl Codegen {
                     salq  R(r), 1;
                     orq   R(r), 1;
                 }
-            }
-
-            AsmInst::FloatCmp { kind, lhs, rhs } => {
-                monoasm! { &mut self.jit,
-                    xorq rax, rax;
-                };
-                self.cmp_float((lhs, rhs), frame.base_stack_offset);
-                self.setflag_float(kind);
-            }
-            AsmInst::FloatCmpBr {
-                kind,
-                lhs,
-                rhs,
-                brkind,
-                branch_dest,
-            } => {
-                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
-                self.cmp_float((lhs, rhs), frame.base_stack_offset);
-                self.condbr_float(kind, branch_dest, brkind);
             }
 
             AsmInst::GenericBinOp {
@@ -1606,6 +1589,31 @@ impl Codegen {
                 movq [rbp - (off)], xmm0;
             ),
         }
+        true
+    }
+
+    /// Float comparison; NaN-correct boolean Value lands in the accumulator.
+    pub(in crate::codegen::jitgen) fn emit_float_cmp(&mut self, kind: CmpKind, lhs: FPReg, rhs: FPReg, base: usize) -> bool {
+        monoasm! { &mut self.jit,
+            xorq rax, rax;
+        };
+        self.cmp_float((lhs, rhs), base);
+        self.setflag_float(kind);
+        true
+    }
+
+    /// Fused float compare + conditional branch (NaN compares false except `!=`).
+    pub(in crate::codegen::jitgen) fn emit_float_cmp_br(
+        &mut self,
+        kind: CmpKind,
+        lhs: FPReg,
+        rhs: FPReg,
+        brkind: BrKind,
+        branch_dest: DestLabel,
+        base: usize,
+    ) -> bool {
+        self.cmp_float((lhs, rhs), base);
+        self.condbr_float(kind, branch_dest, brkind);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -72,7 +72,9 @@ impl Codegen {
             | AsmInst::F64ToFpr(..)
             | AsmInst::FixnumToFpr(..)
             | AsmInst::FloatToFpr(..)
-            | AsmInst::FprToStack(..) => {
+            | AsmInst::FprToStack(..)
+            | AsmInst::XmmSave(..)
+            | AsmInst::XmmRestore(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -257,8 +259,6 @@ impl Codegen {
                 );
                 self.jit.select_page(0);
             }
-            AsmInst::XmmSave(using_xmm, cont) => self.xmm_save_with_cont(using_xmm, cont),
-            AsmInst::XmmRestore(using_xmm, cont) => self.xmm_restore_with_cont(using_xmm, cont),
             AsmInst::SetArguments { callid, callee_fid } => {
                 let offset = store[callee_fid].get_offset();
                 self.jit_set_arguments(callid, callee_fid, offset);
@@ -1560,6 +1560,19 @@ impl Codegen {
     /// [slot] <- box(xmm(x)) (flonum-encode or heap-allocate the f64).
     pub(in crate::codegen::jitgen) fn emit_fpr_to_stack(&mut self, x: FPReg, slot: SlotId, base: usize) -> bool {
         self.fpr_to_stack(x, &[slot], base);
+        true
+    }
+
+    /// Save the live FP pool registers before a C-call. Always succeeds on x86
+    /// (the bool result mirrors the aarch64 twin).
+    pub(in crate::codegen::jitgen) fn emit_xmm_save(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
+        self.xmm_save_with_cont(using_xmm, cont);
+        true
+    }
+
+    /// Restore the live FP pool registers after a C-call.
+    pub(in crate::codegen::jitgen) fn emit_xmm_restore(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
+        self.xmm_restore_with_cont(using_xmm, cont);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -78,7 +78,9 @@ impl Codegen {
             | AsmInst::IntegerBinOp { .. }
             | AsmInst::IntegerCmp { .. }
             | AsmInst::IntegerCmpBr { .. }
-            | AsmInst::FloatBinOp { .. } => {
+            | AsmInst::FloatBinOp { .. }
+            | AsmInst::FloatUnOp { .. }
+            | AsmInst::I64ToBoth(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Init {
@@ -170,39 +172,6 @@ impl Codegen {
                 );
             }
 
-            AsmInst::FloatUnOp { kind, dst } => match kind {
-                UnOpK::Neg => {
-                    let imm = self.jit.const_i64(0x8000_0000_0000_0000u64 as i64);
-                    match dst.loc(frame.base_stack_offset) {
-                        FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                            xorps xmm(p), [rip + imm];
-                        ),
-                        FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                            movq  xmm0, [rbp - (off)];
-                            xorps xmm0, [rip + imm];
-                            movq  [rbp - (off)], xmm0;
-                        ),
-                    }
-                }
-                UnOpK::Pos => {}
-                _ => unreachable!(),
-            },
-
-            AsmInst::I64ToBoth(i, r, x) => {
-                let f = self.jit.const_f64(i as f64);
-                monoasm! {&mut self.jit,
-                    movq [rbp - (rbp_local(r))], (Value::integer(i).id());
-                }
-                match x.loc(frame.base_stack_offset) {
-                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                        movq xmm(p), [rip + f];
-                    ),
-                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                        movq xmm0, [rip + f];
-                        movq [rbp - (off)], xmm0;
-                    ),
-                }
-            }
             AsmInst::GuardArrayTy(r, deopt) => {
                 let deopt = &labels[deopt];
                 self.guard_array_ty(r, deopt)
@@ -1597,6 +1566,46 @@ impl Codegen {
         base: usize,
     ) -> bool {
         self.float_binop(kind, dst, binary_xmm, base);
+        true
+    }
+
+    /// Float unary op: negate (flip the sign bit) or unary-plus (no-op).
+    pub(in crate::codegen::jitgen) fn emit_float_unop(&mut self, kind: UnOpK, dst: FPReg, base: usize) -> bool {
+        match kind {
+            UnOpK::Neg => {
+                let imm = self.jit.const_i64(0x8000_0000_0000_0000u64 as i64);
+                match dst.loc(base) {
+                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                        xorps xmm(p), [rip + imm];
+                    ),
+                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                        movq  xmm0, [rbp - (off)];
+                        xorps xmm0, [rip + imm];
+                        movq  [rbp - (off)], xmm0;
+                    ),
+                }
+            }
+            UnOpK::Pos => {}
+            _ => unreachable!(),
+        }
+        true
+    }
+
+    /// [slot] <- box(i) (integer Value) and fpr(x) <- i as f64.
+    pub(in crate::codegen::jitgen) fn emit_i64_to_both(&mut self, i: i64, slot: SlotId, x: FPReg, base: usize) -> bool {
+        let f = self.jit.const_f64(i as f64);
+        monoasm! {&mut self.jit,
+            movq [rbp - (rbp_local(slot))], (Value::integer(i).id());
+        }
+        match x.loc(base) {
+            FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                movq xmm(p), [rip + f];
+            ),
+            FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                movq xmm0, [rip + f];
+                movq [rbp - (off)], xmm0;
+            ),
+        }
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -151,6 +151,41 @@ impl Codegen {
             // Save / restore live FP pool registers around a C-call.
             AsmInst::XmmSave(using_xmm, cont) => return self.emit_xmm_save(using_xmm, cont),
             AsmInst::XmmRestore(using_xmm, cont) => return self.emit_xmm_restore(using_xmm, cont),
+            // Integer / float arithmetic fast paths. Each backend resolves the
+            // same operands and dispatches to its own emission primitive
+            // (aarch64 bails on an unsupported BinOpK, hence the bool results).
+            AsmInst::IntegerBinOp {
+                kind,
+                lhs,
+                rhs,
+                mode,
+                deopt,
+            } => {
+                let deopt = labels[deopt].clone();
+                return self.emit_integer_binop(lhs, rhs, mode, kind, deopt);
+            }
+            AsmInst::IntegerCmp {
+                mode,
+                kind,
+                lhs,
+                rhs,
+            } => return self.emit_integer_cmp(kind, mode, lhs, rhs),
+            AsmInst::IntegerCmpBr {
+                mode,
+                kind,
+                lhs,
+                rhs,
+                brkind,
+                branch_dest,
+            } => {
+                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
+                return self.emit_integer_cmp_br(kind, mode, lhs, rhs, brkind, branch_dest);
+            }
+            AsmInst::FloatBinOp {
+                kind,
+                binary_xmm,
+                dst,
+            } => return self.emit_float_binop(kind, binary_xmm, dst, frame.base_stack_offset),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -186,6 +186,14 @@ impl Codegen {
                 binary_xmm,
                 dst,
             } => return self.emit_float_binop(kind, binary_xmm, dst, frame.base_stack_offset),
+            AsmInst::FloatUnOp { kind, dst } => {
+                return self.emit_float_unop(kind, dst, frame.base_stack_offset);
+            }
+            // [slot] <- Value::integer(i) and fpr(x) <- i as f64 (constant int
+            // materialized as both a boxed integer and a double).
+            AsmInst::I64ToBoth(i, slot, x) => {
+                return self.emit_i64_to_both(i, slot, x, frame.base_stack_offset);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -194,6 +194,29 @@ impl Codegen {
             AsmInst::I64ToBoth(i, slot, x) => {
                 return self.emit_i64_to_both(i, slot, x, frame.base_stack_offset);
             }
+            // Float comparison. NaN compares false (except `!=`); each backend
+            // picks NaN-correct condition codes (x86 ucomisd + setp tricks,
+            // aarch64 fcmp + MI/LS conditions).
+            AsmInst::FloatCmp { kind, lhs, rhs } => {
+                return self.emit_float_cmp(kind, lhs, rhs, frame.base_stack_offset);
+            }
+            AsmInst::FloatCmpBr {
+                kind,
+                lhs,
+                rhs,
+                brkind,
+                branch_dest,
+            } => {
+                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
+                return self.emit_float_cmp_br(
+                    kind,
+                    lhs,
+                    rhs,
+                    brkind,
+                    branch_dest,
+                    frame.base_stack_offset,
+                );
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -148,6 +148,9 @@ impl Codegen {
             AsmInst::FprToStack(x, slot) => {
                 return self.emit_fpr_to_stack(x, slot, frame.base_stack_offset);
             }
+            // Save / restore live FP pool registers around a C-call.
+            AsmInst::XmmSave(using_xmm, cont) => return self.emit_xmm_save(using_xmm, cont),
+            AsmInst::XmmRestore(using_xmm, cont) => return self.emit_xmm_restore(using_xmm, cont),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1329,6 +1329,46 @@ impl Codegen {
         true
     }
 
+    /// Save the live FP pool registers (D2..) below sp before a C-call.
+    pub(in crate::codegen::jitgen) fn emit_xmm_save(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
+        if using_xmm.not_any() && !cont {
+            return true;
+        }
+        let sp_offset =
+            (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
+        monoasm_arm64!(&mut self.jit, sub sp, sp, #(sp_offset););
+        let mut i = 0u32;
+        for (xi, b) in using_xmm.iter().enumerate() {
+            if *b {
+                let pr = xi as u32 + 2;
+                let ofs = 8 * i;
+                monoasm_arm64!(&mut self.jit, str d(pr), [sp, #(ofs)];);
+                i += 1;
+            }
+        }
+        true
+    }
+
+    /// Restore the live FP pool registers and pop the save area after a C-call.
+    pub(in crate::codegen::jitgen) fn emit_xmm_restore(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
+        if using_xmm.not_any() && !cont {
+            return true;
+        }
+        let sp_offset =
+            (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
+        let mut i = 0u32;
+        for (xi, b) in using_xmm.iter().enumerate() {
+            if *b {
+                let pr = xi as u32 + 2;
+                let ofs = 8 * i;
+                monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
+                i += 1;
+            }
+        }
+        monoasm_arm64!(&mut self.jit, add sp, sp, #(sp_offset););
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -1496,43 +1536,6 @@ impl Codegen {
                     BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
                     _ => return false,
                 }
-                true
-            }
-            // Save / restore live FP pool registers around a C-call.
-            AsmInst::XmmSave(using_xmm, cont) => {
-                if using_xmm.not_any() && !cont {
-                    return true;
-                }
-                let sp_offset =
-                    (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
-                monoasm_arm64!(&mut self.jit, sub sp, sp, #(sp_offset););
-                let mut i = 0u32;
-                for (xi, b) in using_xmm.iter().enumerate() {
-                    if *b {
-                        let pr = xi as u32 + 2;
-                        let ofs = 8 * i;
-                        monoasm_arm64!(&mut self.jit, str d(pr), [sp, #(ofs)];);
-                        i += 1;
-                    }
-                }
-                true
-            }
-            AsmInst::XmmRestore(using_xmm, cont) => {
-                if using_xmm.not_any() && !cont {
-                    return true;
-                }
-                let sp_offset =
-                    (using_xmm.offset() + if cont { CONTINUATION_FRAME_SIZE } else { 0 }) as u32;
-                let mut i = 0u32;
-                for (xi, b) in using_xmm.iter().enumerate() {
-                    if *b {
-                        let pr = xi as u32 + 2;
-                        let ofs = 8 * i;
-                        monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
-                        i += 1;
-                    }
-                }
-                monoasm_arm64!(&mut self.jit, add sp, sp, #(sp_offset););
                 true
             }
             // Phase 3b: more AsmInst lowerings land here, one category at a time.

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1440,6 +1440,49 @@ impl Codegen {
         true
     }
 
+    /// Float unary op: negate (flip bit 63) or unary-plus (no-op). The macro
+    /// lacks `fneg`, so the sign flip goes through a GPR (`fmov`/`eor`/`fmov`).
+    /// Bails (`false`) on a spilled operand or an unsupported `UnOpK`.
+    pub(in crate::codegen::jitgen) fn emit_float_unop(&mut self, kind: UnOpK, dst: FPReg, base: usize) -> bool {
+        match kind {
+            UnOpK::Neg => {
+                let Some(p) = self.a64_fpr(dst, base) else {
+                    return false;
+                };
+                monoasm_arm64!(&mut self.jit,
+                    fmov x9, d(p);
+                    mov x10, (0x8000_0000_0000_0000u64);
+                    eor x9, x9, x10;
+                    fmov d(p), x9;
+                );
+            }
+            UnOpK::Pos => {}
+            _ => return false,
+        }
+        true
+    }
+
+    /// `[lfp - slot*8 - LFP_SELF] <- Value::integer(i)` and `fpr(x) <- i as f64`
+    /// (a constant int materialized as both a boxed integer and a double).
+    /// Bails (`false`) if the FP destination is not lowerable (spilled).
+    pub(in crate::codegen::jitgen) fn emit_i64_to_both(&mut self, i: i64, slot: SlotId, x: FPReg, base: usize) -> bool {
+        let Some(p) = self.a64_fpr(x, base) else {
+            return false;
+        };
+        let lfp = GP::R14.a64().0;
+        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+        let id = Value::integer(i).id();
+        let bits = (i as f64).to_bits();
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (id);
+            sub x10, x(lfp), #(off);
+            str x9, [x10];
+            mov x9, (bits);
+            fmov d(p), x9;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -38,6 +38,34 @@ fn a64_cond_for_cmp(kind: CmpKind, brkind: BrKind) -> monoasm::Cond {
     }
 }
 
+/// Like `a64_cond_for_cmp` but for `fcmp`: NaN (unordered) must compare false
+/// for every operator except `!=`. After `fcmp`, NZCV is set so that `<` needs
+/// `MI` (not `LT`, which is true when unordered) and `<=` needs `LS` (not `LE`);
+/// the inverse for `BrIfNot` is always the ARM bit-complement of the condition.
+fn a64_float_cond_for_cmp(kind: CmpKind, brkind: BrKind) -> monoasm::Cond {
+    use monoasm::Cond;
+    let taken = match kind {
+        CmpKind::Eq | CmpKind::TEq => Cond::Eq,
+        CmpKind::Ne => Cond::Ne,
+        CmpKind::Lt => Cond::Mi,
+        CmpKind::Le => Cond::Ls,
+        CmpKind::Gt => Cond::Gt,
+        CmpKind::Ge => Cond::Ge,
+    };
+    match brkind {
+        BrKind::BrIf => taken,
+        BrKind::BrIfNot => match taken {
+            Cond::Eq => Cond::Ne,
+            Cond::Ne => Cond::Eq,
+            Cond::Mi => Cond::Pl,
+            Cond::Ls => Cond::Hi,
+            Cond::Gt => Cond::Le,
+            Cond::Ge => Cond::Lt,
+            other => other,
+        },
+    }
+}
+
 impl Codegen {
     /// Drive AsmIR→A64 lowering for a whole method. Returns `false` (bail) if
     /// anything is not yet supported; the caller then keeps the method on the
@@ -1480,6 +1508,45 @@ impl Codegen {
             mov x9, (bits);
             fmov d(p), x9;
         );
+        true
+    }
+
+    /// Float comparison; NaN-correct boolean Value in the accumulator. Mirrors
+    /// `a64_flag_to_bool` but on `fcmp` flags with float condition codes. Bails
+    /// (`false`) if either operand is spilled.
+    pub(in crate::codegen::jitgen) fn emit_float_cmp(&mut self, kind: CmpKind, lhs: FPReg, rhs: FPReg, base: usize) -> bool {
+        let (Some(lp), Some(rp)) = (self.a64_fpr(lhs, base), self.a64_fpr(rhs, base)) else {
+            return false;
+        };
+        monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
+        let cond = a64_float_cond_for_cmp(kind, BrKind::BrIf);
+        let rax = GP::Rax.a64();
+        self.jit.cset(rax, cond);
+        monoasm_arm64!(&mut self.jit,
+            lsl x(rax.0), x(rax.0), #(3u32);
+            mov x9, (FALSE_VALUE);
+            orr x(rax.0), x(rax.0), x9;
+        );
+        true
+    }
+
+    /// Fused float compare + conditional branch (NaN compares false except
+    /// `!=`). Bails (`false`) if either operand is spilled.
+    pub(in crate::codegen::jitgen) fn emit_float_cmp_br(
+        &mut self,
+        kind: CmpKind,
+        lhs: FPReg,
+        rhs: FPReg,
+        brkind: BrKind,
+        branch_dest: DestLabel,
+        base: usize,
+    ) -> bool {
+        let (Some(lp), Some(rp)) = (self.a64_fpr(lhs, base), self.a64_fpr(rhs, base)) else {
+            return false;
+        };
+        monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
+        let cond = a64_float_cond_for_cmp(kind, brkind);
+        self.jit.bcond_label(cond, &branch_dest);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1369,6 +1369,77 @@ impl Codegen {
         true
     }
 
+    /// Integer binary op fast path (guarded; deopts to `deopt`). Independent of
+    /// `inline_gen`; emitted when the inline cache says both operands are
+    /// Integer. Bails (`false`) on an unsupported `BinOpK`.
+    pub(in crate::codegen::jitgen) fn emit_integer_binop(
+        &mut self,
+        lhs: GP,
+        rhs: GP,
+        mode: OpMode,
+        kind: BinOpK,
+        deopt: DestLabel,
+    ) -> bool {
+        self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt)
+    }
+
+    /// Integer comparison; result Value lands in the accumulator.
+    pub(in crate::codegen::jitgen) fn emit_integer_cmp(
+        &mut self,
+        kind: CmpKind,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+    ) -> bool {
+        self.a64_cmp_integer(&mode, lhs, rhs);
+        self.a64_flag_to_bool(kind);
+        true
+    }
+
+    /// Fused integer compare + conditional branch to `branch_dest`.
+    pub(in crate::codegen::jitgen) fn emit_integer_cmp_br(
+        &mut self,
+        kind: CmpKind,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+        brkind: BrKind,
+        branch_dest: DestLabel,
+    ) -> bool {
+        self.a64_cmp_integer(&mode, lhs, rhs);
+        let cond = a64_cond_for_cmp(kind, brkind);
+        self.jit.bcond_label(cond, &branch_dest);
+        true
+    }
+
+    /// Float (four-arithmetic) binary op: dst <- lhs <op> rhs in D-registers.
+    /// Bails (`false`) if an operand is not lowerable or `kind` is unsupported.
+    pub(in crate::codegen::jitgen) fn emit_float_binop(
+        &mut self,
+        kind: BinOpK,
+        binary_xmm: (FPReg, FPReg),
+        dst: FPReg,
+        base: usize,
+    ) -> bool {
+        let (l, r) = binary_xmm;
+        let (Some(ld), Some(rd), Some(dd)) = (
+            self.a64_fpr(l, base),
+            self.a64_fpr(r, base),
+            self.a64_fpr(dst, base),
+        ) else {
+            return false;
+        };
+        // aarch64 FP 3-op writes rd, reads rn/rm — no aliasing hazard.
+        match kind {
+            BinOpK::Add => monoasm_arm64!(&mut self.jit, fadd d(dd), d(ld), d(rd);),
+            BinOpK::Sub => monoasm_arm64!(&mut self.jit, fsub d(dd), d(ld), d(rd);),
+            BinOpK::Mul => monoasm_arm64!(&mut self.jit, fmul d(dd), d(ld), d(rd);),
+            BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
+            _ => return false,
+        }
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).
@@ -1493,51 +1564,6 @@ impl Codegen {
             // a64 cannot patch return addresses, so this is a no-op (class
             // version guards cover the staleness it would otherwise catch).
             AsmInst::ImmediateEvict { .. } => true,
-            // Inline integer fast paths (independent of inline_gen; emitted by
-            // the BinOp/Cmp bytecode opcodes when the inline cache says both
-            // operands are Integer).
-            AsmInst::IntegerBinOp { kind, lhs, rhs, mode, deopt } => {
-                let deopt = labels[deopt].clone();
-                self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt)
-            }
-            AsmInst::IntegerCmp { mode, kind, lhs, rhs } => {
-                self.a64_cmp_integer(&mode, lhs, rhs);
-                self.a64_flag_to_bool(kind);
-                true
-            }
-            AsmInst::IntegerCmpBr { mode, kind, lhs, rhs, brkind, branch_dest } => {
-                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
-                self.a64_cmp_integer(&mode, lhs, rhs);
-                let cond = a64_cond_for_cmp(kind, brkind);
-                self.jit.bcond_label(cond, &branch_dest);
-                true
-            }
-            // ---- floating point (four-arithmetic) ----
-            // dst <- lhs <op> rhs  (D-register arithmetic)
-            AsmInst::FloatBinOp {
-                kind,
-                binary_xmm,
-                dst,
-            } => {
-                let base = frame.base_stack_offset;
-                let (l, r) = binary_xmm;
-                let (Some(ld), Some(rd), Some(dd)) = (
-                    self.a64_fpr(l, base),
-                    self.a64_fpr(r, base),
-                    self.a64_fpr(dst, base),
-                ) else {
-                    return false;
-                };
-                // aarch64 FP 3-op writes rd, reads rn/rm — no aliasing hazard.
-                match kind {
-                    BinOpK::Add => monoasm_arm64!(&mut self.jit, fadd d(dd), d(ld), d(rd);),
-                    BinOpK::Sub => monoasm_arm64!(&mut self.jit, fsub d(dd), d(ld), d(rd);),
-                    BinOpK::Mul => monoasm_arm64!(&mut self.jit, fmul d(dd), d(ld), d(rd);),
-                    BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
-                    _ => return false,
-                }
-                true
-            }
             // Phase 3b: more AsmInst lowerings land here, one category at a time.
             _ => false,
         }


### PR DESCRIPTION
## Summary

Continues the x86-64/aarch64 JIT emission-sharing work (#647, #648), moving the
**floating-point family** plus the **integer/float arithmetic fast paths** into
the arch-neutral `compile_asmir` dispatcher. Each instruction now resolves its
shared operands/labels once and dispatches to a tiny per-arch emission
primitive (`emit_*`); the duplicated `monoasm!` / `monoasm_arm64!` arms are
deleted from both backends.

After this PR the floating-point register transfer / arithmetic / unary /
comparison family is fully shared, and several of these instructions gained a
**real aarch64 lowering** for the first time (they previously fell into the
`_ => false` bail and kept the method on the VM).

## What's shared (10 instructions, 4 slices)

| Slice | Instructions | aarch64 status |
|-------|--------------|----------------|
| 9  | `XmmSave`, `XmmRestore` | already implemented — relocated |
| 10 | `IntegerBinOp`, `IntegerCmp`, `IntegerCmpBr`, `FloatBinOp` | already implemented — relocated |
| 11 | `FloatUnOp`, `I64ToBoth` | **newly ported to aarch64** |
| 12 | `FloatCmp`, `FloatCmpBr` | **newly ported to aarch64** |

Each backend keeps its own emission idiom behind the primitive:

- **x86** delegates to the existing helpers (`integer_binop`, `float_binop`,
  `cmp_float`/`setflag_float`/`condbr_float`, `xmm_save_with_cont`, …) and
  always returns `true`.
- **aarch64** uses `monoasm_arm64!` and bails (`false`) when an FP pool
  register is spilled (`a64_fpr` → `None`), consistent with the rest of the
  family.

### Notable aarch64 details

- **`FloatUnOp` negate** flips bit 63 through a GPR (`fmov`/`eor`/`fmov`) — the
  assembler macro has no `fneg`.
- **`I64ToBoth`** stores the boxed-int immediate to `[lfp - slot*8 - LFP_SELF]`
  and loads the f64 bit pattern into the D-register.
- **`FloatCmp`/`FloatCmpBr`** need NaN-correct condition codes: a new
  `a64_float_cond_for_cmp` picks `MI` for `<` and `LS` for `<=` (the integer
  `LT`/`LE` are *true* when unordered), with the `BrIfNot` inverse being the
  ARM bit-complement. NaN compares false for every operator except `!=`.

## Verification

- `cargo check` green on both `x86_64-unknown-linux-gnu` and
  `aarch64-unknown-linux-gnu`, no new warnings.
- x86 `arith` integration test unchanged (58 passed; the lone `defined`
  failure pre-exists this branch and is unrelated to codegen).
- Behavioural equivalence checked per slice with programs exercising the
  relevant ops (collatz/prime sieve for integer arithmetic, mandelbrot for
  float arithmetic, unary minus on accumulators, and a full float-comparison
  table over ordered pairs / ±inf / signed zero / **every NaN combination**).
  Output is **byte-identical on x86-64 and aarch64** (the latter under qemu)
  and matches CRuby.

Behavior-neutral by construction: every primitive emits exactly what the
per-arch arm did; the only new code paths are the aarch64 lowerings that
previously bailed to the VM.

https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT)_