### PR TITLE
parser: honor `# frozen_string_literal: true` magic comment

### DIFF
--- a/monoruby/src/ast/source_info.rs
+++ b/monoruby/src/ast/source_info.rs
@@ -48,6 +48,11 @@ pub struct SourceInfo {
     /// Stored verbatim as written in the source so consumers can
     /// resolve aliases through their own normaliser.
     pub source_encoding: Option<String>,
+    /// Value of the `# frozen_string_literal:` magic comment, if present
+    /// (`None` = not specified → string literals are mutable, Ruby's
+    /// default). When `Some(true)`, every string literal in the file is a
+    /// shared, frozen, deduplicated object.
+    pub frozen_string_literal: Option<bool>,
 }
 
 impl Default for SourceInfo {
@@ -70,6 +75,7 @@ impl SourceInfo {
             code,
             line_offset: 0,
             source_encoding: None,
+            frozen_string_literal: None,
         }
     }
 
@@ -87,6 +93,7 @@ impl SourceInfo {
             code,
             line_offset,
             source_encoding: None,
+            frozen_string_literal: None,
         }
     }
 
@@ -95,6 +102,12 @@ impl SourceInfo {
     /// source encoding after the source has already been wrapped.
     pub fn with_source_encoding(mut self, enc: Option<String>) -> Self {
         self.source_encoding = enc;
+        self
+    }
+
+    /// Builder: attach the `# frozen_string_literal:` magic-comment value.
+    pub fn with_frozen_string_literal(mut self, frozen: Option<bool>) -> Self {
+        self.frozen_string_literal = frozen;
         self
     }
 

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1190,13 +1190,32 @@ impl<'a> BytecodeGen<'a> {
     }
 
 
+    /// Whether this file declared `# frozen_string_literal: true`, in which
+    /// case every string literal is emitted as a shared, frozen, interned
+    /// object rather than a per-execution mutable copy.
+    fn frozen_string_literal(&self) -> bool {
+        self.sourceinfo.frozen_string_literal == Some(true)
+    }
+
+    /// Emit a shared, frozen, deduplicated string literal for a
+    /// `# frozen_string_literal: true` file. Literals with identical
+    /// `(bytes, encoding)` resolve to the same object program-wide.
+    fn emit_frozen_interned(&mut self, dst: BcReg, bytes: &[u8], enc: crate::value::Encoding) {
+        let v = self.store.intern_frozen_str(bytes, enc);
+        self.emit(BytecodeInst::FrozenLiteral(dst, v), Loc::default());
+    }
+
     fn emit_string(&mut self, dst: BcReg, s: String) {
+        let enc = self.source_encoding();
+        if self.frozen_string_literal() {
+            self.emit_frozen_interned(dst, s.as_bytes(), enc);
+            return;
+        }
         // String literals become long-lived templates: `Literal`
         // dispatch `deep_copy`s the template into a fresh RValue on
         // every execution, and the clone preserves the template's
         // `cr`. Pre-classify here so each clone gets `cr` for free
         // instead of re-running classify on first use.
-        let enc = self.source_encoding();
         self.emit_literal(dst, Value::string_from_source_str(&s, enc));
     }
 
@@ -1219,6 +1238,10 @@ impl<'a> BytecodeGen<'a> {
         // invalid under the declared encoding `valid_encoding?` returns
         // false but byte-level operations still work, matching CRuby.
         let enc = self.source_encoding();
+        if self.frozen_string_literal() {
+            self.emit_frozen_interned(dst, &b, enc);
+            return;
+        }
         self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
     }
 
@@ -1231,6 +1254,10 @@ impl<'a> BytecodeGen<'a> {
     fn emit_encoded_string(&mut self, dst: BcReg, b: Vec<u8>, enc_name: &'static str) {
         let enc = crate::value::Encoding::try_from_str(enc_name)
             .unwrap_or(crate::value::Encoding::Utf8);
+        if self.frozen_string_literal() {
+            self.emit_frozen_interned(dst, &b, enc);
+            return;
+        }
         self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
     }
 

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -99,6 +99,14 @@ pub struct Store {
     /// `Executor::flush_compile_warnings` right after compilation, before
     /// the compiled code runs.
     pub(crate) compile_warnings: Vec<String>,
+    /// Intern pool for frozen string literals emitted under a
+    /// `# frozen_string_literal: true` file. Keyed by `(bytes, encoding)`
+    /// so literals with identical content share one shared, frozen object
+    /// across the whole program — including across `require`d files, since
+    /// `Store` outlives any single compilation. Matches CRuby's behaviour
+    /// where `"abc".equal?("abc")` is true under the magic comment. Rooted
+    /// for GC in [`Store::mark`].
+    frozen_str_pool: HashMap<(Vec<u8>, crate::value::Encoding), Value>,
 }
 
 impl std::ops::Deref for Store {
@@ -198,6 +206,7 @@ impl alloc::GC<RValue> for Store {
         self.iseqs.iter().for_each(|info| info.mark(alloc));
         self.constsite_info.iter().for_each(|info| info.mark(alloc));
         self.classes.table.iter().for_each(|info| info.mark(alloc));
+        self.frozen_str_pool.values().for_each(|v| v.mark(alloc));
     }
 }
 
@@ -215,7 +224,24 @@ impl Store {
             default_copy_hooks: None,
             method_cache: RefCell::new(GlobalMethodCache::default()),
             compile_warnings: vec![],
+            frozen_str_pool: HashMap::default(),
         }
+    }
+
+    ///
+    /// Intern a frozen string literal for a `# frozen_string_literal: true`
+    /// file. Returns the shared, frozen `Value` for `(bytes, enc)`, creating
+    /// and caching it on first use so identical literals (in the same or a
+    /// different file) resolve to the same object.
+    ///
+    pub(crate) fn intern_frozen_str(&mut self, bytes: &[u8], enc: crate::value::Encoding) -> Value {
+        if let Some(v) = self.frozen_str_pool.get(&(bytes.to_vec(), enc)) {
+            return *v;
+        }
+        let mut v = Value::string_from_source_bytes(bytes, enc);
+        v.set_frozen();
+        self.frozen_str_pool.insert((bytes.to_vec(), enc), v);
+        v
     }
 
     pub fn iseq(&self, func_id: FuncId) -> &ISeqInfo {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -211,6 +211,75 @@ fn parse_coding_directive(comment: &str) -> Option<String> {
     None
 }
 
+/// Detect a `# frozen_string_literal: true|false` magic comment.
+///
+/// Unlike the encoding directive (which CRuby honours only on the very
+/// first line), the `frozen_string_literal` pragma may appear on any of the
+/// leading comment lines — CRuby scans the contiguous comment block at the
+/// top of the file (after an optional shebang) and stops at the first line
+/// that is not a comment. Returns `Some(true)`/`Some(false)` for the last
+/// matching directive, or `None` when the pragma is absent.
+fn detect_frozen_string_literal(code: &[u8]) -> Option<bool> {
+    let mut result = None;
+    for (idx, line) in code.split(|&b| b == b'\n').enumerate() {
+        // Only ASCII whitespace may precede the `#`.
+        let mut i = 0;
+        while i < line.len() && matches!(line[i], b' ' | b'\t' | b'\r' | 0x0b | 0x0c) {
+            i += 1;
+        }
+        let rest = &line[i..];
+        // A shebang is allowed only on the first line and does not end the
+        // magic-comment block.
+        if idx == 0 && rest.starts_with(b"#!") {
+            continue;
+        }
+        match rest.strip_prefix(b"#") {
+            Some(comment) => {
+                if let Ok(s) = std::str::from_utf8(comment) {
+                    if let Some(v) = parse_frozen_directive(s) {
+                        result = Some(v);
+                    }
+                }
+            }
+            // First non-comment line (code or blank) ends the block.
+            None => break,
+        }
+    }
+    result
+}
+
+/// Scan a comment body for `frozen_string_literal` immediately followed
+/// (after optional blanks) by `:` or `=` and a `true`/`false` value.
+fn parse_frozen_directive(comment: &str) -> Option<bool> {
+    let lower = comment.to_ascii_lowercase();
+    let lb = lower.as_bytes();
+    let key = "frozen_string_literal";
+    let mut from = 0;
+    while let Some(off) = lower[from..].find(key) {
+        let mut j = from + off + key.len();
+        while j < lb.len() && matches!(lb[j], b' ' | b'\t') {
+            j += 1;
+        }
+        if j < lb.len() && matches!(lb[j], b':' | b'=') {
+            j += 1;
+            while j < lb.len() && matches!(lb[j], b' ' | b'\t') {
+                j += 1;
+            }
+            let start = j;
+            while j < lb.len() && (lb[j].is_ascii_alphanumeric() || lb[j] == b'_') {
+                j += 1;
+            }
+            match &lower[start..j] {
+                "true" => return Some(true),
+                "false" => return Some(false),
+                _ => {}
+            }
+        }
+        from += off + 1;
+    }
+    None
+}
+
 fn try_prism_inner(
     code: &str,
     path: PathBuf,
@@ -233,10 +302,12 @@ fn try_prism_inner(
     // only when the line is a comment from its first token. See
     // `detect_source_encoding`.
     let source_encoding: Option<String> = detect_source_encoding(code.as_bytes());
+    let frozen_string_literal: Option<bool> = detect_frozen_string_literal(code.as_bytes());
 
     let source_info: SourceInfoRef = std::rc::Rc::new(
         crate::ast::SourceInfo::new_eval(path, code.to_owned(), line_offset)
-            .with_source_encoding(source_encoding),
+            .with_source_encoding(source_encoding)
+            .with_frozen_string_literal(frozen_string_literal),
     );
 
     if let Some(diag) = result.errors().next() {
@@ -4514,6 +4585,26 @@ $1
             .to_owned()
     }
 
+    /// Under `# frozen_string_literal: true`, every string literal is a
+    /// shared frozen object, so two literals with the same content are
+    /// `equal?` (interned) and each is frozen.
+    #[test]
+    fn frozen_string_literal_interns_and_freezes() {
+        let (_g, val) = run_prism_source(
+            "# frozen_string_literal: true\n\"abc\".frozen? && \"abc\".equal?(\"abc\")\n",
+        );
+        assert_eq!(val, crate::Value::bool(true));
+    }
+
+    /// Without the pragma, literals stay mutable and each evaluation is a
+    /// fresh object.
+    #[test]
+    fn without_frozen_string_literal_literals_are_mutable() {
+        let (_g, val) =
+            run_prism_source("!\"abc\".frozen? && !\"abc\".equal?(\"abc\")\n");
+        assert_eq!(val, crate::Value::bool(true));
+    }
+
     /// `# encoding: binary` makes every string literal in the file
     /// ASCII-8BIT. Without honouring the comment, `pack`-style spec
     /// files (which all open with `# encoding: binary`) compare a
@@ -4597,6 +4688,48 @@ $1
         assert_eq!(detect_source_encoding(b"\n# encoding: big5\n"), None);
         assert_eq!(detect_source_encoding(b"1 + 1 # encoding: big5\n"), None);
         assert_eq!(detect_source_encoding(b"x = 1\n"), None);
+    }
+
+    /// `detect_frozen_string_literal` follows CRuby's magic-comment rules
+    /// for the `frozen_string_literal` pragma.
+    #[test]
+    fn frozen_string_literal_placement_rules() {
+        // Case-insensitive key, `:` or `=` separator, true/false values.
+        assert_eq!(parse_frozen_directive(" frozen_string_literal: true"), Some(true));
+        assert_eq!(parse_frozen_directive(" Frozen_String_Literal = FALSE"), Some(false));
+        // Missing or non-boolean value does not match.
+        assert_eq!(parse_frozen_directive(" frozen_string_literal:"), None);
+        assert_eq!(parse_frozen_directive(" frozen_string_literal: yes"), None);
+        // Key must be followed by `:`/`=`.
+        assert_eq!(parse_frozen_directive(" frozen_string_literal true"), None);
+
+        // First line, or after a shebang.
+        assert_eq!(
+            detect_frozen_string_literal(b"# frozen_string_literal: true\nx = 1\n"),
+            Some(true)
+        );
+        assert_eq!(
+            detect_frozen_string_literal(b"#!/usr/bin/ruby\n# frozen_string_literal: true\n"),
+            Some(true)
+        );
+        // May appear on a later comment line in the leading block (e.g.
+        // below an `# encoding:` directive).
+        assert_eq!(
+            detect_frozen_string_literal(
+                b"# encoding: euc-jp\n# frozen_string_literal: true\n\nx = 1\n"
+            ),
+            Some(true)
+        );
+        // Absent, or after the leading comment block, yields None.
+        assert_eq!(detect_frozen_string_literal(b"x = 1\n"), None);
+        assert_eq!(
+            detect_frozen_string_literal(b"\n# frozen_string_literal: true\n"),
+            None
+        );
+        assert_eq!(
+            detect_frozen_string_literal(b"x = 1\n# frozen_string_literal: true\n"),
+            None
+        );
     }
 
     /// `\xNN` byte escapes in a `# encoding: binary` source come out

--- a/monoruby/stdlib/stringio.rb
+++ b/monoruby/stdlib/stringio.rb
@@ -19,7 +19,7 @@ class StringIO
   # `close`d after the block returns (raising or not), and returns
   # the block's value. Without a block, returns a StringIO -- in
   # which case the caller is responsible for closing it.
-  def self.open(string = "", mode = "r+", &block)
+  def self.open(string = nil, mode = "r+", &block)
     io = new(string, mode)
     return io unless block
     begin
@@ -29,8 +29,21 @@ class StringIO
     end
   end
 
-  def initialize(string = "", mode = "r+")
-    @string = string.is_a?(String) ? string : string.to_s
+  def initialize(string = nil, mode = "r+")
+    # When no backing string is supplied, StringIO owns a fresh, mutable
+    # buffer. Under this file's `# frozen_string_literal: true` a bare
+    # `""` literal is the shared frozen object, so `#write` (which
+    # mutates `@string` in place) must start from an explicitly mutable
+    # string — hence `"".dup`. A caller-supplied string is used as-is,
+    # matching CRuby: writing through a StringIO mutates the original
+    # (and raises FrozenError if the caller passed a frozen string).
+    @string = if string.nil?
+      "".dup
+    elsif string.is_a?(String)
+      string
+    else
+      string.to_s
+    end
     @pos = 0
     @lineno = 0
     @closed_read = false
@@ -553,7 +566,7 @@ class StringIO
     when 'r'
       @closed_write = true
     when 'w', 'w+'
-      @string = "" if mode == 'w'
+      @string = "".dup if mode == 'w'
     when 'a', 'a+'
       @pos = @string.length
     when 'r+', 'r+b', 'rb+'


### PR DESCRIPTION
## Summary

String literals in a file that declares `# frozen_string_literal: true` now become shared, frozen, deduplicated objects, matching CRuby. This fixes the "with a magic frozen comment" section of ruby/spec's `language/string_spec.rb`.

Before, the pragma was a complete no-op:

```ruby
# frozen_string_literal: true
p "abc".frozen?          # => false (mono) / true (ruby)
p "abc".equal?("abc")    # => false (mono) / true (ruby)
```

Both now match CRuby, and interning holds across `require`d files.

## Implementation

- **`SourceInfo`** gains a `frozen_string_literal: Option<bool>` field, set by a new `detect_frozen_string_literal` scanner in the prism backend. Like the encoding directive it lives in the leading comment block (after an optional shebang), but — unlike encoding — it may appear on any of those comment lines (e.g. below an `# encoding:` line), matching CRuby.
- **`Store`** gains a `frozen_str_pool` interning table keyed by `(bytes, encoding)`, so identical literals share one frozen object across the whole program — including across `require`d files, since the pool outlives any single compilation. Rooted for GC in `Store::mark`. Keying on encoding keeps same-bytes/different-encoding literals distinct, as CRuby does.
- **`emit_string` / `emit_bytes` / `emit_encoded_string`** route through the pool (emitting `FrozenLiteral`) when the file declares the pragma, and keep the per-execution mutable-copy path otherwise.

## stringio.rb fix

The pragma is **per-file**, so honoring it also activates it in monoruby's own bundled stdlib stubs that declare it. `stringio.rb` declared the pragma but initialized its write buffer from a bare `""` literal and then mutated it in place — a latent bug masked while the pragma was a no-op (writes began raising `FrozenError`). StringIO now gets a fresh mutable buffer (`"".dup`) when it owns one (default construction and `'w'` truncation), matching CRuby, while still using a caller-supplied string as-is. The other pragma-bearing stubs already build mutable buffers via `.b` / `.dup` / `+"..."`.

## Testing

- New unit tests in `prism_backend`: `frozen_string_literal_placement_rules` (directive parsing + comment-block placement), `frozen_string_literal_interns_and_freezes`, `without_frozen_string_literal_literals_are_mutable`.
- All 5 `language/string_spec.rb` freeze-magic-comment fixtures now print `true` under monoruby (`one_literal`, `two_literals`, `across_files`, `across_files_no_comment`, `across_files_diff_enc`).
- Full `cargo test -p monoruby --lib` green (1830 passed) against CRuby 4.0.2. The stringio.rb fix restores `stringio_write`, kernel `puts`/`printf`/`sprintf` delegation, marshal, and hash-warning-capture tests that route through the StringIO `$stdout` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1aGvxTwkuZLi47aWjWfZ)_