### PR TITLE
constants: class ::Foo top-level binding, private const via const_missing

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -6942,6 +6942,54 @@ mod tests {
     }
 
     #[test]
+    fn toplevel_class_binds_on_object_inside_module() {
+        // `class ::Foo` / `module ::Foo` bind at the top level (Object)
+        // regardless of the enclosing lexical scope, so reopening a nested
+        // class through `class ::Object; module ...` reaches the same class.
+        run_test(
+            r#"
+            module TlWrap
+              class Cont; class Child; end; end
+              class ::Object
+                TL_TOP = :tl_top
+                module TlWrap
+                  class Cont
+                    class Child
+                      def self.m; TL_TOP; end
+                    end
+                  end
+                end
+              end
+            end
+            [TlWrap::Cont::Child.m, Object.const_defined?(:TL_TOP)]
+            "#,
+        );
+    }
+
+    #[test]
+    fn private_constant_routes_through_const_missing() {
+        // A private constant access invokes `const_missing`, so a custom
+        // hook can intercept it; the default hook surfaces the "private
+        // constant" NameError.
+        run_test(
+            r#"
+            module PcMiss
+              X = 1
+              private_constant :X
+              def self.const_missing(n); n == :X ? :intercepted : super; end
+            end
+            r1 = PcMiss::X
+            module PcMiss2
+              Y = 1
+              private_constant :Y
+            end
+            r2 = (begin; PcMiss2::Y; rescue NameError => e; e.message.include?("private"); end)
+            [r1, r2]
+            "#,
+        );
+    }
+
+    #[test]
     fn const_set_allows_non_ascii_uppercase_name() {
         // Unicode uppercase (e.g. Greek `Ἅ`) is a valid constant-name start.
         run_test(r#"m = Module.new; m.const_set("ἍBB", 5); m.const_get("ἍBB")"#);

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1219,7 +1219,27 @@ impl Executor {
         }
         let module = globals[parent].get_module();
         if let Some(defining) = Self::probe_constant_superclass_with_class(globals, module, name) {
-            check_constant_visibility(globals, defining, name)?;
+            if globals.store[defining].is_constant_private(name) {
+                // A private constant routes through `const_missing` (CRuby
+                // calls it), so a custom hook may intercept. If the hook
+                // (default or `super`) raises, surface the "private
+                // constant" NameError carrying the defining class and name.
+                return match self.invoke_const_missing(globals, module, name) {
+                    Ok(v) => Ok((v, base)),
+                    Err(_) => {
+                        let receiver = globals.store[defining].get_module().get();
+                        Err(MonorubyErr::nameerr_with_name_receiver(
+                            format!(
+                                "private constant {}::{} referenced",
+                                defining.get_name(&globals.store),
+                                name
+                            ),
+                            name,
+                            receiver,
+                        ))
+                    }
+                };
+            }
         }
         let v = self.get_qualified_constant_with_missing(globals, module, name)?;
         Ok((v, base))

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -256,7 +256,7 @@ impl Executor {
     /// Invoke `module.const_missing(name)` and rewrap a NameError so its
     /// `name` attribute is preserved across `raise ex_obj` (which otherwise
     /// rebuilds the error and drops the constructor-set name).
-    fn invoke_const_missing(
+    pub(crate) fn invoke_const_missing(
         &mut self,
         globals: &mut Globals,
         module: Module,

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1836,12 +1836,23 @@ impl<'pr> Lowerer<'pr> {
                             None => Some(Box::new(self.lower_node(&parent)?)),
                         }
                     }
-                    // `class ::Foo; end`: matches the ruruby backend,
-                    // which discards the toplevel marker and lowers
-                    // this as a base-less ClassDef. At top level the
-                    // current lexical scope already *is* the toplevel
-                    // so the resulting class binds in the right place.
-                    None => None,
+                    // `class ::Foo; end`: the leading `::` binds `Foo` at
+                    // the top level (on Object) regardless of the enclosing
+                    // lexical scope, so give it an explicit `Object` base.
+                    // Without this, `module M; class ::Foo; end; end` would
+                    // wrongly create `M::Foo`.
+                    None => {
+                        let path_loc = location_to_loc(&path.location());
+                        Some(Box::new(Node {
+                            kind: NodeKind::Const {
+                                toplevel: true,
+                                parent: None,
+                                prefix: vec![],
+                                name: "Object".to_string(),
+                            },
+                            loc: path_loc,
+                        }))
+                    }
                 };
                 Ok((base, name))
             }


### PR DESCRIPTION
## Summary

Two more `language/constants_spec` fixes (**5 → 3** failures for the file):

- **`class ::Foo` / `module ::Foo` top-level binding** — a leading `::`
  now binds the class/module at the top level (on `Object`) regardless of
  the enclosing lexical scope. Previously the toplevel marker was
  discarded, so `module M; class ::Foo; end; end` wrongly created
  `M::Foo`. Transitively, a fixture pattern like `class ::Object; module
  ConstantSpecs; class ContainerA; class ChildA; def self.const20; …`
  reopened a **fresh** namespace instead of the real one, so the method
  was lost (`undefined method 'const20'`). The parser now gives such a
  definition an explicit `Object` base.
- **`private_constant` via `const_missing`** — a private-constant access
  now routes through `const_missing` (as CRuby does), so a custom hook can
  intercept it. If the hook raises (the default hook, or `super`), the
  "private constant … referenced" `NameError` is surfaced carrying the
  defining class (`#receiver`) and constant symbol (`#name`).

## Remaining (out of scope)

The last 3 `constants_spec` failures are singleton-class (`class << obj`)
constant-namespace cases: a `def` inside a repeated `class << obj` block
compiles to a single iseq whose lexical scope is overwritten on each
redefinition, so all copies resolve the constant to the last one. Fixing
it needs per-method-entry (rather than per-iseq) lexical-scope storage.

## Testing

- `language/constants_spec`: 5 → 3 failures.
- Two new CRuby-verified unit tests (`toplevel_class_binds_on_object_inside_module`,
  `private_constant_routes_through_const_missing`); `class ::Foo` /
  `module ::Foo` edge cases (create / reopen / with-superclass / inside a
  module) cross-checked against CRuby.
- Full `cargo test --lib` passes (1795, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_