### PR TITLE
builtins: implement Kernel#local_variables and filter reserved slots

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -52,6 +52,15 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         false,
         Effect::CAPTURE | Effect::BINDING,
     );
+    globals.define_builtin_module_func_with_effect(
+        kernel_class,
+        "local_variables",
+        local_variables,
+        0,
+        0,
+        false,
+        Effect::CAPTURE,
+    );
     globals.define_builtin_module_func(kernel_class, "loop", loop_, 0);
     globals.define_builtin_module_func_with_kw(
         kernel_class,
@@ -619,6 +628,24 @@ fn lambda(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
 #[monoruby_builtin]
 fn binding(vm: &mut Executor, _: &mut Globals, _: Lfp, pc: BytecodePtr) -> Result<Value> {
     Ok(vm.generate_binding(pc).as_val())
+}
+
+///
+/// ### Kernel.#local_variables
+///
+/// - local_variables -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/local_variables.html]
+#[monoruby_builtin]
+fn local_variables(vm: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    // Report the caller's local variables (the frame that invoked us).
+    let caller_cfp = vm.cfp().prev().unwrap();
+    let fid = caller_cfp.lfp().func_id();
+    let v = match globals.store[fid].is_iseq() {
+        Some(iseq) => globals.store.local_variables(iseq),
+        None => vec![],
+    };
+    Ok(Value::array_from_vec(v))
 }
 
 ///
@@ -6629,6 +6656,21 @@ mod tests {
         run_test_error(r#"ObjectSpace.define_finalizer(:sym){ 1 }"#);
         // undefine on a frozen object raises FrozenError
         run_test_error(r#"o = Object.new; o.freeze; ObjectSpace.undefine_finalizer(o)"#);
+    }
+
+    #[test]
+    fn kernel_local_variables() {
+        // Method-wrapped so the test harness's own locals don't leak in.
+        run_test(r#"def m; a = 1; b = 2; local_variables.sort; end; m"#);
+        run_test(r#"def m(x, y); z = 3; local_variables.sort; end; m(1, 2)"#);
+        run_test(r#"def m; local_variables; end; m"#);
+        run_test(r#"def m; [1].each { |i| j = i * 2; return local_variables.sort }; end; m"#);
+        // Anonymous / reserved parameter slots and the hidden `for`-loop
+        // index must not appear.
+        run_test(r#"def m(*args, **kw, &blk); local_variables.sort; end; m(1)"#);
+        run_test(r#"def m; for a, *b in [[1, 2, 3]]; end; local_variables.sort; end; m"#);
+        // `Binding#local_variables` shares the same filtering.
+        run_test(r#"def m; a = 1; b = 2; binding.local_variables.sort; end; m"#);
     }
 
     #[test]

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -662,8 +662,25 @@ impl Store {
             }
             iseq = outer;
         }
-        map.into_iter().map(Value::symbol).collect()
+        // Drop reserved, unspellable slots (anonymous `*` / `**` / `&`, the
+        // hidden `for`-loop index, …) that are not real local variables.
+        map.into_iter()
+            .filter(|id| is_local_variable_name(&id.get_name()))
+            .map(Value::symbol)
+            .collect()
     }
+}
+
+/// Whether `name` is spellable as a Ruby local variable — i.e. begins with a
+/// lowercase letter or `_` and consists only of word characters. Filters out
+/// the compiler's reserved slots (`*`, `**`, `&`'s empty name, `(for)`, …).
+fn is_local_variable_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c == '_' || (!c.is_ascii()) || c.is_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || !c.is_ascii() || c.is_alphanumeric())
 }
 
 ///


### PR DESCRIPTION
## Summary

`Kernel#local_variables` was undefined, so any spec (or program) calling it raised `NoMethodError` (e.g. every "declares variables …" example in `language/for_spec.rb`).

## Change

- Implement `Kernel#local_variables` to report the **caller** frame's local variables, reusing `Store::local_variables` on the caller's iseq — the same source `Binding#local_variables` already uses.
- Filter out the compiler's reserved, unspellable local slots (anonymous `*` / `**` / `&`, and the hidden `(for)` loop index) in `Store::local_variables`, so neither `Kernel#` nor `Binding#local_variables` leaks them. This matches CRuby, which lists only spellable identifiers.

## Spec impact

- `language/for_spec.rb`: 4 errors → **0 failures / 0 errors**.
- `core/kernel/local_variables_spec.rb`: **6/6 pass**.
- `core/binding/local_variables_spec.rb`: still **6/6** (the added filtering doesn't regress `Binding#`).

## Tests

- New `kernel_local_variables` unit test in `builtins/kernel.rs` (method / nested-block / parameterized scopes, anonymous `*`/`**`/`&` params and the hidden `for` index excluded, and the shared `Binding#` filtering), all CRuby-verified.
- Full `monoruby` lib suite (1799) passes on x86-64; the new test also passes on aarch64 (qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_