### PR TITLE
jit(§9): GP register-allocator groundwork — VReg seam + pool + GpAllocator table

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -444,5 +444,29 @@ ordered sequence the allocator can walk and the drainer can replay faithfully.
   (§42), it is a perf experiment gated behind a flag + the M1 A/B bench gate, and
   the shadow digest becomes a delta meter, not an equality check.
 
+### 9d allocatable GP pool (design decision)
+
+The VM's fixed registers stay **pinned** (acc=R15, lfp=R14, pc=R13, globals=R12,
+executor=rbx) and the C-ABI / inline-builtin convention regs (rdi=recv, rax=result,
+rsi/rdx/rcx=call args) are **pre-colored** by the operations that use them — the
+allocator cannot move those. The allocatable pool is the otherwise-unused
+**caller-saved scratch** set:
+
+- **x86-64:** `r8, r9, r10, r11` (4 registers). These are caller-saved, so any of
+  them that is **live across a C-ABI call** (e.g. a runtime helper / `CFunc_*`)
+  must be spilled to the frame and reloaded — the allocator inserts the
+  save/restore exactly as the FP side already does around calls (`fpr_save` /
+  `fpr_restore`).
+- **aarch64:** the analogous caller-saved temps left free in the `GP::a64` map
+  (`x9..x15` minus the encode scratch x9/x10), with the same spill-across-call
+  rule.
+
+So a `VReg` is either **pinned** (an ABI/convention register the front-end chose)
+or **allocatable** (assigned by 9d to a pool register or a spill slot). The
+identity map of 9b is the degenerate all-pinned case; 9d makes the front-end emit
+allocatable `VReg`s for cross-operation temporaries and colours them into the
+pool. The payoff is keeping hot bytecode-slot values in `r8`–`r11` instead of
+re-loading them from the LFP each use.
+
 9a/9b are byte-identical refactors (safe to land once verified); 9c/9d are the
 substantive allocator work and stay behind a flag until the bench gate clears.

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -74,6 +74,12 @@ phys-table = []
 # `shadow-placement` digest becomes a *delta* meter, not an equality check, and
 # the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
 phys-loop-aware = []
+# §9 9d-B: the GP register allocator. Tracks slots resident in the allocatable
+# pool (x86-64 r8-r11) in `gp_alloc` (the `fpr_alloc` analogue), colours
+# `VReg::Alloc` ids into pool registers (spilling under pressure), and spills
+# pool registers live across C-ABI calls. NON-byte-identical once it places a
+# slot; default-off until the M1 A/B bench gate clears (cf. phys-loop-aware §42).
+gp-alloc = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -102,6 +102,18 @@ const COUNT_RECOMPILE_ARECV_CLASS: i32 = 5;
 const COUNT_DEOPT_RECOMPILE: i32 = 10;
 const COUNT_DEOPT_RECOMPILE_SPECIALIZED: i32 = 50;
 
