### PR TITLE
Fix crashes/hangs and improve encoding &amp; Thread handling in the ruby/spec language group

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -689,7 +689,10 @@ class Thread
     return if @ran
     @ran = true
     begin
-      @value = @block.call(*@args)
+      # Route through the native helper so a bare top-level `return` in the
+      # thread body raises LocalJumpError (as in CRuby) instead of performing
+      # a non-local return that escapes the synchronously-run block.
+      @value = __invoke_body(@block, @args)
     rescue => e
       @exception = e
     ensure
@@ -698,6 +701,7 @@ class Thread
     self
   end
   private :__run
+  private :__invoke_body
 
   def value
     __run

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -663,13 +663,27 @@ class Thread
   # concurrently. Only Thread.current (the main thread) is meaningful.
   # Methods that require actual concurrency raise NoMethodError.
 
+  # Deferred thread bodies that have not run yet, oldest first. monoruby
+  # runs `Thread.new` blocks lazily (on `#value`/`#join`), so a main-thread
+  # busy-wait like `Thread.pass until flag` — where `flag` is set by a
+  # thread body — would otherwise spin forever. `Thread.pass` drains this
+  # queue one entry at a time to emulate cooperative scheduling.
+  @@pending = []
+
   def self.current
     @@current
   end
 
-  # Thread.pass is a native sched_yield(2) wrapper (see builtins/thread.rs).
-  # Genuine single-thread blocking is surfaced at the blocking call sites,
-  # not by an artificial Thread.pass call-count guard.
+  # `Thread.pass` runs the oldest not-yet-run deferred thread (so
+  # `Thread.pass until cond` makes progress), then delegates the CPU-yield
+  # hint to the native helper. With no pending thread it is just the
+  # sched_yield(2) wrapper (see builtins/thread.rs).
+  def self.pass
+    t = @@pending.shift
+    t.__send__(:__run) if t
+    __native_yield
+    nil
+  end
 
   def initialize(*args, &block)
     @block = block
@@ -680,6 +694,9 @@ class Thread
     @alive = !@ran
     @keys = {}
     @thread_local = {}
+    # Register runnable (block-bearing) threads so `Thread.pass` can drive
+    # them; `Thread.new` with no block (e.g. the main thread) is already ran.
+    @@pending << self unless @ran
   end
 
   @@current = Thread.new
@@ -687,6 +704,7 @@ class Thread
 
   def __run
     return if @ran
+    @@pending.delete(self)
     @ran = true
     begin
       # Route through the native helper so a bare top-level `return` in the

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -495,7 +495,9 @@ fn encoding_to_rs(enc: crate::value::Encoding) -> Option<&'static encoding_rs::E
         E::Sjis(_) => b"shift_jis",
         E::Iso2022Jp => b"iso-2022-jp",
         // Handled by callers as fast paths / no native codec.
-        E::Utf32Le | E::Utf32Be | E::Ascii8 | E::UsAscii | E::Other(_) => return None,
+        E::Utf32Le | E::Utf32Be | E::Ascii8 | E::UsAscii | E::Other(_) | E::NamedByte(_) => {
+            return None
+        }
     };
     encoding_rs::Encoding::for_label(label)
 }
@@ -1294,6 +1296,7 @@ pub(crate) fn encoding_constant_name(enc: Encoding) -> &'static str {
             4 => "UTF_32",
             _ => "ASCII_8BIT",
         },
