### PR TITLE
ci(darwin): instrument bin/test to localize + capture the flaky arm64 hang

### DIFF
--- a/.github/workflows/darwin-hang-debug.yml
+++ b/.github/workflows/darwin-hang-debug.yml
@@ -1,0 +1,83 @@
+name: darwin hang debug
+
+# Manual-only diagnostic for the intermittent arm64 `bin/test` hang that only
+# reproduces on the macOS GitHub-hosted runner (not on native Apple Silicon).
+# It loops `bin/test` with CI_HANG_DEBUG=1 until an iteration hangs: a per-run
+# watchdog then `sample`s and `lldb`-backtraces the stuck `monoruby` process
+# (printing where it is spinning — JIT region / GC / VM / I/O) and kills it, so
+# the failing run ends with the stack as its last output. Not wired to push/PR,
+# so it never runs automatically and burns no macOS minutes unless dispatched.
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Max bin/test iterations before giving up"
+        default: "5"
+      hang_deadline:
+        description: "Per-iteration hang watchdog deadline (seconds; normal run ~11 min)"
+        default: "1200"
+
+jobs:
+  darwin-hang-debug:
+    runs-on: macos-latest
+    timeout-minutes: 180
+    env:
+      CARGO_TERM_COLOR: always
+      SKIP_COV: "1"
+      CI_HANG_DEBUG: "1"
+      HANG_DEADLINE: ${{ github.event.inputs.hang_deadline }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.1"
+      - name: Install bigdecimal (no longer a default gem since Ruby 3.4)
+        run: gem install bigdecimal --no-document
+      - name: Install ruby-bench gem dependencies
+        run: gem install erubi --no-document
+      - name: Install libffi + pkg-config
+        run: |
+          brew install libffi pkg-config
+          echo "PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig" >> "$GITHUB_ENV"
+      # Allow `lldb` to attach to our own processes non-interactively (the
+      # watchdog's `sample` works without this; this just makes the lldb
+      # backtrace best-effort succeed too).
+      - name: Enable developer mode for lldb attach
+        run: sudo DevToolsSecurity -enable || true
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+      - uses: taiki-e/install-action@nextest
+      - name: Clone optcarrot
+        run: git clone https://github.com/mame/optcarrot.git ../optcarrot
+      - name: Clone ruby/spec and mspec (pinned)
+        env:
+          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
+        run: |
+          git init ../spec
+          git -C ../spec fetch --depth 1 https://github.com/ruby/spec.git "$SPEC_REV"
+          git -C ../spec checkout FETCH_HEAD
+          git init ../mspec
+          git -C ../mspec fetch --depth 1 https://github.com/ruby/mspec.git "$MSPEC_REV"
+          git -C ../mspec checkout FETCH_HEAD
+      - name: Clone ruby-bench
+        run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
+      # Compile up front so each looped bin/test iteration is run-only — the
+      # per-iteration hang watchdog then measures execution time, not build time.
+      - name: Pre-build test + benchmark binaries
+        run: |
+          cargo nextest run --no-run --features stress-spill-pool,gc-stress
+          cargo build --bin monoruby --features stress-spill-pool,gc-stress
+      - name: Loop bin/test until a hang is caught
+        run: |
+          n="${{ github.event.inputs.iterations }}"
+          for i in $(seq 1 "$n"); do
+            echo "==================== iteration $i / $n ===================="
+            if ! bin/test; then
+              echo "iteration $i hung or failed — see the watchdog stack dump above"
+              exit 1
+            fi
+          done
+          echo "no hang reproduced in $n iterations"

--- a/bin/test
+++ b/bin/test
@@ -42,12 +42,54 @@ else
   MONORUBY="$PWD/target/llvm-cov-target/debug/monoruby"
 fi
 
+# --- Hang diagnostics (CI flaky-hang investigation) ------------------------
+# `phase` prints a flushed, timestamped marker so a truncated or timed-out CI
+# log shows the last phase reached (this works in the normal job too: when the
+# `darwin` retry wrapper kills a hung attempt at its 25-min cap, the last
+# `[phase ...]` line names the culprit). Under CI_HANG_DEBUG=1 a background
+# watchdog additionally samples the native + Ruby stacks of any stuck
+# `monoruby` process after HANG_DEADLINE seconds (a normal run is ~11 min),
+# then kills it so the step ends with the diagnostics as its final output.
+# Driven in a loop by .github/workflows/darwin-hang-debug.yml.
+phase() {
+  printf '[phase %s] %s\n' "$(date -u +%H:%M:%S)" "$1"
+  [ -n "${CI_HANG_DEBUG:-}" ] && printf '%s' "$1" > "$PHASE_FILE" 2>/dev/null
+  return 0
+}
+
+if [ -n "${CI_HANG_DEBUG:-}" ]; then
+  PHASE_FILE="$(mktemp 2>/dev/null || echo "/tmp/monoruby_phase.$$")"
+  HANG_DEADLINE="${HANG_DEADLINE:-1200}" # 20 min; a normal run is ~11 min
+  (
+    sleep "$HANG_DEADLINE"
+    echo "==================== HANG WATCHDOG (${HANG_DEADLINE}s) ===================="
+    echo "stuck in phase: $(cat "$PHASE_FILE" 2>/dev/null)"
+    echo "---- processes ----"
+    ps -Ao pid,ppid,etime,%cpu,rss,command | grep -Ei 'monoruby|optcarrot|nextest|[c]argo' | grep -v grep || true
+    for pid in $(pgrep -f 'monoruby' 2>/dev/null); do
+      echo "---- sample $pid (5s) ----"
+      /usr/bin/sample "$pid" 5 2>&1 | sed -n '1,150p' || true
+      echo "---- lldb backtrace $pid ----"
+      lldb --batch -p "$pid" -o 'thread backtrace all' -o detach -o quit 2>&1 | sed -n '1,200p' || true
+    done
+    echo "==================== killing stuck monoruby ===================="
+    pkill -9 -f 'monoruby' 2>/dev/null || true
+    echo "==================== watchdog done ===================="
+  ) &
+  WATCHDOG_PID=$!
+  trap 'kill "$WATCHDOG_PID" 2>/dev/null || true; rm -f "$PHASE_FILE" 2>/dev/null || true' EXIT
+fi
+# ---------------------------------------------------------------------------
+
+phase "nextest (unit + integration tests)"
 cov_clean
 cov_nextest "${STRESS_FEATURES[@]}"
 
 # Rebuild the benchmark binary with the stress features (x86-64 only).
+phase "build benchmark binary"
 cov_build "${STRESS_FEATURES[@]}"
 
+phase "benchmarks: app_fib / tarai / so_nbody"
 $MONORUBY benchmark/app_fib.rb > monoruby.log 2> /dev/null
 "${RUBY[@]}" benchmark/app_fib.rb > ruby.log
 diff -s monoruby.log ruby.log
@@ -62,6 +104,7 @@ diff -s monoruby.log ruby.log
 #"${RUBY[@]}" benchmark/bf.rb > ruby.log
 #diff -s monoruby.log ruby.log
 
+phase "benchmarks: plb2 nqueen / sudoku"
 echo "checking plb2.."
 $MONORUBY benchmark/plb2/nqueen.rb > monoruby.log
 "${RUBY[@]}" benchmark/plb2/nqueen.rb > ruby.log
@@ -76,6 +119,7 @@ diff -s monoruby.log ruby.log
 #"${RUBY[@]}" benchmark/plb2/bedcov.rb > ruby.log
 #diff -s monoruby.log ruby.log
 
+phase "benchmark: so_mandelbrot"
 $MONORUBY benchmark/so_mandelbrot.rb > benchmark/mandel1.ppm
 $MONORUBY --no-jit benchmark/so_mandelbrot.rb > benchmark/mandel2.ppm
 "${RUBY[@]}" benchmark/so_mandelbrot.rb > benchmark/mandel.ppm
@@ -83,10 +127,12 @@ diff -s benchmark/mandel.ppm benchmark/mandel1.ppm
 diff -s benchmark/mandel.ppm benchmark/mandel2.ppm
 rm benchmark/*.ppm
 
+phase "optcarrot (plain) — monoruby"
 $MONORUBY ../optcarrot/bin/optcarrot -b --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
 "${RUBY[@]}" ../optcarrot/bin/optcarrot -b --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
 diff -s monoruby.log ruby.log
 
+phase "optcarrot (--opt) — monoruby"
 $MONORUBY ../optcarrot/bin/optcarrot -b --opt --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
 "${RUBY[@]}" ../optcarrot/bin/optcarrot -b --opt --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
 diff -s monoruby.log ruby.log
@@ -96,6 +142,7 @@ rm *.log
 # present alongside this repo. Reuses the already-built instrumented
 # monoruby and the `ruby` from PATH; exits non-zero on output mismatch.
 if [ -d "../ruby-bench/benchmarks" ]; then
+  phase "ruby-bench output diff"
   echo "Running ruby-bench output diff..."
   MONORUBY="$MONORUBY" CRUBY=ruby bin/ruby-bench-diff
 fi
@@ -105,6 +152,7 @@ if [ -d "../spec" ] && [ -d "../mspec" ]; then
   echo "Running ruby/spec for coverage..."
   cd ../spec
   for cat in basicobject true false nil integer float comparable math builtin_constants class numeric rational struct symbol range set systemexit method unboundmethod; do
+    phase "ruby/spec core/$cat"
     echo "=== core/$cat ==="
     ../mspec/bin/mspec core/$cat -t "$MONORUBY"
   done


### PR DESCRIPTION
## Summary

Follow-up to the darwin retry/timeout mitigation (#766). That bounded the blast radius of the intermittent arm64 `bin/test` hang; this adds the diagnostics needed to actually **find** it. The hang reproduces only on the macOS GitHub-hosted runner (never on native Apple Silicon), pointing at a CI-environment constraint (a resource-constrained M1 VM: low RAM, few cores → different GC/JIT timing under `gc-stress` + parallel `nextest`).

## What this adds

**`bin/test` — phase markers (always on, Step 0)**
A `phase` helper prints a flushed, timestamped `[phase HH:MM:SS] …` marker before each phase (nextest, each benchmark group, optcarrot ×2, ruby-bench, each ruby/spec category). Zero behavioral cost, and it pays off even in the normal `darwin` job: when the retry wrapper kills a hung attempt at its 25-min cap, the **last `[phase …]` line names the command that hung**.

**`bin/test` — stack capture on hang (`CI_HANG_DEBUG=1`, Step 1)**
A background watchdog fires after `HANG_DEADLINE` seconds (default 1200; a normal run is ~11 min), dumps the process table, then `sample`s and `lldb`-backtraces every stuck `monoruby` process before killing it — so a caught hang ends the run with its **native + Ruby spinning stack** as the final output (JIT region / GC / VM / I/O). Off by default, so the normal job is unaffected.

**New workflow `darwin-hang-debug.yml` (manual `workflow_dispatch` only)**
Loops `bin/test` with `CI_HANG_DEBUG=1` (pre-building so each iteration is run-only) until an iteration hangs or `iterations` pass cleanly. Inputs: `iterations` (default 5) and `hang_deadline`. Not wired to push/PR, so it costs no macOS minutes unless dispatched. At the observed ~50% per-run hang rate, 5 iterations catches one ~97% of the time.

## How it's used

After merge: Actions → **"darwin hang debug"** → **Run workflow**. The captured `sample`/`lldb` stack shows where it spins, which then drives Step 2 (toggle `gc-stress` / `stress-spill-pool` / `--no-jit` / `nextest -j1` to isolate the subsystem) and a constrained local repro (limited RAM + cores).

## Safety / scope

Diagnostics only — no production code changes. The phase markers are pure `echo`s; the watchdog and the debug workflow are gated/manual and cannot run on a normal push or PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF87ULUvuPqofXDRcBTcYy)_