### PR TITLE
jit(aarch64): port loop recompile (RecompileDeopt with a loop position)

### DIFF
--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -504,6 +504,41 @@ pub(in crate::codegen) extern "C" fn jit_recompile_method(
     Some(Value::nil())
 }
 
+/// aarch64 loop recompile, called from the `RecompileDeopt` lowering
+/// (`compile_stub.rs`) when `position` is the loop pc. Re-runs `compile_partial`
+/// for the loop body and rewrites the loop's codeptr at `[pc + 8]`, so the next
+/// `loop_start` enters the freshly specialized loop.
+///
+/// Like [`jit_recompile_method`] it returns `Option<Value>` (`Some(nil)` on
+/// success, `None` on a recompile-time panic) and surfaces a panic as a Ruby
+/// `FatalError`: aarch64 can panic while emitting a large loop body (an
+/// out-of-range branch to a far deopt), exactly the case `jit_compile_loop`
+/// already catches for the initial loop JIT.
+#[cfg(not(jit_x86))]
+pub(in crate::codegen) extern "C" fn jit_recompile_loop(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+    reason: RecompileReason,
+) -> Option<Value> {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CODEGEN.with(|codegen| {
+            codegen
+                .borrow_mut()
+                .compile_partial(globals, lfp, pc, Some(reason));
+        });
+    }));
+    if result.is_err() {
+        CODEGEN.with(|codegen| codegen.borrow_mut().jit.finalize());
+        vm.set_error(MonorubyErr::fatal(
+            "internal error: JIT loop recompilation panicked.",
+        ));
+        return None;
+    }
+    Some(Value::nil())
+}
+
 #[cfg(jit_x86)]
 extern "C" fn jit_recompile_method_with_recovery(
     globals: &mut Globals,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -260,8 +260,9 @@ impl Codegen {
             // Basic-operator-redefinition guard: deopt if any BOP was redefined.
             AsmInst::CheckBOP { deopt } => self.emit_check_bop(&labels[deopt]),
             // Recompile-or-deopt point: both arches recompile the whole method
-            // once a small miss counter warms, then deopt. aarch64 has no loop
-            // or specialized recompiler yet, so those positions just deopt.
+            // (or loop body) once a small miss counter warms, then deopt.
+            // aarch64 has no specialized-frame recompiler yet (those go through
+            // RecompileDeoptSpecialized and just deopt).
             AsmInst::RecompileDeopt {
                 position,
                 deopt,

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -2331,11 +2331,11 @@ impl Codegen {
         );
     }
 
-    /// Recompile-or-deopt point. For a whole-method recompile (`position` =
-    /// None) this counter-gates a one-shot call to `jit_recompile_method`
-    /// (mirrors x86 `recompile_and_deopt`) and then deopts. For a loop-JIT
-    /// recompile point (`position` = Some) aarch64 has no loop recompiler yet,
-    /// so it just deopts.
+    /// Recompile-or-deopt point. Counter-gates a one-shot recompile, then falls
+    /// through to the deopt side exit. For a whole-method recompile (`position`
+    /// = None) it calls `jit_recompile_method`; for a loop-JIT recompile point
+    /// (`position` = Some loop-pc) it calls `jit_recompile_loop`. Mirrors x86
+    /// `recompile_and_deopt` / `jit_recompile_loop`.
     pub(in crate::codegen::jitgen) fn emit_recompile_deopt(
         &mut self,
         position: Option<BytecodePtr>,
@@ -2344,20 +2344,13 @@ impl Codegen {
         reason: RecompileReason,
     ) {
         let deopt = deopt.clone();
-        // aarch64 recompiles whole methods only; at a loop-JIT recompile point
-        // (`position` = Some) just deopt (no loop recompile yet).
-        if position.is_some() {
-            monoasm_arm64!(&mut self.jit, b deopt;);
-            return;
-        }
         // Counter-gated one-shot recompile, then fall through to the deopt side
         // exit (which undoes any loop sp-bump, writes back live values, and
-        // re-enters the VM). Mirrors x86 `recompile_and_deopt`: x19-x23 are
-        // AAPCS64 callee-saved so the C call preserves them, and the deopt does
-        // the value write-back; the caller-saved d2-d7 pool is saved around the
-        // call because that write-back reads it (d8-d15 are callee-saved).
+        // re-enters the VM). x19-x23 are AAPCS64 callee-saved so the C call
+        // preserves them, and the deopt does the value write-back; the
+        // caller-saved d2-d7 pool is saved around the call because that
+        // write-back reads it (d8-d15 are callee-saved).
         let counter = Box::into_raw(Box::new(COUNT_DEOPT_RECOMPILE)) as u64;
-        let f = crate::codegen::compiler::jit_recompile_method as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x9, (counter);
             ldr w11, [x9];
@@ -2379,7 +2372,23 @@ impl Codegen {
             mov x0, x19;                     // vm (Executor)
             mov x1, x20;                     // globals
             mov x2, x22;                     // lfp
-            mov x3, (reason as u64);
+        );
+        // Select the recompiler + set up its trailing args. Both take
+        // (vm, globals, lfp, ...) above; the loop variant adds the loop pc.
+        let f = if let Some(pc) = position {
+            let pc_ptr = pc.as_ptr() as u64;
+            monoasm_arm64!(&mut self.jit,
+                mov x3, (pc_ptr);            // loop pc
+                mov x4, (reason as u64);
+            );
+            crate::codegen::compiler::jit_recompile_loop as *const () as u64
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x3, (reason as u64);
+            );
+            crate::codegen::compiler::jit_recompile_method as *const () as u64
+        };
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;                          // -> Option<Value>: None (x0=0) = panic
@@ -2392,10 +2401,10 @@ impl Codegen {
             ldr d7, [sp, #(40)];
             add sp, sp, #(48);
         );
-        // Check the compiler's return value: `jit_recompile_method` caught a
-        // panic, set a Ruby `FatalError`, and returned None (x0 = 0). Branch to
-        // the error side-exit (write-back + raise via entry_raise) instead of
-        // resuming the interpreter. On success (x0 != 0) just deopt.
+        // Check the compiler's return value: the recompiler caught a panic, set
+        // a Ruby `FatalError`, and returned None (x0 = 0). Branch to the error
+        // side-exit (write-back + raise via entry_raise) instead of resuming the
+        // interpreter. On success (x0 != 0) just deopt.
         if let Some(error) = error {
             let error = error.clone();
             monoasm_arm64!(&mut self.jit,


### PR DESCRIPTION
## Summary

Ports **loop recompile** to the aarch64 JIT. The recompiler already handled whole methods, but a loop-JIT recompile point (`RecompileDeopt` whose `position` is the loop pc) just deopted. Now it recompiles the loop body too, mirroring x86 `jit_recompile_loop`.

- **`jit_recompile_loop`** (`not(jit_x86)`): re-runs `compile_partial` for the loop and rewrites the loop's codeptr at `[pc + 8]`, so the next `loop_start` enters the freshly specialized loop. Like `jit_recompile_method` it returns `Option<Value>` and surfaces a recompile-time panic as a Ruby `FatalError` (catch_unwind + re-arm the JIT region + `set_error`) — aarch64 can panic emitting a large loop body, exactly what `jit_compile_loop` already guards for the initial loop JIT.
- **`emit_recompile_deopt`**: the `position = Some` branch now counter-gates a call to `jit_recompile_loop` (loop pc in `x3`, reason in `x4`) instead of deopting immediately, reusing the same FP-save / return-value-check / error side-exit scaffolding as the method path.

Specialized-frame recompile (`RecompileDeoptSpecialized`) still just deopts; aarch64 does not register `specialized_info` yet (separate follow-up).

## Verification

Under **qemu-user (aarch64, JIT build)**:
- **Loop recompile fires and is correct** (confirmed with a temporary marker): a hot loop whose late branch calls a method cold at loop-JIT time recompiles with `reason=NotCached` → `2000005999993` (hand-checked); a late-assigned ivar recompiles with `reason=IvarIdNotFound` → `1999999000000`. `fib`/`poly`/`smoke` workloads unchanged.
- **Panic path**: a temporary forced panic inside the loop recompile raises `internal error: JIT loop recompilation panicked. (FatalError)` with the correct source location and exits cleanly (no SIGABRT). The injection was reverted.
- `cargo check` clean on both **aarch64-unknown-linux-gnu** and **x86-64**.

> Note: not run through the standard `cargo test` harness (compares against a system CRuby ≥ 4.0 not available on this x86 host; aarch64 execution is via qemu only).

https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb)_