### PR TITLE
bytecodegen: warn on duplicate hash keys across literal `**{...}` splats

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4124,10 +4124,19 @@ mod tests {
               !!(cap { eval("{100000000000000000000 => 1, 100000000000000000000 => 2}") } =~ /is duplicated/),
               # A runtime (non-literal) key never warns.
               cap { k = 1; eval("{k => 1, k => 2}", binding) }.empty?,
+              # A duplicate spanning a literal `**{...}` splat is detected
+              # (a compile-time check, so the splat operand's keys count).
+              !!(cap { eval("{a: 1, **{a: 2, b: 3, c: 1}, c: 3}") } =~ /key :a is duplicated/),
+              !!(cap { eval("{a: 1, **{a: 2, b: 3, c: 1}, c: 3}") } =~ /key :c is duplicated/),
+              # Nested literal splats are flattened recursively.
+              !!(cap { eval("{a: 1, **{a: 2, **{d: 5}}, **{d: 6}}") } =~ /key :d is duplicated/),
+              # A runtime `**h` splat is opaque: no compile-time warning.
+              cap { h = {a: 2}; eval("{a: 1, **h}", binding) }.empty?,
               # No duplicate: no warning.
               cap { eval("{a: 1, b: 2}") }.empty?,
               # The overwrite still happens (last value wins).
               eval("{a: 1, a: 2}"),
+              eval("{a: 1, **{a: 2, b: 3, c: 1}, c: 3}"),
             ]
             "#,
         );

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1689,7 +1689,7 @@ impl<'a> BytecodeGen<'a> {
         splat: Vec<(usize, Node)>,
         loc: Loc,
     ) -> Result<()> {
-        self.warn_duplicated_hash_keys(&nodes);
+        self.warn_duplicated_hash_keys(&nodes, &splat);
         if splat.is_empty() {
             if nodes.len() <= LITERAL_CHUNK_LEN {
                 let len = nodes.len();
@@ -1818,41 +1818,82 @@ impl<'a> BytecodeGen<'a> {
     /// through `$stderr` by `Executor::flush_compile_warnings` once
     /// compilation finishes.
     ///
-    fn warn_duplicated_hash_keys(&mut self, nodes: &[(Node, Node)]) {
+    fn warn_duplicated_hash_keys(&mut self, nodes: &[(Node, Node)], splat: &[(usize, Node)]) {
         use std::sync::atomic::Ordering;
         if crate::globals::WARNING.load(Ordering::Relaxed) == 0 {
             return;
         }
+        // Flatten the literal's statically-known keys into source order,
+        // descending into `**{...}` splats whose operand is itself a
+        // literal hash, then warn on every re-occurrence.
+        let mut keys: Vec<(String, String, Loc)> = vec![];
+        Self::collect_hash_literal_keys(nodes, splat, &mut keys);
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (eq, inspect, loc) in keys {
+            if !seen.insert(eq) {
+                let line = self.sourceinfo.get_line(&loc);
+                let msg = format!(
+                    "{}:{}: warning: key {} is duplicated and overwritten on line {}",
+                    self.sourceinfo.path.to_string_lossy(),
+                    line,
+                    inspect,
+                    line,
+                );
+                self.store.compile_warnings.push(msg);
+            }
+        }
+    }
+
+    ///
+    /// Collect a hash literal's *statically known* keys into `out` in
+    /// source order. Descends into `**{...}` splats whose operand is
+    /// itself a literal hash (recursively), so a duplicate spanning a
+    /// literal splat (`{a: 1, **{a: 2}}`) is detected — matching CRuby's
+    /// compile-time check. Runtime splats (`**h`) and runtime-computed
+    /// keys (`{k => 1}`) are opaque and contribute nothing.
+    ///
+    /// `splat[j].0` is the number of ordinary pairs that precede splat
+    /// `j`, so the source order is
+    ///   pairs[0..p0], splat0, pairs[p0..p1], splat1, …, trailing pairs
+    /// — the same interleaving `gen_hash` replays.
+    ///
+    fn collect_hash_literal_keys(
+        nodes: &[(Node, Node)],
+        splat: &[(usize, Node)],
+        out: &mut Vec<(String, String, Loc)>,
+    ) {
+        // (equality key, inspect string)
         fn literal_key(kind: &NodeKind) -> Option<(String, String)> {
-            // (equality key, inspect string)
             match kind {
                 NodeKind::Symbol(s) => Some((format!("sym:{s}"), format!(":{s}"))),
                 NodeKind::String(s) => Some((format!("str:{s}"), format!("{s:?}"))),
                 NodeKind::Integer(i) => Some((format!("int:{i}"), format!("{i}"))),
                 NodeKind::Bignum(n) => Some((format!("int:{n}"), format!("{n}"))),
-                NodeKind::Float(f) => {
-                    Some((format!("flt:{f}"), crate::value::ruby_float_to_s(*f)))
-                }
+                NodeKind::Float(f) => Some((format!("flt:{f}"), crate::value::ruby_float_to_s(*f))),
                 NodeKind::Bool(b) => Some((format!("bool:{b}"), format!("{b}"))),
                 NodeKind::Nil => Some(("nil".to_string(), "nil".to_string())),
                 _ => None,
             }
         }
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for (k, _) in nodes {
-            if let Some((eq, inspect)) = literal_key(&k.kind) {
-                if !seen.insert(eq) {
-                    let line = self.sourceinfo.get_line(&k.loc);
-                    let msg = format!(
-                        "{}:{}: warning: key {} is duplicated and overwritten on line {}",
-                        self.sourceinfo.path.to_string_lossy(),
-                        line,
-                        inspect,
-                        line,
-                    );
-                    self.store.compile_warnings.push(msg);
+        let mut pi = 0usize;
+        for (pos, snode) in splat {
+            while pi < *pos && pi < nodes.len() {
+                let k = &nodes[pi].0;
+                if let Some((eq, inspect)) = literal_key(&k.kind) {
+                    out.push((eq, inspect, k.loc));
                 }
+                pi += 1;
             }
+            if let NodeKind::Hash(inner, inner_splat) = &snode.kind {
+                Self::collect_hash_literal_keys(inner, inner_splat, out);
+            }
+        }
+        while pi < nodes.len() {
+            let k = &nodes[pi].0;
+            if let Some((eq, inspect)) = literal_key(&k.kind) {
+                out.push((eq, inspect, k.loc));
+            }
+            pi += 1;
         }
     }
 


### PR DESCRIPTION
## Summary

CRuby's compile-time `key ... is duplicated and overwritten` warning fires not only for repeated ordinary keys (`{a: 1, a: 2}`) but also when a duplicate spans a **literal** hash splat:

```ruby
{a: 1, **{a: 2, b: 3, c: 1}, c: 3}   # warns for :a AND :c
{a: 2, b: 3, c: 1}; {a: 1, **h, c: 3}  # **h is opaque → no warning
```

Because the `**{...}` operand's keys are known statically, CRuby folds them into the compile-time check; a variable splat (`**h`) stays opaque and never warns.

monoruby only examined the ordinary key/value pairs, so any duplicate involving a `**{...}` operand went unwarned.

## Fix

Extend `warn_duplicated_hash_keys` (in `bytecodegen/expression.rs`) to flatten the literal's statically-known keys into source order via a new `collect_hash_literal_keys` helper that descends **recursively** into `**{...}` splats whose operand is itself a literal hash (nested splats included), then warns on every re-occurrence. The interleaving mirrors the one `gen_hash` already replays (`splat[j].0` = number of preceding ordinary pairs). Runtime splats (`**h`) and runtime-computed keys (`{k => 1}`) remain opaque, matching CRuby's compile-time-only check.

## Testing

- `language/hash_spec.rb`: **3 → 0 failures** (the duplicate-key-via-splat examples), 40 examples all green.
- Extended the `hash_literal_duplicated_key_warning` lib test with literal-splat, recursively-nested-splat, and variable-splat (no-warn) cases.
- Full `cargo test -p monoruby --lib`: **1830 passed, 0 failed** against CRuby 4.0.2.

Verified message-for-message equality with CRuby on all three spec cases plus the variable-splat no-warn case and the plain-duplicate regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1aGvxTwkuZLi47aWjWfZ)_