### PR TITLE
jit(§5): lower AsmInst::Inline to LIR + loop-aware FP allocator (phys-loop-aware)

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -18,9 +18,12 @@ class/method definition, exceptions, `yield`, the method-prologue guards, …) a
 all lowered through `encode_linst`, as is the **entire** method-call family —
 argument setup *and* the call itself (the dispatcher pre-resolves the
 store/frame-dependent values and the encoder stays store-free) — and the cold
-**deopt side-exit handler** blocks. What remains outside is the specialized
-inlined-frame family, the `AsmInst::Inline` escape hatch, and the zero-byte
-patch/recompile bookkeeping that is *not* byte emission — see §8.
+**deopt side-exit handler** blocks. Even the `AsmInst::Inline` builtin escape
+hatch now lowers to a carrier `LInst::Inline` (dispatched via the
+context-carrying `encode_linst_inline`), so **every** `AsmInst` reaching the
+dispatcher lowers to `LInst`. What remains outside `encode_linst` is the
+specialized inlined-frame family and the zero-byte patch/recompile bookkeeping
+that is *not* byte emission — see §8.
 
 ---
 
@@ -274,18 +277,28 @@ encoder dispatches on `LSideExitKind`.
 The remaining things handled **directly** (not through `encode_linst`):
 
 - **Specialized inlined-frame family.** `MethodRetSpecialized`,
-  `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`,
-  `SpecializedYield`, and `Inline` lower an inlined callee/block frame; they
-  resolve frame-local labels and patch points and are dispatched to a per-arch
-  method of the same name (`arch/<arch>/compile/…`).
+  `BlockBreakSpecialized`, `SpecializedCall`, `SetupYieldFrame`, and
+  `SpecializedYield` lower an inlined callee/block frame; they resolve
+  frame-local labels and patch points and are dispatched to a per-arch method of
+  the same name (`arch/<arch>/compile/…`). (`AsmInst::Inline` is no longer in
+  this group — it lowers to `LInst::Inline`; see below.)
 - **The `AsmInst::Inline` escape hatch.** Most builtin inline generators (e.g.
   `emit_math_sqrt`) still run a closure that emits arch asm directly via `gen`.
