### PR TITLE
jit(aarch64): port OptCase + BlockBreak; rename CI job to amd64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
     branches: [master, "darwin*"]
 
 jobs:
-  coverage:
+  amd64:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
@@ -50,7 +50,7 @@ jobs:
     # cfg on arm64 (only `jit_x86` is x86-only), so this builds and runs the
     # AArch64 JIT (AsmIR→A64 backend, asmir/compile_stub.rs) — instructions not
     # yet ported bail to the VM. It runs the same `bin/test` as the Linux
-    # `coverage` job (portable head/yjit handling makes it BSD/macOS-safe), so
+    # `amd64` job (portable head/yjit handling makes it BSD/macOS-safe), so
     # the arm64 VM + JIT get the full check scope (unit tests, benchmark diffs,
     # optcarrot, ruby-bench, ruby/spec).
     #
@@ -60,7 +60,7 @@ jobs:
     # independent of the JIT (`--no-jit` crashes the same way) and does not
     # reproduce on x86-64, qemu-aarch64, or a local Apple Silicon Mac — so it is
     # specific to native-M1 + coverage instrumentation and is tracked
-    # separately. The Linux `coverage` job owns the Codecov upload.
+    # separately. The Linux `amd64` job owns the Codecov upload.
     runs-on: macos-latest
     env:
       CARGO_TERM_COLOR: always

--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 set -e
 
 # Portable helpers so this script runs unmodified on x86-64 Linux (CI's
-# `coverage` job) and native arm64 macOS (the `darwin` job). On arm64 macOS
+# `amd64` job) and native arm64 macOS (the `darwin` job). On arm64 macOS
 # build.rs sets the `jit` cfg, so this also exercises and coverage-measures the
 # AArch64 JIT (asmir/compile_stub.rs).
 
@@ -49,7 +49,7 @@ fi
 
 cov_clean
 cov_nextest "${STRESS_FEATURES[@]}"
-MONORUBY_PARSER=ruruby cov_nextest "${STRESS_FEATURES[@]}"
+#MONORUBY_PARSER=ruruby cov_nextest "${STRESS_FEATURES[@]}"
 
 cov_build
 
@@ -70,19 +70,19 @@ diff -s monoruby.log ruby.log
 #"${RUBY[@]}" benchmark/bf.rb > ruby.log
 #diff -s monoruby.log ruby.log
 
