### PR TITLE
regexp/matchdata encoding: result encoding, source/options, timeout, gsub $~.regexp

### DIFF
--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -156,10 +156,7 @@ fn deconstruct_keys_md(
                 last = Some(i);
             }
         }
-        match last.and_then(|i| m.at(i + 1)) {
-            Some(s) => Value::string_from_vec(s.to_vec()),
-            None => Value::nil(),
-        }
+        last.and_then(|i| m.at_value(i + 1)).unwrap_or_default()
     };
     let mut map = RubyMap::default();
     if arg.is_nil() {
@@ -315,14 +312,9 @@ fn string_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resul
 /// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/pre_match.html]
 #[monoruby_builtin]
 fn pre_match(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_ = lfp.self_val();
-    let m = self_.as_match_data();
-    match m.pos(0) {
-        Some((start, _)) => Ok(Value::string_from_vec(
-            m.string().as_bytes()[..start].to_vec(),
-        )),
-        None => Ok(Value::string_from_str("")),
-    }
+    // The result carries the source string's encoding (CRuby semantics);
+    // `pre_match_value` returns a CoW substring of the haystack snapshot.
+    Ok(lfp.self_val().as_match_data().pre_match_value())
 }
 
 ///
@@ -335,14 +327,8 @@ fn pre_match(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/MatchData/i/post_match.html]
 #[monoruby_builtin]
 fn post_match(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_ = lfp.self_val();
-    let m = self_.as_match_data();
-    match m.pos(0) {
-        Some((_, end)) => Ok(Value::string_from_vec(
-            m.string().as_bytes()[end..].to_vec(),
-        )),
-        None => Ok(Value::string_from_str("")),
-    }
+    // The result carries the source string's encoding (CRuby semantics).
+    Ok(lfp.self_val().as_match_data().post_match_value())
 }
 
 ///
@@ -396,17 +382,15 @@ fn names(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<
 /// The value of named capture `name`: the *last* group sharing that
 /// name whose capture actually participated in the match (CRuby
 /// "latest matched capture"); `None` if the name never matched.
-fn last_matched_named<'a>(
-    m: &'a crate::value::rvalue::MatchDataInner,
+fn last_matched_named(
+    m: &crate::value::rvalue::MatchDataInner,
     capture_names: &[String],
     name: &str,
-) -> Option<&'a [u8]> {
+) -> Option<usize> {
     let mut result = None;
     for (i, n) in capture_names.iter().enumerate() {
-        if n == name
-            && let Some(s) = m.at(i + 1)
-        {
-            result = Some(s);
+        if n == name && m.at(i + 1).is_some() {
+            result = Some(i + 1);
         }
     }
     result
@@ -446,8 +430,7 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
             let e = (s + slice_len as usize).min(m.len());
             for i in s..e {
                 res.push(
-                    m.at(i)
-                        .map(|b| Value::string_from_vec(b.to_vec()))
+                    m.at_value(i)
                         .unwrap_or_default(),
                 );
             }
@@ -479,8 +462,7 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                     ))
                 })?;
             res.push(
-                m.at(i)
-                    .map(|b| Value::string_from_vec(b.to_vec()))
+                m.at_value(i)
                     .unwrap_or_else(Value::nil),
             );
             continue;
@@ -500,8 +482,7 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
             res.push(Value::nil());
         } else {
             res.push(
-                m.at(idx)
-                    .map(|b| Value::string_from_vec(b.to_vec()))
+                m.at_value(idx)
                     .unwrap_or_default(),
             );
         }
@@ -521,9 +502,11 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 #[monoruby_builtin]
 fn deconstruct(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::array_from_iter(
-        lfp.self_val().as_match_data().captures().skip(1).map(|s| {
-            s.map(|b| Value::string_from_vec(b.to_vec())).unwrap_or_default()
-        }),
+        lfp.self_val()
+            .as_match_data()
+            .captures_values()
+            .skip(1)
+            .map(|s| s.unwrap_or_default()),
     ))
 }
 
@@ -552,8 +535,7 @@ fn match_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         if idx >= m.len() {
             return Ok(Value::nil());
         }
