### PR TITLE
bytecodegen: build hash literals with **-splats in source order

### DIFF
--- a/monoruby/src/ast/node.rs
+++ b/monoruby/src/ast/node.rs
@@ -41,7 +41,7 @@ pub enum NodeKind {
         is_const: bool,
     }, // start, end, exclude_end
     Array(Vec<Node>, bool),             // Vec<ELEM>, is_constant_expr
-    Hash(Vec<(Node, Node)>, Vec<Node>), // Vec<KEY, VALUE>, Vec<SPLAT>
+    Hash(Vec<(Node, Node)>, Vec<(usize, Node)>), // Vec<KEY, VALUE>, Vec<(# preceding pairs, SPLAT)>
     RegExp(Vec<Node>, String, bool),    // Vec<STRING>, option, is_constant_expr
 
     LocalVar(usize, String),
@@ -560,7 +560,7 @@ impl Node {
 
     pub(crate) fn new_hash_with_splat(
         key_value: Vec<(Node, Node)>,
-        splat: Vec<Node>,
+        splat: Vec<(usize, Node)>,
         loc: Loc,
     ) -> Self {
         Node::new(NodeKind::Hash(key_value, splat), loc)

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4171,6 +4171,28 @@ mod tests {
     }
 
     #[test]
+    fn hash_literal_double_splat_order() {
+        // A hash literal is built strictly left-to-right: every element
+        // (ordinary `k: v` pair or `**` splat) is applied in source order,
+        // and a later element overwrites an earlier key while preserving
+        // the key's first-seen insertion position. An explicit pair after a
+        // `**` splat must overwrite a key the splat contributed.
+        run_tests(&[
+            r#"h = {b: 2, c: 3}; ({a: 1, **h, c: 4}).to_a"#,
+            r#"h = {b: 2, c: 3}; ({**h, a: 1}).to_a"#,
+            r#"h = {b: 2, c: 3}; ({a: 1, **h}).to_a"#,
+            r#"({x: 0, **{a: 1}, a: 9, y: 5}).to_a"#,
+            // Two interleaved splats with pairs before, between, and after.
+            r#"({**{a: 1}, b: 2, **{a: 3, c: 4}, b: 5}).to_a"#,
+            // `**nil` interleaved between pairs contributes nothing but must
+            // not disturb ordering.
+            r#"({a: 1, **nil, b: 2}).to_a"#,
+            // A `#to_hash` operand overwritten by a trailing explicit pair.
+            r#"o = Object.new; def o.to_hash; {k: 1}; end; ({**o, k: 2}).to_a"#,
+        ]);
+    }
+
+    #[test]
     fn hash_each_block_trailing_comma() {
         // PR #361 follow-up: a trailing comma in a block parameter list
         // (`|k,|`) injects a synthetic anonymous post param, bumping the

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -74,7 +74,7 @@ impl<'a> BytecodeGen<'a> {
                     self.check_defined(k, nil_label, ret, false)?;
                     self.check_defined(v, nil_label, ret, false)?;
                 }
-                for s in splat {
+                for (_, s) in splat {
                     self.check_defined(s, nil_label, ret, false)?;
                 }
             }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1644,75 +1644,124 @@ impl<'a> BytecodeGen<'a> {
         &mut self,
         ret: BcReg,
         nodes: Vec<(Node, Node)>,
-        splat: Vec<Node>,
+        splat: Vec<(usize, Node)>,
         loc: Loc,
     ) -> Result<()> {
         self.warn_duplicated_hash_keys(&nodes);
-        if nodes.len() <= LITERAL_CHUNK_LEN {
-            let len = nodes.len();
-            let old_reg = self.temp;
+        if splat.is_empty() {
+            if nodes.len() <= LITERAL_CHUNK_LEN {
+                let len = nodes.len();
+                let old_reg = self.temp;
+                let args = self.sp();
+                for (k, v) in nodes {
+                    self.push_expr(k)?;
+                    self.push_expr(v)?;
+                }
+                self.temp = old_reg;
+                self.emit_hash(ret, args.into(), len, loc);
+            } else {
+                // Chunked construction for large Hash literals (see
+                // `gen_array`): keeps register usage bounded regardless of
+                // the literal's size (issue #706).
+                let old_reg = self.temp;
+                let hash: BcReg = self.push().into();
+                let base = self.temp;
+                let count = nodes.len();
+                let mut iter = nodes.into_iter();
+                self.emit_hash_pairs(hash, &mut iter, count, true, base, loc)?;
+                self.temp = old_reg;
+                self.emit_mov(ret, hash);
+            }
+            return Ok(());
+        }
+        // At least one `**` splat: replay the elements strictly
+        // left-to-right so later entries overwrite earlier ones
+        // (`{a: 1, **h, c: 4}` ⇒ `{a: 1, b: 2, c: 4}` when `h == {b: 2,
+        // c: 3}`). `splat[j].0` records how many ordinary pairs precede
+        // splat `j`, so the source order is
+        //   pairs[0..p0], splat0, pairs[p0..p1], splat1, …, pairs[p(n-1)..]
+        let total_pairs = nodes.len();
+        let positions: Vec<usize> = splat.iter().map(|(p, _)| *p).collect();
+        let merge_id = IdentId::get_id("merge!");
+        let old_reg = self.temp;
+        let hash: BcReg = self.push().into();
+        let base = self.temp;
+        let mut iter = nodes.into_iter();
+        // Leading run of pairs before the first splat (may be empty, in
+        // which case an empty hash is created to merge into).
+        self.emit_hash_pairs(hash, &mut iter, positions[0], true, base, loc)?;
+        for (j, (pos, snode)) in splat.into_iter().enumerate() {
+            // Merge the `**` operand. A nil operand contributes nothing
+            // (`{a: 1, **nil}` == `{a: 1}`), so guard `merge!` with a nil
+            // check; a non-nil, non-Hash operand still raises via
+            // `merge!` / `#to_hash`.
+            let old_reg2 = self.temp;
+            let splat_arg = self.sp();
+            self.push_expr(snode)?;
+            let skip = self.new_label();
+            self.emit_nilbr(splat_arg.into(), skip, old_reg2);
+            self.temp = old_reg2;
+            let callsite = CallSite::simple(merge_id, 1, splat_arg.into(), hash, Some(hash));
+            self.emit_call(callsite, loc);
+            self.apply_label(skip);
+            // Pairs between this splat and the next one (or the tail).
+            let end = positions.get(j + 1).copied().unwrap_or(total_pairs);
+            self.emit_hash_pairs(hash, &mut iter, end - pos, false, base, loc)?;
+        }
+        self.temp = old_reg;
+        self.emit_mov(ret, hash);
+        Ok(())
+    }
+
+    ///
+    /// Build (`create == true`, first run) or merge-insert (`create ==
+    /// false`) a run of `count` key/value pairs drawn from `iter` into the
+    /// hash register `hash`, chunked at `LITERAL_CHUNK_LEN` to keep register
+    /// pressure bounded. `base` is the temp watermark restored after each
+    /// chunk (the hash register itself must already be reserved below it).
+    ///
+    fn emit_hash_pairs(
+        &mut self,
+        hash: BcReg,
+        iter: &mut impl Iterator<Item = (Node, Node)>,
+        count: usize,
+        create: bool,
+        base: u16,
+        loc: Loc,
+    ) -> Result<()> {
+        if count == 0 {
+            if create {
+                // Empty leading run (`{**h}`): start from an empty hash.
+                let args = self.sp();
+                self.emit_hash(hash, args.into(), 0, loc);
+            }
+            return Ok(());
+        }
+        let mut remaining = count;
+        let mut create = create;
+        while remaining > 0 {
+            let take = remaining.min(LITERAL_CHUNK_LEN);
             let args = self.sp();
-            for (k, v) in nodes {
+            for _ in 0..take {
+                let (k, v) = iter.next().unwrap();
                 self.push_expr(k)?;
                 self.push_expr(v)?;
             }
-            self.temp = old_reg;
-            self.emit_hash(ret, args.into(), len, loc);
-        } else {
-            // Chunked construction for large Hash literals (see `gen_array`):
-            // the first chunk becomes an ordinary Hash instruction; each
-            // following chunk evaluates its key/value pairs into the same
-            // temporary registers and merges them with HashInsert, keeping
-            // register usage bounded regardless of the literal's size.
-            let old_reg = self.temp;
-            let tmp: BcReg = self.push().into();
-            let base = self.temp;
-            let mut first = true;
-            let mut iter = nodes.into_iter().peekable();
-            while iter.peek().is_some() {
-                let args = self.sp();
-                let mut len = 0;
-                for (k, v) in iter.by_ref().take(LITERAL_CHUNK_LEN) {
-                    self.push_expr(k)?;
-                    self.push_expr(v)?;
-                    len += 1;
-                }
-                self.temp = base;
-                if first {
-                    self.emit_hash(tmp, args.into(), len, loc);
-                    first = false;
-                } else {
-                    self.emit(
-                        BytecodeInst::HashInsert {
-                            hash: tmp,
-                            args: args.into(),
-                            len: len as u16,
-                        },
-                        loc,
-                    );
-                }
+            self.temp = base;
+            if create {
+                self.emit_hash(hash, args.into(), take, loc);
+                create = false;
+            } else {
+                self.emit(
+                    BytecodeInst::HashInsert {
+                        hash,
+                        args: args.into(),
+                        len: take as u16,
+                    },
+                    loc,
+                );
             }
-            self.temp = old_reg;
-            self.emit_mov(ret, tmp);
-        }
-        if !splat.is_empty() {
-            // For each `**` operand, merge it into the hash. A nil operand
-            // contributes nothing (`{**nil}` == `{}`, `{a: 1, **nil}` ==
-            // `{a: 1}`), matching CRuby, so guard the `merge!` with a nil
-            // check. This is nil-specific: a non-nil, non-Hash operand
-            // (`{**1}`, `{**false}`) still raises via `merge!`/`#to_hash`.
-            let merge_id = IdentId::get_id("merge!");
-            for s in splat {
-                let old_reg2 = self.temp;
-                let splat_arg = self.sp();
-                self.push_expr(s)?;
-                let skip = self.new_label();
-                self.emit_nilbr(splat_arg.into(), skip, old_reg2);
-                self.temp = old_reg2;
-                let callsite = CallSite::simple(merge_id, 1, splat_arg.into(), ret, Some(ret));
-                self.emit_call(callsite, loc);
-                self.apply_label(skip);
-            }
+            remaining -= take;
         }
         Ok(())
     }

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -383,7 +383,7 @@ impl<'a> BytecodeGen<'a> {
                     self.level_down(n1, level);
                     self.level_down(n2, level);
                 });
-                splat.iter_mut().for_each(|n| self.level_down(n, level));
+                splat.iter_mut().for_each(|(_, n)| self.level_down(n, level));
             }
             NodeKind::FuncCall { arglist, .. } | NodeKind::Yield(arglist) => {
                 self.level_down_arglist(arglist, level);

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1597,7 +1597,7 @@ impl<'pr> Lowerer<'pr> {
                 let kh = n.as_keyword_hash_node().unwrap();
                 let kh_loc = location_to_loc(&kh.location());
                 let mut pairs: Vec<(Node, Node)> = Vec::new();
-                let mut splat: Vec<Node> = Vec::new();
+                let mut splat: Vec<(usize, Node)> = Vec::new();
                 for elem in kh.elements().iter() {
                     match elem {
                         prism::Node::AssocNode { .. } => {
@@ -1615,7 +1615,7 @@ impl<'pr> Lowerer<'pr> {
                                     loc: location_to_loc(&s.location()),
                                 },
                             };
-                            splat.push(inner);
+                            splat.push((pairs.len(), inner));
                         }
                         other => return Err(self.unsupported("array kwarg element", &other)),
                     }
@@ -1641,7 +1641,10 @@ impl<'pr> Lowerer<'pr> {
     fn lower_hash(&mut self, node: &HashNode<'pr>) -> Result<Node, MonorubyErr> {
         let loc = location_to_loc(&node.location());
         let mut pairs: Vec<(Node, Node)> = Vec::new();
-        let mut splat: Vec<Node> = Vec::new();
+        // Each `**` operand records how many ordinary `k: v` pairs precede
+        // it, so `gen_hash` can replay the elements strictly left-to-right
+        // (later entries overwrite earlier ones — `{a: 1, **h, c: 4}`).
+        let mut splat: Vec<(usize, Node)> = Vec::new();
         for elem in node.elements().iter() {
             match elem {
                 prism::Node::AssocNode { .. } => {
@@ -1659,7 +1662,7 @@ impl<'pr> Lowerer<'pr> {
                             loc: location_to_loc(&s.location()),
                         },
                     };
-                    splat.push(inner);
+                    splat.push((pairs.len(), inner));
                 }
                 other => return Err(self.unsupported("hash element", &other)),
             }
@@ -2172,7 +2175,7 @@ impl<'pr> Lowerer<'pr> {
                     // `**kw` slot (or, if there is none, falls
                     // back to a trailing positional hash).
                     let mut pairs: Vec<(Node, Node)> = Vec::new();
-                    let mut inner_splat: Vec<Node> = Vec::new();
+                    let mut inner_splat: Vec<(usize, Node)> = Vec::new();
                     for elem in kh.elements().iter() {
                         match elem {
                             prism::Node::AssocNode { .. } => {
@@ -2190,7 +2193,7 @@ impl<'pr> Lowerer<'pr> {
                                         loc: location_to_loc(&s.location()),
                                     },
                                 };
-                                inner_splat.push(inner);
+                                inner_splat.push((pairs.len(), inner));
                             }
                             other => return Err(self.unsupported("kwarg element", &other)),
                         }


### PR DESCRIPTION
## Summary

A hash literal that interleaves ordinary `k: v` pairs with `**` splats was built in the wrong order. `gen_hash` inserted **every explicit pair first** and only then merged **all** `**` operands, so an explicit pair written *after* a splat failed to overwrite a key the splat contributed:

```ruby
h = {b: 2, c: 3}
{a: 1, **h, c: 4}   # => {a: 1, c: 3, b: 2}   (should be {a: 1, b: 2, c: 4})
```

CRuby evaluates the elements strictly left-to-right, each later element overwriting an earlier key while keeping that key's first-seen insertion position.

## Fix

The `NodeKind::Hash` AST node stored pairs and splats in two separate vectors, discarding their relative order. Record on each `**` operand how many ordinary pairs precede it (`Vec<Node>` → `Vec<(usize, Node)>`), so `gen_hash` can replay the sequence in source order:

1. build the leading run of pairs (empty ⇒ empty hash),
2. for each splat, `merge!` it, then insert the pairs that follow it up to the next splat.

Runs are chunked at `LITERAL_CHUNK_LEN` via a shared `emit_hash_pairs` helper so register pressure stays bounded for large literals (issue #706), and the common no-splat path keeps its single-`Hash`-instruction fast build. `**nil` still contributes nothing.

This is a parser/bytecodegen-only change (AST node shape + the three lowering sites that build it + `gen_hash`); the keyword-argument path (`f(**h, k: v)`) uses a separate `CallSite` representation and is out of scope here.

## Testing

- New CRuby-verified unit test `hash_literal_double_splat_order` in `builtins/hash.rs`: explicit-after-splat overwrite, splat-first, two interleaved splats with pairs before/between/after, `**nil` interleaving, and a `#to_hash` operand overwritten by a trailing pair.
- Manually verified large literals (>256 pairs across both a create-run and an insert-run) still build correctly via the chunked path, and the duplicate-key warning still fires.
- `language/hash_spec`: 5 failures → 3 (remaining are the separate `**` duplicate-key *warning*). No regressions in `language/{keyword_arguments,method,array,block}_spec`.
- `cargo test` green for `lib`, `arith`, `mul_assign`, `method_call`.
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_