### PR TITLE
jit(aarch64): inline Math.sqrt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#0d1129df625ea9f1ec952bd1aee110a7a56660e2"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#04974c5e0b15641d11fecebfd5515763f93ebc95"
 dependencies = [
  "chrono",
  "libc",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#0d1129df625ea9f1ec952bd1aee110a7a56660e2"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#04974c5e0b15641d11fecebfd5515763f93ebc95"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(jit)]
+use jitgen::{AbstractState, JitContext};
 use num::ToPrimitive;
 use std::os::raw::c_int;
 
@@ -86,7 +88,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_class("DomainError", standarderr, klass);
     globals.set_constant_by_str(klass, "PI", Value::float(std::f64::consts::PI));
     globals.set_constant_by_str(klass, "E", Value::float(std::f64::consts::E));
-    globals.define_builtin_module_inline_func(klass, "sqrt", sqrt, inline_gen!(math_sqrt), 1);
+    globals.define_builtin_module_inline_func(klass, "sqrt", sqrt, inline_gen2!(math_sqrt), 1);
 
     globals.define_builtin_module_cfunc_f_f(klass, "cos", cos, extern_cos, 1);
     globals.define_builtin_module_cfunc_f_f(klass, "sin", sin, extern_sin, 1);
@@ -682,8 +684,7 @@ fn log1p(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     Ok(Value::float(f.ln_1p()))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn math_sqrt(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -707,26 +708,30 @@ fn math_sqrt(
     let fret = dst.map(|dst| state.def_F(dst));
     ir.inline(move |r#gen, _, labels, base| {
         let deopt_label = &labels[deopt];
-        let do_sqrt = r#gen.jit.label();
-        // ucomisd sets PF=1 for NaN and CF=1 for val < 0.
         // NaN passes through (sqrt(NaN) = NaN); negative values deopt.
-        // -0.0 compares equal to 0.0, so it skips the deopt and sqrtsd
-        // yields -0.0 as CRuby does.
-        // Load the source into xmm0 (works for either pool or spill).
-        r#gen.load_fpr_into_xmm0(fsrc, base);
-        monoasm!( &mut r#gen.jit,
-            xorpd xmm1, xmm1;
-            ucomisd xmm0, xmm1;
-            jp do_sqrt;
-            jb deopt_label;
-        do_sqrt:
-        );
-        if let Some(fret) = fret {
+        // -0.0 compares equal to 0.0, so it skips the deopt and yields -0.0
+        // as CRuby does.
+        #[cfg(jit_x86)]
+        {
+            let do_sqrt = r#gen.jit.label();
+            // ucomisd sets PF=1 for NaN and CF=1 for val < 0.
+            r#gen.load_fpr_into_xmm0(fsrc, base);
             monoasm!( &mut r#gen.jit,
-                sqrtsd xmm0, xmm0;
+                xorpd xmm1, xmm1;
+                ucomisd xmm0, xmm1;
+                jp do_sqrt;
+                jb deopt_label;
+            do_sqrt:
             );
-            r#gen.store_fpr_into_xmm(fret, base);
+            if let Some(fret) = fret {
+                monoasm!( &mut r#gen.jit,
+                    sqrtsd xmm0, xmm0;
+                );
+                r#gen.store_fpr_into_xmm(fret, base);
+            }
         }
+        #[cfg(not(jit_x86))]
+        r#gen.a64_math_sqrt(fsrc, fret, deopt_label, base);
     });
     true
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3436,6 +3436,55 @@ impl Codegen {
         true
     }
 
+    /// Load a `FPReg` (pool reg or spill slot) into `d0`.
+    fn a64_fpr_into_d0(&mut self, src: FPReg, base: usize) {
+        match src.loc(base) {
+            FPRegLoc::Xmm(p) => monoasm_arm64!(&mut self.jit, fmov d0, d(p as u32);),
+            FPRegLoc::Spill(off) => monoasm_arm64!(&mut self.jit,
+                mov x10, (off as i64 as u64);
+                sub x10, x29, x10;        // [x29 - off] (mirrors x86 [rbp - off])
+                ldr d0, [x10];
+            ),
+        }
+    }
+
+    /// Store `d0` into a `FPReg` (pool reg or spill slot).
+    fn a64_d0_into_fpr(&mut self, dst: FPReg, base: usize) {
+        match dst.loc(base) {
+            FPRegLoc::Xmm(p) => monoasm_arm64!(&mut self.jit, fmov d(p as u32), d0;),
+            FPRegLoc::Spill(off) => monoasm_arm64!(&mut self.jit,
+                mov x10, (off as i64 as u64);
+                sub x10, x29, x10;
+                str d0, [x10];
+            ),
+        }
+    }
+
+    /// Inlined `Math.sqrt`: `fsqrt` on the unboxed argument. NaN passes through
+    /// (`sqrt(NaN) == NaN`); a negative argument deopts so the interpreter
+    /// re-runs the builtin and raises DomainError (`-0.0` compares equal to
+    /// `0.0`, so it falls through and `fsqrt(-0.0) == -0.0`, as CRuby).
+    /// aarch64 twin of x86 `math_sqrt`'s inline body.
+    pub(crate) fn a64_math_sqrt(
+        &mut self,
+        src: FPReg,
+        dst: Option<FPReg>,
+        deopt: &DestLabel,
+        base: usize,
+    ) {
+        self.a64_fpr_into_d0(src, base);
+        let do_sqrt = self.jit.label();
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit, fcmp d0, #0.0;);
+        self.jit.bcond_label(monoasm::Cond::Vs, &do_sqrt); // NaN (unordered) -> sqrt
+        self.jit.bcond_label(monoasm::Cond::Mi, &deopt); // negative -> deopt
+        self.jit.bind_label(do_sqrt);
+        if let Some(dst) = dst {
+            monoasm_arm64!(&mut self.jit, fsqrt d0, d0;);
+            self.a64_d0_into_fpr(dst, base);
+        }
+    }
+
     /// `def name; … end` — runtime::define_method(vm, globals, name, func_id).
     /// The Option<Value> result (None == error) is checked by the trailing
     /// HandleError. Bails when an xmm pool register is live (no save around the


### PR DESCRIPTION
## Summary

Ports the `math_sqrt` inline generator to aarch64 — the last `Math` builtin that wasn't inlined. (`Math.cos` / `sin` / `sinh` / `cosh` use the CFunc path, which already inlines as an `extern` C-call on both arches — verified.)

New `Codegen::a64_math_sqrt`: load the unboxed argument into `d0` (pool reg or spill slot), `fcmp d0, #0.0` — NaN passes through (`sqrt(NaN) == NaN`), a negative argument deopts (interpreter re-runs the builtin and raises `DomainError`; `-0.0` falls through and `fsqrt(-0.0) == -0.0`, same as the VM) — then `fsqrt`. Mirrors x86 `math_sqrt`'s `ucomisd`/`sqrtsd` body.

`monoasm_arm64!` had only two-operand FP arithmetic, so this **bumps the monoasm pin** to a rev that adds the single-source FP ops `fsqrt`/`fneg`/`fabs` (sisshiki1969/monoasm@`aarch`).

## Verification

- Full `cargo nextest run --release` — **2216 passed**.
- The JIT result matches monoruby's own VM (`--no-jit`) for sqrt of positives, `0.0`, `-0.0`, large values, NaN, and the negative-argument `DomainError`.
- `--features emit-asm` shows `fcmp d0, #0.0` / `fsqrt d0, d0` with no method-call frame.

> Note: `Math.sqrt(-0.0)` is `-0.0` in monoruby (both VM and JIT, IEEE/`fsqrt`) vs `0.0` in the macOS reference Ruby — a pre-existing Darwin libm difference, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)