### PR TITLE
bytecodegen: `self[i]` reaches a private `#[]` / `#[]=`

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -704,6 +704,46 @@ mod tests {
     }
 
     #[test]
+    fn self_index_private_visibility() {
+        // An explicit-`self` receiver ignores method visibility, so a
+        // private `#[]` / `#[]=` is reachable through `self[k]`,
+        // `self[k] = v`, and `self[k] op= v` — matching CRuby.
+        run_test(
+            r#"
+            class A
+              def initialize(h) @a = h end
+              def get(k); self[k] end
+              def set(k, v); self[k] = v end
+              def opset(k, v); self[k] ||= v end
+              def andset(k, v); self[k] &&= v end
+              def plusset(k); self[k] += 100 end
+              private
+              def [](k) @a[k] end
+              def []=(k, v) @a[k] = v; 42 end
+            end
+            a = A.new(k: false, n: 1)
+            [a.get(:n), a.set(:x, 9), a.opset(:k, 10), a.andset(:n, 7), a.plusset(:n)]
+            "#,
+        );
+        // Multi-index and splat-index forms on `self` also bypass privacy.
+        run_test(
+            r#"
+            class B
+              def initialize() @h = {} end
+              def set2(a, b, v); self[a, b] = v end
+              def get2(a, b); self[a, b] end
+              def setsplat(ks, v); self[*ks] = v end
+              private
+              def [](a, b = nil) @h[[a, b]] end
+              def []=(*args) @h[args[0..-2]] = args[-1]; :ok end
+            end
+            b = B.new
+            [b.set2(1, 2, :v), b.get2(1, 2), b.setsplat([3, 4], :w)]
+            "#,
+        );
+    }
+
+    #[test]
     fn method_missing_splat() {
         // splat arguments should be expanded and forwarded
         run_test(

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1435,6 +1435,21 @@ impl<'a> BytecodeGen<'a> {
     /// +-----------------+
     ///
     /// ```
+    /// Evaluate the receiver of an index target `base[..]`.
+    ///
+    /// A literal `self` base is returned as `BcReg::Self_` (occupying no
+    /// temp) so the emitted `#[]` / `#[]=` call site is recognised as a
+    /// self-call and may reach a *private* `#[]` / `#[]=` — matching
+    /// CRuby's rule that an explicit-`self` receiver ignores method
+    /// visibility. Any other base is evaluated onto a fresh temp.
+    fn eval_index_base(&mut self, base: &Node) -> Result<BcReg> {
+        if base.kind == NodeKind::SelfValue {
+            Ok(BcReg::Self_)
+        } else {
+            Ok(self.push_expr(base.clone())?.into())
+        }
+    }
+
     fn eval_lvalue(&mut self, lhs: &Node) -> Result<(LvalueKind, bool)> {
         let lhs = match &lhs.kind {
             NodeKind::Const {
@@ -1495,7 +1510,7 @@ impl<'a> BytecodeGen<'a> {
                     // `a[*idx] = v` / `a[i, *idx, j] = v`: the index list
                     // expands at runtime, so lower it like a `[]=` call whose
                     // trailing argument is the assigned value.
-                    let base = self.push_expr(base.clone())?.into();
+                    let base = self.eval_index_base(base)?;
                     let index1 = self.sp();
                     let (_, num, splat_pos) = self.ordinary_args(index.clone())?;
                     self.push(); // register for src.
@@ -1506,12 +1521,25 @@ impl<'a> BytecodeGen<'a> {
                         splat_pos,
                     }
                 } else if index.len() == 1 {
-                    let base = self.push_expr(base.clone())?.into();
+                    let base = self.eval_index_base(base)?;
                     let index = self.push_expr(index[0].clone())?;
                     self.push(); // register for src.
-                    LvalueKind::Index { base, index }
+                    if base == BcReg::Self_ {
+                        // `self[i] = v` must reach a private `#[]=` via the
+                        // explicit-`self` receiver. Route it through the
+                        // general `#[]=` call site (`Index2`) rather than the
+                        // `StoreIndex` fast-path opcode, which always enforces
+                        // visibility.
+                        LvalueKind::Index2 {
+                            base,
+                            index1: index,
+                            num: 1,
+                        }
+                    } else {
+                        LvalueKind::Index { base, index }
+                    }
                 } else {
-                    let base = self.push_expr(base.clone())?.into();
+                    let base = self.eval_index_base(base)?;
                     let index1 = self.push_expr(index[0].clone())?;
                     let num = index.len();
                     for i in 1..index.len() {

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -151,7 +151,11 @@ impl<'a> BytecodeGen<'a> {
                 box base,
                 mut index,
             } => {
-                if index.len() == 1 && !index[0].is_splat() {
+                // A `self[..]` read must go through the general `#[]` call
+                // site (not the `Index` fast-path opcode, which always
+                // enforces visibility) so a private `#[]` is reachable via
+                // the explicit-`self` receiver, matching CRuby.
+                if index.len() == 1 && !index[0].is_splat() && base.kind != NodeKind::SelfValue {
                     self.gen_index(Some(dst), base, index.remove(0), loc)?;
                 } else {
                     let arglist = ArgList::from_args(index);
@@ -457,7 +461,11 @@ impl<'a> BytecodeGen<'a> {
                 box base,
                 mut index,
             } => {
-                if index.len() == 1 && !index[0].is_splat() {
+                // A `self[..]` read must go through the general `#[]` call
+                // site (not the `Index` fast-path opcode, which always
+                // enforces visibility) so a private `#[]` is reachable via
+                // the explicit-`self` receiver, matching CRuby.
+                if index.len() == 1 && !index[0].is_splat() && base.kind != NodeKind::SelfValue {
                     self.gen_index(None, base, index.remove(0), loc)?;
                 } else {
                     let arglist = ArgList::from_args(index);


### PR DESCRIPTION
## Summary

An explicit-`self` receiver ignores method visibility, so `self[k]`, `self[k] = v`, and `self[k] op= v` must be able to call a **private** `#[]` / `#[]=` — the same rule that already lets `self.foo` reach a private `#foo`:

```ruby
class A
  def public_method(k, v); self[k] ||= v end
  private
  def [](k) @a[k] end
  def []=(k, v) @a[k] = v; 42 end
end
```

Previously monoruby raised `NoMethodError: private method '[]' called for self`.

## Cause

The `Index` / `StoreIndex` fast-path opcodes (via `runtime::get_index` / `set_index` → `invoke_method_simple`) always dispatch with `is_func_call = false`, so they enforce visibility unconditionally. Unlike a regular call site, they carry no receiver-is-self information.

Visibility bypass is a **syntactic** property of the literal `self` receiver, *not* a runtime value comparison — `x = self; x[k]` must still respect privacy (verified against CRuby) — so it has to be decided at bytecode-gen time, not by comparing the receiver value to `self` at runtime.

## Fix

When the index base is literally `self`:
- **reads** route through the general `#[]` call site (`gen_method_call`) instead of the `Index` opcode;
- the **single-index store** lowers to the call-site-based `Index2` `#[]=` path instead of the `StoreIndex` opcode;
- **multi-index / splat stores** already used call sites, so they only needed the base register kept as `Self_` (via the new `eval_index_base` helper).

All of these carry `recv = Self_`, which `CallSiteInfo::is_func_call` already treats as a self-call, so a private `#[]` / `#[]=` is reachable while any non-`self` receiver keeps enforcing visibility. The Array / Hash / String fast paths are untouched (their base is not `self`), including the JIT hot path.

## Impact

Fixes the two `language/optional_assignments_spec.rb` "ignores method visibility when receiver is self" examples (`||=` and `&&=`); the file now passes **74/74** (was 72/74 with 2 errors).

## Testing

- New `self_index_private_visibility` unit test: getter / setter / `||=` / `&&=` / `+=`, plus multi-index and splat-index forms on `self` (all CRuby-verified).
- Full library suite green (`cargo test -p monoruby --lib`, 1812 passing).
- Verified identical behavior on x86-64 and aarch64 (qemu): `self[k]` reaches private `#[]`/`#[]=`, `x = self; x[k]` still raises, and Array/Hash/String indexing (incl. a JIT-hot loop) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_