### PR TITLE
Fix String#each_line(chomp:) losing the keyword on the enumerator path (#742)

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -4518,7 +4518,17 @@ fn each_line(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr
         if let Some(rs) = lfp.try_arg(0) {
             args.push(rs);
         }
-        vm.generate_enumerator(IdentId::get_id("each_line"), receiver, args, pc)
+        // Forward the `chomp:` keyword so the enumerator path matches the
+        // block form; the bare positional `args` channel can't carry it
+        // (issue #742).
+        let kw_args = if let Some(chomp) = lfp.try_arg(1) {
+            let mut map = HashmapInner::default();
+            map.insert(Value::symbol(IdentId::get_id("chomp")), chomp, vm, globals)?;
+            Some(Value::hash_from_inner(map).as_hash())
+        } else {
+            None
+        };
+        vm.generate_enumerator_with_kw(IdentId::get_id("each_line"), receiver, args, kw_args, pc)
     }
 }
 
@@ -10392,6 +10402,15 @@ mod tests {
             r##""hello\nworld\n\n\nand\nuniverse\n\n\n\n\n".lines("")"##,
             // Block form returns self for each_line
             r##"a = []; "a\nb".each_line {|s| a << s }; a"##,
+            // Enumerator (no-block) path must preserve the `chomp:` keyword
+            // (issue #742): it was previously dropped, leaving trailing
+            // separators on each yielded line.
+            r##""foo\nbar\nbaz\n".each_line(chomp: true).to_a"##,
+            r##""foo\nbar\nbaz\n".each_line.to_a"##,
+            r##""a-b-c-".each_line("-", chomp: true).to_a"##,
+            r##""a-b-c-".each_line("-").to_a"##,
+            r##"e = "foo\nbar\n".each_line(chomp: true); [e.next, e.next]"##,
+            r##""hello \r\nworld\r\n".each_line(chomp: true).to_a"##,
         ]);
         run_test_error(r##""hello".lines(:sym)"##);
         run_test_error(r##""hello".lines(false)"##);

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2444,7 +2444,7 @@ impl Executor {
         args: Vec<Value>,
         pc: BytecodePtr,
     ) -> Result<Value> {
-        self.generate_enumerator_with_size(method, obj, args, pc, None)
+        self.generate_enumerator_inner(method, obj, args, None, pc, None)
     }
 
     pub(crate) fn generate_enumerator_with_size(
@@ -2455,9 +2455,36 @@ impl Executor {
         pc: BytecodePtr,
         size: Option<Value>,
     ) -> Result<Value> {
+        self.generate_enumerator_inner(method, obj, args, None, pc, size)
+    }
+
+    /// Like [`Self::generate_enumerator`], but also captures the keyword
+    /// arguments the source method received, so they are replayed when the
+    /// enumerator re-invokes the method (e.g. `String#each_line(chomp: true)`
+    /// called without a block). See issue #742.
+    pub(crate) fn generate_enumerator_with_kw(
+        &mut self,
+        method: IdentId,
+        obj: Value,
+        args: Vec<Value>,
+        kw_args: Option<Hashmap>,
+        pc: BytecodePtr,
+    ) -> Result<Value> {
+        self.generate_enumerator_inner(method, obj, args, kw_args, pc, None)
+    }
+
+    fn generate_enumerator_inner(
+        &mut self,
+        method: IdentId,
+        obj: Value,
+        args: Vec<Value>,
+        kw_args: Option<Hashmap>,
+        pc: BytecodePtr,
+        size: Option<Value>,
+    ) -> Result<Value> {
         let outer_lfp = Lfp::dummy_heap_frame_with_self(obj);
         let proc = Proc::from_outer(outer_lfp, ENUM_YIELDER_FUNCID, pc);
-        let e = Value::new_enumerator(obj, method, proc, args, size);
+        let e = Value::new_enumerator(obj, method, proc, args, kw_args, size);
         Ok(e)
     }
 }

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -390,13 +390,14 @@ pub(crate) fn enum_yielder(
     let receiver = e.obj;
     let method = e.method;
     let args = &*e.args;
+    let kw_args = e.kw_args;
     vm.invoke_method_inner(
         globals,
         method,
         receiver,
         args,
         Some(BlockHandler::from_current(YIELDER_FUNCID)),
-        None,
+        kw_args,
     )
 }
 

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1221,9 +1221,10 @@ impl Value {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        kw_args: Option<Hashmap>,
         size: Option<Value>,
     ) -> Self {
-        RValue::new_enumerator(obj, method, proc, args, size).pack()
+        RValue::new_enumerator(obj, method, proc, args, kw_args, size).pack()
     }
 
     pub(crate) fn new_generator(proc: Proc) -> Self {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -412,11 +412,12 @@ impl ObjKind {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        kw_args: Option<Hashmap>,
         size: Option<Value>,
     ) -> Self {
         Self {
             enumerator: ManuallyDrop::new(Box::new(EnumeratorInner::new(
-                obj, method, proc, args, size,
+                obj, method, proc, args, kw_args, size,
             ))),
         }
     }
@@ -1905,11 +1906,12 @@ impl RValue {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        kw_args: Option<Hashmap>,
         size: Option<Value>,
     ) -> Self {
         RValue {
             header: Header::new(ENUMERATOR_CLASS, ObjTy::ENUMERATOR),
-            kind: ObjKind::enumerator(obj, method, proc, args, size),
+            kind: ObjKind::enumerator(obj, method, proc, args, kw_args, size),
             var_table: None,
         }
     }

--- a/monoruby/src/value/rvalue/enumerator.rs
+++ b/monoruby/src/value/rvalue/enumerator.rs
@@ -10,6 +10,11 @@ pub struct EnumeratorInner {
     internal: Option<Fiber>,
     pub proc: Proc,
     pub args: Box<Vec<Value>>,
+    /// Keyword arguments captured at enumerator-creation time, replayed
+    /// when the enumerator re-invokes `method` (e.g. `chomp:` for
+    /// `String#each_line`). `None` when the source method took no
+    /// keywords. See issue #742.
+    pub kw_args: Option<Hashmap>,
     buffer: Option<Array>,
     /// Optional size associated with the Enumerator:
     ///   - `None`                → unknown / fall back to method-name dispatch
@@ -26,6 +31,9 @@ impl alloc::GC<RValue> for EnumeratorInner {
         }
         self.proc.mark(alloc);
         self.args.iter().for_each(|v| v.mark(alloc));
+        if let Some(kw) = self.kw_args {
+            kw.mark(alloc);
+        }
         if let Some(buf) = self.buffer {
             buf.mark(alloc)
         }
@@ -41,6 +49,7 @@ impl EnumeratorInner {
         method: IdentId,
         proc: Proc,
         args: Vec<Value>,
+        kw_args: Option<Hashmap>,
         size: Option<Value>,
     ) -> Self {
         Self {
@@ -49,6 +58,7 @@ impl EnumeratorInner {
             internal: None,
             proc,
             args: Box::new(args),
+            kw_args,
             buffer: None,
             size,
         }


### PR DESCRIPTION
## Summary

Fixes #742. `String#each_line(chomp: true)` called **without a block** dropped the `chomp:` keyword. The returned `Enumerator`, when driven (`.to_a` / `.next` / `.each`), re-invoked `each_line` with only the positional record-separator argument, so `chomp:` defaulted to `false` and each yielded line kept its trailing separator. The block form was already correct.

```ruby
"foo\nbar\nbaz\n".each_line(chomp: true).to_a
# before: ["foo\n", "bar\n", "baz\n"]
# after : ["foo", "bar", "baz"]   (matches CRuby 4.0)
```

## Root cause

The enumerator carried only positional `args` — there was no channel for the keyword arguments the source method received. `enum_yielder` (the proc that re-invokes the method) called `invoke_method_inner` with the kw-arg slot hardcoded to `None`, even though that slot already accepts an `Option<Hashmap>`.

## Fix

Added the missing keyword channel generally, rather than special-casing `each_line`:

- `EnumeratorInner` gains a `kw_args: Option<Hashmap>` field (GC-marked), threaded through `ObjKind::enumerator` / `RValue::new_enumerator` / `Value::new_enumerator`.
- New `Executor::generate_enumerator_with_kw` captures the keywords. `generate_enumerator` / `generate_enumerator_with_size` keep their signatures and pass `None`, so all 30 existing call sites are untouched.
- `enum_yielder` replays `e.kw_args` instead of `None`.
- `each_line`'s no-block path builds a `{ chomp: <v> }` hash and forwards it.

This also lays the groundwork for any future enumerator-returning builtin that accepts keywords (the general gap the issue called out). Other current enumerator builtins — `gsub`/`gsub!`/`each_char`/… — take no keywords, so they are unaffected.

## Verification

- Direct run matches CRuby 4.0 across the enumerator path, the separator + `chomp:` combination, and the `.next` driver.
- Regression cases added to `string_lines_each_line`.
- String suite passes (175 tests, 0 failures); full debug build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_