### PR TITLE
Detect receiver mutation in String#scan/#gsub blocks ("string modified") (#726)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2793,12 +2793,18 @@ fn gsub_main(
         if lfp.block().is_some() {
             eprintln!("warning: default value argument supersedes block");
         }
-        let given = self_val.expect_str(globals)?;
         if arg1.try_hash_ty().is_some() {
-            RegexpInner::replace_all_hash(vm, globals, lfp.arg(0), given, arg1)
+            // Hash form: `Hash#[]` (default_proc) may run Ruby that
+            // mutates the receiver, so pass the live receiver and let
+            // `replace_all_hash` match against a frozen snapshot.
+            RegexpInner::replace_all_hash(vm, globals, lfp.arg(0), self_val, arg1)
         } else {
             check_replacement_encoding_compat(globals, self_val, arg1)?;
             let replace = arg1.coerce_to_str(vm, globals)?;
+            // Borrow after `coerce_to_str` (its `to_str` could mutate
+            // the receiver); the string-replacement loop runs no Ruby,
+            // so the borrow stays valid for its duration.
+            let given = self_val.expect_str(globals)?;
             RegexpInner::replace_all(vm, globals, lfp.arg(0), given, &replace)
         }
     } else {
@@ -2806,8 +2812,7 @@ fn gsub_main(
             None => Err(MonorubyErr::runtimeerr("Currently, not supported.")),
             Some(bh) => {
                 let self_enc = self_val.as_rstring_inner().encoding();
-                let given = self_val.expect_str(globals)?;
-                RegexpInner::replace_all_block(vm, globals, lfp.arg(0), given, bh, Some(self_enc))
+                RegexpInner::replace_all_block(vm, globals, lfp.arg(0), self_val, bh, Some(self_enc))
             }
         }
     }
@@ -2852,7 +2857,7 @@ fn scan(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             Ok(Value::array_from_vec(vec))
         }
         Some(block) => {
-            scan_with_block(vm, globals, re, subject, block)?;
+            scan_with_block(vm, globals, re, self_, subject, block)?;
             Ok(lfp.self_val())
         }
     }
@@ -2862,6 +2867,7 @@ fn scan_with_block(
     vm: &mut Executor,
     globals: &mut Globals,
     re: &RegexpInner,
+    recv: Value,
     subject: Value,
     block: BlockHandler,
 ) -> Result<()> {
@@ -2872,7 +2878,7 @@ fn scan_with_block(
     // block drops every reference to the receiver.
     let temp_len = vm.temp_len();
     vm.temp_push(subject);
-    let res = scan_block_loop(vm, globals, re, subject, &data);
+    let res = scan_block_loop(vm, globals, re, recv, subject, &data);
     vm.temp_clear(temp_len);
     res
 }
@@ -2881,12 +2887,16 @@ fn scan_block_loop(
     vm: &mut Executor,
     globals: &mut Globals,
     re: &RegexpInner,
+    recv: Value,
     subject: Value,
     data: &ProcData,
 ) -> Result<()> {
     // `subject` is frozen (stable buffer) and temp-rooted by the caller,
-    // so this borrow stays valid across `invoke_block`.
+    // so this borrow stays valid across `invoke_block`. Matching runs on
+    // the snapshot; the *live* receiver `recv` is checked for a length
+    // change after each block call to raise "string modified" like CRuby.
     let given = subject.as_rstring_inner().check_utf8()?;
+    let recv_len = recv.as_rstring_inner().len();
     for cap in re.captures_iter(given) {
         let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
         vm.save_capture_special_variables(&cap, given);
@@ -2909,6 +2919,7 @@ fn scan_block_loop(
                 vm.invoke_block(globals, data, &val.as_array())?;
             }
         }
+        check_string_not_modified(recv, recv_len)?;
     }
     Ok(())
 }
@@ -8115,6 +8126,32 @@ mod tests {
         run_test_no_result_check(r###""a&b<c>d".encode(xml: :attr)"###);
         run_test_no_result_check(r###""a&b<c>d".encode(xml: :text)"###);
         run_test_no_result_check(r###""plain".encode(xml: :text)"###);
+    }
+
+    #[test]
+    fn scan_gsub_string_modified() {
+        // A block (or hash default_proc) that changes the receiver's
+        // *length* during scan/gsub must raise `RuntimeError: "string
+        // modified"`, matching CRuby; same-length in-place edits and
+        // mutating a different string must NOT raise. Differential via
+        // begin/rescue so the test compares both the raise and the
+        // non-raise against CRuby.
+        run_tests(&[
+            // length-changing mutations → raise
+            r##"begin; s="a b c".dup; s.scan(/\w/){ s << "x" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s="a b c".dup; s.gsub(/\w/){ s << "x"; "Q" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s="a b c".dup; s.gsub!(/\w/){ s << "x"; "Q" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s=("a "*30).dup; h=Hash.new{|_,_k| s<<"zz"; "Q"}; s.gsub(/\w/,h); :ok; rescue => e; e.class; end"##,
+            r##"begin; s=("a "*40).dup; s.gsub(/a/){ s << ("X"*200); "Q" }; :ok; rescue => e; e.class; end"##,
+            // same-length / no-op mutations → no raise
+            r##"begin; s="a b c".dup; s.scan(/\w/){ s[0]="Z" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s="a b c".dup; s.scan(/\w/){ s.upcase! }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s=("a"*100).dup; s.gsub(/a/){ s.replace("b"*100); "Q" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s="a b c".dup; t=s.dup; s.scan(/\w/){ t << "x" }; :ok; rescue => e; e.class; end"##,
+            r##"begin; s="a b c".dup; s.scan(/\w/){ |m| m }; :ok; rescue => e; e.class; end"##,
+            // grow-then-shrink back to same length within one block → no raise
+            r##"begin; s=("a"*20).dup; s.gsub(/a/){ s << "x"; s.chop!; "Q" }; :ok; rescue => e; e.class; end"##,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -30,7 +30,7 @@ pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
 pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET};
-pub(crate) use string::{string_snapshot, string_substring, STRING_SHARED_TAG};
+pub(crate) use string::{check_string_not_modified, string_snapshot, string_substring, STRING_SHARED_TAG};
 pub(crate) use string::{eucjp_char_width, sjis_char_width};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -886,53 +886,81 @@ impl RegexpInner {
         })
     }
 
-    /// Replaces all non-overlapping matches in `given` string with `replace`.
+    /// Replaces all non-overlapping matches in `recv` with the result of
+    /// calling `bh` for each match.
+    ///
+    /// Matching and splicing run against a frozen snapshot of `recv`, so
+    /// they cannot read freed memory if the block reallocates the
+    /// receiver (no use-after-free). The live `recv` is length-checked
+    /// after each block call: a length change raises
+    /// `RuntimeError: "string modified"`, matching CRuby.
     pub(crate) fn replace_all_block(
         vm: &mut Executor,
         globals: &mut Globals,
         re_val: Value,
-        given: &str,
+        recv: Value,
         bh: BlockHandler,
         self_enc: Option<crate::value::Encoding>,
     ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
-            let mut range = vec![];
-            let data = vm.get_block_data(globals, bh)?;
+            let subject = string_snapshot(recv);
+            let tmp = vm.temp_len();
+            vm.temp_push(subject);
+            let res = re.replace_all_block_inner(vm, globals, subject, recv, bh, self_enc);
+            vm.temp_clear(tmp);
+            res
+        })
+    }
 
-            vm.clear_capture_special_variables();
-            for cap in re.captures_iter(given) {
-                let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
-                let m = cap.get(0).unwrap();
+    fn replace_all_block_inner(
+        &self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+        subject: Value,
+        recv: Value,
+        bh: BlockHandler,
+        self_enc: Option<crate::value::Encoding>,
+    ) -> Result<(RStringInner, bool)> {
+        // `subject` is frozen and temp-rooted by the caller, so `given`
+        // and the matched views stay valid across `invoke_block`.
+        let given = subject.as_rstring_inner().check_utf8()?;
+        let recv_len = recv.as_rstring_inner().len();
+        let mut range = vec![];
+        let data = vm.get_block_data(globals, bh)?;
 
-                let matched_str = m.as_str();
-                let matched = Value::string_from_str(matched_str);
-                vm.save_capture_special_variables(&cap, given);
-                let result = vm.invoke_block(globals, &data, &[matched])?;
-                // CRuby raises Encoding::CompatibilityError if the
-                // block returned a String whose encoding can't merge
-                // with self's. Check before stringifying.
-                if let Some(enc) = self_enc {
-                    if let Some(repl_inner) = result.is_rstring_inner() {
-                        let dummy = crate::value::RStringInner::from_encoding(b"", enc);
-                        if dummy.compatible_encoding(&repl_inner).is_none() {
-                            return Err(MonorubyErr::incompatible_encoding(
-                                &globals.store,
-                                enc,
-                                repl_inner.encoding(),
-                            ));
-                        }
+        vm.clear_capture_special_variables();
+        for cap in self.captures_iter(given) {
+            let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
+            let m = cap.get(0).unwrap();
+
+            let matched = string_substring(subject, m.start(), m.end());
+            vm.save_capture_special_variables(&cap, given);
+            let result = vm.invoke_block(globals, &data, &[matched])?;
+            check_string_not_modified(recv, recv_len)?;
+            // CRuby raises Encoding::CompatibilityError if the
+            // block returned a String whose encoding can't merge
+            // with self's. Check before stringifying.
+            if let Some(enc) = self_enc {
+                if let Some(repl_inner) = result.is_rstring_inner() {
+                    let dummy = crate::value::RStringInner::from_encoding(b"", enc);
+                    if dummy.compatible_encoding(&repl_inner).is_none() {
+                        return Err(MonorubyErr::incompatible_encoding(
+                            &globals.store,
+                            enc,
+                            repl_inner.encoding(),
+                        ));
                     }
                 }
-                let replace = block_result_to_inner(vm, globals, result)?;
-
-                range.push((m.range(), replace));
             }
+            let replace = block_result_to_inner(vm, globals, result)?;
 
-            let is_empty = range.is_empty();
-            let res = RStringInner::splice_all(&globals.store, given, &range)?;
+            range.push((m.range(), replace));
+        }
 
-            Ok((res, !is_empty))
-        })
+        let is_empty = range.is_empty();
+        let res = RStringInner::splice_all(&globals.store, given, &range)?;
+
+        Ok((res, !is_empty))
     }
 
     /// Replaces the first match in `given` string using hash lookup.
@@ -962,35 +990,57 @@ impl RegexpInner {
         })
     }
 
-    /// Replaces all non-overlapping matches in `given` string using hash lookup.
+    /// Replaces all non-overlapping matches in `recv` using hash lookup.
+    /// Like `replace_all_block`: matches against a frozen snapshot (no
+    /// use-after-free if a hash `default_proc` mutates the receiver) and
+    /// raises "string modified" on a live length change after each
+    /// lookup, matching CRuby.
     pub(crate) fn replace_all_hash(
         vm: &mut Executor,
         globals: &mut Globals,
         re_val: Value,
-        given: &str,
+        recv: Value,
         hash_val: Value,
     ) -> Result<(RStringInner, bool)> {
         Self::with_coerced_regexp(vm, globals, re_val, |re, vm, globals| {
-            let mut range = vec![];
-
-            vm.clear_capture_special_variables();
-            for cap in re.captures_iter(given) {
-                let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
-                let m = cap.get(0).unwrap();
-
-                let matched_str = m.as_str();
-                let key = Value::string_from_str(matched_str);
-                vm.save_capture_special_variables(&cap, given);
-                let replacement = lookup_hash_replacement(vm, globals, hash_val, key)?;
-
-                range.push((m.range(), replacement));
-            }
-
-            let is_empty = range.is_empty();
-            let res = RStringInner::splice_all(&globals.store, given, &range)?;
-
-            Ok((res, !is_empty))
+            let subject = string_snapshot(recv);
+            let tmp = vm.temp_len();
+            vm.temp_push(subject);
+            let res = re.replace_all_hash_inner(vm, globals, subject, recv, hash_val);
+            vm.temp_clear(tmp);
+            res
         })
+    }
+
+    fn replace_all_hash_inner(
+        &self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+        subject: Value,
+        recv: Value,
+        hash_val: Value,
+    ) -> Result<(RStringInner, bool)> {
+        let given = subject.as_rstring_inner().check_utf8()?;
+        let recv_len = recv.as_rstring_inner().len();
+        let mut range = vec![];
+
+        vm.clear_capture_special_variables();
+        for cap in self.captures_iter(given) {
+            let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
+            let m = cap.get(0).unwrap();
+
+            let key = string_substring(subject, m.start(), m.end());
+            vm.save_capture_special_variables(&cap, given);
+            let replacement = lookup_hash_replacement(vm, globals, hash_val, key)?;
+            check_string_not_modified(recv, recv_len)?;
+
+            range.push((m.range(), replacement));
+        }
+
+        let is_empty = range.is_empty();
+        let res = RStringInner::splice_all(&globals.store, given, &range)?;
+
+        Ok((res, !is_empty))
     }
 
     pub(crate) fn match_one(

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -2176,6 +2176,20 @@ pub(crate) fn string_snapshot(mut receiver: Value) -> Value {
     }
 }
 
+/// CRuby's `str_mod_check`: raise `RuntimeError: "string modified"` when
+/// the receiver's byte length changed during a block iteration
+/// (`String#scan` / `#gsub` with a block or hash). Length is the only
+/// signal that matches CRuby here — monoruby reallocates the buffer on
+/// in-place same-length edits (copy-on-write detach), so a pointer
+/// comparison would over-trigger on mutations CRuby treats as in place.
+pub(crate) fn check_string_not_modified(recv: Value, expected_len: usize) -> Result<()> {
+    if recv.as_rstring_inner().len() != expected_len {
+        Err(MonorubyErr::runtimeerr("string modified"))
+    } else {
+        Ok(())
+    }
+}
+
 ///
 /// Make `parent`'s byte buffer shareable and return `(root, base)`:
 /// the (frozen, hidden) String owning the buffer and the address of


### PR DESCRIPTION
Fixes #726.

## Problem

`String#scan` and `#gsub` (block and hash forms) never checked whether the block mutated the receiver during iteration. CRuby raises `RuntimeError: "string modified"` when the receiver's byte length changes mid-iteration; monoruby silently completed.

```ruby
s = "a b c".dup
s.scan(/\w/) { s << "x" }          # CRuby: RuntimeError(string modified)   monoruby: (no error)
s.gsub(/\w/) { s << "x"; "Q" }     # CRuby: RuntimeError                    monoruby: (no error)
```

For `#gsub`/`#gsub!` this was also a latent **use-after-free**: `gsub_main` borrowed the live receiver's buffer (`self_val.expect_str()`) and `replace_all_block`/`replace_all_hash` held that `&str` across `invoke_block` / a hash `default_proc`. A block that grew the receiver reallocated the buffer, leaving the borrow (and the final `splice_all`) reading freed memory. (`#scan` already matched against a frozen snapshot since #724, so it was memory-safe but still missed the error.)

## Fix

- `gsub` block/hash now match and splice against a **frozen `string_snapshot`** of the receiver (temp-rooted across block calls), exactly like `scan` — no use-after-free regardless of what the block does.
- All three loops (scan block, gsub block, gsub hash) capture the live receiver's byte length up front and call `check_string_not_modified` after each block / `default_proc` invocation, raising "string modified" on a length change.

**Detection is length-only.** monoruby reallocates the buffer on in-place same-length edits (copy-on-write detach), so comparing the buffer *pointer* would over-trigger on mutations CRuby treats as in place. Verified against CRuby 4.0.5:

| mutation in block | CRuby | monoruby (after) |
|---|---|---|
| `s << "x"` (grow) | RuntimeError | RuntimeError ✓ |
| `s[0]="Z"`, `s.upcase!` (same len) | no error | no error ✓ |
| `s.replace("b"*100)` (same len, realloc) | no error | no error ✓ |
| `s << "x"; s.chop!` (grow then shrink back) | no error | no error ✓ |
| mutate a *different* string | no error | no error ✓ |
| gsub Hash `default_proc` that appends | RuntimeError | RuntimeError ✓ |

## Scope

`sub`/`sub!` are left as-is — CRuby raises for `sub!` but not `sub` (single-match; the non-bang/bang distinction differs), a separate minor case.

## Verification

- Differential scripts byte-identical with CRuby (raise and non-raise cases, including hash `default_proc`)
- The grow case now raises cleanly **under gc-stress** instead of reading freed memory
- Normal (no-mutation) `gsub`/`scan` output unchanged
- New `scan_gsub_string_modified` regression test; full `cargo test --lib` (1,878) green; no new warnings

https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp)_