### PR TITLE
mul-assign: support nested destructuring targets

### DIFF
--- a/monoruby/src/ast/node.rs
+++ b/monoruby/src/ast/node.rs
@@ -65,6 +65,12 @@ pub enum NodeKind {
     Splat(Box<Node>),
     AssignOp(BinOp, Box<Node>, Box<Node>),
     MulAssign(Vec<Node>, Vec<Node>), // mlhs, mrhs
+    /// A nested destructuring target group appearing inside an `mlhs`
+    /// (`(b, c)` in `(a, (b, c)) = ...`). Holds this group's own target
+    /// list, each element itself an assign target (possibly `Splat`,
+    /// `DiscardLhs`, or a further `MulAssignNested`). Only valid as an
+    /// LHS element; never a standalone expression.
+    MulAssignNested(Vec<Node>),
 
     CompStmt(Vec<Node>),
     If {

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -405,7 +405,7 @@ fn defined_str(node: &Node) -> &'static str {
             Some(node) => defined_str(node),
             None => "nil",
         },
-        NodeKind::DiscardLhs => unreachable!(),
+        NodeKind::DiscardLhs | NodeKind::MulAssignNested(..) => unreachable!(),
     }
 }
 

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -10,6 +10,17 @@ use super::*;
 ///
 const LITERAL_CHUNK_LEN: usize = 256;
 
