### PR TITLE
Reduce allocation/dispatch overhead on the addressable benchmarks (12–26% faster)

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -374,7 +374,10 @@ pub(super) fn gen_class_new_inline(
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
-    if !callsite.is_simple() {
+    // Positional and plain keyword callsites are supported; bail on
+    // splat / hash-splat / block-arg shapes (a literal block never
+    // reaches an inline gen).
+    if callsite.has_splat() || callsite.has_hash_splat() || callsite.block_arg.is_some() {
         return false;
     }
     // When `Class#new` is called on a class object, the receiver's class is
@@ -398,6 +401,11 @@ pub(super) fn gen_class_new_inline(
         dst,
         ..
     } = *callsite;
+    let kw_callid = if callsite.kw_args.is_empty() {
+        None
+    } else {
+        Some(callid)
+    };
     state.writeback_acc(ir);
     state.load(ir, recv, GP::Rdi);
     state.write_back_recv_and_callargs(ir, callsite);
@@ -431,21 +439,43 @@ pub(super) fn gen_class_new_inline(
         );
 
         r#gen.jit.select_page(1);
+        if let Some(callid) = kw_callid {
+            monoasm!( &mut r#gen.jit,
+            initialize:
+                // class_new_initialize_kw(vm, globals, FuncId, receiver,
+                //                         CallSiteId, caller_lfp)
+                movq rdi, rbx;
+                movq rsi, r12;
+                movq rdx, rax;
+                movq rcx, r15;
+                movl r8, (callid.0);
+                movq r9, r14;
+                movq rax, (class_new_initialize_kw);
+                call rax;
+                testq rax, rax;
+                jne  exit;
+                xorq r15, r15;
+                jmp  exit;
+            );
+        } else {
+            monoasm!( &mut r#gen.jit,
+            initialize:
+                movq rdi, rbx;
+                movq rsi, r12;
+                movq rdx, rax;
+                movq rcx, r15;
+                lea r8, [r14 - (crate::executor::jitgen::conv(args))];
+                movl r9, (pos_num);
+                // TODO: Currently inline call does not support calling with block arguments.
+                movq rax, (r#gen.method_invoker2);
+                call rax;
+                testq rax, rax;
+                jne  exit;
+                xorq r15, r15;
+                jmp  exit;
+            );
+        }
         monoasm!( &mut r#gen.jit,
-        initialize:
-            movq rdi, rbx;
-            movq rsi, r12;
-            movq rdx, rax;
-            movq rcx, r15;
-            lea r8, [r14 - (crate::executor::jitgen::conv(args))];
-            movl r9, (pos_num);
-            // TODO: Currently inline call does not support calling with block or keyword arguments.
-            movq rax, (r#gen.method_invoker2);
-            call rax;
-            testq rax, rax;
-            jne  exit;
-            xorq r15, r15;
-            jmp  exit;
         slow_path:
             movq rdi, r12;
             movq rsi, r15;
@@ -462,6 +492,52 @@ pub(super) fn gen_class_new_inline(
     ir.handle_error(error);
     state.def_rax2acc(ir, dst);
     true
+}
+
+/// Runtime arm of the inlined `Class#new` for callsites with keyword
+/// arguments: collect the keywords from the caller's frame into a Hash
+/// (`Class#new` forwards them to `initialize` as **kw) and invoke the
+/// cached `initialize`. Returns `None` with the error set on the
+/// executor on failure (the standard native calling convention).
+#[cfg(target_arch = "x86_64")]
+extern "C" fn class_new_initialize_kw(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    func_id: FuncId,
+    receiver: Value,
+    callid: CallSiteId,
+    caller_lfp: Lfp,
+) -> Option<Value> {
+    // The freshly allocated receiver lives only in registers / Rust
+    // locals here (the caller's dst slot is written after this call
+    // returns), so root it — and the kw hash — across the allocations
+    // below. The positional/keyword argument values stay rooted via
+    // the caller's frame slots.
+    let temp_len = vm.temp_len();
+    vm.temp_push(receiver);
+    let (pos_args, kw) = {
+        let callsite = &globals.store[callid];
+        let pos_args: Vec<Value> = (0..callsite.pos_num)
+            .map(|i| caller_lfp.register(callsite.args + i).unwrap())
+            .collect();
+        let mut h = rubymap::RubyMap::default();
+        for (k, id) in callsite.kw_args.iter() {
+            let v = caller_lfp.register(callsite.kw_pos + *id).unwrap();
+            h.insert_sym(crate::value::RubySymbol::new(*k), v);
+        }
+        (pos_args, Value::hash(h))
+    };
+    vm.temp_push(kw);
+    let res = vm.invoke_func(
+        globals,
+        func_id,
+        receiver,
+        &pos_args,
+        None,
+        kw.try_hash_ty(),
+    );
+    vm.temp_clear(temp_len);
+    res
 }
 
 /// aarch64 twin of `gen_class_new_inline`. The hot-path asm (allocate + resolve

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1175,7 +1175,11 @@ extern "C" fn stack_overflow(executor: &mut Executor) -> Option<Value> {
 #[cfg(feature = "profile")]
 extern "C" fn guard_fail(vm: &mut Executor, globals: &mut Globals, self_val: Value) {
     let func_id = vm.cfp().lfp().func_id();
-    globals.jit_class_guard_failed(func_id, self_val.class());
+    // A failing guard may be probing a slot whose heap object has already
+    // been freed; record stats only for live values instead of panicking.
+    if let Some(class) = self_val.debug_class() {
+        globals.jit_class_guard_failed(func_id, class);
+    }
 }
 
 #[cfg(test)]

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2405,11 +2405,7 @@ impl Executor {
         captures: &onigmo_regex::Captures<'h>,
         haystack: &str,
     ) {
-        let positions: Vec<Option<(usize, usize)>> = captures
-            .iter()
-            .map(|m| m.as_ref().map(|m| (m.start(), m.end())))
-            .collect();
-        let mut md = MatchDataInner::new(haystack.to_string(), positions);
+        let mut md = MatchDataInner::from_captures(captures, haystack);
         if let Some(regex_val) = self.sp_match_regex
             && let Some(regex) = regex_val.is_regex()
         {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -296,8 +296,16 @@ pub type AllocFunc = extern "C" fn(ClassId, &mut crate::Globals) -> Value;
 /// Default allocator used by `BasicObject` and inherited by any class that
 /// does not override it. Produces a plain `RValue::Object` tagged with the
 /// given class id.
-pub extern "C" fn default_alloc_func(class_id: ClassId, _: &mut crate::Globals) -> Value {
-    Value::object(class_id)
+///
+/// The spilled ivar table is pre-sized to the class's known ivar count
+/// so constructors that initialize many ivars (more than
+/// `OBJECT_INLINE_IVAR`) allocate it once instead of regrowing it on
+/// every store past the inline slots.
+pub extern "C" fn default_alloc_func(class_id: ClassId, globals: &mut crate::Globals) -> Value {
+    let spill = globals.store[class_id]
+        .ivar_len()
+        .saturating_sub(crate::value::rvalue::OBJECT_INLINE_IVAR);
+    Value::object_with_ivar_capacity(class_id, spill)
 }
 
 /// Allocator for `Struct.new(:a, :b, ...)`-derived classes. Reads

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -2183,10 +2183,8 @@ impl Value {
     }
 
     pub(crate) fn as_hash(self) -> Hashmap {
-        self.try_hash_ty().expect(&format!(
-            "Value expected to be a hash but was {:?}",
-            self.ty()
-        ))
+        self.try_hash_ty()
+            .unwrap_or_else(|| panic!("Value expected to be a hash but was {:?}", self.ty()))
     }
 
     ///

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -888,6 +888,12 @@ impl Value {
         RValue::new_object(class_id).pack()
     }
 
+    /// Like `object`, but pre-allocates the spilled ivar table with
+    /// room for `spill` entries (ivars beyond `OBJECT_INLINE_IVAR`).
+    pub fn object_with_ivar_capacity(class_id: ClassId, spill: usize) -> Self {
+        RValue::new_object_with_ivar_capacity(class_id, spill).pack()
+    }
+
     /// Create a `Struct` subclass instance with `len` slots all set to
     /// nil. The class id determines which `Struct.new(...)`-derived
     /// class this instance belongs to.

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -432,7 +432,7 @@ impl ObjKind {
         }
     }
 
-    fn matchdata(captures: Captures, heystack: String, regex: Regexp) -> Self {
+    fn matchdata(captures: Captures, heystack: &str, regex: Regexp) -> Self {
         Self {
             matchdata: ManuallyDrop::new(MatchDataInner::from_capture(captures, heystack, regex)),
         }
@@ -1530,6 +1530,21 @@ impl RValue {
         }
     }
 
+    /// Like `new_object`, but pre-sizes the spilled ivar table for
+    /// classes known to use more than `OBJECT_INLINE_IVAR` ivars, so
+    /// constructor ivar stores don't regrow it write by write.
+    pub(super) fn new_object_with_ivar_capacity(class_id: ClassId, spill: usize) -> Self {
+        RValue {
+            header: Header::new(class_id, ObjTy::OBJECT),
+            kind: ObjKind::object(),
+            var_table: if spill == 0 {
+                None
+            } else {
+                Some(Box::new(MonoVec::with_capacity(spill)))
+            },
+        }
+    }
+
     /// Create a `Struct` subclass instance with `len` slots, all
     /// initialised to nil. Used by `struct_alloc_func`.
     pub(super) fn new_struct_obj(class_id: ClassId, len: usize) -> Self {
@@ -1921,7 +1936,7 @@ impl RValue {
     pub(super) fn new_match_data(captures: Captures, heystack: &str, regex: Regexp) -> Self {
         RValue {
             header: Header::new(MATCHDATA_CLASS, ObjTy::MATCHDATA),
-            kind: ObjKind::matchdata(captures, heystack.to_string(), regex),
+            kind: ObjKind::matchdata(captures, heystack, regex),
             var_table: None,
         }
     }

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -1,11 +1,48 @@
 use super::*;
+use smallvec::SmallVec;
 
+/// Byte span of one capture group, `(start, end)`.
+///
+/// `NO_MATCH` (the all-ones span) marks a group that did not
+/// participate in the match. Real spans never reach `u32::MAX`
+/// because match subjects are limited to < 4 GiB (asserted at
+/// construction).
+type Span = (u32, u32);
+const NO_MATCH: Span = (u32::MAX, u32::MAX);
+
+#[inline]
+fn encode_span(m: Option<(usize, usize)>) -> Span {
+    match m {
+        Some((start, end)) => (start as u32, end as u32),
+        None => NO_MATCH,
+    }
+}
+
+#[inline]
+fn decode_span(span: Span) -> Option<(usize, usize)> {
+    if span == NO_MATCH {
+        None
+    } else {
+        Some((span.0 as usize, span.1 as usize))
+    }
+}
+
+///
+/// MatchData payload.
+///
+/// `$~` is materialized on every successful regexp match, so this
+/// struct is sized to keep that as cheap as possible while fitting
+/// RValue's 48-byte payload: 8 (regex) + 16 (`Box<str>`) + 24
+/// (SmallVec) = 48. The inline capacity of 2 covers the most common
+/// match shapes (whole match only, or one capture group) without a
+/// positions heap allocation.
+///
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct MatchDataInner {
     regex: Option<Regexp>,
-    heystack: String,
-    matches: Box<Vec<Option<(usize, usize)>>>,
+    heystack: Box<str>,
+    matches: SmallVec<[Span; 2]>,
 }
 
 impl GC<RValue> for MatchDataInner {
@@ -17,11 +54,33 @@ impl GC<RValue> for MatchDataInner {
 }
 
 impl MatchDataInner {
-    pub fn new(heystack: String, matches: Vec<Option<(usize, usize)>>) -> Self {
+    pub fn new(heystack: &str, matches: Vec<Option<(usize, usize)>>) -> Self {
+        assert!(
+            heystack.len() < u32::MAX as usize,
+            "match subject longer than 4GiB is not supported"
+        );
         MatchDataInner {
             regex: None,
-            heystack,
-            matches: Box::new(matches),
+            heystack: Box::from(heystack),
+            matches: matches.into_iter().map(encode_span).collect(),
+        }
+    }
+
+    /// Build directly from onigmo `Captures` without intermediate
+    /// position vectors (hot path: `$~` save on every match).
+    pub fn from_captures(captures: &Captures, heystack: &str) -> Self {
+        assert!(
+            heystack.len() < u32::MAX as usize,
+            "match subject longer than 4GiB is not supported"
+        );
+        let matches = captures
+            .iter()
+            .map(|m| encode_span(m.as_ref().map(|m| (m.start(), m.end()))))
+            .collect();
+        MatchDataInner {
+            regex: None,
+            heystack: Box::from(heystack),
+            matches,
         }
     }
 
@@ -35,20 +94,8 @@ impl MatchDataInner {
         self
     }
 
-    pub fn from_capture(captures: Captures, heystack: String, regex: Regexp) -> Self {
-        let matches = captures
-            .iter()
-            .map(|m| {
-                if let Some(m) = m {
-                    Some((m.start(), m.end()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let mut md = MatchDataInner::new(heystack, matches);
-        md.regex = Some(regex);
-        md
+    pub fn from_capture(captures: Captures, heystack: &str, regex: Regexp) -> Self {
+        Self::from_captures(&captures, heystack).with_regex(regex)
     }
 
     pub fn regexp(&self) -> Option<Regexp> {
@@ -60,7 +107,7 @@ impl MatchDataInner {
     }
 
     pub fn pos(&self, pos: usize) -> Option<(usize, usize)> {
-        self.matches[pos]
+        decode_span(self.matches[pos])
     }
 
     /// Matched bytes for capture `pos`. Slices the haystack on
@@ -71,7 +118,8 @@ impl MatchDataInner {
     /// (which is a `panic_nounwind` ⇒ process abort across the
     /// `#[monoruby_builtin]` extern "C" boundary).
     pub fn at(&self, pos: usize) -> Option<&[u8]> {
-        self.matches[pos].map(|(start, end)| &self.heystack.as_bytes()[start..end])
+        self.pos(pos)
+            .map(|(start, end)| &self.heystack.as_bytes()[start..end])
     }
 
     pub fn len(&self) -> usize {
@@ -81,7 +129,7 @@ impl MatchDataInner {
     pub fn captures(&self) -> impl Iterator<Item = Option<&[u8]>> {
         self.matches
             .iter()
-            .map(|m| m.map(|(start, end)| &self.heystack.as_bytes()[start..end]))
+            .map(|m| decode_span(*m).map(|(start, end)| &self.heystack.as_bytes()[start..end]))
     }
 
     pub fn to_s(&self) -> String {


### PR DESCRIPTION
## Summary

Speeds up the ruby-bench `addressable-*` benchmarks by 12–26% by attacking the allocation / dispatch overhead that profiling showed dominates them (JIT-generated code was only ~6% of samples; malloc/free + GC was ~30%).

| benchmark | master | this PR | Δ | YJIT (4.0.5) |
|---|---|---|---|---|
| addressable-parse | 242ms | **200ms** | −17% | 170ms |
| addressable-to-s | 162ms | **131ms** | −19% | 109ms |
| addressable-normalize | 372ms | **327ms** | −12% | 252ms |
| addressable-getters | 172ms | **127ms** | −26% | 116ms |

(per-iteration times, x86-64 Linux, interleaved A/B runs, 2-round average; the gap to YJIT narrows from ~1.4–1.5× to ~1.1–1.3×)

## Changes

1. **`Value::as_hash`: don't build the panic message eagerly.** `.expect(&format!(...))` evaluated the formatted string on every `Hash#[]` — ~5% of total time on addressable-parse went to `core::fmt` + the malloc/free round trip.

2. **Cheaper `$~` materialization** (it happens on every successful regexp match, ~8×/parse here):
   - capture positions: `Box<Vec<Option<(usize, usize)>>>` (two mallocs) → `SmallVec<[(u32, u32); 2]>` with an all-ones `NO_MATCH` sentinel — inline (zero mallocs) for the common whole-match / one-capture shapes;
   - haystack: `String` → `Box<str>` so the struct still fits RValue's 48-byte payload;
   - spans are built straight from onigmo `Captures` without an intermediate `Vec`. Subjects are limited to < 4 GiB (asserted), matching the `u32` span encoding.

3. **Pre-size the spilled ivar table in `default_alloc_func`.** A 22-ivar class like `Addressable::URI` regrew its heap ivar table once per store past the 6 inline slots (capacities 1→2→4→8→16, ~5 mallocs + memcpys per instance). The class's ivar count is known at allocation time, so allocate the table once. Classes with ≤ 6 ivars are unaffected.

4. **Keyword arguments in the inlined `Class#new`.** Kwarg construction (`URI.new(:scheme => ..., ...)`) previously bailed to the generic builtin: native wrapper frame + rest-array materialization + a global-cache lookup of `initialize` on every call (120k lookups per bench run in `profile` stats — now zero). The inliner keeps the allocation + version-guarded cached `initialize` FuncId and dispatches kwarg callsites through a new runtime arm that collects the keywords into a Hash and invokes `initialize` with it, mirroring the generic path's `**kw` forwarding. The receiver and kw hash are rooted on the executor's temp stack across the allocations. Splat / hash-splat / block-pass shapes still take the generic path; the aarch64 inliner is unchanged (positional-only).

5. **`profile`-feature robustness:** `guard_fail` no longer dereferences dead objects when recording class-guard-failure stats (this aborted profile builds during rubygems activation under Ruby 4.0).

## Testing

- `cargo test -p monoruby`: 1651 passed, 0 failed (identical to master on the same machine).
- Behavior cross-checked against CRuby 4.0.5 for regexp/MatchData edge cases (`$~`, `$1`, `pre/post_match`, named captures, `scan`/`sub`/`gsub` with blocks) and many-ivar objects (`instance_variables`, `dup`, subclass, GC).
- `Class#new` kwarg semantics verified against the generic path (including the pre-existing missing-required-keyword discrepancy, filed separately as #707).

## Related issues filed while investigating

- #706 — StackOverflow on large Hash literals (blocks addressable 2.9.0's `idna/pure.rb`; benchmarks pin 2.8.7)
- #707 — missing required keyword argument doesn't raise `ArgumentError` (pre-existing, reproduces on master)

https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq)_