### PR TITLE
def: private lifecycle hooks, FrozenError, nested-def definee, arg messages

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -3086,6 +3086,75 @@ mod tests {
     }
 
     #[test]
+    fn def_forces_private_lifecycle_hooks() {
+        // `initialize`, `initialize_copy/dup/clone`, and
+        // `respond_to_missing?` are always private when defined via `def`.
+        run_test(
+            r#"
+            class DefLifecycle
+              def initialize; end
+              def initialize_copy(o); end
+              def respond_to_missing?(n, i); end
+            end
+            DefLifecycle.private_instance_methods(false).sort
+            "#,
+        );
+    }
+
+    #[test]
+    fn def_on_frozen_raises_frozen_error() {
+        // Defining a method on a frozen class / module / object raises
+        // FrozenError; nil/true/false still accept singleton methods.
+        run_test(
+            r#"
+            klass = Class.new; klass.freeze
+            r1 = begin; klass.class_eval { def a; end }; :no; rescue FrozenError; :frozen; end
+            o = Object.new; o.freeze
+            r2 = begin; def o.b; end; :no; rescue FrozenError; :frozen; end
+            def nil.gg; 1; end   # allowed despite nil being frozen
+            [r1, r2, nil.gg]
+            "#,
+        );
+    }
+
+    #[test]
+    fn nested_def_targets_owning_class() {
+        // A nested `def` inside a method body defines on the enclosing
+        // method's class and is public, whether that class comes from the
+        // `class` keyword or a dynamic `Class.new`/`class_exec` block.
+        run_test(
+            r#"
+            class NestOuter
+              def build; def built; 42; end; end
+            end
+            NestOuter.new.build
+            a = NestOuter.new.built                       # public, callable
+            cls = Class.new { def build2; def built2; 7; end; end }
+            cls.new.build2
+            b = cls.new.built2
+            c = begin; Object.new.built2; :no; rescue NoMethodError; :nme; end
+            [a, b, c]
+            "#,
+        );
+    }
+
+    #[test]
+    fn wrong_number_of_args_with_rest_uses_plus() {
+        // A method with an explicit `*rest` reports the required count with
+        // a `+` suffix; a private method called with an explicit receiver
+        // reports "private method … called".
+        run_test(
+            r#"
+            def rq(a, b, *c); end
+            m1 = begin; rq(1); rescue ArgumentError => e; e.message; end
+            class PrivRcv; private; def secret; end; end
+            m2 = begin; PrivRcv.new.secret; rescue NoMethodError => e; e.message.include?("private"); end
+            [m1, m2]
+            "#,
+        );
+    }
+
+    #[test]
     fn toplevel_private_public() {
         // Top-level `private`/`public`/`protected` target Object, and
         // Object's own private instance methods surface in

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -148,11 +148,24 @@ fn bo_method_missing(
 ) -> Result<Value> {
     let args = lfp.arg(0).as_array();
     let name = args[0].expect_symbol_or_string(globals)?;
-    Err(MonorubyErr::method_not_found(
-        &globals.store,
-        name,
-        lfp.self_val(),
-    ))
+    let recv = lfp.self_val();
+    // Reaching the default `method_missing` while the method actually
+    // exists means the call violated visibility (a private method called
+    // with an explicit receiver, or an inaccessible protected method).
+    // CRuby reports these as "private/protected method … called" rather
+    // than "undefined method".
+    use crate::executor::Visibility;
+    let err = match globals.store.check_method_for_class(recv.class(), name) {
+        Some(entry) if entry.func_id().is_some() => match entry.visibility() {
+            Visibility::Private => MonorubyErr::private_method_called(&globals.store, name, recv),
+            Visibility::Protected => {
+                MonorubyErr::protected_method_called(&globals.store, name, recv)
+            }
+            _ => MonorubyErr::method_not_found(&globals.store, name, recv),
+        },
+        _ => MonorubyErr::method_not_found(&globals.store, name, recv),
+    };
+    Err(err)
 }
 
 ///

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1185,6 +1185,16 @@ pub(super) extern "C" fn singleton_define_method(
         };
         globals.store[iseq].lexical_context = parent_ctx;
     }
