### PR TITLE
require: resolve `bundler` to the host copy, not the vendored snapshot

### DIFF
--- a/monoruby/src/globals/require.rs
+++ b/monoruby/src/globals/require.rs
@@ -140,6 +140,41 @@ impl Globals {
             }
         }
 
+        // `bundler` (and everything under `bundler/`) must resolve to the
+        // *host* copy whenever one is installed, never the vendored snapshot
+        // in `~/.monoruby/lib`. The vendored bundler is only a no-host
+        // fallback; its version rarely matches an installed host gemspec, so
+        // once it loads, `Bundler.setup`'s
+        // `Gem.bin_path("bundler", "bundle", Bundler::VERSION)` raises
+        // `GemNotFoundException`. Normally host gem *activation* unshifts the
+        // host bundler ahead of the vendored dir, but rubygems' require
+        // fast-path skips activation when there are no unresolved deps — e.g.
+        // yjit-bench's `--harness=harness-warmup` does `require "benchmark"`
+        // before `require "bundler"`, emptying unresolved deps — and the
+        // vendored copy, first on `$LOAD_PATH`, then wins. Pin host
+        // precedence here so the outcome no longer depends on activation
+        // order. When the host has no bundler the normal loop below still
+        // falls back to the vendored copy.
+        let is_bundler = {
+            let s = file_name.to_string_lossy();
+            s == "bundler" || s.starts_with("bundler/")
+        };
+        if is_bundler {
+            let vendored_lib = install_root().join("lib");
+            for lib in self.load_path.as_array().iter() {
+                let Some(lib) = lib.is_str() else {
+                    continue;
+                };
+                let path = std::path::Path::new(lib);
+                if path.starts_with(&vendored_lib) {
+                    continue;
+                }
+                if let Some(p) = probe(path, file_name) {
+                    return Some(p);
+                }
+            }
+        }
+
         for lib in self.load_path.as_array().iter() {
             let lib = match lib.is_str() {
                 Some(s) => s,

--- a/monoruby/tests/require.rs
+++ b/monoruby/tests/require.rs
@@ -11,6 +11,18 @@ fn require() {
     );
 }
 
+// `require "bundler"` must resolve to the host bundler, not the vendored
+// snapshot in `~/.monoruby/lib`. This exercises the host-precedence branch
+// in `Globals::search_lib` (the vendored entries are skipped, then the host
+// bundler is found further down `$LOAD_PATH`). The result is intentionally
+// monoruby-specific — the host bundler version differs per machine — so we
+// only assert that the require succeeds, with no CRuby diff. Requires a host
+// Ruby with bundler installed (always true in CI / dev).
+#[test]
+fn require_bundler_resolves_host_copy() {
+    run_test_no_result_check(r#"require "bundler""#);
+}
+
 #[test]
 fn require_relative() {
     run_test(


### PR DESCRIPTION
## Problem

The yjit-bench bundler-based benchmarks (addressable-\*, erubi, …) fail under monoruby with:

```
rubygems.rb:263:in 'Gem.find_spec_for_exe':
  can't find gem bundler (= 4.0.3) with executable bundle (GemNotFoundException)
  ← Gem.bin_path ← SharedHelpers#bundle_bin_path ← set_bundle_variables
  ← set_bundle_environment ← Runtime#setup ← Bundler.setup ← use_gemfile
```

### Root cause

CI runs yjit-bench with `--harness=harness-warmup`, whose benchmarks do
`require "benchmark"` before `require "bundler"`. That empties rubygems'
unresolved-deps, so the `require "bundler"` takes the require **fast-path that
skips gem activation**. Because the vendored stdlib snapshot (`~/.monoruby/lib`)
is first on `$LOAD_PATH`, the **vendored** bundler then loads instead of the
host one. Its version rarely matches an installed host gemspec, so
`Bundler.setup → set_bundle_environment → Gem.bin_path("bundler", "bundle",
Bundler::VERSION)` raises `GemNotFoundException`, killing the benchmark before
it runs.

The vendored bundler is only meant as a no-host fallback; the existing design
relies on host gem *activation* unshifting the host bundler ahead of the
vendored dir, but the fast-path defeats that. (Re-vendoring the snapshot to
match the host bundler version — #767 — does not fix it: it depends on the
vendored version exactly matching an installable host gemspec, which is brittle
and still mismatches.)

## Fix

In `Globals::search_lib`, for `bundler` and everything under `bundler/`, search
the **non-vendored** `$LOAD_PATH` entries first, falling back to the vendored
copy (via the normal loop) only when the host has no bundler. This pins host
precedence regardless of activation order, so `Bundler::VERSION` always matches
the activatable host gemspec and `Gem.bin_path` succeeds.

## Verification

With host Ruby 4.0.2, `--harness=harness-warmup`:

| Check | Result |
| --- | --- |
| addressable-new / addressable-parse / erubi | pass (were `GemNotFoundException` before) |
| `require` integration test | 15/15 pass |
| integration-test slice (set, comparable, method_call, bigdecimal, …) | green, no regressions |
| no-host fallback | preserved (host without bundler still falls through to the vendored copy) |

`rubyboy` still fails, but only because its Gemfile pulls a `git`-sourced gem
that the sandbox's scoped git proxy blocks — unrelated to monoruby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01458Fz93xy4Aa2A3vAe6VSg

---
_Generated by [Claude Code](https://claude.ai/code/session_01458Fz93xy4Aa2A3vAe6VSg)_