+/// §9 9d allocatable GP pool: the caller-saved scratch registers that are *not*
+/// used by the fixed VM convention (acc/lfp/pc/globals/executor) or the C-ABI /
+/// inline-builtin convention (rdi/rax/rsi/rdx/rcx). The 9d allocator colours
+/// `VReg::Alloc` ids into these (or a frame spill slot); because they are
+/// caller-saved, any live across a C-ABI call is spilled/reloaded around it.
+///
+/// x86-64: `r8`–`r11`. (aarch64's pool is revisited when 9d targets it — these
+/// `GP` names map to `x5`–`x8` via `GP::a64`, which overlap the aarch64 call-arg
+/// scratch, so the aarch64 allocatable set will likely differ.)
+#[allow(dead_code)]
+pub(in crate::codegen) const GP_ALLOC_POOL: [GP; 4] = [GP::R8, GP::R9, GP::R10, GP::R11];
+
 ///
 /// General purpose registers.
 ///

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -21,7 +21,7 @@ use crate::codegen::jitgen::lir::{
 /// pointer is `x9`.
 fn a64_lreg(r: LReg) -> u32 {
     match r {
-        LReg::Gp(g) => g.a64().0,
+        LReg::Gp(v) => v.phys().a64().0,
         LReg::Scratch => 9,
     }
 }
@@ -1627,9 +1627,9 @@ impl Codegen {
                 rhs: LOperand::Imm(i),
             } if dst == lhs => {
                 if i != 0 {
-                    let d = dst.a64().0;
+                    let d = dst.phys().a64().0;
                     let imm = i as u64;
-                    match (op, dst == GP::Rsp) {
+                    match (op, dst.phys() == GP::Rsp) {
                         (LAluOp::Add, false) => {
                             monoasm_arm64!(&mut self.jit, mov x9, (imm); add x(d), x(d), x9;)
                         }
@@ -1652,10 +1652,10 @@ impl Codegen {
             // fixnum bits) is staged through scratch x9, matching
             // `a64_cmp_integer`.
             LInst::Cmp { lhs, rhs } => {
-                let l = lhs.a64().0;
+                let l = lhs.phys().a64().0;
                 match rhs {
                     LOperand::Reg(r) => {
-                        let r = r.a64().0;
+                        let r = r.phys().a64().0;
                         monoasm_arm64!(&mut self.jit, cmp x(l), x(r););
                     }
                     LOperand::Imm(i) => {

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1441,7 +1441,7 @@ impl Codegen {
         match inst {
             // dst <- src (elided when the physical registers coincide)
             LInst::Mov { dst, src } => {
-                let (s, d) = (src.a64().0, dst.a64().0);
+                let (s, d) = (src.phys().a64().0, dst.phys().a64().0);
                 if s != d {
                     monoasm_arm64!(&mut self.jit, mov x(d), x(s););
                 }
@@ -1449,7 +1449,7 @@ impl Codegen {
             // dst <- imm (monoasm_arm64! expands a 64-bit immediate to the
             // movz/movk sequence as needed)
             LInst::LoadImm { dst, imm } => {
-                let d = dst.a64().0;
+                let d = dst.phys().a64().0;
                 monoasm_arm64!(&mut self.jit, mov x(d), (imm););
             }
             // dst <- [lfp - slot]. `a64_frame_load` legalizes the (negative)

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -17,7 +17,7 @@ use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg, LS
 /// pointer is `rdx`.
 fn x86_lreg(r: LReg) -> u64 {
     match r {
-        LReg::Gp(g) => g as u64,
+        LReg::Gp(v) => v.phys() as u64,
         LReg::Scratch => GP::Rdx as u64,
     }
 }
@@ -462,7 +462,7 @@ impl Codegen {
                 rhs: LOperand::Imm(i),
             } if dst == lhs => {
                 if i != 0 {
-                    let r = dst as u64;
+                    let r = dst.phys() as u64;
                     let imm = i as i32;
                     match op {
                         LAluOp::Add => monoasm! { &mut self.jit, addq R(r), (imm); },
@@ -477,9 +477,11 @@ impl Codegen {
             // pattern (a tagged fixnum), passed as u64 so the encoding matches
             // the hand-written `cmp_integer`.
             LInst::Cmp { lhs, rhs } => {
-                let l = lhs as u64;
+                let l = lhs.phys() as u64;
                 match rhs {
-                    LOperand::Reg(r) => monoasm! { &mut self.jit, cmpq R(l), R(r as u64); },
+                    LOperand::Reg(r) => {
+                        monoasm! { &mut self.jit, cmpq R(l), R(r.phys() as u64); }
+                    }
                     LOperand::Imm(i) => monoasm! { &mut self.jit, cmpq R(l), (i as u64); },
                 }
             }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -262,6 +262,7 @@ impl Codegen {
         match inst {
             // dst <- src (elided when src == dst)
             LInst::Mov { dst, src } => {
+                let (src, dst) = (src.phys(), dst.phys());
                 if src != dst {
                     let (src, dst) = (src as u64, dst as u64);
                     monoasm!( &mut self.jit,
@@ -271,7 +272,7 @@ impl Codegen {
             }
             // dst <- imm (full 64-bit immediate; x86 movq r64, imm64)
             LInst::LoadImm { dst, imm } => {
-                let r = dst as u64;
+                let r = dst.phys() as u64;
                 monoasm!( &mut self.jit,
                     movq R(r), (imm);
                 );

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -45,11 +45,14 @@ impl Codegen {
                 self.jit.bind_label(label);
             }
             // dst <- src
-            AsmInst::RegMove(src, dst) => self.encode_linst(LInst::Mov { dst, src }),
+            AsmInst::RegMove(src, dst) => self.encode_linst(LInst::Mov {
+                dst: dst.into(),
+                src: src.into(),
+            }),
             // acc <- reg
             AsmInst::RegToAcc(r) => self.encode_linst(LInst::Mov {
-                dst: GP::R15,
-                src: r,
+                dst: GP::R15.into(),
+                src: r.into(),
             }),
             // [slot] <- acc
             AsmInst::AccToStack(slot) => self.encode_linst(LInst::Store {
@@ -68,7 +71,7 @@ impl Codegen {
             }),
             // reg <- literal Value (immediate)
             AsmInst::LitToReg(v, r) => self.encode_linst(LInst::LoadImm {
-                dst: r,
+                dst: r.into(),
                 imm: v.id(),
             }),
             // [slot] <- literal Value. The encoder legalizes the immediate
@@ -313,7 +316,7 @@ impl Codegen {
                     // lhs).
                     OpMode::IR(i, _) => {
                         self.encode_linst(LInst::LoadImm {
-                            dst: lhs,
+                            dst: lhs.into(),
                             imm: Value::i32(i as i32).id(),
                         });
                         self.encode_linst(LInst::Cmp {
@@ -579,8 +582,8 @@ impl Codegen {
                     value: src,
                 });
                 self.encode_linst(LInst::Mov {
-                    dst: GP::Rax,
-                    src,
+                    dst: GP::Rax.into(),
+                    src: src.into(),
                 });
             }
             // Heap (Box-spilled) Struct member access: deref the heap buffer
@@ -623,8 +626,8 @@ impl Codegen {
                     },
                 });
                 self.encode_linst(LInst::Mov {
-                    dst: GP::Rax,
-                    src,
+                    dst: GP::Rax.into(),
+                    src: src.into(),
                 });
             }
             // reg += i / reg -= i (no-op when i == 0).

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -304,11 +304,11 @@ impl Codegen {
                 let target = frame.resolve_label(&mut self.jit, branch_dest);
                 match mode {
                     OpMode::RR(..) => self.encode_linst(LInst::Cmp {
-                        lhs,
-                        rhs: LOperand::Reg(rhs),
+                        lhs: lhs.into(),
+                        rhs: rhs.into(),
                     }),
                     OpMode::RI(_, i) => self.encode_linst(LInst::Cmp {
-                        lhs,
+                        lhs: lhs.into(),
                         rhs: LOperand::Imm(Value::i32(i as i32).id() as i64),
                     }),
                     // imm on the left: materialize it into lhs, then compare
@@ -320,8 +320,8 @@ impl Codegen {
                             imm: Value::i32(i as i32).id(),
                         });
                         self.encode_linst(LInst::Cmp {
-                            lhs,
-                            rhs: LOperand::Reg(rhs),
+                            lhs: lhs.into(),
+                            rhs: rhs.into(),
                         });
                     }
                 }
@@ -633,14 +633,14 @@ impl Codegen {
             // reg += i / reg -= i (no-op when i == 0).
             AsmInst::RegAdd(reg, i) => self.encode_linst(LInst::Alu {
                 op: LAluOp::Add,
-                dst: reg,
-                lhs: reg,
+                dst: reg.into(),
+                lhs: reg.into(),
                 rhs: LOperand::Imm(i as i64),
             }),
             AsmInst::RegSub(reg, i) => self.encode_linst(LInst::Alu {
                 op: LAluOp::Sub,
-                dst: reg,
-                lhs: reg,
+                dst: reg.into(),
+                lhs: reg.into(),
                 rhs: LOperand::Imm(i as i64),
             }),
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than

--- a/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
+++ b/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
@@ -75,7 +75,7 @@ impl<'a> JitContext<'a> {
         }
         if let Some(backedge) = &mut backedge {
             for i in backedge.all_regs() {
-                if let LinkMode::G(_) = backedge.mode(i) {
+                if let LinkMode::G(_, _) = backedge.mode(i) {
                     let g = backedge.guarded(i);
                     backedge.set_S_with_guard(i, g);
                 }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -97,31 +97,49 @@ impl From<GP> for LReg {
     }
 }
 
-/// A **virtual** general-purpose register (§9 9b).
+/// A **virtual** general-purpose register (§9 9b/9d).
 ///
-/// LIR is meant to carry virtual registers, with physical assignment deferred to
-/// a later arch-dependent phase (§9 9d) — exactly as `FPReg` already is for the
-/// floating-point file. `VReg` is the GP analogue. **Today the map is the
-/// identity**: the front-end still picks a concrete physical `GP` (the fixed VM
-/// calling convention — `Rdi` = receiver, `Rax` = result, `R15` = accumulator,
-/// …), and `VReg` carries it through unchanged, resolving back to the same `GP`
-/// at the encode seam (`phys()`). This only establishes the *type* boundary so a
-/// future allocator can be slotted in between buffering and emission without
-/// touching every `encode_linst` arm again.
+/// LIR carries virtual registers, with physical assignment deferred to a later
+/// arch-dependent phase — exactly as `FPReg` already is for the FP file. A `VReg`
+/// is one of two kinds:
+///
+/// - [`VReg::Pinned`] — a *pre-colored* physical `GP` the front-end chose: the
+///   fixed VM globals (acc=`R15`, lfp=`R14`, …) and the C-ABI / inline-builtin
+///   convention registers (`Rdi`=receiver, `Rax`=result, `Rsi`/`Rdx`/`Rcx`=call
+///   args). The allocator cannot move these.
+/// - [`VReg::Alloc`] — an *allocatable* virtual id, coloured by the 9d allocator
+///   into the [`GP_ALLOC_POOL`] (`r8`–`r11` on x86-64) or a frame spill slot.
+///   Pool registers are caller-saved, so any live across a C-ABI call are
+///   spilled/reloaded around it (as the FP side already does).
+///
+/// **Today the map is the identity** (9b): the front-end emits only `Pinned`, so
+/// `phys()` is total and byte-identical. 9d makes the front-end emit `Alloc` for
+/// cross-operation temporaries and replaces this seam with a map-consulting
+/// resolve (the GP analogue of `PhysMap::resolve` → `FPRegLoc`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::codegen::jitgen) struct VReg(GP);
+pub(in crate::codegen::jitgen) enum VReg {
+    Pinned(GP),
+    Alloc(u32),
+}
 
 impl VReg {
-    /// Resolve to the physical register. Identity for now (§9 9b); the seam
-    /// where the future GP allocator (§9 9d) maps a virtual id to a physical reg.
+    /// Resolve to the physical register at the encode seam. Identity on `Pinned`
+    /// (§9 9b). `Alloc` is unreachable until the 9d allocator is wired (no `Alloc`
+    /// VRegs are emitted yet), at which point this becomes a map-consulting
+    /// resolve that may also yield a spill slot.
     pub(in crate::codegen::jitgen) fn phys(self) -> GP {
-        self.0
+        match self {
+            VReg::Pinned(gp) => gp,
+            VReg::Alloc(_) => {
+                unreachable!("GP allocator (§9 9d) not yet wired; no Alloc VRegs are emitted")
+            }
+        }
     }
 }
 
 impl From<GP> for VReg {
     fn from(r: GP) -> Self {
-        VReg(r)
+        VReg::Pinned(r)
     }
 }
 
@@ -1120,8 +1138,8 @@ mod tests {
         assert!(matches!(
             lir.iter().next(),
             Some(LInst::Mov {
-                dst: VReg(GP::Rax),
-                src: VReg(GP::Rdi)
+                dst: VReg::Pinned(GP::Rax),
+                src: VReg::Pinned(GP::Rdi)
             })
         ));
     }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -59,15 +59,15 @@ use crate::bytecodegen::{BinOpK, UnOpK};
 /// The encoder folds an `Imm` into the instruction's immediate field when it
 /// fits, and materializes it into a scratch register otherwise — the same
 /// legalization story as `LMem` displacements.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::codegen::jitgen) enum LOperand {
-    Reg(GP),
+    Reg(VReg),
     Imm(i64),
 }
 
 impl From<GP> for LOperand {
     fn from(r: GP) -> Self {
-        LOperand::Reg(r)
+        LOperand::Reg(r.into())
     }
 }
 
@@ -85,15 +85,15 @@ impl From<i64> for LOperand {
 /// aarch64. There is deliberately no general-purpose name for these (aarch64's
 /// x9 is outside the `GP` enum's allocatable mapping), so they need their own
 /// operand kind.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::codegen::jitgen) enum LReg {
-    Gp(GP),
+    Gp(VReg),
     Scratch,
 }
 
 impl From<GP> for LReg {
     fn from(r: GP) -> Self {
-        LReg::Gp(r)
+        LReg::Gp(r.into())
     }
 }
 
@@ -342,15 +342,15 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- lhs <op> rhs`.
     Alu {
         op: LAluOp,
-        dst: GP,
-        lhs: GP,
+        dst: VReg,
+        lhs: VReg,
         rhs: LOperand,
     },
     /// Set condition flags from `lhs - rhs` (no result register written). The
     /// immediate of an `Imm` rhs is the operand's raw bit pattern (e.g. a tagged
     /// fixnum `Value`), compared against the raw register bits.
     Cmp {
-        lhs: GP,
+        lhs: VReg,
         rhs: LOperand,
     },
     /// Bind `label` at the current code position.
@@ -1041,8 +1041,8 @@ impl Lir {
     ) -> &mut Self {
         self.push(LInst::Alu {
             op,
-            dst,
-            lhs,
+            dst: dst.into(),
+            lhs: lhs.into(),
             rhs: rhs.into(),
         })
     }
@@ -1053,7 +1053,7 @@ impl Lir {
         rhs: impl Into<LOperand>,
     ) -> &mut Self {
         self.push(LInst::Cmp {
-            lhs,
+            lhs: lhs.into(),
             rhs: rhs.into(),
         })
     }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -97,6 +97,34 @@ impl From<GP> for LReg {
     }
 }
 
+/// A **virtual** general-purpose register (§9 9b).
+///
+/// LIR is meant to carry virtual registers, with physical assignment deferred to
+/// a later arch-dependent phase (§9 9d) — exactly as `FPReg` already is for the
+/// floating-point file. `VReg` is the GP analogue. **Today the map is the
+/// identity**: the front-end still picks a concrete physical `GP` (the fixed VM
+/// calling convention — `Rdi` = receiver, `Rax` = result, `R15` = accumulator,
+/// …), and `VReg` carries it through unchanged, resolving back to the same `GP`
+/// at the encode seam (`phys()`). This only establishes the *type* boundary so a
+/// future allocator can be slotted in between buffering and emission without
+/// touching every `encode_linst` arm again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::codegen::jitgen) struct VReg(GP);
+
+impl VReg {
+    /// Resolve to the physical register. Identity for now (§9 9b); the seam
+    /// where the future GP allocator (§9 9d) maps a virtual id to a physical reg.
+    pub(in crate::codegen::jitgen) fn phys(self) -> GP {
+        self.0
+    }
+}
+
+impl From<GP> for VReg {
+    fn from(r: GP) -> Self {
+        VReg(r)
+    }
+}
+
 /// `LirEncode` implementation legalizes them (immediate field vs.
 /// scratch-register materialization) when lowering.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -244,14 +272,15 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
 #[derive(Debug)]
 pub(in crate::codegen::jitgen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
+    /// (§9 9b) carries virtual GP registers; the encoder resolves them.
     Mov {
-        dst: GP,
-        src: GP,
+        dst: VReg,
+        src: VReg,
     },
     /// `dst <- imm` — materialize a full 64-bit immediate (e.g. a tagged
     /// `Value`'s bit pattern) into a register.
     LoadImm {
-        dst: GP,
+        dst: VReg,
         imm: u64,
     },
     /// `dst <- [mem]`. `dst` may be the scratch pointer (intermediate deref).
@@ -971,11 +1000,17 @@ impl Lir {
     }
 
     pub(in crate::codegen::jitgen) fn mov(&mut self, dst: GP, src: GP) -> &mut Self {
-        self.push(LInst::Mov { dst, src })
+        self.push(LInst::Mov {
+            dst: dst.into(),
+            src: src.into(),
+        })
     }
 
     pub(in crate::codegen::jitgen) fn load_imm(&mut self, dst: GP, imm: u64) -> &mut Self {
-        self.push(LInst::LoadImm { dst, imm })
+        self.push(LInst::LoadImm {
+            dst: dst.into(),
+            imm,
+        })
     }
 
     pub(in crate::codegen::jitgen) fn load(
@@ -1085,8 +1120,8 @@ mod tests {
         assert!(matches!(
             lir.iter().next(),
             Some(LInst::Mov {
-                dst: GP::Rax,
-                src: GP::Rdi
+                dst: VReg(GP::Rax),
+                src: VReg(GP::Rdi)
             })
         ));
     }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -326,7 +326,7 @@ impl AbstractFrame {
                 }
                 GpLoad::Stack(slot, dst)
             }
-            LinkMode::G(_) => GpLoad::Acc(dst),
+            LinkMode::G(_, _) => GpLoad::Acc(dst),
             LinkMode::MaybeNone => GpLoad::Stack(slot, dst),
             LinkMode::V | LinkMode::None => {
                 unreachable!("load() {:?} {:?}: {:?}", slot, self.mode(slot), self);
@@ -390,7 +390,7 @@ impl AbstractFrame {
         // snapshot. The guard-free `Sf`/`F`/`C` arms record no deopt, exactly as
         // before. The side-exit itself is materialized in the emit half.
         let deopt =
-            matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_)).then(|| self.deopt_point());
+            matches!(self.mode(slot), LinkMode::S(_) | LinkMode::G(_, _)).then(|| self.deopt_point());
         let (x, load) = self.load_fpr_fixnum_state(slot);
         ir.transfer(TransferIR::FprFixnumLoad { load, slot, deopt });
         x
@@ -414,7 +414,7 @@ impl AbstractFrame {
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
                 (x, FprFixnumLoad::FromStack(x, guard))
             }
-            LinkMode::G(_) => {
+            LinkMode::G(_, _) => {
                 // G -> Sf
                 let guard = self.guard_class_state(slot, INTEGER_CLASS);
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
@@ -476,7 +476,7 @@ impl AbstractFrame {
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
                 (x, FprLoad::FromStack(x))
             }
-            LinkMode::G(_) => {
+            LinkMode::G(_, _) => {
                 // -> Sf
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
                 (x, FprLoad::FromAcc(x))
@@ -528,7 +528,7 @@ impl AbstractFrame {
         ofs: i32,
     ) {
         match self.mode(slot) {
-            LinkMode::G(_) => {
+            LinkMode::G(_, _) => {
                 self.use_as_value(slot);
                 ir.reg2rsp_offset(GP::R15, ofs);
             }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -241,6 +241,85 @@ impl FprAllocator {
     }
 }
 
+/// §9 9d-B: GP-pool allocation state — the [`FprAllocator`] analogue for the
+/// allocatable GP pool ([`crate::codegen::GP_ALLOC_POOL`], x86-64 `r8`–`r11`).
+///
+/// `vgp[i]` lists the slots whose value currently resides at allocation id `i`:
+/// `i < POOL` → physical pool register `GP_ALLOC_POOL[i]`; `i >= POOL` → frame
+/// spill slot `i - POOL` (mirroring the FP `id < PHYS_FPR_POOL` ? xmm : spill
+/// split). A `VReg::Alloc(i)` is coloured by resolving `i` through this table.
+///
+/// B2.1 establishes the table; the placement policy (B2.2) and codegen (B2.3)
+/// populate and consume it. Inert until then — no `Alloc` VRegs are emitted.
+#[cfg(feature = "gp-alloc")]
+#[allow(dead_code)]
+#[derive(Clone, Default)]
+pub(super) struct GpAllocator {
+    vgp: Vec<Vec<SlotId>>,
+    /// pool registers that must not be reused by allocation until unpinned.
+    pinned: Vec<VReg>,
+}
+
+#[cfg(feature = "gp-alloc")]
+#[allow(dead_code)]
+impl GpAllocator {
+    fn new() -> Self {
+        Self {
+            vgp: (0..crate::codegen::GP_ALLOC_POOL.len())
+                .map(|_| vec![])
+                .collect(),
+            pinned: Vec::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.vgp.len()
+    }
+
+    fn slots(&self, id: usize) -> &[SlotId] {
+        &self.vgp[id]
+    }
+
+    fn is_vacant(&self, id: usize) -> bool {
+        self.vgp[id].is_empty()
+    }
+
+    fn is_pinned(&self, reg: VReg) -> bool {
+        self.pinned.contains(&reg)
+    }
+
+    fn add(&mut self, slot: SlotId, id: usize) {
+        self.vgp[id].push(slot);
+    }
+
+    fn remove(&mut self, slot: SlotId, id: usize) {
+        self.vgp[id].retain(|e| *e != slot);
+    }
+
+    fn clear(&mut self, id: usize) {
+        self.vgp[id].clear();
+    }
+
+    /// Append a fresh spill slot beyond the physical pool and return its id.
+    fn push_spill(&mut self) -> usize {
+        let new_id = self.vgp.len();
+        self.vgp.push(vec![]);
+        new_id
+    }
+
+    fn pin(&mut self, reg: VReg) {
+        if !self.pinned.contains(&reg) {
+            self.pinned.push(reg);
+        }
+    }
+
+    fn unpin(&mut self, reg: VReg) {
+        if let Some(pos) = self.pinned.iter().position(|x| *x == reg) {
+            self.pinned.swap_remove(pos);
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct SlotState {
     /// Per-slot location / representation (the `LinkMode` split into its two
@@ -253,6 +332,10 @@ pub(crate) struct SlotState {
     liveness: Vec<IsUsed>,
     /// fpr-register allocation state (item ②, step 1).
     fpr_alloc: FprAllocator,
+    /// §9 9d-B: GP-pool allocation state (the `fpr_alloc` analogue). Inert in
+    /// B2.1; populated by the allocator (B2.2+).
+    #[cfg(feature = "gp-alloc")]
+    gp_alloc: GpAllocator,
     r15: Option<SlotId>,
     local_num: usize,
     /// D1 forwarding-rest deferral (transient annotation; see the consumers).
@@ -293,6 +376,8 @@ impl SlotState {
             ty: vec![default_ty; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
             fpr_alloc: FprAllocator::new(),
+            #[cfg(feature = "gp-alloc")]
+            gp_alloc: GpAllocator::new(),
             r15: None,
             local_num,
             deferred_rest: None,

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::codegen::jitgen::lir::VReg;
 
 ///
 /// §5 stage 3c-i — the register-allocation **policy** seam.
@@ -412,7 +413,7 @@ impl SlotState {
                         self.set_Sf(slot, x, SfGuarded::Float);
                     }
                 }
-                LinkMode::G(_) | LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
+                LinkMode::G(_, _) | LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
                     unreachable!("use_float {:?}", self.mode(slot));
                 }
             };
@@ -602,7 +603,7 @@ impl SlotState {
                 assert!(self.fpr(fpr).contains(&slot));
                 self.fpr_remove(slot, fpr);
             }
-            LinkMode::G(_) => {
+            LinkMode::G(_, _) => {
                 assert_eq!(self.r15, Some(slot));
                 self.r15 = None;
             }
@@ -883,7 +884,7 @@ impl SlotState {
         if let Some(slot) = slot.into() {
             self.discard(slot);
             self.writeback_acc(ir);
-            self.set_mode(slot, LinkMode::G(guarded));
+            self.set_mode(slot, LinkMode::G(guarded, VReg::Pinned(GP::R15)));
             self.r15 = Some(slot);
         }
     }
@@ -918,7 +919,7 @@ impl SlotState {
                 Spill::Fpr(fpr, slot)
             }
             LinkMode::C(v) => Spill::Lit(v, slot),
-            LinkMode::G(guarded) => {
+            LinkMode::G(guarded, _) => {
                 // G -> S
                 assert_eq!(self.r15, Some(slot));
                 self.r15 = None;
@@ -952,7 +953,7 @@ impl SlotState {
         let spill = match self.mode(slot) {
             LinkMode::F(fpr) => Spill::Fpr(fpr, slot),
             LinkMode::C(v) => Spill::Lit(v, slot),
-            LinkMode::G(_) => Spill::Acc(slot),
+            LinkMode::G(_, _) => Spill::Acc(slot),
             LinkMode::Sf(_, _) | LinkMode::S(_) => Spill::None,
             LinkMode::V => Spill::Lit(Value::nil(), slot),
             LinkMode::MaybeNone | LinkMode::None => {
@@ -1187,7 +1188,7 @@ impl SlotState {
         if let Some(slot) = self.writeback_acc_state() {
             ir.acc2stack(slot);
         }
-        assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_))));
+        assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_, _))));
         assert!(self.r15.is_none());
     }
 
@@ -1235,7 +1236,7 @@ impl SlotState {
             LinkMode::C(v) => {
                 self.def_C(dst, v);
             }
-            LinkMode::G(guarded) => {
+            LinkMode::G(guarded, _) => {
                 ir.reg2stack(GP::R15, src);
                 self.set_S_with_guard(src, guarded);
                 self.def_G(ir, dst, guarded)
@@ -1288,7 +1289,7 @@ impl AbstractFrame {
         // write-back and the guard emission, exactly as the prior `return`s did.
         let mut mode = self.mode(slot);
         match &mut mode {
-            LinkMode::S(guarded) | LinkMode::G(guarded) => {
+            LinkMode::S(guarded) | LinkMode::G(guarded, _) => {
                 if class_guarded == *guarded {
                     return false;
                 } else if *guarded == Guarded::Value {
@@ -1409,7 +1410,7 @@ impl AbstractFrame {
                 }
                 LinkMode::S(_)
                 | LinkMode::C(_)
-                | LinkMode::G(_)
+                | LinkMode::G(_, _)
                 | LinkMode::V
                 | LinkMode::MaybeNone
                 | LinkMode::None => {}
@@ -1584,9 +1585,12 @@ pub(in crate::codegen::jitgen) enum LinkMode {
     ///
     S(Guarded),
     ///
-    /// On the general-purpose register (r15).
+    /// On a general-purpose register (`VReg`). §9 9d: the register is explicit
+    /// (mirroring `F(FPReg)`). Today it is always the pinned accumulator
+    /// `VReg::Pinned(GP::R15)`; the allocator will later place a slot in an
+    /// `Alloc` VReg coloured into the `r8`–`r11` pool.
     ///
-    G(Guarded),
+    G(Guarded, VReg),
     ///
     /// On the floating point register (fpr).
     ///
@@ -1626,7 +1630,7 @@ impl LinkMode {
 
     fn guarded(&self) -> Guarded {
         match self {
-            LinkMode::S(guarded) | LinkMode::G(guarded) => *guarded,
+            LinkMode::S(guarded) | LinkMode::G(guarded, _) => *guarded,
             LinkMode::Sf(_, guarded) => (*guarded).into(),
             LinkMode::F(_) => Guarded::Float,
             LinkMode::C(v) => Guarded::from_concrete_value(*v),
@@ -1645,7 +1649,7 @@ impl LinkMode {
             LinkMode::MaybeNone => Placement::MaybeNone,
             LinkMode::V => Placement::Void,
             LinkMode::S(_) => Placement::Stack,
-            LinkMode::G(_) => Placement::Gp,
+            LinkMode::G(_, _) => Placement::Gp,
             LinkMode::F(x) => Placement::Xmm(*x),
             LinkMode::Sf(x, _) => Placement::FprStack(*x),
             LinkMode::C(v) => Placement::Const(*v),
@@ -1665,7 +1669,7 @@ impl LinkMode {
             Placement::MaybeNone => LinkMode::MaybeNone,
             Placement::Void => LinkMode::V,
             Placement::Stack => LinkMode::S(guarded),
-            Placement::Gp => LinkMode::G(guarded),
+            Placement::Gp => LinkMode::G(guarded, VReg::Pinned(GP::R15)),
             Placement::Xmm(x) => LinkMode::F(x),
             Placement::FprStack(x) => {
                 let sf = match guarded {
@@ -1879,7 +1883,7 @@ impl AbstractFrame {
                     self.to_sf(ir, slot, l, r, guarded);
                 }
             }
-            (LinkMode::F(_) | LinkMode::G(_), LinkMode::S(_)) => {
+            (LinkMode::F(_) | LinkMode::G(_, _), LinkMode::S(_)) => {
                 self.write_back_slot(ir, slot);
             }
             (LinkMode::Sf(l, _), LinkMode::Sf(r, guarded)) => {
@@ -1933,7 +1937,7 @@ impl AbstractFrame {
                     self.set_F(slot, r);
                 }
             }
-            (LinkMode::G(_), LinkMode::Sf(x, SfGuarded::Float)) => {
+            (LinkMode::G(_, _), LinkMode::Sf(x, SfGuarded::Float)) => {
                 // G -> Sf
                 let deopt = ir.new_deopt_with_pc(&self, pc + 1);
                 if self.is_fpr_vacant(x) {
@@ -2211,7 +2215,7 @@ mod tests {
             LinkMode::S(Guarded::Fixnum),
             LinkMode::S(Guarded::Float),
             LinkMode::S(Guarded::Class(NIL_CLASS)),
-            LinkMode::G(Guarded::Fixnum),
+            LinkMode::G(Guarded::Fixnum, VReg::Pinned(GP::R15)),
             LinkMode::F(x),
             LinkMode::Sf(x, SfGuarded::Float),
             LinkMode::Sf(x, SfGuarded::Fixnum),


### PR DESCRIPTION
## Summary

The structural groundwork for the §9 9d **GP register allocator** — all byte-identical, behaviour-preserving. The allocator's pool is the otherwise-unused caller-saved scratch set (x86-64 `r8`–`r11`); this PR lays the model, the operand seam, and the placement-table scaffolding so the behaviour-changing allocation logic (B2.2+) can be built on top without re-touching the emission sites.

### `VReg` operand seam (9b)
- Introduce `VReg`, the GP analogue of the virtual `FPReg`. LIR carries virtual registers; physical assignment is deferred to the encode seam (`VReg::phys()`).
- Migrate the **allocatable core-integer families** onto `VReg`: `Mov`/`LoadImm`, the memory family (`Load`/`Store`/`Field` via `LReg::Gp(VReg)`), and ALU/compare (`Alu`/`Cmp` via `LOperand::Reg(VReg)`). The ABI-pinned macro-op/runtime-call registers stay `GP` (pre-colored).

### Allocator model + pool (9d-A)
- `VReg` becomes an enum: `Pinned(GP)` (a pre-colored physical reg the front-end chose) or `Alloc(u32)` (an allocatable virtual id the 9d allocator colours into the pool/spill). `From<GP>` yields `Pinned`, so the front-end still emits only `Pinned` and `phys()` stays total/identity — byte-identical.
- `GP_ALLOC_POOL = [R8, R9, R10, R11]` (codegen.rs): the x86-64 allocatable pool. Documented in `doc/lir.md` §9 along with the caller-saved spill-across-C-call requirement.

### `LinkMode::G` register seam (9d-B1)
- `LinkMode::G(Guarded)` → `G(Guarded, VReg)`, mirroring `F(FPReg)`: the GP-resident register is now explicit (always `Pinned(R15)` today — the single accumulator). This lets the abstract interpreter later track a slot resident in a pool register rather than only r15. Byte-identical (`self.r15` still tracks the one accumulator).

### `GpAllocator` table (9d-B2.1)
- The `fpr_alloc` analogue (`vgp[i]` = slots resident at allocation id `i`: pool register or spill slot; pin/unpin), wired into `SlotState` behind the **default-off `gp-alloc` feature**. Inert (no placement policy yet), so the default build is provably unchanged — every addition is `cfg(gp-alloc)`-gated.

## Not in this PR (the behaviour-changing allocator core, next focused effort)
B2.2 placement policy · B2.3 codegen (slot→pool load/spill, `Alloc` resolution) · 9d-C spill of pool regs across C-ABI calls · 9d-D flag + M1 A/B bench gate.

## Verification
- x86_64: `cargo build` clean; **1716 lib unit tests pass** at each step.
- aarch64: `cargo check --target aarch64-unknown-linux-gnu` compiles (default + `--features gp-alloc`).
- The whole series is byte-identical: the `VReg`/`G`-register changes are identity maps, and the `gp-alloc` additions are cfg-gated and inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_