### PR TITLE
runtime: alias/undef keyword on an immediate receiver raises TypeError

### DIFF
--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -5019,6 +5019,39 @@ mod tests {
     }
 
     #[test]
+    fn alias_undef_keyword_on_immediate_raises() {
+        // The `alias` / `undef` keywords inside `instance_eval` target the
+        // receiver's singleton class. An immediate (Integer / Symbol) cannot
+        // own a singleton class, so it must raise `TypeError` — matching
+        // `def` and CRuby.
+        run_test(
+            r#"begin; 1.instance_eval { alias :foo :to_s }; :no; rescue TypeError; :te; end"#,
+        );
+        run_test(
+            r#"begin; :sym.instance_eval { alias :foo :to_s }; :no; rescue TypeError; :te; end"#,
+        );
+        run_test(r#"begin; 1.instance_eval { undef to_s }; :no; rescue TypeError; :te; end"#);
+        // A String instance *can* own a singleton class, so `alias` there
+        // succeeds and defines the alias only on that object.
+        run_test(
+            r#"
+            s = "abc"
+            s.instance_eval { alias my_len length }
+            [s.my_len, "other".respond_to?(:my_len)]
+            "#,
+        );
+        // The `alias` keyword in a `class_eval` block and a class body still
+        // targets the class itself.
+        run_test(
+            r#"
+            c = Class.new { def orig; 5; end }
+            c.class_eval { alias al orig }
+            c.new.al
+            "#,
+        );
+    }
+
+    #[test]
     fn alias_method_keeps_special_methods_private() {
         // Aliasing TO a special method name (`initialize`, `initialize_copy`,
         // `initialize_clone`, `initialize_dup`, `respond_to_missing?`) forces

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1286,9 +1286,14 @@ pub(super) extern "C" fn undef_method(
     // plain method body (`def self.x; undef foo; end`) where the method
     // frame is empty — fall back to the iseq's lexical class, matching
     // CRuby's `cref->klass`.
-    let class_id = vm
-        .class_context_id_opt()
-        .unwrap_or_else(|| vm.cfp().lfp().func_id().lexical_class(globals));
+    let class_id = match vm.definee_class_id_opt(globals) {
+        Ok(Some(class_id)) => class_id,
+        Ok(None) => vm.cfp().lfp().func_id().lexical_class(globals),
+        Err(err) => {
+            vm.set_error(err);
+            return None;
+        }
+    };
     match globals.undef_method_for_class(class_id, method) {
         Err(err) => {
             vm.set_error(err);
@@ -1330,8 +1335,18 @@ pub(super) extern "C" fn alias_method(
     // block created at top level and run inside
     // `Module.new do … end` still has Object as its lexical class.
     // `alias` should target the module that's currently being
-    // defined, matching CRuby's `cref->klass`.
-    let class_id = vm.context_class_id();
+    // defined, matching CRuby's `cref->klass`. An `instance_eval`
+    // receiver context resolves to the receiver's singleton class,
+    // which raises `TypeError` for an immediate (`1.instance_eval {
+    // alias … }`), matching `def`.
+    let class_id = match vm.definee_class_id_opt(globals) {
+        Ok(Some(class_id)) => class_id,
+        Ok(None) => OBJECT_CLASS,
+        Err(err) => {
+            vm.set_error(err);
+            return None;
+        }
+    };
     // `Executor::alias_method_for_class` already fires the
     // `method_added` hook, so the alias-keyword path matches
     // `Module#alias_method`'s behaviour for it.

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -848,6 +848,31 @@ impl Executor {
             })
     }
 
+    ///
+    /// The class that `alias` / `undef` target from the innermost runtime
+    /// cref, resolving an `instance_eval` receiver context to the receiver's
+    /// *singleton* class. That resolution raises `TypeError` for an immediate
+    /// value (Integer / Symbol / …) which cannot own a singleton class —
+    /// `1.instance_eval { alias :foo :to_s }` must raise, mirroring `def`.
+    /// Returns `Ok(None)` when no runtime cref is active so the caller applies
+    /// its own lexical-class fallback.
+    ///
+    /// Unlike [`Self::class_context_id_opt`] — which reports a receiver
+    /// context as `val.class()`, the receiver's ordinary class — this is the
+    /// definition definee and so must not silently target the ordinary class.
+    ///
+    pub(crate) fn definee_class_id_opt(&self, globals: &mut Globals) -> Result<Option<ClassId>> {
+        match self.lexical_class.last().unwrap().last().copied() {
+            Some(cref) => match cref.context {
+                DefinitionContext::Class(class_id) => Ok(Some(class_id)),
+                DefinitionContext::Receiver(receiver) => {
+                    Ok(Some(globals.store.get_singleton(receiver)?.id()))
+                }
+            },
+            None => Ok(None),
+        }
+    }
+
     /// Lexical parent for `module Foo; end` / `class Foo; end` /
     /// `X = ...`. Walks the runtime cref stack (top-down) and returns
     /// the first entry tagged as a lexical push — i.e. one introduced


### PR DESCRIPTION
## Summary

The `alias` and `undef` keywords resolved their target class through `context_class_id`, which reports an `instance_eval` receiver context as the receiver's **ordinary** class (`val.class()`). So:

```ruby
1.instance_eval { alias :foo :to_s }
```

silently aliased on `Integer` instead of raising, whereas `def` in the same position correctly raises `TypeError` (an Integer / Symbol immediate cannot own a singleton class). CRuby raises `TypeError` for both `alias` and `undef`.

## Fix

Add `Executor::definee_class_id_opt`, which resolves the innermost runtime cref's receiver context to the receiver's **singleton** class (via `get_singleton`, which raises `TypeError` for an immediate) — mirroring `define_method`'s definee resolution — and returns `None` when no runtime cref is active so each caller keeps its own lexical-class fallback. The `alias` and `undef` keyword runtimes now route through it.

A `String` instance (which *can* own a singleton class) still aliases only on that object, and `class_eval` / class-body / top-level `alias` are unchanged.

## Testing

- New CRuby-verified unit test `alias_undef_keyword_on_immediate_raises` in `builtins/module.rs`: `TypeError` for `alias`/`undef` on Integer and Symbol via `instance_eval`, a working singleton `alias` on a String instance (not leaking to other strings), and `class_eval` alias still targeting the class.
- `language/alias_spec`: 1 failure → 0; `language/undef_spec` still clean. No regressions in `language/{class,module,metaclass}_spec`.
- `cargo test -p monoruby --lib`: 1806 passed.
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_