### PR TITLE
Memoize Kernel#!~'s =~ resolution and inline it in the JIT

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -15,7 +15,13 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     let klass = globals.define_toplevel_module("Kernel");
     let kernel_class = klass.id();
     globals.define_builtin_inline_func(kernel_class, "nil?", nil, inline_gen2!(kernel_nil), 0);
-    globals.define_builtin_func(kernel_class, "!~", not_match, 1);
+    globals.define_builtin_inline_func(
+        kernel_class,
+        "!~",
+        not_match,
+        inline_gen2!(kernel_not_match),
+        1,
+    );
     //globals.define_builtin_module_func_rest(kernel_class, "puts", puts);
     globals.define_builtin_module_func(kernel_class, "gets", gets, 0);
     globals.define_builtin_module_func_rest(kernel_class, "print", print);
@@ -347,10 +353,86 @@ fn kernel_nil(
 ///
 #[monoruby_builtin]
 fn not_match(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let lhs = lfp.self_val();
-    let rhs = lfp.arg(0);
-    let res = vm.invoke_method_inner(globals, IdentId::_MATCH, lhs, &[rhs], None, None)?;
+    not_match_inner(vm, globals, lfp.self_val(), lfp.arg(0))
+}
+
+/// `!(lhs =~ rhs)`. The `=~` resolution is memoized per class_version
+/// (`Store::match_method`), so the common case costs a load instead of a
+/// global-method-cache probe per call. Receivers without `=~` keep the
+/// uncached dispatch for its NoMethodError / method_missing semantics.
+fn not_match_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+) -> Result<Value> {
+    let res = if let Some(fid) = globals
+        .store
+        .match_method(lhs.class(), Globals::class_version())
+    {
+        vm.invoke_func_inner(globals, fid, lhs, &[rhs], None, None)?
+    } else {
+        vm.invoke_method_inner(globals, IdentId::_MATCH, lhs, &[rhs], None, None)?
+    };
     Ok(Value::bool(!res.as_bool()))
+}
+
+/// Runtime arm of the inlined `Kernel#!~` (BinaryOpFn-shaped so the JIT
+/// can emit it via the generic binop call, skipping the `Kernel#!~`
+/// wrapper frame entirely).
+pub(crate) extern "C" fn not_match_values(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+) -> Option<Value> {
+    match not_match_inner(vm, globals, lhs, rhs) {
+        Ok(v) => Some(v),
+        Err(err) => {
+            vm.set_error(err);
+            None
+        }
+    }
+}
+
+/// JIT inliner for `Kernel#!~`: when the receiver class (guarded by the
+/// inline dispatch) resolves `=~`, emit a direct `not_match_values` call
+/// — no `Kernel#!~` frame, and the inner `=~` resolution is the
+/// memoized load. Receivers without `=~` (NoMethodError path) and
+/// non-simple callsites take the generic call.
+fn kernel_not_match(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    ctx: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 {
+        return false;
+    }
+    // BOOL_CLASS is the IC pseudo-class for bool receivers; it has no
+    // method table of its own to resolve `=~` against.
+    if recv_class == BOOL_CLASS
+        || store.match_method(recv_class, ctx.class_version()).is_none()
+    {
+        return false;
+    }
+    let CallSiteInfo {
+        recv, args, dst, ..
+    } = *callsite;
+    state.write_back_recv_and_callargs(ir, callsite);
+    let error = ir.new_error(state);
+    ir.generic_binop(state, recv, args, not_match_values);
+    ir.handle_error(error);
+    // The dispatched `=~` can run arbitrary Ruby; invalidate cached
+    // guards so subsequent instructions re-establish them.
+    state.unset_class_version_guard();
+    state.unset_const_version_guard();
+    state.def_rax2acc(ir, dst);
+    true
 }
 
 fn kernel_block_given(
@@ -3760,6 +3842,29 @@ fn iv_remove(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn not_match_memoized_dispatch() {
+        // Kernel#!~ resolves `=~` through a class_version-stamped memo
+        // (and the JIT inlines the whole call); a later `=~`
+        // (re)definition must be picked up, $~ must still be set, and a
+        // receiver without `=~` keeps NoMethodError.
+        run_test_once(
+            r##"
+        res = []
+        30.times { res << ("abc" !~ /b/) << ("abc" !~ /z/) << (/z/ !~ "ab") }
+        "xyz" !~ /y(z)/
+        res << $1
+        class MatchM713; def =~(o); o == 1; end; end
+        m = MatchM713.new
+        30.times { res << (m !~ 1) << (m !~ 2) }
+        class String; def =~(o); nil; end; end
+        res << ("abc" !~ /b/)
+        res << begin; Object.new !~ /x/; rescue NoMethodError; :nme; end
+        res.uniq
+        "##,
+        );
+    }
 
     #[test]
     fn define_singleton_method_super() {

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -537,7 +537,7 @@ impl AsmIr {
         });
     }
 
-    pub(super) fn generic_binop(
+    pub(crate) fn generic_binop(
         &mut self,
         state: &AbstractFrame,
         lhs: SlotId,

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -198,7 +198,7 @@ impl AbstractFrame {
         self.invariants.class_version_guard = true;
     }
 
-    pub(super) fn unset_class_version_guard(&mut self) {
+    pub(crate) fn unset_class_version_guard(&mut self) {
         self.invariants.class_version_guard = false;
     }
 
@@ -210,7 +210,7 @@ impl AbstractFrame {
         self.invariants.const_version_guard = true;
     }
 
-    pub(super) fn unset_const_version_guard(&mut self) {
+    pub(crate) fn unset_const_version_guard(&mut self) {
         self.invariants.const_version_guard = false;
     }
 

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -764,6 +764,26 @@ impl Store {
         self.default_neq = Some(fid);
     }
 
+    ///
+    /// Resolve `=~` on `class_id`, memoized per class_version (same
+    /// pattern as `no_to_str`: the uncached ancestor walk runs at most
+    /// once per class per class_version and is callable during JIT
+    /// compilation, where the global cache's RefCell may be borrowed).
+    /// `None` when the class (chain) defines no `=~`.
+    ///
+    pub(crate) fn match_method(&self, class_id: ClassId, version: u32) -> Option<FuncId> {
+        if let Some((v, fid)) = self[class_id].match_method_at()
+            && v == version
+        {
+            return Some(fid);
+        }
+        let fid = self
+            .search_method_by_class_id(class_id, IdentId::_MATCH)?
+            .func_id()?;
+        self[class_id].set_match_method_at(version, fid);
+        Some(fid)
+    }
+
     pub(crate) fn custom_neq(&self, class_id: ClassId, version: u32) -> Option<MethodTableEntry> {
         if self[class_id].neq_basic_at() == Some(version) {
             return None;

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -296,6 +296,12 @@ pub struct ClassInfo {
     /// so `a != b` can be computed as `!(a == b)` without dispatch.
     ///
     neq_basic_at: std::cell::Cell<Option<u32>>,
+    ///
+    /// Version-stamped memo: as of class_version `.0`, `=~` on this class
+    /// resolves to FuncId `.1`. Consulted by `Kernel#!~` so the inner
+    /// dispatch costs a load instead of a method-table probe per call.
+    ///
+    match_method_at: std::cell::Cell<Option<(u32, FuncId)>>,
 }
 
 /// C-level allocator function pointer. Given a class id (and a globals
@@ -388,6 +394,7 @@ impl ClassInfo {
             alloc_func: None,
             no_to_str_at: std::cell::Cell::new(None),
             neq_basic_at: std::cell::Cell::new(None),
+            match_method_at: std::cell::Cell::new(None),
         }
     }
 
@@ -408,6 +415,7 @@ impl ClassInfo {
             alloc_func: self.alloc_func,
             no_to_str_at: std::cell::Cell::new(None),
             neq_basic_at: std::cell::Cell::new(None),
+            match_method_at: std::cell::Cell::new(None),
         }
     }
 
@@ -429,6 +437,14 @@ impl ClassInfo {
 
     pub(super) fn set_neq_basic_at(&self, version: u32) {
         self.neq_basic_at.set(Some(version));
+    }
+
+    pub(super) fn match_method_at(&self) -> Option<(u32, FuncId)> {
+        self.match_method_at.get()
+    }
+
+    pub(super) fn set_match_method_at(&self, version: u32, fid: FuncId) {
+        self.match_method_at.set(Some((version, fid)));
     }
 
     pub(crate) fn set_alloc_func(&mut self, f: AllocFunc) {


### PR DESCRIPTION
## Summary

`a !~ b` compiles to a plain method call (`BinOp::Unmatch` has no dedicated opcode), so every execution paid a `Kernel#!~` wrapper frame **plus** an uncached `invoke_method_inner(:=~)` inside it — a global-method-cache probe and a full invoker round trip per call. This was the last big probe source on the addressable benchmarks: **120k `=~`-on-String lookups per profile run** (from `URI#scheme=`'s `new_scheme !~ /\A[a-z][a-z0-9.+-]*\z/i`), the only large entry left after #711/#715.

## Changes

**Runtime side (B — helps all tiers):**
- `ClassInfo` gains a class_version-stamped memo of the resolved `=~` `FuncId` (`Store::match_method`, same pattern as `no_to_str` / `custom_neq`; stale resolution uses the uncached ancestor walk so it is callable during JIT compilation too).
- The `Kernel#!~` builtin dispatches the memoized `FuncId` directly. Receivers without `=~` keep the uncached `invoke_method_inner` path for its `NoMethodError` / `method_missing` semantics.

**JIT side (A — x86-64 and aarch64, no arch-specific code):**
- `Kernel#!~` gets an inline gen that emits a direct call to a `BinaryOpFn`-shaped runtime arm (`not_match_values`) via `AsmIr::generic_binop` when the (guarded) receiver class resolves `=~` — the `Kernel#!~` wrapper frame disappears entirely.
- Bails for `BOOL_CLASS` receivers (an IC pseudo-class with no method table of its own), missing `=~`, and non-simple callsites.
- `AsmIr::generic_binop` and the version-guard invalidations are widened to `pub(crate)` so builtin inliners can use them (mirroring `emit_generic_cmp`'s sequence).

## Results

- `profile` stats on addressable-parse: `=~`-on-String global-cache probes drop **120,004 → 0** per run; the remaining top entry is the unrelated `==`-on-metaclass (60k).
- Wall clock: ~2–5% directionally on addressable-parse (machine noise exceeds the effect size; the probe/frame elimination is the verified part).

## Testing

- New regression test `not_match_memoized_dispatch`: JIT-warmed `!~` over String/Regexp receivers, `$~`/`$1` side effects through `!~`, custom `=~` dispatch (with CRuby's boolean coercion of `!~`), **`String#=~` redefinition after JIT warmup** (memo + inline both invalidated via class_version), and the no-`=~` `NoMethodError` path — all cross-checked against CRuby 4.0.5.
- Full x86-64 suite: **1664 passed, 0 failed.**
- aarch64: kernel/regexp/string subsets run under qemu (247/248; the one failure, `kernel_system`, fails identically on master under qemu — a qemu-user process-spawning artifact, unrelated).

Follow-up to the `==`/`!=` dispatch work in #711/#712/#714/#715.

https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxuzZjCohCy7ga5LSJftDq)_