### PR TITLE
bytecodegen: evaluate nested masgn targets left-to-right before rhs

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -18,7 +18,14 @@ const LITERAL_CHUNK_LEN: usize = 256;
 ///
 enum MulLhs {
     Leaf(LvalueKind),
-    Nested(Vec<Node>),
+    /// A nested destructure group (`(b, c)` in `(a, (b, c)) = ...`). Its
+    /// members' lvalues are already evaluated (receivers / indices captured
+    /// left-to-right, before the rhs); `rest_pos` records the splat slot for
+    /// the group's own `ExpandArray`.
+    Nested {
+        targets: Vec<MulLhs>,
+        rest_pos: Option<u16>,
+    },
 }
 
 impl<'a> BytecodeGen<'a> {
@@ -1264,16 +1271,18 @@ impl<'a> BytecodeGen<'a> {
         let temp = self.temp;
 
         // At first, we evaluate lvalues and save their info(LhsKind).
-        // A nested destructure group (`(b, c)` in `(a, (b, c)) = ...`)
-        // is deferred as `MulLhs::Nested`: its own targets are expanded
-        // with a chained `ExpandArray` once the parent array element is
-        // in hand.
+        // The receiver / index subexpressions of every target — including
+        // those inside a nested destructure group (`(b, c)` in
+        // `(a, (b, c)) = ...`) — are evaluated here, left-to-right and
+        // BEFORE the rhs, matching CRuby's evaluation order. Only the
+        // `ExpandArray` + store of a nested group is deferred (it needs the
+        // parent array element), carrying the pre-evaluated lvalues.
         let mut lhs_kind: Vec<MulLhs> = vec![];
         let mut rest_pos = None;
         for (i, lhs) in mlhs.into_iter().enumerate() {
             match lhs.kind {
                 NodeKind::MulAssignNested(targets) => {
-                    lhs_kind.push(MulLhs::Nested(targets));
+                    lhs_kind.push(self.eval_nested_lvalues(targets)?);
                 }
                 _ => {
                     let (kind, rest) = self.eval_lvalue(&lhs)?;
@@ -1346,7 +1355,9 @@ impl<'a> BytecodeGen<'a> {
             let src = (rhs_reg + i).into();
             match lhs {
                 MulLhs::Leaf(kind) => self.emit_assign(src, kind, None, loc),
-                MulLhs::Nested(targets) => self.gen_destructure(src, targets, loc)?,
+                MulLhs::Nested { targets, rest_pos } => {
+                    self.assign_prepared(src, targets, rest_pos, loc)?
+                }
             }
         }
 
@@ -1385,19 +1396,52 @@ impl<'a> BytecodeGen<'a> {
     }
 
     ///
-    /// Destructure the array in register `src` into `targets`, recursing
-    /// into nested groups with a chained `ExpandArray`. Backs nested
-    /// multiple-assignment targets (`(a, (b, c)) = ...`).
+    /// Evaluate the lvalues of a nested destructure group's `targets`,
+    /// recursing into further groups. Receivers / indices are evaluated
+    /// here (left-to-right, before the rhs); the actual `ExpandArray` +
+    /// store is deferred to [`Self::assign_prepared`]. `rest_pos` records
+    /// the splat slot (`(a, *b)`) for the group's own `ExpandArray`.
     ///
-    /// `src` holds the array element to split; `targets` is this group's
-    /// own target list (each a leaf, a `Splat` rest, `DiscardLhs`, or a
-    /// further `MulAssignNested`). New registers are pushed above the
-    /// caller's stack and left in place — the top-level caller restores
-    /// `temp` once the whole assignment is emitted.
-    ///
-    fn gen_destructure(&mut self, src: BcReg, targets: Vec<Node>, loc: Loc) -> Result<()> {
-        let len = targets.len();
+    fn eval_nested_lvalues(&mut self, targets: Vec<Node>) -> Result<MulLhs> {
         let rest_pos = targets.iter().position(|t| t.is_splat()).map(|p| p as u16);
+        let mut kinds = vec![];
+        for t in targets.into_iter() {
+            match t.kind {
+                NodeKind::MulAssignNested(sub) => {
+                    kinds.push(self.eval_nested_lvalues(sub)?);
+                }
+                _ => {
+                    // Plain leaf or `Splat(target)` rest slot; `eval_lvalue`
+                    // unwraps the splat and returns the inner lvalue kind.
+                    let (kind, _rest) = self.eval_lvalue(&t)?;
+                    kinds.push(MulLhs::Leaf(kind));
+                }
+            }
+        }
+        Ok(MulLhs::Nested {
+            targets: kinds,
+            rest_pos,
+        })
+    }
+
+    ///
+    /// Destructure the array in register `src` into the pre-evaluated
+    /// `targets`, recursing into nested groups with a chained
+    /// `ExpandArray`. Backs nested multiple-assignment targets
+    /// (`(a, (b, c)) = ...`). The targets' receivers / indices were already
+    /// captured by [`Self::eval_nested_lvalues`]; here we only expand and
+    /// store. New registers are pushed above the caller's stack and left in
+    /// place — the top-level caller restores `temp` once the whole
+    /// assignment is emitted.
+    ///
+    fn assign_prepared(
+        &mut self,
+        src: BcReg,
+        targets: Vec<MulLhs>,
+        rest_pos: Option<u16>,
+        loc: Loc,
+    ) -> Result<()> {
+        let len = targets.len();
         let base = self.sp();
         for _ in 0..len {
             self.push();
@@ -1408,15 +1452,10 @@ impl<'a> BytecodeGen<'a> {
         );
         for (i, t) in targets.into_iter().enumerate() {
             let elem = (base + i).into();
-            match t.kind {
-                NodeKind::MulAssignNested(sub) => {
-                    self.gen_destructure(elem, sub, loc)?;
-                }
-                _ => {
-                    // Plain leaf or `Splat(target)` rest slot; `eval_lvalue`
-                    // unwraps the splat and returns the inner lvalue kind.
-                    let (kind, _rest) = self.eval_lvalue(&t)?;
-                    self.emit_assign(elem, kind, None, loc);
+            match t {
+                MulLhs::Leaf(kind) => self.emit_assign(elem, kind, None, loc),
+                MulLhs::Nested { targets, rest_pos } => {
+                    self.assign_prepared(elem, targets, rest_pos, loc)?;
                 }
             }
         }

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -237,6 +237,54 @@ fn index_assign_with_splat() {
 }
 
 #[test]
+fn multi_assign_evaluation_order() {
+    // CRuby evaluates every target's receiver / index subexpression
+    // left-to-right BEFORE the rhs — including inside nested destructure
+    // groups. `$s` records the order so a wrong nested order (rhs before a
+    // nested receiver) is caught.
+    run_tests(&[
+        // Flat accessor targets: receivers, then rhs.
+        r#"$s = []; o = Object.new; def o.a=(v); end
+           (($s << :a); o).a, (($s << :b); o).a = (($s << :c); 1), (($s << :d); 2); $s"#,
+        // Nested accessor: the nested receiver is evaluated before the rhs.
+        r#"$s = []; o = Object.new; def o.a=(v); end
+           ((($s << :a); o).a, foo), bar = [(($s << :b); 1)]; $s"#,
+        // Deeply nested accessors: full left-to-right, then the rhs value.
+        r#"$s = []; o = Object.new
+           def o.a=(v); end; def o.b=(v); end; def o.c=(v); end
+           def o.d=(v); end; def o.e=(v); end; def o.f=(v); end
+           (($s << :a); o).a,
+             ((($s << :b); o).b,
+             ((($s << :c); o).c, (($s << :d); o).d),
+             (($s << :e); o).e),
+           (($s << :f); o).f = (($s << :v); :v)
+           $s"#,
+        // Nested #[]=: receiver, index, then rhs.
+        r#"$s = []; o = Object.new; def o.[]=(_, _); end
+           ((($s << :a); o)[(($s << :b); 0)], foo), bar = [(($s << :c); 1)]; $s"#,
+        // Deeply nested #[]=.
+        r#"$s = []; o = Object.new; def o.[]=(_, _); end
+           (($s << :ra); o)[(($s << :aa); 0)],
+             ((($s << :rb); o)[(($s << :ab); 1)],
+             ((($s << :rc); o)[(($s << :ac); 2)], (($s << :rd); o)[(($s << :ad); 3)]),
+             (($s << :re); o)[(($s << :ae); 4)]),
+           (($s << :rf); o)[(($s << :af); 5)] = (($s << :v); :v)
+           $s"#,
+    ]);
+}
+
+#[test]
+fn multi_assign_nested_values() {
+    // Correctness of nested destructuring (values, not just order).
+    run_tests(&[
+        "((a, b), c), d = [[1, 2], 3], 4; [a, b, c, d]",
+        "(x, (y, z)), *w = [10, [20, 30]], 40, 50; [x, y, z, w]",
+        "(a, *b), (c, d) = [1, 2, 3], [4, 5]; [a, b, c, d]",
+        "arr = []; (arr[0], (arr[1], arr[2])), arr[3] = [1, [2, 3]], 4; arr",
+    ]);
+}
+
+#[test]
 fn for_loop_destructuring_index() {
     // `for` with a splat / post / nested / non-local index target
     // destructures each element, and the targets still leak to the


### PR DESCRIPTION
## Summary

In a multiple assignment, CRuby evaluates every target's receiver / index subexpression **left-to-right before the right-hand side**, then performs the stores. monoruby did this for flat targets (their `eval_lvalue` ran in the first pass, before the rhs), but a **nested destructure group** (`(a.x, foo), bar = rhs`) was deferred raw and only evaluated during the `ExpandArray` + store phase — *after* the rhs.

So this recorded the wrong order:

```ruby
((ScratchPad << :a; o).a, foo), bar = [(ScratchPad << :b; :b)]
ScratchPad.recorded  # monoruby: [:b, :a]   CRuby: [:a, :b]
```

## Change

`gen_mul_assign` now evaluates a nested group's lvalues up front too, via a new `eval_nested_lvalues` (recursing left-to-right), carrying the captured `LvalueKind`s and the group's splat position. Only the `ExpandArray` + store is deferred (`assign_prepared`), since it needs the parent array element in hand. The receiver / index registers stay live below the rhs, exactly like flat leaf targets — so the evaluation order now matches CRuby while the assigned values are unchanged.

`MulLhs::Nested` was changed from holding raw `Vec<Node>` to the pre-evaluated `{ targets: Vec<MulLhs>, rest_pos }`, and the old `gen_destructure` (which interleaved receiver evaluation with the stores) is replaced by the two-phase `eval_nested_lvalues` / `assign_prepared` pair.

## Spec impact

`language/assignments_spec.rb`: **7 failures + 1 error → 1 failure + 1 error** (6 fixed) — the nested / deeply-nested accessor, `#[]=`, and compounded-constant evaluation-order cases.

## Tests

- New `multi_assign_evaluation_order` (flat, nested, deeply-nested accessor and `#[]=` order via a `$s` recorder) and `multi_assign_nested_values` (value correctness for nested destructuring incl. splat and index targets) in `tests/mul_assign.rs`. CRuby-verified.
- Full `monoruby` lib suite (1800), `mul_assign` (7), `method_call` (99), `variables` (13) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_