### PR TITLE
runtime: splat wraps object when #to_a returns nil

### DIFF
--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1580,6 +1580,11 @@ pub(super) extern "C" fn to_a(
         let ary = vm.invoke_func(globals, func_id, src, &[], None, None)?;
         if ary.is_array_ty() {
             Some(ary)
+        } else if ary.is_nil() {
+            // `#to_a` returning nil is treated like a missing `#to_a`:
+            // the splatted object is wrapped in a one-element array,
+            // matching CRuby (`m(*o)` with `o.to_a == nil` -> `[o]`).
+            Some(Value::array1(src))
         } else {
             let src_class = src.class().get_name(&globals.store);
             //let res_class = ary.class().get_name(&globals.store);

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -516,6 +516,52 @@ fn splat2() {
 }
 
 #[test]
+fn splat_to_a_coercion() {
+    // Splatting a non-Array object coerces it via `#to_a`:
+    //   - `#to_a` returning an Array  -> that Array's elements
+    //   - `#to_a` returning nil       -> the object wrapped in `[obj]`
+    //     (treated like a missing `#to_a`)
+    //   - no `#to_a` at all           -> the object wrapped in `[obj]`
+    //   - `#to_a` returning a non-Array, non-nil -> TypeError
+    run_test_with_prelude(
+        r#"
+        arr  = Obj.new([10, 20])
+        nl   = Obj.new(nil)
+        bare = BareObj.new
+        # `to_a` returning an Array expands its elements.
+        r_arr  = m(*arr)
+        r_mid  = m(0, *arr, 9)
+        # `to_a` returning nil wraps the object itself (like no `to_a`).
+        r_nl   = m(*nl)
+        r_nl2  = m(1, *nl)
+        # No `to_a` at all also wraps the object.
+        r_bare = m(*bare)
+        # A non-Array, non-nil `to_a` result is a TypeError.
+        r_bad  = (begin; m(*Bad.new); rescue TypeError; :type_error; end)
+        [
+          r_arr, r_mid,
+          r_nl.size, r_nl.first.equal?(nl),
+          r_nl2.size, r_nl2[0], r_nl2[1].equal?(nl),
+          r_bare.size, r_bare.first.equal?(bare),
+          r_bad,
+        ]
+        "#,
+        r#"
+        def m(*a) = a
+        class Obj
+          def initialize(v) = @v = v
+          def to_a = @v
+        end
+        class BareObj
+        end
+        class Bad
+          def to_a = 42
+        end
+        "#,
+    );
+}
+
+#[test]
 fn hash_splat() {
     run_test_with_prelude(
         r##"


### PR DESCRIPTION
## Summary

When a non-Array object is splatted in a call (`m(*obj)`), it is coerced via `#to_a`. CRuby's rule:

- `#to_a` returns an **Array** → its elements are spread.
- `#to_a` returns **nil** → treated like a missing `#to_a`: the object is wrapped in a one-element array (`[obj]`).
- no `#to_a` at all → wrapped in `[obj]`.
- `#to_a` returns a **non-Array, non-nil** value → `TypeError`.

monoruby raised `TypeError` for the **nil** case too, so every `m(*obj)` where `obj.to_a == nil` failed instead of yielding `[obj]`.

## Change

In the splat `to_a` coercion helper (`codegen/runtime.rs`), a `nil` result now falls back to wrapping the object (`Value::array1(src)`), matching the missing-`#to_a` path. The `TypeError` for genuinely wrong (non-Array, non-nil) results is unchanged.

## Spec impact

`language/method_spec.rb`: **13 errors → 1 error** (12 fixed) — the shared "wraps the argument in an Array if #to_a returns nil" examples across the call / element-assignment / attribute-assignment splat forms.

## Tests

- New `splat_to_a_coercion` test in `tests/method_call.rs` covering all four `#to_a` outcomes (Array spread, nil-wrap, no-`#to_a`-wrap, TypeError), asserting object identity for the wrapped cases. CRuby-verified.
- Full `monoruby` lib suite (1800), `method_call` (66), and `arith` (99) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_