### PR TITLE
jit: share ClassDef/SingletonClassDef, forwarded-args helper, Unreachable, RestKw in compile_asmir

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir/compile.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile.rs
@@ -153,14 +153,13 @@ impl Codegen {
             | AsmInst::SpecializedYield { .. }
             | AsmInst::LoadDynVarSpecialized { .. }
             | AsmInst::StoreDynVarSpecialized { .. }
-            | AsmInst::Inline(..) => {
+            | AsmInst::Inline(..)
+            | AsmInst::ClassDef { .. }
+            | AsmInst::SingletonClassDef { .. }
+            | AsmInst::SetArgumentsForwardedHelper { .. }
+            | AsmInst::Unreachable
+            | AsmInst::RestKw { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
-            }
-            AsmInst::Unreachable => {
-                monoasm!( &mut self.jit,
-                    movq rax, (unreachable);
-                    call rax;
-                );
             }
             AsmInst::GuardClassVersionSpecialized { idx, deopt } => {
                 let deopt = &labels[deopt];
@@ -198,57 +197,6 @@ impl Codegen {
                     deferred_src,
                 );
             }
-            AsmInst::SetArgumentsForwardedHelper { callid, callee_fid } => {
-                let offset = store[callee_fid].get_offset();
-                self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
-            }
-
-            AsmInst::ClassDef {
-                base,
-                superclass,
-                dst,
-                name,
-                func_id,
-                is_module,
-                using_xmm,
-                error,
-            } => {
-                self.class_def(
-                    base,
-                    superclass,
-                    dst,
-                    name,
-                    func_id,
-                    is_module,
-                    using_xmm,
-                    &labels[error],
-                );
-            }
-            AsmInst::SingletonClassDef {
-                base,
-                dst,
-                func_id,
-                using_xmm,
-                error,
-            } => {
-                self.singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
-            }
-            AsmInst::RestKw { rest_kw } => {
-                let data = self.jit.const_align8();
-                for (i, name) in rest_kw.into_iter() {
-                    self.jit.const_i32(name.get() as i32);
-                    self.jit.const_i32(i.0 as i32);
-                }
-                self.jit.const_i32(0);
-                self.jit.const_i32(0);
-
-                monoasm!( &mut self.jit,
-                    lea  rdi, [rip + data];
-                    movq rsi, r14;
-                    movq rax, (runtime::correct_rest_kw);
-                    call rax;
-                );
-            }
         }
         true
     }
@@ -256,6 +204,33 @@ impl Codegen {
     // ---- emission primitives (x86-64) -------------------------------------
     // Tiny arch-specific helpers the arch-neutral `compile_asmir` dispatcher
     // calls. The aarch64 twins live in `compile_stub.rs`.
+
+    /// Trap for statically-unreachable code: call the panicking helper.
+    pub(in crate::codegen::jitgen) fn emit_unreachable(&mut self) {
+        monoasm!( &mut self.jit,
+            movq rax, (unreachable);
+            call rax;
+        );
+    }
+
+    /// `**kwrest` fixup: build a const table of (name, slot) pairs and call
+    /// `correct_rest_kw(&table, lfp) -> kwrest Hash`.
+    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
+        let data = self.jit.const_align8();
+        for (i, name) in rest_kw.into_iter() {
+            self.jit.const_i32(name.get() as i32);
+            self.jit.const_i32(i.0 as i32);
+        }
+        self.jit.const_i32(0);
+        self.jit.const_i32(0);
+
+        monoasm!( &mut self.jit,
+            lea  rdi, [rip + data];
+            movq rsi, r14;
+            movq rax, (runtime::correct_rest_kw);
+            call rax;
+        );
+    }
 
     /// dst <- src (general-purpose register move; self-move is a no-op).
     pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
