### PR TITLE
lir: inline-builtin → typed LIR (goal-2) + §9 two-phase groundwork

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -294,11 +294,22 @@ The remaining things handled **directly** (not through `encode_linst`):
   the `unreachable!` fallthrough.) This is a transitional carrier: migrating the
   closures onto typed, arch-neutral LIR ops — so the variant can eventually go
   away — is **goal 2** of the long-term plan ("express the inline-builtin codegen
-  once, arch-neutrally"). First proof: `Range#begin/end` now lower through the
-  typed `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg` → existing
-  `LInst::Load { Field }` (no new LIR op, byte-identical on both arches,
-  hand-written `emit_range_begin/end` deleted). The remaining generators need a
-  few new FP/branch LIR primitives (e.g. for `sqrt`).
+  once, arch-neutrally"). The migratable category is the *pure* generators —
+  property/field readers and trivial C-function wrappers, whose codegen is one
+  existing LIR op with no arch-specific control flow:
+  - **Field readers** → `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg`
+    → existing `LInst::Load { Field }` (no new op, byte-identical on both arches).
+    Done: `Range#begin/end` (hand-written `emit_range_begin/end` deleted) and
+    `ArithmeticSequence#begin/#end/#step` (via the shared `inline_field_load`
+    helper; hand-written `emit_load_value_field` deleted from both backends).
+  - **C-function wrappers** (e.g. `Math.sin/cos/atan2`, `Float#**`) are *already*
+    arch-neutral: they route through the typed `AsmInst::CFunc_F_F` /
+    `CFunc_FF_F` (→ existing `LInst::CFunc_*`), not the closure escape hatch.
+
+  What stays a closure is the genuinely arch-specific shapes — generators with
+  control flow whose condition-code mapping differs per arch (`Math.sqrt`'s
+  NaN/negative guard: x86 `ucomisd`+`jp`/`jb`, aarch64 `fcmp`+`fsqrt`), object
+  allocation, `send`, etc. Those need a few new FP/branch LIR primitives first.
 - **Pure patch / recompile *bookkeeping*** — the x86/aarch64 *non-coverage*
   asymmetry of `doc/arch_difference.md` §4. The deopt *handler emission* now
   goes through LIR (above); what stays out is the part that **emits no bytes**:

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -297,11 +297,17 @@ The remaining things handled **directly** (not through `encode_linst`):
   once, arch-neutrally"). The migratable category is the *pure* generators —
   property/field readers and trivial C-function wrappers, whose codegen is one
   existing LIR op with no arch-specific control flow:
-  - **Field readers** → `AsmIr::load_field_to_reg` → `AsmInst::LoadFieldToReg`
-    → existing `LInst::Load { Field }` (no new op, byte-identical on both arches).
-    Done: `Range#begin/end` (hand-written `emit_range_begin/end` deleted) and
-    `ArithmeticSequence#begin/#end/#step` (via the shared `inline_field_load`
-    helper; hand-written `emit_load_value_field` deleted from both backends).
+  - **64-bit field readers** → `AsmIr::load_field_to_reg` →
+    `AsmInst::LoadFieldToReg` → existing `LInst::Load { Field }` (no new op,
+    byte-identical on both arches). Done: `Range#begin/end` (hand-written
+    `emit_range_begin/end` deleted) and `ArithmeticSequence#begin/#end/#step`
+    (via the shared `inline_field_load` helper; `emit_load_value_field` deleted
+    from both backends).
+  - **Bool field readers** → `AsmIr::bool_field_to_reg` →
+    `AsmInst::BoolFieldToReg` → `LInst::BoolFieldToReg` (a small macro-op:
+    32-bit load + `shl 3` + `or FALSE_VALUE`, deduping the two byte-identical
+    `emit_*_exclude_end` emitters into one encode arm per arch). Done:
+    `Range#exclude_end?`, `ArithmeticSequence#exclude_end?`.
   - **C-function wrappers** (e.g. `Math.sin/cos/atan2`, `Float#**`) are *already*
     arch-neutral: they route through the typed `AsmInst::CFunc_F_F` /
     `CFunc_FF_F` (→ existing `LInst::CFunc_*`), not the closure escape hatch.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -316,3 +316,86 @@ op) is the single seam for byte emission. The only arms still handled directly
 in the dispatcher are the specialized inlined-frame family (which resolve
 frame-local labels / patch points) and the patch/recompile bookkeeping, which is
 *not* emission by the invariant above.
