### PR TITLE
proc/lambda: subclasses, to_s, curry, lambda?, `it` params, return semantics (+ each_line GC fix)

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -407,25 +407,6 @@ class File
 end
 
 class Proc
-  def curry(arity = nil)
-    arity ||= self.arity
-    arity = -arity - 1 if arity < 0
-    return self if arity == 0
-    orig = self
-    curried = nil
-    curried = lambda do |collected_args|
-      lambda do |*args|
-        new_args = collected_args + args
-        if new_args.size >= arity
-          orig.call(*new_args)
-        else
-          curried.call(new_args)
-        end
-      end
-    end
-    curried.call([])
-  end
-
   def >>(g)
     unless g.is_a?(Proc) || g.is_a?(Method) || g.respond_to?(:call, true)
       raise TypeError, "callable object is expected"

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -734,6 +734,4 @@ end
 class Proc
   def ==(other) = super
   alias eql? ==
-  def to_s = super
-  alias inspect to_s
 end

--- a/monoruby/src/ast/node.rs
+++ b/monoruby/src/ast/node.rs
@@ -166,6 +166,13 @@ pub struct BlockInfo {
     pub body: Box<Node>,
     pub lvar: LvarCollector,
     pub loc: Loc,
+    /// `true` when this block came from a lambda literal (`-> { ... }` /
+    /// `lambda { ... }`-style), `false` for an ordinary brace/`do` block,
+    /// method body, or class body. Both a lambda literal and a brace block
+    /// lower to `NodeKind::Lambda(BlockInfo)`, so this is the only signal
+    /// that distinguishes `foo(&-> {...})` (must stay a lambda) from
+    /// `foo {...}` when a block argument is compiled.
+    pub is_lambda: bool,
 }
 
 impl BlockInfo {
@@ -175,6 +182,7 @@ impl BlockInfo {
             body: Box::new(body),
             lvar,
             loc,
+            is_lambda: false,
         }
     }
 }
