### PR TITLE
Fix JIT block_given? in builtin blocks, String slice, and ENV/File/Dir/FileTest spec gaps

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -622,6 +622,12 @@ class File
   def ctime;     File.ctime(path);     end
   def birthtime; File.birthtime(path); end
 
+  # Instance chmod/chown (core/file/{chmod,chown}_spec.rb): only the class
+  # forms existed. Delegate through #path and return 0, as CRuby's instance
+  # forms do (the class forms return the number of files affected).
+  def chmod(mode);         File.chmod(mode, path);          0; end
+  def chown(owner, group); File.chown(owner, group, path);  0; end
+
   # Purely lexical `dirname` (core/file/dirname_spec.rb). CRuby does *not*
   # resolve `.`/`..` or collapse interior slashes; it only strips the last
   # `/component` (and the slashes immediately before it), `level` times.

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -622,6 +622,40 @@ class File
   def ctime;     File.ctime(path);     end
   def birthtime; File.birthtime(path); end
 
+  # Purely lexical `dirname` (core/file/dirname_spec.rb). CRuby does *not*
+  # resolve `.`/`..` or collapse interior slashes; it only strips the last
+  # `/component` (and the slashes immediately before it), `level` times.
+  def self.dirname(path, level = 1)
+    path = path.to_path if !path.is_a?(String) && path.respond_to?(:to_path)
+    path = path.to_str  if !path.is_a?(String) && path.respond_to?(:to_str)
+    raise TypeError, "no implicit conversion of #{path.class} into String" unless path.is_a?(String)
+    unless level.is_a?(Integer)
+      unless level.respond_to?(:to_int)
+        raise TypeError, "no implicit conversion of #{level.class} into Integer"
+      end
+      level = level.to_int
+    end
+    raise ArgumentError, "negative level: #{level}" if level < 0
+    result = path
+    level.times do
+      prev = result
+      result = _dirname_once(result)
+      break if result == prev
+    end
+    result
+  end
+
+  def self._dirname_once(path)
+    return "/" if path =~ %r{\A/+\z}   # all slashes (incl. "/")
+    s = path.sub(%r{/+\z}, "")         # drop trailing slashes
+    return "." if s.empty?             # empty path
+    idx = s.rindex("/")
+    return "." if idx.nil?             # no directory part
+    prefix = s[0...idx].sub(%r{/+\z}, "")
+    prefix.empty? ? "/" : prefix       # empty prefix only for absolute paths
+  end
+  private_class_method :_dirname_once
+
   def self.zero?(path)
     # A missing file is not an error here (returns false), but a non-path
     # argument (nil/true/Integer/...) must still raise the TypeError that

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -601,7 +601,14 @@ end
 
 class File
   def self.zero?(path)
-    s = (File.size(path) rescue return false)
+    # A missing file is not an error here (returns false), but a non-path
+    # argument (nil/true/Integer/...) must still raise the TypeError that
+    # `File.size` produces — so rescue only filesystem errors, not everything.
+    begin
+      s = File.size(path)
+    rescue SystemCallError
+      return false
+    end
     s == 0
   end
 
@@ -623,12 +630,15 @@ class File
 end
 
 module FileTest
-  def self.zero?(path)
+  def self.empty?(path)
     File.zero?(path)
   end
 
-  def self.empty?(path)
-    File.zero?(path)
+  # core/filetest/zero_spec.rb: `FileTest.zero?` is a strict alias of
+  # `FileTest.empty?` (identity check `method(:zero?) == method(:empty?)`),
+  # so re-point it rather than defining a second method sharing the body.
+  class << self
+    alias zero? empty?
   end
 end
 
@@ -711,4 +721,43 @@ class Thread
   # form for both (matches CRuby's `inspect`==`to_s`).
   def to_s = super
   alias inspect to_s
+end
+
+# ENV is a singleton object (not a class), so its methods live on its
+# singleton class. ruby/spec checks several of them for strict alias identity
+# (`ENV.method(:a) == ENV.method(:b)`). monoruby registered these as separate
+# Rust builtins sharing one fn (distinct FuncId), so re-point them as real
+# aliases here. The originals (`include?`, `value?`, `[]=`, `merge!`) are all
+# registered by `hash.rs` before this file loads.
+class << ENV
+  alias has_key? include?
+  alias key? include?
+  alias member? include?
+  alias has_value? value?
+  alias store []=
+  alias update merge!
+
+  # core/env/clone_spec.rb / dup_spec.rb: unlike a plain Hash, ENV cannot be
+  # copied — CRuby raises TypeError from `#clone`/`#dup`. `#clone` still
+  # validates its `freeze:` keyword first (ArgumentError for a non-boolean
+  # value or an unknown keyword), matching Kernel#clone's signature.
+  def clone(freeze: nil, **rest)
+    unless rest.empty?
+      raise ArgumentError, "unknown keyword: #{rest.keys.first.inspect}"
+    end
+    unless freeze.nil? || freeze == true || freeze == false
+      raise ArgumentError, "unexpected value for freeze: #{freeze.class}"
+    end
+    raise TypeError, "Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash"
+  end
+
+  def dup
+    raise TypeError, "Cannot dup ENV, use ENV.to_h to get a copy of ENV as a hash"
+  end
+
+  # Hash#except is implemented via #dup, which ENV now forbids. CRuby's
+  # ENV.except returns a plain Hash snapshot, so route it through #to_h.
+  def except(*keys)
+    to_h.except(*keys)
+  end
 end

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -507,7 +507,11 @@ class Dir
   def each(&block)
     raise IOError, "closed directory" if @closed
     return to_enum(:each) unless block
