### PR TITLE
jit(aarch64): inline Integer#>> / #<< by a constant shift amount

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -36,8 +36,8 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_inline_func(INTEGER_CLASS, "|", bitor, inline_gen2!(integer_bitor), 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "^", bitxor, inline_gen2!(integer_bitxor), 1);
     globals.define_builtin_func(INTEGER_CLASS, "divmod", divmod, 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, ">>", shr, inline_gen!(integer_shr), 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "<<", shl, inline_gen!(integer_shl), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, ">>", shr, inline_gen2!(integer_shr), 1);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "<<", shl, inline_gen2!(integer_shl), 1);
     // `===` is a true alias of `==` (ruby/spec core/integer/case_compare_spec.rb).
     globals.define_builtin_funcs(INTEGER_CLASS, "==", &["==="], eq, 1);
     globals.define_builtin_func(INTEGER_CLASS, ">=", ge, 1);
@@ -867,8 +867,7 @@ fn fold_shl_pos(lhs: i64, k: u64) -> Option<i64> {
     }
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_shr(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -913,25 +912,50 @@ fn integer_shr(
                     r#gen.gen_shl_rhs_imm(k as u8, &labels[deopt])
                 });
             } else {
-                // shift too large for inline, deopt
+                // shift too large for inline: only 0 stays 0, else deopt.
                 let deopt = ir.new_deopt(state);
-                ir.inline(move |r#gen, _, labels, _| {
-                    let deopt = &labels[deopt];
-                    monoasm!( &mut r#gen.jit,
-                        cmpq rdi, (Value::i32(0).id());
-                        jne deopt;
-                        movq rdi, (Value::i32(0).id());
-                    );
-                });
+                ir.inline(move |r#gen, _, labels, _| shl_overflow_zero(r#gen, &labels[deopt]));
             }
         }
     } else {
-        state.load_fixnum(ir, args, GP::Rcx);
-        let deopt = ir.new_deopt(state);
-        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shr(&labels[deopt]));
+        // Variable shift amount: x86 uses gen_shr (lzcnt overflow guard,
+        // two-page cold path). Not yet ported to aarch64 — bail to a method
+        // call.
+        #[cfg(jit_x86)]
+        {
+            state.load_fixnum(ir, args, GP::Rcx);
+            let deopt = ir.new_deopt(state);
+            ir.inline(move |r#gen, _, labels, _| r#gen.gen_shr(&labels[deopt]));
+        }
+        #[cfg(not(jit_x86))]
+        return false;
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true
+}
+
+/// Inline body for `n << k` / `n >> -k` with `k >= 64`: a non-zero `n`
+/// overflows (deopt); `0` shifts to `0`. Shared by `integer_shl`/`integer_shr`.
+#[cfg(jit)]
+fn shl_overflow_zero(r#gen: &mut Codegen, deopt: &DestLabel) {
+    let z = Value::i32(0).id();
+    #[cfg(jit_x86)]
+    monoasm!( &mut r#gen.jit,
+        cmpq rdi, (z);
+        jne deopt;
+        movq rdi, (z);
+    );
+    #[cfg(not(jit_x86))]
+    {
+        monoasm_arm64!( &mut r#gen.jit,
+            mov x9, (z);
+            cmp x4, x9;              // GP::Rdi == x4
+        );
+        r#gen.jit.bcond_label(Cond::Ne, deopt);
+        monoasm_arm64!( &mut r#gen.jit,
+            mov x4, x9;
+        );
+    }
 }
 
 ///
@@ -945,8 +969,7 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     super::op::shl_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_shl(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -988,25 +1011,26 @@ fn integer_shl(
             let k = (-rhs) as u64;
             ir.inline(move |r#gen, _, _, _| r#gen.gen_shr_imm(k.min(64) as u8));
         } else {
-            // rhs >= 64: deopt (overflow for non-zero lhs)
+            // rhs >= 64: non-zero lhs overflows (deopt); 0 stays 0.
             let deopt = ir.new_deopt(state);
-            ir.inline(move |r#gen, _, labels, _| {
-                let deopt = &labels[deopt];
-                monoasm!( &mut r#gen.jit,
-                    cmpq rdi, (Value::i32(0).id());
-                    jne deopt;
-                    movq rdi, (Value::i32(0).id());
-                );
-            });
+            ir.inline(move |r#gen, _, labels, _| shl_overflow_zero(r#gen, &labels[deopt]));
         }
-    } else if let Some(lhs) = state.is_fixnum_literal(recv) {
-        state.load_fixnum(ir, args, GP::Rcx);
-        let deopt = ir.new_deopt(state);
-        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl_lhs_imm(lhs.get(), &labels[deopt]));
     } else {
-        state.load_fixnum(ir, args, GP::Rcx);
-        let deopt = ir.new_deopt(state);
-        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
+        // Variable shift amount (gen_shl / gen_shl_lhs_imm): x86's lzcnt
+        // overflow guard + two-page cold path is not yet ported to aarch64 —
+        // bail to a method call.
+        #[cfg(jit_x86)]
+        if let Some(lhs) = state.is_fixnum_literal(recv) {
+            state.load_fixnum(ir, args, GP::Rcx);
+            let deopt = ir.new_deopt(state);
+            ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl_lhs_imm(lhs.get(), &labels[deopt]));
+        } else {
+            state.load_fixnum(ir, args, GP::Rcx);
+            let deopt = ir.new_deopt(state);
+            ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
+        }
+        #[cfg(not(jit_x86))]
+        return false;
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -499,6 +499,55 @@ impl Codegen {
         true
     }
 
