### PR TITLE
bytecodegen: warn on duplicated literal keys in a hash literal

### DIFF
--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -124,6 +124,7 @@ fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     // guarantees `lfp.self_val()` matches `BINDING_CLASS`.
     let binding = Binding::try_new(lfp.self_val()).expect("self is Binding");
     globals.compile_script_binding(expr, fname, binding, lineno)?;
+    vm.flush_compile_warnings(globals);
     vm.invoke_binding(globals, binding.binding().unwrap())
 }
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4103,6 +4103,37 @@ mod tests {
     }
 
     #[test]
+    fn hash_literal_duplicated_key_warning() {
+        // A hash literal that repeats a *literal* key warns "key ... is
+        // duplicated and overwritten" through `$stderr` (so a redirected
+        // `$stderr` captures it, as CRuby's compile-time warning does).
+        // Only literal keys are checked; a runtime key (`{k => 1, k => 2}`)
+        // does not warn. The message carries an `(eval at ...)` path prefix
+        // that differs from CRuby's, so match the stable part by regex.
+        run_test(
+            r#"
+            require 'stringio'
+            def cap; $stderr = StringIO.new; yield; s = $stderr.string; $stderr = STDERR; s; end
+            [
+              !!(cap { eval("{foo: :bar, foo: :foo}") } =~ /key :foo is duplicated/),
+              !!(cap { eval(%q[{"a" => 1, "a" => 2}]) } =~ /key "a" is duplicated/),
+              !!(cap { eval("{1000 => :a, 1000 => :b}") } =~ /key 1000 is duplicated/),
+              !!(cap { eval("{1.0 => :a, 1.0 => :b}") } =~ /key 1.0 is duplicated/),
+              !!(cap { eval("{true => 1, true => 2}") } =~ /key true is duplicated/),
+              !!(cap { eval("{nil => 1, nil => 2}") } =~ /key nil is duplicated/),
+              !!(cap { eval("{100000000000000000000 => 1, 100000000000000000000 => 2}") } =~ /is duplicated/),
+              # A runtime (non-literal) key never warns.
+              cap { k = 1; eval("{k => 1, k => 2}", binding) }.empty?,
+              # No duplicate: no warning.
+              cap { eval("{a: 1, b: 2}") }.empty?,
+              # The overwrite still happens (last value wins).
+              eval("{a: 1, a: 2}"),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
     fn hash_literal_freezes_string_keys() {
         // A String key in a hash *literal* is stored as a frozen dup (like
         // `Hash#[]=`), so later mutation of the source String can't corrupt

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2122,11 +2122,13 @@ fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
         globals
             .compile_script_binding(expr, fname, binding, lineno)
             .map_err(downgrade_eval_fatal)?;
+        vm.flush_compile_warnings(globals);
         vm.invoke_binding(globals, binding.binding().unwrap())
     } else {
         let fid = globals
             .compile_script_eval(expr, fname, caller_cfp, None, lineno)
             .map_err(downgrade_eval_fatal)?;
+        vm.flush_compile_warnings(globals);
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         // Isolate the eval's cref so toggles like `module_function`,
         // `private`, … set inside the eval'd source don't leak to

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -377,6 +377,7 @@ fn instance_eval_inner(
         };
         let fid =
             globals.compile_script_eval(expr, path, caller_cfp, Some(self_val.class()), lineno)?;
+        vm.flush_compile_warnings(globals);
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         vm.invoke_block_with_self(globals, &proc, self_val, &[])
     } else {

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1550,6 +1550,7 @@ impl<'a> BytecodeGen<'a> {
         splat: Vec<Node>,
         loc: Loc,
     ) -> Result<()> {
+        self.warn_duplicated_hash_keys(&nodes);
         if nodes.len() <= LITERAL_CHUNK_LEN {
             let len = nodes.len();
             let old_reg = self.temp;
@@ -1617,6 +1618,54 @@ impl<'a> BytecodeGen<'a> {
             }
         }
         Ok(())
+    }
+
+    ///
+    /// Buffer CRuby's "key ... is duplicated and overwritten" warning for a
+    /// hash literal that repeats a *literal* key (`{a: 1, a: 2}`). Only
+    /// constant keys (symbol / string / integer / bignum / float / true /
+    /// false / nil) are checked — runtime-computed keys (`{k => 1, k => 2}`)
+    /// are not — matching CRuby's compile-time check. Silenced at warning
+    /// level 0 (`-W0`). The message is buffered on `Store` and flushed
+    /// through `$stderr` by `Executor::flush_compile_warnings` once
+    /// compilation finishes.
+    ///
+    fn warn_duplicated_hash_keys(&mut self, nodes: &[(Node, Node)]) {
+        use std::sync::atomic::Ordering;
+        if crate::globals::WARNING.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        fn literal_key(kind: &NodeKind) -> Option<(String, String)> {
+            // (equality key, inspect string)
+            match kind {
+                NodeKind::Symbol(s) => Some((format!("sym:{s}"), format!(":{s}"))),
+                NodeKind::String(s) => Some((format!("str:{s}"), format!("{s:?}"))),
+                NodeKind::Integer(i) => Some((format!("int:{i}"), format!("{i}"))),
+                NodeKind::Bignum(n) => Some((format!("int:{n}"), format!("{n}"))),
+                NodeKind::Float(f) => {
+                    Some((format!("flt:{f}"), crate::value::ruby_float_to_s(*f)))
+                }
+                NodeKind::Bool(b) => Some((format!("bool:{b}"), format!("{b}"))),
+                NodeKind::Nil => Some(("nil".to_string(), "nil".to_string())),
+                _ => None,
+            }
+        }
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (k, _) in nodes {
+            if let Some((eq, inspect)) = literal_key(&k.kind) {
+                if !seen.insert(eq) {
+                    let line = self.sourceinfo.get_line(&k.loc);
+                    let msg = format!(
+                        "{}:{}: warning: key {} is duplicated and overwritten on line {}",
+                        self.sourceinfo.path.to_string_lossy(),
+                        line,
+                        inspect,
+                        line,
+                    );
+                    self.store.compile_warnings.push(msg);
+                }
+            }
+        }
     }
 
     fn gen_regexp(&mut self, ret: BcReg, nodes: Vec<Node>, option: String, loc: Loc) -> Result<()> {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -451,7 +451,32 @@ impl Executor {
             Ok(res) => bytecodegen::bytecode_compile_script(globals, res),
             Err(err) => Err(err),
         }?;
+        self.flush_compile_warnings(globals);
         self.eval_toplevel(globals, fid)
+    }
+
+    ///
+    /// Emit warnings buffered during bytecode compilation
+    /// (`Store::compile_warnings`, e.g. a duplicated hash-literal key)
+    /// through the current `$stderr`, so they honour a redirected
+    /// `$stderr` (as CRuby's compile-time warnings do). Must be called
+    /// after compilation and before the compiled code runs.
+    ///
+    pub(crate) fn flush_compile_warnings(&mut self, globals: &mut Globals) {
+        if globals.store.compile_warnings.is_empty() {
+            return;
+        }
+        let msgs = std::mem::take(&mut globals.store.compile_warnings);
+        let stderr = globals
+            .get_gvar(IdentId::get_id("$stderr"))
+            .unwrap_or_default();
+        let write_id = IdentId::get_id("write");
+        for m in msgs {
+            let msg_val = Value::string(format!("{m}\n"));
+            // Ignore errors (e.g. a nil / broken `$stderr` during early
+            // bootstrap): a warning must never mask the program's result.
+            let _ = self.invoke_method_inner(globals, write_id, stderr, &[msg_val], None, None);
+        }
     }
 
     ///

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -92,6 +92,13 @@ pub struct Store {
     /// during JIT compilation); the borrow never outlives a single
     /// cache probe/fill.
     method_cache: RefCell<GlobalMethodCache>,
+    /// Warnings produced during bytecode compilation (e.g. a hash literal
+    /// with a duplicated literal key). Bytecodegen has no `Executor`, so it
+    /// can't route a warning through the redirectable `$stderr`; the
+    /// messages are buffered here and flushed by
+    /// `Executor::flush_compile_warnings` right after compilation, before
+    /// the compiled code runs.
+    pub(crate) compile_warnings: Vec<String>,
 }
 
 impl std::ops::Deref for Store {
@@ -207,6 +214,7 @@ impl Store {
             default_neq: None,
             default_copy_hooks: None,
             method_cache: RefCell::new(GlobalMethodCache::default()),
+            compile_warnings: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

CRuby warns `key ... is duplicated and overwritten on line N` when a hash literal repeats a **literal** key (`{a: 1, a: 2}`, `{1.0 => x, 1.0 => y}`), and routes it through the redirectable `$stderr` — so `-> { eval "..." }.should complain(...)` captures it. monoruby emitted nothing.

## Change

Bytecodegen has no `Executor`, so it can't invoke `$stderr.write` directly. So:

1. During `gen_hash`, detect duplicated **literal** keys (symbol / string / integer / bignum / float / true / false / nil). Runtime-computed keys (`{k => 1, k => 2}`) are left alone, matching CRuby's compile-time check.
2. Buffer the formatted messages on a new `Store::compile_warnings`.
3. Flush them through `$stderr` via a new `Executor::flush_compile_warnings`, called right after compilation and before the compiled code runs — at every compile→run entry point (top-level / `require` via `exec_script`, plus `Kernel#eval` / `instance_eval` / `module_eval` / `Binding#eval`).

Silenced at `-W0`. The float key is rendered with `ruby_float_to_s` so `1.0` prints as `1.0` (not `1`).

This adds **no bytecode instruction** (the compiled bytecode is byte-for-byte unchanged; only a compile-time detection pass + a runtime `$stderr.write` via existing machinery), so both the x86-64 and AArch64 backends are unaffected.

## Spec impact

`language/hash_spec.rb`: fixes "checks duplicated keys on initialization" and "checks duplicated float keys on initialization" (7 → 5 failures). The remaining failures are the `**obj` splat-vs-explicit-key ordering/precedence cases, tracked separately.

## Tests

- New `hash_literal_duplicated_key_warning` in `builtins/hash.rs`: captures `$stderr` via `StringIO` and matches the message for symbol / string / integer / float dup keys, confirms a runtime key does **not** warn, confirms no-dup is silent, and that the overwrite still applies. CRuby-verified.
- Full `monoruby` lib suite (1804) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_