### PR TITLE
jit(aarch64): port method specialization (inlined-frame) lowering + eviction

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -820,9 +820,9 @@ impl Codegen {
             if codegen.bop_redefine_flags() != 0 {
                 // Eviction only applies to JIT-compiled code; the VM-only
                 // build has none, so `cfp` goes unused there.
-                #[cfg(jit_x86)]
+                #[cfg(jit)]
                 codegen.immediate_eviction(cfp);
-                #[cfg(not(jit_x86))]
+                #[cfg(not(jit))]
                 let _ = cfp;
             }
         });
@@ -836,7 +836,7 @@ impl Codegen {
         unsafe { *addr }
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     fn immediate_eviction(&mut self, mut cfp: Cfp) {
         let mut return_addr = unsafe { cfp.return_addr() };
         while let Some(prev_cfp) = cfp.prev() {
@@ -844,13 +844,41 @@ impl Codegen {
             if !self.check_vm_address(ret) {
                 if let Some((patch_point, deopt)) = self.get_deopt_with_return_addr(ret) {
                     let patch_point = patch_point.unwrap();
-                    self.jit.apply_jmp_patch_address(patch_point, &deopt);
-                    unsafe { patch_point.as_ptr().write(0xe9) };
+                    self.patch_return_to_deopt(patch_point, &deopt);
                 }
             }
             cfp = prev_cfp;
             return_addr = unsafe { cfp.return_addr() };
         }
+    }
+
+    /// Overwrite the instruction(s) at a specialized call's return continuation
+    /// (`patch_point`) so the now-stale frame deopts when control returns to it.
+    /// x86 has a coherent I-cache and RWX pages, so it just writes the
+    /// `jmp deopt` in place.
+    #[cfg(jit_x86)]
+    fn patch_return_to_deopt(&mut self, patch_point: CodePtr, deopt: &DestLabel) {
+        self.jit.apply_jmp_patch_address(patch_point, deopt);
+        unsafe { patch_point.as_ptr().write(0xe9) };
+    }
+
+    /// aarch64 twin: overwrite the single 4-byte instruction at `patch_point`
+    /// with an unconditional `B deopt` (`0x14000000 | imm26`). Unlike x86 this
+    /// must (a) make the page writable and (b) synchronize the I-cache, since
+    /// AArch64 does not keep I/D caches coherent across self-modifying code —
+    /// `set_writable`/`set_executable` handle both (the latter invalidates the
+    /// I-cache; both are no-ops on Linux's RWX pages except that invalidation).
+    #[cfg(all(jit, not(jit_x86)))]
+    fn patch_return_to_deopt(&mut self, patch_point: CodePtr, deopt: &DestLabel) {
+        self.jit.set_writable();
+        let dest = self.jit.get_label_address(deopt);
+        // Byte displacement from the patch point to the deopt handler; both are
+        // 4-byte aligned, so imm26 = disp / 4 (B's range is ±128 MiB).
+        let disp = dest - patch_point;
+        let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
+        let word = 0x1400_0000u32 | imm26;
+        unsafe { (patch_point.as_ptr() as *mut u32).write(word) };
+        self.jit.set_executable();
     }
 
     #[cfg(jit)]

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -701,6 +701,89 @@ impl Codegen {
         }
     }
 
+    // ---- specialized (inlined) frame lowering (aarch64) -------------------
+
+    /// `MethodRetSpecialized` / `BlockBreakSpecialized`: a clean return that
+    /// unwinds `rbp_offset` bytes of inlined frames at once. Mirrors x86
+    /// `method_return_specialized` (`lea rbp,[rbp+off]; leave; ret`): adjust the
+    /// native frame base (x29), then run the standard epilogue. No error path —
+    /// the value is already in the accumulator and the caller frame is JIT'd.
+    fn a64_method_ret_specialized(&mut self, rbp_offset: usize) {
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (rbp_offset as u64);
+            add x29, x29, x10;          // rbp += off (skip inlined frames)
+            mov sp, x29;                // leave
+            ldp x29, x30, [sp], #(16);  // restore caller fp/lr
+            ret;
+        );
+    }
+
+    /// `LoadDynVarSpecialized`: rax <- outer-scope local at a pre-resolved
+    /// frame-base offset. Mirrors x86
+    /// `movq rax, [rbp + (offset - (BP_CFP+CFP_LFP) - 8 - conv(reg))]`. The
+    /// effective displacement can be negative, so it is materialized in a
+    /// scratch and added to x29 (x9..x15 are reserved lowering temps, never a
+    /// GP-mapped register).
+    fn a64_load_dyn_var_specialized(&mut self, offset: usize, reg: SlotId) {
+        let e: i64 = offset as i64 - (BP_CFP + CFP_LFP) as i64 - 8 - conv(reg) as i64;
+        let rax = GP::Rax.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (e as u64);
+            add x10, x29, x10;
+            ldr x(rax), [x10];
+        );
+    }
+
+    /// `StoreDynVarSpecialized`: outer-scope local <- src, symmetric to
+    /// `a64_load_dyn_var_specialized`. `src` maps to x0..x8 / x20..x23, never
+    /// the x10 scratch, so there is no clobber.
+    fn a64_store_dyn_var_specialized(&mut self, offset: usize, dst: SlotId, src: GP) {
+        let e: i64 = offset as i64 - (BP_CFP + CFP_LFP) as i64 - 8 - conv(dst) as i64;
+        let s = src.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (e as u64);
+            add x10, x29, x10;
+            str x(s), [x10];
+        );
+    }
+
+    /// `SpecializedCall` / `SpecializedYield`: a direct branch-with-link into
+    /// an inlined method/block entry already emitted in this code buffer.
+    /// Mirrors x86 `do_specialized_call`: set_lfp + push_frame, optionally bind
+    /// the deopt re-entry `patch_point`, `bl entry`, then pop_frame. Returns the
+    /// post-`bl` address (the return continuation); the caller records it via
+    /// `set_deopt_with_return_addr` so `immediate_eviction` can later overwrite
+    /// the continuation with a `B deopt` on BOP redefinition.
+    fn a64_do_specialized_call(
+        &mut self,
+        entry: DestLabel,
+        patch_point: Option<DestLabel>,
+    ) -> CodePtr {
+        // set_lfp + push_frame (mirror a64_do_call).
+        monoasm_arm64!(&mut self.jit,
+            ldr x10, [x19, #(EXECUTOR_CFP as u32)]; // prev cfp
+            sub x11, sp, #(RSP_CFP as u32);          // new cfp addr
+            str x10, [x11];                          // new_cfp.prev = prev
+            str x11, [x19, #(EXECUTOR_CFP as u32)];  // exec.cfp = new cfp
+            sub x22, sp, #(RSP_LOCAL_FRAME as u32);  // callee LFP
+            sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
+            str x22, [x10];                          // new_cfp.lfp = LFP
+        );
+        if let Some(patch) = patch_point {
+            self.jit.bind_label(patch);
+        }
+        monoasm_arm64!(&mut self.jit, bl entry;);
+        let return_addr = self.jit.get_current_address();
+        // pop_frame: restore caller cfp + lfp from x29 (== x86 rbp).
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x29, #(BP_CFP as u32);
+            str x10, [x19, #(EXECUTOR_CFP as u32)];
+            sub x10, x29, #((BP_CFP + CFP_LFP) as u32);
+            ldr x22, [x10];
+        );
+        return_addr
+    }
+
     // ---- emission primitives (aarch64) ------------------------------------
     // Tiny arch-specific helpers the arch-neutral `compile_asmir` dispatcher
     // calls. The x86 twins live in `compile.rs`. Slot `s` lives at
@@ -1667,10 +1750,37 @@ impl Codegen {
         );
     }
 
-    /// Immediate eviction patches a live frame's return address on x86; aarch64
-    /// cannot patch return addresses, so this is a no-op (class-version guards
-    /// cover the staleness it would otherwise catch).
-    pub(in crate::codegen::jitgen) fn emit_immediate_evict(&mut self, _evict: AsmEvict) {}
+    /// Record this position (the return continuation of a specialized call) as
+    /// the return-address patch point for `evict`. On BOP redefinition,
+    /// `Codegen::immediate_eviction` overwrites the instruction here with a
+    /// `B deopt` so the stale specialized frame deopts on return. Mirrors x86.
+    pub(in crate::codegen::jitgen) fn emit_immediate_evict(&mut self, evict: AsmEvict) {
+        // Only specialized calls register a return address on aarch64; normal
+        // calls (`emit_call`) ignore `evict` and rely on the callee's own entry
+        // guard rather than return-address patching. So an unregistered evict
+        // here is a normal call with nothing to patch — skip it. (On x86 every
+        // call registers, so the lookup always succeeds there.)
+        if let Some(&return_addr) = self.asm_return_addr_table.get(&evict) {
+            let patch_point = self.jit.get_current_address();
+            self.return_addr_table
+                .entry(return_addr)
+                .and_modify(|e| e.0 = Some(patch_point));
+        }
+    }
+
+    /// Register a specialized call's return address so `immediate_eviction` can
+    /// find and patch it. Identical to the x86 helper (the tables are arch-
+    /// neutral `#[cfg(jit)]` fields on `Codegen`).
+    fn set_deopt_with_return_addr(
+        &mut self,
+        return_addr: CodePtr,
+        evict: AsmEvict,
+        evict_label: &DestLabel,
+    ) {
+        self.asm_return_addr_table.insert(evict, return_addr);
+        self.return_addr_table
+            .insert(return_addr, (None, evict_label.clone()));
+    }
 
     /// Inline-cache class-version guard: deopt if the global class version moved
     /// since compilation. aarch64 has no recompiler, so the x86 recompile params
@@ -3248,16 +3358,59 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn compile_asmir_arch(
         &mut self,
         _store: &Store,
-        _frame: &mut AsmInfo,
-        _labels: &SideExitLabels,
-        _inst: AsmInst,
+        frame: &mut AsmInfo,
+        labels: &SideExitLabels,
+        inst: AsmInst,
         _class_version: DestLabel,
     ) -> bool {
-        // Every AsmInst the aarch64 backend supports is now handled by the
-        // shared `compile_asmir` dispatcher (via the per-arch `emit_*`
-        // primitives). Anything reaching here is not yet ported, so bail and
+        // The specialized (inlined-frame) AsmInst family is lowered here; every
+        // other variant is handled by the shared `compile_asmir` dispatcher.
+        // Anything still reaching the wildcard is not yet ported, so bail and
         // keep the method VM-interpreted.
-        false
+        match inst {
+            // Clean return / block-break out of an inlined frame.
+            AsmInst::MethodRetSpecialized { rbp_offset }
+            | AsmInst::BlockBreakSpecialized { rbp_offset } => {
+                self.a64_method_ret_specialized(rbp_offset.unwrap_concrete());
+            }
+            // Outer-scope local access at a pre-resolved frame offset.
+            AsmInst::LoadDynVarSpecialized { offset, reg } => {
+                self.a64_load_dyn_var_specialized(offset.unwrap_concrete(), reg);
+            }
+            AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
+                self.a64_store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
+            }
+            // Inline-cache class-version guard. aarch64 has no recompiler, so
+            // both the specialized guard and the recompile-or-deopt point
+            // degrade to a plain deopt (sound — the global class-version
+            // compare conservatively deopts on any class change since compile).
+            AsmInst::GuardClassVersionSpecialized { idx: _, deopt } => {
+                self.a64_guard_class_version(&labels[deopt]);
+            }
+            AsmInst::RecompileDeoptSpecialized {
+                idx: _,
+                deopt,
+                reason: _,
+            } => {
+                self.emit_deopt(&labels[deopt]);
+            }
+            // Direct call into an inlined method entry, with the return-address
+            // patch point recorded for BOP-redefinition eviction.
+            AsmInst::SpecializedCall {
+                entry,
+                patch_point,
+                evict,
+            } => {
+                let patch_point = patch_point.map(|l| frame.resolve_label(&mut self.jit, l));
+                let entry_label = frame.resolve_label(&mut self.jit, entry);
+                let return_addr = self.a64_do_specialized_call(entry_label, patch_point);
+                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+            }
+            // SpecializedYield + SetupYieldFrame (block/yield inlining) are not
+            // ported yet: bail so the method stays VM-interpreted (sound).
+            _ => return false,
+        }
+        true
     }
 }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -284,12 +284,13 @@ impl<'a> JitContext<'a> {
                             && (args..args + pos_num).any(|i| state.is_C_immediate(i))));
                 let iseq_block = block_fid.map(|fid| self.store[fid].is_iseq()).flatten();
 
