### PR TITLE
bytecodegen: evaluate op-assign receiver / index only once

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -491,6 +491,31 @@ impl<'a> BytecodeGen<'a> {
                     }
                     return self.gen_safe_nav_op_assign(receiver, op, lhs, rhs, use_mode, loc);
                 }
+                // Attribute (`recv.attr op= rhs`) and index (`base[idx] op=
+                // rhs`) targets have a receiver / index expression that may
+                // carry side effects, so it must be evaluated exactly once and
+                // reused for both the getter and the setter. Every other target
+                // (const / ivar / cvar / gvar / dynamic var) is side-effect-free
+                // to re-read, so the simpler re-evaluating path stays correct.
+                if matches!(&lhs.kind,
+                    NodeKind::MethodCall { .. } | NodeKind::Index { .. })
+                {
+                    return self.gen_op_assign_with_receiver(op, lhs, rhs, use_mode, loc);
+                }
+                match op {
+                    BinOp::LOr | BinOp::LAnd => {
+                        // `target ||= rhs` / `target &&= rhs`: short-circuit so
+                        // the store only fires when needed. Re-reading a
+                        // side-effect-free target is fine, so lower to the
+                        // ordinary short-circuit binop over an inline assign.
+                        let assign = Node::new(
+                            NodeKind::MulAssign(vec![lhs.clone()], vec![rhs]),
+                            loc,
+                        );
+                        return self.gen_binop(op, lhs, assign, use_mode, loc);
+                    }
+                    _ => {}
+                }
                 let lhs_loc = lhs.loc;
                 let temp = self.temp;
                 // First, evaluate lvalue.
@@ -995,6 +1020,126 @@ impl<'a> BytecodeGen<'a> {
             _ => unreachable!(),
         }
         Ok(())
+    }
+
+    ///
+    /// Generate an op-assign whose target has a side-effecting receiver or
+    /// index (`recv.attr op= rhs`, `base[idx] op= rhs`).
+    ///
+    /// `eval_lvalue` evaluates the receiver / index exactly once (into temp
+    /// registers); the current value is then read through the matching getter,
+    /// combined with `rhs`, and written back through the setter — reusing that
+    /// single evaluation. For `||=` / `&&=` the setter fires only when the
+    /// current value is falsy / truthy respectively.
+    ///
+    fn gen_op_assign_with_receiver(
+        &mut self,
+        op: BinOp,
+        lhs: Node,
+        rhs: Node,
+        use_mode: UseMode2,
+        loc: Loc,
+    ) -> Result<()> {
+        let temp = self.temp;
+        // The getter name for an attribute target (`recv.attr`); `eval_lvalue`
+        // turns the `Send` lvalue's method into the setter (`attr=`), so keep
+        // the original method name for the read.
+        let getter = if let NodeKind::MethodCall { method, .. } = &lhs.kind {
+            Some(IdentId::get_id(method))
+        } else {
+            None
+        };
+        let (lhs_kind, rest) = self.eval_lvalue(&lhs)?;
+        assert!(!rest);
+        // Read the current value.
+        let cur = self.push().into();
+        self.emit_op_assign_getter(&lhs_kind, getter, cur, loc);
+        match op {
+            BinOp::LOr | BinOp::LAnd => {
+                let exit = self.new_label();
+                // `||=`: skip the store when the current value is truthy.
+                // `&&=`: skip the store when the current value is falsy.
+                let jmp_if_true = matches!(op, BinOp::LOr);
+                self.emit_condbr(cur, exit, jmp_if_true, false);
+                self.gen_store_expr(cur, rhs)?;
+                self.emit_assign(cur, lhs_kind, None, loc);
+                self.apply_label(exit);
+            }
+            _ => {
+                let binopk = Self::binop_to_binopk(op);
+                let old = self.temp;
+                let rhs_reg = self.gen_expr_reg(rhs)?;
+                self.temp = old;
+                self.emit(BytecodeInst::BinOp(binopk, Some(cur), (cur, rhs_reg)), loc);
+                self.emit_assign(cur, lhs_kind, None, loc);
+            }
+        }
+        self.temp = temp;
+        self.handle_mode(use_mode, cur)?;
+        Ok(())
+    }
+
+    ///
+    /// Emit the getter for an already-evaluated attribute / index lvalue,
+    /// storing the read value into `dst`.
+    ///
+    fn emit_op_assign_getter(
+        &mut self,
+        lhs_kind: &LvalueKind,
+        getter: Option<IdentId>,
+        dst: BcReg,
+        loc: Loc,
+    ) {
+        let callsite = match lhs_kind {
+            LvalueKind::Send { recv, .. } => CallSite::unary(getter.unwrap(), *recv, Some(dst)),
+            LvalueKind::Index { base, index } => {
+                CallSite::binary(IdentId::_INDEX, *base, (*index).into(), Some(dst))
+            }
+            LvalueKind::Index2 { base, index1, num } => {
+                CallSite::simple(IdentId::_INDEX, *num, (*index1).into(), *base, Some(dst))
+            }
+            LvalueKind::IndexSplat {
+                base,
+                index1,
+                num,
+                splat_pos,
+            } => CallSite::new(
+                IdentId::_INDEX,
+                *num,
+                None,
+                splat_pos.clone(),
+                None,
+                None,
+                (*index1).into(),
+                *base,
+                Some(dst),
+                false,
+            ),
+            _ => unreachable!(),
+        };
+        self.emit_call(callsite, loc);
+    }
+
+    ///
+    /// Map an arithmetic / bitwise op-assign operator to its `BinOpK`.
+    /// `||=` / `&&=` are handled separately (short-circuit) and never reach
+    /// here.
+    ///
+    fn binop_to_binopk(op: BinOp) -> BinOpK {
+        match op {
+            BinOp::Add => BinOpK::Add,
+            BinOp::Sub => BinOpK::Sub,
+            BinOp::Mul => BinOpK::Mul,
+            BinOp::Div => BinOpK::Div,
+            BinOp::Rem => BinOpK::Rem,
+            BinOp::Exp => BinOpK::Exp,
+            BinOp::BitOr => BinOpK::BitOr,
+            BinOp::BitAnd => BinOpK::BitAnd,
+            BinOp::BitXor => BinOpK::BitXor,
+            BinOp::Shl => BinOpK::Shl,
+            BinOp::Shr => BinOpK::Shr,
+            _ => unreachable!("non-arithmetic op-assign operator: {:?}", op),
+        }
     }
 
     fn handle_mode(&mut self, use_mode: UseMode2, src: BcReg) -> Result<()> {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -2323,11 +2323,15 @@ impl<'pr> Lowerer<'pr> {
         })
     }
 
