### PR TITLE
Implement ObjectSpace finalizers and Kernel#at_exit

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -987,9 +987,6 @@ module Kernel
     nil
   end
 
-  def at_exit(&block)
-  end
-
   # Prevent CRuby's bundled_gems.rb from patching require with warning
   # logic.  monoruby provides its own implementations of formerly-bundled
   # gems (fiddle, strscan, etc.) so the warnings are not applicable.
@@ -1281,12 +1278,26 @@ module ObjectSpace
     0
   end
 
+  # Register a finalizer for +obj+. The finalizer (a callable or block,
+  # invoked with the object's id) is run at program termination. monoruby
+  # never runs finalizers asynchronously at GC time, which the spec
+  # explicitly permits. The actual registry lives in the runtime; the
+  # private +__register_finalizer+ primitive records the pair.
   def self.define_finalizer(obj, *args, &block)
-    [0, block || args.first]
+    callable = block || args[0]
+    if callable.nil?
+      raise ArgumentError, "wrong number of arguments (given 1, expected 2)"
+    end
+    unless callable.respond_to?(:call)
+      raise ArgumentError, "no _id2ref or finalizer is given; must respond to #call"
+    end
+    # The primitive returns the effective callable: the one already
+    # registered when an equal finalizer was given before, else +callable+.
+    [0, __register_finalizer(obj, callable)]
   end
 
   def self.undefine_finalizer(obj)
-    obj
+    __unregister_finalizer(obj)
   end
 
   def self.garbage_collect(**opts)

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -158,6 +158,17 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_module_func_with(kernel_class, "abort", abort, 0, 1, false);
     globals.define_builtin_module_func_with(kernel_class, "exit", exit, 0, 1, false);
     globals.define_builtin_module_func_with(kernel_class, "exit!", exit_bang, 0, 1, false);
+    globals.define_builtin_module_func(kernel_class, "at_exit", at_exit, 0);
+    // Registry primitives backing `ObjectSpace.define_finalizer` /
+    // `undefine_finalizer` (the public methods live in startup.rb, which
+    // handles argument validation and the return value).
+    globals.define_private_builtin_func(kernel_class, "__register_finalizer", register_finalizer, 2);
+    globals.define_private_builtin_func(
+        kernel_class,
+        "__unregister_finalizer",
+        unregister_finalizer,
+        1,
+    );
     globals.define_builtin_module_func_with_kw(
         kernel_class,
         "warn",
@@ -3104,6 +3115,7 @@ fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         return Ok(dup_module.as_val());
     }
     let copy = self_val.dup();
+    copy_finalizers(globals, self_val.id(), copy.id());
     // Run the `initialize_dup` hook (default validates; a subclass may
     // override it). Root `copy` across the dispatch (it allocates).
     let temp = vm.temp_len();
@@ -3118,6 +3130,19 @@ fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     )?;
     vm.temp_clear(temp);
     Ok(copy)
+}
+
+/// Re-register every finalizer attached to `from` (an object id) onto
+/// `to`, so that `dup`/`clone` copies of an object inherit its
+/// finalizers, matching CRuby.
+fn copy_finalizers(globals: &mut Globals, from: u64, to: u64) {
+    let copied: Vec<(u64, Value)> = globals
+        .finalizers
+        .iter()
+        .filter(|(k, _)| *k == from)
+        .map(|(_, callable)| (to, *callable))
+        .collect();
+    globals.finalizers.extend(copied);
 }
 
 ///
