### PR TITLE
jit(aarch64): inline the remaining accessor/predicate/conversion builtins

### DIFF
--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(jit)]
+use jitgen::{AbstractState, JitContext};
 
 use num::{BigInt, ToPrimitive, Zero};
 
@@ -43,28 +45,28 @@ pub(super) fn init(globals: &mut Globals) {
         ARITHMETIC_SEQUENCE_CLASS,
         "begin",
         begin,
-        inline_gen!(as_begin_inline),
+        inline_gen2!(as_begin_inline),
         0,
     );
     globals.define_builtin_inline_func(
         ARITHMETIC_SEQUENCE_CLASS,
         "end",
         end,
-        inline_gen!(as_end_inline),
+        inline_gen2!(as_end_inline),
         0,
     );
     globals.define_builtin_inline_func(
         ARITHMETIC_SEQUENCE_CLASS,
         "step",
         step,
-        inline_gen!(as_step_inline),
+        inline_gen2!(as_step_inline),
         0,
     );
     globals.define_builtin_inline_func(
         ARITHMETIC_SEQUENCE_CLASS,
         "exclude_end?",
         exclude_end,
-        inline_gen!(as_exclude_end_inline),
+        inline_gen2!(as_exclude_end_inline),
         0,
     );
     // `each` is intentionally NOT registered here — it's defined in
@@ -109,8 +111,7 @@ fn begin(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(lfp.self_val().as_arithmetic_sequence_inner().begin())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn as_begin_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -134,8 +135,7 @@ fn end(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     Ok(lfp.self_val().as_arithmetic_sequence_inner().end())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn as_end_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -159,8 +159,7 @@ fn step(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     Ok(lfp.self_val().as_arithmetic_sequence_inner().step())
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn as_step_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -191,8 +190,7 @@ fn exclude_end(
     ))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn as_exclude_end_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -209,10 +207,19 @@ fn as_exclude_end_inline(
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movl rax, [rdi + (crate::rvalue::AS_EXCLUDE_END_OFFSET as i32)];
             shlq rax, 3;
             orq  rax, (FALSE_VALUE);
+        }
+        // exclude_end is 0/1; (v<<3) is 0 or 8. FALSE_VALUE=0x14 has bit3 clear,
+        // so `add` == `or`: 0->FALSE_VALUE, 8->0x1c=TRUE_VALUE.
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr w0, [x4, #(crate::rvalue::AS_EXCLUDE_END_OFFSET as u32)];
+            lsl x0, x0, #3;
+            add x0, x0, #(FALSE_VALUE);
         }
     });
     state.def_reg2acc(ir, GP::Rax, dst);
@@ -223,7 +230,7 @@ fn as_exclude_end_inline(
 /// (`begin` / `end` / `step`). Loads a 64-bit `Value` from the given
 /// offset within the receiver's `RValue`. AS has no source-level literal
 /// form, so unlike Range we don't fold against a literal here.
-#[cfg(jit_x86)]
+#[cfg(jit)]
 fn inline_field_load(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -238,8 +245,13 @@ fn inline_field_load(
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rax, [rdi + (offset as i32)];
+        }
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            ldr x0, [x4, #(offset as u32)];
         }
     });
     state.def_reg2acc(ir, GP::Rax, dst);

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -39,14 +39,14 @@ pub(super) fn init(globals: &mut Globals) {
         ARRAY_CLASS,
         "clone",
         clone,
-        inline_gen!(array_clone),
+        inline_gen2!(array_clone),
         0,
     );
     globals.define_builtin_inline_func(
         ARRAY_CLASS,
         "dup",
         dup,
-        inline_gen!(array_dup_inline),
+        inline_gen2!(array_dup_inline),
         0,
     );
     globals.define_builtin_func_with(ARRAY_CLASS, "count", count, 0, 1, false);
@@ -63,7 +63,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(ARRAY_CLASS, "shift", shift, 0, 1, false);
     globals.define_builtin_funcs_rest(ARRAY_CLASS, "unshift", &["prepend"], unshift);
     globals.define_builtin_func_rest(ARRAY_CLASS, "concat", concat);
-    globals.define_builtin_inline_func(ARRAY_CLASS, "<<", shl, inline_gen!(array_shl), 1);
+    globals.define_builtin_inline_func(ARRAY_CLASS, "<<", shl, inline_gen2!(array_shl), 1);
     globals.define_builtin_funcs_with(ARRAY_CLASS, "push", &["append"], push, 0, 0, true);
     globals.define_builtin_func_with(ARRAY_CLASS, "pop", pop, 0, 1, false);
     globals.define_builtin_funcs(ARRAY_CLASS, "==", &["==="], eq, 1);
