### PR TITLE
parser: forward anonymous * / ** parameters

### DIFF
--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -37,6 +37,13 @@ use crate::ast::{
 use crate::globals::{ExternalContext, MonorubyErr};
 use crate::id_table::IdentId;
 
+/// Reserved, unspellable local names bound to anonymous `*` / `**`
+/// parameters so their forwarding forms (`foo(*)` / `foo(**)`) can
+/// reference them. Neither is a valid Ruby identifier, so they can't
+/// collide with a user variable (mirrors the empty name used for `&`).
+const ANON_REST_NAME: &str = "*";
+const ANON_KWREST_NAME: &str = "**";
+
 pub(super) fn parse_program(code: String, path: PathBuf) -> Result<ParseResult, MonorubyErr> {
     try_prism_inner(&code, path, None, None, 0)
 }
@@ -381,8 +388,10 @@ impl<'pr> Lowerer<'pr> {
                 let inner = node.as_splat_node().unwrap();
                 let expr = match inner.expression() {
                     Some(e) => self.lower_node(&e)?,
+                    // Anonymous `*` (forwarding `foo(*)`): splat the reserved
+                    // anonymous-rest local bound by the enclosing `def m(*)`.
                     None => Node {
-                        kind: NodeKind::Nil,
+                        kind: NodeKind::LocalVar(0, ANON_REST_NAME.to_owned()),
                         loc,
                     },
                 };
@@ -2169,8 +2178,11 @@ impl<'pr> Lowerer<'pr> {
                             let s = elem.as_assoc_splat_node().unwrap();
                             let inner = match s.value() {
                                 Some(v) => self.lower_node(&v)?,
+                                // Anonymous `**` (forwarding `foo(**)`): splat
+                                // the reserved anonymous-kwrest local bound by
+                                // the enclosing `def m(**)`.
                                 None => Node {
-                                    kind: NodeKind::Nil,
+                                    kind: NodeKind::LocalVar(0, ANON_KWREST_NAME.to_owned()),
                                     loc: location_to_loc(&s.location()),
                                 },
                             };
@@ -3275,7 +3287,9 @@ impl<'pr> Lowerer<'pr> {
                     let inner = rest.as_rest_parameter_node().unwrap();
                     let name = match inner.name() {
                         Some(id) => Some(constant_name(&id)?),
-                        None => None,
+                        // Anonymous `*`: bind a reserved, unspellable local
+                        // so `foo(*)` forwarding can splat it.
+                        None => Some(ANON_REST_NAME.to_owned()),
                     };
                     if let Some(n) = &name {
                         self.lvars.insert(n);
@@ -3369,7 +3383,9 @@ impl<'pr> Lowerer<'pr> {
                     let loc = location_to_loc(&inner.location());
                     let name_opt = match inner.name() {
                         Some(id) => Some(constant_name(&id)?),
-                        None => None,
+                        // Anonymous `**`: bind a reserved, unspellable local
+                        // so `foo(**)` forwarding can splat it.
+                        None => Some(ANON_KWREST_NAME.to_owned()),
                     };
                     if let Some(n) = &name_opt {
                         self.lvars.insert_kwrest_param(n.clone());

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -770,6 +770,30 @@ fn anonymous_block_forwarding4() {
 }
 
 #[test]
+fn anonymous_rest_forwarding() {
+    // `def m(*)` / `def m(**)` bind reserved locals that `foo(*)` / `foo(**)`
+    // forward, matching CRuby (incl. `#parameters` reporting them as :* / :**).
+    run_test_with_prelude(
+        r##"
+        [
+          d_rest(1, 2, 3),
+          d_kw(a: 1, b: 2),
+          d_both(9, x: 3),
+          d_pre(1, 2, 3),
+          method(:d_both).parameters,
+        ]
+        "##,
+        r##"
+        def target(*a, **k); [a, k]; end
+        def d_rest(*); target(*); end
+        def d_kw(**); target(**); end
+        def d_both(*, **); target(*, **); end
+        def d_pre(a, *); target(a, *); end
+        "##,
+    );
+}
+
+#[test]
 fn destruct() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

`def m(*); target(*); end` and `def m(**); target(**); end` forward the anonymous rest / keyword-rest to another call. monoruby lowered the anonymous `*` argument to `Splat(nil)` and the anonymous `**` to a `nil` hash-splat, so nothing was forwarded — `target` saw empty positional args and empty kwargs.

## Fix

Bind each anonymous parameter to a reserved, unspellable local — `"*"` for the rest, `"**"` for the kwrest — mirroring the empty name (`""`) already used for anonymous `&`. The forwarding forms `foo(*)` / `foo(**)` are lowered to splat those locals.

Neither name is a valid Ruby identifier, so they can't collide with a user variable, and they happen to match CRuby's own `#parameters` reporting:

```ruby
->(*){}.parameters   # => [[:rest, :*]]
->(**){}.parameters  # => [[:keyrest, :**]]
```

## Spec / test impact

- `language/delegation_spec`: **2 → 0 failures** (`delegation with def(*)`, `delegation with def(**)`).

Adds a CRuby-verified `anonymous_rest_forwarding` test covering rest, kwrest, the combined `def(*, **)` form, a leading required param (`def(a, *)`), and `#parameters` reporting.

## Verification

- x86-64: full `--lib` suite (1798 tests) + `method_call` forwarding tests (32) pass, including a JIT-warmup check; no regressions in `def` / `keyword_arguments` / `proc` specs.
- aarch64 (cross/qemu): smoke test matches CRuby. This is arch-neutral parser/bytecodegen — no machine-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_