### PR TITLE
jit(aarch64): eliminate JIT-compile bails for float %/** and variable shifts

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -912,17 +912,10 @@ fn integer_shr(
             }
         }
     } else {
-        // Variable shift amount: x86 uses gen_shr (lzcnt overflow guard,
-        // two-page cold path). Not yet ported to aarch64 — bail to a method
-        // call.
-        #[cfg(jit_x86)]
-        {
-            state.load_fixnum(ir, args, GP::Rcx);
-            let deopt = ir.new_deopt(state);
-            ir.inline(move |r#gen, _, labels, _| r#gen.gen_shr(&labels[deopt]));
-        }
-        #[cfg(not(jit_x86))]
-        return false;
+        // Variable shift amount.
+        state.load_fixnum(ir, args, GP::Rcx);
+        let deopt = ir.new_deopt(state);
+        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shr(&labels[deopt]));
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true
@@ -994,21 +987,21 @@ fn integer_shl(
             ir.inline(move |r#gen, _, labels, _| shl_overflow_zero(r#gen, &labels[deopt]));
         }
     } else {
-        // Variable shift amount (gen_shl / gen_shl_lhs_imm): x86's lzcnt
-        // overflow guard + two-page cold path is not yet ported to aarch64 —
-        // bail to a method call.
+        // Variable shift amount.
+        state.load_fixnum(ir, args, GP::Rcx);
+        let deopt = ir.new_deopt(state);
+        // x86 has a literal-lhs fast path (`gen_shl_lhs_imm`) that folds the
+        // overflow guard to a constant `lzcnt`; aarch64's shift-back overflow
+        // check gains nothing from a constant lhs (recv is already in Rdi), so
+        // it uses `gen_shl` for both cases.
         #[cfg(jit_x86)]
         if let Some(lhs) = state.is_fixnum_literal(recv) {
-            state.load_fixnum(ir, args, GP::Rcx);
-            let deopt = ir.new_deopt(state);
             ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl_lhs_imm(lhs.get(), &labels[deopt]));
         } else {
-            state.load_fixnum(ir, args, GP::Rcx);
-            let deopt = ir.new_deopt(state);
             ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
         }
         #[cfg(not(jit_x86))]
-        return false;
+        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -1114,28 +1114,18 @@ fn integer_rem_float_rhs(
         }
     }
 
-    // The runtime float-remainder path (`gen_int_rem_if`, an xmm C-call) is not
-    // ported to aarch64 yet; bail to a method call.
-    #[cfg(not(jit_x86))]
-    {
-        let _ = (ir, recv, args);
-        false
-    }
-    #[cfg(jit_x86)]
-    {
-        let lhs_xmm = state.load_xmm_fixnum(ir, recv);
-        let rhs_xmm = state.load_xmm(ir, args);
-        let Some(dst) = dst else {
-            // Result discarded; no work needed (rem_ff is pure).
-            return true;
-        };
-        let dst_xmm = state.def_F(dst);
-        let using_xmm = state.get_using_xmm();
-        ir.inline(move |r#gen, _, _, base| {
-            r#gen.gen_int_rem_if(lhs_xmm, rhs_xmm, dst_xmm, using_xmm, base)
-        });
-        true
-    }
+    let lhs_xmm = state.load_xmm_fixnum(ir, recv);
+    let rhs_xmm = state.load_xmm(ir, args);
+    let Some(dst) = dst else {
+        // Result discarded; no work needed (rem_ff is pure).
+        return true;
+    };
+    let dst_xmm = state.def_F(dst);
+    let using_xmm = state.get_using_xmm();
+    ir.inline(move |r#gen, _, _, base| {
+        r#gen.gen_int_rem_if(lhs_xmm, rhs_xmm, dst_xmm, using_xmm, base)
+    });
+    true
 }
 
 ///
@@ -1227,24 +1217,14 @@ fn integer_pow_float_rhs(
         // else: fall through to runtime call
     }
 
-    // The runtime float-power path (`gen_int_pow_if`, an xmm C-call) is not
-    // ported to aarch64 yet; bail to a method call.
-    #[cfg(not(jit_x86))]
-    {
-        let _ = (ir, recv, args);
-        false
-    }
-    #[cfg(jit_x86)]
-    {
-        let lhs_xmm = state.load_xmm_fixnum(ir, recv);
-        let rhs_xmm = state.load_xmm(ir, args);
-        let using_xmm = state.get_using_xmm();
-        ir.inline(move |r#gen, _, _, base| {
-            r#gen.gen_int_pow_if(lhs_xmm, rhs_xmm, using_xmm, base)
-        });
-        state.def_reg2acc(ir, GP::Rax, dst);
-        true
-    }
+    let lhs_xmm = state.load_xmm_fixnum(ir, recv);
+    let rhs_xmm = state.load_xmm(ir, args);
+    let using_xmm = state.get_using_xmm();
+    ir.inline(move |r#gen, _, _, base| {
+        r#gen.gen_int_pow_if(lhs_xmm, rhs_xmm, using_xmm, base)
+    });
+    state.def_reg2acc(ir, GP::Rax, dst);
+    true
 }
 
 ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -609,6 +609,54 @@ impl Codegen {
         );
     }
 
+    /// `Integer#%` with a Float rhs: `rem_ff(lhs, rhs)` (f64,f64 -> f64). The
+    /// operands are loaded into d0/d1, the result (d0) stored into `dst_xmm`.
+    /// aarch64 twin of x86 `gen_int_rem_if`.
+    pub(crate) fn gen_int_rem_if(
+        &mut self,
+        lhs_xmm: FPReg,
+        rhs_xmm: FPReg,
+        dst_xmm: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) {
+        let f = crate::executor::op::rem_ff as *const () as u64;
+        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+        self.emit_xmm_save(using_xmm, false);
+        self.a64_fpr_into_d(lhs_xmm, 0, base);
+        self.a64_fpr_into_d(rhs_xmm, 1, base);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (f);
+            blr x9;                  // d0 = rem_ff(d0, d1)
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
+        self.a64_d0_into_fpr(dst_xmm, base);
+    }
+
+    /// `Integer#**` with a Float rhs: `pow_ff(lhs, rhs)` (f64,f64 -> Value, which
+    /// may be Complex). The operands are loaded into d0/d1; the result Value
+    /// lands in Rax (x0). aarch64 twin of x86 `gen_int_pow_if`.
+    pub(crate) fn gen_int_pow_if(
+        &mut self,
+        lhs_xmm: FPReg,
+        rhs_xmm: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    ) {
+        let f = crate::executor::op::pow_ff as *const () as u64;
+        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+        self.emit_xmm_save(using_xmm, false);
+        self.a64_fpr_into_d(lhs_xmm, 0, base);
+        self.a64_fpr_into_d(rhs_xmm, 1, base);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (f);
+            blr x9;                  // x0 = pow_ff(d0, d1)
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
+    }
+
     /// Compare two tagged fixnums (the tag preserves order). Mirrors x86
     /// `cmp_integer`.
     fn a64_cmp_integer(&mut self, mode: &OpMode, lhs: GP, rhs: GP) {
@@ -3515,12 +3563,18 @@ impl Codegen {
 
     /// Load a `FPReg` (pool reg or spill slot) into `d0`.
     fn a64_fpr_into_d0(&mut self, src: FPReg, base: usize) {
+        self.a64_fpr_into_d(src, 0, base);
+    }
+
+    /// Load a `FPReg` (pool reg or spill slot) into the scratch register `dreg`
+    /// (D0/D1, outside the D2-D15 pool). Spill-aware, so it never bails.
+    fn a64_fpr_into_d(&mut self, src: FPReg, dreg: u32, base: usize) {
         match src.loc(base) {
-            FPRegLoc::Xmm(p) => monoasm_arm64!(&mut self.jit, fmov d0, d(p as u32);),
+            FPRegLoc::Xmm(p) => monoasm_arm64!(&mut self.jit, fmov d(dreg), d(p as u32);),
             FPRegLoc::Spill(off) => monoasm_arm64!(&mut self.jit,
                 mov x10, (off as i64 as u64);
                 sub x10, x29, x10;        // [x29 - off] (mirrors x86 [rbp - off])
-                ldr d0, [x10];
+                ldr d(dreg), [x10];
             ),
         }
     }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -548,6 +548,113 @@ impl Codegen {
         );
     }
 
+    /// `Integer#>>` by a variable amount. lhs (tagged) in Rdi (x4), shift amount
+    /// (tagged) in Rcx (x1); result tagged in Rdi. A negative shift means a left
+    /// shift, which overflows -> deopt. aarch64 twin of x86 `gen_shr`, but
+    /// without `lzcnt`/`select_page`: overflow is checked by shifting back, and
+    /// the cold (left-shift / >=64) blocks are laid out inline.
+    pub(crate) fn gen_shr(&mut self, deopt: &DestLabel) {
+        let shl = self.jit.label();
+        let after = self.jit.label();
+        let under = self.jit.label();
+        let cont = self.jit.label();
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            asr x1, x1, #1;            // untag shift amount (Rcx == x1)
+            cmp x1, #0;
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &shl); // negative -> left shift
+        monoasm_arm64!(&mut self.jit, cmp x1, #64;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &under);
+        monoasm_arm64!(&mut self.jit, asr x4, x4, x1;); // tagged sar (Rdi == x4)
+        self.jit.bind_label(after.clone());
+        monoasm_arm64!(&mut self.jit,
+            mov x9, #1;
+            orr x4, x4, x9;           // re-tag fixnum
+            b cont;
+        );
+        // left shift by -k (cold)
+        self.jit.bind_label(shl);
+        monoasm_arm64!(&mut self.jit, neg x1, x1; cmp x1, #64;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &deopt); // left >=64 -> overflow
+        monoasm_arm64!(&mut self.jit,
+            sub x4, x4, #1;           // strip tag -> 2n
+            lsl x9, x4, x1;           // 2n << k
+            asr x10, x9, x1;          // shift back
+            cmp x10, x4;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt); // overflow
+        monoasm_arm64!(&mut self.jit, mov x4, x9; b after;);
+        // right shift by >= 64 (cold): 0 if lhs >= 0, else -1
+        self.jit.bind_label(under);
+        self.a64_shift_under(&after);
+        self.jit.bind_label(cont);
+    }
+
+    /// `Integer#<<` by a variable amount. lhs (tagged) in Rdi (x4), shift amount
+    /// (tagged) in Rcx (x1); result tagged in Rdi. A left shift that overflows
+    /// the fixnum range deopts; a negative shift means a right shift. aarch64
+    /// twin of x86 `gen_shl` (shift-back overflow, inline cold blocks). Used for
+    /// both the literal- and register-lhs cases (recv is always loaded into Rdi
+    /// by the builtin), so x86's `gen_shl_lhs_imm` has no aarch64 counterpart.
+    pub(crate) fn gen_shl(&mut self, deopt: &DestLabel) {
+        let shr = self.jit.label();
+        let after = self.jit.label();
+        let under = self.jit.label();
+        let cont = self.jit.label();
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            asr x1, x1, #1;            // untag shift amount
+            cmp x1, #0;
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &shr); // negative -> right shift
+        monoasm_arm64!(&mut self.jit, cmp x1, #64;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &deopt); // left >=64 -> overflow
+        monoasm_arm64!(&mut self.jit,
+            sub x4, x4, #1;           // strip tag -> 2n
+            lsl x9, x4, x1;           // 2n << k
+            asr x10, x9, x1;          // shift back
+            cmp x10, x4;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt); // overflow
+        monoasm_arm64!(&mut self.jit, mov x4, x9;);
+        self.jit.bind_label(after.clone());
+        monoasm_arm64!(&mut self.jit,
+            mov x9, #1;
+            orr x4, x4, x9;           // re-tag fixnum
+            b cont;
+        );
+        // right shift by -k (cold)
+        self.jit.bind_label(shr);
+        monoasm_arm64!(&mut self.jit, neg x1, x1; cmp x1, #64;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &under);
+        monoasm_arm64!(&mut self.jit, asr x4, x4, x1; b after;);
+        // right shift by >= 64 (cold): 0 if lhs >= 0, else -1
+        self.jit.bind_label(under);
+        self.a64_shift_under(&after);
+        self.jit.bind_label(cont);
+    }
+
+    /// Shared cold tail for a shift-right by >= 64 bits: the tagged lhs is in
+    /// Rdi (x4); leave 0 (Value 0) for a non-negative lhs or -1 (Value -1) for a
+    /// negative one, then branch to `after` (which re-tags). Mirrors x86
+    /// `shift_under`.
+    fn a64_shift_under(&mut self, after: &DestLabel) {
+        let zero = self.jit.label();
+        monoasm_arm64!(&mut self.jit, cmp x4, #0;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &zero);
+        monoasm_arm64!(&mut self.jit,
+            mov x4, #0;
+            sub x4, x4, #1;           // -1 (sar of a negative number by >=64)
+            b after;
+        );
+        self.jit.bind_label(zero);
+        monoasm_arm64!(&mut self.jit,
+            mov x4, #0;
+            b after;
+        );
+    }
+
     /// Inlined `Integer#%` (general fixnum case). `a` (Rdi/x4) and `b` (Rsi/x3)
     /// are tagged; the floor-mod remainder is returned tagged in Rax (x0). b==0
     /// deopts with a `_divide_by_zero` marker. aarch64 twin of x86


### PR DESCRIPTION
Removes two aarch64 JIT-compile **bail** paths (`#[cfg(not(jit_x86))] return false`), so the affected methods JIT-compile instead of staying VM-interpreted. Both bailed wholesale on aarch64 before.

## 1. `Integer#%` / `Integer#**` with a Float rhs

Adds `gen_int_rem_if` (`rem_ff`: f64,f64 → f64) and `gen_int_pow_if` (`pow_ff`: f64,f64 → Value, possibly Complex) to `compile_stub.rs` — the same xmm-C-call shape as the already-ported `emit_cfunc_ff_f`: operands into d0/d1, `blr` the runtime fn (FP pool saved by xmm_save/restore, LR preserved), result d0→dst (rem) or Value in Rax (pow). FP loads use a new spill-aware `a64_fpr_into_d(src, dreg, base)` (generalizing `a64_fpr_into_d0`), so a spilled operand no longer bails here either.

## 2. `Integer#<<` / `Integer#>>` by a variable amount

x86's `gen_shr`/`gen_shl` use `lzcnt` (left-shift overflow guard) + `select_page` (cold blocks) — neither usable on aarch64. The port avoids both:
- overflow detected by **shifting the stripped value back and comparing** (same trick as `gen_shl_rhs_imm`) — no `clz`;
- cold (opposite-direction / `>=64`) blocks laid out **inline** (aarch64 can't branch to monoasm's far second page);
- left shift by `>=64` deopts conservatively; the `>=64` right-shift `0`/`-1` tail is a shared `a64_shift_under` helper.

aarch64 reuses `gen_shl` for the literal-lhs case (recv is already in Rdi; the shift-back check gains nothing from a constant lhs), so x86's `gen_shl_lhs_imm` has no aarch64 twin.

## Verification

- `JIT == VM(--no-jit) == CRuby` on `i % f` / `i ** f` (Float **and** Complex results).
- `JIT == VM` across an exhaustive shift matrix: lhs ∈ {±small, ±2^40, 2^62, 0} × shift ∈ −70..100 (both directions, the 63/64/65 boundaries); overflowing left shifts correctly **deopt**.
- `jit-log`: the previously-aborting hot blocks (`i % 2.5 + i ** 0.5`, a shift-heavy block) now compile with **0 bails**.
- Full `cargo nextest run`: **2216 passed, 1 skipped**.

### Note (out of scope)

While porting the shifts I found a **pre-existing interpreter bug**: monoruby's executor doesn't promote a variable-shift overflow to Bignum (`5 << 62` → a wrapped i64, not CRuby's Bignum). It's in `executor/op` (affects x86 and aarch64 equally, reproduces with these JIT changes reverted); this PR's JIT deopts to that same interpreter, so `JIT == VM` holds. Flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)