### PR TITLE
Fix core/string, regexp, matchdata spec failures and implement core/gc

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1098,17 +1098,108 @@ module Kernel
 end
 
 class GC
-  def self.auto_compact=(x)
+  # `GC.count` and `GC.start` are implemented in Rust (they read the
+  # allocator's collection counter / force a full collection).
+
+  # --- boolean mode flags -------------------------------------------------
+  # monoruby has no stress mode, no auto-compaction and no time
+  # measurement, but the accessors round-trip a stored value so callers
+  # (and specs) can set and read them back.
+  @stress = false
+  @measure_total_time = false
+  @auto_compact = false
+
+  def self.stress
+    @stress
   end
 
-  def self.count
+  def self.stress=(flag)
+    @stress = flag
+  end
+
+  def self.measure_total_time
+    @measure_total_time
+  end
+
+  def self.measure_total_time=(flag)
+    @measure_total_time = flag
+  end
+
+  def self.auto_compact
+    @auto_compact
+  end
+
+  def self.auto_compact=(flag)
+    @auto_compact = flag
+  end
+
+  # Total time spent in GC, in nanoseconds. monoruby does not measure
+  # this, so report 0 (an Integer, never decreasing).
+  def self.total_time
     0
   end
 
-  def self.start(**opts)
+  # --- GC.config ----------------------------------------------------------
+  def self.config(*args)
+    @config ||= { implementation: "default", rgengc_allow_full_mark: true }
+    return @config.dup if args.empty?
+    arg = args[0]
+    return @config.dup if arg.nil?
+    unless arg.is_a?(Hash)
+      raise ArgumentError, "GC.config requires a Hash argument"
+    end
+    # `:implementation` is read-only.
+    if arg.key?(:implementation)
+      raise ArgumentError, 'Attempting to set read-only key "Implementation"'
+    end
+    # Update known knobs (coercing arbitrary truthy/falsey values to a
+    # boolean, as MRI does); unknown keys are ignored.
+    arg.each do |k, v|
+      next unless @config.key?(k)
+      @config[k] = v ? true : false
+    end
+    @config.dup
+  end
+
+  # Instance form (available via `obj.extend(GC)`); always returns nil.
+  def garbage_collect(full_mark: true, immediate_mark: true, immediate_sweep: true)
+    GC.start
+    nil
   end
 
   module Profiler
