### PR TITLE
frame: remove the unused LFP_CME slot to shrink call frames (fib −~7%)

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -740,7 +740,7 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit, stur x9, [sp, #(-(off as i32))];);
     }
 
-    /// Lower `SetupMethodFrame`: write the callee frame's outer/meta/svar/cme
+    /// Lower `SetupMethodFrame`: write the callee frame's outer/meta/svar
     /// and block fields at `[sp - (RSP_LOCAL_FRAME + LFP_*)]`. Mirrors x86
     /// `setup_method_frame`.
     fn a64_setup_method_frame(
@@ -760,7 +760,6 @@ impl Codegen {
         self.a64_store_x9_below_sp((RSP_LOCAL_FRAME + LFP_META) as u32);
         monoasm_arm64!(&mut self.jit, mov x9, (0u64););
         self.a64_store_x9_below_sp((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
-        self.a64_store_x9_below_sp((RSP_LOCAL_FRAME + LFP_CME) as u32);
         self.a64_set_block(block_fid, block_arg);
     }
 
@@ -1154,7 +1153,7 @@ impl Codegen {
     /// `SetupYieldFrame`: build the callee **block** frame for a specialized
     /// `yield` before `SpecializedYield` branches into it. Walks `outer - 1`
     /// outer-LFP links to the block's defining frame, then writes the callee
-    /// frame's outer/meta/svar/cme/block/self slots. A literal translation of
+    /// frame's outer/meta/svar/block/self slots. A literal translation of
     /// x86 `setup_yield_frame` (x29-free; uses x9 = outer LFP, x11 = value
     /// scratch — neither of which is GP-mapped; `stur`/`ldur` address the
     /// frame fields directly off sp/x9 with no address-scratch register). The cfp
@@ -1179,11 +1178,10 @@ impl Codegen {
             // frame.meta
             mov x11, (meta.get());
             stur x11, [sp, #(-((RSP_LOCAL_FRAME + LFP_META) as i32))];
-            // svar / cme / block = 0 (block callee resolves via outer chain;
+            // svar / block = 0 (block callee resolves via outer chain;
             // zeroed so the GC mark walker stays sound)
             mov x11, (0u64);
             stur x11, [sp, #(-((RSP_LOCAL_FRAME + LFP_SVAR) as i32))];
-            stur x11, [sp, #(-((RSP_LOCAL_FRAME + LFP_CME) as i32))];
             stur x11, [sp, #(-((RSP_LOCAL_FRAME + LFP_BLOCK) as i32))];
             // frame.self = [outer LFP - LFP_SELF]
             ldur x11, [x9, #(-(LFP_SELF as i32))];
@@ -1249,10 +1247,9 @@ impl Codegen {
             stur x10, [sp, #(-((RSP_LOCAL_FRAME + LFP_META) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_BLOCK) as i32))];
             stur x25, [sp, #(-((RSP_LOCAL_FRAME + LFP_SELF) as i32))];
-            // set_method_outer: outer/svar/cme = 0
+            // set_method_outer: outer/svar = 0
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_OUTER) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_SVAR) as i32))];
-            stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_CME) as i32))];
             // call_funcdata (fdata in x26): push frame, set callee LFP/PC, call.
             ldr x10, [x19, #(EXECUTOR_CFP as u32)];
             sub x11, sp, #(RSP_CFP as u32);
@@ -4781,15 +4778,13 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit, mov x2, x1;);
         self.a64_get_func_data_x2(); // x9 = &FuncData (clobbers x10, x11)
         monoasm_arm64!(&mut self.jit, mov x26, x9;);
-        // Build the callee block frame fields below sp (outer/svar/cme/block/
+        // Build the callee block frame fields below sp (outer/svar/block/
         // self/meta). self is inherited from the outer frame.
         monoasm_arm64!(&mut self.jit,
             mov x12, (0u64);
             sub x11, sp, #((RSP_LOCAL_FRAME + LFP_OUTER) as u32);
             str x25, [x11];
             sub x11, sp, #((RSP_LOCAL_FRAME + LFP_SVAR) as u32);
-            str x12, [x11];
-            sub x11, sp, #((RSP_LOCAL_FRAME + LFP_CME) as u32);
             str x12, [x11];
             sub x11, sp, #((RSP_LOCAL_FRAME + LFP_BLOCK) as u32);
             str x12, [x11];

--- a/monoruby/src/codegen/arch/aarch64/invoker.rs
+++ b/monoruby/src/codegen/arch/aarch64/invoker.rs
@@ -242,11 +242,10 @@ impl JitModule {
             mov x13, (0);
             str x3, [x(fb.0)];  // LFP_SELF  = self
             str x6, [x(fb.0), #(8)];  // LFP_BLOCK = block
-            str x13, [x(fb.0), #(16)];  // LFP_CME   = 0
-            str x13, [x(fb.0), #(24)];  // LFP_SVAR  = 0
+            str x13, [x(fb.0), #(16)];  // LFP_SVAR  = 0
             ldr x14, [x(fdata.0), #(FUNCDATA_META as u32)];
-            str x14, [x(fb.0), #(32)];  // LFP_META  = funcdata.meta
-            str x13, [x(fb.0), #(40)];  // LFP_OUTER = 0
+            str x14, [x(fb.0), #(24)];  // LFP_META  = funcdata.meta
+            str x13, [x(fb.0), #(32)];  // LFP_OUTER = 0
         );
         self.a64_invoker_args_and_call(true);
         self.a64_invoker_epilogue();
@@ -270,11 +269,10 @@ impl JitModule {
             mov x7, (0);                // no keyword args
             str x3, [x(fb.0)];          // LFP_SELF  = self
             str x13, [x(fb.0), #(8)];   // LFP_BLOCK = 0
-            str x13, [x(fb.0), #(16)];  // LFP_CME   = 0
-            str x13, [x(fb.0), #(24)];  // LFP_SVAR  = 0
+            str x13, [x(fb.0), #(16)];  // LFP_SVAR  = 0
             ldr x14, [x(fdata.0), #(FUNCDATA_META as u32)];
-            str x14, [x(fb.0), #(32)];  // LFP_META  = funcdata.meta
-            str x13, [x(fb.0), #(40)];  // LFP_OUTER = 0
+            str x14, [x(fb.0), #(24)];  // LFP_META  = funcdata.meta
+            str x13, [x(fb.0), #(32)];  // LFP_OUTER = 0
         );
         self.a64_invoker_args_and_call(false);
         self.a64_invoker_epilogue();
@@ -288,7 +286,7 @@ impl JitModule {
     /// TODO(aarch64): resolve_invalidated_outer (heap-promoted outer frames).
     /// Set up the callee block frame from a `&ProcData` in x2 (self in x3 when
     /// `with_self`). Produces fdata in X9 and meta in X14, and writes self /
-    /// outer / block / cme / svar / meta into the new frame. Shared by the
+    /// outer / block / svar / meta into the new frame. Shared by the
     /// block and fiber invokers.
     /// TODO(aarch64): resolve_invalidated_outer (heap-promoted outer frames).
     pub(in crate::codegen) fn a64_block_frame_setup(&mut self, with_self: bool) {
@@ -336,11 +334,10 @@ impl JitModule {
             );
         }
         monoasm_arm64!(&mut self.jit,
-            str x13, [x(fb.0), #(16)];  // LFP_CME = 0
-            str x13, [x(fb.0), #(24)];  // LFP_SVAR = 0
+            str x13, [x(fb.0), #(16)];  // LFP_SVAR = 0
             ldr x14, [x(fdata.0), #(FUNCDATA_META as u32)];
-            str x14, [x(fb.0), #(32)];  // LFP_META
-            str x3, [x(fb.0), #(40)];  // LFP_OUTER = outer
+            str x14, [x(fb.0), #(24)];  // LFP_META
+            str x3, [x(fb.0), #(32)];  // LFP_OUTER = outer
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1303,11 +1303,10 @@ impl Codegen {
             sub sp, sp, #(16);
             str x(PC.0), [sp];
             str x(ACC.0), [sp, #(8)];
-        // frame setup: zero outer/svar/cme/block; self = class; meta.
+        // frame setup: zero outer/svar/block; self = class; meta.
             mov x12, (0);
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_OUTER) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_SVAR) as i32))];
-            stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_CME) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_BLOCK) as i32))];
             stur x25, [sp, #(-((RSP_LOCAL_FRAME + LFP_SELF) as i32))];  // self = class
             ldr x10, [x26, #(FUNCDATA_META as u32)];
@@ -1454,11 +1453,10 @@ impl Codegen {
             ldr x11, [x11];
             add x10, x10, x11;
             add x15, x10, #(FUNCINFO_DATA as u32);
-        // set_method_outer: zero outer/svar/cme; set meta (kept in X14).
+        // set_method_outer: zero outer/svar; set meta (kept in X14).
             mov x12, (0);
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_OUTER) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_SVAR) as i32))];
-            stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_CME) as i32))];
             ldr x14, [x15, #(FUNCDATA_META as u32)];
             stur x14, [sp, #(-((RSP_LOCAL_FRAME + LFP_META) as i32))];
         // Simple-send opcodes (no block/splat/kw at the call site) may take
@@ -1730,11 +1728,10 @@ impl Codegen {
             ldr x11, [x11];
             add x10, x10, x11;
             add x15, x10, #(FUNCINFO_DATA as u32);
-        // block frame setup: outer = X25, self = outer.self, svar/cme/block 0.
+        // block frame setup: outer = X25, self = outer.self, svar/block 0.
             mov x12, (0);
             stur x25, [sp, #(-((RSP_LOCAL_FRAME + LFP_OUTER) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_SVAR) as i32))];
-            stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_CME) as i32))];
             stur x12, [sp, #(-((RSP_LOCAL_FRAME + LFP_BLOCK) as i32))];
             ldur x10, [x25, #(-(LFP_SELF as i32))];  // self = outer.self
             stur x10, [sp, #(-((RSP_LOCAL_FRAME + LFP_SELF) as i32))];

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -137,7 +137,6 @@ impl Codegen {
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], 0;
             movq rax, [rdi - (LFP_SELF)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF)], rax;
@@ -177,12 +176,10 @@ impl Codegen {
         monoasm! { &mut self.jit,
             movq rax, (meta.get());
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
-            // SVAR / CME slots — zero-fill so the GC mark walker
-            // never dereferences uninitialised stack memory. Lazy
-            // `$~` allocation rewrites SVAR on first MatchData; CME
-            // stays zero pending its own migration.
+            // SVAR slot — zero-fill so the GC mark walker never
+            // dereferences uninitialised stack memory. Lazy `$~`
+            // allocation rewrites SVAR on first MatchData.
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         }
         self.set_block(block_fid, block_arg);
         monoasm! { &mut self.jit,
@@ -216,11 +213,10 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], rdi;
             movq  rax, (meta.get());
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
-            // Yield builds a block frame — SVAR/CME are unused by
+            // Yield builds a block frame — SVAR is unused by
             // block-style callees (they resolve via outer chain),
-            // but zero them so the GC mark walker stays sound.
+            // but zero it so the GC mark walker stays sound.
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
             movq [rsp - (RSP_LOCAL_FRAME + LFP_BLOCK)], 0;
             movq rax, [rdi - (LFP_SELF)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF)], rax;
@@ -445,10 +441,9 @@ impl Codegen {
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], 0;
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
-            // Zero SVAR/CME — method-introducing frame's lazy `$~`
+            // Zero SVAR — method-introducing frame's lazy `$~`
             // container is allocated on first MatchData write.
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
         self.set_block(block_fid, block_arg);
         monoasm!( &mut self.jit,

--- a/monoruby/src/codegen/arch/x86_64/jit_module.rs
+++ b/monoruby/src/codegen/arch/x86_64/jit_module.rs
@@ -425,12 +425,11 @@ impl JitModule {
         monoasm! { &mut self.jit,
             // set outer
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], rax;
-            // SVAR / CME are unused by block frames (they walk the
-            // outer chain to the LEP for `$~`); zero them so any stray
-            // reader sees a clean "absent" sentinel and so the GC
-            // doesn't follow uninitialised stack memory.
+            // SVAR is unused by block frames (they walk the outer
+            // chain to the LEP for `$~`); zero it so any stray reader
+            // sees a clean "absent" sentinel and so the GC doesn't
+            // follow uninitialised stack memory.
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
     }
 
@@ -439,10 +438,8 @@ impl JitModule {
         monoasm! { &mut self.jit,
             movq [rsp - (RSP_LOCAL_FRAME + LFP_OUTER)], 0;
             // Method-introducing frame: own SVAR slot starts unset
-            // (zero = "no MatchData captured"). CME also zero for
-            // now — reserved for a future migration.
+            // (zero = "no MatchData captured").
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         };
     }
 

--- a/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
@@ -184,11 +184,9 @@ impl Codegen {
             // set meta
             movq rax, [r15 + (FUNCDATA_META)];
             movq [rsp - (RSP_LOCAL_FRAME + LFP_META)], rax;
-            // SVAR / CME: zero-fill so the GC mark walker stays
-            // sound. Lazy `$~` allocation writes SVAR on first
-            // MatchData; CME stays zero pending its own migration.
+            // SVAR: zero-fill so the GC mark walker stays sound.
+            // Lazy `$~` allocation writes SVAR on first MatchData.
             movq [rsp - (RSP_LOCAL_FRAME + LFP_SVAR)], 0;
-            movq [rsp - (RSP_LOCAL_FRAME + LFP_CME)], 0;
         }
         monoasm! { &mut self.jit,
             movzxw r9, [r13 + (POS_NUM)];

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -65,14 +65,8 @@ pub(crate) const LFP_FUNCID: i32 = LFP_META + META_FUNCID as i32;
 /// `Array` `Value` container `[$~, $_]` (see `SVAR_BACKREF` /
 /// `SVAR_LASTLINE`).
 pub(crate) const LFP_SVAR: i32 = 16;
-/// Callable Method Entry — reserved for the upcoming CME slot. CRuby
-/// uses `cref_or_me` at the same position in `vm_svar`; monoruby keeps
-/// the slot separate so the SVAR migration above can land without
-/// blocking on the larger CME redesign. Initialised to `0`; no reads
-/// or writes wired up yet.
-pub(crate) const LFP_CME: i32 = 24;
-pub(crate) const LFP_BLOCK: i32 = 32;
-pub(crate) const LFP_SELF: i32 = 40;
+pub(crate) const LFP_BLOCK: i32 = 24;
+pub(crate) const LFP_SELF: i32 = 32;
 pub const LFP_ARG0: i32 = LFP_SELF + 8;
 
 /// Index of `$~` (the MatchData backref) inside the `LFP_SVAR`

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -565,10 +565,9 @@ impl Lfp {
         // Push slots in **ascending memory order**, finishing with
         // LFP_OUTER at the highest index = lfp_addr.
         // Order: locals[0..N], self (LFP_SELF), block (LFP_BLOCK),
-        // cme (LFP_CME), svar (LFP_SVAR), meta (LFP_META), outer (LFP_OUTER).
+        // svar (LFP_SVAR), meta (LFP_META), outer (LFP_OUTER).
         v.push(self_val.id()); // -> LFP_SELF
         v.push(0); //               -> LFP_BLOCK
-        v.push(0); //               -> LFP_CME (unused; zero sentinel)
         v.push(0); //               -> LFP_SVAR (unused; zero sentinel)
         v.push(meta.get()); //      -> LFP_META
         v.push(0); //               -> LFP_OUTER (no outer)
@@ -586,17 +585,15 @@ impl Lfp {
     }
 
     pub fn dummy_heap_frame_with_self(self_val: Value) -> Self {
-        // Same slot order as `heap_frame` (locals.., self, block, cme,
-        // svar, meta, outer) with zero locals. Eight u64 slots: 1 self
-        // + 5 zero header slots (block/cme/svar/meta/outer) padded out
-        // to two extra zeros so the LFP layout stays self-consistent
-        // with the new (post-SVAR/CME) header size.
+        // Same slot order as `heap_frame` (locals.., self, block,
+        // svar, meta, outer) with zero locals. Over-allocated with
+        // padding so the LFP layout stays self-consistent with the
+        // header size (LFP_SELF).
         let v: Box<[u64]> = vec![
             0,                  // padding (matches the historical extra slot)
             0,                  // padding
             self_val.id(),      // LFP_SELF
             0,                  // LFP_BLOCK
-            0,                  // LFP_CME
             0,                  // LFP_SVAR
             0,                  // LFP_META — set via `set_reg_num` below
             0,                  // LFP_OUTER


### PR DESCRIPTION
## What & why

The frame-local `$~`/`$_` feature (#608) inserted **two** new header slots into every call frame — `LFP_SVAR` (used) and `LFP_CME` (reserved for a future Callable-Method-Entry migration). The **CME slot is never read anywhere**; it is only zero-filled on every frame setup. So it is pure per-call overhead: two extra stores + 8 bytes of frame growth on **every** method/block/yield call.

Call-bound workloads pay this directly. Bisecting the ruby-bench `fib` slowdown pinned #608 as the cause: steady-state `fib(32)` regressed **~13%** (≈29.4ms → ≈33ms per iter). The `LFP_SVAR` half is genuinely needed; the `LFP_CME` half is not (yet). This PR removes the CME slot and recovers roughly **half** of that regression.

## Change

- **`executor.rs`**: drop the `LFP_CME` constant; shift `LFP_BLOCK 32→24`, `LFP_SELF 40→32`. The header shrinks 40→32 bytes; `frame_bytes = LFP_SELF + 8*reg_num` follows automatically. `RSP_LOCAL_FRAME` is the callee-LFP reservation and is **independent** of header size, so it stays `40` — the callee LFP base (`= sp − 40`) is unchanged on both arches.
- **x86_64 + aarch64 codegen**: delete the per-call `LFP_CME = 0` stores from every frame prologue (method call, yield, block, method-outer, method/block/fiber invokers). Symbolic-offset stores auto-follow the new constants; the aarch64 invokers use literal `fb`-relative offsets, so `SVAR`/`META`/`OUTER` are shifted down 8 (`OUTER@fb+32 = sp−40 = lfp` ✓).
- **`frame.rs`**: drop the CME slot from `heap_frame` / `dummy_heap_frame_with_self`.

## Measurement (paired, interleaved, `fib(32)` steady-state ms/iter)

| | ms/iter |
|---|---|
| baseline (master) | ~33–35 |
| this PR (no-CME) | ~31–34 |

Faster in **every** paired run; ~4–8% depending on machine load (cleaner low-load runs show ~7–8%).

## Validation

- **x86_64**: `cargo test -p monoruby --lib` → **1815 passed / 0 failed** (includes the VM+JIT integration tests that diff against CRuby, and `heap_frame_reclaim_correctness` which exercises the frame layout directly). `fib`, regex `$~`/`$1`/`$&`, and block/proc/closure programs all match CRuby.
- **aarch64**: hand-ported symmetrically. No host cross-toolchain was available in this environment (`bin/setup-aarch64-cross` needs apt/sudo), so **the macOS CI job is needed to confirm the aarch64 build**.

## ⚠️ Conflicts with in-flight CME work by design

There is an unmerged branch (`claude/cme-slot-review-*`) that plans to actually populate `LFP_CME` (default `CmeId`, `super` / `__callee__` resolution). If that lands, the slot returns — but it should carry its cost **then**, when it has a reader, not sit as dead weight beforehand. Flagging so you can decide the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)