### PR TITLE
Implement __ENCODING__ pseudo-variable

### DIFF
--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -1255,7 +1255,7 @@ pub(super) fn str_encoding(
 
 /// Map an `Encoding` to the corresponding `Encoding::<NAME>` Ruby
 /// constant name registered by `init_encoding`.
-pub(super) fn encoding_constant_name(enc: Encoding) -> &'static str {
+pub(crate) fn encoding_constant_name(enc: Encoding) -> &'static str {
     match enc {
         Encoding::Ascii8 => "ASCII_8BIT",
         Encoding::Utf8 => "UTF_8",

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1135,6 +1135,7 @@ impl<'a> BytecodeGen<'a> {
         }
     }
 
+
     fn emit_string(&mut self, dst: BcReg, s: String) {
         // String literals become long-lived templates: `Literal`
         // dispatch `deep_copy`s the template into a fresh RValue on

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -342,6 +342,9 @@ impl<'a> BytecodeGen<'a> {
                 | NodeKind::RImaginary(..)
                 | NodeKind::String(_)
                 | NodeKind::EncodedString(..) => return Ok(()),
+                // `__ENCODING__` is a pure pseudo-variable; in void
+                // context it has no effect.
+                NodeKind::Ident(name) if name == "__ENCODING__" => return Ok(()),
                 _ => {}
             }
         }
@@ -374,6 +377,23 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::GlobalVar(_) => {
                 let ret = self.push().into();
                 self.gen_store_expr(ret, expr)?;
+            }
+            // `__ENCODING__` — parsed as a bare `Ident`; evaluate to the
+            // source-encoding `Encoding` object. Load it as the constant
+            // `::Encoding::<NAME>` (rather than a baked literal) so it keeps
+            // object identity with the registered `Encoding` singleton.
+            NodeKind::Ident(method) if method == "__ENCODING__" => {
+                let ret = self.push().into();
+                let const_name =
+                    crate::builtins::encoding::encoding_constant_name(self.source_encoding());
+                self.emit_load_const(
+                    Some(ret),
+                    None,
+                    true,
+                    const_name.to_string(),
+                    vec!["Encoding".to_string()],
+                    loc,
+                );
             }
             NodeKind::BinOp(op, box lhs, box rhs) => {
                 self.gen_binop(op, lhs, rhs, use_mode, loc)?;
@@ -1447,5 +1467,20 @@ mod tests {
             c.new.respond_to?(:bar)
         "##,
         );
+    }
+
+    #[test]
+    fn source_encoding_pseudo_variable() {
+        // `__ENCODING__` evaluates to the source `Encoding` object (UTF-8
+        // for this harness), usable in every expression position.
+        run_test(r#"__ENCODING__.name"#);
+        run_test(r#"__ENCODING__.is_a?(Encoding)"#);
+        run_test(r#"x = __ENCODING__; x.name"#);
+        run_test(r#"[__ENCODING__].first.name"#);
+        run_test(r#"def f(e); e.name; end; f(__ENCODING__)"#);
+        // Identity: same object as the corresponding Encoding constant.
+        run_test(r#"__ENCODING__.equal?(Encoding::UTF_8)"#);
+        // Void context is a no-op.
+        run_test(r#"__ENCODING__; 42"#);
     }
 }


### PR DESCRIPTION
## Summary

`__ENCODING__` was parsed as a bare identifier and lowered to a method
call, so evaluating it raised `NoMethodError: undefined method
'__ENCODING__' for main`. This implements it as a real pseudo-variable.

In `bytecodegen`, an `Ident("__ENCODING__")` is now lowered to a load of
the source file's `Encoding` constant (`::Encoding::<NAME>`, where `<NAME>`
is derived from the file's source encoding). Using a constant load rather
than a baked literal keeps object **identity** with the registered
`Encoding` singleton (`__ENCODING__.equal?(Encoding::UTF_8)` is `true`).
In void context it is a no-op, and `defined?(__ENCODING__)` continues to
report `"expression"`.

## Context

This was surfaced while working the `language/magic_comment_spec` cluster:
the in-process scenarios (`load` / `require` / `eval`) all died on
`__ENCODING__` before this fix. The remaining failures in that spec file
require **Big5 source-encoding support** (monoruby's `Encoding` enum has no
Big5 variant, so a `# encoding: big5` file falls back to UTF-8) and the
`-r` / `-e` / stdin CLI options used by the subprocess-based scenarios —
both out of scope here.

## Changes

- `bytecodegen/expression.rs` — lower `__ENCODING__` to `::Encoding::<NAME>`
  in both the value and void-context paths.
- `bytecodegen.rs` — (no new state; uses the existing `source_encoding()`).
- `builtins/encoding.rs` — widen `encoding_constant_name` to `pub(crate)`
  so bytecodegen can map an `Encoding` to its constant name.

## Testing

- New unit test `source_encoding_pseudo_variable` (CRuby-verified): name,
  `is_a?(Encoding)`, assignment/array/argument positions, identity with
  `Encoding::UTF_8`, and void context.
- `defined?(__ENCODING__)` still returns `"expression"`.
- Full `cargo test --lib` passes (1784, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_