### PR TITLE
jit: port object field access (inline/heap ivar &amp; struct) and RegAdd/RegSub to aarch64

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -97,7 +97,11 @@ impl Codegen {
             | AsmInst::FixnumNeg { .. }
             | AsmInst::FixnumBitNot { .. }
             | AsmInst::GuardArrayTy(..)
-            | AsmInst::GuardFrozen { .. } => {
+            | AsmInst::GuardFrozen { .. }
+            | AsmInst::LoadIVarInline { .. }
+            | AsmInst::StoreIVarInline { .. }
+            | AsmInst::LoadStructSlotInline { .. }
+            | AsmInst::StoreStructSlotInline { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::LoopJitRspBump { offset } => {
@@ -364,7 +368,6 @@ impl Codegen {
                 is_object_ty,
                 self_,
             } => self.load_ivar_heap(ivarid, is_object_ty, self_),
-            AsmInst::LoadIVarInline { ivarid } => self.load_ivar_inline(ivarid),
             AsmInst::StoreIVarHeap {
                 src,
                 ivarid,
@@ -376,14 +379,7 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
             } => self.store_self_ivar_heap(src, ivarid, is_object_ty),
-            AsmInst::StoreIVarInline { src, ivarid } => self.store_ivar_object_inline(src, ivarid),
-            AsmInst::LoadStructSlotInline { slot_index } => {
-                self.load_struct_slot_inline(slot_index)
-            }
             AsmInst::LoadStructSlotHeap { slot_index } => self.load_struct_slot_heap(slot_index),
-            AsmInst::StoreStructSlotInline { src, slot_index } => {
-                self.store_struct_slot_inline(src, slot_index)
-            }
             AsmInst::StoreStructSlotHeap { src, slot_index } => {
                 self.store_struct_slot_heap(src, slot_index)
             }
@@ -1677,5 +1673,30 @@ impl Codegen {
     /// Guard that the receiver in rdi is not frozen; deopt otherwise.
     pub(in crate::codegen::jitgen) fn emit_guard_frozen(&mut self, deopt: &DestLabel) {
         self.guard_frozen(deopt);
+    }
+
+    /// Load an inline (object-embedded) instance variable into the accumulator,
+    /// substituting nil for an unset slot.
+    pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
+        self.load_ivar_inline(ivarid);
+        true
+    }
+
+    /// Store the accumulator-side `src` into an inline instance-variable slot.
+    pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
+        self.store_ivar_object_inline(src, ivarid);
+        true
+    }
+
+    /// Load an inline Struct member slot into the accumulator.
+    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_inline(&mut self, slot_index: u16) -> bool {
+        self.load_struct_slot_inline(slot_index);
+        true
+    }
+
+    /// Store `src` into an inline Struct member slot (also returned in rax).
+    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
+        self.store_struct_slot_inline(src, slot_index);
+        true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -101,7 +101,11 @@ impl Codegen {
             | AsmInst::LoadIVarInline { .. }
             | AsmInst::StoreIVarInline { .. }
             | AsmInst::LoadStructSlotInline { .. }
-            | AsmInst::StoreStructSlotInline { .. } => {
+            | AsmInst::StoreStructSlotInline { .. }
+            | AsmInst::LoadStructSlotHeap { .. }
+            | AsmInst::StoreStructSlotHeap { .. }
+            | AsmInst::RegAdd(..)
+            | AsmInst::RegSub(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::LoopJitRspBump { offset } => {
@@ -117,22 +121,6 @@ impl Codegen {
                     movq rax, (unreachable);
                     call rax;
                 );
-            }
-            AsmInst::RegAdd(r, i) => {
-                if i != 0 {
-                    let r = r as u64;
-                    monoasm! { &mut self.jit,
-                        addq R(r), (i);
-                    }
-                }
-            }
-            AsmInst::RegSub(r, i) => {
-                if i != 0 {
-                    let r = r as u64;
-                    monoasm! { &mut self.jit,
-                        subq R(r), (i);
-                    }
-                }
             }
             AsmInst::RegToRSPOffset(r, ofs) => {
                 let r = r as u64;
@@ -379,10 +367,6 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
             } => self.store_self_ivar_heap(src, ivarid, is_object_ty),
-            AsmInst::LoadStructSlotHeap { slot_index } => self.load_struct_slot_heap(slot_index),
-            AsmInst::StoreStructSlotHeap { src, slot_index } => {
-                self.store_struct_slot_heap(src, slot_index)
-            }
             AsmInst::CheckCVar { name, using_xmm } => {
                 self.check_cvar(name, using_xmm);
             }
@@ -1698,5 +1682,33 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
         self.store_struct_slot_inline(src, slot_index);
         true
+    }
+
+    /// Load a heap-spilled Struct member slot into the accumulator.
+    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_heap(&mut self, slot_index: u16) -> bool {
+        self.load_struct_slot_heap(slot_index);
+        true
+    }
+
+    /// Store `src` into a heap-spilled Struct member slot (also returned in rax).
+    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_heap(&mut self, src: GP, slot_index: u16) -> bool {
+        self.store_struct_slot_heap(src, slot_index);
+        true
+    }
+
+    /// reg += i (no-op when i == 0).
+    pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
+        if i != 0 {
+            let r = reg as u64;
+            monoasm! { &mut self.jit, addq R(r), (i); }
+        }
+    }
+
+    /// reg -= i (no-op when i == 0).
+    pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
+        if i != 0 {
+            let r = reg as u64;
+            monoasm! { &mut self.jit, subq R(r), (i); }
+        }
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -281,6 +281,19 @@ impl Codegen {
             // is unfrozen.
             AsmInst::GuardArrayTy(reg, deopt) => self.emit_guard_array_ty(reg, &labels[deopt]),
             AsmInst::GuardFrozen { deopt } => self.emit_guard_frozen(&labels[deopt]),
+            // Inline instance-variable / struct-member access on the receiver in
+            // rdi (no Box deref). aarch64 bails if the field offset exceeds the
+            // 12-bit scaled load/store immediate.
+            AsmInst::LoadIVarInline { ivarid } => return self.emit_load_ivar_inline(ivarid),
+            AsmInst::StoreIVarInline { src, ivarid } => {
+                return self.emit_store_ivar_inline(src, ivarid);
+            }
+            AsmInst::LoadStructSlotInline { slot_index } => {
+                return self.emit_load_struct_slot_inline(slot_index);
+            }
+            AsmInst::StoreStructSlotInline { src, slot_index } => {
+                return self.emit_store_struct_slot_inline(src, slot_index);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -294,6 +294,17 @@ impl Codegen {
             AsmInst::StoreStructSlotInline { src, slot_index } => {
                 return self.emit_store_struct_slot_inline(src, slot_index);
             }
+            // Heap (Box-spilled) Struct member access: deref the heap pointer
+            // first, then load/store the slot (aarch64 bails on a large offset).
+            AsmInst::LoadStructSlotHeap { slot_index } => {
+                return self.emit_load_struct_slot_heap(slot_index);
+            }
+            AsmInst::StoreStructSlotHeap { src, slot_index } => {
+                return self.emit_store_struct_slot_heap(src, slot_index);
+            }
+            // reg += i / reg -= i (no-op when i == 0).
+            AsmInst::RegAdd(reg, i) => self.emit_reg_add(reg, i),
+            AsmInst::RegSub(reg, i) => self.emit_reg_sub(reg, i),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1759,6 +1759,70 @@ impl Codegen {
         );
     }
 
+    /// `ldr`/`str` use a 12-bit scaled (×8) immediate offset; bail above that.
+    fn a64_field_off_ok(off: u32) -> bool {
+        off <= 32760 && off % 8 == 0
+    }
+
+    /// Load an inline (object-embedded) instance variable into the accumulator
+    /// (x23), substituting nil for an unset (zero) slot. Bails if the field
+    /// offset is out of the load immediate's range.
+    pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
+        let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let r15 = GP::R15.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            ldr x(r15), [x(rdi), #(off)];
+            mov x9, (NIL_VALUE);
+            cmp x(r15), #(0u32);
+            csel x(r15), x(r15), x9, ne;   // unset slot (0) -> nil
+        );
+        true
+    }
+
+    /// Store the accumulator-side `src` into an inline instance-variable slot.
+    pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
+        let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let s = src.a64().0;
+        monoasm_arm64!(&mut self.jit, str x(s), [x(rdi), #(off)];);
+        true
+    }
+
+    /// Load an inline Struct member slot into the accumulator (x23).
+    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_inline(&mut self, slot_index: u16) -> bool {
+        let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let r15 = GP::R15.a64().0;
+        monoasm_arm64!(&mut self.jit, ldr x(r15), [x(rdi), #(off)];);
+        true
+    }
+
+    /// Store `src` into an inline Struct member slot (also returned in rax/x0).
+    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
+        let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let s = src.a64().0;
+        let rax = GP::Rax.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            str x(s), [x(rdi), #(off)];
+            mov x(rax), x(s);
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1823,6 +1823,62 @@ impl Codegen {
         true
     }
 
+    /// Load a heap-spilled Struct member slot: deref the heap pointer (into rdi)
+    /// then load the slot into the accumulator (x23).
+    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_heap(&mut self, slot_index: u16) -> bool {
+        let off = slot_index as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let r15 = GP::R15.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            ldr x(r15), [x(rdi), #(off)];
+        );
+        true
+    }
+
+    /// Store `src` into a heap-spilled Struct member slot (also returned in
+    /// rax/x0). Derefs the heap pointer first (clobbering rdi, like x86).
+    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_heap(&mut self, src: GP, slot_index: u16) -> bool {
+        let off = slot_index as u32 * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let s = src.a64().0;
+        let rax = GP::Rax.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            str x(s), [x(rdi), #(off)];
+            mov x(rax), x(s);
+        );
+        true
+    }
+
+    /// reg += i (no-op when i == 0). `i` is materialized so any i32 works.
+    pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
+        if i != 0 {
+            let d = reg.a64().0;
+            monoasm_arm64!(&mut self.jit,
+                mov x9, (i as i64 as u64);
+                add x(d), x(d), x9;
+            );
+        }
+    }
+
+    /// reg -= i (no-op when i == 0).
+    pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
+        if i != 0 {
+            let d = reg.a64().0;
+            monoasm_arm64!(&mut self.jit,
+                mov x9, (i as i64 as u64);
+                sub x(d), x(d), x9;
+            );
+        }
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).


### PR DESCRIPTION
## Summary

Continues the x86-64/aarch64 JIT emission-sharing work (#647–#651), porting the
**object field-access and integer register-arithmetic** instructions to the
aarch64 backend (previously bailed) and routing them through the shared
`compile_asmir` dispatcher.

## What's ported (8 instructions, 2 slices)

| Slice | Instructions |
|-------|--------------|
| 19 | `LoadIVarInline`, `StoreIVarInline`, `LoadStructSlotInline`, `StoreStructSlotInline` |
| 20 | `LoadStructSlotHeap`, `StoreStructSlotHeap`, `RegAdd`, `RegSub` |

All eight gain a real aarch64 lowering (x86 keeps its existing helpers).

### aarch64 details

- **Inline ivar/struct** load/store the field at
  `[rdi + RVALUE_OFFSET_KIND/INLINE + idx*8]`. `LoadIVarInline` substitutes nil
  for an unset (zero) slot branchlessly via `cmp`/`csel`; struct stores also copy
  src to rax/x0 like x86.
- **Heap struct slots** deref `RVALUE_OFFSET_HEAP_PTR` first, then load/store.
- All field accessors bail (`false`) if the field offset exceeds the 12-bit
  scaled load/store immediate (rare; very large ivar/member counts).
- **`RegAdd`/`RegSub`** materialize the i32 immediate (`mov`+`add`/`sub`) so any
  value works; no-op when `i == 0`.

## Verification

- `cargo check` green on x86-64 and aarch64, no new warnings.
- Behavioural checks per slice: small objects (ivar load/store, `+=`, an unset
  ivar reading nil) + 3-member Structs; a 10-member heap-spilled Struct; and a
  hot loop with large constant `+=`/`-=`. Output is **byte-identical on x86-64
  and aarch64** (the latter under qemu) and matches CRuby
  (26991000 / 3000 / 6023000 and 8222000 / 4999985000).

Behavior-neutral on x86 (the primitives wrap the existing helpers); the only new
code paths are the aarch64 lowerings that previously bailed to the VM.

https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT)_