### PR TITLE
jit(§9 9d-B): reserve the x86-64 GP pool (r8-r11) for the allocator

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -498,12 +498,41 @@ placed in the pool:
    Until the placement policy creates a `G(_, Alloc(_))` slot both lists are
    empty, so the fields, their `Hash`/`Debug`, and the write-back/flush loops
    are inert and the emitted bytes are unchanged.
-2. **Placement policy** *(next)*: choose which slots enter the pool (victim
+2. **Reserve the pool registers (x86-64)** *(done)*. The pool design above
+   assumed `r8`–`r11` were "otherwise-unused caller-saved scratch", but an audit
+   of the JIT-body lowerings found that is *not* true: `r8`–`r11` are the JIT's
+   **secondary scratch pool**, used freely once the primary scratch
+   (`rax/rcx/rdx/rsi/rdi`) runs out. To hold a value in a pool register *across*
+   instructions, no intervening lowering may clobber it — so the pool registers
+   must be reserved, exactly as the FP side reserves its xmm pool and confines
+   scratch to `xmm0/xmm1`.
+
+   The audit (in-scope: every `compile.rs` / `compile/*` / `guard.rs` lowering
+   that can run while a pool value is live; out of scope: `vmgen` = the VM
+   interpreter, `invoker`/`wrapper` = reached via a call boundary) found:
+   - `r10`, `r11`: unused in JIT-body code.
+   - `r9`: only `class_def`, a **post-flush** call-staging use (safe).
+   - `r8`: every use is **post-flush call-staging** (a method-send/define/store
+     sequence runs `writeback_acc` *first*, emptying the pool — so `r8` is free
+     there, the GP analogue of using the pool after `fpr_save`) **except one**:
+     `emit_string_setbyte`, a pure inline op that can execute with a pool value
+     live. That one was migrated off `r8` (tag scratch → `rcx`; negative-index
+     adjust → a sign branch instead of a cmov-through-scratch).
+
+   The **reservation invariant**: a JIT-body lowering may use `r8`–`r11` as
+   scratch *only* in a post-flush call-staging window (after `writeback_acc`,
+   where the pool is provably empty). Everywhere a pool value can be live, the
+   pool registers are off-limits. After the migration this holds for the whole
+   x86-64 backend. *(aarch64 pool reservation is pending: `GP::R8`–`R11` map to
+   `x5`–`x8`; that backend needs the same audit before placement targets it. The
+   `gp-alloc` feature is x86-first and off by default, so nothing places into the
+   aarch64 pool yet.)*
+3. **Placement policy** *(next)*: choose which slots enter the pool (victim
    selection under pressure) and populate `gp_alloc` / emit `G(_, Alloc(id))`,
    within a call-free straight-line stretch (the flush at §1 bounds it).
-3. **Branch-merge reconciliation**: agree pool residency across control-flow
+4. **Branch-merge reconciliation**: agree pool residency across control-flow
    joins (or simply flush at every block boundary in the first cut).
-4. **M1 A/B bench gate** before the feature becomes default.
+5. **M1 A/B bench gate** before the feature becomes default.
 
 Note C-ABI call-save is *not* a separate step: the flush-at-boundary (§1) makes
 it unnecessary — pool slots are always written back before a call.

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -54,10 +54,11 @@ impl Codegen {
     /// classification consistent with `RStringInner::set_byte`.
     ///
     /// ### destroy
-    /// - rax, rcx, rdx, rsi, r8
+    /// - rax, rcx, rdx, rsi
     pub(crate) fn emit_string_setbyte(&mut self, deopt: &DestLabel) {
         let exit = self.jit.label();
         let set_unknown = self.jit.label();
+        let pos_idx = self.jit.label();
         monoasm! { &mut self.jit,
             // frozen (0b010) or chilled (0b100) → deopt
             movzxw rax, [rdi + (RVALUE_OFFSET_FLAG)];
@@ -70,18 +71,22 @@ impl Codegen {
             // Shared (copy-on-write) string: the buffer is aliased by
             // other sharers and must not be written in place — deopt to
             // the interpreter, which detaches via `owned_mut`.
-            movq r8, (crate::rvalue::STRING_SHARED_TAG);
-            cmpq rax, r8;
+            // (rcx is free here until the `lea` below, so use it for the
+            // tag scratch rather than r8 — r8-r11 are the allocatable pool.)
+            movq rcx, (crate::rvalue::STRING_SHARED_TAG);
+            cmpq rax, rcx;
             jeq  deopt;
             lea  rcx, [rdi + (RVALUE_OFFSET_INLINE)];
             cmpq rax, (STRING_INLINE_CAP);
             cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
             cmovgtq rcx, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
-            // negative index counts back from the end
-            movq r8, rsi;
-            addq r8, rax;
+            // negative index counts back from the end. Branch on the sign
+            // instead of computing `rsi + rax` into a scratch reg and
+            // cmov'ing, so we need no extra register (r8 is now pool).
             testq rsi, rsi;
-            cmovsq rsi, r8;
+            jns  pos_idx;
+            addq rsi, rax;
+        pos_idx:
             // out of range (unsigned check covers still-negative) → IndexError
             cmpq rsi, rax;
             jae  deopt;


### PR DESCRIPTION
## Summary

Prerequisite for the GP register-allocator **placement** phase (§9 9d-B). The pool design assumed `r8`–`r11` were "otherwise-unused caller-saved scratch" — but an audit of the JIT-body lowerings found that's **not** true: `r8`–`r11` are the JIT's *secondary* scratch pool, used freely once the primary scratch (`rax/rcx/rdx/rsi/rdi`) runs out.

To hold a value in a pool register *across* instructions, no intervening lowering may clobber it. So the pool must be reserved — exactly as the FP side reserves its xmm pool and confines scratch to `xmm0/xmm1`.

## Audit

In scope: every `compile.rs` / `compile/*` / `guard.rs` lowering that can run while a pool value is live. Out of scope: `vmgen` (the VM interpreter — disjoint execution) and `invoker`/`wrapper` (reached via a call boundary).

| Reg | Finding |
|-----|---------|
| `r10`, `r11` | unused in JIT-body code |
| `r9` | only `class_def` — post-flush call-staging (safe) |
| `r8` | **every** use is post-flush call-staging (the send/define/store sequence runs `writeback_acc` first, emptying the pool — the GP analogue of using the pool after `fpr_save`) **except one**: `emit_string_setbyte` |

## The one migration: `emit_string_setbyte`

A pure inline op that can execute with a pool value live, so it cannot use `r8`:
- shared-tag compare → use `rcx` (free until the data-ptr `lea`)
- negative-index adjust → branch on the sign instead of computing `rsi + rax` into a scratch and `cmov`-ing, so **no extra register is needed**

Behaviour-preserving (byte-changing).

## Reservation invariant (doc/lir.md §9-2)

> A JIT-body lowering may use `r8`–`r11` as scratch **only** in a post-flush call-staging window (after `writeback_acc`, where the pool is provably empty). Everywhere a pool value can be live, the pool registers are off-limits.

After the migration this holds for the whole x86-64 backend.

## aarch64

Reservation pending: `GP::R8`–`R11` map to `x5`–`x8`; that backend needs the same audit before placement targets it. The `gp-alloc` feature is x86-first and off by default, so nothing places into the aarch64 pool yet.

## Verification

- ✅ x86 + aarch64 build · ✅ 1716 lib tests pass (incl. `string::tests::setbyte`)

## Note on codecov/patch

If the advisory `codecov/patch` check goes red it's the same pattern as #745–#750 — `emit_string_setbyte` is JIT codegen exercised only when the inline String#setbyte path is JIT-compiled; the real amd64/darwin suites gate correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_