### PR TITLE
String#lines/#each_line/#scan: zero-copy CoW views; #chars: eager code-range

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2835,9 +2835,12 @@ fn gsub_main(
 #[monoruby_builtin]
 fn scan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let given = self_.expect_str(globals)?;
-    // Enable zero-copy $~ haystack snapshots (CoW).
-    vm.set_match_haystack(self_);
+    // Take a stable frozen snapshot of the receiver up front, so every
+    // match can be a zero-copy shared (CoW) view even if a block mutates
+    // the receiver mid-scan. `$~` snapshots share the same buffer.
+    self_.expect_str(globals)?;
+    let subject = string_snapshot(self_);
+    vm.set_match_haystack(subject);
     let arg0 = lfp.arg(0);
     let owned_re;
     let coerced_re;
@@ -2852,14 +2855,16 @@ fn scan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         coerced_re = RegexpInner::from_escaped(&coerced)?;
         &coerced_re
     };
-    let result_enc = self_.is_rstring_inner().map(|r| r.encoding());
     match lfp.block() {
         None => {
-            let vec = re.scan(vm, given, result_enc)?;
+            // SAFETY of the borrow: `subject` is frozen, so its buffer is
+            // never reallocated; `string_substring(subject, …)` only reads.
+            let given = subject.as_rstring_inner().check_utf8()?;
+            let vec = re.scan(vm, subject, given)?;
             Ok(Value::array_from_vec(vec))
         }
         Some(block) => {
-            scan_with_block(vm, globals, re, given, block, result_enc)?;
+            scan_with_block(vm, globals, re, subject, block)?;
             Ok(lfp.self_val())
         }
     }
@@ -2869,40 +2874,51 @@ fn scan_with_block(
     vm: &mut Executor,
     globals: &mut Globals,
     re: &RegexpInner,
-    given: &str,
+    subject: Value,
     block: BlockHandler,
-    result_enc: Option<Encoding>,
 ) -> Result<()> {
-    // We must own the string since `given` borrows from self_val,
-    // and invoke_block may mutate self_val.
-    let given = given.to_string();
     let data = vm.get_block_data(globals, block)?;
     vm.clear_capture_special_variables();
-    let str_with_enc = |s: &str| match result_enc {
-        Some(e) => Value::string_from_inner(RStringInner::from_encoding_scanned(s.as_bytes(), e)),
-        None => Value::string(s.to_string()),
-    };
-    for cap in re.captures_iter(&given) {
+    // Root the snapshot across block invocations (which may GC) so the
+    // borrowed `given` and the shared match views stay alive even if the
+    // block drops every reference to the receiver.
+    let temp_len = vm.temp_len();
+    vm.temp_push(subject);
+    let res = scan_block_loop(vm, globals, re, subject, &data);
+    vm.temp_clear(temp_len);
+    res
+}
+
+fn scan_block_loop(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    re: &RegexpInner,
+    subject: Value,
+    data: &ProcData,
+) -> Result<()> {
+    // `subject` is frozen (stable buffer) and temp-rooted by the caller,
+    // so this borrow stays valid across `invoke_block`.
+    let given = subject.as_rstring_inner().check_utf8()?;
+    for cap in re.captures_iter(given) {
         let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
-        vm.save_capture_special_variables(&cap, &given);
+        vm.save_capture_special_variables(&cap, given);
         match cap.len() {
             0 => unreachable!(),
             1 => {
-                let val = str_with_enc(cap.get(0).unwrap().as_str());
-                vm.invoke_block(globals, &data, &[val])?;
+                let m = cap.get(0).unwrap();
+                let val = string_substring(subject, m.start(), m.end());
+                vm.invoke_block(globals, data, &[val])?;
             }
             len => {
                 let mut vec = vec![];
                 for i in 1..len {
                     match cap.get(i) {
-                        Some(m) => {
-                            vec.push(str_with_enc(m.as_str()));
-                        }
+                        Some(m) => vec.push(string_substring(subject, m.start(), m.end())),
                         None => vec.push(Value::nil()),
                     }
                 }
                 let val = Value::array_from_vec(vec);
-                vm.invoke_block(globals, &data, &val.as_array())?;
+                vm.invoke_block(globals, data, &val.as_array())?;
             }
         }
     }
@@ -3899,19 +3915,14 @@ fn rjust(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn lines(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
-    let inner = receiver.as_rstring_inner();
-    let enc = inner.encoding();
-    let s = inner.check_utf8()?.to_string();
     let chomp = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
-    let parts = split_lines(vm, globals, &s, lfp.try_arg(0), chomp)?;
-    let out = parts
-        .into_iter()
-        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)));
+    // Zero-copy shared (CoW) line views, built eagerly before any block.
+    let lines = build_lines(vm, globals, receiver, lfp.try_arg(0), chomp)?;
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_iter1(globals, bh, out)?;
+        vm.invoke_block_iter1(globals, bh, lines.into_iter())?;
         Ok(receiver)
     } else {
-        Ok(Value::array_from_iter(out))
+        Ok(Value::array_from_vec(lines))
     }
 }
 
@@ -4451,16 +4462,12 @@ fn is_char_boundary(bytes: &[u8], offset: usize) -> bool {
 #[monoruby_builtin]
 fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
-    let inner = receiver.as_rstring_inner();
-    let enc = inner.encoding();
-    let s = inner.check_utf8()?.to_string();
-    let chomp = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
-    let parts = split_lines(vm, globals, &s, lfp.try_arg(0), chomp)?;
-    let out = parts
-        .into_iter()
-        .map(|p| Value::string_from_inner(RStringInner::from_encoding(p.as_bytes(), enc)));
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_iter1(globals, bh, out)?;
+        let chomp = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
+        // Zero-copy shared (CoW) line views, built eagerly before the
+        // block runs so each view references the frozen root buffer.
+        let lines = build_lines(vm, globals, receiver, lfp.try_arg(0), chomp)?;
+        vm.invoke_block_iter1(globals, bh, lines.into_iter())?;
         Ok(receiver)
     } else {
         let mut args = vec![];
@@ -4481,86 +4488,151 @@ fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
 /// When `chomp` is `true`, the trailing separator (or `\r\n` /
 /// `\n` / `\r` when separator is the default newline) is removed
 /// from each yielded part.
-fn split_lines(
+/// Compute the byte ranges (into the receiver's UTF-8 content) of the
+/// lines produced by `String#lines` / `#each_line`, per CRuby's
+/// record-separator rules:
+/// * separator missing or `$/` → uses `"\n"`,
+/// * separator `nil`           → the whole string as one line,
+/// * separator `""`            → paragraph mode (runs of 2+ `\n`),
+/// * any other separator       → splits keeping the separator.
+/// With `chomp: true` the trailing separator (or `\r\n` / `\n` / `\r`
+/// under the default newline) is trimmed from each range's end.
+///
+/// The separator's `to_str` coercion may run Ruby code, so it is
+/// resolved *before* the receiver's bytes are borrowed — a mid-borrow
+/// mutation would invalidate the slice the ranges index into.
+fn line_ranges(
     vm: &mut Executor,
     globals: &mut Globals,
-    s: &str,
+    receiver: Value,
     rs_arg: Option<Value>,
     chomp: bool,
-) -> Result<Vec<String>> {
-    if let Some(arg) = rs_arg {
-        if arg.is_nil() {
-            // nil separator: return the whole string as one element
-            // (ignoring `chomp`, matching CRuby).
-            return Ok(if s.is_empty() {
+) -> Result<Vec<std::ops::Range<usize>>> {
+    enum Sep {
+        Whole,
+        Default,
+        Paragraph,
+        Str(String),
+    }
+    let sep = match rs_arg {
+        None => Sep::Default,
+        Some(arg) if arg.is_nil() => Sep::Whole,
+        Some(arg) => {
+            // CRuby rejects `false`/`true`/Symbol explicitly here, even
+            // though `coerce_to_str` would also raise. We mirror that so
+            // the spec error class matches (TypeError, not NoMethodError).
+            match arg.unpack() {
+                RV::Bool(_) | RV::Symbol(_) => {
+                    return Err(MonorubyErr::no_implicit_conversion(
+                        globals,
+                        arg,
+                        STRING_CLASS,
+                    ));
+                }
+                _ => {}
+            }
+            let sep = arg.coerce_to_str(vm, globals)?.to_string();
+            if sep.is_empty() {
+                Sep::Paragraph
+            } else {
+                Sep::Str(sep)
+            }
+        }
+    };
+    let inner = receiver.as_rstring_inner();
+    let s = inner.check_utf8()?;
+    Ok(match sep {
+        Sep::Whole => {
+            if s.is_empty() {
                 vec![]
             } else {
-                vec![s.to_string()]
-            });
-        }
-        // CRuby rejects `false`/`true`/Symbol explicitly here, even
-        // though `coerce_to_str` would also raise. We mirror that so
-        // the spec error class matches (TypeError, not NoMethodError).
-        match arg.unpack() {
-            RV::Bool(_) | RV::Symbol(_) => {
-                return Err(MonorubyErr::no_implicit_conversion(
-                    globals,
-                    arg,
-                    STRING_CLASS,
-                ));
+                vec![0..s.len()]
             }
-            _ => {}
         }
-        let sep = arg.coerce_to_str(vm, globals)?.to_string();
-        if sep.is_empty() {
-            return Ok(split_paragraphs(s, chomp));
-        }
-        return Ok(split_with_separator(s, &sep, chomp));
-    }
-    Ok(split_with_default_newline(s, chomp))
+        Sep::Default => split_with_default_newline_ranges(s, chomp),
+        Sep::Paragraph => split_paragraph_ranges(s, chomp),
+        Sep::Str(sep) => split_with_separator_ranges(s, &sep, chomp),
+    })
+}
+
+/// Build the line Values for `String#lines` / `#each_line` as zero-copy
+/// shared (CoW) substrings of the receiver. They are materialised
+/// eagerly — before any block runs — so every view references the same
+/// frozen root buffer even if a block later mutates the receiver.
+fn build_lines(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    receiver: Value,
+    rs_arg: Option<Value>,
+    chomp: bool,
+) -> Result<Vec<Value>> {
+    let ranges = line_ranges(vm, globals, receiver, rs_arg, chomp)?;
+    Ok(ranges
+        .into_iter()
+        .map(|r| string_substring(receiver, r.start, r.end))
+        .collect())
 }
 
 /// Default-newline splitter (CRuby treats the unspecified separator as
 /// "\n" but also allows the line to end with `\r\n` or a bare `\r`,
-/// which matters only for `chomp: true`).
-fn split_with_default_newline(s: &str, chomp: bool) -> Vec<String> {
-    let mut out: Vec<String> = s.split_inclusive('\n').map(String::from).collect();
-    if chomp {
-        for line in out.iter_mut() {
-            if let Some(stripped) = line.strip_suffix("\r\n") {
-                *line = stripped.to_string();
-            } else if let Some(stripped) =
-                line.strip_suffix('\n').or_else(|| line.strip_suffix('\r'))
-            {
-                *line = stripped.to_string();
+/// which matters only for `chomp: true`). Returns byte ranges into `s`.
+fn split_with_default_newline_ranges(s: &str, chomp: bool) -> Vec<std::ops::Range<usize>> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for piece in s.split_inclusive('\n') {
+        let mut end = start + piece.len();
+        if chomp {
+            if piece.ends_with("\r\n") {
+                end -= 2;
+            } else if piece.ends_with('\n') || piece.ends_with('\r') {
+                end -= 1;
             }
         }
+        out.push(start..end);
+        start += piece.len();
     }
     out
 }
 
-fn split_with_separator(s: &str, sep: &str, chomp: bool) -> Vec<String> {
-    let mut out: Vec<String> = s.split_inclusive(sep).map(String::from).collect();
-    if chomp {
-        for line in out.iter_mut() {
-            if let Some(stripped) = line.strip_suffix(sep) {
-                *line = stripped.to_string();
-            }
+fn split_with_separator_ranges(s: &str, sep: &str, chomp: bool) -> Vec<std::ops::Range<usize>> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for piece in s.split_inclusive(sep) {
+        let mut end = start + piece.len();
+        if chomp && piece.ends_with(sep) {
+            end -= sep.len();
         }
+        out.push(start..end);
+        start += piece.len();
     }
     out
 }
 
-fn split_paragraphs(s: &str, chomp: bool) -> Vec<String> {
+fn split_paragraph_ranges(s: &str, chomp: bool) -> Vec<std::ops::Range<usize>> {
     // Paragraph mode: skip leading newlines, then split on runs of 2+
     // newlines. CRuby keeps `\n\n` at the end of each paragraph (or
-    // strips it when `chomp: true`).
+    // strips it when `chomp: true`). Ranges are relative to `s`, so the
+    // skipped leading newlines shift every offset by `base`.
     let trimmed = s.trim_start_matches('\n');
     if trimmed.is_empty() {
         return vec![];
     }
+    let base = s.len() - trimmed.len();
     let mut out = Vec::new();
     let bytes = trimmed.as_bytes();
+    // Trim trailing `\n`s from a `[start, end)` paragraph when chomping.
+    let push = |out: &mut Vec<std::ops::Range<usize>>, start: usize, end: usize| {
+        let end = if chomp {
+            let mut e = end;
+            while e > start && bytes[e - 1] == b'\n' {
+                e -= 1;
+            }
+            e
+        } else {
+            end
+        };
+        out.push((base + start)..(base + end));
+    };
     let mut start = 0usize;
     let mut i = 0usize;
     while i < bytes.len() {
@@ -4574,12 +4646,7 @@ fn split_paragraphs(s: &str, chomp: bool) -> Vec<String> {
             if nl_count >= 2 {
                 // Paragraph ends with `\n\n` retained.
                 let para_end = i + 2;
-                let para = &trimmed[start..para_end];
-                out.push(if chomp {
-                    para.trim_end_matches('\n').to_string()
-                } else {
-                    para.to_string()
-                });
+                push(&mut out, start, para_end);
                 start = j;
                 i = j;
                 continue;
@@ -4590,12 +4657,7 @@ fn split_paragraphs(s: &str, chomp: bool) -> Vec<String> {
         }
     }
     if start < trimmed.len() {
-        let para = &trimmed[start..];
-        out.push(if chomp {
-            para.trim_end_matches('\n').to_string()
-        } else {
-            para.to_string()
-        });
+        push(&mut out, start, trimmed.len());
     }
     out
 }
@@ -6783,10 +6845,14 @@ fn chars(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let enc = inner.encoding();
     // Materialise per-char byte slices into owned RStringInner values
     // tagged with the source encoding. Walking eagerly avoids
-    // borrowing `inner` past the iterator.
+    // borrowing `inner` past the iterator. Classify each char's code
+    // range up front (`from_encoding_scanned`): the slice is one
+    // character (1-4 bytes), so the scan is O(1), and it spares a lazy
+    // re-classification on the first `valid_encoding?` / encoding-compat
+    // query (e.g. when the chars are concatenated back together).
     let chars = inner
         .iter_char_bytes()
-        .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)));
+        .map(|s| Value::string_from_inner(RStringInner::from_encoding_scanned(s, enc)));
     if let Some(bh) = lfp.block() {
         vm.invoke_block_map1(globals, bh, chars, None)?;
         Ok(lfp.self_val())
@@ -6891,9 +6957,11 @@ fn each_char(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
     if let Some(bh) = lfp.block() {
         let inner = self_.as_rstring_inner();
         let enc = inner.encoding();
+        // Classify each one-character slice up front (cheap, O(1) per
+        // char) so a later cr query doesn't re-scan — see `chars`.
         let chars = inner
             .iter_char_bytes()
-            .map(|s| Value::string_from_inner(RStringInner::from_encoding(s, enc)));
+            .map(|s| Value::string_from_inner(RStringInner::from_encoding_scanned(s, enc)));
         vm.invoke_block_iter1(globals, bh, chars)?;
         Ok(lfp.self_val())
     } else {
@@ -8441,6 +8509,43 @@ mod tests {
         run_test_error(r##""string".end_with?("jng", 3, "ing")"##);
         // end_with? with Regexp raises TypeError
         run_test_error(r#""hello".end_with?(/lo/)"#);
+    }
+
+    #[test]
+    fn lines_scan_chars_cow() {
+        // lines / each_line return zero-copy shared (CoW) line views;
+        // scan returns shared match views; chars classify their code
+        // range up front. Verify CRuby-identical results, snapshot
+        // semantics (a block mutating the receiver mid-iteration does not
+        // disturb the already-built views), and CoW mutation isolation.
+        run_tests(&[
+            // lines: separators, chomp, paragraph mode, multibyte
+            r##"(("x"*40 + "\n") * 20).lines.length"##,
+            r##""a\nb\nc\n".lines(chomp: true)"##,
+            r##""a\r\nb\r\n".lines(chomp: true)"##,
+            r##""foo|bar|baz|".lines("|", chomp: true)"##,
+            r##""p1\n\np2\n\n\np3".lines("")"##,
+            r##""あ\nい\nう\n".lines.map(&:bytes)"##,
+            // each_line block + receiver mutation mid-iteration (snapshot)
+            r##"t = "p\nq\nr\n".dup; g = []; t.each_line { |l| g << l; t << "X" }; g"##,
+            // lines CoW isolation: mutate a long line, source intact
+            r##"s = (("z"*50 + "\n") * 4).dup; ls = s.lines; ls[0].setbyte(0, 89); [s.getbyte(0), ls[0].getbyte(0)]"##,
+            // scan: groups, named captures, block, multibyte, $~
+            r##""foo bar baz".scan(/\w+/)"##,
+            r##""a1b2c3".scan(/([a-z])(\d)/)"##,
+            r##""no match".scan(/xyz/)"##,
+            r##"r=[]; "foo bar".scan(/\w+/){|m| r<<m.upcase}; r"##,
+            r##""x1y2".scan(/\d/); $~[0]"##,
+            r##""café résumé".scan(/\w+/).map(&:bytes)"##,
+            // scan CoW isolation on a long match
+            r##"src = ("TOK_" + "q"*40 + " ") * 4; t = src.scan(/\S+/); t[0].setbyte(0, 88); [src.getbyte(0), t[0].getbyte(0)]"##,
+            // chars: code-range-dependent queries
+            r##""café".chars.map(&:bytes)"##,
+            r##"["a".chars[0].valid_encoding?, "あ".chars[0].valid_encoding?]"##,
+            r##""aé".chars.map(&:ascii_only?)"##,
+            r##"("a\xFFb").dup.force_encoding("UTF-8").chars.map(&:valid_encoding?)"##,
+            r##"c=[]; "xyz".each_char { |ch| c << ch.upcase }; c"##,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -30,7 +30,7 @@ pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
 pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET};
-pub(crate) use string::{string_substring, STRING_SHARED_TAG};
+pub(crate) use string::{string_snapshot, string_substring, STRING_SHARED_TAG};
 pub(crate) use string::{eucjp_char_width, sjis_char_width};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1064,11 +1064,15 @@ impl RegexpInner {
         }
     }
 
+    /// `subject` is a frozen snapshot whose bytes are exactly `given`;
+    /// each match/capture is returned as a zero-copy shared (CoW)
+    /// substring view of it (`string_substring`), inheriting its
+    /// encoding. The caller is responsible for keeping `subject` alive.
     pub(crate) fn scan(
         &self,
         vm: &mut Executor,
+        subject: Value,
         given: &str,
-        result_enc: Option<crate::value::Encoding>,
     ) -> Result<Vec<Value>> {
         let mut ary = vec![];
         let mut last_captures = None;
@@ -1078,21 +1082,18 @@ impl RegexpInner {
             match cap.len() {
                 0 => unreachable!(),
                 1 => {
-                    let val = build_str_with_enc(cap.get(0).unwrap().as_str(), result_enc);
-                    ary.push(val);
+                    let m = cap.get(0).unwrap();
+                    ary.push(string_substring(subject, m.start(), m.end()));
                 }
                 len => {
                     let mut vec = vec![];
                     for i in 1..len {
                         match cap.get(i) {
-                            Some(m) => {
-                                vec.push(build_str_with_enc(m.as_str(), result_enc));
-                            }
+                            Some(m) => vec.push(string_substring(subject, m.start(), m.end())),
                             None => vec.push(Value::nil()),
                         }
                     }
-                    let val = Value::array_from_vec(vec);
-                    ary.push(val);
+                    ary.push(Value::array_from_vec(vec));
                 }
             }
             last_captures = Some(cap);
@@ -1102,17 +1103,6 @@ impl RegexpInner {
             vm.save_capture_special_variables(&c, given)
         }
         Ok(ary)
-    }
-}
-
-/// Build a String value tagged with `enc` if provided, otherwise
-/// fall back to UTF-8. Used by `scan` (and other regex helpers
-/// that produce string slices) so the result inherits the
-/// receiver's encoding instead of always defaulting to UTF-8.
-fn build_str_with_enc(s: &str, enc: Option<crate::value::Encoding>) -> Value {
-    match enc {
-        Some(e) => Value::string_from_inner(RStringInner::from_encoding_scanned(s.as_bytes(), e)),
-        None => Value::string(s.to_string()),
     }
 }
 

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -2098,6 +2098,34 @@ pub(crate) fn string_substring(mut parent: Value, start: usize, end: usize) -> V
 }
 
 ///
+/// Return a frozen String holding a stable snapshot of `receiver`'s
+/// current bytes — a buffer that never changes, so callers can borrow
+/// its `&str` and slice zero-copy [`string_substring`] views from it
+/// while user code (e.g. a block) may concurrently mutate `receiver`.
+///
+/// * frozen receiver        → itself (already immutable).
+/// * shared / heap-spilled  → a frozen shared root of its buffer
+///   (`receiver` becomes a CoW sharer of the same root).
+/// * small inline receiver  → a frozen clone (cheap; avoids promoting
+///   the receiver to a sharer for a buffer that views would copy anyway).
+pub(crate) fn string_snapshot(mut receiver: Value) -> Value {
+    if receiver.is_frozen() {
+        return receiver;
+    }
+    let shareable = {
+        let inner = receiver.as_rstring_inner();
+        inner.is_shared() || inner.owned_spilled()
+    };
+    if shareable {
+        ensure_shared_root(&mut receiver).0
+    } else {
+        let mut dup = Value::string_from_inner(receiver.as_rstring_inner().clone());
+        dup.set_frozen();
+        dup
+    }
+}
+
+///
 /// Make `parent`'s byte buffer shareable and return `(root, base)`:
 /// the (frozen, hidden) String owning the buffer and the address of
 /// `parent`'s first byte within it.


### PR DESCRIPTION
Continues the shared-substring/CoW work (#720/#722) for the String methods that slice a receiver into many pieces. No behaviour change vs CRuby — verified by differential scripts and a new regression test. Independent of PR #723 (branched from master).

## `lines` / `each_line` — zero-copy CoW line views

Previously each call copied the whole receiver (`check_utf8().to_string()`), copied each line into a `Vec<String>`, then copied again into the result `RStringInner` — three full passes. The split helpers now return **byte ranges** into the receiver (`line_ranges` + `split_*_ranges`), and each line is built as a zero-copy shared (CoW) substring via `string_substring`. Lines are materialised eagerly, before any block runs, so the views reference a stable buffer even if a block mutates the receiver mid-iteration (snapshot semantics, matching the old owned-copy behaviour).

## `scan` — CoW match views from a frozen snapshot

`scan` takes one frozen snapshot of the receiver up front (`string_snapshot`) and returns each match/capture as a CoW view of it. The block form roots the snapshot on the temp stack across block invocations (which may GC and may drop every reference to the receiver) and borrows the frozen snapshot's bytes — stable even as the receiver is mutated. `$~` shares the same snapshot buffer.

## `chars` / `each_char` — eager code-range classification

Each one-character String is built with `from_encoding_scanned` instead of `from_encoding`, classifying the code range up front. The slice is one character (1–4 bytes) so the scan is O(1), and it spares a lazy re-classification on the first `valid_encoding?` / `ascii_only?` / encoding-compat query (e.g. when the chars are concatenated back together).

## Measured (release, x86-64, ×20k)

| op | before | after | CRuby |
|----|--------|-------|-------|
| `doc.lines` (200 lines) | 606 ms | **210 ms** | 352 ms |
| `doc.each_line` | 678 ms | **321 ms** | 459 ms |
| `text.scan` (50 long matches) | 677 ms | **536 ms** | 526 ms |

lines/each_line are ~2–3× faster (and now beat CRuby); scan with long matches is ~1.3× faster. Short scan matches still copy, since views under the 32-byte inline cap copy anyway.

## Verification

- Full `cargo test --lib` (1,873) green; method_call/rescue integration suites green
- New CRuby-differential regression `lines_scan_chars_cow`: separators/chomp/paragraph mode, block-mutates-receiver snapshot semantics, CoW mutation isolation, scan groups/named captures/`$~`, and chars code-range queries (including broken UTF-8)
- gc-stress run of a snapshot-outlives-receiver liveness script for both scan and lines
- Standalone differential scripts byte-identical with CRuby 4.0.5

Note: the pre-existing CRuby divergences observed while testing (paragraph mode dropping a leading-newline-only first element; `scan` not raising `RuntimeError: string modified` when a block mutates the receiver — monoruby has never raised this, the old code also scanned an owned copy) are unrelated to this change and out of scope.

https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp)_