### PR TITLE
runtime: freeze String keys built by hash literals

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -729,16 +729,8 @@ fn index_assign(
     // preservation is handled by the underlying RubyMap. A
     // compare_by_identity hash keys on object identity, so it stores
     // the caller's String as-is (no copy, no freeze).
-    if key.is_str().is_some()
-        && !key.is_frozen()
-        && !lfp.self_val().as_hash().is_compare_by_identity()
-    {
-        // Build a fresh String value from the bytes so the duplicate
-        // does NOT inherit singleton methods from the caller's key.
-        let inner = key.as_rstring_inner().clone();
-        let mut dup = Value::string_from_inner(inner);
-        dup.set_frozen();
-        key = dup;
+    if !lfp.self_val().as_hash().is_compare_by_identity() {
+        key = key.frozen_hash_key();
     }
     lfp.self_val()
         .as_hash_mut(&globals.store)?
@@ -4107,6 +4099,24 @@ mod tests {
         run_tests(&[
             "{nil: 1, false: 2, true: 3}",
             "{nil: 1}.keys",
+        ]);
+    }
+
+    #[test]
+    fn hash_literal_freezes_string_keys() {
+        // A String key in a hash *literal* is stored as a frozen dup (like
+        // `Hash#[]=`), so later mutation of the source String can't corrupt
+        // the hash. Frozen keys and non-String keys are stored as-is.
+        run_tests(&[
+            r#"s = "x"; h = { s => 1 }; [h.keys.first.frozen?, h.keys.first.equal?(s)]"#,
+            // The classic mutate-the-source case: the stored key is unaffected.
+            r#"key = +"foo"; h = { key => "bar" }; key.reverse!; [h["foo"], h.keys.first, key]"#,
+            // An already-frozen String key is stored without copying.
+            r#"s = "x".freeze; h = { s => 1 }; h.keys.first.equal?(s)"#,
+            // Non-String keys are never dup'd.
+            r#"k = [1]; h = { k => 1 }; h.keys.first.equal?(k)"#,
+            // Duplicate string keys in a literal still collapse (last wins).
+            r#"{ "a" => 1, "a" => 2 }"#,
         ]);
     }
 

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -297,7 +297,7 @@ fn gen_hash_inner(
             .copied()
             .rev();
         while let Ok(chunk) = iter.next_chunk::<2>() {
-            map.insert(chunk[0], chunk[1], vm, globals)?;
+            map.insert(chunk[0].frozen_hash_key(), chunk[1], vm, globals)?;
         }
     }
     Ok(map)
@@ -324,7 +324,7 @@ pub(super) extern "C" fn hash_insert(
             .copied()
             .rev();
         while let Ok(chunk) = iter.next_chunk::<2>() {
-            if let Err(err) = h.insert(chunk[0], chunk[1], vm, globals) {
+            if let Err(err) = h.insert(chunk[0].frozen_hash_key(), chunk[1], vm, globals) {
                 vm.set_error(err);
                 return None;
             }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1027,6 +1027,27 @@ impl Value {
         RValue::new_string_from_inner_with_class(inner, class_id).pack()
     }
 
+    ///
+    /// Return the value to store as a Hash key: a mutable String is dup'd
+    /// and frozen (CRuby freezes String keys so later mutation of the
+    /// source String can't corrupt the hash), while frozen Strings and
+    /// non-String keys are returned unchanged. The dup is built from the
+    /// bytes so it does not inherit any singleton methods from the source.
+    ///
+    /// Callers storing into a `compare_by_identity` Hash must skip this
+    /// (identity hashes key on the original object).
+    ///
+    pub(crate) fn frozen_hash_key(self) -> Value {
+        if self.is_str().is_some() && !self.is_frozen() {
+            let inner = self.as_rstring_inner().clone();
+            let mut dup = Value::string_from_inner(inner);
+            dup.set_frozen();
+            dup
+        } else {
+            self
+        }
+    }
+
     pub fn array(ary: ArrayInner) -> Self {
         RValue::new_array(ary).pack()
     }


### PR DESCRIPTION
## Summary

`Hash#[]=` already stores a **frozen dup** of a mutable String key — so later mutation of the caller's String can't corrupt the hash — but the hash-**literal** build path did not. `s = +"x"; h = { s => 1 }` stored the caller's mutable String directly: `h.keys.first.frozen?` was `false`, `h.keys.first.equal?(s)` was `true`, and mutating `s` afterward corrupted the stored key.

## Change

Extract the dup-and-freeze logic into `Value::frozen_hash_key` and apply it in both hash-literal builders (`gen_hash` and the chunked `hash_insert`). `Hash#[]=` now shares the same helper (still skipping it for `compare_by_identity` hashes, which key on object identity). Frozen Strings and non-String keys are stored unchanged.

## Spec impact

`language/hash_spec.rb`: fixes "freezes string keys on initialization". Remaining `hash_spec` failures are unrelated (source-order interleaving of `**` splats vs explicit keys, duplicate-key warnings) and tracked separately.

## Tests

- New `hash_literal_freezes_string_keys` in `builtins/hash.rs` (frozen+copy semantics, the mutate-the-source case, already-frozen key kept, non-String key untouched, duplicate-key collapse). CRuby-verified.
- Full `monoruby` lib suite (1802) and the hash builtin suite (97) pass. Pure Rust runtime change (no machine-code emission), so both backends are affected identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_