### PR TITLE
jit: share the specialized inlined-frame AsmInst family in compile_asmir

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -891,7 +891,7 @@ impl Codegen {
 
     /// aarch64 specialized recompile: overwrite the single 4-byte `bl entry`
     /// instruction at `patch_point` (the `SpecializedCall` site, bound just
-    /// before the `bl` in `a64_do_specialized_call`) so it now branches into
+    /// before the `bl` in `do_specialized_call`) so it now branches into
     /// the freshly compiled body at `entry`. The twin of
     /// [`Self::patch_return_to_deopt`] but writing a `BL` (`0x9400_0000 |
     /// imm26`) instead of a `B`: same ±128 MiB range and the same
@@ -906,7 +906,7 @@ impl Codegen {
         let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
         let word = 0x9400_0000u32 | imm26;
         // SAFETY: `patch_point` is the 4-byte-aligned address of the `bl`
-        // emitted by `a64_do_specialized_call`.
+        // emitted by `do_specialized_call`.
         unsafe { (patch_point.as_ptr() as *mut u32).write(word) };
         self.jit.set_executable();
     }

--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -29,7 +29,7 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn compile_asmir_arch(
         &mut self,
         store: &Store,
-        frame: &mut AsmInfo,
+        _frame: &mut AsmInfo,
         labels: &SideExitLabels,
         inst: AsmInst,
         class_version: DestLabel,
@@ -145,7 +145,15 @@ impl Codegen {
             | AsmInst::Retry(..)
             | AsmInst::Redo(..)
             | AsmInst::EnsureEnd
-            | AsmInst::Yield { .. } => {
+            | AsmInst::Yield { .. }
+            | AsmInst::MethodRetSpecialized { .. }
+            | AsmInst::BlockBreakSpecialized { .. }
+            | AsmInst::SetupYieldFrame { .. }
+            | AsmInst::SpecializedCall { .. }
+            | AsmInst::SpecializedYield { .. }
+            | AsmInst::LoadDynVarSpecialized { .. }
+            | AsmInst::StoreDynVarSpecialized { .. }
+            | AsmInst::Inline(..) => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
             AsmInst::Unreachable => {
@@ -195,39 +203,6 @@ impl Codegen {
                 self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
 
-            AsmInst::MethodRetSpecialized { rbp_offset } => {
-                self.method_return_specialized(rbp_offset.unwrap_concrete());
-            }
-            AsmInst::BlockBreakSpecialized { rbp_offset } => {
-                self.method_return_specialized(rbp_offset.unwrap_concrete());
-            }
-            AsmInst::SetupYieldFrame { meta, outer } => {
-                self.setup_yield_frame(meta, outer);
-            }
-            AsmInst::SpecializedCall {
-                entry,
-                patch_point,
-                evict,
-            } => {
-                let patch_point =
-                    patch_point.map(|label| frame.resolve_label(&mut self.jit, label));
-                let entry_label = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.do_specialized_call(entry_label, patch_point);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
-            }
-            AsmInst::SpecializedYield { entry, evict } => {
-                let block_entry = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.do_specialized_call(block_entry, None);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
-            }
-
-            AsmInst::LoadDynVarSpecialized { offset, reg } => {
-                self.load_dyn_var_specialized(offset.unwrap_concrete(), reg);
-            }
-            AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
-                self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
-            }
-
             AsmInst::ClassDef {
                 base,
                 superclass,
@@ -274,7 +249,6 @@ impl Codegen {
                     call rax;
                 );
             }
-            AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
         }
         true
     }
@@ -556,7 +530,7 @@ impl Codegen {
         true
     }
 
-    fn set_deopt_with_return_addr(
+    pub(super) fn set_deopt_with_return_addr(
         &mut self,
         return_addr: CodePtr,
         evict: AsmEvict,

--- a/monoruby/src/codegen/jitgen/asmir/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/method_call.rs
@@ -196,7 +196,7 @@ impl Codegen {
     /// ### destroy
     /// - rax, rdi
     ///
-    pub(super) fn setup_yield_frame(&mut self, meta: Meta, outer: usize) {
+    pub(in crate::codegen::jitgen) fn setup_yield_frame(&mut self, meta: Meta, outer: usize) {
         let outer = outer - 1;
         monoasm! { &mut self.jit,
             movq rdi, [rbx + (EXECUTOR_CFP)];
@@ -269,7 +269,7 @@ impl Codegen {
         return_addr
     }
 
-    pub(super) fn do_specialized_call(
+    pub(in crate::codegen::jitgen) fn do_specialized_call(
         &mut self,
         entry: DestLabel,
         patch_point: Option<DestLabel>,

--- a/monoruby/src/codegen/jitgen/asmir/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/variables.rs
@@ -297,7 +297,7 @@ impl Codegen {
         );
     }
 
-    pub(super) fn load_dyn_var_specialized(&mut self, offset: usize, reg: SlotId) {
+    pub(in crate::codegen::jitgen) fn load_dyn_var_specialized(&mut self, offset: usize, reg: SlotId) {
         monoasm!( &mut self.jit,
             movq rax, [rbp + ((offset - (BP_CFP + CFP_LFP) as usize - 8 - conv(reg) as usize))];
         );
@@ -311,7 +311,7 @@ impl Codegen {
         );
     }
 
-    pub(super) fn store_dyn_var_specialized(&mut self, offset: usize, dst: SlotId, src: GP) {
+    pub(in crate::codegen::jitgen) fn store_dyn_var_specialized(&mut self, offset: usize, dst: SlotId, src: GP) {
         monoasm!( &mut self.jit,
             movq [rbp + ((offset - (BP_CFP + CFP_LFP) as usize - 8 - conv(dst) as usize))], R(src as _);
         );

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -455,6 +455,48 @@ impl Codegen {
                 let evict_label = labels[evict].clone();
                 return self.emit_yield(callid, &labels[error], evict, &evict_label);
             }
+            // ---- Specialized inlined-frame family ------------------------------
+            // These lower an inlined callee / block frame. Each arm is identical
+            // on both arches and dispatches to a per-arch method of the same name
+            // (defined in `compile.rs` for x86, `compile_stub.rs` for aarch64).
+            // Clean return / block-break out of an inlined frame.
+            AsmInst::MethodRetSpecialized { rbp_offset }
+            | AsmInst::BlockBreakSpecialized { rbp_offset } => {
+                self.method_return_specialized(rbp_offset.unwrap_concrete());
+            }
+            // Outer-scope local access at a pre-resolved frame offset.
+            AsmInst::LoadDynVarSpecialized { offset, reg } => {
+                self.load_dyn_var_specialized(offset.unwrap_concrete(), reg);
+            }
+            AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
+                self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
+            }
+            // Direct call into an inlined method entry; the return-address patch
+            // point is recorded for BOP-redefinition eviction.
+            AsmInst::SpecializedCall {
+                entry,
+                patch_point,
+                evict,
+            } => {
+                let patch_point =
+                    patch_point.map(|label| frame.resolve_label(&mut self.jit, label));
+                let entry_label = frame.resolve_label(&mut self.jit, entry);
+                let return_addr = self.do_specialized_call(entry_label, patch_point);
+                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+            }
+            // Specialized `yield`: build the block frame, then branch into the
+            // inlined block entry (no patch point).
+            AsmInst::SetupYieldFrame { meta, outer } => {
+                self.setup_yield_frame(meta, outer);
+            }
+            AsmInst::SpecializedYield { entry, evict } => {
+                let entry_label = frame.resolve_label(&mut self.jit, entry);
+                let return_addr = self.do_specialized_call(entry_label, None);
+                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+            }
+            // Inlined builtin method body: the generator closure emits the
+            // arch-appropriate asm directly.
+            AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -1037,7 +1037,7 @@ impl Codegen {
     /// `method_return_specialized` (`lea rbp,[rbp+off]; leave; ret`): adjust the
     /// native frame base (x29), then run the standard epilogue. No error path —
     /// the value is already in the accumulator and the caller frame is JIT'd.
-    fn a64_method_ret_specialized(&mut self, rbp_offset: usize) {
+    pub(super) fn method_return_specialized(&mut self, rbp_offset: usize) {
         monoasm_arm64!(&mut self.jit,
             mov x10, (rbp_offset as u64);
             add x29, x29, x10;          // rbp += off (skip inlined frames)
@@ -1053,7 +1053,7 @@ impl Codegen {
     /// effective displacement can be negative, so it is materialized in a
     /// scratch and added to x29 (x9..x15 are reserved lowering temps, never a
     /// GP-mapped register).
-    fn a64_load_dyn_var_specialized(&mut self, offset: usize, reg: SlotId) {
+    pub(super) fn load_dyn_var_specialized(&mut self, offset: usize, reg: SlotId) {
         let e: i64 = offset as i64 - (BP_CFP + CFP_LFP) as i64 - 8 - conv(reg) as i64;
         let rax = GP::Rax.a64().0;
         monoasm_arm64!(&mut self.jit,
@@ -1064,9 +1064,9 @@ impl Codegen {
     }
 
     /// `StoreDynVarSpecialized`: outer-scope local <- src, symmetric to
-    /// `a64_load_dyn_var_specialized`. `src` maps to x0..x8 / x20..x23, never
+    /// `load_dyn_var_specialized`. `src` maps to x0..x8 / x20..x23, never
     /// the x10 scratch, so there is no clobber.
-    fn a64_store_dyn_var_specialized(&mut self, offset: usize, dst: SlotId, src: GP) {
+    pub(super) fn store_dyn_var_specialized(&mut self, offset: usize, dst: SlotId, src: GP) {
         let e: i64 = offset as i64 - (BP_CFP + CFP_LFP) as i64 - 8 - conv(dst) as i64;
         let s = src.a64().0;
         monoasm_arm64!(&mut self.jit,
@@ -1083,7 +1083,7 @@ impl Codegen {
     /// post-`bl` address (the return continuation); the caller records it via
     /// `set_deopt_with_return_addr` so `immediate_eviction` can later overwrite
     /// the continuation with a `B deopt` on BOP redefinition.
-    fn a64_do_specialized_call(
+    pub(super) fn do_specialized_call(
         &mut self,
         entry: DestLabel,
         patch_point: Option<DestLabel>,
@@ -1121,7 +1121,7 @@ impl Codegen {
     /// scratch, x11 = value scratch — none of which are GP-mapped). The cfp
     /// prev/lfp it also writes are immediately overwritten by the following
     /// `SpecializedYield`'s push_frame, exactly as on x86.
-    fn a64_setup_yield_frame(&mut self, meta: Meta, outer: usize) {
+    pub(super) fn setup_yield_frame(&mut self, meta: Meta, outer: usize) {
         let outer = outer - 1;
         monoasm_arm64!(&mut self.jit, ldr x9, [x19, #(EXECUTOR_CFP as u32)];);
         for _ in 0..outer {
@@ -2372,7 +2372,7 @@ impl Codegen {
     /// Register a specialized call's return address so `immediate_eviction` can
     /// find and patch it. Identical to the x86 helper (the tables are arch-
     /// neutral `#[cfg(jit)]` fields on `Codegen`).
-    fn set_deopt_with_return_addr(
+    pub(super) fn set_deopt_with_return_addr(
         &mut self,
         return_addr: CodePtr,
         evict: AsmEvict,
@@ -4675,7 +4675,7 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn compile_asmir_arch(
         &mut self,
         store: &Store,
-        frame: &mut AsmInfo,
+        _frame: &mut AsmInfo,
         labels: &SideExitLabels,
         inst: AsmInst,
         _class_version: DestLabel,
@@ -4685,18 +4685,6 @@ impl Codegen {
         // Anything still reaching the wildcard is not yet ported, so bail and
         // keep the method VM-interpreted.
         match inst {
-            // Clean return / block-break out of an inlined frame.
-            AsmInst::MethodRetSpecialized { rbp_offset }
-            | AsmInst::BlockBreakSpecialized { rbp_offset } => {
-                self.a64_method_ret_specialized(rbp_offset.unwrap_concrete());
-            }
-            // Outer-scope local access at a pre-resolved frame offset.
-            AsmInst::LoadDynVarSpecialized { offset, reg } => {
-                self.a64_load_dyn_var_specialized(offset.unwrap_concrete(), reg);
-            }
-            AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
-                self.a64_store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
-            }
             // Specialized class-version guard: on a version mismatch, recompile
             // the specialized body (rewriting its `SpecializedCall` `bl`) then
             // deopt. Mirrors x86 `guard_class_version_specialized` (no counter —
@@ -4736,29 +4724,6 @@ impl Codegen {
                 );
                 self.a64_call_recompile_specialized(global_idx, reason);
                 monoasm_arm64!(&mut self.jit, b deopt;);
-            }
-            // Direct call into an inlined method entry, with the return-address
-            // patch point recorded for BOP-redefinition eviction.
-            AsmInst::SpecializedCall {
-                entry,
-                patch_point,
-                evict,
-            } => {
-                let patch_point = patch_point.map(|l| frame.resolve_label(&mut self.jit, l));
-                let entry_label = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.a64_do_specialized_call(entry_label, patch_point);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
-            }
-            // Specialized `yield`: build the block frame, then branch into the
-            // inlined block entry (no patch_point — the eviction continuation is
-            // recorded the same way as SpecializedCall).
-            AsmInst::SetupYieldFrame { meta, outer } => {
-                self.a64_setup_yield_frame(meta, outer);
-            }
-            AsmInst::SpecializedYield { entry, evict } => {
-                let entry_label = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.a64_do_specialized_call(entry_label, None);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
             // Trap for statically-unreachable code: call the panicking helper.
             AsmInst::Unreachable => {
@@ -4817,11 +4782,6 @@ impl Codegen {
                 let offset = store[callee_fid].get_offset();
                 return self.a64_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
-            // Inlined builtin method body. The generator's closure emits the
-            // arch-appropriate asm directly (ported generators cfg-switch to
-            // aarch64). Un-ported generators never reach here: they register
-            // `noinline_gen`, which declines to inline. Mirrors x86.
-            AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
             _ => return false,
         }
         true


### PR DESCRIPTION
## Summary

Continues the `compile_asmir` sharing effort (`compile_shared.rs`): moves the **specialized inlined-frame dispatch family** out of the two per-arch `compile_asmir_arch` backends into the arch-neutral shared dispatcher. Each arm's body was already identical across x86 and aarch64 modulo the per-arch method name — the only blocker was naming/visibility.

### Shared now (7 arms)
- `MethodRetSpecialized` | `BlockBreakSpecialized`
- `LoadDynVarSpecialized` / `StoreDynVarSpecialized`
- `SpecializedCall` / `SpecializedYield`
- `SetupYieldFrame`
- `Inline`

### How
- aarch64 methods lose their `a64_` prefix to match the x86 names the shared arm calls (`method_return_specialized`, `load`/`store_dyn_var_specialized`, `do_specialized_call`, `setup_yield_frame`). The x86 twins are cfg-gated in a separate `mod compile`, never compiled together, so no collision.
- Visibility bumps so the `compile_shared` **sibling** module can reach them: `set_deopt_with_return_addr` (both arches) and the x86 submodule helpers in `compile/{method_call,variables}.rs` → `pub(in crate::codegen::jitgen)`. (The aarch64 twins live in the `compile` module **root**, already reachable via `pub(super)`.)
- The moved variants are added to the x86 backend's `unreachable!` guard; the aarch64 backend's `_ => return false` still covers unported variants.
- `compile_asmir_arch`'s now-unused `frame` param → `_frame` on both arches.

### Deferred
The remaining per-arch arms differ structurally (inline asm, or per-arch argument shaping / `bool` returns) and are left for follow-ups: `GuardClassVersionSpecialized`, `RecompileDeoptSpecialized`, `ClassDef`, `SingletonClassDef`, `SetArgumentsForwarded*`, `RestKw`, `Unreachable`.

## Verification

- `cargo check` clean on **aarch64-unknown-linux-gnu** and **x86-64**, no new warnings (the 4 pre-existing darwin warnings are unrelated).
- Release output regression **byte-identical on both arches** (x86 native + aarch64 qemu-user) across method-JIT / loop-JIT / specialization / inlining workloads: `poly`→1999999, `fib`→2178309, `loop3`→2000005999993, `loop4`→1999999000000, `spec2`→11000000, `spec5`→17600000, `mono`→7000000, plus a mixed smoke test. These exercise the specialized `SpecializedCall`/`Yield`/`MethodRet`/`DynVar`/`Inline` paths.

> Not run through `cargo test` (needs system CRuby ≥ 4.0, unavailable here). **Recommend running the JIT test suite on real aarch64 hardware before merge.**

https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb)_