### PR TITLE
refactor: factor builtin inline-asm into arch-specific emit_* methods

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -52,7 +52,11 @@ use codegen::jitgen::asmir::*;
 pub use enumerator::YIELDER;
 #[cfg(jit)]
 pub use monoasm::*;
-#[cfg(jit)]
+// The asm macros are only used by the x86-only inline generators
+// (`fiddle`, the x86 `gen_class_new_inline`/`object_send`, and the integer
+// float/shift paths). aarch64 builtins emit no asm directly — they call the
+// `emit_*` Codegen methods in `asmir/compile_stub.rs`.
+#[cfg(jit_x86)]
 pub use monoasm_macro::*;
 use monoruby_attr::monoruby_builtin;
 use num::ToPrimitive;

--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -206,22 +206,7 @@ fn as_exclude_end_inline(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movl rax, [rdi + (crate::rvalue::AS_EXCLUDE_END_OFFSET as i32)];
-            shlq rax, 3;
-            orq  rax, (FALSE_VALUE);
-        }
-        // exclude_end is 0/1; (v<<3) is 0 or 8. FALSE_VALUE=0x14 has bit3 clear,
-        // so `add` == `or`: 0->FALSE_VALUE, 8->0x1c=TRUE_VALUE.
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr w0, [x4, #(crate::rvalue::AS_EXCLUDE_END_OFFSET as u32)];
-            lsl x0, x0, #3;
-            add x0, x0, #(FALSE_VALUE);
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_as_exclude_end());
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }
@@ -244,16 +229,7 @@ fn inline_field_load(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rax, [rdi + (offset as i32)];
-        }
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr x0, [x4, #(offset as u32)];
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_load_value_field(offset));
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -348,19 +348,7 @@ fn array_size(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        r#gen.get_array_length();
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            salq  rax, 1;
-            orq   rax, 1;
-        }
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            lsl x0, x0, #1;
-            add x0, x0, #1;
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_array_size());
 
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);
     true
@@ -402,13 +390,7 @@ fn array_clone(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rax, (array_clone_extern);
-            call rax;
-        }
-        #[cfg(not(jit_x86))]
-        r#gen.a64_array_clone(array_clone_extern as *const () as u64);
+        r#gen.emit_array_clone(array_clone_extern as *const () as u64)
     });
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, class_id);
@@ -452,15 +434,7 @@ fn array_dup_inline(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            // rdi already holds val from state.load above.
-            movq rsi, r12; // globals
-            movq rax, (array_dup_extern);
-            call rax;
-        }
-        #[cfg(not(jit_x86))]
-        r#gen.a64_array_dup(array_dup_extern as *const () as u64);
+        r#gen.emit_array_dup(array_dup_extern as *const () as u64)
     });
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, class_id);
@@ -956,15 +930,7 @@ fn array_shl(
     state.load(ir, args, GP::Rsi);
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm!( &mut r#gen.jit,
-            movq rax, (ary_shl);
-            call rax;
-        );
-        #[cfg(not(jit_x86))]
-        r#gen.a64_array_shl(ary_shl as *const () as u64);
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_array_shl(ary_shl as *const () as u64));
     ir.xmm_restore(using_xmm);
     state.def_reg2acc_class(ir, GP::Rax, dst, recv_class);
     true

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -60,16 +60,7 @@ pub(super) fn gen_class_allocate_inline(
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
     ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm!( &mut r#gen.jit,
-            // alloc_func(class_id, &mut Globals) -> Value
-            movl rdi, (class_id.u32());
-            movq rsi, r12;
-            movq rax, (alloc_func);
-            call rax;
-        );
-        #[cfg(not(jit_x86))]
-        r#gen.a64_class_allocate(class_id.u32(), alloc_func as *const () as u64);
+        r#gen.emit_class_allocate(class_id.u32(), alloc_func as *const () as u64)
     });
     ir.xmm_restore(using_xmm);
     // The allocator produces an instance of exactly `class_id`. Record
@@ -525,7 +516,7 @@ pub(super) fn gen_class_new_inline(
     let alloc_func = alloc_func as *const () as u64;
     let ci = check_initializer as *const () as u64;
     ir.inline(move |r#gen, _, _, _| {
-        r#gen.a64_class_new(class_id.u32(), alloc_func, args_off as u32, pos_num, ci);
+        r#gen.emit_class_new(class_id.u32(), alloc_func, args_off as u32, pos_num, ci);
     });
     ir.xmm_restore(using_xmm);
     ir.handle_error(error);

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -98,65 +98,19 @@ fn fiber_yield_inline(
     let using_xmm = state.get_using_xmm();
     let error = ir.new_error(state);
     ir.xmm_save(using_xmm);
+    // TODO: we must check if the parent fiber exits.
     if pos_num == 0 {
-        ir.inline(move |r#gen, _, _, _| {
-            // TODO: we must check if the parent fiber exits.
-            #[cfg(jit_x86)]
-            monoasm! { &mut r#gen.jit,
-                movq rsi, (Value::nil().id());
-            }
-            #[cfg(not(jit_x86))]
-            monoasm_arm64! { &mut r#gen.jit,
-                mov x3, (Value::nil().id());   // GP::Rsi == x3
-            }
-        });
+        ir.inline(move |r#gen, _, _, _| r#gen.emit_fiber_yield_value_nil());
     } else if pos_num == 1 {
         state.load(ir, args, GP::Rsi);
     } else {
         state.write_back_recv_and_callargs(ir, callsite);
-        ir.inline(move |r#gen, _, _, _| {
-            // TODO: we must check if the parent fiber exits.
-            #[cfg(jit_x86)]
-            monoasm! { &mut r#gen.jit,
-                lea rdi, [r14 - (jitgen::conv(args))];
-                movq rsi, (pos_num);
-                movq rax, (crate::runtime::create_array);
-                call rax;
-                movq rsi, rax;
-            }
-            // create_array(&args, len) -> Array; result -> Rsi (x3).
-            #[cfg(not(jit_x86))]
-            monoasm_arm64! { &mut r#gen.jit,
-                sub x0, x22, #(jitgen::conv(args) as u32);   // &args (lfp - conv)
-                mov x1, (pos_num);
-                mov x9, (crate::runtime::create_array as *const () as u64);
-                str x30, [sp, #-16]!;
-                blr x9;
-                ldr x30, [sp], #16;
-                mov x3, x0;
-            }
-        });
+        let args_off = jitgen::conv(args) as usize;
+        ir.inline(move |r#gen, _, _, _| r#gen.emit_fiber_yield_value_array(args_off, pos_num));
     }
     ir.inline(move |r#gen, _, _, _| {
-        let fiber_yield = r#gen.yield_fiber;
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rdi, rbx;
-            movq rax, (fiber_yield);
-            call rax;
-        }
-        // yield_fiber(vm, value). Save the method's own LR: the invoker's
-        // a64_push_callee_save stashes the *post-blr* x30, not ours, so we
-        // restore the real return address after the fiber resumes here.
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            mov x0, x19;          // vm (EXEC)
-            mov x1, x3;           // value (Rsi)
-            mov x9, (fiber_yield as *const () as u64);
-            str x30, [sp, #-16]!;
-            blr x9;
-            ldr x30, [sp], #16;
-        }
+        let yield_fiber = r#gen.yield_fiber as *const () as u64;
+        r#gen.emit_fiber_yield_call(yield_fiber)
     });
     ir.xmm_restore(using_xmm);
     ir.handle_error(error);

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -797,17 +797,7 @@ fn hash_index(
     state.load(ir, callsite.recv, GP::Rdx);
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
-    ir.inline(|r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! {&mut r#gen.jit,
-            movq rdi, rbx;
-            movq rsi, r12;
-            movq rax, (hashindex);
-            call rax;
-        }
-        #[cfg(not(jit_x86))]
-        r#gen.a64_hash_index(hashindex as *const () as u64);
-    });
+    ir.inline(|r#gen, _, _, _| r#gen.emit_hash_index(hashindex as *const () as u64));
     ir.xmm_restore(using_xmm);
     let error = ir.new_error(state);
     ir.handle_error(error);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -335,22 +335,7 @@ fn kernel_nil(
         }
     } else {
         state.load(ir, recv, GP::Rdi);
-        ir.inline(|r#gen, _, _, _| {
-            #[cfg(jit_x86)]
-            monoasm! { &mut r#gen.jit,
-                movq rax, (FALSE_VALUE);
-                movq rsi, (TRUE_VALUE);
-                cmpq rdi, (NIL_VALUE);
-                cmoveqq rax, rsi;
-            }
-            #[cfg(not(jit_x86))]
-            monoasm_arm64! { &mut r#gen.jit,
-                mov  x0, #(FALSE_VALUE);    // GP::Rax == x0
-                mov  x3, #(TRUE_VALUE);     // GP::Rsi == x3
-                cmp  x4, #(NIL_VALUE);      // GP::Rdi == x4
-                csel x0, x3, x0, eq;        // nil -> TRUE, else FALSE
-            }
-        });
+        ir.inline(|r#gen, _, _, _| r#gen.emit_kernel_nil());
         state.def_rax2acc(ir, dst);
     }
     true
