### PR TITLE
super / class-reopen: correct error messages and fix cached-super crash

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -425,7 +425,7 @@ module Kernel
   module_function :warn
 end
 
-class Process
+module Process
   CLOCK_REALTIME = 0
   CLOCK_MONOTONIC = 1
   CLOCK_PROCESS_CPUTIME_ID = 2
@@ -978,7 +978,7 @@ class NilClass
   end
 end
 
-class Marshal
+module Marshal
   MAJOR_VERSION = 4
   MINOR_VERSION = 8
 end
@@ -1124,7 +1124,7 @@ module Kernel
   end
 end
 
-class GC
+module GC
   # `GC.count` and `GC.start` are implemented in Rust (they read the
   # allocator's collection counter / force a full collection).
 

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -61,7 +61,9 @@ fn find_super(vm: &mut Executor, globals: &mut Globals) -> Result<FuncId> {
     let self_class = self_val.class();
     match globals.store.check_super(self_class, func_id, func_name) {
         Some(func_id) => Ok(func_id),
-        None => Err(MonorubyErr::method_not_found(globals, func_name, self_val)),
+        None => Err(MonorubyErr::super_method_not_found(
+            globals, func_name, self_val,
+        )),
     }
 }
 
@@ -657,7 +659,20 @@ pub(crate) extern "C" fn invoke_method_missing(
 ) -> Option<Value> {
     if globals[callsite].name.is_none() {
         // A super call: CRuby never falls through to method_missing when no
-        // superclass method is found. The error is already set; return None.
+        // superclass method is found.
+        //
+        // On the first (uncached) miss, `find_super` has just set the error.
+        // But once the inline cache is warm (class matches, fid slot = 0),
+        // the VM fast path jumps straight here without calling `find_method`,
+        // so no error is set yet — set it now, mirroring `find_super`.
+        if vm.exception().is_none() {
+            let func_id = vm.method_func_id();
+            let self_val = vm.cfp().lfp().self_val();
+            let func_name = globals.store[func_id].name().unwrap();
+            vm.set_error(MonorubyErr::super_method_not_found(
+                globals, func_name, self_val,
+            ));
+        }
         return None;
     }
     vm.discard_error();

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2374,7 +2374,17 @@ impl Executor {
         }
         let (self_val, is_new) = match self.get_constant(globals, parent, name)? {
             Some(val) => {
-                let val = val.expect_class_or_module(&globals.store)?;
+                // Reopening an existing constant: `class X` requires `X` to be
+                // a Class, `module X` a Module. CRuby names the *constant*
+                // (`X is not a class`), not the current value, and rejects
+                // reopening a Module as a Class (and vice versa).
+                let val = if is_module {
+                    val.is_module()
+                        .ok_or_else(|| MonorubyErr::is_not_module(name.to_string()))?
+                } else {
+                    val.is_class()
+                        .ok_or_else(|| MonorubyErr::is_not_class(name.to_string()))?
+                };
                 if let Some(superclass) = superclass {
                     assert!(!is_module);
                     let superclass_id = superclass.expect_class(globals)?.id();

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -415,6 +415,21 @@ impl MonorubyErr {
         )
     }
 
+    ///
+    /// `NoMethodError` for a `super` call whose superclass chain has no
+    /// method of the current name — CRuby phrases this differently from an
+    /// ordinary missing method (`super: no superclass method '<name>' …`).
+    ///
+    pub(crate) fn super_method_not_found(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
+        MonorubyErr::new(
+            MonorubyErrKind::NotMethod(Some(obj.id())),
+            format!(
+                "super: no superclass method `{name}' for {}",
+                obj.to_s(store)
+            ),
+        )
+    }
+
     pub(crate) fn method_not_found_for_class(
         store: &Store,
         name: IdentId,
@@ -573,6 +588,10 @@ impl MonorubyErr {
 
     pub(crate) fn is_not_class(name: String) -> MonorubyErr {
         MonorubyErr::typeerr(format!("{name} is not a class"))
+    }
+
+    pub(crate) fn is_not_module(name: String) -> MonorubyErr {
+        MonorubyErr::typeerr(format!("{name} is not a module"))
     }
 
     pub(crate) fn superclass_mismatch(name: IdentId) -> MonorubyErr {

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -547,6 +547,52 @@ fn cache_invalidation_define_method() {
 //
 
 #[test]
+fn super_no_superclass_method() {
+    // A `super` with no superclass method raises a `super`-specific
+    // NoMethodError, not the ordinary "undefined method" message.
+    run_test_with_prelude(
+        r##"
+        begin
+          B.new.foo
+        rescue NoMethodError => e
+          # Only the `super` prefix is portable; the receiver rendering
+          # differs from CRuby, so don't compare the whole message.
+          e.message.start_with?("super: no superclass method")
+        end
+        "##,
+        r##"
+        class A; end
+        class B < A
+          def foo; super; end
+        end
+        "##,
+    );
+}
+
+#[test]
+fn class_module_reopen_type_error() {
+    // Reopening a constant with the wrong keyword names the *constant*
+    // (`X is not a class` / `is not a module`) and rejects class<->module.
+    run_test(
+        r##"
+        Nc = 1
+        module RM1; end
+        RM2 = Class.new
+        msgs = []
+        # CRuby appends a "previous definition" line; compare only the prefix.
+        begin; class Nc; end;             rescue TypeError => e; msgs << e.message.start_with?("Nc is not a class"); end
+        begin; eval("class RM1; end");    rescue TypeError => e; msgs << e.message.start_with?("RM1 is not a class"); end
+        begin; eval("module RM2; end");   rescue TypeError => e; msgs << e.message.start_with?("RM2 is not a module"); end
+        # same-kind reopen is fine
+        class GoodC; end; class GoodC; X = 1; end
+        module GoodM; end; module GoodM; Y = 2; end
+        msgs << [GoodC::X, GoodM::Y]
+        msgs
+        "##,
+    );
+}
+
+#[test]
 fn super_with_block() {
     run_test_with_prelude(
         r##"


### PR DESCRIPTION
## Summary

Fixes a cluster of `language/super_spec.rb` and `language/class_spec.rb` failures, plus a pre-existing JIT/VM crash exposed while fixing the `super` message.

### `super` with no superclass method
- Now raises a `super`-specific `NoMethodError` — `super: no superclass method \`name' for ...` — instead of a generic "undefined method" message, matching CRuby.
- **Bug fix (cached-super crash):** once the inline cache was warm, a repeated `super`-not-found call took the VM fast path straight to the `method_missing` runtime helper. That helper returned an error signal *without* setting the exception, on the assumption that `find_super` had already set it — but on a cache hit `find_super` never runs, so the VM raised `internal error: unknown exception` (`FatalError`). `invoke_method_missing` now sets the super-not-found error itself when none is pending. Verified on x86-64 and aarch64 (under qemu).

### Reopening a constant with the wrong keyword
- `class X` where `X` is not a class (or `module X` where `X` is not a module) now names the *constant* and rejects class↔module mismatches — `Nc is not a class` / `RM2 is not a module` — matching CRuby.
- This required `Process` / `Marshal` / `GC` in `builtins/startup.rb` to be declared `module` (they are Modules in CRuby); the previous looser check silently allowed reopening them as `class`.

## Spec impact
- `language/super_spec.rb`: 5 → 4 errors
- `language/class_spec.rb`: down 1 failure + 1 error

## Tests
- New unit tests `super_no_superclass_method` and `class_module_reopen_type_error` in `tests/add_coverage.rs` (CRuby-verified, prefix-compared where the receiver rendering differs).
- Full `monoruby` lib suite (1799), `add_coverage` (63), `method_call` (95), `class_chain` (4) pass on x86-64; super regression test also passes on aarch64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_