+    # #each always yields every entry (so repeated calls give the same result),
+    # then leaves the read cursor at end-of-stream so a following #read returns
+    # nil (core/dir/each_spec.rb).
     @entries.each { |e| block.call(e) }
+    @pos = @entries.length
     self
   end
 
@@ -541,7 +545,12 @@ class Dir
     @pos = newpos
   end
 
-  alias seek pos=
+  # Unlike `pos=` (which yields the assigned value), Dir#seek returns the Dir
+  # itself (core/dir/seek_spec.rb).
+  def seek(newpos)
+    self.pos = newpos
+    self
+  end
 
   def close
     @closed = true
@@ -565,9 +574,14 @@ class Dir
   def self.each_child(path, encoding: nil, &block)
     return to_enum(:each_child, path) unless block
     children(path).each { |e| block.call(e) }
+    nil
   end
 
   def self.empty?(path)
+    # A path that exists but is not a directory is not "empty" — it returns
+    # false rather than raising (core/dir/empty_spec.rb). A missing path still
+    # raises Errno::ENOENT (surfaced by `children`/`entries`).
+    return false if File.exist?(path) && !File.directory?(path)
     children(path).empty?
   end
 end

--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -614,6 +614,14 @@ class Array
 end
 
 class File
+  # Instance timestamp readers (core/file/{atime,mtime,ctime,birthtime}_spec.rb).
+  # monoruby only defined the File.<name>(path) class methods; delegate the
+  # instance form through the receiver's #path.
+  def atime;     File.atime(path);     end
+  def mtime;     File.mtime(path);     end
+  def ctime;     File.ctime(path);     end
+  def birthtime; File.birthtime(path); end
+
   def self.zero?(path)
     # A missing file is not an error here (returns false), but a non-path
     # argument (nil/true/Integer/...) must still raise the TypeError that

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -567,41 +567,47 @@ fn process_glob_pattern(
     };
 
     // Build the component list from the remaining path segments.
+    let segments: Vec<&str> = segments.collect();
+    let last_idx = segments.len().saturating_sub(1);
     let mut components: Vec<PathComponent> = vec![];
