### PR TITLE
JIT: inline small array-literal allocation from the GC free list

### DIFF
--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -547,6 +547,36 @@ impl<T: GCBox> Allocator<T> {
     }
 
     ///
+    /// Address of the free-list head (`self.free`), exposed so the JIT can
+    /// inline the free-list allocation fast path (pop a recycled cell)
+    /// without a runtime call. `self.free` is `Option<NonNull<T>>`, which is
+    /// pointer-sized with a null niche, so reading/writing it as `*mut usize`
+    /// is sound (`0` == `None`). The allocator is a single-threaded
+    /// thread-local whose address is stable for the process lifetime, and JIT
+    /// code only touches it between safepoints (never while Rust holds a
+    /// borrow of `ALLOC`, and never during `gc()`), so there is no aliasing.
+    ///
+    pub(crate) fn free_list_head_addr(&self) -> *mut usize {
+        &self.free as *const _ as *mut usize
+    }
+
+    ///
+    /// Address of `self.free_list_count`, kept in sync by the inline fast
+    /// path so the gc-log/gc-debug bookkeeping stays correct.
+    ///
+    pub(crate) fn free_list_count_addr(&self) -> *mut usize {
+        &self.free_list_count as *const _ as *mut usize
+    }
+
+    ///
+    /// Address of `self.total_allocated_objects`, bumped by the inline fast
+    /// path so allocation stats match the runtime path.
+    ///
+    pub(crate) fn total_allocated_addr(&self) -> *mut usize {
+        &self.total_allocated_objects as *const _ as *mut usize
+    }
+
+    ///
     /// Set allocation flag.
     ///
     fn set_alloc_flag(&self) {

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -602,6 +602,15 @@ pub struct Codegen {
     class_version_addr: *mut u32,
     const_version_addr: *mut u64,
 
+    /// Addresses of the GC allocator's free-list state, captured once at
+    /// `Codegen::new` (the allocator is a stable single-threaded
+    /// thread-local). Baked into JIT code so small array literals can be
+    /// allocated inline from the free list without a runtime call. See
+    /// `Allocator::free_list_head_addr`.
+    alloc_free_head_addr: *mut usize,
+    alloc_free_count_addr: *mut usize,
+    alloc_total_addr: *mut usize,
+
     compilation_unit: Vec<CompilationUnitInfo>,
 
     /// return_addr => (patch_point, deopt)
@@ -926,6 +935,9 @@ impl Codegen {
             signal_stubs: HashMap::default(),
             class_version_addr,
             const_version_addr,
+            alloc_free_head_addr: std::ptr::null_mut(),
+            alloc_free_count_addr: std::ptr::null_mut(),
+            alloc_total_addr: std::ptr::null_mut(),
             compilation_unit: Vec::new(),
             return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
@@ -983,7 +995,14 @@ impl Codegen {
 
         let address = codegen.jit.get_label_address(&codegen.alloc_flag).as_ptr() as *mut u32;
         alloc::ALLOC.with(|alloc| {
-            alloc.borrow_mut().set_alloc_flag_address(address);
+            let mut alloc = alloc.borrow_mut();
+            alloc.set_alloc_flag_address(address);
+            // Capture the allocator's free-list state addresses for the JIT
+            // inline-allocation fast path (stable thread-local; see the
+            // Codegen field docs).
+            codegen.alloc_free_head_addr = alloc.free_list_head_addr();
+            codegen.alloc_free_count_addr = alloc.free_list_count_addr();
+            codegen.alloc_total_addr = alloc.total_allocated_addr();
         });
 
         codegen

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -2363,8 +2363,22 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_new_array(
         &mut self,
         callid: CallSiteId,
+        inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     ) -> bool {
+        match inline {
+            // Inline the common case (small no-splat literal) when the
+            // allocator free-list addresses were captured at startup.
+            Some((args, len)) if !self.alloc_free_head_addr.is_null() => {
+                self.new_array_inline(callid, args, len, using_fpr);
+            }
+            _ => self.new_array_runtime(callid, using_fpr),
+        }
+        true
+    }
+
+    /// rax(x0) <- Array literal (splat-aware) via the runtime call site.
+    fn new_array_runtime(&mut self, callid: CallSiteId, using_fpr: UsingFpr) {
         let lfp = GP::R14.a64().0;
         let f = runtime::gen_array as *const () as u64;
         self.emit_fpr_save(using_fpr, false);
@@ -2379,7 +2393,62 @@ impl Codegen {
             ldr x30, [sp], #16;
         );
         self.emit_fpr_restore(using_fpr, false);
-        true
+    }
+
+    /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
+    /// literal: pop a recycled cell from the GC free list and initialise it
+    /// directly as an inline-storage Array, falling back to the runtime
+    /// `gen_array` when the free list is empty. See the x86_64
+    /// `new_array_inline` for the correctness argument (young object needs no
+    /// write barrier; no GC safepoint mid-build).
+    fn new_array_inline(
+        &mut self,
+        callid: CallSiteId,
+        args: SlotId,
+        len: u16,
+        using_fpr: UsingFpr,
+    ) {
+        let rax = GP::Rax.a64().0; // x0 (result)
+        let lfp = GP::R14.a64().0; // x22
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        let free_head = self.alloc_free_head_addr as u64;
+        let free_count = self.alloc_free_count_addr as u64;
+        let total = self.alloc_total_addr as u64;
+        // 8-byte object header: flag=1 | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
+        let header: u64 =
+            ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (free_head);
+            ldr x(rax), [x9];          // rax = free-list head (cell ptr, or 0 = None)
+            cbz x(rax), slow;
+            ldr x12, [x(rax)];         // x12 = (*cell).header.next (free link @ offset 0)
+            str x12, [x9];             // free = next
+            mov x9, (free_count);
+            ldr x12, [x9];
+            sub x12, x12, #1;
+            str x12, [x9];
+            mov x9, (total);
+            ldr x12, [x9];
+            add x12, x12, #1;
+            str x12, [x9];
+            mov x11, (header);
+            str x11, [x(rax)];                              // header (offset 0)
+            mov x12, #0;
+            str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
+            mov x12, (len as u64);
+            str x12, [x(rax), #(RVALUE_OFFSET_ARY_CAPA as u32)]; // inline length
+        );
+        for k in 0..len {
+            let slot = SlotId(args.0 + k);
+            let off = RVALUE_OFFSET_INLINE as u32 + (k as u32) * 8;
+            self.a64_frame_load(12, lfp, conv(slot) as u32);
+            self.a64_field_store(12, rax, off);
+        }
+        monoasm_arm64!(&mut self.jit, b cont;);
+        self.jit.bind_label(slow);
+        self.new_array_runtime(callid, using_fpr);
+        self.jit.bind_label(cont);
     }
 
     /// rax <- Hash literal via gen_hash(vm, globals, &slot[args], len).

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -935,10 +935,79 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_new_array(
         &mut self,
         callid: CallSiteId,
+        inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     ) -> bool {
-        self.new_array(callid, using_fpr);
+        match inline {
+            // Inline the common case (small no-splat literal) when the
+            // allocator free-list addresses were captured at startup.
+            Some((args, len)) if !self.alloc_free_head_addr.is_null() => {
+                self.new_array_inline(callid, args, len, using_fpr);
+            }
+            _ => self.new_array(callid, using_fpr),
+        }
         true
+    }
+
+    /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
+    /// literal: pop a recycled cell from the GC free list and initialise it
+    /// directly as an inline-storage Array, with no runtime call. When the
+    /// free list is empty, fall back to the runtime `gen_array` (which also
+    /// handles bump allocation, page growth, and the alloc flag).
+    ///
+    /// The elements have already been written back to consecutive stack
+    /// slots starting at `args` (see `TraceIr::Array`). A freshly allocated
+    /// young Array needs no write barrier for its elements (the barrier
+    /// guards old→young stores), and there is no GC safepoint between the
+    /// free-list pop and the field initialisation, so the partially built
+    /// object is never observed by a collection.
+    fn new_array_inline(
+        &mut self,
+        callid: CallSiteId,
+        args: SlotId,
+        len: u16,
+        using_fpr: UsingFpr,
+    ) {
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        let free_head = self.alloc_free_head_addr as u64;
+        let free_count = self.alloc_free_count_addr as u64;
+        let total = self.alloc_total_addr as u64;
+        // 8-byte object header: flag=1 (live) | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
+        let header: u64 =
+            ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
+        monoasm! { &mut self.jit,
+            movq rdi, (free_head);
+            movq rax, [rdi];          // rax = free-list head (cell ptr, or 0 = None)
+            testq rax, rax;
+            jz   slow;
+            movq rcx, [rax];          // rcx = (*cell).header.next (free link @ offset 0)
+            movq [rdi], rcx;          // free = next
+            movq rdi, (free_count);
+            subq [rdi], 1;
+            movq rdi, (total);
+            addq [rdi], 1;
+            movq rdi, (header);
+            movq [rax + (RVALUE_OFFSET_FLAG)], rdi;   // header (offset 0); overwrites the free link
+            movq [rax + (RVALUE_OFFSET_VAR)], 0;      // var_table = None
+            movq [rax + (RVALUE_OFFSET_ARY_CAPA)], (len as i32);  // inline length (capa == len <= 5)
+        }
+        for k in 0..len {
+            let slot = SlotId(args.0 + k);
+            let off = RVALUE_OFFSET_INLINE as i32 + (k as i32) * 8;
+            monoasm! { &mut self.jit,
+                movq rcx, [rbp - (rbp_local(slot))];
+                movq [rax + (off)], rcx;
+            }
+        }
+        monoasm! { &mut self.jit,
+            jmp  cont;
+        slow:
+        }
+        self.new_array(callid, using_fpr);
+        monoasm! { &mut self.jit,
+        cont:
+        }
     }
 
     /// rax <- Hash literal from the `len` key/value slots at `args`.

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -877,8 +877,17 @@ impl AsmIr {
 ///
 
 impl AsmIr {
-    pub(super) fn new_array(&mut self, using_fpr: UsingFpr, callid: CallSiteId) {
-        self.push(AsmInst::NewArray { callid, using_fpr });
+    pub(super) fn new_array(
+        &mut self,
+        using_fpr: UsingFpr,
+        callid: CallSiteId,
+        inline: Option<(SlotId, u16)>,
+    ) {
+        self.push(AsmInst::NewArray {
+            callid,
+            inline,
+            using_fpr,
+        });
     }
 
     pub(super) fn new_hash(&mut self, using_fpr: UsingFpr, args: SlotId, len: usize) {
@@ -1785,6 +1794,11 @@ pub(super) enum AsmInst {
     ///
     NewArray {
         callid: CallSiteId,
+        /// `Some((args, len))` when the literal has no splat and `1 <= len <=
+        /// ARRAY_INLINE_CAPA`, enabling the JIT inline free-list fast path
+        /// (elements live in consecutive slots starting at `args`). `None`
+        /// falls back to the runtime `gen_array` call.
+        inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     },
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -192,9 +192,15 @@ impl Codegen {
             AsmInst::CreateArray { src, len } => {
                 self.encode_linst(LInst::CreateArray { src, len })
             }
-            AsmInst::NewArray { callid, using_fpr } => {
-                self.encode_linst(LInst::NewArray { callid, using_fpr })
-            }
+            AsmInst::NewArray {
+                callid,
+                inline,
+                using_fpr,
+            } => self.encode_linst(LInst::NewArray {
+                callid,
+                inline,
+                using_fpr,
+            }),
             AsmInst::NewHash(args, len, using_fpr) => {
                 self.encode_linst(LInst::NewHash { args, len, using_fpr })
             }
@@ -1213,8 +1219,12 @@ impl Codegen {
             LInst::CreateArray { src, len } => {
                 self.emit_create_array(src, len);
             }
-            LInst::NewArray { callid, using_fpr } => {
-                self.emit_new_array(callid, using_fpr);
+            LInst::NewArray {
+                callid,
+                inline,
+                using_fpr,
+            } => {
+                self.emit_new_array(callid, inline, using_fpr);
             }
             LInst::NewHash { args, len, using_fpr } => {
                 self.emit_new_hash(args, len, using_fpr);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -247,7 +247,17 @@ impl<'a> JitContext<'a> {
                 state.write_back_range(ir, args, pos_num as u16);
                 state.discard(dst);
                 let using_fpr = state.get_using_fpr(ir);
-                ir.new_array(using_fpr, callid);
+                // A no-splat literal whose length fits the array's inline
+                // storage can be allocated inline from the free list, with no
+                // runtime call. Otherwise fall back to `gen_array`.
+                let inline = if self.store[callid].splat_pos.is_empty()
+                    && (1..=ARRAY_INLINE_CAPA).contains(&pos_num)
+                {
+                    Some((args, pos_num as u16))
+                } else {
+                    None
+                };
+                ir.new_array(using_fpr, callid, inline);
                 state.def_reg2acc_class(ir, GP::Rax, dst, ARRAY_CLASS);
             }
             TraceIr::Lambda { .. } => {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -673,6 +673,7 @@ pub(in crate::codegen) enum LInst {
     },
     NewArray {
         callid: CallSiteId,
+        inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     },
     NewHash {


### PR DESCRIPTION
## Summary

Array literals (`[a, b]`, `[x, h, w]`, …) in JIT code previously always went through a full runtime `gen_array` C-call: fpr save/restore, a call-site table lookup, a reversed/cloned iterator, and a thread-local `RefCell` allocator borrow — **once per array created**.

The **bedcov** (plb2) benchmark allocates ~66M arrays (its interval-overlap stack pushes `[x, h, w]` tuples ~52M times), so this path dominates after GC. Profiling on bedcov showed **GC ~27%** of runtime and **`gen_array` ~9%**, both driven by allocation volume.

This PR inlines the common case directly in compiled code: for a **no-splat literal whose length fits the Array's inline storage** (`1..=ARRAY_INLINE_CAPA`, i.e. ≤5), pop a recycled cell from the allocator free list and initialise it in place (header / `var_table` / inline length / elements), falling back to the runtime `gen_array` call only when the free list is empty (which also handles bump allocation, page growth, and the alloc flag).

The allocator's free-list state addresses (`free` head, `free_list_count`, `total_allocated_objects`) are captured once at `Codegen::new` — a stable single-threaded thread-local — and baked into the emitted code, mirroring how `set_alloc_flag_address` already wires the JIT to the allocator.

## Correctness

- A freshly allocated **young** object needs no write barrier for its elements (the barrier guards old→young stores).
- There is **no GC safepoint** between the free-list pop and the field writes, so a collection never observes a half-built object.
- Free-list cells are always young (`old_bits == 0`), matching the `alloc()` free-list branch exactly; the alloc flag (set only on the bump path) is therefore untouched.
- `free_list_count` / `total_allocated_objects` are kept in sync so gc-debug asserts and gc-log stats stay correct.

## Results

| Metric | Value |
|---|---|
| bedcov speedup | **~9%** (interleaved min **8.73s** vs **9.67s** baseline; YJIT ~7.5s) |
| Output | `8195494005` — matches CRuby |
| Tests | **all 2310 release tests pass**, incl. gc-stress array workloads matching CRuby |

## Notes / risk

- **aarch64**: the x86_64 path is fully validated locally. The aarch64 mirror is **review-validated only** — no aarch64 cross toolchain was available in the dev environment, so it was not compiled locally. It is a faithful translation of the tested x86_64 logic using only idioms already present in the aarch64 backend (`cbz`/`b`/`bind_label`/`a64_frame_load`/`a64_field_store`/64-bit `mov`). **Relies on the macOS (AArch64) CI job for verification.**
- The **VM tier is intentionally unchanged** (it still calls `gen_array`); bedcov is JIT-hot, and leaving the cold tier alone keeps the change small and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)