### PR TITLE
Data: keyword initializer, argument validation, deconstruct_keys

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1522,39 +1522,165 @@ TOPLEVEL_BINDING = binding
 
 require_relative 'comparable'
 
-# Minimal Data class (Ruby 3.2+). Modeled on Struct but conceptually
-# immutable. Full semantics (keyword-only initializer, with-method, frozen
-# instances) are not yet implemented; this is enough for fixtures that
-# reference `Data.define`.
+# Data class (Ruby 3.2+): immutable value objects with a keyword-based
+# initializer. Built on top of Struct for storage, attribute readers,
+# equality, hashing and inspection; the keyword initializer, argument
+# validation, `new`/`[]` positional-to-keyword coercion, frozen instances
+# and `with` are layered on here.
 class Data
   def self.define(*members, &block)
-    members = members.map { |m| m.is_a?(String) ? m.to_sym : m }
+    members = members.map do |m|
+      case m
+      when Symbol then m
+      when String then m.to_sym
+      else raise TypeError, "#{m} is not a symbol"
+      end
+    end
     klass = ::Struct.new(*members)
-    # CRuby renders `Data` instances as `#<data ...>` rather than
-    # `#<struct ...>`. Reuse Struct's (correct) inspect — which already
-    # handles qualified/anonymous class names and bypasses an overridden
-    # `#name` — and only relabel the prefix.
     klass.class_eval do
