### PR TITLE
jit(aarch64): specialized recompile via single-BL patch

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -888,6 +888,28 @@ impl Codegen {
     ) -> Option<(Option<CodePtr>, DestLabel)> {
         self.return_addr_table.get(&return_addr).cloned()
     }
+
+    /// aarch64 specialized recompile: overwrite the single 4-byte `bl entry`
+    /// instruction at `patch_point` (the `SpecializedCall` site, bound just
+    /// before the `bl` in `a64_do_specialized_call`) so it now branches into
+    /// the freshly compiled body at `entry`. The twin of
+    /// [`Self::patch_return_to_deopt`] but writing a `BL` (`0x9400_0000 |
+    /// imm26`) instead of a `B`: same ±128 MiB range and the same
+    /// writable / I-cache-synchronize dance (AArch64 has no I/D coherence for
+    /// self-modifying code). The new `bl` keeps the same return continuation
+    /// (the next instruction), so the post-call frame teardown is unchanged.
+    #[cfg(all(jit, not(jit_x86)))]
+    fn patch_call_to_entry(&mut self, patch_point: CodePtr, entry: &DestLabel) {
+        self.jit.set_writable();
+        let dest = self.jit.get_label_address(entry);
+        let disp = dest - patch_point;
+        let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
+        let word = 0x9400_0000u32 | imm26;
+        // SAFETY: `patch_point` is the 4-byte-aligned address of the `bl`
+        // emitted by `a64_do_specialized_call`.
+        unsafe { (patch_point.as_ptr() as *mut u32).write(word) };
+        self.jit.set_executable();
+    }
 }
 
 #[repr(C)]

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -420,6 +420,43 @@ impl Codegen {
         self.jit.apply_jmp_patch_address(patch_point, &entry);
         Some(())
     }
+
+    /// aarch64 specialized recompile. Mirrors the x86 variant, but installs the
+    /// recompiled body by rewriting the `SpecializedCall` site's `bl` to it
+    /// (aarch64 has no `apply_jmp_patch_address`, but it can patch a single
+    /// branch instruction — see [`Codegen::patch_call_to_entry`]). Bails
+    /// (leaving the old specialized body in place) if the lowering bails.
+    #[cfg(not(jit_x86))]
+    fn recompile_specialized(
+        &mut self,
+        globals: &mut Globals,
+        idx: usize,
+        reason: RecompileReason,
+    ) -> Option<()> {
+        let (iseq_id, self_class, patch_point) = self.specialized_info[idx].clone();
+        let entry = self.jit.label();
+        let class_version = self.class_version();
+        let compiled = self
+            .compile(
+                globals,
+                iseq_id,
+                self_class,
+                None,
+                entry.clone(),
+                class_version,
+                Some(reason),
+            )
+            .is_some();
+        // Re-arm executable permission / flush the I-cache for the freshly
+        // emitted body (and resolve `entry`'s address) before patching.
+        self.jit.finalize();
+        if !compiled {
+            return None;
+        }
+        let patch_point = self.jit.get_label_address(&patch_point);
+        self.patch_call_to_entry(patch_point, &entry);
+        Some(())
+    }
 }
 
 //
@@ -437,6 +474,33 @@ extern "C" fn jit_recompile_specialized(
             .borrow_mut()
             .recompile_specialized(globals, idx, reason);
     });
