### PR TITLE
parser: support destructuring / non-local targets in `for` loops

### DIFF
--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -44,6 +44,14 @@ use crate::id_table::IdentId;
 const ANON_REST_NAME: &str = "*";
 const ANON_KWREST_NAME: &str = "**";
 
+/// Reserved, unspellable local bound to the hidden single loop variable
+/// synthesized for a `for <complex-target> in ...` loop (one whose index
+/// has a splat / post element / nested or non-local target). The body is
+/// prefixed with `<target> = <this>` so the ordinary multiple-assignment
+/// machinery destructures each element while the targets still leak to the
+/// enclosing scope. Not a valid Ruby identifier, so it can't collide.
+const FOR_INDEX_NAME: &str = "(for)";
+
 pub(super) fn parse_program(code: String, path: PathBuf) -> Result<ParseResult, MonorubyErr> {
     try_prism_inner(&code, path, None, None, 0)
 }
@@ -905,10 +913,17 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::ForNode { .. } => {
                 let n = node.as_for_node().unwrap();
                 let index = n.index();
-                let param: Vec<(usize, String)> = match index {
+                // `prepend` is a destructuring assignment to run at the top
+                // of the body when the index can't be expressed as a flat
+                // list of leaked loop variables (splat / post / nested /
+                // non-local targets).
+                let (param, prepend): (Vec<(usize, String)>, Option<Node>) = match index {
                     prism::Node::LocalVariableTargetNode { .. } => {
                         let inner = index.as_local_variable_target_node().unwrap();
-                        vec![(inner.depth() as usize, constant_name(&inner.name())?)]
+                        (
+                            vec![(inner.depth() as usize, constant_name(&inner.name())?)],
+                            None,
+                        )
                     }
                     // `for a, b in ...` / `for (a, b) in ...` lands
                     // as MultiTargetNode. ruruby flattens this into
@@ -916,32 +931,57 @@ impl<'pr> Lowerer<'pr> {
                     prism::Node::MultiTargetNode { .. } => {
                         let mt = index.as_multi_target_node().unwrap();
                         let mt_loc = location_to_loc(&index.location());
-                        if mt.rest().is_some() {
-                            return Err(self.unsupported_node("for index with splat", mt_loc));
-                        }
-                        if mt.rights().iter().next().is_some() {
-                            return Err(
-                                self.unsupported_node("for index with post element", mt_loc)
-                            );
-                        }
-                        let mut out: Vec<(usize, String)> = Vec::new();
-                        for tgt in mt.lefts().iter() {
-                            match tgt {
-                                prism::Node::LocalVariableTargetNode { .. } => {
-                                    let inner = tgt.as_local_variable_target_node().unwrap();
-                                    out.push((
-                                        inner.depth() as usize,
-                                        constant_name(&inner.name())?,
-                                    ));
-                                }
-                                other => {
-                                    return Err(self.unsupported("for index target", &other));
-                                }
+                        // Fast path: a flat list of plain locals maps directly
+                        // to leaked loop variables.
+                        let flat = mt.rest().is_none()
+                            && mt.rights().iter().next().is_none()
+                            && mt.lefts().iter().all(|t| {
+                                matches!(t, prism::Node::LocalVariableTargetNode { .. })
+                            });
+                        if flat {
+                            let mut out: Vec<(usize, String)> = Vec::new();
+                            for tgt in mt.lefts().iter() {
+                                let inner = tgt.as_local_variable_target_node().unwrap();
+                                out.push((
+                                    inner.depth() as usize,
+                                    constant_name(&inner.name())?,
+                                ));
                             }
+                            (out, None)
+                        } else {
+                            // Desugar to a single hidden loop variable plus a
+                            // destructuring assignment; the ordinary MulAssign
+                            // machinery handles rest / post / nested targets.
+                            let lefts: Vec<_> = mt.lefts().iter().collect();
+                            let rights: Vec<_> = mt.rights().iter().collect();
+                            let mlhs = self.lower_target_list(&lefts, mt.rest(), &rights)?;
+                            let read = Node {
+                                kind: NodeKind::LocalVar(0, FOR_INDEX_NAME.to_owned()),
+                                loc: mt_loc,
+                            };
+                            let assign = Node {
+                                kind: NodeKind::MulAssign(mlhs, vec![read]),
+                                loc: mt_loc,
+                            };
+                            (vec![(0, FOR_INDEX_NAME.to_owned())], Some(assign))
                         }
-                        out
                     }
-                    other => return Err(self.unsupported("for index", &other)),
+                    // A single non-local target (`for @x in ...`,
+                    // `for CONST in ...`, `for a[i] in ...`): desugar to the
+                    // hidden loop variable plus a plain assignment.
+                    other => {
+                        let tgt = self.lower_assign_target(&other)?;
+                        let t_loc = tgt.loc;
+                        let read = Node {
+                            kind: NodeKind::LocalVar(0, FOR_INDEX_NAME.to_owned()),
+                            loc: t_loc,
+                        };
+                        let assign = Node {
+                            kind: NodeKind::MulAssign(vec![tgt], vec![read]),
+                            loc: t_loc,
+                        };
+                        (vec![(0, FOR_INDEX_NAME.to_owned())], Some(assign))
+                    }
                 };
                 let iter = self.lower_node(&n.collection())?;
                 let body_loc = match n.statements() {
@@ -954,6 +994,13 @@ impl<'pr> Lowerer<'pr> {
                         kind: NodeKind::Nil,
                         loc: body_loc,
                     },
+                };
+                let body = match prepend {
+                    Some(assign) => Node {
+                        kind: NodeKind::CompStmt(vec![assign, body]),
+                        loc: body_loc,
+                    },
+                    None => body,
                 };
                 // ruruby's `for` body lives in a `BlockInfo` whose
                 // own LvarCollector is empty — the loop variable is

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -235,3 +235,33 @@ fn index_assign_with_splat() {
         "h = Hash.new(0); k = [:x]; h[*k] += 1; h[*k] += 1; h[:x]",
     ]);
 }
+
+#[test]
+fn for_loop_destructuring_index() {
+    // `for` with a splat / post / nested / non-local index target
+    // destructures each element, and the targets still leak to the
+    // enclosing scope.
+    run_tests(&[
+        // Trailing comma / anonymous splat.
+        "r = []; for i, in [[1, 2]]; r << i; end; r",
+        "r = []; for i, * in [[1, 2, 3]]; r << i; end; r",
+        // Rest in head / middle / tail.
+        "r = []; for a, *b in [[1, 2, 3], [4, 5]]; r << [a, b]; end; r",
+        "r = []; for *a, z in [[1, 2, 3]]; r << [a, z]; end; r",
+        "r = []; for a, *b, c in [[1, 2, 3, 4]]; r << [a, b, c]; end; r",
+        // Scalar elements (single-value multiple assignment).
+        "r = []; for a, *b in [1, 2]; r << [a, b]; end; r",
+        // Nested destructure target.
+        "r = []; for a, (b, c) in [[1, [2, 3]]]; r << [a, b, c]; end; r",
+        // Targets leak to the enclosing scope.
+        "for a, *b in [[1, 2, 3]]; end; [a, b]",
+        // Single non-local targets.
+        "@x = nil; for @x in [1, 2, 3]; end; @x",
+        "arr = [0, 0]; for arr[1] in [7, 8, 9]; end; arr",
+        "r = []; for @y in [[1, 2]]; r << @y; end; r",
+        // Nested for-loops with destructuring reuse the hidden variable.
+        "r = []; for i, * in [[10, 20]]; for j, *k in [[1, 2, 3]]; r << [i, j, k]; end; end; r",
+        // Plain (flat) destructure still works unchanged.
+        "r = []; for a, b in [[1, 2], [3, 4]]; r << [a, b]; end; r",
+    ]);
+}


### PR DESCRIPTION
## Summary

`for a, *b in coll` (splat), `for *a, z in coll` (post element), `for a, (b, c) in coll` (nested), and single non-local targets like `for @x in coll` / `for a[i] in coll` raised `SyntaxError: prism lowerer hit an unsupported node for index ...`. Because these appear at file scope, `language/for_spec.rb` failed to **load** entirely.

## Change

The `for` index previously only supported a flat list of plain locals (mapped to leaked loop variables). When the index isn't a flat-local list, desugar it to:

- a **single hidden loop variable** (`(for)`, an unspellable reserved name, like the existing anonymous `*`/`**` locals), plus
- a `<target> = (for)` assignment prepended to the loop body.

The ordinary multiple-assignment machinery then handles rest / post / nested / ivar / index targets. Because the assignment runs in the body against enclosing-scope locals — with the hidden variable leaked as an ordinary `for` parameter and `level_down` bumping the target depths — the targets still **leak to the enclosing scope**, matching `for` semantics (`for a, *b in …; end; a` is visible). The flat-local fast path is unchanged.

## Spec impact

`language/for_spec.rb` now loads and runs: **0 → 33 examples, 0 failures**. The 4 remaining errors are an unrelated missing builtin (`Kernel#local_variables`).

## Tests

- New `for_loop_destructuring_index` test in `tests/mul_assign.rs` (splat head/middle/tail, scalar elements, nested target, variable leak, `@ivar`/`a[i]` targets, nested for-loops, and the unchanged flat path), all CRuby-verified. `run_tests` exercises both the VM and JIT.
- Full `monoruby` lib suite (1799) passes on x86-64; the new test also passes on aarch64 (qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_