-    /// `target ||= value` -> `BinOp(LOr, target, MulAssign([target],
-    /// [value]))` and likewise for `&&=` -> `LAnd`. Prism reports
-    /// these via `*OrWriteNode` / `*AndWriteNode`; we collapse them
-    /// into the same shape ruruby's parser produces (a short-circuit
-    /// binop wrapped around an inline assignment).
+    /// `target ||= value` -> `AssignOp(LOr, target, value)` and likewise
+    /// for `&&=` -> `LAnd`. Prism reports these via `*OrWriteNode` /
+    /// `*AndWriteNode`. Routing them through `AssignOp` (rather than a
+    /// `BinOp(LOr, target, MulAssign([target], [value]))` wrapper) lets
+    /// bytecodegen evaluate an attribute/index receiver exactly once for
+    /// both the read and the conditional write — the wrapper form
+    /// re-evaluated the receiver, so `a[side_effect] ||= v` ran the index
+    /// twice. Bytecodegen still short-circuits: the setter fires only when
+    /// the current value is falsy (`||=`) / truthy (`&&=`).
     fn build_short_circuit_assign(
         &mut self,
         op: BinOp,
@@ -2336,12 +2340,8 @@ impl<'pr> Lowerer<'pr> {
         loc: Loc,
     ) -> Result<Node, MonorubyErr> {
         let value = self.lower_node(value)?;
-        let assign = Node {
-            kind: NodeKind::MulAssign(vec![target.clone()], vec![value]),
-            loc,
-        };
         Ok(Node {
-            kind: NodeKind::BinOp(op, Box::new(target), Box::new(assign)),
+            kind: NodeKind::AssignOp(op, Box::new(target), Box::new(value)),
             loc,
         })
     }

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -1520,3 +1520,116 @@ fn fp_spill_loop() {
         "#,
     );
 }
