### PR TITLE
block args: drop the tail when a rest-less block gets excess args

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -484,11 +484,24 @@ fn fill_positional_args(
             (post_pos, opt_pos + args_num..buf_len),
             buf_len..buf_len,
         )
-    } else {
+    } else if callee.is_rest() {
+        // More args than fit the fixed params, with a `*rest` to absorb the
+        // middle: pre + optionals fill from the front, post takes the last
+        // `post_num`, and the rest gets everything in between.
         (
             (0, 0..rest_pos),
             (post_pos, buf_len + post_pos - end_pos..buf_len),
             rest_pos..buf_len + post_pos - end_pos,
+        )
+    } else {
+        // More args than the params accept and no rest to absorb them —
+        // only reachable for block-style (loose) binding. CRuby fills
+        // positionally and drops the tail, so the post params sit right
+        // after the (fully-filled) optionals rather than at the very end.
+        (
+            (0, 0..rest_pos),
+            (post_pos, rest_pos..end_pos),
+            rest_pos..rest_pos,
         )
     };
 

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -172,6 +172,34 @@ fn method_post() {
 }
 
 #[test]
+fn block_pre_opt_post() {
+    // Block-style (loose) binding of required-pre + optional + required-post
+    // with NO rest, across arg counts up to and beyond the maximum. When
+    // there are more args than params, CRuby fills positionally and drops
+    // the tail — the post params sit right after the filled optionals, not
+    // at the very end.
+    run_test_with_prelude(
+        r#"
+        [
+          t([1])             { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2])           { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2,3])         { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2,3,4])       { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2,3,4,5])     { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2,3,4,5,6])   { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          t([1,2,3,4,5,6,7]) { |a, b=5, c=6, d, e| [a,b,c,d,e] },
+          # with a rest to absorb the middle excess
+          t([1,2,3,4,5,6])   { |a, b=5, c=6, *r, d, e| [a,b,c,r,d,e] },
+          t([1,2,3])         { |a, b=5, c=6, *r, d, e| [a,b,c,r,d,e] },
+        ]
+        "#,
+        r#"
+        def t(a) yield a end
+        "#,
+    );
+}
+
+#[test]
 fn keyword() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

For block-style (loose) argument binding of `|a, b=opt, c=opt, d, e|` (required-pre + optionals + required-post, **no rest**), when more arguments are supplied than the parameters accept, CRuby fills positionally and drops the surplus from the tail — the post parameters sit immediately after the fully-filled optionals.

monoruby instead took the post parameters from the very end, so `|a, b=5, c=6, d, e|` called with six values gave `[1, 2, 3, 5, 6]` instead of CRuby's `[1, 2, 3, 4, 5]`.

## Fix

`fill_positional_args`' `buf_len > max_args` arm used the end-anchored post source range (`buf_len + post_pos - end_pos .. buf_len`) unconditionally. That range is correct only when a `*rest` absorbs the middle excess. The arm is split:

- **with `*rest`** — unchanged (pre + optionals from the front, post from the end, rest gets the middle);
- **no rest** (only reachable in block-style binding) — post args are placed right after the optionals (`rest_pos..end_pos`) and the remainder is dropped.

## Spec / test impact

- `language/block_spec`: **6 → 3 failures**. The remaining 3 are all `respond_to?`-mediated `#to_ary` lookup (a distinct sub-feature; monoruby uses direct method lookup).

Adds a CRuby-verified `block_pre_opt_post` test across arg counts (below, at, and above the maximum), with and without a rest.

## Verification

- x86-64: full `--lib` suite (1798 tests) + `method_call` (92) pass, including a JIT-warmup check; lambda strict-arity is unaffected.
- aarch64 (cross/qemu): smoke test matches CRuby. This is arch-neutral Rust (`fill_positional_args`), no machine-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_