+///
+/// A single target of a multiple assignment: either a resolved leaf
+/// lvalue, or a deferred nested destructure group (`(b, c)` in
+/// `(a, (b, c)) = ...`) whose targets are expanded once its parent array
+/// element is available.
+///
+enum MulLhs {
+    Leaf(LvalueKind),
+    Nested(Vec<Node>),
+}
+
 impl<'a> BytecodeGen<'a> {
     ///
     /// Evaluate *expr*, push the result, and return the register.
@@ -181,9 +192,21 @@ impl<'a> BytecodeGen<'a> {
                     } else {
                         let temp = self.temp;
                         let (lhs, rest) = self.eval_lvalue(&lhs)?;
-                        assert!(!rest);
-                        self.gen_store_expr(dst, rhs)?;
-                        self.emit_assign(dst, lhs, Some(temp), loc);
+                        if rest {
+                            // `*a = rhs` used as a value (`x = (*a = ...)`):
+                            // the expression evaluates to `rhs` itself, while
+                            // `a` receives the splatted form (an Array
+                            // distributes, a scalar/`nil` is wrapped). Put
+                            // `rhs` in `dst`, then splat a copy into `a`.
+                            self.gen_store_expr(dst, rhs)?;
+                            let tmp = self.push().into();
+                            self.emit_mov(tmp, dst);
+                            self.emit(BytecodeInst::ExpandArray(tmp, tmp, 1, Some(0)), loc);
+                            self.emit_assign(tmp, lhs, Some(temp), loc);
+                        } else {
+                            self.gen_store_expr(dst, rhs)?;
+                            self.emit_assign(dst, lhs, Some(temp), loc);
+                        }
                     }
                 } else {
                     self.gen_mul_assign(mlhs, mrhs, UseMode2::Push)?;
@@ -446,15 +469,28 @@ impl<'a> BytecodeGen<'a> {
                     let temp = self.temp;
                     let (lhs, rest) = self.eval_lvalue(&lhs)?;
                     if rest {
-                        // `*a = rhs`: splat `rhs` into `a`. An Array `rhs`
-                        // distributes its elements (`*a = [1, 2]` ⇒ `[1, 2]`),
-                        // a non-Array is wrapped (`*a = 1` ⇒ `[1]`,
-                        // `*a = nil` ⇒ `[nil]`). `ExpandArray` with a lone
-                        // rest slot performs exactly this — unlike a blind
-                        // 1-element array build, which double-wrapped arrays.
-                        let src = self.gen_expr_reg(rhs)?;
-                        self.emit(BytecodeInst::ExpandArray(src, src, 1, Some(0)), loc);
-                        return self.assign_with_mode(use_mode, src, lhs, temp, loc);
+                        // `*a = rhs`: `a` receives the splatted `rhs` — an
+                        // Array distributes its elements (`*a = [1, 2]` ⇒
+                        // `[1, 2]`), a non-Array is wrapped (`*a = 1` ⇒ `[1]`,
+                        // `*a = nil` ⇒ `[nil]`) — via `ExpandArray` with a
+                        // lone rest slot. As a *value*, though, the whole
+                        // expression is `rhs` itself (`x = (*a = 1)` ⇒ `1`),
+                        // so when the result is used we keep the original and
+                        // splat a copy into `a`.
+                        if matches!(use_mode, UseMode2::NotUse) {
+                            let src = self.gen_expr_reg(rhs)?;
+                            self.emit(BytecodeInst::ExpandArray(src, src, 1, Some(0)), loc);
+                            self.emit_assign(src, lhs, Some(temp), loc);
+                            return Ok(());
+                        }
+                        let rhs_reg = self.push_expr(rhs)?.into();
+                        let tmp = self.push().into();
+                        self.emit_mov(tmp, rhs_reg);
+                        self.emit(BytecodeInst::ExpandArray(tmp, tmp, 1, Some(0)), loc);
+                        self.emit_assign(tmp, lhs, None, loc);
+                        self.temp = temp;
+                        self.handle_mode(use_mode, rhs_reg)?;
+                        return Ok(());
                     } else {
                         let src = self.gen_expr_reg(rhs)?;
                         return self.assign_with_mode(use_mode, src, lhs, temp, loc);
@@ -846,7 +882,9 @@ impl<'a> BytecodeGen<'a> {
             NodeKind::Splat(..) => {
                 return Err(self.unsupported_lhs(&expr));
             }
-            NodeKind::DiscardLhs => unreachable!(),
+            // Only ever appears as an LHS element of a `MulAssign`, where
+            // `gen_mul_assign` consumes it directly.
+            NodeKind::DiscardLhs | NodeKind::MulAssignNested(..) => unreachable!(),
         }
         match use_mode {
             UseMode2::Ret => {
@@ -929,14 +967,25 @@ impl<'a> BytecodeGen<'a> {
         let temp = self.temp;
 
         // At first, we evaluate lvalues and save their info(LhsKind).
-        let mut lhs_kind = vec![];
+        // A nested destructure group (`(b, c)` in `(a, (b, c)) = ...`)
+        // is deferred as `MulLhs::Nested`: its own targets are expanded
+        // with a chained `ExpandArray` once the parent array element is
+        // in hand.
+        let mut lhs_kind: Vec<MulLhs> = vec![];
         let mut rest_pos = None;
-        for (i, lhs) in mlhs.iter().enumerate() {
-            let (lhs, rest) = self.eval_lvalue(&lhs)?;
-            if rest {
-                rest_pos = Some(i as u16)
+        for (i, lhs) in mlhs.into_iter().enumerate() {
+            match lhs.kind {
+                NodeKind::MulAssignNested(targets) => {
+                    lhs_kind.push(MulLhs::Nested(targets));
+                }
+                _ => {
+                    let (kind, rest) = self.eval_lvalue(&lhs)?;
+                    if rest {
+                        rest_pos = Some(i as u16)
+                    }
+                    lhs_kind.push(MulLhs::Leaf(kind));
+                }
             }
-            lhs_kind.push(lhs);
         }
 
         // Next, we evaluate rvalues and save them in temporary registers which start from temp_reg.
@@ -946,7 +995,7 @@ impl<'a> BytecodeGen<'a> {
             let rhs_reg = self.sp();
             let lhs_len = lhs_kind
                 .iter()
-                .filter(|kind| kind != &&LvalueKind::Discard)
+                .filter(|kind| !matches!(kind, MulLhs::Leaf(LvalueKind::Discard)))
                 .count();
             for _ in 0..lhs_len {
                 self.push();
@@ -983,7 +1032,10 @@ impl<'a> BytecodeGen<'a> {
         // Finally, assign rvalues to lvalue.
         for (i, lhs) in lhs_kind.into_iter().enumerate() {
             let src = (rhs_reg + i).into();
-            self.emit_assign(src, lhs, None, loc);
+            match lhs {
+                MulLhs::Leaf(kind) => self.emit_assign(src, kind, None, loc),
+                MulLhs::Nested(targets) => self.gen_destructure(src, targets, loc)?,
+            }
         }
 
         self.temp = temp;
@@ -1017,6 +1069,45 @@ impl<'a> BytecodeGen<'a> {
             UseMode2::NotUse => {}
         }
 
+        Ok(())
+    }
+
+    ///
+    /// Destructure the array in register `src` into `targets`, recursing
+    /// into nested groups with a chained `ExpandArray`. Backs nested
+    /// multiple-assignment targets (`(a, (b, c)) = ...`).
+    ///
+    /// `src` holds the array element to split; `targets` is this group's
+    /// own target list (each a leaf, a `Splat` rest, `DiscardLhs`, or a
+    /// further `MulAssignNested`). New registers are pushed above the
+    /// caller's stack and left in place — the top-level caller restores
+    /// `temp` once the whole assignment is emitted.
+    ///
+    fn gen_destructure(&mut self, src: BcReg, targets: Vec<Node>, loc: Loc) -> Result<()> {
+        let len = targets.len();
+        let rest_pos = targets.iter().position(|t| t.is_splat()).map(|p| p as u16);
+        let base = self.sp();
+        for _ in 0..len {
+            self.push();
+        }
+        self.emit(
+            BytecodeInst::ExpandArray(src, base.into(), len as u16, rest_pos),
+            loc,
+        );
+        for (i, t) in targets.into_iter().enumerate() {
+            let elem = (base + i).into();
+            match t.kind {
+                NodeKind::MulAssignNested(sub) => {
+                    self.gen_destructure(elem, sub, loc)?;
+                }
+                _ => {
+                    // Plain leaf or `Splat(target)` rest slot; `eval_lvalue`
+                    // unwraps the splat and returns the inner lvalue kind.
+                    let (kind, _rest) = self.eval_lvalue(&t)?;
+                    self.emit_assign(elem, kind, None, loc);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -266,6 +266,25 @@ impl<'a> BytecodeGen<'a> {
                 });
                 n2.iter_mut().for_each(|n| self.level_down(n, level));
             }
+            NodeKind::MulAssignNested(targets) => {
+                // A nested destructure group inside an mlhs: bind its own
+                // `LocalVar(0)` / `Splat(LocalVar(0))` targets at level 0
+                // and recurse, exactly as the `MulAssign` mlhs above.
+                targets.iter_mut().for_each(|n| {
+                    if level == 0 {
+                        if let NodeKind::LocalVar(0, name) = &n.kind {
+                            let name = IdentId::get_id(name);
+                            self.assign_local(name);
+                        } else if let NodeKind::Splat(n) = &n.kind {
+                            if let NodeKind::LocalVar(0, name) = &n.kind {
+                                let name = IdentId::get_id(name);
+                                self.assign_local(name);
+                            }
+                        }
+                    }
+                    self.level_down(n, level);
+                });
+            }
             NodeKind::Lambda(box BlockInfo { params, body, .. }) => {
                 self.level_down(body, level + 1);
                 for p in params {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -2296,13 +2296,23 @@ impl<'pr> Lowerer<'pr> {
     /// multi-RHS form `[1, 2]`. `a, b = [1, 2]` -> explicit -> single-
     /// element RHS `[Array([1,2])]`. Any non-array RHS (`a, b = c`)
     /// goes in unwrapped as a single-element RHS.
-    fn lower_multi_write(&mut self, node: &MultiWriteNode<'pr>) -> Result<Node, MonorubyErr> {
-        let loc = location_to_loc(&node.location());
+    /// Builds a flat `Vec<Node>` of assign targets from a
+    /// `lefts` / optional `rest` / `rights` triple, the shared shape of
+    /// both `MultiWriteNode` (top-level `a, b = ...`) and a nested
+    /// `MultiTargetNode` (`(b, c)` inside a larger LHS). The rest is
+    /// lowered to `Splat(target)` (`*a` / `*` → `Splat(DiscardLhs)`) or
+    /// a bare `DiscardLhs` for a trailing-comma `ImplicitRestNode`.
+    fn lower_target_list(
+        &mut self,
+        lefts: &[prism::Node<'pr>],
+        rest: Option<prism::Node<'pr>>,
+        rights: &[prism::Node<'pr>],
+    ) -> Result<Vec<Node>, MonorubyErr> {
         let mut lhs: Vec<Node> = Vec::new();
-        for n in node.lefts().iter() {
-            lhs.push(self.lower_assign_target(&n)?);
+        for n in lefts {
+            lhs.push(self.lower_assign_target(n)?);
         }
-        if let Some(rest) = node.rest() {
+        if let Some(rest) = rest {
             match rest {
                 prism::Node::SplatNode { .. } => {
                     let inner = rest.as_splat_node().unwrap();
@@ -2339,9 +2349,17 @@ impl<'pr> Lowerer<'pr> {
                 other => return Err(self.unsupported("multi-write rest", &other)),
             }
         }
-        for n in node.rights().iter() {
-            lhs.push(self.lower_assign_target(&n)?);
+        for n in rights {
+            lhs.push(self.lower_assign_target(n)?);
         }
+        Ok(lhs)
+    }
+
+    fn lower_multi_write(&mut self, node: &MultiWriteNode<'pr>) -> Result<Node, MonorubyErr> {
+        let loc = location_to_loc(&node.location());
+        let lefts: Vec<_> = node.lefts().iter().collect();
+        let rights: Vec<_> = node.rights().iter().collect();
+        let lhs = self.lower_target_list(&lefts, node.rest(), &rights)?;
 
         let value = node.value();
         let rhs: Vec<Node> = match value {
@@ -2519,8 +2537,21 @@ impl<'pr> Lowerer<'pr> {
                     loc,
                 }
             }
-            // Nested destructure (`((a, b), c) = ...`) needs its own
-            // per-shape lowering. Defer.
+            // Nested destructure (`(a, (b, c)) = ...`): Prism nests a
+            // `MultiTargetNode` inside the LHS. Lower its own
+            // lefts/rest/rights recursively and wrap in
+            // `MulAssignNested`, which bytecodegen expands with a
+            // chained `ExpandArray`.
+            prism::Node::MultiTargetNode { .. } => {
+                let mt = node.as_multi_target_node().unwrap();
+                let lefts: Vec<_> = mt.lefts().iter().collect();
+                let rights: Vec<_> = mt.rights().iter().collect();
+                let targets = self.lower_target_list(&lefts, mt.rest(), &rights)?;
+                Node {
+                    kind: NodeKind::MulAssignNested(targets),
+                    loc,
+                }
+            }
             other => return Err(self.unsupported("assign target", &other)),
         })
     }

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -112,3 +112,50 @@ fn multi_assign() {
         "##,
     ]);
 }
+
+#[test]
+fn nested_assign() {
+    run_tests(&[
+        // Basic nested destructure.
+        "(a, (b, c)) = [1, [2, 3]]; [a, b, c]",
+        "((a, b), c) = [[1, 2], 3]; [a, b, c]",
+        // Nested with a splat inside the group.
+        "(x, (y, *z)) = [1, [2, 3, 4]]; [x, y, z]",
+        "(a, (*b)) = [1, [2, 3]]; [a, b]",
+        // Splat at the outer level combined with a nested group.
+        "(a, *b, (c, d)) = [1, 2, 3, [4, 5]]; [a, b, c, d]",
+        "(a, (b, c), *d) = [1, [2, 3], 4, 5]; [a, b, c, d]",
+        // Deep nesting, multiple splats.
+        "(a, (b, (c, d))) = [1, [2, [3, 4]]]; [a, b, c, d]",
+        "(a, (b, *c, (d, e)), *f) = [1, [2, 3, 4, [5, 6]], 7, 8]; [a, b, c, d, e, f]",
+        // Short / nil-fill RHS.
+        "(a, (b, c)) = [1, 2]; [a, b, c]",
+        "(a, (b, c)) = [1, nil]; [a, b, c]",
+        // Return value of a nested multiple assignment is the RHS.
+        "r = ((a, (b, c)) = [1, [2, 3]]); [r, a, b, c]",
+        // Ivar / gvar targets inside a nested group.
+        "$g = nil; (@x, (@y, $g)) = [1, [2, 3]]; [@x, @y, $g]",
+        // Index / attr targets inside a nested group.
+        "arr = [0, 0]; h = {}; (arr[0], (arr[1], h[:k])) = [1, [2, 3]]; [arr, h]",
+        // Nested destructure in a block-parameter scope.
+        "[1, [2, 3]].then { |(m, (n, o))| [m, n, o] }",
+        // Nested destructure *assignment* inside a block body (exercises
+        // `level_down`'s local binding + depth adjustment).
+        "proc { (a, (b, c)) = [1, [2, 3]]; [a, b, c] }.call",
+        "proc { (a, (b, *c)) = [1, [2, 3, 4]]; [a, b, c] }.call",
+        // ...and captured by a nested block referencing an outer local.
+        "x = 100; [0].each { proc { (a, (b, c)) = [1, [2, 3]]; x = a + b + c }.call }; x",
+        // ...and inside a `for`-loop body.
+        "r = nil; for i in [1] do (a, (b, c)) = [1, [2, 3]]; r = [a, b, c] end; r",
+        // Splat-assign as a value in a push context (array element).
+        "y = [(*a = 1)]; [y, a]",
+        // `*a = rhs` used as a value: the expression is `rhs`, `a` is the
+        // splatted form (Array distributes, scalar/nil wraps). Both the
+        // store context (`x = ...`) and the method-return context.
+        "x = (*a = [1, 2]); [x, a]",
+        "x = (*a = 1); [x, a]",
+        "x = (*a = nil); [x, a]",
+        "def f; (*a = 1); end; f",
+        "def g; (*a = [3, 4]); end; g",
+    ]);
+}


### PR DESCRIPTION
## Summary

Nested destructuring assignment (`(a, (b, c)) = [1, [2, 3]]`) previously failed at parse time with `unsupported node "assign target:MultiTargetNode"` — `lower_assign_target` had no handler for a nested `MultiTargetNode`. This PR lowers and expands nested destructure targets recursively, to arbitrary depth and with splats at any level.

## Changes

- **`ast`**: add `NodeKind::MulAssignNested(Vec<Node>)` for a nested target group inside an mlhs.
- **`parser/prism_backend`**: factor the `lefts`/`rest`/`rights` → `Vec<Node>` lowering into a shared `lower_target_list`, used by both the top-level `MultiWriteNode` and a nested `MultiTargetNode` (the latter lowers to `MulAssignNested`).
- **`bytecodegen`**: `gen_mul_assign` defers nested groups as `MulLhs::Nested`; after the parent `ExpandArray`, each group's array element is split with a chained `ExpandArray` via the new recursive `gen_destructure` (honoring an inner splat / discard at any depth). `level_down` binds a nested group's own locals so closures capture them.

## Drive-by fix: `*a = rhs` used as an expression

Exposed while running `language/variables_spec`: `gen_store_expr` hit `assert!(!rest)` and **aborted** on `x = (*a = [1,2])`, and `gen_expr` returned the *splatted* array rather than `rhs`. Both paths now evaluate to `rhs` itself while binding `a` to the splatted form, matching CRuby:

```ruby
x = (*a = 1)    # x == 1,      a == [1]
x = (*a = [1,2])# x == [1, 2], a == [1, 2]
x = (*a = nil)  # x == nil,    a == [nil]
```

## Tests

Adds CRuby-verified `nested_assign` tests: nesting to arbitrary depth, inner/outer splats, short/nil-fill RHS, the assignment's return value, ivar/gvar/index/attr targets inside a group, nested destructure in a block-param scope, and the `*a = rhs`-as-value cases (store and method-return contexts).

Full `--lib` suite (1798 tests), `method_call`, `mul_assign`, and `literal` integration tests pass with no regressions; `block_spec` / `lambda_spec` / `proc_spec` are unchanged.

Note: `variables_spec` still does not load to completion, but for an unrelated, pre-existing reason — it uses index-splat LHS (`a[*[1]] = 1`), which monoruby does not lower. That is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_