+
+#[test]
+fn op_assign_evaluates_receiver_once() {
+    // `recv.attr op= v` and `base[idx] op= v` must evaluate the
+    // receiver / index expression exactly once, sharing it between the
+    // implicit getter and setter. A side-effecting receiver run twice
+    // would corrupt the log below.
+    run_test_with_prelude(
+        r#"
+        $log = []
+        c = C.new
+        c.v = 10
+        c.v += 5          # attr arithmetic
+        c[c.key] = 1
+        c[c.key] += 10    # index arithmetic: key evaluated once here
+        c.w ||= 7         # attr ||=
+        c.w &&= 3         # attr &&=
+        arr = [nil, 2]
+        arr[c.side] ||= 99  # index ||=
+        arr[c.side] &&= 77  # index &&=
+        [c.v, c[:k], c.w, arr, $log]
+        "#,
+        r#"
+        class C
+          def initialize; @h = {}; @w = nil; end
+          def key; $log << :key; :k; end
+          def side; $log << :side; 0; end
+          def [](k); @h[k]; end
+          def []=(k, v); @h[k] = v; end
+          attr_accessor :v, :w
+        end
+        "#,
+    );
+}
+
+#[test]
+fn op_assign_all_operators_on_receiver() {
+    // Every arithmetic / bitwise op-assign operator applied to an
+    // attribute target, exercising each `BinOpK` on the single-eval
+    // getter/setter path.
+    run_test_with_prelude(
+        r#"
+        c = C.new
+        res = []
+        c.v = 20;  c.v += 5;  res << c.v
+        c.v = 20;  c.v -= 5;  res << c.v
+        c.v = 20;  c.v *= 5;  res << c.v
+        c.v = 20;  c.v /= 5;  res << c.v
+        c.v = 20;  c.v %= 6;  res << c.v
+        c.v = 2;   c.v **= 5; res << c.v
+        c.v = 12;  c.v |= 3;  res << c.v
+        c.v = 14;  c.v &= 6;  res << c.v
+        c.v = 10;  c.v ^= 6;  res << c.v
+        c.v = 1;   c.v <<= 4; res << c.v
+        c.v = 256; c.v >>= 3; res << c.v
+        res
+        "#,
+        r#"
+        class C
+          attr_accessor :v
+        end
+        "#,
+    );
+}
+
+#[test]
+fn op_assign_multi_and_splat_index() {
+    // Multi-argument index (`m[i, j] op= v`) and splatted index
+    // (`m[*idx] op= v`) op-assign, including `||=` / `&&=`, must
+    // evaluate the index arguments once and reuse them for get + set.
+    run_test_with_prelude(
+        r#"
+        m = M.new
+        m[1, 2] = 10
+        m[1, 2] += 5
+        idx = [3, 4]
+        m[*idx] = 100
+        m[*idx] *= 2
+        m[7, 8] ||= 42
+        m[7, 8] &&= 9
+        [m[1, 2], m[3, 4], m[7, 8]]
+        "#,
+        r#"
+        class M
+          def initialize; @h = {}; end
+          def [](*k); @h[k]; end
+          def []=(*args); v = args.pop; @h[args] = v; end
+        end
+        "#,
+    );
+}
+
+#[test]
+fn op_assign_target_kinds() {
+    // Op-assign over the non-attribute target kinds keeps short-circuit
+    // semantics (`||=` / `&&=` store only when needed) and value results.
+    run_test(
+        r#"
+        res = []
+        a = 1; a += 2; res << a
+        b = nil; b ||= 5; res << b
+        cc = 3; cc &&= 7; res << cc
+        d = nil; d &&= 9; res << d
+        $g = 10; $g -= 3; res << $g
+        $h = nil; $h ||= 42; res << $h
+        x = {a: 1}
+        res << (x[:a] += 100)
+        res << (x[:b] ||= :new)
+        res << x
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

`recv.attr op= v` and `recv[i] op= v` — for arithmetic (`+=`, `-=`, …) and the short-circuit `||=` / `&&=` — evaluated the receiver (and, for an index target, each index argument) **twice**: once for the getter read and once for the setter write. CRuby evaluates them exactly once.

- Arithmetic op-assign lowers to `AssignOp(op, target, value)`, and bytecodegen read `target` twice (`eval_lvalue` for the setter + `gen_binop` for the getter).
- `||=` / `&&=` lowered to `target || (target = value)`, duplicating `target` in the AST.

Both re-ran the receiver / index expression.

## Change

Handled entirely in **bytecodegen** by reusing `eval_lvalue`'s single evaluation of the receiver / index (they already land in temp registers) — no synthetic locals or AST rewriting.

- The `*OrWriteNode` / `*AndWriteNode` shapes now lower to `AssignOp(LOr/LAnd, target, value)` (instead of the `BinOp(LOr, target, MulAssign([target],[value]))` wrapper), so `||=` / `&&=` share the same single-evaluation path as arithmetic op-assign.
- A dedicated path handles attribute / index targets: evaluate the receiver / index once, read the current value through the matching getter (from the already-evaluated temps), combine (arithmetic via `BinOpK`; `||=` / `&&=` via a short-circuit branch whose setter fires only when needed), and write back through the setter.
- Side-effect-free targets (local, `self`, ivar, cvar, gvar, constant, dynamic var) keep the simpler re-evaluating path and preserve short-circuit store semantics (e.g. `A ||= 1` still avoids reassigning an already-initialized constant).

## Spec impact

`language/optional_assignments_spec.rb`: **12 failures + 4 errors → 4 + 2** (10 fixed). Remaining failures are the constant-path (`Foo::Bar ||= …`) module-part side-effect cases, tracked separately.

## Tests

- New `op_assign_evaluates_receiver_once` and `op_assign_target_kinds` tests in `tests/arith.rs` (attr `+=` / `||=` / `&&=`, index `+=` / `||=` / `&&=`, and the side-effect-free target kinds with short-circuit and value semantics), all CRuby-verified.
- Full `monoruby` lib suite (1800), `arith` (64), and `method_call` (98) pass on x86-64. The change lives entirely in arch-neutral bytecodegen. No regression in `variables` / `assignments` / `send` specs (18 → 15 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_