### PR TITLE
jit(aarch64): inline Array#[] / Array#[]= (integer index read/write)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -74,7 +74,7 @@ pub(super) fn init(globals: &mut Globals) {
         "[]",
         &["slice"],
         index,
-        inline_gen!(array_index),
+        inline_gen2!(array_index),
         1,
         2,
         false,
@@ -83,7 +83,7 @@ pub(super) fn init(globals: &mut Globals) {
         ARRAY_CLASS,
         "[]=",
         index_assign,
-        inline_gen!(array_index_assign),
+        inline_gen2!(array_index_assign),
         2,
         3,
         false,
@@ -1203,8 +1203,7 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     }
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_index(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -1301,8 +1300,7 @@ fn index_assign(
     }
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn array_index_assign(
     state: &mut AbstractState,
     ir: &mut AsmIr,

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3561,6 +3561,117 @@ impl Codegen {
         );
     }
 
+    ///
+    /// Array index read with a non-negative i64 index. aarch64 twin of x86
+    /// `array_index`.
+    ///
+    /// ### in
+    /// - Rdi (x4): base Array
+    /// - Rsi (x3): index, non-negative i64
+    ///
+    /// ### out
+    /// - Rax (x0): result Value (NIL when out of range)
+    ///
+    pub(crate) fn array_index(&mut self, out_range: &DestLabel) {
+        // Unlike x86, the cold (heap / out-of-range) blocks are laid out inline
+        // on the same page: aarch64 b/b.cond can't reach monoasm's second page
+        // (it is mapped far past the ±128 MB branch range).
+        let exit = self.jit.label();
+        let heap = self.jit.label();
+        let out_range = out_range.clone();
+        monoasm_arm64! { &mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x0, #(ARRAY_INLINE_CAPA as u32);
+            b.gt heap;
+            // inline: x3 (index) is a non-negative integer.
+            cmp x0, x3;                              // capa vs index
+            b.le out_range;                          // index >= capa -> out of range
+            add x9, x4, x3, lsl #3;
+            ldr x0, [x9, #(RVALUE_OFFSET_INLINE as u32)];
+            b exit;
+        }
+        self.jit.bind_label(heap);
+        monoasm_arm64! { &mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, x3;
+            b.le out_range;
+            ldr x4, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            ldr x0, [x4, x3, lsl #3];
+            b exit;
+        }
+        self.jit.bind_label(out_range);
+        monoasm_arm64! { &mut self.jit,
+            mov x0, #(NIL_VALUE as u32);
+        }
+        self.jit.bind_label(exit); // out_range falls through to exit
+    }
+
+    ///
+    /// Array index assign with a non-negative i64 index. aarch64 twin of x86
+    /// `array_index_assign`.
+    ///
+    /// ### in
+    /// - Rdi (x4): base Array
+    /// - Rsi (x3): index, non-negative i64
+    /// - Rdx (x2): source Value
+    ///
+    /// ### destroy
+    /// - caller-save registers except the FP pool
+    ///
+    pub(crate) fn array_index_assign(
+        &mut self,
+        using_xmm: UsingXmm,
+        generic: &DestLabel,
+        error: &DestLabel,
+    ) {
+        // Cold (heap / generic-C-call) blocks laid out inline; see array_index
+        // for why select_page can't be used on aarch64.
+        let exit = self.jit.label();
+        let heap = self.jit.label();
+        let generic = generic.clone();
+        monoasm_arm64! { &mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x0, #(ARRAY_INLINE_CAPA as u32);
+            b.gt heap;
+            // inline: x3 (index) is a non-negative integer.
+            cmp x0, x3;
+            b.le generic;                            // index >= capa -> generic
+            add x9, x4, x3, lsl #3;
+            str x2, [x9, #(RVALUE_OFFSET_INLINE as u32)];  // src (Rdx) -> slot
+            b exit;
+        }
+        self.jit.bind_label(heap);
+        monoasm_arm64! { &mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, x3;
+            b.le generic;
+            ldr x4, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            add x9, x4, x3, lsl #3;
+            str x2, [x9];
+            b exit;
+        }
+        self.jit.bind_label(generic);
+        self.emit_xmm_save(using_xmm, false);
+        // set_array_integer_index(base, index, vm, globals, src). Source regs at
+        // entry: base=x4, index=x3, src=x2. Reorder into the C ABI args
+        // (x0..x4) without clobbering a still-needed source.
+        let f = set_array_integer_index as *const () as u64;
+        monoasm_arm64! { &mut self.jit,
+            mov x0, x4;            // base -> arg0
+            mov x4, x2;            // src  -> arg4   (x2 free after this)
+            mov x1, x3;            // index -> arg1
+            mov x3, x20;           // globals -> arg3
+            mov x2, x19;           // vm -> arg2
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        }
+        self.emit_xmm_restore(using_xmm, false);
+        self.emit_handle_error(error);
+        self.jit.bind_label(exit); // generic C-call path falls through to exit
+    }
+
     /// Inlined `Integer#to_f`: untag the tagged fixnum in Rdi (x4), convert to
     /// double with `scvtf`, and store into `fret`. aarch64 twin of x86
     /// `integer_tof`'s `sarq` + `cvtsi2sdq` + `store_fpr_into_xmm`.
@@ -4274,4 +4385,20 @@ extern "C" fn extend_ivar(rvalue: &mut RValue, heap_len: usize) {
 /// `compile.rs` (a `jit_x86`-only module), so aarch64 carries its own copy.
 extern "C" fn unreachable() {
     unreachable!("reached unreachable code");
+}
+
+/// Generic `Array#[]=` fallback (out-of-fast-path index). Returns `None` and
+/// sets the error on failure (negative index past the start). The x86 twin
+/// lives in the `jit_x86`-only `asmir/compile/index.rs`.
+extern "C" fn set_array_integer_index(
+    base: Value,
+    index: i64,
+    vm: &mut Executor,
+    _globals: &mut Globals,
+    src: Value,
+) -> Option<Value> {
+    base.as_array()
+        .set_index(index, src)
+        .map_err(|err| vm.set_error(err))
+        .ok()
 }

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(all(jit, not(jit_x86)))]
+use monoasm_macro::monoasm_arm64;
 
 impl<'a> JitContext<'a> {
     pub(super) fn index(
@@ -104,6 +106,53 @@ impl AbstractState {
         self.def_rax2acc(ir, dst);
     }
 
+    /// aarch64 twin of `array_integer_index`. The hot-path asm lives in
+    /// `Codegen::array_index` (compile_stub.rs); here we set up the index
+    /// register (Rsi/x3) and the negative-index normalization.
+    #[cfg(all(jit, not(jit_x86)))]
+    pub(crate) fn array_integer_index(
+        &mut self,
+        ir: &mut AsmIr,
+        store: &Store,
+        dst: SlotId,
+        base: SlotId,
+        idx: SlotId,
+    ) {
+        self.load_array_ty(ir, store, base, GP::Rdi);
+        if let Some(idx) = self.is_u16(idx) {
+            ir.inline(move |r#gen, _, _, _| {
+                let out_range = r#gen.jit.label();
+                monoasm_arm64! { &mut r#gen.jit,
+                    mov x3, (idx as u64);   // Rsi <- index (already non-negative)
+                }
+                r#gen.array_index(&out_range);
+            });
+        } else {
+            self.load_fixnum(ir, idx, GP::Rsi);
+            ir.inline(move |r#gen, _, _, _| {
+                // Single-page layout (no select_page — see Codegen::array_index):
+                // the negative-index normalization is laid out inline; a
+                // non-negative index branches straight to `checked`.
+                let generic = r#gen.jit.label();
+                let checked = r#gen.jit.label();
+                monoasm_arm64! { &mut r#gen.jit,
+                    asr x3, x3, #1;         // untag index (Rsi)
+                    cmp x3, #0;
+                    b.pl checked;           // non-negative -> use as-is
+                }
+                r#gen.get_array_length();   // Rax <- len, Rdi (base) preserved
+                monoasm_arm64! { &mut r#gen.jit,
+                    adds x3, x3, x0;        // index += len, set flags
+                    b.pl checked;           // normalized non-negative -> recheck
+                    b generic;              // past the start -> out of range
+                }
+                r#gen.jit.bind_label(checked.clone());
+                r#gen.array_index(&generic);
+            });
+        }
+        self.def_rax2acc(ir, dst);
+    }
+
     ///
     /// Aray index assign operation.
     ///
@@ -161,6 +210,57 @@ impl AbstractState {
                     jmp  generic;
                 }
                 r#gen.jit.select_page(0);
+            });
+        }
+    }
+
+    /// aarch64 twin of `array_integer_index_assign`. The hot-path + generic
+    /// C-call asm lives in `Codegen::array_index_assign` (compile_stub.rs);
+    /// here we set up the index (Rsi/x3) + source (Rdx/x2) and normalize a
+    /// negative index.
+    #[cfg(all(jit, not(jit_x86)))]
+    pub(crate) fn array_integer_index_assign(
+        &mut self,
+        ir: &mut AsmIr,
+        store: &Store,
+        src: SlotId,
+        base: SlotId,
+        idx: SlotId,
+    ) {
+        self.load_array_ty(ir, store, base, GP::Rdi);
+        if let Some(idx) = self.is_u16(idx) {
+            self.load(ir, src, GP::Rdx);
+            let using_xmm = self.get_using_xmm();
+            let error = ir.new_error(self);
+            ir.inline(move |r#gen, _, labels, _| {
+                let generic = r#gen.jit.label();
+                monoasm_arm64! { &mut r#gen.jit,
+                    mov x3, (idx as u64);   // Rsi <- index (already non-negative)
+                }
+                r#gen.array_index_assign(using_xmm, &generic, &labels[error]);
+            });
+        } else {
+            self.load_fixnum(ir, idx, GP::Rsi);
+            self.load(ir, src, GP::Rdx);
+            let using_xmm = self.get_using_xmm();
+            let error = ir.new_error(self);
+            ir.inline(move |r#gen, _, labels, _| {
+                // Single-page layout (no select_page — see array_index_assign).
+                let generic = r#gen.jit.label();
+                let checked = r#gen.jit.label();
+                monoasm_arm64! { &mut r#gen.jit,
+                    asr x3, x3, #1;         // untag index (Rsi)
+                    cmp x3, #0;
+                    b.pl checked;           // non-negative -> use as-is
+                }
+                r#gen.get_array_length();   // Rax <- len, Rdi (base) preserved
+                monoasm_arm64! { &mut r#gen.jit,
+                    adds x3, x3, x0;        // index += len, set flags
+                    b.pl checked;           // normalized non-negative -> recheck
+                    b generic;              // past the start -> out of range
+                }
+                r#gen.jit.bind_label(checked.clone());
+                r#gen.array_index_assign(using_xmm, &generic, &labels[error]);
             });
         }
     }


