### PR TITLE
lambda/def: `**nil` forbids keyword arguments

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -505,9 +505,41 @@ fn handle_keyword(
     callee_lfp: Lfp,
     caller_lfp: Lfp,
 ) -> Result<()> {
+    // `**nil` accepts no keywords: any actual keyword raises.
+    if globals[callee].forbid_keyword() {
+        if any_keyword_passed(globals, caller, caller_lfp)? {
+            return Err(MonorubyErr::argumenterr("no keywords accepted"));
+        }
+        return Ok(());
+    }
     ordinary_keyword(globals, callee, caller, callee_lfp, caller_lfp)?;
     hash_splat_and_kw_rest(vm, globals, callee, caller, callee_lfp, caller_lfp)?;
     check_missing_keyword(&globals.store[callee], callee_lfp)
+}
+
+/// Whether the call site actually supplies at least one keyword — either a
+/// literal `k: v` pair or a non-empty `**hash` splat. An empty `**{}` splat
+/// supplies none.
+fn any_keyword_passed(
+    globals: &Globals,
+    caller: CallSiteId,
+    caller_lfp: Lfp,
+) -> Result<bool> {
+    let cs = &globals[caller];
+    if !cs.kw_args.is_empty() {
+        return Ok(true);
+    }
+    for pos in cs.hash_splat_pos.iter() {
+        let h = caller_lfp.register(*pos).unwrap();
+        if h.is_nil() {
+            continue;
+        }
+        match h.try_hash_ty() {
+            Some(hash) if hash.len() == 0 => {}
+            _ => return Ok(true),
+        }
+    }
+    Ok(false)
 }
 
 fn handle_keyword_simple(callee: &FuncInfo, mut callee_lfp: Lfp) -> Result<()> {
@@ -834,6 +866,11 @@ fn invoker_arguments_inner(
         None
     };
 
+    // `**nil` accepts no keywords: any remaining keyword raises.
+    if info.forbid_keyword() && kw_arg.is_some() {
+        return Err(MonorubyErr::argumenterr("no keywords accepted"));
+    }
+
     // keyword rest
     let ex = if let Some(kw_rest) = info.kw_rest() {
         let v = if let Some(kw_arg) = kw_arg {
@@ -876,6 +913,34 @@ fn invoker_arguments_inner(
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn no_keywords_parameter() {
+        // `**nil` accepts no keywords: passing any keyword raises
+        // ArgumentError("no keywords accepted"), while no keywords / an
+        // empty `**{}` splat is fine. Applies to lambdas and methods.
+        run_test(
+            r#"
+            def rescue_msg
+              yield; :no_error
+            rescue ArgumentError => e
+              e.message
+            end
+            l1 = ->(**nil) { :ok }
+            l2 = lambda { |a, **nil| a }
+            def m(**nil); :mok; end
+            [
+              rescue_msg { l1.call(a: 1) },
+              l1.call,
+              l1.call(**{}),
+              l2.call(3),
+              rescue_msg { l2.call(3, b: 4) },
+              m,
+              rescue_msg { m(x: 1) },
+            ]
+            "#,
+        );
+    }
 
     #[test]
     fn zsuper_reassigned_scalar_rest() {

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -929,14 +929,20 @@ mod tests {
             l1 = ->(**nil) { :ok }
             l2 = lambda { |a, **nil| a }
             def m(**nil); :mok; end
+            full = { a: 1 }
+            empty = {}
             [
               rescue_msg { l1.call(a: 1) },
               l1.call,
               l1.call(**{}),
+              l1.call(**empty),
+              rescue_msg { l1.call(**full) },   # non-empty hash splat
               l2.call(3),
               rescue_msg { l2.call(3, b: 4) },
-              m,
-              rescue_msg { m(x: 1) },
+              m,                                 # method dispatch, no kw
+              rescue_msg { m(x: 1) },            # method dispatch, literal kw
+              rescue_msg { m(**full) },          # method dispatch, hash splat
+              m(**empty),                        # method dispatch, empty splat
             ]
             "#,
         );

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1051,6 +1051,7 @@ impl Store {
         let mut for_param_info = vec![];
         let mut forwarding = false;
         let mut it_param = false;
+        let mut forbid_keyword = false;
         for (dst_outer, dst_reg, _name) in for_params {
             for_param_info.push(ForParamInfo::new(dst_outer, dst_reg, args_names.len()));
             args_names.push(None);
@@ -1124,6 +1125,12 @@ impl Store {
                     keyword_initializers.push(init);
                 }
                 ParamKind::KWRest(name) => {
+                    // `**nil` is lowered to a kwrest literally named `nil`
+                    // (an impossible real variable name), which flags a
+                    // keyword-forbidding definition.
+                    if name.as_deref() == Some("nil") {
+                        forbid_keyword = true;
+                    }
                     let name = name.map(IdentId::get_id_from_string);
                     assert!(kw_rest_param.is_none());
                     kw_rest_param = Some(SlotId(1 + args_names.len() as u16));
@@ -1160,6 +1167,7 @@ impl Store {
             block_param,
             forwarding,
             it_param,
+            forbid_keyword,
         );
         let compile_info = CompileInfo::new(
             body,

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1098,6 +1098,11 @@ impl FuncInfo {
         self.kw_names().is_empty() && self.kw_rest().is_none()
     }
 
+    /// `**nil` — the definition explicitly forbids keyword arguments.
+    pub(crate) fn forbid_keyword(&self) -> bool {
+        self.ext.params.forbid_keyword()
+    }
+
     pub(crate) fn is_rest(&self) -> bool {
         self.ext.params.is_rest().is_some()
     }
@@ -1331,7 +1336,7 @@ impl Store {
         if pos_num == 1 && info.single_arg_expand() {
             return false;
         };
-        if info.no_keyword() && callsite.kw_may_exists() {
+        if (info.no_keyword() || info.forbid_keyword()) && callsite.kw_may_exists() {
             return false;
         };
         // A callsite that statically lacks a required keyword must take

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -685,6 +685,9 @@ pub(crate) struct ParamsInfo {
     /// `true` when the sole parameter is the implicit `it` (Ruby 3.4).
     /// `#parameters` then reports it without a name.
     it_param: bool,
+    /// `true` for `**nil` — the definition explicitly accepts no keywords,
+    /// so passing any keyword raises `ArgumentError("no keywords accepted")`.
+    forbid_keyword: bool,
 }
 
 impl ParamsInfo {
@@ -701,6 +704,7 @@ impl ParamsInfo {
         block_param: Option<IdentId>,
         forwarding: bool,
         it_param: bool,
+        forbid_keyword: bool,
     ) -> Self {
         ParamsInfo {
             required_num,
@@ -715,7 +719,13 @@ impl ParamsInfo {
             block_param,
             forwarding,
             it_param,
+            forbid_keyword,
         }
+    }
+
+    /// `**nil` — the definition explicitly forbids keyword arguments.
+    pub(crate) fn forbid_keyword(&self) -> bool {
+        self.forbid_keyword
     }
 
     /// Whether the sole parameter is the implicit `it` (reported
@@ -742,6 +752,7 @@ impl ParamsInfo {
             block_param: None,
             forwarding: false,
             it_param: false,
+            forbid_keyword: false,
         }
     }
 
@@ -776,6 +787,7 @@ impl ParamsInfo {
             block_param: None,
             forwarding: false,
             it_param: false,
+            forbid_keyword: false,
         }
     }
 


### PR DESCRIPTION
## Summary

A `**nil` parameter now rejects any keyword argument with
`ArgumentError("no keywords accepted")` — for lambdas / procs **and**
methods — while still accepting no keywords or an empty `**{}` splat,
matching CRuby.

Previously `**nil` was lowered to a keyword-rest literally named `nil`
(`KWRest(Some("nil"))`), so any passed keywords were silently absorbed
into it (`->(**nil){}.call(a: 1)` returned normally instead of raising).

## Implementation

- `ParamsInfo` gains a `forbid_keyword` flag, set when the kwrest parameter
  is the impossible name `nil` (produced only by `**nil` — a real variable
  can't be named `nil`).
- `is_simple_call` routes a call with keywords to the generic argument path
  when the callee forbids keywords (as it already does for `no_keyword`).
- Both keyword-binding paths raise when a keyword is actually supplied:
  `handle_keyword` (method dispatch) and `invoker_arguments_inner`
  (block / proc / lambda dispatch). An empty `**{}` supplies none, so it
  is allowed.

## Remaining (out of scope)

The other 8 `lambda_spec` failures are destructuring block parameters that
contain a splat or a nested target (`|(*a, b)|`, `|((a, b), c)|`,
`|(a, *b, c)|`). The current `ParamKind::Destruct(Vec<(name, loc)>)` is a
flat list; supporting these needs a recursive `Destruct` representation
plus the matching prologue codegen — a larger change left for a follow-up.

## Testing

- `language/lambda_spec`: 12 → 8 failures.
- New unit test `no_keywords_parameter` (CRuby-verified): lambda + method,
  keyword rejection, and the no-keyword / empty-`**{}` allowances.
- Full `cargo test --lib` passes (1798, 0 failures) against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_