### PR TITLE
builtins: exclude implicit block params from local_variables

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -6673,6 +6673,15 @@ mod tests {
         run_test(r#"def m; for a, *b in [[1, 2, 3]]; end; local_variables.sort; end; m"#);
         // `Binding#local_variables` shares the same filtering.
         run_test(r#"def m; a = 1; b = 2; binding.local_variables.sort; end; m"#);
+        // The implicit `it` block parameter and numbered parameters
+        // (`_1`..`_9`) are not reported as local variables...
+        run_test(r#"def m; [1].map { it; local_variables }; end; m"#);
+        run_test(r#"def m; [[1, 2]].map { _1 + _2; local_variables }; end; m"#);
+        run_test(r#"def m; [1].map { it; binding.local_variables }; end; m"#);
+        // ...but an explicit `it` local, or an explicit `|it|` block
+        // parameter, still is.
+        run_test(r#"def m; it = 5; local_variables; end; m"#);
+        run_test(r#"def m; [1].map { |it| j = it; local_variables.sort }; end; m"#);
     }
 
     #[test]

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -646,24 +646,28 @@ impl Store {
     ///
     pub(crate) fn local_variables(&self, mut iseq: ISeqId) -> Vec<Value> {
         let mut map = indexmap::IndexSet::<IdentId>::default();
-        self[iseq].locals.keys().for_each(|id| {
-            map.insert(*id);
-        });
-        if let Some(id) = self[iseq].block_param() {
-            map.insert(id);
-        }
-
-        while let Some(outer) = self[iseq].outer {
-            self[outer].locals.keys().for_each(|id| {
+        loop {
+            // The implicit `it` block parameter (Ruby 3.4) is not a reportable
+            // local variable, while an explicit `it = ...` local is — so only
+            // skip `it` in the iseq that actually takes the implicit parameter.
+            let it_param = self[iseq].args.it_param();
+            self[iseq].locals.keys().for_each(|id| {
+                if it_param && id.get_name() == "it" {
+                    return;
+                }
                 map.insert(*id);
             });
-            if let Some(id) = self[outer].block_param() {
+            if let Some(id) = self[iseq].block_param() {
                 map.insert(id);
             }
-            iseq = outer;
+            match self[iseq].outer {
+                Some(outer) => iseq = outer,
+                None => break,
+            }
         }
         // Drop reserved, unspellable slots (anonymous `*` / `**` / `&`, the
-        // hidden `for`-loop index, …) that are not real local variables.
+        // hidden `for`-loop index, the numbered block parameters `_1`..`_9`, …)
+        // that are not real local variables.
         map.into_iter()
             .filter(|id| is_local_variable_name(&id.get_name()))
             .map(Value::symbol)
@@ -672,9 +676,18 @@ impl Store {
 }
 
 /// Whether `name` is spellable as a Ruby local variable — i.e. begins with a
-/// lowercase letter or `_` and consists only of word characters. Filters out
-/// the compiler's reserved slots (`*`, `**`, `&`'s empty name, `(for)`, …).
+/// lowercase letter or `_` and consists only of word characters, and is not a
+/// numbered block parameter (`_1`..`_9`, which Ruby reserves and never reports
+/// as a local variable). Filters out the compiler's reserved slots (`*`, `**`,
+/// `&`'s empty name, `(for)`, …).
 fn is_local_variable_name(name: &str) -> bool {
+    // Numbered block parameters `_1`..`_9`.
+    if let Some(rest) = name.strip_prefix('_')
+        && rest.len() == 1
+        && matches!(rest.as_bytes()[0], b'1'..=b'9')
+    {
+        return false;
+    }
     let mut chars = name.chars();
     match chars.next() {
         Some(c) if c == '_' || (!c.is_ascii()) || c.is_lowercase() => {}


### PR DESCRIPTION
## Summary

`local_variables` / `Binding#local_variables` reported the implicit `it` block parameter (Ruby 3.4) and the numbered block parameters `_1`..`_9`, which CRuby never lists:

- `[1].map { it; binding.local_variables }` → CRuby `[]`, monoruby `[:it]`
- `[[1, 2]].map { _1 + _2; local_variables }` → CRuby `[]`, monoruby `[:_1, :_2]`

## Change

- Numbered parameters are reserved names (`_1 = 5; local_variables` is `[]` in CRuby too), so `is_local_variable_name` now filters `_1`..`_9` out unconditionally.
- `it`, by contrast, is a valid ordinary local (`it = 5` → `[:it]`) and a valid explicit block parameter (`|it|`), so it's only skipped in the iseq that actually takes the **implicit** `it`, gated on `ParamsInfo::it_param`.

Both `Kernel#local_variables` and `Binding#local_variables` go through the same `Store::local_variables`, so one change covers both. Pure Rust filtering — no codegen — so both backends are unaffected.

## Spec impact

Fixes `language/it_parameter_spec.rb` "does not affect binding local variables" (**1 → 0 failures**, file now clean) and `language/numbered_parameters_spec.rb` "does not affect binding local variables" (**1 fail + 1 err → 0 fail + 1 err**; the remaining error is the separate `_10`/">9 params" case).

## Tests

- Extended `kernel_local_variables` in `builtins/kernel.rs`: implicit `it` and numbered `_1`/`_2` are excluded (via `local_variables` and `binding.local_variables`), while an explicit `it = 5` local and an explicit `|it|` block parameter are still reported. CRuby-verified.
- Full `monoruby` lib suite (1804) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_