### PR TITLE
jit: per-self-class warm-up profiler before specializing a method

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/wrapper.rs
+++ b/monoruby/src/codegen/arch/aarch64/wrapper.rs
@@ -63,10 +63,13 @@ impl Codegen {
                         cbz x11, compile_hot;    // hot → fall through to compile
                         b vm_entry;              // not hot yet → VM (long range)
                     compile_hot:
-                        // hot: jit_compile_patch(globals=x20, lfp=x22, slot)
+                        // hot enough overall: profile this self-class and
+                        // compile only if *it* (not just any class) is hot.
+                        // jit_profile_patch(globals=x20, lfp=x22, slot, &counter)
                         mov x0, x(GLOBALS.0);
                         mov x1, x(LFP.0);
                         mov x2, (jit_slot);      // where to publish the entry
+                        mov x3, (counter_addr);  // re-armed if this class isn't hot yet
                         str x30, [sp, #-16]!;    // save LR
                         // Reserve scratch below SP so the (deep) compile C-call
                         // can't trample the just-built callee Ruby frame, which
@@ -74,7 +77,7 @@ impl Codegen {
                         // (mirrors x86 `subq rsp, 4088`). 4080 fits a 12-bit imm
                         // and is 16-aligned.
                         sub sp, sp, #(4080);
-                        mov x9, (crate::codegen::compiler::jit_compile_patch as *const () as u64);
+                        mov x9, (crate::codegen::compiler::jit_profile_patch as *const () as u64);
                         blr x9;
                         add sp, sp, #(4080);
                         ldr x30, [sp], #16;      // restore LR
@@ -203,13 +206,16 @@ impl Codegen {
             cbz x11, compile_next;   // hot for this new class -> compile it
             b vm_entry;              // still cold -> VM
         compile_next:
-            // jit_compile_patch(globals=x20, lfp=x22, slot=next_slot)
+            // profile this new class; compile a specialization only once it is
+            // hot (re-arming next_counter otherwise — see jit_profile_patch).
+            // jit_profile_patch(globals=x20, lfp=x22, slot=next_slot, &next_counter)
             mov x0, x(GLOBALS.0);
             mov x1, x(LFP.0);
             mov x2, (next_slot);     // publish the new class's guard here
+            mov x3, (next_counter);  // re-armed if this class isn't hot yet
             str x30, [sp, #-16]!;    // save LR
             sub sp, sp, #(4080);     // scratch below the callee frame (see gen_wrapper)
-            mov x9, (crate::codegen::compiler::jit_compile_patch as *const () as u64);
+            mov x9, (crate::codegen::compiler::jit_profile_patch as *const () as u64);
             blr x9;
             add sp, sp, #(4080);
             ldr x30, [sp], #16;      // restore LR

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -41,11 +41,16 @@ impl Codegen {
             subl [rip + counter], 1;
             jne no_compile_exit;
 
+            // hot enough overall: profile this self-class and compile only if
+            // *it* (not just any class) is hot. jit_profile_patch re-arms the
+            // counter (rcx) when the class isn't hot yet, so the stub keeps
+            // interpreting and samples again later.
             movq rdi, r12;
             movq rsi, r14;
             movq rdx, (patch_point_addr.as_ptr());
+            lea  rcx, [rip + counter];
             subq rsp, 4088;
-            movq rax, (jit_compile_patch as *const ());
+            movq rax, (jit_profile_patch as *const ());
             call rax;
             addq rsp, 4088;
             jmp entry;
@@ -519,6 +524,42 @@ pub(in crate::codegen) extern "C" fn jit_compile_patch(
     //    #[cfg(feature = "jit-log")]
     //    eprintln!("[JIT] compile_patch panicked, falling back to VM interpreter");
     //}
+}
+
+/// Warm-up profiler hook: called from the JIT stub when its per-stub warm-up
+/// counter expires. Instead of unconditionally compiling for whatever receiver
+/// class happens to be current (which thrashes the compiler when each call has
+/// a fresh receiver class — e.g. `Class.new.foo` in a loop), it samples the
+/// current `self`'s class and only compiles once that class is hot.
+///
+/// If the class is not hot yet, it re-arms the stub's counter (`counter_addr`)
+/// so the stub keeps interpreting and samples again after another interval.
+///
+/// `entry_patch_point` is the stub's patch/slot pointer, forwarded verbatim to
+/// `compile_patch` (an entry to branch-patch on x86; an indirect-dispatch slot
+/// on aarch64).
+pub(in crate::codegen) extern "C" fn jit_profile_patch(
+    globals: &mut Globals,
+    lfp: Lfp,
+    entry_patch_point: monoasm::CodePtr,
+    counter_addr: *mut i32,
+) {
+    let self_class = lfp.self_val().class();
+    let func_id = lfp.func_id();
+    let iseq_id = globals.store[func_id].as_iseq();
+    if globals.store[iseq_id].profile_self_class(self_class) {
+        CODEGEN.with(|codegen| {
+            codegen
+                .borrow_mut()
+                .compile_patch(globals, lfp, entry_patch_point);
+        });
+    } else {
+        // Not hot yet — keep interpreting and sample again later.
+        // SAFETY: `counter_addr` is the address of the calling stub's own i32
+        // warm-up counter (a heap-leaked word on aarch64, a JIT data slot on
+        // x86); the stub passes its own counter's address.
+        unsafe { *counter_addr = COUNT_START_COMPILE };
+    }
 }
 
 #[cfg(jit_x86)]

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -154,6 +154,14 @@ pub struct ISeqInfo {
     /// (aarch64 installs JIT code via this slot, not x86 branch patching).
     #[cfg(not(jit_x86))]
     pub(super) jit_slot: HashMap<ClassId, u64>,
+    /// Bounded per-self-class warm-up profile used to decide *which* receiver
+    /// class is hot enough to specialize for. Without it, the first call that
+    /// trips the global warm-up counter compiles for whatever class happens to
+    /// be current — so a hot loop that calls a method on a fresh `Class.new`
+    /// object every iteration compiles the method once per (singleton-class of
+    /// each) class. Capped so transient classes evict each other and never
+    /// accumulate. See `profile_self_class`.
+    pub(super) jit_class_profile: Vec<(ClassId, u32)>,
     pub(super) jit_invalidated: bool,
     ///
     /// Basic block information.
@@ -220,6 +228,7 @@ impl ISeqInfo {
             jit_entry: HashMap::default(),
             #[cfg(not(jit_x86))]
             jit_slot: HashMap::default(),
+            jit_class_profile: Vec::new(),
             jit_invalidated: false,
             bb_info: BasicBlockInfo::default(),
             callsite_map: HashMap::default(),
@@ -531,8 +540,42 @@ impl ISeqInfo {
     pub(crate) fn invalidate_jit_code(&mut self) {
         self.jit_invalidated = true;
         self.jit_entry.clear();
+        self.jit_class_profile.clear();
         #[cfg(not(jit_x86))]
         self.jit_slot.clear();
+    }
+
+    /// Record one warm-up sample of *self_class* for this iseq and report
+    /// whether that class has now been seen enough times to justify compiling
+    /// a specialization for it.
+    ///
+    /// The profile is a small bounded set: a class must be sampled
+    /// `PROFILE_THRESHOLD` times before it is considered hot. Because the
+    /// sampler runs only when the stub's warm-up counter expires (every
+    /// `COUNT_START_COMPILE` calls), a receiver class that is used for just a
+    /// single call — e.g. every `Class.new` object in a hot loop — is sampled
+    /// at most once and is evicted by later classes, so it never reaches the
+    /// threshold and is never compiled for. A genuinely hot (mono- or modestly
+    /// polymorphic) receiver is sampled repeatedly and crosses the threshold.
+    pub(crate) fn profile_self_class(&mut self, class: ClassId) -> bool {
+        const PROFILE_CAP: usize = 8;
+        const PROFILE_THRESHOLD: u32 = 2;
+        let prof = &mut self.jit_class_profile;
+        if let Some(idx) = prof.iter().position(|(c, _)| *c == class) {
+            prof[idx].1 += 1;
+            if prof[idx].1 >= PROFILE_THRESHOLD {
+                // hot: drop the profile entry (the class is about to be
+                // compiled and will fast-path the guard from now on).
+                prof.remove(idx);
+                return true;
+            }
+            return false;
+        }
+        if prof.len() >= PROFILE_CAP {
+            prof.remove(0);
+        }
+        prof.push((class, 1));
+        false
     }
 }
 

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -2533,3 +2533,24 @@ fn method_missing_in_hot_loop() {
         "##,
     );
 }
+
+#[test]
+fn method_call_on_fresh_class_each_iteration() {
+    // Calling an (inherited) instance method on a freshly created class object
+    // every iteration: the receiver's self-class is a brand-new singleton class
+    // each time. The JIT must not compile a specialization per singleton class
+    // (the per-class warm-up profiler keeps these one-shot classes out of the
+    // compiler). Correctness must be unaffected regardless.
+    run_test_with_prelude(
+        r##"
+        res = 0
+        300.times { res += Class.new.tag }
+        res
+        "##,
+        r##"
+        class Object
+          def tag = 7
+        end
+        "##,
+    );
+}


### PR DESCRIPTION
## Summary

The method-JIT warm-up counter is **per-FuncId** and counts every call regardless of receiver class. So the first call that trips it compiles a specialization for whatever `self`'s class happens to be current, and the class-guard chain then compiles a fresh specialization for each new self-class it later sees.

For a method invoked on a **class object**, the relevant self-class is that class's **singleton class** — unique per class. So a hot loop that calls a method on a fresh `Class.new` object every iteration (`n.times { Class.new.foo }`) compiles `foo` **once per created class** — O(N) full method compilations plus an ever-growing guard chain.

This is the dominant cost of #675's `Class.new.should.is_a?` workload — mspec calls `Object#should` on each new anonymous class. Measured on aarch64-darwin (N=64000): **~28s JIT vs ~0.18s `--no-jit`**, with **identical GC profiles** between JIT and VM (143k vs 146k allocs, 2 GCs each) — confirming it is *compilation*, not GC. `jit-log` shows `Object#should`/`#myshould`/`#probe` recompiled with a different `#<Class:#<Class:0x…>>` singleton each iteration.

## Fix

Gate compilation on **per-class heat**. Each iseq keeps a small bounded profile of `(self_class → sample count)`. The stub's warm-up counter now calls `jit_profile_patch`, which samples the current self-class and only compiles once that class has been seen `PROFILE_THRESHOLD` (=2) times; otherwise it re-arms the counter so the stub keeps interpreting and samples again later.

- A class used for a single call is sampled at most once, evicted by later classes (cap 8), and **never compiled for**.
- Genuinely hot mono-/polymorphic receivers cross the threshold and specialize as before.

Wired into both warm-up paths via the shared stub helpers: aarch64 `gen_wrapper` + `a64_gen_class_guard_stub`, x86 `gen_compile_patch`.

## Effect (aarch64-darwin)

| workload | before | after |
|---|---|---|
| `n.times { Class.new.probe }` — `Object#probe` compiles (N=800) | 471 | **0** |
| `Class.new.should`-shaped, N=64000 | ~28s | **~0.2s** (VM-equal) |
| fib(34) — normal monomorphic JIT | 0.25s | **0.25s** (unchanged; faster than CRuby 0.53s) |

## Test

- New `method_call_on_fresh_class_each_iteration`.
- Full `cargo nextest` suite on aarch64-darwin: **2217/2217 passed**, 1 skipped.

## Trade-off

A method's receiver class now warms up over ~2 sampling intervals instead of 1 before it JITs — a negligible extra interpreter warm-up. (Con noted up front by the original suggestion: a small per-call profiling cost while a class is not yet specialized.)

## Note

`jit_compile_patch` is now superseded by `jit_profile_patch` at all call sites; left in place (it is `pub(in crate::codegen)`, no warning) and can be removed in a follow-up.

## Relation to #675

#675's `Class.new.should` workload hits **two** independent JIT pathologies. This PR fixes the per-singleton-class compile storm. The method_missing recompile-thrash is fixed separately in #694. Both are needed for that workload to be fully fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
