### PR TITLE
jit(§9 9d-B2): make the G-mode (GP-resident-slot) machinery register-aware

### DIFF
--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -123,16 +123,15 @@ pub(in crate::codegen::jitgen) enum VReg {
 }
 
 impl VReg {
-    /// Resolve to the physical register at the encode seam. Identity on `Pinned`
-    /// (§9 9b). `Alloc` is unreachable until the 9d allocator is wired (no `Alloc`
-    /// VRegs are emitted yet), at which point this becomes a map-consulting
-    /// resolve that may also yield a spill slot.
+    /// Resolve to the physical register at the encode seam. `Pinned` is the
+    /// front-end's choice (identity); `Alloc(id)` resolves to its pool register
+    /// `GP_ALLOC_POOL[id]`. Unlike the FP file, GP has no separate spill file — a
+    /// slot "spills" to its own LFP home — so every `Alloc` id is in `0..POOL`
+    /// (the allocator guarantees the bound), and this stays total.
     pub(in crate::codegen::jitgen) fn phys(self) -> GP {
         match self {
             VReg::Pinned(gp) => gp,
-            VReg::Alloc(_) => {
-                unreachable!("GP allocator (§9 9d) not yet wired; no Alloc VRegs are emitted")
-            }
+            VReg::Alloc(id) => crate::codegen::GP_ALLOC_POOL[id as usize],
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -98,8 +98,10 @@ pub(in crate::codegen::jitgen) enum GpLoad {
     Lit(Value, GP),
     /// `stack2reg(slot, dst)`
     Stack(SlotId, GP),
-    /// `reg_move(r15, dst)`
-    Acc(GP),
+    /// `G` slot resident in a GP register: `reg_move(src, dst)`. `src` is the
+    /// slot's register (`r15` for the accumulator, a pool register `r8`–`r11`
+    /// once 9d places it).
+    Reg(GP, GP),
 }
 
 impl GpLoad {
@@ -111,7 +113,7 @@ impl GpLoad {
             }
             GpLoad::Lit(v, dst) => ir.lit2reg(v, dst),
             GpLoad::Stack(slot, dst) => ir.stack2reg(slot, dst),
-            GpLoad::Acc(dst) => ir.reg_move(GP::R15, dst),
+            GpLoad::Reg(src, dst) => ir.reg_move(src, dst),
         }
     }
 }
@@ -326,7 +328,7 @@ impl AbstractFrame {
                 }
                 GpLoad::Stack(slot, dst)
             }