@@ -247,6 +255,12 @@ impl FormalParam {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParamKind {
     Param(String),
+    /// The implicit Ruby 3.4 `it` parameter (`proc { it }` /
+    /// `-> { it }`). Binds a single required local named `it` exactly
+    /// like `Param("it")`, but is flagged so `#parameters` reports it
+    /// anonymously (`[[:opt]]` / `[[:req]]`), matching CRuby — an
+    /// *explicit* `|it|` keeps its name.
+    ItParam,
     Post(Option<String>),
     Optional(String, Box<Node>), // name, default expr
     Rest(Option<String>),
@@ -924,10 +938,9 @@ impl Node {
         lvar: LvarCollector,
         loc: Loc,
     ) -> Self {
-        Node::new(
-            NodeKind::Lambda(Box::new(BlockInfo::new(params, body, lvar, loc))),
-            loc,
-        )
+        let mut info = BlockInfo::new(params, body, lvar, loc);
+        info.is_lambda = true;
+        Node::new(NodeKind::Lambda(Box::new(info)), loc)
     }
 
     pub fn is_splat(&self) -> bool {

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -32,7 +32,7 @@ mod module;
 mod nil_class;
 mod numeric;
 mod object;
-mod proc;
+pub(crate) mod proc;
 mod process;
 mod random;
 mod range;

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -94,6 +94,15 @@ fn fiber_yield_inline(
     if pos_num > 1 && jitgen::conv(args) as u32 > 4095 {
         return false;
     }
+    // `Fiber.yield` suspends this fiber: control returns to the resumer
+    // and arbitrary code (including GCs) runs while this frame stays live
+    // on the fiber's stack. Unlike a normal call, the inlined yield does
+    // not otherwise spill register/literal-resident slots, so the
+    // suspended frame would not be GC-complete and a collection in the
+    // resumer could free a value the frame still holds (e.g. an
+    // interpolation operand). Write the frame back (the standard GC
+    // safepoint) before yielding so every live slot is materialised.
+    state.exec_gc(ir, false);
     let using_xmm = state.get_using_xmm();
     let error = ir.new_error(state);
     ir.xmm_save(using_xmm);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3090,7 +3090,7 @@ fn to_enum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/clone.html]
 #[monoruby_builtin]
-fn dup(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     if let Some(module) = self_val.is_class_or_module() {
         if module.id() == BASIC_OBJECT_CLASS {
@@ -3103,7 +3103,21 @@ fn dup(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let dup_module = globals.store.duplicate_module(module.id());
         return Ok(dup_module.as_val());
     }
-    Ok(self_val.dup())
+    let copy = self_val.dup();
+    // Run the `initialize_dup` hook (default validates; a subclass may
+    // override it). Root `copy` across the dispatch (it allocates).
+    let temp = vm.temp_len();
+    vm.temp_push(copy);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("initialize_dup"),
+        copy,
+        &[self_val],
+        None,
+        None,
+    )?;
+    vm.temp_clear(temp);
+    Ok(copy)
 }
 
 ///
@@ -3114,12 +3128,30 @@ fn dup(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/clone.html]
 #[monoruby_builtin]
 fn clone_val(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(lfp.self_val().clone_value())
+    let self_val = lfp.self_val();
+    let copy = self_val.clone_value();
+    if self_val.is_class_or_module().is_some() {
+        return Ok(copy);
+    }
+    // Run the `initialize_clone` hook (default validates; a subclass may
+    // override it). Root `copy` across the dispatch (it allocates).
+    let temp = vm.temp_len();
+    vm.temp_push(copy);
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("initialize_clone"),
+        copy,
+        &[self_val],
+        None,
+        None,
+    )?;
+    vm.temp_clear(temp);
+    Ok(copy)
 }
 
 /// ### Kernel#define_singleton_method

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -6,7 +6,19 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Proc", PROC_CLASS, ObjTy::PROC);
-    globals.define_builtin_class_func_with_effect(PROC_CLASS, "new", new, 0, 0, Effect::CAPTURE);
+    // `rest` so that `SubclassOfProc.new(*args) { }` forwards the
+    // positional args to the subclass's `#initialize`.
+    let proc_meta = globals.store.get_metaclass(PROC_CLASS).id();
+    globals.define_builtin_funcs_with_effect(
+        proc_meta,
+        "new",
+        &[],
+        new,
+        0,
+        0,
+        true,
+        Effect::CAPTURE,
+    );
     globals.store[PROC_CLASS].clear_alloc_func();
     globals.define_builtin_funcs_with_kw(
         PROC_CLASS,
@@ -56,12 +68,25 @@ fn ruby2_keywords(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 /// [https://docs.ruby-lang.org/ja/latest/method/Proc/s/new.html]
 #[monoruby_builtin]
 fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    if let Some(bh) = lfp.block() {
-        let p = vm.generate_proc(globals, bh, pc)?;
-        Ok(p.into())
-    } else {
-        Err(MonorubyErr::create_proc_no_block())
+    let Some(bh) = lfp.block() else {
+        return Err(MonorubyErr::create_proc_no_block());
+    };
+    let p = vm.generate_proc(globals, bh, pc)?;
+    let class_id = lfp.self_val().as_class_id();
+    if class_id == PROC_CLASS {
+        return Ok(p.into());
     }
+    // A subclass of Proc: re-tag the freshly built proc with the
+    // subclass and run its `#initialize(*args)` (CRuby binds the block
+    // before `initialize`, so a custom `initialize` need not `super`).
+    let mut obj: Value = p.into();
+    obj.change_class(class_id);
+    let args: Vec<Value> = lfp.arg(0).as_array().iter().copied().collect();
+    let temp = vm.temp_len();
+    vm.temp_push(obj);
+    vm.invoke_method_inner(globals, IdentId::INITIALIZE, obj, &args, None, None)?;
+    vm.temp_clear(temp);
+    Ok(obj)
 }
 
 ///
@@ -479,6 +504,28 @@ mod tests {
                (-> () {}).to_s.include?(" (lambda)"),
                :foo.to_proc.to_s.include?("(&:foo)"),
                proc { }.inspect.start_with?("#<Proc:0x")]"##,
+        );
+    }
+
+    #[test]
+    fn proc_subclass_new() {
+        // A Proc subclass without a custom initialize.
+        run_test(r#"class PSubA < Proc; end; p = PSubA.new { 5 }; [p.is_a?(PSubA), p.call]"#);
+        // A subclass whose #initialize takes positional args (CRuby binds
+        // the block before #initialize, so it need not call super).
+        run_test(
+            r#"class PSubB < Proc; def initialize(a, b); @a = a; @b = b; end; attr_reader :a, :b; end
+               o = PSubB.new(:x, 2) { 9 }; [o.class.name, o.a, o.b, o.call]"#,
+        );
+        // dup / clone run initialize_dup / initialize_clone (and the
+        // result is an instance of the subclass).
+        run_test(
+            r#"class PSubC < Proc
+                 def initialize_dup(o); super; @tag = :dup; end
+                 def initialize_clone(o, **k); super; @tag = :clone; end
+                 attr_reader :tag
+               end
+               o = PSubC.new { 1 }; [o.dup.class.name, o.dup.tag, o.clone.tag]"#,
         );
     }
 

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -1049,6 +1049,33 @@ mod tests {
         ]);
     }
 
+    /// `return` semantics: a (non-lambda) Proc's `return` is a non-local
+    /// return to the method that created it (if still on the stack — else
+    /// LocalJumpError); a lambda's `return` exits the lambda itself.
+    #[test]
+    fn proc_return_semantics() {
+        run_tests(&[
+            // proc created & called in the same method: non-local return.
+            "def m; proc { return 7 }.call; 99; end; m",
+            // return from a block via `each`: non-local.
+            "def m; [1].each { return 5 }; 99; end; m",
+            // lambda return is local; the method continues.
+            "def m; lambda { return 8 }.call; 99; end; m",
+            "def m; ->(){ return 8 }.call; 99; end; m",
+            // a `lambda { }` brace block promoted by Kernel#lambda still
+            // returns locally.
+            "f = lambda { return 8 }; [f.call, 99]",
+            "g = ->(x){ return x*2; 999 }; g.call(5)",
+            // detached proc whose creation site already returned.
+            "def make; proc { return 3 }; end; (make.call rescue $!.class)",
+            // long return flowing through an intervening Proc#call.
+            "def inner; b = proc { return :good }; pr = ->x{ x.call }; pr.call(b); :bad; end; inner",
+            // break in a lambda exits the lambda with the value.
+            "->(){ break 11 }.call",
+            "lambda { break 12 }.call",
+        ]);
+    }
+
     /// `&:sym` passed as a block should materialize a Proc only
     /// on demand; capturing it back as `&blk` must work (used to
     /// fail with `not yet implemented: block handler …`).

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -21,6 +21,7 @@ pub(super) fn init(globals: &mut Globals) {
     );
     globals.define_builtin_func(PROC_CLASS, "binding", binding_, 0);
     globals.define_builtin_func(PROC_CLASS, "source_location", source_location, 0);
+    globals.define_builtin_funcs(PROC_CLASS, "to_s", &["inspect"], to_s, 0);
     globals.define_builtin_func(PROC_CLASS, "lambda?", lambda_, 0);
     globals.define_builtin_func(PROC_CLASS, "arity", proc_arity, 0);
     globals.define_builtin_func_with_kw(
@@ -157,6 +158,56 @@ fn source_location(
     } else {
         Ok(Value::nil())
     }
+}
+
+///
+/// ### Proc#to_s, Proc#inspect
+///
+/// - to_s -> String
+/// - inspect -> String
+///
+/// Returns `#<Proc:0xADDR FILE:LINE>` (plus ` (lambda)` for a lambda).
+/// The result has BINARY (ASCII-8BIT) encoding, matching CRuby.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Proc/i/to_s.html]
+#[monoruby_builtin]
+fn to_s(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let proc = Proc::new(self_);
+    let func_id = proc.func_id();
+    let is_lambda = !globals[func_id].is_block_style();
+    // A Method#to_proc proc reports the method's source location.
+    let src_fid = if func_id == METHOD_TO_PROC_BODY_FUNCID
+        && let Some(m) = proc.self_val().is_method()
+    {
+        m.func_id()
+    } else {
+        func_id
+    };
+    let mut s = format!("#<Proc:0x{:016x}", self_.id());
+    if func_id == SYMBOL_TO_PROC_BODY_FUNCID
+        && let Some(sym) = proc.self_val().try_symbol()
+    {
+        // `:foo.to_proc` renders as `#<Proc:0x..(&:foo) (lambda)>`.
+        s.push_str(&format!("(&:{})", sym));
+    } else if let Some(iseq) = globals.store.resolve_iseq(src_fid) {
+        let info = &globals.store[iseq];
+        s.push_str(&format!(
+            " {}:{}",
+            info.sourceinfo.file_name(),
+            info.sourceinfo.get_line(&info.loc)
+        ));
+    }
+    if is_lambda {
+        s.push_str(" (lambda)");
+    }
+    s.push('>');
+    Ok(Value::string_from_inner(
+        crate::value::rvalue::RStringInner::from_encoding(
+            s.as_bytes(),
+            crate::value::Encoding::Ascii8,
+        ),
+    ))
 }
 
 ///
@@ -416,6 +467,20 @@ fn proc_arity(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn proc_to_s() {
+        // The address differs per run, so check the stable invariants
+        // (CRuby: `#<Proc:0xADDR FILE:LINE [(lambda)]>`, BINARY encoding;
+        // `inspect` == `to_s`; `:sym.to_proc` shows `(&:sym)`).
+        run_test(r#"proc { }.to_s.encoding.to_s"#);
+        run_test(
+            r##"[proc { }.to_s.start_with?("#<Proc:0x"),
+               (-> () {}).to_s.include?(" (lambda)"),
+               :foo.to_proc.to_s.include?("(&:foo)"),
+               proc { }.inspect.start_with?("#<Proc:0x")]"##,
+        );
+    }
 
     #[test]
     fn proc_new() {

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -52,6 +52,141 @@ pub(super) fn init(globals: &mut Globals) {
     // trailing hash at the runtime level in a way that needs this marker,
     // so it's a safe no-op that returns the receiver.
     globals.define_builtin_func(PROC_CLASS, "ruby2_keywords", ruby2_keywords, 0);
+    globals.define_builtin_func_with(PROC_CLASS, "curry", curry, 0, 1, false);
+}
+
+/// Build a curry proc: a Proc backed by the shared native
+/// [`PROC_CURRY_BODY_FUNCID`] body, carrying its state — `[orig,
+/// collected, arity, lambda?]` — on the proc's `outer_lfp` self.
+pub(crate) fn make_curry_proc(
+    globals: &Globals,
+    orig: Value,
+    collected: Value,
+    arity: i64,
+    is_lambda: bool,
+    pc: BytecodePtr,
+) -> Value {
+    let state = Value::array_from_vec(vec![
+        orig,
+        collected,
+        Value::integer(arity),
+        Value::bool(is_lambda),
+    ]);
+    let frame = Lfp::heap_frame(state, globals[PROC_CURRY_BODY_FUNCID].meta());
+    Proc::from_outer(frame, PROC_CURRY_BODY_FUNCID, pc).into()
+}
+
+/// Whether `proc` reports `lambda? == true` (the curry procs inherit
+/// this from the proc they were built from). A curry proc reads its own
+/// stored flag; otherwise it is derived from the body's block-style.
+fn proc_is_lambda(globals: &Globals, proc: &Proc) -> bool {
+    if proc.func_id() == PROC_CURRY_BODY_FUNCID {
+        return proc.self_val().as_array()[3].as_bool();
+    }
+    !globals[proc.func_id()].is_block_style()
+}
+
+/// `Proc#arity`-equivalent for the curry-time default (mirrors
+/// `proc_arity`): a `Method#to_proc` proc reports the bound method's
+/// arity, everything else the func's arity.
+fn proc_arity_value(globals: &Globals, proc: &Proc) -> i64 {
+    if proc.func_id() == METHOD_TO_PROC_BODY_FUNCID
+        && let Some(m) = proc.self_val().is_method()
+    {
+        if m.method_missing_name().is_some() {
+            return -1;
+        }
+        return globals[m.func_id()].arity();
+    }
+    globals[proc.func_id()].arity()
+}
+
+///
+/// ### Proc#curry
+///
+/// - curry -> Proc
+/// - curry(arity) -> Proc
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Proc/i/curry.html]
+#[monoruby_builtin]
+fn curry(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let proc = Proc::new(self_val);
+    let is_lambda = proc_is_lambda(globals, &proc);
+    let arity_given = lfp.try_arg(0).filter(|v| !v.is_nil());
+    let mut arity = match arity_given {
+        Some(v) => v.coerce_to_int_i64(vm, globals)?,
+        None => proc_arity_value(globals, &proc),
+    };
+    if arity < 0 {
+        arity = -arity - 1;
+    }
+    // A lambda only accepts an arity its own signature can satisfy.
+    if is_lambda && globals.store.resolve_iseq(proc.func_id()).is_some() {
+        let params = globals[proc.func_id()].params();
+        let req = (params.req_num() + params.post_num()) as i64;
+        let has_rest = params.is_rest().is_some() && !params.rest_is_implicit();
+        let max = if has_rest {
+            i64::MAX
+        } else {
+            req + params.opt_num() as i64
+        };
+        if arity < req || arity > max {
+            return Err(MonorubyErr::wrong_number_of_arg_range(
+                arity as usize,
+                req as usize..=max as usize,
+            ));
+        }
+    }
+    if arity <= 0 {
+        return Ok(self_val);
+    }
+    Ok(make_curry_proc(
+        globals,
+        self_val,
+        Value::array_empty(),
+        arity,
+        is_lambda,
+        pc,
+    ))
+}
+
+/// Shared body of curry procs (see [`PROC_CURRY_BODY_FUNCID`]). Appends
+/// the call arguments to the collected ones; once enough are gathered
+/// it calls the original proc, otherwise it returns a further-curried
+/// proc that captures the accumulated arguments.
+#[monoruby_builtin]
+pub(crate) fn proc_curry_body(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let state = lfp
+        .outer()
+        .expect("proc_curry_body called without outer_lfp")
+        .self_val();
+    let st = state.as_array();
+    let orig = st[0];
+    let collected = st[1].as_array();
+    let arity = st[2].try_fixnum().unwrap();
+    let is_lambda = st[3].as_bool();
+    let mut new_args: Vec<Value> = collected.iter().copied().collect();
+    new_args.extend(lfp.arg(0).as_array().iter().copied());
+    if (new_args.len() as i64) >= arity {
+        let call = IdentId::get_id("call");
+        let bh = lfp.block();
+        vm.invoke_method_inner(globals, call, orig, &new_args, bh, None)
+    } else {
+        Ok(make_curry_proc(
+            globals,
+            orig,
+            Value::array_from_vec(new_args),
+            arity,
+            is_lambda,
+            pc,
+        ))
+    }
 }
 
 /// `Proc#ruby2_keywords` — no-op marker that returns self.
@@ -244,6 +379,10 @@ fn to_s(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn binding_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let proc = Proc::new(lfp.self_val());
+    // Curry procs have no Ruby-level binding (CRuby raises ArgumentError).
+    if proc.func_id() == PROC_CURRY_BODY_FUNCID {
+        return Err(MonorubyErr::argumenterr("Can't create Binding from C level Proc"));
+    }
     // For a Method#to_proc proc, the outer self is the Method object;
     // its binding's receiver must be the *method's* receiver (CRuby).
     if proc.func_id() == METHOD_TO_PROC_BODY_FUNCID
@@ -261,8 +400,7 @@ fn binding_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn lambda_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let proc = Proc::new(lfp.self_val());
-    let func_id = proc.func_id();
-    Ok(Value::bool(!globals[func_id].is_block_style()))
+    Ok(Value::bool(proc_is_lambda(globals, &proc)))
 }
 
 /// ### Proc#parameters
@@ -320,7 +458,11 @@ pub(crate) fn build_parameters(globals: &Globals, func_id: FuncId, is_lambda: bo
     let mut name_idx = 0;
     // required params
     for _ in 0..params.req_num() {
-        let entry = if let Some(Some(name)) = args_names.get(name_idx) {
+        // The implicit `it` parameter is reported anonymously
+        // (`[[:req]]` / `[[:opt]]`); an explicit `|it|` keeps its name.
+        let entry = if params.it_param() {
+            Value::array1(req_tag)
+        } else if let Some(Some(name)) = args_names.get(name_idx) {
             Value::array2(req_tag, Value::symbol(*name))
         } else {
             Value::array1(req_tag)
@@ -860,6 +1002,34 @@ mod tests {
             "proc {|a,b,c| a+b+c}.curry[1,2,3]",
             "->(a,b) { a + b }.curry[1][2]",
             "proc {|a,b,c| [a,b,c]}.curry(3)[1][2][3]",
+            // curry metadata: lambda-ness is inherited, parameters are
+            // anonymous rest, source_location is nil, arity is -1.
+            "->(a,b,c){}.curry.lambda?",
+            "proc {|a,b,c|}.curry.lambda?",
+            "->(a,b,c){}.curry(3).lambda?",
+            "->(a,b,c){}.curry.call(1).lambda?",
+            "proc {|a,b,c|}.curry.call(1).lambda?",
+            "->(a,b,c){}.curry.parameters",
+            "->(a,b,c){}.curry.source_location",
+            "->(a,b,c){}.curry.arity",
+            r#"(->(a,b,c){}.curry.binding rescue $!.class)"#,
+            // curry(arity) on a lambda validates the requested arity.
+            r#"(->(a,b,c){}.curry(2) rescue $!.class)"#,
+            r#"(->(a,b,c){}.curry(4) rescue $!.class)"#,
+            // proc curry tolerates extra args; lambda curry rejects them.
+            "proc {|a,b,c| (a||0)+(b||0)+(c||0)}.curry[1,2,3,4]",
+            r#"(->(a,b,c){ a+b+c }.curry[1,2,3,4] rescue $!.class)"#,
+            // `&-> {}` keeps the lambda-ness; `&proc {}` / a literal block
+            // stays a non-lambda.
+            "proc(&->{}).lambda?",
+            "proc(&proc{}).lambda?",
+            "Proc.new(&->(x){x}).lambda?",
+            "def amp(&b); b; end; amp(&->{}).lambda?",
+            "def amp2(&b); b; end; amp2 {}.lambda?",
+            // implicit `it` reports an anonymous parameter; explicit keeps it.
+            "eval('proc { it }').parameters",
+            "eval('lambda { it }').parameters",
+            "proc {|it| }.parameters",
             r#"->(&b) { b.call }.call { Integer }.equal?(Integer)"#,
             r#"
               step = ->(a, b, &blk) { a.step(b, &blk) }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -10420,6 +10420,32 @@ mod tests {
     }
 
     #[test]
+    fn string_shared_root_old_to_young_gc() {
+        // Regression for a generational-GC use-after-free in the CoW
+        // shared-string root edge. When an already-old String is first
+        // turned into a sharer (`scan`/`lines`/`[]` taking a long view via
+        // `ensure_shared_root`), it gains an edge to a freshly allocated
+        // (young) hidden root. That store must be write-barriered, and
+        // `young_child_exists` must report the root — otherwise a minor GC
+        // reclaims the root while the old sharer still views its buffer, and
+        // a later mark walks the freed root ("Dead object"). Aging the
+        // parents first, then sharing, then churning young allocations is
+        // what exposes it under `--features gc-stress`/`gc-verify`.
+        run_test(
+            r##"
+            parents = []
+            300.times { |i| parents << ("hello world " * 12 + i.to_s) }
+            8.times { GC.start }
+            parents.each { |s| s.scan(/\w+/) }
+            junk = []
+            400.times { |i| junk << ("z" * 70 + i.to_s) }
+            GC.start
+            parents.map { |s| s.length }.sum
+            "##,
+        );
+    }
+
+    #[test]
     fn string_chomp_record_separator() {
         // No-argument chomp/chomp! use `$/` (default "\n") as the separator.
         run_test(r#""abc\n".chomp"#);

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3963,7 +3963,7 @@ fn lines(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     // Zero-copy shared (CoW) line views, built eagerly before any block.
     let lines = build_lines(vm, globals, receiver, lfp.try_arg(0), chomp)?;
     if let Some(bh) = lfp.block() {
-        vm.invoke_block_iter1(globals, bh, lines.into_iter())?;
+        vm.invoke_block_iter1_rooted(globals, bh, lines)?;
         Ok(receiver)
     } else {
         Ok(Value::array_from_vec(lines))
@@ -4509,7 +4509,7 @@ fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
         // Zero-copy shared (CoW) line views, built eagerly before the
         // block runs so each view references the frozen root buffer.
         let lines = build_lines(vm, globals, receiver, lfp.try_arg(0), chomp)?;
-        vm.invoke_block_iter1(globals, bh, lines.into_iter())?;
+        vm.invoke_block_iter1_rooted(globals, bh, lines)?;
         Ok(receiver)
     } else {
         let mut args = vec![];
@@ -10393,6 +10393,30 @@ mod tests {
         ]);
         run_test_error(r##""hello".lines(:sym)"##);
         run_test_error(r##""hello".lines(false)"##);
+    }
+
+    #[test]
+    fn string_each_line_to_a_gc() {
+        // Regression for a GC use-after-free: `each_line`/`lines` build all
+        // line views eagerly into a `Vec<Value>`, then drive the block from
+        // it. The not-yet-yielded views must stay rooted — otherwise an
+        // allocation inside the block (here, `l[dedent..-1]` and the `map`
+        // result) can trigger a GC that sweeps a pending line, leaving a
+        // dangling pointer once it is finally collected into the result
+        // array. Reliably aborts under `--features gc-stress` without the
+        // fix (a remembered old array ends up holding a dead element).
+        run_test(
+            r##"
+            def fmt(ruby)
+              lines = ruby.each_line.to_a
+              dedent = 2
+              lines.map { |l| l[dedent..-1] }.join
+            end
+            r = ""
+            200.times { |i| r = fmt("      a#{i}\n      b\n") }
+            r
+            "##,
+        );
     }
 
     #[test]

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -495,6 +495,11 @@ struct BytecodeGen<'a> {
     mother: (ISeqId, ParamsInfo, usize),
     /// ID of the outer iseq.
     outer: Option<ISeqId>,
+    /// Whether this iseq is a *block* (block-style) rather than a lambda
+    /// or method. A block's `return`/`break` escape to the enclosing
+    /// method (non-local); a lambda's are local. Both have an `outer`,
+    /// so this is what distinguishes them.
+    block_style: bool,
     /// bytecode IR.
     ir: Vec<(BytecodeInst, Loc)>,
     /// the temp stack pointer for each bytecode instruction.
@@ -547,12 +552,14 @@ impl<'a> BytecodeGen<'a> {
         let func_id = info.func_id();
         let sourceinfo = info.sourceinfo.clone();
         let outer = info.outer;
+        let block_style = store[func_id].is_block_style();
         let mut codegen = Self {
             store,
             iseq_id,
             func_id,
             mother: (mother, mother_params, mother_outer),
             outer,
+            block_style,
             ir: vec![],
             sp: vec![],
             labels: BytecodeLabels::new(), // The first label is for redo.
@@ -693,6 +700,13 @@ impl<'a> BytecodeGen<'a> {
 
     fn is_block(&self) -> bool {
         self.outer.is_some()
+    }
+
+    /// A *real* block (not a lambda or method): its `return` / `break`
+    /// transfer control non-locally to the enclosing method. A lambda
+    /// has an `outer` too but returns/breaks locally, like a method.
+    fn is_escaping_block(&self) -> bool {
+        self.outer.is_some() && self.block_style
     }
 
     fn add_method(

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -259,7 +259,7 @@ impl<'a> BytecodeGen<'a> {
                 self.gen_method_call(method, None, arglist, safe_nav, UseMode2::Store(dst), loc)?;
             }
             NodeKind::Return(box val) => {
-                if self.is_block() {
+                if self.is_escaping_block() {
                     return self.gen_method_return(val, UseMode2::Store(dst));
                 } else {
                     return self.gen_return(val, UseMode2::Store(dst));
@@ -581,8 +581,13 @@ impl<'a> BytecodeGen<'a> {
                 } = match self.loops.last() {
                     Some(data) => data.clone(),
                     None => {
-                        if self.is_block() {
+                        if self.is_escaping_block() {
                             self.gen_block_break(val, use_mode)?;
+                            return Ok(());
+                        } else if self.outer.is_some() {
+                            // `break` in a lambda exits the lambda with the
+                            // value, like `return` (not a non-local break).
+                            self.gen_return(val, use_mode)?;
                             return Ok(());
                         } else {
                             return Err(self.escape_from_eval("break", loc));
@@ -652,7 +657,7 @@ impl<'a> BytecodeGen<'a> {
                 return Ok(());
             }
             NodeKind::Return(box val) => {
-                if self.is_block() {
+                if self.is_escaping_block() {
                     self.gen_method_return(val, use_mode)?;
                 } else {
                     self.gen_return(val, use_mode)?;

--- a/monoruby/src/bytecodegen/method_call/arguments.rs
+++ b/monoruby/src/bytecodegen/method_call/arguments.rs
@@ -273,7 +273,20 @@ impl<'a> BytecodeGen<'a> {
 
     fn block_arg(&mut self, block: Node, loc: Loc) -> Result<Option<FuncId>> {
         match block.kind {
-            NodeKind::Lambda(box block) => return Ok(Some(self.handle_block(vec![], block)?)),
+            // A brace/`do` block *and* a lambda literal both lower to
+            // `NodeKind::Lambda`. When the source was a lambda literal
+            // passed as a block argument (`foo(&-> { ... })`) it must stay
+            // a *lambda* (method-style func) so the resulting block/Proc
+            // reports `lambda? == true` and keeps strict arity; an ordinary
+            // block stays block-style. (See core/proc/lambda_spec "preserved
+            // when passing a Proc with & ...".)
+            NodeKind::Lambda(box block) => {
+                return Ok(Some(if block.is_lambda {
+                    self.handle_lambda(block)?
+                } else {
+                    self.handle_block(vec![], block)?
+                }));
+            }
             NodeKind::LocalVar(0, proc_local) => {
                 let dst = self.push().into();
                 if let Some(local) = self.refer_local(&proc_local) {

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1382,8 +1382,21 @@ pub(super) extern "C" fn err_divide_by_zero(vm: &mut Executor) {
     vm.err_divide_by_zero();
 }
 
-pub(super) extern "C" fn err_method_return(vm: &mut Executor, _globals: &mut Globals, val: Value) {
-    let target_lfp = vm.cfp().outermost_lfp();
+pub(super) extern "C" fn err_method_return(vm: &mut Executor, globals: &mut Globals, val: Value) {
+    // `return` is only compiled to a method-return inside a block (a
+    // brace/`do` block — a lambda literal returns locally). At runtime
+    // the same block may have been promoted to a lambda by `Kernel#lambda`
+    // (`set_method_style`), in which case `return` exits the lambda
+    // itself rather than the creation-site method. So the unwind target
+    // is decided here from the frame's *current* style: a real block
+    // returns non-locally to its home method (`outermost_lfp`), a lambda
+    // returns from its own frame.
+    let cfp = vm.cfp();
+    let target_lfp = if globals[cfp.lfp().func_id()].is_block_style() {
+        cfp.outermost_lfp()
+    } else {
+        cfp.lfp()
+    };
     vm.set_error(MonorubyErr::method_return(val, target_lfp));
 }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2019,10 +2019,19 @@ impl Executor {
         )
         .ok_or_else(|| {
             let err = self.take_error();
-            // MethodReturn that escapes a Proc#call means the target method
-            // has already returned — convert to LocalJumpError.
-            if let MonorubyErrKind::MethodReturn(val, _) = err.kind() {
-                MonorubyErr::localjumperr_with_val("unexpected return", *val)
+            // A `return` inside a (non-lambda) Proc unwinds to the method
+            // that created it. If that method's frame is still on the
+            // stack, let the `MethodReturn` keep propagating so it exits
+            // there (a non-local return — `proc { return }.call`, or a
+            // "long return" flowing through an intervening `Proc#call`).
+            // If the creation-site method has already returned, the frame
+            // is gone and the return is a `LocalJumpError`.
+            if let MonorubyErrKind::MethodReturn(val, target_lfp) = err.kind() {
+                if self.is_frame_on_stack(*target_lfp) {
+                    err
+                } else {
+                    MonorubyErr::localjumperr_with_val("unexpected return", *val)
+                }
             } else {
                 err
             }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1845,6 +1845,45 @@ impl Executor {
         Ok(())
     }
 
+    /// Like [`invoke_block_iter1`], but for an *eagerly materialised*
+    /// `Vec<Value>` of freshly allocated heap objects (e.g. the line views
+    /// built by `String#each_line` / `#lines`). Unlike a lazy iterator —
+    /// where each element is created just before it is yielded and only
+    /// the current one is live — every element here already exists, so the
+    /// not-yet-yielded ones must be kept reachable: a block allocation can
+    /// otherwise trigger a GC that sweeps a pending element, leaving a
+    /// dangling pointer once it is finally yielded. We root the whole batch
+    /// on the temp stack and index into it (re-reading through the rooted
+    /// slot each step, since `invoke_block` may itself push temps).
+    pub(crate) fn invoke_block_iter1_rooted(
+        &mut self,
+        globals: &mut Globals,
+        bh: BlockHandler,
+        values: Vec<Value>,
+    ) -> Result<()> {
+        let base = self.temp_len();
+        for v in &values {
+            self.temp_push(*v);
+        }
+        let data = match self.get_block_data(globals, bh) {
+            Ok(data) => data,
+            Err(err) => {
+                self.temp_clear(base);
+                return Err(err);
+            }
+        };
+        let mut result = Ok(());
+        for i in 0..values.len() {
+            let val = self.temp_at(base + i);
+            if let Err(err) = self.invoke_block(globals, &data, &[val]) {
+                result = Err(err);
+                break;
+            }
+        }
+        self.temp_clear(base);
+        result
+    }
+
     /*pub(crate) fn invoke_block_iter_with_index1(
         &mut self,
         globals: &mut Globals,

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -203,6 +203,28 @@ impl Executor {
             (vm, cfp) = Self::try_prev_cfp(vm, cfp)?;
         }
     }
+
+    /// Whether `target` is the LFP of a frame still live on the current
+    /// control-frame chain (walking parent fibers too). Used to decide
+    /// whether a `MethodReturn` escaping a `Proc#call` can still unwind
+    /// to its creation-site method (a non-local return) or whether that
+    /// method has already returned — in which case the return is a
+    /// `LocalJumpError`. A promoted (heap) home frame is matched because
+    /// `move_frame_to_heap` redirects its on-stack `cfp.lfp()` to the
+    /// heap copy.
+    pub(crate) fn is_frame_on_stack(&self, target: Lfp) -> bool {
+        let mut vm: &Executor = self;
+        let mut cfp = self.cfp();
+        loop {
+            if cfp.lfp() == target {
+                return true;
+            }
+            match Self::try_prev_cfp(vm, cfp) {
+                Some((v, prev)) => (vm, cfp) = (v, prev),
+                None => return false,
+            }
+        }
+    }
 }
 
 ///

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -417,6 +417,14 @@ impl Globals {
             METHOD_TO_PROC_BODY_FUNCID,
             globals.define_builtin_func_rest(OBJECT_CLASS, "", method_to_proc_body)
         );
+        assert_eq!(
+            PROC_CURRY_BODY_FUNCID,
+            globals.define_builtin_func_rest(
+                OBJECT_CLASS,
+                "",
+                crate::builtins::proc::proc_curry_body
+            )
+        );
         globals.random.init_with_seed(None);
         gvar::init_builtin_gvars(&mut globals);
         crate::builtins::init_builtins(&mut globals);

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -436,6 +436,7 @@ impl Store {
             body: Box::new(result.node),
             lvar: LvarCollector::new(),
             loc: Loc::default(),
+            is_lambda: false,
         };
         let compile_info = Store::handle_args(info, vec![])?;
         let fid = self.new_iseq_method(
@@ -528,6 +529,7 @@ impl Store {
             body: Box::new(result.node),
             lvar: LvarCollector::new(),
             loc,
+            is_lambda: false,
         };
         let compile_info = Store::handle_args(info, vec![])?;
         self.new_block(outer, compile_info, false, loc, result.source_info)
@@ -996,6 +998,7 @@ impl Store {
         let mut block_param = None;
         let mut for_param_info = vec![];
         let mut forwarding = false;
+        let mut it_param = false;
         for (dst_outer, dst_reg, _name) in for_params {
             for_param_info.push(ForParamInfo::new(dst_outer, dst_reg, args_names.len()));
             args_names.push(None);
@@ -1006,6 +1009,14 @@ impl Store {
                 ParamKind::Param(name) => {
                     args_names.push(Some(IdentId::get_id_from_string(name)));
                     required_num += 1;
+                }
+                ParamKind::ItParam => {
+                    // Implicit `it`: bind a required local named `it` (so
+                    // the body's `it` reads resolve), but flag it so
+                    // `#parameters` omits the name.
+                    args_names.push(Some(IdentId::get_id("it")));
+                    required_num += 1;
+                    it_param = true;
                 }
                 ParamKind::Destruct(names) => {
                     expand.push((args_names.len(), destruct_args.len(), names.len()));
@@ -1096,6 +1107,7 @@ impl Store {
             kw_rest_param,
             block_param,
             forwarding,
+            it_param,
         );
         let compile_info = CompileInfo::new(
             body,

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -532,7 +532,12 @@ impl Store {
             is_lambda: false,
         };
         let compile_info = Store::handle_args(info, vec![])?;
-        self.new_block(outer, compile_info, false, loc, result.source_info)
+        // eval'd code is block-style: a `return` / `break` in the string
+        // escapes to the enclosing method, like a block (not locally like
+        // a lambda). eval bodies and lambdas are otherwise both
+        // method-style (no own params), so this flag is what keeps their
+        // non-local-vs-local `return` semantics apart.
+        self.new_block(outer, compile_info, true, loc, result.source_info)
     }
 
     pub(crate) fn new_builtin_func(

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -369,6 +369,16 @@ pub(crate) const SYMBOL_TO_PROC_BODY_FUNCID: FuncId = FuncId::new(3);
 ///
 pub(crate) const METHOD_TO_PROC_BODY_FUNCID: FuncId = FuncId::new(4);
 
+///
+/// Pre-assigned FuncId for the shared body of the procs produced by
+/// `Proc#curry` / `Method#curry`. The curry state — `[orig, collected,
+/// arity, lambda?]` — lives on the proc's `outer_lfp` self; the body
+/// (`crate::builtins::proc::proc_curry_body`) reads it, appends the call
+/// args, and either invokes `orig` or returns a further-curried proc.
+/// A constant FuncId lets `#lambda?` / `#binding` recognise curry procs.
+///
+pub(crate) const PROC_CURRY_BODY_FUNCID: FuncId = FuncId::new(5);
+
 #[monoruby_builtin]
 pub(crate) fn enum_yielder(
     vm: &mut Executor,

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -682,6 +682,9 @@ pub(crate) struct ParamsInfo {
     pub kw_rest: Option<SlotId>,
     pub block_param: Option<IdentId>,
     forwarding: bool,
+    /// `true` when the sole parameter is the implicit `it` (Ruby 3.4).
+    /// `#parameters` then reports it without a name.
+    it_param: bool,
 }
 
 impl ParamsInfo {
@@ -697,6 +700,7 @@ impl ParamsInfo {
         kw_rest: Option<SlotId>,
         block_param: Option<IdentId>,
         forwarding: bool,
+        it_param: bool,
     ) -> Self {
         ParamsInfo {
             required_num,
@@ -710,7 +714,14 @@ impl ParamsInfo {
             kw_rest,
             block_param,
             forwarding,
+            it_param,
         }
+    }
+
+    /// Whether the sole parameter is the implicit `it` (reported
+    /// anonymously by `#parameters`).
+    pub(crate) fn it_param(&self) -> bool {
+        self.it_param
     }
 
     pub fn new_attr_reader() -> Self {
@@ -730,6 +741,7 @@ impl ParamsInfo {
             kw_rest: None,
             block_param: None,
             forwarding: false,
+            it_param: false,
         }
     }
 
@@ -763,6 +775,7 @@ impl ParamsInfo {
             },
             block_param: None,
             forwarding: false,
+            it_param: false,
         }
     }
 

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -959,6 +959,7 @@ impl<'pr> Lowerer<'pr> {
                             body: Box::new(body),
                             lvar: LvarCollector::new(),
                             loc: body_loc,
+                            is_lambda: false,
                         }),
                     },
                     loc,
@@ -1722,6 +1723,7 @@ impl<'pr> Lowerer<'pr> {
                     body: Box::new(body),
                     lvar: class_lvars,
                     loc,
+                    is_lambda: false,
                 })
             }
             Err(e) => {
@@ -2891,6 +2893,7 @@ impl<'pr> Lowerer<'pr> {
                     body: Box::new(body),
                     lvar: method_lvars,
                     loc,
+                    is_lambda: false,
                 });
                 let kind = match singleton_receiver {
                     Some(recv) => NodeKind::SingletonMethodDef(Box::new(recv), name, info),
@@ -2946,7 +2949,7 @@ impl<'pr> Lowerer<'pr> {
                             let ip_loc = location_to_loc(&ip.location());
                             this.lvars.insert("it");
                             vec![crate::ast::FormalParam {
-                                kind: ParamKind::Param("it".to_string()),
+                                kind: ParamKind::ItParam,
                                 loc: ip_loc,
                             }]
                         }
@@ -2973,6 +2976,7 @@ impl<'pr> Lowerer<'pr> {
                         body: Box::new(body),
                         lvar: lambda_lvars,
                         loc,
+                        is_lambda: true,
                     })),
                     loc,
                 })
@@ -3048,7 +3052,7 @@ impl<'pr> Lowerer<'pr> {
                             let ip_loc = location_to_loc(&ip.location());
                             this.lvars.insert("it");
                             vec![crate::ast::FormalParam {
-                                kind: ParamKind::Param("it".to_string()),
+                                kind: ParamKind::ItParam,
                                 loc: ip_loc,
                             }]
                         }
@@ -3075,6 +3079,7 @@ impl<'pr> Lowerer<'pr> {
                         body: Box::new(body),
                         lvar: block_lvars,
                         loc,
+                        is_lambda: false,
                     })),
                     loc,
                 })

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -923,7 +923,18 @@ impl alloc::GCBox for RValue {
         // (see `is_promotable`); each accesses its matching union field.
         unsafe {
             match self.ty() {
-                ObjTy::STRING | ObjTy::BIGNUM | ObjTy::FLOAT => false,
+                // A shared (CoW) substring keeps its hidden frozen root
+                // alive — `mark_children` marks it, so `young_child_exists`
+                // MUST report it too. Otherwise a remembered old sharer with
+                // a still-young root is dropped from the remembered set and
+                // re-armed; a later minor GC then frees the unreachable root
+                // while the sharer still points at it, and the next major's
+                // `mark_children` walks that freed root ("Dead object").
+                ObjTy::STRING => self
+                    .as_rstring()
+                    .shared_root()
+                    .is_some_and(|root| is_young(root, alloc)),
+                ObjTy::BIGNUM | ObjTy::FLOAT => false,
                 ObjTy::OBJECT => self
                     .as_object()
                     .iter()

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -2243,6 +2243,14 @@ fn ensure_shared_root(parent: &mut Value) -> (Value, *const u8) {
             root,
         },
     };
+    // `parent` now holds an edge to the freshly allocated (young) `root`.
+    // If `parent` is already old, this is an un-barriered old→young store:
+    // a later minor GC would reclaim `root` while `parent` still views its
+    // buffer, and a subsequent mark of `parent` would walk the freed root
+    // ("Dead object"). Record the edge — this (and a sharer's clone) is the
+    // only path that gives a String an outgoing reference, mirrored by
+    // `young_child_exists`/`is_promotable`.
+    parent.write_barrier(root);
     (root, ptr)
 }
 


### PR DESCRIPTION
Improves `core/proc` conformance and fixes a GC use-after-free found along the way. Each commit is self-contained.

## Commits

- **proc: Proc#to_s / #inspect include source location and (lambda)** — native `Proc#to_s`/`#inspect` rendering `#<Proc:0x.. FILE:LINE [(lambda)]>` (BINARY encoding), `(&:sym)` for symbol-to-procs.
- **proc: Proc.new honours subclasses; dup/clone run initialize hooks** — `SubclassOfProc.new(*args) { }` re-classes the proc and runs the subclass `#initialize`; `dup`/`clone` invoke `initialize_dup`/`initialize_clone`→`initialize_copy`.
- **string: root eagerly-built each_line/lines views across block GC** — fixes a generational-GC use-after-free: `String#each_line`/`#lines` materialise all line views into a `Vec<Value>` then drive the block from it; the not-yet-yielded views were unrooted, so a block allocation could sweep one and leave a dangling pointer (deterministic abort under `--features gc-stress`). Adds `invoke_block_iter1_rooted`.
- **proc: native curry, lambda? preservation through &, anonymous `it`** — `&-> { }` keeps its lambda-ness (new `BlockInfo::is_lambda`); implicit `it` reports anonymous `[[:opt]]`/`[[:req]]` from `#parameters` (new `ParamKind::ItParam`); native `Proc#curry`/`Method#curry` whose procs inherit lambda-ness and report `[[:rest]]` / `nil` source_location / raise on `#binding` / `arity -1`, matching CRuby.
- **proc: correct return/break semantics for procs and lambdas** — a Proc's `return` is a non-local return to its still-live creation site (else `LocalJumpError`); a lambda's `return`/`break` are local. Runtime-dispatched in `err_method_return` so `lambda { }` brace blocks promoted by `Kernel#lambda` return locally.

## Testing

- Full lib suite passes (1703 tests), including a gc-stress regression test for the each_line fix.
- ruby/spec: `core/proc/{curry,lambda,parameters}_spec`, `core/method/curry_spec`, `core/kernel/proc_spec` pass with 0 failures; `core/kernel/lambda_spec` 3 errors→0; `language/break_spec` 12 errors→0. Baseline-compared: no regressions in proc/lambda/next specs.
- Curry / return / lambda behaviours cross-checked byte-identical to CRuby 4.0.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_