### PR TITLE
block: auto-splat a single non-Array arg via #to_ary

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -26,9 +26,9 @@ pub(crate) fn set_frame_arguments_simple(
     pos_num: usize,
 ) -> Result<()> {
     let callee_fid = callee_lfp.func_id();
-    let callee = &globals.store[callee_fid];
 
-    positional_simple(callee, src, pos_num, callee_lfp)?;
+    positional_simple(vm, globals, callee_fid, src, pos_num, callee_lfp)?;
+    let callee = &globals.store[callee_fid];
     if !callee.no_keyword() {
         handle_keyword(vm, globals, callee_fid, callid, callee_lfp, caller_lfp)?;
     }
@@ -185,6 +185,32 @@ pub(crate) extern "C" fn jit_forwarded_set_arguments(
     }
 }
 
+///
+/// Block auto-splat coercion of a single non-Array argument.
+///
+/// When a block taking multiple parameters is passed a single argument
+/// that is not already an Array, CRuby coerces it once via `#to_ary`:
+/// an Array result is splatted into the parameters, `nil` or a missing
+/// `#to_ary` leaves the argument a scalar, and any other result raises
+/// `TypeError`. Returns `Ok(Some(array))` when coerced (the caller must
+/// keep the returned `Value` alive while filling from its buffer),
+/// `Ok(None)` to leave the value as a single scalar argument.
+///
+fn block_arg_to_ary(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<Option<Value>> {
+    if let Some(func_id) = globals.check_method(v, IdentId::TO_ARY) {
+        let res = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
+        if res.is_array_ty() {
+            Ok(Some(res))
+        } else if res.is_nil() {
+            Ok(None)
+        } else {
+            Err(MonorubyErr::cant_convert_error_ary(globals, v, res))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 fn check_single_arg_expand(
     splat_pos: &[usize],
     pos_args: usize,
@@ -256,8 +282,30 @@ fn set_callee_frame_arguments(
         None
     };
 
+    // Block auto-splat: a single non-Array argument to a multi-param block
+    // is coerced via `#to_ary` (kept alive here while its buffer is read).
+    // Done before binding `splat_pos` so its mutable `globals` borrow ends.
+    let coerced = if globals[callee_fid].single_arg_expand()
+        && pos_args == 1
+        && ex.is_none()
+        && globals[callid].splat_pos.is_empty()
+        && !unsafe { *src }.is_array_ty()
+    {
+        block_arg_to_ary(vm, globals, unsafe { *src })?
+    } else {
+        None
+    };
     let splat_pos = &globals[callid].splat_pos;
-    if globals[callee_fid].single_arg_expand()
+    if let Some(coerced) = coerced {
+        let ary = coerced.try_array_ty().unwrap();
+        fill_positional_args(
+            dst,
+            &globals[callee_fid],
+            ary.as_ref().as_ptr(),
+            ary.len(),
+            true,
+        )?;
+    } else if globals[callee_fid].single_arg_expand()
         && let Some((ptr, len)) = check_single_arg_expand(splat_pos, pos_args, src, ex)
     {
         // single array argument expansion for blocks
@@ -470,7 +518,9 @@ fn fill_positional_args(
 }
 
 fn positional_simple(
-    callee: &FuncInfo,
+    vm: &mut Executor,
+    globals: &mut Globals,
+    callee_fid: FuncId,
     src: *const Value,
     pos_num: usize,
     callee_lfp: Lfp,
@@ -478,6 +528,25 @@ fn positional_simple(
     let dst = callee_lfp.register_ptr(SlotId(1));
     let pos_args = pos_num;
 
+    // Block auto-splat: a single non-Array argument to a multi-param block
+    // is coerced via `#to_ary` (kept alive while its buffer is read).
+    if globals.store[callee_fid].single_arg_expand()
+        && pos_args == 1
+        && !unsafe { *src }.is_array_ty()
+    {
+        if let Some(coerced) = block_arg_to_ary(vm, globals, unsafe { *src })? {
+            let ary = coerced.try_array_ty().unwrap();
+            return fill_positional_args(
+                dst,
+                &globals.store[callee_fid],
+                ary.as_ref().as_ptr(),
+                ary.len(),
+                true,
+            );
+        }
+    }
+
+    let callee = &globals.store[callee_fid];
     // single array argument expansion for blocks
     if callee.single_arg_expand()
         && let Some((ptr, len)) = check_single_arg_expand(&[], pos_args, src, None)

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -843,6 +843,49 @@ fn destruct_to_ary() {
 }
 
 #[test]
+fn block_autosplat_to_ary() {
+    // A single non-Array argument yielded to a multi-parameter block is
+    // auto-splatted via `#to_ary`: an Array result is distributed, `nil` /
+    // no `#to_ary` leaves it a scalar, other results raise `TypeError`.
+    run_test_with_prelude(
+        r#"
+        def m(a) yield a end
+        nily = Nily.new
+        none = None.new
+        [
+          m(Ary.new) { |a, b, c| [a, b, c] },
+          m(nily) { |a, b| [a.equal?(nily), b] },
+          m(none) { |a, b| [a.equal?(none), b] },
+          m(42) { |a, b| [a, b] },
+          # single argument / single rest do NOT auto-splat (no #to_ary).
+          m(Ary.new) { |a| a.class.name },
+          m(Ary.new) { |*a| [a[0].class.name, a.size] },
+          # the Rust-side invoke_block path (Array#each / #map).
+          [Ary.new].map { |a, b, c| [a, b, c] },
+        ]
+        "#,
+        r#"
+        class Ary;  def to_ary; [1, 2]; end; end
+        class Nily; def to_ary; nil;    end; end
+        class None; end
+        "#,
+    );
+    run_test_error(
+        r#"
+        class Bad; def to_ary; 42; end; end
+        def m(a) yield a end
+        m(Bad.new) { |a, b| [a, b] }
+        "#,
+    );
+    run_test_error(
+        r#"
+        class Boom; def to_ary; raise "boom"; end; end
+        [Boom.new].each { |a, b| [a, b] }
+        "#,
+    );
+}
+
+#[test]
 fn block_param() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

When a block taking multiple parameters is yielded a single argument that is not already an Array, CRuby coerces it once via `#to_ary` and splats the result into the parameters:

- `#to_ary` returns an Array → distribute it;
- `#to_ary` returns `nil`, or the value has no `#to_ary` → treat as a scalar;
- `#to_ary` returns anything else → raise `TypeError`.

monoruby only auto-splatted values that were *already* Arrays, so `m(obj) { |a, b, c| }` bound `a = obj, b = c = nil` even when `obj` defined `#to_ary`.

## Implementation

This is a pure-Rust runtime change (no machine-code changes). A new `block_arg_to_ary` helper performs the coercion, called from the two positional arg-setup paths that handle block dispatch for a single non-Array argument:

- `set_callee_frame_arguments` (already has `vm`/`globals`);
- `positional_simple` (now threaded `vm`/`globals` + `FuncId` from `set_frame_arguments_simple`).

The coerced array is held on the stack while its buffer is copied into the callee frame.

## Spec / test impact

- `language/block_spec`: **28 → 6 failures** (22 fixed).

The remaining 6 are separate sub-features, out of scope here: `respond_to?`-mediated `#to_ary` lookup (monoruby uses direct method lookup, consistent with its other `#to_ary` sites), a pre/post argument distribution edge, and a `#to_hash` case.

Adds CRuby-verified `block_autosplat_to_ary` tests: Array / nil / no-method / scalar coercion, the single-arg and single-rest no-splat cases, the `Array#each` / `#map` invoke-block path, and the `TypeError` / raise-propagation cases.

## Verification

- x86-64: full `--lib` suite (1798 tests) + `method_call` (91) pass; `proc_spec` / `lambda_spec` remain green.
- aarch64 (cross/qemu): smoke test matches CRuby (the block-invoke path uses arch-specific invoker stubs, unchanged here, calling the shared arg-setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_