### PR TITLE
sprintf/printf/String#%: result encoding, '#' flag on zero, $VERBOSE warning

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -6091,6 +6091,16 @@ mod tests {
     }
 
     #[test]
+    fn sprintf_encoding_error_and_debug() {
+        // Incompatible non-ASCII encodings raise Encoding::CompatibilityError;
+        // a non-String format operand is coerced via #to_str; excess positional
+        // args raise ArgumentError under $DEBUG.
+        run_test_once(
+            r##"[ (begin; format("hello %s".encode("utf-8"), "world".encode("UTF-16LE")); rescue => e; e.class; end), (o=Object.new; def o.to_str; "%d!"; end; format(o, 5)), (old=$DEBUG; $DEBUG=true; r=(begin; format("test", 1); rescue => e; e.class; end); $DEBUG=old; r) ]"##,
+        );
+    }
+
+    #[test]
     fn sprintf_hash_flag_zero_precision() {
         // `#` on b/B/x/X does nothing for a zero argument with zero precision.
         run_test(

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -835,10 +835,40 @@ fn format(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     if args.is_empty() {
         return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
     }
-    let fmt = args[0].coerce_to_str(vm, globals)?;
+    let fmt_val = args[0];
+    let fmt = fmt_val.coerce_to_str(vm, globals)?;
     let arguments = &args[1..];
     let result = vm.format_by_args(globals, &fmt, arguments)?;
-    Ok(Value::string(result))
+    // Negotiate the result encoding across the format String and every String
+    // argument (matching String#%): the compatible union wins (so the format's
+    // encoding is preserved, or widened to an argument's), and two
+    // ASCII-incompatible non-ASCII encodings raise Encoding::CompatibilityError.
+    if let Some(fmt_inner) = fmt_val.is_rstring_inner() {
+        let mut result_inner = fmt_inner.clone();
+        for v in arguments {
+            if let Some(arg_inner) = v.is_rstring_inner() {
+                match result_inner.compatible_encoding(arg_inner) {
+                    Some(combined) if combined != result_inner.encoding() => {
+                        result_inner.set_encoding(combined);
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(MonorubyErr::incompatible_encoding(
+                            &globals.store,
+                            result_inner.encoding(),
+                            arg_inner.encoding(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(Value::string_from_inner(RStringInner::from_encoding_scanned(
+            result.as_bytes(),
+            result_inner.encoding(),
+        )))
+    } else {
+        Ok(Value::string(result))
+    }
 }
 
 ///
@@ -6048,6 +6078,31 @@ mod tests {
               def to_str; "num: %d"; end
             end
             "#,
+        );
+    }
+
+    #[test]
+    fn sprintf_result_encoding() {
+        // The result keeps the format String's encoding, widening to an
+        // argument's when the format encoding is more restrictive.
+        run_test_once(
+            r##"(a=format('%s'.encode(Encoding::US_ASCII), 'foobar').encoding.name; b=format('%s'.encode(Encoding::UTF_8), 'x').encoding.name; arg=[98,195,188,114].pack("C*").force_encoding(Encoding::UTF_8); c=("foo %s".dup.force_encoding(Encoding::US_ASCII) % arg).encoding.name; [a,b,c])"##,
+        );
+    }
+
+    #[test]
+    fn sprintf_hash_flag_zero_precision() {
+        // `#` on b/B/x/X does nothing for a zero argument with zero precision.
+        run_test(
+            r##"[sprintf('%#.0b',0), sprintf('%#.0B',0), sprintf('%#.0x',0), sprintf('%#.0X',0), sprintf('%#b',0), sprintf('%#b',5), sprintf('%#x',255)]"##,
+        );
+    }
+
+    #[test]
+    fn sprintf_verbose_too_many_arguments() {
+        // With $VERBOSE, excess positional args warn to $stderr.
+        run_test_once(
+            r##"(require "stringio"; old=$VERBOSE; $VERBOSE=true; s1=StringIO.new; $stderr=s1; format("test",1); w=s1.string; $stderr=STDERR; $VERBOSE=old; w.include?("too many arguments for format string"))"##,
         );
     }
 

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -1120,7 +1120,10 @@ impl Executor {
                         }
                     } else {
                         let digits = apply_int_precision(&pos_digits.unwrap(), precision);
-                        let is_zero = digits == "0";
+                        // `apply_int_precision("0", Some(0))` is "" — so an
+                        // empty result is also "zero", and the `#` prefix is
+                        // suppressed (`"%#.0b" % 0 == ""`).
+                        let is_zero = digits.is_empty() || digits == "0";
                         let prefix = if hash_flag && !is_zero {
                             if ch == 'B' { "0B" } else { "0b" }
                         } else {
@@ -1225,7 +1228,10 @@ impl Executor {
                         }
                     } else {
                         let digits = apply_int_precision(&pos_digits.unwrap(), precision);
-                        let is_zero = digits == "0";
+                        // See the `%b` branch: precision 0 with value 0 gives
+                        // "", which is still "zero" and suppresses the prefix
+                        // (`"%#.0x" % 0 == ""`).
+                        let is_zero = digits.is_empty() || digits == "0";
                         let prefix = if hash_flag && !is_zero {
                             if upper { "0X" } else { "0x" }
                         } else {
@@ -1342,18 +1348,34 @@ impl Executor {
             format_str += &format;
         }
 
-        // With `$DEBUG` enabled, CRuby raises when sequential
-        // (unnumbered) formatting leaves arguments unused.
-        if !used_numbered
-            && !used_named
-            && arg_no < arguments.len()
-            && globals
+        // Sequential (unnumbered) formatting that leaves positional arguments
+        // unused: `$DEBUG` raises, and `$VERBOSE` warns (to `$stderr`, so
+        // captured by ruby/spec's `complain`). A trailing keyword Hash is the
+        // named-reference source, not a positional argument, so exclude it —
+        // `format("test", k: 1)` must not warn.
+        let positional_len = if arguments
+            .last()
+            .is_some_and(|v| v.try_hash_ty().is_some())
+        {
+            arguments.len() - 1
+        } else {
+            arguments.len()
+        };
+        if !used_numbered && !used_named && arg_no < positional_len {
+            if globals
                 .get_gvar(IdentId::get_id("$DEBUG"))
                 .is_some_and(|v| v.as_bool())
-        {
-            return Err(MonorubyErr::argumenterr(
-                "too many arguments for format string",
-            ));
+            {
+                return Err(MonorubyErr::argumenterr(
+                    "too many arguments for format string",
+                ));
+            }
+            if globals
+                .get_gvar(IdentId::get_id("$VERBOSE"))
+                .is_some_and(|v| v.as_bool())
+            {
+                self.ruby_warn(globals, "warning: too many arguments for format string")?;
+            }
         }
 
         Ok(format_str)


### PR DESCRIPTION
## Summary

Fixes the tractable slice of the `sprintf`/`printf`/`String#%` failures (the shared format engine), covering the ones that are **not** blocked by monoruby's limited encoding set. **~12 examples fixed** across `core/kernel/sprintf`, `core/kernel/printf`, and `core/string/modulo`.

### Result encoding negotiation for `Kernel#sprintf`/`format`
The engine built a Rust `String` and returned `Value::string` (always UTF‑8), ignoring the format String's encoding. `Kernel#format` now negotiates the result encoding across the format String and its String arguments — the same logic `String#%` already had: the compatible union wins (so `'%s'.encode(US_ASCII)` yields `US-ASCII`, widening to an argument's encoding when the format is more restrictive), and two ASCII‑incompatible non‑ASCII encodings raise `Encoding::CompatibilityError`.

### `#` flag on `%b/%B/%x/%X` with a zero argument + zero precision
`apply_int_precision("0", 0)` is `""`, but the "is this zero?" check only compared against `"0"`, so the `0b`/`0x` prefix was wrongly emitted (`"%#.0b" % 0` gave `"0b"`). An empty result now also counts as zero → `""`, matching CRuby.

### `$VERBOSE` "too many arguments" warning
Leftover *positional* arguments now warn (`"too many arguments for format string"`) when `$VERBOSE` is true, routed through the Ruby `$stderr` object so ruby/spec's `complain` matcher captures it (monoruby previously only raised under `$DEBUG`). A trailing keyword `Hash` is excluded, so `format("test", k: 1)` doesn't warn.

## Scope note
The remaining `sprintf`/`%` encoding failures (`same encoding as format` with KOI8‑U, `CompatibilityError` with windows‑125x, and the `%c` codepoint cases) are **blocked** by monoruby not implementing those encodings (`force_encoding("KOI8-U")` degrades to BINARY) and lacking codepoint→arbitrary‑encoding transcoding (`9415601.chr(Encoding::EUC_JP)` raises) — a separate, larger effort, intentionally out of scope here.

## Testing
- Per-spec: **printf 6→0, sprintf 8→5, modulo 8→5** failures.
- `core/string` overall 187→184 failures (0 error change); 33 format-related cargo unit tests pass; added `run_test` cases for result encoding, the `#`/zero-precision branch, and the `$VERBOSE` warning.

Reference: CRuby 4.0.2 (vendored `.ruby-version` pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_