### PR TITLE
JIT: spill the accumulator before a class/module definition (#730)

### DIFF
--- a/monoruby/src/codegen/jitgen/definition.rs
+++ b/monoruby/src/codegen/jitgen/definition.rs
@@ -11,6 +11,12 @@ impl AbstractState {
         func_id: FuncId,
         is_module: bool,
     ) {
+        // A class/module body is a full call (`enter_classdef`) that
+        // clobbers the accumulator (r15). When `class ... end` appears in
+        // expression position (e.g. `a << (class C; ...; end)`) the
+        // accumulator holds a live slot — spill it first, exactly like a
+        // method call does, or the later use reads a clobbered register.
+        self.writeback_acc(ir);
         if let Some(base) = base {
             self.write_back_slots(ir, &[base]);
         }
@@ -41,6 +47,9 @@ impl AbstractState {
         base: SlotId,
         func_id: FuncId,
     ) {
+        // See `class_def`: `class << obj` runs a body that clobbers the
+        // accumulator, so spill it before the call.
+        self.writeback_acc(ir);
         self.write_back_slots(ir, &[base]);
         if let Some(dst) = dst {
             self.def_S(dst);

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -86,3 +86,36 @@ fn redefine_test4() {
         "##,
     );
 }
+
+// Regression for #730: a `class`/`module`/`class << obj` definition used
+// in *expression* position (its value feeds a surrounding operation)
+// must not clobber the accumulator that holds a live operand. Here `a`
+// (a freshly built Array) is the receiver of `<<` while the argument is a
+// class definition; the JIT used to leave `a` in the accumulator across
+// the class-body call, so the `<<` read a clobbered register and tripped
+// a non-Array assertion. `run_test` exercises the JIT (≥ warmup runs).
+#[test]
+fn class_def_in_expression_position_730() {
+    run_test(
+        r##"
+        out = nil
+        50.times do
+          a = []
+          a << (class C730A; 42; end)
+          a << (class C730B; def m; 7; end; end; "z")
+          obj = Object.new
+          a << (class << obj; 99; end)
+          out = a
+        end
+        out
+        "##,
+    );
+    // module form, and the value flowing into arithmetic
+    run_test(
+        r##"
+        r = nil
+        50.times { r = 1 + (module M730; 41; end) }
+        r
+        "##,
+    );
+}


### PR DESCRIPTION
Fixes #730.

## Root cause

A `class` / `module` / `class << obj` body compiles to a runtime call (`enter_classdef`) that clobbers the accumulator register (r15). The method-call and variable-store paths spill the accumulator first via `writeback_acc`, but `AbstractState::class_def` / `singleton_class_def` did not.

When such a definition appears in **expression position** — its value feeds a surrounding operation — the accumulator holds a live operand. In the repro `a << (class C; ...; end)`, the accumulator holds `a` (a freshly built `Array`, placed there by `def_reg2acc_class` after `NewArray`). The class body call then clobbers r15, but the abstract state still believed `a` lived there, so the surrounding `<<` loaded the clobbered register and dispatched `Array#<<` on a non-Array receiver → assertion failure in `as_array_inner_mut` (or, under the test harness with lowered JIT thresholds, an out-of-bounds class-table index in `find_method`).

## Fix

Call `writeback_acc(ir)` at the start of `class_def` and `singleton_class_def`, exactly as the method-call path does — spill the accumulator to its stack slot and clear the link before the class-body call.

## Note on the issue's framing

#730 was reported as "`super` from a redefined builtin crashes under the JIT", but `super` is incidental. Minimising it showed the trigger is *any* class/module definition used as a sub-expression inside a JIT-compiled loop:

```ruby
50.times { a = []; a << (class C; 42; end) }   # was: panic
```

`super` / `to_s` / redefinition are not required. (`a` must be assigned inside the loop so it occupies the accumulator; `a` hoisted out of the loop, or `1 + (class ...)` with a literal receiver, did not trip it.)

## Verification

- All minimised repros and the original `super`-from-redefined-`to_s` cases run cleanly with correct values (matching CRuby; the only residual `to_s` value difference is the separate #716, fixed in #729)
- New `class_def_in_expression_position_730` regression test, run under the JIT (covers class/module/`class << obj` in `<<` and arithmetic operand position)
- Full `cargo test --lib` (1,879) green; no new warnings

https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkWSe9mz3eh3q31M77vePp)_