@@ -383,8 +383,7 @@ fn clone(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     Ok(cloned)
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_clone(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -403,10 +402,13 @@ fn array_clone(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rax, (array_clone_extern);
             call rax;
         }
+        #[cfg(not(jit_x86))]
+        r#gen.a64_array_clone(array_clone_extern as *const () as u64);
     });
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, class_id);
@@ -431,8 +433,7 @@ fn dup(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     ))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_dup_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -451,12 +452,15 @@ fn array_dup_inline(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             // rdi already holds val from state.load above.
             movq rsi, r12; // globals
             movq rax, (array_dup_extern);
             call rax;
         }
+        #[cfg(not(jit_x86))]
+        r#gen.a64_array_dup(array_dup_extern as *const () as u64);
     });
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, class_id);
@@ -931,8 +935,7 @@ extern "C" fn ary_shl(mut ary: Array, arg: Value) -> Value {
     ary.into()
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_shl(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -954,10 +957,13 @@ fn array_shl(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm!( &mut r#gen.jit,
             movq rax, (ary_shl);
             call rax;
         );
+        #[cfg(not(jit_x86))]
+        r#gen.a64_array_shl(ary_shl as *const () as u64);
     });
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, recv_class);

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 
 //
 // Hash class
@@ -24,7 +26,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(HASH_CLASS, "<=", le, 1);
     globals.define_builtin_func(HASH_CLASS, ">", gt, 1);
     globals.define_builtin_func(HASH_CLASS, ">=", ge, 1);
-    globals.define_builtin_inline_func(HASH_CLASS, "[]", index, inline_gen!(hash_index), 1);
+    globals.define_builtin_inline_func(HASH_CLASS, "[]", index, inline_gen2!(hash_index), 1);
     globals.define_builtin_func(HASH_CLASS, "[]=", index_assign, 2);
     globals.define_builtin_func(HASH_CLASS, "clear", clear, 0);
     globals.define_builtin_func(HASH_CLASS, "replace", replace, 1);
