### PR TITLE
constants: no top-level fallback, error-message #name, private_constant, unicode names

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -288,7 +288,14 @@ class Module
   def const_missing(name)
     # Drop the implicit `Object::` prefix so a top-level miss reads
     # `uninitialized constant Foo` (not `Object::Foo`), matching CRuby.
-    qual = self.equal?(Object) ? name.to_s : "#{self}::#{name}"
+    # For a qualified miss, CRuby crafts the prefix from the module's
+    # `#name`, falling back to `#inspect` when the module is anonymous.
+    if self.equal?(Object)
+      qual = name.to_s
+    else
+      prefix = self.name || self.inspect
+      qual = "#{prefix}::#{name}"
+    end
     raise NameError.new("uninitialized constant #{qual}", name)
   end
 

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1096,7 +1096,10 @@ fn is_valid_const_name(name: &str) -> bool {
         Some(c) => c,
         None => return false,
     };
-    if !first.is_ascii_uppercase() {
+    // The first character must be uppercase — Unicode-aware, so non-ASCII
+    // uppercase letters (e.g. Greek `Ἅ`) are valid constant-name starts,
+    // matching CRuby's `rb_enc_isupper`.
+    if !first.is_uppercase() {
         return false;
     }
     chars.all(|c| c.is_alphanumeric() || c == '_')
@@ -6886,6 +6889,62 @@ mod tests {
             c.constants.sort
             "#,
         );
+    }
+
+    #[test]
+    fn qualified_constant_no_toplevel_fallback() {
+        // `A::X` does not fall through to Object's own top-level constants
+        // (`String::Hash` raises NameError), but the walk still continues
+        // into modules mixed into Object and normal ancestors resolve.
+        run_tests(&[
+            r#"begin; String::Hash; :no; rescue NameError; :nme; end"#,
+            r#"begin; Enumerable::Hash; :no; rescue NameError; :nme; end"#,
+        ]);
+        run_test(
+            r#"
+            module QTopA; X = 1; module Inner; Y = 2; end; end
+            [QTopA::X, QTopA::Inner::Y, defined?(QTopA::X)]
+            "#,
+        );
+    }
+
+    #[test]
+    fn const_missing_message_uses_name_then_inspect() {
+        // A qualified miss crafts its prefix from the module's `#name`,
+        // falling back to `#inspect` for an anonymous module.
+        run_test(
+            r#"
+            m = Module.new { def self.name; "MdName"; end }
+            begin; m::NOPE; rescue NameError => e; e.message; end
+            "#,
+        );
+    }
+
+    #[test]
+    fn private_constant_qualified_access() {
+        // A `private_constant` is not `defined?` through the `A::B` form and
+        // cannot be reopened with a qualified `class`/`module` keyword, but
+        // stays reachable lexically.
+        run_test(
+            r#"
+            module PrivC
+              class Sec; end
+              private_constant :Sec
+              REACH = (Sec.equal?(const_get(:Sec)))
+            end
+            [
+              defined?(PrivC::Sec),
+              (begin; class PrivC::Sec; end; :no; rescue NameError; :nme; end),
+              PrivC::REACH,
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn const_set_allows_non_ascii_uppercase_name() {
+        // Unicode uppercase (e.g. Greek `Ἅ`) is a valid constant-name start.
+        run_test(r#"m = Module.new; m.const_set("ἍBB", 5); m.const_get("ἍBB")"#);
     }
 
     // -- module_function eval-boundary isolation --------------------------

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2327,6 +2327,13 @@ impl Executor {
             }
             found
         };
+        // A qualified definition (`class A::B`) is a qualified constant
+        // access, so `private_constant`-marked names are rejected — CRuby
+        // raises "private constant A::B referenced". An unqualified `class
+        // B` is a lexical access and stays exempt.
+        if base.is_some() {
+            check_constant_visibility(globals, parent, name)?;
+        }
         let (self_val, is_new) = match self.get_constant(globals, parent, name)? {
             Some(val) => {
                 let val = val.expect_class_or_module(&globals.store)?;

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -204,16 +204,50 @@ impl Executor {
         Err(MonorubyErr::uninitialized_constant(name))
     }
 
+    /// Ancestor-chain lookup for the segment of a **qualified** reference
+    /// (`A::B`). Like [`Self::get_constant_superclass`] but the walk stops
+    /// before Object unless the qualifier itself is Object: a qualified
+    /// reference does not fall through to top-level constants
+    /// (`String::Hash` raises `NameError` even though `Hash` is a top-level
+    /// constant). Mirrors CRuby's `rb_const_search` skipping `rb_cObject`.
+    fn get_constant_superclass_qualified(
+        &mut self,
+        globals: &mut Globals,
+        mut module: Module,
+        name: IdentId,
+    ) -> Result<Option<Value>> {
+        let start = module.id();
+        loop {
+            let cid = module.id();
+            // A qualified reference does not see Object's *own* top-level
+            // constants (`String::Hash` ⇒ NameError), but the walk still
+            // continues past Object into its included modules / BasicObject
+            // (`ChildA::CONST` where `CONST` lives in a module mixed into
+            // Object is still found). So skip only Object's own table.
+            let skip_own = cid == OBJECT_CLASS && start != OBJECT_CLASS;
+            if !skip_own {
+                if let Some(v) = self.get_constant(globals, cid, name)? {
+                    return Ok(Some(v));
+                }
+            }
+            match module.superclass() {
+                Some(superclass) => module = superclass,
+                None => return Ok(None),
+            }
+        }
+    }
+
     /// Walk the ancestor chain of *module* to find *name*; if missing, fall
     /// back to `module.const_missing(name)` so user-defined hooks fire for
-    /// qualified `Foo::Bar` access (matching CRuby's `rb_const_get`).
+    /// qualified `Foo::Bar` access (matching CRuby's `rb_const_get`). The
+    /// walk does not fall through to top-level constants on Object.
     pub(crate) fn get_qualified_constant_with_missing(
         &mut self,
         globals: &mut Globals,
         module: Module,
         name: IdentId,
     ) -> Result<Value> {
-        if let Some(v) = self.get_constant_superclass(globals, module, name)? {
+        if let Some(v) = self.get_constant_superclass_qualified(globals, module, name)? {
             return Ok(v);
         }
         self.invoke_const_missing(globals, module, name)
@@ -398,13 +432,14 @@ impl Executor {
         let mut module = module;
         loop {
             let cid = module.id();
-            if cid == OBJECT_CLASS && start != OBJECT_CLASS {
-                // Reached Object via a qualified lookup: top-level
-                // constants are not visible here.
-                return false;
-            }
-            if Self::probe_constant_at(globals, cid, name) {
-                return true;
+            // Skip only Object's *own* constant table for a qualified
+            // lookup; keep walking into Object's included modules /
+            // BasicObject (see `get_constant_superclass_qualified`).
+            let skip_own = cid == OBJECT_CLASS && start != OBJECT_CLASS;
+            if !skip_own && Self::probe_constant_at(globals, cid, name) {
+                // A qualified reference to a `private_constant` is not
+                // considered defined (`defined?(A::PrivConst)` ⇒ nil).
+                return !globals.store[cid].is_constant_private(name);
             }
             match module.superclass() {
                 Some(superclass) => module = superclass,


### PR DESCRIPTION
## Summary

Fixes several `language/constants_spec` failures (**20 → 8** for the file):

- **No top-level fallback for qualified references** — `A::X` no longer
  resolves to Object's *own* top-level constants (`String::Hash` /
  `Enumerable::Hash` now raise `NameError`), while the ancestor walk still
  continues **past** Object into modules mixed into Object (so
  `Child::CONST`, where `CONST` lives in a module included into Object, is
  still found). Applied to both the runtime resolver and `defined?`.
- **Error-message prefix** — a qualified "uninitialized constant" NameError
  now builds its prefix from the module's `#name`, falling back to
  `#inspect` for an anonymous module, instead of always using `to_s`
  (which ignored a custom `#name`).
- **`private_constant` enforcement** — a private constant is no longer
  `defined?` through the `A::B` form, and a qualified `class` / `module`
  reopening of one raises `NameError` ("private constant … referenced").
  Lexical (unqualified) access stays exempt.
- **Unicode constant names** — a constant name may now start with a
  non-ASCII uppercase letter (e.g. Greek `Ἅ`), matching CRuby's
  `rb_enc_isupper`.

## Remaining (out of scope)

Eight `constants_spec` examples still fail: `NameError#receiver` /
`#name` attributes (needs the `Name` error kind to carry a receiver),
routing a private-constant access through a custom `const_missing`, the
"searches Object as a lexical scope only if Object is explicitly opened"
cases, and constant resolution inside a `class << obj` singleton body.

## Changes

- `executor/constants.rs` — `get_constant_superclass_qualified` +
  `probe_constant_superclass_qualified` skip only Object's own table;
  `defined?` respects `private_constant`.
- `executor.rs` — `define_class` enforces constant visibility for a
  qualified (`class A::B`) definition.
- `builtins/module.rs` — `is_valid_const_name` is Unicode-aware; four new
  CRuby-verified unit tests.
- `builtins/startup.rb` — `const_missing` prefixes with `#name` / `#inspect`.

## Testing

- `language/constants_spec`: 20 → 8 failures; `core/module/const_get` /
  `const_defined` unchanged.
- Four new unit tests, each CRuby-verified.
- Full `cargo test --lib` passes (1792, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_