### PR TITLE
bytecodegen: pass a non-interpolated command literal's string frozen

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -670,8 +670,35 @@ impl<'a> BytecodeGen<'a> {
                 return self.gen_super(arglist.map(|arglist| *arglist), use_mode, loc);
             }
             NodeKind::Command(box expr) => {
-                let arglist = ArgList::from_args(vec![expr]);
                 let method = IdentId::get_id("`");
+                // A non-interpolated command literal (`` `cmd` `` / `%x{…}`)
+                // passes its command string to the `` ` `` method FROZEN,
+                // matching CRuby (which freezes it regardless of any
+                // `frozen_string_literal` pragma). Build the call directly so
+                // the argument is a frozen literal; an interpolated form
+                // (`` `cmd #{x}` ``) builds a fresh, unfrozen string and takes
+                // the ordinary method-call path below.
+                if let NodeKind::String(s) = expr.kind {
+                    let (dst, push_flag) = match use_mode {
+                        UseMode2::NotUse => (None, false),
+                        UseMode2::Push | UseMode2::Ret => (Some(self.sp().into()), true),
+                        UseMode2::Store(dst) => (Some(dst), false),
+                    };
+                    let old_temp = self.temp;
+                    let arg = self.push().into();
+                    self.emit_frozen_string(arg, &s);
+                    self.temp = old_temp;
+                    if push_flag {
+                        self.push();
+                    }
+                    let callsite = CallSite::simple(method, 1, arg, BcReg::Self_, dst);
+                    self.emit_call(callsite, loc);
+                    if use_mode.is_ret() {
+                        self.emit_ret(None)?;
+                    }
+                    return Ok(());
+                }
+                let arglist = ArgList::from_args(vec![expr]);
                 return self.gen_method_call(method, None, arglist, false, use_mode, loc);
             }
             NodeKind::Yield(arglist) => {

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -268,3 +268,38 @@ fn literal_regexp_format() {
         r#"format("%02d:%02d:%02d", 1, 2, 3)"#,
     ]);
 }
+
+#[test]
+fn command_literal_frozen_argument() {
+    // A non-interpolated command literal (`` `cmd` `` / `%x{...}`) passes its
+    // command string to `Kernel#\`` FROZEN, matching CRuby (regardless of any
+    // frozen_string_literal pragma). An interpolated command builds a fresh,
+    // unfrozen string. `Kernel#\`` is redefined so the tests don't spawn a
+    // real process.
+    run_test(
+        r#"
+        def `(cmd); [cmd, cmd.frozen?]; end
+        `echo hello`
+        "#,
+    );
+    run_test(
+        r#"
+        def `(cmd); [cmd, cmd.frozen?]; end
+        %x{echo hello}
+        "#,
+    );
+    run_test(
+        r#"
+        def `(cmd); [cmd, cmd.frozen?]; end
+        x = "hi"
+        `echo #{x}`
+        "#,
+    );
+    // The result value flows through discard / return / argument positions.
+    run_test(
+        r#"
+        def `(cmd); cmd.upcase; end
+        [`ab`, `cd`]
+        "#,
+    );
+}

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -295,11 +295,34 @@ fn command_literal_frozen_argument() {
         `echo #{x}`
         "#,
     );
-    // The result value flows through discard / return / argument positions.
+    // The result value flows through argument positions.
     run_test(
         r#"
         def `(cmd); cmd.upcase; end
         [`ab`, `cd`]
+        "#,
+    );
+    // …and through assignment (Store), a discarded statement (NotUse), and a
+    // method's return value (Ret) — each `use_mode` of the command literal.
+    run_test(
+        r#"
+        def `(cmd); cmd.frozen?; end
+        x = `ab`
+        x
+        "#,
+    );
+    run_test(
+        r#"
+        def `(cmd); $g = cmd.frozen?; end
+        `ab`
+        $g
+        "#,
+    );
+    run_test(
+        r#"
+        def `(cmd); cmd.frozen?; end
+        def m; `ab`; end
+        m
         "#,
     );
 }


### PR DESCRIPTION
## Summary

`` `cmd` `` and `%x{cmd}` desugar to a call to `Kernel#\``. CRuby passes the command string to that method **frozen** — regardless of any `frozen_string_literal` pragma — but monoruby built it with the ordinary (mutable) string-literal path:

```ruby
def `(cmd); cmd.frozen?; end
`echo hello`   # => false  (should be true)
```

## Fix

In the `NodeKind::Command` bytecodegen path: when the command body is a non-interpolated string, emit the argument as a **frozen** string literal (`emit_frozen_string`) and build the `` ` `` call directly. An interpolated command (`` `cmd #{x}` ``) still builds a fresh, unfrozen string via the ordinary method-call path, matching CRuby.

## Testing

- New CRuby-verified unit test `command_literal_frozen_argument` in `tests/literal.rs` (redefines `Kernel#\`` so no process is spawned): frozen for `` `echo hello` `` and `%x{...}`, **not** frozen for the interpolated form, and the result value flowing through discard / return / argument positions.
- `language/execution_spec`: 2 failures → 0.
- `cargo test -p monoruby --lib`: 1806 passed.
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor