### PR TITLE
ci: run the Rust workflow for the `gpalloc` branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [master, "darwin*"]
+    branches: [master, gpalloc, "darwin*"]
   pull_request:
-    branches: [master, "darwin*"]
+    branches: [master, gpalloc, "darwin*"]
 
 jobs:
   amd64:


### PR DESCRIPTION
## Summary

The gp-alloc / slot-IR work lives on the long-lived `gpalloc` branch rather than `master`, but `.github/workflows/rust.yml` only triggers on `master` / `darwin*`. As a result PRs targeting `gpalloc` (e.g. #760) get **no CI**.

Add `gpalloc` to both the `push` and `pull_request` branch filters so `gpalloc` pushes and PRs into `gpalloc` run the same Linux (x86-64) + macOS (AArch64) checks before the work is rolled up into `master`.

```yaml
on:
  push:
    branches: [master, gpalloc, "darwin*"]
  pull_request:
    branches: [master, gpalloc, "darwin*"]
```

> Note: GitHub evaluates the `pull_request.branches` filter against the workflow file **on the base branch**, so this takes effect for *subsequent* `gpalloc` PRs once this merges — it won't retroactively run CI on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_