### PR TITLE
jit(aarch64): port StoreIVarHeap (heap instance-variable store)

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -114,6 +114,7 @@ impl Codegen {
             | AsmInst::BlockArg { .. }
             | AsmInst::LoopJitRspBump { .. }
             | AsmInst::StoreSelfIVarHeap { .. }
+            | AsmInst::StoreIVarHeap { .. }
             | AsmInst::LoadIVarHeap { .. }
             | AsmInst::UndefMethod { .. }
             | AsmInst::AliasGvar { .. }
@@ -255,12 +256,6 @@ impl Codegen {
                 self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
             }
 
-            AsmInst::StoreIVarHeap {
-                src,
-                ivarid,
-                is_object_ty,
-                using_xmm,
-            } => self.store_ivar_heap(src, ivarid, is_object_ty, using_xmm),
             AsmInst::ClassDef {
                 base,
                 superclass,
@@ -1883,6 +1878,19 @@ impl Codegen {
         self.block_arg(using_xmm, call_site_bc_ptr);
         self.handle_error(error);
         self.store_rax(ret);
+        true
+    }
+
+    // ---- heap instance-variable store (former per-arch arm) ----
+
+    pub(in crate::codegen::jitgen) fn emit_store_ivar_heap(
+        &mut self,
+        src: GP,
+        ivarid: IvarId,
+        is_object_ty: bool,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.store_ivar_heap(src, ivarid, is_object_ty, using_xmm);
         true
     }
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -329,6 +329,15 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
             } => return self.emit_store_self_ivar_heap(src, ivarid, is_object_ty),
+            // Store into a heap-spilled ivar of another object (bounds-checked;
+            // grows the table via a runtime call on miss). aarch64 bails on an
+            // out-of-range field offset.
+            AsmInst::StoreIVarHeap {
+                src,
+                ivarid,
+                is_object_ty,
+                using_xmm,
+            } => return self.emit_store_ivar_heap(src, ivarid, is_object_ty, using_xmm),
             // Load a heap-spilled instance variable (bounds-checked unless self),
             // substituting nil for an out-of-range / unset slot.
             AsmInst::LoadIVarHeap {

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1960,6 +1960,70 @@ impl Codegen {
         true
     }
 
+    /// Store `src` into a heap-spilled instance variable of the object in rdi
+    /// (x4) — the non-self twin of emit_store_self_ivar_heap. The var-table may
+    /// be too small (None / capa 0 / len <= idx), so the fast inline store is
+    /// guarded by a bounds check that falls through to a cold
+    /// `set_ivar(obj, ivarid, src)` runtime call (which grows the table). The
+    /// live FP pool is saved around that call. aarch64 lays the cold path inline
+    /// (no separate page). Bails on an out-of-range field offset.
+    pub(in crate::codegen::jitgen) fn emit_store_ivar_heap(
+        &mut self,
+        src: GP,
+        ivarid: IvarId,
+        is_object_ty: bool,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        let ivar = ivarid.get() as u32;
+        let idx = if is_object_ty {
+            ivar - OBJECT_INLINE_IVAR as u32
+        } else {
+            ivar
+        };
+        let off = idx * 8;
+        if !Self::a64_field_off_ok(off) {
+            return false;
+        }
+        let rdi = GP::Rdi.a64().0; // object (&RValue)
+        let s = src.a64().0;
+        let generic = self.jit.label();
+        let exit = self.jit.label();
+        // var_table bounds check (None / capa 0 / len <= idx -> grow via runtime).
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_VAR as u32)];
+            cbz x9, generic;
+            ldr x10, [x9, #(MONOVEC_CAPA as u32)];
+            cbz x10, generic;
+            ldr x10, [x9, #(MONOVEC_LEN as u32)];
+            cmp x10, #(idx);
+        );
+        self.jit.bcond_label(monoasm::Cond::Le, &generic); // len <= idx -> grow
+        // fast path: write straight into the table slot.
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x9, #(MONOVEC_PTR as u32)];
+            str x(s), [x9, #(off)];
+            b exit;
+        );
+        // cold path: set_ivar(obj, ivarid, src), preserving the FP pool. src (s)
+        // and rdi survive emit_xmm_save (it only touches d-regs / sp) and are
+        // read into the C-arg regs just before the call.
+        let f = set_ivar as *const () as u64;
+        monoasm_arm64!(&mut self.jit, generic:);
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);            // base: &mut RValue
+            mov x1, (ivar as u64);     // id: IvarId
+            mov x2, x(s);              // val
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit, exit:);
+        true
+    }
+
     /// Load a heap-spilled instance variable into the accumulator (x23). Unless
     /// loading from self, bounds-check the var-table (None / capa 0 / len <= idx
     /// -> nil); an unset (zero) slot also reads nil. Bails on an out-of-range
@@ -3124,4 +3188,12 @@ impl Codegen {
         // keep the method VM-interpreted.
         false
     }
+}
+
+/// `set_ivar(base, id, val)` runtime helper for the StoreIVarHeap cold path
+/// (grows the var-table as needed). The x86 twin lives in
+/// `compile/variables.rs`; that module is `jit_x86`-only, so aarch64 carries
+/// its own copy (the two are never compiled together).
+extern "C" fn set_ivar(base: &mut RValue, id: IvarId, val: Value) {
+    base.set_ivar_by_ivarid(id, val)
 }


### PR DESCRIPTION
## Overview

Continues the aarch64 JIT `AsmInst` porting (follow-up to #654). Ports
**StoreIVarHeap** — the non-self twin of the already-ported StoreSelfIVarHeap.

Emitted by the attr_writer fast path (`obj.attr = val`) when the ivar lives in
the heap-spilled var-table of an object that isn't necessarily `self`, so the
table may be too small and must be grown.

`emit_store_ivar_heap` (aarch64):
- Bounds-checks the var-table (None / capa 0 / len ≤ idx) — same shape as the
  ported `emit_load_ivar_heap` — and on the fast path writes straight into the
  slot.
- On a miss, falls through to a cold `set_ivar(obj, ivarid, src)` runtime call
  that grows the table, with the live FP pool saved/restored around it. aarch64
  lays the cold path inline (no separate page), so no page switch is needed.
- Bails on an out-of-range field offset.

`set_ivar` lives in the `jit_x86`-only `compile/variables.rs`; since the x86 and
aarch64 backend modules are never compiled together, aarch64 carries its own
identical copy.

## Verification

`cargo check` on x86_64 and aarch64-unknown-linux-gnu. Under qemu-aarch64,
`obj.attr = v` for a heap-spilled ivar JIT-compiles and matches CRuby / the x86
build (`13498500`), exercising both the table-grow cold path (fresh objects) and
the fast inline store (reused object). The decisive validation is this PR's
**darwin (native arm64) CI** — in #654 two bugs (an SP no-op and a missing
with-pc-builtin pc arg) surfaced only on native hardware, not under qemu, so a
native run is the real gate here.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae

---
_Generated by [Claude Code](https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae)_