### PR TITLE
jit(aarch64): enable inline-method generators + inline integer &/|/^

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -47,12 +47,12 @@ mod true_class;
 
 #[cfg(jit_x86)]
 use crate::codegen::jitgen::AbstractState;
-#[cfg(jit_x86)]
+#[cfg(jit)]
 use codegen::jitgen::asmir::*;
 pub use enumerator::YIELDER;
-#[cfg(jit_x86)]
+#[cfg(jit)]
 pub use monoasm::*;
-#[cfg(jit_x86)]
+#[cfg(jit)]
 pub use monoasm_macro::*;
 use monoruby_attr::monoruby_builtin;
 use num::ToPrimitive;

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -1,6 +1,6 @@
 use super::*;
-#[cfg(jit_x86)]
-use jitgen::JitContext;
+#[cfg(jit)]
+use jitgen::{AbstractState, JitContext};
 use num::{BigInt, ToPrimitive, Zero};
 use std::ops::{BitAnd, BitOr, BitXor};
 
@@ -32,9 +32,9 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         1,
     );
     globals.define_builtin_inline_func(INTEGER_CLASS, "**", int_pow, inline_gen!(integer_pow), 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "&", bitand, inline_gen!(integer_bitand), 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, inline_gen!(integer_bitor), 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "^", bitxor, inline_gen!(integer_bitxor), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "&", bitand, inline_gen2!(integer_bitand), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, inline_gen2!(integer_bitor), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "^", bitxor, inline_gen2!(integer_bitxor), 1);
     globals.define_builtin_func(INTEGER_CLASS, "divmod", divmod, 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, ">>", shr, inline_gen!(integer_shr), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "<<", shl, inline_gen!(integer_shl), 1);
