### PR TITLE
exception: a bare `rescue` catches only StandardError

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -37,19 +37,26 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(system_exit_id, "status", system_exit_status, 0);
     globals.define_builtin_func(system_exit_id, "success?", system_exit_success_p, 0);
 
-    globals.define_class("NoMemoryError", standarderr, OBJECT_CLASS);
-    globals.define_class("SecurityError", standarderr, OBJECT_CLASS);
+    // These all inherit directly from `Exception`, not `StandardError`, so a
+    // bare `rescue` (== `rescue StandardError`) does not catch them — matching
+    // CRuby's hierarchy.
+    globals.define_class("NoMemoryError", exception_class, OBJECT_CLASS);
+    globals.define_class("SecurityError", exception_class, OBJECT_CLASS);
+    // `SystemStackError` is raised on stack overflow.
+    globals.define_class("SystemStackError", exception_class, OBJECT_CLASS);
     let signal_exception = globals.define_builtin_exception_class(
         "SignalException",
         SIGNAL_EXCEPTION_CLASS,
-        standarderr,
+        exception_class,
     );
     // `Interrupt` is the Ruby class raised on SIGINT (Ctrl-C). It is a
     // subclass of SignalException — `rescue SignalException` catches it
     // but a bare `rescue` (StandardError) does not.
     globals.define_builtin_exception_class("Interrupt", INTERRUPT_CLASS, signal_exception);
 
-    let scripterr = globals.define_class("ScriptError", standarderr, OBJECT_CLASS);
+    // `ScriptError` (and its `LoadError` / `SyntaxError` /
+    // `NotImplementedError` subclasses) inherits directly from `Exception`.
+    let scripterr = globals.define_class("ScriptError", exception_class, OBJECT_CLASS);
     let loaderr = globals.define_builtin_exception_class("LoadError", LOAD_ERROR_CLASS, scripterr);
     globals.define_builtin_func(loaderr.id(), "path", loaderror_path, 0);
     globals.define_builtin_exception_class("SyntaxError", SYNTAX_ERROR_CLASS, scripterr);
@@ -1211,6 +1218,76 @@ mod tests {
               (begin; raise Interrupt; rescue Exception => e; e.class.name; end),
             ]
             "##,
+        );
+    }
+
+    #[test]
+    fn non_standard_error_hierarchy() {
+        // These classes inherit directly from `Exception`, not
+        // `StandardError`, so a bare `rescue` must not catch them.
+        run_test(
+            r#"
+            [
+              NoMemoryError, ScriptError, SecurityError, SignalException,
+              SystemStackError, LoadError, SyntaxError, NotImplementedError
+            ].map { |k| [k.name, k < StandardError, k < Exception] }
+            "#,
+        );
+    }
+
+    #[test]
+    fn bare_rescue_only_catches_standard_error() {
+        // A bare `rescue` (== `rescue StandardError`) catches StandardError
+        // and its subclasses, but a non-StandardError propagates.
+        run_test(
+            r#"
+            def caught?(k)
+              begin
+                begin
+                  raise k
+                rescue
+                  :caught
+                end
+              rescue Exception
+                :propagated
+              end
+            end
+            [
+              caught?(StandardError), caught?(RuntimeError), caught?(ArgumentError),
+              caught?(Exception), caught?(NoMemoryError), caught?(ScriptError),
+              caught?(SecurityError), caught?(SystemStackError), caught?(NotImplementedError)
+            ]
+            "#,
+        );
+        // Inline (modifier) `rescue` also only rescues StandardError.
+        run_test(r#"raise(StandardError) rescue 1"#);
+        run_test(
+            r#"
+            begin
+              raise(Exception) rescue 1
+              :not_reached
+            rescue Exception
+              :reraised
+            end
+            "#,
+        );
+        // A bare `rescue` with a non-local capture target (regression: the
+        // capture target's scratch temps must not corrupt the match stack).
+        run_test(
+            r#"
+            class C
+              def initialize; @h = {}; end
+              def []=(k, v); @h[k] = v; end
+              def [](k); @h[k]; end
+              def capture(msg)
+                raise msg
+              rescue => self[:error]
+                :caught
+              end
+            end
+            c = C.new
+            [c.capture("boom"), c[:error].message]
+            "#,
         );
     }
 }

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -439,6 +439,11 @@ impl<'a> BytecodeGen<'a> {
             }
             self.temp = base;
             let err_reg = self.push().into();