+      # CRuby renders `Data` instances as `#<data ...>` rather than
+      # `#<struct ...>`. Reuse Struct's (correct) inspect — which already
+      # handles qualified/anonymous class names and bypasses an overridden
+      # `#name` — and only relabel the prefix.
       def inspect
         ::Struct.instance_method(:inspect).bind(self).call.sub(/\A#<struct/, '#<data')
       end
       alias_method :to_s, :inspect
 
-      # Returns a copy with the given members replaced. Does not go
-      # through `self.class.new` (CRuby allocates + initializes directly).
+      # The keyword initializer is layered in a module so a user-defined
+      # `initialize` (from the `define` block) can `super` into it.
+      include(::Module.new do
+        def initialize(*args, **kw)
+          ms = self.class.members
+          kw = ::Hash[ms.zip(args)].merge(kw) unless args.empty?
+          values = ::Data.__data_values(ms, kw)
+          super(*values)
+          freeze
+        end
+      end)
+
+      # `new` / `[]` accept positional *or* keyword arguments; positional
+      # ones are zipped onto the members, then `initialize` (possibly
+      # user-overridden) is dispatched with keywords.
+      def self.new(*args, **kw)
+        ::Data.__data_alloc_init(self, args, kw)
+      end
+      class << self
+        alias_method :[], :new
+      end
+
+      # Returns a frozen copy with the given members replaced. Allocates
+      # and initializes directly rather than going through `new`, matching
+      # CRuby (a redefined `new` must not affect `with`).
       def with(**kw)
         return self if kw.empty?
-        kw = kw.map { |k, v| [k.is_a?(String) ? k.to_sym : k, v] }.to_h
-        ms = self.class.members
-        merged = to_h.merge(kw)
+        norm = {}
+        kw.each { |k, v| norm[k.is_a?(::String) ? k.to_sym : k] = v }
         copy = self.class.allocate
-        copy.send(:initialize, *ms.map { |m| merged[m] })
-        copy.freeze
+        copy.send(:initialize, **to_h.merge(norm))
         copy
+      end
+
+      # `deconstruct_keys(keys)` for pattern matching: `nil` returns all
+      # members; otherwise the requested keys (Symbol / String / `#to_str`)
+      # are looked up, stopping at the first non-member.
+      def deconstruct_keys(keys)
+        return to_h if keys.nil?
+        unless keys.is_a?(::Array)
+          raise TypeError, "wrong argument type #{keys.class} (expected Array or nil)"
+        end
+        ms = self.class.members
+        return {} if keys.size > ms.size
+        result = {}
+        keys.each do |k|
+          sym, rkey =
+            case k
+            when ::Symbol then [k, k]
+            when ::String then [k.to_sym, k]
+            else
+              if k.respond_to?(:to_str)
+                s = k.to_str
+                unless s.is_a?(::String)
+                  raise TypeError, "can't convert #{k.class} into String"
+                end
+                [s.to_sym, s]
+              else
+                raise TypeError, "#{k} is not a symbol nor a string"
+              end
+            end
+          break unless ms.include?(sym)
+          result[rkey] = send(sym)
+        end
+        result
       end
     end
     klass.class_eval(&block) if block
     klass
+  end
+
+  # The base initializer, reachable as `Data.instance_method(:initialize)`
+  # (used by e.g. marshalling libraries to populate an allocated instance).
+  def initialize(**kw)
+    ms = self.class.members
+    values = ::Data.__data_values(ms, kw)
+    ms.each_with_index { |m, i| send("#{m}=", values[i]) }
+    freeze
+  end
+
+  def self.__data_alloc_init(klass, args, kw)
+    ms = klass.members
+    unless args.empty?
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)" unless kw.empty?
+      unless args.size == ms.size
+        raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)"
+      end
+      kw = ::Hash[ms.zip(args)]
+    end
+    obj = klass.allocate
+    obj.send(:initialize, **kw)
+    obj
+  end
+
+  # Validate `kw` against `members` (converting String / `#to_str` keys to
+  # Symbols) and return the member values in declaration order.
+  def self.__data_values(members, kw)
+    norm = {}
+    unknown = []
+    kw.each do |k, v|
+      key, disp = __data_key(k)
+      if members.include?(key)
+        norm[key] = v
+      else
+        unknown << disp
+      end
+    end
+    missing = members.reject { |m| norm.key?(m) }
+    unless missing.empty?
+      s = missing.size == 1 ? "" : "s"
+      raise ArgumentError, "missing keyword#{s}: #{missing.map { |m| ":#{m}" }.join(", ")}"
+    end
+    unless unknown.empty?
+      s = unknown.size == 1 ? "" : "s"
+      raise ArgumentError, "unknown keyword#{s}: #{unknown.join(", ")}"
+    end
+    members.map { |m| norm[m] }
+  end
+
+  # Normalize a keyword key to `[symbol, display]`, where `display` is how
+  # the key appears in an "unknown keyword" message (`:sym` / `"str"`).
+  def self.__data_key(k)
+    case k
+    when Symbol then [k, ":#{k}"]
+    when String then [k.to_sym, k.inspect]
+    else
+      if k.respond_to?(:to_str)
+        s = k.to_str
+        raise TypeError, "can't convert #{k.class} into String" unless s.is_a?(String)
+        [s.to_sym, s.inspect]
+      else
+        raise TypeError, "#{k} is not a symbol nor a string"
+      end
+    end
   end
 end unless defined?(::Data)
 

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -1808,4 +1808,41 @@ mod tests {
         run_test_with_prelude(r#"M.new(1, "m").with("amount" => 9).to_h"#, prelude);
         run_test_with_prelude(r#"M.new(1, "m").with(amount: 9).frozen?"#, prelude);
     }
+
+    #[test]
+    fn data_initialize_keywords() {
+        let prelude = r#"M = Data.define(:amount, :unit)"#;
+        // Positional, keyword, String-keyword, and `[]` construction.
+        run_test_with_prelude(r#"M.new(42, "km").to_h"#, prelude);
+        run_test_with_prelude(r#"M.new(amount: 42, unit: "km").to_h"#, prelude);
+        run_test_with_prelude(r#"M.new("amount" => 42, "unit" => "km").to_h"#, prelude);
+        run_test_with_prelude(r#"M[42, "km"].to_h"#, prelude);
+        run_test_with_prelude(r#"M.new(42, "km", **{}).to_h"#, prelude);
+        run_test_with_prelude(r#"M.new(42, "km").frozen?"#, prelude);
+        // A String and Symbol key for the same member: the last wins.
+        run_test_with_prelude(r#"M.new("amount" => 1, amount: 9, unit: "m").amount"#, prelude);
+        // An overridden initialize is called with keyword arguments even
+        // for positional construction, and can `super`.
+        run_test(
+            r#"
+            D = Data.define(:a, :b) do
+              def initialize(*rest, **kw); super; $log = [rest, kw]; end
+            end
+            D.new(1, 2)
+            $log
+            "#,
+        );
+        // deconstruct_keys with Symbol / String / nil keys.
+        run_test_with_prelude(r#"M.new(1, "m").deconstruct_keys([:amount])"#, prelude);
+        run_test_with_prelude(r#"M.new(1, "m").deconstruct_keys(["amount"])"#, prelude);
+        run_test_with_prelude(r#"M.new(1, "m").deconstruct_keys(nil)"#, prelude);
+        run_test_with_prelude(r#"M.new(1, "m").deconstruct_keys([:amount, :x, :unit])"#, prelude);
+        // Argument-validation errors.
+        run_test_with_prelude(r#"begin; M.new; rescue ArgumentError => e; e.message; end"#, prelude);
+        run_test_with_prelude(r#"begin; M.new(unit: "km"); rescue ArgumentError => e; e.message; end"#, prelude);
+        run_test_with_prelude(
+            r#"begin; M.new(amount: 1, unit: "m", system: "x"); rescue ArgumentError => e; e.message; end"#,
+            prelude,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fleshes out monoruby's minimal `Data` class (built on `Struct`) into the real Ruby 3.2+ value-object semantics.

Takes `core/data` from **20 failures + 2 errors → 2 failures + 1 error (19 fixed, 0 regressions)**.

## What changed

- **Keyword initializer / construction.** `Data.define(...).new` and `.[]` accept positional *or* keyword arguments; positional ones are zipped onto the members, and `initialize` is always dispatched with **keywords** — so a user-overridden `initialize` (from the `define` block) receives keyword arguments and can `super` into the base initializer. Instances are frozen.
- **Argument validation.** The base initializer validates its keywords against the members, accepting String / `#to_str` keys, and raises CRuby's messages: `missing keyword(s): :a, :b`, `unknown keyword(s): :x` / `"x"`, `X is not a symbol nor a string`, `can't convert X into String`. `Data#initialize` is defined on `Data` itself so it is reachable via `Data.instance_method(:initialize)`.
- **`#with`** allocates and initializes directly (a redefined `new` must not affect it).
- **`#deconstruct_keys`** handles Symbol / String / `#to_str` keys, the non-Array argument error, and the count / first-miss rules.

## Testing

- Added `data_initialize_keywords` (positional/keyword/String-keyword/`[]` construction, frozen, last-key-wins, overridden-initialize-gets-keywords-and-supers, `deconstruct_keys`, and the missing/unknown-keyword messages).
- `core/data` ruby/spec: 20→2 failures, 2→1 errors.

## Remaining (out of scope / follow-up)

- Recursive `#to_s` (the self-referential attribute should render as `...`) needs an inspect recursion guard.
- `Data.instance_method(:initialize).bind_call(instance, …)` — monoruby's `Data.define` returns a `Struct` subclass (not a `Data` subclass), so binding `Data`'s instance method to it is rejected; making instances `is_a?(Data)` is a larger structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_