### PR TITLE
jit(aarch64): port specialized yield / block inlining

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -784,6 +784,55 @@ impl Codegen {
         return_addr
     }
 
+    /// `SetupYieldFrame`: build the callee **block** frame for a specialized
+    /// `yield` before `SpecializedYield` branches into it. Walks `outer - 1`
+    /// outer-LFP links to the block's defining frame, then writes the callee
+    /// frame's outer/meta/svar/cme/block/self slots. A literal translation of
+    /// x86 `setup_yield_frame` (x29-free; uses x9 = outer LFP, x10 = address
+    /// scratch, x11 = value scratch — none of which are GP-mapped). The cfp
+    /// prev/lfp it also writes are immediately overwritten by the following
+    /// `SpecializedYield`'s push_frame, exactly as on x86.
+    fn a64_setup_yield_frame(&mut self, meta: Meta, outer: usize) {
+        let outer = outer - 1;
+        monoasm_arm64!(&mut self.jit, ldr x9, [x19, #(EXECUTOR_CFP as u32)];);
+        for _ in 0..outer {
+            monoasm_arm64!(&mut self.jit, ldr x9, [x9];);
+        }
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x9, #(CFP_LFP as u32);
+            ldr x9, [x10];                                    // x9 <- outer LFP
+            // new_cfp.prev = exec.cfp
+            ldr x11, [x19, #(EXECUTOR_CFP as u32)];
+            sub x10, sp, #(RSP_CFP as u32);
+            str x11, [x10];
+            // new_cfp.lfp = rsp + (24 - RSP_LOCAL_FRAME) = sp - 16
+            sub x11, sp, #(16u32);
+            sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
+            str x11, [x10];
+            // frame.outer = outer LFP
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_OUTER) as u32);
+            str x9, [x10];
+            // frame.meta
+            mov x11, (meta.get());
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_META) as u32);
+            str x11, [x10];
+            // svar / cme / block = 0 (block callee resolves via outer chain;
+            // zeroed so the GC mark walker stays sound)
+            mov x11, (0u64);
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
+            str x11, [x10];
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_CME) as u32);
+            str x11, [x10];
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_BLOCK) as u32);
+            str x11, [x10];
+            // frame.self = [outer LFP - LFP_SELF]
+            sub x10, x9, #(LFP_SELF as u32);
+            ldr x11, [x10];
+            sub x10, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+            str x11, [x10];
+        );
+    }
+
     // ---- emission primitives (aarch64) ------------------------------------
     // Tiny arch-specific helpers the arch-neutral `compile_asmir` dispatcher
     // calls. The x86 twins live in `compile.rs`. Slot `s` lives at
