### PR TITLE
jit(aarch64): inline-cache write-back + FP-pool/forwarding completion

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 cargo build --release
-cd benchmark && benchmark-driver -o markdown app_fib.yml so_nbody.yml so_mandelbrot.yml app_aobench.rb bf.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb -e ../target/release/monoruby --rbenv '4.0.1 --yjit'
+cd benchmark && benchmark-driver -o markdown app_fib.yml so_nbody.yml so_mandelbrot.yml app_aobench.rb bf.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb -e ../target/release/monoruby --rbenv '4.0.2 --yjit'
 # cd benchmark && benchmark-driver -o markdown quick_sort.yaml app_fib.yml tarai.rb so_mandelbrot.yml so_nbody.yml app_aobench.rb bf.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb --rbenv '3.4.1 --yjit; truffleruby-24.1.1' -e ../target/release/monoruby
 # benchmark-driver -o markdown benchmark/app_fib.yml benchmark/so_mandelbrot.yml benchmark/so_nbody.yml --rbenv '3.4.0-preview1 --yjit' -e target/release/monoruby

--- a/monoruby/src/codegen/arch/aarch64/invoker.rs
+++ b/monoruby/src/codegen/arch/aarch64/invoker.rs
@@ -6,6 +6,39 @@ use super::*;
 use monoasm_macro::monoasm_arm64;
 
 impl JitModule {
+    /// Save the AAPCS64 callee-saved FP registers D8-D15 (64 bytes) below sp.
+    /// The JIT uses the whole FP pool D2-D15 as scratch (see `a64_fpr`), so
+    /// every Rust↔JIT boundary must preserve D8-D15 for the Rust caller.
+    /// `monoasm_arm64`'s `stp`/`ldp` are GPR-only, so save them individually.
+    pub(in crate::codegen) fn a64_save_fp_callee_save(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(64);
+            str d8,  [sp];
+            str d9,  [sp, #(8)];
+            str d10, [sp, #(16)];
+            str d11, [sp, #(24)];
+            str d12, [sp, #(32)];
+            str d13, [sp, #(40)];
+            str d14, [sp, #(48)];
+            str d15, [sp, #(56)];
+        );
+    }
+
+    /// Restore what `a64_save_fp_callee_save` saved and pop the 64-byte area.
+    pub(in crate::codegen) fn a64_restore_fp_callee_save(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr d8,  [sp];
+            ldr d9,  [sp, #(8)];
+            ldr d10, [sp, #(16)];
+            ldr d11, [sp, #(24)];
+            ldr d12, [sp, #(32)];
+            ldr d13, [sp, #(40)];
+            ldr d14, [sp, #(48)];
+            ldr d15, [sp, #(56)];
+            add sp, sp, #(64);
+        );
+    }
+
     pub(in crate::codegen) fn a64_invoker_prologue(&mut self) {
         monoasm_arm64!(&mut self.jit,
             stp x29, x30, [sp, #(-16)]!;
@@ -16,6 +49,9 @@ impl JitModule {
             mov x(EXEC.0), x0;
             mov x(GLOBALS.0), x1;
         );
+        // Preserve the Rust caller's callee-saved FP regs (the JIT body
+        // clobbers D8-D15 as FP-pool scratch). Mirrored by the epilogue.
+        self.a64_save_fp_callee_save();
     }
 
     /// fdata(X9) = funcinfo_base + (X2 = funcid)*64 + FUNCINFO_DATA.
@@ -120,6 +156,7 @@ impl JitModule {
     /// Standard invoker epilogue: restore the callee-saved registers saved by
     /// a64_invoker_prologue and return (result in x0).
     pub(in crate::codegen) fn a64_invoker_epilogue(&mut self) {
+        self.a64_restore_fp_callee_save();
         monoasm_arm64!(&mut self.jit,
             ldp x25, x26, [sp], #(16);
             ldp x(ACC.0), x24, [sp], #(16);
@@ -130,7 +167,11 @@ impl JitModule {
         );
     }
 
-    /// Save all callee-saved GPRs (x19-x28) + fp/lr for a fiber context switch.
+    /// Save all callee-saved GPRs (x19-x28) + fp/lr + the callee-saved FP regs
+    /// (D8-D15) for a fiber context switch. D8-D15 are part of the JIT FP pool
+    /// (see `a64_fpr`), so a fiber yielding mid-computation — and the parent
+    /// whose D8-D15 the fiber body clobbers — both need them preserved across
+    /// the switch.
     pub(in crate::codegen) fn a64_push_callee_save(&mut self) {
         monoasm_arm64!(&mut self.jit,
             stp x29, x30, [sp, #(-16)]!;
@@ -140,10 +181,12 @@ impl JitModule {
             stp x21, x22, [sp, #(-16)]!;
             stp x19, x20, [sp, #(-16)]!;
         );
+        self.a64_save_fp_callee_save();
     }
 
     /// Restore what a64_push_callee_save saved (reverse order).
     pub(in crate::codegen) fn a64_pop_callee_save(&mut self) {
+        self.a64_restore_fp_callee_save();
         monoasm_arm64!(&mut self.jit,
             ldp x19, x20, [sp], #(16);
             ldp x21, x22, [sp], #(16);
@@ -331,15 +374,10 @@ impl JitModule {
             sub x11, sp, #(RSP_CFP as u32);
             ldr x10, [x11];
             str x10, [x(EXEC.0), #(EXECUTOR_CFP as u32)];
-        // epilogue
-            ldp x25, x26, [sp], #(16);
-            ldp x(ACC.0), x24, [sp], #(16);
-            ldp x(PC.0), x(LFP.0), [sp], #(16);
-            ldp x(EXEC.0), x(GLOBALS.0), [sp], #(16);
-            ldp x29, x30, [sp], #(16);
-            ret;
-        // SAFETY: codeptr is an extern "C" fn with the BindingInvoker ABI.
         );
+        // epilogue (restores D8-D15 + the saved GPRs, then ret)
+        self.a64_invoker_epilogue();
+        // SAFETY: codeptr is an extern "C" fn with the BindingInvoker ABI.
         unsafe { std::mem::transmute_copy::<*mut u8, BindingInvoker>(&codeptr.as_ptr()) }
     }
     pub(in crate::codegen) fn fiber_invoker(&mut self) -> FiberInvoker {

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1310,10 +1310,13 @@ impl Codegen {
         p
     }
 
-    /// op 30-33 `send`/`send_simple`: method call (slow-path only — no inline
-    /// cache; `find_method` does the lookup every time). Handles the simple
-    /// case (no kw/block/splat). Bytecode (32 bytes): `+0` callid, `+4` ret
-    /// slot, `+8` pos_num, `+10` arg slot, `+12` recv slot.
+    /// op 30-33 `send`/`send_simple`: method call. The VM always does the
+    /// `find_method` lookup (no VM-side fast-path read of the cache), but it
+    /// now writes the inline cache (FuncId/class/version via
+    /// [`Self::a64_save_method_cache`]) so the JIT can specialize the site.
+    /// Handles the simple case (no kw/block/splat). Bytecode (32 bytes): `+0`
+    /// callid, `+4` ret slot, `+8` pos_num, `+10` arg slot, `+12` recv slot;
+    /// inline cache `+16` FuncId, `+24` class, `+28` version.
     pub(in crate::codegen) fn a64_op_send(&mut self, is_simple: bool) -> CodePtr {
         let p = self.jit.get_current_address();
         let mm = self.jit.label();
@@ -1350,6 +1353,11 @@ impl Codegen {
             mov x9, (runtime::find_method as *const () as u64);
             blr x9;
             cbz x0, mm;
+        );
+        // Populate the inline cache (X0 = FuncId) so the JIT can type this
+        // call site. X0 is preserved across the call.
+        self.a64_save_method_cache();
+        monoasm_arm64!(&mut self.jit,
         // get_func_data: X15 = funcinfo_base + funcid*64 + FUNCINFO_DATA
             lsl x10, x0, #(6);
             mov x11, (GLOBALS_FUNCINFO as u64);
@@ -1723,6 +1731,9 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             tbz x13, #(0), generic;
             tbz x14, #(0), generic;
+        );
+        self.a64_save_binary_integer();
+        monoasm_arm64!(&mut self.jit,
             cmp x13, x14;
         );
         self.jit.cset(X13, cond);
@@ -1800,6 +1811,51 @@ impl Codegen {
         );
     }
 
+    /// Fixnum-fast-path counterpart of [`Self::a64_save_binary_class`]: stamp
+    /// `Integer`/`Integer` into the BinOp inline cache (`[PC+8]` classid1,
+    /// `[PC+12]` classid2) so the JIT can type integer arithmetic/compare
+    /// sites. Without this the cache stays empty (`<INVALID>`) and the JIT
+    /// deopts every integer binop. Mirrors x86 `vm_save_binary_integer`.
+    /// Clobbers X10; leaves the NZCV flags untouched (mov-immediate + stores).
+    pub(in crate::codegen) fn a64_save_binary_integer(&mut self) {
+        let int_class: u32 = INTEGER_CLASS.into();
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (int_class);
+            str w10, [x(PC.0), #(8)];   // classid1
+            str w10, [x(PC.0), #(12)];  // classid2
+        );
+    }
+
+    /// Stamp the method-call inline cache so the JIT can specialize this call
+    /// site (otherwise `pc.method_cache()` stays `None` and every call deopts).
+    /// Mirrors x86 `save_cache`. On entry X0 = the resolved FuncId. Writes
+    /// FuncId @ `[PC+16]`, receiver ClassId @ `[PC+24]` and the current
+    /// class_version @ `[PC+28]` (the layout `method_cache()` reads). The
+    /// receiver is reloaded from its slot `[PC+12]` (rather than trusting a
+    /// register) since `find_method` is a C call that clobbers the caller-saved
+    /// receiver register. X0 is preserved (reloaded from the FuncId cache
+    /// slot); clobbers X1/X2/X11 and the link register.
+    pub(in crate::codegen) fn a64_save_method_cache(&mut self) {
+        let cv_addr = self
+            .jit
+            .get_label_address(&self.class_version_label())
+            .as_ptr() as u64;
+        let get_class = self.get_class.clone();
+        monoasm_arm64!(&mut self.jit,
+            str w0, [x(PC.0), #(16)];   // CACHED_FUNCID (also our save of X0)
+            ldrh x0, [x(PC.0), #(12)];  // recv slot index
+        );
+        self.a64_slot_value(X0); // X0 = receiver value
+        monoasm_arm64!(&mut self.jit,
+            bl get_class;               // x0 = class(recv)
+            str w0, [x(PC.0), #(24)];   // CACHED_CLASS
+            mov x11, (cv_addr);
+            ldr w0, [x11];              // class_version (i32)
+            str w0, [x(PC.0), #(28)];   // CACHED_VERSION
+            ldr w0, [x(PC.0), #(16)];   // reload FuncId into X0 (u32, zero-ext)
+        );
+    }
+
     pub(in crate::codegen) fn a64_generic_binop(&mut self, func: BinaryOpFn) {
         let raise = self.entry_raise.clone();
         self.a64_save_binary_class();
@@ -1851,6 +1907,7 @@ impl Codegen {
             tbz x13, #(0), generic;
             tbz x14, #(0), generic;
         );
+        self.a64_save_binary_integer();
         if is_sub {
             monoasm_arm64!(&mut self.jit,
                 subs x9, x13, x14;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -255,12 +255,22 @@ impl Codegen {
         let p = self.jit.get_current_address();
         let raise = self.entry_raise.clone();
         monoasm_arm64!(&mut self.jit,
-            mov x0, x(EXEC.0);
-            mov x1, x(GLOBALS.0);
             ldrh x2, [x(PC.0), #(2)];
         );
-        self.a64_slot_value(X2); // src
+        self.a64_slot_value(X2); // src (for get_class)
+        // Fill the UnOp inline cache (operand class @ classid1 = [PC+8]) so the
+        // JIT can type the operand instead of bailing NotCached. Mirrors x86
+        // vm_save_lhs_class. NB: get_class clobbers x1/x2 for immediate
+        // receivers (nil/bool/symbol), so the operand is reloaded below before
+        // the op call.
+        self.a64_save_lhs_class();
         monoasm_arm64!(&mut self.jit,
+            ldrh x2, [x(PC.0), #(2)];
+        );
+        self.a64_slot_value(X2); // reload src (get_class clobbered x2)
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
             mov x9, (abs);
             blr x9;
         );
@@ -1752,6 +1762,13 @@ impl Codegen {
         self.a64_fetch_and_dispatch();
         monoasm_arm64!(&mut self.jit,
             generic:
+        );
+        // Fill the BinOp inline cache on the generic (non-fixnum) path too, so
+        // the JIT can type non-integer comparisons (Float/String/...) instead
+        // of bailing NotCached and recompiling forever. Reads X13/X14 (they
+        // survive get_class), clobbers x0.
+        self.a64_save_binary_class();
+        monoasm_arm64!(&mut self.jit,
         // cmp_*_values(vm, globals, lhs=X13, rhs=X14) -> Option<Value>
             mov x2, x13;  // lhs
             mov x3, x14;  // rhs
@@ -1799,6 +1816,20 @@ impl Codegen {
     /// `[PC+12]` = classid2. Mirrors x86 `vm_save_binary_class` (sans the
     /// polymorphic-flag bookkeeping for now). Operands are the Values in X13
     /// (lhs) / X14 (rhs); `get_class` reads X0 only, so X13/X14 survive.
+    /// Record the unary operand's class into the UnOp inline cache (classid1
+    /// `[PC+8]`) so the JIT can type the site. Mirrors x86 `vm_save_lhs_class`.
+    /// Operand is the Value in x2. NB: `get_class` clobbers x1/x2 for
+    /// immediate receivers, so callers must reload the operand afterwards.
+    /// Clobbers x0/x1/x2 and the link register.
+    pub(in crate::codegen) fn a64_save_lhs_class(&mut self) {
+        let get_class = self.get_class.clone();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x2;
+            bl get_class;             // x0 = class(operand)
+            str w0, [x(PC.0), #(8)];  // classid1
+        );
+    }
+
     pub(in crate::codegen) fn a64_save_binary_class(&mut self) {
         let get_class = self.get_class.clone();
         monoasm_arm64!(&mut self.jit,

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3070,8 +3070,10 @@ impl Codegen {
     /// Ruby result is exact bit (identity) equality, produced inline via
     /// cmp + cset; otherwise fall through to the generic C-call `func`
     /// (x0=vm, x1=globals, x2=lhs, x3=rhs). `lhs`/`rhs` are loaded into x2/x3
-    /// up front so the slow path can reuse them. Bails on a live xmm pool reg
-    /// or an out-of-range frame offset.
+    /// up front so the slow path can reuse them. The live xmm pool is
+    /// saved/restored *only* around the slow-path C call (the inline fast path
+    /// never touches the caller-saved d2.. pool regs); bails only on an
+    /// out-of-range frame offset.
     pub(in crate::codegen::jitgen) fn emit_opt_eq_cmp(
         &mut self,
         lhs: SlotId,
@@ -3080,9 +3082,6 @@ impl Codegen {
         func: crate::executor::BinaryOpFn,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
@@ -3127,10 +3126,20 @@ impl Codegen {
         slow:
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals (x2=lhs, x3=rhs intact)
+        );
+        // Save the live FP pool only on the slow path: the C call clobbers the
+        // caller-saved d2.. pool regs, but the inline fast path above (which
+        // branches straight to `done`) leaves them untouched, so both paths
+        // reach `done` with sp and the pool registers consistent.
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
             ldr x30, [sp], #16;
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
         done:
         );
         true
@@ -3585,8 +3594,10 @@ impl Codegen {
     /// `&block` captured as a Proc value: runtime::block_arg(vm, globals, lfp,
     /// call_site) materializes the current frame's block handler into a Proc
     /// (promoting the frame to the heap if needed). The Option<Value> result is
-    /// stored to `ret` after a HandleError. Bails on a live xmm pool reg (no
-    /// save around the C call) or an out-of-range frame offset.
+    /// stored to `ret` after a HandleError. The live xmm pool is saved/restored
+    /// around the C call (restore placed before the HandleError branch so the
+    /// side exit writes the live floats back from the pool); bails only on an
+    /// out-of-range frame offset.
     pub(in crate::codegen::jitgen) fn emit_block_arg(
         &mut self,
         ret: SlotId,
@@ -3594,9 +3605,6 @@ impl Codegen {
         call_site_bc_ptr: BytecodePtr,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off = ret.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
@@ -3604,6 +3612,7 @@ impl Codegen {
         }
         let cs = call_site_bc_ptr.as_ptr() as u64;
         let f = runtime::block_arg as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;          // vm
             mov x1, x20;          // globals
@@ -3614,6 +3623,7 @@ impl Codegen {
             blr x9;               // x0 = Option<Value>
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         self.emit_handle_error(error);
         let rax = GP::Rax.a64().0;
         monoasm_arm64!(&mut self.jit,

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -877,7 +877,13 @@ impl Codegen {
     /// new class/module `self` in x0. Mirrors x86 `jit_class_def_sub`; the
     /// call_funcdata sequence is the same as `emit_yield`'s. `dst_off`, if set,
     /// is the pre-range-checked `conv(dst)` byte offset of the result slot.
-    fn a64_jit_class_def_sub(&mut self, func_id: FuncId, dst_off: Option<u32>, error: &DestLabel) {
+    fn a64_jit_class_def_sub(
+        &mut self,
+        func_id: FuncId,
+        dst_off: Option<u32>,
+        using_xmm: UsingXmm,
+        error: &DestLabel,
+    ) {
         let lfp = GP::R14.a64().0; // x22
         let f_enter = runtime::enter_classdef as *const () as u64;
         let f_exit = runtime::exit_classdef as *const () as u64;
@@ -946,12 +952,17 @@ impl Codegen {
             ldr x30, [sp], #16;
             mov x0, x25;
         );
+        // Reload the pool (clobbered by the class body + exit_classdef) and pop
+        // the save area before the final HandleError branch.
+        self.emit_xmm_restore(using_xmm, false);
         self.emit_handle_error(error);
     }
 
-    /// `ClassDef`: define (or reopen) a class/module, then run its body.
-    /// Bails on a live xmm pool reg (no FP save around the C calls, matching the
-    /// other aarch64 runtime-call emits) or an out-of-range frame slot.
+    /// `ClassDef`: define (or reopen) a class/module, then run its body. The
+    /// live FP pool is saved once for the whole sequence (the define/enter/exit
+    /// C calls and the class body all clobber d2..) and reloaded into the pool
+    /// registers before each HandleError branch; bails only on an out-of-range
+    /// frame slot.
     fn a64_class_def(
         &mut self,
         base: Option<SlotId>,
@@ -963,9 +974,6 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         // Range-check every frame slot up front (so we never bail mid-emit).
         let sc_off = match superclass {
             Some(s) => match (conv(s) as u32 <= 4095).then(|| conv(s) as u32) {
@@ -990,6 +998,10 @@ impl Codegen {
         };
         let lfp = GP::R14.a64().0; // x22
         let f = runtime::define_class as *const () as u64;
+        // Save the live FP pool for the whole ClassDef sequence; it persists
+        // across define_class, the class body, and exit_classdef, is reloaded
+        // into d2.. before each HandleError, and is popped once at the end.
+        self.emit_xmm_save(using_xmm, false);
         // superclass -> x3, base -> x5 (Option<Value>; 0 == None)
         match sc_off {
             Some(off) => monoasm_arm64!(&mut self.jit, sub x10, x(lfp), #(off); ldr x3, [x10];),
@@ -1010,8 +1022,9 @@ impl Codegen {
             blr x9;                                        // x0 = Option<Value> self
             ldr x30, [sp], #16;
         );
+        self.a64_xmm_reload(using_xmm);
         self.emit_handle_error(error);
-        self.a64_jit_class_def_sub(func_id, dst_off, error);
+        self.a64_jit_class_def_sub(func_id, dst_off, using_xmm, error);
         true
     }
 
@@ -1025,9 +1038,6 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let base_off = conv(base) as u32;
         let dst_off = match dst {
             Some(d) => Some(conv(d) as u32),
@@ -1038,6 +1048,7 @@ impl Codegen {
         }
         let lfp = GP::R14.a64().0; // x22
         let f = runtime::define_singleton_class as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         // define_singleton_class(vm, globals, base)
         monoasm_arm64!(&mut self.jit,
             sub x10, x(lfp), #(base_off);
@@ -1049,8 +1060,9 @@ impl Codegen {
             blr x9;                                        // x0 = Option<Value> self
             ldr x30, [sp], #16;
         );
+        self.a64_xmm_reload(using_xmm);
         self.emit_handle_error(error);
-        self.a64_jit_class_def_sub(func_id, dst_off, error);
+        self.a64_jit_class_def_sub(func_id, dst_off, using_xmm, error);
         true
     }
 
@@ -1800,6 +1812,24 @@ impl Codegen {
         }
         monoasm_arm64!(&mut self.jit, add sp, sp, #(sp_offset););
         true
+    }
+
+    /// Reload the live FP pool registers from the save area *without* popping
+    /// it. Used inside a multi-C-call emit (class_def) whose save area must
+    /// persist across several clobbering calls: the pool regs are reloaded
+    /// before each intermediate side-exit branch (whose handler reads the pool
+    /// *registers*), while the save area itself is popped only once at the end
+    /// via `emit_xmm_restore`. No-op when the pool is empty.
+    fn a64_xmm_reload(&mut self, using_xmm: UsingXmm) {
+        let mut i = 0u32;
+        for (xi, b) in using_xmm.iter().enumerate() {
+            if *b {
+                let pr = xi as u32 + 2;
+                let ofs = 8 * i;
+                monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
+                i += 1;
+            }
+        }
     }
 
     /// Integer binary op fast path (guarded; deopts to `deopt`). Independent of

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -754,16 +754,19 @@ impl Codegen {
     /// Physical D-register index for a pool-resident `FPReg`, or `None` (bail →
     /// the method stays VM-interpreted) otherwise.
     ///
-    /// Capped to the caller-saved D2-D7: under AAPCS64 D8-D15 are callee-saved
-    /// (unlike x86-64 SysV where every xmm is caller-saved), and the aarch64
-    /// invoker / JIT prologue does not yet preserve them. Restricting the JIT'd
-    /// FP pool to caller-saved registers keeps the ABI sound without that
-    /// prologue work; methods needing >6 live floats (or any spill) just don't
-    /// JIT yet. `f64_to_val`'s heap path and `XmmSave` are consistent with this
-    /// (they only ever touch D2-D7).
+    /// Covers the full FP pool D2-D15 (`PHYS_XMM_POOL` = 14 ⇒ `Xmm(2..=15)`).
+    /// D2-D7 are AAPCS64 caller-saved; D8-D15 are callee-saved, so the
+    /// Rust↔JIT boundary (the invoker prologue/epilogue and the fiber-switch
+    /// `a64_{push,pop}_callee_save`) saves/restores D8-D15 to preserve the Rust
+    /// caller's values. Within the JIT world the whole pool is treated as
+    /// caller-saved — `XmmSave`/`XmmRestore` spill the live subset around any
+    /// clobbering call (a JIT→JIT `blr` clobbers D2-D15; a C-call's Rust callee
+    /// preserves D8-D15 but the spill is harmless), and `f64_to_val`'s heap
+    /// path saves D2-D7 while relying on `float_heap` to preserve D8-D15.
+    /// Only a spill (>14 live floats) still bails.
     fn a64_fpr(&self, x: FPReg, base: usize) -> Option<u32> {
         match x.loc(base) {
-            FPRegLoc::Xmm(p) if p <= 7 => Some(p as u32),
+            FPRegLoc::Xmm(p) if p <= 15 => Some(p as u32),
             _ => None,
         }
     }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -579,6 +579,58 @@ impl Codegen {
         true
     }
 
+    /// Lower `SetArgumentsForwarded` (the `g(*rest, **kw, &blk)` trampoline
+    /// fast path). aarch64 does not yet emit the inline element-copy fast path,
+    /// so the non-deferred shape falls back to the generic
+    /// `jit_generic_set_arguments` — the x86 fast path's own miss target, so
+    /// correct, just unoptimized. The `deferred_src` (D1) shape skipped building
+    /// `f`'s `...` rest array on the JIT path, so it cannot use the generic
+    /// helper and bails (the method stays VM-interpreted, where the array is
+    /// built normally).
+    fn a64_set_arguments_forwarded(
+        &mut self,
+        callid: CallSiteId,
+        fid: FuncId,
+        offset: usize,
+        deferred_src: Option<(SlotId, u16)>,
+    ) -> bool {
+        if deferred_src.is_some() {
+            return false;
+        }
+        self.a64_set_arguments(callid, fid, offset)
+    }
+
+    /// Lower `SetArgumentsForwardedHelper`: same asm shape as
+    /// `a64_set_arguments`, but dispatches to the specialized
+    /// `jit_forwarded_set_arguments` runtime helper (forwarding `g(x.., ...)`
+    /// into a no-keyword iseq with opt/post/rest). Bails if the callee frame
+    /// size exceeds a 12-bit immediate.
+    fn a64_set_arguments_forwarded_helper(
+        &mut self,
+        callid: CallSiteId,
+        fid: FuncId,
+        offset: usize,
+    ) -> bool {
+        if offset > 4080 {
+            return false;
+        }
+        let f = crate::runtime::jit_forwarded_set_arguments as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                       // vm
+            mov x1, x20;                       // globals
+            mov x2, (callid.get() as u64);     // callid
+            sub x3, sp, #(RSP_LOCAL_FRAME as u32); // callee_lfp (call-site sp)
+            mov x4, (fid.get() as u64);        // callee fid
+            str x30, [sp, #-16]!;              // save LR
+            sub sp, sp, #(offset as u32);      // reserve callee scratch
+            mov x9, (f);
+            blr x9;
+            add sp, sp, #(offset as u32);
+            ldr x30, [sp], #16;                // restore LR
+        );
+        true
+    }
+
     /// Lower `Call` (the call itself): set the callee LFP, push a control
     /// frame, set PC, `blr` the callee codeptr, then restore the caller's
     /// cfp/lfp. Mirrors x86 `do_call` (set_lfp + push_frame + call + pop_frame)
@@ -3688,7 +3740,7 @@ impl Codegen {
     /// not-yet-ported variant (the method then stays VM-interpreted).
     pub(in crate::codegen::jitgen) fn compile_asmir_arch(
         &mut self,
-        _store: &Store,
+        store: &Store,
         frame: &mut AsmInfo,
         labels: &SideExitLabels,
         inst: AsmInst,
@@ -3791,6 +3843,19 @@ impl Codegen {
                 error,
             } => {
                 return self.a64_singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
+            }
+            AsmInst::SetArgumentsForwarded {
+                callid,
+                callee_fid,
+                deferred_src,
+                ..
+            } => {
+                let offset = store[callee_fid].get_offset();
+                return self.a64_set_arguments_forwarded(callid, callee_fid, offset, deferred_src);
+            }
+            AsmInst::SetArgumentsForwardedHelper { callid, callee_fid } => {
+                let offset = store[callee_fid].get_offset();
+                return self.a64_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
             _ => return false,
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1298,15 +1298,13 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let error = error.clone();
         let cv_addr = self
             .jit
             .get_label_address(&self.const_version_label())
             .as_ptr() as u64;
         let f = runtime::set_constant as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x3, x0;                 // val (was in rax)
             mov x0, x19;                // vm
@@ -1320,6 +1318,11 @@ impl Codegen {
             mov x9, (f);
             blr x9;
             ldr x30, [sp], #16;
+        );
+        // Restore the FP pool *before* the error branch: the cold error handler
+        // writes the live floats back from the pool, so they must be valid.
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
             cbz x0, error;              // None -> error
         );
         true
@@ -1335,10 +1338,8 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::get_global_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
@@ -1348,6 +1349,7 @@ impl Codegen {
             blr x9;                       // result in x0 (= rax)
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -1358,15 +1360,13 @@ impl Codegen {
         src: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::set_global_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
@@ -1378,6 +1378,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -1387,10 +1388,8 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::get_class_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm
             mov x1, x20;                  // globals
@@ -1400,6 +1399,7 @@ impl Codegen {
             blr x9;                       // result in x0
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2566,10 +2566,8 @@ impl Codegen {
     /// when an xmm pool register is live (no aarch64 xmm save around C calls
     /// yet); lr is preserved across the `blr`.
     pub(in crate::codegen::jitgen) fn emit_undef_method(&mut self, undef: IdentId, using_xmm: UsingXmm) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::undef_method as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                   // vm (Executor)
             mov x1, x20;                   // globals
@@ -2579,16 +2577,15 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
     /// Alias a global var via runtime::alias_global_var(globals=x20, new, old).
     /// Bails when an xmm pool register is live.
     pub(in crate::codegen::jitgen) fn emit_alias_gvar(&mut self, new: IdentId, old: IdentId, using_xmm: UsingXmm) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::alias_global_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x20;                 // globals
             mov x1, (new.get() as u64);  // new IdentId
@@ -2598,6 +2595,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2609,10 +2607,8 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::check_class_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
@@ -2622,6 +2618,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2635,15 +2632,13 @@ impl Codegen {
         src: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::set_class_var as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
@@ -2655,6 +2650,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2669,9 +2665,6 @@ impl Codegen {
         old: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off_old = old.0 as u32 * 8 + LFP_SELF as u32;
         let off_new = new.0 as u32 * 8 + LFP_SELF as u32;
@@ -2679,6 +2672,7 @@ impl Codegen {
             return false;
         }
         let f = runtime::alias_method as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm (Executor)
             mov x1, x20;                 // globals
@@ -2691,6 +2685,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2709,15 +2704,13 @@ impl Codegen {
         dst: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_yield as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
@@ -2728,6 +2721,7 @@ impl Codegen {
             sub x10, x(lfp), #(off);
             str x0, [x10];               // -> dst
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2737,15 +2731,13 @@ impl Codegen {
         dst: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_super as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2756,6 +2748,7 @@ impl Codegen {
             sub x10, x(lfp), #(off);
             str x0, [x10];
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2766,15 +2759,13 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_gvar as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2786,6 +2777,7 @@ impl Codegen {
             sub x10, x(lfp), #(off);
             str x0, [x10];
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2796,15 +2788,13 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_cvar as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2816,6 +2806,7 @@ impl Codegen {
             sub x10, x(lfp), #(off);
             str x0, [x10];
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2826,15 +2817,13 @@ impl Codegen {
         siteid: ConstSiteId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_const as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2845,6 +2834,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2856,9 +2846,6 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off_dst = dst.0 as u32 * 8 + LFP_SELF as u32;
         let off_recv = recv.0 as u32 * 8 + LFP_SELF as u32;
@@ -2866,6 +2853,7 @@ impl Codegen {
             return false;
         }
         let f = runtime::defined_method as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2878,6 +2866,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2888,15 +2877,13 @@ impl Codegen {
         name: IdentId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::defined_ivar as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
@@ -2907,6 +2894,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2920,9 +2908,6 @@ impl Codegen {
         func: crate::executor::BinaryOpFn,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
@@ -2930,6 +2915,7 @@ impl Codegen {
             return false;
         }
         let f = func as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
@@ -2942,6 +2928,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2953,9 +2940,6 @@ impl Codegen {
         rhs: SlotId,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0;
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
@@ -2963,6 +2947,7 @@ impl Codegen {
             return false;
         }
         let f = runtime::array_teq as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
@@ -2975,6 +2960,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -2989,15 +2975,13 @@ impl Codegen {
         len: u16,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off = arg.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::concatenate_regexp as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
@@ -3008,6 +2992,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -3053,9 +3038,6 @@ impl Codegen {
         rest_pos: Option<usize>,
         using_xmm: UsingXmm,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let rest = if let Some(rest_pos) = rest_pos {
             rest_pos as u64 + 1
         } else {
@@ -3068,6 +3050,7 @@ impl Codegen {
         }
         let rdi = GP::Rdi.a64().0; // x4 holds src
         let f = runtime::expand_array as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x(rdi);              // src (from GP::Rdi)
             sub x1, x(lfp), #(off);      // &dst (descending base)
@@ -3078,6 +3061,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         true
     }
 
@@ -3238,10 +3222,8 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let f = runtime::define_method as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                     // vm (Executor)
             mov x1, x20;                     // globals
@@ -3252,6 +3234,7 @@ impl Codegen {
             blr x9;                          // x0 = Option<Value>
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         self.emit_handle_error(error);
         true
     }
@@ -3268,15 +3251,13 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        if using_xmm.iter().any(|b| *b) {
-            return false;
-        }
         let lfp = GP::R14.a64().0; // x22
         let off = obj.0 as u32 * 8 + LFP_SELF as u32;
         if off > 4095 {
             return false;
         }
         let f = runtime::singleton_define_method as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                     // vm (Executor)
             mov x1, x20;                     // globals
@@ -3289,6 +3270,7 @@ impl Codegen {
             blr x9;                          // x0 = Option<Value>
             ldr x30, [sp], #16;
         );
+        self.emit_xmm_restore(using_xmm, false);
         self.emit_handle_error(error);
         true
     }

--- a/monoruby/tests/class_chain.rs
+++ b/monoruby/tests/class_chain.rs
@@ -77,3 +77,49 @@ fn class_chain2() {
     "##,
     );
 }
+
+#[test]
+fn classdef_with_live_float() {
+    // Regression: a ClassDef reached while a float accumulator is live in the
+    // JIT's FP pool must preserve the float (the pool is saved once across the
+    // define/enter/body/exit sequence and reloaded into the pool registers
+    // before each HandleError). The harness runs this 25x, so the top-level
+    // method gets JIT-compiled and exercises the ClassDef emit.
+    run_test(
+        r##"
+        acc = 0.0
+        i = 0
+        while i < 30
+          acc += i.to_f * 0.5
+          class Foo
+            def bar; 2; end
+          end
+          acc += Foo.new.bar
+          i += 1
+        end
+        acc
+        "##,
+    );
+}
+
+#[test]
+fn singleton_classdef_with_live_float() {
+    // Regression: same as classdef_with_live_float for `class << obj`.
+    run_test(
+        r##"
+        obj = Object.new
+        acc = 0.0
+        i = 0
+        while i < 30
+          acc += i.to_f * 0.25
+          class << obj
+            def greet; 7; end
+          end
+          acc += obj.greet
+          i += 1
+        end
+        acc
+        "##,
+    );
+}
+

--- a/monoruby/tests/yield.rs
+++ b/monoruby/tests/yield.rs
@@ -108,3 +108,53 @@ fn yield_in_detached_context() {
     "#,
     );
 }
+
+#[test]
+fn block_arg_with_live_float() {
+    // Regression: materializing the block parameter into a Proc (`p = blk`,
+    // a BlockArg) while a float accumulator is live in the JIT's FP pool must
+    // preserve the float across the runtime call (the pool is saved/restored
+    // around it). Before that, the method bailed out of JIT compilation.
+    run_test(
+        r#"
+        def with_block(&blk)
+          acc = 0.0
+          j = 0
+          while j < 200
+            acc += j.to_f * 1.25
+            p = blk
+            acc += 2.0 if p.nil?
+            j += 1
+          end
+          acc
+        end
+        with_block
+        "#,
+    );
+}
+
+#[test]
+fn opt_eq_cmp_with_live_float() {
+    // Regression: a polymorphic `==` (receiver class varies -> the inline
+    // opt_eq_cmp with a generic C-call slow path) must preserve a live FP pool
+    // across the slow-path call.
+    run_test(
+        r#"
+        def calc(n, vals)
+          a = 0.0; b = 1.0; c = 2.0; d = 3.0
+          i = 0
+          while i < n
+            a += i.to_f * 0.5
+            b += a * 0.25
+            c += b * 0.125
+            d += c * 0.0625
+            v = vals[i % 5]
+            a -= 1.0 if (v == nil)
+            i += 1
+          end
+          a + b + c + d
+        end
+        calc(200, [1, nil, :s, "x", 2.0])
+        "#,
+    );
+}


### PR DESCRIPTION
Follow-up aarch64 JIT work on top of #667 (FP-pool save/restore), bringing the
AArch64 backend's inline-cache and FP handling to parity with x86 and widening
what method-JITs instead of bailing to the VM.

## Changes
- **FP-pool save/restore — block_arg / opt_eq_cmp** and **class_def /
  singleton_class_def**: the last `using_xmm` bails are gone, so a method that
  keeps a float live across these emits JITs instead of aborting. `opt_eq_cmp`
  now matches the x86 twin; `class_def` reloads the pool into d2.. before each
  HandleError (the aarch64 side exit recovers floats from registers, unlike
  x86's stack slots).
- **VM inline-cache write-back** (int binops + method calls): the aarch64 VM
  now populates `classid1/2` and the method cache, so the JIT can type those
  sites (previously always `<INVALID>` → deopt).
- **BinOp/UnOp inline-cache on the VM generic paths**: `a64_op_cmp`'s generic
  (non-fixnum) path now stamps the operand classes (`a64_save_binary_class`),
  and `a64_op_unop` stamps the operand class (`a64_save_lhs_class`, reloading
  the operand because `get_class` clobbers x1/x2 for immediate receivers).
  This eliminates the NotCached → repeated-RecompileDeopt churn that
  non-integer comparisons / unary ops caused (startup-library methods such as
  RbConfig / Gem::* dropped from dozens of recompiles to ~none). Constant and
  ivar caches were already filled, so no change there.
- **SetArgumentsForwarded / SetArgumentsForwardedHelper** lowering for aarch64
  (`...` argument forwarding).
- **FP pool extended to D2-D15** (float-heavy method JIT: so_nbody /
  so_mandelbrot), and a benchmark reference bump.

## Verification (native arm64 / Darwin)
- `cargo nextest run` 2210/2210 passed (1 skipped).
- Float-live block_arg / opt_eq_cmp / class_def, non-integer `==`/`<=>`, and
  unary ops on bool/nil/int/array match CRuby 4.0.2. x86 untouched.

## Not included
A whole-method **recompile mechanism** for aarch64 was prototyped but is held
back: it triggers an intermittent, parallelism-only fault (clean serially and
under gc-stress; flaky only under full-suite parallel load) consistent with a
self-modifying-code / icache-coherency hazard in the recompile path, and the
inline-cache fixes above already remove the NotCached situation it was meant
to recover from. Tracked separately.