+
+---
+
+## §9 The two-phase pipeline: whole-function buffering + virtual GP + physical allocation
+
+Everything above is the **single-pass** seam: `compile_asmir` lowers each
+`AsmInst` to one or more `LInst`s and *emits them immediately* through
+`encode_linst`. That gave us one byte-emission description per op, but it cannot
+host a register allocator: allocation needs the **whole function's** instruction
+stream in hand to compute liveness, so an op cannot be encoded the instant it is
+produced.
+
+The next architectural step (the `AsmIr → LIR` pipeline) splits emission into two
+phases while keeping `AsmIr` and `LIR` as **separate layers** (collapsing them
+would just reconstruct `AsmIr`):
+
+```text
+AsmIr (AsmInst, frame-INDEPENDENT, FP already virtual, GP physical)
+  │  lower (resolve frame size / labels / patch points)
+  ▼
+LIR  = Vec<LInst>   ← whole compiled unit, offsets baked in, GP *virtual*
+  │  arch-dependent physical-register allocation pass (GP virtual → physical)
+  ▼
+encode (drain → encode_linst → bytes)
+```
+
+- **LIR is barely-arch-independent and offset-baked.** Frame base, slot
+  displacements, field offsets, and labels are all resolved when `AsmIr` lowers
+  to `LIR` (`AsmInst` is frame-independent; `LInst` already carries `base`). What
+  `LIR` does *not* yet bake is the physical register assignment.
+- **Registers are virtual in LIR.** FP registers already are (`FPReg` =
+  phys-or-spill, resolved by `PhysMap` at encode time — §25/§27). GP registers
+  are *not*: today `LInst` names concrete `GP`s (`R15` = accumulator, `R12` =
+  globals, `R14` = LFP, plus scratch temporaries). The pipeline introduces a
+  **virtual GP** (`VReg`) for the *allocatable* GP uses; the fixed globals
+  (acc / pc / lfp / globals / executor — see `CLAUDE.md`) stay pinned and are
+  **not** virtualized. Only the temporary/scratch GP traffic becomes virtual and
+  is assigned in the post-LIR phase.
+
+### Blockers (from the current driver, `asmir.rs::compile` ~2293–2400)
+
+The single-pass driver interleaves byte emission with **ordering operations** that
+are not themselves `LInst`s emitted through `encode_linst`:
+
+1. `self.jit.label()` / `bind_label(..)` — label creation and binding.
+2. `self.jit.select_page(1)` — cold/hot page selection (x86 lays side-exit
+   handlers on the cold page).
+3. `frame.sourcemap.push((i, pos))` — source-position records keyed on the
+   *current* code position.
+4. Patch-point / return-address-table bookkeeping (`doc/arch_difference.md` §4),
+   which emits zero bytes but is position-sensitive.
+
+If LIR buffered only the `encode_linst` calls and left (1)–(4) inline, replaying
+the buffer later would desync every label, page boundary, and source mapping.
+Therefore the buffer must model these as **ordering pseudo-ops** in the same
+`Vec<LInst>` (e.g. `LInst::BindLabel`, `LInst::SelectPage`, `LInst::SourcePos`),
+so the *entire* emission stream — bytes **and** position metadata — is one
+ordered sequence the allocator can walk and the drainer can replay faithfully.
+
+### Staged increments
+
+- **9a — Make the emission stream fully reified.** Add the ordering pseudo-ops so
+  `compile_asmir` + the side-exit loop produce a single `Vec<LInst>` covering
+  *all* of byte emission, label binding, page selection, and sourcemap. Verify
+  **byte-identical** output by draining the buffer immediately (no allocation
+  pass yet) — a pure refactor, gated/shadowed like the §24 placement harness.
+- **9b — Introduce `VReg` (virtual GP) with an identity map.** Replace the
+  *allocatable* GP operands with `VReg`, lowered through a trivial
+  virtual→physical map that reproduces today's assignment. Still byte-identical;
+  this only changes the *type* carried, establishing the seam.
+- **9c — Carry liveness / loop metadata into LIR.** Per §27.1, re-deriving
+  liveness after LIR-flatten cost 2.5×, so the allocator must consume the
+  metadata the ① fixpoint already computed (loop-carried sets, etc.) rather than
+  recompute it. Thread it onto the buffer.
+- **9d — The arch-dependent physical-allocation pass.** Walk the buffered LIR,
+  assign physical GPs to `VReg`s (spilling to frame slots under pressure, exactly
+  as `FPReg` does for FP), then drain → encode. This is the first point the
+  output may legitimately differ from today's bytes; like `phys-loop-aware`
+  (§42), it is a perf experiment gated behind a flag + the M1 A/B bench gate, and
+  the shadow digest becomes a delta meter, not an equality check.
+
+9a/9b are byte-identical refactors (safe to land once verified); 9c/9d are the
+substantive allocator work and stay behind a flag until the bench gate clears.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -308,6 +308,14 @@ The remaining things handled **directly** (not through `encode_linst`):
     32-bit load + `shl 3` + `or FALSE_VALUE`, deduping the two byte-identical
     `emit_*_exclude_end` emitters into one encode arm per arch). Done:
     `Range#exclude_end?`, `ArithmeticSequence#exclude_end?`.