@@ -3406,8 +3455,17 @@ impl Codegen {
                 let return_addr = self.a64_do_specialized_call(entry_label, patch_point);
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
-            // SpecializedYield + SetupYieldFrame (block/yield inlining) are not
-            // ported yet: bail so the method stays VM-interpreted (sound).
+            // Specialized `yield`: build the block frame, then branch into the
+            // inlined block entry (no patch_point — the eviction continuation is
+            // recorded the same way as SpecializedCall).
+            AsmInst::SetupYieldFrame { meta, outer } => {
+                self.a64_setup_yield_frame(meta, outer);
+            }
+            AsmInst::SpecializedYield { entry, evict } => {
+                let entry_label = frame.resolve_label(&mut self.jit, entry);
+                let return_addr = self.a64_do_specialized_call(entry_label, None);
+                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+            }
             _ => return false,
         }
         true

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -465,10 +465,8 @@ impl<'a> JitContext<'a> {
                 cache,
             } => return self.method_call(state, ir, callid, cache),
             TraceIr::Yield { callid } => {
-                // aarch64: specialized (inlined) yield is unsupported by the A64
-                // lowering, so fall through to the plain `compile_yield` path.
-                if cfg!(jit_x86)
-                    && let Some(block_info) = self.current_method_given_block()
+                // Specialized (inlined) yield is lowered on both x86 and aarch64.
+                if let Some(block_info) = self.current_method_given_block()
                     && let Some(iseq) = self.store[block_info.block_fid].is_iseq()
                 {
                     return self.compile_yield_specialized(state, ir, callid, &block_info, iseq);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -284,13 +284,10 @@ impl<'a> JitContext<'a> {
                             && (args..args + pos_num).any(|i| state.is_C_immediate(i))));
                 let iseq_block = block_fid.map(|fid| self.store[fid].is_iseq()).flatten();
 
-                // Method specialization (inlining a callee iseq) is now lowered
-                // on both x86 and aarch64. Block-argument inlining
-                // (`iseq_block`) stays x86-only — its `SpecializedYield` /
-                // `SetupYieldFrame` lowering is not ported to aarch64 yet, so
-                // keep that path gated and fall through to the plain `send`.
-                if (specializable && self.specialize_level() < 5)
-                    || (cfg!(jit_x86) && iseq_block.is_some())
+                // Method specialization (inlining a callee iseq) and block-
+                // argument inlining (`iseq_block`, which drives specialized
+                // `yield`) are both lowered on x86 and aarch64 now.
+                if (specializable && self.specialize_level() < 5) || iseq_block.is_some()
                 /*name == Some(IdentId::NEW)*/
                 {
                     return self.specialized_iseq(

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1098,11 +1098,8 @@ impl<'a> JitContext<'a> {
     /// [`Self::method_caller_specialized_ids`].
     ///
     pub(super) fn iter_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
-        // aarch64: no specialized frames (see `method_caller_specialized_ids`),
-        // so emit the plain `BlockBreak` instead of `BlockBreakSpecialized`.
-        if !cfg!(jit_x86) {
-            return None;
-        }
+        // Block inlining is lowered on aarch64 now, so `break` out of an inlined
+        // block can encode its caller chain for `BlockBreakSpecialized` too.
         let caller = self.iter_caller_pos()?;
         let begin = caller + 1;
         let end = self.stack_frame.len() - 1;


### PR DESCRIPTION
## Overview

Follow-up to #658. Enables **block-argument inlining and specialized `yield`** on aarch64 — the last part of the specialized-frame (inlining) family that was still x86-only. With this, aarch64 specialization matches x86.

## Backend lowering (`compile_stub.rs`)

- **`SetupYieldFrame`**: builds the callee **block** frame before the inlined `yield` — walks `outer - 1` outer-LFP links to the block's defining frame, then writes the callee `outer`/`meta`/`svar`/`cme`/`block`/`self` slots. A literal translation of x86 `setup_yield_frame` (x29-free; `x9` = outer LFP, `x10` = address scratch, `x11` = value).
- **`SpecializedYield`**: reuses `a64_do_specialized_call` to `bl` into the inlined block entry and record the return-address patch point for eviction — exactly like `SpecializedCall` in #658.
- **`BlockBreakSpecialized`** was already lowered in #658 (it shares `a64_method_ret_specialized`); it is now actually emitted on aarch64 via the un-gated `iter_caller_specialized_ids`.

## Front end

The three remaining `cfg!(jit_x86)` gates are dropped: `iseq_block` inlining (`method_call.rs`), `compile_yield_specialized` (`compile.rs`), and the `BlockBreakSpecialized` caller chain (`iter_caller_specialized_ids`). **x86 behavior is unchanged** — those gates were always true on x86.

## Validation

- **x86** (unchanged): lib **1644**, `add_coverage` **61**, `method_call` **87**, `yield` **4**, `redefine` **4**, `enumerable` **4** — green.
- **aarch64** (qemu): `yield` **4**, `redefine` **4** (the BOP-redefinition eviction path), `enumerable` **4**, `proc_compose` **6**, `rescue` **23**, `case` **12**, `class_chain` **2**, `add_coverage` **61**, `method_call` **87** — all green.

> ⚠️ As in #658, the native arm64 CI (`darwin`) job is the decisive check: qemu's TCG model keeps caches coherent, so it does not exercise the AArch64 I-cache-invalidation requirement of the self-modifying eviction path. Please weight `darwin` accordingly.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae

---
_Generated by [Claude Code](https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae)_