### PR TITLE
bytecodegen: support splat in index-assignment targets

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -176,6 +176,16 @@ enum LvalueKind {
         // the number of indices
         num: usize,
     },
+    /// base[index1, ..., *splat, ...] = src   (index list contains a splat)
+    /// The index args occupy `num` registers starting at `index1` (some of
+    /// them splatted per `splat_pos`); `src` is the trailing register at
+    /// `index1 + num`, and the whole thing lowers to a `[]=` call.
+    IndexSplat {
+        base: BcReg,
+        index1: BcTemp,
+        num: usize,
+        splat_pos: Vec<usize>,
+    },
     Send {
         recv: BcReg,
         method: IdentId,
@@ -1470,7 +1480,21 @@ impl<'a> BytecodeGen<'a> {
                 LvalueKind::DynamicVar { outer, dst }
             }
             NodeKind::Index { box base, index } => {
-                if index.len() == 1 {
+                if index.iter().any(|i| i.is_splat()) {
+                    // `a[*idx] = v` / `a[i, *idx, j] = v`: the index list
+                    // expands at runtime, so lower it like a `[]=` call whose
+                    // trailing argument is the assigned value.
+                    let base = self.push_expr(base.clone())?.into();
+                    let index1 = self.sp();
+                    let (_, num, splat_pos) = self.ordinary_args(index.clone())?;
+                    self.push(); // register for src.
+                    LvalueKind::IndexSplat {
+                        base,
+                        index1,
+                        num,
+                        splat_pos,
+                    }
+                } else if index.len() == 1 {
                     let base = self.push_expr(base.clone())?.into();
                     let index = self.push_expr(index[0].clone())?;
                     self.push(); // register for src.
@@ -1557,6 +1581,30 @@ impl<'a> BytecodeGen<'a> {
             LvalueKind::Index2 { base, index1, num } => {
                 let callsite =
                     CallSite::simple(IdentId::_INDEX_ASSIGN, num + 1, index1.into(), base, None);
+                self.emit_mov((index1 + num).into(), src);
+                self.set_temp(old_temp);
+                self.emit_call(callsite, loc);
+            }
+            LvalueKind::IndexSplat {
+                base,
+                index1,
+                num,
+                splat_pos,
+            } => {
+                // `[]=` with `num` (possibly splatted) index args plus the
+                // trailing assigned value at `index1 + num`.
+                let callsite = CallSite::new(
+                    IdentId::_INDEX_ASSIGN,
+                    num + 1,
+                    None,
+                    splat_pos,
+                    None,
+                    None,
+                    index1.into(),
+                    base,
+                    None,
+                    false,
+                );
                 self.emit_mov((index1 + num).into(), src);
                 self.set_temp(old_temp);
                 self.emit_call(callsite, loc);

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -159,3 +159,35 @@ fn nested_assign() {
         "def g; (*a = [3, 4]); end; g",
     ]);
 }
+
+#[test]
+fn index_assign_with_splat() {
+    // `a[*idx] = v` and friends: the index list is expanded at runtime and
+    // the whole thing lowers to a `[]=` call whose trailing arg is `v`.
+    run_tests(&[
+        // Single splat index.
+        "a = []; a[*[0]] = 10; a",
+        "a = []; x = [2]; a[*x] = 99; a",
+        // Splat mixed with fixed indices (front / middle / back).
+        r##"
+        class Obj
+          attr_reader :result
+          def []=(*args); @result = args; end
+        end
+        b = Obj.new
+        b[1, *[2, 3], 4] = 5
+        b.result
+        "##,
+        // Multiple assignment, both targets are splat-indexed.
+        "a = []; a[*[1]], a[*[2]] = 1, 2; a",
+        // Nested / mixed with a plain-index target.
+        "c = []; d = []; c[*[0]], d[0] = :a, :b; [c, d]",
+        // The splat expression is a method call.
+        "def idx; [2]; end; e = []; e[*idx] = :hit; e",
+        // Value of an index-splat assignment is the RHS, not the `[]=` result.
+        "d = []; (d[*[0]] = 7)",
+        // Op-assign through a splat index.
+        "a = [10, 20, 30]; a[*[1]] += 5; a",
+        "h = Hash.new(0); k = [:x]; h[*k] += 1; h[*k] += 1; h[:x]",
+    ]);
+}


### PR DESCRIPTION
## Summary

`a[*idx] = v`, `a[i, *idx, j] = v`, and their multiple-assignment / op-assign forms previously raised `NotImplementedError: unsupported lhs Splat(...)`: `eval_lvalue` evaluated each index element as a plain expression and hit the bare-`Splat` reject. Because these appear at file scope in several ruby/spec `language` files, the whole file failed to **load**.

## Change

Add an `IndexSplat` lvalue kind. When the index list of an assignment target contains a splat, `eval_lvalue` now builds the index args via `ordinary_args` (which expands splats and records their positions) and lowers the assignment to a `[]=` call whose trailing argument is the assigned value, carrying the splat positions so the runtime expands them. The non-splat `Index` / `Index2` paths are unchanged. The assignment expression still evaluates to the RHS (Ruby semantics), not the `[]=` return value.

## Spec impact

Four `language` spec files that previously errored out at parse time now load and run:
- `array_spec.rb` (+24 examples), `method_spec.rb` (+168), `optional_assignments_spec.rb` (+74), `send_spec.rb` (+78).

`case_spec.rb` and `variables_spec.rb` advance past the index-splat blocker to distinct, unrelated blockers (`when *array` without a subject; parenthesized-splat mlhs) — separate follow-ups.

## Tests

- New `index_assign_with_splat` test in `tests/mul_assign.rs` covering single / mixed / multiple-assignment / method-call / value-semantics / op-assign forms (all CRuby-verified).
- Full `monoruby` lib suite (1799) and `mul_assign` pass on x86-64; the new test also passes on aarch64 (qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_