### PR TITLE
Marshal: dump class/module names with multibyte characters

### DIFF
--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -1776,9 +1776,21 @@ fn marshal_dump_value(
                         }
                         let tag = if is_module { b'm' } else { b'c' };
                         let name_bytes = class_name.as_bytes();
+                        // A name with non-ASCII (UTF-8) bytes is wrapped in
+                        // an 'I' block recording its encoding, like a
+                        // String/Symbol.
+                        let ascii = name_bytes.iter().all(|&b| b < 0x80);
+                        if !ascii {
+                            buf.push(b'I');
+                        }
                         buf.push(tag);
                         marshal_write_fixnum(buf, name_bytes.len() as i32);
                         buf.extend_from_slice(name_bytes);
+                        if !ascii {
+                            marshal_write_fixnum(buf, 1);
+                            marshal_write_symbol(buf, IdentId::get_id("E"), symbols);
+                            buf.push(b'T'); // class names are UTF-8
+                        }
                     }
                     Some(ObjTy::RANGE) => {
                         // Serialize Range as a generic 'o' object with the
@@ -3055,6 +3067,30 @@ mod tests {
             r#"
             dump = "\x04\b[\aI:\t\xE2\x82\xACa\x06:\x06ETI:\t\xE2\x82\xACb\x06;\x06T".b
             Marshal.load(dump).map { |s| [s.to_s, s.encoding.to_s] }
+            "#,
+        );
+    }
+
+    #[test]
+    fn marshal_multibyte_class_name() {
+        // A class/module whose name has non-ASCII bytes is dumped with an
+        // 'I' encoding wrapper (`I c … :E T`) and round-trips.
+        run_test(
+            r#"
+            module MBSpec; end
+            name = "WideあClass"
+            MBSpec.const_set(name, Class.new)
+            k = MBSpec.const_get(name)
+            Marshal.dump(k).bytes
+            "#,
+        );
+        run_test(
+            r#"
+            module MBSpec2; end
+            name = "Wideあmod"
+            MBSpec2.const_set(name, Module.new)
+            m = MBSpec2.const_get(name)
+            Marshal.load(Marshal.dump(m)).equal?(m)
             "#,
         );
     }

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -3072,6 +3072,29 @@ mod tests {
     }
 
     #[test]
+    fn marshal_load_malformed() {
+        // Reader error paths: unsupported tag, truncated data, wrong
+        // version header, bad symbol/object back-references.
+        run_test_error(r#"Marshal.load("\x04\bx".b)"#);
+        run_test_error(r#"Marshal.load("\x04".b)"#);
+        run_test_error(r#"Marshal.load("\x03\bi\x06".b)"#);
+        run_test_error(r#"Marshal.load("\x04\b;\x00".b)"#);
+        run_test_error(r#"Marshal.load("\x04\b@\x00".b)"#);
+    }
+
+    #[test]
+    fn marshal_numeric_edges() {
+        // Float special values and a large Bignum round-trip.
+        run_test(r#"Marshal.load(Marshal.dump(Float::INFINITY)) == Float::INFINITY"#);
+        run_test(r#"Marshal.load(Marshal.dump(-Float::INFINITY)) == -Float::INFINITY"#);
+        run_test(r#"Marshal.load(Marshal.dump(Float::NAN)).nan?"#);
+        run_test(r#"Marshal.load(Marshal.dump(0.0)) == 0.0"#);
+        run_test(r#"Marshal.load(Marshal.dump(-0.0)).to_s"#);
+        run_test(r#"Marshal.load(Marshal.dump(10 ** 100)) == 10 ** 100"#);
+        run_test(r#"Marshal.load(Marshal.dump(-(2 ** 80))) == -(2 ** 80)"#);
+    }
+
+    #[test]
     fn marshal_multibyte_class_name() {
         // A class/module whose name has non-ASCII bytes is dumped with an
         // 'I' encoding wrapper (`I c … :E T`) and round-trips.


### PR DESCRIPTION
## Summary

Continues `core/marshal` ruby/spec conformance (follow-up to #780–#783). A class or module whose qualified name contains non-ASCII (UTF-8) bytes is now dumped with an `I` encoding wrapper (`I c … 1 ivar :E T`), like a String or Symbol; ASCII names stay a bare `c`/`m`. The load path already resolves the UTF-8 name through the ivar-wrapped class-reference reader, so such classes/modules round-trip.

Takes the `core/marshal` spec suite from **44 → 41 failures (3 fixed, 0 regressions)** — the class, module, and Time-subclass multibyte-name cases. All byte formats verified against CRuby 4.0.2; full `cargo test --lib` (1765 tests) passes.

## Testing

- Added a unit test covering multibyte class/module name dump bytes and round-trip.
- `cargo test --lib`: 1765 passed, 0 failed.
- `core/marshal` ruby/spec: 44 → 41 failures, no regressions.

## Remaining (follow-up — larger infrastructure)

The remaining `core/marshal` failures need more than incremental fixes:
- **Time zone/offset** (~7) — monoruby's `Time` is `Utc | Local(FixedOffset)` and does **not** track zone *names* (a local time's `#zone` is always `nil`), and `_dump`/`_load` lose the offset (a local time reloads in the system TZ). Matching CRuby needs zone-name tracking and offset-preserving reconstruction on load.
- **IO / StringIO readers** — `Marshal.load` from an IO-like source (needed for the EOFError and StringIO specs).
- **`singleton can't be dumped`**, a couple of `#_dump`/`#marshal_dump` + link + proc edge cases, and specs whose hard-coded expectations predate the CRuby 4.0 marshal format (e.g. Exception message encoding — monoruby already matches real CRuby 4.0 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_