### PR TITLE
JIT/LIR §9a: buffer the region body into one ordered LInst stream (allocation-pass seam)

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -656,6 +656,12 @@ pub struct Codegen {
     pub(crate) resume_fiber: extern "C" fn(*mut Executor, &mut Executor, Value) -> Option<Value>,
     pub(crate) yield_fiber: extern "C" fn(*mut Executor, Value) -> Option<Value>,
     pub(crate) startup_flag: bool,
+    /// (§9a-ii) When `Some`, `encode_linst*` and the per-arch fallthrough buffer
+    /// the lowered `LInst`s here instead of emitting, so the region driver
+    /// (`gen_asm`) collects the whole body into one ordered stream and drains it
+    /// (the seam the future GP physical-allocation pass slots into). `None`
+    /// during the drain and everywhere else — emission is immediate.
+    pub(crate) lir_buf: Option<Vec<crate::codegen::jitgen::lir::LInst>>,
     #[cfg(any(feature = "jit-log", feature = "jit-debug"))]
     pub(crate) jit_compile_time: std::time::Duration,
 }
@@ -946,6 +952,7 @@ impl Codegen {
             resume_fiber,
             yield_fiber,
             startup_flag: false,
+            lir_buf: None,
             #[cfg(any(feature = "jit-log", feature = "jit-debug"))]
             jit_compile_time: std::time::Duration::default(),
         };

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1437,6 +1437,12 @@ impl Codegen {
     /// `doc/lir.md`.
     ///
     pub(in crate::codegen::jitgen) fn encode_linst(&mut self, inst: LInst) {
+        // (§9a-ii) Buffering pass: collect the lowered op, don't emit. The
+        // region driver drains the buffer (with `lir_buf` cleared) afterwards.
+        if let Some(buf) = self.lir_buf.as_mut() {
+            buf.push(inst);
+            return;
+        }
         match inst {
             // dst <- src (elided when the physical registers coincide)
             LInst::Mov { dst, src } => {

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -257,6 +257,12 @@ impl Codegen {
     /// `doc/lir.md`.
     ///
     pub(in crate::codegen::jitgen) fn encode_linst(&mut self, inst: LInst) {
+        // (§9a-ii) Buffering pass: collect the lowered op, don't emit. The
+        // region driver drains the buffer (with `lir_buf` cleared) afterwards.
+        if let Some(buf) = self.lir_buf.as_mut() {
+            buf.push(inst);
+            return;
+        }
         match inst {
             // dst <- src (elided when src == dst)
             LInst::Mov { dst, src } => {

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -39,7 +39,7 @@ mod guard;
 #[path = "arch/aarch64/guard.rs"]
 mod guard;
 // Unified low-level IR (Phase-1 Stage 1: data model only, not yet wired in).
-mod lir;
+pub(in crate::codegen) mod lir;
 mod merge;
 mod state;
 pub mod trace_ir;

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -23,6 +23,19 @@ pub(super) struct InlineProcedure {
     proc: Box<dyn FnOnce(&mut Codegen, &Store, &SideExitLabels, usize)>,
 }
 
+impl InlineProcedure {
+    /// Wrap a context-carrying generator as an `LInst::Inline` payload. Lets the
+    /// `compile_asmir` lowering route the not-yet-typed families (specialized
+    /// inlined-frame ops, `gen_array_index*`) through the same `LInst::Inline`
+    /// escape hatch as the inline-builtin generators, so *every* `AsmInst`
+    /// lowers to an `LInst` (the §9a whole-region-buffering prerequisite).
+    pub(in crate::codegen::jitgen) fn new(
+        f: impl FnOnce(&mut Codegen, &Store, &SideExitLabels, usize) + 'static,
+    ) -> Self {
+        InlineProcedure { proc: Box::new(f) }
+    }
+}
+
 impl std::fmt::Debug for InlineProcedure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "InlineProcedure")

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2471,11 +2471,11 @@ impl Codegen {
         }
 
         if entry.is_some() && exit.is_some() {
-            self.jit.select_page(1);
+            self.encode_linst(LInst::SelectPage(1));
         }
 
         if let Some(entry) = &entry {
-            self.jit.bind_label(entry.clone());
+            self.encode_linst(LInst::BindLabel(entry.clone()));
         }
 
         for inst in ir.inst {
@@ -2493,7 +2493,7 @@ impl Codegen {
             }
         }
         if entry.is_some() && exit.is_some() {
-            self.jit.select_page(0);
+            self.encode_linst(LInst::SelectPage(0));
         }
     }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2491,12 +2491,34 @@ impl Codegen {
             self.encode_linst(LInst::BindLabel(entry.clone()));
         }
 
+        // (§9a-ii) Lower the whole body into one ordered `Vec<LInst>` (the
+        // `encode_linst*` + per-arch-fallthrough buffer-pass guards collect
+        // instead of emitting), then drain it. The buffer is the seam the future
+        // GP physical-allocation pass slots between these two loops; today it
+        // drains immediately, so the output is byte-identical.
+        self.lir_buf = Some(Vec::new());
         for inst in ir.inst {
             #[cfg(feature = "emit-asm")]
             {
                 //eprintln!("  ; {}", inst.dump(store));
             }
             self.compile_asmir(store, frame, &side_exits, inst, class_version.clone());
+        }
+        let body = self.lir_buf.take().unwrap();
+        for inst in body {
+            match inst {
+                LInst::Inline(_) => {
+                    self.encode_linst_inline(inst, store, &side_exits, frame.base_stack_offset)
+                }
+                LInst::SourcePos { .. } => self.encode_linst_frame(inst, frame),
+                LInst::DeferredArch {
+                    inst,
+                    class_version,
+                } => {
+                    self.compile_asmir_arch(store, frame, &side_exits, inst, class_version);
+                }
+                _ => self.encode_linst(inst),
+            }
         }
 
         if let Some(exit) = exit {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1047,7 +1047,21 @@ impl Codegen {
             // `correct_rest_kw(&table, lfp) -> kwrest Hash`.
             AsmInst::RestKw { rest_kw } => self.encode_linst(LInst::RestKw { rest_kw }),
             // Not a shared instruction: hand off to the per-arch backend.
-            other => return self.compile_asmir_arch(store, frame, labels, other, class_version),
+            // (§9a-ii) Not-yet-LIR-ized arms still emit directly in the per-arch
+            // `compile_asmir_arch`. During the buffering pass, defer them as
+            // `LInst::DeferredArch` so they run at drain (correct position)
+            // rather than emitting now (which would scramble order vs. the
+            // buffered ops). Otherwise (immediate path) dispatch directly.
+            other => {
+                if let Some(buf) = self.lir_buf.as_mut() {
+                    buf.push(LInst::DeferredArch {
+                        inst: other,
+                        class_version,
+                    });
+                    return true;
+                }
+                return self.compile_asmir_arch(store, frame, labels, other, class_version);
+            }
         }
         true
     }
@@ -1069,6 +1083,11 @@ impl Codegen {
         labels: &SideExitLabels,
         base: usize,
     ) {
+        // (§9a-ii) Buffering pass: collect, don't run the generator yet.
+        if let Some(buf) = self.lir_buf.as_mut() {
+            buf.push(inst);
+            return;
+        }
         match inst {
             LInst::Inline(proc) => (proc.proc)(self, store, labels, base),
             _ => unreachable!("encode_linst_inline only handles LInst::Inline"),
@@ -1084,6 +1103,12 @@ impl Codegen {
         inst: LInst,
         frame: &mut AsmInfo,
     ) {
+        // (§9a-ii) Buffering pass: collect, don't record the position yet (the
+        // position is only meaningful at drain time, in emission order).
+        if let Some(buf) = self.lir_buf.as_mut() {
+            buf.push(inst);
+            return;
+        }
         match inst {
             LInst::SourcePos { idx } => {
                 let pos = self.jit.get_current() - frame.start_codepos;

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -42,7 +42,7 @@ impl Codegen {
             // Bind a JIT label at the current position.
             AsmInst::Label(label) => {
                 let label = frame.resolve_label(&mut self.jit, label);
-                self.jit.bind_label(label);
+                self.encode_linst(LInst::BindLabel(label));
             }
             // dst <- src
             AsmInst::RegMove(src, dst) => self.encode_linst(LInst::Mov {
@@ -1060,6 +1060,11 @@ impl Codegen {
     ///
     pub(in crate::codegen::jitgen) fn encode_linst_macro(&mut self, inst: LInst) {
         match inst {
+            // (§9 9a) Ordering pseudo-ops: reproduce the inline jit calls at
+            // drain time. Arch-neutral (pure `self.jit` ops), so they live here
+            // rather than in each backend's `encode_linst`.
+            LInst::SelectPage(page) => self.jit.select_page(page),
+            LInst::BindLabel(label) => self.jit.bind_label(label),
             LInst::LoadIVarHeap {
                 ivarid,
                 is_object_ty,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -869,17 +869,28 @@ impl Codegen {
             // Clean return / block-break out of an inlined frame.
             AsmInst::MethodRetSpecialized { rbp_offset }
             | AsmInst::BlockBreakSpecialized { rbp_offset } => {
-                self.method_return_specialized(rbp_offset.unwrap_concrete());
+                let off = rbp_offset.unwrap_concrete();
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.method_return_specialized(off);
+                });
             }
             // Outer-scope local access at a pre-resolved frame offset.
             AsmInst::LoadDynVarSpecialized { offset, reg } => {
-                self.load_dyn_var_specialized(offset.unwrap_concrete(), reg);
+                let off = offset.unwrap_concrete();
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.load_dyn_var_specialized(off, reg);
+                });
             }
             AsmInst::StoreDynVarSpecialized { offset, dst, src } => {
-                self.store_dyn_var_specialized(offset.unwrap_concrete(), dst, src);
+                let off = offset.unwrap_concrete();
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.store_dyn_var_specialized(off, dst, src);
+                });
             }
             // Direct call into an inlined method entry; the return-address patch
-            // point is recorded for BOP-redefinition eviction.
+            // point is recorded for BOP-redefinition eviction. Labels are
+            // resolved now (frame); the call + patch run at drain time, where
+            // `do_specialized_call`'s return address is the correct position.
             AsmInst::SpecializedCall {
                 entry,
                 patch_point,
@@ -888,18 +899,24 @@ impl Codegen {
                 let patch_point =
                     patch_point.map(|label| frame.resolve_label(&mut self.jit, label));
                 let entry_label = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.do_specialized_call(entry_label, patch_point);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, labels, _| {
+                    let return_addr = cg.do_specialized_call(entry_label, patch_point);
+                    cg.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                });
             }
             // Specialized `yield`: build the block frame, then branch into the
             // inlined block entry (no patch point).
             AsmInst::SetupYieldFrame { meta, outer } => {
-                self.setup_yield_frame(meta, outer);
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.setup_yield_frame(meta, outer);
+                });
             }
             AsmInst::SpecializedYield { entry, evict } => {
                 let entry_label = frame.resolve_label(&mut self.jit, entry);
-                let return_addr = self.do_specialized_call(entry_label, None);
-                self.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, labels, _| {
+                    let return_addr = cg.do_specialized_call(entry_label, None);
+                    cg.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                });
             }
             // Inlined builtin method body: lower to `LInst::Inline`, the
             // context-carrying escape hatch. Unlike every other `LInst` (which
@@ -914,12 +931,20 @@ impl Codegen {
             // `ir.inline` closures, so `AsmInst` is `Clone`). The per-arch
             // index-register setup + `array_index*` call lives in
             // `gen_array_index*`.
-            AsmInst::ArrayIndex { kind } => self.gen_array_index(kind),
+            AsmInst::ArrayIndex { kind } => {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.gen_array_index(kind);
+                });
+            }
             AsmInst::ArrayIndexAssign {
                 kind,
                 using_fpr,
                 error,
-            } => self.gen_array_index_assign(kind, using_fpr, &labels[error]),
+            } => {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, labels, _| {
+                    cg.gen_array_index_assign(kind, using_fpr, &labels[error]);
+                });
+            }
             // Typed field-load (replaces the `ir.inline` escape hatch for trivial
             // field-reader inline builtins). Goal-2 proof: an inline builtin's
             // codegen expressed once in arch-neutral LIR via an existing op.
@@ -1066,6 +1091,21 @@ impl Codegen {
             }
             _ => unreachable!("encode_linst_frame only handles frame-needing pseudo-ops"),
         }
+    }
+
+    /// (§9a) Lower a not-yet-typed family op (specialized inlined-frame ops,
+    /// `gen_array_index*`) through the `LInst::Inline` escape hatch, so every
+    /// `AsmInst` produces an `LInst`. Resolve any frame `JitLabel`s to
+    /// `DestLabel`s *before* calling — the closure runs at drain time with only
+    /// `(store, labels, base)`, exactly like the inline-builtin generators.
+    fn lower_via_inline(
+        &mut self,
+        store: &Store,
+        labels: &SideExitLabels,
+        base: usize,
+        f: impl FnOnce(&mut Codegen, &Store, &SideExitLabels, usize) + 'static,
+    ) {
+        self.encode_linst_inline(LInst::Inline(InlineProcedure::new(f)), store, labels, base);
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -36,8 +36,7 @@ impl Codegen {
         match inst {
             // Source-position record (no machine code).
             AsmInst::BcIndex(i) => {
-                let pos = self.jit.get_current() - frame.start_codepos;
-                frame.sourcemap.push((i, pos));
+                self.encode_linst_frame(LInst::SourcePos { idx: i }, frame);
             }
             // Bind a JIT label at the current position.
             AsmInst::Label(label) => {
@@ -1048,6 +1047,24 @@ impl Codegen {
         match inst {
             LInst::Inline(proc) => (proc.proc)(self, store, labels, base),
             _ => unreachable!("encode_linst_inline only handles LInst::Inline"),
+        }
+    }
+
+    /// (§9 9a) Drain a frame-needing ordering pseudo-op. Unlike `encode_linst`
+    /// (frameless) and `encode_linst_inline` (`store`/`labels`/`base`), this
+    /// reproduces the position-metadata side effects that read/write the frame.
+    /// It is the frame-aware seam the whole-region buffering will route through.
+    pub(in crate::codegen::jitgen) fn encode_linst_frame(
+        &mut self,
+        inst: LInst,
+        frame: &mut AsmInfo,
+    ) {
+        match inst {
+            LInst::SourcePos { idx } => {
+                let pos = self.jit.get_current() - frame.start_codepos;
+                frame.sourcemap.push((idx, pos));
+            }
+            _ => unreachable!("encode_linst_frame only handles frame-needing pseudo-ops"),
         }
     }
 

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -287,7 +287,7 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
 /// which is move-only. `LInst`s are produced, encoded once, and dropped, so a
 /// clone is never needed.
 #[derive(Debug)]
-pub(in crate::codegen::jitgen) enum LInst {
+pub(in crate::codegen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
     /// (§9 9b) carries virtual GP registers; the encoder resolves them.
     Mov {
@@ -991,6 +991,15 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// variant can eventually go away) is the "express inline-builtin codegen
     /// once" goal (`doc/lir.md` §8).
     Inline(super::asmir::InlineProcedure),
+    /// (§9a-ii) A not-yet-LIR-ized `AsmInst` whose per-arch lowering
+    /// (`compile_asmir_arch`) still emits directly via `monoasm!`. Buffered
+    /// verbatim and re-dispatched to `compile_asmir_arch` at drain — where the
+    /// frame is in hand — so its direct emission lands at the correct position
+    /// in the one ordered stream (rather than during the buffering pass).
+    DeferredArch {
+        inst: super::asmir::AsmInst,
+        class_version: DestLabel,
+    },
 }
 
 /// A straight-line sequence of `LInst`s produced by lowering one (or more)

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -974,6 +974,13 @@ pub(in crate::codegen::jitgen) enum LInst {
     /// (§9 9a) Ordering pseudo-op: bind a `DestLabel` at the current emission
     /// position (reproduces `self.jit.bind_label(label)` at drain time).
     BindLabel(DestLabel),
+    /// (§9 9a) Ordering pseudo-op: record a source-position entry for `idx` at
+    /// the current emission position (reproduces `AsmInst::BcIndex`'s
+    /// `frame.sourcemap.push((idx, cur - start))`). Needs the frame, so it is
+    /// drained through the frame-aware `encode_linst_frame`, not `encode_linst`.
+    SourcePos {
+        idx: BcIndex,
+    },
     /// Inlined-builtin escape hatch: an opaque generator closure that emits the
     /// arch-appropriate asm directly. Unlike every other `LInst` (which is
     /// store-free and lowered by `encode_linst`), its emit needs the compile

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -966,6 +966,14 @@ pub(in crate::codegen::jitgen) enum LInst {
         loop_jit_spill_bytes: usize,
         base: usize,
     },
+    /// (§9 9a) Ordering pseudo-op: select the hot (0) / cold (1) emission page.
+    /// Emits no machine code of its own; reproduces `self.jit.select_page(n)` at
+    /// drain time so page selection is part of the single ordered LIR stream the
+    /// future allocation pass walks.
+    SelectPage(usize),
+    /// (§9 9a) Ordering pseudo-op: bind a `DestLabel` at the current emission
+    /// position (reproduces `self.jit.bind_label(label)` at drain time).
+    BindLabel(DestLabel),
     /// Inlined-builtin escape hatch: an opaque generator closure that emits the
     /// arch-appropriate asm directly. Unlike every other `LInst` (which is
     /// store-free and lowered by `encode_linst`), its emit needs the compile


### PR DESCRIPTION
Carries the §9a step of the `AsmIr → LIR` two-phase pipeline (`doc/lir.md` §9) to completion: a region's whole body is now lowered into one ordered `Vec<LInst>` and drained, establishing the seam the future GP physical-allocation pass (§9d) slots between buffering and draining. Today it drains immediately, so every commit is **byte-identical**.

## Commits
1. **`reify page-select / label-bind as ordering pseudo-ops`** — `LInst::SelectPage` / `LInst::BindLabel` route the inline `jit.select_page` / `bind_label` through `encode_linst` so page/label ordering joins the LIR stream.
2. **`reify the source-position record as an ordering pseudo-op`** — `LInst::SourcePos` + a frame-aware drain seam `encode_linst_frame` (the sourcemap push needs the frame).
3. **`lower the last direct-emit families through LInst::Inline`** — the seven specialized inlined-frame / `gen_array_index*` arms in the *shared* `compile_asmir` now lower through the `LInst::Inline` escape hatch (via a new `InlineProcedure::new`), so all shared-match arms produce an `LInst`.
4. **`buffer the whole region body into one ordered LInst stream`** — `gen_asm` buffers a block's body into `Codegen::lir_buf` and drains it. The catch was the per-arch fallthrough: ~137 arms still emit directly in `compile_asmir_arch`, bypassing `encode_linst`. A naive buffering let them emit *during* the pass, scrambling order and miscompiling control flow (the non-opt optcarrot PPU fiber terminated early). Fix: `LInst::DeferredArch` carries such an `AsmInst` verbatim and the drain re-dispatches it to `compile_asmir_arch` at the correct position. Migrating those arms to typed LIR stays the long-term §6/§8 goal; they buffer fine as opaque deferred blocks (fixed/pinned regs, no allocation needed).

## Validation (byte-identical, every commit)
- `cargo test --features gc-stress`: **1716/0**.
- optcarrot `--debug` **and** `--opt` both match CRuby (the `--debug` fiber path is exactly what the naive buffering broke — it is the regression gate here).
- mandelbrot JIT == `--no-jit`; error-backtrace line numbers intact.
- aarch64 (`aarch64-unknown-linux-gnu`) cross-build clean; qemu `app_fib` matches CRuby.

## Next
§9c (thread the ① fixpoint's liveness onto the buffer) + §9d (the GP physical-allocation pass over the buffered LIR: slot-as-virtual-GP, cross-merge register retention via a GP-extended `bridge`, call-clobber spills, then retire the abstract-interp `GpAllocator`) build on this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_