### PR TITLE
error: carry the method name on a dispatch NoMethodError so #name works

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -982,6 +982,31 @@ mod tests {
     }
 
     #[test]
+    fn nomethoderror_name() {
+        // `NoMethodError#name` (inherited from NameError) returns the missing
+        // method's name — for an ordinary missing method, an operator, a
+        // private/protected call, and a failed `super`.
+        run_tests(&[
+            r#"begin; nil.foobar; rescue NoMethodError => e; e.name; end"#,
+            r#"begin; nil + 3; rescue NoMethodError => e; e.name; end"#,
+            r#"
+            class C; private def sec; end; end
+            begin; C.new.sec; rescue NoMethodError => e; e.name; end
+            "#,
+            r#"
+            class A; end
+            class B < A; def m; super; end; end
+            begin; B.new.m; rescue NoMethodError => e; e.name; end
+            "#,
+            // `name` and `receiver` are both populated.
+            r#"
+            o = Object.new
+            begin; o.nope; rescue NoMethodError => e; [e.name, e.receiver.equal?(o)]; end
+            "#,
+        ]);
+    }
+
+    #[test]
     fn nomethoderror_class() {
         run_test(
             r#"

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1059,13 +1059,22 @@ impl Executor {
                     .unwrap();
                 v
             }
-            MonorubyErrKind::NotMethod(Some(receiver)) => {
+            MonorubyErrKind::NotMethod { name, receiver } => {
+                let name = *name;
                 let receiver = *receiver;
                 let v = Value::new_exception(err);
-                globals
-                    .store
-                    .set_ivar(v, IdentId::get_id("/receiver"), Value::from_u64(receiver))
-                    .unwrap();
+                if let Some(name) = name {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::_NAME, Value::symbol(name))
+                        .unwrap();
+                }
+                if let Some(receiver) = receiver {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::get_id("/receiver"), Value::from_u64(receiver))
+                        .unwrap();
+                }
                 v
             }
             MonorubyErrKind::Name(name, receiver) => {

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -90,7 +90,9 @@ impl MonorubyErr {
         match &self.kind {
             // Packed `Value::id()` of the receiver that triggered the
             // NoMethodError (set by `MonorubyErr::no_method_for_*`).
-            MonorubyErrKind::NotMethod(Some(id)) => {
+            MonorubyErrKind::NotMethod {
+                receiver: Some(id), ..
+            } => {
                 Value::from_u64(*id).mark(alloc);
             }
             // Receiver / key Values (packed) for KeyError.
@@ -198,7 +200,7 @@ impl MonorubyErr {
     pub fn class_name(&self, store: &Store) -> String {
         match &self.kind {
             MonorubyErrKind::Exception => "Exception",
-            MonorubyErrKind::NotMethod(_) => "NoMethodError",
+            MonorubyErrKind::NotMethod { .. } => "NoMethodError",
             MonorubyErrKind::Arguments => "ArgumentError",
             MonorubyErrKind::Syntax => "SyntaxError",
             MonorubyErrKind::Unimplemented => "RuntimeError",
@@ -253,7 +255,7 @@ impl MonorubyErr {
     pub fn class_id(&self) -> ClassId {
         match &self.kind {
             MonorubyErrKind::Exception => EXCEPTION_CLASS,
-            MonorubyErrKind::NotMethod(_) => NO_METHOD_ERROR_CLASS,
+            MonorubyErrKind::NotMethod { .. } => NO_METHOD_ERROR_CLASS,
             MonorubyErrKind::Arguments => ARGUMENTS_ERROR_CLASS,
             MonorubyErrKind::Syntax => SYNTAX_ERROR_CLASS,
             MonorubyErrKind::Unimplemented => UNIMPLEMENTED_ERROR_CLASS,
@@ -305,7 +307,7 @@ impl MonorubyErr {
     }
 
     pub fn is_no_method_error(&self) -> bool {
-        matches!(self.kind, MonorubyErrKind::NotMethod(_))
+        matches!(self.kind, MonorubyErrKind::NotMethod { .. })
     }
 }
 
@@ -410,7 +412,10 @@ impl MonorubyErr {
 
     pub(crate) fn method_not_found(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod(Some(obj.id())),
+            MonorubyErrKind::NotMethod {
+                name: Some(name),
+                receiver: Some(obj.id()),
+            },
             format!("undefined method `{name}' for {}", obj.to_s(store)),
         )
     }
@@ -422,7 +427,10 @@ impl MonorubyErr {
     ///
     pub(crate) fn super_method_not_found(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod(Some(obj.id())),
+            MonorubyErrKind::NotMethod {
+                name: Some(name),
+                receiver: Some(obj.id()),
+            },
             format!(
                 "super: no superclass method `{name}' for {}",
                 obj.to_s(store)
@@ -436,7 +444,10 @@ impl MonorubyErr {
         class: ClassId,
     ) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod(None),
+            MonorubyErrKind::NotMethod {
+                name: Some(name),
+                receiver: None,
+            },
             format!(
                 "undefined method `{name}' for {}",
                 store.get_class_name(class)
@@ -446,7 +457,10 @@ impl MonorubyErr {
 
     pub(crate) fn private_method_called(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod(Some(obj.id())),
+            MonorubyErrKind::NotMethod {
+                name: Some(name),
+                receiver: Some(obj.id()),
+            },
             format!(
                 "private method `{name}' called for {}:{}",
                 obj.to_s(store),
@@ -457,7 +471,10 @@ impl MonorubyErr {
 
     pub(crate) fn protected_method_called(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
-            MonorubyErrKind::NotMethod(Some(obj.id())),
+            MonorubyErrKind::NotMethod {
+                name: Some(name),
+                receiver: Some(obj.id()),
+            },
             format!(
                 "protected method `{name}' called for {}:{}",
                 obj.to_s(store),
@@ -960,7 +977,14 @@ impl MonorubyErr {
 #[derive(Debug, Clone, PartialEq)]
 pub enum MonorubyErrKind {
     Exception,
-    NotMethod(Option<u64>),
+    /// `NoMethodError`. `name` is the missing method name (surfaced as
+    /// `NoMethodError#name`); `receiver` is the packed `Value::id()` of the
+    /// receiver (surfaced as `#receiver`). Either may be absent for errors
+    /// built without that context.
+    NotMethod {
+        name: Option<IdentId>,
+        receiver: Option<u64>,
+    },
     Arguments,
     Syntax,
     Unimplemented,
@@ -1011,7 +1035,10 @@ impl MonorubyErrKind {
     pub fn from_class_id(class_id: ClassId) -> Self {
         match class_id {
             EXCEPTION_CLASS => MonorubyErrKind::Exception,
-            NO_METHOD_ERROR_CLASS => MonorubyErrKind::NotMethod(None),
+            NO_METHOD_ERROR_CLASS => MonorubyErrKind::NotMethod {
+                name: None,
+                receiver: None,
+            },
             ARGUMENTS_ERROR_CLASS => MonorubyErrKind::Arguments,
             SYNTAX_ERROR_CLASS => MonorubyErrKind::Syntax,
             UNIMPLEMENTED_ERROR_CLASS => MonorubyErrKind::Unimplemented,


### PR DESCRIPTION
## Summary

`NoMethodError#name` (inherited from `NameError`) returned `nil` for an error raised by **method dispatch** — `nil.foo`, `nil + 3`, a private/protected call, or a failed `super` — because the `NotMethod` error kind stored only the receiver, not the missing method name. Errors built via `NameError.new(..)` set the `/name` ivar, but the dispatch path never did:

```ruby
begin; nil.foo; rescue NoMethodError => e; e.name; end   # => nil  (want :foo)
```

## Fix

Give `MonorubyErrKind::NotMethod` a `name: Option<IdentId>` field alongside its existing `receiver`, thread the (already-available) method name through every constructor (`method_not_found`, `super_method_not_found`, `private_method_called`, `protected_method_called`, `method_not_found_for_class`), and set the `/name` ivar in `take_ex_obj` next to `/receiver` so `NoMethodError#name` returns it.

## Testing

- New CRuby-verified unit test `nomethoderror_name` in `builtins/exception.rs`: `#name` for an ordinary missing method, an operator (`+`), a private call, a failed `super`, and that `#name` + `#receiver` are both populated.
- `language/safe_navigator_spec`: 1 failure → 0 (`obj&.foo += 3`, where `obj.foo` is `nil`, must raise a `NoMethodError` whose `name` is `:+`).
- `cargo test -p monoruby --lib`: 1806 passed (no regression).
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_