### PR TITLE
defined?: respond_to_missing?, protected visibility, $+, scoped consts, not/!

### DIFF
--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -497,9 +497,53 @@ mod tests {
     }
 
     #[test]
+    fn defined_scoped_constant_resolution() {
+        // Qualified constants: direct, nested-qualifier walk, top-level
+        // qualified, and the negative paths (undefined leaf / undefined
+        // qualifier — the latter must not fire `const_missing`).
+        run_test(
+            r#"
+            module CovM
+              CONST = 1
+              module Inner; DEEP = 2; end
+            end
+            [
+              defined?(CovM::CONST),        # "constant"
+              defined?(CovM::Inner),        # "constant"
+              defined?(CovM::Inner::DEEP),  # "constant" (prefix walk)
+              defined?(CovM::Inner::Nope),  # nil
+              defined?(CovM::Missing::X),   # nil (undefined qualifier)
+              defined?(::CovM::CONST),      # "constant" (top-level qualified)
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn defined_method_negative_visibility_and_raising_respond_to_missing() {
+        // Private methods are not defined via an explicit receiver, an
+        // `undef`ined method is not defined, and an exception raised by
+        // `respond_to_missing?` is swallowed to nil (never propagated).
+        run_test(
+            r#"
+            class CovP; def pm; end; private :pm; end
+            class CovU; def m; end; undef_method :m; end
+            class CovR; def respond_to_missing?(n, i); raise "boom"; end; end
+            [
+              defined?(CovP.new.pm),   # private via explicit recv => nil
+              defined?(CovU.new.m),    # undef'd => nil
+              defined?(CovR.new.x),    # respond_to_missing? raises => nil
+            ]
+            "#,
+        );
+    }
+
+    #[test]
     fn defined_last_paren_match_and_not_operator() {
         // `$+` is the last non-empty captured group.
         run_test(r#""mis-matched" =~ /s(-)m(.)/; [defined?($+), $+]"#);
+        // A match with no capture groups leaves `$+` undefined.
+        run_test(r#""abc" =~ /b/; [defined?($+), $+]"#);
         // `defined?(not X)` / `defined?(!X)` evaluate a method operand as
         // the operator's receiver — executing its side effects and
         // reporting "method".
@@ -508,6 +552,15 @@ mod tests {
             $dlog = []
             def dse; $dlog << :se; 1; end
             [[defined?(not dse), defined?(!dse)], $dlog]
+            "#,
+        );
+        // When the evaluated operand raises, the exception is swallowed to
+        // nil, but its side effects still run.
+        run_test(
+            r#"
+            $clog = []
+            def craise; $clog << :r; raise "x"; end
+            [defined?(not craise), $clog]
             "#,
         );
     }

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -78,9 +78,45 @@ impl<'a> BytecodeGen<'a> {
                     self.check_defined(s, nil_label, ret, false)?;
                 }
             }
-            NodeKind::Splat(box n)
-            | NodeKind::Begin { body: box n, .. }
-            | NodeKind::UnOp(_, box n) => self.check_defined(n, nil_label, ret, false)?,
+            NodeKind::Splat(box n) | NodeKind::Begin { body: box n, .. } => {
+                self.check_defined(n, nil_label, ret, false)?
+            }
+            NodeKind::UnOp(_, box n) => {
+                // `defined?(not X)` / `defined?(!X)` / `defined?(-X)` parse
+                // the operator as a method call `X.op`. When the operand `X`
+                // is itself a method call, CRuby *evaluates* it (as the
+                // receiver of the operator) — executing its side effects and
+                // reporting "method", or swallowing any exception it raises
+                // to `nil`. A bare variable/const operand keeps the ordinary
+                // definedness recursion (an undefined operand ⇒ `nil`).
+                let evaluate_operand = top
+                    && matches!(
+                        n.kind,
+                        NodeKind::FuncCall { .. }
+                            | NodeKind::MethodCall { .. }
+                            | NodeKind::Index { .. }
+                            | NodeKind::BinOp(..)
+                            | NodeKind::UnOp(..)
+                    );
+                if evaluate_operand {
+                    let body_start = self.new_label();
+                    let body_end = self.new_label();
+                    self.apply_label(body_start);
+                    let _ = self.gen_temp_expr(n)?;
+                    self.apply_label(body_end);
+                    self.exception_table.push(ExceptionEntry {
+                        range: body_start..body_end,
+                        rescue: Some(nil_label),
+                        ensure: None,
+                        err_reg: None,
+                    });
+                    // `ret` already holds "method"; the operator method
+                    // (`!`, `-@`, …) is defined on every object, so there is
+                    // nothing more to check.
+                } else {
+                    self.check_defined(n, nil_label, ret, false)?;
+                }
+            }
             NodeKind::BinOp(op, box l, box r) => {
                 // `&&` / `||` (and `and`/`or`) are not method calls:
                 // CRuby `defined?(a && b)` is always "expression" and
@@ -426,6 +462,52 @@ mod tests {
               def t; [defined?(@@v), defined?(@@v).frozen?]; end
             end
             DefCV.new.t
+            "#,
+        );
+    }
+
+    #[test]
+    fn defined_method_respond_to_missing_and_protected() {
+        // `defined?(recv.meth)` consults `respond_to_missing?`, honours
+        // protected-method visibility (checked against the *defining*
+        // class), and a qualified constant does not fall through to a
+        // top-level constant.
+        run_test(
+            r#"
+            module DefM1; end
+            class DefR
+              def respond_to_missing?(name, inc); name == :foo; end
+            end
+            class DefPB
+              def m; end
+              protected :m
+              def chk(o); defined?(o.m); end
+            end
+            class DefPS < DefPB; end
+            [
+              defined?(DefR.new.foo),      # respond_to_missing? => "method"
+              defined?(DefR.new.bar),      # => nil
+              DefPB.new.chk(DefPS.new),    # protected, subclass recv => "method"
+              DefPB.new.chk(DefPB.new),    # protected, base recv => "method"
+              defined?(DefM1::String),     # no top-level fallback => nil
+              defined?(Integer::String),   # no top-level fallback => nil
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn defined_last_paren_match_and_not_operator() {
+        // `$+` is the last non-empty captured group.
+        run_test(r#""mis-matched" =~ /s(-)m(.)/; [defined?($+), $+]"#);
+        // `defined?(not X)` / `defined?(!X)` evaluate a method operand as
+        // the operator's receiver — executing its side effects and
+        // reporting "method".
+        run_test(
+            r#"
+            $dlog = []
+            def dse; $dlog << :se; 1; end
+            [[defined?(not dse), defined?(!dse)], $dlog]
             "#,
         );
     }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1343,10 +1343,52 @@ pub(super) extern "C" fn defined_method(
     recv: Value,
     name: IdentId,
 ) {
+    use crate::executor::Visibility;
     let is_func_call = vm.cfp().lfp().self_val() == recv;
-    if vm.find_method(globals, recv, name, is_func_call).is_err() {
-        unsafe { *reg = Value::nil() }
+    if let Some(entry) = globals.store.check_method_for_class(recv.class(), name) {
+        if entry.func_id().is_some() {
+            let visible = match entry.visibility() {
+                Visibility::Public => true,
+                // A private method counts as defined only through an
+                // implicit (function-call) receiver.
+                Visibility::Private => is_func_call,
+                // A protected method counts as defined when the caller's
+                // `self` is a kind of the class/module that *owns* the
+                // method — CRuby checks the defining class, not the
+                // receiver's class.
+                Visibility::Protected => {
+                    let caller_self = vm.cfp().lfp().self_val();
+                    caller_self.is_kind_of(&globals.store, entry.owner())
+                }
+                // An explicitly `undef`ined method is not defined.
+                Visibility::Undefined => false,
+            };
+            if visible {
+                return;
+            }
+        }
     }
+    // CRuby's `defined?(recv.meth)` also consults `respond_to_missing?`
+    // (with `include_private` = the func-call form). A truthy result
+    // reports the call as "method".
+    if let Some(fid) = globals.check_method(recv, IdentId::RESPOND_TO_MISSING_) {
+        match vm.invoke_func_inner(
+            globals,
+            fid,
+            recv,
+            &[Value::symbol(name), Value::bool(is_func_call)],
+            None,
+            None,
+        ) {
+            Ok(v) if v.as_bool() => return,
+            Ok(_) => {}
+            // `defined?` never propagates an exception; discard it.
+            Err(_) => {
+                let _ = vm.take_error();
+            }
+        }
+    }
+    unsafe { *reg = Value::nil() }
 }
 
 ///

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1382,9 +1382,13 @@ pub(super) extern "C" fn defined_method(
         ) {
             Ok(v) if v.as_bool() => return,
             Ok(_) => {}
-            // `defined?` never propagates an exception; discard it.
+            // `defined?` never propagates an exception raised by
+            // `respond_to_missing?`; discard it and report nil. The error
+            // is carried in the `Err` value (not the executor's slot), so
+            // use `discard_error` rather than `take_error` (which would
+            // unwrap an empty slot and panic).
             Err(_) => {
-                let _ = vm.take_error();
+                vm.discard_error();
             }
         }
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2653,6 +2653,23 @@ impl Executor {
         None
     }
 
+    /// `$+` reader — the last (highest-numbered) capture group that
+    /// actually matched, or `None` when there is no current match / no
+    /// group matched. Mirrors CRuby's `last_paren_match_getter`.
+    pub(crate) fn sp_last_paren_match(&self) -> Option<Value> {
+        let v = self.current_match_data()?;
+        let md = v.as_match_data();
+        let len = md.len();
+        // Walk the captures ($1..$N) from the end and return the last
+        // one that participated in the match.
+        for idx in (1..len).rev() {
+            if let Some(bytes) = md.at(idx) {
+                return Some(Value::string_from_str(&String::from_utf8_lossy(bytes)));
+            }
+        }
+        None
+    }
+
     /// `$~` reader — returns the MatchData `Value` from the current
     /// LEP, or `nil` if no match has been recorded in this scope.
     pub(crate) fn get_last_matchdata(&self) -> Value {

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -250,17 +250,63 @@ impl Executor {
         name: IdentId,
         current_func: FuncId,
     ) -> Result<Value> {
+        match self.search_constant_no_missing(globals, name, current_func)? {
+            Some(v) => Ok(v),
+            None => {
+                // CRuby invokes `const_missing` on the innermost lexical
+                // class when unqualified constant lookup fails; user-defined
+                // hooks (e.g. `Delegator.const_missing` delegating to
+                // `::Object.const_get`) can resolve the reference. The
+                // default `Module#const_missing` raises NameError,
+                // preserving the previous behaviour for classes without a
+                // custom hook.
+                let lexical_class = self.const_missing_lexical_class(globals, current_func);
+                let module = globals[lexical_class].get_module();
+                self.invoke_const_missing(globals, module, name)
+            }
+        }
+    }
+
+    /// Innermost lexical class used as the `const_missing` receiver when
+    /// unqualified lookup fails.
+    fn const_missing_lexical_class(
+        &mut self,
+        globals: &mut Globals,
+        current_func: FuncId,
+    ) -> ClassId {
+        let frame_func = self.cfp().lfp().func_id();
+        if frame_func != current_func {
+            let fc = frame_func.lexical_class(globals);
+            if fc != OBJECT_CLASS {
+                return fc;
+            }
+        }
+        current_func.lexical_class(globals)
+    }
+
+    /// The lexical + ancestor-chain resolution of an *unqualified* constant
+    /// reference, triggering autoload but **without** falling back to
+    /// `const_missing`. Returns `Ok(None)` when the constant simply does
+    /// not exist. Used both by [`Self::search_constant_checked`] (which then
+    /// invokes `const_missing`) and by `defined?`'s qualifier resolution
+    /// (which must not fire `const_missing`).
+    pub(super) fn search_constant_no_missing(
+        &mut self,
+        globals: &mut Globals,
+        name: IdentId,
+        current_func: FuncId,
+    ) -> Result<Option<Value>> {
         // Search the current frame's lexical_context first (covers string
         // eval where the eval's ISeqInfo has the receiver's class set).
         let frame_func = self.cfp().lfp().func_id();
         if frame_func != current_func {
             if let Some(v) = self.search_lexical_stack(globals, name, frame_func)? {
-                return Ok(v);
+                return Ok(Some(v));
             }
         }
         // Then search the enclosing method's lexical_context.
         if let Some(v) = self.search_lexical_stack(globals, name, current_func)? {
-            return Ok(v);
+            return Ok(Some(v));
         }
         // For superclass fallback, prefer the frame's lexical class if the
         // frame has its own lexical_context (i.e. string eval), otherwise
@@ -277,25 +323,19 @@ impl Executor {
         };
         let module = globals[lexical_class].get_module();
         match self.get_constant_superclass(globals, module, name)? {
-            Some(v) => return Ok(v),
+            Some(v) => return Ok(Some(v)),
             None => {
                 // Fall back to Object class, matching CRuby's implicit
                 // top-level cref.  This ensures that classes inheriting from
                 // BasicObject can still resolve top-level constants.
                 if lexical_class == BASIC_OBJECT_CLASS {
                     if let Some(v) = self.get_constant(globals, OBJECT_CLASS, name)? {
-                        return Ok(v);
+                        return Ok(Some(v));
                     }
                 }
             }
         }
-        // CRuby invokes `const_missing` on the innermost lexical class when
-        // unqualified constant lookup fails; user-defined hooks (e.g.
-        // `Delegator.const_missing` delegating to `::Object.const_get`) can
-        // resolve the reference. The default `Module#const_missing` raises
-        // NameError, preserving the previous behaviour for classes without
-        // a custom hook.
-        self.invoke_const_missing(globals, module, name)
+        Ok(None)
     }
 
     /// Non-triggering probe of a constant directly on `class_id` —
@@ -333,6 +373,37 @@ impl Executor {
     ) -> bool {
         loop {
             if Self::probe_constant_at(globals, module.id(), name) {
+                return true;
+            }
+            match module.superclass() {
+                Some(superclass) => module = superclass,
+                None => return false,
+            }
+        }
+    }
+
+    /// Non-triggering walk of the ancestor chain for the *final* segment
+    /// of a **qualified** reference (`A::B`). Unlike
+    /// [`Self::probe_constant_superclass`], the walk stops before Object
+    /// unless the qualifier itself is Object: a qualified reference does
+    /// not fall through to top-level constants (`defined?(Foo::String)` is
+    /// `nil` even though `String` is a top-level constant). Mirrors
+    /// CRuby's `rb_const_search` skipping `rb_cObject` for `klass != Object`.
+    pub(crate) fn probe_constant_superclass_qualified(
+        globals: &Globals,
+        module: Module,
+        name: IdentId,
+    ) -> bool {
+        let start = module.id();
+        let mut module = module;
+        loop {
+            let cid = module.id();
+            if cid == OBJECT_CLASS && start != OBJECT_CLASS {
+                // Reached Object via a qualified lookup: top-level
+                // constants are not visible here.
+                return false;
+            }
+            if Self::probe_constant_at(globals, cid, name) {
                 return true;
             }
             match module.superclass() {
@@ -447,15 +518,17 @@ impl Executor {
             }
             return false;
         } else {
-            // Resolve the leading qualifier with the normal triggering
-            // path; we need the actual class to walk further.
+            // Resolve the leading qualifier. `defined?` must not fire
+            // `const_missing` for an undefined qualifier (e.g.
+            // `defined?(Undefined::Object)` leaves `Object.const_missing`
+            // untouched), so use the no-missing search.
             let parent = prefix.remove(0);
-            match self.search_constant_checked(globals, parent, current_func) {
-                Ok(v) => match v.is_class_or_module() {
+            match self.search_constant_no_missing(globals, parent, current_func) {
+                Ok(Some(v)) => match v.is_class_or_module() {
                     Some(m) => m.id(),
                     None => return false,
                 },
-                Err(_) => return false,
+                Ok(None) | Err(_) => return false,
             }
         };
         let mut parent = parent;
@@ -472,7 +545,9 @@ impl Executor {
                 Err(_) => return false,
             }
         }
-        Self::probe_constant_superclass(globals, globals.store[parent].get_module(), name)
+        // Qualified final segment: does not fall through to top-level
+        // constants on Object (unless the qualifier is Object itself).
+        Self::probe_constant_superclass_qualified(globals, globals.store[parent].get_module(), name)
     }
 
     fn search_lexical_stack(

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -333,6 +333,14 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
         vm.sp_pre_match()
     }
 
+    fn get_last_paren_match(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        vm.sp_last_paren_match()
+    }
+
     /// `$1`, `$2`, ... — `name` is of the form `$n`. Strip the `$` and parse
     /// the decimal digits; any non-numeric suffix yields `None`.
     fn get_match_nth(
@@ -354,6 +362,8 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     globals.define_hooked_variable(IdentId::get_id("$&"), get_last_match, None);
     globals.define_hooked_variable(IdentId::get_id("$'"), get_post_match, None);
     globals.define_hooked_variable(IdentId::get_id("$`"), get_pre_match, None);
+    // `$+` — the last non-empty captured group of the current match.
+    globals.define_hooked_variable(IdentId::get_id("$+"), get_last_paren_match, None);
 
     // `$_` (last line read by `gets` / `readline`) is frame-local in
     // CRuby — it lives in `vm_svar.lastline` alongside `$~`. monoruby


### PR DESCRIPTION
## Summary

Continues the `language/defined_spec` work (previously 43→12 in #797). This
takes the file from **12 → 2 failures** by fixing five more clusters:

- **`respond_to_missing?`** — `defined?(recv.meth)` now consults
  `respond_to_missing?` when the method isn't found, reporting `"method"`
  on a truthy result (CRuby's `basic_obj_respond_to_missing`).
- **Protected visibility** — a protected method counts as defined when the
  caller's `self` is a kind of the class/module that *owns* the method
  (CRuby checks the **defining** class, not the receiver's class). Private
  methods still count only through an implicit (func-call) receiver.
- **`$+`** — the last non-empty captured group is now a hooked global
  variable (`Executor::sp_last_paren_match`), so it reads correctly and
  reports `"global-variable"` in `defined?`.
- **Scoped constants** — a qualified reference (`A::B`) no longer falls
  through to top-level constants on `Object`
  (`defined?(Foo::String)` ⇒ `nil`), and resolving an undefined leading
  qualifier (`defined?(Undefined::Object)`) no longer fires
  `const_missing`. Regular constant resolution is untouched.
- **`not` / `!` / unary ops** — `defined?(not X)` / `defined?(!X)` /
  `defined?(-X)` now evaluate a *method* operand as the operator's
  receiver: side effects run and the result is `"method"`, or a raised
  exception is swallowed to `nil`. A bare variable/const operand keeps the
  ordinary definedness recursion.

The two remaining `defined_spec` failures require void-context warning
support (`warning: possibly useless use of defined? in void context` and
not evaluating the receiver in void context), which is a separate parser
feature and out of scope here.

## Changes

- `codegen/runtime.rs` — rewrite `defined_method` (visibility rule +
  `respond_to_missing?` fallback; discards any error since `defined?`
  never propagates).
- `executor/constants.rs` — extract `search_constant_no_missing` (used by
  both `search_constant_checked` and `defined?`'s qualifier resolution),
  add `probe_constant_superclass_qualified` (stops at `Object` for
  qualified lookups), and use them in `probe_constant`.
- `executor.rs` + `globals/gvar.rs` — `sp_last_paren_match` and the `$+`
  hook registration.
- `bytecodegen/defined.rs` — evaluate method operands under unary
  operators; two new CRuby-verified unit tests.

## Testing

- `language/defined_spec`: 12 → 2 failures (remaining 2 are void-context).
- Two new unit tests (`defined_method_respond_to_missing_and_protected`,
  `defined_last_paren_match_and_not_operator`), each CRuby-verified.
- Full `cargo test --lib` failure count unchanged vs master (37 = 37,
  all pre-existing ruby-3.3.6-env discrepancies); `language/constants_spec`
  and `core/module/const_*` counts unchanged vs master — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_