### PR TITLE
jit(aarch64): ClassDef/SingletonClassDef lowering + ruby/spec alias-drift fix

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -652,3 +652,61 @@ module FileTest
     File.zero?(path)
   end
 end
+
+# True aliases required by ruby/spec's "Move <Class> to rely less on shared
+# examples" refactoring wave (2026-06; e.g. ruby/spec d714c5a84 for Integer and
+# its siblings for Float/Symbol/Set/...), which replaced behavioral shared
+# examples with strict `Klass.instance_method(:a) == Klass.instance_method(:b)`
+# identity checks. monoruby had registered several of these as separate builtins
+# sharing one Rust fn (distinct FuncId), so the identity checks failed. Redefine
+# them as real aliases, matching CRuby. (Integer's are handled in
+# `builtins/numeric/integer.rs`.) This file loads after every class .rb, so the
+# aliased originals are all defined by now.
+class Float
+  alias === ==
+  alias modulo %
+  alias quo fdiv
+end
+class Symbol
+  alias === ==
+  alias id2name to_s
+  alias intern to_sym
+  alias size length
+end
+class Rational
+  alias magnitude abs
+end
+class Hash
+  alias store []=
+end
+class Set
+  alias < proper_subset?
+  alias > proper_superset?
+  alias << add
+  alias eql? ==
+end
+class Thread
+  alias exit kill
+end
+class Time
+  alias asctime ctime
+end
+class Encoding
+  alias to_s name
+end
+class MatchData
+  alias deconstruct captures
+end
+class Struct
+  alias inspect to_s
+end
+# Deferred (not fixed here): Complex#quo, Enumerator#with_object, Proc#eql?,
+# Proc#inspect, Thread#inspect. CRuby defines the aliased *originals*
+# (Complex#/, Enumerable... -> Enumerator#each_with_object, Proc#==, Proc#to_s,
+# Thread#to_s) directly on the class, whereas monoruby inherits them (from
+# Numeric/Enumerable/BasicObject/Kernel). A Ruby `alias` here would only copy
+# the inherited entry under the new name, so the strict
+# `instance_method(:a) == instance_method(:b)` identity check would still fail
+# (different owner) AND it would shadow monoruby's own class-specific impls
+# (e.g. Proc#inspect). These need the originals defined on the class first;
+# they are not in `bin/test`'s ruby/spec category list, so they don't block CI.

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -22,7 +22,15 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_basic_op(INTEGER_CLASS, "-", sub, 1);
     globals.define_basic_op(INTEGER_CLASS, "*", mul, 1);
     globals.define_basic_op(INTEGER_CLASS, "/", div, 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "%", int_rem, inline_gen!(integer_rem), 1);
+    // `modulo` is a true alias of `%` (ruby/spec core/integer/modulo_spec.rb).
+    globals.define_builtin_inline_funcs(
+        INTEGER_CLASS,
+        "%",
+        &["modulo"],
+        int_rem,
+        inline_gen!(integer_rem),
+        1,
+    );
     globals.define_builtin_inline_func(INTEGER_CLASS, "**", int_pow, inline_gen!(integer_pow), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "&", bitand, inline_gen!(integer_bitand), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, inline_gen!(integer_bitor), 1);
@@ -30,8 +38,8 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_func(INTEGER_CLASS, "divmod", divmod, 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, ">>", shr, inline_gen!(integer_shr), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "<<", shl, inline_gen!(integer_shl), 1);
-    globals.define_builtin_func(INTEGER_CLASS, "==", eq, 1);
-    globals.define_builtin_func(INTEGER_CLASS, "===", eq, 1);
+    // `===` is a true alias of `==` (ruby/spec core/integer/case_compare_spec.rb).
+    globals.define_builtin_funcs(INTEGER_CLASS, "==", &["==="], eq, 1);
     globals.define_builtin_func(INTEGER_CLASS, ">=", ge, 1);
     globals.define_builtin_func(INTEGER_CLASS, ">", gt, 1);
     globals.define_builtin_func(INTEGER_CLASS, "<=", le, 1);