+            // The balanced stack level while matching a rescue clause: only
+            // `err_reg` is live. A clause's `=> target` capture may leave
+            // scratch temps above this (e.g. `rescue => self[:error]` reserves
+            // base/index/src), so the match code below resets to it.
+            let match_temp = self.temp;
             let rescue_pos = self.new_label();
             self.apply_label(rescue_pos);
             self.retry_labels.push(body_start);
@@ -484,6 +489,9 @@ impl<'a> BytecodeGen<'a> {
                         self.emit_assign(err_reg, lhs, None, loc);
                     }
                 };
+                // Reclaim any scratch temps the capture target reserved so the
+                // exception-match branches below all record the same stack sp.
+                self.temp = match_temp;
                 let cont_pos = self.new_label();
                 let next_pos = self.new_label();
                 if !exception_list.is_empty() {
@@ -506,6 +514,21 @@ impl<'a> BytecodeGen<'a> {
                             self.gen_teq_condbr(ex, err_reg, cont_pos, true)?;
                         }
                     }
+                    self.emit_br(next_pos);
+                } else {
+                    // A bare `rescue` (no exception list, with or without a
+                    // `=> e` capture) is `rescue StandardError`: only
+                    // StandardError and its subclasses are caught, so a
+                    // non-StandardError (Exception, SignalException,
+                    // SystemExit, …) propagates instead of being swallowed.
+                    let std_err = Node::new_const(
+                        "StandardError".to_string(),
+                        false,
+                        None,
+                        vec![],
+                        Loc::default(),
+                    );
+                    self.gen_teq_condbr(std_err, err_reg, cont_pos, true)?;
                     self.emit_br(next_pos);
                 };
                 self.apply_label(cont_pos);


### PR DESCRIPTION
## Summary

A bare `rescue` (no exception list, with or without a `=> e` capture) is `rescue StandardError` — it must catch StandardError and its subclasses only, letting a non-StandardError propagate. monoruby compiled the empty exception list as an unconditional catch, so `rescue` / `rescue => e` swallowed **every** exception, including `Exception`, `SignalException`, `SystemExit`, and the stack-overflow / no-memory errors:

```ruby
raise(Exception) rescue 1   # wrongly returned 1; must re-raise
```

## Changes

- **Bare rescue matching**: lower an empty rescue exception list as `StandardError === err` (branch to the clause body only on a match) instead of falling straight through to it.
- **Match stack-pointer reset**: a clause's non-local `=> target` capture (e.g. `rescue => self[:error]`) leaves scratch temps on the stack. The new match code below now branches, so those temps would otherwise desync the branch/merge stack heights and trip the `into_bytecode` sp-consistency assertion. Reset the stack pointer to the `err`-register level after the capture.
- **Class hierarchy**: `NoMemoryError`, `SecurityError`, `ScriptError` (with its `LoadError` / `SyntaxError` / `NotImplementedError` subclasses), and `SignalException` now inherit directly from `Exception`, not `StandardError`; add the missing `SystemStackError` (also an `Exception` subclass). Otherwise a bare `rescue` would still catch them via the wrong ancestry.

## Impact

Fixes several `language/rescue_spec.rb` examples:
- bare `rescue` / inline-modifier `rescue` only rescuing StandardError
- "will not rescue exceptions except StandardError"
- the missing `SystemStackError` constant

`rescue_spec` goes from 3 failures / 7 errors to 1 failure / 2 errors. The remaining failures (a non-Module/Class rescue operand should raise `TypeError`, and backtrace entries) are independent and left for follow-ups.

## Testing

- New `non_standard_error_hierarchy` and `bare_rescue_only_catches_standard_error` unit tests, the latter including the `rescue => self[:error]` capture regression (all CRuby-verified).
- Full library suite green (`cargo test -p monoruby --lib`, 1817 passing) — no regression from the broadened hierarchy / bare-rescue semantics.
- Verified on x86-64 and aarch64 (qemu). The change is in the arch-neutral bytecode generator and class initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvFzM944gwaFHZ3VPwhor)_