### PR TITLE
jit: port heap ivar access, loop-JIT stack bump, and first runtime-call ops (undef/alias-gvar) to aarch64

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -105,16 +105,10 @@ impl Codegen {
             | AsmInst::LoadStructSlotHeap { .. }
             | AsmInst::StoreStructSlotHeap { .. }
             | AsmInst::RegAdd(..)
-            | AsmInst::RegSub(..) => {
+            | AsmInst::RegSub(..)
+            | AsmInst::LoopJitRspBump { .. }
+            | AsmInst::StoreSelfIVarHeap { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
-            }
-            AsmInst::LoopJitRspBump { offset } => {
-                let bytes = offset.unwrap_concrete();
-                if bytes > 0 {
-                    monoasm! { &mut self.jit,
-                        subq rsp, (bytes as i32);
-                    }
-                }
             }
             AsmInst::Unreachable => {
                 monoasm!( &mut self.jit,
@@ -362,11 +356,6 @@ impl Codegen {
                 is_object_ty,
                 using_xmm,
             } => self.store_ivar_heap(src, ivarid, is_object_ty, using_xmm),
-            AsmInst::StoreSelfIVarHeap {
-                src,
-                ivarid,
-                is_object_ty,
-            } => self.store_self_ivar_heap(src, ivarid, is_object_ty),
             AsmInst::CheckCVar { name, using_xmm } => {
                 self.check_cvar(name, using_xmm);
             }
@@ -1710,5 +1699,26 @@ impl Codegen {
             let r = reg as u64;
             monoasm! { &mut self.jit, subq R(r), (i); }
         }
+    }
+
+    /// Loop-JIT entry: reserve the loop body's spill area on the native stack.
+    pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(&mut self, offset: LoopRspOffset) -> bool {
+        let bytes = offset.unwrap_concrete();
+        if bytes > 0 {
+            monoasm! { &mut self.jit, subq rsp, (bytes as i32); }
+        }
+        true
+    }
+
+    /// Store the accumulator-side `src` into a heap-spilled instance variable of
+    /// self (no bounds check; the table is pre-sized).
+    pub(in crate::codegen::jitgen) fn emit_store_self_ivar_heap(
+        &mut self,
+        src: GP,
+        ivarid: IvarId,
+        is_object_ty: bool,
+    ) -> bool {
+        self.store_self_ivar_heap(src, ivarid, is_object_ty);
+        true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -108,7 +108,9 @@ impl Codegen {
             | AsmInst::RegSub(..)
             | AsmInst::LoopJitRspBump { .. }
             | AsmInst::StoreSelfIVarHeap { .. }
-            | AsmInst::LoadIVarHeap { .. } => {
+            | AsmInst::LoadIVarHeap { .. }
+            | AsmInst::UndefMethod { .. }
+            | AsmInst::AliasGvar { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -457,17 +459,6 @@ impl Codegen {
             } => {
                 self.concat_regexp(arg, len, using_xmm);
             }
-            AsmInst::UndefMethod { undef, using_xmm } => {
-                self.xmm_save(using_xmm);
-                monoasm!( &mut self.jit,
-                    movq rdi, rbx;
-                    movq rsi, r12;
-                    movl rdx, (undef.get());
-                    movq rax, (runtime::undef_method);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
-            }
             AsmInst::AliasMethod {
                 new,
                 old,
@@ -480,21 +471,6 @@ impl Codegen {
                     movq rdx, [r14 - (conv(old))];
                     movq rcx, [r14 - (conv(new))];
                     movq rax, (runtime::alias_method);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
-            }
-            AsmInst::AliasGvar {
-                new,
-                old,
-                using_xmm,
-            } => {
-                self.xmm_save(using_xmm);
-                monoasm!( &mut self.jit,
-                    movq rdi, r12;          // &mut Globals
-                    movl rsi, (new.get());  // new IdentId
-                    movl rdx, (old.get());  // old IdentId
-                    movq rax, (runtime::alias_global_var);
                     call rax;
                 );
                 self.xmm_restore(using_xmm);
@@ -1727,6 +1703,34 @@ impl Codegen {
         self_: bool,
     ) -> bool {
         self.load_ivar_heap(ivarid, is_object_ty, self_);
+        true
+    }
+
+    /// `undef`-method via runtime::undef_method(vm, globals, id).
+    pub(in crate::codegen::jitgen) fn emit_undef_method(&mut self, undef: IdentId, using_xmm: UsingXmm) -> bool {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movl rdx, (undef.get());
+            movq rax, (runtime::undef_method);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        true
+    }
+
+    /// Alias a global var via runtime::alias_global_var(globals, new, old).
+    pub(in crate::codegen::jitgen) fn emit_alias_gvar(&mut self, new: IdentId, old: IdentId, using_xmm: UsingXmm) -> bool {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, r12;          // &mut Globals
+            movl rsi, (new.get());  // new IdentId
+            movl rdx, (old.get());  // old IdentId
+            movq rax, (runtime::alias_global_var);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -107,7 +107,8 @@ impl Codegen {
             | AsmInst::RegAdd(..)
             | AsmInst::RegSub(..)
             | AsmInst::LoopJitRspBump { .. }
-            | AsmInst::StoreSelfIVarHeap { .. } => {
+            | AsmInst::StoreSelfIVarHeap { .. }
+            | AsmInst::LoadIVarHeap { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -345,11 +346,6 @@ impl Codegen {
                 self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
             }
 
-            AsmInst::LoadIVarHeap {
-                ivarid,
-                is_object_ty,
-                self_,
-            } => self.load_ivar_heap(ivarid, is_object_ty, self_),
             AsmInst::StoreIVarHeap {
                 src,
                 ivarid,
@@ -1719,6 +1715,18 @@ impl Codegen {
         is_object_ty: bool,
     ) -> bool {
         self.store_self_ivar_heap(src, ivarid, is_object_ty);
+        true
+    }
+
+    /// Load a heap-spilled instance variable into the accumulator, substituting
+    /// nil for an out-of-range (non-self) or unset slot.
+    pub(in crate::codegen::jitgen) fn emit_load_ivar_heap(
+        &mut self,
+        ivarid: IvarId,
+        is_object_ty: bool,
+        self_: bool,
+    ) -> bool {
+        self.load_ivar_heap(ivarid, is_object_ty, self_);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -315,6 +315,13 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
             } => return self.emit_store_self_ivar_heap(src, ivarid, is_object_ty),
+            // Load a heap-spilled instance variable (bounds-checked unless self),
+            // substituting nil for an out-of-range / unset slot.
+            AsmInst::LoadIVarHeap {
+                ivarid,
+                is_object_ty,
+                self_,
+            } => return self.emit_load_ivar_heap(ivarid, is_object_ty, self_),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -322,6 +322,14 @@ impl Codegen {
                 is_object_ty,
                 self_,
             } => return self.emit_load_ivar_heap(ivarid, is_object_ty, self_),
+            // Runtime-call definition ops (undef a method / alias a global var).
+            // aarch64 bails when an xmm pool register is live (no xmm save yet).
+            AsmInst::UndefMethod { undef, using_xmm } => {
+                return self.emit_undef_method(undef, using_xmm);
+            }
+            AsmInst::AliasGvar { new, old, using_xmm } => {
+                return self.emit_alias_gvar(new, old, using_xmm);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -305,6 +305,16 @@ impl Codegen {
             // reg += i / reg -= i (no-op when i == 0).
             AsmInst::RegAdd(reg, i) => self.emit_reg_add(reg, i),
             AsmInst::RegSub(reg, i) => self.emit_reg_sub(reg, i),
+            // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
+            // the 12-bit sub-sp immediate).
+            AsmInst::LoopJitRspBump { offset } => return self.emit_loop_jit_rsp_bump(offset),
+            // Store into a heap-spilled instance variable of self (the table is
+            // known large enough, so no bounds check / runtime extend).
+            AsmInst::StoreSelfIVarHeap {
+                src,
+                ivarid,
+                is_object_ty,
+            } => return self.emit_store_self_ivar_heap(src, ivarid, is_object_ty),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1922,6 +1922,54 @@ impl Codegen {
         true
     }
 
+    /// Load a heap-spilled instance variable into the accumulator (x23). Unless
+    /// loading from self, bounds-check the var-table (None / capa 0 / len <= idx
+    /// -> nil); an unset (zero) slot also reads nil. Bails on an out-of-range
+    /// field offset. `x9` is the scratch for the table/data pointer chain.
+    pub(in crate::codegen::jitgen) fn emit_load_ivar_heap(
+        &mut self,
+        ivarid: IvarId,
+        is_object_ty: bool,
+        self_: bool,
+    ) -> bool {
+        let ivar = ivarid.get() as u32;
+        let idx = if is_object_ty {
+            ivar - OBJECT_INLINE_IVAR as u32
+        } else {
+            ivar
+        };
+        let off = idx * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let r15 = GP::R15.a64().0;
+        let nil = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_VAR as u32)];   // var_table
+        );
+        if !self_ {
+            monoasm_arm64!(&mut self.jit,
+                cbz x9, nil;                                 // None -> nil
+                ldr x10, [x9, #(MONOVEC_CAPA as u32)];
+                cbz x10, nil;                                // capa 0 -> nil
+                ldr x10, [x9, #(MONOVEC_LEN as u32)];
+                cmp x10, #(idx);
+            );
+            self.jit.bcond_label(monoasm::Cond::Le, &nil);   // len <= idx -> nil
+        }
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x9, #(MONOVEC_PTR as u32)];             // data ptr
+            ldr x(r15), [x9, #(off)];                        // value
+            cbnz x(r15), exit;                               // set -> exit
+        nil:
+            mov x(r15), (NIL_VALUE);
+        exit:
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1879,6 +1879,49 @@ impl Codegen {
         }
     }
 
+    /// Loop-JIT entry stack bump. Bails if the byte count exceeds the 12-bit
+    /// `sub sp, sp, #imm` immediate.
+    pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(&mut self, offset: LoopRspOffset) -> bool {
+        let bytes = offset.unwrap_concrete();
+        if bytes == 0 {
+            return true;
+        }
+        if bytes > 4095 {
+            return false;
+        }
+        monoasm_arm64!(&mut self.jit, sub sp, sp, #(bytes as u32););
+        true
+    }
+
+    /// Store `src` into a heap-spilled instance variable of self: deref the
+    /// var-table and its data pointer (via scratch x9), then store. No bounds
+    /// check (the table is pre-sized). Bails on an out-of-range field offset.
+    pub(in crate::codegen::jitgen) fn emit_store_self_ivar_heap(
+        &mut self,
+        src: GP,
+        ivarid: IvarId,
+        is_object_ty: bool,
+    ) -> bool {
+        let ivar = ivarid.get() as u32;
+        let idx = if is_object_ty {
+            ivar - OBJECT_INLINE_IVAR as u32
+        } else {
+            ivar
+        };
+        let off = idx * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0;
+        let s = src.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_VAR as u32)];
+            ldr x9, [x9, #(MONOVEC_PTR as u32)];
+            str x(s), [x9, #(off)];
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1970,6 +1970,45 @@ impl Codegen {
         true
     }
 
+    /// `undef`-method via runtime::undef_method(vm=x19, globals=x20, id). Bails
+    /// when an xmm pool register is live (no aarch64 xmm save around C calls
+    /// yet); lr is preserved across the `blr`.
+    pub(in crate::codegen::jitgen) fn emit_undef_method(&mut self, undef: IdentId, using_xmm: UsingXmm) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::undef_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                   // vm (Executor)
+            mov x1, x20;                   // globals
+            mov x2, (undef.get() as u64);  // undef (IdentId)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// Alias a global var via runtime::alias_global_var(globals=x20, new, old).
+    /// Bails when an xmm pool register is live.
+    pub(in crate::codegen::jitgen) fn emit_alias_gvar(&mut self, new: IdentId, old: IdentId, using_xmm: UsingXmm) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::alias_global_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x20;                 // globals
+            mov x1, (new.get() as u64);  // new IdentId
+            mov x2, (old.get() as u64);  // old IdentId
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).


### PR DESCRIPTION
## Summary

Continues the x86-64/aarch64 JIT emission-sharing work (#647–#652), porting more
instructions to the aarch64 backend (previously bailed) and routing them through
the shared `compile_asmir` dispatcher. This batch also **establishes the
aarch64 runtime-call (C-ABI) template** used by the remaining call-heavy ops.

## What's ported (5 instructions, 3 slices)

| Slice | Instructions |
|-------|--------------|
| 21 | `LoopJitRspBump`, `StoreSelfIVarHeap` |
| 22 | `LoadIVarHeap` |
| 23 | `UndefMethod`, `AliasGvar` |

x86 keeps its existing helpers; aarch64 gains real lowerings.

### aarch64 details

- **`LoopJitRspBump`** → `sub sp, sp, #bytes` (bails above the 12-bit immediate).
- **`StoreSelfIVarHeap`** derefs the var-table + data pointer (scratch x9) and
  stores — no bounds check (self ivar table is pre-sized).
- **`LoadIVarHeap`** derefs the var-table; unless loading from self it
  bounds-checks (None / capa 0 / len ≤ idx → nil) and substitutes nil for an
  unset slot, using inline `nil:`/`exit:` labels exactly like x86.
- **`UndefMethod` / `AliasGvar`** are the first aarch64 ports that issue a
  runtime C call: args in `x0..` (vm=x19, globals=x20), `str x30,[sp,#-16]!` to
  preserve lr across `blr`, bailing when an xmm pool register is live (no
  aarch64 xmm-save around C calls yet) — the same convention as `emit_store_gvar`.
- Field accessors bail on an out-of-range scaled load/store immediate.

The general `StoreIVarHeap` (runtime table extend) remains per-arch for a later
slice.

## Verification

- `cargo check` green on x86-64 and aarch64, no new warnings.
- Behavioural checks (byte-identical on x86-64 and aarch64 under qemu, matching
  CRuby):
  - 10-ivar object mutating self ivars + 100k float loop → `75269996 / 5000249995.0`
  - >6-ivar objects read via accessors (bounds-checked) + unset ivar → `150270000 / 5000`
  - `alias $dst $src` + `undef foo` from JIT-hot methods → `2000, 2000, 3, "foo undefined", 2`

Behavior-neutral on x86 (primitives wrap the existing helpers); the only new
code paths are the aarch64 lowerings that previously bailed to the VM.

https://claude.ai/code/session_01JxErh7a4yAiMWxVfLEr6gT