### PR TITLE
singleton class: reject instantiation and propagate frozen state

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -347,6 +347,14 @@ fn allocate(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 /// Look up the receiver class's `alloc_func` and invoke it; raise the
 /// standard "allocator undefined" TypeError when None.
 pub(crate) fn call_alloc_func(globals: &mut Globals, class_id: ClassId) -> Result<Value> {
+    // A singleton class (metaclass) can never be instantiated: `new` and
+    // `allocate` both raise TypeError in CRuby, even though the singleton
+    // inherits an allocator through its attached object's class.
+    if globals.store[class_id].get_module().is_singleton().is_some() {
+        return Err(MonorubyErr::typeerr(
+            "can't create instance of singleton class",
+        ));
+    }
     match globals.store[class_id].alloc_func() {
         Some(f) => Ok(f(class_id, globals)),
         None => Err(MonorubyErr::typeerr(format!(
@@ -387,6 +395,12 @@ pub(super) fn gen_class_new_inline(
         self_module = origin.as_class();
     }
     let class_id = self_module.id();
+
+    // Instantiating a singleton class raises TypeError; bail to the slow
+    // path (Rust `new` → `call_alloc_func`) so it does the raising.
+    if store[class_id].get_module().is_singleton().is_some() {
+        return false;
+    }
 
     let alloc_func = match store[class_id].alloc_func() {
         Some(f) => f,

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -116,10 +116,15 @@ fn bo_noop_hook(_: &mut Executor, _: &mut Globals, _lfp: Lfp, _: BytecodePtr) ->
 /// Freezes the object, preventing further modification.
 ///
 #[monoruby_builtin]
-fn freeze(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn freeze(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_val = lfp.self_val();
     if !self_val.is_packed_value() {
         self_val.set_frozen();
+        // Freezing an object also freezes its singleton class, if one has
+        // already been created (CRuby "Frozen properties").
+        if let Some(singleton) = globals.store.has_singleton(self_val) {
+            singleton.as_val().set_frozen();
+        }
     }
     Ok(self_val)
 }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -825,6 +825,10 @@ impl ClassInfoTable {
         {
             assert_eq!(singleton.id(), obj.class());
         }
+        // The singleton class of a frozen object is itself frozen.
+        if obj.is_frozen() {
+            singleton.as_val().set_frozen();
+        }
         Ok(singleton)
     }
 

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -593,6 +593,49 @@ fn class_module_reopen_type_error() {
 }
 
 #[test]
+fn singleton_class_not_instantiable() {
+    // A singleton class (metaclass) cannot be instantiated: both `new`
+    // and `allocate` raise TypeError, even though it inherits an
+    // allocator through its attached object's class.
+    run_test(
+        r##"
+        o = Object.new
+        msgs = []
+        begin; o.singleton_class.new;      rescue TypeError => e; msgs << e.message; end
+        begin; o.singleton_class.allocate; rescue TypeError => e; msgs << e.message; end
+        # Ordinary classes still allocate normally.
+        msgs << String.new("ok")
+        msgs << Class.new.new.is_a?(Object)
+        msgs
+        "##,
+    );
+}
+
+#[test]
+fn singleton_class_frozen_propagation() {
+    // The singleton class of a frozen object is frozen; freezing an object
+    // freezes its already-created singleton class.
+    run_test(
+        r##"
+        res = []
+        o = Object.new
+        o.freeze
+        res << o.singleton_class.frozen?          # created from a frozen object
+        o2 = Object.new
+        sc = o2.singleton_class
+        res << sc.frozen?                          # not yet frozen
+        o2.freeze
+        res << sc.frozen?                          # freezing the object freezes it
+        # clone(freeze: false) yields an unfrozen singleton class
+        a = Object.new
+        a.freeze
+        res << a.clone(freeze: false).singleton_class.frozen?
+        res
+        "##,
+    );
+}
+
+#[test]
 fn super_with_block() {
     run_test_with_prelude(
         r##"


### PR DESCRIPTION
## Summary

Fixes 4 examples in `language/singleton_class_spec.rb` (9 → 5 failures).

### Singleton classes are not instantiable
`Object.new.singleton_class.new` and `.allocate` previously silently allocated an instance of the attached object's class (a singleton class inherits an allocator through that class). They now raise `TypeError: can't create instance of singleton class`, matching CRuby.

- The check lives in `call_alloc_func`, so both `new` and `allocate` are covered.
- The JIT `Class#new` inliner (`gen_class_new_inline`) bails to the slow path when the resolved receiver class is a singleton, so it does the raising.

### Frozen state propagation
A singleton class now tracks the frozen state of its attached object:
- the singleton class of an already-frozen object is created frozen (`get_singleton`);
- freezing an object also freezes its already-created singleton class (`Object#freeze`).

`clone(freeze: false)` still yields an unfrozen singleton class (the previously-passing example is unaffected), and freezing a class continues to freeze its metaclass — both verified against CRuby.

## Tests
- New unit tests `singleton_class_not_instantiable` and `singleton_class_frozen_propagation` in `tests/add_coverage.rs` (CRuby-verified).
- Full `monoruby` lib suite (1799), `add_coverage` (65), `class_chain` (4) pass on x86-64; both new tests also pass on aarch64 (qemu).
- `core/kernel/freeze_spec.rb` and `core/kernel/frozen_spec.rb` still pass (no regression from the broadened `freeze`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_