### PR TITLE
jit: deopt (not recompile) on method_missing-dispatched call sites

### DIFF
--- a/monoruby/src/bytecode.rs
+++ b/monoruby/src/bytecode.rs
@@ -1,5 +1,5 @@
 #[cfg(jit)]
-use crate::codegen::jitgen::trace_ir::MethodCacheEntry;
+use crate::codegen::jitgen::trace_ir::{MethodCache, MethodCacheEntry};
 
 use super::*;
 
@@ -356,15 +356,24 @@ impl BytecodePtr {
     }
 
     #[cfg(jit)]
-    pub(crate) fn method_cache(self) -> Option<MethodCacheEntry> {
-        if let Some(cached_class) = self.cached_class1() {
-            Some(MethodCacheEntry {
-                recv_class: cached_class,
-                func_id: self.cached_fid()?,
-                version: (self + 1).cached_version(),
-            })
+    pub(crate) fn method_cache_state(self) -> MethodCache {
+        if let Some(recv_class) = self.cached_class1() {
+            let version = (self + 1).cached_version();
+            match self.cached_fid() {
+                Some(func_id) => MethodCache::Cached(MethodCacheEntry {
+                    recv_class,
+                    func_id,
+                    version,
+                }),
+                // class cached but func_id slot is null → the VM resolved this
+                // call to `method_missing`.
+                None => MethodCache::MethodMissing {
+                    recv_class,
+                    version,
+                },
+            }
         } else {
-            None
+            MethodCache::None
         }
     }
 

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -70,6 +70,10 @@ enum CompileResult {
     Break(ReturnState),
     /// deoptimize and recompile.
     Recompile(RecompileReason),
+    /// deoptimize to the VM without recompiling (e.g. a `method_missing`
+    /// dispatch site, which the JIT cannot lower but the VM handles — recompiling
+    /// would loop forever on `NotCached`).
+    Deopt,
     /// internal error.
     #[allow(dead_code)]
     Abort,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -118,6 +118,11 @@ impl<'a> JitContext<'a> {
                     self.recompile_and_deopt(&mut state, &mut ir, reason);
                     return Ok(ir);
                 }
+                CompileResult::Deopt => {
+                    self.new_return(ReturnState::default());
+                    ir.deopt(&mut state);
+                    return Ok(ir);
+                }
                 CompileResult::Abort => {
                     #[cfg(feature = "emit-bc")]
                     self.dump_iseq();

--- a/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
+++ b/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
@@ -124,6 +124,7 @@ impl<'a> JitContext<'a> {
                 | CompileResult::Break(_)
                 | CompileResult::MethodReturn(_)
                 | CompileResult::Recompile(_)
+                | CompileResult::Deopt
                 | CompileResult::ExitLoop => {
                     liveness.join(&state);
                     return Ok(());

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -14,7 +14,7 @@ impl<'a> JitContext<'a> {
         state: &mut AbstractState,
         ir: &mut AsmIr,
         callid: CallSiteId,
-        cache: Option<MethodCacheEntry>,
+        cache: MethodCache,
     ) -> JitResult<CompileResult> {
         let callsite = &self.store[callid];
         let recv_class = state.class(callsite.recv);
@@ -27,23 +27,39 @@ impl<'a> JitContext<'a> {
             }
         } else {
             // here, recv_class is none.
-            if let Some(cache) = cache {
-                if cache.version != self.class_version() {
-                    // the inline method cache is invalid.
-                    let recv_class = cache.recv_class;
-                    let func_id = if let Some(fid) = self.jit_check_call(recv_class, callsite.name)
-                    {
-                        fid
+            match cache {
+                MethodCache::Cached(cache) => {
+                    if cache.version != self.class_version() {
+                        // the inline method cache is invalid.
+                        let recv_class = cache.recv_class;
+                        let func_id =
+                            if let Some(fid) = self.jit_check_call(recv_class, callsite.name) {
+                                fid
+                            } else {
+                                return Ok(CompileResult::Recompile(
+                                    RecompileReason::MethodNotFound,
+                                ));
+                            };
+                        (recv_class, func_id)
                     } else {
-                        return Ok(CompileResult::Recompile(RecompileReason::MethodNotFound));
-                    };
-                    (recv_class, func_id)
-                } else {
-                    // the inline method cache is valid.
-                    (cache.recv_class, cache.func_id)
+                        // the inline method cache is valid.
+                        (cache.recv_class, cache.func_id)
+                    }
                 }
-            } else {
-                return Ok(CompileResult::Recompile(RecompileReason::NotCached));
+                // The VM resolved this call to `method_missing` and the cached
+                // class version is still current. The JIT has no lowering for a
+                // method_missing dispatch, so plain-deopt to the VM here instead
+                // of requesting a recompile. A recompile would re-read the null
+                // fid → `NotCached` → recompile again, never stabilizing — the
+                // recompile-thrash that makes method_missing-heavy hot loops
+                // ~100x slower than the interpreter.
+                MethodCache::MethodMissing { version, .. } if version == self.class_version() => {
+                    return Ok(CompileResult::Deopt);
+                }
+                // No cache, or a stale method_missing cache (the resolution may
+                // have changed): fall back to the recompile-once path, which
+                // re-reads the cache after the VM warms it.
+                _ => return Ok(CompileResult::Recompile(RecompileReason::NotCached)),
             }
         };
         self.compile_method_call(state, ir, recv_class, None, func_id, callid, false)

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -59,6 +59,23 @@ impl std::cmp::PartialEq for MethodCacheEntry {
     }
 }
 
+/// State of a method call's inline cache, as read from the bytecode at JIT
+/// compile time.
+#[derive(Debug, Clone)]
+pub(crate) enum MethodCache {
+    /// Both the receiver class and the resolved func are cached.
+    Cached(MethodCacheEntry),
+    /// The receiver class is cached, but the call dispatches via
+    /// `method_missing` (the cached func_id slot is null). The VM handles this
+    /// fine; the JIT has no lowering for it, so it must plain-deopt here rather
+    /// than request a recompile (which would re-read the null fid → `NotCached`
+    /// → recompile, looping forever). `version` is the class version at the time
+    /// the VM populated the cache.
+    MethodMissing { recv_class: ClassId, version: u32 },
+    /// Nothing cached yet (the call site has not been executed by the VM).
+    None,
+}
+
 ///
 /// IR for JIT compiler.
 ///
@@ -182,7 +199,7 @@ pub(crate) enum TraceIr {
     MethodCall {
         _polymorphic: bool,
         callid: CallSiteId,
-        cache: Option<MethodCacheEntry>,
+        cache: MethodCache,
     },
 
     /// return(%src)
@@ -415,11 +432,7 @@ impl TraceIr {
                         1 => true,
                         _ => unreachable!(),
                     };
-                    let cache = if let Some(cache) = pc.method_cache() {
-                        Some(cache)
-                    } else {
-                        None
-                    };
+                    let cache = pc.method_cache_state();
                     TraceIr::MethodCall {
                         _polymorphic: polymorphic,
                         callid,
@@ -982,20 +995,21 @@ impl TraceIr {
                 let CallSiteInfo { recv, dst, .. } = callsite;
                 let s = callsite.format_args();
                 let op1 = format!("{} = {:?}.{name}{s}", ret_str(*dst), recv);
+                let (cache_class, cache_fid) = match &cache {
+                    MethodCache::Cached(entry) => {
+                        (Some(entry.recv_class), format!("{:?}", entry.func_id))
+                    }
+                    MethodCache::MethodMissing { recv_class, .. } => {
+                        (Some(*recv_class), "method_missing".to_string())
+                    }
+                    MethodCache::None => (None, "-".to_string()),
+                };
                 format!(
                     "{:36} {}[{}] {}",
                     op1,
                     if polymorphic { "POLYMORPHIC " } else { "" },
-                    store.debug_class_name(if let Some(entry) = &cache {
-                        Some(entry.recv_class)
-                    } else {
-                        None
-                    }),
-                    if let Some(entry) = cache {
-                        format!("{:?}", entry.func_id)
-                    } else {
-                        "-".to_string()
-                    }
+                    store.debug_class_name(cache_class),
+                    cache_fid
                 )
             }
             TraceIr::Yield { callid } => {

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -2506,3 +2506,30 @@ fn forwarding_super_block_passthrough() {
         "##,
     );
 }
+
+#[test]
+fn method_missing_in_hot_loop() {
+    // A call site that dispatches via `method_missing` caches the receiver
+    // class with a null func_id. The JIT must plain-deopt such a site (the VM
+    // handles method_missing) rather than request a recompile — otherwise the
+    // hot method recompiles on every warm-up cycle (`NotCached`) forever and
+    // never stabilizes. This drives the call through a BasicObject proxy's
+    // method_missing 100×, well past the JIT threshold, then checks the result.
+    run_test_with_prelude(
+        r##"
+        res = 0
+        d = Proxy.new(Target.new)
+        200.times { res += d.value_plus(40) }
+        res
+        "##,
+        r##"
+        class Target
+          def value_plus(n) = 2 + n
+        end
+        class Proxy < BasicObject
+          def initialize(t) = @t = t
+          def method_missing(name, *args) = @t.__send__(name, *args)
+        end
+        "##,
+    );
+}


### PR DESCRIPTION
## Summary

A method call that dispatches via `method_missing` was a permanent JIT recompile-thrash source. This makes the JIT emit a plain **deopt** for such sites instead of requesting a recompile.

### Root cause

When a call resolves through `method_missing`, the VM caches the call site with the **receiver class set but a null func_id** (`save_cache` writes `FUNCID=0`; `vm_send` reads a null `FUNCID` → `method_missing`). The JIT dropped that case: `BytecodePtr::method_cache()` used `func_id: self.cached_fid()?`, so a null fid made the whole entry read as `None`, and `method_call` returned `Recompile(RecompileReason::NotCached)`.

Since the JIT has no lowering for a method_missing dispatch, the recompiled body re-reads the null fid → `NotCached` → recompiles again. Every `COUNT_DEOPT_RECOMPILE` (=10) deopts it recompiles the whole method afresh; in between it deopts to the VM. It **never stabilizes**: a hot loop calling through a `method_missing` proxy does **O(N) full-method recompiles** and runs ~100× slower than the interpreter.

This is the dominant JIT cost in #675's `Class.new.should.is_a?` workload — mspec's matcher dispatches `is_a?` through `SpecPositiveOperatorMatcher#method_missing`.

### Fix

Surface the method_missing cache case to the compiler and, when the cached class version is still current, emit a plain deopt (the VM handles method_missing) instead of a recompile. Arch-neutral — both x86 and aarch64 benefit.

- `MethodCache` enum (`trace_ir.rs`): `Cached` / `MethodMissing { recv_class, version }` / `None`; `method_cache()` → `method_cache_state()`.
- `method_call` (`compile/method_call.rs`): valid `MethodMissing` → new `CompileResult::Deopt`; stale/absent cache → `Recompile(NotCached)` as before.
- `CompileResult::Deopt` (`jitgen.rs`): handled in the compile loop like `Recompile` but emits `ir.deopt` (no recompile); added to the liveness and loop-analysis matches.

### Effect

aarch64-darwin, a `method_missing` proxy called in a hot loop:

| | recompiles | time |
|---|---|---|
| before | 78 (N=16k) | ~1.0s |
| after | **0** | **~0.19s** (N=32k) |

### Test

- New regression test `method_missing_in_hot_loop` (drives a BasicObject proxy's method_missing 200× past the JIT threshold, output compared to CRuby).
- Full `cargo nextest` suite on aarch64-darwin: **2218/2218 passed**, 1 skipped.

### Scope

This fixes the JIT recompile-thrash only. #675's `Class.new.should` workload also has a **separate, VM-level super-linear cost** — GC of the mass-created anonymous classes (a class-reuse variant is flat; `--no-gc` removes the cost) — which this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
