### PR TITLE
Zero-copy MatchData/$~ haystack snapshots + backref fixes (index family, String#match)

### DIFF
--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -884,6 +884,42 @@ fn named_captures(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
 mod tests {
     use crate::tests::*;
 
+    // The haystack is snapshotted at match time (zero-copy shared
+    // substring + CoW): mutating the subject afterwards must not
+    // change the MatchData or `$~`.
+    #[test]
+    fn match_data_haystack_snapshot() {
+        run_test(
+            r##"
+        s = "hello world foo bar baz " * 10
+        m = s.match(/world (\w+)/)
+        before = [m[0], m[1], m.pre_match.bytesize, m.string.dup]
+        s << "tail"
+        s.setbyte(6, 33)
+        after = [m[0], m[1], m.pre_match.bytesize, m.string]
+        [before == after, m.string.include?("world"), s.getbyte(6)]
+        "##,
+        );
+        run_test(
+            r##"
+        big = "x" * 100 + "needle" + "y" * 100
+        rest = big.byteslice(50..)
+        mt = rest.match(/needle/)
+        big.setbyte(150, 33)
+        [mt[0], mt.pre_match.bytesize, mt.post_match.bytesize]
+        "##,
+        );
+        // Subjects that die before the MatchData does (the snapshot
+        // must keep the haystack alive through GC).
+        run_test(
+            r##"
+        mds = 20.times.map { |i| ("p#{i} " + "x" * 64 + " needle#{i}").match(/needle\d+/) }
+        GC.start
+        mds.each_with_index.map { |m, i| m[0] == "needle#{i}" && m.string.start_with?("p#{i}") }.all?
+        "##,
+        );
+    }
+
     #[test]
     fn match_data() {
         run_tests(&[

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -890,7 +890,22 @@ fn rmatch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         vm.clear_capture_special_variables();
         return Ok(Value::nil());
     }
-    let heystack = arg0.expect_symbol_or_string(globals)?.to_string();
+    // Borrow the subject's bytes directly (and stash the Value for
+    // the zero-copy MatchData snapshot) when it is a UTF-8 String;
+    // Symbols and non-UTF-8 subjects fall back to the owned
+    // conversion as before.
+    let heystack_owned;
+    let heystack: &str = match arg0.is_rstring() {
+        Some(rs) if std::str::from_utf8(rs.as_bytes()).is_ok() => {
+            vm.set_match_haystack(arg0);
+            // SAFETY: just validated as UTF-8.
+            unsafe { std::str::from_utf8_unchecked(arg0.as_rstring_inner().as_bytes()) }
+        }
+        _ => {
+            heystack_owned = arg0.expect_symbol_or_string(globals)?.to_string();
+            &heystack_owned
+        }
+    };
     let char_pos = if let Some(pos) = lfp.try_arg(1) {
         match conv_index(
             pos.coerce_to_int_i64(vm, globals)?,
@@ -910,8 +925,8 @@ fn rmatch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         None => 0, //return Ok(Value::bool(false)),
     };
     vm.set_match_regex(self_);
-    let md = if let Some(captures) = regex.captures_from_pos(&heystack, byte_pos, vm)? {
-        Value::new_matchdata(captures, &heystack, regex)
+    let md = if let Some(captures) = regex.captures_from_pos(heystack, byte_pos, vm)? {
+        Value::new_matchdata_snap(captures, heystack, vm.resolve_haystack(heystack), regex)
     } else {
         Value::nil()
     };

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1417,6 +1417,8 @@ fn locate_regex_match(
     globals: &mut Globals,
 ) -> Result<(usize, usize)> {
     let given = self_val.expect_str(globals)?;
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(*self_val);
     let captures = match re.captures_from_pos(given, 0, vm)? {
         Some(c) => c,
         None => return Err(MonorubyErr::indexerr("regexp not matched")),
@@ -1864,6 +1866,8 @@ fn enc_char_boundary(enc: crate::value::Encoding, bytes: &[u8], pos: usize) -> b
 #[monoruby_builtin]
 fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     // Non-UTF-8 receiver + empty String separator: split into
     // characters via the encoding-aware iterator (the generic path
     // below needs a `&str`, which would error for EUC-JP/Shift_JIS).
@@ -2682,6 +2686,8 @@ fn sub_main(
     self_val: Value,
     lfp: Lfp,
 ) -> Result<(RStringInner, bool)> {
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_val);
     if let Some(arg1) = lfp.try_arg(1) {
         if lfp.block().is_some() {
             eprintln!("warning: default value argument supersedes block");
@@ -2793,6 +2799,8 @@ fn gsub_main(
     self_val: Value,
     lfp: Lfp,
 ) -> Result<(RStringInner, bool)> {
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_val);
     if let Some(arg1) = lfp.try_arg(1) {
         if lfp.block().is_some() {
             eprintln!("warning: default value argument supersedes block");
@@ -2828,6 +2836,8 @@ fn gsub_main(
 fn scan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let given = self_.expect_str(globals)?;
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     let arg0 = lfp.arg(0);
     let owned_re;
     let coerced_re;
@@ -2925,6 +2935,8 @@ fn string_match(
     let given = self_.expect_str(globals)?;
     let re = lfp.arg(0).coerce_to_regexp_or_string(vm, globals)?;
 
+    // Enable zero-copy MatchData/$~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     RegexpInner::match_one(vm, globals, re, given, lfp.block(), pos)
 }
 
@@ -2977,6 +2989,8 @@ fn string_index(
     };
     let self_ = lfp.self_val();
     let given = self_.is_rstring().unwrap();
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     if let Some(arg_inner) = lfp.arg(0).is_rstring_inner() {
         check_string_encoding_compat(&given, &arg_inner, globals)?;
         // Non-UTF-8 receiver + String needle: encoding-aware byte
@@ -3037,6 +3051,8 @@ fn string_index(
 fn byteindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let given = self_.is_rstring().unwrap();
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     check_pattern_encoding_compat(&given, lfp.arg(0), globals)?;
     let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let haystack = given.as_bytes();
@@ -3094,6 +3110,8 @@ fn byteindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 fn byterindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let given = self_.is_rstring().unwrap();
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     check_pattern_encoding_compat(&given, lfp.arg(0), globals)?;
     let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let haystack = given.as_bytes();
@@ -3232,6 +3250,8 @@ fn string_rindex(
 ) -> Result<Value> {
     let self_ = lfp.self_val();
     let given = self_.is_rstring().unwrap();
+    // Enable zero-copy $~ haystack snapshots (CoW).
+    vm.set_match_haystack(self_);
     if let Some(arg_inner) = lfp.arg(0).is_rstring_inner() {
         check_string_encoding_compat(&given, &arg_inner, globals)?;
     }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3179,6 +3179,7 @@ fn byterindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         }
     }
 
+    rindex_set_backref(vm, &re, s, best)?;
     Ok(match best {
         Some(p) => Value::integer(p as i64),
         None => Value::nil(),
@@ -3293,6 +3294,7 @@ fn string_rindex(
     for (char_pos, (byte_pos, _)) in s.char_indices().enumerate() {
         if last_byte_pos == byte_pos {
             if char_pos > max_char_pos {
+                rindex_set_backref(vm, &re, s, last_char_pos.map(|p| char_to_byte_pos(s, p)))?;
                 return Ok(match last_char_pos {
                     Some(pos) => Value::integer(pos as i64),
                     None => Value::nil(),
@@ -3304,11 +3306,16 @@ fn string_rindex(
             continue;
         }
         match re.captures_from_pos(s, byte_pos, vm)? {
-            None => return Ok(Value::integer(last_char_pos.unwrap() as i64)),
+            None => {
+                let pos = last_char_pos.unwrap();
+                rindex_set_backref(vm, &re, s, Some(char_to_byte_pos(s, pos)))?;
+                return Ok(Value::integer(pos as i64));
+            }
             Some(captures) => {
                 last_byte_pos = captures.get(0).unwrap().start();
                 if last_byte_pos == byte_pos {
                     if char_pos > max_char_pos {
+                        rindex_set_backref(vm, &re, s, last_char_pos.map(|p| char_to_byte_pos(s, p)))?;
                         return Ok(match last_char_pos {
                             Some(pos) => Value::integer(pos as i64),
                             None => Value::nil(),
@@ -3333,10 +3340,38 @@ fn string_rindex(
             }
         }
     }
+    rindex_set_backref(vm, &re, s, last_char_pos.map(|p| char_to_byte_pos(s, p)))?;
     Ok(match last_char_pos {
         Some(pos) => Value::integer(pos as i64),
         None => Value::nil(),
     })
+}
+
+
+/// Final `$~` fix-up for the `rindex`-style forward scans: the loop
+/// probes *past* the match it ends up returning, leaving `$~` as the
+/// last (failed or too-far) probe. Re-run one probe at the returned
+/// match's byte position so `$~` reflects the result (CRuby
+/// behaviour); a `None` result clears `$~`.
+fn rindex_set_backref(
+    vm: &mut Executor,
+    re: &Regexp,
+    s: &str,
+    byte_pos: Option<usize>,
+) -> Result<()> {
+    match byte_pos {
+        Some(p) => {
+            re.captures_from_pos(s, p, vm)?;
+        }
+        None => vm.clear_capture_special_variables(),
+    }
+    Ok(())
+}
+
+/// Byte position of character index `cp` in `s` (`s.len()` for the
+/// one-past-the-end position).
+fn char_to_byte_pos(s: &str, cp: usize) -> usize {
+    s.char_indices().nth(cp).map(|(b, _)| b).unwrap_or(s.len())
 }
 
 /// `String#rindex` with a String argument. Splits off from
@@ -7388,6 +7423,33 @@ fn unicode_normalize_(
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn rindex_and_byterindex_set_backref() {
+        // The forward-scan rindex implementations probe past the
+        // returned match; `$~` must still end up as the match at the
+        // returned position (and nil when there is no match).
+        run_tests(&[
+            r##"u = "one two three two one"; [u.rindex(/two/), $~[0], $~.begin(0)]"##,
+            r##"u = "one two three two one"; [u.rindex(/two/, 10), $~[0], $~.begin(0)]"##,
+            r##"u = "one two three two one"; [u.rindex(/zzz/), $~.nil?]"##,
+            r##"u = "one two three two one"; [u.byterindex(/two/), $~[0], $~.begin(0)]"##,
+            r##"u = "one two three two one"; [u.byterindex(/zzz/), $~.nil?]"##,
+            r##"u = "abcabc"; [u.rindex(/b/), $~[0], $~.pre_match]"##,
+        ]);
+    }
+
+    #[test]
+    fn string_match_attaches_regexp_to_backref() {
+        // `$~` saved by `String#match` must carry the Regexp so
+        // named-capture lookup works (used to raise IndexError).
+        run_tests(&[
+            r##""alpha beta".match(/(?<a>\w+) (?<b>\w+)/); [$~[:a], $~[:b]]"##,
+            r##""alpha beta".match(/(?<a>\w+) (?<b>\w+)/); $~.named_captures"##,
+            r##""alpha beta".match(/(?<a>\w+)/); $~.regexp.source"##,
+            r##""x42y".match(/(?<n>\d+)/) { |m| m[:n] } + $~[:n]"##,
+        ]);
+    }
 
     #[test]
     fn string_new_group() {

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2993,22 +2993,21 @@ fn string_index(
     vm.set_match_haystack(self_);
     if let Some(arg_inner) = lfp.arg(0).is_rstring_inner() {
         check_string_encoding_compat(&given, &arg_inner, globals)?;
-        // Non-UTF-8 receiver + String needle: encoding-aware byte
-        // search at character boundaries (the regex path below needs
-        // valid UTF-8).
-        if !given.encoding().is_utf8_compatible() {
-            let from = match given.conv_char_index(char_pos) {
-                Some(p) => p,
-                None => return Ok(Value::nil()),
-            };
-            let needle = arg_inner.as_bytes().to_vec();
-            return Ok(
-                match nonutf8_substring_index(&given, &needle, from, false) {
-                    Some(cp) => Value::integer(cp as i64),
-                    None => Value::nil(),
-                },
-            );
-        }
+        // String needle: substring search at character boundaries.
+        // Never enters the regex engine, so `$~` is untouched (CRuby
+        // only sets the backref for Regexp patterns — issue #721) and
+        // broken-UTF-8 receivers work (CRuby allows them here).
+        let from = match given.conv_char_index(char_pos) {
+            Some(p) => p,
+            None => return Ok(Value::nil()),
+        };
+        let needle = arg_inner.as_bytes().to_vec();
+        return Ok(
+            match substring_char_index(&given, &needle, from, false) {
+                Some(cp) => Value::integer(cp as i64),
+                None => Value::nil(),
+            },
+        );
     }
     let re = lfp.arg(0).coerce_to_regexp_or_string(vm, globals)?;
 
@@ -3054,7 +3053,6 @@ fn byteindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     // Enable zero-copy $~ haystack snapshots (CoW).
     vm.set_match_haystack(self_);
     check_pattern_encoding_compat(&given, lfp.arg(0), globals)?;
-    let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let haystack = given.as_bytes();
     let byte_offset = if let Some(arg1) = lfp.try_arg(1) {
         let offset = arg1.coerce_to_int_i64(vm, globals)?;
@@ -3074,6 +3072,24 @@ fn byteindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     if byte_offset > haystack.len() {
         return Ok(Value::nil());
     }
+
+    // String needle: plain byte search (CRuby's `rb_memsearch`).
+    // Never enters the regex engine, so `$~` is untouched (CRuby only
+    // sets the backref for Regexp patterns — issue #721) and broken
+    // receivers work; the boundary check is encoding-aware.
+    if let Some(needle) = lfp.arg(0).is_rstring_inner() {
+        if !is_enc_char_boundary(&given, byte_offset) {
+            return Err(MonorubyErr::indexerr(format!(
+                "offset {byte_offset} does not land on character boundary"
+            )));
+        }
+        return Ok(match byte_search_fwd(haystack, needle.as_bytes(), byte_offset) {
+            Some(p) => Value::integer(p as i64),
+            None => Value::nil(),
+        });
+    }
+
+    let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let s = std::str::from_utf8(haystack).map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
 
     // Ensure byte_offset falls on a valid UTF-8 character boundary.
@@ -3113,7 +3129,6 @@ fn byterindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     // Enable zero-copy $~ haystack snapshots (CoW).
     vm.set_match_haystack(self_);
     check_pattern_encoding_compat(&given, lfp.arg(0), globals)?;
-    let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let haystack = given.as_bytes();
     let bytesize = haystack.len();
 
@@ -3137,6 +3152,22 @@ fn byterindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         bytesize
     };
 
+    // String needle: plain reverse byte search — `$~` untouched
+    // (issue #721), broken receivers allowed, encoding-aware
+    // boundary check.
+    if let Some(needle) = lfp.arg(0).is_rstring_inner() {
+        if !is_enc_char_boundary(&given, byte_offset) {
+            return Err(MonorubyErr::indexerr(format!(
+                "offset {byte_offset} does not land on character boundary"
+            )));
+        }
+        return Ok(match byte_search_rev(haystack, needle.as_bytes(), byte_offset) {
+            Some(p) => Value::integer(p as i64),
+            None => Value::nil(),
+        });
+    }
+
+    let re = coerce_pattern_for_byte_search(vm, globals, lfp.arg(0))?;
     let s = std::str::from_utf8(haystack).map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
 
     if !s.is_char_boundary(byte_offset) {
@@ -3184,6 +3215,46 @@ fn byterindex(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         Some(p) => Value::integer(p as i64),
         None => Value::nil(),
     })
+}
+
+
+/// Whether `pos` lands on a character boundary of `inner` in its
+/// declared encoding (broken bytes count as single characters, like
+/// CRuby's byte-position checks). `0` and `inner.len()` are always
+/// boundaries.
+fn is_enc_char_boundary(inner: &RStringInner, pos: usize) -> bool {
+    if pos == 0 || pos == inner.len() {
+        return true;
+    }
+    let mut off = 0usize;
+    for ch in inner.iter_char_bytes() {
+        if off >= pos {
+            return off == pos;
+        }
+        off += ch.len();
+    }
+    off == pos
+}
+
+/// First byte index `>= from` where `needle` occurs in `haystack`
+/// (plain byte search — CRuby's `rb_memsearch`; no boundary
+/// constraint). Empty needles match at `from`.
+fn byte_search_fwd(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return (from <= haystack.len()).then_some(from);
+    }
+    let last = haystack.len().checked_sub(needle.len())?;
+    (from..=last).find(|&i| haystack[i..].starts_with(needle))
+}
+
+/// Last byte index `<= upto` where `needle` occurs in `haystack`.
+/// Empty needles match at `upto` (clamped to the length).
+fn byte_search_rev(haystack: &[u8], needle: &[u8], upto: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(upto.min(haystack.len()));
+    }
+    let last = haystack.len().checked_sub(needle.len())?;
+    (0..=last.min(upto)).rev().find(|&i| haystack[i..].starts_with(needle))
 }
 
 /// Coerce a value to a `Regexp` for `byteindex`/`byterindex`. Accepts
@@ -3382,13 +3453,16 @@ fn char_to_byte_pos(s: &str, cp: usize) -> usize {
 /// matches right-to-left and is bytewise correct because it works on
 /// `&str`: candidate positions inside a multibyte char's interior are
 /// skipped by `str::Searcher`'s boundary check.
-/// Character index of `needle`'s bytes within a non-UTF-8 receiver,
-/// constrained to character boundaries (so an ASCII needle never
-/// matches a Shift_JIS trail byte). `rev=false` ⇒ first match at or
-/// after `anchor`; `rev=true` ⇒ last match at or before `anchor`.
-/// The caller has already passed `check_string_encoding_compat`, so
-/// `needle` is ASCII or same-encoding bytes.
-fn nonutf8_substring_index(
+/// Character index of `needle`'s bytes within the receiver,
+/// constrained to character boundaries in the receiver's declared
+/// encoding (so an ASCII needle never matches a Shift_JIS trail byte;
+/// broken bytes count as single characters, like CRuby). Works for any
+/// encoding, including broken UTF-8 — it never enters the regex engine,
+/// so `$~` is untouched. `rev=false` ⇒ first match at or after
+/// `anchor`; `rev=true` ⇒ last match at or before `anchor`. The caller
+/// has already passed `check_string_encoding_compat`, so `needle` is
+/// ASCII or same-encoding bytes.
+fn substring_char_index(
     inner: &RStringInner,
     needle: &[u8],
     anchor: usize,
@@ -3453,11 +3527,13 @@ fn string_rindex_string(
         return Ok(Value::integer(max_char_pos as i64));
     }
 
-    // Non-UTF-8 receiver: encoding-aware reverse byte search at
-    // character boundaries.
-    if !given.encoding().is_utf8_compatible() {
+    // Non-UTF-8 or broken-UTF-8 receiver: encoding-aware reverse
+    // byte search at character boundaries (`rmatch_indices` below
+    // needs a valid `&str`; CRuby allows String needles on broken
+    // receivers).
+    if !given.encoding().is_utf8_compatible() || !given.is_valid_encoding() {
         return Ok(
-            match nonutf8_substring_index(given, needle_bytes, max_char_pos, true) {
+            match substring_char_index(given, needle_bytes, max_char_pos, true) {
                 Some(cp) => Value::integer(cp as i64),
                 None => Value::nil(),
             },
@@ -7425,6 +7501,33 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn index_family_string_pattern_preserves_backref() {
+        // String patterns must never touch `$~` (CRuby only sets the
+        // backref for Regexp patterns) — issue #721.
+        run_tests(&[
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.index("two"); [$~[0], $~[1]]"##,
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.index("zzz"); $~[0]"##,
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.byteindex("two"); $~[0]"##,
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.byteindex("zzz"); $~[0]"##,
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.byterindex("two"); $~[0]"##,
+            r##"u = "one two"; "seed" =~ /se(ed)/; u.byterindex("zzz"); $~[0]"##,
+        ]);
+        // ... and the byte searches themselves must match CRuby,
+        // including overlap, offsets, boundaries, and broken UTF-8.
+        run_tests(&[
+            r##""ababa".byteindex("aba", 1)"##,
+            r##""ababa".byterindex("aba")"##,
+            r##""ababa".byterindex("aba", 1)"##,
+            r##""abc".byterindex("", 2)"##,
+            r##"u = "あいうあいう"; [u.index("い"), u.index("い", 2), u.rindex("い"), u.byteindex("い"), u.byteindex("い", 6), u.byterindex("い"), u.byterindex("い", 6)]"##,
+            r##"s = ("ab\xFFcd").dup.force_encoding("UTF-8"); [s.index("c"), s.rindex("c"), s.byteindex("c", 3), s.byterindex("c")]"##,
+            r##"begin; "あいう".byteindex("い", 1); rescue IndexError; :boundary; end"##,
+            r##"begin; "あいう".byterindex("あ", 1); rescue IndexError; :boundary; end"##,
+            r##"sj = "soft".encode("Shift_JIS"); sj.index("f".dup.force_encoding("Shift_JIS"))"##,
+        ]);
+    }
+
+    #[test]
     fn rindex_and_byterindex_set_backref() {
         // The forward-scan rindex implementations probe past the
         // returned match; `$~` must still end up as the match at the
@@ -9215,10 +9318,14 @@ mod tests {
     }
 
     #[test]
-    fn string_rindex_string_invalid_utf8_raises() {
-        // Same contract as the regex path: broken UTF-8 receivers
-        // raise ArgumentError rather than silently scan bytes.
-        run_test_error(r#""\xC3".dup.force_encoding("UTF-8").rindex("a")"#);
+    fn string_rindex_string_invalid_utf8() {
+        // CRuby allows String needles on broken-UTF-8 receivers (only
+        // the Regexp path raises): the search runs on encoding-aware
+        // character boundaries, counting each broken byte as one char.
+        run_tests(&[
+            r#""\xC3".dup.force_encoding("UTF-8").rindex("a")"#,
+            r#""ab\xC3cd".dup.force_encoding("UTF-8").rindex("c")"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -119,6 +119,15 @@ pub struct Executor {
     /// LEP's `LFP_SVAR`. All other per-match state (`$~`, `$&`, `$'`,
     /// `$\``, `$1`..`$N`) now lives frame-locally on the LEP.
     sp_match_regex: Option<Value>,
+    /// In-flight haystack stash: regex-matching entry points that know
+    /// the *subject String Value* (e.g. `String#match`, `Regexp#match`,
+    /// `String#gsub`) record it here so MatchData / `$~` construction
+    /// can snapshot the haystack as a zero-copy shared substring
+    /// instead of copying the bytes. Consumers verify by pointer
+    /// containment (`resolve_haystack`) that the `&str` they hold
+    /// actually borrows from this Value's buffer, so a stale stash can
+    /// never mis-attribute a haystack — it only falls back to copying.
+    sp_match_haystack: Option<Value>,
     temp_stack: Vec<Value>,
     require_level: usize,
     /// Stack of canonical paths currently being executed via `require` /
@@ -157,6 +166,7 @@ impl std::default::Default for Executor {
             lexical_class: vec![vec![]],
             toplevel_visibility: Visibility::Private,
             sp_match_regex: None,
+            sp_match_haystack: None,
             temp_stack: vec![],
             require_level: 0,
             loading_paths: vec![],
@@ -193,6 +203,15 @@ impl alloc::GC<RValue> for Executor {
         // returns. See `MonorubyErr::mark`.
         if let Some(err) = &self.exception {
             err.mark(alloc);
+        }
+        // Transient per-match stashes: live across the MatchData
+        // allocation in `save_capture_special_variables`, which can
+        // trigger GC.
+        if let Some(v) = self.sp_match_regex {
+            v.mark(alloc);
+        }
+        if let Some(v) = self.sp_match_haystack {
+            v.mark(alloc);
         }
         // Deferred `MethodReturn` / `Throw` carry packed Values (return
         // value, throw tag/value) and an `Lfp`; keep them alive across
@@ -2404,6 +2423,32 @@ impl Executor {
         self.sp_match_regex = Some(regex);
     }
 
+    /// Stash the subject String `Value` about to be matched, enabling
+    /// zero-copy haystack snapshots (see the `sp_match_haystack` field
+    /// docs). Non-String values are ignored.
+    pub(crate) fn set_match_haystack(&mut self, subject: Value) {
+        if subject.is_rstring().is_some() {
+            self.sp_match_haystack = Some(subject);
+        }
+    }
+
+    /// If `s` borrows from the stashed subject's byte buffer, return
+    /// `(subject, byte offset of s within it)`. The pointer-containment
+    /// check makes a stale or unrelated stash harmless: it simply
+    /// resolves to `None` and the caller copies the haystack as before.
+    pub(crate) fn resolve_haystack(&self, s: &str) -> Option<(Value, usize)> {
+        let subject = self.sp_match_haystack?;
+        let rs = subject.is_rstring()?;
+        let bytes = rs.as_bytes();
+        let base = bytes.as_ptr() as usize;
+        let p = s.as_ptr() as usize;
+        if p >= base && p + s.len() <= base + bytes.len() {
+            Some((subject, p - base))
+        } else {
+            None
+        }
+    }
+
     ///
     /// Build a `MatchData` from `captures` + `haystack` (plus the
     /// transient `sp_match_regex` stash) and store it as the current
@@ -2414,7 +2459,8 @@ impl Executor {
         captures: &onigmo_regex::Captures<'h>,
         haystack: &str,
     ) {
-        let mut md = MatchDataInner::from_captures(captures, haystack);
+        let mut md =
+            MatchDataInner::from_captures_snap(captures, haystack, self.resolve_haystack(haystack));
         if let Some(regex_val) = self.sp_match_regex
             && let Some(regex) = regex_val.is_regex()
         {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1234,11 +1234,7 @@ impl Value {
         RValue::new_binding(outer_lfp, pc).pack()
     }
 
-    pub(crate) fn new_matchdata(captures: Captures, heystack: &str, regex: Regexp) -> Self {
-        RValue::new_match_data(captures, heystack, regex).pack()
-    }
-
-    /// Like `new_matchdata`, but takes the result of
+    /// Construct a MatchData. Takes the result of
     /// `Executor::resolve_haystack` so the haystack snapshot can be a
     /// zero-copy shared substring of the subject String.
     pub(crate) fn new_matchdata_snap(

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1238,6 +1238,21 @@ impl Value {
         RValue::new_match_data(captures, heystack, regex).pack()
     }
 
+    /// Like `new_matchdata`, but takes the result of
+    /// `Executor::resolve_haystack` so the haystack snapshot can be a
+    /// zero-copy shared substring of the subject String.
+    pub(crate) fn new_matchdata_snap(
+        captures: Captures,
+        heystack: &str,
+        resolved: Option<(Value, usize)>,
+        regex: Regexp,
+    ) -> Self {
+        RValue::new_match_data_from_inner(MatchDataInner::from_capture_snap(
+            captures, heystack, resolved, regex,
+        ))
+        .pack()
+    }
+
     pub(crate) fn unpack(&self) -> RV<'_> {
         if let Some(i) = self.try_fixnum() {
             RV::Fixnum(i)

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -433,12 +433,6 @@ impl ObjKind {
         }
     }
 
-    fn matchdata(captures: Captures, heystack: &str, regex: Regexp) -> Self {
-        Self {
-            matchdata: ManuallyDrop::new(MatchDataInner::from_capture(captures, heystack, regex)),
-        }
-    }
-
     fn matchdata_from_inner(inner: MatchDataInner) -> Self {
         Self {
             matchdata: ManuallyDrop::new(inner),
@@ -1936,14 +1930,6 @@ impl RValue {
         RValue {
             header: Header::new(BINDING_CLASS, ObjTy::BINDING),
             kind: ObjKind::binding(outer_lfp, call_site_pc),
-            var_table: None,
-        }
-    }
-
-    pub(super) fn new_match_data(captures: Captures, heystack: &str, regex: Regexp) -> Self {
-        RValue {
-            header: Header::new(MATCHDATA_CLASS, ObjTy::MATCHDATA),
-            kind: ObjKind::matchdata(captures, heystack, regex),
             var_table: None,
         }
     }

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -32,16 +32,24 @@ fn decode_span(span: Span) -> Option<(usize, usize)> {
 ///
 /// `$~` is materialized on every successful regexp match, so this
 /// struct is sized to keep that as cheap as possible while fitting
-/// RValue's 48-byte payload: 8 (regex) + 16 (`Box<str>`) + 24
-/// (SmallVec) = 48. The inline capacity of 2 covers the most common
-/// match shapes (whole match only, or one capture group) without a
-/// positions heap allocation.
+/// RValue's 48-byte payload: 8 (regex) + 8 (`Value`) + 24 (SmallVec)
+/// = 40. The inline capacity of 2 covers the most common match shapes
+/// (whole match only, or one capture group) without a positions heap
+/// allocation.
+///
+/// `heystack` is a *snapshot* String taken at match time — a shared
+/// (copy-on-write) view when the subject's Value was known to the
+/// matcher (see `Executor::resolve_haystack`), an owned copy
+/// otherwise — so later mutation of the subject never changes this
+/// MatchData (CRuby behaviour: `MatchData#string` is frozen). Its
+/// content is guaranteed valid UTF-8: every constructor takes the
+/// haystack as `&str`.
 ///
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct MatchDataInner {
     regex: Option<Regexp>,
-    heystack: Box<str>,
+    heystack: Value,
     matches: SmallVec<[Span; 2]>,
 }
 
@@ -50,25 +58,33 @@ impl GC<RValue> for MatchDataInner {
         if let Some(re) = &self.regex {
             re.mark(alloc);
         }
+        self.heystack.mark(alloc);
     }
 }
 
 impl MatchDataInner {
-    pub fn new(heystack: &str, matches: Vec<Option<(usize, usize)>>) -> Self {
-        assert!(
-            heystack.len() < u32::MAX as usize,
-            "match subject longer than 4GiB is not supported"
-        );
-        MatchDataInner {
-            regex: None,
-            heystack: Box::from(heystack),
-            matches: matches.into_iter().map(encode_span).collect(),
+    /// Snapshot the haystack as a String `Value`. When `resolved` says
+    /// `s` borrows from a known String Value's buffer (verified by
+    /// pointer containment in `Executor::resolve_haystack`), the
+    /// snapshot is a zero-copy shared substring (the subject becomes a
+    /// CoW sharer); otherwise the bytes are copied, exactly as the old
+    /// `Box<str>` field did.
+    fn snapshot(s: &str, resolved: Option<(Value, usize)>) -> Value {
+        match resolved {
+            Some((val, offset)) => string_substring(val, offset, offset + s.len()),
+            None => Value::string_from_str(s),
         }
     }
 
     /// Build directly from onigmo `Captures` without intermediate
     /// position vectors (hot path: `$~` save on every match).
-    pub fn from_captures(captures: &Captures, heystack: &str) -> Self {
+    /// `resolved` (from `Executor::resolve_haystack`) enables the
+    /// zero-copy haystack snapshot.
+    pub fn from_captures_snap(
+        captures: &Captures,
+        heystack: &str,
+        resolved: Option<(Value, usize)>,
+    ) -> Self {
         assert!(
             heystack.len() < u32::MAX as usize,
             "match subject longer than 4GiB is not supported"
@@ -79,9 +95,14 @@ impl MatchDataInner {
             .collect();
         MatchDataInner {
             regex: None,
-            heystack: Box::from(heystack),
+            heystack: Self::snapshot(heystack, resolved),
             matches,
         }
+    }
+
+    /// `from_captures_snap` without a haystack Value (always copies).
+    pub fn from_captures(captures: &Captures, heystack: &str) -> Self {
+        Self::from_captures_snap(captures, heystack, None)
     }
 
     /// Builder helper: attach a `Regexp` to a freshly-constructed
@@ -98,12 +119,28 @@ impl MatchDataInner {
         Self::from_captures(&captures, heystack).with_regex(regex)
     }
 
+    pub fn from_capture_snap(
+        captures: Captures,
+        heystack: &str,
+        resolved: Option<(Value, usize)>,
+        regex: Regexp,
+    ) -> Self {
+        Self::from_captures_snap(&captures, heystack, resolved).with_regex(regex)
+    }
+
     pub fn regexp(&self) -> Option<Regexp> {
         self.regex
     }
 
+    fn heystack_bytes(&self) -> &[u8] {
+        self.heystack.as_rstring_inner().as_bytes()
+    }
+
     pub fn string(&self) -> &str {
-        &self.heystack
+        // SAFETY: every constructor receives the haystack as `&str`
+        // and the snapshot preserves those exact bytes (shared view or
+        // copy), so the content is valid UTF-8.
+        unsafe { std::str::from_utf8_unchecked(self.heystack_bytes()) }
     }
 
     pub fn pos(&self, pos: usize) -> Option<(usize, usize)> {
@@ -119,7 +156,7 @@ impl MatchDataInner {
     /// `#[monoruby_builtin]` extern "C" boundary).
     pub fn at(&self, pos: usize) -> Option<&[u8]> {
         self.pos(pos)
-            .map(|(start, end)| &self.heystack.as_bytes()[start..end])
+            .map(|(start, end)| &self.heystack_bytes()[start..end])
     }
 
     pub fn len(&self) -> usize {
@@ -129,7 +166,7 @@ impl MatchDataInner {
     pub fn captures(&self) -> impl Iterator<Item = Option<&[u8]>> {
         self.matches
             .iter()
-            .map(|m| decode_span(*m).map(|(start, end)| &self.heystack.as_bytes()[start..end]))
+            .map(|m| decode_span(*m).map(|(start, end)| &self.heystack_bytes()[start..end]))
     }
 
     pub fn to_s(&self) -> String {

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -115,10 +115,6 @@ impl MatchDataInner {
         self
     }
 
-    pub fn from_capture(captures: Captures, heystack: &str, regex: Regexp) -> Self {
-        Self::from_captures(&captures, heystack).with_regex(regex)
-    }
-
     pub fn from_capture_snap(
         captures: Captures,
         heystack: &str,

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1016,7 +1016,15 @@ impl RegexpInner {
         match re.captures_from_pos(given, byte_pos, vm)? {
             None => Ok(Value::nil()),
             Some(captures) => {
-                let match_data = Value::new_matchdata(captures, given, re);
+                // Zero-copy haystack snapshot when the caller stashed
+                // the subject Value (see `Executor::resolve_haystack`).
+                let md = MatchDataInner::from_capture_snap(
+                    captures,
+                    given,
+                    vm.resolve_haystack(given),
+                    re,
+                );
+                let match_data = RValue::new_match_data_from_inner(md).pack();
                 if let Some(bh) = block {
                     vm.invoke_block_once(globals, bh, &[match_data])
                 } else {

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1013,6 +1013,10 @@ impl RegexpInner {
             Some((pos, _)) => pos,
             None => return Ok(Value::nil()),
         };
+        // Attach the Regexp to the `$~` this match is about to save, so
+        // named-capture lookup (`$~[:name]`) works after `String#match`
+        // (same stash `Regexp#match` sets on its own path).
+        vm.set_match_regex(re.as_val());
         match re.captures_from_pos(given, byte_pos, vm)? {
             None => Ok(Value::nil()),
             Some(captures) => {


### PR DESCRIPTION
Follow-up to #720 (which shipped the String shared-substring/CoW machinery). Three commits:

## 1. Eliminate MatchData / `$~` haystack copies via CoW string snapshots

`MatchDataInner` stored its haystack as a `Box<str>`, copying the entire subject on every successful match — twice on the common paths, since `$~` is materialized per match in addition to any explicit MatchData (tinygql: ~340MB copied per 80KB-document lex).

The haystack is now a String `Value` snapshot taken with the shared-substring machinery: when the matcher knows the subject Value, the snapshot is a zero-copy CoW sharer of the subject's buffer (the subject's later mutation detaches itself, so the MatchData stays immutable — CRuby's frozen-string semantics); otherwise the bytes are copied as before. The GC marks the snapshot.

Plumbing uses the same transient-stash pattern as `sp_match_regex`: regex entry points that own the subject Value (`String#match`, `#index`, `#rindex`, `#byteindex`, `#byterindex`, `#split`, `#scan`, `#sub`/`#gsub`(+`!`), `#[]=`(regexp), `Regexp#match`) call `vm.set_match_haystack(subject)`; MatchData construction verifies by **pointer containment** (`Executor::resolve_haystack`) that the `&str` it holds borrows from the stashed Value's buffer, so a stale or unrelated stash can never mis-attribute a haystack — it just falls back to copying. Both `sp_match_regex` and `sp_match_haystack` are now GC-marked (the former previously wasn't). `Regexp#match` also stops materializing an owned copy of String subjects.

**tinygql:** lexer 4.0s → ~0.29s per 20 lexes; parse benchmark 4.75s (session start) → **~0.33-0.39s (12×)**; CRuby 4.0.5 is ~0.13-0.18s, so the original 27× gap is now ~2-3×. app_fib unchanged.

## 2. Fix `$~` after `String#rindex`/`#byterindex`; attach the Regexp to `String#match`'s `$~`

- The forward-scan rindex implementations left `$~` as the *last probe* (usually the failed probe past the final match, clearing it). They now re-run one anchored probe at the returned match's byte position (`rindex_set_backref`), and clear `$~` on nil — CRuby behaviour.
- `$~` saved on the `String#match` path carried no Regexp (the `sp_match_regex` stash was only set by `Regexp#match`/`#=~`), so `$~[:name]` / `$~.named_captures` / `$~.regexp` raised `IndexError`. `match_one` now stashes the Regexp like the Regexp-side entry points.

## 3. `String#index`/`#byteindex`/`#byterindex` with a String pattern: plain byte search, no `$~` clobber (fixes #721)

The String-pattern paths converted the needle to a Regexp and probed via `captures_from_pos`, setting `$~` on a hit and clearing it on a miss — CRuby leaves `$~` untouched for String patterns. They now use byte searches that never enter the regex engine (`substring_char_index` for `index`, new `byte_search_fwd`/`byte_search_rev` for the byte-indexed pair, with an encoding-aware offset boundary check). Bonus fidelity fixes verified against CRuby: broken-UTF-8 receivers now work with String needles (we used to raise; one test pinning the old behaviour was updated), boundary `IndexError` is encoding-aware, and the per-call Regexp construction is gone. Also removes the dead pre-snapshot MatchData constructor chain.

## Verification

- Full `cargo test --lib` (1,874) green on the rebased branch; method_call/require/rescue/literal integration suites green
- New CRuby-differential regression tests: `match_data_haystack_snapshot` (subject mutation after match, shared-byteslice subjects, subjects dying before their MatchData under GC), `rindex_and_byterindex_set_backref`, `string_match_attaches_regexp_to_backref`, `index_family_string_pattern_preserves_backref`
- Seven standalone differential scripts ($~ matrices, boundary/broken-UTF-8 matrices, overlap/offset edges, Shift_JIS trail-byte safety, JIT-warmed `$~` preservation) byte-identical with CRuby 4.0.5 on the release build
- gc-stress runs of the MatchData/CoW GC-liveness scripts pass

Fixes #721

https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp)_