-    for seg in segments {
-        components.push(match seg {
+    for (i, seg) in segments.iter().enumerate() {
+        components.push(match *seg {
             "." => PathComponent::Current,
             ".." => PathComponent::Parent,
             "" => PathComponent::None,
+            // `**` recurses only when it is a full directory component
+            // (i.e. followed by `/`). A trailing `**` with no slash — the
+            // last segment — behaves like `*`, matching just this level
+            // (CRuby: `Dir.glob("**") == Dir.glob("*")`).
+            "**" if i == last_idx => glob_name_component("*")?,
             "**" => PathComponent::Globstar,
-            s => {
-                let normalized = normalize_glob_segment(s);
-                // macOS's default filesystem (APFS / HFS+) is
-                // case-insensitive but case-preserving. CRuby compiles
-                // with `HAVE_CASEFOLD_FILESYSTEM` and silently adds
-                // FNM_CASEFOLD to every Dir.glob there, so `glob("C*")`
-                // also matches `c.rb`. Mirror that on macOS so the
-                // monoruby/CRuby differential tests agree (e.g. the
-                // `Dir.glob("./././C*")` arm of the `glob` test).
-                // `mut` is used only on macos (`case_insensitive` below).
-                #[allow(unused_mut)]
-                let mut b = globset::GlobBuilder::new(&normalized);
-                #[cfg(target_os = "macos")]
-                b.case_insensitive(true);
-                PathComponent::Name(match b.build() {
-                    Ok(g) => g,
-                    Err(e) => {
-                        return Err(MonorubyErr::runtimeerr(format!(
-                            "invalid glob pattern {:?}: {}",
-                            s, e
-                        )));
-                    }
-                })
-            }
+            s => glob_name_component(s)?,
         });
     }
 
     traverse_dir(path, components, matches, dotmatch)
+}
+
+/// Compile a single glob path segment into a `PathComponent::Name` matcher.
+fn glob_name_component(s: &str) -> Result<PathComponent> {
+    let normalized = normalize_glob_segment(s);
+    // macOS's default filesystem (APFS / HFS+) is case-insensitive but
+    // case-preserving. CRuby compiles with `HAVE_CASEFOLD_FILESYSTEM` and
+    // silently adds FNM_CASEFOLD to every Dir.glob there, so `glob("C*")`
+    // also matches `c.rb`. Mirror that on macOS so the monoruby/CRuby
+    // differential tests agree (e.g. the `Dir.glob("./././C*")` arm of the
+    // `glob` test). `mut` is used only on macos (`case_insensitive` below).
+    #[allow(unused_mut)]
+    let mut b = globset::GlobBuilder::new(&normalized);
+    #[cfg(target_os = "macos")]
+    b.case_insensitive(true);
+    match b.build() {
+        Ok(g) => Ok(PathComponent::Name(g)),
+        Err(e) => Err(MonorubyErr::runtimeerr(format!(
+            "invalid glob pattern {:?}: {}",
+            s, e
+        ))),
+    }
 }
 
 fn traverse_dir(

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -82,7 +82,14 @@ fn children(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/foreach.html]
 #[monoruby_builtin]
-fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    // Without a block, return a (lazy, size-less) Enumerator that replays
+    // `Dir.foreach(path)` when iterated — matching CRuby, which defers the
+    // directory read (and any ENOENT) until enumeration.
+    let Some(bh) = lfp.block() else {
+        let method = IdentId::get_id("foreach");
+        return vm.generate_enumerator(method, lfp.self_val(), vec![lfp.arg(0)], pc);
+    };
     let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
     let mut names = vec![".".to_string(), "..".to_string()];
     for entry in std::fs::read_dir(&path)
@@ -92,17 +99,11 @@ fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             entry.map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?;
         names.push(entry.file_name().to_string_lossy().to_string());
     }
-    if let Some(bh) = lfp.block() {
-        let p = vm.get_block_data(globals, bh)?;
-        for name in names {
-            vm.invoke_block(globals, &p, &[Value::string(name)])?;
-        }
-        Ok(Value::nil())
-    } else {
-        Ok(Value::array_from_vec(
-            names.into_iter().map(Value::string).collect(),
-        ))
+    let p = vm.get_block_data(globals, bh)?;
+    for name in names {
+        vm.invoke_block(globals, &p, &[Value::string(name)])?;
     }
+    Ok(Value::nil())
 }
 
 ///
@@ -716,7 +717,32 @@ fn traverse_dir(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/home.html]
 #[monoruby_builtin]
-fn home(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+fn home(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // With a username argument, return that user's home directory. An unknown
+    // user raises ArgumentError (core/dir/home_spec.rb), matching CRuby.
+    if let Some(arg) = lfp.try_arg(0)
+        && !arg.is_nil()
+    {
+        let user = arg.coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
+        let c_user = std::ffi::CString::new(user.as_bytes())
+            .map_err(|_| MonorubyErr::argumenterr("user name cannot contain NUL"))?;
+        // SAFETY: `getpwnam` reads the passwd DB for the NUL-terminated name
+        // and returns a pointer into a static buffer (or null when unknown);
+        // we only read `pw_dir` immediately, before any other libc call.
+        let dir = unsafe {
+            let pw = libc::getpwnam(c_user.as_ptr());
+            if pw.is_null() {
+                return Err(MonorubyErr::argumenterr(format!(
+                    "user {} doesn't exist",
+                    user
+                )));
+            }
+            std::ffi::CStr::from_ptr((*pw).pw_dir)
+                .to_string_lossy()
+                .to_string()
+        };
+        return Ok(Value::string(dir));
+    }
     let home = match dirs::home_dir() {
         Some(home) => home,
         None => return Ok(Value::nil()),
@@ -943,7 +969,9 @@ fn fchdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let rc = unsafe { libc::fchdir(fd) };
     if rc != 0 {
         let err = std::io::Error::last_os_error();
-        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, ""));
+        // CRuby tags the SystemCallError message with the syscall name, e.g.
+        // "Bad file descriptor - fchdir" (core/dir/fchdir_spec.rb).
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "fchdir"));
     }
     if let Some(bh) = lfp.block() {
         let result = vm.invoke_block_once(globals, bh, &[]);

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -1025,6 +1025,16 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn dir_methods_coverage() {
+        // Dir.home(user) via getpwnam (+ ArgumentError for an unknown user),
+        // Dir.foreach's no-block Enumerator (size == nil), Dir.fchdir's tagged
+        // SystemCallError message, and the trailing `**` glob == `*` behaviour.
+        run_test_once(
+            r##"(a=Dir.home("root"); b=(begin; Dir.home("no_such_user_zzq"); rescue => e; e.class; end); c=Dir.foreach("/").is_a?(Enumerator); d=Dir.foreach("/").size; e2=(begin; Dir.fchdir(-1); rescue => x; [x.class, x.message]; end); f=(Dir.glob("**").sort==Dir.glob("*").sort); [a,b,c,d,e2,f])"##,
+        );
+    }
+
+    #[test]
     fn exist() {
         run_tests(&[
             r#"Dir.exist?(".")"#,

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -666,9 +666,44 @@ fn file_basename(
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/directory=3f.html]
 #[monoruby_builtin]
 fn directory_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    match to_canonicalized_path(vm, globals, lfp.arg(0), "1st arg") {
+    // CRuby's `rb_stat` accepts either a path (coerced via `#to_path`/`#to_str`)
+    // or an IO/fd (converted via `#to_io` and `fstat`'d). Try the path form
+    // first — this covers String and IO objects that expose `#to_path` — and
+    // fall back to `#to_io` on a coercion failure before surfacing the
+    // TypeError. `Path::is_dir` stats the path and returns false for a
+    // non-existent entry, so no canonicalization (which would swallow the
+    // TypeError for a non-path type such as Integer/nil) is needed.
+    let arg = lfp.arg(0);
+    match to_path(vm, globals, arg) {
         Ok(path) => Ok(Value::bool(path.is_dir())),
-        Err(_) => Ok(Value::bool(false)),
+        Err(e) => {
+            let to_io = IdentId::get_id("to_io");
+            if globals.check_method(arg, to_io).is_some() {
+                let io = vm.invoke_method_inner(globals, to_io, arg, &[], None, None)?;
+                if let Some(rv) = io.try_rvalue()
+                    && rv.ty() == ObjTy::IO
+                {
+                    let fd = io.as_io_inner().fileno()?;
+                    return Ok(Value::bool(fd_is_dir(fd)));
+                }
+            }
+            Err(e)
+        }
+    }
+}
+
+/// `fstat(2)` an open file descriptor and report whether it refers to a
+/// directory. A failed `fstat` (bad fd, etc.) reports `false`.
+fn fd_is_dir(fd: i32) -> bool {
+    // SAFETY: `fstat` fills a zeroed `stat` buffer for an open fd; we only
+    // read `st_mode`. On failure the buffer is unused and we return false.
+    unsafe {
+        let mut st: libc::stat = std::mem::zeroed();
+        if libc::fstat(fd, &mut st) == 0 {
+            (st.st_mode & libc::S_IFMT) == libc::S_IFDIR
+        } else {
+            false
+        }
     }
 }
 

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -87,6 +87,7 @@ pub(super) fn init(globals: &mut Globals) {
 
     globals.define_builtin_func_rest(file, "write", write);
     globals.define_builtin_func(file, "size", size, 0);
+    globals.define_builtin_func(file, "truncate", file_truncate_instance, 1);
     globals.define_builtin_func(file, "flock", flock_, 1);
 
     globals.define_builtin_class_func_with(file, "umask", umask, 0, 1, false);
@@ -1931,6 +1932,39 @@ fn file_truncate(
     file.set_len(length as u64).map_err(|e| {
         MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_truncate", &path_str)
     })?;
+    Ok(Value::integer(0))
+}
+
+///
+/// ### File#truncate (instance method)
+/// - truncate(length) -> 0
+///
+/// Truncates the open file to at most `length` bytes via `ftruncate(2)` on the
+/// underlying descriptor (so it works even after the path was unlinked, and
+/// does not disturb the read/write offset).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/File/i/truncate.html]
+#[monoruby_builtin]
+fn file_truncate_instance(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let length = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if length < 0 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "negative length {}",
+            length
+        )));
+    }
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: `fd` is this File's open descriptor; `ftruncate` only resizes it.
+    let rc = unsafe { libc::ftruncate(fd, length as libc::off_t) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "ftruncate"));
+    }
     Ok(Value::integer(0))
 }
 

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1425,23 +1425,6 @@ fn extend(path: &mut std::path::PathBuf, extend: std::path::PathBuf) -> Result<(
     Ok(())
 }
 