+}
+
+/// aarch64 specialized recompile entry, called from the
+/// `GuardClassVersionSpecialized` / `RecompileDeoptSpecialized` lowering
+/// (`compile_stub.rs`). Unlike x86 this catches a recompile-time panic so it
+/// cannot abort across the `extern "C"` boundary (aarch64 can panic emitting a
+/// large body); on panic it re-arms the JIT region as executable (mirrors
+/// `jit_compile_loop`) and returns — the generated code then just deopts to the
+/// interpreter (the old specialized body stays installed). No `Option<Value>`
+/// is returned: there is no FatalError path here, matching x86's recompile
+/// behavior (which is best-effort and falls back to deopt on failure).
+#[cfg(not(jit_x86))]
+pub(in crate::codegen) extern "C" fn jit_recompile_specialized(
+    globals: &mut Globals,
+    idx: usize,
+    reason: RecompileReason,
+) {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CODEGEN.with(|codegen| {
+            codegen
+                .borrow_mut()
+                .recompile_specialized(globals, idx, reason);
+        });
+    }));
+    if result.is_err() {
+        CODEGEN.with(|codegen| codegen.borrow_mut().jit.finalize());
+    }
 }
 
 pub(in crate::codegen) extern "C" fn jit_compile_patch(

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -261,8 +261,8 @@ impl Codegen {
             AsmInst::CheckBOP { deopt } => self.emit_check_bop(&labels[deopt]),
             // Recompile-or-deopt point: both arches recompile the whole method
             // (or loop body) once a small miss counter warms, then deopt.
-            // aarch64 has no specialized-frame recompiler yet (those go through
-            // RecompileDeoptSpecialized and just deopt).
+            // (Specialized frames recompile via RecompileDeoptSpecialized /
+            // GuardClassVersionSpecialized in the per-arch lowering.)
             AsmInst::RecompileDeopt {
                 position,
                 deopt,

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -82,14 +82,28 @@ impl Codegen {
         // the `SpecializedCall` sites in the main body can branch into them.
         // This must run *before* binding `entry_label`, so entering the main
         // body does not fall through the specialized bodies (mirrors the x86
-        // `gen_machine_code` recursion). aarch64 ignores the specialized
-        // recompile index — its `GuardClassVersionSpecialized` /
-        // `RecompileDeoptSpecialized` degrade to a plain deopt — so, unlike x86,
-        // we do not register `self.specialized_info`; the `SpecializedCall`
-        // lowering binds each call-site patch point itself.
-        for info_entry in std::mem::take(&mut frame.specialized_methods) {
-            let entry = frame.resolve_label(&mut self.jit, info_entry.entry);
-            if !self.a64_gen_machine_code(info_entry.info, store, entry, class_version.clone()) {
+        // `gen_machine_code` recursion). For each direct specialized child of
+        // the outermost frame, register `(iseq, self_class, patch_point)` in
+        // `self.specialized_info` (mirrors x86) so a later
+        // `GuardClassVersionSpecialized` / `RecompileDeoptSpecialized` can
+        // recompile it and rewrite the `SpecializedCall` site's `bl`. The
+        // `patch_point` label is bound at that `bl` by `a64_do_specialized_call`.
+        for crate::codegen::jitgen::context::SpecializeInfo {
+            entry: specialized_entry,
+            info: specialized_info,
+            patch_point,
+        } in std::mem::take(&mut frame.specialized_methods)
+        {
+            if !frame.is_specialized() {
+                let patch_point = frame.resolve_label(&mut self.jit, patch_point.unwrap());
+                self.specialized_info.push((
+                    specialized_info.iseq_id,
+                    specialized_info.self_class,
+                    patch_point,
+                ));
+            }
+            let entry = frame.resolve_label(&mut self.jit, specialized_entry);
+            if !self.a64_gen_machine_code(specialized_info, store, entry, class_version.clone()) {
                 return false;
             }
         }
@@ -153,6 +167,13 @@ impl Codegen {
             ) {
                 return false;
             }
+        }
+
+        // Advance the specialized-recompile base past this compilation's
+        // entries, so the next compilation's local `idx` maps to fresh
+        // `specialized_info` slots (mirrors x86 `gen_machine_code`).
+        if !frame.is_specialized() {
+            self.specialized_base = self.specialized_info.len();
         }
 
         // Dump the generated A64 machine code, mirroring x86's `gen_machine_code`
@@ -2571,6 +2592,39 @@ impl Codegen {
         );
     }
 
+    /// Emit the FP-pool-preserving C call to
+    /// `jit_recompile_specialized(globals, idx, reason)`. The caller-saved
+    /// d2-d7 pool is saved around the call because the following deopt's
+    /// write-back reads it (d8-d15 are callee-saved); x19-x23 are AAPCS64
+    /// callee-saved so the VM globals survive. `global_idx` is the resolved
+    /// `specialized_base + idx` slot in `specialized_info`.
+    fn a64_call_recompile_specialized(&mut self, global_idx: usize, reason: RecompileReason) {
+        let f = crate::codegen::compiler::jit_recompile_specialized as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(48);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            mov x0, x20;                  // globals
+            mov x1, (global_idx as u64);  // specialized_info index
+            mov x2, (reason as u64);      // RecompileReason
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            add sp, sp, #(48);
+        );
+    }
+
     /// The call itself. aarch64 has no runtime branch patching, so the `evict`
     /// return-address patch point is not registered (class-version guards cover
     /// the staleness it would otherwise catch); the x86-only params are unused.
@@ -4734,19 +4788,45 @@ impl Codegen {
             AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
                 self.a64_store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
             }
-            // Inline-cache class-version guard. aarch64 has no recompiler, so
-            // both the specialized guard and the recompile-or-deopt point
-            // degrade to a plain deopt (sound — the global class-version
-            // compare conservatively deopts on any class change since compile).
-            AsmInst::GuardClassVersionSpecialized { idx: _, deopt } => {
-                self.a64_guard_class_version(&labels[deopt]);
+            // Specialized class-version guard: on a version mismatch, recompile
+            // the specialized body (rewriting its `SpecializedCall` `bl`) then
+            // deopt. Mirrors x86 `guard_class_version_specialized` (no counter —
+            // the recompile bakes in the new version, so it won't re-fire).
+            AsmInst::GuardClassVersionSpecialized { idx, deopt } => {
+                let global_idx = self.specialized_base + idx;
+                let deopt = labels[deopt].clone();
+                let miss = self.jit.label();
+                let done = self.jit.label();
+                self.a64_guard_class_version(&miss); // mismatch -> miss
+                monoasm_arm64!(&mut self.jit, b done;); // match -> continue
+                self.jit.bind_label(miss.clone());
+                self.a64_call_recompile_specialized(
+                    global_idx,
+                    RecompileReason::ClassVersionGuardFailed,
+                );
+                monoasm_arm64!(&mut self.jit, b deopt;);
+                self.jit.bind_label(done);
             }
-            AsmInst::RecompileDeoptSpecialized {
-                idx: _,
-                deopt,
-                reason: _,
-            } => {
-                self.emit_deopt(&labels[deopt]);
+            // Counter-gated specialized recompile-or-deopt point (mirrors x86
+            // `recompile_and_deopt_specialized`).
+            AsmInst::RecompileDeoptSpecialized { idx, deopt, reason } => {
+                let global_idx = self.specialized_base + idx;
+                let deopt = labels[deopt].clone();
+                let counter =
+                    Box::into_raw(Box::new(COUNT_DEOPT_RECOMPILE_SPECIALIZED)) as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (counter);
+                    ldr w11, [x9];
+                    cmp w11, #0;
+                );
+                self.jit.bcond_label(monoasm::Cond::Le, &deopt); // <= 0 -> deopt
+                monoasm_arm64!(&mut self.jit,
+                    sub w11, w11, #1;
+                    str w11, [x9];
+                    cbnz w11, deopt;                 // not yet exhausted -> deopt
+                );
+                self.a64_call_recompile_specialized(global_idx, reason);
+                monoasm_arm64!(&mut self.jit, b deopt;);
             }
             // Direct call into an inlined method entry, with the return-address
             // patch point recorded for BOP-redefinition eviction.


### PR DESCRIPTION
> Rebased onto `darwin` (the single specialized-recompile commit) now that #688 has merged. Supersedes the closed draft #689, whose base branch (`claude/aarch64-loop-recompile`) was deleted on merge and could not be reopened.

## Summary

Ports **specialized-frame recompile** to the aarch64 JIT. `RecompileDeoptSpecialized` / `GuardClassVersionSpecialized` previously just deopted (degraded). This uses the single-branch-instruction patch capability aarch64 already has for eviction (`patch_return_to_deopt`), **not** an indirect-dispatch redesign.

- **`patch_call_to_entry`** (`codegen.rs`, `not(jit_x86)`): the `BL` twin of `patch_return_to_deopt` — overwrites the `SpecializedCall` site's `bl` (the `patch_point` bound in `a64_do_specialized_call`) so it branches into a freshly compiled body, with the same `set_writable` / I-cache-sync dance.
- **`recompile_specialized` + `jit_recompile_specialized`** (`compiler.rs`, `not(jit_x86)`): mirror the x86 helpers; install the recompiled body by patching the `bl` instead of `apply_jmp_patch_address`. `jit_recompile_specialized` additionally `catch_unwind`s (aarch64 can panic emitting a large body) and on panic re-arms the JIT region and falls back to deopt — best-effort, matching x86's deopt-on-failure (no FatalError path here).
- **`a64_gen_machine_code`** now registers `specialized_info` (iseq / self_class / patch_point) and advances `specialized_base`, mirroring x86 `gen_machine_code`.
- The two specialized lowerings now recompile: `GuardClassVersionSpecialized` does the version compare and, on miss, recompiles (no counter — the recompile bakes in the new version) then deopts; `RecompileDeoptSpecialized` counter-gates (`COUNT_DEOPT_RECOMPILE_SPECIALIZED`) then recompiles + deopts. Shared `a64_call_recompile_specialized` helper.

## Verification

- ✅ `cargo build` clean on **aarch64-darwin** (Apple Silicon), no new warnings; x86 path unchanged (all new code is `not(jit_x86)`).
- ✅ **Full `cargo nextest` suite on real aarch64 hardware: 2217 / 2217 passed, 1 skipped.** This includes the `redefine_*`, `polymorphic*`, and `forwarding_specialized_*` suites (the class-version-change / specialization paths this PR touches), all compared against CRuby — exactly the hardware validation the original draft was waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
