### PR TITLE
bytecodegen: fix scoped constant op-assign scope re-eval and const_missing

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -509,6 +509,15 @@ impl<'a> BytecodeGen<'a> {
                 {
                     return self.gen_op_assign_with_receiver(op, lhs, rhs, use_mode, loc);
                 }
+                // A scoped constant `Scope::CONST op= rhs` has a scope
+                // (module part) expression that may carry side effects
+                // (`(x += 1; M)::C ||= v`), so it must be evaluated exactly
+                // once and reused for both the read and the store. A bare
+                // constant (`CONST op= rhs`, no parent) is side-effect-free
+                // to re-read, so it stays on the simpler path below.
+                if matches!(&lhs.kind, NodeKind::Const { parent: Some(_), .. }) {
+                    return self.gen_scoped_const_op_assign(op, lhs, rhs, use_mode, loc);
+                }
                 match op {
                     BinOp::LOr | BinOp::LAnd => {
                         // `target ||= rhs` / `target &&= rhs`: short-circuit so
@@ -1073,6 +1082,94 @@ impl<'a> BytecodeGen<'a> {
                 self.apply_label(exit);
             }
             _ => {
+                let binopk = Self::binop_to_binopk(op);
+                let old = self.temp;
+                let rhs_reg = self.gen_expr_reg(rhs)?;
+                self.temp = old;
+                self.emit(BytecodeInst::BinOp(binopk, Some(cur), (cur, rhs_reg)), loc);
+                self.emit_assign(cur, lhs_kind, None, loc);
+            }
+        }
+        self.temp = temp;
+        self.handle_mode(use_mode, cur)?;
+        Ok(())
+    }
+
+    ///
+    /// Op-assign to a scoped constant `Scope::CONST op= rhs`.
+    ///
+    /// The scope (module part) is evaluated exactly once — `eval_lvalue`
+    /// reserves it as `base` — and reused for both the read and the store,
+    /// so a side-effecting scope (`(x += 1; M)::C ||= v`) fires only once.
+    ///
+    fn gen_scoped_const_op_assign(
+        &mut self,
+        op: BinOp,
+        lhs: Node,
+        rhs: Node,
+        use_mode: UseMode2,
+        loc: Loc,
+    ) -> Result<()> {
+        let temp = self.temp;
+        // Evaluates the scope once and keeps it reserved as `base`.
+        let (lhs_kind, rest) = self.eval_lvalue(&lhs)?;
+        assert!(!rest);
+        let (toplevel, base, prefix, name) = match &lhs_kind {
+            LvalueKind::Const {
+                toplevel,
+                parent,
+                prefix,
+                name,
+            } => (*toplevel, *parent, prefix.clone(), *name),
+            _ => unreachable!(),
+        };
+        let cur = self.push().into();
+        match op {
+            BinOp::LOr | BinOp::LAnd => {
+                let exit = self.new_label();
+                // `Scope::C ||= rhs` reads the constant without raising when
+                // it is undefined (nil ⇒ store fires); `&&=` uses the plain
+                // load (undefined ⇒ NameError), matching CRuby.
+                if matches!(op, BinOp::LOr) {
+                    self.emit(
+                        BytecodeInst::CheckConst {
+                            dst: cur,
+                            base,
+                            toplevel,
+                            prefix,
+                            name,
+                        },
+                        loc,
+                    );
+                } else {
+                    self.emit(
+                        BytecodeInst::LoadConst {
+                            dst: cur,
+                            base,
+                            toplevel,
+                            prefix,
+                            name,
+                        },
+                        loc,
+                    );
+                }
+                let jmp_if_true = matches!(op, BinOp::LOr);
+                self.emit_condbr(cur, exit, jmp_if_true, false);
+                self.gen_store_expr(cur, rhs)?;
+                self.emit_assign(cur, lhs_kind, None, loc);
+                self.apply_label(exit);
+            }
+            _ => {
+                self.emit(
+                    BytecodeInst::LoadConst {
+                        dst: cur,
+                        base,
+                        toplevel,
+                        prefix,
+                        name,
+                    },
+                    loc,
+                );
                 let binopk = Self::binop_to_binopk(op);
                 let old = self.temp;
                 let rhs_reg = self.gen_expr_reg(rhs)?;

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -708,7 +708,9 @@ pub(crate) extern "C" fn vm_check_constant(
             return Some(cache.value);
         };
     }
-    match vm.find_constant(globals, site_id) {
+    // The `||=` / `&&=` definedness check must not fire `const_missing`
+    // (CRuby checks definedness only), so use the no-missing resolver.
+    match vm.find_constant_no_missing(globals, site_id) {
         Ok((value, base_class)) => {
             globals.store[site_id].cache = Some(ConstCache {
                 version: const_version,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1197,6 +1197,32 @@ impl Executor {
         globals: &mut Globals,
         site_id: ConstSiteId,
     ) -> Result<(Value, Option<Value>)> {
+        self.find_constant_impl(globals, site_id, true)
+    }
+
+    ///
+    /// Like [`Self::find_constant`], but the *final* constant name is resolved
+    /// without falling back to `const_missing` — an undefined constant yields
+    /// a `NameError` (mapped to `nil` by the `||=` / `&&=` check path) instead
+    /// of invoking a user `const_missing` hook. The scope (module part) is
+    /// still resolved normally, since evaluating `A::B` in `A::B::C ||= v` is
+    /// an ordinary read that may legitimately fire `const_missing`. Matches
+    /// CRuby, whose constant op-assign checks definedness without `const_missing`.
+    ///
+    pub(crate) fn find_constant_no_missing(
+        &mut self,
+        globals: &mut Globals,
+        site_id: ConstSiteId,
+    ) -> Result<(Value, Option<Value>)> {
+        self.find_constant_impl(globals, site_id, false)
+    }
+
+    fn find_constant_impl(
+        &mut self,
+        globals: &mut Globals,
+        site_id: ConstSiteId,
+        final_missing: bool,
+    ) -> Result<(Value, Option<Value>)> {
         let ConstSiteInfo {
             name,
             toplevel,
@@ -1216,7 +1242,14 @@ impl Executor {
             // Lexical access (`Foo` with no qualifier): visibility is not
             // enforced. Constants are reachable from their own lexical
             // scope regardless of `private_constant`.
-            let v = self.search_constant_checked(globals, name, current_func)?;
+            let v = if final_missing {
+                self.search_constant_checked(globals, name, current_func)?
+            } else {
+                match self.search_constant_no_missing(globals, name, current_func)? {
+                    Some(v) => v,
+                    None => return Ok((Value::nil(), None)),
+                }
+            };
             return Ok((v, None));
         } else {
             let parent = prefix.remove(0);
@@ -1243,6 +1276,18 @@ impl Executor {
             parent = val.expect_class_or_module(&globals.store)?.id();
         }
         let module = globals[parent].get_module();
+        if !final_missing {
+            // `||=` / `&&=` definedness check on the (already-resolved) scope:
+            // return the value if the constant exists on the ancestor chain,
+            // otherwise `nil` — without invoking `const_missing`, and without
+            // enforcing `private_constant` visibility (a bare op-assign target
+            // is reachable like a definedness probe).
+            let v = match self.get_constant_superclass_qualified(globals, module, name)? {
+                Some(v) => v,
+                None => Value::nil(),
+            };
+            return Ok((v, base));
+        }
         if let Some(defining) = Self::probe_constant_superclass_with_class(globals, module, name) {
             if globals.store[defining].is_constant_private(name) {
                 // A private constant routes through `const_missing` (CRuby

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -210,7 +210,7 @@ impl Executor {
     /// reference does not fall through to top-level constants
     /// (`String::Hash` raises `NameError` even though `Hash` is a top-level
     /// constant). Mirrors CRuby's `rb_const_search` skipping `rb_cObject`.
-    fn get_constant_superclass_qualified(
+    pub(super) fn get_constant_superclass_qualified(
         &mut self,
         globals: &mut Globals,
         mut module: Module,

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -1556,6 +1556,97 @@ fn op_assign_evaluates_receiver_once() {
 }
 
 #[test]
+fn scoped_const_op_assign_evaluates_scope_once() {
+    // `Scope::CONST op= rhs` must evaluate the scope (module part)
+    // expression exactly once, sharing it between the read and the store.
+    // A side-effecting scope run twice would bump the counter to 2.
+    run_test(
+        r#"
+        module M1; end
+        x = 0
+        (x += 1; M1)::C ||= :assigned
+        [x, M1::C]
+        "#,
+    );
+    run_test(
+        r#"
+        module M2; C = nil; end
+        x = 0
+        (x += 1; M2)::C ||= :a
+        [x, M2::C]
+        "#,
+    );
+    run_test(
+        r#"
+        module M3; C = 1; end
+        x = 0
+        (x += 1; M3)::C &&= :a
+        [x, M3::C]
+        "#,
+    );
+    run_test(
+        r#"
+        module M4; C = 10; end
+        x = 0
+        (x += 1; M4)::C += 5
+        [x, M4::C]
+        "#,
+    );
+    // The rhs must not be evaluated when the scope expression raises.
+    run_test(
+        r#"
+        module M5; C = nil; end
+        x = 0; y = 0
+        begin
+          (x += 1; raise "boom"; M5)::C ||= (y += 1; :a)
+        rescue
+        end
+        [x, y]
+        "#,
+    );
+}
+
+#[test]
+fn const_op_assign_does_not_invoke_const_missing() {
+    // `CONST ||= v` / `Scope::CONST ||= v` check definedness like CRuby —
+    // they must NOT trigger `const_missing` (which could make an undefined
+    // constant read back as truthy and skip the assignment).
+    run_test(
+        r#"
+        module MM
+          def self.const_missing(c); c; end
+        end
+        MM::NOSUCH ||= :assigned
+        MM::NOSUCH
+        "#,
+    );
+    // A bare `CONST ||=` at top level with a custom Object const_missing.
+    run_test(
+        r#"
+        class Object
+          def self.const_missing(c); c; end
+        end
+        NO_SUCH_TOP ||= :assigned
+        NO_SUCH_TOP
+        "#,
+    );
+    // A normal read still fires const_missing.
+    run_test(
+        r#"
+        module MN
+          def self.const_missing(c); "missing:#{c}"; end
+        end
+        MN::WHATEVER
+        "#,
+    );
+    // Defined constants are kept; nil constants are (re)assigned.
+    run_tests(&[
+        "Y_KEEP = 3; Y_KEEP ||= 9; Y_KEEP",
+        "Z_NIL = nil; Z_NIL ||= 5; Z_NIL",
+    ]);
+}
+
+#[test]
 fn op_assign_all_operators_on_receiver() {
     // Every arithmetic / bitwise op-assign operator applied to an
     // attribute target, exercising each `BinOpK` on the single-eval


### PR DESCRIPTION
## Summary

Two related bugs in constant op-assign (`Scope::CONST op= rhs` and `CONST op= rhs`), surfaced by `language/optional_assignments_spec`.

### 1. Scope (module part) evaluated twice

A scoped-constant op-assign re-evaluated its scope expression once for the read and once for the store, so a side-effecting scope fired twice:

```ruby
module M; end
x = 0
(x += 1; M)::C ||= :assigned
x   # => 2  (should be 1)
```

The op-assign desugaring only hoisted the receiver of `recv.attr` / `base[idx]` targets into a temp; a constant target with a computed scope re-evaluated that scope on both sides. Scoped-constant op-assign (`Const` node with a `parent` expression) now goes through a dedicated path (`gen_scoped_const_op_assign`) that evaluates the scope **once** via `eval_lvalue` and reuses it for the read and the store. A bare `CONST op= rhs` (no parent) stays on the simpler re-reading path — re-reading it has no side effects.

### 2. `||=` / `&&=` check fired `const_missing`

The definedness check read the constant through the normal resolver, which falls back to `const_missing`. A user hook returning a truthy value then made `||=` treat an undefined constant as already-set and skip the assignment:

```ruby
module M
  def self.const_missing(c) = c
end
M::NOSUCH ||= :assigned
M::NOSUCH   # => :NOSUCH  (should be :assigned)
```

Added `find_constant_no_missing`, which resolves the **final** constant name without `const_missing` (the scope is still resolved normally — evaluating `A::B` in `A::B::C ||= v` is an ordinary read that may legitimately fire `const_missing`), and routed `vm_check_constant` through it. Matches CRuby, whose constant op-assign checks definedness only. The JIT inherits this via the per-site const cache (populated by `vm_check_constant`, folded under a const-version guard).

## Testing

- New CRuby-verified unit tests in `tests/arith.rs`:
  - `scoped_const_op_assign_evaluates_scope_once` — scope evaluated once for `||=`/`&&=`/`+=`, and rhs not evaluated when the scope raises.
  - `const_op_assign_does_not_invoke_const_missing` — `||=` skips `const_missing` (scoped + top level), a normal read still fires it, defined constants kept, nil constants reassigned.
- `language/optional_assignments_spec`: 4 failures → 0 (2 remaining errors are an unrelated `self[...] ||=` private-visibility issue). One `language/assignments_spec` failure also fixed as a side effect.
- No regressions in `language/{constants,defined,class,module}_spec` (same baseline).
- `cargo test` green for `lib`, `arith`, `method_call`, `variables`, `mul_assign`.
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_