### PR TITLE
bytecodegen: support safe-navigation setter as a rescue target

### DIFF
--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -450,10 +450,39 @@ impl<'a> BytecodeGen<'a> {
             } in rescue
             {
                 if let Some(box assign) = assign {
-                    let (lhs, rest) = self.eval_lvalue(&assign)?;
-                    assert!(!rest);
                     let loc = assign.loc;
-                    self.emit_assign(err_reg, lhs, None, loc);
+                    // `rescue => recv&.attr`: assign the caught exception via a
+                    // safe-navigation setter — skip the store when `recv` is nil.
+                    if matches!(&assign.kind,
+                        NodeKind::MethodCall { arglist, safe_nav: true, .. }
+                            if arglist.args.is_empty()
+                                && arglist.block.is_none()
+                                && arglist.kw_args.is_empty())
+                    {
+                        let NodeKind::MethodCall {
+                            box receiver,
+                            method,
+                            ..
+                        } = assign.kind
+                        else {
+                            unreachable!()
+                        };
+                        let setter = IdentId::get_id_from_string(format!("{method}="));
+                        let old = self.temp;
+                        let recv = self.push_expr(receiver)?.into();
+                        let skip = self.new_label();
+                        self.emit_nilbr(recv, skip, old);
+                        let arg = self.push().into();
+                        self.emit_mov(arg, err_reg);
+                        let callsite = CallSite::simple(setter, 1, arg, recv, None);
+                        self.emit_method_assign(callsite, loc);
+                        self.temp = old;
+                        self.apply_label(skip);
+                    } else {
+                        let (lhs, rest) = self.eval_lvalue(&assign)?;
+                        assert!(!rest);
+                        self.emit_assign(err_reg, lhs, None, loc);
+                    }
                 };
                 let cont_pos = self.new_label();
                 let next_pos = self.new_label();

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -456,6 +456,36 @@ fn raise_no_args_without_current_exception() {
 }
 
 #[test]
+fn rescue_safe_nav_target() {
+    // `rescue => recv&.attr`: the caught exception is stored via a
+    // safe-navigation setter; a nil receiver skips the store (the
+    // exception is still rescued).
+    run_test_with_prelude(
+        r##"
+        res = []
+        t = T.new
+        begin; raise "boom"; rescue => t&.e; end
+        res << t.e.message
+        n = nil
+        begin; raise "x"; rescue => n&.e; end
+        res << n
+        # with an explicit exception class, and as a value.
+        r = begin; raise TypeError, "z"; rescue TypeError => t&.e; :done; end
+        res << [r, t.e.class.name]
+        # JIT warm-up.
+        i = 0
+        while i < 200
+          begin; raise "b#{i}"; rescue => t&.e; end
+          i += 1
+        end
+        res << t.e.message
+        res
+        "##,
+        "class T; attr_accessor :e; end",
+    );
+}
+
+#[test]
 fn eval_custom_filename_and_lineno() {
     run_tests(&[
         r#"


### PR DESCRIPTION
## Summary

`rescue => recv&.attr` — a safe-navigation attribute setter used as the exception-capture target — raised `NotImplementedError: unsupported lhs MethodCall { ... safe_nav: true }`. The rescue clause fed the target straight to `eval_lvalue`, which rejects a bare safe-nav setter. Because this appears at file scope, `language/rescue_spec.rb` failed to **load** entirely.

## Change

The captured exception is already in hand (`err_reg`), so — unlike an expression-context safe-nav assignment — there's nothing to short-circuit: just guard the setter call on the receiver. Evaluate the receiver; if nil, skip the store (the exception is still rescued); otherwise call `attr=` with the exception. Ordinary (non-safe-nav) rescue targets are unchanged.

## Spec impact

`language/rescue_spec.rb` now loads and runs: **0 → 59 examples**. The remaining failures/errors are unrelated pre-existing gaps (splatted rescue exception lists `rescue *exceptions`, which bytecodegen still TODOs; backtrace details; `StandardError` filtering).

## Tests

- New `rescue_safe_nav_target` test in `tests/rescue.rs` (nil / non-nil receiver, explicit exception class, value context, hot-loop JIT), CRuby-verified.
- Full `monoruby` lib suite (1799) and `rescue` (23) pass on x86-64; the new test also passes on aarch64 (qemu). No regression in ordinary `rescue => e` / `rescue => @ivar` targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_