-            LinkMode::G(_, _) => GpLoad::Acc(dst),
+            LinkMode::G(_, vreg) => GpLoad::Reg(vreg.phys(), dst),
             LinkMode::MaybeNone => GpLoad::Stack(slot, dst),
             LinkMode::V | LinkMode::None => {
                 unreachable!("load() {:?} {:?}: {:?}", slot, self.mode(slot), self);

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -50,8 +50,9 @@ pub(in crate::codegen::jitgen) enum FprLoad {
     None,
     /// `stack2reg(slot, Rdi); float_to_fpr(Rdi, x, deopt)`
     FromStack(FPReg),
-    /// `reg2stack(R15, slot); float_to_fpr(R15, x, deopt)`
-    FromAcc(FPReg),
+    /// `G` slot in a GP register: `reg2stack(src, slot); float_to_fpr(src, x,
+    /// deopt)`. `src` is `r15` for the accumulator or a pool register once placed.
+    FromReg(GP, FPReg),
     /// `f64_to_fpr(f, x)` (guard-free)
     FromF64(f64, FPReg),
     /// `i64_to_stack_and_fpr(i, slot, x)` (guard-free)
@@ -72,10 +73,10 @@ impl FprLoad {
                 ir.stack2reg(slot, GP::Rdi);
                 ir.float_to_fpr(GP::Rdi, x, deopt);
             }
-            FprLoad::FromAcc(x) => {
+            FprLoad::FromReg(src, x) => {
                 let deopt = ir.deopt_from_point(deopt.unwrap());
-                ir.reg2stack(GP::R15, slot);
-                ir.float_to_fpr(GP::R15, x, deopt);
+                ir.reg2stack(src, slot);
+                ir.float_to_fpr(src, x, deopt);
             }
             FprLoad::FromF64(f, x) => ir.f64_to_fpr(f, x),
             FprLoad::FromFixnum(i, x) => ir.i64_to_stack_and_fpr(i, slot, x),
@@ -139,8 +140,9 @@ pub(in crate::codegen::jitgen) enum FprFixnumLoad {
     None,
     /// `stack2reg(slot, Rdi); [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`
     FromStack(FPReg, bool),
-    /// `reg2stack(R15, slot); [GuardClass(R15)]; fixnum2fpr(R15, x)`
-    FromAcc(FPReg, bool),
+    /// `G` slot in a GP register: `reg2stack(src, slot); [GuardClass(src)];
+    /// fixnum2fpr(src, x)`. `src` is `r15` or a pool register once placed.
+    FromReg(GP, FPReg, bool),
     /// guard-free numeric literal (`LinkMode::C`) — reuses the [`FprLoad`] record
     Numeric(FprLoad),
 }
@@ -162,13 +164,13 @@ impl FprFixnumLoad {
                 }
                 ir.fixnum2fpr(GP::Rdi, x);
             }
-            FprFixnumLoad::FromAcc(x, guard) => {
+            FprFixnumLoad::FromReg(src, x, guard) => {
                 let deopt = deopt.map(|p| ir.deopt_from_point(p));
-                ir.reg2stack(GP::R15, slot);
+                ir.reg2stack(src, slot);
                 if guard {
-                    ir.push(AsmInst::GuardClass(GP::R15, INTEGER_CLASS, deopt.unwrap()));
+                    ir.push(AsmInst::GuardClass(src, INTEGER_CLASS, deopt.unwrap()));
                 }
-                ir.fixnum2fpr(GP::R15, x);
+                ir.fixnum2fpr(src, x);
             }
             FprFixnumLoad::Numeric(load) => load.emit(ir, slot, None),
         }
@@ -416,11 +418,12 @@ impl AbstractFrame {
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
                 (x, FprFixnumLoad::FromStack(x, guard))
             }
-            LinkMode::G(_, _) => {
+            LinkMode::G(_, vreg) => {
                 // G -> Sf
+                let src = vreg.phys();
                 let guard = self.guard_class_state(slot, INTEGER_CLASS);
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                (x, FprFixnumLoad::FromAcc(x, guard))
+                (x, FprFixnumLoad::FromReg(src, x, guard))
             }
             LinkMode::C(v) => {
                 let (x, load) = self.load_fpr_from_C_state(slot, v);
@@ -478,10 +481,11 @@ impl AbstractFrame {
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
                 (x, FprLoad::FromStack(x))
             }
-            LinkMode::G(_, _) => {
+            LinkMode::G(_, vreg) => {
                 // -> Sf
+                let src = vreg.phys();
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
-                (x, FprLoad::FromAcc(x))
+                (x, FprLoad::FromReg(src, x))
             }
             LinkMode::C(v) => self.load_fpr_from_C_state(slot, v),
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1004,12 +1004,12 @@ impl SlotState {
                 Spill::Fpr(fpr, slot)
             }
             LinkMode::C(v) => Spill::Lit(v, slot),
-            LinkMode::G(guarded, _) => {
+            LinkMode::G(guarded, vreg) => {
                 // G -> S
                 assert_eq!(self.r15, Some(slot));
                 self.r15 = None;
                 self.set_mode(slot, LinkMode::S(guarded));
-                Spill::Acc(slot)
+                Spill::Reg(vreg.phys(), slot)
             }
             LinkMode::Sf(_, _) | LinkMode::S(_) | LinkMode::MaybeNone => Spill::None,
             LinkMode::V | LinkMode::None => {
@@ -1038,7 +1038,7 @@ impl SlotState {
         let spill = match self.mode(slot) {
             LinkMode::F(fpr) => Spill::Fpr(fpr, slot),
             LinkMode::C(v) => Spill::Lit(v, slot),
-            LinkMode::G(_, _) => Spill::Acc(slot),
+            LinkMode::G(_, vreg) => Spill::Reg(vreg.phys(), slot),
             LinkMode::Sf(_, _) | LinkMode::S(_) => Spill::None,
             LinkMode::V => Spill::Lit(Value::nil(), slot),
             LinkMode::MaybeNone | LinkMode::None => {
@@ -1604,8 +1604,11 @@ pub(in crate::codegen::jitgen) enum Spill {
     Fpr(FPReg, SlotId),
     /// `ir.lit2stack(value, slot)`
     Lit(Value, SlotId),
-    /// `ir.acc2stack(slot)`
-    Acc(SlotId),
+    /// Write back a `G`-slot's register to its stack home: `ir.reg2stack(reg,
+    /// slot)`. `reg` is the slot's register (`r15` for the accumulator — then
+    /// byte-identical to the old `acc2stack` — or a pool register once 9d places
+    /// it).
+    Reg(GP, SlotId),
 }
 
 impl Spill {
@@ -1614,7 +1617,7 @@ impl Spill {
             Spill::None => {}
             Spill::Fpr(fpr, slot) => ir.fpr2stack(fpr, slot),
             Spill::Lit(v, slot) => ir.lit2stack(v, slot),
-            Spill::Acc(slot) => ir.acc2stack(slot),
+            Spill::Reg(reg, slot) => ir.reg2stack(reg, slot),
         }
     }
 }


### PR DESCRIPTION
## Summary

Continues the §9 9d GP register allocator (after the #748 groundwork): make the `LinkMode::G` (GP-resident-slot) machinery **fully register-aware** so a slot placed in a pool register reads/spills/converts through that register instead of the hardcoded accumulator `r15`. **Byte-identical** — every `G` is still `Pinned(R15)` today, so the emitted code is unchanged; this only routes the register through the slot's `VReg`.

### `VReg::Alloc` resolution
`VReg::phys()` now resolves `Alloc(id)` to `GP_ALLOC_POOL[id]` (GP has no separate spill file — a slot spills to its own LFP home — so every `Alloc` id is a pool register; the allocator guarantees the bound). Removes the placeholder `unreachable!`.

### G-mode I/O is no longer r15-hardcoded
All four G-mode consumers now carry the source register, read from the slot's `LinkMode::G(_, vreg)`:
- integer read: `GpLoad::Acc(dst)` → `GpLoad::Reg(src, dst)`
- spill: `Spill::Acc(slot)` → `Spill::Reg(reg, slot)` (`reg2stack(R15, slot)` ≡ the old `acc2stack`)
- `G → Sf` float/fixnum conversions: `FprLoad::FromAcc` / `FprFixnumLoad::FromAcc` → `FromReg(src, ..)`

With this, the G-mode machinery is fully pool-ready; the next phase is the placement policy (the first behaviour-changing step) + flush / C-ABI call-save / branch-merge, all behind the default-off `gp-alloc` feature.

## Verification
- x86_64: `cargo build` clean; **1716 lib unit tests pass**.
- aarch64: `cargo check --target aarch64-unknown-linux-gnu` compiles.
- Byte-identical: `Pinned(R15)` resolves to `R15`, so `reg_move(R15,…)` / `reg2stack(R15,…)` / `float_to_fpr(R15,…)` reproduce the old accumulator emission exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_