### PR TITLE
jit(aarch64): inline accessor builtins (Array#size, Range#begin/end/exclude_end?, String#bytesize)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1,6 +1,8 @@
 use super::*;
 #[cfg(jit_x86)]
 use jitgen::JitContext;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 use rubymap::RubyEql;
 use smallvec::smallvec;
 use std::cmp::Ordering;
@@ -30,7 +32,7 @@ pub(super) fn init(globals: &mut Globals) {
         "size",
         &["length"],
         size,
-        inline_gen!(array_size),
+        inline_gen2!(array_size),
         0,
     );
     globals.define_builtin_inline_func(
@@ -330,8 +332,7 @@ fn size(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     Ok(Value::integer(len as i64))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_size(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -349,9 +350,15 @@ fn array_size(
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
         r#gen.get_array_length();
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             salq  rax, 1;
             orq   rax, 1;
+        }
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            lsl x0, x0, #1;
+            add x0, x0, #1;
         }
     });
 

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(jit)]
+use jitgen::{AbstractState, JitContext};
 
 //
 // Range class
@@ -8,15 +10,15 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Range", RANGE_CLASS, ObjTy::RANGE);
     globals.define_builtin_class_func_with(RANGE_CLASS, "new", range_new, 2, 3, false);
     globals.store[RANGE_CLASS].set_alloc_func(range_alloc_func);
-    globals.define_builtin_inline_func(RANGE_CLASS, "begin", begin, inline_gen!(range_begin), 0);
+    globals.define_builtin_inline_func(RANGE_CLASS, "begin", begin, inline_gen2!(range_begin), 0);
     globals.define_builtin_func_with(RANGE_CLASS, "first", first, 0, 1, false);
-    globals.define_builtin_inline_func(RANGE_CLASS, "end", end, inline_gen!(range_end), 0);
+    globals.define_builtin_inline_func(RANGE_CLASS, "end", end, inline_gen2!(range_end), 0);
     globals.define_builtin_func_with(RANGE_CLASS, "last", last, 0, 1, false);
     globals.define_builtin_inline_func(
         RANGE_CLASS,
         "exclude_end?",
         exclude_end,
-        inline_gen!(range_exclude_end),
+        inline_gen2!(range_exclude_end),
         0,
     );
     globals.define_builtin_func(RANGE_CLASS, "each", each, 0);
@@ -82,8 +84,7 @@ fn begin(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(lfp.self_val().as_range().start())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn range_begin(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -106,8 +107,13 @@ fn range_begin(
     }
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rax, [rdi + (crate::rvalue::RANGE_START_OFFSET as i32)];
+        }
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr x0, [x4, #(crate::rvalue::RANGE_START_OFFSET as u32)];
         }
     });
 
@@ -126,8 +132,7 @@ fn end(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     Ok(lfp.self_val().as_range().end())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn range_end(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -150,8 +155,13 @@ fn range_end(
     }
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rax, [rdi + (crate::rvalue::RANGE_END_OFFSET as i32)];
+        }
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr x0, [x4, #(crate::rvalue::RANGE_END_OFFSET as u32)];
         }
     });
 
@@ -241,8 +251,7 @@ fn exclude_end(
     Ok(Value::bool(lfp.self_val().as_range().exclude_end()))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn range_exclude_end(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -264,10 +273,19 @@ fn range_exclude_end(
     }
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movl rax, [rdi + (crate::rvalue::RANGE_EXCLUDE_END_OFFSET as i32)];
             shlq rax, 3;
             orq  rax, (FALSE_VALUE);
+        }
+        // exclude_end is 0/1; (v<<3) is 0 or 8. FALSE_VALUE=0x14 has bit3 clear,
+        // so `add` == `or` here: 0+0x14=FALSE_VALUE, 8+0x14=0x1c=TRUE_VALUE.
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr w0, [x4, #(crate::rvalue::RANGE_EXCLUDE_END_OFFSET as u32)];
+            lsl x0, x0, #3;
+            add x0, x0, #(FALSE_VALUE);
         }
     });
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5,6 +5,8 @@ use super::*;
 use crate::value::rvalue::{eucjp_char_width, sjis_char_width};
 #[cfg(jit_x86)]
 use jitgen::JitContext;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 
 //
 // String class
