### PR TITLE
jit(§9 9d-B): GP-pool write-back + flush support (placement groundwork)

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -478,21 +478,32 @@ registers, and keeping the frame consistent) is built as a sequence of
 feature-gated (`gp-alloc`) increments, each byte-identical while no slot is yet
 placed in the pool:
 
-1. **Write-back pool-support** *(done)*. `WriteBack` carries a `gp:
-   Vec<(GP, SlotId)>` list — the pool-resident slots and their physical
-   registers — alongside the single `r15` accumulator. Every flush / deopt / GC
-   safepoint write-back (`gen_write_back`, `gen_write_back_for_deopt`,
-   `a64_gen_write_back_for_deopt`) stores each pool register to its slot's frame
-   home, exactly as it already does for `r15`. The producer (`wb_gp`) scans for
-   slots in mode `G(_, VReg::Alloc(_))`; until the placement policy creates such
-   a slot the list is always empty, so the field, its `Hash`/`Debug`, and the
-   write-back loops are inert and the emitted bytes are unchanged. This is the
-   prerequisite that makes a pool-resident value survive a flush/deopt before
-   the placement *trigger* exists.
+1. **Write-back + flush pool-support** *(done)*. Two seams, both inert until a
+   slot is placed:
+   - *Side-exit / deopt / GC write-back.* `WriteBack` carries a `gp:
+     Vec<(GP, SlotId)>` list — the pool-resident slots and their physical
+     registers — alongside the single `r15` accumulator. Every such write-back
+     (`gen_write_back`, `gen_write_back_for_deopt`,
+     `a64_gen_write_back_for_deopt`) stores each pool register to its slot's
+     frame home, exactly as for `r15`. The producer (`wb_gp`) scans for slots in
+     mode `G(_, VReg::Alloc(_))`.
+   - *In-function flush-at-boundary.* `writeback_acc` — already called before
+     every call / store / definition, and already asserting no `G(_, _)` slot
+     survives it — now also flushes the pool residents (`writeback_pool_state`):
+     each `G(_, Alloc)` slot is stored to its home and dropped to `S`. Because
+     this runs before every C-ABI call, **a pool value never stays resident
+     across a call**, so the GP allocator needs *no* caller-saved spill/reload
+     threading (`using_gp`) the way the FP side does — the flush already did it.
+
+   Until the placement policy creates a `G(_, Alloc(_))` slot both lists are
+   empty, so the fields, their `Hash`/`Debug`, and the write-back/flush loops
+   are inert and the emitted bytes are unchanged.
 2. **Placement policy** *(next)*: choose which slots enter the pool (victim
-   selection under pressure) and populate `gp_alloc` / emit `G(_, Alloc(id))`.
-3. **C-ABI call-save**: spill live pool registers across runtime calls (the GP
-   analogue of `fpr_save` / `fpr_restore`).
-4. **Branch-merge reconciliation**: agree pool residency across control-flow
-   joins.
-5. **M1 A/B bench gate** before the feature becomes default.
+   selection under pressure) and populate `gp_alloc` / emit `G(_, Alloc(id))`,
+   within a call-free straight-line stretch (the flush at §1 bounds it).
+3. **Branch-merge reconciliation**: agree pool residency across control-flow
+   joins (or simply flush at every block boundary in the first cut).
+4. **M1 A/B bench gate** before the feature becomes default.
+
+Note C-ABI call-save is *not* a separate step: the flush-at-boundary (§1) makes
+it unnecessary — pool slots are always written back before a call.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -470,3 +470,29 @@ re-loading them from the LFP each use.
 
 9a/9b are byte-identical refactors (safe to land once verified); 9c/9d are the
 substantive allocator work and stay behind a flag until the bench gate clears.
+
+### 9d placement build order
+
+The placement phase (filling `gp_alloc`, colouring `VReg::Alloc` into pool
+registers, and keeping the frame consistent) is built as a sequence of
+feature-gated (`gp-alloc`) increments, each byte-identical while no slot is yet
+placed in the pool:
+
+1. **Write-back pool-support** *(done)*. `WriteBack` carries a `gp:
+   Vec<(GP, SlotId)>` list — the pool-resident slots and their physical
+   registers — alongside the single `r15` accumulator. Every flush / deopt / GC
+   safepoint write-back (`gen_write_back`, `gen_write_back_for_deopt`,
+   `a64_gen_write_back_for_deopt`) stores each pool register to its slot's frame
+   home, exactly as it already does for `r15`. The producer (`wb_gp`) scans for
+   slots in mode `G(_, VReg::Alloc(_))`; until the placement policy creates such
+   a slot the list is always empty, so the field, its `Hash`/`Debug`, and the
+   write-back loops are inert and the emitted bytes are unchanged. This is the
+   prerequisite that makes a pool-resident value survive a flush/deopt before
+   the placement *trigger* exists.
+2. **Placement policy** *(next)*: choose which slots enter the pool (victim
+   selection under pressure) and populate `gp_alloc` / emit `G(_, Alloc(id))`.
+3. **C-ABI call-save**: spill live pool registers across runtime calls (the GP
+   analogue of `fpr_save` / `fpr_restore`).
+4. **Branch-merge reconciliation**: agree pool residency across control-flow
+   joins.
+5. **M1 A/B bench gate** before the feature becomes default.

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -118,7 +118,7 @@ pub(in crate::codegen) const GP_ALLOC_POOL: [GP; 4] = [GP::R8, GP::R9, GP::R10, 
 /// General purpose registers.
 ///
 #[allow(dead_code)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum GP {
     Rax = 0,
     Rcx = 1,

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -355,6 +355,10 @@ impl Codegen {
             let acc = GP::R15.a64().0; // x23
             self.a64_frame_store(acc, lfp, off);
         }
+        for (reg, slot) in &wb.gp {
+            let off = slot.0 as u32 * 8 + LFP_SELF as u32;
+            self.a64_frame_store(reg.a64().0, lfp, off);
+        }
     }
 
     /// Inline fixnum binary op. Fixnums are tagged `2n+1`; signed 64-bit

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -140,6 +140,13 @@ pub(crate) struct WriteBack {
     literal: Vec<(Value, SlotId)>,
     void: Vec<SlotId>,
     r15: Option<SlotId>,
+    /// §9 9d-B: slots resident in the allocatable GP pool (x86-64 `r8`–`r11`),
+    /// each paired with the physical register holding it. Written back to the
+    /// slot's frame home at every flush / deopt / GC safepoint, exactly like
+    /// `r15` (the dedicated accumulator) but for the pool registers. Empty until
+    /// the GP allocator (the `gp-alloc` feature) places a slot, so shipping
+    /// builds carry an always-empty vec and emit byte-identical code.
+    gp: Vec<(GP, SlotId)>,
     /// Deferred forwarding-rest materialization (D1). Each entry
     /// `(dst, src, len)`: the rest-parameter slot `dst` of a
     /// forwarding-trampoline frame was *not* materialized as an `Array`
@@ -169,6 +176,10 @@ impl Hash for WriteBack {
         if let Some(slot) = self.r15 {
             slot.hash(state);
         }
+        for (reg, slot) in &self.gp {
+            reg.hash(state);
+            slot.hash(state);
+        }
         for (dst, src, len) in &self.forward_rest {
             dst.hash(state);
             src.hash(state);
@@ -195,6 +206,9 @@ impl std::fmt::Debug for WriteBack {
         if let Some(slot) = self.r15 {
             s.push_str(&format!(" R15->{:?}", slot));
         }
+        for (reg, slot) in &self.gp {
+            s.push_str(&format!(" {:?}->{:?}", reg, slot));
+        }
         for (dst, src, len) in &self.forward_rest {
             s.push_str(&format!(" fwdrest[{:?};{}]->{:?}", src, len, dst));
         }
@@ -208,6 +222,7 @@ impl WriteBack {
         literal: Vec<(Value, SlotId)>,
         r15: Option<SlotId>,
         void: Vec<SlotId>,
+        gp: Vec<(GP, SlotId)>,
         forward_rest: Vec<(SlotId, SlotId, u16)>,
     ) -> Self {
         Self {
@@ -215,6 +230,7 @@ impl WriteBack {
             literal,
             r15,
             void,
+            gp,
             forward_rest,
         }
     }
@@ -864,8 +880,13 @@ impl JitModule {
             self.literal_to_stack(*slot, Value::nil());
         }
         if let Some(slot) = wb.r15 {
-            monoasm! { self,
+            monoasm! { &mut *self,
                 movq [rbp - (rbp_local(slot))], r15;
+            }
+        }
+        for (reg, slot) in &wb.gp {
+            monoasm! { &mut *self,
+                movq [rbp - (rbp_local(*slot))], R(*reg as _);
             }
         }
     }
@@ -894,6 +915,11 @@ impl JitModule {
         if let Some(slot) = wb.r15 {
             monoasm! { &mut *self,
                 movq [r14 - (conv(slot))], r15;
+            }
+        }
+        for (reg, slot) in &wb.gp {
+            monoasm! { &mut *self,
+                movq [r14 - (conv(*slot))], R(*reg as _);
             }
         }
         // D1: materialize deferred forwarding-rest arrays. Runs last so

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1269,9 +1269,42 @@ impl SlotState {
         Some(slot)
     }
 
+    /// §9 9d-B flush-at-boundary: evict every allocatable-pool resident
+    /// (`G(_, VReg::Alloc(_))`) to its stack home in the *abstract state*,
+    /// returning the `(reg, slot)` pairs so the emission half can store them.
+    /// The dedicated accumulator (`Pinned(R15)`) is handled by
+    /// [`Self::writeback_acc_state`]; this is its pool analogue.
+    ///
+    /// This runs at every call / store / definition boundary (every
+    /// `writeback_acc` site), so a pool value never stays resident across a
+    /// C-ABI call — which is exactly why the GP allocator needs no
+    /// caller-saved spill/reload threading (`using_gp`) the way the FP side
+    /// does: the flush already wrote it back. Empty until the placement policy
+    /// puts a slot in the pool.
+    #[cfg(feature = "gp-alloc")]
+    fn writeback_pool_state(&mut self) -> Vec<(GP, SlotId)> {
+        let mut out = vec![];
+        for slot in self.all_regs() {
+            if let LinkMode::G(_, vreg @ VReg::Alloc(_)) = self.mode(slot) {
+                let guarded = self.guarded(slot);
+                let reg = vreg.phys();
+                self.set_mode(slot, LinkMode::S(guarded));
+                out.push((reg, slot));
+            }
+        }
+        if !out.is_empty() {
+            self.gp_alloc = GpAllocator::new();
+        }
+        out
+    }
+
     pub(crate) fn writeback_acc(&mut self, ir: &mut AsmIr) {
         if let Some(slot) = self.writeback_acc_state() {
             ir.acc2stack(slot);
+        }
+        #[cfg(feature = "gp-alloc")]
+        for (reg, slot) in self.writeback_pool_state() {
+            ir.reg2stack(reg, slot);
         }
         assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_, _))));
         assert!(self.r15.is_none());

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1459,7 +1459,11 @@ impl AbstractFrame {
         // capturable, so no heap snapshot observes it pre-consume.
         let literal = self.wb_literal(|_| true);
         let void = self.wb_void();
-        WriteBack::new(vec![], literal, self.r15, void, vec![])
+        #[cfg(feature = "gp-alloc")]
+        let gp = self.wb_gp(|_| true);
+        #[cfg(not(feature = "gp-alloc"))]
+        let gp = vec![];
+        WriteBack::new(vec![], literal, self.r15, void, gp, vec![])
     }
 
     pub(crate) fn get_write_back(&self) -> WriteBack {
@@ -1470,7 +1474,11 @@ impl AbstractFrame {
             Some(slot) if f(slot) => Some(slot),
             _ => None,
         };
-        WriteBack::new(fpr, literal, r15, vec![], self.wb_forward_rest())
+        #[cfg(feature = "gp-alloc")]
+        let gp = self.wb_gp(f);
+        #[cfg(not(feature = "gp-alloc"))]
+        let gp = vec![];
+        WriteBack::new(fpr, literal, r15, vec![], gp, self.wb_forward_rest())
     }
 
     fn fpr_swap(&mut self, l: FPReg, r: FPReg) {
@@ -1533,6 +1541,21 @@ impl AbstractFrame {
         self.all_regs()
             .filter_map(|idx| match self.mode(idx) {
                 LinkMode::V => Some(idx),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// §9 9d-B: collect the slots resident in the allocatable GP pool
+    /// (`VReg::Alloc`), each paired with its physical pool register. The
+    /// dedicated accumulator (`VReg::Pinned(R15)`) is *not* included — it is
+    /// written back separately via `self.r15`. Empty until the allocator places
+    /// a slot in the pool.
+    #[cfg(feature = "gp-alloc")]
+    fn wb_gp(&self, f: impl Fn(SlotId) -> bool) -> Vec<(GP, SlotId)> {
+        self.all_regs()
+            .filter_map(|idx| match self.mode(idx) {
+                LinkMode::G(_, vreg @ VReg::Alloc(_)) if f(idx) => Some((vreg.phys(), idx)),
                 _ => None,
             })
             .collect()


### PR DESCRIPTION
## Summary

First two increments of the **GP register-allocator placement phase** (§9 9d-B). Both are the prerequisite groundwork that lets a pool-resident value (x86-64 `r8`–`r11`) stay consistent with the frame — *before* the placement trigger exists. Inert (byte-identical) until a later increment actually places a slot.

### 1. Side-exit / deopt / GC write-back (commit 1)

`WriteBack` gains a `gp: Vec<(GP, SlotId)>` list alongside its single `r15` accumulator — pool-resident slots paired with the physical register holding each. Every such write-back stores each pool register to its slot's frame home, exactly as for `r15`:

- `gen_write_back` (x86, rbp-relative)
- `gen_write_back_for_deopt` (x86, r14-relative)
- `a64_gen_write_back_for_deopt` (aarch64, lfp/x22-relative)

Producer `wb_gp` (gated on `gp-alloc`) collects slots in mode `G(_, VReg::Alloc(_))`. `GP` gains `Hash` (fieldless enum) for the `WriteBack` hash.

### 2. In-function flush-at-boundary (commit 2)

`writeback_acc` — already called before every call / store / definition, and already asserting no `G(_, _)` slot survives it — now also flushes the pool residents (`writeback_pool_state`): each `G(_, Alloc)` slot is stored to its home and dropped to `S`.

Because this runs before every C-ABI call, **a pool value never stays resident across a call** → the GP allocator needs *no* caller-saved spill/reload threading (`using_gp`) the way the FP side does. This removes "C-ABI call-save" from the placement build order.

## Why byte-identical

No slot is placed in the pool yet (placement policy is a later increment), so `wb_gp` / `writeback_pool_state` always return empty → the write-back & flush loops emit nothing → emitted machine code is unchanged.

## Verification

- ✅ default build · ✅ `--features gp-alloc` build · ✅ aarch64 build
- ✅ 1716 lib tests pass

## Note on codecov/patch

The advisory `codecov/patch` check is red because the new `wb.gp` / `writeback_pool_state` loops are **inert by design** — unreachable until a later increment places a slot in the pool, so they cannot be covered now. The real correctness gates (amd64 + darwin test suites) are green. Same advisory pattern as #745–#749.

## Placement build order (doc/lir.md §9)

1. **Write-back + flush pool-support** — *this PR*
2. Placement policy (victim selection, populate `gp_alloc`, emit `G(_, Alloc(id))`)
3. Branch-merge reconciliation
4. M1 A/B bench gate before default

🤖 Generated with [Claude Code](https://claude.com/claude-code)