### PR TITLE
args: **nil binds no local and rejects keywords before positional binding

### DIFF
--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -253,6 +253,17 @@ fn set_callee_frame_arguments(
     let dst = callee_lfp.register_ptr(SlotId(1));
     let pos_args = globals[callid].pos_num;
 
+    // `**nil` forbids keywords: reject any passed keyword up front, before
+    // positional binding, so the error is "no keywords accepted" rather than
+    // a positional arity error — `def m(a, **nil); end; m(a: 1)` must raise
+    // the former, not "wrong number of arguments" (the keyword is not
+    // silently reinterpreted as the positional `a`).
+    if globals[callee_fid].forbid_keyword()
+        && any_keyword_passed(globals, callid, caller_lfp)?
+    {
+        return Err(MonorubyErr::argumenterr("no keywords accepted"));
+    }
+
     let ex = if globals[callee_fid].no_keyword() && globals[callid].kw_may_exists() {
         // handle excessive keyword arguments
         let mut h = RubyMap::default();
@@ -1050,6 +1061,50 @@ mod tests {
               rescue_msg { m(**full) },          # method dispatch, hash splat
               m(**empty),                        # method dispatch, empty splat
             ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn no_keywords_parameter_with_positional() {
+        // With a required positional param, `**nil` still rejects keywords
+        // with "no keywords accepted" — the keyword must NOT be reinterpreted
+        // as the positional argument (which would raise a bogus "wrong
+        // number of arguments"). A hash passed positionally still binds.
+        run_test(
+            r#"
+            def rescue_msg
+              yield; :no_error
+            rescue ArgumentError => e
+              e.message
+            end
+            def m(a, **nil); a; end
+            [
+              m({a: 1}),                       # positional hash binds to `a`
+              m({"a" => 1}),                   # string-key positional hash
+              rescue_msg { m(a: 1) },          # literal keyword -> rejected
+              rescue_msg { m(**{a: 1}) },      # hash splat -> rejected
+              rescue_msg { m("a" => 1) },      # non-symbol keyword -> rejected
+              m(7),                            # plain positional
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn no_keywords_parameter_local_variables_and_parameters() {
+        // `**nil` binds no local (it must not appear in `local_variables`)
+        // but `#parameters` still reports it as `[:nokey]`.
+        run_test(
+            r#"
+            def m(a, **nil); local_variables; end
+            m(1)
+            "#,
+        );
+        run_test(
+            r#"
+            def m(a, **nil); end
+            method(:m).parameters
             "#,
         );
     }

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -681,6 +681,13 @@ impl Store {
 /// as a local variable). Filters out the compiler's reserved slots (`*`, `**`,
 /// `&`'s empty name, `(for)`, …).
 fn is_local_variable_name(name: &str) -> bool {
+    // `**nil` (a keyword-forbidding definition) is modeled internally as a
+    // kwrest slot literally named `nil` so `#parameters` can report it as
+    // `[:nokey]`. `nil` is a reserved word and can never be a real local
+    // variable, so it must not surface in `local_variables`.
+    if name == "nil" {
+        return false;
+    }
     // Numbered block parameters `_1`..`_9`.
     if let Some(rest) = name.strip_prefix('_')
         && rest.len() == 1


### PR DESCRIPTION
## Summary

Two fixes for the keyword-forbidding definition `def m(a, **nil)`:

### 1. `**nil` leaked into `local_variables`

`**nil` is modeled internally as a kwrest slot literally named `nil` (so `#parameters` can report it as `[:nokey]`), but `nil` is a reserved word and can never be a real local variable. It surfaced in `local_variables`:

```ruby
def m(a, **nil); local_variables; end
m(1)   # => [:a, :nil]   (want [:a])
```

Exclude `nil` in `is_local_variable_name`; `#parameters` still reports `[:nokey]`.

### 2. Keyword passed to `**nil` raised the wrong error

```ruby
def m(a, **nil); a; end
m(a: 1)   # raised "wrong number of arguments (given 0, expected 1)"
          # (want "no keywords accepted")
```

Because `**nil` carries a (never-written) kwrest slot, the keyword was not folded into a trailing positional hash, leaving zero positional args to bind the required `a`, and the positional arity check fired before the keyword check. Reject forbidden keywords up front in `set_callee_frame_arguments`, before positional binding: `m(a: 1)` / `m(**{a: 1})` / `m("a" => 1)` now raise `ArgumentError: no keywords accepted`, while a hash passed positionally (`m({a: 1})`) still binds to `a`.

## Testing

- New CRuby-verified unit tests in `codegen/runtime/args.rs`: `no_keywords_parameter_with_positional` (positional hash binds; keyword/splat/non-symbol-key rejected with the right message) and `no_keywords_parameter_local_variables_and_parameters` (`local_variables` omits `nil`; `#parameters` reports `[:nokey]`).
- `language/method_spec`: the `def m(a, **nil)` example now passes (5 failures / **1 error → 5 failures / 0 errors**; the remaining failures are the unrelated unused-block-argument warning feature).
- `cargo test -p monoruby --lib`: 1808 passed (no regression).
- Verified on x86_64 (native) and aarch64 (cross build under qemu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_