+  - **Container length** → `AsmIr::array_len_fixnum` / `string_len_fixnum` →
+    `AsmInst::ArrayLenFixnum` / `StringLenFixnum` → the matching `LInst` (a
+    macro-op: load inline capa + conditional-select the heap length when capa
+    exceeds the inline cap + fixnum-tag; the conditional select is the only
+    per-arch part, x86 `cmov` / aarch64 `csel`). Done: `Array#size`,
+    `String#bytesize` — one op each (differing only in the inline-cap constant,
+    `ARRAY_INLINE_CAPA` vs `STRING_INLINE_CAP`), replacing the four
+    `emit_array_size`/`emit_string_bytesize` emitters.
   - **C-function wrappers** (e.g. `Math.sin/cos/atan2`, `Float#**`) are *already*
     arch-neutral: they route through the typed `AsmInst::CFunc_F_F` /
     `CFunc_FF_F` (→ existing `LInst::CFunc_*`), not the closure escape hatch.

--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -201,7 +201,8 @@ fn as_exclude_end_inline(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_as_exclude_end());
+    // Pure-LIR bool-field read (no arch-specific closure), as `range_exclude_end`.
+    ir.bool_field_to_reg(GP::Rax, GP::Rdi, crate::rvalue::AS_EXCLUDE_END_OFFSET as i32);
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -223,7 +223,10 @@ fn inline_field_load(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_load_value_field(offset));
+    // Pure-LIR field read (no arch-specific closure): the receiver is in Rdi,
+    // load `[Rdi + offset]` into Rax. Lowers to `AsmInst::LoadFieldToReg` →
+    // `LInst::Load { Field }`, identical on both arches (cf. `range_begin`).
+    ir.load_field_to_reg(GP::Rax, GP::Rdi, offset as i32);
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -346,8 +346,9 @@ fn array_size(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_array_size());
-
+    // Pure-LIR container length (no arch-specific closure): inline-or-heap length
+    // of the array receiver in Rdi, fixnum-tagged into Rax.
+    ir.array_len_fixnum(GP::Rax, GP::Rdi);
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -250,8 +250,9 @@ fn range_exclude_end(
         return true;
     }
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_range_exclude_end());
-
+    // Pure-LIR bool-field read (no arch-specific closure): load the 32-bit
+    // exclude-end flag from `[Rdi + off]` and convert it to a Ruby bool Value.
+    ir.bool_field_to_reg(GP::Rax, GP::Rdi, crate::rvalue::RANGE_EXCLUDE_END_OFFSET as i32);
     state.def_reg2acc(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3682,7 +3682,9 @@ fn string_bytesize(
     }
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.inline(move |r#gen, _, _, _| r#gen.emit_string_bytesize());
+    // Pure-LIR container length (no arch-specific closure): inline-or-heap byte
+    // length of the string receiver in Rdi, fixnum-tagged into Rax.
+    ir.string_len_fixnum(GP::Rax, GP::Rdi);
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);
     true
 }

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3817,14 +3817,6 @@ impl Codegen {
         );
     }
 
-    /// Load a 64-bit Value field at `offset` from the receiver in Rdi (x4) → Rax
-    /// (x0). Shared by `ArithmeticSequence#begin`/`#end`/`#step`.
-    pub(crate) fn emit_load_value_field(&mut self, offset: usize) {
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [x4, #(offset as u32)];
-        );
-    }
-
     /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
     /// eq→TRUE, ne→FALSE. Receiver in Rdi (x4) → Rax (x0).
     pub(crate) fn emit_object_not(&mut self) {

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1482,6 +1482,31 @@ impl Codegen {
                     add x(d), x(d), #(FALSE_VALUE);
                 );
             }
