### PR TITLE
JIT: register-allocation separation + loop-entry float specialization (and LIR migration)

### DIFF
--- a/doc/arch_difference.md
+++ b/doc/arch_difference.md
@@ -1,69 +1,74 @@
 # x86-64 / aarch64 JIT backend differences
 
 A survey of how the two JIT machine-code backends differ today, focused on
-**AsmInst coverage** and **lowering logic**. It is current as of the
-`codegen/arch/` consolidation (commits up to #702).
+**AsmInst coverage** and **lowering logic**. It is current as of the full
+aarch64 port (`#704`) and the chunked-literal frame-size fix (`#709`).
 
 - x86-64 backend: `monoruby/src/codegen/arch/x86_64/` — `compile/` (split into
   `mod.rs`, `binary_op.rs`, `method_call.rs`, `variables.rs`, `index.rs`,
   `builtin.rs`, `defined.rs`, `definition.rs`, `constants.rs`,
   `init_method.rs`) + `guard.rs`.
 - aarch64 backend: `monoruby/src/codegen/arch/aarch64/` — `compile.rs`
-  (one ~4.7 k-line file) + `guard.rs`.
+  (one ~4.8 k-line file) + `guard.rs`.
 - Shared front-end + dispatcher: `monoruby/src/codegen/jitgen/` (TraceIR →
   AsmIR) and `jitgen/asmir/compile_shared.rs` (the arch-neutral AsmInst
   lowering dispatcher).
 
+> **History.** An earlier revision of this document (pre-`#704`) described
+> aarch64 as a *streaming port that bails to the VM* on any instruction shape it
+> could not lower, and catalogued ~two dozen bail sites. **That is no longer
+> true.** As of `#704` aarch64 lowers every `AsmInst` and every side exit, so it
+> never bails out of JIT compilation. The sections below describe the current,
+> bail-free state; §4 covers the asymmetries that *do* remain (recompilation
+> strategy and eviction patching — not coverage).
+
 ---
 
-## 1. The big picture: one front-end, two backends, one asymmetry
+## 1. The big picture: one front-end, two backends, coverage-symmetric
 
-Both backends consume the **same** arch-neutral `AsmIR` produced by
-`jitgen` (TraceIR → register-allocated AsmIR). They diverge only at the final
-AsmIR → machine-code step. That step is driven by a single shared dispatcher,
+Both backends consume the **same** arch-neutral `AsmIR` produced by `jitgen`
+(TraceIR → register-allocated AsmIR). They diverge only at the final
+AsmIR → machine-code step, driven by a single shared dispatcher,
 `Codegen::compile_asmir`
-([compile_shared.rs:23](../monoruby/src/codegen/jitgen/asmir/compile_shared.rs#L23)),
+([compile_shared.rs:25](../monoruby/src/codegen/jitgen/asmir/compile_shared.rs#L25)),
 which lowers each `AsmInst` by one of two routes:
 
 1. **Shared arm** — the `match` in `compile_asmir` handles the instruction
    structurally and calls a tiny per-arch **emission primitive**
    (`emit_reg_move`, `emit_reg_to_stack`, `emit_guard_class`,
    `emit_integer_binop`, …). Only the emitted bytes differ per arch.
-2. **Per-arch arm** — the `other =>` fallthrough calls
-   `compile_asmir_arch`, the backend-private match
+2. **Per-arch arm** — the `other =>` fallthrough calls `compile_asmir_arch`,
+   the backend-private match
    ([x86_64/compile/mod.rs:23](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L23),
-   [aarch64/compile.rs:4687](../monoruby/src/codegen/arch/aarch64/compile.rs#L4687)).
+   [aarch64/compile.rs:4730](../monoruby/src/codegen/arch/aarch64/compile.rs#L4730)).
+   On both arches this handles only the *same three* specialized inlined-frame
+   variants (`GuardClassVersionSpecialized`, `RecompileDeoptSpecialized`,
+   `SetArgumentsForwarded`); everything else is handled by the shared arm.
 
-### The defining asymmetry: bail vs. always-emit
+### The `bool` return is now vestigial
 
-Every emission primitive returns a `bool`:
+Every emission primitive (and `compile_asmir` itself) returns a `bool`. In the
+pre-`#704` port this was the aarch64 "not-yet-ported / out-of-range → bail to
+the VM" signal. **Today both backends always return `true`:**
 
-- **x86-64 always returns `true`.** It is the fully-featured reference
-  backend; it never declines to emit an instruction. Its `compile_asmir_arch`
-  ends with `true` ([mod.rs:195](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L195)),
-  and emit primitives carry comments like *"Always succeeds on x86 (no
-  immediate-range limit); the bool result exists for the aarch64 twin."*
-- **aarch64 may return `false` to *bail*.** A `false` propagates up through
-  `compile_asmir` and aborts the whole compilation; the method/loop stays
-  **VM-interpreted** instead. aarch64 is a streaming port that bails on any
-  instruction shape it cannot yet lower.
+- x86-64 is the original fully-featured reference backend; it never declines.
+- aarch64 now lowers everything too — large frame/field/sp offsets are
+  materialized through scratch registers rather than bailing, and the one shape
+  that needed unported caller-relative codegen (the `...`-forwarding *deferral*)
+  is disabled upstream in `forward_rest_deferral` instead of bailing in the
+  backend. See the header comment at
+  [aarch64/compile.rs:1](../monoruby/src/codegen/arch/aarch64/compile.rs#L1):
+  *"Every `AsmInst` and side exit is lowered … aarch64 never bails out of JIT
+  compilation; `compile_asmir`'s `bool` is vestigial."*
 
-So the `bool` return is, in practice, the aarch64 "not-yet-ported / out-of-range"
-signal. The entire difference between the two backends can be read off as
-*"the set of cases where the aarch64 primitive returns `false`."* The rest of
-this document catalogs that set.
-
-> Consequence: aarch64 never produces *wrong* code for an unported case — it
-> falls back to the VM. The cost is coverage, not correctness. A single bailing
-> instruction anywhere in a method forces the entire method back to the
-> interpreter
-> ([aarch64/compile.rs:160](../monoruby/src/codegen/arch/aarch64/compile.rs#L160)).
+There is no `return false` anywhere in the aarch64 lowering (`compile.rs`,
+`guard.rs`). The driver chain (`gen_asm` / `gen_machine_code` / `jit_compile`)
+no longer acts on the result either; the `bool` is kept only because flipping
+~150 signatures to `()` is pure churn.
 
 ---
 
-## 2. AsmInst coverage
-
-### 2.1 Shared instructions (≈120 variants)
+## 2. AsmInst coverage — full on both arches
 
 The large majority of `AsmInst` variants are dispatched through the shared
 `compile_asmir` match and lowered by per-arch emit primitives. Structurally
@@ -94,175 +99,106 @@ identical families covered on both arches include:
   exceptions (`Raise`, `Retry`, `Redo`, `EnsureEnd`), `Yield`, `Inline`,
   and the specialized inlined-frame family.
 
-On x86-64 all of these emit unconditionally. On aarch64 each can bail per the
-conditions in §3.
+Both backends emit all of these unconditionally. The aarch64 wildcard in
+`compile_asmir_arch` is `unreachable!("handled by the shared compile_asmir
+dispatcher")` — it can no longer be a bail.
 
-### 2.2 Per-arch `compile_asmir_arch` — identical, tiny
+### How aarch64 lowers what used to bail
 
-Notably, **both** backends route only the *same three* specialized
-inlined-frame variants through their private `compile_asmir_arch`:
+The pre-`#704` bail sites were overwhelmingly **12-bit immediate-range limits**
+(aarch64 fixed-width instructions encode only small immediates). They are now
+handled, not declined:
 
-| AsmInst                          | x86-64                      | aarch64                       |
-| -------------------------------- | --------------------------- | ----------------------------- |
-| `GuardClassVersionSpecialized`   | [mod.rs:158](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L158) | [compile.rs:4703](../monoruby/src/codegen/arch/aarch64/compile.rs#L4703) |
-| `RecompileDeoptSpecialized`      | [mod.rs:166](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L166) | [compile.rs:4720](../monoruby/src/codegen/arch/aarch64/compile.rs#L4720) |
-| `SetArgumentsForwarded`          | [mod.rs:170](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L170) | [compile.rs:4742](../monoruby/src/codegen/arch/aarch64/compile.rs#L4742) |
-
-The difference is the wildcard:
-
-- x86-64: `_` cannot be reached for a real instruction (the shared dispatcher
-  already handled it); the function returns `true`.
-- aarch64: `_ => return false`
-  ([compile.rs:4749](../monoruby/src/codegen/arch/aarch64/compile.rs#L4749)) —
-  *"Anything still reaching the wildcard is not yet ported, so bail and keep
-  the method VM-interpreted."*
-
-So there is **no AsmInst that aarch64 handles in `compile_asmir_arch` but
-x86 does not** — the two private matches are the same three arms. All real
-divergence is in the *emit primitives* (whether they bail) and in the
-patching/recompile machinery (§4).
-
----
-
-## 3. aarch64 bail conditions (the coverage gap)
-
-These are the cases where the aarch64 emit primitives return `false` and force
-a VM fallback. x86-64 emits all of them.
-
-### 3.1 Immediate-range limits — the dominant category
-
-aarch64 fixed-width instructions encode small immediates only, so any offset
-that overflows the field cannot be emitted inline:
-
-- **LFP-relative frame offsets, 12-bit (`> 4095` bytes)**. Slot access is
-  `[lfp, #(slot*8 + LFP_SELF)]`. Roughly two dozen emit primitives guard
-  `off > 4095` and bail, covering `LitToStack`
-  ([compile.rs:1445](../monoruby/src/codegen/arch/aarch64/compile.rs#L1445)),
-  `StoreGVar`, `Load/StoreDynVar`, `CreateArray`, `NewHash`, `NewRange`,
-  `ConcatStr`, `ToA`, `StoreCVar`, `AliasMethod`, the whole `defined?` family,
-  `GenericBinOp`, `ArrayTEq`, `OptEqCmp`, `ConcatRegexp`, `CheckKwRest`,
-  `ExpandArray`, `SingletonMethodDef`, and the deopt write-back path.
-- **RValue heap-field offsets, 12-bit scaled (`> 32760` or non-8-aligned)**,
-  via `a64_field_off_ok`. Bails the inline/heap ivar & struct-slot
-  loads/stores ([compile.rs:2729–3000](../monoruby/src/codegen/arch/aarch64/compile.rs#L2729)).
-- **Callee-frame `sub sp, sp, #imm` (`> 4080`, 16-aligned)** — argument setup
-  ([compile.rs:762](../monoruby/src/codegen/arch/aarch64/compile.rs#L762)) and
-  the forwarded helper ([compile.rs:814](../monoruby/src/codegen/arch/aarch64/compile.rs#L814)).
-- **Method prologue frame `sub sp` (`> 4095`)** in `emit_init`
-  ([compile.rs:2595](../monoruby/src/codegen/arch/aarch64/compile.rs#L2595)).
-- **Loop-JIT entry stack bump (`> 4095`)**
-  ([compile.rs:2869](../monoruby/src/codegen/arch/aarch64/compile.rs#L2869)).
-- **RSP-relative argument stores (`> 4095`)** via `a64_rsp_slot_addr` —
-  `RegToRSPOffset`, `ZeroToRSPOffset`, `U64ToRSPOffset`
-  ([compile.rs:4523](../monoruby/src/codegen/arch/aarch64/compile.rs#L4523)).
-- **Block-arg frame offset / tag (`> 4095`)**
-  ([compile.rs:4590](../monoruby/src/codegen/arch/aarch64/compile.rs#L4590)).
-- **`class`/`module` definition field offsets (`> 4095`)** in `class_def` /
-  `singleton_class_def`
-  ([compile.rs:1298](../monoruby/src/codegen/arch/aarch64/compile.rs#L1298)).
-
-On x86-64 these are all `[reg + disp32]` / `sub rsp, imm32` — no comparable
-limit, so nothing bails.
-
-### 3.2 FP / xmm-pool related
-
-- **Float `FloatBinOp`** supports only `Add | Sub | Mul | Div`; anything else
-  bails ([compile.rs:2207](../monoruby/src/codegen/arch/aarch64/compile.rs#L2207)).
-- **Float `FloatUnOp`** supports only `Neg`/`Pos`; others bail
-  ([compile.rs:2242](../monoruby/src/codegen/arch/aarch64/compile.rs#L2242)).
-- **Spilled FP operands** — several FP paths (`emit_fpr_to_stack`, the C-func
-  calls) bail when a pool register has been spilled and the spill slot is
-  out of range.
-- **Live xmm/FP-pool register across a runtime call** — a number of
-  runtime-call primitives (`UndefMethod`, `AliasGvar`, `CheckCVar`,
-  `StoreCVar`, `AliasMethod`, the `defined?` family, `class_def`, …) bail when
-  any pool FP register is live, because aarch64 has not yet ported the
-  save/restore of the FP pool around those calls. The shared dispatcher
-  comments flag each of these as *"aarch64 bails when an xmm pool register is
-  live"*.
-
-x86-64 implements xmm save/restore for all of these and supports the full
-`BinOpK`/`UnOpK` set.
-
-### 3.3 Unsupported integer ops
-
-`a64_integer_binop` lowers only `Add | Sub | Mul | Div`; the `_ => return
-false` arm ([compile.rs:396](../monoruby/src/codegen/arch/aarch64/compile.rs#L396))
-bails the rest (in practice `Rem` and the bit-ops are lowered as method calls
-upstream, so they should not reach the JIT — but the guard is there).
-
-### 3.4 Deopt / write-back path
-
-The side-exit (deopt/error-handler) generator `a64_gen_write_back_for_deopt`
-bails when it cannot reconstruct live frame state:
-
-- `forward_rest` is non-empty (rest-arg forwarding in write-back not ported)
-  ([compile.rs:249](../monoruby/src/codegen/arch/aarch64/compile.rs#L249)).
-- a live FP register cannot be spilled, or an immediate / accumulator slot
-  offset exceeds 4095
-  ([compile.rs:256–274](../monoruby/src/codegen/arch/aarch64/compile.rs#L256)).
-- an unexpected side-exit variant (`SideExit::Evict(None)`) is seen
-  ([compile.rs:147](../monoruby/src/codegen/arch/aarch64/compile.rs#L147)).
-
-### 3.5 Forwarded arguments
-
-`a64_set_arguments_forwarded` bails on the *deferred-source* shape
-(`g(*rest, **kw, &blk)`), where the rest array is built on the generic path but
-was skipped on the JIT path
-([compile.rs:797](../monoruby/src/codegen/arch/aarch64/compile.rs#L797)).
+- **LFP-relative frame offsets, callee-frame / prologue / loop-JIT `sub sp`,
+  RSP-relative argument stores, block-arg offsets, class-def field offsets** —
+  offsets that overflow the field are materialized into a scratch register
+  (`mov xN, #imm` + register-offset addressing) instead of bailing. See the
+  `a64_frame_*` / `a64_sp_*` / `a64_rsp_*` helpers in `compile.rs`.
+- **RValue heap-field offsets** (inline/heap ivar & struct-slot access) — same
+  scratch-materialization treatment.
+- **Float `FloatBinOp` / `FloatUnOp`** — the full `BinOpK` / `UnOpK` set is
+  lowered (the old port handled only `Add|Sub|Mul|Div` / `Neg|Pos`).
+- **Live FP-pool register across a runtime call** — the runtime-call primitives
+  save/restore the live xmm pool (`emit_xmm_save` / `emit_xmm_restore`) around
+  the call, so they no longer bail on a live pool register.
+- **Deopt write-back & forwarded arguments** — the side-exit generator
+  reconstructs live frame state for all shapes; the single unported shape (the
+  deferred-source `...`-forwarding deferral, `g(*rest, **kw, &blk)`) is
+  prevented upstream by `forward_rest_deferral`, so it never reaches the
+  backend.
 
 ---
 
-## 4. x86-only machinery with no aarch64 equivalent
+## 3. (former §3 "aarch64 bail conditions" — removed)
 
-Beyond the bail conditions, x86-64 has two whole mechanisms aarch64 does not
-implement, both centered on **patching already-emitted code**.
+This section catalogued the aarch64 bail sites. With the full port (`#704`)
+there are no bail sites left; the content has been folded into §2's "How
+aarch64 lowers what used to bail". The remaining *non-bail* asymmetries are in
+§4.
 
-### 4.1 Return-address patching / deopt patch points
+---
 
-x86-64 records, for each call site, the return address plus a patch point so
-that on **BOP (basic-op) redefinition** it can rewrite the live code to
-redirect into a deopt handler — *without* recompiling.
+## 4. Remaining asymmetry: recompilation & eviction patching (not coverage)
 
-- State: `return_addr_table` and `asm_return_addr_table` on `Codegen`
-  ([codegen.rs:399](../monoruby/src/codegen.rs#L399)).
-- `AsmInst::ImmediateEvict` records the patch-point position
-  ([mod.rs `emit_immediate_evict`](../monoruby/src/codegen/arch/x86_64/compile/mod.rs)).
-- `emit_call` / `emit_yield` record the return-address deopt patch point via
-  `set_deopt_with_return_addr`.
+Two mechanisms still differ, both centered on **patching / recompiling
+already-emitted code**, and both scoped to **non-specialized** frames. Neither
+is a coverage gap: where x86 patches or recompiles in place, aarch64 deopts to
+the VM, which then re-JITs through the normal warm-up counters. Correctness is
+identical; only the recompile *strategy* (and thus steady-state performance
+after a class-version change or BOP redefinition) differs.
 
-aarch64 has **no branch patching**. `ImmediateEvict` is effectively a no-op,
-`Call`/`Yield` record no patch point, and BOP-redefinition safety is covered by
-the inline class-version guards instead. The shared dispatcher documents this
-at `AsmInst::Call` / `ImmediateEvict`
-([compile_shared.rs:230–285](../monoruby/src/codegen/jitgen/asmir/compile_shared.rs#L230)).
+### 4.1 Class-version-miss recompilation
 
-### 4.2 In-place recompilation + recovery
+- **x86-64:** `guard_class_version`
+  ([x86_64/guard.rs:28](../monoruby/src/codegen/arch/x86_64/guard.rs#L28))
+  emits a fast inline version check (page 0) plus an outlined
+  recompile-and-recover slow path (page 1) via `gen_recompile`, distinguishing
+  loop vs. method recompiles via `position` and offering a `with_recovery`
+  jump-back. On a version miss it recompiles the whole method/loop **in place**
+  and resumes.
+- **aarch64:** `a64_guard_class_version`
+  ([aarch64/guard.rs:89](../monoruby/src/codegen/arch/aarch64/guard.rs#L89))
+  emits the inline check and **just deopts on miss** — *"Unlike x86 we do not
+  recompile on miss yet — just deopt."* It ignores the x86 recompile params
+  (`position`, `with_recovery`) it has no recompiler for.
+- **Specialized frames are symmetric:** the specialized class-version guard
+  *does* recompile on both arches. x86 uses `guard_class_version_specialized` /
+  `gen_recompile_specialized`
+  ([x86_64/guard.rs:57](../monoruby/src/codegen/arch/x86_64/guard.rs#L57));
+  aarch64 uses `GuardClassVersionSpecialized` / `RecompileDeoptSpecialized` →
+  `a64_call_recompile_specialized`
+  ([aarch64/compile.rs:4755](../monoruby/src/codegen/arch/aarch64/compile.rs#L4755)),
+  which rewrites the specialized body's `SpecializedCall` `bl`.
 
-x86-64's class-version guard can, on a miss, **recompile the whole method (or
-loop body) in place** and resume, via `gen_recompile` /
-`gen_recompile_specialized`
-([compiler.rs:71](../monoruby/src/codegen/compiler.rs#L71)), driven by
-`guard_class_version(position, with_recovery, …)`
-([x86_64/guard.rs:28](../monoruby/src/codegen/arch/x86_64/guard.rs#L28)). It
-emits a fast inline version check (page 0) plus an outlined recompile-and-
-recover slow path (page 1), distinguishing loop vs. method recompiles via
-`position` and offering a `with_recovery` jump-back.
+So the gap is specifically the **non-specialized method/loop class-version
+guard**: x86 recompiles, aarch64 deopts.
 
-aarch64's **non-specialized** class-version guard `a64_guard_class_version`
-just deopts on miss — no recompile, no recovery
-([aarch64/guard.rs:89](../monoruby/src/codegen/arch/aarch64/guard.rs#L89)):
-*"Unlike x86 we do not recompile on miss yet — just deopt."* It also ignores
-the x86 recompile params (`position`, `with_recovery`) it has no recompiler
-for.
+### 4.2 Eviction via return-address patching (BOP redefinition)
 
-> Exception worth noting: the **specialized** (inlined-frame) variants *do*
-> recompile on aarch64. `GuardClassVersionSpecialized` and
-> `RecompileDeoptSpecialized` both call `a64_call_recompile_specialized`,
-> rewriting the specialized body's `SpecializedCall` `bl`
-> ([compile.rs:4703–4736](../monoruby/src/codegen/arch/aarch64/compile.rs#L4703)).
-> So the "no recompile" gap is specifically the *non-specialized* method/loop
-> class-version guard.
+- **x86-64:** the regular `Call` / `Yield` records, per call site, the return
+  address plus a patch point (`emit_call` → `set_deopt_with_return_addr`,
+  [x86_64/compile/mod.rs:1285](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L1285)).
+  On **BOP (basic-op) redefinition** it rewrites the live return path to
+  redirect into a deopt handler — *without* recompiling.
+- **aarch64:** `a64_do_call`
+  ([aarch64/compile.rs:825](../monoruby/src/codegen/arch/aarch64/compile.rs#L825))
+  **skips** the return-address patching for the regular `Call`/`Yield` —
+  *"The eviction-on-return patching (`set_deopt_with_return_addr`) is x86-only
+  (runtime branch patching), so it is skipped — class-version changes are
+  caught by `GuardClassVersion` deopts instead."*
+- **Specialized calls/yields are symmetric:** aarch64 *does* implement
+  return-address patching for the specialized inlined-frame path —
+  `do_specialized_call`
+  ([aarch64/compile.rs:1068](../monoruby/src/codegen/arch/aarch64/compile.rs#L1068))
+  records the return address via `set_deopt_with_return_addr`
+  ([aarch64/compile.rs:2433](../monoruby/src/codegen/arch/aarch64/compile.rs#L2433)),
+  and `emit_immediate_evict`
+  ([aarch64/compile.rs:2416](../monoruby/src/codegen/arch/aarch64/compile.rs#L2416))
+  overwrites the recorded instruction on eviction.
+
+So the gap is specifically the **non-specialized `Call`/`Yield`**: x86 patches
+the return path for BOP eviction, aarch64 relies on the inline class-version
+deopt.
 
 ---
 
@@ -270,45 +206,41 @@ for.
 
 | Guard                         | x86-64                                                            | aarch64                                                                 |
 | ----------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `guard_class` immediates      | Fixnum/nil/true/false/symbol/float/**bool** via `testq`/`cmpq`   | Fixnum/nil/true/false/symbol/float via `tbz`/`tbnz`/`cmp`; no dedicated bool collapse |
-| `guard_class` heap            | `guard_rvalue` (low-3-bits + class compare)                      | `a64_guard_rvalue` (same logic, `and`/`cbnz`/`ldr w`)                   |
-| `guard_class2` (BigNum→VM)    | yes — BigNum always routed to VM entry                           | not present                                                            |
+| `guard_class` immediates      | Fixnum/nil/true/false/symbol/float via `testq`/`cmpq`            | Fixnum/nil/true/false/symbol/float via `tbz`/`tbnz`/`cmp` ([guard.rs:14](../monoruby/src/codegen/arch/aarch64/guard.rs#L14)) |
+| `guard_class` heap            | `guard_rvalue` (low-3-bits + class compare)                      | `a64_guard_rvalue` (same logic, `and`/`cbnz`/`ldr w`, [guard.rs:68](../monoruby/src/codegen/arch/aarch64/guard.rs#L68)) |
+| `guard_class2` (BigNum→VM)    | yes — x86-only helper ([guard.rs:177](../monoruby/src/codegen/arch/x86_64/guard.rs#L177)), called from the monomorphic method-entry patch path (`codegen/patch.rs:158`) | not present                                                            |
 | `guard_array_ty`              | yes (`ObjTy::ARRAY` at `RVALUE_OFFSET_TY`)                        | yes                                                                    |
 | `guard_capture`               | yes (`branch_if_captured`)                                       | yes                                                                    |
 | `float_to_f64` unbox          | yes (flonum / heap-Float, 0.0 sign-bit trick)                    | yes (mirrored)                                                         |
-| class-version guard           | inline check **+ recompile + recovery** (page split)             | inline check, **deopt only** (recompile only for specialized frames)  |
+| class-version guard           | inline check **+ recompile + recovery** (page split, §4.1)       | inline check, **deopt only** for non-specialized; recompile for specialized frames (§4.1) |
+| eviction on BOP redefinition  | return-address patching for regular & specialized calls (§4.2)  | return-address patching for **specialized** calls only; regular calls rely on class-version deopt (§4.2) |
 
-The `a64_guard_class` primitive returns `bool` for symmetry with x86, but in
-its current form it handles every `ClassId` (immediates inline, everything else
-via the heap `a64_guard_rvalue` fallback) and **always returns `true`** — i.e.
-class guards themselves do not currently bail
-([aarch64/guard.rs:14–63](../monoruby/src/codegen/arch/aarch64/guard.rs#L14)).
-(The shared dispatcher's "aarch64 bails for not-yet-supported class kinds"
-comment is forward-looking; no class kind bails today.)
+Both `a64_guard_class` and `a64_guard_rvalue` always emit (they return a `bool`
+for symmetry with x86, but never return `false` — every `ClassId` is handled,
+immediates inline and everything else via the heap fallback).
 
 ---
 
 ## 6. Practical consequences
 
-- **Correctness is equal.** Both backends produce correct results; aarch64
-  simply executes more code in the VM tier.
-- **Coverage differs by frame size and feature mix.** Methods with large
-  local frames, many locals/ivars (large offsets), the full float/integer op
-  set on spilled operands, live-FP-across-runtime-call shapes, rest-arg
-  forwarding in deopt, or the deferred-source forwarding shape will JIT on
-  x86-64 but fall back to the VM on aarch64.
-- **The dominant gap is immediate-range encoding** (≈80% of aarch64 bail
-  sites), not missing instruction semantics. Closing it means emitting
-  materialize-offset-into-scratch-register sequences in those primitives.
-- **The structural gaps are patching-based**: BOP-eviction via return-address
-  patching, and non-specialized method/loop recompile-on-version-miss. aarch64
-  substitutes plain deopt-to-VM for both.
+- **Correctness is equal.** Both backends produce correct results.
+- **Coverage is equal.** Both backends JIT every method/loop the front-end
+  produces; aarch64 no longer falls back to the VM for any instruction shape.
+- **Steady-state recompile behavior differs** in two narrow, non-specialized
+  cases (§4): after a class-version change, x86 recompiles the method/loop in
+  place while aarch64 deopts and re-JITs via warm-up counters; and on BOP
+  redefinition, x86 patches the live return path of regular calls while aarch64
+  relies on the inline class-version deopt. Both eventually reach an equivalent
+  JIT-compiled steady state; the difference is the transition cost.
+- **`guard_class2` / BigNum routing** is an x86-only method-entry guard helper
+  (`patch.rs`); aarch64 has no equivalent on that path.
 
 ### One-line summary
 
-> x86-64 is the complete reference backend that always emits and can patch
-> live code; aarch64 shares the entire AsmIR front-end and the same instruction
-> dispatch, but each emit primitive may *bail to the VM* — overwhelmingly on
-> 12-bit immediate-range limits, plus a few not-yet-ported feature shapes (full
-> FP/int op set, xmm-save-around-call, code patching, non-specialized
-> recompile).
+> x86-64 and aarch64 now share the entire AsmIR front-end *and* full AsmInst
+> coverage — aarch64 lowers everything (large immediates via scratch
+> registers), so the `bool` bail return is vestigial. The only remaining
+> asymmetries are non-coverage: x86 recompiles-in-place / patches live return
+> addresses for **non-specialized** class-version misses and BOP eviction,
+> where aarch64 deopts to the VM and re-JITs (specialized frames are symmetric);
+> plus the x86-only `guard_class2` BigNum-routing helper.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -278,8 +278,14 @@ The remaining things handled **directly** (not through `encode_linst`):
   `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
   resolve frame-local labels and patch points and are dispatched to a per-arch
   method of the same name (`arch/<arch>/compile/…`).
-- **The `AsmInst::Inline` escape hatch.** Builtin inline generators (e.g.
-  `emit_math_sqrt`) run a closure that emits arch asm directly via `gen`.
+- **The `AsmInst::Inline` escape hatch.** Most builtin inline generators (e.g.
+  `emit_math_sqrt`) still run a closure that emits arch asm directly via `gen`.
+  Migrating these onto LIR is **goal 2** of the long-term plan ("express the
+  inline-builtin codegen once, arch-neutrally"). First proof: `Range#begin/end`
+  now lower through the typed `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg`
+  → existing `LInst::Load { Field }` (no new LIR op, byte-identical on both
+  arches, hand-written `emit_range_begin/end` deleted). The remaining
+  generators need a few new FP/branch LIR primitives (e.g. for `sqrt`).
 - **Pure patch / recompile *bookkeeping*** — the x86/aarch64 *non-coverage*
   asymmetry of `doc/arch_difference.md` §4. The deopt *handler emission* now
   goes through LIR (above); what stays out is the part that **emits no bytes**:

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -5,14 +5,19 @@ between `AsmIR` and the per-arch `monoasm!` / `monoasm_arm64!` byte emission.
 This is **Phase-1 item ①** ("a low-level IR that describes amd64 and aarch64
 uniformly").
 
-Status: **actively migrating `AsmInst` families onto LIR, family by family.**
-The model lives in
+Status: **the great majority of `AsmInst` families now lower through
+`encode_linst`.** The model lives in
 [`monoruby/src/codegen/jitgen/lir.rs`](../monoruby/src/codegen/jitgen/lir.rs);
 the per-arch encoder is `Codegen::encode_linst`, defined once in each
 `arch/<arch>/compile/…` file. As of this writing the integer + control-flow
 core, all addressing modes, the GC write barrier, the common guard/check family,
-fixnum arithmetic (with overflow deopt), and the first floating-point family are
-all lowered through `encode_linst`.
+fixnum arithmetic (with overflow deopt), the **whole floating-point family**,
+the bounds-checked heap-ivar load/store, and the large **runtime-call macro-op**
+families (array/hash/string/range construction, `defined?`, generic binops,
+class/method definition, exceptions, `yield`, the method-prologue guards, …) are
+all lowered through `encode_linst`. What remains in the dispatcher is the set of
+arms that need `&Store` or live frame state (the method-call argument-setup
+family) and the specialized inlined-frame family — see §8.
 
 ---
 
@@ -64,7 +69,11 @@ selects the right encoder.
 
 Defined in `lir.rs`. Branch and side-exit targets carry a **resolved monoasm
 `DestLabel`** (the encoder runs after label resolution), so `LInst` is
-`#[derive(Debug, Clone, PartialEq)]` — `DestLabel` is `Clone` but not `Copy`.
+`#[derive(Debug, Clone)]` — `DestLabel` is `Clone` but not `Copy`. `PartialEq`
+is intentionally **not** derived: several payload types reached by the macro-op
+variants (`WriteBack`, `AsmEvict`, `FnInitInfo`, …) are not `PartialEq`, and
+deriving it would force a `PartialEq` cascade across unrelated types for no
+benefit. The `lir.rs` unit test uses `matches!` instead of `==`.
 
 ### Operands
 
@@ -88,11 +97,27 @@ Defined in `lir.rs`. Branch and side-exit targets carry a **resolved monoasm
 | Branch | `Label`, `Br`, `CondBr { cond: LCond, … }`, `BranchTruthy { negate }`, `BranchIfNil`, `BranchIfNonzero` |
 | GC / nil | `WriteBarrier { parent, value }`, `NilIfZero { reg }` |
 | Guards (carry a side-exit `deopt`) | `GuardClass`, `GuardArrayTy`, `GuardFrozen`, `GuardConstBaseClass`, `GuardConstVersion`, `GuardCapture`, `CheckBOP` |
-| Arithmetic w/ deopt | `IntegerBinOp { kind, mode, lhs, rhs, deopt }` |
-| Floating-point | `FprMove`, `F64ToFpr`, `FixnumToFpr`, `FprToStack` (carry the spill `base`) |
+| Integer arithmetic | `IntegerBinOp { …, deopt }`, `IntegerCmp`, `FixnumNeg { …, deopt }`, `FixnumBitNot` |
+| Floating-point | `FprMove`, `F64ToFpr`, `FixnumToFpr`, `FprToStack`, `FprSwap`, `FloatToFpr` (deopt), `I64ToBoth`, `FloatBinOp`, `FloatUnOp`, `FloatCmp`, `FloatCmpBr`, `XmmSave`, `XmmRestore`, `CFunc_F_F`, `CFunc_FF_F` (FP ops carry the spill `base`) |
+| Heap ivar (macro-op) | `LoadIVarHeap`, `StoreIVarHeap` |
+| Construction (macro-op) | `CreateArray`, `NewArray`, `NewHash`, `HashInsert`, `ArrayConcat`, `NewRange`, `ConcatStr`, `ConcatRegexp`, `ToA`, `DeepCopyLit`, `ExpandArray` |
+| Variables (macro-op) | `StoreConstant`, `LoadGVar`, `StoreGVar`, `LoadCVar`, `CheckCVar`, `StoreCVar`, `LoadDynVar`, `StoreDynVar`, `AliasGvar` |
+| `defined?` (macro-op) | `DefinedYield`, `DefinedSuper`, `DefinedGvar`, `DefinedCvar`, `DefinedConst`, `DefinedMethod`, `DefinedIvar` |
+| Dispatch helpers (macro-op) | `GenericBinOp`, `OptEqCmp`, `ArrayTEq`, `CheckKwRest`, `RestKw` |
+| Definition (macro-op) | `MethodDef`, `SingletonMethodDef`, `ClassDef`, `SingletonClassDef`, `AliasMethod`, `UndefMethod` |
+| Method-prologue guards (macro-op) | `GuardClassVersion`, `RecompileDeopt`, `CheckStack`, `ExecGc`, `Init`, `LoopJitRspBump` |
+| Control flow / exceptions (macro-op) | `Ret`, `MethodRet`, `BlockBreak`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `BlockArgProxy`, `BlockArg`, `ImmediateEvict`, `Deopt`, `HandleError`, `Unreachable` |
 
 `Lir` is a thin `Vec<LInst>` builder used where a multi-instruction sequence is
 convenient.
+
+The macro-op variants do not lower to primitives inside `encode_linst`; instead
+each backend's `encode_linst` ends with `other => self.encode_linst_macro(other)`,
+and the **arch-neutral** `encode_linst_macro`
+([compile_shared.rs](../monoruby/src/codegen/jitgen/asmir/compile_shared.rs))
+delegates each macro-op to the existing per-arch `emit_*` helper. This keeps the
+delegation in one place (rather than duplicating it in both backends) while
+still funnelling *all* emission through `encode_linst`. See §5.
 
 ### The legalization contract (the core idea)
 
@@ -141,11 +166,20 @@ prior code:
   (whose spill-aware bodies were *moved* from `emit_*` into the encoder arms,
   deleting those `emit_*`).
 - **Macro-op delegation** — a single `LInst` whose encoder calls an existing
-  per-arch helper that stays (the tag-test / page-split / tagged-arith logic is
-  irreducibly per-arch). Used by the guards (delegate to `guard_class`,
-  `a64_guard_class`, `guard_capture`, …) and `IntegerBinOp` (delegate to
-  `integer_binop` / `a64_integer_binop`, which keep the x86 cold-page overflow
-  handler). The thin `emit_*` wrappers are deleted; the substantive helper stays.
+  per-arch helper that stays (the tag-test / page-split / tagged-arith / C-call
+  sequence is irreducibly per-arch). Two sub-cases:
+  - *decomposed-style delegation* (guards, `IntegerBinOp`): the per-arch
+    `encode_linst` matches the variant directly and calls the substantive helper
+    (`guard_class` / `a64_guard_class`, `integer_binop` / `a64_integer_binop`, …);
+    the thin `emit_*` wrapper is deleted.
+  - *`encode_linst_macro`-style delegation* (the large runtime-call families):
+    the variant falls through each backend's `other =>` arm into the
+    **arch-neutral** `encode_linst_macro`, which calls the per-arch `emit_*`
+    helper. The `emit_*` helper is retained verbatim, so the migration is a pure
+    routing change — the dispatcher arm now builds an `LInst` and hands it to
+    `encode_linst` instead of calling `emit_*` directly. This is how the
+    construction / variable / `defined?` / definition / control-flow families
+    were migrated (batches A and B).
 
 ---
 
@@ -174,6 +208,14 @@ accumulator).
 | 3-C | const-base-class / const-version / capture / BOP guards | |
 | 3-D | fixnum `IntegerBinOp` (overflow deopt) | hottest arithmetic path |
 | 3-E | FP transfer/convert (`FprMove` / `F64ToFpr` / `FixnumToFpr` / `FprToStack`) | first FP family; real decomposition |
+| 3-F | FP swap / `FloatToFpr` (deopt) / `I64ToBoth` | |
+| 3-G | FP arithmetic & compare (`FloatBinOp` / `FloatUnOp` / `FloatCmp` / `FloatCmpBr`) | NaN-correct conditions |
+| 3-H | FP C-calls (`CFunc_F_F` / `CFunc_FF_F`) + `XmmSave` / `XmmRestore` | completes the FP family |
+| A | bounds-checked heap-ivar load/store (`LoadIVarHeap` / `StoreIVarHeap`) | first macro-op via `encode_linst_macro` |
+| B1 | variable + construction macro-ops (g/c/dyn-var, array/hash/range/str, `to_a`, `defined?`, generic binop, alias/undef, …) | bulk macro-op routing |
+| B2 | remaining construction / `defined?` / dispatch-helper macro-ops | |
+| B3 | control-flow / exception / definition macro-ops (`Ret`, `MethodRet`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `MethodDef`, `Init`, `CheckStack`, `ExecGc`, `IntegerCmp`, `BlockArg`, …) | `Raise`/`Retry`/`Redo`/`EnsureEnd` carry `loop_jit_spill_bytes` for the aarch64 loop-JIT sp unwind |
+| B4 | class-def + method-prologue guards (`ClassDef`, `SingletonClassDef`, `GuardClassVersion`, `RecompileDeopt`) | last non-store/non-frame arms |
 
 ---
 
@@ -202,23 +244,36 @@ preservation under a correct reference Ruby**:
 
 ## 8. Remaining work
 
-Families still lowered directly via `emit_*` (not yet through `encode_linst`):
+The arms still handled **directly in the `compile_asmir` dispatcher** (not routed
+through `encode_linst`) fall into three groups. The first two are a *deliberate*
+boundary — they are not pure machine-code emission — and the third is small:
 
-- **Floating point (rest):** `FprSwap`, `FloatToFpr` (deopt), `FloatBinOp` /
-  `FloatUnOp` / `FloatCmp` / `FloatCmpBr` (NaN-correct conditions), `I64ToBoth`,
-  the FP C-calls `CFunc_F_F` / `CFunc_FF_F`, and `XmmSave` / `XmmRestore`.
-- **Bounds-checked heap ivar** load/store (non-`self`): needs a bounds-check →
-  deopt/nil branch on top of the scratch model.
-- **Runtime-call macro-ops:** `NewArray` / `NewHash` / `ConcatStr` / `defined?`
-  family / `GenericBinOp` / class & method definition / the method-call prologue
-  (`SetupMethodFrame`, `SetArguments`, `Call`, `Init`) / exceptions / `Yield` /
-  the specialized inlined-frame family. These are large C-call sequences; most
-  would migrate as macro-ops carrying the relevant labels.
-- **Patch / recompile machinery** (return-address eviction, in-place recompile)
-  — the x86/aarch64 *non-coverage* asymmetry from `doc/arch_difference.md` §4;
-  the hardest to model.
+- **Store-/frame-dependent method-call family.** `SetupMethodFrame`,
+  `SetArguments`, `Call`, `Preparation`, `OptCase`, and
+  `SetArgumentsForwardedHelper` need `&Store` (callee metadata, arg shape,
+  frame offsets) or mutate the live `frame` (label resolution, sourcemap). They
+  are *argument-massage + dispatch* logic rather than a fixed machine-code
+  sequence, so `encode_linst` — which receives neither `&Store` nor `&mut frame`
+  — is the wrong seam for them. They stay in the dispatcher, which *does* have
+  that context and still calls `encode_linst` for every primitive it emits.
+- **Specialized inlined-frame family.** `MethodRetSpecialized`,
+  `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`,
+  `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
+  resolve frame-local labels and patch points and are dispatched to a per-arch
+  method of the same name (`arch/<arch>/compile/…`). Same rationale.
+- **Elementary moves.** The register/stack move leaves (`RegMove`, `RegToAcc`,
+  `AccToStack`, `RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`, `RegAdd`,
+  `RegSub`) still call their `emit_*` leaf directly from the dispatcher. These
+  *could* be expressed as `LInst::{Mov,Load,Store,LoadImm,Alu}` and routed, but
+  they already bottom out in the very same `emit_*` leaves that the decomposed
+  `encode_linst` arms target, so the win is cosmetic; left as a follow-up.
 
-These extend, but do not invalidate, the model: each needs either a macro-op
-(carrying its labels) or, where the per-arch shape genuinely differs (FP spill,
-NaN compares, page-split deopt), a dedicated op whose encoder reproduces the
-arch sequence byte-for-byte.
+Beyond the dispatcher, the **patch / recompile machinery** (return-address
+eviction, in-place recompile) remains the x86/aarch64 *non-coverage* asymmetry
+described in `doc/arch_difference.md` §4 — the hardest piece to model and not yet
+unified.
+
+None of this invalidates the model: `encode_linst` (with `encode_linst_macro`)
+is now the single seam for emission, and the residual dispatcher arms either lack
+the right context to *be* emission-only or are elementary leaves trivially
+reachable from it.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -15,11 +15,11 @@ fixnum arithmetic (with overflow deopt), the **whole floating-point family**,
 the bounds-checked heap-ivar load/store, and the large **runtime-call macro-op**
 families (array/hash/string/range construction, `defined?`, generic binops,
 class/method definition, exceptions, `yield`, the method-prologue guards, …) are
-all lowered through `encode_linst`, as is the method-call argument-setup family
-(the dispatcher pre-resolves the store/frame-dependent values and the encoder
-stays store-free). What remains in the dispatcher is the hot-path `Call`
-(deferred, not excluded), the specialized inlined-frame family, and the
-patch/recompile bookkeeping that is *not* byte emission — see §8.
+all lowered through `encode_linst`, as is the **entire** method-call family —
+argument setup *and* the call itself (the dispatcher pre-resolves the
+store/frame-dependent values and the encoder stays store-free). What remains in
+the dispatcher is the specialized inlined-frame family and the patch/recompile
+bookkeeping that is *not* byte emission — see §8.
 
 ---
 
@@ -219,7 +219,8 @@ accumulator).
 | B3 | control-flow / exception / definition macro-ops (`Ret`, `MethodRet`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `MethodDef`, `Init`, `CheckStack`, `ExecGc`, `IntegerCmp`, `BlockArg`, …) | `Raise`/`Retry`/`Redo`/`EnsureEnd` carry `loop_jit_spill_bytes` for the aarch64 loop-JIT sp unwind |
 | B4 | class-def + method-prologue guards (`ClassDef`, `SingletonClassDef`, `GuardClassVersion`, `RecompileDeopt`) | last non-store/non-frame arms |
 | B5 | elementary moves (`RegMove`/`RegToAcc`/`AccToStack`/`RegToStack`/`StackToReg`/`LitToReg`/`LitToStack`/`RegAdd`/`RegSub`) | dispatcher lowers straight to `LInst`; the thin `emit_*` move wrappers deleted from both backends |
-| B6 | method-call / argument-setup (`SetupMethodFrame`, `SetArguments`, `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) | dispatcher pre-resolves the store/frame-dependent values (offset, block info, heap-ivar length, jump-table labels) into the `LInst`; per-arch helpers made store-free. `Call` deliberately left out (see §8) |
+| B6 | method-call / argument-setup (`SetupMethodFrame`, `SetArguments`, `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) | dispatcher pre-resolves the store/frame-dependent values (offset, block info, heap-ivar length, jump-table labels) into the `LInst`; per-arch helpers made store-free |
+| B7 | the call itself (`Call`) | dispatcher pre-resolves `codeptr` / `is_iseq` / callee+call-site pcs / x86 JIT entry (`get_jit_entry`); `do_call`/`a64_do_call` made store-free. x86 still records the return-address patch point inside the call's encoder (it is captured at the emission point); aarch64 ignores the x86-only fields |
 
 ---
 
@@ -248,31 +249,26 @@ preservation under a correct reference Ruby**:
 
 ## 8. Remaining work
 
-The arms still handled **directly in the `compile_asmir` dispatcher** (not routed
-through `encode_linst`) fall into a few groups.
+First, what is **no longer** a blocker. The **whole method-call family** is now
+migrated — argument setup (`SetupMethodFrame`, `SetArguments`,
+`SetArgumentsForwardedHelper`, `Preparation`, `OptCase`; B6) **and** the call
+itself (`Call`; B7) lower through `encode_linst`. The dispatcher — which holds
+`&Store` / `&mut AsmInfo` — resolves every store/frame-dependent value (callee
+scratch `offset`, block `(fid, arg)`, heap-ivar table length, jump-table
+`DestLabel`s, and for `Call` the `codeptr` / `is_iseq` / callee & call-site pcs /
+x86 JIT entry) and carries them in the `LInst`, so the per-arch helpers
+(`do_call`/`a64_do_call`, …) are store-free. `Call`'s encoder also records the
+return-address patch point, which is captured *at* the emission point and so
+belongs with the call's emission. (The elementary register/stack moves were
+likewise inlined into the dispatcher in B5, deleting their forwarding wrappers.)
 
-- **Store-/frame-dependent values are pre-resolved, not a blocker.** The
-  method-call / argument-setup family (`SetupMethodFrame`, `SetArguments`,
-  `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) was migrated in B6:
-  the dispatcher — which holds `&Store` / `&mut AsmInfo` — resolves the
-  store/frame-dependent values (callee scratch `offset`, block `(fid, arg)`,
-  heap-ivar table length, jump-table `DestLabel`s) and carries them in the
-  `LInst`, so the per-arch helper stays store-free. The same recipe applies to
-  the remaining `Call`, which is left for later only because it pre-resolves
-  more fields (codeptr / pc / jit-entry / iseq-ness from `store[callee_fid]`)
-  and sits on the hottest path; it is *deferred, not excluded*.
+The arms still handled **directly in the `compile_asmir` dispatcher**:
+
 - **Specialized inlined-frame family.** `MethodRetSpecialized`,
   `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`,
   `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
   resolve frame-local labels and patch points and are dispatched to a per-arch
-  method of the same name (`arch/<arch>/compile/…`). Same rationale.
-The elementary register/stack moves (`RegMove`, `RegToAcc`, `AccToStack`,
-`RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`, `RegAdd`, `RegSub`) are
-now lowered to `LInst::{Mov,Load,Store,LoadImm,Alu}` straight in the dispatcher;
-the thin `emit_reg_move` / `emit_reg_to_stack` / `emit_stack_to_reg` /
-`emit_lit_to_reg` / `emit_lit_to_stack` / `emit_reg_add` / `emit_reg_sub`
-wrappers (which only forwarded to `encode_linst`) were removed from both
-backends.
+  method of the same name (`arch/<arch>/compile/…`).
 
 Beyond the dispatcher, the **patch / recompile machinery** (return-address
 eviction, in-place recompile) is the x86/aarch64 *non-coverage* asymmetry
@@ -288,6 +284,7 @@ abstraction. The clean invariant is therefore:
 > dispatcher / `Codegen`.
 
 None of this invalidates the model: `encode_linst` (with `encode_linst_macro`)
-is the single seam for emission, and the residual dispatcher arms either are
-bookkeeping rather than emission, or are deferred (`Call`) by effort rather than
-by a modelling limit.
+is the single seam for byte emission. The only arms still handled directly in
+the dispatcher are the specialized inlined-frame family (which resolve
+frame-local labels / patch points) and the patch/recompile bookkeeping, which is
+*not* emission by the invariant above.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -216,6 +216,7 @@ accumulator).
 | B2 | remaining construction / `defined?` / dispatch-helper macro-ops | |
 | B3 | control-flow / exception / definition macro-ops (`Ret`, `MethodRet`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `MethodDef`, `Init`, `CheckStack`, `ExecGc`, `IntegerCmp`, `BlockArg`, …) | `Raise`/`Retry`/`Redo`/`EnsureEnd` carry `loop_jit_spill_bytes` for the aarch64 loop-JIT sp unwind |
 | B4 | class-def + method-prologue guards (`ClassDef`, `SingletonClassDef`, `GuardClassVersion`, `RecompileDeopt`) | last non-store/non-frame arms |
+| B5 | elementary moves (`RegMove`/`RegToAcc`/`AccToStack`/`RegToStack`/`StackToReg`/`LitToReg`/`LitToStack`/`RegAdd`/`RegSub`) | dispatcher lowers straight to `LInst`; the thin `emit_*` move wrappers deleted from both backends |
 
 ---
 
@@ -261,12 +262,13 @@ boundary — they are not pure machine-code emission — and the third is small:
   `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
   resolve frame-local labels and patch points and are dispatched to a per-arch
   method of the same name (`arch/<arch>/compile/…`). Same rationale.
-- **Elementary moves.** The register/stack move leaves (`RegMove`, `RegToAcc`,
-  `AccToStack`, `RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`, `RegAdd`,
-  `RegSub`) still call their `emit_*` leaf directly from the dispatcher. These
-  *could* be expressed as `LInst::{Mov,Load,Store,LoadImm,Alu}` and routed, but
-  they already bottom out in the very same `emit_*` leaves that the decomposed
-  `encode_linst` arms target, so the win is cosmetic; left as a follow-up.
+The elementary register/stack moves (`RegMove`, `RegToAcc`, `AccToStack`,
+`RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`, `RegAdd`, `RegSub`) are
+now lowered to `LInst::{Mov,Load,Store,LoadImm,Alu}` straight in the dispatcher;
+the thin `emit_reg_move` / `emit_reg_to_stack` / `emit_stack_to_reg` /
+`emit_lit_to_reg` / `emit_lit_to_stack` / `emit_reg_add` / `emit_reg_sub`
+wrappers (which only forwarded to `encode_linst`) were removed from both
+backends.
 
 Beyond the dispatcher, the **patch / recompile machinery** (return-address
 eviction, in-place recompile) remains the x86/aarch64 *non-coverage* asymmetry

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -15,9 +15,11 @@ fixnum arithmetic (with overflow deopt), the **whole floating-point family**,
 the bounds-checked heap-ivar load/store, and the large **runtime-call macro-op**
 families (array/hash/string/range construction, `defined?`, generic binops,
 class/method definition, exceptions, `yield`, the method-prologue guards, …) are
-all lowered through `encode_linst`. What remains in the dispatcher is the set of
-arms that need `&Store` or live frame state (the method-call argument-setup
-family) and the specialized inlined-frame family — see §8.
+all lowered through `encode_linst`, as is the method-call argument-setup family
+(the dispatcher pre-resolves the store/frame-dependent values and the encoder
+stays store-free). What remains in the dispatcher is the hot-path `Call`
+(deferred, not excluded), the specialized inlined-frame family, and the
+patch/recompile bookkeeping that is *not* byte emission — see §8.
 
 ---
 
@@ -217,6 +219,7 @@ accumulator).
 | B3 | control-flow / exception / definition macro-ops (`Ret`, `MethodRet`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `MethodDef`, `Init`, `CheckStack`, `ExecGc`, `IntegerCmp`, `BlockArg`, …) | `Raise`/`Retry`/`Redo`/`EnsureEnd` carry `loop_jit_spill_bytes` for the aarch64 loop-JIT sp unwind |
 | B4 | class-def + method-prologue guards (`ClassDef`, `SingletonClassDef`, `GuardClassVersion`, `RecompileDeopt`) | last non-store/non-frame arms |
 | B5 | elementary moves (`RegMove`/`RegToAcc`/`AccToStack`/`RegToStack`/`StackToReg`/`LitToReg`/`LitToStack`/`RegAdd`/`RegSub`) | dispatcher lowers straight to `LInst`; the thin `emit_*` move wrappers deleted from both backends |
+| B6 | method-call / argument-setup (`SetupMethodFrame`, `SetArguments`, `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) | dispatcher pre-resolves the store/frame-dependent values (offset, block info, heap-ivar length, jump-table labels) into the `LInst`; per-arch helpers made store-free. `Call` deliberately left out (see §8) |
 
 ---
 
@@ -246,17 +249,18 @@ preservation under a correct reference Ruby**:
 ## 8. Remaining work
 
 The arms still handled **directly in the `compile_asmir` dispatcher** (not routed
-through `encode_linst`) fall into three groups. The first two are a *deliberate*
-boundary — they are not pure machine-code emission — and the third is small:
+through `encode_linst`) fall into a few groups.
 
-- **Store-/frame-dependent method-call family.** `SetupMethodFrame`,
-  `SetArguments`, `Call`, `Preparation`, `OptCase`, and
-  `SetArgumentsForwardedHelper` need `&Store` (callee metadata, arg shape,
-  frame offsets) or mutate the live `frame` (label resolution, sourcemap). They
-  are *argument-massage + dispatch* logic rather than a fixed machine-code
-  sequence, so `encode_linst` — which receives neither `&Store` nor `&mut frame`
-  — is the wrong seam for them. They stay in the dispatcher, which *does* have
-  that context and still calls `encode_linst` for every primitive it emits.
+- **Store-/frame-dependent values are pre-resolved, not a blocker.** The
+  method-call / argument-setup family (`SetupMethodFrame`, `SetArguments`,
+  `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) was migrated in B6:
+  the dispatcher — which holds `&Store` / `&mut AsmInfo` — resolves the
+  store/frame-dependent values (callee scratch `offset`, block `(fid, arg)`,
+  heap-ivar table length, jump-table `DestLabel`s) and carries them in the
+  `LInst`, so the per-arch helper stays store-free. The same recipe applies to
+  the remaining `Call`, which is left for later only because it pre-resolves
+  more fields (codeptr / pc / jit-entry / iseq-ness from `store[callee_fid]`)
+  and sits on the hottest path; it is *deferred, not excluded*.
 - **Specialized inlined-frame family.** `MethodRetSpecialized`,
   `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`,
   `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
@@ -271,11 +275,19 @@ wrappers (which only forwarded to `encode_linst`) were removed from both
 backends.
 
 Beyond the dispatcher, the **patch / recompile machinery** (return-address
-eviction, in-place recompile) remains the x86/aarch64 *non-coverage* asymmetry
-described in `doc/arch_difference.md` §4 — the hardest piece to model and not yet
-unified.
+eviction, in-place recompile) is the x86/aarch64 *non-coverage* asymmetry
+described in `doc/arch_difference.md` §4. This is **explicitly out of scope** for
+LIR: it does not *emit bytes* — it records code-position metadata
+(`return_addr_table` patch points, which emit zero bytes), mutates `Codegen`
+tables, and triggers recompilation. Forcing it into `LInst` would add zero-byte
+"instructions" that only touch side tables, degrading the machine-op
+abstraction. The clean invariant is therefore:
+
+> `encode_linst` is the single seam for byte **emission**; code-position
+> metadata / patch / recompile bookkeeping is *not* emission and stays in the
+> dispatcher / `Codegen`.
 
 None of this invalidates the model: `encode_linst` (with `encode_linst_macro`)
-is now the single seam for emission, and the residual dispatcher arms either lack
-the right context to *be* emission-only or are elementary leaves trivially
-reachable from it.
+is the single seam for emission, and the residual dispatcher arms either are
+bookkeeping rather than emission, or are deferred (`Call`) by effort rather than
+by a modelling limit.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -1,44 +1,36 @@
 # Unified low-level IR (LIR)
 
-Design notes and migration plan for the arch-neutral, machine-level IR that
-sits between `AsmIR` and the per-arch `monoasm!` / `monoasm_arm64!` byte
-emission. This is **Phase-1 item ①** ("a低レベルIR that describes amd64 and
-aarch64 uniformly").
+Design notes and migration log for the arch-neutral, machine-level IR that sits
+between `AsmIR` and the per-arch `monoasm!` / `monoasm_arm64!` byte emission.
+This is **Phase-1 item ①** ("a low-level IR that describes amd64 and aarch64
+uniformly").
 
-Status: **Stage 1 — data model defined, not yet wired into the pipeline.**
+Status: **actively migrating `AsmInst` families onto LIR, family by family.**
 The model lives in
-[`monoruby/src/codegen/jitgen/lir.rs`](../monoruby/src/codegen/jitgen/lir.rs).
+[`monoruby/src/codegen/jitgen/lir.rs`](../monoruby/src/codegen/jitgen/lir.rs);
+the per-arch encoder is `Codegen::encode_linst`, defined once in each
+`arch/<arch>/compile/…` file. As of this writing the integer + control-flow
+core, all addressing modes, the GC write barrier, the common guard/check family,
+fixnum arithmetic (with overflow deopt), and the first floating-point family are
+all lowered through `encode_linst`.
 
 ---
 
-## 1. Motivation (post-`#704`)
+## 1. Motivation
 
-The original justification for a unified IR was "close the aarch64 *bail* gap".
-That justification is **gone**: the full aarch64 port (`#704`) made aarch64
-lower every `AsmInst` (large immediates are materialized through scratch
-registers; see `doc/arch_difference.md`). The `bool` bail return is now
-vestigial.
+The original justification ("close the aarch64 *bail* gap") is **gone**: the
+full aarch64 port (`#704`) made aarch64 lower every `AsmInst` (see
+`doc/arch_difference.md`). The remaining — and real — motivation is
+**description unification**:
 
-The remaining — and still real — motivation is **description unification**:
-
-- The AsmIR → machine-code step is two parallel sets of emission primitives:
-  ≈145 `emit_*` methods on x86 (`arch/x86_64/compile/*.rs`) and ≈143 on aarch64
-  (`arch/aarch64/compile.rs`). Each backend re-implements register moves, frame
-  addressing, immediate-range handling and FP-pool save/restore by hand.
-- The aarch64 backend already factors immediate-range handling into helpers
-  (`a64_frame_load`, `a64_field_load`, `a64_sp_sub`, `a64_addr_sub`, …), each of
-  which folds a small displacement into the instruction or materializes a large
-  one into scratch `x9`/`x10`. That pattern is exactly what a low-level IR with
-  an addressing-mode abstraction formalizes — **once**, instead of per
-  primitive.
-- LIR is also the concrete **code-generation target** that the future
+- The AsmIR → machine-code step used to be two parallel sets of `emit_*`
+  primitives (x86 `arch/x86_64/compile/*.rs`, aarch64 `arch/aarch64/compile.rs`).
+  LIR makes `encode_linst` the **single seam** through which all migrated
+  families emit code.
+- LIR is also the concrete **code-generation target** the future
   interpreter/JIT DSL (Phase-1 item ③, "derive interpreter + JIT from one
-  description via partial evaluation") lowers to. Building it now gives ③ a
-  well-defined, hand-validated target.
-
-So Stage 1 is worth doing for unification and as ③'s foundation — but its
-priority should be weighed against that, not against a (now non-existent)
-coverage gap.
+  description") lowers to. A hand-written, test-validated LIR gives ③ a
+  well-defined target and a correctness oracle.
 
 ---
 
@@ -47,124 +39,186 @@ coverage gap.
 ```text
 TraceIR
   → AsmIR (AsmInst, arch-neutral, register-allocated)
-  → [compile_asmir dispatcher]                       jitgen/asmir/compile_shared.rs
-  → LIR (arch-neutral machine ops + logical addressing)   ← NEW (this layer)
-  → [per-arch LirEncode + legalize]                  arch/<arch>/lir_encode.rs (future)
+  → [compile_asmir dispatcher]                         jitgen/asmir/compile_shared.rs
+  → LIR (LInst, arch-neutral machine ops)              jitgen/lir.rs            ← this layer
+  → [per-arch Codegen::encode_linst]                   arch/<arch>/compile/…
   → monoasm! / monoasm_arm64!
   → bytes
 ```
 
-LIR does **not** replace `AsmIR`. `AsmIR` stays the register-allocated,
-arch-neutral *front-end* output (one `AsmInst` per semantic operation, often a
-macro-op that expands to a runtime call). LIR is the *machine-level* tier below
-it: a small set of real machine instructions with logical operands.
+`AsmIR` stays the register-allocated, arch-neutral *front-end* output (one
+`AsmInst` per semantic operation). The arch-neutral dispatcher
+`compile_asmir` ([compile_shared.rs](../monoruby/src/codegen/jitgen/asmir/compile_shared.rs))
+lowers each migrated `AsmInst` into one or more `LInst`s and feeds them to
+`encode_linst`; not-yet-migrated families still call their per-arch `emit_*`
+directly from the dispatcher.
+
+`encode_linst` is an inherent `Codegen` method, **defined once per arch** in the
+file that the `compile` module includes for the active `target_arch`. Because
+only one compiles per target, no trait/dynamic dispatch is needed — `cfg`
+selects the right encoder.
 
 ---
 
-## 3. Data model (Stage 1)
+## 3. Data model
 
-Defined in `lir.rs`. The model deliberately starts small, covering the integer
-move / memory / ALU / branch core migrated first in Stage 2.
+Defined in `lir.rs`. Branch and side-exit targets carry a **resolved monoasm
+`DestLabel`** (the encoder runs after label resolution), so `LInst` is
+`#[derive(Debug, Clone, PartialEq)]` — `DestLabel` is `Clone` but not `Copy`.
+
+### Operands
 
 | Type        | Role |
 | ----------- | ---- |
-| `GP`        | General-purpose register. **Reused as-is** from `codegen.rs`; already arch-neutral (maps to x86 regs / A64 `x0..x23` per `target_arch`). |
-| `FPReg`     | Virtual FP register (phys-xmm-or-spill). Reused; FP `LInst`s come in a later stage. |
-| `LOperand`  | `Reg(GP)` or `Imm(i64)` — an ALU/compare source that the encoder folds or materializes. |
-| `LMem`      | *Logical* memory location with **unbounded** displacement: `Slot(SlotId)` (LFP-relative, negative disp), `Field { base, disp }` (object field, positive disp), `RspRel { disp }` (callee-frame arg slot). |
-| `LCond`     | Signed integer branch condition (`Eq/Ne/Lt/Le/Gt/Ge`), with `from_int_cmp` / `invert`. Float/NaN-aware compares get dedicated variants later. |
+| `GP`        | General-purpose register. Reused from `codegen.rs`; already arch-neutral. |
+| `LReg`      | `Gp(GP)` or `Scratch` — a register that may be the per-arch reserved **scratch pointer** (`rdx` on x86, `x9` on aarch64). For intermediate pointers (heap var-table derefs) that must not clobber an allocated value; aarch64's x9 is outside `GP`'s allocatable map, so it needs its own kind. `From<GP>`. |
+| `FPReg`     | Virtual FP register (physical xmm/d-reg **or** a stack spill); the encoder resolves the spill via `FPReg::loc(base)`, so FP `LInst`s carry the frame's spill `base`. |
+| `LOperand`  | `Reg(GP)` or `Imm(i64)` — an ALU/compare source the encoder folds or materializes. |
+| `LMem`      | A *logical* memory location with **unbounded** displacement: `Slot(SlotId)` (LFP-relative, negative), `Field { base: LReg, disp }` (object field / scratch-relative, positive), `RspRel { disp }` (callee-frame arg slot). The encoder legalizes the displacement per arch. |
+| `LCond`     | Signed integer branch condition (`Eq/Ne/Lt/Le/Gt/Ge`), with `from_int_cmp` / `invert`. |
 | `LAluOp`    | `Add/Sub/Mul/And/Or/Xor/Shl/Sar`, with `from_binop`. |
-| `LInst`     | One machine instruction: `Mov`, `LoadImm`, `Load`, `Store`, `StoreImm`, `Alu`, `Cmp`, `Label`, `Br`, `CondBr`. |
-| `Lir`       | A straight-line `Vec<LInst>` with an ergonomic builder (`.mov().load().alu()…`). |
 
-Branch targets use the existing front-end `JitLabel` (resolved to a monoasm
-`DestLabel` by `JitContext::resolve_label`), matching how `AsmInst` carries
-labels.
+### Instructions (`LInst`)
+
+| Group | Variants |
+| ----- | -------- |
+| Move / immediate | `Mov`, `LoadImm` |
+| Memory | `Load`, `Store`, `StoreImm` (over `LMem::Slot` / `Field` / `RspRel`) |
+| ALU / compare | `Alu`, `Cmp` |
+| Branch | `Label`, `Br`, `CondBr { cond: LCond, … }`, `BranchTruthy { negate }`, `BranchIfNil`, `BranchIfNonzero` |
+| GC / nil | `WriteBarrier { parent, value }`, `NilIfZero { reg }` |
+| Guards (carry a side-exit `deopt`) | `GuardClass`, `GuardArrayTy`, `GuardFrozen`, `GuardConstBaseClass`, `GuardConstVersion`, `GuardCapture`, `CheckBOP` |
+| Arithmetic w/ deopt | `IntegerBinOp { kind, mode, lhs, rhs, deopt }` |
+| Floating-point | `FprMove`, `F64ToFpr`, `FixnumToFpr`, `FprToStack` (carry the spill `base`) |
+
+`Lir` is a thin `Vec<LInst>` builder used where a multi-instruction sequence is
+convenient.
 
 ### The legalization contract (the core idea)
 
-`LMem` displacements and `LOperand::Imm` values are **unbounded**. The per-arch
-encoder is solely responsible for legalizing them:
+`LMem` displacements and `LOperand::Imm` values are **unbounded**; the per-arch
+encoder legalizes them:
 
-- **x86-64**: `[reg + disp32]` and `imm32`/`imm64` cover essentially everything;
-  legalization is mostly a no-op.
-- **aarch64**: fixed-width encodings allow only small immediates. The encoder
-  folds a fitting displacement into the instruction (`ldur`/`stur` ±256,
-  scaled `ldr`/`str` ≤ 32760, `sub sp` ≤ 4095) and otherwise materializes the
-  byte offset into reserved scratch `x9`/`x10` and uses a register-offset form —
-  i.e. exactly what `a64_frame_load` / `a64_field_load` / `a64_addr_sub` do
-  today, but in one place.
-
-This is the single biggest structural win: the ~two dozen ad-hoc range checks
-currently scattered across the aarch64 primitives collapse into one legalizer.
+- **x86-64**: `[reg + disp32]` / `imm32` cover essentially everything — mostly a
+  no-op.
+- **aarch64**: fixed-width encodings allow only small immediates, so the encoder
+  folds a fitting displacement into the instruction (`ldur`/`stur` ±256, scaled
+  `ldr`/`str`, `sub sp`) and otherwise materializes the offset into reserved
+  scratch `x9`/`x10` (the `a64_frame_*` / `a64_field_*` / `a64_rsp_slot_addr`
+  helpers).
 
 ---
 
-## 4. The per-arch encoder seam
+## 4. The two model extensions (Stage 3)
 
-Stage 2 adds a per-arch lowering implemented on `Codegen`:
+Stages 2-A…2-J were *byte-for-byte family ports* that fit the data model as-is.
+Stage 3 extended the model so the harder families could be expressed:
 
-```rust
-trait LirEncode {
-    /// Emit one already-register-allocated `LInst`, legalizing immediates and
-    /// displacements. May use the arch's reserved scratch registers freely
-    /// (x9/x10 on aarch64).
-    fn encode(&mut self, inst: &LInst, labels: &SideExitLabels);
-}
-```
+1. **Scratch register operand (`LReg::Scratch`).** Lets the LIR express
+   intermediate pointers that map to a different physical register per arch
+   (x86 `rdx`, aarch64 `x9`). Without it, an abstract `GP` would either pick a
+   register that aarch64 keeps allocatable (clobber hazard) or have no name for
+   aarch64's reserved scratch. First user: the self heap-ivar store
+   (`Load{Scratch ← [rdi+VAR]} ; Load{Scratch ← [Scratch+MONOVEC_PTR]} ;
+   Store{[Scratch+idx*8] ← src} ; WriteBarrier`).
 
-`x86_64` impl emits via `monoasm!`; `aarch64` impl via `monoasm_arm64!` plus the
-existing `a64_*` addressing helpers. The seam is declared (commented) in
-`lir.rs` for visibility but left unimplemented in Stage 1.
-
----
-
-## 5. Migration plan (family by family, behind the dispatcher)
-
-Each `AsmInst` family is migrated independently and is independently
-revertible, because the change is local to its `emit_*` primitive: the primitive
-builds an `Lir` and runs it through `encode` instead of emitting bytes directly.
-`compile_asmir`'s dispatch is untouched.
-
-1. **Stage 2 — move / memory / ALU / branch core.** `RegMove`, `RegToAcc`,
-   `AccToStack`, `RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`,
-   `RegAdd`, `RegSub`, `IntegerBinOp` (Add/Sub/Mul fast path), `IntegerCmp`,
-   `IntegerCmpBr`, `CondBr`. These are the families behind the simplest
-   primitives and exercise the whole `LMem` + legalizer path.
-2. **Stage 3 — FP transfer / compare.** `FprMove`, `FprSwap`, `F64ToFpr`,
-   `FixnumToFpr`, `FloatToFpr`, `FprToStack`, `FloatBinOp`, `FloatUnOp`,
-   `FloatCmp(Br)`, `I64ToBoth`. Adds FP `LInst` variants; NaN-aware compares are
-   dedicated ops (x86 `ucomisd`+`setp` vs aarch64 `fcmp`+MI/LS).
-3. **Stage 4 — runtime-call macro-ops.** `NewArray`/`NewHash`/`defined?`/
-   `GenericBinOp`/`class_def`/… lower to an `LInst::Call` sequence with FP-pool
-   `Save`/`Restore` expressed in LIR, so the save/restore is written once.
-4. **Stage 5 — patch / recompile machinery.** Return-address patch points and
-   in-place recompile (the two remaining x86/aarch64 *non-coverage*
-   asymmetries, see `doc/arch_difference.md` §4). Hardest; may stay partly
-   arch-specific.
-5. **Stage 6 — cleanup.** Drop the now-vestigial `bool` returns of migrated
-   families; delete dead per-arch code; the aarch64 `compile.rs` monolith
-   shrinks and can be split to mirror x86.
+2. **Deopt side-exits.** Guard ops carry the *resolved* side-exit `DestLabel`
+   they fall through to, making deopt a first-class LIR concept. The
+   arch-neutral dispatcher resolves `labels[deopt]` and builds the guard; the
+   encoder branches to it. This pattern carries the overflow exit of
+   `IntegerBinOp` and every guard/check op.
 
 ---
 
-## 6. Verification strategy (replaces the old bail-metric)
+## 5. Encoding styles: decomposition vs. macro-op
 
-Because bails no longer exist, the Stage-0 "count aarch64 bails" metric is moot.
-The safety net is instead **behaviour preservation**:
+Migrated families use one of two encoder styles, both **byte-identical** to the
+prior code:
 
-- **x86 byte-identity.** For a fixed corpus (`benchmark/`, selected `tests/`),
-  the machine code emitted before and after each family migration must be
-  byte-identical on x86 (the reference backend is not changing *what* it emits,
-  only *how* the emission is expressed). The `emit-asm` feature dumps the
-  generated asm for diffing.
-- **aarch64 correctness.** `bin/test-aarch64` (qemu / native arm64) must stay
-  green; where aarch64 output legitimately changes (e.g. a large-offset path now
-  goes through the unified legalizer), correctness is checked against CRuby via
-  the normal `run_test` harness rather than byte-identity.
-- **Unit tests** on the LIR model itself (`lir.rs` `#[cfg(test)]`): condition
-  inversion, builder ordering, `from_binop` / `from_int_cmp` mappings.
+- **Decomposition** — the LIR sequence is built from reusable primitives and the
+  per-arch lowering lives in `encode_linst`. Used by the move/memory/ALU/branch
+  core, the field load/store + write-barrier, and the FP transfer/convert ops
+  (whose spill-aware bodies were *moved* from `emit_*` into the encoder arms,
+  deleting those `emit_*`).
+- **Macro-op delegation** — a single `LInst` whose encoder calls an existing
+  per-arch helper that stays (the tag-test / page-split / tagged-arith logic is
+  irreducibly per-arch). Used by the guards (delegate to `guard_class`,
+  `a64_guard_class`, `guard_capture`, …) and `IntegerBinOp` (delegate to
+  `integer_binop` / `a64_integer_binop`, which keep the x86 cold-page overflow
+  handler). The thin `emit_*` wrappers are deleted; the substantive helper stays.
 
-The north-star is "two `emit_*` sets collapse toward one shared description with
-no behaviour change", measured by lines of per-arch lowering removed and the
-green test matrix — not by a bail counter.
+---
+
+## 6. Migration log
+
+Each stage routes one family through `encode_linst`, commits, and is verified by
+the full `cargo test --lib` suite (see §7). All stages are byte-identical
+(modulo eliding a redundant self-`mov` when a value is already in the
+accumulator).
+
+| Stage | Family | Notes |
+| ----- | ------ | ----- |
+| 0 / 1 | LIR data model + this doc | scaffolding |
+| 2-A | `Mov` (`emit_reg_move`) | first `encode_linst` user |
+| 2-B | slot memory (`Load`/`Store`/`LoadImm`/`StoreImm` over `Slot`) | frame legalization |
+| 2-C | reg-imm ALU (`emit_reg_add/sub` → `Alu`) | `LAluOp` / `LOperand` |
+| 2-D | integer compare-branch (`Cmp` + `CondBr`) | `LCond`; built in shared dispatcher |
+| 2-E | conditional branches (`BranchTruthy` / `BranchIfNil` / `BranchIfNonzero`) | |
+| 2-F | inline struct-slot load (`Load` over `LMem::Field`) | first field-offset legalization |
+| 2-G | inline ivar/struct stores (`Store{Field}` + `WriteBarrier`) | introduces `WriteBarrier` |
+| 2-H | inline ivar load (`Load{Field}` + `NilIfZero`) | introduces `NilIfZero` |
+| 2-I | heap struct-slot load/store | composed from existing ops — no new op |
+| 2-J | rsp-relative arg stores (`LMem::RspRel`) | completes the addressing modes |
+| 3-A | **scratch operand** + self heap-ivar store | model extension ① |
+| 3-B | **deopt model** + class / array-ty / frozen guards | model extension ② |
+| 3-C | const-base-class / const-version / capture / BOP guards | |
+| 3-D | fixnum `IntegerBinOp` (overflow deopt) | hottest arithmetic path |
+| 3-E | FP transfer/convert (`FprMove` / `F64ToFpr` / `FixnumToFpr` / `FprToStack`) | first FP family; real decomposition |
+
+---
+
+## 7. Verification
+
+Because the migrations are pure refactors, the safety net is **behaviour
+preservation under a correct reference Ruby**:
+
+- The harness compares JIT output against the system `ruby`, and monoruby targets
+  **CRuby 4.0+**. With an older Ruby (e.g. 3.3) ~33 `--lib` tests fail on format
+  differences (3.4 `Hash#inspect`, etc.) — *unrelated to LIR*. Every stage here
+  is verified under **CRuby 4.0.5**, where the baseline is **1702 passed / 0
+  failed**; each migration keeps it at 1702 / 0 with no new warnings.
+- Each family migration is local to its `emit_*` / dispatcher arm and is
+  independently revertible.
+
+> Building CRuby 4.x from source in a restricted-network sandbox: the official
+> tarball host (`cache.ruby-lang.org`) may be blocked while GitHub is reachable.
+> Fetch the git tag source archive from `codeload.github.com`, install `gperf`
+> (needed to generate `lex.c`), empty `gems/bundled_gems` to skip the
+> bundled-gem download (or set `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+> so the bundled-gem fetch trusts the egress proxy CA), then
+> `autogen → configure → make → make install`.
+
+---
+
+## 8. Remaining work
+
+Families still lowered directly via `emit_*` (not yet through `encode_linst`):
+
+- **Floating point (rest):** `FprSwap`, `FloatToFpr` (deopt), `FloatBinOp` /
+  `FloatUnOp` / `FloatCmp` / `FloatCmpBr` (NaN-correct conditions), `I64ToBoth`,
+  the FP C-calls `CFunc_F_F` / `CFunc_FF_F`, and `XmmSave` / `XmmRestore`.
+- **Bounds-checked heap ivar** load/store (non-`self`): needs a bounds-check →
+  deopt/nil branch on top of the scratch model.
+- **Runtime-call macro-ops:** `NewArray` / `NewHash` / `ConcatStr` / `defined?`
+  family / `GenericBinOp` / class & method definition / the method-call prologue
+  (`SetupMethodFrame`, `SetArguments`, `Call`, `Init`) / exceptions / `Yield` /
+  the specialized inlined-frame family. These are large C-call sequences; most
+  would migrate as macro-ops carrying the relevant labels.
+- **Patch / recompile machinery** (return-address eviction, in-place recompile)
+  — the x86/aarch64 *non-coverage* asymmetry from `doc/arch_difference.md` §4;
+  the hardest to model.
+
+These extend, but do not invalidate, the model: each needs either a macro-op
+(carrying its labels) or, where the per-arch shape genuinely differs (FP spill,
+NaN compares, page-split deopt), a dedicated op whose encoder reproduces the
+arch sequence byte-for-byte.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -1,0 +1,170 @@
+# Unified low-level IR (LIR)
+
+Design notes and migration plan for the arch-neutral, machine-level IR that
+sits between `AsmIR` and the per-arch `monoasm!` / `monoasm_arm64!` byte
+emission. This is **Phase-1 item ①** ("a低レベルIR that describes amd64 and
+aarch64 uniformly").
+
+Status: **Stage 1 — data model defined, not yet wired into the pipeline.**
+The model lives in
+[`monoruby/src/codegen/jitgen/lir.rs`](../monoruby/src/codegen/jitgen/lir.rs).
+
+---
+
+## 1. Motivation (post-`#704`)
+
+The original justification for a unified IR was "close the aarch64 *bail* gap".
+That justification is **gone**: the full aarch64 port (`#704`) made aarch64
+lower every `AsmInst` (large immediates are materialized through scratch
+registers; see `doc/arch_difference.md`). The `bool` bail return is now
+vestigial.
+
+The remaining — and still real — motivation is **description unification**:
+
+- The AsmIR → machine-code step is two parallel sets of emission primitives:
+  ≈145 `emit_*` methods on x86 (`arch/x86_64/compile/*.rs`) and ≈143 on aarch64
+  (`arch/aarch64/compile.rs`). Each backend re-implements register moves, frame
+  addressing, immediate-range handling and FP-pool save/restore by hand.
+- The aarch64 backend already factors immediate-range handling into helpers
+  (`a64_frame_load`, `a64_field_load`, `a64_sp_sub`, `a64_addr_sub`, …), each of
+  which folds a small displacement into the instruction or materializes a large
+  one into scratch `x9`/`x10`. That pattern is exactly what a low-level IR with
+  an addressing-mode abstraction formalizes — **once**, instead of per
+  primitive.
+- LIR is also the concrete **code-generation target** that the future
+  interpreter/JIT DSL (Phase-1 item ③, "derive interpreter + JIT from one
+  description via partial evaluation") lowers to. Building it now gives ③ a
+  well-defined, hand-validated target.
+
+So Stage 1 is worth doing for unification and as ③'s foundation — but its
+priority should be weighed against that, not against a (now non-existent)
+coverage gap.
+
+---
+
+## 2. Where LIR sits
+
+```text
+TraceIR
+  → AsmIR (AsmInst, arch-neutral, register-allocated)
+  → [compile_asmir dispatcher]                       jitgen/asmir/compile_shared.rs
+  → LIR (arch-neutral machine ops + logical addressing)   ← NEW (this layer)
+  → [per-arch LirEncode + legalize]                  arch/<arch>/lir_encode.rs (future)
+  → monoasm! / monoasm_arm64!
+  → bytes
+```
+
+LIR does **not** replace `AsmIR`. `AsmIR` stays the register-allocated,
+arch-neutral *front-end* output (one `AsmInst` per semantic operation, often a
+macro-op that expands to a runtime call). LIR is the *machine-level* tier below
+it: a small set of real machine instructions with logical operands.
+
+---
+
+## 3. Data model (Stage 1)
+
+Defined in `lir.rs`. The model deliberately starts small, covering the integer
+move / memory / ALU / branch core migrated first in Stage 2.
+
+| Type        | Role |
+| ----------- | ---- |
+| `GP`        | General-purpose register. **Reused as-is** from `codegen.rs`; already arch-neutral (maps to x86 regs / A64 `x0..x23` per `target_arch`). |
+| `FPReg`     | Virtual FP register (phys-xmm-or-spill). Reused; FP `LInst`s come in a later stage. |
+| `LOperand`  | `Reg(GP)` or `Imm(i64)` — an ALU/compare source that the encoder folds or materializes. |
+| `LMem`      | *Logical* memory location with **unbounded** displacement: `Slot(SlotId)` (LFP-relative, negative disp), `Field { base, disp }` (object field, positive disp), `RspRel { disp }` (callee-frame arg slot). |
+| `LCond`     | Signed integer branch condition (`Eq/Ne/Lt/Le/Gt/Ge`), with `from_int_cmp` / `invert`. Float/NaN-aware compares get dedicated variants later. |
+| `LAluOp`    | `Add/Sub/Mul/And/Or/Xor/Shl/Sar`, with `from_binop`. |
+| `LInst`     | One machine instruction: `Mov`, `LoadImm`, `Load`, `Store`, `StoreImm`, `Alu`, `Cmp`, `Label`, `Br`, `CondBr`. |
+| `Lir`       | A straight-line `Vec<LInst>` with an ergonomic builder (`.mov().load().alu()…`). |
+
+Branch targets use the existing front-end `JitLabel` (resolved to a monoasm
+`DestLabel` by `JitContext::resolve_label`), matching how `AsmInst` carries
+labels.
+
+### The legalization contract (the core idea)
+
+`LMem` displacements and `LOperand::Imm` values are **unbounded**. The per-arch
+encoder is solely responsible for legalizing them:
+
+- **x86-64**: `[reg + disp32]` and `imm32`/`imm64` cover essentially everything;
+  legalization is mostly a no-op.
+- **aarch64**: fixed-width encodings allow only small immediates. The encoder
+  folds a fitting displacement into the instruction (`ldur`/`stur` ±256,
+  scaled `ldr`/`str` ≤ 32760, `sub sp` ≤ 4095) and otherwise materializes the
+  byte offset into reserved scratch `x9`/`x10` and uses a register-offset form —
+  i.e. exactly what `a64_frame_load` / `a64_field_load` / `a64_addr_sub` do
+  today, but in one place.
+
+This is the single biggest structural win: the ~two dozen ad-hoc range checks
+currently scattered across the aarch64 primitives collapse into one legalizer.
+
+---
+
+## 4. The per-arch encoder seam
+
+Stage 2 adds a per-arch lowering implemented on `Codegen`:
+
+```rust
+trait LirEncode {
+    /// Emit one already-register-allocated `LInst`, legalizing immediates and
+    /// displacements. May use the arch's reserved scratch registers freely
+    /// (x9/x10 on aarch64).
+    fn encode(&mut self, inst: &LInst, labels: &SideExitLabels);
+}
+```
+
+`x86_64` impl emits via `monoasm!`; `aarch64` impl via `monoasm_arm64!` plus the
+existing `a64_*` addressing helpers. The seam is declared (commented) in
+`lir.rs` for visibility but left unimplemented in Stage 1.
+
+---
+
+## 5. Migration plan (family by family, behind the dispatcher)
+
+Each `AsmInst` family is migrated independently and is independently
+revertible, because the change is local to its `emit_*` primitive: the primitive
+builds an `Lir` and runs it through `encode` instead of emitting bytes directly.
+`compile_asmir`'s dispatch is untouched.
+
+1. **Stage 2 — move / memory / ALU / branch core.** `RegMove`, `RegToAcc`,
+   `AccToStack`, `RegToStack`, `StackToReg`, `LitToReg`, `LitToStack`,
+   `RegAdd`, `RegSub`, `IntegerBinOp` (Add/Sub/Mul fast path), `IntegerCmp`,
+   `IntegerCmpBr`, `CondBr`. These are the families behind the simplest
+   primitives and exercise the whole `LMem` + legalizer path.
+2. **Stage 3 — FP transfer / compare.** `FprMove`, `FprSwap`, `F64ToFpr`,
+   `FixnumToFpr`, `FloatToFpr`, `FprToStack`, `FloatBinOp`, `FloatUnOp`,
+   `FloatCmp(Br)`, `I64ToBoth`. Adds FP `LInst` variants; NaN-aware compares are
+   dedicated ops (x86 `ucomisd`+`setp` vs aarch64 `fcmp`+MI/LS).
+3. **Stage 4 — runtime-call macro-ops.** `NewArray`/`NewHash`/`defined?`/
+   `GenericBinOp`/`class_def`/… lower to an `LInst::Call` sequence with FP-pool
+   `Save`/`Restore` expressed in LIR, so the save/restore is written once.
+4. **Stage 5 — patch / recompile machinery.** Return-address patch points and
+   in-place recompile (the two remaining x86/aarch64 *non-coverage*
+   asymmetries, see `doc/arch_difference.md` §4). Hardest; may stay partly
+   arch-specific.
+5. **Stage 6 — cleanup.** Drop the now-vestigial `bool` returns of migrated
+   families; delete dead per-arch code; the aarch64 `compile.rs` monolith
+   shrinks and can be split to mirror x86.
+
+---
+
+## 6. Verification strategy (replaces the old bail-metric)
+
+Because bails no longer exist, the Stage-0 "count aarch64 bails" metric is moot.
+The safety net is instead **behaviour preservation**:
+
+- **x86 byte-identity.** For a fixed corpus (`benchmark/`, selected `tests/`),
+  the machine code emitted before and after each family migration must be
+  byte-identical on x86 (the reference backend is not changing *what* it emits,
+  only *how* the emission is expressed). The `emit-asm` feature dumps the
+  generated asm for diffing.
+- **aarch64 correctness.** `bin/test-aarch64` (qemu / native arm64) must stay
+  green; where aarch64 output legitimately changes (e.g. a large-offset path now
+  goes through the unified legalizer), correctness is checked against CRuby via
+  the normal `run_test` harness rather than byte-identity.
+- **Unit tests** on the LIR model itself (`lir.rs` `#[cfg(test)]`): condition
+  inversion, builder ordering, `from_binop` / `from_int_cmp` mappings.
+
+The north-star is "two `emit_*` sets collapse toward one shared description with
+no behaviour change", measured by lines of per-arch lowering removed and the
+green test matrix — not by a bail counter.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -17,9 +17,10 @@ families (array/hash/string/range construction, `defined?`, generic binops,
 class/method definition, exceptions, `yield`, the method-prologue guards, …) are
 all lowered through `encode_linst`, as is the **entire** method-call family —
 argument setup *and* the call itself (the dispatcher pre-resolves the
-store/frame-dependent values and the encoder stays store-free). What remains in
-the dispatcher is the specialized inlined-frame family and the patch/recompile
-bookkeeping that is *not* byte emission — see §8.
+store/frame-dependent values and the encoder stays store-free) — and the cold
+**deopt side-exit handler** blocks. What remains outside is the specialized
+inlined-frame family, the `AsmInst::Inline` escape hatch, and the zero-byte
+patch/recompile bookkeeping that is *not* byte emission — see §8.
 
 ---
 
@@ -221,6 +222,7 @@ accumulator).
 | B5 | elementary moves (`RegMove`/`RegToAcc`/`AccToStack`/`RegToStack`/`StackToReg`/`LitToReg`/`LitToStack`/`RegAdd`/`RegSub`) | dispatcher lowers straight to `LInst`; the thin `emit_*` move wrappers deleted from both backends |
 | B6 | method-call / argument-setup (`SetupMethodFrame`, `SetArguments`, `SetArgumentsForwardedHelper`, `Preparation`, `OptCase`) | dispatcher pre-resolves the store/frame-dependent values (offset, block info, heap-ivar length, jump-table labels) into the `LInst`; per-arch helpers made store-free |
 | B7 | the call itself (`Call`) | dispatcher pre-resolves `codeptr` / `is_iseq` / callee+call-site pcs / x86 JIT entry (`get_jit_entry`); `do_call`/`a64_do_call` made store-free. x86 still records the return-address patch point inside the call's encoder (it is captured at the emission point); aarch64 ignores the x86-only fields |
+| B8 | cold side-exit / deopt handlers (`LInst::SideExit { kind }`) | both `gen_asm` side-exit loops build an `LInst::SideExit` and route through `encode_linst`; the per-arch encoder dispatches on `LSideExitKind` (Deopt / Evict / RecompileDeopt / Error) to the existing handler emitters (x86 `gen_*_with_label` / `gen_handle_error`; aarch64 `a64_gen_deopt` / `a64_gen_handle_error`, which collapse Evict/RecompileDeopt to a plain deopt) |
 
 ---
 
@@ -262,26 +264,32 @@ return-address patch point, which is captured *at* the emission point and so
 belongs with the call's emission. (The elementary register/stack moves were
 likewise inlined into the dispatcher in B5, deleting their forwarding wrappers.)
 
-The arms still handled **directly in the `compile_asmir` dispatcher**:
+The **cold side-exit / deopt handler blocks** that guards branch *to* — laid
+out by `gen_asm` *before* the main instruction loop, not by an `AsmInst` — are
+also byte emission, and as of B8 they route through `encode_linst` via
+`LInst::SideExit` (write-back + sp-unwind + VM-resume / unwind). Both arches'
+`gen_asm` side-exit loops now build an `LInst::SideExit` and the per-arch
+encoder dispatches on `LSideExitKind`.
+
+The remaining things handled **directly** (not through `encode_linst`):
 
 - **Specialized inlined-frame family.** `MethodRetSpecialized`,
   `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`,
   `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
   resolve frame-local labels and patch points and are dispatched to a per-arch
   method of the same name (`arch/<arch>/compile/…`).
+- **The `AsmInst::Inline` escape hatch.** Builtin inline generators (e.g.
+  `emit_math_sqrt`) run a closure that emits arch asm directly via `gen`.
+- **Pure patch / recompile *bookkeeping*** — the x86/aarch64 *non-coverage*
+  asymmetry of `doc/arch_difference.md` §4. The deopt *handler emission* now
+  goes through LIR (above); what stays out is the part that **emits no bytes**:
+  `ImmediateEvict` records a `return_addr_table` patch point (zero bytes), and
+  the actual return-address overwrite happens at BOP-redefinition time, not at
+  compile time. The clean invariant is therefore:
 
-Beyond the dispatcher, the **patch / recompile machinery** (return-address
-eviction, in-place recompile) is the x86/aarch64 *non-coverage* asymmetry
-described in `doc/arch_difference.md` §4. This is **explicitly out of scope** for
-LIR: it does not *emit bytes* — it records code-position metadata
-(`return_addr_table` patch points, which emit zero bytes), mutates `Codegen`
-tables, and triggers recompilation. Forcing it into `LInst` would add zero-byte
-"instructions" that only touch side tables, degrading the machine-op
-abstraction. The clean invariant is therefore:
-
-> `encode_linst` is the single seam for byte **emission**; code-position
-> metadata / patch / recompile bookkeeping is *not* emission and stays in the
-> dispatcher / `Codegen`.
+> `encode_linst` is the single seam for byte **emission**; zero-byte
+> code-position metadata / runtime patch bookkeeping is *not* emission and stays
+> in the dispatcher / `Codegen`.
 
 None of this invalidates the model: `encode_linst` (with `encode_linst_macro`)
 is the single seam for byte emission. The only arms still handled directly in

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1,0 +1,189 @@
+# Separating the abstract interpreter from register allocation
+
+Design study for **Phase-1 item ②** ("separate the abstract interpreter /
+fixpoint search from register allocation"). This is the structural prerequisite
+for the longer-term goals: collapsing AsmIR into LIR (goal 1) and deriving the
+VM and JIT from one description via partial evaluation (goal 3 / item ③).
+
+Status: **design proposal only** — no code has moved yet.
+
+---
+
+## 1. Where the two concerns are fused today
+
+The JIT's middle end runs a single abstract-interpretation pass over TraceIR
+that *simultaneously* infers types and assigns physical storage. The fusion
+lives in three places:
+
+### `LinkMode` — one enum, three concerns
+
+`monoruby/src/codegen/jitgen/state/slot.rs:1229`
+
+```rust
+enum LinkMode {
+    V,                  // no value
+    None / MaybeNone,   // optional-arg sentinels
+    S(Guarded),         // boxed on the stack      + type guard
+    G(Guarded),         // boxed in GP r15 (acc)   + type guard
+    F(FPReg),           // unboxed f64 in an xmm    (type = Float)
+    Sf(FPReg, SfGuarded // unboxed in xmm + boxed cache on stack + type
+    C(Value),           // compile-time constant   (type = guarded(v))
+}
+```
+
+Each variant encodes **all three** of: the abstract *type* (`Guarded` class /
+float-ness / concrete value), the *representation* (boxed `Value` vs unboxed
+`f64`), and the *location* (stack home / GP `r15` / xmm pool).
+
+### `SlotState` — type lattice and allocation map in one struct
+
+`monoruby/src/codegen/jitgen/state/slot.rs:4`
+
+```rust
+struct SlotState {
+    slots: Vec<LinkMode>,    // per-slot fused type+repr+location
+    liveness: Vec<IsUsed>,   // analysis
+    vfpr: Vec<Vec<SlotId>>,  // allocation: reverse map xmm/spill -> slots
+    r15: Option<SlotId>,     // allocation: who owns the accumulator
+    pinned_vfpr: Vec<FPReg>, // allocation directive (anti-aliasing)
+    …
+}
+```
+
+### Allocation decisions are taken *inside* the dataflow
+
+- `alloc_xmm` (`slot.rs:370`) does greedy linear-scan allocation (find a vacant
+  physical xmm `0..PHYS_XMM_POOL`; else demote an `Sf` cache; else spill to
+  `FPReg(N≥PHYS_XMM_POOL)`).
+- `def_F` / `def_Sf_*` (`slot.rs:554`) allocate a register **and** set the slot's
+  type in one call.
+- `AbstractFrame::join` (`state/join.rs:46`) merges *type guards* and
+  *reconciles registers* together — it can even allocate a fresh xmm mid-merge
+  (`try_set_new_F`) when two predecessors hold a value in different xmms.
+
+### What is already factored out
+
+`FPReg` (`codegen.rs:181`) is **already a virtual register**: `FPReg(0..13)` →
+`xmm2..xmm15`, `FPReg(14+)` → an 8-byte stack spill, resolved late by
+`FPReg::loc(base)` (`codegen.rs:188`). `AsmInst` operands carry `FPReg`, so the
+*operand* layer is virtual. What is **not** factored out is *when/where the
+FPReg assignment is decided* — it happens inline with type inference.
+
+**Net:** type analysis, representation (box/unbox), and register allocation are
+one pass over one fused `LinkMode`/`SlotState`. ② is about teasing these apart.
+
+---
+
+## 2. Why separate (the payoff)
+
+- **Goal 1 (collapse AsmIR into LIR).** Once allocation is a distinct step that
+  *emits*, it can emit `LInst` directly; the `AsmInst` layer (already ~isomorphic
+  to `LInst` after the B-migrations) stops carrying its own existence.
+- **Goal 3 (one description → VM + JIT).** Partial evaluation needs the *analysis*
+  to be reusable under two different allocation policies:
+  - **JIT residual** = analysis with inline-cache types + the greedy xmm
+    allocator (today's behaviour).
+  - **VM residual** = analysis with ⊤ (no specialization) + a *fixed-convention*
+    allocator (everything boxed in its stack home, no pool). 
+  You cannot instantiate two allocators while allocation is welded to inference.
+- **Maintainability.** The `join` table conflates a type lattice with a register
+  reconciler; splitting them makes each independently testable.
+
+---
+
+## 3. Target architecture
+
+Three layers, with a typed IR in the middle:
+
+```
+TraceIR
+  │  ① analysis pass  (fixpoint; types + liveness only — NO locations)
+  ▼
+Typed IR            per-slot AbstractType lattice + liveness; operands are
+  │                 (slot, representation) — still virtual, no phys regs
+  │  ② allocation + lowering pass  (pluggable Allocator)
+  ▼
+LIR (LInst)         concrete regs/spills; emitted straight to encode_linst
+  ▼  encode_linst → bytes
+```
+
+### Layer ① — the type lattice (analysis)
+
+A pure lattice element per slot, *no* location:
+
+```rust
+enum AbstractType {
+    Top,                 // unknown (⊤)
+    Class(ClassId),      // boxed value of known class (+ guard)
+    Float,               // value known to be Float (unboxable)
+    Fixnum,              // value known to be Fixnum
+    Concrete(Value),     // compile-time constant (⊥-ish)
+    Bottom,              // unreachable
+}
+```
+
+`join` over this is a *pure* lattice meet — no register churn. Liveness stays
+here. This pass is what goal 3's partial evaluator parameterizes (feed ⊤ for the
+VM residual, IC-narrowed types for the JIT residual).
+
+### Layer ② — representation + allocation
+
+Given the typed IR + liveness, a separate step decides:
+1. **Representation**: keep a `Float`/`Fixnum` value unboxed where it is consumed
+   by FP arithmetic, else boxed. (Today: the `F` vs `S` vs `Sf` choice.)
+2. **Placement**: assign each live unboxed value an `FPReg` (pool or spill) and
+   each boxed value its stack home / the `r15` accumulator. Insert transfer /
+   spill / φ-move code at edges.
+
+This is the swappable `Allocator`. The default is the current greedy policy;
+the VM policy is "no pool, everything in its stack home."
+
+---
+
+## 4. Incremental migration path
+
+Each step is independently shippable and verified at **1702/0** (behaviour
+preservation under CRuby 4.0+). Order chosen so the risky structural change
+comes last, after the data is already decoupled.
+
+| Step | Change | Risk |
+| ---- | ------ | ---- |
+| **0. Data split** | Inside `SlotState`, replace the fused `Vec<LinkMode>` with two parallel views: `ty: Vec<AbstractType>` (lattice) and `place: Vec<Placement>` (Stack / Gp / Xmm(FPReg) / XmmStack(FPReg)). `LinkMode` becomes a derived accessor. `join` splits into `join_ty` + `reconcile_place`. **No behaviour change.** | low |
+| **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
+| **2. Standalone analysis** | Run the layer-① fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
+| **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
+| **4. Two allocators (goal 3 enabler)** | Add the fixed-convention VM `Allocator`; spike VM-residual generation for one bytecode. | research |
+
+Steps 0–1 are mechanical decoupling that pay off immediately (clearer code,
+testable lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
+
+---
+
+## 5. Hard parts / open questions
+
+- **Join-time reallocation.** Today `join` may allocate a fresh xmm when two
+  predecessors hold a value in different registers. Separated, the allocator must
+  resolve this as an SSA-φ with **edge moves** (insert `FprMove`s on the
+  CFG edges) rather than reallocation during the meet. This is the crux: step 2
+  effectively turns the fused greedy pass into a proper linear-scan / SSA
+  allocator with edge fixups. Codegen quality must not regress (the current
+  greedy is decent on the FP-heavy benchmarks).
+- **`Sf` (xmm + stack cache).** It is a *representation* optimisation that blurs
+  type and placement. In the split it is `(ty = Float|Fixnum, place = both)`; the
+  *demote-on-pressure* logic (`try_alloc_xmm` phase 1) is an allocation policy
+  that must move wholesale into the `Allocator`.
+- **`r15` accumulator.** The single GP "accumulator" slot is its own tiny
+  allocation problem fused into `SlotState.r15`; it follows the same split
+  (type vs placement) but is simpler than the xmm pool.
+- **Spill-region sizing across joins** (`grow_xmm_to`, `gen_bridge`) becomes the
+  allocator's responsibility once placement is its own layer.
+
+---
+
+## 6. Recommendation
+
+Start with **step 0 (data split)**: factor `LinkMode` into a type lattice +
+a placement map *without* changing the single-pass control flow. It is low-risk,
+keeps the suite at 1702/0, and immediately yields a reusable `AbstractType`
+lattice — the exact artifact goal 3's partial evaluator will consume. Steps 1–2
+then follow with the structural separation, and goals 1/3 fall out of step 3–4.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -321,3 +321,12 @@ analysis-precomputed placement at that point; the typed IR records the deopt
 program point (pc), not a frozen `AsmDeopt`. This is the main wrinkle that
 distinguishes the FP-load transfers from the simple evictions, and it is where
 the typed IR must carry per-point placement (which the analysis already tracks).
+
+**Resolved (`load_xmm` split).** `load_xmm` / `load_xmm_fixnum` now split into a
+`load_xmm_state` half (allocate the xmm, bind the slot) returning an `XmmLoad`
+record (`None` / `FromStack` / `FromAcc` / `FromF64` / `FromFixnum`), plus a
+wrapper that creates the deopt **first** (so its write-back snapshot is the
+pre-load placement) and passes it as `Option<AsmDeopt>` to `XmmLoad::emit`. The
+deopt is therefore supplied by the codegen side, **not** frozen into the record;
+the guard-free numeric variants pass `None`. This confirms the resolution above
+concretely — behaviour-identical at 1703/0.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -378,3 +378,66 @@ a record-replaying emit half. That completes the prerequisite for the two-pass
 wiring: the analysis pass calls the `*_state` halves and collects the records;
 codegen replays `record.emit(...)`. The remaining step is plumbing those two
 passes through `compile_instruction` / `analyse_basic_block`.
+
+## 10. The analysis/codegen seam already exists: `codegen_mode`
+
+Before building a two-pass from scratch, a closer read of the driver shows the
+seam is **already present**, which reframes step 2.
+
+### What is actually there
+
+`AsmIr` carries `codegen_mode: bool` (`asmir.rs:76`), seeded from
+`JitContext::codegen_mode()`. Crucially **`AsmIr::push` is already gated on it**:
+
+```rust
+fn push(&mut self, inst: AsmInst) {
+    if self.codegen_mode { self.inst.push(inst); }   // no-op in analysis mode
+}
+```
+
+Two passes already run the *same* `compile_instruction` under the two modes:
+
+- **Loop-analysis pre-pass** — `JitContext::loop_analysis` sets
+  `codegen_mode: false` (`context.rs:687`). `analyse_backedge_fixpoint` →
+  `analyse_basic_block` runs the handlers to compute the loop's back-edge /
+  liveness fix-point. `push` is suppressed, so **no `AsmInst` is built** — it
+  produces *abstract state*, not an instruction stream.
+- **Codegen pass** — `traceir_to_asmir` → `compile_basic_block` runs with
+  `codegen_mode: true`, doing analysis **and** emission in one fused walk.
+
+Handlers that must diverge between the two modes already branch on
+`self.codegen_mode()` (e.g. `binop_uncached` in `binary_op.rs:25` widens to `S`
+during analysis but emits a per-instruction deopt+recompile during codegen).
+
+**Correction to §9:** the claim that the analysis pass "builds `AsmInst` only to
+drop them" is wrong — `push` is gated, so analysis never accumulates the stream.
+The only residual analysis-mode waste is computing a transfer record and then
+calling its no-op `emit`, plus ungated `side_exit` growth (`new_deopt` /
+`new_label` are not gated, but their results are unused in analysis).
+
+### What this means for step 2
+
+The separation is **not** "introduce an analysis pass" — that exists. It is two
+remaining, independent pieces:
+
+1. **De-fuse allocation from the dataflow (the §5 crux).** Today *both* passes
+   allocate: `alloc_xmm` / `join`'s register reconciliation mutate placement
+   *inside* the abstract-interpretation walk. So the loop pre-pass is "analysis +
+   allocation with emission suppressed," not pure type/liveness analysis. The real
+   work is pulling placement out of the join — turning join-time reallocation into
+   SSA-φ **edge moves** — so the analysis pass computes *only* `Guarded` + liveness
+   and the allocator runs as the second pass over that result. This is the
+   high-risk core; codegen quality (the greedy xmm policy) must not regress.
+2. **Record-driven lowering (goal 1).** Once allocation is its own pass, the
+   codegen walk replays the typed-IR records (`Spill` / `FpXfer` / `XmmLoad` /
+   `GpLoad` / `XmmFixnumLoad` / guard) emitting `LInst` directly, and `AsmInst`
+   retires. The transfer-primitive split (now complete) is exactly what makes the
+   replay possible; the open wrinkle is the deopt, which must become a *program
+   point* reconstructed from the analysis-precomputed placement at that pc rather
+   than the frozen `AsmDeopt` the records carry today (§9 deopt note).
+
+So the two-mode `compile_instruction` is the chassis; the remaining engineering
+is (1) then (2). (1) is the architectural fork — re-execution-based (generalize
+the `codegen_mode` pre-pass to all code, feeding precomputed states forward) vs.
+record-stream-based (collect records, lower from them) — and is the decision to
+take deliberately, since it sets how allocation is staged.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -287,3 +287,37 @@ This is a far more bounded and mechanical change than a per-handler rewrite, and
 each primitive split is independently shippable and behaviour-verifiable at
 1703/0 (the `writeback_acc` split is the first). It also subsumes goal 1: once
 lowering is its own pass, it emits `LInst` directly and `AsmInst` retires.
+
+### Progress on the transfer-primitive split
+
+Split so far, each behaviour-identical at 1703/0:
+
+- **Stack writebacks** → the `Spill` record (`None` / `Fpr` / `Lit` / `Acc`):
+  `writeback_acc`, `write_back_slot`, `to_S_unguarded`.
+- **FP-register transfers** → the `FpXfer` record (`Move` / `Swap`): `to_sf`
+  (`gen_xmm_swap` was already a clean state-line + emit-line).
+
+Each primitive now has a `*_state` half that performs the abstract-state
+transition and returns the record, plus a thin codegen wrapper `record.emit(ir)`.
+The records (`Spill`, `FpXfer`) are the growing **typed IR** vocabulary.
+
+### The hard tail: deopt-carrying transfers
+
+The unbox loads (`load_xmm` and friends) are *not* a clean `(state) + (record →
+emit)` split, because they create a **deopt side-exit** mid-flight:
+
+```rust
+let deopt = ir.new_deopt(self);     // captures state.get_write_back() — a
+self.use_as_float(slot);            // SNAPSHOT of the live placement state
+match self.mode(slot) { S(_) => { let x = self.set_new_Sf(..); 
+    ir.stack2reg(slot, Rdi); ir.float_to_fpr(Rdi, x, deopt); x } … }
+```
+
+`new_deopt` snapshots `get_write_back()` — *which* values are unboxed/in-acc and
+must be restored to the stack if the float guard fails. That snapshot is the
+placement state **at this program point**. So in the separated design the deopt
+is created by the **codegen pass**, reconstructing the write-back from the
+analysis-precomputed placement at that point; the typed IR records the deopt
+program point (pc), not a frozen `AsmDeopt`. This is the main wrinkle that
+distinguishes the FP-load transfers from the simple evictions, and it is where
+the typed IR must carry per-point placement (which the analysis already tracks).

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1167,3 +1167,33 @@ the loop-carried-float type precision fix. (aarch64 unverified here — no cross
 toolchain in this container; the new bridge arms reuse `float_to_fpr` / `fpr_move`,
 which both backends already lower, so they are arch-neutral by construction, but
 this needs an M1 `bin/test` to confirm.)
+
+### 15.5 Root cause + sound fix: loop-JIT conservative entry typing
+
+The "type loss" is **not** a literal-handling bug. `jit-debug` on a loop-JIT
+(`start:[:loop_start]`) shows the loop-entry forward state has *every* local as
+`S(Value)` — because a **loop JIT does not see the values produced before the
+loop** (`x = 0.0` ran in the VM). So a loop-carried float necessarily enters from
+the VM as a conservative boxed `S(Value)`, even though the back-edge fixpoint
+proves it is a `Float (F)`. The merge `join(S(Value), F)` → `S(Value)` then forces
+the body to decode+rebox it every iteration (§15.3/§15.4).
+
+**Sound fix (`loop-keep-float`, suite 1704/0, default-off).** At the loop header,
+adopt the back-edge fixpoint's `F` for such a slot. The forward entry is unboxed
+**once** at the pre-header by the new `S -> F` bridge arm, whose `float_to_fpr`
+carries the **runtime float guard** (deopt if the VM value is not a float) — so the
+specialization is sound for a runtime value. Soundness across *all* predecessors
+is enforced by `keep_backedge_floats`'s `promotable(i)` gate: promote only when
+every predecessor entry has a valid `_ -> F` bridge (`F`/`S`/`Sf`/float-`C`); a
+non-float-`C` path is genuinely not a float, so it is left boxed (this is the gate
+the earlier `guarded == Float` over-approximated, which made it a no-op — §15.4).
+
+Result on the mandelbrot kernel: **`call float_to_value` 16 → 0**, the hot inner
+loop becomes pure xmm, and the per-iteration flonum decode collapses to a single
+guarded pre-header unbox. Correct on the whole suite (1704/0), including the
+`xmm_swap`/bridge regression cases. Static `do_it` grows 340 → 450 (the decodes
+move to the per-loop-entry pre-headers), so the win is dynamic (hot loop) — to be
+confirmed by an M1 `--release` bench A/B (and aarch64, which reuses the same
+`float_to_fpr`/`fpr_move` AsmIR ops). This is the first measured *improvement* over
+base in the §5 line, and it lands as a guarded loop-entry type specialization —
+the same shape YJIT uses — rather than a new allocator.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -538,3 +538,30 @@ What remains for full record-driven lowering is the §10-item-1 core (de-fuse
 allocation from the join — the SSA-φ edge-move rewrite) and lowering the *op
 handlers'* direct emissions through records too; the transfer primitives are
 done.
+
+## 12. §5 crux, first cut: de-fusing allocation from the join
+
+The §5 crux is that `AbstractFrame::join` *allocates* (`try_set_new_F` /
+`try_set_new_Sf`) during the meet — fusing register allocation into the
+dataflow. First de-fusion step, mirroring the transfer state/emit split:
+
+The per-slot meet table is now split into
+- **`decide_join(other, i) -> JoinAction`** — a pure, read-only function of the
+  two predecessors' `LinkMode`s: the merge *decision*; and
+- **`apply_join(i, action)`** — which performs the placement mutation and is the
+  **only** place the meet allocates an xmm.
+
+`JoinAction` reifies the nine meet outcomes (`Nop` / `SetMaybeNone` / `Discard` /
+`TryFreshFKeep` / `TryFreshFElseS` / `SetSf` / `TryFreshSfElseKeep` /
+`TryFreshSfElseS` / `SetS`). The fresh-xmm rebinds (`TryFresh*`) are the
+join-time reallocation §5 targets; they are now isolated in `apply_join`, behind
+one seam. Behaviour is identical (the same operations, reorganized) — suite
+1703/0.
+
+This is the structural prerequisite for the real change: an allocator pass that
+consumes the `JoinAction` stream and assigns registers + inserts edge moves
+(`bridge` already emits the FprMove/swap edge fixups), instead of `apply_join`
+allocating inline during the meet. The `decide`/`apply` boundary is exactly where
+that pass plugs in. Not yet done: turning the `TryFresh*` inline allocations into
+allocator-assigned φ registers (the SSA-φ edge-move rewrite) — but the meet is
+now cleanly type-decision (`decide_join`) vs placement-allocation (`apply_join`).

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1212,3 +1212,17 @@ Remaining before default-on: a full `bin/bench` incl. **optcarrot** (headline) a
 the other float loops (matmul/bedcov, which may also improve), confirming no
 regression; then flip the cargo `default` to include the feature (and fold the
 `S -> F` / `Sf -> F` bridge arms in unconditionally, as they are general-purpose).
+
+### 15.7 Landed: default-on
+
+Bench gate cleared on both arches, so the loop-entry float specialization is now
+**default** (no feature flag): mandelbrot +12.5 %, matmul +2.4 %, optcarrot
+184.8 → 186.2 fps (checksum unchanged, 59662), everything else flat, no
+regressions; suite **1705/0**, mandelbrot do_it `call float_to_value` 0 in the
+default build. `keep_backedge_floats` + the predecessor-gated promotion in
+`incoming_context`, and the `S -> F` / `Sf -> F` bridge arms, are now
+unconditional. The two experimental features (`loop-keep-float`,
+`loop-type-only-entry`) and the dead `strip_xmm_to_stack` probe are removed;
+`loop-type-only-entry`'s lesson (the analysis-pass backedge is load-bearing — a
+naive type-only strip regresses 2.5×) is retained in §13–14 as the calibration
+that led here. Added `test_loop_carried_float_kept_unboxed`.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -158,7 +158,8 @@ comes last, after the data is already decoupled.
 | Step | Change | Risk |
 | ---- | ------ | ---- |
 | **0a. Decomposition + test** ✅ | Add the location-only `Placement` enum, plus `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. The type lattice is the existing `Guarded` (no new type — per review, `Sf` is a representation mark, not a type; its `SfGuarded` refinement is recovered from the paired `Guarded`). Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
-| **0b. Storage split** | Replace `SlotState.slots: Vec<LinkMode>` with `ty: Vec<Guarded>` + `place: Vec<Placement>`; `mode()`/`set_*` become `from_parts`/decompose shims. `join` splits into `join_ty` (pure lattice meet) + `reconcile_place`. Behaviour-identical. | med |
+| **0b. Storage split** ✅ | (0b-i) Encapsulate every `self.slots` access behind `mode()`/`set_mode()`/`all_regs()`/`slots_len()` (the two in-place mutations become local-copy RMW). (0b-ii) Replace `SlotState.slots: Vec<LinkMode>` with `place: Vec<Placement>` + `ty: Vec<Guarded>`; `mode()` composes via `from_parts`, `set_mode()` decomposes. Behaviour-identical. *Done; suite 1703/0.* | done |
+| **0c. Split `join`** | Split `AbstractFrame::join` / `bridge` into a pure `ty` lattice meet (`Guarded::join`) plus a `place` reconciler (the register/φ reconciliation). Behaviour-identical. | med |
 | **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
 | **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
 | **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
@@ -204,8 +205,11 @@ existing `Guarded`; `Sf` is treated as a representation mark (the `XmmStack`
 placement), not a type, with its refinement recovered from the paired `Guarded`.
 No live state changed; suite at 1703/0.
 
-**Next: step 0b (storage split)** — back `SlotState` with separate `Vec<Guarded>`
-+ `Vec<Placement>` and split `join` into a pure type meet plus a placement
-reconciler, keeping behaviour identical. Then the `Allocator` seam (step 1) and
+**Step 0b is done.** `SlotState` is now backed by `place: Vec<Placement>` +
+`ty: Vec<Guarded>` (via `mode`/`set_mode` compose/decompose), so the type
+lattice is a standalone per-slot vector. Suite at 1703/0, behaviour-identical.
+
+**Next: step 0c** — split `AbstractFrame::join` / `bridge` into a pure `ty`
+lattice meet plus a `place` reconciler. Then the `Allocator` seam (step 1) and
 the standalone analysis pass (step 2), after which goals 1/3 fall out of
 steps 3–4.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -159,7 +159,7 @@ comes last, after the data is already decoupled.
 | ---- | ------ | ---- |
 | **0a. Decomposition + test** ✅ | Add the location-only `Placement` enum, plus `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. The type lattice is the existing `Guarded` (no new type — per review, `Sf` is a representation mark, not a type; its `SfGuarded` refinement is recovered from the paired `Guarded`). Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
 | **0b. Storage split** ✅ | (0b-i) Encapsulate every `self.slots` access behind `mode()`/`set_mode()`/`all_regs()`/`slots_len()` (the two in-place mutations become local-copy RMW). (0b-ii) Replace `SlotState.slots: Vec<LinkMode>` with `place: Vec<Placement>` + `ty: Vec<Guarded>`; `mode()` composes via `from_parts`, `set_mode()` decomposes. Behaviour-identical. *Done; suite 1703/0.* | done |
-| **0c. Split `join`** | Split `AbstractFrame::join` / `bridge` into a pure `ty` lattice meet (`Guarded::join`) plus a `place` reconciler (the register/φ reconciliation). Behaviour-identical. | med |
+| **0c. Factor the type meet** ✅ | Extract the analysis-layer join as a reusable primitive: relocate `Guarded::join` next to `Guarded` and add `SlotState::join_ty` (element-wise `Guarded::join` over the `ty` vec). Verified arm-by-arm that the fused `AbstractFrame::join`'s resulting *type* equals this meet for every non-sentinel slot, so the fused join's remaining work is purely placement reconciliation (which carries the allocation side-effects and moves to the `Allocator` in steps 1–2). *Done; suite 1703/0.* | done |
 | **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
 | **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
 | **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
@@ -205,11 +205,17 @@ existing `Guarded`; `Sf` is treated as a representation mark (the `XmmStack`
 placement), not a type, with its refinement recovered from the paired `Guarded`.
 No live state changed; suite at 1703/0.
 
-**Step 0b is done.** `SlotState` is now backed by `place: Vec<Placement>` +
-`ty: Vec<Guarded>` (via `mode`/`set_mode` compose/decompose), so the type
-lattice is a standalone per-slot vector. Suite at 1703/0, behaviour-identical.
+**Steps 0a–0c are done.** `SlotState` is backed by `place: Vec<Placement>` +
+`ty: Vec<Guarded>`; the type lattice is a standalone per-slot vector with a
+reusable meet (`join_ty`). Crucially, the fused `AbstractFrame::join`'s *type*
+result is exactly that meet for every non-sentinel slot — so the join's residual
+work is **purely placement reconciliation** (the register/φ reconciliation that
+carries allocation side-effects). That confirms the clean split point: the type
+analysis is already separable; what remains entangled is allocation, which is
+precisely what steps 1–2 pull out.
 
-**Next: step 0c** — split `AbstractFrame::join` / `bridge` into a pure `ty`
-lattice meet plus a `place` reconciler. Then the `Allocator` seam (step 1) and
-the standalone analysis pass (step 2), after which goals 1/3 fall out of
+**Next: step 1 (Allocator seam)** — route `alloc_xmm` / `def_F` / `pin_xmm` /
+spill sizing through one `Allocator` abstraction (default = today's greedy), so
+the placement reconciliation stops mutating `vfpr` directly. Then step 2 (the
+standalone analysis pass consuming `join_ty`), after which goals 1/3 fall out of
 steps 3–4.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -999,3 +999,41 @@ existing allocation fixpoint as its own pass, unchanged**, so the placements are
 re-derived. A better *policy* (3c-ii linear scan) comes only after that seam
 exists and is benchmark-gated. The `loop-type-only-entry` feature stays as the
 negative-result probe.
+
+## 15. §5 stage 3c-i implementation plan: extract the allocator, unchanged
+
+The behaviour-preserving separation (per §14.7's conclusion). Surface map of where
+the JIT allocates an xmm today (outside the merge, which is already decide/apply
+split):
+
+- operand loads: `load_xmm` / `load_xmm_fixnum` / `load_binary_xmm` /
+  `fetch_float_assume` (state/read_slot.rs, compile/binary_op.rs) — allocate an
+  xmm for an operand and emit the load (the per-use flonum decode seen in §14.6);
+- destination defs: `def_F` / `def_Sf_float` (compile/binary_op.rs,
+  method_call.rs, variables.rs, compile.rs);
+- the merge: `apply_join`'s `TryFresh*` (already isolated, §5 stage 1).
+
+**Every one of these funnels through two primitives** — `SlotState::try_alloc_xmm`
+(phase-0 vacant / phase-1 Sf-demote) and `alloc_xmm` (+ phase-2 spill). So those
+two are the universal allocation seam, and the loop-aware spill-victim choice that
+3c-ii needs (demote/spill by furthest next-use across the loop, §14.3) lives
+exactly in phase-1 of `try_alloc_xmm`.
+
+Increment sequence (each behaviour-identical, suite + stage-1 shadow verified):
+
+1. **Extract the register-selection policy** into a named `alloc_policy` unit:
+   `try_alloc_xmm` / `alloc_xmm` move out of the `SlotState` impl into a child
+   module taking `&mut SlotState`; the methods delegate. No field, no dispatch
+   yet — the seam is the module boundary. *This increment.*
+2. **Thread an `AllocCtx`** (the live-interval / loop-membership info 3c-ii's
+   victim choice needs) into the policy, computed by the existing liveness pass.
+   Default greedy ignores it → identical placements.
+3. **Add the loop-aware policy** (3c-ii) behind the seam: phase-1 picks the
+   victim with the furthest next-use instead of the first all-`Sf` register;
+   gated on mandelbrot/nbody (match-or-beat backedge) + optcarrot (flat).
+
+The full Layer-② "type-only fixpoint then allocation pass" (un-welding the type
+computation from the operand-load/def handlers above) is the larger, later arc;
+3c-i increments 1–3 deliver the swappable allocator and the measured win first,
+since that is where the §14.6 regression and the latent base-case back-edge boxing
+both live.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -967,3 +967,35 @@ temporaries, i.e. choose spill victims by furthest next-use across the whole loo
 `use_float` does not. This is the property §14.3 named, now backed by the asm:
 optcarrot stayed flat because its hot loops do not exceed the float pool, so the
 spill choice never bites; mandelbrot/nbody do, so it dominates.
+
+### 14.7 Negative result: the cheap spill-policy lever does not fix 3b
+
+Tested the simplest 3c-ii lever directly: make `use_float`'s promotion spill an
+unboxed float (`set_new_Sf` → VirtFPReg) instead of leaving it boxed in `S` when
+the physical pool is full. **No-op** — the mandelbrot kernel's JIT asm was
+byte-identical to plain 3b (412 insts, same box count). So `try_alloc_xmm` was
+already succeeding for the slots `use_float` touches; the boxed-operand decodes
+that cause the regression do **not** originate from `use_float`'s best-effort
+fallback. Reverted.
+
+Two refinements this pins down:
+1. **The regression is specific to `for…in` loops.** A `while`-loop float kernel
+   (zr/zi loop-carried) produces *identical* asm base-vs-3b — no regression.
+   mandelbrot/nbody use `for…in` (inlined, multiple loop_starts within one iseq);
+   that is where the placement divergence lives. The earlier "simple float loop is
+   codegen-neutral" (§13.7) was right *and* misleading: the neutral case is the
+   `while` loop; the `for…in` case is where 3b loses.
+2. **It is not a local heuristic miss.** A point fix to the promotion policy
+   cannot recover it, because the boxed operands are not the ones the promotion
+   pass decides. The analysis-pass backedge fixpoint reaches a globally-consistent
+   loop placement that a single forward `use_float` pass over a stripped
+   (all-`S`) entry simply does not reconstruct.
+
+**Conclusion — abandon "strip + re-derive" (3b) as the separation mechanism.**
+3b's value was diagnostic (it calibrated the bar and proved the backedge is
+load-bearing). The behaviour-preserving separation is §14.2's **3c-i: extract the
+existing allocation fixpoint as its own pass, unchanged**, so the placements are
+*identical* to today (shadow-verified, zero regression) — not stripped and
+re-derived. A better *policy* (3c-ii linear scan) comes only after that seam
+exists and is benchmark-gated. The `loop-type-only-entry` feature stays as the
+negative-result probe.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -160,7 +160,7 @@ comes last, after the data is already decoupled.
 | **0a. Decomposition + test** ✅ | Add the location-only `Placement` enum, plus `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. The type lattice is the existing `Guarded` (no new type — per review, `Sf` is a representation mark, not a type; its `SfGuarded` refinement is recovered from the paired `Guarded`). Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
 | **0b. Storage split** ✅ | (0b-i) Encapsulate every `self.slots` access behind `mode()`/`set_mode()`/`all_regs()`/`slots_len()` (the two in-place mutations become local-copy RMW). (0b-ii) Replace `SlotState.slots: Vec<LinkMode>` with `place: Vec<Placement>` + `ty: Vec<Guarded>`; `mode()` composes via `from_parts`, `set_mode()` decomposes. Behaviour-identical. *Done; suite 1703/0.* | done |
 | **0c. Factor the type meet** ✅ | Extract the analysis-layer join as a reusable primitive: relocate `Guarded::join` next to `Guarded` and add `SlotState::join_ty` (element-wise `Guarded::join` over the `ty` vec). Verified arm-by-arm that the fused `AbstractFrame::join`'s resulting *type* equals this meet for every non-sentinel slot, so the fused join's remaining work is purely placement reconciliation (which carries the allocation side-effects and moves to the `Allocator` in steps 1–2). *Done; suite 1703/0.* | done |
-| **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
+| **1. Allocator seam** ✅ | Extract `vfpr` + `pinned_vfpr` and the pure pool primitives into an `XmmAllocator` struct owned by `SlotState`; the `xmm_*` methods delegate to it. The policy (`try_alloc_xmm`/`alloc_xmm`) stays on `SlotState` (it also mutates slot placements). *Done; suite 1703/0.* | done |
 | **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
 | **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
 | **4. Two allocators (goal 3 enabler)** | Add the fixed-convention VM `Allocator`; spike VM-residual generation for one bytecode. | research |
@@ -214,8 +214,12 @@ carries allocation side-effects). That confirms the clean split point: the type
 analysis is already separable; what remains entangled is allocation, which is
 precisely what steps 1–2 pull out.
 
-**Next: step 1 (Allocator seam)** — route `alloc_xmm` / `def_F` / `pin_xmm` /
-spill sizing through one `Allocator` abstraction (default = today's greedy), so
-the placement reconciliation stops mutating `vfpr` directly. Then step 2 (the
-standalone analysis pass consuming `join_ty`), after which goals 1/3 fall out of
-steps 3–4.
+**Step 1 is done.** The xmm allocation state (`vfpr` + `pinned_vfpr`) and its
+pure pool primitives now live in an `XmmAllocator` struct owned by `SlotState`,
+physically separated from the slot type/placement state. The allocation policy
+still sits on `SlotState`.
+
+**Next: step 2 (standalone analysis pass)** — run the `Guarded`/liveness fixpoint
+as its own pass (consuming `join_ty`) producing a typed IR, before the
+allocation+lowering pass. This is the high-risk structural change; goals 1/3
+fall out of steps 3–4 afterward.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -668,14 +668,32 @@ greedy xmm policy) must not regress."
 The naive view is "stage 3 is all benchmark-gated." It is not — one more slice
 stays shadow-able:
 
-- **3a — safe / shadow-able: the analysis fixpoint is allocation-independent.**
-  Extend the stage-2 result from a single merge to the loop *fixpoint*: run the
-  analysis pre-pass both with and without `apply_join` allocation and assert the
-  resulting **type + liveness** fixpoint (the back-edge `AbstractState`'s
-  `Guarded` per slot + the `Liveness` sets) is identical. This proves stripping
-  allocation from the analysis pass does not perturb what that pass exists to
-  compute. Debug-only, no behaviour change; promotes stage 2 to the fixpoint
-  level. *This is the next implementable step.*
+- **3a — safe: the analysis fixpoint is allocation-independent.** The goal was to
+  prove stripping allocation from the analysis pass does not perturb the type +
+  liveness it exists to compute. This splits into two halves:
+  - **Merge half — already discharged by stage 2.** `AbstractState::join_entries`
+    (state.rs:81) calls `AbstractFrame::join`, where the stage-2 assertion
+    (`self.guarded(i) == join_ty(pre, other)[i]`) lives. `join_entries` is reached
+    from both `incoming_context` *and* `analyse_backedge_fixpoint` (merge.rs:77,
+    79, 107), and the analysis pre-pass `loop_analysis` (context.rs:682,
+    `codegen_mode:false`) drives them. So stage 2 already runs on every
+    analysis-pass merge **and** every back-edge fixpoint merge; the suite exercises
+    loop JIT and passes 1704/0 with it active. Merge-level type meet is therefore
+    allocation-independent by an assertion that is *already live* — no duplicate
+    fixpoint harness needed (building one would be disproportionate).
+  - **Transfer half — by construction, confirmed by the gate.** Between merges the
+    fixpoint runs the per-instruction transfer handlers. Their *type* result is
+    computed from operand `Guarded`s + IC classes, never from placement (handlers
+    branch on `codegen_mode()` only to choose *emission*, e.g. `binop_uncached`
+    widens to `S` in analysis — the `Guarded` it records is the same). A full
+    static shadow of every handler is disproportionate; this half is covered
+    empirically by 3b's benchmark gate plus the exact CRuby-diff correctness suite
+    (any type-fixpoint perturbation would change output, which the suite catches
+    exactly).
+
+  Net: the safe regime of stage 3 is essentially complete — the merge half is
+  formally asserted (live), the transfer half rests on the handlers' type/emission
+  split and is confirmed by the gate. The next implementable step is 3b.
 
 - **3b — benchmark-gated: actually strip allocation from the analysis pass.**
   Make `loop_analysis` (and any other `codegen_mode:false` walk) call the

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -931,3 +931,39 @@ it is shadow-verifiable against the fused result. 3c-ii is the only step that ma
 regress, and it is gated on the exact benchmarks 3b flagged. 3b is retained as the
 negative-result probe that calibrated the bar: any allocator that cannot match the
 backedge on mandelbrot/nbody is not ready to land.
+
+### 14.6 The 3b regression, diagnosed at the asm level (what 3c-ii must reproduce)
+
+Diffing the JIT asm of the mandelbrot kernel (`for dummy in 0..ITER` with several
+live floats) base-vs-3b pins the mechanism exactly. do_it grows from **340 → 412
+instructions (+21%)** under 3b. The delta is not the back-edge box (both box the
+same loop-carried results); it is the **operand loads inside the loop body**:
+
+- **base** keeps the loop-invariant / loop-carried floats (`cr`, `ci`, …) resident
+  in xmm across the loop, so each use is a direct `movq xmmA,xmmCr; mulsd …`:
+  ```
+  movq xmm9,xmm2 ; mulsd xmm9,xmm2      # cr already in xmm2
+  ```
+- **3b** demotes them to their boxed stack home, so *every use* re-loads and
+  re-decodes the flonum (~10 insts: tag tests + the `sar/add/and/or/rol/movq`
+  flonum-decode) before the `mulsd`:
+  ```
+  mov rdi,[rbp-N]; test rdi,1; jne…; test rdi,2; je…; …; rol rdi,0x3d; movq xmm2,rdi
+  movq xmm3,xmm2 ; mulsd xmm3,xmm2
+  ```
+
+Why `use_float` does not recover it: the inner loop has more simultaneously-live
+floats than the xmm pool, so the per-entry best-effort `try_set_new_Sf` promotion
+loses the race for some of them and they stay boxed — re-decoded every use. The
+backedge **fixpoint** instead converges on a stable assignment that keeps the
+hot floats resident. So the missing quality is not the `Sf` *mark* (liveness has
+it) but the *spill choice* under pressure.
+
+**Spec for 3c-ii, made concrete.** The loop-aware linear scan must keep floats
+whose live interval **spans the loop body** (loop-invariant operands and
+loop-carried accumulators) resident in xmm with priority over intra-iteration
+temporaries, i.e. choose spill victims by furthest next-use across the whole loop
+— exactly what the backedge fixpoint approximates and what greedy per-entry
+`use_float` does not. This is the property §14.3 named, now backed by the asm:
+optcarrot stayed flat because its hot loops do not exceed the float pool, so the
+spill choice never bites; mandelbrot/nbody do, so it dominates.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -148,14 +148,16 @@ comes last, after the data is already decoupled.
 
 | Step | Change | Risk |
 | ---- | ------ | ---- |
-| **0. Data split** | Inside `SlotState`, replace the fused `Vec<LinkMode>` with two parallel views: `ty: Vec<AbstractType>` (lattice) and `place: Vec<Placement>` (Stack / Gp / Xmm(FPReg) / XmmStack(FPReg)). `LinkMode` becomes a derived accessor. `join` splits into `join_ty` + `reconcile_place`. **No behaviour change.** | low |
+| **0a. Decomposition + test** ✅ | Add `Placement` (the location/representation dual of the existing `Guarded` type lattice) + `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
+| **0b. Storage split** | Replace `SlotState.slots: Vec<LinkMode>` with `ty: Vec<Guarded>` + `place: Vec<Placement>`; `mode()`/`set_*` become `from_parts`/decompose shims. `join` splits into `join_ty` (pure lattice meet) + `reconcile_place`. Behaviour-identical. | med |
 | **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
-| **2. Standalone analysis** | Run the layer-① fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
+| **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
 | **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
 | **4. Two allocators (goal 3 enabler)** | Add the fixed-convention VM `Allocator`; spike VM-residual generation for one bytecode. | research |
 
-Steps 0–1 are mechanical decoupling that pay off immediately (clearer code,
-testable lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
+Step 0a is shipped (`Placement` + projections + round-trip test). Steps 0b–1
+are mechanical decoupling that pay off immediately (clearer code, testable
+lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
 
 ---
 
@@ -180,10 +182,16 @@ testable lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
 
 ---
 
-## 6. Recommendation
+## 6. Progress
 
-Start with **step 0 (data split)**: factor `LinkMode` into a type lattice +
-a placement map *without* changing the single-pass control flow. It is low-risk,
-keeps the suite at 1702/0, and immediately yields a reusable `AbstractType`
-lattice — the exact artifact goal 3's partial evaluator will consume. Steps 1–2
-then follow with the structural separation, and goals 1/3 fall out of step 3–4.
+**Step 0a is done.** `LinkMode` now has the `placement()` / `from_parts()`
+projections, and a unit test (`linkmode_placement_roundtrip`) proves it is
+isomorphic to `(Placement, Guarded)`. The type lattice already existed as
+`Guarded` (`Value`=⊤, `Fixnum`, `Float`, `Class(c)`) with a `join`; step 0a
+adds its location dual. No live state changed; suite at 1703/0.
+
+**Next: step 0b (storage split)** — back `SlotState` with separate `Vec<Guarded>`
++ `Vec<Placement>` and split `join` into a pure type meet plus a placement
+reconciler, keeping behaviour identical. Then the `Allocator` seam (step 1) and
+the standalone analysis pass (step 2), after which goals 1/3 fall out of
+steps 3–4.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1130,3 +1130,40 @@ change to how `incoming_context` builds the target, not a new allocator — and 
 fixes the latent base-case box, not just the 3b regression. (The earlier no-op
 probes were no-ops precisely because they targeted the allocator/promotion, while
 the value was being boxed by the *merge* upstream of them.)
+
+### 15.4 Prototype result: the box CAN be eliminated, but it is blocked by a TYPE loss, not placement
+
+Prototyped the §15.3 fix (`loop-keep-float`): a new `S -> F` (and `Sf -> F`)
+bridge arm + `keep_backedge_floats`, which re-adopts the back-edge fixpoint's `F`
+for loop-carried floats the loop-entry merge collapsed.
+
+- **Concept proven (x86-64).** With an *unguarded* promotion, the mandelbrot do_it
+  loses **all** boxing: `call float_to_value` count 16 → **0**, the inner-loop
+  body becomes pure xmm (`movq xmm,xmm; mulsd`), and the per-iteration
+  flonum-decode moves to a single pre-header unbox. The optimisation is real.
+- **But it is unsound as written**, and that exposed the actual blocker. The
+  loop-carried float is typed **`S(Value)` at the loop-entry merge, not
+  `S(Float)`** (verified in `jit-debug`: the pre-header forward entry holds
+  `%3: S(Value)` even though it is `zr = 0.0`). The fixpoint correctly has it as
+  `F` (Float); the codegen merge `SetS(join(Value, Float)) = Value` degrades it.
+  Forcing `F` on a `Value`-typed slot then panics at the `C(non-float) -> F`
+  bridge (a *different* slot that genuinely is a non-float const in some path) —
+  and would be silently wrong for any slot that is actually sometimes non-float,
+  since an `F` slot carries no runtime guard.
+- **The sound guard (`guarded == Float`) makes it a no-op**, because the
+  loop-carried floats are `Value`-typed: suite 1704/0, but mandelbrot is byte-
+  identical to base (340/16). The placement fix has nothing to act on until the
+  *type* is `Float`.
+
+**So the lever is the type analysis, not placement or allocation.** A loop-carried
+pure float (`zr = 0.0` then float arithmetic) is typed `Value` at the loop-entry
+merge instead of `Float`; fix that precision loss and the (already-prototyped,
+sound) `guarded == Float` promotion fires and removes the box — on the shipping
+build, not just under 3b. This also finally explains the whole §15 thread: every
+allocator/placement lever was downstream of a value the *type meet* had already
+widened to `Value`. The `loop-keep-float` feature (default off, 1704/0) and the
+`S -> F` / `Sf -> F` bridge arms are kept as the staging ground; the next step is
+the loop-carried-float type precision fix. (aarch64 unverified here — no cross
+toolchain in this container; the new bridge arms reuse `float_to_fpr` / `fpr_move`,
+which both backends already lower, so they are arch-neutral by construction, but
+this needs an M1 `bin/test` to confirm.)

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -99,7 +99,7 @@ Three layers, with a typed IR in the middle:
 TraceIR
   │  ① analysis pass  (fixpoint; types + liveness only — NO locations)
   ▼
-Typed IR            per-slot AbstractType lattice + liveness; operands are
+Typed IR            per-slot `Guarded` type lattice + liveness; operands are
   │                 (slot, representation) — still virtual, no phys regs
   │  ② allocation + lowering pass  (pluggable Allocator)
   ▼
@@ -107,29 +107,33 @@ LIR (LInst)         concrete regs/spills; emitted straight to encode_linst
   ▼  encode_linst → bytes
 ```
 
-### Layer ① — the type / analysis-state lattice
+### Layer ① — the type lattice (analysis)
 
-A pure lattice element per slot, *no* location. The existing `Guarded` class
-lattice (`Value`=⊤ / `Fixnum` / `Float` / `Class(c)`) plus one extra state:
+A pure lattice element per slot, *no* location. This is the **existing**
+`Guarded` enum — no new type is needed:
 
 ```rust
-enum AbstractType {          // implemented in step 0a
-    Value,                   // ⊤ (unknown class)
-    Fixnum,
-    Float,
-    Class(ClassId),
-    FixnumOrFloat,           // Integer-or-Float kept coerced-to-f64 (the `Sf` state)
-}
+enum Guarded { Value /*⊤*/, Fixnum, Float, Class(ClassId) }
 ```
 
-`FixnumOrFloat` is the key insight from review: the `Sf` linkage is not a mere
-"xmm + stack cache" *placement*, it is a **def-use-derived abstract state** —
-"this slot holds an Integer (or Float) that is *coerced to `f64`* at its use
-sites." So its refinement (`SfGuarded`) belongs to the *type* layer, not
-placement; `Placement::XmmStack` carries only the `FPReg`. `join` over
-`AbstractType` is a *pure* lattice meet — no register churn. Liveness stays here.
-This is exactly what goal 3's partial evaluator parameterizes (feed ⊤ for the VM
-residual, IC-narrowed types for the JIT residual).
+`join` over `Guarded` is a *pure* lattice meet (`Guarded::join` already exists) —
+no register churn. Liveness stays here. This is what goal 3's partial evaluator
+parameterizes (feed ⊤ for the VM residual, IC-narrowed types for the JIT
+residual).
+
+**`Sf` is not a type.** Per review, the `Sf` linkage ("Integer def'd, Float
+use'd, kept coerced to `f64`") is **not** a lattice element but a *representation
+decision* taken by a separate analysis. In the typed IR an `Sf` slot lowers to
+its plain boxed type (`Fixnum`); a dedicated def-use + loop pass then *marks* it
+for the xmm-coerced representation when:
+
+> the slot is def'd as Integer **and** use'd as Float, **and** it is a
+> constant/literal **or** def'd outside a loop and use'd inside it
+> (i.e. the coercion is loop-invariant and worth hoisting into an xmm).
+
+That mark *is* the `XmmStack` placement. Keeping it out of the type lattice is
+what lets the VM residual (no marks, everything boxed) and the JIT residual
+(marks applied) share one analysis.
 
 ### Layer ② — representation + allocation
 
@@ -153,7 +157,7 @@ comes last, after the data is already decoupled.
 
 | Step | Change | Risk |
 | ---- | ------ | ---- |
-| **0a. Decomposition + test** ✅ | Add the layer-① `AbstractType` lattice (`Guarded` + `FixnumOrFloat`) and the location-only `Placement`, plus `LinkMode::{abstract_type, placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, AbstractType)`. Per review, the `Sf` coercion refinement lives in `AbstractType`, not `Placement`. Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
+| **0a. Decomposition + test** ✅ | Add the location-only `Placement` enum, plus `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. The type lattice is the existing `Guarded` (no new type — per review, `Sf` is a representation mark, not a type; its `SfGuarded` refinement is recovered from the paired `Guarded`). Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
 | **0b. Storage split** | Replace `SlotState.slots: Vec<LinkMode>` with `ty: Vec<Guarded>` + `place: Vec<Placement>`; `mode()`/`set_*` become `from_parts`/decompose shims. `join` splits into `join_ty` (pure lattice meet) + `reconcile_place`. Behaviour-identical. | med |
 | **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
 | **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
@@ -175,11 +179,14 @@ lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
   effectively turns the fused greedy pass into a proper linear-scan / SSA
   allocator with edge fixups. Codegen quality must not regress (the current
   greedy is decent on the FP-heavy benchmarks).
-- **`Sf` (xmm + stack cache).** *Resolved in review:* `Sf` is a def-use abstract
-  state ("Integer/Float coerced to `f64`"), so its `SfGuarded` refinement is part
-  of `AbstractType` (the `FixnumOrFloat` element), and `Placement::XmmStack`
-  carries only the `FPReg`. The *demote-on-pressure* logic (`try_alloc_xmm` phase
-  1) remains an allocation policy that must move into the `Allocator`.
+- **`Sf` (xmm + stack cache).** *Resolved in review:* `Sf` is a representation
+  decision, not a type. The typed IR carries the plain boxed type (`Fixnum`); a
+  separate def-use + loop analysis marks the slot for the xmm-coerced
+  representation (the `XmmStack` placement) using the heuristic in §3. The
+  *demote-on-pressure* logic (`try_alloc_xmm` phase 1) is a further allocation
+  policy that moves into the `Allocator`. (In the current fused state the
+  `SfGuarded` refinement still round-trips losslessly through the paired
+  `Guarded`, since `SfGuarded → Guarded` is injective.)
 - **`r15` accumulator.** The single GP "accumulator" slot is its own tiny
   allocation problem fused into `SlotState.r15`; it follows the same split
   (type vs placement) but is simpler than the xmm pool.
@@ -190,13 +197,12 @@ lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
 
 ## 6. Progress
 
-**Step 0a is done** (revised per review). `LinkMode` now has the
-`abstract_type()` / `placement()` / `from_parts()` projections, and a unit test
-(`linkmode_placement_roundtrip`) proves it is isomorphic to
-`(Placement, AbstractType)`. `AbstractType` extends the existing `Guarded`
-lattice with `FixnumOrFloat` so the `Sf` def-use coercion state is carried on
-the *type* side, leaving `Placement` purely about location. No live state
-changed; suite at 1703/0.
+**Step 0a is done** (revised per review). `LinkMode` now has the `placement()` /
+`from_parts()` projections, and a unit test (`linkmode_placement_roundtrip`)
+proves it is isomorphic to `(Placement, Guarded)`. The type lattice is the
+existing `Guarded`; `Sf` is treated as a representation mark (the `XmmStack`
+placement), not a type, with its refinement recovered from the paired `Guarded`.
+No live state changed; suite at 1703/0.
 
 **Next: step 0b (storage split)** — back `SlotState` with separate `Vec<Guarded>`
 + `Vec<Placement>` and split `join` into a pure type meet plus a placement

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -759,3 +759,37 @@ debug shadows compile out, so they do not affect it):
    allocator's only spill mechanism today; a linear-scan allocator (3c) subsumes
    it but must preserve the "stack is canonical, dropping the xmm cache needs no
    asm" property that makes demotion free.
+
+### 13.7 §5 stage 3b: landed behind a default-off feature
+
+3b is implemented as the `loop-type-only-entry` cargo feature (default off, so the
+shipping build is bit-identical). When on, `incoming_context` strips the analysis
+pass's loop-carried `backedge` frame to a type-only projection
+(`AbstractState::strip_xmm_to_stack`: every `F`/`Sf` slot → `S(guarded)`) before
+`target.join(&backedge)`, so the codegen pass re-derives the loop-entry xmm
+bindings itself via the liveness pass (`liveness_analysis` → `use_float`'s
+`try_set_new_Sf`) instead of inheriting them. This is the minimal, reversible lever
+for "the codegen pass owns allocation; the analysis pass contributes only types +
+liveness."
+
+Verified:
+- **Default (off): unchanged** — the strip is `#[cfg]`-compiled out; the join takes
+  the placed backedge verbatim.
+- **Feature on: correct** — suite 1704/0 (stage-1/2 shadows active) and the sample
+  programs match CRuby (`249750.0`, `1249925000.0`).
+- **Codegen neutral on the canonical float loop** — `emit-asm` for the
+  `x += i*0.5` while-loop is *identical* off vs on: the loop-carried accumulator
+  was already `Sf` (boxed per iteration) in the baseline, and `use_float`
+  re-promotes it to the same `Sf`, so the analysis-pass backedge placement was
+  redundant with liveness-driven promotion here. This is the intended
+  behaviour-preserving result — 3b removes the analysis-pass allocation without
+  regressing this hot path.
+
+What 3b does **not** do: it does not *improve* the per-iteration box (keeping the
+float in an xmm across the back-edge is the 3c allocator-policy change). 3b only
+establishes that de-fusing analysis-pass allocation is codegen-neutral on the
+canonical case. Cases where liveness-promotion and the analysis backedge diverge
+(the regression risk surface) are what the broad benchmark A/B on M1 must probe;
+build `--release` twice (with/without the feature) and compare `bin/bench` +
+optcarrot before considering a default flip / removing the analysis-pass
+allocation outright.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -482,3 +482,35 @@ stream with no analysis frame in hand), and the assert is a standing guard
 against a future transfer whose emit sneaks in a state dependence. All transfer
 emit helpers are single deterministic `push`es, so the check holds for the whole
 suite (1703/0, debug build, every codegen-mode transfer exercised).
+
+### Deopt program-point-ification: the stream is now codegen-independent
+
+The one remaining codegen dependence in the `TransferIR` stream was the frozen
+`AsmDeopt` (an index into the codegen pass's `side_exit` table) carried by the
+guarded `XmmLoad` / `XmmFixnumLoad` records. That index is meaningless without
+the exact `side_exit` table it points into — so a standalone lowering pass could
+not replay the stream.
+
+Resolved as doc §9 foretold: the records now carry a **`DeoptPoint`** — the
+program point `(pc, write_back)`, both pure analysis values the frame already
+tracks (`get_write_back()` is the placement snapshot restored on guard failure).
+The analysis half (`load_xmm` / `load_xmm_fixnum` wrappers) records the point via
+`deopt_point()` (no `side_exit` push); the **emit half** materializes the actual
+side-exit via `AsmIr::deopt_from_point`, so `side_exit` construction lives
+entirely on the codegen side. `new_deopt` is no longer called from the transfer
+wrappers.
+
+Ordering is preserved exactly: within `load_xmm{,_fixnum}` the only `side_exit`
+push was this one deopt, created "first" — `deopt_from_point` runs at the top of
+the emit arm, at the same relative position, so the `side_exit` table is
+byte-identical. The guarded-but-`guard == false` `S`/`G` arms still materialize
+the (dead) deopt, matching the pre-split wrapper.
+
+`TransferIR` is consequently `Clone` (not `Copy` — a `DeoptPoint` owns a
+`WriteBack`). The shadow harness was strengthened accordingly: emit is now a pure
+function of the record **and the `side_exit` cursor** (a guarded record
+materializes `AsmDeopt(side_exit.len())`), so the replay pre-pads the scratch's
+`side_exit` to the same length and asserts both the produced `AsmInst`s *and* the
+produced `SideExit`s match (Debug-compared; neither is `PartialEq`). Suite
+1703/0, no replay mismatches — the stream is now fully codegen-independent, the
+last prerequisite for record-driven lowering (step 3).

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1093,3 +1093,40 @@ intervals** of §14.3: rank pool occupancy by interval length / loop membership,
 not allocation order. The seam (incr. 1) and the calibrated bar (mandelbrot/nbody
 regress, optcarrot flat) are in place; what remains is the interval analysis +
 the priority allocator, a substantial standalone implementation.
+
+### 15.3 CORRECTION: it is not register pressure — the loop-entry merge discards the fixpoint's `F`
+
+§15.2's "register pressure forces the `S` box" is **wrong**. Re-verified facts:
+
+- **No pressure.** The float kernel uses 2 of 14 physical xmm; base mandelbrot
+  uses 10 of 14. The pool is never exhausted.
+- **Spilling is unboxed by design.** `alloc_xmm` phase-2 (`push_spill`) hands back
+  a `VirtFPReg` that lives on the stack as a raw `f64` (`movsd`), never a boxed
+  `Value`. A spilled float is *not* re-decoded. So boxing ≠ spilling.
+
+The actual mechanism, from `jit-debug` on the kernel loop:
+
+```
+fixed: 1 { … [%3(zr): F(FPReg4)] [%4(zi): F(FPReg6)] … }   ← backedge fixpoint: F (good)
+target:  { … [%3(zr): S(Value)]  [%4(zi): S(Value)]  … }   ← codegen loop-entry: S (boxed!)
+```
+
+The **back-edge fixpoint already computes the loop-carried floats as `F` (pure
+xmm)** — the right answer. But codegen's loop-entry target is
+`incoming.join(backedge)` (merge.rs), and the forward entry (`incoming`, the first
+loop entry from outside) holds the loop-carried float as `S` — the boxed initial
+value (`zr = 0.0` materialised boxed). `decide_join` has **no `S`/`F` arm**, so
+`(S, F)` falls to the default `_ => SetS` → `S`. The merge therefore *discards the
+fixpoint's `F`* and collapses the whole loop body to boxed, decoding+re-boxing the
+loop-carried float every iteration — with 12 xmm sitting free.
+
+So the lever is neither the allocator, the spill policy, nor register pressure: it
+is the **loop-entry merge letting the forward entry's boxed initial value win over
+the back-edge's unboxed steady-state placement**. The fix is to make the loop
+header adopt the back-edge's `F`/`Sf` placement for loop-carried floats (a
+one-time unbox of the forward entry at the pre-header bridge, which the bridge's
+`S -> F`/`Sf` arms already emit) instead of `SetS`. This is a loop-header-local
+change to how `incoming_context` builds the target, not a new allocator — and it
+fixes the latent base-case box, not just the 3b regression. (The earlier no-op
+probes were no-ops precisely because they targeted the allocator/promotion, while
+the value was being boxed by the *merge* upstream of them.)

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1065,3 +1065,31 @@ governs both the 3b regression *and* the latent base-case back-edge box. Increme
 win must come from the join arms, not the spill policy. The next concrete step is
 to read the loop-header join decision for a loop-carried float and determine
 whether keeping it `F` across the back-edge (no boxed cache) is sound and cheaper.
+
+### 15.2 jit-debug confirms: loop-carried floats *can* be `F`; pressure forces `S`
+
+`jit-debug` on the float kernel shows the same loop compiled two ways:
+
+- one specialization keeps the loop-carried floats `F(FPReg0)` / `F(FPReg1)` —
+  pure xmm, **no per-iteration box**, back-edge is an xmm move;
+- another puts them in `S(Value)` (boxed) while the loop-*invariant* operands take
+  the physical pool as `Sf` — so the loop-carried values lose the pool and box
+  every iteration.
+
+So `F` for a loop-carried float is achievable and is the good outcome. The `S`
+fallback comes from the loop-header join's `C/F` arm `TryFreshFElseS`
+(join.rs:228) and the `F/F` arm `TryFreshFKeep`: both *try* a fresh/kept xmm and
+**fall back to `S` only when no physical xmm is free**. The per-iteration box is
+exactly that fallback firing under register pressure — the loop-carried value
+losing the pool to other live values.
+
+This closes the diagnosis loop: every lever (use_float promotion, phase-1 spill
+victim, join arm) ultimately bottoms out at the same thing — **which live values
+hold the physical pool across the loop**. Today that is decided greedily in
+allocation order; the loop-carried/invariant floats must instead win the pool over
+short-lived temporaries. There is no cheaper intermediate fix (three no-op probes
+confirm it). 3c-ii is therefore necessarily the loop-aware **linear scan over live
+intervals** of §14.3: rank pool occupancy by interval length / loop membership,
+not allocation order. The seam (incr. 1) and the calibrated bar (mandelbrot/nbody
+regress, optcarrot flat) are in place; what remains is the interval analysis +
+the priority allocator, a substantial standalone implementation.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -793,3 +793,42 @@ canonical case. Cases where liveness-promotion and the analysis backedge diverge
 build `--release` twice (with/without the feature) and compare `bin/bench` +
 optcarrot before considering a default flip / removing the analysis-pass
 allocation outright.
+
+### 13.8 §5 stage 3b benchmark verdict: REGRESSION — the analysis-pass backedge is load-bearing
+
+**Corrects §13.7.** The canonical `x += i*0.5` loop produced identical asm off/on,
+which I wrongly generalised to "codegen neutral." The real float-heavy benchmarks
+say otherwise. M1 `bin/bench` (iter/sec, higher = faster) and an independent
+x86-64 wall-clock A/B (seconds, lower = faster) both show 3b **regressing**:
+
+| benchmark | base | 3b | verdict |
+|---|---|---|---|
+| mandelbrot (M1, iter/s) | 24.903 | 9.716 | **2.56× slower** |
+| nbody (M1, iter/s) | 11.353 | 10.184 | ~10% slower |
+| mandelbrot (x86-64, wall-clock) | 0.792 s | 1.479 s | **1.87× slower** |
+| fib / aobench / bf / nqueen / sudoku / matmul / bedcov | — | — | flat |
+
+So 3b fails the §13.4 gate (>2% regression on the hot float path). It stays
+**default-off** — nothing shipped, and the gate did its job.
+
+**The finding (the experiment's real value).** The analysis pre-pass's backedge
+placement is **load-bearing** for float-heavy loops: it captures good loop-carried
+xmm bindings (floats kept in registers across the back-edge) that liveness-driven
+re-derivation (`use_float`) does **not** recover. The canonical loop was too
+trivial to show this (its accumulator was already `Sf`/boxed-per-iteration, so
+both paths agreed); mandelbrot/nbody carry several live floats across the loop
+where the fixpoint's placement genuinely beats a from-scratch `use_float` pass.
+This **refutes** the "backedge placement is redundant with liveness" hypothesis
+from §13.7.
+
+**Consequence for the architecture.** De-fusing allocation from the analysis pass
+cannot simply *discard* the loop-carried placement and re-derive it from liveness
+— that information is real and the greedy fixpoint computes it well. The allocator
+pass (stage 3c / §3 Layer ②) must **reconstruct or carry forward** at least the
+quality of the current analysis-pass backedge bindings, i.e. a proper loop-aware
+allocation (linear-scan with loop-carried liveness), not the liveness-hint
+promotion `use_float` does today. The keep-`Sf`-cache, drop-xmm-free demotion
+property (stage-1 finding) and the backedge fixpoint together are the bar 3c must
+clear. Net: 3b is retained as a **negative result / regression probe** behind its
+feature flag; the next real step is designing 3c to match-or-beat the backedge,
+not to replace it with liveness promotion.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -610,3 +610,134 @@ behaviour-changing switch — an allocator that assigns φ registers (reusing a
 predecessor's where it lowers edge-move cost) instead of `apply_join`'s inline
 `TryFresh*` grab — which is benchmark-gated (codegen quality must not regress) and
 will diverge from the stage-1 placement shadow by construction.
+
+## 13. §5 stage 3 design: lifting allocation out of the dataflow (the high-risk core)
+
+Stages 1–2 finished the *de-fusion inside the merge*: the meet is now
+`decide_join` (pure, allocation-free, type result proven `== join_ty`) + a
+recorded `apply_join` placement-allocation stream. Stage 3 is the architectural
+switch — the §10-item-1 / §4-step-2 core — and it is **behaviour-changing and
+benchmark-gated**: the stage-1/2 shadows are necessary scaffolding for it but
+stop applying the moment placements are allowed to diverge.
+
+### 13.1 What the bridge investigation changed about the plan
+
+A read of the edge-move machinery (`AbstractFrame::bridge`, slot.rs:1707; driver
+`gen_bridge`, state.rs:89; merge in merge.rs:60–116) settled the key question:
+
+- **Edge moves already exist.** The actual φ-reconciliation MOVs/swaps/spills are
+  emitted by `bridge`, *not* by the merge. `bridge` pattern-matches
+  `(pred.mode(slot), target.mode(slot))` and has both placements in hand.
+- **The merge is commutative and predecessor-blind.** `decide_join` sees only the
+  two `LinkMode`s; it does **not** know which predecessor carried `F(xmm2)` vs
+  `F(xmm3)`, nor how many predecessors there are. So a "reuse predecessor *p*'s
+  register" policy is **not expressible at merge time** — only the bridge, or a
+  later pass with per-predecessor placement, can express it.
+
+Consequence: the quick "prefer-keep-`l` instead of grab-fresh" heuristic in the
+`TryFresh*` arms is a *weak, commutative* lever (it biases toward whichever frame
+happens to be `self`), not the principled fix. **We do not pursue it as stage 3.**
+The principled fix is to move allocation to a pass that runs after the
+type/liveness fixpoint and can see global/per-predecessor placement — exactly the
+§3 Layer ② `Allocator`.
+
+### 13.2 What stage 3 actually is
+
+Today *both* compile passes call `AbstractFrame::join` = `decide_join` (types) +
+`apply_join` (allocation):
+
+- the **analysis pre-pass** (`loop_analysis`, `codegen_mode:false`, context.rs:687)
+  allocates with emission suppressed — so it is "analysis **+** allocation," not
+  pure type/liveness;
+- the **codegen pass** (`codegen_mode:true`) allocates *and* emits in one walk,
+  and `bridge` turns the per-edge placement deltas into MOVs.
+
+Stage 2 proved the analysis pass does not *need* `apply_join`: its type result is
+exactly `join_ty`. Stage 3 acts on that:
+
+> **The analysis pre-pass computes only `join_ty` + liveness (no `apply_join`,
+> no xmm allocation). The codegen pass owns *all* placement/allocation, and the
+> existing `bridge` already turns the resulting per-edge placement deltas into
+> edge moves.**
+
+This is the de-fusion §10 item 1 calls "the high-risk core; codegen quality (the
+greedy xmm policy) must not regress."
+
+### 13.3 Decomposition (re-narrowing the safe regime)
+
+The naive view is "stage 3 is all benchmark-gated." It is not — one more slice
+stays shadow-able:
+
+- **3a — safe / shadow-able: the analysis fixpoint is allocation-independent.**
+  Extend the stage-2 result from a single merge to the loop *fixpoint*: run the
+  analysis pre-pass both with and without `apply_join` allocation and assert the
+  resulting **type + liveness** fixpoint (the back-edge `AbstractState`'s
+  `Guarded` per slot + the `Liveness` sets) is identical. This proves stripping
+  allocation from the analysis pass does not perturb what that pass exists to
+  compute. Debug-only, no behaviour change; promotes stage 2 to the fixpoint
+  level. *This is the next implementable step.*
+
+- **3b — benchmark-gated: actually strip allocation from the analysis pass.**
+  Make `loop_analysis` (and any other `codegen_mode:false` walk) call the
+  type-only meet; let the codegen pass allocate from a type-only loop-entry
+  frame. The final asm *will* differ (the codegen pass no longer inherits the
+  pre-pass's placements), so the stage-1 placement shadow is expected to diverge
+  and must be scoped off for the `codegen_mode:false` path. Gate: §13.4.
+
+- **3c — benchmark-gated: improve the allocator with its new global view.** Only
+  now is "reuse a predecessor's register / minimise edge moves" expressible,
+  because the allocator pass can see per-predecessor placements (the
+  `BranchEntry` states, jitgen.rs:114) instead of the commutative merge. Linear
+  scan over the type/liveness result; spill = today's `try_alloc_xmm` phase-1
+  demotion generalised. Each policy change is an independent benchmark-gated diff.
+
+### 13.4 The benchmark gate
+
+Baseline must be captured **before** any 3b change, from a `--release` build (the
+debug shadows compile out, so they do not affect it):
+
+1. `cargo build --release` at the pre-3b commit; record `bin/bench` numbers and
+   `optcarrot` fps for the standard set (`benchmark/*.rb`: `app_fib`, the binary-
+   trees / so_* set, optcarrot). M1 `bin/test` already passing is the correctness
+   baseline; the gate adds the *speed* baseline.
+2. Acceptance for promoting 3b/3c to default: **no benchmark regresses beyond
+   noise (≈2 %)** vs baseline, and the headline JIT benchmarks (optcarrot,
+   app_fib) are within noise or better. A regression that is real and not
+   quickly recoverable parks the change behind a runtime flag (mirroring
+   `--no-jit`) rather than flipping the default.
+3. Run on both backends (x86-64 CI + M1 aarch64) before default-flip, since the
+   bridge emits per-arch and the aarch64 backend deopts on unported insts.
+
+### 13.5 Where the existing harness applies / stops
+
+- Stage-2 type-meet assertion: **still valid through 3a/3b** — types never depend
+  on allocation, so it keeps guarding the analysis pass after allocation is
+  stripped. Keep it.
+- Stage-1 placement replay shadow: **valid until 3b** — it asserts the recorded
+  stream reproduces *the current* placements; once the analysis pass stops
+  allocating, the `codegen_mode:false` path has no placement stream to replay, so
+  the shadow is scoped to the codegen pass only (or retired). It is *not* a
+  correctness oracle for 3b's intended divergence.
+- Net: 3a is covered by shadows; 3b/3c are covered by the benchmark gate plus the
+  full CRuby-diff suite (output correctness is still an exact oracle — only
+  *speed/codegen* is what the gate watches).
+
+### 13.6 Open questions / risks
+
+1. **Deopt as a program point.** §10 item 2 / §9's deopt note: once placement is
+   decided in a later pass, a deopt must be reconstructed from the analysis-
+   precomputed placement at that pc, not the frozen `AsmDeopt` the records carry.
+   3b can sidestep this only if the codegen pass still decides placement in its
+   own forward walk (it does today) — i.e. 3b strips allocation from *analysis*
+   but keeps codegen single-walk. Full Layer-② extraction (allocation as a
+   distinct pass feeding codegen) is a later step and is where the deopt-program-
+   point work lands.
+2. **Loop-entry placement quality.** The pre-pass's allocation currently seeds the
+   loop body with sensible xmm bindings; a type-only fixpoint hands codegen a
+   placement-free entry, so the codegen pass must pick loop-carried xmm bindings
+   itself. This is the most likely source of a 3b regression (loop bodies are the
+   hot JIT path) and is what the optcarrot/app_fib gate specifically watches.
+3. **Phase-1 demotion as spill.** The cross-slot demotion (stage-1 finding) is the
+   allocator's only spill mechanism today; a linear-scan allocator (3c) subsumes
+   it but must preserve the "stack is canonical, dropping the xmm cache needs no
+   asm" property that makes demotion free.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -107,24 +107,29 @@ LIR (LInst)         concrete regs/spills; emitted straight to encode_linst
   ▼  encode_linst → bytes
 ```
 
-### Layer ① — the type lattice (analysis)
+### Layer ① — the type / analysis-state lattice
 
-A pure lattice element per slot, *no* location:
+A pure lattice element per slot, *no* location. The existing `Guarded` class
+lattice (`Value`=⊤ / `Fixnum` / `Float` / `Class(c)`) plus one extra state:
 
 ```rust
-enum AbstractType {
-    Top,                 // unknown (⊤)
-    Class(ClassId),      // boxed value of known class (+ guard)
-    Float,               // value known to be Float (unboxable)
-    Fixnum,              // value known to be Fixnum
-    Concrete(Value),     // compile-time constant (⊥-ish)
-    Bottom,              // unreachable
+enum AbstractType {          // implemented in step 0a
+    Value,                   // ⊤ (unknown class)
+    Fixnum,
+    Float,
+    Class(ClassId),
+    FixnumOrFloat,           // Integer-or-Float kept coerced-to-f64 (the `Sf` state)
 }
 ```
 
-`join` over this is a *pure* lattice meet — no register churn. Liveness stays
-here. This pass is what goal 3's partial evaluator parameterizes (feed ⊤ for the
-VM residual, IC-narrowed types for the JIT residual).
+`FixnumOrFloat` is the key insight from review: the `Sf` linkage is not a mere
+"xmm + stack cache" *placement*, it is a **def-use-derived abstract state** —
+"this slot holds an Integer (or Float) that is *coerced to `f64`* at its use
+sites." So its refinement (`SfGuarded`) belongs to the *type* layer, not
+placement; `Placement::XmmStack` carries only the `FPReg`. `join` over
+`AbstractType` is a *pure* lattice meet — no register churn. Liveness stays here.
+This is exactly what goal 3's partial evaluator parameterizes (feed ⊤ for the VM
+residual, IC-narrowed types for the JIT residual).
 
 ### Layer ② — representation + allocation
 
@@ -148,7 +153,7 @@ comes last, after the data is already decoupled.
 
 | Step | Change | Risk |
 | ---- | ------ | ---- |
-| **0a. Decomposition + test** ✅ | Add `Placement` (the location/representation dual of the existing `Guarded` type lattice) + `LinkMode::{placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, Guarded)`. Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
+| **0a. Decomposition + test** ✅ | Add the layer-① `AbstractType` lattice (`Guarded` + `FixnumOrFloat`) and the location-only `Placement`, plus `LinkMode::{abstract_type, placement, from_parts}` projections, with a round-trip test proving `LinkMode ≅ (Placement, AbstractType)`. Per review, the `Sf` coercion refinement lives in `AbstractType`, not `Placement`. Additive scaffolding — no live state touched. *Done; suite 1703/0.* | none |
 | **0b. Storage split** | Replace `SlotState.slots: Vec<LinkMode>` with `ty: Vec<Guarded>` + `place: Vec<Placement>`; `mode()`/`set_*` become `from_parts`/decompose shims. `join` splits into `join_ty` (pure lattice meet) + `reconcile_place`. Behaviour-identical. | med |
 | **1. Allocator seam** | Route `alloc_xmm` / `def_F` / `pin_xmm` / spill sizing through one `Allocator` abstraction (default = today's greedy). Inference calls the seam instead of mutating `vfpr` directly. | low–med |
 | **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
@@ -170,10 +175,11 @@ lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
   effectively turns the fused greedy pass into a proper linear-scan / SSA
   allocator with edge fixups. Codegen quality must not regress (the current
   greedy is decent on the FP-heavy benchmarks).
-- **`Sf` (xmm + stack cache).** It is a *representation* optimisation that blurs
-  type and placement. In the split it is `(ty = Float|Fixnum, place = both)`; the
-  *demote-on-pressure* logic (`try_alloc_xmm` phase 1) is an allocation policy
-  that must move wholesale into the `Allocator`.
+- **`Sf` (xmm + stack cache).** *Resolved in review:* `Sf` is a def-use abstract
+  state ("Integer/Float coerced to `f64`"), so its `SfGuarded` refinement is part
+  of `AbstractType` (the `FixnumOrFloat` element), and `Placement::XmmStack`
+  carries only the `FPReg`. The *demote-on-pressure* logic (`try_alloc_xmm` phase
+  1) remains an allocation policy that must move into the `Allocator`.
 - **`r15` accumulator.** The single GP "accumulator" slot is its own tiny
   allocation problem fused into `SlotState.r15`; it follows the same split
   (type vs placement) but is simpler than the xmm pool.
@@ -184,11 +190,13 @@ lattice) and de-risk step 2. Steps 3–4 are where goals 1 and 3 land.
 
 ## 6. Progress
 
-**Step 0a is done.** `LinkMode` now has the `placement()` / `from_parts()`
-projections, and a unit test (`linkmode_placement_roundtrip`) proves it is
-isomorphic to `(Placement, Guarded)`. The type lattice already existed as
-`Guarded` (`Value`=⊤, `Fixnum`, `Float`, `Class(c)`) with a `join`; step 0a
-adds its location dual. No live state changed; suite at 1703/0.
+**Step 0a is done** (revised per review). `LinkMode` now has the
+`abstract_type()` / `placement()` / `from_parts()` projections, and a unit test
+(`linkmode_placement_roundtrip`) proves it is isomorphic to
+`(Placement, AbstractType)`. `AbstractType` extends the existing `Guarded`
+lattice with `FixnumOrFloat` so the `Sf` def-use coercion state is carried on
+the *type* side, leaving `Placement` purely about location. No live state
+changed; suite at 1703/0.
 
 **Next: step 0b (storage split)** — back `SlotState` with separate `Vec<Guarded>`
 + `Vec<Placement>` and split `join` into a pure type meet plus a placement

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1197,3 +1197,18 @@ confirmed by an M1 `--release` bench A/B (and aarch64, which reuses the same
 `float_to_fpr`/`fpr_move` AsmIR ops). This is the first measured *improvement* over
 base in the §5 line, and it lands as a guarded loop-entry type specialization —
 the same shape YJIT uses — rather than a new allocator.
+
+### 15.6 Confirmed on both arches
+
+M1 (`bin/bench`, i/s) base vs `loop-keep-float`: **mandelbrot 24.326 → 27.372
+(+12.5 %)**, everything else flat (fib/nbody/aobench/bf/nqueen/sudoku within
+noise). Matches the x86-64 local `--release` result (mandelbrot ~0.80 s → ~0.70 s,
+~12 %). So the guarded loop-entry float specialization is a real, arch-neutral win
+(the `S -> F` / `Sf -> F` bridge arms reuse `float_to_fpr` / `fpr_move`, which both
+backends already lower — confirmed on aarch64). `fib -1.6 %` is noise: fib has no
+float loop, so `keep_backedge_floats` never fires and its codegen is byte-identical.
+
+Remaining before default-on: a full `bin/bench` incl. **optcarrot** (headline) and
+the other float loops (matmul/bedcov, which may also improve), confirming no
+regression; then flip the cargo `default` to include the feature (and fold the
+`S -> F` / `Sf -> F` bridge arms in unconditionally, as they are general-purpose).

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -441,3 +441,31 @@ is (1) then (2). (1) is the architectural fork — re-execution-based (generaliz
 the `codegen_mode` pre-pass to all code, feeding precomputed states forward) vs.
 record-stream-based (collect records, lower from them) — and is the decision to
 take deliberately, since it sets how allocation is staged.
+
+## 11. Record collection: the `TransferIR` stream
+
+The first concrete step of record-driven lowering (chosen over the §5 allocation
+de-fusing as the lower-risk groundwork): collect the transfer records into a
+stream so a later pass can replay them.
+
+- **Unified element.** The five per-primitive records (`Spill`, `FpXfer`,
+  `GpLoad`, `XmmLoad`, `XmmFixnumLoad`) now share one enum
+  `TransferIR` (`state/read_slot.rs`) with a single `emit` dispatch. The two
+  deopt-carrying variants still freeze an `AsmDeopt` (lifting it to a program
+  point is §9's open item, the next wall).
+- **One funnel.** `AsmIr::transfer(t)` is the sole sink: it pushes `t` onto the
+  new `transfers: Vec<TransferIR>` (codegen mode only, so it stays in lock-step
+  with the `codegen_mode`-gated `inst`) and then emits via `t.emit(self)`. Every
+  transfer/eviction wrapper (`load`, `load_xmm`, `load_xmm_fixnum`,
+  `write_back_slot`, `to_S_unguarded`, `to_sf`) now calls `ir.transfer(...)`
+  instead of `record.emit(ir, …)`.
+- **Faithful by construction.** The collected `t` *is* the record that gets
+  emitted (same value, same call), so the stream is exactly the emitted transfer
+  sequence — no shadow comparison needed; the suite (1703/0) confirms emission is
+  byte-identical. `save`/`restore` truncates `transfers` alongside `inst`, so the
+  stream survives speculative-emit rollback intact.
+
+The `transfers` stream is **collected but not yet consumed** — that is the
+groundwork. The next steps are (1) lift the deopt to a program point so the
+stream is codegen-independent, then (2) drive lowering from the stream (replay
+`TransferIR` → `LInst`) and retire the corresponding direct `AsmInst` emission.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -161,7 +161,7 @@ comes last, after the data is already decoupled.
 | **0b. Storage split** ✅ | (0b-i) Encapsulate every `self.slots` access behind `mode()`/`set_mode()`/`all_regs()`/`slots_len()` (the two in-place mutations become local-copy RMW). (0b-ii) Replace `SlotState.slots: Vec<LinkMode>` with `place: Vec<Placement>` + `ty: Vec<Guarded>`; `mode()` composes via `from_parts`, `set_mode()` decomposes. Behaviour-identical. *Done; suite 1703/0.* | done |
 | **0c. Factor the type meet** ✅ | Extract the analysis-layer join as a reusable primitive: relocate `Guarded::join` next to `Guarded` and add `SlotState::join_ty` (element-wise `Guarded::join` over the `ty` vec). Verified arm-by-arm that the fused `AbstractFrame::join`'s resulting *type* equals this meet for every non-sentinel slot, so the fused join's remaining work is purely placement reconciliation (which carries the allocation side-effects and moves to the `Allocator` in steps 1–2). *Done; suite 1703/0.* | done |
 | **1. Allocator seam** ✅ | Extract `vfpr` + `pinned_vfpr` and the pure pool primitives into an `XmmAllocator` struct owned by `SlotState`; the `xmm_*` methods delegate to it. The policy (`try_alloc_xmm`/`alloc_xmm`) stays on `SlotState` (it also mutates slot placements). *Done; suite 1703/0.* | done |
-| **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. | high |
+| **2. Standalone analysis** | Run the `Guarded`/liveness fixpoint as its own pass producing a typed IR, *before* the allocation+lowering pass consumes it. The lowering pass becomes `fn(typed_ir, &mut Allocator) -> Vec<LInst>`. This is the real separation. **Spike done** — see §9. | high |
 | **3. AsmIR → LIR (goal 1)** | The lowering pass emits `LInst` directly; retire `AsmInst` as a distinct stream (its `AsmIr` bookkeeping — `side_exit`, flags — moves to the lowering driver). | med |
 | **4. Two allocators (goal 3 enabler)** | Add the fixed-convention VM `Allocator`; spike VM-residual generation for one bytecode. | research |
 
@@ -223,3 +223,67 @@ still sits on `SlotState`.
 as its own pass (consuming `join_ty`) producing a typed IR, before the
 allocation+lowering pass. This is the high-risk structural change; goals 1/3
 fall out of steps 3–4 afterward.
+
+---
+
+## 9. Step-2 spike: where the analysis/emission fusion actually lives
+
+Before committing to step 2 (the big rewrite), a spike traced exactly *how*
+analysis and emission are entangled in `compile_instruction`. The finding
+reshapes the plan.
+
+### What the spike found
+
+The bytecode handlers (`compile_instruction`, ~100 `TraceIr` arms) are **not**
+where analysis and emission are knotted together. A handler like `LoadGvar` is
+just `discard(dst); push(LoadGVar); def_rax2acc(dst)`. Following that down:
+
+```
+def_rax2acc → def_reg2acc_guarded → def_G → writeback_acc
+```
+
+the *only* emission on the whole chain is at the very bottom, in a handful of
+**transfer / eviction primitives** — `writeback_acc` (evict the `r15`
+accumulator owner to its stack home), the xmm spill/swap emitters, etc. Almost
+everything else (the `Guarded` lattice, liveness, placement bookkeeping in
+`place`/`ty`/`XmmAllocator`) is *already pure state*.
+
+And those transfer primitives split **cleanly**. `writeback_acc` was:
+
+```rust
+fn writeback_acc(&mut self, ir) {
+    if let Some(slot) = self.r15 {
+        self.set_mode(slot, S(self.guarded(slot)));  // state
+        self.r15 = None;                              // state
+        ir.acc2stack(slot);                           // emission
+    }
+}
+```
+
+The spike split it into `writeback_acc_state() -> Option<SlotId>` (the pure
+state transition, returns *which* slot was evicted) and the residual
+`writeback_acc` = `if let Some(slot) = self.writeback_acc_state() { ir.acc2stack(slot) }`.
+The emission is fully determined by the slot the state half returns — i.e. the
+transfer primitive is `(state-mutation that yields a transfer record) + (emit
+from that record)`. Behaviour-identical; suite 1703/0.
+
+### How this reshapes step 2
+
+Step 2 is therefore **not** "split ~100 op handlers". It is:
+
+1. Split each **transfer/eviction primitive** (a bounded set — `writeback_acc`,
+   the xmm spill/swap/`float_to_fpr` emitters, `def_*`'s eviction step) into a
+   state half that *returns a transfer record* and an emit half that consumes
+   it. The records are exactly the **typed IR** the analysis pass produces.
+2. The standalone **analysis pass** runs the handlers with the state halves and
+   collects the transfer records (no `AsmIr`). It already exists in skeleton
+   form: `analyse_basic_block` reuses `compile_instruction` but discards its
+   `AsmIr` — today that discard is wasteful (it builds `AsmInst` only to drop
+   them); after the split it would call the state halves and skip emission.
+3. The **lowering pass** replays the records, emitting `LInst` via the emit
+   halves + `encode_linst`.
+
+This is a far more bounded and mechanical change than a per-handler rewrite, and
+each primitive split is independently shippable and behaviour-verifiable at
+1703/0 (the `writeback_acc` split is the first). It also subsumes goal 1: once
+lowering is its own pass, it emits `LInst` directly and `AsmInst` retires.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -469,3 +469,16 @@ The `transfers` stream is **collected but not yet consumed** — that is the
 groundwork. The next steps are (1) lift the deopt to a program point so the
 stream is codegen-independent, then (2) drive lowering from the stream (replay
 `TransferIR` → `LInst`) and retire the corresponding direct `AsmInst` emission.
+
+### Shadow harness: the records are self-contained
+
+A debug-only shadow check in `AsmIr::transfer` replays each record alone into a
+fresh scratch `AsmIr` and asserts it reproduces *exactly* the `AsmInst`s the real
+emit just appended (compared via `Debug`, since `AsmInst` is not `PartialEq`).
+This proves `TransferIR::emit` is a **pure function of the record** — it reads
+nothing from `self`/the frame beyond the record's own payload. That self-
+containment is precisely what record-driven lowering needs (it will replay the
+stream with no analysis frame in hand), and the assert is a standing guard
+against a future transfer whose emit sneaks in a state dependence. All transfer
+emit helpers are single deterministic `push`es, so the check holds for the whole
+suite (1703/0, debug build, every codegen-mode transfer exercised).

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -587,3 +587,26 @@ replays `apply_join` in order, demotions included). This rules out the naive
 "decide-all then allocate-all" staging and tells us the allocator pass must model
 the pool as evolving across the merge's slots (a linear-scan-style sweep), not a
 batch assignment — the constraint that shapes stage 2.
+
+### §5 stage 2: type-meet separability is now a standing invariant
+
+Stage 2 promotes doc §6's once-checked claim — "the fused join's type result is
+exactly `join_ty` for every non-sentinel slot" — to a **standing debug
+assertion** in `verify_join_replay`: after each merge, `self.guarded(i)` equals
+the standalone `join_ty(pre, other)[i]` (the allocation-free `Guarded` meet) for
+every non-sentinel slot. Verified arm-by-arm and then across the whole suite
+(1703/0): every meet arm's result type is `join_ty`, because the `SfGuarded →
+Guarded` projection is a **join homomorphism** (`FixnumOrFloat ↦ Value`, matching
+`join_ty(Fixnum, Float) = Value`), so even the `Sf` arms that look like they
+refine the type actually agree with the plain `Guarded` meet.
+
+This nails down the type/placement split *at the merge*: a standalone
+type+liveness analysis pass — running `join_ty` with **no xmm allocation** —
+computes types identical to the fused meet, and all allocation is isolated in
+`apply_join`. Combined with §5 stage 1 (the merge is a replayable record stream)
+the merge is now cleanly factored into (a) a separable, allocation-free type meet
+and (b) a recorded placement-allocation stream. What remains for stage 3 is the
+behaviour-changing switch — an allocator that assigns φ registers (reusing a
+predecessor's where it lowers edge-move cost) instead of `apply_join`'s inline
+`TryFresh*` grab — which is benchmark-gated (codegen quality must not regress) and
+will diverge from the stage-1 placement shadow by construction.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -330,3 +330,33 @@ pre-load placement) and passes it as `Option<AsmDeopt>` to `XmmLoad::emit`. The
 deopt is therefore supplied by the codegen side, **not** frozen into the record;
 the guard-free numeric variants pass `None`. This confirms the resolution above
 concretely — behaviour-identical at 1703/0.
+
+### The guard primitive, and the limit of single-record splits
+
+`guard_class` (the guard primitive behind `guard_fixnum` / `load_fixnum` /
+`load_array_ty`) splits into `guard_class_state(slot, class) -> bool` (refine the
+slot's type; return whether a runtime guard must be emitted) plus the emit
+`if guard_class_state { ir.push(GuardClass(r, class, deopt)) }`. `load_fixnum`
+and `load_array_ty` then *compose* split primitives (`load` + the guard).
+
+`load_xmm_fixnum`'s `S`/`G` arms are the case that **does not** reduce to a
+single `(state) + (record → emit)` pair. They interleave as:
+
+```
+stack2reg(Rdi)            // emit
+new_deopt                 // deopt — must be AFTER the load, BEFORE set_new_Sf
+guard_class_state         // state (type)
+push GuardClass(deopt)    // emit
+set_new_Sf                // state (placement — allocates the xmm)
+fixnum2fpr(Rdi, x)        // emit
+```
+
+The deopt snapshot must precede the placement change (`set_new_Sf`), but the
+load (`stack2reg`) must precede the deopt — so emission, deopt, and *two* state
+mutations are interleaved and cannot be hoisted into one state half + one emit
+half. This is exactly the general shape the **analysis pass** handles: the typed
+IR is a *sequence* of emission records, and the analysis walks the primitive
+mutating state while *appending* records at each emission point (codegen then
+replays the sequence). So fully splitting `load_xmm_fixnum` *is* the analysis-pass
+wiring — the single-record splits above are its tractable subset, and this is the
+natural boundary between "split the transfer primitives" and "wire the two-pass".

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -832,3 +832,102 @@ property (stage-1 finding) and the backedge fixpoint together are the bar 3c mus
 clear. Net: 3b is retained as a **negative result / regression probe** behind its
 feature flag; the next real step is designing 3c to match-or-beat the backedge,
 not to replace it with liveness promotion.
+
+## 14. §5 stage 3c design: a separable allocator that matches the backedge
+
+Stage 3b established the hard constraint: the analysis pre-pass's loop **backedge
+fixpoint** computes loop-carried xmm placements that are *load-bearing* for tight
+float loops (mandelbrot 1.9–2.6× slower without them), and a naive
+liveness-only re-derivation does not recover them. optcarrot was flat base-vs-3b,
+so the placement quality that matters is localized to tight loops carrying several
+live floats across the back-edge — that is the regression surface 3c must not
+touch.
+
+### 14.1 The realization: loop allocation is *already* a fixpoint
+
+`analyse_backedge_fixpoint` (compile/loop_analysis.rs) iterates `analyse_loop`
+(≤10 times) until the back-edge `AbstractState` stops changing (`be.equiv`). Each
+iteration runs the per-BB walk with `apply_join` allocation, so the loop's
+placement is the fixed point of the greedy per-merge allocator. The fusion is that
+this single fixpoint co-evolves **types** *and* **placements**. Stages 2/3a proved
+the type half is allocation-independent. So the separation is not "remove
+allocation from the loop" (3b's mistake) — it is **sequence two fixpoints instead
+of fusing one**:
+
+```
+fused today:     one fixpoint over (types + placements)        [analyse_loop ×N]
+3c target:       fixpoint-1 over (types + liveness)   — NO placement
+                 fixpoint-2 over (placements)         — greedy alloc on fixed types
+```
+
+Because fixpoint-2 runs the *same* greedy `apply_join` allocation, just sequenced
+after type analysis rather than interleaved with it, it converges to the **same
+loop-carried placements** — that is what makes the separation behaviour-preserving
+and shadow-verifiable. 3b failed precisely because it replaced fixpoint-2 with a
+single `use_float` liveness hint, not a placement fixpoint.
+
+### 14.2 Decomposition
+
+- **3c-i — safe / shadow-able: extract the allocation fixpoint as its own pass.**
+  Run a type+liveness-only fixpoint first (the §3 Layer-① analysis; the type meet
+  is already `join_ty`, the liveness is already separate), then run the greedy
+  allocation fixpoint over the frozen types to produce placements. The allocator
+  is now a distinct, pluggable component running today's greedy policy. Verify
+  with the stage-1 placement replay shadow that the placements equal the fused
+  result, slot-for-slot, including the backedge. No behaviour change — this is the
+  real Layer-② extraction, and the thing 3b should have been. *Next implementable
+  step (behind a feature until the shadow is green across the suite + benches).*
+
+- **3c-ii — benchmark-gated: swap the greedy fixpoint for linear scan.** With the
+  allocator extracted, replace the iterate-to-fixpoint greedy policy with a
+  loop-aware linear-scan over live intervals (below). Gate against the
+  mandelbrot/nbody bar (must match-or-beat the backedge) and optcarrot (must stay
+  flat). Each policy change is an independent gated diff.
+
+### 14.3 3c-ii allocator shape (the linear-scan)
+
+Inputs (all allocation-independent, already computed by Layer ①):
+- per-slot `Guarded` type at each program point;
+- the representation decision **kept separate from placement**: "this slot is used
+  as f64" (today's `use_float` liveness) decides *unboxed-float-ness*; the
+  allocator then decides *which* xmm (or spill) — splitting `Sf`'s two jobs (mark
+  vs register) per §3 Layer ②;
+- live intervals per slot, with **loop-carried intervals** (live across the
+  back-edge) flagged so the scan keeps them resident across the whole loop body —
+  this is what reproduces the backedge's "float stays in xmm across iterations."
+
+Output: a placement per (slot, point) + edge moves. The edge moves already exist —
+`AbstractFrame::bridge` emits the φ-reconciliation MOV/swap/spill from
+`(pred.mode, target.mode)`; the allocator only chooses the target registers and
+the bridge lowers them (so the recently-fixed `xmm_swap` and the F/Sf/S bridge
+arms are reused unchanged).
+
+Two properties the scan must preserve (both already in the codebase):
+1. **Free spill of read-only caches.** `try_alloc_xmm` phase-1 demotes an all-`Sf`
+   register to `S` with *no* asm (stack is canonical). A linear-scan spill of an
+   `Sf` interval must keep this — spilling a clean float cache costs nothing.
+2. **Loop-carried priority.** The fixpoint today keeps loop-carried floats in xmm
+   by construction; the scan must give intervals that span the back-edge higher
+   priority than intra-loop temporaries when registers are scarce, or it will
+   reintroduce the 3b regression.
+
+### 14.4 Hard parts carried over
+
+- **Deopt as a program point (§10 item 2).** Once placement is decided in
+  fixpoint-2, a deopt's register/stack map must be reconstructed from the
+  allocator's result at that pc, not the frozen `AsmDeopt` the transfer records
+  carry today. 3c-i sidesteps this only if fixpoint-2 still emits in a forward
+  walk that knows placements at each pc (it does, today). Full record-driven
+  lowering (goal 1) is where the deopt-program-point work lands.
+- **Representation vs placement split.** Today `Sf`/`F`/`S` bundle "unboxed?" with
+  "which register?". 3c separates them: liveness marks unboxed-float slots; the
+  allocator assigns registers. The typed IR carries the mark, not the register.
+
+### 14.5 Why this is the right order
+
+3c-i is the behaviour-preserving separation the whole §5 effort has been building
+toward (decide/apply split, record stream, type-meet invariant all feed it), and
+it is shadow-verifiable against the fused result. 3c-ii is the only step that may
+regress, and it is gated on the exact benchmarks 3b flagged. 3b is retained as the
+negative-result probe that calibrated the bar: any allocator that cannot match the
+backedge on mandelbrot/nbody is not ready to land.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -331,7 +331,7 @@ deopt is therefore supplied by the codegen side, **not** frozen into the record;
 the guard-free numeric variants pass `None`. This confirms the resolution above
 concretely — behaviour-identical at 1703/0.
 
-### The guard primitive, and the limit of single-record splits
+### The guard primitive
 
 `guard_class` (the guard primitive behind `guard_fixnum` / `load_fixnum` /
 `load_array_ty`) splits into `guard_class_state(slot, class) -> bool` (refine the
@@ -339,24 +339,42 @@ slot's type; return whether a runtime guard must be emitted) plus the emit
 `if guard_class_state { ir.push(GuardClass(r, class, deopt)) }`. `load_fixnum`
 and `load_array_ty` then *compose* split primitives (`load` + the guard).
 
-`load_xmm_fixnum`'s `S`/`G` arms are the case that **does not** reduce to a
-single `(state) + (record → emit)` pair. They interleave as:
+### `load_xmm_fixnum`: the interleaving dissolves (single record after all)
+
+`load_xmm_fixnum`'s `S`/`G` arms *looked* like the case that could not reduce to
+a single `(state) + (record → emit)` pair, because they interleave a load, a
+`new_deopt`, a guard and the conversion:
 
 ```
-stack2reg(Rdi)            // emit
-new_deopt                 // deopt — must be AFTER the load, BEFORE set_new_Sf
+stack2reg(Rdi)            // emit  — load the boxed value
+new_deopt                 // deopt
 guard_class_state         // state (type)
-push GuardClass(deopt)    // emit
+push GuardClass(deopt)    // emit  — Integer guard
 set_new_Sf                // state (placement — allocates the xmm)
-fixnum2fpr(Rdi, x)        // emit
+fixnum2fpr(Rdi, x)        // emit  — int → f64
 ```
 
-The deopt snapshot must precede the placement change (`set_new_Sf`), but the
-load (`stack2reg`) must precede the deopt — so emission, deopt, and *two* state
-mutations are interleaved and cannot be hoisted into one state half + one emit
-half. This is exactly the general shape the **analysis pass** handles: the typed
-IR is a *sequence* of emission records, and the analysis walks the primitive
-mutating state while *appending* records at each emission point (codegen then
-replays the sequence). So fully splitting `load_xmm_fixnum` *is* the analysis-pass
-wiring — the single-record splits above are its tractable subset, and this is the
-natural boundary between "split the transfer primitives" and "wire the two-pass".
+The deopt snapshot (`get_write_back`) must precede the placement change
+(`set_new_Sf`). The apparent obstacle was that the load (`stack2reg`) "must"
+precede the deopt. But **`stack2reg`/`reg2stack` are pure emits on `ir`** — they
+push an `AsmInst` and never touch the frame's placement state — so `new_deopt`
+**commutes** with them. Reordered, the dependency chain is just
+`new_deopt → {guard_class_state, set_new_Sf}`, the same shape `load_xmm` already
+solved: create the deopt up front, run the (now reorderable) state half, defer
+all emission into the record. The guard folds into the record as a bool
+(`guard_class_state`'s verdict). So `load_xmm_fixnum` splits into
+`load_xmm_fixnum_state -> (FPReg, XmmFixnumLoad)` plus a wrapper that creates the
+deopt *only* for the guarded `S`/`G` arms (peeking the mode — `use_as_value`
+only marks liveness, so the peek is stable) and supplies it to `XmmFixnumLoad::emit`.
+Behaviour-identical at 1703/0.
+
+The lesson: **a "pure emit" instruction between a state mutation and a `new_deopt`
+is not a true interleaving** — it commutes out to the emit half. The
+single-record model is therefore more general than first thought, and with this
+split *every* transfer/eviction primitive in the table is now decomposed into a
+`*_state` analysis half returning a typed-IR record (`Spill` / `FpXfer` /
+`XmmLoad` / `GpLoad` / `XmmFixnumLoad`, plus the `guard_class_state` verdict) and
+a record-replaying emit half. That completes the prerequisite for the two-pass
+wiring: the analysis pass calls the `*_state` halves and collects the records;
+codegen replays `record.emit(...)`. The remaining step is plumbing those two
+passes through `compile_instruction` / `analyse_basic_block`.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -514,3 +514,27 @@ materializes `AsmDeopt(side_exit.len())`), so the replay pre-pads the scratch's
 produced `SideExit`s match (Debug-compared; neither is `PartialEq`). Suite
 1703/0, no replay mismatches — the stream is now fully codegen-independent, the
 last prerequisite for record-driven lowering (step 3).
+
+### Analysis pass skips emission (doc §9 step 2, realized)
+
+With the deopt program-point-ified, `AsmIr::transfer` now **returns immediately
+in analysis mode** (`codegen_mode == false`). The abstract-state mutation already
+happened in the wrapper's `*_state` half; `emit` only writes to `ir`, and the
+loop pre-pass discards its local `AsmIr` (`analyse_basic_block` drops it — the
+`loop_analysis` context "emits AsmIr only for analysis, it is never codegen'd",
+context.rs:692). So emission in analysis mode was pure dead work — and, since
+`new_deopt`/`deopt_from_point` are not `push`-gated, it also grew a `side_exit`
+table nobody reads (the waste §10 flagged).
+
+This is provably safe: `emit`'s signature, `fn emit(self, ir: &mut AsmIr)`, cannot
+touch frame/abstract state — the same property the shadow check independently
+verifies. So the analysis pass now literally "calls the state halves and skips
+emission" for every transfer primitive, exactly the §9-step-2 shape. The §10
+deopt wrinkle ("the open wrinkle is the deopt … frozen `AsmDeopt`") is closed:
+the records carry a `DeoptPoint`, and the only thing left fusing analysis and
+codegen for the *transfer primitives* is gone. Suite 1703/0.
+
+What remains for full record-driven lowering is the §10-item-1 core (de-fuse
+allocation from the join — the SSA-φ edge-move rewrite) and lowering the *op
+handlers'* direct emissions through records too; the transfer primitives are
+done.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -565,3 +565,25 @@ allocating inline during the meet. The `decide`/`apply` boundary is exactly wher
 that pass plugs in. Not yet done: turning the `TryFresh*` inline allocations into
 allocator-assigned φ registers (the SSA-φ edge-move rewrite) — but the meet is
 now cleanly type-decision (`decide_join`) vs placement-allocation (`apply_join`).
+
+### §5 stage 1: the merge as a replayable record stream
+
+With the meet split into `decide_join` / `apply_join`, stage 1 of the safe
+allocator de-fusion records the per-slot `JoinAction` stream as the merge runs,
+then (debug) **replays it from a clone of the pre-merge frame and asserts it
+reproduces the identical placement** (every slot's resulting `LinkMode`). This is
+the allocation analog of the transfer shadow harness: it locks the property the
+separated allocator pass relies on — the decision stream plus `apply_join` is a
+*complete*, replayable record of the meet — and becomes the regression harness
+future allocator changes shadow against. Suite 1703/0, no replay mismatches.
+
+**Key finding for the allocator design — the meet has cross-slot coupling.** A
+`TryFresh*` action's allocation (`try_alloc_xmm` phase 1) can **demote other
+slots'** `Sf` bindings to `S` to free a physical xmm. So a later slot's
+`decide_join` may read a `LinkMode` that an earlier slot's `apply_join` mutated:
+`decide` and `apply` are *not* separable into two clean passes over the slots —
+they must interleave. The replay shadow confirms this reproduces faithfully (it
+replays `apply_join` in order, demotions included). This rules out the naive
+"decide-all then allocate-all" staging and tells us the allocator pass must model
+the pool as evolving across the merge's slots (a linear-scan-style sweep), not a
+batch assignment — the constraint that shapes stage 2.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -1037,3 +1037,31 @@ computation from the operand-load/def handlers above) is the larger, later arc;
 3c-i increments 1–3 deliver the swappable allocator and the measured win first,
 since that is where the §14.6 regression and the latent base-case back-edge boxing
 both live.
+
+### 15.1 Two no-op experiments locate the lever: it is the merge, not the allocator
+
+Increment 1 gave a clean `alloc_policy` seam, but two targeted experiments behind
+it both came back **byte-identical** on the mandelbrot kernel:
+
+- **`use_float` spill fallback** (§14.7): promote a pool-full float to an unboxed
+  spill (`set_new_Sf`) instead of leaving it boxed `S`. No-op.
+- **`liveness-aware-spill`**: in `try_alloc_xmm` phase 1, prefer demoting a clean
+  `Sf` register whose slots are *dead* over one still *live* (using the `IsUsed`
+  liveness `SlotState` already carries). No-op (340→340 insts, same decode count).
+
+Two independent per-call allocation levers changing nothing means the
+per-iteration boxing of loop-carried floats is **not** decided in `alloc_policy`
+or `use_float`. It is decided at the **loop-header merge** — `decide_join` /
+`apply_join` choose the loop-carried float's mode (`F` pure-xmm vs `Sf`/`S`
+boxed-cache), and *that* is what the body inherits and re-decodes each iteration
+(§14.6). The allocator only places what the merge already decided to keep
+unboxed; it never gets the chance to keep a value the merge boxed.
+
+**Redirect for 3c-ii.** The lever is the loop-header join's float placement: why
+the meet demotes a loop-carried `F` to `Sf`/`S` instead of keeping it `F`. That is
+in the already-split `decide_join` table (the `F/F`, `F/Sf`, `F/S` arms) — and it
+governs both the 3b regression *and* the latent base-case back-edge box. Increment
+1's `alloc_policy` seam stays as valid structural cleanup, but 3c-ii's measured
+win must come from the join arms, not the spill policy. The next concrete step is
+to read the loop-header join decision for a loop-carried float and determine
+whether keeping it `F` across the back-edge (no boxed cache) is sound and cheaper.

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -44,17 +44,6 @@ profile = ["dump-bc", "dump-traceir"]
 perf = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
-# §5 stage 3b experiment: feed the codegen pass a placement-free (type-only)
-# loop-carried frame, so it re-derives xmm bindings via liveness instead of
-# inheriting the analysis pass's allocation. Behaviour-changing (codegen quality
-# only); off by default. Build twice (with/without) to A/B-benchmark. See
-# doc/regalloc_separation.md §13.
-loop-type-only-entry = []
-# §15.3 prototype: at a loop header, adopt the back-edge fixpoint's `F` placement
-# for loop-carried floats the merge collapsed to `S` (the boxed forward-entry
-# initial value), so the loop body stays unboxed instead of decoding+reboxing the
-# float every iteration. Pairs with the `S -> F` bridge arm. Off by default.
-loop-keep-float = []
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -50,6 +50,11 @@ dump-require = []
 # only); off by default. Build twice (with/without) to A/B-benchmark. See
 # doc/regalloc_separation.md §13.
 loop-type-only-entry = []
+# §15.3 prototype: at a loop header, adopt the back-edge fixpoint's `F` placement
+# for loop-carried floats the merge collapsed to `S` (the boxed forward-entry
+# initial value), so the loop body stays unboxed instead of decoding+reboxing the
+# float every iteration. Pairs with the `S -> F` bridge arm. Off by default.
+loop-keep-float = []
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -44,6 +44,12 @@ profile = ["dump-bc", "dump-traceir"]
 perf = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
+# §5 stage 3b experiment: feed the codegen pass a placement-free (type-only)
+# loop-carried frame, so it re-derives xmm bindings via liveness instead of
+# inheriting the analysis pass's allocation. Behaviour-changing (codegen quality
+# only); off by default. Build twice (with/without) to A/B-benchmark. See
+# doc/regalloc_separation.md §13.
+loop-type-only-entry = []
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -104,7 +104,7 @@ fn range_begin(
         }
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_begin());
+    ir.load_field_to_reg(GP::Rax, GP::Rdi, crate::rvalue::RANGE_START_OFFSET as i32);
 
     state.def_reg2acc(ir, GP::Rax, dst);
     true
@@ -142,7 +142,7 @@ fn range_end(
         }
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_end());
+    ir.load_field_to_reg(GP::Rax, GP::Rdi, crate::rvalue::RANGE_END_OFFSET as i32);
 
     state.def_reg2acc(ir, GP::Rax, dst);
     true

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -337,7 +337,7 @@ impl FnInitInfo {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(crate) struct DynVar {
     pub reg: SlotId,
     pub outer: usize,

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -833,10 +833,13 @@ impl Codegen {
     /// patching (`set_deopt_with_return_addr`) is x86-only (runtime branch
     /// patching), so it is skipped — class-version changes are caught by
     /// `GuardClassVersion` deopts instead.
-    fn a64_do_call(&mut self, store: &Store, callee_fid: FuncId, call_site_bc_ptr: BytecodePtr) {
-        let callee = &store[callee_fid];
-        let is_iseq = callee.is_iseq().is_some();
-        let (_meta, codeptr, pc) = callee.get_data();
+    fn a64_do_call(
+        &mut self,
+        codeptr: CodePtr,
+        is_iseq: bool,
+        callee_pc: Option<BytecodePtrBase>,
+        call_site_bc_ptr: BytecodePtr,
+    ) {
         let codeptr_addr = codeptr.as_ptr() as u64;
         // set_lfp + push_frame (EXEC=x19, LFP=x22).
         monoasm_arm64!(&mut self.jit,
@@ -849,7 +852,7 @@ impl Codegen {
         );
         if is_iseq {
             // iseq: PC <- callee pc (read by the VM tier / prologue).
-            if let Some(pc) = pc {
+            if let Some(pc) = callee_pc {
                 let pc_ptr = pc.as_ptr() as u64;
                 monoasm_arm64!(&mut self.jit, mov x21, (pc_ptr););
             }
@@ -2721,16 +2724,20 @@ impl Codegen {
     /// The call itself. aarch64 has no runtime branch patching, so the `evict`
     /// return-address patch point is not registered (class-version guards cover
     /// the staleness it would otherwise catch); the x86-only params are unused.
+    /// aarch64 always calls `codeptr` directly (no JIT-entry dispatch or
+    /// return-address patching — class-version guards cover invalidation), so
+    /// `jit_entry` / `evict` / `evict_label` are unused here.
     pub(in crate::codegen::jitgen) fn emit_call(
         &mut self,
-        store: &Store,
-        callee_fid: FuncId,
-        _recv_class: ClassId,
+        codeptr: CodePtr,
+        is_iseq: bool,
+        callee_pc: Option<BytecodePtrBase>,
+        call_site_bc_ptr: BytecodePtr,
+        _jit_entry: Option<DestLabel>,
         _evict: AsmEvict,
         _evict_label: &DestLabel,
-        pc: BytecodePtr,
     ) {
-        self.a64_do_call(store, callee_fid, pc);
+        self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr);
     }
 
     /// Method prologue: establish fp/lr, reserve the local frame, and nil-fill

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::LInst;
+use crate::codegen::jitgen::lir::{LInst, LMem};
 use monoasm_macro::monoasm_arm64;
 
 ///
@@ -1351,6 +1351,44 @@ impl Codegen {
                     monoasm_arm64!(&mut self.jit, mov x(d), x(s););
                 }
             }
+            // dst <- imm (monoasm_arm64! expands a 64-bit immediate to the
+            // movz/movk sequence as needed)
+            LInst::LoadImm { dst, imm } => {
+                let d = dst.a64().0;
+                monoasm_arm64!(&mut self.jit, mov x(d), (imm););
+            }
+            // dst <- [lfp - slot]. `a64_frame_load` legalizes the (negative)
+            // frame displacement: it folds small offsets into `ldur` and
+            // materializes large ones through scratch x10.
+            LInst::Load {
+                dst,
+                mem: LMem::Slot(slot),
+            } => {
+                let lfp = GP::R14.a64().0;
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                self.a64_frame_load(dst.a64().0, lfp, off);
+            }
+            // [lfp - slot] <- src (legalized like `Load`).
+            LInst::Store {
+                src,
+                mem: LMem::Slot(slot),
+            } => {
+                let lfp = GP::R14.a64().0;
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                self.a64_frame_store(src.a64().0, lfp, off);
+            }
+            // [lfp - slot] <- imm. aarch64 has no store-immediate, so the
+            // immediate is staged through scratch x9 (no allocated GP clobbered),
+            // then stored via the legalizing `a64_frame_store`.
+            LInst::StoreImm {
+                imm,
+                mem: LMem::Slot(slot),
+            } => {
+                let lfp = GP::R14.a64().0;
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                monoasm_arm64!(&mut self.jit, mov x9, (imm););
+                self.a64_frame_store(9, lfp, off);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1470,34 +1508,36 @@ impl Codegen {
 
     /// [lfp - slot*8 - LFP_SELF] <- reg
     pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
-        let lfp = GP::R14.a64().0;
-        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        self.a64_frame_store(r.a64().0, lfp, off);
+        self.encode_linst(LInst::Store {
+            src: r,
+            mem: LMem::Slot(slot),
+        });
     }
 
     /// reg <- [lfp - slot*8 - LFP_SELF]
     pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
-        let lfp = GP::R14.a64().0;
-        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        self.a64_frame_load(r.a64().0, lfp, off);
+        self.encode_linst(LInst::Load {
+            dst: r,
+            mem: LMem::Slot(slot),
+        });
     }
 
     /// reg <- literal Value (immediate)
     pub(in crate::codegen::jitgen) fn emit_lit_to_reg(&mut self, v: Value, r: GP) {
-        let dst = r.a64().0;
-        let imm = v.id();
-        monoasm_arm64!(&mut self.jit, mov x(dst), (imm););
+        self.encode_linst(LInst::LoadImm {
+            dst: r,
+            imm: v.id(),
+        });
     }
 
     /// [lfp - slot*8 - LFP_SELF] <- literal Value. The immediate is
     /// materialized in a scratch reg (aarch64 has no store-immediate), so no GP
     /// register is clobbered. Mirrors x86 `literal_to_stack`.
     pub(in crate::codegen::jitgen) fn emit_lit_to_stack(&mut self, v: Value, slot: SlotId) -> bool {
-        let lfp = GP::R14.a64().0;
-        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        let imm = v.id();
-        monoasm_arm64!(&mut self.jit, mov x9, (imm););
-        self.a64_frame_store(9, lfp, off);
+        self.encode_linst(LInst::StoreImm {
+            imm: v.id(),
+            mem: LMem::Slot(slot),
+        });
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -710,10 +710,10 @@ impl Codegen {
     /// `setup_method_frame`.
     fn a64_setup_method_frame(
         &mut self,
-        store: &Store,
         meta: Meta,
-        callid: CallSiteId,
         outer_lfp: Option<Lfp>,
+        block_fid: Option<FuncId>,
+        block_arg: Option<SlotId>,
     ) {
         let outer = match outer_lfp {
             Some(lfp) => lfp.as_ptr() as u64,
@@ -726,8 +726,6 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit, mov x9, (0u64););
         self.a64_store_x9_below_sp((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
         self.a64_store_x9_below_sp((RSP_LOCAL_FRAME + LFP_CME) as u32);
-        let callsite = &store[callid];
-        let (block_fid, block_arg) = (callsite.block_fid, callsite.block_arg);
         self.a64_set_block(block_fid, block_arg);
     }
 
@@ -2508,18 +2506,15 @@ impl Codegen {
     /// basic block (the `br` is an unconditional indirect branch).
     pub(in crate::codegen::jitgen) fn emit_opt_case(
         &mut self,
-        frame: &mut AsmInfo,
         max: u16,
         min: u16,
-        else_label: JitLabel,
-        branch_labels: Box<[JitLabel]>,
+        else_dest: DestLabel,
+        branch_dests: Box<[DestLabel]>,
     ) {
         let jump_table = self.jit.const_align8();
-        for label in branch_labels.iter() {
-            let dest_label = frame.resolve_label(&mut self.jit, *label);
-            self.jit.abs_address(dest_label);
+        for dest_label in branch_dests.iter() {
+            self.jit.abs_address(dest_label.clone());
         }
-        let else_dest = frame.resolve_label(&mut self.jit, else_label);
         let cond = GP::Rdi.a64().0; // x4
         monoasm_arm64!(&mut self.jit,
             asr x(cond), x(cond), #1;   // untag fixnum: x4 = n
@@ -2586,24 +2581,23 @@ impl Codegen {
     /// Write the callee frame's meta/outer/block fields before a call.
     pub(in crate::codegen::jitgen) fn emit_setup_method_frame(
         &mut self,
-        store: &Store,
         meta: Meta,
-        callid: CallSiteId,
         outer_lfp: Option<Lfp>,
+        block_fid: Option<FuncId>,
+        block_arg: Option<SlotId>,
     ) {
-        self.a64_setup_method_frame(store, meta, callid, outer_lfp);
+        self.a64_setup_method_frame(meta, outer_lfp, block_fid, block_arg);
     }
 
-    /// Marshal the call arguments into the callee frame. Bails (`false`) on a
-    /// not-yet-ported argument shape.
+    /// Marshal the call arguments into the callee frame (`offset` is the callee
+    /// scratch-area size, pre-resolved by the dispatcher).
     pub(in crate::codegen::jitgen) fn emit_set_arguments(
         &mut self,
-        store: &Store,
         callid: CallSiteId,
         callee_fid: FuncId,
-    ) -> bool {
-        let offset = store[callee_fid].get_offset();
-        self.a64_set_arguments(callid, callee_fid, offset)
+        offset: usize,
+    ) {
+        self.a64_set_arguments(callid, callee_fid, offset);
     }
 
     /// Recompile-or-deopt point. Counter-gates a one-shot recompile, then falls
@@ -2771,15 +2765,9 @@ impl Codegen {
     /// paths can write straight to a slot); grow it via `extend_ivar` otherwise.
     /// A no-op when no heap ivar is accessed or self is always-frozen. Mirrors
     /// x86 `emit_preparation` (inline cold path instead of a page-1 split).
-    pub(in crate::codegen::jitgen) fn emit_preparation(&mut self, store: &Store, frame: &AsmInfo) -> bool {
-        if frame.self_class.is_always_frozen() || !frame.ivar_heap_accessed {
-            return true;
-        }
-        let ivar_len = store[frame.self_class].ivar_len();
-        let heap_len = if frame.self_ty == Some(ObjTy::OBJECT) {
-            ivar_len - OBJECT_INLINE_IVAR
-        } else {
-            ivar_len
+    pub(in crate::codegen::jitgen) fn emit_preparation(&mut self, heap_len: Option<usize>) {
+        let Some(heap_len) = heap_len else {
+            return;
         };
         let lfp = GP::R14.a64().0; // x22
         let f = extend_ivar as *const () as u64;
@@ -2810,7 +2798,6 @@ impl Codegen {
             ldr x30, [sp], #16;
             exit:
         );
-        true
     }
 
     ///

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1708,6 +1708,64 @@ impl Codegen {
                 );
                 self.a64_fpr_commit(dst, 0, base);
             }
+            // ---- FP arithmetic / comparison ----------------------------------
+            LInst::FloatBinOp { kind, lhs, rhs, dst, base } => {
+                // Only Add/Sub/Mul/Div reach FloatBinOp (Rem/pow are method
+                // calls). Operands resolve to a pool reg or load a spill into
+                // d0/d1; the result writes its pool reg or scratch d0.
+                let ld = self.a64_fpr_read(lhs, 0, base);
+                let rd = self.a64_fpr_read(rhs, 1, base);
+                let dd = self.a64_fpr_wtmp(dst, 0, base);
+                match kind {
+                    BinOpK::Add => monoasm_arm64!(&mut self.jit, fadd d(dd), d(ld), d(rd);),
+                    BinOpK::Sub => monoasm_arm64!(&mut self.jit, fsub d(dd), d(ld), d(rd);),
+                    BinOpK::Mul => monoasm_arm64!(&mut self.jit, fmul d(dd), d(ld), d(rd);),
+                    BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
+                    _ => unreachable!(),
+                }
+                self.a64_fpr_commit(dst, 0, base);
+            }
+            LInst::FloatUnOp { kind, dst, base } => match kind {
+                UnOpK::Neg => {
+                    let p = self.a64_fpr_read(dst, 0, base);
+                    monoasm_arm64!(&mut self.jit,
+                        fmov x9, d(p);
+                        mov x10, (0x8000_0000_0000_0000u64);
+                        eor x9, x9, x10;
+                        fmov d(p), x9;
+                    );
+                    self.a64_fpr_commit(dst, 0, base);
+                }
+                UnOpK::Pos => {}
+                _ => unreachable!(),
+            },
+            LInst::FloatCmp { kind, lhs, rhs, base } => {
+                let lp = self.a64_fpr_read(lhs, 0, base);
+                let rp = self.a64_fpr_read(rhs, 1, base);
+                monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
+                let cond = a64_float_cond_for_cmp(kind, BrKind::BrIf);
+                let rax = GP::Rax.a64();
+                self.jit.cset(rax, cond);
+                monoasm_arm64!(&mut self.jit,
+                    lsl x(rax.0), x(rax.0), #(3u32);
+                    mov x9, (FALSE_VALUE);
+                    orr x(rax.0), x(rax.0), x9;
+                );
+            }
+            LInst::FloatCmpBr {
+                kind,
+                lhs,
+                rhs,
+                brkind,
+                dest,
+                base,
+            } => {
+                let lp = self.a64_fpr_read(lhs, 0, base);
+                let rp = self.a64_fpr_read(rhs, 1, base);
+                monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
+                let cond = a64_float_cond_for_cmp(kind, brkind);
+                self.jit.bcond_label(cond, &dest);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2397,95 +2455,6 @@ impl Codegen {
     ) -> bool {
         self.a64_cmp_integer(&mode, lhs, rhs);
         self.a64_flag_to_bool(kind);
-        true
-    }
-
-    /// Float (four-arithmetic) binary op: dst <- lhs <op> rhs in D-registers.
-    /// Bails (`false`) if an operand is not lowerable or `kind` is unsupported.
-    pub(in crate::codegen::jitgen) fn emit_float_binop(
-        &mut self,
-        kind: BinOpK,
-        binary_xmm: (FPReg, FPReg),
-        dst: FPReg,
-        base: usize,
-    ) -> bool {
-        let (l, r) = binary_xmm;
-        // Only the four arithmetic ops are emitted as FloatBinOp (Rem/pow/etc.
-        // are method calls); the `_ => unreachable!()` in the op match below
-        // mirrors x86 `float_binop`.
-        // Operands resolve to their pool register, or load a spill into d0/d1;
-        // the result writes its pool register or scratch d0 (committed below).
-        let ld = self.a64_fpr_read(l, 0, base);
-        let rd = self.a64_fpr_read(r, 1, base);
-        let dd = self.a64_fpr_wtmp(dst, 0, base);
-        // aarch64 FP 3-op writes rd, reads rn/rm — no aliasing hazard.
-        match kind {
-            BinOpK::Add => monoasm_arm64!(&mut self.jit, fadd d(dd), d(ld), d(rd);),
-            BinOpK::Sub => monoasm_arm64!(&mut self.jit, fsub d(dd), d(ld), d(rd);),
-            BinOpK::Mul => monoasm_arm64!(&mut self.jit, fmul d(dd), d(ld), d(rd);),
-            BinOpK::Div => monoasm_arm64!(&mut self.jit, fdiv d(dd), d(ld), d(rd);),
-            _ => unreachable!(),
-        }
-        self.a64_fpr_commit(dst, 0, base);
-        true
-    }
-
-    /// Float unary op: negate (flip bit 63) or unary-plus (no-op). The macro
-    /// lacks `fneg`, so the sign flip goes through a GPR (`fmov`/`eor`/`fmov`).
-    /// Bails (`false`) on a spilled operand or an unsupported `UnOpK`.
-    pub(in crate::codegen::jitgen) fn emit_float_unop(&mut self, kind: UnOpK, dst: FPReg, base: usize) -> bool {
-        match kind {
-            UnOpK::Neg => {
-                let p = self.a64_fpr_read(dst, 0, base);
-                monoasm_arm64!(&mut self.jit,
-                    fmov x9, d(p);
-                    mov x10, (0x8000_0000_0000_0000u64);
-                    eor x9, x9, x10;
-                    fmov d(p), x9;
-                );
-                self.a64_fpr_commit(dst, 0, base);
-            }
-            UnOpK::Pos => {}
-            // Float unary ops are only Neg/Pos (BitNot is integer-only).
-            _ => unreachable!(),
-        }
-        true
-    }
-
-    /// Float comparison; NaN-correct boolean Value in the accumulator. Mirrors
-    /// `a64_flag_to_bool` but on `fcmp` flags with float condition codes. Bails
-    /// (`false`) if either operand is spilled.
-    pub(in crate::codegen::jitgen) fn emit_float_cmp(&mut self, kind: CmpKind, lhs: FPReg, rhs: FPReg, base: usize) -> bool {
-        let lp = self.a64_fpr_read(lhs, 0, base);
-        let rp = self.a64_fpr_read(rhs, 1, base);
-        monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
-        let cond = a64_float_cond_for_cmp(kind, BrKind::BrIf);
-        let rax = GP::Rax.a64();
-        self.jit.cset(rax, cond);
-        monoasm_arm64!(&mut self.jit,
-            lsl x(rax.0), x(rax.0), #(3u32);
-            mov x9, (FALSE_VALUE);
-            orr x(rax.0), x(rax.0), x9;
-        );
-        true
-    }
-
-    /// Fused float compare + conditional branch (NaN compares false except
-    /// `!=`). Bails (`false`) if either operand is spilled.
-    pub(in crate::codegen::jitgen) fn emit_float_cmp_br(
-        &mut self,
-        kind: CmpKind,
-        lhs: FPReg,
-        rhs: FPReg,
-        brkind: BrKind,
-        branch_dest: DestLabel,
-        base: usize,
-    ) -> bool {
-        let lp = self.a64_fpr_read(lhs, 0, base);
-        let rp = self.a64_fpr_read(rhs, 1, base);
-        monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
-        let cond = a64_float_cond_for_cmp(kind, brkind);
-        self.jit.bcond_label(cond, &branch_dest);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1368,6 +1368,15 @@ impl Codegen {
                 let off = slot.0 as u32 * 8 + LFP_SELF as u32;
                 self.a64_frame_load(dst.a64().0, lfp, off);
             }
+            // dst <- [base + disp] (object field). `a64_field_load` legalizes
+            // the (positive) displacement: scaled ldr immediate, else scratch
+            // x10 materialization.
+            LInst::Load {
+                dst,
+                mem: LMem::Field { base, disp },
+            } => {
+                self.a64_field_load(dst.a64().0, base.a64().0, disp as u32);
+            }
             // [lfp - slot] <- src (legalized like `Load`).
             LInst::Store {
                 src,
@@ -2955,15 +2964,6 @@ impl Codegen {
         self.a64_field_store(s, rdi, off);
         // Write barrier: rdi = the object (parent), src = stored value.
         self.emit_write_barrier(GP::Rdi, src);
-        true
-    }
-
-    /// Load an inline Struct member slot into the accumulator (x23).
-    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_inline(&mut self, slot_index: u16) -> bool {
-        let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let r15 = GP::R15.a64().0;
-        self.a64_field_load(r15, rdi, off);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -975,6 +975,18 @@ impl Codegen {
         }
     }
 
+    /// Spill an FP-pool register to `slot` as a boxed Float `Value` (via
+    /// `f64_to_val`), r14(x22)-relative. Shared by the `FprToStack` LIR op and
+    /// the deopt write-back.
+    fn emit_fpr_to_stack(&mut self, src: FPReg, slot: SlotId, base: usize) {
+        let lfp = GP::R14.a64().0;
+        let f64_to_val = self.f64_to_val.clone();
+        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+        self.a64_fpr_load(src, 0, base); // value -> d0 (pool fmov or spill load)
+        monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
+        self.a64_frame_store(0, lfp, off);
+    }
+
     /// Store physical D-register `dreg` into `dst` unconditionally (`fmov` for a
     /// pool register, a frame store for a spill slot).
     fn a64_fpr_save(&mut self, dst: FPReg, dreg: u32, base: usize) {
@@ -1665,12 +1677,7 @@ impl Codegen {
                 self.a64_fpr_commit(dst, 0, base);
             }
             LInst::FprToStack { src, slot, base } => {
-                let lfp = GP::R14.a64().0;
-                let f64_to_val = self.f64_to_val.clone();
-                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-                self.a64_fpr_load(src, 0, base); // value -> d0 (pool fmov or spill load)
-                monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
-                self.a64_frame_store(0, lfp, off);
+                self.emit_fpr_to_stack(src, slot, base);
             }
             LInst::FprSwap { lhs, rhs, base } => {
                 // Force both values into scratch, then store back crossed.

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::{LInst, LMem};
+use crate::codegen::jitgen::lir::{LAluOp, LInst, LMem, LOperand};
 use monoasm_macro::monoasm_arm64;
 
 ///
@@ -1388,6 +1388,38 @@ impl Codegen {
                 let off = slot.0 as u32 * 8 + LFP_SELF as u32;
                 monoasm_arm64!(&mut self.jit, mov x9, (imm););
                 self.a64_frame_store(9, lfp, off);
+            }
+            // dst <op>= imm (in-place register/immediate ALU; the only Alu
+            // shape produced so far, from RegAdd/RegSub). The immediate is
+            // staged through scratch x9; SP (reg 31 == XZR in the
+            // shifted-register form) is updated via x10. No-op when imm == 0.
+            LInst::Alu {
+                op,
+                dst,
+                lhs,
+                rhs: LOperand::Imm(i),
+            } if dst == lhs => {
+                if i != 0 {
+                    let d = dst.a64().0;
+                    let imm = i as u64;
+                    match (op, dst == GP::Rsp) {
+                        (LAluOp::Add, false) => {
+                            monoasm_arm64!(&mut self.jit, mov x9, (imm); add x(d), x(d), x9;)
+                        }
+                        (LAluOp::Add, true) => monoasm_arm64!(&mut self.jit,
+                            mov x9, (imm); mov x10, sp; add x10, x10, x9; mov sp, x10;
+                        ),
+                        (LAluOp::Sub, false) => {
+                            monoasm_arm64!(&mut self.jit, mov x9, (imm); sub x(d), x(d), x9;)
+                        }
+                        (LAluOp::Sub, true) => monoasm_arm64!(&mut self.jit,
+                            mov x9, (imm); mov x10, sp; sub x10, x10, x9; mov sp, x10;
+                        ),
+                        _ => todo!(
+                            "LIR encode (aarch64): Alu {op:?} imm not yet migrated (Phase-1 Stage > 2-C)"
+                        ),
+                    }
+                }
             }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
@@ -2976,47 +3008,22 @@ impl Codegen {
 
     /// reg += i (no-op when i == 0). `i` is materialized so any i32 works.
     pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
-        if i != 0 {
-            let d = reg.a64().0;
-            if reg == GP::Rsp {
-                // Register 31 decodes as XZR (not SP) in the add/sub
-                // shifted-register form, so `add x31, x31, x9` would be a no-op.
-                // Go through a GP temp: mov to/from SP is the sp-aware form.
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (i as i64 as u64);
-                    mov x10, sp;
-                    add x10, x10, x9;
-                    mov sp, x10;
-                );
-            } else {
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (i as i64 as u64);
-                    add x(d), x(d), x9;
-                );
-            }
-        }
+        self.encode_linst(LInst::Alu {
+            op: LAluOp::Add,
+            dst: reg,
+            lhs: reg,
+            rhs: LOperand::Imm(i as i64),
+        });
     }
 
     /// reg -= i (no-op when i == 0).
     pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
-        if i != 0 {
-            let d = reg.a64().0;
-            if reg == GP::Rsp {
-                // See emit_reg_add: SP must be updated via a GP temp (reg 31 is
-                // XZR in the shifted-register form).
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (i as i64 as u64);
-                    mov x10, sp;
-                    sub x10, x10, x9;
-                    mov sp, x10;
-                );
-            } else {
-                monoasm_arm64!(&mut self.jit,
-                    mov x9, (i as i64 as u64);
-                    sub x(d), x(d), x9;
-                );
-            }
-        }
+        self.encode_linst(LInst::Alu {
+            op: LAluOp::Sub,
+            dst: reg,
+            lhs: reg,
+            rhs: LOperand::Imm(i as i64),
+        });
     }
 
     /// Loop-JIT entry stack bump (large bumps go through `a64_sp_sub`).

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1655,6 +1655,59 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
                 self.a64_frame_store(0, lfp, off);
             }
+            LInst::FprSwap { lhs, rhs, base } => {
+                // Force both values into scratch, then store back crossed.
+                self.a64_fpr_load(lhs, 0, base);
+                self.a64_fpr_load(rhs, 1, base);
+                self.a64_fpr_save(lhs, 1, base);
+                self.a64_fpr_save(rhs, 0, base);
+            }
+            LInst::FloatToFpr { src, dst, deopt, base } => {
+                let p = self.a64_fpr_wtmp(dst, 0, base);
+                let r = src.a64().0;
+                let heap = self.jit.label();
+                let exit = self.jit.label();
+                monoasm_arm64!(&mut self.jit,
+                    tbnz x(r), #(0), deopt;   // fixnum -> deopt (expected a Float)
+                    tbz x(r), #(1), heap;     // not flonum -> heap Float
+                    // flonum: handle 0.0, else decode.
+                    fmov d(p), xzr;
+                    mov x9, (FLOAT_ZERO);
+                    cmp x(r), x9;
+                );
+                self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+                monoasm_arm64!(&mut self.jit,
+                    asr x9, x(r), #(63);      // sign: all-1s / all-0s
+                    add x9, x9, #(2);         // 2 - signbit  (1 or 2)
+                    lsr x10, x(r), #(2);
+                    lsl x10, x10, #(2);       // reg & ~3
+                    orr x10, x10, x9;
+                    ror x10, x10, #(3);       // rotate_right 3
+                    fmov d(p), x10;
+                    b exit;
+                    heap:
+                );
+                self.a64_guard_rvalue(r, FLOAT_CLASS, &deopt);
+                monoasm_arm64!(&mut self.jit,
+                    ldr d(p), [x(r), #(RVALUE_OFFSET_KIND as u32)];
+                    exit:
+                );
+                self.a64_fpr_commit(dst, 0, base);
+            }
+            LInst::I64ToBoth { i, slot, dst, base } => {
+                let p = self.a64_fpr_wtmp(dst, 0, base);
+                let lfp = GP::R14.a64().0;
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                let id = Value::integer(i).id();
+                let bits = (i as f64).to_bits();
+                monoasm_arm64!(&mut self.jit, mov x9, (id););
+                self.a64_frame_store(9, lfp, off);
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (bits);
+                    fmov d(p), x9;
+                );
+                self.a64_fpr_commit(dst, 0, base);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2276,62 +2329,6 @@ impl Codegen {
     // `_wtmp`/`_load`/`_save`/`_commit`). All return bool; `base` is the spill
     // base.
 
-    /// swap two FP registers (via scratch D0/D1, spill-aware).
-    pub(in crate::codegen::jitgen) fn emit_fpr_swap(&mut self, l: FPReg, r: FPReg, base: usize) -> bool {
-        // Force both values into scratch, then store back crossed. (When both
-        // are pool-resident this is the old `fmov`-through-d0 swap.)
-        self.a64_fpr_load(l, 0, base);
-        self.a64_fpr_load(r, 1, base);
-        self.a64_fpr_save(l, 1, base);
-        self.a64_fpr_save(r, 0, base);
-        true
-    }
-
-    /// dst(f64) <- Float Value in GP `reg`; deopt if `reg` is not a Float.
-    /// Mirrors x86 float_to_f64 / float_val_to_f64 (flonum decode + heap-Float
-    /// load). `and`/`ror` have no immediate form / the macro grew `ror`, so the
-    /// rotate uses `ror` and the mask uses shifts.
-    pub(in crate::codegen::jitgen) fn emit_float_to_fpr(
-        &mut self,
-        reg: GP,
-        x: FPReg,
-        deopt: &DestLabel,
-        base: usize,
-    ) -> bool {
-        let p = self.a64_fpr_wtmp(x, 0, base);
-        let deopt = deopt.clone();
-        let r = reg.a64().0;
-        let heap = self.jit.label();
-        let exit = self.jit.label();
-        monoasm_arm64!(&mut self.jit,
-            tbnz x(r), #(0), deopt;   // fixnum -> deopt (expected a Float)
-            tbz x(r), #(1), heap;     // not flonum -> heap Float
-            // flonum: handle 0.0, else decode.
-            fmov d(p), xzr;
-            mov x9, (FLOAT_ZERO);
-            cmp x(r), x9;
-        );
-        self.jit.bcond_label(monoasm::Cond::Eq, &exit);
-        monoasm_arm64!(&mut self.jit,
-            asr x9, x(r), #(63);      // sign: all-1s / all-0s
-            add x9, x9, #(2);         // 2 - signbit  (1 or 2)
-            lsr x10, x(r), #(2);
-            lsl x10, x10, #(2);       // reg & ~3
-            orr x10, x10, x9;
-            ror x10, x10, #(3);       // rotate_right 3
-            fmov d(p), x10;
-            b exit;
-            heap:
-        );
-        self.a64_guard_rvalue(r, FLOAT_CLASS, &deopt);
-        monoasm_arm64!(&mut self.jit,
-            ldr d(p), [x(r), #(RVALUE_OFFSET_KIND as u32)];
-            exit:
-        );
-        self.a64_fpr_commit(x, 0, base);
-        true
-    }
-
     /// Save the live FP pool registers (D2..) below sp before a C-call.
     pub(in crate::codegen::jitgen) fn emit_xmm_save(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
         if using_xmm.not_any() && !cont {
@@ -2452,25 +2449,6 @@ impl Codegen {
             // Float unary ops are only Neg/Pos (BitNot is integer-only).
             _ => unreachable!(),
         }
-        true
-    }
-
-    /// `[lfp - slot*8 - LFP_SELF] <- Value::integer(i)` and `fpr(x) <- i as f64`
-    /// (a constant int materialized as both a boxed integer and a double).
-    /// Bails (`false`) if the FP destination is not lowerable (spilled).
-    pub(in crate::codegen::jitgen) fn emit_i64_to_both(&mut self, i: i64, slot: SlotId, x: FPReg, base: usize) -> bool {
-        let p = self.a64_fpr_wtmp(x, 0, base);
-        let lfp = GP::R14.a64().0;
-        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        let id = Value::integer(i).id();
-        let bits = (i as f64).to_bits();
-        monoasm_arm64!(&mut self.jit, mov x9, (id););
-        self.a64_frame_store(9, lfp, off);
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (bits);
-            fmov d(p), x9;
-        );
-        self.a64_fpr_commit(x, 0, base);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1620,6 +1620,41 @@ impl Codegen {
             } => {
                 self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt);
             }
+            // ---- FP transfer / convert (spill-aware) -------------------------
+            LInst::FprMove { src, dst, base } => {
+                let s = self.a64_fpr_read(src, 0, base);
+                let d = self.a64_fpr_wtmp(dst, 0, base);
+                if s != d {
+                    monoasm_arm64!(&mut self.jit, fmov d(d), d(s););
+                }
+                self.a64_fpr_commit(dst, 0, base);
+            }
+            LInst::F64ToFpr { f, dst, base } => {
+                let p = self.a64_fpr_wtmp(dst, 0, base);
+                let bits = f.to_bits();
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (bits);
+                    fmov d(p), x9;
+                );
+                self.a64_fpr_commit(dst, 0, base);
+            }
+            LInst::FixnumToFpr { src, dst, base } => {
+                let p = self.a64_fpr_wtmp(dst, 0, base);
+                let r = src.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    asr x9, x(r), #(1);   // untag: value >> 1
+                    scvtf d(p), x9;
+                );
+                self.a64_fpr_commit(dst, 0, base);
+            }
+            LInst::FprToStack { src, slot, base } => {
+                let lfp = GP::R14.a64().0;
+                let f64_to_val = self.f64_to_val.clone();
+                let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+                self.a64_fpr_load(src, 0, base); // value -> d0 (pool fmov or spill load)
+                monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
+                self.a64_frame_store(0, lfp, off);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2241,22 +2276,6 @@ impl Codegen {
     // `_wtmp`/`_load`/`_save`/`_commit`). All return bool; `base` is the spill
     // base.
 
-    /// dst(f64) <- src.
-    pub(in crate::codegen::jitgen) fn emit_fpr_move(
-        &mut self,
-        src: FPReg,
-        dst: FPReg,
-        base: usize,
-    ) -> bool {
-        let s = self.a64_fpr_read(src, 0, base);
-        let d = self.a64_fpr_wtmp(dst, 0, base);
-        if s != d {
-            monoasm_arm64!(&mut self.jit, fmov d(d), d(s););
-        }
-        self.a64_fpr_commit(dst, 0, base);
-        true
-    }
-
     /// swap two FP registers (via scratch D0/D1, spill-aware).
     pub(in crate::codegen::jitgen) fn emit_fpr_swap(&mut self, l: FPReg, r: FPReg, base: usize) -> bool {
         // Force both values into scratch, then store back crossed. (When both
@@ -2265,30 +2284,6 @@ impl Codegen {
         self.a64_fpr_load(r, 1, base);
         self.a64_fpr_save(l, 1, base);
         self.a64_fpr_save(r, 0, base);
-        true
-    }
-
-    /// dst(f64) <- f64 constant `f`.
-    pub(in crate::codegen::jitgen) fn emit_f64_to_fpr(&mut self, f: f64, x: FPReg, base: usize) -> bool {
-        let p = self.a64_fpr_wtmp(x, 0, base);
-        let bits = f.to_bits();
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (bits);
-            fmov d(p), x9;
-        );
-        self.a64_fpr_commit(x, 0, base);
-        true
-    }
-
-    /// dst(f64) <- fixnum in GP `reg` (untag, signed int -> double).
-    pub(in crate::codegen::jitgen) fn emit_fixnum_to_fpr(&mut self, reg: GP, x: FPReg, base: usize) -> bool {
-        let p = self.a64_fpr_wtmp(x, 0, base);
-        let r = reg.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            asr x9, x(r), #(1);   // untag: value >> 1
-            scvtf d(p), x9;
-        );
-        self.a64_fpr_commit(x, 0, base);
         true
     }
 
@@ -2334,17 +2329,6 @@ impl Codegen {
             exit:
         );
         self.a64_fpr_commit(x, 0, base);
-        true
-    }
-
-    /// [slot] <- box(f64 in x): flonum-encode or heap-allocate.
-    pub(in crate::codegen::jitgen) fn emit_fpr_to_stack(&mut self, x: FPReg, slot: SlotId, base: usize) -> bool {
-        let lfp = GP::R14.a64().0;
-        let f64_to_val = self.f64_to_val.clone();
-        let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-        self.a64_fpr_load(x, 0, base); // value -> d0 (pool fmov or spill load)
-        monoasm_arm64!(&mut self.jit, bl f64_to_val;); // x0 = Value(f64)
-        self.a64_frame_store(0, lfp, off);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1766,6 +1766,40 @@ impl Codegen {
                 let cond = a64_float_cond_for_cmp(kind, brkind);
                 self.jit.bcond_label(cond, &dest);
             }
+            // ---- FP pool save/restore + FP C-calls ---------------------------
+            LInst::XmmSave { using_xmm, cont } => {
+                self.emit_xmm_save(using_xmm, cont);
+            }
+            LInst::XmmRestore { using_xmm, cont } => {
+                self.emit_xmm_restore(using_xmm, cont);
+            }
+            LInst::CFunc_F_F { f, src, dst, using_xmm, base } => {
+                let fp = f as u64;
+                monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+                self.emit_xmm_save(using_xmm, false);
+                self.a64_fpr_load(src, 0, base); // arg -> d0
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (fp);
+                    blr x9;            // result in d0
+                );
+                self.emit_xmm_restore(using_xmm, false);
+                monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
+                self.a64_fpr_save(dst, 0, base); // result d0 -> dst
+            }
+            LInst::CFunc_FF_F { f, lhs, rhs, dst, using_xmm, base } => {
+                let fp = f as u64;
+                monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
+                self.emit_xmm_save(using_xmm, false);
+                self.a64_fpr_load(lhs, 0, base); // arg0 -> d0
+                self.a64_fpr_load(rhs, 1, base); // arg1 -> d1
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (fp);
+                    blr x9;            // result in d0
+                );
+                self.emit_xmm_restore(using_xmm, false);
+                monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
+                self.a64_fpr_save(dst, 0, base); // result d0 -> dst
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -3570,62 +3604,6 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
         done:
         );
-        true
-    }
-
-    /// Unary float C helper `f(f64) -> f64` (sin, sqrt, …): load the operand
-    /// into d0 (the first/only AAPCS f64 arg = return reg), call, store d0 into
-    /// dst. The live FP pool (d2-d7, caller-saved = clobbered by the callee) is
-    /// saved/restored around the call exactly like the x86 twin. A spilled
-    /// source/destination is handled by the spill-aware load/save helpers.
-    pub(in crate::codegen::jitgen) fn emit_cfunc_f_f(
-        &mut self,
-        f: unsafe extern "C" fn(f64) -> f64,
-        src: FPReg,
-        dst: FPReg,
-        using_xmm: UsingXmm,
-        base: usize,
-    ) -> bool {
-        let fp = f as u64;
-        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
-        self.emit_xmm_save(using_xmm, false);
-        self.a64_fpr_load(src, 0, base); // arg -> d0 (spill slots are x29-relative)
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (fp);
-            blr x9;            // result in d0
-        );
-        self.emit_xmm_restore(using_xmm, false);
-        monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
-        self.a64_fpr_save(dst, 0, base); // result d0 -> dst (after the pool restore)
-        true
-    }
-
-    /// Binary float C helper `f(f64, f64) -> f64` (atan2, hypot, …): load lhs
-    /// into d0 and rhs into d1 (the first two AAPCS f64 args), call, store the
-    /// d0 result into dst. Pool sources resolve to d2-d7 so they never alias the
-    /// d0/d1 scratch regs. Saves/restores the live FP pool like the x86 twin.
-    /// Bails if any operand or the destination is a spill slot.
-    pub(in crate::codegen::jitgen) fn emit_cfunc_ff_f(
-        &mut self,
-        f: extern "C" fn(f64, f64) -> f64,
-        lhs: FPReg,
-        rhs: FPReg,
-        dst: FPReg,
-        using_xmm: UsingXmm,
-        base: usize,
-    ) -> bool {
-        let fp = f as u64;
-        monoasm_arm64!(&mut self.jit, str x30, [sp, #-16]!;);
-        self.emit_xmm_save(using_xmm, false);
-        self.a64_fpr_load(lhs, 0, base); // arg0 -> d0
-        self.a64_fpr_load(rhs, 1, base); // arg1 -> d1
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (fp);
-            blr x9;            // result in d0
-        );
-        self.emit_xmm_restore(using_xmm, false);
-        monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
-        self.a64_fpr_save(dst, 0, base); // result d0 -> dst (after the pool restore)
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1534,6 +1534,33 @@ impl Codegen {
                     csel x(r), x(r), x9, ne;
                 );
             }
+            // Class guard: deopt unless `reg`'s runtime class matches.
+            LInst::GuardClass { reg, class, deopt } => {
+                self.a64_guard_class(reg, class, &deopt);
+            }
+            // Type guard: deopt unless `reg` is an Array (immediate check, then
+            // the RValue.ty byte).
+            LInst::GuardArrayTy { reg, deopt } => {
+                let r = reg.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (0b111);
+                    and x9, x(r), x9;
+                    cbnz x9, deopt;                              // immediate -> deopt
+                    ldrb w9, [x(r), #(RVALUE_OFFSET_TY as u32)]; // RValue.ty (u8)
+                    cmp x9, #(ObjTy::ARRAY.get() as u32);
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+            }
+            // Deopt if the receiver (rdi) is frozen.
+            LInst::GuardFrozen { deopt } => {
+                let rdi = GP::Rdi.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    ldrb w9, [x(rdi), #(RVALUE_OFFSET_FLAG as u32)];
+                    mov x10, (0b10);
+                    and x9, x9, x10;       // isolate the frozen bit
+                    cbnz x9, deopt;        // frozen -> deopt
+                );
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1684,17 +1711,6 @@ impl Codegen {
             mem: LMem::Slot(slot),
         });
         true
-    }
-
-    /// Type guard: deopt (jump to `fail`) if `r`'s class is not `class`.
-    /// Returns `false` (bail) for not-yet-supported class kinds.
-    pub(in crate::codegen::jitgen) fn emit_guard_class(
-        &mut self,
-        r: GP,
-        class: ClassId,
-        fail: &DestLabel,
-    ) -> bool {
-        self.a64_guard_class(r, class, fail)
     }
 
     /// Unconditional jump to a side-exit (deopt) label.
@@ -2877,34 +2893,6 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             mov x9, (0u64);
             sub x(r), x9, x(r);    // -t  == tagged(~n)
-        );
-    }
-
-    /// Guard that `reg` is an Array RValue: deopt if it is an immediate (low 3
-    /// bits set) or its `ty` byte is not `ObjTy::ARRAY`.
-    pub(in crate::codegen::jitgen) fn emit_guard_array_ty(&mut self, reg: GP, deopt: &DestLabel) {
-        let r = reg.a64().0;
-        let deopt = deopt.clone();
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (0b111);
-            and x9, x(r), x9;
-            cbnz x9, deopt;                              // immediate -> deopt
-            ldrb w9, [x(r), #(RVALUE_OFFSET_TY as u32)]; // RValue.ty (u8)
-            cmp x9, #(ObjTy::ARRAY.get() as u32);
-        );
-        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
-    }
-
-    /// Guard that the receiver in rdi (x-reg) is not frozen: deopt if the frozen
-    /// flag bit (0b10) is set.
-    pub(in crate::codegen::jitgen) fn emit_guard_frozen(&mut self, deopt: &DestLabel) {
-        let rdi = GP::Rdi.a64().0;
-        let deopt = deopt.clone();
-        monoasm_arm64!(&mut self.jit,
-            ldrb w9, [x(rdi), #(RVALUE_OFFSET_FLAG as u32)];
-            mov x10, (0b10);
-            and x9, x9, x10;       // isolate the frozen bit
-            cbnz x9, deopt;        // frozen -> deopt
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1497,6 +1497,15 @@ impl Codegen {
             LInst::WriteBarrier { parent, value } => {
                 self.emit_write_barrier(parent, value);
             }
+            // reg <- nil if reg == 0 (aarch64: branchless csel).
+            LInst::NilIfZero { reg } => {
+                let r = reg.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (NIL_VALUE);
+                    cmp x(r), #(0u32);
+                    csel x(r), x(r), x9, ne;
+                );
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2950,22 +2959,6 @@ impl Codegen {
     /// `ldr`/`str` use a 12-bit scaled (×8) immediate offset; bail above that.
     fn a64_field_off_ok(off: u32) -> bool {
         off <= 32760 && off % 8 == 0
-    }
-
-    /// Load an inline (object-embedded) instance variable into the accumulator
-    /// (x23), substituting nil for an unset (zero) slot. Bails if the field
-    /// offset is out of the load immediate's range.
-    pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
-        let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let r15 = GP::R15.a64().0;
-        self.a64_field_load(r15, rdi, off);
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (NIL_VALUE);
-            cmp x(r15), #(0u32);
-            csel x(r15), x(r15), x9, ne;   // unset slot (0) -> nil
-        );
-        true
     }
 
     /// Load a heap-spilled Struct member slot: deref the heap pointer (into rdi)

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1386,6 +1386,14 @@ impl Codegen {
                 let off = slot.0 as u32 * 8 + LFP_SELF as u32;
                 self.a64_frame_store(src.a64().0, lfp, off);
             }
+            // [base + disp] <- src (object field; `a64_field_store` legalizes
+            // the positive displacement).
+            LInst::Store {
+                src,
+                mem: LMem::Field { base, disp },
+            } => {
+                self.a64_field_store(src.a64().0, base.a64().0, disp as u32);
+            }
             // [lfp - slot] <- imm. aarch64 has no store-immediate, so the
             // immediate is staged through scratch x9 (no allocated GP clobbered),
             // then stored via the legalizing `a64_frame_store`.
@@ -1484,6 +1492,10 @@ impl Codegen {
             LInst::BranchIfNonzero { target } => {
                 let rax = GP::Rax.a64().0;
                 monoasm_arm64!(&mut self.jit, cbnz x(rax), target;);
+            }
+            // GC write barrier (aarch64 takes the parent register explicitly).
+            LInst::WriteBarrier { parent, value } => {
+                self.emit_write_barrier(parent, value);
             }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
@@ -2953,30 +2965,6 @@ impl Codegen {
             cmp x(r15), #(0u32);
             csel x(r15), x(r15), x9, ne;   // unset slot (0) -> nil
         );
-        true
-    }
-
-    /// Store the accumulator-side `src` into an inline instance-variable slot.
-    pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
-        let off = RVALUE_OFFSET_KIND as u32 + ivarid.get() as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let s = src.a64().0;
-        self.a64_field_store(s, rdi, off);
-        // Write barrier: rdi = the object (parent), src = stored value.
-        self.emit_write_barrier(GP::Rdi, src);
-        true
-    }
-
-    /// Store `src` into an inline Struct member slot (also returned in rax/x0).
-    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
-        let off = RVALUE_OFFSET_INLINE as u32 + slot_index as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let s = src.a64().0;
-        let rax = GP::Rax.a64().0;
-        self.a64_field_store(s, rdi, off);
-        // Write barrier: rdi = the struct (parent), src = stored value.
-        self.emit_write_barrier(GP::Rdi, src);
-        monoasm_arm64!(&mut self.jit, mov x(rax), x(s););
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -2961,37 +2961,6 @@ impl Codegen {
         off <= 32760 && off % 8 == 0
     }
 
-    /// Load a heap-spilled Struct member slot: deref the heap pointer (into rdi)
-    /// then load the slot into the accumulator (x23).
-    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_heap(&mut self, slot_index: u16) -> bool {
-        let off = slot_index as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let r15 = GP::R15.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
-        );
-        self.a64_field_load(r15, rdi, off);
-        true
-    }
-
-    /// Store `src` into a heap-spilled Struct member slot (also returned in
-    /// rax/x0). Derefs the heap pointer first (clobbering rdi, like x86).
-    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_heap(&mut self, src: GP, slot_index: u16) -> bool {
-        let off = slot_index as u32 * 8;
-        let rdi = GP::Rdi.a64().0;
-        let s = src.a64().0;
-        let rax = GP::Rax.a64().0;
-        // Write barrier before `rdi` is repointed at the heap buffer:
-        // rdi = the struct (parent), src = stored value.
-        self.emit_write_barrier(GP::Rdi, src);
-        monoasm_arm64!(&mut self.jit,
-            ldr x(rdi), [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
-        );
-        self.a64_field_store(s, rdi, off);
-        monoasm_arm64!(&mut self.jit, mov x(rax), x(s););
-        true
-    }
-
     /// reg += i (no-op when i == 0). `i` is materialized so any i32 works.
     pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
         self.encode_linst(LInst::Alu {

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1561,6 +1561,55 @@ impl Codegen {
                     cbnz x9, deopt;        // frozen -> deopt
                 );
             }
+            // Constant-load base-class guard.
+            LInst::GuardConstBaseClass { base_class, deopt } => {
+                let rax = GP::Rax.a64().0;
+                let cached = base_class.id() as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x10, (cached);
+                    cmp x(rax), x10;
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+            }
+            // Constant-load version guard.
+            LInst::GuardConstVersion { const_version, deopt } => {
+                let gv_addr = self
+                    .jit
+                    .get_label_address(&self.const_version_label())
+                    .as_ptr() as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (gv_addr);
+                    ldr x9, [x9];
+                    mov x10, (const_version as u64);
+                    cmp x9, x10;
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+            }
+            // Block-passing side-effect guard: deopt if the frame was captured
+            // or invalidated.
+            LInst::GuardCapture { deopt } => {
+                let lfp = GP::R14.a64().0; // x22
+                let off = (LFP_META as i64 - META_KIND as i64) as u32; // == 1 (kind byte)
+                monoasm_arm64!(&mut self.jit,
+                    sub x10, x(lfp), #(off);
+                    ldrb w9, [x10];
+                    mov x11, (0b1000_1000u64);
+                    tst x9, x11;                 // captured or invalidated?
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, &deopt); // set -> deopt to VM
+            }
+            // BOP-redefinition guard.
+            LInst::CheckBOP { deopt } => {
+                let flag_addr = self
+                    .jit
+                    .get_label_address(&self.bop_redefined_flags)
+                    .as_ptr() as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (flag_addr);
+                    ldr w9, [x9];
+                    cbnz x9, deopt;   // any BOP redefined -> deopt
+                );
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1797,45 +1846,6 @@ impl Codegen {
         );
         self.jit.bind_label(skip);
         true
-    }
-
-    /// Constant base-class guard: deopt if the accumulator (rax/x0) is not the
-    /// cached base class. Mirrors x86 `GuardConstBaseClass`.
-    pub(in crate::codegen::jitgen) fn emit_guard_const_base_class(
-        &mut self,
-        base_class: Value,
-        deopt: &DestLabel,
-    ) {
-        let deopt = deopt.clone();
-        let rax = GP::Rax.a64().0;
-        let cached = base_class.id() as u64;
-        monoasm_arm64!(&mut self.jit,
-            mov x10, (cached);
-            cmp x(rax), x10;
-        );
-        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
-    }
-
-    /// Constant version guard: deopt if the global constant version moved since
-    /// compilation (`const_version` is the baked-in cached value). Mirrors x86
-    /// `guard_const_version`.
-    pub(in crate::codegen::jitgen) fn emit_guard_const_version(
-        &mut self,
-        const_version: usize,
-        deopt: &DestLabel,
-    ) {
-        let deopt = deopt.clone();
-        let gv_addr = self
-            .jit
-            .get_label_address(&self.const_version_label())
-            .as_ptr() as u64;
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (gv_addr);
-            ldr x9, [x9];
-            mov x10, (const_version as u64);
-            cmp x9, x10;
-        );
-        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
     }
 
     /// Store the accumulator to a constant via set_constant(vm, globals, id,
@@ -2649,22 +2659,6 @@ impl Codegen {
     ) -> bool {
         let offset = store[callee_fid].get_offset();
         self.a64_set_arguments(callid, callee_fid, offset)
-    }
-
-    /// Basic-operator-redefinition guard: deopt if any BOP has been redefined
-    /// since compilation. The deopt PC is the BOP instruction itself, so the
-    /// interpreter re-runs it through the de-optimized VM handler.
-    pub(in crate::codegen::jitgen) fn emit_check_bop(&mut self, deopt: &DestLabel) {
-        let deopt = deopt.clone();
-        let flag_addr = self
-            .jit
-            .get_label_address(&self.bop_redefined_flags)
-            .as_ptr() as u64;
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (flag_addr);
-            ldr w9, [x9];
-            cbnz x9, deopt;   // any BOP redefined -> deopt
-        );
     }
 
     /// Recompile-or-deopt point. Counter-gates a one-shot recompile, then falls
@@ -4686,26 +4680,6 @@ impl Codegen {
         self.emit_handle_error(error);
         let rax = GP::Rax.a64().0;
         self.a64_frame_store(rax, lfp, off); // ret <- Proc
-        true
-    }
-
-    /// Side-effect guard for a method that passes a block: deopt if the current
-    /// frame has been captured/promoted (so a materialized closure observes
-    /// later local writes). Tests the captured (0b1000_0000) / invalidated
-    /// (0b0000_1000) bits of the Meta `kind` byte at `[lfp - 1]`. Mirrors x86
-    /// `branch_if_captured` + `guard_capture`; aarch64 lays the deopt inline (no
-    /// cold page) so this is just a conditional branch to the deopt label.
-    pub(in crate::codegen::jitgen) fn emit_guard_capture(&mut self, deopt: &DestLabel) -> bool {
-        let lfp = GP::R14.a64().0; // x22
-        let off = (LFP_META as i64 - META_KIND as i64) as u32; // == 1 (kind byte)
-        let deopt = deopt.clone();
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x(lfp), #(off);
-            ldrb w9, [x10];
-            mov x11, (0b1000_1000u64);
-            tst x9, x11;                 // captured or invalidated?
-        );
-        self.jit.bcond_label(monoasm::Cond::Ne, &deopt); // set -> deopt to VM
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1394,6 +1394,16 @@ impl Codegen {
             } => {
                 self.a64_field_store(src.a64().0, base.a64().0, disp as u32);
             }
+            // [rsp + (disp - RSP_LOCAL_FRAME)] <- src (callee-frame arg slot).
+            // `a64_rsp_slot_addr` forms the address in scratch x10.
+            LInst::Store {
+                src,
+                mem: LMem::RspRel { disp },
+            } => {
+                self.a64_rsp_slot_addr(disp, 10);
+                let s = src.a64().0;
+                monoasm_arm64!(&mut self.jit, str x(s), [x10];);
+            }
             // [lfp - slot] <- imm. aarch64 has no store-immediate, so the
             // immediate is staged through scratch x9 (no allocated GP clobbered),
             // then stored via the legalizing `a64_frame_store`.
@@ -1405,6 +1415,15 @@ impl Codegen {
                 let off = slot.0 as u32 * 8 + LFP_SELF as u32;
                 monoasm_arm64!(&mut self.jit, mov x9, (imm););
                 self.a64_frame_store(9, lfp, off);
+            }
+            // [rsp + (disp - RSP_LOCAL_FRAME)] <- imm (callee-frame arg slot):
+            // address in x10, immediate staged through x9.
+            LInst::StoreImm {
+                imm,
+                mem: LMem::RspRel { disp },
+            } => {
+                self.a64_rsp_slot_addr(disp, 10);
+                monoasm_arm64!(&mut self.jit, mov x9, (imm); str x9, [x10];);
             }
             // dst <op>= imm (in-place register/immediate ALU; the only Alu
             // shape produced so far, from RegAdd/RegSub). The immediate is
@@ -4621,34 +4640,6 @@ impl Codegen {
 
     // ---- callee-frame argument stores ([sp + (ofs - RSP_LOCAL_FRAME)]) ------
     // Used by the inline argument-setup fast path (fetch_for_callee).
-
-    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- reg`
-    pub(in crate::codegen::jitgen) fn emit_reg_to_rsp_offset(&mut self, r: GP, ofs: i32) -> bool {
-        self.a64_rsp_slot_addr(ofs, 10);
-        let r = r.a64().0;
-        monoasm_arm64!(&mut self.jit, str x(r), [x10];);
-        true
-    }
-
-    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- 0`
-    pub(in crate::codegen::jitgen) fn emit_zero_to_rsp_offset(&mut self, ofs: i32) -> bool {
-        self.a64_rsp_slot_addr(ofs, 10);
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (0u64);
-            str x9, [x10];
-        );
-        true
-    }
-
-    /// `[sp + (ofs - RSP_LOCAL_FRAME)] <- imm`
-    pub(in crate::codegen::jitgen) fn emit_u64_to_rsp_offset(&mut self, i: u64, ofs: i32) -> bool {
-        self.a64_rsp_slot_addr(ofs, 10);
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (i);
-            str x9, [x10];
-        );
-        true
-    }
 
     /// `&block` proxy: materialize the current method's block handler into
     /// `ret`. Walk `outer` outer-frame links to reach the method LFP (x0), load

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::{LAluOp, LInst, LMem, LOperand};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand};
 use monoasm_macro::monoasm_arm64;
 
 ///
@@ -1421,6 +1421,36 @@ impl Codegen {
                     }
                 }
             }
+            // Set flags from `lhs - rhs`. An `Imm` (the operand's raw tagged-
+            // fixnum bits) is staged through scratch x9, matching
+            // `a64_cmp_integer`.
+            LInst::Cmp { lhs, rhs } => {
+                let l = lhs.a64().0;
+                match rhs {
+                    LOperand::Reg(r) => {
+                        let r = r.a64().0;
+                        monoasm_arm64!(&mut self.jit, cmp x(l), x(r););
+                    }
+                    LOperand::Imm(i) => {
+                        let imm = i as u64;
+                        monoasm_arm64!(&mut self.jit, mov x9, (imm); cmp x(l), x9;);
+                    }
+                }
+            }
+            // Conditional branch on the preceding `Cmp` (mirrors
+            // `bcond_label(a64_cond_for_cmp(..), dest)`; the BrKind inversion is
+            // folded into `cond` by the builder).
+            LInst::CondBr { cond, target } => {
+                let c = match cond {
+                    LCond::Eq => monoasm::Cond::Eq,
+                    LCond::Ne => monoasm::Cond::Ne,
+                    LCond::Lt => monoasm::Cond::Lt,
+                    LCond::Le => monoasm::Cond::Le,
+                    LCond::Gt => monoasm::Cond::Gt,
+                    LCond::Ge => monoasm::Cond::Ge,
+                };
+                self.jit.bcond_label(c, &target);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2315,22 +2345,6 @@ impl Codegen {
     ) -> bool {
         self.a64_cmp_integer(&mode, lhs, rhs);
         self.a64_flag_to_bool(kind);
-        true
-    }
-
-    /// Fused integer compare + conditional branch to `branch_dest`.
-    pub(in crate::codegen::jitgen) fn emit_integer_cmp_br(
-        &mut self,
-        kind: CmpKind,
-        mode: OpMode,
-        lhs: GP,
-        rhs: GP,
-        brkind: BrKind,
-        branch_dest: DestLabel,
-    ) -> bool {
-        self.a64_cmp_integer(&mode, lhs, rhs);
-        let cond = a64_cond_for_cmp(kind, brkind);
-        self.jit.bcond_label(cond, &branch_dest);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg, LSideExitKind};
 
 /// Resolve a LIR register operand to its aarch64 register number. The scratch
 /// pointer is `x9`.
@@ -132,7 +132,14 @@ impl Codegen {
                 // `__immediate_evict` logging is `cfg(deopt/profile)`-only).
                 SideExit::Evict(Some((pc, wb))) => {
                     let label = self.jit.label();
-                    self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset);
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::Evict,
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes: bump,
+                        base: frame.base_stack_offset,
+                    });
                     label
                 }
                 SideExit::Deoptimize(pc, wb) => {
@@ -141,7 +148,14 @@ impl Codegen {
                         label.clone()
                     } else {
                         let label = self.jit.label();
-                        self.a64_gen_deopt(key.0, &key.1, label.clone(), bump, frame.base_stack_offset);
+                        self.encode_linst(LInst::SideExit {
+                            kind: LSideExitKind::Deopt,
+                            pc: key.0,
+                            wb: key.1.clone(),
+                            entry: label.clone(),
+                            loop_jit_spill_bytes: bump,
+                            base: frame.base_stack_offset,
+                        });
                         deopt_table.insert(key, label.clone());
                         label
                     }
@@ -149,14 +163,28 @@ impl Codegen {
                 // Treat recompile-deopt as a plain deopt for now: fall back to
                 // the interpreter without the counter-gated recompile (still
                 // correct, just not yet self-optimizing).
-                SideExit::RecompileDeoptimize(pc, wb, _reason, _position) => {
+                SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
                     let label = self.jit.label();
-                    self.a64_gen_deopt(pc, &wb, label.clone(), bump, frame.base_stack_offset);
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::RecompileDeopt { reason, position },
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes: bump,
+                        base: frame.base_stack_offset,
+                    });
                     label
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();
-                    self.a64_gen_handle_error(pc, &wb, label.clone(), bump, frame.base_stack_offset);
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::Error,
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes: bump,
+                        base: frame.base_stack_offset,
+                    });
                     label
                 }
                 // Evict(None) is a placeholder always overwritten with
@@ -1820,6 +1848,25 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
                 self.a64_fpr_save(dst, 0, base); // result d0 -> dst
             }
+            // Cold side-exit (deopt) handler blocks. aarch64 has no recompiler,
+            // so Evict / RecompileDeopt collapse to a plain deopt.
+            LInst::SideExit {
+                kind,
+                pc,
+                wb,
+                entry,
+                loop_jit_spill_bytes,
+                base,
+            } => match kind {
+                LSideExitKind::Deopt
+                | LSideExitKind::Evict
+                | LSideExitKind::RecompileDeopt { .. } => {
+                    self.a64_gen_deopt(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+                LSideExitKind::Error => {
+                    self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+            },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the
             // arch-neutral fallback, which dispatches to the per-arch `emit_*`.
             other => self.encode_linst_macro(other),

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1610,6 +1610,16 @@ impl Codegen {
                     cbnz x9, deopt;   // any BOP redefined -> deopt
                 );
             }
+            // Fixnum fast-path arithmetic with an overflow deopt.
+            LInst::IntegerBinOp {
+                kind,
+                mode,
+                lhs,
+                rhs,
+                deopt,
+            } => {
+                self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -2394,20 +2404,6 @@ impl Codegen {
                 i += 1;
             }
         }
-    }
-
-    /// Integer binary op fast path (guarded; deopts to `deopt`). Independent of
-    /// `inline_gen`; emitted when the inline cache says both operands are
-    /// Integer. Bails (`false`) on an unsupported `BinOpK`.
-    pub(in crate::codegen::jitgen) fn emit_integer_binop(
-        &mut self,
-        lhs: GP,
-        rhs: GP,
-        mode: OpMode,
-        kind: BinOpK,
-        deopt: DestLabel,
-    ) -> bool {
-        self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt)
     }
 
     /// Integer comparison; result Value lands in the accumulator.

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,6 +12,7 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
+use crate::codegen::jitgen::lir::LInst;
 use monoasm_macro::monoasm_arm64;
 
 ///
@@ -1328,9 +1329,31 @@ impl Codegen {
 
     /// dst <- src (general-purpose register move; self-move is a no-op).
     pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
-        let (s, d) = (src.a64().0, dst.a64().0);
-        if s != d {
-            monoasm_arm64!(&mut self.jit, mov x(d), x(s););
+        self.encode_linst(LInst::Mov { dst, src });
+    }
+
+    ///
+    /// Per-arch (aarch64) LIR encoder seam (Phase-1 Stage 2).
+    ///
+    /// Lower one already-register-allocated `LInst` to machine code via
+    /// `monoasm_arm64!`, emitting byte-identical output to the hand-written
+    /// `emit_*` primitive it replaces (and legalizing immediates/displacements
+    /// through scratch x9/x10 as the migrated families grow). Only the migrated
+    /// families are implemented; the rest `todo!()` until ported. See
+    /// `doc/lir.md`.
+    ///
+    pub(in crate::codegen::jitgen) fn encode_linst(&mut self, inst: LInst) {
+        match inst {
+            // dst <- src (elided when the physical registers coincide)
+            LInst::Mov { dst, src } => {
+                let (s, d) = (src.a64().0, dst.a64().0);
+                if s != d {
+                    monoasm_arm64!(&mut self.jit, mov x(d), x(s););
+                }
+            }
+            other => {
+                todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
+            }
         }
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1451,6 +1451,31 @@ impl Codegen {
                 };
                 self.jit.bcond_label(c, &target);
             }
+            // Ruby-truthiness branch: `orr 0x10` folds nil(0x04)/false(0x14) to
+            // FALSE_VALUE; truthy (!= FALSE) takes Ne, falsy takes Eq.
+            LInst::BranchTruthy { negate, target } => {
+                let rax = GP::Rax.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    mov x10, (0x10);
+                    orr x(rax), x(rax), x10;
+                    cmp x(rax), #(FALSE_VALUE as u32);
+                );
+                let cond = if negate {
+                    monoasm::Cond::Eq
+                } else {
+                    monoasm::Cond::Ne
+                };
+                self.jit.bcond_label(cond, &target);
+            }
+            LInst::BranchIfNil { target } => {
+                let rax = GP::Rax.a64().0;
+                monoasm_arm64!(&mut self.jit, cmp x(rax), #(NIL_VALUE as u32););
+                self.jit.bcond_label(monoasm::Cond::Eq, &target);
+            }
+            LInst::BranchIfNonzero { target } => {
+                let rax = GP::Rax.a64().0;
+                monoasm_arm64!(&mut self.jit, cbnz x(rax), target;);
+            }
             other => {
                 todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1601,40 +1626,6 @@ impl Codegen {
             mem: LMem::Slot(slot),
         });
         true
-    }
-
-    /// Conditional branch on the truthiness of rax (x0). `orr 0x10` folds
-    /// nil(0x04) and false(0x14) to FALSE_VALUE(0x14); everything else stays
-    /// != FALSE_VALUE. BrIf jumps when truthy (Ne), BrIfNot when falsy (Eq).
-    /// Mirrors x86 `cond_br` and the VM's CondBr.
-    pub(in crate::codegen::jitgen) fn emit_cond_br(&mut self, dest: DestLabel, brkind: BrKind) {
-        let rax = GP::Rax.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            mov x10, (0x10);
-            orr x(rax), x(rax), x10;
-            cmp x(rax), #(FALSE_VALUE as u32);
-        );
-        let cond = match brkind {
-            BrKind::BrIf => monoasm::Cond::Ne,
-            BrKind::BrIfNot => monoasm::Cond::Eq,
-        };
-        self.jit.bcond_label(cond, &dest);
-    }
-
-    /// Branch to dest if rax (x0) is nil. Mirrors x86 `cmpq rax, NIL_VALUE; jeq`.
-    pub(in crate::codegen::jitgen) fn emit_nil_br(&mut self, dest: DestLabel) {
-        let rax = GP::Rax.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            cmp x(rax), #(NIL_VALUE as u32);
-        );
-        self.jit.bcond_label(monoasm::Cond::Eq, &dest);
-    }
-
-    /// Branch to dest if the local (rax/x0) is already set (non-zero).
-    /// Mirrors x86 `testq rax, rax; jnz dest`.
-    pub(in crate::codegen::jitgen) fn emit_check_local(&mut self, dest: DestLabel) {
-        let rax = GP::Rax.a64().0;
-        monoasm_arm64!(&mut self.jit, cbnz x(rax), dest;);
     }
 
     /// Type guard: deopt (jump to `fail`) if `r`'s class is not `class`.

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1348,11 +1348,6 @@ impl Codegen {
         );
     }
 
-    /// dst <- src (general-purpose register move; self-move is a no-op).
-    pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
-        self.encode_linst(LInst::Mov { dst, src });
-    }
-
     ///
     /// Per-arch (aarch64) LIR encoder seam (Phase-1 Stage 2).
     ///
@@ -1939,41 +1934,6 @@ impl Codegen {
                 mov sp, x10;
             );
         }
-    }
-
-    /// [lfp - slot*8 - LFP_SELF] <- reg
-    pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
-        self.encode_linst(LInst::Store {
-            src: r,
-            mem: LMem::Slot(slot),
-        });
-    }
-
-    /// reg <- [lfp - slot*8 - LFP_SELF]
-    pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
-        self.encode_linst(LInst::Load {
-            dst: r.into(),
-            mem: LMem::Slot(slot),
-        });
-    }
-
-    /// reg <- literal Value (immediate)
-    pub(in crate::codegen::jitgen) fn emit_lit_to_reg(&mut self, v: Value, r: GP) {
-        self.encode_linst(LInst::LoadImm {
-            dst: r,
-            imm: v.id(),
-        });
-    }
-
-    /// [lfp - slot*8 - LFP_SELF] <- literal Value. The immediate is
-    /// materialized in a scratch reg (aarch64 has no store-immediate), so no GP
-    /// register is clobbered. Mirrors x86 `literal_to_stack`.
-    pub(in crate::codegen::jitgen) fn emit_lit_to_stack(&mut self, v: Value, slot: SlotId) -> bool {
-        self.encode_linst(LInst::StoreImm {
-            imm: v.id(),
-            mem: LMem::Slot(slot),
-        });
-        true
     }
 
     /// Unconditional jump to a side-exit (deopt) label.
@@ -2932,26 +2892,6 @@ impl Codegen {
     /// `ldr`/`str` use a 12-bit scaled (×8) immediate offset; bail above that.
     fn a64_field_off_ok(off: u32) -> bool {
         off <= 32760 && off % 8 == 0
-    }
-
-    /// reg += i (no-op when i == 0). `i` is materialized so any i32 works.
-    pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
-        self.encode_linst(LInst::Alu {
-            op: LAluOp::Add,
-            dst: reg,
-            lhs: reg,
-            rhs: LOperand::Imm(i as i64),
-        });
-    }
-
-    /// reg -= i (no-op when i == 0).
-    pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
-        self.encode_linst(LInst::Alu {
-            op: LAluOp::Sub,
-            dst: reg,
-            lhs: reg,
-            rhs: LOperand::Imm(i as i64),
-        });
     }
 
     /// Loop-JIT entry stack bump (large bumps go through `a64_sp_sub`).

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3645,20 +3645,6 @@ impl Codegen {
         }
     }
 
-    /// `Range#begin`: load the start Value from the receiver in Rdi (x4) → Rax.
-    pub(crate) fn emit_range_begin(&mut self) {
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [x4, #(crate::rvalue::RANGE_START_OFFSET as u32)];
-        );
-    }
-
-    /// `Range#end`: load the end Value from the receiver in Rdi (x4) → Rax.
-    pub(crate) fn emit_range_end(&mut self) {
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [x4, #(crate::rvalue::RANGE_END_OFFSET as u32)];
-        );
-    }
-
     /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, then add
     /// FALSE_VALUE (whose bit 3 is clear, so `add` == `or`): 0→FALSE_VALUE,
     /// 8→0x1c=TRUE_VALUE. Receiver in Rdi (x4) → Rax (x0).

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -108,7 +108,32 @@ impl Codegen {
         entry: Option<DestLabel>,
         exit: Option<BasicBlockId>,
         class_version: DestLabel,
+        // Is this block reachable by fall-through from the code emitted just
+        // before it? See `gen_machine_code`. When `false`, the body label binds
+        // *after* the handlers and is the only way in, so the `b skip` that
+        // jumps over the handlers is dead and we omit it.
+        fallthrough_in: bool,
     ) {
+        // Pure-deopt block (e.g. a loop's natural exit): its whole body is
+        // `[Label(bb), Deopt(d)]`, i.e. a bare jump to its deopt handler. Emit
+        // the deopt inline *at* the block label instead of laying a cold
+        // handler and branching to it. Combined with the empty-bridge threading
+        // in `gen_machine_code`, the predecessor's branch then lands straight on
+        // the deopt code with no intervening `b`. Only the plain main-block case
+        // (no `entry`/`exit` wrapper) is handled; anything else falls through to
+        // the ordinary path. (The block's `BcIndex` source-position marker is
+        // dropped here — perf/emit-asm cosmetic only, no machine-code effect.)
+        if entry.is_none()
+            && exit.is_none()
+            && let Some((bb, deopt)) = ir.as_pure_deopt()
+            && let Some((pc, wb)) = ir.pure_deopt_target(deopt)
+        {
+            let wb = wb.clone();
+            let bb_label = frame.resolve_label(&mut self.jit, bb);
+            self.a64_gen_deopt(pc, &wb, bb_label, frame.loop_jit_spill_bytes, frame.base_stack_offset);
+            return;
+        }
+
         // Generate the block's side-exit (deopt/evict/error) handlers. They are
         // cold, so we lay them out here but jump over them (`b skip`); guards in
         // the main body branch *back* to them (short-range b.cond). aarch64 has
@@ -119,7 +144,12 @@ impl Codegen {
         } else {
             Some(self.jit.label())
         };
-        if let Some(skip) = &skip {
+        // Only guard against fall-through into the handlers when the block can
+        // actually be entered that way; a block reached solely by branches to
+        // its (post-handler) body label needs no `b skip`.
+        if let Some(skip) = &skip
+            && fallthrough_in
+        {
             monoasm_arm64!(&mut self.jit, b skip;);
         }
         let mut deopt_table: std::collections::HashMap<(BytecodePtr, WriteBack), DestLabel> =

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1620,6 +1620,23 @@ impl Codegen {
             } => {
                 self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt);
             }
+            // Fixnum unary negate (tagged); deopt on i63 overflow.
+            LInst::FixnumNeg { reg, deopt } => {
+                let r = reg.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (2u64);
+                    subs x(r), x9, x(r);   // 2 - t  == tagged(-n)
+                );
+                self.jit.bcond_label(monoasm::Cond::Vs, &deopt);
+            }
+            // Fixnum bitwise-not (tagged); cannot overflow.
+            LInst::FixnumBitNot { reg } => {
+                let r = reg.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (0u64);
+                    sub x(r), x9, x(r);    // -t  == tagged(~n)
+                );
+            }
             // ---- FP transfer / convert (spill-aware) -------------------------
             LInst::FprMove { src, dst, base } => {
                 let s = self.a64_fpr_read(src, 0, base);
@@ -2827,28 +2844,6 @@ impl Codegen {
             exit:
         );
         true
-    }
-
-    /// Fixnum negate. For a tagged value `t = 2n+1`, `tagged(-n) = 2 - t`, which
-    /// overflows i64 exactly when `-n` is out of i63 range (e.g. -i63::MIN), so
-    /// deopt on the V flag.
-    pub(in crate::codegen::jitgen) fn emit_fixnum_neg(&mut self, reg: GP, deopt: &DestLabel) {
-        let r = reg.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (2u64);
-            subs x(r), x9, x(r);   // 2 - t  == tagged(-n)
-        );
-        self.jit.bcond_label(monoasm::Cond::Vs, deopt);
-    }
-
-    /// Fixnum bitwise-not. For a tagged value `t = 2n+1`, `tagged(~n) = -t`
-    /// (since ~n = -n-1), which is always a valid tagged fixnum (no overflow).
-    pub(in crate::codegen::jitgen) fn emit_fixnum_bit_not(&mut self, reg: GP) {
-        let r = reg.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            mov x9, (0u64);
-            sub x(r), x9, x(r);    // -t  == tagged(~n)
-        );
     }
 
     ///

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -12,7 +12,16 @@ use super::*;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg};
+
+/// Resolve a LIR register operand to its aarch64 register number. The scratch
+/// pointer is `x9`.
+fn a64_lreg(r: LReg) -> u32 {
+    match r {
+        LReg::Gp(g) => g.a64().0,
+        LReg::Scratch => 9,
+    }
+}
 use monoasm_macro::monoasm_arm64;
 
 ///
@@ -1366,7 +1375,7 @@ impl Codegen {
             } => {
                 let lfp = GP::R14.a64().0;
                 let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-                self.a64_frame_load(dst.a64().0, lfp, off);
+                self.a64_frame_load(a64_lreg(dst), lfp, off);
             }
             // dst <- [base + disp] (object field). `a64_field_load` legalizes
             // the (positive) displacement: scaled ldr immediate, else scratch
@@ -1375,7 +1384,7 @@ impl Codegen {
                 dst,
                 mem: LMem::Field { base, disp },
             } => {
-                self.a64_field_load(dst.a64().0, base.a64().0, disp as u32);
+                self.a64_field_load(a64_lreg(dst), a64_lreg(base), disp as u32);
             }
             // [lfp - slot] <- src (legalized like `Load`).
             LInst::Store {
@@ -1392,7 +1401,7 @@ impl Codegen {
                 src,
                 mem: LMem::Field { base, disp },
             } => {
-                self.a64_field_store(src.a64().0, base.a64().0, disp as u32);
+                self.a64_field_store(src.a64().0, a64_lreg(base), disp as u32);
             }
             // [rsp + (disp - RSP_LOCAL_FRAME)] <- src (callee-frame arg slot).
             // `a64_rsp_slot_addr` forms the address in scratch x10.
@@ -1653,7 +1662,7 @@ impl Codegen {
     /// reg <- [lfp - slot*8 - LFP_SELF]
     pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
         self.encode_linst(LInst::Load {
-            dst: r,
+            dst: r.into(),
             mem: LMem::Slot(slot),
         });
     }
@@ -3004,34 +3013,6 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(&mut self, offset: LoopRspOffset) -> bool {
         let bytes = offset.unwrap_concrete();
         self.a64_sp_sub(bytes as u32);
-        true
-    }
-
-    /// Store `src` into a heap-spilled instance variable of self: deref the
-    /// var-table and its data pointer (via scratch x9), then store. No bounds
-    /// check (the table is pre-sized). Bails on an out-of-range field offset.
-    pub(in crate::codegen::jitgen) fn emit_store_self_ivar_heap(
-        &mut self,
-        src: GP,
-        ivarid: IvarId,
-        is_object_ty: bool,
-    ) -> bool {
-        let ivar = ivarid.get() as u32;
-        let idx = if is_object_ty {
-            ivar - OBJECT_INLINE_IVAR as u32
-        } else {
-            ivar
-        };
-        let off = idx * 8;
-        let rdi = GP::Rdi.a64().0;
-        let s = src.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            ldr x9, [x(rdi), #(RVALUE_OFFSET_VAR as u32)];
-            ldr x9, [x9, #(MONOVEC_PTR as u32)];
-        );
-        self.a64_field_store(s, 9, off);
-        // Write barrier: rdi = self (parent), src = stored value.
-        self.emit_write_barrier(GP::Rdi, src);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1817,9 +1817,9 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
                 self.a64_fpr_save(dst, 0, base); // result d0 -> dst
             }
-            other => {
-                todo!("LIR encode (aarch64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
-            }
+            // Macro-ops (irreducible runtime-call shapes) are delegated to the
+            // arch-neutral fallback, which dispatches to the per-arch `emit_*`.
+            other => self.encode_linst_macro(other),
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -435,27 +435,6 @@ macro_rules! cmp_main {
     };
 }
 
-macro_rules! jit_cmp_opt_main {
-    (($op:ident, $rev_op:ident, $sop:ident, $rev_sop:ident)) => {
-        paste! {
-            fn [<condbr_int_ $sop>](&mut self, branch_dest: DestLabel, brkind: BrKind) {
-                match brkind {
-                    BrKind::BrIf => monoasm! { &mut self.jit,
-                        [<j $sop>] branch_dest;
-                    },
-                    BrKind::BrIfNot => monoasm! { &mut self.jit,
-                        [<j $rev_sop>] branch_dest;
-                    },
-                }
-            }
-        }
-    };
-    (($op1:ident, $rev_op1:ident, $sop1:ident, $rev_sop1:ident), $(($op2:ident, $rev_op2:ident, $sop2:ident, $rev_sop2:ident)),+) => {
-        jit_cmp_opt_main!(($op1, $rev_op1, $sop1, $rev_sop1));
-        jit_cmp_opt_main!($(($op2, $rev_op2, $sop2, $rev_sop2)),+);
-    };
-}
-
 impl Codegen {
     pub(super) fn cmp_float(&mut self, binary_xmm: (FPReg, FPReg), base_stack_offset: usize) {
         let (l, r) = binary_xmm;
@@ -557,27 +536,6 @@ impl Codegen {
             },
         }
     }
-
-    pub(super) fn condbr_int(&mut self, kind: CmpKind, branch_dest: DestLabel, brkind: BrKind) {
-        match kind {
-            CmpKind::Eq => self.condbr_int_eq(branch_dest, brkind),
-            CmpKind::Ne => self.condbr_int_ne(branch_dest, brkind),
-            CmpKind::Ge => self.condbr_int_ge(branch_dest, brkind),
-            CmpKind::Gt => self.condbr_int_gt(branch_dest, brkind),
-            CmpKind::Le => self.condbr_int_le(branch_dest, brkind),
-            CmpKind::Lt => self.condbr_int_lt(branch_dest, brkind),
-            CmpKind::TEq => self.condbr_int_eq(branch_dest, brkind),
-        }
-    }
-
-    jit_cmp_opt_main!(
-        (eq, ne, eq, ne),
-        (ne, eq, ne, eq),
-        (a, be, gt, le),
-        (b, ae, lt, ge),
-        (ae, b, ge, lt),
-        (be, a, le, gt)
-    );
 
     /// Float conditional branch with proper NaN (unordered) handling.
     ///

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -521,22 +521,6 @@ impl Codegen {
         }
     }
 
-    pub(super) fn cond_br(&mut self, branch_dest: DestLabel, brkind: BrKind) {
-        monoasm!( &mut self.jit,
-            orq  rax, 0x10;
-            cmpq rax, (FALSE_VALUE);
-            // if true, Z=0(not set).
-        );
-        match brkind {
-            BrKind::BrIf => monoasm! { &mut self.jit,
-                jnz branch_dest;
-            },
-            BrKind::BrIfNot => monoasm! { &mut self.jit,
-                jz  branch_dest;
-            },
-        }
-    }
-
     /// Float conditional branch with proper NaN (unordered) handling.
     ///
     /// ucomisd sets ZF=1, PF=1, CF=1 for NaN. We must check PF for Eq/Ne/Lt/Le

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -9,20 +9,6 @@
 use super::*;
 
 impl Codegen {
-    /// `Range#begin`: load the start Value from the receiver in rdi → rax.
-    pub(crate) fn emit_range_begin(&mut self) {
-        monoasm! { &mut self.jit,
-            movq rax, [rdi + (crate::rvalue::RANGE_START_OFFSET as i32)];
-        }
-    }
-
-    /// `Range#end`: load the end Value from the receiver in rdi → rax.
-    pub(crate) fn emit_range_end(&mut self) {
-        monoasm! { &mut self.jit,
-            movq rax, [rdi + (crate::rvalue::RANGE_END_OFFSET as i32)];
-        }
-    }
-
     /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, OR with
     /// FALSE_VALUE so 0→FALSE_VALUE and 1→TRUE_VALUE. Receiver in rdi → rax.
     pub(crate) fn emit_range_exclude_end(&mut self) {

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -159,12 +159,11 @@ impl Codegen {
     ///
     pub(super) fn setup_method_frame(
         &mut self,
-        store: &Store,
         meta: Meta,
-        callid: CallSiteId,
         outer_lfp: Option<Lfp>,
+        block_fid: Option<FuncId>,
+        block_arg: Option<SlotId>,
     ) {
-        let callsite = &store[callid];
         if let Some(outer_lfp) = outer_lfp {
             monoasm! { &mut self.jit,
                 movq rax, (outer_lfp.as_ptr());
@@ -185,7 +184,7 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         }
-        self.set_block(callsite.block_fid, callsite.block_arg);
+        self.set_block(block_fid, block_arg);
         monoasm! { &mut self.jit,
         }
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -227,20 +227,25 @@ impl Codegen {
         };
     }
 
-    pub(super) fn do_call(
+    /// The call itself: enter the callee and record a return-address deopt
+    /// patch point for `evict`. Store/frame-dependent target info is pre-resolved
+    /// by the dispatcher (codeptr / is_iseq / pcs / JIT entry), so this is
+    /// store-free.
+    pub(in crate::codegen::jitgen) fn emit_call(
         &mut self,
-        store: &Store,
-        callee_fid: FuncId,
-        recv_class: ClassId,
+        codeptr: CodePtr,
+        is_iseq: bool,
+        callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
-    ) -> CodePtr {
-        let callee = &store[callee_fid];
-        let (_, codeptr, pc) = callee.get_data();
+        jit_entry: Option<DestLabel>,
+        evict: AsmEvict,
+        evict_label: &DestLabel,
+    ) {
         self.set_lfp();
         self.push_frame();
 
-        if let Some(iseq) = callee.is_iseq() {
-            match store[iseq].get_jit_entry(recv_class) {
+        if is_iseq {
+            match jit_entry {
                 Some(dest) => {
                     monoasm! { &mut self.jit,
                         call dest;  // CALL_SITE
@@ -249,7 +254,7 @@ impl Codegen {
                 None => {
                     // set pc.
                     monoasm! { &mut self.jit,
-                        movq r13, (pc.unwrap().as_ptr());
+                        movq r13, (callee_pc.unwrap().as_ptr());
                     }
                     self.call_codeptr(codeptr);
                 }
@@ -265,7 +270,7 @@ impl Codegen {
         let return_addr = self.jit.get_current_address();
 
         self.pop_frame();
-        return_addr
+        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
     }
 
     pub(in crate::codegen::jitgen) fn do_specialized_call(

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -455,6 +455,53 @@ impl Codegen {
             } => {
                 self.integer_binop(lhs, rhs, &mode, kind, &deopt);
             }
+            // ---- FP transfer / convert (spill-aware) -------------------------
+            LInst::FprMove { src, dst, base } => {
+                if src != dst {
+                    match (src.loc(base), dst.loc(base)) {
+                        (FPRegLoc::Xmm(s), FPRegLoc::Xmm(d)) => monoasm!( &mut self.jit,
+                            movq xmm(d), xmm(s);
+                        ),
+                        (FPRegLoc::Xmm(s), FPRegLoc::Spill(d_off)) => monoasm!( &mut self.jit,
+                            movq [rbp - (d_off)], xmm(s);
+                        ),
+                        (FPRegLoc::Spill(s_off), FPRegLoc::Xmm(d)) => monoasm!( &mut self.jit,
+                            movq xmm(d), [rbp - (s_off)];
+                        ),
+                        (FPRegLoc::Spill(s_off), FPRegLoc::Spill(d_off)) => monoasm!( &mut self.jit,
+                            movq xmm0, [rbp - (s_off)];
+                            movq [rbp - (d_off)], xmm0;
+                        ),
+                    }
+                }
+            }
+            LInst::F64ToFpr { f, dst, base } => {
+                let f_const = self.jit.const_f64(f);
+                match dst.loc(base) {
+                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                        movq xmm(p), [rip + f_const];
+                    ),
+                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                        movq xmm0, [rip + f_const];
+                        movq [rbp - (off)], xmm0;
+                    ),
+                }
+            }
+            LInst::FixnumToFpr { src, dst, base } => {
+                let (work, spill_off) = match dst.loc(base) {
+                    FPRegLoc::Xmm(p) => (p, None),
+                    FPRegLoc::Spill(off) => (0u64, Some(off)),
+                };
+                self.integer_val_to_f64(src, work);
+                if let Some(off) = spill_off {
+                    monoasm!( &mut self.jit,
+                        movq [rbp - (off)], xmm(work);
+                    );
+                }
+            }
+            LInst::FprToStack { src, slot, base } => {
+                self.fpr_to_stack(src, &[slot], base);
+            }
             LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
             // BOP-redefinition guard: outline the deopt path (page 1) so the hot
             // path is a single load + branch.
@@ -1080,35 +1127,6 @@ impl Codegen {
     /// combination and avoid the round-trip through xmm0 that the
     /// generic `expand_spills` wrapping would otherwise produce.
     ///
-    /// dst(f64) <- src. Spill-aware. Always succeeds on x86 (the bool result
-    /// exists for the aarch64 twin, which bails on an unlowerable FP register).
-    pub(in crate::codegen::jitgen) fn emit_fpr_move(
-        &mut self,
-        src: FPReg,
-        dst: FPReg,
-        base: usize,
-    ) -> bool {
-        if src == dst {
-            return true;
-        }
-        match (src.loc(base), dst.loc(base)) {
-            (FPRegLoc::Xmm(s), FPRegLoc::Xmm(d)) => monoasm!( &mut self.jit,
-                movq xmm(d), xmm(s);
-            ),
-            (FPRegLoc::Xmm(s), FPRegLoc::Spill(d_off)) => monoasm!( &mut self.jit,
-                movq [rbp - (d_off)], xmm(s);
-            ),
-            (FPRegLoc::Spill(s_off), FPRegLoc::Xmm(d)) => monoasm!( &mut self.jit,
-                movq xmm(d), [rbp - (s_off)];
-            ),
-            (FPRegLoc::Spill(s_off), FPRegLoc::Spill(d_off)) => monoasm!( &mut self.jit,
-                movq xmm0, [rbp - (s_off)];
-                movq [rbp - (d_off)], xmm0;
-            ),
-        }
-        true
-    }
-
     ///
     /// Spill-aware xmm swap. When both operands are spilled we swap
     /// the two memory slots through xmm0+xmm1 (avoiding rax/rcx so
@@ -1149,36 +1167,6 @@ impl Codegen {
         true
     }
 
-    /// xmm(x) <- f64 constant `f`. Spill-aware.
-    pub(in crate::codegen::jitgen) fn emit_f64_to_fpr(&mut self, f: f64, x: FPReg, base: usize) -> bool {
-        let f_const = self.jit.const_f64(f);
-        match x.loc(base) {
-            FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                movq xmm(p), [rip + f_const];
-            ),
-            FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                movq xmm0, [rip + f_const];
-                movq [rbp - (off)], xmm0;
-            ),
-        }
-        true
-    }
-
-    /// xmm(x) <- the fixnum in GP `r`, converted to f64. Spill-aware.
-    pub(in crate::codegen::jitgen) fn emit_fixnum_to_fpr(&mut self, r: GP, x: FPReg, base: usize) -> bool {
-        let (work, spill_off) = match x.loc(base) {
-            FPRegLoc::Xmm(p) => (p, None),
-            FPRegLoc::Spill(off) => (0u64, Some(off)),
-        };
-        self.integer_val_to_f64(r, work);
-        if let Some(off) = spill_off {
-            monoasm!( &mut self.jit,
-                movq [rbp - (off)], xmm(work);
-            );
-        }
-        true
-    }
-
     /// xmm(x) <- the Float Value in GP `reg`, decoded to f64; deopt if `reg` is
     /// not a Float. Spill-aware.
     pub(in crate::codegen::jitgen) fn emit_float_to_fpr(
@@ -1198,12 +1186,6 @@ impl Codegen {
                 movq [rbp - (off)], xmm(work);
             );
         }
-        true
-    }
-
-    /// [slot] <- box(xmm(x)) (flonum-encode or heap-allocate the f64).
-    pub(in crate::codegen::jitgen) fn emit_fpr_to_stack(&mut self, x: FPReg, slot: SlotId, base: usize) -> bool {
-        self.fpr_to_stack(x, &[slot], base);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -595,6 +595,30 @@ impl Codegen {
                 self.cmp_float((lhs, rhs), base);
                 self.condbr_float(kind, dest, brkind);
             }
+            // ---- FP pool save/restore + FP C-calls ---------------------------
+            LInst::XmmSave { using_xmm, cont } => self.xmm_save_with_cont(using_xmm, cont),
+            LInst::XmmRestore { using_xmm, cont } => self.xmm_restore_with_cont(using_xmm, cont),
+            LInst::CFunc_F_F { f, src, dst, using_xmm, base } => {
+                self.xmm_save(using_xmm);
+                self.load_fpr_into_xmm0(src, base);
+                monoasm!( &mut self.jit,
+                    movq rax, (f);
+                    call rax;
+                );
+                self.xmm_restore(using_xmm);
+                self.store_fpr_into_xmm(dst, base);
+            }
+            LInst::CFunc_FF_F { f, lhs, rhs, dst, using_xmm, base } => {
+                self.xmm_save(using_xmm);
+                self.load_fpr_into_xmm0(lhs, base);
+                self.load_fpr_into_xmm1(rhs, base);
+                monoasm!( &mut self.jit,
+                    movq rax, (f);
+                    call rax;
+                );
+                self.xmm_restore(using_xmm);
+                self.store_fpr_into_xmm(dst, base);
+            }
             LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
             // BOP-redefinition guard: outline the deopt path (page 1) so the hot
             // path is a single load + branch.
@@ -1214,19 +1238,6 @@ impl Codegen {
         true
     }
 
-    /// Save the live FP pool registers before a C-call. Always succeeds on x86
-    /// (the bool result mirrors the aarch64 twin).
-    pub(in crate::codegen::jitgen) fn emit_xmm_save(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
-        self.xmm_save_with_cont(using_xmm, cont);
-        true
-    }
-
-    /// Restore the live FP pool registers after a C-call.
-    pub(in crate::codegen::jitgen) fn emit_xmm_restore(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
-        self.xmm_restore_with_cont(using_xmm, cont);
-        true
-    }
-
     /// Integer comparison; result Value lands in the accumulator.
     pub(in crate::codegen::jitgen) fn emit_integer_cmp(
         &mut self,
@@ -1704,51 +1715,6 @@ impl Codegen {
             call rax;
         );
         self.xmm_restore(using_xmm);
-        true
-    }
-
-    // ---- float C-function calls (the former per-arch arms, verbatim) ----
-
-    pub(in crate::codegen::jitgen) fn emit_cfunc_f_f(
-        &mut self,
-        f: unsafe extern "C" fn(f64) -> f64,
-        src: FPReg,
-        dst: FPReg,
-        using_xmm: UsingXmm,
-        base: usize,
-    ) -> bool {
-        self.xmm_save(using_xmm);
-        self.load_fpr_into_xmm0(src, base);
-        monoasm!( &mut self.jit,
-            movq rax, (f);
-            call rax;
-        );
-        self.xmm_restore(using_xmm);
-        self.store_fpr_into_xmm(dst, base);
-        true
-    }
-
-    pub(in crate::codegen::jitgen) fn emit_cfunc_ff_f(
-        &mut self,
-        f: extern "C" fn(f64, f64) -> f64,
-        lhs: FPReg,
-        rhs: FPReg,
-        dst: FPReg,
-        using_xmm: UsingXmm,
-        base: usize,
-    ) -> bool {
-        self.xmm_save(using_xmm);
-        // Load both args into xmm0/xmm1 (the SysV ABI passes f64 args
-        // in xmm0, xmm1, ...). Pool ids resolve to xmm2..xmm15, so a
-        // Phys source can never alias the scratch register written into.
-        self.load_fpr_into_xmm0(lhs, base);
-        self.load_fpr_into_xmm1(rhs, base);
-        monoasm!( &mut self.jit,
-            movq rax, (f);
-            call rax;
-        );
-        self.xmm_restore(using_xmm);
-        self.store_fpr_into_xmm(dst, base);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -291,6 +291,16 @@ impl Codegen {
                     movq [rbp - (rbp_local(slot))], R(r);
                 );
             }
+            // [base + disp] <- src (object field; no immediate-range limit on x86)
+            LInst::Store {
+                src,
+                mem: LMem::Field { base, disp },
+            } => {
+                let (s, b) = (src as u64, base as u64);
+                monoasm!( &mut self.jit,
+                    movq [R(b) + (disp)], R(s);
+                );
+            }
             // [lfp - slot] <- imm. Legalization: a 64-bit immediate that does
             // not fit x86's imm32 store form is staged through rax (mirrors
             // `literal_to_stack`).
@@ -374,6 +384,11 @@ impl Codegen {
                     testq rax, rax;
                     jnz  target;
                 }
+            }
+            // GC write barrier (parent is fixed in rdi on x86).
+            LInst::WriteBarrier { parent, value } => {
+                debug_assert_eq!(parent, GP::Rdi, "x86 write barrier expects parent in rdi");
+                self.emit_write_barrier_rdi(value);
             }
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
@@ -1496,18 +1511,6 @@ impl Codegen {
     /// substituting nil for an unset slot.
     pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
         self.load_ivar_inline(ivarid);
-        true
-    }
-
-    /// Store the accumulator-side `src` into an inline instance-variable slot.
-    pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
-        self.store_ivar_object_inline(src, ivarid);
-        true
-    }
-
-    /// Store `src` into an inline Struct member slot (also returned in rax).
-    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_inline(&mut self, src: GP, slot_index: u16) -> bool {
-        self.store_struct_slot_inline(src, slot_index);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -455,6 +455,28 @@ impl Codegen {
             } => {
                 self.integer_binop(lhs, rhs, &mode, kind, &deopt);
             }
+            // Fixnum unary negate (tagged); deopt on i63 overflow.
+            LInst::FixnumNeg { reg, deopt } => {
+                let r = reg as u64;
+                monoasm! { &mut self.jit,
+                    sarq  R(r), 1;
+                    negq  R(r);
+                    jo    deopt;
+                    addq  R(r), R(r);
+                    jo    deopt;
+                    orq   R(r), 1;
+                }
+            }
+            // Fixnum bitwise-not (tagged); cannot overflow.
+            LInst::FixnumBitNot { reg } => {
+                let r = reg as u64;
+                monoasm! { &mut self.jit,
+                    sarq  R(r), 1;
+                    notq  R(r);
+                    salq  R(r), 1;
+                    orq   R(r), 1;
+                }
+            }
             // ---- FP transfer / convert (spill-aware) -------------------------
             LInst::FprMove { src, dst, base } => {
                 if src != dst {
@@ -1427,30 +1449,6 @@ impl Codegen {
             self.jit.select_page(0);
         }
         true
-    }
-
-    /// Fixnum negate (tagged): untag, negate, re-tag; deopt on i63 overflow.
-    pub(in crate::codegen::jitgen) fn emit_fixnum_neg(&mut self, reg: GP, deopt: &DestLabel) {
-        let r = reg as u64;
-        monoasm! { &mut self.jit,
-            sarq  R(r), 1;
-            negq  R(r);
-            jo    deopt;
-            addq  R(r), R(r);
-            jo    deopt;
-            orq   R(r), 1;
-        }
-    }
-
-    /// Fixnum bitwise-not (tagged): untag, complement, re-tag. Cannot overflow.
-    pub(in crate::codegen::jitgen) fn emit_fixnum_bit_not(&mut self, reg: GP) {
-        let r = reg as u64;
-        monoasm! { &mut self.jit,
-            sarq  R(r), 1;
-            notq  R(r);
-            salq  R(r), 1;
-            orq   R(r), 1;
-        }
     }
 
     /// reg += i (no-op when i == 0).

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -445,6 +445,16 @@ impl Codegen {
             LInst::GuardConstVersion { const_version, deopt } => {
                 self.guard_const_version(const_version, &deopt);
             }
+            // Fixnum fast-path arithmetic with an overflow deopt.
+            LInst::IntegerBinOp {
+                kind,
+                mode,
+                lhs,
+                rhs,
+                deopt,
+            } => {
+                self.integer_binop(lhs, rhs, &mode, kind, &deopt);
+            }
             LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
             // BOP-redefinition guard: outline the deopt path (page 1) so the hot
             // path is a single load + branch.
@@ -1207,20 +1217,6 @@ impl Codegen {
     /// Restore the live FP pool registers after a C-call.
     pub(in crate::codegen::jitgen) fn emit_xmm_restore(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
         self.xmm_restore_with_cont(using_xmm, cont);
-        true
-    }
-
-    /// Integer binary op fast path (guarded; deopts to `deopt` on overflow /
-    /// type miss). Always succeeds on x86 (the bool mirrors the aarch64 twin).
-    pub(in crate::codegen::jitgen) fn emit_integer_binop(
-        &mut self,
-        lhs: GP,
-        rhs: GP,
-        mode: OpMode,
-        kind: BinOpK,
-        deopt: DestLabel,
-    ) -> bool {
-        self.integer_binop(lhs, rhs, &mode, kind, &deopt);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,7 +11,7 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
-use crate::codegen::jitgen::lir::LInst;
+use crate::codegen::jitgen::lir::{LInst, LMem};
 
 impl Codegen {
     ///
@@ -254,6 +254,51 @@ impl Codegen {
                     );
                 }
             }
+            // dst <- imm (full 64-bit immediate; x86 movq r64, imm64)
+            LInst::LoadImm { dst, imm } => {
+                let r = dst as u64;
+                monoasm!( &mut self.jit,
+                    movq R(r), (imm);
+                );
+            }
+            // dst <- [lfp - slot]
+            LInst::Load {
+                dst,
+                mem: LMem::Slot(slot),
+            } => {
+                let r = dst as u64;
+                monoasm!( &mut self.jit,
+                    movq R(r), [rbp - (rbp_local(slot))];
+                );
+            }
+            // [lfp - slot] <- src
+            LInst::Store {
+                src,
+                mem: LMem::Slot(slot),
+            } => {
+                let r = src as u64;
+                monoasm!( &mut self.jit,
+                    movq [rbp - (rbp_local(slot))], R(r);
+                );
+            }
+            // [lfp - slot] <- imm. Legalization: a 64-bit immediate that does
+            // not fit x86's imm32 store form is staged through rax (mirrors
+            // `literal_to_stack`).
+            LInst::StoreImm {
+                imm,
+                mem: LMem::Slot(slot),
+            } => {
+                if i32::try_from(imm as i64).is_ok() {
+                    monoasm!( &mut self.jit,
+                        movq [rbp - (rbp_local(slot))], (imm);
+                    );
+                } else {
+                    monoasm!( &mut self.jit,
+                        movq rax, (imm);
+                        movq [rbp - (rbp_local(slot))], rax;
+                    );
+                }
+            }
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -262,32 +307,35 @@ impl Codegen {
 
     /// [lfp - slot] <- reg
     pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
-        let r = r as u64;
-        monoasm!( &mut self.jit,
-            movq [rbp - (rbp_local(slot))], R(r);
-        );
+        self.encode_linst(LInst::Store {
+            src: r,
+            mem: LMem::Slot(slot),
+        });
     }
 
     /// reg <- [lfp - slot]
     pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
-        let r = r as u64;
-        monoasm!( &mut self.jit,
-            movq R(r), [rbp - (rbp_local(slot))];
-        );
+        self.encode_linst(LInst::Load {
+            dst: r,
+            mem: LMem::Slot(slot),
+        });
     }
 
     /// reg <- literal Value (immediate)
     pub(in crate::codegen::jitgen) fn emit_lit_to_reg(&mut self, v: Value, r: GP) {
-        let r = r as u64;
-        monoasm!( &mut self.jit,
-            movq R(r), (v.id());
-        );
+        self.encode_linst(LInst::LoadImm {
+            dst: r,
+            imm: v.id(),
+        });
     }
 
     /// [lfp - slot] <- literal Value. Always succeeds on x86 (no immediate-range
     /// limit); the bool result exists for the aarch64 twin.
     pub(in crate::codegen::jitgen) fn emit_lit_to_stack(&mut self, v: Value, slot: SlotId) -> bool {
-        self.literal_to_stack(slot, v);
+        self.encode_linst(LInst::StoreImm {
+            imm: v.id(),
+            mem: LMem::Slot(slot),
+        });
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -502,6 +502,60 @@ impl Codegen {
             LInst::FprToStack { src, slot, base } => {
                 self.fpr_to_stack(src, &[slot], base);
             }
+            LInst::FprSwap { lhs, rhs, base } => {
+                if lhs != rhs {
+                    match (lhs.loc(base), rhs.loc(base)) {
+                        (FPRegLoc::Xmm(lp), FPRegLoc::Xmm(rp)) => monoasm!( &mut self.jit,
+                            movq xmm0, xmm(lp);
+                            movq xmm(lp), xmm(rp);
+                            movq xmm(rp), xmm0;
+                        ),
+                        (FPRegLoc::Xmm(lp), FPRegLoc::Spill(r_off)) => monoasm!( &mut self.jit,
+                            movq xmm0, [rbp - (r_off)];
+                            movq [rbp - (r_off)], xmm(lp);
+                            movq xmm(lp), xmm0;
+                        ),
+                        (FPRegLoc::Spill(l_off), FPRegLoc::Xmm(rp)) => monoasm!( &mut self.jit,
+                            movq xmm0, [rbp - (l_off)];
+                            movq [rbp - (l_off)], xmm(rp);
+                            movq xmm(rp), xmm0;
+                        ),
+                        (FPRegLoc::Spill(l_off), FPRegLoc::Spill(r_off)) => monoasm!( &mut self.jit,
+                            movq xmm0, [rbp - (l_off)];
+                            movq xmm1, [rbp - (r_off)];
+                            movq [rbp - (r_off)], xmm0;
+                            movq [rbp - (l_off)], xmm1;
+                        ),
+                    }
+                }
+            }
+            LInst::FloatToFpr { src, dst, deopt, base } => {
+                let (work, spill_off) = match dst.loc(base) {
+                    FPRegLoc::Xmm(p) => (p, None),
+                    FPRegLoc::Spill(off) => (0u64, Some(off)),
+                };
+                self.float_to_f64(src, work, &deopt);
+                if let Some(off) = spill_off {
+                    monoasm!( &mut self.jit,
+                        movq [rbp - (off)], xmm(work);
+                    );
+                }
+            }
+            LInst::I64ToBoth { i, slot, dst, base } => {
+                let f = self.jit.const_f64(i as f64);
+                monoasm! {&mut self.jit,
+                    movq [rbp - (rbp_local(slot))], (Value::integer(i).id());
+                }
+                match dst.loc(base) {
+                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                        movq xmm(p), [rip + f];
+                    ),
+                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                        movq xmm0, [rip + f];
+                        movq [rbp - (off)], xmm0;
+                    ),
+                }
+            }
             LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
             // BOP-redefinition guard: outline the deopt path (page 1) so the hot
             // path is a single load + branch.
@@ -1121,74 +1175,6 @@ impl Codegen {
         true
     }
 
-    ///
-    /// Spill-aware xmm-to-xmm move. Each operand may live in a phys
-    /// xmm or a spill slot; we emit the cheapest form for each
-    /// combination and avoid the round-trip through xmm0 that the
-    /// generic `expand_spills` wrapping would otherwise produce.
-    ///
-    ///
-    /// Spill-aware xmm swap. When both operands are spilled we swap
-    /// the two memory slots through xmm0+xmm1 (avoiding rax/rcx so
-    /// nothing in the surrounding code's GP state is disturbed).
-    ///
-    pub(in crate::codegen::jitgen) fn emit_fpr_swap(
-        &mut self,
-        l: FPReg,
-        r: FPReg,
-        base: usize,
-    ) -> bool {
-        if l == r {
-            return true;
-        }
-        match (l.loc(base), r.loc(base)) {
-            (FPRegLoc::Xmm(lp), FPRegLoc::Xmm(rp)) => monoasm!( &mut self.jit,
-                movq xmm0, xmm(lp);
-                movq xmm(lp), xmm(rp);
-                movq xmm(rp), xmm0;
-            ),
-            (FPRegLoc::Xmm(lp), FPRegLoc::Spill(r_off)) => monoasm!( &mut self.jit,
-                movq xmm0, [rbp - (r_off)];
-                movq [rbp - (r_off)], xmm(lp);
-                movq xmm(lp), xmm0;
-            ),
-            (FPRegLoc::Spill(l_off), FPRegLoc::Xmm(rp)) => monoasm!( &mut self.jit,
-                movq xmm0, [rbp - (l_off)];
-                movq [rbp - (l_off)], xmm(rp);
-                movq xmm(rp), xmm0;
-            ),
-            (FPRegLoc::Spill(l_off), FPRegLoc::Spill(r_off)) => monoasm!( &mut self.jit,
-                movq xmm0, [rbp - (l_off)];
-                movq xmm1, [rbp - (r_off)];
-                movq [rbp - (r_off)], xmm0;
-                movq [rbp - (l_off)], xmm1;
-            ),
-        }
-        true
-    }
-
-    /// xmm(x) <- the Float Value in GP `reg`, decoded to f64; deopt if `reg` is
-    /// not a Float. Spill-aware.
-    pub(in crate::codegen::jitgen) fn emit_float_to_fpr(
-        &mut self,
-        reg: GP,
-        x: FPReg,
-        deopt: &DestLabel,
-        base: usize,
-    ) -> bool {
-        let (work, spill_off) = match x.loc(base) {
-            FPRegLoc::Xmm(p) => (p, None),
-            FPRegLoc::Spill(off) => (0u64, Some(off)),
-        };
-        self.float_to_f64(reg, work, deopt);
-        if let Some(off) = spill_off {
-            monoasm!( &mut self.jit,
-                movq [rbp - (off)], xmm(work);
-            );
-        }
-        true
-    }
-
     /// Save the live FP pool registers before a C-call. Always succeeds on x86
     /// (the bool result mirrors the aarch64 twin).
     pub(in crate::codegen::jitgen) fn emit_xmm_save(&mut self, using_xmm: UsingXmm, cont: bool) -> bool {
@@ -1245,24 +1231,6 @@ impl Codegen {
             }
             UnOpK::Pos => {}
             _ => unreachable!(),
-        }
-        true
-    }
-
-    /// [slot] <- box(i) (integer Value) and fpr(x) <- i as f64.
-    pub(in crate::codegen::jitgen) fn emit_i64_to_both(&mut self, i: i64, slot: SlotId, x: FPReg, base: usize) -> bool {
-        let f = self.jit.const_f64(i as f64);
-        monoasm! {&mut self.jit,
-            movq [rbp - (rbp_local(slot))], (Value::integer(i).id());
-        }
-        match x.loc(base) {
-            FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                movq xmm(p), [rip + f];
-            ),
-            FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                movq xmm0, [rip + f];
-                movq [rbp - (off)], xmm0;
-            ),
         }
         true
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,6 +11,7 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
+use crate::codegen::jitgen::lir::LInst;
 
 impl Codegen {
     ///
@@ -230,11 +231,32 @@ impl Codegen {
 
     /// dst <- src (general-purpose register move; self-move is a no-op).
     pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
-        if src != dst {
-            let (src, dst) = (src as u64, dst as u64);
-            monoasm!( &mut self.jit,
-                movq R(dst), R(src);
-            );
+        self.encode_linst(LInst::Mov { dst, src });
+    }
+
+    ///
+    /// Per-arch (x86-64) LIR encoder seam (Phase-1 Stage 2).
+    ///
+    /// Lower one already-register-allocated `LInst` to machine code via
+    /// `monoasm!`, emitting byte-identical output to the hand-written `emit_*`
+    /// primitive it replaces. Only the migrated families are implemented; the
+    /// rest `todo!()` until their `AsmInst` family is ported onto LIR. See
+    /// `doc/lir.md`.
+    ///
+    pub(in crate::codegen::jitgen) fn encode_linst(&mut self, inst: LInst) {
+        match inst {
+            // dst <- src (elided when src == dst)
+            LInst::Mov { dst, src } => {
+                if src != dst {
+                    let (src, dst) = (src as u64, dst as u64);
+                    monoasm!( &mut self.jit,
+                        movq R(dst), R(src);
+                    );
+                }
+            }
+            other => {
+                todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
+            }
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -301,6 +301,16 @@ impl Codegen {
                     movq [R(b) + (disp)], R(s);
                 );
             }
+            // [rsp + (disp - RSP_LOCAL_FRAME)] <- src (callee-frame arg slot)
+            LInst::Store {
+                src,
+                mem: LMem::RspRel { disp },
+            } => {
+                let s = src as u64;
+                monoasm!( &mut self.jit,
+                    movq [rsp + (disp - RSP_LOCAL_FRAME)], R(s);
+                );
+            }
             // [lfp - slot] <- imm. Legalization: a 64-bit immediate that does
             // not fit x86's imm32 store form is staged through rax (mirrors
             // `literal_to_stack`).
@@ -318,6 +328,15 @@ impl Codegen {
                         movq [rbp - (rbp_local(slot))], rax;
                     );
                 }
+            }
+            // [rsp + (disp - RSP_LOCAL_FRAME)] <- imm (callee-frame arg slot)
+            LInst::StoreImm {
+                imm,
+                mem: LMem::RspRel { disp },
+            } => {
+                monoasm!( &mut self.jit,
+                    movq [rsp + (disp - RSP_LOCAL_FRAME)], (imm);
+                );
             }
             // dst <op>= imm (in-place register/immediate ALU; the only Alu
             // shape produced so far, from RegAdd/RegSub). No-op when imm == 0.
@@ -1939,30 +1958,6 @@ impl Codegen {
     ) -> bool {
         let return_addr = self.gen_yield(callid, error);
         self.set_deopt_with_return_addr(return_addr, evict, evict_label);
-        true
-    }
-
-    // ---- callee-frame argument stores (former per-arch arms) ----
-
-    pub(in crate::codegen::jitgen) fn emit_reg_to_rsp_offset(&mut self, r: GP, ofs: i32) -> bool {
-        let r = r as u64;
-        monoasm!( &mut self.jit,
-            movq [rsp + (ofs - RSP_LOCAL_FRAME)], R(r);
-        );
-        true
-    }
-
-    pub(in crate::codegen::jitgen) fn emit_zero_to_rsp_offset(&mut self, ofs: i32) -> bool {
-        monoasm!( &mut self.jit,
-            movq [rsp + (ofs - RSP_LOCAL_FRAME)], 0;
-        );
-        true
-    }
-
-    pub(in crate::codegen::jitgen) fn emit_u64_to_rsp_offset(&mut self, i: u64, ofs: i32) -> bool {
-        monoasm!( &mut self.jit,
-            movq [rsp + (ofs - RSP_LOCAL_FRAME)], (i);
-        );
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -390,6 +390,17 @@ impl Codegen {
                 debug_assert_eq!(parent, GP::Rdi, "x86 write barrier expects parent in rdi");
                 self.emit_write_barrier_rdi(value);
             }
+            // reg <- nil if reg == 0 (x86: branch over the nil mov).
+            LInst::NilIfZero { reg } => {
+                let r = reg as u64;
+                let skip = self.jit.label();
+                monoasm! { &mut self.jit,
+                    testq R(r), R(r);
+                    jne  skip;
+                    movq R(r), (NIL_VALUE);
+                skip:
+                }
+            }
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1505,13 +1516,6 @@ impl Codegen {
     /// Guard that the receiver in rdi is not frozen; deopt otherwise.
     pub(in crate::codegen::jitgen) fn emit_guard_frozen(&mut self, deopt: &DestLabel) {
         self.guard_frozen(deopt);
-    }
-
-    /// Load an inline (object-embedded) instance variable into the accumulator,
-    /// substituting nil for an unset slot.
-    pub(in crate::codegen::jitgen) fn emit_load_ivar_inline(&mut self, ivarid: IvarId) -> bool {
-        self.load_ivar_inline(ivarid);
-        true
     }
 
     /// Load a heap-spilled Struct member slot into the accumulator.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,7 +11,7 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
-use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg, LSideExitKind};
 
 /// Resolve a LIR register operand to its x86 register number. The scratch
 /// pointer is `rdx`.
@@ -656,6 +656,34 @@ impl Codegen {
                 );
                 self.jit.select_page(0);
             }
+            // Cold side-exit (deopt) handler blocks. Dispatch on the kind to the
+            // existing x86 handler emitters (defined in `jitgen.rs`).
+            LInst::SideExit {
+                kind,
+                pc,
+                wb,
+                entry,
+                loop_jit_spill_bytes,
+                base,
+            } => match kind {
+                LSideExitKind::Deopt => {
+                    self.gen_deopt_with_label(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+                LSideExitKind::Evict => {
+                    self.gen_evict_with_label(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+                LSideExitKind::RecompileDeopt { reason, position } => self
+                    .gen_recompile_deopt_with_label(
+                        pc,
+                        &wb,
+                        reason,
+                        position,
+                        entry,
+                        loop_jit_spill_bytes,
+                        base,
+                    ),
+                LSideExitKind::Error => self.gen_handle_error(pc, wb, entry, base),
+            },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the
             // arch-neutral fallback, which dispatches to the per-arch `emit_*`.
             other => self.encode_linst_macro(other),

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,7 +11,7 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
-use crate::codegen::jitgen::lir::{LAluOp, LInst, LMem, LOperand};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand};
 
 impl Codegen {
     ///
@@ -319,6 +319,27 @@ impl Codegen {
                     }
                 }
             }
+            // Set flags from `lhs - rhs`. An `Imm` is the operand's raw bit
+            // pattern (a tagged fixnum), passed as u64 so the encoding matches
+            // the hand-written `cmp_integer`.
+            LInst::Cmp { lhs, rhs } => {
+                let l = lhs as u64;
+                match rhs {
+                    LOperand::Reg(r) => monoasm! { &mut self.jit, cmpq R(l), R(r as u64); },
+                    LOperand::Imm(i) => monoasm! { &mut self.jit, cmpq R(l), (i as u64); },
+                }
+            }
+            // Signed conditional branch on the preceding `Cmp` (mirrors
+            // `condbr_int`; the BrKind inversion is folded into `cond` by the
+            // builder).
+            LInst::CondBr { cond, target } => match cond {
+                LCond::Eq => monoasm! { &mut self.jit, jeq target; },
+                LCond::Ne => monoasm! { &mut self.jit, jne target; },
+                LCond::Lt => monoasm! { &mut self.jit, jlt target; },
+                LCond::Le => monoasm! { &mut self.jit, jle target; },
+                LCond::Gt => monoasm! { &mut self.jit, jgt target; },
+                LCond::Ge => monoasm! { &mut self.jit, jge target; },
+            },
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -1147,20 +1168,6 @@ impl Codegen {
         true
     }
 
-    /// Fused integer compare + conditional branch to `branch_dest`.
-    pub(in crate::codegen::jitgen) fn emit_integer_cmp_br(
-        &mut self,
-        kind: CmpKind,
-        mode: OpMode,
-        lhs: GP,
-        rhs: GP,
-        brkind: BrKind,
-        branch_dest: DestLabel,
-    ) -> bool {
-        self.cmp_integer(&mode, lhs, rhs);
-        self.condbr_int(kind, branch_dest, brkind);
-        true
-    }
 
     /// Float (four-arithmetic) binary op: dst <- lhs <op> rhs in FP registers.
     pub(in crate::codegen::jitgen) fn emit_float_binop(

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -160,6 +160,7 @@ impl Codegen {
             | AsmInst::LoadDynVarSpecialized { .. }
             | AsmInst::StoreDynVarSpecialized { .. }
             | AsmInst::Inline(..)
+            | AsmInst::LoadFieldToReg { .. }
             | AsmInst::ClassDef { .. }
             | AsmInst::SingletonClassDef { .. }
             | AsmInst::SetArgumentsForwardedHelper { .. }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -429,6 +429,10 @@ impl Codegen {
                 skip:
                 }
             }
+            // Type / class guards: deopt (jump to the side-exit) on a mismatch.
+            LInst::GuardClass { reg, class, deopt } => self.guard_class(reg, class, &deopt),
+            LInst::GuardArrayTy { reg, deopt } => self.guard_array_ty(reg, &deopt),
+            LInst::GuardFrozen { deopt } => self.guard_frozen(&deopt),
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -466,19 +470,6 @@ impl Codegen {
             imm: v.id(),
             mem: LMem::Slot(slot),
         });
-        true
-    }
-
-    /// Type guard: deopt (jump to `fail`) if `r`'s class is not `class`.
-    /// Always succeeds on x86 (the bool result exists for the aarch64 twin,
-    /// which bails on not-yet-supported class kinds).
-    pub(in crate::codegen::jitgen) fn emit_guard_class(
-        &mut self,
-        r: GP,
-        class: ClassId,
-        fail: &DestLabel,
-    ) -> bool {
-        self.guard_class(r, class, fail);
         true
     }
 
@@ -1534,16 +1525,6 @@ impl Codegen {
             salq  R(r), 1;
             orq   R(r), 1;
         }
-    }
-
-    /// Guard that `reg` is an Array RValue; deopt otherwise.
-    pub(in crate::codegen::jitgen) fn emit_guard_array_ty(&mut self, reg: GP, deopt: &DestLabel) {
-        self.guard_array_ty(reg, deopt);
-    }
-
-    /// Guard that the receiver in rdi is not frozen; deopt otherwise.
-    pub(in crate::codegen::jitgen) fn emit_guard_frozen(&mut self, deopt: &DestLabel) {
-        self.guard_frozen(deopt);
     }
 
     /// reg += i (no-op when i == 0).

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -238,11 +238,6 @@ impl Codegen {
         );
     }
 
-    /// dst <- src (general-purpose register move; self-move is a no-op).
-    pub(in crate::codegen::jitgen) fn emit_reg_move(&mut self, src: GP, dst: GP) {
-        self.encode_linst(LInst::Mov { dst, src });
-    }
-
     ///
     /// Per-arch (x86-64) LIR encoder seam (Phase-1 Stage 2).
     ///
@@ -668,39 +663,6 @@ impl Codegen {
     }
 
     /// [lfp - slot] <- reg
-    pub(in crate::codegen::jitgen) fn emit_reg_to_stack(&mut self, r: GP, slot: SlotId) {
-        self.encode_linst(LInst::Store {
-            src: r,
-            mem: LMem::Slot(slot),
-        });
-    }
-
-    /// reg <- [lfp - slot]
-    pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
-        self.encode_linst(LInst::Load {
-            dst: r.into(),
-            mem: LMem::Slot(slot),
-        });
-    }
-
-    /// reg <- literal Value (immediate)
-    pub(in crate::codegen::jitgen) fn emit_lit_to_reg(&mut self, v: Value, r: GP) {
-        self.encode_linst(LInst::LoadImm {
-            dst: r,
-            imm: v.id(),
-        });
-    }
-
-    /// [lfp - slot] <- literal Value. Always succeeds on x86 (no immediate-range
-    /// limit); the bool result exists for the aarch64 twin.
-    pub(in crate::codegen::jitgen) fn emit_lit_to_stack(&mut self, v: Value, slot: SlotId) -> bool {
-        self.encode_linst(LInst::StoreImm {
-            imm: v.id(),
-            mem: LMem::Slot(slot),
-        });
-        true
-    }
-
     /// Unconditional jump to a side-exit (deopt) label.
     pub(in crate::codegen::jitgen) fn emit_deopt(&mut self, deopt: &DestLabel) {
         monoasm!( &mut self.jit,
@@ -1449,26 +1411,6 @@ impl Codegen {
             self.jit.select_page(0);
         }
         true
-    }
-
-    /// reg += i (no-op when i == 0).
-    pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
-        self.encode_linst(LInst::Alu {
-            op: LAluOp::Add,
-            dst: reg,
-            lhs: reg,
-            rhs: LOperand::Imm(i as i64),
-        });
-    }
-
-    /// reg -= i (no-op when i == 0).
-    pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
-        self.encode_linst(LInst::Alu {
-            op: LAluOp::Sub,
-            dst: reg,
-            lhs: reg,
-            rhs: LOperand::Imm(i as i64),
-        });
     }
 
     /// Loop-JIT entry: reserve the loop body's spill area on the native stack.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1518,18 +1518,6 @@ impl Codegen {
         self.guard_frozen(deopt);
     }
 
-    /// Load a heap-spilled Struct member slot into the accumulator.
-    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_heap(&mut self, slot_index: u16) -> bool {
-        self.load_struct_slot_heap(slot_index);
-        true
-    }
-
-    /// Store `src` into a heap-spilled Struct member slot (also returned in rax).
-    pub(in crate::codegen::jitgen) fn emit_store_struct_slot_heap(&mut self, src: GP, slot_index: u16) -> bool {
-        self.store_struct_slot_heap(src, slot_index);
-        true
-    }
-
     /// reg += i (no-op when i == 0).
     pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
         self.encode_linst(LInst::Alu {

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -433,6 +433,38 @@ impl Codegen {
             LInst::GuardClass { reg, class, deopt } => self.guard_class(reg, class, &deopt),
             LInst::GuardArrayTy { reg, deopt } => self.guard_array_ty(reg, &deopt),
             LInst::GuardFrozen { deopt } => self.guard_frozen(&deopt),
+            // Constant-load base-class guard: deopt unless the accumulator equals
+            // the cached base class.
+            LInst::GuardConstBaseClass { base_class, deopt } => {
+                let cached_base_class = self.jit.const_i64(base_class.id() as _);
+                monoasm! { &mut self.jit,
+                    cmpq rax, [rip + cached_base_class];
+                    jne  deopt;
+                }
+            }
+            LInst::GuardConstVersion { const_version, deopt } => {
+                self.guard_const_version(const_version, &deopt);
+            }
+            LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
+            // BOP-redefinition guard: outline the deopt path (page 1) so the hot
+            // path is a single load + branch.
+            LInst::CheckBOP { deopt } => {
+                let bop_flag = self.bop_redefined_flags.clone();
+                let l1 = self.jit.label();
+                assert_eq!(0, self.jit.get_page());
+                monoasm!(
+                    &mut self.jit,
+                    cmpl [rip + bop_flag], 0;
+                    jnz l1;
+                );
+                self.jit.select_page(1);
+                monoasm!( &mut self.jit,
+                l1:
+                    movq rdi, (Value::symbol_from_str("_bop_guard").id());
+                    jmp  deopt;
+                );
+                self.jit.select_page(0);
+            }
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -507,29 +539,6 @@ impl Codegen {
     ) -> bool {
         self.jit_execute_gc(&write_back, error, base);
         true
-    }
-
-    /// Constant base-class guard: deopt if the accumulator (rax) is not the
-    /// cached base class.
-    pub(in crate::codegen::jitgen) fn emit_guard_const_base_class(
-        &mut self,
-        base_class: Value,
-        deopt: &DestLabel,
-    ) {
-        let cached_base_class = self.jit.const_i64(base_class.id() as _);
-        monoasm! { &mut self.jit,
-            cmpq rax, [rip + cached_base_class];  // rax: base_class
-            jne  deopt;
-        }
-    }
-
-    /// Constant version guard: deopt if the global constant version moved.
-    pub(in crate::codegen::jitgen) fn emit_guard_const_version(
-        &mut self,
-        const_version: usize,
-        deopt: &DestLabel,
-    ) {
-        self.guard_const_version(const_version, deopt);
     }
 
     /// Store the accumulator to a constant and bump the global constant
@@ -1402,26 +1411,6 @@ impl Codegen {
         true
     }
 
-    /// Basic-operator-redefinition guard: deopt (via the `_bop_guard` symbol) if
-    /// any BOP has been redefined since compilation.
-    pub(in crate::codegen::jitgen) fn emit_check_bop(&mut self, deopt: &DestLabel) {
-        let bop_flag = self.bop_redefined_flags.clone();
-        let l1 = self.jit.label();
-        assert_eq!(0, self.jit.get_page());
-        monoasm!(
-            &mut self.jit,
-            cmpl [rip + bop_flag], 0;
-            jnz l1;
-        );
-        self.jit.select_page(1);
-        monoasm!( &mut self.jit,
-        l1:
-            movq rdi, (Value::symbol_from_str("_bop_guard").id());
-            jmp  deopt;
-        );
-        self.jit.select_page(0);
-    }
-
     /// Recompile-or-deopt: deopt now and schedule recompilation once the inline
     /// cache warms.
     pub(in crate::codegen::jitgen) fn emit_recompile_deopt(
@@ -1939,12 +1928,6 @@ impl Codegen {
         true
     }
 
-    // ---- block-passing side-effect guard (former per-arch arm) ----
-
-    pub(in crate::codegen::jitgen) fn emit_guard_capture(&mut self, deopt: &DestLabel) -> bool {
-        self.guard_capture(deopt);
-        true
-    }
 
     // ---- &block forwarding (former per-arch arms) ----
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1341,21 +1341,6 @@ impl Codegen {
         self.recompile_and_deopt(position, deopt, reason);
     }
 
-    /// The call itself: enter the callee and record a return-address deopt
-    /// patch point for `evict`.
-    pub(in crate::codegen::jitgen) fn emit_call(
-        &mut self,
-        store: &Store,
-        callee_fid: FuncId,
-        recv_class: ClassId,
-        evict: AsmEvict,
-        evict_label: &DestLabel,
-        pc: BytecodePtr,
-    ) {
-        let return_addr = self.do_call(store, callee_fid, recv_class, pc);
-        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
-    }
-
     /// Method prologue. Always succeeds on x86 (the bool result mirrors the
     /// aarch64 twin, which bails on an over-large frame).
     pub(in crate::codegen::jitgen) fn emit_init(

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -340,6 +340,31 @@ impl Codegen {
                 LCond::Gt => monoasm! { &mut self.jit, jgt target; },
                 LCond::Ge => monoasm! { &mut self.jit, jge target; },
             },
+            // Ruby-truthiness branch: `orq 0x10` folds nil(0x04)/false(0x14) to
+            // FALSE_VALUE; truthy (non-FALSE) takes jnz, falsy takes jz.
+            LInst::BranchTruthy { negate, target } => {
+                monoasm! { &mut self.jit,
+                    orq  rax, 0x10;
+                    cmpq rax, (FALSE_VALUE);
+                };
+                if negate {
+                    monoasm! { &mut self.jit, jz  target; }
+                } else {
+                    monoasm! { &mut self.jit, jnz target; }
+                }
+            }
+            LInst::BranchIfNil { target } => {
+                monoasm! { &mut self.jit,
+                    cmpq rax, (NIL_VALUE);
+                    jeq  target;
+                }
+            }
+            LInst::BranchIfNonzero { target } => {
+                monoasm! { &mut self.jit,
+                    testq rax, rax;
+                    jnz  target;
+                }
+            }
             other => {
                 todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
             }
@@ -378,27 +403,6 @@ impl Codegen {
             mem: LMem::Slot(slot),
         });
         true
-    }
-
-    /// Conditional branch on the truthiness of the accumulator (rax).
-    pub(in crate::codegen::jitgen) fn emit_cond_br(&mut self, dest: DestLabel, brkind: BrKind) {
-        self.cond_br(dest, brkind);
-    }
-
-    /// Branch to dest if the accumulator (rax) is nil.
-    pub(in crate::codegen::jitgen) fn emit_nil_br(&mut self, dest: DestLabel) {
-        monoasm!( &mut self.jit,
-            cmpq rax, (NIL_VALUE);
-            jeq  dest;
-        );
-    }
-
-    /// Branch to dest if the local (accumulator, rax) is already set (non-zero).
-    pub(in crate::codegen::jitgen) fn emit_check_local(&mut self, dest: DestLabel) {
-        monoasm!( &mut self.jit,
-            testq rax, rax;
-            jnz  dest;
-        );
     }
 
     /// Type guard: deopt (jump to `fail`) if `r`'s class is not `class`.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -661,9 +661,9 @@ impl Codegen {
                 );
                 self.jit.select_page(0);
             }
-            other => {
-                todo!("LIR encode (x86-64): {other:?} not yet migrated (Phase-1 Stage > 2-A)")
-            }
+            // Macro-ops (irreducible runtime-call shapes) are delegated to the
+            // arch-neutral fallback, which dispatches to the per-arch `emit_*`.
+            other => self.encode_linst_macro(other),
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,7 +11,16 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
-use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg};
+
+/// Resolve a LIR register operand to its x86 register number. The scratch
+/// pointer is `rdx`.
+fn x86_lreg(r: LReg) -> u64 {
+    match r {
+        LReg::Gp(g) => g as u64,
+        LReg::Scratch => GP::Rdx as u64,
+    }
+}
 
 impl Codegen {
     ///
@@ -266,7 +275,7 @@ impl Codegen {
                 dst,
                 mem: LMem::Slot(slot),
             } => {
-                let r = dst as u64;
+                let r = x86_lreg(dst);
                 monoasm!( &mut self.jit,
                     movq R(r), [rbp - (rbp_local(slot))];
                 );
@@ -276,7 +285,7 @@ impl Codegen {
                 dst,
                 mem: LMem::Field { base, disp },
             } => {
-                let (d, b) = (dst as u64, base as u64);
+                let (d, b) = (x86_lreg(dst), x86_lreg(base));
                 monoasm!( &mut self.jit,
                     movq R(d), [R(b) + (disp)];
                 );
@@ -296,7 +305,7 @@ impl Codegen {
                 src,
                 mem: LMem::Field { base, disp },
             } => {
-                let (s, b) = (src as u64, base as u64);
+                let (s, b) = (src as u64, x86_lreg(base));
                 monoasm!( &mut self.jit,
                     movq [R(b) + (disp)], R(s);
                 );
@@ -437,7 +446,7 @@ impl Codegen {
     /// reg <- [lfp - slot]
     pub(in crate::codegen::jitgen) fn emit_stack_to_reg(&mut self, slot: SlotId, r: GP) {
         self.encode_linst(LInst::Load {
-            dst: r,
+            dst: r.into(),
             mem: LMem::Slot(slot),
         });
     }
@@ -1563,18 +1572,6 @@ impl Codegen {
         if bytes > 0 {
             monoasm! { &mut self.jit, subq rsp, (bytes as i32); }
         }
-        true
-    }
-
-    /// Store the accumulator-side `src` into a heap-spilled instance variable of
-    /// self (no bounds check; the table is pre-sized).
-    pub(in crate::codegen::jitgen) fn emit_store_self_ivar_heap(
-        &mut self,
-        src: GP,
-        ivarid: IvarId,
-        is_object_ty: bool,
-    ) -> bool {
-        self.store_self_ivar_heap(src, ivarid, is_object_ty);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -271,6 +271,16 @@ impl Codegen {
                     movq R(r), [rbp - (rbp_local(slot))];
                 );
             }
+            // dst <- [base + disp] (object field; no immediate-range limit on x86)
+            LInst::Load {
+                dst,
+                mem: LMem::Field { base, disp },
+            } => {
+                let (d, b) = (dst as u64, base as u64);
+                monoasm!( &mut self.jit,
+                    movq R(d), [R(b) + (disp)];
+                );
+            }
             // [lfp - slot] <- src
             LInst::Store {
                 src,
@@ -1492,12 +1502,6 @@ impl Codegen {
     /// Store the accumulator-side `src` into an inline instance-variable slot.
     pub(in crate::codegen::jitgen) fn emit_store_ivar_inline(&mut self, src: GP, ivarid: IvarId) -> bool {
         self.store_ivar_object_inline(src, ivarid);
-        true
-    }
-
-    /// Load an inline Struct member slot into the accumulator.
-    pub(in crate::codegen::jitgen) fn emit_load_struct_slot_inline(&mut self, slot_index: u16) -> bool {
-        self.load_struct_slot_inline(slot_index);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1261,20 +1261,17 @@ impl Codegen {
     /// it with `cond - min`.
     pub(in crate::codegen::jitgen) fn emit_opt_case(
         &mut self,
-        frame: &mut AsmInfo,
         max: u16,
         min: u16,
-        else_label: JitLabel,
-        branch_labels: Box<[JitLabel]>,
+        else_dest: DestLabel,
+        branch_dests: Box<[DestLabel]>,
     ) {
         // generate a jump table.
         let jump_table = self.jit.const_align8();
-        for label in branch_labels.iter() {
-            let dest_label = frame.resolve_label(&mut self.jit, *label);
-            self.jit.abs_address(dest_label);
+        for dest_label in branch_dests.iter() {
+            self.jit.abs_address(dest_label.clone());
         }
 
-        let else_dest = frame.resolve_label(&mut self.jit, else_label);
         monoasm! {&mut self.jit,
             sarq rdi, 1;
             cmpq rdi, (max);
@@ -1307,29 +1304,27 @@ impl Codegen {
         self.guard_class_version(class_version, position, with_recovery, &deopt);
     }
 
-    /// Write the callee frame's meta/outer/block fields before a call.
+    /// Write the callee frame's meta/outer/block fields before a call. The
+    /// store-dependent block info is pre-resolved by the dispatcher.
     pub(in crate::codegen::jitgen) fn emit_setup_method_frame(
         &mut self,
-        store: &Store,
         meta: Meta,
-        callid: CallSiteId,
         outer_lfp: Option<Lfp>,
+        block_fid: Option<FuncId>,
+        block_arg: Option<SlotId>,
     ) {
-        self.setup_method_frame(store, meta, callid, outer_lfp);
+        self.setup_method_frame(meta, outer_lfp, block_fid, block_arg);
     }
 
-    /// Marshal the call arguments into the callee frame. Always succeeds on x86
-    /// (the bool result mirrors the aarch64 twin, which bails on unsupported
-    /// argument shapes).
+    /// Marshal the call arguments into the callee frame (`offset` is the callee
+    /// scratch-area size, pre-resolved by the dispatcher).
     pub(in crate::codegen::jitgen) fn emit_set_arguments(
         &mut self,
-        store: &Store,
         callid: CallSiteId,
         callee_fid: FuncId,
-    ) -> bool {
-        let offset = store[callee_fid].get_offset();
+        offset: usize,
+    ) {
         self.jit_set_arguments(callid, callee_fid, offset);
-        true
     }
 
     /// Recompile-or-deopt: deopt now and schedule recompilation once the inline
@@ -1373,16 +1368,11 @@ impl Codegen {
     }
 
     /// Per-method ivar-cache preparation: ensure the heap ivar table is large
-    /// enough (extending it via a runtime call if not). No-op for frozen/
-    /// inline-only selves. Always succeeds on x86.
-    pub(in crate::codegen::jitgen) fn emit_preparation(&mut self, store: &Store, frame: &AsmInfo) -> bool {
-        if !frame.self_class.is_always_frozen() && frame.ivar_heap_accessed {
-            let ivar_len = store[frame.self_class].ivar_len();
-            let heap_len = if frame.self_ty == Some(ObjTy::OBJECT) {
-                ivar_len - OBJECT_INLINE_IVAR
-            } else {
-                ivar_len
-            };
+    /// enough (extending it via a runtime call if not). `heap_len` is `None`
+    /// for a frozen / inline-only self (no-op); the value is pre-resolved by the
+    /// dispatcher.
+    pub(in crate::codegen::jitgen) fn emit_preparation(&mut self, heap_len: Option<usize>) {
+        if let Some(heap_len) = heap_len {
             let fail = self.jit.label();
             let exit = self.jit.label();
             monoasm!(&mut self.jit,
@@ -1410,7 +1400,6 @@ impl Codegen {
             );
             self.jit.select_page(0);
         }
-        true
     }
 
     /// Loop-JIT entry: reserve the loop body's spill area on the native stack.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -11,7 +11,7 @@ mod method_call;
 mod variables;
 
 use super::compile_shared::{extend_ivar, unreachable};
-use crate::codegen::jitgen::lir::{LInst, LMem};
+use crate::codegen::jitgen::lir::{LAluOp, LInst, LMem, LOperand};
 
 impl Codegen {
     ///
@@ -297,6 +297,26 @@ impl Codegen {
                         movq rax, (imm);
                         movq [rbp - (rbp_local(slot))], rax;
                     );
+                }
+            }
+            // dst <op>= imm (in-place register/immediate ALU; the only Alu
+            // shape produced so far, from RegAdd/RegSub). No-op when imm == 0.
+            LInst::Alu {
+                op,
+                dst,
+                lhs,
+                rhs: LOperand::Imm(i),
+            } if dst == lhs => {
+                if i != 0 {
+                    let r = dst as u64;
+                    let imm = i as i32;
+                    match op {
+                        LAluOp::Add => monoasm! { &mut self.jit, addq R(r), (imm); },
+                        LAluOp::Sub => monoasm! { &mut self.jit, subq R(r), (imm); },
+                        _ => todo!(
+                            "LIR encode (x86-64): Alu {op:?} imm not yet migrated (Phase-1 Stage > 2-C)"
+                        ),
+                    }
                 }
             }
             other => {
@@ -1490,18 +1510,22 @@ impl Codegen {
 
     /// reg += i (no-op when i == 0).
     pub(in crate::codegen::jitgen) fn emit_reg_add(&mut self, reg: GP, i: i32) {
-        if i != 0 {
-            let r = reg as u64;
-            monoasm! { &mut self.jit, addq R(r), (i); }
-        }
+        self.encode_linst(LInst::Alu {
+            op: LAluOp::Add,
+            dst: reg,
+            lhs: reg,
+            rhs: LOperand::Imm(i as i64),
+        });
     }
 
     /// reg -= i (no-op when i == 0).
     pub(in crate::codegen::jitgen) fn emit_reg_sub(&mut self, reg: GP, i: i32) {
-        if i != 0 {
-            let r = reg as u64;
-            monoasm! { &mut self.jit, subq R(r), (i); }
-        }
+        self.encode_linst(LInst::Alu {
+            op: LAluOp::Sub,
+            dst: reg,
+            lhs: reg,
+            rhs: LOperand::Imm(i as i64),
+        });
     }
 
     /// Loop-JIT entry: reserve the loop body's spill area on the native stack.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -556,6 +556,45 @@ impl Codegen {
                     ),
                 }
             }
+            // ---- FP arithmetic / comparison ----------------------------------
+            LInst::FloatBinOp { kind, lhs, rhs, dst, base } => {
+                self.float_binop(kind, dst, (lhs, rhs), base);
+            }
+            LInst::FloatUnOp { kind, dst, base } => match kind {
+                UnOpK::Neg => {
+                    let imm = self.jit.const_i64(0x8000_0000_0000_0000u64 as i64);
+                    match dst.loc(base) {
+                        FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
+                            xorps xmm(p), [rip + imm];
+                        ),
+                        FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
+                            movq  xmm0, [rbp - (off)];
+                            xorps xmm0, [rip + imm];
+                            movq  [rbp - (off)], xmm0;
+                        ),
+                    }
+                }
+                UnOpK::Pos => {}
+                _ => unreachable!(),
+            },
+            LInst::FloatCmp { kind, lhs, rhs, base } => {
+                monoasm! { &mut self.jit,
+                    xorq rax, rax;
+                };
+                self.cmp_float((lhs, rhs), base);
+                self.setflag_float(kind);
+            }
+            LInst::FloatCmpBr {
+                kind,
+                lhs,
+                rhs,
+                brkind,
+                dest,
+                base,
+            } => {
+                self.cmp_float((lhs, rhs), base);
+                self.condbr_float(kind, dest, brkind);
+            }
             LInst::GuardCapture { deopt } => self.guard_capture(&deopt),
             // BOP-redefinition guard: outline the deopt path (page 1) so the hot
             // path is a single load + branch.
@@ -1200,65 +1239,6 @@ impl Codegen {
         true
     }
 
-
-    /// Float (four-arithmetic) binary op: dst <- lhs <op> rhs in FP registers.
-    pub(in crate::codegen::jitgen) fn emit_float_binop(
-        &mut self,
-        kind: BinOpK,
-        binary_xmm: (FPReg, FPReg),
-        dst: FPReg,
-        base: usize,
-    ) -> bool {
-        self.float_binop(kind, dst, binary_xmm, base);
-        true
-    }
-
-    /// Float unary op: negate (flip the sign bit) or unary-plus (no-op).
-    pub(in crate::codegen::jitgen) fn emit_float_unop(&mut self, kind: UnOpK, dst: FPReg, base: usize) -> bool {
-        match kind {
-            UnOpK::Neg => {
-                let imm = self.jit.const_i64(0x8000_0000_0000_0000u64 as i64);
-                match dst.loc(base) {
-                    FPRegLoc::Xmm(p) => monoasm!( &mut self.jit,
-                        xorps xmm(p), [rip + imm];
-                    ),
-                    FPRegLoc::Spill(off) => monoasm!( &mut self.jit,
-                        movq  xmm0, [rbp - (off)];
-                        xorps xmm0, [rip + imm];
-                        movq  [rbp - (off)], xmm0;
-                    ),
-                }
-            }
-            UnOpK::Pos => {}
-            _ => unreachable!(),
-        }
-        true
-    }
-
-    /// Float comparison; NaN-correct boolean Value lands in the accumulator.
-    pub(in crate::codegen::jitgen) fn emit_float_cmp(&mut self, kind: CmpKind, lhs: FPReg, rhs: FPReg, base: usize) -> bool {
-        monoasm! { &mut self.jit,
-            xorq rax, rax;
-        };
-        self.cmp_float((lhs, rhs), base);
-        self.setflag_float(kind);
-        true
-    }
-
-    /// Fused float compare + conditional branch (NaN compares false except `!=`).
-    pub(in crate::codegen::jitgen) fn emit_float_cmp_br(
-        &mut self,
-        kind: CmpKind,
-        lhs: FPReg,
-        rhs: FPReg,
-        brkind: BrKind,
-        branch_dest: DestLabel,
-        base: usize,
-    ) -> bool {
-        self.cmp_float((lhs, rhs), base);
-        self.condbr_float(kind, branch_dest, brkind);
-        true
-    }
 
     /// Method epilogue: tear down the frame and return.
     pub(in crate::codegen::jitgen) fn emit_ret(&mut self) {

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -101,25 +101,6 @@ impl Codegen {
 
     ///
     /// Load slot `slot_index` of a `Struct` instance whose slot
-    /// vector is **inline** in the RValue's union (i.e. the class has
-    /// `≤ STRUCT_INLINE_SLOTS` members). Single mov, no Box deref.
-    ///
-    /// Receiver class is already guarded by the call-site cache, so
-    /// the JIT picks this variant statically based on the class's
-    /// member count.
-    ///
-    /// #### in
-    /// - rdi: &RValue (a STRUCT instance)
-    /// #### out
-    /// - r15: Value
-    pub(super) fn load_struct_slot_inline(&mut self, slot_index: u16) {
-        monoasm! {&mut self.jit,
-            movq r15, [rdi + ((slot_index as i32) * 8 + RVALUE_OFFSET_INLINE as i32)];
-        }
-    }
-
-    ///
-    /// Load slot `slot_index` of a `Struct` instance whose slot
     /// vector spilled to the **heap** (the class has more than
     /// `STRUCT_INLINE_SLOTS` members). Two movs.
     ///

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -63,46 +63,6 @@ impl Codegen {
     }
 
     ///
-    /// Load slot `slot_index` of a `Struct` instance whose slot
-    /// vector spilled to the **heap** (the class has more than
-    /// `STRUCT_INLINE_SLOTS` members). Two movs.
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    /// #### out
-    /// - r15: Value
-    /// #### destroy
-    /// - rdi
-    pub(super) fn load_struct_slot_heap(&mut self, slot_index: u16) {
-        monoasm! {&mut self.jit,
-            movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
-            movq r15, [rdi + ((slot_index as i32) * 8)];
-        }
-    }
-
-    ///
-    /// Store *src* into heap slot `slot_index` of `rdi`. Two movs.
-    /// Caller must have emitted `GuardFrozen` already.
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    /// - src: Value to store
-    /// #### out
-    /// - rax: src
-    /// #### destroy
-    /// - rdi
-    pub(super) fn store_struct_slot_heap(&mut self, src: GP, slot_index: u16) {
-        // Write barrier before `rdi` is repointed at the heap buffer:
-        // rdi = the struct (parent), src = stored value.
-        self.emit_write_barrier_rdi(src);
-        monoasm! {&mut self.jit,
-            movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
-            movq [rdi + ((slot_index as i32) * 8)], R(src as _);
-            movq rax, R(src as _);
-        }
-    }
-
-    ///
     /// Store *src* in an instance var *ivarid* of the object *rdi*.
     ///
     /// #### in

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -3,30 +3,6 @@ use crate::codegen::jitgen::asmir::compile_shared::set_ivar;
 
 impl Codegen {
     ///
-    /// Load ivar embedded to RValue. (only for object type)
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    ///
-    /// #### out
-    /// - r15: Value
-    ///
-    /// #### destroy
-    /// - rdi
-    ///
-    pub(super) fn load_ivar_inline(&mut self, ivarid: IvarId) {
-        let exit = self.jit.label();
-        monoasm! {&mut self.jit,
-            movq r15, [rdi + (RVALUE_OFFSET_KIND as i32 + (ivarid.get() as i32) * 8)];
-            // We must check whether the ivar slot is None.
-            testq r15, r15;
-            jne  exit;
-            movq r15, (NIL_VALUE);
-        exit:
-        }
-    }
-
-    ///
     /// Load ivar on `var_table`.
     ///
     /// #### in

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -87,19 +87,6 @@ impl Codegen {
     }
 
     ///
-    /// Store *src* in ivar embedded to RValue `rdi`. (only for object type)
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    ///
-    pub(super) fn store_ivar_object_inline(&mut self, src: GP, ivarid: IvarId) {
-        monoasm!( &mut self.jit,
-            movq [rdi + (RVALUE_OFFSET_KIND as i32 + (ivarid.get() as i32) * 8)], R(src as _);
-        );
-        self.emit_write_barrier_rdi(src);
-    }
-
-    ///
     /// Load slot `slot_index` of a `Struct` instance whose slot
     /// vector spilled to the **heap** (the class has more than
     /// `STRUCT_INLINE_SLOTS` members). Two movs.
@@ -114,26 +101,6 @@ impl Codegen {
         monoasm! {&mut self.jit,
             movq rdi, [rdi + (RVALUE_OFFSET_HEAP_PTR as i32)];
             movq r15, [rdi + ((slot_index as i32) * 8)];
-        }
-    }
-
-    ///
-    /// Store *src* into inline slot `slot_index` of `rdi`. Single mov.
-    /// Caller must have emitted `GuardFrozen` already.
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    /// - src: Value to store
-    /// #### out
-    /// - rax: src (return value of the writer)
-    pub(super) fn store_struct_slot_inline(&mut self, src: GP, slot_index: u16) {
-        monoasm! {&mut self.jit,
-            movq [rdi + ((slot_index as i32) * 8 + RVALUE_OFFSET_INLINE as i32)], R(src as _);
-        }
-        // Write barrier: rdi = the struct (parent), src = stored value.
-        self.emit_write_barrier_rdi(src);
-        monoasm! {&mut self.jit,
-            movq rax, R(src as _);
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -87,19 +87,6 @@ impl Codegen {
     /// #### in
     /// - rdi: &RValue
     ///
-    /// #### destroy
-    /// - rdx
-    ///
-    pub(super) fn store_self_ivar_heap(&mut self, src: GP, ivarid: IvarId, is_object_ty: bool) {
-        self.store_ivar_heap_inner(src, ivarid, is_object_ty, None);
-    }
-
-    ///
-    /// Store *src* in an instance var *ivarid* of the object *rdi*.
-    ///
-    /// #### in
-    /// - rdi: &RValue
-    ///
     /// #### destroy (if using.is_some())
     /// - caller-save registers
     ///

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -864,7 +864,13 @@ impl JitModule {
 
 #[cfg(target_arch = "x86_64")]
 impl Codegen {
-    fn gen_handle_error(&mut self, pc: BytecodePtr, wb: WriteBack, entry: DestLabel, base: usize) {
+    pub(in crate::codegen) fn gen_handle_error(
+        &mut self,
+        pc: BytecodePtr,
+        wb: WriteBack,
+        entry: DestLabel,
+        base: usize,
+    ) {
         let raise = self.entry_raise();
         assert_eq!(0, self.jit.get_page());
         self.jit.select_page(1);
@@ -885,7 +891,7 @@ impl Codegen {
     /// ### in
     /// - rdi: deopt-reason:Value
     ///
-    fn gen_deopt_with_label(
+    pub(in crate::codegen) fn gen_deopt_with_label(
         &mut self,
         pc: BytecodePtr,
         wb: &WriteBack,
@@ -905,7 +911,7 @@ impl Codegen {
     /// monomorphic-compiled BinCmp sites so they flip to the
     /// non-deopting polymorphic path (Part B).
     ///
-    fn gen_recompile_deopt_with_label(
+    pub(in crate::codegen) fn gen_recompile_deopt_with_label(
         &mut self,
         pc: BytecodePtr,
         wb: &WriteBack,
@@ -929,7 +935,7 @@ impl Codegen {
     ///
     /// Get *DestLabel* for fallback to interpreter by immediate eviction.
     ///
-    fn gen_evict_with_label(
+    pub(in crate::codegen) fn gen_evict_with_label(
         &mut self,
         pc: BytecodePtr,
         wb: &WriteBack,

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -82,7 +82,7 @@ enum CompileResult {
     Abort,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct JitLabel(usize);
 
 #[derive(Debug, Clone, PartialEq)]
@@ -430,6 +430,13 @@ impl Codegen {
 
         let ir_vec = frame.detach_ir();
 
+        // Jump-threading: drop empty outline-bridge forwarders and alias their
+        // entry labels straight to the destination block. Done *before* the
+        // main emission loop so the source branches (emitted there) resolve
+        // through the alias. The surviving non-empty bridges are emitted after
+        // the main loop as before.
+        let outline_bridges = frame.thread_empty_outline_bridges();
+
         let mut live_bb: HashSet<BasicBlockId> = HashSet::default();
         ir_vec.iter().for_each(|(bb, ir)| {
             if let Some(bb) = bb {
@@ -440,8 +447,21 @@ impl Codegen {
         });
 
         // generate machine code for a main context and inlined bridges.
+        //
+        // `fallthrough_in` tracks whether the next emission is reachable by
+        // fall-through from the code just laid down. The first block is
+        // entered from the prologue (which falls into it) and via
+        // `entry_label`, both of which land *before* the block's inline
+        // side-exit handlers, so it starts `true`. Once a block ends in an
+        // unconditional terminator (or a bridge ends in an unconditional
+        // `b exit`), the following block is reached only by branches to its
+        // body label — which bind *after* the handlers — so its `b skip`
+        // over those handlers is dead and `gen_asm` (aarch64) drops it.
+        let mut fallthrough_in = true;
         for (bbid, ir) in ir_vec.into_iter() {
-            self.gen_asm(ir, store, &mut frame, None, None, class_version.clone());
+            let main_ends = ir.ends_unconditionally();
+            self.gen_asm(ir, store, &mut frame, None, None, class_version.clone(), fallthrough_in);
+            fallthrough_in = !main_ends;
             // generate machine code for the inlined bridge
             if let Some((ir, exit)) = frame.remove_inline_bridge(bbid) {
                 let exit = if let Some(bbid) = bbid {
@@ -455,12 +475,18 @@ impl Codegen {
                 } else {
                     None
                 };
-                self.gen_asm(ir, store, &mut frame, None, exit, class_version.clone());
+                let bridge_ends = exit.is_some() || ir.ends_unconditionally();
+                self.gen_asm(ir, store, &mut frame, None, exit, class_version.clone(), fallthrough_in);
+                fallthrough_in = !bridge_ends;
             }
         }
 
-        // generate machine code for outlined bridges
-        for (ir, entry, exit) in frame.detach_outline_bridges() {
+        // generate machine code for the surviving (non-empty) outlined
+        // bridges. Each is reached only via its `entry` label (it is
+        // *outlined* cold code, never fallen into) and ends in an
+        // unconditional `b exit`, so neither it nor its successor is
+        // fall-through reachable.
+        for (ir, entry, exit) in outline_bridges {
             let entry = frame.resolve_label(&mut self.jit, entry);
             self.gen_asm(
                 ir,
@@ -469,6 +495,7 @@ impl Codegen {
                 Some(entry),
                 Some(exit),
                 class_version.clone(),
+                false,
             );
         }
 

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -16,7 +16,7 @@ use crate::{
 pub(crate) use crate::basic_block::{BasicBlockId, BasicBlockInfoEntry};
 pub(crate) use self::context::JitContext;
 pub(crate) use self::state::{AbstractFrame, AbstractState};
-use state::{LinkMode, ReturnState, TransferIR};
+use state::{DeoptPoint, LinkMode, ReturnState, TransferIR};
 
 use super::*;
 use asmir::*;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -16,7 +16,7 @@ use crate::{
 pub(crate) use crate::basic_block::{BasicBlockId, BasicBlockInfoEntry};
 pub(crate) use self::context::JitContext;
 pub(crate) use self::state::{AbstractFrame, AbstractState};
-use state::{LinkMode, ReturnState};
+use state::{LinkMode, ReturnState, TransferIR};
 
 use super::*;
 use asmir::*;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -220,7 +220,7 @@ impl WriteBack {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub(crate) struct UsingXmm {
     inner: bitvec::prelude::BitArr!(for 14, in u16),
 }

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -38,6 +38,8 @@ mod guard;
 #[cfg(target_arch = "aarch64")]
 #[path = "arch/aarch64/guard.rs"]
 mod guard;
+// Unified low-level IR (Phase-1 Stage 1: data model only, not yet wired in).
+mod lir;
 mod merge;
 mod state;
 pub mod trace_ir;

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -26,7 +26,7 @@ impl std::fmt::Debug for InlineProcedure {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AsmDeopt(usize);
 
 #[derive(Debug, Clone, Copy)]
@@ -90,6 +90,12 @@ pub(crate) struct AsmIr {
     /// generic / native callee). Producer skips `create_array` only
     /// when `deferred_rest && !needs_rest_array`.
     needs_rest_array: bool,
+    /// Item ② step 2 (record collection): the typed-IR transfer stream, grown
+    /// in lock-step with `inst` whenever a transfer/eviction primitive funnels
+    /// through [`Self::transfer`] (codegen mode only). Not yet consumed — this
+    /// is the faithful record stream that record-driven lowering will replay.
+    /// Truncated alongside `inst` by `save`/`restore`.
+    transfers: Vec<TransferIR>,
 }
 
 impl std::ops::Index<AsmEvict> for AsmIr {
@@ -125,7 +131,21 @@ impl AsmIr {
             had_deopt: false,
             deferred_rest: false,
             needs_rest_array: false,
+            transfers: vec![],
         }
+    }
+
+    ///
+    /// Funnel a transfer/eviction primitive's typed-IR record (item ② step 2):
+    /// collect it into the `transfers` stream (codegen mode only, so it stays in
+    /// lock-step with the gated `inst`) and emit it. The emission is identical to
+    /// the prior direct `record.emit(ir, …)`; collection is purely additive.
+    ///
+    pub(super) fn transfer(&mut self, t: TransferIR) {
+        if self.codegen_mode {
+            self.transfers.push(t);
+        }
+        t.emit(self);
     }
 
     pub(super) fn had_deopt(&self) -> bool {
@@ -226,9 +246,10 @@ impl AsmIr {
         }
     }
 
-    pub(super) fn save(&mut self) -> (usize, usize, bool, bool, bool, bool) {
+    pub(super) fn save(&mut self) -> (usize, usize, usize, bool, bool, bool, bool) {
         (
             self.inst.len(),
+            self.transfers.len(),
             self.side_exit.len(),
             self.codegen_mode,
             self.had_deopt,
@@ -239,7 +260,8 @@ impl AsmIr {
 
     pub(super) fn restore(
         &mut self,
-        (inst, side_exit, codegen_mode, had_deopt, deferred_rest, needs_rest_array): (
+        (inst, transfers, side_exit, codegen_mode, had_deopt, deferred_rest, needs_rest_array): (
+            usize,
             usize,
             usize,
             bool,
@@ -249,6 +271,7 @@ impl AsmIr {
         ),
     ) {
         self.inst.truncate(inst);
+        self.transfers.truncate(transfers);
         self.side_exit.truncate(side_exit);
         self.codegen_mode = codegen_mode;
         self.had_deopt = had_deopt;

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1,4 +1,5 @@
 use crate::bytecodegen::BinOpK;
+use crate::codegen::jitgen::lir::{LInst, LSideExitKind};
 
 use super::*;
 
@@ -2012,7 +2013,14 @@ impl Codegen {
             let label = match side_exit {
                 SideExit::Evict(Some((pc, wb))) => {
                     let label = self.jit.label();
-                    self.gen_evict_with_label(pc, &wb, label.clone(), loop_jit_spill_bytes, base);
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::Evict,
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes,
+                        base,
+                    });
                     label
                 }
                 SideExit::Deoptimize(pc, wb) => {
@@ -2021,33 +2029,40 @@ impl Codegen {
                         label.clone()
                     } else {
                         let label = self.jit.label();
-                        self.gen_deopt_with_label(
-                            pc,
-                            &t.1,
-                            label.clone(),
+                        self.encode_linst(LInst::SideExit {
+                            kind: LSideExitKind::Deopt,
+                            pc: t.0,
+                            wb: t.1.clone(),
+                            entry: label.clone(),
                             loop_jit_spill_bytes,
                             base,
-                        );
+                        });
                         deopt_table.insert(t, label.clone());
                         label
                     }
                 }
                 SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
                     let label = self.jit.label();
-                    self.gen_recompile_deopt_with_label(
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::RecompileDeopt { reason, position },
                         pc,
-                        &wb,
-                        reason,
-                        position,
-                        label.clone(),
+                        wb,
+                        entry: label.clone(),
                         loop_jit_spill_bytes,
                         base,
-                    );
+                    });
                     label
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();
-                    self.gen_handle_error(pc, wb, label.clone(), base);
+                    self.encode_linst(LInst::SideExit {
+                        kind: LSideExitKind::Error,
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes,
+                        base,
+                    });
                     label
                 }
                 _ => unreachable!("unexpected {side_exit:?}"),

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -149,6 +149,17 @@ impl AsmIr {
     /// lock-step with the gated `inst`) and emit it. The emission is identical to
     /// the prior direct `record.emit(ir, …)`; collection is purely additive.
     ///
+    /// **Analysis mode** (`codegen_mode == false`, the loop pre-pass) returns
+    /// immediately: the abstract-state mutation already happened in the wrapper's
+    /// `*_state` half, and `emit` only writes to `ir` — which the analysis pass
+    /// discards (`analyse_basic_block` drops its local `AsmIr`). This is doc §9
+    /// step 2's "the analysis pass calls the state halves and **skips
+    /// emission**", and it stops the dead `side_exit` growth a guarded record's
+    /// `deopt_from_point` would otherwise cause (the waste doc §10 flagged). It is
+    /// provably safe: `emit`'s signature (`fn emit(self, ir: &mut AsmIr)`) cannot
+    /// touch frame/abstract state, as the shadow check below independently relies
+    /// on.
+    ///
     /// In debug builds a **shadow check** replays the record alone into a scratch
     /// buffer and asserts it reproduces exactly the `AsmInst`s *and* `SideExit`s
     /// this call appended. That proves `TransferIR::emit` is a pure function of
@@ -160,7 +171,6 @@ impl AsmIr {
     ///
     pub(super) fn transfer(&mut self, t: TransferIR) {
         if !self.codegen_mode {
-            t.emit(self);
             return;
         }
         self.transfers.push(t.clone());

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -112,6 +112,14 @@ impl std::ops::IndexMut<AsmEvict> for AsmIr {
     }
 }
 
+/// Element-wise `Debug`-string equality, the `transfer` shadow check's
+/// comparator: neither `AsmInst` nor `SideExit` is `PartialEq` (they carry
+/// non-comparable payloads such as boxed closures), but both are `Debug`.
+#[cfg(debug_assertions)]
+fn dbg_slice_eq<T: std::fmt::Debug>(a: &[T], b: &[T]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| format!("{x:?}") == format!("{y:?}"))
+}
+
 // private interface
 impl AsmIr {
     fn new_label(&mut self, side_exit: SideExit) -> usize {
@@ -142,33 +150,41 @@ impl AsmIr {
     /// the prior direct `record.emit(ir, …)`; collection is purely additive.
     ///
     /// In debug builds a **shadow check** replays the record alone into a scratch
-    /// buffer and asserts it reproduces exactly the `AsmInst`s this call appended.
-    /// That proves `TransferIR::emit` is a pure function of the record (no hidden
-    /// dependence on `self`/frame state) — the self-containment that record-driven
-    /// lowering relies on, and a guard against future transfers that read state.
+    /// buffer and asserts it reproduces exactly the `AsmInst`s *and* `SideExit`s
+    /// this call appended. That proves `TransferIR::emit` is a pure function of
+    /// the record and the current `side_exit` cursor — its only codegen input,
+    /// since a guarded record materializes its deopt as `AsmDeopt(side_exit.len())`
+    /// (the scratch is pre-padded to the same length so the index matches). This
+    /// is the self-containment record-driven lowering relies on, and a standing
+    /// guard against a future transfer that reads other frame/codegen state.
     ///
     pub(super) fn transfer(&mut self, t: TransferIR) {
         if !self.codegen_mode {
             t.emit(self);
             return;
         }
-        self.transfers.push(t);
-        #[cfg(debug_assertions)]
-        let start = self.inst.len();
+        self.transfers.push(t.clone());
+        #[cfg(not(debug_assertions))]
         t.emit(self);
         #[cfg(debug_assertions)]
         {
+            let (inst_start, se_start) = (self.inst.len(), self.side_exit.len());
+            t.clone().emit(self);
+            // Replay into a scratch whose deopt cursor (`side_exit.len()`) matches,
+            // so a materialized `AsmDeopt` index is identical.
             let mut scratch = AsmIr::shadow_scratch();
-            t.emit(&mut scratch);
-            let produced = &self.inst[start..];
+            scratch
+                .side_exit
+                .resize_with(se_start, || SideExit::Evict(None));
+            t.clone().emit(&mut scratch);
             debug_assert!(
-                produced.len() == scratch.inst.len()
-                    && produced
-                        .iter()
-                        .zip(&scratch.inst)
-                        .all(|(a, b)| format!("{a:?}") == format!("{b:?}")),
-                "TransferIR replay mismatch: {t:?}\n  real:   {produced:?}\n  replay: {:?}",
-                scratch.inst
+                dbg_slice_eq(&self.inst[inst_start..], &scratch.inst)
+                    && dbg_slice_eq(&self.side_exit[se_start..], &scratch.side_exit[se_start..]),
+                "TransferIR replay mismatch: {t:?}\n  real inst:    {:?}\n  replay inst:  {:?}\n  real exit:    {:?}\n  replay exit:  {:?}",
+                &self.inst[inst_start..],
+                &scratch.inst,
+                &self.side_exit[se_start..],
+                &scratch.side_exit[se_start..],
             );
         }
     }
@@ -333,6 +349,21 @@ impl AsmIr {
     pub(crate) fn new_deopt(&mut self, state: &AbstractFrame) -> AsmDeopt {
         let pc = state.pc();
         self.new_deopt_with_pc(state, pc)
+    }
+
+    ///
+    /// Materialize a guarded transfer record's deopt **program point** (a
+    /// [`DeoptPoint`], recorded by the analysis half — doc §9) into a `side_exit`
+    /// label, returning its `AsmDeopt`. The emit/codegen half calls this so that
+    /// `side_exit` construction lives entirely on the codegen side and the
+    /// `TransferIR` stream stays codegen-independent. Equivalent to `new_deopt`,
+    /// but driven by the recorded `(pc, write_back)` rather than reading the live
+    /// `AbstractFrame`.
+    ///
+    pub(super) fn deopt_from_point(&mut self, point: &DeoptPoint) -> AsmDeopt {
+        let i = self.new_label(SideExit::Deoptimize(point.pc(), point.write_back().clone()));
+        self.had_deopt = true;
+        AsmDeopt(i)
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -141,11 +141,51 @@ impl AsmIr {
     /// lock-step with the gated `inst`) and emit it. The emission is identical to
     /// the prior direct `record.emit(ir, …)`; collection is purely additive.
     ///
+    /// In debug builds a **shadow check** replays the record alone into a scratch
+    /// buffer and asserts it reproduces exactly the `AsmInst`s this call appended.
+    /// That proves `TransferIR::emit` is a pure function of the record (no hidden
+    /// dependence on `self`/frame state) — the self-containment that record-driven
+    /// lowering relies on, and a guard against future transfers that read state.
+    ///
     pub(super) fn transfer(&mut self, t: TransferIR) {
-        if self.codegen_mode {
-            self.transfers.push(t);
+        if !self.codegen_mode {
+            t.emit(self);
+            return;
         }
+        self.transfers.push(t);
+        #[cfg(debug_assertions)]
+        let start = self.inst.len();
         t.emit(self);
+        #[cfg(debug_assertions)]
+        {
+            let mut scratch = AsmIr::shadow_scratch();
+            t.emit(&mut scratch);
+            let produced = &self.inst[start..];
+            debug_assert!(
+                produced.len() == scratch.inst.len()
+                    && produced
+                        .iter()
+                        .zip(&scratch.inst)
+                        .all(|(a, b)| format!("{a:?}") == format!("{b:?}")),
+                "TransferIR replay mismatch: {t:?}\n  real:   {produced:?}\n  replay: {:?}",
+                scratch.inst
+            );
+        }
+    }
+
+    /// An empty codegen-mode `AsmIr` for the [`Self::transfer`] shadow check —
+    /// the replay target. Needs no `JitContext`.
+    #[cfg(debug_assertions)]
+    fn shadow_scratch() -> Self {
+        Self {
+            codegen_mode: true,
+            inst: vec![],
+            side_exit: vec![],
+            had_deopt: false,
+            deferred_rest: false,
+            needs_rest_array: false,
+            transfers: vec![],
+        }
     }
 
     pub(super) fn had_deopt(&self) -> bool {

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -166,6 +166,66 @@ impl AsmIr {
         self.inst.is_empty()
     }
 
+    ///
+    /// Does this block's instruction stream end with an unconditional
+    /// terminator (so the code physically following it is not reached by
+    /// fall-through)? See [`AsmInst::is_unconditional_terminator`]; the
+    /// answer is conservative (an empty stream, or one ending in any
+    /// non-terminator, is treated as fall-through).
+    ///
+    pub(super) fn ends_unconditionally(&self) -> bool {
+        self.inst
+            .last()
+            .is_some_and(AsmInst::is_unconditional_terminator)
+    }
+
+    ///
+    /// If this block's whole body is a label, optional source-position
+    /// markers, and a single trailing `Deopt` (e.g. a loop's natural exit
+    /// block, which only deopts to the interpreter), return the block label
+    /// and the deopt. Such a block is a pure indirection to its deopt handler,
+    /// so the aarch64 backend emits the deopt inline at the block label rather
+    /// than laying a cold handler and branching to it — letting predecessors
+    /// land straight on the deopt code. `BcIndex` markers emit no machine code
+    /// (they only feed the perf/emit-asm source map) and are ignored here.
+    ///
+    /// aarch64-only: x86 lays deopt handlers on the cold page and has no
+    /// inline-handler indirection to collapse.
+    ///
+    #[cfg(target_arch = "aarch64")]
+    pub(super) fn as_pure_deopt(&self) -> Option<(JitLabel, AsmDeopt)> {
+        let (first, rest) = self.inst.split_first()?;
+        let AsmInst::Label(bb) = first else {
+            return None;
+        };
+        let (last, middle) = rest.split_last()?;
+        let AsmInst::Deopt(deopt) = last else {
+            return None;
+        };
+        middle
+            .iter()
+            .all(|i| matches!(i, AsmInst::BcIndex(_)))
+            .then_some((*bb, *deopt))
+    }
+
+    ///
+    /// The single `SideExit` of a pure-deopt block (see [`Self::as_pure_deopt`])
+    /// when it is a plain `Deoptimize(pc, write_back)` and the block's only side
+    /// exit, returned as `(pc, write_back)`. `None` otherwise (e.g. an evict /
+    /// recompile-deopt, or extra side exits), so callers fall back to the
+    /// ordinary cold-handler path. aarch64-only (see [`Self::as_pure_deopt`]).
+    ///
+    #[cfg(target_arch = "aarch64")]
+    pub(super) fn pure_deopt_target(&self, deopt: AsmDeopt) -> Option<(BytecodePtr, &WriteBack)> {
+        if self.side_exit.len() == 1
+            && let SideExit::Deoptimize(pc, wb) = &self.side_exit[deopt.0]
+        {
+            Some((*pc, wb))
+        } else {
+            None
+        }
+    }
+
     pub(super) fn save(&mut self) -> (usize, usize, bool, bool, bool, bool) {
         (
             self.inst.len(),
@@ -1889,6 +1949,36 @@ pub(super) enum AsmInst {
 
 impl AsmInst {
     ///
+    /// Does this instruction unconditionally transfer control away, so that
+    /// the instruction physically following it is *not* reached by
+    /// fall-through?
+    ///
+    /// Conservative: returns `true` only for variants that are definitely
+    /// unconditional terminators. Anything uncertain returns `false` (the
+    /// caller then assumes the next block *is* fall-through reachable). A
+    /// false negative only keeps a harmless `b skip` over the aarch64
+    /// inline side-exit handlers; a false positive would drop a *needed*
+    /// `b skip` and let control fall into the cold handlers, so the bias
+    /// must stay on the safe side.
+    ///
+    pub(super) fn is_unconditional_terminator(&self) -> bool {
+        matches!(
+            self,
+            Self::Ret
+                | Self::BlockBreak(_)
+                | Self::MethodRet(_)
+                | Self::BlockBreakSpecialized { .. }
+                | Self::MethodRetSpecialized { .. }
+                | Self::Raise
+                | Self::Retry(_)
+                | Self::Redo(_)
+                | Self::Deopt(_)
+                | Self::RecompileDeopt { .. }
+                | Self::RecompileDeoptSpecialized { .. }
+        )
+    }
+
+    ///
     /// Enumerate every `VirtFPReg` operand referenced by this
     /// instruction (in any role — read, write, or read-write).
     /// Used by `pop_frame` to compute the frame's max
@@ -2022,6 +2112,11 @@ impl Codegen {
         entry: Option<DestLabel>,
         exit: Option<BasicBlockId>,
         class_version: DestLabel,
+        // Whether this block is fall-through reachable. Only the aarch64 backend
+        // acts on it (to drop a dead `b skip` over inline side-exit handlers);
+        // x86 lays its handlers on the cold page via `select_page`, so there is
+        // no skip branch to elide and the flag is unused here.
+        _fallthrough_in: bool,
     ) {
         let mut side_exits = SideExitLabels::new();
         let mut deopt_table: HashMap<(BytecodePtr, WriteBack), DestLabel> = HashMap::default();

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -797,6 +797,14 @@ impl AsmIr {
             .push(AsmInst::Inline(InlineProcedure { proc: Box::new(f) }));
     }
 
+    /// Emit `dst <- [base + disp]` (load a heap-object field into a GP register).
+    /// A typed alternative to `inline` for trivial field-reader inline builtins,
+    /// so their codegen flows through LIR (`LInst::Load { Field }`) instead of
+    /// hand-written per-arch asm.
+    pub(crate) fn load_field_to_reg(&mut self, dst: GP, base: GP, disp: i32) {
+        self.inst.push(AsmInst::LoadFieldToReg { dst, base, disp });
+    }
+
     pub(crate) fn bc_index(&mut self, index: BcIndex) {
         self.push(AsmInst::BcIndex(index));
     }
@@ -1328,6 +1336,16 @@ pub(super) enum AsmInst {
         evict: AsmEvict,
     },
     Inline(InlineProcedure),
+    /// `dst <- [base + disp]`: load a field of a heap object into a GP register.
+    /// A typed replacement for the `ir.inline(|gen| gen.emit_*())` escape hatch
+    /// used by trivial field-reader inline builtins (e.g. `Range#begin/end`),
+    /// so their codegen is expressed once in arch-neutral LIR rather than as
+    /// per-arch hand-written asm. Lowers to `LInst::Load { mem: Field }`.
+    LoadFieldToReg {
+        dst: GP,
+        base: GP,
+        disp: i32,
+    },
     #[allow(non_camel_case_types)]
     CFunc_F_F {
         f: unsafe extern "C" fn(f64) -> f64,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -193,7 +193,13 @@ impl Codegen {
                 deopt,
             } => {
                 let deopt = labels[deopt].clone();
-                return self.emit_integer_binop(lhs, rhs, mode, kind, deopt);
+                self.encode_linst(LInst::IntegerBinOp {
+                    kind,
+                    mode,
+                    lhs,
+                    rhs,
+                    deopt,
+                });
             }
             AsmInst::IntegerCmp {
                 mode,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -11,7 +11,7 @@
 //! instruction family at a time; see `doc/aarch64-x86-jit-differences.md`.
 
 use super::*;
-use crate::codegen::jitgen::lir::{LCond, LInst, LMem, LOperand};
+use crate::codegen::jitgen::lir::{LCond, LInst, LMem, LOperand, LReg};
 
 impl Codegen {
     ///
@@ -352,9 +352,9 @@ impl Codegen {
             AsmInst::LoadIVarInline { ivarid } => {
                 let disp = RVALUE_OFFSET_KIND as i32 + ivarid.get() as i32 * 8;
                 self.encode_linst(LInst::Load {
-                    dst: GP::R15,
+                    dst: GP::R15.into(),
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp,
                     },
                 });
@@ -367,7 +367,7 @@ impl Codegen {
                 self.encode_linst(LInst::Store {
                     src,
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp,
                     },
                 });
@@ -382,9 +382,9 @@ impl Codegen {
             AsmInst::LoadStructSlotInline { slot_index } => {
                 let disp = slot_index as i32 * 8 + RVALUE_OFFSET_INLINE as i32;
                 self.encode_linst(LInst::Load {
-                    dst: GP::R15,
+                    dst: GP::R15.into(),
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp,
                     },
                 });
@@ -396,7 +396,7 @@ impl Codegen {
                 self.encode_linst(LInst::Store {
                     src,
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp,
                     },
                 });
@@ -413,16 +413,16 @@ impl Codegen {
             // pointer into rdi, then load/store the slot at `slot_index * 8`.
             AsmInst::LoadStructSlotHeap { slot_index } => {
                 self.encode_linst(LInst::Load {
-                    dst: GP::Rdi,
+                    dst: GP::Rdi.into(),
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp: RVALUE_OFFSET_HEAP_PTR as i32,
                     },
                 });
                 self.encode_linst(LInst::Load {
-                    dst: GP::R15,
+                    dst: GP::R15.into(),
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp: slot_index as i32 * 8,
                     },
                 });
@@ -435,16 +435,16 @@ impl Codegen {
                     value: src,
                 });
                 self.encode_linst(LInst::Load {
-                    dst: GP::Rdi,
+                    dst: GP::Rdi.into(),
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp: RVALUE_OFFSET_HEAP_PTR as i32,
                     },
                 });
                 self.encode_linst(LInst::Store {
                     src,
                     mem: LMem::Field {
-                        base: GP::Rdi,
+                        base: GP::Rdi.into(),
                         disp: slot_index as i32 * 8,
                     },
                 });
@@ -484,11 +484,47 @@ impl Codegen {
             }
             // Store into a heap-spilled instance variable of self (the table is
             // known large enough, so no bounds check / runtime extend).
+            // `self.@ivar = src` where the ivar spilled to self's heap var-table
+            // (which is known large enough — no bounds check). The two derefs
+            // (RValue → var-table struct → buffer pointer) go through the scratch
+            // pointer so rdi is preserved as the barrier's parent.
             AsmInst::StoreSelfIVarHeap {
                 src,
                 ivarid,
                 is_object_ty,
-            } => return self.emit_store_self_ivar_heap(src, ivarid, is_object_ty),
+            } => {
+                let ivar = ivarid.get() as i32;
+                let idx = if is_object_ty {
+                    ivar - OBJECT_INLINE_IVAR as i32
+                } else {
+                    ivar
+                };
+                self.encode_linst(LInst::Load {
+                    dst: LReg::Scratch,
+                    mem: LMem::Field {
+                        base: GP::Rdi.into(),
+                        disp: RVALUE_OFFSET_VAR as i32,
+                    },
+                });
+                self.encode_linst(LInst::Load {
+                    dst: LReg::Scratch,
+                    mem: LMem::Field {
+                        base: LReg::Scratch,
+                        disp: MONOVEC_PTR as i32,
+                    },
+                });
+                self.encode_linst(LInst::Store {
+                    src,
+                    mem: LMem::Field {
+                        base: LReg::Scratch,
+                        disp: idx * 8,
+                    },
+                });
+                self.encode_linst(LInst::WriteBarrier {
+                    parent: GP::Rdi,
+                    value: src,
+                });
+            }
             // Store into a heap-spilled ivar of another object (bounds-checked;
             // grows the table via a runtime call on miss). aarch64 bails on an
             // out-of-range field offset.

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -409,13 +409,49 @@ impl Codegen {
                     src,
                 });
             }
-            // Heap (Box-spilled) Struct member access: deref the heap pointer
-            // first, then load/store the slot (aarch64 bails on a large offset).
+            // Heap (Box-spilled) Struct member access: deref the heap buffer
+            // pointer into rdi, then load/store the slot at `slot_index * 8`.
             AsmInst::LoadStructSlotHeap { slot_index } => {
-                return self.emit_load_struct_slot_heap(slot_index);
+                self.encode_linst(LInst::Load {
+                    dst: GP::Rdi,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp: RVALUE_OFFSET_HEAP_PTR as i32,
+                    },
+                });
+                self.encode_linst(LInst::Load {
+                    dst: GP::R15,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp: slot_index as i32 * 8,
+                    },
+                });
             }
             AsmInst::StoreStructSlotHeap { src, slot_index } => {
-                return self.emit_store_struct_slot_heap(src, slot_index);
+                // Barrier first: it needs rdi = the struct (parent), before the
+                // deref repoints rdi at the heap buffer.
+                self.encode_linst(LInst::WriteBarrier {
+                    parent: GP::Rdi,
+                    value: src,
+                });
+                self.encode_linst(LInst::Load {
+                    dst: GP::Rdi,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp: RVALUE_OFFSET_HEAP_PTR as i32,
+                    },
+                });
+                self.encode_linst(LInst::Store {
+                    src,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp: slot_index as i32 * 8,
+                    },
+                });
+                self.encode_linst(LInst::Mov {
+                    dst: GP::Rax,
+                    src,
+                });
             }
             // reg += i / reg -= i (no-op when i == 0).
             AsmInst::RegAdd(reg, i) => self.emit_reg_add(reg, i),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -111,12 +111,17 @@ impl Codegen {
             // Constant base-class guard: deopt if the constant's base class (in
             // the accumulator) is not the cached one.
             AsmInst::GuardConstBaseClass { base_class, deopt } => {
-                self.emit_guard_const_base_class(base_class, &labels[deopt]);
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardConstBaseClass { base_class, deopt });
             }
             // Constant version guard: deopt if the global constant version moved
             // since compilation.
             AsmInst::GuardConstVersion { const_version, deopt } => {
-                self.emit_guard_const_version(const_version, &labels[deopt]);
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardConstVersion {
+                    const_version,
+                    deopt,
+                });
             }
             // Store to a constant, bumping the global constant version (aarch64
             // bails if any xmm is live, hence the bool result).
@@ -306,7 +311,10 @@ impl Codegen {
                 return self.emit_set_arguments(store, callid, callee_fid);
             }
             // Basic-operator-redefinition guard: deopt if any BOP was redefined.
-            AsmInst::CheckBOP { deopt } => self.emit_check_bop(&labels[deopt]),
+            AsmInst::CheckBOP { deopt } => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::CheckBOP { deopt });
+            }
             // Recompile-or-deopt point: both arches recompile the whole method
             // (or loop body) once a small miss counter warms, then deopt.
             // (Specialized frames recompile via RecompileDeoptSpecialized /
@@ -485,7 +493,10 @@ impl Codegen {
             }),
             // Side-effect guard for block-passing calls: deopt if the frame was
             // captured/promoted.
-            AsmInst::GuardCapture(deopt) => return self.emit_guard_capture(&labels[deopt]),
+            AsmInst::GuardCapture(deopt) => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardCapture { deopt });
+            }
             // `&block` forwarding: proxy the block handler, or materialize it
             // into a Proc value (aarch64 bails on a live xmm / range overflow).
             AsmInst::BlockArgProxy { ret, outer } => return self.emit_block_arg_proxy(ret, outer),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -170,7 +170,11 @@ impl Codegen {
                 dst,
                 base: frame.base_stack_offset,
             }),
-            AsmInst::FprSwap(l, r) => return self.emit_fpr_swap(l, r, frame.base_stack_offset),
+            AsmInst::FprSwap(l, r) => self.encode_linst(LInst::FprSwap {
+                lhs: l,
+                rhs: r,
+                base: frame.base_stack_offset,
+            }),
             AsmInst::F64ToFpr(f, x) => self.encode_linst(LInst::F64ToFpr {
                 f,
                 dst: x,
@@ -182,7 +186,13 @@ impl Codegen {
                 base: frame.base_stack_offset,
             }),
             AsmInst::FloatToFpr(reg, x, deopt) => {
-                return self.emit_float_to_fpr(reg, x, &labels[deopt], frame.base_stack_offset);
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::FloatToFpr {
+                    src: reg,
+                    dst: x,
+                    deopt,
+                    base: frame.base_stack_offset,
+                });
             }
             AsmInst::FprToStack(x, slot) => self.encode_linst(LInst::FprToStack {
                 src: x,
@@ -270,9 +280,12 @@ impl Codegen {
             }
             // [slot] <- Value::integer(i) and fpr(x) <- i as f64 (constant int
             // materialized as both a boxed integer and a double).
-            AsmInst::I64ToBoth(i, slot, x) => {
-                return self.emit_i64_to_both(i, slot, x, frame.base_stack_offset);
-            }
+            AsmInst::I64ToBoth(i, slot, x) => self.encode_linst(LInst::I64ToBoth {
+                i,
+                slot,
+                dst: x,
+                base: frame.base_stack_offset,
+            }),
             // Float comparison. NaN compares false (except `!=`); each backend
             // picks NaN-correct condition codes (x86 ucomisd + setp tricks,
             // aarch64 fcmp + MI/LS conditions).

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -85,10 +85,14 @@ impl Codegen {
                 else_label,
                 branch_labels,
             } => self.emit_opt_case(frame, max, min, else_label, branch_labels),
-            // Type guard: deopt if `r`'s runtime class is not `class`. (aarch64
-            // bails for not-yet-supported class kinds, hence the bool result.)
+            // Type guard: deopt if `r`'s runtime class is not `class`.
             AsmInst::GuardClass(r, class, deopt) => {
-                return self.emit_guard_class(r, class, &labels[deopt]);
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardClass {
+                    reg: r,
+                    class,
+                    deopt,
+                });
             }
             // Unconditional jump to a side-exit (deopt) label.
             AsmInst::Deopt(deopt) => self.emit_deopt(&labels[deopt]),
@@ -342,8 +346,14 @@ impl Codegen {
             AsmInst::FixnumBitNot { reg } => self.emit_fixnum_bit_not(reg),
             // Type guards: deopt unless `reg` is an Array / the receiver in rdi
             // is unfrozen.
-            AsmInst::GuardArrayTy(reg, deopt) => self.emit_guard_array_ty(reg, &labels[deopt]),
-            AsmInst::GuardFrozen { deopt } => self.emit_guard_frozen(&labels[deopt]),
+            AsmInst::GuardArrayTy(reg, deopt) => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardArrayTy { reg, deopt });
+            }
+            AsmInst::GuardFrozen { deopt } => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardFrozen { deopt });
+            }
             // Inline instance-variable / struct-member access on the receiver in
             // rdi (no Box deref). aarch64 bails if the field offset exceeds the
             // 12-bit scaled load/store immediate.

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -630,65 +630,61 @@ impl Codegen {
             // Runtime-call definition ops (undef a method / alias a global var).
             // aarch64 bails when an xmm pool register is live (no xmm save yet).
             AsmInst::UndefMethod { undef, using_xmm } => {
-                return self.emit_undef_method(undef, using_xmm);
+                self.encode_linst(LInst::UndefMethod { undef, using_xmm })
             }
             AsmInst::AliasGvar { new, old, using_xmm } => {
-                return self.emit_alias_gvar(new, old, using_xmm);
+                self.encode_linst(LInst::AliasGvar { new, old, using_xmm })
             }
-            // Runtime-call class-variable / method-alias ops. aarch64 bails
-            // when an xmm pool register is live (no xmm save yet).
+            // Runtime-call class-variable / method-alias ops.
             AsmInst::CheckCVar { name, using_xmm } => {
-                return self.emit_check_cvar(name, using_xmm);
+                self.encode_linst(LInst::CheckCVar { name, using_xmm })
             }
             AsmInst::StoreCVar { name, src, using_xmm } => {
-                return self.emit_store_cvar(name, src, using_xmm);
+                self.encode_linst(LInst::StoreCVar { name, src, using_xmm })
             }
             AsmInst::AliasMethod { new, old, using_xmm } => {
-                return self.emit_alias_method(new, old, using_xmm);
+                self.encode_linst(LInst::AliasMethod { new, old, using_xmm })
             }
-            // defined? runtime-call family (aarch64 bails on a live xmm pool reg
-            // or an out-of-range frame offset).
+            // defined? runtime-call family.
             AsmInst::DefinedYield { dst, using_xmm } => {
-                return self.emit_defined_yield(dst, using_xmm);
+                self.encode_linst(LInst::DefinedYield { dst, using_xmm })
             }
             AsmInst::DefinedSuper { dst, using_xmm } => {
-                return self.emit_defined_super(dst, using_xmm);
+                self.encode_linst(LInst::DefinedSuper { dst, using_xmm })
             }
             AsmInst::DefinedGvar { dst, name, using_xmm } => {
-                return self.emit_defined_gvar(dst, name, using_xmm);
+                self.encode_linst(LInst::DefinedGvar { dst, name, using_xmm })
             }
             AsmInst::DefinedCvar { dst, name, using_xmm } => {
-                return self.emit_defined_cvar(dst, name, using_xmm);
+                self.encode_linst(LInst::DefinedCvar { dst, name, using_xmm })
             }
             AsmInst::DefinedConst { dst, siteid, using_xmm } => {
-                return self.emit_defined_const(dst, siteid, using_xmm);
+                self.encode_linst(LInst::DefinedConst { dst, siteid, using_xmm })
             }
             AsmInst::DefinedMethod { dst, recv, name, using_xmm } => {
-                return self.emit_defined_method(dst, recv, name, using_xmm);
+                self.encode_linst(LInst::DefinedMethod { dst, recv, name, using_xmm })
             }
             AsmInst::DefinedIvar { dst, name, using_xmm } => {
-                return self.emit_defined_ivar(dst, name, using_xmm);
+                self.encode_linst(LInst::DefinedIvar { dst, name, using_xmm })
             }
-            // Generic binary-op / Array=== runtime calls (aarch64 bails on a
-            // live xmm pool reg or an out-of-range frame offset).
+            // Generic binary-op / Array=== runtime calls.
             AsmInst::GenericBinOp { lhs, rhs, func, using_xmm } => {
-                return self.emit_generic_binop(lhs, rhs, func, using_xmm);
+                self.encode_linst(LInst::GenericBinOp { lhs, rhs, func, using_xmm })
             }
             AsmInst::OptEqCmp { lhs, rhs, kind, func, using_xmm } => {
-                return self.emit_opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
+                self.encode_linst(LInst::OptEqCmp { lhs, rhs, kind, func, using_xmm })
             }
             AsmInst::ArrayTEq { lhs, rhs, using_xmm } => {
-                return self.emit_array_teq(lhs, rhs, using_xmm);
+                self.encode_linst(LInst::ArrayTEq { lhs, rhs, using_xmm })
             }
             // Regexp interpolation / keyword-rest fixup runtime calls.
             AsmInst::ConcatRegexp { arg, len, using_xmm } => {
-                return self.emit_concat_regexp(arg, len, using_xmm);
+                self.encode_linst(LInst::ConcatRegexp { arg, len, using_xmm })
             }
-            AsmInst::CheckKwRest(slot) => return self.emit_check_kw_rest(slot),
-            // Multiple-assignment array expansion (aarch64 bails on a live xmm
-            // pool reg or an out-of-range frame offset).
+            AsmInst::CheckKwRest(slot) => self.encode_linst(LInst::CheckKwRest { slot }),
+            // Multiple-assignment array expansion.
             AsmInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
-                return self.emit_expand_array(dst, len, rest_pos, using_xmm);
+                self.encode_linst(LInst::ExpandArray { dst, len, rest_pos, using_xmm })
             }
             // Float C-function calls (Math.sqrt/sin/…): save the live FP pool
             // around the call.
@@ -889,6 +885,60 @@ impl Codegen {
             }
             LInst::DeepCopyLit { v, using_xmm } => {
                 self.emit_deep_copy_lit(v, using_xmm);
+            }
+            LInst::UndefMethod { undef, using_xmm } => {
+                self.emit_undef_method(undef, using_xmm);
+            }
+            LInst::AliasGvar { new, old, using_xmm } => {
+                self.emit_alias_gvar(new, old, using_xmm);
+            }
+            LInst::CheckCVar { name, using_xmm } => {
+                self.emit_check_cvar(name, using_xmm);
+            }
+            LInst::StoreCVar { name, src, using_xmm } => {
+                self.emit_store_cvar(name, src, using_xmm);
+            }
+            LInst::AliasMethod { new, old, using_xmm } => {
+                self.emit_alias_method(new, old, using_xmm);
+            }
+            LInst::DefinedYield { dst, using_xmm } => {
+                self.emit_defined_yield(dst, using_xmm);
+            }
+            LInst::DefinedSuper { dst, using_xmm } => {
+                self.emit_defined_super(dst, using_xmm);
+            }
+            LInst::DefinedGvar { dst, name, using_xmm } => {
+                self.emit_defined_gvar(dst, name, using_xmm);
+            }
+            LInst::DefinedCvar { dst, name, using_xmm } => {
+                self.emit_defined_cvar(dst, name, using_xmm);
+            }
+            LInst::DefinedConst { dst, siteid, using_xmm } => {
+                self.emit_defined_const(dst, siteid, using_xmm);
+            }
+            LInst::DefinedMethod { dst, recv, name, using_xmm } => {
+                self.emit_defined_method(dst, recv, name, using_xmm);
+            }
+            LInst::DefinedIvar { dst, name, using_xmm } => {
+                self.emit_defined_ivar(dst, name, using_xmm);
+            }
+            LInst::GenericBinOp { lhs, rhs, func, using_xmm } => {
+                self.emit_generic_binop(lhs, rhs, func, using_xmm);
+            }
+            LInst::OptEqCmp { lhs, rhs, kind, func, using_xmm } => {
+                self.emit_opt_eq_cmp(lhs, rhs, kind, func, using_xmm);
+            }
+            LInst::ArrayTEq { lhs, rhs, using_xmm } => {
+                self.emit_array_teq(lhs, rhs, using_xmm);
+            }
+            LInst::ConcatRegexp { arg, len, using_xmm } => {
+                self.emit_concat_regexp(arg, len, using_xmm);
+            }
+            LInst::CheckKwRest { slot } => {
+                self.emit_check_kw_rest(slot);
+            }
+            LInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
+                self.emit_expand_array(dst, len, rest_pos, using_xmm);
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -367,7 +367,12 @@ impl Codegen {
                 deopt,
             } => {
                 let deopt = labels[deopt].clone();
-                self.emit_guard_class_version(class_version, position, with_recovery, deopt);
+                self.encode_linst(LInst::GuardClassVersion {
+                    class_version,
+                    position,
+                    with_recovery,
+                    deopt,
+                });
             }
             AsmInst::SetupMethodFrame {
                 meta,
@@ -393,7 +398,12 @@ impl Codegen {
                 reason,
             } => {
                 let error = error.map(|e| labels[e].clone());
-                self.emit_recompile_deopt(position, &labels[deopt], error.as_ref(), reason)
+                self.encode_linst(LInst::RecompileDeopt {
+                    position,
+                    deopt: labels[deopt].clone(),
+                    error,
+                    reason,
+                });
             }
             // The call itself. x86 records a return-address deopt patch point;
             // aarch64 has no branch patching (class-version guards cover it).
@@ -832,7 +842,7 @@ impl Codegen {
                 using_xmm,
                 error,
             } => {
-                return self.class_def(
+                self.encode_linst(LInst::ClassDef {
                     base,
                     superclass,
                     dst,
@@ -840,8 +850,8 @@ impl Codegen {
                     func_id,
                     is_module,
                     using_xmm,
-                    &labels[error],
-                );
+                    error: labels[error].clone(),
+                });
             }
             AsmInst::SingletonClassDef {
                 base,
@@ -850,7 +860,13 @@ impl Codegen {
                 using_xmm,
                 error,
             } => {
-                return self.singleton_class_def(base, dst, func_id, using_xmm, &labels[error]);
+                self.encode_linst(LInst::SingletonClassDef {
+                    base,
+                    dst,
+                    func_id,
+                    using_xmm,
+                    error: labels[error].clone(),
+                });
             }
             // Forwarding-trampoline helper frame setup (aarch64 bails on an
             // out-of-range frame offset).
@@ -1057,6 +1073,52 @@ impl Codegen {
             }
             LInst::RestKw { rest_kw } => {
                 self.emit_rest_kw(rest_kw);
+            }
+            LInst::GuardClassVersion {
+                class_version,
+                position,
+                with_recovery,
+                deopt,
+            } => {
+                self.emit_guard_class_version(class_version, position, with_recovery, deopt);
+            }
+            LInst::RecompileDeopt {
+                position,
+                deopt,
+                error,
+                reason,
+            } => {
+                self.emit_recompile_deopt(position, &deopt, error.as_ref(), reason);
+            }
+            LInst::ClassDef {
+                base,
+                superclass,
+                dst,
+                name,
+                func_id,
+                is_module,
+                using_xmm,
+                error,
+            } => {
+                self.class_def(
+                    base,
+                    superclass,
+                    dst,
+                    name,
+                    func_id,
+                    is_module,
+                    using_xmm,
+                    &error,
+                );
+            }
+            LInst::SingletonClassDef {
+                base,
+                dst,
+                func_id,
+                using_xmm,
+                error,
+            } => {
+                self.singleton_class_def(base, dst, func_id, using_xmm, &error);
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -459,11 +459,20 @@ impl Codegen {
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
             // the 12-bit sub-sp immediate).
             AsmInst::LoopJitRspBump { offset } => return self.emit_loop_jit_rsp_bump(offset),
-            // Inline argument-setup stores into the callee frame (aarch64 bails
-            // on an out-of-range slot offset).
-            AsmInst::RegToRSPOffset(r, ofs) => return self.emit_reg_to_rsp_offset(r, ofs),
-            AsmInst::ZeroToRSPOffset(ofs) => return self.emit_zero_to_rsp_offset(ofs),
-            AsmInst::U64ToRSPOffset(i, ofs) => return self.emit_u64_to_rsp_offset(i, ofs),
+            // Inline argument-setup stores into the callee frame, at a
+            // (raw) rsp-relative offset the encoder legalizes per arch.
+            AsmInst::RegToRSPOffset(r, ofs) => self.encode_linst(LInst::Store {
+                src: r,
+                mem: LMem::RspRel { disp: ofs },
+            }),
+            AsmInst::ZeroToRSPOffset(ofs) => self.encode_linst(LInst::StoreImm {
+                imm: 0,
+                mem: LMem::RspRel { disp: ofs },
+            }),
+            AsmInst::U64ToRSPOffset(i, ofs) => self.encode_linst(LInst::StoreImm {
+                imm: i,
+                mem: LMem::RspRel { disp: ofs },
+            }),
             // Side-effect guard for block-passing calls: deopt if the frame was
             // captured/promoted.
             AsmInst::GuardCapture(deopt) => return self.emit_guard_capture(&labels[deopt]),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -4,14 +4,16 @@
 //! The AsmIR→machine-code lowering used to be two fully parallel matches —
 //! `arch/x86_64/compile/*.rs` (x86, `monoasm!`) and `arch/aarch64/compile.rs`
 //! (aarch64, `monoasm_arm64!`). Instructions whose lowering is identical in
-//! *structure* (only the emitted bytes differ) are handled here ONCE and call
-//! tiny per-arch **emission primitives** (`emit_reg_move`, `emit_reg_to_stack`,
-//! `emit_stack_to_reg`, `emit_lit_to_reg`). Everything else is forwarded to the
-//! per-arch `compile_asmir_arch`. Coverage of the shared match grows one
-//! instruction family at a time; see `doc/aarch64-x86-jit-differences.md`.
+//! *structure* (only the emitted bytes differ) are handled here ONCE: each is
+//! lowered to one or more arch-neutral `LInst`s and handed to the per-arch
+//! `Codegen::encode_linst` (the single machine-code emission seam; see
+//! `doc/lir.md`). Macro-op `LInst`s that still wrap a substantive per-arch
+//! helper are routed through `encode_linst_macro` below. Everything else is
+//! forwarded to the per-arch `compile_asmir_arch`. Coverage of the shared match
+//! grows one instruction family at a time; see `doc/arch_difference.md`.
 
 use super::*;
-use crate::codegen::jitgen::lir::{LCond, LInst, LMem, LOperand, LReg};
+use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg};
 
 impl Codegen {
     ///
@@ -43,20 +45,38 @@ impl Codegen {
                 self.jit.bind_label(label);
             }
             // dst <- src
-            AsmInst::RegMove(src, dst) => self.emit_reg_move(src, dst),
+            AsmInst::RegMove(src, dst) => self.encode_linst(LInst::Mov { dst, src }),
             // acc <- reg
-            AsmInst::RegToAcc(r) => self.emit_reg_move(r, GP::R15),
+            AsmInst::RegToAcc(r) => self.encode_linst(LInst::Mov {
+                dst: GP::R15,
+                src: r,
+            }),
             // [slot] <- acc
-            AsmInst::AccToStack(slot) => self.emit_reg_to_stack(GP::R15, slot),
+            AsmInst::AccToStack(slot) => self.encode_linst(LInst::Store {
+                src: GP::R15,
+                mem: LMem::Slot(slot),
+            }),
             // [slot] <- reg
-            AsmInst::RegToStack(r, slot) => self.emit_reg_to_stack(r, slot),
+            AsmInst::RegToStack(r, slot) => self.encode_linst(LInst::Store {
+                src: r,
+                mem: LMem::Slot(slot),
+            }),
             // reg <- [slot]
-            AsmInst::StackToReg(slot, r) => self.emit_stack_to_reg(slot, r),
+            AsmInst::StackToReg(slot, r) => self.encode_linst(LInst::Load {
+                dst: r.into(),
+                mem: LMem::Slot(slot),
+            }),
             // reg <- literal Value (immediate)
-            AsmInst::LitToReg(v, r) => self.emit_lit_to_reg(v, r),
-            // [slot] <- literal Value (aarch64 bails if the frame offset
-            // exceeds the 12-bit immediate range, hence the bool result).
-            AsmInst::LitToStack(v, slot) => return self.emit_lit_to_stack(v, slot),
+            AsmInst::LitToReg(v, r) => self.encode_linst(LInst::LoadImm {
+                dst: r,
+                imm: v.id(),
+            }),
+            // [slot] <- literal Value. The encoder legalizes the immediate
+            // (aarch64 stages an over-large frame offset through a scratch reg).
+            AsmInst::LitToStack(v, slot) => self.encode_linst(LInst::StoreImm {
+                imm: v.id(),
+                mem: LMem::Slot(slot),
+            }),
             // Conditional branch on the truthiness of the accumulator.
             AsmInst::CondBr(brkind, dest) => {
                 let target = frame.resolve_label(&mut self.jit, dest);
@@ -555,8 +575,18 @@ impl Codegen {
                 });
             }
             // reg += i / reg -= i (no-op when i == 0).
-            AsmInst::RegAdd(reg, i) => self.emit_reg_add(reg, i),
-            AsmInst::RegSub(reg, i) => self.emit_reg_sub(reg, i),
+            AsmInst::RegAdd(reg, i) => self.encode_linst(LInst::Alu {
+                op: LAluOp::Add,
+                dst: reg,
+                lhs: reg,
+                rhs: LOperand::Imm(i as i64),
+            }),
+            AsmInst::RegSub(reg, i) => self.encode_linst(LInst::Alu {
+                op: LAluOp::Sub,
+                dst: reg,
+                lhs: reg,
+                rhs: LOperand::Imm(i as i64),
+            }),
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
             // the 12-bit sub-sp immediate).
             AsmInst::LoopJitRspBump { offset } => self.encode_linst(LInst::LoopJitRspBump { offset }),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -11,7 +11,7 @@
 //! instruction family at a time; see `doc/aarch64-x86-jit-differences.md`.
 
 use super::*;
-use crate::codegen::jitgen::lir::{LCond, LInst, LOperand};
+use crate::codegen::jitgen::lir::{LCond, LInst, LMem, LOperand};
 
 impl Codegen {
     ///
@@ -351,8 +351,18 @@ impl Codegen {
             AsmInst::StoreIVarInline { src, ivarid } => {
                 return self.emit_store_ivar_inline(src, ivarid);
             }
+            // Inline struct-member load: `r15 <- self.@slot` at a fixed field
+            // offset on the receiver (rdi). Lowered to a field load whose
+            // (positive) displacement the encoder legalizes per arch.
             AsmInst::LoadStructSlotInline { slot_index } => {
-                return self.emit_load_struct_slot_inline(slot_index);
+                let disp = slot_index as i32 * 8 + RVALUE_OFFSET_INLINE as i32;
+                self.encode_linst(LInst::Load {
+                    dst: GP::R15,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp,
+                    },
+                });
             }
             AsmInst::StoreStructSlotInline { src, slot_index } => {
                 return self.emit_store_struct_slot_inline(src, slot_index);

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -59,18 +59,21 @@ impl Codegen {
             AsmInst::LitToStack(v, slot) => return self.emit_lit_to_stack(v, slot),
             // Conditional branch on the truthiness of the accumulator.
             AsmInst::CondBr(brkind, dest) => {
-                let dest = frame.resolve_label(&mut self.jit, dest);
-                self.emit_cond_br(dest, brkind);
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::BranchTruthy {
+                    negate: brkind == BrKind::BrIfNot,
+                    target,
+                });
             }
             // Branch to dest if the accumulator is nil.
             AsmInst::NilBr(dest) => {
-                let dest = frame.resolve_label(&mut self.jit, dest);
-                self.emit_nil_br(dest);
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::BranchIfNil { target });
             }
             // Branch to dest if the local (accumulator) is already set (non-zero).
             AsmInst::CheckLocal(dest) => {
-                let dest = frame.resolve_label(&mut self.jit, dest);
-                self.emit_check_local(dest);
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::BranchIfNonzero { target });
             }
             // Dense-integer `case`: range-check the (fixnum) condition against
             // `[min, max]`, then dispatch through a jump table of absolute

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -274,10 +274,18 @@ impl Codegen {
                 kind,
                 binary_xmm,
                 dst,
-            } => return self.emit_float_binop(kind, binary_xmm, dst, frame.base_stack_offset),
-            AsmInst::FloatUnOp { kind, dst } => {
-                return self.emit_float_unop(kind, dst, frame.base_stack_offset);
-            }
+            } => self.encode_linst(LInst::FloatBinOp {
+                kind,
+                lhs: binary_xmm.0,
+                rhs: binary_xmm.1,
+                dst,
+                base: frame.base_stack_offset,
+            }),
+            AsmInst::FloatUnOp { kind, dst } => self.encode_linst(LInst::FloatUnOp {
+                kind,
+                dst,
+                base: frame.base_stack_offset,
+            }),
             // [slot] <- Value::integer(i) and fpr(x) <- i as f64 (constant int
             // materialized as both a boxed integer and a double).
             AsmInst::I64ToBoth(i, slot, x) => self.encode_linst(LInst::I64ToBoth {
@@ -289,9 +297,12 @@ impl Codegen {
             // Float comparison. NaN compares false (except `!=`); each backend
             // picks NaN-correct condition codes (x86 ucomisd + setp tricks,
             // aarch64 fcmp + MI/LS conditions).
-            AsmInst::FloatCmp { kind, lhs, rhs } => {
-                return self.emit_float_cmp(kind, lhs, rhs, frame.base_stack_offset);
-            }
+            AsmInst::FloatCmp { kind, lhs, rhs } => self.encode_linst(LInst::FloatCmp {
+                kind,
+                lhs,
+                rhs,
+                base: frame.base_stack_offset,
+            }),
             AsmInst::FloatCmpBr {
                 kind,
                 lhs,
@@ -299,15 +310,15 @@ impl Codegen {
                 brkind,
                 branch_dest,
             } => {
-                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
-                return self.emit_float_cmp_br(
+                let dest = frame.resolve_label(&mut self.jit, branch_dest);
+                self.encode_linst(LInst::FloatCmpBr {
                     kind,
                     lhs,
                     rhs,
                     brkind,
-                    branch_dest,
-                    frame.base_stack_offset,
-                );
+                    dest,
+                    base: frame.base_stack_offset,
+                });
             }
             // Method return / eviction family. `Ret` tears down the frame and
             // returns; `MethodRet` sets the resume PC then returns through the

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -165,20 +165,30 @@ impl Codegen {
             // Floating-point register transfer/convert family (aarch64 bails if
             // the FP pool register is not lowerable, hence the bool results).
             // `base` is the spill base; deopt is a side-exit label.
-            AsmInst::FprMove(src, dst) => {
-                return self.emit_fpr_move(src, dst, frame.base_stack_offset);
-            }
+            AsmInst::FprMove(src, dst) => self.encode_linst(LInst::FprMove {
+                src,
+                dst,
+                base: frame.base_stack_offset,
+            }),
             AsmInst::FprSwap(l, r) => return self.emit_fpr_swap(l, r, frame.base_stack_offset),
-            AsmInst::F64ToFpr(f, x) => return self.emit_f64_to_fpr(f, x, frame.base_stack_offset),
-            AsmInst::FixnumToFpr(r, x) => {
-                return self.emit_fixnum_to_fpr(r, x, frame.base_stack_offset);
-            }
+            AsmInst::F64ToFpr(f, x) => self.encode_linst(LInst::F64ToFpr {
+                f,
+                dst: x,
+                base: frame.base_stack_offset,
+            }),
+            AsmInst::FixnumToFpr(r, x) => self.encode_linst(LInst::FixnumToFpr {
+                src: r,
+                dst: x,
+                base: frame.base_stack_offset,
+            }),
             AsmInst::FloatToFpr(reg, x, deopt) => {
                 return self.emit_float_to_fpr(reg, x, &labels[deopt], frame.base_stack_offset);
             }
-            AsmInst::FprToStack(x, slot) => {
-                return self.emit_fpr_to_stack(x, slot, frame.base_stack_offset);
-            }
+            AsmInst::FprToStack(x, slot) => self.encode_linst(LInst::FprToStack {
+                src: x,
+                slot,
+                base: frame.base_stack_offset,
+            }),
             // Save / restore live FP pool registers around a C-call.
             AsmInst::XmmSave(using_xmm, cont) => return self.emit_xmm_save(using_xmm, cont),
             AsmInst::XmmRestore(using_xmm, cont) => return self.emit_xmm_restore(using_xmm, cont),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -200,8 +200,12 @@ impl Codegen {
                 base: frame.base_stack_offset,
             }),
             // Save / restore live FP pool registers around a C-call.
-            AsmInst::XmmSave(using_xmm, cont) => return self.emit_xmm_save(using_xmm, cont),
-            AsmInst::XmmRestore(using_xmm, cont) => return self.emit_xmm_restore(using_xmm, cont),
+            AsmInst::XmmSave(using_xmm, cont) => {
+                self.encode_linst(LInst::XmmSave { using_xmm, cont })
+            }
+            AsmInst::XmmRestore(using_xmm, cont) => {
+                self.encode_linst(LInst::XmmRestore { using_xmm, cont })
+            }
             // Integer / float arithmetic fast paths. Each backend resolves the
             // same operands and dispatches to its own emission primitive
             // (aarch64 bails on an unsupported BinOpK, hence the bool results).
@@ -665,13 +669,24 @@ impl Codegen {
             AsmInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
                 return self.emit_expand_array(dst, len, rest_pos, using_xmm);
             }
-            // Float C-function calls (Math.sqrt/sin/…). aarch64 saves the live
-            // FP pool (d2-d7) around the call and bails on a spilled operand.
-            AsmInst::CFunc_F_F { f, src, dst, using_xmm } => {
-                return self.emit_cfunc_f_f(f, src, dst, using_xmm, frame.base_stack_offset);
-            }
+            // Float C-function calls (Math.sqrt/sin/…): save the live FP pool
+            // around the call.
+            AsmInst::CFunc_F_F { f, src, dst, using_xmm } => self.encode_linst(LInst::CFunc_F_F {
+                f,
+                src,
+                dst,
+                using_xmm,
+                base: frame.base_stack_offset,
+            }),
             AsmInst::CFunc_FF_F { f, lhs, rhs, dst, using_xmm } => {
-                return self.emit_cfunc_ff_f(f, lhs, rhs, dst, using_xmm, frame.base_stack_offset);
+                self.encode_linst(LInst::CFunc_FF_F {
+                    f,
+                    lhs,
+                    rhs,
+                    dst,
+                    using_xmm,
+                    base: frame.base_stack_offset,
+                })
             }
             // Method definition (`def`). aarch64 bails on a live xmm pool reg.
             AsmInst::MethodDef { name, func_id, using_xmm, error } => {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -104,7 +104,19 @@ impl Codegen {
                 min,
                 else_label,
                 branch_labels,
-            } => self.emit_opt_case(frame, max, min, else_label, branch_labels),
+            } => {
+                let branch_dests: Box<[DestLabel]> = branch_labels
+                    .iter()
+                    .map(|l| frame.resolve_label(&mut self.jit, *l))
+                    .collect();
+                let else_dest = frame.resolve_label(&mut self.jit, else_label);
+                self.encode_linst(LInst::OptCase {
+                    max,
+                    min,
+                    else_dest,
+                    branch_dests,
+                });
+            }
             // Type guard: deopt if `r`'s runtime class is not `class`.
             AsmInst::GuardClass(r, class, deopt) => {
                 let deopt = labels[deopt].clone();
@@ -398,9 +410,23 @@ impl Codegen {
                 meta,
                 callid,
                 outer_lfp,
-            } => self.emit_setup_method_frame(store, meta, callid, outer_lfp),
+            } => {
+                let callsite = &store[callid];
+                let (block_fid, block_arg) = (callsite.block_fid, callsite.block_arg);
+                self.encode_linst(LInst::SetupMethodFrame {
+                    meta,
+                    outer_lfp,
+                    block_fid,
+                    block_arg,
+                });
+            }
             AsmInst::SetArguments { callid, callee_fid } => {
-                return self.emit_set_arguments(store, callid, callee_fid);
+                let offset = store[callee_fid].get_offset();
+                self.encode_linst(LInst::SetArguments {
+                    callid,
+                    callee_fid,
+                    offset,
+                });
             }
             // Basic-operator-redefinition guard: deopt if any BOP was redefined.
             AsmInst::CheckBOP { deopt } => {
@@ -446,8 +472,21 @@ impl Codegen {
                 info,
                 prologue_offset,
             }),
-            // Per-method ivar-cache prep; aarch64 bails on the heap-ivar path.
-            AsmInst::Preparation => return self.emit_preparation(store, frame),
+            // Per-method ivar-cache prep. The store/frame-dependent heap length
+            // is resolved here; the encoder only emits the table-extend guard.
+            AsmInst::Preparation => {
+                let heap_len = if !frame.self_class.is_always_frozen() && frame.ivar_heap_accessed {
+                    let ivar_len = store[frame.self_class].ivar_len();
+                    Some(if frame.self_ty == Some(ObjTy::OBJECT) {
+                        ivar_len - OBJECT_INLINE_IVAR
+                    } else {
+                        ivar_len
+                    })
+                } else {
+                    None
+                };
+                self.encode_linst(LInst::Preparation { heap_len });
+            }
             // Fixnum unary ops on the tagged value. Negate deopts on i63
             // overflow (e.g. -i63::MIN); bitwise-not cannot overflow.
             AsmInst::FixnumNeg { reg, deopt } => {
@@ -902,7 +941,11 @@ impl Codegen {
             // out-of-range frame offset).
             AsmInst::SetArgumentsForwardedHelper { callid, callee_fid } => {
                 let offset = store[callee_fid].get_offset();
-                return self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
+                self.encode_linst(LInst::SetArgumentsForwardedHelper {
+                    callid,
+                    callee_fid,
+                    offset,
+                });
             }
             // Trap for statically-unreachable code: call the panicking helper.
             AsmInst::Unreachable => self.encode_linst(LInst::Unreachable),
@@ -1149,6 +1192,39 @@ impl Codegen {
                 error,
             } => {
                 self.singleton_class_def(base, dst, func_id, using_xmm, &error);
+            }
+            LInst::SetupMethodFrame {
+                meta,
+                outer_lfp,
+                block_fid,
+                block_arg,
+            } => {
+                self.emit_setup_method_frame(meta, outer_lfp, block_fid, block_arg);
+            }
+            LInst::SetArguments {
+                callid,
+                callee_fid,
+                offset,
+            } => {
+                self.emit_set_arguments(callid, callee_fid, offset);
+            }
+            LInst::SetArgumentsForwardedHelper {
+                callid,
+                callee_fid,
+                offset,
+            } => {
+                self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
+            }
+            LInst::Preparation { heap_len } => {
+                self.emit_preparation(heap_len);
+            }
+            LInst::OptCase {
+                max,
+                min,
+                else_dest,
+                branch_dests,
+            } => {
+                self.emit_opt_case(max, min, else_dest, branch_dests);
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -347,7 +347,19 @@ impl Codegen {
             // Inline instance-variable / struct-member access on the receiver in
             // rdi (no Box deref). aarch64 bails if the field offset exceeds the
             // 12-bit scaled load/store immediate.
-            AsmInst::LoadIVarInline { ivarid } => return self.emit_load_ivar_inline(ivarid),
+            // Inline ivar load: `r15 <- self.@ivar` at a fixed field offset on
+            // the receiver (rdi); an unset slot reads as 0 and becomes nil.
+            AsmInst::LoadIVarInline { ivarid } => {
+                let disp = RVALUE_OFFSET_KIND as i32 + ivarid.get() as i32 * 8;
+                self.encode_linst(LInst::Load {
+                    dst: GP::R15,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp,
+                    },
+                });
+                self.encode_linst(LInst::NilIfZero { reg: GP::R15 });
+            }
             // Inline ivar store: `self.@ivar = src` at a fixed field offset on
             // the receiver (rdi), followed by the GC write barrier.
             AsmInst::StoreIVarInline { src, ivarid } => {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -601,14 +601,23 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
                 using_xmm,
-            } => return self.emit_store_ivar_heap(src, ivarid, is_object_ty, using_xmm),
+            } => self.encode_linst(LInst::StoreIVarHeap {
+                src,
+                ivarid,
+                is_object_ty,
+                using_xmm,
+            }),
             // Load a heap-spilled instance variable (bounds-checked unless self),
             // substituting nil for an out-of-range / unset slot.
             AsmInst::LoadIVarHeap {
                 ivarid,
                 is_object_ty,
                 self_,
-            } => return self.emit_load_ivar_heap(ivarid, is_object_ty, self_),
+            } => self.encode_linst(LInst::LoadIVarHeap {
+                ivarid,
+                is_object_ty,
+                self_,
+            }),
             // Runtime-call definition ops (undef a method / alias a global var).
             // aarch64 bails when an xmm pool register is live (no xmm save yet).
             AsmInst::UndefMethod { undef, using_xmm } => {
@@ -801,6 +810,34 @@ impl Codegen {
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }
         true
+    }
+
+    ///
+    /// Arch-neutral fallback of `encode_linst` for the macro-op `LInst`s — the
+    /// irreducible per-arch sequences that delegate to an existing `emit_*`
+    /// helper. Routing them here (rather than duplicating the delegation in each
+    /// backend's `encode_linst`) keeps the per-arch encoder for the decomposed
+    /// ops while still funnelling *all* emission through `encode_linst`.
+    ///
+    pub(in crate::codegen::jitgen) fn encode_linst_macro(&mut self, inst: LInst) {
+        match inst {
+            LInst::LoadIVarHeap {
+                ivarid,
+                is_object_ty,
+                self_,
+            } => {
+                self.emit_load_ivar_heap(ivarid, is_object_ty, self_);
+            }
+            LInst::StoreIVarHeap {
+                src,
+                ivarid,
+                is_object_ty,
+                using_xmm,
+            } => {
+                self.emit_store_ivar_heap(src, ivarid, is_object_ty, using_xmm);
+            }
+            other => unreachable!("encode_linst_macro: unexpected {other:?}"),
+        }
     }
 }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -95,18 +95,32 @@ impl Codegen {
                 });
             }
             // Unconditional jump to a side-exit (deopt) label.
-            AsmInst::Deopt(deopt) => self.emit_deopt(&labels[deopt]),
+            AsmInst::Deopt(deopt) => self.encode_linst(LInst::Deopt {
+                deopt: labels[deopt].clone(),
+            }),
             // Branch to the error handler if the preceding runtime call failed
             // (returned a null/None result in the accumulator).
-            AsmInst::HandleError(error) => self.emit_handle_error(&labels[error]),
+            AsmInst::HandleError(error) => self.encode_linst(LInst::HandleError {
+                error: labels[error].clone(),
+            }),
             // Stack-overflow check before establishing a callee frame (aarch64
             // bails if the write-back needs an unsupported feature).
             AsmInst::CheckStack { write_back, error } => {
-                return self.emit_check_stack(write_back, &labels[error], frame.base_stack_offset);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::CheckStack {
+                    write_back,
+                    error,
+                    base: frame.base_stack_offset,
+                });
             }
-            // GC safepoint (aarch64 bails like CheckStack).
+            // GC safepoint.
             AsmInst::ExecGc { write_back, error } => {
-                return self.emit_exec_gc(write_back, &labels[error], frame.base_stack_offset);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::ExecGc {
+                    write_back,
+                    error,
+                    base: frame.base_stack_offset,
+                });
             }
             // Constant base-class guard: deopt if the constant's base class (in
             // the accumulator) is not the cached one.
@@ -239,7 +253,7 @@ impl Codegen {
                 kind,
                 lhs,
                 rhs,
-            } => return self.emit_integer_cmp(kind, mode, lhs, rhs),
+            } => self.encode_linst(LInst::IntegerCmp { kind, mode, lhs, rhs }),
             // Fused integer compare + conditional branch, lowered to LIR here
             // (arch-neutral) and encoded per-arch. The compare sets flags; the
             // branch is a signed conditional jump with the BrKind inversion
@@ -339,10 +353,10 @@ impl Codegen {
             // block-break path (a non-local `break` out of a block);
             // `ImmediateEvict` records a return-address patch point on x86 (a
             // no-op on aarch64, which can't patch them).
-            AsmInst::Ret => self.emit_ret(),
-            AsmInst::MethodRet(pc) => self.emit_method_ret(pc),
-            AsmInst::BlockBreak(pc) => self.emit_block_break(pc),
-            AsmInst::ImmediateEvict { evict } => self.emit_immediate_evict(evict),
+            AsmInst::Ret => self.encode_linst(LInst::Ret),
+            AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet { pc }),
+            AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak { pc }),
+            AsmInst::ImmediateEvict { evict } => self.encode_linst(LInst::ImmediateEvict { evict }),
             // Method-call prologue: class-version guard, callee frame fields,
             // argument massage. (aarch64 SetArguments bails on a not-yet-ported
             // argument shape, hence the bool result; the guard ignores the x86
@@ -398,7 +412,10 @@ impl Codegen {
             AsmInst::Init {
                 info,
                 prologue_offset,
-            } => return self.emit_init(info, prologue_offset),
+            } => self.encode_linst(LInst::Init {
+                info,
+                prologue_offset,
+            }),
             // Per-method ivar-cache prep; aarch64 bails on the heap-ivar path.
             AsmInst::Preparation => return self.emit_preparation(store, frame),
             // Fixnum unary ops on the tagged value. Negate deopts on i63
@@ -532,7 +549,7 @@ impl Codegen {
             AsmInst::RegSub(reg, i) => self.emit_reg_sub(reg, i),
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
             // the 12-bit sub-sp immediate).
-            AsmInst::LoopJitRspBump { offset } => return self.emit_loop_jit_rsp_bump(offset),
+            AsmInst::LoopJitRspBump { offset } => self.encode_linst(LInst::LoopJitRspBump { offset }),
             // Inline argument-setup stores into the callee frame, at a
             // (raw) rsp-relative offset the encoder legalizes per arch.
             AsmInst::RegToRSPOffset(r, ofs) => self.encode_linst(LInst::Store {
@@ -555,9 +572,15 @@ impl Codegen {
             }
             // `&block` forwarding: proxy the block handler, or materialize it
             // into a Proc value (aarch64 bails on a live xmm / range overflow).
-            AsmInst::BlockArgProxy { ret, outer } => return self.emit_block_arg_proxy(ret, outer),
+            AsmInst::BlockArgProxy { ret, outer } => self.encode_linst(LInst::BlockArgProxy { ret, outer }),
             AsmInst::BlockArg { ret, _outer: _, using_xmm, error, call_site_bc_ptr } => {
-                return self.emit_block_arg(ret, using_xmm, call_site_bc_ptr, &labels[error]);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::BlockArg {
+                    ret,
+                    using_xmm,
+                    call_site_bc_ptr,
+                    error,
+                });
             }
             // Store into a heap-spilled instance variable of self (the table is
             // known large enough, so no bounds check / runtime extend).
@@ -707,23 +730,52 @@ impl Codegen {
             }
             // Method definition (`def`). aarch64 bails on a live xmm pool reg.
             AsmInst::MethodDef { name, func_id, using_xmm, error } => {
-                return self.emit_method_def(name, func_id, using_xmm, &labels[error]);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::MethodDef {
+                    name,
+                    func_id,
+                    using_xmm,
+                    error,
+                });
             }
             AsmInst::SingletonMethodDef { obj, name, func_id, using_xmm, error } => {
-                return self.emit_singleton_method_def(obj, name, func_id, using_xmm, &labels[error]);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::SingletonMethodDef {
+                    obj,
+                    name,
+                    func_id,
+                    using_xmm,
+                    error,
+                });
             }
             // Exception / non-local control flow (raise / retry / redo / ensure).
             // All branch into the shared entry_raise unwind path.
-            AsmInst::Raise => return self.emit_raise(frame.loop_jit_spill_bytes),
-            AsmInst::Retry(pc) => return self.emit_retry(pc, frame.loop_jit_spill_bytes),
-            AsmInst::Redo(pc) => return self.emit_redo(pc, frame.loop_jit_spill_bytes),
-            AsmInst::EnsureEnd => return self.emit_ensure_end(frame.loop_jit_spill_bytes),
+            AsmInst::Raise => self.encode_linst(LInst::Raise {
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
+            AsmInst::Retry(pc) => self.encode_linst(LInst::Retry {
+                pc,
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
+            AsmInst::Redo(pc) => self.encode_linst(LInst::Redo {
+                pc,
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
+            AsmInst::EnsureEnd => self.encode_linst(LInst::EnsureEnd {
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
             // Generic `yield` (block target resolved at runtime). aarch64 builds
             // the block frame and calls the funcdata indirectly; the x86-only
             // return-address eviction patch is applied by the x86 emit_yield.
             AsmInst::Yield { callid, error, evict } => {
                 let evict_label = labels[evict].clone();
-                return self.emit_yield(callid, &labels[error], evict, &evict_label);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::Yield {
+                    callid,
+                    error,
+                    evict,
+                    evict_label,
+                });
             }
             // ---- Specialized inlined-frame family ------------------------------
             // These lower an inlined callee / block frame. Each arm is identical
@@ -807,10 +859,10 @@ impl Codegen {
                 return self.jit_set_arguments_forwarded_helper(callid, callee_fid, offset);
             }
             // Trap for statically-unreachable code: call the panicking helper.
-            AsmInst::Unreachable => self.emit_unreachable(),
+            AsmInst::Unreachable => self.encode_linst(LInst::Unreachable),
             // `**kwrest` fixup: build a (name, slot) const table and call
             // `correct_rest_kw(&table, lfp) -> kwrest Hash`.
-            AsmInst::RestKw { rest_kw } => self.emit_rest_kw(rest_kw),
+            AsmInst::RestKw { rest_kw } => self.encode_linst(LInst::RestKw { rest_kw }),
             // Not a shared instruction: hand off to the per-arch backend.
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }
@@ -939,6 +991,72 @@ impl Codegen {
             }
             LInst::ExpandArray { dst, len, rest_pos, using_xmm } => {
                 self.emit_expand_array(dst, len, rest_pos, using_xmm);
+            }
+            LInst::Deopt { deopt } => {
+                self.emit_deopt(&deopt);
+            }
+            LInst::HandleError { error } => {
+                self.emit_handle_error(&error);
+            }
+            LInst::CheckStack { write_back, error, base } => {
+                self.emit_check_stack(write_back, &error, base);
+            }
+            LInst::ExecGc { write_back, error, base } => {
+                self.emit_exec_gc(write_back, &error, base);
+            }
+            LInst::IntegerCmp { kind, mode, lhs, rhs } => {
+                self.emit_integer_cmp(kind, mode, lhs, rhs);
+            }
+            LInst::Ret => {
+                self.emit_ret();
+            }
+            LInst::MethodRet { pc } => {
+                self.emit_method_ret(pc);
+            }
+            LInst::BlockBreak { pc } => {
+                self.emit_block_break(pc);
+            }
+            LInst::ImmediateEvict { evict } => {
+                self.emit_immediate_evict(evict);
+            }
+            LInst::Init { info, prologue_offset } => {
+                self.emit_init(info, prologue_offset);
+            }
+            LInst::LoopJitRspBump { offset } => {
+                self.emit_loop_jit_rsp_bump(offset);
+            }
+            LInst::BlockArgProxy { ret, outer } => {
+                self.emit_block_arg_proxy(ret, outer);
+            }
+            LInst::BlockArg { ret, using_xmm, call_site_bc_ptr, error } => {
+                self.emit_block_arg(ret, using_xmm, call_site_bc_ptr, &error);
+            }
+            LInst::MethodDef { name, func_id, using_xmm, error } => {
+                self.emit_method_def(name, func_id, using_xmm, &error);
+            }
+            LInst::SingletonMethodDef { obj, name, func_id, using_xmm, error } => {
+                self.emit_singleton_method_def(obj, name, func_id, using_xmm, &error);
+            }
+            LInst::Raise { loop_jit_spill_bytes } => {
+                self.emit_raise(loop_jit_spill_bytes);
+            }
+            LInst::Retry { pc, loop_jit_spill_bytes } => {
+                self.emit_retry(pc, loop_jit_spill_bytes);
+            }
+            LInst::Redo { pc, loop_jit_spill_bytes } => {
+                self.emit_redo(pc, loop_jit_spill_bytes);
+            }
+            LInst::EnsureEnd { loop_jit_spill_bytes } => {
+                self.emit_ensure_end(loop_jit_spill_bytes);
+            }
+            LInst::Yield { callid, error, evict, evict_label } => {
+                self.emit_yield(callid, &error, evict, &evict_label);
+            }
+            LInst::Unreachable => {
+                self.emit_unreachable();
+            }
+            LInst::RestKw { rest_kw } => {
+                self.emit_rest_kw(rest_kw);
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -11,6 +11,7 @@
 //! instruction family at a time; see `doc/aarch64-x86-jit-differences.md`.
 
 use super::*;
+use crate::codegen::jitgen::lir::{LCond, LInst, LOperand};
 
 impl Codegen {
     ///
@@ -188,6 +189,10 @@ impl Codegen {
                 lhs,
                 rhs,
             } => return self.emit_integer_cmp(kind, mode, lhs, rhs),
+            // Fused integer compare + conditional branch, lowered to LIR here
+            // (arch-neutral) and encoded per-arch. The compare sets flags; the
+            // branch is a signed conditional jump with the BrKind inversion
+            // folded into the condition.
             AsmInst::IntegerCmpBr {
                 mode,
                 kind,
@@ -196,8 +201,36 @@ impl Codegen {
                 brkind,
                 branch_dest,
             } => {
-                let branch_dest = frame.resolve_label(&mut self.jit, branch_dest);
-                return self.emit_integer_cmp_br(kind, mode, lhs, rhs, brkind, branch_dest);
+                let target = frame.resolve_label(&mut self.jit, branch_dest);
+                match mode {
+                    OpMode::RR(..) => self.encode_linst(LInst::Cmp {
+                        lhs,
+                        rhs: LOperand::Reg(rhs),
+                    }),
+                    OpMode::RI(_, i) => self.encode_linst(LInst::Cmp {
+                        lhs,
+                        rhs: LOperand::Imm(Value::i32(i as i32).id() as i64),
+                    }),
+                    // imm on the left: materialize it into lhs, then compare
+                    // reg-reg (mirrors `cmp_integer`'s IR path, which clobbers
+                    // lhs).
+                    OpMode::IR(i, _) => {
+                        self.encode_linst(LInst::LoadImm {
+                            dst: lhs,
+                            imm: Value::i32(i as i32).id(),
+                        });
+                        self.encode_linst(LInst::Cmp {
+                            lhs,
+                            rhs: LOperand::Reg(rhs),
+                        });
+                    }
+                }
+                // TEq compares like Eq for integers; BrIfNot takes the inverse.
+                let mut cond = LCond::from_int_cmp(kind).unwrap_or(LCond::Eq);
+                if brkind == BrKind::BrIfNot {
+                    cond = cond.invert();
+                }
+                self.encode_linst(LInst::CondBr { cond, target });
             }
             AsmInst::FloatBinOp {
                 kind,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -348,8 +348,21 @@ impl Codegen {
             // rdi (no Box deref). aarch64 bails if the field offset exceeds the
             // 12-bit scaled load/store immediate.
             AsmInst::LoadIVarInline { ivarid } => return self.emit_load_ivar_inline(ivarid),
+            // Inline ivar store: `self.@ivar = src` at a fixed field offset on
+            // the receiver (rdi), followed by the GC write barrier.
             AsmInst::StoreIVarInline { src, ivarid } => {
-                return self.emit_store_ivar_inline(src, ivarid);
+                let disp = RVALUE_OFFSET_KIND as i32 + ivarid.get() as i32 * 8;
+                self.encode_linst(LInst::Store {
+                    src,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp,
+                    },
+                });
+                self.encode_linst(LInst::WriteBarrier {
+                    parent: GP::Rdi,
+                    value: src,
+                });
             }
             // Inline struct-member load: `r15 <- self.@slot` at a fixed field
             // offset on the receiver (rdi). Lowered to a field load whose
@@ -364,8 +377,25 @@ impl Codegen {
                     },
                 });
             }
+            // Inline struct-member store: field store + write barrier, with the
+            // stored value also returned in the accumulator (rax).
             AsmInst::StoreStructSlotInline { src, slot_index } => {
-                return self.emit_store_struct_slot_inline(src, slot_index);
+                let disp = slot_index as i32 * 8 + RVALUE_OFFSET_INLINE as i32;
+                self.encode_linst(LInst::Store {
+                    src,
+                    mem: LMem::Field {
+                        base: GP::Rdi,
+                        disp,
+                    },
+                });
+                self.encode_linst(LInst::WriteBarrier {
+                    parent: GP::Rdi,
+                    value: src,
+                });
+                self.encode_linst(LInst::Mov {
+                    dst: GP::Rax,
+                    src,
+                });
             }
             // Heap (Box-spilled) Struct member access: deref the heap pointer
             // first, then load/store the slot (aarch64 bails on a large offset).

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -460,7 +460,21 @@ impl Codegen {
                 pc,
             } => {
                 let evict_label = labels[evict].clone();
-                self.emit_call(store, callee_fid, recv_class, evict, &evict_label, pc);
+                let callee = &store[callee_fid];
+                let is_iseq = callee.is_iseq();
+                let (_, codeptr, callee_pc) = callee.get_data();
+                // x86 JIT-entry lookup (aarch64 ignores it; the lookup is a
+                // side-effect-free table read, so pre-resolving here is safe).
+                let jit_entry = is_iseq.and_then(|iseq| store[iseq].get_jit_entry(recv_class));
+                self.encode_linst(LInst::Call {
+                    codeptr,
+                    is_iseq: is_iseq.is_some(),
+                    callee_pc,
+                    call_site_bc_ptr: pc,
+                    jit_entry,
+                    evict,
+                    evict_label,
+                });
             }
             // Method prologue: establish fp/lr, reserve the local frame, nil-fill
             // non-argument locals (aarch64 bails if the frame exceeds the 12-bit
@@ -1225,6 +1239,25 @@ impl Codegen {
                 branch_dests,
             } => {
                 self.emit_opt_case(max, min, else_dest, branch_dests);
+            }
+            LInst::Call {
+                codeptr,
+                is_iseq,
+                callee_pc,
+                call_site_bc_ptr,
+                jit_entry,
+                evict,
+                evict_label,
+            } => {
+                self.emit_call(
+                    codeptr,
+                    is_iseq,
+                    callee_pc,
+                    call_site_bc_ptr,
+                    jit_entry,
+                    evict,
+                    &evict_label,
+                );
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -126,42 +126,51 @@ impl Codegen {
             // Store to a constant, bumping the global constant version (aarch64
             // bails if any xmm is live, hence the bool result).
             AsmInst::StoreConstant { id, using_xmm, error } => {
-                return self.emit_store_constant(id, using_xmm, &labels[error]);
+                let error = labels[error].clone();
+                self.encode_linst(LInst::StoreConstant { id, using_xmm, error })
             }
-            // Variable access (aarch64 bails on a live xmm / range overflow,
-            // hence the bool results). gvar/cvar go via a runtime call; dynvar
-            // walks the outer-LFP chain.
-            AsmInst::LoadGVar { name, using_xmm } => return self.emit_load_gvar(name, using_xmm),
+            // Variable access. gvar/cvar go via a runtime call; dynvar walks the
+            // outer-LFP chain.
+            AsmInst::LoadGVar { name, using_xmm } => {
+                self.encode_linst(LInst::LoadGVar { name, using_xmm })
+            }
             AsmInst::StoreGVar { name, src, using_xmm } => {
-                return self.emit_store_gvar(name, src, using_xmm);
+                self.encode_linst(LInst::StoreGVar { name, src, using_xmm })
             }
-            AsmInst::LoadCVar { name, using_xmm } => return self.emit_load_cvar(name, using_xmm),
-            AsmInst::LoadDynVar { src } => return self.emit_load_dyn_var(src),
-            AsmInst::StoreDynVar { dst, src } => return self.emit_store_dyn_var(dst, src),
-            // Runtime allocation / C-call family: each builds a heap object via
-            // a runtime call (aarch64 bails on a live xmm / range overflow,
-            // hence the bool results).
-            AsmInst::CreateArray { src, len } => return self.emit_create_array(src, len),
+            AsmInst::LoadCVar { name, using_xmm } => {
+                self.encode_linst(LInst::LoadCVar { name, using_xmm })
+            }
+            AsmInst::LoadDynVar { src } => self.encode_linst(LInst::LoadDynVar { src }),
+            AsmInst::StoreDynVar { dst, src } => {
+                self.encode_linst(LInst::StoreDynVar { dst, src })
+            }
+            // Runtime allocation / C-call family: each builds a heap object via a
+            // runtime call.
+            AsmInst::CreateArray { src, len } => {
+                self.encode_linst(LInst::CreateArray { src, len })
+            }
             AsmInst::NewArray { callid, using_xmm } => {
-                return self.emit_new_array(callid, using_xmm);
+                self.encode_linst(LInst::NewArray { callid, using_xmm })
             }
             AsmInst::NewHash(args, len, using_xmm) => {
-                return self.emit_new_hash(args, len, using_xmm);
+                self.encode_linst(LInst::NewHash { args, len, using_xmm })
             }
             AsmInst::HashInsert { hash, args, len, using_xmm } => {
-                return self.emit_hash_insert(hash, args, len, using_xmm);
+                self.encode_linst(LInst::HashInsert { hash, args, len, using_xmm })
             }
             AsmInst::ArrayConcat { dst, src, using_xmm } => {
-                return self.emit_array_concat(dst, src, using_xmm);
+                self.encode_linst(LInst::ArrayConcat { dst, src, using_xmm })
             }
             AsmInst::NewRange { start, end, exclude_end, using_xmm } => {
-                return self.emit_new_range(start, end, exclude_end, using_xmm);
+                self.encode_linst(LInst::NewRange { start, end, exclude_end, using_xmm })
             }
             AsmInst::ConcatStr { arg, len, using_xmm } => {
-                return self.emit_concat_str(arg, len, using_xmm);
+                self.encode_linst(LInst::ConcatStr { arg, len, using_xmm })
             }
-            AsmInst::ToA { src, using_xmm } => return self.emit_to_a(src, using_xmm),
-            AsmInst::DeepCopyLit(v, using_xmm) => return self.emit_deep_copy_lit(v, using_xmm),
+            AsmInst::ToA { src, using_xmm } => self.encode_linst(LInst::ToA { src, using_xmm }),
+            AsmInst::DeepCopyLit(v, using_xmm) => {
+                self.encode_linst(LInst::DeepCopyLit { v, using_xmm })
+            }
             // Floating-point register transfer/convert family (aarch64 bails if
             // the FP pool register is not lowerable, hence the bool results).
             // `base` is the spill base; deopt is a side-exit label.
@@ -835,6 +844,51 @@ impl Codegen {
                 using_xmm,
             } => {
                 self.emit_store_ivar_heap(src, ivarid, is_object_ty, using_xmm);
+            }
+            LInst::StoreConstant { id, using_xmm, error } => {
+                self.emit_store_constant(id, using_xmm, &error);
+            }
+            LInst::LoadGVar { name, using_xmm } => {
+                self.emit_load_gvar(name, using_xmm);
+            }
+            LInst::StoreGVar { name, src, using_xmm } => {
+                self.emit_store_gvar(name, src, using_xmm);
+            }
+            LInst::LoadCVar { name, using_xmm } => {
+                self.emit_load_cvar(name, using_xmm);
+            }
+            LInst::LoadDynVar { src } => {
+                self.emit_load_dyn_var(src);
+            }
+            LInst::StoreDynVar { dst, src } => {
+                self.emit_store_dyn_var(dst, src);
+            }
+            LInst::CreateArray { src, len } => {
+                self.emit_create_array(src, len);
+            }
+            LInst::NewArray { callid, using_xmm } => {
+                self.emit_new_array(callid, using_xmm);
+            }
+            LInst::NewHash { args, len, using_xmm } => {
+                self.emit_new_hash(args, len, using_xmm);
+            }
+            LInst::HashInsert { hash, args, len, using_xmm } => {
+                self.emit_hash_insert(hash, args, len, using_xmm);
+            }
+            LInst::ArrayConcat { dst, src, using_xmm } => {
+                self.emit_array_concat(dst, src, using_xmm);
+            }
+            LInst::NewRange { start, end, exclude_end, using_xmm } => {
+                self.emit_new_range(start, end, exclude_end, using_xmm);
+            }
+            LInst::ConcatStr { arg, len, using_xmm } => {
+                self.emit_concat_str(arg, len, using_xmm);
+            }
+            LInst::ToA { src, using_xmm } => {
+                self.emit_to_a(src, using_xmm);
+            }
+            LInst::DeepCopyLit { v, using_xmm } => {
+                self.emit_deep_copy_lit(v, using_xmm);
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),
         }

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -394,8 +394,11 @@ impl Codegen {
             AsmInst::Preparation => return self.emit_preparation(store, frame),
             // Fixnum unary ops on the tagged value. Negate deopts on i63
             // overflow (e.g. -i63::MIN); bitwise-not cannot overflow.
-            AsmInst::FixnumNeg { reg, deopt } => self.emit_fixnum_neg(reg, &labels[deopt]),
-            AsmInst::FixnumBitNot { reg } => self.emit_fixnum_bit_not(reg),
+            AsmInst::FixnumNeg { reg, deopt } => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::FixnumNeg { reg, deopt });
+            }
+            AsmInst::FixnumBitNot { reg } => self.encode_linst(LInst::FixnumBitNot { reg }),
             // Type guards: deopt unless `reg` is an Array / the receiver in rdi
             // is unfrozen.
             AsmInst::GuardArrayTy(reg, deopt) => {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -912,6 +912,16 @@ impl Codegen {
             // Inlined builtin method body: the generator closure emits the
             // arch-appropriate asm directly.
             AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
+            // Typed field-load (replaces the `ir.inline` escape hatch for trivial
+            // field-reader inline builtins). Goal-2 proof: an inline builtin's
+            // codegen expressed once in arch-neutral LIR via an existing op.
+            AsmInst::LoadFieldToReg { dst, base, disp } => self.encode_linst(LInst::Load {
+                dst: dst.into(),
+                mem: LMem::Field {
+                    base: base.into(),
+                    disp,
+                },
+            }),
             // ---- Class/module definition + misc runtime-call ops --------------
             // `class`/`module` (re)definition + body, and `class << obj`. aarch64
             // bails on a live xmm pool reg / out-of-range frame offset.

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -165,6 +165,15 @@ pub(super) struct AsmInfo {
     /// Destination labels for each BasicBlock.
     ///
     basic_block_labels: HashMap<BasicBlockId, JitLabel>,
+    ///
+    /// Jump-threading aliases: a `JitLabel` mapped here resolves to its
+    /// target instead of itself. Populated for the entry labels of
+    /// *empty* outline bridges (a `Side` edge whose write-back glue is a
+    /// no-op): rather than emit a one-instruction `b dest_bb` forwarder,
+    /// the branch that targeted the bridge resolves straight to the
+    /// destination block. `resolve_label` chases the chain.
+    ///
+    label_alias: HashMap<JitLabel, JitLabel>,
 
     ///
     /// Generated AsmIr.
@@ -236,6 +245,7 @@ impl AsmInfo {
             self_ty: self.self_ty,
             labels: self.labels.clone(),
             basic_block_labels: self.basic_block_labels.clone(),
+            label_alias: HashMap::default(),
             ir: vec![],
             outline_bridges: vec![],
             inline_bridges: HashMap::default(),
@@ -262,6 +272,18 @@ impl AsmInfo {
     /// Resolve *JitLabel* and return *DestLabel*.
     ///
     pub(super) fn resolve_label(&mut self, jit: &mut JitMemory, label: JitLabel) -> DestLabel {
+        // Follow jump-threading aliases first (bounded: aliases only ever
+        // point at a real BB label, which is never itself aliased, so the
+        // chain is at most one hop — the loop is just defensive).
+        let mut label = label;
+        let mut guard = self.label_alias.len() + 1;
+        while let Some(&next) = self.label_alias.get(&label) {
+            label = next;
+            guard -= 1;
+            if guard == 0 {
+                break;
+            }
+        }
         match &self.labels[label.0] {
             Some(l) => l.clone(),
             None => {
@@ -270,6 +292,28 @@ impl AsmInfo {
                 l
             }
         }
+    }
+
+    ///
+    /// Partition the outline bridges into *empty* (no write-back glue) and
+    /// the rest. For each empty one, install a jump-threading alias from the
+    /// bridge's entry label to its destination block, so the branch that
+    /// targeted the bridge resolves straight through (the empty `b dest_bb`
+    /// forwarder is never emitted). Returns the non-empty bridges, which the
+    /// caller still emits.
+    ///
+    pub(super) fn thread_empty_outline_bridges(&mut self) -> Vec<(AsmIr, JitLabel, BasicBlockId)> {
+        let bridges = std::mem::take(&mut self.outline_bridges);
+        let mut keep = Vec::with_capacity(bridges.len());
+        for (ir, dest, bbid) in bridges {
+            if ir.is_empty() {
+                let target = self.basic_block_labels.get(&bbid).copied().unwrap();
+                self.label_alias.insert(dest, target);
+            } else {
+                keep.push((ir, dest, bbid));
+            }
+        }
+        keep
     }
 
     pub(super) fn resolve_bb_label(&mut self, jit: &mut JitMemory, bb: BasicBlockId) -> DestLabel {
@@ -282,10 +326,6 @@ impl AsmInfo {
     }
 
     // bridge operations
-
-    pub(super) fn detach_outline_bridges(&mut self) -> Vec<(AsmIr, JitLabel, BasicBlockId)> {
-        std::mem::take(&mut self.outline_bridges)
-    }
 
     pub(super) fn inline_bridge_exists(&self, src_bb: BasicBlockId) -> bool {
         self.inline_bridges.contains_key(&Some(src_bb))
@@ -491,6 +531,7 @@ impl JitStackFrame {
                 self_ty,
                 labels,
                 basic_block_labels,
+                label_alias: HashMap::default(),
                 ir: vec![],
                 outline_bridges: vec![],
                 inline_bridges: HashMap::default(),

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -301,22 +301,20 @@ impl Lir {
     }
 }
 
-/// The per-arch lowering seam that Stage 2 implements on `Codegen`.
-///
-/// Each backend provides one `encode` that pattern-matches an `LInst` and emits
-/// the corresponding `monoasm!` / `monoasm_arm64!` bytes, performing immediate
-/// and displacement **legalization** in the process. It is declared here (and
-/// left unimplemented) so the intended contract is visible alongside the data
-/// model; no `impl` is provided yet, so this remains pure scaffolding.
-///
-/// ```ignore
-/// pub(in crate::codegen::jitgen) trait LirEncode {
-///     /// Emit one already-register-allocated `LInst`. The encoder may use the
-///     /// arch's reserved scratch registers (x9/x10 on aarch64) freely.
-///     fn encode(&mut self, inst: &LInst, labels: &SideExitLabels);
-/// }
-/// ```
-const _: () = ();
+// ## The per-arch lowering seam
+//
+// The encoder is an inherent `Codegen::encode_linst(inst: LInst)` method,
+// defined once per arch in the file that the `compile` module includes for the
+// active `target_arch` (`arch/x86_64/compile/mod.rs` emits via `monoasm!`;
+// `arch/aarch64/compile.rs` via `monoasm_arm64!`). Because only one of those
+// files compiles per target, no trait/dynamic dispatch is needed — the right
+// `encode_linst` is selected by `cfg`. Each backend pattern-matches an `LInst`,
+// performs immediate/displacement **legalization** (folding small immediates,
+// materializing large ones into scratch x9/x10 on aarch64), and emits
+// byte-identical output to the `emit_*` primitive it replaces.
+//
+// Stage 2-A wires only the `Mov` family (behind `emit_reg_move`); the remaining
+// variants `todo!()` until their `AsmInst` family is migrated.
 
 #[cfg(test)]
 mod tests {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -43,7 +43,7 @@
 
 use super::*;
 use crate::ast::CmpKind;
-use crate::bytecodegen::BinOpK;
+use crate::bytecodegen::{BinOpK, UnOpK};
 
 /// A general-purpose-register operand or an inline integer immediate.
 ///
@@ -343,6 +343,39 @@ pub(in crate::codegen::jitgen) enum LInst {
         i: i64,
         slot: SlotId,
         dst: FPReg,
+        base: usize,
+    },
+    /// `dst <- lhs <op> rhs` in FP registers (the four arithmetic ops).
+    FloatBinOp {
+        kind: BinOpK,
+        lhs: FPReg,
+        rhs: FPReg,
+        dst: FPReg,
+        base: usize,
+    },
+    /// `dst <- <op> dst` in an FP register (`Neg` flips the sign bit; `Pos` is a
+    /// no-op).
+    FloatUnOp {
+        kind: UnOpK,
+        dst: FPReg,
+        base: usize,
+    },
+    /// Float comparison producing a Ruby boolean in the accumulator. NaN
+    /// compares false for every operator except `!=`; the encoder picks
+    /// NaN-correct condition codes per arch.
+    FloatCmp {
+        kind: CmpKind,
+        lhs: FPReg,
+        rhs: FPReg,
+        base: usize,
+    },
+    /// Fused float compare + conditional branch to `dest` (NaN-correct).
+    FloatCmpBr {
+        kind: CmpKind,
+        lhs: FPReg,
+        rhs: FPReg,
+        brkind: BrKind,
+        dest: DestLabel,
         base: usize,
     },
 }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -298,6 +298,31 @@ pub(in crate::codegen::jitgen) enum LInst {
         rhs: GP,
         deopt: DestLabel,
     },
+    // ---- floating-point transfer / convert -----------------------------------
+    // FP operands are virtual `FPReg`s (physical xmm/d-reg or a stack spill); the
+    // encoders resolve the spill via `FPReg::loc(base)`, so these carry the
+    // frame's `base` spill offset.
+    /// `dst <- src` between FP registers (spill-aware; no-op when equal).
+    FprMove {
+        src: FPReg,
+        dst: FPReg,
+        base: usize,
+    },
+    /// `dst <- f` — materialize an f64 constant into an FP register.
+    F64ToFpr { f: f64, dst: FPReg, base: usize },
+    /// `dst <- (src as fixnum) as f64` — untag and convert.
+    FixnumToFpr {
+        src: GP,
+        dst: FPReg,
+        base: usize,
+    },
+    /// `[slot] <- Value::float(src)` — box the FP register into a `Value` and
+    /// store it to a frame slot.
+    FprToStack {
+        src: FPReg,
+        slot: SlotId,
+        base: usize,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -793,6 +793,24 @@ pub(in crate::codegen::jitgen) enum LInst {
         else_dest: DestLabel,
         branch_dests: Box<[DestLabel]>,
     },
+    /// The call itself. Store/frame-dependent target info is pre-resolved by the
+    /// dispatcher. x86 dispatches to a JIT entry (`jit_entry`) when present and
+    /// records a return-address deopt patch point (`evict` / `evict_label`);
+    /// aarch64 always calls `codeptr` and ignores those fields (class-version
+    /// guards cover it).
+    Call {
+        /// callee entry code pointer (`store[callee_fid].get_data()`).
+        codeptr: CodePtr,
+        is_iseq: bool,
+        /// callee's own pc (iseq callees), used when there is no JIT entry.
+        callee_pc: Option<BytecodePtrBase>,
+        /// call-site bytecode pointer (passed to with-pc builtins).
+        call_site_bc_ptr: BytecodePtr,
+        /// x86 JIT entry for this recv_class (`store[iseq].get_jit_entry`).
+        jit_entry: Option<DestLabel>,
+        evict: AsmEvict,
+        evict_label: DestLabel,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -220,6 +220,14 @@ pub(in crate::codegen::jitgen) enum LInst {
     Br(DestLabel),
     /// Branch to `target` when the preceding `Cmp` satisfied `cond`.
     CondBr { cond: LCond, target: DestLabel },
+    /// Branch to `target` on the Ruby truthiness of the accumulator (everything
+    /// except `nil`/`false` is truthy). `negate` branches on *falsy* instead.
+    BranchTruthy { negate: bool, target: DestLabel },
+    /// Branch to `target` if the accumulator is `nil`.
+    BranchIfNil { target: DestLabel },
+    /// Branch to `target` if the accumulator is non-zero (e.g. an already-set
+    /// local slot).
+    BranchIfNonzero { target: DestLabel },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -211,17 +211,32 @@ impl LAluOp {
 #[derive(Debug, Clone)]
 pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
-    Mov { dst: GP, src: GP },
+    Mov {
+        dst: GP,
+        src: GP,
+    },
     /// `dst <- imm` — materialize a full 64-bit immediate (e.g. a tagged
     /// `Value`'s bit pattern) into a register.
-    LoadImm { dst: GP, imm: u64 },
+    LoadImm {
+        dst: GP,
+        imm: u64,
+    },
     /// `dst <- [mem]`. `dst` may be the scratch pointer (intermediate deref).
-    Load { dst: LReg, mem: LMem },
+    Load {
+        dst: LReg,
+        mem: LMem,
+    },
     /// `[mem] <- src`.
-    Store { src: GP, mem: LMem },
+    Store {
+        src: GP,
+        mem: LMem,
+    },
     /// `[mem] <- imm`. aarch64 has no store-immediate, so the encoder routes it
     /// through a scratch register without clobbering any allocated GP.
-    StoreImm { imm: u64, mem: LMem },
+    StoreImm {
+        imm: u64,
+        mem: LMem,
+    },
     /// `dst <- lhs <op> rhs`.
     Alu {
         op: LAluOp,
@@ -232,31 +247,49 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// Set condition flags from `lhs - rhs` (no result register written). The
     /// immediate of an `Imm` rhs is the operand's raw bit pattern (e.g. a tagged
     /// fixnum `Value`), compared against the raw register bits.
-    Cmp { lhs: GP, rhs: LOperand },
+    Cmp {
+        lhs: GP,
+        rhs: LOperand,
+    },
     /// Bind `label` at the current code position.
     Label(DestLabel),
     /// Unconditional branch to `target`.
     Br(DestLabel),
     /// Branch to `target` when the preceding `Cmp` satisfied `cond`.
-    CondBr { cond: LCond, target: DestLabel },
+    CondBr {
+        cond: LCond,
+        target: DestLabel,
+    },
     /// Branch to `target` on the Ruby truthiness of the accumulator (everything
     /// except `nil`/`false` is truthy). `negate` branches on *falsy* instead.
-    BranchTruthy { negate: bool, target: DestLabel },
+    BranchTruthy {
+        negate: bool,
+        target: DestLabel,
+    },
     /// Branch to `target` if the accumulator is `nil`.
-    BranchIfNil { target: DestLabel },
+    BranchIfNil {
+        target: DestLabel,
+    },
     /// Branch to `target` if the accumulator is non-zero (e.g. an already-set
     /// local slot).
-    BranchIfNonzero { target: DestLabel },
+    BranchIfNonzero {
+        target: DestLabel,
+    },
     /// Generational-GC write barrier after storing `value` into a field of the
     /// heap object `parent`: if `parent` is an old object not yet remembered and
     /// `value` is a heap pointer, record `parent` in the remembered set. A
     /// macro-op — the encoder emits the arch's inline fast-path + slow-path call
     /// (x86 fixes `parent` in rdi).
-    WriteBarrier { parent: GP, value: GP },
+    WriteBarrier {
+        parent: GP,
+        value: GP,
+    },
     /// `reg <- nil` if `reg == 0` (an unset inline-ivar slot reads as 0). The
     /// arches differ structurally — x86 branches over a `mov`, aarch64 uses a
     /// branchless `csel` — so this is its own op rather than a Load + branch.
-    NilIfZero { reg: GP },
+    NilIfZero {
+        reg: GP,
+    },
     /// Class guard: branch to the side-exit `deopt` unless `reg`'s runtime class
     /// is `class`. `deopt` is a resolved side-exit label (the deopt model:
     /// guards carry the side-exit they fall through to).
@@ -266,9 +299,14 @@ pub(in crate::codegen::jitgen) enum LInst {
         deopt: DestLabel,
     },
     /// Type guard: deopt unless `reg` holds an `Array`.
-    GuardArrayTy { reg: GP, deopt: DestLabel },
+    GuardArrayTy {
+        reg: GP,
+        deopt: DestLabel,
+    },
     /// Deopt if the receiver (rdi) is frozen.
-    GuardFrozen { deopt: DestLabel },
+    GuardFrozen {
+        deopt: DestLabel,
+    },
     /// Constant-load guard: deopt unless the cached base class (in the
     /// accumulator) equals `base_class`.
     GuardConstBaseClass {
@@ -283,9 +321,13 @@ pub(in crate::codegen::jitgen) enum LInst {
     },
     /// Block-passing side-effect guard: deopt if the current frame was captured
     /// or invalidated.
-    GuardCapture { deopt: DestLabel },
+    GuardCapture {
+        deopt: DestLabel,
+    },
     /// Basic-operator-redefinition guard: deopt if any BOP was redefined.
-    CheckBOP { deopt: DestLabel },
+    CheckBOP {
+        deopt: DestLabel,
+    },
     /// Fixnum fast-path arithmetic (`lhs <op> rhs`) on tagged integers, with an
     /// overflow side-exit to `deopt`. A macro-op: the encoder emits the arch's
     /// tagged-arith sequence and overflow handler (x86 outlines the handler to a
@@ -300,9 +342,14 @@ pub(in crate::codegen::jitgen) enum LInst {
     },
     /// Fixnum unary negate on the tagged value in `reg`; deopt on i63 overflow
     /// (e.g. `-i63::MIN`).
-    FixnumNeg { reg: GP, deopt: DestLabel },
+    FixnumNeg {
+        reg: GP,
+        deopt: DestLabel,
+    },
     /// Fixnum bitwise-not on the tagged value in `reg` (cannot overflow).
-    FixnumBitNot { reg: GP },
+    FixnumBitNot {
+        reg: GP,
+    },
     // ---- floating-point transfer / convert -----------------------------------
     // FP operands are virtual `FPReg`s (physical xmm/d-reg or a stack spill); the
     // encoders resolve the spill via `FPReg::loc(base)`, so these carry the
@@ -314,7 +361,11 @@ pub(in crate::codegen::jitgen) enum LInst {
         base: usize,
     },
     /// `dst <- f` — materialize an f64 constant into an FP register.
-    F64ToFpr { f: f64, dst: FPReg, base: usize },
+    F64ToFpr {
+        f: f64,
+        dst: FPReg,
+        base: usize,
+    },
     /// `dst <- (src as fixnum) as f64` — untag and convert.
     FixnumToFpr {
         src: GP,
@@ -385,11 +436,18 @@ pub(in crate::codegen::jitgen) enum LInst {
     },
     /// Save the live FP pool registers before a C-call (`cont` reserves a
     /// continuation frame).
-    XmmSave { using_xmm: UsingXmm, cont: bool },
+    XmmSave {
+        using_xmm: UsingXmm,
+        cont: bool,
+    },
     /// Restore the live FP pool registers after a C-call.
-    XmmRestore { using_xmm: UsingXmm, cont: bool },
+    XmmRestore {
+        using_xmm: UsingXmm,
+        cont: bool,
+    },
     /// Call an `f64 -> f64` C function (e.g. `Math.sqrt`): save the FP pool, load
     /// `src` into the arg register, call, restore, and store the result in `dst`.
+    #[allow(non_camel_case_types)]
     CFunc_F_F {
         f: unsafe extern "C" fn(f64) -> f64,
         src: FPReg,
@@ -398,6 +456,7 @@ pub(in crate::codegen::jitgen) enum LInst {
         base: usize,
     },
     /// Call an `(f64, f64) -> f64` C function (e.g. `Math.atan2`).
+    #[allow(non_camel_case_types)]
     CFunc_FF_F {
         f: extern "C" fn(f64, f64) -> f64,
         lhs: FPReg,
@@ -742,7 +801,11 @@ impl Lir {
         self.push(LInst::LoadImm { dst, imm })
     }
 
-    pub(in crate::codegen::jitgen) fn load(&mut self, dst: impl Into<LReg>, mem: LMem) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn load(
+        &mut self,
+        dst: impl Into<LReg>,
+        mem: LMem,
+    ) -> &mut Self {
         self.push(LInst::Load {
             dst: dst.into(),
             mem,
@@ -772,7 +835,11 @@ impl Lir {
         })
     }
 
-    pub(in crate::codegen::jitgen) fn cmp(&mut self, lhs: GP, rhs: impl Into<LOperand>) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn cmp(
+        &mut self,
+        lhs: GP,
+        rhs: impl Into<LOperand>,
+    ) -> &mut Self {
         self.push(LInst::Cmp {
             lhs,
             rhs: rhs.into(),
@@ -787,7 +854,11 @@ impl Lir {
         self.push(LInst::Br(target))
     }
 
-    pub(in crate::codegen::jitgen) fn cond_br(&mut self, cond: LCond, target: DestLabel) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn cond_br(
+        &mut self,
+        cond: LCond,
+        target: DestLabel,
+    ) -> &mut Self {
         self.push(LInst::CondBr { cond, target })
     }
 }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -323,6 +323,28 @@ pub(in crate::codegen::jitgen) enum LInst {
         slot: SlotId,
         base: usize,
     },
+    /// Swap two FP registers (spill-aware).
+    FprSwap {
+        lhs: FPReg,
+        rhs: FPReg,
+        base: usize,
+    },
+    /// `dst <- decode_float(src)` — unbox a `Float` Value in GP `src` to f64;
+    /// deopt if `src` is not a Float.
+    FloatToFpr {
+        src: GP,
+        dst: FPReg,
+        deopt: DestLabel,
+        base: usize,
+    },
+    /// Materialize the constant integer `i` as both a boxed `Value` (into frame
+    /// `slot`) and an f64 (into FP register `dst`).
+    I64ToBoth {
+        i: i64,
+        slot: SlotId,
+        dst: FPReg,
+        base: usize,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -41,7 +41,6 @@
 // Stage-1 scaffolding: the model exists but nothing consumes it yet.
 #![allow(dead_code)]
 
-use super::JitLabel;
 use super::*;
 use crate::ast::CmpKind;
 use crate::bytecodegen::BinOpK;
@@ -179,13 +178,18 @@ impl LAluOp {
 /// One arch-neutral low-level instruction.
 ///
 /// The set intentionally starts small — it covers the integer move / memory /
-/// ALU / branch core that Stage 2 migrates first (the families behind
+/// ALU / compare-branch core that Stage 2 migrates first (the families behind
 /// `emit_reg_move`, `emit_reg_to_stack`, `emit_stack_to_reg`, `emit_lit_to_reg`,
-/// `emit_lit_to_stack`, `emit_integer_binop`, `emit_integer_cmp(_br)`,
-/// `emit_reg_add/sub`, `emit_cond_br`). FP transfer/compare, runtime calls (with
-/// FP-pool save/restore), and the patch/recompile machinery are added in later
-/// stages as their `AsmInst` families are ported onto LIR.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// `emit_lit_to_stack`, `emit_reg_add/sub`, `emit_integer_cmp_br`). FP
+/// transfer/compare, runtime calls (with FP-pool save/restore), and the
+/// patch/recompile machinery are added in later stages as their `AsmInst`
+/// families are ported onto LIR.
+///
+/// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
+/// `JitLabel`), because the encoder runs after label resolution — the `emit_*`
+/// primitives already receive `DestLabel`s. `DestLabel` is `Clone` but not
+/// `Copy`, so `LInst` is `Clone`/`PartialEq` but not `Copy`.
+#[derive(Debug, Clone, PartialEq)]
 pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
     Mov { dst: GP, src: GP },
@@ -206,14 +210,16 @@ pub(in crate::codegen::jitgen) enum LInst {
         lhs: GP,
         rhs: LOperand,
     },
-    /// Set condition flags from `lhs - rhs` (no result register written).
+    /// Set condition flags from `lhs - rhs` (no result register written). The
+    /// immediate of an `Imm` rhs is the operand's raw bit pattern (e.g. a tagged
+    /// fixnum `Value`), compared against the raw register bits.
     Cmp { lhs: GP, rhs: LOperand },
     /// Bind `label` at the current code position.
-    Label(JitLabel),
+    Label(DestLabel),
     /// Unconditional branch to `target`.
-    Br(JitLabel),
+    Br(DestLabel),
     /// Branch to `target` when the preceding `Cmp` satisfied `cond`.
-    CondBr { cond: LCond, target: JitLabel },
+    CondBr { cond: LCond, target: DestLabel },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)
@@ -288,15 +294,15 @@ impl Lir {
         })
     }
 
-    pub(in crate::codegen::jitgen) fn label(&mut self, label: JitLabel) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn label(&mut self, label: DestLabel) -> &mut Self {
         self.push(LInst::Label(label))
     }
 
-    pub(in crate::codegen::jitgen) fn br(&mut self, target: JitLabel) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn br(&mut self, target: DestLabel) -> &mut Self {
         self.push(LInst::Br(target))
     }
 
-    pub(in crate::codegen::jitgen) fn cond_br(&mut self, cond: LCond, target: JitLabel) -> &mut Self {
+    pub(in crate::codegen::jitgen) fn cond_br(&mut self, cond: LCond, target: DestLabel) -> &mut Self {
         self.push(LInst::CondBr { cond, target })
     }
 }
@@ -345,7 +351,7 @@ mod tests {
             .cmp(GP::Rax, 0i64);
         assert_eq!(lir.len(), 4);
         assert_eq!(
-            lir.iter().next().copied(),
+            lir.iter().next().cloned(),
             Some(LInst::Mov {
                 dst: GP::Rax,
                 src: GP::Rdi

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -761,6 +761,38 @@ pub(in crate::codegen::jitgen) enum LInst {
         using_xmm: UsingXmm,
         error: DestLabel,
     },
+    // ---- method-call / argument-setup macro-ops ----------------------------
+    // Store/frame-dependent values are pre-resolved by the dispatcher (which
+    // holds `&Store` / `&mut AsmInfo`) and carried here, so the encoder stays
+    // store-free. They delegate to the existing per-arch helpers.
+    SetupMethodFrame {
+        meta: Meta,
+        outer_lfp: Option<Lfp>,
+        block_fid: Option<FuncId>,
+        block_arg: Option<SlotId>,
+    },
+    SetArguments {
+        callid: CallSiteId,
+        callee_fid: FuncId,
+        /// callee scratch-area size (`store[callee_fid].get_offset()`).
+        offset: usize,
+    },
+    SetArgumentsForwardedHelper {
+        callid: CallSiteId,
+        callee_fid: FuncId,
+        offset: usize,
+    },
+    Preparation {
+        /// `Some(heap_len)` when the self heap ivar-table must be ensured large
+        /// enough; `None` for a frozen / inline-only self (no-op).
+        heap_len: Option<usize>,
+    },
+    OptCase {
+        max: u16,
+        min: u16,
+        else_dest: DestLabel,
+        branch_dests: Box<[DestLabel]>,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -406,6 +406,26 @@ pub(in crate::codegen::jitgen) enum LInst {
         using_xmm: UsingXmm,
         base: usize,
     },
+    // ---- macro-ops -----------------------------------------------------------
+    // Irreducible per-arch sequences (mostly runtime-call shapes). The encoder
+    // delegates to the existing per-arch `emit_*` helper via the arch-neutral
+    // `encode_linst_macro`; the LInst exists so that *all* emission flows through
+    // `encode_linst`.
+    /// Load a heap-spilled instance variable (bounds-checked unless `self_`),
+    /// substituting nil for an out-of-range / unset slot.
+    LoadIVarHeap {
+        ivarid: IvarId,
+        is_object_ty: bool,
+        self_: bool,
+    },
+    /// Store into a heap-spilled instance variable of another object
+    /// (bounds-checked; grows the var-table on miss via a runtime call).
+    StoreIVarHeap {
+        src: GP,
+        ivarid: IvarId,
+        is_object_ty: bool,
+        using_xmm: UsingXmm,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -426,6 +426,76 @@ pub(in crate::codegen::jitgen) enum LInst {
         is_object_ty: bool,
         using_xmm: UsingXmm,
     },
+    // Variable access (gvar/cvar via runtime call; dynvar walks the LFP chain).
+    StoreConstant {
+        id: ConstSiteId,
+        using_xmm: UsingXmm,
+        error: DestLabel,
+    },
+    LoadGVar {
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    StoreGVar {
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    },
+    LoadCVar {
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    LoadDynVar {
+        src: DynVar,
+    },
+    StoreDynVar {
+        dst: DynVar,
+        src: GP,
+    },
+    // Runtime allocation / C-call family (each builds a heap object).
+    CreateArray {
+        src: SlotId,
+        len: usize,
+    },
+    NewArray {
+        callid: CallSiteId,
+        using_xmm: UsingXmm,
+    },
+    NewHash {
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    },
+    HashInsert {
+        hash: SlotId,
+        args: SlotId,
+        len: usize,
+        using_xmm: UsingXmm,
+    },
+    ArrayConcat {
+        dst: SlotId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    },
+    NewRange {
+        start: SlotId,
+        end: SlotId,
+        exclude_end: bool,
+        using_xmm: UsingXmm,
+    },
+    ConcatStr {
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    },
+    ToA {
+        src: SlotId,
+        using_xmm: UsingXmm,
+    },
+    DeepCopyLit {
+        v: Value,
+        using_xmm: UsingXmm,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -1,0 +1,357 @@
+//! # Unified low-level IR (LIR) — arch-neutral machine-level instructions
+//!
+//! **Stage 1 of the Phase-1 "unified low-level IR" effort.** This module
+//! defines the *data model only*; it is not yet wired into the compilation
+//! pipeline (hence the module-level `dead_code` allow). Subsequent stages
+//! migrate the per-arch `emit_*` primitives onto it one instruction family at a
+//! time. See `doc/lir.md` for the full design and migration plan.
+//!
+//! ## Where it sits
+//!
+//! ```text
+//! TraceIR → AsmIR (AsmInst, arch-neutral, register-allocated)
+//!         → [compile_asmir dispatcher]
+//!         → LIR (this module: arch-neutral machine ops + logical addressing)   ← NEW
+//!         → [per-arch LirEncode + legalize]
+//!         → monoasm! / monoasm_arm64!  → bytes
+//! ```
+//!
+//! Today `emit_*` lowers each `AsmInst` *directly* to machine code, so each
+//! backend re-implements register moves, frame addressing, immediate-range
+//! handling, and FP-pool save/restore by hand (≈145 primitives on x86, ≈143 on
+//! aarch64). The aarch64 side already factors the immediate-range handling into
+//! helpers like `a64_frame_load` / `a64_field_load` / `a64_sp_sub`, each of
+//! which materializes an over-large offset into a scratch register. LIR
+//! promotes that pattern into an explicit contract:
+//!
+//! - **Operands are *logical*.** `LMem` carries an unbounded displacement; the
+//!   per-arch encoder is responsible for **legalization** (folding a small
+//!   displacement into the instruction's immediate field, or materializing a
+//!   large one into a scratch register). A single legalizer replaces the ~two
+//!   dozen ad-hoc range checks currently spread across the aarch64 backend.
+//! - **Registers are already arch-neutral.** `GP` (general) and `FPReg`
+//!   (virtual FP, phys-xmm-or-spill) are defined in `codegen.rs` and map to
+//!   physical registers per `target_arch`, so LIR reuses them as-is.
+//!
+//! The payoff is no longer closing aarch64 *bails* (the full port `#704`
+//! already removed those): it is collapsing the two parallel `emit_*` sets into
+//! one description, which is also the concrete code-generation target the future
+//! interpreter/JIT DSL (Phase-1 item ③) lowers to.
+
+// Stage-1 scaffolding: the model exists but nothing consumes it yet.
+#![allow(dead_code)]
+
+use super::JitLabel;
+use super::*;
+use crate::ast::CmpKind;
+use crate::bytecodegen::BinOpK;
+
+/// A general-purpose-register operand or an inline integer immediate.
+///
+/// The encoder folds an `Imm` into the instruction's immediate field when it
+/// fits, and materializes it into a scratch register otherwise — the same
+/// legalization story as `LMem` displacements.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LOperand {
+    Reg(GP),
+    Imm(i64),
+}
+
+impl From<GP> for LOperand {
+    fn from(r: GP) -> Self {
+        LOperand::Reg(r)
+    }
+}
+
+impl From<i64> for LOperand {
+    fn from(i: i64) -> Self {
+        LOperand::Imm(i)
+    }
+}
+
+/// A *logical* memory location. Displacements are unbounded here; the per-arch
+/// `LirEncode` implementation legalizes them (immediate field vs.
+/// scratch-register materialization) when lowering.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LMem {
+    /// An LFP-relative local-variable / temporary slot. Slots live at a
+    /// *negative* byte displacement from the local frame pointer:
+    /// `[rbp - rbp_local(slot)]` on x86, `[lfp - (slot*8 + LFP_SELF)]` on
+    /// aarch64. The encoder owns that arch-specific displacement formula.
+    Slot(SlotId),
+    /// An object field at a *positive* byte displacement from a base register
+    /// (e.g. an `RValue` header/ivar field). `disp` may exceed any
+    /// single-instruction immediate range; the encoder materializes it into a
+    /// scratch register when needed (cf. `a64_field_load`).
+    Field { base: GP, disp: i32 },
+    /// A callee-frame argument slot at a *positive* byte displacement below the
+    /// stack pointer, used while marshalling arguments before a call
+    /// (cf. the aarch64 `a64_rsp_*` helpers).
+    RspRel { disp: i32 },
+}
+
+/// Condition for a `CondBr` following a `Cmp`. Integer Ruby comparisons are
+/// signed; float/NaN-aware comparisons are *not* modelled here — they get
+/// dedicated `LInst` variants in a later stage because their condition-code
+/// mapping differs per arch (x86 `ucomisd`+`setp`, aarch64 `fcmp`+MI/LS).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LCond {
+    Eq,
+    Ne,
+    /// signed `<`
+    Lt,
+    /// signed `<=`
+    Le,
+    /// signed `>`
+    Gt,
+    /// signed `>=`
+    Ge,
+}
+
+impl LCond {
+    /// Map an integer-comparison `CmpKind` to its signed LIR condition. Returns
+    /// `None` for `TEq` (`===`), which is not a plain signed integer comparison
+    /// and is lowered through another path.
+    pub(in crate::codegen::jitgen) fn from_int_cmp(kind: CmpKind) -> Option<Self> {
+        Some(match kind {
+            CmpKind::Eq => LCond::Eq,
+            CmpKind::Ne => LCond::Ne,
+            CmpKind::Lt => LCond::Lt,
+            CmpKind::Le => LCond::Le,
+            CmpKind::Gt => LCond::Gt,
+            CmpKind::Ge => LCond::Ge,
+            CmpKind::TEq => return None,
+        })
+    }
+
+    /// The condition that is true exactly when `self` is false.
+    pub(in crate::codegen::jitgen) fn invert(self) -> Self {
+        match self {
+            LCond::Eq => LCond::Ne,
+            LCond::Ne => LCond::Eq,
+            LCond::Lt => LCond::Ge,
+            LCond::Le => LCond::Gt,
+            LCond::Gt => LCond::Le,
+            LCond::Ge => LCond::Lt,
+        }
+    }
+}
+
+/// An integer ALU operation on general-purpose registers.
+///
+/// This is the *machine-level* op set (no overflow/deopt semantics — those are
+/// expressed by the surrounding `LInst`s / guards). Ruby's `BinOpK` maps onto a
+/// subset; bit-shift and division corner cases are handled by the higher tiers
+/// before reaching LIR.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LAluOp {
+    Add,
+    Sub,
+    Mul,
+    And,
+    Or,
+    Xor,
+    /// logical shift left
+    Shl,
+    /// arithmetic shift right
+    Sar,
+}
+
+impl LAluOp {
+    /// Map the directly-lowerable subset of `BinOpK` to an `LAluOp`. `Div` /
+    /// `Rem` (which need an idiv / call sequence) and any op routed through a
+    /// method call upstream return `None`.
+    pub(in crate::codegen::jitgen) fn from_binop(kind: BinOpK) -> Option<Self> {
+        Some(match kind {
+            BinOpK::Add => LAluOp::Add,
+            BinOpK::Sub => LAluOp::Sub,
+            BinOpK::Mul => LAluOp::Mul,
+            BinOpK::BitAnd => LAluOp::And,
+            BinOpK::BitOr => LAluOp::Or,
+            BinOpK::BitXor => LAluOp::Xor,
+            BinOpK::Shl => LAluOp::Shl,
+            BinOpK::Shr => LAluOp::Sar,
+            BinOpK::Div | BinOpK::Rem | BinOpK::Exp => return None,
+        })
+    }
+}
+
+/// One arch-neutral low-level instruction.
+///
+/// The set intentionally starts small — it covers the integer move / memory /
+/// ALU / branch core that Stage 2 migrates first (the families behind
+/// `emit_reg_move`, `emit_reg_to_stack`, `emit_stack_to_reg`, `emit_lit_to_reg`,
+/// `emit_lit_to_stack`, `emit_integer_binop`, `emit_integer_cmp(_br)`,
+/// `emit_reg_add/sub`, `emit_cond_br`). FP transfer/compare, runtime calls (with
+/// FP-pool save/restore), and the patch/recompile machinery are added in later
+/// stages as their `AsmInst` families are ported onto LIR.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LInst {
+    /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
+    Mov { dst: GP, src: GP },
+    /// `dst <- imm` — materialize a full 64-bit immediate (e.g. a tagged
+    /// `Value`'s bit pattern) into a register.
+    LoadImm { dst: GP, imm: u64 },
+    /// `dst <- [mem]`.
+    Load { dst: GP, mem: LMem },
+    /// `[mem] <- src`.
+    Store { src: GP, mem: LMem },
+    /// `[mem] <- imm`. aarch64 has no store-immediate, so the encoder routes it
+    /// through a scratch register without clobbering any allocated GP.
+    StoreImm { imm: u64, mem: LMem },
+    /// `dst <- lhs <op> rhs`.
+    Alu {
+        op: LAluOp,
+        dst: GP,
+        lhs: GP,
+        rhs: LOperand,
+    },
+    /// Set condition flags from `lhs - rhs` (no result register written).
+    Cmp { lhs: GP, rhs: LOperand },
+    /// Bind `label` at the current code position.
+    Label(JitLabel),
+    /// Unconditional branch to `target`.
+    Br(JitLabel),
+    /// Branch to `target` when the preceding `Cmp` satisfied `cond`.
+    CondBr { cond: LCond, target: JitLabel },
+}
+
+/// A straight-line sequence of `LInst`s produced by lowering one (or more)
+/// `AsmInst`. Stage 2 builds one of these per migrated family and hands it to
+/// the per-arch encoder; for now it is a thin, ergonomic builder over `Vec`.
+#[derive(Debug, Clone, Default)]
+pub(in crate::codegen::jitgen) struct Lir {
+    insts: Vec<LInst>,
+}
+
+impl Lir {
+    pub(in crate::codegen::jitgen) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(in crate::codegen::jitgen) fn is_empty(&self) -> bool {
+        self.insts.is_empty()
+    }
+
+    pub(in crate::codegen::jitgen) fn len(&self) -> usize {
+        self.insts.len()
+    }
+
+    pub(in crate::codegen::jitgen) fn iter(&self) -> std::slice::Iter<'_, LInst> {
+        self.insts.iter()
+    }
+
+    pub(in crate::codegen::jitgen) fn push(&mut self, inst: LInst) -> &mut Self {
+        self.insts.push(inst);
+        self
+    }
+
+    pub(in crate::codegen::jitgen) fn mov(&mut self, dst: GP, src: GP) -> &mut Self {
+        self.push(LInst::Mov { dst, src })
+    }
+
+    pub(in crate::codegen::jitgen) fn load_imm(&mut self, dst: GP, imm: u64) -> &mut Self {
+        self.push(LInst::LoadImm { dst, imm })
+    }
+
+    pub(in crate::codegen::jitgen) fn load(&mut self, dst: GP, mem: LMem) -> &mut Self {
+        self.push(LInst::Load { dst, mem })
+    }
+
+    pub(in crate::codegen::jitgen) fn store(&mut self, src: GP, mem: LMem) -> &mut Self {
+        self.push(LInst::Store { src, mem })
+    }
+
+    pub(in crate::codegen::jitgen) fn store_imm(&mut self, imm: u64, mem: LMem) -> &mut Self {
+        self.push(LInst::StoreImm { imm, mem })
+    }
+
+    pub(in crate::codegen::jitgen) fn alu(
+        &mut self,
+        op: LAluOp,
+        dst: GP,
+        lhs: GP,
+        rhs: impl Into<LOperand>,
+    ) -> &mut Self {
+        self.push(LInst::Alu {
+            op,
+            dst,
+            lhs,
+            rhs: rhs.into(),
+        })
+    }
+
+    pub(in crate::codegen::jitgen) fn cmp(&mut self, lhs: GP, rhs: impl Into<LOperand>) -> &mut Self {
+        self.push(LInst::Cmp {
+            lhs,
+            rhs: rhs.into(),
+        })
+    }
+
+    pub(in crate::codegen::jitgen) fn label(&mut self, label: JitLabel) -> &mut Self {
+        self.push(LInst::Label(label))
+    }
+
+    pub(in crate::codegen::jitgen) fn br(&mut self, target: JitLabel) -> &mut Self {
+        self.push(LInst::Br(target))
+    }
+
+    pub(in crate::codegen::jitgen) fn cond_br(&mut self, cond: LCond, target: JitLabel) -> &mut Self {
+        self.push(LInst::CondBr { cond, target })
+    }
+}
+
+/// The per-arch lowering seam that Stage 2 implements on `Codegen`.
+///
+/// Each backend provides one `encode` that pattern-matches an `LInst` and emits
+/// the corresponding `monoasm!` / `monoasm_arm64!` bytes, performing immediate
+/// and displacement **legalization** in the process. It is declared here (and
+/// left unimplemented) so the intended contract is visible alongside the data
+/// model; no `impl` is provided yet, so this remains pure scaffolding.
+///
+/// ```ignore
+/// pub(in crate::codegen::jitgen) trait LirEncode {
+///     /// Emit one already-register-allocated `LInst`. The encoder may use the
+///     /// arch's reserved scratch registers (x9/x10 on aarch64) freely.
+///     fn encode(&mut self, inst: &LInst, labels: &SideExitLabels);
+/// }
+/// ```
+const _: () = ();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lcond_invert_is_involution() {
+        for c in [
+            LCond::Eq,
+            LCond::Ne,
+            LCond::Lt,
+            LCond::Le,
+            LCond::Gt,
+            LCond::Ge,
+        ] {
+            assert_eq!(c, c.invert().invert());
+        }
+        assert_eq!(LCond::Lt.invert(), LCond::Ge);
+        assert_eq!(LCond::Le.invert(), LCond::Gt);
+    }
+
+    #[test]
+    fn builder_records_in_order() {
+        let mut lir = Lir::new();
+        lir.mov(GP::Rax, GP::Rdi)
+            .load(GP::Rcx, LMem::Slot(SlotId::new(3)))
+            .alu(LAluOp::Add, GP::Rax, GP::Rax, GP::Rcx)
+            .cmp(GP::Rax, 0i64);
+        assert_eq!(lir.len(), 4);
+        assert_eq!(
+            lir.iter().next().copied(),
+            Some(LInst::Mov {
+                dst: GP::Rax,
+                src: GP::Rdi
+            })
+        );
+    }
+}

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -196,13 +196,13 @@ impl LAluOp {
 
 /// One arch-neutral low-level instruction.
 ///
-/// The set intentionally starts small — it covers the integer move / memory /
-/// ALU / compare-branch core that Stage 2 migrates first (the families behind
-/// `emit_reg_move`, `emit_reg_to_stack`, `emit_stack_to_reg`, `emit_lit_to_reg`,
-/// `emit_lit_to_stack`, `emit_reg_add/sub`, `emit_integer_cmp_br`). FP
-/// transfer/compare, runtime calls (with FP-pool save/restore), and the
-/// patch/recompile machinery are added in later stages as their `AsmInst`
-/// families are ported onto LIR.
+/// The set began with the integer move / memory / ALU / compare-branch core
+/// (register moves, slot/field load-store, reg-imm ALU) and has since grown to
+/// cover the GC write barrier, the guard/check family, fixnum + float
+/// arithmetic, and the large runtime-call macro-ops (construction, variable
+/// access, `defined?`, definition, control flow / exceptions). The remaining
+/// gap is the patch/recompile machinery (return-address eviction, in-place
+/// recompile). See `doc/lir.md` for the migration log.
 ///
 /// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
 /// `JitLabel`), because the encoder runs after label resolution — the `emit_*`
@@ -873,10 +873,9 @@ impl Lir {
 // `encode_linst` is selected by `cfg`. Each backend pattern-matches an `LInst`,
 // performs immediate/displacement **legalization** (folding small immediates,
 // materializing large ones into scratch x9/x10 on aarch64), and emits
-// byte-identical output to the `emit_*` primitive it replaces.
-//
-// Stage 2-A wires only the `Mov` family (behind `emit_reg_move`); the remaining
-// variants `todo!()` until their `AsmInst` family is migrated.
+// byte-identical output to the hand-written primitive it replaces. Macro-op
+// variants that still wrap a substantive per-arch helper fall through each
+// backend's `other =>` arm into the arch-neutral `encode_linst_macro`.
 
 #[cfg(test)]
 mod tests {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -208,7 +208,7 @@ impl LAluOp {
 /// `JitLabel`), because the encoder runs after label resolution — the `emit_*`
 /// primitives already receive `DestLabel`s. `DestLabel` is `Clone` but not
 /// `Copy`, so `LInst` is `Clone`/`PartialEq` but not `Copy`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
     Mov { dst: GP, src: GP },
@@ -586,6 +586,93 @@ pub(in crate::codegen::jitgen) enum LInst {
         rest_pos: Option<usize>,
         using_xmm: UsingXmm,
     },
+    // Control flow / frame / exceptions / definitions.
+    Deopt {
+        deopt: DestLabel,
+    },
+    HandleError {
+        error: DestLabel,
+    },
+    CheckStack {
+        write_back: WriteBack,
+        error: DestLabel,
+        base: usize,
+    },
+    ExecGc {
+        write_back: WriteBack,
+        error: DestLabel,
+        base: usize,
+    },
+    IntegerCmp {
+        kind: CmpKind,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+    },
+    Ret,
+    MethodRet {
+        pc: BytecodePtr,
+    },
+    BlockBreak {
+        pc: BytecodePtr,
+    },
+    ImmediateEvict {
+        evict: AsmEvict,
+    },
+    Init {
+        info: FnInitInfo,
+        prologue_offset: PrologueOffset,
+    },
+    LoopJitRspBump {
+        offset: LoopRspOffset,
+    },
+    BlockArgProxy {
+        ret: SlotId,
+        outer: usize,
+    },
+    BlockArg {
+        ret: SlotId,
+        using_xmm: UsingXmm,
+        call_site_bc_ptr: BytecodePtr,
+        error: DestLabel,
+    },
+    MethodDef {
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: DestLabel,
+    },
+    SingletonMethodDef {
+        obj: SlotId,
+        name: IdentId,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: DestLabel,
+    },
+    Raise {
+        loop_jit_spill_bytes: usize,
+    },
+    Retry {
+        pc: BytecodePtr,
+        loop_jit_spill_bytes: usize,
+    },
+    Redo {
+        pc: BytecodePtr,
+        loop_jit_spill_bytes: usize,
+    },
+    EnsureEnd {
+        loop_jit_spill_bytes: usize,
+    },
+    Yield {
+        callid: CallSiteId,
+        error: DestLabel,
+        evict: AsmEvict,
+        evict_label: DestLabel,
+    },
+    Unreachable,
+    RestKw {
+        rest_kw: Vec<(SlotId, IdentId)>,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)
@@ -719,12 +806,12 @@ mod tests {
             .alu(LAluOp::Add, GP::Rax, GP::Rax, GP::Rcx)
             .cmp(GP::Rax, 0i64);
         assert_eq!(lir.len(), 4);
-        assert_eq!(
-            lir.iter().next().cloned(),
+        assert!(matches!(
+            lir.iter().next(),
             Some(LInst::Mov {
                 dst: GP::Rax,
                 src: GP::Rdi
             })
-        );
+        ));
     }
 }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -234,6 +234,10 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// macro-op — the encoder emits the arch's inline fast-path + slow-path call
     /// (x86 fixes `parent` in rdi).
     WriteBarrier { parent: GP, value: GP },
+    /// `reg <- nil` if `reg == 0` (an unset inline-ivar slot reads as 0). The
+    /// arches differ structurally — x86 branches over a `mov`, aarch64 uses a
+    /// branchless `csel` — so this is its own op rather than a Load + branch.
+    NilIfZero { reg: GP },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -286,6 +286,18 @@ pub(in crate::codegen::jitgen) enum LInst {
     GuardCapture { deopt: DestLabel },
     /// Basic-operator-redefinition guard: deopt if any BOP was redefined.
     CheckBOP { deopt: DestLabel },
+    /// Fixnum fast-path arithmetic (`lhs <op> rhs`) on tagged integers, with an
+    /// overflow side-exit to `deopt`. A macro-op: the encoder emits the arch's
+    /// tagged-arith sequence and overflow handler (x86 outlines the handler to a
+    /// cold page; aarch64 lays it inline), so the tag manipulation and the
+    /// idiv/imul-vs-aarch64 lowering stay per-arch.
+    IntegerBinOp {
+        kind: BinOpK,
+        mode: OpMode,
+        lhs: GP,
+        rhs: GP,
+        deopt: DestLabel,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -257,6 +257,18 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// arches differ structurally — x86 branches over a `mov`, aarch64 uses a
     /// branchless `csel` — so this is its own op rather than a Load + branch.
     NilIfZero { reg: GP },
+    /// Class guard: branch to the side-exit `deopt` unless `reg`'s runtime class
+    /// is `class`. `deopt` is a resolved side-exit label (the deopt model:
+    /// guards carry the side-exit they fall through to).
+    GuardClass {
+        reg: GP,
+        class: ClassId,
+        deopt: DestLabel,
+    },
+    /// Type guard: deopt unless `reg` holds an `Array`.
+    GuardArrayTy { reg: GP, deopt: DestLabel },
+    /// Deopt if the receiver (rdi) is frozen.
+    GuardFrozen { deopt: DestLabel },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -269,6 +269,23 @@ pub(in crate::codegen::jitgen) enum LInst {
     GuardArrayTy { reg: GP, deopt: DestLabel },
     /// Deopt if the receiver (rdi) is frozen.
     GuardFrozen { deopt: DestLabel },
+    /// Constant-load guard: deopt unless the cached base class (in the
+    /// accumulator) equals `base_class`.
+    GuardConstBaseClass {
+        base_class: Value,
+        deopt: DestLabel,
+    },
+    /// Constant-load guard: deopt if the global constant version moved away from
+    /// `const_version` since compilation.
+    GuardConstVersion {
+        const_version: usize,
+        deopt: DestLabel,
+    },
+    /// Block-passing side-effect guard: deopt if the current frame was captured
+    /// or invalidated.
+    GuardCapture { deopt: DestLabel },
+    /// Basic-operator-redefinition guard: deopt if any BOP was redefined.
+    CheckBOP { deopt: DestLabel },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -228,6 +228,12 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// Branch to `target` if the accumulator is non-zero (e.g. an already-set
     /// local slot).
     BranchIfNonzero { target: DestLabel },
+    /// Generational-GC write barrier after storing `value` into a field of the
+    /// heap object `parent`: if `parent` is an old object not yet remembered and
+    /// `value` is a heap pointer, record `parent` in the remembered set. A
+    /// macro-op — the encoder emits the arch's inline fast-path + slow-path call
+    /// (x86 fixes `parent` in rdi).
+    WriteBarrier { parent: GP, value: GP },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -673,6 +673,35 @@ pub(in crate::codegen::jitgen) enum LInst {
     RestKw {
         rest_kw: Vec<(SlotId, IdentId)>,
     },
+    GuardClassVersion {
+        class_version: DestLabel,
+        position: Option<BytecodePtr>,
+        with_recovery: bool,
+        deopt: DestLabel,
+    },
+    RecompileDeopt {
+        position: Option<BytecodePtr>,
+        deopt: DestLabel,
+        error: Option<DestLabel>,
+        reason: RecompileReason,
+    },
+    ClassDef {
+        base: Option<SlotId>,
+        superclass: Option<SlotId>,
+        dst: Option<SlotId>,
+        name: IdentId,
+        func_id: FuncId,
+        is_module: bool,
+        using_xmm: UsingXmm,
+        error: DestLabel,
+    },
+    SingletonClassDef {
+        base: SlotId,
+        dst: Option<SlotId>,
+        func_id: FuncId,
+        using_xmm: UsingXmm,
+        error: DestLabel,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -378,6 +378,29 @@ pub(in crate::codegen::jitgen) enum LInst {
         dest: DestLabel,
         base: usize,
     },
+    /// Save the live FP pool registers before a C-call (`cont` reserves a
+    /// continuation frame).
+    XmmSave { using_xmm: UsingXmm, cont: bool },
+    /// Restore the live FP pool registers after a C-call.
+    XmmRestore { using_xmm: UsingXmm, cont: bool },
+    /// Call an `f64 -> f64` C function (e.g. `Math.sqrt`): save the FP pool, load
+    /// `src` into the arg register, call, restore, and store the result in `dst`.
+    CFunc_F_F {
+        f: unsafe extern "C" fn(f64) -> f64,
+        src: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    },
+    /// Call an `(f64, f64) -> f64` C function (e.g. `Math.atan2`).
+    CFunc_FF_F {
+        f: extern "C" fn(f64, f64) -> f64,
+        lhs: FPReg,
+        rhs: FPReg,
+        dst: FPReg,
+        using_xmm: UsingXmm,
+        base: usize,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -204,6 +204,27 @@ impl LAluOp {
 /// gap is the patch/recompile machinery (return-address eviction, in-place
 /// recompile). See `doc/lir.md` for the migration log.
 ///
+/// Which kind of cold side-exit (deopt) handler an `LInst::SideExit` emits. The
+/// handler writes all live Ruby values back to the LFP (so the frame is
+/// GC-consistent) and resumes the interpreter / unwinds; this mirrors the
+/// `SideExit` cases the JIT records while building `AsmIr`.
+#[derive(Debug, Clone)]
+pub(in crate::codegen::jitgen) enum LSideExitKind {
+    /// Plain deoptimization back to the VM fetch loop.
+    Deopt,
+    /// Immediate eviction (BOP redefinition) — same shape as `Deopt`, with a
+    /// distinct `cfg(deopt/profile)` log reason.
+    Evict,
+    /// Deopt that, once a miss counter is exhausted, recompiles the method/loop
+    /// (x86 only; aarch64 treats it as a plain `Deopt`).
+    RecompileDeopt {
+        reason: RecompileReason,
+        position: Option<BytecodePtr>,
+    },
+    /// Error handler: write back then jump to the raise/`handle_error` path.
+    Error,
+}
+
 /// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
 /// `JitLabel`), because the encoder runs after label resolution — the `emit_*`
 /// primitives already receive `DestLabel`s. `DestLabel` is `Clone` but not
@@ -810,6 +831,19 @@ pub(in crate::codegen::jitgen) enum LInst {
         jit_entry: Option<DestLabel>,
         evict: AsmEvict,
         evict_label: DestLabel,
+    },
+    /// A cold side-exit (deopt) handler block: bind `entry`, undo any loop-JIT
+    /// sp bump, write `wb` back to the LFP, then resume the VM / unwind. The
+    /// per-arch encoder dispatches on `kind` to the existing handler emitter
+    /// (x86 `gen_*_with_label` / `gen_handle_error`; aarch64 `a64_gen_deopt` /
+    /// `a64_gen_handle_error`).
+    SideExit {
+        kind: LSideExitKind,
+        pc: BytecodePtr,
+        wb: WriteBack,
+        entry: DestLabel,
+        loop_jit_spill_bytes: usize,
+        base: usize,
     },
 }
 

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -298,6 +298,11 @@ pub(in crate::codegen::jitgen) enum LInst {
         rhs: GP,
         deopt: DestLabel,
     },
+    /// Fixnum unary negate on the tagged value in `reg`; deopt on i63 overflow
+    /// (e.g. `-i63::MIN`).
+    FixnumNeg { reg: GP, deopt: DestLabel },
+    /// Fixnum bitwise-not on the tagged value in `reg` (cannot overflow).
+    FixnumBitNot { reg: GP },
     // ---- floating-point transfer / convert -----------------------------------
     // FP operands are virtual `FPReg`s (physical xmm/d-reg or a stack spill); the
     // encoders resolve the spill via `FPReg::loc(base)`, so these carry the

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -496,6 +496,96 @@ pub(in crate::codegen::jitgen) enum LInst {
         v: Value,
         using_xmm: UsingXmm,
     },
+    // Runtime-call definition / defined? / generic-op family.
+    UndefMethod {
+        undef: IdentId,
+        using_xmm: UsingXmm,
+    },
+    AliasGvar {
+        new: IdentId,
+        old: IdentId,
+        using_xmm: UsingXmm,
+    },
+    CheckCVar {
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    StoreCVar {
+        name: IdentId,
+        src: SlotId,
+        using_xmm: UsingXmm,
+    },
+    AliasMethod {
+        new: SlotId,
+        old: SlotId,
+        using_xmm: UsingXmm,
+    },
+    DefinedYield {
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    },
+    DefinedSuper {
+        dst: SlotId,
+        using_xmm: UsingXmm,
+    },
+    DefinedGvar {
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    DefinedCvar {
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    DefinedConst {
+        dst: SlotId,
+        siteid: ConstSiteId,
+        using_xmm: UsingXmm,
+    },
+    DefinedMethod {
+        dst: SlotId,
+        recv: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    DefinedIvar {
+        dst: SlotId,
+        name: IdentId,
+        using_xmm: UsingXmm,
+    },
+    GenericBinOp {
+        lhs: SlotId,
+        rhs: SlotId,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    },
+    OptEqCmp {
+        lhs: SlotId,
+        rhs: SlotId,
+        kind: CmpKind,
+        func: crate::executor::BinaryOpFn,
+        using_xmm: UsingXmm,
+    },
+    ArrayTEq {
+        lhs: SlotId,
+        rhs: SlotId,
+        using_xmm: UsingXmm,
+    },
+    ConcatRegexp {
+        arg: SlotId,
+        len: u16,
+        using_xmm: UsingXmm,
+    },
+    CheckKwRest {
+        slot: SlotId,
+    },
+    ExpandArray {
+        dst: SlotId,
+        len: usize,
+        rest_pos: Option<usize>,
+        using_xmm: UsingXmm,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -69,6 +69,25 @@ impl From<i64> for LOperand {
 }
 
 /// A *logical* memory location. Displacements are unbounded here; the per-arch
+/// A register operand that is either an allocatable general-purpose register or
+/// the per-arch reserved *scratch* pointer register. The scratch is for
+/// intermediate pointers (e.g. dereferencing an object's heap var-table) that
+/// must not clobber an allocated value; it maps to **rdx** on x86 and **x9** on
+/// aarch64. There is deliberately no general-purpose name for these (aarch64's
+/// x9 is outside the `GP` enum's allocatable mapping), so they need their own
+/// operand kind.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum LReg {
+    Gp(GP),
+    Scratch,
+}
+
+impl From<GP> for LReg {
+    fn from(r: GP) -> Self {
+        LReg::Gp(r)
+    }
+}
+
 /// `LirEncode` implementation legalizes them (immediate field vs.
 /// scratch-register materialization) when lowering.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -79,10 +98,10 @@ pub(in crate::codegen::jitgen) enum LMem {
     /// aarch64. The encoder owns that arch-specific displacement formula.
     Slot(SlotId),
     /// An object field at a *positive* byte displacement from a base register
-    /// (e.g. an `RValue` header/ivar field). `disp` may exceed any
+    /// (which may be the scratch pointer). `disp` may exceed any
     /// single-instruction immediate range; the encoder materializes it into a
     /// scratch register when needed (cf. `a64_field_load`).
-    Field { base: GP, disp: i32 },
+    Field { base: LReg, disp: i32 },
     /// A callee-frame argument slot at a *positive* byte displacement below the
     /// stack pointer, used while marshalling arguments before a call
     /// (cf. the aarch64 `a64_rsp_*` helpers).
@@ -196,8 +215,8 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- imm` — materialize a full 64-bit immediate (e.g. a tagged
     /// `Value`'s bit pattern) into a register.
     LoadImm { dst: GP, imm: u64 },
-    /// `dst <- [mem]`.
-    Load { dst: GP, mem: LMem },
+    /// `dst <- [mem]`. `dst` may be the scratch pointer (intermediate deref).
+    Load { dst: LReg, mem: LMem },
     /// `[mem] <- src`.
     Store { src: GP, mem: LMem },
     /// `[mem] <- imm`. aarch64 has no store-immediate, so the encoder routes it
@@ -278,8 +297,11 @@ impl Lir {
         self.push(LInst::LoadImm { dst, imm })
     }
 
-    pub(in crate::codegen::jitgen) fn load(&mut self, dst: GP, mem: LMem) -> &mut Self {
-        self.push(LInst::Load { dst, mem })
+    pub(in crate::codegen::jitgen) fn load(&mut self, dst: impl Into<LReg>, mem: LMem) -> &mut Self {
+        self.push(LInst::Load {
+            dst: dst.into(),
+            mem,
+        })
     }
 
     pub(in crate::codegen::jitgen) fn store(&mut self, src: GP, mem: LMem) -> &mut Self {

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -82,7 +82,19 @@ impl<'a> JitContext<'a> {
             let mut target = incoming;
             if let Some((liveness, backedge)) = self.loop_info(bbid) {
                 if let Some(backedge) = backedge {
-                    target.join(&backedge);
+                    // §5 stage 3b: under `loop-type-only-entry`, strip the
+                    // analysis pass's allocation from the loop-carried frame so
+                    // the codegen pass re-derives xmm bindings via liveness below
+                    // (`liveness_analysis` → `use_float`) instead of inheriting
+                    // it. Default build joins the placed backedge unchanged.
+                    #[cfg(not(feature = "loop-type-only-entry"))]
+                    target.join(backedge);
+                    #[cfg(feature = "loop-type-only-entry")]
+                    {
+                        let mut backedge = backedge.clone();
+                        backedge.strip_xmm_to_stack();
+                        target.join(&backedge);
+                    }
                 }
 
                 target.liveness_analysis(liveness);

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -81,6 +81,15 @@ impl<'a> JitContext<'a> {
 
             let mut target = incoming;
             if let Some((liveness, backedge)) = self.loop_info(bbid) {
+                // §15.3 prototype: the loop fixpoint computed loop-carried
+                // floats as `F`, but `incoming.join(backedge)` collapses them to
+                // `S` (the boxed forward-entry initial value wins, since
+                // `decide_join` has no `S`/`F` arm), so the body boxes every
+                // iteration with the xmm pool free. Re-adopt the back-edge's `F`
+                // for those slots; the new `S -> F` bridge unboxes the forward
+                // entry once at the pre-header.
+                #[cfg(feature = "loop-keep-float")]
+                let backedge_for_floats = backedge.as_ref().map(|b| b.slot_state().clone());
                 if let Some(backedge) = backedge {
                     // §5 stage 3b: under `loop-type-only-entry`, strip the
                     // analysis pass's allocation from the loop-carried frame so
@@ -98,6 +107,11 @@ impl<'a> JitContext<'a> {
                 }
 
                 target.liveness_analysis(liveness);
+
+                #[cfg(feature = "loop-keep-float")]
+                if let Some(be) = &backedge_for_floats {
+                    target.keep_backedge_floats(be);
+                }
             }
             #[cfg(feature = "jit-debug")]
             eprintln!("  target:  {:?}\n", target.slot_state());

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -110,7 +110,19 @@ impl<'a> JitContext<'a> {
 
                 #[cfg(feature = "loop-keep-float")]
                 if let Some(be) = &backedge_for_floats {
-                    target.keep_backedge_floats(be);
+                    // A slot is promotable to `F` only if every predecessor entry
+                    // has a valid `_ -> F` bridge: `F`/`S`/`Sf`, or a float `C`.
+                    // A non-float `C` (or `G`/`V`/sentinel) path could not bridge
+                    // and would not actually be a float, so leave it boxed.
+                    let float_bridgeable = |m: LinkMode| {
+                        matches!(
+                            m,
+                            LinkMode::F(_) | LinkMode::S(_) | LinkMode::Sf(_, _)
+                        ) || matches!(m, LinkMode::C(v) if v.is_float())
+                    };
+                    target.keep_backedge_floats(be, |i| {
+                        entries.iter().all(|e| float_bridgeable(e.state.mode(i)))
+                    });
                 }
             }
             #[cfg(feature = "jit-debug")]

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -81,44 +81,27 @@ impl<'a> JitContext<'a> {
 
             let mut target = incoming;
             if let Some((liveness, backedge)) = self.loop_info(bbid) {
-                // §15.3 prototype: the loop fixpoint computed loop-carried
-                // floats as `F`, but `incoming.join(backedge)` collapses them to
-                // `S` (the boxed forward-entry initial value wins, since
-                // `decide_join` has no `S`/`F` arm), so the body boxes every
-                // iteration with the xmm pool free. Re-adopt the back-edge's `F`
-                // for those slots; the new `S -> F` bridge unboxes the forward
-                // entry once at the pre-header.
-                #[cfg(feature = "loop-keep-float")]
                 let backedge_for_floats = backedge.as_ref().map(|b| b.slot_state().clone());
                 if let Some(backedge) = backedge {
-                    // §5 stage 3b: under `loop-type-only-entry`, strip the
-                    // analysis pass's allocation from the loop-carried frame so
-                    // the codegen pass re-derives xmm bindings via liveness below
-                    // (`liveness_analysis` → `use_float`) instead of inheriting
-                    // it. Default build joins the placed backedge unchanged.
-                    #[cfg(not(feature = "loop-type-only-entry"))]
                     target.join(backedge);
-                    #[cfg(feature = "loop-type-only-entry")]
-                    {
-                        let mut backedge = backedge.clone();
-                        backedge.strip_xmm_to_stack();
-                        target.join(&backedge);
-                    }
                 }
 
                 target.liveness_analysis(liveness);
 
-                #[cfg(feature = "loop-keep-float")]
+                // §15.5 loop-entry float specialization: a loop JIT enters a
+                // loop-carried float from the VM as a conservative boxed
+                // `S(Value)` even though the back-edge fixpoint proved it is a
+                // `Float (F)`; `join(S(Value), F)` keeps `S`, so the body would
+                // decode+rebox it every iteration. Re-adopt the back-edge's `F`
+                // (the forward entry is unboxed once at the pre-header by the
+                // `S -> F` bridge, whose `float_to_fpr` carries the runtime float
+                // guard). Promote a slot only when every predecessor entry has a
+                // valid `_ -> F` bridge (`F`/`S`/`Sf`/float-`C`); a non-float-`C`
+                // path is genuinely not a float, so it is left boxed.
                 if let Some(be) = &backedge_for_floats {
-                    // A slot is promotable to `F` only if every predecessor entry
-                    // has a valid `_ -> F` bridge: `F`/`S`/`Sf`, or a float `C`.
-                    // A non-float `C` (or `G`/`V`/sentinel) path could not bridge
-                    // and would not actually be a float, so leave it boxed.
                     let float_bridgeable = |m: LinkMode| {
-                        matches!(
-                            m,
-                            LinkMode::F(_) | LinkMode::S(_) | LinkMode::Sf(_, _)
-                        ) || matches!(m, LinkMode::C(v) if v.is_float())
+                        matches!(m, LinkMode::F(_) | LinkMode::S(_) | LinkMode::Sf(_, _))
+                            || matches!(m, LinkMode::C(v) if v.is_float())
                     };
                     target.keep_backedge_floats(be, |i| {
                         entries.iter().all(|e| float_bridgeable(e.state.mode(i)))

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -7,7 +7,9 @@ mod slot;
 
 use liveness::IsUsed;
 pub(super) use liveness::Liveness;
+pub(super) use read_slot::TransferIR;
 use slot::SfGuarded;
+use slot::{FpXfer, Spill};
 pub(super) use slot::{Guarded, LinkMode, SlotState};
 
 #[derive(Debug, Clone)]

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -7,7 +7,7 @@ mod slot;
 
 use liveness::IsUsed;
 pub(super) use liveness::Liveness;
-pub(super) use read_slot::TransferIR;
+pub(super) use read_slot::{DeoptPoint, TransferIR};
 use slot::SfGuarded;
 use slot::{FpXfer, Spill};
 pub(super) use slot::{Guarded, LinkMode, SlotState};

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -76,29 +76,58 @@ impl AbstractFrame {
     }
 
     ///
-    /// Stage-1 shadow check: replay the recorded `JoinAction` stream from the
-    /// pre-merge frame and assert it reproduces the merged placement (the
-    /// resulting `LinkMode` of every slot). Proves the decision stream +
-    /// `apply_join` is a complete, replayable record of the meet — including its
-    /// cross-slot coupling (a `TryFresh*` allocation can demote *other* slots'
-    /// `Sf` bindings via `try_alloc_xmm`'s phase 1, and the replay reproduces
-    /// that). Debug-only.
+    /// Stage-1 + stage-2 shadow checks (debug-only), given the pre-merge frame
+    /// `pre` (consumed as the replay target) and the recorded action stream:
+    ///
+    /// **Stage 2 — type-meet separability.** Assert the fused meet's *type*
+    /// result (`self.guarded(i)`) equals the standalone `join_ty` pass —
+    /// `join_ty` computes `Guarded`s with **no allocation**. Proven arm-by-arm:
+    /// every non-sentinel arm's result type is `join_ty(self, other)` (the
+    /// `SfGuarded → Guarded` map is a join homomorphism, so the `Sf` arms agree
+    /// too). This is the type/placement split at the merge — a standalone
+    /// type+liveness analysis pass computes identical types, with allocation
+    /// peeled off into `apply_join` (doc §10 item 1, doc §12).
+    ///
+    /// **Stage 1 — placement record completeness.** Replay the recorded
+    /// `JoinAction` stream from `pre` and assert it reproduces the merged
+    /// placement (every slot's `LinkMode`), including the `try_alloc_xmm` phase-1
+    /// cross-slot demotions.
     ///
     #[cfg(debug_assertions)]
     fn verify_join_replay(
         &self,
         other: &AbstractFrame,
-        mut replay: AbstractFrame,
+        mut pre: AbstractFrame,
         actions: &[(SlotId, JoinAction)],
     ) {
-        replay.invariants.join(&other.invariants);
+        // Stage 2: the fused meet's type result == the allocation-free `join_ty`
+        // pass, for every non-sentinel slot (`guarded()` is undefined on the
+        // None/MaybeNone/V sentinels, and the meet leaves sentinel-involved slots
+        // untyped).
+        let is_sentinel =
+            |m| matches!(m, LinkMode::None | LinkMode::MaybeNone | LinkMode::V);
+        let expected_ty = pre.slot_state().join_ty(other.slot_state());
+        for i in self.all_regs() {
+            if is_sentinel(pre.mode(i)) || is_sentinel(other.mode(i)) || is_sentinel(self.mode(i))
+            {
+                continue;
+            }
+            debug_assert_eq!(
+                self.guarded(i),
+                expected_ty[i.0 as usize],
+                "type-meet separability broken at {i:?}",
+            );
+        }
+
+        // Stage 1: replay the action stream from `pre` and check placement.
+        pre.invariants.join(&other.invariants);
         for &(i, action) in actions {
-            replay.is_used_mut(i).join(other.is_used(i));
-            replay.apply_join(i, action);
+            pre.is_used_mut(i).join(other.is_used(i));
+            pre.apply_join(i, action);
         }
         for i in self.all_regs() {
             debug_assert_eq!(
-                replay.mode(i),
+                pre.mode(i),
                 self.mode(i),
                 "JoinAction replay mismatch at {i:?}",
             );

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -47,89 +47,145 @@ impl AbstractFrame {
         self.invariants.join(&other.invariants);
         for i in self.all_regs() {
             self.is_used_mut(i).join(other.is_used(i));
-            match (self.mode(i), other.mode(i)) {
-                (LinkMode::None, LinkMode::None) => {}
-                (LinkMode::MaybeNone, _) => {}
-                (_, LinkMode::MaybeNone) => {
-                    self.set_MaybeNone(i);
+            // De-fuse the meet (§5): `decide_join` is a pure read-only function
+            // of the two input `LinkMode`s (the merge *decision*); `apply_join`
+            // performs the placement mutation — and is the *only* place the meet
+            // allocates an xmm (`try_set_new_F` / `try_set_new_Sf`). This is the
+            // seam the allocator pass will own: it will consume the `JoinAction`
+            // stream and assign registers + emit edge moves, instead of
+            // `apply_join` allocating inline. Behaviour is identical to the old
+            // fused per-slot match.
+            let action = self.decide_join(other, i);
+            self.apply_join(i, action);
+        }
+    }
+}
+
+///
+/// The per-slot merge decision (§5 de-fusion): a pure function of the two
+/// predecessors' `LinkMode`s, computed by [`AbstractFrame::decide_join`] and
+/// executed by [`AbstractFrame::apply_join`]. Reifying the decision separates
+/// the *meet* (analysis) from the *placement mutation + xmm allocation*
+/// (codegen/allocation) — the prerequisite for moving allocation into its own
+/// pass that lowers these actions to register assignments + edge moves.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum JoinAction {
+    /// keep `self`'s binding unchanged
+    Nop,
+    /// `_ -> MaybeNone`
+    SetMaybeNone,
+    /// `_ -> V`
+    Discard,
+    /// registers disagree across branches: try to rebind to a fresh xmm so each
+    /// bridge is a single move; keep the current `F` binding if no phys xmm is
+    /// free (the bridge then swaps). [`F`/`F` arm]
+    TryFreshFKeep,
+    /// try fresh-xmm `F`; fall back to `S(Float)` if no phys xmm is free.
+    /// [`C`/`F` and `C`/`C`-both-float arms]
+    TryFreshFElseS,
+    /// rebind to `Sf(x, guarded)` with the current xmm `x` (registers agree, or
+    /// the `Sf`/`C` arm folding a literal into the guard).
+    SetSf(FPReg, SfGuarded),
+    /// try fresh-xmm `Sf(guarded)`; keep `Sf(x, guarded)` if no phys xmm is free.
+    /// [`F`|`Sf` / `Sf`|`F` arm, registers disagree]
+    TryFreshSfElseKeep(FPReg, SfGuarded),
+    /// try fresh-xmm `Sf(guarded)`; fall back to `S(guarded)` if no phys xmm.
+    /// [`C` / `Sf` arm]
+    TryFreshSfElseS(SfGuarded),
+    /// `_ -> S(guarded)`
+    SetS(Guarded),
+}
+
+impl AbstractFrame {
+    ///
+    /// Decide the merge action for slot *i* from the two predecessors' modes
+    /// (the meet table in [`Self::join`]). Pure: reads `self`/`other` only.
+    ///
+    fn decide_join(&self, other: &AbstractFrame, i: SlotId) -> JoinAction {
+        use JoinAction::*;
+        match (self.mode(i), other.mode(i)) {
+            (LinkMode::None, LinkMode::None) => Nop,
+            (LinkMode::MaybeNone, _) => Nop,
+            (_, LinkMode::MaybeNone) => SetMaybeNone,
+            (LinkMode::V, _) => Nop,
+            (_, LinkMode::V) => Discard,
+            (LinkMode::F(l), LinkMode::F(r)) => {
+                if l != r {
+                    TryFreshFKeep
+                } else {
+                    Nop
                 }
-                (LinkMode::V, _) => {}
-                (_, LinkMode::V) => {
-                    self.discard(i);
+            }
+            (LinkMode::F(_), LinkMode::C(r)) if r.is_float() => Nop,
+            (LinkMode::F(x), LinkMode::Sf(_, _))
+            | (LinkMode::Sf(x, _), LinkMode::Sf(_, _) | LinkMode::F(_)) => {
+                let mut guarded = match self.mode(i) {
+                    LinkMode::F(_) => SfGuarded::Float,
+                    LinkMode::Sf(_, guarded) => guarded,
+                    _ => unreachable!(),
+                };
+                let (other_xmm, other_g) = match other.mode(i) {
+                    LinkMode::F(y) => (y, SfGuarded::Float),
+                    LinkMode::Sf(y, guarded) => (y, guarded),
+                    _ => unreachable!(),
+                };
+                guarded.join(other_g);
+                if x == other_xmm {
+                    SetSf(x, guarded)
+                } else {
+                    TryFreshSfElseKeep(x, guarded)
                 }
-                (LinkMode::F(l), LinkMode::F(r)) => {
-                    if l != r {
-                        // Registers differ across branches. Keeping `F(l)`
-                        // here would force the `F(r)` side's bridge to swap
-                        // `l <-> r`, which displaces any other slot bound to
-                        // `l` in that source state (a common occurrence when
-                        // the `F(l)` side reached the merge via the zero-cost
-                        // alias created by `copy_slot`). Rebind to a fresh
-                        // xmm that no slot in the merge context uses, so
-                        // each bridge can emit a single `xmm_move` instead.
-                        // No AsmIr here — if a Phase-2 spill would be needed,
-                        // fall back to keeping `F(l)` and let the bridge swap.
-                        let _ = self.try_set_new_F(i);
-                    }
+            }
+            (LinkMode::Sf(x, mut guarded), LinkMode::C(r)) if r.is_float() || r.is_fixnum() => {
+                guarded.join(SfGuarded::from_concrete_value(r));
+                SetSf(x, guarded)
+            }
+            (LinkMode::C(v), LinkMode::F(_)) if v.is_float() => TryFreshFElseS,
+            (LinkMode::C(v), LinkMode::Sf(_, r)) if v.is_float() || v.is_fixnum() => {
+                let mut guarded = SfGuarded::from_concrete_value(v);
+                guarded.join(r);
+                TryFreshSfElseS(guarded)
+            }
+            (LinkMode::C(l), LinkMode::C(r)) if l == r => Nop,
+            (LinkMode::C(l), LinkMode::C(r)) if l.is_float() && r.is_float() => TryFreshFElseS,
+            _ => SetS(self.guarded(i).join(&other.guarded(i))),
+        }
+    }
+
+    ///
+    /// Apply a merge action to slot *i*. The **only** place [`Self::join`]
+    /// mutates placement or allocates an xmm.
+    ///
+    fn apply_join(&mut self, i: SlotId, action: JoinAction) {
+        match action {
+            JoinAction::Nop => {}
+            JoinAction::SetMaybeNone => self.set_MaybeNone(i),
+            JoinAction::Discard => self.discard(i),
+            JoinAction::TryFreshFKeep => {
+                // No AsmIr here — if a Phase-2 spill would be needed,
+                // fall back to keeping `F(l)` and let the bridge swap.
+                let _ = self.try_set_new_F(i);
+            }
+            JoinAction::TryFreshFElseS => {
+                if self.try_set_new_F(i).is_none() {
+                    // Fall back to S — bridge materialises from the concrete
+                    // literal on the C side and from xmm on the F side.
+                    self.set_S_with_guard(i, Guarded::Float);
                 }
-                (LinkMode::F(_), LinkMode::C(r)) if r.is_float() => {}
-                (LinkMode::F(x), LinkMode::Sf(_, _))
-                | (LinkMode::Sf(x, _), LinkMode::Sf(_, _) | LinkMode::F(_)) => {
-                    let mut guarded = match self.mode(i) {
-                        LinkMode::F(_) => SfGuarded::Float,
-                        LinkMode::Sf(_, guarded) => guarded,
-                        _ => unreachable!(),
-                    };
-                    let (other_xmm, other_g) = match other.mode(i) {
-                        LinkMode::F(y) => (y, SfGuarded::Float),
-                        LinkMode::Sf(y, guarded) => (y, guarded),
-                        _ => unreachable!(),
-                    };
-                    guarded.join(other_g);
-                    if x == other_xmm {
-                        self.set_Sf(i, x, guarded);
-                    } else {
-                        // Same reasoning as the F/F arm: register disagreement
-                        // across branches would force bridge-time swaps that
-                        // trample partner slots created by `copy_slot`'s
-                        // zero-cost alias. Rebind to a fresh xmm if possible;
-                        // otherwise keep the current Sf binding and let the
-                        // bridge handle the swap.
-                        if self.try_set_new_Sf(i, guarded).is_none() {
-                            self.set_Sf(i, x, guarded);
-                        }
-                    }
+            }
+            JoinAction::SetSf(x, guarded) => self.set_Sf(i, x, guarded),
+            JoinAction::TryFreshSfElseKeep(x, guarded) => {
+                if self.try_set_new_Sf(i, guarded).is_none() {
+                    self.set_Sf(i, x, guarded);
                 }
-                (LinkMode::Sf(x, mut guarded), LinkMode::C(r)) if r.is_float() || r.is_fixnum() => {
-                    guarded.join(SfGuarded::from_concrete_value(r));
-                    self.set_Sf(i, x, guarded)
+            }
+            JoinAction::TryFreshSfElseS(guarded) => {
+                if self.try_set_new_Sf(i, guarded).is_none() {
+                    self.set_S_with_guard(i, guarded.into());
                 }
-                (LinkMode::C(v), LinkMode::F(_)) if v.is_float() => {
-                    if self.try_set_new_F(i).is_none() {
-                        // Fall back to S — bridge will materialise from the
-                        // concrete literal on the C side and from xmm on the
-                        // F side.
-                        self.set_S_with_guard(i, Guarded::Float);
-                    }
-                }
-                (LinkMode::C(v), LinkMode::Sf(_, r)) if v.is_float() || v.is_fixnum() => {
-                    let mut guarded = SfGuarded::from_concrete_value(v);
-                    guarded.join(r);
-                    if self.try_set_new_Sf(i, guarded).is_none() {
-                        self.set_S_with_guard(i, guarded.into());
-                    }
-                }
-                (LinkMode::C(l), LinkMode::C(r)) if l == r => {}
-                (LinkMode::C(l), LinkMode::C(r)) if l.is_float() && r.is_float() => {
-                    if self.try_set_new_F(i).is_none() {
-                        self.set_S_with_guard(i, Guarded::Float);
-                    }
-                }
-                _ => {
-                    let guarded = self.guarded(i).join(&other.guarded(i));
-                    self.set_S_with_guard(i, guarded);
-                }
-            };
+            }
+            JoinAction::SetS(guarded) => self.set_S_with_guard(i, guarded),
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -164,9 +164,3 @@ impl IsUsed {
         };
     }
 }
-
-impl Guarded {
-    fn join(&self, other: &Self) -> Self {
-        if self == other { *self } else { Guarded::Value }
-    }
-}

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -9,16 +9,6 @@ impl AbstractState {
             lhs.join(rhs);
         }
     }
-
-    /// Type-only projection of every frame: demote all xmm-resident slots to
-    /// their stack home (doc §13 stage 3b experiment). See
-    /// [`SlotState::strip_xmm_to_stack`].
-    #[cfg(feature = "loop-type-only-entry")]
-    pub(in crate::codegen::jitgen) fn strip_xmm_to_stack(&mut self) {
-        for frame in &mut self.frames {
-            frame.strip_xmm_to_stack();
-        }
-    }
 }
 
 impl Liveness {

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -44,7 +44,18 @@ impl AbstractFrame {
     ///
     /// ~~~
     fn join(&mut self, other: &AbstractFrame) {
+        // §5 allocator de-fusion, stage 1: record the per-slot `JoinAction`
+        // stream as we merge, then (debug) replay it from the pre-merge frame and
+        // assert it reproduces the identical placement. This locks the property
+        // the separated allocator pass relies on — the (allocation-free) decision
+        // stream plus `apply_join` is a *complete* record of the meet's placement
+        // work — and is the regression harness future allocator changes shadow
+        // against. See doc/regalloc_separation.md §12.
+        #[cfg(debug_assertions)]
+        let pre = self.clone();
         self.invariants.join(&other.invariants);
+        #[cfg(debug_assertions)]
+        let mut actions = Vec::new();
         for i in self.all_regs() {
             self.is_used_mut(i).join(other.is_used(i));
             // De-fuse the meet (§5): `decide_join` is a pure read-only function
@@ -56,7 +67,41 @@ impl AbstractFrame {
             // `apply_join` allocating inline. Behaviour is identical to the old
             // fused per-slot match.
             let action = self.decide_join(other, i);
+            #[cfg(debug_assertions)]
+            actions.push((i, action));
             self.apply_join(i, action);
+        }
+        #[cfg(debug_assertions)]
+        self.verify_join_replay(other, pre, &actions);
+    }
+
+    ///
+    /// Stage-1 shadow check: replay the recorded `JoinAction` stream from the
+    /// pre-merge frame and assert it reproduces the merged placement (the
+    /// resulting `LinkMode` of every slot). Proves the decision stream +
+    /// `apply_join` is a complete, replayable record of the meet — including its
+    /// cross-slot coupling (a `TryFresh*` allocation can demote *other* slots'
+    /// `Sf` bindings via `try_alloc_xmm`'s phase 1, and the replay reproduces
+    /// that). Debug-only.
+    ///
+    #[cfg(debug_assertions)]
+    fn verify_join_replay(
+        &self,
+        other: &AbstractFrame,
+        mut replay: AbstractFrame,
+        actions: &[(SlotId, JoinAction)],
+    ) {
+        replay.invariants.join(&other.invariants);
+        for &(i, action) in actions {
+            replay.is_used_mut(i).join(other.is_used(i));
+            replay.apply_join(i, action);
+        }
+        for i in self.all_regs() {
+            debug_assert_eq!(
+                replay.mode(i),
+                self.mode(i),
+                "JoinAction replay mismatch at {i:?}",
+            );
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -9,6 +9,16 @@ impl AbstractState {
             lhs.join(rhs);
         }
     }
+
+    /// Type-only projection of every frame: demote all xmm-resident slots to
+    /// their stack home (doc §13 stage 3b experiment). See
+    /// [`SlotState::strip_xmm_to_stack`].
+    #[cfg(feature = "loop-type-only-entry")]
+    pub(in crate::codegen::jitgen) fn strip_xmm_to_stack(&mut self) {
+        for frame in &mut self.frames {
+            frame.strip_xmm_to_stack();
+        }
+    }
 }
 
 impl Liveness {

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -79,6 +79,58 @@ impl GpLoad {
     }
 }
 
+///
+/// A deopt-carrying *fixnum* unbox load produced by `load_xmm_fixnum` (item ②,
+/// step 2). Mirrors [`XmmLoad`] but the boxed value is known to be an `Integer`,
+/// so the conversion is `fixnum2fpr` (no float reinterpret) preceded by an
+/// explicit `Integer` class guard.
+///
+/// This is the case doc §9 once flagged as "needs the sequence model": its
+/// `S`/`G` arms interleave a load (`stack2reg`), a `new_deopt`, a guard and the
+/// conversion. The interleaving dissolves because `stack2reg`/`reg2stack` are
+/// *pure emits* on `ir` that never touch the frame's placement state, so
+/// `new_deopt` **commutes** with them — the deopt can be created up front (as in
+/// `load_xmm`) and the load deferred into this record's emit half. The guard is
+/// folded in as a bool (`guard_class_state`'s verdict); when set, the codegen
+/// half pushes `GuardClass` with the wrapper-supplied deopt.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum XmmFixnumLoad {
+    /// already in an xmm (`Sf` / `F`) — nothing to emit
+    None,
+    /// `stack2reg(slot, Rdi); [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`
+    FromStack(FPReg, bool),
+    /// `reg2stack(R15, slot); [GuardClass(R15)]; fixnum2fpr(R15, x)`
+    FromAcc(FPReg, bool),
+    /// guard-free numeric literal (`LinkMode::C`) — reuses the [`XmmLoad`] record
+    Numeric(XmmLoad),
+}
+
+impl XmmFixnumLoad {
+    /// `deopt` is required by the guarded (`FromStack` / `FromAcc` with the bool
+    /// set) variants and `None` for the guard-free ones.
+    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<AsmDeopt>) {
+        match self {
+            XmmFixnumLoad::None => {}
+            XmmFixnumLoad::FromStack(x, guard) => {
+                ir.stack2reg(slot, GP::Rdi);
+                if guard {
+                    ir.push(AsmInst::GuardClass(GP::Rdi, INTEGER_CLASS, deopt.unwrap()));
+                }
+                ir.fixnum2fpr(GP::Rdi, x);
+            }
+            XmmFixnumLoad::FromAcc(x, guard) => {
+                ir.reg2stack(GP::R15, slot);
+                if guard {
+                    ir.push(AsmInst::GuardClass(GP::R15, INTEGER_CLASS, deopt.unwrap()));
+                }
+                ir.fixnum2fpr(GP::R15, x);
+            }
+            XmmFixnumLoad::Numeric(load) => load.emit(ir, slot, None),
+        }
+    }
+}
+
 impl AbstractFrame {
     ///
     /// load *slot* into *dst*.
@@ -177,30 +229,47 @@ impl AbstractFrame {
     /// - rdi
     ///
     pub(crate) fn load_xmm_fixnum(&mut self, ir: &mut AsmIr, slot: SlotId) -> FPReg {
+        // Only the `S`/`G` arms guard, so a deopt is created only for them — and
+        // *before* the state transition, so its write-back snapshot is the
+        // pre-load placement (cf. `load_xmm`). `use_as_value` (below, in the
+        // state half) only touches liveness, so this peek is stable; and the
+        // later `stack2reg`/`reg2stack` are pure emits that don't perturb the
+        // snapshot. The guard-free `Sf`/`F`/`C` arms create no deopt, exactly as
+        // before.
+        let deopt = matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_))
+            .then(|| ir.new_deopt(self));
+        let (x, load) = self.load_xmm_fixnum_state(slot);
+        load.emit(ir, slot, deopt);
+        x
+    }
+
+    ///
+    /// Analysis half of [`Self::load_xmm_fixnum`] (item ②, step 2): refine the
+    /// slot to `Integer`, allocate the xmm and bind the slot, returning the
+    /// register plus the conversion (and whether a runtime guard is needed) to
+    /// emit. Pure state.
+    ///
+    fn load_xmm_fixnum_state(&mut self, slot: SlotId) -> (FPReg, XmmFixnumLoad) {
         self.use_as_value(slot);
         match self.mode(slot) {
-            LinkMode::Sf(x, _) | LinkMode::F(x) => x,
+            LinkMode::Sf(x, _) | LinkMode::F(x) => (x, XmmFixnumLoad::None),
             LinkMode::S(_) => {
-                // S -> Sf
-                ir.stack2reg(slot, GP::Rdi);
-                self.guard_fixnum(ir, slot, GP::Rdi);
+                // S -> Sf. Refine the type first (its guard verdict) then take
+                // the placement; `set_new_Sf` overwrites the refined `S` guarded
+                // with `Sf(Fixnum)`, exactly as `guard_fixnum` + `set_new_Sf` did.
+                let guard = self.guard_class_state(slot, INTEGER_CLASS);
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                ir.fixnum2fpr(GP::Rdi, x);
-                x
+                (x, XmmFixnumLoad::FromStack(x, guard))
             }
             LinkMode::G(_) => {
                 // G -> Sf
-                ir.reg2stack(GP::R15, slot);
-                self.guard_fixnum(ir, slot, GP::R15);
+                let guard = self.guard_class_state(slot, INTEGER_CLASS);
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                ir.fixnum2fpr(GP::R15, x);
-                x
+                (x, XmmFixnumLoad::FromAcc(x, guard))
             }
             LinkMode::C(v) => {
-                // Guard-free (numeric literal): no deopt needed.
                 let (x, load) = self.load_xmm_from_C_state(slot, v);
-                load.emit(ir, slot, None);
-                x
+                (x, XmmFixnumLoad::Numeric(load))
             }
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("load_xmm_fixnum() {:?}", self.mode(slot));

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -1,5 +1,51 @@
 use super::*;
 
+///
+/// A deopt-carrying unbox load produced by `load_xmm` (item ②, step 2): the
+/// conversion to emit when materializing a slot's value into an FP register.
+///
+/// The `FromStack` / `FromAcc` variants need a guard (their `float_to_fpr`
+/// deopts if the boxed value is not actually a `Float`); the deopt is supplied
+/// by the codegen wrapper, **not** frozen in the record — the analysis half only
+/// decided the conversion, while the codegen side creates the side-exit from the
+/// placement state at this point (see doc/regalloc_separation.md §9). The
+/// numeric-literal variants are guard-free.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum XmmLoad {
+    /// already in an xmm (`Sf` / `F`) — nothing to emit
+    None,
+    /// `stack2reg(slot, Rdi); float_to_fpr(Rdi, x, deopt)`
+    FromStack(FPReg),
+    /// `reg2stack(R15, slot); float_to_fpr(R15, x, deopt)`
+    FromAcc(FPReg),
+    /// `f64_to_fpr(f, x)` (guard-free)
+    FromF64(f64, FPReg),
+    /// `i64_to_stack_and_fpr(i, slot, x)` (guard-free)
+    FromFixnum(i64, FPReg),
+}
+
+impl XmmLoad {
+    /// `deopt` is required by the guarded (`FromStack` / `FromAcc`) variants and
+    /// ignored by the guard-free ones; the guard-free `load_xmm_from_C_state`
+    /// path passes `None`.
+    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<AsmDeopt>) {
+        match self {
+            XmmLoad::None => {}
+            XmmLoad::FromStack(x) => {
+                ir.stack2reg(slot, GP::Rdi);
+                ir.float_to_fpr(GP::Rdi, x, deopt.unwrap());
+            }
+            XmmLoad::FromAcc(x) => {
+                ir.reg2stack(GP::R15, slot);
+                ir.float_to_fpr(GP::R15, x, deopt.unwrap());
+            }
+            XmmLoad::FromF64(f, x) => ir.f64_to_fpr(f, x),
+            XmmLoad::FromFixnum(i, x) => ir.i64_to_stack_and_fpr(i, slot, x),
+        }
+    }
+}
+
 impl AbstractFrame {
     ///
     /// load *slot* into *r*.
@@ -113,7 +159,12 @@ impl AbstractFrame {
                 ir.fixnum2fpr(GP::R15, x);
                 x
             }
-            LinkMode::C(v) => self.load_xmm_from_C(ir, slot, v),
+            LinkMode::C(v) => {
+                // Guard-free (numeric literal): no deopt needed.
+                let (x, load) = self.load_xmm_from_C_state(slot, v);
+                load.emit(ir, slot, None);
+                x
+            }
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("load_xmm_fixnum() {:?}", self.mode(slot));
             }
@@ -128,25 +179,37 @@ impl AbstractFrame {
     ///
     ///
     pub(crate) fn load_xmm(&mut self, ir: &mut AsmIr, slot: SlotId) -> FPReg {
+        // The deopt is created *before* the state transition, so its write-back
+        // snapshot (`get_write_back`) is the pre-load placement — see the
+        // deopt-carrying-transfer note in doc/regalloc_separation.md §9. The
+        // record carries only the conversion; the deopt is supplied here (the
+        // codegen side), not frozen into the record.
         let deopt = ir.new_deopt(self);
+        let (x, load) = self.load_xmm_state(slot);
+        load.emit(ir, slot, Some(deopt));
+        x
+    }
+
+    ///
+    /// Analysis half of [`Self::load_xmm`] (item ②, step 2): perform the
+    /// abstract-state transition (allocate the xmm, bind the slot) and return
+    /// the allocated register plus the conversion to emit. Pure state.
+    ///
+    fn load_xmm_state(&mut self, slot: SlotId) -> (FPReg, XmmLoad) {
         self.use_as_float(slot);
         match self.mode(slot) {
-            LinkMode::Sf(x, _) | LinkMode::F(x) => x,
+            LinkMode::Sf(x, _) | LinkMode::F(x) => (x, XmmLoad::None),
             LinkMode::S(_) => {
                 // -> Sf
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
-                ir.stack2reg(slot, GP::Rdi);
-                ir.float_to_fpr(GP::Rdi, x, deopt);
-                x
+                (x, XmmLoad::FromStack(x))
             }
             LinkMode::G(_) => {
                 // -> Sf
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
-                ir.reg2stack(GP::R15, slot);
-                ir.float_to_fpr(GP::R15, x, deopt);
-                x
+                (x, XmmLoad::FromAcc(x))
             }
-            LinkMode::C(v) => self.load_xmm_from_C(ir, slot, v),
+            LinkMode::C(v) => self.load_xmm_from_C_state(slot, v),
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("load_xmm() {:?}", self.mode(slot));
             }
@@ -154,31 +217,25 @@ impl AbstractFrame {
     }
 
     #[allow(non_snake_case)]
-    fn load_xmm_from_C(&mut self, ir: &mut AsmIr, slot: SlotId, v: Value) -> FPReg {
+    fn load_xmm_from_C_state(&mut self, slot: SlotId, v: Value) -> (FPReg, XmmLoad) {
         // `LinkMode::C` may hold any Value; xmm loads only ever come from
         // numeric literals (fixnum / float / heap Float), so anything else
         // is a bug at the call site.
         match v.unpack() {
             RV::Float(f) => {
                 // -> F
-                self.load_xmm_from_f64(ir, slot, f)
+                let x = self.set_new_F(slot);
+                (x, XmmLoad::FromF64(f, x))
             }
             RV::Fixnum(i) => {
                 // -> Sf
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                ir.i64_to_stack_and_fpr(i, slot, x);
-                x
+                (x, XmmLoad::FromFixnum(i, x))
             }
             _ => {
                 unreachable!("load_xmm_from_C() {:?}", v);
             }
         }
-    }
-
-    fn load_xmm_from_f64(&mut self, ir: &mut AsmIr, slot: SlotId, f: f64) -> FPReg {
-        let x = self.set_new_F(slot);
-        ir.f64_to_fpr(f, x);
-        x
     }
 }
 

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -1,14 +1,46 @@
 use super::*;
 
 ///
+/// The **deopt program point** a guarded transfer record carries (doc §9): the
+/// bytecode `pc` and the write-back placement snapshot needed to rebuild the
+/// side-exit if the float/Integer guard fails.
+///
+/// This is the codegen-*independent* replacement for a frozen `AsmDeopt` (an
+/// index into the codegen pass's `side_exit` table). The analysis half records
+/// the point (pure values it already tracks); the emit/codegen half materializes
+/// the actual side-exit from it via [`AsmIr::deopt_from_point`]. With this the
+/// `TransferIR` stream no longer embeds any codegen-pass state — the prerequisite
+/// for replaying it from a standalone lowering pass.
+///
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::codegen::jitgen) struct DeoptPoint {
+    pc: BytecodePtr,
+    write_back: WriteBack,
+}
+
+impl DeoptPoint {
+    pub(super) fn new(pc: BytecodePtr, write_back: WriteBack) -> Self {
+        Self { pc, write_back }
+    }
+
+    pub(in crate::codegen::jitgen) fn pc(&self) -> BytecodePtr {
+        self.pc
+    }
+
+    pub(in crate::codegen::jitgen) fn write_back(&self) -> &WriteBack {
+        &self.write_back
+    }
+}
+
+///
 /// A deopt-carrying unbox load produced by `load_xmm` (item ②, step 2): the
 /// conversion to emit when materializing a slot's value into an FP register.
 ///
 /// The `FromStack` / `FromAcc` variants need a guard (their `float_to_fpr`
-/// deopts if the boxed value is not actually a `Float`); the deopt is supplied
-/// by the codegen wrapper, **not** frozen in the record — the analysis half only
-/// decided the conversion, while the codegen side creates the side-exit from the
-/// placement state at this point (see doc/regalloc_separation.md §9). The
+/// deopts if the boxed value is not actually a `Float`); the emit half
+/// materializes the side-exit from the record's [`DeoptPoint`] program point,
+/// **not** a frozen `AsmDeopt` — the analysis half only decided the conversion
+/// and recorded the point (see doc/regalloc_separation.md §9). The
 /// numeric-literal variants are guard-free.
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -26,19 +58,23 @@ pub(in crate::codegen::jitgen) enum XmmLoad {
 }
 
 impl XmmLoad {
-    /// `deopt` is required by the guarded (`FromStack` / `FromAcc`) variants and
-    /// ignored by the guard-free ones; the guard-free `load_xmm_from_C_state`
-    /// path passes `None`.
-    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<AsmDeopt>) {
+    /// `deopt` (the program point) is required by the guarded (`FromStack` /
+    /// `FromAcc`) variants and ignored by the guard-free ones; the guard-free
+    /// `load_xmm_from_C_state` path passes `None`. The side-exit is materialized
+    /// here (codegen side) via [`AsmIr::deopt_from_point`], matching the old
+    /// "create the deopt first" order so the `side_exit` table is identical.
+    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<&DeoptPoint>) {
         match self {
             XmmLoad::None => {}
             XmmLoad::FromStack(x) => {
+                let deopt = ir.deopt_from_point(deopt.unwrap());
                 ir.stack2reg(slot, GP::Rdi);
-                ir.float_to_fpr(GP::Rdi, x, deopt.unwrap());
+                ir.float_to_fpr(GP::Rdi, x, deopt);
             }
             XmmLoad::FromAcc(x) => {
+                let deopt = ir.deopt_from_point(deopt.unwrap());
                 ir.reg2stack(GP::R15, slot);
-                ir.float_to_fpr(GP::R15, x, deopt.unwrap());
+                ir.float_to_fpr(GP::R15, x, deopt);
             }
             XmmLoad::FromF64(f, x) => ir.f64_to_fpr(f, x),
             XmmLoad::FromFixnum(i, x) => ir.i64_to_stack_and_fpr(i, slot, x),
@@ -107,12 +143,16 @@ pub(in crate::codegen::jitgen) enum XmmFixnumLoad {
 }
 
 impl XmmFixnumLoad {
-    /// `deopt` is required by the guarded (`FromStack` / `FromAcc` with the bool
-    /// set) variants and `None` for the guard-free ones.
-    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<AsmDeopt>) {
+    /// `deopt` (the program point) is `Some` for the guarded `S`/`G` arms and
+    /// `None` for the guard-free ones. The side-exit is materialized for the
+    /// `S`/`G` arms whenever the point is `Some` — even if `guard` is false, so
+    /// the `side_exit` table stays identical to the pre-split wrapper, which
+    /// created the deopt unconditionally for those arms.
+    fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<&DeoptPoint>) {
         match self {
             XmmFixnumLoad::None => {}
             XmmFixnumLoad::FromStack(x, guard) => {
+                let deopt = deopt.map(|p| ir.deopt_from_point(p));
                 ir.stack2reg(slot, GP::Rdi);
                 if guard {
                     ir.push(AsmInst::GuardClass(GP::Rdi, INTEGER_CLASS, deopt.unwrap()));
@@ -120,6 +160,7 @@ impl XmmFixnumLoad {
                 ir.fixnum2fpr(GP::Rdi, x);
             }
             XmmFixnumLoad::FromAcc(x, guard) => {
+                let deopt = deopt.map(|p| ir.deopt_from_point(p));
                 ir.reg2stack(GP::R15, slot);
                 if guard {
                     ir.push(AsmInst::GuardClass(GP::R15, INTEGER_CLASS, deopt.unwrap()));
@@ -138,11 +179,13 @@ impl XmmFixnumLoad {
 /// the record (building the typed-IR stream that record-driven lowering will
 /// replay) and emits it via [`TransferIR::emit`].
 ///
-/// The deopt is still a frozen `AsmDeopt` here (the `XmmLoad` / `XmmFixnumLoad`
-/// guarded variants). Lifting it to a program point — so the stream is fully
-/// codegen-independent — is the next step (see doc/regalloc_separation.md §9).
+/// The guarded variants (`XmmLoad` / `XmmFixnumLoad`) carry the deopt as a
+/// [`DeoptPoint`] program point, **not** a frozen `AsmDeopt` index — so the
+/// stream is now fully codegen-independent (the emit half materializes the
+/// side-exit). `TransferIR` is therefore `Clone` but not `Copy` (a `DeoptPoint`
+/// owns a `WriteBack`).
 ///
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(in crate::codegen::jitgen) enum TransferIR {
     Spill(Spill),
     FpXfer(FpXfer),
@@ -151,14 +194,14 @@ pub(in crate::codegen::jitgen) enum TransferIR {
     XmmLoad {
         load: XmmLoad,
         slot: SlotId,
-        deopt: AsmDeopt,
+        deopt: DeoptPoint,
     },
     /// `load_xmm_fixnum`: unbox Integer to float; `deopt` present only for the
     /// guarded `S`/`G` arms.
     XmmFixnumLoad {
         load: XmmFixnumLoad,
         slot: SlotId,
-        deopt: Option<AsmDeopt>,
+        deopt: Option<DeoptPoint>,
     },
 }
 
@@ -168,8 +211,8 @@ impl TransferIR {
             TransferIR::Spill(s) => s.emit(ir),
             TransferIR::FpXfer(f) => f.emit(ir),
             TransferIR::GpLoad(g) => g.emit(ir),
-            TransferIR::XmmLoad { load, slot, deopt } => load.emit(ir, slot, Some(deopt)),
-            TransferIR::XmmFixnumLoad { load, slot, deopt } => load.emit(ir, slot, deopt),
+            TransferIR::XmmLoad { load, slot, deopt } => load.emit(ir, slot, Some(&deopt)),
+            TransferIR::XmmFixnumLoad { load, slot, deopt } => load.emit(ir, slot, deopt.as_ref()),
         }
     }
 }
@@ -273,15 +316,15 @@ impl AbstractFrame {
     /// - rdi
     ///
     pub(crate) fn load_xmm_fixnum(&mut self, ir: &mut AsmIr, slot: SlotId) -> FPReg {
-        // Only the `S`/`G` arms guard, so a deopt is created only for them — and
-        // *before* the state transition, so its write-back snapshot is the
-        // pre-load placement (cf. `load_xmm`). `use_as_value` (below, in the
-        // state half) only touches liveness, so this peek is stable; and the
+        // Only the `S`/`G` arms guard, so a deopt point is recorded only for
+        // them — and *before* the state transition, so its write-back snapshot
+        // is the pre-load placement (cf. `load_xmm`). `use_as_value` (below, in
+        // the state half) only touches liveness, so this peek is stable; and the
         // later `stack2reg`/`reg2stack` are pure emits that don't perturb the
-        // snapshot. The guard-free `Sf`/`F`/`C` arms create no deopt, exactly as
-        // before.
-        let deopt = matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_))
-            .then(|| ir.new_deopt(self));
+        // snapshot. The guard-free `Sf`/`F`/`C` arms record no deopt, exactly as
+        // before. The side-exit itself is materialized in the emit half.
+        let deopt =
+            matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_)).then(|| self.deopt_point());
         let (x, load) = self.load_xmm_fixnum_state(slot);
         ir.transfer(TransferIR::XmmFixnumLoad { load, slot, deopt });
         x
@@ -329,15 +372,28 @@ impl AbstractFrame {
     ///
     ///
     pub(crate) fn load_xmm(&mut self, ir: &mut AsmIr, slot: SlotId) -> FPReg {
-        // The deopt is created *before* the state transition, so its write-back
-        // snapshot (`get_write_back`) is the pre-load placement — see the
-        // deopt-carrying-transfer note in doc/regalloc_separation.md §9. The
-        // record carries only the conversion; the deopt is supplied here (the
-        // codegen side), not frozen into the record.
-        let deopt = ir.new_deopt(self);
+        // The deopt point is recorded *before* the state transition, so its
+        // write-back snapshot (`get_write_back`) is the pre-load placement — see
+        // doc/regalloc_separation.md §9. The record carries the program point
+        // (pc + write-back), not a frozen `AsmDeopt`; the emit half materializes
+        // the side-exit from it.
+        let deopt = self.deopt_point();
         let (x, load) = self.load_xmm_state(slot);
         ir.transfer(TransferIR::XmmLoad { load, slot, deopt });
         x
+    }
+
+    ///
+    /// Capture the deopt **program point** at the current placement state (item
+    /// ②, step 2 — deopt program-point-ification, doc §9): the bytecode `pc`
+    /// plus the write-back snapshot `get_write_back()` — *which* values are
+    /// unboxed/in-acc and must be restored to the stack if a guard fails. This is
+    /// pure analysis state; the codegen half turns it into an `AsmDeopt`
+    /// side-exit via [`AsmIr::deopt_from_point`]. Mirrors `AsmIr::new_deopt`'s
+    /// snapshot, minus the `side_exit` push.
+    ///
+    fn deopt_point(&self) -> DeoptPoint {
+        DeoptPoint::new(self.pc(), self.get_write_back())
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -46,9 +46,42 @@ impl XmmLoad {
     }
 }
 
+///
+/// A GP-register load produced by `load` (item ②, step 2): how to materialize a
+/// slot's boxed `Value` into a general-purpose register. Like the other typed-IR
+/// records, the *what* is decided by the analysis half (`load_state`) and
+/// emitted by the codegen half via [`GpLoad::emit`].
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum GpLoad {
+    /// `F` slot: box the xmm to its stack home (leaving the boxed value in rax),
+    /// then move rax into `dst`. `fpr2stack(fpr, slot); reg_move(rax, dst)`.
+    FprBox(FPReg, SlotId, GP),
+    /// `lit2reg(value, dst)`
+    Lit(Value, GP),
+    /// `stack2reg(slot, dst)`
+    Stack(SlotId, GP),
+    /// `reg_move(r15, dst)`
+    Acc(GP),
+}
+
+impl GpLoad {
+    fn emit(self, ir: &mut AsmIr) {
+        match self {
+            GpLoad::FprBox(fpr, slot, dst) => {
+                ir.fpr2stack(fpr, slot);
+                ir.reg_move(GP::Rax, dst);
+            }
+            GpLoad::Lit(v, dst) => ir.lit2reg(v, dst),
+            GpLoad::Stack(slot, dst) => ir.stack2reg(slot, dst),
+            GpLoad::Acc(dst) => ir.reg_move(GP::R15, dst),
+        }
+    }
+}
+
 impl AbstractFrame {
     ///
-    /// load *slot* into *r*.
+    /// load *slot* into *dst*.
     ///
     /// ### destroy
     /// - rax, rcx
@@ -57,6 +90,15 @@ impl AbstractFrame {
     /// - if *slot* is V or None.
     ///
     pub(crate) fn load(&mut self, ir: &mut AsmIr, slot: SlotId, dst: GP) {
+        self.load_state(slot, dst).emit(ir);
+    }
+
+    ///
+    /// Analysis half of [`Self::load`] (item ②, step 2): the abstract-state
+    /// transition (only the `F` arm changes state, to `Sf`) plus the GP load to
+    /// emit. Pure state.
+    ///
+    fn load_state(&mut self, slot: SlotId, dst: GP) -> GpLoad {
         self.use_as_value(slot);
         match self.mode(slot) {
             LinkMode::F(fpr) => {
@@ -64,28 +106,23 @@ impl AbstractFrame {
                     assert!(self.no_r15());
                 }
                 // F -> Sf
-                ir.fpr2stack(fpr, slot);
-                ir.reg_move(GP::Rax, dst);
                 self.set_Sf_float(slot, fpr);
+                GpLoad::FprBox(fpr, slot, dst)
             }
             LinkMode::C(v) => {
                 if dst == GP::R15 {
                     assert!(self.no_r15());
                 }
-                ir.lit2reg(v, dst);
+                GpLoad::Lit(v, dst)
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) => {
                 if dst == GP::R15 {
                     assert!(self.no_r15());
                 }
-                ir.stack2reg(slot, dst);
+                GpLoad::Stack(slot, dst)
             }
-            LinkMode::G(_) => {
-                ir.reg_move(GP::R15, dst);
-            }
-            LinkMode::MaybeNone => {
-                ir.stack2reg(slot, dst);
-            }
+            LinkMode::G(_) => GpLoad::Acc(dst),
+            LinkMode::MaybeNone => GpLoad::Stack(slot, dst),
             LinkMode::V | LinkMode::None => {
                 unreachable!("load() {:?} {:?}: {:?}", slot, self.mode(slot), self);
             }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -12,7 +12,7 @@ use super::*;
 /// numeric-literal variants are guard-free.
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum XmmLoad {
+pub(in crate::codegen::jitgen) enum XmmLoad {
     /// already in an xmm (`Sf` / `F`) — nothing to emit
     None,
     /// `stack2reg(slot, Rdi); float_to_fpr(Rdi, x, deopt)`
@@ -53,7 +53,7 @@ impl XmmLoad {
 /// emitted by the codegen half via [`GpLoad::emit`].
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum GpLoad {
+pub(in crate::codegen::jitgen) enum GpLoad {
     /// `F` slot: box the xmm to its stack home (leaving the boxed value in rax),
     /// then move rax into `dst`. `fpr2stack(fpr, slot); reg_move(rax, dst)`.
     FprBox(FPReg, SlotId, GP),
@@ -95,7 +95,7 @@ impl GpLoad {
 /// half pushes `GuardClass` with the wrapper-supplied deopt.
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum XmmFixnumLoad {
+pub(in crate::codegen::jitgen) enum XmmFixnumLoad {
     /// already in an xmm (`Sf` / `F`) — nothing to emit
     None,
     /// `stack2reg(slot, Rdi); [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`
@@ -131,6 +131,49 @@ impl XmmFixnumLoad {
     }
 }
 
+///
+/// The unified **typed-IR stream element** (item ②, step 2 — record collection).
+/// Every transfer/eviction primitive's analysis half produces one of these; the
+/// codegen pass funnels them through [`AsmIr::transfer`], which both *collects*
+/// the record (building the typed-IR stream that record-driven lowering will
+/// replay) and emits it via [`TransferIR::emit`].
+///
+/// The deopt is still a frozen `AsmDeopt` here (the `XmmLoad` / `XmmFixnumLoad`
+/// guarded variants). Lifting it to a program point — so the stream is fully
+/// codegen-independent — is the next step (see doc/regalloc_separation.md §9).
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum TransferIR {
+    Spill(Spill),
+    FpXfer(FpXfer),
+    GpLoad(GpLoad),
+    /// `load_xmm`: deopt-carrying unbox-to-float (always guarded).
+    XmmLoad {
+        load: XmmLoad,
+        slot: SlotId,
+        deopt: AsmDeopt,
+    },
+    /// `load_xmm_fixnum`: unbox Integer to float; `deopt` present only for the
+    /// guarded `S`/`G` arms.
+    XmmFixnumLoad {
+        load: XmmFixnumLoad,
+        slot: SlotId,
+        deopt: Option<AsmDeopt>,
+    },
+}
+
+impl TransferIR {
+    pub(in crate::codegen::jitgen) fn emit(self, ir: &mut AsmIr) {
+        match self {
+            TransferIR::Spill(s) => s.emit(ir),
+            TransferIR::FpXfer(f) => f.emit(ir),
+            TransferIR::GpLoad(g) => g.emit(ir),
+            TransferIR::XmmLoad { load, slot, deopt } => load.emit(ir, slot, Some(deopt)),
+            TransferIR::XmmFixnumLoad { load, slot, deopt } => load.emit(ir, slot, deopt),
+        }
+    }
+}
+
 impl AbstractFrame {
     ///
     /// load *slot* into *dst*.
@@ -142,7 +185,8 @@ impl AbstractFrame {
     /// - if *slot* is V or None.
     ///
     pub(crate) fn load(&mut self, ir: &mut AsmIr, slot: SlotId, dst: GP) {
-        self.load_state(slot, dst).emit(ir);
+        let g = self.load_state(slot, dst);
+        ir.transfer(TransferIR::GpLoad(g));
     }
 
     ///
@@ -239,7 +283,7 @@ impl AbstractFrame {
         let deopt = matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_))
             .then(|| ir.new_deopt(self));
         let (x, load) = self.load_xmm_fixnum_state(slot);
-        load.emit(ir, slot, deopt);
+        ir.transfer(TransferIR::XmmFixnumLoad { load, slot, deopt });
         x
     }
 
@@ -292,7 +336,7 @@ impl AbstractFrame {
         // codegen side), not frozen into the record.
         let deopt = ir.new_deopt(self);
         let (x, load) = self.load_xmm_state(slot);
-        load.emit(ir, slot, Some(deopt));
+        ir.transfer(TransferIR::XmmLoad { load, slot, deopt });
         x
     }
 

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1213,61 +1213,23 @@ impl AbstractFrame {
     }
 
     fn xmm_swap(&mut self, l: FPReg, r: FPReg) {
-        let mut guarded_l = None;
-        let mut guarded_r = None;
-        for slot in self.all_regs() {
-            match &self.mode(slot) {
-                LinkMode::F(x) => {
-                    if *x == l {
-                        if let Some(g) = guarded_l {
-                            assert_eq!(g, SfGuarded::Float);
-                        }
-                        guarded_l = Some(SfGuarded::Float);
-                    } else if *x == r {
-                        if let Some(g) = guarded_r {
-                            assert_eq!(g, SfGuarded::Float);
-                        }
-                        guarded_r = Some(SfGuarded::Float);
-                    }
-                }
-                LinkMode::Sf(x, guarded) => {
-                    if *x == l {
-                        if let Some(g) = guarded_l {
-                            assert_eq!(g, *guarded);
-                        }
-                        guarded_l = Some(*guarded);
-                    } else if *x == r {
-                        if let Some(g) = guarded_r {
-                            assert_eq!(g, *guarded);
-                        }
-                        guarded_r = Some(*guarded);
-                    }
-                }
-                _ => {}
-            }
-        }
         self.xmm_alloc.swap(l, r);
-        // Local-copy RMW per slot (item ② encapsulation; `LinkMode` is `Copy`,
-        // so identical to the prior `slots.iter_mut()`).
+        // A physical xmm swap (`FprSwap`) only changes *which register* holds
+        // each live value; every slot keeps its own representation and
+        // refinement. The two registers need not share a refinement — e.g. the
+        // bridge's `F(l) -> F(r)` arm swaps a pure-Float `F` slot in `l` with
+        // whatever occupies `r`, which may be a Fixnum-refined `Sf` slot. So just
+        // relabel each slot's register index; do not cross-assign refinements
+        // (the `Sf` refinement rides along in `ty`, untouched here).
+        // Local-copy RMW per slot (item ② encapsulation; `LinkMode` is `Copy`).
         for slot in self.all_regs() {
             let mut link = self.mode(slot);
             match &mut link {
-                LinkMode::Sf(x, guarded) => {
+                LinkMode::F(x) | LinkMode::Sf(x, _) => {
                     if *x == l {
                         *x = r;
-                        *guarded = guarded_r.unwrap();
                     } else if *x == r {
                         *x = l;
-                        *guarded = guarded_l.unwrap();
-                    }
-                }
-                LinkMode::F(x) => {
-                    if *x == l {
-                        *x = r;
-                        assert_eq!(guarded_r, Some(SfGuarded::Float));
-                    } else if *x == r {
-                        *x = l;
-                        assert_eq!(guarded_l, Some(SfGuarded::Float));
                     }
                 }
                 LinkMode::S(_)
@@ -1907,6 +1869,38 @@ mod tests {
           res
         end
         test
+        "###,
+        );
+    }
+
+    /// Regression test for the `xmm_swap` mixed-refinement panic. A diamond
+    /// (`if/else`) inside a loop that updates a `Float` accumulator on both arms
+    /// drives the back-edge bridge to `gen_xmm_swap` a pure-`Float` `F` register
+    /// against a Fixnum-refined `Sf` register (the loop counter coerced to f64).
+    /// `xmm_swap` used to `assert_eq!(guarded_r, Some(Float))` / cross-assign the
+    /// partner register's refinement, assuming both swapped registers shared a
+    /// refinement — so this aborted the process at `slot.rs` with
+    /// `left: Some(Fixnum), right: Some(Float)` in both debug and release. The
+    /// swap only relabels register indices now, so each slot keeps its own
+    /// refinement. Expected result: `1249925000.0`.
+    #[test]
+    fn test_xmm_swap_mixed_refinement() {
+        run_test(
+            r###"
+        def f(n)
+          x = 0.0
+          i = 0
+          while i < n
+            if i.even?
+              x += i * 0.5
+            else
+              x -= 1.0
+            end
+            i += 1
+          end
+          x
+        end
+        f(100000)
         "###,
         );
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -132,6 +132,22 @@ impl SlotState {
         self.place.len()
     }
 
+    /// The pure type-lattice meet over the per-slot `ty` vectors — the
+    /// analysis-layer join (item ②, the reusable primitive for the standalone
+    /// analysis pass in step 2). Element-wise `Guarded::join`; placement /
+    /// sentinel reconciliation is a separate concern that the fused
+    /// `AbstractFrame::join` still owns today. For non-sentinel slots this equals
+    /// the fused join's resulting type (verified arm-by-arm; see
+    /// `doc/regalloc_separation.md`).
+    #[allow(dead_code)] // wired in by step 2 (standalone analysis pass)
+    pub(super) fn join_ty(&self, other: &SlotState) -> Vec<Guarded> {
+        self.ty
+            .iter()
+            .zip(other.ty.iter())
+            .map(|(a, b)| a.join(b))
+            .collect()
+    }
+
     pub(super) fn no_r15(&self) -> bool {
         self.r15.is_none()
     }
@@ -1547,6 +1563,14 @@ impl Guarded {
             Guarded::Float => FLOAT_CLASS,
             Guarded::Class(c) => *c,
         })
+    }
+
+    /// Type-lattice meet (item ②): two equal types stay; disagreement widens to
+    /// `Value` (⊤). This is the *type* component of `AbstractFrame::join` — the
+    /// fused join's resulting type equals this meet for every non-sentinel slot
+    /// (placement reconciliation is the rest of `join`).
+    pub(super) fn join(&self, other: &Self) -> Self {
+        if self == other { *self } else { Guarded::Value }
     }
 }
 

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1101,7 +1101,7 @@ impl AbstractFrame {
     /// `GuardClass` with the `deopt`, which it (the caller) created *before* this
     /// runs so the deopt's write-back snapshot is the pre-guard placement.
     ///
-    fn guard_class_state(&mut self, slot: SlotId, class: ClassId) -> bool {
+    pub(super) fn guard_class_state(&mut self, slot: SlotId, class: ClassId) -> bool {
         if self.class(slot) == Some(class) {
             return false;
         }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -759,7 +759,8 @@ impl SlotState {
     }
 
     pub(in crate::codegen::jitgen) fn write_back_slot(&mut self, ir: &mut AsmIr, slot: SlotId) {
-        self.write_back_slot_state(slot).emit(ir);
+        let s = self.write_back_slot_state(slot);
+        ir.transfer(TransferIR::Spill(s));
     }
 
     ///
@@ -790,7 +791,8 @@ impl SlotState {
 
     #[allow(non_snake_case)]
     pub(in crate::codegen::jitgen) fn to_S_unguarded(&mut self, ir: &mut AsmIr, slot: SlotId) {
-        self.to_S_unguarded_state(slot).emit(ir);
+        let s = self.to_S_unguarded_state(slot);
+        ir.transfer(TransferIR::Spill(s));
     }
 }
 
@@ -1373,7 +1375,7 @@ pub(in crate::codegen::jitgen) enum Placement {
 /// [`Spill::emit`].
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(super) enum Spill {
+pub(in crate::codegen::jitgen) enum Spill {
     None,
     /// `ir.fpr2stack(xmm, slot)`
     Fpr(FPReg, SlotId),
@@ -1384,7 +1386,7 @@ pub(super) enum Spill {
 }
 
 impl Spill {
-    fn emit(self, ir: &mut AsmIr) {
+    pub(super) fn emit(self, ir: &mut AsmIr) {
         match self {
             Spill::None => {}
             Spill::Fpr(xmm, slot) => ir.fpr2stack(xmm, slot),
@@ -1401,7 +1403,7 @@ impl Spill {
 /// by the codegen half via [`FpXfer::emit`].
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(super) enum FpXfer {
+pub(in crate::codegen::jitgen) enum FpXfer {
     /// `ir.fpr_move(l, r)`
     Move(FPReg, FPReg),
     /// `ir.push(AsmInst::FprSwap(l, r))`
@@ -1409,7 +1411,7 @@ pub(super) enum FpXfer {
 }
 
 impl FpXfer {
-    fn emit(self, ir: &mut AsmIr) {
+    pub(super) fn emit(self, ir: &mut AsmIr) {
         match self {
             FpXfer::Move(l, r) => ir.fpr_move(l, r),
             FpXfer::Swap(l, r) => ir.push(AsmInst::FprSwap(l, r)),
@@ -1841,7 +1843,8 @@ impl AbstractFrame {
     }
 
     fn to_sf(&mut self, ir: &mut AsmIr, slot: SlotId, l: FPReg, r: FPReg, guarded: SfGuarded) {
-        self.to_sf_state(slot, l, r, guarded).emit(ir);
+        let f = self.to_sf_state(slot, l, r, guarded);
+        ir.transfer(TransferIR::FpXfer(f));
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1223,61 +1223,18 @@ impl Into<Guarded> for SfGuarded {
 }
 
 ///
-/// The *abstract type / analysis state* half of a [`LinkMode`] — the boxed
-/// value's class lattice (`Guarded`: `Value`=⊤ / `Fixnum` / `Float` /
-/// `Class(c)`) **plus** `FixnumOrFloat`, the def-use-derived state of a slot
-/// that is an Integer-or-Float kept coerced-to-`f64` for its float uses (the
-/// abstract state the `Sf` linkage represents — see review note in
-/// `doc/regalloc_separation.md`).
-///
-/// This is layer ① of item ②: a pure analysis lattice with **no** location
-/// information. Paired with a [`Placement`] it reconstructs a `LinkMode` via
-/// [`LinkMode::from_parts`].
-///
-#[allow(dead_code)] // step-0a scaffolding; the live lattice in step 0b
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(in crate::codegen::jitgen) enum AbstractType {
-    Value,
-    Fixnum,
-    Float,
-    Class(ClassId),
-    /// Integer-or-Float coerced to `f64` (only ever xmm-backed).
-    FixnumOrFloat,
-}
-
-#[allow(dead_code)]
-impl AbstractType {
-    fn from_guarded(g: Guarded) -> Self {
-        match g {
-            Guarded::Value => AbstractType::Value,
-            Guarded::Fixnum => AbstractType::Fixnum,
-            Guarded::Float => AbstractType::Float,
-            Guarded::Class(c) => AbstractType::Class(c),
-        }
-    }
-
-    /// Project back to the coarse `Guarded` class lattice (the coercion state
-    /// `FixnumOrFloat` widens to `Value`, matching `SfGuarded::into`).
-    fn to_guarded(self) -> Guarded {
-        match self {
-            AbstractType::Value | AbstractType::FixnumOrFloat => Guarded::Value,
-            AbstractType::Fixnum => Guarded::Fixnum,
-            AbstractType::Float => Guarded::Float,
-            AbstractType::Class(c) => Guarded::Class(c),
-        }
-    }
-}
-
-///
-/// The *location / representation* half of a [`LinkMode`], with the abstract
-/// type factored out — the dual of [`AbstractType`].
+/// The *location / representation* half of a [`LinkMode`], with the type/class
+/// (`Guarded`) factored out — the dual of [`LinkMode::guarded`].
 ///
 /// Part of item ② (separating value placement from type analysis; see
-/// `doc/regalloc_separation.md`). It records only *where the live copies are*:
-/// the boxed cases (`Stack` / `Gp`) drop the type entirely, the FP cases keep
-/// their `FPReg`, and `Const` keeps the value.
-/// `LinkMode::from_parts(self.placement(), self.abstract_type())` reconstructs
-/// the original `LinkMode` (verified by a unit test).
+/// `doc/regalloc_separation.md`). It records only *where the live copies are*.
+/// The `Sf` linkage is the `XmmStack` placement: per review, `Sf` is **not** a
+/// type — it is a representation chosen for "Integer def'd / Float use'd" slots
+/// by a dedicated def-use + loop analysis. Its `SfGuarded` refinement is exactly
+/// the boxed value's class, so it is recovered from the paired `Guarded` (the
+/// `SfGuarded → Guarded` map is injective: `FixnumOrFloat ↔ Value`).
+/// `LinkMode::from_parts(self.placement(), self.guarded())` reconstructs the
+/// original `LinkMode` (verified by a unit test).
 ///
 // Scaffolding for item ②: consumed by the round-trip test now and by the
 // storage split (step 0b) next; not yet wired into the live state.
@@ -1295,7 +1252,7 @@ pub(in crate::codegen::jitgen) enum Placement {
     /// unboxed f64 in an xmm (type is implicitly `Float`)
     Xmm(FPReg),
     /// unboxed f64 in an xmm + a read-only boxed cache on the stack (the `Sf`
-    /// linkage; its Int/Float refinement lives in [`AbstractType`])
+    /// linkage); the Int/Float refinement is recovered from the paired `Guarded`
     XmmStack(FPReg),
     /// compile-time constant (no register / stack location)
     Const(Value),
@@ -1381,27 +1338,8 @@ impl LinkMode {
     }
 
     ///
-    /// The abstract-type / analysis-state half of this mode — the dual of
-    /// [`Self::placement`]. Unlike [`Self::guarded`] it preserves the `Sf`
-    /// coercion state (`FixnumOrFloat`). See [`AbstractType`].
-    ///
-    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
-    fn abstract_type(&self) -> AbstractType {
-        match self {
-            LinkMode::S(g) | LinkMode::G(g) => AbstractType::from_guarded(*g),
-            LinkMode::F(_) => AbstractType::Float,
-            LinkMode::Sf(_, SfGuarded::Float) => AbstractType::Float,
-            LinkMode::Sf(_, SfGuarded::Fixnum) => AbstractType::Fixnum,
-            LinkMode::Sf(_, SfGuarded::FixnumOrFloat) => AbstractType::FixnumOrFloat,
-            LinkMode::C(v) => AbstractType::from_guarded(Guarded::from_concrete_value(*v)),
-            LinkMode::V => AbstractType::Class(NIL_CLASS),
-            LinkMode::None | LinkMode::MaybeNone => unreachable!("{:?}", self),
-        }
-    }
-
-    ///
     /// The location/representation half of this mode (the dual of
-    /// [`Self::abstract_type`]). See [`Placement`].
+    /// [`Self::guarded`]). See [`Placement`].
     ///
     #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
     fn placement(&self) -> Placement {
@@ -1418,27 +1356,27 @@ impl LinkMode {
     }
 
     ///
-    /// Recombine a placement with an abstract type into a `LinkMode` — the
-    /// inverse of [`Self::placement`] + [`Self::abstract_type`]. The type is
-    /// used by the boxed `Stack` / `Gp` cases and to pick the `Sf` refinement
-    /// for `XmmStack`; the `Xmm` / `Const` / sentinel placements carry their own
-    /// type, so it is ignored for them.
+    /// Recombine a placement with a type guard into a `LinkMode` — the inverse
+    /// of [`Self::placement`] + [`Self::guarded`]. The `guarded` types the boxed
+    /// `Stack` / `Gp` cases and picks the `Sf` refinement for `XmmStack` (the
+    /// `Guarded → SfGuarded` inverse: `Value → FixnumOrFloat`); the `Xmm` /
+    /// `Const` / sentinel placements carry their own type, so it is ignored.
     ///
     #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
-    fn from_parts(place: Placement, ty: AbstractType) -> Self {
+    fn from_parts(place: Placement, guarded: Guarded) -> Self {
         match place {
             Placement::None => LinkMode::None,
             Placement::MaybeNone => LinkMode::MaybeNone,
             Placement::Void => LinkMode::V,
-            Placement::Stack => LinkMode::S(ty.to_guarded()),
-            Placement::Gp => LinkMode::G(ty.to_guarded()),
+            Placement::Stack => LinkMode::S(guarded),
+            Placement::Gp => LinkMode::G(guarded),
             Placement::Xmm(x) => LinkMode::F(x),
             Placement::XmmStack(x) => {
-                let sf = match ty {
-                    AbstractType::Float => SfGuarded::Float,
-                    AbstractType::Fixnum => SfGuarded::Fixnum,
-                    AbstractType::FixnumOrFloat => SfGuarded::FixnumOrFloat,
-                    _ => unreachable!("XmmStack with non-float-coercible type {ty:?}"),
+                let sf = match guarded {
+                    Guarded::Float => SfGuarded::Float,
+                    Guarded::Fixnum => SfGuarded::Fixnum,
+                    Guarded::Value => SfGuarded::FixnumOrFloat,
+                    Guarded::Class(_) => unreachable!("XmmStack with class guard {guarded:?}"),
                 };
                 LinkMode::Sf(x, sf)
             }
@@ -1862,13 +1800,13 @@ mod tests {
     }
 
     /// Item ②: `LinkMode` decomposes losslessly into a `Placement` (location /
-    /// representation) and an `AbstractType` (analysis state, incl. the `Sf`
-    /// coercion), and recombines via `from_parts`.
+    /// representation) and a `Guarded` (type), and recombines via `from_parts`.
+    /// The `Sf` (`XmmStack`) refinement is recovered from the paired `Guarded`.
     #[test]
     fn linkmode_placement_roundtrip() {
         use super::*;
         let x = FPReg(0);
-        // Value-carrying modes: from_parts(placement(), abstract_type()) == self.
+        // Value-carrying modes: from_parts(placement(), guarded()) == self.
         let value_modes = [
             LinkMode::S(Guarded::Value),
             LinkMode::S(Guarded::Fixnum),
@@ -1884,11 +1822,11 @@ mod tests {
             LinkMode::V,
         ];
         for lm in value_modes {
-            assert_eq!(LinkMode::from_parts(lm.placement(), lm.abstract_type()), lm);
+            assert_eq!(LinkMode::from_parts(lm.placement(), lm.guarded()), lm);
         }
-        // None / MaybeNone carry no type; placement() round-trips with any type.
+        // None / MaybeNone carry no type; placement() round-trips with any guard.
         for lm in [LinkMode::None, LinkMode::MaybeNone] {
-            assert_eq!(LinkMode::from_parts(lm.placement(), AbstractType::Value), lm);
+            assert_eq!(LinkMode::from_parts(lm.placement(), Guarded::Value), lm);
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -563,24 +563,6 @@ impl SlotState {
     }
 
     ///
-    /// Demote every xmm-resident slot (`F`/`Sf`) to its boxed stack home (`S`),
-    /// keeping each slot's `Guarded` type (`set_S_with_guard` clears the xmm
-    /// binding). The `loop-type-only-entry` experiment (doc §13 stage 3b) uses
-    /// this to hand the codegen pass a placement-free, type-only loop-carried
-    /// frame, so it re-derives xmm bindings itself via liveness (`use_float`)
-    /// instead of inheriting the analysis pass's allocation.
-    ///
-    #[cfg(feature = "loop-type-only-entry")]
-    pub(in crate::codegen::jitgen) fn strip_xmm_to_stack(&mut self) {
-        for slot in self.all_regs() {
-            if matches!(self.mode(slot), LinkMode::F(_) | LinkMode::Sf(_, _)) {
-                let g = self.guarded(slot);
-                self.set_S_with_guard(slot, g);
-            }
-        }
-    }
-
-    ///
     /// §15.3/§15.5 (`loop-keep-float`): adopt the back-edge fixpoint's `F` for a
     /// loop-carried float the loop-entry merge collapsed to `S`. In a *loop* JIT
     /// the value enters from the VM as a conservative boxed `S(Value)` even when
@@ -595,7 +577,6 @@ impl SlotState {
     /// bridge (`F`/`S`/`Sf`/float-`C`) — otherwise a non-float-`C` path would hit
     /// the `C -> F` `unreachable!` and `F` would be unsound for it.
     ///
-    #[cfg(feature = "loop-keep-float")]
     pub(in crate::codegen::jitgen) fn keep_backedge_floats(
         &mut self,
         backedge: &SlotState,
@@ -2001,6 +1982,31 @@ mod tests {
           x
         end
         f(100000)
+        "###,
+        );
+    }
+
+    /// §15.5: a loop-carried float enters a loop JIT from the VM as a boxed
+    /// `S(Value)`, but the back-edge fixpoint proves it is a `Float`. The
+    /// loop-entry specialization re-adopts `F` (the `S -> F` bridge unboxes the
+    /// forward entry once, guarded), so the body stays unboxed. Correctness
+    /// regression for that path + the `keep_backedge_floats` promotion gate.
+    #[test]
+    fn test_loop_carried_float_kept_unboxed() {
+        run_test(
+            r###"
+        def f(n)
+          x = 0.0
+          y = 1.0
+          i = 0
+          while i < n
+            x = x * 1.5 + i * 0.5
+            y = y - x * 0.25
+            i += 1
+          end
+          [x, y]
+        end
+        f(1000)
         "###,
         );
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1,12 +1,89 @@
 use super::*;
 
 ///
+/// §5 stage 3c-i — the register-allocation **policy** seam.
+///
+/// Every xmm allocation in the JIT funnels through these two primitives (operand
+/// loads `load_xmm*` / `fetch_float*`, destination defs `def_F` / `def_Sf*`, and
+/// the merge's `apply_join` `TryFresh*` all reach them via `set_new_*` /
+/// `try_set_new_*`). Isolating them as a named unit is the Layer-② allocator
+/// seam: the body here is today's greedy policy verbatim, and a future loop-aware
+/// policy (3c-ii) plugs in here — its furthest-next-use spill-victim choice
+/// replaces phase 1's "first all-`Sf` register". The functions take `&mut
+/// SlotState` because the policy reads/mutates slot placements (the phase-1
+/// demotion). Behaviour-identical to the prior `SlotState` methods.
+///
+mod alloc_policy {
+    use super::*;
+
+    ///
+    /// Returns `None` if every xmm holds at least one `F` slot (a real spill;
+    /// use [`alloc_xmm`] from a context that has access to `AsmIr`).
+    ///
+    pub(super) fn try_alloc_xmm(state: &mut SlotState) -> Option<FPReg> {
+        // Phase 0: a vacant xmm.
+        for i in 0..state.xmm_alloc.len() {
+            let xmm = FPReg(i);
+            if state.xmm_alloc.is_pinned(xmm) {
+                continue;
+            }
+            if state.xmm_alloc.is_vacant(xmm) {
+                return Some(xmm);
+            }
+        }
+        // Phase 1: an xmm whose linked slots are all `Sf` — demote them.
+        for i in 0..state.xmm_alloc.len() {
+            let xmm = FPReg(i);
+            if state.xmm_alloc.is_pinned(xmm) || state.xmm_alloc.is_vacant(xmm) {
+                continue;
+            }
+            let all_sf = state
+                .xmm_alloc
+                .slots(xmm)
+                .iter()
+                .all(|&s| matches!(state.mode(s), LinkMode::Sf(_, _)));
+            if !all_sf {
+                continue;
+            }
+            let to_demote: Vec<(SlotId, SfGuarded)> = state
+                .xmm_alloc
+                .slots(xmm)
+                .iter()
+                .map(|&s| match state.mode(s) {
+                    LinkMode::Sf(_, g) => (s, g),
+                    _ => unreachable!(),
+                })
+                .collect();
+            state.xmm_alloc.clear(xmm);
+            for (s, g) in to_demote {
+                state.set_mode(s, LinkMode::S(g.into()));
+            }
+            return Some(xmm);
+        }
+        None
+    }
+
+    ///
+    /// Allocate a new VirtFPReg. Phase 0 (vacant phys) and Phase 1 (Sf-only
+    /// demote) first; if both fail, a fresh phase-2 spill slot (`VirtFPReg(N)`,
+    /// `N >= PHYS_XMM_POOL`) that lives on the stack and is swapped in at use.
+    ///
+    pub(super) fn alloc_xmm(state: &mut SlotState) -> FPReg {
+        if let Some(x) = try_alloc_xmm(state) {
+            return x;
+        }
+        state.xmm_alloc.push_spill()
+    }
+}
+
+///
 /// The xmm-register allocation state (item ②, step 1): the reverse map from
 /// physical/spill FP registers to the slots bound to them, plus the pin set.
 /// `SlotState` owns one of these and drives it through its `xmm_*` methods; the
-/// allocation *policy* (`try_alloc_xmm` / `alloc_xmm`) stays on `SlotState`
-/// because it also reads/mutates slot placements. Indices `0..PHYS_XMM_POOL`
-/// map to physical `xmm2..xmm15`; `>= PHYS_XMM_POOL` are stack spills.
+/// allocation *policy* (`alloc_policy::try_alloc_xmm` / `alloc_xmm`) takes `&mut
+/// SlotState` because it also reads/mutates slot placements. Indices
+/// `0..PHYS_XMM_POOL` map to physical `xmm2..xmm15`; `>= PHYS_XMM_POOL` are stack
+/// spills.
 ///
 #[derive(Clone, Default)]
 pub(super) struct XmmAllocator {
@@ -401,66 +478,11 @@ impl SlotState {
     /// `AsmIr`).
     ///
     fn try_alloc_xmm(&mut self) -> Option<FPReg> {
-        // Phase 0: a vacant xmm.
-        for i in 0..self.xmm_alloc.len() {
-            let xmm = FPReg(i);
-            if self.xmm_alloc.is_pinned(xmm) {
-                continue;
-            }
-            if self.xmm_alloc.is_vacant(xmm) {
-                return Some(xmm);
-            }
-        }
-        // Phase 1: an xmm whose linked slots are all `Sf` — demote them.
-        for i in 0..self.xmm_alloc.len() {
-            let xmm = FPReg(i);
-            if self.xmm_alloc.is_pinned(xmm) || self.xmm_alloc.is_vacant(xmm) {
-                continue;
-            }
-            let all_sf = self
-                .xmm_alloc
-                .slots(xmm)
-                .iter()
-                .all(|&s| matches!(self.mode(s), LinkMode::Sf(_, _)));
-            if !all_sf {
-                continue;
-            }
-            let to_demote: Vec<(SlotId, SfGuarded)> = self
-                .xmm_alloc
-                .slots(xmm)
-                .iter()
-                .map(|&s| match self.mode(s) {
-                    LinkMode::Sf(_, g) => (s, g),
-                    _ => unreachable!(),
-                })
-                .collect();
-            self.xmm_alloc.clear(xmm);
-            for (s, g) in to_demote {
-                self.set_mode(s, LinkMode::S(g.into()));
-            }
-            return Some(xmm);
-        }
-        None
+        alloc_policy::try_alloc_xmm(self)
     }
 
-    ///
-    /// Allocate a new VirtFPReg.
-    ///
-    /// Tries Phase 0 (vacant phys) and Phase 1 (Sf-only demote) first. If both
-    /// fail, allocates a fresh spill slot — a `VirtFPReg(N)` where `N >=
-    /// PHYS_XMM_POOL`. The spill slot lives on the stack (the frame's
-    /// `stack_offset` grows by 8 bytes for each spill); at code generation,
-    /// any operation that uses such a `VirtFPReg` swaps a scratch xmm with
-    /// the stack slot to do its work.
-    ///
     fn alloc_xmm(&mut self) -> FPReg {
-        if let Some(x) = self.try_alloc_xmm() {
-            return x;
-        }
-        // Phase 2: spill — append a new slot beyond the physical pool. The
-        // existing F / Sf bindings are left in place; the value lives on the
-        // stack and gets swapped in at use time.
-        self.xmm_alloc.push_spill()
+        alloc_policy::alloc_xmm(self)
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -732,29 +732,34 @@ impl SlotState {
     /// ### destroy
     /// - rax, rcx
     ///
-    pub(in crate::codegen::jitgen) fn write_back_slot(&mut self, ir: &mut AsmIr, slot: SlotId) {
+    /// Analysis half (item ②, step 2): perform the abstract-state transition and
+    /// return the pending stack write-back as a [`Spill`] record, without
+    /// touching `AsmIr`. The codegen wrapper [`Self::write_back_slot`] emits it.
+    fn write_back_slot_state(&mut self, slot: SlotId) -> Spill {
         match self.mode(slot) {
             LinkMode::F(xmm) => {
                 // F -> Sf
                 self.set_Sf_float(slot, xmm);
-                ir.fpr2stack(xmm, slot);
+                Spill::Fpr(xmm, slot)
             }
-            LinkMode::C(v) => {
-                ir.lit2stack(v, slot);
-            }
+            LinkMode::C(v) => Spill::Lit(v, slot),
             LinkMode::G(guarded) => {
                 // G -> S
-                ir.acc2stack(slot);
                 assert_eq!(self.r15, Some(slot));
                 self.r15 = None;
                 self.set_mode(slot, LinkMode::S(guarded));
+                Spill::Acc(slot)
             }
-            LinkMode::Sf(_, _) | LinkMode::S(_) | LinkMode::MaybeNone => {}
+            LinkMode::Sf(_, _) | LinkMode::S(_) | LinkMode::MaybeNone => Spill::None,
             LinkMode::V | LinkMode::None => {
                 eprintln!("{:?}", self);
                 unreachable!("write_back_slot() {slot:?} {:?}", self.mode(slot));
             }
         }
+    }
+
+    pub(in crate::codegen::jitgen) fn write_back_slot(&mut self, ir: &mut AsmIr, slot: SlotId) {
+        self.write_back_slot_state(slot).emit(ir);
     }
 
     ///
@@ -765,28 +770,27 @@ impl SlotState {
     /// ### destroy
     /// - rax, rcx
     ///
+    /// Analysis half (item ②, step 2): see [`Self::write_back_slot_state`].
     #[allow(non_snake_case)]
-    pub(in crate::codegen::jitgen) fn to_S_unguarded(&mut self, ir: &mut AsmIr, slot: SlotId) {
-        match self.mode(slot) {
-            LinkMode::F(xmm) => {
-                ir.fpr2stack(xmm, slot);
-            }
-            LinkMode::C(v) => {
-                ir.lit2stack(v, slot);
-            }
-            LinkMode::G(_) => {
-                ir.acc2stack(slot);
-            }
-            LinkMode::Sf(_, _) | LinkMode::S(_) => {}
-            LinkMode::V => {
-                ir.lit2stack(Value::nil(), slot);
-            }
+    fn to_S_unguarded_state(&mut self, slot: SlotId) -> Spill {
+        let spill = match self.mode(slot) {
+            LinkMode::F(xmm) => Spill::Fpr(xmm, slot),
+            LinkMode::C(v) => Spill::Lit(v, slot),
+            LinkMode::G(_) => Spill::Acc(slot),
+            LinkMode::Sf(_, _) | LinkMode::S(_) => Spill::None,
+            LinkMode::V => Spill::Lit(Value::nil(), slot),
             LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!("to_S_unguarded() {:?}", self.mode(slot));
             }
-        }
+        };
         self.clear(slot);
         self.set_mode(slot, LinkMode::S(Guarded::Value));
+        spill
+    }
+
+    #[allow(non_snake_case)]
+    pub(in crate::codegen::jitgen) fn to_S_unguarded(&mut self, ir: &mut AsmIr, slot: SlotId) {
+        self.to_S_unguarded_state(slot).emit(ir);
     }
 }
 
@@ -1346,6 +1350,36 @@ pub(in crate::codegen::jitgen) enum Placement {
     XmmStack(FPReg),
     /// compile-time constant (no register / stack location)
     Const(Value),
+}
+
+///
+/// A pending stack write-back produced by a transfer/eviction primitive
+/// (item ②, step 2): the *what* of an eviction, decided by the primitive's
+/// analysis (state) half and emitted by the codegen half. This is the first
+/// concrete "typed IR record" — a standalone analysis pass collects these
+/// instead of pushing `AsmInst`, and the lowering pass replays them via
+/// [`Spill::emit`].
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum Spill {
+    None,
+    /// `ir.fpr2stack(xmm, slot)`
+    Fpr(FPReg, SlotId),
+    /// `ir.lit2stack(value, slot)`
+    Lit(Value, SlotId),
+    /// `ir.acc2stack(slot)`
+    Acc(SlotId),
+}
+
+impl Spill {
+    fn emit(self, ir: &mut AsmIr) {
+        match self {
+            Spill::None => {}
+            Spill::Fpr(xmm, slot) => ir.fpr2stack(xmm, slot),
+            Spill::Lit(v, slot) => ir.lit2stack(v, slot),
+            Spill::Acc(slot) => ir.acc2stack(slot),
+        }
+    }
 }
 
 ///

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -541,6 +541,24 @@ impl SlotState {
     }
 
     ///
+    /// Demote every xmm-resident slot (`F`/`Sf`) to its boxed stack home (`S`),
+    /// keeping each slot's `Guarded` type (`set_S_with_guard` clears the xmm
+    /// binding). The `loop-type-only-entry` experiment (doc §13 stage 3b) uses
+    /// this to hand the codegen pass a placement-free, type-only loop-carried
+    /// frame, so it re-derives xmm bindings itself via liveness (`use_float`)
+    /// instead of inheriting the analysis pass's allocation.
+    ///
+    #[cfg(feature = "loop-type-only-entry")]
+    pub(in crate::codegen::jitgen) fn strip_xmm_to_stack(&mut self) {
+        for slot in self.all_regs() {
+            if matches!(self.mode(slot), LinkMode::F(_) | LinkMode::Sf(_, _)) {
+                let g = self.guarded(slot);
+                self.set_S_with_guard(slot, g);
+            }
+        }
+    }
+
+    ///
     /// F/Sf -> F
     ///
     #[allow(non_snake_case)]

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -987,11 +987,23 @@ impl SlotState {
     ///
     /// The slot is set to LinkMode::Stack.
     ///
+    ///
+    /// Analysis half of [`Self::writeback_acc`] (item ②, step-2 spike): evict
+    /// the accumulator (`r15`) owner to its stack home in the *abstract state*
+    /// only, returning the evicted slot so the emission half can store it. This
+    /// is the pure state transition — a standalone analysis pass calls this and
+    /// never touches `AsmIr`; codegen calls `writeback_acc` (this + the store).
+    ///
+    fn writeback_acc_state(&mut self) -> Option<SlotId> {
+        let slot = self.r15?;
+        let guarded = self.guarded(slot);
+        self.set_mode(slot, LinkMode::S(guarded));
+        self.r15 = None;
+        Some(slot)
+    }
+
     pub(crate) fn writeback_acc(&mut self, ir: &mut AsmIr) {
-        if let Some(slot) = self.r15 {
-            let guarded = self.guarded(slot);
-            self.set_mode(slot, LinkMode::S(guarded));
-            self.r15 = None;
+        if let Some(slot) = self.writeback_acc_state() {
             ir.acc2stack(slot);
         }
         assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_))));

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -581,23 +581,30 @@ impl SlotState {
     }
 
     ///
-    /// §15.3 prototype (`loop-keep-float`): adopt the back-edge's `F` placement
-    /// for loop-carried floats that the loop-entry merge collapsed to `S`/`Sf`.
-    /// The fixpoint already proved `F` is sound for the loop body; re-establishing
-    /// it keeps the body unboxed (the forward-entry box is unboxed *once* at the
-    /// pre-header by the new `S -> F` bridge arm; the back-edge `F -> F` bridge
-    /// moves into the fresh xmm). With no register pressure this is the latent
-    /// per-iteration box removed (§15.3).
+    /// §15.3/§15.5 (`loop-keep-float`): adopt the back-edge fixpoint's `F` for a
+    /// loop-carried float the loop-entry merge collapsed to `S`. In a *loop* JIT
+    /// the value enters from the VM as a conservative boxed `S(Value)` even when
+    /// the fixpoint proves it is a `Float`; left as `S` the body decodes+reboxes
+    /// it every iteration (§15.4). Re-establishing `F` keeps the body unboxed;
+    /// the forward entry is unboxed *once* at the pre-header by the `S -> F`
+    /// bridge, whose `float_to_fpr` carries the runtime float **guard** (deopt if
+    /// the VM value is not a float), so the specialization is sound.
+    ///
+    /// `promotable(i)` (computed by the caller from the actual predecessor
+    /// entries) gates each slot: every predecessor must have a valid `_ -> F`
+    /// bridge (`F`/`S`/`Sf`/float-`C`) — otherwise a non-float-`C` path would hit
+    /// the `C -> F` `unreachable!` and `F` would be unsound for it.
     ///
     #[cfg(feature = "loop-keep-float")]
-    pub(in crate::codegen::jitgen) fn keep_backedge_floats(&mut self, backedge: &SlotState) {
+    pub(in crate::codegen::jitgen) fn keep_backedge_floats(
+        &mut self,
+        backedge: &SlotState,
+        promotable: impl Fn(SlotId) -> bool,
+    ) {
         for i in self.all_regs() {
-            // Sound only when every path agrees the slot is a `Float`: a forward
-            // predecessor holding a non-float `C`/`S` would have no `_ -> F`
-            // bridge. `guarded == Float` is exactly that agreement.
             if matches!(backedge.mode(i), LinkMode::F(_))
-                && self.guarded(i) == Guarded::Float
                 && matches!(self.mode(i), LinkMode::S(_) | LinkMode::Sf(_, _))
+                && promotable(i)
             {
                 self.set_new_F(i);
             }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -587,7 +587,12 @@ impl SlotState {
                 && matches!(self.mode(i), LinkMode::S(_) | LinkMode::Sf(_, _))
                 && promotable(i)
             {
-                self.set_new_F(i);
+                // `try_set_new_F` (no phase-2 spill): only specialize to `F` when
+                // a physical xmm is actually free. Spilling a *speculative*
+                // loop-entry promotion into a `VirtFPReg` is not worth it and is
+                // exercised wrongly under register pressure (the `stress-spill-pool`
+                // path); leave the slot boxed in that case.
+                self.try_set_new_F(i);
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -37,8 +37,8 @@ pub(crate) struct SlotState {
 impl std::fmt::Debug for SlotState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{ ")?;
-        for (i, state) in self.slots.iter().enumerate() {
-            write!(f, "[%{i}: {state:?}] ")?;
+        for i in self.all_regs() {
+            write!(f, "[%{}: {:?}] ", i.0, self.mode(i))?;
         }
         write!(f, "}}")?;
         Ok(())
@@ -84,7 +84,7 @@ impl SlotState {
             for (i, arg) in args.iter().enumerate() {
                 match arg {
                     LinkMode::C(_) | LinkMode::MaybeNone | LinkMode::None => {
-                        ctx.slots[i] = arg.clone();
+                        ctx.set_mode(SlotId(i as u16), *arg);
                     }
                     _ => {}
                 }
@@ -128,11 +128,9 @@ impl SlotState {
     }
 
     pub(super) fn equiv(&self, other: &Self) -> bool {
-        assert_eq!(self.slots.len(), other.slots.len());
-        self.slots
-            .iter()
-            .zip(other.slots.iter())
-            .all(|(lhs, rhs)| lhs.equiv(rhs))
+        assert_eq!(self.slots_len(), other.slots_len());
+        self.all_regs()
+            .all(|i| self.mode(i).equiv(&other.mode(i)))
     }
 
     pub(in crate::codegen::jitgen) fn liveness_analysis(&mut self, liveness: &Liveness) {
@@ -178,11 +176,11 @@ impl SlotState {
     }
 
     pub(in crate::codegen::jitgen) fn all_regs(&self) -> std::ops::Range<SlotId> {
-        SlotId(0)..SlotId(self.slots.len() as u16)
+        SlotId(0)..SlotId(self.slots_len() as u16)
     }
 
     fn temps(&self) -> std::ops::Range<SlotId> {
-        self.temp_start()..SlotId(self.slots.len() as u16)
+        self.temp_start()..SlotId(self.slots_len() as u16)
     }
 
     pub(super) fn temp_start(&self) -> SlotId {
@@ -910,7 +908,7 @@ impl SlotState {
             self.r15 = None;
             ir.acc2stack(slot);
         }
-        assert!(!self.slots.iter().any(|link| matches!(link, LinkMode::G(_))));
+        assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_))));
         assert!(self.r15.is_none());
     }
 
@@ -992,7 +990,13 @@ impl AbstractFrame {
             return;
         }
         let class_guarded = Guarded::from_class(class);
-        match &mut self.slots[slot.0 as usize] {
+        // Operate on a local copy and write it back, so the per-slot state goes
+        // through `mode`/`set_mode` rather than a direct `slots` borrow (item ②
+        // encapsulation; `LinkMode` is `Copy`, so this is identical to the prior
+        // in-place mutation). The `return`s below skip both the write-back and
+        // the guard emission, exactly as before.
+        let mut mode = self.mode(slot);
+        match &mut mode {
             LinkMode::S(guarded) | LinkMode::G(guarded) => {
                 if class_guarded == *guarded {
                     return;
@@ -1039,11 +1043,11 @@ impl AbstractFrame {
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                 unreachable!(
                     "guard_class(): current:{:?} given:{:?}",
-                    self.mode(slot),
-                    class_guarded
+                    mode, class_guarded
                 );
             }
         }
+        self.set_mode(slot, mode);
         ir.push(AsmInst::GuardClass(r, class, deopt));
     }
 
@@ -1099,8 +1103,8 @@ impl AbstractFrame {
     fn xmm_swap(&mut self, l: FPReg, r: FPReg) {
         let mut guarded_l = None;
         let mut guarded_r = None;
-        for link in self.slots.iter() {
-            match link {
+        for slot in self.all_regs() {
+            match &self.mode(slot) {
                 LinkMode::F(x) => {
                     if *x == l {
                         if let Some(g) = guarded_l {
@@ -1131,32 +1135,38 @@ impl AbstractFrame {
             }
         }
         self.vfpr.swap(l.0 as usize, r.0 as usize);
-        self.slots.iter_mut().for_each(|link| match link {
-            LinkMode::Sf(x, guarded) => {
-                if *x == l {
-                    *x = r;
-                    *guarded = guarded_r.unwrap();
-                } else if *x == r {
-                    *x = l;
-                    *guarded = guarded_l.unwrap();
+        // Local-copy RMW per slot (item ② encapsulation; `LinkMode` is `Copy`,
+        // so identical to the prior `slots.iter_mut()`).
+        for slot in self.all_regs() {
+            let mut link = self.mode(slot);
+            match &mut link {
+                LinkMode::Sf(x, guarded) => {
+                    if *x == l {
+                        *x = r;
+                        *guarded = guarded_r.unwrap();
+                    } else if *x == r {
+                        *x = l;
+                        *guarded = guarded_l.unwrap();
+                    }
                 }
-            }
-            LinkMode::F(x) => {
-                if *x == l {
-                    *x = r;
-                    assert_eq!(guarded_r, Some(SfGuarded::Float));
-                } else if *x == r {
-                    *x = l;
-                    assert_eq!(guarded_l, Some(SfGuarded::Float));
+                LinkMode::F(x) => {
+                    if *x == l {
+                        *x = r;
+                        assert_eq!(guarded_r, Some(SfGuarded::Float));
+                    } else if *x == r {
+                        *x = l;
+                        assert_eq!(guarded_l, Some(SfGuarded::Float));
+                    }
                 }
+                LinkMode::S(_)
+                | LinkMode::C(_)
+                | LinkMode::G(_)
+                | LinkMode::V
+                | LinkMode::MaybeNone
+                | LinkMode::None => {}
             }
-            LinkMode::S(_)
-            | LinkMode::C(_)
-            | LinkMode::G(_)
-            | LinkMode::V
-            | LinkMode::MaybeNone
-            | LinkMode::None => {}
-        });
+            self.set_mode(slot, link);
+        }
     }
 
     fn wb_xmm(&self, f: impl Fn(SlotId) -> bool) -> Vec<(FPReg, Vec<SlotId>)> {
@@ -1183,22 +1193,18 @@ impl AbstractFrame {
     }
 
     fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Value, SlotId)> {
-        self.slots
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, link)| match link {
-                LinkMode::C(v) if f(SlotId(idx as u16)) => Some((*v, SlotId(idx as u16))),
+        self.all_regs()
+            .filter_map(|idx| match self.mode(idx) {
+                LinkMode::C(v) if f(idx) => Some((v, idx)),
                 _ => None,
             })
             .collect()
     }
 
     fn wb_void(&self) -> Vec<SlotId> {
-        self.slots
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, link)| match link {
-                LinkMode::V => Some(SlotId(idx as u16)),
+        self.all_regs()
+            .filter_map(|idx| match self.mode(idx) {
+                LinkMode::V => Some(idx),
                 _ => None,
             })
             .collect()

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1088,20 +1088,32 @@ impl AbstractFrame {
         class: ClassId,
         deopt: AsmDeopt,
     ) {
+        if self.guard_class_state(slot, class) {
+            ir.push(AsmInst::GuardClass(r, class, deopt));
+        }
+    }
+
+    ///
+    /// Analysis half of [`Self::guard_class`] (item ②, step 2): refine the
+    /// slot's abstract type to `class` and return whether a runtime guard must
+    /// be emitted (`false` when the type already statically matches, so no guard
+    /// — and no state change — is needed). Pure state; the codegen wrapper emits
+    /// `GuardClass` with the `deopt`, which it (the caller) created *before* this
+    /// runs so the deopt's write-back snapshot is the pre-guard placement.
+    ///
+    fn guard_class_state(&mut self, slot: SlotId, class: ClassId) -> bool {
         if self.class(slot) == Some(class) {
-            return;
+            return false;
         }
         let class_guarded = Guarded::from_class(class);
-        // Operate on a local copy and write it back, so the per-slot state goes
-        // through `mode`/`set_mode` rather than a direct `slots` borrow (item ②
-        // encapsulation; `LinkMode` is `Copy`, so this is identical to the prior
-        // in-place mutation). The `return`s below skip both the write-back and
-        // the guard emission, exactly as before.
+        // Operate on a local copy and write it back (item ② encapsulation;
+        // `LinkMode` is `Copy`). The `return false`s below skip both the
+        // write-back and the guard emission, exactly as the prior `return`s did.
         let mut mode = self.mode(slot);
         match &mut mode {
             LinkMode::S(guarded) | LinkMode::G(guarded) => {
                 if class_guarded == *guarded {
-                    return;
+                    return false;
                 } else if *guarded == Guarded::Value {
                     *guarded = class_guarded;
                 } else {
@@ -1112,7 +1124,7 @@ impl AbstractFrame {
             LinkMode::Sf(_, guarded) => {
                 match (*guarded, class_guarded) {
                     (SfGuarded::Fixnum, Guarded::Fixnum) | (SfGuarded::Float, Guarded::Float) => {
-                        return;
+                        return false;
                     }
                     (SfGuarded::FixnumOrFloat, Guarded::Fixnum) => {
                         *guarded = SfGuarded::Fixnum;
@@ -1125,19 +1137,19 @@ impl AbstractFrame {
             }
             LinkMode::F(_) => {
                 if class_guarded == Guarded::Float {
-                    return;
+                    return false;
                 }
                 // in this case, Guard will always fail
             }
             LinkMode::C(v) => {
                 if class == INTEGER_CLASS {
                     if v.is_fixnum() {
-                        return;
+                        return false;
                     }
                     // If v is Bignum, Guard will fail
                 } else {
                     if v.class() == class {
-                        return;
+                        return false;
                     }
                     // in this case, Guard will always fail
                 }
@@ -1150,7 +1162,7 @@ impl AbstractFrame {
             }
         }
         self.set_mode(slot, mode);
-        ir.push(AsmInst::GuardClass(r, class, deopt));
+        true
     }
 
     pub(crate) fn guard_fixnum(&mut self, ir: &mut AsmIr, slot: SlotId, r: GP) {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2,8 +2,12 @@ use super::*;
 
 #[derive(Clone, Default)]
 pub(crate) struct SlotState {
-    /// Slot states.
-    slots: Vec<LinkMode>,
+    /// Per-slot location / representation (the `LinkMode` split into its two
+    /// halves; item ②). Paired index-for-index with `ty`.
+    place: Vec<Placement>,
+    /// Per-slot abstract type (the class lattice). The `Sf` refinement is
+    /// recovered from this via `LinkMode::from_parts`. Paired with `place`.
+    ty: Vec<Guarded>,
     /// Liveness information.
     liveness: Vec<IsUsed>,
     /// Information for VirtFPReg slots. Indices 0..14 map to physical
@@ -50,8 +54,13 @@ impl SlotState {
         let total_reg_num = cc.total_reg_num();
         let local_num = cc.local_num();
         let self_class = Guarded::from_class(cc.self_class());
+        let default_ty = match default {
+            LinkMode::None | LinkMode::MaybeNone | LinkMode::V => Guarded::Value,
+            o => o.guarded(),
+        };
         let mut ctx = SlotState {
-            slots: vec![default; total_reg_num],
+            place: vec![default.placement(); total_reg_num],
+            ty: vec![default_ty; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
             vfpr: (0..PHYS_XMM_POOL).map(|_| vec![]).collect(),
             r15: None,
@@ -120,7 +129,7 @@ impl SlotState {
     }
 
     pub(super) fn slots_len(&self) -> usize {
-        self.slots.len()
+        self.place.len()
     }
 
     pub(super) fn no_r15(&self) -> bool {
@@ -188,7 +197,8 @@ impl SlotState {
     }
 
     pub(in crate::codegen::jitgen) fn mode(&self, slot: SlotId) -> LinkMode {
-        self.slots[slot.0 as usize]
+        let i = slot.0 as usize;
+        LinkMode::from_parts(self.place[i], self.ty[i])
     }
 
     pub(in crate::codegen::jitgen) fn guarded(&self, slot: SlotId) -> Guarded {
@@ -217,7 +227,13 @@ impl SlotState {
 
 impl SlotState {
     pub(super) fn set_mode(&mut self, slot: SlotId, mode: LinkMode) {
-        self.slots[slot.0 as usize] = mode;
+        let i = slot.0 as usize;
+        self.place[i] = mode.placement();
+        // Sentinels carry no type; `from_parts` ignores `ty` for them.
+        self.ty[i] = match mode {
+            LinkMode::None | LinkMode::MaybeNone | LinkMode::V => Guarded::Value,
+            o => o.guarded(),
+        };
     }
 
     /// D1: if `slot` is the deferred forwarding-rest slot, return its
@@ -1242,9 +1258,6 @@ impl Into<Guarded> for SfGuarded {
 /// `LinkMode::from_parts(self.placement(), self.guarded())` reconstructs the
 /// original `LinkMode` (verified by a unit test).
 ///
-// Scaffolding for item ②: consumed by the round-trip test now and by the
-// storage split (step 0b) next; not yet wired into the live state.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(in crate::codegen::jitgen) enum Placement {
     None,
@@ -1347,7 +1360,6 @@ impl LinkMode {
     /// The location/representation half of this mode (the dual of
     /// [`Self::guarded`]). See [`Placement`].
     ///
-    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
     fn placement(&self) -> Placement {
         match self {
             LinkMode::None => Placement::None,
@@ -1368,7 +1380,6 @@ impl LinkMode {
     /// `Guarded → SfGuarded` inverse: `Value → FixnumOrFloat`); the `Xmm` /
     /// `Const` / sentinel placements carry their own type, so it is ignored.
     ///
-    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
     fn from_parts(place: Placement, guarded: Guarded) -> Self {
         match place {
             Placement::None => LinkMode::None,

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1223,15 +1223,61 @@ impl Into<Guarded> for SfGuarded {
 }
 
 ///
-/// The *location / representation* half of a [`LinkMode`], with the type/class
-/// (`Guarded`) factored out — the dual of [`LinkMode::guarded`].
+/// The *abstract type / analysis state* half of a [`LinkMode`] — the boxed
+/// value's class lattice (`Guarded`: `Value`=⊤ / `Fixnum` / `Float` /
+/// `Class(c)`) **plus** `FixnumOrFloat`, the def-use-derived state of a slot
+/// that is an Integer-or-Float kept coerced-to-`f64` for its float uses (the
+/// abstract state the `Sf` linkage represents — see review note in
+/// `doc/regalloc_separation.md`).
+///
+/// This is layer ① of item ②: a pure analysis lattice with **no** location
+/// information. Paired with a [`Placement`] it reconstructs a `LinkMode` via
+/// [`LinkMode::from_parts`].
+///
+#[allow(dead_code)] // step-0a scaffolding; the live lattice in step 0b
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum AbstractType {
+    Value,
+    Fixnum,
+    Float,
+    Class(ClassId),
+    /// Integer-or-Float coerced to `f64` (only ever xmm-backed).
+    FixnumOrFloat,
+}
+
+#[allow(dead_code)]
+impl AbstractType {
+    fn from_guarded(g: Guarded) -> Self {
+        match g {
+            Guarded::Value => AbstractType::Value,
+            Guarded::Fixnum => AbstractType::Fixnum,
+            Guarded::Float => AbstractType::Float,
+            Guarded::Class(c) => AbstractType::Class(c),
+        }
+    }
+
+    /// Project back to the coarse `Guarded` class lattice (the coercion state
+    /// `FixnumOrFloat` widens to `Value`, matching `SfGuarded::into`).
+    fn to_guarded(self) -> Guarded {
+        match self {
+            AbstractType::Value | AbstractType::FixnumOrFloat => Guarded::Value,
+            AbstractType::Fixnum => Guarded::Fixnum,
+            AbstractType::Float => Guarded::Float,
+            AbstractType::Class(c) => Guarded::Class(c),
+        }
+    }
+}
+
+///
+/// The *location / representation* half of a [`LinkMode`], with the abstract
+/// type factored out — the dual of [`AbstractType`].
 ///
 /// Part of item ② (separating value placement from type analysis; see
-/// `doc/regalloc_separation.md`). For the boxed cases (`Stack` / `Gp`) the type
-/// is dropped entirely and lives only in `Guarded`; the FP cases keep their
-/// `FPReg` (and `Sf`'s representation refinement), and `Const` keeps the value.
-/// `LinkMode::from_parts(self.placement(), self.guarded())` reconstructs the
-/// original `LinkMode` (verified by a unit test).
+/// `doc/regalloc_separation.md`). It records only *where the live copies are*:
+/// the boxed cases (`Stack` / `Gp`) drop the type entirely, the FP cases keep
+/// their `FPReg`, and `Const` keeps the value.
+/// `LinkMode::from_parts(self.placement(), self.abstract_type())` reconstructs
+/// the original `LinkMode` (verified by a unit test).
 ///
 // Scaffolding for item ②: consumed by the round-trip test now and by the
 // storage split (step 0b) next; not yet wired into the live state.
@@ -1248,9 +1294,9 @@ pub(in crate::codegen::jitgen) enum Placement {
     Gp,
     /// unboxed f64 in an xmm (type is implicitly `Float`)
     Xmm(FPReg),
-    /// unboxed f64 in an xmm + a read-only boxed cache on the stack; carries the
-    /// representation refinement (`Fixnum` / `Float` / `FixnumOrFloat`)
-    XmmStack(FPReg, SfGuarded),
+    /// unboxed f64 in an xmm + a read-only boxed cache on the stack (the `Sf`
+    /// linkage; its Int/Float refinement lives in [`AbstractType`])
+    XmmStack(FPReg),
     /// compile-time constant (no register / stack location)
     Const(Value),
 }
@@ -1335,8 +1381,27 @@ impl LinkMode {
     }
 
     ///
+    /// The abstract-type / analysis-state half of this mode — the dual of
+    /// [`Self::placement`]. Unlike [`Self::guarded`] it preserves the `Sf`
+    /// coercion state (`FixnumOrFloat`). See [`AbstractType`].
+    ///
+    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
+    fn abstract_type(&self) -> AbstractType {
+        match self {
+            LinkMode::S(g) | LinkMode::G(g) => AbstractType::from_guarded(*g),
+            LinkMode::F(_) => AbstractType::Float,
+            LinkMode::Sf(_, SfGuarded::Float) => AbstractType::Float,
+            LinkMode::Sf(_, SfGuarded::Fixnum) => AbstractType::Fixnum,
+            LinkMode::Sf(_, SfGuarded::FixnumOrFloat) => AbstractType::FixnumOrFloat,
+            LinkMode::C(v) => AbstractType::from_guarded(Guarded::from_concrete_value(*v)),
+            LinkMode::V => AbstractType::Class(NIL_CLASS),
+            LinkMode::None | LinkMode::MaybeNone => unreachable!("{:?}", self),
+        }
+    }
+
+    ///
     /// The location/representation half of this mode (the dual of
-    /// [`Self::guarded`]). See [`Placement`].
+    /// [`Self::abstract_type`]). See [`Placement`].
     ///
     #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
     fn placement(&self) -> Placement {
@@ -1347,27 +1412,36 @@ impl LinkMode {
             LinkMode::S(_) => Placement::Stack,
             LinkMode::G(_) => Placement::Gp,
             LinkMode::F(x) => Placement::Xmm(*x),
-            LinkMode::Sf(x, g) => Placement::XmmStack(*x, *g),
+            LinkMode::Sf(x, _) => Placement::XmmStack(*x),
             LinkMode::C(v) => Placement::Const(*v),
         }
     }
 
     ///
-    /// Recombine a placement with a type guard into a `LinkMode` — the inverse
-    /// of [`Self::placement`] + [`Self::guarded`]. The `guarded` is used only by
-    /// the boxed `Stack` / `Gp` cases (the FP / `Const` / sentinel placements
-    /// carry their own type), so it is ignored for the others.
+    /// Recombine a placement with an abstract type into a `LinkMode` — the
+    /// inverse of [`Self::placement`] + [`Self::abstract_type`]. The type is
+    /// used by the boxed `Stack` / `Gp` cases and to pick the `Sf` refinement
+    /// for `XmmStack`; the `Xmm` / `Const` / sentinel placements carry their own
+    /// type, so it is ignored for them.
     ///
     #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
-    fn from_parts(place: Placement, guarded: Guarded) -> Self {
+    fn from_parts(place: Placement, ty: AbstractType) -> Self {
         match place {
             Placement::None => LinkMode::None,
             Placement::MaybeNone => LinkMode::MaybeNone,
             Placement::Void => LinkMode::V,
-            Placement::Stack => LinkMode::S(guarded),
-            Placement::Gp => LinkMode::G(guarded),
+            Placement::Stack => LinkMode::S(ty.to_guarded()),
+            Placement::Gp => LinkMode::G(ty.to_guarded()),
             Placement::Xmm(x) => LinkMode::F(x),
-            Placement::XmmStack(x, g) => LinkMode::Sf(x, g),
+            Placement::XmmStack(x) => {
+                let sf = match ty {
+                    AbstractType::Float => SfGuarded::Float,
+                    AbstractType::Fixnum => SfGuarded::Fixnum,
+                    AbstractType::FixnumOrFloat => SfGuarded::FixnumOrFloat,
+                    _ => unreachable!("XmmStack with non-float-coercible type {ty:?}"),
+                };
+                LinkMode::Sf(x, sf)
+            }
             Placement::Const(v) => LinkMode::C(v),
         }
     }
@@ -1788,12 +1862,13 @@ mod tests {
     }
 
     /// Item ②: `LinkMode` decomposes losslessly into a `Placement` (location /
-    /// representation) and a `Guarded` (type), and recombines via `from_parts`.
+    /// representation) and an `AbstractType` (analysis state, incl. the `Sf`
+    /// coercion), and recombines via `from_parts`.
     #[test]
     fn linkmode_placement_roundtrip() {
         use super::*;
         let x = FPReg(0);
-        // Value-carrying modes: from_parts(placement(), guarded()) == self.
+        // Value-carrying modes: from_parts(placement(), abstract_type()) == self.
         let value_modes = [
             LinkMode::S(Guarded::Value),
             LinkMode::S(Guarded::Fixnum),
@@ -1806,13 +1881,14 @@ mod tests {
             LinkMode::Sf(x, SfGuarded::FixnumOrFloat),
             LinkMode::C(Value::nil()),
             LinkMode::C(Value::i32(7)),
+            LinkMode::V,
         ];
         for lm in value_modes {
-            assert_eq!(LinkMode::from_parts(lm.placement(), lm.guarded()), lm);
+            assert_eq!(LinkMode::from_parts(lm.placement(), lm.abstract_type()), lm);
         }
-        // Sentinels carry no type; placement() round-trips with any guard.
-        for lm in [LinkMode::None, LinkMode::MaybeNone, LinkMode::V] {
-            assert_eq!(LinkMode::from_parts(lm.placement(), Guarded::Value), lm);
+        // None / MaybeNone carry no type; placement() round-trips with any type.
+        for lm in [LinkMode::None, LinkMode::MaybeNone] {
+            assert_eq!(LinkMode::from_parts(lm.placement(), AbstractType::Value), lm);
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1,5 +1,86 @@
 use super::*;
 
+///
+/// The xmm-register allocation state (item ②, step 1): the reverse map from
+/// physical/spill FP registers to the slots bound to them, plus the pin set.
+/// `SlotState` owns one of these and drives it through its `xmm_*` methods; the
+/// allocation *policy* (`try_alloc_xmm` / `alloc_xmm`) stays on `SlotState`
+/// because it also reads/mutates slot placements. Indices `0..PHYS_XMM_POOL`
+/// map to physical `xmm2..xmm15`; `>= PHYS_XMM_POOL` are stack spills.
+///
+#[derive(Clone, Default)]
+pub(super) struct XmmAllocator {
+    vfpr: Vec<Vec<SlotId>>,
+    /// xmm registers that must not be reused by `alloc_xmm` until unpinned.
+    pinned: Vec<FPReg>,
+}
+
+impl XmmAllocator {
+    fn new() -> Self {
+        Self {
+            vfpr: (0..PHYS_XMM_POOL).map(|_| vec![]).collect(),
+            pinned: Vec::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.vfpr.len()
+    }
+
+    fn slots(&self, xmm: FPReg) -> &[SlotId] {
+        &self.vfpr[xmm.0 as usize]
+    }
+
+    fn is_vacant(&self, xmm: FPReg) -> bool {
+        self.vfpr[xmm.0 as usize].is_empty()
+    }
+
+    fn is_pinned(&self, xmm: FPReg) -> bool {
+        self.pinned.contains(&xmm)
+    }
+
+    fn add(&mut self, slot: SlotId, xmm: FPReg) {
+        self.vfpr[xmm.0 as usize].push(slot);
+    }
+
+    fn remove(&mut self, slot: SlotId, xmm: FPReg) {
+        self.vfpr[xmm.0 as usize].retain(|e| *e != slot);
+    }
+
+    fn clear(&mut self, xmm: FPReg) {
+        self.vfpr[xmm.0 as usize].clear();
+    }
+
+    fn grow_to(&mut self, new_len: usize) {
+        while self.vfpr.len() < new_len {
+            self.vfpr.push(vec![]);
+        }
+    }
+
+    /// Append a fresh spill slot beyond the physical pool and return its id.
+    fn push_spill(&mut self) -> FPReg {
+        let new_id = self.vfpr.len();
+        self.vfpr.push(vec![]);
+        FPReg(new_id)
+    }
+
+    fn pin(&mut self, xmm: FPReg) {
+        if !self.pinned.contains(&xmm) {
+            self.pinned.push(xmm);
+        }
+    }
+
+    fn unpin(&mut self, xmm: FPReg) {
+        if let Some(pos) = self.pinned.iter().position(|x| *x == xmm) {
+            self.pinned.swap_remove(pos);
+        }
+    }
+
+    fn swap(&mut self, l: FPReg, r: FPReg) {
+        self.vfpr.swap(l.0 as usize, r.0 as usize);
+    }
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct SlotState {
     /// Per-slot location / representation (the `LinkMode` split into its two
@@ -10,31 +91,11 @@ pub(crate) struct SlotState {
     ty: Vec<Guarded>,
     /// Liveness information.
     liveness: Vec<IsUsed>,
-    /// Information for VirtFPReg slots. Indices 0..14 map to physical
-    /// xmm2..xmm15; indices >= 14 are spilled (live on stack — at use
-    /// time the codegen swaps them with a scratch xmm).
-    vfpr: Vec<Vec<SlotId>>,
+    /// xmm-register allocation state (item ②, step 1).
+    xmm_alloc: XmmAllocator,
     r15: Option<SlotId>,
     local_num: usize,
-    /// xmm registers that must not be reused by `alloc_xmm` /
-    /// `try_alloc_xmm_demote`. Used by callers that have just produced
-    /// an xmm-resident value but have not yet emitted the consuming
-    /// instruction — without this, a subsequent allocation can pick
-    /// that same xmm as a spill victim (e.g. demote its `Sf` slot to
-    /// `S`) and hand the same physical register back, so the consumer
-    /// ends up reading both operands from the same register.
-    pinned_vfpr: Vec<FPReg>,
-    /// D1 forwarding-rest deferral: `Some((dst, src, len))` means the
-    /// rest-parameter slot `dst` of a forwarding-trampoline frame has
-    /// not been materialized as an `Array` on the fast path; its
-    /// positional source args live at `src .. src + len` in the
-    /// (outermost, non-specialized) caller frame. The slot's `LinkMode`
-    /// is kept at `C(nil)` (always GC-safe); this annotation only
-    /// (a) routes the single forwarding consumer to copy straight from
-    /// the source range and (b) adds an `Array` materialization to every
-    /// deopt `WriteBack` while it is live. Strictly transient: produced
-    /// at trampoline-frame entry, cleared at the single forwarding
-    /// consume; gated so it never crosses a basic-block join.
+    /// D1 forwarding-rest deferral (transient annotation; see the consumers).
     deferred_rest: Option<(SlotId, SlotId, u16)>,
 }
 
@@ -62,10 +123,9 @@ impl SlotState {
             place: vec![default.placement(); total_reg_num],
             ty: vec![default_ty; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
-            vfpr: (0..PHYS_XMM_POOL).map(|_| vec![]).collect(),
+            xmm_alloc: XmmAllocator::new(),
             r15: None,
             local_num,
-            pinned_vfpr: Vec::new(),
             deferred_rest: None,
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
@@ -280,7 +340,7 @@ impl SlotState {
     }
 
     fn xmm(&self, xmm: FPReg) -> &[SlotId] {
-        &self.vfpr[xmm.0 as usize]
+        self.xmm_alloc.slots(xmm)
     }
 
     ///
@@ -289,7 +349,7 @@ impl SlotState {
     /// `xmm` vec up to the target's width before merge bridging.
     ///
     pub(super) fn xmm_len(&self) -> usize {
-        self.vfpr.len()
+        self.xmm_alloc.len()
     }
 
     ///
@@ -301,17 +361,15 @@ impl SlotState {
     /// vacant binding, which `is_xmm_vacant` correctly reports.
     ///
     pub(super) fn grow_xmm_to(&mut self, new_len: usize) {
-        while self.vfpr.len() < new_len {
-            self.vfpr.push(vec![]);
-        }
+        self.xmm_alloc.grow_to(new_len);
     }
 
     fn xmm_add(&mut self, slot: SlotId, xmm: FPReg) {
-        self.vfpr[xmm.0 as usize].push(slot);
+        self.xmm_alloc.add(slot, xmm);
     }
 
     fn xmm_remove(&mut self, slot: SlotId, xmm: FPReg) {
-        self.vfpr[xmm.0 as usize].retain(|e| *e != slot);
+        self.xmm_alloc.remove(slot, xmm);
     }
 
     /// Mark *xmm* off-limits for subsequent `alloc_xmm` /
@@ -322,15 +380,11 @@ impl SlotState {
     /// freshly-loaded xmm as a spill victim and reuse it for an unrelated
     /// value.
     pub(in crate::codegen::jitgen) fn pin_xmm(&mut self, xmm: FPReg) {
-        if !self.pinned_vfpr.contains(&xmm) {
-            self.pinned_vfpr.push(xmm);
-        }
+        self.xmm_alloc.pin(xmm);
     }
 
     pub(in crate::codegen::jitgen) fn unpin_xmm(&mut self, xmm: FPReg) {
-        if let Some(pos) = self.pinned_vfpr.iter().position(|x| *x == xmm) {
-            self.pinned_vfpr.swap_remove(pos);
-        }
+        self.xmm_alloc.unpin(xmm);
     }
 
     ///
@@ -347,42 +401,44 @@ impl SlotState {
     /// `AsmIr`).
     ///
     fn try_alloc_xmm(&mut self) -> Option<FPReg> {
-        let pinned = &self.pinned_vfpr;
         // Phase 0: a vacant xmm.
-        for (i, xmm) in self.vfpr.iter().enumerate() {
-            if pinned.contains(&FPReg(i as usize)) {
+        for i in 0..self.xmm_alloc.len() {
+            let xmm = FPReg(i);
+            if self.xmm_alloc.is_pinned(xmm) {
                 continue;
             }
-            if xmm.is_empty() {
-                return Some(FPReg(i as usize));
+            if self.xmm_alloc.is_vacant(xmm) {
+                return Some(xmm);
             }
         }
         // Phase 1: an xmm whose linked slots are all `Sf` — demote them.
-        for i in 0..self.vfpr.len() {
-            if self.pinned_vfpr.contains(&FPReg(i as usize)) {
+        for i in 0..self.xmm_alloc.len() {
+            let xmm = FPReg(i);
+            if self.xmm_alloc.is_pinned(xmm) || self.xmm_alloc.is_vacant(xmm) {
                 continue;
             }
-            if self.vfpr[i].is_empty() {
-                continue;
-            }
-            let all_sf = self.vfpr[i]
+            let all_sf = self
+                .xmm_alloc
+                .slots(xmm)
                 .iter()
                 .all(|&s| matches!(self.mode(s), LinkMode::Sf(_, _)));
             if !all_sf {
                 continue;
             }
-            let to_demote: Vec<(SlotId, SfGuarded)> = self.vfpr[i]
+            let to_demote: Vec<(SlotId, SfGuarded)> = self
+                .xmm_alloc
+                .slots(xmm)
                 .iter()
                 .map(|&s| match self.mode(s) {
                     LinkMode::Sf(_, g) => (s, g),
                     _ => unreachable!(),
                 })
                 .collect();
-            self.vfpr[i].clear();
+            self.xmm_alloc.clear(xmm);
             for (s, g) in to_demote {
                 self.set_mode(s, LinkMode::S(g.into()));
             }
-            return Some(FPReg(i as usize));
+            return Some(xmm);
         }
         None
     }
@@ -404,9 +460,7 @@ impl SlotState {
         // Phase 2: spill — append a new slot beyond the physical pool. The
         // existing F / Sf bindings are left in place; the value lives on the
         // stack and gets swapped in at use time.
-        let new_id = self.vfpr.len();
-        self.vfpr.push(vec![]);
-        FPReg(new_id)
+        self.xmm_alloc.push_spill()
     }
 
     ///
@@ -1092,15 +1146,11 @@ impl AbstractFrame {
         let mut b = UsingXmm::new();
         // Only physical pool slots need save/restore at call
         // boundaries; spill slots already live on the stack.
-        self.vfpr
-            .iter()
-            .enumerate()
-            .take(PHYS_XMM_POOL)
-            .for_each(|(i, v)| {
-                if !v.is_empty() {
-                    b.set(i, true);
-                }
-            });
+        for i in 0..PHYS_XMM_POOL {
+            if !self.xmm_alloc.is_vacant(FPReg(i)) {
+                b.set(i, true);
+            }
+        }
         b
     }
 
@@ -1166,7 +1216,7 @@ impl AbstractFrame {
                 _ => {}
             }
         }
-        self.vfpr.swap(l.0 as usize, r.0 as usize);
+        self.xmm_alloc.swap(l, r);
         // Local-copy RMW per slot (item ② encapsulation; `LinkMode` is `Copy`,
         // so identical to the prior `slots.iter_mut()`).
         for slot in self.all_regs() {
@@ -1202,24 +1252,17 @@ impl AbstractFrame {
     }
 
     fn wb_xmm(&self, f: impl Fn(SlotId) -> bool) -> Vec<(FPReg, Vec<SlotId>)> {
-        self.vfpr
-            .iter()
-            .enumerate()
-            .filter_map(|(i, v)| {
-                if v.is_empty() {
-                    None
-                } else {
-                    let v: Vec<_> = self.vfpr[i]
-                        .iter()
-                        .filter(|reg| f(**reg) && matches!(self.mode(**reg), LinkMode::F(_)))
-                        .cloned()
-                        .collect();
-                    if v.is_empty() {
-                        None
-                    } else {
-                        Some((FPReg::new(i as usize), v))
-                    }
-                }
+        (0..self.xmm_alloc.len())
+            .filter_map(|i| {
+                let reg = FPReg::new(i);
+                let v: Vec<_> = self
+                    .xmm_alloc
+                    .slots(reg)
+                    .iter()
+                    .filter(|s| f(**s) && matches!(self.mode(**s), LinkMode::F(_)))
+                    .cloned()
+                    .collect();
+                if v.is_empty() { None } else { Some((reg, v)) }
             })
             .collect()
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1383,6 +1383,29 @@ impl Spill {
 }
 
 ///
+/// An FP-register transfer produced by a transfer primitive (item ②, step 2):
+/// either a move into a vacant register or a swap of two live registers. Like
+/// [`Spill`], the *what* is decided by a primitive's analysis half and emitted
+/// by the codegen half via [`FpXfer::emit`].
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum FpXfer {
+    /// `ir.fpr_move(l, r)`
+    Move(FPReg, FPReg),
+    /// `ir.push(AsmInst::FprSwap(l, r))`
+    Swap(FPReg, FPReg),
+}
+
+impl FpXfer {
+    fn emit(self, ir: &mut AsmIr) {
+        match self {
+            FpXfer::Move(l, r) => ir.fpr_move(l, r),
+            FpXfer::Swap(l, r) => ir.push(AsmInst::FprSwap(l, r)),
+        }
+    }
+}
+
+///
 /// Mode of linkage between stack slot and xmm registers.
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1792,13 +1815,21 @@ impl AbstractFrame {
     ///
     /// Generate bridge AsmIr from F/Sf(l) to Sf(r).
     ///
-    fn to_sf(&mut self, ir: &mut AsmIr, slot: SlotId, l: FPReg, r: FPReg, guarded: SfGuarded) {
+    /// Analysis half (item ②, step 2): bind `slot` to `r` as `Sf` and return the
+    /// FP-register transfer to emit (a move into a vacant `r`, or a swap when
+    /// `r` is occupied). Pure state; codegen wrapper [`Self::to_sf`] emits it.
+    fn to_sf_state(&mut self, slot: SlotId, l: FPReg, r: FPReg, guarded: SfGuarded) -> FpXfer {
         if self.is_xmm_vacant(r) {
             self.set_Sf(slot, r, guarded);
-            ir.fpr_move(l, r);
+            FpXfer::Move(l, r)
         } else {
-            self.gen_xmm_swap(ir, l, r);
+            self.xmm_swap(l, r);
+            FpXfer::Swap(l, r)
         }
+    }
+
+    fn to_sf(&mut self, ir: &mut AsmIr, slot: SlotId, l: FPReg, r: FPReg, guarded: SfGuarded) {
+        self.to_sf_state(slot, l, r, guarded).emit(ir);
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1223,6 +1223,39 @@ impl Into<Guarded> for SfGuarded {
 }
 
 ///
+/// The *location / representation* half of a [`LinkMode`], with the type/class
+/// (`Guarded`) factored out — the dual of [`LinkMode::guarded`].
+///
+/// Part of item ② (separating value placement from type analysis; see
+/// `doc/regalloc_separation.md`). For the boxed cases (`Stack` / `Gp`) the type
+/// is dropped entirely and lives only in `Guarded`; the FP cases keep their
+/// `FPReg` (and `Sf`'s representation refinement), and `Const` keeps the value.
+/// `LinkMode::from_parts(self.placement(), self.guarded())` reconstructs the
+/// original `LinkMode` (verified by a unit test).
+///
+// Scaffolding for item ②: consumed by the round-trip test now and by the
+// storage split (step 0b) next; not yet wired into the live state.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum Placement {
+    None,
+    MaybeNone,
+    /// void (temp slot above sp)
+    Void,
+    /// boxed `Value` in its stack home
+    Stack,
+    /// boxed `Value` in the GP accumulator (r15)
+    Gp,
+    /// unboxed f64 in an xmm (type is implicitly `Float`)
+    Xmm(FPReg),
+    /// unboxed f64 in an xmm + a read-only boxed cache on the stack; carries the
+    /// representation refinement (`Fixnum` / `Float` / `FixnumOrFloat`)
+    XmmStack(FPReg, SfGuarded),
+    /// compile-time constant (no register / stack location)
+    Const(Value),
+}
+
+///
 /// Mode of linkage between stack slot and xmm registers.
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1298,6 +1331,44 @@ impl LinkMode {
             LinkMode::C(v) => Guarded::from_concrete_value(*v),
             LinkMode::V => Guarded::Class(NIL_CLASS),
             _ => unreachable!("{:?}", self),
+        }
+    }
+
+    ///
+    /// The location/representation half of this mode (the dual of
+    /// [`Self::guarded`]). See [`Placement`].
+    ///
+    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
+    fn placement(&self) -> Placement {
+        match self {
+            LinkMode::None => Placement::None,
+            LinkMode::MaybeNone => Placement::MaybeNone,
+            LinkMode::V => Placement::Void,
+            LinkMode::S(_) => Placement::Stack,
+            LinkMode::G(_) => Placement::Gp,
+            LinkMode::F(x) => Placement::Xmm(*x),
+            LinkMode::Sf(x, g) => Placement::XmmStack(*x, *g),
+            LinkMode::C(v) => Placement::Const(*v),
+        }
+    }
+
+    ///
+    /// Recombine a placement with a type guard into a `LinkMode` — the inverse
+    /// of [`Self::placement`] + [`Self::guarded`]. The `guarded` is used only by
+    /// the boxed `Stack` / `Gp` cases (the FP / `Const` / sentinel placements
+    /// carry their own type), so it is ignored for the others.
+    ///
+    #[allow(dead_code)] // step-0a scaffolding; wired in by the storage split
+    fn from_parts(place: Placement, guarded: Guarded) -> Self {
+        match place {
+            Placement::None => LinkMode::None,
+            Placement::MaybeNone => LinkMode::MaybeNone,
+            Placement::Void => LinkMode::V,
+            Placement::Stack => LinkMode::S(guarded),
+            Placement::Gp => LinkMode::G(guarded),
+            Placement::Xmm(x) => LinkMode::F(x),
+            Placement::XmmStack(x, g) => LinkMode::Sf(x, g),
+            Placement::Const(v) => LinkMode::C(v),
         }
     }
 
@@ -1714,5 +1785,34 @@ mod tests {
         test
         "###,
         );
+    }
+
+    /// Item ②: `LinkMode` decomposes losslessly into a `Placement` (location /
+    /// representation) and a `Guarded` (type), and recombines via `from_parts`.
+    #[test]
+    fn linkmode_placement_roundtrip() {
+        use super::*;
+        let x = FPReg(0);
+        // Value-carrying modes: from_parts(placement(), guarded()) == self.
+        let value_modes = [
+            LinkMode::S(Guarded::Value),
+            LinkMode::S(Guarded::Fixnum),
+            LinkMode::S(Guarded::Float),
+            LinkMode::S(Guarded::Class(NIL_CLASS)),
+            LinkMode::G(Guarded::Fixnum),
+            LinkMode::F(x),
+            LinkMode::Sf(x, SfGuarded::Float),
+            LinkMode::Sf(x, SfGuarded::Fixnum),
+            LinkMode::Sf(x, SfGuarded::FixnumOrFloat),
+            LinkMode::C(Value::nil()),
+            LinkMode::C(Value::i32(7)),
+        ];
+        for lm in value_modes {
+            assert_eq!(LinkMode::from_parts(lm.placement(), lm.guarded()), lm);
+        }
+        // Sentinels carry no type; placement() round-trips with any guard.
+        for lm in [LinkMode::None, LinkMode::MaybeNone, LinkMode::V] {
+            assert_eq!(LinkMode::from_parts(lm.placement(), Guarded::Value), lm);
+        }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -581,6 +581,30 @@ impl SlotState {
     }
 
     ///
+    /// §15.3 prototype (`loop-keep-float`): adopt the back-edge's `F` placement
+    /// for loop-carried floats that the loop-entry merge collapsed to `S`/`Sf`.
+    /// The fixpoint already proved `F` is sound for the loop body; re-establishing
+    /// it keeps the body unboxed (the forward-entry box is unboxed *once* at the
+    /// pre-header by the new `S -> F` bridge arm; the back-edge `F -> F` bridge
+    /// moves into the fresh xmm). With no register pressure this is the latent
+    /// per-iteration box removed (§15.3).
+    ///
+    #[cfg(feature = "loop-keep-float")]
+    pub(in crate::codegen::jitgen) fn keep_backedge_floats(&mut self, backedge: &SlotState) {
+        for i in self.all_regs() {
+            // Sound only when every path agrees the slot is a `Float`: a forward
+            // predecessor holding a non-float `C`/`S` would have no `_ -> F`
+            // bridge. `guarded == Float` is exactly that agreement.
+            if matches!(backedge.mode(i), LinkMode::F(_))
+                && self.guarded(i) == Guarded::Float
+                && matches!(self.mode(i), LinkMode::S(_) | LinkMode::Sf(_, _))
+            {
+                self.set_new_F(i);
+            }
+        }
+    }
+
+    ///
     /// F/Sf -> F
     ///
     #[allow(non_snake_case)]
@@ -1767,6 +1791,35 @@ impl AbstractFrame {
                     let tmp = self.set_new_Sf(slot, SfGuarded::Float);
                     ir.float_to_fpr(GP::Rax, tmp, deopt);
                     self.gen_xmm_swap(ir, x, tmp);
+                }
+            }
+            (LinkMode::S(_), LinkMode::F(x)) => {
+                // S -> F: one-time unbox of a boxed float into a pure-xmm
+                // binding (no boxed cache) — a loop pre-header entry adopting the
+                // back-edge's `F` placement (§15.3). Mirrors the `S -> Sf` arm but
+                // sets `F`; reuses `float_to_fpr`, which both backends lower.
+                ir.stack2reg(slot, GP::Rax);
+                let deopt = ir.new_deopt_with_pc(&self, pc + 1);
+                if self.is_xmm_vacant(x) {
+                    ir.float_to_fpr(GP::Rax, x, deopt);
+                    self.set_F(slot, x);
+                } else {
+                    let tmp = self.set_new_F(slot);
+                    ir.float_to_fpr(GP::Rax, tmp, deopt);
+                    self.gen_xmm_swap(ir, x, tmp);
+                }
+            }
+            (LinkMode::Sf(l, _), LinkMode::F(r)) => {
+                // Sf -> F: the value is already unboxed in xmm `l`; drop the
+                // boxed cache and rebind as pure `F`. Mirrors the `F -> F` arm.
+                if l == r {
+                    self.set_F(slot, l);
+                } else if self.is_xmm_vacant(r) {
+                    self.set_F(slot, r);
+                    ir.fpr_move(l, r);
+                } else {
+                    self.gen_xmm_swap(ir, l, r);
+                    self.set_F(slot, r);
                 }
             }
             (LinkMode::G(_), LinkMode::Sf(x, SfGuarded::Float)) => {


### PR DESCRIPTION
## Summary

This branch advances the JIT middle/back-end on two fronts and ships a concrete, benchmark-gated performance win.

- **Register-allocation separation (Phase-1 item ②, doc `regalloc_separation.md` §5).** De-fuse type analysis / representation / placement in the abstract interpreter, and — as the first measured payoff — a **loop-entry float specialization** that keeps loop-carried floats unboxed across loops.
- **LIR migration (goal 1).** Route codegen through a unified low-level IR (`encode_linst`), retiring the bespoke `emit_*`/`AsmInst` paths incrementally (the B-series), incl. aarch64 follow-ups.
- A pre-existing JIT crash fixed along the way.

## Headline: loop-entry float specialization (the shipped win)

A loop JIT enters a loop-carried float from the VM as a conservative boxed `S(Value)` even though the back-edge fixpoint proves it is a `Float`. The merge `join(S(Value), F)` kept `S`, so the loop body decoded **and re-boxed** the float **every iteration** — with the xmm pool free. The fix adopts the back-edge's `F` at the loop header, unboxing the forward entry **once** at the pre-header via a new guarded `S -> F` bridge arm (`float_to_fpr` carries the runtime float guard / deopt). Promotion is gated on every predecessor having a valid `_ -> F` bridge, so non-float paths stay boxed — sound. Same shape as YJIT's guarded loop-entry type specialization, no new allocator.

Result — `call float_to_value` in the mandelbrot inner loop goes **16 → 0**; measured on **both arches**, no regressions:

| benchmark | base | this PR | |
|---|--:|--:|:--|
| mandelbrot | 24.33 | 27.37 i/s | **+12.5%** (M1); ~+13% x86-64 |
| matmul | 0.041 | 0.042 i/s | +2.4% |
| optcarrot | 184.8 | 186.2 fps | +0.7% (checksum unchanged) |
| fib / nbody / aobench / bf / nqueen / sudoku / bedcov | — | — | flat |

## Register-allocation separation groundwork (§5)

Behaviour-preserving steps that made the above tractable and safe:

- Split the meet into a pure `decide_join` (type meet, allocation-free) and `apply_join` (placement + allocation), and recorded it as a replayable `JoinAction` stream with a debug shadow.
- Proved the type meet is **allocation-independent** (`== join_ty`) as a standing debug invariant — the analysis pass can compute types/liveness without allocating.
- Extracted the xmm allocation policy (`try_alloc_xmm`/`alloc_xmm`) into a named `alloc_policy` seam (the universal allocation funnel).
- Documented the diagnosis trail (§13–15): a benchmark regression from a naive "type-only" loop entry calibrated the bar and led to the correct root cause (loop-JIT conservative entry typing), captured in the docs as the negative result that shaped the fix.

## Bug fix

`xmm_swap` assumed both swapped registers shared an `Sf` refinement; a diamond (`if/else`) inside a loop updating a `Float` accumulator on both arms drove the back-edge bridge to swap a pure-`Float` register against a `Fixnum`-refined `Sf`, aborting the process (assert, in release too) while CRuby ran fine. Fixed to relabel each slot's register index keeping its own refinement; regression test added.

## Testing

- `cargo test` (debug, gc shadows active): **1705/0** under CRuby 4.0.
- **M1 `bin/test` full run** passes (aarch64 correctness + benchmark diffs + optcarrot) with the optimization default-on.
- Benchmarks A/B'd on both arches (table above); the new bridge arms reuse existing `float_to_fpr`/`fpr_move` AsmIR ops, so they are arch-neutral.
- Added `test_loop_carried_float_kept_unboxed` and `test_xmm_swap_mixed_refinement`.

## Docs

`doc/regalloc_separation.md` extended through §15.7 with the full design, diagnosis, prototype, measurement, and default-on landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcpFg5RLbp58qCVEbx9aA4)_