### PR TITLE
Preserve the return value of custom ==/!= dispatches

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -389,6 +389,21 @@ mod tests {
     }
 
     #[test]
+    fn cmp_dispatch_raw_in_bop_redefined_mode() {
+        // Overwriting a basic op (Integer#!=) trips set_bop_redefine and
+        // flips the VM to the *_no_opt cmp handlers; those must also
+        // dispatch ==/!= raw (and honor the redefined basic op itself).
+        run_test_once(
+            r##"
+        class Integer; def !=(o); "INT-NE"; end; end
+        class CustomEqB; def ==(o); "RAW-B"; end; end
+        e = CustomEqB.new
+        [1 != 2, e == 1, e != 1, "a" == "a", "a" != "b", nil == nil, nil != 1]
+        "##,
+        );
+    }
+
+    #[test]
     fn neq_custom_redefinition() {
         // Exercises the version-stamped `custom_neq` memo: `!=` on a class
         // computes `!(a == b)` while it resolves to the default, and a

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -370,6 +370,25 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn cmp_dispatch_preserves_return_value() {
+        // A custom `==` / `!=` may return an arbitrary value; the binop
+        // must evaluate to it untouched (CRuby semantics). Reverse
+        // coercion dispatches (`1 == obj`) stay boolean-coerced, and the
+        // default `!=` is the boolean negation of `==`.
+        run_test_once(
+            r##"
+        class CustomEq; def ==(o); "EQ-RAW"; end; end
+        class CustomNe; def ==(o); true; end; def !=(o); "NE-RAW"; end; end
+        e = CustomEq.new
+        n = CustomNe.new
+        res = [e == 1, e != 1, n != 1, n == 1, 1 == e, "a" == e]
+        30.times { res << (e == 1) << (n != 1) }
+        res
+        "##,
+        );
+    }
+
+    #[test]
     fn neq_custom_redefinition() {
         // Exercises the version-stamped `custom_neq` memo: `!=` on a class
         // computes `!(a == b)` while it resolves to the default, and a

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1613,9 +1613,18 @@ impl Executor {
         lhs: Value,
         rhs: Value,
     ) -> Result<bool> {
+        Ok(self.invoke_eq_raw(globals, lhs, rhs)?.as_bool())
+    }
+
+    /// Dispatch `lhs == rhs` and return the method's value untouched.
+    pub(crate) fn invoke_eq_raw(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+    ) -> Result<Value> {
         let func_id = self.find_method(globals, lhs, IdentId::_EQ, true)?;
-        let b = self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)?;
-        Ok(b.as_bool())
+        self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)
     }
 
     pub(crate) fn invoke_method_missing(

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -169,12 +169,20 @@ cmp_values!(
 );
 
 impl Executor {
-    pub(crate) fn eq_values_bool(
+    ///
+    /// `==` with CRuby-faithful result-value semantics: the fast paths
+    /// produce booleans, and a *reverse* coercion dispatch (`1 == obj`
+    /// re-asking `obj == 1`) coerces the answer to a boolean exactly like
+    /// CRuby's `rb_equal`, but a direct dispatch of the receiver's own
+    /// `==` returns the method's value untouched (`obj == 1` evaluates to
+    /// whatever `obj.==` returned).
+    ///
+    pub(crate) fn eq_values(
         &mut self,
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
-    ) -> Result<bool> {
+    ) -> Result<Value> {
         let b = match (lhs.unpack(), rhs.unpack()) {
             (RV::Nil, RV::Nil) => true,
             (RV::Nil, _) => false,
@@ -182,8 +190,9 @@ impl Executor {
             (RV::Fixnum(lhs), RV::BigInt(rhs)) => BigInt::from(lhs).eq(rhs),
             (RV::Fixnum(lhs), RV::Float(rhs)) => (lhs as f64).eq(&rhs),
             (RV::Fixnum(_), _) => {
-                // Reverse dispatch: try rhs == lhs
-                return self.invoke_eq(globals, rhs, lhs);
+                // Reverse dispatch: try rhs == lhs (boolean-coerced, like
+                // CRuby's num_equal -> rb_equal)
+                return Ok(Value::bool(self.invoke_eq(globals, rhs, lhs)?));
             }
             (RV::BigInt(lhs), RV::Fixnum(rhs)) => lhs.eq(&BigInt::from(rhs)),
             (RV::BigInt(lhs), RV::BigInt(rhs)) => lhs.eq(rhs),
@@ -191,8 +200,8 @@ impl Executor {
                 bigint_cmp_float(lhs, rhs) == Some(std::cmp::Ordering::Equal)
             }
             (RV::BigInt(_), _) => {
-                // Reverse dispatch: try rhs == lhs
-                return self.invoke_eq(globals, rhs, lhs);
+                // Reverse dispatch: try rhs == lhs (boolean-coerced)
+                return Ok(Value::bool(self.invoke_eq(globals, rhs, lhs)?));
             }
             (RV::Float(lhs), RV::Fixnum(rhs)) => lhs.eq(&(rhs as f64)),
             (RV::Float(lhs), RV::BigInt(rhs)) => {
@@ -200,8 +209,8 @@ impl Executor {
             }
             (RV::Float(lhs), RV::Float(rhs)) => lhs.eq(&rhs),
             (RV::Float(_), _) => {
-                // Reverse dispatch: try rhs == lhs
-                return self.invoke_eq(globals, rhs, lhs);
+                // Reverse dispatch: try rhs == lhs (boolean-coerced)
+                return Ok(Value::bool(self.invoke_eq(globals, rhs, lhs)?));
             }
             (RV::Bool(lhs), RV::Bool(rhs)) => lhs.eq(&rhs),
             (RV::Bool(_), _) => false,
@@ -228,29 +237,44 @@ impl Executor {
                 if globals.store.no_to_str(rhs.class(), Globals::class_version()) {
                     false
                 } else {
-                    return self.invoke_eq(globals, rhs, lhs);
+                    return Ok(Value::bool(self.invoke_eq(globals, rhs, lhs)?));
                 }
             }
-            _ => self.invoke_eq(globals, lhs, rhs)?,
+            _ => return self.invoke_eq_raw(globals, lhs, rhs),
         };
-        Ok(b)
+        Ok(Value::bool(b))
     }
 
-    pub(crate) fn eq_values_bool_no_opt(
+    pub(crate) fn eq_values_bool(
         &mut self,
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
     ) -> Result<bool> {
-        self.invoke_eq(globals, lhs, rhs)
+        Ok(self.eq_values(globals, lhs, rhs)?.as_bool())
     }
 
-    pub(crate) fn ne_values_bool(
+    pub(crate) fn eq_values_no_opt(
         &mut self,
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
-    ) -> Result<bool> {
+    ) -> Result<Value> {
+        self.invoke_eq_raw(globals, lhs, rhs)
+    }
+
+    ///
+    /// `!=` with CRuby-faithful result-value semantics: while `!=`
+    /// resolves to a basic op / the default `BasicObject#!=`, the result
+    /// is the boolean negation of `==`; a custom `!=` returns the
+    /// method's value untouched.
+    ///
+    pub(crate) fn ne_values(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+    ) -> Result<Value> {
         // Check if the receiver has a custom != method (not a basic op /
         // the default BasicObject#!=). If so, dispatch to it directly
         // instead of negating ==. `custom_neq` is memoized per
@@ -259,25 +283,34 @@ impl Executor {
         let class_id = lhs.class();
         if let Some(entry) = globals.store.custom_neq(class_id, Globals::class_version()) {
             if let Some(func_id) = entry.func_id() {
-                let b = self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)?;
-                return Ok(b.as_bool());
+                return self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None);
             }
         }
-        Ok(!self.eq_values_bool(globals, lhs, rhs)?)
+        Ok(Value::bool(!self.eq_values_bool(globals, lhs, rhs)?))
     }
 
-    pub(crate) fn ne_values_bool_no_opt(
+    pub(crate) fn ne_values_bool(
         &mut self,
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
     ) -> Result<bool> {
+        Ok(self.ne_values(globals, lhs, rhs)?.as_bool())
+    }
+
+    pub(crate) fn ne_values_no_opt(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+    ) -> Result<Value> {
         let func_id = self.find_method(globals, lhs, IdentId::_NEQ, true)?;
-        let b = self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)?;
-        Ok(b.as_bool())
+        self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)
     }
 }
 
+// `==` / `!=` wrappers return the dispatched method's value as-is (the
+// fast paths inside `eq_values` / `ne_values` produce booleans).
 macro_rules! eq_values {
     ($op:ident) => {
         paste! {
@@ -287,8 +320,8 @@ macro_rules! eq_values {
                 lhs: Value,
                 rhs: Value
             ) -> Option<Value> {
-                match vm.[<$op _values_bool>](globals, lhs, rhs) {
-                    Ok(b) => Some(Value::bool(b)),
+                match vm.[<$op _values>](globals, lhs, rhs) {
+                    Ok(v) => Some(v),
                     Err(err) => {
                         vm.set_error(err);
                         None
@@ -304,8 +337,8 @@ macro_rules! eq_values {
                 lhs: Value,
                 rhs: Value
             ) -> Option<Value> {
-                match vm.[<$op _values_bool_no_opt>](globals, lhs, rhs) {
-                    Ok(b) => Some(Value::bool(b)),
+                match vm.[<$op _values_no_opt>](globals, lhs, rhs) {
+                    Ok(v) => Some(v),
                     Err(err) => {
                         vm.set_error(err);
                         None


### PR DESCRIPTION
## Summary

Fixes divergence (b) found while auditing `!=` resolution: a binop `a == b` / `a != b` that dispatches the receiver's **own** method must evaluate to whatever that method returned. monoruby coerced the result to a boolean (a custom `!=` returning a string evaluated to `true`) — and the VM tier disagreed with the JIT-monomorphic tier, which compiles a real method call and was already returning the raw value.

```ruby
class Foo
  def ==(o); "EQ-RAW"; end
end
Foo.new == 1   # CRuby: "EQ-RAW" / before: true / after: "EQ-RAW"
```

## Changes

- `Executor::eq_values` / `ne_values` (new): `Value`-returning forms.
  - fast paths and the **default** `!=` (boolean negation of `==`, matching CRuby's `rb_obj_not_equal`) still produce booleans;
  - a direct dispatch of the receiver's own `==` / a custom `!=` returns the method's value untouched;
  - **reverse** coercion dispatches (`1 == obj` re-asking `obj == 1`) keep CRuby's boolean coercion (`rb_equal` / `num_equal` semantics — verified against CRuby 4.0.5: `1 == obj_with_custom_eq` is `true`, not the custom value).
- `eq_values_bool` / `ne_values_bool` become truthiness wrappers for internal callers that only branch on the answer (`Array#==`, `Struct#==`, `Integer#!=`, …).
- `cmp_eq/ne_values` (+ `_no_opt`) — the VM and JIT-generic entry points — pass the `Value` through instead of re-wrapping with `Value::bool`.
- `Executor::invoke_eq_raw` (new), with `invoke_eq` as its truthiness wrapper.

## Testing

- New regression test `cmp_dispatch_preserves_return_value` covering: raw custom `==`, default `!=` over a custom `==` (boolean), raw custom `!=`, reverse coercion, and JIT-warmed iterations.
- Full suite: **1655 passed, 0 failed.**
- Output matrix cross-checked against CRuby 4.0.5.

Note: while building the verification matrix for this fix I found an unrelated, pre-existing VM bug — the method-call inline cache keys `true`/`false` receivers by the unified `BOOL_CLASS` without checking that `TrueClass`/`FalseClass` resolve to the same method, so `p true; p false` prints `true` twice (the second call runs `TrueClass#inspect` via the Ruby-level `p`'s `args[0].inspect` call site). Filing it as a separate issue with the full analysis.

https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq)_