+    /// Inlined `Integer#>>` / `Integer#<<` by a constant shift amount (the
+    /// "shift right by `imm`" primitive). Operand is the tagged fixnum `2n+1`
+    /// in Rdi (x4). aarch64 twin of x86 `gen_shr_imm`.
+    pub(crate) fn gen_shr_imm(&mut self, imm: u8) {
+        let rdi = GP::Rdi.a64().0; // x4
+        if imm >= 64 {
+            // Shift-out: -1 (all bits) collapses to -1, everything else to 0.
+            let zero = self.jit.label();
+            let exit = self.jit.label();
+            let neg1 = Value::i32(-1).id();
+            let z = Value::i32(0).id();
+            monoasm_arm64!(&mut self.jit,
+                tbz x(rdi), #(63), zero;   // non-negative -> 0
+                mov x(rdi), (neg1);
+                b exit;
+                zero:
+                mov x(rdi), (z);
+                exit:
+            );
+        } else {
+            // `((2n+1) >>a imm) | 1` == `2*(n>>imm) + 1`. monoasm has no
+            // `orr`-immediate, so set the tag bit via a scratch register.
+            monoasm_arm64!(&mut self.jit,
+                asr x(rdi), x(rdi), #(imm as u32);
+                mov x9, #(1);
+                orr x(rdi), x(rdi), x9;
+            );
+        }
+    }
+
+    /// Inlined `Integer#<<` by a constant shift amount, with a fixnum-overflow
+    /// guard that deopts. Operand `2n+1` in Rdi (x4). aarch64 twin of x86
+    /// `gen_shl_rhs_imm`. x86 uses `lzcnt` for the overflow test; monoasm has
+    /// no `clz`, so detect overflow by shifting back: a fixnum `n<<rhs` fits
+    /// i63 iff the tagged `2n<<rhs` fits i64, i.e. `(2n<<rhs) >>a rhs == 2n`.
+    pub(crate) fn gen_shl_rhs_imm(&mut self, rhs: u8, deopt: &DestLabel) {
+        let rdi = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            sub x(rdi), x(rdi), #(1);          // 2n (strip tag)
+            lsl x9, x(rdi), #(rhs as u32);     // 2n << rhs
+            asr x10, x9, #(rhs as u32);        // shift back (signed)
+            cmp x(rdi), x10;                   // lost significant bits?
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, deopt); // overflow -> deopt
+        monoasm_arm64!(&mut self.jit,
+            add x(rdi), x9, #(1);              // 2(n<<rhs) is even, so +1 sets the tag
+        );
+    }
+
     /// Compare two tagged fixnums (the tag preserves order). Mirrors x86
     /// `cmp_integer`.
     fn a64_cmp_integer(&mut self, mode: &OpMode, lhs: GP, rhs: GP) {


### PR DESCRIPTION
## Summary

Second group on the inline-generator foundation (#672): ports the **constant-shift-amount** paths of `Integer#>>` / `#<<` to aarch64.

New aarch64 `Codegen::gen_shr_imm` / `gen_shl_rhs_imm` twins:

- **`>> imm`**: `asr`, then set the tag bit (monoasm has no `orr`-immediate, so via a scratch reg); `imm >= 64` collapses to `0` / `-1` by sign.
- **`<< imm`**: x86 guards overflow with `lzcnt`, which monoasm lacks (no `clz`). Instead detect overflow by **shifting back**: a fixnum `n<<rhs` fits i63 iff the tagged `2n<<rhs` fits i64, i.e. `(2n<<rhs) >>a rhs == 2n` — deopt on mismatch, then re-tag (`2n<<rhs` is even, so `+1`).

The `rhs >= 64` overflow-or-zero tail is shared via a small `shl_overflow_zero` helper.

**Not ported (bail → method call):** variable shift amounts (x86 `gen_shr` / `gen_shl` / `gen_shl_lhs_imm`, with their `lzcnt` guards and two-page cold paths). Those paths `return false` on aarch64.

## Verification

- Full `cargo nextest run --release` — **2210 passed**.
- Constant + variable shifts, negative shift amounts, `>= 64` shifts, and overflow-to-BigInt all match CRuby.
- `--features emit-asm` shows `a << 3` / `a >> 2` lowering to inline `lsl` / `asr` with no method-call frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)