### PR TITLE
startup.rb: derive a local RbConfig prefix when no host CRuby is configured

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -47,6 +47,28 @@ end
 # and stashes the result in two env vars; we just read and apply.
 host_rubylibprefix = ENV['MONORUBY_HOST_RUBYLIBPREFIX']
 ruby_api_version   = ENV['MONORUBY_HOST_RUBY_API_VERSION']
+host_configured = host_rubylibprefix && !host_rubylibprefix.empty? &&
+                  ruby_api_version && !ruby_api_version.empty?
+
+# Without a configured host CRuby (no GEM_PATH at startup, or a consumer
+# such as `Bundler.setup` cleared it), the vendored rbconfig.rb's
+# `rubylibprefix` still points at the *build* host's prefix (e.g.
+# `/opt/rbenv/versions/ruby-4.0.2-custom/lib/ruby`), which exists on no
+# other machine. `Gem.default_dir` (== `<rubylibprefix>/gems/<ruby_version>`)
+# would then be that bogus path and `Gem::Specification` enumeration would
+# silently come up empty. Fall back to a prefix derived from monoruby's own
+# install root — this file lives at `<root>/builtins/startup.rb` — so the
+# value is at least a real, local path rather than a snapshot-build-machine
+# one. (No gems live there in the no-host case, which is fine: enumeration
+# is legitimately empty instead of pointed at a nonexistent directory.)
+unless host_configured
+  install_root = (File.dirname(File.dirname(File.realpath(__FILE__))) rescue nil)
+  if install_root && !install_root.empty?
+    host_rubylibprefix = "#{install_root}/lib/ruby"
+    ruby_api_version   = RbConfig::CONFIG['ruby_version']
+  end
+end
+
 if host_rubylibprefix && !host_rubylibprefix.empty? && ruby_api_version && !ruby_api_version.empty?
   RbConfig::CONFIG['rubylibprefix']  = host_rubylibprefix
   RbConfig::CONFIG['rubylibdir']     = "#{host_rubylibprefix}/#{ruby_api_version}"
@@ -63,8 +85,9 @@ if host_rubylibprefix && !host_rubylibprefix.empty? && ruby_api_version && !ruby
   # When we are resolving against a host CRuby's gems, report "yes" so the
   # api version matches and those gems resolve. monoruby still can't run
   # their native .so, but require.rs pins its own pure-Ruby stubs ahead of
-  # $LOAD_PATH for the libraries it replaces, so they load the stub.
-  RbConfig::CONFIG['ENABLE_SHARED']  = 'yes'
+  # $LOAD_PATH for the libraries it replaces, so they load the stub. Only
+  # meaningful for the host case; leave the vendored value otherwise.
+  RbConfig::CONFIG['ENABLE_SHARED']  = 'yes' if host_configured
 end
 
 # The vendored rbconfig.rb hard-codes `target_os` / `target_cpu` to

--- a/monoruby/tests/rbconfig.rs
+++ b/monoruby/tests/rbconfig.rs
@@ -1,0 +1,27 @@
+extern crate monoruby;
+
+// #772: with no host CRuby configured, RbConfig's prefix must fall back to
+// monoruby's own install root, not the vendored snapshot's baked
+// build-machine prefix (`/opt/rbenv/versions/ruby-X.Y.Z-custom`, which exists
+// on no other machine and made `Gem.default_dir` resolve to a bogus path so
+// `Gem::Specification` enumeration silently came up empty).
+//
+// Forcing an empty `MONORUBY_GEM_PATH` makes monoruby take the no-host path
+// regardless of whether a host Ruby happens to be on `PATH`, so this is
+// reproducible in CI (where a host Ruby is installed).
+#[test]
+fn rbconfig_prefix_falls_back_to_install_root() {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env("MONORUBY_GEM_PATH", "")
+        .arg("-e")
+        .arg(r#"print RbConfig::CONFIG["rubylibprefix"]"#)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let prefix = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        prefix.contains("/.monoruby/"),
+        "rubylibprefix should be under monoruby's install root when no host \
+         Ruby is configured, got: {prefix:?}"
+    );
+}


### PR DESCRIPTION
Fixes #772.

## Problem

The vendored `rbconfig.rb`'s `TOPDIR` detection
(`File.dirname(__FILE__).chomp!("/lib/ruby/4.0.0/x86_64-linux")`) assumes
CRuby's install layout. monoruby installs `rbconfig.rb` at
`<install_root>/lib/rbconfig.rb`, so the `chomp!` returns `nil`, `TOPDIR` is
`nil`, and `CONFIG["prefix"]` / `rubylibprefix` fall back to the build host's
baked prefix (`/opt/rbenv/versions/ruby-4.0.2-custom`), which exists on no
other machine. `Gem.default_dir` (== `<rubylibprefix>/gems/<ruby_version>`)
is then a bogus path and `Gem::Specification` enumeration silently comes up
empty whenever `GEM_PATH` is unset (no host Ruby, or a consumer such as
`Bundler.setup` clearing it).

## Fix

`startup.rb` already overrode `rubylibprefix` from the GEM_PATH-derived host
env vars, but only when a host CRuby was configured. Extend it: when no host
is configured, fall back to a prefix derived from monoruby's own install root
(this file lives at `<root>/builtins/startup.rb`), so the value is a real,
local path instead of a snapshot-build-machine one. No gems live there in the
no-host case, which is correct — enumeration is legitimately empty rather than
pointed at a nonexistent directory.

The host case is unchanged; `ENABLE_SHARED="yes"` (which exists to match a
host's gem-extension layout) is now only applied in the host case.

## Verification

| scenario | `RbConfig::CONFIG["rubylibprefix"]` |
| --- | --- |
| no host (before) | `/opt/rbenv/versions/ruby-4.0.2-custom/lib/ruby` ❌ |
| no host (after) | `~/.monoruby/v0.3.0/lib/ruby` ✅ |
| host present | `<host-prefix>/lib/ruby` (unchanged) ✅ |

Added a subprocess test (`tests/rbconfig.rs`) that forces the no-host path via
an empty `MONORUBY_GEM_PATH` (reproducible in CI, where a host Ruby is
installed) and asserts the prefix is under monoruby's install root. The
`require` and `bigdecimal` integration tests (which exercise the host
RbConfig path) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01458Fz93xy4Aa2A3vAe6VSg

---
_Generated by [Claude Code](https://claude.ai/code/session_01458Fz93xy4Aa2A3vAe6VSg)_