### PR TITLE
bytecodegen: don't const-fold methods with side-effecting param defaults

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -645,6 +645,15 @@ impl<'a> BytecodeGen<'a> {
         {
             self.gen_expand_array(src, dst, len, rest_pos);
         }
+        // A trivial-method hint (`ConstReturn` / `SelfReturn`) makes the
+        // native wrapper return immediately, skipping the whole parameter
+        // prologue below. That is only sound when the prologue has no
+        // observable side effects. Optional- and keyword-parameter default
+        // expressions can run arbitrary user code (e.g.
+        // `def f(a = ($x = 1)); 1; end` — calling `f` must still assign
+        // `$x`), so their presence disqualifies the method from the hint.
+        let prologue_has_side_effects = !info.optional_info.is_empty()
+            || info.keyword_initializers.iter().any(|i| i.is_some());
         for OptionalInfo { local, initializer } in info.optional_info {
             let local = local.into();
             let next = self.new_label();
@@ -682,7 +691,9 @@ impl<'a> BytecodeGen<'a> {
         }
 
         let ast = info.ast;
-        if let Some(hint) = self.hint(&ast) {
+        if !prologue_has_side_effects
+            && let Some(hint) = self.hint(&ast)
+        {
             self.store[self.iseq_id].hint = hint;
         }
         self.apply_label(self.redo_label);

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -26,6 +26,80 @@ fn test_method_optional() {
 }
 
 #[test]
+fn optional_default_side_effect_trivial_body() {
+    // A method whose body is a single constant literal (or `self`) used to
+    // be optimized into an immediate "constant return" wrapper that skipped
+    // the whole parameter prologue. When such a method also had an optional
+    // (or keyword) parameter with a side-effecting default expression, that
+    // default was silently dropped on a call that omitted the argument.
+    // Each body below (`1`, `nil`, `self`, empty) is trivial, so the
+    // optional default `$x = ...` must still run.
+    run_test(
+        r#"
+        def f(a = ($x = 1)); 1; end
+        f
+        $x
+        "#,
+    );
+    run_test(
+        r#"
+        def f(a = ($x = 2)); nil; end
+        f
+        $x
+        "#,
+    );
+    run_test(
+        r#"
+        class C
+          def f(a = ($x = 3)); self; end
+        end
+        C.new.f
+        $x
+        "#,
+    );
+    run_test(
+        r#"
+        def f(a = ($x = 4)); end
+        f
+        $x
+        "#,
+    );
+    // Two optional params, both defaults must fire.
+    run_test(
+        r#"
+        def f(a = ($x = 1), b = ($y = 2)); 7; end
+        f
+        [$x, $y]
+        "#,
+    );
+    // A leading required param plus a trivial body; the optional default
+    // still runs when only the required arg is supplied.
+    run_test(
+        r#"
+        def f(r, a = ($x = 10)); 0; end
+        f(9)
+        [$x]
+        "#,
+    );
+    // Keyword-parameter default with a side effect and a trivial body.
+    run_test(
+        r#"
+        def f(k: ($x = 5)); true; end
+        f
+        $x
+        "#,
+    );
+    // When the argument IS supplied, the default must NOT run.
+    run_test(
+        r#"
+        def f(a = ($x = 1)); 1; end
+        f(99)
+        $x.inspect
+        "#,
+    );
+}
+
+#[test]
 fn method_rest() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

A method whose body is a single constant literal (`nil`, a fixnum, a bool) or `self` is optimized into a **trivial method**: its native wrapper (`gen_wrapper` in `codegen/arch/*/wrapper.rs`) returns the value immediately, without building a frame or running the bytecode. That wrapper skips the entire parameter prologue.

This is unsound when the method also has an **optional (or keyword) parameter whose default expression has an observable side effect**:

```ruby
def f(a = ($x = 1)); 1; end
f
p $x   # => nil   (should be 1)
```

Calling `f` with no argument must evaluate the default `$x = 1`, but the `ConstReturn` wrapper returned `1` without ever running the optional-parameter prologue (`check_local` + initializer), so `$x` was never assigned. The argument handler still ran and correctly wrote the "not given" sentinel to the optional slot — the body that would have consumed it simply never executed.

The defect was observable on the VM path too (`--no-jit`), since the wrapper is shared between the VM and JIT tiers, and on both `x86_64` and `aarch64`.

## Fix

In `bytecodegen`, disqualify a method from the trivial-method hint (`ConstReturn` / `SelfReturn`) when its parameter prologue can run user code — i.e. when it has optional-parameter defaults or keyword-parameter defaults. Plain trivial methods (no parameters, or only required parameters, which bind without running user code) keep the optimization.

The check is captured before the prologue loops consume the relevant `CompileInfo` vectors:

```rust
let prologue_has_side_effects = !info.optional_info.is_empty()
    || info.keyword_initializers.iter().any(|i| i.is_some());
```

This is an arch-neutral change (touches only `bytecodegen`); it fixes both backends by never emitting the hint for these methods.

## Testing

- New regression test `optional_default_side_effect_trivial_body` in `tests/method_call.rs`, covering trivial bodies (`1`, `nil`, `self`, empty), two optional defaults, a leading required param plus an optional default, a keyword default, and the argument-supplied case where the default must **not** run. All assertions are CRuby-verified via `run_test` (25× JIT warm-up + output comparison).
- Verified the repro on both architectures — `x86_64` (native) and `aarch64` (cross build under qemu) — now match CRuby, while plain trivial methods (`def g; 42; end`, `self`-returning methods) remain optimized and correct.
- `cargo test` green for the `method_call` (100), `lib` (116), `arith`, `literal`, `yield`, `rescue`, and `variables` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_