### PR TITLE
Kernel: clone freeze:, format alias, __method__/__callee__, loop, respond_to_missing? (core/kernel)

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -823,3 +823,22 @@ class << ENV
     to_h.except(*keys)
   end
 end
+
+module Kernel
+  # core/kernel/format_spec.rb: `format` is a strict alias of `sprintf`, both
+  # as the private instance method and as the module (singleton) method.
+  # monoruby registered them as separate builtins sharing one Rust fn (distinct
+  # FuncId), so re-point them as real aliases.
+  class << self
+    alias format sprintf
+  end
+  alias format sprintf
+
+  # core/kernel/respond_to_missing_spec.rb: the default
+  # `Kernel#respond_to_missing?` is a *private* instance method that returns
+  # false (and is therefore not a module/singleton method). monoruby handled the
+  # protocol internally without defining the method, so define the default here.
+  private def respond_to_missing?(name, include_all = false)
+    false
+  end
+end

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -4124,6 +4124,46 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn clone_freeze_coverage() {
+        // Kernel#clone `freeze:` keyword: forced frozen state, ArgumentError on
+        // a bad value, and `freeze: nil` inheriting the original's state.
+        run_test_once(
+            r##"(o=Object.new; a=o.clone(freeze: true).frozen?; b=(x="s".freeze; x.clone(freeze: false).frozen?); c=(begin; o.clone(freeze: 1); rescue => e; e.class; end); d=o.clone(freeze: nil).frozen?; e2=("f".freeze.clone(freeze: nil).frozen?); [a,b,c,d,e2])"##,
+        );
+        // `freeze:` is forwarded to #initialize_clone as a keyword argument.
+        run_test_once(
+            r##"(class KC; def initialize_clone(orig, **kw); $rec=kw; super(orig); end; end; obj=KC.new; obj.clone(freeze: true); r1=($rec == {freeze: true}); class KC2; def initialize_clone(orig); super; end; end; r2=(begin; KC2.new.clone(freeze: true); rescue => e; e.class; end); [r1, r2])"##,
+        );
+    }
+
+    #[test]
+    fn method_callee_coverage() {
+        // __method__/__callee__ inside a define_method body, through send, and
+        // in a normal method; nil outside any method.
+        run_test_once(
+            r##"(class MC; define_method(:dm){ [__method__, __callee__] }; def from_send; send "__method__"; end; def normal; __method__; end; end; o=MC.new; [o.dm, o.from_send, o.normal, (__method__)])"##,
+        );
+    }
+
+    #[test]
+    fn loop_coverage() {
+        // No-block Enumerator (infinite size) and rescue of StopIteration
+        // subclasses / a finished iterator.
+        run_test_once(
+            r##"(a=loop.instance_of?(Enumerator); b=(loop.size == Float::INFINITY); sub=Class.new(StopIteration); c=(loop{ raise sub }; :done); e=[1,2].each; d=(loop{ e.next }; :finished); [a,b,c,d])"##,
+        );
+    }
+
+    #[test]
+    fn format_alias_coverage() {
+        // format/sprintf alias identity (instance + module method) and the
+        // private default respond_to_missing?.
+        run_test_once(
+            r##"(a=Kernel.instance_method(:format)==Kernel.instance_method(:sprintf); b=Kernel.method(:format)==Kernel.method(:sprintf); c=Kernel.private_method_defined?(:respond_to_missing?); e2=format("%03d", 7); [a,b,c,e2])"##,
+        );
+    }
+
+    #[test]
     fn caller_start_length_and_range() {
         // `caller(start, length)` and `caller(range)`. Assert via sizes and
         // booleans so the result is independent of file paths / the toplevel

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2562,8 +2562,26 @@ fn dir_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/__method__.html]
 #[monoruby_builtin]
 fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let fid = vm.cfp().prev().unwrap().method_func_id();
-    if !globals.store[fid].is_method() {
+    // Skip native (builtin) caller frames such as `send`/`__send__`/
+    // `public_send` so that `send("__method__")` reports the Ruby method that
+    // invoked `send`, not `send` itself.
+    let mut cfp = vm.cfp().prev();
+    while let Some(f) = cfp {
+        if !f.lfp().meta().is_native() {
+            break;
+        }
+        cfp = f.prev();
+    }
+    let Some(caller) = cfp else {
+        return Ok(Value::nil());
+    };
+    let outer = caller.outermost_lfp();
+    let fid = outer.func_id();
+    // `__method__` yields nil outside of a method body. A `define_method`
+    // body is a Proc-typed function (not `FuncType::Method`) but runs in a
+    // frame tagged `proc_method` and carries the installed method name, so
+    // accept those too.
+    if !globals.store[fid].is_method() && !outer.meta().is_proc_method() {
         return Ok(Value::nil());
     }
     globals.store[fid]

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -214,7 +214,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "hash", hash, 0);
     globals.define_builtin_func(kernel_class, "eql?", eql_, 1);
     globals.define_builtin_func(kernel_class, "dup", dup, 0);