@@ -850,12 +825,12 @@ impl Codegen {
     /// ### destroy
     /// - caller save registers
     ///
-    fn jit_set_arguments_forwarded_helper(
+    pub(in crate::codegen::jitgen) fn jit_set_arguments_forwarded_helper(
         &mut self,
         callid: CallSiteId,
         fid: FuncId,
         offset: usize,
-    ) {
+    ) -> bool {
         monoasm! { &mut self.jit,
             movq rdi, rbx;
             movq rsi, r12;
@@ -867,6 +842,7 @@ impl Codegen {
             call rax;
             addq rsp, (offset);
         }
+        true
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile/definition.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile/definition.rs
@@ -14,7 +14,7 @@ impl Codegen {
     /// - dst: destination slot (SlotId).
     /// - name: class name (IdentId)
     /// ~~~
-    pub(super) fn class_def(
+    pub(in crate::codegen::jitgen) fn class_def(
         &mut self,
         base: Option<SlotId>,
         superclass: Option<SlotId>,
@@ -24,7 +24,7 @@ impl Codegen {
         is_module: bool,
         using_xmm: UsingXmm,
         error: &DestLabel,
-    ) {
+    ) -> bool {
         self.xmm_save(using_xmm);
         // r9 <- base: Option<Value>
         if let Some(base) = base {
@@ -54,16 +54,17 @@ impl Codegen {
         self.handle_error(&error);
         self.jit_class_def_sub(func_id, dst, error);
         self.xmm_restore(using_xmm);
+        true
     }
 
-    pub(super) fn singleton_class_def(
+    pub(in crate::codegen::jitgen) fn singleton_class_def(
         &mut self,
         base: SlotId,
         dst: Option<SlotId>,
         func_id: FuncId,
         using_xmm: UsingXmm,
         error: &DestLabel,
-    ) {
+    ) -> bool {
         self.xmm_save(using_xmm);
         monoasm! { &mut self.jit,
             movq rdx, [rbp - (rbp_local(base))];  // rdx <- name
@@ -75,6 +76,7 @@ impl Codegen {
         self.handle_error(&error);
         self.jit_class_def_sub(func_id, dst, error);
         self.xmm_restore(using_xmm);
+        true
     }
 
     pub(super) fn method_def(&mut self, name: IdentId, func_id: FuncId, using_xmm: UsingXmm) {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -497,6 +497,50 @@ impl Codegen {
             // Inlined builtin method body: the generator closure emits the
             // arch-appropriate asm directly.
             AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
+            // ---- Class/module definition + misc runtime-call ops --------------
+            // `class`/`module` (re)definition + body, and `class << obj`. aarch64
+            // bails on a live xmm pool reg / out-of-range frame offset.
+            AsmInst::ClassDef {
+                base,
+                superclass,
+                dst,
+                name,
+                func_id,
+                is_module,
+                using_xmm,
+                error,
+            } => {
+                return self.class_def(
+                    base,
+                    superclass,
+                    dst,
+                    name,
+                    func_id,
+                    is_module,
+                    using_xmm,
+                    &labels[error],
+                );
+            }
+            AsmInst::SingletonClassDef {
+                base,
+                dst,
+                func_id,
+                using_xmm,
+                error,
+            } => {
+                return self.singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
+            }
+            // Forwarding-trampoline helper frame setup (aarch64 bails on an
+            // out-of-range frame offset).
+            AsmInst::SetArgumentsForwardedHelper { callid, callee_fid } => {
+                let offset = store[callee_fid].get_offset();
+                return self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
+            }
+            // Trap for statically-unreachable code: call the panicking helper.
+            AsmInst::Unreachable => self.emit_unreachable(),
+            // `**kwrest` fixup: build a (name, slot) const table and call
+            // `correct_rest_kw(&table, lfp) -> kwrest Hash`.
+            AsmInst::RestKw { rest_kw } => self.emit_rest_kw(rest_kw),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_stub.rs
@@ -801,7 +801,7 @@ impl Codegen {
     /// `jit_forwarded_set_arguments` runtime helper (forwarding `g(x.., ...)`
     /// into a no-keyword iseq with opt/post/rest). Bails if the callee frame
     /// size exceeds a 12-bit immediate.
-    fn a64_set_arguments_forwarded_helper(
+    pub(in crate::codegen::jitgen) fn jit_set_arguments_forwarded_helper(
         &mut self,
         callid: CallSiteId,
         fid: FuncId,
@@ -1167,7 +1167,7 @@ impl Codegen {
     /// reads the listed slots and returns the `**kwrest` Hash in x0. Mirrors
     /// the x86 `RestKw` arm; the const-table emission is arch-neutral and the
     /// table address is taken with PC-relative `adr` (as in OptCase).
-    fn a64_rest_kw(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
+    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
         let data = self.jit.const_align8();
         for (i, name) in rest_kw.into_iter() {
             self.jit.const_i32(name.get() as i32);
@@ -1277,7 +1277,7 @@ impl Codegen {
     /// C calls and the class body all clobber d2..) and reloaded into the pool
     /// registers before each HandleError branch; bails only on an out-of-range
     /// frame slot.
-    fn a64_class_def(
+    pub(in crate::codegen::jitgen) fn class_def(
         &mut self,
         base: Option<SlotId>,
         superclass: Option<SlotId>,
@@ -1342,9 +1342,9 @@ impl Codegen {
         true
     }
 
-    /// `SingletonClassDef`: `class << obj; … end`. Like `a64_class_def` but the
+    /// `SingletonClassDef`: `class << obj; … end`. Like `class_def` but the
     /// class is obtained via `define_singleton_class(vm, globals, obj)`.
-    fn a64_singleton_class_def(
+    pub(in crate::codegen::jitgen) fn singleton_class_def(
         &mut self,
         base: SlotId,
         dst: Option<SlotId>,
@@ -1384,6 +1384,15 @@ impl Codegen {
     // Tiny arch-specific helpers the arch-neutral `compile_asmir` dispatcher
     // calls. The x86 twins live in `compile.rs`. Slot `s` lives at
     // `[lfp(x22) - s*8 - LFP_SELF]` (same addressing as the VM's `a64_op_ret`).
+
+    /// Trap for statically-unreachable code: call the panicking helper.
+    pub(in crate::codegen::jitgen) fn emit_unreachable(&mut self) {
+        let f = unreachable as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (f);
+            blr x9;
+        );
+    }
 
     /// dst <- src (general-purpose register move; self-move is a no-op).
     pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
@@ -4725,50 +4734,6 @@ impl Codegen {
                 self.a64_call_recompile_specialized(global_idx, reason);
                 monoasm_arm64!(&mut self.jit, b deopt;);
             }
-            // Trap for statically-unreachable code: call the panicking helper.
-            AsmInst::Unreachable => {
-                let f = unreachable as *const () as u64;
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (f);
-                    blr x9;
-                );
-            }
-            // `**kwrest` fixup: build a const table of (name, slot) pairs and
-            // call correct_rest_kw(&table, lfp) -> kwrest Hash (result in x0).
-            AsmInst::RestKw { rest_kw } => {
-                self.a64_rest_kw(rest_kw);
-            }
-            // `class`/`module` (re)definition + body, and `class << obj`.
-            AsmInst::ClassDef {
-                base,
-                superclass,
-                dst,
-                name,
-                func_id,
-                is_module,
-                using_xmm,
-                error,
-            } => {
-                return self.a64_class_def(
-                    base,
-                    superclass,
-                    dst,
-                    name,
-                    func_id,
-                    is_module,
-                    using_xmm,
-                    &labels[error],
-                );
-            }
-            AsmInst::SingletonClassDef {
-                base,
-                dst,
-                func_id,
-                using_xmm,
-                error,
-            } => {
-                return self.a64_singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
-            }
             AsmInst::SetArgumentsForwarded {
                 callid,
                 callee_fid,
@@ -4777,10 +4742,6 @@ impl Codegen {
             } => {
                 let offset = store[callee_fid].get_offset();
                 return self.a64_set_arguments_forwarded(callid, callee_fid, offset, deferred_src);
-            }
-            AsmInst::SetArgumentsForwardedHelper { callid, callee_fid } => {
-                let offset = store[callee_fid].get_offset();
-                return self.a64_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
             _ => return false,
         }


### PR DESCRIPTION
## Summary

Continues the `compile_asmir` sharing (`compile_shared.rs`), moving **five more** AsmInst arms out of the two per-arch `compile_asmir_arch` backends into the arch-neutral shared dispatcher. Implements the next candidates in the agreed order (1→2→3).

### 1. ClassDef / SingletonClassDef (bool-return unification)
x86 `class_def`/`singleton_class_def` now return `bool` (always `true`); aarch64 `a64_class_def`/`a64_singleton_class_def` drop the prefix to match. The shared arm `return`s the bool so the aarch64 bail (live xmm pool reg / out-of-range frame offset) propagates.

### 2. SetArgumentsForwardedHelper (bool-return unification)
x86 `jit_set_arguments_forwarded_helper` now returns `bool`; the aarch64 twin drops its `a64_` prefix to match.

### 3. Unreachable / RestKw (inline-asm → emit primitive)
The inline asm (x86 was inline in the arm; aarch64 had `a64_rest_kw`) is extracted into per-arch `emit_unreachable` / `emit_rest_kw` primitives, so the shared arm is a one-liner dispatch.

### Visibility / guard
The x86 helpers in `compile/definition.rs` and the new `emit_*` primitives are `pub(in crate::codegen::jitgen)` so the sibling `compile_shared` module can reach them; the aarch64 twins (in the `compile` module root) were bumped to match. Moved variants are added to the x86 backend's `unreachable!` guard; aarch64's `_ => return false` still covers unported ones.

### Deferred
`GuardClassVersionSpecialized`, `RecompileDeoptSpecialized`, `SetArgumentsForwarded` differ structurally (inline asm with per-arch recompile sequencing / per-arch argument shaping) and are left for follow-ups.

## Verification

- `cargo check` clean on **aarch64-unknown-linux-gnu** and **x86-64**, default and `--features emit-asm`, no new warnings (the 4 pre-existing darwin warnings are unrelated).
- Release output **byte-identical on both arches** (x86 native + aarch64 qemu-user) across the standard method/loop-JIT/specialization workloads (`poly`→1999999, `fib`→2178309, `loop3`→2000005999993, `loop4`→1999999000000, `spec2`→11000000, `spec5`→17600000, `mono`→7000000) **plus a new class-definition test** exercising `class` / `module` / `class << obj` / `include` / `**kwrest` → `12800` and `"hi"` on both. This directly exercises the moved ClassDef / SingletonClassDef / RestKw paths.

> Not run through `cargo test` (needs system CRuby ≥ 4.0, unavailable here). **Recommend running the JIT test suite on real aarch64 hardware before merge.**

https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpZDx5oL4Y6qgbRDuoVihb)_