### PR TITLE
jit: per-BB local GP register allocator (gp-alloc-lir)

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cargo build --release && mv target/release/monoruby /tmp/master
-cargo build --release --features gp-alloc && mv target/release/monoruby /tmp/alloc
-cd benchmark && benchmark-driver -o markdown app_fib.yml so_nbody.yml so_mandelbrot.yml app_aobench.rb bf.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb -e /tmp/master -e /tmp/alloc
+#cargo build --release --features gp-alloc && mv target/release/monoruby /tmp/alloc
+cd benchmark && benchmark-driver -o markdown app_fib.yml so_nbody.yml so_mandelbrot.yml app_aobench.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb -e /tmp/master --rbenv '4.0.5 --yjit; 4.0.5 --zjit'
 # cd benchmark && benchmark-driver -o markdown quick_sort.yaml app_fib.yml tarai.rb so_mandelbrot.yml so_nbody.yml app_aobench.rb bf.rb plb2/nqueen.rb plb2/sudoku.rb plb2/matmul.rb plb2/bedcov.rb --rbenv '3.4.1 --yjit; truffleruby-24.1.1' -e ../target/release/monoruby
 # benchmark-driver -o markdown benchmark/app_fib.yml benchmark/so_mandelbrot.yml benchmark/so_nbody.yml --rbenv '3.4.0-preview1 --yjit' -e target/release/monoruby

--- a/bin/doom
+++ b/bin/doom
@@ -1,1 +1,1 @@
-cargo run --features jit-log,gc-log,stress-spill-pool,gc-stress,gp-alloc -- ../doom/bin/doom
+cargo run --features jit-log,gc-log,stress-spill-pool,gc-stress -- ../doom/bin/doom

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -564,10 +564,10 @@ Notes:
   registers are caller-saved, so a Fixnum left resident there would otherwise be
   clobbered by the helper's C call (e.g. `String#clear`'s `bytesize` in `r8`,
   clobbered by the `""` literal's `value_deep_copy`). The asmir builders that take
-  `&AbstractFrame` (immutable, so they cannot flush) get an explicit `flush_pool`
+  `&AbstractFrame` (immutable, so they cannot flush) get an explicit `flush_gp`
   in their handler instead.
 - Branch-merge reconciliation needs no special pool handling: pool residents are
-  flushed (→ `S`) before any branch (the compile-loop `flush_pool` and the
+  flushed (→ `S`) before any branch (the compile-loop `flush_gp` and the
   back-edge analysis G→S demotion), so a merge never sees a `G(_, Alloc)` slot.
 
 ### 9d outcome: GP register residency does not pay; the untagged-Fixnum direction does

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -64,13 +64,6 @@ phys-table = []
 # `shadow-placement` digest becomes a *delta* meter, not an equality check, and
 # the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
 phys-loop-aware = []
-# Per-basic-block local GP register allocator (doc/regalloc_separation.md §3 /
-# `jitgen::gp_alloc`). When on, fixnum `IntegerBinOp` keeps operands/results in
-# GP registers (`r8`–`r11`) across consecutive binops; every other instruction
-# flushes the live GP residents back to their stack homes up front, so only
-# `IntegerBinOp` is GP-aware for now. Default-off until the perf A/B gate clears;
-# the shipping build stays bit-identical.
-gp-local-alloc = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -64,6 +64,13 @@ phys-table = []
 # `shadow-placement` digest becomes a *delta* meter, not an equality check, and
 # the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
 phys-loop-aware = []
+# Per-basic-block local GP register allocator (doc/regalloc_separation.md §3 /
+# `jitgen::gp_alloc`). When on, fixnum `IntegerBinOp` keeps operands/results in
+# GP registers (`r8`–`r11`) across consecutive binops; every other instruction
+# flushes the live GP residents back to their stack homes up front, so only
+# `IntegerBinOp` is GP-aware for now. Default-off until the perf A/B gate clears;
+# the shipping build stays bit-identical.
+gp-local-alloc = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -53,7 +53,6 @@ pub(super) fn gen_class_allocate_inline(
         None => return false,
     };
     let CallSiteInfo { dst, .. } = *callsite;
-    state.writeback_acc(ir);
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
     ir.inline(move |r#gen, _, _, _| {
@@ -406,7 +405,6 @@ pub(super) fn gen_class_new_inline(
     } else {
         Some(callid)
     };
-    state.writeback_acc(ir);
     state.load(ir, recv, GP::Rdi);
     state.write_back_recv_and_callargs(ir, callsite);
     let using_fpr = state.get_using_fpr(ir);
@@ -580,7 +578,6 @@ pub(super) fn gen_class_new_inline(
     if args_off > 4095 {
         return false;
     }
-    state.writeback_acc(ir);
     state.load(ir, recv, GP::Rdi);
     state.write_back_recv_and_callargs(ir, callsite);
     let using_fpr = state.get_using_fpr(ir);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2978,7 +2978,6 @@ pub fn object_send(
     }
 
     state.write_back_recv_and_callargs(ir, callsite);
-    state.writeback_acc(ir);
     let using_fpr = state.get_using_fpr(ir);
     let error = ir.new_error(state);
     let callid = callsite.id;

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -360,57 +360,22 @@ impl Codegen {
     /// overflow of the tagged arithmetic == fixnum overflow, so we branch to
     /// `deopt` on the V flag. Result is left in `lhs`'s register, mirroring x86
     /// `integer_binop`. Mul/Div/etc. not yet ported (bail).
-    fn a64_integer_binop(
-        &mut self,
-        lhs: GP,
-        rhs: GP,
-        mode: &OpMode,
-        kind: BinOpK,
-        deopt: &DestLabel,
-    ) -> bool {
+    fn a64_integer_binop(&mut self, lhs: GP, rhs: GP, kind: BinOpK, deopt: &DestLabel) -> bool {
         let l = lhs.a64().0;
         let r = rhs.a64().0;
         match kind {
             BinOpK::Add => {
-                match mode {
-                    OpMode::RR(..) => monoasm_arm64!(&mut self.jit,
-                        sub x(l), x(l), #(1u32);
-                        adds x(l), x(l), x(r);
-                    ),
-                    OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                        let imm = Value::i32(*i as i32).id().wrapping_sub(1);
-                        monoasm_arm64!(&mut self.jit,
-                            mov x9, (imm);
-                            adds x(l), x(l), x9;
-                        );
-                    }
-                }
+                monoasm_arm64!(&mut self.jit,
+                    sub x(l), x(l), #(1u32);
+                    adds x(l), x(l), x(r);
+                );
                 self.jit.bcond_label(monoasm::Cond::Vs, deopt);
             }
-            BinOpK::Sub => match mode {
-                OpMode::RR(..) => {
-                    monoasm_arm64!(&mut self.jit, subs x(l), x(l), x(r););
-                    self.jit.bcond_label(monoasm::Cond::Vs, deopt);
-                    monoasm_arm64!(&mut self.jit, add x(l), x(l), #(1u32););
-                }
-                OpMode::RI(_, rhs_i) => {
-                    let imm = Value::i32(*rhs_i as i32).id().wrapping_sub(1);
-                    monoasm_arm64!(&mut self.jit,
-                        mov x9, (imm);
-                        subs x(l), x(l), x9;
-                    );
-                    self.jit.bcond_label(monoasm::Cond::Vs, deopt);
-                }
-                OpMode::IR(lhs_i, _) => {
-                    let imm = Value::i32(*lhs_i as i32).id();
-                    monoasm_arm64!(&mut self.jit,
-                        mov x(l), (imm);
-                        subs x(l), x(l), x(r);
-                    );
-                    self.jit.bcond_label(monoasm::Cond::Vs, deopt);
-                    monoasm_arm64!(&mut self.jit, add x(l), x(l), #(1u32););
-                }
-            },
+            BinOpK::Sub => {
+                monoasm_arm64!(&mut self.jit, subs x(l), x(l), x(r););
+                self.jit.bcond_label(monoasm::Cond::Vs, deopt);
+                monoasm_arm64!(&mut self.jit, add x(l), x(l), #(1u32););
+            }
             // Mul: compute `2a * b` (matching x86's `imul` on the half-untagged
             // lhs). aarch64 has no `smulh`, so detect overflow with a checking
             // `sdiv`: if `2a != 0` and `(2a*b)/(2a) != b` the product wrapped.
@@ -419,19 +384,10 @@ impl Codegen {
             // high half (`smulh`) must equal the sign-extension of the low half
             // (`low >> 63`); a mismatch means the product wrapped.
             BinOpK::Mul => {
-                match mode {
-                    OpMode::RR(..) => monoasm_arm64!(&mut self.jit,
-                        asr x(r), x(r), #(1u32);   // b (untagged)
-                        sub x(l), x(l), #(1u32);   // 2a
-                    ),
-                    OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                        let imm = *i as i64 as u64; // raw multiplier
-                        monoasm_arm64!(&mut self.jit,
-                            mov x(r), (imm);
-                            sub x(l), x(l), #(1u32);
-                        );
-                    }
-                }
+                monoasm_arm64!(&mut self.jit,
+                    asr x(r), x(r), #(1u32);   // b (untagged)
+                    sub x(l), x(l), #(1u32);   // 2a
+                );
                 monoasm_arm64!(&mut self.jit, mul x9, x(l), x(r);); // low 64
                 monoasm_arm64!(&mut self.jit, smulh x10, x(l), x(r););
                 monoasm_arm64!(&mut self.jit,
@@ -740,23 +696,10 @@ impl Codegen {
 
     /// Compare two tagged fixnums (the tag preserves order). Mirrors x86
     /// `cmp_integer`.
-    fn a64_cmp_integer(&mut self, mode: &OpMode, lhs: GP, rhs: GP) {
+    fn a64_cmp_integer(&mut self, lhs: GP, rhs: GP) {
         let l = lhs.a64().0;
-        match mode {
-            OpMode::RR(..) => {
-                let r = rhs.a64().0;
-                monoasm_arm64!(&mut self.jit, cmp x(l), x(r););
-            }
-            OpMode::RI(_, i) => {
-                let imm = Value::i32(*i as i32).id();
-                monoasm_arm64!(&mut self.jit, mov x9, (imm); cmp x(l), x9;);
-            }
-            OpMode::IR(i, _) => {
-                let r = rhs.a64().0;
-                let imm = Value::i32(*i as i32).id();
-                monoasm_arm64!(&mut self.jit, mov x(l), (imm); cmp x(l), x(r););
-            }
-        }
+        let r = rhs.a64().0;
+        monoasm_arm64!(&mut self.jit, cmp x(l), x(r););
     }
 
     /// After `a64_cmp_integer`, materialize a Ruby boolean in rax (x0):
@@ -1803,12 +1746,11 @@ impl Codegen {
             // Fixnum fast-path arithmetic with an overflow deopt.
             LInst::IntegerBinOp {
                 kind,
-                mode,
                 lhs,
                 rhs,
                 deopt,
             } => {
-                self.a64_integer_binop(lhs, rhs, &mode, kind, &deopt);
+                self.a64_integer_binop(lhs, rhs, kind, &deopt);
             }
             // Fixnum unary negate (tagged); deopt on i63 overflow.
             LInst::FixnumNeg { reg, deopt } => {
@@ -2688,11 +2630,10 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_integer_cmp(
         &mut self,
         kind: CmpKind,
-        mode: OpMode,
         lhs: GP,
         rhs: GP,
     ) -> bool {
-        self.a64_cmp_integer(&mode, lhs, rhs);
+        self.a64_cmp_integer(lhs, rhs);
         self.a64_flag_to_bool(kind);
         true
     }

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3143,6 +3143,7 @@ impl Codegen {
         ivarid: IvarId,
         is_object_ty: bool,
         self_: bool,
+        dst: GP,
     ) -> bool {
         let ivar = ivarid.get() as u32;
         let idx = if is_object_ty {
@@ -3152,7 +3153,7 @@ impl Codegen {
         };
         let off = idx * 8;
         let rdi = GP::Rdi.a64().0;
-        let r15 = GP::R15.a64().0;
+        let dst = dst.a64().0;
         let nil = self.jit.label();
         let exit = self.jit.label();
         monoasm_arm64!(&mut self.jit,
@@ -3169,11 +3170,11 @@ impl Codegen {
             self.jit.bcond_label(monoasm::Cond::Le, &nil);   // len <= idx -> nil
         }
         monoasm_arm64!(&mut self.jit, ldr x9, [x9, #(MONOVEC_PTR as u32)];); // data ptr
-        self.a64_field_load(r15, 9, off);                    // value
+        self.a64_field_load(dst, 9, off);                    // value
         monoasm_arm64!(&mut self.jit,
-            cbnz x(r15), exit;                               // set -> exit
+            cbnz x(dst), exit;                               // set -> exit
         nil:
-            mov x(r15), (NIL_VALUE);
+            mov x(dst), (NIL_VALUE);
         exit:
         );
         true

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -422,7 +422,22 @@ impl Codegen {
                     add x(rax), x(rax), #(1u32); // 2q+1 (tagged)
                 );
             }
-            // Rem/bit-ops are compiled as method calls, never IntegerBinOp
+            // Bitwise ops on tagged fixnums need no overflow check and never
+            // clobber `rhs`; the result lands in `lhs` like Add/Sub. `&`/`|` keep
+            // the LSB tag; `^` clears it, so re-tag with `+1`.
+            BinOpK::BitOr => {
+                monoasm_arm64!(&mut self.jit, orr x(l), x(l), x(r););
+            }
+            BinOpK::BitAnd => {
+                monoasm_arm64!(&mut self.jit, and x(l), x(l), x(r););
+            }
+            BinOpK::BitXor => {
+                monoasm_arm64!(&mut self.jit,
+                    eor x(l), x(l), x(r);
+                    add x(l), x(l), #(1u32);
+                );
+            }
+            // Rem/Exp/Shl/Shr are compiled as method calls, never IntegerBinOp
             // (mirrors x86 `integer_binop`'s `_ => unreachable!()`).
             _ => unreachable!(),
         }

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -15,35 +15,18 @@ use super::*;
 /// - stack
 ///
 impl Codegen {
-    pub(super) fn integer_binop(
-        &mut self,
-        lhs: GP,
-        rhs: GP,
-        mode: &OpMode,
-        kind: BinOpK,
-        deopt: &DestLabel,
-    ) {
+    pub(super) fn integer_binop(&mut self, lhs: GP, rhs: GP, kind: BinOpK, deopt: &DestLabel) {
         let lhs_r = lhs as u64;
         let rhs_r = rhs as u64;
         assert_eq!(0, self.jit.get_page());
         match kind {
             BinOpK::Add => {
                 let overflow = self.jit.label();
-                match mode {
-                    OpMode::RR(_, _) => {
-                        monoasm!( &mut self.jit,
-                            subq R(lhs_r), 1;
-                            addq R(lhs_r), R(rhs_r);
-                            jo overflow;
-                        );
-                    }
-                    OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                        monoasm!( &mut self.jit,
-                            addq  R(lhs_r), (Value::i32(*i as i32).id() - 1);
-                            jo overflow;
-                        );
-                    }
-                }
+                monoasm!( &mut self.jit,
+                    subq R(lhs_r), 1;
+                    addq R(lhs_r), R(rhs_r);
+                    jo overflow;
+                );
                 self.jit.select_page(1);
                 monoasm!( &mut self.jit,
                 overflow:
@@ -54,19 +37,8 @@ impl Codegen {
             }
             BinOpK::Mul => {
                 let overflow = self.jit.label();
-                match mode {
-                    OpMode::RR(_, _) => {
-                        monoasm!( &mut self.jit,
-                            sarq R(rhs_r), 1;
-                        );
-                    }
-                    OpMode::RI(_, i) | OpMode::IR(i, _) => {
-                        monoasm!( &mut self.jit,
-                            movq R(rhs_r), (*i as i64);
-                        );
-                    }
-                }
                 monoasm!( &mut self.jit,
+                    sarq R(rhs_r), 1;
                     subq R(lhs_r), 1;
                     imul R(lhs_r), R(rhs_r);
                     jo overflow;
@@ -82,29 +54,11 @@ impl Codegen {
             }
             BinOpK::Sub => {
                 let overflow = self.jit.label();
-                match mode {
-                    OpMode::RR(_, _) => {
-                        monoasm!( &mut self.jit,
-                            subq R(lhs_r), R(rhs_r);
-                            jo overflow;
-                            addq R(lhs_r), 1;
-                        );
-                    }
-                    OpMode::RI(_, rhs) => {
-                        monoasm!( &mut self.jit,
-                            subq R(lhs_r), (Value::i32(*rhs as i32).id() - 1);
-                            jo overflow;
-                        );
-                    }
-                    OpMode::IR(lhs, _) => {
-                        monoasm!( &mut self.jit,
-                            movq R(lhs_r), (Value::i32(*lhs as i32).id());
-                            subq R(lhs_r), R(rhs_r);
-                            jo overflow;
-                            addq R(lhs_r), 1;
-                        );
-                    }
-                }
+                monoasm!( &mut self.jit,
+                    subq R(lhs_r), R(rhs_r);
+                    jo overflow;
+                    addq R(lhs_r), 1;
+                );
                 self.jit.select_page(1);
                 monoasm!( &mut self.jit,
                 overflow:
@@ -501,11 +455,11 @@ impl Codegen {
 
     cmp_main!(eq, ne, lt, le, gt, ge);
 
-    pub(super) fn integer_cmp(&mut self, kind: CmpKind, mode: OpMode, lhs: GP, rhs: GP) {
+    pub(super) fn integer_cmp(&mut self, kind: CmpKind, lhs: GP, rhs: GP) {
         monoasm! { &mut self.jit,
             xorq rax, rax;
         };
-        self.cmp_integer(&mode, lhs, rhs);
+        self.cmp_integer(lhs, rhs);
         self.flag_to_bool(kind);
     }
 
@@ -639,25 +593,10 @@ impl Codegen {
     ///
     /// - rdi
     ///
-    pub(super) fn cmp_integer(&mut self, mode: &OpMode, lhs: GP, rhs: GP) {
-        match mode {
-            OpMode::RR(..) => {
-                monoasm!( &mut self.jit,
-                    cmpq R(lhs as u64), R(rhs as u64);
-                );
-            }
-            OpMode::RI(_, r) => {
-                monoasm!( &mut self.jit,
-                    cmpq R(lhs as u64), (Value::i32(*r as i32).id());
-                );
-            }
-            OpMode::IR(l, _) => {
-                monoasm!( &mut self.jit,
-                    movq R(lhs as u64), (Value::i32(*l as i32).id());
-                    cmpq R(lhs as u64), R(rhs as u64);
-                );
-            }
-        }
+    pub(super) fn cmp_integer(&mut self, lhs: GP, rhs: GP) {
+        monoasm!( &mut self.jit,
+            cmpq R(lhs as u64), R(rhs as u64);
+        );
     }
 }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -105,13 +105,23 @@ impl Codegen {
                 );
                 self.jit.select_page(0);
             }
-            BinOpK::Rem
-            | BinOpK::Exp
-            | BinOpK::BitOr
-            | BinOpK::BitAnd
-            | BinOpK::BitXor
-            | BinOpK::Shl
-            | BinOpK::Shr => unreachable!(),
+            // Bitwise ops on tagged fixnums need no overflow check and never
+            // clobber `rhs`; the result lands in `lhs` like Add/Sub. `&`/`|` keep
+            // the LSB tag (`(2a+1)&(2b+1) = 2(a&b)+1`); `^` clears it, so re-tag
+            // with `+1`.
+            BinOpK::BitOr => {
+                monoasm!( &mut self.jit, orq R(lhs_r), R(rhs_r); );
+            }
+            BinOpK::BitAnd => {
+                monoasm!( &mut self.jit, andq R(lhs_r), R(rhs_r); );
+            }
+            BinOpK::BitXor => {
+                monoasm!( &mut self.jit,
+                    xorq R(lhs_r), R(rhs_r);
+                    addq R(lhs_r), 1;
+                );
+            }
+            BinOpK::Rem | BinOpK::Exp | BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -82,7 +82,6 @@ impl Codegen {
             | AsmInst::FprToStack(..)
             | AsmInst::FprSave(..)
             | AsmInst::FprRestore(..)
-            | AsmInst::IntegerBinOpSlot { .. }
             | AsmInst::IntegerBinOpReg { .. }
             | AsmInst::IntegerCmpReg { .. }
             | AsmInst::IntegerCmpBrReg { .. }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -83,6 +83,7 @@ impl Codegen {
             | AsmInst::FprSave(..)
             | AsmInst::FprRestore(..)
             | AsmInst::IntegerBinOpSlot { .. }
+            | AsmInst::IntegerBinOpReg { .. }
             | AsmInst::IntegerCmpSlot { .. }
             | AsmInst::IntegerCmpBrSlot { .. }
             | AsmInst::FloatBinOp { .. }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -82,7 +82,6 @@ impl Codegen {
             | AsmInst::FprToStack(..)
             | AsmInst::FprSave(..)
             | AsmInst::FprRestore(..)
-            | AsmInst::IntegerBinOp { .. }
             | AsmInst::IntegerBinOpSlot { .. }
             | AsmInst::IntegerCmpSlot { .. }
             | AsmInst::IntegerCmpBrSlot { .. }
@@ -572,12 +571,11 @@ impl Codegen {
             // Fixnum fast-path arithmetic with an overflow deopt.
             LInst::IntegerBinOp {
                 kind,
-                mode,
                 lhs,
                 rhs,
                 deopt,
             } => {
-                self.integer_binop(lhs, rhs, &mode, kind, &deopt);
+                self.integer_binop(lhs, rhs, kind, &deopt);
             }
             // Fixnum unary negate (tagged); deopt on i63 overflow.
             LInst::FixnumNeg { reg, deopt } => {
@@ -1383,11 +1381,10 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_integer_cmp(
         &mut self,
         kind: CmpKind,
-        mode: OpMode,
         lhs: GP,
         rhs: GP,
     ) -> bool {
-        self.integer_cmp(kind, mode, lhs, rhs);
+        self.integer_cmp(kind, lhs, rhs);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -84,6 +84,7 @@ impl Codegen {
             | AsmInst::FprRestore(..)
             | AsmInst::IntegerBinOpSlot { .. }
             | AsmInst::IntegerBinOpReg { .. }
+            | AsmInst::IntegerCmpReg { .. }
             | AsmInst::IntegerCmpSlot { .. }
             | AsmInst::IntegerCmpBrSlot { .. }
             | AsmInst::FloatBinOp { .. }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -85,8 +85,7 @@ impl Codegen {
             | AsmInst::IntegerBinOpSlot { .. }
             | AsmInst::IntegerBinOpReg { .. }
             | AsmInst::IntegerCmpReg { .. }
-            | AsmInst::IntegerCmpSlot { .. }
-            | AsmInst::IntegerCmpBrSlot { .. }
+            | AsmInst::IntegerCmpBrReg { .. }
             | AsmInst::FloatBinOp { .. }
             | AsmInst::FloatUnOp { .. }
             | AsmInst::I64ToBoth(..)

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1550,15 +1550,16 @@ impl Codegen {
         true
     }
 
-    /// Load a heap-spilled instance variable into the accumulator, substituting
+    /// Load a heap-spilled instance variable into `dst`, substituting
     /// nil for an out-of-range (non-self) or unset slot.
     pub(in crate::codegen::jitgen) fn emit_load_ivar_heap(
         &mut self,
         ivarid: IvarId,
         is_object_ty: bool,
         self_: bool,
+        dst: GP,
     ) -> bool {
-        self.load_ivar_heap(ivarid, is_object_ty, self_);
+        self.load_ivar_heap(ivarid, is_object_ty, self_, dst);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -9,12 +9,12 @@ impl Codegen {
     /// - rdi: &RValue
     ///
     /// #### out
-    /// - r15: Value
+    /// - dst: Value
     ///
     /// #### destroy
     /// - rdi, rsi, rdx
     ///
-    pub(super) fn load_ivar_heap(&mut self, ivarid: IvarId, is_object_ty: bool, self_: bool) {
+    pub(super) fn load_ivar_heap(&mut self, ivarid: IvarId, is_object_ty: bool, self_: bool, dst: GP) {
         let ivar = ivarid.get() as u32;
         let idx = if is_object_ty {
             ivar - OBJECT_INLINE_IVAR as u32
@@ -31,11 +31,11 @@ impl Codegen {
         }
         monoasm! { &mut self.jit,
             movq rdi, [rdx + (MONOVEC_PTR)]; // ptr
-            movq r15, [rdi + (idx as i32 * 8)];
-            testq r15, r15;
+            movq R(dst as _), [rdi + (idx as i32 * 8)];
+            testq R(dst as _), R(dst as _);
             jne  exit;
         nil:
-            movq r15, (NIL_VALUE);
+            movq R(dst as _), (NIL_VALUE);
         exit:
         }
     }

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -28,6 +28,8 @@ pub mod asmir;
 mod compile;
 mod context;
 mod definition;
+#[allow(dead_code)]
+mod gp_alloc;
 #[cfg(target_arch = "x86_64")]
 mod deoptimize;
 // Type / class guards, split per arch (mirrors the asmir `compile` backend):

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -876,6 +876,28 @@ impl AsmIr {
         });
     }
 
+    /// `gp-local-alloc`: register-form fixnum binop `dst = lhs <kind> rhs` with
+    /// all three operands in physical GP registers chosen by the local
+    /// allocator. The result computes in place in `lhs`; the lowering moves
+    /// `lhs` into `dst` first when they differ. Only the non-`rhs`-clobbering
+    /// `Add`/`Sub` use this form (Mul/Div go through the slot path).
+    pub(in crate::codegen::jitgen) fn integer_binop_reg(
+        &mut self,
+        kind: BinOpK,
+        dst: GP,
+        lhs: GP,
+        rhs: GP,
+        deopt: AsmDeopt,
+    ) {
+        self.push(AsmInst::IntegerBinOpReg {
+            kind,
+            dst,
+            lhs,
+            rhs,
+            deopt,
+        });
+    }
+
     ///
     /// Float binary operation
     ///
@@ -1741,6 +1763,19 @@ pub(super) enum AsmInst {
         kind: BinOpK,
         dst: Option<SlotId>,
         mode: OpMode,
+        deopt: AsmDeopt,
+    },
+    ///
+    /// `gp-local-alloc`: register-form fixnum binop `dst = lhs <kind> rhs`, all
+    /// in physical GP registers from the local allocator. Computes in place in
+    /// `lhs` (overflow -> `deopt`); the lowering moves `lhs` into `dst` first
+    /// when they differ. `Add`/`Sub` only.
+    ///
+    IntegerBinOpReg {
+        kind: BinOpK,
+        dst: GP,
+        lhs: GP,
+        rhs: GP,
         deopt: AsmDeopt,
     },
     ///

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -878,7 +878,7 @@ impl AsmIr {
         });
     }
 
-    /// `gp-local-alloc`: register-form fixnum binop `dst = lhs <kind> rhs` with
+    /// register-form fixnum binop `dst = lhs <kind> rhs` with
     /// all three operands in physical GP registers chosen by the local
     /// allocator. The result computes in place in `lhs`; the lowering moves
     /// `lhs` into `dst` first when they differ. Only the non-`rhs`-clobbering
@@ -900,10 +900,10 @@ impl AsmIr {
         });
     }
 
-    /// `gp-local-alloc`: register-form fixnum comparison `dst = lhs <kind> rhs`
-    /// (a boolean `Value`), operands already in GP registers chosen by the local
-    /// allocator and fixnum-guarded. The lowering compares and stores the bool to
-    /// `dst`'s stack home (the result is a bool, never a GP resident).
+    /// Register-form fixnum comparison `dst = lhs <kind> rhs` (a boolean
+    /// `Value`), operands already in GP registers chosen by the local allocator
+    /// and fixnum-guarded. The lowering compares and stores the bool to `dst`'s
+    /// stack home (the result is a bool, never a GP resident).
     pub(in crate::codegen::jitgen) fn integer_cmp_reg(
         &mut self,
         kind: CmpKind,
@@ -912,6 +912,26 @@ impl AsmIr {
         rhs: GP,
     ) {
         self.push(AsmInst::IntegerCmpReg { kind, dst, lhs, rhs });
+    }
+
+    /// Register-form fused fixnum compare + conditional branch, operands already
+    /// in GP registers and fixnum-guarded. The lowering compares and branches to
+    /// `branch_dest` per `kind`/`brkind`.
+    pub(in crate::codegen::jitgen) fn integer_cmpbr_reg(
+        &mut self,
+        kind: CmpKind,
+        brkind: BrKind,
+        branch_dest: JitLabel,
+        lhs: GP,
+        rhs: GP,
+    ) {
+        self.push(AsmInst::IntegerCmpBrReg {
+            kind,
+            brkind,
+            branch_dest,
+            lhs,
+            rhs,
+        });
     }
 
     ///
@@ -932,48 +952,6 @@ impl AsmIr {
             kind,
             binary_fpr: (lhs, rhs),
             dst,
-        });
-    }
-
-    ///
-    /// Integer comparison
-    ///
-    /// §slot-IR: slot-based fixnum comparison (see [`AsmInst::IntegerCmpSlot`]).
-    pub(super) fn integer_cmp_slot(
-        &mut self,
-        lhs: SlotId,
-        rhs: SlotId,
-        kind: CmpKind,
-        dst: Option<SlotId>,
-        deopt: AsmDeopt,
-    ) {
-        self.push(AsmInst::IntegerCmpSlot {
-            kind,
-            lhs,
-            rhs,
-            dst,
-            deopt,
-        });
-    }
-
-    /// §slot-IR: slot-based fused fixnum compare + branch (see
-    /// [`AsmInst::IntegerCmpBrSlot`]).
-    pub(super) fn integer_cmp_br_slot(
-        &mut self,
-        lhs: SlotId,
-        rhs: SlotId,
-        kind: CmpKind,
-        brkind: BrKind,
-        branch_dest: JitLabel,
-        deopt: AsmDeopt,
-    ) {
-        self.push(AsmInst::IntegerCmpBrSlot {
-            lhs,
-            rhs,
-            kind,
-            brkind,
-            branch_dest,
-            deopt,
         });
     }
 
@@ -1787,7 +1765,7 @@ pub(super) enum AsmInst {
         deopt: AsmDeopt,
     },
     ///
-    /// `gp-local-alloc`: register-form fixnum binop `dst = lhs <kind> rhs`, all
+    /// register-form fixnum binop `dst = lhs <kind> rhs`, all
     /// in physical GP registers from the local allocator. Computes in place in
     /// `lhs` (overflow -> `deopt`); the lowering moves `lhs` into `dst` first
     /// when they differ. `Add`/`Sub` only.
@@ -1800,7 +1778,7 @@ pub(super) enum AsmInst {
         deopt: AsmDeopt,
     },
     ///
-    /// `gp-local-alloc`: register-form fixnum comparison `dst = lhs <kind> rhs`
+    /// register-form fixnum comparison `dst = lhs <kind> rhs`
     /// (a bool `Value`), operands already in GP registers and fixnum-guarded.
     /// The lowering compares and stores the boolean to `dst`'s stack home.
     ///
@@ -1811,32 +1789,16 @@ pub(super) enum AsmInst {
         rhs: GP,
     },
     ///
+    /// Register-form fused fixnum compare + conditional branch, operands already
+    /// in GP registers and fixnum-guarded. The lowering compares and branches to
+    /// `branch_dest` per `kind`/`brkind`.
     ///
-    /// §slot-IR: slot-based fixnum comparison (`dst = lhs <kind> rhs` as a bool
-    /// `Value`, all stack slots). The LIR lowering loads each operand slot into a
-    /// scratch reg, fixnum-guards it (`deopt`), compares, and stores the boolean
-    /// result to `dst` (when present). No GP register at the AsmIR layer.
-    ///
-    IntegerCmpSlot {
-        lhs: SlotId,
-        rhs: SlotId,
-        kind: CmpKind,
-        dst: Option<SlotId>,
-        deopt: AsmDeopt,
-    },
-    ///
-    /// §slot-IR: slot-based fused fixnum compare + conditional branch. The LIR
-    /// lowering loads each operand slot into a scratch reg, fixnum-guards it
-    /// (`deopt`), compares, and branches to `branch_dest` per `kind`/`brkind`.
-    /// No GP register at the AsmIR layer.
-    ///
-    IntegerCmpBrSlot {
-        lhs: SlotId,
-        rhs: SlotId,
+    IntegerCmpBrReg {
         kind: CmpKind,
         brkind: BrKind,
         branch_dest: JitLabel,
-        deopt: AsmDeopt,
+        lhs: GP,
+        rhs: GP,
     },
     FloatCmp {
         kind: CmpKind,

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -857,27 +857,6 @@ impl AsmIr {
 //
 impl AsmIr {
 
-    /// §slot-IR: slot-based fixnum binop. Operands and destination are stack
-    /// slots; the LIR lowering loads them into scratch registers, fixnum-guards,
-    /// computes (overflow -> `deopt`), and stores the result back to `dst`. No
-    /// physical register appears at the AsmIR level.
-    pub(super) fn integer_binop_slot(
-        &mut self,
-        kind: BinOpK,
-        dst: Option<SlotId>,
-        lhs: SlotId,
-        rhs: SlotId,
-        deopt: AsmDeopt,
-    ) {
-        self.push(AsmInst::IntegerBinOpSlot {
-            kind,
-            dst,
-            lhs,
-            rhs,
-            deopt,
-        });
-    }
-
     /// register-form fixnum binop `dst = lhs <kind> rhs` with
     /// all three operands in physical GP registers chosen by the local
     /// allocator. The result computes in place in `lhs`; the lowering moves
@@ -1751,24 +1730,12 @@ pub(super) enum AsmInst {
     },
 
     ///
-    /// §slot-IR: slot-based fixnum binop (`dst = lhs <kind> rhs`, all stack
-    /// slots). The LIR lowering materializes the physical registers — load each
-    /// operand slot into a scratch reg, fixnum-guard it, compute in place
-    /// (overflow -> `deopt`), and store the result to `dst`. The AsmIR layer
-    /// carries no GP register for this op (the slot-IR migration).
-    ///
-    IntegerBinOpSlot {
-        kind: BinOpK,
-        dst: Option<SlotId>,
-        lhs: SlotId,
-        rhs: SlotId,
-        deopt: AsmDeopt,
-    },
-    ///
-    /// register-form fixnum binop `dst = lhs <kind> rhs`, all
-    /// in physical GP registers from the local allocator. Computes in place in
-    /// `lhs` (overflow -> `deopt`); the lowering moves `lhs` into `dst` first
-    /// when they differ. `Add`/`Sub` only.
+    /// Register-form fixnum binop `dst = lhs <kind> rhs`, all in physical GP
+    /// registers from the local allocator (overflow / divide-by-zero -> `deopt`).
+    /// `Add`/`Sub`/`Mul` compute in place in the `lhs` position (the lowering
+    /// moves `lhs` into `dst` first when they differ); `Div` reads `lhs`, clobbers
+    /// `rhs`, and produces the quotient in `rax`, which the lowering copies to
+    /// `dst`.
     ///
     IntegerBinOpReg {
         kind: BinOpK,

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -898,6 +898,20 @@ impl AsmIr {
         });
     }
 
+    /// `gp-local-alloc`: register-form fixnum comparison `dst = lhs <kind> rhs`
+    /// (a boolean `Value`), operands already in GP registers chosen by the local
+    /// allocator and fixnum-guarded. The lowering compares and stores the bool to
+    /// `dst`'s stack home (the result is a bool, never a GP resident).
+    pub(in crate::codegen::jitgen) fn integer_cmp_reg(
+        &mut self,
+        kind: CmpKind,
+        dst: Option<SlotId>,
+        lhs: GP,
+        rhs: GP,
+    ) {
+        self.push(AsmInst::IntegerCmpReg { kind, dst, lhs, rhs });
+    }
+
     ///
     /// Float binary operation
     ///
@@ -1777,6 +1791,17 @@ pub(super) enum AsmInst {
         lhs: GP,
         rhs: GP,
         deopt: AsmDeopt,
+    },
+    ///
+    /// `gp-local-alloc`: register-form fixnum comparison `dst = lhs <kind> rhs`
+    /// (a bool `Value`), operands already in GP registers and fixnum-guarded.
+    /// The lowering compares and stores the boolean to `dst`'s stack home.
+    ///
+    IntegerCmpReg {
+        kind: CmpKind,
+        dst: Option<SlotId>,
+        lhs: GP,
+        rhs: GP,
     },
     ///
     ///

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -856,36 +856,6 @@ impl AsmIr {
 // binary operations
 //
 impl AsmIr {
-    ///
-    /// Integer binary operation.
-    ///
-    /// ### in
-    /// - rdi  lhs
-    /// - rsi  rhs
-    ///
-    /// ### out
-    /// - rdi  dst
-    ///
-    /// ### destroy
-    /// - caller save registers
-    /// - stack
-    ///
-    pub(super) fn integer_binop(
-        &mut self,
-        kind: BinOpK,
-        lhs: GP,
-        rhs: GP,
-        mode: OpMode,
-        deopt: AsmDeopt,
-    ) {
-        self.push(AsmInst::IntegerBinOp {
-            kind,
-            lhs,
-            rhs,
-            mode,
-            deopt,
-        });
-    }
 
     /// §slot-IR: slot-based fixnum binop. Operands and destination are stack
     /// slots; the LIR lowering loads them into scratch registers, fixnum-guards,
@@ -1760,27 +1730,6 @@ pub(super) enum AsmInst {
         reg: GP,
     },
 
-    ///
-    /// Integer binary operation.
-    ///
-    /// ### in
-    /// - rdi  lhs
-    /// - rsi  rhs
-    ///
-    /// ### out
-    /// - rdi  dst
-    ///
-    /// ### destroy
-    /// - caller save registers
-    /// - stack
-    ///
-    IntegerBinOp {
-        kind: BinOpK,
-        lhs: GP,
-        rhs: GP,
-        mode: OpMode,
-        deopt: AsmDeopt,
-    },
     ///
     /// §slot-IR: slot-based fixnum binop (`dst = lhs <kind> rhs`, all stack
     /// slots). The LIR lowering materializes the physical registers — load each

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1925,13 +1925,13 @@ pub(super) enum AsmInst {
         call_site_bc_ptr: BytecodePtr,
     },
 
-    /// Load instance var *ivarid* of the object *rdi* into register *rax*.
+    /// Load instance var *ivarid* of the object *rdi* into register *dst*.
     ///
     /// #### in
     /// - rdi: &RValue
     ///
     /// #### out
-    /// - r15: Value
+    /// - dst: Value
     ///
     /// #### destroy
     /// - rdi, rsi
@@ -1940,6 +1940,7 @@ pub(super) enum AsmInst {
         ivarid: IvarId,
         is_object_ty: bool,
         self_: bool,
+        dst: GP,
     },
     ///
     /// Load ivar embedded to RValue. (only for object type)
@@ -1948,13 +1949,14 @@ pub(super) enum AsmInst {
     /// - rdi: &RValue
     ///
     /// #### out
-    /// - r15: Value
+    /// - dst: Value
     ///
     /// #### destroy
     /// - rdi
     ///
     LoadIVarInline {
         ivarid: IvarId,
+        dst: GP,
     },
     ///
     /// Store *src* in an instance var *ivarid* of the object *rdi*.

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -865,13 +865,15 @@ impl AsmIr {
         &mut self,
         kind: BinOpK,
         dst: Option<SlotId>,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         deopt: AsmDeopt,
     ) {
         self.push(AsmInst::IntegerBinOpSlot {
             kind,
             dst,
-            mode,
+            lhs,
+            rhs,
             deopt,
         });
     }
@@ -939,14 +941,16 @@ impl AsmIr {
     /// §slot-IR: slot-based fixnum comparison (see [`AsmInst::IntegerCmpSlot`]).
     pub(super) fn integer_cmp_slot(
         &mut self,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         dst: Option<SlotId>,
         deopt: AsmDeopt,
     ) {
         self.push(AsmInst::IntegerCmpSlot {
             kind,
-            mode,
+            lhs,
+            rhs,
             dst,
             deopt,
         });
@@ -956,14 +960,16 @@ impl AsmIr {
     /// [`AsmInst::IntegerCmpBrSlot`]).
     pub(super) fn integer_cmp_br_slot(
         &mut self,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         brkind: BrKind,
         branch_dest: JitLabel,
         deopt: AsmDeopt,
     ) {
         self.push(AsmInst::IntegerCmpBrSlot {
-            mode,
+            lhs,
+            rhs,
             kind,
             brkind,
             branch_dest,
@@ -1776,7 +1782,8 @@ pub(super) enum AsmInst {
     IntegerBinOpSlot {
         kind: BinOpK,
         dst: Option<SlotId>,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         deopt: AsmDeopt,
     },
     ///
@@ -1811,7 +1818,8 @@ pub(super) enum AsmInst {
     /// result to `dst` (when present). No GP register at the AsmIR layer.
     ///
     IntegerCmpSlot {
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         dst: Option<SlotId>,
         deopt: AsmDeopt,
@@ -1823,7 +1831,8 @@ pub(super) enum AsmInst {
     /// No GP register at the AsmIR layer.
     ///
     IntegerCmpBrSlot {
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         brkind: BrKind,
         branch_dest: JitLabel,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -258,60 +258,11 @@ impl Codegen {
             AsmInst::FprRestore(using_fpr, cont) => {
                 self.encode_linst(LInst::FprRestore { using_fpr, cont })
             }
-            // Integer / float arithmetic fast paths. Each backend resolves the
-            // same operands and dispatches to its own emission primitive
-            // (aarch64 bails on an unsupported BinOpK, hence the bool results).
-            // §slot-IR: lower the slot-based fixnum binop to the physical
-            // sequence — load each operand slot into a scratch reg, fixnum-guard
-            // it, compute in place in `Rdi` (overflow -> deopt), and store the
-            // result to `dst`'s slot. This is where the GP registers the AsmIR
-            // layer no longer carries are materialized (`%dst = %lhs op %rhs` ->
-            // `Rdi=%lhs; Rsi=%rhs; Rdi=Rdi op Rsi; %dst=Rdi`).
-            AsmInst::IntegerBinOpSlot {
-                kind,
-                dst,
-                lhs,
-                rhs,
-                deopt,
-            } => {
-                let deopt = labels[deopt].clone();
-                let mut load_guard = |me: &mut Self, slot: SlotId, reg: GP| {
-                    me.encode_linst(LInst::Load {
-                        dst: reg.into(),
-                        mem: LMem::Slot(slot),
-                    });
-                    me.encode_linst(LInst::GuardClass {
-                        reg,
-                        class: INTEGER_CLASS,
-                        deopt: deopt.clone(),
-                    });
-                };
-                // Load both operands (Rdi=lhs, Rsi=rhs) and fixnum-guard each.
-                // Add/Sub/Mul compute in place in `Rdi`; `Div` produces its
-                // quotient in `rax`.
-                load_guard(self, lhs, GP::Rdi);
-                load_guard(self, rhs, GP::Rsi);
-                let result_reg = if matches!(kind, BinOpK::Div) {
-                    GP::Rax
-                } else {
-                    GP::Rdi
-                };
-                self.encode_linst(LInst::IntegerBinOp {
-                    kind,
-                    lhs: GP::Rdi,
-                    rhs: GP::Rsi,
-                    deopt,
-                });
-                if let Some(dst) = dst {
-                    self.encode_linst(LInst::Store {
-                        src: result_reg,
-                        mem: LMem::Slot(dst),
-                    });
-                }
-            }
-            // register-form binop. The op computes in place in
-            // its `lhs`, so move `lhs` into `dst` first when they differ, then
-            // run the shared `IntegerBinOp` on `dst` (overflow -> deopt).
+            // Register-form binop. `Add`/`Sub`/`Mul` compute in place in their
+            // `lhs`, so move `lhs` into `dst` first when they differ, then run
+            // the shared `IntegerBinOp` on `dst` (overflow -> deopt). `Div` reads
+            // `lhs` (preserved) and clobbers `rhs`, producing the quotient in
+            // `rax`; copy it to `dst` afterwards.
             AsmInst::IntegerBinOpReg {
                 kind,
                 dst,
@@ -320,18 +271,31 @@ impl Codegen {
                 deopt,
             } => {
                 let deopt = labels[deopt].clone();
-                if dst != lhs {
+                if matches!(kind, BinOpK::Div) {
+                    self.encode_linst(LInst::IntegerBinOp {
+                        kind,
+                        lhs,
+                        rhs,
+                        deopt,
+                    });
                     self.encode_linst(LInst::Mov {
                         dst: dst.into(),
-                        src: lhs.into(),
+                        src: GP::Rax.into(),
+                    });
+                } else {
+                    if dst != lhs {
+                        self.encode_linst(LInst::Mov {
+                            dst: dst.into(),
+                            src: lhs.into(),
+                        });
+                    }
+                    self.encode_linst(LInst::IntegerBinOp {
+                        kind,
+                        lhs: dst,
+                        rhs,
+                        deopt,
                     });
                 }
-                self.encode_linst(LInst::IntegerBinOp {
-                    kind,
-                    lhs: dst,
-                    rhs,
-                    deopt,
-                });
             }
             // Register-form comparison. Operands are already in GP registers and
             // fixnum-guarded, so just compare (result in rax) and store the

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -333,6 +333,23 @@ impl Codegen {
                     deopt,
                 });
             }
+            // `gp-local-alloc`: register-form comparison. Operands are already in
+            // GP registers and fixnum-guarded, so just compare (result in rax) and
+            // store the boolean to `dst`'s slot.
+            AsmInst::IntegerCmpReg {
+                kind,
+                dst,
+                lhs,
+                rhs,
+            } => {
+                self.encode_linst(LInst::IntegerCmp { kind, lhs, rhs });
+                if let Some(dst) = dst {
+                    self.encode_linst(LInst::Store {
+                        src: GP::Rax,
+                        mem: LMem::Slot(dst),
+                    });
+                }
+            }
             // §slot-IR: lower the slot-based fixnum comparison — load each operand
             // slot into the scratch reg `integer_cmp` expects (Rdi=lhs, Rsi=rhs;
             // RI loads only lhs, IR only rhs), fixnum-guard it, compare (result in

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -309,7 +309,7 @@ impl Codegen {
                     });
                 }
             }
-            // `gp-local-alloc`: register-form binop. The op computes in place in
+            // register-form binop. The op computes in place in
             // its `lhs`, so move `lhs` into `dst` first when they differ, then
             // run the shared `IntegerBinOp` on `dst` (overflow -> deopt).
             AsmInst::IntegerBinOpReg {
@@ -333,9 +333,9 @@ impl Codegen {
                     deopt,
                 });
             }
-            // `gp-local-alloc`: register-form comparison. Operands are already in
-            // GP registers and fixnum-guarded, so just compare (result in rax) and
-            // store the boolean to `dst`'s slot.
+            // Register-form comparison. Operands are already in GP registers and
+            // fixnum-guarded, so just compare (result in rax) and store the
+            // boolean to `dst`'s slot.
             AsmInst::IntegerCmpReg {
                 kind,
                 dst,
@@ -350,72 +350,19 @@ impl Codegen {
                     });
                 }
             }
-            // §slot-IR: lower the slot-based fixnum comparison — load each operand
-            // slot into the scratch reg `integer_cmp` expects (Rdi=lhs, Rsi=rhs;
-            // RI loads only lhs, IR only rhs), fixnum-guard it, compare (result in
-            // rax), and store the boolean to `dst`'s slot.
-            AsmInst::IntegerCmpSlot {
-                lhs,
-                rhs,
-                kind,
-                dst,
-                deopt,
-            } => {
-                let deopt = labels[deopt].clone();
-                let mut load_guard = |me: &mut Self, slot: SlotId, reg: GP| {
-                    me.encode_linst(LInst::Load {
-                        dst: reg.into(),
-                        mem: LMem::Slot(slot),
-                    });
-                    me.encode_linst(LInst::GuardClass {
-                        reg,
-                        class: INTEGER_CLASS,
-                        deopt: deopt.clone(),
-                    });
-                };
-                load_guard(self, lhs, GP::Rdi);
-                load_guard(self, rhs, GP::Rsi);
-                self.encode_linst(LInst::IntegerCmp {
-                    kind,
-                    lhs: GP::Rdi,
-                    rhs: GP::Rsi,
-                });
-                if let Some(dst) = dst {
-                    self.encode_linst(LInst::Store {
-                        src: GP::Rax,
-                        mem: LMem::Slot(dst),
-                    });
-                }
-            }
-            // §slot-IR: lower the slot-based compare+branch — load each operand
-            // slot into the scratch reg the compare expects (Rdi=lhs, Rsi=rhs),
-            // fixnum-guard it, then emit the same Cmp/CondBr as `IntegerCmpBr`.
-            AsmInst::IntegerCmpBrSlot {
-                lhs,
-                rhs,
+            // Register-form compare+branch. Operands are already in GP registers
+            // and fixnum-guarded; compare and branch per `kind`/`brkind`.
+            AsmInst::IntegerCmpBrReg {
                 kind,
                 brkind,
                 branch_dest,
-                deopt,
+                lhs,
+                rhs,
             } => {
-                let deopt = labels[deopt].clone();
-                let mut load_guard = |me: &mut Self, slot: SlotId, reg: GP| {
-                    me.encode_linst(LInst::Load {
-                        dst: reg.into(),
-                        mem: LMem::Slot(slot),
-                    });
-                    me.encode_linst(LInst::GuardClass {
-                        reg,
-                        class: INTEGER_CLASS,
-                        deopt: deopt.clone(),
-                    });
-                };
-                load_guard(self, lhs, GP::Rdi);
-                load_guard(self, rhs, GP::Rsi);
                 let target = frame.resolve_label(&mut self.jit, branch_dest);
                 self.encode_linst(LInst::Cmp {
-                    lhs: GP::Rdi.into(),
-                    rhs: GP::Rsi.into(),
+                    lhs: lhs.into(),
+                    rhs: rhs.into(),
                 });
                 let mut cond = LCond::from_int_cmp(kind).unwrap_or(LCond::Eq);
                 if brkind == BrKind::BrIfNot {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -261,22 +261,6 @@ impl Codegen {
             // Integer / float arithmetic fast paths. Each backend resolves the
             // same operands and dispatches to its own emission primitive
             // (aarch64 bails on an unsupported BinOpK, hence the bool results).
-            AsmInst::IntegerBinOp {
-                kind,
-                lhs,
-                rhs,
-                mode,
-                deopt,
-            } => {
-                let deopt = labels[deopt].clone();
-                self.encode_linst(LInst::IntegerBinOp {
-                    kind,
-                    mode,
-                    lhs,
-                    rhs,
-                    deopt,
-                });
-            }
             // §slot-IR: lower the slot-based fixnum binop to the physical
             // sequence — load each operand slot into a scratch reg, fixnum-guard
             // it, compute in place in `Rdi` (overflow -> deopt), and store the
@@ -290,10 +274,6 @@ impl Codegen {
                 deopt,
             } => {
                 let deopt = labels[deopt].clone();
-                // Place the slot operand(s) into the registers `integer_binop`
-                // expects for this (mode, kind) and fixnum-guard each; the
-                // immediate (if any) is folded by `integer_binop` from `mode`.
-                // The result is computed in place in `Rdi` (= `lhs`).
                 let mut load_guard = |me: &mut Self, slot: SlotId, reg: GP| {
                     me.encode_linst(LInst::Load {
                         dst: reg.into(),
@@ -305,58 +285,19 @@ impl Codegen {
                         deopt: deopt.clone(),
                     });
                 };
-                // `Div` needs both operands in registers (Rdi=lhs, Rsi=rhs) with
-                // immediates materialized, and produces its quotient in `rax`.
-                // Add/Sub/Mul fold the immediate from `mode` and compute in place
-                // in `Rdi` (with a commutative-aware operand placement).
+                // Load both operands (Rdi=lhs, Rsi=rhs) and fixnum-guard each.
+                // Add/Sub/Mul compute in place in `Rdi`; `Div` produces its
+                // quotient in `rax`.
+                let OpMode::RR(l, r) = mode;
+                load_guard(self, l, GP::Rdi);
+                load_guard(self, r, GP::Rsi);
                 let result_reg = if matches!(kind, BinOpK::Div) {
-                    match mode {
-                        OpMode::RR(l, r) => {
-                            load_guard(self, l, GP::Rdi);
-                            load_guard(self, r, GP::Rsi);
-                        }
-                        OpMode::RI(l, i) => {
-                            load_guard(self, l, GP::Rdi);
-                            self.encode_linst(LInst::LoadImm {
-                                dst: GP::Rsi.into(),
-                                imm: Value::i32(i as i32).id(),
-                            });
-                        }
-                        OpMode::IR(i, r) => {
-                            self.encode_linst(LInst::LoadImm {
-                                dst: GP::Rdi.into(),
-                                imm: Value::i32(i as i32).id(),
-                            });
-                            load_guard(self, r, GP::Rsi);
-                        }
-                    }
                     GP::Rax
                 } else {
-                    match mode {
-                        OpMode::RR(l, r) => {
-                            load_guard(self, l, GP::Rdi);
-                            load_guard(self, r, GP::Rsi);
-                        }
-                        // rhs is the immediate: only lhs slot is loaded (into Rdi).
-                        OpMode::RI(l, _) => load_guard(self, l, GP::Rdi),
-                        // lhs is the immediate. Add/Mul are commutative, so the reg
-                        // operand becomes the in-place accumulator (Rdi); Sub
-                        // materializes the immediate into Rdi and subtracts the reg
-                        // operand from Rsi.
-                        OpMode::IR(_, r) => {
-                            let reg = if matches!(kind, BinOpK::Sub) {
-                                GP::Rsi
-                            } else {
-                                GP::Rdi
-                            };
-                            load_guard(self, r, reg);
-                        }
-                    }
                     GP::Rdi
                 };
                 self.encode_linst(LInst::IntegerBinOp {
                     kind,
-                    mode,
                     lhs: GP::Rdi,
                     rhs: GP::Rsi,
                     deopt,
@@ -390,17 +331,11 @@ impl Codegen {
                         deopt: deopt.clone(),
                     });
                 };
-                match mode {
-                    OpMode::RR(l, r) => {
-                        load_guard(self, l, GP::Rdi);
-                        load_guard(self, r, GP::Rsi);
-                    }
-                    OpMode::RI(l, _) => load_guard(self, l, GP::Rdi),
-                    OpMode::IR(_, r) => load_guard(self, r, GP::Rsi),
-                }
+                let OpMode::RR(l, r) = mode;
+                load_guard(self, l, GP::Rdi);
+                load_guard(self, r, GP::Rsi);
                 self.encode_linst(LInst::IntegerCmp {
                     kind,
-                    mode,
                     lhs: GP::Rdi,
                     rhs: GP::Rsi,
                 });
@@ -433,35 +368,14 @@ impl Codegen {
                         deopt: deopt.clone(),
                     });
                 };
-                match mode {
-                    OpMode::RR(l, r) => {
-                        load_guard(self, l, GP::Rdi);
-                        load_guard(self, r, GP::Rsi);
-                    }
-                    OpMode::RI(l, _) => load_guard(self, l, GP::Rdi),
-                    OpMode::IR(_, r) => load_guard(self, r, GP::Rsi),
-                }
+                let OpMode::RR(l, r) = mode;
+                load_guard(self, l, GP::Rdi);
+                load_guard(self, r, GP::Rsi);
                 let target = frame.resolve_label(&mut self.jit, branch_dest);
-                match mode {
-                    OpMode::RR(..) => self.encode_linst(LInst::Cmp {
-                        lhs: GP::Rdi.into(),
-                        rhs: GP::Rsi.into(),
-                    }),
-                    OpMode::RI(_, i) => self.encode_linst(LInst::Cmp {
-                        lhs: GP::Rdi.into(),
-                        rhs: LOperand::Imm(Value::i32(i as i32).id() as i64),
-                    }),
-                    OpMode::IR(i, _) => {
-                        self.encode_linst(LInst::LoadImm {
-                            dst: GP::Rdi.into(),
-                            imm: Value::i32(i as i32).id(),
-                        });
-                        self.encode_linst(LInst::Cmp {
-                            lhs: GP::Rdi.into(),
-                            rhs: GP::Rsi.into(),
-                        });
-                    }
-                }
+                self.encode_linst(LInst::Cmp {
+                    lhs: GP::Rdi.into(),
+                    rhs: GP::Rsi.into(),
+                });
                 let mut cond = LCond::from_int_cmp(kind).unwrap_or(LCond::Eq);
                 if brkind == BrKind::BrIfNot {
                     cond = cond.invert();
@@ -1434,8 +1348,8 @@ impl Codegen {
             LInst::ExecGc { write_back, error, base } => {
                 self.emit_exec_gc(write_back, &error, base);
             }
-            LInst::IntegerCmp { kind, mode, lhs, rhs } => {
-                self.emit_integer_cmp(kind, mode, lhs, rhs);
+            LInst::IntegerCmp { kind, lhs, rhs } => {
+                self.emit_integer_cmp(kind, lhs, rhs);
             }
             LInst::Ret => {
                 self.emit_ret();

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -309,6 +309,30 @@ impl Codegen {
                     });
                 }
             }
+            // `gp-local-alloc`: register-form binop. The op computes in place in
+            // its `lhs`, so move `lhs` into `dst` first when they differ, then
+            // run the shared `IntegerBinOp` on `dst` (overflow -> deopt).
+            AsmInst::IntegerBinOpReg {
+                kind,
+                dst,
+                lhs,
+                rhs,
+                deopt,
+            } => {
+                let deopt = labels[deopt].clone();
+                if dst != lhs {
+                    self.encode_linst(LInst::Mov {
+                        dst: dst.into(),
+                        src: lhs.into(),
+                    });
+                }
+                self.encode_linst(LInst::IntegerBinOp {
+                    kind,
+                    lhs: dst,
+                    rhs,
+                    deopt,
+                });
+            }
             // §slot-IR: lower the slot-based fixnum comparison — load each operand
             // slot into the scratch reg `integer_cmp` expects (Rdi=lhs, Rsi=rhs;
             // RI loads only lhs, IR only rhs), fixnum-guard it, compare (result in

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -270,7 +270,8 @@ impl Codegen {
             AsmInst::IntegerBinOpSlot {
                 kind,
                 dst,
-                mode,
+                lhs,
+                rhs,
                 deopt,
             } => {
                 let deopt = labels[deopt].clone();
@@ -288,9 +289,8 @@ impl Codegen {
                 // Load both operands (Rdi=lhs, Rsi=rhs) and fixnum-guard each.
                 // Add/Sub/Mul compute in place in `Rdi`; `Div` produces its
                 // quotient in `rax`.
-                let OpMode::RR(l, r) = mode;
-                load_guard(self, l, GP::Rdi);
-                load_guard(self, r, GP::Rsi);
+                load_guard(self, lhs, GP::Rdi);
+                load_guard(self, rhs, GP::Rsi);
                 let result_reg = if matches!(kind, BinOpK::Div) {
                     GP::Rax
                 } else {
@@ -355,7 +355,8 @@ impl Codegen {
             // RI loads only lhs, IR only rhs), fixnum-guard it, compare (result in
             // rax), and store the boolean to `dst`'s slot.
             AsmInst::IntegerCmpSlot {
-                mode,
+                lhs,
+                rhs,
                 kind,
                 dst,
                 deopt,
@@ -372,9 +373,8 @@ impl Codegen {
                         deopt: deopt.clone(),
                     });
                 };
-                let OpMode::RR(l, r) = mode;
-                load_guard(self, l, GP::Rdi);
-                load_guard(self, r, GP::Rsi);
+                load_guard(self, lhs, GP::Rdi);
+                load_guard(self, rhs, GP::Rsi);
                 self.encode_linst(LInst::IntegerCmp {
                     kind,
                     lhs: GP::Rdi,
@@ -391,7 +391,8 @@ impl Codegen {
             // slot into the scratch reg the compare expects (Rdi=lhs, Rsi=rhs),
             // fixnum-guard it, then emit the same Cmp/CondBr as `IntegerCmpBr`.
             AsmInst::IntegerCmpBrSlot {
-                mode,
+                lhs,
+                rhs,
                 kind,
                 brkind,
                 branch_dest,
@@ -409,9 +410,8 @@ impl Codegen {
                         deopt: deopt.clone(),
                     });
                 };
-                let OpMode::RR(l, r) = mode;
-                load_guard(self, l, GP::Rdi);
-                load_guard(self, r, GP::Rsi);
+                load_guard(self, lhs, GP::Rdi);
+                load_guard(self, rhs, GP::Rsi);
                 let target = frame.resolve_label(&mut self.jit, branch_dest);
                 self.encode_linst(LInst::Cmp {
                     lhs: GP::Rdi.into(),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -526,18 +526,18 @@ impl Codegen {
             // Inline instance-variable / struct-member access on the receiver in
             // rdi (no Box deref). aarch64 bails if the field offset exceeds the
             // 12-bit scaled load/store immediate.
-            // Inline ivar load: `r15 <- self.@ivar` at a fixed field offset on
+            // Inline ivar load: `dst <- self.@ivar` at a fixed field offset on
             // the receiver (rdi); an unset slot reads as 0 and becomes nil.
-            AsmInst::LoadIVarInline { ivarid } => {
+            AsmInst::LoadIVarInline { ivarid, dst } => {
                 let disp = RVALUE_OFFSET_KIND as i32 + ivarid.get() as i32 * 8;
                 self.encode_linst(LInst::Load {
-                    dst: GP::R15.into(),
+                    dst: dst.into(),
                     mem: LMem::Field {
                         base: GP::Rdi.into(),
                         disp,
                     },
                 });
-                self.encode_linst(LInst::NilIfZero { reg: GP::R15 });
+                self.encode_linst(LInst::NilIfZero { reg: dst });
             }
             // Inline ivar store: `self.@ivar = src` at a fixed field offset on
             // the receiver (rdi), followed by the GC write barrier.
@@ -743,10 +743,12 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
                 self_,
+                dst,
             } => self.encode_linst(LInst::LoadIVarHeap {
                 ivarid,
                 is_object_ty,
                 self_,
+                dst,
             }),
             // Runtime-call definition ops (undef a method / alias a global var).
             // aarch64 bails when an fpr pool register is live (no fpr save yet).
@@ -1178,8 +1180,9 @@ impl Codegen {
                 ivarid,
                 is_object_ty,
                 self_,
+                dst,
             } => {
-                self.emit_load_ivar_heap(ivarid, is_object_ty, self_);
+                self.emit_load_ivar_heap(ivarid, is_object_ty, self_, dst);
             }
             LInst::StoreIVarHeap {
                 src,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -96,7 +96,7 @@ impl<'a> JitContext<'a> {
                     // recorded — the merge machinery is R15/stack-only, so a
                     // successor must never inherit a pool-resident (`Alloc`) slot.
                     state.flush_pool(&mut ir);
-                    // `gp-local-alloc`: a successor block starts with an empty GP
+                    // a successor block starts with an empty GP
                     // register file (the file is never carried across a merge).
                     state.flush_gp(&mut ir);
                     self.new_branch(bc_pos, dest_bb, state);
@@ -143,7 +143,7 @@ impl<'a> JitContext<'a> {
             // §9 9d-B: flush pool residents before the fall-through state is
             // recorded for the next block (the merge machinery is stack-only).
             state.flush_pool(&mut ir);
-            // `gp-local-alloc`: the last instruction may be a GP-aware binop, so
+            // the last instruction may be a GP-aware binop, so
             // flush the GP residents before the fall-through state is recorded —
             // the successor block starts with an empty register file.
             state.flush_gp(&mut ir);
@@ -173,14 +173,17 @@ impl<'a> JitContext<'a> {
         if let Some(fmt) = TraceIr::format(self.store, self.iseq_id(), pc) {
             eprintln!("{fmt}");
         }
-        // `gp-local-alloc`: the integer `BinOp` and `BinCmp` paths are GP-aware.
-        // Every other instruction first flushes the live GP residents back to
-        // their stack homes, so it observes slots in their canonical location.
-        // (`BinOp`/`BinCmp` are exempt here; their non-integer paths flush inside
-        // `binary_op` / `binary_cmp`.) A no-op when the register file is empty,
-        // which is always the case without the feature — so the default build is
-        // unchanged.
-        if !matches!(trace_ir, TraceIr::BinOp { .. } | TraceIr::BinCmp { .. }) {
+        // The integer `BinOp`, `BinCmp` and `BinCmpBr` paths are GP-aware. Every
+        // other instruction first flushes the live GP residents back to their
+        // stack homes, so it observes slots in their canonical location. (These
+        // three are exempt here; their non-integer paths flush inside
+        // `binary_op` / `binary_cmp` / `binary_cmp_br`, and the integer compare +
+        // branch flushes before its branch since it ends the block.) A no-op when
+        // the register file is empty.
+        if !matches!(
+            trace_ir,
+            TraceIr::BinOp { .. } | TraceIr::BinCmp { .. } | TraceIr::BinCmpBr { .. }
+        ) {
             state.flush_gp(ir);
         }
         match trace_ir {

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -171,46 +171,33 @@ impl<'a> JitContext<'a> {
         if let Some(fmt) = TraceIr::format(self.store, self.iseq_id(), pc) {
             eprintln!("{fmt}");
         }
-        // The integer `BinOp`, `BinCmp` and `BinCmpBr` paths are GP-aware. Every
-        // other instruction first flushes the live GP residents back to their
-        // stack homes, so it observes slots in their canonical location. (These
-        // three are exempt here; their non-integer paths flush inside
-        // `binary_op` / `binary_cmp` / `binary_cmp_br`, and the integer compare +
-        // branch flushes before its branch since it ends the block.) A no-op when
+        // An arm flushes the local GP register file at its head only when it can
+        // clobber the caller-saved pool (a C-ABI helper) *without* passing the
+        // `get_using_fpr` chokepoint first — `get_using_fpr` itself flushes (see
+        // `SlotState::get_using_fpr`), so an arm that reaches it (directly, via the
+        // cached `send`, or inside its `ir.<helper>` / `jit_*` builder) before any
+        // clobber needs no head flush. Every slot *read* goes through the
+        // GP-resident-aware `load` / `write_back_slot` / `to_S_unguarded` /
+        // `copy_slot`, each of which re-homes a live resident rather than reading a
+        // stale stack home, so leaving a resident live into such an arm is safe.
+        // (That resident-awareness was missing from `write_back_slot` /
+        // `to_S_unguarded` / `copy_slot` and showed up as `string_scrub_block_form`
+        // / `hash_*` JIT miscompiles until fixed.) A head flush is also a no-op when
         // the register file is empty.
         //
-        // The following are also exempt because they neither call a GP-clobbering
-        // C-ABI helper nor read a slot through its stale stack home (every slot
-        // read goes through the GP-resident-aware `load`):
-        // - `FrozenLiteral` materializes a literal into `dst` (register-only).
-        // - `LoadConst` folds to a constant / `Sf` (register-only) and `StoreConst`
-        //   flushes at its own `get_using_fpr` chokepoint.
-        // - `StoreIvar` stores from a register and its write barrier preserves the
-        //   caller-saved set.
-        // - `Ret` loads the return value into rax (`reg_move` straight from a
-        //   resident when live) and returns, abandoning the dead residents.
+        // So the arms that omit the head flush are: the GP-aware integer `BinOp` /
+        // `BinCmp` / `BinCmpBr`; the register-only / self-chokepointing
+        // `FrozenLiteral` / `LoadConst` / `StoreConst` / `StoreIvar` / `Ret`;
+        // `MethodCall` / `Yield` / `Index` / `IndexAssign` (route through `send` /
+        // the yield lowerings); and every arm whose body reaches `get_using_fpr`
+        // (the `new_*` builders, cvar/gvar accessors, `*Def`, `Defined*`).
         //
-        // `LoadIvar` is deliberately **not** exempt: it loads the ivar into a pool
-        // register, but a prior resident left live *across* that load sequence gets
-        // corrupted under register pressure (a `core/math` ruby/spec regression).
-        // Flushing before it still keeps the `@ivar op x` register fast-path: the
-        // value loads straight into a pool register and the *consuming* op (a
-        // `BinOp`) is exempt, so the ivar resident survives into it.
-        if !matches!(
-            trace_ir,
-            TraceIr::BinOp { .. }
-                | TraceIr::BinCmp { .. }
-                | TraceIr::BinCmpBr { .. }
-                | TraceIr::FrozenLiteral(..)
-                | TraceIr::LoadConst(..)
-                | TraceIr::StoreConst(..)
-                | TraceIr::StoreIvar(..)
-                | TraceIr::Ret(..)
-        ) {
-            state.flush_gp(ir);
-        }
+        // `LoadIvar` still flushes: it loads the ivar into a pool register with no
+        // `get_using_fpr` on the path, and a prior resident left live *across* that
+        // load is corrupted under register pressure (a `core/math` regression).
         match trace_ir {
             TraceIr::InitMethod(info) => {
+                state.flush_gp(ir);
                 assert!(!self.is_loop());
                 ir.push(AsmInst::Init {
                     info,
@@ -219,11 +206,13 @@ impl<'a> JitContext<'a> {
                 ir.push(AsmInst::Preparation);
             }
             TraceIr::LoopStart { .. } => {
+                state.flush_gp(ir);
                 state.unset_side_effect_guard();
                 self.inc_loop_count();
                 state.exec_gc(ir, false);
             }
             TraceIr::LoopEnd => {
+                state.flush_gp(ir);
                 state.unset_side_effect_guard();
                 assert_ne!(0, self.loop_count());
                 self.dec_loop_count();
@@ -256,6 +245,7 @@ impl<'a> JitContext<'a> {
                 state.def_reg2acc_class(ir, GP::Rax, dst, ARRAY_CLASS);
             }
             TraceIr::Lambda { .. } => {
+                state.flush_gp(ir);
                 return Err(CompileError);
             }
             TraceIr::Hash { dst, args, len } => {
@@ -305,6 +295,7 @@ impl<'a> JitContext<'a> {
                 state.store_constant(ir, src, id);
             }
             TraceIr::LoadIvar(dst, name, cache) => {
+                state.flush_gp(ir);
                 let self_class = self.self_class();
                 if let Some(ivarid) = self.store[self_class].get_ivarid(name) {
                     if let Some((cached_class, cached_ivarid)) = cache
@@ -350,15 +341,18 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
             TraceIr::LoadDynVar(dst, src) => {
+                state.flush_gp(ir);
                 assert!(!dst.is_self());
                 self.load_dynvar(state, ir, src);
                 state.def_rax2acc(ir, dst);
             }
             TraceIr::StoreDynVar(dst, src) => {
+                state.flush_gp(ir);
                 self.store_dynvar(state, ir, dst, src);
                 state.unset_side_effect_guard();
             }
             TraceIr::BlockArgProxy(ret, outer) => {
+                state.flush_gp(ir);
                 // When this frame is specialized for a caller call site
                 // that passes no block (no literal block and no `&blk`),
                 // the forwarded `&block` of `...` is provably nil at
@@ -380,6 +374,7 @@ impl<'a> JitContext<'a> {
                 }
             }
             TraceIr::BlockArg(ret, outer) => {
+                state.flush_gp(ir);
                 state.def_S(ret);
                 ir.block_arg(state, ret, outer, pc);
                 state.unset_side_effect_guard();
@@ -551,6 +546,7 @@ impl<'a> JitContext<'a> {
             TraceIr::InlineCache => {}
 
             TraceIr::ArrayTEq { lhs, rhs } => {
+                state.flush_gp(ir);
                 state.write_back_slots(ir, &[lhs, rhs]);
                 state.discard(lhs);
                 let error = ir.new_error(state);
@@ -561,6 +557,7 @@ impl<'a> JitContext<'a> {
             }
 
             TraceIr::ToA { dst, src } => {
+                state.flush_gp(ir);
                 let error = ir.new_error(state);
                 state.write_back_slot(ir, src);
                 ir.to_a(state, src);
@@ -569,9 +566,11 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
             TraceIr::Mov(dst, src) => {
+                state.flush_gp(ir);
                 state.copy_slot(ir, src, dst);
             }
             TraceIr::ConcatStr(dst, arg, len) => {
+                state.flush_gp(ir);
                 state.write_back_range(ir, arg, len);
                 state.discard(dst);
                 let error = ir.new_error(state);
@@ -581,6 +580,7 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
             TraceIr::ConcatRegexp(dst, arg, len) => {
+                state.flush_gp(ir);
                 state.write_back_range(ir, arg, len);
                 state.discard(dst);
                 let error = ir.new_error(state);
@@ -593,6 +593,7 @@ impl<'a> JitContext<'a> {
                 src,
                 dst: (dst, len, rest_pos),
             } => {
+                state.flush_gp(ir);
                 state.load(ir, src, GP::Rdi);
                 for reg in dst.0..dst.0 + len {
                     state.def_S(SlotId(reg));
@@ -600,12 +601,14 @@ impl<'a> JitContext<'a> {
                 ir.expand_array(state, dst, len, rest_pos);
             }
             TraceIr::UndefMethod { undef } => {
+                state.flush_gp(ir);
                 ir.undef_method(state, undef);
                 state.unset_class_version_guard();
                 state.unset_const_version_guard();
                 state.unset_side_effect_guard();
             }
             TraceIr::AliasMethod { new, old } => {
+                state.flush_gp(ir);
                 state.write_back_slots(ir, &[new, old]);
                 ir.alias_method(state, new, old);
                 state.unset_class_version_guard();
@@ -749,6 +752,7 @@ impl<'a> JitContext<'a> {
                 return Ok(CompileResult::Return(result));
             }
             TraceIr::MethodRet(ret) => {
+                state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
                 if let Some((spec_ids, extra)) = self.method_caller_specialized_ids() {
@@ -766,6 +770,7 @@ impl<'a> JitContext<'a> {
                 return Ok(CompileResult::MethodReturn(result));
             }
             TraceIr::BlockBreak(ret) => {
+                state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
                 if let Some((spec_ids, extra)) = self.iter_caller_specialized_ids() {
@@ -783,31 +788,37 @@ impl<'a> JitContext<'a> {
                 return Ok(CompileResult::Break(result));
             }
             TraceIr::Raise(ret) => {
+                state.flush_gp(ir);
                 state.locals_to_S(ir);
                 state.load(ir, ret, GP::Rax);
                 ir.push(AsmInst::Raise);
                 return Ok(CompileResult::Raise);
             }
             TraceIr::Retry => {
+                state.flush_gp(ir);
                 state.locals_to_S(ir);
                 ir.push(AsmInst::Retry(pc));
                 return Ok(CompileResult::Raise);
             }
             TraceIr::Redo => {
+                state.flush_gp(ir);
                 state.locals_to_S(ir);
                 ir.push(AsmInst::Redo(pc));
                 return Ok(CompileResult::Raise);
             }
 
             TraceIr::EnsureEnd => {
+                state.flush_gp(ir);
                 state.locals_to_S(ir);
                 ir.push(AsmInst::EnsureEnd);
             }
             TraceIr::Br(disp) => {
+                state.flush_gp(ir);
                 let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
                 return Ok(CompileResult::Branch(dest_bb));
             }
             TraceIr::CondBr(cond_, disp, false, brkind) => {
+                state.flush_gp(ir);
                 let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
                 if state.is_truthy(cond_) {
                     if brkind == BrKind::BrIf {
@@ -823,6 +834,7 @@ impl<'a> JitContext<'a> {
                 }
             }
             TraceIr::NilBr(cond_, disp) => {
+                state.flush_gp(ir);
                 let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
                 if state.is_nil(cond_) {
                     return Ok(CompileResult::Branch(dest_bb));
@@ -834,8 +846,11 @@ impl<'a> JitContext<'a> {
                     self.new_side_branch(bc_pos, dest_bb, state.clone(), branch_dest);
                 }
             }
-            TraceIr::CondBr(_, _, true, _) => {}
+            TraceIr::CondBr(_, _, true, _) => {
+                state.flush_gp(ir);
+            }
             TraceIr::CheckLocal(local, disp) => {
+                state.flush_gp(ir);
                 let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
                 match state.mode(local) {
                     LinkMode::S(_) | LinkMode::C(_) => {
@@ -855,6 +870,7 @@ impl<'a> JitContext<'a> {
                 }
             }
             TraceIr::CheckKwRest(local) => {
+                state.flush_gp(ir);
                 // D1 kwrest deferral: in a specialized pure forwarding
                 // trampoline (`def f(...) = g(...)`) whose `...` rest is
                 // source-routed (see `forward_rest_deferral`), skip
@@ -877,6 +893,7 @@ impl<'a> JitContext<'a> {
                 else_disp,
                 branch_table,
             } => {
+                state.flush_gp(ir);
                 state.load_fixnum(ir, cond, GP::Rdi);
                 let mut branch_labels = vec![];
                 let else_dest = self.iseq().get_bb(bc_pos + 1 + else_disp);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -185,11 +185,17 @@ impl<'a> JitContext<'a> {
         // - `FrozenLiteral` materializes a literal into `dst` (register-only).
         // - `LoadConst` folds to a constant / `Sf` (register-only) and `StoreConst`
         //   flushes at its own `get_using_fpr` chokepoint.
-        // - `LoadIvar` loads the ivar straight into a pool register (a resident);
-        //   `StoreIvar` stores from a register and its write barrier preserves the
+        // - `StoreIvar` stores from a register and its write barrier preserves the
         //   caller-saved set.
         // - `Ret` loads the return value into rax (`reg_move` straight from a
         //   resident when live) and returns, abandoning the dead residents.
+        //
+        // `LoadIvar` is deliberately **not** exempt: it loads the ivar into a pool
+        // register, but a prior resident left live *across* that load sequence gets
+        // corrupted under register pressure (a `core/math` ruby/spec regression).
+        // Flushing before it still keeps the `@ivar op x` register fast-path: the
+        // value loads straight into a pool register and the *consuming* op (a
+        // `BinOp`) is exempt, so the ivar resident survives into it.
         if !matches!(
             trace_ir,
             TraceIr::BinOp { .. }
@@ -198,7 +204,6 @@ impl<'a> JitContext<'a> {
                 | TraceIr::FrozenLiteral(..)
                 | TraceIr::LoadConst(..)
                 | TraceIr::StoreConst(..)
-                | TraceIr::LoadIvar(..)
                 | TraceIr::StoreIvar(..)
                 | TraceIr::Ret(..)
         ) {

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -1034,19 +1034,12 @@ impl<'a> JitContext<'a> {
 }
 
 enum BinaryOpType {
-    Integer(OpMode),
+    Integer(SlotId, SlotId),
     Float(FBinOpInfo),
     Other(Option<ClassId>, Option<ClassId>),
 }
 
 impl AbstractState {
-    fn binary_integer_mode(&self, lhs: SlotId, rhs: SlotId) -> OpMode {
-        // `OpMode` is RR-only: an integer-literal operand is no longer folded
-        // into an immediate (`RI`/`IR`); it is materialized in its stack slot
-        // and loaded like any other operand.
-        OpMode::RR(lhs, rhs)
-    }
-
     fn binary_class(
         &self,
         lhs: SlotId,
@@ -1071,8 +1064,7 @@ impl AbstractState {
         if let (Some(lhs_class), Some(rhs_class)) = (lhs_class, rhs_class) {
             match (lhs_class, rhs_class) {
                 (INTEGER_CLASS, INTEGER_CLASS) => {
-                    let mode = self.binary_integer_mode(lhs, rhs);
-                    return BinaryOpType::Integer(mode);
+                    return BinaryOpType::Integer(lhs, rhs);
                 }
                 (INTEGER_CLASS | FLOAT_CLASS, INTEGER_CLASS | FLOAT_CLASS) => {
                     let info = FBinOpInfo {

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -1024,13 +1024,10 @@ enum BinaryOpType {
 
 impl AbstractState {
     fn binary_integer_mode(&self, lhs: SlotId, rhs: SlotId) -> OpMode {
-        if let Some(rhs) = self.is_i16_literal(rhs) {
-            OpMode::RI(lhs, rhs)
-        } else if let Some(lhs) = self.is_i16_literal(lhs) {
-            OpMode::IR(lhs, rhs)
-        } else {
-            OpMode::RR(lhs, rhs)
-        }
+        // `OpMode` is RR-only: an integer-literal operand is no longer folded
+        // into an immediate (`RI`/`IR`); it is materialized in its stack slot
+        // and loaded like any other operand.
+        OpMode::RR(lhs, rhs)
     }
 
     fn binary_class(

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -96,6 +96,9 @@ impl<'a> JitContext<'a> {
                     // recorded — the merge machinery is R15/stack-only, so a
                     // successor must never inherit a pool-resident (`Alloc`) slot.
                     state.flush_pool(&mut ir);
+                    // `gp-local-alloc`: a successor block starts with an empty GP
+                    // register file (the file is never carried across a merge).
+                    state.flush_gp(&mut ir);
                     self.new_branch(bc_pos, dest_bb, state);
                     return Ok(ir);
                 }
@@ -140,6 +143,10 @@ impl<'a> JitContext<'a> {
             // §9 9d-B: flush pool residents before the fall-through state is
             // recorded for the next block (the merge machinery is stack-only).
             state.flush_pool(&mut ir);
+            // `gp-local-alloc`: the last instruction may be a GP-aware binop, so
+            // flush the GP residents before the fall-through state is recorded —
+            // the successor block starts with an empty register file.
+            state.flush_gp(&mut ir);
             self.prepare_next(state, end)
         }
 
@@ -165,6 +172,15 @@ impl<'a> JitContext<'a> {
         #[cfg(feature = "jit-debug")]
         if let Some(fmt) = TraceIr::format(self.store, self.iseq_id(), pc) {
             eprintln!("{fmt}");
+        }
+        // `gp-local-alloc`: only `IntegerBinOp` is GP-aware. Every other
+        // instruction first flushes the live GP residents back to their stack
+        // homes, so it observes slots in their canonical location. (`BinOp` is
+        // exempt here; its non-integer paths flush inside `binary_op`.) A no-op
+        // when the register file is empty, which is always the case without the
+        // feature — so the default build is unchanged.
+        if !matches!(trace_ir, TraceIr::BinOp { .. }) {
+            state.flush_gp(ir);
         }
         match trace_ir {
             TraceIr::InitMethod(info) => {

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -95,7 +95,6 @@ impl<'a> JitContext<'a> {
                     // §9 9d-B: flush pool residents before the branch state is
                     // recorded — the merge machinery is R15/stack-only, so a
                     // successor must never inherit a pool-resident (`Alloc`) slot.
-                    state.flush_pool(&mut ir);
                     // a successor block starts with an empty GP
                     // register file (the file is never carried across a merge).
                     state.flush_gp(&mut ir);
@@ -142,7 +141,6 @@ impl<'a> JitContext<'a> {
         if !last {
             // §9 9d-B: flush pool residents before the fall-through state is
             // recorded for the next block (the merge machinery is stack-only).
-            state.flush_pool(&mut ir);
             // the last instruction may be a GP-aware binop, so
             // flush the GP residents before the fall-through state is recorded —
             // the successor block starts with an empty register file.
@@ -180,9 +178,14 @@ impl<'a> JitContext<'a> {
         // `binary_op` / `binary_cmp` / `binary_cmp_br`, and the integer compare +
         // branch flushes before its branch since it ends the block.) A no-op when
         // the register file is empty.
+        // `FrozenLiteral` is also exempt: it materializes a literal into `dst`
+        // (register-only, no clobbering call) and is GP-resident-aware.
         if !matches!(
             trace_ir,
-            TraceIr::BinOp { .. } | TraceIr::BinCmp { .. } | TraceIr::BinCmpBr { .. }
+            TraceIr::BinOp { .. }
+                | TraceIr::BinCmp { .. }
+                | TraceIr::BinCmpBr { .. }
+                | TraceIr::FrozenLiteral(..)
         ) {
             state.flush_gp(ir);
         }
@@ -213,9 +216,9 @@ impl<'a> JitContext<'a> {
                 if let Some(imm) = val.is_immediate() {
                     state.def_C(dst, imm);
                 } else {
-                    state.discard(dst);
-                    ir.lit2reg(val, GP::Rax);
-                    state.def_reg2acc_concrete_value(ir, GP::Rax, dst, val);
+                    // Load the literal straight into a GP-pool register resident
+                    // rather than through rax to the stack home (see `def_lit2gp`).
+                    state.def_lit2gp(ir, dst, val);
                 }
             }
             TraceIr::Literal(dst, val) => {
@@ -358,7 +361,6 @@ impl<'a> JitContext<'a> {
             }
             TraceIr::BlockArg(ret, outer) => {
                 state.def_S(ret);
-                state.flush_pool(ir);
                 ir.block_arg(state, ret, outer, pc);
                 state.unset_side_effect_guard();
             }
@@ -531,7 +533,6 @@ impl<'a> JitContext<'a> {
             TraceIr::ArrayTEq { lhs, rhs } => {
                 state.write_back_slots(ir, &[lhs, rhs]);
                 state.discard(lhs);
-                state.flush_pool(ir);
                 let error = ir.new_error(state);
                 ir.array_teq(state, lhs, rhs);
                 ir.handle_error(error);
@@ -542,7 +543,6 @@ impl<'a> JitContext<'a> {
             TraceIr::ToA { dst, src } => {
                 let error = ir.new_error(state);
                 state.write_back_slot(ir, src);
-                state.flush_pool(ir);
                 ir.to_a(state, src);
                 ir.handle_error(error);
                 state.def_rax2acc(ir, dst);
@@ -554,7 +554,6 @@ impl<'a> JitContext<'a> {
             TraceIr::ConcatStr(dst, arg, len) => {
                 state.write_back_range(ir, arg, len);
                 state.discard(dst);
-                state.flush_pool(ir);
                 let error = ir.new_error(state);
                 ir.concat_str(state, arg, len);
                 ir.handle_error(error);
@@ -564,7 +563,6 @@ impl<'a> JitContext<'a> {
             TraceIr::ConcatRegexp(dst, arg, len) => {
                 state.write_back_range(ir, arg, len);
                 state.discard(dst);
-                state.flush_pool(ir);
                 let error = ir.new_error(state);
                 ir.concat_regexp(state, arg, len);
                 ir.handle_error(error);
@@ -579,11 +577,9 @@ impl<'a> JitContext<'a> {
                 for reg in dst.0..dst.0 + len {
                     state.def_S(SlotId(reg));
                 }
-                state.flush_pool(ir);
                 ir.expand_array(state, dst, len, rest_pos);
             }
             TraceIr::UndefMethod { undef } => {
-                state.flush_pool(ir);
                 ir.undef_method(state, undef);
                 state.unset_class_version_guard();
                 state.unset_const_version_guard();
@@ -591,7 +587,6 @@ impl<'a> JitContext<'a> {
             }
             TraceIr::AliasMethod { new, old } => {
                 state.write_back_slots(ir, &[new, old]);
-                state.flush_pool(ir);
                 ir.alias_method(state, new, old);
                 state.unset_class_version_guard();
                 state.unset_const_version_guard();

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -178,14 +178,29 @@ impl<'a> JitContext<'a> {
         // `binary_op` / `binary_cmp` / `binary_cmp_br`, and the integer compare +
         // branch flushes before its branch since it ends the block.) A no-op when
         // the register file is empty.
-        // `FrozenLiteral` is also exempt: it materializes a literal into `dst`
-        // (register-only, no clobbering call) and is GP-resident-aware.
+        //
+        // The following are also exempt because they neither call a GP-clobbering
+        // C-ABI helper nor read a slot through its stale stack home (every slot
+        // read goes through the GP-resident-aware `load`):
+        // - `FrozenLiteral` materializes a literal into `dst` (register-only).
+        // - `LoadConst` folds to a constant / `Sf` (register-only) and `StoreConst`
+        //   flushes at its own `get_using_fpr` chokepoint.
+        // - `LoadIvar` loads the ivar straight into a pool register (a resident);
+        //   `StoreIvar` stores from a register and its write barrier preserves the
+        //   caller-saved set.
+        // - `Ret` loads the return value into rax (`reg_move` straight from a
+        //   resident when live) and returns, abandoning the dead residents.
         if !matches!(
             trace_ir,
             TraceIr::BinOp { .. }
                 | TraceIr::BinCmp { .. }
                 | TraceIr::BinCmpBr { .. }
                 | TraceIr::FrozenLiteral(..)
+                | TraceIr::LoadConst(..)
+                | TraceIr::StoreConst(..)
+                | TraceIr::LoadIvar(..)
+                | TraceIr::StoreIvar(..)
+                | TraceIr::Ret(..)
         ) {
             state.flush_gp(ir);
         }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -173,13 +173,14 @@ impl<'a> JitContext<'a> {
         if let Some(fmt) = TraceIr::format(self.store, self.iseq_id(), pc) {
             eprintln!("{fmt}");
         }
-        // `gp-local-alloc`: only `IntegerBinOp` is GP-aware. Every other
-        // instruction first flushes the live GP residents back to their stack
-        // homes, so it observes slots in their canonical location. (`BinOp` is
-        // exempt here; its non-integer paths flush inside `binary_op`.) A no-op
-        // when the register file is empty, which is always the case without the
-        // feature — so the default build is unchanged.
-        if !matches!(trace_ir, TraceIr::BinOp { .. }) {
+        // `gp-local-alloc`: the integer `BinOp` and `BinCmp` paths are GP-aware.
+        // Every other instruction first flushes the live GP residents back to
+        // their stack homes, so it observes slots in their canonical location.
+        // (`BinOp`/`BinCmp` are exempt here; their non-integer paths flush inside
+        // `binary_op` / `binary_cmp`.) A no-op when the register file is empty,
+        // which is always the case without the feature — so the default build is
+        // unchanged.
+        if !matches!(trace_ir, TraceIr::BinOp { .. } | TraceIr::BinCmp { .. }) {
             state.flush_gp(ir);
         }
         match trace_ir {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -574,8 +574,22 @@ impl AbstractFrame {
         if let Some(gp) = self.gp_regfile.reg_of(slot) {
             return (gp, false);
         }
-        // Not resident: put the value at its canonical stack home (a no-op for an
-        // `S` slot; materializes a constant / boxed float), then load it.
+        // Compile-time fixnum constant: load the tagged immediate straight into a
+        // register, skipping the stack-home round-trip (`%1 = %2 + 1` loads `1`
+        // as `movabs gp, 0x3` rather than materializing it to a slot and reading
+        // it back). The value is a known fixnum, so it needs no guard — report
+        // `fresh = false`.
+        if let Some(v) = self.fixnum_literal_value(slot) {
+            let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
+            if let Some((reg, s)) = spill {
+                ir.reg2stack(reg, s);
+            }
+            ir.lit2reg(v, gp);
+            self.gp_regfile.bind(gp, slot, /* dirty */ false);
+            return (gp, false);
+        }
+        // Not resident and not a constant: put the value at its canonical stack
+        // home (a no-op for an `S` slot; materializes a boxed float), then load it.
         self.write_back_slot(ir, slot);
         let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
         if let Some((reg, s)) = spill {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -506,21 +506,37 @@ impl AbstractFrame {
     #[cfg(feature = "gp-local-alloc")]
     fn binop_integer_gp(&mut self, ir: &mut AsmIr, kind: BinOpK, dst: Option<SlotId>, mode: OpMode) {
         let OpMode::RR(lhs, rhs) = mode;
+        // 1. Load the operands into registers (reusing a resident copy).
         let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
         let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        // 2. Snapshot the deopt write-back *before* clearing: it must re-home the
+        //    dirty residents that are live at this op's PC — which includes a
+        //    dirty operand that is itself a dead-after temporary (a prior binop
+        //    result consumed here). The guards and the overflow check below all
+        //    side-exit to this point, where the interpreter re-reads the operands
+        //    from their stack homes, so they have to be recoverable.
+        let deopt = ir.new_deopt(self);
+        // 3. `dst` is about to be redefined: drop any stale GP cache of it (done
+        //    after the snapshot, so a `dst` that aliases a dirty operand is still
+        //    re-homed for the re-execution).
         if let Some(dst) = dst {
             self.gp_regfile.invalidate(dst);
         }
-        // The result must stay resident: take a register (evicting the oldest
-        // non-operand resident when full), spilling its dirty value first.
-        let (dst_gp, spill) = self.gp_regfile.alloc_reg(&[lhs_gp, rhs_gp]);
+        // 4. Clear `next_sp`: every temporary the stack pointer has popped is now
+        //    dead. `next_sp` is the sp *after* this op, so the operands — already
+        //    read into registers in step 1 — are freed here too. This must run
+        //    after the load (which still reads them) and before the result
+        //    allocation (so the result can reuse a freed operand's register).
+        let next_sp = self.next_sp();
+        self.gp_regfile.free_above_sp(next_sp);
+        // 5. Allocate the result register and run the op. Pin only `rhs_gp`: the
+        //    result may reuse `lhs_gp` in place (the in-place `dst = lhs op rhs`
+        //    that `IntegerBinOpReg` lowers without a move), but it must never
+        //    collide with `rhs`, which the op reads after the `dst <- lhs` move.
+        let (dst_gp, spill) = self.gp_regfile.alloc_reg(&[rhs_gp]);
         if let Some((reg, slot)) = spill {
             ir.reg2stack(reg, slot);
         }
-        // The register file now reflects the final resident set, so the deopt's
-        // write-back re-homes exactly the dirty residents that are still in
-        // registers (the operands are clean / at their home).
-        let deopt = ir.new_deopt(self);
         if lhs_fresh {
             ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
         }
@@ -532,9 +548,6 @@ impl AbstractFrame {
             self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
             self.def_S_guarded(dst, Guarded::Fixnum);
         }
-        // Liveness: free temporaries the stack pointer has popped.
-        let sp = self.next_sp();
-        self.gp_regfile.free_above_sp(sp);
     }
 
     /// Bring `slot` into a GP register: reuse its resident copy (returning

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -72,6 +72,11 @@ impl<'a> JitContext<'a> {
             | BinOpK::BitXor
             | BinOpK::Exp
             | BinOpK::Rem => {
+                // Not the integer Add/Sub GP path: these always lower to a
+                // (possibly inlined) method call that reads its operands from
+                // their stack homes, so spill the live GP residents first.
+                #[cfg(feature = "gp-local-alloc")]
+                state.flush_gp(ir);
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
                     None => Ok(self.binop_uncached(state, dst)),
@@ -101,13 +106,25 @@ impl<'a> JitContext<'a> {
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Float(info) => {
+                    // The fpr path materializes operands from their stack homes
+                    // (and may box a result); flush the GP residents first.
+                    #[cfg(feature = "gp-local-alloc")]
+                    state.flush_gp(ir);
                     state.binop_float(ir, kind, dst, info);
                     Ok(CompileResult::Continue)
                 }
-                BinaryOpType::Other(None, _) => Ok(self.binop_uncached(state, dst)),
-                BinaryOpType::Other(Some(lhs_class), rhs_class) => self.call_binary_method(
-                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
-                ),
+                BinaryOpType::Other(None, _) => {
+                    #[cfg(feature = "gp-local-alloc")]
+                    state.flush_gp(ir);
+                    Ok(self.binop_uncached(state, dst))
+                }
+                BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                    #[cfg(feature = "gp-local-alloc")]
+                    state.flush_gp(ir);
+                    self.call_binary_method(
+                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
+                    )
+                }
             },
         }
     }
@@ -429,9 +446,28 @@ impl AbstractFrame {
         if let Some((lhs, rhs)) = self.check_concrete_i64(mode)
             && let Some(result) = self.binop_integer_folded(kind, lhs, rhs)
         {
+            // The fold redefines `dst` as a constant; drop any stale GP cache of
+            // it so a later op does not reuse the register's old value. Other
+            // residents stay live (the fold emits nothing and reads no slot).
+            #[cfg(feature = "gp-local-alloc")]
+            if let Some(dst) = dst {
+                self.gp_regfile.invalidate(dst);
+            }
             self.def_C(dst, result);
             return;
         };
+
+        // `gp-local-alloc`: keep `Add`/`Sub` operands and result in GP registers
+        // across consecutive binops (the local allocator). `Mul`/`Div` clobber
+        // `rhs` / use rax-rdx, so they fall through to the slot path below after
+        // flushing the register file.
+        #[cfg(feature = "gp-local-alloc")]
+        if let BinOpK::Add | BinOpK::Sub = kind {
+            self.binop_integer_gp(ir, kind, dst, mode);
+            return;
+        }
+        #[cfg(feature = "gp-local-alloc")]
+        self.flush_gp(ir);
 
         // §slot-IR: keep the AsmIR layer free of physical registers for the
         // fixnum binop. Write the operand slots back to their stack homes and
@@ -458,6 +494,67 @@ impl AbstractFrame {
         if let Some(dst) = dst {
             self.def_S_guarded(dst, Guarded::Fixnum);
         }
+    }
+
+    /// `gp-local-alloc`: the register-allocated `Add`/`Sub` path. Operands are
+    /// brought into GP registers (reusing a resident copy, else materialized to
+    /// the stack home and loaded + fixnum-guarded), the result is allocated a
+    /// register (evicting the oldest resident if full), and the op runs in
+    /// registers (overflow -> deopt). The result stays resident — its stack home
+    /// is written only when the file is flushed (before a non-binop or at the
+    /// block boundary) or re-homed by a deopt write-back.
+    #[cfg(feature = "gp-local-alloc")]
+    fn binop_integer_gp(&mut self, ir: &mut AsmIr, kind: BinOpK, dst: Option<SlotId>, mode: OpMode) {
+        let OpMode::RR(lhs, rhs) = mode;
+        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        if let Some(dst) = dst {
+            self.gp_regfile.invalidate(dst);
+        }
+        // The result must stay resident: take a register (evicting the oldest
+        // non-operand resident when full), spilling its dirty value first.
+        let (dst_gp, spill) = self.gp_regfile.alloc_reg(&[lhs_gp, rhs_gp]);
+        if let Some((reg, slot)) = spill {
+            ir.reg2stack(reg, slot);
+        }
+        // The register file now reflects the final resident set, so the deopt's
+        // write-back re-homes exactly the dirty residents that are still in
+        // registers (the operands are clean / at their home).
+        let deopt = ir.new_deopt(self);
+        if lhs_fresh {
+            ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
+        }
+        if rhs_fresh {
+            ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
+        }
+        ir.integer_binop_reg(kind, dst_gp, lhs_gp, rhs_gp, deopt);
+        if let Some(dst) = dst {
+            self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
+            self.def_S_guarded(dst, Guarded::Fixnum);
+        }
+        // Liveness: free temporaries the stack pointer has popped.
+        let sp = self.next_sp();
+        self.gp_regfile.free_above_sp(sp);
+    }
+
+    /// Bring `slot` into a GP register: reuse its resident copy (returning
+    /// `fresh = false`, no reload/guard) or materialize it to its stack home,
+    /// load it, and report `fresh = true` so the caller emits the fixnum guard.
+    #[cfg(feature = "gp-local-alloc")]
+    fn gp_ensure(&mut self, ir: &mut AsmIr, slot: SlotId, pinned: &[GP]) -> (GP, bool) {
+        if let Some(gp) = self.gp_regfile.reg_of(slot) {
+            return (gp, false);
+        }
+        // Not resident: put the value at its canonical stack home (a no-op for an
+        // `S` slot; materializes a constant / boxed float), then load it.
+        self.write_back_slot(ir, slot);
+        let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
+        if let Some((reg, s)) = spill {
+            ir.reg2stack(reg, s);
+        }
+        ir.stack2reg(slot, gp);
+        self.gp_regfile.bind(gp, slot, /* dirty */ false);
+        (gp, true)
     }
 
     fn binop_float_folded(&self, kind: BinOpK, lhs: f64, rhs: f64) -> Option<f64> {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -65,16 +65,10 @@ impl<'a> JitContext<'a> {
             // Integer#| / Integer#& / Integer#^ / Integer#** / Integer#% /
             // Float#** / Float#% handles code generation using both-side class
             // info from the BinOp inline cache.
-            BinOpK::Shl
-            | BinOpK::Shr
-            | BinOpK::BitOr
-            | BinOpK::BitAnd
-            | BinOpK::BitXor
-            | BinOpK::Exp
-            | BinOpK::Rem => {
-                // Not the integer Add/Sub GP path: these always lower to a
-                // (possibly inlined) method call that reads its operands from
-                // their stack homes, so spill the live GP residents first.
+            BinOpK::Shl | BinOpK::Shr | BinOpK::Exp | BinOpK::Rem => {
+                // Not the integer GP path: these always lower to a (possibly
+                // inlined) method call that reads its operands from their stack
+                // homes, so spill the live GP residents first.
                 state.flush_gp(ir);
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
@@ -437,13 +431,11 @@ impl AbstractFrame {
                 }
                 return Immediate::check_fixnum(lhs.ruby_div(&rhs));
             }
-            BinOpK::Rem
-            | BinOpK::Exp
-            | BinOpK::BitOr
-            | BinOpK::BitAnd
-            | BinOpK::BitXor
-            | BinOpK::Shl
-            | BinOpK::Shr => unreachable!(),
+            // Bitwise ops on two i63 fixnums always yield an i63 fixnum.
+            BinOpK::BitOr => return Immediate::check_fixnum(lhs | rhs),
+            BinOpK::BitAnd => return Immediate::check_fixnum(lhs & rhs),
+            BinOpK::BitXor => return Immediate::check_fixnum(lhs ^ rhs),
+            BinOpK::Rem | BinOpK::Exp | BinOpK::Shl | BinOpK::Shr => unreachable!(),
         }
         None
     }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -66,10 +66,11 @@ impl<'a> JitContext<'a> {
             // Float#** / Float#% handles code generation using both-side class
             // info from the BinOp inline cache.
             BinOpK::Shl | BinOpK::Shr | BinOpK::Exp | BinOpK::Rem => {
-                // Not the integer GP path: these always lower to a (possibly
-                // inlined) method call that reads its operands from their stack
-                // homes, so spill the live GP residents first.
-                state.flush_gp(ir);
+                // Dispatched through `call_binary_method`. No flush here: a
+                // register-only inline (e.g. `Integer#<<`) reads its operands
+                // GP-resident-aware and keeps the residents live, while any C-ABI
+                // call (a clobbering inline like `Array#<<`, or the cached
+                // method-call path) flushes them at its `get_using_fpr` chokepoint.
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
                     None => Ok(self.binop_uncached(state, dst)),
@@ -112,11 +113,11 @@ impl<'a> JitContext<'a> {
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Other(None, _) => {
-                    state.flush_gp(ir);
+                    // Recompiles (deopts) — its write-back re-homes the residents.
                     Ok(self.binop_uncached(state, dst))
                 }
                 BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                    state.flush_gp(ir);
+                    // Any C-ABI call flushes at its `get_using_fpr` chokepoint.
                     self.call_binary_method(
                         state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
                     )
@@ -561,8 +562,10 @@ impl AbstractFrame {
             self.gp_regfile.invalidate(rhs);
         }
         if let Some(dst) = dst {
-            self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
+            // Define first (this clears any stale resident of `dst` via `clear`),
+            // then bind the result register.
             self.def_S_guarded(dst, Guarded::Fixnum);
+            self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
         }
     }
 

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -479,50 +479,24 @@ impl AbstractFrame {
             return;
         };
 
-        // keep `Add`/`Sub` operands and result in GP registers
-        // across consecutive binops (the local allocator). `Mul`/`Div` clobber
-        // `rhs` / use rax-rdx, so they fall through to the slot path below after
-        // flushing the register file.
-        if let BinOpK::Add | BinOpK::Sub = kind {
-            self.binop_integer_gp(ir, kind, dst, lhs, rhs);
-            return;
-        }
-        self.flush_gp(ir);
-
-        // §slot-IR: keep the AsmIR layer free of physical registers for the
-        // fixnum binop. Write the operand slots back to their stack homes and
-        // emit a slot-based op; the LIR lowering loads them into scratch regs,
-        // fixnum-guards, computes (overflow -> deopt), and stores the result to
-        // `dst` (when present). The result lives on the stack (`S(Fixnum)`) — the
-        // universal interchange with the still-register-based ops, so the two
-        // coexist. A `None` dst is the discarded-result case: the op still runs
-        // (its overflow / divide-by-zero side-exit is observable) but nothing is
-        // stored. `Div`'s result is produced in `rax` (the lowering handles that).
-        debug_assert!(matches!(
-            kind,
-            BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div
-        ));
-        self.write_back_slots(ir, &[lhs, rhs]);
-        let deopt = self.deopt_point();
-        ir.transfer(TransferIR::IntegerBinOpSlot {
-            kind,
-            dst,
-            lhs,
-            rhs,
-            deopt,
-        });
-        if let Some(dst) = dst {
-            self.def_S_guarded(dst, Guarded::Fixnum);
-        }
+        // All four fixnum ops keep their operands and result in GP registers
+        // (the local allocator), reusing residents across consecutive ops.
+        self.binop_integer_gp(ir, kind, dst, lhs, rhs);
     }
 
-    /// the register-allocated `Add`/`Sub` path. Operands are
-    /// brought into GP registers (reusing a resident copy, else materialized to
-    /// the stack home and loaded + fixnum-guarded), the result is allocated a
-    /// register (evicting the oldest resident if full), and the op runs in
-    /// registers (overflow -> deopt). The result stays resident — its stack home
-    /// is written only when the file is flushed (before a non-binop or at the
-    /// block boundary) or re-homed by a deopt write-back.
+    /// The register-allocated fixnum binop. Operands are brought into GP
+    /// registers (reusing a resident copy, else materialized to the stack home
+    /// and loaded + fixnum-guarded), the result is allocated a register (evicting
+    /// the oldest resident if full), and the op runs in registers (overflow ->
+    /// deopt). The result stays resident — its stack home is written only when
+    /// the file is flushed (before a non-binop or at the block boundary) or
+    /// re-homed by a deopt write-back.
+    ///
+    /// `Mul` and `Div` destroy the `rhs` register (Mul untags it in place; Div's
+    /// `idiv` sequence sarq's it), and `Div` produces its quotient in `rax`. So
+    /// for those two the `rhs` resident is written back to its home (if dirty and
+    /// still live) before the op and dropped from the file afterwards, and `Div`
+    /// pins both operands so the result lands in a distinct register.
     fn binop_integer_gp(
         &mut self,
         ir: &mut AsmIr,
@@ -531,9 +505,24 @@ impl AbstractFrame {
         lhs: SlotId,
         rhs: SlotId,
     ) {
+        // `Mul` and `Div` destroy the `rhs` register before their overflow /
+        // divide-by-zero side-exit (Mul `sarq`s it; Div's idiv sequence too).
+        let rhs_clobbered = matches!(kind, BinOpK::Mul | BinOpK::Div);
         // 1. Load the operands into registers (reusing a resident copy).
         let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
         let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        // 1b. For `Mul`/`Div`: if `rhs` is a dirty resident, write it to its home
+        //     and mark it clean *before* the deopt snapshot. The op clobbers
+        //     `rhs_gp` before the side-exit, so the snapshot must re-home `rhs`
+        //     from its (now-current) stack home, not from the dead register — a
+        //     `dirty_residents()` entry would otherwise store garbage to the slot
+        //     on deopt (e.g. the untagged divisor, an invalid `Value`). A fresh /
+        //     constant operand is already recoverable (its home is current, or it
+        //     re-materializes from `LinkMode::C`).
+        if rhs_clobbered && let Some(reg) = self.gp_regfile.dirty_reg_of(rhs) {
+            ir.reg2stack(reg, rhs);
+            self.gp_regfile.sync(rhs);
+        }
         // 2. Snapshot the deopt write-back *before* clearing: it must re-home the
         //    dirty residents that are live at this op's PC — which includes a
         //    dirty operand that is itself a dead-after temporary (a prior binop
@@ -554,11 +543,17 @@ impl AbstractFrame {
         //    allocation (so the result can reuse a freed operand's register).
         let next_sp = self.next_sp();
         self.gp_regfile.free_above_sp(next_sp);
-        // 5. Allocate the result register and run the op. Pin only `rhs_gp`: the
-        //    result may reuse `lhs_gp` in place (the in-place `dst = lhs op rhs`
-        //    that `IntegerBinOpReg` lowers without a move), but it must never
-        //    collide with `rhs`, which the op reads after the `dst <- lhs` move.
-        let (dst_gp, spill) = self.gp_regfile.alloc_reg(&[rhs_gp]);
+        // 5. Allocate the result register and run the op. `Add`/`Sub` compute in
+        //    the lhs position, so pin only `rhs_gp` and let the result reuse
+        //    `lhs_gp` in place (no move). `Mul`/`Div` clobber `rhs` and (Div)
+        //    produce in `rax`, so pin both operands — `lhs_gp` must survive the op
+        //    intact for the deopt write-back — and take a distinct register.
+        let pinned: &[GP] = if rhs_clobbered {
+            &[lhs_gp, rhs_gp]
+        } else {
+            &[rhs_gp]
+        };
+        let (dst_gp, spill) = self.gp_regfile.alloc_reg(pinned);
         if let Some((reg, slot)) = spill {
             ir.reg2stack(reg, slot);
         }
@@ -569,6 +564,10 @@ impl AbstractFrame {
             ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
         }
         ir.integer_binop_reg(kind, dst_gp, lhs_gp, rhs_gp, deopt);
+        // The op left garbage in `rhs_gp`: forget that it cached `rhs`.
+        if rhs_clobbered {
+            self.gp_regfile.invalidate(rhs);
+        }
         if let Some(dst) = dst {
             self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
             self.def_S_guarded(dst, Guarded::Fixnum);

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -106,10 +106,16 @@ impl<'a> JitContext<'a> {
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Float(info) => {
-                    // The fpr path materializes operands from their stack homes
-                    // (and may box a result); flush the GP residents first.
+                    // The fpr path computes in xmm: it never touches the GP
+                    // allocatable registers and never allocates (a flonum result
+                    // stays in an FPReg; boxing is deferred to a later write-back,
+                    // which flushes GP itself), and its deopt write-back already
+                    // re-homes the GP residents. So the residents survive a flush.
+                    // But it reads its operands from their stack homes, so a
+                    // GP-resident operand (the integer side of a mixed op) must be
+                    // synced to its home first; then drop a stale cache of `dst`.
                     #[cfg(feature = "gp-local-alloc")]
-                    state.flush_gp(ir);
+                    state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
                     state.binop_float(ir, kind, dst, info);
                     Ok(CompileResult::Continue)
                 }
@@ -147,6 +153,14 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Continue)
             }
             BinaryOpType::Float(info) => {
+                // The float comparison computes in xmm and stores a bool: it
+                // never touches the GP allocatable registers and never allocates,
+                // and its deopt write-back re-homes the GP residents. The
+                // residents survive, but the op reads its operands from their
+                // stack homes — so sync a GP-resident operand (the integer side
+                // of a mixed compare) first, then drop a stale cache of `dst`.
+                #[cfg(feature = "gp-local-alloc")]
+                state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
                 state.gen_cmp_float(ir, dst, info, kind);
                 Ok(CompileResult::Continue)
             }
@@ -154,6 +168,8 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                #[cfg(feature = "gp-local-alloc")]
+                state.flush_gp(ir);
                 if polymorphic {
                     self.emit_generic_cmp(state, ir, kind, lhs, rhs);
                     state.def_rax2acc(ir, dst);
@@ -570,6 +586,30 @@ impl AbstractFrame {
         (gp, true)
     }
 
+    /// `gp-local-alloc`: prepare the GP register file for a float op that keeps
+    /// the residents alive (it computes in xmm without clobbering them). The op
+    /// reads its operands from their stack homes, so a GP-resident operand — the
+    /// integer side of a mixed `Integer <op> Float` — is written back to its home
+    /// and marked clean (it stays cached for a following integer op). Finally any
+    /// stale GP cache of the result slot is dropped.
+    #[cfg(feature = "gp-local-alloc")]
+    fn gp_sync_float_operands(
+        &mut self,
+        ir: &mut AsmIr,
+        lhs: SlotId,
+        rhs: SlotId,
+        dst: Option<SlotId>,
+    ) {
+        for slot in [lhs, rhs] {
+            if let Some(reg) = self.gp_regfile.sync(slot) {
+                ir.reg2stack(reg, slot);
+            }
+        }
+        if let Some(dst) = dst {
+            self.gp_regfile.invalidate(dst);
+        }
+    }
+
     fn binop_float_folded(&self, kind: BinOpK, lhs: f64, rhs: f64) -> Option<f64> {
         Some(match kind {
             BinOpK::Add => lhs + rhs,
@@ -630,25 +670,77 @@ impl AbstractFrame {
         mode: OpMode,
     ) {
         if let Some((lhs, rhs)) = self.check_concrete_i64(mode) {
+            // The fold redefines `dst`; drop any stale GP cache of it.
+            #[cfg(feature = "gp-local-alloc")]
+            if let Some(dst) = dst {
+                self.gp_regfile.invalidate(dst);
+            }
             self.fold_constant_cmp(kind, lhs, rhs, dst);
             return;
         };
+        #[cfg(feature = "gp-local-alloc")]
+        {
+            self.gen_cmp_integer_gp(ir, kind, dst, mode);
+            return;
+        }
         // §slot-IR: keep the AsmIR layer free of physical registers for the
         // fixnum comparison. Write the operand slots back to the stack and emit
         // a slot-based cmp; the LIR lowering loads them into scratch regs,
         // fixnum-guards, compares, and stores the boolean result to `dst`.
-        let OpMode::RR(l, r) = mode;
-        self.write_back_slots(ir, &[l, r]);
-        let deopt = self.deopt_point();
-        ir.transfer(TransferIR::IntegerCmpSlot {
-            mode,
-            kind,
-            dst,
-            deopt,
-        });
+        #[cfg(not(feature = "gp-local-alloc"))]
+        {
+            let OpMode::RR(l, r) = mode;
+            self.write_back_slots(ir, &[l, r]);
+            let deopt = self.deopt_point();
+            ir.transfer(TransferIR::IntegerCmpSlot {
+                mode,
+                kind,
+                dst,
+                deopt,
+            });
+            if let Some(dst) = dst {
+                // The result is a boolean `Value` on the stack (the lowering
+                // stored it). `def_S` defines it as `Guarded::Value`; match that.
+                self.def_S(dst);
+            }
+        }
+    }
+
+    /// `gp-local-alloc`: the register-allocated fixnum comparison. Operands are
+    /// brought into GP registers (reusing residents from a prior binop), guarded,
+    /// and compared in registers; the boolean result is stored to `dst`'s stack
+    /// home (a bool is never a GP resident, so the file shrinks by the operands
+    /// the stack pointer has popped and gains nothing).
+    #[cfg(feature = "gp-local-alloc")]
+    fn gen_cmp_integer_gp(
+        &mut self,
+        ir: &mut AsmIr,
+        kind: CmpKind,
+        dst: Option<SlotId>,
+        mode: OpMode,
+    ) {
+        let OpMode::RR(lhs, rhs) = mode;
+        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        // Snapshot the deopt write-back before clearing (the guards side-exit to
+        // a point where the interpreter re-reads the operands from their homes).
+        let deopt = ir.new_deopt(self);
+        // The result `dst` is redefined as a bool: drop any stale GP cache of it.
         if let Some(dst) = dst {
-            // The result is a boolean `Value` on the stack (the lowering stored
-            // it). `def_rax2acc` defines it as `Guarded::Value`; match that.
+            self.gp_regfile.invalidate(dst);
+        }
+        // Clear the popped operand temporaries so a following binop can reuse
+        // their registers.
+        let next_sp = self.next_sp();
+        self.gp_regfile.free_above_sp(next_sp);
+        if lhs_fresh {
+            ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
+        }
+        if rhs_fresh {
+            ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
+        }
+        ir.integer_cmp_reg(kind, dst, lhs_gp, rhs_gp);
+        if let Some(dst) = dst {
             self.def_S(dst);
         }
     }

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -198,7 +198,6 @@ impl<'a> JitContext<'a> {
         state.write_back_slots(ir, &[lhs, rhs]);
         // §9 9d-B: the generic comparison emits a C-ABI call; flush any
         // caller-saved GP-pool resident first (no-op when the pool is empty).
-        state.flush_pool(ir);
         self.guard_class_version(state, ir, true);
         let error = ir.new_error(state);
         // Part C: `==`/`!=` get an inline immediate fast path with a
@@ -565,7 +564,7 @@ impl AbstractFrame {
             // Define first (this clears any stale resident of `dst` via `clear`),
             // then bind the result register.
             self.def_S_guarded(dst, Guarded::Fixnum);
-            self.gp_regfile.bind(dst_gp, dst, /* dirty */ true);
+            self.gp_regfile.bind(dst_gp, dst, /* dirty */ true, /* fixnum */ true);
         }
     }
 
@@ -574,7 +573,11 @@ impl AbstractFrame {
     /// load it, and report `fresh = true` so the caller emits the fixnum guard.
     fn gp_ensure(&mut self, ir: &mut AsmIr, slot: SlotId, pinned: &[GP]) -> (GP, bool) {
         if let Some(gp) = self.gp_regfile.reg_of(slot) {
-            return (gp, false);
+            // A resident produced by an integer op is a known fixnum (no guard).
+            // A resident produced by a call/yield result is a general `Value`:
+            // the first integer op to consume it must emit a fixnum guard, after
+            // which `take_needs_fixnum_guard` upgrades it to known-fixnum.
+            return (gp, self.gp_regfile.take_needs_fixnum_guard(slot));
         }
         // Compile-time fixnum constant: load the tagged immediate straight into a
         // register, skipping the stack-home round-trip (`%1 = %2 + 1` loads `1`
@@ -587,7 +590,7 @@ impl AbstractFrame {
                 ir.reg2stack(reg, s);
             }
             ir.lit2reg(v, gp);
-            self.gp_regfile.bind(gp, slot, /* dirty */ false);
+            self.gp_regfile.bind(gp, slot, /* dirty */ false, /* fixnum */ true);
             return (gp, false);
         }
         // Not resident and not a constant: put the value at its canonical stack
@@ -598,7 +601,9 @@ impl AbstractFrame {
             ir.reg2stack(reg, s);
         }
         ir.stack2reg(slot, gp);
-        self.gp_regfile.bind(gp, slot, /* dirty */ false);
+        // `fresh = true`: the caller emits a fixnum guard, after which this
+        // resident is a known fixnum.
+        self.gp_regfile.bind(gp, slot, /* dirty */ false, /* fixnum */ true);
         (gp, true)
     }
 

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -105,10 +105,10 @@ impl<'a> JitContext<'a> {
                     // stays in an FPReg; boxing is deferred to a later write-back,
                     // which flushes GP itself), and its deopt write-back already
                     // re-homes the GP residents. So the residents survive a flush.
-                    // But it reads its operands from their stack homes, so a
-                    // GP-resident operand (the integer side of a mixed op) must be
-                    // synced to its home first; then drop a stale cache of `dst`.
-                    state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
+                    // A GP-resident operand (the integer side of a mixed op) is
+                    // read straight from its register by the fpr load (see
+                    // `load_fpr_fixnum`); `dst`'s stale resident is dropped by the
+                    // result `def`.
                     state.binop_float(ir, kind, dst, info);
                     Ok(CompileResult::Continue)
                 }
@@ -147,10 +147,10 @@ impl<'a> JitContext<'a> {
                 // The float comparison computes in xmm and stores a bool: it
                 // never touches the GP allocatable registers and never allocates,
                 // and its deopt write-back re-homes the GP residents. The
-                // residents survive, but the op reads its operands from their
-                // stack homes — so sync a GP-resident operand (the integer side
-                // of a mixed compare) first, then drop a stale cache of `dst`.
-                state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
+                // residents survive; a GP-resident operand (the integer side of a
+                // mixed compare) is read straight from its register by the fpr
+                // load (see `load_fpr_fixnum`), and `dst`'s stale resident is
+                // dropped by the result `def`.
                 state.gen_cmp_float(ir, dst, info, kind);
                 Ok(CompileResult::Continue)
             }
@@ -613,23 +613,6 @@ impl AbstractFrame {
     /// integer side of a mixed `Integer <op> Float` — is written back to its home
     /// and marked clean (it stays cached for a following integer op). Finally any
     /// stale GP cache of the result slot is dropped.
-    fn gp_sync_float_operands(
-        &mut self,
-        ir: &mut AsmIr,
-        lhs: SlotId,
-        rhs: SlotId,
-        dst: Option<SlotId>,
-    ) {
-        for slot in [lhs, rhs] {
-            if let Some(reg) = self.gp_regfile.sync(slot) {
-                ir.reg2stack(reg, slot);
-            }
-        }
-        if let Some(dst) = dst {
-            self.gp_regfile.invalidate(dst);
-        }
-    }
-
     fn binop_float_folded(&self, kind: BinOpK, lhs: f64, rhs: f64) -> Option<f64> {
         Some(match kind {
             BinOpK::Add => lhs + rhs,

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -75,7 +75,6 @@ impl<'a> JitContext<'a> {
                 // Not the integer Add/Sub GP path: these always lower to a
                 // (possibly inlined) method call that reads its operands from
                 // their stack homes, so spill the live GP residents first.
-                #[cfg(feature = "gp-local-alloc")]
                 state.flush_gp(ir);
                 let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
                 match lhs_class {
@@ -114,18 +113,15 @@ impl<'a> JitContext<'a> {
                     // But it reads its operands from their stack homes, so a
                     // GP-resident operand (the integer side of a mixed op) must be
                     // synced to its home first; then drop a stale cache of `dst`.
-                    #[cfg(feature = "gp-local-alloc")]
                     state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
                     state.binop_float(ir, kind, dst, info);
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Other(None, _) => {
-                    #[cfg(feature = "gp-local-alloc")]
                     state.flush_gp(ir);
                     Ok(self.binop_uncached(state, dst))
                 }
                 BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                    #[cfg(feature = "gp-local-alloc")]
                     state.flush_gp(ir);
                     self.call_binary_method(
                         state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
@@ -159,7 +155,6 @@ impl<'a> JitContext<'a> {
                 // residents survive, but the op reads its operands from their
                 // stack homes — so sync a GP-resident operand (the integer side
                 // of a mixed compare) first, then drop a stale cache of `dst`.
-                #[cfg(feature = "gp-local-alloc")]
                 state.gp_sync_float_operands(ir, info.lhs, info.rhs, dst);
                 state.gen_cmp_float(ir, dst, info, kind);
                 Ok(CompileResult::Continue)
@@ -168,7 +163,6 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
-                #[cfg(feature = "gp-local-alloc")]
                 state.flush_gp(ir);
                 if polymorphic {
                     self.emit_generic_cmp(state, ir, kind, lhs, rhs);
@@ -260,6 +254,10 @@ impl<'a> JitContext<'a> {
                 {
                     return Ok(result);
                 }
+                // Block terminator: spill the GP residents to their homes before
+                // the branch. This also makes a mixed integer operand's home
+                // current for the float compare's stack read.
+                state.flush_gp(ir);
                 let src_idx = bc_pos + 1;
                 let dest = self.label();
                 let mode = state.load_binary_fpr(ir, info);
@@ -268,9 +266,11 @@ impl<'a> JitContext<'a> {
                 Ok(CompileResult::Continue)
             }
             BinaryOpType::Other(None, _) => {
+                state.flush_gp(ir);
                 Ok(CompileResult::Recompile(RecompileReason::NotCached))
             }
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
+                state.flush_gp(ir);
                 if polymorphic {
                     self.emit_generic_cmp(state, ir, kind, lhs, rhs);
                     let src_idx = bc_pos + 1;
@@ -472,7 +472,6 @@ impl AbstractFrame {
             // The fold redefines `dst` as a constant; drop any stale GP cache of
             // it so a later op does not reuse the register's old value. Other
             // residents stay live (the fold emits nothing and reads no slot).
-            #[cfg(feature = "gp-local-alloc")]
             if let Some(dst) = dst {
                 self.gp_regfile.invalidate(dst);
             }
@@ -480,16 +479,14 @@ impl AbstractFrame {
             return;
         };
 
-        // `gp-local-alloc`: keep `Add`/`Sub` operands and result in GP registers
+        // keep `Add`/`Sub` operands and result in GP registers
         // across consecutive binops (the local allocator). `Mul`/`Div` clobber
         // `rhs` / use rax-rdx, so they fall through to the slot path below after
         // flushing the register file.
-        #[cfg(feature = "gp-local-alloc")]
         if let BinOpK::Add | BinOpK::Sub = kind {
             self.binop_integer_gp(ir, kind, dst, lhs, rhs);
             return;
         }
-        #[cfg(feature = "gp-local-alloc")]
         self.flush_gp(ir);
 
         // §slot-IR: keep the AsmIR layer free of physical registers for the
@@ -519,14 +516,13 @@ impl AbstractFrame {
         }
     }
 
-    /// `gp-local-alloc`: the register-allocated `Add`/`Sub` path. Operands are
+    /// the register-allocated `Add`/`Sub` path. Operands are
     /// brought into GP registers (reusing a resident copy, else materialized to
     /// the stack home and loaded + fixnum-guarded), the result is allocated a
     /// register (evicting the oldest resident if full), and the op runs in
     /// registers (overflow -> deopt). The result stays resident — its stack home
     /// is written only when the file is flushed (before a non-binop or at the
     /// block boundary) or re-homed by a deopt write-back.
-    #[cfg(feature = "gp-local-alloc")]
     fn binop_integer_gp(
         &mut self,
         ir: &mut AsmIr,
@@ -582,7 +578,6 @@ impl AbstractFrame {
     /// Bring `slot` into a GP register: reuse its resident copy (returning
     /// `fresh = false`, no reload/guard) or materialize it to its stack home,
     /// load it, and report `fresh = true` so the caller emits the fixnum guard.
-    #[cfg(feature = "gp-local-alloc")]
     fn gp_ensure(&mut self, ir: &mut AsmIr, slot: SlotId, pinned: &[GP]) -> (GP, bool) {
         if let Some(gp) = self.gp_regfile.reg_of(slot) {
             return (gp, false);
@@ -613,13 +608,12 @@ impl AbstractFrame {
         (gp, true)
     }
 
-    /// `gp-local-alloc`: prepare the GP register file for a float op that keeps
+    /// prepare the GP register file for a float op that keeps
     /// the residents alive (it computes in xmm without clobbering them). The op
     /// reads its operands from their stack homes, so a GP-resident operand — the
     /// integer side of a mixed `Integer <op> Float` — is written back to its home
     /// and marked clean (it stays cached for a following integer op). Finally any
     /// stale GP cache of the result slot is dropped.
-    #[cfg(feature = "gp-local-alloc")]
     fn gp_sync_float_operands(
         &mut self,
         ir: &mut AsmIr,
@@ -699,47 +693,20 @@ impl AbstractFrame {
     ) {
         if let Some((lhs, rhs)) = self.check_concrete_i64(lhs, rhs) {
             // The fold redefines `dst`; drop any stale GP cache of it.
-            #[cfg(feature = "gp-local-alloc")]
             if let Some(dst) = dst {
                 self.gp_regfile.invalidate(dst);
             }
             self.fold_constant_cmp(kind, lhs, rhs, dst);
             return;
         };
-        #[cfg(feature = "gp-local-alloc")]
-        {
-            self.gen_cmp_integer_gp(ir, kind, dst, lhs, rhs);
-            return;
-        }
-        // §slot-IR: keep the AsmIR layer free of physical registers for the
-        // fixnum comparison. Write the operand slots back to the stack and emit
-        // a slot-based cmp; the LIR lowering loads them into scratch regs,
-        // fixnum-guards, compares, and stores the boolean result to `dst`.
-        #[cfg(not(feature = "gp-local-alloc"))]
-        {
-            self.write_back_slots(ir, &[lhs, rhs]);
-            let deopt = self.deopt_point();
-            ir.transfer(TransferIR::IntegerCmpSlot {
-                lhs,
-                rhs,
-                kind,
-                dst,
-                deopt,
-            });
-            if let Some(dst) = dst {
-                // The result is a boolean `Value` on the stack (the lowering
-                // stored it). `def_S` defines it as `Guarded::Value`; match that.
-                self.def_S(dst);
-            }
-        }
+        self.gen_cmp_integer_gp(ir, kind, dst, lhs, rhs);
     }
 
-    /// `gp-local-alloc`: the register-allocated fixnum comparison. Operands are
+    /// the register-allocated fixnum comparison. Operands are
     /// brought into GP registers (reusing residents from a prior binop), guarded,
     /// and compared in registers; the boolean result is stored to `dst`'s stack
     /// home (a bool is never a GP resident, so the file shrinks by the operands
     /// the stack pointer has popped and gains nothing).
-    #[cfg(feature = "gp-local-alloc")]
     fn gen_cmp_integer_gp(
         &mut self,
         ir: &mut AsmIr,
@@ -794,6 +761,13 @@ impl AbstractFrame {
         self.def_rax2acc(ir, dst);
     }
 
+    /// The register-allocated fixnum compare + branch. Like `gen_cmp_integer_gp`,
+    /// the operands are brought into GP registers (reusing residents from a prior
+    /// binop) and fixnum-guarded. Because this terminates the basic block, the
+    /// register file is then **flushed** — every dirty resident spilled to its
+    /// stack home — *before* the conditional branch, so both successor blocks
+    /// (taken and fall-through) observe slots in their canonical homes and start
+    /// with an empty file. The operands stay in their registers for the compare.
     pub(super) fn gen_cmpbr_integer(
         &mut self,
         ir: &mut AsmIr,
@@ -803,19 +777,22 @@ impl AbstractFrame {
         brkind: BrKind,
         branch_dest: JitLabel,
     ) {
-        // §slot-IR: write the operand slots back to the stack and emit a
-        // slot-based compare+branch; the LIR lowering loads them into scratch
-        // regs, fixnum-guards, compares, and branches.
-        self.write_back_slots(ir, &[lhs, rhs]);
-        let deopt = self.deopt_point();
-        ir.transfer(TransferIR::IntegerCmpBrSlot {
-            lhs,
-            rhs,
-            kind,
-            brkind,
-            branch_dest,
-            deopt,
-        });
+        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        // Snapshot the deopt write-back before the flush/branch (the guards
+        // side-exit to a point where the interpreter re-reads the operands).
+        let deopt = ir.new_deopt(self);
+        if lhs_fresh {
+            ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
+        }
+        if rhs_fresh {
+            ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
+        }
+        // Block terminator: spill the dirty residents to their stack homes before
+        // the branch (the operands' registers still hold their values for the
+        // compare), leaving the file empty for both successors.
+        self.flush_gp(ir);
+        ir.integer_cmpbr_reg(kind, brkind, branch_dest, lhs_gp, rhs_gp);
     }
 
     pub(super) fn load_binary_fpr(&mut self, ir: &mut AsmIr, info: FBinOpInfo) -> (FPReg, FPReg) {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -331,21 +331,10 @@ impl AbstractFrame {
     }
 
     fn check_concrete_i64(&self, mode: OpMode) -> Option<(i64, i64)> {
-        match mode {
-            OpMode::RR(lhs, rhs) => {
-                let lhs = self.is_fixnum_literal(lhs)?.get();
-                let rhs = self.is_fixnum_literal(rhs)?.get();
-                Some((lhs, rhs))
-            }
-            OpMode::RI(lhs, rhs) => {
-                let lhs = self.is_fixnum_literal(lhs)?.get();
-                Some((lhs, rhs as i64))
-            }
-            OpMode::IR(lhs, rhs) => {
-                let rhs = self.is_fixnum_literal(rhs)?.get();
-                Some((lhs as i64, rhs))
-            }
-        }
+        let OpMode::RR(lhs, rhs) = mode;
+        let lhs = self.is_fixnum_literal(lhs)?.get();
+        let rhs = self.is_fixnum_literal(rhs)?.get();
+        Some((lhs, rhs))
     }
 
     #[allow(non_snake_case)]
@@ -445,7 +434,7 @@ impl AbstractFrame {
         };
 
         // §slot-IR: keep the AsmIR layer free of physical registers for the
-        // fixnum binop. Write the operand slot(s) back to their stack homes and
+        // fixnum binop. Write the operand slots back to their stack homes and
         // emit a slot-based op; the LIR lowering loads them into scratch regs,
         // fixnum-guards, computes (overflow -> deopt), and stores the result to
         // `dst` (when present). The result lives on the stack (`S(Fixnum)`) — the
@@ -453,74 +442,21 @@ impl AbstractFrame {
         // coexist. A `None` dst is the discarded-result case: the op still runs
         // (its overflow / divide-by-zero side-exit is observable) but nothing is
         // stored. `Div`'s result is produced in `rax` (the lowering handles that).
-        if let BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div = kind {
-            match mode {
-                OpMode::RR(l, r) => self.write_back_slots(ir, &[l, r]),
-                OpMode::RI(l, _) => self.write_back_slot(ir, l),
-                OpMode::IR(_, r) => self.write_back_slot(ir, r),
-            }
-            let deopt = self.deopt_point();
-            ir.transfer(TransferIR::IntegerBinOpSlot {
-                kind,
-                dst,
-                mode,
-                deopt,
-            });
-            if let Some(dst) = dst {
-                self.def_S_guarded(dst, Guarded::Fixnum);
-            }
-            return;
-        }
-
-        match kind {
-            BinOpK::Add | BinOpK::Sub | BinOpK::Mul => {
-                let rhs = GP::Rsi;
-                if let Some(dst) = dst {
-                    // Compute the result *in place* in `dst`'s register — the
-                    // value is born in its destination, so there is no `Rdi`-copy
-                    // + relocate `mov` (the old `def_reg2acc_fixnum` store). The
-                    // lhs operand is brought into that register (R15, or a pool
-                    // register under gp-alloc so the result stays resident); when
-                    // it is already there (`(a+b)+c`) not even a load is emitted.
-                    let dst_reg = self.fetch_fixnum_inplace(ir, kind, rhs, mode);
-                    // §19 (B): route the guarded integer op through the record
-                    // stream, carrying its deopt as a program point.
-                    let deopt = self.deopt_point();
-                    ir.transfer(TransferIR::IntegerBinOp {
-                        kind,
-                        lhs: dst_reg,
-                        rhs,
-                        mode,
-                        deopt,
-                    });
-                    self.def_inplace_fixnum(ir, dst, dst_reg);
-                } else {
-                    // Result discarded: run the op in the Rdi scratch purely for
-                    // the overflow side-exit; no destination store.
-                    let lhs = GP::Rdi;
-                    match kind {
-                        BinOpK::Sub => self.fetch_fixnum_mode(ir, lhs, rhs, mode),
-                        _ => self.fetch_fixnum_comm(ir, lhs, rhs, mode),
-                    }
-                    let deopt = self.deopt_point();
-                    ir.transfer(TransferIR::IntegerBinOp { kind, lhs, rhs, mode, deopt });
-                }
-            }
-            BinOpK::Div => {
-                let lhs = GP::Rdi;
-                let rhs = GP::Rsi;
-                self.fetch_fixnum_binary(ir, lhs, rhs, mode);
-                let deopt = self.deopt_point();
-                ir.transfer(TransferIR::IntegerBinOp { kind, lhs, rhs, mode, deopt });
-                self.def_reg2acc_fixnum(ir, GP::Rax, dst);
-            }
-            BinOpK::Rem
-            | BinOpK::Exp
-            | BinOpK::BitOr
-            | BinOpK::BitAnd
-            | BinOpK::BitXor
-            | BinOpK::Shl
-            | BinOpK::Shr => unreachable!(),
+        debug_assert!(matches!(
+            kind,
+            BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div
+        ));
+        let OpMode::RR(l, r) = mode;
+        self.write_back_slots(ir, &[l, r]);
+        let deopt = self.deopt_point();
+        ir.transfer(TransferIR::IntegerBinOpSlot {
+            kind,
+            dst,
+            mode,
+            deopt,
+        });
+        if let Some(dst) = dst {
+            self.def_S_guarded(dst, Guarded::Fixnum);
         }
     }
 
@@ -588,14 +524,11 @@ impl AbstractFrame {
             return;
         };
         // §slot-IR: keep the AsmIR layer free of physical registers for the
-        // fixnum comparison. Write the operand slot(s) back to the stack and emit
+        // fixnum comparison. Write the operand slots back to the stack and emit
         // a slot-based cmp; the LIR lowering loads them into scratch regs,
         // fixnum-guards, compares, and stores the boolean result to `dst`.
-        match mode {
-            OpMode::RR(l, r) => self.write_back_slots(ir, &[l, r]),
-            OpMode::RI(l, _) => self.write_back_slot(ir, l),
-            OpMode::IR(_, r) => self.write_back_slot(ir, r),
-        }
+        let OpMode::RR(l, r) = mode;
+        self.write_back_slots(ir, &[l, r]);
         let deopt = self.deopt_point();
         ir.transfer(TransferIR::IntegerCmpSlot {
             mode,
@@ -639,14 +572,11 @@ impl AbstractFrame {
         brkind: BrKind,
         branch_dest: JitLabel,
     ) {
-        // §slot-IR: write the operand slot(s) back to the stack and emit a
+        // §slot-IR: write the operand slots back to the stack and emit a
         // slot-based compare+branch; the LIR lowering loads them into scratch
         // regs, fixnum-guards, compares, and branches.
-        match mode {
-            OpMode::RR(l, r) => self.write_back_slots(ir, &[l, r]),
-            OpMode::RI(l, _) => self.write_back_slot(ir, l),
-            OpMode::IR(_, r) => self.write_back_slot(ir, r),
-        }
+        let OpMode::RR(l, r) = mode;
+        self.write_back_slots(ir, &[l, r]);
         let deopt = self.deopt_point();
         ir.transfer(TransferIR::IntegerCmpBrSlot {
             mode,
@@ -655,89 +585,6 @@ impl AbstractFrame {
             branch_dest,
             deopt,
         });
-    }
-
-    /// Operand fetch for an *in-place* fixnum binop. Brings the lhs reg operand
-    /// into the register where the encoder's in-place sequence leaves the result
-    /// (via `fetch_lhs_to_inplace_reg`: R15 or a pool register), and returns that
-    /// register so the caller can emit the op and define `dst` there with no
-    /// relocate move. `rhs` is the scratch register for the rhs reg operand
-    /// (`Rsi`).
-    fn fetch_fixnum_inplace(
-        &mut self,
-        ir: &mut AsmIr,
-        kind: BinOpK,
-        rhs: GP,
-        mode: OpMode,
-    ) -> GP {
-        match mode {
-            OpMode::RR(l, r) => {
-                self.load(ir, r, rhs);
-                self.guard_fixnum(ir, r, rhs);
-                self.fetch_lhs_to_inplace_reg(ir, l)
-            }
-            OpMode::RI(l, _) => {
-                // rhs is an immediate folded by the encoder; lhs reg -> dst reg.
-                self.fetch_lhs_to_inplace_reg(ir, l)
-            }
-            OpMode::IR(_, r) => match kind {
-                // Add/Mul are commutative, so the reg operand becomes the
-                // in-place accumulator (≡ RI) and the immediate is folded.
-                BinOpK::Add | BinOpK::Mul => self.fetch_lhs_to_inplace_reg(ir, r),
-                // Sub: the encoder materializes the immediate (lhs) into the
-                // result register then subtracts the reg operand, so the result
-                // register must be free and the reg operand in the `rhs` scratch.
-                _ => {
-                    self.load(ir, r, rhs);
-                    self.guard_fixnum(ir, r, rhs);
-                    self.alloc_inplace_reg(ir)
-                }
-            },
-        }
-    }
-
-    fn fetch_fixnum_comm(&mut self, ir: &mut AsmIr, lhs: GP, rhs: GP, mode: OpMode) {
-        match mode {
-            OpMode::RR(l, r) => self.fetch_fixnum_rr(ir, l, r, lhs, rhs),
-            OpMode::RI(slot, _) | OpMode::IR(_, slot) => self.fetch_fixnum_r(ir, slot, lhs),
-        }
-    }
-
-    fn fetch_fixnum_mode(&mut self, ir: &mut AsmIr, lhs: GP, rhs: GP, mode: OpMode) {
-        match mode {
-            OpMode::RR(l, r) => self.fetch_fixnum_rr(ir, l, r, lhs, rhs),
-            OpMode::RI(l, _) => self.fetch_fixnum_r(ir, l, lhs),
-            OpMode::IR(_, r) => self.fetch_fixnum_r(ir, r, rhs),
-        }
-    }
-
-    fn fetch_fixnum_binary(&mut self, ir: &mut AsmIr, lhs: GP, rhs: GP, mode: OpMode) {
-        match mode {
-            OpMode::RR(l, r) => self.fetch_fixnum_rr(ir, l, r, lhs, rhs),
-            OpMode::RI(l, r) => {
-                ir.lit2reg(Value::i32(r as i32), rhs);
-                self.fetch_fixnum_r(ir, l, lhs);
-            }
-            OpMode::IR(l, r) => {
-                ir.lit2reg(Value::i32(l as i32), lhs);
-                self.fetch_fixnum_r(ir, r, rhs);
-            }
-        }
-    }
-
-    fn fetch_fixnum_rr(&mut self, ir: &mut AsmIr, l: SlotId, r: SlotId, lhs: GP, rhs: GP) {
-        self.load(ir, l, lhs);
-        self.load(ir, r, rhs);
-        self.guard_fixnum(ir, l, lhs);
-        self.guard_fixnum(ir, r, rhs);
-    }
-
-    fn fetch_fixnum_r(&mut self, ir: &mut AsmIr, slot: SlotId, r: GP) {
-        self.load(ir, slot, r);
-        if self.is_fixnum_literal(slot).is_some() {
-        } else {
-            self.guard_fixnum(ir, slot, r);
-        }
     }
 
     pub(super) fn load_binary_fpr(&mut self, ir: &mut AsmIr, info: FBinOpInfo) -> (FPReg, FPReg) {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -86,7 +86,7 @@ impl<'a> JitContext<'a> {
                 }
             }
             _ => match state.binop_type(lhs, rhs, ic) {
-                BinaryOpType::Integer(mode) => {
+                BinaryOpType::Integer(l, r) => {
                     // A constant-fold bakes the result (e.g. `100 * 100` -> 10000)
                     // assuming the builtin operator, with no runtime trace of the
                     // op. Guard that assumption: emit `CheckBOP` *before* the fold
@@ -99,10 +99,10 @@ impl<'a> JitContext<'a> {
                     // register fast-path keeps its operands at runtime, so it is
                     // not worth a guard on every arithmetic op.
                     #[cfg(target_arch = "aarch64")]
-                    if state.check_concrete_i64(mode).is_some() {
+                    if state.check_concrete_i64(l, r).is_some() {
                         ir.check_bop(state);
                     }
-                    state.binop_integer(ir, kind, dst, mode);
+                    state.binop_integer(ir, kind, dst, l, r);
                     Ok(CompileResult::Continue)
                 }
                 BinaryOpType::Float(info) => {
@@ -148,8 +148,8 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) => {
-                state.gen_cmp_integer(ir, kind, dst, mode);
+            BinaryOpType::Integer(l, r) => {
+                state.gen_cmp_integer(ir, kind, dst, l, r);
                 Ok(CompileResult::Continue)
             }
             BinaryOpType::Float(info) => {
@@ -244,13 +244,13 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         match state.binop_type(lhs, rhs, ic) {
-            BinaryOpType::Integer(mode) => {
-                if let Some(result) = state.check_concrete_i64_cmpbr(mode, kind, brkind, dest_bb) {
+            BinaryOpType::Integer(l, r) => {
+                if let Some(result) = state.check_concrete_i64_cmpbr(l, r, kind, brkind, dest_bb) {
                     return Ok(result);
                 }
                 let src_idx = bc_pos + 1;
                 let dest = self.label();
-                state.gen_cmpbr_integer(ir, kind, mode, brkind, dest);
+                state.gen_cmpbr_integer(ir, kind, l, r, brkind, dest);
                 self.new_side_branch(src_idx, dest_bb, state.clone(), dest);
                 Ok(CompileResult::Continue)
             }
@@ -363,8 +363,7 @@ impl AbstractFrame {
         self.def_C(dst, Immediate::bool(b));
     }
 
-    fn check_concrete_i64(&self, mode: OpMode) -> Option<(i64, i64)> {
-        let OpMode::RR(lhs, rhs) = mode;
+    fn check_concrete_i64(&self, lhs: SlotId, rhs: SlotId) -> Option<(i64, i64)> {
         let lhs = self.is_fixnum_literal(lhs)?.get();
         let rhs = self.is_fixnum_literal(rhs)?.get();
         Some((lhs, rhs))
@@ -379,12 +378,13 @@ impl AbstractFrame {
 
     pub(super) fn check_concrete_i64_cmpbr(
         &mut self,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         brkind: BrKind,
         dest_bb: BasicBlockId,
     ) -> Option<CompileResult> {
-        if let Some((lhs, rhs)) = self.check_concrete_i64(mode) {
+        if let Some((lhs, rhs)) = self.check_concrete_i64(lhs, rhs) {
             let b = cmp(kind, lhs, rhs) ^ (brkind == BrKind::BrIfNot);
             return Some(if b {
                 CompileResult::Branch(dest_bb)
@@ -458,8 +458,15 @@ impl AbstractFrame {
     /// ### out
     /// - r15: dst
     ///
-    fn binop_integer(&mut self, ir: &mut AsmIr, kind: BinOpK, dst: Option<SlotId>, mode: OpMode) {
-        if let Some((lhs, rhs)) = self.check_concrete_i64(mode)
+    fn binop_integer(
+        &mut self,
+        ir: &mut AsmIr,
+        kind: BinOpK,
+        dst: Option<SlotId>,
+        lhs: SlotId,
+        rhs: SlotId,
+    ) {
+        if let Some((lhs, rhs)) = self.check_concrete_i64(lhs, rhs)
             && let Some(result) = self.binop_integer_folded(kind, lhs, rhs)
         {
             // The fold redefines `dst` as a constant; drop any stale GP cache of
@@ -479,7 +486,7 @@ impl AbstractFrame {
         // flushing the register file.
         #[cfg(feature = "gp-local-alloc")]
         if let BinOpK::Add | BinOpK::Sub = kind {
-            self.binop_integer_gp(ir, kind, dst, mode);
+            self.binop_integer_gp(ir, kind, dst, lhs, rhs);
             return;
         }
         #[cfg(feature = "gp-local-alloc")]
@@ -498,13 +505,13 @@ impl AbstractFrame {
             kind,
             BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div
         ));
-        let OpMode::RR(l, r) = mode;
-        self.write_back_slots(ir, &[l, r]);
+        self.write_back_slots(ir, &[lhs, rhs]);
         let deopt = self.deopt_point();
         ir.transfer(TransferIR::IntegerBinOpSlot {
             kind,
             dst,
-            mode,
+            lhs,
+            rhs,
             deopt,
         });
         if let Some(dst) = dst {
@@ -520,8 +527,14 @@ impl AbstractFrame {
     /// is written only when the file is flushed (before a non-binop or at the
     /// block boundary) or re-homed by a deopt write-back.
     #[cfg(feature = "gp-local-alloc")]
-    fn binop_integer_gp(&mut self, ir: &mut AsmIr, kind: BinOpK, dst: Option<SlotId>, mode: OpMode) {
-        let OpMode::RR(lhs, rhs) = mode;
+    fn binop_integer_gp(
+        &mut self,
+        ir: &mut AsmIr,
+        kind: BinOpK,
+        dst: Option<SlotId>,
+        lhs: SlotId,
+        rhs: SlotId,
+    ) {
         // 1. Load the operands into registers (reusing a resident copy).
         let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
         let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
@@ -681,9 +694,10 @@ impl AbstractFrame {
         ir: &mut AsmIr,
         kind: CmpKind,
         dst: Option<SlotId>,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
     ) {
-        if let Some((lhs, rhs)) = self.check_concrete_i64(mode) {
+        if let Some((lhs, rhs)) = self.check_concrete_i64(lhs, rhs) {
             // The fold redefines `dst`; drop any stale GP cache of it.
             #[cfg(feature = "gp-local-alloc")]
             if let Some(dst) = dst {
@@ -694,7 +708,7 @@ impl AbstractFrame {
         };
         #[cfg(feature = "gp-local-alloc")]
         {
-            self.gen_cmp_integer_gp(ir, kind, dst, mode);
+            self.gen_cmp_integer_gp(ir, kind, dst, lhs, rhs);
             return;
         }
         // §slot-IR: keep the AsmIR layer free of physical registers for the
@@ -703,11 +717,11 @@ impl AbstractFrame {
         // fixnum-guards, compares, and stores the boolean result to `dst`.
         #[cfg(not(feature = "gp-local-alloc"))]
         {
-            let OpMode::RR(l, r) = mode;
-            self.write_back_slots(ir, &[l, r]);
+            self.write_back_slots(ir, &[lhs, rhs]);
             let deopt = self.deopt_point();
             ir.transfer(TransferIR::IntegerCmpSlot {
-                mode,
+                lhs,
+                rhs,
                 kind,
                 dst,
                 deopt,
@@ -731,9 +745,9 @@ impl AbstractFrame {
         ir: &mut AsmIr,
         kind: CmpKind,
         dst: Option<SlotId>,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
     ) {
-        let OpMode::RR(lhs, rhs) = mode;
         let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
         let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
         // Snapshot the deopt write-back before clearing (the guards side-exit to
@@ -784,18 +798,19 @@ impl AbstractFrame {
         &mut self,
         ir: &mut AsmIr,
         kind: CmpKind,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         brkind: BrKind,
         branch_dest: JitLabel,
     ) {
         // §slot-IR: write the operand slots back to the stack and emit a
         // slot-based compare+branch; the LIR lowering loads them into scratch
         // regs, fixnum-guards, compares, and branches.
-        let OpMode::RR(l, r) = mode;
-        self.write_back_slots(ir, &[l, r]);
+        self.write_back_slots(ir, &[lhs, rhs]);
         let deopt = self.deopt_point();
         ir.transfer(TransferIR::IntegerCmpBrSlot {
-            mode,
+            lhs,
+            rhs,
             kind,
             brkind,
             branch_dest,

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -788,20 +788,9 @@ impl<'a> JitContext<'a> {
         recv_class: ClassId,
         arg_class: Option<ClassId>,
     ) -> bool {
-        // Flush the GP register pool (§9 9d-B) to the slots' frame homes before
-        // running the inline-method codegen `f`. `f` may emit C-ABI helper
-        // calls and deopt write-backs that clobber the caller-saved pool
-        // registers (aarch64 x5–x8 / x86-64 r8–r11), so a pool-resident Fixnum
-        // left live across the inline body would be read back as garbage. This
-        // mirrors the explicit `flush_pool` at every other helper-emitting
-        // boundary (ToA, ConcatStr, ConcatRegexp, ExpandArray, the generic
-        // binop/cmp fallbacks, …); the inline-method path was the one gap.
-        // Manifested as an aarch64-only optcarrot `--opt` divergence at frame
-        // 34 with a non-empty GP pool. No-op when the pool is empty (aarch64). Done
-        // before the save/restore snapshot so the spill is permanent whether or
-        // not `f` succeeds (on bail the caller falls back to the full call,
-        // which re-flushes — a no-op by then).
-        state.flush_pool(ir);
+        // No GP flush here: a register-only inline keeps the residents live,
+        // while a C-ABI-call inline flushes them at its `get_using_fpr`
+        // chokepoint (see `SlotState::get_using_fpr`).
         let state_save = state.clone();
         let ir_save = ir.save();
         if f(state, ir, self, &self.store, callid, recv_class, arg_class) {
@@ -871,10 +860,11 @@ impl AbstractState {
         // When a capture guard follows (the callee may `move_frame_to_heap`,
         // e.g. by turning a block into a Proc), the result must be homed via
         // the LFP so it follows the frame onto the heap — see
-        // `def_rax2acc_capturing`. Otherwise the ordinary rbp-relative store is
-        // fine (and lets the result stay pool-resident).
+        // `def_rax2acc_capturing`. Otherwise park the result in a GP-pool
+        // register (a resident) so a following integer op consumes it without a
+        // stack round-trip — see `def_rax2gp`.
         if self.no_capture_guard() {
-            self.def_rax2acc(ir, dst);
+            self.def_rax2gp(ir, dst);
         } else {
             self.def_rax2acc_capturing(ir, dst);
         }
@@ -950,9 +940,10 @@ impl AbstractState {
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         // A yielded block can capture this frame; home the result via the LFP
-        // when a capture guard follows (see `def_rax2acc_capturing`).
+        // when a capture guard follows (see `def_rax2acc_capturing`). Otherwise
+        // park it in a GP-pool register resident (see `def_rax2gp`).
         if self.no_capture_guard() {
-            self.def_rax2acc(ir, dst);
+            self.def_rax2gp(ir, dst);
         } else {
             self.def_rax2acc_capturing(ir, dst);
         }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -415,7 +415,6 @@ impl<'a> JitContext<'a> {
         state.discard(dst);
         state.clear_above_next_sp();
         let error = ir.new_error(state);
-        state.writeback_acc(ir);
         let evict = ir.new_evict();
         let meta = self.store[callee_fid].meta();
         ir.push(AsmInst::SetupYieldFrame { meta, outer });
@@ -449,7 +448,6 @@ impl<'a> JitContext<'a> {
         assert!(callsite.block_arg.is_none());
         state.load(ir, recv, GP::Rdi);
         state.discard(dst);
-        state.writeback_acc(ir);
         if recv_class.is_always_frozen() {
             if dst.is_some() {
                 ir.lit2reg(Value::nil(), GP::Rax);
@@ -462,12 +460,16 @@ impl<'a> JitContext<'a> {
             };
             let is_object_ty = self.store[recv_class].is_object_ty_instance();
             if is_object_ty && ivarid.is_inline() {
-                ir.push(AsmInst::LoadIVarInline { ivarid })
+                ir.push(AsmInst::LoadIVarInline {
+                    ivarid,
+                    dst: GP::R15,
+                })
             } else {
                 ir.push(AsmInst::LoadIVarHeap {
                     ivarid,
                     is_object_ty,
                     self_: false,
+                    dst: GP::R15,
                 });
             }
         }
@@ -549,7 +551,6 @@ impl<'a> JitContext<'a> {
         assert!(callsite.block_arg.is_none());
         state.load(ir, recv, GP::Rdi);
         state.discard(dst);
-        state.writeback_acc(ir);
         if inline {
             ir.push(AsmInst::LoadStructSlotInline { slot_index });
         } else {
@@ -827,13 +828,13 @@ impl AbstractState {
         // Flush the GP pool up front (folded into `get_using_fpr`), before
         // `set_arguments`. An earlier optimization deferred this for simple,
         // block-less calls — reading args straight from the pool registers and
-        // letting the later `writeback_acc` do the flush — to skip spilling the
-        // dead `dst`/temp args. That deferral proved unsound under register
-        // pressure: keeping locals pool-resident through `set_arguments` /
-        // `discard` / `clear_above_next_sp` diverged from the up-front-flush
-        // semantics (optcarrot `--opt` mis-emulated a few frames in on aarch64
-        // `gp-alloc`, e.g. a wrong PPU value broke the vblank-wait loop), so we
-        // always flush before the call now.
+        // letting a later flush handle it — to skip spilling the dead `dst`/temp
+        // args. That deferral proved unsound under register pressure: keeping
+        // locals pool-resident through `set_arguments` / `discard` /
+        // `clear_above_next_sp` diverged from the up-front-flush semantics
+        // (optcarrot `--opt` mis-emulated a few frames in on aarch64 `gp-alloc`,
+        // e.g. a wrong PPU value broke the vblank-wait loop), so we always flush
+        // before the call now.
         let using_fpr = self.get_using_fpr(ir);
         // stack pointer adjustment
         // -using_fpr.offset()
@@ -842,7 +843,6 @@ impl AbstractState {
         self.discard(dst);
         self.clear_above_next_sp();
         let error = ir.new_error(self);
-        self.writeback_acc(ir);
         let meta = store[callee_fid].meta();
         ir.push(AsmInst::SetupMethodFrame {
             meta,
@@ -903,7 +903,6 @@ impl AbstractState {
         self.discard(store[callid].dst);
         self.clear_above_next_sp();
         let error = ir.new_error(self);
-        self.writeback_acc(ir);
         let meta = store[callee_fid].meta();
         ir.push(AsmInst::SetupMethodFrame {
             meta,
@@ -924,7 +923,6 @@ impl AbstractState {
         let callinfo = &store[callid];
         let dst = callinfo.dst;
         self.write_back_recv_and_callargs(ir, &callinfo);
-        self.writeback_acc(ir);
         let using_fpr = self.get_using_fpr(ir);
         let error = ir.new_error(self);
         let evict = ir.new_evict();

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::codegen::jitgen::state::Guarded;
 
 impl<'a> JitContext<'a> {
     pub(super) fn load_ivar(
@@ -10,21 +11,26 @@ impl<'a> JitContext<'a> {
         ivarid: IvarId,
     ) {
         assert!(!self_class.is_always_frozen());
-        state.discard(dst);
-        state.writeback_acc(ir);
+        // Allocate a pool register and load the ivar value straight into it (a
+        // resident), so a following integer op consumes it without a stack
+        // round-trip. `alloc_gp_for` clears `dst`'s stale link and spills an
+        // evicted victim; the load writes only `gp` (its scratch is rdi/rsi/rdx,
+        // none of them pool registers), so other residents survive.
+        let gp = state.alloc_gp_for(ir, dst, Guarded::Value);
         ir.self2reg(GP::Rdi);
         let is_object_ty = self.self_ty() == Some(ObjTy::OBJECT);
         if is_object_ty && ivarid.is_inline() {
-            ir.push(AsmInst::LoadIVarInline { ivarid });
+            ir.push(AsmInst::LoadIVarInline { ivarid, dst: gp });
         } else {
             ir.push(AsmInst::LoadIVarHeap {
                 ivarid,
                 is_object_ty,
                 self_: true,
+                dst: gp,
             });
             self.set_ivar_heap_accessed();
         };
-        state.def_reg2acc(ir, GP::R15, dst);
+        state.bind_gp_resident(gp, dst);
     }
 
     pub(super) fn store_ivar(

--- a/monoruby/src/codegen/jitgen/definition.rs
+++ b/monoruby/src/codegen/jitgen/definition.rs
@@ -16,7 +16,6 @@ impl AbstractState {
         // expression position (e.g. `a << (class C; ...; end)`) the
         // accumulator holds a live slot — spill it first, exactly like a
         // method call does, or the later use reads a clobbered register.
-        self.writeback_acc(ir);
         if let Some(base) = base {
             self.write_back_slots(ir, &[base]);
         }
@@ -49,7 +48,6 @@ impl AbstractState {
     ) {
         // See `class_def`: `class << obj` runs a body that clobbers the
         // accumulator, so spill it before the call.
-        self.writeback_acc(ir);
         self.write_back_slots(ir, &[base]);
         if let Some(dst) = dst {
             self.def_S(dst);

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -244,6 +244,22 @@ impl GpRegFile {
         self.holder[Self::index_of(reg)] = Some(Holder { slot, dirty, age });
     }
 
+    /// If `slot` is a GP resident, return its register and mark it **clean** —
+    /// the caller is about to write the register to `slot`'s stack home, making
+    /// the home current. Used to feed a GP-resident value to a non-GP consumer
+    /// that reads the operand from its stack home (e.g. the integer operand of a
+    /// mixed `Integer + Float` op), without evicting the resident: it stays
+    /// cached (now clean), so a following integer op still reuses it and a later
+    /// flush does not re-spill it.
+    pub(in crate::codegen::jitgen) fn sync(&mut self, slot: SlotId) -> Option<GP> {
+        let idx = self
+            .holder
+            .iter()
+            .position(|h| h.map(|h| h.slot) == Some(slot))?;
+        self.holder[idx].as_mut().unwrap().dirty = false;
+        Some(GP_ALLOC_SET[idx])
+    }
+
     /// Free every register caching a slot at or above `sp` — those temporaries
     /// are dead (popped past the stack pointer), so they are dropped without a
     /// spill, mirroring `clear_above_next_sp`.
@@ -448,5 +464,23 @@ mod tests {
                 .iter()
                 .any(|a| matches!(a, GpAction::Spill { slot, .. } if *slot == sl(s))));
         }
+    }
+
+    /// `sync` makes a resident's stack home current (returns its register) and
+    /// leaves it cached but clean — so a later flush does not re-spill it and a
+    /// later op still reuses it. Used to feed a GP-resident integer operand to a
+    /// mixed `Integer + Float` op, which reads it from its stack home.
+    #[test]
+    fn sync_marks_clean_and_keeps_resident() {
+        let mut rf = GpRegFile::new();
+        rf.bind(R8, sl(7), /* dirty */ true);
+        // A dirty resident syncs to its register and is now clean.
+        assert_eq!(rf.sync(sl(7)), Some(R8));
+        assert!(rf.reg_of(sl(7)) == Some(R8)); // still cached
+        assert!(rf.dirty_residents().is_empty()); // but clean now
+        // A flush of the (now clean) file emits no spill.
+        assert!(rf.take_dirty_spills().is_empty());
+        // Syncing a non-resident slot is a no-op.
+        assert_eq!(GpRegFile::new().sync(sl(3)), None);
     }
 }

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -105,6 +105,11 @@ struct Holder {
     /// the register's value differs from `slot`'s stack home (a binop result);
     /// a clean holder (freshly loaded, unmodified) needs no spill.
     dirty: bool,
+    /// the cached value is a known `Fixnum` — true for a fixnum binop result, a
+    /// fixnum-guarded load, or a fixnum constant. A general-value resident (a
+    /// `call`/`yield` result or a frozen heap literal bound into a register) is
+    /// `false`, so a fixnum binop that reuses it must (re)emit the class guard.
+    fixnum: bool,
     /// monotonically-increasing stamp set when the slot was bound, used to pick
     /// the oldest resident as the eviction victim (FIFO).
     age: u64,
@@ -245,14 +250,45 @@ impl GpRegFile {
     }
 
     /// Record that `reg` now caches `slot`, dropping any prior cache of `slot`.
-    pub(in crate::codegen::jitgen) fn bind(&mut self, reg: GP, slot: SlotId, dirty: bool) {
+    /// `fixnum` marks whether the cached value is a known fixnum (see [`Holder`]).
+    pub(in crate::codegen::jitgen) fn bind(
+        &mut self,
+        reg: GP,
+        slot: SlotId,
+        dirty: bool,
+        fixnum: bool,
+    ) {
         for h in self.holder.iter_mut() {
             if h.map(|h| h.slot) == Some(slot) {
                 *h = None;
             }
         }
         let age = self.tick();
-        self.holder[Self::index_of(reg)] = Some(Holder { slot, dirty, age });
+        self.holder[Self::index_of(reg)] = Some(Holder {
+            slot,
+            dirty,
+            fixnum,
+            age,
+        });
+    }
+
+    /// For a fixnum binop reusing `slot` as an operand: report whether it must
+    /// emit a fixnum class guard (the resident is not yet a known fixnum) and, if
+    /// so, upgrade the resident to known-fixnum (the guard, once emitted, proves
+    /// it). Returns `false` for a non-resident (the caller handles that path).
+    pub(in crate::codegen::jitgen) fn take_needs_fixnum_guard(&mut self, slot: SlotId) -> bool {
+        for h in self.holder.iter_mut() {
+            if let Some(held) = h
+                && held.slot == slot
+            {
+                if held.fixnum {
+                    return false;
+                }
+                held.fixnum = true;
+                return true;
+            }
+        }
+        false
     }
 
     /// If `slot` is a GP resident, return its register and mark it **clean** —
@@ -311,7 +347,7 @@ pub(in crate::codegen::jitgen) fn allocate_run(insts: &[BinOpInst]) -> Vec<GpAct
             lhs: lhs_reg,
             rhs: rhs_reg,
         });
-        rf.bind(dst_reg, inst.dst, /* dirty */ true);
+        rf.bind(dst_reg, inst.dst, /* dirty */ true, /* fixnum */ true);
     }
 
     flush_dirty(&mut rf, &mut out);
@@ -330,7 +366,7 @@ fn ensure(rf: &mut GpRegFile, slot: SlotId, pinned: &[GP], out: &mut Vec<GpActio
         reg,
         guard: true,
     });
-    rf.bind(reg, slot, /* dirty */ false);
+    rf.bind(reg, slot, /* dirty */ false, /* fixnum */ true);
     reg
 }
 
@@ -484,7 +520,7 @@ mod tests {
     #[test]
     fn sync_marks_clean_and_keeps_resident() {
         let mut rf = GpRegFile::new();
-        rf.bind(R8, sl(7), /* dirty */ true);
+        rf.bind(R8, sl(7), /* dirty */ true, /* fixnum */ true);
         // A dirty resident syncs to its register and is now clean.
         assert_eq!(rf.sync(sl(7)), Some(R8));
         assert!(rf.reg_of(sl(7)) == Some(R8)); // still cached

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -183,27 +183,34 @@ impl GpRegFile {
     }
 
     /// The register currently caching `slot`, if any (the reuse lookup).
-    fn reg_of(&self, slot: SlotId) -> Option<GP> {
+    pub(in crate::codegen::jitgen) fn reg_of(&self, slot: SlotId) -> Option<GP> {
         self.holder
             .iter()
             .position(|h| h.map(|h| h.slot) == Some(slot))
             .map(|i| GP_ALLOC_SET[i])
     }
 
-    fn find_free(&self) -> Option<GP> {
-        self.holder
-            .iter()
-            .position(|h| h.is_none())
+    /// A free register that is not `pinned`. Pinned registers hold operands that
+    /// are live across this allocation (e.g. when the result slot aliases an
+    /// operand slot, `invalidate(dst)` leaves the operand's register unbound but
+    /// still in use), so they must never be handed out even when free.
+    fn find_free(&self, pinned: &[GP]) -> Option<GP> {
+        (0..self.holder.len())
+            .find(|&i| self.holder[i].is_none() && !pinned.contains(&GP_ALLOC_SET[i]))
             .map(|i| GP_ALLOC_SET[i])
     }
 
-    /// Allocate a register, always succeeding: a free register if any, else the
-    /// **oldest** resident that is not `pinned` is evicted (its dirty value
-    /// written back) so the caller — typically a binop result that must stay
-    /// resident — always gets a register.
-    fn alloc(&mut self, pinned: &[GP], out: &mut Vec<GpAction>) -> GP {
-        if let Some(reg) = self.find_free() {
-            return reg;
+    /// Online allocation primitive for the codegen driver: return a register
+    /// (a free one, else the **oldest** non-`pinned` resident) plus the spill
+    /// the caller must emit when a dirty resident was evicted. The returned
+    /// register is left **unbound** — the caller binds it after loading/computing
+    /// the value (so the binop result always lands in a register).
+    pub(in crate::codegen::jitgen) fn alloc_reg(
+        &mut self,
+        pinned: &[GP],
+    ) -> (GP, Option<(GP, SlotId)>) {
+        if let Some(reg) = self.find_free(pinned) {
+            return (reg, None);
         }
         let victim_idx = (0..self.holder.len())
             .filter(|&i| !pinned.contains(&GP_ALLOC_SET[i]))
@@ -211,15 +218,23 @@ impl GpRegFile {
             .expect("more pinned registers than the allocatable set");
         let reg = GP_ALLOC_SET[victim_idx];
         let h = self.holder[victim_idx].unwrap();
-        if h.dirty {
-            out.push(GpAction::Spill { reg, slot: h.slot });
-        }
+        let spill = if h.dirty { Some((reg, h.slot)) } else { None };
         self.holder[victim_idx] = None;
+        (reg, spill)
+    }
+
+    /// Internal `alloc` used by the pure `allocate_run` reference: like
+    /// [`Self::alloc_reg`] but emits the spill into `out`.
+    fn alloc(&mut self, pinned: &[GP], out: &mut Vec<GpAction>) -> GP {
+        let (reg, spill) = self.alloc_reg(pinned);
+        if let Some((reg, slot)) = spill {
+            out.push(GpAction::Spill { reg, slot });
+        }
         reg
     }
 
     /// Record that `reg` now caches `slot`, dropping any prior cache of `slot`.
-    fn bind(&mut self, reg: GP, slot: SlotId, dirty: bool) {
+    pub(in crate::codegen::jitgen) fn bind(&mut self, reg: GP, slot: SlotId, dirty: bool) {
         for h in self.holder.iter_mut() {
             if h.map(|h| h.slot) == Some(slot) {
                 *h = None;
@@ -232,7 +247,7 @@ impl GpRegFile {
     /// Free every register caching a slot at or above `sp` — those temporaries
     /// are dead (popped past the stack pointer), so they are dropped without a
     /// spill, mirroring `clear_above_next_sp`.
-    fn free_above_sp(&mut self, sp: SlotId) {
+    pub(in crate::codegen::jitgen) fn free_above_sp(&mut self, sp: SlotId) {
         for h in self.holder.iter_mut() {
             if let Some(held) = *h
                 && held.slot >= sp
@@ -256,7 +271,7 @@ pub(in crate::codegen::jitgen) fn allocate_run(insts: &[BinOpInst]) -> Vec<GpAct
         // The result is (re)defined: drop any stale cache, then claim a register
         // for it (always — results stay resident), pinning the operand registers
         // across the possible eviction.
-        rf.bind_invalidate(inst.dst);
+        rf.invalidate(inst.dst);
         let dst_reg = rf.alloc(&[lhs_reg, rhs_reg], &mut out);
         out.push(GpAction::BinOp {
             kind: inst.kind,
@@ -306,7 +321,7 @@ fn flush_dirty(rf: &mut GpRegFile, out: &mut Vec<GpAction>) {
 impl GpRegFile {
     /// A slot is about to be redefined: drop any stale register cache of it (the
     /// old value is dead, so no spill).
-    fn bind_invalidate(&mut self, slot: SlotId) {
+    pub(in crate::codegen::jitgen) fn invalidate(&mut self, slot: SlotId) {
         for h in self.holder.iter_mut() {
             if h.map(|h| h.slot) == Some(slot) {
                 *h = None;

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -1,0 +1,381 @@
+//! Per-basic-block **local GP register allocator** (Layer-② first cut).
+//!
+//! This is the first slice of the register-allocation pass discussed in
+//! `doc/regalloc_separation.md` §3: a *local* (single basic block) allocator
+//! that scans the typed IR and assigns physical GP registers to the fixnum
+//! binop operands and results, **reusing** a register across instructions when
+//! a slot it already caches is read again. For
+//!
+//! ```text
+//! %1 = %2 + %3
+//! ```
+//!
+//! it emits, mirroring the design note's worked example:
+//!
+//! - `%2` not yet in a GP → load it into `GP1`,
+//! - `%3` not yet in a GP → load it into `GP2`,
+//! - `GP3 = GP1 + GP2`,
+//! - record that `%1` is now held in `GP3`.
+//!
+//! A subsequent `%4 = %1 + %5` then finds `%1` already resident and skips its
+//! reload — the win local allocation buys over the always-reload slot-IR
+//! lowering.
+//!
+//! ## Policy
+//!
+//! - **The result is always kept in a GP.** A binop result is very likely the
+//!   operand of the next instruction, so it is never spilled at its def; if the
+//!   register file is full the allocator evicts a *victim* to make room. Victim
+//!   selection is the simplest useful policy — **evict the oldest resident**
+//!   (FIFO) — and the evicted value is written back to its stack home.
+//! - **Liveness is the AsmIR stack pointer.** A temporary slot at or above
+//!   `next_sp` has been popped and will not be read again (exactly what
+//!   `clear_above_next_sp` discards), so after each instruction the allocator
+//!   frees every register caching such a slot — *without* a spill, since the
+//!   value is dead. This is the cheap, exact liveness the design note asks for,
+//!   and it keeps registers available for the results that matter.
+//!
+//! ## Scope / correctness model
+//!
+//! The register file is reset at basic-block entry and *flushed* — every dirty
+//! resident spilled to its stack home — at the block boundary and before any
+//! non-binop operation, so the rest of codegen always observes a slot in its
+//! canonical stack home. Being strictly per-block and never part of a
+//! cross-block merge, it avoids the loop-back-edge placement coupling that made
+//! the old analysis-fused `LinkMode::G` load-bearing (doc §13.8).
+//!
+//! This module is the **pure allocator**: it consumes a list of binop records
+//! (each tagged with the post-instruction `next_sp`) and produces a list of
+//! [`GpAction`]s. It is codegen-independent and unit-tested in isolation;
+//! wiring the actions into the AsmIR→LIR lowering (and threading dirty
+//! residents into the deopt write-back) is the next step.
+
+use crate::bytecodegen::BinOpK;
+use crate::codegen::GP;
+use crate::jitgen::SlotId;
+
+/// The allocatable GP registers for the local allocator: the caller-saved
+/// scratch registers that are *not* part of the fixed VM convention
+/// (acc/lfp/pc/globals/executor) or the C-ABI / inline-builtin scratch
+/// (rdi/rax/rsi/rdx/rcx). These are the registers the abolished `GP_ALLOC_POOL`
+/// used; the allocator re-uses them, but driven by an explicit local pass
+/// rather than fused into the type fixpoint.
+pub(in crate::codegen::jitgen) const GP_ALLOC_SET: &[GP] = &[GP::R8, GP::R9, GP::R10, GP::R11];
+
+/// One fixnum binop in the typed IR: `dst = lhs <kind> rhs`, all stack slots.
+///
+/// `next_sp` is the stack pointer *after* this instruction: every resident slot
+/// whose index is `>= next_sp` is a dead temporary (mirrors
+/// `clear_above_next_sp`) and is freed once the op has consumed it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) struct BinOpInst {
+    pub kind: BinOpK,
+    pub dst: SlotId,
+    pub lhs: SlotId,
+    pub rhs: SlotId,
+    pub next_sp: SlotId,
+}
+
+/// A single lowered action the allocator emits for the codegen half to replay.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum GpAction {
+    /// Load `slot` from its stack home into `reg`. `guard` requests a fixnum
+    /// type guard (needed for a value freshly read from the stack; a value
+    /// produced by a prior binop is already a known fixnum and skips it).
+    Load { slot: SlotId, reg: GP, guard: bool },
+    /// `dst = lhs <kind> rhs`, all three already in registers. The overflow /
+    /// type side-exit is the consumer's responsibility (it is a deopt point).
+    BinOp {
+        kind: BinOpK,
+        dst: GP,
+        lhs: GP,
+        rhs: GP,
+    },
+    /// Spill `reg` to `slot`'s stack home — emitted when a *dirty* resident is
+    /// evicted to free its register, or at the block-boundary flush. A clean
+    /// resident (freshly loaded, unmodified) already matches its home and is
+    /// dropped without a store.
+    Spill { reg: GP, slot: SlotId },
+}
+
+/// What an allocatable register currently caches.
+#[derive(Clone, Copy)]
+struct Holder {
+    slot: SlotId,
+    /// the register's value differs from `slot`'s stack home (a binop result);
+    /// a clean holder (freshly loaded, unmodified) needs no spill.
+    dirty: bool,
+    /// monotonically-increasing stamp set when the slot was bound, used to pick
+    /// the oldest resident as the eviction victim (FIFO).
+    age: u64,
+}
+
+/// The per-basic-block GP register file: which slot, if any, each allocatable
+/// register currently caches. The `vgp`-style `holder` vector mirrors the xmm
+/// `FprAllocator`.
+struct GpRegFile {
+    /// `holder[i]` is what `GP_ALLOC_SET[i]` caches (`None` = free).
+    holder: Vec<Option<Holder>>,
+    /// FIFO clock for victim selection.
+    clock: u64,
+}
+
+impl GpRegFile {
+    fn new() -> Self {
+        Self {
+            holder: vec![None; GP_ALLOC_SET.len()],
+            clock: 0,
+        }
+    }
+
+    fn tick(&mut self) -> u64 {
+        self.clock += 1;
+        self.clock
+    }
+
+    fn index_of(reg: GP) -> usize {
+        GP_ALLOC_SET.iter().position(|&r| r == reg).unwrap()
+    }
+
+    /// The register currently caching `slot`, if any (the reuse lookup).
+    fn reg_of(&self, slot: SlotId) -> Option<GP> {
+        self.holder
+            .iter()
+            .position(|h| h.map(|h| h.slot) == Some(slot))
+            .map(|i| GP_ALLOC_SET[i])
+    }
+
+    fn find_free(&self) -> Option<GP> {
+        self.holder
+            .iter()
+            .position(|h| h.is_none())
+            .map(|i| GP_ALLOC_SET[i])
+    }
+
+    /// Allocate a register, always succeeding: a free register if any, else the
+    /// **oldest** resident that is not `pinned` is evicted (its dirty value
+    /// written back) so the caller — typically a binop result that must stay
+    /// resident — always gets a register.
+    fn alloc(&mut self, pinned: &[GP], out: &mut Vec<GpAction>) -> GP {
+        if let Some(reg) = self.find_free() {
+            return reg;
+        }
+        let victim_idx = (0..self.holder.len())
+            .filter(|&i| !pinned.contains(&GP_ALLOC_SET[i]))
+            .min_by_key(|&i| self.holder[i].unwrap().age)
+            .expect("more pinned registers than the allocatable set");
+        let reg = GP_ALLOC_SET[victim_idx];
+        let h = self.holder[victim_idx].unwrap();
+        if h.dirty {
+            out.push(GpAction::Spill { reg, slot: h.slot });
+        }
+        self.holder[victim_idx] = None;
+        reg
+    }
+
+    /// Record that `reg` now caches `slot`, dropping any prior cache of `slot`.
+    fn bind(&mut self, reg: GP, slot: SlotId, dirty: bool) {
+        for h in self.holder.iter_mut() {
+            if h.map(|h| h.slot) == Some(slot) {
+                *h = None;
+            }
+        }
+        let age = self.tick();
+        self.holder[Self::index_of(reg)] = Some(Holder { slot, dirty, age });
+    }
+
+    /// Free every register caching a slot at or above `sp` — those temporaries
+    /// are dead (popped past the stack pointer), so they are dropped without a
+    /// spill, mirroring `clear_above_next_sp`.
+    fn free_above_sp(&mut self, sp: SlotId) {
+        for h in self.holder.iter_mut() {
+            if let Some(held) = *h
+                && held.slot >= sp
+            {
+                *h = None;
+            }
+        }
+    }
+}
+
+/// Allocate GP registers for a straight-line run of fixnum binops (one basic
+/// block, or a maximal binop sub-run within one). Returns the lowered
+/// [`GpAction`] stream, terminated by the flush of every dirty resident.
+pub(in crate::codegen::jitgen) fn allocate_run(insts: &[BinOpInst]) -> Vec<GpAction> {
+    let mut rf = GpRegFile::new();
+    let mut out = Vec::new();
+
+    for inst in insts {
+        let lhs_reg = ensure(&mut rf, inst.lhs, &[], &mut out);
+        let rhs_reg = ensure(&mut rf, inst.rhs, &[lhs_reg], &mut out);
+        // The result is (re)defined: drop any stale cache, then claim a register
+        // for it (always — results stay resident), pinning the operand registers
+        // across the possible eviction.
+        rf.bind_invalidate(inst.dst);
+        let dst_reg = rf.alloc(&[lhs_reg, rhs_reg], &mut out);
+        out.push(GpAction::BinOp {
+            kind: inst.kind,
+            dst: dst_reg,
+            lhs: lhs_reg,
+            rhs: rhs_reg,
+        });
+        rf.bind(dst_reg, inst.dst, /* dirty */ true);
+        // Liveness: free temporaries the stack pointer has popped (incl. the
+        // just-consumed operands), making their registers reusable.
+        rf.free_above_sp(inst.next_sp);
+    }
+
+    flush_dirty(&mut rf, &mut out);
+    out
+}
+
+/// Bring `slot` into a register and return it, reusing the resident copy when
+/// present (no reload, no re-guard) and otherwise loading + fixnum-guarding it.
+fn ensure(rf: &mut GpRegFile, slot: SlotId, pinned: &[GP], out: &mut Vec<GpAction>) -> GP {
+    if let Some(reg) = rf.reg_of(slot) {
+        return reg;
+    }
+    let reg = rf.alloc(pinned, out);
+    out.push(GpAction::Load {
+        slot,
+        reg,
+        guard: true,
+    });
+    rf.bind(reg, slot, /* dirty */ false);
+    reg
+}
+
+/// Flush dirty residents to their stack homes and clear the file.
+fn flush_dirty(rf: &mut GpRegFile, out: &mut Vec<GpAction>) {
+    for i in 0..rf.holder.len() {
+        if let Some(Holder { slot, dirty: true, .. }) = rf.holder[i] {
+            out.push(GpAction::Spill {
+                reg: GP_ALLOC_SET[i],
+                slot,
+            });
+        }
+        rf.holder[i] = None;
+    }
+}
+
+impl GpRegFile {
+    /// A slot is about to be redefined: drop any stale register cache of it (the
+    /// old value is dead, so no spill).
+    fn bind_invalidate(&mut self, slot: SlotId) {
+        for h in self.holder.iter_mut() {
+            if h.map(|h| h.slot) == Some(slot) {
+                *h = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sl(i: u16) -> SlotId {
+        SlotId::new(i)
+    }
+
+    /// `dst = lhs + rhs`, with `next_sp` so that slots `>= next_sp` are dead.
+    fn add(dst: u16, lhs: u16, rhs: u16, next_sp: u16) -> BinOpInst {
+        BinOpInst {
+            kind: BinOpK::Add,
+            dst: sl(dst),
+            lhs: sl(lhs),
+            rhs: sl(rhs),
+            next_sp: sl(next_sp),
+        }
+    }
+
+    const R8: GP = GP::R8;
+    const R9: GP = GP::R9;
+    const R10: GP = GP::R10;
+
+    /// The worked example `%1 = %2 + %3` (operands %2/%3 popped, %1 live):
+    /// %2 → R8, %3 → R9, R10 = R8 + R9, %1 recorded in R10, R10 spilled at flush.
+    #[test]
+    fn single_binop() {
+        // next_sp = 2 → slots %2,%3 (idx 2,3) dead, %1 (idx 1) live.
+        let out = allocate_run(&[add(1, 2, 3, 2)]);
+        assert_eq!(
+            out,
+            vec![
+                GpAction::Load { slot: sl(2), reg: R8, guard: true },
+                GpAction::Load { slot: sl(3), reg: R9, guard: true },
+                GpAction::BinOp { kind: BinOpK::Add, dst: R10, lhs: R8, rhs: R9 },
+                GpAction::Spill { reg: R10, slot: sl(1) },
+            ]
+        );
+    }
+
+    /// `%1 = %2 + %3; %4 = %1 + %5` — `%1` stays resident and is reused as an
+    /// operand with no reload; `%2`/`%3` freed by the stack pointer are reused.
+    #[test]
+    fn result_reused_as_operand() {
+        let out = allocate_run(&[add(1, 2, 3, 2), add(4, 1, 5, 4)]);
+        // %1 is never reloaded (it is produced in a register and consumed there).
+        assert!(!out
+            .iter()
+            .any(|a| matches!(a, GpAction::Load { slot, .. } if *slot == sl(1))));
+        // %1's register is an operand of the second op.
+        assert!(out
+            .iter()
+            .any(|a| matches!(a, GpAction::BinOp { lhs, .. } if *lhs == R10)));
+    }
+
+    /// The result is always kept in a register even under pressure: four live
+    /// results force an eviction (spill of the oldest) rather than spilling the
+    /// new result.
+    #[test]
+    fn result_always_resident_under_pressure() {
+        // Five chained results, all kept live (next_sp high so nothing is freed).
+        // %2..%6 are source locals; results %10..%14. With only 4 registers the
+        // 5th result must evict the oldest resident, not skip its own register.
+        let insts = [
+            add(10, 2, 3, 100),
+            add(11, 10, 4, 100),
+            add(12, 11, 5, 100),
+            add(13, 12, 6, 100),
+            add(14, 13, 7, 100),
+        ];
+        let out = allocate_run(&insts);
+        // Every binop result lands in a register (there is a BinOp for each).
+        let binops = out
+            .iter()
+            .filter(|a| matches!(a, GpAction::BinOp { .. }))
+            .count();
+        assert_eq!(binops, 5);
+        // Pressure forced at least one mid-run spill (a victim eviction).
+        let mid_spills = out
+            .iter()
+            .take_while(|a| !matches!(a, GpAction::BinOp { .. } if false)) // all
+            .filter(|a| matches!(a, GpAction::Spill { .. }))
+            .count();
+        assert!(mid_spills >= 1, "pressure should force a victim spill");
+    }
+
+    /// Liveness via the stack pointer frees a dead temporary's register so a
+    /// later op reuses it instead of growing register pressure.
+    #[test]
+    fn sp_frees_dead_temporary() {
+        // op1: %3 = %1 + %2, next_sp = 3 → %1,%2 dead, freed. %3 live in a reg.
+        // op2: %5 = %3 + %4 — %1,%2's registers are free for %4 / the result.
+        let out = allocate_run(&[add(3, 1, 2, 3), add(5, 3, 4, 5)]);
+        // %1 and %2 are each loaded exactly once; their registers are recycled.
+        for s in [1u16, 2] {
+            let loads = out
+                .iter()
+                .filter(|a| matches!(a, GpAction::Load { slot, .. } if *slot == sl(s)))
+                .count();
+            assert_eq!(loads, 1);
+        }
+        // No spill of the dead operands %1/%2 (freed without write-back).
+        for s in [1u16, 2] {
+            assert!(!out
+                .iter()
+                .any(|a| matches!(a, GpAction::Spill { slot, .. } if *slot == sl(s))));
+        }
+    }
+}

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -190,6 +190,17 @@ impl GpRegFile {
             .map(|i| GP_ALLOC_SET[i])
     }
 
+    /// The register caching `slot` only if that cache is **dirty** (its value
+    /// differs from the stack home). Used before an op that clobbers an operand
+    /// register (`Mul`/`Div` destroy `rhs`): the dirty value must be written to
+    /// its home first, since the register will not survive the op.
+    pub(in crate::codegen::jitgen) fn dirty_reg_of(&self, slot: SlotId) -> Option<GP> {
+        self.holder
+            .iter()
+            .position(|h| matches!(h, Some(Holder { slot: s, dirty: true, .. }) if *s == slot))
+            .map(|i| GP_ALLOC_SET[i])
+    }
+
     /// A free register that is not `pinned`. Pinned registers hold operands that
     /// are live across this allocation (e.g. when the result slot aliases an
     /// operand slot, `invalidate(dst)` leaves the operand's register unbound but

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -113,19 +113,64 @@ struct Holder {
 /// The per-basic-block GP register file: which slot, if any, each allocatable
 /// register currently caches. The `vgp`-style `holder` vector mirrors the xmm
 /// `FprAllocator`.
-struct GpRegFile {
+///
+/// Held in the abstract state and driven online during the basic-block walk:
+/// `IntegerBinOp` reuses/allocates registers through it, while every other
+/// instruction calls [`Self::take_dirty_spills`] up front to flush the live GP
+/// residents back to their stack homes (only `IntegerBinOp` is GP-aware so far).
+///
+/// It is flushed empty at every basic-block boundary, so although it rides
+/// inside the cloned/merged `SlotState` it never actually carries state across a
+/// block merge (the per-block-locality the design requires).
+#[derive(Clone)]
+pub(in crate::codegen::jitgen) struct GpRegFile {
     /// `holder[i]` is what `GP_ALLOC_SET[i]` caches (`None` = free).
     holder: Vec<Option<Holder>>,
     /// FIFO clock for victim selection.
     clock: u64,
 }
 
+impl Default for GpRegFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GpRegFile {
-    fn new() -> Self {
+    pub(in crate::codegen::jitgen) fn new() -> Self {
         Self {
             holder: vec![None; GP_ALLOC_SET.len()],
             clock: 0,
         }
+    }
+
+    /// True when no register is occupied (the common case — flushing then is a
+    /// no-op, so the hot path pays nothing).
+    pub(in crate::codegen::jitgen) fn is_empty(&self) -> bool {
+        self.holder.iter().all(|h| h.is_none())
+    }
+
+    /// The `(reg, slot)` pairs of every **dirty** resident, for inclusion in a
+    /// deopt / GC write-back (the values that differ from their stack home and
+    /// must be re-homed if the VM resumes). Does not mutate the file.
+    pub(in crate::codegen::jitgen) fn dirty_residents(&self) -> Vec<(GP, SlotId)> {
+        (0..self.holder.len())
+            .filter_map(|i| match self.holder[i] {
+                Some(Holder { slot, dirty: true, .. }) => Some((GP_ALLOC_SET[i], slot)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Flush: return the `(reg, slot)` spills for every dirty resident and clear
+    /// the file. The caller emits the stores (the block-boundary / pre-non-binop
+    /// flush). Clean residents need no store and are simply dropped.
+    pub(in crate::codegen::jitgen) fn take_dirty_spills(&mut self) -> Vec<(GP, SlotId)> {
+        let spills = self.dirty_residents();
+        for h in self.holder.iter_mut() {
+            *h = None;
+        }
+        spills
     }
 
     fn tick(&mut self) -> u64 {

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -266,13 +266,18 @@ pub(in crate::codegen::jitgen) fn allocate_run(insts: &[BinOpInst]) -> Vec<GpAct
     let mut out = Vec::new();
 
     for inst in insts {
+        // 1. Load the operands.
         let lhs_reg = ensure(&mut rf, inst.lhs, &[], &mut out);
         let rhs_reg = ensure(&mut rf, inst.rhs, &[lhs_reg], &mut out);
-        // The result is (re)defined: drop any stale cache, then claim a register
-        // for it (always — results stay resident), pinning the operand registers
-        // across the possible eviction.
+        // 2. The result is (re)defined: drop any stale cache of it.
         rf.invalidate(inst.dst);
-        let dst_reg = rf.alloc(&[lhs_reg, rhs_reg], &mut out);
+        // 3. Clear `next_sp`: the popped temporaries (the just-consumed operands
+        //    included) are dead. Done before the result allocation so the result
+        //    can reuse a freed operand's register.
+        rf.free_above_sp(inst.next_sp);
+        // 4. Claim a register for the result (always — results stay resident),
+        //    pinning only `rhs` so the result may reuse `lhs` in place.
+        let dst_reg = rf.alloc(&[rhs_reg], &mut out);
         out.push(GpAction::BinOp {
             kind: inst.kind,
             dst: dst_reg,
@@ -280,9 +285,6 @@ pub(in crate::codegen::jitgen) fn allocate_run(insts: &[BinOpInst]) -> Vec<GpAct
             rhs: rhs_reg,
         });
         rf.bind(dst_reg, inst.dst, /* dirty */ true);
-        // Liveness: free temporaries the stack pointer has popped (incl. the
-        // just-consumed operands), making their registers reusable.
-        rf.free_above_sp(inst.next_sp);
     }
 
     flush_dirty(&mut rf, &mut out);
@@ -354,7 +356,9 @@ mod tests {
     const R10: GP = GP::R10;
 
     /// The worked example `%1 = %2 + %3` (operands %2/%3 popped, %1 live):
-    /// %2 → R8, %3 → R9, R10 = R8 + R9, %1 recorded in R10, R10 spilled at flush.
+    /// %2 → R8, %3 → R9; then `next_sp` frees both operand registers, so the
+    /// result reuses `lhs`'s R8 in place — R8 = R8 + R9 — and is spilled to %1's
+    /// home at flush.
     #[test]
     fn single_binop() {
         // next_sp = 2 → slots %2,%3 (idx 2,3) dead, %1 (idx 1) live.
@@ -364,8 +368,8 @@ mod tests {
             vec![
                 GpAction::Load { slot: sl(2), reg: R8, guard: true },
                 GpAction::Load { slot: sl(3), reg: R9, guard: true },
-                GpAction::BinOp { kind: BinOpK::Add, dst: R10, lhs: R8, rhs: R9 },
-                GpAction::Spill { reg: R10, slot: sl(1) },
+                GpAction::BinOp { kind: BinOpK::Add, dst: R8, lhs: R8, rhs: R9 },
+                GpAction::Spill { reg: R8, slot: sl(1) },
             ]
         );
     }
@@ -379,10 +383,17 @@ mod tests {
         assert!(!out
             .iter()
             .any(|a| matches!(a, GpAction::Load { slot, .. } if *slot == sl(1))));
-        // %1's register is an operand of the second op.
-        assert!(out
+        // The second op's `lhs` is exactly the register the first op produced
+        // `%1` in — the result flows directly into the next op with no reload.
+        let binops: Vec<_> = out
             .iter()
-            .any(|a| matches!(a, GpAction::BinOp { lhs, .. } if *lhs == R10)));
+            .filter_map(|a| match a {
+                GpAction::BinOp { dst, lhs, .. } => Some((*dst, *lhs)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(binops.len(), 2);
+        assert_eq!(binops[1].1, binops[0].0);
     }
 
     /// The result is always kept in a register even under pressure: four live

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -624,6 +624,7 @@ pub(in crate::codegen) enum LInst {
         ivarid: IvarId,
         is_object_ty: bool,
         self_: bool,
+        dst: GP,
     },
     /// Store into a heap-spilled instance variable of another object
     /// (bounds-checked; grows the var-table on miss via a runtime call).

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -461,7 +461,6 @@ pub(in crate::codegen) enum LInst {
     /// idiv/imul-vs-aarch64 lowering stay per-arch.
     IntegerBinOp {
         kind: BinOpK,
-        mode: OpMode,
         lhs: GP,
         rhs: GP,
         deopt: DestLabel,
@@ -813,7 +812,6 @@ pub(in crate::codegen) enum LInst {
     },
     IntegerCmp {
         kind: CmpKind,
-        mode: OpMode,
         lhs: GP,
         rhs: GP,
     },

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -180,6 +180,10 @@ impl AbstractFrame {
         self.next_sp = slot;
     }
 
+    pub(in crate::codegen::jitgen) fn next_sp(&self) -> SlotId {
+        self.next_sp
+    }
+
     pub(super) fn no_capture_guard(&self) -> bool {
         self.invariants.no_capture_guard
     }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -269,16 +269,38 @@ impl AbstractFrame {
     /// leaves no register resident.
     pub(crate) fn def_rax2gp(&mut self, ir: &mut AsmIr, dst: impl Into<Option<SlotId>>) {
         if let Some(dst) = dst.into() {
-            // Clear any stale resident / link of `dst` first (mirrors the binop
-            // result path), then bind the freshly allocated register.
-            self.def_S_guarded(dst, slot::Guarded::Value);
-            let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
-            if let Some((reg, slot)) = spill {
-                ir.reg2stack(reg, slot);
-            }
+            let gp = self.alloc_gp_for(ir, dst, slot::Guarded::Value);
             ir.reg_move(GP::Rax, gp);
-            self.gp_regfile.bind(gp, dst, /* dirty */ true, /* fixnum */ false);
+            self.bind_gp_resident(gp, dst);
         }
+    }
+
+    /// Allocate a pool GP register to receive a freshly-produced general `Value`
+    /// for `dst`: clear `dst`'s stale link (refining it to `guarded`), evict and
+    /// spill a victim resident if the pool is full, and return the (still
+    /// **unbound**) register. The caller emits the value-producing instruction
+    /// into it and then calls [`Self::bind_gp_resident`] — binding only after the
+    /// value is in the register keeps a victim spill from clobbering it and
+    /// matches the binop-result ordering.
+    pub(in crate::codegen::jitgen) fn alloc_gp_for(
+        &mut self,
+        ir: &mut AsmIr,
+        dst: SlotId,
+        guarded: slot::Guarded,
+    ) -> GP {
+        self.def_S_guarded(dst, guarded);
+        let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
+        if let Some((reg, slot)) = spill {
+            ir.reg2stack(reg, slot);
+        }
+        gp
+    }
+
+    /// Bind `gp` as the live (dirty, general-`Value`) resident of `dst` after the
+    /// value has been produced in it. Marked `fixnum = false`, so the first
+    /// integer op to consume it re-guards (`gp_ensure` → `take_needs_fixnum_guard`).
+    pub(in crate::codegen::jitgen) fn bind_gp_resident(&mut self, gp: GP, dst: SlotId) {
+        self.gp_regfile.bind(gp, dst, /* dirty */ true, /* fixnum */ false);
     }
 
     /// Define `dst` from a concrete (non-immediate) literal by loading it
@@ -291,13 +313,9 @@ impl AbstractFrame {
     /// next `flush_gp` — exactly as the old `def_reg2acc_concrete_value` path
     /// left the pointer physically in the stack slot.
     pub(crate) fn def_lit2gp(&mut self, ir: &mut AsmIr, dst: SlotId, v: Value) {
-        self.def_S_guarded(dst, Guarded::from_concrete_value(v));
-        let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
-        if let Some((reg, slot)) = spill {
-            ir.reg2stack(reg, slot);
-        }
+        let gp = self.alloc_gp_for(ir, dst, Guarded::from_concrete_value(v));
         ir.lit2reg(v, gp);
-        self.gp_regfile.bind(gp, dst, /* dirty */ true, /* fixnum */ false);
+        self.bind_gp_resident(gp, dst);
     }
 
     pub(crate) fn def_reg2acc(&mut self, ir: &mut AsmIr, src: GP, dst: impl Into<Option<SlotId>>) {

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -379,7 +379,7 @@ impl AbstractFrame {
         slot.iter().for_each(|r| self.write_back_slot(ir, *r));
     }
 
-    /// Flush the per-block local GP register file (`gp-local-alloc`): spill every
+    /// Flush the per-block local GP register file (the local GP allocator): spill every
     /// dirty resident to its stack home and clear the file. Called up front by
     /// every non-`IntegerBinOp` instruction — only that op is GP-aware so far —
     /// and at block boundaries, so the rest of codegen always observes a slot in

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -256,6 +256,50 @@ impl AbstractFrame {
         }
     }
 
+    /// Define `dst` from a call/yield result in rax by parking it in a GP-pool
+    /// register (making it a resident) instead of writing it to its stack home.
+    /// A following integer op can then consume it straight out of the register.
+    ///
+    /// The result is a general `Value` of unknown class, so the resident is
+    /// marked `fixnum = false`: the first integer op to consume it re-guards
+    /// (`gp_ensure` → `take_needs_fixnum_guard`). It is bound **dirty**, so a
+    /// deopt / GC safepoint re-homes it (`dirty_residents`) and the next
+    /// `flush_gp` spills it. Only sound when the frame is *not* capturable — a
+    /// capturing call must use `def_rax2acc_capturing` (LFP-relative store) and
+    /// leaves no register resident.
+    pub(crate) fn def_rax2gp(&mut self, ir: &mut AsmIr, dst: impl Into<Option<SlotId>>) {
+        if let Some(dst) = dst.into() {
+            // Clear any stale resident / link of `dst` first (mirrors the binop
+            // result path), then bind the freshly allocated register.
+            self.def_S_guarded(dst, slot::Guarded::Value);
+            let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
+            if let Some((reg, slot)) = spill {
+                ir.reg2stack(reg, slot);
+            }
+            ir.reg_move(GP::Rax, gp);
+            self.gp_regfile.bind(gp, dst, /* dirty */ true, /* fixnum */ false);
+        }
+    }
+
+    /// Define `dst` from a concrete (non-immediate) literal by loading it
+    /// straight into a GP-pool register (a resident) rather than through rax to
+    /// the stack home. The literal is a heap value (frozen String/Array/…), so
+    /// the resident is `fixnum = false`; it carries its concrete guarded type.
+    /// The slot is `LinkMode::S`, so it is re-homed at a deopt / GC safepoint
+    /// purely as a **dirty** resident (`dirty_residents` spills the register to
+    /// the stack home, where GC then scans the heap pointer), and spilled at the
+    /// next `flush_gp` — exactly as the old `def_reg2acc_concrete_value` path
+    /// left the pointer physically in the stack slot.
+    pub(crate) fn def_lit2gp(&mut self, ir: &mut AsmIr, dst: SlotId, v: Value) {
+        self.def_S_guarded(dst, Guarded::from_concrete_value(v));
+        let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
+        if let Some((reg, slot)) = spill {
+            ir.reg2stack(reg, slot);
+        }
+        ir.lit2reg(v, gp);
+        self.gp_regfile.bind(gp, dst, /* dirty */ true, /* fixnum */ false);
+    }
+
     pub(crate) fn def_reg2acc(&mut self, ir: &mut AsmIr, src: GP, dst: impl Into<Option<SlotId>>) {
         self.def_reg2acc_guarded(ir, src, dst, slot::Guarded::Value)
     }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -375,6 +375,22 @@ impl AbstractFrame {
         slot.iter().for_each(|r| self.write_back_slot(ir, *r));
     }
 
+    /// Flush the per-block local GP register file (`gp-local-alloc`): spill every
+    /// dirty resident to its stack home and clear the file. Called up front by
+    /// every non-`IntegerBinOp` instruction — only that op is GP-aware so far —
+    /// and at block boundaries, so the rest of codegen always observes a slot in
+    /// its canonical stack home. A no-op when the file is empty (the default
+    /// build never populates it, and even with the feature on most instructions
+    /// see an empty file), so the emitted code is unchanged there.
+    pub(in crate::codegen::jitgen) fn flush_gp(&mut self, ir: &mut AsmIr) {
+        if self.gp_regfile.is_empty() {
+            return;
+        }
+        for (reg, slot) in self.gp_regfile.take_dirty_spills() {
+            ir.reg2stack(reg, slot);
+        }
+    }
+
     ///
     /// Fetch from *args* to *args* + *len* - 1 and store in corresponding stack slots.
     ///

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -91,6 +91,10 @@ pub(in crate::codegen::jitgen) enum GpLoad {
     Lit(Value, GP),
     /// `stack2reg(slot, dst)`
     Stack(SlotId, GP),
+    /// The slot is a live GP resident (an integer binop result still in a
+    /// register): move it from the resident register instead of reading its
+    /// possibly-stale stack home. `reg_move(src, dst)`.
+    FromGp(GP, GP),
 }
 
 impl GpLoad {
@@ -102,6 +106,7 @@ impl GpLoad {
             }
             GpLoad::Lit(v, dst) => ir.lit2reg(v, dst),
             GpLoad::Stack(slot, dst) => ir.stack2reg(slot, dst),
+            GpLoad::FromGp(src, dst) => ir.reg_move(src, dst),
         }
     }
 }
@@ -256,7 +261,15 @@ impl AbstractFrame {
                 GpLoad::FprBox(fpr, slot, dst)
             }
             LinkMode::C(v) => GpLoad::Lit(v, dst),
-            LinkMode::Sf(_, _) | LinkMode::S(_) => GpLoad::Stack(slot, dst),
+            LinkMode::Sf(_, _) | LinkMode::S(_) => {
+                // A live GP resident holds the slot's (possibly dirty) value in a
+                // register; move it from there rather than reading a stale home.
+                if let Some(src) = self.gp_regfile.reg_of(slot) {
+                    GpLoad::FromGp(src, dst)
+                } else {
+                    GpLoad::Stack(slot, dst)
+                }
+            }
             LinkMode::MaybeNone => GpLoad::Stack(slot, dst),
             LinkMode::V | LinkMode::None => {
                 unreachable!("load() {:?} {:?}: {:?}", slot, self.mode(slot), self);

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -204,16 +204,6 @@ pub(in crate::codegen::jitgen) enum TransferIR {
         lhs: FPReg,
         rhs: FPReg,
     },
-    /// §slot-IR: a slot-based fixnum binop (`dst = lhs <kind> rhs`, all stack
-    /// slots). It carries its deopt as a program point;
-    /// no physical register appears (the LIR lowering materializes them).
-    IntegerBinOpSlot {
-        kind: BinOpK,
-        dst: Option<SlotId>,
-        lhs: SlotId,
-        rhs: SlotId,
-        deopt: DeoptPoint,
-    },
 }
 
 impl TransferIR {
@@ -232,16 +222,6 @@ impl TransferIR {
             } => ir.fpr_binop(kind, lhs, rhs, dst),
             TransferIR::FloatCmp { kind, lhs, rhs } => {
                 ir.push(AsmInst::FloatCmp { kind, lhs, rhs })
-            }
-            TransferIR::IntegerBinOpSlot {
-                kind,
-                dst,
-                lhs,
-                rhs,
-                deopt,
-            } => {
-                let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_binop_slot(kind, dst, lhs, rhs, deopt);
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -48,8 +48,10 @@ impl DeoptPoint {
 pub(in crate::codegen::jitgen) enum FprLoad {
     /// already in an fpr (`Sf` / `F`) — nothing to emit
     None,
-    /// `stack2reg(slot, Rdi); float_to_fpr(Rdi, x, deopt)`
-    FromStack(FPReg),
+    /// `<load Rdi>; float_to_fpr(Rdi, x, deopt)`. `Rdi` is loaded from the slot's
+    /// live GP resident (`reg_move`) when one is present, else from its stack
+    /// home (`stack2reg`).
+    FromStack(FPReg, Option<GP>),
     /// `f64_to_fpr(f, x)` (guard-free)
     FromF64(f64, FPReg),
     /// `i64_to_stack_and_fpr(i, slot, x)` (guard-free)
@@ -65,9 +67,12 @@ impl FprLoad {
     fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<&DeoptPoint>) {
         match self {
             FprLoad::None => {}
-            FprLoad::FromStack(x) => {
+            FprLoad::FromStack(x, gp) => {
                 let deopt = ir.deopt_from_point(deopt.unwrap());
-                ir.stack2reg(slot, GP::Rdi);
+                match gp {
+                    Some(reg) => ir.reg_move(reg, GP::Rdi),
+                    None => ir.stack2reg(slot, GP::Rdi),
+                }
                 ir.float_to_fpr(GP::Rdi, x, deopt);
             }
             FprLoad::FromF64(f, x) => ir.f64_to_fpr(f, x),
@@ -130,8 +135,11 @@ impl GpLoad {
 pub(in crate::codegen::jitgen) enum FprFixnumLoad {
     /// already in an fpr (`Sf` / `F`) — nothing to emit
     None,
-    /// `stack2reg(slot, Rdi); [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`
-    FromStack(FPReg, bool),
+    /// `<load Rdi>; [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`. `Rdi` is loaded from
+    /// the slot's live GP resident (`reg_move`) when one is present — the integer
+    /// side of a mixed `Integer op Float` is typically still in a register from a
+    /// prior integer op — else from its stack home (`stack2reg`).
+    FromStack(FPReg, bool, Option<GP>),
     /// guard-free numeric literal (`LinkMode::C`) — reuses the [`FprLoad`] record
     Numeric(FprLoad),
 }
@@ -145,9 +153,12 @@ impl FprFixnumLoad {
     fn emit(self, ir: &mut AsmIr, slot: SlotId, deopt: Option<&DeoptPoint>) {
         match self {
             FprFixnumLoad::None => {}
-            FprFixnumLoad::FromStack(x, guard) => {
+            FprFixnumLoad::FromStack(x, guard, gp) => {
                 let deopt = deopt.map(|p| ir.deopt_from_point(p));
-                ir.stack2reg(slot, GP::Rdi);
+                match gp {
+                    Some(reg) => ir.reg_move(reg, GP::Rdi),
+                    None => ir.stack2reg(slot, GP::Rdi),
+                }
                 if guard {
                     ir.push(AsmInst::GuardClass(GP::Rdi, INTEGER_CLASS, deopt.unwrap()));
                 }
@@ -353,9 +364,14 @@ impl AbstractFrame {
                 // S -> Sf. Refine the type first (its guard verdict) then take
                 // the placement; `set_new_Sf` overwrites the refined `S` guarded
                 // with `Sf(Fixnum)`, exactly as `guard_fixnum` + `set_new_Sf` did.
+                // Capture any live GP resident *before* `set_new_Sf` clears it, so
+                // the emit reads the value from the register instead of its
+                // possibly-stale stack home (the conversion copies to Rdi first, so
+                // the resident register survives intact).
+                let gp = self.gp_regfile.reg_of(slot);
                 let guard = self.guard_class_state(slot, INTEGER_CLASS);
                 let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                (x, FprFixnumLoad::FromStack(x, guard))
+                (x, FprFixnumLoad::FromStack(x, guard, gp))
             }
             LinkMode::C(v) => {
                 let (x, load) = self.load_fpr_from_C_state(slot, v);
@@ -409,9 +425,12 @@ impl AbstractFrame {
         match self.mode(slot) {
             LinkMode::Sf(x, _) | LinkMode::F(x) => (x, FprLoad::None),
             LinkMode::S(_) => {
-                // -> Sf
+                // -> Sf. Capture any live GP resident before `set_new_Sf` clears
+                // it so the emit reads from the register rather than the stack
+                // home (see `load_fpr_fixnum_state`).
+                let gp = self.gp_regfile.reg_of(slot);
                 let x = self.set_new_Sf(slot, SfGuarded::Float);
-                (x, FprLoad::FromStack(x))
+                (x, FprLoad::FromStack(x, gp))
             }
             LinkMode::C(v) => self.load_fpr_from_C_state(slot, v),
             LinkMode::V | LinkMode::MaybeNone | LinkMode::None => {

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -48,9 +48,10 @@ impl DeoptPoint {
 pub(in crate::codegen::jitgen) enum FprLoad {
     /// already in an fpr (`Sf` / `F`) — nothing to emit
     None,
-    /// `<load Rdi>; float_to_fpr(Rdi, x, deopt)`. `Rdi` is loaded from the slot's
-    /// live GP resident (`reg_move`) when one is present, else from its stack
-    /// home (`stack2reg`).
+    /// `<load Rdi>; float_to_fpr(Rdi, x, deopt)`. When the slot has a live GP
+    /// resident the value is flushed home (`reg2stack`, to keep the `Sf`
+    /// invariant) and read into Rdi from the register (`reg_move`); otherwise it
+    /// is read from the stack home (`stack2reg`).
     FromStack(FPReg, Option<GP>),
     /// `f64_to_fpr(f, x)` (guard-free)
     FromF64(f64, FPReg),
@@ -70,7 +71,17 @@ impl FprLoad {
             FprLoad::FromStack(x, gp) => {
                 let deopt = ir.deopt_from_point(deopt.unwrap());
                 match gp {
-                    Some(reg) => ir.reg_move(reg, GP::Rdi),
+                    // The slot transitions `S -> Sf`, whose contract is that its
+                    // stack home holds the canonical boxed value (a later
+                    // fpr-pressure demote `Sf -> S` emits no spill — see
+                    // `try_alloc_fpr_ctx` phase 1). A GP resident's value lives
+                    // only in `reg`, so flush it home here before reading it into
+                    // Rdi for the conversion; otherwise the home stays stale and
+                    // the value is lost on demote.
+                    Some(reg) => {
+                        ir.reg2stack(reg, slot);
+                        ir.reg_move(reg, GP::Rdi);
+                    }
                     None => ir.stack2reg(slot, GP::Rdi),
                 }
                 ir.float_to_fpr(GP::Rdi, x, deopt);
@@ -135,10 +146,12 @@ impl GpLoad {
 pub(in crate::codegen::jitgen) enum FprFixnumLoad {
     /// already in an fpr (`Sf` / `F`) — nothing to emit
     None,
-    /// `<load Rdi>; [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`. `Rdi` is loaded from
-    /// the slot's live GP resident (`reg_move`) when one is present — the integer
-    /// side of a mixed `Integer op Float` is typically still in a register from a
-    /// prior integer op — else from its stack home (`stack2reg`).
+    /// `<load Rdi>; [GuardClass(Rdi)]; fixnum2fpr(Rdi, x)`. When the slot has a
+    /// live GP resident — the integer side of a mixed `Integer op Float` is
+    /// typically still in a register from a prior integer op — the value is
+    /// flushed home (`reg2stack`, to keep the `Sf` invariant) and read into Rdi
+    /// from the register (`reg_move`); else it is read from its stack home
+    /// (`stack2reg`).
     FromStack(FPReg, bool, Option<GP>),
     /// guard-free numeric literal (`LinkMode::C`) — reuses the [`FprLoad`] record
     Numeric(FprLoad),
@@ -156,7 +169,13 @@ impl FprFixnumLoad {
             FprFixnumLoad::FromStack(x, guard, gp) => {
                 let deopt = deopt.map(|p| ir.deopt_from_point(p));
                 match gp {
-                    Some(reg) => ir.reg_move(reg, GP::Rdi),
+                    // See `FprLoad::FromStack`: the slot becomes `Sf`, so its
+                    // stack home must hold the canonical boxed value. Flush the
+                    // resident home before reading it into Rdi.
+                    Some(reg) => {
+                        ir.reg2stack(reg, slot);
+                        ir.reg_move(reg, GP::Rdi);
+                    }
                     None => ir.stack2reg(slot, GP::Rdi),
                 }
                 if guard {

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -204,20 +204,8 @@ pub(in crate::codegen::jitgen) enum TransferIR {
         lhs: FPReg,
         rhs: FPReg,
     },
-    /// §19 (B): an integer binary **operation** with an overflow/`bignum` guard.
-    /// Like the guarded loads (`FprLoad`), it carries its deopt as a
-    /// [`DeoptPoint`] program point (not a frozen `AsmDeopt`); the emit half
-    /// materializes the side-exit via `deopt_from_point`, keeping the record
-    /// codegen-independent.
-    IntegerBinOp {
-        kind: BinOpK,
-        lhs: GP,
-        rhs: GP,
-        mode: OpMode,
-        deopt: DeoptPoint,
-    },
     /// §slot-IR: a slot-based fixnum binop (`dst = lhs <kind> rhs`, all stack
-    /// slots). Like `IntegerBinOp` it carries its deopt as a program point;
+    /// slots). It carries its deopt as a program point;
     /// no physical register appears (the LIR lowering materializes them).
     IntegerBinOpSlot {
         kind: BinOpK,
@@ -261,16 +249,6 @@ impl TransferIR {
             } => ir.fpr_binop(kind, lhs, rhs, dst),
             TransferIR::FloatCmp { kind, lhs, rhs } => {
                 ir.push(AsmInst::FloatCmp { kind, lhs, rhs })
-            }
-            TransferIR::IntegerBinOp {
-                kind,
-                lhs,
-                rhs,
-                mode,
-                deopt,
-            } => {
-                let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_binop(kind, lhs, rhs, mode, deopt);
             }
             TransferIR::IntegerBinOpSlot {
                 kind,
@@ -339,44 +317,6 @@ impl AbstractFrame {
                 unreachable!("load() {:?} {:?}: {:?}", slot, self.mode(slot), self);
             }
         }
-    }
-
-    /// Bring `lhs` into the register where an in-place fixnum binop computes its
-    /// result, and return that register. No `Rdi` copy, no relocate `mov`.
-    ///
-    /// Register choice, in priority order:
-    /// 1. **`lhs` is already in a GP register** (R15 or a pool register) →
-    ///    compute in place there, reusing it for the result (zero operand
-    ///    copies — the chained-arithmetic / loop-carried fast path). `lhs` is
-    ///    spilled to its stack home first (`write_back_slot`), which preserves
-    ///    it for any later use *and* keeps the overflow-deopt snapshot
-    ///    consistent (the in-place op clobbers the register, but the snapshot
-    ///    reads the spilled home).
-    /// 2. **gp-alloc, a vacant pool register** → load `lhs` into it and compute
-    ///    there, so the result stays resident in `r8`–`r11` and later reads
-    ///    avoid a stack reload (this is what makes the pool pay off).
-    /// 3. otherwise → the R15 accumulator (freed first).
-    pub(in crate::codegen::jitgen) fn fetch_lhs_to_inplace_reg(
-        &mut self,
-        ir: &mut AsmIr,
-        lhs: SlotId,
-    ) -> GP {
-        if let Some(reg) = self.on_reg(lhs) {
-            self.write_back_slot(ir, lhs);
-            self.guard_fixnum(ir, lhs, reg);
-            return reg;
-        }
-        self.load(ir, lhs, GP::R15);
-        self.guard_fixnum(ir, lhs, GP::R15);
-        GP::R15
-    }
-
-    /// Choose the in-place result register for a fixnum binop whose lhs is an
-    /// immediate (the `IR`-Sub case, where the encoder materializes the
-    /// immediate into the result register): the freed R15 accumulator (the GP
-    /// pool is abolished).
-    pub(in crate::codegen::jitgen) fn alloc_inplace_reg(&mut self, _ir: &mut AsmIr) -> GP {
-        GP::R15
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -214,26 +214,6 @@ pub(in crate::codegen::jitgen) enum TransferIR {
         rhs: SlotId,
         deopt: DeoptPoint,
     },
-    /// §slot-IR: a slot-based fixnum comparison (`dst = lhs <kind> rhs`, all
-    /// stack slots). Carries its deopt as a program point (for the operand
-    /// fixnum guards); no physical register appears.
-    IntegerCmpSlot {
-        lhs: SlotId,
-        rhs: SlotId,
-        kind: CmpKind,
-        dst: Option<SlotId>,
-        deopt: DeoptPoint,
-    },
-    /// §slot-IR: a slot-based fused fixnum compare + branch. Carries its deopt
-    /// as a program point (operand guards) and the branch target `JitLabel`.
-    IntegerCmpBrSlot {
-        lhs: SlotId,
-        rhs: SlotId,
-        kind: CmpKind,
-        brkind: BrKind,
-        branch_dest: JitLabel,
-        deopt: DeoptPoint,
-    },
 }
 
 impl TransferIR {
@@ -262,27 +242,6 @@ impl TransferIR {
             } => {
                 let deopt = ir.deopt_from_point(&deopt);
                 ir.integer_binop_slot(kind, dst, lhs, rhs, deopt);
-            }
-            TransferIR::IntegerCmpSlot {
-                lhs,
-                rhs,
-                kind,
-                dst,
-                deopt,
-            } => {
-                let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_cmp_slot(lhs, rhs, kind, dst, deopt);
-            }
-            TransferIR::IntegerCmpBrSlot {
-                lhs,
-                rhs,
-                kind,
-                brkind,
-                branch_dest,
-                deopt,
-            } => {
-                let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_cmp_br_slot(lhs, rhs, kind, brkind, branch_dest, deopt);
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -210,14 +210,16 @@ pub(in crate::codegen::jitgen) enum TransferIR {
     IntegerBinOpSlot {
         kind: BinOpK,
         dst: Option<SlotId>,
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         deopt: DeoptPoint,
     },
     /// §slot-IR: a slot-based fixnum comparison (`dst = lhs <kind> rhs`, all
     /// stack slots). Carries its deopt as a program point (for the operand
     /// fixnum guards); no physical register appears.
     IntegerCmpSlot {
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         dst: Option<SlotId>,
         deopt: DeoptPoint,
@@ -225,7 +227,8 @@ pub(in crate::codegen::jitgen) enum TransferIR {
     /// §slot-IR: a slot-based fused fixnum compare + branch. Carries its deopt
     /// as a program point (operand guards) and the branch target `JitLabel`.
     IntegerCmpBrSlot {
-        mode: OpMode,
+        lhs: SlotId,
+        rhs: SlotId,
         kind: CmpKind,
         brkind: BrKind,
         branch_dest: JitLabel,
@@ -253,30 +256,33 @@ impl TransferIR {
             TransferIR::IntegerBinOpSlot {
                 kind,
                 dst,
-                mode,
+                lhs,
+                rhs,
                 deopt,
             } => {
                 let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_binop_slot(kind, dst, mode, deopt);
+                ir.integer_binop_slot(kind, dst, lhs, rhs, deopt);
             }
             TransferIR::IntegerCmpSlot {
-                mode,
+                lhs,
+                rhs,
                 kind,
                 dst,
                 deopt,
             } => {
                 let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_cmp_slot(mode, kind, dst, deopt);
+                ir.integer_cmp_slot(lhs, rhs, kind, dst, deopt);
             }
             TransferIR::IntegerCmpBrSlot {
-                mode,
+                lhs,
+                rhs,
                 kind,
                 brkind,
                 branch_dest,
                 deopt,
             } => {
                 let deopt = ir.deopt_from_point(&deopt);
-                ir.integer_cmp_br_slot(mode, kind, brkind, branch_dest, deopt);
+                ir.integer_cmp_br_slot(lhs, rhs, kind, brkind, branch_dest, deopt);
             }
         }
     }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1130,14 +1130,6 @@ impl SlotState {
         None
     }
 
-
-    /// Flush GP-pool residents to their stack homes at a branch / block /
-    /// safepoint boundary. **Now a no-op**: GP-pool residence (`LinkMode::G`)
-    /// is abolished, so no value is ever register-resident in a pool slot. The
-    /// call sites are retained as explicit boundary markers (and so the seam is
-    /// available should a GP allocator be reintroduced).
-    pub(crate) fn flush_pool(&mut self, _ir: &mut AsmIr) {}
-
     /// Write the accumulator back before a call / safepoint. **Now a no-op**:
     /// with the R15 accumulator retired and the GP pool abolished there is no
     /// register-resident accumulator to spill. Retained as a boundary marker.
@@ -1303,7 +1295,6 @@ impl AbstractFrame {
     /// [`Self::using_fpr_offset`] where only the stack-offset is needed and no
     /// call (hence no flush) happens.
     pub(crate) fn get_using_fpr(&mut self, ir: &mut AsmIr) -> UsingFpr {
-        self.flush_pool(ir);
         // Single chokepoint for GP-clobbering calls: every C-ABI call (inline-asm
         // generators, CFunc inlines, the cached method-call path) takes a
         // `get_using_fpr` snapshot first, so flushing the local GP register file

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -252,6 +252,10 @@ pub(crate) struct SlotState {
     liveness: Vec<IsUsed>,
     /// fpr-register allocation state (item ②, step 1).
     fpr_alloc: FprAllocator,
+    /// Per-basic-block local GP register file (`gp-local-alloc`). Empty (and
+    /// flushed) at every block boundary, so it never carries state across a
+    /// merge despite living in the cloned `SlotState`.
+    pub(in crate::codegen::jitgen) gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile,
     local_num: usize,
     /// D1 forwarding-rest deferral (transient annotation; see the consumers).
     deferred_rest: Option<(SlotId, SlotId, u16)>,
@@ -291,6 +295,7 @@ impl SlotState {
             ty: vec![default_ty; total_reg_num],
             liveness: vec![IsUsed::default(); total_reg_num],
             fpr_alloc: FprAllocator::new(),
+            gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile::new(),
             local_num,
             deferred_rest: None,
             loop_carried: std::collections::HashSet::new(),
@@ -1315,16 +1320,22 @@ impl AbstractFrame {
         // capturable, so no heap snapshot observes it pre-consume.
         let literal = self.wb_literal(|_| true);
         let void = self.wb_void();
-        // No GP-pool residents to spill (`LinkMode::G` abolished).
-        WriteBack::new(vec![], literal, void, vec![], vec![])
+        // `gp-local-alloc`: spill dirty GP residents so the GC marks them (the
+        // registers themselves survive the collection — `exec_gc` preserves the
+        // caller-saved set). Empty without the feature.
+        let gp = self.gp_regfile.dirty_residents();
+        WriteBack::new(vec![], literal, void, gp, vec![])
     }
 
     pub(crate) fn get_write_back(&self) -> WriteBack {
         let f = |_| true;
         let fpr = self.wb_fpr(f);
         let literal = self.wb_literal(f);
-        // No GP-pool residents to re-home (`LinkMode::G` abolished).
-        WriteBack::new(fpr, literal, vec![], vec![], self.wb_forward_rest())
+        // `gp-local-alloc`: re-home dirty GP residents (a binop result still in a
+        // register) so a deopt resuming in the VM reads them from their stack
+        // home. Empty without the feature.
+        let gp = self.gp_regfile.dirty_residents();
+        WriteBack::new(fpr, literal, vec![], gp, self.wb_forward_rest())
     }
 
     fn fpr_swap(&mut self, l: FPReg, r: FPReg) {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -994,16 +994,6 @@ impl SlotState {
         u16::try_from(i).ok()
     }
 
-    pub fn is_i16_literal(&self, slot: SlotId) -> Option<i16> {
-        let i = self.is_fixnum_literal(slot)?.get();
-        i16::try_from(i).ok()
-    }
-
-    //pub fn is_u8_literal(&self, slot: SlotId) -> Option<u8> {
-    //    let i = self.is_fixnum_literal(slot)?.get();
-    //    u8::try_from(i).ok()
-    //}
-
     pub fn is_array_ty(&self, store: &Store, slot: SlotId) -> bool {
         let b = if let Guarded::Class(class) = self.guarded(slot) {
             store[class].is_array_ty_instance()
@@ -1120,16 +1110,6 @@ impl SlotState {
         None
     }
 
-    /// Define `dst` as a Fixnum produced in-place by a fixnum binop in `reg`.
-    /// With the R15 accumulator retired and the GP pool abolished, `reg` is
-    /// always the transient R15 scratch: the value is stored to `dst`'s stack
-    /// home and `dst` becomes `S`.
-    pub(crate) fn def_inplace_fixnum(&mut self, ir: &mut AsmIr, dst: SlotId, reg: GP) {
-        debug_assert_eq!(reg, GP::R15);
-        self.discard(dst);
-        ir.reg2stack(reg, dst);
-        self.set_mode(dst, LinkMode::S(Guarded::Fixnum));
-    }
 
     /// Flush GP-pool residents to their stack homes at a branch / block /
     /// safepoint boundary. **Now a no-op**: GP-pool residence (`LinkMode::G`)

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -957,6 +957,17 @@ impl SlotState {
         }
     }
 
+    /// The tagged `Value` of a fixnum compile-time-constant slot, if any — the
+    /// immediate to load straight into a register (`gp-local-alloc`), skipping
+    /// the stack-home materialization and the fixnum guard.
+    pub fn fixnum_literal_value(&self, slot: SlotId) -> Option<Value> {
+        if let LinkMode::C(v) = self.mode(slot) {
+            v.is_immediate()?.try_fixnum().map(|_| v)
+        } else {
+            None
+        }
+    }
+
     pub fn is_flonum_literal(&self, slot: SlotId) -> Option<Flonum> {
         if let LinkMode::C(v) = self.mode(slot) {
             v.is_immediate()?.try_flonum()

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -252,7 +252,7 @@ pub(crate) struct SlotState {
     liveness: Vec<IsUsed>,
     /// fpr-register allocation state (item ②, step 1).
     fpr_alloc: FprAllocator,
-    /// Per-basic-block local GP register file (`gp-local-alloc`). Empty (and
+    /// Per-basic-block local GP register file (the local GP allocator). Empty (and
     /// flushed) at every block boundary, so it never carries state across a
     /// merge despite living in the cloned `SlotState`.
     pub(in crate::codegen::jitgen) gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile,
@@ -958,7 +958,7 @@ impl SlotState {
     }
 
     /// The tagged `Value` of a fixnum compile-time-constant slot, if any — the
-    /// immediate to load straight into a register (`gp-local-alloc`), skipping
+    /// immediate to load straight into a register (the local GP allocator), skipping
     /// the stack-home materialization and the fixnum guard.
     pub fn fixnum_literal_value(&self, slot: SlotId) -> Option<Value> {
         if let LinkMode::C(v) = self.mode(slot) {
@@ -1331,7 +1331,7 @@ impl AbstractFrame {
         // capturable, so no heap snapshot observes it pre-consume.
         let literal = self.wb_literal(|_| true);
         let void = self.wb_void();
-        // `gp-local-alloc`: spill dirty GP residents so the GC marks them (the
+        // spill dirty GP residents so the GC marks them (the
         // registers themselves survive the collection — `exec_gc` preserves the
         // caller-saved set). Empty without the feature.
         let gp = self.gp_regfile.dirty_residents();
@@ -1342,7 +1342,7 @@ impl AbstractFrame {
         let f = |_| true;
         let fpr = self.wb_fpr(f);
         let literal = self.wb_literal(f);
-        // `gp-local-alloc`: re-home dirty GP residents (a binop result still in a
+        // re-home dirty GP residents (a binop result still in a
         // register) so a deopt resuming in the VM reads them from their stack
         // home. Empty without the feature.
         let gp = self.gp_regfile.dirty_residents();

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -596,6 +596,10 @@ impl SlotState {
     /// Clear slot *reg* and set LinkMode to V.
     ///
     fn clear(&mut self, slot: SlotId) {
+        // Redefining a slot drops any GP resident caching its old value (mirrors
+        // `fpr_remove` for the fpr file). The binop that *creates* a resident
+        // rebinds it after this `clear`, so the cache stays correct.
+        self.gp_regfile.invalidate(slot);
         match self.mode(slot) {
             LinkMode::Sf(fpr, _) | LinkMode::F(fpr) => {
                 assert!(self.fpr(fpr).contains(&slot));
@@ -1300,6 +1304,13 @@ impl AbstractFrame {
     /// call (hence no flush) happens.
     pub(crate) fn get_using_fpr(&mut self, ir: &mut AsmIr) -> UsingFpr {
         self.flush_pool(ir);
+        // Single chokepoint for GP-clobbering calls: every C-ABI call (inline-asm
+        // generators, CFunc inlines, the cached method-call path) takes a
+        // `get_using_fpr` snapshot first, so flushing the local GP register file
+        // here re-homes the residents for all of them — the inline generators no
+        // longer each need their own flush, and register-only inlines (which make
+        // no call and never call this) keep their residents.
+        self.flush_gp(ir);
         self.using_fpr_offset()
     }
 

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1130,11 +1130,6 @@ impl SlotState {
         None
     }
 
-    /// Write the accumulator back before a call / safepoint. **Now a no-op**:
-    /// with the R15 accumulator retired and the GP pool abolished there is no
-    /// register-resident accumulator to spill. Retained as a boundary marker.
-    pub(crate) fn writeback_acc(&mut self, _ir: &mut AsmIr) {}
-
     fn is_fpr_vacant(&self, fpr: FPReg) -> bool {
         self.fpr(fpr).is_empty()
     }
@@ -1290,8 +1285,7 @@ impl AbstractFrame {
     /// kept resident there must not survive a C call. Every runtime helper that
     /// can clobber them is preceded by a `get_using_fpr` snapshot (here, or
     /// inside the `ir.<helper>(state, …)` builders), so flushing the GP pool at
-    /// this single chokepoint covers them all. Method calls already flush via
-    /// `writeback_acc`, so the flush here is a redundant no-op for them. Use
+    /// this single chokepoint covers them all. Use
     /// [`Self::using_fpr_offset`] where only the stack-offset is needed and no
     /// call (hence no flush) happens.
     pub(crate) fn get_using_fpr(&mut self, ir: &mut AsmIr) -> UsingFpr {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -908,6 +908,14 @@ impl SlotState {
     }
 
     pub(in crate::codegen::jitgen) fn write_back_slot(&mut self, ir: &mut AsmIr, slot: SlotId) {
+        // A GP resident keeps `LinkMode::S` while its live value sits in a
+        // (dirty) pool register; `write_back_slot_state` would then see `S` and
+        // emit nothing, leaving the stack home stale. Re-home the dirty register
+        // first and drop the resident, so the slot is genuinely in its stack home.
+        if let Some(reg) = self.gp_regfile.dirty_reg_of(slot) {
+            ir.reg2stack(reg, slot);
+        }
+        self.gp_regfile.invalidate(slot);
         let s = self.write_back_slot_state(slot);
         ir.transfer(TransferIR::Spill(s));
     }
@@ -939,6 +947,11 @@ impl SlotState {
 
     #[allow(non_snake_case)]
     pub(in crate::codegen::jitgen) fn to_S_unguarded(&mut self, ir: &mut AsmIr, slot: SlotId) {
+        // Same GP-resident caveat as `write_back_slot`: re-home the dirty pool
+        // register before `to_S_unguarded_state`'s `clear` drops it unspilled.
+        if let Some(reg) = self.gp_regfile.dirty_reg_of(slot) {
+            ir.reg2stack(reg, slot);
+        }
         let s = self.to_S_unguarded_state(slot);
         ir.transfer(TransferIR::Spill(s));
     }
@@ -1163,8 +1176,15 @@ impl SlotState {
                 self.set_Sf(dst, x, guarded);
             }
             LinkMode::S(guarded) => {
-                ir.stack2reg(src, GP::Rax);
-                ir.reg2stack(GP::Rax, dst);
+                // A live GP resident holds `src`'s value in a register; copy it
+                // from there rather than reading a stale stack home (mirrors
+                // `load`'s resident-aware `S` arm).
+                if let Some(reg) = self.gp_regfile.reg_of(src) {
+                    ir.reg2stack(reg, dst);
+                } else {
+                    ir.stack2reg(src, GP::Rax);
+                    ir.reg2stack(GP::Rax, dst);
+                }
                 self.def_S_guarded(dst, guarded);
             }
             LinkMode::C(v) => {

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -1,16 +1,6 @@
 use super::*;
 use crate::bytecodegen::{BinOpK, UnOpK, inst::*};
 
-/// Operand mode for an integer binop / comparison. **RR-only**: both operands
-/// are stack slots. An integer-literal operand is no longer folded into an
-/// immediate (the former `RI` / `IR` modes) — it is materialized in its slot
-/// and loaded like any other operand, which keeps the AsmIR/LIR layers free of
-/// per-operand immediate special-casing.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum OpMode {
-    RR(SlotId, SlotId),
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FOpClass {
     Float,

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -1,11 +1,14 @@
 use super::*;
 use crate::bytecodegen::{BinOpK, UnOpK, inst::*};
 
+/// Operand mode for an integer binop / comparison. **RR-only**: both operands
+/// are stack slots. An integer-literal operand is no longer folded into an
+/// immediate (the former `RI` / `IR` modes) — it is materialized in its slot
+/// and loaded like any other operand, which keeps the AsmIR/LIR layers free of
+/// per-operand immediate special-casing.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum OpMode {
     RR(SlotId, SlotId),
-    RI(SlotId, i16),
-    IR(i16, SlotId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/monoruby/tests/gp_float_reuse_repro.rs
+++ b/monoruby/tests/gp_float_reuse_repro.rs
@@ -1,0 +1,28 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// Regression for a JIT mixed Integer/Float bug (mspec SpinnerFormatter ETR
+// crash, `NilClass can't be coerced into Float`). A Float operand held only in
+// a GP resident register (a builtin call result) was promoted to `Sf` and read
+// straight from the register without flushing its boxed value to the stack
+// home; under fpr pressure the `Sf` cache could be demoted (`Sf -> S`, no spill
+// emitted) and the slot then reloaded a stale `nil`. Reproduces under
+// `--features stress-spill-pool` (CI runs that).
+#[test]
+fn gp_resident_float_reused_after_mixed_op() {
+    run_test(
+        r##"
+        class C
+          def initialize; @percent = 7; @start = Time.now; end
+          def f
+            elapsed = Time.now - @start
+            ((100 * elapsed / @percent) - elapsed).is_a?(Float)
+          end
+        end
+        c = C.new
+        r = nil
+        60.times { r = c.f }
+        r
+        "##,
+    );
+}


### PR DESCRIPTION
Builds a per-basic-block **local GP register allocator** on top of the slot-IR,
so integer/general `Value`s can stay resident in the caller-saved pool registers
(`r8`–`r11`) across instructions instead of round-tripping through their stack
home. Stacks on top of `gpalloc` (`#760`, abolish `LinkMode::G`).

### What it does
- Per-BB local GP allocator (pure allocator first, then wired in): `OpMode`
  collapsed to RR-only, `RI`/`IR` immediate modes dropped.
- GP-allocates the integer binops (`Add`/`Sub`, `Mul`/`Div`, `&`/`|`/`^`),
  integer compare + compare-branch, and the mixed Integer/Float ops (reading
  GP-resident operands directly).
- Fixnum-constant operands and call / yield / frozen-literal / ivar results land
  straight in a GP register (a *resident*).
- Residence is flushed at the single `get_using_fpr` call chokepoint rather than
  per dispatch; the per-arm head `flush_gp` is kept only where an arm clobbers
  the pool without reaching that chokepoint (or records branch/merge state).

### Resident-aware slot write-back (final commit)
A GP resident keeps `LinkMode::S` while its live value sits in a (dirty) pool
register. `load` consulted the register file, but the *write-back* side did not:
`write_back_slot` / `to_S_unguarded` saw `S` and emitted nothing (or `clear`'d
the resident unspilled), and `copy_slot`'s `S` arm read the stale stack home. A
dirty resident left live across a call whose lowering re-homes args/locals
through those ops (the block `locals_to_S`, the `ISeqHint::SelfReturn` fold's
`copy_slot`) was silently dropped — `string_scrub_block_form` / `hash_select` /
`hash_reject` JIT miscompiles (SIGABRT in the harness). Fixed by re-homing a live
resident in all three ops before reading/dropping it. With every read **and**
write-back resident-aware, the redundant head flushes on the arms that reach
`get_using_fpr` (and on `MethodCall` / `Yield` / `Index` / `IndexAssign` / `UnOp`
/ `InlineCache`) are dropped.

### Tests
`monoruby` lib suite: **1721 passed / 0 failed** (plain and `gc-stress`).
Resident-stress scenarios (arithmetic resident live across index / call / yield /
unop / ivar+Math / dynvar) match CRuby under `gc-stress`. x86-64 verified locally;
the slot ops are arch-neutral (`state/slot.rs`), so the fix applies to aarch64 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)