### PR TITLE
Raise ArgumentError for missing required keyword arguments (fixes #707)

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -399,7 +399,8 @@ fn fill_positional_args(
     // Only an *explicit* `*rest`/`*` lifts the upper bound.
     if !is_block_style && (buf_len < min_args || (buf_len > max_args && !callee.is_explicit_rest()))
     {
-        return Err(MonorubyErr::wrong_number_of_arg_range(
+        return Err(wrong_number_of_arg_with_kw(
+            callee,
             buf_len,
             min_args..=max_args,
         ));
@@ -505,7 +506,8 @@ fn handle_keyword(
     caller_lfp: Lfp,
 ) -> Result<()> {
     ordinary_keyword(globals, callee, caller, callee_lfp, caller_lfp)?;
-    hash_splat_and_kw_rest(vm, globals, callee, caller, callee_lfp, caller_lfp)
+    hash_splat_and_kw_rest(vm, globals, callee, caller, callee_lfp, caller_lfp)?;
+    check_missing_keyword(&globals.store[callee], callee_lfp)
 }
 
 fn handle_keyword_simple(callee: &FuncInfo, mut callee_lfp: Lfp) -> Result<()> {
@@ -519,7 +521,83 @@ fn handle_keyword_simple(callee: &FuncInfo, mut callee_lfp: Lfp) -> Result<()> {
     if let Some(rest) = callee.kw_rest() {
         unsafe { callee_lfp.set_register(rest, Some(Value::nil())) }
     }
-    Ok(())
+    check_missing_keyword(callee, callee_lfp)
+}
+
+///
+/// Raise ArgumentError if a required keyword parameter (one with no
+/// default expression) was left unbound (None) after keyword binding.
+/// Must run after *all* keyword sources (ordinary keyword arguments and
+/// hash splats) have been applied. An unbound optional keyword slot is
+/// left as None on purpose — the method prologue fills in the default.
+///
+fn check_missing_keyword(callee: &FuncInfo, callee_lfp: Lfp) -> Result<()> {
+    let kw_pos = callee.kw_reg_pos();
+    let mut missing = vec![];
+    for (i, name) in callee.kw_names().iter().enumerate() {
+        if callee.kw_is_required(i) && callee_lfp.register(kw_pos + i).is_none() {
+            missing.push(*name);
+        }
+    }
+    missing_keyword_err(&missing)
+}
+
+///
+/// Positional-arity ArgumentError. When the callee also has required
+/// keyword parameters, CRuby appends them to the message:
+/// `wrong number of arguments (given 0, expected 1; required keyword: x)`.
+///
+fn wrong_number_of_arg_with_kw(
+    callee: &FuncInfo,
+    given: usize,
+    range: std::ops::RangeInclusive<usize>,
+) -> MonorubyErr {
+    let required: Vec<_> = callee
+        .kw_names()
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| callee.kw_is_required(*i))
+        .map(|(_, name)| name.to_string())
+        .collect();
+    if required.is_empty() {
+        return MonorubyErr::wrong_number_of_arg_range(given, range);
+    }
+    let expected = if range.start() == range.end() {
+        format!("{}", range.start())
+    } else {
+        format!("{}..{}", range.start(), range.end())
+    };
+    let suffix = if required.len() == 1 {
+        format!("; required keyword: {}", required[0])
+    } else {
+        format!("; required keywords: {}", required.join(", "))
+    };
+    MonorubyErr::argumenterr(format!(
+        "wrong number of arguments (given {given}, expected {expected}{suffix})"
+    ))
+}
+
+///
+/// Build CRuby-compatible `missing keyword(s)` ArgumentError (no-op for
+/// an empty list): `missing keyword: :x` / `missing keywords: :x, :y`.
+///
+fn missing_keyword_err(missing: &[IdentId]) -> Result<()> {
+    match missing {
+        [] => Ok(()),
+        [name] => Err(MonorubyErr::argumenterr(format!(
+            "missing keyword: :{name}"
+        ))),
+        _ => {
+            let names = missing
+                .iter()
+                .map(|name| format!(":{name}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(MonorubyErr::argumenterr(format!(
+                "missing keywords: {names}"
+            )))
+        }
+    }
 }
 
 fn ordinary_keyword(
@@ -777,6 +855,10 @@ fn invoker_arguments_inner(
     // required + optional + post + rest
     positional_invoker(info, callee_lfp, args, arg_num, upward, ex)?;
 
+    // After the positional check, so a call that is wrong in both ways
+    // reports the positional arity error first, like CRuby.
+    check_missing_keyword(info, callee_lfp)?;
+
     Ok(Value::nil())
 }
 
@@ -811,6 +893,42 @@ mod tests {
             B3.new.a(1, 2)
             "#,
         );
+    }
+
+    #[test]
+    fn missing_required_keyword() {
+        // issue #707: a call without one of the required keyword
+        // arguments must raise ArgumentError (`missing keyword: :x`)
+        // instead of silently binding nil. Compare the exact message
+        // with CRuby via the rescue idiom; `run_test`'s warm-up loop
+        // also exercises the JIT path.
+        let msg = "def msg; yield; \"no error\"; rescue ArgumentError => e; e.message; end;";
+        run_test(&format!("{msg} def m(x:, y: 10) = [x, y]; msg {{ m(y: 1) }}"));
+        run_test(&format!("{msg} def m(x:, y:) = [x, y]; msg {{ m() }}"));
+        run_test(&format!("{msg} def m(x:, **r) = [x, r]; msg {{ m(a: 1) }}"));
+        run_test(&format!("{msg} def m(x:) = x; msg {{ m(**{{}}) }}"));
+        // A hash splat *can* supply the required keyword.
+        run_test(&format!("{msg} def m(x:) = x; h = {{x: 5}}; [msg {{ m(**h) }}, m(**h)]"));
+        // Positional arity errors win and mention the required keywords.
+        run_test(&format!("{msg} def m(a, x:) = [a, x]; msg {{ m() }}"));
+        run_test(&format!("{msg} msg {{ lambda {{ |a, x:, y:| }}.call }}"));
+        // Native forwarding (Class#new), send, Method#call, procs,
+        // blocks, and define_method all take the invoker/blocks paths.
+        run_test(&format!(
+            "{msg} class KwOnly; def initialize(x:, y: 10) = @x = x; end; msg {{ KwOnly.new(y: 1) }}"
+        ));
+        run_test(&format!("{msg} def m(x:) = x; msg {{ send(:m) }}"));
+        run_test(&format!("{msg} def m(x:) = x; msg {{ method(:m).call }}"));
+        run_test(&format!("{msg} msg {{ proc {{ |x:| x }}.call }}"));
+        run_test(&format!("{msg} msg {{ [1].each {{ |x:| x }} }}"));
+        run_test(&format!(
+            "{msg} define_method(:dm) {{ |x:| x }}; msg {{ dm }}"
+        ));
+        run_test(&format!(
+            "{msg} def m(x:, y: 10) = [x, y]; def fw(...) = m(...); [msg {{ fw(y: 2) }}, fw(x: 9)]"
+        ));
+        // Optional-only keywords still default without error.
+        run_test("def m(y: 10) = y; [m, m(y: 1)]");
     }
 
     #[test]

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1073,6 +1073,12 @@ impl FuncInfo {
         &self.ext.params.kw_names
     }
 
+    /// Whether the keyword parameter at `idx` in `kw_names` is required
+    /// (has no default expression).
+    pub(crate) fn kw_is_required(&self, idx: usize) -> bool {
+        self.ext.params.kw_is_required(idx)
+    }
+
     pub(crate) fn kw_rest(&self) -> Option<SlotId> {
         self.ext.params.kw_rest
     }
@@ -1317,6 +1323,16 @@ impl Store {
         if info.no_keyword() && callsite.kw_may_exists() {
             return false;
         };
+        // A callsite that statically lacks a required keyword must take
+        // the generic runtime path, which raises the `missing keyword`
+        // ArgumentError; the inline argument setup would silently bind
+        // None. (A hash splat could still supply it, but hash-splat
+        // callsites are rejected below anyway.)
+        for (i, name) in info.kw_names().iter().enumerate() {
+            if info.kw_is_required(i) && !callsite.kw_args.contains_key(name) {
+                return false;
+            }
+        }
         !callsite.has_splat()
             && !callsite.has_hash_splat()
             && (info.is_block_style()


### PR DESCRIPTION
## Summary

Fixes #707: calling a method without one of its **required** keyword arguments silently bound the parameter to `nil` instead of raising `ArgumentError (missing keyword: :x)`. The unknown-keyword check existed, but the missing-required check was absent from every callee-side binding path. The `kw_required` metadata already existed on `ParamsInfo` (used only by `Method#parameters`); this wires it into argument binding.

## Fix

- Add `check_missing_keyword`, run after *all* keyword binding (ordinary keywords + hash splats) on every callee-side path:
  - `handle_keyword` — ordinary calls and splat/forwarding calls
  - `handle_keyword_simple` — `send`-splat calls
  - `invoker_arguments_inner` — invoker calls (`Class#new` native forwarding, `Method#call`, procs/blocks/`define_method`); placed after the positional check so a doubly-wrong call reports the arity error first, like CRuby
- The JIT's inline argument setup for cached simple calls bypasses those runtime handlers and would bind `None` silently, so `is_simple_call` now statically rejects callsites that lack a required keyword, routing them through the generic runtime path (the situation is statically known: such a call always raises).
- CRuby-compatible messages: `missing keyword: :x` / `missing keywords: :x, :y`, and the positional-arity message now appends required keywords when present: `wrong number of arguments (given 0, expected 1; required keyword: x)`.

## Verification

- Issue repro (plain call, JIT and `--no-jit`, `Class#new`) now matches CRuby.
- ~20 edge cases compared against CRuby with exact message equality: `**h` supplying the keyword, `**{}` not, `send` / `Method#call` / proc / lambda / blocks / `define_method` / `each`-block / zsuper / `...` forwarding, `**rest` not satisfying required keywords, JIT-warmed loops (30 calls), error precedence with positional arity.
- New regression test `missing_required_keyword` (15 cases, message strings compared with CRuby; `run_test`'s warm-up loop exercises the JIT path).
- Full `cargo test --lib`: failure set identical to the master baseline in this environment (pre-existing failures due to local Ruby 3.3.6 < required 4.0).
- aarch64 cross-check passes (the change is arch-neutral Rust only).

https://claude.ai/code/session_01LENQ2cMQseji6L1HB27Ggj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LENQ2cMQseji6L1HB27Ggj)_