@@ -391,36 +376,7 @@ fn kernel_block_given(
             state.def_C(dst, Immediate::bool(b));
         }
     } else {
-        ir.inline(|r#gen, _, _, _| {
-            let exit = r#gen.jit.label();
-            #[cfg(jit_x86)]
-            monoasm! { &mut r#gen.jit,
-                movq rax, (FALSE_VALUE);
-                movq rdi, [r14 - (LFP_BLOCK)];
-                testq rdi, rdi;
-                jz exit;
-                cmpq rdi, (NIL_VALUE);
-                jeq exit;
-                movq rax, (TRUE_VALUE);
-            exit:
-            }
-            // block slot at [LFP - LFP_BLOCK]; 0 or NIL means no block given.
-            #[cfg(not(jit_x86))]
-            {
-                monoasm_arm64! { &mut r#gen.jit,
-                    mov x0, #(FALSE_VALUE);             // GP::Rax == x0
-                    sub x9, x22, #(LFP_BLOCK as u32);   // x22 == LFP (r14)
-                    ldr x4, [x9];                       // block handle -> GP::Rdi
-                    cbz x4, exit;
-                    cmp x4, #(NIL_VALUE);
-                }
-                r#gen.jit.bcond_label(monoasm::Cond::Eq, &exit);
-                monoasm_arm64! { &mut r#gen.jit,
-                    mov x0, #(TRUE_VALUE);
-                }
-                r#gen.jit.bind_label(exit);
-            }
-        });
+        ir.inline(|r#gen, _, _, _| r#gen.emit_block_given());
         state.def_rax2acc(ir, dst);
     }
 

--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -707,31 +707,10 @@ fn math_sqrt(
     let deopt = ir.new_deopt(state);
     let fret = dst.map(|dst| state.def_F(dst));
     ir.inline(move |r#gen, _, labels, base| {
-        let deopt_label = &labels[deopt];
-        // NaN passes through (sqrt(NaN) = NaN); negative values deopt.
-        // -0.0 compares equal to 0.0, so it skips the deopt and yields -0.0
-        // as CRuby does.
-        #[cfg(jit_x86)]
-        {
-            let do_sqrt = r#gen.jit.label();
-            // ucomisd sets PF=1 for NaN and CF=1 for val < 0.
-            r#gen.load_fpr_into_xmm0(fsrc, base);
-            monoasm!( &mut r#gen.jit,
-                xorpd xmm1, xmm1;
-                ucomisd xmm0, xmm1;
-                jp do_sqrt;
-                jb deopt_label;
-            do_sqrt:
-            );
-            if let Some(fret) = fret {
-                monoasm!( &mut r#gen.jit,
-                    sqrtsd xmm0, xmm0;
-                );
-                r#gen.store_fpr_into_xmm(fret, base);
-            }
-        }
-        #[cfg(not(jit_x86))]
-        r#gen.a64_math_sqrt(fsrc, fret, deopt_label, base);
+        // NaN passes through (sqrt(NaN) = NaN); negative values deopt (the
+        // interpreter re-runs and raises DomainError). -0.0 compares equal to
+        // 0.0, so it skips the deopt and yields -0.0 as CRuby does.
+        r#gen.emit_math_sqrt(fsrc, fret, &labels[deopt], base)
     });
     true
 }

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -211,20 +211,7 @@ fn float_toi(
     let deopt = ir.new_deopt(state);
     if let Some(dst) = dst {
         ir.inline(move |r#gen, _, labels, base| {
-            let deopt = &labels[deopt];
-            #[cfg(jit_x86)]
-            {
-                // Load fsrc into xmm0 (handles both pool and spill).
-                r#gen.load_fpr_into_xmm0(fsrc, base);
-                monoasm! { &mut r#gen.jit,
-                    cvttsd2siq rdi, xmm0;
-                    addq  rdi, rdi;
-                    jo    deopt;
-                    orq   rdi, 1;
-                }
-            }
-            #[cfg(not(jit_x86))]
-            r#gen.a64_float_to_int(fsrc, deopt, base);
+            r#gen.emit_float_to_int(fsrc, &labels[deopt], base)
         });
         state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     }

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -603,19 +603,7 @@ fn integer_tof(
         // `496.to_f #=> NaN`.
         state.load(ir, recv, GP::Rdi);
         let fret = state.def_F(ret);
-        ir.inline(move |r#gen, _, _, base| {
-            // Convert into xmm0, then store into fret (pool or spill).
-            #[cfg(jit_x86)]
-            {
-                monoasm! { &mut r#gen.jit,
-                    sarq  rdi, 1;
-                    cvtsi2sdq xmm0, rdi;
-                }
-                r#gen.store_fpr_into_xmm(fret, base);
-            }
-            #[cfg(not(jit_x86))]
-            r#gen.a64_int_to_float(fret, base);
-        });
+        ir.inline(move |r#gen, _, _, base| r#gen.emit_int_to_float(fret, base));
     }
     true
 }
@@ -944,24 +932,8 @@ fn integer_shr(
 /// overflows (deopt); `0` shifts to `0`. Shared by `integer_shl`/`integer_shr`.
 #[cfg(jit)]
 fn shl_overflow_zero(r#gen: &mut Codegen, deopt: &DestLabel) {
-    let z = Value::i32(0).id();
-    #[cfg(jit_x86)]
-    monoasm!( &mut r#gen.jit,
-        cmpq rdi, (z);
-        jne deopt;
-        movq rdi, (z);
-    );
-    #[cfg(not(jit_x86))]
-    {
-        monoasm_arm64!( &mut r#gen.jit,
-            mov x9, (z);
-            cmp x4, x9;              // GP::Rdi == x4
-        );
-        r#gen.jit.bcond_label(Cond::Ne, deopt);
-        monoasm_arm64!( &mut r#gen.jit,
-            mov x4, x9;
-        );
-    }
+    let z = Value::i32(0).id() as i64;
+    r#gen.emit_shl_overflow_zero(z, deopt);
 }
 
 ///
@@ -1108,21 +1080,8 @@ fn integer_rem_int_rhs(
         if rhs_val > 0 && (rhs_val as u64).is_power_of_two() {
             state.load_fixnum(ir, recv, GP::Rdi);
             let mask = rhs_val * 2 - 1;
-            ir.inline(move |r#gen, _, _, _| {
-                // lhs % 2^k == lhs & mask, applied to the tagged fixnum.
-                #[cfg(jit_x86)]
-                if let Ok(imm32) = i32::try_from(mask) {
-                    let imm = imm32 as i64;
-                    monoasm!( &mut r#gen.jit, andq rdi, (imm); );
-                } else {
-                    monoasm!( &mut r#gen.jit, movq rax, (mask); andq rdi, rax; );
-                }
-                #[cfg(not(jit_x86))]
-                monoasm_arm64!( &mut r#gen.jit,
-                    mov x9, (mask as u64);
-                    and x4, x4, x9;          // GP::Rdi == x4
-                );
-            });
+            // lhs % 2^k == lhs & mask, applied to the tagged fixnum.
+            ir.inline(move |r#gen, _, _, _| r#gen.emit_int_rem_pow2_mask(mask));
             state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
             return true;
         }
@@ -1370,15 +1329,7 @@ fn emit_bitop_imm(
         ir.inline(move |r#gen, _, _, _| emit_imm(r#gen, tagged));
     } else {
         ir.inline(move |r#gen, _, _, _| {
-            // Load the 64-bit tagged literal into rsi (x86) / x3 (aarch64).
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit,
-                movq rsi, (tagged);
-            );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                mov x3, (tagged as u64);  // GP::Rsi == x3
-            );
+            r#gen.emit_load_tagged_rsi(tagged);
             emit_rr(r#gen);
         });
     }
@@ -1401,24 +1352,8 @@ fn integer_bitor(
         callid,
         rhs_class,
         |a, b| a | b,
-        |r#gen, imm| {
-            // `(2a+1) | (2b+1)` keeps LSB=1, so the tag survives directly.
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit, orq rdi, (imm); );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                mov x9, (imm as u64);
-                orr x4, x4, x9;          // GP::Rdi == x4
-            );
-        },
-        |r#gen| {
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit, orq rdi, rsi; );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                orr x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
-            );
-        },
+        |r#gen, imm| r#gen.emit_bitor_imm(imm),
+        |r#gen| r#gen.emit_bitor_rr(),
     )
 }
 
@@ -1439,24 +1374,8 @@ fn integer_bitand(
         callid,
         rhs_class,
         |a, b| a & b,
-        |r#gen, imm| {
-            // `(2a+1) & (2b+1)` keeps LSB=1, so the tag survives directly.
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit, andq rdi, (imm); );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                mov x9, (imm as u64);
-                and x4, x4, x9;          // GP::Rdi == x4
-            );
-        },
-        |r#gen| {
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit, andq rdi, rsi; );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                and x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
-            );
-        },
+        |r#gen, imm| r#gen.emit_bitand_imm(imm),
+        |r#gen| r#gen.emit_bitand_rr(),
     )
 }
 
@@ -1480,30 +1399,8 @@ fn integer_bitxor(
         callid,
         rhs_class,
         |a, b| a ^ b,
-        |r#gen, imm| {
-            // XOR clears the tag bit; using `imm - 1` (tag stripped from the
-            // literal) keeps lhs's tag, so no re-tag is needed.
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit, xorq rdi, (imm - 1); );
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                mov x9, ((imm - 1) as u64);
-                eor x4, x4, x9;          // GP::Rdi == x4
-            );
-        },
-        |r#gen| {
-            #[cfg(jit_x86)]
-            monoasm!( &mut r#gen.jit,
-                xorq rdi, rsi;
-                addq rdi, 1;
-            );
-            // `(2a+1) ^ (2b+1)` clears LSB, so re-tag with `+1`.
-            #[cfg(not(jit_x86))]
-            monoasm_arm64!( &mut r#gen.jit,
-                eor x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
-                add x4, x4, #(1);
-            );
-        },
+        |r#gen, imm| r#gen.emit_bitxor_imm(imm),
+        |r#gen| r#gen.emit_bitxor_rr(),
     )
 }
 

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -191,28 +191,7 @@ fn object_not(
         }
     } else {
         state.load(ir, recv, GP::Rdi);
-        ir.inline(|r#gen, _, _, _| {
-            // `recv | 0x10` maps nil(0x04)->0x14 and false(0x14)->0x14, so the
-            // result is FALSE_VALUE exactly for the two falsy immediates; any
-            // truthy value differs. eq -> TRUE, ne -> FALSE.
-            #[cfg(jit_x86)]
-            monoasm! { &mut r#gen.jit,
-                orq  rdi, (0x10);
-                movq rax, (TRUE_VALUE);
-                movq rsi, (FALSE_VALUE);
-                cmpq rdi, (FALSE_VALUE);
-                cmovneq rax, rsi;
-            }
-            #[cfg(not(jit_x86))]
-            monoasm_arm64! { &mut r#gen.jit,
-                mov  x9, #(0x10);
-                orr  x4, x4, x9;            // GP::Rdi == x4
-                mov  x0, #(TRUE_VALUE);     // GP::Rax == x0
-                mov  x3, #(FALSE_VALUE);    // GP::Rsi == x3
-                cmp  x4, #(FALSE_VALUE);
-                csel x0, x0, x3, eq;        // eq -> TRUE, else FALSE
-            }
-        });
+        ir.inline(|r#gen, _, _, _| r#gen.emit_object_not());
         state.def_rax2acc(ir, dst);
     }
     true
@@ -274,15 +253,7 @@ pub(super) fn object_object_id(
     state.load(ir, recv, GP::Rdi);
     let using_xmm = state.get_using_xmm();
     ir.xmm_save(using_xmm);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! {&mut r#gen.jit,
-            movq rax, (crate::executor::op::i64_to_value);
-            call rax;
-        }
-        #[cfg(not(jit_x86))]
-        r#gen.a64_object_id();
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_object_id());
     ir.xmm_restore(using_xmm);
     state.def_rax2acc(ir, ret);
     true

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -106,16 +106,7 @@ fn range_begin(
         }
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rax, [rdi + (crate::rvalue::RANGE_START_OFFSET as i32)];
-        }
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr x0, [x4, #(crate::rvalue::RANGE_START_OFFSET as u32)];
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_begin());
 
     state.def_reg2acc(ir, GP::Rax, dst);
     true
@@ -154,16 +145,7 @@ fn range_end(
         }
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rax, [rdi + (crate::rvalue::RANGE_END_OFFSET as i32)];
-        }
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr x0, [x4, #(crate::rvalue::RANGE_END_OFFSET as u32)];
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_end());
 
     state.def_reg2acc(ir, GP::Rax, dst);
     true
@@ -272,22 +254,7 @@ fn range_exclude_end(
         return true;
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movl rax, [rdi + (crate::rvalue::RANGE_EXCLUDE_END_OFFSET as i32)];
-            shlq rax, 3;
-            orq  rax, (FALSE_VALUE);
-        }
-        // exclude_end is 0/1; (v<<3) is 0 or 8. FALSE_VALUE=0x14 has bit3 clear,
-        // so `add` == `or` here: 0+0x14=FALSE_VALUE, 8+0x14=0x1c=TRUE_VALUE.
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr w0, [x4, #(crate::rvalue::RANGE_EXCLUDE_END_OFFSET as u32)];
-            lsl x0, x0, #3;
-            add x0, x0, #(FALSE_VALUE);
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_exclude_end());
 
     state.def_reg2acc(ir, GP::Rax, dst);
     true

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3398,25 +3398,7 @@ fn string_bytesize(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| {
-        #[cfg(jit_x86)]
-        monoasm! { &mut r#gen.jit,
-            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
-            cmpq rax, (STRING_INLINE_CAP);
-            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
-            salq rax, 1;
-            orq  rax, 1;
-        }
-        #[cfg(not(jit_x86))]
-        monoasm_arm64! { &mut r#gen.jit,
-            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
-            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
-            cmp x0, #(STRING_INLINE_CAP as u32);
-            csel x0, x9, x0, gt;   // capa > inline cap -> use heap_len
-            lsl x0, x0, #1;
-            add x0, x0, #1;
-        }
-    });
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_string_bytesize());
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod binary_op;
+mod builtin;
 mod constants;
 mod defined;
 mod definition;

--- a/monoruby/src/codegen/jitgen/asmir/compile/builtin.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/builtin.rs
@@ -1,0 +1,298 @@
+//! x86-64 machine-code emitters for builtin-method JIT inliners.
+//!
+//! These are the assembly bodies of the `#[monoruby_builtin]` inline
+//! generators (`builtins/*.rs`). The generators themselves are arch-neutral
+//! (they build `AsmIr` and call one of these `emit_*` methods from inside
+//! `ir.inline`); the aarch64 counterparts live in `asmir/compile_stub.rs`
+//! with the same method names.
+
+use super::*;
+
+impl Codegen {
+    /// `Range#begin`: load the start Value from the receiver in rdi → rax.
+    pub(crate) fn emit_range_begin(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rax, [rdi + (crate::rvalue::RANGE_START_OFFSET as i32)];
+        }
+    }
+
+    /// `Range#end`: load the end Value from the receiver in rdi → rax.
+    pub(crate) fn emit_range_end(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rax, [rdi + (crate::rvalue::RANGE_END_OFFSET as i32)];
+        }
+    }
+
+    /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, OR with
+    /// FALSE_VALUE so 0→FALSE_VALUE and 1→TRUE_VALUE. Receiver in rdi → rax.
+    pub(crate) fn emit_range_exclude_end(&mut self) {
+        monoasm! { &mut self.jit,
+            movl rax, [rdi + (crate::rvalue::RANGE_EXCLUDE_END_OFFSET as i32)];
+            shlq rax, 3;
+            orq  rax, (FALSE_VALUE);
+        }
+    }
+
+    /// `Enumerator::ArithmeticSequence#exclude_end?`: same encoding as
+    /// `emit_range_exclude_end` but from the AS field.
+    pub(crate) fn emit_as_exclude_end(&mut self) {
+        monoasm! { &mut self.jit,
+            movl rax, [rdi + (crate::rvalue::AS_EXCLUDE_END_OFFSET as i32)];
+            shlq rax, 3;
+            orq  rax, (FALSE_VALUE);
+        }
+    }
+
+    /// Load a 64-bit Value field at `offset` from the receiver in rdi → rax.
+    /// Shared by `ArithmeticSequence#begin`/`#end`/`#step`.
+    pub(crate) fn emit_load_value_field(&mut self, offset: usize) {
+        monoasm! { &mut self.jit,
+            movq rax, [rdi + (offset as i32)];
+        }
+    }
+
+    /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
+    /// eq→TRUE, ne→FALSE. Receiver in rdi → rax.
+    pub(crate) fn emit_object_not(&mut self) {
+        monoasm! { &mut self.jit,
+            orq  rdi, (0x10);
+            movq rax, (TRUE_VALUE);
+            movq rsi, (FALSE_VALUE);
+            cmpq rdi, (FALSE_VALUE);
+            cmovneq rax, rsi;
+        }
+    }
+
+    /// `BasicObject#object_id`: `i64_to_value(self_id)`; self id in rdi → rax.
+    pub(crate) fn emit_object_id(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rax, (crate::executor::op::i64_to_value);
+            call rax;
+        }
+    }
+
+    /// `Kernel#nil?`: receiver in rdi → rax, nil→TRUE else FALSE.
+    pub(crate) fn emit_kernel_nil(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rax, (FALSE_VALUE);
+            movq rsi, (TRUE_VALUE);
+            cmpq rdi, (NIL_VALUE);
+            cmoveqq rax, rsi;
+        }
+    }
+
+    /// `Kernel#block_given?`: the block slot at [r14 - LFP_BLOCK] is 0 or NIL
+    /// when no block was passed. Result Value in rax.
+    pub(crate) fn emit_block_given(&mut self) {
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            movq rax, (FALSE_VALUE);
+            movq rdi, [r14 - (LFP_BLOCK)];
+            testq rdi, rdi;
+            jz exit;
+            cmpq rdi, (NIL_VALUE);
+            jeq exit;
+            movq rax, (TRUE_VALUE);
+        exit:
+        }
+    }
+
+    /// `Array#size`/`#length`: untagged length (`get_array_length`) tagged as a
+    /// fixnum in rax.
+    pub(crate) fn emit_array_size(&mut self) {
+        self.get_array_length();
+        monoasm! { &mut self.jit,
+            salq  rax, 1;
+            orq   rax, 1;
+        }
+    }
+
+    /// `String#bytesize`: inline-vs-heap length select, tagged as a fixnum in
+    /// rax. Receiver in rdi.
+    pub(crate) fn emit_string_bytesize(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            cmpq rax, (STRING_INLINE_CAP);
+            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            salq rax, 1;
+            orq  rax, 1;
+        }
+    }
+
+    /// `Hash#[]`: `hashindex(vm, globals, recv, key)`. recv in rdx, key in rcx.
+    /// Result Value in rax (errors via the trailing HandleError).
+    pub(crate) fn emit_hash_index(&mut self, hashindex: u64) {
+        monoasm! { &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (hashindex);
+            call rax;
+        }
+    }
+
+    /// `Array#clone`: `array_clone_extern(recv)`. recv in rdi → rax.
+    pub(crate) fn emit_array_clone(&mut self, f: u64) {
+        monoasm! { &mut self.jit,
+            movq rax, (f);
+            call rax;
+        }
+    }
+
+    /// `Array#dup`: `array_dup_extern(recv, globals)`. recv in rdi → rax.
+    pub(crate) fn emit_array_dup(&mut self, f: u64) {
+        monoasm! { &mut self.jit,
+            movq rsi, r12; // globals
+            movq rax, (f);
+            call rax;
+        }
+    }
+
+    /// `Array#<<`: `ary_shl(recv, arg)`. recv in rdi, arg in rsi → rax.
+    pub(crate) fn emit_array_shl(&mut self, f: u64) {
+        monoasm! { &mut self.jit,
+            movq rax, (f);
+            call rax;
+        }
+    }
+
+    /// `Class#allocate`: `alloc_func(class_id, globals)` → rax.
+    pub(crate) fn emit_class_allocate(&mut self, class_id: u32, alloc_func: u64) {
+        monoasm! { &mut self.jit,
+            movl rdi, (class_id);
+            movq rsi, r12;
+            movq rax, (alloc_func);
+            call rax;
+        }
+    }
+
+    /// `Integer#to_f`: untag the fixnum in rdi, convert to double, store to fret.
+    pub(crate) fn emit_int_to_float(&mut self, fret: FPReg, base: usize) {
+        monoasm! { &mut self.jit,
+            sarq  rdi, 1;
+            cvtsi2sdq xmm0, rdi;
+        }
+        self.store_fpr_into_xmm(fret, base);
+    }
+
+    /// `Float#to_i`: truncate `fsrc` to i64, tag as fixnum in rdi, deopt on
+    /// out-of-fixnum overflow.
+    pub(crate) fn emit_float_to_int(&mut self, fsrc: FPReg, deopt: &DestLabel, base: usize) {
+        self.load_fpr_into_xmm0(fsrc, base);
+        monoasm! { &mut self.jit,
+            cvttsd2siq rdi, xmm0;
+            addq  rdi, rdi;
+            jo    deopt;
+            orq   rdi, 1;
+        }
+    }
+
+    /// `Math.sqrt`: `sqrtsd` on `fsrc`; NaN passes through, a negative argument
+    /// deopts (the interpreter re-runs and raises DomainError).
+    pub(crate) fn emit_math_sqrt(
+        &mut self,
+        fsrc: FPReg,
+        fret: Option<FPReg>,
+        deopt: &DestLabel,
+        base: usize,
+    ) {
+        let do_sqrt = self.jit.label();
+        // ucomisd sets PF=1 for NaN and CF=1 for val < 0.
+        self.load_fpr_into_xmm0(fsrc, base);
+        monoasm!( &mut self.jit,
+            xorpd xmm1, xmm1;
+            ucomisd xmm0, xmm1;
+            jp do_sqrt;
+            jb deopt;
+        do_sqrt:
+        );
+        if let Some(fret) = fret {
+            monoasm!( &mut self.jit,
+                sqrtsd xmm0, xmm0;
+            );
+            self.store_fpr_into_xmm(fret, base);
+        }
+    }
+
+    /// `Fiber.yield` with no args: the yielded value (rsi) is nil.
+    pub(crate) fn emit_fiber_yield_value_nil(&mut self) {
+        monoasm! { &mut self.jit,
+            movq rsi, (Value::nil().id());
+        }
+    }
+
+    /// `Fiber.yield(*args)` with ≥2 args: build the args array, leaving it in
+    /// rsi. `args_off` is `conv(args)`.
+    pub(crate) fn emit_fiber_yield_value_array(&mut self, args_off: usize, pos_num: usize) {
+        monoasm! { &mut self.jit,
+            lea rdi, [r14 - (args_off as i32)];
+            movq rsi, (pos_num);
+            movq rax, (crate::runtime::create_array);
+            call rax;
+            movq rsi, rax;
+        }
+    }
+
+    /// `Fiber.yield`: call `yield_fiber(vm, value)` (value already in rsi).
+    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64) {
+        monoasm! { &mut self.jit,
+            movq rdi, rbx;
+            movq rax, (yield_fiber);
+            call rax;
+        }
+    }
+
+    /// Load a 64-bit tagged fixnum literal into rsi (the RHS register) for an
+    /// `Integer` bit-op whose immediate doesn't fit a 32-bit encoding.
+    pub(crate) fn emit_load_tagged_rsi(&mut self, tagged: i64) {
+        monoasm!( &mut self.jit, movq rsi, (tagged); );
+    }
+
+    /// `Integer#|` with a tagged immediate (`(2a+1)|(2b+1)` keeps LSB=1).
+    pub(crate) fn emit_bitor_imm(&mut self, imm: i64) {
+        monoasm!( &mut self.jit, orq rdi, (imm); );
+    }
+    /// `Integer#|` register-register.
+    pub(crate) fn emit_bitor_rr(&mut self) {
+        monoasm!( &mut self.jit, orq rdi, rsi; );
+    }
+    /// `Integer#&` with a tagged immediate (`(2a+1)&(2b+1)` keeps LSB=1).
+    pub(crate) fn emit_bitand_imm(&mut self, imm: i64) {
+        monoasm!( &mut self.jit, andq rdi, (imm); );
+    }
+    /// `Integer#&` register-register.
+    pub(crate) fn emit_bitand_rr(&mut self) {
+        monoasm!( &mut self.jit, andq rdi, rsi; );
+    }
+    /// `Integer#^` with a tagged immediate (use `imm-1` so lhs's tag survives).
+    pub(crate) fn emit_bitxor_imm(&mut self, imm: i64) {
+        monoasm!( &mut self.jit, xorq rdi, (imm - 1); );
+    }
+    /// `Integer#^` register-register (`(2a+1)^(2b+1)` clears LSB, re-tag +1).
+    pub(crate) fn emit_bitxor_rr(&mut self) {
+        monoasm!( &mut self.jit,
+            xorq rdi, rsi;
+            addq rdi, 1;
+        );
+    }
+
+    /// `n << k` / `n >> -k` with `k >= 64`: a non-zero `n` overflows (deopt);
+    /// `0` shifts to `0`. lhs in rdi.
+    pub(crate) fn emit_shl_overflow_zero(&mut self, z: i64, deopt: &DestLabel) {
+        monoasm!( &mut self.jit,
+            cmpq rdi, (z);
+            jne deopt;
+            movq rdi, (z);
+        );
+    }
+
+    /// `Integer#%` by a positive power of two: `lhs & mask` on the tagged
+    /// fixnum in rdi.
+    pub(crate) fn emit_int_rem_pow2_mask(&mut self, mask: i64) {
+        if let Ok(imm32) = i32::try_from(mask) {
+            let imm = imm32 as i64;
+            monoasm!( &mut self.jit, andq rdi, (imm); );
+        } else {
+            monoasm!( &mut self.jit, movq rax, (mask); andq rdi, rax; );
+        }
+    }
+}

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -3526,7 +3526,7 @@ impl Codegen {
     /// re-runs the builtin and raises DomainError (`-0.0` compares equal to
     /// `0.0`, so it falls through and `fsqrt(-0.0) == -0.0`, as CRuby).
     /// aarch64 twin of x86 `math_sqrt`'s inline body.
-    pub(crate) fn a64_math_sqrt(
+    pub(crate) fn emit_math_sqrt(
         &mut self,
         src: FPReg,
         dst: Option<FPReg>,
@@ -3544,6 +3544,214 @@ impl Codegen {
             monoasm_arm64!(&mut self.jit, fsqrt d0, d0;);
             self.a64_d0_into_fpr(dst, base);
         }
+    }
+
+    /// `Range#begin`: load the start Value from the receiver in Rdi (x4) → Rax.
+    pub(crate) fn emit_range_begin(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(crate::rvalue::RANGE_START_OFFSET as u32)];
+        );
+    }
+
+    /// `Range#end`: load the end Value from the receiver in Rdi (x4) → Rax.
+    pub(crate) fn emit_range_end(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(crate::rvalue::RANGE_END_OFFSET as u32)];
+        );
+    }
+
+    /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, then add
+    /// FALSE_VALUE (whose bit 3 is clear, so `add` == `or`): 0→FALSE_VALUE,
+    /// 8→0x1c=TRUE_VALUE. Receiver in Rdi (x4) → Rax (x0).
+    pub(crate) fn emit_range_exclude_end(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr w0, [x4, #(crate::rvalue::RANGE_EXCLUDE_END_OFFSET as u32)];
+            lsl x0, x0, #3;
+            add x0, x0, #(FALSE_VALUE);
+        );
+    }
+
+    /// `Fiber.yield` with no args: the yielded value (Rsi/x3) is nil.
+    pub(crate) fn emit_fiber_yield_value_nil(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            mov x3, (Value::nil().id());   // GP::Rsi == x3
+        );
+    }
+
+    /// `Fiber.yield(*args)` with ≥2 args: build the args array, leaving it in
+    /// Rsi (x3). `args_off` is `conv(args)`; bounded by the caller.
+    pub(crate) fn emit_fiber_yield_value_array(&mut self, args_off: usize, pos_num: usize) {
+        monoasm_arm64!(&mut self.jit,
+            sub x0, x22, #(args_off as u32);   // &args (lfp - conv)
+            mov x1, (pos_num);
+            mov x9, (crate::runtime::create_array as *const () as u64);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+            mov x3, x0;
+        );
+    }
+
+    /// `Fiber.yield`: call `yield_fiber(vm, value)` with value in Rsi (x3). The
+    /// method's own LR is saved: the invoker's a64_push_callee_save stashes the
+    /// *post-blr* x30, not ours, so we restore the real return address after the
+    /// fiber resumes back here.
+    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;          // vm (EXEC)
+            mov x1, x3;           // value (Rsi)
+            mov x9, (yield_fiber);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// Load a 64-bit tagged fixnum literal into Rsi (x3) for an `Integer` bit-op
+    /// whose immediate doesn't fit a 32-bit encoding.
+    pub(crate) fn emit_load_tagged_rsi(&mut self, tagged: i64) {
+        monoasm_arm64!(&mut self.jit, mov x3, (tagged as u64);); // GP::Rsi == x3
+    }
+
+    /// `Integer#|` with a tagged immediate (`(2a+1)|(2b+1)` keeps LSB=1).
+    pub(crate) fn emit_bitor_imm(&mut self, imm: i64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (imm as u64);
+            orr x4, x4, x9;          // GP::Rdi == x4
+        );
+    }
+    /// `Integer#|` register-register.
+    pub(crate) fn emit_bitor_rr(&mut self) {
+        monoasm_arm64!(&mut self.jit, orr x4, x4, x3;); // Rdi==x4, Rsi==x3
+    }
+    /// `Integer#&` with a tagged immediate (`(2a+1)&(2b+1)` keeps LSB=1).
+    pub(crate) fn emit_bitand_imm(&mut self, imm: i64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (imm as u64);
+            and x4, x4, x9;          // GP::Rdi == x4
+        );
+    }
+    /// `Integer#&` register-register.
+    pub(crate) fn emit_bitand_rr(&mut self) {
+        monoasm_arm64!(&mut self.jit, and x4, x4, x3;);
+    }
+    /// `Integer#^` with a tagged immediate (use `imm-1` so lhs's tag survives).
+    pub(crate) fn emit_bitxor_imm(&mut self, imm: i64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x9, ((imm - 1) as u64);
+            eor x4, x4, x9;          // GP::Rdi == x4
+        );
+    }
+    /// `Integer#^` register-register (`(2a+1)^(2b+1)` clears LSB, re-tag +1).
+    pub(crate) fn emit_bitxor_rr(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            eor x4, x4, x3;          // GP::Rdi == x4, GP::Rsi == x3
+            add x4, x4, #(1);
+        );
+    }
+
+    /// `n << k` / `n >> -k` with `k >= 64`: a non-zero `n` overflows (deopt);
+    /// `0` shifts to `0`. lhs in Rdi (x4).
+    pub(crate) fn emit_shl_overflow_zero(&mut self, z: i64, deopt: &DestLabel) {
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (z as u64);
+            cmp x4, x9;              // GP::Rdi == x4
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, deopt);
+        monoasm_arm64!(&mut self.jit,
+            mov x4, x9;
+        );
+    }
+
+    /// `Integer#%` by a positive power of two: `lhs & mask` on the tagged
+    /// fixnum in Rdi (x4).
+    pub(crate) fn emit_int_rem_pow2_mask(&mut self, mask: i64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (mask as u64);
+            and x4, x4, x9;          // GP::Rdi == x4
+        );
+    }
+
+    /// `Enumerator::ArithmeticSequence#exclude_end?`: same encoding as
+    /// `emit_range_exclude_end` but from the AS field.
+    pub(crate) fn emit_as_exclude_end(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr w0, [x4, #(crate::rvalue::AS_EXCLUDE_END_OFFSET as u32)];
+            lsl x0, x0, #3;
+            add x0, x0, #(FALSE_VALUE);
+        );
+    }
+
+    /// Load a 64-bit Value field at `offset` from the receiver in Rdi (x4) → Rax
+    /// (x0). Shared by `ArithmeticSequence#begin`/`#end`/`#step`.
+    pub(crate) fn emit_load_value_field(&mut self, offset: usize) {
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(offset as u32)];
+        );
+    }
+
+    /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
+    /// eq→TRUE, ne→FALSE. Receiver in Rdi (x4) → Rax (x0).
+    pub(crate) fn emit_object_not(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            mov  x9, #(0x10);
+            orr  x4, x4, x9;            // GP::Rdi == x4
+            mov  x0, #(TRUE_VALUE);     // GP::Rax == x0
+            mov  x3, #(FALSE_VALUE);    // GP::Rsi == x3
+            cmp  x4, #(FALSE_VALUE);
+            csel x0, x0, x3, eq;        // eq -> TRUE, else FALSE
+        );
+    }
+
+    /// `Kernel#nil?`: receiver in Rdi (x4) → Rax (x0), nil→TRUE else FALSE.
+    pub(crate) fn emit_kernel_nil(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            mov  x0, #(FALSE_VALUE);    // GP::Rax == x0
+            mov  x3, #(TRUE_VALUE);     // GP::Rsi == x3
+            cmp  x4, #(NIL_VALUE);      // GP::Rdi == x4
+            csel x0, x3, x0, eq;        // nil -> TRUE, else FALSE
+        );
+    }
+
+    /// `Kernel#block_given?`: the block slot at [LFP - LFP_BLOCK] is 0 or NIL
+    /// when no block was passed. Result Value in Rax (x0).
+    pub(crate) fn emit_block_given(&mut self) {
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(FALSE_VALUE);             // GP::Rax == x0
+            sub x9, x22, #(LFP_BLOCK as u32);   // x22 == LFP (r14)
+            ldr x4, [x9];                       // block handle -> GP::Rdi
+            cbz x4, exit;
+            cmp x4, #(NIL_VALUE);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(TRUE_VALUE);
+        );
+        self.jit.bind_label(exit);
+    }
+
+    /// `Array#size`/`#length`: untagged length (`get_array_length`) tagged as a
+    /// fixnum in Rax (x0).
+    pub(crate) fn emit_array_size(&mut self) {
+        self.get_array_length();
+        monoasm_arm64!(&mut self.jit,
+            lsl x0, x0, #1;
+            add x0, x0, #1;
+        );
+    }
+
+    /// `String#bytesize`: inline-vs-heap length select, tagged as a fixnum in
+    /// Rax (x0). Receiver in Rdi (x4).
+    pub(crate) fn emit_string_bytesize(&mut self) {
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, #(STRING_INLINE_CAP as u32);
+            csel x0, x9, x0, gt;   // capa > inline cap -> use heap_len
+            lsl x0, x0, #1;
+            add x0, x0, #1;
+        );
     }
 
     /// Length of the array whose pointer is in Rdi (x4) → Rax (x0), untagged.
