### PR TITLE
bytecodegen: handle arity-mismatch and rest in multiple assignment

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -962,11 +962,8 @@ impl<'a> BytecodeGen<'a> {
         use_mode: UseMode2,
     ) -> Result<()> {
         let mlhs_len = mlhs.len();
-        let mut mrhs_len = mrhs.len();
+        let mrhs_len = mrhs.len();
         let loc = mlhs[0].loc().merge(mrhs.last().unwrap().loc());
-        if mlhs_len != mrhs_len && mrhs_len != 1 {
-            return Err(self.unsupported_feature("mlhs_len != mrhs_len", loc));
-        };
 
         let temp = self.temp;
 
@@ -993,30 +990,45 @@ impl<'a> BytecodeGen<'a> {
         }
 
         // Next, we evaluate rvalues and save them in temporary registers which start from temp_reg.
-        let (rhs_reg, ret_val) = if mlhs_len != 1 && mrhs_len == 1 {
-            let rhs = self.push_expr(std::mem::take(&mut mrhs[0]))?.into();
-            mrhs_len = mlhs_len;
+        //
+        // When the mlhs has a rest target (`a, *b = ...`) or the arities
+        // differ, CRuby collects the whole rhs into one array and
+        // destructures it (distributing to the rest, truncating extras, or
+        // nil-filling shortfalls). Only a rest-free, equal-arity mlhs uses a
+        // true parallel assignment (which keeps `a, b = b, a` swap
+        // semantics). The whole assignment expression evaluates to the rhs
+        // array in either case.
+        let use_expand = rest_pos.is_some() || mlhs_len != mrhs_len;
+        let (rhs_reg, ret_val) = if use_expand {
+            // A single source value to expand: the lone rhs itself when
+            // there is one, otherwise the collected `[rhs0, rhs1, ..]` array.
+            let src: BcReg = if mrhs_len == 1 {
+                self.push_expr(std::mem::take(&mut mrhs[0]))?.into()
+            } else {
+                let arr: BcReg = self.push().into();
+                self.gen_array(arr, mrhs, loc)?;
+                arr
+            };
             let rhs_reg = self.sp();
-            let lhs_len = lhs_kind
-                .iter()
-                .filter(|kind| !matches!(kind, MulLhs::Leaf(LvalueKind::Discard)))
-                .count();
-            for _ in 0..lhs_len {
+            // One expanded slot per mlhs target (including discards), so the
+            // per-target indices below line up with the `ExpandArray` output.
+            let expand_len = lhs_kind.len();
+            for _ in 0..expand_len {
                 self.push();
             }
             self.emit(
-                BytecodeInst::ExpandArray(rhs, rhs_reg.into(), lhs_len as u16, rest_pos),
+                BytecodeInst::ExpandArray(src, rhs_reg.into(), expand_len as u16, rest_pos),
                 Loc::default(),
             );
-            // lhs0, lhs1, .. = rhs
+            // lhs0, lhs1, .. = src
             //
-            //   temp               rhs   rhs_reg         sp
-            //   v                  v     v               v
-            // -+-----------------+-----+---------------+--
-            //  | lhs working reg | rhs | lhs * lhs_len |
-            // -+-----------------+-----+---------------+--
+            //   temp               src   rhs_reg              sp
+            //   v                  v     v                    v
+            // -+-----------------+-----+--------------------+--
+            //  | lhs working reg | src | lhs * expand_len   |
+            // -+-----------------+-----+--------------------+--
             //
-            (rhs_reg, Some(rhs))
+            (rhs_reg, Some(src))
         } else {
             let rhs_reg = self.sp();
             for rhs in mrhs {

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -161,6 +161,50 @@ fn nested_assign() {
 }
 
 #[test]
+fn multi_assign_arity_mismatch() {
+    // A multiple assignment whose lhs has a rest target, or whose arities
+    // differ, collects the rhs into an array and destructures it:
+    // extras truncate, shortfalls nil-fill, and a rest slot soaks up the
+    // middle. The expression evaluates to the whole rhs array.
+    run_tests(&[
+        // Too many rhs values: extras are dropped.
+        "a, b = 1, 2, 3; [a, b]",
+        "a, b, c = 1, 2, 3, 4, 5; [a, b, c]",
+        // Too few: missing targets become nil.
+        "a, b, c = 1, 2; [a, b, c]",
+        "a, b, c = 1; [a, b, c]",
+        // Rest target with equal / longer / shorter rhs.
+        "a, *b = 1, 2; [a, b]",
+        "a, *b = 1, 2, 3, 4; [a, b]",
+        "a, *b = 1; [a, b]",
+        "a, *b = 5; [a, b]",
+        // Rest in the head / middle / with a trailing target.
+        "*a, z = 1, 2, 3; [a, z]",
+        "a, *b, c = 1, 2, 3, 4, 5; [a, b, c]",
+        "a, *b, c = 1, 2; [a, b, c]",
+        // Lone splat lhs collects everything.
+        "*a = 1, 2, 3; a",
+        // Anonymous rest / trailing splat discard the collected part.
+        "*, z = 1, 2, 3; z",
+        "a, * = 1, 2, 3; a",
+        // Splats inside the rhs are flattened before distribution.
+        "a, b, c = 1, *[2, 3]; [a, b, c]",
+        "a, *b = 0, *[1, 2, 3]; [a, b]",
+        "x, y, z = *[1, 2], 3; [x, y, z]",
+        // Index / attr targets, mixed with a rest.
+        "arr = [0, 0, 0]; arr[0], arr[1] = 1, 2, 3; arr",
+        "h = {}; h[:a], *h[:b] = 1, 2, 3; [h[:a], h[:b]]",
+        // Value of the assignment is the whole rhs array.
+        "x = (a, b, c = 1, 2); [x, a, b, c]",
+        "(a, b = 1, 2, 3)",
+        "(a, *b = 1, 2)",
+        "def f; a, *b = 1, 2, 3; end; f",
+        // Equal arity, no rest: still a plain parallel assignment (swaps).
+        "x, y = 5, 6; x, y = y, x; [x, y]",
+    ]);
+}
+
+#[test]
 fn index_assign_with_splat() {
     // `a[*idx] = v` and friends: the index list is expanded at runtime and
     // the whole thing lowers to a `[]=` call whose trailing arg is `v`.


### PR DESCRIPTION
## Summary

Common multiple-assignment forms were broken:

| Form | Before | Expected |
|------|--------|----------|
| `a, b = 1, 2, 3` | `NotImplementedError: mlhs_len != mrhs_len` | `a=1, b=2` (truncate) |
| `a, b, c = 1, 2` | `NotImplementedError` | `a=1, b=2, c=nil` (nil-fill) |
| `a, *b = 1, 2` | `b == 2` (wrong) | `b == [2]` |
| `a, *b = 1, 2, 3, 4` | `NotImplementedError` | `b == [2, 3, 4]` |
| `*a = 1, 2, 3` / `*a, z = 1, 2, 3` | `NotImplementedError` | `a == [1,2,3]` / `a==[1,2], z==3` |

`gen_mul_assign` only supported a parallel assignment (equal arity, no rest) or a single-array rhs. When the rhs held several values it never collected them into an array, so a rest target or an arity mismatch had nowhere to distribute them, and an erroring guard rejected the mismatch outright.

## Change

Whenever the mlhs has a rest target **or** the arities differ, the rhs values are collected into one array and destructured with `ExpandArray` (distributing to the rest slot, truncating extras, nil-filling shortfalls) — reusing the mechanism of the existing single-array-rhs path. A rest-free, equal-arity mlhs still uses a true parallel assignment, so `a, b = b, a` keeps its swap semantics. `ExpandArray` now emits one slot per mlhs target (including discards) so the per-target writes stay aligned with the assignment loop. The whole assignment still evaluates to the rhs array.

## Spec impact

`language/variables_spec.rb` now loads and runs: **0 → 119 examples** (it previously errored out at parse time). The remaining failures/errors are unrelated pre-existing gaps.

## Tests

- New `multi_assign_arity_mismatch` test in `tests/mul_assign.rs` (24 forms: truncate / nil-fill / rest in head/middle/tail / lone & anonymous splat / rhs-splat flattening / index & attr targets / value semantics / swap), all CRuby-verified. `run_tests` exercises both the VM and JIT.
- Full `monoruby` lib suite (1799), all integration tests, and `mul_assign` pass on x86-64; the new test and smoke cases also pass on aarch64 (qemu). No regressions in `optional_assignments` / `block` / `method` specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_