### PR DESCRIPTION
Ports the integer-index array fast path to aarch64 so `a[i]` / `a[i] = v` emit inline bounds-checked loads/stores instead of a method-call fallback. Follow-up to #677 / #678 / #679.

## What

- New aarch64 emitters in `compile_stub.rs`: `Codegen::array_index`, `array_index_assign`, plus the `set_array_integer_index` generic fallback.
- aarch64 twins of the `AbstractState` index builders in `jitgen/compile/index.rs` (set up index reg + negative-index normalization).
- Registrations `inline_gen!` → `inline_gen2!`; builtins `cfg(jit_x86)` → `cfg(jit)`.

Index handling mirrors x86: inline-storage vs heap-buffer dispatch on `capa`, an upper-bound check (out of range → `nil` for read, generic C-call for write), and negative-index normalization (`index += len`, re-check). The write's generic path calls `set_array_integer_index(base, index, vm, globals, src)` with the GP regs reordered into the aarch64 C ABI, LR preserved across `blr`, FP pool saved by `xmm_save`/`xmm_restore`, and the `Option` result checked by `emit_handle_error`.

## Key aarch64 difference: no `select_page`

Unlike x86, the cold (heap / out-of-range / generic) blocks are laid out **inline on the same page** rather than via `select_page`. monoasm maps its second code page far past aarch64's ±128 MB branch range, so a `b`/`b.cond` from page 0 to page 1 raised *"displacement out of range"*. The negative-index normalization likewise falls through inline, with a non-negative index branching straight to the bounds check.

## Verification

- `JIT == VM(--no-jit) == CRuby` on read/write across inline and heap arrays, every negative/out-of-range boundary, and both `IndexError` cases (`a[-3] = x`, `a[-100000] = x`).
- Random-index hot-loop stress test (read + write + out-of-range), JIT == VM == CRuby.
- `emit-asm` shows inline `[x4, x3, lsl #3]` / `[x9, #off]` accesses — no method dispatch.
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)