### PR TITLE
jit(aarch64): whole-method recompile at RecompileDeopt points

### DIFF
--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -311,6 +311,49 @@ impl Codegen {
         Some(())
     }
 
+    /// aarch64 whole-method recompile: re-run the front-end + A64 lowering and
+    /// overwrite the method's dispatch slot in place (aarch64 installs JIT code
+    /// via the indirect slot recorded at `compile_patch`, not x86 branch
+    /// patching). Bails (leaving the old code) if the slot is unknown or the
+    /// method was JIT-invalidated.
+    #[cfg(not(jit_x86))]
+    fn recompile_method(
+        &mut self,
+        globals: &mut Globals,
+        lfp: Lfp,
+        reason: RecompileReason,
+    ) -> Option<()> {
+        let self_class = lfp.self_val().class();
+        let func_id = lfp.func_id();
+        let iseq_id = globals.store[func_id].as_iseq();
+        if globals.store[iseq_id].jit_invalidated() {
+            return None;
+        }
+        let slot = globals.store[iseq_id].get_jit_slot(self_class)?;
+        let jit_entry = self.jit.label();
+        let class_version = self.class_version();
+        let compiled = self
+            .compile_method(
+                globals,
+                iseq_id,
+                self_class,
+                jit_entry.clone(),
+                class_version,
+                Some(reason),
+            )
+            .is_some();
+        if !compiled {
+            self.jit.finalize();
+            return None;
+        }
+        let guard = self.a64_gen_class_guard_stub(self_class, &jit_entry);
+        self.jit.finalize();
+        let guard_addr = self.jit.get_label_address(&guard).as_ptr() as u64;
+        // SAFETY: `slot` is the dispatch word recorded by `compile_patch`.
+        unsafe { *(slot as *mut u64) = guard_addr };
+        Some(())
+    }
+
     #[cfg(jit)]
     fn compile_partial(
         &mut self,
@@ -425,6 +468,20 @@ extern "C" fn jit_recompile_method(globals: &mut Globals, lfp: Lfp, reason: Reco
     //    #[cfg(feature = "jit-log")]
     //    eprintln!("[JIT] recompile_method panicked, falling back to VM interpreter");
     //}
+}
+
+/// aarch64 counterpart, called from the `RecompileDeopt` lowering
+/// (`compile_stub.rs`). Recompiles the current method and overwrites its
+/// dispatch slot via [`Codegen::recompile_method`].
+#[cfg(not(jit_x86))]
+pub(in crate::codegen) extern "C" fn jit_recompile_method(
+    globals: &mut Globals,
+    lfp: Lfp,
+    reason: RecompileReason,
+) {
+    CODEGEN.with(|codegen| {
+        codegen.borrow_mut().recompile_method(globals, lfp, reason);
+    });
 }
 
 #[cfg(jit_x86)]

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2217,12 +2217,59 @@ impl Codegen {
     /// recompile params are unused here.
     pub(in crate::codegen::jitgen) fn emit_recompile_deopt(
         &mut self,
-        _position: Option<BytecodePtr>,
+        position: Option<BytecodePtr>,
         deopt: &DestLabel,
-        _reason: RecompileReason,
+        reason: RecompileReason,
     ) {
         let deopt = deopt.clone();
-        monoasm_arm64!(&mut self.jit, b deopt;);
+        // aarch64 recompiles whole methods only; at a loop-JIT recompile point
+        // (`position` = Some) just deopt (no loop recompile yet).
+        if position.is_some() {
+            monoasm_arm64!(&mut self.jit, b deopt;);
+            return;
+        }
+        // Counter-gated one-shot recompile, then fall through to the deopt side
+        // exit (which undoes any loop sp-bump, writes back live values, and
+        // re-enters the VM). Mirrors x86 `recompile_and_deopt`: x19-x23 are
+        // AAPCS64 callee-saved so the C call preserves them, and the deopt does
+        // the value write-back; the caller-saved d2-d7 pool is saved around the
+        // call because that write-back reads it (d8-d15 are callee-saved).
+        let counter = Box::into_raw(Box::new(COUNT_DEOPT_RECOMPILE)) as u64;
+        let f = crate::codegen::compiler::jit_recompile_method as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (counter);
+            ldr w11, [x9];
+            cmp w11, #0;
+        );
+        self.jit.bcond_label(monoasm::Cond::Le, &deopt); // <= 0 -> just deopt
+        monoasm_arm64!(&mut self.jit,
+            sub w11, w11, #1;
+            str w11, [x9];
+            cbnz w11, deopt;                 // not yet exhausted -> just deopt
+            // counter hit 0: recompile once, then deopt.
+            sub sp, sp, #(48);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            mov x0, x20;                     // globals
+            mov x1, x22;                     // lfp
+            mov x2, (reason as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            add sp, sp, #(48);
+            b deopt;
+        );
     }
 
     /// The call itself. aarch64 has no runtime branch patching, so the `evict`

--- a/monoruby/src/codegen/patch.rs
+++ b/monoruby/src/codegen/patch.rs
@@ -68,6 +68,11 @@ impl Codegen {
         // SAFETY: `slot` is the address of the wrapper's (or a parent guard's)
         // heap-leaked u64 chain word (see arch/aarch64/wrapper.rs).
         unsafe { *(slot.as_ptr() as *mut u64) = guard_addr };
+        // Record the slot so the recompiler can overwrite it in place later
+        // (this is the slot the wrapper / guard chain uses to reach
+        // `self_class`'s entry; `jit_compile_patch` passes the right one for
+        // both the head class and chained classes).
+        globals.store[iseq_id].set_jit_slot(self_class, slot.as_ptr() as u64);
         Some(())
     }
 

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -148,6 +148,12 @@ pub struct ISeqInfo {
     /// JIT code info for each class of *self*.
     ///
     pub(super) jit_entry: HashMap<ClassId, JitInfo>,
+    /// aarch64 only: per-self-class address of the indirect-dispatch slot
+    /// (the wrapper's / a class-guard chain link's heap word). Recorded at
+    /// `compile_patch` so the recompiler can overwrite the slot in place
+    /// (aarch64 installs JIT code via this slot, not x86 branch patching).
+    #[cfg(not(jit_x86))]
+    pub(super) jit_slot: HashMap<ClassId, u64>,
     pub(super) jit_invalidated: bool,
     ///
     /// Basic block information.
@@ -212,6 +218,8 @@ impl ISeqInfo {
             lexical_context: vec![],
             sourceinfo,
             jit_entry: HashMap::default(),
+            #[cfg(not(jit_x86))]
+            jit_slot: HashMap::default(),
             jit_invalidated: false,
             bb_info: BasicBlockInfo::default(),
             callsite_map: HashMap::default(),
@@ -468,6 +476,20 @@ impl ISeqInfo {
         eprintln!("{:?}", self.jit_entry);
     }
 
+    /// aarch64 only: record the indirect-dispatch slot address for a self
+    /// class (see `jit_slot`). Called from `compile_patch` after publishing
+    /// the compiled guard stub into the slot.
+    #[cfg(not(jit_x86))]
+    pub(crate) fn set_jit_slot(&mut self, self_class: ClassId, slot: u64) {
+        self.jit_slot.insert(self_class, slot);
+    }
+
+    /// aarch64 only: the dispatch-slot address for a self class, if compiled.
+    #[cfg(not(jit_x86))]
+    pub(crate) fn get_jit_slot(&self, self_class: ClassId) -> Option<u64> {
+        self.jit_slot.get(&self_class).copied()
+    }
+
     pub(crate) fn get_cache_map(
         &self,
         self_class: ClassId,
@@ -509,6 +531,8 @@ impl ISeqInfo {
     pub(crate) fn invalidate_jit_code(&mut self) {
         self.jit_invalidated = true;
         self.jit_entry.clear();
+        #[cfg(not(jit_x86))]
+        self.jit_slot.clear();
     }
 }
 


### PR DESCRIPTION
Adds the whole-method **recompile** mechanism for the aarch64 JIT, on top of
the loop-JIT (#669) / inline-cache (#668) work already in `darwin`.

## Problem
A call/op site that is `NotCached` (etc.) when a method first JIT-compiles
emits a `RecompileDeopt`. On aarch64 that just deopted *forever* — once the
site's inline cache warmed, the method never got recompiled to specialize it,
so it stayed on the interpreter fallback.

## Change
Mirror x86's whole-method recompile, adapted to aarch64's indirect dispatch
(no runtime branch patching):

- **Dispatch-slot tracking**: `compile_patch` records the per-(iseq,
  self_class) slot address — the wrapper's / class-guard chain's heap word it
  publishes the entry into — in `IseqInfo::jit_slot`.
- **`recompile_method`** (+ `jit_recompile_method`): re-runs the front-end +
  A64 lowering, fronts the result with a fresh class-guard stub, and
  overwrites that slot in place. Bails if the slot is unknown or the method
  was JIT-invalidated.
- **`emit_recompile_deopt`**: counter-gated *one-shot* recompile (mirrors x86
  `recompile_and_deopt`), then falls through to the regular deopt side exit,
  which undoes the loop-JIT sp-bump and writes back live values. x19-x23 are
  AAPCS64 callee-saved so the C call preserves them; the caller-saved d2-d7
  pool is saved around the call because the deopt write-back reads it.

## Scope / safety
Whole-method only. A loop-JIT recompile point (`position = Some`) and the
`BlockArgProxy`-style `RecompileDeoptimize` side exit still plain-deopt:
routing recompile through a path that does **not** undo the loop sp-bump was
the cause of an intermittent, parallel-load-only corruption during
development, so recompile is confined to the bump-aware deopt fall-through.

## Verification (native arm64 / Darwin)
- `cargo nextest run` 2210/2210 — **three consecutive clean full runs** (the
  earlier bug was parallel-load-only, so multiple runs were used to confirm).
- The recompile fires naturally and **one-shot per site** (fib's startup
  recompiles Gem::Specification/Version once each) and matches CRuby; the
  inline-cache fixes in #668 keep `NotCached` rare so it rarely needs to fire.
- x86 untouched (`recompile_method` / `jit_recompile_method` are
  `#[cfg(not(jit_x86))]`; the x86 path is unchanged).
