### PR TITLE
CRuby semantics for case/when & rescue-clause `===` dispatch, and superclass validation

### DIFF
--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -193,16 +193,18 @@ pub(crate) extern "C" fn class_alloc_func(_class_id: ClassId, globals: &mut Glob
 
 /// Validate a value used as a superclass for `Class.new`/`Class#initialize`.
 /// Raises TypeError with a CRuby-compatible message when the value is not a
-/// real (non-singleton) Class.
+/// real (non-singleton) Class. Same rules as the `class X < expr` keyword
+/// (see `Executor::expect_superclass`).
 fn expect_class_for_superclass(val: Value, globals: &Globals) -> Result<Module> {
     match val.is_class() {
         Some(class) if class.is_singleton().is_none() => Ok(class),
-        _ => {
-            let name = val.inspect(&globals.store);
-            Err(MonorubyErr::typeerr(format!(
-                "superclass must be an instance of Class (given an instance of {name})"
-            )))
-        }
+        Some(_) => Err(MonorubyErr::typeerr(
+            "can't make subclass of singleton class",
+        )),
+        None => Err(MonorubyErr::typeerr(format!(
+            "superclass must be an instance of Class (given an instance of {})",
+            val.get_real_class_name(&globals.store)
+        ))),
     }
 }
 

--- a/monoruby/src/bytecodegen/binary.rs
+++ b/monoruby/src/bytecodegen/binary.rs
@@ -81,6 +81,28 @@ impl<'a> BytecodeGen<'a> {
         Ok(())
     }
 
+    ///
+    /// Generate a rescue-clause match + conditional branch (same shape
+    /// as `gen_teq_condbr`, but through the RescueTEq opcode, which
+    /// validates that the clause is a Class/Module and dispatches
+    /// `===` with funcall semantics).
+    ///
+    pub(super) fn gen_rescue_teq_condbr(
+        &mut self,
+        lhs: Node,
+        rhs: BcReg,
+        cont_pos: Label,
+        jmp_if_true: bool,
+    ) -> Result<()> {
+        let loc = lhs.loc;
+        let old = self.temp;
+        let lhs = self.push_expr(lhs)?.into();
+        self.emit(BytecodeInst::RescueTEq { lhs, rhs }, loc);
+        self.temp = old;
+        self.emit_condbr(lhs, cont_pos, jmp_if_true, true);
+        Ok(())
+    }
+
     pub(super) fn gen_opt_condbr(
         &mut self,
         jmp_if_true: bool,

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -459,6 +459,11 @@ impl<'a> BytecodeGen<'a> {
                     .new_callsite_map_entry(self.iseq_id, bc_pos, callid);
                 Bytecode::from_with_class2(enc_www(160 + kind as u16, op1.0, op2.0, op3.0))
             }
+            BytecodeInst::RescueTEq { lhs, rhs } => {
+                let op1 = self.slot_id(&lhs);
+                let op2 = self.slot_id(&rhs);
+                Bytecode::from_with_class2(enc_www(157, op1.0, op1.0, op2.0))
+            }
             BytecodeInst::Cmp(kind, ret, (lhs, rhs), optimizable) => {
                 let op1 = ret.map_or(SlotId::self_(), |ret| self.slot_id(&ret));
                 let op2 = self.slot_id(&lhs);

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -166,6 +166,13 @@ pub(super) enum BytecodeInst {
         lhs: BcReg,
         rhs: BcReg,
     },
+    /// `rescue` clause match: `lhs = lhs === rhs` where `lhs` (the
+    /// clause) must be a Class or Module (TypeError otherwise) and
+    /// `===` is dispatched with funcall semantics.
+    RescueTEq {
+        lhs: BcReg,
+        rhs: BcReg,
+    },
     /// Subject-less `case`/`when *arr` match: set `reg` to `true` if any
     /// element of the array in `reg` is truthy, `false` otherwise.
     ArrayAny {

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -531,7 +531,7 @@ impl<'a> BytecodeGen<'a> {
                             self.temp = old;
                             self.emit_condbr(ary, cont_pos, true, false);
                         } else {
-                            self.gen_teq_condbr(ex, err_reg, cont_pos, true)?;
+                            self.gen_rescue_teq_condbr(ex, err_reg, cont_pos, true)?;
                         }
                     }
                     self.emit_br(next_pos);

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -763,7 +763,13 @@ pub(crate) struct VmHandlers {
     pub le: CodePtr,                  // 143, 153
     pub gt: CodePtr,                  // 144, 154
     pub ge: CodePtr,                  // 145, 155
-    pub teq: CodePtr,                 // 146, 156
+    pub teq: CodePtr,                 // 146
+    /// TEq with case/when's funcall semantics (opcode 156 only —
+    /// the optimizable TEq that case/when emits).
+    pub teq_case: CodePtr,
+    /// TEq for rescue-clause matching (opcode 157): validates that
+    /// the clause is a Class/Module, then dispatches like `teq_case`.
+    pub teq_rescue: CodePtr,
     pub load_dvar: CodePtr,           // 148
     pub store_dvar: CodePtr,          // 149
     pub add: CodePtr,                 // 160
@@ -887,7 +893,10 @@ impl Codegen {
         self.dispatch[153] = h.le;
         self.dispatch[154] = h.gt;
         self.dispatch[155] = h.ge;
-        self.dispatch[156] = h.teq;
+        // The optimizable TEq opcode is only emitted for case/when and
+        // rescue matching, whose `===` uses funcall semantics.
+        self.dispatch[156] = h.teq_case;
+        self.dispatch[157] = h.teq_rescue;
 
         self.dispatch[160] = h.add;
         self.dispatch[161] = h.sub;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -62,6 +62,13 @@ impl Codegen {
         let gt = self.a64_op_cmp(Cond::Gt, cmp_gt_values as *const () as u64);
         let ge = self.a64_op_cmp(Cond::Ge, cmp_ge_values as *const () as u64);
         let teq = self.a64_op_cmp(Cond::Eq, cmp_teq_values as *const () as u64);
+        // Funcall-semantics TEq for the optimizable opcode (case/when
+        // and rescue matching).
+        let teq_case = self.a64_op_cmp(Cond::Eq, cmp_teq_case_values as *const () as u64);
+        // RescueTEq: no fixnum fast path (a non-Module clause must
+        // raise TypeError, so everything goes through the runtime
+        // helper).
+        let teq_rescue = self.a64_op_cmp_no_opt(cmp_teq_rescue_values as *const () as u64);
         let method_def = self.a64_op_method_def();
         let send_simple = self.a64_op_send(true);
         let send = self.a64_op_send(false);
@@ -222,6 +229,8 @@ impl Codegen {
             gt,
             ge,
             teq,
+            teq_case,
+            teq_rescue,
             load_dvar,
             store_dvar,
             add: add_rr,

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -60,6 +60,43 @@ macro_rules! vm_cmp_opt {
 impl Codegen {
     vm_cmp_opt!(eq, ne, gt, ge, lt, le, teq);
 
+    /// RescueTEq: no fixnum fast path (a non-Module clause must raise
+    /// TypeError, so every operand pair goes through the runtime
+    /// helper).
+    fn vm_teq_rescue_rr(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        let generic = self.jit.label();
+        self.fetch3();
+        self.vm_get_slot_value(GP::Rdi);
+        self.vm_get_slot_value(GP::Rsi);
+        self.vm_save_binary_integer();
+        self.vm_generic_binop(&generic, cmp_teq_rescue_values as _);
+        self.fetch_and_dispatch();
+        label
+    }
+
+    /// Same shape as the macro-generated `vm_teq_opt_rr`, but backed
+    /// by `cmp_teq_case_values` (funcall semantics) — the handler for
+    /// the optimizable TEq opcode, which only case/when emits.
+    fn vm_teq_case_opt_rr(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        let generic = self.jit.label();
+        self.fetch3();
+        self.vm_get_slot_value(GP::Rdi);
+        self.vm_get_slot_value(GP::Rsi);
+        self.guard_rdi_rsi_fixnum(&generic);
+        self.vm_save_binary_integer();
+
+        self.icmp_eq();
+        self.vm_store_r15(GP::Rax);
+        self.fetch_and_dispatch();
+
+        self.vm_generic_binop(&generic, cmp_teq_case_values as _);
+        self.fetch_and_dispatch();
+
+        label
+    }
+
     ///
     /// Emit the VM entry and every bytecode-opcode handler, returning their
     /// entry points. The arch-neutral [`Codegen::construct_vm`] lays the
@@ -311,6 +348,8 @@ impl Codegen {
             gt: self.vm_gt_opt_rr(),
             ge: self.vm_ge_opt_rr(),
             teq: self.vm_teq_opt_rr(),
+            teq_case: self.vm_teq_case_opt_rr(),
+            teq_rescue: self.vm_teq_rescue_rr(),
             load_dvar: self.vm_load_dvar(),
             store_dvar: self.vm_store_dvar(),
             add: add_rr,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -505,15 +505,6 @@ impl<'a> JitContext<'a> {
                     bc_pos,
                 )
             }
-            TraceIr::RescueTEqBr {
-                lhs,
-                rhs,
-                disp,
-                brkind,
-            } => {
-                let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
-                return self.rescue_teq_br(state, ir, lhs, rhs, dest_bb, brkind, bc_pos);
-            }
             TraceIr::BinCmpBr {
                 kind,
                 _dst: _,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -505,6 +505,15 @@ impl<'a> JitContext<'a> {
                     bc_pos,
                 )
             }
+            TraceIr::RescueTEqBr {
+                lhs,
+                rhs,
+                disp,
+                brkind,
+            } => {
+                let dest_bb = self.iseq().get_bb(bc_pos + 1 + disp);
+                return self.rescue_teq_br(state, ir, lhs, rhs, dest_bb, brkind, bc_pos);
+            }
             TraceIr::BinCmpBr {
                 kind,
                 _dst: _,

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -225,37 +225,6 @@ impl<'a> JitContext<'a> {
         state.unset_side_effect_guard();
     }
 
-    /// Rescue-clause match + branch: always the generic runtime call
-    /// (`cmp_teq_rescue_values` validates the clause and dispatches
-    /// `===` with funcall semantics), never a typed fast path — a
-    /// non-Module clause must raise TypeError even for
-    /// integer-looking operand pairs.
-    pub(super) fn rescue_teq_br(
-        &mut self,
-        state: &mut AbstractState,
-        ir: &mut AsmIr,
-        lhs: SlotId,
-        rhs: SlotId,
-        dest_bb: BasicBlockId,
-        brkind: BrKind,
-        bc_pos: BcIndex,
-    ) -> JitResult<CompileResult> {
-        state.flush_gp(ir);
-        state.write_back_slots(ir, &[lhs, rhs]);
-        self.guard_class_version(state, ir, true);
-        let error = ir.new_error(state);
-        ir.generic_binop(state, lhs, rhs, crate::executor::op::cmp_teq_rescue_values);
-        ir.handle_error(error);
-        // The helper can run arbitrary Ruby (a user-defined `===`);
-        // invalidate cached guards like the generic cmp path does.
-        state.unset_class_version_guard();
-        state.unset_const_version_guard();
-        state.unset_side_effect_guard();
-        let src_idx = bc_pos + 1;
-        self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
-        Ok(CompileResult::Continue)
-    }
-
     pub(super) fn binary_cmp_br(
         &mut self,
         state: &mut AbstractState,

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -160,7 +160,7 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
                 state.flush_gp(ir);
                 if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, false);
                     state.def_rax2acc(ir, dst);
                     Ok(CompileResult::Continue)
                 } else {
@@ -194,6 +194,10 @@ impl<'a> JitContext<'a> {
         kind: CmpKind,
         lhs: SlotId,
         rhs: SlotId,
+        // `BinCmpBr` (the optimizable opcode: case/when and rescue
+        // matching) dispatches `===` with funcall semantics; a plain
+        // `BinCmp` (`a === b`) is a public-only call.
+        case_semantics: bool,
     ) {
         state.write_back_slots(ir, &[lhs, rhs]);
         // §9 9d-B: the generic comparison emits a C-ABI call; flush any
@@ -207,6 +211,9 @@ impl<'a> JitContext<'a> {
             CmpKind::Eq | CmpKind::Ne => {
                 ir.opt_eq_cmp(state, lhs, rhs, kind, cmp_generic_fn(kind))
             }
+            CmpKind::TEq if case_semantics => {
+                ir.generic_binop(state, lhs, rhs, crate::executor::op::cmp_teq_case_values)
+            }
             _ => ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind)),
         }
         ir.handle_error(error);
@@ -216,6 +223,37 @@ impl<'a> JitContext<'a> {
         state.unset_class_version_guard();
         state.unset_const_version_guard();
         state.unset_side_effect_guard();
+    }
+
+    /// Rescue-clause match + branch: always the generic runtime call
+    /// (`cmp_teq_rescue_values` validates the clause and dispatches
+    /// `===` with funcall semantics), never a typed fast path — a
+    /// non-Module clause must raise TypeError even for
+    /// integer-looking operand pairs.
+    pub(super) fn rescue_teq_br(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        lhs: SlotId,
+        rhs: SlotId,
+        dest_bb: BasicBlockId,
+        brkind: BrKind,
+        bc_pos: BcIndex,
+    ) -> JitResult<CompileResult> {
+        state.flush_gp(ir);
+        state.write_back_slots(ir, &[lhs, rhs]);
+        self.guard_class_version(state, ir, true);
+        let error = ir.new_error(state);
+        ir.generic_binop(state, lhs, rhs, crate::executor::op::cmp_teq_rescue_values);
+        ir.handle_error(error);
+        // The helper can run arbitrary Ruby (a user-defined `===`);
+        // invalidate cached guards like the generic cmp path does.
+        state.unset_class_version_guard();
+        state.unset_const_version_guard();
+        state.unset_side_effect_guard();
+        let src_idx = bc_pos + 1;
+        self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
+        Ok(CompileResult::Continue)
     }
 
     pub(super) fn binary_cmp_br(
@@ -266,7 +304,7 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
                 state.flush_gp(ir);
                 if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs);
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, true);
                     let src_idx = bc_pos + 1;
                     self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
                     return Ok(CompileResult::Continue);

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -190,6 +190,16 @@ pub(crate) enum TraceIr {
         ic: Option<(ClassId, ClassId)>,
         polymorphic: bool,
     },
+    /// Rescue-clause match fused with the following conditional
+    /// branch (opcode 157 + CondBr). Always lowered through the
+    /// generic runtime helper: the clause must be validated as a
+    /// Class/Module even when both operands look like integers.
+    RescueTEqBr {
+        lhs: SlotId,
+        rhs: SlotId,
+        disp: i32,
+        brkind: BrKind,
+    },
     ArrayTEq {
         lhs: SlotId,
         rhs: SlotId,
@@ -660,6 +670,20 @@ impl TraceIr {
                         polymorphic: pc.opcode_sub() == 1,
                     }
                 }
+                157 => {
+                    let lhs = SlotId::new(op2_w2);
+                    let rhs = SlotId::new(op3_w3);
+                    let (disp, brkind) = match TraceIr::from_pc(pc + 1, store) {
+                        TraceIr::CondBr(_, dest, true, brkind) => (dest + 1, brkind),
+                        _ => unreachable!(),
+                    };
+                    TraceIr::RescueTEqBr {
+                        lhs,
+                        rhs,
+                        disp,
+                        brkind,
+                    }
+                }
                 160..=170 => {
                     let kind = BinOpK::from(opcode - 160);
                     let dst = SlotId::from(op1_w1);
@@ -1007,6 +1031,10 @@ impl TraceIr {
                 polymorphic,
                 ..
             } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), true, polymorphic),
+
+            TraceIr::RescueTEqBr { lhs, rhs, .. } => {
+                format!("{lhs:?} = {lhs:?} ===(rescue) {rhs:?}; condbr")
+            }
 
             TraceIr::ArrayTEq { lhs, rhs } => {
                 format!("{lhs:?} = *{lhs:?} === {rhs:?}")

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -190,16 +190,6 @@ pub(crate) enum TraceIr {
         ic: Option<(ClassId, ClassId)>,
         polymorphic: bool,
     },
-    /// Rescue-clause match fused with the following conditional
-    /// branch (opcode 157 + CondBr). Always lowered through the
-    /// generic runtime helper: the clause must be validated as a
-    /// Class/Module even when both operands look like integers.
-    RescueTEqBr {
-        lhs: SlotId,
-        rhs: SlotId,
-        disp: i32,
-        brkind: BrKind,
-    },
     ArrayTEq {
         lhs: SlotId,
         rhs: SlotId,
@@ -671,18 +661,17 @@ impl TraceIr {
                     }
                 }
                 157 => {
-                    let lhs = SlotId::new(op2_w2);
-                    let rhs = SlotId::new(op3_w3);
-                    let (disp, brkind) = match TraceIr::from_pc(pc + 1, store) {
-                        TraceIr::CondBr(_, dest, true, brkind) => (dest + 1, brkind),
-                        _ => unreachable!(),
-                    };
-                    TraceIr::RescueTEqBr {
-                        lhs,
-                        rhs,
-                        disp,
-                        brkind,
-                    }
+                    // RescueTEq: the rescue-clause match. It only ever
+                    // executes inside an exception handler, and the
+                    // JIT's BB graph has no edge into handler blocks
+                    // (see `taint_for_unmodeled_rescue`), so the
+                    // compiler can never reach this opcode — exception
+                    // dispatch always side-exits to the interpreter,
+                    // whose opcode-157 handler does the clause
+                    // validation and funcall-`===`.
+                    unreachable!(
+                        "RescueTEq is handler-side only; the JIT does not visit exception-handler blocks"
+                    )
                 }
                 160..=170 => {
                     let kind = BinOpK::from(opcode - 160);
@@ -1031,10 +1020,6 @@ impl TraceIr {
                 polymorphic,
                 ..
             } => cmp_fmt(store, kind, dst, lhs, rhs, ic.clone(), true, polymorphic),
-
-            TraceIr::RescueTEqBr { lhs, rhs, .. } => {
-                format!("{lhs:?} = {lhs:?} ===(rescue) {rhs:?}; condbr")
-            }
 
             TraceIr::ArrayTEq { lhs, rhs } => {
                 format!("{lhs:?} = *{lhs:?} === {rhs:?}")

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -235,13 +235,13 @@ pub(super) extern "C" fn array_teq(
 ) -> Option<Value> {
     if let Some(lhs_ary) = lhs.try_array_ty() {
         for lhs in lhs_ary.iter().cloned() {
-            if op::cmp_teq_values(vm, globals, lhs, rhs)?.as_bool() {
+            if op::cmp_teq_case_values(vm, globals, lhs, rhs)?.as_bool() {
                 return Some(Value::bool(true));
             }
         }
         Some(Value::bool(false))
     } else {
-        op::cmp_teq_values(vm, globals, lhs, rhs)
+        op::cmp_teq_case_values(vm, globals, lhs, rhs)
     }
 }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2425,6 +2425,21 @@ impl Executor {
             .expect_string(globals)
     }
 
+    /// Validate the `class X < expr` superclass operand: it must be a
+    /// Class (not merely a Module), and not a singleton class.
+    fn expect_superclass(globals: &Globals, superclass: Value) -> Result<Module> {
+        let m = superclass.is_class().ok_or_else(|| {
+            MonorubyErr::typeerr(format!(
+                "superclass must be an instance of Class (given an instance of {})",
+                superclass.get_real_class_name(&globals.store)
+            ))
+        })?;
+        if m.is_singleton().is_some() {
+            return Err(MonorubyErr::typeerr("can't make subclass of singleton class"));
+        }
+        Ok(m)
+    }
+
     pub(crate) fn define_class(
         &mut self,
         globals: &mut Globals,
@@ -2489,7 +2504,7 @@ impl Executor {
                 };
                 if let Some(superclass) = superclass {
                     assert!(!is_module);
-                    let superclass_id = superclass.expect_class(globals)?.id();
+                    let superclass_id = Self::expect_superclass(globals, superclass)?.id();
                     if Some(superclass_id) != val.get_real_superclass().map(|m| m.id()) {
                         return Err(MonorubyErr::superclass_mismatch(name));
                     }
@@ -2500,7 +2515,7 @@ impl Executor {
                 let superclass = match superclass {
                     Some(superclass) => {
                         assert!(!is_module);
-                        superclass.expect_class(globals)?
+                        Self::expect_superclass(globals, superclass)?
                     }
                     None => globals.store.object_class(),
                 };

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -404,6 +404,49 @@ pub(crate) extern "C" fn cmp_teq_values(
     lhs: Value,
     rhs: Value,
 ) -> Option<Value> {
+    cmp_teq_values_impl(vm, globals, lhs, rhs, false)
+}
+
+/// `===` dispatch for the *optimizable* TEq opcode, which bytecodegen
+/// only emits for case/when and rescue matching: CRuby dispatches
+/// those `===` calls with funcall semantics, so a private `===` is
+/// allowed (an explicit `a === b` compiles to the non-optimizable
+/// opcode and stays a public-only call).
+pub(crate) extern "C" fn cmp_teq_case_values(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+) -> Option<Value> {
+    cmp_teq_values_impl(vm, globals, lhs, rhs, true)
+}
+
+/// `===` dispatch for rescue-clause matching (the RescueTEq opcode):
+/// the clause must be a Class or Module — CRuby raises TypeError
+/// before any `===` dispatch — and the call itself has funcall
+/// semantics like case/when.
+pub(crate) extern "C" fn cmp_teq_rescue_values(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+) -> Option<Value> {
+    if lhs.is_class_or_module().is_none() {
+        vm.set_error(MonorubyErr::typeerr(
+            "class or module required for rescue clause",
+        ));
+        return None;
+    }
+    cmp_teq_values_impl(vm, globals, lhs, rhs, true)
+}
+
+fn cmp_teq_values_impl(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+    private_ok: bool,
+) -> Option<Value> {
     let b = match (lhs.unpack(), rhs.unpack()) {
         (RV::Nil, RV::Nil) => true,
         (RV::Nil, _) => false,
@@ -437,7 +480,7 @@ pub(crate) extern "C" fn cmp_teq_values(
             return vm.invoke_method_simple(globals, IdentId::_EQ, rhs, &[lhs]);
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_TEQ, lhs, &[rhs]);
+            return vm.invoke_method(globals, IdentId::_TEQ, private_ok, lhs, &[rhs], None, None);
         }
     };
     Some(Value::bool(b))

--- a/monoruby/tests/case.rs
+++ b/monoruby/tests/case.rs
@@ -307,3 +307,72 @@ fn case_calls_private_teq() {
         "#,
     );
 }
+
+// Drive the case/when `===` dispatch through the JIT tier: the
+// integration-test binaries use the production JIT thresholds, so the
+// construct lives in a method called >20 times. The two matcher
+// classes at the same call site make the comparison polymorphic,
+// forcing the generic-cmp lowering (which must use funcall semantics
+// for case/when: private `===` is still reachable).
+#[test]
+fn case_private_teq_jit() {
+    run_test(
+        r#"
+        matcher_a = Class.new do
+          def ===(x); x == :a; end
+          private :===
+        end.new
+        matcher_b = Class.new do
+          def ===(x); x == :b; end
+        end.new
+
+        def case_match(x, m)
+          case x
+          when m then "matcher"
+          when Symbol then "symbol"
+          else "other"
+          end
+        end
+
+        res = []
+        30.times do
+          res << case_match(:a, matcher_a)
+          res << case_match(:b, matcher_a)
+          res << case_match(:b, matcher_b)
+          res << case_match(1, matcher_b)
+        end
+        res
+        "#,
+    );
+}
+
+// Same for the splat form: `when *arr` goes through the array_teq
+// runtime helper, which must also dispatch `===` with funcall
+// semantics under the JIT.
+#[test]
+fn case_splat_teq_jit() {
+    run_test(
+        r#"
+        private_matcher = Class.new do
+          def ===(x); x == :hit; end
+          private :===
+        end.new
+
+        def case_splat(x, arr)
+          case x
+          when *arr then "in"
+          else "out"
+          end
+        end
+
+        res = []
+        list = [private_matcher, Integer]
+        30.times do
+          res << case_splat(:hit, list)
+          res << case_splat(7, list)
+          res << case_splat(:miss, list)
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/case.rs
+++ b/monoruby/tests/case.rs
@@ -278,3 +278,32 @@ fn case_when_splat() {
         "#,
     ]);
 }
+
+#[test]
+fn case_calls_private_teq() {
+    // case/when dispatches `===` with funcall semantics (a private
+    // `===` is allowed), unlike an explicit `a === b`.
+    run_test(
+        r#"
+        klass = Class.new do
+          def ===(o); o == 1; end
+          private :===
+        end
+        matcher = klass.new
+        res = []
+        3.times do |i|
+          case i
+          when matcher then res << "match #{i}"
+          else res << "no #{i}"
+          end
+        end
+        begin
+          matcher === 1
+          res << "no error"
+        rescue NoMethodError
+          res << "NoMethodError"
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/class_chain.rs
+++ b/monoruby/tests/class_chain.rs
@@ -123,3 +123,27 @@ fn singleton_classdef_with_live_float() {
     );
 }
 
+
+#[test]
+fn superclass_must_be_a_class() {
+    run_test_once(
+        r#"
+        res = []
+        [42, "s", :sym, Module.new, Object.new.singleton_class].each do |sup|
+          begin
+            Class.new(sup)
+            res << "no error"
+          rescue TypeError => e
+            res << e.message
+          end
+          begin
+            eval("class SuperclassCheckSpec < sup; end")
+            res << "no error"
+          rescue TypeError => e
+            res << e.message
+          end
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -514,3 +514,53 @@ fn eval_custom_filename_and_lineno() {
         "#,
     ]);
 }
+
+#[test]
+fn rescue_clause_requires_class_or_module() {
+    run_test(
+        r#"
+        res = []
+        rescuer = 42
+        3.times do
+          begin
+            begin
+              raise "error"
+            rescue rescuer
+              res << "wrong"
+            end
+          rescue TypeError => e
+            res << e.message
+          rescue RuntimeError => e
+            res << "runtime: #{e.message}"
+          end
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn rescue_clause_private_teq() {
+    // The rescue-clause `===` dispatch has funcall semantics once the
+    // clause passes the Class/Module check.
+    run_test(
+        r#"
+        klass = Class.new(StandardError)
+        class << klass
+          def ===(e); e.message == "yes"; end
+          private :===
+        end
+        res = []
+        [["yes", :caught], ["no", :other]].map do |msg, _|
+          begin
+            raise StandardError, msg
+          rescue klass
+            res << "special #{msg}"
+          rescue StandardError
+            res << "plain #{msg}"
+          end
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -564,3 +564,41 @@ fn rescue_clause_private_teq() {
         "#,
     );
 }
+
+// Rescue-clause matching in a JIT-hot method: the method is called
+// more than 20 times (the production method-JIT threshold used by
+// integration-test binaries), so its happy path is JIT-compiled,
+// while every exception dispatch side-exits to the interpreter,
+// whose opcode-157 handler validates the clause and dispatches `===`
+// with funcall semantics. The JIT deliberately has no lowering for
+// the rescue-clause match — its BB graph never enters exception
+// handlers — and this test pins the tier hand-off behavior.
+#[test]
+fn rescue_clause_match_jit() {
+    run_test(
+        r#"
+        def rescue_match(exc_msg, clause)
+          begin
+            begin
+              raise RuntimeError, exc_msg
+            rescue clause => e
+              "caught #{e.message}"
+            rescue RuntimeError => e
+              "unmatched #{e.message}"
+            end
+          rescue TypeError => e
+            "type: #{e.message}"
+          end
+        end
+
+        special = Class.new(RuntimeError)
+        res = []
+        30.times do |i|
+          res << rescue_match("m#{i}", RuntimeError)   # clause matches
+          res << rescue_match("n#{i}", special)        # clause misses
+          res << rescue_match("o#{i}", 42)             # clause invalid -> TypeError
+        end
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Second batch of ruby/spec `language` fixes (follow-up to #861), continuing down the classified failure list in cost/benefit order.

### 1. case/when dispatches `===` with funcall semantics

`case x when matcher` must call a private `===` (CRuby uses funcall semantics for checkmatch), while an explicit `a === b` stays a public-only call. Both forms compile to TEq opcodes (146 non-optimizable / 156 optimizable), but the arch-neutral dispatch mapping in `codegen.rs` pointed **both opcodes at the same handler** — the per-arch dispatch assignments it later overwrites turned out to be dead code. The fix:

- `cmp_teq_values` is refactored into a shared impl with a `private_ok` flag; new `cmp_teq_case_values` entry point.
- New `teq_case` handler in `VmHandlers`, wired to opcode 156 on both x86-64 and aarch64.
- The JIT's generic-cmp path gets a `case_semantics` flag: `BinCmpBr` (case/when) uses the funcall entry, `BinCmp` (explicit `===`) keeps public dispatch.
- `array_teq` (the `when *arr` splat helper) follows the case semantics.

### 2. rescue clauses require a Class or Module

`begin ... rescue 42; end` now raises CRuby's `TypeError: class or module required for rescue clause` instead of silently not matching. Scalar clauses compile to a new `RescueTEq` opcode (157) with **no integer fast path** — a non-Module clause must raise even for integer operand pairs — handled by both VM backends. The clause `===` itself also uses funcall semantics once validated.

There is deliberately **no JIT lowering** for the rescue-clause match: the JIT's basic-block graph has no edge into exception handlers, so exception dispatch always side-exits to the interpreter, whose opcode-157 handler does the work. (An earlier revision of this PR added a `RescueTEqBr` TraceIR + lowering; probing showed it was unreachable, and it has been removed in favor of an `unreachable!()` documenting the invariant.) Splatted clauses (`rescue *list`) still go through the unvalidated `array_teq` path for now (noted as future work).

### 3. Superclass validation in class definitions

`class X < expr` previously reported `42 is not a class` and **silently accepted a singleton class** as superclass. Both the keyword path (`Executor::define_class`) and `Class.new` now enforce CRuby's rules and messages:

- `superclass must be an instance of Class (given an instance of Integer)` — naming the operand's class, not its inspect output;
- `can't make subclass of singleton class` for metaclasses.

## ruby/spec impact

- `language/case_spec.rb`: private-`===` example fixed.
- `language/rescue_spec.rb`: scalar rescue-clause TypeError example fixed.
- `language/class_spec.rb`: 4 → 2 failing (metaclass-superclass + message examples fixed).

## Test plan

- `cargo test` — full suite green, including new integration tests in `tests/case.rs`, `tests/rescue.rs`, `tests/class_chain.rs`.
- **JIT-tier coverage**: integration-test binaries link the library with the production JIT thresholds (the 5-call/15-iteration test thresholds are `cfg(test)`-gated and only apply to in-crate unit tests), so `run_test`'s 25 iterations alone never leave the interpreter. The `*_jit` tests therefore put each construct into a method called 30 times; temporary probes confirmed the generic case-teq path is lowered by the JIT, and that rescue matching side-exits to the interpreter as designed.
- Manual diff scripts for all three areas verified byte-identical output against CRuby 4.0.2, including JIT-warmed loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK