### PR TITLE
jit(aarch64): raise FatalError on recompile panic; refresh stale recompiler docs

### DIFF
--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -473,15 +473,35 @@ extern "C" fn jit_recompile_method(globals: &mut Globals, lfp: Lfp, reason: Reco
 /// aarch64 counterpart, called from the `RecompileDeopt` lowering
 /// (`compile_stub.rs`). Recompiles the current method and overwrites its
 /// dispatch slot via [`Codegen::recompile_method`].
+///
+/// Returns `Option<Value>`: `Some(nil)` on success, `None` if recompilation
+/// panicked. A panic must not cross this `extern "C"` boundary and abort the
+/// process — aarch64 can panic while emitting a large method body (e.g. an
+/// out-of-range branch to a far deopt). We catch it, re-arm the JIT region as
+/// executable (the aborted emit left it writable, mirroring `jit_compile_loop`),
+/// and set a Ruby `FatalError` on `vm`. The caller (`emit_recompile_deopt`)
+/// checks the `None` return and branches to the error side-exit so the
+/// `FatalError` is raised (it is uncatchable by `rescue` and propagates up).
 #[cfg(not(jit_x86))]
 pub(in crate::codegen) extern "C" fn jit_recompile_method(
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     reason: RecompileReason,
-) {
-    CODEGEN.with(|codegen| {
-        codegen.borrow_mut().recompile_method(globals, lfp, reason);
-    });
+) -> Option<Value> {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CODEGEN.with(|codegen| {
+            codegen.borrow_mut().recompile_method(globals, lfp, reason);
+        });
+    }));
+    if result.is_err() {
+        CODEGEN.with(|codegen| codegen.borrow_mut().jit.finalize());
+        vm.set_error(MonorubyErr::fatal(
+            "internal error: JIT method recompilation panicked.",
+        ));
+        return None;
+    }
+    Some(Value::nil())
 }
 
 #[cfg(jit_x86)]

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1129,6 +1129,11 @@ pub(super) enum AsmInst {
     RecompileDeopt {
         position: Option<BytecodePtr>,
         deopt: AsmDeopt,
+        /// Error side-exit reached when the recompile itself raises (a Rust
+        /// `panic!` during recompilation, caught at the `extern "C"` boundary
+        /// and turned into a Ruby `FatalError`). `None` on x86, which
+        /// recompiles in place and never returns an error here.
+        error: Option<AsmError>,
         reason: RecompileReason,
     },
     RecompileDeoptSpecialized {
@@ -1917,6 +1922,7 @@ impl AsmInst {
             Self::RecompileDeopt {
                 position,
                 deopt: _,
+                error: _,
                 reason,
             } => {
                 format!("recompile_deopt {:?} {:?}", position, reason)

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -1281,6 +1281,9 @@ impl Codegen {
         &mut self,
         position: Option<BytecodePtr>,
         deopt: &DestLabel,
+        // x86 recompiles in place (no extern-boundary panic surfaced here), so
+        // the aarch64-only error side-exit is unused.
+        _error: Option<&DestLabel>,
         reason: RecompileReason,
     ) {
         self.recompile_and_deopt(position, deopt, reason);

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -259,13 +259,18 @@ impl Codegen {
             }
             // Basic-operator-redefinition guard: deopt if any BOP was redefined.
             AsmInst::CheckBOP { deopt } => self.emit_check_bop(&labels[deopt]),
-            // Recompile-or-deopt point: x86 recompiles once the inline cache
-            // warms; aarch64 has no recompiler and just deopts.
+            // Recompile-or-deopt point: both arches recompile the whole method
+            // once a small miss counter warms, then deopt. aarch64 has no loop
+            // or specialized recompiler yet, so those positions just deopt.
             AsmInst::RecompileDeopt {
                 position,
                 deopt,
+                error,
                 reason,
-            } => self.emit_recompile_deopt(position, &labels[deopt], reason),
+            } => {
+                let error = error.map(|e| labels[e].clone());
+                self.emit_recompile_deopt(position, &labels[deopt], error.as_ref(), reason)
+            }
             // The call itself. x86 records a return-address deopt patch point;
             // aarch64 has no branch patching (class-version guards cover it).
             AsmInst::Call {

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2331,13 +2331,16 @@ impl Codegen {
         );
     }
 
-    /// Recompile-or-deopt point: aarch64 has no recompiler yet, so treat it as a
-    /// plain deopt to the interpreter (correct, just not re-optimized). The x86
-    /// recompile params are unused here.
+    /// Recompile-or-deopt point. For a whole-method recompile (`position` =
+    /// None) this counter-gates a one-shot call to `jit_recompile_method`
+    /// (mirrors x86 `recompile_and_deopt`) and then deopts. For a loop-JIT
+    /// recompile point (`position` = Some) aarch64 has no loop recompiler yet,
+    /// so it just deopts.
     pub(in crate::codegen::jitgen) fn emit_recompile_deopt(
         &mut self,
         position: Option<BytecodePtr>,
         deopt: &DestLabel,
+        error: Option<&DestLabel>,
         reason: RecompileReason,
     ) {
         let deopt = deopt.clone();
@@ -2373,12 +2376,13 @@ impl Codegen {
             str d5, [sp, #(24)];
             str d6, [sp, #(32)];
             str d7, [sp, #(40)];
-            mov x0, x20;                     // globals
-            mov x1, x22;                     // lfp
-            mov x2, (reason as u64);
+            mov x0, x19;                     // vm (Executor)
+            mov x1, x20;                     // globals
+            mov x2, x22;                     // lfp
+            mov x3, (reason as u64);
             str x30, [sp, #-16]!;
             mov x9, (f);
-            blr x9;
+            blr x9;                          // -> Option<Value>: None (x0=0) = panic
             ldr x30, [sp], #16;
             ldr d2, [sp, #(0)];
             ldr d3, [sp, #(8)];
@@ -2387,6 +2391,18 @@ impl Codegen {
             ldr d6, [sp, #(32)];
             ldr d7, [sp, #(40)];
             add sp, sp, #(48);
+        );
+        // Check the compiler's return value: `jit_recompile_method` caught a
+        // panic, set a Ruby `FatalError`, and returned None (x0 = 0). Branch to
+        // the error side-exit (write-back + raise via entry_raise) instead of
+        // resuming the interpreter. On success (x0 != 0) just deopt.
+        if let Some(error) = error {
+            let error = error.clone();
+            monoasm_arm64!(&mut self.jit,
+                cbz x0, error;
+            );
+        }
+        monoasm_arm64!(&mut self.jit,
             b deopt;
         );
     }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -920,11 +920,22 @@ impl<'a> JitContext<'a> {
                 deopt,
                 reason,
             }),
-            _ => ir.push(AsmInst::RecompileDeopt {
-                position: self.position(),
-                deopt,
-                reason,
-            }),
+            _ => {
+                // aarch64 surfaces a recompile-time panic as a Ruby FatalError,
+                // so it needs an error side-exit (write-back + raise) to branch
+                // into when `jit_recompile_method` returns None. x86 recompiles
+                // in place and never returns an error here.
+                #[cfg(not(jit_x86))]
+                let error = Some(ir.new_error(state));
+                #[cfg(jit_x86)]
+                let error = None;
+                ir.push(AsmInst::RecompileDeopt {
+                    position: self.position(),
+                    deopt,
+                    error,
+                    reason,
+                })
+            }
         }
     }
 }

--- a/monoruby/src/codegen/patch.rs
+++ b/monoruby/src/codegen/patch.rs
@@ -21,15 +21,14 @@ impl Codegen {
     ///
     /// ```
     ///
-    /// aarch64 has no emission yet: `compile_method` runs the arch-neutral
-    /// front-end and bails (returns `None`), so a minimal `not(jit_x86)`
-    /// variant just drives that and never patches — the A64 trigger falls
-    /// through to `vm_entry` on its own. See `doc/aarch64-jitgen-plan.md`.
-    /// aarch64 install via **indirect dispatch** (no runtime branch patching):
-    /// `slot` points at the wrapper's per-method JIT-entry word (init 0). On a
-    /// successful compile we write the compiled entry address there; the
-    /// wrapper loads it and branches to the JIT code on the next call. On bail
-    /// the slot stays 0 and the method stays VM-interpreted.
+    /// aarch64 installs JIT code via **indirect dispatch** (no runtime branch
+    /// patching): `slot` points at the wrapper's per-method JIT-entry word
+    /// (init 0). `compile_method` runs the arch-neutral front-end and the A64
+    /// lowering; on success we publish the compiled entry's address (fronted by
+    /// a self-class guard, see below) into `slot`, and the wrapper loads it and
+    /// branches to the JIT code on the next call. If the lowering bails on an
+    /// unported AsmInst the slot stays 0 and the method stays VM-interpreted.
+    /// See `doc/aarch64-jitgen-plan.md`.
     #[cfg(not(jit_x86))]
     pub(super) fn compile_patch(
         &mut self,


### PR DESCRIPTION
## Summary

Two changes around the aarch64 whole-method recompiler (VM-tier JIT). All changes are confined to the JIT codegen; x86-64 behavior is unchanged.

### 1. Refresh stale "aarch64 has no recompiler" comments
Three comments claimed aarch64 has no recompiler, contradicting the code — aarch64 has recompiled whole methods in place (via the indirect dispatch slot) since the recompiler landed. Updated to describe the actual behavior:
- `asmir/compile_stub.rs` `emit_recompile_deopt` doc
- `asmir/compile_shared.rs` `RecompileDeopt` dispatch comment
- `patch.rs` `compile_patch` (`not(jit_x86)`) doc

### 2. Raise a Ruby `FatalError` on a recompile-time panic
aarch64 can `panic!` while emitting a large recompiled method (e.g. an out-of-range branch to a far deopt — `TBZ`/`TBNZ` imm14 is only ±32 KiB), exactly the case the loop compiler (`jit_compile_loop`) already guards with `catch_unwind`. The method recompile path had no such guard, so a panic would cross the `extern "C"` boundary and abort the process. Now:

- **`jit_recompile_method`** (`not(jit_x86)`) takes `vm: &mut Executor`, wraps `recompile_method` in `catch_unwind`, and on panic re-arms the JIT region as executable (mirrors `jit_compile_loop`), sets `MonorubyErr::fatal` on the executor, and returns `None` (`Option<Value>`); `Some(nil)` on success.
- **`AsmInst::RecompileDeopt`** now carries an `error` side-exit (write-back + raise via `entry_raise`). `recompile_and_deopt` populates it on aarch64 only (x86 recompiles in place and never returns an error here).
- **`emit_recompile_deopt`** (aarch64) passes `vm` in `x0`, and **checks the return value after the call** (`cbz x0, error`): on `None` (panic → `FatalError` set) it branches to the error side-exit to raise, instead of resuming the interpreter; on success it deopts as before.

The `FatalError` is uncatchable by `rescue` and propagates to the top (`handle_error` already special-cases fatal errors).

## Verification

- `cargo check` clean on both **aarch64-unknown-linux-gnu** and **x86-64** (no new warnings).
- Under **qemu-user (aarch64, JIT build)**:
  - No regression: `fib(32)` → `2178309`, a polymorphic call site (`arr[i%3].v`) → `1999999`, and a mixed int/float workload return the expected values (normal recompile is unaffected).
  - Panic path proven: a temporary forced `panic!` in `recompile_method` raises `internal error: JIT method recompilation panicked. (FatalError)` with the correct source location and exits cleanly (no SIGABRT) instead of aborting. The injection was reverted.

> Note: not run through the standard `cargo test` harness, which compares against a system CRuby ≥ 4.0 not available on this x86 host (aarch64 execution is via qemu only).

https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb)_