### PR TITLE
jit(aarch64): inline Fiber.yield (and note Class#new blocker)

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -476,6 +476,14 @@ pub(super) fn gen_class_new_inline(
     true
 }
 
+// NOTE(aarch64): `Class#new` is NOT inlined on aarch64. It needs to invoke the
+// resolved `initialize` via `method_invoker2`, but that invoker is still a trap
+// stub (`a64_stub_fn(0x2)`) on aarch64 — calling it aborts with "unimplemented
+// opcode 0x51410002". Porting the real method invoker is a prerequisite; until
+// then `gen_class_new_object` stays on the `inline_gen!` noinline fallback.
+// (`Class#allocate` *is* inlined — see `gen_class_allocate_inline` — so object
+// construction through startup.rb's Ruby `Class#new` still inlines the alloc.)
+
 extern "C" fn check_initializer(globals: &mut Globals, receiver: Value) -> Option<FuncId> {
     globals.check_method(receiver, IdentId::INITIALIZE)
 }

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(all(jit, not(jit_x86)))]
+use jitgen::{AbstractState, JitContext};
 
 //
 // Fiber class
@@ -18,7 +20,7 @@ pub(super) fn init(globals: &mut Globals) {
         FIBER_CLASS,
         "yield",
         fiber_yield,
-        inline_gen!(fiber_yield_inline),
+        inline_gen2!(fiber_yield_inline),
     );
     globals.define_builtin_func_rest(FIBER_CLASS, "resume", resume);
 }
@@ -70,8 +72,7 @@ fn fiber_yield(
     vm.yield_fiber(val)
 }
 
-#[cfg(jit_x86)]
-
+#[cfg(jit)]
 fn fiber_yield_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -88,14 +89,25 @@ fn fiber_yield_inline(
     let CallSiteInfo {
         args, pos_num, dst, ..
     } = *callsite;
+    // aarch64 reaches the args via `sub x0, lfp, #conv(args)` (bounded
+    // immediate); bail to the slow path on an out-of-range frame.
+    #[cfg(not(jit_x86))]
+    if pos_num > 1 && jitgen::conv(args) as u32 > 4095 {
+        return false;
+    }
     let using_xmm = state.get_using_xmm();
     let error = ir.new_error(state);
     ir.xmm_save(using_xmm);
     if pos_num == 0 {
         ir.inline(move |r#gen, _, _, _| {
             // TODO: we must check if the parent fiber exits.
+            #[cfg(jit_x86)]
             monoasm! { &mut r#gen.jit,
                 movq rsi, (Value::nil().id());
+            }
+            #[cfg(not(jit_x86))]
+            monoasm_arm64! { &mut r#gen.jit,
+                mov x3, (Value::nil().id());   // GP::Rsi == x3
             }
         });
     } else if pos_num == 1 {
@@ -104,6 +116,7 @@ fn fiber_yield_inline(
         state.write_back_recv_and_callargs(ir, callsite);
         ir.inline(move |r#gen, _, _, _| {
             // TODO: we must check if the parent fiber exits.
+            #[cfg(jit_x86)]
             monoasm! { &mut r#gen.jit,
                 lea rdi, [r14 - (jitgen::conv(args))];
                 movq rsi, (pos_num);
@@ -111,14 +124,38 @@ fn fiber_yield_inline(
                 call rax;
                 movq rsi, rax;
             }
+            // create_array(&args, len) -> Array; result -> Rsi (x3).
+            #[cfg(not(jit_x86))]
+            monoasm_arm64! { &mut r#gen.jit,
+                sub x0, x22, #(jitgen::conv(args) as u32);   // &args (lfp - conv)
+                mov x1, (pos_num);
+                mov x9, (crate::runtime::create_array as *const () as u64);
+                str x30, [sp, #-16]!;
+                blr x9;
+                ldr x30, [sp], #16;
+                mov x3, x0;
+            }
         });
     }
     ir.inline(move |r#gen, _, _, _| {
         let fiber_yield = r#gen.yield_fiber;
+        #[cfg(jit_x86)]
         monoasm! { &mut r#gen.jit,
             movq rdi, rbx;
             movq rax, (fiber_yield);
             call rax;
+        }
+        // yield_fiber(vm, value). Save the method's own LR: the invoker's
+        // a64_push_callee_save stashes the *post-blr* x30, not ours, so we
+        // restore the real return address after the fiber resumes here.
+        #[cfg(not(jit_x86))]
+        monoasm_arm64! { &mut r#gen.jit,
+            mov x0, x19;          // vm (EXEC)
+            mov x1, x3;           // value (Rsi)
+            mov x9, (fiber_yield as *const () as u64);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
         }
     });
     ir.xmm_restore(using_xmm);


### PR DESCRIPTION
Ports `fiber_yield_inline` to aarch64 so `Fiber.yield` emits a direct call to the pre-built `yield_fiber` invoker instead of a method-call fallback. Follow-up to #677 / #678 / #679 / #680.

`yield_fiber` is a real codeptr on aarch64 (unlike `method_invoker2`, which is still a trap stub), so the yield path is inlinable.

## What

All three argument shapes mirror x86 with arch-switched asm:
- **0 args** → `mov x3, nil`
- **1 arg** → load into Rsi (x3)
- **>1 args** → `create_array(&spilled_args, len)` → Rsi

Then `yield_fiber(vm, value)` via `blr`.

**LR handling:** the method's own x30 is saved around `blr yield_fiber`. The invoker's `a64_push_callee_save` stashes the *post-blr* x30, not the JIT method's return address, so we restore the real LR after the fiber resumes back to this site. The >1-arg path bails when `conv(args)` exceeds the `sub` immediate range.

## Also: why `Class#new` isn't inlined on aarch64 (documented in code)

While here I attempted `gen_class_new` and found a hard blocker, now noted at `gen_class_new_inline`: inlining `Class#new` requires invoking the resolved `initialize` through `method_invoker2`, which is **still a trap stub** on aarch64 (`a64_stub_fn(0x2)` — a call aborts with *"unimplemented opcode 0x51410002"*). Porting the real method invoker is the prerequisite. `Class#allocate` is already inlined (#679), so construction through startup.rb's Ruby `Class#new` still inlines the allocation step.

## Verification

- `JIT == VM(--no-jit) == CRuby` on the 0/1/3-arg yield fiber test and the `fib` generator.
- All 10 fiber unit tests pass; `emit-asm` shows the inline `yield_fiber` call.
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)