### PR TITLE
Don't unify true/false in the method-call IC unless both classes resolve identically (fixes #713)

### DIFF
--- a/monoruby/src/builtins/true_class.rs
+++ b/monoruby/src/builtins/true_class.rs
@@ -14,6 +14,51 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn bool_receiver_ic_divergent_methods() {
+        // #713: a single call site dispatching on both `true` and `false`
+        // may only share the BOOL_CLASS-unified inline cache when
+        // TrueClass and FalseClass resolve the method to the same
+        // FuncId. Divergent methods (inspect/to_s, user-defined) must
+        // run each receiver's own method; unified ones (`!`) keep the
+        // fast path. 50 iterations cover the JIT tier.
+        run_test_once(
+            r##"
+        res = []
+        50.times do |i|
+          v = (i % 2 == 0)
+          res << v.inspect << v.to_s << v.!
+        end
+        res.uniq
+        "##,
+        );
+        run_test_once(
+            r##"
+        class TrueClass; def label713; "yes"; end; end
+        class FalseClass; def label713; "no"; end; end
+        res = []
+        50.times { |i| res << (i % 2 == 0).label713 }
+        res.uniq
+        "##,
+        );
+        // A method present on only one of the two classes must not leak
+        // to the other through the unified cache.
+        run_test_once(
+            r##"
+        class TrueClass; def only_true713; 1; end; end
+        res = []
+        50.times do |i|
+          begin
+            res << (i % 2 == 0).only_true713
+          rescue NoMethodError
+            res << :nme
+          end
+        end
+        res.uniq
+        "##,
+        );
+    }
+
+    #[test]
     fn to_s() {
         run_tests(&[
             r##"true.to_s"##,

--- a/monoruby/src/builtins/true_class.rs
+++ b/monoruby/src/builtins/true_class.rs
@@ -40,6 +40,18 @@ mod tests {
         res.uniq
         "##,
         );
+        // Super dispatch on a bool receiver (a callsite without a name)
+        // tags the cache with the real class unconditionally. `super`
+        // has no super-method here, so both engines raise NoMethodError.
+        run_test_once(
+            r##"
+        class TrueClass; def label_t713; super rescue "T"; end; end
+        class FalseClass; def label_f713; super rescue "F"; end; end
+        res = []
+        50.times { |i| v = (i % 2 == 0); res << (v ? v.label_t713 : v.label_f713) }
+        res.uniq
+        "##,
+        );
         // A method present on only one of the two classes must not leak
         // to the other through the unified cache.
         run_test_once(

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1577,7 +1577,11 @@ impl Codegen {
         // the caller-saved receiver register; recv was stored there above).
             ldur x3, [sp, #(-((RSP_LOCAL_FRAME + LFP_SELF) as i32))];
             mov x9, (runtime::find_method as *const () as u64);
-            blr x9;  // x0 = Option<FuncId> (0 = method_missing)
+            // x0 = (ClassId to tag the cache with) << 32 | FuncId
+            // (low 32 = 0 -> method_missing). The tag is the receiver's
+            // IC class, or its real class for a bool receiver whose
+            // method is not unified across TrueClass/FalseClass (#713).
+            blr x9;
         );
         // Populate the inline cache (X0 = FuncId, preserved across the call).
         self.a64_save_method_cache();
@@ -2038,31 +2042,26 @@ impl Codegen {
 
     /// Stamp the method-call inline cache so the JIT can specialize this call
     /// site (otherwise `pc.method_cache()` stays `None` and every call deopts).
-    /// Mirrors x86 `save_cache`. On entry X0 = the resolved FuncId. Writes
-    /// FuncId @ `[PC+16]`, receiver ClassId @ `[PC+24]` and the current
-    /// class_version @ `[PC+28]` (the layout `method_cache()` reads). The
-    /// receiver is reloaded from its slot `[PC+12]` (rather than trusting a
-    /// register) since `find_method` is a C call that clobbers the caller-saved
-    /// receiver register. X0 is preserved (reloaded from the FuncId cache
-    /// slot); clobbers X1/X2/X11 and the link register.
+    /// Mirrors x86 `save_cache`. On entry X0 = `runtime::find_method`'s packed
+    /// result: the cache-tag ClassId in the high 32 bits and the resolved
+    /// FuncId in the low 32 (the tag is the receiver's IC class, or its real
+    /// class for a bool receiver with a non-unified method — #713). Writes
+    /// FuncId @ `[PC+16]`, the tag ClassId @ `[PC+24]` and the current
+    /// class_version @ `[PC+28]` (the layout `method_cache()` reads). On exit
+    /// X0 = the FuncId (zero-extended); clobbers X1/X11.
     pub(in crate::codegen) fn a64_save_method_cache(&mut self) {
         let cv_addr = self
             .jit
             .get_label_address(&self.class_version_label())
             .as_ptr() as u64;
-        let get_class = self.get_class.clone();
         monoasm_arm64!(&mut self.jit,
-            str w0, [x(PC.0), #(16)];   // CACHED_FUNCID (also our save of X0)
-            ldrh x0, [x(PC.0), #(12)];  // recv slot index
-        );
-        self.a64_slot_value(X0); // X0 = receiver value
-        monoasm_arm64!(&mut self.jit,
-            bl get_class;               // x0 = class(recv)
-            str w0, [x(PC.0), #(24)];   // CACHED_CLASS
+            str w0, [x(PC.0), #(16)];   // CACHED_FUNCID (low 32 bits)
+            lsr x1, x0, #(32);
+            str w1, [x(PC.0), #(24)];   // CACHED_CLASS (cache tag)
             mov x11, (cv_addr);
-            ldr w0, [x11];              // class_version (i32)
-            str w0, [x(PC.0), #(28)];   // CACHED_VERSION
-            ldr w0, [x(PC.0), #(16)];   // reload FuncId into X0 (u32, zero-ext)
+            ldr w1, [x11];              // class_version (i32)
+            str w1, [x(PC.0), #(28)];   // CACHED_VERSION
+            ldr w0, [x(PC.0), #(16)];   // X0 = FuncId (u32, zero-ext)
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1576,12 +1576,20 @@ impl Codegen {
         // reload recv from the callee self slot (get_class/find_method clobber
         // the caller-saved receiver register; recv was stored there above).
             ldur x3, [sp, #(-((RSP_LOCAL_FRAME + LFP_SELF) as i32))];
+        // Reserve scratch below the callee frame being built: its slots
+        // (LFP_SELF in particular) live *below* SP, and AAPCS64 has no
+        // red zone, so find_method's C frame would otherwise overwrite
+        // them — boot-breaking once the callee's frame happens to reach
+        // that depth. Mirrors x86 `subq rsp, 1016` around the same call
+        // and the vm_handle_arguments reservation below.
+            sub sp, sp, #(1024);
             mov x9, (runtime::find_method as *const () as u64);
             // x0 = (ClassId to tag the cache with) << 32 | FuncId
             // (low 32 = 0 -> method_missing). The tag is the receiver's
             // IC class, or its real class for a bool receiver whose
             // method is not unified across TrueClass/FalseClass (#713).
             blr x9;
+            add sp, sp, #(1024);
         );
         // Populate the inline cache (X0 = FuncId, preserved across the call).
         self.a64_save_method_cache();

--- a/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
@@ -277,7 +277,13 @@ impl Codegen {
             movq rsi, r12;
             movl rdx, [r13 + (CALLSITE_ID)];  // CallSiteId
             movq rax, (runtime::find_method);
-            call rax;   // rax <- Option<FuncId>
+            // rax <- (ClassId to tag the cache with) << 32 | FuncId
+            // (0 = method_missing). The tag differs from r15's
+            // get_class result for a bool receiver whose method is not
+            // unified across TrueClass/FalseClass (#713).
+            call rax;
+            movq r15, rax;
+            shrq r15, 32;
             movl rax, rax;
             popq rcx;
             addq rsp, 1016;
@@ -295,7 +301,9 @@ impl Codegen {
     ///
     /// ### in
     /// - rax: FuncId
-    /// - r15: ClassId of receiver
+    /// - r15: ClassId to tag the cache with (the receiver's IC class,
+    ///   or the real class for a bool receiver with a non-unified
+    ///   method — see `runtime::find_method`)
     ///
     fn save_cache(&mut self) {
         let class_version = self.class_version_label();

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -10,20 +10,48 @@ pub const PROCDATA_FUNCID: i64 = std::mem::offset_of!(ProcData, func_id) as _;
 // Runtime functions.
 //
 
+/// Resolve the method for a call-site inline-cache miss.
+///
+/// Returns the resolved `FuncId` in the **low 32 bits** (0 = not found /
+/// method_missing; the error, if any, is set on the executor) and the
+/// `ClassId` to **tag the inline cache with** in the **high 32 bits**.
+///
+/// For most receivers the tag is the receiver's class. `true` / `false`
+/// are unified under `BOOL_CLASS` *only when both `TrueClass` and
+/// `FalseClass` resolve the name to the same method* (the
+/// `check_bool_method_with_version` rule). Otherwise the cache is tagged
+/// with the receiver's real class, so the *other* boolean misses and
+/// re-resolves instead of hitting this entry and running the wrong
+/// class's method (#713). Super dispatch (no callsite name) is tagged
+/// with the real class unconditionally.
 pub(super) extern "C" fn find_method(
     vm: &mut Executor,
     globals: &mut Globals,
     callid: CallSiteId,
     recv: Value,
-) -> Option<FuncId> {
-    if let Some(func_name) = globals[callid].name {
+) -> u64 {
+    let name = globals[callid].name;
+    let fid = if let Some(func_name) = name {
         let is_func_call = globals[callid].is_func_call();
         vm.find_method(globals, recv, func_name, is_func_call)
     } else {
         find_super(vm, globals)
     }
     .map_err(|err| vm.set_error(err))
-    .ok()
+    .ok();
+    let cache_class = {
+        let ic_class = recv.class_for_ic();
+        if ic_class == BOOL_CLASS {
+            let unified = match name {
+                Some(name) => globals.store.check_method_for_class(BOOL_CLASS, name).is_some(),
+                None => false,
+            };
+            if unified { BOOL_CLASS } else { recv.class() }
+        } else {
+            ic_class
+        }
+    };
+    ((cache_class.u32() as u64) << 32) | fid.map_or(0, |f| f.get()) as u64
 }
 
 fn find_super(vm: &mut Executor, globals: &mut Globals) -> Result<FuncId> {


### PR DESCRIPTION
## Summary

Fixes #713: a method call on a `true`/`false` receiver tagged its inline cache with the unified `BOOL_CLASS` (the `get_class` result) while caching the `FuncId` that `vm.find_method` resolved via the **per-class fallback**. When `TrueClass` and `FalseClass` resolve the name differently — `inspect`, `to_s`, user-defined methods, or a method present on only one of them — the other boolean then hit the poisoned entry and ran the wrong class's method:

```console
$ monoruby -e 'p true; p false'   # before
true
true
```

The polymorphic-site detection (`opcode_sub`) could never fire for such sites either, because both receivers report the same IC class — the cache looked healthy while misdispatching, and the JIT inherited the poisoned `MethodCache`.

## Fix

`runtime::find_method` now returns the **ClassId to tag the cache with** in the high 32 bits of its result (`FuncId` stays in the low 32):

- normally the receiver's IC class (unchanged);
- for bool receivers, `BOOL_CLASS` **only when `check_method_for_class(BOOL_CLASS, name)` unifies** (both classes resolve to the same `FuncId` — the rule `check_bool_method_with_version` already implements for the global cache), and the receiver's **real class** otherwise;
- super dispatch (no callsite name) is tagged with the real class unconditionally.

The x86-64 VM slow path unpacks the tag into `r15` before `save_cache`; the aarch64 `a64_save_method_cache` takes the tag from the packed `X0` and drops its `get_class` recomputation (one fewer call on the miss path).

Consequences for divergent-method sites: the other boolean now misses and re-resolves; the existing `opcode_sub` polymorphic marking starts working (the mismatch is finally observable); and the JIT — which reads this cache as `MethodCache` — guards the exact class (`guard_class` already supports `TRUE_CLASS`/`FALSE_CLASS` on both arches). Unified methods (`!`, `&`, `|`, …) keep the `BOOL_CLASS` fast path; the extra resolution cost is confined to cache misses.

## Testing

- `p true; p false` / `p false; p true` now print correctly; a single call site alternating over booleans for 50 iterations (JIT tier included) returns `["true", "false"]` (was `["true"]`).
- New regression test `bool_receiver_ic_divergent_methods`: divergent builtins (`inspect`/`to_s`) + unified `!` at one site, user-defined divergent methods, and a method present on only one class (must raise `NoMethodError` on the other instead of leaking through the cache).
- Full suite: **1663 passed, 0 failed.**
- aarch64: asm follows existing `lsr`/`str w` patterns; the darwin CI job compile-verifies and runs that path.

https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq)_