### PR TITLE
aarch64: port remaining inline-method JIT emitters

### DIFF
--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -1,8 +1,7 @@
 use std::ffi::c_void;
 
 use super::*;
-#[cfg(target_arch = "x86_64")]
-use jitgen::JitContext;
+use jitgen::{AbstractState, JitContext};
 use libffi::middle::{Arg, Cif, CodePtr, Type};
 
 // ---------------------------------------------------------------------------
@@ -422,8 +421,6 @@ enum ReadKind {
     F64,
 }
 
-#[cfg(target_arch = "x86_64")]
-
 fn fiddle_read_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -463,38 +460,22 @@ fn fiddle_read_inline(
         ReadKind::F64 => {
             let fret = state.def_F(dst);
             ir.inline(move |r#gen, _, labels, base| {
-                let deopt_label = &labels[deopt];
-                monoasm! { &mut r#gen.jit,
-                    sarq rdi, 1;
-                    testq rdi, rdi;
-                    jz deopt_label;
-                    movq xmm0, [rdi];
-                };
-                r#gen.store_fpr_into_xmm(fret, base);
+                r#gen.emit_fiddle_read_f64(fret, &labels[deopt], base);
             });
         }
         _ => {
+            // (byte width, signed) for the typed integer load.
+            let (width, signed) = match kind {
+                ReadKind::I8 => (1, true),
+                ReadKind::U8 => (1, false),
+                ReadKind::I16 => (2, true),
+                ReadKind::U16 => (2, false),
+                ReadKind::I32 => (4, true),
+                ReadKind::U32 => (4, false),
+                ReadKind::F64 => unreachable!(),
+            };
             ir.inline(move |r#gen, _, labels, _| {
-                let deopt_label = &labels[deopt];
-                monoasm! { &mut r#gen.jit,
-                    sarq rdi, 1;
-                    testq rdi, rdi;
-                    jz deopt_label;
-                };
-                match kind {
-                    ReadKind::I8 => monoasm! { &mut r#gen.jit, movsxb rax, [rdi]; },
-                    ReadKind::U8 => monoasm! { &mut r#gen.jit, movzxb rax, [rdi]; },
-                    ReadKind::I16 => monoasm! { &mut r#gen.jit, movsxw rax, [rdi]; },
-                    ReadKind::U16 => monoasm! { &mut r#gen.jit, movzxw rax, [rdi]; },
-                    ReadKind::I32 => monoasm! { &mut r#gen.jit, movsxl rax, [rdi]; },
-                    ReadKind::U32 => monoasm! { &mut r#gen.jit, movl rax, [rdi]; },
-                    ReadKind::F64 => unreachable!(),
-                };
-                // Tag as Fixnum: rax = (rax << 1) | 1.
-                monoasm! { &mut r#gen.jit,
-                    addq rax, rax;
-                    orq rax, 1;
-                };
+                r#gen.emit_fiddle_read_int(width, signed, &labels[deopt]);
             });
             state.def_reg2acc_fixnum(ir, GP::Rax, dst);
         }
@@ -509,8 +490,6 @@ enum WriteKind {
     Int32,
     F64,
 }
-
-#[cfg(target_arch = "x86_64")]
 
 fn fiddle_write_inline(
     state: &mut AbstractState,
@@ -546,35 +525,20 @@ fn fiddle_write_inline(
             let xsrc = state.load_xmm(ir, val_slot);
             let deopt = ir.new_deopt(state);
             ir.inline(move |r#gen, _, labels, base| {
-                let deopt_label = &labels[deopt];
-                r#gen.load_fpr_into_xmm0(xsrc, base);
-                monoasm! { &mut r#gen.jit,
-                    movq rax, rdi;
-                    sarq rdi, 1;
-                    testq rdi, rdi;
-                    jz deopt_label;
-                    movq [rdi], xmm0;
-                };
+                r#gen.emit_fiddle_write_f64(xsrc, &labels[deopt], base);
             });
         }
         _ => {
             state.load_fixnum(ir, val_slot, GP::Rsi);
             let deopt = ir.new_deopt(state);
+            let width = match kind {
+                WriteKind::Int8 => 1,
+                WriteKind::Int16 => 2,
+                WriteKind::Int32 => 4,
+                WriteKind::F64 => unreachable!(),
+            };
             ir.inline(move |r#gen, _, labels, _| {
-                let deopt_label = &labels[deopt];
-                monoasm! { &mut r#gen.jit,
-                    movq rax, rdi;
-                    sarq rdi, 1;
-                    testq rdi, rdi;
-                    jz deopt_label;
-                    sarq rsi, 1;
-                };
-                match kind {
-                    WriteKind::Int8 => monoasm! { &mut r#gen.jit, movb [rdi], rsi; },
-                    WriteKind::Int16 => monoasm! { &mut r#gen.jit, movw [rdi], rsi; },
-                    WriteKind::Int32 => monoasm! { &mut r#gen.jit, movl [rdi], rsi; },
-                    WriteKind::F64 => unreachable!(),
-                };
+                r#gen.emit_fiddle_write_int(width, &labels[deopt]);
             });
         }
     }
@@ -675,14 +639,14 @@ pub(super) fn init(globals: &mut Globals) {
         fiddle,
         "___read",
         fiddle_read,
-        inline_gen!(fiddle_read_inline),
+        inline_gen2!(fiddle_read_inline),
         2,
     );
     globals.define_builtin_module_inline_func(
         fiddle,
         "___write",
         fiddle_write,
-        inline_gen!(fiddle_write_inline),
+        inline_gen2!(fiddle_write_inline),
         3,
     );
     globals.define_builtin_module_func(fiddle, "___read_string", fiddle_read_string, 1);

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -17,7 +17,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         "succ",
         &["next"],
         succ,
-        inline_gen!(integer_succ),
+        inline_gen2!(integer_succ),
         0,
     );
     //globals.define_builtin_func(INTEGER_CLASS, "times", times, 0);
@@ -539,7 +539,6 @@ fn succ(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// The receiver-class guard already pins the receiver to a fixnum (a Bignum
 /// receiver deopts there); i63 overflow deopts to the interpreter, which
 /// returns a Bignum.
-#[cfg(target_arch = "x86_64")]
 fn integer_succ(
     state: &mut AbstractState,
     ir: &mut AsmIr,

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -107,7 +107,7 @@ pub(super) fn init(globals: &mut Globals) {
         STRING_CLASS,
         "getbyte",
         getbyte,
-        inline_gen!(string_getbyte),
+        inline_gen2!(string_getbyte),
         1,
     );
     globals.define_builtin_func_with(STRING_CLASS, "byteslice", byteslice, 1, 2, false);
@@ -116,7 +116,7 @@ pub(super) fn init(globals: &mut Globals) {
         STRING_CLASS,
         "setbyte",
         setbyte,
-        inline_gen!(string_setbyte),
+        inline_gen2!(string_setbyte),
         2,
     );
     globals.define_builtin_func_with_kw(
@@ -4047,7 +4047,6 @@ fn setbyte(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 /// otherwise — the interpreter handles `to_int` coercion / TypeError) and
 /// emits the load + bounds check inline. Out-of-range yields nil inline, so
 /// `while b = s.getbyte(i)` loops don't deopt at termination.
-#[cfg(target_arch = "x86_64")]
 fn string_getbyte(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -4077,7 +4076,6 @@ fn string_getbyte(
 /// JIT inliner for `String#setbyte`: guards both arguments to fixnums and
 /// emits the byte store inline. Frozen/chilled receivers and out-of-range
 /// indices deopt — the interpreter raises (or warns and unchills) there.
-#[cfg(target_arch = "x86_64")]
 fn string_setbyte(
     state: &mut AbstractState,
     ir: &mut AsmIr,

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -4276,6 +4276,201 @@ impl Codegen {
         );
     }
 
+    /// `Integer#succ` / `#next`: fixnum in Rdi (x4); tagged `+1` is `+2` on the
+    /// raw bits. Deopts on i63 overflow (interpreter returns a Bignum). aarch64
+    /// twin of x86 `addq;jo`.
+    pub(crate) fn emit_integer_succ(&mut self, deopt: &DestLabel) {
+        let rdi = GP::Rdi.a64().0; // x4
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            adds x(rdi), x(rdi), #(2u32);   // set NZCV
+        );
+        self.jit.bcond_label(monoasm::Cond::Vs, &deopt); // overflow -> deopt
+    }
+
+    /// `String#getbyte`: receiver String in Rdi (x4), fixnum index in Rsi (x3) →
+    /// Rax (x0) = byte tagged as a fixnum, or nil when the (negative-adjusted)
+    /// index is out of range. aarch64 twin of x86 `emit_string_getbyte`
+    /// (`cmovgt` → `csel`, `jae` → `b.ls` on the swapped operands; `ldrb`/`strb`
+    /// have no register-offset form here so the address is materialised first).
+    ///
+    /// ### destroy
+    /// - x0 (Rax), x1 (Rcx), x2 (Rdx), x3 (Rsi), x9
+    pub(crate) fn emit_string_getbyte(&mut self) {
+        let exit = self.jit.label();
+        // x4=recv(Rdi), x3=index(Rsi), x0=result(Rax), x1=data ptr(Rcx),
+        // x2=tmp(Rdx), x9=scratch
+        monoasm_arm64!(&mut self.jit,
+            asr x3, x3, #(1);                                // untag index
+            // len -> x0 (inline capa vs heap_len select)
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, #(STRING_INLINE_CAP as u32);
+            csel x0, x9, x0, gt;                             // capa>cap -> heap_len
+            // data ptr -> x1 (flags from the cmp above still live)
+            add x1, x4, #(RVALUE_OFFSET_INLINE as u32);
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            csel x1, x9, x1, gt;                             // capa>cap -> heap_ptr
+            // negative index counts back from the end
+            add x2, x3, x0;                                  // idx + len
+            cmp x3, #(0);
+            csel x3, x2, x3, lt;                             // idx<0 -> idx+len
+            // unsigned bound check (also catches a still-negative index)
+            cmp x0, x3;                                      // len vs idx
+            mov x0, #(NIL_VALUE);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ls, &exit); // len<=idx (unsigned) -> nil
+        monoasm_arm64!(&mut self.jit,
+            add x1, x1, x3;                                  // &data[idx]
+            ldrb w0, [x1];
+            lsl x0, x0, #(1);
+            add x0, x0, #(1);
+        );
+        self.jit.bind_label(exit);
+    }
+
+    /// `String#setbyte`: receiver String in Rdi (x4), fixnum index in Rsi (x3),
+    /// fixnum byte value in Rdx (x2). Deopts when the receiver is frozen or
+    /// chilled, copy-on-write shared, or the index is out of range (the
+    /// interpreter raises / warns there). Keeps the cached code-range
+    /// classification consistent with `RStringInner::set_byte`. aarch64 twin of
+    /// x86 `emit_string_setbyte`.
+    ///
+    /// ### destroy
+    /// - x0 (Rax), x1 (Rcx), x3 (Rsi), x9
+    pub(crate) fn emit_string_setbyte(&mut self, deopt: &DestLabel) {
+        let exit = self.jit.label();
+        let set_unknown = self.jit.label();
+        let deopt = deopt.clone();
+        // frozen (0b010) or chilled (0b100) -> deopt
+        monoasm_arm64!(&mut self.jit,
+            ldrh w0, [x4, #(RVALUE_OFFSET_FLAG as u32)];
+            mov x9, (0b110u64);
+            tst x0, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+        monoasm_arm64!(&mut self.jit,
+            asr x3, x3, #(1);                                // untag index
+            asr x2, x2, #(1);                                // untag byte value
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)]; // capa / shared tag
+            // shared (copy-on-write) buffer -> deopt (interpreter detaches)
+            mov x9, (crate::rvalue::STRING_SHARED_TAG as u64);
+            cmp x0, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &deopt);
+        monoasm_arm64!(&mut self.jit,
+            // len -> x0, data ptr -> x1 (inline vs heap select)
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, #(STRING_INLINE_CAP as u32);
+            csel x0, x9, x0, gt;
+            add x1, x4, #(RVALUE_OFFSET_INLINE as u32);
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            csel x1, x9, x1, gt;
+            // negative index counts back from the end
+            add x9, x3, x0;                                  // idx + len
+            cmp x3, #(0);
+            csel x3, x9, x3, lt;                             // idx<0 -> idx+len
+            // out of range (unsigned, covers still-negative) -> deopt
+            cmp x0, x3;                                      // len vs idx
+        );
+        self.jit.bcond_label(monoasm::Cond::Ls, &deopt); // len<=idx (unsigned)
+        monoasm_arm64!(&mut self.jit,
+            add x1, x1, x3;                                  // &data[idx]
+            strb w2, [x1];
+            // code range cache: poking an ASCII byte into a SevenBit string
+            // keeps SevenBit; anything else degrades to Unknown.
+            ldrb w9, [x4, #(crate::rvalue::STRING_CR_OFFSET as u32)];
+            cmp x9, #(crate::rvalue::CodeRange::SevenBit as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &set_unknown);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (0x80u64);
+            tst x2, x9;                                      // high bit set?
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &exit); // ASCII -> stays SevenBit
+        self.jit.bind_label(set_unknown);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, #(crate::rvalue::CodeRange::Unknown as u32);
+            strb w9, [x4, #(crate::rvalue::STRING_CR_OFFSET as u32)];
+        );
+        self.jit.bind_label(exit);
+    }
+
+    /// `Fiddle.___read` integer load: untag the pointer in Rdi (x4), deopt on
+    /// NULL, load a `width`-byte value (sign/zero-extended per `signed`), tag
+    /// the result as a fixnum in Rax (x0). aarch64 twin of x86
+    /// `emit_fiddle_read_int`; signed byte/half loads sign-extend via lsl+asr
+    /// since the macro has no `ldrsb`/`ldrsh`.
+    pub(crate) fn emit_fiddle_read_int(&mut self, width: u8, signed: bool, deopt: &DestLabel) {
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            asr x4, x4, #(1);     // untag ptr (Rdi == x4)
+            cbz x4, deopt;        // NULL -> deopt
+        );
+        match (width, signed) {
+            (1, true) => monoasm_arm64!(&mut self.jit,
+                ldrb w0, [x4]; lsl x0, x0, #(56); asr x0, x0, #(56);),
+            (1, false) => monoasm_arm64!(&mut self.jit, ldrb w0, [x4];),
+            (2, true) => monoasm_arm64!(&mut self.jit,
+                ldrh w0, [x4]; lsl x0, x0, #(48); asr x0, x0, #(48);),
+            (2, false) => monoasm_arm64!(&mut self.jit, ldrh w0, [x4];),
+            (4, true) => monoasm_arm64!(&mut self.jit, ldrsw x0, [x4];),
+            (4, false) => monoasm_arm64!(&mut self.jit, ldr w0, [x4];),
+            _ => unreachable!(),
+        }
+        // Tag as Fixnum: x0 = (x0 << 1) | 1.
+        monoasm_arm64!(&mut self.jit,
+            lsl x0, x0, #(1);
+            add x0, x0, #(1);
+        );
+    }
+
+    /// `Fiddle.___read` f64 load: untag the pointer in Rdi (x4), deopt on NULL,
+    /// load the double into `fret`. aarch64 twin of x86 `emit_fiddle_read_f64`.
+    pub(crate) fn emit_fiddle_read_f64(&mut self, fret: FPReg, deopt: &DestLabel, base: usize) {
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            asr x4, x4, #(1);
+            cbz x4, deopt;
+            ldr d0, [x4];
+        );
+        self.a64_d0_into_fpr(fret, base);
+    }
+
+    /// `Fiddle.___write` integer store: save the tagged pointer (the return
+    /// value) in Rax (x0), untag the pointer in Rdi (x4), deopt on NULL, untag
+    /// the value in Rsi (x3) and store its low `width` bytes. aarch64 twin of
+    /// x86 `emit_fiddle_write_int`.
+    pub(crate) fn emit_fiddle_write_int(&mut self, width: u8, deopt: &DestLabel) {
+        let deopt = deopt.clone();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x4;           // rax = tagged ptr (return value)
+            asr x4, x4, #(1);     // untag ptr
+            cbz x4, deopt;        // NULL -> deopt
+            asr x3, x3, #(1);     // untag value (Rsi == x3)
+        );
+        match width {
+            1 => monoasm_arm64!(&mut self.jit, strb w3, [x4];),
+            2 => monoasm_arm64!(&mut self.jit, strh w3, [x4];),
+            4 => monoasm_arm64!(&mut self.jit, str w3, [x4];),
+            _ => unreachable!(),
+        }
+    }
+
+    /// `Fiddle.___write` f64 store: load the source double into d0, save the
+    /// tagged pointer in Rax (x0), untag the pointer in Rdi (x4), deopt on NULL,
+    /// store the double. aarch64 twin of x86 `emit_fiddle_write_f64`.
+    pub(crate) fn emit_fiddle_write_f64(&mut self, xsrc: FPReg, deopt: &DestLabel, base: usize) {
+        let deopt = deopt.clone();
+        self.a64_fpr_into_d0(xsrc, base);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x4;           // rax = tagged ptr (return value)
+            asr x4, x4, #(1);     // untag ptr
+            cbz x4, deopt;        // NULL -> deopt
+            str d0, [x4];
+        );
+    }
+
     /// `def name; … end` — runtime::define_method(vm, globals, name, func_id).
     /// The Option<Value> result (None == error) is checked by the trailing
     /// HandleError. Bails when an xmm pool register is live (no save around the

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -374,6 +374,76 @@ impl Codegen {
         );
     }
 
+    /// `Fiddle.___read` integer load: untag the pointer in rdi, deopt on NULL,
+    /// load a `width`-byte value (sign/zero-extended per `signed`), tag the
+    /// result as a fixnum in rax.
+    pub(crate) fn emit_fiddle_read_int(&mut self, width: u8, signed: bool, deopt: &DestLabel) {
+        monoasm! { &mut self.jit,
+            sarq rdi, 1;
+            testq rdi, rdi;
+            jz deopt;
+        }
+        match (width, signed) {
+            (1, true) => monoasm! { &mut self.jit, movsxb rax, [rdi]; },
+            (1, false) => monoasm! { &mut self.jit, movzxb rax, [rdi]; },
+            (2, true) => monoasm! { &mut self.jit, movsxw rax, [rdi]; },
+            (2, false) => monoasm! { &mut self.jit, movzxw rax, [rdi]; },
+            (4, true) => monoasm! { &mut self.jit, movsxl rax, [rdi]; },
+            (4, false) => monoasm! { &mut self.jit, movl rax, [rdi]; },
+            _ => unreachable!(),
+        }
+        // Tag as Fixnum: rax = (rax << 1) | 1.
+        monoasm! { &mut self.jit,
+            addq rax, rax;
+            orq rax, 1;
+        }
+    }
+
+    /// `Fiddle.___read` f64 load: untag the pointer in rdi, deopt on NULL, load
+    /// the double into `fret`.
+    pub(crate) fn emit_fiddle_read_f64(&mut self, fret: FPReg, deopt: &DestLabel, base: usize) {
+        monoasm! { &mut self.jit,
+            sarq rdi, 1;
+            testq rdi, rdi;
+            jz deopt;
+            movq xmm0, [rdi];
+        }
+        self.store_fpr_into_xmm(fret, base);
+    }
+
+    /// `Fiddle.___write` integer store: save the tagged pointer (the return
+    /// value) in rax, untag the pointer in rdi, deopt on NULL, untag the value
+    /// in rsi and store its low `width` bytes.
+    pub(crate) fn emit_fiddle_write_int(&mut self, width: u8, deopt: &DestLabel) {
+        monoasm! { &mut self.jit,
+            movq rax, rdi;
+            sarq rdi, 1;
+            testq rdi, rdi;
+            jz deopt;
+            sarq rsi, 1;
+        }
+        match width {
+            1 => monoasm! { &mut self.jit, movb [rdi], rsi; },
+            2 => monoasm! { &mut self.jit, movw [rdi], rsi; },
+            4 => monoasm! { &mut self.jit, movl [rdi], rsi; },
+            _ => unreachable!(),
+        }
+    }
+
+    /// `Fiddle.___write` f64 store: load the source double into xmm0, save the
+    /// tagged pointer in rax, untag the pointer in rdi, deopt on NULL, store the
+    /// double.
+    pub(crate) fn emit_fiddle_write_f64(&mut self, xsrc: FPReg, deopt: &DestLabel, base: usize) {
+        self.load_fpr_into_xmm0(xsrc, base);
+        monoasm! { &mut self.jit,
+            movq rax, rdi;
+            sarq rdi, 1;
+            testq rdi, rdi;
+            jz deopt;
+            movq [rdi], xmm0;
+        }
+    }
+
     /// `Integer#%` by a positive power of two: `lhs & mask` on the tagged
     /// fixnum in rdi.
     pub(crate) fn emit_int_rem_pow2_mask(&mut self, mask: i64) {


### PR DESCRIPTION
## Summary

Several builtin inline JIT generators were registered with `inline_gen!`, which on aarch64 expands to a no-op (`noinline_gen`) — the inline asm was never ported, so calls fell back to a normal method dispatch. This ports the **lowest-cost** ones to real A64 inline assembly and switches them to `inline_gen2!` (asm available on both arches):

| Method | aarch64 emitter |
|---|---|
| `Integer#succ` / `#next` | `emit_integer_succ` |
| `String#getbyte` | `emit_string_getbyte` |
| `String#setbyte` | `emit_string_setbyte` |
| `Fiddle.___read` (int / f64) | `emit_fiddle_read_int` / `emit_fiddle_read_f64` |
| `Fiddle.___write` (int / f64) | `emit_fiddle_write_int` / `emit_fiddle_write_f64` |

The fiddle generators previously emitted x86 `monoasm!` directly inside their `ir.inline` closures. They're refactored into arch-neutral generators that call new `emit_*` `Codegen` methods, with mirrored x86 and aarch64 bodies (matching the convention used by the already-ported emitters).

## aarch64-specific handling

- Signed byte/half loads sign-extend via `lsl`+`asr` (the monoasm macro has no `ldrsb`/`ldrsh`/`sxtb`/`sxth`).
- `ldrb`/`strb` have no register-offset form in the macro, so the effective address is materialised with `add` first.
- Logic ops are register-only, so immediates go through scratch `x9`.
- Unsigned bound checks swap operands to use `b.ls` (`Hs`/`Lo` conditions aren't exposed).

## Remaining

Only `object_send` and `Struct`'s `gen_class_new_object` are still un-inlined on aarch64 (they depend on x86-only dispatch helpers — higher implementation cost).

## Testing

- Output verified against CRuby for `succ`/`getbyte`/`setbyte`, including edge cases (negative & out-of-range indices, heap-backed strings, code-range degradation).
- Existing `fiddle_read_write_inline_jit` test (hot loop over all widths, signed/unsigned, double) passes on aarch64.
- **Full lib test suite — 1884 tests — passes on arm64-apple-darwin.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)