### PR TITLE
thread: make $~ / $_ thread-local in synchronously-run bodies

### DIFF
--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -21,18 +21,26 @@ pub(super) fn init(globals: &mut Globals) {
 ///
 /// ### Thread#__invoke_body(block, args)
 ///
-/// Runs a thread body block, translating a top-level non-local `return`
-/// into a `LocalJumpError`. Used by `Thread#__run` in startup.rb.
+/// Runs a thread body block. Used by `Thread#__run` in startup.rb. Emulates
+/// two thread semantics that monoruby's synchronous, single-threaded model
+/// would otherwise break:
 ///
-/// CRuby runs each thread on its own stack, so a `return` written directly
-/// in a `Thread.new { ... }` block has no enclosing method frame to return
-/// to and raises `LocalJumpError: unexpected return`. monoruby is
-/// single-threaded and runs thread bodies synchronously on the caller's
-/// stack (see `Thread#__run`), so the block's home frame is still live and
-/// the `return` would otherwise perform a real non-local return, escaping
-/// the thread body entirely (and, under mspec, corrupting the harness).
-/// Catch that escaping `MethodReturn` here and convert it, matching
-/// CRuby's observable behavior for the common (uncaught) case.
+/// 1. **`return` → `LocalJumpError`.** CRuby runs each thread on its own
+///    stack, so a `return` written directly in a `Thread.new { ... }` block
+///    has no enclosing method frame to return to and raises
+///    `LocalJumpError: unexpected return`. monoruby runs the body
+///    synchronously on the caller's stack, so the block's home frame is
+///    still live and the `return` would otherwise perform a real non-local
+///    return, escaping the body (and, under mspec, corrupting the harness).
+///    Catch the escaping `MethodReturn` here and convert it.
+///
+/// 2. **Thread-local `$~` / `$_`.** These special variables are frame-local,
+///    stored on the block's lexical home method frame — which, run
+///    synchronously, is shared with the code that spawned the thread. Save
+///    that frame's svar container, run the body against a fresh (empty) one,
+///    and restore it, so the body's `$~` / `$_` neither leak out to nor
+///    inherit from the spawning thread (matching CRuby's thread-local
+///    semantics).
 #[monoruby_builtin]
 fn invoke_body(
     vm: &mut Executor,
@@ -42,7 +50,29 @@ fn invoke_body(
 ) -> Result<Value> {
     let block = Proc::new(lfp.arg(0));
     let args = lfp.arg(1).as_array();
-    match vm.invoke_proc(globals, &block, &args) {
+
+    // Isolate the block's home method frame's `$~`/`$_` container for the
+    // duration of the body (item 2 above). The saved container is kept
+    // reachable for the GC via the temp stack while it is off the frame.
+    let home_mfp = block.outer_lfp().map(|o| o.mfp());
+    let saved = home_mfp.and_then(|m| m.svar_slot_value());
+    if let Some(m) = home_mfp {
+        if let Some(s) = saved {
+            vm.temp_push(s);
+        }
+        m.restore_svar_slot(None);
+    }
+
+    let result = vm.invoke_proc(globals, &block, &args);
+
+    if let Some(m) = home_mfp {
+        m.restore_svar_slot(saved);
+        if saved.is_some() {
+            vm.temp_pop();
+        }
+    }
+
+    match result {
         Ok(v) => Ok(v),
         Err(err) if matches!(err.kind(), MonorubyErrKind::MethodReturn(..)) => {
             Err(MonorubyErr::localjumperr("unexpected return"))
@@ -165,6 +195,42 @@ mod tests {
             t.value
             Thread.pass
             n
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_body_special_vars_are_thread_local() {
+        // `$~` / `$_` are frame-local special variables; a thread body must
+        // not leak them to the thread that spawned it, and must start with a
+        // fresh (nil) view — matching CRuby's thread-local semantics.
+        // `$_` set in a body does not leak out.
+        run_test_once(
+            r#"
+            $_ = nil
+            running = false
+            thr = Thread.new { $_ = "line"; running = true }
+            Thread.pass until running
+            r = $_
+            thr.join
+            r
+            "#,
+        );
+        // `$~` set in a body does not disturb the outer match.
+        run_test_once(
+            r#"
+            "x" =~ /x/
+            before = $~[0]
+            Thread.new { "y" =~ /y/ }.join
+            [$~[0], before]
+            "#,
+        );
+        // The body sees a fresh `$_` (not the spawner's), and can still use
+        // `$~` / `$1` internally.
+        run_test_once(
+            r#"
+            $_ = "outer"
+            Thread.new { r = ("abc" =~ /(b)/; $1); [$_, r] }.value
             "#,
         );
     }

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -416,6 +416,24 @@ impl Lfp {
         self.set_svar_slot(val);
     }
 
+    /// Read **this** frame's raw `LFP_SVAR` slot (no outer-chain walk),
+    /// returning `None` for the zero "no container yet" sentinel. Unlike
+    /// [`Lfp::svar`] this does not walk to the LEP — pass a frame that is
+    /// already the method frame (e.g. from [`Lfp::mfp`]).
+    pub(crate) fn svar_slot_value(self) -> Option<Value> {
+        self.svar_slot()
+    }
+
+    /// Restore **this** frame's `LFP_SVAR` slot to a previously saved
+    /// value (or the zero "no container" sentinel when `val` is `None`).
+    /// Used to isolate `$~` / `$_` for a synchronously-run thread body
+    /// (see `builtins::thread::invoke_body`): the home method frame's
+    /// container is saved, cleared for the body, then restored here.
+    pub(crate) fn restore_svar_slot(self, val: Option<Value>) {
+        let raw = val.map(|v| v.id()).unwrap_or(0);
+        unsafe { *(self.sub(LFP_SVAR as _) as *mut u64) = raw }
+    }
+
     ///
     /// Read the **LEP's** `LFP_SVAR` slot — the `$~`/`$_` container
     /// (or `None` if no container has been allocated yet).


### PR DESCRIPTION
## Summary

`$~` and `$_` are frame-local special variables, stored on the block's
lexical home method frame. monoruby runs `Thread.new` bodies synchronously
(the block shares that home frame), so a body's `$~` / `$_` writes leaked to
the thread that spawned it, and the body saw the spawner's values rather
than a fresh nil — unlike CRuby, where they are thread-local.

```ruby
$_ = nil
Thread.new { $_ = "x" }.value
$_    # => nil (was "x")
```

## Approach

In `Thread#__invoke_body` (the synchronous body runner), save the home
method frame's svar container, clear it for the body, and restore it
afterward. The saved container is kept GC-reachable via the temp stack while
it is off the frame. Both `$~` and `$_` live in that one container, so this
isolates both — the body neither leaks out to nor inherits from the spawning
thread.

Adds `Lfp::svar_slot_value` / `Lfp::restore_svar_slot` helpers.

## Testing
- `cargo test -p monoruby --lib`: **1825 passed, 0 failed**. New regression
  test covers leak-out, no-inherit, and in-body use of `$~` / `$1`.
- `language/predefined_spec.rb`: the "`$_` is Thread-local" example now
  passes. Comparing the failing-example *sets* against master (the raw
  failure count fluctuates 82–85 due to pre-existing `ps` / `ruby_exe`
  subprocess flakiness), the only delta is that example flipping to pass —
  no `$~`/`$_`-related regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1aGvxTwkuZLi47aWjWfZ)_