-/// Convert `file` to canonicalized PathBuf.
-fn to_canonicalized_path(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    file: Value,
-    msg: &str,
-) -> Result<std::path::PathBuf> {
-    let path = to_path(vm, globals, file)?;
-    match path.canonicalize() {
-        Ok(file) => Ok(file),
-        Err(_) => Err(MonorubyErr::argumenterr(format!(
-            "{} is an invalid filename. {:?}",
-            msg, path
-        ))),
-    }
-}
-
 /// Convert `file` to PathBuf.
 fn to_path(vm: &mut Executor, globals: &mut Globals, file: Value) -> Result<std::path::PathBuf> {
     let file = to_path_str(vm, globals, file)?;
@@ -2573,6 +2556,24 @@ fn file_realdirpath(
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn file_instance_method_coverage() {
+        // File# instance timestamps, #truncate (ftruncate on the fd), and
+        // #chmod/#chown (return 0).
+        run_test_once(
+            r##"(f="/tmp/mono_cov_#{Process.pid}.txt"; File.write(f,"hello world"); io=File.open(f,"r+"); a=(io.mtime==File.mtime(f)); b=io.atime.class; c=io.ctime.class; io.truncate(5); io.close; d=File.read(f); g=File.open(f); e2=g.chmod(0o600); h=g.chown(nil,nil); g.close; File.delete(f); [a,b,c,d,e2,h])"##,
+        );
+    }
+
+    #[test]
+    fn file_directory_and_join_coverage() {
+        // File.directory? on an IO / #to_io object and its TypeError branch,
+        // File.join array flattening + NUL check, and lexical dirname edges.
+        run_test_once(
+            r##"(a=File.directory?(STDIN); o=Object.new; def o.to_io; STDIN; end; b=File.directory?(o); c=(begin; File.directory?(1); rescue => e; e.class; end); d=(begin; File.directory?(nil); rescue => e; e.class; end); e2=File.join("a",["b","c"]); f=(begin; File.join("\x00x","y"); rescue => x; [x.class,x.message]; end); [a,b,c,d,e2,f,File.dirname("/.."),File.dirname("./b"),File.dirname("..")])"##,
+        );
+    }
 
     #[test]
     fn basename_suffix() {

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -497,46 +497,69 @@ fn io_try_convert(
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/join.html]
 #[monoruby_builtin]
 fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // Collect the leaf path components in order (flattening nested arrays).
     fn flatten(
         vm: &mut Executor,
         globals: &mut Globals,
-        path: &mut String,
+        parts: &mut Vec<String>,
         val: Value,
         seen: &mut Vec<u64>,
     ) -> Result<()> {
         match val.try_array_ty() {
             Some(ainfo) => {
+                // An empty array argument joins as a single empty component,
+                // so `File.join([], [])` == "/" (core/file/join_spec.rb).
+                if ainfo.len() == 0 {
+                    parts.push(String::new());
+                    return Ok(());
+                }
                 let id = val.id();
                 if seen.contains(&id) {
                     return Err(MonorubyErr::argumenterr("recursive array"));
                 }
                 seen.push(id);
                 for v in ainfo.iter().cloned() {
-                    flatten(vm, globals, path, v, seen)?;
+                    flatten(vm, globals, parts, v, seen)?;
                 }
                 seen.pop();
             }
             None => {
-                if !path.is_empty() && !path.ends_with('/') {
-                    path.push('/');
-                }
                 let s = val.coerce_to_path_rstring(vm, globals)?;
-                let s = s.to_str()?;
-                path.push_str(if !path.is_empty() && !s.is_empty() && s.starts_with('/') {
-                    &s[1..]
-                } else if path.is_empty() && s.is_empty() {
-                    "/"
-                } else {
-                    &s
-                });
+                let s = s.to_str()?.to_string();
+                if s.as_bytes().contains(&0) {
+                    return Err(MonorubyErr::argumenterr("string contains null byte"));
+                }
+                parts.push(s);
             }
         }
         Ok(())
     }
-    let mut path = String::new();
+    let mut parts = vec![];
     let mut seen = vec![];
     for v in lfp.arg(0).as_array().iter().cloned() {
-        flatten(vm, globals, &mut path, v, &mut seen)?;
+        flatten(vm, globals, &mut parts, v, &mut seen)?;
+    }
+    // Join adjacent components with a single separator. When both sides of a
+    // junction already carry a separator, CRuby keeps the right part's leading
+    // separators and drops the left part's trailing ones ("usr//" + "/bin" ->
+    // "usr/bin", "usr/" + "//bin" -> "usr//bin"); when exactly one side has one
+    // it is reused; when neither does a "/" is inserted.
+    let mut path = String::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i == 0 {
+            path.push_str(part);
+            continue;
+        }
+        let left_sep = path.ends_with('/');
+        let right_sep = part.starts_with('/');
+        if left_sep && right_sep {
+            while path.ends_with('/') {
+                path.pop();
+            }
+        } else if !left_sep && !right_sep {
+            path.push('/');
+        }
+        path.push_str(part);
     }
     Ok(Value::string(path))
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -108,7 +108,7 @@ pub(super) fn init(globals: &mut Globals) {
 
     let env = Value::hash(env_map);
     globals.set_constant_by_str(OBJECT_CLASS, "ENV", env);
-    globals.define_builtin_singleton_func_with(env, "fetch", fetch, 1, 2, false);
+    globals.define_builtin_singleton_func_with(env, "fetch", env_fetch, 1, 2, false);
     globals.define_builtin_singleton_func(env, "[]", env_index, 1);
     globals.define_builtin_singleton_func(env, "[]=", env_index_assign, 2);
     globals.define_builtin_singleton_func(env, "store", env_index_assign, 2);
@@ -1580,12 +1580,71 @@ fn env_index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         let s = key.coerce_to_str(vm, globals)?;
         Value::string(s)
     };
-    let val = lfp
-        .self_val()
-        .as_hash()
-        .get(key, vm, globals)?
-        .unwrap_or_default();
-    Ok(val)
+    match lfp.self_val().as_hash().get(key, vm, globals)? {
+        // ENV values are always Strings; CRuby returns a fresh *frozen* copy
+        // so a caller can never mutate the live environment through it.
+        Some(v) if v.is_str().is_some() => {
+            let s = v.expect_string(&globals.store)?;
+            let mut frozen = Value::string(s);
+            frozen.set_frozen();
+            Ok(frozen)
+        }
+        Some(v) => Ok(v),
+        None => Ok(Value::nil()),
+    }
+}
+
+///
+/// ### ENV.fetch
+///
+/// - fetch(key) -> String
+/// - fetch(key, default) -> String
+/// - fetch(key) {|key| ... } -> String
+///
+/// Like `Hash#fetch`, but the key is first coerced to a `String` (via
+/// `#to_str`). A key that is not a String and does not respond to `#to_str`
+/// raises `TypeError("no implicit conversion of <Class> into String")`,
+/// matching CRuby's `ENV.fetch`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/ENV/s/fetch.html]
+#[monoruby_builtin]
+fn env_fetch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg0 = lfp.arg(0);
+    let key = if arg0.is_str().is_some() {
+        arg0
+    } else {
+        let s = arg0.coerce_to_str(vm, globals)?;
+        Value::string(s)
+    };
+    let hash = lfp.self_val().as_hash();
+    let s = if let Some(bh) = lfp.block() {
+        if lfp.try_arg(1).is_some() {
+            let warn_id = IdentId::get_id("warn");
+            let msg = Value::string_from_str("warning: block supersedes default value argument");
+            vm.invoke_method_inner(globals, warn_id, lfp.self_val(), &[msg], None, None)?;
+        }
+        match hash.get(key, vm, globals)? {
+            Some(v) => v,
+            None => vm.invoke_block_once(globals, bh, &[key])?,
+        }
+    } else if let Some(arg1) = lfp.try_arg(1) {
+        match hash.get(key, vm, globals)? {
+            Some(v) => v,
+            None => arg1,
+        }
+    } else {
+        match hash.get(key, vm, globals)? {
+            Some(v) => v,
+            None => {
+                return Err(MonorubyErr::keyerr_with(
+                    format!("key not found: {}", key.inspect(&globals.store)),
+                    lfp.self_val(),
+                    key,
+                ));
+            }
+        }
+    };
+    Ok(s)
 }
 
 ///
