### PR TITLE
bytecodegen: `defined?` in a void context evaluates nothing

### DIFF
--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -431,6 +431,32 @@ mod tests {
     }
 
     #[test]
+    fn defined_void_context_does_not_evaluate() {
+        // `defined?` in a void (statement) context must not evaluate its
+        // operand — the receiver's side effects never fire — while a value
+        // context still probes it.
+        run_test(
+            r#"
+            $log = []
+            def se; $log << :ran; 1; end
+            defined?(se / 2)          # void: must not call `se`
+            a = $log.dup
+            x = defined?(se / 2)      # value: does call `se`
+            [a, x, $log]
+            "#,
+        );
+        // Void `defined?` on an undefined name is likewise a no-op.
+        run_test(
+            r#"
+            $c = 0
+            def bump; $c += 1; self; end
+            defined?(bump.no_such_method)
+            $c
+            "#,
+        );
+    }
+
+    #[test]
     fn defined_frozen_and_assignment() {
         // `defined?` returns a frozen String.
         run_tests(&[

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1023,6 +1023,13 @@ impl<'a> BytecodeGen<'a> {
                 self.push_nil();
             }
             NodeKind::Defined(box node) => {
+                // `defined?` in a void (statement) context evaluates nothing:
+                // CRuby elides the whole expression, so the operand's
+                // receiver side effects never fire. In a value context the
+                // operand is still probed by `gen_defined`.
+                if use_mode == UseMode2::NotUse {
+                    return Ok(());
+                }
                 self.gen_defined(node)?;
             }
             NodeKind::Splat(..) => {


### PR DESCRIPTION
## Summary

`defined?(expr)` used as a statement (void context) must not evaluate its operand — CRuby elides the whole expression, so the operand's receiver side effects never fire:

```ruby
defined?(obj.meth / 2)   # as a statement: `obj` is never evaluated
```

monoruby lowered the `Defined` node unconditionally and only discarded the result afterwards, so `gen_defined` still probed (and thus evaluated) the operand's receiver — a side effect that CRuby never produces.

## Fix

Skip code generation entirely for a `Defined` node when the use mode is `NotUse` (void context). A value context still probes the operand via `gen_defined`, so `x = defined?(obj.meth)` is unchanged.

## Impact

Fixes `language/defined_spec.rb` "in a void context does not execute the receiver". The sibling "warns about the void context" example needs a separate parse-time verbose warning and is intentionally left as-is.

## Testing

- New `defined_void_context_does_not_evaluate` unit test: a void `defined?` does not run the operand's receiver, while a value `defined?` does (CRuby-verified).
- Full library suite green (`cargo test -p monoruby --lib`, 1814 passing).
- Verified identical output on x86-64 and aarch64 (qemu). The change is in the arch-neutral bytecode generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_