-        Ok(m.at(idx)
-            .map(|b| Value::string_from_vec(b.to_vec()))
+        Ok(m.at_value(idx)
             .unwrap_or_default())
     } else if let Some(sym) = arg.try_symbol_or_string() {
         if let Some(i) = m
@@ -561,8 +543,7 @@ fn match_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             .map(|r| r.get_group_members(&format!("{sym}")))
             .and_then(|g| g.last().copied())
         {
-            Ok(m.at(i as usize)
-                .map(|b| Value::string_from_vec(b.to_vec()))
+            Ok(m.at_value(i as usize)
                 .unwrap_or_default())
         } else {
             Err(MonorubyErr::indexerr(format!(
@@ -636,13 +617,11 @@ fn match_length(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodeP
 #[monoruby_builtin]
 fn captures(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::array_from_iter(
-        lfp.self_val().as_match_data().captures().skip(1).map(|s| {
-            if let Some(s) = s {
-                Value::string_from_vec(s.to_vec())
-            } else {
-                Value::nil()
-            }
-        }),
+        lfp.self_val()
+            .as_match_data()
+            .captures_values()
+            .skip(1)
+            .map(|s| s.unwrap_or_default()),
     ))
 }
 
@@ -654,13 +633,10 @@ fn captures(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resu
 #[monoruby_builtin]
 fn to_a(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     Ok(Value::array_from_iter(
-        lfp.self_val().as_match_data().captures().map(|s| {
-            if let Some(s) = s {
-                Value::string_from_vec(s.to_vec())
-            } else {
-                Value::nil()
-            }
-        }),
+        lfp.self_val()
+            .as_match_data()
+            .captures_values()
+            .map(|s| s.unwrap_or_default()),
     ))
 }
 
@@ -704,8 +680,7 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         if idx >= m.len() {
             return Ok(Value::nil());
         }
-        Ok(m.at(idx as usize)
-            .map(|s| Value::string_from_vec(s.to_vec()))
+        Ok(m.at_value(idx as usize)
             .unwrap_or_default())
     } else if let Some(range) = lfp.arg(0).is_range() {
         // `[start..end]` / `[start...]` / `[..end]` slicing.
@@ -729,8 +704,8 @@ fn index(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         // actually matched (CRuby semantics); nil if none matched.
         let mut result = Value::nil();
         for i in members {
-            if let Some(s) = m.at(i as usize) {
-                result = Value::string_from_vec(s.to_vec());
+            if let Some(s) = m.at_value(i as usize) {
+                result = s;
             }
         }
         Ok(result)
@@ -760,8 +735,7 @@ fn slice_match_data(
     let mut out = Vec::with_capacity(e - s);
     for i in s..e {
         out.push(
-            m.at(i)
-                .map(|v| Value::string_from_vec(v.to_vec()))
+            m.at_value(i)
                 .unwrap_or_default(),
         );
     }
@@ -878,7 +852,7 @@ fn named_captures(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
             Value::string_from_str(name)
         };
         let val = last_matched_named(&m, &names, name)
-            .map(|b| Value::string_from_vec(b.to_vec()))
+            .and_then(|i| m.at_value(i))
             .unwrap_or_default();
         map.insert(key, val, vm, globals)?;
     }
@@ -1153,6 +1127,28 @@ mod tests {
     fn match_data_string_frozen() {
         // MatchData#string is a single frozen object, the same on every call.
         run_test(r##"md = /(.)(\d+)/.match("THX1138"); [md.string, md.string.frozen?, md.string.equal?(md.string)]"##);
+    }
+
+    #[test]
+    fn match_data_result_encoding() {
+        // Capture / pre_match / post_match strings inherit the subject's
+        // encoding (not a fixed UTF-8/ASCII-8BIT auto-detection).
+        run_test(
+            r#"s = "abc".dup.force_encoding(Encoding::EUC_JP); \
+               m = s.match(/b/); [m.pre_match.encoding.to_s, m.post_match.encoding.to_s]"#,
+        );
+        run_test(
+            r#"s = "abc".dup.force_encoding(Encoding::ISO_8859_1); \
+               s.match(/a/).pre_match.encoding.to_s"#,
+        );
+        run_test(
+            r#"md = "haystack".dup.force_encoding("euc-jp").match(/(?<t>t(?<a>ack))/u); \
+               [md[:t].encoding.to_s, md[1].encoding.to_s]"#,
+        );
+        run_test(
+            r#"s = "abc".dup.force_encoding(Encoding::EUC_JP); \
+               s.match(/(b)(c)/).captures.map { |x| x.encoding.to_s }"#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -1130,6 +1130,12 @@ mod tests {
     }
 
     #[test]
+    fn match_data_regexp_after_gsub_string() {
+        // gsub(String) attaches the (escaped) Regexp to `$~`.
+        run_test(r#"'he[[o'.gsub('[', ']'); $~.regexp == /\[/"#);
+    }
+
+    #[test]
     fn match_data_result_encoding() {
         // Capture / pre_match / post_match strings inherit the subject's
         // encoding (not a fixed UTF-8/ASCII-8BIT auto-detection).

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1071,12 +1071,19 @@ fn regexp_linear_time_p(
     Ok(Value::bool(pattern_is_linear_time(&s)))
 }
 
+// The global `Regexp.timeout` (in seconds). monoruby does not enforce
+// per-match timeouts yet, but the accessor round-trips the value (CRuby
+// stores it as a Float), which user code and specs read back.
+thread_local!(
+    static REGEXP_TIMEOUT: std::cell::Cell<Option<f64>> = const { std::cell::Cell::new(None) }
+);
+
 ///
 /// ### Regexp.timeout
 /// - timeout -> Float | nil
 ///
-/// monoruby does not implement per-match timeouts; the global
-/// setting reads as `nil`.
+/// Returns the global timeout (a Float), or `nil` when unset. The value
+/// is stored but not yet enforced (no ReDoS interruption).
 #[monoruby_builtin]
 fn regexp_timeout_get(
     _: &mut Executor,
@@ -1084,23 +1091,30 @@ fn regexp_timeout_get(
     _: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(Value::nil())
+    Ok(REGEXP_TIMEOUT.with(|t| t.get()).map_or_else(Value::nil, Value::float))
 }
 
 ///
 /// ### Regexp.timeout=
 /// - timeout=(sec) -> sec
 ///
-/// Accepted but not enforced — monoruby has no regex timeout
-/// implementation. Returns the argument so chained assignments work.
+/// Stores the global timeout (`nil` clears it). The value is coerced to a
+/// Float, as in CRuby. Not yet enforced during matching.
 #[monoruby_builtin]
 fn regexp_timeout_set(
-    _: &mut Executor,
-    _: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(lfp.arg(0))
+    let arg = lfp.arg(0);
+    let stored = if arg.is_nil() {
+        None
+    } else {
+        Some(arg.coerce_to_f64(vm, globals)?)
+    };
+    REGEXP_TIMEOUT.with(|t| t.set(stored));
+    Ok(arg)
 }
 
 ///
@@ -1521,9 +1535,12 @@ mod tests {
     #[test]
     fn regexp_timeout_accessors() {
         run_tests(&[
-            // monoruby has no per-match timeout; accessors are stubs.
-            r#"Regexp.timeout"#,
+            // `Regexp.timeout` round-trips the global value (a Float),
+            // `nil` clears it. (Reset first so the value is deterministic
+            // across the harness's repeated in-process evaluations.)
+            r#"Regexp.timeout = nil; Regexp.timeout"#,
             r#"(Regexp.timeout = 1.0)"#,
+            r#"Regexp.timeout = 3; r = Regexp.timeout; Regexp.timeout = nil; [r, Regexp.timeout]"#,
             r#"
             $_ = "input data"
             ~ /at/

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1879,4 +1879,13 @@ mod tests {
         // An arg that can't be coerced ⇒ TypeError.
         run_test_error(r#"Regexp.escape(5)"#);
     }
+
+    #[test]
+    fn regexp_options_fixedencoding() {
+        // The `u`/`e`/`s` encoding modifiers pin the encoding, so
+        // `#options` exposes Regexp::FIXEDENCODING; a plain regexp does not.
+        run_test(
+            "[/abc/u, /abc/e, /abc/s, /abc/].map { |r| (r.options & Regexp::FIXEDENCODING) != 0 }",
+        );
+    }
 }

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -818,7 +818,20 @@ fn conv_index(i: i64, len: usize) -> Option<usize> {
 #[monoruby_builtin]
 fn source(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    Ok(Value::string_from_str(self_.is_regex().unwrap().as_str()))
+    let re = self_.is_regex().unwrap();
+    let src = re.as_str();
+    // CRuby's `Regexp#source.encoding`: a regexp whose encoding is pinned
+    // (the `u`/`e`/`s` modifiers, a non-ASCII `\u{}` escape, or non-ASCII
+    // source bytes) carries that encoding; an unpinned, 7-bit-only source
+    // is US-ASCII.
+    let enc = if re.fixed_encoding() {
+        re.declared_encoding()
+    } else {
+        crate::value::Encoding::UsAscii
+    };
+    Ok(Value::string_from_inner(
+        crate::value::rvalue::RStringInner::from_encoding_scanned(src.as_bytes(), enc),
+    ))
 }
 
 ///
@@ -1886,6 +1899,18 @@ mod tests {
         // `#options` exposes Regexp::FIXEDENCODING; a plain regexp does not.
         run_test(
             "[/abc/u, /abc/e, /abc/s, /abc/].map { |r| (r.options & Regexp::FIXEDENCODING) != 0 }",
+        );
+    }
+
+    #[test]
+    fn regexp_source_encoding() {
+        // A 7-bit, unpinned source is US-ASCII; a pinned encoding (u/e/s
+        // modifier, non-ASCII `\u{}` escape, non-ASCII source) carries
+        // that encoding.
+        run_test(
+            r#"[ /abc/, /abc/u, /abc/e, /\u{61}/, /\u{3042}/,
+                Regexp.new("abc"), Regexp.new("\u{ff}"), Regexp.new("ほげ") ]
+              .map { |r| r.source.encoding.to_s }"#,
         );
     }
 }

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -164,6 +164,32 @@ impl MatchDataInner {
             .map(|(start, end)| &self.heystack_bytes()[start..end])
     }
 
+    /// Matched capture `pos` as a String `Value` carrying the **source
+    /// string's encoding** (CRuby: capture/pre/post strings inherit the
+    /// subject's encoding). A zero-copy shared (CoW) substring of the
+    /// haystack snapshot, sliced on byte boundaries (safe for binary
+    /// regexps).
+    pub fn at_value(&self, pos: usize) -> Option<Value> {
+        self.pos(pos)
+            .map(|(start, end)| string_substring(self.heystack, start, end))
+    }
+
+    /// `pre_match` as a String `Value` in the source string's encoding
+    /// (the portion of the subject before the whole match; empty when
+    /// there is no match position).
+    pub fn pre_match_value(&self) -> Value {
+        let start = self.pos(0).map(|(s, _)| s).unwrap_or(0);
+        string_substring(self.heystack, 0, start)
+    }
+
+    /// `post_match` as a String `Value` in the source string's encoding
+    /// (the portion of the subject after the whole match).
+    pub fn post_match_value(&self) -> Value {
+        let len = self.heystack_bytes().len();
+        let end = self.pos(0).map(|(_, e)| e).unwrap_or(len);
+        string_substring(self.heystack, end, len)
+    }
+
     pub fn len(&self) -> usize {
         self.matches.len()
     }
@@ -172,6 +198,12 @@ impl MatchDataInner {
         self.matches
             .iter()
             .map(|m| decode_span(*m).map(|(start, end)| &self.heystack_bytes()[start..end]))
+    }
+
+    /// Like [`captures`] but yields each group as a String `Value` in the
+    /// source string's encoding (`None` for groups that did not match).
+    pub fn captures_values(&self) -> impl Iterator<Item = Option<Value>> + '_ {
+        (0..self.len()).map(move |i| self.at_value(i))
     }
 
     pub fn to_s(&self) -> String {

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1209,6 +1209,9 @@ impl RegexpInner {
         let res = RStringInner::splice_all(store, given, &replacements)?;
 
         if let Some(c) = last_captures {
+            // Attach the (possibly coerced-from-String) Regexp to `$~` so
+            // `$~.regexp` works after `gsub(String)`.
+            vm.set_match_regex(Value::regexp(self.clone()));
             vm.save_capture_special_variables(&c, given)
         }
 

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -117,6 +117,13 @@ impl RegexpInner {
         if self.encoding == OnigmoEncoding::ASCII {
             opt |= Self::NOENCODING;
         }
+        if self.fixed_encoding {
+            // `Regexp#options` exposes FIXEDENCODING for a regexp whose
+            // encoding is pinned (the `u`/`e`/`s` modifiers, or a source
+            // with non-ASCII bytes). `raw_option`/`#==`/`#hash` are
+            // unaffected — they intentionally ignore the encoding flags.
+            opt |= Self::FIXEDENCODING;
+        }
         opt
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #733, working through the deferred regexp/matchdata **encoding** failures in order of tractability. Implements the parts that don't require the larger "store regexp source as bytes+encoding" refactor (see Deferred).

| category | before | after |
|---|---|---|
| **core/matchdata** | 6 failures | **0 failures, 0 errors** |
| core/regexp | 26 failures + 4 errors | 15 failures + 6 errors |

All 1694 lib unit tests pass; no regressions.

## Changes

### MatchData result encoding (Tier 1)
- `MatchData#pre_match` / `#post_match` / `#[]` (index & name) / `#captures` / `#to_a` / `#deconstruct` / `#values_at` / `#match` / `#named_captures` now return strings in the **source string's encoding**, via zero-copy CoW substrings of the haystack snapshot (new `MatchDataInner::at_value` / `pre_match_value` / `post_match_value` / `captures_values`), instead of re-detecting UTF-8/ASCII-8BIT and discarding the encoding.
- `#regexp` / `$~.regexp` now return the (escaped) Regexp after `str.gsub('[', ']')` — the String-pattern gsub/sub path (`replace_repeat`) stashes the coerced Regexp before saving `$~`.

### Regexp encoding/options
- `Regexp#options` exposes `Regexp::FIXEDENCODING` when the encoding is pinned (the `u`/`e`/`s` modifiers, a non-ASCII `\u{}` escape, or non-ASCII source). `raw_option` / `#==` / `#hash` are unaffected (they intentionally ignore the encoding flags).
- `Regexp#source` returns a String tagged **US-ASCII** for an unpinned 7-bit source, or the regexp's pinned encoding otherwise — matching CRuby's `Regexp#source.encoding` (previously always UTF-8).

### Regexp.timeout
- `Regexp.timeout` / `Regexp.timeout=` round-trip the global timeout (a Float; `nil` clears it) instead of being no-op stubs. Not yet enforced during matching, and `Regexp::TimeoutError` is intentionally left **undefined** — defining it without enforcement would let the ruby/spec timeout examples proceed into a catastrophic-backtracking match and hang the process.

## Testing
- New unit tests cover: MatchData result encoding, `MatchData#string` identity, `$~` visibility in a lambda, `$~.regexp` after `gsub(String)`, `Regexp#options` FIXEDENCODING, `Regexp#source.encoding`, and `Regexp.timeout` round-trip.
- Full `cargo test --lib` (1694) passes; `core/matchdata` is fully green, `core/regexp` improved 26→15 failures, with no regressions (per-run spec diffs).

## Deferred (need the non-UTF-8 source-byte refactor)
monoruby stores a regexp's source as a UTF-8 `&str`, so non-UTF-8 sources (Shift_JIS / UTF-16 / binary) can't be represented faithfully. The remaining core/regexp failures depend on extending `RegexpInner`'s source storage to bytes + encoding:
- `Regexp.new`/`compile` adopting the input String's encoding (Shift_JIS, …).
- `Regexp#encoding` returning BINARY (`/n` + non-ASCII), NOENCODING, and the embedded-String upgrade.
- `Regexp.union` ASCII-incompatible (UTF-16) detection + CRuby-exact `ArgumentError` messages, and ASCII-8BIT propagation.
- `Regexp#match` invalid-encoding `ArgumentError`.

Also deferred: `Regexp::TimeoutError` enforcement (needs a ReDoS interrupt), and `Regexp.new` for subclasses with an overridden `#initialize`.

https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_