### PR TITLE
destructure: coerce a single non-Array via #to_ary

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3713,11 +3713,13 @@ impl Codegen {
         true
     }
 
-    /// Multiple-assignment array expansion via runtime::expand_array(src, dst,
-    /// len, rest). `src` is already in GP::Rdi (x4) from the preceding load;
-    /// `dst` is the (descending) destination base x22-conv(dst). aarch64 C-args:
-    /// x0=src, x1=&dst, x2=len, x3=rest (rest = rest_pos+1, or 0 for none).
-    /// Bails on a live xmm pool reg or an out-of-range frame offset.
+    /// Multiple-assignment array expansion via
+    /// runtime::expand_array(vm, globals, src, &dst, len, rest). `src` is
+    /// already in GP::Rdx (x2) — the C-arg slot for `src` — from the
+    /// preceding load; `dst` is the (descending) destination base
+    /// x22-conv(dst). aarch64 C-args: x0=vm, x1=globals, x2=src, x3=&dst,
+    /// x4=len, x5=rest (rest = rest_pos+1, or 0 for none). May dispatch
+    /// `#to_ary` and raise — the caller emits a `HandleError` after this.
     pub(in crate::codegen::jitgen) fn emit_expand_array(
         &mut self,
         dst: SlotId,
@@ -3732,14 +3734,18 @@ impl Codegen {
         };
         let lfp = GP::R14.a64().0; // x22
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
-        let rdi = GP::Rdi.a64().0; // x4 holds src
         let f = runtime::expand_array as *const () as u64;
         self.emit_fpr_save(using_fpr, false);
-        monoasm_arm64!(&mut self.jit, mov x0, x(rdi);); // src (from GP::Rdi)
-        self.a64_addr_sub(1, lfp, off);  // x1 = &dst (descending base)
+        // x2 already holds `src` (GP::Rdx). Fill the remaining C-args.
+        // x19 = EXEC (&mut Executor), x20 = GLOBALS (&mut Globals).
         monoasm_arm64!(&mut self.jit,
-            mov x2, (len as u64);        // len
-            mov x3, (rest);              // rest (0 = none)
+            mov x0, x19;   // &mut Executor
+            mov x1, x20;   // &mut Globals
+        );
+        self.a64_addr_sub(3, lfp, off);  // x3 = &dst (descending base)
+        monoasm_arm64!(&mut self.jit,
+            mov x4, (len as u64);        // len
+            mov x5, (rest);              // rest (0 = none)
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -926,23 +926,28 @@ impl Codegen {
         p
     }
 
-    /// op 173 `ExpandArray`: expand_array(src `[pc+4]`, &dst `[pc+2]`,
-    /// len `[pc+0]`, rest `[pc+8]`). No result.
+    /// op 173 `ExpandArray`: expand_array(vm, globals, src `[pc+4]`,
+    /// &dst `[pc+2]`, len `[pc+0]`, rest `[pc+8]`). May dispatch `#to_ary`
+    /// and raise, so the `X0 == 0` error path branches to `entry_raise`.
     pub(in crate::codegen) fn a64_op_expand_array(&mut self) -> CodePtr {
         let p = self.jit.get_current_address();
+        let raise = self.entry_raise.clone();
         monoasm_arm64!(&mut self.jit,
-            ldrh x0, [x(PC.0), #(4)];
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            ldrh x2, [x(PC.0), #(4)];
         );
-        self.a64_slot_value(X0); // src (an Array Value)
+        self.a64_slot_value(X2); // src
         monoasm_arm64!(&mut self.jit,
-            ldrh x1, [x(PC.0), #(2)];
+            ldrh x3, [x(PC.0), #(2)];
         );
-        self.a64_slot_addr(X1); // &dst
+        self.a64_slot_addr(X3); // &dst
         monoasm_arm64!(&mut self.jit,
-            ldrh x2, [x(PC.0)];  // len
-            ldrh x3, [x(PC.0), #(8)];  // rest
+            ldrh x4, [x(PC.0)];  // len
+            ldrh x5, [x(PC.0), #(8)];  // rest
             mov x9, (runtime::expand_array as *const () as u64);
             blr x9;
+            cbz x0, raise;
             add x(PC.0), x(PC.0), #(16);
         );
         self.a64_fetch_and_dispatch();

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1865,10 +1865,15 @@ impl Codegen {
             0
         };
         self.fpr_save(using_fpr);
+        // `src` is already in rdx (loaded by the caller). Args:
+        // rdi = &mut Executor, rsi = &mut Globals, rdx = src, rcx = &dst,
+        // r8 = len, r9 = rest.
         monoasm!( &mut self.jit,
-            lea rsi, [rbp - (rbp_local(dst))];
-            movq rdx, (len);
-            movq rcx, (rest);
+            lea rcx, [rbp - (rbp_local(dst))];
+            movq r8, (len);
+            movq r9, (rest);
+            movq rdi, rbx;
+            movq rsi, r12;
             movq rax, (runtime::expand_array);
             call rax;
         );

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -620,19 +620,23 @@ impl Codegen {
         let label = self.jit.get_current_address();
         self.fetch3();
         monoasm! { &mut self.jit,
-            // rcx <- rst
-            movzxw rcx, [r13 - 8];
-            // rdx <- len
-            movq rdx, rsi;
-            // rsi <- dst
+            // r9 <- rst
+            movzxw r9, [r13 - 8];
+            // r8 <- len
+            movq r8, rsi;
+            // rcx <- dst
             negq rdi;
-            lea rsi, [r14 + rdi * 8 - (LFP_SELF)];
-            // rdi <- *src
+            lea rcx, [r14 + rdi * 8 - (LFP_SELF)];
+            // rdx <- *src
             negq r15;
-            movq rdi, [r14 + r15 * 8 - (LFP_SELF)];
+            movq rdx, [r14 + r15 * 8 - (LFP_SELF)];
+            // rdi <- &mut Executor, rsi <- &mut Globals
+            movq rdi, rbx;
+            movq rsi, r12;
             movq rax, (runtime::expand_array);
             call rax;
         };
+        self.vm_handle_error();
         self.fetch_and_dispatch();
         label
     }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -609,11 +609,14 @@ impl<'a> JitContext<'a> {
                 dst: (dst, len, rest_pos),
             } => {
                 state.flush_gp(ir);
-                state.load(ir, src, GP::Rdi);
+                // `expand_array` may dispatch `#to_ary` and raise, so guard it.
+                state.load(ir, src, GP::Rdx);
+                let error = ir.new_error(state);
                 for reg in dst.0..dst.0 + len {
                     state.def_S(SlotId(reg));
                 }
                 ir.expand_array(state, dst, len, rest_pos);
+                ir.handle_error(error);
             }
             TraceIr::UndefMethod { undef } => {
                 state.flush_gp(ir);

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -479,7 +479,37 @@ pub(super) extern "C" fn concatenate_regexp(
     Some(Value::regexp(inner))
 }
 
-pub(super) extern "C" fn expand_array(src: Value, dst: *mut Value, len: usize, rest: usize) {
+pub(super) extern "C" fn expand_array(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: Value,
+    dst: *mut Value,
+    len: usize,
+    rest: usize,
+) -> Option<Value> {
+    // Destructuring (multiple assignment and block/proc `|(a, b)|` params)
+    // coerces a non-Array `src` once via `#to_ary`: an Array result is
+    // expanded, `nil` or a missing `#to_ary` leaves `src` a scalar, and any
+    // other result raises `TypeError`. Returns `None` (a null in `rax`) so
+    // the VM / JIT error path fires.
+    let src = if src.is_array_ty() {
+        src
+    } else if let Some(func_id) = globals.check_method(src, IdentId::TO_ARY) {
+        match vm.invoke_func_inner(globals, func_id, src, &[], None, None) {
+            Ok(v) if v.is_array_ty() => v,
+            Ok(v) if v.is_nil() => src,
+            Ok(v) => {
+                vm.set_error(MonorubyErr::cant_convert_error_ary(globals, src, v));
+                return None;
+            }
+            Err(err) => {
+                vm.set_error(err);
+                return None;
+            }
+        }
+    } else {
+        src
+    };
     let rest_pos: Option<usize> = if rest == 0 { None } else { Some(rest - 1) };
     match src.try_array_ty() {
         Some(ary) => {
@@ -565,6 +595,7 @@ pub(super) extern "C" fn expand_array(src: Value, dst: *mut Value, len: usize, r
             }
         }
     }
+    Some(Value::nil())
 }
 
 pub(crate) extern "C" fn create_array(src: *mut Value, len: usize) -> Value {

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -793,6 +793,56 @@ fn destruct_nested() {
 }
 
 #[test]
+fn destruct_to_ary() {
+    // Destructuring a single non-Array argument coerces it via `#to_ary`:
+    // an Array result is expanded; `nil` / no `#to_ary` leaves it a scalar.
+    // `#to_ary`-returning objects yield deterministic arrays; the nil /
+    // no-`#to_ary` cases fall back to `[obj, nil]` — checked by identity to
+    // avoid address-dependent `inspect` output.
+    run_test_with_prelude(
+        r#"
+        nily = Nily.new
+        none = None.new
+        [
+          proc { |(a, b)| [a, b] }.call(Ary.new),
+          proc { |(a, b)| [a.equal?(nily), b] }.call(nily),
+          proc { |(a, b)| [a.equal?(none), b] }.call(none),
+          proc { |(a, b)| [a, b] }.call(42),
+          proc { |(a, (b, c))| [a, b, c] }.call([0, Ary.new]),
+          (x, y = Ary.new; [x, y]),
+          ((p1, q) = nily; [p1.equal?(nily), q]),
+          (m, *n = Ary.new; [m, n]),
+        ]
+        "#,
+        r#"
+        class Ary;  def to_ary; [1, 2]; end; end
+        class Nily; def to_ary; nil;    end; end
+        class None; end
+        "#,
+    );
+    // A `#to_ary` returning a non-Array raises TypeError.
+    run_test_error(
+        r#"
+        class Bad; def to_ary; 42; end; end
+        proc { |(a, b)| [a, b] }.call(Bad.new)
+        "#,
+    );
+    run_test_error(
+        r#"
+        class Bad; def to_ary; 42; end; end
+        a, b = Bad.new
+        "#,
+    );
+    // An error raised *inside* `#to_ary` propagates.
+    run_test_error(
+        r#"
+        class Boom; def to_ary; raise "boom"; end; end
+        proc { |(a, b)| [a, b] }.call(Boom.new)
+        "#,
+    );
+}
+
+#[test]
 fn block_param() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

Destructuring a single non-Array value — in a block/proc `|(a, b)|` parameter or a multiple assignment (`a, b = obj`, `(a, b) = obj`, plus nested and splat forms) — must coerce it once through `#to_ary`, matching CRuby:

- `#to_ary` returns an Array → expand it;
- `#to_ary` returns `nil`, or the value has no `#to_ary` → treat as a scalar (`[obj, nil]`);
- `#to_ary` returns anything else → raise `TypeError`.

monoruby previously skipped this, so `proc { |(a, b)| }.call(obj)` bound `a = obj, b = nil` even when `obj` defined `#to_ary`.

## Implementation

`runtime::expand_array` now performs the `#to_ary` coercion at its top, so it needs `&mut Executor` / `&mut Globals` and can fail. Its signature gains those two args and returns `Option<Value>` (`None` = error). The four call sites are updated:

- **x86-64 / aarch64 VM** (`vm_expand_array` / `a64_op_expand_array`): pass vm+globals, shift the value args, and branch to the raise path on a null return.
- **x86-64 / aarch64 JIT** (`emit_expand_array`): the source is loaded into the `src` C-arg register (`GP::Rdx` → rdx / x2), vm+globals are filled in, and `jitgen::compile` wraps the op in a `HandleError` guard.

## Spec / test impact

- `language/proc_spec`: **4 → 0 failures** (fully green)
- `language/block_spec`: **35 → 28 failures** (7 fixed)
- Adds CRuby-verified `destruct_to_ary` unit tests (Array / nil / no-method / scalar / nested, plus the `TypeError` case).

## Verification

- x86-64: full `--lib` suite (1798 tests) + `method_call` / `mul_assign` / `literal` integration tests pass.
- aarch64 (via the cross/qemu setup): compiles clean; `mul_assign` and `method_call::destruct*` tests pass, and a VM+JIT `#to_ary` smoke test matches CRuby — confirming both the VM and JIT machine-code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_