### PR TITLE
JIT-inline String#getbyte/#setbyte and Integer#succ/#next (7x faster ruby-xor)

### DIFF
--- a/monoruby/builtins/integer.rb
+++ b/monoruby/builtins/integer.rb
@@ -1,7 +1,6 @@
 class Integer
-  #def succ
-  #  self + 1
-  #end
+  # succ / next are implemented in Rust (integer.rs) with a JIT inline
+  # specialization.
 
   def to_i
     self
@@ -65,11 +64,6 @@ class Integer
     self
   end
 
-
-  def next
-    self + 1
-  end
-  alias succ next
 
   def pred
     self - 1

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -11,7 +11,15 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_class("Integer", INTEGER_CLASS, numeric, OBJECT_CLASS, None);
     globals.store[INTEGER_CLASS].clear_alloc_func();
     globals.define_builtin_func_with(INTEGER_CLASS, "chr", chr, 0, 1, false);
-    //globals.define_builtin_inline_func(INTEGER_CLASS, "succ", succ, inline_gen!(integer_succ), 0);
+    // `next` is a true alias of `succ`.
+    globals.define_builtin_inline_funcs(
+        INTEGER_CLASS,
+        "succ",
+        &["next"],
+        succ,
+        inline_gen!(integer_succ),
+        0,
+    );
     //globals.define_builtin_func(INTEGER_CLASS, "times", times, 0);
     //globals.define_builtin_func_with(INTEGER_CLASS, "step", step, 1, 2, false);
     globals.define_builtin_func(INTEGER_CLASS, "upto", upto, 1);
@@ -511,24 +519,27 @@ fn chr_set_encoding_label(globals: &mut Globals, val: Value, enc_name: &str) {
     }
 }
 
-// Integer#succ is defined in Ruby (integer.rb).
-// The Rust implementation and JIT inline specialization are commented out
-// because the Ruby definition takes precedence at runtime.
-/*
+///
+/// ### Integer#succ / Integer#next
+///
+/// - succ -> Integer
+/// - next -> Integer
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/succ.html]
 #[monoruby_builtin]
 fn succ(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(match lfp.self_val().unpack() {
-        RV::Fixnum(i) => i
-            .checked_add(1)
-            .map(Value::integer)
-            .unwrap_or_else(|| Value::bigint(BigInt::from(i) + 1)),
+        RV::Fixnum(i) => Value::integer(i + 1),
         RV::BigInt(b) => Value::bigint(b + 1),
-        _ => unimplemented!(),
+        _ => unreachable!(),
     })
 }
 
+/// JIT inliner for `Integer#succ` / `#next`: a tagged-fixnum increment.
+/// The receiver-class guard already pins the receiver to a fixnum (a Bignum
+/// receiver deopts there); i63 overflow deopts to the interpreter, which
+/// returns a Bignum.
 #[cfg(target_arch = "x86_64")]
-
 fn integer_succ(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -536,9 +547,10 @@ fn integer_succ(
     store: &Store,
     callid: CallSiteId,
     _: ClassId,
+    _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
-    if !callsite.is_simple() {
+    if !callsite.is_simple() || callsite.pos_num != 0 {
         return false;
     }
     let CallSiteInfo { dst, recv, .. } = *callsite;
@@ -551,19 +563,10 @@ fn integer_succ(
 
     let deopt = ir.new_deopt(state);
     state.load(ir, recv, GP::Rdi);
-    ir.inline(move |r#gen, _, labels, _| {
-        let deopt = &labels[deopt];
-        monoasm! { &mut r#gen.jit,
-            addq  rdi, 2;
-            jo    deopt;
-        }
-    });
-    if let Some(dst) = dst {
-        state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
-    }
+    ir.inline(move |r#gen, _, labels, _| r#gen.emit_integer_succ(&labels[deopt]));
+    state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true
 }
-*/
 
 #[monoruby_builtin]
 fn to_f(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -103,10 +103,22 @@ pub(super) fn init(globals: &mut Globals) {
         false,
     );
     globals.define_builtin_func(STRING_CLASS, "bytes", bytes, 0);
-    globals.define_builtin_func(STRING_CLASS, "getbyte", getbyte, 1);
+    globals.define_builtin_inline_func(
+        STRING_CLASS,
+        "getbyte",
+        getbyte,
+        inline_gen!(string_getbyte),
+        1,
+    );
     globals.define_builtin_func_with(STRING_CLASS, "byteslice", byteslice, 1, 2, false);
     globals.define_builtin_func_with(STRING_CLASS, "bytesplice", bytesplice, 2, 5, false);
-    globals.define_builtin_func(STRING_CLASS, "setbyte", setbyte, 2);
+    globals.define_builtin_inline_func(
+        STRING_CLASS,
+        "setbyte",
+        setbyte,
+        inline_gen!(string_setbyte),
+        2,
+    );
     globals.define_builtin_func_with_kw(
         STRING_CLASS,
         "each_line",
@@ -3843,6 +3855,70 @@ fn setbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         .as_rstring_inner_mut()
         .set_byte(idx as usize, byte_val as u8);
     Ok(lfp.arg(1))
+}
+
+/// JIT inliner for `String#getbyte`: guards the index to a fixnum (deopt
+/// otherwise — the interpreter handles `to_int` coercion / TypeError) and
+/// emits the load + bounds check inline. Out-of-range yields nil inline, so
+/// `while b = s.getbyte(i)` loops don't deopt at termination.
+#[cfg(target_arch = "x86_64")]
+fn string_getbyte(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+    state.load(ir, recv, GP::Rdi);
+    state.load_fixnum(ir, args, GP::Rsi);
+    if dst.is_some() {
+        ir.inline(move |r#gen, _, _, _| r#gen.emit_string_getbyte());
+        // result is a fixnum or nil
+        state.def_reg2acc(ir, GP::Rax, dst);
+    }
+    true
+}
+
+/// JIT inliner for `String#setbyte`: guards both arguments to fixnums and
+/// emits the byte store inline. Frozen/chilled receivers and out-of-range
+/// indices deopt — the interpreter raises (or warns and unchills) there.
+#[cfg(target_arch = "x86_64")]
+fn string_setbyte(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 2 {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+    state.load(ir, recv, GP::Rdi);
+    state.load_fixnum(ir, args, GP::Rsi);
+    state.load_fixnum(ir, args + 1usize, GP::Rdx);
+    let deopt = ir.new_deopt(state);
+    ir.inline(move |r#gen, _, labels, _| r#gen.emit_string_setbyte(&labels[deopt]));
+    if dst.is_some() {
+        // setbyte returns its value argument (a fixnum after the guard above)
+        state.load(ir, args + 1usize, GP::Rax);
+        state.def_reg2acc_fixnum(ir, GP::Rax, dst);
+    }
+    true
 }
 
 ///

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -119,6 +119,89 @@ impl Codegen {
         }
     }
 
+    /// `String#getbyte`: receiver String in rdi, fixnum index in rsi →
+    /// rax = byte tagged as a fixnum, or nil when the (negative-adjusted)
+    /// index is out of range.
+    pub(crate) fn emit_string_getbyte(&mut self) {
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            sarq rsi, 1;
+            // rax = len, rcx = data ptr (inline vs heap storage select)
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            lea  rcx, [rdi + (RVALUE_OFFSET_INLINE)];
+            cmpq rax, (STRING_INLINE_CAP);
+            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            cmovgtq rcx, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+            // negative index counts back from the end
+            movq rdx, rsi;
+            addq rdx, rax;
+            testq rsi, rsi;
+            cmovsq rsi, rdx;
+            // unsigned bound check covers a still-negative index too
+            cmpq rsi, rax;
+            movq rax, (NIL_VALUE);
+            jae  exit;
+            movzxb rax, [rcx + rsi];
+            salq rax, 1;
+            orq  rax, 1;
+        exit:
+        }
+    }
+
+    /// `String#setbyte`: receiver String in rdi, fixnum index in rsi, fixnum
+    /// byte value in rdx. Deopts when the receiver is frozen or chilled
+    /// (interpreter raises / warns) or the index is out of range
+    /// (interpreter raises IndexError). Keeps the cached code-range
+    /// classification consistent with `RStringInner::set_byte`.
+    ///
+    /// ### destroy
+    /// - rax, rcx, rdx, rsi, r8
+    pub(crate) fn emit_string_setbyte(&mut self, deopt: &DestLabel) {
+        let exit = self.jit.label();
+        let set_unknown = self.jit.label();
+        monoasm! { &mut self.jit,
+            // frozen (0b010) or chilled (0b100) → deopt
+            movzxw rax, [rdi + (RVALUE_OFFSET_FLAG)];
+            testq rax, (0b110);
+            jne  deopt;
+            sarq rsi, 1;
+            sarq rdx, 1;
+            // rax = len, rcx = data ptr (inline vs heap storage select)
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            lea  rcx, [rdi + (RVALUE_OFFSET_INLINE)];
+            cmpq rax, (STRING_INLINE_CAP);
+            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            cmovgtq rcx, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+            // negative index counts back from the end
+            movq r8, rsi;
+            addq r8, rax;
+            testq rsi, rsi;
+            cmovsq rsi, r8;
+            // out of range (unsigned check covers still-negative) → IndexError
+            cmpq rsi, rax;
+            jae  deopt;
+            movb [rcx + rsi], rdx;
+            // code range cache: poking an ASCII byte into a SevenBit string
+            // keeps SevenBit; anything else degrades to Unknown.
+            cmpb [rdi + (crate::rvalue::STRING_CR_OFFSET)], (CodeRange::SevenBit as u64);
+            jne  set_unknown;
+            testq rdx, (0x80);
+            jeq  exit;
+        set_unknown:
+            movb [rdi + (crate::rvalue::STRING_CR_OFFSET)], (CodeRange::Unknown as u64);
+        exit:
+        }
+    }
+
+    /// `Integer#succ` / `#next`: fixnum in rdi; tagged `+1` is `+2` on the
+    /// raw bits. Deopts on i63 overflow (interpreter returns a Bignum).
+    pub(crate) fn emit_integer_succ(&mut self, deopt: &DestLabel) {
+        monoasm! { &mut self.jit,
+            addq rdi, 2;
+            jo   deopt;
+        }
+    }
+
     /// `Hash#[]`: `hashindex(vm, globals, recv, key)`. recv in rdx, key in rcx.
     /// Result Value in rax (errors via the trailing HandleError).
     pub(crate) fn emit_hash_index(&mut self, hashindex: u64) {

--- a/monoruby/src/value/coerce.rs
+++ b/monoruby/src/value/coerce.rs
@@ -90,6 +90,9 @@ impl Value {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<i64> {
+        if let Some(i) = self.try_fixnum() {
+            return Ok(i);
+        }
         let res = match self.unpack() {
             RV::Fixnum(_) | RV::BigInt(_) => *self,
             _ => self.coerce_to_int(vm, globals)?,

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -29,7 +29,7 @@ pub use range::{RANGE_END_OFFSET, RANGE_EXCLUDE_END_OFFSET, RANGE_START_OFFSET, 
 pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
-pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner};
+pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET};
 pub(crate) use string::{eucjp_char_width, sjis_char_width};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -140,16 +140,20 @@ impl<'a> Iterator for CharByteIter<'a> {
 /// to its declared `encoding`. CRuby's `enum ruby_coderange_type`
 /// equivalent — keeps `valid_encoding?` / `ascii_only?` /
 /// compatibility checks O(1) after the first walk.
+/// `repr(u8)` with fixed discriminants because the JIT's inline
+/// `String#setbyte` pokes the cached classification directly (see
+/// `STRING_CR_OFFSET` / `emit_string_setbyte`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum CodeRange {
     /// Not yet computed.
-    Unknown,
+    Unknown = 0,
     /// Every byte is < 0x80; safe under any ASCII-compatible encoding.
-    SevenBit,
+    SevenBit = 1,
     /// Encoding-valid (and contains at least one non-ASCII codepoint).
-    Valid,
+    Valid = 2,
     /// Contains a byte sequence invalid in the declared encoding.
-    Broken,
+    Broken = 3,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -507,6 +511,12 @@ pub struct RStringInner {
     ty: Encoding,
     cr: Cell<CodeRange>,
 }
+
+/// Byte offset of the cached `CodeRange` (`cr`) from the head of an
+/// `RValue` holding a String, for the JIT's inline `String#setbyte`.
+/// `Cell<CodeRange>` has the same layout as `CodeRange` (`repr(u8)`).
+pub const STRING_CR_OFFSET: usize =
+    super::RVALUE_OFFSET_KIND + std::mem::offset_of!(RStringInner, cr);
 
 impl std::ops::Deref for RStringInner {
     type Target = [u8];


### PR DESCRIPTION
## Summary

Investigating why ruby-bench's **ruby-xor** is slow showed that nearly all of its runtime went into `String#getbyte`/`#setbyte` dispatch: every byte paid the full native-method trampoline (frame setup, generic `to_int` coercion through `Value::unpack`, result boxing). This PR removes that overhead in two steps:

1. **`coerce_to_int_i64` Fixnum fast path** — the coercion went through `Value::unpack` (building an `RV` enum) twice even for the overwhelmingly common Fixnum case (~30% of ruby-xor's total runtime). Check `try_fixnum` first. (~17% faster on its own)
2. **JIT inliners (x86-64)** for the hot methods:
   - **`String#getbyte`**: fixnum-guarded index (deopt falls back to the interpreter's `to_int` coercion), inline length / data-pointer select (inline vs heap storage), negative-index adjust, and an inline `nil` result for out-of-range so `while b = s.getbyte(i)` loops don't deopt at termination.
   - **`String#setbyte`**: additionally deopts on frozen/chilled receivers and out-of-range indices (the interpreter raises/warns there), and keeps the cached `CodeRange` classification consistent with `RStringInner::set_byte`. `CodeRange` becomes `repr(u8)` and the `cr` field offset is exported as `STRING_CR_OFFSET` so the JIT can poke it.
   - **`Integer#succ`/`#next`**: moved from the Ruby definition (`self + 1`, a real method call per use) to a Rust builtin, enabling the long-commented-out tagged-fixnum-increment inliner (`addq rdi, 2`, deopt on i63 overflow → interpreter returns a Bignum), updated to the current `InlineGen` signature. Fixnum literals constant-fold.

aarch64 falls back to plain builtin calls via the existing `inline_gen!` mechanism (cross `cargo check`/`build` + qemu smoke test pass).

## Results (x86-64, per ruby-xor iteration)

| | before | after |
|---|---|---|
| monoruby | 0.089s | **0.010s** (~7x) |
| CRuby 4.0.2 +YJIT | 0.022s | — |

Microbenchmarks: `getbyte` 19ns → 1.7ns/call, `setbyte` 26ns → 3.1ns/call, on par with the already-inlined `bytesize`. A perf profile after the change shows the JIT-compiled benchmark body dominating instead of dispatch overhead.

## Verification

- Full lib test suite passes (1664/1664)
- `bin/ruby-bench-diff`: output matches CRuby 4.0.2 on all benchmarks (incl. ruby-xor's correctness check)
- ruby/spec core/string + core/integer: failure set identical to master (no new failures); `getbyte_spec` / `setbyte_spec` / `succ_spec` / `next_spec` all green
- Edge cases compared against CRuby 4.0.2 across JIT warmup: negative indices, out-of-range nil/IndexError, frozen receiver, `Float` index via `to_int` coercion (deopt path), heap-stored long strings, `succ` at the i63 boundary → Bignum, `(10**30).succ`
- Benchmark output diffs (app_fib / tarai / so_nbody / so_mandelbrot ±JIT) all match

https://claude.ai/code/session_013iATPVcu4Dt9Dkbhb3QLuC

---
_Generated by [Claude Code](https://claude.ai/code/session_013iATPVcu4Dt9Dkbhb3QLuC)_