### PR TITLE
regexp: store raw source bytes — non-UTF-8 sources, union, /n BINARY, interpolation, subclasses

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -55,7 +55,14 @@ pub(crate) fn init(globals: &mut Globals) {
     // - `TypeError` otherwise (CRuby treats every monoruby Regexp as
     //   "already initialized" since `Regexp.new` is the sole entry
     //   point and produces a fully-built instance).
-    let init_id = globals.define_private_builtin_func(REGEXP_CLASS, "initialize", regexp_initialize, 1);
+    let init_id = globals.define_private_builtin_func_with(
+        REGEXP_CLASS,
+        "initialize",
+        regexp_initialize,
+        1,
+        2,
+        false,
+    );
     let _ = init_id;
     globals.store[REGEXP_CLASS].set_alloc_func(regexp_alloc_func);
 }
@@ -96,24 +103,39 @@ pub(crate) extern "C" fn regexp_alloc_func(class_id: ClassId, _: &mut Globals) -
     Value::regexp_with_class(regexp, class_id)
 }
 
-/// Private `Regexp#initialize` that always rejects re-initialisation.
-/// `Regexp.new` builds a fully-formed instance via the alloc function +
-/// internal construction path, so any subsequent `.send(:initialize, …)`
-/// must be either a frozen literal (FrozenError) or an already-built
-/// instance (TypeError "already initialized regexp"). matches CRuby
-/// (the `< 4.1` branch of `initialize_spec.rb`).
+/// Private `Regexp#initialize`. On a freshly-`allocate`d (uninitialized)
+/// receiver — the path taken by `SubclassOfRegexp.new` and an explicit
+/// `super` from an overridden `#initialize` — it compiles the source and
+/// fills in the instance. Re-initialising an already-built regexp is
+/// rejected: `FrozenError` for a frozen literal, otherwise `TypeError`
+/// "already initialized regexp" (matches CRuby).
 #[monoruby_builtin]
 fn regexp_initialize(
-    _: &mut Executor,
-    _: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let self_ = lfp.self_val();
+    let mut self_ = lfp.self_val();
     if self_.is_frozen() {
         return Err(MonorubyErr::frozenerr("can't modify frozen Regexp"));
     }
-    Err(MonorubyErr::typeerr("already initialized regexp"))
+    if self_.as_regexp_inner().initialized() {
+        return Err(MonorubyErr::typeerr("already initialized regexp"));
+    }
+    // Root the receiver and the source/option args across the allocating
+    // build below: this runs from `super` in an overridden `#initialize`,
+    // whose frame slots aren't otherwise reachable by the GC here.
+    let temp = vm.temp_len();
+    vm.temp_push(self_);
+    vm.temp_push(lfp.arg(0));
+    if let Some(a1) = lfp.try_arg(1) {
+        vm.temp_push(a1);
+    }
+    let inner = build_regexp_inner(vm, globals, lfp)?;
+    *self_.as_regexp_inner_mut() = inner;
+    vm.temp_clear(temp);
+    Ok(Value::nil())
 }
 
 ///
@@ -124,6 +146,44 @@ fn regexp_initialize(
 /// [https://docs.ruby-lang.org/ja/latest/method/Regexp/s/compile.html]
 #[monoruby_builtin]
 fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class_id = lfp.self_val().as_class_id();
+    if class_id == REGEXP_CLASS {
+        // Fast path for the base class: build directly.
+        return Ok(Value::regexp(build_regexp_inner(vm, globals, lfp)?));
+    }
+    // A subclass: allocate an instance of it, then initialize. Root the
+    // fresh instance across the construction below, which allocates (and
+    // may GC) before the instance is reachable from the Ruby stack.
+    let mut obj = regexp_alloc_func(class_id, globals);
+    let temp = vm.temp_len();
+    vm.temp_push(obj);
+    let init_fid = vm.find_method(globals, obj, IdentId::INITIALIZE, true)?;
+    if globals.store[init_fid].is_iseq().is_some() {
+        // The subclass overrides `#initialize` (a Ruby method): run it so
+        // its `super` reaches `Regexp#initialize` and its own body (e.g.
+        // `@args = args`) executes.
+        let args: Vec<Value> = match lfp.try_arg(1) {
+            Some(opt) => vec![lfp.arg(0), opt],
+            None => vec![lfp.arg(0)],
+        };
+        vm.invoke_func_inner(globals, init_fid, obj, &args, None, None)?;
+    } else {
+        // Inherited `Regexp#initialize`: build the data directly into the
+        // freshly-allocated instance.
+        let inner = build_regexp_inner(vm, globals, lfp)?;
+        *obj.as_regexp_inner_mut() = inner;
+    }
+    vm.temp_clear(temp);
+    Ok(obj)
+}
+
+/// Parse `Regexp.new`/`#initialize` arguments (source + optional option)
+/// into a fully-built `RegexpInner`.
+fn build_regexp_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+) -> Result<RegexpInner> {
     let arg0 = lfp.arg(0);
     // When given an existing Regexp, carry over both source and
     // options so `Regexp.new(/abc/i) == /abc/i`. CRuby's `rb_reg_init`
@@ -216,7 +276,7 @@ fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         source_encoding,
         source_bytes,
     )?;