-                // aarch64: the A64 lowering does not yet support specialized
-                // (inlined) frames, so never enter one — fall through to the
-                // plain `send` path below, which is always a correct
-                // (un-inlined) fallback. On x86 keep specializing as before.
-                if cfg!(jit_x86)
-                    && (iseq_block.is_some() || (specializable && self.specialize_level() < 5))
+                // Method specialization (inlining a callee iseq) is now lowered
+                // on both x86 and aarch64. Block-argument inlining
+                // (`iseq_block`) stays x86-only — its `SpecializedYield` /
+                // `SetupYieldFrame` lowering is not ported to aarch64 yet, so
+                // keep that path gated and fall through to the plain `send`.
+                if (specializable && self.specialize_level() < 5)
+                    || (cfg!(jit_x86) && iseq_block.is_some())
                 /*name == Some(IdentId::NEW)*/
                 {
                     return self.specialized_iseq(

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1074,12 +1074,9 @@ impl<'a> JitContext<'a> {
     /// [`Self::outer_specialized_ids`] for the rationale.
     ///
     pub(super) fn method_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
-        // aarch64 never builds specialized frames (see the `cfg!(jit_x86)` gate
-        // in method_call.rs), so there is no caller chain to encode — fall back
-        // to the plain `MethodRet` instead of `MethodRetSpecialized`.
-        if !cfg!(jit_x86) {
-            return None;
-        }
+        // Method specialization is lowered on both arches now, so the caller
+        // chain is encoded for `MethodRetSpecialized` on aarch64 too. (Block
+        // inlining stays x86-only — see `iter_caller_specialized_ids`.)
         let caller = self.method_caller_pos()?;
         let begin = caller + 1;
         let end = self.stack_frame.len() - 1;


### PR DESCRIPTION
## Overview

Enables JIT **method specialization** (inlining a callee iseq into its caller) on aarch64. Until now the whole specialized-frame family was gated to x86 at the front end; this lowers the specialized `AsmInst`s and — crucially — ports the runtime return-address **eviction** that keeps inlined frames sound when a basic operator is redefined.

This continues the incremental aarch64 AsmInst coverage work (#651–#656). Block-argument inlining and specialized `yield` remain x86-only and are a follow-up (see Scope).

## Backend lowering (`compile_stub.rs` `compile_asmir_arch`)

| AsmInst | aarch64 lowering |
|---|---|
| `SpecializedCall` | `bl entry` into the inlined method (mirrors `a64_do_call` frame push/pop); records the post-call return address |
| `MethodRetSpecialized` / `BlockBreakSpecialized` | adjust native frame base `x29` by the resolved offset, then the standard epilogue — unwinds the inlined frames at once (x86 `lea rbp,..; leave; ret`) |
| `Load`/`StoreDynVarSpecialized` | `x29`-relative access at the pre-resolved frame offset |
| `GuardClassVersionSpecialized` / `RecompileDeoptSpecialized` | aarch64 has no recompiler, so both **degrade to a plain deopt** (sound: the global class-version compare conservatively deopts on any change since compile) |

## Runtime eviction (`codegen.rs`)

`immediate_eviction` (fired on BOP redefinition) is now `#[cfg(jit)]` (was x86-only). The patch byte-write is arch-split:
- **x86**: unchanged — `jmp deopt` (`0xe9` + rel32).
- **aarch64**: overwrite the single 4-byte continuation instruction with `B deopt`, wrapped in `set_writable`/`set_executable` so the page is writable and the **I-cache is synchronized** (AArch64 I/D caches are not coherent for self-modifying code; both are no-ops on Linux RWX pages except the I-cache invalidate). No monoasm change needed.

`emit_immediate_evict` records the patch point only for evicts a specialized call registered — normal aarch64 calls ignore `evict` (they rely on the callee's entry guard), so an unregistered evict is a normal call with nothing to patch. (On x86 every call registers, so its lookup always succeeds.)

## Front end

Method specialization (`specializable`) is no longer gated to x86. **x86 behavior is unchanged** (the gate is identical there).

## Scope / follow-up

Block-argument inlining (`iseq_block`) and specialized `yield` (`SpecializedYield` / `SetupYieldFrame`) stay x86-only — their lowering isn't ported yet, so those paths fall through to the plain send/yield (correct, just un-inlined). Porting them is the natural next step.

## Validation

- **x86** (unchanged): lib **1644**, `add_coverage` **61**, `method_call` **87** — all green.
- **aarch64** (qemu): `add_coverage` **61** and `method_call` **87** pass. The full aarch64 lib suite is impractical to run to completion under qemu (~20× slowdown × 1644 tests × 25 warmups).

> ⚠️ **The native arm64 CI (`darwin`) job is the decisive check.** qemu's TCG model keeps caches coherent, so it does **not** exercise the AArch64 I-cache-invalidation requirement of the self-modifying eviction path — only real hardware does. Please weight the `darwin` job accordingly.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae

---
_Generated by [Claude Code](https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae)_