@@ -1617,7 +1676,28 @@ fn env_to_hash(
         let mut new_map = RubyMap::default();
         for (k, v) in pairs {
             let result = vm.invoke_block(globals, &data, &[k, v])?;
-            let arr = result.expect_array_ty(globals)?;
+            // CRuby coerces the block's return value to an Array *only* via
+            // `#to_ary` (never `#to_a`); anything else raises
+            // `TypeError("wrong element type <Class> (expected array)")`.
+            let arr = if result.is_array_ty() {
+                result.as_array()
+            } else {
+                let converted = if let Some(func_id) =
+                    globals.check_method(result, IdentId::TO_ARY)
+                {
+                    vm.invoke_func_inner(globals, func_id, result, &[], None, None)?
+                } else {
+                    Value::nil()
+                };
+                if converted.is_array_ty() {
+                    converted.as_array()
+                } else {
+                    return Err(MonorubyErr::typeerr(format!(
+                        "wrong element type {} (expected array)",
+                        result.get_real_class_name(&globals.store),
+                    )));
+                }
+            };
             if arr.len() != 2 {
                 return Err(MonorubyErr::argumenterr(format!(
                     "element has wrong array length (expected 2, was {})",

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2656,6 +2656,37 @@ mod tests {
     }
 
     #[test]
+    fn env_fetch_coverage() {
+        let _g = env_lock();
+        // key coercion (String), default arg, block, and the TypeError /
+        // KeyError branches of `env_fetch`.
+        run_test_once(
+            r##"(a=ENV.fetch("PATH").class; b=ENV.fetch("NO_SUCH_VAR_ZZ","def"); c=ENV.fetch("NO_SUCH_VAR_ZZ"){|k| "blk:#{k}"}; d=(begin; ENV.fetch(Object.new); rescue => e; e.class; end); f=(begin; ENV.fetch("NO_SUCH_VAR_ZZ"); rescue => e; e.class; end); [a,b,c,d,f])"##,
+        );
+    }
+
+    #[test]
+    fn env_to_h_block_coverage() {
+        let _g = env_lock();
+        // `env_to_hash` block form: #to_ary coercion is fine, a non-array
+        // result raises TypeError, and a wrong-length array raises
+        // ArgumentError.
+        run_test_once(
+            r##"(h=ENV.to_h{|k,v| [k.to_sym, v.length]}; a=h.keys.all?{|x| x.is_a?(Symbol)}; b=(begin; ENV.to_h{|k,v| "x"}; rescue => e; e.class; end); c=(begin; ENV.to_h{|k,v| [k]}; rescue => e; e.class; end); [a,b,c])"##,
+        );
+    }
+
+    #[test]
+    fn env_alias_and_copy_coverage() {
+        let _g = env_lock();
+        // `ENV[]` returns a frozen String, the alias identities hold, and
+        // clone/dup/except take their dedicated paths.
+        run_test_once(
+            r##"(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV.method(:include?); c=ENV.method(:key?)==ENV.method(:include?); d=ENV.method(:member?)==ENV.method(:include?); e2=ENV.method(:has_value?)==ENV.method(:value?); f=(begin; ENV.clone(freeze:1); rescue => x; x.class; end); g=(begin; ENV.clone(foo:1); rescue => x; x.class; end); h=(begin; ENV.clone; rescue => x; x.class; end); i=(begin; ENV.dup; rescue => x; x.class; end); j=ENV.except("MONO_T_ZZ").class; k=ENV.except("MONO_T_ZZ").key?("MONO_T_ZZ"); ENV.delete("MONO_T_ZZ"); [a,b,c,d,e2,f,g,h,i,j,k])"##,
+        );
+    }
+
+    #[test]
     fn env_index_assign_updates_hash() {
         let _g = env_lock();
         // Assignment is visible via ENV[]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -971,36 +971,39 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 INTEGER_CLASS,
             ));
         }
-        // Beginless: nil start ⇒ index 0. Endless: nil end ⇒ char_length - 1
-        // (so the inclusive `end` reaches the last character; the
-        // exclusive bookkeeping below subtracts as usual). `char_length`
-        // is O(1) for ASCII-only strings (cached SevenBit code range).
+        // Resolve the Range following CRuby's `rb_range_beg_len`: normalize a
+        // negative begin/end against the length *first*, then fold
+        // `exclude_end` into an exclusive upper bound. Doing the exclusive
+        // adjustment before negative-index resolution is what previously made
+        // `"abc"[0...0]` wrap the end to -1 and return the whole string.
+        // `char_length` is O(1) for ASCII-only strings (cached SevenBit).
         let char_length = lhs.char_length() as i64;
-        let start = if info.start().is_nil() {
+        let mut beg = if info.start().is_nil() {
             0
         } else {
             info.start().coerce_to_int_i64(vm, globals)?
         };
-        let end = if info.end().is_nil() {
-            // For endless ranges we just want "everything from start".
-            // Use char_length and treat exclude_end as a no-op so the
-            // slice extends through the final character.
-            char_length - 1
+        if beg < 0 {
+            beg += char_length;
+        }
+        // A begin past the end is out of range (nil); begin == length yields "".
+        if beg < 0 || beg > char_length {
+            return Ok(Value::nil());
+        }
+        let end_excl = if info.end().is_nil() {
+            char_length
         } else {
-            info.end().coerce_to_int_i64(vm, globals)? - info.exclude_end() as i64
-        };
-        let (start, len) = match (lhs.conv_char_index(start), lhs.conv_char_index(end)) {
-            (Some(start), Some(end)) => {
-                if start > end {
-                    (start, 0)
-                } else {
-                    (start, end - start + 1)
-                }
+            let mut end = info.end().coerce_to_int_i64(vm, globals)?;
+            if end < 0 {
+                end += char_length;
             }
-            (Some(start), None) => (start, 0),
-            (None, _) => return Ok(Value::nil()),
+            if !info.exclude_end() {
+                end += 1;
+            }
+            end
         };
-        let r = lhs.get_range(start, len);
+        let len = (end_excl - beg).max(0) as usize;
+        let r = lhs.get_range(beg as usize, len);
         // Zero-copy shared substring (CoW) for long enough slices.
         Ok(string_substring(self_, r.start, r.end))
     } else if let Some(re) = lfp.arg(0).is_regex() {

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -1516,13 +1516,35 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, adds x(r), x(r), #(2u32););
                 self.jit.bcond_label(monoasm::Cond::Vs, &deopt);
             }
-            // Kernel#block_given?: FALSE unless [LFP - LFP_BLOCK] is set & non-nil.
+            // Kernel#block_given?: walk to the outermost method frame, then
+            // report whether its block slot is set & non-nil. Running inside a
+            // block frame, the current LFP's own block slot is that block's
+            // block param (usually nil), so first follow the `outer` chain up
+            // to the outermost method — mirroring `Lfp::outermost` (stop at a
+            // `proc_method` frame or when there is no outer).
             LInst::BlockGiven { dst } => {
                 let (d, lfp, rdi) = (dst.a64().0, GP::R14.a64().0, GP::Rdi.a64().0);
+                // Byte offset (from an LFP) of the meta `kind` byte holding the
+                // `proc_method` flag (bit 5).
+                let kind_off = (LFP_META - META_KIND as i32) as u32;
                 let exit = self.jit.label();
+                let walk = self.jit.label();
+                let found = self.jit.label();
                 monoasm_arm64!(&mut self.jit,
+                    mov x(rdi), x(lfp);              // rdi = current LFP
+                    sub x9, x(rdi), #(kind_off);
+                    ldrb w10, [x9];
+                    tbnz x10, #(5), found;           // is_proc_method -> stop
+                walk:
+                    ldr x9, [x(rdi)];                // outer LFP (LFP_OUTER == 0)
+                    cbz x9, found;                   // no outer -> rdi is outermost
+                    mov x(rdi), x9;
+                    sub x9, x(rdi), #(kind_off);
+                    ldrb w10, [x9];
+                    tbz x10, #(5), walk;             // not a method boundary -> keep walking
+                found:
                     mov x(d), #(FALSE_VALUE);
-                    sub x9, x(lfp), #(LFP_BLOCK as u32);
+                    sub x9, x(rdi), #(LFP_BLOCK as u32);
                     ldr x(rdi), [x9];
                     cbz x(rdi), exit;
                     cmp x(rdi), #(NIL_VALUE);

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -386,13 +386,33 @@ impl Codegen {
                     jo   deopt;
                 );
             }
-            // Kernel#block_given?: FALSE unless [r14 - LFP_BLOCK] is set & non-nil.
+            // Kernel#block_given?: walk to the outermost method frame, then
+            // report whether its block slot is set & non-nil.
             LInst::BlockGiven { dst } => {
                 let d = dst as u64;
                 let exit = self.jit.label();
+                let walk = self.jit.label();
+                let found = self.jit.label();
+                // `block_given?` reports whether the *enclosing method* was
+                // given a block. When this runs inside a block frame, the
+                // current LFP's own block slot is that block's block param
+                // (usually nil), so we must first walk the `outer` chain up to
+                // the outermost method frame — mirroring `Lfp::outermost`
+                // (stop at a `proc_method` frame or when there is no outer).
                 monoasm!( &mut self.jit,
+                    movq rdi, r14;                              // rdi = current LFP
+                    testb [rdi - (LFP_META - META_KIND)], (0b0010_0000_u8 as i8); // is_proc_method?
+                    jnz found;
+                walk:
+                    movq rax, [rdi - (LFP_OUTER)];              // rax = outer LFP (0 = none)
+                    testq rax, rax;
+                    jz found;                                   // no outer -> rdi is outermost
+                    movq rdi, rax;
+                    testb [rdi - (LFP_META - META_KIND)], (0b0010_0000_u8 as i8);
+                    jz walk;                                    // not a method boundary -> keep walking
+                found:
                     movq R(d), (FALSE_VALUE);
-                    movq rdi, [r14 - (LFP_BLOCK)];
+                    movq rdi, [rdi - (LFP_BLOCK)];
                     testq rdi, rdi;
                     jz exit;
                     cmpq rdi, (NIL_VALUE);

--- a/monoruby/src/value/coerce.rs
+++ b/monoruby/src/value/coerce.rs
@@ -428,7 +428,10 @@ impl Value {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<RString> {
-        coerce_to_rstring_inner(vm, globals, *self, &[IdentId::TO_STR, IdentId::TO_PATH])
+        // CRuby's path coercion (`rb_get_path`) prefers `#to_path`, only
+        // falling back to `#to_str` when `#to_path` is absent
+        // (core/dir/chdir_spec.rb "prefers #to_path over #to_str").
+        coerce_to_rstring_inner(vm, globals, *self, &[IdentId::TO_PATH, IdentId::TO_STR])
     }
 
     /// Like `expect_regexp_or_string` but tries `to_str` coercion for


### PR DESCRIPTION
## Summary

Investigates and fixes failures/panics in the `core/filetest`, `env`, `file`, `dir`, and `argf` ruby/spec categories, prioritising low-cost, high-impact fixes. Two of the changes are general correctness fixes that reach well beyond these categories.

### Highest-impact fix — JIT `block_given?` inside builtin-invoked blocks
`block_given?` read the **current** frame's block slot. Inside a block that a builtin invokes (e.g. `File.open(path){ … }`), that slot is the block's own (usually `nil`) block param, not the enclosing method's block. Once the enclosing method was JIT-compiled, `block_given?` there wrongly returned `false`, so `yield … if block_given?` fixtures — notably mspec's `touch` — silently did nothing, leaving files empty and cascading into a large cluster of File/FileTest/Dir failures (the whole `FileTest.size` cluster, etc.). The runtime `BlockGiven` lowering now walks the `outer` chain to the outermost method frame (mirroring `Lfp::outermost`) before reading the block slot, on both x86-64 and aarch64.

### `String#[]` zero-length Range
`String#[]` applied `exclude_end` to the raw end index *before* resolving negative indices, so `"abc"[0...0]` computed end `-1`, wrapped it to the last char, and returned the whole string. Begin/end are now resolved against the length first (CRuby's `rb_range_beg_len`), then folded into an exclusive upper bound. `str[0...0]`, `str[i...i]`, endless/beginless and negative-bound ranges all match CRuby now.

### ENV / FileTest / File / Dir
- **Aliases & identity**: `ENV.has_key?/key?/member? → include?`, `has_value? → value?`, `store → []=`, `update → merge!`; `FileTest.zero? → empty?`.
- **Error handling**: `File.zero?` only rescues `SystemCallError` (non-path args still raise `TypeError`); `File.directory?` raises `TypeError` on non-paths and handles `#to_io` via `fstat`; `ENV.fetch`/`clone`/`dup`/`to_h`; `Dir.fchdir`/`empty?`/`home` (getpwnam); `File.join` NUL check.
- **Missing instance methods**: `File#atime/mtime/ctime/birthtime/truncate/chmod/chown`.
- **Lexical algorithms**: `File.dirname` (no longer resolves `..`; supports `level`), `File.join` (junction slash dedup + empty components), `Dir` enumerator/return-value semantics (`foreach`→Enumerator, `each`, `seek`, `each_child`), and glob `**`-as-last-segment behaving like `*`.
- Path coercion (`coerce_to_path_rstring`) now prefers `#to_path` over `#to_str`, matching CRuby's `rb_get_path`.

## Testing

Ran the full `core` suite with this branch **and** a baseline built from the branch's parent commit, then diffed per category — **0 regressions**:

| Category | baseline (F/E) | this PR (F/E) |
|---|---|---|
| filetest | 14 / 0 | **3 / 0** |
| dir | 49 / 5 | **40 / 3** |
| file | 20 / 35 | **14 / 22** |
| string | 190 / 106 | **187 / 106** |
| env | 14 / 4 | **13 / 0** |
| all other core categories | — | **identical** |

No category regressed on failures or errors. The broad `String#[]` and JIT `block_given?` changes left `array`/`enumerable`/`proc`/`method`/etc. unchanged.

Reference: CRuby 4.0.2 (matching the vendored `.ruby-version` pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_