### PR TITLE
fix(integer): promote Integer#<< value overflow to Bignum (#687)

### DIFF
--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -853,8 +853,13 @@ fn fold_shl_pos(lhs: i64, k: u64) -> Option<i64> {
         // when k > u32::MAX (handled by safe_int_shl as RangeError).
         return None;
     }
-    let result = lhs.checked_shl(k as u32)?;
-    if Value::is_i63(result) {
+    // `checked_shl` only guards the shift amount (k >= 64), not the value
+    // overflow `lhs << k` silently drops the high bits (e.g. `3 << 62`).
+    // Confirm the shift is lossless by shifting back before trusting it, then
+    // require the result to fit an i63 fixnum; otherwise fold is not possible.
+    let k = k as u32;
+    let result = lhs.wrapping_shl(k);
+    if result.wrapping_shr(k) == lhs && Value::is_i63(result) {
         Some(result)
     } else {
         None
@@ -2958,11 +2963,44 @@ r##"
             def shl_g; -1 << -100; end
             def shl_h; 1 << 62; end
             def shl_i; 1 << 100; end
+            # Regression (#687): the fold guard used `checked_shl`, which only
+            # catches a shift amount >= 64, so a value overflow wrapped into a
+            # bogus fixnum instead of promoting to Bignum.
+            def shl_ov_a; 3 << 62; end
+            def shl_ov_b; 4 << 62; end
+            def shl_ov_c; 5 << 62; end
+            def shl_ov_d; 7 << 62; end
+            def shl_ov_e; -5 << 62; end
+            def shl_ov_f; -256 << 62; end
+            def shl_ov_g; 16 << 60; end
+            def shl_ov_h; 8 << 61; end
+            def shl_ov_i; 123456789 << 40; end
         ";
         run_test_with_prelude(
             "[shr_a, shr_b, shr_c, shr_d, shr_e, shr_f, shr_g, shr_h, shr_i,
-              shl_a, shl_b, shl_c, shl_d, shl_e, shl_f, shl_g, shl_h, shl_i]",
+              shl_a, shl_b, shl_c, shl_d, shl_e, shl_f, shl_g, shl_h, shl_i,
+              shl_ov_a, shl_ov_b, shl_ov_c, shl_ov_d, shl_ov_e, shl_ov_f,
+              shl_ov_g, shl_ov_h, shl_ov_i]",
             prelude,
+        );
+    }
+
+    #[test]
+    fn integer_shl_overflow_promotes_to_bignum() {
+        // Regression (#687): `safe_int_shl` used `checked_shl` + a sign-preserve
+        // guard, which let a value overflow (shift amount < 64) wrap into i64
+        // instead of promoting to Bignum. The amounts are non-literal here so
+        // the runtime helper is exercised rather than constant folding.
+        run_test(
+            "
+            r = []
+            [0, 1, 2, 3, 4, 5, 7, 16, 100, 123456789,
+             -1, -4, -5, -256, 4611686018427387903, -4611686018427387904].each do |v|
+              [40, 60, 61, 62, 63, 64, 100].each do |s|
+                r << (v << s)
+              end
+            end
+            r",
         );
     }
 

--- a/monoruby/src/executor/op/binary_ops.rs
+++ b/monoruby/src/executor/op/binary_ops.rs
@@ -732,10 +732,17 @@ fn safe_int_shl(lhs: i64, rhs: u64, vm: &mut Executor) -> Option<Value> {
         }
     } else {
         let rhs = rhs as u32;
-        Some(match lhs.checked_shl(rhs) {
-            Some(res) if lhs.is_positive() == res.is_positive() => Value::integer(res),
-            _ => bigint_shl(&BigInt::from(lhs), rhs),
-        })
+        // `checked_shl` only fails when `rhs >= 64`; it silently drops the high
+        // bits on an i64 value overflow (e.g. `5 << 62`). Detect lost bits by
+        // shifting back: if `(lhs << rhs) >> rhs == lhs`, the result is exact and
+        // fits in i64; otherwise promote to Bignum.
+        if rhs < i64::BITS {
+            let res = lhs.wrapping_shl(rhs);
+            if res.wrapping_shr(rhs) == lhs {
+                return Some(Value::integer(res));
+            }
+        }
+        Some(bigint_shl(&BigInt::from(lhs), rhs))
     }
 }
 


### PR DESCRIPTION
Fixes #687.

## Problem

`Integer#<<` by an amount `< 64` wrapped into a bogus i64 fixnum instead of promoting to Bignum when the value overflowed:

| expression | before | CRuby |
|---|---|---|
| `5 << 62` | `4611686018427387904` | `23058430092136939520` |
| `-256 << 62` | `0` | `-1180591620717411303424` |
| `3 << 62` (const-fold) | `-4611686018427387904` | `13835058055282163712` |

## Root cause

Two helpers used `i64::checked_shl`, which only reports failure when the **shift amount** is `>= 64` — it silently drops the high bits on a **value** overflow:

- `safe_int_shl` (`executor/op/binary_ops.rs`) — the runtime path. Its `lhs.is_positive() == res.is_positive()` guard only catches sign-flipping overflows, missing cases like `5 << 62` (stays positive) and `-256 << 62` (wraps to 0).
- `fold_shl_pos` (`builtins/numeric/integer.rs`) — the JIT constant-fold path. Its `is_i63(result)` guard accidentally rejected most wrapped values, but a brute-force sweep found 207 inputs where the wrapped value still passed `is_i63`, yielding a wrong fold (e.g. `3 << 62`, `4 << 62`).

## Fix

Detect lost bits with a shift-back test — `(lhs << k) >> k == lhs` — in both helpers. Anything inexact (or, in the folder, not fitting an i63 fixnum) falls through to the Bignum path.

## Testing

- New runtime-path regression test `integer_shl_overflow_promotes_to_bignum`.
- Extended `integer_shift_constant_folding` with the overflow cases.
- Verified against CRuby across an exhaustive sweep of operands × shift amounts (0–70, plus large) on **both** the runtime and constant-fold paths — all match.
- Full `numeric` suite (128 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)