### PR TITLE
runtime: don't call #to_a when splatting an Array or nil

### DIFF
--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1578,6 +1578,18 @@ pub(super) extern "C" fn to_a(
     globals: &mut Globals,
     src: Value,
 ) -> Option<Value> {
+    // A splat of a value that is already an Array (including an Array
+    // subclass) uses it directly — `#to_a` is NOT invoked (`a, b = *ary`
+    // and `m(*ary)` must not call a user-defined `Array#to_a`). The
+    // downstream array build makes the copy / normalizes to a plain Array.
+    if src.is_array_ty() {
+        return Some(src);
+    }
+    // A splat of `nil` yields an empty array without invoking any method
+    // (`*nil` ⇒ `[]`; CRuby special-cases nil rather than calling `to_a`).
+    if src.is_nil() {
+        return Some(Value::array_empty());
+    }
     if let Some(func_id) = globals.check_method(src, IdentId::TO_A) {
         let ary = vm.invoke_func(globals, func_id, src, &[], None, None)?;
         if ary.is_array_ty() {

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -285,6 +285,66 @@ fn multi_assign_nested_values() {
 }
 
 #[test]
+fn splat_rhs_does_not_call_to_a_on_array() {
+    // A splatted value that is already an Array is used directly — `#to_a`
+    // must NOT be invoked. `$flag` is reset each run so the assertion is
+    // idempotent under the 25-iteration warm-up loop.
+    run_test(
+        r#"
+        arr = [1, 2]
+        def arr.to_a; $flag = true; super; end
+        $flag = false
+        a, b = *arr
+        [$flag, a, b]
+        "#,
+    );
+    // Array subclass RHS: to_a must not run; the result is a plain Array.
+    run_test(
+        r#"
+        class MyArr < Array; def to_a; $flag = true; super; end; end
+        $flag = false
+        arr = MyArr.new([1, 2])
+        x = *arr
+        [$flag, x, x.class]
+        "#,
+    );
+    // Call-site splat of an Array must not call to_a either.
+    run_test(
+        r#"
+        arr = [1, 2]
+        def arr.to_a; $flag = true; super; end
+        $flag = false
+        def f(*a); a; end
+        r = f(*arr)
+        [$flag, r]
+        "#,
+    );
+    // `x = *arr` copies (result is not the same object).
+    run_test("arr = [1, 2]; x = *arr; x.equal?(arr)");
+    // `*nil` ⇒ `[]` without invoking any method on nil.
+    run_test(
+        r#"
+        class NilClass; def to_a; $flag = true; super; end; end
+        $flag = false
+        a, b = *nil
+        [$flag, a, b]
+        "#,
+    );
+    run_test("x = *nil; x");
+    run_test("def g(*a); a; end; g(*nil)");
+    // A genuine non-Array value is still converted via #to_a.
+    run_test(
+        r#"
+        o = Object.new
+        def o.to_a; $flag = true; [7, 8]; end
+        $flag = false
+        a, b = *o
+        [$flag, a, b]
+        "#,
+    );
+}
+
+#[test]
 fn for_loop_destructuring_index() {
     // `for` with a splat / post / nested / non-local index target
     // destructures each element, and the targets still leak to the


### PR DESCRIPTION
## Summary

A splat operator (`a, b = *rhs`, `m(*rhs)`, `[*rhs]`) lowers a non-Array-literal operand through the `ToA` bytecode, whose runtime unconditionally invoked `#to_a`. That is wrong when the operand is already an Array (or an Array subclass) or is `nil`:

```ruby
class Array; def to_a; $called = true; super; end; end
a, b = *[1, 2]
$called   # => true  (should stay falsy — CRuby does not call #to_a)
```

CRuby uses an Array (including a subclass) directly and treats `*nil` as `[]`, without invoking any conversion method — only a non-Array, non-nil value goes through `#to_a`. The mismatch was observable whenever a user defined `Array#to_a` / `NilClass#to_a` (or via ruby/spec's method mocks).

## Fix

Short-circuit `runtime::to_a`: return the value as-is when it is already an array (`is_array_ty()`, which covers subclasses), and return an empty array for `nil`, before the `#to_a` dispatch. The downstream splat array-build still makes the copy and normalizes an Array subclass to a plain Array, so value semantics are unchanged.

The x86_64/aarch64 JIT `to_a` helpers already guard the exact-Array case inline (`guard_rvalue … ARRAY_CLASS`) and fall through to this runtime for everything else (including subclasses and nil), so both tiers and both arches inherit the fix from this single change.

## Testing

- New CRuby-verified unit test `splat_rhs_does_not_call_to_a_on_array` in `tests/mul_assign.rs`: Array/subclass RHS (no `to_a`, plain-Array result), call-site splat, copy semantics (`x = *arr` is a distinct object), `*nil ⇒ []` with no method call, and a genuine non-Array value still routed through `#to_a`.
- `language/variables_spec`: 9 failures → 3 (remaining are the `respond_to?`-dispatch protocol and an unrelated verbose-mode gvar warning). `language/array_spec`: 2 → 0.
- No regressions in `language/{block,method,keyword_arguments}_spec` (same baseline).
- `cargo test` green for `lib`, `mul_assign`, `method_call`, `arith`.
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_