### PR TITLE
lambda/block: support nested & splat destructuring parameters

### DIFF
--- a/monoruby/src/ast/node.rs
+++ b/monoruby/src/ast/node.rs
@@ -243,13 +243,20 @@ impl FormalParam {
     pub(crate) fn forwarding(loc: Loc) -> Self {
         FormalParam::new(ParamKind::Forwarding, loc)
     }
+}
 
-    pub(crate) fn destruct_param(params: Vec<(String, Loc)>) -> Self {
-        let loc = params
-            .iter()
-            .fold(params[0].1, |acc, elem| acc.merge(elem.1));
-        FormalParam::new(ParamKind::Destruct(params), loc)
-    }
+/// One element of a destructuring block/lambda parameter (`|(a, *b, (c, d))|`).
+/// A whole destructure target is a `Vec<DestructEntry>` with at most one
+/// `Rest` entry; entries before it are the "pre" targets, after it the
+/// "post" targets.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DestructEntry {
+    /// A named leaf target (`a`).
+    Param(String, Loc),
+    /// A splat target — `*a` (named) or `*` (anonymous).
+    Rest(Option<String>, Loc),
+    /// A nested destructure — `(c, d)` inside a larger target.
+    Nested(Vec<DestructEntry>, Loc),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -275,7 +282,11 @@ pub enum ParamKind {
     KWRest(Option<String>),
     Block(Option<String>),
     Forwarding,
-    Destruct(Vec<(String, Loc)>),
+    Destruct(Vec<DestructEntry>),
+    /// A destructuring parameter appearing *after* a rest (`*c, (*d, e)`).
+    /// Same shape as `Destruct` but occupies a post slot (counts toward
+    /// `post_num`, not `required_num`).
+    PostDestruct(Vec<DestructEntry>),
 }
 
 impl std::default::Default for ParamKind {

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -403,11 +403,17 @@ pub(crate) struct DestructureInfo {
     src: usize,
     dst: usize,
     len: usize,
+    rest_pos: Option<usize>,
 }
 
 impl DestructureInfo {
-    pub fn new(src: usize, dst: usize, len: usize) -> Self {
-        Self { src, dst, len }
+    pub fn new(src: usize, dst: usize, len: usize, rest_pos: Option<usize>) -> Self {
+        Self {
+            src,
+            dst,
+            len,
+            rest_pos,
+        }
     }
 }
 
@@ -620,8 +626,14 @@ impl<'a> BytecodeGen<'a> {
                 Loc::default(),
             );
         }
-        for DestructureInfo { src, dst, len } in info.destruct_info {
-            self.gen_expand_array(src, dst, len, None);
+        for DestructureInfo {
+            src,
+            dst,
+            len,
+            rest_pos,
+        } in info.destruct_info
+        {
+            self.gen_expand_array(src, dst, len, rest_pos);
         }
         for OptionalInfo { local, initializer } in info.optional_info {
             let local = local.into();

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1,7 +1,7 @@
 use inline::InlineTable;
 use monoasm::DestLabel;
 
-use crate::ast::{LvarCollector, ParseResult};
+use crate::ast::{DestructEntry, LvarCollector, ParseResult};
 use crate::bytecodegen::{BcLocal, CompileInfo, DestructureInfo, ForParamInfo, OptionalInfo};
 
 use super::*;
@@ -1024,6 +1024,59 @@ impl Store {
     }
 }
 
+/// Where the source array of an `ExpandArray` lives while `handle_args`
+/// is still building the parameter layout. `Surface` slots are already
+/// absolute (allocated among the visible params); `Destruct` slots are
+/// offsets into the yet-to-be-appended `destruct_args` region and are
+/// rebased once its start is known.
+enum ExpandSrc {
+    Surface(usize),
+    Destruct(usize),
+}
+
+/// Recursively flattens a destructuring parameter (`|(a, *b, (c, d))|`)
+/// into a sequence of `ExpandArray` descriptors. `src` names the slot
+/// holding the array to split; each direct child gets a consecutive slot
+/// in `destruct_args`, and every `Nested` child recurses with its own
+/// slot as the source (a chained `ExpandArray` fills it in). Parent
+/// descriptors are pushed before their children so the prologue emits
+/// them in dependency order.
+fn flatten_destruct(
+    entries: &[DestructEntry],
+    src: ExpandSrc,
+    expand: &mut Vec<(ExpandSrc, usize, usize, Option<usize>)>,
+    destruct_args: &mut Vec<Option<IdentId>>,
+) {
+    let len = entries.len();
+    let dst_start = destruct_args.len();
+    let mut rest_pos = None;
+    let mut child_slots = Vec::with_capacity(len);
+    for (i, entry) in entries.iter().enumerate() {
+        child_slots.push(destruct_args.len());
+        match entry {
+            DestructEntry::Param(name, _) => {
+                destruct_args.push(Some(IdentId::get_id_from_string(name.clone())));
+            }
+            DestructEntry::Rest(name, _) => {
+                rest_pos = Some(i);
+                destruct_args
+                    .push(name.as_ref().map(|n| IdentId::get_id_from_string(n.clone())));
+            }
+            DestructEntry::Nested(_, _) => {
+                // Temp slot: the parent `ExpandArray` writes the sub-array
+                // here, then the recursive descriptor splits it further.
+                destruct_args.push(None);
+            }
+        }
+    }
+    expand.push((src, dst_start, len, rest_pos));
+    for (i, entry) in entries.iter().enumerate() {
+        if let DestructEntry::Nested(sub, _) = entry {
+            flatten_destruct(sub, ExpandSrc::Destruct(child_slots[i]), expand, destruct_args);
+        }
+    }
+}
+
 impl Store {
     pub(crate) fn handle_args(
         info: BlockInfo,
@@ -1071,13 +1124,25 @@ impl Store {
                     required_num += 1;
                     it_param = true;
                 }
-                ParamKind::Destruct(names) => {
-                    expand.push((args_names.len(), destruct_args.len(), names.len()));
+                ParamKind::Destruct(entries) => {
+                    // The whole destructured argument is bound to an
+                    // anonymous surface slot; `flatten_destruct` records
+                    // the `ExpandArray` that splits it into `destruct_args`
+                    // slots, recursing into nested groups (chained
+                    // `ExpandArray`s) and honoring an optional splat.
+                    let src = args_names.len();
                     args_names.push(None);
                     required_num += 1;
-                    names.into_iter().for_each(|(name, _)| {
-                        destruct_args.push(Some(IdentId::get_id_from_string(name)));
-                    });
+                    flatten_destruct(&entries, ExpandSrc::Surface(src), &mut expand, &mut destruct_args);
+                }
+                ParamKind::PostDestruct(entries) => {
+                    // Same as `Destruct`, but the surface slot lives in the
+                    // post region (after the rest), so it counts toward
+                    // `post_num` rather than `required_num`.
+                    let src = args_names.len();
+                    args_names.push(None);
+                    post_num += 1;
+                    flatten_destruct(&entries, ExpandSrc::Surface(src), &mut expand, &mut destruct_args);
                 }
                 ParamKind::Optional(name, box initializer) => {
                     let local = BcLocal(args_names.len() as u16);
@@ -1145,9 +1210,20 @@ impl Store {
             }
         }
 
+        // `destruct_args` is appended after all surface params, so the
+        // destruct region begins at the current `args_names.len()`.
+        // Surface srcs are already absolute; destruct-relative srcs and
+        // all dsts are rebased onto that region here.
+        let base = args_names.len();
         let expand_info: Vec<_> = expand
             .into_iter()
-            .map(|(src, dst, len)| DestructureInfo::new(src, args_names.len() + dst, len))
+            .map(|(src, dst, len, rest_pos)| {
+                let src = match src {
+                    ExpandSrc::Surface(i) => i,
+                    ExpandSrc::Destruct(o) => base + o,
+                };
+                DestructureInfo::new(src, base + dst, len, rest_pos)
+            })
             .collect();
         args_names.append(&mut destruct_args);
         let kw_required: Vec<bool> = keyword_initializers

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -31,8 +31,8 @@ use ruby_prism::{
 };
 
 use crate::ast::{
-    BinOp, BlockInfo, CmpKind, Loc, LvarCollector, NReal, Node, NodeKind, ParamKind, ParseResult,
-    SourceInfoRef, UnOp,
+    BinOp, BlockInfo, CmpKind, DestructEntry, Loc, LvarCollector, NReal, Node, NodeKind, ParamKind,
+    ParseResult, SourceInfoRef, UnOp,
 };
 use crate::globals::{ExternalContext, MonorubyErr};
 use crate::id_table::IdentId;
@@ -3102,6 +3102,75 @@ impl<'pr> Lowerer<'pr> {
         }
     }
 
+    /// Recursively lowers a destructuring block/lambda parameter
+    /// (`MultiTargetNode`) into a `Vec<DestructEntry>`. Leaves are
+    /// `RequiredParameterNode` (`Param`), the optional `rest` is a
+    /// `SplatNode` (`Rest`, named or anonymous), and nested groups are
+    /// `MultiTargetNode` (`Nested`). Entries are emitted in source
+    /// order: `lefts`, then `rest`, then `rights`.
+    fn lower_destruct_el(
+        &mut self,
+        entries: &mut Vec<DestructEntry>,
+        el: &prism::Node<'pr>,
+    ) -> Result<(), MonorubyErr> {
+        match el {
+            prism::Node::RequiredParameterNode { .. } => {
+                let inner = el.as_required_parameter_node().unwrap();
+                let name = constant_name(&inner.name())?;
+                self.lvars.insert(&name);
+                entries.push(DestructEntry::Param(name, location_to_loc(&inner.location())));
+            }
+            prism::Node::MultiTargetNode { .. } => {
+                let nested = el.as_multi_target_node().unwrap();
+                let nested_loc = location_to_loc(&el.location());
+                let sub = self.lower_destruct(&nested)?;
+                entries.push(DestructEntry::Nested(sub, nested_loc));
+            }
+            other => {
+                return Err(self.unsupported("destructure param leaf", other));
+            }
+        }
+        Ok(())
+    }
+
+    fn lower_destruct(
+        &mut self,
+        mt: &prism::MultiTargetNode<'pr>,
+    ) -> Result<Vec<DestructEntry>, MonorubyErr> {
+        let mut entries: Vec<DestructEntry> = Vec::new();
+        for el in mt.lefts().iter() {
+            self.lower_destruct_el(&mut entries, &el)?;
+        }
+        if let Some(rest) = mt.rest() {
+            match rest {
+                prism::Node::SplatNode { .. } => {
+                    let inner = rest.as_splat_node().unwrap();
+                    let rest_loc = location_to_loc(&inner.location());
+                    let name = match inner.expression() {
+                        Some(e) => match e {
+                            prism::Node::RequiredParameterNode { .. } => {
+                                let rp = e.as_required_parameter_node().unwrap();
+                                let name = constant_name(&rp.name())?;
+                                self.lvars.insert(&name);
+                                Some(name)
+                            }
+                            other => {
+                                return Err(self.unsupported("destructure splat target", &other));
+                            }
+                        },
+                        None => None,
+                    };
+                    entries.push(DestructEntry::Rest(name, rest_loc));
+                }
+                other => return Err(self.unsupported("destructure rest", &other)),
+            }
+        }
+        for el in mt.rights().iter() {
+            self.lower_destruct_el(&mut entries, &el)?;
+        }
+        Ok(entries)
+    }
+
     /// Lowers a `ParametersNode` (the typed parameter cluster shared by
     /// method definitions and block parameters) into ruruby's flat
     /// `Vec<FormalParam>` AND threads each parameter into the current
@@ -3129,51 +3198,22 @@ impl<'pr> Lowerer<'pr> {
                         loc: location_to_loc(&inner.location()),
                     });
                 }
-                // `|(a, b)|` block-destructure: Prism wraps it in a
-                // `MultiTargetNode` whose `lefts` list holds the
-                // individual `RequiredParameterNode` leaves. ruruby's
-                // shape is `ParamKind::Destruct(Vec<(name, loc)>)` —
-                // flat, no splat / post entries — so we reject nested
-                // destructure (`|((a, b), c)|`) and `|(*rest)|` for
-                // now.
+                // `|(a, *b, (c, d))|` block-destructure: Prism wraps it
+                // in a `MultiTargetNode` whose `lefts`/`rest`/`rights`
+                // lists hold the individual leaves (`RequiredParameterNode`),
+                // an optional splat (`SplatNode`), and nested destructures
+                // (`MultiTargetNode`). We lower this recursively into a
+                // `Vec<DestructEntry>` supporting splat + nesting.
                 prism::Node::MultiTargetNode { .. } => {
                     let mt = n.as_multi_target_node().unwrap();
                     let mt_loc = location_to_loc(&n.location());
-                    if mt.rest().is_some() {
-                        return Err(self.unsupported_node("destructure param with splat", mt_loc));
-                    }
-                    if mt.rights().iter().next().is_some() {
-                        return Err(
-                            self.unsupported_node("destructure param with post element", mt_loc)
-                        );
-                    }
-                    let mut destruct: Vec<(String, Loc)> = Vec::new();
-                    for el in mt.lefts().iter() {
-                        match el {
-                            prism::Node::RequiredParameterNode { .. } => {
-                                let inner = el.as_required_parameter_node().unwrap();
-                                let name = constant_name(&inner.name())?;
-                                self.lvars.insert(&name);
-                                destruct.push((name, location_to_loc(&inner.location())));
-                            }
-                            other => {
-                                return Err(self.unsupported("destructure param leaf", &other));
-                            }
-                        }
-                    }
-                    if destruct.is_empty() {
+                    let entries = self.lower_destruct(&mt)?;
+                    if entries.is_empty() {
                         return Err(self.unsupported_node("empty destructure param", mt_loc));
                     }
-                    // Match ruruby's loc-merging convention so
-                    // bytecodegen reports matching source spans.
-                    let merged = destruct
-                        .iter()
-                        .map(|(_, l)| *l)
-                        .reduce(|a, b| a.merge(b))
-                        .unwrap();
                     out.push(crate::ast::FormalParam {
-                        kind: ParamKind::Destruct(destruct),
-                        loc: merged,
+                        kind: ParamKind::Destruct(entries),
+                        loc: mt_loc,
                     });
                 }
                 other => return Err(self.unsupported("required param", &other)),
@@ -3243,6 +3283,19 @@ impl<'pr> Lowerer<'pr> {
                     out.push(crate::ast::FormalParam {
                         kind: ParamKind::Post(Some(name)),
                         loc: location_to_loc(&inner.location()),
+                    });
+                }
+                // `|*c, (*d, e)|` — a destructure in post position.
+                prism::Node::MultiTargetNode { .. } => {
+                    let mt = n.as_multi_target_node().unwrap();
+                    let mt_loc = location_to_loc(&n.location());
+                    let entries = self.lower_destruct(&mt)?;
+                    if entries.is_empty() {
+                        return Err(self.unsupported_node("empty destructure param", mt_loc));
+                    }
+                    out.push(crate::ast::FormalParam {
+                        kind: ParamKind::PostDestruct(entries),
+                        loc: mt_loc,
                     });
                 }
                 other => return Err(self.unsupported("post param", &other)),

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -757,6 +757,42 @@ fn destruct() {
 }
 
 #[test]
+fn destruct_nested() {
+    // Splat inside a destructure target, both leading, middle, and trailing.
+    run_test(r#"->((a, *b, c)) { [a, b, c] }.call([1, 2, 3, 4, 5])"#);
+    run_test(r#"->((*a, b)) { [a, b] }.call([1, 2, 3])"#);
+    run_test(r#"->((*a, b)) { [a, b] }.call([1])"#);
+    run_test(r#"->((a, *)) { a }.call([1, 2, 3])"#);
+    run_test(r#"->((*, a)) { a }.call([1, 2, 3])"#);
+    // Nested destructure groups.
+    run_test(r#"->((a, (b, c))) { [a, b, c] }.call([1, [2, 3]])"#);
+    run_test(r#"lambda { |((*a, b))| [a, b] }.call([[1, 2, 3]])"#);
+    // Deeply nested with splats at several levels.
+    run_test(
+        r#"
+        f = ->(a, (b, (c, *d, (e, (*f)), g), (h, (i, j)))) { [a, b, c, d, e, f, g, h, i, j] }
+        f.call(1, [2, [3, 4, 5, [6, [7]], 8], [9, [10, 11]]])
+        "#,
+    );
+    // Multiple top-level destructure params, each with splat.
+    run_test(
+        r#"
+        f = ->((a, b, *c, d), (*e, f, g), (*h)) { [a, b, c, d, e, f, g, h] }
+        f.call([1, 2, 3, 4, 5], [6, 7, 8], [9, 10])
+        "#,
+    );
+    // Destructure in post position (after a rest), mixed with kwargs/block.
+    run_test(
+        r#"
+        f = ->(a, b = 1, *c, (*d, (e)), f: 2, g:, h:, **k, &l) do
+          [a, b, c, d, e, f, g, h, k, l]
+        end
+        f.call(9, 8, 7, 6, [5, 4, [3]], g: 2, h: 1)
+        "#,
+    );
+}
+
+#[test]
 fn block_param() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

Destructuring block/lambda parameters previously only accepted a **flat** list of leaves (`|(a, b)|`). Any splat (`|(a, *b, c)|`), nested group (`|(a, (b, c))|`), or destructure in post position (`|*c, (*d, e)|`) was rejected with an "unsupported node" syntax error — which aborted the entire `language/block_spec.rb` file at parse time.

This PR lowers destructuring parameters recursively so the full CRuby shape is supported.

## Changes

- **`ast`**: add a `DestructEntry` enum (`Param` / `Rest` / `Nested`) so a destructure target is a recursive tree, and a `PostDestruct` param kind for destructures appearing after a rest.
- **`parser/prism_backend`**: lower a `MultiTargetNode` recursively into `Vec<DestructEntry>`, handling the `SplatNode` rest (named or anonymous) and nested `MultiTargetNode`s, in both required and post position.
- **`globals/store::handle_args`**: flatten the tree into a chain of `ExpandArray` descriptors — each nested group occupies a temp slot that becomes the source of a further `ExpandArray` — and thread an optional `rest_pos` through `DestructureInfo`.
- **`bytecodegen`**: carry `rest_pos` on `DestructureInfo` and pass it to the prologue's `gen_expand_array`.

## Impact on ruby/spec (`language`)

| spec | before | after |
| --- | --- | --- |
| `lambda_spec` | 8 errors | **0 failures, 0 errors** |
| `block_spec` | aborted at load (1 error, 0 examples ran) | 166 examples run (35 pre-existing failures now exposed) |
| `proc_spec` | 4 failures | 4 failures (unchanged; pre-existing `#to_ary` gap) |

## Tests

Adds a CRuby-verified `destruct_nested` test covering leading/middle/trailing splats, deep nesting (`->(a, (b, (c, *d, (e, (*f)), g), (h, (i, j))))`), multiple top-level destructure params, and post-position destructure mixed with kwargs/block. Full `--lib` suite (1798 tests) and `method_call`/`literal` integration tests pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_