+        Encoding::NamedByte(i) => crate::value::named_byte_const_name(i),
     }
 }
 

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -1839,7 +1839,7 @@ fn read_one_char(io: &mut IoInner) -> Result<Vec<u8>> {
 fn char_width_from_lead(enc: crate::value::Encoding, b: u8) -> usize {
     use crate::value::Encoding as E;
     match enc {
-        E::Ascii8 | E::UsAscii | E::Iso8859(_) | E::Other(_) | E::Iso2022Jp => 1,
+        E::Ascii8 | E::UsAscii | E::Iso8859(_) | E::Other(_) | E::NamedByte(_) | E::Iso2022Jp => 1,
         E::EucJp => match b {
             0x8e => 2,
             0x8f => 3,

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -585,6 +585,7 @@ fn encoding_ordinal(enc: Encoding) -> i32 {
         Encoding::Iso8859(n) => 100 + n as i32,
         Encoding::Iso2022Jp => 200,
         Encoding::Other(_) => 300,
+        Encoding::NamedByte(i) => 400 + i as i32,
     }
 }
 

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -12,6 +12,40 @@ use super::*;
 pub(super) fn init(globals: &mut Globals) {
     let klass = globals.define_class_under_obj("Thread").id();
     globals.define_builtin_class_func(klass, "pass", pass, 0);
+    globals.define_builtin_func(klass, "__invoke_body", invoke_body, 2);
+}
+
+///
+/// ### Thread#__invoke_body(block, args)
+///
+/// Runs a thread body block, translating a top-level non-local `return`
+/// into a `LocalJumpError`. Used by `Thread#__run` in startup.rb.
+///
+/// CRuby runs each thread on its own stack, so a `return` written directly
+/// in a `Thread.new { ... }` block has no enclosing method frame to return
+/// to and raises `LocalJumpError: unexpected return`. monoruby is
+/// single-threaded and runs thread bodies synchronously on the caller's
+/// stack (see `Thread#__run`), so the block's home frame is still live and
+/// the `return` would otherwise perform a real non-local return, escaping
+/// the thread body entirely (and, under mspec, corrupting the harness).
+/// Catch that escaping `MethodReturn` here and convert it, matching
+/// CRuby's observable behavior for the common (uncaught) case.
+#[monoruby_builtin]
+fn invoke_body(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let block = Proc::new(lfp.arg(0));
+    let args = lfp.arg(1).as_array();
+    match vm.invoke_proc(globals, &block, &args) {
+        Ok(v) => Ok(v),
+        Err(err) if matches!(err.kind(), MonorubyErrKind::MethodReturn(..)) => {
+            Err(MonorubyErr::localjumperr("unexpected return"))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 ///
@@ -47,6 +81,51 @@ mod tests {
     fn thread_pass_returns_nil() {
         run_test("Thread.pass");
         run_test("Thread.pass.nil?");
+    }
+
+    #[test]
+    fn thread_body_bare_return_raises_localjumperror() {
+        // A bare top-level `return` in a thread body is a LocalJumpError in
+        // CRuby (the thread has no enclosing method frame). monoruby runs the
+        // body synchronously, so without the `__invoke_body` conversion the
+        // `return` would escape the block entirely. Observe it at `#value`.
+        run_test(
+            r#"
+            begin
+              Thread.new { return }.value
+              :no_error
+            rescue LocalJumpError => e
+              e.message
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            begin
+              Thread.new { return 5 }.value
+              :no_error
+            rescue LocalJumpError
+              :local_jump
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_body_normal_paths_unaffected() {
+        // The return-conversion wrapper must not disturb ordinary thread
+        // bodies: plain values, arguments, and normal exceptions.
+        run_test("Thread.new { 40 + 2 }.value");
+        run_test("Thread.new(3, 4) { |a, b| a * b }.value");
+        run_test(
+            r#"
+            begin
+              Thread.new { raise "boom" }.value
+            rescue => e
+              e.message
+            end
+            "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -11,7 +11,10 @@ use super::*;
 
 pub(super) fn init(globals: &mut Globals) {
     let klass = globals.define_class_under_obj("Thread").id();
-    globals.define_builtin_class_func(klass, "pass", pass, 0);
+    // `Thread.pass` is reopened in startup.rb to first run a pending
+    // deferred thread (cooperative scheduling); it delegates the actual
+    // CPU-yield hint to this native helper.
+    globals.define_builtin_class_func(klass, "__native_yield", pass, 0);
     globals.define_builtin_func(klass, "__invoke_body", invoke_body, 2);
 }
 
@@ -124,6 +127,44 @@ mod tests {
             rescue => e
               e.message
             end
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_pass_drives_deferred_thread_bodies() {
+        // `Thread.new` runs its block lazily, so a main-thread busy-wait on a
+        // flag set by a thread body must still make progress: `Thread.pass`
+        // runs the oldest pending thread. Without this the loop would hang.
+        run_test_once(
+            r#"
+            running = false
+            thr = Thread.new { running = true }
+            Thread.pass until running
+            thr.join
+            running
+            "#,
+        );
+        // Multiple pending threads are drained oldest-first across passes.
+        run_test_once(
+            r#"
+            a = []
+            t1 = Thread.new { a << 1 }
+            t2 = Thread.new { a << 2 }
+            Thread.pass until a.size == 2
+            t1.join
+            t2.join
+            a.sort
+            "#,
+        );
+        // A thread run directly via #value is not re-run by a later pass.
+        run_test_once(
+            r#"
+            n = 0
+            t = Thread.new { n += 1 }
+            t.value
+            Thread.pass
+            n
             "#,
         );
     }

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -566,7 +566,18 @@ impl<'a> BytecodeGen<'a> {
             self.apply_label(no_match_pos);
             // no rescue branch was matched.
             if let Some(box ensure) = &ensure {
+                // Keep `err_reg` reserved while emitting the `ensure` body: the
+                // re-raise below reads the in-flight exception back out of
+                // `err_reg`, so the body's scratch temps must not reuse that
+                // slot. `match_temp` sits one slot above `err_reg` (only
+                // `err_reg` is live here), so generating the body from there
+                // leaves the exception intact. (Without this the body would
+                // start at `finish`, which can alias `err_reg` and cause a
+                // non-exception value — e.g. a `puts` string — to be re-raised.)
+                let saved = self.temp;
+                self.temp = match_temp;
                 self.gen_expr(ensure.clone(), UseMode2::NotUse)?;
+                self.temp = saved;
             }
             self.emit(BytecodeInst::Raise(err_reg), Loc::default());
 
@@ -754,6 +765,55 @@ mod test {
               end
             end
             [m, $log]
+            "#,
+        );
+    }
+
+    #[test]
+    fn reraise_through_ensure_preserves_exception() {
+        // Regression: `err_reg` (the slot the exception dispatcher stashes the
+        // in-flight exception in, re-raised after the `ensure`) must not be
+        // reused as a scratch temp by the `ensure` body. When it was, an
+        // `ensure` that built a string (e.g. via `puts`/interpolation) left a
+        // String in `err_reg`, so the re-raise handed a non-exception value to
+        // the runtime and aborted the process. Here the outer `rescue` must
+        // receive the original exception object, not the ensure's string.
+        run_test(
+            r#"
+            o = StandardError.new "outer"
+            i = StandardError.new "inner"
+            begin
+              raise o
+            rescue
+              begin
+                begin
+                  raise i
+                rescue
+                  raise i
+                ensure
+                  s = "ensure: #{i.message}"
+                end
+              rescue => e
+                [e.class.name, e.message, e.equal?(i)]
+              end
+            end
+            "#,
+        );
+        // Same shape without an outer pending exception, re-raising the bare
+        // `$!` through an `ensure` whose body allocates scratch temps.
+        run_test(
+            r#"
+            begin
+              begin
+                raise ArgumentError, "boom"
+              rescue
+                raise
+              ensure
+                _ = "x" * 4
+              end
+            rescue => e
+              [e.class.name, e.message]
+            end
             "#,
         );
     }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1584,7 +1584,15 @@ pub(super) extern "C" fn ensure_end(vm: &mut Executor) -> usize {
 pub(super) extern "C" fn raise_err(vm: &mut Executor, err_val: Value) {
     match err_val.is_exception() {
         Some(ex) => vm.set_error(MonorubyErr::new_from_exception(ex).with_original(err_val)),
-        None => unimplemented!(),
+        // The `Raise` opcode only re-raises an in-flight exception object
+        // stashed in `err_reg` by the exception dispatcher, so a
+        // non-exception value here means an internal invariant was
+        // violated (e.g. `err_reg` was clobbered before the re-raise).
+        // Surface it as an uncatchable `FatalError` rather than panicking
+        // across the `extern "C"` boundary, which would abort the process.
+        None => vm.set_error(MonorubyErr::fatal(
+            "raise: re-raised value is not an exception object (internal error)",
+        )),
     }
 }
 

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -160,8 +160,16 @@ fn main() {
         if finish_flag {
             return;
         }
-        let mut code = String::new();
-        std::io::stdin().read_to_string(&mut code).unwrap();
+        // Read stdin as raw bytes: a script piped in may contain
+        // non-UTF-8 bytes (e.g. a `# encoding:`-tagged source with
+        // high bytes in a string literal). monoruby stores source as
+        // UTF-8 and cannot round-trip arbitrary bytes, but it must not
+        // abort — decode lossily rather than `unwrap`-ing.
+        let mut bytes = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut bytes)
+            .expect("failed to read stdin");
+        let code = String::from_utf8_lossy(&bytes).into_owned();
         (code, std::path::PathBuf::from("-"))
     };
     if let Some(kind) = args.ast {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -142,6 +142,75 @@ enum CallBlock {
     Delegate,
 }
 
+/// Extract the source-encoding name declared by a `# coding:` /
+/// `# encoding:` magic comment, following CRuby's placement rules:
+///
+/// * The directive must be on the first line, or the second line when
+///   the first line is a shebang (`#!...`).
+/// * That line must be a comment from its first token — only ASCII
+///   whitespace may precede the `#` (so `1 + 1 # encoding: x` does not
+///   count).
+/// * Within the comment the name is whatever follows `coding` (as a
+///   substring, so both `coding` and `encoding` match — and `fileencoding`
+///   in a vim modeline) immediately followed by `:` or `=`. The match is
+///   case-insensitive. Emacs `-*- coding: X -*-` and vim
+///   `fileencoding=X` fall out of the same scan.
+///
+/// Returns the raw declared name (e.g. `"big5"`); the caller maps it to an
+/// [`crate::value::Encoding`] via `Encoding::try_from_str`.
+fn detect_source_encoding(code: &[u8]) -> Option<String> {
+    let mut lines = code.split(|&b| b == b'\n');
+    let first = lines.next().unwrap_or(&[]);
+    let candidate: &[u8] = if first.starts_with(b"#!") {
+        lines.next().unwrap_or(&[])
+    } else {
+        first
+    };
+    // Only ASCII whitespace may precede the `#`.
+    let mut i = 0;
+    while i < candidate.len()
+        && matches!(candidate[i], b' ' | b'\t' | b'\r' | 0x0b | 0x0c)
+    {
+        i += 1;
+    }
+    let comment = candidate.get(i..)?.strip_prefix(b"#")?;
+    let comment = std::str::from_utf8(comment).ok()?;
+    parse_coding_directive(comment)
+}
+
+/// Scan a comment body for `coding` immediately followed (after optional
+/// blanks) by `:` or `=` and an encoding name. See `detect_source_encoding`.
+fn parse_coding_directive(comment: &str) -> Option<String> {
+    let lower = comment.to_ascii_lowercase();
+    let lb = lower.as_bytes();
+    let cb = comment.as_bytes();
+    let mut from = 0;
+    while let Some(off) = lower[from..].find("coding") {
+        let mut j = from + off + "coding".len();
+        while j < lb.len() && matches!(lb[j], b' ' | b'\t') {
+            j += 1;
+        }
+        if j < lb.len() && matches!(lb[j], b':' | b'=') {
+            j += 1;
+            while j < lb.len() && matches!(lb[j], b' ' | b'\t') {
+                j += 1;
+            }
+            let start = j;
+            while j < cb.len()
+                && (cb[j].is_ascii_alphanumeric() || cb[j] == b'_' || cb[j] == b'-')
+            {
+                j += 1;
+            }
+            if j > start {
+                // Preserve the declared case; `try_from_str` normalizes.
+                return Some(comment[start..j].to_string());
+            }
+        }
+        from += off + 1;
+    }
+    None
+}
+
 fn try_prism_inner(
     code: &str,
     path: PathBuf,
@@ -156,16 +225,14 @@ fn try_prism_inner(
         None => prism::parse(code.as_bytes()),
     };
 
-    // Pull `# encoding: NAME` / `# coding: NAME` (also Emacs-style
-    // `# -*- coding: NAME -*-`) out of the magic comment list before
-    // we touch any string literals. Prism normalises all of these
-    // into one entry per key=value pair, so we just look for the
-    // canonical key. If both are present (rare), the first wins —
-    // matching CRuby's "first magic comment line" semantics.
-    let source_encoding: Option<String> = result
-        .magic_comments()
-        .find(|c| matches!(c.key(), b"encoding" | b"coding"))
-        .and_then(|c| std::str::from_utf8(c.value()).ok().map(str::to_owned));
+    // Detect the source encoding from the `# coding:` / `# encoding:`
+    // magic comment ourselves rather than via prism's `magic_comments()`
+    // list: prism reports every `key: value` comment regardless of
+    // position, whereas CRuby only honours an encoding directive on the
+    // first line (or the second line when the first is a shebang) and
+    // only when the line is a comment from its first token. See
+    // `detect_source_encoding`.
+    let source_encoding: Option<String> = detect_source_encoding(code.as_bytes());
 
     let source_info: SourceInfoRef = std::rc::Rc::new(
         crate::ast::SourceInfo::new_eval(path, code.to_owned(), line_offset)
@@ -4478,6 +4545,58 @@ $1
     fn magic_comment_default_is_utf8() {
         let enc = run_encoding_query("\"abc\".encoding.to_s\n");
         assert_eq!(enc, "UTF-8");
+    }
+
+    /// ASCII-compatible national byte encodings (Big5, GBK, …) are now
+    /// name-preserved via `Encoding::NamedByte` rather than folded onto
+    /// ASCII-8BIT, so `# encoding: big5` reports "Big5".
+    #[test]
+    fn magic_comment_named_byte_encoding_preserves_name() {
+        assert_eq!(
+            run_encoding_query("# encoding: big5\n\"abc\".encoding.to_s\n"),
+            "Big5"
+        );
+        assert_eq!(
+            run_encoding_query("# encoding: GBK\n\"abc\".encoding.to_s\n"),
+            "GBK"
+        );
+        // ASCII-only content stays SevenBit and inspects normally
+        // (not \xHH-escaped) — Big5 is ASCII-compatible.
+        assert_eq!(run_encoding_query("# encoding: big5\n\"abc\"\n"), "abc");
+    }
+
+    /// `detect_source_encoding` follows CRuby's placement rules.
+    #[test]
+    fn magic_comment_placement_rules() {
+        // Case-insensitive key, mixed-case value.
+        assert_eq!(parse_coding_directive(" CoDiNg: bIg5"), Some("bIg5".into()));
+        // `=` separator and a junk prefix are allowed.
+        assert_eq!(
+            parse_coding_directive(" foo encoding = big5"),
+            Some("big5".into())
+        );
+        // `coding` must be immediately followed by `:`/`=`; `encodings:`
+        // does not match.
+        assert_eq!(parse_coding_directive(" encodings: big5"), None);
+        // `fileencoding=` inside a vim modeline is caught by the same scan.
+        assert_eq!(
+            parse_coding_directive(" vim: filetype=ruby, fileencoding=big5, tabsize=3"),
+            Some("big5".into())
+        );
+
+        // Only the first line (or the second after a shebang) counts, and
+        // only when the line is a comment from its first token.
+        assert_eq!(
+            detect_source_encoding(b"# encoding: big5\nx = 1\n"),
+            Some("big5".into())
+        );
+        assert_eq!(
+            detect_source_encoding(b"#!/usr/bin/ruby\n# encoding: big5\n"),
+            Some("big5".into())
+        );
+        assert_eq!(detect_source_encoding(b"\n# encoding: big5\n"), None);
+        assert_eq!(detect_source_encoding(b"1 + 1 # encoding: big5\n"), None);
+        assert_eq!(detect_source_encoding(b"x = 1\n"), None);
     }
 
     /// `\xNN` byte escapes in a `# encoding: binary` source come out

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -31,7 +31,7 @@ pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
 pub use string::{CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET};
 pub(crate) use string::{check_string_not_modified, string_snapshot, string_substring, STRING_SHARED_TAG};
-pub(crate) use string::{eucjp_char_width, sjis_char_width};
+pub(crate) use string::{eucjp_char_width, named_byte_const_name, sjis_char_width};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};
 
 mod arithmetic_sequence;

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -74,6 +74,7 @@ impl<'a> Iterator for CharByteIter<'a> {
             | Encoding::UsAscii
             | Encoding::Iso8859(_)
             | Encoding::Other(_)
+            | Encoding::NamedByte(_)
             // ISO-2022-JP groups bytes 1-at-a-time at the codepoint
             // iterator level — the actual char-vs-ESC-sequence
             // chunking happens further up via `encoding_rs`. This
@@ -199,6 +200,15 @@ pub enum Encoding {
     /// bytes); only `#name`, `#inspect` and ASCII-incompatibility
     /// differ.
     Other(u8),
+    /// An ASCII-*compatible* byte-oriented national encoding monoruby
+    /// has no native codec for (Big5, GBK, GB18030, EUC-KR, the
+    /// Windows-125x / IBM / KOI8 / TIS-620 family, …). Unlike
+    /// [`Encoding::Other`] these keep bytes < 0x80 as ASCII, so they
+    /// behave like `ASCII-8BIT` for storage/iteration but preserve
+    /// their declared name (so `# encoding: big5` makes
+    /// `__ENCODING__.name == "Big5"`). The payload indexes
+    /// [`NAMED_BYTE_ENCODINGS`].
+    NamedByte(u8),
 }
 
 /// Canonical names for [`Encoding::Other`] variants (stateful /
@@ -206,6 +216,66 @@ pub enum Encoding {
 /// index is the `Encoding::Other` payload.
 pub(crate) const OTHER_ENC_NAMES: &[&str] =
     &["UTF-7", "CP50220", "CP50221", "UTF-16", "UTF-32"];
+
+/// `(display name, `Encoding::<CONST>` suffix)` for
+/// [`Encoding::NamedByte`] variants — ASCII-compatible byte
+/// encodings monoruby name-preserves but has no native codec for.
+/// The index is the `Encoding::NamedByte` payload. The constant
+/// suffix must match a registered `Encoding::*` constant so
+/// `__ENCODING__` can load it.
+pub(crate) const NAMED_BYTE_ENCODINGS: &[(&str, &str)] = &[
+    ("Big5", "Big5"),
+    ("Big5-HKSCS", "Big5_HKSCS"),
+    ("Big5-UAO", "Big5_UAO"),
+    ("GBK", "GBK"),
+    ("GB2312", "GB2312"),
+    ("GB18030", "GB18030"),
+    ("GB12345", "GB12345"),
+    ("EUC-KR", "EUC_KR"),
+    ("EUC-TW", "EUC_TW"),
+    ("CP949", "CP949"),
+    ("TIS-620", "TIS_620"),
+    ("KOI8-R", "KOI8_R"),
+    ("KOI8-U", "KOI8_U"),
+    ("Windows-1250", "Windows_1250"),
+    ("Windows-1251", "Windows_1251"),
+    ("Windows-1252", "Windows_1252"),
+    ("Windows-1253", "Windows_1253"),
+    ("Windows-1254", "Windows_1254"),
+    ("Windows-1255", "Windows_1255"),
+    ("Windows-1256", "Windows_1256"),
+    ("Windows-1257", "Windows_1257"),
+    ("Windows-1258", "Windows_1258"),
+    ("IBM437", "IBM437"),
+    ("IBM737", "IBM737"),
+    ("IBM775", "IBM775"),
+    ("IBM850", "IBM850"),
+    ("IBM852", "IBM852"),
+    ("IBM855", "IBM855"),
+    ("IBM857", "IBM857"),
+    ("IBM860", "IBM860"),
+    ("IBM861", "IBM861"),
+    ("IBM862", "IBM862"),
+    ("IBM863", "IBM863"),
+    ("IBM864", "IBM864"),
+    ("IBM865", "IBM865"),
+    ("IBM866", "IBM866"),
+    ("IBM869", "IBM869"),
+];
+
+/// Look up a [`Encoding::NamedByte`] index by its normalized
+/// (uppercased, `-`/`.`→`_`) constant suffix.
+pub(crate) fn named_byte_index(normalized_const: &str) -> Option<u8> {
+    NAMED_BYTE_ENCODINGS
+        .iter()
+        .position(|(_, konst)| konst.eq_ignore_ascii_case(normalized_const))
+        .map(|i| i as u8)
+}
+
+/// The `Encoding::<CONST>` suffix for a [`Encoding::NamedByte`] payload.
+pub(crate) fn named_byte_const_name(index: u8) -> &'static str {
+    NAMED_BYTE_ENCODINGS[index as usize].1
+}
 
 impl Encoding {
     /// True if the encoding is a strict superset of US-ASCII for
@@ -244,6 +314,7 @@ impl Encoding {
     pub fn name(self) -> &'static str {
         match self {
             Encoding::Other(i) => OTHER_ENC_NAMES[i as usize],
+            Encoding::NamedByte(i) => NAMED_BYTE_ENCODINGS[i as usize].0,
             Encoding::Ascii8 => "ASCII-8BIT",
             Encoding::Utf8 => "UTF-8",
             Encoding::UsAscii => "US-ASCII",
@@ -311,7 +382,7 @@ impl Encoding {
             },
             Encoding::Ascii8 => CodeRange::Valid, // every byte is "valid"
             // No native codec: raw bytes, every sequence "valid".
-            Encoding::Other(_) => CodeRange::Valid,
+            Encoding::Other(_) | Encoding::NamedByte(_) => CodeRange::Valid,
             Encoding::Iso8859(_) => CodeRange::Valid, // every byte 0..256 represents a glyph
             // For encodings we don't decode natively, treat any
             // sequence as Valid unless its byte count contradicts
@@ -429,23 +500,76 @@ impl Encoding {
             "SHIFT_JIS" | "SJIS" | "MACJAPANESE" | "MACJAPAN" => Ok(Encoding::Sjis(0)),
             "WINDOWS_31J" | "CP932" | "CSWINDOWS31J" | "WINDOWS31J" => Ok(Encoding::Sjis(1)),
 
-            // Other byte-oriented encodings without native support
-            // are stored as ASCII-8BIT but the name isn't preserved
-            // (consistent with monoruby's prior behaviour). Includes
-            // dummy encodings that Ruby exposes by name for round-
-            // trip purposes (UTF-7, Emacs-Mule, CP50220/CP50221).
-            "WINDOWS_1250" | "CP1250" | "WINDOWS_1251" | "CP1251" | "WINDOWS_1252" | "CP1252"
-            | "WINDOWS_1253" | "CP1253" | "WINDOWS_1254" | "CP1254" | "WINDOWS_1255" | "CP1255"
-            | "WINDOWS_1256" | "CP1256" | "WINDOWS_1257" | "CP1257" | "WINDOWS_1258" | "CP1258"
-            | "IBM437" | "CP437" | "IBM737" | "CP737" | "IBM775" | "CP775" | "IBM850" | "CP850"
-            | "IBM852" | "CP852" | "IBM855" | "CP855" | "IBM857" | "CP857" | "IBM860" | "CP860"
-            | "IBM861" | "CP861" | "IBM862" | "CP862" | "IBM863" | "CP863" | "IBM864" | "CP864"
-            | "IBM865" | "CP865" | "IBM866" | "CP866" | "IBM869" | "CP869" | "KOI8_R"
-            | "KOI8_U" | "GB2312" | "EUC_CN" | "GBK" | "CP936" | "GB18030" | "BIG5"
-            | "BIG5_HKSCS" | "BIG5_UAO" | "EUC_KR" | "EUCKR" | "CP949" | "EUC_TW" | "EUCTW"
-            | "TIS_620" | "TIS620" | "EMACS_MULE" | "GB12345"
-            | "MACCYRILLIC" | "MACGREEK" | "MACICELAND" | "MACROMAN" | "MACROMANIA" | "MACTHAI"
-            | "MACTURKISH" | "MACUKRAINE" => Ok(Encoding::Ascii8),
+            // ASCII-compatible national byte encodings without a native
+            // codec: bytes are stored raw (like ASCII-8BIT) but the
+            // declared name is preserved via `Encoding::NamedByte`, so
+            // `# encoding: big5` reports `__ENCODING__.name == "Big5"`.
+            "BIG5" | "CP950" => Ok(Encoding::NamedByte(named_byte_index("Big5").unwrap())),
+            "BIG5_HKSCS" | "BIG5HKSCS" | "CP951" => {
+                Ok(Encoding::NamedByte(named_byte_index("Big5_HKSCS").unwrap()))
+            }
+            "BIG5_UAO" => Ok(Encoding::NamedByte(named_byte_index("Big5_UAO").unwrap())),
+            "GBK" | "CP936" => Ok(Encoding::NamedByte(named_byte_index("GBK").unwrap())),
+            "GB2312" | "EUC_CN" | "EUCCN" => {
+                Ok(Encoding::NamedByte(named_byte_index("GB2312").unwrap()))
+            }
+            "GB18030" => Ok(Encoding::NamedByte(named_byte_index("GB18030").unwrap())),
+            "GB12345" => Ok(Encoding::NamedByte(named_byte_index("GB12345").unwrap())),
+            "EUC_KR" | "EUCKR" | "CP949" => {
+                Ok(Encoding::NamedByte(named_byte_index("EUC_KR").unwrap()))
+            }
+            "EUC_TW" | "EUCTW" => Ok(Encoding::NamedByte(named_byte_index("EUC_TW").unwrap())),
+            "TIS_620" | "TIS620" => Ok(Encoding::NamedByte(named_byte_index("TIS_620").unwrap())),
+            "KOI8_R" => Ok(Encoding::NamedByte(named_byte_index("KOI8_R").unwrap())),
+            "KOI8_U" => Ok(Encoding::NamedByte(named_byte_index("KOI8_U").unwrap())),
+            "WINDOWS_1250" | "CP1250" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1250").unwrap()))
+            }
+            "WINDOWS_1251" | "CP1251" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1251").unwrap()))
+            }
+            "WINDOWS_1252" | "CP1252" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1252").unwrap()))
+            }
+            "WINDOWS_1253" | "CP1253" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1253").unwrap()))
+            }
+            "WINDOWS_1254" | "CP1254" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1254").unwrap()))
+            }
+            "WINDOWS_1255" | "CP1255" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1255").unwrap()))
+            }
+            "WINDOWS_1256" | "CP1256" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1256").unwrap()))
+            }
+            "WINDOWS_1257" | "CP1257" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1257").unwrap()))
+            }
+            "WINDOWS_1258" | "CP1258" => {
+                Ok(Encoding::NamedByte(named_byte_index("Windows_1258").unwrap()))
+            }
+            "IBM437" | "CP437" => Ok(Encoding::NamedByte(named_byte_index("IBM437").unwrap())),
+            "IBM737" | "CP737" => Ok(Encoding::NamedByte(named_byte_index("IBM737").unwrap())),
+            "IBM775" | "CP775" => Ok(Encoding::NamedByte(named_byte_index("IBM775").unwrap())),
+            "IBM850" | "CP850" => Ok(Encoding::NamedByte(named_byte_index("IBM850").unwrap())),
+            "IBM852" | "CP852" => Ok(Encoding::NamedByte(named_byte_index("IBM852").unwrap())),
+            "IBM855" | "CP855" => Ok(Encoding::NamedByte(named_byte_index("IBM855").unwrap())),
+            "IBM857" | "CP857" => Ok(Encoding::NamedByte(named_byte_index("IBM857").unwrap())),
+            "IBM860" | "CP860" => Ok(Encoding::NamedByte(named_byte_index("IBM860").unwrap())),
+            "IBM861" | "CP861" => Ok(Encoding::NamedByte(named_byte_index("IBM861").unwrap())),
+            "IBM862" | "CP862" => Ok(Encoding::NamedByte(named_byte_index("IBM862").unwrap())),
+            "IBM863" | "CP863" => Ok(Encoding::NamedByte(named_byte_index("IBM863").unwrap())),
+            "IBM864" | "CP864" => Ok(Encoding::NamedByte(named_byte_index("IBM864").unwrap())),
+            "IBM865" | "CP865" => Ok(Encoding::NamedByte(named_byte_index("IBM865").unwrap())),
+            "IBM866" | "CP866" => Ok(Encoding::NamedByte(named_byte_index("IBM866").unwrap())),
+            "IBM869" | "CP869" => Ok(Encoding::NamedByte(named_byte_index("IBM869").unwrap())),
+
+            // Byte encodings we still fold onto ASCII-8BIT without
+            // name preservation (dummy / stateful, or Mac* — kept as
+            // the prior behaviour to avoid ASCII-compat edge cases).
+            "EMACS_MULE" | "MACCYRILLIC" | "MACGREEK" | "MACICELAND" | "MACROMAN"
+            | "MACROMANIA" | "MACTHAI" | "MACTURKISH" | "MACUKRAINE" => Ok(Encoding::Ascii8),
 
             _ => Err(MonorubyErr::argumenterr(format!(
                 "unknown encoding name - {s}"
@@ -1213,7 +1337,8 @@ impl RStringInner {
             Encoding::Ascii8
             | Encoding::UsAscii
             | Encoding::Iso8859(_)
-            | Encoding::Other(_) => self.len(),
+            | Encoding::Other(_)
+            | Encoding::NamedByte(_) => self.len(),
             // UTF-16 / UTF-32 with one extra unit per broken trailing
             // byte. CRuby's `String#length` for these reports the
             // number of *complete* code units plus one per stray byte
@@ -1602,9 +1727,10 @@ impl RStringInner {
             CodeRange::Valid => match parent.encoding() {
                 // Single-byte encodings: every byte position is a
                 // character boundary; Valid trivially propagates.
-                Encoding::Ascii8 | Encoding::Iso8859(_) | Encoding::Other(_) => {
-                    CodeRange::Valid
-                }
+                Encoding::Ascii8
+                | Encoding::Iso8859(_)
+                | Encoding::Other(_)
+                | Encoding::NamedByte(_) => CodeRange::Valid,
                 // UTF-8: the cut points must land on character
                 // boundaries (a non-continuation byte or one-past-the-
                 // end). When both endpoints align, the byte sequence
@@ -1799,7 +1925,8 @@ impl RStringInner {
             Encoding::Ascii8
             | Encoding::UsAscii
             | Encoding::Iso8859(_)
-            | Encoding::Other(_) => Some(1),
+            | Encoding::Other(_)
+            | Encoding::NamedByte(_) => Some(1),
             Encoding::Utf16Le | Encoding::Utf16Be => Some(2),
             Encoding::Utf32Le | Encoding::Utf32Be => Some(4),
             // ISO-2022-JP still iterates byte-wise (stateful decode


### PR DESCRIPTION
## Summary

Works through failures in the ruby/spec `language` group. After these
changes the whole group runs with **no crashes and no timeouts** — every
file completes and is measured (previously two files aborted the process
and one hung the runner).

Three self-contained changes:

### 1. Fix two crashes (`b60b4ae`)
- **`predefined_spec.rb` SIGABRT** — in a nested `rescue`/`ensure` that
  re-raises with an outer exception pending, `err_reg` (the slot the
  exception dispatcher stashes the in-flight exception in, re-raised after
  the `ensure`) was allocated at the frame base but the no-match `ensure`
  body was emitted starting at `finish`, which could alias it. An `ensure`
  doing string work then overwrote the exception with a `String`, so the
  re-raise handed a non-exception value to `runtime::raise_err`, whose
  `None` arm was `unimplemented!()` — a panic that aborts across the
  `extern "C"` boundary. Emit the no-match `ensure` body above `err_reg`,
  and turn the `raise_err` `None` arm into an uncatchable `FatalError`.
- **`return_spec.rb` harness abort** — a bare top-level `return` in a
  `Thread.new { ... }` body performed a non-local return that escaped the
  block (monoruby runs thread bodies synchronously, so the home frame is
  live), corrupting mspec. Route the body through `Thread#__invoke_body`,
  which converts an escaping `MethodReturn` into `LocalJumpError`.

### 2. Magic-comment source encodings (`cc14e09`)
`language/magic_comment_spec.rb`: **46 failures + 2 errors → 4 failures + 2 errors.**
- Add an ASCII-compatible, name-preserving `Encoding::NamedByte` variant so
  national byte encodings (Big5, GBK, EUC-KR, Windows-125x, IBM/KOI8/…) keep
  their name instead of folding onto ASCII-8BIT — `# encoding: big5` now
  reports `__ENCODING__.name == "Big5"`.
- Replace prism's `magic_comments()` scan with `detect_source_encoding`,
  following CRuby's placement rules (first line, or second after a shebang;
  comment from its first token; case-insensitive `coding[:=]`, covering
  emacs `-*-` and vim `fileencoding=`).
- Read piped stdin as bytes with `from_utf8_lossy` so a non-UTF-8 script no
  longer aborts the process.

### 3. `Thread.pass` drives deferred thread bodies (`a776bdf`)
`Thread.new` runs blocks lazily, so `Thread.pass until flag` (flag set by a
thread body) hung forever and timed out `predefined_spec.rb`. Give `Thread`
a queue of not-yet-run threads and reopen `Thread.pass` to run the oldest
pending one before yielding. predefined_spec now runs to completion (172
examples) instead of hanging.

## Testing
- `cargo test -p monoruby --lib`: **1824 passed, 0 failed**. New regression
  tests cover the re-raise-through-ensure crash, the Thread `return`
  conversion, the named-byte encodings + magic-comment placement rules, and
  the `Thread.pass` cooperative-scheduling behavior.
- Full `language`-group re-run: **no crashes, no timeouts**; no per-file
  regressions vs. the pre-change baseline (the two previously-crashing files
  and the previously-hanging file now run and have their real results
  counted).

## Known follow-ups (out of scope here)
- Nested-`rescue` `$!` restoration (touches the exception-dispatch ABI).
- Thread-local `$_` / `$~` (some remaining predefined_spec failures).
- Byte-preserving source storage for non-UTF-8 literals (the 4 remaining
  magic_comment_spec failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1aGvxTwkuZLi47aWjWfZ)_