@@ -1253,7 +1253,7 @@ fn integer_pow_float_rhs(
 /// `emit_imm` generates `<op>q rdi, imm` (rdi: tagged fixnum lhs, imm: tagged
 /// fixnum rhs that fits in `i32`).
 /// `emit_rr` generates `<op>q rdi, rsi` (both tagged fixnums in rdi/rsi).
-#[cfg(jit_x86)]
+#[cfg(jit)]
 fn integer_bitop_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -1310,7 +1310,7 @@ fn integer_bitop_inline(
 /// representation fits in `i32`, emit the immediate form directly via
 /// `emit_imm`. Otherwise load the full 64-bit tagged value into rsi and
 /// emit the register form via `emit_rr`.
-#[cfg(jit_x86)]
+#[cfg(jit)]
 fn emit_bitop_imm(
     ir: &mut AsmIr,
     imm: Fixnum,
@@ -1322,16 +1322,21 @@ fn emit_bitop_imm(
         ir.inline(move |r#gen, _, _, _| emit_imm(r#gen, tagged));
     } else {
         ir.inline(move |r#gen, _, _, _| {
+            // Load the 64-bit tagged literal into rsi (x86) / x3 (aarch64).
+            #[cfg(jit_x86)]
             monoasm!( &mut r#gen.jit,
                 movq rsi, (tagged);
+            );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                mov x3, (tagged as u64);  // GP::Rsi == x3
             );
             emit_rr(r#gen);
         });
     }
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_bitor(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -1349,20 +1354,27 @@ fn integer_bitor(
         rhs_class,
         |a, b| a | b,
         |r#gen, imm| {
-            monoasm!( &mut r#gen.jit,
-                orq rdi, (imm);
+            // `(2a+1) | (2b+1)` keeps LSB=1, so the tag survives directly.
+            #[cfg(jit_x86)]
+            monoasm!( &mut r#gen.jit, orq rdi, (imm); );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                mov x9, (imm as u64);
+                orr x4, x4, x9;          // GP::Rdi == x4
             );
         },
         |r#gen| {
-            monoasm!( &mut r#gen.jit,
-                orq rdi, rsi;
+            #[cfg(jit_x86)]
+            monoasm!( &mut r#gen.jit, orq rdi, rsi; );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                orr x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
             );
         },
     )
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_bitand(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -1380,20 +1392,27 @@ fn integer_bitand(
         rhs_class,
         |a, b| a & b,
         |r#gen, imm| {
-            monoasm!( &mut r#gen.jit,
-                andq rdi, (imm);
+            // `(2a+1) & (2b+1)` keeps LSB=1, so the tag survives directly.
+            #[cfg(jit_x86)]
+            monoasm!( &mut r#gen.jit, andq rdi, (imm); );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                mov x9, (imm as u64);
+                and x4, x4, x9;          // GP::Rdi == x4
             );
         },
         |r#gen| {
-            monoasm!( &mut r#gen.jit,
-                andq rdi, rsi;
+            #[cfg(jit_x86)]
+            monoasm!( &mut r#gen.jit, andq rdi, rsi; );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                and x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
             );
         },
     )
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_bitxor(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -1414,14 +1433,27 @@ fn integer_bitxor(
         rhs_class,
         |a, b| a ^ b,
         |r#gen, imm| {
-            monoasm!( &mut r#gen.jit,
-                xorq rdi, (imm - 1);
+            // XOR clears the tag bit; using `imm - 1` (tag stripped from the
+            // literal) keeps lhs's tag, so no re-tag is needed.
+            #[cfg(jit_x86)]
+            monoasm!( &mut r#gen.jit, xorq rdi, (imm - 1); );
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                mov x9, ((imm - 1) as u64);
+                eor x4, x4, x9;          // GP::Rdi == x4
             );
         },
         |r#gen| {
+            #[cfg(jit_x86)]
             monoasm!( &mut r#gen.jit,
                 xorq rdi, rsi;
                 addq rdi, 1;
+            );
+            // `(2a+1) ^ (2b+1)` clears LSB, so re-tag with `+1`.
+            #[cfg(not(jit_x86))]
+            monoasm_arm64!( &mut r#gen.jit,
+                eor x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
+                add x4, x4, #(1);
             );
         },
     )

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3964,6 +3964,11 @@ impl Codegen {
                 let offset = store[callee_fid].get_offset();
                 return self.a64_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
+            // Inlined builtin method body. The generator's closure emits the
+            // arch-appropriate asm directly (ported generators cfg-switch to
+            // aarch64). Un-ported generators never reach here: they register
+            // `noinline_gen`, which declines to inline. Mirrors x86.
+            AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
             _ => return false,
         }
         true

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -121,7 +121,7 @@ impl<'a> JitContext<'a> {
             && let Some(info) = self.store.inline_info.get_inline(func_id)
         {
             match info {
-                #[cfg(jit_x86)]
+                #[cfg(jit)]
                 InlineFuncInfo::InlineGen(f) => {
                     if self.inline_asm(state, ir, f, callid, recv_class, arg_class) {
                         state.unset_side_effect_guard();

--- a/monoruby/src/executor/inline.rs
+++ b/monoruby/src/executor/inline.rs
@@ -2,14 +2,14 @@ use super::*;
 
 #[allow(non_camel_case_types)]
 pub(crate) enum InlineFuncInfo {
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     InlineGen(Box<InlineGen>),
     CFunc_F_F(unsafe extern "C" fn(f64) -> f64),
     CFunc_FF_F(extern "C" fn(f64, f64) -> f64),
 }
 
 impl InlineFuncInfo {
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn new_inline_gen(f: Box<InlineGen>) -> Self {
         InlineFuncInfo::InlineGen(f)
     }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -24,7 +24,7 @@ pub use store::*;
 
 pub static WARNING: std::sync::LazyLock<AtomicU8> = std::sync::LazyLock::new(|| AtomicU8::new(0u8));
 
-#[cfg(jit_x86)]
+#[cfg(jit)]
 pub(crate) type InlineGen = dyn Fn(
     &mut jitgen::AbstractState,
     &mut jitgen::asmir::AsmIr,
@@ -34,6 +34,25 @@ pub(crate) type InlineGen = dyn Fn(
     ClassId,
     Option<ClassId>,
 ) -> bool;
+
+/// Universal inline generator that always declines to inline (returns
+/// `false`), so the call site falls back to a normal method call. Used on
+/// aarch64 for builtins whose hand-written inline asm has not been ported yet:
+/// registration goes through the same path on both arches, but un-ported
+/// generators register this instead of arch-specific codegen (see the
+/// `inline_gen!` macro). x86 never uses it.
+#[cfg(jit)]
+pub(crate) fn noinline_gen(
+    _: &mut jitgen::AbstractState,
+    _: &mut jitgen::asmir::AsmIr,
+    _: &crate::jitgen::JitContext,
+    _: &Store,
+    _: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    false
+}
 
 pub(crate) const GLOBALS_FUNCINFO: usize =
     std::mem::offset_of!(Globals, store.functions.info) + MONOVEC_PTR;

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -472,7 +472,7 @@ impl Globals {
         func_id
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_inline_func(
         &mut self,
         class_id: ClassId,
@@ -484,7 +484,7 @@ impl Globals {
         self.define_builtin_inline_funcs(class_id, name, &[], address, inline_gen, arg_num)
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_inline_funcs(
         &mut self,
         class_id: ClassId,
@@ -499,7 +499,7 @@ impl Globals {
         )
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_inline_func_with(
         &mut self,
         class_id: ClassId,
@@ -522,7 +522,7 @@ impl Globals {
         )
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_inline_funcs_with(
         &mut self,
         class_id: ClassId,
@@ -548,7 +548,7 @@ impl Globals {
         )
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_inline_funcs_with_kw(
         &mut self,
         class_id: ClassId,
@@ -585,7 +585,7 @@ impl Globals {
     // is dropped to `()` by `inline_gen!`, so only the runtime function is
     // registered. The VM function is identical to the inline form's
     // `address`, so dispatch is unaffected.
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_inline_func(
         &mut self,
         class_id: ClassId,
@@ -597,7 +597,7 @@ impl Globals {
         self.define_builtin_func(class_id, name, address, arg_num)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_inline_funcs(
         &mut self,
         class_id: ClassId,
@@ -610,7 +610,7 @@ impl Globals {
         self.define_builtin_funcs(class_id, name, alias, address, arg_num)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_inline_func_with(
         &mut self,
         class_id: ClassId,
@@ -624,7 +624,7 @@ impl Globals {
         self.define_builtin_func_with(class_id, name, address, min, max, rest)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_inline_funcs_with(
         &mut self,
         class_id: ClassId,
@@ -639,7 +639,7 @@ impl Globals {
         self.define_builtin_funcs_with(class_id, name, alias, address, min, max, rest)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_inline_funcs_with_kw(
         &mut self,
         class_id: ClassId,
@@ -777,7 +777,7 @@ impl Globals {
         )
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_class_inline_func_rest(
         &mut self,
         class_id: ClassId,
@@ -789,7 +789,7 @@ impl Globals {
         self.define_builtin_inline_func_with(class_id, name, address, inline_gen, 0, 0, true)
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_class_inline_funcs_catch_all(
         &mut self,
         class_id: ClassId,
@@ -837,7 +837,7 @@ impl Globals {
         self.define_builtin_func_with(class_id, name, address, min, max, rest)
     }
 
-    #[cfg(jit_x86)]
+    #[cfg(jit)]
     pub(crate) fn define_builtin_module_inline_func(
         &mut self,
         class_id: ClassId,
@@ -852,7 +852,7 @@ impl Globals {
         fid
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_class_inline_func_rest(
         &mut self,
         class_id: ClassId,
@@ -864,7 +864,7 @@ impl Globals {
         self.define_builtin_func_with(class_id, name, address, 0, 0, true)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_class_inline_funcs_catch_all(
         &mut self,
         class_id: ClassId,
@@ -877,7 +877,7 @@ impl Globals {
         self.define_builtin_funcs_with_kw(class_id, name, alias, address, 0, 0, true, &[], true)
     }
 
-    #[cfg(not(jit_x86))]
+    #[cfg(not(jit))]
     pub(crate) fn define_builtin_module_inline_func(
         &mut self,
         class_id: ClassId,

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -21,8 +21,34 @@ macro_rules! inline_gen {
         Box::new($f)
     };
 }
-#[cfg(not(jit_x86))]
+// aarch64 JIT: the generator `$f` is still x86-only (its inline asm has not
+// been ported), so register the universal `noinline_gen` instead — it declines
+// to inline, falling back to a normal method call, without ever naming `$f`.
+#[cfg(all(jit, not(jit_x86)))]
 macro_rules! inline_gen {
+    ($f:expr) => {
+        Box::new(crate::globals::noinline_gen)
+    };
+}
+#[cfg(not(jit))]
+macro_rules! inline_gen {
+    ($f:expr) => {
+        ()
+    };
+}
+
+/// Like [`inline_gen!`], but for generators whose inline asm has been ported to
+/// every JIT arch (`$f` exists and is valid on both x86 and aarch64). Use this
+/// when registering a builtin whose generator is `#[cfg(jit)]` with
+/// arch-switched asm; `inline_gen!` stays for the x86-only ones.
+#[cfg(jit)]
+macro_rules! inline_gen2 {
+    ($f:expr) => {
+        Box::new($f)
+    };
+}
+#[cfg(not(jit))]
+macro_rules! inline_gen2 {
     ($f:expr) => {
         ()
     };


### PR DESCRIPTION
## Summary

The whole inline-method-generator subsystem (`InlineGen`, the `inline_gen!` macro, the `define_builtin_inline_*` registrars, the `Inline` AsmInst lowering) was `jit_x86`-gated, so on aarch64 every inlinable builtin fell back to a normal method call. This brings the mechanism up on **every JIT arch** (`jit`) so generators can emit arch-appropriate asm, and ports the first generators.

## Mechanism (foundation)

- `InlineGen` / `InlineFuncInfo::InlineGen` / the call-site dispatch / the `define_builtin_inline_*` registrars / the `monoasm{,_macro}` + asmir re-exports in builtins are now `#[cfg(jit)]`.
- The `Inline` AsmInst lowering runs the generator's closure on aarch64 too (it already did on x86).
- **Incremental-porting scaffolding:** on aarch64, `inline_gen!` registers the new universal `noinline_gen` (declines to inline → method-call fallback) instead of naming the still-x86-only generator, so un-ported builtins build unchanged. Generators ported to both arches register via the new `inline_gen2!`. This lets generators be ported one group at a time without a flag-day.

## First ported generators

`Integer#&` / `#|` / `#^`. The asm closures cfg-switch to aarch64: `and`/`orr`/`eor` on the tagged operands (x4 = `GP::Rdi`, x3 = `GP::Rsi`), materializing the literal through x9; `^` re-tags the result with `+1`. All other inline generators keep falling back to method calls for now (future PRs port shifts, `%`, `**`, `Math.*`, `Array#each`, …).

## Verification

- Full `cargo nextest run --release` — **2210 passed**.
- `&` / `|` / `^` (including negative and >32-bit literals) match CRuby.
- `--features emit-asm` confirms `Object#f { a & b }` lowers to an inline `and x4, x4, x3` with no method-call frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)