### PR TITLE
Elide redundant fixnum guards in the local GP allocator

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -501,8 +501,8 @@ impl AbstractFrame {
         // divide-by-zero side-exit (Mul `sarq`s it; Div's idiv sequence too).
         let rhs_clobbered = matches!(kind, BinOpK::Mul | BinOpK::Div);
         // 1. Load the operands into registers (reusing a resident copy).
-        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
-        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        let (lhs_gp, lhs_guard) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_guard) = self.gp_ensure(ir, rhs, &[lhs_gp]);
         // 1b. For `Mul`/`Div`: if `rhs` is a dirty resident, write it to its home
         //     and mark it clean *before* the deopt snapshot. The op clobbers
         //     `rhs_gp` before the side-exit, so the snapshot must re-home `rhs`
@@ -549,16 +549,15 @@ impl AbstractFrame {
         if let Some((reg, slot)) = spill {
             ir.reg2stack(reg, slot);
         }
-        // A `fresh` operand is only speculatively an integer (the resident is a
-        // general `Value`, or it was just loaded from its home), so guard it; the
-        // guard then *proves* it a fixnum, so refine its abstract type in place
-        // (keeping the resident) — a later integer op on the same slot reuses it
-        // guard-free via `is_fixnum`.
-        if lhs_fresh {
+        // An operand not yet proven a fixnum is only speculatively an integer,
+        // so guard it; the guard then *proves* it a fixnum, so refine its
+        // abstract type in place (keeping the resident) — a later integer op on
+        // the same slot consumes it guard-free via `is_fixnum`, resident or not.
+        if lhs_guard {
             ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
             self.refine_S_fixnum(lhs);
         }
-        if rhs_fresh {
+        if rhs_guard {
             ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
             self.refine_S_fixnum(rhs);
         }
@@ -575,9 +574,13 @@ impl AbstractFrame {
         }
     }
 
-    /// Bring `slot` into a GP register: reuse its resident copy (returning
-    /// `fresh = false`, no reload/guard) or materialize it to its stack home,
-    /// load it, and report `fresh = true` so the caller emits the fixnum guard.
+    /// Bring `slot` into a GP register, reusing its resident copy when present
+    /// (no reload) and otherwise materializing it to its stack home and loading
+    /// it. The returned bool asks the caller to emit a fixnum guard; it is
+    /// decided by the slot's abstract type (`is_fixnum`), never by residency —
+    /// a reloaded slot that an earlier guard/def already proved a fixnum (e.g.
+    /// an evicted binop result) is consumed guard-free, exactly like a resident
+    /// one.
     fn gp_ensure(&mut self, ir: &mut AsmIr, slot: SlotId, pinned: &[GP]) -> (GP, bool) {
         if let Some(gp) = self.gp_regfile.reg_of(slot) {
             // Reuse the resident copy. Whether it needs a fixnum class guard is
@@ -591,8 +594,7 @@ impl AbstractFrame {
         // Compile-time fixnum constant: load the tagged immediate straight into a
         // register, skipping the stack-home round-trip (`%1 = %2 + 1` loads `1`
         // as `movabs gp, 0x3` rather than materializing it to a slot and reading
-        // it back). The value is a known fixnum, so it needs no guard — report
-        // `fresh = false`.
+        // it back). The value is a known fixnum, so it needs no guard.
         if let Some(v) = self.fixnum_literal_value(slot) {
             let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
             if let Some((reg, s)) = spill {
@@ -610,10 +612,12 @@ impl AbstractFrame {
             ir.reg2stack(reg, s);
         }
         ir.stack2reg(slot, gp);
-        // `fresh = true`: the caller emits a fixnum guard, after which this
-        // resident is a known fixnum.
         self.gp_regfile.bind(gp, slot, /* dirty */ false);
-        (gp, true)
+        // Guard iff the slot is not already a proven fixnum — the same criterion
+        // as the resident path above. An `S(Fixnum)` slot's stack home always
+        // holds the proven-fixnum value, so reloading it (after an eviction or
+        // a flush) needs no re-guard.
+        (gp, !self.is_fixnum(slot))
     }
 
     /// prepare the GP register file for a float op that keeps
@@ -702,8 +706,8 @@ impl AbstractFrame {
         lhs: SlotId,
         rhs: SlotId,
     ) {
-        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
-        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        let (lhs_gp, lhs_guard) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_guard) = self.gp_ensure(ir, rhs, &[lhs_gp]);
         // Snapshot the deopt write-back before clearing (the guards side-exit to
         // a point where the interpreter re-reads the operands from their homes).
         let deopt = ir.new_deopt(self);
@@ -715,11 +719,16 @@ impl AbstractFrame {
         // their registers.
         let next_sp = self.next_sp();
         self.gp_regfile.free_above_sp(next_sp);
-        if lhs_fresh {
+        // Guard-then-refine, as in `binop_integer_gp`: the guard proves the
+        // operand a fixnum, so record that on the slot and later integer ops
+        // consume it guard-free.
+        if lhs_guard {
             ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
+            self.refine_S_fixnum(lhs);
         }
-        if rhs_fresh {
+        if rhs_guard {
             ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
+            self.refine_S_fixnum(rhs);
         }
         ir.integer_cmp_reg(kind, dst, lhs_gp, rhs_gp);
         if let Some(dst) = dst {
@@ -763,16 +772,21 @@ impl AbstractFrame {
         brkind: BrKind,
         branch_dest: JitLabel,
     ) {
-        let (lhs_gp, lhs_fresh) = self.gp_ensure(ir, lhs, &[]);
-        let (rhs_gp, rhs_fresh) = self.gp_ensure(ir, rhs, &[lhs_gp]);
+        let (lhs_gp, lhs_guard) = self.gp_ensure(ir, lhs, &[]);
+        let (rhs_gp, rhs_guard) = self.gp_ensure(ir, rhs, &[lhs_gp]);
         // Snapshot the deopt write-back before the flush/branch (the guards
         // side-exit to a point where the interpreter re-reads the operands).
         let deopt = ir.new_deopt(self);
-        if lhs_fresh {
+        // Guard-then-refine, as in `binop_integer_gp`. The refinement is
+        // recorded on the slot (not the register file), so it survives the
+        // block-terminator flush below and propagates to the successor blocks.
+        if lhs_guard {
             ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
+            self.refine_S_fixnum(lhs);
         }
-        if rhs_fresh {
+        if rhs_guard {
             ir.push(AsmInst::GuardClass(rhs_gp, INTEGER_CLASS, deopt));
+            self.refine_S_fixnum(rhs);
         }
         // Block terminator: spill the dirty residents to their stack homes before
         // the branch (the operands' registers still hold their values for the

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -1,10 +1,14 @@
-//! Per-basic-block **local GP register allocator** (Layer-② first cut).
+//! Per-basic-block **local GP register allocator** (Layer-②).
 //!
-//! This is the first slice of the register-allocation pass discussed in
-//! `doc/regalloc_separation.md` §3: a *local* (single basic block) allocator
-//! that scans the typed IR and assigns physical GP registers to the fixnum
-//! binop operands and results, **reusing** a register across instructions when
-//! a slot it already caches is read again. For
+//! The register-allocation pass discussed in `doc/regalloc_separation.md` §3:
+//! a *local* (single basic block) allocator that assigns physical GP registers
+//! to fixnum operands and results, **reusing** a register across instructions
+//! when a slot it already caches is read again. The GP-aware operations that
+//! drive it online are the integer binops (`binop_integer_gp`), the integer
+//! compares / compare-branches (`gen_cmp_integer_gp` / `gen_cmpbr_integer`),
+//! call/yield-result parking (`def_rax2gp`) and concrete-literal defs
+//! (`def_lit2gp`); generic slot reads and write-backs consult the residents,
+//! and dirty residents are threaded into deopt / GC write-backs. For
 //!
 //! ```text
 //! %1 = %2 + %3
@@ -39,16 +43,18 @@
 //!
 //! The register file is reset at basic-block entry and *flushed* — every dirty
 //! resident spilled to its stack home — at the block boundary and before any
-//! non-binop operation, so the rest of codegen always observes a slot in its
-//! canonical stack home. Being strictly per-block and never part of a
+//! non-GP-aware operation, so the rest of codegen always observes a slot in
+//! its canonical stack home. Being strictly per-block and never part of a
 //! cross-block merge, it avoids the loop-back-edge placement coupling that made
 //! the old analysis-fused `LinkMode::G` load-bearing (doc §13.8).
 //!
-//! This module is the **pure allocator**: it consumes a list of binop records
-//! (each tagged with the post-instruction `next_sp`) and produces a list of
-//! [`GpAction`]s. It is codegen-independent and unit-tested in isolation;
-//! wiring the actions into the AsmIR→LIR lowering (and threading dirty
-//! residents into the deopt write-back) is the next step.
+//! This module holds the register file ([`GpRegFile`], driven online by the
+//! codegen paths above) plus a **pure reference allocator** ([`allocate_run`]):
+//! the latter consumes a list of binop records (each tagged with the
+//! post-instruction `next_sp`), produces a list of [`GpAction`]s, and is
+//! unit-tested in isolation. Unlike the online driver it does not model the
+//! slot-side abstract types, so it guards every fresh load; the online driver
+//! keys guards off `is_fixnum(slot)` instead (see `gp_ensure`).
 
 use crate::bytecodegen::BinOpK;
 use crate::codegen::GP;
@@ -80,8 +86,10 @@ pub(in crate::codegen::jitgen) struct BinOpInst {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(in crate::codegen::jitgen) enum GpAction {
     /// Load `slot` from its stack home into `reg`. `guard` requests a fixnum
-    /// type guard (needed for a value freshly read from the stack; a value
-    /// produced by a prior binop is already a known fixnum and skips it).
+    /// type guard. In this pure reference every fresh stack read is guarded;
+    /// the online driver (`gp_ensure`) instead decides the guard from the
+    /// slot's abstract type (`is_fixnum`), so a slot a prior guard/def already
+    /// proved a fixnum reloads guard-free.
     Load { slot: SlotId, reg: GP, guard: bool },
     /// `dst = lhs <kind> rhs`, all three already in registers. The overflow /
     /// type side-exit is the consumer's responsibility (it is a deopt point).
@@ -115,9 +123,11 @@ struct Holder {
 /// `FprAllocator`.
 ///
 /// Held in the abstract state and driven online during the basic-block walk:
-/// `IntegerBinOp` reuses/allocates registers through it, while every other
-/// instruction calls [`Self::take_dirty_spills`] up front to flush the live GP
-/// residents back to their stack homes (only `IntegerBinOp` is GP-aware so far).
+/// the GP-aware operations (integer binops, integer compares/compare-branches,
+/// call/yield-result parking, concrete-literal defs) reuse/allocate registers
+/// through it, while every other instruction flushes the live GP residents
+/// back to their stack homes up front (via `flush_gp` →
+/// [`Self::take_dirty_spills`]).
 ///
 /// It is flushed empty at every basic-block boundary, so although it rides
 /// inside the cloned/merged `SlotState` it never actually carries state across a

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -443,11 +443,14 @@ impl AbstractFrame {
 
     /// Flush the per-block local GP register file (the local GP allocator): spill every
     /// dirty resident to its stack home and clear the file. Called up front by
-    /// every non-`IntegerBinOp` instruction — only that op is GP-aware so far —
-    /// and at block boundaries, so the rest of codegen always observes a slot in
-    /// its canonical stack home. A no-op when the file is empty (the default
-    /// build never populates it, and even with the feature on most instructions
-    /// see an empty file), so the emitted code is unchanged there.
+    /// every instruction that is not GP-aware, and at block boundaries, so the
+    /// rest of codegen always observes a slot in its canonical stack home. The
+    /// GP-aware operations that keep the file live across instructions are the
+    /// integer binops (`binop_integer_gp`), the integer compares /
+    /// compare-branches (`gen_cmp_integer_gp` / `gen_cmpbr_integer`),
+    /// call/yield-result parking (`def_rax2gp`) and concrete-literal defs
+    /// (`def_lit2gp`); generic slot reads and write-backs consult the residents
+    /// without flushing. A no-op when the file is empty.
     pub(in crate::codegen::jitgen) fn flush_gp(&mut self, ir: &mut AsmIr) {
         if self.gp_regfile.is_empty() {
             return;


### PR DESCRIPTION
## Summary

Guard necessity is the slot's abstract type (`Guarded`), not residency — but two paths in the local GP allocator ignored the slot-side information and emitted redundant fixnum guards:

1. **`gp_ensure`'s reload path always guarded.** A slot already proven `Fixnum` (e.g. a binop result evicted by pool pressure or by a pre-call flush) was re-guarded with `test reg,0x1; je deopt` on every reload. The reload path now keys the guard off `is_fixnum(slot)`, the same criterion the resident-reuse path already used. This is sound because an `S(Fixnum)` slot's stack home always holds the proven-fixnum value. Since the returned bool now means "needs a guard" rather than "freshly loaded", `lhs_fresh`/`rhs_fresh` are renamed to `lhs_guard`/`rhs_guard`.

2. **Integer compares never recorded what their guards proved.** `gen_cmp_integer_gp` / `gen_cmpbr_integer` emitted fixnum guards but did not call `refine_S_fixnum`, so a fact proven by a comparison was lost and later ops re-guarded the same slot. They now refine after the guard, as `binop_integer_gp` already did. For the compare-branch the refinement is slot-side state, so it survives the block-terminator flush and propagates to both successor blocks.

## Observed effect (emit-asm)

- An evicted-then-reloaded binop result no longer re-emits its guard (verified with 5 live results vs. the 4-register pool, single block, no calls).
- A proven fixnum reloaded after a method-call flush is consumed guard-free.
- In a `while i < n` loop body, the guard on `i` (proved by the loop-head compare) disappears. The guards remaining at the loop head are sound-required: partial (loop) compiles start from unproven VM state.

## Doc updates

The `gp_alloc.rs` module header, `GpAction::Load` / `GpRegFile` docs, and `flush_gp`'s doc comment still described the "first cut" where only `IntegerBinOp` was GP-aware and the file was never populated by default. They now list the actual GP-aware operations (integer binops, integer compares / compare-branches, call/yield-result parking, concrete-literal defs) and mark `allocate_run` as the unit-tested pure reference.

## Testing

- `cargo test` (full suite) passes.
- Emitted-assembly inspection of the three cases above, before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XwuKBUyUfUvZa2JpqRxX9

---
_Generated by [Claude Code](https://claude.ai/code/session_016XwuKBUyUfUvZa2JpqRxX9)_