### PR TITLE
parser: support numbered parameters in lambdas

### DIFF
--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -3007,6 +3007,28 @@ impl<'pr> Lowerer<'pr> {
                                 loc: ip_loc,
                             }]
                         }
+                        prism::Node::NumberedParametersNode { .. } => {
+                            // `-> { _1 + _2 }` — numbered params in a
+                            // lambda behave exactly like in a block; mirror
+                            // the block-form arm.
+                            let np = p.as_numbered_parameters_node().unwrap();
+                            let max = np.maximum() as usize;
+                            let np_loc = location_to_loc(&np.location());
+                            let mut out = Vec::with_capacity(max);
+                            for i in 1..=max {
+                                let name = format!("_{i}");
+                                this.lvars.insert(&name);
+                                out.push(crate::ast::FormalParam {
+                                    kind: ParamKind::Param(name),
+                                    loc: np_loc,
+                                });
+                            }
+                            if max > 0 {
+                                this.lvars.numbered_param = Some(np_loc);
+                                this.lvars.numbered_param_max = max as u8;
+                            }
+                            out
+                        }
                         other => return Err(this.unsupported("lambda parameters", &other)),
                     },
                 };

--- a/monoruby/tests/numbered_param.rs
+++ b/monoruby/tests/numbered_param.rs
@@ -59,3 +59,15 @@ fn it_param_lambda() {
 fn it_param_shadowed_by_local() {
     run_test("it = 5; it + 1");
 }
+
+#[test]
+fn numbered_param_lambda() {
+    // Numbered parameters in a `->`/`lambda` body, like in a block.
+    run_test("f = ->{ _1 }; f.call(5)");
+    run_test("f = ->{ _1 + _2 }; f.call(3, 4)");
+    run_test("f = lambda { _1 * 10 }; f.call(2)");
+    run_test("[->{ _1 }.arity, ->{ _1 + _2 }.arity]");
+    run_test("f = ->{ [_1, _2, _3] }; f.call(1, 2, 3)");
+    // JIT warm-up loop.
+    run_test("f = ->{ _1 + _2 }; s = 0; i = 0; while i < 200; s += f.call(i, 1); i += 1; end; s");
+}


### PR DESCRIPTION
## Summary

`-> { _1 }` / `lambda { _1 + _2 }` raised `SyntaxError: prism lowerer hit an unsupported node lambda parameters:NumberedParametersNode`. The lambda parameter lowering (`lower_lambda`) handled block-parameter and `it`-parameter shapes but not `NumberedParametersNode` — even though the ordinary block form already did. Since these appear at file scope, `language/numbered_parameters_spec.rb` failed to **load** entirely.

## Change

Mirror the block-form `NumberedParametersNode` arm in `lower_lambda`: synthesize one `_N` param per referenced index (up to `np.maximum()`) and set the `numbered_param` flag on the collector, so lambdas and blocks treat `_1`.. identically (same params, arity, and auto-binding).

## Spec impact

`language/numbered_parameters_spec.rb` now loads and runs: **0 → 13 examples**. The two remaining failures are unrelated pre-existing gaps (`_10` raising `NoMethodError` instead of `NameError`; `binding.local_variables` introspection).

## Tests

- New `numbered_param_lambda` test in `tests/numbered_param.rs` (`_1`/`_2`/`_3`, `lambda {}` form, `.arity`, hot-loop JIT), all CRuby-verified.
- Full `monoruby` lib suite (1799) and `numbered_param` (7) pass on x86-64; the new test also passes on aarch64 (qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_