### PR TITLE
ci(darwin): cap the Test step at 25 min and auto-retry once

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,11 @@ jobs:
     # specific to native-M1 + coverage instrumentation and is tracked
     # separately. The Linux `amd64` job owns the Codecov upload.
     runs-on: macos-latest
+    # Backstop: if a hung attempt somehow escapes the per-attempt 25-min cap on
+    # the Test step below, GitHub cancels the job cleanly here (2 attempts ×
+    # 25 min + setup/clone overhead) rather than letting the runner die with
+    # "lost communication".
+    timeout-minutes: 70
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
@@ -123,5 +128,16 @@ jobs:
         run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
 
       - name: Test (VM + AArch64 JIT, arm64-apple-darwin)
-        run: bin/test
+        # The arm64 JIT/runtime intermittently hangs (a non-deterministic
+        # divergence, separate from the already-fixed optcarrot register-save
+        # bug). Left uncapped, the hang runs ~48 min until the macOS runner
+        # "loses communication" (the agent dies) and the run must be re-run by
+        # hand. A normal pass is ~11 min, so cap each attempt at 25 min and
+        # retry once: a hang is killed cleanly and fast, and the retry recovers
+        # the run automatically. Track/fix the underlying arm64 hang separately.
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 25
+          max_attempts: 2
+          command: bin/test
 


### PR DESCRIPTION
## Summary

The macOS (arm64) `darwin` job intermittently fails with **"The hosted runner lost communication with the server."** Investigation of the failing attempts shows the arm64 JIT/runtime **non-deterministically hangs** in `bin/test`, and with no time cap the hang runs **~48 min** until the runner agent dies — forcing a manual re-run.

### Evidence (from #764 / #765 merge runs on master)

| | Test step duration | Outcome |
|---|---|---|
| darwin attempt 1 | ~48–50 min (step never completes) | runner "lost communication" |
| darwin attempt 2 (re-run) | **~11 min** | ✅ success |
| amd64 | ~11 min | ✅ success |

A normal pass is ~11 min and a manual re-run almost always goes green, so the hang is transient and a single retry recovers it. (This is distinct from the already-fixed deterministic optcarrot register-save bug.)

## Change (darwin job only)

- Wrap the **Test** step in `nick-fields/retry@v3` with a **25-min per-attempt cap** and **`max_attempts: 2`**. A hung attempt is now killed cleanly and fast — well under the ~48-min runner-death point — and the retry recovers the run without manual intervention. 25 min is >2× the ~11-min normal pass, so legitimate runs aren't cut short.
- Add a job-level **`timeout-minutes: 70`** backstop (2 × 25 min + setup/clone) so the runner can never sit hung long enough to "lose communication" even if the per-attempt kill misbehaves.

`nick-fields/retry` is a new action dependency, consistent with the workflow's existing use of third-party actions (`actions/checkout`, `ruby/setup-ruby`, `dtolnay/rust-toolchain`, `codecov/codecov-action`, …).

## Scope / follow-up

This **bounds the blast radius** of the flaky hang (no more "lost communication", no manual re-runs); it does **not** fix the underlying arm64 hang, which is masked by the retry and tracked separately (reproducing it needs a native arm64 / qemu-aarch64 environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_