### PR TITLE
jit: make the GP-pool allocator standard (remove the `gp-alloc` feature)

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -16,15 +16,11 @@ drop_last3() { awk 'NR>3{print buf[NR%3]} {buf[NR%3]=$0}'; }
 RUBY=(ruby --yjit)
 
 # stress-spill-pool / gc-stress amplify the JIT's spill + GC paths and run on
-# every arch. `gp-alloc` (the GP-register pool allocator) is only enabled on
-# x86-64: on the AArch64 JIT it still intermittently diverges on
-# `optcarrot --opt` under gc-stress (reproducible on the macOS CI runner, though
-# not on a local M1 or qemu-aarch64), so keep it off there until the aarch64
-# pool path is fixed.
-case "$(uname -m)" in
-  x86_64) STRESS_FEATURES=(--features stress-spill-pool,gc-stress,gp-alloc) ;;
-  *)      STRESS_FEATURES=(--features stress-spill-pool,gc-stress) ;;
-esac
+# every arch. The GP-register pool allocator is now standard (always compiled);
+# on the AArch64 JIT its pool is empty (`GP_ALLOC_POOL = &[]`), so it is inert
+# there — no pool allocation happens, which sidesteps the macOS-runner
+# `optcarrot --opt` divergence that the (non-empty) aarch64 pool path used to hit.
+STRESS_FEATURES=(--features stress-spill-pool,gc-stress)
 
 # Coverage wrappers. SKIP_COV=1 runs the whole script without llvm-cov
 # instrumentation and uploads nothing. Used by the arm64 macOS `darwin` job:

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -18,7 +18,7 @@ name = "irm"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["gp-alloc"]
+default = []
 dump-bc = []
 dump-traceir = []
 emit-asm = ["dump-bc", "dump-traceir", "jit-log"]
@@ -64,23 +64,15 @@ phys-table = []
 # `shadow-placement` digest becomes a *delta* meter, not an equality check, and
 # the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
 phys-loop-aware = []
-# §9 9d-B: the GP register allocator. Tracks slots resident in the allocatable
-# pool (x86-64 r8-r11) in `gp_alloc` (the `fpr_alloc` analogue), colours
-# `VReg::Alloc` ids into pool registers (spilling under pressure), and spills
-# pool registers live across C-ABI calls. NON-byte-identical once it places a
-# slot; default-off until the M1 A/B bench gate clears (cf. phys-loop-aware §42).
-gp-alloc = []
-# §9 9d-2: move the GP-pool allocation *decision* out of the abstract
-# interpreter (`gp-alloc`) into the LIR pass (`gp_alloc::allocate`, run from
-# `allocate_gp`). Builds live ranges + a pool-clobber map over the buffered
-# `LInst` stream and linear-scan-assigns `VReg::Alloc` ids to pool registers,
-# so cross-merge register retention (keeping a value resident past a boundary
-# the front-end currently flushes at) becomes expressible at the LIR layer.
-# Implies `gp-alloc` (it re-colours the ids that allocator emits). The machinery
-# step is byte-identical (the LIR scan reproduces a valid assignment); the perf
-# step that relaxes the front-end flush is NON-byte-identical and gated on the
-# M1 A/B bench (x86 `bin/bench` A/B as the proxy here). Default-off.
-gp-alloc-lir = ["gp-alloc"]
+# §9 9d-2: cross-merge GP register retention in the LIR pass (`gp_alloc::allocate`,
+# run from `allocate_gp`). The GP register allocator itself (the allocatable pool
+# `r8`-`r11` tracked in `gp_alloc`, the `fpr_alloc` analogue) is now standard —
+# always compiled; on aarch64 the pool is empty (`GP_ALLOC_POOL = &[]`) so it is
+# inert. This feature additionally lets a pool resident stay in its register
+# across a control-flow edge (fall-through, forward branch, loop back-edge)
+# instead of flushing at the boundary. NON-byte-identical once it retains;
+# default-off until the M1 A/B bench gate clears (cf. phys-loop-aware §42).
+gp-alloc-lir = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -2209,7 +2209,7 @@ impl Codegen {
         self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::executor::execute_gc as *const () as u64;
         // Preserve the GP-alloc pool (x5-x8 = GP::R8-R11) across the call. They
-        // are AAPCS64 caller-saved and hold live Values under `gp-alloc`. The
+        // are AAPCS64 caller-saved and hold live pool Values. The
         // write-back above spills them to their frame homes for GC marking, but
         // the post-GC code keeps reading the *registers* (e.g. a pool-resident
         // call receiver), so they must survive `execute_gc`. x86 preserves
@@ -2217,7 +2217,6 @@ impl Codegen {
         // The GC is mark-and-sweep (non-moving), so a heap value the write-back
         // kept alive is not relocated and restoring the raw register value is
         // correct (Fixnum immediates are trivially fine for the same reason).
-        #[cfg(feature = "gp-alloc")]
         monoasm_arm64!(&mut self.jit,
             stp x5, x6, [sp, #-16]!;
             stp x7, x8, [sp, #-16]!;
@@ -2230,7 +2229,6 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
-        #[cfg(feature = "gp-alloc")]
         monoasm_arm64!(&mut self.jit,
             ldp x7, x8, [sp], #16;
             ldp x5, x6, [sp], #16;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -147,7 +147,7 @@ pub(crate) struct WriteBack {
     /// §9 9d-B: slots resident in the allocatable GP pool (x86-64 `r8`–`r11`),
     /// each paired with the physical register holding it. Written back to the
     /// slot's frame home at every flush / deopt / GC safepoint. Empty until
-    /// the GP allocator (the `gp-alloc` feature) places a slot, so shipping
+    /// the GP allocator places a pool slot, so shipping
     /// builds carry an always-empty vec and emit byte-identical code.
     gp: Vec<(GP, SlotId)>,
     /// Deferred forwarding-rest materialization (D1). Each entry

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -98,7 +98,7 @@ impl<'a> JitContext<'a> {
                     // into a loop header — can inherit the pool register, so skip
                     // the flush. The loop-entry merge and the fixpoint keep or
                     // reconcile the binding (`bridge`).
-                    #[cfg(all(feature = "gp-alloc", not(feature = "gp-alloc-lir")))]
+                    #[cfg(not(feature = "gp-alloc-lir"))]
                     state.flush_pool(&mut ir);
                     self.new_branch(bc_pos, dest_bb, state);
                     return Ok(ir);
@@ -147,7 +147,7 @@ impl<'a> JitContext<'a> {
             // pool binding, `bridge` reconciles a disagreement), so a fall-through
             // successor can inherit the pool register instead of reloading — skip
             // the flush and let the merge retain or write back as needed.
-            #[cfg(all(feature = "gp-alloc", not(feature = "gp-alloc-lir")))]
+            #[cfg(not(feature = "gp-alloc-lir"))]
             state.flush_pool(&mut ir);
             self.prepare_next(state, end)
         }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -797,7 +797,7 @@ impl<'a> JitContext<'a> {
         // boundary (ToA, ConcatStr, ConcatRegexp, ExpandArray, the generic
         // binop/cmp fallbacks, …); the inline-method path was the one gap.
         // Manifested as an aarch64-only optcarrot `--opt` divergence at frame
-        // 34 under `--features gp-alloc`. No-op when the pool is empty. Done
+        // 34 with a non-empty GP pool. No-op when the pool is empty (aarch64). Done
         // before the save/restore snapshot so the spill is permanent whether or
         // not `f` succeeds (on bail the caller falls back to the full call,
         // which re-flushes — a no-op by then).

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -278,7 +278,6 @@ impl AbstractFrame {
             // fires there). Any value type may go to the pool (it is GC-rooted
             // at every safepoint). With the R15 accumulator retired, a value
             // that gets no pool register is stored straight to its stack home.
-            #[cfg(feature = "gp-alloc")]
             if let Some(vreg) = self.try_def_G_pool(dst, guarded) {
                 ir.reg_move(src, vreg.phys());
                 return;

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -350,7 +350,6 @@ impl AbstractFrame {
             self.guard_fixnum(ir, lhs, reg);
             return reg;
         }
-        #[cfg(feature = "gp-alloc")]
         if let Some(id) = self.try_vacant_pool_id() {
             let reg = crate::codegen::GP_ALLOC_POOL[id];
             self.load(ir, lhs, reg);
@@ -367,7 +366,6 @@ impl AbstractFrame {
     /// immediate into the result register): a vacant pool register under
     /// gp-alloc, else the freed R15 accumulator.
     pub(in crate::codegen::jitgen) fn alloc_inplace_reg(&mut self, _ir: &mut AsmIr) -> GP {
-        #[cfg(feature = "gp-alloc")]
         if let Some(id) = self.try_vacant_pool_id() {
             return crate::codegen::GP_ALLOC_POOL[id];
         }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -251,7 +251,6 @@ impl FprAllocator {
 ///
 /// B2.1 establishes the table; the placement policy (B2.2) and codegen (B2.3)
 /// populate and consume it. Inert until then — no `Alloc` VRegs are emitted.
-#[cfg(feature = "gp-alloc")]
 #[allow(dead_code)]
 #[derive(Clone, Default)]
 pub(super) struct GpAllocator {
@@ -260,7 +259,6 @@ pub(super) struct GpAllocator {
     pinned: Vec<VReg>,
 }
 
-#[cfg(feature = "gp-alloc")]
 #[allow(dead_code)]
 impl GpAllocator {
     fn new() -> Self {
@@ -341,7 +339,6 @@ pub(crate) struct SlotState {
     fpr_alloc: FprAllocator,
     /// §9 9d-B: GP-pool allocation state (the `fpr_alloc` analogue). Inert in
     /// B2.1; populated by the allocator (B2.2+).
-    #[cfg(feature = "gp-alloc")]
     gp_alloc: GpAllocator,
     local_num: usize,
     /// D1 forwarding-rest deferral (transient annotation; see the consumers).
@@ -382,7 +379,6 @@ impl SlotState {
             ty: vec![default_ty; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
             fpr_alloc: FprAllocator::new(),
-            #[cfg(feature = "gp-alloc")]
             gp_alloc: GpAllocator::new(),
             local_num,
             deferred_rest: None,
@@ -705,10 +701,7 @@ impl SlotState {
                     unreachable!("R15 accumulator retired; slot residence is pool-only")
                 }
                 VReg::Alloc(_id) => {
-                    #[cfg(feature = "gp-alloc")]
                     self.gp_alloc.remove(slot, _id as usize);
-                    #[cfg(not(feature = "gp-alloc"))]
-                    unreachable!("Alloc VReg without the gp-alloc feature");
                 }
             },
             LinkMode::C(_) => {}
@@ -1012,10 +1005,7 @@ impl SlotState {
                         unreachable!("R15 accumulator retired; slot residence is pool-only")
                     }
                     VReg::Alloc(_id) => {
-                        #[cfg(feature = "gp-alloc")]
                         self.gp_alloc.remove(slot, _id as usize);
-                        #[cfg(not(feature = "gp-alloc"))]
-                        unreachable!("Alloc VReg without the gp-alloc feature");
                     }
                 }
                 self.set_mode(slot, LinkMode::S(guarded));
@@ -1273,7 +1263,6 @@ impl SlotState {
     /// caller-saved spill/reload threading (`using_gp`) the way the FP side
     /// does: the flush already wrote it back. Empty until the placement policy
     /// puts a slot in the pool.
-    #[cfg(feature = "gp-alloc")]
     fn writeback_pool_state(&mut self) -> Vec<(GP, SlotId)> {
         let mut out = vec![];
         for slot in self.all_regs() {
@@ -1294,7 +1283,6 @@ impl SlotState {
     /// full. Used by the in-place fixnum-binop path to keep the result resident
     /// in the pool (so later reads avoid a stack reload), the move-free analogue
     /// of `try_def_G_pool`.
-    #[cfg(feature = "gp-alloc")]
     pub(crate) fn try_vacant_pool_id(&self) -> Option<usize> {
         self.gp_alloc.find_vacant()
     }
@@ -1310,7 +1298,6 @@ impl SlotState {
             ir.reg2stack(GP::R15, dst);
             self.set_mode(dst, LinkMode::S(Guarded::Fixnum));
         } else {
-            #[cfg(feature = "gp-alloc")]
             {
                 let id = crate::codegen::GP_ALLOC_POOL
                     .iter()
@@ -1319,8 +1306,6 @@ impl SlotState {
                 self.set_mode(dst, LinkMode::G(Guarded::Fixnum, VReg::Alloc(id as u32)));
                 self.gp_alloc.add(dst, id);
             }
-            #[cfg(not(feature = "gp-alloc"))]
-            unreachable!("pool register without the gp-alloc feature");
         }
     }
 
@@ -1335,7 +1320,6 @@ impl SlotState {
     /// home so the collector marks it, and the `execute_gc` stub preserves the
     /// pool registers across the call. The GC is mark-and-sweep (non-moving),
     /// so the preserved raw pointer stays valid for a heap value that survived.
-    #[cfg(feature = "gp-alloc")]
     #[allow(non_snake_case)]
     pub(in crate::codegen::jitgen) fn try_def_G_pool(
         &mut self,
@@ -1355,17 +1339,14 @@ impl SlotState {
     /// a merged successor never sees a pool-resident slot (the merge machinery
     /// is R15-only). The R15 accumulator is left untouched.
     ///
-    /// Unconditional so callers need no `cfg` gate: without the `gp-alloc`
-    /// feature the pool is always empty, so this is a no-op.
+    /// A no-op where the pool is empty (e.g. aarch64, `GP_ALLOC_POOL = &[]`).
     pub(crate) fn flush_pool(&mut self, _ir: &mut AsmIr) {
-        #[cfg(feature = "gp-alloc")]
         for (reg, slot) in self.writeback_pool_state() {
             _ir.reg2stack(reg, slot);
         }
     }
 
     pub(crate) fn writeback_acc(&mut self, _ir: &mut AsmIr) {
-        #[cfg(feature = "gp-alloc")]
         for (reg, slot) in self.writeback_pool_state() {
             _ir.reg2stack(reg, slot);
         }
@@ -1429,14 +1410,11 @@ impl SlotState {
                     VReg::Pinned(_) => {
                         unreachable!("R15 accumulator retired; slot residence is pool-only")
                     }
-                    #[cfg(feature = "gp-alloc")]
                     VReg::Alloc(id) => {
                         self.discard(dst);
                         self.set_mode(dst, LinkMode::G(guarded, vreg));
                         self.gp_alloc.add(dst, id as usize);
                     }
-                    #[cfg(not(feature = "gp-alloc"))]
-                    VReg::Alloc(_) => unreachable!("Alloc VReg without the gp-alloc feature"),
                 }
             }
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {
@@ -1591,10 +1569,7 @@ impl AbstractFrame {
         // capturable, so no heap snapshot observes it pre-consume.
         let literal = self.wb_literal(|_| true);
         let void = self.wb_void();
-        #[cfg(feature = "gp-alloc")]
         let gp = self.wb_gp(|_| true);
-        #[cfg(not(feature = "gp-alloc"))]
-        let gp = vec![];
         WriteBack::new(vec![], literal, void, gp, vec![])
     }
 
@@ -1602,10 +1577,7 @@ impl AbstractFrame {
         let f = |_| true;
         let fpr = self.wb_fpr(f);
         let literal = self.wb_literal(f);
-        #[cfg(feature = "gp-alloc")]
         let gp = self.wb_gp(f);
-        #[cfg(not(feature = "gp-alloc"))]
-        let gp = vec![];
         WriteBack::new(fpr, literal, vec![], gp, self.wb_forward_rest())
     }
 
@@ -1677,7 +1649,6 @@ impl AbstractFrame {
     /// §9 9d-B: collect the slots resident in the allocatable GP pool
     /// (`VReg::Alloc`), each paired with its physical pool register. Empty until
     /// the allocator places a slot in the pool.
-    #[cfg(feature = "gp-alloc")]
     fn wb_gp(&self, f: impl Fn(SlotId) -> bool) -> Vec<(GP, SlotId)> {
         self.all_regs()
             .filter_map(|idx| match self.mode(idx) {


### PR DESCRIPTION
## Overview

Promotes the eager GP-pool register allocator to **standard** by removing the `gp-alloc` cargo feature and compiling its paths unconditionally.

Rationale: `gp-alloc` was already `default`-on for x86-64 and was validated on Apple Silicon (the M1 `bin/test --features gp-alloc-lir` run, which pulls `gp-alloc` in, completed). So making it always-on is a no-op for the actually-shipped configurations.

## Changes

- **Cargo.toml**: drop the `gp-alloc` feature and `default = ["gp-alloc"]`; `gp-alloc-lir` no longer needs to imply it (`gp-alloc-lir = []`).
- **Source**: delete every `#[cfg(feature = "gp-alloc")]` gate (code always compiled) and the now-dead `#[cfg(not(feature = "gp-alloc"))]` fallback branches; the two `all(feature = "gp-alloc", not(feature = "gp-alloc-lir"))` gates become `not(feature = "gp-alloc-lir")`. Stale doc comments updated.
- **bin/test**: `gp-alloc` drops out of `STRESS_FEATURES` (now identical on both arches). On aarch64 the pool is empty (`GP_ALLOC_POOL = &[]`), so the allocator is **inert** there — no pool allocation happens, which sidesteps the macOS-runner `optcarrot --opt` divergence the non-empty aarch64 pool used to hit.

## Behaviour

- **x86-64**: same (already-default) codegen — byte-identical / unchanged.
- **aarch64**: stays inert via the empty pool (always compiled, nothing allocated).

## Validation

- default build + `--features gp-alloc-lir` + aarch64 cross-build — all clean, no `unexpected cfg` warnings
- lib **1716 + 86** and all integration tests pass
- mandelbrot + optcarrot `--opt` match CRuby; mandelbrot / nbody / fib JIT == `--no-jit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_