### PR TITLE
bytecodegen: skip nil operand in hash-literal ** splat

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4111,6 +4111,25 @@ mod tests {
     }
 
     #[test]
+    fn hash_literal_double_splat_nil() {
+        // `**nil` in a hash literal contributes nothing (CRuby treats a
+        // nil operand as empty), whether the operand is a literal nil or a
+        // variable that holds nil at runtime.
+        run_tests(&[
+            "{**nil}",
+            "x = nil; {**x}",
+            "{a: 1, **nil, b: 2}",
+            "h = {a: 1}; {**h, **nil}",
+            "{**nil}.empty?",
+            // A non-nil, non-Hash operand still raises TypeError.
+            "begin; {**1}; rescue TypeError; :te; end",
+            "begin; {**false}; rescue TypeError; :te; end",
+            // A `#to_hash` object still expands normally alongside `**nil`.
+            "o = Object.new; def o.to_hash; {z: 9}; end; {**o, **nil}",
+        ]);
+    }
+
+    #[test]
     fn hash_each_block_trailing_comma() {
         // PR #361 follow-up: a trailing comma in a block parameter list
         // (`|k,|`) injects a synthetic anonymous post param, bumping the

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1598,15 +1598,22 @@ impl<'a> BytecodeGen<'a> {
             self.emit_mov(ret, tmp);
         }
         if !splat.is_empty() {
-            // For each splat, call merge! on the hash
+            // For each `**` operand, merge it into the hash. A nil operand
+            // contributes nothing (`{**nil}` == `{}`, `{a: 1, **nil}` ==
+            // `{a: 1}`), matching CRuby, so guard the `merge!` with a nil
+            // check. This is nil-specific: a non-nil, non-Hash operand
+            // (`{**1}`, `{**false}`) still raises via `merge!`/`#to_hash`.
             let merge_id = IdentId::get_id("merge!");
             for s in splat {
                 let old_reg2 = self.temp;
                 let splat_arg = self.sp();
                 self.push_expr(s)?;
+                let skip = self.new_label();
+                self.emit_nilbr(splat_arg.into(), skip, old_reg2);
                 self.temp = old_reg2;
                 let callsite = CallSite::simple(merge_id, 1, splat_arg.into(), ret, Some(ret));
                 self.emit_call(callsite, loc);
+                self.apply_label(skip);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

`**nil` in a hash literal contributes nothing in CRuby — `{**nil}` == `{}`, `{a: 1, **nil, b: 2}` == `{a: 1, b: 2}` — for both a literal `nil` and a variable that holds `nil` at runtime. monoruby compiled every `**` operand to an unconditional `merge!`, so a `nil` operand raised `TypeError: no implicit conversion of NilClass into Hash`.

## Change

Guard each `**`-splat `merge!` in a hash literal with a `NilBr` nil check, skipping the merge when the operand is `nil`. The check is **nil-specific**: a non-nil, non-Hash operand (`{**1}`, `{**false}`) still raises via `merge!` / `#to_hash`, and a `#to_hash` object still expands normally.

`NilBr` is a pure "branch if nil" instruction already lowered by both the x86-64 and AArch64 backends (it backs safe-navigation), so there is no arch-specific codegen. Verified on `aarch64-unknown-linux-gnu` under qemu — output matches CRuby for all cases.

## Spec impact

`language/hash_spec.rb`: fixes the "expands nil using ** into {}" example (was an error). The remaining `hash_spec` failures are unrelated (source-order interleaving of `**` splats vs explicit keys, duplicate-key warnings, frozen string keys) and tracked separately.

## Tests

- New `hash_literal_double_splat_nil` in `builtins/hash.rs` (literal/variable nil, mixed with explicit keys and another `**obj`, plus the `{**1}` / `{**false}` TypeError guards). CRuby-verified.
- Full `monoruby` lib suite (1801) passes; aarch64 spot-check under qemu matches CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_