### PR TITLE
parser: support non-constant base in constant-path assignment

### DIFF
--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -2542,23 +2542,27 @@ impl<'pr> Lowerer<'pr> {
                         prefix: vec![],
                         name,
                     },
-                    Some(p) => {
-                        let mut inner = self.collect_const_chain(&p)?.ok_or_else(|| {
-                            self.unsupported_node(
-                                "non-constant constant path target prefix",
-                                location_to_loc(&p.location()),
-                            )
-                        })?;
-                        if inner.parent.is_some() {
-                            return Err(self.unsupported_node(
-                                "constant path target nested under non-constant parent",
-                                loc,
-                            ));
+                    Some(p) => match self.collect_const_chain(&p)? {
+                        // A constant chain, possibly already rooted on a
+                        // non-constant base (`(expr)::A::B`): slide the inner
+                        // leaf into `prefix` and take this target's name,
+                        // exactly as the read-side `collect_const_chain` does.
+                        Some(mut inner) => {
+                            inner.prefix.push(std::mem::take(&mut inner.name));
+                            inner.name = name;
+                            inner
                         }
-                        inner.prefix.push(std::mem::take(&mut inner.name));
-                        inner.name = name;
-                        inner
-                    }
+                        // `(expr)::A = value` — a non-constant prefix. Lower
+                        // it as an ordinary expression and use it as the
+                        // constant's base scope (bytecodegen evaluates it),
+                        // mirroring the read-side `ConstantPathNode` path.
+                        None => ConstChain {
+                            toplevel: false,
+                            parent: Some(Box::new(self.lower_node(&p)?)),
+                            prefix: vec![],
+                            name,
+                        },
+                    },
                 };
                 Node {
                     kind: NodeKind::Const {

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -236,6 +236,40 @@ fn const_dynamic_access() {
 }
 
 #[test]
+fn const_path_assign_dynamic_base() {
+    // Constant assignment whose path prefix is a runtime expression rather
+    // than a static constant chain. Single assignment goes through the
+    // constant-path write path; a multiple-assignment target goes through
+    // `lower_assign_target` (the branch this test guards).
+    run_test(
+        r##"
+        res = []
+        m = Module.new
+        (m)::X = 7
+        res << m::X
+        # Multiple-assignment const-path targets with a non-constant base.
+        (m)::A, (m)::B = 1, 2
+        res << [m::A, m::B]
+        x, (m)::C = 10, 20
+        res << [x, m::C]
+        (m::D, m::E), c = [:d, :e], nil
+        res << [m::D, m::E, c]
+        # ...and with a static constant-chain base.
+        Fo = Module.new
+        Fo::P, Fo::Q = 3, 4
+        res << [Fo::P, Fo::Q]
+        (Fo::R, Fo::S), d = [5, 6], 7
+        res << [Fo::R, Fo::S, d]
+        # ...and a nested path already rooted on a non-constant base.
+        m::N = Module.new
+        (m)::N::Deep, e = 8, 9
+        res << [m::N::Deep, e]
+        res
+        "##,
+    );
+}
+
+#[test]
 fn const_inherited() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

`(expr)::A = value` and multiple-assignment targets like `(m)::A, (m)::B = 1, 2` and `(m)::A::B, x = ...` — a constant assignment whose path prefix is a runtime expression rather than a static constant chain — raised `SyntaxError: prism lowerer hit an unsupported node non-constant constant path target prefix`. Because this appears at file scope, `language/assignments_spec.rb` failed to **load** entirely.

## Change

`lower_assign_target` only handled a `ConstantPathTargetNode` whose parent flattened to a *rootless* constant chain. Reuse the read-side `collect_const_chain` shape:

- when the parent isn't a constant chain, lower it as an ordinary expression and root the constant on it (the non-constant base);
- when it *is* a chain already rooted on a non-constant base (`(expr)::A::B`), slide its leaf into the prefix — exactly as `collect_const_chain` does for reads.

`LvalueKind::Const` already evaluates a computed `parent`, so bytecodegen needs no change. (Single `(expr)::A = value` already worked via `ConstantPathWriteNode` → `lower_const_chain`; this fixes the *multiple-assignment target* path, and additionally supports `(expr)::A::B` targets that previously raised an "unsupported" error.)

## Spec impact

`language/assignments_spec.rb` now loads and runs: **0 → 38 examples**. The remaining failures/errors are unrelated pre-existing gaps (e.g. `[]=` op-assign with a block/keyword arg, `self`-receiver visibility).

## Tests

- New `const_path_assign_dynamic_base` test in `tests/add_coverage.rs` covering the non-constant base, constant-chain base, and non-constant-rooted nested (`(m)::A::B`) branches in both single- and multiple-assignment forms, all CRuby-verified.
- Full `monoruby` lib suite (1799) and `class_chain` pass on x86-64; the new test also passes on aarch64 (qemu). No regression in ordinary `X::A = v` constant assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)