-    Ok(Value::regexp(regexp))
+    Ok(regexp)
 }
 
 /// Map a Ruby-visible encoding to the matching KCODE_* bit, mirroring
@@ -1967,6 +2027,21 @@ mod tests {
         run_test(r#"[/\u{61}/.source, /\u{61}/.inspect, (/\u{61}/ == /a/)]"#);
         // A Regexp argument preserves the original source verbatim.
         run_test(r#"Regexp.new(/\u{61}/).source"#);
+    }
+
+    #[test]
+    fn regexp_subclass_new() {
+        // A subclass with an overridden #initialize: the override runs
+        // (its `super` builds the regexp, its body sets @args), and the
+        // result is an instance of the subclass.
+        run_test(
+            r#"class ReSubA < Regexp; def initialize(*a); super; @a = a; end; attr_reader :a; end
+               r = ReSubA.new("hi"); [r.is_a?(ReSubA), r.a.first, r.source, r.match("xhiy")[0]]"#,
+        );
+        // A subclass without an overridden #initialize.
+        run_test(r#"class ReSubB < Regexp; end; r = ReSubB.new("hi"); [r.is_a?(ReSubB), r.source]"#);
+        // Re-initializing an already-built regexp still raises.
+        run_test(r#"(Regexp.new("x").send(:initialize, "y"); nil) rescue $!.class"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -928,6 +928,17 @@ fn rmatch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         vm.clear_capture_special_variables();
         return Ok(Value::nil());
     }
+    // A subject String that is invalid in its own encoding can't be
+    // matched — CRuby raises ArgumentError before scanning.
+    if arg0.is_rstring().is_some() {
+        let inner = arg0.as_rstring_inner();
+        if !inner.is_valid_encoding() {
+            return Err(MonorubyErr::argumenterr(format!(
+                "invalid byte sequence in {}",
+                inner.encoding().name()
+            )));
+        }
+    }
     // Borrow the subject's bytes directly (and stash the Value for
     // the zero-copy MatchData snapshot) when it is a UTF-8 String;
     // Symbols and non-UTF-8 subjects fall back to the owned
@@ -1956,6 +1967,22 @@ mod tests {
         run_test(r#"[/\u{61}/.source, /\u{61}/.inspect, (/\u{61}/ == /a/)]"#);
         // A Regexp argument preserves the original source verbatim.
         run_test(r#"Regexp.new(/\u{61}/).source"#);
+    }
+
+    #[test]
+    fn regexp_match_invalid_encoding() {
+        // Matching a subject that is invalid in its own encoding raises
+        // ArgumentError (CRuby), instead of mis-matching or erroring.
+        run_test(
+            r#"x = [150].pack("C").force_encoding("utf-8");
+               (/(.).(.)/.match("ab #{x} cd", 1); nil) rescue [$!.class, $!.message]"#,
+        );
+        run_test(
+            r#"x = [150].pack("C").force_encoding("utf-8");
+               (/(.).(.)/.match("ab #{x} cd", -1); nil) rescue [$!.class, $!.message]"#,
+        );
+        // A valid (binary) subject still matches.
+        run_test(r#"/a/.match("xay".b).nil?"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1970,6 +1970,17 @@ mod tests {
     }
 
     #[test]
+    fn regexp_interpolation_encoding() {
+        // An interpolated non-ASCII String upgrades the regexp's encoding.
+        run_test(r#"s = "文字化け".encode("euc-jp"); /#{s}/.encoding.to_s"#);
+        // A 7-bit interpolated String stays US-ASCII even if tagged EUC-JP.
+        run_test(r#"a = "abc".encode("euc-jp"); /#{a}/.encoding.to_s"#);
+        run_test(r#"/#{"あ"}/.encoding.to_s"#);
+        // Interpolation still matches.
+        run_test(r#"x = "wor"; "hello world" =~ /#{x}ld/"#);
+    }
+
+    #[test]
     fn regexp_match_invalid_encoding() {
         // Matching a subject that is invalid in its own encoding raises
         // ArgumentError (CRuby), instead of mis-matching or erroring.

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -475,8 +475,17 @@ impl UnionEnc {
             }
         } else if prev_pinned {
             // Previous side is non-ASCII-compat; arg is anything
-            // else (even pure-ASCII). CRuby still rejects.
+            // else (even pure-ASCII). CRuby still rejects. When the
+            // other side is pure 7-bit ASCII, CRuby phrases it as
+            // "ASCII incompatible encoding: <enc>"; otherwise it names
+            // both encodings.
             if let UnionEnc::Pinned(prev) = self {
+                if arg.ascii_only {
+                    return Err(MonorubyErr::argumenterr(format!(
+                        "ASCII incompatible encoding: {}",
+                        prev.name()
+                    )));
+                }
                 return Err(MonorubyErr::argumenterr(format!(
                     "incompatible encodings: {} and {}",
                     prev.name(),
@@ -1942,6 +1951,28 @@ mod tests {
         run_test(r#"[/\u{61}/.source, /\u{61}/.inspect, (/\u{61}/ == /a/)]"#);
         // A Regexp argument preserves the original source verbatim.
         run_test(r#"Regexp.new(/\u{61}/).source"#);
+    }
+
+    #[test]
+    fn regexp_union_ascii_incompatible() {
+        // A single ASCII-incompatible (UTF-16) arg pins the result.
+        run_test(r#"Regexp.union("a".encode("UTF-16LE")).encoding.to_s"#);
+        run_test(r#"Regexp.new("a".encode("UTF-16LE")).encoding.to_s"#);
+        // ASCII-incompatible + ASCII-only -> "ASCII incompatible encoding".
+        run_test(
+            r#"(Regexp.union("a".encode("UTF-16LE"), "b".encode("UTF-8")); nil) rescue [$!.class, $!.message]"#,
+        );
+        run_test(
+            r#"(Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("b".encode("UTF-8"))); nil) rescue [$!.class, $!.message]"#,
+        );
+        // Two conflicting ASCII-incompatible encodings -> names both.
+        run_test(
+            r#"(Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("b".encode("UTF-16BE"))); nil) rescue [$!.class, $!.message]"#,
+        );
+        // ASCII-incompatible + non-ASCII content in a different encoding.
+        run_test(
+            r#"(Regexp.union("a".encode("UTF-16LE"), "©".encode("ISO-8859-1")); nil) rescue [$!.class, $!.message]"#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -136,31 +136,37 @@ fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     // ends up with `encoding == UTF-8` and `fixed_encoding? == true`.
     // `raw_option()` doesn't carry KCODE/NOENCODING/FIXEDENCODING
     // bits (those live in `RegexpInner`, not in Onigmo's option word).
-    let (string, default_option, source_encoding, default_kcode) = if let Some(re) = arg0.is_regex()
-    {
-        let kc = if re.fixed_encoding() {
-            kcode_from_encoding(re.declared_encoding())
+    let (string, default_option, source_encoding, default_kcode, source_bytes) =
+        if let Some(re) = arg0.is_regex() {
+            let kc = if re.fixed_encoding() {
+                kcode_from_encoding(re.declared_encoding())
+            } else {
+                None
+            };
+            let mut opt = re.raw_option();
+            if let Some(bits) = kc {
+                opt |= bits;
+            }
+            (
+                re.as_str().to_string(),
+                Some(opt),
+                Some(re.declared_encoding()),
+                kc,
+                // Preserve the original Regexp's source verbatim.
+                Some(re.source_bytes().to_vec()),
+            )
         } else {
-            None
+            // The matching engine needs a UTF-8 view, so escape non-UTF-8
+            // bytes (`coerce_to_string`), but keep the *raw* bytes for
+            // `Regexp#source` so a Shift_JIS/EUC-JP/binary source survives.
+            let s = arg0.coerce_to_string(vm, globals)?;
+            let raw = arg0.is_rstring_inner().map(|r| r.as_bytes().to_vec());
+            let enc = arg0
+                .is_rstring_inner()
+                .map(|r| r.encoding())
+                .unwrap_or(crate::value::Encoding::Utf8);
+            (s, None, Some(enc), None, raw)
         };
-        let mut opt = re.raw_option();
-        if let Some(bits) = kc {
-            opt |= bits;
-        }
-        (
-            re.as_str().to_string(),
-            Some(opt),
-            Some(re.declared_encoding()),
-            kc,
-        )
-    } else {
-        let s = arg0.coerce_to_string(vm, globals)?;
-        let enc = arg0
-            .is_rstring_inner()
-            .map(|r| r.encoding())
-            .unwrap_or(crate::value::Encoding::Utf8);
-        (s, None, Some(enc), None)
-    };
     let option_provided = lfp.try_arg(1).is_some_and(|v| !v.is_nil());
     if arg0.is_regex().is_some() && option_provided {
         // CRuby emits "warning: flags ignored" (without raising) when
@@ -202,8 +208,14 @@ fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     } else {
         default_kcode
     };
-    let regexp =
-        RegexpInner::with_option_kcode(string, option, encoding, kcode, source_encoding)?;
+    let regexp = RegexpInner::with_option_kcode_source(
+        string,
+        option,
+        encoding,
+        kcode,
+        source_encoding,
+        source_bytes,
+    )?;
     Ok(Value::regexp(regexp))
 }
 
@@ -515,7 +527,7 @@ impl UnionEnc {
 /// non-fixed US-ASCII bucket.
 fn union_arg_encoding(globals: &Globals, arg: Value) -> ArgEnc {
     if let Some(re) = arg.is_regex() {
-        let ascii_only = re.as_str().bytes().all(|b| b < 0x80);
+        let ascii_only = re.source_bytes().iter().all(|&b| b < 0x80);
         return ArgEnc {
             encoding: re.declared_encoding(),
             fixed: re.fixed_encoding(),
@@ -696,7 +708,7 @@ fn regexp_eq(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     if !rhs.initialized() {
         return Err(MonorubyErr::typeerr("uninitialized Regexp"));
     }
-    let same_source = lhs.as_str() == rhs.as_str();
+    let same_source = lhs.source_bytes() == rhs.source_bytes();
     let same_options =
         (lhs.raw_option() & REGEXP_EQ_OPTION_MASK) == (rhs.raw_option() & REGEXP_EQ_OPTION_MASK);
     let same_encoding = lhs.declared_encoding() == rhs.declared_encoding();
@@ -715,7 +727,7 @@ fn regexp_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let self_ = lfp.self_val();
     let re = self_.as_regexp_inner();
     let mut h = std::collections::hash_map::DefaultHasher::new();
-    re.as_str().hash(&mut h);
+    re.source_bytes().hash(&mut h);
     (re.raw_option() & REGEXP_EQ_OPTION_MASK).hash(&mut h);
     Ok(Value::integer(h.finish() as i64))
 }
@@ -819,7 +831,6 @@ fn conv_index(i: i64, len: usize) -> Option<usize> {
 fn source(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
     let re = self_.is_regex().unwrap();
-    let src = re.as_str();
     // CRuby's `Regexp#source.encoding`: a regexp whose encoding is pinned
     // (the `u`/`e`/`s` modifiers, a non-ASCII `\u{}` escape, or non-ASCII
     // source bytes) carries that encoding; an unpinned, 7-bit-only source
@@ -830,7 +841,7 @@ fn source(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result
         crate::value::Encoding::UsAscii
     };
     Ok(Value::string_from_inner(
-        crate::value::rvalue::RStringInner::from_encoding_scanned(src.as_bytes(), enc),
+        crate::value::rvalue::RStringInner::from_encoding_scanned(re.source_bytes(), enc),
     ))
 }
 
@@ -1917,6 +1928,20 @@ mod tests {
         run_test(
             "[/abc/u, /abc/e, /abc/s, /abc/].map { |r| (r.options & Regexp::FIXEDENCODING) != 0 }",
         );
+    }
+
+    #[test]
+    fn regexp_source_bytes_preserved() {
+        // A non-UTF-8 (Shift_JIS) source survives in #source / #encoding.
+        run_test(
+            r#"s = "\x82\xa0".dup.force_encoding(Encoding::Shift_JIS); r = Regexp.new(s);
+               [r.encoding.to_s, r.source.encoding.to_s, r.source.bytes]"#,
+        );
+        // `\u{}` source is kept as written (not expanded), distinct from
+        // its decoded form.
+        run_test(r#"[/\u{61}/.source, /\u{61}/.inspect, (/\u{61}/ == /a/)]"#);
+        // A Regexp argument preserves the original source verbatim.
+        run_test(r#"Regexp.new(/\u{61}/).source"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -536,7 +536,12 @@ impl UnionEnc {
 /// non-fixed US-ASCII bucket.
 fn union_arg_encoding(globals: &Globals, arg: Value) -> ArgEnc {
     if let Some(re) = arg.is_regex() {
-        let ascii_only = re.source_bytes().iter().all(|&b| b < 0x80);
+        // A BINARY (`/.../n` with high `\xHH` escapes) regexp carries
+        // non-ASCII content even though its source *text* is 7-bit, so
+        // it must not be treated as ASCII-only (which would let
+        // `Regexp.union` downgrade the result to US-ASCII).
+        let ascii_only = re.declared_encoding() != crate::value::Encoding::Ascii8
+            && re.source_bytes().iter().all(|&b| b < 0x80);
         return ArgEnc {
             encoding: re.declared_encoding(),
             fixed: re.fixed_encoding(),
@@ -1951,6 +1956,18 @@ mod tests {
         run_test(r#"[/\u{61}/.source, /\u{61}/.inspect, (/\u{61}/ == /a/)]"#);
         // A Regexp argument preserves the original source verbatim.
         run_test(r#"Regexp.new(/\u{61}/).source"#);
+    }
+
+    #[test]
+    fn regexp_encoding_binary_noencoding() {
+        // `/.../n` with a high `\xHH` escape is BINARY; pure-ASCII /n is
+        // US-ASCII.
+        run_test(r#"[/\xc2\xa1/n.encoding.to_s, /abc/n.encoding.to_s, /\x7f/n.encoding.to_s]"#);
+        run_test(
+            r#"Regexp.new('([\x00-\xFF])', Regexp::IGNORECASE | Regexp::NOENCODING).encoding.to_s"#,
+        );
+        // union keeps BINARY when a part is BINARY-with-non-ASCII.
+        run_test(r#"Regexp.union(/abc/, /[\x00-\x7f]/n, /[\x80-\xBF]/n).encoding.to_s"#);
     }
 
     #[test]

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -438,12 +438,38 @@ pub(super) extern "C" fn concatenate_regexp(
     arg: *mut Value,
     len: usize,
 ) -> Option<Value> {
-    let mut res = String::new();
-    for i in 0..len {
-        let v = unsafe { *arg.sub(i) };
-        res += &v.to_s(&globals.store);
-    }
-    let inner = match RegexpInner::with_option(res, 0) {
+    use crate::value::rvalue::Encoding;
+    // Build the interpolated source as a String first, so each operand's
+    // bytes and encoding combine under the same rules as `"#{}"` — a
+    // non-ASCII embedded String (e.g. EUC-JP) then upgrades the regexp's
+    // encoding (`/#{euc_str}/.encoding == EUC-JP`).
+    let s_val = match concatenate_string_inner(vm, globals, arg, len) {
+        Ok(v) => v,
+        Err(err) => {
+            vm.set_error(err);
+            return None;
+        }
+    };
+    let inner = s_val.as_rstring_inner();
+    let bytes = inner.as_bytes().to_vec();
+    let enc = inner.encoding();
+    // The matching engine only understands UTF-8/ASCII; feed it a
+    // best-effort UTF-8 view while the raw bytes + encoding drive
+    // `Regexp#source` / `#encoding`.
+    let reg_str = String::from_utf8_lossy(&bytes).into_owned();
+    let onig_enc = if enc == Encoding::Ascii8 {
+        onigmo_regex::OnigmoEncoding::ASCII
+    } else {
+        onigmo_regex::OnigmoEncoding::UTF8
+    };
+    let inner = match RegexpInner::with_option_kcode_source(
+        reg_str,
+        0,
+        onig_enc,
+        None,
+        Some(enc),
+        Some(bytes),
+    ) {
         Ok(inner) => inner,
         Err(err) => {
             vm.set_error(err);

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -408,11 +408,13 @@ pub(crate) fn resolve_declared_encoding(
     // the matching engine sees.
     let has_non_ascii = source.iter().any(|&b| b >= 0x80);
     if option & RegexpInner::NOENCODING != 0 {
-        // `/.../n` (NOENCODING): BINARY when source has non-ASCII
-        // bytes, US-ASCII otherwise. CRuby's regex parser only
-        // pins to ASCII-8BIT when there's actual binary content
-        // — pure-ASCII patterns stay re-tag-free.
-        if has_non_ascii {
+        // `/.../n` (NOENCODING): BINARY when the source carries
+        // non-ASCII content — either raw bytes >= 0x80 or a `\xHH`
+        // escape decoding to one (`/\xc2\xa1/n` is BINARY) — US-ASCII
+        // otherwise. CRuby's regex parser only pins to ASCII-8BIT when
+        // there's actual binary content; pure-ASCII patterns stay
+        // re-tag-free.
+        if has_non_ascii || has_non_ascii_hex_escape(source) {
             return (Encoding::Ascii8, true);
         }
         return (Encoding::UsAscii, false);
@@ -454,6 +456,42 @@ fn source_encoding_fallback(
         None if has_non_ascii => (Encoding::Utf8, true),
         None => (Encoding::UsAscii, fixed_flag),
     }
+}
+
+/// Scan `source` for a `\xHH` hexadecimal escape whose byte value is
+/// non-ASCII (>= 0x80), e.g. `\xc2` or `\xFF`. Used by the `/.../n`
+/// (NOENCODING) path to pin the encoding to BINARY when the pattern
+/// embeds high bytes via escapes (`/\xc2\xa1/n.encoding == BINARY`).
+/// A literal escaped backslash (`\\`) is skipped so `\\xFF` is not
+/// mistaken for a high-byte escape.
+fn has_non_ascii_hex_escape(source: &[u8]) -> bool {
+    let mut i = 0;
+    while i + 1 < source.len() {
+        if source[i] != b'\\' {
+            i += 1;
+            continue;
+        }
+        match source[i + 1] {
+            b'x' => {
+                let mut j = i + 2;
+                let mut val: u32 = 0;
+                let mut n = 0;
+                while j < source.len() && n < 2 && source[j].is_ascii_hexdigit() {
+                    val = val * 16 + (source[j] as char).to_digit(16).unwrap();
+                    j += 1;
+                    n += 1;
+                }
+                if n > 0 && val >= 0x80 {
+                    return true;
+                }
+                i = j;
+            }
+            // Any other escaped char (incl. `\\`) consumes both bytes,
+            // so an escaped backslash can't start a spurious `\x`.
+            _ => i += 2,
+        }
+    }
+    false
 }
 
 /// Scan `src` for a `\u` escape (`\uXXXX` or `\u{...}`) whose

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -445,6 +445,10 @@ fn source_encoding_fallback(
     let fixed_flag = option & RegexpInner::FIXEDENCODING != 0;
     match source_encoding {
         Some(src) if has_non_ascii => (src, true),
+        // An ASCII-incompatible source encoding (UTF-16/32) is pinned
+        // even when the content is all 7-bit: such a string can never be
+        // re-interpreted as US-ASCII.
+        Some(src) if !src.is_ascii_compatible() => (src, true),
         Some(src) if fixed_flag => (src, true),
         Some(_) => (Encoding::UsAscii, false),
         None if has_non_ascii => (Encoding::Utf8, true),

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -20,6 +20,14 @@ pub struct Regexp(Value);
 #[derive(Clone, Debug)]
 pub struct RegexpInner {
     regex: Arc<Regex>,
+    /// The original regex *source* bytes, exactly as supplied (before
+    /// `\u{}` expansion and without any escaping of non-UTF-8 input),
+    /// in `declared_encoding`. The matching engine (`regex`) only ever
+    /// sees a UTF-8/ASCII view, but `Regexp#source` / `#==` / `#hash` /
+    /// `#inspect` / `#to_s` reflect these bytes so non-UTF-8 sources
+    /// (Shift_JIS / EUC-JP / binary) round-trip faithfully. `Arc` keeps
+    /// `RegexpInner::clone` cheap.
+    source: Arc<[u8]>,
     /// The encoding the matching engine runs under
     /// (`UTF8` / `ASCII`). Onigmo only exposes those two; richer
     /// encodings (EUC-JP, Shift_JIS, ISO-8859-*) fall through to
@@ -50,7 +58,7 @@ impl PartialEq for RegexpInner {
         if Arc::ptr_eq(&self.regex, &other.regex) {
             return true;
         }
-        self.as_str() == other.as_str()
+        self.source == other.source
             && self.encoding == other.encoding
             && self.declared_encoding == other.declared_encoding
     }
@@ -76,8 +84,24 @@ impl RegexpInner {
     pub const KCODE_SJIS: u32 = 1 << 10;
     pub const KCODE_MASK: u32 = Self::KCODE_UTF8 | Self::KCODE_EUCJP | Self::KCODE_SJIS;
 
+    /// The onigmo matching pattern (UTF-8/ASCII view, with `\u{}`
+    /// expanded). Use [`source_bytes`](Self::source_bytes) for the
+    /// CRuby-visible `Regexp#source`.
     pub fn as_str(&self) -> &str {
         self.regex.as_str()
+    }
+
+    /// The original source bytes (CRuby `Regexp#source`), in
+    /// `declared_encoding`.
+    pub fn source_bytes(&self) -> &[u8] {
+        &self.source
+    }
+
+    /// The source rendered as a `String` for display (`#inspect` /
+    /// `#to_s`). Valid-UTF-8 sources pass through unchanged; non-UTF-8
+    /// bytes are shown lossily (a rare edge for exotic-encoding regexps).
+    pub fn source_string(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.source)
     }
 
     pub fn encoding(&self) -> OnigmoEncoding {
@@ -373,13 +397,16 @@ fn expand_unicode_braces(src: &str) -> Result<String> {
 ///      *not* pinned. Such regexps freely combine with strings
 ///      of any ASCII-compatible encoding.
 pub(crate) fn resolve_declared_encoding(
-    reg_str: &str,
+    source: &[u8],
     option: u32,
     kcode: Option<u32>,
     source_encoding: Option<crate::value::Encoding>,
 ) -> (crate::value::Encoding, bool) {
     use crate::value::Encoding;
-    let has_non_ascii = reg_str.bytes().any(|b| b >= 0x80);
+    // Non-ASCII is decided on the *raw source* bytes (which may be
+    // non-UTF-8, e.g. a Shift_JIS pattern), not the escaped UTF-8 view
+    // the matching engine sees.
+    let has_non_ascii = source.iter().any(|&b| b >= 0x80);
     if option & RegexpInner::NOENCODING != 0 {
         // `/.../n` (NOENCODING): BINARY when source has non-ASCII
         // bytes, US-ASCII otherwise. CRuby's regex parser only
@@ -534,9 +561,30 @@ impl RegexpInner {
         kcode: Option<u32>,
         source_encoding: Option<crate::value::Encoding>,
     ) -> Result<Self> {
+        Self::with_option_kcode_source(reg_str, option, encoding, kcode, source_encoding, None)
+    }
+
+    /// As [`with_option_kcode`](Self::with_option_kcode) but with an
+    /// explicit raw `source` byte sequence (CRuby `Regexp#source`).
+    /// When `None`, the source is taken from `reg_str`'s bytes (the
+    /// common case — a UTF-8/ASCII pattern that *is* its own source).
+    /// `Regexp.new` on a non-UTF-8 String passes the original bytes here
+    /// so they survive instead of being escaped away.
+    pub fn with_option_kcode_source(
+        reg_str: impl Into<String>,
+        option: u32,
+        encoding: OnigmoEncoding,
+        kcode: Option<u32>,
+        source_encoding: Option<crate::value::Encoding>,
+        source: Option<Vec<u8>>,
+    ) -> Result<Self> {
         let reg_str: String = reg_str.into();
+        // Capture the source as written (before `\u{}` expansion); the
+        // caller may override with the true raw bytes for non-UTF-8 input.
+        let source: Arc<[u8]> =
+            source.map_or_else(|| Arc::from(reg_str.as_bytes()), Arc::from);
         let (mut declared_encoding, mut fixed_encoding) =
-            resolve_declared_encoding(&reg_str, option, kcode, source_encoding);
+            resolve_declared_encoding(&source, option, kcode, source_encoding);
         // CRuby pins the regex to UTF-8 when the source contains a
         // `\u` escape that decodes to a non-ASCII codepoint, even on
         // an otherwise pure-7-bit pattern (`/\u{1234}/.fixed_encoding?`
@@ -570,6 +618,7 @@ impl RegexpInner {
         {
             std::collections::hash_map::Entry::Occupied(entry) => Ok(RegexpInner {
                 regex: entry.get().clone(),
+                source,
                 encoding,
                 declared_encoding,
                 fixed_encoding,
@@ -582,6 +631,7 @@ impl RegexpInner {
                         entry.insert(regex.clone());
                         Ok(RegexpInner {
                             regex,
+                            source,
                             encoding,
                             declared_encoding,
                             fixed_encoding,
@@ -667,7 +717,7 @@ impl RegexpInner {
         // CRuby `rb_reg_to_s`: while the whole pattern is a single
         // wrapping option group `(?on-off:body)` (or `(?:body)`), fold
         // its flags into the displayed options and recurse on `body`.
-        let mut src = self.as_str().to_string();
+        let mut src = self.source_string().into_owned();
         loop {
             let b = src.as_bytes();
             if b.len() < 4 || b[0] != b'(' || b[1] != b'?' {
@@ -744,7 +794,7 @@ impl RegexpInner {
     pub fn inspect(&self) -> String {
         format!(
             "/{}/{}",
-            escape_unescaped_slashes(self.as_str()),
+            escape_unescaped_slashes(&self.source_string()),
             self.option_string()
         )
     }


### PR DESCRIPTION
## Summary

Follow-up to #734. Stores a regexp's **raw source bytes** separately from the onigmo matching pattern, which unblocks the remaining `core/regexp` encoding failures (non-UTF-8 sources, `Regexp.union`, `/n` BINARY, interpolation encoding, invalid-encoding match, and Regexp subclasses).

| category | before (post-#734) | after |
|---|---|---|
| core/matchdata | 0 failures | **0 failures, 0 errors** |
| core/regexp | 15 failures + 6 errors | **0 failures, 2 errors** |

The two remaining `core/regexp` errors are `Regexp.timeout` raising `Regexp::TimeoutError`, which needs real ReDoS-interrupt enforcement and is intentionally out of scope here. All 1700 lib unit tests pass; no regressions.

## Changes

### Raw source storage
`RegexpInner` now keeps the original source bytes (`Arc<[u8]>`, in `declared_encoding`) separately from the onigmo `Regex`, which only ever sees a UTF-8/ASCII view. `Regexp#source` / `#==` / `#hash` / `#inspect` / `#to_s` and `Regexp.union`'s ASCII check read these bytes, so:
- `Regexp.new` on a non-UTF-8 String (Shift_JIS / EUC-JP / binary) keeps the real bytes and adopts the input's encoding for `#source` / `#encoding`.
- `#source` reflects the source *as written*: `/\u{61}/.source` is `"\\u{61}"` (not the expanded `"a"`), and `/\u{61}/ == /a/` is false.

### Regexp.union
- An ASCII-incompatible source encoding (UTF-16/32) pins the regexp even for 7-bit content.
- Raises CRuby-exact `ArgumentError`: `"ASCII incompatible encoding: <enc>"` (incompatible meets pure-ASCII) and `"incompatible encodings: <a> and <b>"` (two conflicting non-ASCII encodings).

### Regexp#encoding
- `/.../n` pins to BINARY when the source embeds a high byte via a `\xHH` escape (`/\xc2\xa1/n`), and `Regexp.union` keeps the BINARY result instead of downgrading.
- An interpolated non-ASCII String upgrades the encoding: `/#{euc_str}/.encoding == EUC-JP` (the interpolated source's bytes + encoding combine like `"#{}"`).

### Regexp#match
- A subject String that is invalid in its own encoding raises `ArgumentError "invalid byte sequence in <enc>"` (was a confusing TypeError).

### Subclasses
- `Regexp.new`/`compile` on a subclass allocate an instance of it and run its `#initialize`: an overridden Ruby `#initialize` executes (its `super` reaches `Regexp#initialize`), and a subclass without one builds the data directly. `Regexp#initialize` is now a real private initializer (still rejects re-initializing a built regexp). Fixed a latent crash: `Regexp#initialize` needed arity `(1, 2)` so `try_arg(1)` is a valid frame slot under the JIT.

## Testing
New unit tests cover raw-source round-trip, `/\u{}/` source/`==`, `Regexp.union` ASCII-incompatible messages, `/n` BINARY, invalid-encoding match, interpolation encoding, and subclass `new`/`initialize`. Full `cargo test --lib` (1700) passes; `core/matchdata` and `core/regexp` (excluding the two timeout errors) are green; no regressions (per-run spec diffs).

## Deferred
`Regexp.timeout` / `Regexp::TimeoutError` enforcement (needs a ReDoS interrupt).

https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_