### PR TITLE
exception: NameError#receiver and FrozenError#receiver

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -79,6 +79,8 @@ pub(super) fn init(globals: &mut Globals) {
     let nameerr =
         globals.define_builtin_exception_class("NameError", NAME_ERROR_CLASS, standarderr);
     globals.define_builtin_func(NAME_ERROR_CLASS, "name", nameerr_name, 0);
+    // `NameError#receiver` (inherited by NoMethodError).
+    globals.define_builtin_func(NAME_ERROR_CLASS, "receiver", exc_receiver, 0);
     globals.define_builtin_func_with(
         NAME_ERROR_CLASS,
         "initialize",
@@ -88,11 +90,12 @@ pub(super) fn init(globals: &mut Globals) {
         false,
     );
     globals.define_builtin_exception_class("NoMethodError", NO_METHOD_ERROR_CLASS, nameerr);
-    globals.define_builtin_func(NO_METHOD_ERROR_CLASS, "receiver", nomethoderr_receiver, 0);
 
     let runtimeerr =
         globals.define_builtin_exception_class("RuntimeError", RUNTIME_ERROR_CLASS, standarderr);
     globals.define_builtin_exception_class("FrozenError", FROZEN_ERROR_CLASS, runtimeerr);
+    // `FrozenError#receiver` — the frozen object that was modified.
+    globals.define_builtin_func(FROZEN_ERROR_CLASS, "receiver", exc_receiver, 0);
 
     globals.define_builtin_exception_class("RangeError", RANGE_ERROR_CLASS, standarderr);
     globals.define_builtin_exception_class("RegexpError", REGEX_ERROR_CLASS, standarderr);
@@ -120,9 +123,10 @@ pub(super) fn init(globals: &mut Globals) {
     );
 }
 
-/// ### NoMethodError#receiver
+/// Shared reader for the `/receiver` ivar — `NameError#receiver` /
+/// `NoMethodError#receiver` / `FrozenError#receiver`.
 #[monoruby_builtin]
-fn nomethoderr_receiver(
+fn exc_receiver(
     _vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
@@ -608,6 +612,44 @@ fn cause(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn error_receiver_attributes() {
+        // `NameError#receiver` / `#name` for a private-constant access
+        // expose the *defining* class and the constant symbol;
+        // `FrozenError#receiver` is the frozen object; `NoMethodError`
+        // inherits `#receiver`.
+        run_test(
+            r#"
+            module RcvV
+              class Base; PRIV = 1; private_constant :PRIV; end
+              class Child < Base; end
+            end
+            begin
+              RcvV::Child::PRIV
+            rescue NameError => e
+              [e.receiver.equal?(RcvV::Base), e.name]
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            o = Object.new
+            o.freeze
+            begin
+              def o.x; end
+            rescue FrozenError => e
+              [e.receiver.equal?(o), e.message.include?("can't modify frozen Object")]
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            obj = Object.new
+            begin; obj.nope_method; rescue NoMethodError => e; e.receiver.equal?(obj); end
+            "#,
+        );
+    }
 
     #[test]
     fn exception() {

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -1065,7 +1065,7 @@ fn const_get(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                     None,
                 ) {
                     Ok(v) => Ok(v),
-                    Err(e) if matches!(e.kind, MonorubyErrKind::Name(_)) => {
+                    Err(e) if matches!(e.kind, MonorubyErrKind::Name(..)) => {
                         Err(MonorubyErr::nameerr_with_name(e.message, sym))
                     }
                     Err(e) => Err(e),

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1018,12 +1018,30 @@ impl Executor {
                     .unwrap();
                 v
             }
-            MonorubyErrKind::Name(Some(name)) => {
+            MonorubyErrKind::Name(name, receiver) => {
                 let name = *name;
+                let receiver = *receiver;
+                let v = Value::new_exception(err);
+                if let Some(name) = name {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::_NAME, Value::symbol(name))
+                        .unwrap();
+                }
+                if let Some(receiver) = receiver {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::get_id("/receiver"), Value::from_u64(receiver))
+                        .unwrap();
+                }
+                v
+            }
+            MonorubyErrKind::Frozen(Some(receiver)) => {
+                let receiver = *receiver;
                 let v = Value::new_exception(err);
                 globals
                     .store
-                    .set_ivar(v, IdentId::_NAME, Value::symbol(name))
+                    .set_ivar(v, IdentId::get_id("/receiver"), Value::from_u64(receiver))
                     .unwrap();
                 v
             }
@@ -2832,11 +2850,18 @@ pub(crate) fn check_constant_visibility(
     name: IdentId,
 ) -> Result<()> {
     if globals.store[class_id].is_constant_private(name) {
-        return Err(MonorubyErr::nameerr(format!(
-            "private constant {}::{} referenced",
-            class_id.get_name(&globals.store),
-            name
-        )));
+        // CRuby's `NameError` for a private constant exposes the *defining*
+        // class as `#receiver` and the constant symbol as `#name`.
+        let receiver = globals.store[class_id].get_module().get();
+        return Err(MonorubyErr::nameerr_with_name_receiver(
+            format!(
+                "private constant {}::{} referenced",
+                class_id.get_name(&globals.store),
+                name
+            ),
+            name,
+            receiver,
+        ));
     }
     Ok(())
 }

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -271,7 +271,7 @@ impl Executor {
             None,
         ) {
             Ok(v) => Ok(v),
-            Err(e) if matches!(e.kind, MonorubyErrKind::Name(_)) => {
+            Err(e) if matches!(e.kind, MonorubyErrKind::Name(..)) => {
                 Err(MonorubyErr::nameerr_with_name(e.message, name))
             }
             Err(e) => Err(e),

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -98,6 +98,10 @@ impl MonorubyErr {
                 Value::from_u64(*recv).mark(alloc);
                 Value::from_u64(*key).mark(alloc);
             }
+            // Packed receiver Value for NameError / FrozenError.
+            MonorubyErrKind::Name(_, Some(id)) | MonorubyErrKind::Frozen(Some(id)) => {
+                Value::from_u64(*id).mark(alloc);
+            }
             // Non-local return: carries the return value and the
             // captured frame pointer it must return to.
             MonorubyErrKind::MethodReturn(v, lfp) => {
@@ -198,13 +202,13 @@ impl MonorubyErr {
             MonorubyErrKind::Arguments => "ArgumentError",
             MonorubyErrKind::Syntax => "SyntaxError",
             MonorubyErrKind::Unimplemented => "RuntimeError",
-            MonorubyErrKind::Name(_) => "NameError",
+            MonorubyErrKind::Name(..) => "NameError",
             MonorubyErrKind::DivideByZero => "ZeroDivisionError",
             MonorubyErrKind::LocalJump => "LocalJumpError",
             MonorubyErrKind::Range => "RangeError",
             MonorubyErrKind::Type => "TypeError",
             MonorubyErrKind::Index => "IndexError",
-            MonorubyErrKind::Frozen => "FrozenError",
+            MonorubyErrKind::Frozen(_) => "FrozenError",
             MonorubyErrKind::Load(_) => "LoadError",
             MonorubyErrKind::Regex => "RegexpError",
             MonorubyErrKind::Runtime => "RuntimeError",
@@ -253,13 +257,13 @@ impl MonorubyErr {
             MonorubyErrKind::Arguments => ARGUMENTS_ERROR_CLASS,
             MonorubyErrKind::Syntax => SYNTAX_ERROR_CLASS,
             MonorubyErrKind::Unimplemented => UNIMPLEMENTED_ERROR_CLASS,
-            MonorubyErrKind::Name(_) => NAME_ERROR_CLASS,
+            MonorubyErrKind::Name(..) => NAME_ERROR_CLASS,
             MonorubyErrKind::DivideByZero => ZERO_DIVISION_ERROR_CLASS,
             MonorubyErrKind::LocalJump => LOCAL_JUMP_ERROR_CLASS,
             MonorubyErrKind::Range => RANGE_ERROR_CLASS,
             MonorubyErrKind::Type => TYPE_ERROR_CLASS,
             MonorubyErrKind::Index => INDEX_ERROR_CLASS,
-            MonorubyErrKind::Frozen => FROZEN_ERROR_CLASS,
+            MonorubyErrKind::Frozen(_) => FROZEN_ERROR_CLASS,
             MonorubyErrKind::Load(_) => LOAD_ERROR_CLASS,
             MonorubyErrKind::Regex => REGEX_ERROR_CLASS,
             MonorubyErrKind::Runtime => RUNTIME_ERROR_CLASS,
@@ -497,14 +501,28 @@ impl MonorubyErr {
     }
 
     pub(crate) fn nameerr(msg: impl ToString) -> MonorubyErr {
-        Self::new(MonorubyErrKind::Name(None), msg)
+        Self::new(MonorubyErrKind::Name(None, None), msg)
     }
 
     /// Like [`nameerr`], but additionally records the missing-name
     /// symbol so the resulting `NameError`'s `#name` Ruby method returns
     /// it (matches CRuby's `rb_name_err_new`).
     pub(crate) fn nameerr_with_name(msg: impl ToString, name: IdentId) -> MonorubyErr {
-        Self::new(MonorubyErrKind::Name(Some(name)), msg)
+        Self::new(MonorubyErrKind::Name(Some(name), None), msg)
+    }
+
+    /// Like [`nameerr_with_name`], but also records the receiver `Value`
+    /// (the object the missing name was looked up on) so the resulting
+    /// `NameError`'s `#receiver` Ruby method returns it.
+    pub(crate) fn nameerr_with_name_receiver(
+        msg: impl ToString,
+        name: IdentId,
+        receiver: Value,
+    ) -> MonorubyErr {
+        Self::new(
+            MonorubyErrKind::Name(Some(name), Some(receiver.id())),
+            msg,
+        )
     }
 
     pub(crate) fn uninitialized_constant(name: IdentId) -> MonorubyErr {
@@ -757,15 +775,18 @@ impl MonorubyErr {
     }
 
     pub(crate) fn frozenerr(msg: impl ToString) -> MonorubyErr {
-        MonorubyErr::new(MonorubyErrKind::Frozen, msg)
+        MonorubyErr::new(MonorubyErrKind::Frozen(None), msg)
     }
 
     pub(crate) fn cant_modify_frozen(store: &Store, val: Value) -> MonorubyErr {
-        MonorubyErr::frozenerr(format!(
-            "can't modify frozen {}: {}",
-            val.get_real_class_name(store),
-            val.inspect(store),
-        ))
+        MonorubyErr::new(
+            MonorubyErrKind::Frozen(Some(val.id())),
+            format!(
+                "can't modify frozen {}: {}",
+                val.get_real_class_name(store),
+                val.inspect(store),
+            ),
+        )
     }
 
     pub(crate) fn loaderr(msg: impl ToString, path: PathBuf) -> MonorubyErr {
@@ -926,14 +947,17 @@ pub enum MonorubyErrKind {
     Unimplemented,
     /// `NameError` with an optional `name` symbol that the
     /// `NameError#name` Ruby method exposes (e.g. the missing constant
-    /// or method name passed to `Module#instance_method`).
-    Name(Option<IdentId>),
+    /// or method name passed to `Module#instance_method`) and an optional
+    /// packed `Value::id()` of the receiver surfaced by `NameError#receiver`.
+    Name(Option<IdentId>, Option<u64>),
     DivideByZero,
     LocalJump,
     Range,
     Type,
     Index,
-    Frozen,
+    /// `FrozenError` with an optional packed `Value::id()` of the frozen
+    /// receiver, surfaced by `FrozenError#receiver`.
+    Frozen(Option<u64>),
     Load(PathBuf),
     Regex,
     Runtime,
@@ -972,13 +996,13 @@ impl MonorubyErrKind {
             ARGUMENTS_ERROR_CLASS => MonorubyErrKind::Arguments,
             SYNTAX_ERROR_CLASS => MonorubyErrKind::Syntax,
             UNIMPLEMENTED_ERROR_CLASS => MonorubyErrKind::Unimplemented,
-            NAME_ERROR_CLASS => MonorubyErrKind::Name(None),
+            NAME_ERROR_CLASS => MonorubyErrKind::Name(None, None),
             ZERO_DIVISION_ERROR_CLASS => MonorubyErrKind::DivideByZero,
             LOCAL_JUMP_ERROR_CLASS => MonorubyErrKind::LocalJump,
             RANGE_ERROR_CLASS => MonorubyErrKind::Range,
             TYPE_ERROR_CLASS => MonorubyErrKind::Type,
             INDEX_ERROR_CLASS => MonorubyErrKind::Index,
-            FROZEN_ERROR_CLASS => MonorubyErrKind::Frozen,
+            FROZEN_ERROR_CLASS => MonorubyErrKind::Frozen(None),
             LOAD_ERROR_CLASS => MonorubyErrKind::Load(PathBuf::new()),
             REGEX_ERROR_CLASS => MonorubyErrKind::Regex,
             RUNTIME_ERROR_CLASS => MonorubyErrKind::Runtime,


### PR DESCRIPTION
## Summary

`NameError` and `FrozenError` now carry the receiver `Value` so their
`#receiver` Ruby method returns it, matching CRuby. This is a cross-cutting
fix that clears remaining `def_spec` and `constants_spec` failures.

- **`NameError#receiver`** (inherited by `NoMethodError`) — for a
  private-constant access it is the constant's **defining** class, with
  `#name` the constant symbol. The `receiver` reader moves from
  `NoMethodError` up to `NameError` so both share it (NoMethodError <
  NameError).
- **`FrozenError#receiver`** — the frozen object that was modified. Used by
  the specs that reconstruct the message as
  `"can't modify frozen C: #{e.receiver}"`.

## Implementation

- `MonorubyErrKind::Name(Option<IdentId>)` → `Name(Option<IdentId>,
  Option<u64>)` (name symbol + packed receiver id); `Frozen` →
  `Frozen(Option<u64>)`. Both new receiver ids are GC-marked and
  materialised into the `/receiver` ivar when the exception object is
  built.
- `check_constant_visibility` records the defining class + constant name;
  `cant_modify_frozen` records the frozen receiver.
- The `/receiver` reader is registered on `NAME_ERROR_CLASS` and
  `FROZEN_ERROR_CLASS`.

## Testing

- `language/def_spec`: 7 → 6 failures; `language/constants_spec`: 8 → 6.
- New unit test `error_receiver_attributes` (CRuby-verified): NameError
  receiver+name for a private constant, FrozenError receiver, and
  NoMethodError's inherited receiver.
- Full `cargo test --lib` passes (1793, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_