@@ -48,8 +56,8 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_func_with(INTEGER_CLASS, "to_s", to_s, 0, 1, false);
     globals.define_builtin_func_with(INTEGER_CLASS, "inspect", to_s, 0, 1, false);
     globals.define_builtin_func(INTEGER_CLASS, "eql?", eql_, 1);
-    globals.define_builtin_func(INTEGER_CLASS, "abs", abs, 0);
-    globals.define_builtin_func(INTEGER_CLASS, "magnitude", abs, 0);
+    // `magnitude` is a true alias of `abs` (ruby/spec core/integer/magnitude_spec.rb).
+    globals.define_builtin_funcs(INTEGER_CLASS, "abs", &["magnitude"], abs, 0);
     globals.define_builtin_func_with(INTEGER_CLASS, "pow", pow, 1, 2, false);
     globals.define_builtin_func_with(INTEGER_CLASS, "floor", int_floor, 0, 1, false);
     globals.define_builtin_func_with(INTEGER_CLASS, "ceil", int_ceil, 0, 1, false);

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -857,6 +857,188 @@ impl Codegen {
         );
     }
 
+    /// Shared tail of `ClassDef` / `SingletonClassDef`: enter the class
+    /// context, run the class body, store the result, then leave. Expects the
+    /// new class/module `self` in x0. Mirrors x86 `jit_class_def_sub`; the
+    /// call_funcdata sequence is the same as `emit_yield`'s. `dst_off`, if set,
+    /// is the pre-range-checked `conv(dst)` byte offset of the result slot.
+    fn a64_jit_class_def_sub(&mut self, func_id: FuncId, dst_off: Option<u32>, error: &DestLabel) {
+        let lfp = GP::R14.a64().0; // x22
+        let f_enter = runtime::enter_classdef as *const () as u64;
+        let f_exit = runtime::exit_classdef as *const () as u64;
+        // x25 <- self (callee-saved, survives the C calls). enter_classdef(
+        // vm, globals, func_id, self) -> x0 = &FuncData; saved in x26.
+        monoasm_arm64!(&mut self.jit,
+            mov x25, x0;
+            mov x0, x19;
+            mov x1, x20;
+            mov x2, (func_id.get() as u64);
+            mov x3, x25;
+            str x30, [sp, #-16]!;
+            mov x9, (f_enter);
+            blr x9;
+            ldr x30, [sp], #16;
+            mov x26, x0;                                  // &FuncData
+            // callee block/method frame fields below sp.
+            mov x12, (0u64);
+            ldr x10, [x26, #(FUNCDATA_META as u32)];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_META) as u32);
+            str x10, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_BLOCK) as u32);
+            str x12, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+            str x25, [x11];
+            // set_method_outer: outer/svar/cme = 0
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_OUTER) as u32);
+            str x12, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
+            str x12, [x11];
+            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_CME) as u32);
+            str x12, [x11];
+            // call_funcdata (fdata in x26): push frame, set callee LFP/PC, call.
+            ldr x10, [x19, #(EXECUTOR_CFP as u32)];
+            sub x11, sp, #(RSP_CFP as u32);
+            str x10, [x11];
+            str x11, [x19, #(EXECUTOR_CFP as u32)];
+            sub x22, sp, #(RSP_LOCAL_FRAME as u32);
+            sub x10, sp, #((RSP_CFP + CFP_LFP) as u32);
+            str x22, [x10];
+            sub x3, x21, #(16u32);                        // with-pc call-site bc ptr
+            ldr x21, [x26, #(FUNCDATA_PC as u32)];
+            ldr x10, [x26, #(FUNCDATA_CODEPTR as u32)];
+            blr x10;                                       // x0 = body result
+            sub x11, sp, #(RSP_CFP as u32);
+            ldr x10, [x11];
+            str x10, [x19, #(EXECUTOR_CFP as u32)];
+            sub x10, x29, #((BP_CFP + CFP_LFP) as u32);
+            ldr x22, [x10];
+        );
+        // store_rax(dst)
+        if let Some(off) = dst_off {
+            monoasm_arm64!(&mut self.jit,
+                sub x10, x(lfp), #(off);
+                str x0, [x10];
+            );
+        }
+        // pop class context: exit_classdef(vm, globals), preserving the result.
+        monoasm_arm64!(&mut self.jit,
+            mov x25, x0;
+            mov x0, x19;
+            mov x1, x20;
+            str x30, [sp, #-16]!;
+            mov x9, (f_exit);
+            blr x9;
+            ldr x30, [sp], #16;
+            mov x0, x25;
+        );
+        self.emit_handle_error(error);
+    }
+
+    /// `ClassDef`: define (or reopen) a class/module, then run its body.
+    /// Bails on a live xmm pool reg (no FP save around the C calls, matching the
+    /// other aarch64 runtime-call emits) or an out-of-range frame slot.
+    fn a64_class_def(
+        &mut self,
+        base: Option<SlotId>,
+        superclass: Option<SlotId>,
+        dst: Option<SlotId>,
+        name: IdentId,
+        func_id: FuncId,
+        is_module: bool,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        // Range-check every frame slot up front (so we never bail mid-emit).
+        let sc_off = match superclass {
+            Some(s) => match (conv(s) as u32 <= 4095).then(|| conv(s) as u32) {
+                Some(o) => Some(o),
+                None => return false,
+            },
+            None => None,
+        };
+        let base_off = match base {
+            Some(b) => match (conv(b) as u32 <= 4095).then(|| conv(b) as u32) {
+                Some(o) => Some(o),
+                None => return false,
+            },
+            None => None,
+        };
+        let dst_off = match dst {
+            Some(d) => match (conv(d) as u32 <= 4095).then(|| conv(d) as u32) {
+                Some(o) => Some(o),
+                None => return false,
+            },
+            None => None,
+        };
+        let lfp = GP::R14.a64().0; // x22
+        let f = runtime::define_class as *const () as u64;
+        // superclass -> x3, base -> x5 (Option<Value>; 0 == None)
+        match sc_off {
+            Some(off) => monoasm_arm64!(&mut self.jit, sub x10, x(lfp), #(off); ldr x3, [x10];),
+            None => monoasm_arm64!(&mut self.jit, mov x3, (0u64);),
+        }
+        match base_off {
+            Some(off) => monoasm_arm64!(&mut self.jit, sub x10, x(lfp), #(off); ldr x5, [x10];),
+            None => monoasm_arm64!(&mut self.jit, mov x5, (0u64);),
+        }
+        // define_class(vm, globals, name, superclass, is_module, base)
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            mov x1, x20;
+            mov x2, (name.get() as u64);
+            mov x4, (is_module as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                                        // x0 = Option<Value> self
+            ldr x30, [sp], #16;
+        );
+        self.emit_handle_error(error);
+        self.a64_jit_class_def_sub(func_id, dst_off, error);
+        true
+    }
+
+    /// `SingletonClassDef`: `class << obj; … end`. Like `a64_class_def` but the
+    /// class is obtained via `define_singleton_class(vm, globals, obj)`.
+    fn a64_singleton_class_def(
+        &mut self,
+        base: SlotId,
+        dst: Option<SlotId>,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) -> bool {
+        if using_xmm.iter().any(|b| *b) {
+            return false;
+        }
+        let base_off = conv(base) as u32;
+        let dst_off = match dst {
+            Some(d) => Some(conv(d) as u32),
+            None => None,
+        };
+        if base_off > 4095 || dst_off.is_some_and(|o| o > 4095) {
+            return false;
+        }
+        let lfp = GP::R14.a64().0; // x22
+        let f = runtime::define_singleton_class as *const () as u64;
+        // define_singleton_class(vm, globals, base)
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x(lfp), #(base_off);
+            ldr x2, [x10];                                 // base (receiver Value)
+            mov x0, x19;
+            mov x1, x20;
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                                        // x0 = Option<Value> self
+            ldr x30, [sp], #16;
+        );
+        self.emit_handle_error(error);
+        self.a64_jit_class_def_sub(func_id, dst_off, error);
+        true
+    }
+
     // ---- emission primitives (aarch64) ------------------------------------
     // Tiny arch-specific helpers the arch-neutral `compile_asmir` dispatcher
     // calls. The x86 twins live in `compile.rs`. Slot `s` lives at
@@ -3502,6 +3684,37 @@ impl Codegen {
             // call correct_rest_kw(&table, lfp) -> kwrest Hash (result in x0).
             AsmInst::RestKw { rest_kw } => {
                 self.a64_rest_kw(rest_kw);
+            }
+            // `class`/`module` (re)definition + body, and `class << obj`.
+            AsmInst::ClassDef {
+                base,
+                superclass,
+                dst,
+                name,
+                func_id,
+                is_module,
+                using_xmm,
+                error,
+            } => {
+                return self.a64_class_def(
+                    base,
+                    superclass,
+                    dst,
+                    name,
+                    func_id,
+                    is_module,
+                    using_xmm,
+                    &labels[error],
+                );
+            }
+            AsmInst::SingletonClassDef {
+                base,
+                dst,
+                func_id,
+                using_xmm,
+                error,
+            } => {
+                return self.a64_singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
             }
             _ => return false,
         }


### PR DESCRIPTION
Two independent changes (bundled because the second unblocks this PR's CI — single working branch):

## 1. jit(aarch64): port ClassDef / SingletonClassDef lowering

Lowers class/module (re)definition and `class << obj` on aarch64 (previously bailed → VM-interpreted). Composed from `define_class`/`define_singleton_class` C calls + `a64_jit_class_def_sub` (enter_classdef → frame setup → the `emit_yield`-style indirect call_funcdata → store result → exit_classdef). Offsets range-checked up front; bails on a live xmm pool reg. Validated under qemu: class_chain 2, redefine 4, comparable 7, enumerable 4, add_coverage 61.

## 2. Fix the ruby/spec "shared-example refactoring" alias drift (repo-wide CI blocker)

**Unrelated to ClassDef.** ruby/spec's *"Move `<Class>` to rely less on shared examples"* wave (2026‑06: Integer `d714c5a84`, Float `ec8c2461c`, Symbol `c1c7e4464`, Set `3e241dea1`, Rational `197392bf3`, Struct `ced6a06bf`, …) replaced behavioral shared examples with **strict `Klass.instance_method(:a) == Klass.instance_method(:b)` identity checks**. monoruby registered several aliases as *separate* builtins (distinct `FuncId`), so the identity checks failed on both amd64 and the native arm64 `darwin` job (ruby/spec is cloned at HEAD each run — this is why #660 was green before the wave landed and #661 was not).

Fixed as **real aliases** (matching CRuby):
- `numeric/integer.rs`: `==`(`===`), `abs`(`magnitude`), `%`(`modulo`).
- `builtins.rb` (loads after every class .rb): Float `=== modulo quo`, Symbol `=== id2name intern size`, Rational `magnitude`, Set `< > << eql?`, Struct `inspect`, plus Hash/Time/Encoding/MatchData/Thread#exit.

**Deferred** (not in `bin/test`'s spec category list; need the originals defined *on* the class rather than inherited, which a Ruby `alias` alone can't satisfy and would shadow class-specific impls): Complex#quo, Enumerator#with_object, Proc#eql?/#inspect, Thread#inspect.

### Verification (real ruby/spec + mspec)
All 17 `bin/test` categories — `basicobject true false nil integer float comparable math builtin_constants class numeric rational struct symbol range set systemexit` — now report **0 failures / 0 errors**. x86 lib **1644** passes (no behavior regression); aarch64 ClassDef tests pass under qemu.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae