### PR TITLE
Fix super from a redefined builtin to_s / arithmetic operator (#716)

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3252,7 +3252,25 @@ fn initialize_clone(
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/to_s.html]
 #[monoruby_builtin]
 fn to_s(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let s = lfp.self_val().to_s(&globals.store);
+    let recv = lfp.self_val();
+    // This is the default `Object#to_s`. It is normally shadowed by a
+    // more specific `to_s` (e.g. `TrueClass#to_s`, `Integer#to_s`); it
+    // is reached on a bare object or via `super` from a redefined
+    // `to_s`. CRuby's `Object#to_s` returns `"#<ClassName:0x...>"` for
+    // *every* receiver. For heap objects that is what `Value::to_s`
+    // already produces, but for immediates (true/false/nil/Integer/
+    // Symbol) it returns the value literal ("true", "3", …) — that
+    // literal is the general-purpose stringification used elsewhere, not
+    // the default object representation, so build the `#<...>` form here.
+    let s = if recv.try_rvalue().is_some() {
+        recv.to_s(&globals.store)
+    } else {
+        format!(
+            "#<{}:0x{:016x}>",
+            recv.get_real_class_name(&globals.store),
+            recv.id()
+        )
+    };
     Ok(Value::string(s))
 }
 
@@ -3842,6 +3860,57 @@ fn iv_remove(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn super_from_redefined_builtin_716() {
+        // #716: `super` from a method that redefines a builtin must walk
+        // to the real ancestor, not re-enter the replaced builtin.
+        //
+        // `to_s`: super reaches the default `Object#to_s`, which returns
+        // "#<ClassName:0x...>" for *every* receiver, including immediates
+        // (previously returned the value literal like "true"/"3").
+        //
+        // Arithmetic operators are not defined on `Numeric` (CRuby
+        // semantics), so `super` from a redefined `Integer#+` / `Float#*`
+        // finds no super method and raises `NoMethodError`.
+        //
+        // NOTE: `run_test_once` (single interpreter run) is used
+        // deliberately. Re-running these `super`-from-a-redefined-
+        // immediate-`to_s` snippets enough times to JIT-compile them
+        // trips a *separate, pre-existing* JIT codegen bug (the compiled
+        // `super` corrupts a surrounding register); that is tracked
+        // separately and is independent of the method-resolution fix
+        // verified here.
+        run_test_once(
+            r##"class TrueClass; def to_s; "T:" + super; end; end
+                true.to_s.sub(/0x[0-9a-f]+/, "0xADDR")"##,
+        );
+        run_test_once(
+            r##"class NilClass; def to_s; "N:" + super; end; end
+                nil.to_s.sub(/0x[0-9a-f]+/, "0xADDR")"##,
+        );
+        run_test_once(
+            r##"class Integer; def to_s; "I:" + super; end; end
+                5.to_s.sub(/0x[0-9a-f]+/, "0xADDR")"##,
+        );
+        run_test_once(
+            r##"class Symbol; def to_s; "S:" + super; end; end
+                :foo.to_s.sub(/0x[0-9a-f]+/, "0xADDR")"##,
+        );
+        // a bare object's default to_s is unchanged
+        run_test_once(r##"Object.new.to_s.sub(/0x[0-9a-f]+/, "0xADDR")"##);
+        // immediates' own (non-super) to_s is unaffected
+        run_test(r##"[true.to_s, 5.to_s, nil.to_s, :foo.to_s]"##);
+        // arithmetic super → NoMethodError (Numeric has no operators)
+        run_test_once(
+            r##"class Integer; def +(o); super(o) * 10; end; end
+                begin; 1 + 2; rescue NoMethodError; :nme; end"##,
+        );
+        run_test_once(
+            r##"class Float; def *(o); super(o); end; end
+                begin; 2.0 * 3; rescue NoMethodError; :nme; end"##,
+        );
+    }
 
     #[test]
     fn not_match_memoized_dispatch() {

--- a/monoruby/src/builtins/numeric.rs
+++ b/monoruby/src/builtins/numeric.rs
@@ -16,12 +16,18 @@ pub(super) fn init(globals: &mut Globals) {
     float::init(globals, numeric);
     complex::init(globals, numeric);
     rational::init(globals, numeric);
-    globals.define_builtin_func(NUMERIC_CLASS, "+", add, 1);
-    globals.define_builtin_func(NUMERIC_CLASS, "-", sub, 1);
-    globals.define_builtin_func(NUMERIC_CLASS, "*", mul, 1);
-    globals.define_builtin_func(NUMERIC_CLASS, "/", div, 1);
-    globals.define_builtin_funcs(NUMERIC_CLASS, "%", &["module"], rem, 1);
-    globals.define_builtin_func(NUMERIC_CLASS, "**", pow, 1);
+    // The binary arithmetic operators are NOT defined on `Numeric` in
+    // CRuby — each concrete subclass owns its own. `Integer`/`Float`/
+    // `Rational` already do (`define_basic_op` in their `init`), so `super`
+    // from a redefined `Integer#+` must reach `Numeric`, find nothing, and
+    // raise `NoMethodError` (issue #716). `Complex` is the only built-in
+    // that lacked its own, so re-root the generic coerce-based `add`/`sub`/
+    // `mul` directly on it (CRuby's `Complex` has `+ - * / **`; it has no
+    // `%`, which now correctly becomes a `NoMethodError` here too). `/` and
+    // `**` are already defined on `Complex` in `complex::init`.
+    globals.define_builtin_func(COMPLEX_CLASS, "+", add, 1);
+    globals.define_builtin_func(COMPLEX_CLASS, "-", sub, 1);
+    globals.define_builtin_func(COMPLEX_CLASS, "*", mul, 1);
     globals.define_builtin_func(INTEGER_CLASS, "-@", neg, 0);
     globals.define_builtin_func(FLOAT_CLASS, "-@", neg, 0);
     // NOTE: `Complex#-@` is defined in `complex::init` (`neg_op`), which sends

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -2309,10 +2309,12 @@ r##"
 
     #[test]
     fn bop_redefinition() {
-        // Verify that redefining Integer#+ does not crash the JIT.
-        // Uses run_test_no_result_check because BOP redefinition
-        // affects global state and the result may differ from CRuby.
-        run_test_no_result_check(
+        // Redefining Integer#+ must not crash, and once the redefinition
+        // is removed `1 + 2` has no `+` to fall back on — Numeric defines
+        // no arithmetic operators (issue #716) — so it raises
+        // NoMethodError, matching CRuby (`[3, -1, :nme]`). `run_test_once`
+        // (single run) because the script permanently removes Integer#+.
+        run_test_once(
             r##"
             res = []
             res << (1 + 2)
@@ -2325,7 +2327,11 @@ r##"
             class Integer
               remove_method :+
             end
-            res << (1 + 2)
+            begin
+              res << (1 + 2)
+            rescue NoMethodError
+              res << :nme
+            end
             res
             "##,
         );


### PR DESCRIPTION
Fixes #716.

## Root cause

`super` from a method that redefines a builtin resolved to a divergent ancestor. Instrumenting `Store::check_super` showed it is **actually correct** — it returns the real ancestor method (`Kernel#to_s` for the `to_s` case, `Numeric#+` for the `+` case). The issue's hypothesis (check_super using the owner) is disproven. The divergence comes from two method **layout/behaviour** mismatches with CRuby:

### 1. `Object#to_s` returns the value literal for immediates

`super` from a redefined `TrueClass#to_s`/`Integer#to_s`/… reaches the default `Object#to_s` (= `Kernel#to_s`), which delegated to `Value::to_s`. For heap objects that yields `"#<Class:0x..>"`, but for immediates (true/false/nil/Integer/Symbol) it returned the value literal (`"true"`, `"3"`, …) — that literal is the *general-purpose* stringification, not the default object representation. CRuby's `Object#to_s` returns `"#<ClassName:0x..>"` for **every** receiver.

```ruby
class TrueClass; def to_s; "T:" + super; end; end
true.to_s   # was "T:true"   now "T:#<TrueClass:0x...>"  (CRuby)
```

`Kernel#to_s` now builds the `#<…>` form for immediates too; heap-object behaviour is unchanged.

### 2. Arithmetic operators were defined on `Numeric`

`+ - * / % **` were registered on `Numeric`. CRuby leaves `Numeric` without them (each concrete class owns its own), so `super` from a redefined `Integer#+` must reach `Numeric`, find nothing, and raise `NoMethodError` — monoruby found `Numeric#+` and performed the addition.

```ruby
class Integer; def +(o); super(o) * 10; end; end
1 + 2   # was 30   now NoMethodError  (CRuby)
```

The operators are removed from `Numeric`. `Integer`/`Float`/`Rational` already define their own; `Complex` (the only built-in that inherited them) gets `+ - *` re-rooted directly onto it (it already owns `/` and `**`). Re-rooting reuses the **same** `add`/`sub`/`mul` functions, so all numeric/Complex/coerce arithmetic results are unchanged. `Complex#%` correctly becomes `NoMethodError`, matching CRuby (Complex `undef`s it there).

This explains the issue's "method-dependent" observation: `String#size` already raised correctly (no `size` in its ancestors); only methods with a divergent ancestor implementation (`Numeric#+`, immediate `Kernel#to_s`) diverged.

The `bop_redefinition` test relied on the old `Numeric#+` fallback after `remove_method :+`; updated to expect CRuby's `NoMethodError` (`[3, -1, :nme]`).

## Verification

- Full `cargo test --lib` (1,880) green; `method_call`/`redefine` integration suites green
- Comprehensive numeric/Complex/coerce arithmetic differential is byte-identical with CRuby 4.0.5 (verified against a master build that re-rooting changes nothing)
- New `super_from_redefined_builtin_716` regression test (to_s for each immediate, bare-object default, arithmetic super → NoMethodError)

## Out of scope (separate, pre-existing)

While testing I found a **pre-existing JIT codegen bug**: `super` from a redefined immediate `to_s`, once JIT-compiled, corrupts a surrounding register (manifests as a `TypeError`/class-table out-of-bounds). It reproduces on master with my fix reverted, so it is independent of this method-resolution change. Filed separately. The regression test uses single interpreter runs to stay clear of it.

https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp)_