@@ -3135,6 +3160,7 @@ fn clone_val(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let copy = self_val.clone_value();
+    copy_finalizers(globals, self_val.id(), copy.id());
     if self_val.is_class_or_module().is_some() {
         return Ok(copy);
     }
@@ -3152,6 +3178,98 @@ fn clone_val(
     )?;
     vm.temp_clear(temp);
     Ok(copy)
+}
+
+///
+/// ### Kernel#at_exit
+///
+/// - at_exit { ... } -> Proc
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/at_exit.html]
+#[monoruby_builtin]
+fn at_exit(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let Some(bh) = lfp.block() else {
+        return Err(MonorubyErr::argumenterr("called without a block"));
+    };
+    let proc = vm.generate_proc(globals, bh, pc)?;
+    let proc = proc.as_val();
+    globals.at_exit_handlers.push(proc);
+    Ok(proc)
+}
+
+///
+/// `ObjectSpace.define_finalizer` registry primitive (private).
+///
+/// Validation of the callable (`respond_to?(:call)`) happens in the Ruby
+/// wrapper; here we reject non-reference objects, warn about a
+/// self-referencing finalizer, deduplicate, and record the `(object id,
+/// callable)` pair (run at program termination). Returns the effective
+/// callable — the originally-registered one when a duplicate is given.
+#[monoruby_builtin]
+fn register_finalizer(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let obj = lfp.arg(0);
+    let callable = lfp.arg(1);
+    // Immediates (Integer, Symbol, Float-flonum, nil, true, false) have
+    // no stable per-object identity, so a finalizer cannot be attached.
+    if obj.is_packed_value() {
+        return Err(MonorubyErr::argumenterr(format!(
+            "cannot define finalizer for {}",
+            obj.get_real_class_name(&globals.store)
+        )));
+    }
+    // CRuby warns when the finalizer closes over (or is bound to) the very
+    // object being finalized, since that keeps it alive until exit.
+    let references_self = if let Some(p) = callable.is_proc() {
+        p.self_val().id() == obj.id()
+    } else if let Some(m) = callable.is_method() {
+        m.receiver().id() == obj.id()
+    } else {
+        false
+    };
+    if references_self {
+        vm.ruby_warn(globals, "warning: finalizer references object to be finalized")?;
+    }
+    // A finalizer `==` to one already registered for this object is
+    // recorded only once; the originally-registered callable is returned.
+    let id = obj.id();
+    let existing: Vec<Value> = globals
+        .finalizers
+        .iter()
+        .filter(|(k, _)| *k == id)
+        .map(|(_, c)| *c)
+        .collect();
+    for c in existing {
+        if vm.invoke_eq(globals, c, callable)? {
+            return Ok(c);
+        }
+    }
+    globals.finalizers.push((id, callable));
+    Ok(callable)
+}
+
+///
+/// `ObjectSpace.undefine_finalizer` registry primitive (private).
+///
+#[monoruby_builtin]
+fn unregister_finalizer(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let obj = lfp.arg(0);
+    // CRuby refuses to mutate the finalizer set of a frozen object.
+    if obj.is_frozen() {
+        return Err(MonorubyErr::cant_modify_frozen(&globals.store, obj));
+    }
+    let id = obj.id();
+    globals.finalizers.retain(|(k, _)| *k != id);
+    Ok(obj)
 }
 
 /// ### Kernel#define_singleton_method
@@ -6243,5 +6361,41 @@ mod tests {
             o.inspect
             "#,
         );
