### PR TITLE
jit(aarch64): VM-tier send inline cache, loop_start GC poll, polymorphic flag

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -47,9 +47,9 @@ impl Codegen {
         self.dispatch[163] = div_rr;
 
         // loop_end (15): just advance to the next instruction.
-        // loop_start (14): drives the loop (partial) JIT under `jit`; without
-        // it (no-jit build) it also just advances. TODO(aarch64): the GC poll
-        // in loop_start (vm_execute_gc) — currently skipped (works with --no-gc).
+        // loop_start (14): drives the loop (partial) JIT under `jit` and polls
+        // GC/signals on the back-edge (see `a64_op_loop_start`); without it
+        // (no-jit build) it just advances like loop_end.
         self.dispatch[15] = self.a64_op_loop();
         #[cfg(jit)]
         {
@@ -1327,13 +1327,15 @@ impl Codegen {
         p
     }
 
-    /// op 30-33 `send`/`send_simple`: method call. The VM always does the
-    /// `find_method` lookup (no VM-side fast-path read of the cache), but it
-    /// now writes the inline cache (FuncId/class/version via
-    /// [`Self::a64_save_method_cache`]) so the JIT can specialize the site.
-    /// Handles the simple case (no kw/block/splat). Bytecode (32 bytes): `+0`
-    /// callid, `+4` ret slot, `+8` pos_num, `+10` arg slot, `+12` recv slot;
-    /// inline cache `+16` FuncId, `+24` class, `+28` version.
+    /// op 30-33 `send`/`send_simple`: method call. Reads the monomorphic inline
+    /// cache on the VM fast path (mirrors x86 `vm_send`): if the receiver class
+    /// and `class_version` match the cached pair, the cached FuncId is used
+    /// directly; otherwise the slow path calls `find_method` and refills the
+    /// cache (FuncId/class/version via [`Self::a64_save_method_cache`]), which
+    /// also lets the JIT specialize the site. A cached FuncId of 0 means
+    /// method_missing. Handles the simple case (no kw/block/splat). Bytecode
+    /// (32 bytes): `+0` callid, `+4` ret slot, `+8` pos_num, `+10` arg slot,
+    /// `+12` recv slot; inline cache `+16` FuncId, `+24` class, `+28` version.
     pub(in crate::codegen) fn a64_op_send(&mut self, is_simple: bool) -> CodePtr {
         let p = self.jit.get_current_address();
         let mm = self.jit.label();
@@ -1343,7 +1345,16 @@ impl Codegen {
         let docall = self.jit.label();
         let skip = self.jit.label();
         let after_call = self.jit.label();
+        let exec = self.jit.label();
+        let slow = self.jit.label();
         let raise = self.entry_raise.clone();
+        let get_class = self.get_class.clone();
+        // Absolute address of the global `class_version` (aarch64 has no
+        // RIP-relative addressing, so we bake the data label's address in).
+        let cv_addr = self
+            .jit
+            .get_label_address(&self.class_version_label())
+            .as_ptr() as u64;
         // Raise SystemStackError before pushing the new frame (so the caller's
         // LFP is still intact when entry_raise inspects it for a rescue).
         self.a64_check_stack();
@@ -1362,19 +1373,31 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
             str x4, [x11];
-        // find_method(vm, globals, callid, recv) -> funcid
-            mov x0, x(EXEC.0);
-            mov x1, x(GLOBALS.0);
-            ldr w2, [x(PC.0)];  // callid
-            mov x3, x4;  // recv
-            mov x9, (runtime::find_method as *const () as u64);
-            blr x9;
-            cbz x0, mm;
+        // Monomorphic inline-cache fast path (mirrors x86 `vm_send`): compute
+        // the receiver class and compare it against the cached (class,
+        // class_version); on a hit, use the cached FuncId directly instead of
+        // calling find_method. Inline-cache layout is PC-relative and absolute
+        // (aarch64 does not pre-advance PC): +16 FuncId, +24 class, +28 version.
+        // get_class: x0 = recv in, w0 = class out (clobbers x1/x2/x9/lr; x4 is
+        // preserved but recv is reloaded from its slot where needed).
+            mov x0, x4;
+            bl get_class;
+            ldr w11, [x(PC.0), #(24)];  // CACHED_CLASS
+            cmp w0, w11;
         );
-        // Populate the inline cache (X0 = FuncId) so the JIT can type this
-        // call site. X0 is preserved across the call.
-        self.a64_save_method_cache();
+        self.jit.bcond_label(Cond::Ne, &slow); // class mismatch -> slow path
         monoasm_arm64!(&mut self.jit,
+            mov x11, (cv_addr);
+            ldr w11, [x11];             // current class_version
+            ldr w12, [x(PC.0), #(28)];  // CACHED_VERSION
+            cmp w11, w12;
+        );
+        self.jit.bcond_label(Cond::Ne, &slow); // version mismatch -> slow path
+        monoasm_arm64!(&mut self.jit,
+        // cache hit: load the cached FuncId. 0 means method_missing was cached.
+            exec:
+            ldr w0, [x(PC.0), #(16)];   // CACHED_FUNCID
+            cbz x0, mm;
         // get_func_data: X15 = funcinfo_base + funcid*64 + FUNCINFO_DATA
             lsl x10, x0, #(6);
             mov x11, (GLOBALS_FUNCINFO as u64);
@@ -1521,6 +1544,28 @@ impl Codegen {
             mov x9, (crate::codegen::runtime::invoke_method_missing as *const () as u64);
             blr x9;
             b after_call;
+        );
+        // --- slow path: inline-cache miss. Look up the method, populate the
+        // inline cache (FuncId/class/version via a64_save_method_cache) so the
+        // JIT can type the site, then rejoin at `exec`. A method_missing result
+        // (FuncId 0) is cached as well, so repeated misses hit the fast path and
+        // fall through to `mm` without re-running find_method.
+        monoasm_arm64!(&mut self.jit,
+            slow:
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            ldr w2, [x(PC.0)];  // callid
+        // reload recv from the callee self slot (get_class/find_method clobber
+        // the caller-saved receiver register; recv was stored there above).
+            sub x3, sp, #((RSP_LOCAL_FRAME + LFP_SELF) as u32);
+            ldr x3, [x3];
+            mov x9, (runtime::find_method as *const () as u64);
+            blr x9;  // x0 = Option<FuncId> (0 = method_missing)
+        );
+        // Populate the inline cache (X0 = FuncId, preserved across the call).
+        self.a64_save_method_cache();
+        monoasm_arm64!(&mut self.jit,
+            b exec;
         );
         p
     }
@@ -1720,6 +1765,13 @@ impl Codegen {
         let count = self.jit.label();
         let enter = self.jit.label();
         let f = crate::codegen::compiler::jit_compile_loop as *const () as u64;
+        // GC + signal poll on the loop back-edge (x86 `vm_loop_start` calls
+        // `vm_execute_gc` first). A tight loop that never calls a method would
+        // otherwise never reach a safepoint, so a pending Signal.trap callback
+        // (or the GC the signal handler requested) could not run. The non-opt
+        // loop_start (`a64_op_loop`, also used for loop_end and `not(jit)`)
+        // omits this, mirroring x86 `vm_loop_start_no_opt`.
+        self.a64_vm_execute_gc();
         monoasm_arm64!(&mut self.jit,
             // Skip the JIT for a captured frame: the meta `kind` byte at
             // [LFP - (LFP_META - META_KIND)] has bit7 = on_heap, bit3 = invalidated.

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1346,7 +1346,8 @@ impl Codegen {
         let skip = self.jit.label();
         let after_call = self.jit.label();
         let exec = self.jit.label();
-        let slow = self.jit.label();
+        let slow_class = self.jit.label();
+        let slow_ver = self.jit.label();
         let raise = self.entry_raise.clone();
         let get_class = self.get_class.clone();
         // Absolute address of the global `class_version` (aarch64 has no
@@ -1385,14 +1386,14 @@ impl Codegen {
             ldr w11, [x(PC.0), #(24)];  // CACHED_CLASS
             cmp w0, w11;
         );
-        self.jit.bcond_label(Cond::Ne, &slow); // class mismatch -> slow path
+        self.jit.bcond_label(Cond::Ne, &slow_class); // class mismatch (maybe polymorphic)
         monoasm_arm64!(&mut self.jit,
             mov x11, (cv_addr);
             ldr w11, [x11];             // current class_version
             ldr w12, [x(PC.0), #(28)];  // CACHED_VERSION
             cmp w11, w12;
         );
-        self.jit.bcond_label(Cond::Ne, &slow); // version mismatch -> slow path
+        self.jit.bcond_label(Cond::Ne, &slow_ver); // version mismatch -> plain refill
         monoasm_arm64!(&mut self.jit,
         // cache hit: load the cached FuncId. 0 means method_missing was cached.
             exec:
@@ -1550,8 +1551,22 @@ impl Codegen {
         // JIT can type the site, then rejoin at `exec`. A method_missing result
         // (FuncId 0) is cached as well, so repeated misses hit the fast path and
         // fall through to `mm` without re-running find_method.
+        //
+        // `slow_class` is the class-mismatch entry (mirrors x86 `slow_path1`):
+        // if a FuncId was already cached, the call site has now seen >=2
+        // receiver classes, so mark it polymorphic by writing 1 to the
+        // `opcode_sub` byte (offset +7; PC points at the op start on aarch64).
+        // The JIT reads this back via `BytecodePtr::opcode_sub()` and emits a
+        // non-deoptimizing dispatch instead of a monomorphic class guard. The
+        // version-mismatch entry (`slow_ver`, x86 `slow_path2`) skips this:
+        // the class still matched, so a stale class_version is not polymorphism.
         monoasm_arm64!(&mut self.jit,
-            slow:
+            slow_class:
+            ldr w11, [x(PC.0), #(16)];  // CACHED_FUNCID
+            cbz w11, slow_ver;          // nothing cached yet -> first resolution
+            mov x11, (1);
+            strb w11, [x(PC.0), #(7)];  // opcode_sub = 1 (polymorphic)
+            slow_ver:
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             ldr w2, [x(PC.0)];  // callid
@@ -1901,7 +1916,7 @@ impl Codegen {
         // Fill the BinOp inline cache on the generic (non-fixnum) path too, so
         // the JIT can type non-integer comparisons (Float/String/...) instead
         // of bailing NotCached and recompiling forever. Reads X13/X14 (they
-        // survive get_class), clobbers x0.
+        // survive get_class), clobbers x0/x1/x2 and x10/x11/x12.
         self.a64_save_binary_class();
         monoasm_arm64!(&mut self.jit,
         // cmp_*_values(vm, globals, lhs=X13, rhs=X14) -> Option<Value>
@@ -1948,9 +1963,11 @@ impl Codegen {
 
     /// Record the runtime operand classes into the BinOp inline cache so the
     /// JIT can type the site (e.g. classify a Float `+`): `[PC+8]` = classid1,
-    /// `[PC+12]` = classid2. Mirrors x86 `vm_save_binary_class` (sans the
-    /// polymorphic-flag bookkeeping for now). Operands are the Values in X13
-    /// (lhs) / X14 (rhs); `get_class` reads X0 only, so X13/X14 survive.
+    /// `[PC+12]` = classid2. Mirrors x86 `vm_save_binary_class`, including the
+    /// polymorphic-flag bookkeeping (sets `opcode_sub` = 1 when an operand
+    /// class changes after the cache is populated). Operands are the Values in
+    /// X13 (lhs) / X14 (rhs); `get_class` reads X0 only, so X13/X14 survive.
+    /// Clobbers x0/x1/x2 and x10/x11/x12 and the link register.
     /// Record the unary operand's class into the UnOp inline cache (classid1
     /// `[PC+8]`) so the JIT can type the site. Mirrors x86 `vm_save_lhs_class`.
     /// Operand is the Value in x2. NB: `get_class` clobbers x1/x2 for
@@ -1967,13 +1984,42 @@ impl Codegen {
 
     pub(in crate::codegen) fn a64_save_binary_class(&mut self) {
         let get_class = self.get_class.clone();
+        let set_poly = self.jit.label();
+        let skip = self.jit.label();
         monoasm_arm64!(&mut self.jit,
+            // Read the previously-cached operand classes before overwriting
+            // them (x10 = old classid1, x12 = old classid2; 0 = cache empty),
+            // for polymorphic detection. get_class only touches x0/x1/x2/x9/lr,
+            // so x10/x12/x13/x14 survive across the calls below.
+            ldr w10, [x(PC.0), #(8)];   // old classid1
+            ldr w12, [x(PC.0), #(12)];  // old classid2
             mov x0, x13;
             bl get_class;             // x0 = class(lhs)
             str w0, [x(PC.0), #(8)];  // classid1
             mov x0, x14;
             bl get_class;             // x0 = class(rhs)
             str w0, [x(PC.0), #(12)]; // classid2
+            // Polymorphic detection (mirrors x86 `vm_save_binary_class`): once
+            // the cache is populated (old classid1 != 0), if either operand's
+            // class changed, mark the site polymorphic (opcode_sub = 1, offset
+            // +7) so the JIT emits a non-deoptimizing dispatch instead of a
+            // monomorphic class guard.
+            cbz w10, skip;
+            ldr w11, [x(PC.0), #(8)];
+            cmp w10, w11;
+        );
+        self.jit.bcond_label(Cond::Ne, &set_poly);
+        monoasm_arm64!(&mut self.jit,
+            ldr w11, [x(PC.0), #(12)];
+            cmp w12, w11;
+        );
+        self.jit.bcond_label(Cond::Ne, &set_poly);
+        monoasm_arm64!(&mut self.jit,
+            b skip;
+            set_poly:
+            mov x11, (1);
+            strb w11, [x(PC.0), #(7)];  // opcode_sub = 1 (polymorphic)
+            skip:
         );
     }
 


### PR DESCRIPTION
## Summary

Three VM-tier improvements to the aarch64 backend, each mirroring an existing x86 behavior that the aarch64 port had left out. All changes are confined to `monoruby/src/codegen/arch/aarch64/vmgen.rs`.

### 1. `loop_start` GC/signal poll (commit 1)
`a64_op_loop_start` now calls `a64_vm_execute_gc` on the loop back-edge, like x86 `vm_loop_start`. Previously a tight loop that never called a method never reached a safepoint, so a pending `Signal.trap` callback (or a signal-requested GC) could not run — the handler only worked under `--no-gc`. The non-opt `a64_op_loop` (also used for `loop_end` and `not(jit)`) deliberately omits the poll, mirroring x86 `vm_loop_start_no_opt`.

### 2. VM-side send monomorphic inline-cache fast path (commit 1)
`a64_op_send` now reads the inline cache: if the receiver class and `class_version` match the cached pair, the cached FuncId is used directly instead of calling `find_method` on every send. The slow path looks up the method, refills the cache (FuncId/class/version), and rejoins at `exec`; a method_missing result (FuncId 0) is cached too, so repeated misses also hit the fast path. Inline-cache offsets are absolute (PC is not pre-advanced on aarch64): `+16` FuncId, `+24` class, `+28` version.

### 3. Polymorphic-flag bookkeeping (commit 2)
Port the `opcode_sub` writes the x86 VM does in `vm_send` slow_path1 and `vm_save_binary_class`:
- `a64_op_send`: the inline-cache miss is split into a class-mismatch entry (`slow_class`) and a version-mismatch entry (`slow_ver`). On a class mismatch with a FuncId already cached, the site has seen ≥2 receiver classes → write 1 to `opcode_sub` (offset `+7`). A version mismatch (class still matched) is cache staleness, not polymorphism, so it skips the flag.
- `a64_save_binary_class`: read the previously-cached operand classes before overwriting them and, once the cache is populated, set `opcode_sub = 1` when either operand's class changed.

The JIT reads this back via `BytecodePtr::opcode_sub()` (`trace_ir.rs`) and emits a non-deoptimizing dispatch instead of a monomorphic class guard at polymorphic sites.

## Benchmark (VM tier, `--features no-jit`, aarch64 under qemu-user, best of 5)

The send inline cache eliminates the per-call `find_method` lookup on the hit path:

| benchmark | before | after | speedup |
|---|---|---|---|
| 10M monomorphic calls | 6.374s | 3.630s | **1.76×** |
| recursive `fib(32)` | 3.765s | 2.539s | **1.48×** |

(Relative numbers under emulation; the direction is robust — before/after never overlap.)

## Verification

- `cargo check --target aarch64-unknown-linux-gnu` — clean (no code warnings).
- Run under qemu-user (aarch64), both the JIT and `no-jit` builds:
  - polymorphic call site (`arr[i % 3].v` over 3 classes, 1M iters) → `1999999` (hand-computed); monomorphic → `7000000`; `fib(32)` → `2178309`.
  - a mixed arrays/strings/blocks/Float-arithmetic smoke test is byte-identical before vs after.

> Note: not run through the standard `cargo test` harness, which compares against a system CRuby ≥ 4.0 that is not available on this x86 host (aarch64 execution is via qemu only).

https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb)_