-echo "checking plb2.."
-$MONORUBY benchmark/plb2/nqueen.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/nqueen.rb > ruby.log
-diff -s monoruby.log ruby.log
-$MONORUBY benchmark/plb2/sudoku.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/sudoku.rb > ruby.log
-diff -s monoruby.log ruby.log
-$MONORUBY benchmark/plb2/matmul.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/matmul.rb > ruby.log
-diff -s monoruby.log ruby.log
-$MONORUBY benchmark/plb2/bedcov.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/bedcov.rb > ruby.log
-diff -s monoruby.log ruby.log
+#echo "checking plb2.."
+#$MONORUBY benchmark/plb2/nqueen.rb > monoruby.log
+#"${RUBY[@]}" benchmark/plb2/nqueen.rb > ruby.log
+#diff -s monoruby.log ruby.log
+#$MONORUBY benchmark/plb2/sudoku.rb > monoruby.log
+#"${RUBY[@]}" benchmark/plb2/sudoku.rb > ruby.log
+#diff -s monoruby.log ruby.log
+#$MONORUBY benchmark/plb2/matmul.rb > monoruby.log
+#"${RUBY[@]}" benchmark/plb2/matmul.rb > ruby.log
+#diff -s monoruby.log ruby.log
+#$MONORUBY benchmark/plb2/bedcov.rb > monoruby.log
+#"${RUBY[@]}" benchmark/plb2/bedcov.rb > ruby.log
+#diff -s monoruby.log ruby.log
 
 $MONORUBY benchmark/so_mandelbrot.rb > benchmark/mandel1.ppm
 $MONORUBY --no-jit benchmark/so_mandelbrot.rb > benchmark/mandel2.ppm

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -47,6 +47,7 @@ impl Codegen {
             | AsmInst::CondBr(..)
             | AsmInst::NilBr(..)
             | AsmInst::CheckLocal(..)
+            | AsmInst::OptCase { .. }
             | AsmInst::GuardClass(..)
             | AsmInst::Deopt(..)
             | AsmInst::HandleError(..)
@@ -204,31 +205,6 @@ impl Codegen {
             AsmInst::BlockBreakSpecialized { rbp_offset } => {
                 self.method_return_specialized(rbp_offset.unwrap_concrete());
             }
-            AsmInst::OptCase {
-                max,
-                min,
-                else_label,
-                branch_labels,
-            } => {
-                // generate a jump table.
-                let jump_table = self.jit.const_align8();
-                for label in branch_labels.iter() {
-                    let dest_label = frame.resolve_label(&mut self.jit, *label);
-                    self.jit.abs_address(dest_label);
-                }
-
-                let else_dest = frame.resolve_label(&mut self.jit, else_label);
-                monoasm! {&mut self.jit,
-                    sarq rdi, 1;
-                    cmpq rdi, (max);
-                    jgt  else_dest;
-                    subq rdi, (min);
-                    jlt  else_dest;
-                    lea  rax, [rip + jump_table];
-                    jmp  [rax + rdi * 8];
-                };
-            }
-
             AsmInst::SetupYieldFrame { meta, outer } => {
                 self.setup_yield_frame(meta, outer);
             }
@@ -1198,6 +1174,36 @@ impl Codegen {
             movq r13, ((pc + 1).as_ptr());
         };
         self.method_return();
+    }
+
+    /// Dense-integer `case` dispatch (cond fixnum in rdi). Build a jump table of
+    /// absolute branch-target addresses, range-check `[min, max]`, then index
+    /// it with `cond - min`.
+    pub(in crate::codegen::jitgen) fn emit_opt_case(
+        &mut self,
+        frame: &mut AsmInfo,
+        max: u16,
+        min: u16,
+        else_label: JitLabel,
+        branch_labels: Box<[JitLabel]>,
+    ) {
+        // generate a jump table.
+        let jump_table = self.jit.const_align8();
+        for label in branch_labels.iter() {
+            let dest_label = frame.resolve_label(&mut self.jit, *label);
+            self.jit.abs_address(dest_label);
+        }
+
+        let else_dest = frame.resolve_label(&mut self.jit, else_label);
+        monoasm! {&mut self.jit,
+            sarq rdi, 1;
+            cmpq rdi, (max);
+            jgt  else_dest;
+            subq rdi, (min);
+            jlt  else_dest;
+            lea  rax, [rip + jump_table];
+            jmp  [rax + rdi * 8];
+        };
     }
 
     /// Record this position as the return-address patch point for `evict`.

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -86,6 +86,7 @@ impl Codegen {
             | AsmInst::FloatCmpBr { .. }
             | AsmInst::Ret
             | AsmInst::MethodRet(..)
+            | AsmInst::BlockBreak(..)
             | AsmInst::ImmediateEvict { .. }
             | AsmInst::GuardClassVersion { .. }
             | AsmInst::SetupMethodFrame { .. }
@@ -193,12 +194,6 @@ impl Codegen {
                 self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
 
-            AsmInst::BlockBreak(pc) => {
-                monoasm! { &mut self.jit,
-                    movq r13, ((pc + 1).as_ptr());
-                };
-                self.block_break();
-            }
             AsmInst::MethodRetSpecialized { rbp_offset } => {
                 self.method_return_specialized(rbp_offset.unwrap_concrete());
             }
@@ -1174,6 +1169,14 @@ impl Codegen {
             movq r13, ((pc + 1).as_ptr());
         };
         self.method_return();
+    }
+
+    /// Non-local exit through the block-break path, resuming at `pc + 1`.
+    pub(in crate::codegen::jitgen) fn emit_block_break(&mut self, pc: BytecodePtr) {
+        monoasm! { &mut self.jit,
+            movq r13, ((pc + 1).as_ptr());
+        };
+        self.block_break();
     }
 
     /// Dense-integer `case` dispatch (cond fixnum in rdi). Build a jump table of

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -69,6 +69,16 @@ impl Codegen {
                 let dest = frame.resolve_label(&mut self.jit, dest);
                 self.emit_check_local(dest);
             }
+            // Dense-integer `case`: range-check the (fixnum) condition against
+            // `[min, max]`, then dispatch through a jump table of absolute
+            // branch-target addresses (else for out-of-range). Terminates the
+            // basic block (no fallthrough).
+            AsmInst::OptCase {
+                max,
+                min,
+                else_label,
+                branch_labels,
+            } => self.emit_opt_case(frame, max, min, else_label, branch_labels),
             // Type guard: deopt if `r`'s runtime class is not `class`. (aarch64
             // bails for not-yet-supported class kinds, hence the bool result.)
             AsmInst::GuardClass(r, class, deopt) => {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -229,10 +229,13 @@ impl Codegen {
             }
             // Method return / eviction family. `Ret` tears down the frame and
             // returns; `MethodRet` sets the resume PC then returns through the
-            // method-return path; `ImmediateEvict` records a return-address
-            // patch point on x86 (a no-op on aarch64, which can't patch them).
+            // method-return path; `BlockBreak` does the same through the
+            // block-break path (a non-local `break` out of a block);
+            // `ImmediateEvict` records a return-address patch point on x86 (a
+            // no-op on aarch64, which can't patch them).
             AsmInst::Ret => self.emit_ret(),
             AsmInst::MethodRet(pc) => self.emit_method_ret(pc),
+            AsmInst::BlockBreak(pc) => self.emit_block_break(pc),
             AsmInst::ImmediateEvict { evict } => self.emit_immediate_evict(evict),
             // Method-call prologue: class-version guard, callee frame fields,
             // argument massage. (aarch64 SetArguments bails on a not-yet-ported

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -636,6 +636,30 @@ impl Codegen {
         );
     }
 
+    /// Lower `BlockBreak`: a `break` out of a block. Same shape as
+    /// `a64_method_ret` (set PC, call the error builder with the break value in
+    /// x0, jump to `entry_raise`) but through `err_block_break`, which unwinds
+    /// to the block's defining method rather than the current frame's caller.
+    ///
+    /// As in `a64_method_ret`, PC points at *this* instruction (not `pc + 1`):
+    /// aarch64's `entry_raise` hands PC to `handle_error` without the x86 `-16`
+    /// fixup, so storing `pc` (the value x86 reaches via `pc + 1` then `-16`)
+    /// keeps the exception-table lookup aligned with the raising instruction.
+    fn a64_block_break(&mut self, pc: BytecodePtr) {
+        let pc0 = pc.as_ptr() as u64;
+        let f = runtime::err_block_break as *const () as u64;
+        let raise = self.entry_raise();
+        monoasm_arm64!(&mut self.jit,
+            mov x21, (pc0);
+            mov x2, x0;       // val (was in rax/x0)
+            mov x0, x19;      // vm
+            mov x1, x20;      // globals
+            mov x9, (f);
+            blr x9;
+            b raise;
+        );
+    }
+
     /// `[lfp - slot*8 - LFP_SELF] <- imm` via a scratch register (x9/x10).
     fn a64_store_imm_to_slot(&mut self, imm: u64, slot: SlotId, lfp: u32) -> bool {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
@@ -1594,6 +1618,11 @@ impl Codegen {
     /// Return through the method-return path, resuming the caller at `pc + 1`.
     pub(in crate::codegen::jitgen) fn emit_method_ret(&mut self, pc: BytecodePtr) {
         self.a64_method_ret(pc);
+    }
+
+    /// Non-local exit through the block-break path (a `break` out of a block).
+    pub(in crate::codegen::jitgen) fn emit_block_break(&mut self, pc: BytecodePtr) {
+        self.a64_block_break(pc);
     }
 
     /// Dense-integer `case` dispatch — aarch64 twin of x86 `emit_opt_case`. The

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1596,6 +1596,48 @@ impl Codegen {
         self.a64_method_ret(pc);
     }
 
+    /// Dense-integer `case` dispatch — aarch64 twin of x86 `emit_opt_case`. The
+    /// condition (a tagged fixnum) is in x4 (`GP::Rdi`), placed by the
+    /// front-end. Untag, range-check `[min, max]` (signed, both < 2048 so they
+    /// fit a 12-bit `cmp` immediate), then index a jump table of absolute
+    /// branch-target addresses by `cond - min` and branch indirectly.
+    ///
+    /// The table is built with `const_align8` + `abs_address`, exactly as on
+    /// x86; `resolve_constants` emits it into this method's own code page right
+    /// after the body, so it is well within `adr`'s ±1MB reach. Terminates the
+    /// basic block (the `br` is an unconditional indirect branch).
+    pub(in crate::codegen::jitgen) fn emit_opt_case(
+        &mut self,
+        frame: &mut AsmInfo,
+        max: u16,
+        min: u16,
+        else_label: JitLabel,
+        branch_labels: Box<[JitLabel]>,
+    ) {
+        let jump_table = self.jit.const_align8();
+        for label in branch_labels.iter() {
+            let dest_label = frame.resolve_label(&mut self.jit, *label);
+            self.jit.abs_address(dest_label);
+        }
+        let else_dest = frame.resolve_label(&mut self.jit, else_label);
+        let cond = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            asr x(cond), x(cond), #1;   // untag fixnum: x4 = n
+            cmp x(cond), #(max as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &else_dest); // n > max -> else
+        monoasm_arm64!(&mut self.jit,
+            cmp x(cond), #(min as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &else_dest); // n < min -> else
+        monoasm_arm64!(&mut self.jit,
+            sub x(cond), x(cond), #(min as u32);     // index = n - min
+            adr x10, jump_table;                     // table base (PC-relative)
+            ldr x10, [x10, x(cond), lsl #3];         // table[n - min]
+            br x10;
+        );
+    }
+
     /// Immediate eviction patches a live frame's return address on x86; aarch64
     /// cannot patch return addresses, so this is a no-op (class-version guards
     /// cover the staleness it would otherwise catch).

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -302,6 +302,30 @@ fn case_opt() {
     ]);
 }
 
+// A `break` out of a block lowers to the `BlockBreak` AsmInst (a non-local
+// exit through `err_block_break`). Each method's block is exercised enough to
+// JIT, so the break path runs through native code on both the x86-64 `amd64`
+// job and the native arm64 `darwin` job. Covers conditional and unconditional
+// breaks, breaks carrying a value, and `each`/`times`/range iterators.
+#[test]
+fn block_break_jit() {
+    run_test(
+        r#"
+        def first_even(a); a.each { |x| break x if x % 2 == 0 }; end
+        def take_first(a); a.each { |x| break x * 10 }; end
+        def upto_three(n); (0...n).each { |i| break i if i == 3 }; end
+        def sum_until(n); r = 0; n.times { |i| break if i == 5; r += i }; r; end
+        [
+          first_even([1, 3, 8, 9]),
+          first_even([1, 3, 5]),
+          take_first([5, 6, 7]),
+          upto_three(10),
+          sum_until(10),
+        ]
+        "#,
+    );
+}
+
 // A dense (>= 8 integer `when`) `case` lowers to the `OptCase` jump-table
 // bytecode rather than an `===` chain. Wrapping it in a method exercised many
 // times forces the JIT to compile the `OptCase` AsmInst (covered on both the

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -302,6 +302,49 @@ fn case_opt() {
     ]);
 }
 
+// A dense (>= 8 integer `when`) `case` lowers to the `OptCase` jump-table
+// bytecode rather than an `===` chain. Wrapping it in a method exercised many
+// times forces the JIT to compile the `OptCase` AsmInst (covered on both the
+// x86-64 `amd64` job and the native arm64 `darwin` job). Covers below-min,
+// in-range, boundaries, above-max -> else, a non-zero `min`, and several
+// `when` values mapping to one body.
+#[test]
+fn case_opt_jit() {
+    run_test(
+        r#"
+        def classify(n)
+          case n
+          when 0 then "z0"
+          when 1 then "z1"
+          when 2 then "z2"
+          when 3 then "z3"
+          when 4 then "z4"
+          when 5 then "z5"
+          when 6 then "z6"
+          when 7 then "z7"
+          when 8 then "z8"
+          when 9 then "z9"
+          else "other"
+          end
+        end
+        (-3..13).map { |n| classify(n) }
+        "#,
+    );
+    run_test(
+        r#"
+        def bucket(n)
+          case n
+          when 10, 12, 14 then :low
+          when 11, 13, 15 then :mid
+          when 16, 17, 18, 19 then :high
+          else :none
+          end
+        end
+        (8..21).map { |n| bucket(n) }
+        "#,
+    );
+}
+
 //
 // Tests for call site patterns (exercises CallSiteInfo methods)
 //


### PR DESCRIPTION
## Overview

Continues the aarch64 JIT `AsmInst` porting (follow-up to #655), plus a small
CI/test housekeeping change. Three commits:

### 1. ci: rename `coverage` job to `amd64`; disable ruruby-parser and plb2 checks
- Rename the Linux GitHub Actions job `coverage` → `amd64` (comment references in
  `rust.yml` and `bin/test` updated to match).
- In `bin/test`, comment out the `MONORUBY_PARSER=ruruby` nextest pass and the
  plb2 benchmark output-diff group (nqueen/sudoku/matmul/bedcov).

### 2. jit(aarch64): port OptCase (dense-integer `case` jump table)
Lowers the jump-table dispatch for a dense `case`/`when` (the bytecodegen
optimization that fires when a `case` has ≥ 8 integer `when` values in
[0, 2048)). OptCase moves from the x86-only `compile_asmir_arch` into the shared
`compile_asmir` dispatcher via a new per-arch `emit_opt_case` primitive (x86
keeps the verbatim code; aarch64 gains a twin):
- Untag the fixnum condition (in x4 / `GP::Rdi`), range-check `[min, max]`
  signed (both < 2048 → fit a 12-bit `cmp` immediate), then index a jump table
  of absolute branch-target addresses by `cond - min` and branch indirectly
  (`adr` + `ldr [base, idx, lsl #3]` + `br`); out-of-range → `else`.
- The table is built with `const_align8` + `abs_address`, identical to x86;
  `resolve_constants` emits it into this method's own code page right after the
  body, so it is well within `adr`'s ±1MB reach.

### 3. jit(aarch64): port BlockBreak (non-local `break` out of a block)
Same refactor shape as `MethodRet`: BlockBreak moves into the shared dispatcher
via a new `emit_block_break` primitive. The aarch64 `a64_block_break` mirrors
`a64_method_ret` (set PC, call the error builder with the break value in x0,
branch to `entry_raise`) but through `err_block_break`, which unwinds to the
block's defining method. As in `a64_method_ret`, PC points at *this* instruction
(not `pc + 1`): aarch64's `entry_raise` hands PC to `handle_error` without the
x86 `-16` fixup.

Both ports add regression tests (`case_opt_jit`, `block_break_jit`) — methods
exercised enough to JIT the new AsmInst rather than stay VM-interpreted.

## Verification

`cargo check` on x86_64 and aarch64-unknown-linux-gnu. Under qemu-aarch64 both
new tests and the full `tests/add_coverage` suite (61 tests) pass and match the
x86 build, covering OptCase's below-min / in-range / boundary / above-max→else /
non-zero-min / duplicate-`when` cases and BlockBreak's conditional, unconditional
and value-carrying breaks over each/times/range. Instrumentation confirmed each
new path JIT-compiles through its aarch64 lowering (`emit_opt_case` /
`a64_block_break`) rather than bailing to the VM — before these changes, a method
with a dense `case` or a block `break` stayed VM-interpreted on aarch64.

The decisive validation is this PR's **darwin (native arm64) CI** — in #654 two
bugs surfaced only on native hardware, not under qemu, so a native run is the
real gate.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae

---
_Generated by [Claude Code](https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae)_