+            // dst <- fixnum(Array#size): inline-or-heap length, fixnum-tagged.
+            // `lsl` clears bit 0, so `add #1` == `orr #1`. Scratch x9 holds heap_len.
+            LInst::ArrayLenFixnum { dst, base } => {
+                let (d, b) = (dst.a64().0, base.a64().0);
+                monoasm_arm64!(&mut self.jit,
+                    ldr x(d), [x(b), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+                    ldr x9, [x(b), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+                    cmp x(d), #(ARRAY_INLINE_CAPA as u32);
+                    csel x(d), x9, x(d), gt;
+                    lsl x(d), x(d), #1;
+                    add x(d), x(d), #1;
+                );
+            }
+            // dst <- fixnum(String#bytesize): inline-or-heap byte length, tagged.
+            LInst::StringLenFixnum { dst, base } => {
+                let (d, b) = (dst.a64().0, base.a64().0);
+                monoasm_arm64!(&mut self.jit,
+                    ldr x(d), [x(b), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+                    ldr x9, [x(b), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+                    cmp x(d), #(STRING_INLINE_CAP as u32);
+                    csel x(d), x9, x(d), gt;
+                    lsl x(d), x(d), #1;
+                    add x(d), x(d), #1;
+                );
+            }
             // [lfp - slot] <- src (legalized like `Load`).
             LInst::Store {
                 src,
@@ -3847,29 +3872,6 @@ impl Codegen {
             mov x0, #(TRUE_VALUE);
         );
         self.jit.bind_label(exit);
-    }
-
-    /// `Array#size`/`#length`: untagged length (`get_array_length`) tagged as a
-    /// fixnum in Rax (x0).
-    pub(crate) fn emit_array_size(&mut self) {
-        self.get_array_length();
-        monoasm_arm64!(&mut self.jit,
-            lsl x0, x0, #1;
-            add x0, x0, #1;
-        );
-    }
-
-    /// `String#bytesize`: inline-vs-heap length select, tagged as a fixnum in
-    /// Rax (x0). Receiver in Rdi (x4).
-    pub(crate) fn emit_string_bytesize(&mut self) {
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
-            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
-            cmp x0, #(STRING_INLINE_CAP as u32);
-            csel x0, x9, x0, gt;   // capa > inline cap -> use heap_len
-            lsl x0, x0, #1;
-            add x0, x0, #1;
-        );
     }
 
     /// Length of the array whose pointer is in Rdi (x4) → Rax (x0), untagged.

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1472,6 +1472,16 @@ impl Codegen {
             } => {
                 self.a64_field_load(a64_lreg(dst), a64_lreg(base), disp as u32);
             }
+            // dst <- bool([base + disp]): 32-bit raw-bool field → Ruby bool Value.
+            // `lsl` clears the low 3 bits, so `add #FALSE_VALUE` == `orr`.
+            LInst::BoolFieldToReg { dst, base, disp } => {
+                let (d, b) = (dst.a64().0, base.a64().0);
+                monoasm_arm64!(&mut self.jit,
+                    ldr w(d), [x(b), #(disp as u32)];
+                    lsl x(d), x(d), #3;
+                    add x(d), x(d), #(FALSE_VALUE);
+                );
+            }
             // [lfp - slot] <- src (legalized like `Load`).
             LInst::Store {
                 src,
@@ -3695,16 +3705,6 @@ impl Codegen {
         }
     }
 
-    /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, then add
-    /// FALSE_VALUE (whose bit 3 is clear, so `add` == `or`): 0→FALSE_VALUE,
-    /// 8→0x1c=TRUE_VALUE. Receiver in Rdi (x4) → Rax (x0).
-    pub(crate) fn emit_range_exclude_end(&mut self) {
-        monoasm_arm64!(&mut self.jit,
-            ldr w0, [x4, #(crate::rvalue::RANGE_EXCLUDE_END_OFFSET as u32)];
-            lsl x0, x0, #3;
-            add x0, x0, #(FALSE_VALUE);
-        );
-    }
 
     /// `Fiber.yield` with no args: the yielded value (Rsi/x3) is nil.
     pub(crate) fn emit_fiber_yield_value_nil(&mut self) {
@@ -3807,15 +3807,6 @@ impl Codegen {
         );
     }
 
-    /// `Enumerator::ArithmeticSequence#exclude_end?`: same encoding as
-    /// `emit_range_exclude_end` but from the AS field.
-    pub(crate) fn emit_as_exclude_end(&mut self) {
-        monoasm_arm64!(&mut self.jit,
-            ldr w0, [x4, #(crate::rvalue::AS_EXCLUDE_END_OFFSET as u32)];
-            lsl x0, x0, #3;
-            add x0, x0, #(FALSE_VALUE);
-        );
-    }
 
     /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
     /// eq→TRUE, ne→FALSE. Receiver in Rdi (x4) → Rax (x0).

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -13,7 +13,9 @@ use crate::codegen::jitgen::asmir::ArrayIndexKind;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
 };
-use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg, LSideExitKind};
+use crate::codegen::jitgen::lir::{
+    LAluOp, LCond, LInst, LMem, LOperand, LReg, LSideExitKind, Lir,
+};
 
 /// Resolve a LIR register operand to its aarch64 register number. The scratch
 /// pointer is `x9`.
@@ -157,13 +159,20 @@ impl Codegen {
             std::collections::HashMap::new();
         // Loop-JIT entry sp-bump to undo before any exit resumes the VM.
         let bump = frame.loop_jit_spill_bytes;
+        // §9 (9a, first brick): reify the side-exit handler block into a
+        // whole-region `Lir` buffer, drained through `encode_linst` below. The
+        // handlers sit between the `b skip` (already emitted) and `bind(skip)`,
+        // so draining here — before the `skip` bind — preserves emission order
+        // and is byte-identical. Labels are still created eagerly for the body to
+        // reference; the drain is the seam the future phys-alloc pass slots into.
+        let mut lir = Lir::new();
         for side_exit in ir.side_exit {
             let label = match side_exit {
                 // Eviction falls back to the interpreter like a deopt (the
                 // `__immediate_evict` logging is `cfg(deopt/profile)`-only).
                 SideExit::Evict(Some((pc, wb))) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::Evict,
                         pc,
                         wb,
@@ -179,7 +188,7 @@ impl Codegen {
                         label.clone()
                     } else {
                         let label = self.jit.label();
-                        self.encode_linst(LInst::SideExit {
+                        lir.push(LInst::SideExit {
                             kind: LSideExitKind::Deopt,
                             pc: key.0,
                             wb: key.1.clone(),
@@ -196,7 +205,7 @@ impl Codegen {
                 // correct, just not yet self-optimizing).
                 SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::RecompileDeopt { reason, position },
                         pc,
                         wb,
@@ -208,7 +217,7 @@ impl Codegen {
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::Error,
                         pc,
                         wb,
@@ -224,6 +233,9 @@ impl Codegen {
                 _ => unreachable!("unexpected {side_exit:?}"),
             };
             labels.push(label);
+        }
+        for inst in lir.into_insts() {
+            self.encode_linst(inst);
         }
         if let Some(skip) = &skip {
             self.jit.bind_label(skip.clone());

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -9,26 +9,6 @@
 use super::*;
 
 impl Codegen {
-    /// `Range#exclude_end?`: read the 0/1 flag, shift into bit 3, OR with
-    /// FALSE_VALUE so 0→FALSE_VALUE and 1→TRUE_VALUE. Receiver in rdi → rax.
-    pub(crate) fn emit_range_exclude_end(&mut self) {
-        monoasm! { &mut self.jit,
-            movl rax, [rdi + (crate::rvalue::RANGE_EXCLUDE_END_OFFSET as i32)];
-            shlq rax, 3;
-            orq  rax, (FALSE_VALUE);
-        }
-    }
-
-    /// `Enumerator::ArithmeticSequence#exclude_end?`: same encoding as
-    /// `emit_range_exclude_end` but from the AS field.
-    pub(crate) fn emit_as_exclude_end(&mut self) {
-        monoasm! { &mut self.jit,
-            movl rax, [rdi + (crate::rvalue::AS_EXCLUDE_END_OFFSET as i32)];
-            shlq rax, 3;
-            orq  rax, (FALSE_VALUE);
-        }
-    }
-
     /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
     /// eq→TRUE, ne→FALSE. Receiver in rdi → rax.
     pub(crate) fn emit_object_not(&mut self) {

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -29,14 +29,6 @@ impl Codegen {
         }
     }
 
-    /// Load a 64-bit Value field at `offset` from the receiver in rdi → rax.
-    /// Shared by `ArithmeticSequence#begin`/`#end`/`#step`.
-    pub(crate) fn emit_load_value_field(&mut self, offset: usize) {
-        monoasm! { &mut self.jit,
-            movq rax, [rdi + (offset as i32)];
-        }
-    }
-
     /// `BasicObject#!`: `recv | 0x10` is FALSE_VALUE iff recv is nil/false; map
     /// eq→TRUE, ne→FALSE. Receiver in rdi → rax.
     pub(crate) fn emit_object_not(&mut self) {

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -55,28 +55,6 @@ impl Codegen {
         }
     }
 
-    /// `Array#size`/`#length`: untagged length (`get_array_length`) tagged as a
-    /// fixnum in rax.
-    pub(crate) fn emit_array_size(&mut self) {
-        self.get_array_length();
-        monoasm! { &mut self.jit,
-            salq  rax, 1;
-            orq   rax, 1;
-        }
-    }
-
-    /// `String#bytesize`: inline-vs-heap length select, tagged as a fixnum in
-    /// rax. Receiver in rdi.
-    pub(crate) fn emit_string_bytesize(&mut self) {
-        monoasm! { &mut self.jit,
-            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
-            cmpq rax, (STRING_INLINE_CAP);
-            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
-            salq rax, 1;
-            orq  rax, 1;
-        }
-    }
-
     /// `String#getbyte`: receiver String in rdi, fixnum index in rsi →
     /// rax = byte tagged as a fixnum, or nil when the (negative-adjusted)
     /// index is out of range.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -163,6 +163,7 @@ impl Codegen {
             | AsmInst::ArrayIndex { .. }
             | AsmInst::ArrayIndexAssign { .. }
             | AsmInst::LoadFieldToReg { .. }
+            | AsmInst::BoolFieldToReg { .. }
             | AsmInst::ClassDef { .. }
             | AsmInst::SingletonClassDef { .. }
             | AsmInst::SetArgumentsForwardedHelper { .. }
@@ -286,6 +287,15 @@ impl Codegen {
                 let (d, b) = (x86_lreg(dst), x86_lreg(base));
                 monoasm!( &mut self.jit,
                     movq R(d), [R(b) + (disp)];
+                );
+            }
+            // dst <- bool([base + disp]): 32-bit raw-bool field → Ruby bool Value
+            LInst::BoolFieldToReg { dst, base, disp } => {
+                let (d, b) = (dst as u64, base as u64);
+                monoasm!( &mut self.jit,
+                    movl R(d), [R(b) + (disp)];
+                    shlq R(d), 3;
+                    orq  R(d), (FALSE_VALUE);
                 );
             }
             // [lfp - slot] <- src

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -164,6 +164,8 @@ impl Codegen {
             | AsmInst::ArrayIndexAssign { .. }
             | AsmInst::LoadFieldToReg { .. }
             | AsmInst::BoolFieldToReg { .. }
+            | AsmInst::ArrayLenFixnum { .. }
+            | AsmInst::StringLenFixnum { .. }
             | AsmInst::ClassDef { .. }
             | AsmInst::SingletonClassDef { .. }
             | AsmInst::SetArgumentsForwardedHelper { .. }
@@ -296,6 +298,28 @@ impl Codegen {
                     movl R(d), [R(b) + (disp)];
                     shlq R(d), 3;
                     orq  R(d), (FALSE_VALUE);
+                );
+            }
+            // dst <- fixnum(Array#size): inline-or-heap length, fixnum-tagged.
+            LInst::ArrayLenFixnum { dst, base } => {
+                let (d, b) = (dst as u64, base as u64);
+                monoasm!( &mut self.jit,
+                    movq R(d), [R(b) + (RVALUE_OFFSET_ARY_CAPA)];
+                    cmpq R(d), (ARRAY_INLINE_CAPA);
+                    cmovgtq R(d), [R(b) + (RVALUE_OFFSET_HEAP_LEN)];
+                    salq R(d), 1;
+                    orq  R(d), 1;
+                );
+            }
+            // dst <- fixnum(String#bytesize): inline-or-heap byte length, tagged.
+            LInst::StringLenFixnum { dst, base } => {
+                let (d, b) = (dst as u64, base as u64);
+                monoasm!( &mut self.jit,
+                    movq R(d), [R(b) + (RVALUE_OFFSET_ARY_CAPA)];
+                    cmpq R(d), (STRING_INLINE_CAP);
+                    cmovgtq R(d), [R(b) + (RVALUE_OFFSET_HEAP_LEN)];
+                    salq R(d), 1;
+                    orq  R(d), 1;
                 );
             }
             // [lfp - slot] <- src

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1,5 +1,8 @@
 use crate::bytecodegen::BinOpK;
-use crate::codegen::jitgen::lir::{Lir, LInst, LSideExitKind};
+// Only the x86-gated `gen_asm` driver uses these directly; the aarch64 driver
+// lives in `arch/aarch64/compile.rs` with its own imports.
+#[cfg(target_arch = "x86_64")]
+use crate::codegen::jitgen::lir::{LInst, LSideExitKind, Lir};
 
 use super::*;
 
@@ -1013,6 +1016,18 @@ impl AsmIr {
         self.inst.push(AsmInst::BoolFieldToReg { dst, base, disp });
     }
 
+    /// Emit `dst <- fixnum(Array#size)`: the fixnum-tagged length of the array
+    /// receiver in `base`. Typed alternative to `inline` for `Array#size`.
+    pub(crate) fn array_len_fixnum(&mut self, dst: GP, base: GP) {
+        self.inst.push(AsmInst::ArrayLenFixnum { dst, base });
+    }
+
+    /// Emit `dst <- fixnum(String#bytesize)`: the fixnum-tagged byte length of
+    /// the string receiver in `base`. Typed alternative to `inline`.
+    pub(crate) fn string_len_fixnum(&mut self, dst: GP, base: GP) {
+        self.inst.push(AsmInst::StringLenFixnum { dst, base });
+    }
+
     pub(crate) fn bc_index(&mut self, index: BcIndex) {
         self.push(AsmInst::BcIndex(index));
     }
@@ -1579,6 +1594,21 @@ pub(super) enum AsmInst {
         dst: GP,
         base: GP,
         disp: i32,
+    },
+    /// `dst <- fixnum(Array#size)`: the fixnum-tagged length of the array
+    /// receiver in `base` (inline `capa`, or the heap length when `capa` exceeds
+    /// `ARRAY_INLINE_CAPA`), `(n << 1) | 1`. Typed replacement for the
+    /// `emit_array_size` closure. Lowers to `LInst::ArrayLenFixnum`.
+    ArrayLenFixnum {
+        dst: GP,
+        base: GP,
+    },
+    /// `dst <- fixnum(String#bytesize)`: as `ArrayLenFixnum` but for a string
+    /// receiver (inline threshold `STRING_INLINE_CAP`). Typed replacement for the
+    /// `emit_string_bytesize` closure. Lowers to `LInst::StringLenFixnum`.
+    StringLenFixnum {
+        dst: GP,
+        base: GP,
     },
     #[allow(non_camel_case_types)]
     CFunc_F_F {

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1,5 +1,5 @@
 use crate::bytecodegen::BinOpK;
-use crate::codegen::jitgen::lir::{LInst, LSideExitKind};
+use crate::codegen::jitgen::lir::{Lir, LInst, LSideExitKind};
 
 use super::*;
 
@@ -2294,11 +2294,18 @@ impl Codegen {
         let mut deopt_table: HashMap<(BytecodePtr, WriteBack), DestLabel> = HashMap::default();
         let loop_jit_spill_bytes = frame.loop_jit_spill_bytes;
         let base = frame.base_stack_offset;
+        // §9 (9a, first brick): reify the isolated side-exit handler block into a
+        // whole-region `Lir` buffer, then drain it through `encode_linst` below
+        // instead of emitting each handler inline. Byte-identical (immediate
+        // drain, no allocation pass yet); the labels are still created eagerly so
+        // the main body can reference them. This is the seam the future
+        // physical-allocation pass slots into (between buffering and the drain).
+        let mut lir = Lir::new();
         for side_exit in ir.side_exit {
             let label = match side_exit {
                 SideExit::Evict(Some((pc, wb))) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::Evict,
                         pc,
                         wb,
@@ -2314,7 +2321,7 @@ impl Codegen {
                         label.clone()
                     } else {
                         let label = self.jit.label();
-                        self.encode_linst(LInst::SideExit {
+                        lir.push(LInst::SideExit {
                             kind: LSideExitKind::Deopt,
                             pc: t.0,
                             wb: t.1.clone(),
@@ -2328,7 +2335,7 @@ impl Codegen {
                 }
                 SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::RecompileDeopt { reason, position },
                         pc,
                         wb,
@@ -2340,7 +2347,7 @@ impl Codegen {
                 }
                 SideExit::Error(pc, wb) => {
                     let label = self.jit.label();
-                    self.encode_linst(LInst::SideExit {
+                    lir.push(LInst::SideExit {
                         kind: LSideExitKind::Error,
                         pc,
                         wb,
@@ -2353,6 +2360,9 @@ impl Codegen {
                 _ => unreachable!("unexpected {side_exit:?}"),
             };
             side_exits.push(label);
+        }
+        for inst in lir.into_insts() {
+            self.encode_linst(inst);
         }
 
         if entry.is_some() && exit.is_some() {

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1006,6 +1006,13 @@ impl AsmIr {
         self.inst.push(AsmInst::LoadFieldToReg { dst, base, disp });
     }
 
+    /// Emit `dst <- bool([base + disp])`: load a 32-bit raw-bool field and
+    /// convert it to a Ruby `true`/`false` `Value`. Typed alternative to
+    /// `inline` for the `exclude_end?` field-reader inline builtins.
+    pub(crate) fn bool_field_to_reg(&mut self, dst: GP, base: GP, disp: i32) {
+        self.inst.push(AsmInst::BoolFieldToReg { dst, base, disp });
+    }
+
     pub(crate) fn bc_index(&mut self, index: BcIndex) {
         self.push(AsmInst::BcIndex(index));
     }
@@ -1559,6 +1566,16 @@ pub(super) enum AsmInst {
     /// so their codegen is expressed once in arch-neutral LIR rather than as
     /// per-arch hand-written asm. Lowers to `LInst::Load { mem: Field }`.
     LoadFieldToReg {
+        dst: GP,
+        base: GP,
+        disp: i32,
+    },
+    /// `dst <- bool([base + disp])`: load a 32-bit raw-bool field of a heap
+    /// object and convert it to a Ruby `true`/`false` `Value` (`(b << 3) |
+    /// FALSE_VALUE`). A typed replacement for the `emit_*_exclude_end` closures
+    /// (`Range#exclude_end?`, `ArithmeticSequence#exclude_end?`), which were
+    /// byte-identical bar the offset. Lowers to `LInst::BoolFieldToReg`.
+    BoolFieldToReg {
         dst: GP,
         base: GP,
         disp: i32,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -942,6 +942,14 @@ impl Codegen {
             AsmInst::BoolFieldToReg { dst, base, disp } => {
                 self.encode_linst(LInst::BoolFieldToReg { dst, base, disp })
             }
+            // Typed container-length-as-fixnum (replaces `emit_array_size` /
+            // `emit_string_bytesize`).
+            AsmInst::ArrayLenFixnum { dst, base } => {
+                self.encode_linst(LInst::ArrayLenFixnum { dst, base })
+            }
+            AsmInst::StringLenFixnum { dst, base } => {
+                self.encode_linst(LInst::StringLenFixnum { dst, base })
+            }
             // ---- Class/module definition + misc runtime-call ops --------------
             // `class`/`module` (re)definition + body, and `class << obj`. aarch64
             // bails on a live fpr pool reg / out-of-range frame offset.

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -938,6 +938,10 @@ impl Codegen {
                     disp,
                 },
             }),
+            // Typed bool-field load (replaces the `emit_*_exclude_end` closures).
+            AsmInst::BoolFieldToReg { dst, base, disp } => {
+                self.encode_linst(LInst::BoolFieldToReg { dst, base, disp })
+            }
             // ---- Class/module definition + misc runtime-call ops --------------
             // `class`/`module` (re)definition + body, and `class << obj`. aarch64
             // bails on a live fpr pool reg / out-of-range frame offset.

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -259,6 +259,16 @@ pub(in crate::codegen::jitgen) enum LInst {
         dst: LReg,
         mem: LMem,
     },
+    /// `dst <- bool([base + disp])`: zero-extend a 32-bit raw-bool object field
+    /// and convert it to a Ruby `true`/`false` `Value` (`(b << 3) |
+    /// FALSE_VALUE`). A small macro-op (32-bit load + shift + or, identical on
+    /// both arches bar the load encoding); replaces the per-arch
+    /// `emit_*_exclude_end` field-reader emitters.
+    BoolFieldToReg {
+        dst: GP,
+        base: GP,
+        disp: i32,
+    },
     /// `[mem] <- src`.
     Store {
         src: GP,

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -894,6 +894,14 @@ impl Lir {
         self.insts.iter()
     }
 
+    /// Consume the buffer, yielding its `LInst`s in order. The drain point for
+    /// the two-phase pipeline (§9): a region is buffered, then replayed through
+    /// `encode_linst` here. (A later increment runs the physical-allocation pass
+    /// over the `Vec` between buffering and this drain.)
+    pub(in crate::codegen::jitgen) fn into_insts(self) -> Vec<LInst> {
+        self.insts
+    }
+
     pub(in crate::codegen::jitgen) fn push(&mut self, inst: LInst) -> &mut Self {
         self.insts.push(inst);
         self

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -269,6 +269,21 @@ pub(in crate::codegen::jitgen) enum LInst {
         base: GP,
         disp: i32,
     },
+    /// `dst <- fixnum(Array#size)`: fixnum-tagged length of an inline-or-heap
+    /// array. A macro-op (load inline capa + conditional-select heap len when
+    /// capa > `ARRAY_INLINE_CAPA` + `(n << 1) | 1` tag); the conditional select
+    /// is the per-arch part (x86 `cmov`, aarch64 `csel`). Replaces the per-arch
+    /// `emit_array_size` emitter.
+    ArrayLenFixnum {
+        dst: GP,
+        base: GP,
+    },
+    /// `dst <- fixnum(String#bytesize)`: as `ArrayLenFixnum` but with the string
+    /// inline threshold `STRING_INLINE_CAP`. Replaces `emit_string_bytesize`.
+    StringLenFixnum {
+        dst: GP,
+        base: GP,
+    },
     /// `[mem] <- src`.
     Store {
         src: GP,


### PR DESCRIPTION
## Summary

LIR-consolidation follow-ups to #745, in two related threads. All commits are byte-identical / behaviour-preserving refactors (the closures' machine code is reproduced exactly through typed LIR ops).

### goal-2: migrate pure inline builtins off the `AsmInst::Inline` closure escape hatch
`doc/lir.md` §8 goal-2 is "express the inline-builtin codegen once, arch-neutrally". The *pure* generators — property/field readers and simple length helpers — are one existing/typed LIR op with no arch-specific control flow, so they migrate off the per-arch closure:

- **Field readers** (`ArithmeticSequence#begin/#end/#step`) → `AsmIr::load_field_to_reg` → existing `LInst::Load { Field }`. Deletes the hand-written `emit_load_value_field` from both backends. (Same path `Range#begin/end` already use.)
- **Bool field readers** (`Range#exclude_end?`, `ArithmeticSequence#exclude_end?`) → new typed `BoolFieldToReg` (32-bit load + `shl 3` + `or FALSE_VALUE`). Dedups the two byte-identical `emit_*_exclude_end` emitters into one encode arm per arch.
- **Container length** (`Array#size`, `String#bytesize`) → new typed `ArrayLenFixnum` / `StringLenFixnum` (load inline capa + conditional-select heap len + fixnum-tag). The two ops differ only in the inline-cap constant (`ARRAY_INLINE_CAPA` vs `STRING_INLINE_CAP`); together they replace the four `emit_array_size`/`emit_string_bytesize` emitters. The one per-arch part is the conditional select (x86 `cmov` / aarch64 `csel`).

Net: 7 inline builtins move to arch-independent LIR; 8 hand-written per-arch emitters removed; the `AsmInst::Inline` escape hatch shrinks toward only the genuinely arch-specific shapes (e.g. `Math.sqrt`'s NaN guard, allocation, `send`).

### §9: two-phase pipeline groundwork
Design + first brick for the `AsmIr → LIR` two-phase pipeline (whole-function buffering → arch-dependent physical-register allocation → drain/encode), the next step toward a register allocator over LIR:

- `doc/lir.md` §9 records the target architecture, the blockers in the current single-pass driver (emission interleaved with label-bind / page-select / sourcemap / patch bookkeeping), and the staged increments 9a–9d.
- **9a (first brick):** both drivers now buffer the isolated cold side-exit handler block into a `Lir` and drain it through `encode_linst`, instead of emitting each handler inline — establishing the buffer→drain seam the future allocation pass slots into. Byte-identical (immediate drain, no allocation pass yet).

## Verification
- x86_64: `cargo build` clean; **1716 lib unit tests pass** (warm the JIT 25×, exercising the migrated builtins + the deopt/side-exit handlers); array/string/range/arithmetic_sequence integration tests pass.
- aarch64: `cargo check --target aarch64-unknown-linux-gnu` compiles clean.
- Value spot-check vs CRuby: `Array#size` / `String#bytesize` / `exclude_end?` match on both inline and heap paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_