@@ -774,8 +776,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     }
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn hash_index(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -797,12 +798,15 @@ fn hash_index(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(|r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! {&mut r#gen.jit,
             movq rdi, rbx;
             movq rsi, r12;
             movq rax, (hashindex);
             call rax;
         }
+        #[cfg(not(jit_x86))]
+        r#gen.a64_hash_index(hashindex as *const () as u64);
     });
     ir.xmm_restore(using_xmm);
     let error = ir.new_error(state);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1,6 +1,8 @@
 use super::*;
 #[cfg(jit_x86)]
 use jitgen::JitContext;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 use num::ToPrimitive;
 use num::Zero;
 use std::{io::Write, mem::transmute};
@@ -12,7 +14,7 @@ use std::{io::Write, mem::transmute};
 pub(super) fn init(globals: &mut Globals) -> Module {
     let klass = globals.define_toplevel_module("Kernel");
     let kernel_class = klass.id();
-    globals.define_builtin_inline_func(kernel_class, "nil?", nil, inline_gen!(kernel_nil), 0);
+    globals.define_builtin_inline_func(kernel_class, "nil?", nil, inline_gen2!(kernel_nil), 0);
     globals.define_builtin_func(kernel_class, "!~", not_match, 1);
     //globals.define_builtin_module_func_rest(kernel_class, "puts", puts);
     globals.define_builtin_module_func(kernel_class, "gets", gets, 0);
@@ -72,7 +74,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         kernel_class,
         "block_given?",
         block_given,
-        inline_gen!(kernel_block_given),
+        inline_gen2!(kernel_block_given),
         0,
     );
     //globals.define_builtin_module_func_rest(kernel_class, "p", p);
@@ -205,14 +207,14 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         kernel_class,
         "object_id",
         super::object::object_id,
-        inline_gen!(super::object::object_object_id),
+        inline_gen2!(super::object::object_object_id),
         0,
     );
     globals.define_builtin_inline_func_with(
         kernel_class,
         "respond_to?",
         respond_to,
-        inline_gen!(object_respond_to),
+        inline_gen2!(object_respond_to),
         1,
         2,
         false,
@@ -231,7 +233,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         "is_a?",
         &["kind_of?"],
         is_a,
-        inline_gen!(kernel_is_a),
+        inline_gen2!(kernel_is_a),
         1,
     );
     globals.define_builtin_inline_funcs_with_kw(
@@ -308,8 +310,7 @@ fn nil(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     Ok(Value::bool(lfp.self_val().is_nil()))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn kernel_nil(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -335,11 +336,19 @@ fn kernel_nil(
     } else {
         state.load(ir, recv, GP::Rdi);
         ir.inline(|r#gen, _, _, _| {
+            #[cfg(jit_x86)]
             monoasm! { &mut r#gen.jit,
                 movq rax, (FALSE_VALUE);
                 movq rsi, (TRUE_VALUE);
                 cmpq rdi, (NIL_VALUE);
                 cmoveqq rax, rsi;
+            }
+            #[cfg(not(jit_x86))]
+            monoasm_arm64! { &mut r#gen.jit,
+                mov  x0, #(FALSE_VALUE);    // GP::Rax == x0
+                mov  x3, #(TRUE_VALUE);     // GP::Rsi == x3
+                cmp  x4, #(NIL_VALUE);      // GP::Rdi == x4
+                csel x0, x3, x0, eq;        // nil -> TRUE, else FALSE
             }
         });
         state.def_rax2acc(ir, dst);
@@ -360,8 +369,7 @@ fn not_match(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(Value::bool(!res.as_bool()))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn kernel_block_given(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -385,6 +393,7 @@ fn kernel_block_given(
     } else {
         ir.inline(|r#gen, _, _, _| {
             let exit = r#gen.jit.label();
+            #[cfg(jit_x86)]
             monoasm! { &mut r#gen.jit,
                 movq rax, (FALSE_VALUE);
                 movq rdi, [r14 - (LFP_BLOCK)];
@@ -394,6 +403,22 @@ fn kernel_block_given(
                 jeq exit;
                 movq rax, (TRUE_VALUE);
             exit:
+            }
+            // block slot at [LFP - LFP_BLOCK]; 0 or NIL means no block given.
+            #[cfg(not(jit_x86))]
+            {
+                monoasm_arm64! { &mut r#gen.jit,
+                    mov x0, #(FALSE_VALUE);             // GP::Rax == x0
+                    sub x9, x22, #(LFP_BLOCK as u32);   // x22 == LFP (r14)
+                    ldr x4, [x9];                       // block handle -> GP::Rdi
+                    cbz x4, exit;
+                    cmp x4, #(NIL_VALUE);
+                }
+                r#gen.jit.bcond_label(monoasm::Cond::Eq, &exit);
+                monoasm_arm64! { &mut r#gen.jit,
+                    mov x0, #(TRUE_VALUE);
+                }
+                r#gen.jit.bind_label(exit);
             }
         });
         state.def_rax2acc(ir, dst);
@@ -2944,8 +2969,7 @@ fn is_a(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     ))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn kernel_is_a(
     state: &mut AbstractState,
     _ir: &mut AsmIr,
@@ -3235,8 +3259,7 @@ fn respond_to(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     Ok(Value::bool(false))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn object_respond_to(
     state: &mut AbstractState,
     _: &mut AsmIr,

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -4,6 +4,8 @@ use super::*;
 use crate::executor::Visibility;
 #[cfg(jit_x86)]
 use jitgen::JitContext;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 
 //
 // Float class
@@ -32,7 +34,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         "to_i",
         &["to_int"],
         toi,
-        inline_gen!(float_toi),
+        inline_gen2!(float_toi),
         0,
     );
     globals.define_basic_op(FLOAT_CLASS, "+", add, 1);
@@ -190,8 +192,7 @@ extern "C" fn rem_ff_f(lhs: f64, rhs: f64) -> f64 {
     lhs.ruby_mod(&rhs)
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn float_toi(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -211,14 +212,19 @@ fn float_toi(
     if let Some(dst) = dst {
         ir.inline(move |r#gen, _, labels, base| {
             let deopt = &labels[deopt];
-            // Load fsrc into xmm0 (handles both pool and spill).
-            r#gen.load_fpr_into_xmm0(fsrc, base);
-            monoasm! { &mut r#gen.jit,
-                cvttsd2siq rdi, xmm0;
-                addq  rdi, rdi;
-                jo    deopt;
-                orq   rdi, 1;
+            #[cfg(jit_x86)]
+            {
+                // Load fsrc into xmm0 (handles both pool and spill).
+                r#gen.load_fpr_into_xmm0(fsrc, base);
+                monoasm! { &mut r#gen.jit,
+                    cvttsd2siq rdi, xmm0;
+                    addq  rdi, rdi;
+                    jo    deopt;
+                    orq   rdi, 1;
+                }
             }
+            #[cfg(not(jit_x86))]
+            r#gen.a64_float_to_int(fsrc, deopt, base);
         });
         state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     }

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -17,7 +17,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     //globals.define_builtin_func_with(INTEGER_CLASS, "step", step, 1, 2, false);
     globals.define_builtin_func(INTEGER_CLASS, "upto", upto, 1);
     globals.define_builtin_func(INTEGER_CLASS, "downto", downto, 1);
-    globals.define_builtin_inline_func(INTEGER_CLASS, "to_f", to_f, inline_gen!(integer_tof), 0);
+    globals.define_builtin_inline_func(INTEGER_CLASS, "to_f", to_f, inline_gen2!(integer_tof), 0);
     globals.define_basic_op(INTEGER_CLASS, "+", add, 1);
     globals.define_basic_op(INTEGER_CLASS, "-", sub, 1);
     globals.define_basic_op(INTEGER_CLASS, "*", mul, 1);
@@ -576,8 +576,7 @@ fn to_f(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     Ok(Value::float(f))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn integer_tof(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -606,11 +605,16 @@ fn integer_tof(
         let fret = state.def_F(ret);
         ir.inline(move |r#gen, _, _, base| {
             // Convert into xmm0, then store into fret (pool or spill).
-            monoasm! { &mut r#gen.jit,
-                sarq  rdi, 1;
-                cvtsi2sdq xmm0, rdi;
+            #[cfg(jit_x86)]
+            {
+                monoasm! { &mut r#gen.jit,
+                    sarq  rdi, 1;
+                    cvtsi2sdq xmm0, rdi;
+                }
+                r#gen.store_fpr_into_xmm(fret, base);
             }
-            r#gen.store_fpr_into_xmm(fret, base);
+            #[cfg(not(jit_x86))]
+            r#gen.a64_int_to_float(fret, base);
         });
     }
     true

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -1,6 +1,8 @@
 use super::*;
 #[cfg(jit_x86)]
 use jitgen::JitContext;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 
 //
 // BasicObject class and Object class
@@ -14,7 +16,7 @@ pub(super) fn init(globals: &mut Globals) {
         BASIC_OBJECT_CLASS,
         "__id__",
         object_id,
-        inline_gen!(object_object_id),
+        inline_gen2!(object_object_id),
         0,
     );
     // `equal?` is an alias of `==` on BasicObject (they share one method
@@ -27,7 +29,7 @@ pub(super) fn init(globals: &mut Globals) {
     // mspec's `SpecPositiveOperatorMatcher`) instead of routing through
     // `method_missing`, breaking the `actual.should === expected` idiom.
     globals.define_builtin_func(OBJECT_CLASS, "===", case_eq, 1);
-    globals.define_builtin_inline_func(BASIC_OBJECT_CLASS, "!", not_, inline_gen!(object_not), 0);
+    globals.define_builtin_inline_func(BASIC_OBJECT_CLASS, "!", not_, inline_gen2!(object_not), 0);
     globals.define_builtin_func(BASIC_OBJECT_CLASS, "!=", ne, 1);
     globals.define_builtin_funcs_with_effect(
         BASIC_OBJECT_CLASS,
@@ -164,8 +166,7 @@ fn not_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<V
     Ok(Value::bool(!lfp.self_val().as_bool()))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn object_not(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -191,12 +192,25 @@ fn object_not(
     } else {
         state.load(ir, recv, GP::Rdi);
         ir.inline(|r#gen, _, _, _| {
+            // `recv | 0x10` maps nil(0x04)->0x14 and false(0x14)->0x14, so the
+            // result is FALSE_VALUE exactly for the two falsy immediates; any
+            // truthy value differs. eq -> TRUE, ne -> FALSE.
+            #[cfg(jit_x86)]
             monoasm! { &mut r#gen.jit,
                 orq  rdi, (0x10);
                 movq rax, (TRUE_VALUE);
                 movq rsi, (FALSE_VALUE);
                 cmpq rdi, (FALSE_VALUE);
                 cmovneq rax, rsi;
+            }
+            #[cfg(not(jit_x86))]
+            monoasm_arm64! { &mut r#gen.jit,
+                mov  x9, #(0x10);
+                orr  x4, x4, x9;            // GP::Rdi == x4
+                mov  x0, #(TRUE_VALUE);     // GP::Rax == x0
+                mov  x3, #(FALSE_VALUE);    // GP::Rsi == x3
+                cmp  x4, #(FALSE_VALUE);
+                csel x0, x0, x3, eq;        // eq -> TRUE, else FALSE
             }
         });
         state.def_rax2acc(ir, dst);
@@ -242,8 +256,7 @@ pub(super) fn object_id(
     Ok(Value::integer(lfp.self_val().id() as i64))
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 pub(super) fn object_object_id(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -262,10 +275,13 @@ pub(super) fn object_object_id(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
+        #[cfg(jit_x86)]
         monoasm! {&mut r#gen.jit,
             movq rax, (crate::executor::op::i64_to_value);
             call rax;
         }
+        #[cfg(not(jit_x86))]
+        r#gen.a64_object_id();
     });
     ir.xmm_restore(using_xmm);
     state.def_rax2acc(ir, ret);

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3561,6 +3561,113 @@ impl Codegen {
         );
     }
 
+    /// Inlined `Integer#to_f`: untag the tagged fixnum in Rdi (x4), convert to
+    /// double with `scvtf`, and store into `fret`. aarch64 twin of x86
+    /// `integer_tof`'s `sarq` + `cvtsi2sdq` + `store_fpr_into_xmm`.
+    pub(crate) fn a64_int_to_float(&mut self, fret: FPReg, base: usize) {
+        let rdi = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            asr x(rdi), x(rdi), #(1);  // untag
+            scvtf d0, x(rdi);
+        );
+        self.a64_d0_into_fpr(fret, base);
+    }
+
+    /// Inlined `Float#to_i`: truncate the double in `fsrc` to i64 (`fcvtzs`),
+    /// then tag it as a fixnum. `fcvtzs` saturates out-of-range doubles to
+    /// i64::MIN/MAX; doubling the result (`adds`) then overflows for both the
+    /// saturated case and any value that doesn't fit in a 63-bit fixnum, so a
+    /// single signed-overflow branch covers both. aarch64 twin of x86
+    /// `cvttsd2siq` + `addq;jo` + `orq 1`. Result Value lands in Rdi (x4).
+    pub(crate) fn a64_float_to_int(&mut self, fsrc: FPReg, deopt: &DestLabel, base: usize) {
+        let rdi = GP::Rdi.a64().0; // x4
+        self.a64_fpr_into_d0(fsrc, base);
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            fcvtzs x(rdi), d0;
+            adds x(rdi), x(rdi), x(rdi);   // ×2, set NZCV
+        );
+        self.jit.bcond_label(monoasm::Cond::Vs, &deopt); // overflow -> deopt
+        monoasm_arm64!(&mut self.jit,
+            add x(rdi), x(rdi), #(1);      // tag (low bit clear after ×2)
+        );
+    }
+
+    /// Inlined `BasicObject#object_id`: `i64_to_value(self_id)`. The receiver
+    /// (its raw id) is in Rdi (x4); move it to the C ABI arg0 (x0) and call.
+    /// Result Value lands in Rax (x0). The FP pool is saved by the surrounding
+    /// AsmIr xmm_save/xmm_restore; here we only preserve LR around the `blr`.
+    pub(crate) fn a64_object_id(&mut self) {
+        let rdi = GP::Rdi.a64().0; // x4
+        let f = crate::executor::op::i64_to_value as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // self id -> arg0
+            mov x9, (f);
+            str x30, [sp, #-16]!; // save LR
+            blr x9;               // x0 = i64_to_value(id)
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// Inlined `Hash#[]`: `hashindex(vm, globals, recv, key)`. The receiver is
+    /// already in Rdx (x2 == C arg2) and the key in Rcx (x1); move the key to
+    /// arg3 first (before x1 is overwritten by globals), then load vm/globals.
+    /// Result Value lands in Rax (x0); errors are checked by the trailing
+    /// HandleError. FP pool saved by the surrounding xmm_save/restore.
+    pub(crate) fn a64_hash_index(&mut self, hashindex: u64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x3, x1;           // key (Rcx) -> arg3   [recv already in x2 == Rdx]
+            mov x0, x19;          // vm (EXEC) -> arg0
+            mov x1, x20;          // globals (GLOBALS) -> arg1
+            mov x9, (hashindex);
+            str x30, [sp, #-16]!; // save LR
+            blr x9;               // x0 = hashindex(vm, globals, recv, key)
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// Inlined `Array#clone`: `array_clone_extern(recv)`. recv (Rdi/x4) -> arg0.
+    /// Result Value in Rax (x0). FP pool saved by the surrounding xmm_save.
+    pub(crate) fn a64_array_clone(&mut self, f: u64) {
+        let rdi = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // recv -> arg0
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// Inlined `Array#dup`: `array_dup_extern(recv, globals)`. recv (Rdi/x4) ->
+    /// arg0, globals (GLOBALS/x20) -> arg1. Result Value in Rax (x0).
+    pub(crate) fn a64_array_dup(&mut self, f: u64) {
+        let rdi = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // recv -> arg0
+            mov x1, x20;          // globals -> arg1
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// Inlined `Array#<<`: `ary_shl(recv, arg)`. recv (Rdi/x4) -> arg0,
+    /// arg (Rsi/x3) -> arg1. Result Value in Rax (x0).
+    pub(crate) fn a64_array_shl(&mut self, f: u64) {
+        let rdi = GP::Rdi.a64().0; // x4
+        let rsi = GP::Rsi.a64().0; // x3
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // recv -> arg0
+            mov x1, x(rsi);       // arg  -> arg1
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+    }
+
     /// `def name; … end` — runtime::define_method(vm, globals, name, func_id).
     /// The Option<Value> result (None == error) is checked by the trailing
     /// HandleError. Bails when an xmm pool register is live (no save around the


### PR DESCRIPTION
Ports the rest of the simple `InlineGen` generators to aarch64 so these hot builtins emit inline machine code instead of falling back to a full method call (`blr`). Follow-up to #677.

## Generators ported

| Method(s) | aarch64 lowering |
|---|---|
| `Enumerator::ArithmeticSequence#begin/#end/#step` | field `ldr` |
| `ArithmeticSequence#exclude_end?` | `ldr` + `lsl #3` + `add FALSE_VALUE` |
| `BasicObject#!` | `orr 0x10` + `cmp` + `csel` |
| `BasicObject#object_id` / `Kernel#object_id` | `i64_to_value` C call (`a64_object_id`) |
| `Kernel#nil?` | `cmp NIL` + `csel` |
| `Kernel#block_given?` | `ldr [LFP-LFP_BLOCK]` + `cbz`/`cmp` branches |
| `Kernel#is_a?`, `#respond_to?` | pure abstract-interp folding — **cfg change only, no asm** |
| `Integer#to_f` | `asr` + `scvtf` (`a64_int_to_float`) |
| `Float#to_i` | `fcvtzs` + `adds`/overflow-deopt + tag (`a64_float_to_int`) |
| `Hash#[]` | `hashindex` C call (`a64_hash_index`) |
| `Array#clone`/`#dup`/`#<<` | C-call wrappers (`a64_array_clone`/`_dup`/`_shl`) |

For `Float#to_i`, `fcvtzs` saturates out-of-range doubles to i64::MIN/MAX, so doubling the result (`adds`) overflows for **both** the out-of-i64 and out-of-fixnum cases — a single signed-overflow branch covers both (matching x86 `cvttsd2si` + `addq;jo`).

## How

- Registrations switch `inline_gen!` → `inline_gen2!`; generator fns move `cfg(jit_x86)` → `cfg(jit)`.
- Each raw-asm block is cfg-switched (`monoasm!` x86 / `monoasm_arm64!` aarch64).
- Per-file `#[cfg(all(jit, not(jit_x86)))] use jitgen::{AbstractState, JitContext};`.
- New `compile_stub.rs` helpers: `a64_int_to_float`, `a64_float_to_int`, `a64_object_id`, `a64_hash_index`, `a64_array_clone`, `a64_array_dup`, `a64_array_shl`. C-call helpers preserve LR (x30) around `blr` and map GP regs to the aarch64 C ABI (`Rdi=x4→x0`, `Rsi=x3→x1`, `Rdx=x2`, `Rcx=x1→x3`, `EXEC=x19→x0`, `GLOBALS=x20→x1`); the FP pool is saved by the surrounding `xmm_save`/`xmm_restore` AsmInsts.

## Still deferred (noinline fallback on aarch64)

Allocation / index-lowering / dispatch paths — a larger follow-up: `Array#[]`/`#[]=`, `Class.new`/`allocate`, `Struct.new`, `Kernel#__send__`/`#send`, `Fiber.yield`, `Fiddle` read/write.

## Verification

- `JIT == VM(--no-jit) == CRuby` on a mixed workload exercising every ported method.
- `emit-asm` confirms inlining (`scvtf`/`fcvtzs`/`csel`/`blr`, no method-call dispatch).
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)