### PR TITLE
parser: bind named captures to locals for `/regexp/ =~ str`

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1530,6 +1530,85 @@ mod tests {
     }
 
     #[test]
+    fn match_named_capture_locals() {
+        // `/literal/ =~ str` with named captures binds each capture to a
+        // local variable named after it (the value, or `nil` when that
+        // group did not participate in the match). The snippets that
+        // inspect `local_variables` are wrapped in a method so the scope
+        // is isolated from the test harness's own top-level locals.
+        run_test(
+            r#"
+            def m
+              /(?<matched>foo)(?<unmatched>bar)?/ =~ "foofoo"
+              [local_variables, matched, unmatched]
+            end
+            m
+        "#,
+        );
+        // No match: every named-capture local becomes `nil`, but is
+        // still declared.
+        run_test(
+            r#"
+            def m
+              /(?<a>foo)/ =~ "nope"
+              [local_variables, a]
+            end
+            m
+        "#,
+        );
+        // The whole expression evaluates to the `=~` result (match
+        // position or `nil`), independent of any `nil` capture value.
+        run_test(r#"/(?<z>foo)/ =~ "foofoo""#);
+        run_test(r#"/(?<z>foo)(?<opt>bar)?/ =~ "foofoo""#);
+        run_test(r#"/(?<z>foo)/ =~ "nope""#);
+        // A capture matching an existing local in an enclosing scope
+        // assigns to that outer local rather than a fresh block-local.
+        run_test(
+            r#"
+            def m
+              a = 42
+              1.times { /(?<a>foo)/ =~ "foofoo" }
+              a
+            end
+            m
+        "#,
+        );
+        // Regexp on the *right*, a regexp *variable*, and an explicit
+        // method call all bind no locals.
+        run_test(
+            r#"
+            def m
+              "foofoo" =~ /(?<matched>foo)/
+              local_variables
+            end
+            m
+        "#,
+        );
+        run_test(
+            r#"
+            def m
+              re = /(?<matched>foo)/
+              re =~ "foofoo"
+              local_variables
+            end
+            m
+        "#,
+        );
+        run_test(
+            r#"
+            def m
+              /(?<matched>foo)/.=~("foofoo")
+              local_variables
+            end
+            m
+        "#,
+        );
+        // Used as a condition: a match is truthy, a no-match falsy.
+        run_test(r#"if /(?<w>foo)/ =~ "foofoo" then "hit" else "miss" end"#);
+        run_test(r#"if /(?<w>foo)/ =~ "nope" then "hit" else "miss" end"#);
+    }
+
+    #[test]
     fn regexp_new_invalid_flag_string_raises() {
         // `e` is *not* accepted in the string-form flag arg.
         run_test_error(r#"Regexp.new("Hi", "e")"#);

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -549,19 +549,62 @@ impl<'pr> Lowerer<'pr> {
                 // `/(?<name>...)/ =~ value` — Prism wraps the `=~`
                 // CallNode with a list of `LocalVariableTargetNode`
                 // targets that should receive each named capture.
-                // monoruby (matching the ruruby backend) doesn't
-                // implement the named-capture binding, so lower to
-                // just the inner call. The targets are already on
-                // the surrounding scope's `locals` list (Prism
-                // declares them at parse time), so reading them
-                // afterwards yields `nil` rather than parsing as a
-                // method call. That's the no-match path; the match
-                // path leaves them at `nil` instead of the captured
-                // string, which is wrong but lets bundler/rubygems
-                // load on x86_64-linux where the relevant `if`
-                // guards never fire.
+                // Prism only produces a `MatchWriteNode` for the exact
+                // syntactic form of a *regexp literal* with named
+                // captures on the *left* of `=~`; every other shape
+                // (`str =~ /re/`, a regexp *variable*, an explicit
+                // `.=~` / `.send` call) is a plain `CallNode` and binds
+                // nothing. Prism has also already declared each target
+                // on its owning scope's `locals` list (at the right
+                // depth), so `local_variables` reports them and outer
+                // scopes are reused rather than shadowed.
+                //
+                // Desugar to:
+                //   %match = (/re/ =~ value)                # run the match, set `$~`
+                //   name1  = Regexp.last_match(:name1)       # capture or nil
+                //   name2  = Regexp.last_match(:name2)
+                //   %match                                   # value == `=~` result
+                //
+                // The trailing `%match` read preserves the expression's
+                // value (the match position, or `nil`) so uses like
+                // `if /re/ =~ s` keep the correct truthiness even when a
+                // capture is `nil`. `%match` starts with `%`, which is
+                // not a spellable local-variable name, so it never
+                // surfaces in `local_variables`. `Regexp.last_match`
+                // returns `nil` when the match failed, giving every
+                // capture the `nil` no-match value for free.
                 let n = node.as_match_write_node().unwrap();
-                self.lower_call(&n.call(), location_to_loc(&n.call().location()))?
+                let call = n.call();
+                let call_node = self.lower_call(&call, location_to_loc(&call.location()))?;
+                let temp_name = "%match".to_string();
+                let mut stmts = vec![Node::new_mul_assign(
+                    vec![Node {
+                        kind: NodeKind::LocalVar(0, temp_name.clone()),
+                        loc,
+                    }],
+                    vec![call_node],
+                )];
+                for target in n.targets().iter() {
+                    let tgt = self.lower_assign_target(&target)?;
+                    let cap_name = match &tgt.kind {
+                        NodeKind::LocalVar(_, name) => name.clone(),
+                        _ => unreachable!("MatchWriteNode target is not a local variable"),
+                    };
+                    let regexp = Node::new_const("Regexp".to_string(), false, None, vec![], loc);
+                    let arglist =
+                        crate::ast::ArgList::from_args(vec![Node::new_symbol(cap_name, loc)]);
+                    let last_match =
+                        Node::new_mcall(regexp, "last_match".to_string(), arglist, false, loc);
+                    stmts.push(Node::new_mul_assign(vec![tgt], vec![last_match]));
+                }
+                stmts.push(Node {
+                    kind: NodeKind::LocalVar(0, temp_name),
+                    loc,
+                });
+                Node {
+                    kind: NodeKind::CompStmt(stmts),
+                    loc,
+                }
             }
             prism::Node::BeginNode { .. } => self.lower_begin(&node.as_begin_node().unwrap())?,
             // `BEGIN { ... }` / `END { ... }`. Full Ruby semantics hoist


### PR DESCRIPTION
## Summary

When a regexp **literal** with named captures appears on the left of `=~`, Ruby binds each capture to a local variable named after it (the captured string, or `nil` when that group did not participate in the match):

```ruby
/(?<matched>foo)(?<unmatched>bar)?/ =~ "foofoo"
matched    #=> "foo"
unmatched  #=> nil
local_variables #=> [:matched, :unmatched]
```

Prism models this exact syntactic form as a `MatchWriteNode` wrapping the `=~` call plus one `LocalVariableTargetNode` per capture. Every other shape — `str =~ /re/`, a regexp **variable**, an explicit `.=~` / `.send` call, or a literal without named captures — is a plain `CallNode` and binds nothing.

Previously the `MatchWriteNode` lowering dropped the targets and left the locals at `nil`. This PR desugars it into:

```
%match = (/re/ =~ str)              # run the match, set `$~`
name   = Regexp.last_match(:name)   # capture value, or nil
...
%match                              # value == the `=~` result
```

The trailing `%match` read preserves the expression's value (the match position, or `nil`) so `if /re/ =~ s` keeps the correct truthiness even when a capture is `nil`. `%match` is not a spellable local-variable name, so it never surfaces in `local_variables`, and `Regexp.last_match` returns `nil` on a failed match, giving every capture its no-match value for free. Prism has already declared each target at the correct scope depth, so an existing outer local is reused rather than shadowed.

## Impact

Fixes the two `language/match_spec.rb` named-capture examples:
- "sets local variables by the captured pairs"
- "sets existing local variables if declared in a higher scope"

`language/match_spec.rb` now passes 8/8 examples (was 6/8).

## Testing

- New `match_named_capture_locals` unit test covering capture values, the no-match `nil` case, expression value / truthiness, outer-scope reuse, and every non-binding syntactic form (all CRuby-verified).
- Full library suite green (`cargo test -p monoruby --lib`, 1811 passing).
- Verified identical output on both x86-64 and aarch64 (qemu). The change is entirely in the arch-neutral prism→AST bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_