### PR TITLE
Build large collection literals in chunks to bound frame size (fixes #706)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -3911,28 +3911,32 @@ mod tests {
     #[test]
     fn array_literal_chunked() {
         // An Array literal longer than LITERAL_CHUNK_LEN (256 elements) is
-        // built in chunks (issue #706). Cover ordering across the chunk
-        // boundary and splats in chunked literals.
+        // built in chunks (issue #706). Elements must be non-constant: a
+        // constant-only Array literal is folded into a single deep-copied
+        // Literal and never reaches the chunked construction path. Cover
+        // ordering across the chunk boundary and splats in chunked literals;
+        // `run_test`'s warm-up loop exercises the JIT lowering (ArrayConcat).
         let elems = (0..600)
-            .map(|i| i.to_string())
+            .map(|i| format!("n + {i}"))
             .collect::<Vec<_>>()
             .join(", ");
         run_test(&format!(
-            "a = [{elems}]; [a.size, a[0], a[255], a[256], a[-1]]"
+            "n = 1; a = [{elems}]; [a.size, a[0], a[255], a[256], a[-1]]"
         ));
         run_test_once(&format!(
-            "x = [-1, -2]; a = [*x, {elems}, *x]; [a.size, a[0], a[1], a[2], a[-1]]"
+            "n = 1; x = [-1, -2]; a = [*x, {elems}, *x]; [a.size, a[0], a[1], a[2], a[-1]]"
         ));
     }
 
     #[test]
     fn array_literal_huge() {
         // issue #706: keep frame register usage bounded for huge literals.
-        let elems = (0..4000)
-            .map(|i| i.to_string())
+        // The leading `n` keeps the literal non-constant (see above).
+        let elems = std::iter::once("n".to_string())
+            .chain((1..4000).map(|i| i.to_string()))
             .collect::<Vec<_>>()
             .join(", ");
-        run_test_once(&format!("a = [{elems}]; [a.size, a[3999]]"));
+        run_test_once(&format!("n = 0; a = [{elems}]; [a.size, a[3999]]"));
     }
 
     #[test]

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -3909,6 +3909,33 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn array_literal_chunked() {
+        // An Array literal longer than LITERAL_CHUNK_LEN (256 elements) is
+        // built in chunks (issue #706). Cover ordering across the chunk
+        // boundary and splats in chunked literals.
+        let elems = (0..600)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        run_test(&format!(
+            "a = [{elems}]; [a.size, a[0], a[255], a[256], a[-1]]"
+        ));
+        run_test_once(&format!(
+            "x = [-1, -2]; a = [*x, {elems}, *x]; [a.size, a[0], a[1], a[2], a[-1]]"
+        ));
+    }
+
+    #[test]
+    fn array_literal_huge() {
+        // issue #706: keep frame register usage bounded for huge literals.
+        let elems = (0..4000)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        run_test_once(&format!("a = [{elems}]; [a.size, a[3999]]"));
+    }
+
+    #[test]
     fn array_new() {
         run_test_with_prelude(
             r##"

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -3108,6 +3108,40 @@ mod tests {
     }
 
     #[test]
+    fn hash_literal_chunked() {
+        // A Hash literal longer than LITERAL_CHUNK_LEN (256 entries) is
+        // built in chunks (issue #706). Cover insertion order, duplicate
+        // keys across chunk boundaries (last wins), and a `**` splat
+        // following the chunked part.
+        let mut entries = String::new();
+        for i in 0..600 {
+            entries += &format!("{} => {}, ", i % 300, i);
+        }
+        run_test(&format!(
+            "h = {{ {entries} }}; [h.size, h[0], h[299], h.keys[0], h.keys[-1]]"
+        ));
+        let mut entries = String::new();
+        for i in 0..300 {
+            entries += &format!("{i} => {i}, ");
+        }
+        run_test_once(&format!(
+            "s = {{ 9999 => 1 }}; h = {{ {entries} **s }}; [h.size, h[9999], h.keys[-1]]"
+        ));
+    }
+
+    #[test]
+    fn hash_literal_huge() {
+        // issue #706: a Hash literal with thousands of entries used to
+        // allocate ~2 temporary registers per entry in a single frame and
+        // overflow the native stack (frames live on the machine stack).
+        let mut entries = String::new();
+        for i in 0..4000 {
+            entries += &format!("{i} => [0, 0, nil, nil, nil, {i}, nil], ");
+        }
+        run_test_once(&format!("h = {{ {entries} }}; [h.size, h[3999]]"));
+    }
+
+    #[test]
     fn hash_literal_error_propagation() {
         run_test_error(
             r##"

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -505,6 +505,18 @@ impl<'a> BytecodeGen<'a> {
                 let callid = self.new_callsite(callsite, bc_pos)?;
                 Bytecode::from(enc_wl(39, op1.0, callid.get()))
             }
+            BytecodeInst::ArrayConcat { dst, src } => {
+                // 41
+                let op1 = self.slot_id(&dst);
+                let op2 = self.slot_id(&src);
+                Bytecode::from(enc_ww(41, op1.0, op2.0))
+            }
+            BytecodeInst::HashInsert { hash, args, len } => {
+                // 42
+                let op1 = self.slot_id(&hash);
+                let op2 = self.slot_id(&args);
+                Bytecode::from(enc_www(42, op1.0, op2.0, len))
+            }
             BytecodeInst::DefinedYield { dst } => {
                 // 64
                 let op1 = self.slot_id(&dst);

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+///
+/// Maximum number of elements (Array) / entries (Hash) of a collection
+/// literal that are evaluated into consecutive temporary registers at once.
+/// Longer literals are built in chunks of this size, re-using the same
+/// registers for every chunk (see `gen_array` / `gen_hash`), so that the
+/// frame's register count — frames live on the native machine stack — stays
+/// bounded no matter how large the literal is (issue #706).
+///
+const LITERAL_CHUNK_LEN: usize = 256;
+
 impl<'a> BytecodeGen<'a> {
     ///
     /// Evaluate *expr*, push the result, and return the register.
@@ -1004,9 +1014,48 @@ impl<'a> BytecodeGen<'a> {
     }
 
     fn gen_array(&mut self, ret: BcReg, nodes: Vec<Node>, loc: Loc) -> Result<()> {
-        let (src, len, splat) = self.ordinary_args(nodes)?;
-        self.popn(len);
-        self.emit_array(ret, src, len, splat, loc);
+        if nodes.len() <= LITERAL_CHUNK_LEN {
+            let (src, len, splat) = self.ordinary_args(nodes)?;
+            self.popn(len);
+            self.emit_array(ret, src, len, splat, loc);
+            return Ok(());
+        }
+        // Build a large Array literal in bounded chunks so the number of
+        // temporary registers does not grow with the literal's length: emit
+        // the first chunk with an ordinary Array instruction, then build each
+        // following chunk into a scratch register (re-using the same element
+        // registers) and concatenate it. Construct into a temporary so `ret`
+        // (which may be a local variable) never holds a half-built array.
+        let old_reg = self.temp;
+        let tmp: BcReg = self.push().into();
+        let base = self.temp;
+        let mut first = true;
+        let mut iter = nodes.into_iter().peekable();
+        while iter.peek().is_some() {
+            let chunk: Vec<Node> = iter.by_ref().take(LITERAL_CHUNK_LEN).collect();
+            if first {
+                let (src, len, splat) = self.ordinary_args(chunk)?;
+                self.popn(len);
+                self.emit_array(tmp, src, len, splat, loc);
+                first = false;
+            } else {
+                let chunk_dst: BcReg = self.push().into();
+                let (src, len, splat) = self.ordinary_args(chunk)?;
+                self.popn(len);
+                self.emit_array(chunk_dst, src, len, splat, loc);
+                self.pop();
+                self.emit(
+                    BytecodeInst::ArrayConcat {
+                        dst: tmp,
+                        src: chunk_dst,
+                    },
+                    loc,
+                );
+            }
+            debug_assert_eq!(base, self.temp);
+        }
+        self.temp = old_reg;
+        self.emit_mov(ret, tmp);
         Ok(())
     }
 
@@ -1017,15 +1066,53 @@ impl<'a> BytecodeGen<'a> {
         splat: Vec<Node>,
         loc: Loc,
     ) -> Result<()> {
-        let len = nodes.len();
-        let old_reg = self.temp;
-        let args = self.sp();
-        for (k, v) in nodes {
-            self.push_expr(k)?;
-            self.push_expr(v)?;
+        if nodes.len() <= LITERAL_CHUNK_LEN {
+            let len = nodes.len();
+            let old_reg = self.temp;
+            let args = self.sp();
+            for (k, v) in nodes {
+                self.push_expr(k)?;
+                self.push_expr(v)?;
+            }
+            self.temp = old_reg;
+            self.emit_hash(ret, args.into(), len, loc);
+        } else {
+            // Chunked construction for large Hash literals (see `gen_array`):
+            // the first chunk becomes an ordinary Hash instruction; each
+            // following chunk evaluates its key/value pairs into the same
+            // temporary registers and merges them with HashInsert, keeping
+            // register usage bounded regardless of the literal's size.
+            let old_reg = self.temp;
+            let tmp: BcReg = self.push().into();
+            let base = self.temp;
+            let mut first = true;
+            let mut iter = nodes.into_iter().peekable();
+            while iter.peek().is_some() {
+                let args = self.sp();
+                let mut len = 0;
+                for (k, v) in iter.by_ref().take(LITERAL_CHUNK_LEN) {
+                    self.push_expr(k)?;
+                    self.push_expr(v)?;
+                    len += 1;
+                }
+                self.temp = base;
+                if first {
+                    self.emit_hash(tmp, args.into(), len, loc);
+                    first = false;
+                } else {
+                    self.emit(
+                        BytecodeInst::HashInsert {
+                            hash: tmp,
+                            args: args.into(),
+                            len: len as u16,
+                        },
+                        loc,
+                    );
+                }
+            }
+            self.temp = old_reg;
+            self.emit_mov(ret, tmp);
         }
-        self.temp = old_reg;
-        self.emit_hash(ret, args.into(), len, loc);
         if !splat.is_empty() {
             // For each splat, call merge! on the hash
             let merge_id = IdentId::get_id("merge!");

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -55,8 +55,21 @@ pub(super) enum BytecodeInst {
     /// Heap object (not frozen)
     Literal(BcReg, Value),
     Array(BcReg, Box<CallSite>),
+    /// Concatenate the Array in `src` onto the Array in `dst` (used for the
+    /// 2nd and later chunks of a chunked Array literal).
+    ArrayConcat {
+        dst: BcReg,
+        src: BcReg,
+    },
     Hash {
         ret: BcReg,
+        args: BcReg,
+        len: u16,
+    },
+    /// Insert `len` key/value pairs starting at `args` into the Hash in
+    /// `hash` (used for the 2nd and later chunks of a chunked Hash literal).
+    HashInsert {
+        hash: BcReg,
         args: BcReg,
         len: u16,
     },

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -508,6 +508,8 @@ pub(crate) struct VmHandlers {
     pub lambda: CodePtr,              // 38
     pub array: CodePtr,               // 39
     pub array_teq: CodePtr,           // 40
+    pub array_concat: CodePtr,        // 41
+    pub hash_insert: CodePtr,         // 42
     pub defined_yield: CodePtr,       // 64
     pub defined_const: CodePtr,       // 65
     pub defined_method: CodePtr,      // 66
@@ -614,6 +616,8 @@ impl Codegen {
         self.dispatch[38] = h.lambda;
         self.dispatch[39] = h.array;
         self.dispatch[40] = h.array_teq;
+        self.dispatch[41] = h.array_concat;
+        self.dispatch[42] = h.hash_insert;
 
         self.dispatch[64] = h.defined_yield;
         self.dispatch[65] = h.defined_const;

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1857,6 +1857,67 @@ impl Codegen {
         true
     }
 
+    /// rax <- the Hash in `hash` after inserting the `len` key/value pairs
+    /// at `args`, via hash_insert(vm, globals, &slot[args], len, hash)
+    /// (chunked Hash literal).
+    pub(in crate::codegen::jitgen) fn emit_hash_insert(
+        &mut self,
+        hash: SlotId,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        let lfp = GP::R14.a64().0;
+        let args_off = args.0 as u32 * 8 + LFP_SELF as u32;
+        let hash_off = hash.0 as u32 * 8 + LFP_SELF as u32;
+        let f = runtime::hash_insert as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;              // vm
+            mov x1, x20;              // globals
+        );
+        self.a64_addr_sub(2, lfp, args_off); // x2 = &slot[args]
+        self.a64_frame_load(4, lfp, hash_off); // x4 = hash value
+        monoasm_arm64!(&mut self.jit,
+            mov x3, (len as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        true
+    }
+
+    /// rax <- the Array in `dst` after concatenating the Array in `src`,
+    /// via array_concat(vm, globals, dst, src) (chunked Array literal).
+    pub(in crate::codegen::jitgen) fn emit_array_concat(
+        &mut self,
+        dst: SlotId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        let lfp = GP::R14.a64().0;
+        let dst_off = dst.0 as u32 * 8 + LFP_SELF as u32;
+        let src_off = src.0 as u32 * 8 + LFP_SELF as u32;
+        let f = runtime::array_concat as *const () as u64;
+        self.emit_xmm_save(using_xmm, false);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;              // vm
+            mov x1, x20;              // globals
+        );
+        self.a64_frame_load(2, lfp, dst_off); // x2 = dst value
+        self.a64_frame_load(3, lfp, src_off); // x3 = src value
+        monoasm_arm64!(&mut self.jit,
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.emit_xmm_restore(using_xmm, false);
+        true
+    }
+
     /// rax <- Range via gen_range(start, end, vm, globals, exclude_end).
     pub(in crate::codegen::jitgen) fn emit_new_range(
         &mut self,

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -103,7 +103,9 @@ impl Codegen {
         // literal constructors / aggregate ops
         let array = self.a64_op_array();
         let array_teq = self.a64_op_array_teq();
+        let array_concat = self.a64_op_array_concat();
         let hash = self.a64_op_hash();
+        let hash_insert = self.a64_op_hash_insert();
         let concat = self.a64_op_concat(runtime::concatenate_string as *const () as u64);
         let concat_regexp = self.a64_op_concat(runtime::concatenate_regexp as *const () as u64);
         let range_incl = self.a64_op_range(false);
@@ -186,6 +188,8 @@ impl Codegen {
             lambda,
             array,
             array_teq,
+            array_concat,
+            hash_insert,
             defined_yield,
             defined_const,
             defined_method,
@@ -825,6 +829,53 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             ldrh x3, [x(PC.0)];  // len
             mov x9, (runtime::gen_hash as *const () as u64);
+            blr x9;
+        );
+        self.a64_checked_store_next(&raise);
+        p
+    }
+
+    /// op 42 `HashInsert`: hash_insert(vm, globals, src `[pc+2]`,
+    /// len `[pc+0]`, hash `[pc+4]`). The hash slot doubles as the
+    /// destination (the runtime returns the same hash).
+    pub(in crate::codegen) fn a64_op_hash_insert(&mut self) -> CodePtr {
+        let p = self.jit.get_current_address();
+        let raise = self.entry_raise.clone();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            ldrh x2, [x(PC.0), #(2)];
+        );
+        self.a64_slot_addr(X2); // src
+        monoasm_arm64!(&mut self.jit,
+            ldrh x3, [x(PC.0)];      // len
+            ldrh x10, [x(PC.0), #(4)];  // hash slot
+        );
+        self.a64_load_slot(X10, X4, X11); // x4 = hash value
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (runtime::hash_insert as *const () as u64);
+            blr x9;
+        );
+        self.a64_checked_store_next(&raise);
+        p
+    }
+
+    /// op 41 `ArrayConcat`: array_concat(vm, globals, dst `[pc+4]`,
+    /// src `[pc+2]`). The dst slot doubles as the destination (the runtime
+    /// returns dst).
+    pub(in crate::codegen) fn a64_op_array_concat(&mut self) -> CodePtr {
+        let p = self.jit.get_current_address();
+        let raise = self.entry_raise.clone();
+        monoasm_arm64!(&mut self.jit,
+            ldrh x10, [x(PC.0), #(4)];  // dst slot
+            ldrh x11, [x(PC.0), #(2)];  // src slot
+        );
+        self.a64_load_slot(X10, X2, X12); // x2 = dst value
+        self.a64_load_slot(X11, X3, X12); // x3 = src value
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            mov x9, (runtime::array_concat as *const () as u64);
             blr x9;
         );
         self.a64_checked_store_next(&raise);

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -59,6 +59,8 @@ impl Codegen {
             | AsmInst::CreateArray { .. }
             | AsmInst::NewArray { .. }
             | AsmInst::NewHash(..)
+            | AsmInst::HashInsert { .. }
+            | AsmInst::ArrayConcat { .. }
             | AsmInst::NewRange { .. }
             | AsmInst::ConcatStr { .. }
             | AsmInst::ToA { .. }
@@ -455,6 +457,50 @@ impl Codegen {
         using_xmm: UsingXmm,
     ) -> bool {
         self.new_hash(args, len, using_xmm);
+        true
+    }
+
+    /// rax <- the Hash in `hash` after inserting the `len` key/value pairs
+    /// at `args` (chunked Hash literal).
+    pub(in crate::codegen::jitgen) fn emit_hash_insert(
+        &mut self,
+        hash: SlotId,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            lea  rdx, [rbp - (rbp_local(args))];
+            movq rcx, (len);
+            movq r8, [rbp - (rbp_local(hash))];
+            movq rax, (runtime::hash_insert);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
+        true
+    }
+
+    /// rax <- the Array in `dst` after concatenating the Array in `src`
+    /// (chunked Array literal).
+    pub(in crate::codegen::jitgen) fn emit_array_concat(
+        &mut self,
+        dst: SlotId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    ) -> bool {
+        self.xmm_save(using_xmm);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rdx, [rbp - (rbp_local(dst))];
+            movq rcx, [rbp - (rbp_local(src))];
+            movq rax, (runtime::array_concat);
+            call rax;
+        );
+        self.xmm_restore(using_xmm);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -278,6 +278,8 @@ impl Codegen {
             lambda: self.vm_lambda(),
             array: self.vm_array(),
             array_teq: self.vm_array_teq(),
+            array_concat: self.vm_array_concat(),
+            hash_insert: self.vm_hash_insert(),
             defined_yield: self.vm_defined_yield(),
             defined_const: self.vm_defined_const(),
             defined_method: self.vm_defined_method(),
@@ -868,6 +870,54 @@ impl Codegen {
             movq rdi, rbx;
             movq rsi, r12;
             movq rax, (runtime::gen_hash);
+            call rax;
+        };
+        self.vm_handle_error();
+        self.vm_store_r15(GP::Rax);
+        self.fetch_and_dispatch();
+        label
+    }
+
+    /// op 42 `HashInsert`: hash_insert(vm, globals, src, len, hash). The
+    /// hash slot (:1) doubles as the destination (the runtime returns the
+    /// same hash).
+    fn vm_hash_insert(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        self.fetch3();
+        self.vm_get_slot_addr(GP::Rdi);
+        monoasm! { &mut self.jit,
+            movq rdx, rdi;      // src: *const Value
+            movzxw rcx, rsi;    // len: usize
+            // r8 <- hash value (from slot r15, keeping r15 for the store)
+            movq r8, r15;
+            negq r8;
+            movq r8, [r14 + r8 * 8 - (LFP_SELF)];
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::hash_insert);
+            call rax;
+        };
+        self.vm_handle_error();
+        self.vm_store_r15(GP::Rax);
+        self.fetch_and_dispatch();
+        label
+    }
+
+    /// op 41 `ArrayConcat`: array_concat(vm, globals, dst, src). The dst
+    /// slot (:1) doubles as the destination (the runtime returns dst).
+    fn vm_array_concat(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        self.fetch3();
+        self.vm_get_slot_value(GP::Rdi);
+        monoasm! { &mut self.jit,
+            movq rcx, rdi;      // src: Value
+            // rdx <- dst value (from slot r15, keeping r15 for the store)
+            movq rdx, r15;
+            negq rdx;
+            movq rdx, [r14 + rdx * 8 - (LFP_SELF)];
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::array_concat);
             call rax;
         };
         self.vm_handle_error();

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -750,6 +750,23 @@ impl AsmIr {
         self.push(AsmInst::NewHash(args, len, using_xmm));
     }
 
+    pub(super) fn hash_insert(&mut self, using_xmm: UsingXmm, hash: SlotId, args: SlotId, len: usize) {
+        self.push(AsmInst::HashInsert {
+            hash,
+            args,
+            len,
+            using_xmm,
+        });
+    }
+
+    pub(super) fn array_concat(&mut self, using_xmm: UsingXmm, dst: SlotId, src: SlotId) {
+        self.push(AsmInst::ArrayConcat {
+            dst,
+            src,
+            using_xmm,
+        });
+    }
+
     pub(super) fn new_range(
         &mut self,
         start: SlotId,
@@ -1496,6 +1513,25 @@ pub(super) enum AsmInst {
     /// Create a new Hash object and store it to *rax*
     ///
     NewHash(SlotId, usize, UsingXmm),
+    ///
+    /// Insert `len` key/value pairs at `args` into the Hash in `hash`
+    /// (chunked Hash literal); the hash is returned in *rax*.
+    ///
+    HashInsert {
+        hash: SlotId,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    },
+    ///
+    /// Concatenate the Array in `src` onto the Array in `dst` (chunked
+    /// Array literal); dst is returned in *rax*.
+    ///
+    ArrayConcat {
+        dst: SlotId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    },
     ///
     /// Create a new Range object and store it to *rax*
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -135,6 +135,12 @@ impl Codegen {
             AsmInst::NewHash(args, len, using_xmm) => {
                 return self.emit_new_hash(args, len, using_xmm);
             }
+            AsmInst::HashInsert { hash, args, len, using_xmm } => {
+                return self.emit_hash_insert(hash, args, len, using_xmm);
+            }
+            AsmInst::ArrayConcat { dst, src, using_xmm } => {
+                return self.emit_array_concat(dst, src, using_xmm);
+            }
             AsmInst::NewRange { start, end, exclude_end, using_xmm } => {
                 return self.emit_new_range(start, end, exclude_end, using_xmm);
             }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -214,6 +214,21 @@ impl<'a> JitContext<'a> {
                 ir.handle_error(error);
                 state.def_rax2acc(ir, dst);
             }
+            TraceIr::HashInsert { hash, args, len } => {
+                state.write_back_range(ir, args, len * 2);
+                state.write_back_slots(ir, &[hash]);
+                let error = ir.new_error(state);
+                ir.hash_insert(state.get_using_xmm(), hash, args, len as _);
+                ir.handle_error(error);
+                state.def_rax2acc(ir, hash);
+            }
+            TraceIr::ArrayConcat { dst, src } => {
+                state.write_back_slots(ir, &[dst, src]);
+                let error = ir.new_error(state);
+                ir.array_concat(state.get_using_xmm(), dst, src);
+                ir.handle_error(error);
+                state.def_rax2acc(ir, dst);
+            }
             TraceIr::Range {
                 dst,
                 start,

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -106,9 +106,22 @@ pub(crate) enum TraceIr {
         dst: SlotId,
         callid: CallSiteId,
     },
+    /// Concatenate the Array in `src` onto the Array in `dst` (2nd and later
+    /// chunks of a chunked Array literal).
+    ArrayConcat {
+        dst: SlotId,
+        src: SlotId,
+    },
     Lambda,
     Hash {
         dst: SlotId,
+        args: SlotId,
+        len: u16,
+    },
+    /// Insert `len` key/value pairs starting at `args` into the Hash in
+    /// `hash` (2nd and later chunks of a chunked Hash literal).
+    HashInsert {
+        hash: SlotId,
         args: SlotId,
         len: u16,
     },
@@ -472,6 +485,21 @@ impl TraceIr {
                     TraceIr::ArrayTEq {
                         lhs: SlotId::new(op1_w2),
                         rhs: SlotId::new(op1_w3),
+                    }
+                }
+                41 => {
+                    let (op1_w1, op1_w2, _) = dec_www(op1);
+                    TraceIr::ArrayConcat {
+                        dst: SlotId::new(op1_w1),
+                        src: SlotId::new(op1_w2),
+                    }
+                }
+                42 => {
+                    let (op1_w1, op1_w2, op1_w3) = dec_www(op1);
+                    TraceIr::HashInsert {
+                        hash: SlotId::new(op1_w1),
+                        args: SlotId::new(op1_w2),
+                        len: op1_w3,
                     }
                 }
                 _ => unreachable!("{:016x}", op1),
@@ -851,6 +879,12 @@ impl TraceIr {
             }
             TraceIr::Hash { dst, args, len } => {
                 format!("{:?} = hash[{:?}; {}]", dst, args, len)
+            }
+            TraceIr::HashInsert { hash, args, len } => {
+                format!("{:?}.insert[{:?}; {}]", hash, args, len)
+            }
+            TraceIr::ArrayConcat { dst, src } => {
+                format!("{:?}.concat({:?})", dst, src)
             }
             TraceIr::Index {
                 _dst: dst,

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -258,6 +258,52 @@ fn gen_hash_inner(
     Ok(map)
 }
 
+///
+/// Insert `len` key/value pairs (the `len * 2` slots ending at `src`) into
+/// the Hash `hash`. Used for the 2nd and later chunks of a chunked Hash
+/// literal (op 42); duplicate keys overwrite, like `gen_hash`.
+///
+pub(super) extern "C" fn hash_insert(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: *const Value,
+    len: usize,
+    hash: Value,
+) -> Option<Value> {
+    let mut h = hash.as_hash();
+    if len > 0 {
+        // SAFETY: the bytecode compiler guarantees `len * 2` consecutive
+        // value slots ending at `src` (same layout as `gen_hash`).
+        let mut iter = unsafe { std::slice::from_raw_parts(src.sub(len * 2 - 1), len * 2) }
+            .iter()
+            .copied()
+            .rev();
+        while let Ok(chunk) = iter.next_chunk::<2>() {
+            if let Err(err) = h.insert(chunk[0], chunk[1], vm, globals) {
+                vm.set_error(err);
+                return None;
+            }
+        }
+    }
+    Some(hash)
+}
+
+///
+/// Concatenate the Array `src` onto the Array `dst`. Used for the 2nd and
+/// later chunks of a chunked Array literal (op 41).
+///
+pub(super) extern "C" fn array_concat(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    dst: Value,
+    src: Value,
+) -> Option<Value> {
+    let mut d = dst.as_array();
+    let s = src.as_array();
+    d.extend_from_slice(&s);
+    Some(dst)
+}
+
 pub(super) extern "C" fn empty_hash() -> Value {
     let map = RubyMap::default();
     Value::hash(map)


### PR DESCRIPTION
## Summary

Fixes #706: a Hash/Array literal allocated ~2 temporary registers per entry (one per element) in a single frame. Since `Lfp` frames live on the native machine stack (`MAX_STACK_SIZE` = 64 KiB), a literal with thousands of entries exhausted the whole budget by itself: entering the enclosing frame succeeded (`vm_init` allocates unchecked), and the first nested invocation afterwards — for the repro, the `const_added` hook fired by `Executor::set_constant` for the constant assignment holding the literal — hit the invoker-prologue stack check and raised `StackOverflow`. This is what made addressable 2.9.0 (`idna/pure.rb`, ~4,234-entry `UNICODE_DATA`) fail to load. Literals with >32k entries additionally panicked on u16 overflow of bytecodegen's temp-register counter.

## Fix

Following CRuby's compiler, literals longer than `LITERAL_CHUNK_LEN` (256) are now built in chunks that re-use the same temporary registers, so per-frame register usage is bounded regardless of literal size:

- **Hash**: the first chunk uses the existing `Hash` instruction; each later chunk re-evaluates its key/value pairs into the same registers and merges them with a new `HashInsert` bytecode (op 42 → `runtime::hash_insert`, write-barrier-aware via `Hashmap::insert`, duplicate keys overwrite as before). `**` splats keep using the existing `merge!` path.
- **Array**: the first chunk uses the existing (splat-aware) `Array` instruction; each later chunk is built into a scratch register and appended with a new `ArrayConcat` bytecode (op 41 → `runtime::array_concat`, write-barrier-aware via `Array::extend_from_slice`).
- Both build into a temporary and `Mov` to the destination at the end, so a local-variable destination never holds a half-built collection if an element expression raises (matches CRuby).

Both new ops are implemented in the VM tier **and** the JIT lowering (TraceIR → AsmIR → machine code) for x86-64 and aarch64; JIT compilation of methods containing chunked literals was verified with `jit-log`.

## Verification

- Issue repro: 3,000 / 4,000 / 40,000-entry Hash literals all load and evaluate correctly (40,000 previously panicked on the u16 temp counter; chunking removes that too).
- Compared against CRuby: insertion order and duplicate keys across chunk boundaries, splats inside chunked array literals, `**` splat after a chunked Hash part, element evaluation order/side effects, and exception behavior mid-literal.
- New regression tests in `builtins/hash.rs` / `builtins/array.rs` (chunk-boundary cases + 4,000-entry repros; `run_test` exercises the JIT path).
- Full `cargo test --lib`: failure set identical to master in this environment (the 33 pre-existing failures are due to the local Ruby being 3.3.6 instead of the required 4.0+); +4 passes from the new tests.
- aarch64 backend type-checked via cross-compilation (`cargo check --target aarch64-unknown-linux-gnu`).

https://claude.ai/code/session_01LENQ2cMQseji6L1HB27Ggj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LENQ2cMQseji6L1HB27Ggj)_