@@ -71,7 +73,7 @@ pub(super) fn init(globals: &mut Globals) {
         "bytesize",
         &[],
         bytesize,
-        inline_gen!(string_bytesize),
+        inline_gen2!(string_bytesize),
         0,
     );
     globals.define_builtin_func(STRING_CLASS, "ord", ord, 0);
@@ -3380,8 +3382,7 @@ fn bytesize(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     Ok(Value::integer(length as i64))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn string_bytesize(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -3398,12 +3399,22 @@ fn string_bytesize(
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
             cmpq rax, (STRING_INLINE_CAP);
             cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
             salq rax, 1;
             orq  rax, 1;
+        }
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, #(STRING_INLINE_CAP as u32);
+            csel x0, x9, x0, gt;   // capa > inline cap -> use heap_len
+            lsl x0, x0, #1;
+            add x0, x0, #1;
         }
     });
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3546,6 +3546,21 @@ impl Codegen {
         }
     }
 
+    /// Length of the array whose pointer is in Rdi (x4) → Rax (x0), untagged.
+    /// Arrays store a short length inline (the `capa` field) and switch to a
+    /// heap buffer past `ARRAY_INLINE_CAPA`, in which case the real length is
+    /// `heap_len`. aarch64 twin of x86 `get_array_length` (`cmovgt` → `csel`).
+    pub(crate) fn get_array_length(&mut self) {
+        let rdi = GP::Rdi.a64().0; // x4
+        let rax = GP::Rax.a64().0; // x0
+        monoasm_arm64!(&mut self.jit,
+            ldr x(rax), [x(rdi), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x(rax), #(ARRAY_INLINE_CAPA as u32);
+            csel x(rax), x9, x(rax), gt;   // capa > inline cap -> use heap_len
+        );
+    }
+
     /// `def name; … end` — runtime::define_method(vm, globals, name, func_id).
     /// The Option<Value> result (None == error) is checked by the trailing
     /// HandleError. Bails when an xmm pool register is live (no save around the


### PR DESCRIPTION
Ports the InlineGen accessor generators to aarch64 so these hot, tiny methods emit inline machine code instead of falling back to a full method call (`blr`).

## What

| Method | aarch64 inline asm |
|---|---|
| `Array#size` / `#length` | `get_array_length()` (new aarch64 twin of x86 `cmovgt` helper, using `csel`) then tag `lsl #1; add #1` |
| `Range#begin` / `#end` | single `ldr` from `RANGE_START/END_OFFSET` |
| `Range#exclude_end?` | `ldr` the 0/1 byte, `lsl #3`, `add FALSE_VALUE` |
| `String#bytesize` | capa/heap_len select via `csel`, then tag |

For `exclude_end?`, `add` is valid in place of `or` because bit 3 of `FALSE_VALUE` (0x14) is clear: `0 -> FALSE_VALUE`, `8 -> 0x1c = TRUE_VALUE`.

## How

- Registrations switch `inline_gen!` → `inline_gen2!`.
- Generator fns move from `cfg(jit_x86)` to `cfg(jit)`, with their raw-asm block cfg-switched (`monoasm!` for x86 / `monoasm_arm64!` for aarch64).
- Per-file `#[cfg(all(jit, not(jit_x86)))] use jitgen::{AbstractState, JitContext};`.
- Adds `Codegen::get_array_length()` to `compile_stub.rs` (aarch64).

## Verification

- `JIT == VM(--no-jit) == CRuby` on a mixed accessor workload.
- `emit-asm` confirms inlining (`csel`/`ldr`, no method-call `blr`).
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)