@@ -3675,7 +3883,7 @@ impl Codegen {
     /// Inlined `Integer#to_f`: untag the tagged fixnum in Rdi (x4), convert to
     /// double with `scvtf`, and store into `fret`. aarch64 twin of x86
     /// `integer_tof`'s `sarq` + `cvtsi2sdq` + `store_fpr_into_xmm`.
-    pub(crate) fn a64_int_to_float(&mut self, fret: FPReg, base: usize) {
+    pub(crate) fn emit_int_to_float(&mut self, fret: FPReg, base: usize) {
         let rdi = GP::Rdi.a64().0; // x4
         monoasm_arm64!(&mut self.jit,
             asr x(rdi), x(rdi), #(1);  // untag
@@ -3690,7 +3898,7 @@ impl Codegen {
     /// saturated case and any value that doesn't fit in a 63-bit fixnum, so a
     /// single signed-overflow branch covers both. aarch64 twin of x86
     /// `cvttsd2siq` + `addq;jo` + `orq 1`. Result Value lands in Rdi (x4).
-    pub(crate) fn a64_float_to_int(&mut self, fsrc: FPReg, deopt: &DestLabel, base: usize) {
+    pub(crate) fn emit_float_to_int(&mut self, fsrc: FPReg, deopt: &DestLabel, base: usize) {
         let rdi = GP::Rdi.a64().0; // x4
         self.a64_fpr_into_d0(fsrc, base);
         let deopt = deopt.clone();
@@ -3708,7 +3916,7 @@ impl Codegen {
     /// (its raw id) is in Rdi (x4); move it to the C ABI arg0 (x0) and call.
     /// Result Value lands in Rax (x0). The FP pool is saved by the surrounding
     /// AsmIr xmm_save/xmm_restore; here we only preserve LR around the `blr`.
-    pub(crate) fn a64_object_id(&mut self) {
+    pub(crate) fn emit_object_id(&mut self) {
         let rdi = GP::Rdi.a64().0; // x4
         let f = crate::executor::op::i64_to_value as *const () as u64;
         monoasm_arm64!(&mut self.jit,
@@ -3725,7 +3933,7 @@ impl Codegen {
     /// arg3 first (before x1 is overwritten by globals), then load vm/globals.
     /// Result Value lands in Rax (x0); errors are checked by the trailing
     /// HandleError. FP pool saved by the surrounding xmm_save/restore.
-    pub(crate) fn a64_hash_index(&mut self, hashindex: u64) {
+    pub(crate) fn emit_hash_index(&mut self, hashindex: u64) {
         monoasm_arm64!(&mut self.jit,
             mov x3, x1;           // key (Rcx) -> arg3   [recv already in x2 == Rdx]
             mov x0, x19;          // vm (EXEC) -> arg0
@@ -3741,7 +3949,7 @@ impl Codegen {
     /// (a u32) and the resolved allocator pointer are embedded as constants;
     /// arg0 = class_id, arg1 = globals (GLOBALS/x20). Result Value in Rax (x0).
     /// FP pool saved by the surrounding xmm_save.
-    pub(crate) fn a64_class_allocate(&mut self, class_id: u32, alloc_func: u64) {
+    pub(crate) fn emit_class_allocate(&mut self, class_id: u32, alloc_func: u64) {
         monoasm_arm64!(&mut self.jit,
             mov x0, (class_id as u64); // class_id -> arg0 (low 32 bits read)
             mov x1, x20;               // globals -> arg1
@@ -3766,7 +3974,7 @@ impl Codegen {
     /// `initialize` error (checked by the trailing HandleError). FP pool saved
     /// by the surrounding xmm_save/restore. The args slot offset is bounded by
     /// the caller (`gen_class_new_inline` bails past the `sub` immediate range).
-    pub(crate) fn a64_class_new(
+    pub(crate) fn emit_class_new(
         &mut self,
         class_id: u32,
         alloc_func: u64,
@@ -3817,7 +4025,7 @@ impl Codegen {
 
     /// Inlined `Array#clone`: `array_clone_extern(recv)`. recv (Rdi/x4) -> arg0.
     /// Result Value in Rax (x0). FP pool saved by the surrounding xmm_save.
-    pub(crate) fn a64_array_clone(&mut self, f: u64) {
+    pub(crate) fn emit_array_clone(&mut self, f: u64) {
         let rdi = GP::Rdi.a64().0; // x4
         monoasm_arm64!(&mut self.jit,
             mov x0, x(rdi);       // recv -> arg0
@@ -3830,7 +4038,7 @@ impl Codegen {
 
     /// Inlined `Array#dup`: `array_dup_extern(recv, globals)`. recv (Rdi/x4) ->
     /// arg0, globals (GLOBALS/x20) -> arg1. Result Value in Rax (x0).
-    pub(crate) fn a64_array_dup(&mut self, f: u64) {
+    pub(crate) fn emit_array_dup(&mut self, f: u64) {
         let rdi = GP::Rdi.a64().0; // x4
         monoasm_arm64!(&mut self.jit,
             mov x0, x(rdi);       // recv -> arg0
@@ -3844,7 +4052,7 @@ impl Codegen {
 
     /// Inlined `Array#<<`: `ary_shl(recv, arg)`. recv (Rdi/x4) -> arg0,
     /// arg (Rsi/x3) -> arg1. Result Value in Rax (x0).
-    pub(crate) fn a64_array_shl(&mut self, f: u64) {
+    pub(crate) fn emit_array_shl(&mut self, f: u64) {
         let rdi = GP::Rdi.a64().0; // x4
         let rsi = GP::Rsi.a64().0; // x3
         monoasm_arm64!(&mut self.jit,


### PR DESCRIPTION
Unifies the x86-64 / aarch64 code for the `#[monoruby_builtin]` inline JIT generators by **moving every machine-code body out of `builtins/*.rs`** and into named `emit_*` Codegen methods, so the generators are arch-neutral.

## Before / after

Each generator closure collapses from an inline arch switch:

```rust
ir.inline(move |r#gen, _, _, _| {
    #[cfg(jit_x86)]      monoasm! { … }
    #[cfg(not(jit_x86))] monoasm_arm64! { … }
});
```

to a single call:

```rust
ir.inline(move |r#gen, _, _, _| r#gen.emit_range_begin());
```

The assembly lives in the existing per-arch JIT-asm split:
- **x86-64** → new `asmir/compile/builtin.rs`
- **aarch64** → `asmir/compile_stub.rs` (the `a64_*` builtin helpers are renamed to `emit_*` to match)

## Covered generators

`Range#begin`/`#end`/`#exclude_end?`, `ArithmeticSequence` accessors, `BasicObject#!`/`#object_id`, `Kernel#nil?`/`#block_given?`, `Array#size`/`#clone`/`#dup`/`#<<`, `String#bytesize`, `Hash#[]`, `Class#allocate`, `Integer#to_f`, `Float#to_i`, `Math.sqrt`, `Fiber.yield`, and the `Integer` bit-ops (`|`/`&`/`^`), power-of-two `%`, and `>=64` shift-overflow inliners.

aarch64 builtins now emit no asm directly, so the `monoasm_macro::*` re-export in `builtins.rs` is gated to `jit_x86` (still used by the x86-only generators: `fiddle`, the x86 `gen_class_new_inline`/`object_send`, and the `Integer` float/shift paths). The `monoasm::*` type re-export (`DestLabel` etc.) stays for both arches.

Genuinely per-arch generators (whole-function differences, not asm switches) are left as-is: `fiddle` read/write and `object_send` (x86-only), the x86 `gen_class_new_inline` inline-cache variant, and the aarch64 `return false` bails for the not-yet-ported `Integer` variable-shift / float-rem-pow paths.

## Verification

Pure refactor, no behaviour change. Net **−171 lines** in `builtins/`. Full `cargo nextest run`: **2216 passed, 1 skipped**; spot-checked JIT == CRuby on the accessor/predicate/fiber workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)