### PR TITLE
bytecodegen: support splat in subject-less case/when

### DIFF
--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -573,6 +573,10 @@ impl<'a> BytecodeGen<'a> {
                 let op2 = self.slot_id(&rhs);
                 Bytecode::from(enc_www(40, 0, op1.0, op2.0))
             }
+            BytecodeInst::ArrayAny { reg } => {
+                let op1 = self.slot_id(&reg);
+                Bytecode::from(enc_www(43, 0, op1.0, 0))
+            }
             BytecodeInst::LoadDynVar { dst, src, outer } => {
                 let op1 = self.slot_id(&dst);
                 let op2 = self.slot_id(&src);

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1150,7 +1150,7 @@ impl<'a> BytecodeGen<'a> {
         Ok(())
     }
 
-    fn gen_array(&mut self, ret: BcReg, nodes: Vec<Node>, loc: Loc) -> Result<()> {
+    pub(super) fn gen_array(&mut self, ret: BcReg, nodes: Vec<Node>, loc: Loc) -> Result<()> {
         if nodes.len() <= LITERAL_CHUNK_LEN {
             let (src, len, splat) = self.ordinary_args(nodes)?;
             self.popn(len);

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -166,6 +166,11 @@ pub(super) enum BytecodeInst {
         lhs: BcReg,
         rhs: BcReg,
     },
+    /// Subject-less `case`/`when *arr` match: set `reg` to `true` if any
+    /// element of the array in `reg` is truthy, `false` otherwise.
+    ArrayAny {
+        reg: BcReg,
+    },
     Cmp(CmpKind, Option<BcReg>, (BcReg, BcReg), bool), // kind, dst, (lhs, rhs), optimizable
     Mov(BcReg, BcReg),                                 // dst, offset
     ToA {

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -233,6 +233,35 @@ impl<'a> BytecodeGen<'a> {
         }
     }
 
+    /// Emit the condition test for one `when` value of a *subjectless*
+    /// `case` (`case; when cond; ...`), where each `when` value is tested
+    /// for plain truthiness rather than `===`.
+    fn gen_case_cond_condbr(
+        &mut self,
+        when: Node,
+        cont_pos: Label,
+        jmp_if_true: bool,
+    ) -> Result<()> {
+        if when.is_splat() {
+            // `when *arr` with no subject matches when any element of `arr`
+            // is truthy. `when` is the `Splat` node itself, so wrapping it in
+            // an array literal expands the splat (mirroring CRuby's
+            // `splatarray`); `ArrayAny` then tests truthiness of any element
+            // (CRuby's `checkmatch` with `VM_CHECKMATCH_TYPE_WHEN`), without
+            // any user-visible method call.
+            let loc = when.loc;
+            let old = self.temp;
+            let arr: BcReg = self.push().into();
+            self.gen_array(arr, vec![when], loc)?;
+            self.emit(BytecodeInst::ArrayAny { reg: arr }, loc);
+            self.temp = old;
+            self.emit_condbr(arr, cont_pos, jmp_if_true, false);
+            Ok(())
+        } else {
+            self.gen_opt_condbr(jmp_if_true, when, cont_pos)
+        }
+    }
+
     pub(super) fn gen_case(
         &mut self,
         cond: Option<Box<Node>>,
@@ -340,11 +369,11 @@ impl<'a> BytecodeGen<'a> {
                 let succ_pos = self.new_label();
                 if when.len() == 1 {
                     let when = when.remove(0);
-                    self.gen_opt_condbr(false, when, succ_pos)?;
+                    self.gen_case_cond_condbr(when, succ_pos, false)?;
                 } else {
                     let then_pos = self.new_label();
                     for when in when {
-                        self.gen_opt_condbr(true, when, then_pos)?;
+                        self.gen_case_cond_condbr(when, then_pos, true)?;
                     }
                     self.emit_br(succ_pos);
                     self.apply_label(then_pos);

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -733,6 +733,7 @@ pub(crate) struct VmHandlers {
     pub array_teq: CodePtr,           // 40
     pub array_concat: CodePtr,        // 41
     pub hash_insert: CodePtr,         // 42
+    pub array_any: CodePtr,           // 43
     pub defined_yield: CodePtr,       // 64
     pub defined_const: CodePtr,       // 65
     pub defined_method: CodePtr,      // 66
@@ -841,6 +842,7 @@ impl Codegen {
         self.dispatch[40] = h.array_teq;
         self.dispatch[41] = h.array_concat;
         self.dispatch[42] = h.hash_insert;
+        self.dispatch[43] = h.array_any;
 
         self.dispatch[64] = h.defined_yield;
         self.dispatch[65] = h.defined_const;

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3655,6 +3655,32 @@ impl Codegen {
         true
     }
 
+    /// `any element truthy` for the array in `reg` via runtime::array_any
+    /// (x0=vm, x1=globals, x2=val); Value result in x0. Cannot raise.
+    pub(in crate::codegen::jitgen) fn emit_array_any(
+        &mut self,
+        reg: SlotId,
+        using_fpr: UsingFpr,
+    ) -> bool {
+        let lfp = GP::R14.a64().0;
+        let off = reg.0 as u32 * 8 + LFP_SELF as u32;
+        let f = runtime::array_any as *const () as u64;
+        self.emit_fpr_save(using_fpr, false);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;                 // vm
+            mov x1, x20;                 // globals
+        );
+        self.a64_frame_load(2, lfp, off); // x2 = val
+        monoasm_arm64!(&mut self.jit,
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.emit_fpr_restore(using_fpr, false);
+        true
+    }
+
     /// Build a Regexp from the `len` interpolated parts based at slot `arg` via
     /// runtime::concatenate_regexp (x0=vm, x1=globals, x2=&arg, x3=len);
     /// Option<Value> result in x0. The runtime reads `arg, arg-1, …` (descending

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -103,6 +103,7 @@ impl Codegen {
         // literal constructors / aggregate ops
         let array = self.a64_op_array();
         let array_teq = self.a64_op_array_teq();
+        let array_any = self.a64_op_array_any();
         let array_concat = self.a64_op_array_concat();
         let hash = self.a64_op_hash();
         let hash_insert = self.a64_op_hash_insert();
@@ -188,6 +189,7 @@ impl Codegen {
             lambda,
             array,
             array_teq,
+            array_any,
             array_concat,
             hash_insert,
             defined_yield,
@@ -804,6 +806,36 @@ impl Codegen {
             blr x9;
             cbz x0, raise;
         // dst slot = lhs slot from [PC+2]
+            ldrh x10, [x(PC.0), #(2)];
+            cbz x10, skip;
+            neg x10, x10;
+            add x11, x(LFP.0), x10, lsl #(3);
+            stur x0, [x11, #(-(LFP_SELF as i32))];
+            skip:
+            add x(PC.0), x(PC.0), #(16);
+        );
+        self.a64_fetch_and_dispatch();
+        p
+    }
+
+    /// op 43 `ArrayAny`: %reg = any element of the array in %reg is truthy.
+    /// The result overwrites the reg slot. Bytecode: `+2` reg (also dst).
+    /// `array_any` returns a plain `Value` and cannot raise.
+    pub(in crate::codegen) fn a64_op_array_any(&mut self) -> CodePtr {
+        let p = self.jit.get_current_address();
+        let skip = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            ldrh x11, [x(PC.0), #(2)];  // reg slot (also dst)
+        );
+        self.a64_load_slot(X11, X3, X12); // X3 = val
+        // array_any(vm, globals, val) -> Value
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x3;  // val (arg #3)
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            mov x9, (runtime::array_any as *const () as u64);
+            blr x9;
+        // dst slot = reg slot from [PC+2]
             ldrh x10, [x(PC.0), #(2)];
             cbz x10, skip;
             neg x10, x10;

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -138,6 +138,7 @@ impl Codegen {
             | AsmInst::DefinedCvar { .. }
             | AsmInst::GenericBinOp { .. }
             | AsmInst::ArrayTEq { .. }
+            | AsmInst::ArrayAny { .. }
             | AsmInst::ConcatRegexp { .. }
             | AsmInst::CheckKwRest(..)
             | AsmInst::ExpandArray { .. }
@@ -1181,6 +1182,20 @@ impl Codegen {
         self.fpr_restore(using_fpr);
     }
 
+    /// `any element truthy` for the array in `reg` via runtime::array_any
+    /// (rdi=vm, rsi=globals, rdx=val); result Value in rax. Cannot raise.
+    fn array_any(&mut self, reg: SlotId, using_fpr: UsingFpr) {
+        self.fpr_save(using_fpr);
+        self.load_rdx(reg);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::array_any);
+            call rax;
+        );
+        self.fpr_restore(using_fpr);
+    }
+
     ///
     /// Call a generic `BinaryOpFn` C helper with no receiver-class
     /// guard. Mirrors the VM's `call_binop` calling convention
@@ -1812,6 +1827,15 @@ impl Codegen {
         using_fpr: UsingFpr,
     ) -> bool {
         self.array_teq(lhs, rhs, using_fpr);
+        true
+    }
+
+    pub(in crate::codegen::jitgen) fn emit_array_any(
+        &mut self,
+        reg: SlotId,
+        using_fpr: UsingFpr,
+    ) -> bool {
+        self.array_any(reg, using_fpr);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -278,6 +278,7 @@ impl Codegen {
             lambda: self.vm_lambda(),
             array: self.vm_array(),
             array_teq: self.vm_array_teq(),
+            array_any: self.vm_array_any(),
             array_concat: self.vm_array_concat(),
             hash_insert: self.vm_hash_insert(),
             defined_yield: self.vm_defined_yield(),
@@ -836,6 +837,26 @@ impl Codegen {
             call rax;
         };
         self.vm_handle_error();
+        self.vm_store_r15(GP::Rax);
+        self.fetch_and_dispatch();
+        label
+    }
+
+    fn vm_array_any(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        monoasm! { &mut self.jit,
+            movzxw rdi, [r13 - 14];     // rdi <- :2 (reg, also dst)
+            movl   r15, rdi;
+        }
+        self.vm_get_slot_value(GP::Rdi);
+        monoasm! { &mut self.jit,
+            movq rdx, rdi;
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::array_any);
+            call rax;
+        };
+        // array_any returns a plain `Value` and cannot raise.
         self.vm_store_r15(GP::Rax);
         self.fetch_and_dispatch();
         label

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -681,6 +681,14 @@ impl AsmIr {
         });
     }
 
+    ///
+    /// Set rax to true iff any element of the array in `reg` is truthy.
+    ///
+    pub(super) fn array_any(&mut self, state: &AbstractFrame, reg: SlotId) {
+        let using_fpr = state.using_fpr_offset();
+        self.push(AsmInst::ArrayAny { reg, using_fpr });
+    }
+
     pub(crate) fn generic_binop(
         &mut self,
         state: &AbstractFrame,
@@ -1752,6 +1760,15 @@ pub(super) enum AsmInst {
     ArrayTEq {
         lhs: SlotId,
         rhs: SlotId,
+        using_fpr: UsingFpr,
+    },
+
+    ///
+    /// Subject-less `when *arr`: rax = true iff any element of the array in
+    /// `reg` is truthy.
+    ///
+    ArrayAny {
+        reg: SlotId,
         using_fpr: UsingFpr,
     },
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -806,6 +806,9 @@ impl Codegen {
             AsmInst::ArrayTEq { lhs, rhs, using_fpr } => {
                 self.encode_linst(LInst::ArrayTEq { lhs, rhs, using_fpr })
             }
+            AsmInst::ArrayAny { reg, using_fpr } => {
+                self.encode_linst(LInst::ArrayAny { reg, using_fpr })
+            }
             // Regexp interpolation / keyword-rest fixup runtime calls.
             AsmInst::ConcatRegexp { arg, len, using_fpr } => {
                 self.encode_linst(LInst::ConcatRegexp { arg, len, using_fpr })
@@ -1291,6 +1294,9 @@ impl Codegen {
             }
             LInst::ArrayTEq { lhs, rhs, using_fpr } => {
                 self.emit_array_teq(lhs, rhs, using_fpr);
+            }
+            LInst::ArrayAny { reg, using_fpr } => {
+                self.emit_array_any(reg, using_fpr);
             }
             LInst::ConcatRegexp { arg, len, using_fpr } => {
                 self.emit_concat_regexp(arg, len, using_fpr);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -571,6 +571,17 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
 
+            TraceIr::ArrayAny { reg } => {
+                state.flush_gp(ir);
+                state.write_back_slots(ir, &[reg]);
+                state.discard(reg);
+                // `array_any` performs no user-visible call and cannot raise,
+                // so no error edge is needed.
+                ir.array_any(state, reg);
+                state.def_rax2acc(ir, reg);
+                state.unset_side_effect_guard();
+            }
+
             TraceIr::ToA { dst, src } => {
                 state.flush_gp(ir);
                 let error = ir.new_error(state);

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -787,6 +787,10 @@ pub(in crate::codegen) enum LInst {
         rhs: SlotId,
         using_fpr: UsingFpr,
     },
+    ArrayAny {
+        reg: SlotId,
+        using_fpr: UsingFpr,
+    },
     ConcatRegexp {
         arg: SlotId,
         len: u16,

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -194,6 +194,9 @@ pub(crate) enum TraceIr {
         lhs: SlotId,
         rhs: SlotId,
     },
+    ArrayAny {
+        reg: SlotId,
+    },
     Index {
         _dst: SlotId,
         base: SlotId,
@@ -482,6 +485,12 @@ impl TraceIr {
                     TraceIr::ArrayTEq {
                         lhs: SlotId::new(op1_w2),
                         rhs: SlotId::new(op1_w3),
+                    }
+                }
+                43 => {
+                    let (_, op1_w2, _) = dec_www(op1);
+                    TraceIr::ArrayAny {
+                        reg: SlotId::new(op1_w2),
                     }
                 }
                 41 => {
@@ -1001,6 +1010,10 @@ impl TraceIr {
 
             TraceIr::ArrayTEq { lhs, rhs } => {
                 format!("{lhs:?} = *{lhs:?} === {rhs:?}")
+            }
+
+            TraceIr::ArrayAny { reg } => {
+                format!("{reg:?} = any_truthy(*{reg:?})")
             }
 
             TraceIr::Ret(reg) => format!("ret {:?}", reg),

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -245,6 +245,21 @@ pub(super) extern "C" fn array_teq(
     }
 }
 
+/// Subject-less `case`/`when *arr` match: true iff any element of `arr` is
+/// truthy. Mirrors CRuby's `checkmatch` with `VM_CHECKMATCH_TYPE_WHEN |
+/// VM_CHECKMATCH_ARRAY` — plain truthiness (`RTEST`) of each element, with
+/// no `===` and no user-visible method call. `val` is always an Array here
+/// (the caller wraps the splat in an array literal); a non-Array is treated
+/// as its own truthiness for safety.
+pub(super) extern "C" fn array_any(_vm: &mut Executor, _globals: &mut Globals, val: Value) -> Value {
+    let any = if let Some(ary) = val.try_array_ty() {
+        ary.iter().any(|e| e.as_bool())
+    } else {
+        val.as_bool()
+    };
+    Value::bool(any)
+}
+
 pub(super) extern "C" fn gen_lambda(
     vm: &mut Executor,
     _: &mut Globals,

--- a/monoruby/tests/case.rs
+++ b/monoruby/tests/case.rs
@@ -235,3 +235,46 @@ fn case_opt5() {
         "#,
     );
 }
+
+#[test]
+fn case_when_splat() {
+    // Subject-less `case` with a splat `when *arr`: matches when any
+    // element of `arr` is truthy.
+    run_tests(&[
+        r#"
+        def t(arr)
+          case
+          when *arr then "match"
+          else "no"
+          end
+        end
+        [t([false, nil]), t([false, 3]), t([]), t([nil]), t([true])]
+        "#,
+        // Splat combined with an ordinary condition (boolean disjunction).
+        r#"
+        def u(x)
+          case
+          when *[false], x then "y"
+          else "n"
+          end
+        end
+        [u(true), u(false)]
+        "#,
+        // Multiple splat `when` clauses pick the first truthy one.
+        r#"
+        case
+        when *[false] then "a"
+        when *[nil, 7] then "b"
+        else "c"
+        end
+        "#,
+        // With-subject splat still works (=== against each element).
+        r#"
+        case 3
+        when *[1, 2] then "lo"
+        when *[3, 4] then "hi"
+        else "no"
+        end
+        "#,
+    ]);
+}


### PR DESCRIPTION
## Summary

`case; when *arr; ...` — a `when` clause with a splat but no case subject — previously raised `NotImplementedError: unsupported lhs Splat(...)`. The subject-less path fed each `when` value straight to `gen_opt_condbr`, which rejects a bare splat. Because such clauses appear at file scope, `language/case_spec.rb` failed to **load** entirely.

## Change

A subject-less `when *arr` matches when any element of `arr` is truthy (CRuby treats each `when` value as a plain condition, so a splat is a boolean disjunction over its elements — verified against CRuby). This mirrors CRuby's own lowering, `splatarray` + `checkmatch` with `VM_CHECKMATCH_TYPE_WHEN | VM_CHECKMATCH_ARRAY`:

- Wrap the splat node in an array literal so the splat expands (`splatarray`).
- Test truthiness of any element with a **new dedicated `ArrayAny` bytecode** (opcode 43), *not* a `[*arr].any?` method call. `ArrayAny` calls `runtime::array_any`, which `RTEST`s each element with no user-visible dispatch (so redefining `Array#any?` can't change `case` semantics).

`ArrayAny` is lowered on both the x86-64 and aarch64 VM and JIT backends (mirroring the existing `ArrayTEq`). The with-subject splat path (`ArrayTEq`, i.e. `===` against each element) is unchanged.

## Spec impact

`language/case_spec.rb` now loads and runs: **0 → 50 examples**. The two remaining failures are unrelated pre-existing gaps (private `===` visibility; duplicate-`when` compile warning).

## Tests

- New `case_when_splat` test in `tests/case.rs` covering truthiness matching, disjunction with an ordinary condition, first-match selection, and the unchanged with-subject splat path (all CRuby-verified). The `run_tests` harness exercises both the VM and the JIT (25× warmup loop).
- Full `monoruby` lib suite (1799) and `case` (13) pass on x86-64; the new test and both VM + JIT paths of `ArrayAny` also pass on aarch64 (qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)