### PR TITLE
while/until: fix `redo` to restart the body, not re-test the condition

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -712,7 +712,11 @@ impl<'a> BytecodeGen<'a> {
                         }
                     }
                 };
-                self.emit(BytecodeInst::Br(*redo_dest), loc);
+                // Use the `Redo` op (a `goto` via the error path) rather than a
+                // plain `Br`: its target can sit in the middle of the loop body
+                // (skipping the condition) without the JIT seeing a second
+                // back-edge into the loop, which its loop analysis can't merge.
+                self.emit(BytecodeInst::Redo(*redo_dest), loc);
                 return Ok(());
             }
             NodeKind::Retry => {

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -151,17 +151,24 @@ impl<'a> BytecodeGen<'a> {
         use_value: bool,
     ) -> Result<()> {
         let loop_start = self.new_label();
+        let body_start = self.new_label();
         let succ_pos = self.new_label();
         let loop_exit = self.new_label();
         let ret = match use_value {
             true => Some(self.push_nil()),
             false => None,
         };
-        self.loop_push(loop_exit, loop_start, loop_start, ret);
+        // `next` re-checks the condition (→ `loop_start`); `redo` restarts the
+        // body without re-evaluating it (→ `body_start`, after the condition).
+        // `redo` is emitted as a `Redo` op — a `goto` routed through the error
+        // path that the JIT treats as a bail — not a plain back-edge branch, so
+        // the JIT never sees a second back-edge into the loop body.
+        self.loop_push(loop_exit, loop_start, body_start, ret);
         let loc = body.loc;
         self.apply_label(loop_start);
         self.emit(BytecodeInst::LoopStart, loc);
         self.gen_opt_condbr(!cond_op, cond, succ_pos)?;
+        self.apply_label(body_start);
         self.gen_expr(body, UseMode2::NotUse)?;
         self.emit_br(loop_start);
         self.apply_label(succ_pos);
@@ -538,6 +545,27 @@ mod test {
             "a = []; i = 42; 1.times { for i in 0..3; a << i; end }; a << i; a",
             "a = []; for i in 0..2; a << i; i = i + 10; end; [a, i]",
             "a = []; i = 42; 1.times { for i in 0..2; a << i; i = i + 10; end }; [a, i]",
+        ]);
+    }
+
+    #[test]
+    fn redo_loop() {
+        // `redo` restarts the loop body without re-evaluating the condition
+        // (so a side-effecting condition like `(i += 1)` does not re-run).
+        // The `run_tests` harness wraps each snippet in a hot `for` loop, so
+        // these also exercise a `while`-redo nested inside a loop-JIT'd loop.
+        run_tests(&[
+            "a=[]; i=0; j=0; while (i+=1)<3; a<<i; j+=1; redo if j<3; end; a",
+            "a=[]; i=0; j=0; until (i+=1)>=3; a<<i; j+=1; redo if j<3; end; a",
+            // `next` still re-checks the condition; `break` still exits.
+            "i=0; r=[]; while (i+=1)<6; next if i==2; break if i==5; r<<i; end; r",
+            // nested while, `redo` on the inner loop only
+            "o=[]; x=0; while (x+=1)<3; y=0; k=0; while (y+=1)<3; k+=1; o<<[x,y]; redo if k<3 && x==1; end; end; o",
+            // postfix / do-while form
+            "a=[]; i=0; j=0; begin; a<<i; i+=1; j+=1; redo if j<3 && i==1; end while i<3; a",
+            // a method-JIT'd body: a `while`-redo nested inside a `for` loop
+            // (the redo must not corrupt the enclosing loop's counter).
+            "def rr; o=[]; for k in 0..3; a=[]; i=0; j=0; while (i+=1)<3; a<<i; j+=1; redo if j<3; end; o<<a; end; o; end; rr",
         ]);
     }
 }

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -163,6 +163,17 @@ impl Codegen {
         if position.is_none() && globals.store[iseq_id].jit_invalidated() {
             return None;
         }
+        // A `while`/`until` `redo` (the `Redo` op) bails through the error
+        // path, whose `goto` resumes the interpreter in the current native
+        // frame without flushing JIT register state or tearing the frame
+        // down. Inside a JIT'd enclosing loop that corrupts the enclosing
+        // loop's state (method JIT) or re-enters the loop-JIT and overflows
+        // the stack (loop JIT). Decline to JIT any iseq containing one —
+        // both the method and loop JIT opt out; the interpreter runs `redo`
+        // correctly.
+        if globals.store[iseq_id].contains_redo() {
+            return None;
+        }
         #[cfg(feature = "profile")]
         {
             if let Some(reason) = &_is_recompile {

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -289,6 +289,23 @@ impl ISeqInfo {
     }
 
     ///
+    /// Whether this iseq contains a `Redo` op (opcode 87), i.e. a `redo`
+    /// targeting a `while`/`until` loop body.
+    ///
+    /// The loop (partial) JIT declines to compile such an iseq: a `redo`
+    /// resumes the interpreter in the current native frame (the error
+    /// path's `goto` does not tear the frame down), and re-entering a
+    /// loop-JIT'd loop from there corrupts the native stack. The method
+    /// JIT and the interpreter both run `redo` correctly, so only the
+    /// loop JIT opts out.
+    ///
+    pub(crate) fn contains_redo(&self) -> bool {
+        self.bytecode
+            .as_ref()
+            .is_some_and(|bc| bc.iter().any(|b| (b.op1() >> 48) as u8 == 87))
+    }
+
+    ///
     /// Get a number of registers.
     ///
     pub(crate) fn total_reg_num(&self) -> usize {


### PR DESCRIPTION
## Summary

`redo` inside a `while`/`until` loop re-evaluated the loop condition — so a side-effecting condition like `(i += 1) < n` ran again — behaving like `next`:

```ruby
a=[]; i=0; j=0
while (i+=1)<3
  a<<i; j+=1
  redo if j<3
end
a   # monoruby: [1, 2]   CRuby: [1, 1, 1, 2]
```

## Fix

`gen_while` now points `redo` at a `body_start` label placed **after** the condition test, so the body restarts without re-evaluating the condition (`next` still targets the loop head and re-checks it).

The loop `redo` is emitted as the **`Redo` op** — a `goto` routed through the error path that the JIT treats as a bail — rather than a plain `Br`, so the JIT never sees a second back-edge into the middle of the loop body (its loop analysis can't merge that).

### JIT interaction

The `Redo` bail resumes the interpreter in the current native frame without flushing JIT register state or unwinding the frame. Reached inside a JIT-compiled *enclosing* loop, that would corrupt the enclosing loop's state (method JIT) or re-enter the loop-JIT and overflow the native stack (loop JIT). So monoruby now **declines to JIT any iseq that contains a `Redo` op** (`ISeqInfo::contains_redo`, checked in the shared `compile`): both the method and loop JIT opt out, and the interpreter — which runs `redo` correctly — handles it. `redo` is rare, so the lost JIT coverage is negligible.

## Spec / test impact

- `language/while_spec`: redo failure fixed (**0 failures**).
- `language/until_spec`: redo failure fixed (**0 failures**).

Adds a `redo_loop` bytecodegen test: while/until, `next`/`break` unaffected, nested loops (`redo` on the inner loop only), the postfix `begin…end while` form, and a method-JIT'd `while`-redo nested inside a `for` loop.

## Verification

- x86-64: full `--lib` suite (1799 tests) pass; `while`/`until` specs green; `break_spec` unchanged.
- aarch64 (cross/qemu): the loop/method-JIT decline is arch-neutral Rust; the crashing repros and the `redo_loop` test pass under qemu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_