### PR TITLE
executor: raise TypeError for a non-coercible &obj block argument

### DIFF
--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -1173,6 +1173,24 @@ mod tests {
         );
     }
 
+    /// `&obj` where `obj` is not a Proc is coerced via `#to_proc`; a
+    /// missing `#to_proc` or a non-Proc result raises TypeError (matching
+    /// CRuby), rather than the old "not yet implemented" RuntimeError.
+    #[test]
+    fn block_arg_to_proc_type_errors() {
+        run_tests(&[
+            // No `#to_proc`: "no implicit conversion of Object into Proc".
+            r#"o = Object.new; def mk(&b); b; end
+               begin; mk(&o); rescue TypeError => e; e.message; end"#,
+            // `#to_proc` returning a non-Proc raises TypeError (the exact
+            // message wording varies by CRuby version, so check the class).
+            r#"class R; def to_proc; 42; end; end; def mk(&b); b; end
+               begin; mk(&R.new); rescue => e; e.class; end"#,
+            // A well-behaved `#to_proc` (Symbol / Method) still works.
+            r#"def mk(&b); b; end; mk(&:to_s).call(42)"#,
+        ]);
+    }
+
     /// `&:sym` forwarded as `&b` through a middle Proc and
     /// re-dispatched must behave the same as a direct `&:sym`
     /// block arg.

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2503,18 +2503,31 @@ impl Executor {
             let outer = outer.move_frame_to_heap();
             return Ok(Proc::from_outer(outer, fid, pc));
         }
-        // `to_proc` fallback. If the value responds, use the resulting
-        // Proc; otherwise propagate the original "not yet implemented"
-        // diagnostic so unrecognised cases stay loud.
+        // `to_proc` fallback (Method#to_proc, user classes with #to_proc,
+        // ...). Matches CRuby's `&obj` coercion: a non-Proc `#to_proc`
+        // result and a missing `#to_proc` both raise TypeError.
         if let Some(result) =
             self.invoke_method_if_exists(globals, IdentId::TO_PROC, bh.0, &[], None, None)?
-            && let Some(proc) = result.is_proc()
         {
-            return Ok(proc);
+            if let Some(proc) = result.is_proc() {
+                return Ok(proc);
+            }
+            // `#to_proc` returned a non-Proc:
+            // `can't convert X into Proc (X#to_proc gives Y)`.
+            return Err(MonorubyErr::cant_convert_error(
+                &globals.store,
+                bh.0,
+                result,
+                "Proc",
+                IdentId::TO_PROC,
+            ));
         }
-        Err(MonorubyErr::runtimeerr(format!(
-            "not yet implemented: block handler {bh:?}"
-        )))
+        // No `#to_proc`: `no implicit conversion of X into Proc`.
+        Err(MonorubyErr::no_implicit_conversion(
+            &globals.store,
+            bh.0,
+            PROC_CLASS,
+        ))
     }
 
     pub(crate) fn generate_lambda(&mut self, func_id: FuncId, pc: BytecodePtr) -> Proc {


### PR DESCRIPTION
## Summary

When `&obj` is passed as a block and `obj` is not a Proc, monoruby materializes it through `generate_proc_inner`, which falls back to `obj.to_proc`. Previously, if `#to_proc` was **missing** or **returned a non-Proc**, it raised a generic `RuntimeError: not yet implemented: block handler ...`. CRuby raises `TypeError`.

## Change

Match CRuby's `&obj` coercion errors:
- missing `#to_proc` → `TypeError: no implicit conversion of X into Proc`
- non-Proc `#to_proc` result → `TypeError: can't convert X into Proc (X#to_proc gives Y)`

The Proc / Symbol / `Method#to_proc` fast paths are unchanged (`&:sym`, `&Time.method(:now)`, etc. still work).

## Spec impact

`language/send_spec.rb`: fixes the two `makeproc(&obj)` cases — "raises TypeError if 'to_proc' doesn't return a Proc" and "raises TypeError if block object isn't a Proc and doesn't respond to `to_proc`" (2 errors → resolved).

## Tests

- New `block_arg_to_proc_type_errors` in `builtins/proc.rs` (missing `#to_proc` message, non-Proc `#to_proc` by error class — the exact wording varies by CRuby version — and a working `#to_proc`). CRuby-verified.
- Full `monoruby` lib suite (1803) passes. Pure Rust error-handling change (no machine-code emission), so both backends are affected identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_