### PR TITLE
jit(aarch64): port method_invoker2; inline Class#new (and Struct.new)

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -11,7 +11,7 @@ use jitgen::{AbstractState, JitContext};
 /// function pointer into the generated code, and calls it directly (ABI:
 /// `extern "C" fn(ClassId, &mut Globals) -> Value`), matching the slow-path
 /// `call_alloc_func` helper.
-#[cfg(jit_x86)]
+#[cfg(jit)]
 pub fn gen_class_new_object() -> Box<InlineGen> {
     Box::new(gen_class_new_inline)
 }
@@ -121,7 +121,7 @@ pub(super) fn init(globals: &mut Globals) {
         "new",
         &[],
         new,
-        inline_gen!(gen_class_new_object()),
+        inline_gen2!(gen_class_new_object()),
         0,
         0,
         true,
@@ -476,13 +476,62 @@ pub(super) fn gen_class_new_inline(
     true
 }
 
-// NOTE(aarch64): `Class#new` is NOT inlined on aarch64. It needs to invoke the
-// resolved `initialize` via `method_invoker2`, but that invoker is still a trap
-// stub (`a64_stub_fn(0x2)`) on aarch64 — calling it aborts with "unimplemented
-// opcode 0x51410002". Porting the real method invoker is a prerequisite; until
-// then `gen_class_new_object` stays on the `inline_gen!` noinline fallback.
-// (`Class#allocate` *is* inlined — see `gen_class_allocate_inline` — so object
-// construction through startup.rb's Ruby `Class#new` still inlines the alloc.)
+/// aarch64 twin of `gen_class_new_inline`. The hot-path asm (allocate + resolve
+/// + invoke `initialize` via `method_invoker2`) lives in `Codegen::a64_class_new`;
+/// here we resolve the allocator at JIT-compile time and write back the
+/// receiver/args so the invoker can read them from the frame.
+#[cfg(all(jit, not(jit_x86)))]
+pub(super) fn gen_class_new_inline(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    self_class: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    let mut self_module = store[self_class].get_module();
+    if let Some(origin) = self_module.is_singleton() {
+        self_module = origin.as_class();
+    }
+    let class_id = self_module.id();
+    let alloc_func = match store[class_id].alloc_func() {
+        Some(f) => f,
+        None => return false,
+    };
+    let CallSiteInfo {
+        recv,
+        args,
+        pos_num,
+        dst,
+        ..
+    } = *callsite;
+    // `a64_class_new` reaches the args via `sub x4, lfp, #conv(args)`, whose
+    // immediate is bounded; bail to the slow path on an out-of-range frame.
+    let args_off = crate::executor::jitgen::conv(args);
+    if args_off > 4095 {
+        return false;
+    }
+    state.writeback_acc(ir);
+    state.load(ir, recv, GP::Rdi);
+    state.write_back_recv_and_callargs(ir, callsite);
+    let using_xmm = state.get_using_xmm();
+    let error = ir.new_error(state);
+    ir.xmm_save(using_xmm);
+    let alloc_func = alloc_func as *const () as u64;
+    let ci = check_initializer as *const () as u64;
+    ir.inline(move |r#gen, _, _, _| {
+        r#gen.a64_class_new(class_id.u32(), alloc_func, args_off as u32, pos_num, ci);
+    });
+    ir.xmm_restore(using_xmm);
+    ir.handle_error(error);
+    state.def_rax2acc(ir, dst);
+    true
+}
 
 extern "C" fn check_initializer(globals: &mut Globals, receiver: Value) -> Option<FuncId> {
     globals.check_method(receiver, IdentId::INITIALIZE)

--- a/monoruby/src/codegen/arch/aarch64/invoker.rs
+++ b/monoruby/src/codegen/arch/aarch64/invoker.rs
@@ -72,7 +72,11 @@ impl JitModule {
     /// argument setup (simple copy or runtime arg massager), call into the
     /// callee, then the epilogue. Assumes fdata in X9, meta in X14, x4 = args
     /// ptr, x5 = len, x7 = kw (Option<Hashmap>).
-    pub(in crate::codegen) fn a64_invoker_args_and_call(&mut self) {
+    /// `upward == true`: args are an ascending `*const Value` (method/block
+    /// invoker). `upward == false`: args are a descending `Arg` in a caller
+    /// frame (method_invoker2). Only the simple-copy direction and the generic
+    /// runtime handler (`handle_invoker_arguments` vs `…2`) differ.
+    pub(in crate::codegen) fn a64_invoker_args_and_call(&mut self, upward: bool) {
         let fdata = X9;
         let generic = self.jit.label();
         let simple_done = self.jit.label();
@@ -90,25 +94,47 @@ impl JitModule {
         self.jit.bcond_label(Cond::Ne, &generic);
         monoasm_arm64!(&mut self.jit,
             cbnz x7, generic;  // kw present
-        // simple copy (upward): args[0..len] -> callee slots 1..=len
             cbz x5, simple_done;
-            mov x10, x5;  // down counter = len
-            neg x11, x5;  // up counter = -len
-            sub x12, x4, #(8);  // args - 8
-            argloop:
-            add x13, x12, x10, lsl #(3);  // &args[down-1]
-            ldr x14, [x13];
-            sub x15, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
-            add x15, x15, x11, lsl #(3);
-            str x14, [x15];
-            sub x10, x10, #(1);
-            add x11, x11, #(1);
-            cbnz x11, argloop;
-            simple_done:
-            b aftargs;
-        // generic: handle_invoker_arguments(exec, globals, callee_lfp,
+        );
+        if upward {
+            // ascending args: args[len-1..0] -> callee slots, src counts down.
+            monoasm_arm64!(&mut self.jit,
+                mov x10, x5;  // down counter = len
+                neg x11, x5;  // up counter = -len
+                sub x12, x4, #(8);  // args - 8
+                argloop:
+                add x13, x12, x10, lsl #(3);  // &args[down-1]
+                ldr x14, [x13];
+                sub x15, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+                add x15, x15, x11, lsl #(3);
+                str x14, [x15];
+                sub x10, x10, #(1);
+                add x11, x11, #(1);
+                cbnz x11, argloop;
+                simple_done:
+                b aftargs;
+            );
+        } else {
+            // descending args (Arg): args[0] at x4, args[i] at x4 - i*8.
+            // counter x11 runs -len..0; src = [x4 + x11*8 + 8].
+            monoasm_arm64!(&mut self.jit,
+                neg x11, x5;  // counter = -len
+                argloop:
+                add x13, x4, x11, lsl #(3);
+                ldr x14, [x13, #(8)];         // [x4 + x11*8 + 8]
+                sub x15, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+                add x15, x15, x11, lsl #(3);
+                str x14, [x15];
+                add x11, x11, #(1);
+                cbnz x11, argloop;
+                simple_done:
+                b aftargs;
+            );
+        }
+        // generic: handle_invoker_arguments[2](exec, globals, callee_lfp,
         // arg_num, args, kw). Reserve scratch below the callee frame and
         // preserve SP (X25) + funcdata (X26, caller-saved) across the call.
+        monoasm_arm64!(&mut self.jit,
             generic:
             mov x25, sp;
             mov x26, x(fdata.0);
@@ -122,8 +148,15 @@ impl JitModule {
             mov x5, x7;  // kw
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
-        // x4 = args (unchanged); upward path => handle_invoker_arguments
-            mov x9, (runtime::handle_invoker_arguments as *const () as u64);
+        // x4 = args (unchanged)
+        );
+        let handler = if upward {
+            runtime::handle_invoker_arguments as *const () as u64
+        } else {
+            runtime::handle_invoker_arguments2 as *const () as u64
+        };
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (handler);
             blr x9;
             mov x9, x26;  // restore fdata
             mov sp, x25;  // restore SP
@@ -217,14 +250,38 @@ impl JitModule {
             str x14, [x(fb.0), #(32)];  // LFP_META  = funcdata.meta
             str x13, [x(fb.0), #(40)];  // LFP_OUTER = 0
         );
-        self.a64_invoker_args_and_call();
+        self.a64_invoker_args_and_call(true);
         self.a64_invoker_epilogue();
         // SAFETY: codeptr points at an extern "C" fn with the MethodInvoker ABI.
         unsafe { std::mem::transmute_copy::<*mut u8, MethodInvoker>(&codeptr.as_ptr()) }
     }
 
+    /// Like `method_invoker`, but the args come as a descending `Arg` in a
+    /// caller frame (not an ascending `*const Value`) and there is no block or
+    /// keyword argument. ABI: x0 exec, x1 globals, x2 funcid, x3 self, x4 args
+    /// (Arg), x5 len. Used by the inlined `Class#new` to run `initialize`.
     pub(in crate::codegen) fn method_invoker2(&mut self) -> MethodInvoker2 {
-        self.a64_stub_fn(0x2)
+        let codeptr = self.jit.get_current_address();
+        let fdata = X9;
+        self.a64_invoker_prologue();
+        self.a64_get_func_data_x2();
+        let fb = X12;
+        monoasm_arm64!(&mut self.jit,
+            sub x(fb.0), sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+            mov x13, (0);
+            mov x7, (0);                // no keyword args
+            str x3, [x(fb.0)];          // LFP_SELF  = self
+            str x13, [x(fb.0), #(8)];   // LFP_BLOCK = 0
+            str x13, [x(fb.0), #(16)];  // LFP_CME   = 0
+            str x13, [x(fb.0), #(24)];  // LFP_SVAR  = 0
+            ldr x14, [x(fdata.0), #(FUNCDATA_META as u32)];
+            str x14, [x(fb.0), #(32)];  // LFP_META  = funcdata.meta
+            str x13, [x(fb.0), #(40)];  // LFP_OUTER = 0
+        );
+        self.a64_invoker_args_and_call(false);
+        self.a64_invoker_epilogue();
+        // SAFETY: codeptr points at an extern "C" fn with the MethodInvoker2 ABI.
+        unsafe { std::mem::transmute_copy::<*mut u8, MethodInvoker2>(&codeptr.as_ptr()) }
     }
 
     /// Block invoker. AAPCS64 in: x0 exec, x1 globals, x2 &ProcData,
@@ -299,7 +356,7 @@ impl JitModule {
         monoasm_arm64!(&mut self.jit,
             mov x7, x6;  // shared arg setup expects kw in x7
         );
-        self.a64_invoker_args_and_call();
+        self.a64_invoker_args_and_call(true);
         self.a64_invoker_epilogue();
         // SAFETY: codeptr points at an extern "C" fn with the BlockInvoker ABI.
         unsafe { std::mem::transmute_copy::<*mut u8, BlockInvoker>(&codeptr.as_ptr()) }
@@ -333,7 +390,7 @@ impl JitModule {
         monoasm_arm64!(&mut self.jit,
             mov x7, (0);  // fibers carry no keyword args
         );
-        self.a64_invoker_args_and_call();
+        self.a64_invoker_args_and_call(true);
         // body completed: mark this fiber terminated, switch back to parent.
         monoasm_arm64!(&mut self.jit,
             mov x10, (u64::MAX);  // -1 = terminated

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3752,6 +3752,69 @@ impl Codegen {
         );
     }
 
+    /// Inlined `Class#new`: allocate via the resolved `alloc_func`, then run
+    /// `initialize` on the new instance through `method_invoker2` (now a real
+    /// invoker on aarch64). aarch64 twin of x86 `gen_class_new_inline`, minus
+    /// the self-modifying inline cache: `data_i32` slots are bound only at
+    /// `finalize`, so an emit-time `get_label_address` would bake a bogus
+    /// address. Instead `initialize` is re-resolved with `check_initializer` on
+    /// every call (a cheap method-table lookup) — still cheaper than the
+    /// un-inlined `Class#new` dispatch.
+    ///
+    /// The new instance is held in R15 (x23, ACC — overwritten by the trailing
+    /// def_rax2acc anyway); the result Value lands in Rax (x0), 0 on an
+    /// `initialize` error (checked by the trailing HandleError). FP pool saved
+    /// by the surrounding xmm_save/restore. The args slot offset is bounded by
+    /// the caller (`gen_class_new_inline` bails past the `sub` immediate range).
+    pub(crate) fn a64_class_new(
+        &mut self,
+        class_id: u32,
+        alloc_func: u64,
+        args_off: u32,
+        pos_num: usize,
+        check_initializer: u64,
+    ) {
+        let r15 = GP::R15.a64().0; // x23 (instance holder)
+        let m2 = self.method_invoker2 as *const () as u64;
+        let use_instance = self.jit.label();
+        let done = self.jit.label();
+        monoasm_arm64! { &mut self.jit,
+            // o = alloc_func(class_id, globals)
+            mov x0, (class_id as u64);
+            mov x1, x20;
+            mov x9, (alloc_func);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+            mov x(r15), x0;               // R15 = new instance
+            // fid = check_initializer(globals, instance)  (0 == no initialize)
+            mov x0, x20;
+            mov x1, x(r15);
+            mov x9, (check_initializer);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+            cbz x0, use_instance;         // no initialize -> return instance
+            // method_invoker2(vm, globals, fid, recv, args, pos_num)
+            mov x2, x0;                   // fid
+            mov x0, x19;                  // vm
+            mov x1, x20;                  // globals
+            mov x3, x(r15);               // receiver
+            sub x4, x22, #(args_off);     // &args (lfp - conv(args))
+            mov x5, (pos_num as u64);
+            mov x9, (m2);
+            str x30, [sp, #-16]!;
+            blr x9;                       // x0 = Option<Value> (0 == error)
+            ldr x30, [sp], #16;
+            cbz x0, done;                 // initialize raised -> x0 = 0
+        }
+        self.jit.bind_label(use_instance);
+        monoasm_arm64! { &mut self.jit,
+            mov x0, x(r15);               // result = instance
+        }
+        self.jit.bind_label(done);
+    }
+
     /// Inlined `Array#clone`: `array_clone_extern(recv)`. recv (Rdi/x4) -> arg0.
     /// Result Value in Rax (x0). FP pool saved by the surrounding xmm_save.
     pub(crate) fn a64_array_clone(&mut self, f: u64) {


### PR DESCRIPTION
Implements the real `method_invoker2` on aarch64 (it was an `a64_stub_fn` trap that aborted with *"unimplemented opcode 0x51410002"*), then uses it to inline `Class#new`. Follow-up to #677–#681; removes the blocker noted in #681.

## method_invoker2

Mirrors the existing `method_invoker` but takes args as a **descending `Arg`** in a caller frame (not an ascending `*const Value`) and has no block/keyword arg. `a64_invoker_args_and_call` grows an `upward: bool`:
- simple-copy loop runs in the matching direction;
- generic fallback dispatches to `handle_invoker_arguments` (upward) or `handle_invoker_arguments2` (downward).

The three existing callers (method/block/fiber invokers) pass `true`; `method_invoker2` passes `false`, zeroes the block/kw slots, sets self from x3. The `method_invoker2` Codegen field is already populated at init (codegen.rs), so it now builds the real invoker instead of the trap.

## Class#new (`a64_class_new`)

Allocates via the resolved `alloc_func`, re-resolves `initialize` with `check_initializer` each call, and runs it through `method_invoker2`. **No self-modifying inline cache** (unlike x86): `data_i32` slots bind only at `finalize`, so an emit-time `get_label_address` would bake a bogus address — re-resolving each call is still cheaper than the un-inlined dispatch. The new instance is held in R15 across the calls (LR saved around each `blr`); the result is the instance, or `0 → HandleError` on an `initialize` raise.

`gen_class_new_object` switches `inline_gen!` → `inline_gen2!` with an aarch64 `gen_class_new_inline`. This unblocks **`Struct.new`** too (shared generator).

## Verification

- `JIT == VM(--no-jit) == CRuby` on `Class#new` with 0/1/2/5 args, an optional-arg `initialize` (the non-simple → generic invoker path), an `initialize` that raises, and `Struct.new` in a hot loop.
- class + struct unit tests (191) pass; `emit-asm` shows the inline alloc + `method_invoker2` `blr`.
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)