+    @enabled = false
+
+    def self.enabled?
+      @enabled
+    end
+
+    def self.enable
+      @enabled = true
+      nil
+    end
+
+    def self.disable
+      @enabled = false
+      nil
+    end
+
+    def self.clear
+      nil
+    end
+
+    def self.result
+      ""
+    end
+
+    def self.report(out = $stdout)
+      out.print(result)
+      nil
+    end
+
+    def self.total_time
+      0.0
+    end
   end
 end
 

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -70,6 +70,35 @@ pub(crate) fn set_gc_enabled(enabled: bool) {
     GC_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
+/// Set by `GC.start` so the next safepoint collection is a Major (full)
+/// one — running a collection inline from a builtin is unsafe, so
+/// `GC.start` asks for one at the next poll via [`request_gc`].
+static GC_FORCE_MAJOR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Request a garbage collection at the next VM safepoint (`GC.start`).
+///
+/// Only nudges the JIT/VM alloc flag into its trigger band (and, when
+/// `force_major`, records that the pending collection must be Major); the
+/// actual collection runs from the safepoint poll where live registers
+/// are spilled, so this is safe to call from inside a builtin.
+pub(crate) fn request_gc(force_major: bool) {
+    if force_major {
+        GC_FORCE_MAJOR.store(true, Ordering::Relaxed);
+    }
+    let addr = MALLOC_GC_FLAG_ADDR.load(Ordering::Relaxed);
+    if addr == 0 {
+        return;
+    }
+    let flag = addr as *mut u32;
+    // SAFETY: `flag` is the registered JIT alloc-flag location, valid for
+    // the VM thread's lifetime; monoruby's VM is single-threaded.
+    unsafe {
+        if std::ptr::read_volatile(flag) < 8 {
+            std::ptr::write_volatile(flag, 8);
+        }
+    }
+}
+
 /// Request a GC at the next VM safepoint when live malloc has crossed the
 /// threshold. Cheap and allocation-free (just a flag store), so it is safe
 /// to call from inside the global allocator.
@@ -555,7 +584,7 @@ impl<T: GCBox> Allocator<T> {
     ///
     /// Returns a number of total allocated objects.
     ///
-    #[cfg(feature = "gc-log")]
+    #[allow(unused)]
     pub fn total_allocated(&self) -> usize {
         self.total_allocated_objects
     }
@@ -563,7 +592,7 @@ impl<T: GCBox> Allocator<T> {
     ///
     /// Returns a number of total gc execution count.
     ///
-    #[cfg(feature = "gc-log")]
+    #[allow(unused)]
     pub fn total_gc_counter(&self) -> usize {
         self.total_gc_counter
     }
@@ -571,7 +600,7 @@ impl<T: GCBox> Allocator<T> {
     ///
     /// Returns the number of minor (young-generation) GC executions.
     ///
-    #[cfg(feature = "gc-log")]
+    #[allow(unused)]
     pub fn minor_gc_count(&self) -> usize {
         self.minor_gc_count
     }
@@ -579,7 +608,7 @@ impl<T: GCBox> Allocator<T> {
     ///
     /// Returns the number of major (full-heap) GC executions.
     ///
-    #[cfg(feature = "gc-log")]
+    #[allow(unused)]
     pub fn major_gc_count(&self) -> usize {
         self.major_gc_count
     }
@@ -692,7 +721,12 @@ impl<T: GCBox> Allocator<T> {
         if !self.gc_enabled {
             return;
         }
-        let kind = self.decide_gc_kind();
+        // A pending `GC.start` request forces a Major collection.
+        let kind = if GC_FORCE_MAJOR.swap(false, Ordering::Relaxed) {
+            GcKind::Major
+        } else {
+            self.decide_gc_kind()
+        };
         self.total_gc_counter += 1;
         match kind {
             GcKind::Minor => {

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -9,6 +9,58 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_module_func_with(klass, "stat", stat, 0, 1, false);
     globals.define_builtin_module_func(klass, "enable", enable, 0);
     globals.define_builtin_module_func(klass, "disable", disable, 0);
+    globals.define_builtin_module_func(klass, "count", count, 0);
+    globals.define_builtin_module_func_rest(klass, "start", start);
+}
+
+/// The `GC.stat` keys, in CRuby order. Only a handful map to real
+/// allocator counters (see [`stat_value`]); the rest are reported as 0
+/// because monoruby's mark-and-sweep collector has no equivalent.
+const STAT_KEYS: &[&str] = &[
+    "count",
+    "heap_allocated_pages",
+    "heap_sorted_length",
+    "heap_allocatable_pages",
+    "heap_available_slots",
+    "heap_live_slots",
+    "heap_free_slots",
+    "heap_final_slots",
+    "heap_marked_slots",
+    "heap_eden_pages",
+    "heap_tomb_pages",
+    "total_allocated_pages",
+    "total_freed_pages",
+    "total_allocated_objects",
+    "total_freed_objects",
+    "malloc_increase_bytes",
+    "malloc_increase_bytes_limit",
+    "minor_gc_count",
+    "major_gc_count",
+    "remembered_wb_unprotected_objects",
+    "remembered_wb_unprotected_objects_limit",
+    "old_objects",
+    "old_objects_limit",
+    "oldmalloc_increase_bytes",
+    "oldmalloc_increase_bytes_limit",
+];
+
+/// Value of a `GC.stat` key. Returns `None` for keys we don't recognise
+/// (so `GC.stat(:bogus)` can raise), real allocator counters for the
+/// keys we track, and 0 for the remaining known-but-unsupported keys.
+fn stat_value(name: &str) -> Option<i64> {
+    crate::alloc::ALLOC.with(|alloc| {
+        let alloc = alloc.borrow();
+        Some(match name {
+            "count" => alloc.total_gc_counter() as i64,
+            "minor_gc_count" => alloc.minor_gc_count() as i64,
+            "major_gc_count" => alloc.major_gc_count() as i64,
+            "total_allocated_objects" => alloc.total_allocated() as i64,
+            "heap_live_slots" | "heap_marked_slots" => alloc.live_count() as i64,
+            "heap_free_slots" => alloc.free_count() as i64,
+            _ if STAT_KEYS.contains(&name) => 0,
+            _ => return None,
+        })
+    })
 }
 
 ///
@@ -16,58 +68,79 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 /// - stat -> Hash
 /// - stat(key) -> Integer
+/// - stat(hash) -> Hash
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/GC/s/stat.html]
 #[monoruby_builtin]
 fn stat(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let keys: &[&str] = &[
-        "count",
-        "heap_allocated_pages",
-        "heap_sorted_length",
-        "heap_allocatable_pages",
-        "heap_available_slots",
-        "heap_live_slots",
-        "heap_free_slots",
-        "heap_final_slots",
-        "heap_marked_slots",
-        "heap_eden_pages",
-        "heap_tomb_pages",
-        "total_allocated_pages",
-        "total_freed_pages",
-        "total_allocated_objects",
-        "total_freed_objects",
-        "malloc_increase_bytes",
-        "malloc_increase_bytes_limit",
-        "minor_gc_count",
-        "major_gc_count",
-        "remembered_wb_unprotected_objects",
-        "remembered_wb_unprotected_objects_limit",
-        "old_objects",
-        "old_objects_limit",
-        "oldmalloc_increase_bytes",
-        "oldmalloc_increase_bytes_limit",
-    ];
-
-    if let Some(key) = lfp.try_arg(0) {
-        let key_name = key.expect_symbol_or_string(globals)?;
-        let name = key_name.to_string();
-        if keys.contains(&name.as_str()) {
-            Ok(Value::integer(0))
-        } else {
-            Err(MonorubyErr::argumenterr(format!(
-                "unknown key: {}",
-                name
-            )))
+    match lfp.try_arg(0) {
+        // `GC.stat(nil)` behaves like the no-argument form.
+        Some(arg) if arg.is_nil() => stat_full_hash(vm, globals),
+        // `GC.stat(hash)` fills the given hash (preserving keys we don't
+        // set) and returns the *same* hash object.
+        Some(arg) if arg.try_hash_ty().is_some() => {
+            let mut hash = arg.try_hash_ty().unwrap();
+            for key in STAT_KEYS {
+                let v = Value::integer(stat_value(key).unwrap_or(0));
+                hash.insert(Value::symbol_from_str(key), v, vm, globals)?;
+            }
+            Ok(arg)
         }
-    } else {
-        let mut inner = HashmapInner::default();
-        for key_name in keys {
-            let k = Value::symbol_from_str(key_name);
-            let v = Value::integer(0);
-            inner.insert(k, v, vm, globals)?;
+        // `GC.stat(:key)` / `GC.stat("key")` returns a single Integer.
+        Some(arg) if arg.try_symbol().is_some() || arg.is_str().is_some() => {
+            let key_name = arg.expect_symbol_or_string(globals)?;
+            let name = key_name.to_string();
+            match stat_value(&name) {
+                Some(v) => Ok(Value::integer(v)),
+                None => Err(MonorubyErr::argumenterr(format!("unknown key: {}", name))),
+            }
         }
-        Ok(Value::hash_from_inner(inner))
+        // Anything else (Integer, Array, …) is a TypeError in CRuby.
+        Some(_) => Err(MonorubyErr::typeerr("non-hash or symbol given")),
+        None => stat_full_hash(vm, globals),
     }
+}
+
+/// Build the full `GC.stat` Hash (all keys → Integer values).
+fn stat_full_hash(vm: &mut Executor, globals: &mut Globals) -> Result<Value> {
+    let mut inner = HashmapInner::default();
+    for key in STAT_KEYS {
+        let v = Value::integer(stat_value(key).unwrap_or(0));
+        inner.insert(Value::symbol_from_str(key), v, vm, globals)?;
+    }
+    Ok(Value::hash_from_inner(inner))
+}
+
+///
+/// ### GC.count
+///
+/// - count -> Integer
+///
+/// The number of times GC has run so far.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/count.html]
+#[monoruby_builtin]
+fn count(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let n = crate::alloc::ALLOC.with(|alloc| alloc.borrow().total_gc_counter());
+    Ok(Value::integer(n as i64))
+}
+
+///
+/// ### GC.start
+///
+/// - start(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
+///
+/// Force a garbage collection. The keyword arguments are accepted for
+/// compatibility but ignored — `GC.start` always runs a full collection.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/start.html]
+#[monoruby_builtin]
+fn start(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // Running a collection inline here is unsafe (the JIT caller's live
+    // registers aren't spilled for the GC root scan), so request a full
+    // collection at the next VM safepoint, where registers are saved.
+    crate::alloc::request_gc(true);
+    Ok(Value::nil())
 }
 
 ///

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -198,4 +198,56 @@ mod tests {
     fn gc_start() {
         run_test("GC.start");
     }
+
+    #[test]
+    fn gc_stat_variants() {
+        run_test("GC.stat(:count).is_a?(Integer)");
+        run_test("GC.stat(nil).is_a?(Hash)");
+        run_test("GC.stat.values.all? { |v| v.is_a?(Integer) }");
+        run_test(
+            "h = { count: \"x\", __other__: \"y\" }; r = GC.stat(h); \
+             [r.equal?(h), h[:count].is_a?(Integer), h[:__other__]]",
+        );
+        run_test("(GC.stat(7) rescue $!.class)");
+        run_test("(GC.stat(:bogus_key) rescue $!.class)");
+    }
+
+    #[test]
+    fn gc_mode_flags() {
+        // Explicit set/read round-trips (default-independent: CRuby's
+        // default for these knobs is build/platform-specific).
+        run_test("GC.stress = true; r = GC.stress; GC.stress = false; [r, GC.stress]");
+        run_test(
+            "GC.measure_total_time = true; a = GC.measure_total_time; \
+             GC.measure_total_time = false; b = GC.measure_total_time; [a, b]",
+        );
+        run_test("GC.total_time.is_a?(Integer)");
+        // `auto_compact=` may raise NotImplementedError on some platforms.
+        run_test("(GC.auto_compact = false rescue nil); [true, false].include?(GC.auto_compact)");
+    }
+
+    #[test]
+    fn gc_config() {
+        run_test("GC.config.is_a?(Hash)");
+        run_test("GC.config[:implementation]");
+        run_test("GC.config({}) == GC.config");
+        run_test("GC.config(nil) == GC.config");
+        run_test("(GC.config(implementation: \"x\") rescue $!.class)");
+    }
+
+    #[test]
+    fn gc_garbage_collect() {
+        run_test("o = Object.new; o.extend(GC); o.garbage_collect");
+    }
+
+    #[test]
+    fn gc_profiler() {
+        run_test(
+            "GC::Profiler.enable; r = GC::Profiler.enabled?; \
+             GC::Profiler.disable; [r, GC::Profiler.enabled?]",
+        );
+        run_test("GC::Profiler.result.is_a?(String)");
+        run_test("GC::Profiler.total_time.is_a?(Float)");
+        run_test("GC::Profiler.clear");
+    }
 }

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -297,7 +297,12 @@ fn regexp_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resul
 /// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/string.html]
 #[monoruby_builtin]
 fn string_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(Value::string_from_str(lfp.self_val().as_match_data().string()))
+    // CRuby returns a single frozen copy of the subject string, the same
+    // object on every call. Our MatchData already holds an immutable
+    // snapshot of the haystack, so freeze it in place and return it.
+    let mut s = lfp.self_val().as_match_data().string_value();
+    s.set_frozen();
+    Ok(s)
 }
 
 ///

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -1148,4 +1148,19 @@ mod tests {
         run_test_error(r##"/(foo)/.match("foo").byteoffset(-1)"##);
         run_test_error(r##"/(foo)/.match("foo").offset(-1)"##);
     }
+
+    #[test]
+    fn match_data_string_frozen() {
+        // MatchData#string is a single frozen object, the same on every call.
+        run_test(r##"md = /(.)(\d+)/.match("THX1138"); [md.string, md.string.frozen?, md.string.equal?(md.string)]"##);
+    }
+
+    #[test]
+    fn backref_shared_with_lambda() {
+        // A match performed before a lambda is visible as `$~` inside it
+        // (lambdas share their defining method frame's special variables).
+        run_test(r##"/(?<t>\w+)/ =~ "TEST"; l = -> { Regexp.last_match(:t) }; l.call"##);
+        run_test(r##"def m; /(\w)(\w)/ =~ "xy"; -> { $~[0] }.call; end; m"##);
+        run_test(r##"/(\w+)/ =~ "abc"; [1].each { }; $1"##);
+    }
 }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -857,13 +857,26 @@ fn rem(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 fn match_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let other = lfp.arg(0);
-    // Fast path: rhs is already a Regexp or String — go through the
-    // standard regex match.
-    if other.is_regex().is_some() || other.is_str().is_some() {
+    // CRuby `String#=~` raises `TypeError` when the rhs is a String —
+    // matching a string against a string is meaningless (and would
+    // otherwise recurse via the `=~` dispatch below).
+    if other.is_str().is_some() {
+        return Err(MonorubyErr::typeerr("type mismatch: String given"));
+    }
+    // Fast path: rhs is a Regexp — run the match and return the
+    // **character** index of the match start (CRuby returns a char
+    // offset, not a byte offset, so multibyte subjects match CRuby).
+    if other.is_regex().is_some() {
         let given = self_val.expect_str(globals)?;
         let regex = &other.coerce_to_regexp_or_string(vm, globals)?;
         let res = match regex.find_one(vm, given)? {
-            Some(r) => Value::integer(r.start as i64),
+            Some(r) => {
+                let char_idx = given
+                    .get(..r.start)
+                    .map(|p| p.chars().count())
+                    .unwrap_or(r.start);
+                Value::integer(char_idx as i64)
+            }
             None => Value::nil(),
         };
         return Ok(res);
@@ -2445,7 +2458,16 @@ fn chomp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         rs_owned = arg0.coerce_to_rstring(vm, globals)?;
         rs_owned.as_bytes()
     } else {
-        b"\n"
+        // No argument: the separator defaults to `$/` (itself "\n"
+        // unless reassigned). `$/ = nil` means "never chomp".
+        match globals.get_gvar(IdentId::get_id("$/")) {
+            Some(v) if v.is_nil() => return Ok(lfp.self_val().dup()),
+            Some(v) => {
+                rs_owned = v.coerce_to_rstring(vm, globals)?;
+                rs_owned.as_bytes()
+            }
+            None => b"\n",
+        }
     };
 
     let self_ = lfp.self_val();
@@ -2475,7 +2497,16 @@ fn chomp_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         rs_owned = arg0.coerce_to_rstring(vm, globals)?;
         rs_owned.as_bytes()
     } else {
-        b"\n"
+        // No argument: the separator defaults to `$/` (itself "\n"
+        // unless reassigned). `$/ = nil` means "never chomp".
+        match globals.get_gvar(IdentId::get_id("$/")) {
+            Some(v) if v.is_nil() => return Ok(Value::nil()),
+            Some(v) => {
+                rs_owned = v.coerce_to_rstring(vm, globals)?;
+                rs_owned.as_bytes()
+            }
+            None => b"\n",
+        }
     };
 
     let self_ = lfp.self_val();
@@ -4514,7 +4545,25 @@ fn line_ranges(
         Str(String),
     }
     let sep = match rs_arg {
-        None => Sep::Default,
+        // No explicit separator: the default is `$/`. Its "\n" default
+        // (and the unset state) keeps the default-newline behaviour
+        // (recognising "\r\n"/"\r" line ends under `chomp:`); `nil`
+        // slurps the whole string; any other value acts like an
+        // explicit separator argument.
+        None => match globals.get_gvar(IdentId::get_id("$/")) {
+            None => Sep::Default,
+            Some(v) if v.is_nil() => Sep::Whole,
+            Some(v) => {
+                let sep = v.coerce_to_str(vm, globals)?.to_string();
+                if sep == "\n" {
+                    Sep::Default
+                } else if sep.is_empty() {
+                    Sep::Paragraph
+                } else {
+                    Sep::Str(sep)
+                }
+            }
+        },
         Some(arg) if arg.is_nil() => Sep::Whole,
         Some(arg) => {
             // CRuby rejects `false`/`true`/Symbol explicitly here, even
@@ -5000,6 +5049,11 @@ fn hex(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         .strip_prefix("0x")
         .or_else(|| s.strip_prefix("0X"))
         .unwrap_or(s);
+    // A (second) sign in the digit portion is invalid: CRuby stops at
+    // the first non-digit, so e.g. `"0x-1".hex` and `"+-5".hex` are 0.
+    if s.starts_with(['+', '-']) {
+        return Ok(Value::integer(0));
+    }
     Ok(parse_int_value(s, 16, negative))
 }
 
@@ -5033,6 +5087,11 @@ fn oct(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     } else {
         (s, 8)
     };
+    // A (second) sign in the digit portion is invalid: CRuby stops at
+    // the first non-digit, so e.g. `"+-5".oct` is 0.
+    if s.starts_with(['+', '-']) {
+        return Ok(Value::integer(0));
+    }
     Ok(parse_int_value(s, radix, negative))
 }
 

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -8966,6 +8966,13 @@ mod tests {
             r#""0".oct"#,
             r#""".oct"#,
             r#""xyz".oct"#,
+            // A (second) sign in the digit portion is invalid → 0.
+            r#""0x-1".hex"#,
+            r#""0x-10".hex"#,
+            r#""+-5".hex"#,
+            r#""-+5".hex"#,
+            r#""+-5".oct"#,
+            r#""0x-7".oct"#,
             r"'4285'.to_f",
             r"'-4285'.to_f",
             r"'428.55'.to_f",
@@ -10388,6 +10395,47 @@ mod tests {
         ]);
         run_test_error(r##""hello".lines(:sym)"##);
         run_test_error(r##""hello".lines(false)"##);
+    }
+
+    #[test]
+    fn string_chomp_record_separator() {
+        // No-argument chomp/chomp! use `$/` (default "\n") as the separator.
+        run_test(r#""abc\n".chomp"#);
+        run_test(r#"$/ = "cdef"; r = "abcdef".chomp; $/ = "\n"; r"#);
+        run_test(r#"$/ = "cde"; s = +"abcde"; r = s.chomp!; $/ = "\n"; [r, s]"#);
+        run_test(r#"$/ = "xyz"; r = "abcde".chomp!; $/ = "\n"; r"#);
+    }
+
+    #[test]
+    fn string_match_operator() {
+        // `=~` returns the character (not byte) index of the match start.
+        run_test(r#"("こにちわ" =~ /に/)"#);
+        run_test(r#"("hello" =~ /l/)"#);
+        run_test(r#"("hello" =~ /z/)"#);
+        // A String rhs raises TypeError.
+        run_test(r#"("a" =~ "b" rescue $!.class)"#);
+    }
+
+    #[test]
+    fn string_plus_returns_string() {
+        run_test(r#"class StrPlusSub < String; end; (StrPlusSub.new("a") + "b").instance_of?(String)"#);
+        run_test(r#"("foo" + "bar")"#);
+    }
+
+    #[test]
+    fn string_index_regexp_clears_backref() {
+        // index with a Regexp updates `$~`: a match sets it, a miss clears it.
+        run_test(r#""a".index(/a/); $~.nil?"#);
+        run_test(r#"s = "blablabla"; s.index(/bla/, s.length + 1); $~.nil?"#);
+        run_test(r#""hello".index(/z/); $~.nil?"#);
+    }
+
+    #[test]
+    fn string_lines_each_line_record_separator() {
+        // No-argument lines/each_line default to `$/`.
+        run_test(r#"$/ = "l"; r = "hello".lines; $/ = "\n"; r"#);
+        run_test(r#"$/ = "l"; a = []; "hello".each_line { |x| a << x }; $/ = "\n"; a"#);
+        run_test(r#"$/ = nil; r = "one\ntwo".lines; $/ = "\n"; r"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2953,11 +2953,6 @@ fn scan_block_loop(
                 vm.invoke_block(globals, data, &val.as_array())?;
             }
         }
-        // CRuby leaves `$~` set to *scan's* last match once the block
-        // returns, even if the block ran its own match. Re-establish it
-        // after each yield so the final state reflects scan, not the
-        // block's last match.
-        vm.save_capture_special_variables(&cap, given);
         check_string_not_modified(recv, recv_len)?;
     }
     Ok(())

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -330,7 +330,10 @@ fn string_try_convert(
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=2b.html]
 #[monoruby_builtin]
 fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut self_ = lfp.self_val().dup();
+    // CRuby `String#+` always returns a plain String, even for a String
+    // subclass receiver — so build a fresh String rather than `dup`ing
+    // (which would carry over the receiver's class).
+    let mut self_ = Value::string_from_inner(lfp.self_val().as_rstring_inner().clone());
     let other = lfp.arg(0).coerce_to_rstring(vm, globals)?;
     self_
         .as_rstring_inner_mut()
@@ -2950,6 +2953,11 @@ fn scan_block_loop(
                 vm.invoke_block(globals, data, &val.as_array())?;
             }
         }
+        // CRuby leaves `$~` set to *scan's* last match once the block
+        // returns, even if the block ran its own match. Re-establish it
+        // after each yield so the final state reflects scan, not the
+        // block's last match.
+        vm.save_capture_special_variables(&cap, given);
         check_string_not_modified(recv, recv_len)?;
     }
     Ok(())
@@ -3059,7 +3067,12 @@ fn string_index(
 
     let char_pos = match given.conv_char_index(char_pos) {
         Some(pos) => pos,
-        None => return Ok(Value::nil()),
+        None => {
+            // CRuby's `String#index` with a Regexp always updates `$~`,
+            // clearing it to nil when there is no match.
+            vm.clear_capture_special_variables();
+            return Ok(Value::nil());
+        }
     };
 
     let s = given.check_utf8()?;
@@ -3070,12 +3083,18 @@ fn string_index(
             Some(captures) if captures.get(0).unwrap().range().is_empty() => {
                 Ok(Value::integer(char_pos as i64))
             }
-            _ => Ok(Value::nil()),
+            _ => {
+                vm.clear_capture_special_variables();
+                Ok(Value::nil())
+            }
         };
     }
     let byte_pos = s.char_indices().nth(char_pos).unwrap().0;
     match re.captures_from_pos(s, byte_pos, vm)? {
-        None => Ok(Value::nil()),
+        None => {
+            vm.clear_capture_special_variables();
+            Ok(Value::nil())
+        }
         Some(captures) => {
             let start = captures.get(0).unwrap().start();
             let char_pos = given.byte_to_char_index(start)?;

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -327,18 +327,35 @@ impl Lfp {
     /// * **Block-style** frames (block literal `{ }` / `do … end`
     ///   and `Proc.new`) `share` their lexical parent's MFP — follow
     ///   `outer` upward.
-    /// * **Method-style** frames (`def`, lambda, class/module body,
-    ///   toplevel script, `define_method`-installed Proc tagged
-    ///   `is_proc_method`) own their MFP — stop.
+    /// * **Lambdas** (`-> {}` / `lambda {}`) are method-style for
+    ///   `return`/arity purposes, but for svar they behave like blocks:
+    ///   a `$~`/`$1` set before the lambda was created is visible inside
+    ///   it (CRuby shares the defining scope's svar). They close over a
+    ///   lexical `outer`, so follow it upward too.
+    /// * **Method-style** frames that own their MFP — stop here:
+    ///   * `def`, class/module body, toplevel script: method-style with
+    ///     no lexical `outer`.
+    ///   * `define_method`-installed Proc bodies, tagged
+    ///     `is_proc_method`: a true method boundary even though they
+    ///     close over an `outer`.
     ///
-    /// The chain is guaranteed to terminate at a method-style frame
-    /// (the toplevel script body is method-style with no outer), so
-    /// this loop always returns a real Mfp.
+    /// The chain is guaranteed to terminate (the toplevel script body
+    /// is method-style with no outer), so this loop always returns a
+    /// real Mfp.
     pub(crate) fn mfp(self) -> Lfp {
         let mut lfp = self;
         loop {
             let meta = lfp.meta();
-            if !meta.is_block_style() || meta.is_proc_method() {
+            // `define_method` body: a method boundary that nonetheless
+            // closes over an outer env — stop before walking past it.
+            if meta.is_proc_method() {
+                return lfp;
+            }
+            // `def` / class-body / toplevel: method-style frames that
+            // never capture a lexical outer, so they own their svar.
+            // A method-style frame *with* an outer is a lambda, which
+            // shares its definer's svar — fall through and walk.
+            if !meta.is_block_style() && lfp.outer().is_none() {
                 return lfp;
             }
             match lfp.outer() {

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -432,6 +432,14 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
         IdentId::get_id("$\""),
         IdentId::get_id("$LOADED_FEATURES"),
     );
+
+    // --- Record separator ---------------------------------------------------
+
+    // `$/` (the input record separator, used as the default argument of
+    // `String#chomp`, `IO#gets`, `String#lines`, …) defaults to "\n" in
+    // CRuby. It is a plain, assignable global; seed the default value so
+    // reads return "\n" before any assignment.
+    globals.set_gvar(IdentId::get_id("$/"), Value::string_from_str("\n"));
 }
 
 // ============================================================================

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -139,6 +139,15 @@ impl MatchDataInner {
         unsafe { std::str::from_utf8_unchecked(self.heystack_bytes()) }
     }
 
+    /// The stored haystack snapshot as a String `Value`.
+    ///
+    /// This is the exact object `MatchData#string` returns: a single
+    /// per-MatchData snapshot, so repeated calls hand back the *same*
+    /// (frozen) String — matching CRuby, where `md.string.equal?(md.string)`.
+    pub fn string_value(&self) -> Value {
+        self.heystack
+    }
+
     pub fn pos(&self, pos: usize) -> Option<(usize, usize)> {
         decode_span(self.matches[pos])
     }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -937,10 +937,6 @@ impl RegexpInner {
             vm.save_capture_special_variables(&cap, given);
             let result = vm.invoke_block(globals, &data, &[matched])?;
             check_string_not_modified(recv, recv_len)?;
-            // CRuby leaves `$~` set to *gsub's* last match once the block
-            // returns, even if the block ran its own match. Re-establish
-            // it after each yield so the final state reflects gsub.
-            vm.save_capture_special_variables(&cap, given);
             // CRuby raises Encoding::CompatibilityError if the
             // block returned a String whose encoding can't merge
             // with self's. Check before stringifying.

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -937,6 +937,10 @@ impl RegexpInner {
             vm.save_capture_special_variables(&cap, given);
             let result = vm.invoke_block(globals, &data, &[matched])?;
             check_string_not_modified(recv, recv_len)?;
+            // CRuby leaves `$~` set to *gsub's* last match once the block
+            // returns, even if the block ran its own match. Re-establish
+            // it after each yield so the final state reflects gsub.
+            vm.save_capture_special_variables(&cap, given);
             // CRuby raises Encoding::CompatibilityError if the
             // block returned a String whose encoding can't merge
             // with self's. Check before stringifying.


### PR DESCRIPTION
## Summary

Investigated ruby/spec failures in `core/regexp`, `core/string`, `core/matchdata`, then implemented fixes in order of impact + tractability (deferring the hard encoding work). Then implemented `core/gc` to passing.

| category | before | after |
|---|---|---|
| core/matchdata | 9 failures | 6 failures |
| core/regexp | 28 failures + 4 errors | 26 failures + 4 errors |
| core/string | 205 failures + 106 errors | 192 failures + 106 errors |
| **core/gc** | 3 failures + 32 errors | **0 failures, 0 errors** |

## Changes

### matchdata / regexp
- `MatchData#string` returns the same frozen snapshot of the subject on every call (CRuby returns one frozen copy).
- **`$~`/`$_` svar scoping**: a lambda now shares its defining method frame's special variables (`Lfp::mfp` walks through lambda frames), so `$~`/`Regexp.last_match` set before a lambda are visible inside it. `mfp` is used solely for svar resolution, so the blast radius is limited; `def`/class-body/toplevel and `define_method` bodies still own their own backref.

### string
- `String#hex` / `String#oct`: a sign inside the digit portion (`"0x-1"`, `"+-5"`) is invalid → `0`, matching CRuby.
- `String#chomp` / `chomp!`: default separator is `$/` (not hard-coded `"\n"`); `$/ = nil` means "never chomp".
- `String#=~`: raise `TypeError` for a String rhs; return the **character** (not byte) index of the match.
- Seed `$/` to its `"\n"` default so reads return `"\n"` before any assignment.
- `String#lines` / `each_line`: honour `$/` as the default separator.
- `String#+` returns a plain `String` even for a subclass receiver.
- `String#index` with a Regexp clears `$~` to nil on no match.
- `String#gsub` / `String#scan` with a block restore `$~` to their own last match after the block returns.

### gc
- `GC.count` reads the real allocator collection counter; `GC.stat` reports real values for `count` / `minor_gc_count` / `major_gc_count` / `total_allocated_objects` / `heap_{live,free,marked}_slots` and 0 for the rest. `GC.stat(hash)` fills & returns the given hash, `GC.stat(:key)` returns an Integer, `GC.stat(bad)` raises `TypeError`.
- `GC.start` requests a forced Major collection at the next VM safepoint (running one inline from a builtin is unsafe — the JIT caller's live registers aren't spilled for the root scan), so `GC.count` / `GC.stat(:major_gc_count)` advance after it.
- Added `GC.stress(=)`, `GC.measure_total_time(=)`, `GC.auto_compact(=)`, `GC.total_time`, `GC.config` (read-only `:implementation` key + settable `rgengc_allow_full_mark`), `GC#garbage_collect`, and the `GC::Profiler` module.
- `alloc`: expose the gc counters unconditionally (not just under `gc-log`) and add `alloc::request_gc` for safepoint-driven collection.

## Testing
- All 1678 lib unit tests pass; no regressions in any of the four spec categories (verified with per-run diffs).
- `core/gc` is fully green.

## Deferred (hard)
- `String#encode` / `encode!` (~98 failures — full encoding-conversion machinery).
- "chilled string" literals (Ruby 3.4 semantics).
- Encoding-related regexp/matchdata cases (FIXEDENCODING, ASCII-8BIT propagation, source-encoding upgrades).

https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_