### PR TITLE
jit: enforce `#[]` / `#[]=` visibility in the index fast path

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -744,6 +744,46 @@ mod tests {
     }
 
     #[test]
+    fn non_self_index_private_visibility() {
+        // A private `#[]` / `#[]=` reached through a *non-`self`* receiver
+        // (a plain object, or a local variable that merely holds `self`)
+        // must raise `NoMethodError` — the JIT index fast path must not
+        // bypass the visibility check the interpreter enforces. `run_test`
+        // warms the JIT (25 iterations under a JITted loop), so this also
+        // covers the compiled path.
+        run_test(
+            r#"
+            class D
+              def initialize() @a = {k: 1} end
+              private
+              def [](k) @a[k] end
+              def []=(k, v) @a[k] = v end
+            end
+            obj = D.new
+            g = (obj[:k] rescue :get_raised)
+            s = begin; obj[:k] = 9; :set_ok; rescue NoMethodError; :set_raised; end
+            [g, s]
+            "#,
+        );
+        // A local variable holding `self` is not the literal `self`
+        // keyword, so it must respect visibility too.
+        run_test(
+            r#"
+            class E
+              def initialize() @a = {k: 1} end
+              def viaval
+                x = self
+                x[:k] rescue :raised
+              end
+              private
+              def [](k) @a[k] end
+            end
+            E.new.viaval
+            "#,
+        );
+    }
+
+    #[test]
     fn method_missing_splat() {
         // splat arguments should be expanded and forwarded
         run_test(

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -1086,6 +1086,31 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Whether *name* resolves to a **public** method on *class_id* at compile
+    /// time (or is not defined at all, i.e. no visibility constraint applies
+    /// here — that case is handled elsewhere).
+    ///
+    /// The `Index` / `IndexAssign` fast paths call the resolved `#[]` / `#[]=`
+    /// directly, without the `is_func_call = false` visibility gate that the
+    /// VM's `get_index` / `set_index` apply. A non-public `#[]` / `#[]=` must
+    /// therefore not be compiled inline (it would be reachable from JIT while
+    /// the interpreter correctly raises `NoMethodError`); such sites bail to
+    /// the interpreter instead.
+    ///
+    fn jit_index_method_is_public(&self, class_id: ClassId, name: IdentId) -> bool {
+        let class_version = self.class_version();
+        match self
+            .store
+            .check_method_for_class_with_version(class_id, name, class_version)
+        {
+            Some(entry) => entry.visibility() == Visibility::Public,
+            // Not defined here: let the ordinary `MethodNotFound` path handle
+            // it rather than forcing a deopt.
+            None => true,
+        }
+    }
+
+    ///
     /// Check whether `super` of class *class_id* exists in compile time.
     ///
     fn jit_check_super(&mut self, recv_class: ClassId) -> Option<FuncId> {

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -13,6 +13,14 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(lhs_class) = base_class {
+            // The `Index` fast-path calls `#[]` directly, bypassing the
+            // `is_func_call = false` visibility gate the VM's `get_index`
+            // applies. Bail to the interpreter for a non-public `#[]` so its
+            // `NoMethodError` still fires (a literal `self[i]` reaches a
+            // private `#[]` through the ordinary call site, not here).
+            if !self.jit_index_method_is_public(lhs_class, IdentId::_INDEX) {
+                return Ok(CompileResult::Deopt);
+            }
             return self.call_binary_method(
                 state,
                 ir,
@@ -40,6 +48,14 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(recv_class) = base_class {
+            // The `IndexAssign` fast-path calls `#[]=` directly, bypassing the
+            // `is_func_call = false` visibility gate the VM's `set_index`
+            // applies. Bail to the interpreter for a non-public `#[]=` so its
+            // `NoMethodError` still fires (a literal `self[i] = v` reaches a
+            // private `#[]=` through the ordinary call site, not here).
+            if !self.jit_index_method_is_public(recv_class, IdentId::_INDEX_ASSIGN) {
+                return Ok(CompileResult::Deopt);
+            }
             return self.call_ternary_method(
                 state,
                 ir,


### PR DESCRIPTION
## Summary

The `Index` / `IndexAssign` JIT fast paths resolve `#[]` / `#[]=` by receiver class (`jit_check_method`) and emit a direct call, skipping the `is_func_call = false` visibility gate that the interpreter's `get_index` / `set_index` apply. A **private** (or protected) `#[]` / `#[]=` was therefore reachable once the site was JIT-compiled, while the interpreter correctly raised `NoMethodError` — a JIT/VM divergence:

```ruby
class D
  def initialize; @a = {k: 1}; end
  private
  def [](k) @a[k] end
end
obj = D.new
# in a hot loop:
obj[:k]   # interpreter: NoMethodError;  JIT-compiled: silently returns 1
```

This affects any private/protected `#[]` / `#[]=`, whether the receiver is a plain object or a local that merely holds `self` — it is **not** about the literal-`self` receiver.

## Cause

Ordinary method calls avoid this because they depend on a VM-populated inline cache that a visibility violation (which always raises) never fills, so the JIT deopts and the interpreter raises. The index fast path resolves straight from the receiver class and never consults that cache, so it slipped past the check.

## Fix

Bail to the interpreter (`CompileResult::Deopt`) whenever the resolved `#[]` / `#[]=` is not public, so its `NoMethodError` still fires.

- Public `#[]` / `#[]=` — Array / Hash / String and user-defined public ones — are unaffected (no extra deopt on the hot path).
- A literal `self[i]` that legitimately reaches a private `#[]` already lowers to the ordinary call site (`recv = Self_`), not this fast path, so it keeps working.

## Testing

- New `non_self_index_private_visibility` unit test: a private `#[]` / `#[]=` reached through a plain object and through a local holding `self` both raise `NoMethodError` after JIT warmup (`run_test` runs 25 iterations under a JITted loop, so the compiled path is exercised). CRuby-verified.
- Full library suite green (`cargo test -p monoruby --lib`, 1813 passing).
- Verified on x86-64 and aarch64 (qemu): the divergence is gone (all reproductions consistently raise), while public user-defined and builtin Array / Hash indexing in a JIT-hot loop, and the literal-`self[k]` private case, all still work. The change is in the arch-neutral JIT front-end, so both backends benefit.

## Note

This is a follow-up to #844 (which made a literal `self[i]` reach a private `#[]` in bytecode-gen). It fixes the independent JIT-side hole where the index fast path never enforced `#[]` / `#[]=` visibility at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_