### PR TITLE
jit(aarch64): honor --no-jit in gen_wrapper (gate method JIT trigger)

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/wrapper.rs
+++ b/monoruby/src/codegen/arch/aarch64/wrapper.rs
@@ -11,6 +11,8 @@ impl Codegen {
     /// vm-stub `b vm_entry` (x86 `gen_vm_stub`). TODO(aarch64): other
     /// FuncKinds (Builtin/AttrReader/ConstReturn/…).
     pub(crate) fn gen_wrapper(&mut self, globals: &Globals, fid: FuncId) -> DestLabel {
+        #[cfg(jit)]
+        let no_jit = globals.no_jit;
         let entry = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             entry:
@@ -32,7 +34,15 @@ impl Codegen {
                 // x19..x23 are callee-saved across the `extern "C"` call; LR is
                 // saved across `blr`.
                 #[cfg(jit)]
-                {
+                if no_jit {
+                    // `--no-jit`: never install the JIT trigger; stay in the VM
+                    // (mirrors x86 `gen_wrapper` emitting `gen_vm_stub`). Without
+                    // this gate the method JIT — and its class-version recompile
+                    // path — fires regardless of the flag.
+                    monoasm_arm64!(&mut self.jit,
+                        b vm_entry;
+                    );
+                } else {
                     let counter_addr = Box::into_raw(Box::new(COUNT_START_COMPILE)) as u64;
                     let jit_slot = Box::into_raw(Box::new(0u64)) as u64;
                     let run_jit = self.jit.label();


### PR DESCRIPTION
## Summary

On aarch64, `--no-jit` did not actually disable method JIT. The per-method `gen_wrapper` always installed the counter-based JIT-entry trigger for ISeq methods, ignoring `globals.no_jit` — so methods were still compiled, hit class-version guards, and recompiled. x86's `gen_wrapper` already gates this (`if !no_jit` → emit the VM stub).

This change gates the aarch64 trigger the same way: under `--no-jit`, emit `b vm_entry` so the method stays in the interpreter. Loop JIT was already gated (`jit_compile_loop` checks `no_jit`), so once the method path is gated no JIT code is generated and the class-version recompile path is never reached.

## Why this surfaced

Investigating #675 (core/class spec slow) on aarch64-darwin, both JIT and `--no-jit` were equally slow (~24s), which contradicted the issue's x86 data (JIT 34.9s vs `--no-jit` 0.55s). Profiling the `--no-jit` run showed `jit_recompile_method` → `recompile_method` → `a64_gen_machine_code` dominating — i.e. `--no-jit` was still JIT-compiling and recompile-thrashing.

## Effect

aarch64-darwin, the `core/class/subclasses_spec.rb` workload from #675 (16008 expectations):

| | before | after |
|---|---|---|
| `--no-jit` | 24.2s (still JIT + recompile thrash) | **0.65s** (VM only) |

0.65s matches x86's ~0.55s baseline. The JIT-enabled path is byte-for-byte unchanged (the `no_jit == false` branch is the original code).

## Scope

This only restores the `--no-jit` escape hatch on aarch64. The underlying recompile **thrashing under JIT** (#675 proper) is unchanged and still needs the recompile-hysteresis / version-reload mitigation (x86's `update_inline_cache` recovery covers the non-loop method path but not the loop-recompile path).

## Test

- Full `cargo nextest` suite on aarch64-darwin: **2217/2217 passed**, 1 skipped.
- `--no-jit` output verified against CRuby (fib / Enumerable chain / Struct / sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
