### PR TITLE
jit(aarch64): make AsmIR lowering infallible and remove the bail mechanism

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -251,8 +251,7 @@ impl Codegen {
         if let Some(slot) = wb.r15 {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
             let acc = GP::R15.a64().0; // x23
-            self.a64_addr_sub(10, lfp, off);
-            monoasm_arm64!(&mut self.jit, str x(acc), [x10];);
+            self.a64_frame_store(acc, lfp, off);
         }
     }
 
@@ -903,8 +902,7 @@ impl Codegen {
     fn a64_store_imm_to_slot(&mut self, imm: u64, slot: SlotId, lfp: u32) {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         monoasm_arm64!(&mut self.jit, mov x9, (imm););
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, str x9, [x10];);
+        self.a64_frame_store(9, lfp, off);
     }
 
     /// Walk `outer` outer-LFP links, leaving the target outer LFP in `dst`.
@@ -1340,18 +1338,33 @@ impl Codegen {
         }
     }
 
-    /// `x(dst) <- [lfp - off]`: load the value of a frame slot. Large-offset
-    /// safe (the address is formed in scratch x10, so `dst` must not be x10).
+    /// `x(dst) <- [lfp - off]`: load the value of a frame slot. Slots sit at a
+    /// *negative* displacement from the LFP, which the scaled `ldr` immediate
+    /// cannot encode; `ldur`'s signed 9-bit offset can, so a small frame folds
+    /// to one instruction. A larger offset forms the address in scratch x10
+    /// (so `dst` must not be x10).
     fn a64_frame_load(&mut self, dst: u32, lfp: u32, off: u32) {
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, ldr x(dst), [x10];);
+        if off <= 256 {
+            let neg = -(off as i32);
+            monoasm_arm64!(&mut self.jit, ldur x(dst), [x(lfp), #(neg)];);
+        } else {
+            self.a64_addr_sub(10, lfp, off);
+            monoasm_arm64!(&mut self.jit, ldr x(dst), [x10];);
+        }
     }
 
-    /// `[lfp - off] <- x(src)`: store into a frame slot. Large-offset safe (the
-    /// address is formed in scratch x10, so `src` must not be x10).
+    /// `[lfp - off] <- x(src)`: store into a frame slot. `stur`'s signed 9-bit
+    /// offset folds a small (negative) frame displacement to one instruction;
+    /// a larger offset forms the address in scratch x10 (so `src` must not be
+    /// x10).
     fn a64_frame_store(&mut self, src: u32, lfp: u32, off: u32) {
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, str x(src), [x10];);
+        if off <= 256 {
+            let neg = -(off as i32);
+            monoasm_arm64!(&mut self.jit, stur x(src), [x(lfp), #(neg)];);
+        } else {
+            self.a64_addr_sub(10, lfp, off);
+            monoasm_arm64!(&mut self.jit, str x(src), [x10];);
+        }
     }
 
     /// `x(dst) <- [x(base) + off]`: load an object field. The scaled `ldr`
@@ -1422,18 +1435,14 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
         let lfp = GP::R14.a64().0;
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        let src = r.a64().0;
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, str x(src), [x10];);
+        self.a64_frame_store(r.a64().0, lfp, off);
     }
 
     /// reg <- [lfp - slot*8 - LFP_SELF]
     pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
         let lfp = GP::R14.a64().0;
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        let dst = r.a64().0;
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, ldr x(dst), [x10];);
+        self.a64_frame_load(r.a64().0, lfp, off);
     }
 
     /// reg <- literal Value (immediate)
@@ -1451,8 +1460,7 @@ impl Codegen {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         let imm = v.id();
         monoasm_arm64!(&mut self.jit, mov x9, (imm););
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, str x9, [x10];);
+        self.a64_frame_store(9, lfp, off);
         true
     }
 
@@ -1706,9 +1714,8 @@ impl Codegen {
             mov x1, x20;                  // globals
             mov x2, (name.get() as u64); // name (IdentId)
         );
