### PR TITLE
defined?: frozen result string, ||= / &&= "assignment", pseudo-vars

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1145,6 +1145,17 @@ impl<'a> BytecodeGen<'a> {
         self.emit_literal(dst, Value::string_from_source_str(&s, enc));
     }
 
+    /// Emit a shared, frozen string literal (e.g. the result of
+    /// `defined?`, which CRuby returns as a frozen String). Unlike
+    /// `emit_string` this does not deep-copy on each execution.
+    pub(crate) fn emit_frozen_string(&mut self, dst: BcReg, s: &str) {
+        let enc = self.source_encoding();
+        let mut v = Value::string_from_source_str(s, enc);
+        v.set_frozen();
+        self.iseq_mut().literals.push(v);
+        self.emit(BytecodeInst::FrozenLiteral(dst, v), Loc::default());
+    }
+
     fn emit_bytes(&mut self, dst: BcReg, b: Vec<u8>) {
         // `NodeKind::Bytes` comes from source literals containing `\xNN`
         // escapes. Tag with the file's `# encoding:` magic-comment value

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -21,7 +21,8 @@ impl<'a> BytecodeGen<'a> {
             }
             _ => {
                 let res = defined_str(&node);
-                self.emit_string(dst, res.to_string());
+                // CRuby returns a frozen String from `defined?`.
+                self.emit_frozen_string(dst, res);
                 let exit_label = self.new_label();
                 let nil_label = self.new_label();
                 self.check_defined(node, nil_label, dst, true)?;
@@ -135,6 +136,10 @@ impl<'a> BytecodeGen<'a> {
                 self.check_defined(r, nil_label, ret, false)?;
             }
             NodeKind::Ident(name) => {
+                // `__ENCODING__` is a pseudo-variable, always defined.
+                if name == "__ENCODING__" {
+                    return Ok(());
+                }
                 let name = IdentId::get_id_from_string(name);
                 self.emit(
                     BytecodeInst::DefinedMethod {
@@ -336,10 +341,23 @@ fn defined_str(node: &Node) -> &'static str {
         NodeKind::LocalVar(..) => "local-variable",
         NodeKind::InstanceVar(..) => "instance-variable",
         NodeKind::GlobalVar(..) => "global-variable",
-        NodeKind::ClassVar(..) => "class-variable",
+        // CRuby uses a space (not a hyphen) for class variables.
+        NodeKind::ClassVar(..) => "class variable",
         NodeKind::Const { .. } => "constant",
-        // `&&` / `||` are expressions, not method calls.
-        NodeKind::BinOp(BinOp::LAnd | BinOp::LOr, ..) => "expression",
+        // `target ||= value` / `&&=` desugar to
+        // `BinOp(LOr/LAnd, target, MulAssign([target], [value]))`;
+        // `defined?` reports these as "assignment". A plain `a || b`
+        // (RHS is not an inline assignment) stays "expression".
+        NodeKind::BinOp(BinOp::LAnd | BinOp::LOr, _, r) => {
+            if matches!(r.kind, NodeKind::MulAssign(..)) {
+                "assignment"
+            } else {
+                "expression"
+            }
+        }
+        // `__ENCODING__` is a pseudo-variable (parsed as a bare Ident),
+        // not a method call.
+        NodeKind::Ident(name) if name == "__ENCODING__" => "expression",
         NodeKind::BinOp(..)
         | NodeKind::FuncCall { .. }
         | NodeKind::MethodCall { .. }
@@ -374,5 +392,41 @@ mod tests {
         run_test(r#"defined?(1 =~ 2).inspect"#);
         run_test(r#"defined?(1 !~ 2)"#);
         run_test(r#"defined?(undef_x =~ /a/).inspect"#);
+    }
+
+    #[test]
+    fn defined_frozen_and_assignment() {
+        // `defined?` returns a frozen String.
+        run_tests(&[
+            r#"defined?(self)"#,
+            r#"defined?(self).frozen?"#,
+            r#"defined?(nil).frozen?"#,
+            r#"defined?(true)"#,
+            r#"defined?(false)"#,
+            r#"defined?([Object, Array])"#,
+            r#"defined?([Object, Array]).frozen?"#,
+            r#"$g = 5; [defined?($g), defined?($g).frozen?]"#,
+            r#"$n = nil; defined?($n)"#,
+            r#"defined?(__ENCODING__)"#,
+            // `||=` / `&&=` are "assignment" for every target kind.
+            r#"x = 1; defined?(x ||= 2)"#,
+            r#"x = 1; defined?(x &&= 2)"#,
+            r#"@i = 1; defined?(@i ||= 2)"#,
+            r#"$g2 = 1; defined?($g2 ||= 2)"#,
+            r#"a = [0]; defined?(a[0] ||= 2)"#,
+            // A plain `a || b` stays "expression".
+            r#"a = 1; b = 2; defined?(a || b)"#,
+        ]);
+        // Class variables report "class variable" (a space, not a hyphen),
+        // frozen.
+        run_test(
+            r#"
+            class DefCV
+              @@v = 1
+              def t; [defined?(@@v), defined?(@@v).frozen?]; end
+            end
+            DefCV.new.t
+            "#,
+        );
     }
 }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1293,13 +1293,20 @@ pub(super) extern "C" fn defined_const(
 ///
 /// Set `dst`` to `nil` if not exists.
 ///
+/// `defined?` returns a frozen String — build one for the runtime checks.
+fn defined_frozen_str(s: &str) -> Value {
+    let mut v = Value::string_from_str(s);
+    v.set_frozen();
+    v
+}
+
 pub(super) extern "C" fn defined_gvar(
     vm: &mut Executor,
     globals: &mut Globals,
     name: IdentId,
 ) -> Value {
     if GvarTable::defined_runtime(vm, globals, name) {
-        Value::string_from_str("global-variable")
+        defined_frozen_str("global-variable")
     } else {
         Value::nil()
     }
@@ -1311,7 +1318,7 @@ pub(super) extern "C" fn defined_cvar(
     name: IdentId,
 ) -> Value {
     if vm.find_class_variable(globals, name).is_ok() {
-        Value::string_from_str("class variable")
+        defined_frozen_str("class variable")
     } else {
         Value::nil()
     }
@@ -1353,7 +1360,7 @@ pub(super) extern "C" fn defined_super(vm: &mut Executor, globals: &mut Globals)
     let name = globals.store[func_id].name().unwrap();
     let self_class = self_val.class();
     if globals.check_super(self_class, func_id, name).is_some() {
-        Value::string_from_str("super")
+        defined_frozen_str("super")
     } else {
         Value::nil()
     }
@@ -1366,7 +1373,7 @@ pub(super) extern "C" fn defined_super(vm: &mut Executor, globals: &mut Globals)
 ///
 pub(super) extern "C" fn defined_yield(vm: &mut Executor, _globals: &mut Globals) -> Value {
     if vm.cfp().block_given() {
-        Value::string_from_str("yield")
+        defined_frozen_str("yield")
     } else {
         Value::nil()
     }


### PR DESCRIPTION
## Summary

Brings the `defined?` keyword closer to CRuby.

Takes `language/defined_spec` from **43 → 12 failures (31 fixed, 0 regressions)**.

## What changed

- **Frozen result String.** `defined?` now returns a frozen String. Literal / expression results go through a new `emit_frozen_string`, and the runtime checks (`defined_gvar` / `defined_cvar` / `defined_super` / `defined_yield`) return frozen strings too (the ivar / method / const paths already keep the frozen placeholder). Many specs assert `defined?(x).frozen?`.
- **`||=` / `&&=` → "assignment".** These desugar to `BinOp(LOr/LAnd, target, MulAssign([target], [value]))`; `defined?` now reports `"assignment"` for every target kind (local / ivar / gvar / cvar / const / index / attr), while a plain `a || b` stays `"expression"`.
- **Class variables** report `"class variable"` — a space, matching CRuby's historical spelling (every other variable kind uses a hyphen).
- **`__ENCODING__`** (parsed as a bare Ident) reports `"expression"`, not `"method"`.

## Testing

- Added `defined_frozen_and_assignment` (frozen literal/gvar/cvar results, `||=`/`&&=` across target kinds, plain `||` staying "expression", `__ENCODING__`, and the `"class variable"` spelling) — all host-Ruby-version-stable.
- `language/defined_spec`: 43 → 12 failures.

## Remaining (out of scope / follow-up)

`respond_to_missing?` consultation, protected-method visibility, the void-context warning, `not` expressions, `$+` regexp globals, and the scoped-constant top-level-fallback edge are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_