### PR TITLE
jit(aarch64): emit specialized (inlined) method bodies

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -78,15 +78,24 @@ impl Codegen {
         entry_label: DestLabel,
         class_version: DestLabel,
     ) -> bool {
+        // Emit the inlined (specialized) method bodies first, recursively, so
+        // the `SpecializedCall` sites in the main body can branch into them.
+        // This must run *before* binding `entry_label`, so entering the main
+        // body does not fall through the specialized bodies (mirrors the x86
+        // `gen_machine_code` recursion). aarch64 ignores the specialized
+        // recompile index — its `GuardClassVersionSpecialized` /
+        // `RecompileDeoptSpecialized` degrade to a plain deopt — so, unlike x86,
+        // we do not register `self.specialized_info`; the `SpecializedCall`
+        // lowering binds each call-site patch point itself.
+        for info_entry in std::mem::take(&mut frame.specialized_methods) {
+            let entry = frame.resolve_label(&mut self.jit, info_entry.entry);
+            if !self.a64_gen_machine_code(info_entry.info, store, entry, class_version.clone()) {
+                return false;
+            }
+        }
+
         self.jit.bind_label(entry_label);
         frame.start_codepos = self.jit.get_current();
-        // Specialized (inlined) frames are unsupported by the A64 lowering, so
-        // the front-end never builds them on aarch64 (see the `cfg!(jit_x86)`
-        // gate in compile.rs / method_call.rs). This stays as a defensive net:
-        // if one ever appears, bail to the VM rather than emit wrong code.
-        if !frame.specialized_methods.is_empty() {
-            return false;
-        }
 
         let ir_vec = frame.detach_ir();
 


### PR DESCRIPTION
## Summary

`a64_gen_machine_code` bailed whenever a frame had any `specialized_methods` — i.e. whenever the front-end inlined a method or block call. The bail comment claimed the front-end never builds these on aarch64, but `compile_specialized_func` is **not** `jit_x86`-gated, so it does. Measuring optcarrot's `--opt` core showed **22/22 of the JIT bails were exactly this** (`PPU#run` / `CPU#run` and the `OptimizedCodeBuilder` blocks aborting their whole compile).

The per-instruction lowering for inlined frames was already ported (`SpecializedCall`, `SpecializedYield`, `MethodRetSpecialized`, `GuardClassVersionSpecialized`, `LoadDynVarSpecialized`, …); only the recursion that **emits the inlined bodies** was missing.

## Change

Port the recursion from the x86 `gen_machine_code`: walk `frame.specialized_methods` and recursively emit each body **before** binding `entry_label` (so entering the main body doesn't fall through the inlined ones).

aarch64 ignores the specialized recompile index — `GuardClassVersionSpecialized` / `RecompileDeoptSpecialized` already degrade to a plain deopt (`idx: _`) — so, unlike x86, we don't register `self.specialized_info`; the `SpecializedCall` lowering binds each call-site patch point itself.

## Verification

- Full `cargo nextest run --release` — **2210 passed**.
- optcarrot `-b --opt` matches CRuby (**checksum 59662**); JIT aborts dropped **15 → 1** (the lone remaining one is an unrelated unported feature in one block), finished compiles 145 → 207, ~1.5× higher fps.
- `so_nbody` / `so_mandelbrot` / `app_fib` still match CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)