-  Migrating these onto LIR is **goal 2** of the long-term plan ("express the
-  inline-builtin codegen once, arch-neutrally"). First proof: `Range#begin/end`
-  now lower through the typed `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg`
-  → existing `LInst::Load { Field }` (no new LIR op, byte-identical on both
-  arches, hand-written `emit_range_begin/end` deleted). The remaining
-  generators need a few new FP/branch LIR primitives (e.g. for `sqrt`).
+  As of the AsmIR→LIR consolidation, `AsmInst::Inline` *does* lower to a
+  carrier LIR op — `LInst::Inline(InlineProcedure)` — so **every** `AsmInst`
+  reaching the dispatcher now lowers to `LInst`. `LInst::Inline` is the one LIR
+  op whose emit is *not* store-free: its wrapped closure needs the compile
+  context (`&Store`, `&SideExitLabels`, frame `base`), so it is dispatched at
+  the lowering boundary via `encode_linst_inline` rather than through the
+  store-free `encode_linst`. (If it ever reached `encode_linst`/`_macro` it hits
+  the `unreachable!` fallthrough.) This is a transitional carrier: migrating the
+  closures onto typed, arch-neutral LIR ops — so the variant can eventually go
+  away — is **goal 2** of the long-term plan ("express the inline-builtin codegen
+  once, arch-neutrally"). First proof: `Range#begin/end` now lower through the
+  typed `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg` → existing
+  `LInst::Load { Field }` (no new LIR op, byte-identical on both arches,
+  hand-written `emit_range_begin/end` deleted). The remaining generators need a
+  few new FP/branch LIR primitives (e.g. for `sqrt`).
 - **Pure patch / recompile *bookkeeping*** — the x86/aarch64 *non-coverage*
   asymmetry of `doc/arch_difference.md` §4. The deopt *handler emission* now
   goes through LIR (above); what stays out is the part that **emits no bytes**:
@@ -297,8 +310,9 @@ The remaining things handled **directly** (not through `encode_linst`):
 > code-position metadata / runtime patch bookkeeping is *not* emission and stays
 > in the dispatcher / `Codegen`.
 
-None of this invalidates the model: `encode_linst` (with `encode_linst_macro`)
-is the single seam for byte emission. The only arms still handled directly in
-the dispatcher are the specialized inlined-frame family (which resolve
+None of this invalidates the model: `encode_linst` (with `encode_linst_macro`,
+plus the context-carrying `encode_linst_inline` for the one `LInst::Inline`
+op) is the single seam for byte emission. The only arms still handled directly
+in the dispatcher are the specialized inlined-frame family (which resolve
 frame-local labels / patch points) and the patch/recompile bookkeeping, which is
 *not* emission by the invariant above.

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -2971,3 +2971,101 @@ semantics, so a darwin-aarch64 codegen miscompile in the `POOL=14` float path. I
 is sidestepped by `stress-spill-pool` (so `bin/test` and the benchmark-driver
 warmup path are unaffected) and is unrelated to layer2 (reproduces on `base`).
 Tracked separately; not reproducible under linux-aarch64 QEMU.
+
+## 42. Stage 2a+2b landed behind `phys-loop-aware`: §29 inertness cracked (under pressure)
+
+Implements the §27.3 loop-aware allocator and — unlike the reverted §28/§29 attempt
+— **verifies it is non-inert**.
+
+**Stage 2a (collect `L`).** A `loop_carried: HashSet<SlotId>` on `SlotState` records
+the loop-carried float set (slots `F`/`Sf` at the back-edge), populated at the
+loop-entry merge from `backedge_for_floats`. The timing §29 lacked is solved by the
+**multi-iteration fixpoint**: the back-edge is already computed before real codegen,
+so `L` is known at merge time. It propagates into the body for free via `Clone` and
+the `&mut self` joins (a correctness-neutral hint). Confirmed populated: the
+complex-iteration kernel gives `L=6` (F=4, Sf=2); `so_nbody` `L=8` (F=7, Sf=1).
+
+**Stage 2b (use `L`).** The phase-1 spill-victim filter (gated on `phys-loop-aware`)
+excludes an all-`Sf` fpr that holds a loop-carried slot, so a fresh value takes a
+phase-2 spill instead of evicting a loop-carried `Sf` cache — fewer in-loop reloads
+(§27.3-2b).
+
+**Non-inertness (the verification the user asked for).** Via the §24 shadow digest,
+on the kernel:
+
+| config | kernel loop digest | `n` (placements) |
+|---|---|---|
+| `shadow-placement` (off) | `0x48168ad7c99d76d5` | 28 |
+| `+ phys-loop-aware` | `0x6191a84d9623dbad` | **26** |
+
+The digest **differs** and the placement count drops **28 → 26** — keeping the
+loop-carried `Sf` resident removed two in-loop reload placements, exactly §26's
+predicted "fewer back-edge moves / different placement". So the §29 wall ("`L`
+always empty at allocation") is cracked: `L` is available *and* changes placement.
+
+**Scope / honest caveat.** The lever only engages under **register pressure**:
+phase 1 (the Sf-demote it gates) runs only when phase 0 finds no vacant fpr. Under
+the shipping `POOL=14`, float loops with `< 14` simultaneously-live floats never hit
+phase 1, so `phys-loop-aware` is **inert there** and the shipping build stays
+byte-identical (the `so_nbody` `POOL=14` digest diff is empty). It bites under
+`stress-spill-pool` (`POOL=2`) and on genuinely high-pressure loops (the
+`doom`-renderer ≈14-float class). So its real-hardware value is narrow, and 2c (the
+M1 perf A/B) measures exactly that.
+
+**Correctness.** `stress-spill-pool,gc-stress,phys-loop-aware` (the lever firing
+under GC) is **2090/2090**. Default build unaffected (the field is an inert,
+`#[allow(dead_code)]` hint; all policy code is `phys-loop-aware`-gated).
+
+**Status.** Stage 2a+2b are implemented and proven non-inert; 2c (M1 perf A/B on
+high-pressure float code) is the gate, and given the POOL=14 inertness it should be
+evaluated on whether any shipping benchmark has enough FP pressure to benefit.
+
+## 43. (2) the global-pin lever: headroom measured, win is *copy coalescing* (partial)
+
+Per the user's choice to pursue the §26 "eliminate back-edge moves" lever (which,
+unlike §42's pressure-gated policy, can bite under shipping `POOL=14`), the back-edge
+FP-reconciliation move count was measured (default build, POOL=14, per loop
+iteration):
+
+| benchmark | back-edge bridges w/ moves | total `FprMove`+`FprSwap` |
+|---|---|---|
+| kernel (complex iter) | 1 | 4 |
+| so_nbody | 1 | 7 |
+| so_mandelbrot (150) | 6 | 29 |
+
+So there **is** per-iteration headroom under POOL=14. But the emit-asm decomposition
+of the kernel's 4 fixes *what kind* of move, and it reshapes (2):
+
+```
+000265: movq xmm4,xmm9     ; zr (new, in xmm9) -> xmm4
+00026a: movq xmm5,xmm8     ; zi (new, in xmm8) -> xmm5
+000273: movq xmm6,xmm9     ; zr -> xmm6   ← duplicate copy of zr
+000278: movq xmm7,xmm8     ; zi -> xmm7   ← duplicate copy of zi
+```
+
+The 4 moves are **2 reconciliations** (`zr`,`zi` land in the header's regs) **+ 2
+duplications** (`zr` is kept in *two* regs `xmm4`/`xmm6`, `zi` in `xmm5`/`xmm7`,
+because two copy-aliased slots each got their own fpr).
+
+### 43.1 Only the duplications are eliminable
+
+- **The reconciliations are intrinsic.** `zr := tr` produces the new `zr` in `tr`'s
+  reg; landing it in the header's expected reg costs one move *somewhere*. Pinning
+  `zr` to a fixed reg merely relocates that move from the back-edge bridge into the
+  body assignment — same per-iteration cost (confirmed by the SSA model: a relabel
+  reconciliation cannot be moved off the critical path, only shifted).
+- **The duplications are coalescable.** `FprAllocator.vfpr` is `Vec<Vec<SlotId>>` —
+  one fpr *already* can hold several slots. The two `zr`-aliases sit in separate
+  fprs only because the parallel-assignment codegen split them. Coalescing
+  copy-aliased loop-carried floats into one fpr removes the duplicate back-edge move
+  (kernel 4 → 2).
+
+### 43.2 Consequence
+
+(2) is a **copy-coalescing** optimization, not a generic "global pin": it recovers
+~half the back-edge moves (the duplications), and the rest are intrinsic. That is a
+real but *partial* win, a substantial fixpoint-allocator change (coalesce decision
+threaded through `copy_slot` + the merge target), squarely in §16.6's regressed-
+before risk class, and still M1-gated. The cheaper §42 `phys-loop-aware` lever is
+orthogonal (pressure-gated); coalescing is the POOL=14-relevant one but pays only
+on copy-heavy loop-carried floats (the `a,b = c,d` swap/rotate shape).

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -66,6 +66,14 @@ shadow-placement = []
 # formula it replaces (verified via `shadow-placement` digests); the seam where
 # P4's loop-aware allocator swaps in. Default-off until the M1 A/B gate clears.
 phys-table = []
+# §5 §27.3 Stage-2: the loop-aware FP allocation policy. ① (the back-edge
+# fixpoint) records the loop-carried float set `L`; the phase-1 spill-victim
+# policy then keeps `L`'s `Sf` caches resident (a fresh value spills instead of
+# evicting a loop-carried float), cutting in-loop reloads. NON-byte-identical by
+# design (§26): it changes placement / removes back-edge moves, so the
+# `shadow-placement` digest becomes a *delta* meter, not an equality check, and
+# the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
+phys-loop-aware = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -909,9 +909,15 @@ impl Codegen {
                 let return_addr = self.do_specialized_call(entry_label, None);
                 self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
             }
-            // Inlined builtin method body: the generator closure emits the
-            // arch-appropriate asm directly.
-            AsmInst::Inline(proc) => (proc.proc)(self, store, labels, frame.base_stack_offset),
+            // Inlined builtin method body: lower to `LInst::Inline`, the
+            // context-carrying escape hatch. Unlike every other `LInst` (which
+            // is store-free and goes through `encode_linst`), its emit needs
+            // `store`/`labels`/`base`, so it is dispatched here via
+            // `encode_linst_inline` — the one LIR op whose machine-code emit
+            // lives at the lowering boundary rather than in `encode_linst`.
+            AsmInst::Inline(proc) => {
+                self.encode_linst_inline(LInst::Inline(proc), store, labels, frame.base_stack_offset)
+            }
             // §20 (B): typed array integer-index read/assign (replaces the
             // `ir.inline` closures, so `AsmInst` is `Clone`). The per-arch
             // index-register setup + `array_index*` call lives in
@@ -990,6 +996,29 @@ impl Codegen {
             other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
         }
         true
+    }
+
+    ///
+    /// Emit the one context-carrying `LInst`: `LInst::Inline`. The wrapped
+    /// generator closure emits arch-appropriate asm directly and, unlike the
+    /// store-free `encode_linst`, needs the compile context (`store`, the
+    /// side-exit `labels`, and the frame `base`). It is therefore dispatched
+    /// from the AsmIR→LIR lowering boundary (`compile_asmir`) rather than from
+    /// `encode_linst`. Accessing `InlineProcedure::proc` is sound here because
+    /// `compile_shared` is a child module of `asmir`, where the field is
+    /// declared.
+    ///
+    pub(in crate::codegen::jitgen) fn encode_linst_inline(
+        &mut self,
+        inst: LInst,
+        store: &Store,
+        labels: &SideExitLabels,
+        base: usize,
+    ) {
+        match inst {
+            LInst::Inline(proc) => (proc.proc)(self, store, labels, base),
+            _ => unreachable!("encode_linst_inline only handles LInst::Inline"),
+        }
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -1,10 +1,18 @@
 //! # Unified low-level IR (LIR) — arch-neutral machine-level instructions
 //!
-//! **Stage 1 of the Phase-1 "unified low-level IR" effort.** This module
-//! defines the *data model only*; it is not yet wired into the compilation
-//! pipeline (hence the module-level `dead_code` allow). Subsequent stages
-//! migrate the per-arch `emit_*` primitives onto it one instruction family at a
-//! time. See `doc/lir.md` for the full design and migration plan.
+//! **The unified low-level IR (Phase-1 item ③).** This module defines the
+//! arch-neutral machine-level instruction set (`LInst`) and its logical
+//! operands (`LOperand` / `LReg` / `LMem`). It **is** wired into the pipeline:
+//! both backends' `encode_linst` (`arch/<arch>/compile`) consume `LInst` as the
+//! **single byte-emission seam**. The family migration is far along — register
+//! moves, slot/field memory, the full FP family, fixnum arithmetic, the guard /
+//! check family, the whole method-call family, and the cold side-exit/deopt
+//! handlers all lower through `encode_linst` (stages 2-A…3-H + A, B5–B8; see the
+//! migration log in `doc/lir.md` §6). The arms still handled directly in the
+//! dispatcher are the specialized inlined-frame family and the zero-byte
+//! patch/recompile bookkeeping (`doc/lir.md` §8); migrating the `AsmInst::Inline`
+//! builtin generators onto LIR is the remaining "express inline-builtin codegen
+//! once, arch-neutrally" goal.
 //!
 //! ## Where it sits
 //!
@@ -38,7 +46,8 @@
 //! one description, which is also the concrete code-generation target the future
 //! interpreter/JIT DSL (Phase-1 item ③) lowers to.
 
-// Stage-1 scaffolding: the model exists but nothing consumes it yet.
+// Some `LInst` variants / helpers are only used by not-yet-migrated families
+// (the `AsmInst::Inline` builtin generators); keep them ahead of their consumers.
 #![allow(dead_code)]
 
 use super::*;
@@ -228,8 +237,11 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
 /// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
 /// `JitLabel`), because the encoder runs after label resolution — the `emit_*`
 /// primitives already receive `DestLabel`s. `DestLabel` is `Clone` but not
-/// `Copy`, so `LInst` is `Clone`/`PartialEq` but not `Copy`.
-#[derive(Debug, Clone)]
+/// `Copy`, so `LInst` is not `Copy`. It is also not `Clone`: the `Inline`
+/// escape hatch wraps a `Box<dyn FnOnce>` generator (see `InlineProcedure`),
+/// which is move-only. `LInst`s are produced, encoded once, and dropped, so a
+/// clone is never needed.
+#[derive(Debug)]
 pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
     Mov {
@@ -845,12 +857,22 @@ pub(in crate::codegen::jitgen) enum LInst {
         loop_jit_spill_bytes: usize,
         base: usize,
     },
+    /// Inlined-builtin escape hatch: an opaque generator closure that emits the
+    /// arch-appropriate asm directly. Unlike every other `LInst` (which is
+    /// store-free and lowered by `encode_linst`), its emit needs the compile
+    /// context (`&Store`, `&SideExitLabels`, frame `base`), so it is dispatched
+    /// by `encode_linst_inline` at the LIR-emit boundary, not `encode_linst`.
+    /// This is the transitional carrier that lets *every* `AsmInst` lower to
+    /// `LInst`; migrating the closures to typed, arch-neutral LIR ops (so this
+    /// variant can eventually go away) is the "express inline-builtin codegen
+    /// once" goal (`doc/lir.md` §8).
+    Inline(super::asmir::InlineProcedure),
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)
 /// `AsmInst`. Stage 2 builds one of these per migrated family and hands it to
 /// the per-arch encoder; for now it is a thin, ergonomic builder over `Vec`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub(in crate::codegen::jitgen) struct Lir {
     insts: Vec<LInst>,
 }

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -140,6 +140,21 @@ impl<'a> JitContext<'a> {
                         target.keep_backedge_floats(adopt, promotable);
                     }
                 }
+                // §27.3 Stage-2a: record the loop-carried float set `L` (slots
+                // `F`/`Sf` at the back-edge) on the loop-entry state, so the
+                // `phys-loop-aware` policy can keep them resident in the body.
+                // Available here only because the fixpoint already computed the
+                // back-edge — the timing §29's forward attempt lacked. It
+                // propagates into the body via clones / `&mut self` joins, and
+                // is an inert hint on the default path.
+                #[cfg(feature = "phys-loop-aware")]
+                if let Some(be) = &backedge_for_floats {
+                    let lc: std::collections::HashSet<SlotId> = be
+                        .all_regs()
+                        .filter(|&i| matches!(be.mode(i), LinkMode::F(_) | LinkMode::Sf(_, _)))
+                        .collect();
+                    target.set_loop_carried(lc);
+                }
             }
             #[cfg(feature = "jit-debug")]
             eprintln!("  target:  {:?}\n", target.slot_state());

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -102,6 +102,26 @@ mod alloc_policy {
             .map(FPReg)
             .filter(|&fpr| !state.fpr_alloc.is_pinned(fpr) && !state.fpr_alloc.is_vacant(fpr))
             .filter(|&fpr| {
+                // §27.3 Stage-2b (`phys-loop-aware`): do not demote the `Sf`
+                // cache of a loop-carried float — keep `L` resident so the
+                // body re-reads it from `xmm` instead of decoding it each
+                // iteration; the fresh value goes to a phase-2 spill instead.
+                // Default path: this filter is absent (`loop_carried` empty),
+                // so victim selection is byte-identical.
+                #[cfg(feature = "phys-loop-aware")]
+                if state
+                    .fpr_alloc
+                    .slots(fpr)
+                    .iter()
+                    .any(|&s| state.loop_carried.contains(&s))
+                    && state
+                        .fpr_alloc
+                        .slots(fpr)
+                        .iter()
+                        .all(|&s| matches!(state.mode(s), LinkMode::Sf(_, _)))
+                {
+                    return false;
+                }
                 state
                     .fpr_alloc
                     .slots(fpr)
@@ -236,6 +256,15 @@ pub(crate) struct SlotState {
     local_num: usize,
     /// D1 forwarding-rest deferral (transient annotation; see the consumers).
     deferred_rest: Option<(SlotId, SlotId, u16)>,
+    /// §27.3 Stage-2a: the loop-carried float set `L` for the enclosing loop —
+    /// slots that are `F`/`Sf` at the loop back-edge (so they round-trip the
+    /// loop). Populated at the loop-entry merge from the fixpoint's back-edge
+    /// (which is why §29's forward-allocation attempt found it empty), and
+    /// propagated through clones / `&mut self` joins. A correctness-neutral
+    /// *hint*: read only by the `phys-loop-aware` allocation policy to keep
+    /// loop-carried `Sf` resident; empty (no effect) on the default path.
+    #[cfg_attr(not(feature = "phys-loop-aware"), allow(dead_code))]
+    loop_carried: std::collections::HashSet<SlotId>,
 }
 
 impl std::fmt::Debug for SlotState {
@@ -266,6 +295,7 @@ impl SlotState {
             r15: None,
             local_num,
             deferred_rest: None,
+            loop_carried: std::collections::HashSet::new(),
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
         ctx
@@ -425,6 +455,15 @@ impl SlotState {
     /// of the analysis-pass placement (`mode == F`). See doc §16.
     pub(in crate::codegen::jitgen) fn is_float_typed(&self, slot: SlotId) -> bool {
         matches!(self.guarded(slot), Guarded::Float)
+    }
+
+    /// §27.3 Stage-2a: record the loop-carried float set for this loop body.
+    #[cfg_attr(not(feature = "phys-loop-aware"), allow(dead_code))]
+    pub(in crate::codegen::jitgen) fn set_loop_carried(
+        &mut self,
+        set: std::collections::HashSet<SlotId>,
+    ) {
+        self.loop_carried = set;
     }
 
     pub(in crate::codegen::jitgen) fn class(&self, slot: SlotId) -> Option<ClassId> {


### PR DESCRIPTION
## Summary

Two steps of the §5 *regalloc separation* effort, **rebased clean onto current master** (the layer2 work is already on master via #743). Replaces #744, which had a merge conflict from #743's squash-merge; this branch is a single clean commit with the net 7-file diff.

### 1. `LInst::Inline` — every `AsmInst` now lowers to LIR
Adds `LInst::Inline(InlineProcedure)`, closing the last `AsmInst` arm that bypassed LIR in the `compile_asmir` dispatcher. After this, **every** `AsmInst` reaching the dispatcher lowers to an `LInst`.

`LInst::Inline` is the one LIR op whose emit is *not* store-free: its wrapped generator closure needs the compile context (`&Store`, `&SideExitLabels`, frame `base`), which the store-free `encode_linst` does not receive. It is therefore dispatched at the AsmIR→LIR lowering boundary via a new `encode_linst_inline`, and hits the `unreachable!` fallthrough if it ever reaches `encode_linst`/`encode_linst_macro`.

`LInst`/`Lir` drop their (unused) `Clone` derive, since `InlineProcedure` wraps a move-only `Box<dyn FnOnce>`. Byte-identical / behaviour-preserving.

### 2. `phys-loop-aware` — loop-aware FP allocation (default-off, §42)
A new default-off feature implementing §27.3 Stage 2a+2b. The back-edge fixpoint (①) records the loop-carried float set `L`; the phase-1 spill-victim policy then keeps `L`'s `Sf` caches resident (a fresh value spills instead of evicting a loop-carried float), cutting in-loop reloads.

This cracks §29's "inertness": supplying `L` at merge time (where the fixpoint has already computed the back-edge) makes the policy actually fire. Verified non-inert under `stress-spill-pool` (POOL=2: placement count 28→26, digest changes) and inert under the shipping POOL=14 (so shipping is byte-identical). It is **non-byte-identical by design** (§26) — the `shadow-placement` digest becomes a delta meter, not an equality check — so it stays behind the flag until the M1 perf A/B gate clears.

### Docs
- `doc/regalloc_separation.md`: §42 (Stage 2a+2b landing) and §43 (the deferred global-pin lever — headroom measured, the win is copy coalescing, partial).
- `doc/lir.md`: §6/§8 updated for the `LInst::Inline` carrier.

## Verification
- x86_64: `cargo build` clean; **1716 lib unit tests pass** (exercises sqrt / array-index inline builtins through the new `LInst::Inline` path).
- aarch64: `cargo check --target aarch64-unknown-linux-gnu` compiles.
- Correctness under `phys-loop-aware` + `stress-spill-pool`: 2090/2090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_