### PR TITLE
JIT: retire the R15 accumulator — the GP pool is the sole register residence

### DIFF
--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -18,7 +18,7 @@ name = "irm"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["gp-alloc"]
 dump-bc = []
 dump-traceir = []
 emit-asm = ["dump-bc", "dump-traceir", "jit-log"]

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -108,11 +108,14 @@ const COUNT_DEOPT_RECOMPILE_SPECIALIZED: i32 = 50;
 /// `VReg::Alloc` ids into these (or a frame spill slot); because they are
 /// caller-saved, any live across a C-ABI call is spilled/reloaded around it.
 ///
-/// x86-64: `r8`–`r11`. (aarch64's pool is revisited when 9d targets it — these
-/// `GP` names map to `x5`–`x8` via `GP::a64`, which overlap the aarch64 call-arg
-/// scratch, so the aarch64 allocatable set will likely differ.)
-#[allow(dead_code)]
-pub(in crate::codegen) const GP_ALLOC_POOL: [GP; 4] = [GP::R8, GP::R9, GP::R10, GP::R11];
+/// Arch-specific. x86-64 uses `r8`–`r11`. aarch64's pool is **empty**: the
+/// `GP` names `R8`–`R11` map to `x5`–`x8` via `GP::a64`, which overlap the
+/// aarch64 call-arg scratch, so no GP register is allocatable there and every
+/// value lives in its frame home (the R15 accumulator having been retired).
+#[cfg(target_arch = "x86_64")]
+pub(in crate::codegen) const GP_ALLOC_POOL: &[GP] = &[GP::R8, GP::R9, GP::R10, GP::R11];
+#[cfg(target_arch = "aarch64")]
+pub(in crate::codegen) const GP_ALLOC_POOL: &[GP] = &[];
 
 ///
 /// General purpose registers.

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -350,11 +350,6 @@ impl Codegen {
         for slot in &wb.void {
             self.a64_store_imm_to_slot(NIL_VALUE as u64, *slot, lfp);
         }
-        if let Some(slot) = wb.r15 {
-            let off = slot.0 as u32 * 8 + LFP_SELF as u32;
-            let acc = GP::R15.a64().0; // x23
-            self.a64_frame_store(acc, lfp, off);
-        }
         for (reg, slot) in &wb.gp {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
             self.a64_frame_store(reg.a64().0, lfp, off);

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -43,8 +43,6 @@ impl Codegen {
             AsmInst::BcIndex(..)
             | AsmInst::Label(..)
             | AsmInst::RegMove(..)
-            | AsmInst::RegToAcc(..)
-            | AsmInst::AccToStack(..)
             | AsmInst::RegToStack(..)
             | AsmInst::StackToReg(..)
             | AsmInst::LitToReg(..)

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -130,20 +130,18 @@ pub(crate) fn rbp_local(reg: SlotId) -> i32 {
 }
 
 ///
-/// The struct holds information for writing back Value's in fpr registers or accumulator to the corresponding stack slots.
+/// The struct holds information for writing back Value's in fpr registers or pool registers to the corresponding stack slots.
 ///
-/// Currently supports `literal`s, `fpr` registers and a `R15` register (as an accumulator).
+/// Currently supports `literal`s, `fpr` registers and `gp` pool registers.
 ///
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct WriteBack {
     fpr: Vec<(FPReg, Vec<SlotId>)>,
     literal: Vec<(Value, SlotId)>,
     void: Vec<SlotId>,
-    r15: Option<SlotId>,
     /// §9 9d-B: slots resident in the allocatable GP pool (x86-64 `r8`–`r11`),
     /// each paired with the physical register holding it. Written back to the
-    /// slot's frame home at every flush / deopt / GC safepoint, exactly like
-    /// `r15` (the dedicated accumulator) but for the pool registers. Empty until
+    /// slot's frame home at every flush / deopt / GC safepoint. Empty until
     /// the GP allocator (the `gp-alloc` feature) places a slot, so shipping
     /// builds carry an always-empty vec and emit byte-identical code.
     gp: Vec<(GP, SlotId)>,
@@ -173,9 +171,6 @@ impl Hash for WriteBack {
         for slot in &self.void {
             slot.hash(state);
         }
-        if let Some(slot) = self.r15 {
-            slot.hash(state);
-        }
         for (reg, slot) in &self.gp {
             reg.hash(state);
             slot.hash(state);
@@ -203,9 +198,6 @@ impl std::fmt::Debug for WriteBack {
         for slot in &self.void {
             s.push_str(&format!(" nil->{:?}", slot));
         }
-        if let Some(slot) = self.r15 {
-            s.push_str(&format!(" R15->{:?}", slot));
-        }
         for (reg, slot) in &self.gp {
             s.push_str(&format!(" {:?}->{:?}", reg, slot));
         }
@@ -220,7 +212,6 @@ impl WriteBack {
     fn new(
         fpr: Vec<(FPReg, Vec<SlotId>)>,
         literal: Vec<(Value, SlotId)>,
-        r15: Option<SlotId>,
         void: Vec<SlotId>,
         gp: Vec<(GP, SlotId)>,
         forward_rest: Vec<(SlotId, SlotId, u16)>,
@@ -228,7 +219,6 @@ impl WriteBack {
         Self {
             fpr,
             literal,
-            r15,
             void,
             gp,
             forward_rest,
@@ -879,11 +869,6 @@ impl JitModule {
         for slot in &wb.void {
             self.literal_to_stack(*slot, Value::nil());
         }
-        if let Some(slot) = wb.r15 {
-            monoasm! { &mut *self,
-                movq [rbp - (rbp_local(slot))], r15;
-            }
-        }
         for (reg, slot) in &wb.gp {
             monoasm! { &mut *self,
                 movq [rbp - (rbp_local(*slot))], R(*reg as _);
@@ -911,11 +896,6 @@ impl JitModule {
         }
         for slot in &wb.void {
             self.literal_to_stack2(*slot, Value::nil());
-        }
-        if let Some(slot) = wb.r15 {
-            monoasm! { &mut *self,
-                movq [r14 - (conv(slot))], r15;
-            }
         }
         for (reg, slot) in &wb.gp {
             monoasm! { &mut *self,

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -573,10 +573,6 @@ impl AsmIr {
         self.push(AsmInst::LitToReg(v, reg));
     }
 
-    pub fn acc2stack(&mut self, reg: SlotId) {
-        self.push(AsmInst::AccToStack(reg));
-    }
-
     ///
     /// Convert Fixnum to f64.
     ///
@@ -1177,11 +1173,6 @@ pub(super) enum AsmInst {
     Unreachable,
     /// move reg to stack
     RegToStack(GP, SlotId),
-    /// move acc to stack
-    AccToStack(SlotId),
-
-    /// move reg to acc
-    RegToAcc(GP),
 
     /// move reg to stack
     StackToReg(SlotId, GP),
@@ -2301,8 +2292,6 @@ impl AsmInst {
     #[allow(dead_code)]
     pub fn dump(&self, store: &Store) -> String {
         match self {
-            Self::AccToStack(slot) => format!("{:?} = R15", slot),
-            Self::RegToAcc(gpr) => format!("R15 = {:?}", gpr),
             Self::RegToStack(gpr, slot) => format!("{:?} = {:?}", slot, gpr),
             Self::StackToReg(slot, gpr) => format!("{:?} = {:?}", gpr, slot),
             Self::LitToReg(val, gpr) => format!("{:?} = {}", gpr, val.debug(store)),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -49,16 +49,6 @@ impl Codegen {
                 dst: dst.into(),
                 src: src.into(),
             }),
-            // acc <- reg
-            AsmInst::RegToAcc(r) => self.encode_linst(LInst::Mov {
-                dst: GP::R15.into(),
-                src: r.into(),
-            }),
-            // [slot] <- acc
-            AsmInst::AccToStack(slot) => self.encode_linst(LInst::Store {
-                src: GP::R15,
-                mem: LMem::Slot(slot),
-            }),
             // [slot] <- reg
             AsmInst::RegToStack(r, slot) => self.encode_linst(LInst::Store {
                 src: r,

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -464,7 +464,7 @@ impl AbstractFrame {
                         mode,
                         deopt,
                     });
-                    self.def_inplace_fixnum(dst, dst_reg);
+                    self.def_inplace_fixnum(ir, dst, dst_reg);
                 } else {
                     // Result discarded: run the op in the Rdi scratch purely for
                     // the overflow side-exit; no destination store.

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -273,18 +273,18 @@ impl AbstractFrame {
         guarded: slot::Guarded,
     ) {
         if let Some(dst) = dst.into() {
-            // §9 9d-B accumulator register file: put the result straight into a
-            // free pool register (`r8`–`r11`) rather than the single R15
-            // accumulator — no R15 round-trip / relocate `mov`. Any value type
-            // may go to the pool (it is GC-rooted at every safepoint like R15);
-            // falls back to the R15 accumulator only when the pool is full.
+            // §9 9d-B accumulator register file: put the result into a free pool
+            // register (x86 `r8`–`r11`; aarch64's pool is empty so this never
+            // fires there). Any value type may go to the pool (it is GC-rooted
+            // at every safepoint). With the R15 accumulator retired, a value
+            // that gets no pool register is stored straight to its stack home.
             #[cfg(feature = "gp-alloc")]
             if let Some(vreg) = self.try_def_G_pool(dst, guarded) {
                 ir.reg_move(src, vreg.phys());
                 return;
             }
-            self.def_G(ir, dst, guarded);
-            ir.push(AsmInst::RegToAcc(src));
+            ir.reg2stack(src, dst);
+            self.def_S_guarded(dst, guarded);
         }
     }
 

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -311,25 +311,12 @@ impl AbstractFrame {
         self.use_as_value(slot);
         match self.mode(slot) {
             LinkMode::F(fpr) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
                 // F -> Sf
                 self.set_Sf_float(slot, fpr);
                 GpLoad::FprBox(fpr, slot, dst)
             }
-            LinkMode::C(v) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
-                GpLoad::Lit(v, dst)
-            }
-            LinkMode::Sf(_, _) | LinkMode::S(_) => {
-                if dst == GP::R15 {
-                    assert!(self.no_r15());
-                }
-                GpLoad::Stack(slot, dst)
-            }
+            LinkMode::C(v) => GpLoad::Lit(v, dst),
+            LinkMode::Sf(_, _) | LinkMode::S(_) => GpLoad::Stack(slot, dst),
             LinkMode::G(_, vreg) => GpLoad::Reg(vreg.phys(), dst),
             LinkMode::MaybeNone => GpLoad::Stack(slot, dst),
             LinkMode::V | LinkMode::None => {
@@ -370,7 +357,6 @@ impl AbstractFrame {
             self.guard_fixnum(ir, lhs, reg);
             return reg;
         }
-        self.free_acc(ir);
         self.load(ir, lhs, GP::R15);
         self.guard_fixnum(ir, lhs, GP::R15);
         GP::R15
@@ -380,12 +366,11 @@ impl AbstractFrame {
     /// immediate (the `IR`-Sub case, where the encoder materializes the
     /// immediate into the result register): a vacant pool register under
     /// gp-alloc, else the freed R15 accumulator.
-    pub(in crate::codegen::jitgen) fn alloc_inplace_reg(&mut self, ir: &mut AsmIr) -> GP {
+    pub(in crate::codegen::jitgen) fn alloc_inplace_reg(&mut self, _ir: &mut AsmIr) -> GP {
         #[cfg(feature = "gp-alloc")]
         if let Some(id) = self.try_vacant_pool_id() {
             return crate::codegen::GP_ALLOC_POOL[id];
         }
-        self.free_acc(ir);
         GP::R15
     }
 

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1361,18 +1361,16 @@ impl SlotState {
         self.gp_alloc.find_vacant()
     }
 
-    /// Define `dst` as a Fixnum already resident in `reg` — the in-place result
-    /// of a fixnum binop. Emits no code: the value is already in `reg` and the
-    /// register was freed (R15 by `free_acc`/`write_back_slot`, a pool register
-    /// by being vacant), so this only updates the abstract state (the move-free
-    /// analogue of `def_reg2acc_fixnum`). `reg` is either R15 or a pool register
-    /// returned by [`Self::try_vacant_pool_id`].
-    pub(crate) fn def_inplace_fixnum(&mut self, dst: SlotId, reg: GP) {
+    /// Define `dst` as a Fixnum produced in-place by a fixnum binop in `reg`.
+    /// `reg` is either a pool register (the value stays resident) or R15, the
+    /// transient scratch used when no pool register was free. With the R15
+    /// accumulator retired, the R15 case is not a residence: the value is
+    /// stored to `dst`'s stack home and `dst` becomes `S`.
+    pub(crate) fn def_inplace_fixnum(&mut self, ir: &mut AsmIr, dst: SlotId, reg: GP) {
         self.discard(dst);
         if reg == GP::R15 {
-            debug_assert!(self.no_r15());
-            self.set_mode(dst, LinkMode::G(Guarded::Fixnum, VReg::Pinned(GP::R15)));
-            self.r15 = Some(dst);
+            ir.reg2stack(GP::R15, dst);
+            self.set_mode(dst, LinkMode::S(Guarded::Fixnum));
         } else {
             #[cfg(feature = "gp-alloc")]
             {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -343,7 +343,6 @@ pub(crate) struct SlotState {
     /// B2.1; populated by the allocator (B2.2+).
     #[cfg(feature = "gp-alloc")]
     gp_alloc: GpAllocator,
-    r15: Option<SlotId>,
     local_num: usize,
     /// D1 forwarding-rest deferral (transient annotation; see the consumers).
     deferred_rest: Option<(SlotId, SlotId, u16)>,
@@ -385,7 +384,6 @@ impl SlotState {
             fpr_alloc: FprAllocator::new(),
             #[cfg(feature = "gp-alloc")]
             gp_alloc: GpAllocator::new(),
-            r15: None,
             local_num,
             deferred_rest: None,
             loop_carried: std::collections::HashSet::new(),
@@ -468,10 +466,6 @@ impl SlotState {
             .zip(other.ty.iter())
             .map(|(a, b)| a.join(b))
             .collect()
-    }
-
-    pub(super) fn no_r15(&self) -> bool {
-        self.r15.is_none()
     }
 
     pub(super) fn equiv(&self, other: &Self) -> bool {
@@ -697,8 +691,7 @@ impl SlotState {
             }
             LinkMode::G(_, vreg) => match vreg {
                 VReg::Pinned(_) => {
-                    assert_eq!(self.r15, Some(slot));
-                    self.r15 = None;
+                    unreachable!("R15 accumulator retired; slot residence is pool-only")
                 }
                 VReg::Alloc(_id) => {
                     #[cfg(feature = "gp-alloc")]
@@ -971,30 +964,6 @@ impl SlotState {
         }
     }
 
-    ///
-    /// Link *slot* to the accumulator.
-    ///
-    #[allow(non_snake_case)]
-    pub(crate) fn def_G(
-        &mut self,
-        ir: &mut AsmIr,
-        slot: impl Into<Option<SlotId>>,
-        guarded: Guarded,
-    ) {
-        if let Some(slot) = slot.into() {
-            self.discard(slot);
-            // Free only R15 for the new accumulator; pool (`Alloc`) residents
-            // persist across the `def_G` (they are flushed at call/store/def
-            // boundaries via `writeback_acc`, not here). The placement trigger
-            // (`try_relocate_acc_to_pool`) runs *before* this in
-            // `def_reg2acc_guarded`, where it can check that the new value's
-            // source register is not R15 (so R15 still holds the old value).
-            self.writeback_r15(ir);
-            self.set_mode(slot, LinkMode::G(guarded, VReg::Pinned(GP::R15)));
-            self.r15 = Some(slot);
-        }
-    }
-
     // APIs for 'use'
 
     /// used as f64 with no conversion
@@ -1029,8 +998,7 @@ impl SlotState {
                 // G -> S
                 match vreg {
                     VReg::Pinned(_) => {
-                        assert_eq!(self.r15, Some(slot));
-                        self.r15 = None;
+                        unreachable!("R15 accumulator retired; slot residence is pool-only")
                     }
                     VReg::Alloc(_id) => {
                         #[cfg(feature = "gp-alloc")]
@@ -1284,31 +1252,9 @@ impl SlotState {
     }
 
     ///
-    ///
-    /// Write back acc(`r15``) to the stack slot.
-    ///
-    /// The slot is set to LinkMode::Stack.
-    ///
-    ///
-    /// Analysis half of [`Self::writeback_acc`] (item ②, step-2 spike): evict
-    /// the accumulator (`r15`) owner to its stack home in the *abstract state*
-    /// only, returning the evicted slot so the emission half can store it. This
-    /// is the pure state transition — a standalone analysis pass calls this and
-    /// never touches `AsmIr`; codegen calls `writeback_acc` (this + the store).
-    ///
-    fn writeback_acc_state(&mut self) -> Option<SlotId> {
-        let slot = self.r15?;
-        let guarded = self.guarded(slot);
-        self.set_mode(slot, LinkMode::S(guarded));
-        self.r15 = None;
-        Some(slot)
-    }
-
     /// §9 9d-B flush-at-boundary: evict every allocatable-pool resident
     /// (`G(_, VReg::Alloc(_))`) to its stack home in the *abstract state*,
     /// returning the `(reg, slot)` pairs so the emission half can store them.
-    /// The dedicated accumulator (`Pinned(R15)`) is handled by
-    /// [`Self::writeback_acc_state`]; this is its pool analogue.
     ///
     /// This runs at every call / store / definition boundary (every
     /// `writeback_acc` site), so a pool value never stays resident across a
@@ -1331,25 +1277,6 @@ impl SlotState {
             self.gp_alloc = GpAllocator::new();
         }
         out
-    }
-
-    /// Spill only the dedicated accumulator (R15) to its stack home, leaving
-    /// any pool (`Alloc`) residents in place. Used by `def_G` to free R15 for a
-    /// new accumulator value while letting pool-resident slots persist across
-    /// it. (`writeback_acc` is the *full* flush — R15 *and* pool — used at the
-    /// call / store / definition boundaries.)
-    fn writeback_r15(&mut self, ir: &mut AsmIr) {
-        if let Some(slot) = self.writeback_acc_state() {
-            ir.acc2stack(slot);
-        }
-    }
-
-    /// Free the R15 accumulator by spilling its current occupant (if any) to
-    /// the stack, so R15 can serve as the in-place result register of a fixnum
-    /// binop. Afterwards `self.r15 == None`. Pool (`Alloc`) residents are left
-    /// in place (this is the R15-only half of `writeback_acc`).
-    pub(crate) fn free_acc(&mut self, ir: &mut AsmIr) {
-        self.writeback_r15(ir);
     }
 
     /// A vacant allocatable GP-pool id (`r8`–`r11`), or `None` when the pool is
@@ -1426,16 +1353,12 @@ impl SlotState {
         }
     }
 
-    pub(crate) fn writeback_acc(&mut self, ir: &mut AsmIr) {
-        if let Some(slot) = self.writeback_acc_state() {
-            ir.acc2stack(slot);
-        }
+    pub(crate) fn writeback_acc(&mut self, _ir: &mut AsmIr) {
         #[cfg(feature = "gp-alloc")]
         for (reg, slot) in self.writeback_pool_state() {
-            ir.reg2stack(reg, slot);
+            _ir.reg2stack(reg, slot);
         }
         assert!(!self.all_regs().any(|i| matches!(self.mode(i), LinkMode::G(_, _))));
-        assert!(self.r15.is_none());
     }
 
     fn is_fpr_vacant(&self, fpr: FPReg) -> bool {
@@ -1492,7 +1415,9 @@ impl SlotState {
                 ir.reg2stack(vreg.phys(), src);
                 self.set_S_with_guard(src, guarded);
                 match vreg {
-                    VReg::Pinned(_) => self.def_G(ir, dst, guarded),
+                    VReg::Pinned(_) => {
+                        unreachable!("R15 accumulator retired; slot residence is pool-only")
+                    }
                     #[cfg(feature = "gp-alloc")]
                     VReg::Alloc(id) => {
                         self.discard(dst);
@@ -1659,22 +1584,18 @@ impl AbstractFrame {
         let gp = self.wb_gp(|_| true);
         #[cfg(not(feature = "gp-alloc"))]
         let gp = vec![];
-        WriteBack::new(vec![], literal, self.r15, void, gp, vec![])
+        WriteBack::new(vec![], literal, void, gp, vec![])
     }
 
     pub(crate) fn get_write_back(&self) -> WriteBack {
         let f = |_| true;
         let fpr = self.wb_fpr(f);
         let literal = self.wb_literal(f);
-        let r15 = match self.r15 {
-            Some(slot) if f(slot) => Some(slot),
-            _ => None,
-        };
         #[cfg(feature = "gp-alloc")]
         let gp = self.wb_gp(f);
         #[cfg(not(feature = "gp-alloc"))]
         let gp = vec![];
-        WriteBack::new(fpr, literal, r15, vec![], gp, self.wb_forward_rest())
+        WriteBack::new(fpr, literal, vec![], gp, self.wb_forward_rest())
     }
 
     fn fpr_swap(&mut self, l: FPReg, r: FPReg) {
@@ -1743,10 +1664,8 @@ impl AbstractFrame {
     }
 
     /// §9 9d-B: collect the slots resident in the allocatable GP pool
-    /// (`VReg::Alloc`), each paired with its physical pool register. The
-    /// dedicated accumulator (`VReg::Pinned(R15)`) is *not* included — it is
-    /// written back separately via `self.r15`. Empty until the allocator places
-    /// a slot in the pool.
+    /// (`VReg::Alloc`), each paired with its physical pool register. Empty until
+    /// the allocator places a slot in the pool.
     #[cfg(feature = "gp-alloc")]
     fn wb_gp(&self, f: impl Fn(SlotId) -> bool) -> Vec<(GP, SlotId)> {
         self.all_regs()
@@ -1828,9 +1747,7 @@ pub(in crate::codegen::jitgen) enum Spill {
     /// `ir.lit2stack(value, slot)`
     Lit(Value, SlotId),
     /// Write back a `G`-slot's register to its stack home: `ir.reg2stack(reg,
-    /// slot)`. `reg` is the slot's register (`r15` for the accumulator — then
-    /// byte-identical to the old `acc2stack` — or a pool register once 9d places
-    /// it).
+    /// slot)`. `reg` is the slot's pool register.
     Reg(GP, SlotId),
 }
 


### PR DESCRIPTION
Retires the R15 accumulator as a JIT value residence: the GP-alloc pool becomes the sole place a slot's value lives in a register, with overflow going to the stack. R15 (`x23`) stays only as a transient scratch / ABI / return register and the VM-tier accumulator (vmgen is untouched).

## Commits

1. **`make the GP pool the default allocator, arch-specific`** — `gp-alloc` becomes a default feature and `GP_ALLOC_POOL` is arch-specific: x86-64 keeps `r8`–`r11`; aarch64 is **empty** (its `R8`–`R11` map to `x5`–`x8`, which overlap the call-arg scratch). The pool type is `&[GP]` so the arches can differ. With an empty pool the aarch64 allocator never places a slot in a register.

2. **`retire the R15 accumulator as a JIT value residence`** — the two paths that placed a value in R15 now route elsewhere: a result that gets no pool register is stored straight to its stack home (`reg2stack` + `S`); the in-place fixnum-binop R15 case (transient scratch when no pool register is free) stores its result to the stack. `self.r15` is never set again. Net effect — x86-64: Fixnum/heap values in the `r8`–`r11` pool, overflow to stack; aarch64: every value in its stack home.

3. **`remove the dead R15-accumulator scaffolding`** — with `self.r15` never set, the accumulator machinery is dead and removed: the `r15` field, `def_G`, `writeback_acc_state`/`writeback_r15`/`free_acc`, `no_r15`, the `RegToAcc`/`AccToStack` AsmInsts + `acc2stack` + their lowering, `WriteBack::r15` (incl. the x86/aarch64 deopt accumulator store), and the now-impossible `LinkMode::G(_, VReg::Pinned(_))` slot-residence arms (`unreachable!`). `VReg::Pinned` is **kept** — it is the LIR's physical-register operand (`From<GP>`), unrelated to the retired accumulator. Net −146 lines.

## Validation (x86-64)
- `cargo test --features gc-stress`: **1716/0** (gc-stress surfaces any GC-rooting hole; the pool is rooted at every safepoint like R15 was).
- mandelbrot JIT == `--no-jit`; optcarrot `--debug` and `--opt` both match CRuby.
- default, `--no-default-features`, and `aarch64-unknown-linux-gnu` cross builds all clean; the aarch64 all-stack path matches CRuby (app_fib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_