### PR TITLE
jit(aarch64): expand AsmInst coverage — runtime-call ops, float C-calls, def/exception, and the call/block/yield cluster

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -120,7 +120,9 @@ impl Codegen {
             | AsmInst::DefinedSuper { .. }
             | AsmInst::DefinedGvar { .. }
             | AsmInst::DefinedIvar { .. }
-            | AsmInst::DefinedCvar { .. } => {
+            | AsmInst::DefinedCvar { .. }
+            | AsmInst::GenericBinOp { .. }
+            | AsmInst::ArrayTEq { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -309,14 +311,6 @@ impl Codegen {
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
 
-            AsmInst::GenericBinOp {
-                lhs,
-                rhs,
-                func,
-                using_xmm,
-            } => {
-                self.generic_binop(lhs, rhs, func, using_xmm);
-            }
             AsmInst::OptEqCmp {
                 lhs,
                 rhs,
@@ -326,14 +320,6 @@ impl Codegen {
             } => {
                 self.opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
             }
-            AsmInst::ArrayTEq {
-                lhs,
-                rhs,
-                using_xmm,
-            } => {
-                self.array_teq(lhs, rhs, using_xmm);
-            }
-
             AsmInst::BlockArgProxy { ret, outer } => {
                 self.get_method_lfp(outer);
                 self.block_arg_proxy(outer);
@@ -1795,6 +1781,29 @@ impl Codegen {
         using_xmm: UsingXmm,
     ) -> bool {
         self.defined_ivar(dst, name, using_xmm);
+        true
+    }
+
+    // ---- generic binary-op runtime calls (delegate to the helpers) ----
+
+    pub(in crate::codegen::jitgen) fn emit_generic_binop(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.generic_binop(lhs, rhs, func, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_array_teq(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.array_teq(lhs, rhs, using_xmm);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -110,6 +110,8 @@ impl Codegen {
             | AsmInst::ZeroToRSPOffset(..)
             | AsmInst::U64ToRSPOffset(..)
             | AsmInst::GuardCapture(..)
+            | AsmInst::BlockArgProxy { .. }
+            | AsmInst::BlockArg { .. }
             | AsmInst::LoopJitRspBump { .. }
             | AsmInst::StoreSelfIVarHeap { .. }
             | AsmInst::LoadIVarHeap { .. }
@@ -244,23 +246,6 @@ impl Codegen {
                 let block_entry = frame.resolve_label(&mut self.jit, entry);
                 let return_addr = self.do_specialized_call(block_entry, None);
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
-            }
-
-            AsmInst::BlockArgProxy { ret, outer } => {
-                self.get_method_lfp(outer);
-                self.block_arg_proxy(outer);
-                self.store_rax(ret);
-            }
-            AsmInst::BlockArg {
-                ret,
-                _outer: _,
-                using_xmm,
-                error,
-                call_site_bc_ptr,
-            } => {
-                self.block_arg(using_xmm, call_site_bc_ptr);
-                self.handle_error(&labels[error]);
-                self.store_rax(ret);
             }
 
             AsmInst::LoadDynVarSpecialized { offset, reg } => {
@@ -1872,6 +1857,32 @@ impl Codegen {
 
     pub(in crate::codegen::jitgen) fn emit_guard_capture(&mut self, deopt: &DestLabel) -> bool {
         self.guard_capture(deopt);
+        true
+    }
+
+    // ---- &block forwarding (former per-arch arms) ----
+
+    pub(in crate::codegen::jitgen) fn emit_block_arg_proxy(
+        &mut self,
+        ret: SlotId,
+        outer: usize,
+    ) -> bool {
+        self.get_method_lfp(outer);
+        self.block_arg_proxy(outer);
+        self.store_rax(ret);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_block_arg(
+        &mut self,
+        ret: SlotId,
+        using_xmm: UsingXmm,
+        call_site_bc_ptr: BytecodePtr,
+        error: &DestLabel,
+    ) -> bool {
+        self.block_arg(using_xmm, call_site_bc_ptr);
+        self.handle_error(error);
+        self.store_rax(ret);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -106,6 +106,9 @@ impl Codegen {
             | AsmInst::StoreStructSlotHeap { .. }
             | AsmInst::RegAdd(..)
             | AsmInst::RegSub(..)
+            | AsmInst::RegToRSPOffset(..)
+            | AsmInst::ZeroToRSPOffset(..)
+            | AsmInst::U64ToRSPOffset(..)
             | AsmInst::LoopJitRspBump { .. }
             | AsmInst::StoreSelfIVarHeap { .. }
             | AsmInst::LoadIVarHeap { .. }
@@ -144,23 +147,6 @@ impl Codegen {
                     call rax;
                 );
             }
-            AsmInst::RegToRSPOffset(r, ofs) => {
-                let r = r as u64;
-                monoasm!( &mut self.jit,
-                    movq [rsp + (ofs - RSP_LOCAL_FRAME)], R(r);
-                );
-            }
-            AsmInst::ZeroToRSPOffset(ofs) => {
-                monoasm!( &mut self.jit,
-                    movq [rsp + (ofs - RSP_LOCAL_FRAME)], 0;
-                );
-            }
-            AsmInst::U64ToRSPOffset(i, ofs) => {
-                monoasm!( &mut self.jit,
-                    movq [rsp + (ofs - RSP_LOCAL_FRAME)], (i);
-                );
-            }
-
             AsmInst::GuardCapture(deopt) => {
                 let deopt = &labels[deopt];
                 self.guard_capture(deopt)
@@ -1859,6 +1845,30 @@ impl Codegen {
     ) -> bool {
         let return_addr = self.gen_yield(callid, error);
         self.set_deopt_with_return_addr(return_addr, evict, evict_label);
+        true
+    }
+
+    // ---- callee-frame argument stores (former per-arch arms) ----
+
+    pub(in crate::codegen::jitgen) fn emit_reg_to_rsp_offset(&mut self, r: GP, ofs: i32) -> bool {
+        let r = r as u64;
+        monoasm!( &mut self.jit,
+            movq [rsp + (ofs - RSP_LOCAL_FRAME)], R(r);
+        );
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_zero_to_rsp_offset(&mut self, ofs: i32) -> bool {
+        monoasm!( &mut self.jit,
+            movq [rsp + (ofs - RSP_LOCAL_FRAME)], 0;
+        );
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_u64_to_rsp_offset(&mut self, i: u64, ofs: i32) -> bool {
+        monoasm!( &mut self.jit,
+            movq [rsp + (ofs - RSP_LOCAL_FRAME)], (i);
+        );
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -128,7 +128,9 @@ impl Codegen {
             | AsmInst::ExpandArray { .. }
             | AsmInst::OptEqCmp { .. }
             | AsmInst::CFunc_F_F { .. }
-            | AsmInst::CFunc_FF_F { .. } => {
+            | AsmInst::CFunc_FF_F { .. }
+            | AsmInst::MethodDef { .. }
+            | AsmInst::SingletonMethodDef { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -366,26 +368,6 @@ impl Codegen {
             } => {
                 self.singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
             }
-            AsmInst::MethodDef {
-                name,
-                func_id,
-                using_xmm,
-                error,
-            } => {
-                self.method_def(name, func_id, using_xmm);
-                self.handle_error(&labels[error]);
-            }
-            AsmInst::SingletonMethodDef {
-                obj,
-                name,
-                func_id,
-                using_xmm,
-                error,
-            } => {
-                self.singleton_method_def(obj, name, func_id, using_xmm);
-                self.handle_error(&labels[error]);
-            }
-
             AsmInst::RestKw { rest_kw } => {
                 let data = self.jit.const_align8();
                 for (i, name) in rest_kw.into_iter() {
@@ -1830,6 +1812,33 @@ impl Codegen {
         );
         self.xmm_restore(using_xmm);
         self.store_fpr_into_xmm(dst, base);
+        true
+    }
+
+    // ---- method definition (the former per-arch arms, verbatim) ----
+
+    pub(in crate::codegen::jitgen) fn emit_method_def(
+        &mut self,
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        self.method_def(name, func_id, using_xmm);
+        self.handle_error(error);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_singleton_method_def(
+        &mut self,
+        obj: SlotId,
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        self.singleton_method_def(obj, name, func_id, using_xmm);
+        self.handle_error(error);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -109,6 +109,7 @@ impl Codegen {
             | AsmInst::RegToRSPOffset(..)
             | AsmInst::ZeroToRSPOffset(..)
             | AsmInst::U64ToRSPOffset(..)
+            | AsmInst::GuardCapture(..)
             | AsmInst::LoopJitRspBump { .. }
             | AsmInst::StoreSelfIVarHeap { .. }
             | AsmInst::LoadIVarHeap { .. }
@@ -147,11 +148,6 @@ impl Codegen {
                     call rax;
                 );
             }
-            AsmInst::GuardCapture(deopt) => {
-                let deopt = &labels[deopt];
-                self.guard_capture(deopt)
-            }
-
             AsmInst::GuardClassVersionSpecialized { idx, deopt } => {
                 let deopt = &labels[deopt];
                 self.guard_class_version_specialized(
@@ -1869,6 +1865,13 @@ impl Codegen {
         monoasm!( &mut self.jit,
             movq [rsp + (ofs - RSP_LOCAL_FRAME)], (i);
         );
+        true
+    }
+
+    // ---- block-passing side-effect guard (former per-arch arm) ----
+
+    pub(in crate::codegen::jitgen) fn emit_guard_capture(&mut self, deopt: &DestLabel) -> bool {
+        self.guard_capture(deopt);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -125,7 +125,8 @@ impl Codegen {
             | AsmInst::ArrayTEq { .. }
             | AsmInst::ConcatRegexp { .. }
             | AsmInst::CheckKwRest(..)
-            | AsmInst::ExpandArray { .. } => {
+            | AsmInst::ExpandArray { .. }
+            | AsmInst::OptEqCmp { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -303,15 +304,6 @@ impl Codegen {
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
 
-            AsmInst::OptEqCmp {
-                lhs,
-                rhs,
-                kind,
-                func,
-                using_xmm,
-            } => {
-                self.opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
-            }
             AsmInst::BlockArgProxy { ret, outer } => {
                 self.get_method_lfp(outer);
                 self.block_arg_proxy(outer);
@@ -1768,6 +1760,18 @@ impl Codegen {
         using_xmm: UsingXmm,
     ) -> bool {
         self.array_teq(lhs, rhs, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_opt_eq_cmp(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -134,7 +134,8 @@ impl Codegen {
             | AsmInst::Raise
             | AsmInst::Retry(..)
             | AsmInst::Redo(..)
-            | AsmInst::EnsureEnd => {
+            | AsmInst::EnsureEnd
+            | AsmInst::Yield { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -255,15 +256,6 @@ impl Codegen {
                     patch_point.map(|label| frame.resolve_label(&mut self.jit, label));
                 let entry_label = frame.resolve_label(&mut self.jit, entry);
                 let return_addr = self.do_specialized_call(entry_label, patch_point);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
-            }
-            AsmInst::Yield {
-                callid,
-                error,
-                evict,
-            } => {
-                let error = &labels[error];
-                let return_addr = self.gen_yield(callid, error);
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
             AsmInst::SpecializedYield { entry, evict } => {
@@ -1853,6 +1845,20 @@ impl Codegen {
             testq rax, rax;
             jne  raise;
         };
+        true
+    }
+
+    // ---- generic yield (former per-arch arm) ----
+
+    pub(in crate::codegen::jitgen) fn emit_yield(
+        &mut self,
+        callid: CallSiteId,
+        error: &DestLabel,
+        evict: AsmEvict,
+        evict_label: &DestLabel,
+    ) -> bool {
+        let return_addr = self.gen_yield(callid, error);
+        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -110,7 +110,10 @@ impl Codegen {
             | AsmInst::StoreSelfIVarHeap { .. }
             | AsmInst::LoadIVarHeap { .. }
             | AsmInst::UndefMethod { .. }
-            | AsmInst::AliasGvar { .. } => {
+            | AsmInst::AliasGvar { .. }
+            | AsmInst::CheckCVar { .. }
+            | AsmInst::StoreCVar { .. }
+            | AsmInst::AliasMethod { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -354,17 +357,6 @@ impl Codegen {
                 is_object_ty,
                 using_xmm,
             } => self.store_ivar_heap(src, ivarid, is_object_ty, using_xmm),
-            AsmInst::CheckCVar { name, using_xmm } => {
-                self.check_cvar(name, using_xmm);
-            }
-            AsmInst::StoreCVar {
-                name,
-                src,
-                using_xmm,
-            } => {
-                self.store_cvar(name, src, using_xmm);
-            }
-
             AsmInst::ClassDef {
                 base,
                 superclass,
@@ -458,22 +450,6 @@ impl Codegen {
                 using_xmm,
             } => {
                 self.concat_regexp(arg, len, using_xmm);
-            }
-            AsmInst::AliasMethod {
-                new,
-                old,
-                using_xmm,
-            } => {
-                self.xmm_save(using_xmm);
-                monoasm!( &mut self.jit,
-                    movq rdi, rbx;
-                    movq rsi, r12;
-                    movq rdx, [r14 - (conv(old))];
-                    movq rcx, [r14 - (conv(new))];
-                    movq rax, (runtime::alias_method);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
             }
             AsmInst::DefinedYield { dst, using_xmm } => self.defined_yield(dst, using_xmm),
             AsmInst::DefinedConst {
@@ -1728,6 +1704,47 @@ impl Codegen {
             movl rsi, (new.get());  // new IdentId
             movl rdx, (old.get());  // old IdentId
             movq rax, (runtime::alias_global_var);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        true
+    }
+
+    /// Check class-variable existence via runtime::check_class_var.
+    pub(in crate::codegen::jitgen) fn emit_check_cvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.check_cvar(name, using_xmm);
+        true
+    }
+
+    /// @@cvar <- src via runtime::set_class_var.
+    pub(in crate::codegen::jitgen) fn emit_store_cvar(
+        &mut self,
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.store_cvar(name, src, using_xmm);
+        true
+    }
+
+    /// Alias a method via runtime::alias_method (old/new read from frame slots).
+    pub(in crate::codegen::jitgen) fn emit_alias_method(
+        &mut self,
+        new: SlotId,
+        old: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rdx, [r14 - (conv(old))];
+            movq rcx, [r14 - (conv(new))];
+            movq rax, (runtime::alias_method);
             call rax;
         );
         self.xmm_restore(using_xmm);

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -122,7 +122,9 @@ impl Codegen {
             | AsmInst::DefinedIvar { .. }
             | AsmInst::DefinedCvar { .. }
             | AsmInst::GenericBinOp { .. }
-            | AsmInst::ArrayTEq { .. } => {
+            | AsmInst::ArrayTEq { .. }
+            | AsmInst::ConcatRegexp { .. }
+            | AsmInst::CheckKwRest(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -244,17 +246,6 @@ impl Codegen {
                     call rax;
                     testq rax, rax;
                     jne  raise;
-                };
-            }
-            AsmInst::CheckKwRest(slot) => {
-                let exit = self.jit.label();
-                monoasm! { &mut self.jit,
-                    cmpq [rbp - (rbp_local(slot))], (NIL_VALUE);
-                    jne  exit;
-                    movq rax, (runtime::empty_hash);
-                    call rax;
-                    movq [rbp - (rbp_local(slot))], rax;
-                exit:
                 };
             }
             AsmInst::OptCase {
@@ -436,13 +427,6 @@ impl Codegen {
                     movq rax, (runtime::correct_rest_kw);
                     call rax;
                 );
-            }
-            AsmInst::ConcatRegexp {
-                arg,
-                len,
-                using_xmm,
-            } => {
-                self.concat_regexp(arg, len, using_xmm);
             }
             AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
             AsmInst::CFunc_F_F {
@@ -1804,6 +1788,31 @@ impl Codegen {
         using_xmm: UsingXmm,
     ) -> bool {
         self.array_teq(lhs, rhs, using_xmm);
+        true
+    }
+
+    // ---- regexp build / kw-rest fixup runtime calls ----
+
+    pub(in crate::codegen::jitgen) fn emit_concat_regexp(
+        &mut self,
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.concat_regexp(arg, len, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_check_kw_rest(&mut self, slot: SlotId) -> bool {
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            cmpq [rbp - (rbp_local(slot))], (NIL_VALUE);
+            jne  exit;
+            movq rax, (runtime::empty_hash);
+            call rax;
+            movq [rbp - (rbp_local(slot))], rax;
+        exit:
+        };
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -130,7 +130,11 @@ impl Codegen {
             | AsmInst::CFunc_F_F { .. }
             | AsmInst::CFunc_FF_F { .. }
             | AsmInst::MethodDef { .. }
-            | AsmInst::SingletonMethodDef { .. } => {
+            | AsmInst::SingletonMethodDef { .. }
+            | AsmInst::Raise
+            | AsmInst::Retry(..)
+            | AsmInst::Redo(..)
+            | AsmInst::EnsureEnd => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -213,46 +217,6 @@ impl Codegen {
             }
             AsmInst::BlockBreakSpecialized { rbp_offset } => {
                 self.method_return_specialized(rbp_offset.unwrap_concrete());
-            }
-            AsmInst::Raise => {
-                let raise = self.entry_raise();
-                monoasm! { &mut self.jit,
-                    movq rdi, rbx;
-                    movq rsi, rax;
-                    movq rax, (runtime::raise_err);
-                    call rax;
-                    jmp  raise;
-                };
-            }
-            AsmInst::Retry(pc) => {
-                let raise = self.entry_raise();
-                monoasm! { &mut self.jit,
-                    movq r13, ((pc + 1).as_ptr());
-                    movq rdi, rbx;
-                    movq rax, (runtime::err_retry);
-                    call rax;
-                    jmp  raise;
-                };
-            }
-            AsmInst::Redo(pc) => {
-                let raise = self.entry_raise();
-                monoasm! { &mut self.jit,
-                    movq r13, ((pc + 1).as_ptr());
-                    movq rdi, rbx;
-                    movq rax, (runtime::err_redo);
-                    call rax;
-                    jmp  raise;
-                };
-            }
-            AsmInst::EnsureEnd => {
-                let raise = self.entry_raise();
-                monoasm! { &mut self.jit,
-                    movq rdi, rbx;
-                    movq rax, (runtime::ensure_end);
-                    call rax;
-                    testq rax, rax;
-                    jne  raise;
-                };
             }
             AsmInst::OptCase {
                 max,
@@ -1839,6 +1803,56 @@ impl Codegen {
     ) -> bool {
         self.singleton_method_def(obj, name, func_id, using_xmm);
         self.handle_error(error);
+        true
+    }
+
+    // ---- exception / non-local control flow (former per-arch arms) ----
+
+    pub(in crate::codegen::jitgen) fn emit_raise(&mut self) -> bool {
+        let raise = self.entry_raise();
+        monoasm! { &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, rax;
+            movq rax, (runtime::raise_err);
+            call rax;
+            jmp  raise;
+        };
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_retry(&mut self, pc: BytecodePtr) -> bool {
+        let raise = self.entry_raise();
+        monoasm! { &mut self.jit,
+            movq r13, ((pc + 1).as_ptr());
+            movq rdi, rbx;
+            movq rax, (runtime::err_retry);
+            call rax;
+            jmp  raise;
+        };
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_redo(&mut self, pc: BytecodePtr) -> bool {
+        let raise = self.entry_raise();
+        monoasm! { &mut self.jit,
+            movq r13, ((pc + 1).as_ptr());
+            movq rdi, rbx;
+            movq rax, (runtime::err_redo);
+            call rax;
+            jmp  raise;
+        };
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_ensure_end(&mut self) -> bool {
+        let raise = self.entry_raise();
+        monoasm! { &mut self.jit,
+            movq rdi, rbx;
+            movq rax, (runtime::ensure_end);
+            call rax;
+            testq rax, rax;
+            jne  raise;
+        };
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -113,7 +113,14 @@ impl Codegen {
             | AsmInst::AliasGvar { .. }
             | AsmInst::CheckCVar { .. }
             | AsmInst::StoreCVar { .. }
-            | AsmInst::AliasMethod { .. } => {
+            | AsmInst::AliasMethod { .. }
+            | AsmInst::DefinedYield { .. }
+            | AsmInst::DefinedConst { .. }
+            | AsmInst::DefinedMethod { .. }
+            | AsmInst::DefinedSuper { .. }
+            | AsmInst::DefinedGvar { .. }
+            | AsmInst::DefinedIvar { .. }
+            | AsmInst::DefinedCvar { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -451,37 +458,6 @@ impl Codegen {
             } => {
                 self.concat_regexp(arg, len, using_xmm);
             }
-            AsmInst::DefinedYield { dst, using_xmm } => self.defined_yield(dst, using_xmm),
-            AsmInst::DefinedConst {
-                dst,
-                siteid,
-                using_xmm,
-            } => self.defined_const(dst, siteid, using_xmm),
-            AsmInst::DefinedMethod {
-                dst,
-                recv,
-                name,
-                using_xmm,
-            } => self.defined_method(dst, recv, name, using_xmm),
-            AsmInst::DefinedSuper { dst, using_xmm } => self.defined_super(dst, using_xmm),
-            AsmInst::DefinedGvar {
-                dst,
-                name,
-                using_xmm,
-            } => self.defined_gvar(dst, name, using_xmm),
-
-            AsmInst::DefinedIvar {
-                dst,
-                name,
-                using_xmm,
-            } => self.defined_ivar(dst, name, using_xmm),
-
-            AsmInst::DefinedCvar {
-                dst,
-                name,
-                using_xmm,
-            } => self.defined_cvar(dst, name, using_xmm),
-
             AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
             AsmInst::CFunc_F_F {
                 f,
@@ -1748,6 +1724,77 @@ impl Codegen {
             call rax;
         );
         self.xmm_restore(using_xmm);
+        true
+    }
+
+    // ---- defined? runtime-call family (delegate to the existing helpers) ----
+
+    pub(in crate::codegen::jitgen) fn emit_defined_yield(
+        &mut self,
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_yield(dst, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_super(
+        &mut self,
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_super(dst, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_gvar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_gvar(dst, name, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_cvar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_cvar(dst, name, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_const(
+        &mut self,
+        dst: SlotId,
+        siteid: ConstSiteId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_const(dst, siteid, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_method(
+        &mut self,
+        dst: SlotId,
+        recv: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_method(dst, recv, name, using_xmm);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_defined_ivar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.defined_ivar(dst, name, using_xmm);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -124,7 +124,8 @@ impl Codegen {
             | AsmInst::GenericBinOp { .. }
             | AsmInst::ArrayTEq { .. }
             | AsmInst::ConcatRegexp { .. }
-            | AsmInst::CheckKwRest(..) => {
+            | AsmInst::CheckKwRest(..)
+            | AsmInst::ExpandArray { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -391,27 +392,6 @@ impl Codegen {
                 self.handle_error(&labels[error]);
             }
 
-            AsmInst::ExpandArray {
-                dst,
-                len,
-                rest_pos,
-                using_xmm,
-            } => {
-                let rest = if let Some(rest_pos) = rest_pos {
-                    rest_pos + 1
-                } else {
-                    0
-                };
-                self.xmm_save(using_xmm);
-                monoasm!( &mut self.jit,
-                    lea rsi, [rbp - (rbp_local(dst))];
-                    movq rdx, (len);
-                    movq rcx, (rest);
-                    movq rax, (runtime::expand_array);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
-            }
             AsmInst::RestKw { rest_kw } => {
                 let data = self.jit.const_align8();
                 for (i, name) in rest_kw.into_iter() {
@@ -1813,6 +1793,30 @@ impl Codegen {
             movq [rbp - (rbp_local(slot))], rax;
         exit:
         };
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_expand_array(
+        &mut self,
+        dst: SlotId,
+        len: usize,
+        rest_pos: Option<usize>,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        let rest = if let Some(rest_pos) = rest_pos {
+            rest_pos + 1
+        } else {
+            0
+        };
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            lea rsi, [rbp - (rbp_local(dst))];
+            movq rdx, (len);
+            movq rcx, (rest);
+            movq rax, (runtime::expand_array);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -126,7 +126,9 @@ impl Codegen {
             | AsmInst::ConcatRegexp { .. }
             | AsmInst::CheckKwRest(..)
             | AsmInst::ExpandArray { .. }
-            | AsmInst::OptEqCmp { .. } => {
+            | AsmInst::OptEqCmp { .. }
+            | AsmInst::CFunc_F_F { .. }
+            | AsmInst::CFunc_FF_F { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -401,44 +403,6 @@ impl Codegen {
                 );
             }
             AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
-            AsmInst::CFunc_F_F {
-                f,
-                src,
-                dst,
-                using_xmm,
-            } => {
-                let base = frame.base_stack_offset;
-                self.xmm_save(using_xmm);
-                self.load_fpr_into_xmm0(src, base);
-                monoasm!( &mut self.jit,
-                    movq rax, (f);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
-                self.store_fpr_into_xmm(dst, base);
-            }
-            AsmInst::CFunc_FF_F {
-                f,
-                lhs,
-                rhs,
-                dst,
-                using_xmm,
-            } => {
-                let base = frame.base_stack_offset;
-                self.xmm_save(using_xmm);
-                // Load both args into xmm0/xmm1 (the SysV ABI passes
-                // f64 args in xmm0, xmm1, ...). Pool ids resolve to
-                // xmm2..xmm15, so a Phys source can never alias the
-                // scratch register we're writing into.
-                self.load_fpr_into_xmm0(lhs, base);
-                self.load_fpr_into_xmm1(rhs, base);
-                monoasm!( &mut self.jit,
-                    movq rax, (f);
-                    call rax;
-                );
-                self.xmm_restore(using_xmm);
-                self.store_fpr_into_xmm(dst, base);
-            }
         }
         true
     }
@@ -1821,6 +1785,51 @@ impl Codegen {
             call rax;
         );
         self.xmm_restore(using_xmm);
+        true
+    }
+
+    // ---- float C-function calls (the former per-arch arms, verbatim) ----
+
+    pub(in crate::codegen::jitgen) fn emit_cfunc_f_f(
+        &mut self,
+        f: unsafe extern "C" fn(f64) -> f64,
+        src: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) -> bool {
+        self.xmm_save(using_xmm);
+        self.load_fpr_into_xmm0(src, base);
+        monoasm!( &mut self.jit,
+            movq rax, (f);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        self.store_fpr_into_xmm(dst, base);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_cfunc_ff_f(
+        &mut self,
+        f: extern "C" fn(f64, f64) -> f64,
+        lhs: FPReg,
+        rhs: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) -> bool {
+        self.xmm_save(using_xmm);
+        // Load both args into xmm0/xmm1 (the SysV ABI passes f64 args
+        // in xmm0, xmm1, ...). Pool ids resolve to xmm2..xmm15, so a
+        // Phys source can never alias the scratch register written into.
+        self.load_fpr_into_xmm0(lhs, base);
+        self.load_fpr_into_xmm1(rhs, base);
+        monoasm!( &mut self.jit,
+            movq rax, (f);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        self.store_fpr_into_xmm(dst, base);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -385,6 +385,14 @@ impl Codegen {
             AsmInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
                 return self.emit_expand_array(dst, len, rest_pos, using_xmm);
             }
+            // Float C-function calls (Math.sqrt/sin/…). aarch64 saves the live
+            // FP pool (d2-d7) around the call and bails on a spilled operand.
+            AsmInst::CFunc_F_F { f, src, dst, using_xmm } => {
+                return self.emit_cfunc_f_f(f, src, dst, using_xmm, frame.base_stack_offset);
+            }
+            AsmInst::CFunc_FF_F { f, lhs, rhs, dst, using_xmm } => {
+                return self.emit_cfunc_ff_f(f, lhs, rhs, dst, using_xmm, frame.base_stack_offset);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -372,6 +372,11 @@ impl Codegen {
             AsmInst::ArrayTEq { lhs, rhs, using_xmm } => {
                 return self.emit_array_teq(lhs, rhs, using_xmm);
             }
+            // Regexp interpolation / keyword-rest fixup runtime calls.
+            AsmInst::ConcatRegexp { arg, len, using_xmm } => {
+                return self.emit_concat_regexp(arg, len, using_xmm);
+            }
+            AsmInst::CheckKwRest(slot) => return self.emit_check_kw_rest(slot),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -316,6 +316,12 @@ impl Codegen {
             // Side-effect guard for block-passing calls: deopt if the frame was
             // captured/promoted.
             AsmInst::GuardCapture(deopt) => return self.emit_guard_capture(&labels[deopt]),
+            // `&block` forwarding: proxy the block handler, or materialize it
+            // into a Proc value (aarch64 bails on a live xmm / range overflow).
+            AsmInst::BlockArgProxy { ret, outer } => return self.emit_block_arg_proxy(ret, outer),
+            AsmInst::BlockArg { ret, _outer: _, using_xmm, error, call_site_bc_ptr } => {
+                return self.emit_block_arg(ret, using_xmm, call_site_bc_ptr, &labels[error]);
+            }
             // Store into a heap-spilled instance variable of self (the table is
             // known large enough, so no bounds check / runtime extend).
             AsmInst::StoreSelfIVarHeap {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -330,6 +330,17 @@ impl Codegen {
             AsmInst::AliasGvar { new, old, using_xmm } => {
                 return self.emit_alias_gvar(new, old, using_xmm);
             }
+            // Runtime-call class-variable / method-alias ops. aarch64 bails
+            // when an xmm pool register is live (no xmm save yet).
+            AsmInst::CheckCVar { name, using_xmm } => {
+                return self.emit_check_cvar(name, using_xmm);
+            }
+            AsmInst::StoreCVar { name, src, using_xmm } => {
+                return self.emit_store_cvar(name, src, using_xmm);
+            }
+            AsmInst::AliasMethod { new, old, using_xmm } => {
+                return self.emit_alias_method(new, old, using_xmm);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -377,6 +377,11 @@ impl Codegen {
                 return self.emit_concat_regexp(arg, len, using_xmm);
             }
             AsmInst::CheckKwRest(slot) => return self.emit_check_kw_rest(slot),
+            // Multiple-assignment array expansion (aarch64 bails on a live xmm
+            // pool reg or an out-of-range frame offset).
+            AsmInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
+                return self.emit_expand_array(dst, len, rest_pos, using_xmm);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -308,6 +308,11 @@ impl Codegen {
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
             // the 12-bit sub-sp immediate).
             AsmInst::LoopJitRspBump { offset } => return self.emit_loop_jit_rsp_bump(offset),
+            // Inline argument-setup stores into the callee frame (aarch64 bails
+            // on an out-of-range slot offset).
+            AsmInst::RegToRSPOffset(r, ofs) => return self.emit_reg_to_rsp_offset(r, ofs),
+            AsmInst::ZeroToRSPOffset(ofs) => return self.emit_zero_to_rsp_offset(ofs),
+            AsmInst::U64ToRSPOffset(i, ofs) => return self.emit_u64_to_rsp_offset(i, ofs),
             // Store into a heap-spilled instance variable of self (the table is
             // known large enough, so no bounds check / runtime extend).
             AsmInst::StoreSelfIVarHeap {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -393,6 +393,13 @@ impl Codegen {
             AsmInst::CFunc_FF_F { f, lhs, rhs, dst, using_xmm } => {
                 return self.emit_cfunc_ff_f(f, lhs, rhs, dst, using_xmm, frame.base_stack_offset);
             }
+            // Method definition (`def`). aarch64 bails on a live xmm pool reg.
+            AsmInst::MethodDef { name, func_id, using_xmm, error } => {
+                return self.emit_method_def(name, func_id, using_xmm, &labels[error]);
+            }
+            AsmInst::SingletonMethodDef { obj, name, func_id, using_xmm, error } => {
+                return self.emit_singleton_method_def(obj, name, func_id, using_xmm, &labels[error]);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -313,6 +313,9 @@ impl Codegen {
             AsmInst::RegToRSPOffset(r, ofs) => return self.emit_reg_to_rsp_offset(r, ofs),
             AsmInst::ZeroToRSPOffset(ofs) => return self.emit_zero_to_rsp_offset(ofs),
             AsmInst::U64ToRSPOffset(i, ofs) => return self.emit_u64_to_rsp_offset(i, ofs),
+            // Side-effect guard for block-passing calls: deopt if the frame was
+            // captured/promoted.
+            AsmInst::GuardCapture(deopt) => return self.emit_guard_capture(&labels[deopt]),
             // Store into a heap-spilled instance variable of self (the table is
             // known large enough, so no bounds check / runtime extend).
             AsmInst::StoreSelfIVarHeap {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -364,6 +364,14 @@ impl Codegen {
             AsmInst::DefinedIvar { dst, name, using_xmm } => {
                 return self.emit_defined_ivar(dst, name, using_xmm);
             }
+            // Generic binary-op / Array=== runtime calls (aarch64 bails on a
+            // live xmm pool reg or an out-of-range frame offset).
+            AsmInst::GenericBinOp { lhs, rhs, func, using_xmm } => {
+                return self.emit_generic_binop(lhs, rhs, func, using_xmm);
+            }
+            AsmInst::ArrayTEq { lhs, rhs, using_xmm } => {
+                return self.emit_array_teq(lhs, rhs, using_xmm);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -400,6 +400,12 @@ impl Codegen {
             AsmInst::SingletonMethodDef { obj, name, func_id, using_xmm, error } => {
                 return self.emit_singleton_method_def(obj, name, func_id, using_xmm, &labels[error]);
             }
+            // Exception / non-local control flow (raise / retry / redo / ensure).
+            // All branch into the shared entry_raise unwind path.
+            AsmInst::Raise => return self.emit_raise(),
+            AsmInst::Retry(pc) => return self.emit_retry(pc),
+            AsmInst::Redo(pc) => return self.emit_redo(pc),
+            AsmInst::EnsureEnd => return self.emit_ensure_end(),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -406,6 +406,13 @@ impl Codegen {
             AsmInst::Retry(pc) => return self.emit_retry(pc),
             AsmInst::Redo(pc) => return self.emit_redo(pc),
             AsmInst::EnsureEnd => return self.emit_ensure_end(),
+            // Generic `yield` (block target resolved at runtime). aarch64 builds
+            // the block frame and calls the funcdata indirectly; the x86-only
+            // return-address eviction patch is applied by the x86 emit_yield.
+            AsmInst::Yield { callid, error, evict } => {
+                let evict_label = labels[evict].clone();
+                return self.emit_yield(callid, &labels[error], evict, &evict_label);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -369,6 +369,9 @@ impl Codegen {
             AsmInst::GenericBinOp { lhs, rhs, func, using_xmm } => {
                 return self.emit_generic_binop(lhs, rhs, func, using_xmm);
             }
+            AsmInst::OptEqCmp { lhs, rhs, kind, func, using_xmm } => {
+                return self.emit_opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
+            }
             AsmInst::ArrayTEq { lhs, rhs, using_xmm } => {
                 return self.emit_array_teq(lhs, rhs, using_xmm);
             }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -341,6 +341,29 @@ impl Codegen {
             AsmInst::AliasMethod { new, old, using_xmm } => {
                 return self.emit_alias_method(new, old, using_xmm);
             }
+            // defined? runtime-call family (aarch64 bails on a live xmm pool reg
+            // or an out-of-range frame offset).
+            AsmInst::DefinedYield { dst, using_xmm } => {
+                return self.emit_defined_yield(dst, using_xmm);
+            }
+            AsmInst::DefinedSuper { dst, using_xmm } => {
+                return self.emit_defined_super(dst, using_xmm);
+            }
+            AsmInst::DefinedGvar { dst, name, using_xmm } => {
+                return self.emit_defined_gvar(dst, name, using_xmm);
+            }
+            AsmInst::DefinedCvar { dst, name, using_xmm } => {
+                return self.emit_defined_cvar(dst, name, using_xmm);
+            }
+            AsmInst::DefinedConst { dst, siteid, using_xmm } => {
+                return self.emit_defined_const(dst, siteid, using_xmm);
+            }
+            AsmInst::DefinedMethod { dst, recv, name, using_xmm } => {
+                return self.emit_defined_method(dst, recv, name, using_xmm);
+            }
+            AsmInst::DefinedIvar { dst, name, using_xmm } => {
+                return self.emit_defined_ivar(dst, name, using_xmm);
+            }
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2105,6 +2105,222 @@ impl Codegen {
         true
     }
 
+    // ---- defined? runtime-call family --------------------------------------
+    //
+    // Two ABI shapes (mirroring the x86 helpers):
+    //  * result-in-x0 then stored to `dst` (yield/super/gvar/cvar)
+    //  * `dst` passed as an out-pointer the runtime writes through
+    //    (const/method/ivar)
+    // All bail when an xmm pool reg is live or a slot offset exceeds the 12-bit
+    // `sub`/`ldr`/`str` immediate.
+
+    /// "yield" if a block is callable, else nil. result -> dst.
+    pub(in crate::codegen::jitgen) fn emit_defined_yield(
+        &mut self,
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_yield as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                      // result in x0
+            ldr x30, [sp], #16;
+            sub x10, x(lfp), #(off);
+            str x0, [x10];               // -> dst
+        );
+        true
+    }
+
+    /// "super" if super is callable, else nil. result -> dst.
+    pub(in crate::codegen::jitgen) fn emit_defined_super(
+        &mut self,
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_super as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            sub x10, x(lfp), #(off);
+            str x0, [x10];
+        );
+        true
+    }
+
+    /// "global-variable" if $name exists, else nil. result -> dst.
+    pub(in crate::codegen::jitgen) fn emit_defined_gvar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_gvar as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            mov x2, (name.get() as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            sub x10, x(lfp), #(off);
+            str x0, [x10];
+        );
+        true
+    }
+
+    /// "class variable" if @@name exists, else nil. result -> dst.
+    pub(in crate::codegen::jitgen) fn emit_defined_cvar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_cvar as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            mov x2, (name.get() as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            sub x10, x(lfp), #(off);
+            str x0, [x10];
+        );
+        true
+    }
+
+    /// defined?(Const): runtime writes the result through the `dst` out-pointer.
+    pub(in crate::codegen::jitgen) fn emit_defined_const(
+        &mut self,
+        dst: SlotId,
+        siteid: ConstSiteId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_const as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            sub x2, x(lfp), #(off);      // &dst (out-pointer)
+            mov x3, (siteid.0 as u64);   // ConstSiteId
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// defined?(recv.name): runtime writes the result through `dst`.
+    pub(in crate::codegen::jitgen) fn emit_defined_method(
+        &mut self,
+        dst: SlotId,
+        recv: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off_dst = dst.0 as u32 * 8 + LFP_SELF as u32;
+        let off_recv = recv.0 as u32 * 8 + LFP_SELF as u32;
+        if off_dst > 4095 || off_recv > 4095 {
+            return false;
+        }
+        let f = runtime::defined_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            sub x2, x(lfp), #(off_dst);  // &dst (out-pointer)
+            sub x10, x(lfp), #(off_recv);
+            ldr x3, [x10];               // recv (slot value)
+            mov x4, (name.get() as u64); // name
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// defined?(@name): runtime writes the result through `dst`.
+    pub(in crate::codegen::jitgen) fn emit_defined_ivar(
+        &mut self,
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::defined_ivar as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            sub x2, x(lfp), #(off);      // &dst (out-pointer)
+            mov x3, (name.get() as u64); // name
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2389,6 +2389,69 @@ impl Codegen {
         true
     }
 
+    /// Build a Regexp from the `len` interpolated parts based at slot `arg` via
+    /// runtime::concatenate_regexp (x0=vm, x1=globals, x2=&arg, x3=len);
+    /// Option<Value> result in x0. The runtime reads `arg, arg-1, …` (descending
+    /// addresses), matching the x86 `lea rdx,[rbp-rbp_local(arg)]`. Bails on a
+    /// live xmm pool reg or an out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_concat_regexp(
+        &mut self,
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off = arg.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::concatenate_regexp as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals
+            sub x2, x(lfp), #(off);      // &arg (slot address)
+            mov x3, (len as u64);        // len
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// Keyword-rest fixup: if the `slot` is nil, replace it with a fresh empty
+    /// Hash (runtime::empty_hash, no args, result in x0). Mirrors the x86 inline
+    /// path (no xmm save — no xmm is live at kw-rest setup). Bails on an
+    /// out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_check_kw_rest(&mut self, slot: SlotId) -> bool {
+        let lfp = GP::R14.a64().0; // x22
+        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let exit = self.jit.label();
+        let f = runtime::empty_hash as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off);
+            ldr x11, [x10];
+            cmp x11, #(NIL_VALUE);       // slot == nil ?
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &exit); // not nil -> keep
+        monoasm_arm64!(&mut self.jit,
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                      // x0 = {}
+            ldr x30, [sp], #16;
+            sub x10, x(lfp), #(off);     // x10 clobbered by the call; recompute
+            str x0, [x10];               // slot = {}
+        exit:
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2963,6 +2963,26 @@ impl Codegen {
         true
     }
 
+    /// Side-effect guard for a method that passes a block: deopt if the current
+    /// frame has been captured/promoted (so a materialized closure observes
+    /// later local writes). Tests the captured (0b1000_0000) / invalidated
+    /// (0b0000_1000) bits of the Meta `kind` byte at `[lfp - 1]`. Mirrors x86
+    /// `branch_if_captured` + `guard_capture`; aarch64 lays the deopt inline (no
+    /// cold page) so this is just a conditional branch to the deopt label.
+    pub(in crate::codegen::jitgen) fn emit_guard_capture(&mut self, deopt: &DestLabel) -> bool {
+        let lfp = GP::R14.a64().0; // x22
+        let off = (LFP_META as i64 - META_KIND as i64) as u32; // == 1 (kind byte)
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off);
+            ldrb w9, [x10];
+            mov x11, (0b1000_1000u64);
+            tst x9, x11;                 // captured or invalidated?
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt); // set -> deopt to VM
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2782,6 +2782,129 @@ impl Codegen {
         true
     }
 
+    /// If the outer LFP in `x(reg)` points at a stack frame already promoted to
+    /// the heap (its Meta `kind` byte at `[lfp - 1]` has the `invalidated` bit
+    /// 0b1000 set), forward the pointer to the live heap copy stored in the
+    /// owning CFP's LFP slot (`[lfp + 8]`). Null `reg` (default ProcData on a
+    /// no-block error) is left as-is. Mirrors x86 `resolve_invalidated_outer`.
+    fn a64_resolve_invalidated_outer(&mut self, reg: u32) {
+        let skip = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            cbz x(reg), skip;             // null outer -> leave (error checked later)
+            sub x10, x(reg), #(1u32);
+            ldrb w9, [x10];               // Meta.kind byte
+            mov x11, (0b1000u64);
+            tst x9, x11;                  // invalidated bit?
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &skip); // clear -> not promoted
+        monoasm_arm64!(&mut self.jit,
+            ldr x(reg), [x(reg), #(8u32)]; // forward to heap copy (cfp.lfp slot)
+            skip:
+        );
+    }
+
+    /// Lower the generic `Yield` (block call whose target is resolved at runtime
+    /// via `get_yield_data`). Mirrors x86 `gen_yield`: fetch the block's
+    /// ProcData, build the callee block frame, massage arguments, then call the
+    /// block's funcdata indirectly. The eviction-on-return patching is x86-only
+    /// (runtime branch patching), so it is skipped — class-version guards cover
+    /// it. `error` catches a missing block, an argument error, or a callee
+    /// raise. Bails on an out-of-range callee-frame offset.
+    pub(in crate::codegen::jitgen) fn emit_yield(
+        &mut self,
+        callid: CallSiteId,
+        error: &DestLabel,
+        _evict: AsmEvict,
+        _evict_label: &DestLabel,
+    ) -> bool {
+        // Closely mirrors the proven VM `a64_op_yield`. x25/x26 are callee-saved
+        // and used by neither the JIT global set (x19-x23) nor JIT'd code, so
+        // they survive the C calls and hold the outer LFP / funcdata. The
+        // continuation frame is already reserved by the surrounding
+        // xmm_save_cont, so no extra push here.
+        let f_yield = runtime::get_yield_data as *const () as u64;
+        let f_args = runtime::jit_handle_arguments_no_block as *const () as u64;
+        // get_yield_data(vm, globals) -> x0 = outer Lfp, x1 = FuncId.
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            str x30, [sp, #-16]!;
+            mov x9, (f_yield);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.a64_resolve_invalidated_outer(0);
+        self.emit_handle_error(error); // null outer (no block given) -> error
+        monoasm_arm64!(&mut self.jit, mov x25, x0;); // outer (callee-saved)
+        // get_func_data: FuncId (x1) -> &FuncData (x9 -> x26).
+        monoasm_arm64!(&mut self.jit, mov x2, x1;);
+        self.a64_get_func_data_x2(); // x9 = &FuncData (clobbers x10, x11)
+        monoasm_arm64!(&mut self.jit, mov x26, x9;);
+        // Build the callee block frame fields below sp (outer/svar/cme/block/
+        // self/meta). self is inherited from the outer frame.
+        monoasm_arm64!(&mut self.jit,
+            mov x12, (0u64);
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_OUTER) as u32);
+            str x25, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
+            str x12, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_CME) as u32);
+            str x12, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_BLOCK) as u32);
+            str x12, [x11];
+            sub x10, x25, #(LFP_SELF as u32);
+            ldr x10, [x10];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+            str x10, [x11];
+            ldr x10, [x26, #(FUNCDATA_META as u32)];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_META) as u32);
+            str x10, [x11];
+        );
+        // jit_handle_arguments_no_block(vm, globals, caller_lfp, callee_lfp,
+        // callid). callee_lfp is computed before the dynamic callee-scratch
+        // reservation; the pre-reservation sp is saved in x25 and restored
+        // afterwards (x26 survives as fdata).
+        monoasm_arm64!(&mut self.jit,
+            sub x3, sp, #(RSP_LOCAL_FRAME as u32);   // callee_lfp
+            mov x25, sp;                             // save sp (outer no longer needed)
+            ldrh w10, [x26, #(FUNCDATA_OFS as u32)];
+            lsl x10, x10, #(4);
+            add x10, x10, #(16);                     // 16-aligned reservation
+            sub x11, x25, x10;
+            mov sp, x11;
+            mov x0, x19;
+            mov x1, x20;
+            mov x2, x22;                             // caller LFP
+            mov x4, (callid.get() as u64);
+            mov x9, (f_args);
+            blr x9;                                  // x0 = Option<Value>
+            mov sp, x25;                             // restore sp
+        );
+        self.emit_handle_error(error); // argument error -> error
+        // call_funcdata (indirect, fdata in x26): push the control frame, set
+        // the callee LFP/PC, blr the codeptr, then restore the caller frame
+        // (cfp from the saved prev slot, lfp from x29 == the JIT frame pointer).
+        monoasm_arm64!(&mut self.jit,
+            ldr x10, [x19, #(EXECUTOR_CFP as u32)];
+            sub x11, sp, #(RSP_CFP as u32);
+            str x10, [x11];
+            str x11, [x19, #(EXECUTOR_CFP as u32)];
+            sub x22, sp, #(RSP_LOCAL_FRAME as u32);
+            sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
+            str x22, [x10];
+            sub x1, x21, #(16u32);                       // rcx = call_site bc ptr (caller pc - 16)
+            ldr x21, [x26, #(FUNCDATA_PC as u32)];        // PC <- callee pc
+            ldr x10, [x26, #(FUNCDATA_CODEPTR as u32)];
+            blr x10;                                       // result in x0
+            sub x11, sp, #(RSP_CFP as u32);
+            ldr x10, [x11];
+            str x10, [x19, #(EXECUTOR_CFP as u32)];
+            sub x10, x29, #((BP_CFP + CFP_LFP) as u32);
+            ldr x22, [x10];
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2321,6 +2321,74 @@ impl Codegen {
         true
     }
 
+    /// Generic binary-op C-call (no receiver-class guard), mirroring the VM's
+    /// call_binop convention: x0=vm, x1=globals, x2=lhs, x3=rhs; Option<Value>
+    /// result in x0. Bails on a live xmm pool reg or an out-of-range offset.
+    pub(in crate::codegen::jitgen) fn emit_generic_binop(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
+        let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
+        if off_l > 4095 || off_r > 4095 {
+            return false;
+        }
+        let f = func as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals
+            sub x10, x(lfp), #(off_l);
+            ldr x2, [x10];               // lhs
+            sub x10, x(lfp), #(off_r);
+            ldr x3, [x10];               // rhs
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// `lhs === rhs` for an Array lhs via runtime::array_teq (x0=vm, x1=globals,
+    /// x2=lhs, x3=rhs); Option<Value> result in x0. Bails as above.
+    pub(in crate::codegen::jitgen) fn emit_array_teq(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0;
+        let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
+        let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
+        if off_l > 4095 || off_r > 4095 {
+            return false;
+        }
+        let f = runtime::array_teq as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals
+            sub x10, x(lfp), #(off_l);
+            ldr x2, [x10];               // lhs
+            sub x10, x(lfp), #(off_r);
+            ldr x3, [x10];               // rhs
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -571,8 +571,10 @@ impl Codegen {
     /// patching (`set_deopt_with_return_addr`) is x86-only (runtime branch
     /// patching), so it is skipped — class-version changes are caught by
     /// `GuardClassVersion` deopts instead.
-    fn a64_do_call(&mut self, store: &Store, callee_fid: FuncId) {
-        let (_meta, codeptr, pc) = store[callee_fid].get_data();
+    fn a64_do_call(&mut self, store: &Store, callee_fid: FuncId, call_site_bc_ptr: BytecodePtr) {
+        let callee = &store[callee_fid];
+        let is_iseq = callee.is_iseq().is_some();
+        let (_meta, codeptr, pc) = callee.get_data();
         let codeptr_addr = codeptr.as_ptr() as u64;
         // set_lfp + push_frame (EXEC=x19, LFP=x22).
         monoasm_arm64!(&mut self.jit,
@@ -584,9 +586,19 @@ impl Codegen {
             sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
             str x22, [x10];                          // new_cfp.lfp = LFP
         );
-        if let Some(pc) = pc {
-            let pc_ptr = pc.as_ptr() as u64;
-            monoasm_arm64!(&mut self.jit, mov x21, (pc_ptr);); // PC for the VM path
+        if is_iseq {
+            // iseq: PC <- callee pc (read by the VM tier / prologue).
+            if let Some(pc) = pc {
+                let pc_ptr = pc.as_ptr() as u64;
+                monoasm_arm64!(&mut self.jit, mov x21, (pc_ptr););
+            }
+        } else {
+            // builtin: x3 is the 4th C-arg = the `pc` parameter, which with-pc
+            // builtins use as the call-site bytecode pointer. The native-func
+            // wrapper passes x3 through untouched (mirrors x86 do_call setting
+            // rcx to the call-site bc ptr).
+            let cs = call_site_bc_ptr.as_ptr() as u64;
+            monoasm_arm64!(&mut self.jit, mov x3, (cs););
         }
         monoasm_arm64!(&mut self.jit,
             mov x10, (codeptr_addr);
@@ -1664,9 +1676,9 @@ impl Codegen {
         _recv_class: ClassId,
         _evict: AsmEvict,
         _evict_label: &DestLabel,
-        _pc: BytecodePtr,
+        pc: BytecodePtr,
     ) {
-        self.a64_do_call(store, callee_fid);
+        self.a64_do_call(store, callee_fid, pc);
     }
 
     /// Method prologue: establish fp/lr, reserve the local frame, and nil-fill
@@ -2915,7 +2927,7 @@ impl Codegen {
             sub x22, sp, #(RSP_LOCAL_FRAME as u32);
             sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
             str x22, [x10];
-            sub x1, x21, #(16u32);                       // rcx = call_site bc ptr (caller pc - 16)
+            sub x3, x21, #(16u32);                       // x3 = pc arg (call-site bc ptr) for with-pc callees
             ldr x21, [x26, #(FUNCDATA_PC as u32)];        // PC <- callee pc
             ldr x10, [x26, #(FUNCDATA_CODEPTR as u32)];
             blr x10;                                       // result in x0

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2905,6 +2905,64 @@ impl Codegen {
         true
     }
 
+    /// `dst <- sp + (ofs - RSP_LOCAL_FRAME)` (the absolute callee-slot address).
+    /// The displacement is usually negative (the callee frame sits below sp).
+    /// Returns `false` if it exceeds the 12-bit add/sub immediate.
+    fn a64_rsp_slot_addr(&mut self, ofs: i32, dst: u32) -> bool {
+        let signed = ofs - RSP_LOCAL_FRAME;
+        if signed >= 0 {
+            if signed > 4095 {
+                return false;
+            }
+            monoasm_arm64!(&mut self.jit, add x(dst), sp, #(signed as u32););
+        } else {
+            let n = (-signed) as u32;
+            if n > 4095 {
+                return false;
+            }
+            monoasm_arm64!(&mut self.jit, sub x(dst), sp, #(n););
+        }
+        true
+    }
+
+    // ---- callee-frame argument stores ([sp + (ofs - RSP_LOCAL_FRAME)]) ------
+    // Used by the inline argument-setup fast path (fetch_for_callee). Bail on an
+    // out-of-range slot offset.
+
+    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- reg`
+    pub(in crate::codegen::jitgen) fn emit_reg_to_rsp_offset(&mut self, r: GP, ofs: i32) -> bool {
+        if !self.a64_rsp_slot_addr(ofs, 10) {
+            return false;
+        }
+        let r = r.a64().0;
+        monoasm_arm64!(&mut self.jit, str x(r), [x10];);
+        true
+    }
+
+    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- 0`
+    pub(in crate::codegen::jitgen) fn emit_zero_to_rsp_offset(&mut self, ofs: i32) -> bool {
+        if !self.a64_rsp_slot_addr(ofs, 10) {
+            return false;
+        }
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (0u64);
+            str x9, [x10];
+        );
+        true
+    }
+
+    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- imm`
+    pub(in crate::codegen::jitgen) fn emit_u64_to_rsp_offset(&mut self, i: u64, ofs: i32) -> bool {
+        if !self.a64_rsp_slot_addr(ofs, 10) {
+            return false;
+        }
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (i);
+            str x9, [x10];
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2492,6 +2492,77 @@ impl Codegen {
         true
     }
 
+    /// `==` / `!=` with an inline immediate fast path (mirrors the x86
+    /// `opt_eq_cmp`). If BOTH operands are non-heap, non-flonum immediates the
+    /// Ruby result is exact bit (identity) equality, produced inline via
+    /// cmp + cset; otherwise fall through to the generic C-call `func`
+    /// (x0=vm, x1=globals, x2=lhs, x3=rhs). `lhs`/`rhs` are loaded into x2/x3
+    /// up front so the slow path can reuse them. Bails on a live xmm pool reg
+    /// or an out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_opt_eq_cmp(
+        &mut self,
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
+        let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
+        if off_l > 4095 || off_r > 4095 {
+            return false;
+        }
+        let f = func as u64;
+        let slow = self.jit.label();
+        let done = self.jit.label();
+        // Load operands into the C-arg registers (reused by the slow path).
+        // Heap iff (bits & 0b111) == 0; Flonum iff (bits & 0b011) == 0b010.
+        // Either operand heap/flonum -> generic C-call.
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off_l);
+            ldr x2, [x10];               // lhs
+            sub x10, x(lfp), #(off_r);
+            ldr x3, [x10];               // rhs
+            mov x14, (7u64);
+            and x9, x2, x14;
+            cbz x9, slow;                // lhs heap -> slow
+            mov x14, (3u64);
+            and x9, x2, x14;
+            cmp x9, #(2u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &slow); // lhs flonum -> slow
+        monoasm_arm64!(&mut self.jit,
+            mov x14, (7u64);
+            and x9, x3, x14;
+            cbz x9, slow;                // rhs heap -> slow
+            mov x14, (3u64);
+            and x9, x3, x14;
+            cmp x9, #(2u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &slow); // rhs flonum -> slow
+        // Fast path: both identity-comparable immediates -> bit equality.
+        monoasm_arm64!(&mut self.jit,
+            cmp x2, x3;
+        );
+        self.a64_flag_to_bool(kind); // x0 = bool Value
+        monoasm_arm64!(&mut self.jit,
+            b done;
+        slow:
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals (x2=lhs, x3=rhs intact)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        done:
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2963,6 +2963,95 @@ impl Codegen {
         true
     }
 
+    /// `&block` proxy: materialize the current method's block handler into
+    /// `ret`. Walk `outer` outer-frame links to reach the method LFP (x0), load
+    /// its block slot ([lfp - LFP_BLOCK]); if the low bit is set (already a
+    /// BlockHandler proxy rather than a frame pointer) bump the nesting tag by
+    /// `(outer << 2) + 2`. No runtime call, no xmm pressure. Bails on an
+    /// out-of-range frame offset or nesting tag immediate.
+    pub(in crate::codegen::jitgen) fn emit_block_arg_proxy(
+        &mut self,
+        ret: SlotId,
+        outer: usize,
+    ) -> bool {
+        let lfp = GP::R14.a64().0; // x22
+        let rax = GP::Rax.a64().0; // x0
+        let off = ret.0 as u32 * 8 + LFP_SELF as u32;
+        let tag = ((outer << 2) + 2) as u32;
+        if off > 4095 || tag > 4095 {
+            return false;
+        }
+        // get_method_lfp(outer): x0 <- method LFP (walk `outer` outer links).
+        if outer == 0 {
+            monoasm_arm64!(&mut self.jit, mov x(rax), x(lfp););
+        } else {
+            monoasm_arm64!(&mut self.jit, ldr x(rax), [x(lfp)];);
+            for _ in 0..outer - 1 {
+                monoasm_arm64!(&mut self.jit, ldr x(rax), [x(rax)];);
+            }
+        }
+        // block_arg_proxy(outer): x0 <- [x0 - LFP_BLOCK]; if (x0 & 1) bump tag.
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(rax), #(LFP_BLOCK as u32);
+            ldr x(rax), [x10];
+            mov x11, (1u64);
+            tst x(rax), x11;             // Z = ((x0 & 1) == 0)
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+        monoasm_arm64!(&mut self.jit,
+            add x(rax), x(rax), #(tag);
+            exit:
+        );
+        // store_rax(ret): [lfp - off] <- x0
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off);
+            str x(rax), [x10];
+        );
+        true
+    }
+
+    /// `&block` captured as a Proc value: runtime::block_arg(vm, globals, lfp,
+    /// call_site) materializes the current frame's block handler into a Proc
+    /// (promoting the frame to the heap if needed). The Option<Value> result is
+    /// stored to `ret` after a HandleError. Bails on a live xmm pool reg (no
+    /// save around the C call) or an out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_block_arg(
+        &mut self,
+        ret: SlotId,
+        using_xmm: UsingXmm,
+        call_site_bc_ptr: BytecodePtr,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off = ret.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let cs = call_site_bc_ptr.as_ptr() as u64;
+        let f = runtime::block_arg as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;          // vm
+            mov x1, x20;          // globals
+            mov x2, x(lfp);       // caller LFP
+            mov x3, (cs);         // call-site bc ptr
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;               // x0 = Option<Value>
+            ldr x30, [sp], #16;
+        );
+        self.emit_handle_error(error);
+        let rax = GP::Rax.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(off);
+            str x(rax), [x10];    // ret <- Proc
+        );
+        true
+    }
+
     /// Side-effect guard for a method that passes a block: deopt if the current
     /// frame has been captured/promoted (so a materialized closure observes
     /// later local writes). Tests the captured (0b1000_0000) / invalidated

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2563,6 +2563,81 @@ impl Codegen {
         true
     }
 
+    /// Unary float C helper `f(f64) -> f64` (sin, sqrt, …): load the operand
+    /// into d0 (the first/only AAPCS f64 arg = return reg), call, store d0 into
+    /// dst. The live FP pool (d2-d7, caller-saved = clobbered by the callee) is
+    /// saved/restored around the call exactly like the x86 twin. Bails if the
+    /// source or destination is a spill slot (a64_fpr only handles d2-d7).
+    pub(in crate::codegen::jitgen) fn emit_cfunc_f_f(
+        &mut self,
+        f: unsafe extern "C" fn(f64) -> f64,
+        src: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) -> bool {
+        let Some(s) = self.a64_fpr(src, base) else {
+            return false;
+        };
+        let Some(d) = self.a64_fpr(dst, base) else {
+            return false;
+        };
+        let fp = f as u64;
+        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            fmov d0, d(s);
+            mov x9, (fp);
+            blr x9;            // result in d0
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            ldr x30, [sp], #16;
+            fmov d(d), d0;
+        );
+        true
+    }
+
+    /// Binary float C helper `f(f64, f64) -> f64` (atan2, hypot, …): load lhs
+    /// into d0 and rhs into d1 (the first two AAPCS f64 args), call, store the
+    /// d0 result into dst. Pool sources resolve to d2-d7 so they never alias the
+    /// d0/d1 scratch regs. Saves/restores the live FP pool like the x86 twin.
+    /// Bails if any operand or the destination is a spill slot.
+    pub(in crate::codegen::jitgen) fn emit_cfunc_ff_f(
+        &mut self,
+        f: extern "C" fn(f64, f64) -> f64,
+        lhs: FPReg,
+        rhs: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) -> bool {
+        let Some(l) = self.a64_fpr(lhs, base) else {
+            return false;
+        };
+        let Some(r) = self.a64_fpr(rhs, base) else {
+            return false;
+        };
+        let Some(d) = self.a64_fpr(dst, base) else {
+            return false;
+        };
+        let fp = f as u64;
+        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            fmov d0, d(l);
+            fmov d1, d(r);
+            mov x9, (fp);
+            blr x9;            // result in d0
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            ldr x30, [sp], #16;
+            fmov d(d), d0;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2012,6 +2012,99 @@ impl Codegen {
         true
     }
 
+    /// Check class variable existence via runtime::check_class_var(vm, globals,
+    /// name); the looked-up Value lands in x0. Bails when an xmm pool register
+    /// is live (no xmm save around the C call yet).
+    pub(in crate::codegen::jitgen) fn emit_check_cvar(
+        &mut self,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::check_class_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, (name.get() as u64); // name (IdentId)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// @@cvar <- src via runtime::set_class_var(vm, globals, name, val). The
+    /// Option<Value> result (None == error) is checked by a following
+    /// HandleError. Bails when an xmm pool register is live or the slot offset
+    /// exceeds the 12-bit scaled load immediate.
+    pub(in crate::codegen::jitgen) fn emit_store_cvar(
+        &mut self,
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off = src.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::set_class_var as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, (name.get() as u64); // name (IdentId)
+            sub x10, x(lfp), #(off);
+            ldr x3, [x10];               // val (from slot)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
+    /// Alias a method via runtime::alias_method(vm, globals, old, new) where
+    /// `old`/`new` are the symbol/string Values read from the `old`/`new`
+    /// frame slots. The Option<Value> result (None == error) is checked by a
+    /// following HandleError. Bails when an xmm pool register is live or a slot
+    /// offset exceeds the 12-bit scaled load immediate.
+    pub(in crate::codegen::jitgen) fn emit_alias_method(
+        &mut self,
+        new: SlotId,
+        old: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off_old = old.0 as u32 * 8 + LFP_SELF as u32;
+        let off_new = new.0 as u32 * 8 + LFP_SELF as u32;
+        if off_old > 4095 || off_new > 4095 {
+            return false;
+        }
+        let f = runtime::alias_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm (Executor)
+            mov x1, x20;                 // globals
+            sub x10, x(lfp), #(off_old);
+            ldr x2, [x10];              // old (slot value)
+            sub x10, x(lfp), #(off_new);
+            ldr x3, [x10];             // new (slot value)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2704,6 +2704,84 @@ impl Codegen {
         true
     }
 
+    // ---- exception / non-local control flow -------------------------------
+    // All four branch into `entry_raise` (the shared unwind/dispatch entry,
+    // bound by a64_gen_entry_raise). None carry a `using_xmm` set — an
+    // in-flight exception abandons the FP pool. C-arg regs: x0=vm (x19).
+
+    /// `raise` — runtime::raise_err(vm, err_val) then unwind. The value to
+    /// raise is in the accumulator scratch (GP::Rax = x0), so it is moved into
+    /// x1 *before* x0 is overwritten with the executor.
+    pub(in crate::codegen::jitgen) fn emit_raise(&mut self) -> bool {
+        let raise = self.entry_raise();
+        let acc = GP::Rax.a64().0; // x0
+        let f = runtime::raise_err as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x1, x(acc);          // err_val (read before clobbering x0)
+            mov x0, x19;             // vm
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            b raise;
+        );
+        true
+    }
+
+    /// `retry` — set PC (x21) to `pc + 1`, call runtime::err_retry(vm), unwind.
+    pub(in crate::codegen::jitgen) fn emit_retry(&mut self, pc: BytecodePtr) -> bool {
+        let raise = self.entry_raise();
+        let pcv = (pc + 1).as_ptr() as u64;
+        let f = runtime::err_retry as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x21, (pcv);          // PC <- pc + 1
+            mov x0, x19;             // vm
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            b raise;
+        );
+        true
+    }
+
+    /// `redo` — like `retry` but runtime::err_redo(vm).
+    pub(in crate::codegen::jitgen) fn emit_redo(&mut self, pc: BytecodePtr) -> bool {
+        let raise = self.entry_raise();
+        let pcv = (pc + 1).as_ptr() as u64;
+        let f = runtime::err_redo as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x21, (pcv);          // PC <- pc + 1
+            mov x0, x19;             // vm
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            b raise;
+        );
+        true
+    }
+
+    /// End of an `ensure` clause — runtime::ensure_end(vm) returns a nonzero
+    /// value when a pending exception must keep propagating (→ entry_raise);
+    /// zero means fall through to the normal continuation.
+    pub(in crate::codegen::jitgen) fn emit_ensure_end(&mut self) -> bool {
+        let raise = self.entry_raise();
+        let cont = self.jit.label();
+        let f = runtime::ensure_end as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;             // vm
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                  // x0 = 0 (continue) / nonzero (re-raise)
+            ldr x30, [sp], #16;
+            cbz x0, cont;
+            b raise;
+            cont:
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2638,6 +2638,72 @@ impl Codegen {
         true
     }
 
+    /// `def name; … end` — runtime::define_method(vm, globals, name, func_id).
+    /// The Option<Value> result (None == error) is checked by the trailing
+    /// HandleError. Bails when an xmm pool register is live (no save around the
+    /// C call).
+    pub(in crate::codegen::jitgen) fn emit_method_def(
+        &mut self,
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let f = runtime::define_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                     // vm (Executor)
+            mov x1, x20;                     // globals
+            mov x2, (name.get() as u64);     // name (IdentId)
+            mov x3, (func_id.get() as u64);  // func_id (FuncId)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                          // x0 = Option<Value>
+            ldr x30, [sp], #16;
+        );
+        self.emit_handle_error(error);
+        true
+    }
+
+    /// `def obj.name; … end` — runtime::singleton_define_method(vm, globals,
+    /// name, func_id, obj) where `obj` is the receiver Value read from its
+    /// frame slot (5th AAPCS arg = x4). Bails on a live xmm pool reg or an
+    /// out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_singleton_method_def(
+        &mut self,
+        obj: SlotId,
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let off = obj.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let f = runtime::singleton_define_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                     // vm (Executor)
+            mov x1, x20;                     // globals
+            mov x2, (name.get() as u64);     // name (IdentId)
+            mov x3, (func_id.get() as u64);  // func_id (FuncId)
+            sub x10, x(lfp), #(off);
+            ldr x4, [x10];                   // obj (receiver Value)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                          // x0 = Option<Value>
+            ldr x30, [sp], #16;
+        );
+        self.emit_handle_error(error);
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2452,6 +2452,46 @@ impl Codegen {
         true
     }
 
+    /// Multiple-assignment array expansion via runtime::expand_array(src, dst,
+    /// len, rest). `src` is already in GP::Rdi (x4) from the preceding load;
+    /// `dst` is the (descending) destination base x22-conv(dst). aarch64 C-args:
+    /// x0=src, x1=&dst, x2=len, x3=rest (rest = rest_pos+1, or 0 for none).
+    /// Bails on a live xmm pool reg or an out-of-range frame offset.
+    pub(in crate::codegen::jitgen) fn emit_expand_array(
+        &mut self,
+        dst: SlotId,
+        len: usize,
+        rest_pos: Option<usize>,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let rest = if let Some(rest_pos) = rest_pos {
+            rest_pos as u64 + 1
+        } else {
+            0
+        };
+        let lfp = GP::R14.a64().0; // x22
+        let off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        if off > 4095 {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0; // x4 holds src
+        let f = runtime::expand_array as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);              // src (from GP::Rdi)
+            sub x1, x(lfp), #(off);      // &dst (descending base)
+            mov x2, (len as u64);        // len
+            mov x3, (rest);              // rest (0 = none)
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        true
+    }
+
     /// Per-arch (aarch64) lowering for every `AsmInst` not handled by the
     /// arch-neutral `compile_asmir` dispatcher. Returns `false` for any
     /// not-yet-ported variant (the method then stays VM-interpreted).

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -80,7 +80,10 @@ impl Codegen {
     ) -> bool {
         self.jit.bind_label(entry_label);
         frame.start_codepos = self.jit.get_current();
-        // Specialized methods / inline bridges are not supported yet.
+        // Specialized (inlined) frames are unsupported by the A64 lowering, so
+        // the front-end never builds them on aarch64 (see the `cfg!(jit_x86)`
+        // gate in compile.rs / method_call.rs). This stays as a defensive net:
+        // if one ever appears, bail to the VM rather than emit wrong code.
         if !frame.specialized_methods.is_empty() {
             return false;
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1864,10 +1864,22 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
         if i != 0 {
             let d = reg.a64().0;
-            monoasm_arm64!(&mut self.jit,
-                mov x9, (i as i64 as u64);
-                add x(d), x(d), x9;
-            );
+            if reg == GP::Rsp {
+                // Register 31 decodes as XZR (not SP) in the add/sub
+                // shifted-register form, so `add x31, x31, x9` would be a no-op.
+                // Go through a GP temp: mov to/from SP is the sp-aware form.
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (i as i64 as u64);
+                    mov x10, sp;
+                    add x10, x10, x9;
+                    mov sp, x10;
+                );
+            } else {
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (i as i64 as u64);
+                    add x(d), x(d), x9;
+                );
+            }
         }
     }
 
@@ -1875,10 +1887,21 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
         if i != 0 {
             let d = reg.a64().0;
-            monoasm_arm64!(&mut self.jit,
-                mov x9, (i as i64 as u64);
-                sub x(d), x(d), x9;
-            );
+            if reg == GP::Rsp {
+                // See emit_reg_add: SP must be updated via a GP temp (reg 31 is
+                // XZR in the shifted-register form).
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (i as i64 as u64);
+                    mov x10, sp;
+                    sub x10, x10, x9;
+                    mov sp, x10;
+                );
+            } else {
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (i as i64 as u64);
+                    sub x(d), x(d), x9;
+                );
+            }
         }
     }
 

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -465,7 +465,10 @@ impl<'a> JitContext<'a> {
                 cache,
             } => return self.method_call(state, ir, callid, cache),
             TraceIr::Yield { callid } => {
-                if let Some(block_info) = self.current_method_given_block()
+                // aarch64: specialized (inlined) yield is unsupported by the A64
+                // lowering, so fall through to the plain `compile_yield` path.
+                if cfg!(jit_x86)
+                    && let Some(block_info) = self.current_method_given_block()
                     && let Some(iseq) = self.store[block_info.block_fid].is_iseq()
                 {
                     return self.compile_yield_specialized(state, ir, callid, &block_info, iseq);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -284,7 +284,12 @@ impl<'a> JitContext<'a> {
                             && (args..args + pos_num).any(|i| state.is_C_immediate(i))));
                 let iseq_block = block_fid.map(|fid| self.store[fid].is_iseq()).flatten();
 
-                if iseq_block.is_some() || (specializable && self.specialize_level() < 5)
+                // aarch64: the A64 lowering does not yet support specialized
+                // (inlined) frames, so never enter one — fall through to the
+                // plain `send` path below, which is always a correct
+                // (un-inlined) fallback. On x86 keep specializing as before.
+                if cfg!(jit_x86)
+                    && (iseq_block.is_some() || (specializable && self.specialize_level() < 5))
                 /*name == Some(IdentId::NEW)*/
                 {
                     return self.specialized_iseq(

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1074,6 +1074,12 @@ impl<'a> JitContext<'a> {
     /// [`Self::outer_specialized_ids`] for the rationale.
     ///
     pub(super) fn method_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
+        // aarch64 never builds specialized frames (see the `cfg!(jit_x86)` gate
+        // in method_call.rs), so there is no caller chain to encode — fall back
+        // to the plain `MethodRet` instead of `MethodRetSpecialized`.
+        if !cfg!(jit_x86) {
+            return None;
+        }
         let caller = self.method_caller_pos()?;
         let begin = caller + 1;
         let end = self.stack_frame.len() - 1;
@@ -1095,6 +1101,11 @@ impl<'a> JitContext<'a> {
     /// [`Self::method_caller_specialized_ids`].
     ///
     pub(super) fn iter_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
+        // aarch64: no specialized frames (see `method_caller_specialized_ids`),
+        // so emit the plain `BlockBreak` instead of `BlockBreakSpecialized`.
+        if !cfg!(jit_x86) {
+            return None;
+        }
         let caller = self.iter_caller_pos()?;
         let begin = caller + 1;
         let end = self.stack_frame.len() - 1;


### PR DESCRIPTION
## Overview

Incrementally grows the aarch64 JIT (`jitgen`) `AsmInst` coverage. Each instruction family is moved into the shared `compile_asmir` dispatcher with an x86 (`monoasm!`) twin and an aarch64 (`monoasm_arm64!`) twin; anything still unported bails cleanly (`false`) so the method stays VM-interpreted. The end result: real Ruby — custom iterators, `&block` forwarding, method/class definitions, float math, exceptions — now JIT-compiles on aarch64.

Based on `darwin` (which already carries the prior aarch64 series up to #653); the diff here is exactly the 14 commits below.

## Contents

### Foundation
- **Disable method/block specialization on aarch64** so the plain (un-inlined) `send` path is always emitted — specialized/inlined frames are not yet supported, and this keeps the deferred `Specialized*` ops unreachable rather than half-handled.

### Runtime-call op families
- **CheckCVar / StoreCVar / AliasMethod**
- **`defined?` family** (7 variants: method/const/ivar/gvar/cvar/yield/super, two ABI shapes)
- **GenericBinOp / ArrayTEq**
- **ConcatRegexp / CheckKwRest**
- **ExpandArray** (multiple-assignment splat)
- **OptEqCmp** (`==`/`!=` inline-immediate fast path)
- **MethodDef / SingletonMethodDef** (`def` / `def obj.meth`)

### Float C-function calls
- **CFunc_F_F / CFunc_FF_F** — `Math.sin/cos/exp/…` and `Float#/ % **`. Loads operands into d0/d1, saves/restores the live FP pool (D2–D7, caller-saved) around the call, stores the d0 result.

### Exception / non-local control flow
- **Raise / Retry / Redo / EnsureEnd** — all branch into the shared `entry_raise` unwind path.

### Call / block / yield cluster
- **RegToRSPOffset / ZeroToRSPOffset / U64ToRSPOffset** — inline argument-setup stores; unblocks **any method call with arguments**.
- **generic Yield** — `yield` resolved at runtime via `get_yield_data` + indirect `call_funcdata`; mirrors the proven VM `a64_op_yield`. Unblocks **all custom iterators**.
- **GuardCapture** — block-passing side-effect guard; unblocks **block-passing callers** (`foo { … }`).
- **BlockArgProxy / BlockArg** — `&block` forwarding and capture-as-Proc.

Deferred (per request): `SpecializedCall` / `SpecializedYield` / `SetupYieldFrame` (specialized/inlined paths). `BlockBreak` is not emitted by ordinary `break` (which JITs via the yield-return path) and so is left unported until a case that needs it appears. `OptCase` / `RestKw` / `StoreIVarHeap` still need new infrastructure (const-pool / PC-relative addressing / cold-page allocation).

## Verification

Every slice was checked with `cargo check` on **x86_64** and **aarch64-unknown-linux-gnu**, then run under **qemu-aarch64** and compared against both CRuby and the x86 monoruby build. The aarch64 methods were confirmed to actually JIT-compile (no `abort compile`) so the new lowerings are exercised on the JIT path, not just compiled. Representative end-to-end check (custom iterators + `&block` forwarding + `break` + classes/ivars): CRuby = aarch64 = x86 = `102000`.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae