### PR TITLE
tests: speed up the five slowest nextest tests (~13s → ~3s)

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -4543,7 +4543,7 @@ mod tests {
 
     #[test]
     fn kernel() {
-        run_test_no_result_check("sleep 1");
+        run_test_no_result_check("sleep 0.05");
         run_tests(&["system 'ls'", "system 'ls', '-a'"]);
         run_test_error("abort 1");
         run_test_no_result_check("exit");

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -1105,7 +1105,12 @@ fn defined() {
             end
         "#,
     );
-    // Pure expressions — batch together
+    // Batched together. Each entry that originally ran in its own process
+    // (fresh global state) is given a unique name here, so they share one
+    // CRuby spawn without contaminating one another's `defined?` result.
+    // `defined?` does not evaluate its operand, so the `def`/`class`/
+    // backtick entries create nothing; the `class …; X.new.f` entries do
+    // run, hence the unique class names.
     run_tests(&[
         r#"defined? 10"#,
         r#"defined? 100000000000000000000000000000000000000000000000000000000"#,
@@ -1117,26 +1122,42 @@ fn defined() {
         r#"defined? a=z"#, r#"defined? a+=z"#,
         r#"defined? puts"#,
         r#"defined?(1+(2+3))"#, r#"defined? 1+(2+3)"#,
+        // definitions / commands (defined? does not evaluate them)
+        r#"defined? (def defmeth1;end)"#,
+        r#"defined? (def self.defmeth2;end)"#,
+        r#"defined? (class DefinedClsA;end)"#,
+        r#"defined? (class << obj F;end)"#,
+        r#"defined? `ls -a`"#,
+        // local variables
+        r#"(lset=10; defined? lset)"#,
+        r#"defined? lundef"#,
+        r#"(lstr=""; defined? 1+lstr)"#,
+        r#"defined? lundef_idx[1]"#,
+        r#"defined? (lundef_asgn[1]=5)"#,
+        r#"(larr=[]; defined? larr[1])"#,
+        r#"(larr2=[]; defined? (larr2[1]=5))"#,
+        // instance variables
+        r#"defined? @iv_unset"#,
+        r#"(@iv_set=10; defined? @iv_set)"#,
+        // global variables
+        r#"defined? $gv_unset"#,
+        r#"($gv_set=10; defined? $gv_set)"#,
+        // constants
+        r#"(KonstSet=10; defined? KonstSet)"#,
+        r#"defined? KonstUnset"#,
+        // instance variables via methods (unique class names)
+        r#"(class DefA1; def initialize; @x=1; end; def f; defined?(@x); end; def g; defined?(@y); end; end; [DefA1.new.f, DefA1.new.g])"#,
+        r#"(class DefA2; def f; @v=10; [defined?(@v), defined?(@w)]; end; end; DefA2.new.f)"#,
+        // global variables (array form)
+        r#"($gx=1; [defined?($gx), defined?($gy)])"#,
+        // methods
+        r#"(class DefA3; def foo; end; def f; defined?(foo); end; def g; defined?(bar); end; end; [DefA3.new.f, DefA3.new.g])"#,
+        // class variables (unique class names)
+        r#"(class DefA4; @@x=1; def f; defined?(@@x); end; end; DefA4.new.f)"#,
+        r#"(class DefA5; def f; defined?(@@x); end; end; DefA5.new.f)"#,
+        r#"(class DefA6; @@v=10; def f; defined?(@@v); end; def g; defined?(@@w); end; end; [DefA6.new.f, DefA6.new.g])"#,
+        r#"(class DefB7; @@b=1; end; class DefC7 < DefB7; def f; defined?(@@b); end; end; DefC7.new.f)"#,
     ]);
-    // Expressions with side effects or definitions — must run individually
-    run_test(r#"defined? (def f;end)"#);
-    run_test(r#"defined? (def self.f;end)"#);
-    run_test(r#"defined? (class F;end)"#);
-    run_test(r#"defined? (class << obj F;end)"#);
-    run_test(r#"defined? a[1]"#);
-    run_test(r#"defined? (a[1]=5)"#);
-    run_test(r#"defined? `ls -a`"#);
-    run_test(r#"a=10; defined? a"#);
-    run_test(r#"defined? a"#);
-    run_test(r#"a=""; defined? 1+a"#);
-    run_test(r#"defined? @a"#);
-    run_test(r#"@a=10; defined? @a"#);
-    run_test(r#"defined? $a"#);
-    run_test(r#"$a=10; defined? $a"#);
-    run_test(r#"C=10; defined? C"#);
-    run_test(r#"defined? C"#);
-    run_test(r#"a = []; defined? a[1]"#);
-    run_test(r#"a = []; defined? (a[1]=5)"#);
     run_test_with_prelude(
         r#"
             [ C.new.f, S.new.f ]
@@ -1155,32 +1176,8 @@ fn defined() {
             end
     "#,
     );
-    // instance variables
-    run_test(
-        r#"
-        class A
-          def initialize; @x = 1; end
-          def f; defined?(@x); end
-          def g; defined?(@y); end
-        end
-        [A.new.f, A.new.g]
-    "#,
-    );
-    run_test(
-        r#"
-        class A
-          def f; @v = 10; [defined?(@v), defined?(@w)]; end
-        end
-        A.new.f
-    "#,
-    );
-    // global variables
-    run_test(
-        r#"
-        $gx = 1
-        [defined?($gx), defined?($gy)]
-    "#,
-    );
+    // (instance-variable, global-variable, and class-variable cases are
+    // batched into the single `run_tests` above.)
     // constants
     run_test_with_prelude(
         r#"
@@ -1203,17 +1200,6 @@ fn defined() {
         end
     "#,
     );
-    // methods
-    run_test(
-        r#"
-        class A
-          def foo; end
-          def f; defined?(foo); end
-          def g; defined?(bar); end
-        end
-        [A.new.f, A.new.g]
-    "#,
-    );
     run_tests(&[
         r#"defined? $stdout"#, r#"defined? $0"#, r#"defined? $LOAD_PATH"#,
         r#"defined? Integer"#, r#"defined? String"#, r#"defined? NoSuchConstant"#,
@@ -1221,45 +1207,6 @@ fn defined() {
         r#"defined? [].map"#, r#"defined? [].no_such_method"#,
         r#"defined? 1.to_s"#,
     ]);
-    // class variables
-    run_test(
-        r#"
-        class A
-          @@x = 1
-          def f; defined?(@@x); end
-        end
-        A.new.f
-    "#,
-    );
-    run_test(
-        r#"
-        class A
-          def f; defined?(@@x); end
-        end
-        A.new.f
-    "#,
-    );
-    run_test(
-        r#"
-        class A
-          @@v = 10
-          def f; defined?(@@v); end
-          def g; defined?(@@w); end
-        end
-        [A.new.f, A.new.g]
-    "#,
-    );
-    run_test(
-        r#"
-        class B
-          @@b = 1
-        end
-        class C < B
-          def f; defined?(@@b); end
-        end
-        C.new.f
-    "#,
-    );
 }
 
 #[test]

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -42,10 +42,10 @@ fn redefine_test3() {
     run_test_once(
         r##"
         a = 0
-        30.times do |x|
-          30.times do |y|
-            30.times do |z|
-              s = if x == 28 && y == 28 && z == 28
+        20.times do |x|
+          20.times do |y|
+            20.times do |z|
+              s = if x == 18 && y == 18 && z == 18
                 "def *(other); 42; end;"
               else
                 ""
@@ -67,10 +67,10 @@ fn redefine_test4() {
     run_test_once(
         r##"
         a = 0
-        for x in 0..30
-          for y in 0..30
-            for z in 0..30
-              s = if x == 28 && y == 28 && z == 28
+        for x in 0..20
+          for y in 0..20
+            for z in 0..20
+              s = if x == 18 && y == 18 && z == 18
                 "def *(other); 42; end;"
               else
                 ""


### PR DESCRIPTION
## Summary

`cargo nextest run` had five tests over ~2s. Each `run_test*` / `run_tests` call spawns one CRuby process (~65ms measured), so the main lever is folding per-process tests into a single batched spawn, plus trimming two non-spawn hotspots. No production code changes — test-only.

## Measured results (individual nextest runs)

| Test | Before | After | Speedup |
|------|--------|-------|---------|
| `arith::defined` | 2.33s | **0.48s** | 4.8× |
| `redefine_test4` | 5.05s | **0.76s** | 6.7× |
| `redefine_test3` | 0.69s | **0.31s** | 2.2× |
| `builtins::kernel::tests::kernel` | 2.02s | **~1.1s** | ~1.9× |
| **total** | ~13.1s | **~3.1s** | |

## Changes

- **`arith::defined`**: the ~25 individual `run_test` calls each ran in their own CRuby process purely to get a fresh global state. Re-create that freshness with unique identifiers / class names and fold them all into the existing `run_tests` batch (one spawn). `defined?` never evaluates its operand, so the `def`/`class`/backtick entries create nothing; the executing `class …; X.new.f` entries use distinct class names so they can't contaminate each other. Per-entry semantics are unchanged, hence identical CRuby results.

- **`redefine_test4`** (and its sibling **`redefine_test3`**): the redefine-during-JIT stress loop was a 30³ cube (the `for`-loop form runs ~7× slower than the `.times` form). Shrunk to 20³ with the redefine at 18 — still far above the test-mode loop-JIT threshold (15), and the redefine still fires inside the JIT-compiled region, so coverage is preserved.

- **`builtins::kernel::tests::kernel`**: `sleep 1` was a bare smoke test of `Kernel#sleep` (result unchecked); `sleep 0.05` exercises the same path without burning a real second.

## Not changed (analysis)

`binop_numeric` / `cmp_numeric` (~3.7s each) already batch into just 2 CRuby spawns via `run_binop_tests`; their cost is bignum/complex arithmetic × the 26× JIT-warmup loop — intentional JIT-path coverage that batching can't reduce and trimming would weaken. Left as-is.

## Verification

All affected tests pass; monoruby output still matches CRuby on every batched `defined?` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_