+    }
+
+    #[test]
+    fn objectspace_define_finalizer() {
+        // Returns `[0, callable]`; `[0]` is comparable across runtimes.
+        run_test(r#"ObjectSpace.define_finalizer(Object.new, ->(id){ id })[0]"#);
+        run_test(r#"ObjectSpace.define_finalizer(Object.new){ |id| id }[0]"#);
+        // A bound method is an acceptable callable.
+        run_test(
+            r#"
+            h = Object.new
+            def h.finalize(id); end
+            ObjectSpace.define_finalizer(Object.new, h.method(:finalize))[0]
+            "#,
+        );
+        // undefine_finalizer returns its argument.
+        run_test(r#"o = Object.new; ObjectSpace.undefine_finalizer(o).equal?(o)"#);
+    }
+
+    #[test]
+    fn objectspace_define_finalizer_errors() {
+        // callable must respond to #call
+        run_test_error(r#"ObjectSpace.define_finalizer(Object.new, Object.new)"#);
+        // finalizer cannot be attached to a non-reference (immediate)
+        run_test_error(r#"ObjectSpace.define_finalizer(:sym){ 1 }"#);
+        // undefine on a frozen object raises FrozenError
+        run_test_error(r#"o = Object.new; o.freeze; ObjectSpace.undefine_finalizer(o)"#);
+    }
+
+    #[test]
+    fn kernel_at_exit() {
+        // `at_exit` returns the registered Proc.
+        run_test(r#"at_exit { }.is_a?(Proc)"#);
+        run_test(r#"at_exit { }.lambda?"#);
+        // `at_exit` without a block raises ArgumentError.
+        run_test_error(r#"at_exit"#);
     }
 }

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -511,6 +511,58 @@ pub(crate) fn cmp_teq_values_bool_no_opt(
 }
 
 impl Executor {
+    /// Run `Kernel#at_exit` handlers (LIFO) and `ObjectSpace` finalizers
+    /// at program termination. Invoked once from `Globals::run` after the
+    /// script body finishes, regardless of how it finished.
+    ///
+    /// Each handler is dispatched via `#call`, matching CRuby: at_exit
+    /// blocks are Procs, finalizers may be any callable (Proc, Method, or
+    /// an object with `call`). Finalizers receive the object's id.
+    ///
+    /// Errors raised inside a handler do not abort the remaining ones:
+    /// a `SystemExit` (`exit` called from within a handler) is swallowed,
+    /// and any other exception is reported as a warning when `$VERBOSE`
+    /// is not `nil`, then execution continues with the next handler.
+    pub(crate) fn run_exit_handlers(&mut self, globals: &mut Globals) {
+        if globals.at_exit_handlers.is_empty() && globals.finalizers.is_empty() {
+            return;
+        }
+        let call = IdentId::get_id("call");
+        // at_exit handlers run in reverse registration order.
+        while let Some(handler) = globals.at_exit_handlers.pop() {
+            if let Err(err) = self.invoke_method_inner(globals, call, handler, &[], None, None) {
+                self.report_exit_handler_error(globals, err, "at_exit");
+            }
+        }
+        // Finalizers run last. Draining the vector (rather than iterating a
+        // snapshot) lets a finalizer define further finalizers that then
+        // run too, matching CRuby.
+        while let Some((id, callable)) = globals.finalizers.pop() {
+            let arg = Value::integer(id as i64);
+            if let Err(err) = self.invoke_method_inner(globals, call, callable, &[arg], None, None) {
+                self.report_exit_handler_error(globals, err, "finalizer");
+            }
+        }
+    }
+
+    /// Report (or swallow) an error escaping an `at_exit`/finalizer handler.
+    fn report_exit_handler_error(&mut self, globals: &mut Globals, err: MonorubyErr, kind: &str) {
+        // `exit` from within a handler simply stops that handler; the
+        // remaining handlers still run.
+        if matches!(err.kind(), MonorubyErrKind::SystemExit(_)) {
+            return;
+        }
+        // CRuby only warns about a finalizer exception when `$VERBOSE`
+        // is not `nil`.
+        let verbose = globals
+            .get_gvar(IdentId::get_id("$VERBOSE"))
+            .is_some_and(|v| !v.is_nil());
+        if verbose {
+            let msg = format!("warning: Exception in {kind}: {}", err.message());
+            let _ = self.ruby_warn(globals, &msg);
+        }
+    }
+
     /// Emit a Ruby warning by writing to `$stderr`.
     pub(crate) fn ruby_warn(&mut self, globals: &mut Globals, msg: &str) -> Result<()> {
         let stderr_id = IdentId::get_id("$stderr");

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -149,6 +149,17 @@ pub struct Globals {
     /// signal runs a Ruby `Proc`, is ignored, or lowers to the default
     /// exception. See doc/signal_handling.md A7.
     pub(crate) signal_handlers: Vec<crate::codegen::signal_table::SignalDisposition>,
+    /// `Kernel#at_exit` handler Procs, run in LIFO order at program
+    /// termination. Held here as GC roots: they are reachable only from
+    /// this table yet must survive until the program exits.
+    pub(crate) at_exit_handlers: Vec<Value>,
+    /// `ObjectSpace.define_finalizer` finalizers: `(object identity,
+    /// callable)`. Keyed by the raw `Value` bits of the object (its
+    /// `object_id`); the callable is invoked with that id at program
+    /// termination. The callables are GC roots (see `mark`). monoruby
+    /// runs finalizers only at exit, never asynchronously at GC time,
+    /// which the spec explicitly permits.
+    pub(crate) finalizers: Vec<(u64, Value)>,
     /// stats for deoptimization
     #[cfg(feature = "profile")]
     deopt_stats: HashMap<(FuncId, bytecodegen::BcIndex), usize>,
@@ -187,6 +198,15 @@ impl alloc::GC<RValue> for Globals {
             if let crate::codegen::signal_table::SignalDisposition::Handler(v) = disp {
                 v.mark(alloc);
             }
+        }
+        // `at_exit` handlers and `ObjectSpace` finalizer callables are GC
+        // roots: nothing else references them, yet they must survive until
+        // they run at program termination.
+        for v in &self.at_exit_handlers {
+            v.mark(alloc);
+        }
+        for (_, v) in &self.finalizers {
+            v.mark(alloc);
         }
     }
 }
@@ -370,6 +390,8 @@ impl Globals {
             },
             invokers,
             enum_block_arity: Vec::new(),
+            at_exit_handlers: Vec::new(),
+            finalizers: Vec::new(),
             #[cfg(feature = "profile")]
             deopt_stats: HashMap::default(),
             #[cfg(feature = "profile")]
@@ -584,6 +606,13 @@ impl Globals {
         let mut executor = Executor::init(self, &program_name)?;
         executor.init_stack_limit(self);
         let res = executor.exec_script(self, code, path);
+        // Run `at_exit` handlers and `ObjectSpace` finalizers before the
+        // process leaves. This must happen even when `res` is a
+        // `SystemExit` (raised by `Kernel#exit`) or an uncaught
+        // exception — CRuby runs both on any normal-ish termination.
+        // `Kernel#exit!` / `Process.exit!` bypass this by calling
+        // `std::process::exit` directly and never returning here.
+        executor.run_exit_handlers(self);
         let _ = self.flush_stdout();
         #[cfg(any(feature = "profile", feature = "jit-log"))]
         self.show_stats();


### PR DESCRIPTION
## Summary

Replaces the no-op `at_exit` / `ObjectSpace.define_finalizer` / `undefine_finalizer` stubs with a working implementation that runs handlers at program termination. This fixes the core/method and core/unboundmethod **"copies the finalizer"** specs and resolves core/objectspace/undefine_finalizer.

| spec | before | after |
|---|---|---|
| core/method dup/clone | finalizer copy missing | **0 failures** |
| core/unboundmethod dup/clone | finalizer copy missing | **0 failures** |
| core/objectspace/undefine_finalizer | 2 failures | **0 failures** |
| core/objectspace/define_finalizer | 5 failures | 2 failures* |

\* The two remaining define_finalizer specs ("defines same finalizer only once" / "returns the defined finalizer") depend on `Proc#==` treating `p.dup == p` as `true`, which monoruby does not yet implement. The dedup logic here is already correct and will pass once `Proc#==` is fixed.

## Changes

### Runtime state (`globals.rs`)
- `Globals` gains `at_exit_handlers: Vec<Value>` and `finalizers: Vec<(u64, Value)>` registries, both marked as **GC roots** — the callables are reachable only from these tables yet must survive until they run.
- `Globals::run` invokes `Executor::run_exit_handlers` after the script body finishes — on normal completion, on `SystemExit` (from `Kernel#exit`), and on an uncaught exception. `exit!` / `Process.exit!` still bypass this by exiting the process directly.

### Exit handling (`executor/op.rs`)
- `run_exit_handlers`: at_exit handlers run **LIFO**, finalizers run afterwards. The finalizer registry is **drained** so a finalizer that defines another finalizer still runs. `exit` inside a handler stops that handler only; any other exception is reported as a warning when `$VERBOSE` is not `nil`, then the next handler runs.

### Builtins (`builtins/kernel.rs`, `builtins/startup.rb`)
- `Kernel#at_exit` registers its block (returns the Proc; raises `ArgumentError` without a block).
- `ObjectSpace.define_finalizer` validates the callable responds to `#call`, rejects non-reference receivers, warns on a self-referencing finalizer, deduplicates equal finalizers, and returns `[0, callable]`.
- `ObjectSpace.undefine_finalizer` raises `FrozenError` on a frozen object.
- `dup` / `clone` copy an object's finalizers to the new object (integrated with the existing `initialize_dup` / `initialize_clone` hooks).

## Scope note
Advanced at_exit semantics — exit-status propagation when a handler raises, and `$!`/`$@` access inside handlers — are intentionally out of scope here (handlers "warn and continue"). The basic functionality (LIFO ordering, return value, run-on-exit, continue-on-error) works.

## Testing
- New unit tests for define_finalizer / undefine_finalizer / at_exit value and error semantics.
- Full `cargo test --lib` passes (1700+ tests, no regressions).
- Spec results verified with the debug binary as shown above.

https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_