-        self.a64_addr_sub(10, lfp, off);
+        self.a64_frame_load(3, lfp, off); // x3 = val (from slot)
         monoasm_arm64!(&mut self.jit,
-            ldr x3, [x10];                // val (from slot)
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -1747,8 +1754,7 @@ impl Codegen {
         let off = src.reg.0 as u32 * 8 + LFP_SELF as u32;
         let rax = GP::Rax.a64().0;
         self.a64_get_outer(src.outer, lfp, rax);
-        self.a64_addr_sub(10, rax, off);
-        monoasm_arm64!(&mut self.jit, ldr x(rax), [x10];);
+        self.a64_frame_load(rax, rax, off);
         true
     }
 
@@ -1762,8 +1768,7 @@ impl Codegen {
         // only to x0..x8 / x20..x23), so `src` is never clobbered whatever
         // register it is.
         self.a64_get_outer(dst.outer, lfp, 9);
-        self.a64_addr_sub(10, 9, off);
-        monoasm_arm64!(&mut self.jit, str x(s), [x10];);
+        self.a64_frame_store(s, 9, off);
         true
     }
 
@@ -1851,11 +1856,9 @@ impl Codegen {
         let eoff = end.0 as u32 * 8 + LFP_SELF as u32;
         let f = runtime::gen_range as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
-        self.a64_addr_sub(10, lfp, soff);
-        monoasm_arm64!(&mut self.jit, ldr x0, [x10];); // start value
-        self.a64_addr_sub(10, lfp, eoff);
+        self.a64_frame_load(0, lfp, soff); // x0 = start value
+        self.a64_frame_load(1, lfp, eoff); // x1 = end value
         monoasm_arm64!(&mut self.jit,
-            ldr x1, [x10];            // end value
             mov x2, x19;              // vm
             mov x3, x20;              // globals
             mov x4, (exclude_end as u64);
@@ -1908,8 +1911,7 @@ impl Codegen {
         // already-Array fast path and the to_a C call fall through to the
         // matching restore, so sp stays balanced either way.
         self.emit_xmm_save(using_xmm, false);
-        self.a64_addr_sub(10, lfp, off);
-        monoasm_arm64!(&mut self.jit, ldr x0, [x10];); // val (rax)
+        self.a64_frame_load(0, lfp, off); // val (rax)
         self.a64_guard_rvalue(GP::Rax.a64().0, ARRAY_CLASS, &toa); // not Array -> toa
         monoasm_arm64!(&mut self.jit, b exit;); // already Array
         let f = runtime::to_a as *const () as u64;
@@ -2599,8 +2601,7 @@ impl Codegen {
         // so they are set up *before* the var-table checks (which may branch to
         // `extend` straight away on a None table).
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(LFP_SELF as u32);
-            ldr x0, [x10];                              // self
+            ldur x0, [x(lfp), #(-(LFP_SELF as i32))];   // self
             mov x1, (heap_len as u64);                  // heap_len
             ldr x9, [x0, #(RVALUE_OFFSET_VAR as u32)];  // var_table ptr
             cbz x9, extend;                             // None -> grow
@@ -3345,9 +3346,8 @@ impl Codegen {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         let exit = self.jit.label();
         let f = runtime::empty_hash as *const () as u64;
-        self.a64_addr_sub(10, lfp, off);
+        self.a64_frame_load(11, lfp, off);
         monoasm_arm64!(&mut self.jit,
-            ldr x11, [x10];
             cmp x11, #(NIL_VALUE);       // slot == nil ?
         );
         self.jit.bcond_label(monoasm::Cond::Ne, &exit); // not nil -> keep
@@ -4481,8 +4481,7 @@ impl Codegen {
         // block_arg_proxy(outer): x0 <- [x0 - LFP_BLOCK]; if (x0 & 1) bump tag.
         let exit = self.jit.label();
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(rax), #(LFP_BLOCK as u32);
-            ldr x(rax), [x10];
+            ldur x(rax), [x(rax), #(-(LFP_BLOCK as i32))];
             mov x11, (1u64);
             tst x(rax), x11;             // Z = ((x0 & 1) == 0)
         );

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -143,8 +143,10 @@ impl Codegen {
                     }
                     label
                 }
-                // Evict(None) is not expected here.
-                _ => return false,
+                // Evict(None) is a placeholder always overwritten with
+                // Evict(Some(..)) before codegen (mirrors x86 gen_asm's
+                // `_ => unreachable!()`).
+                _ => unreachable!("unexpected {side_exit:?}"),
             };
             labels.push(label);
         }
@@ -173,11 +175,11 @@ impl Codegen {
     /// sp-relative, so every loop-JIT exit that resumes the VM (deopt, error,
     /// raise, retry, redo) must restore sp first. `bytes` is
     /// `frame.loop_jit_spill_bytes` (0 for a non-loop frame or a loop without
-    /// spill); the entry bump bailed if it exceeded 4095, so it fits `add`'s
-    /// 12-bit immediate here.
+    /// spill); large bumps go through `a64_sp_add` (mirroring the entry
+    /// `a64_sp_sub`).
     fn a64_undo_loop_rsp_bump(&mut self, bytes: usize) {
         if bytes > 0 {
-            monoasm_arm64!(&mut self.jit, add sp, sp, #(bytes as u32););
+            self.a64_sp_add(bytes as u32);
         }
     }
 
@@ -270,14 +272,9 @@ impl Codegen {
         }
         if let Some(slot) = wb.r15 {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-            if off > 4095 {
-                return false;
-            }
             let acc = GP::R15.a64().0; // x23
-            monoasm_arm64!(&mut self.jit,
-                sub x10, x(lfp), #(off);
-                str x(acc), [x10];
-            );
+            self.a64_addr_sub(10, lfp, off);
+            monoasm_arm64!(&mut self.jit, str x(acc), [x10];);
         }
         true
     }
@@ -392,8 +389,9 @@ impl Codegen {
                     add x(rax), x(rax), #(1u32); // 2q+1 (tagged)
                 );
             }
-            // Rem/bit-ops are compiled as method calls, never IntegerBinOp.
-            _ => return false,
+            // Rem/bit-ops are compiled as method calls, never IntegerBinOp
+            // (mirrors x86 `integer_binop`'s `_ => unreachable!()`).
+            _ => unreachable!(),
         }
         true
     }
@@ -742,10 +740,7 @@ impl Codegen {
         } else if let Some(block) = block_arg {
             let lfp = GP::R14.a64().0;
             let off = block.0 as u32 * 8 + LFP_SELF as u32;
-            monoasm_arm64!(&mut self.jit,
-                sub x10, x(lfp), #(off);
-                ldr x9, [x10];
-            );
+            self.a64_frame_load(9, lfp, off);
         } else {
             monoasm_arm64!(&mut self.jit, mov x9, (0u64););
         }
@@ -756,11 +751,8 @@ impl Codegen {
     /// globals, callid, callee_lfp, fid)` which massages the caller's args into
     /// the callee frame. Returns rax==0 (None) on error (followed by a
     /// HandleError in the IR). `offset` (callee frame size, 16-aligned) is
-    /// reserved below sp around the call. Bails if it exceeds a 12-bit imm.
+    /// reserved below sp around the call (large frames go through `a64_sp_*`).
     fn a64_set_arguments(&mut self, callid: CallSiteId, fid: FuncId, offset: usize) -> bool {
-        if offset > 4080 {
-            return false;
-        }
         let f = crate::runtime::jit_generic_set_arguments as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                       // vm
@@ -769,10 +761,14 @@ impl Codegen {
             sub x3, sp, #(RSP_LOCAL_FRAME as u32); // callee_lfp (call-site sp)
             mov x4, (fid.get() as u64);        // callee fid
             str x30, [sp, #-16]!;              // save LR
-            sub sp, sp, #(offset as u32);      // reserve callee scratch
+        );
+        self.a64_sp_sub(offset as u32);        // reserve callee scratch
+        monoasm_arm64!(&mut self.jit,
             mov x9, (f);
             blr x9;
-            add sp, sp, #(offset as u32);
+        );
+        self.a64_sp_add(offset as u32);
+        monoasm_arm64!(&mut self.jit,
             ldr x30, [sp], #16;                // restore LR
         );
         true
@@ -802,17 +798,14 @@ impl Codegen {
     /// Lower `SetArgumentsForwardedHelper`: same asm shape as
     /// `a64_set_arguments`, but dispatches to the specialized
     /// `jit_forwarded_set_arguments` runtime helper (forwarding `g(x.., ...)`
-    /// into a no-keyword iseq with opt/post/rest). Bails if the callee frame
-    /// size exceeds a 12-bit immediate.
+    /// into a no-keyword iseq with opt/post/rest). Large callee frames go
+    /// through `a64_sp_*`.
     pub(in crate::codegen::jitgen) fn jit_set_arguments_forwarded_helper(
         &mut self,
         callid: CallSiteId,
         fid: FuncId,
         offset: usize,
     ) -> bool {
-        if offset > 4080 {
-            return false;
-        }
         let f = crate::runtime::jit_forwarded_set_arguments as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                       // vm
@@ -821,10 +814,14 @@ impl Codegen {
             sub x3, sp, #(RSP_LOCAL_FRAME as u32); // callee_lfp (call-site sp)
             mov x4, (fid.get() as u64);        // callee fid
             str x30, [sp, #-16]!;              // save LR
-            sub sp, sp, #(offset as u32);      // reserve callee scratch
+        );
+        self.a64_sp_sub(offset as u32);        // reserve callee scratch
+        monoasm_arm64!(&mut self.jit,
             mov x9, (f);
             blr x9;
-            add sp, sp, #(offset as u32);
+        );
+        self.a64_sp_add(offset as u32);
+        monoasm_arm64!(&mut self.jit,
             ldr x30, [sp], #16;                // restore LR
         );
         true
@@ -927,14 +924,9 @@ impl Codegen {
     /// `[lfp - slot*8 - LFP_SELF] <- imm` via a scratch register (x9/x10).
     fn a64_store_imm_to_slot(&mut self, imm: u64, slot: SlotId, lfp: u32) -> bool {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (imm);
-            sub x10, x(lfp), #(off);
-            str x9, [x10];
-        );
+        monoasm_arm64!(&mut self.jit, mov x9, (imm););
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, str x9, [x10];);
         true
     }
 
@@ -1231,10 +1223,7 @@ impl Codegen {
         );
         // store_rax(dst)
         if let Some(off) = dst_off {
-            monoasm_arm64!(&mut self.jit,
-                sub x10, x(lfp), #(off);
-                str x0, [x10];
-            );
+            self.a64_frame_store(0, lfp, off);
         }
         // pop class context: exit_classdef(vm, globals), preserving the result.
         monoasm_arm64!(&mut self.jit,
@@ -1256,8 +1245,7 @@ impl Codegen {
     /// `ClassDef`: define (or reopen) a class/module, then run its body. The
     /// live FP pool is saved once for the whole sequence (the define/enter/exit
     /// C calls and the class body all clobber d2..) and reloaded into the pool
-    /// registers before each HandleError branch; bails only on an out-of-range
-    /// frame slot.
+    /// registers before each HandleError branch.
     pub(in crate::codegen::jitgen) fn class_def(
         &mut self,
         base: Option<SlotId>,
@@ -1269,28 +1257,9 @@ impl Codegen {
         using_xmm: UsingXmm,
         error: &DestLabel,
     ) -> bool {
-        // Range-check every frame slot up front (so we never bail mid-emit).
-        let sc_off = match superclass {
-            Some(s) => match (conv(s) as u32 <= 4095).then(|| conv(s) as u32) {
-                Some(o) => Some(o),
-                None => return false,
-            },
-            None => None,
-        };
-        let base_off = match base {
-            Some(b) => match (conv(b) as u32 <= 4095).then(|| conv(b) as u32) {
-                Some(o) => Some(o),
-                None => return false,
-            },
-            None => None,
-        };
-        let dst_off = match dst {
-            Some(d) => match (conv(d) as u32 <= 4095).then(|| conv(d) as u32) {
-                Some(o) => Some(o),
-                None => return false,
-            },
-            None => None,
-        };
+        let sc_off = superclass.map(|s| conv(s) as u32);
+        let base_off = base.map(|b| conv(b) as u32);
+        let dst_off = dst.map(|d| conv(d) as u32);
         let lfp = GP::R14.a64().0; // x22
         let f = runtime::define_class as *const () as u64;
         // Save the live FP pool for the whole ClassDef sequence; it persists
@@ -1299,11 +1268,11 @@ impl Codegen {
         self.emit_xmm_save(using_xmm, false);
         // superclass -> x3, base -> x5 (Option<Value>; 0 == None)
         match sc_off {
-            Some(off) => monoasm_arm64!(&mut self.jit, sub x10, x(lfp), #(off); ldr x3, [x10];),
+            Some(off) => self.a64_frame_load(3, lfp, off),
             None => monoasm_arm64!(&mut self.jit, mov x3, (0u64);),
         }
         match base_off {
-            Some(off) => monoasm_arm64!(&mut self.jit, sub x10, x(lfp), #(off); ldr x5, [x10];),
+            Some(off) => self.a64_frame_load(5, lfp, off),
             None => monoasm_arm64!(&mut self.jit, mov x5, (0u64);),
         }
         // define_class(vm, globals, name, superclass, is_module, base)
@@ -1334,20 +1303,13 @@ impl Codegen {
         error: &DestLabel,
     ) -> bool {
         let base_off = conv(base) as u32;
-        let dst_off = match dst {
-            Some(d) => Some(conv(d) as u32),
-            None => None,
-        };
-        if base_off > 4095 || dst_off.is_some_and(|o| o > 4095) {
-            return false;
-        }
+        let dst_off = dst.map(|d| conv(d) as u32);
         let lfp = GP::R14.a64().0; // x22
         let f = runtime::define_singleton_class as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         // define_singleton_class(vm, globals, base)
+        self.a64_frame_load(2, lfp, base_off);             // x2 = base (receiver Value)
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(base_off);
-            ldr x2, [x10];                                 // base (receiver Value)
             mov x0, x19;
             mov x1, x20;
             str x30, [sp, #-16]!;
@@ -1383,15 +1345,109 @@ impl Codegen {
         }
     }
 
+    /// Emit `addr <- base - off` (a byte offset into a frame).
+    ///
+    /// `sub`'s 12-bit immediate caps a direct subtract at `off <= 4095`; above
+    /// that the offset is materialized into `addr` first and a register subtract
+    /// is used, so *any* frame offset is addressable (no bail). `addr` doubles
+    /// as the materialization scratch, so it must differ from `base`.
+    fn a64_addr_sub(&mut self, addr: u32, base: u32, off: u32) {
+        debug_assert_ne!(addr, base, "a64_addr_sub: addr must differ from base");
+        if off <= 4095 {
+            monoasm_arm64!(&mut self.jit, sub x(addr), x(base), #(off););
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x(addr), (off as u64);
+                sub x(addr), x(base), x(addr);
+            );
+        }
+    }
+
+    /// `x(dst) <- [lfp - off]`: load the value of a frame slot. Large-offset
+    /// safe (the address is formed in scratch x10, so `dst` must not be x10).
+    fn a64_frame_load(&mut self, dst: u32, lfp: u32, off: u32) {
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, ldr x(dst), [x10];);
+    }
+
+    /// `[lfp - off] <- x(src)`: store into a frame slot. Large-offset safe (the
+    /// address is formed in scratch x10, so `src` must not be x10).
+    fn a64_frame_store(&mut self, src: u32, lfp: u32, off: u32) {
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, str x(src), [x10];);
+    }
+
+    /// `x(dst) <- [x(base) + off]`: load an object field. The scaled `ldr`
+    /// immediate covers `off <= 32760` (8-aligned); a larger/unaligned offset
+    /// goes through a register-offset load (byte offset materialized in scratch
+    /// x10, so `dst`/`base` must not be x10).
+    fn a64_field_load(&mut self, dst: u32, base: u32, off: u32) {
+        if Self::a64_field_off_ok(off) {
+            monoasm_arm64!(&mut self.jit, ldr x(dst), [x(base), #(off)];);
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x10, (off as u64);
+                ldr x(dst), [x(base), x10];
+            );
+        }
+    }
+
+    /// `[x(base) + off] <- x(src)`: store an object field. Large-offset safe
+    /// like `a64_field_load` (`src`/`base` must not be x10).
+    fn a64_field_store(&mut self, src: u32, base: u32, off: u32) {
+        if Self::a64_field_off_ok(off) {
+            monoasm_arm64!(&mut self.jit, str x(src), [x(base), #(off)];);
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x10, (off as u64);
+                str x(src), [x(base), x10];
+            );
+        }
+    }
+
+    /// `sp <- sp - off`, materializing offsets beyond the 12-bit `sub sp`
+    /// immediate. The register form addresses sp via a GP temp (x9/x10) because
+    /// reg 31 decodes as XZR — not SP — in the shifted-register add/sub.
+    fn a64_sp_sub(&mut self, off: u32) {
+        if off == 0 {
+            return;
+        }
+        if off <= 4095 {
+            monoasm_arm64!(&mut self.jit, sub sp, sp, #(off););
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x9, (off as u64);
+                mov x10, sp;
+                sub x10, x10, x9;
+                mov sp, x10;
+            );
+        }
+    }
+
+    /// `sp <- sp + off`, the inverse of `a64_sp_sub` (same sp-via-temp caveat).
+    fn a64_sp_add(&mut self, off: u32) {
+        if off == 0 {
+            return;
+        }
+        if off <= 4095 {
+            monoasm_arm64!(&mut self.jit, add sp, sp, #(off););
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x9, (off as u64);
+                mov x10, sp;
+                add x10, x10, x9;
+                mov sp, x10;
+            );
+        }
+    }
+
     /// [lfp - slot*8 - LFP_SELF] <- reg
     pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
         let lfp = GP::R14.a64().0;
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         let src = r.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            str x(src), [x10];
-        );
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, str x(src), [x10];);
     }
 
     /// reg <- [lfp - slot*8 - LFP_SELF]
@@ -1399,10 +1455,8 @@ impl Codegen {
         let lfp = GP::R14.a64().0;
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         let dst = r.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            ldr x(dst), [x10];
-        );
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, ldr x(dst), [x10];);
     }
 
     /// reg <- literal Value (immediate)
@@ -1414,20 +1468,14 @@ impl Codegen {
 
     /// [lfp - slot*8 - LFP_SELF] <- literal Value. The immediate is
     /// materialized in a scratch reg (aarch64 has no store-immediate), so no GP
-    /// register is clobbered. Bails (`false`) if the frame offset exceeds the
-    /// 12-bit immediate range. Mirrors x86 `literal_to_stack`.
+    /// register is clobbered. Mirrors x86 `literal_to_stack`.
     pub(in crate::codegen::jitgen) fn emit_lit_to_stack(&mut self, v: Value, slot: SlotId) -> bool {
         let lfp = GP::R14.a64().0;
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let imm = v.id();
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (imm);
-            sub x10, x(lfp), #(off);
-            str x9, [x10];
-        );
+        monoasm_arm64!(&mut self.jit, mov x9, (imm););
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, str x9, [x10];);
         true
     }
 
@@ -1678,16 +1726,15 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::set_global_var as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
             mov x2, (name.get() as u64); // name (IdentId)
-            sub x10, x(lfp), #(off);
+        );
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit,
             ldr x3, [x10];                // val (from slot)
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -1725,15 +1772,10 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_load_dyn_var(&mut self, src: DynVar) -> bool {
         let lfp = GP::R14.a64().0;
         let off = src.reg.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let rax = GP::Rax.a64().0;
         self.a64_get_outer(src.outer, lfp, rax);
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(rax), #(off);
-            ldr x(rax), [x10];
-        );
+        self.a64_addr_sub(10, rax, off);
+        monoasm_arm64!(&mut self.jit, ldr x(rax), [x10];);
         true
     }
 
@@ -1741,21 +1783,14 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_store_dyn_var(&mut self, dst: DynVar, src: GP) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.reg.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
-        // walk to the outer LFP in `outer` (avoid clobbering `src`).
-        let outer = GP::Rcx.a64().0;
         let s = src.a64().0;
-        if s == outer || s == 10 {
-            // src would be clobbered by the walk/scratch; bail (rare).
-            return false;
-        }
-        self.a64_get_outer(dst.outer, lfp, outer);
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(outer), #(off);
-            str x(s), [x10];
-        );
+        // Walk to the outer LFP in x9 and form the address in x10 — both pure
+        // lowering scratch (x9..x15 never alias a GP value register, which map
+        // only to x0..x8 / x20..x23), so `src` is never clobbered whatever
+        // register it is.
+        self.a64_get_outer(dst.outer, lfp, 9);
+        self.a64_addr_sub(10, 9, off);
+        monoasm_arm64!(&mut self.jit, str x(s), [x10];);
         true
     }
 
@@ -1768,12 +1803,9 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_create_array(&mut self, src: SlotId, len: usize) -> bool {
         let lfp = GP::R14.a64().0;
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::create_array as *const () as u64;
+        self.a64_addr_sub(0, lfp, off); // x0 = &slot[src]
         monoasm_arm64!(&mut self.jit,
-            sub x0, x(lfp), #(off);   // &slot[src]
             mov x1, (len as u64);
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -1815,15 +1847,14 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = args.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::gen_hash as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;              // vm
             mov x1, x20;              // globals
-            sub x2, x(lfp), #(off);   // &slot[args]
+        );
+        self.a64_addr_sub(2, lfp, off); // x2 = &slot[args]
+        monoasm_arm64!(&mut self.jit,
             mov x3, (len as u64);
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -1845,15 +1876,12 @@ impl Codegen {
         let lfp = GP::R14.a64().0;
         let soff = start.0 as u32 * 8 + LFP_SELF as u32;
         let eoff = end.0 as u32 * 8 + LFP_SELF as u32;
-        if soff > 4095 || eoff > 4095 {
-            return false;
-        }
         let f = runtime::gen_range as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
+        self.a64_addr_sub(10, lfp, soff);
+        monoasm_arm64!(&mut self.jit, ldr x0, [x10];); // start value
+        self.a64_addr_sub(10, lfp, eoff);
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(soff);
-            ldr x0, [x10];            // start value
-            sub x10, x(lfp), #(eoff);
             ldr x1, [x10];            // end value
             mov x2, x19;              // vm
             mov x3, x20;              // globals
@@ -1878,15 +1906,14 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = arg.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::concatenate_string as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;              // vm
             mov x1, x20;              // globals
-            sub x2, x(lfp), #(off);   // &slot[arg]
+        );
+        self.a64_addr_sub(2, lfp, off); // x2 = &slot[arg]
+        monoasm_arm64!(&mut self.jit,
             mov x3, (len as u64);
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -1902,19 +1929,14 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_to_a(&mut self, src: SlotId, using_xmm: UsingXmm) -> bool {
         let lfp = GP::R14.a64().0;
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let toa = self.jit.label();
         let exit = self.jit.label();
         // Reserve the FP-pool save area for the whole sequence; both the
         // already-Array fast path and the to_a C call fall through to the
         // matching restore, so sp stays balanced either way.
         self.emit_xmm_save(using_xmm, false);
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            ldr x0, [x10];          // val (rax)
-        );
+        self.a64_addr_sub(10, lfp, off);
+        monoasm_arm64!(&mut self.jit, ldr x0, [x10];); // val (rax)
         self.a64_guard_rvalue(GP::Rax.a64().0, ARRAY_CLASS, &toa); // not Array -> toa
         monoasm_arm64!(&mut self.jit, b exit;); // already Array
         let f = runtime::to_a as *const () as u64;
@@ -2061,11 +2083,8 @@ impl Codegen {
         let f64_to_val = self.f64_to_val.clone();
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         self.a64_fpr_load(x, 0, base); // value -> d0 (pool fmov or spill load)
-        monoasm_arm64!(&mut self.jit,
-            bl f64_to_val;          // x0 = Value(f64)
-            sub x10, x(lfp), #(off);
-            str x0, [x10];
-        );
+        monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
+        self.a64_frame_store(0, lfp, off);
         true
     }
 
@@ -2180,10 +2199,9 @@ impl Codegen {
         base: usize,
     ) -> bool {
         let (l, r) = binary_xmm;
-        // Reject an unsupported op before emitting any operand loads.
-        if !matches!(kind, BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div) {
-            return false;
-        }
+        // Only the four arithmetic ops are emitted as FloatBinOp (Rem/pow/etc.
+        // are method calls); the `_ => unreachable!()` in the op match below
+        // mirrors x86 `float_binop`.
         // Operands resolve to their pool register, or load a spill into d0/d1;
         // the result writes its pool register or scratch d0 (committed below).
         let ld = self.a64_fpr_read(l, 0, base);
@@ -2217,7 +2235,8 @@ impl Codegen {
                 self.a64_fpr_commit(dst, 0, base);
             }
             UnOpK::Pos => {}
-            _ => return false,
+            // Float unary ops are only Neg/Pos (BitNot is integer-only).
+            _ => unreachable!(),
         }
         true
     }
@@ -2231,10 +2250,9 @@ impl Codegen {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         let id = Value::integer(i).id();
         let bits = (i as f64).to_bits();
+        monoasm_arm64!(&mut self.jit, mov x9, (id););
+        self.a64_frame_store(9, lfp, off);
         monoasm_arm64!(&mut self.jit,
-            mov x9, (id);
-            sub x10, x(lfp), #(off);
-            str x9, [x10];
             mov x9, (bits);
             fmov d(p), x9;
         );
@@ -2569,27 +2587,17 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let prologue_bytes = prologue_offset.unwrap_concrete();
-        if prologue_bytes > 4095 {
-            return false;
-        }
         monoasm_arm64!(&mut self.jit,
             stp x29, x30, [sp, #-16]!;
             mov x29, sp;
         );
-        if prologue_bytes > 0 {
-            monoasm_arm64!(&mut self.jit,
-                sub sp, sp, #(prologue_bytes as u32);
-            );
-        }
+        self.a64_sp_sub(prologue_bytes as u32);
         let clear_len = info.reg_num - info.arg_num;
         if clear_len > 0 {
             monoasm_arm64!(&mut self.jit, mov x9, (NIL_VALUE););
             for i in 0..clear_len {
                 let off = (info.arg_num + i) as u32 * 8 + LFP_ARG0 as u32;
-                monoasm_arm64!(&mut self.jit,
-                    sub x10, x(lfp), #(off);
-                    str x9, [x10];
-                );
+                self.a64_frame_store(9, lfp, off);
             }
         }
         true
@@ -2703,13 +2711,10 @@ impl Codegen {
     /// offset is out of the load immediate's range.
     pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
         let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let r15 = GP::R15.a64().0;
+        self.a64_field_load(r15, rdi, off);
         monoasm_arm64!(&mut self.jit,
-            ldr x(r15), [x(rdi), #(off)];
             mov x9, (NIL_VALUE);
             cmp x(r15), #(0u32);
             csel x(r15), x(r15), x9, ne;   // unset slot (0) -> nil
@@ -2720,40 +2725,29 @@ impl Codegen {
     /// Store the accumulator-side `src` into an inline instance-variable slot.
     pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
         let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let s = src.a64().0;
-        monoasm_arm64!(&mut self.jit, str x(s), [x(rdi), #(off)];);
+        self.a64_field_store(s, rdi, off);
         true
     }
 
     /// Load an inline Struct member slot into the accumulator (x23).
     pub(in crate::codegen::jitgen) fn emit_load_struct_slot_inline(&mut self, slot_index: u16) -> bool {
         let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let r15 = GP::R15.a64().0;
-        monoasm_arm64!(&mut self.jit, ldr x(r15), [x(rdi), #(off)];);
+        self.a64_field_load(r15, rdi, off);
         true
     }
 
     /// Store `src` into an inline Struct member slot (also returned in rax/x0).
     pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
         let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let s = src.a64().0;
         let rax = GP::Rax.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            str x(s), [x(rdi), #(off)];
-            mov x(rax), x(s);
-        );
+        self.a64_field_store(s, rdi, off);
+        monoasm_arm64!(&mut self.jit, mov x(rax), x(s););
         true
     }
 
@@ -2761,15 +2755,12 @@ impl Codegen {
     /// then load the slot into the accumulator (x23).
     pub(in crate::codegen::jitgen) fn emit_load_struct_slot_heap(&mut self, slot_index: u16) -> bool {
         let off = slot_index as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let r15 = GP::R15.a64().0;
         monoasm_arm64!(&mut self.jit,
             ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
-            ldr x(r15), [x(rdi), #(off)];
         );
+        self.a64_field_load(r15, rdi, off);
         true
     }
 
@@ -2777,17 +2768,14 @@ impl Codegen {
     /// rax/x0). Derefs the heap pointer first (clobbering rdi, like x86).
     pub(in crate::codegen::jitgen) fn emit_store_struct_slot_heap(&mut self, src: GP, slot_index: u16) -> bool {
         let off = slot_index as u32 * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let s = src.a64().0;
         let rax = GP::Rax.a64().0;
         monoasm_arm64!(&mut self.jit,
             ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
-            str x(s), [x(rdi), #(off)];
-            mov x(rax), x(s);
         );
+        self.a64_field_store(s, rdi, off);
+        monoasm_arm64!(&mut self.jit, mov x(rax), x(s););
         true
     }
 
@@ -2836,17 +2824,10 @@ impl Codegen {
         }
     }
 
-    /// Loop-JIT entry stack bump. Bails if the byte count exceeds the 12-bit
-    /// `sub sp, sp, #imm` immediate.
+    /// Loop-JIT entry stack bump (large bumps go through `a64_sp_sub`).
     pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(&mut self, offset: LoopRspOffset) -> bool {
         let bytes = offset.unwrap_concrete();
-        if bytes == 0 {
-            return true;
-        }
-        if bytes > 4095 {
-            return false;
-        }
-        monoasm_arm64!(&mut self.jit, sub sp, sp, #(bytes as u32););
+        self.a64_sp_sub(bytes as u32);
         true
     }
 
@@ -2866,16 +2847,13 @@ impl Codegen {
             ivar
         };
         let off = idx * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let s = src.a64().0;
         monoasm_arm64!(&mut self.jit,
             ldr x9, [x(rdi), #(RVALUE_OFFSET_VAR as u32)];
             ldr x9, [x9, #(MONOVEC_PTR as u32)];
-            str x(s), [x9, #(off)];
         );
+        self.a64_field_store(s, 9, off);
         true
     }
 
@@ -2900,9 +2878,6 @@ impl Codegen {
             ivar
         };
         let off = idx * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0; // object (&RValue)
         let s = src.a64().0;
         let generic = self.jit.label();
@@ -2918,11 +2893,9 @@ impl Codegen {
         );
         self.jit.bcond_label(monoasm::Cond::Le, &generic); // len <= idx -> grow
         // fast path: write straight into the table slot.
-        monoasm_arm64!(&mut self.jit,
-            ldr x9, [x9, #(MONOVEC_PTR as u32)];
-            str x(s), [x9, #(off)];
-            b exit;
-        );
+        monoasm_arm64!(&mut self.jit, ldr x9, [x9, #(MONOVEC_PTR as u32)];);
+        self.a64_field_store(s, 9, off);
+        monoasm_arm64!(&mut self.jit, b exit;);
         // cold path: set_ivar(obj, ivarid, src), preserving the FP pool. src (s)
         // and rdi survive emit_xmm_save (it only touches d-regs / sp) and are
         // read into the C-arg regs just before the call.
@@ -2960,9 +2933,6 @@ impl Codegen {
             ivar
         };
         let off = idx * 8;
-        if !Self::a64_field_off_ok(off) {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0;
         let r15 = GP::R15.a64().0;
         let nil = self.jit.label();
@@ -2980,9 +2950,9 @@ impl Codegen {
             );
             self.jit.bcond_label(monoasm::Cond::Le, &nil);   // len <= idx -> nil
         }
+        monoasm_arm64!(&mut self.jit, ldr x9, [x9, #(MONOVEC_PTR as u32)];); // data ptr
+        self.a64_field_load(r15, 9, off);                    // value
         monoasm_arm64!(&mut self.jit,
-            ldr x9, [x9, #(MONOVEC_PTR as u32)];             // data ptr
-            ldr x(r15), [x9, #(off)];                        // value
             cbnz x(r15), exit;                               // set -> exit
         nil:
             mov x(r15), (NIL_VALUE);
@@ -3063,17 +3033,15 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = src.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::set_class_var as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                  // vm (Executor)
             mov x1, x20;                  // globals
             mov x2, (name.get() as u64); // name (IdentId)
-            sub x10, x(lfp), #(off);
-            ldr x3, [x10];               // val (from slot)
+        );
+        self.a64_frame_load(3, lfp, off); // x3 = val (from slot)
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -3097,18 +3065,15 @@ impl Codegen {
         let lfp = GP::R14.a64().0; // x22
         let off_old = old.0 as u32 * 8 + LFP_SELF as u32;
         let off_new = new.0 as u32 * 8 + LFP_SELF as u32;
-        if off_old > 4095 || off_new > 4095 {
-            return false;
-        }
         let f = runtime::alias_method as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm (Executor)
             mov x1, x20;                 // globals
-            sub x10, x(lfp), #(off_old);
-            ldr x2, [x10];              // old (slot value)
-            sub x10, x(lfp), #(off_new);
-            ldr x3, [x10];             // new (slot value)
+        );
+        self.a64_frame_load(2, lfp, off_old); // x2 = old (slot value)
+        self.a64_frame_load(3, lfp, off_new); // x3 = new (slot value)
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -3135,9 +3100,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_yield as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
@@ -3147,9 +3109,8 @@ impl Codegen {
             mov x9, (f);
             blr x9;                      // result in x0
             ldr x30, [sp], #16;
-            sub x10, x(lfp), #(off);
-            str x0, [x10];               // -> dst
         );
+        self.a64_frame_store(0, lfp, off); // -> dst
         self.emit_xmm_restore(using_xmm, false);
         true
     }
@@ -3162,9 +3123,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_super as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
@@ -3174,9 +3132,8 @@ impl Codegen {
             mov x9, (f);
             blr x9;
             ldr x30, [sp], #16;
-            sub x10, x(lfp), #(off);
-            str x0, [x10];
         );
+        self.a64_frame_store(0, lfp, off);
         self.emit_xmm_restore(using_xmm, false);
         true
     }
@@ -3190,9 +3147,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_gvar as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
@@ -3203,9 +3157,8 @@ impl Codegen {
             mov x9, (f);
             blr x9;
             ldr x30, [sp], #16;
-            sub x10, x(lfp), #(off);
-            str x0, [x10];
         );
+        self.a64_frame_store(0, lfp, off);
         self.emit_xmm_restore(using_xmm, false);
         true
     }
@@ -3219,9 +3172,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_cvar as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
@@ -3232,9 +3182,8 @@ impl Codegen {
             mov x9, (f);
             blr x9;
             ldr x30, [sp], #16;
-            sub x10, x(lfp), #(off);
-            str x0, [x10];
         );
+        self.a64_frame_store(0, lfp, off);
         self.emit_xmm_restore(using_xmm, false);
         true
     }
@@ -3248,15 +3197,14 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_const as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
-            sub x2, x(lfp), #(off);      // &dst (out-pointer)
+        );
+        self.a64_addr_sub(2, lfp, off);  // x2 = &dst (out-pointer)
+        monoasm_arm64!(&mut self.jit,
             mov x3, (siteid.0 as u64);   // ConstSiteId
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -3278,17 +3226,15 @@ impl Codegen {
         let lfp = GP::R14.a64().0;
         let off_dst = dst.0 as u32 * 8 + LFP_SELF as u32;
         let off_recv = recv.0 as u32 * 8 + LFP_SELF as u32;
-        if off_dst > 4095 || off_recv > 4095 {
-            return false;
-        }
         let f = runtime::defined_method as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
-            sub x2, x(lfp), #(off_dst);  // &dst (out-pointer)
-            sub x10, x(lfp), #(off_recv);
-            ldr x3, [x10];               // recv (slot value)
+        );
+        self.a64_addr_sub(2, lfp, off_dst);   // x2 = &dst (out-pointer)
+        self.a64_frame_load(3, lfp, off_recv); // x3 = recv (slot value)
+        monoasm_arm64!(&mut self.jit,
             mov x4, (name.get() as u64); // name
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -3308,15 +3254,14 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0;
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::defined_ivar as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
             mov x1, x20;
-            sub x2, x(lfp), #(off);      // &dst (out-pointer)
+        );
+        self.a64_addr_sub(2, lfp, off);  // x2 = &dst (out-pointer)
+        monoasm_arm64!(&mut self.jit,
             mov x3, (name.get() as u64); // name
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -3340,18 +3285,15 @@ impl Codegen {
         let lfp = GP::R14.a64().0; // x22
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
-        if off_l > 4095 || off_r > 4095 {
-            return false;
-        }
         let f = func as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
-            sub x10, x(lfp), #(off_l);
-            ldr x2, [x10];               // lhs
-            sub x10, x(lfp), #(off_r);
-            ldr x3, [x10];               // rhs
+        );
+        self.a64_frame_load(2, lfp, off_l); // x2 = lhs
+        self.a64_frame_load(3, lfp, off_r); // x3 = rhs
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -3372,18 +3314,15 @@ impl Codegen {
         let lfp = GP::R14.a64().0;
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
-        if off_l > 4095 || off_r > 4095 {
-            return false;
-        }
         let f = runtime::array_teq as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
-            sub x10, x(lfp), #(off_l);
-            ldr x2, [x10];               // lhs
-            sub x10, x(lfp), #(off_r);
-            ldr x3, [x10];               // rhs
+        );
+        self.a64_frame_load(2, lfp, off_l); // x2 = lhs
+        self.a64_frame_load(3, lfp, off_r); // x3 = rhs
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -3406,15 +3345,14 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = arg.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::concatenate_regexp as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals
-            sub x2, x(lfp), #(off);      // &arg (slot address)
+        );
+        self.a64_addr_sub(2, lfp, off);  // x2 = &arg (slot address)
+        monoasm_arm64!(&mut self.jit,
             mov x3, (len as u64);        // len
             str x30, [sp, #-16]!;
             mov x9, (f);
@@ -3432,13 +3370,10 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_check_kw_rest(&mut self, slot: SlotId) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let exit = self.jit.label();
         let f = runtime::empty_hash as *const () as u64;
+        self.a64_addr_sub(10, lfp, off);
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
             ldr x11, [x10];
             cmp x11, #(NIL_VALUE);       // slot == nil ?
         );
@@ -3448,8 +3383,9 @@ impl Codegen {
             mov x9, (f);
             blr x9;                      // x0 = {}
             ldr x30, [sp], #16;
-            sub x10, x(lfp), #(off);     // x10 clobbered by the call; recompute
-            str x0, [x10];               // slot = {}
+        );
+        self.a64_frame_store(0, lfp, off); // slot = {}
+        monoasm_arm64!(&mut self.jit,
         exit:
         );
         true
@@ -3474,15 +3410,12 @@ impl Codegen {
         };
         let lfp = GP::R14.a64().0; // x22
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let rdi = GP::Rdi.a64().0; // x4 holds src
         let f = runtime::expand_array as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit, mov x0, x(rdi);); // src (from GP::Rdi)
+        self.a64_addr_sub(1, lfp, off);  // x1 = &dst (descending base)
         monoasm_arm64!(&mut self.jit,
-            mov x0, x(rdi);              // src (from GP::Rdi)
-            sub x1, x(lfp), #(off);      // &dst (descending base)
             mov x2, (len as u64);        // len
             mov x3, (rest);              // rest (0 = none)
             str x30, [sp, #-16]!;
@@ -3514,20 +3447,15 @@ impl Codegen {
         let lfp = GP::R14.a64().0; // x22
         let off_l = lhs.0 as u32 * 8 + LFP_SELF as u32;
         let off_r = rhs.0 as u32 * 8 + LFP_SELF as u32;
-        if off_l > 4095 || off_r > 4095 {
-            return false;
-        }
         let f = func as u64;
         let slow = self.jit.label();
         let done = self.jit.label();
         // Load operands into the C-arg registers (reused by the slow path).
         // Heap iff (bits & 0b111) == 0; Flonum iff (bits & 0b011) == 0b010.
         // Either operand heap/flonum -> generic C-call.
+        self.a64_frame_load(2, lfp, off_l); // lhs
+        self.a64_frame_load(3, lfp, off_r); // rhs
         monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off_l);
-            ldr x2, [x10];               // lhs
-            sub x10, x(lfp), #(off_r);
-            ldr x3, [x10];               // rhs
             mov x14, (7u64);
             and x9, x2, x14;
             cbz x9, slow;                // lhs heap -> slow
@@ -4246,9 +4174,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = obj.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let f = runtime::singleton_define_method as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
         monoasm_arm64!(&mut self.jit,
@@ -4256,8 +4181,9 @@ impl Codegen {
             mov x1, x20;                     // globals
             mov x2, (name.get() as u64);     // name (IdentId)
             mov x3, (func_id.get() as u64);  // func_id (FuncId)
-            sub x10, x(lfp), #(off);
-            ldr x4, [x10];                   // obj (receiver Value)
+        );
+        self.a64_frame_load(4, lfp, off);    // x4 = obj (receiver Value)
+        monoasm_arm64!(&mut self.jit,
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;                          // x0 = Option<Value>
@@ -4493,33 +4419,43 @@ impl Codegen {
 
     /// `dst <- sp + (ofs - RSP_LOCAL_FRAME)` (the absolute callee-slot address).
     /// The displacement is usually negative (the callee frame sits below sp).
-    /// Returns `false` if it exceeds the 12-bit add/sub immediate.
-    fn a64_rsp_slot_addr(&mut self, ofs: i32, dst: u32) -> bool {
+    /// Large displacements go through a GP temp (x9): reg 31 decodes as XZR, not
+    /// SP, in the shifted-register add/sub, so sp is read via an sp-aware `mov`.
+    /// `dst` must not be x9.
+    fn a64_rsp_slot_addr(&mut self, ofs: i32, dst: u32) {
+        debug_assert_ne!(dst, 9);
         let signed = ofs - RSP_LOCAL_FRAME;
         if signed >= 0 {
-            if signed > 4095 {
-                return false;
+            let n = signed as u32;
+            if n <= 4095 {
+                monoasm_arm64!(&mut self.jit, add x(dst), sp, #(n););
+            } else {
+                monoasm_arm64!(&mut self.jit,
+                    mov x(dst), sp;
+                    mov x9, (n as u64);
+                    add x(dst), x(dst), x9;
+                );
             }
-            monoasm_arm64!(&mut self.jit, add x(dst), sp, #(signed as u32););
         } else {
             let n = (-signed) as u32;
-            if n > 4095 {
-                return false;
+            if n <= 4095 {
+                monoasm_arm64!(&mut self.jit, sub x(dst), sp, #(n););
+            } else {
+                monoasm_arm64!(&mut self.jit,
+                    mov x(dst), sp;
+                    mov x9, (n as u64);
+                    sub x(dst), x(dst), x9;
+                );
             }
-            monoasm_arm64!(&mut self.jit, sub x(dst), sp, #(n););
         }
-        true
     }
 
     // ---- callee-frame argument stores ([sp + (ofs - RSP_LOCAL_FRAME)]) ------
-    // Used by the inline argument-setup fast path (fetch_for_callee). Bail on an
-    // out-of-range slot offset.
+    // Used by the inline argument-setup fast path (fetch_for_callee).
 
     /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- reg`
     pub(in crate::codegen::jitgen) fn emit_reg_to_rsp_offset(&mut self, r: GP, ofs: i32) -> bool {
-        if !self.a64_rsp_slot_addr(ofs, 10) {
-            return false;
-        }
+        self.a64_rsp_slot_addr(ofs, 10);
         let r = r.a64().0;
         monoasm_arm64!(&mut self.jit, str x(r), [x10];);
         true
@@ -4527,9 +4463,7 @@ impl Codegen {
 
     /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- 0`
     pub(in crate::codegen::jitgen) fn emit_zero_to_rsp_offset(&mut self, ofs: i32) -> bool {
-        if !self.a64_rsp_slot_addr(ofs, 10) {
-            return false;
-        }
+        self.a64_rsp_slot_addr(ofs, 10);
         monoasm_arm64!(&mut self.jit,
             mov x9, (0u64);
             str x9, [x10];
@@ -4539,9 +4473,7 @@ impl Codegen {
 
     /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- imm`
     pub(in crate::codegen::jitgen) fn emit_u64_to_rsp_offset(&mut self, i: u64, ofs: i32) -> bool {
-        if !self.a64_rsp_slot_addr(ofs, 10) {
-            return false;
-        }
+        self.a64_rsp_slot_addr(ofs, 10);
         monoasm_arm64!(&mut self.jit,
             mov x9, (i);
             str x9, [x10];
@@ -4564,9 +4496,6 @@ impl Codegen {
         let rax = GP::Rax.a64().0; // x0
         let off = ret.0 as u32 * 8 + LFP_SELF as u32;
         let tag = ((outer << 2) + 2) as u32;
-        if off > 4095 || tag > 4095 {
-            return false;
-        }
         // get_method_lfp(outer): x0 <- method LFP (walk `outer` outer links).
         if outer == 0 {
             monoasm_arm64!(&mut self.jit, mov x(rax), x(lfp););
@@ -4585,15 +4514,14 @@ impl Codegen {
             tst x(rax), x11;             // Z = ((x0 & 1) == 0)
         );
         self.jit.bcond_label(monoasm::Cond::Eq, &exit);
-        monoasm_arm64!(&mut self.jit,
-            add x(rax), x(rax), #(tag);
-            exit:
-        );
+        if tag <= 4095 {
+            monoasm_arm64!(&mut self.jit, add x(rax), x(rax), #(tag););
+        } else {
+            monoasm_arm64!(&mut self.jit, mov x11, (tag as u64); add x(rax), x(rax), x11;);
+        }
+        monoasm_arm64!(&mut self.jit, exit:);
         // store_rax(ret): [lfp - off] <- x0
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            str x(rax), [x10];
-        );
+        self.a64_frame_store(rax, lfp, off);
         true
     }
 
@@ -4613,9 +4541,6 @@ impl Codegen {
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
         let off = ret.0 as u32 * 8 + LFP_SELF as u32;
-        if off > 4095 {
-            return false;
-        }
         let cs = call_site_bc_ptr.as_ptr() as u64;
         let f = runtime::block_arg as *const () as u64;
         self.emit_xmm_save(using_xmm, false);
@@ -4632,10 +4557,7 @@ impl Codegen {
         self.emit_xmm_restore(using_xmm, false);
         self.emit_handle_error(error);
         let rax = GP::Rax.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            str x(rax), [x10];    // ret <- Proc
-        );
+        self.a64_frame_store(rax, lfp, off); // ret <- Proc
         true
     }
 
@@ -4724,7 +4646,10 @@ impl Codegen {
                 let offset = store[callee_fid].get_offset();
                 return self.a64_set_arguments_forwarded(callid, callee_fid, offset, deferred_src);
             }
-            _ => return false,
+            // Every other AsmInst variant is handled by the shared
+            // `compile_asmir` dispatcher before reaching here, so the wildcard
+            // is unreachable (mirrors x86 `compile_asmir_arch`'s wildcard).
+            _ => unreachable!("handled by the shared compile_asmir dispatcher"),
         }
         true
     }

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1,12 +1,12 @@
-//! aarch64 AsmIR→machine-code lowering (Phase 3b, incremental).
+//! aarch64 AsmIR→machine-code lowering.
 //!
 //! The arch-neutral front-end builds `AsmIr`; this drives the lowering on
-//! aarch64. `compile_asmir` returns `true` if it emitted code for the
-//! instruction and `false` if the instruction is not yet ported — in which
-//! case the driver returns `false`, `jit_compile` returns `Err`, and the
-//! method stays VM-interpreted (the existing `compile() -> None` bail). So
-//! only methods whose every `AsmInst` is supported actually JIT; coverage
-//! grows one variant at a time. See `doc/aarch64-jitgen-plan.md`.
+//! aarch64. Every `AsmInst` and side exit is lowered: large frame/field/sp
+//! offsets are materialized through scratch registers rather than bailing, and
+//! the `...`-forwarding deferral — the one shape that needed unported
+//! caller-relative codegen — is disabled for aarch64 in `forward_rest_deferral`.
+//! So aarch64 never bails out of JIT compilation; `compile_asmir`'s `bool` is
+//! vestigial. See `doc/aarch64-jitgen-plan.md`.
 
 use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
@@ -73,10 +73,9 @@ impl Codegen {
 
     /// Lower one block's `AsmIr`. `entry` (if any) is bound first; `exit` (if
     /// any) appends an unconditional branch to that basic block at the end.
-    /// Always succeeds (returns `true`): every `AsmInst` and side exit lowers,
-    /// so aarch64 never bails out of JIT compilation. The `bool` is kept only to
-    /// match the x86 `gen_asm` signature the shared `gen_machine_code` driver
-    /// calls (the x86 half is in `asmir.rs`).
+    /// Every `AsmInst` and side exit lowers, so aarch64 never bails out of JIT
+    /// compilation. (aarch64 half of the per-arch `gen_asm` the shared
+    /// `gen_machine_code` driver calls; the x86 half is in `asmir.rs`.)
     pub(in crate::codegen::jitgen) fn gen_asm(
         &mut self,
         ir: AsmIr,
@@ -85,7 +84,7 @@ impl Codegen {
         entry: Option<DestLabel>,
         exit: Option<BasicBlockId>,
         class_version: DestLabel,
-    ) -> bool {
+    ) {
         // Generate the block's side-exit (deopt/evict/error) handlers. They are
         // cold, so we lay them out here but jump over them (`b skip`); guards in
         // the main body branch *back* to them (short-range b.cond). aarch64 has
@@ -157,7 +156,6 @@ impl Codegen {
             let exit = frame.resolve_bb_label(&mut self.jit, exit);
             monoasm_arm64!(&mut self.jit, b exit;);
         }
-        true
     }
 
     /// Undo the loop-JIT entry sp-bump (`emit_loop_jit_rsp_bump`) before

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -73,9 +73,10 @@ impl Codegen {
 
     /// Lower one block's `AsmIr`. `entry` (if any) is bound first; `exit` (if
     /// any) appends an unconditional branch to that basic block at the end.
-    /// Returns `false` (bail) on any unsupported instruction or side exit.
-    /// (aarch64 half of the per-arch `gen_asm` the shared `gen_machine_code`
-    /// driver calls; the x86 half is in `asmir.rs`.)
+    /// Always succeeds (returns `true`): every `AsmInst` and side exit lowers,
+    /// so aarch64 never bails out of JIT compilation. The `bool` is kept only to
+    /// match the x86 `gen_asm` signature the shared `gen_machine_code` driver
+    /// calls (the x86 half is in `asmir.rs`).
     pub(in crate::codegen::jitgen) fn gen_asm(
         &mut self,
         ir: AsmIr,
@@ -108,9 +109,7 @@ impl Codegen {
                 // `__immediate_evict` logging is `cfg(deopt/profile)`-only).
                 SideExit::Evict(Some((pc, wb))) => {
                     let label = self.jit.label();
-                    if !self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset) {
-                        return false;
-                    }
+                    self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset);
                     label
                 }
                 SideExit::Deoptimize(pc, wb) => {
@@ -119,9 +118,7 @@ impl Codegen {
                         label.clone()
                     } else {
                         let label = self.jit.label();
-                        if !self.a64_gen_deopt(key.0, &key.1, label.clone(), bump, frame.base_stack_offset) {
-                            return false;
-                        }
+                        self.a64_gen_deopt(key.0, &key.1, label.clone(), bump, frame.base_stack_offset);
                         deopt_table.insert(key, label.clone());
                         label
                     }
@@ -131,16 +128,12 @@ impl Codegen {
                 // correct, just not yet self-optimizing).
                 SideExit::RecompileDeoptimize(pc, wb, _reason, _position) => {
                     let label = self.jit.label();
-                    if !self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset) {
-                        return false;
-                    }
+                    self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset);
                     label
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();
-                    if !self.a64_gen_handle_error(pc, &wb, label.clone(), bump, frame.base_stack_offset) {
-                        return false;
-                    }
+                    self.a64_gen_handle_error(pc, &wb, label.clone(), bump, frame.base_stack_offset);
                     label
                 }
                 // Evict(None) is a placeholder always overwritten with
@@ -158,9 +151,7 @@ impl Codegen {
             self.jit.bind_label(entry.clone());
         }
         for inst in ir.inst {
-            if !self.compile_asmir(store, frame, &labels, inst, class_version.clone()) {
-                return false;
-            }
+            self.compile_asmir(store, frame, &labels, inst, class_version.clone());
         }
         if let Some(exit) = exit {
             let exit = frame.resolve_bb_label(&mut self.jit, exit);
@@ -186,7 +177,6 @@ impl Codegen {
     /// Deopt handler: write all live Ruby values back to the LFP (so the frame
     /// is GC-consistent and the interpreter can resume), set PC, and jump to
     /// the VM fetch loop. Mirrors x86 `side_exit_with_label` (deopt path).
-    /// Returns `false` (bail) if the write-back needs an unsupported feature.
     fn a64_gen_deopt(
         &mut self,
         pc: BytecodePtr,
@@ -194,12 +184,10 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
-    ) -> bool {
+    ) {
         self.jit.bind_label(entry);
         self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
-        if !self.a64_gen_write_back_for_deopt(wb, base) {
-            return false;
-        }
+        self.a64_gen_write_back_for_deopt(wb, base);
         let pc_ptr = pc.as_ptr() as u64;
         let fetch = self.vm_fetch();
         // PC == x21.
@@ -207,7 +195,6 @@ impl Codegen {
             mov x21, (pc_ptr);
             b fetch;
         );
-        true
     }
 
     /// Error handler: write back, set PC to *this* instruction, and jump to
@@ -227,48 +214,41 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
-    ) -> bool {
+    ) {
         self.jit.bind_label(entry);
         self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
-        if !self.a64_gen_write_back_for_deopt(wb, base) {
-            return false;
-        }
+        self.a64_gen_write_back_for_deopt(wb, base);
         let pc0 = pc.as_ptr() as u64;
         let raise = self.entry_raise();
         monoasm_arm64!(&mut self.jit,
             mov x21, (pc0);
             b raise;
         );
-        true
     }
 
     /// Write back live values to LFP slots for a side exit, r14(x22)-relative
     /// (the local frame may be on the heap after a call returns). Mirrors x86
-    /// `gen_write_back_for_deopt`. Bails on FP / forwarding-rest write-backs,
-    /// which need machinery not yet ported.
-    fn a64_gen_write_back_for_deopt(&mut self, wb: &WriteBack, base: usize) -> bool {
-        if !wb.forward_rest.is_empty() {
-            return false;
-        }
+    /// `gen_write_back_for_deopt`. The deferred forwarding-rest write-back never
+    /// occurs on aarch64 (the deferral is disabled in `forward_rest_deferral`),
+    /// so every write-back lowers.
+    fn a64_gen_write_back_for_deopt(&mut self, wb: &WriteBack, base: usize) {
+        debug_assert!(
+            wb.forward_rest.is_empty(),
+            "aarch64 disables forward-rest deferral, so a deopt write-back never carries one",
+        );
         // Spill each live FP-pool register to its slot(s) as a boxed Float
         // Value, so the interpreter sees the up-to-date float after the deopt.
         for (fpr, slots) in &wb.fpr {
             for slot in slots {
-                if !self.emit_fpr_to_stack(*fpr, *slot, base) {
-                    return false;
-                }
+                self.emit_fpr_to_stack(*fpr, *slot, base);
             }
         }
         let lfp = GP::R14.a64().0; // x22
         for (v, slot) in &wb.literal {
-            if !self.a64_store_imm_to_slot(v.id(), *slot, lfp) {
-                return false;
-            }
+            self.a64_store_imm_to_slot(v.id(), *slot, lfp);
         }
         for slot in &wb.void {
-            if !self.a64_store_imm_to_slot(NIL_VALUE as u64, *slot, lfp) {
-                return false;
-            }
+            self.a64_store_imm_to_slot(NIL_VALUE as u64, *slot, lfp);
         }
         if let Some(slot) = wb.r15 {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
@@ -276,7 +256,6 @@ impl Codegen {
             self.a64_addr_sub(10, lfp, off);
             monoasm_arm64!(&mut self.jit, str x(acc), [x10];);
         }
-        true
     }
 
     /// Inline fixnum binary op. Fixnums are tagged `2n+1`; signed 64-bit
@@ -775,13 +754,12 @@ impl Codegen {
     }
 
     /// Lower `SetArgumentsForwarded` (the `g(*rest, **kw, &blk)` trampoline
-    /// fast path). aarch64 does not yet emit the inline element-copy fast path,
-    /// so the non-deferred shape falls back to the generic
-    /// `jit_generic_set_arguments` — the x86 fast path's own miss target, so
-    /// correct, just unoptimized. The `deferred_src` (D1) shape skipped building
-    /// `f`'s `...` rest array on the JIT path, so it cannot use the generic
-    /// helper and bails (the method stays VM-interpreted, where the array is
-    /// built normally).
+    /// fast path). aarch64 does not emit the inline element-copy fast path, so it
+    /// always falls back to the generic `jit_generic_set_arguments` — the x86
+    /// fast path's own miss target, so correct, just unoptimized. The deferred
+    /// `...`-rest (`deferred_src`) shape never occurs because aarch64 disables
+    /// the deferral (`forward_rest_deferral`), so the rest array is always built
+    /// normally and forwarding goes through the generic helper.
     fn a64_set_arguments_forwarded(
         &mut self,
         callid: CallSiteId,
@@ -789,9 +767,11 @@ impl Codegen {
         offset: usize,
         deferred_src: Option<(SlotId, u16)>,
     ) -> bool {
-        if deferred_src.is_some() {
-            return false;
-        }
+        debug_assert!(
+            deferred_src.is_none(),
+            "aarch64 disables forward-rest deferral, so SetArgumentsForwarded never carries deferred_src",
+        );
+        let _ = deferred_src;
         self.a64_set_arguments(callid, fid, offset)
     }
 
@@ -922,12 +902,11 @@ impl Codegen {
     }
 
     /// `[lfp - slot*8 - LFP_SELF] <- imm` via a scratch register (x9/x10).
-    fn a64_store_imm_to_slot(&mut self, imm: u64, slot: SlotId, lfp: u32) -> bool {
+    fn a64_store_imm_to_slot(&mut self, imm: u64, slot: SlotId, lfp: u32) {
         let off = slot.0 as u32 * 8 + LFP_SELF as u32;
         monoasm_arm64!(&mut self.jit, mov x9, (imm););
         self.a64_addr_sub(10, lfp, off);
         monoasm_arm64!(&mut self.jit, str x9, [x10];);
-        true
     }
 
     /// Walk `outer` outer-LFP links, leaving the target outer LFP in `dst`.
@@ -1558,9 +1537,7 @@ impl Codegen {
             cmp x10, x11;
         );
         self.jit.bcond_label(monoasm::Cond::Gt, &ok); // sp > limit -> ok
-        if !self.a64_gen_write_back_for_deopt(&write_back, base) {
-            return false;
-        }
+        self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::codegen::stack_overflow as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
@@ -1597,9 +1574,7 @@ impl Codegen {
             cmp x9, #(8u32);
         );
         self.jit.bcond_label(monoasm::Cond::Lt, &skip); // < 8 -> no GC
-        if !self.a64_gen_write_back_for_deopt(&write_back, base) {
-            return false;
-        }
+        self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::executor::execute_gc as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -341,12 +341,12 @@ impl Codegen {
 
         // Front-end (TraceIR→AsmIR) is arch-neutral and has run by here. The
         // shared `gen_machine_code` driver then drives the per-arch `gen_asm`
-        // lowering. It returns `false` only on aarch64, when the lowering bails
-        // on a not-yet-ported `AsmInst`; we turn that into `Err` and the method
-        // stays VM-interpreted (x86 always succeeds).
+        // lowering, which lowers every `AsmInst` on both arches — so machine-code
+        // generation never bails (the front-end's `?` above is the only way to
+        // fall back to the interpreter).
         self.jit.finalize();
         let class_version_label = self.jit.const_i32(class_version as _);
-        let ok = self.gen_machine_code(
+        self.gen_machine_code(
             frame.asm_info,
             store,
             entry_label,
@@ -359,22 +359,16 @@ impl Codegen {
         // emission (e.g. the class-guard stub).
         #[cfg(target_arch = "x86_64")]
         self.jit.finalize();
-        if ok {
-            Ok((inline_cache, specialized_info, class_version_label))
-        } else {
-            Err(CompileError)
-        }
+        Ok((inline_cache, specialized_info, class_version_label))
     }
 }
 
 impl Codegen {
     /// Arch-neutral driver: emit machine code for a whole method and its
     /// inlined specialized callees (recursively), calling the per-arch
-    /// `gen_asm` per basic block / bridge. Returns `false` if the lowering
-    /// bailed on a not-yet-ported instruction (aarch64 only; x86 always returns
-    /// `true`) — the caller then keeps the method VM-interpreted. Does not
-    /// `finalize`; `jit_compile` does that (x86) or the outer caller does
-    /// (aarch64).
+    /// `gen_asm` per basic block / bridge. Both arches lower every `AsmInst`,
+    /// so this never bails. Does not `finalize`; `jit_compile` does that (x86)
+    /// or the outer caller does (aarch64).
     fn gen_machine_code(
         &mut self,
         mut frame: AsmInfo,
@@ -382,7 +376,7 @@ impl Codegen {
         entry_label: DestLabel,
         level: usize,
         class_version: DestLabel,
-    ) -> bool {
+    ) {
         for context::SpecializeInfo {
             entry: specialized_entry,
             info: specialized_info,
@@ -398,15 +392,13 @@ impl Codegen {
                 ));
             }
             let entry = frame.resolve_label(&mut self.jit, specialized_entry);
-            if !self.gen_machine_code(
+            self.gen_machine_code(
                 specialized_info,
                 store,
                 entry,
                 level + 1,
                 class_version.clone(),
-            ) {
-                return false;
-            }
+            );
         }
 
         self.jit.bind_label(entry_label);
@@ -447,9 +439,7 @@ impl Codegen {
 
         // generate machine code for a main context and inlined bridges.
         for (bbid, ir) in ir_vec.into_iter() {
-            if !self.gen_asm(ir, store, &mut frame, None, None, class_version.clone()) {
-                return false;
-            }
+            self.gen_asm(ir, store, &mut frame, None, None, class_version.clone());
             // generate machine code for the inlined bridge
             if let Some((ir, exit)) = frame.remove_inline_bridge(bbid) {
                 let exit = if let Some(bbid) = bbid {
@@ -463,25 +453,21 @@ impl Codegen {
                 } else {
                     None
                 };
-                if !self.gen_asm(ir, store, &mut frame, None, exit, class_version.clone()) {
-                    return false;
-                }
+                self.gen_asm(ir, store, &mut frame, None, exit, class_version.clone());
             }
         }
 
         // generate machine code for outlined bridges
         for (ir, entry, exit) in frame.detach_outline_bridges() {
             let entry = frame.resolve_label(&mut self.jit, entry);
-            if !self.gen_asm(
+            self.gen_asm(
                 ir,
                 store,
                 &mut frame,
                 Some(entry),
                 Some(exit),
                 class_version.clone(),
-            ) {
-                return false;
-            }
+            );
         }
 
         if !frame.is_specialized() {
@@ -510,8 +496,6 @@ impl Codegen {
             let desc = format!("JIT:<{}>", store.func_description(fid));
             self.perf_info(pair, &desc);
         }
-
-        true
     }
 }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -5,9 +5,8 @@ use super::*;
 // AsmIR→machine-code lowering. The per-arch backend (`compile`) provides the
 // emission primitives + `compile_asmir_arch`; the arch-neutral dispatcher
 // (`compile_shared`) owns the shared instruction arms and forwards the rest.
-// x86 emits via `monoasm!`; aarch64 emits what it can via `monoasm_arm64!`
-// and bails (→ deopt to VM) on a not-yet-ported instruction (see
-// doc/aarch64-jitgen-plan.md).
+// x86 emits via `monoasm!`, aarch64 via `monoasm_arm64!`; both lower every
+// `AsmInst`, so neither bails (see doc/aarch64-jitgen-plan.md).
 #[cfg(target_arch = "x86_64")]
 #[path = "../arch/x86_64/compile/mod.rs"]
 mod compile;
@@ -1968,7 +1967,7 @@ impl Codegen {
         entry: Option<DestLabel>,
         exit: Option<BasicBlockId>,
         class_version: DestLabel,
-    ) -> bool {
+    ) {
         let mut side_exits = SideExitLabels::new();
         let mut deopt_table: HashMap<(BytecodePtr, WriteBack), DestLabel> = HashMap::default();
         let loop_jit_spill_bytes = frame.loop_jit_spill_bytes;
@@ -2045,9 +2044,6 @@ impl Codegen {
         if entry.is_some() && exit.is_some() {
             self.jit.select_page(0);
         }
-        // x86 never bails (every `AsmInst` is lowered); the `bool` return exists
-        // only to share the driver (`gen_machine_code`) with aarch64.
-        true
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -16,9 +16,11 @@ impl Codegen {
     ///
     /// Lower one `AsmInst`. The single entry point both backends' drivers call.
     ///
-    /// Returns `true` if the instruction was emitted, `false` to bail (only the
-    /// aarch64 backend bails today, on a not-yet-ported instruction; the x86
-    /// backend always returns `true`). The shared arms never bail.
+    /// Both backends lower every `AsmInst`, so this never bails — the `bool`
+    /// it (and the per-arch emission primitives) returns is always `true` and
+    /// is ignored by the callers. It is kept only because flipping ~80 dispatch
+    /// arms and ~100 leaf emitters to `()` is pure churn; the driver chain
+    /// (`gen_asm` / `gen_machine_code` / `jit_compile`) no longer acts on it.
     ///
     pub(in crate::codegen::jitgen) fn compile_asmir(
         &mut self,

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1175,6 +1175,16 @@ impl<'a> JitContext<'a> {
     /// positional count, `rest_local` `f`'s synthetic rest local slot.
     ///
     pub(super) fn forward_rest_deferral(&self) -> Option<(SlotId, SlotId, u16)> {
+        // The aarch64 AsmIR lowering does not implement the deferred-rest
+        // optimization (the side-exit `forward_rest` materialize and the
+        // `SetArgumentsForwarded` inline fast path), so it never defers: the
+        // `...` rest array is built the normal way and forwarding goes through
+        // the generic helper. Correct, just unoptimized — and it keeps the
+        // aarch64 lowering bail-free (no `forward_rest` / `deferred_src` ever
+        // reach codegen). x86 keeps the optimization.
+        if cfg!(target_arch = "aarch64") {
+            return None;
+        }
         if !self.is_specialized() || self.specialize_level() != 1 {
             return None;
         }


### PR DESCRIPTION
## Summary

The aarch64 AsmIR→machine-code lowering used to *bail* (keep the method
VM-interpreted) whenever it hit a frame/field/sp offset outside a 12-bit
immediate, a few defensively-"unsupported" arms, or the specialized
`...`-forwarding deferral. This series removes every bail case one by one and
then drops the bail mechanism itself, so aarch64 now JIT-compiles **every**
method/loop — parity with x86 (which never bailed).

## Commits

1. **remove frame/field/sp-offset and dead AsmInst-lowering bails** — replace
   the per-site `if off > 4095 { return false }` shortcuts with offset-safe
   helpers:
   - `a64_addr_sub` / `a64_frame_load` / `a64_frame_store` — LFP-relative slot
     addressing, materializing the offset into scratch `x10` past the `sub`
     immediate.
   - `a64_field_load` / `a64_field_store` — object-field addressing, falling
     back to a register-offset load/store past the scaled immediate.
   - `a64_sp_sub` / `a64_sp_add` / `a64_rsp_slot_addr` — sp adjustment via a GP
     temp (reg 31 is XZR, not SP, in the shifted-register form).

   The defensively-unreachable arms (`IntegerBinOp`/`FloatBinOp` non-arithmetic
   kinds, `FloatUnOp` non-Neg/Pos, the `SideExit::Evict(None)` placeholder, the
   `compile_asmir_arch` wildcard) become `unreachable!()`, matching their x86
   twins. `emit_store_dyn_var` no longer bails on a src/scratch clash (the walk
   and address now use pure scratch `x9`/`x10`, which never alias a GP value
   register).

2. **make AsmIR lowering infallible (drop all bail paths)** — the last two
   bails were the specialized `...`-forwarding deferral's deopt-time
   `forward_rest` materialize and `SetArgumentsForwarded`'s `deferred_src`
   fast path, both needing caller-frame-relative codegen that isn't ported to
   aarch64. Rather than emit unverifiable specialized-frame code, the deferral
   is disabled on aarch64 in the arch-neutral `forward_rest_deferral`: the
   `...` rest array is built normally and forwarding goes through the generic
   helper (correct, just unoptimized). **x86 keeps the optimization.** With the
   deferral off, the side-exit write-back / `set_arguments_forwarded` paths
   become infallible.

3. **remove the AsmIR-lowering bail mechanism** — with lowering infallible,
   the `bool`/`Err` plumbing that propagated a bail is dead. `gen_machine_code`
   and both per-arch `gen_asm` return `()`, and `jit_compile` no longer turns a
   lowering result into `Err(CompileError)`. (`CompileError` stays for the
   front-end's own `traceir_to_asmir` bail, which is unrelated.) `compile_asmir`
   and the leaf emitters keep a now-ignored `bool` to avoid churning ~180
   call sites.

4. **use ldur/stur for negative-offset frame access** — frame slots sit at a
   *negative* LFP displacement, which the scaled `ldr`/`str` immediate can't
   encode (hence the old `sub x10, …; ldr [x10]` two-instruction sequence).
   The new `ldur`/`stur` (unscaled signed 9-bit offset) fold a small frame
   access (`off ≤ 256`, the common case) to a single instruction; larger
   offsets keep the materialize path. Requires the monoasm bump
   (`04974c5` → `13bc64a`) bundled in this PR's `Cargo.lock`.

## Verification

- **aarch64** (qemu-aarch64 vs CRuby): coverage script over every changed path
  (integer/float arithmetic, gvar/cvar, inline+heap ivar, class def,
  array/hash/range/string-concat, `defined?`, polymorphic `==`, block_arg),
  a 700-local large-frame method (exercises both the `ldur`/`stur` fast path
  and the materialize fallback, with jit-log confirming it actually
  JIT-compiles), `def f(...) = g(...)` forwarding, nested `&block` proxy
  forwarding, and `app_fib`/`tarai`/`so_nbody` all match CRuby. The
  `arith` (targeted subset), `yield`, `class_chain`, `comparable`, `rational`,
  `method_call` (splat) suites pass under qemu.
- **x86** unaffected (deferral still on): forwarding result matches CRuby and
  the `arith`/`method_call`/`yield`/`class_chain`/`comparable`/`rational`/
  `variables`/`case`/`enumerable`/`literal` suites pass natively.

## Follow-up (not in this PR)

Re-enabling the `...`-forwarding deferral on aarch64 (the deopt-time
`forward_rest` materialize + the inline `deferred_src` fast path) needs
caller-frame-relative codegen best verified on real aarch64 hardware.

https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae

---
_Generated by [Claude Code](https://claude.ai/code/session_01RipQNC5jMjigWfRGNiNQae)_