### PR TITLE
runtime: gate destructuring #to_ary / #to_a on respond_to?

### DIFF
--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -509,10 +509,27 @@ pub(super) extern "C" fn expand_array(
     // expanded, `nil` or a missing `#to_ary` leaves `src` a scalar, and any
     // other result raises `TypeError`. Returns `None` (a null in `rax`) so
     // the VM / JIT error path fires.
+    //
+    // CRuby gates the `#to_ary` call on `respond_to?(:to_ary, true)` — the
+    // *dynamic* predicate, which a user may override — rather than a raw
+    // method-table lookup, so honour an overridden `respond_to?` here too.
     let src = if src.is_array_ty() {
         src
-    } else if let Some(func_id) = globals.check_method(src, IdentId::TO_ARY) {
-        match vm.invoke_func_inner(globals, func_id, src, &[], None, None) {
+    } else if match vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("respond_to?"),
+        src,
+        &[Value::symbol(IdentId::TO_ARY), Value::bool(true)],
+        None,
+        None,
+    ) {
+        Ok(v) => v.as_bool(),
+        Err(err) => {
+            vm.set_error(err);
+            return None;
+        }
+    } {
+        match vm.invoke_method_inner(globals, IdentId::TO_ARY, src, &[], None, None) {
             Ok(v) if v.is_array_ty() => v,
             Ok(v) if v.is_nil() => src,
             Ok(v) => {
@@ -1613,8 +1630,31 @@ pub(super) extern "C" fn to_a(
     if src.is_nil() {
         return Some(Value::array_empty());
     }
-    if let Some(func_id) = globals.check_method(src, IdentId::TO_A) {
-        let ary = vm.invoke_func(globals, func_id, src, &[], None, None)?;
+    // Like `#to_ary` destructuring above, CRuby gates the `#to_a` call on
+    // `respond_to?(:to_a, true)` (a user may override it), not a raw
+    // method-table lookup.
+    let responds = match vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("respond_to?"),
+        src,
+        &[Value::symbol(IdentId::TO_A), Value::bool(true)],
+        None,
+        None,
+    ) {
+        Ok(v) => v.as_bool(),
+        Err(err) => {
+            vm.set_error(err);
+            return None;
+        }
+    };
+    if responds {
+        let ary = match vm.invoke_method_inner(globals, IdentId::TO_A, src, &[], None, None) {
+            Ok(v) => v,
+            Err(err) => {
+                vm.set_error(err);
+                return None;
+            }
+        };
         if ary.is_array_ty() {
             Some(ary)
         } else if ary.is_nil() {
@@ -1624,7 +1664,6 @@ pub(super) extern "C" fn to_a(
             Some(Value::array1(src))
         } else {
             let src_class = src.class().get_name(&globals.store);
-            //let res_class = ary.class().get_name(&globals.store);
             vm.set_error(MonorubyErr::typeerr(format!(
                 "can't convert {src_class} into Array"
             )));

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -414,3 +414,40 @@ fn massign_respects_overridden_respond_to() {
         "class V; def to_a; [1, 2, 3]; end; end; a, b, c = *V.new; [a, b, c]",
     ]);
 }
+
+#[test]
+fn massign_to_ary_to_a_coercion_edge_cases() {
+    // Exercises the `#to_ary` / `#to_a` result handling in destructuring:
+    // a non-Array result raises TypeError, a raised error propagates, and a
+    // `nil` result leaves the value a scalar (`#to_ary`) or wraps it
+    // (`#to_a`).
+    // NOTE: `run_tests` concatenates every snippet into one program and runs
+    // it 25×, so each snippet must use a *distinct* class name — a reused
+    // class carrying an overridden (e.g. raising) `respond_to?` from one
+    // snippet would otherwise break another on the second iteration.
+    run_tests(&[
+        // `#to_ary` returning a non-Array -> TypeError.
+        r#"class ToAryNonArray; def to_ary; 5; end; end
+           begin; a, b = ToAryNonArray.new; :no_raise; rescue TypeError; :type_error; end"#,
+        // `#to_ary` raising -> the error propagates.
+        r#"class ToAryRaise; def to_ary; raise "boom"; end; end
+           begin; a, b = ToAryRaise.new; :no_raise; rescue => e; e.message; end"#,
+        // `#to_ary` returning nil -> the value stays a scalar.
+        r#"class ToAryNil; def to_ary; nil; end; end
+           a, b = ToAryNil.new; [a.class.name, b]"#,
+        // Splat `#to_a` returning a non-Array -> TypeError.
+        r#"class ToANonArray; def to_a; 5; end; end
+           begin; a, b = *ToANonArray.new; :no_raise; rescue TypeError; :type_error; end"#,
+        // Splat `#to_a` raising -> the error propagates.
+        r#"class ToARaise; def to_a; raise "boom2"; end; end
+           begin; a, b = *ToARaise.new; :no_raise; rescue => e; e.message; end"#,
+        // Splat `#to_a` returning nil -> the value is wrapped in `[value]`.
+        r#"class ToANil; def to_a; nil; end; end
+           a, b = *ToANil.new; [a.class.name, b]"#,
+        // A raising `respond_to?` propagates out of the destructure / splat.
+        r#"class RespToAryRaise; def respond_to?(m, i = false); raise "rr"; end; def to_ary; [1]; end; end
+           begin; a, b = RespToAryRaise.new; :no_raise; rescue => e; e.message; end"#,
+        r#"class RespToARaise; def respond_to?(m, i = false); raise "rr2"; end; def to_a; [1]; end; end
+           begin; a, b = *RespToARaise.new; :no_raise; rescue => e; e.message; end"#,
+    ]);
+}

--- a/monoruby/tests/mul_assign.rs
+++ b/monoruby/tests/mul_assign.rs
@@ -373,3 +373,44 @@ fn for_loop_destructuring_index() {
         "r = []; for a, b in [[1, 2], [3, 4]]; r << [a, b]; end; r",
     ]);
 }
+
+#[test]
+fn massign_respects_overridden_respond_to() {
+    // CRuby gates the `#to_ary` / `#to_a` coercion in destructuring on the
+    // dynamic `respond_to?(:to_ary, true)` / `respond_to?(:to_a, true)`
+    // predicate. An object whose `respond_to?` returns false must be left a
+    // scalar even if it defines `#to_ary` / `#to_a`.
+    run_tests(&[
+        // `respond_to?` false -> `#to_ary` not consulted, RHS stays scalar.
+        r#"
+        class X
+          def respond_to?(m, inc = false); false; end
+          def to_ary; raise "should not be called"; end
+        end
+        a, b, c = X.new
+        [a.class.name, b, c]
+        "#,
+        // `respond_to?` is called with (:to_ary, true) before `#to_ary`.
+        r#"
+        $log = []
+        class Z
+          def respond_to?(m, inc = false); $log << [m, inc]; super; end
+          def to_ary; $log << :to_ary; [10, 20]; end
+        end
+        a, b = Z.new
+        [$log, a, b]
+        "#,
+        // Splat consults `respond_to?(:to_a, true)`.
+        r#"
+        class W
+          def respond_to?(m, inc = false); false; end
+          def to_a; raise "should not be called"; end
+        end
+        a, b = *W.new
+        [a.class.name, b]
+        "#,
+        // A genuine `#to_ary` / `#to_a` still expands.
+        "class Y; def to_ary; [7, 8]; end; end; a, b = Y.new; [a, b]",
+        "class V; def to_a; [1, 2, 3]; end; end; a, b, c = *V.new; [a, b, c]",
+    ]);
+}


### PR DESCRIPTION
## Summary

Multiple assignment (`a, b = x`) and splat (`a, b = *x`) coerce a non-Array
value via `#to_ary` / `#to_a`. monoruby looked the method up directly in the
method table, but CRuby gates the call on the *dynamic* predicate
`respond_to?(:to_ary, true)` / `respond_to?(:to_a, true)` — which a user may
override. An object whose `respond_to?` returns `false` was therefore
coerced anyway, and an overridden `respond_to?` was never consulted.

```ruby
x = Object.new
def x.respond_to?(m, inc = false) = false
def x.to_ary = raise "never"
a, b = x     # => a = x, b = nil  (was: called #to_ary and raised)
```

## Approach

In `expand_array` / `to_a` (`codegen/runtime.rs`), call
`respond_to?(sym, true)` before invoking the conversion, mirroring the
existing pattern in `Array#==`. The value is left a scalar when the
predicate is false, and the conversion is dispatched dynamically when true.

## Testing
- `cargo test -p monoruby --lib`: **1826 passed, 0 failed**. New integration
  test in `tests/mul_assign.rs` covers false-`respond_to?`, call order
  (`respond_to?(:to_ary, true)` before `#to_ary`), splat `#to_a`, and the
  normal expansion paths.
- `language/variables_spec.rb`: **3 → 1 failure** (the two "does not call
  #to_ary / #to_a if #respond_to? returns false" examples now pass; the
  remaining failure is an unrelated verbose-mode warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1aGvxTwkuZLi47aWjWfZ)_