### PR TITLE
Kernel#dup/#clone: skip the copy-hook dispatch for default hooks

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -215,9 +215,15 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "eql?", eql_, 1);
     globals.define_builtin_func(kernel_class, "dup", dup, 0);
     globals.define_builtin_func_with(kernel_class, "clone", clone_val, 0, 1, false);
-    globals.define_private_builtin_func(kernel_class, "initialize_copy", initialize_copy, 1);
-    globals.define_private_builtin_func(kernel_class, "initialize_clone", initialize_clone, 1);
-    globals.define_private_builtin_func(kernel_class, "initialize_dup", initialize_clone, 1);
+    let init_copy_fid =
+        globals.define_private_builtin_func(kernel_class, "initialize_copy", initialize_copy, 1);
+    let init_clone_fid =
+        globals.define_private_builtin_func(kernel_class, "initialize_clone", initialize_clone, 1);
+    let init_dup_fid =
+        globals.define_private_builtin_func(kernel_class, "initialize_dup", initialize_clone, 1);
+    globals
+        .store
+        .set_default_copy_hooks(init_copy_fid, init_dup_fid, init_clone_fid);
     globals.define_builtin_funcs_rest(kernel_class, "enum_for", &["to_enum"], to_enum);
     globals.define_builtin_func_rest(kernel_class, "extend", extend);
     globals.define_builtin_inline_func(
@@ -3116,13 +3122,25 @@ fn dup(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     }
     let copy = self_val.dup();
     copy_finalizers(globals, self_val.id(), copy.id());
+    // When the class uses the default (no-op) copy hooks, skip the hook
+    // dispatch entirely and return the raw shallow copy — `dup` always
+    // produces a same-class copy, so the default `initialize_copy`
+    // validation would always pass. This is the hot path for
+    // `String#dup`, `Object#dup`, … (CRuby skips it the same way).
+    let version = Globals::class_version();
+    if globals
+        .store
+        .uses_default_copy_hooks(copy.class(), version)
+    {
+        return Ok(copy);
+    }
     // Run the `initialize_dup` hook (default validates; a subclass may
     // override it). Root `copy` across the dispatch (it allocates).
     let temp = vm.temp_len();
     vm.temp_push(copy);
     vm.invoke_method_inner(
         globals,
-        IdentId::get_id("initialize_dup"),
+        IdentId::INITIALIZE_DUP,
         copy,
         &[self_val],
         None,
@@ -3164,13 +3182,22 @@ fn clone_val(
     if self_val.is_class_or_module().is_some() {
         return Ok(copy);
     }
+    // Skip the no-op copy-hook dispatch when the class uses the default
+    // hooks (see `dup` / `uses_default_copy_hooks`).
+    let version = Globals::class_version();
+    if globals
+        .store
+        .uses_default_copy_hooks(copy.class(), version)
+    {
+        return Ok(copy);
+    }
     // Run the `initialize_clone` hook (default validates; a subclass may
     // override it). Root `copy` across the dispatch (it allocates).
     let temp = vm.temp_len();
     vm.temp_push(copy);
     vm.invoke_method_inner(
         globals,
-        IdentId::get_id("initialize_clone"),
+        IdentId::INITIALIZE_CLONE,
         copy,
         &[self_val],
         None,
@@ -6397,5 +6424,35 @@ mod tests {
         run_test(r#"at_exit { }.lambda?"#);
         // `at_exit` without a block raises ArgumentError.
         run_test_error(r#"at_exit"#);
+    }
+
+    #[test]
+    fn dup_clone_copy_hooks() {
+        // Default-hook classes copy correctly (the fast path that skips
+        // the no-op `initialize_copy`/`dup`/`clone` dispatch).
+        run_test(r#"s = +"abc"; t = s.dup; t << "d"; [s, t]"#);
+        run_test(r#"["x".freeze.dup.frozen?, "x".freeze.clone.frozen?]"#);
+        // A class with custom copy hooks still has them invoked.
+        run_test(
+            r#"class CH
+                 attr_accessor :tag
+                 def initialize_dup(o); super; @tag = :dup; end
+                 def initialize_clone(o, **); super; @tag = :clone; end
+               end
+               c = CH.new
+               [c.dup.tag, c.clone.tag]"#,
+        );
+        // A custom `initialize_copy` (reached via both dup and clone) runs.
+        run_test(
+            r#"class CC
+                 attr_accessor :n
+                 def initialize_copy(o); super; @n = (o.n || 0) + 1; end
+               end
+               c = CC.new; c.n = 10
+               [c.dup.n, c.clone.n]"#,
+        );
+        // Array's builtin `initialize_copy` (alias of replace) keeps dup a
+        // shallow, independent copy.
+        run_test(r#"a = [1, 2, 3]; b = a.dup; b << 4; [a, b]"#);
     }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -81,6 +81,11 @@ pub struct Store {
     /// FuncId of the default `BasicObject#!=`, used to recognize that an
     /// unredefined `!=` may be computed as `!(a == b)` without dispatch.
     default_neq: Option<FuncId>,
+    /// FuncIds of the default `initialize_copy` / `initialize_dup` /
+    /// `initialize_clone` builtins. `Kernel#dup` / `#clone` compare a
+    /// class's resolved hooks against these to recognize the no-op case
+    /// and skip the copy-hook dispatch. Set once during builtin init.
+    default_copy_hooks: Option<[FuncId; 3]>,
     /// Global method cache: memoizes `name` × `class` → method-table
     /// entry lookups, cleared as a whole when class_version moves on.
     /// In a `RefCell` because lookups happen behind `&Store` (including
@@ -200,6 +205,7 @@ impl Store {
             classes: ClassInfoTable::new(),
             inline_info: InlineTable::default(),
             default_neq: None,
+            default_copy_hooks: None,
             method_cache: RefCell::new(GlobalMethodCache::default()),
         }
     }
@@ -772,6 +778,47 @@ impl Store {
     ///
     pub(crate) fn set_default_neq(&mut self, fid: FuncId) {
         self.default_neq = Some(fid);
+    }
+
+    /// Record the FuncIds of the default `initialize_copy` /
+    /// `initialize_dup` / `initialize_clone` builtins (see
+    /// `uses_default_copy_hooks`).
+    pub(crate) fn set_default_copy_hooks(&mut self, copy: FuncId, dup: FuncId, clone: FuncId) {
+        self.default_copy_hooks = Some([copy, dup, clone]);
+    }
+
+    ///
+    /// `class_id` (its whole ancestor chain) uses the *default*
+    /// `initialize_copy` / `initialize_dup` / `initialize_clone` builtins,
+    /// i.e. none of them is user-overridden. When true, `Kernel#dup` /
+    /// `#clone` can return the raw shallow copy without dispatching the
+    /// (no-op) copy hook — a hot-path win for `String#dup` and friends.
+    ///
+    /// Memoized per class_version (same pattern as `no_to_str`): any
+    /// method (re)definition bumps class_version and invalidates the memo.
+    /// `version` must be the current class_version.
+    ///
+    pub(crate) fn uses_default_copy_hooks(&self, class_id: ClassId, version: u32) -> bool {
+        if self[class_id].default_copy_at() == Some(version) {
+            return true;
+        }
+        let Some([copy, dup, clone]) = self.default_copy_hooks else {
+            return false;
+        };
+        let resolves_to = |name: IdentId, default: FuncId| {
+            self.search_method_by_class_id(class_id, name)
+                .and_then(|e| e.func_id())
+                == Some(default)
+        };
+        if resolves_to(IdentId::INITIALIZE_COPY, copy)
+            && resolves_to(IdentId::INITIALIZE_DUP, dup)
+            && resolves_to(IdentId::INITIALIZE_CLONE, clone)
+        {
+            self[class_id].set_default_copy_at(version);
+            true
+        } else {
+            false
+        }
     }
 
     ///

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -302,6 +302,14 @@ pub struct ClassInfo {
     /// dispatch costs a load instead of a method-table probe per call.
     ///
     match_method_at: std::cell::Cell<Option<(u32, FuncId)>>,
+    ///
+    /// Version-stamped memo: as of class_version `v`, this class (its whole
+    /// ancestor chain) uses the *default* `initialize_copy` /
+    /// `initialize_dup` / `initialize_clone` builtins (i.e. none is
+    /// user-overridden), so `Kernel#dup` / `#clone` may skip the no-op
+    /// copy-hook dispatch and return the raw shallow copy.
+    ///
+    default_copy_at: std::cell::Cell<Option<u32>>,
 }
 
 /// C-level allocator function pointer. Given a class id (and a globals
@@ -395,6 +403,7 @@ impl ClassInfo {
             no_to_str_at: std::cell::Cell::new(None),
             neq_basic_at: std::cell::Cell::new(None),
             match_method_at: std::cell::Cell::new(None),
+            default_copy_at: std::cell::Cell::new(None),
         }
     }
 
@@ -416,6 +425,7 @@ impl ClassInfo {
             no_to_str_at: std::cell::Cell::new(None),
             neq_basic_at: std::cell::Cell::new(None),
             match_method_at: std::cell::Cell::new(None),
+            default_copy_at: std::cell::Cell::new(None),
         }
     }
 
@@ -445,6 +455,14 @@ impl ClassInfo {
 
     pub(super) fn set_match_method_at(&self, version: u32, fid: FuncId) {
         self.match_method_at.set(Some((version, fid)));
+    }
+
+    pub(super) fn default_copy_at(&self) -> Option<u32> {
+        self.default_copy_at.get()
+    }
+
+    pub(super) fn set_default_copy_at(&self, version: u32) {
+        self.default_copy_at.set(Some(version));
     }
 
     pub(crate) fn set_alloc_func(&mut self, f: AllocFunc) {


### PR DESCRIPTION
## Summary

Fixes a large performance regression introduced by PR #737 in `Kernel#dup` / `#clone`, which showed up in ruby-bench's **ruby-xor** (and any dup-heavy workload).

PR #737 made `dup`/`clone` **unconditionally** invoke the `initialize_dup`/`initialize_clone` hook via a full Ruby method dispatch on every call. For the common case — a class that hasn't overridden `initialize_copy`/`initialize_dup`/`initialize_clone` — that hook is a no-op (the default `initialize_copy` only validates the copy is the same class, always true for dup/clone), yet the dispatch **roughly doubled** the cost of `dup`/`clone`.

### Measured (this repo, x86_64-linux, release, interleaved A/B)
| | `String#dup` ×5M | ruby-xor median |
|---|---|---|
| #737 (dispatch every call) | ~1114ms | ~12.7ms |
| this PR (skip default hooks) | ~482ms (**2.3× faster**) | ~10.2ms |

`dup` is back to the pre-#737 native-copy speed; ruby-xor recovers accordingly.

## Approach

Special-case the default hooks, mirroring how `allocate` is handled (per-class, **not** a global flag — builtin classes such as `Array` legitimately define a custom `initialize_copy`, so a global "redefined" flag would be tripped at startup and the optimization would never engage):

- Record the FuncIds of the default `initialize_copy`/`dup`/`clone` builtins at init (`Store::set_default_copy_hooks`).
- `Store::uses_default_copy_hooks(class, version)` reports whether a class's whole ancestor chain still resolves these three to the defaults, **memoized per `class_version`** on `ClassInfo` (same pattern as `no_to_str`; any method (re)definition bumps `class_version` and invalidates the memo).
- `dup` / `clone` return the raw shallow copy when the hooks are default, and only dispatch when a class overrides one of them.
- The remaining dispatch path now uses the interned `IdentId::INITIALIZE_DUP` / `INITIALIZE_CLONE` constants instead of `IdentId::get_id(...)` (which took a global RwLock write per call).

## Correctness (verified against CRuby)
- Subclasses overriding `initialize_dup`/`initialize_clone`/`initialize_copy` still have them invoked.
- `Array#dup` (custom builtin `initialize_copy` = `replace`) stays a shallow independent copy; `String#dup` independent; `clone` keeps frozen state, `dup` drops it.
- Full `cargo test --lib` passes (1709+ tests, no regressions); new `dup_clone_copy_hooks` unit test added.

https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK

---
_Generated by [Claude Code](https://claude.ai/code/session_019WB9vETeTKVMQpjzraUWoK)_