### PR TITLE
Implement flip-flops, BEGIN/END semantics, and CRuby-compatible predefined globals (ruby/spec language: 182 → 115 failures)

### DIFF
--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -234,6 +234,10 @@ impl Executor {
         globals.set_gvar(IdentId::get_id("$VERBOSE"), verbose);
         globals.alias_global_variable(IdentId::get_id("$-v"), IdentId::get_id("$VERBOSE"));
         globals.alias_global_variable(IdentId::get_id("$-w"), IdentId::get_id("$VERBOSE"));
+        // `$DEBUG` defaults to false (monoruby has no `-d` switch);
+        // `$-d` is its alias.
+        globals.set_gvar(IdentId::get_id("$DEBUG"), Value::bool(false));
+        globals.alias_global_variable(IdentId::get_id("$-d"), IdentId::get_id("$DEBUG"));
         let mut executor = Self::default();
         // Bring-up/testing aid (used by the in-progress aarch64 VM port): skip
         // loading startup.rb + gems so a trivial program can exercise the VM
@@ -2754,7 +2758,7 @@ impl Executor {
 
     /// Write `$~` (a MatchData `Value` or nil) into the current MFP's
     /// svar container.
-    fn set_backref(&mut self, val: Value) {
+    pub(crate) fn set_backref(&mut self, val: Value) {
         if let Some(c) = self.svar_container_create() {
             c.as_array()[SVAR_BACKREF] = val;
         }

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -519,19 +519,39 @@ impl Executor {
     /// blocks are Procs, finalizers may be any callable (Proc, Method, or
     /// an object with `call`). Finalizers receive the object's id.
     ///
-    /// Errors raised inside a handler do not abort the remaining ones:
-    /// a `SystemExit` (`exit` called from within a handler) is swallowed,
-    /// and any other exception is reported as a warning when `$VERBOSE`
-    /// is not `nil`, then execution continues with the next handler.
-    pub(crate) fn run_exit_handlers(&mut self, globals: &mut Globals) {
+    /// Errors raised inside a handler do not abort the remaining ones,
+    /// but they do affect the process exit status, which is what the
+    /// returned value reports (`None` = leave the script's own status
+    /// alone):
+    ///
+    /// - `SystemExit` (`exit` called from within a handler) makes its
+    ///   status the process exit status, overriding the main script's.
+    /// - Any other exception is printed like an uncaught exception, is
+    ///   exposed as `$!` to the handlers that run after it, and makes
+    ///   the process fail with status 1 (unless a `SystemExit` chose a
+    ///   status explicitly).
+    pub(crate) fn run_exit_handlers(&mut self, globals: &mut Globals) -> Option<i32> {
         if globals.at_exit_handlers.is_empty() && globals.finalizers.is_empty() {
-            return;
+            return None;
         }
         let call = IdentId::get_id("call");
+        let mut status_override = None;
+        let mut handler_failed = false;
         // at_exit handlers run in reverse registration order.
         while let Some(handler) = globals.at_exit_handlers.pop() {
             if let Err(err) = self.invoke_method_inner(globals, call, handler, &[], None, None) {
-                self.report_exit_handler_error(globals, err, "at_exit");
+                if let MonorubyErrKind::SystemExit(status) = err.kind() {
+                    status_override = Some(*status as i32);
+                    continue;
+                }
+                err.show_error_message_and_all_loc(&globals.store);
+                // Expose the exception as `$!` to the remaining
+                // handlers (mirrors CRuby, and is what the
+                // `$!.message` at_exit specs rely on).
+                self.set_error(err);
+                let err_val = self.take_ex_obj(globals);
+                globals.set_gvar(IdentId::get_id("$!"), err_val);
+                handler_failed = true;
             }
         }
         // Finalizers run last. Draining the vector (rather than iterating a
@@ -540,15 +560,16 @@ impl Executor {
         while let Some((id, callable)) = globals.finalizers.pop() {
             let arg = Value::integer(id as i64);
             if let Err(err) = self.invoke_method_inner(globals, call, callable, &[arg], None, None) {
-                self.report_exit_handler_error(globals, err, "finalizer");
+                self.report_finalizer_error(globals, err);
             }
         }
+        status_override.or(if handler_failed { Some(1) } else { None })
     }
 
-    /// Report (or swallow) an error escaping an `at_exit`/finalizer handler.
-    fn report_exit_handler_error(&mut self, globals: &mut Globals, err: MonorubyErr, kind: &str) {
-        // `exit` from within a handler simply stops that handler; the
-        // remaining handlers still run.
+    /// Report (or swallow) an error escaping an `ObjectSpace` finalizer.
+    fn report_finalizer_error(&mut self, globals: &mut Globals, err: MonorubyErr) {
+        // `exit` from within a finalizer simply stops that finalizer;
+        // the remaining ones still run.
         if matches!(err.kind(), MonorubyErrKind::SystemExit(_)) {
             return;
         }
@@ -558,7 +579,7 @@ impl Executor {
             .get_gvar(IdentId::get_id("$VERBOSE"))
             .is_some_and(|v| !v.is_nil());
         if verbose {
-            let msg = format!("warning: Exception in {kind}: {}", err.message());
+            let msg = format!("warning: Exception in finalizer: {}", err.message());
             let _ = self.ruby_warn(globals, &msg);
         }
     }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -669,7 +669,7 @@ impl Globals {
         // exception — CRuby runs both on any normal-ish termination.
         // `Kernel#exit!` / `Process.exit!` bypass this by calling
         // `std::process::exit` directly and never returning here.
-        executor.run_exit_handlers(self);
+        let handler_status = executor.run_exit_handlers(self);
         let _ = self.flush_stdout();
         #[cfg(any(feature = "profile", feature = "jit-log"))]
         self.show_stats();
@@ -688,7 +688,25 @@ impl Globals {
                 eprintln!("active pages:            {}", alloc.pages_len());
             });
         }
-        res
+        // An exit status chosen by the handlers themselves (a
+        // `SystemExit` raised in one, or status 1 after an uncaught
+        // handler exception) overrides the script's own. The script's
+        // non-SystemExit error is still reported first, as CRuby
+        // prints both.
+        match handler_status {
+            Some(status) => {
+                if let Err(err) = res
+                    && !matches!(err.kind(), MonorubyErrKind::SystemExit(_))
+                {
+                    err.show_error_message_and_all_loc(&self.store);
+                }
+                Err(MonorubyErr::new(
+                    MonorubyErrKind::SystemExit(status as u8),
+                    "exit",
+                ))
+            }
+            None => res,
+        }
     }
 
     pub(crate) fn compile_script_eval(

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -162,6 +162,7 @@ impl GvarTable {
         name: IdentId,
         val: Value,
     ) -> Result<()> {
+        let val = write_special_check(vm, globals, name, val)?;
         // Intern the entry first so we can assign to plain globals without
         // going through the hook path.
         let id = globals.gvars.entry_id(name);
@@ -175,8 +176,7 @@ impl GvarTable {
             GvarEntry::Hooked { setter, .. } => match *setter {
                 Some(setter) => setter(vm, globals, name, val),
                 None => Err(MonorubyErr::nameerr(format!(
-                    "can't set variable {}",
-                    name
+                    "{name} is a read-only variable"
                 ))),
             },
         }
@@ -268,6 +268,118 @@ impl GvarTable {
     }
 }
 
+/// CRuby installs setter hooks on a number of special globals that
+/// validate or coerce the assigned value, or reject the write outright.
+/// monoruby keeps most of them as plain [`GvarEntry::Simple`] storage
+/// because Rust-side writers update them through `set_simple` (which
+/// must stay hook-free), so the Ruby-level assignment path applies the
+/// equivalent checks by name here instead. Returns the (possibly
+/// coerced) value to store.
+fn write_special_check(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    name: IdentId,
+    val: Value,
+) -> Result<Value> {
+    /// `$/`-style setter (Ruby 4.0 semantics): the value must be a
+    /// String or nil. Unless it is already a frozen bare String, it is
+    /// replaced by a frozen plain-String copy (subclass and instance
+    /// variables are dropped, like CRuby's `rb_str_new_frozen`).
+    fn frozen_string_or_nil(name: &str, val: Value) -> Result<Value> {
+        if val.is_nil() {
+            return Ok(val);
+        }
+        let Some(s) = val.is_rstring_inner() else {
+            return Err(MonorubyErr::typeerr(format!(
+                "value of {name} must be String"
+            )));
+        };
+        if val.is_frozen() && val.class() == STRING_CLASS {
+            return Ok(val);
+        }
+        let mut v = Value::string_from_inner(s.clone());
+        v.set_frozen();
+        Ok(v)
+    }
+
+    let n = name.get_name();
+    match n.as_str() {
+        // Read-only variables backed by plain storage: `$?` is updated
+        // from Rust via `set_simple` (which bypasses this check), the
+        // others have no writer at all. `$!` is read-only in CRuby
+        // too, but monoruby's rescue bookkeeping bytecode stores to it
+        // through this path, so it cannot be listed.
+        "$?" | "$<" | "$FILENAME" => Err(MonorubyErr::nameerr(format!(
+            "{n} is a read-only variable"
+        ))),
+        // The input record separator: String or nil, stored as a
+        // frozen plain-String copy. `$-0` is an alias of `$/`
+        // (registered in `init_builtin_gvars`), but the alias name
+        // still reaches this check, so match it too for the error
+        // message's sake.
+        "$/" | "$-0" => frozen_string_or_nil(&n, val),
+        // Output record / field separators: String or nil, stored
+        // as-is (CRuby does not copy these).
+        "$\\" | "$," => {
+            if val.is_nil() || val.is_rstring().is_some() {
+                Ok(val)
+            } else {
+                Err(MonorubyErr::typeerr(format!(
+                    "value of {n} must be String"
+                )))
+            }
+        }
+        // The input field separator additionally accepts a Regexp.
+        "$;" => {
+            if val.is_nil() || val.is_rstring().is_some() || val.is_regex().is_some() {
+                Ok(val)
+            } else {
+                Err(MonorubyErr::typeerr(format!(
+                    "value of {n} must be String or Regexp"
+                )))
+            }
+        }
+        // `$.` (last input line number) coerces via `#to_int`.
+        "$." => Ok(Value::integer(val.coerce_to_int_i64(vm, globals)?)),
+        // `$stdout` / `$stderr` accept any object with a `write`
+        // method.
+        "$stdout" | "$stderr" => {
+            if globals
+                .store
+                .check_method_for_class(val.class(), IdentId::get_id("write"))
+                .is_some()
+            {
+                Ok(val)
+            } else {
+                Err(MonorubyErr::typeerr(format!(
+                    "{n} must have write method, {} given",
+                    val.get_real_class_name(&globals.store)
+                )))
+            }
+        }
+        // `$VERBOSE` normalizes any truthy assignment to `true`
+        // (nil and false are stored as-is).
+        "$VERBOSE" | "$-v" | "$-w" => Ok(if val.as_bool() {
+            Value::bool(true)
+        } else {
+            val
+        }),
+        // `$0` requires a String.
+        "$0" | "$PROGRAM_NAME" => {
+            if val.is_rstring().is_some() {
+                Ok(val)
+            } else {
+                Err(MonorubyErr::no_implicit_conversion(
+                    &globals.store,
+                    val,
+                    STRING_CLASS,
+                ))
+            }
+        }
+        _ => Ok(val),
+    }
+}
+
 ///
 /// Register hook-based special variables at `Globals::new` time.
 ///
@@ -292,17 +404,29 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
 
     fn set_match_data(
         vm: &mut Executor,
-        _globals: &mut Globals,
+        globals: &mut Globals,
         _name: IdentId,
         val: Value,
     ) -> Result<()> {
-        // CRuby only allows `$~ = nil | MatchData`. We mirror the previous
-        // behaviour: nil clears the capture state, anything else is a no-op
-        // for now (see TODO in original runtime::set_special_var).
+        // CRuby only allows `$~ = nil | MatchData`: nil clears the
+        // capture state, a MatchData replaces it (so the derived
+        // globals `$&`, `$1`, ... immediately reflect it), anything
+        // else is a TypeError.
         if val.is_nil() {
             vm.clear_capture_special_variables();
+            Ok(())
+        } else if val
+            .try_rvalue()
+            .is_some_and(|rv| rv.ty() == ObjTy::MATCHDATA)
+        {
+            vm.set_backref(val);
+            Ok(())
+        } else {
+            Err(MonorubyErr::typeerr(format!(
+                "wrong argument type {} (expected MatchData)",
+                val.get_real_class_name(&globals.store)
+            )))
         }
-        Ok(())
     }
 
     // $&, $', $`, $1..$N are derived from $~ and CRuby parses them as
@@ -420,8 +544,9 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
         get_load_path_hook,
         None,
     );
-    // `$:` is an alias of `$LOAD_PATH`.
+    // `$:` and `$-I` are aliases of `$LOAD_PATH`.
     globals.alias_global_variable(IdentId::get_id("$:"), IdentId::get_id("$LOAD_PATH"));
+    globals.alias_global_variable(IdentId::get_id("$-I"), IdentId::get_id("$LOAD_PATH"));
 
     // --- Loaded features ----------------------------------------------------
 
@@ -448,8 +573,83 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     // `$/` (the input record separator, used as the default argument of
     // `String#chomp`, `IO#gets`, `String#lines`, …) defaults to "\n" in
     // CRuby. It is a plain, assignable global; seed the default value so
-    // reads return "\n" before any assignment.
-    globals.set_gvar(IdentId::get_id("$/"), Value::string_from_str("\n"));
+    // reads return "\n" before any assignment. `$-0` is its alias.
+    let mut sep = Value::string_from_str("\n");
+    sep.set_frozen();
+    globals.set_gvar(IdentId::get_id("$/"), sep);
+    globals.alias_global_variable(IdentId::get_id("$-0"), IdentId::get_id("$/"));
+
+    // --- Exception backtrace --------------------------------------------------
+
+    // `$@` delegates to `$!`: reading returns `$!.backtrace` (nil when
+    // no exception is set), writing calls `$!.set_backtrace` (which
+    // validates the value) and raises ArgumentError when `$!` is not
+    // set. CRuby reports `defined?($@)` as "global-variable"
+    // unconditionally, so the getter always returns `Some`.
+    fn get_errinfo_backtrace(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        let err = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+        if err.is_nil() {
+            return Some(Value::nil());
+        }
+        match vm.invoke_method_simple(globals, IdentId::get_id("backtrace"), err, &[]) {
+            Some(v) => Some(v),
+            None => {
+                // Don't leave a pending error behind a plain read.
+                let _ = vm.take_error();
+                Some(Value::nil())
+            }
+        }
+    }
+
+    fn set_errinfo_backtrace(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        _name: IdentId,
+        val: Value,
+    ) -> Result<()> {
+        let err = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+        if err.is_nil() {
+            return Err(MonorubyErr::argumenterr("$! not set"));
+        }
+        match vm.invoke_method_simple(globals, IdentId::get_id("set_backtrace"), err, &[val]) {
+            Some(_) => Ok(()),
+            None => Err(vm.take_error()),
+        }
+    }
+
+    globals.define_hooked_variable(
+        IdentId::get_id("$@"),
+        get_errinfo_backtrace,
+        Some(set_errinfo_backtrace),
+    );
+
+    // `$.` (last input line number) defaults to 0 in CRuby. Seeding it
+    // matters beyond fidelity: its Ruby-level setter coerces with
+    // `#to_int`, and code like rubygems' StubSpecification saves and
+    // restores `$.` verbatim — a nil default would blow up the
+    // restore.
+    globals.set_gvar(IdentId::get_id("$."), Value::integer(0));
+
+    // --- Command-line flag mirrors -------------------------------------------
+
+    // `$-a`, `$-l`, `$-p` mirror the corresponding CLI switches, none of
+    // which monoruby implements, so they read as `false` and are
+    // read-only like in CRuby.
+    fn get_false(
+        _vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        Some(Value::bool(false))
+    }
+
+    for flag in ["$-a", "$-l", "$-p"] {
+        globals.define_hooked_variable(IdentId::get_id(flag), get_false, None);
+    }
 }
 
 // ============================================================================

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -520,6 +520,9 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::ArrayNode { .. } => self.lower_array(&node.as_array_node().unwrap())?,
             prism::Node::HashNode { .. } => self.lower_hash(&node.as_hash_node().unwrap())?,
             prism::Node::RangeNode { .. } => self.lower_range(&node.as_range_node().unwrap())?,
+            prism::Node::FlipFlopNode { .. } => {
+                self.lower_flip_flop(&node.as_flip_flop_node().unwrap())?
+            }
             prism::Node::ParenthesesNode { .. } => {
                 let inner = node.as_parentheses_node().unwrap();
                 match inner.body() {
@@ -1887,6 +1890,100 @@ impl<'pr> Lowerer<'pr> {
             },
             loc,
         })
+    }
+
+    /// Lower a flip-flop (`(a)..(b)` in a conditional) by desugaring
+    /// it into an `if` chain over a hidden global variable that
+    /// carries the per-site on/off state:
+    ///
+    /// ```text
+    /// if $__flip_flop_N          # currently on
+    ///   $__flip_flop_N = false if (b)
+    ///   true
+    /// elsif (a)                  # currently off, begin-condition hit
+    ///   $__flip_flop_N = <`..`: !(b), `...`: true>
+    ///   true
+    /// else
+    ///   false
+    /// end
+    /// ```
+    ///
+    /// Each lowered flip-flop draws a fresh id from a process-global
+    /// counter, so distinct sites — including re-`eval`s of the same
+    /// source — get independent state, while every evaluation of one
+    /// parsed site shares it (an unset global reads as nil = off).
+    /// CRuby instead keeps the state in the frame's special storage;
+    /// the observable difference (thread isolation) doesn't matter in
+    /// monoruby's single-threaded runtime.
+    fn lower_flip_flop(
+        &mut self,
+        node: &prism::FlipFlopNode<'pr>,
+    ) -> Result<Node, MonorubyErr> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT_FLIP_FLOP_ID: AtomicUsize = AtomicUsize::new(0);
+        let loc = location_to_loc(&node.location());
+        let state = format!(
+            "$__flip_flop_{}",
+            NEXT_FLIP_FLOP_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        let left = self.lower_flip_flop_operand(node.left(), loc)?;
+        let right = self.lower_flip_flop_operand(node.right(), loc)?;
+        let state_var = || Node::new_global_var(state.clone(), loc);
+        let set_state = |value: Node| Node::new_mul_assign(vec![state_var()], vec![value]);
+        // On: evaluate the end condition; a hit turns the flip-flop
+        // off after this (still truthy) evaluation.
+        let on_arm = Node::new_comp_stmt(
+            vec![
+                Node::new_if(
+                    right.clone(),
+                    set_state(Node::new_bool(false, loc)),
+                    Node::new_nil(loc),
+                    loc,
+                ),
+                Node::new_bool(true, loc),
+            ],
+            loc,
+        );
+        // Off + begin-condition hit: `..` also evaluates the end
+        // condition immediately (a simultaneous hit keeps it off),
+        // `...` defers it to the next evaluation.
+        let turn_on = if node.is_exclude_end() {
+            Node::new_bool(true, loc)
+        } else {
+            Node::new_unop(UnOp::Not, right, loc)
+        };
+        let off_arm = Node::new_if(
+            left,
+            Node::new_comp_stmt(vec![set_state(turn_on), Node::new_bool(true, loc)], loc),
+            Node::new_bool(false, loc),
+            loc,
+        );
+        Ok(Node::new_if(state_var(), on_arm, off_arm, loc))
+    }
+
+    /// A bare Integer literal as a flip-flop operand compares against
+    /// `$.` (the last input line number) in CRuby, not its own
+    /// truthiness. A missing operand can never hit (nil).
+    fn lower_flip_flop_operand(
+        &mut self,
+        node: Option<prism::Node<'pr>>,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        let Some(node) = node else {
+            return Ok(Node::new_nil(loc));
+        };
+        let lowered = self.lower_node(&node)?;
+        Ok(
+            if matches!(lowered.kind, NodeKind::Integer(_) | NodeKind::Bignum(_)) {
+                Node::new_binop(
+                    BinOp::Cmp(CmpKind::Eq),
+                    lowered,
+                    Node::new_global_var("$.".to_string(), loc),
+                )
+            } else {
+                lowered
+            },
+        )
     }
 
     /// Lower a `StatementsNode`-shaped body to ruruby-parse's compact

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -362,6 +362,27 @@ struct Lowerer<'pr> {
     /// frame instead of starting back at 1 inside the eval body.
     line_offset: i64,
     lvars: LvarCollector,
+    /// Number of prism scopes (program → def/class/block/lambda
+    /// nesting) currently entered. Maintained by
+    /// `enter_prism_scope` / `exit_prism_scope` and consumed by
+    /// `adjust_lvar_depth`.
+    prism_scope_level: u32,
+    /// Prism scope levels at which the lowerer synthesized a closure
+    /// scope prism doesn't know about (currently only the hidden
+    /// `at_exit` block wrapping an `END { ... }` body). A local
+    /// variable reference whose target scope lies at or outside such
+    /// a level must hop one extra scope per crossed wrap; the crossed
+    /// names are collected so the wrap site can anchor them in their
+    /// home scope.
+    scope_wraps: Vec<ScopeWrap>,
+}
+
+/// See [`Lowerer::scope_wraps`].
+struct ScopeWrap {
+    /// Prism scope level the wrap was inserted at.
+    level: u32,
+    /// Names of locals referenced across this wrap.
+    escaped: Vec<String>,
 }
 
 impl<'pr> Lowerer<'pr> {
@@ -372,7 +393,50 @@ impl<'pr> Lowerer<'pr> {
             source_info,
             line_offset: 0,
             lvars: LvarCollector::new(),
+            prism_scope_level: 0,
+            scope_wraps: Vec::new(),
         }
+    }
+
+    /// Enter a prism scope (def/class/block/lambda body): bumps the
+    /// scope level and hands out a fresh `LvarCollector`, returning
+    /// the outer one for `exit_prism_scope` to restore.
+    fn enter_prism_scope(&mut self) -> LvarCollector {
+        self.prism_scope_level += 1;
+        std::mem::take(&mut self.lvars)
+    }
+
+    /// Leave a prism scope: restores the outer `LvarCollector` and
+    /// returns the scope's own collector (used by block/def lowering
+    /// to attach it to the produced `BlockInfo`).
+    fn exit_prism_scope(&mut self, saved: LvarCollector) -> LvarCollector {
+        self.prism_scope_level -= 1;
+        std::mem::replace(&mut self.lvars, saved)
+    }
+
+    /// Translate a prism-reported local variable depth into a
+    /// monoruby-AST depth, adding one hop for every synthesized
+    /// closure scope (`scope_wraps`) between the reference and its
+    /// target scope. Every crossing is also recorded on the crossed
+    /// wraps so `lower_post_execution` can anchor the variable in its
+    /// home scope (bytecodegen materializes local slots lazily on
+    /// first depth-0 reference, which a variable only ever referenced
+    /// from inside the synthesized block would otherwise never get).
+    fn adjust_lvar_depth(&mut self, depth: usize, name: &str) -> usize {
+        if self.scope_wraps.is_empty() {
+            return depth;
+        }
+        let target = self.prism_scope_level - depth as u32;
+        let mut hops = 0;
+        for wrap in self.scope_wraps.iter_mut() {
+            if target <= wrap.level {
+                hops += 1;
+                if !wrap.escaped.iter().any(|n| n == name) {
+                    wrap.escaped.push(name.to_string());
+                }
+            }
+        }
+        depth + hops
     }
 
     fn into_lvars(self) -> LvarCollector {
@@ -427,7 +491,22 @@ impl<'pr> Lowerer<'pr> {
         // would have produced (bytecodegen reads `LvarCollector` to
         // assign register slots before walking the tree).
         self.collect_locals(&node.locals())?;
-        let stmts = self.lower_statements_into_vec(&node.statements())?;
+        // `BEGIN { ... }` blocks run before the rest of the code
+        // unit, in source order: CRuby hoists them to the top of the
+        // program, and their bodies share the toplevel scope, so
+        // simply lowering the hoisted statements first is enough.
+        let body = node.statements();
+        let mut stmts = Vec::new();
+        for n in body.body().iter() {
+            if n.as_pre_execution_node().is_some() {
+                stmts.push(self.lower_node(&n)?);
+            }
+        }
+        for n in body.body().iter() {
+            if n.as_pre_execution_node().is_none() {
+                stmts.push(self.lower_node(&n)?);
+            }
+        }
         Ok(Node {
             kind: NodeKind::CompStmt(stmts),
             loc,
@@ -555,13 +634,13 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::SingletonClassNode { .. } => {
                 let n = node.as_singleton_class_node().unwrap();
                 let singleton = self.lower_node(&n.expression())?;
-                let saved = std::mem::take(&mut self.lvars);
+                let saved = self.enter_prism_scope();
                 if let Err(e) = self.collect_locals(&n.locals()) {
-                    self.lvars = saved;
+                    self.exit_prism_scope(saved);
                     return Err(e);
                 }
                 let info_res = self.lower_class_body(n.body(), loc);
-                self.lvars = saved;
+                self.exit_prism_scope(saved);
                 let info = info_res?;
                 Node {
                     kind: NodeKind::SingletonClassDef {
@@ -748,11 +827,12 @@ impl<'pr> Lowerer<'pr> {
                 }
             }
             prism::Node::BeginNode { .. } => self.lower_begin(&node.as_begin_node().unwrap())?,
-            // `BEGIN { ... }` / `END { ... }`. Full Ruby semantics hoist
-            // the body before / after the program; for the common cases
-            // (notably `eval("BEGIN { ... }")`) lowering the body inline
-            // at its source position is sufficient and avoids the
-            // unsupported-node path entirely.
+            // `BEGIN { ... }`: hoisted to the top of the code unit by
+            // `lower_program`, so by the time this arm runs the node is
+            // already in first position and its body (which shares the
+            // toplevel scope) can be lowered inline. `END { ... }`
+            // registers its body as a once-only at_exit handler (see
+            // `lower_post_execution`).
             prism::Node::PreExecutionNode { .. } => {
                 let n = node.as_pre_execution_node().unwrap();
                 match n.statements() {
@@ -765,13 +845,7 @@ impl<'pr> Lowerer<'pr> {
             }
             prism::Node::PostExecutionNode { .. } => {
                 let n = node.as_post_execution_node().unwrap();
-                match n.statements() {
-                    Some(stmts) => self.lower_statements_compact(&stmts, loc)?,
-                    None => Node {
-                        kind: NodeKind::Nil,
-                        loc,
-                    },
-                }
+                self.lower_post_execution(&n, loc)?
             }
             prism::Node::MultiWriteNode { .. } => {
                 self.lower_multi_write(&node.as_multi_write_node().unwrap())?
@@ -779,7 +853,11 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::LocalVariableOperatorWriteNode { .. } => {
                 let n = node.as_local_variable_operator_write_node().unwrap();
                 let target = Node {
-                    kind: NodeKind::LocalVar(n.depth() as usize, constant_name(&n.name())?),
+                    kind: {
+                        let name = constant_name(&n.name())?;
+                        let depth = self.adjust_lvar_depth(n.depth() as usize, &name);
+                        NodeKind::LocalVar(depth, name)
+                    },
                     loc: location_to_loc(&n.name_loc()),
                 };
                 self.build_op_assign(target, &n.binary_operator(), &n.value(), loc)?
@@ -787,7 +865,11 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::LocalVariableOrWriteNode { .. } => {
                 let n = node.as_local_variable_or_write_node().unwrap();
                 let target = Node {
-                    kind: NodeKind::LocalVar(n.depth() as usize, constant_name(&n.name())?),
+                    kind: {
+                        let name = constant_name(&n.name())?;
+                        let depth = self.adjust_lvar_depth(n.depth() as usize, &name);
+                        NodeKind::LocalVar(depth, name)
+                    },
                     loc: location_to_loc(&n.name_loc()),
                 };
                 self.build_short_circuit_assign(BinOp::LOr, target, &n.value(), loc)?
@@ -795,7 +877,11 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::LocalVariableAndWriteNode { .. } => {
                 let n = node.as_local_variable_and_write_node().unwrap();
                 let target = Node {
-                    kind: NodeKind::LocalVar(n.depth() as usize, constant_name(&n.name())?),
+                    kind: {
+                        let name = constant_name(&n.name())?;
+                        let depth = self.adjust_lvar_depth(n.depth() as usize, &name);
+                        NodeKind::LocalVar(depth, name)
+                    },
                     loc: location_to_loc(&n.name_loc()),
                 };
                 self.build_short_circuit_assign(BinOp::LAnd, target, &n.value(), loc)?
@@ -1105,7 +1191,12 @@ impl<'pr> Lowerer<'pr> {
                     prism::Node::LocalVariableTargetNode { .. } => {
                         let inner = index.as_local_variable_target_node().unwrap();
                         (
-                            vec![(inner.depth() as usize, constant_name(&inner.name())?)],
+                            {
+                                let name = constant_name(&inner.name())?;
+                                let depth =
+                                    self.adjust_lvar_depth(inner.depth() as usize, &name);
+                                vec![(depth, name)]
+                            },
                             None,
                         )
                     }
@@ -1126,10 +1217,12 @@ impl<'pr> Lowerer<'pr> {
                             let mut out: Vec<(usize, String)> = Vec::new();
                             for tgt in mt.lefts().iter() {
                                 let inner = tgt.as_local_variable_target_node().unwrap();
-                                out.push((
-                                    inner.depth() as usize,
-                                    constant_name(&inner.name())?,
-                                ));
+                                out.push({
+                                    let name = constant_name(&inner.name())?;
+                                    let depth = self
+                                        .adjust_lvar_depth(inner.depth() as usize, &name);
+                                    (depth, name)
+                                });
                             }
                             (out, None)
                         } else {
@@ -1601,10 +1694,10 @@ impl<'pr> Lowerer<'pr> {
         }
     }
 
-    fn lower_local_var_read(&self, node: &LocalVariableReadNode<'pr>) -> Result<Node, MonorubyErr> {
+    fn lower_local_var_read(&mut self, node: &LocalVariableReadNode<'pr>) -> Result<Node, MonorubyErr> {
         let name = constant_name(&node.name())?;
         Ok(Node {
-            kind: NodeKind::LocalVar(node.depth() as usize, name),
+            kind: NodeKind::LocalVar(self.adjust_lvar_depth(node.depth() as usize, &name), name),
             loc: location_to_loc(&node.location()),
         })
     }
@@ -1614,7 +1707,7 @@ impl<'pr> Lowerer<'pr> {
         node: &LocalVariableWriteNode<'pr>,
     ) -> Result<Node, MonorubyErr> {
         let name = constant_name(&node.name())?;
-        let depth = node.depth() as usize;
+        let depth = self.adjust_lvar_depth(node.depth() as usize, &name);
         let target = Node {
             kind: NodeKind::LocalVar(depth, name),
             loc: location_to_loc(&node.name_loc()),
@@ -1986,6 +2079,95 @@ impl<'pr> Lowerer<'pr> {
         )
     }
 
+    /// Lower `END { body }`: register the body to run at process
+    /// exit, once per site even if the END statement is executed
+    /// repeatedly:
+    ///
+    /// ```text
+    /// unless $__end_block_N   # once-only gate, fresh id per site
+    ///   $__end_block_N = true
+    ///   at_exit { <body> }
+    /// end
+    /// ```
+    ///
+    /// CRuby compiles the body as a block sharing the enclosing
+    /// scope; the hidden `at_exit` block does the same, with the
+    /// `scope_wraps` bookkeeping re-aiming local variable references
+    /// across the synthesized closure scope (prism reports depths
+    /// that don't know about it).
+    fn lower_post_execution(
+        &mut self,
+        node: &prism::PostExecutionNode<'pr>,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT_END_BLOCK_ID: AtomicUsize = AtomicUsize::new(0);
+        let gate = format!(
+            "$__end_block_{}",
+            NEXT_END_BLOCK_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        self.scope_wraps.push(ScopeWrap {
+            level: self.prism_scope_level,
+            escaped: Vec::new(),
+        });
+        let body = match node.statements() {
+            Some(stmts) => self.lower_statements_compact(&stmts, loc),
+            None => Ok(Node::new_nil(loc)),
+        };
+        let escaped = self.scope_wraps.pop().unwrap().escaped;
+        let body = body?;
+        let block = Node::new(
+            NodeKind::Lambda(Box::new(BlockInfo::new(
+                Vec::new(),
+                body,
+                LvarCollector::new(),
+                loc,
+            ))),
+            loc,
+        );
+        let arglist = crate::ast::ArgList {
+            block: Some(Box::new(block)),
+            ..Default::default()
+        };
+        let register = Node::new_comp_stmt(
+            vec![
+                Node::new_mul_assign(
+                    vec![Node::new_global_var(gate.clone(), loc)],
+                    vec![Node::new_bool(true, loc)],
+                ),
+                Node::new_fcall("at_exit".to_string(), arglist, false, loc),
+                Node::new_nil(loc),
+            ],
+            loc,
+        );
+        let gated = Node::new_if(
+            Node::new_global_var(gate, loc),
+            Node::new_nil(loc),
+            register,
+            loc,
+        );
+        if escaped.is_empty() {
+            return Ok(gated);
+        }
+        // Anchor every local the body referenced across the wrap with
+        // a bare read at the END statement's position: bytecodegen
+        // materializes local slots lazily on first same-scope
+        // reference, and these variables' home scope is out here, not
+        // inside the hidden block. The reads evaluate to nil and are
+        // discarded. Re-adjusting the depth (0 = home scope in
+        // prism's model) also re-records the names on any still-open
+        // outer wrap, propagating anchors for nested END bodies.
+        let mut stmts: Vec<Node> = escaped
+            .into_iter()
+            .map(|name| {
+                let depth = self.adjust_lvar_depth(0, &name);
+                Node::new_lvar(name, depth, loc)
+            })
+            .collect();
+        stmts.push(gated);
+        Ok(Node::new_comp_stmt(stmts, loc))
+    }
+
     /// Lower a `StatementsNode`-shaped body to ruruby-parse's compact
     /// shape:
     ///
@@ -2041,7 +2223,7 @@ impl<'pr> Lowerer<'pr> {
         body: Option<prism::Node<'pr>>,
         loc: Loc,
     ) -> Result<BlockInfo, MonorubyErr> {
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         let body_res = self.lower_compact_body(body, loc);
         match body_res {
             Ok(body_inner) => {
@@ -2054,7 +2236,7 @@ impl<'pr> Lowerer<'pr> {
                     },
                     loc,
                 };
-                let class_lvars = std::mem::replace(&mut self.lvars, saved);
+                let class_lvars = self.exit_prism_scope(saved);
                 Ok(BlockInfo {
                     params: vec![],
                     body: Box::new(body),
@@ -2064,7 +2246,7 @@ impl<'pr> Lowerer<'pr> {
                 })
             }
             Err(e) => {
-                self.lvars = saved;
+                self.exit_prism_scope(saved);
                 Err(e)
             }
         }
@@ -2080,15 +2262,15 @@ impl<'pr> Lowerer<'pr> {
         // The class body's `locals` list lives on the ClassNode itself
         // (Prism scopes it to the class definition). Seed the lowerer
         // with those before lowering the body.
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         if let Err(e) = self.collect_locals(&node.locals()) {
-            self.lvars = saved;
+            self.exit_prism_scope(saved);
             return Err(e);
         }
         let info_res = self.lower_class_body(node.body(), loc);
         // `lower_class_body` already swapped lvars back — restore the
         // outer scope from `saved` here regardless of outcome.
-        self.lvars = saved;
+        self.exit_prism_scope(saved);
         let info = info_res?;
         Ok(Node {
             kind: NodeKind::ClassDef {
@@ -2105,13 +2287,13 @@ impl<'pr> Lowerer<'pr> {
     fn lower_module(&mut self, node: &ModuleNode<'pr>) -> Result<Node, MonorubyErr> {
         let loc = location_to_loc(&node.location());
         let (base, name) = self.split_class_path(&node.constant_path())?;
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         if let Err(e) = self.collect_locals(&node.locals()) {
-            self.lvars = saved;
+            self.exit_prism_scope(saved);
             return Err(e);
         }
         let info_res = self.lower_class_body(node.body(), loc);
-        self.lvars = saved;
+        self.exit_prism_scope(saved);
         let info = info_res?;
         Ok(Node {
             kind: NodeKind::ClassDef {
@@ -2760,7 +2942,11 @@ impl<'pr> Lowerer<'pr> {
             prism::Node::LocalVariableTargetNode { .. } => {
                 let n = node.as_local_variable_target_node().unwrap();
                 Node {
-                    kind: NodeKind::LocalVar(n.depth() as usize, constant_name(&n.name())?),
+                    kind: {
+                        let name = constant_name(&n.name())?;
+                        let depth = self.adjust_lvar_depth(n.depth() as usize, &name);
+                        NodeKind::LocalVar(depth, name)
+                    },
                     loc,
                 }
             }
@@ -3236,7 +3422,7 @@ impl<'pr> Lowerer<'pr> {
             None => None,
         };
 
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         let result =
             (|this: &mut Self| -> Result<(Vec<crate::ast::FormalParam>, Node), MonorubyErr> {
                 // Parameters first so the LvarCollector's special
@@ -3273,7 +3459,7 @@ impl<'pr> Lowerer<'pr> {
 
         match result {
             Ok((params, body)) => {
-                let method_lvars = std::mem::replace(&mut self.lvars, saved);
+                let method_lvars = self.exit_prism_scope(saved);
                 let info = Box::new(BlockInfo {
                     params,
                     body: Box::new(body),
@@ -3288,7 +3474,7 @@ impl<'pr> Lowerer<'pr> {
                 Ok(Node { kind, loc })
             }
             Err(e) => {
-                self.lvars = saved;
+                self.exit_prism_scope(saved);
                 Err(e)
             }
         }
@@ -3304,7 +3490,7 @@ impl<'pr> Lowerer<'pr> {
     /// proc depending on how it's used.
     fn lower_lambda(&mut self, node: &LambdaNode<'pr>) -> Result<Node, MonorubyErr> {
         let loc = location_to_loc(&node.location());
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         let result =
             (|this: &mut Self| -> Result<(Vec<crate::ast::FormalParam>, Node), MonorubyErr> {
                 let params = match node.parameters() {
@@ -3377,7 +3563,7 @@ impl<'pr> Lowerer<'pr> {
 
         match result {
             Ok((params, body)) => {
-                let lambda_lvars = std::mem::replace(&mut self.lvars, saved);
+                let lambda_lvars = self.exit_prism_scope(saved);
                 Ok(Node {
                     kind: NodeKind::Lambda(Box::new(BlockInfo {
                         params,
@@ -3390,7 +3576,7 @@ impl<'pr> Lowerer<'pr> {
                 })
             }
             Err(e) => {
-                self.lvars = saved;
+                self.exit_prism_scope(saved);
                 Err(e)
             }
         }
@@ -3402,7 +3588,7 @@ impl<'pr> Lowerer<'pr> {
         // and install a fresh table for the block body. The body
         // lowering is wrapped so an error inside it doesn't leak the
         // partially-built block scope into the outer lowerer.
-        let saved = std::mem::take(&mut self.lvars);
+        let saved = self.enter_prism_scope();
         let result =
             (|this: &mut Self| -> Result<(Vec<crate::ast::FormalParam>, Node), MonorubyErr> {
                 // Parameters first (see comment on the def-node lowerer for
@@ -3480,7 +3666,7 @@ impl<'pr> Lowerer<'pr> {
 
         match result {
             Ok((params, body)) => {
-                let block_lvars = std::mem::replace(&mut self.lvars, saved);
+                let block_lvars = self.exit_prism_scope(saved);
                 Ok(Node {
                     kind: NodeKind::Lambda(Box::new(BlockInfo {
                         params,
@@ -3493,7 +3679,7 @@ impl<'pr> Lowerer<'pr> {
                 })
             }
             Err(e) => {
-                self.lvars = saved;
+                self.exit_prism_scope(saved);
                 Err(e)
             }
         }

--- a/monoruby/tests/begin_end.rs
+++ b/monoruby/tests/begin_end.rs
@@ -1,0 +1,74 @@
+//! `BEGIN { ... }` / `END { ... }` semantics, which only fully
+//! materialize at process exit: run the same script under both the
+//! built monoruby binary and the host `ruby` and compare stdout,
+//! stderr, and exit status.
+
+use std::process::Command;
+
+fn run_both(script: &str) {
+    let mono = Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .args(["-e", script])
+        .output()
+        .unwrap();
+    let ruby = Command::new("ruby")
+        .args(["-e", script])
+        .output()
+        .unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&mono.stdout),
+        String::from_utf8_lossy(&ruby.stdout),
+        "stdout mismatch for {script:?}"
+    );
+    assert_eq!(
+        mono.status.code(),
+        ruby.status.code(),
+        "exit status mismatch for {script:?}"
+    );
+}
+
+#[test]
+fn begin_runs_first() {
+    run_both("puts 'main'; BEGIN { puts 'begin1' }; BEGIN { puts 'begin2' }");
+}
+
+#[test]
+fn begin_shares_toplevel_scope() {
+    run_both("a = 1; BEGIN { b = 2 }; p [a, b]");
+}
+
+#[test]
+fn end_runs_last_in_reverse_order() {
+    run_both("END { puts 'end1' }; at_exit { puts 'at_exit' }; END { puts 'end2' }; puts 'main'");
+}
+
+#[test]
+fn end_registers_once_per_site() {
+    run_both("3.times { END { puts 'once' } }");
+}
+
+#[test]
+fn end_shares_enclosing_scope() {
+    run_both("a = 1; END { p a; zz = 5 }; a = 42; at_exit { p defined?(zz) }");
+}
+
+#[test]
+fn end_nested_handler_runs_right_after_outer() {
+    run_both("END { puts :first }; END { puts :before; END { puts :nested }; puts :after }; END { puts :last }");
+}
+
+#[test]
+fn end_exit_in_handler_decides_exit_status() {
+    run_both("END { exit 43 }; exit 42");
+}
+
+#[test]
+fn end_handler_exception_sets_failure_status() {
+    // Backtrace formats differ, so only compare stdout + exit status
+    // (stderr carries the error report in both implementations).
+    run_both("END { puts 'ran' }; END { raise 'boom' }");
+}
+
+#[test]
+fn end_handler_exception_is_visible_as_errinfo() {
+    run_both("END { puts '$!.message = ' + $!.message }; END { raise 'foo' }");
+}

--- a/monoruby/tests/flip_flop.rs
+++ b/monoruby/tests/flip_flop.rs
@@ -1,0 +1,113 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn flip_flop_inclusive() {
+    run_test(
+        r#"
+        r = []
+        10.times { |i| r << i if (i == 4)..(i == 5) }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_exclusive() {
+    run_test(
+        r#"
+        r = []
+        10.times { |i| r << i if (i == 4)...(i == 5) }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_single_element_inclusive() {
+    run_test(
+        r#"
+        r = []
+        10.times { |i| r << i if (i == 4)..(i == 4) }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_single_element_exclusive() {
+    // `...` does not evaluate the end condition on the turn-on
+    // evaluation, so `(i == 4)...(i == 4)` stays on for the rest.
+    // The site ends this snippet still on, and that state persists
+    // into any re-execution of the same site, so run it only once.
+    run_test_once(
+        r#"
+        r = []
+        10.times { |i| r << i if (i == 4)...(i == 4) }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_combined() {
+    run_test(
+        r#"
+        r = []
+        10.times { |i| r << i if (i == 4)..(i == 5) or (i == 7)...(i == 8) }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_state_shared_across_invocations() {
+    run_test(
+        r#"
+        r = []
+        store_me = proc { |i| r << i if (i == 4)..(i == 7) }
+        store_me[1]
+        store_me[4]
+        proc { store_me[1] }.call
+        store_me[7]
+        store_me[5]
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_lazy_end_condition() {
+    run_test(
+        r#"
+        r = []
+        calls = 0
+        10.times { |i| r << i if (calls += 1; i == 4)..(i == 6) }
+        [r, calls]
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_integer_literal_compares_with_last_line_number() {
+    // A bare Integer literal operand compares against `$.`, not its
+    // own truthiness ($. is nil here, so this can never turn on).
+    run_test(
+        r#"
+        r = []
+        10.times { |i| r << i if 4..5 }
+        r
+        "#,
+    );
+}
+
+#[test]
+fn flip_flop_as_ternary_condition() {
+    run_test(
+        r#"
+        from = 1
+        to = 2
+        [(from..to ? 3 : 4), (from...to ? 3 : 4)]
+        "#,
+    );
+}

--- a/monoruby/tests/predefined_gvar.rs
+++ b/monoruby/tests/predefined_gvar.rs
@@ -1,0 +1,170 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn read_only_gvar_message() {
+    run_test_once(
+        r#"
+        res = []
+        [proc { $: = [] }, proc { $" = [] }, proc { $-I = [] },
+         proc { $? = 1 }, proc { $FILENAME = "x" }, proc { $< = 1 },
+         proc { $-a = 1 }, proc { $-l = 1 }, proc { $-p = 1 }].each do |blk|
+          begin
+            blk.call
+            res << "no error"
+          rescue NameError => e
+            res << e.message
+          end
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn record_separator_validation() {
+    run_test_once(
+        r#"
+        res = []
+        begin; $/ = 1; rescue TypeError => e; res << e.message; end
+        begin; $, = :sym; rescue TypeError => e; res << e.message; end
+        begin; $; = 1.0; rescue TypeError => e; res << e.message; end
+        $; = /,/
+        res << $;.class
+        $; = nil
+        begin; $\ = 42; rescue TypeError => e; res << e.message; end
+        $/ = "abc"
+        res << $/.frozen? << $/ << $-0
+        $-0 = "xyz"
+        res << $/
+        $/ = "\n"
+        str = Class.new(String).new("sub")
+        $/ = str
+        res << $/.instance_of?(String) << ($/ == "sub")
+        $/ = "\n"
+        s = +"zz"
+        $\ = s
+        res << $\.equal?(s)
+        $\ = nil
+        res
+        "#,
+    );
+}
+
+#[test]
+fn last_line_number_coerces_with_to_int() {
+    run_test_once(
+        r#"
+        res = [$.]
+        $. = 123.5
+        res << $.
+        obj = Object.new
+        def obj.to_int = 321
+        $. = obj
+        res << $.
+        begin; $. = Object.new; rescue TypeError; res << "TypeError"; end
+        $. = 0
+        res
+        "#,
+    );
+}
+
+#[test]
+fn stdout_must_have_write_method() {
+    run_test_once(
+        r#"
+        res = []
+        begin; $stdout = nil; rescue TypeError => e; res << e.message; end
+        begin; $stderr = 42; rescue TypeError => e; res << e.message; end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn verbose_normalizes_truthy_to_true() {
+    run_test_once(
+        r#"
+        saved = $VERBOSE
+        $VERBOSE = 1
+        res = [$VERBOSE]
+        $VERBOSE = nil
+        res << $VERBOSE
+        $VERBOSE = false
+        res << $VERBOSE
+        $VERBOSE = saved
+        res
+        "#,
+    );
+}
+
+#[test]
+fn debug_flag_alias() {
+    run_test_once(
+        r#"
+        res = [$DEBUG, $-d]
+        $DEBUG = true
+        res << $-d
+        $DEBUG = false
+        res
+        "#,
+    );
+}
+
+#[test]
+fn match_data_assignment() {
+    run_test_once(
+        r#"
+        res = []
+        begin; $~ = Object.new; rescue TypeError => e; res << e.message; end
+        begin; $~ = 1; rescue TypeError => e; res << e.message; end
+        "foo" =~ /(f)oo/
+        m = $~
+        "bar" =~ /(b)ar/
+        res << $1
+        $~ = m
+        res << $1 << $& << $~.equal?(m)
+        $~ = nil
+        res << $~ << $1
+        res
+        "#,
+    );
+}
+
+#[test]
+fn errinfo_backtrace_gvar() {
+    run_test_once(
+        r#"
+        res = [defined?($@), $@]
+        begin
+          $@ = ["x"]
+        rescue ArgumentError => e
+          res << e.message
+        end
+        begin
+          raise "oops"
+        rescue => err
+          res << $@.instance_of?(Array)
+          $@ = ["custom"]
+          res << err.backtrace
+          $@ = "single"
+          res << err.backtrace
+          begin; $@ = :sym; rescue TypeError; res << "TypeError"; end
+          begin; $@ = [nil]; rescue TypeError; res << "TypeError2"; end
+          begin; $@ = [["nested"]]; rescue TypeError; res << "TypeError3"; end
+          $@ = nil
+          res << err.backtrace
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn load_path_aliases_share_identity() {
+    run_test_once(
+        r#"
+        [$:.equal?($LOAD_PATH), $:.equal?($-I)]
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Ran the full ruby/spec `language` category against monoruby (CRuby 4.0.2 reference), classified all 182 failures/errors by root cause, and fixed the three lowest-cost / highest-impact groups. Total for the category: **182 → 115 failing examples**, while the number of runnable examples grew by 84 (two spec files previously failed to load at all).

### 1. Flip-flop operator support (`parser`)

`FlipFlopNode` was an unsupported prism node, so `language/if_spec.rb` and `language/precedence_spec.rb` failed to load entirely. Flip-flops are now desugared at lowering time into an `if` chain over a hidden per-site global (`$__flip_flop_N`, fresh id per lowered node, so re-`eval`s of the same source get independent state while every evaluation of one parsed site shares it). `..` evaluates the end condition on the turn-on evaluation, `...` defers it; bare Integer literal operands compare against `$.` as in CRuby.

**84 examples unlocked, 83 pass** (the remaining one expects the `integer literal in flip-flop` parse warning).

### 2. Predefined global variables (`runtime`)

- Read-only globals raise CRuby's message (`$x is a read-only variable`), and `$?`, `$<`, `$FILENAME`, `$-a`, `$-l`, `$-p` are now actually read-only.
- Ruby-level assignment validates/coerces like CRuby: `$/` (+ new alias `$-0`) stores a frozen plain-String copy; `$\` and `$,` take String-or-nil as-is; `$;` also accepts Regexp; `$.` coerces via `#to_int` and defaults to 0; `$stdout`/`$stderr` require `#write`; `$VERBOSE` normalizes truthy to `true`; `$0` requires a String.
- `$~ =` accepts a MatchData (derived `$&`, `$1`, … update accordingly) or nil, TypeError otherwise.
- New `$@` hook delegates to `$!` (`backtrace` / `set_backtrace`, ArgumentError when `$!` is unset).
- `$DEBUG` defaults to `false` with alias `$-d`; `$-I` aliases `$LOAD_PATH`.

Rust-side writers keep using the hook-free `set_simple` path, so interpreter/JIT internals are unaffected; the JIT's `StoreGVar`/`LoadGVar` already route through the same hook-aware `GvarTable::set`/`get`.

**predefined_spec.rb: 87 → 32 failing.**

### 3. BEGIN/END block semantics (`parser` + `runtime`)

Previously both ran inline at their source position. Now:

- `BEGIN { ... }` hoists to the top of its code unit (bodies share the toplevel scope, so hoisting the statements suffices).
- `END { ... }` registers its body as a once-only `at_exit` handler via a hidden gated call. CRuby compiles the body as a block *sharing the enclosing scope*, so the lowerer tracks synthesized closure scopes: prism-reported lvar depths crossing the hidden block gain an extra hop, and crossed names are anchored with a bare read at the END site so bytecodegen materializes their slot in the home scope.
- Exit-time semantics match CRuby: `SystemExit` from a handler decides the process exit status (overriding the main script's); any other handler exception is printed like an uncaught exception, exposed as `$!` to subsequent handlers, and fails the process with status 1. Finalizers keep warn-and-continue.

**END_spec.rb + BEGIN_spec.rb: 12 → 1 failing** (the survivor expects the `END in method` parse warning).

## Test plan

- `cargo test` — full suite green, including 27 new integration tests (`tests/flip_flop.rs`, `tests/predefined_gvar.rs`, `tests/begin_end.rs`; the last compares monoruby vs host `ruby` subprocess output/exit status since END semantics only materialize at process exit).
- Manual差分検証: flip-flop / gvar / BEGIN-END のスクリプトを CRuby 4.0.2 と diff して完全一致を確認。
- ruby/spec language カテゴリ全 68 ファイルを再実行し、リグレッションなしで 182 → 115 failing を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_