-    globals.define_builtin_func_with(kernel_class, "clone", clone_val, 0, 1, false);
+    globals.define_builtin_func_with_kw(kernel_class, "clone", clone_val, 0, 0, false, &["freeze"], false);
     let init_copy_fid =
         globals.define_private_builtin_func(kernel_class, "initialize_copy", initialize_copy, 1);
     let init_clone_fid =
@@ -3210,33 +3210,60 @@ fn clone_val(
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-    let copy = self_val.clone_value();
+    // `freeze:` keyword (slot 0): `None` = not passed, `Some(v)` = passed
+    // (including `Some(nil)`). Only nil / true / false are accepted.
+    let freeze_arg = lfp.try_arg(0);
+    if let Some(v) = freeze_arg {
+        if !(v.is_nil() || v == Value::bool(true) || v == Value::bool(false)) {
+            return Err(MonorubyErr::argumenterr(format!(
+                "unexpected value for freeze: {}",
+                v.get_real_class_name(&globals.store)
+            )));
+        }
+    }
+    // `freeze: true`  -> copy is frozen; `freeze: false` -> copy is not frozen;
+    // `freeze: nil` / omitted -> copy inherits the original's frozen state
+    // (which `clone_value` already carried over).
+    let target_frozen = match freeze_arg {
+        Some(v) if v == Value::bool(true) => true,
+        Some(v) if v == Value::bool(false) => false,
+        _ => self_val.is_frozen(),
+    };
+
+    let mut copy = self_val.clone_value();
     copy_finalizers(globals, self_val.id(), copy.id());
     if self_val.is_class_or_module().is_some() {
         return Ok(copy);
     }
-    // Skip the no-op copy-hook dispatch when the class uses the default
-    // hooks (see `dup` / `uses_default_copy_hooks`).
+    // Keep the copy mutable while the copy hook runs (CRuby freezes only
+    // afterwards), so a hook may still initialise a to-be-frozen copy.
+    copy.clear_frozen();
+
+    // Skip the no-op copy-hook dispatch when the class uses the default hooks
+    // (see `dup` / `uses_default_copy_hooks`).
     let version = Globals::class_version();
-    if globals
-        .store
-        .uses_default_copy_hooks(copy.class(), version)
-    {
-        return Ok(copy);
+    if !globals.store.uses_default_copy_hooks(copy.class(), version) {
+        // Run the `initialize_clone` hook. When `freeze:` was passed explicitly,
+        // forward it as a keyword argument (matching CRuby), so a hook that does
+        // not accept keywords raises ArgumentError. Root `copy` across the
+        // dispatch (it allocates).
+        let temp = vm.temp_len();
+        vm.temp_push(copy);
+        let kw = if let Some(v) = freeze_arg {
+            let mut map = RubyMap::default();
+            map.insert(Value::symbol(IdentId::get_id("freeze")), v, vm, globals)?;
+            Some(Hashmap::new(Value::hash(map)))
+        } else {
+            None
+        };
+        vm.invoke_method_inner(globals, IdentId::INITIALIZE_CLONE, copy, &[self_val], None, kw)?;
+        vm.temp_clear(temp);
     }
-    // Run the `initialize_clone` hook (default validates; a subclass may
-    // override it). Root `copy` across the dispatch (it allocates).
-    let temp = vm.temp_len();
-    vm.temp_push(copy);
-    vm.invoke_method_inner(
-        globals,
-        IdentId::INITIALIZE_CLONE,
-        copy,
-        &[self_val],
-        None,
-        None,
-    )?;
-    vm.temp_clear(temp);
+    // Packed immediates (Integer/Symbol/true/…) are always frozen and have no
+    // mutable header, so only real heap values need the frozen flag applied.
+    if target_frozen && !copy.is_packed_value() {
+        copy.set_frozen();
+    }
     Ok(copy)
 }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -628,12 +628,19 @@ fn binding(vm: &mut Executor, _: &mut Globals, _: Lfp, pc: BytecodePtr) -> Resul
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/loop.html]
 #[monoruby_builtin]
-fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let bh = lfp.expect_block()?;
+fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let Some(bh) = lfp.block() else {
+        // No block: return an infinite Enumerator (size == Float::INFINITY).
+        let method = IdentId::get_id("loop");
+        let size = Value::float(f64::INFINITY);
+        return vm.generate_enumerator_with_size(method, lfp.self_val(), vec![], pc, Some(size));
+    };
     let data = vm.get_block_data(globals, bh)?;
     loop {
         if let Err(err) = vm.invoke_block(globals, &data, &[]) {
-            return if err.kind() == &MonorubyErrKind::StopIteration {
+            // `loop` swallows StopIteration and any user subclass of it, and
+            // re-raises everything else (including control-flow signals).
+            return if err.is_stop_iteration(&globals.store) {
                 Ok(Value::nil())
             } else {
                 Err(err)

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -223,6 +223,29 @@ impl MonorubyErr {
         .to_string()
     }
 
+    /// Whether this error is a `StopIteration` (or a subclass of it). Returns
+    /// `false` for the internal control-flow kinds (`return`/`throw`/`retry`/
+    /// `redo`), which have no exception class. Used by `Kernel#loop`, which
+    /// terminates on `StopIteration` and any user subclass of it.
+    pub fn is_stop_iteration(&self, store: &Store) -> bool {
+        match &self.kind {
+            MonorubyErrKind::MethodReturn(..)
+            | MonorubyErrKind::Throw(..)
+            | MonorubyErrKind::Retry
+            | MonorubyErrKind::Redo => false,
+            _ => {
+                let mut module = Some(store[self.class_id()].get_module());
+                while let Some(m) = module {
+                    if m.id() == STOP_ITERATION_CLASS {
+                        return true;
+                    }
+                    module = m.superclass();
+                }
+                false
+            }
+        }
+    }
+
     pub fn class_id(&self) -> ClassId {
         match &self.kind {
             MonorubyErrKind::Exception => EXCEPTION_CLASS,

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -582,6 +582,14 @@ impl Value {
         self.rvalue_mut().set_frozen()
     }
 
+    /// Clear the frozen flag on `self` (used by `clone(freeze: false)`).
+    /// No-op for packed values, which are always frozen.
+    pub(crate) fn clear_frozen(&mut self) {
+        if !self.is_packed_value() {
+            self.rvalue_mut().clear_frozen()
+        }
+    }
+
     ///
     /// Ensure `self` is not frozen. Returns FrozenError if it is.
     ///

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -969,6 +969,10 @@ impl RValue {
         self.header.set_frozen()
     }
 
+    pub(crate) fn clear_frozen(&mut self) {
+        self.header.clear_frozen()
+    }
+
     pub(crate) fn is_chilled(&self) -> bool {
         self.header.is_chilled()
     }
@@ -2279,6 +2283,10 @@ impl Header {
 
     fn set_frozen(&mut self) {
         unsafe { self.meta.flag |= 0b10 }
+    }
+
+    fn clear_frozen(&mut self) {
+        unsafe { self.meta.flag &= !0b10 }
     }
 
     ///


### PR DESCRIPTION
## Summary

Improves `core/kernel` ruby/spec pass rate by fixing several tractable, self-contained failures. ~19 examples across 6 Kernel methods now pass that previously failed.

### `Kernel#clone` with `freeze:` (7 failures)
`clone` ignored the `freeze:` keyword entirely. It now:
- forces the copy's frozen state for `freeze: true`/`false` (independent of the original), inherits it for `freeze: nil`/omitted, and raises `ArgumentError` for any other value;
- forwards `freeze:` to `#initialize_clone` as a keyword argument (so a hook that doesn't accept it raises), keeping the copy mutable while the hook runs and freezing only afterwards, matching CRuby.

Adds `Value::clear_frozen` (guarded for packed immediates, which are always frozen).

### `Kernel#__method__` / `#__callee__` (7 failures)
Returned `nil` inside a `define_method` body (its function is `Proc`-typed, so the old `FuncType::Method` guard rejected it) and returned `:send` for `send("__method__")` (the caller frame was the native `send` builtin). Now accepts proc-method frames (which carry the installed name) and skips native caller frames to report the innermost Ruby method.

### `Kernel#loop` (2 failures)
Without a block, returns an infinite `Enumerator` (`size == Float::INFINITY`) instead of raising; terminates on any subclass of `StopIteration`, not just `StopIteration` itself (new subclass-aware `MonorubyErr::is_stop_iteration` that leaves control-flow signals untouched).

### `Kernel#format` / `#respond_to_missing?` (3 failures)
`format`/`Kernel.format` are now true aliases of `sprintf` (identity), and the default private `Kernel#respond_to_missing?` (returning false) is defined so it reports as a private instance method.

## Testing
- Added `run_test_once` unit tests (verified against CRuby 4.0.2) for every new Rust path: clone `freeze:`, `__method__`/`__callee__`, `loop`, and the format alias.
- Per-spec confirmation: `clone` 7→0, `format` 2→0, `__method__` 3→0, `__callee__` 5→1, `loop` (1F+3E)→(1F+1E), `respond_to_missing?` 2→1.
- Regression-checked `object`, `array`, `string`, `hash`, `set`, `comparable`, `basicobject`, `method`, `unboundmethod` — all unchanged (clone/dup/method are used broadly).

Reference: CRuby 4.0.2 (vendored `.ruby-version` pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_