+    // `def obj.foo` on a frozen object raises FrozenError — except for the
+    // special singletons nil / true / false, which accept singleton methods
+    // (they are defined on NilClass / TrueClass / FalseClass) despite being
+    // frozen.
+    if !obj.is_nil() && obj != Value::bool(true) && obj != Value::bool(false) {
+        if let Err(err) = obj.ensure_not_frozen(&globals.store) {
+            vm.set_error(err);
+            return None;
+        }
+    }
     let class_id = match obj.get_singleton(&mut globals.store) {
         Ok(val) => val.as_class_id(),
         Err(err) => {

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -559,10 +559,21 @@ fn wrong_number_of_arg_with_kw(
         .filter(|(i, _)| callee.kw_is_required(*i))
         .map(|(_, name)| name.to_string())
         .collect();
+    // An explicit `*rest` lifts the upper bound: CRuby reports the required
+    // count with a `+` suffix (`expected 2+`) rather than a bounded range.
+    // This branch is only reached for the too-few-args case (a too-many
+    // error is not raised when an explicit rest is present).
+    let has_rest = callee.is_explicit_rest();
     if required.is_empty() {
-        return MonorubyErr::wrong_number_of_arg_range(given, range);
+        return if has_rest {
+            MonorubyErr::wrong_number_of_arg_min(given, *range.start())
+        } else {
+            MonorubyErr::wrong_number_of_arg_range(given, range)
+        };
     }
-    let expected = if range.start() == range.end() {
+    let expected = if has_rest {
+        format!("{}+", range.start())
+    } else if range.start() == range.end() {
         format!("{}", range.start())
     } else {
         format!("{}..{}", range.start(), range.end())

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1519,6 +1519,14 @@ impl Executor {
         func: FuncId,
     ) -> Result<Value> {
         let cref = self.get_class_context();
+        // A `def` executed directly inside a *method* body is a nested
+        // definition: its default definee is the enclosing method's
+        // lexical class (not the runtime cref, which may be a caller's
+        // `instance_eval` / `class_eval` context leaking in through the
+        // shared cref stack), and its visibility resets to public. A `def`
+        // in any other frame (class/module body, `class_eval` /
+        // `instance_eval` block, or the top level) uses the runtime cref.
+        let in_method_body = globals.store[self.cfp().lfp().func_id()].is_method();
         let current_func = self.definition_func_id(globals);
         if let Some(iseq) = globals.store[func].is_iseq() {
             // Inherit the enclosing method's lexical context. The
@@ -1538,16 +1546,57 @@ impl Executor {
                 (func.get() as u64) + ((name.get() as u64) << 32)
             )));
         }
-        let class_id = match cref.context {
-            DefinitionContext::Class(class_id) => class_id,
-            DefinitionContext::Receiver(receiver) => globals.store.get_singleton(receiver)?.id(),
+        let class_id = if in_method_body {
+            // The definee is the class that owns the enclosing method
+            // (CRuby's method cref class). For a method defined via
+            // `Class.new do … end` / `class_exec` / `instance_eval` / an
+            // `eval`ed body this is the dynamic class, not the lexically
+            // enclosing scope — so prefer the owner, falling back to the
+            // lexical class only when no owner is recorded.
+            match globals.store[self.method_func_id()].owner_class().last() {
+                Some(&owner) => owner,
+                None => self.lexical_context_class_id(globals),
+            }
+        } else {
+            match cref.context {
+                DefinitionContext::Class(class_id) => class_id,
+                DefinitionContext::Receiver(receiver) => {
+                    globals.store.get_singleton(receiver)?.id()
+                }
+            }
         };
+        // Defining a method modifies the target class/module; a frozen one
+        // raises FrozenError. For a singleton class (`class << obj`), the
+        // attached object's frozen state is what matters.
+        let target = globals.store[class_id].get_module();
+        target.get().ensure_not_frozen(&globals.store)?;
+        if let Some(attached) = target.is_singleton() {
+            attached.ensure_not_frozen(&globals.store)?;
+        }
         Codegen::check_bop_redefine(self.cfp());
         if cref.module_function {
             self.add_method(globals, class_id, name, func, Visibility::Private)?;
             self.add_singleton_method(globals, class_id, name, func, cref.visibility)?;
         } else {
-            self.add_method(globals, class_id, name, func, cref.visibility)?;
+            // A nested `def` inside a method body resets the visibility to
+            // public (CRuby resets the def-visibility scope on method
+            // entry); every other frame keeps the current default (a
+            // class-body toggle, or the top-level `private` default).
+            let default_visibility = if in_method_body {
+                Visibility::Public
+            } else {
+                cref.visibility
+            };
+            // Object-lifecycle hooks (`initialize`, `initialize_copy`, …)
+            // and `respond_to_missing?` are always private when defined,
+            // regardless of the current default visibility (CRuby's
+            // `def` forces this via `rb_method_entry_make`).
+            let visibility = if crate::globals::method::is_always_private_method(name) {
+                Visibility::Private
+            } else {
+                default_visibility
+            };
+            self.add_method(globals, class_id, name, func, visibility)?;
         }
         Ok(Value::nil())
     }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -10,7 +10,7 @@ use super::*;
 mod dump;
 mod error;
 mod gvar;
-mod method;
+pub(crate) mod method;
 mod prng;
 mod require;
 mod store;

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -942,7 +942,7 @@ impl Globals {
 /// `initialize_dup`) and `respond_to_missing?`. The spec
 /// `Module#alias_method "aliasing special methods keeps … private"`
 /// exercises this for the alias path.
-fn is_always_private_method(name: IdentId) -> bool {
+pub(crate) fn is_always_private_method(name: IdentId) -> bool {
     name == IdentId::INITIALIZE
         || name == IdentId::INITIALIZE_COPY
         || name == IdentId::INITIALIZE_CLONE


### PR DESCRIPTION
## Summary

Fixes several `language/def_spec` failures (**23 → 7** for the file) across
four independent clusters:

- **Forced-private lifecycle hooks** — `def initialize` /
  `initialize_copy` / `initialize_dup` / `initialize_clone` /
  `respond_to_missing?` are now always private when defined, matching
  CRuby's `rb_method_entry_make`. Previously only the `alias` path forced
  this; the `def` path used the ambient default visibility.
- **FrozenError on definition** — defining a method on a frozen class /
  module / object (including through `class << obj`) now raises
  FrozenError. `nil` / `true` / `false` still accept singleton methods
  despite being frozen (they define on NilClass / TrueClass / FalseClass).
- **Nested-def definee + visibility** — a `def` inside a method body now
  targets the enclosing method's **owning class** (the class it was
  defined on — which for a `Class.new do … end` / `class_exec` /
  `instance_eval` / `eval` body is the dynamic class, not the lexical
  scope) and resets its visibility to public. This also stops a caller's
  `instance_eval` / `class_eval` context from leaking into a called
  method through the shared cref stack.
- **Argument / visibility error messages** — a method with an explicit
  `*rest` reports the required count with a `+` suffix (`expected 2+`)
  instead of a bounded range, and the default `method_missing` reports
  "private/protected method … called" rather than "undefined method" when
  the target exists but is not visible to the call.

## Remaining (out of scope)

Seven `def_spec` examples still fail: `FrozenError#receiver` (needs
exception-receiver support), a nested-singleton-class freeze edge case,
"extreme default argument" evaluation scope (2), one `def obj.method`
nested-definee nuance, and `eval`-defined-method visibility (2, definee is
already correct). Each needs a separate, more involved change.

## Changes

- `executor.rs` — nested-def definee (owner-based) + visibility reset +
  instance-method FrozenError check.
- `codegen/runtime.rs` — singleton-def FrozenError check (excluding
  nil/true/false).
- `globals/method.rs`, `globals.rs` — expose `is_always_private_method`;
  apply it on the `def` path.
- `codegen/runtime/args.rs` — `expected N+` for explicit-rest arity errors.
- `builtins/object.rs` — visibility-aware default `method_missing`.
- `builtins/module.rs` — four new CRuby-verified unit tests.

## Testing

- `language/def_spec`: 23 → 7 failures.
- Four new unit tests (lifecycle-private, FrozenError, nested-def,
  arg-message/private-message), each CRuby-verified.
- Full `cargo test --lib` passes (1788, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_