### PR TITLE
JIT: fold layer2-float-by-type into the default; allow non-Fixnum objects in the gp-alloc pool

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -1,1 +1,1 @@
-cargo run --features jit-log,gc-log,stress-spill-pool,gc-stress,layer2-float-by-type,gp-alloc -- ../doom/bin/doom
+cargo run --features jit-log,gc-log,stress-spill-pool,gc-stress,gp-alloc -- ../doom/bin/doom

--- a/bin/test
+++ b/bin/test
@@ -15,15 +15,15 @@ drop_last3() { awk 'NR>3{print buf[NR%3]} {buf[NR%3]=$0}'; }
 # not semantics, so the output diffs are unaffected either way.
 RUBY=(ruby --yjit)
 
-# stress-spill-pool / gc-stress / layer2-float-by-type amplify the JIT's spill +
-# GC paths and run on every arch. `gp-alloc` (the GP-register pool allocator) is
-# only enabled on x86-64: on the AArch64 JIT it still intermittently diverges on
+# stress-spill-pool / gc-stress amplify the JIT's spill + GC paths and run on
+# every arch. `gp-alloc` (the GP-register pool allocator) is only enabled on
+# x86-64: on the AArch64 JIT it still intermittently diverges on
 # `optcarrot --opt` under gc-stress (reproducible on the macOS CI runner, though
 # not on a local M1 or qemu-aarch64), so keep it off there until the aarch64
 # pool path is fixed.
 case "$(uname -m)" in
-  x86_64) STRESS_FEATURES=(--features stress-spill-pool,gc-stress,layer2-float-by-type,gp-alloc) ;;
-  *)      STRESS_FEATURES=(--features stress-spill-pool,gc-stress,layer2-float-by-type) ;;
+  x86_64) STRESS_FEATURES=(--features stress-spill-pool,gc-stress,gp-alloc) ;;
+  *)      STRESS_FEATURES=(--features stress-spill-pool,gc-stress) ;;
 esac
 
 # Coverage wrappers. SKIP_COV=1 runs the whole script without llvm-cov

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -3069,3 +3069,22 @@ threaded through `copy_slot` + the merge target), squarely in §16.6's regressed
 before risk class, and still M1-gated. The cheaper §42 `phys-loop-aware` lever is
 orthogonal (pressure-gated); coalescing is the POOL=14-relevant one but pays only
 on copy-heavy loop-carried floats (the `a,b = c,d` swap/rotate shape).
+
+## 44. `layer2-float-by-type` folded into the default and removed
+
+The type+liveness loop-entry float adoption (§16 L2-1, promoted to default-on in
+§41) has soaked as the default with no regression, so the Cargo feature is now
+**removed** rather than merely default-on:
+
+- the adopt block in `merge.rs` is unconditional (the union-adopt of §40 — the
+  mandelbrot-safe signal `be.is_float_typed(i) && loop_used_as_float(i)` ∪
+  `be.mode(i) == F`);
+- the A/B-only `#[cfg(not(feature = "layer2-float-by-type"))]` placement-based
+  adopt path is deleted;
+- `layer2-float-by-type` is dropped from `[features]` and the `default` set in
+  `monoruby/Cargo.toml`, and the `bin/` harness (`test`, `bench`, `doom`) no
+  longer passes it.
+
+Only the build knob is gone; runtime behaviour is unchanged from the default-on
+state. The §31/§32 `layer2-float-by-type` × `stress-spill-pool` history is
+retained above as the record of the pressure bug that §39/§40 fixed.

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -18,11 +18,7 @@ name = "irm"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# `layer2-float-by-type` (§5 L2-1) is default-on: the M1 + x86-64 bench gate
-# cleared (doc §41 — no regression beyond noise, mandelbrot/aobench/nqueen/bedcov
-# improved). The feature is retained for A/B and `--no-default-features` rollback;
-# it will be folded once it has soaked as the default.
-default = ["layer2-float-by-type"]
+default = []
 dump-bc = []
 dump-traceir = []
 emit-asm = ["dump-bc", "dump-traceir", "jit-log"]
@@ -46,12 +42,6 @@ gc-verify = []
 stress-spill-pool = []
 profile = ["dump-bc", "dump-traceir"]
 perf = []
-# §5 Layer-② extraction L2-1 (doc §16): drive the loop-entry float adoption from
-# the analysis pass's *type + liveness* (back-edge type `Float` ∧ used-as-float in
-# the loop) instead of its *placement* (`mode == F`), decoupling that consumer
-# from the analysis-pass xmm allocation. Now **default-on** (added to `default`):
-# the bench gate cleared on x86-64 and M1 after the §40 union-adopt fix (doc §41).
-layer2-float-by-type = []
 # §5 Layer-② extraction: stage-1 *placement shadow*. Records, in emission order,
 # every physical FP placement that ③ commits (one entry per `PhysMap::resolve`),
 # producing a per-`jit_compile` fingerprint of the FPReg→FPRegLoc lowering. The

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -2208,13 +2208,14 @@ impl Codegen {
         self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::executor::execute_gc as *const () as u64;
         // Preserve the GP-alloc pool (x5-x8 = GP::R8-R11) across the call. They
-        // are AAPCS64 caller-saved and hold live Fixnums under `gp-alloc`. The
+        // are AAPCS64 caller-saved and hold live Values under `gp-alloc`. The
         // write-back above spills them to their frame homes for GC marking, but
         // the post-GC code keeps reading the *registers* (e.g. a pool-resident
         // call receiver), so they must survive `execute_gc`. x86 preserves
         // r8-r11 the same way in its `exec_gc` stub (save/restore_registers).
-        // GP-pool values are Fixnums (immediates), so GC never relocates them
-        // and restoring the raw register value is correct.
+        // The GC is mark-and-sweep (non-moving), so a heap value the write-back
+        // kept alive is not relocated and restoring the raw register value is
+        // correct (Fixnum immediates are trivially fine for the same reason).
         #[cfg(feature = "gp-alloc")]
         monoasm_arm64!(&mut self.jit,
             stp x5, x6, [sp, #-16]!;

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -106,33 +106,24 @@ impl<'a> JitContext<'a> {
                     // Adoption policy (Layer-② representation decision, §16): which
                     // loop-carried slots re-adopt the back-edge fixpoint's `F`.
                     //
-                    // Default reads the fixpoint's *placement* (`mode == F`) — the
-                    // remaining dependence on the analysis-pass allocation. L2-1
-                    // (feature `layer2-float-by-type`) replaces it with the
-                    // allocation-free *type + liveness* signal: the back-edge type
-                    // is `Float` and the slot is used as float in the loop
-                    // (`Liveness::loop_used_as_float`). `try_set_new_F` (inside the
-                    // mechanism) still self-limits to a free physical fpr, so a
-                    // promotion the fixpoint could not place under pressure simply
-                    // does not fire.
+                    // Use the allocation-free *type + liveness* signal: the
+                    // back-edge type is `Float` and the slot is used as a float in
+                    // the loop (`Liveness::loop_used_as_float`). `try_set_new_F`
+                    // (inside the mechanism) still self-limits to a free physical
+                    // fpr, so a promotion the fixpoint could not place under
+                    // pressure simply does not fire.
                     let promotable =
                         |i| entries.iter().all(|e| float_bridgeable(e.state.mode(i)));
-                    #[cfg(not(feature = "layer2-float-by-type"))]
-                    {
-                        let adopt = |i| matches!(be.mode(i), LinkMode::F(_));
-                        target.keep_backedge_floats(adopt, promotable);
-                    }
-                    #[cfg(feature = "layer2-float-by-type")]
                     {
                         let loop_float: std::collections::HashSet<SlotId> =
                             liveness.loop_used_as_float().map(|(s, _)| s).collect();
-                        // Adopt the *type+liveness* signal (the L2-1 decoupling
-                        // goal), but never adopt a *narrower* set than the
-                        // fixpoint's placement: a loop-carried float the fixpoint
-                        // already kept `F` must stay `F`, else the back-edge boxes
-                        // it every iteration (the mandelbrot regression — the
-                        // type signal misses copy-aliased carried floats). So
-                        // adopt the union, keeping layer2 ⊇ the default greedy.
+                        // Adopt the type+liveness signal, but never adopt a
+                        // *narrower* set than the fixpoint's placement: a
+                        // loop-carried float the fixpoint already kept `F` must
+                        // stay `F`, else the back-edge boxes it every iteration
+                        // (the mandelbrot regression — the type signal misses
+                        // copy-aliased carried floats). So adopt the union,
+                        // keeping it ⊇ the placement-based greedy set.
                         let adopt = |i| {
                             (be.is_float_typed(i) && loop_float.contains(&i))
                                 || matches!(be.mode(i), LinkMode::F(_))

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -275,8 +275,9 @@ impl AbstractFrame {
         if let Some(dst) = dst.into() {
             // §9 9d-B accumulator register file: put the result straight into a
             // free pool register (`r8`–`r11`) rather than the single R15
-            // accumulator — no R15 round-trip / relocate `mov`. Falls back to
-            // R15 when the pool is full or the value is not a Fixnum immediate.
+            // accumulator — no R15 round-trip / relocate `mov`. Any value type
+            // may go to the pool (it is GC-rooted at every safepoint like R15);
+            // falls back to the R15 accumulator only when the pool is full.
             #[cfg(feature = "gp-alloc")]
             if let Some(vreg) = self.try_def_G_pool(dst, guarded) {
                 ir.reg_move(src, vreg.phys());

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1392,8 +1392,13 @@ impl SlotState {
     /// pool register (`r8`–`r11`) instead of routing the result through R15.
     /// Returns the chosen `VReg` (the caller moves the result into it), or
     /// `None` when the pool is full (caller falls back to the R15 accumulator).
-    /// Fixnum-only — a pool register is not a GC root, so only an immediate
-    /// (Fixnum) value may reside there.
+    ///
+    /// Any value type may reside in the pool, not just Fixnums. A pool register
+    /// is rooted for GC the same way the R15 accumulator is: every GC safepoint
+    /// (`get_gc_write_back` → `wb_gp`) spills each pool resident to its frame
+    /// home so the collector marks it, and the `execute_gc` stub preserves the
+    /// pool registers across the call. The GC is mark-and-sweep (non-moving),
+    /// so the preserved raw pointer stays valid for a heap value that survived.
     #[cfg(feature = "gp-alloc")]
     #[allow(non_snake_case)]
     pub(in crate::codegen::jitgen) fn try_def_G_pool(
@@ -1401,9 +1406,6 @@ impl SlotState {
         dst: SlotId,
         guarded: Guarded,
     ) -> Option<VReg> {
-        if guarded != Guarded::Fixnum {
-            return None;
-        }
         let id = self.gp_alloc.find_vacant()?;
         self.discard(dst);
         let vreg = VReg::Alloc(id as u32);
@@ -1614,7 +1616,7 @@ impl AbstractFrame {
     /// lowerings save/restore around the C-ABI call) **and**, as a side effect,
     /// flush any live GP-pool residents to their stack homes.
     ///
-    /// §9 9d-B: GP-pool registers (`r8`–`r11`) are caller-saved, so a Fixnum
+    /// §9 9d-B: GP-pool registers (`r8`–`r11`) are caller-saved, so a value
     /// kept resident there must not survive a C call. Every runtime helper that
     /// can clobber them is preceded by a `get_using_fpr` snapshot (here, or
     /// inside the `ir.<helper>(state, …)` builders), so flushing the GP pool at


### PR DESCRIPTION
Two focused JIT changes on top of current `master` (the gp-alloc pool-flush, Set GC-rooting, and `Gem.loaded_specs` work already landed via #754, so this PR contains only the parts not yet on `master`).

## 1. Fold `layer2-float-by-type` into the default and remove the feature
`c7552047`

The type+liveness loop-entry float adoption (`doc/regalloc_separation.md` §16 L2-1, default-on since §41) has soaked with no regression, so it becomes standard behaviour and the Cargo feature is removed:

- `merge.rs`: the loop-carried-float adopt block is now unconditional — the §40 union-adopt (`be.is_float_typed(i) && loop_used_as_float(i)` ∪ `be.mode(i) == F`). The A/B-only `#[cfg(not(feature = "layer2-float-by-type"))]` placement-based path is deleted.
- `Cargo.toml`: drop `layer2-float-by-type` from `[features]` and from `default` (now empty).
- `bin/test`, `bin/doom`: stop passing the feature.
- `doc/regalloc_separation.md`: §44 records the fold.

Runtime behaviour is unchanged from the prior default-on build.

## 2. Allow non-Fixnum objects to reside in gp-alloc pool registers
`5497322b`

The GP-alloc pool was restricted to Fixnum immediates on the premise that a pool register "is not a GC root". That premise is unnecessary — the pool is rooted exactly like the R15 accumulator:

- every GC safepoint `get_gc_write_back` → `wb_gp` spills each pool resident to its frame home so the collector marks it;
- the `execute_gc` stub preserves the pool registers across the call (x86 `save_registers`/`restore_registers` cover `r8`–`r11`; aarch64 `stp`/`ldp` cover `x5`–`x8`);
- the GC is mark-and-sweep (non-moving), so a heap value the write-back kept alive is not relocated and the preserved raw pointer stays valid — identical to how the R15 accumulator already carries heap values across GC.

Change: drop the `guarded != Fixnum` early-return in `try_def_G_pool` so any value type can be placed in the pool, and fix the now-stale "Fixnum-only" comments. The in-place fixnum-binop path (`def_inplace_fixnum`) stays Fixnum as it is arithmetic-specific.

## Validation (x86-64, on the master base)
- `cargo test --features gp-alloc,gc-stress`: **1716/0** (gc-stress surfaces any GC-rooting hole, as it did for the recent Set use-after-free).
- mandelbrot JIT == `--no-jit` (the §40 float canary); optcarrot `--debug` and `--opt` both match CRuby.
- Default build and aarch64 cross-build (default and `+gp-alloc`) both compile.

Note: `gp-alloc` remains x86-only in `bin/test`; change #2 takes effect there, and is ready to apply to aarch64 once its pool (`x5`–`x8` scratch overlap) is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_