### PR TITLE
NameError for failed variable calls, compile-time yield validation, and rescue-splat clause checks

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -146,7 +146,7 @@ fn frozen(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result
 ///
 #[monoruby_builtin]
 fn bo_method_missing(
-    _: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -154,6 +154,18 @@ fn bo_method_missing(
     let args = lfp.arg(0).as_array();
     let name = args[0].expect_symbol_or_string(globals)?;
     let recv = lfp.self_val();
+    // A failed "variable call" (bare identifier — could as well have
+    // been a local variable) raises NameError, not NoMethodError,
+    // mirroring CRuby's default method_missing on a VCALL.
+    if vm.take_method_missing_vcall() {
+        return Err(MonorubyErr::nameerr_with_name(
+            format!(
+                "undefined local variable or method `{name}' for {}",
+                recv.to_s(&globals.store)
+            ),
+            name,
+        ));
+    }
     // Reaching the default `method_missing` while the method actually
     // exists means the call violated visibility (a private method called
     // with an explicit receiver, or an inaccessible protected method).

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -248,6 +248,10 @@ struct CallSite {
     /// Bypass `private` visibility. Set for the privileged
     /// `recv.__builtin_initialize__(...)` intrinsic spelling.
     bypass_visibility: bool,
+    /// A "variable call" (bare identifier, no receiver / args /
+    /// parens): a failed lookup raises NameError instead of
+    /// NoMethodError.
+    vcall: bool,
 }
 
 impl CallSite {
@@ -276,6 +280,7 @@ impl CallSite {
             dst,
             forwarding,
             bypass_visibility: false,
+            vcall: false,
         }
     }
 

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -93,6 +93,7 @@ impl<'a> BytecodeGen<'a> {
                     && matches!(
                         n.kind,
                         NodeKind::FuncCall { .. }
+                            | NodeKind::Ident(_)
                             | NodeKind::MethodCall { .. }
                             | NodeKind::Index { .. }
                             | NodeKind::BinOp(..)

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -573,10 +573,15 @@ impl<'a> BytecodeGen<'a> {
                 Bytecode::from(enc_www(86, op1.0, op2.0, len as u16))
             }
 
-            BytecodeInst::ArrayTEq { lhs, rhs } => {
+            BytecodeInst::ArrayTEq {
+                lhs,
+                rhs,
+                rescue_clause,
+            } => {
                 let op1 = self.slot_id(&lhs);
                 let op2 = self.slot_id(&rhs);
-                Bytecode::from(enc_www(40, 0, op1.0, op2.0))
+                let opcode = if rescue_clause { 44 } else { 40 };
+                Bytecode::from(enc_www(opcode, 0, op1.0, op2.0))
             }
             BytecodeInst::ArrayAny { reg } => {
                 let op1 = self.slot_id(&reg);
@@ -699,6 +704,7 @@ impl<'a> BytecodeGen<'a> {
             dst,
             forwarding,
             bypass_visibility,
+            vcall,
         } = callsite;
 
         let args = self.slot_id(&args);
@@ -735,6 +741,7 @@ impl<'a> BytecodeGen<'a> {
             dst,
             forwarding,
             bypass_visibility,
+            vcall,
         ))
     }
 }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -164,6 +164,7 @@ impl<'a> BytecodeGen<'a> {
                         Some(base),
                         arglist,
                         false,
+                        false,
                         UseMode2::Store(dst),
                         loc,
                     )?;
@@ -304,6 +305,7 @@ impl<'a> BytecodeGen<'a> {
                     Some(receiver),
                     arglist,
                     safe_nav,
+                    false,
                     UseMode2::Store(dst),
                     loc,
                 )?;
@@ -314,7 +316,7 @@ impl<'a> BytecodeGen<'a> {
                 safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                self.gen_method_call(method, None, arglist, safe_nav, UseMode2::Store(dst), loc)?;
+                self.gen_method_call(method, None, arglist, safe_nav, false, UseMode2::Store(dst), loc)?;
             }
             NodeKind::Return(box val) => {
                 if self.is_escaping_block() {
@@ -473,6 +475,7 @@ impl<'a> BytecodeGen<'a> {
                         IdentId::_INDEX,
                         Some(base),
                         arglist,
+                        false,
                         false,
                         use_mode,
                         loc,
@@ -662,6 +665,7 @@ impl<'a> BytecodeGen<'a> {
                     Some(receiver),
                     arglist,
                     safe_nav,
+                    false,
                     use_mode,
                     loc,
                 );
@@ -672,7 +676,7 @@ impl<'a> BytecodeGen<'a> {
                 safe_nav,
             } => {
                 let method = IdentId::get_id_from_string(method);
-                return self.gen_method_call(method, None, arglist, safe_nav, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, safe_nav, false, use_mode, loc);
             }
             NodeKind::Super(arglist) => {
                 return self.gen_super(arglist.map(|arglist| *arglist), use_mode, loc);
@@ -707,7 +711,7 @@ impl<'a> BytecodeGen<'a> {
                     return Ok(());
                 }
                 let arglist = ArgList::from_args(vec![expr]);
-                return self.gen_method_call(method, None, arglist, false, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, false, false, use_mode, loc);
             }
             NodeKind::Yield(arglist) => {
                 return self.gen_yield(*arglist, use_mode, loc);
@@ -715,7 +719,7 @@ impl<'a> BytecodeGen<'a> {
             NodeKind::Ident(method) => {
                 let arglist = ArgList::default();
                 let method = IdentId::get_id_from_string(method);
-                return self.gen_method_call(method, None, arglist, false, use_mode, loc);
+                return self.gen_method_call(method, None, arglist, false, true, use_mode, loc);
             }
             NodeKind::If {
                 box cond,
@@ -1015,6 +1019,7 @@ impl<'a> BytecodeGen<'a> {
                         IdentId::get_id("undef_method"),
                         None,
                         arglist,
+                        false,
                         false,
                         UseMode2::NotUse,
                         loc,

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -165,6 +165,10 @@ pub(super) enum BytecodeInst {
     ArrayTEq {
         lhs: BcReg,
         rhs: BcReg,
+        /// Splatted `rescue *list` clause: each element must be a
+        /// Class or Module (TypeError otherwise) and `===` dispatches
+        /// with funcall semantics. Encoded as opcode 44 instead of 40.
+        rescue_clause: bool,
     },
     /// `rescue` clause match: `lhs = lhs === rhs` where `lhs` (the
     /// clause) must be a Class or Module (TypeError otherwise) and

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -40,6 +40,9 @@ impl<'a> BytecodeGen<'a> {
         receiver: Option<Node>,
         arglist: ArgList,
         safe_nav: bool,
+        // Bare-identifier call (`foo` with no receiver/args/parens):
+        // a failed lookup raises NameError instead of NoMethodError.
+        vcall: bool,
         use_mode: UseMode2,
         loc: Loc,
     ) -> Result<()> {
@@ -94,6 +97,7 @@ impl<'a> BytecodeGen<'a> {
         if builtin_initialize {
             callid.bypass_visibility = true;
         }
+        callid.vcall = vcall;
 
         self.temp = old_temp;
         if push_flag {
@@ -213,6 +217,15 @@ impl<'a> BytecodeGen<'a> {
         use_mode: UseMode2,
         loc: Loc,
     ) -> Result<()> {
+        // CRuby rejects `yield` at parse time unless the surrounding
+        // non-block scope is a method body: yield in a class/module
+        // body, at the top level, or in a block belonging to either
+        // is a SyntaxError. (`defined?(yield)` compiles to its own
+        // instruction and never reaches here.)
+        let mother_fid = self.store[self.mother.0].func_id();
+        if !self.store[mother_fid].is_method() {
+            return Err(self.syntax_error("Invalid yield", loc));
+        }
         let dst = match use_mode {
             UseMode2::NotUse => None,
             UseMode2::Push | UseMode2::Ret => Some(self.push().into()),

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -224,7 +224,14 @@ impl<'a> BytecodeGen<'a> {
             let loc = when.loc;
             let old = self.temp;
             let lhs = self.push_expr(when)?.into();
-            self.emit(BytecodeInst::ArrayTEq { lhs, rhs: reg }, loc);
+            self.emit(
+                BytecodeInst::ArrayTEq {
+                    lhs,
+                    rhs: reg,
+                    rescue_clause: false,
+                },
+                loc,
+            );
             self.temp = old;
             self.emit_condbr(lhs, cont_pos, jmp_if_true, false);
             Ok(())
@@ -527,7 +534,14 @@ impl<'a> BytecodeGen<'a> {
                             let loc = ex.loc;
                             let old = self.temp;
                             let ary = self.push_expr(Node::new_array(vec![ex], loc))?.into();
-                            self.emit(BytecodeInst::ArrayTEq { lhs: ary, rhs: err_reg }, loc);
+                            self.emit(
+                                BytecodeInst::ArrayTEq {
+                                    lhs: ary,
+                                    rhs: err_reg,
+                                    rescue_clause: true,
+                                },
+                                loc,
+                            );
                             self.temp = old;
                             self.emit_condbr(ary, cont_pos, true, false);
                         } else {

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -734,6 +734,7 @@ pub(crate) struct VmHandlers {
     pub array_concat: CodePtr,        // 41
     pub hash_insert: CodePtr,         // 42
     pub array_any: CodePtr,           // 43
+    pub rescue_array_teq: CodePtr,    // 44
     pub defined_yield: CodePtr,       // 64
     pub defined_const: CodePtr,       // 65
     pub defined_method: CodePtr,      // 66
@@ -849,6 +850,7 @@ impl Codegen {
         self.dispatch[41] = h.array_concat;
         self.dispatch[42] = h.hash_insert;
         self.dispatch[43] = h.array_any;
+        self.dispatch[44] = h.rescue_array_teq;
 
         self.dispatch[64] = h.defined_yield;
         self.dispatch[65] = h.defined_const;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -109,7 +109,8 @@ impl Codegen {
 
         // literal constructors / aggregate ops
         let array = self.a64_op_array();
-        let array_teq = self.a64_op_array_teq();
+        let array_teq = self.a64_op_array_teq(runtime::array_teq as *const () as u64);
+        let rescue_array_teq = self.a64_op_array_teq(runtime::rescue_array_teq as *const () as u64);
         let array_any = self.a64_op_array_any();
         let array_concat = self.a64_op_array_concat();
         let hash = self.a64_op_hash();
@@ -196,6 +197,7 @@ impl Codegen {
             lambda,
             array,
             array_teq,
+            rescue_array_teq,
             array_any,
             array_concat,
             hash_insert,
@@ -795,7 +797,9 @@ impl Codegen {
     /// op 40 `ArrayTEq`: %lhs = (%lhs === %rhs). If %lhs is an Array, returns
     /// true iff some element matches %rhs (via `===`). The result overwrites
     /// the lhs slot. Bytecode: `+0` rhs, `+2` lhs (also dst).
-    pub(in crate::codegen) fn a64_op_array_teq(&mut self) -> CodePtr {
+    /// Shared generator for op 40 (`ArrayTEq`, `f` = runtime::array_teq)
+    /// and op 44 (rescue-splat variant, `f` = runtime::rescue_array_teq).
+    pub(in crate::codegen) fn a64_op_array_teq(&mut self, f: u64) -> CodePtr {
         let p = self.jit.get_current_address();
         let raise = self.entry_raise.clone();
         let skip = self.jit.label();
@@ -805,13 +809,13 @@ impl Codegen {
         );
         self.a64_load_slot(X11, X3, X12); // X3 = lhs value
         self.a64_load_slot(X10, X4, X12); // X4 = rhs value
-        // array_teq(vm, globals, lhs, rhs) -> Option<Value>
+        // array_teq / rescue_array_teq (vm, globals, lhs, rhs) -> Option<Value>
         monoasm_arm64!(&mut self.jit,
             mov x2, x3;  // lhs (arg #3)
             mov x3, x4;  // rhs (arg #4)
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
-            mov x9, (runtime::array_teq as *const () as u64);
+            mov x9, (f);
             blr x9;
             cbz x0, raise;
         // dst slot = lhs slot from [PC+2]

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -314,7 +314,8 @@ impl Codegen {
             nilbr: self.vm_nilbr(&branch),
             lambda: self.vm_lambda(),
             array: self.vm_array(),
-            array_teq: self.vm_array_teq(),
+            array_teq: self.vm_array_teq(runtime::array_teq as _),
+            rescue_array_teq: self.vm_array_teq(runtime::rescue_array_teq as _),
             array_any: self.vm_array_any(),
             array_concat: self.vm_array_concat(),
             hash_insert: self.vm_hash_insert(),
@@ -858,7 +859,9 @@ impl Codegen {
         label
     }
 
-    fn vm_array_teq(&mut self) -> CodePtr {
+    /// Shared generator for op 40 (`ArrayTEq`, `f` = runtime::array_teq)
+    /// and op 44 (rescue-splat variant, `f` = runtime::rescue_array_teq).
+    fn vm_array_teq(&mut self, f: u64) -> CodePtr {
         let label = self.jit.get_current_address();
         monoasm! { &mut self.jit,
             movzxw rdi, [r13 - 14];     // rdi <- :2
@@ -872,7 +875,7 @@ impl Codegen {
             movq rcx, rsi;
             movq rdi, rbx;
             movq rsi, r12;
-            movq rax, (runtime::array_teq);
+            movq rax, (f);
             call rax;
         };
         self.vm_handle_error();

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -660,6 +660,13 @@ impl TraceIr {
                         polymorphic: pc.opcode_sub() == 1,
                     }
                 }
+                44 => {
+                    // Rescue-splat clause match: handler-side only,
+                    // same invariant as opcode 157 below.
+                    unreachable!(
+                        "rescue-splat ArrayTEq is handler-side only; the JIT does not visit exception-handler blocks"
+                    )
+                }
                 157 => {
                     // RescueTEq: the rescue-clause match. It only ever
                     // executes inside an exception handler, and the

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -233,15 +233,38 @@ pub(super) extern "C" fn array_teq(
     lhs: Value,
     rhs: Value,
 ) -> Option<Value> {
+    array_teq_impl(vm, globals, lhs, rhs, op::cmp_teq_case_values)
+}
+
+/// `rescue *list` clause match (opcode 44): like `array_teq`, but each
+/// element must be a Class or Module — `cmp_teq_rescue_values` raises
+/// CRuby's "class or module required for rescue clause" TypeError
+/// otherwise.
+pub(super) extern "C" fn rescue_array_teq(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+) -> Option<Value> {
+    array_teq_impl(vm, globals, lhs, rhs, op::cmp_teq_rescue_values)
+}
+
+fn array_teq_impl(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lhs: Value,
+    rhs: Value,
+    teq: extern "C" fn(&mut Executor, &mut Globals, Value, Value) -> Option<Value>,
+) -> Option<Value> {
     if let Some(lhs_ary) = lhs.try_array_ty() {
         for lhs in lhs_ary.iter().cloned() {
-            if op::cmp_teq_case_values(vm, globals, lhs, rhs)?.as_bool() {
+            if teq(vm, globals, lhs, rhs)?.as_bool() {
                 return Some(Value::bool(true));
             }
         }
         Some(Value::bool(false))
     } else {
-        op::cmp_teq_case_values(vm, globals, lhs, rhs)
+        teq(vm, globals, lhs, rhs)
     }
 }
 
@@ -1028,6 +1051,7 @@ pub(super) extern "C" fn get_index(
             let method = base.as_method();
             let receiver = method.receiver();
             if let Some(target) = method.method_missing_name() {
+                vm.reset_method_missing_vcall();
                 return vm.invoke_method(
                     globals,
                     IdentId::METHOD_MISSING,

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -123,6 +123,14 @@ pub struct Executor {
     /// never mis-attribute a haystack — it only falls back to copying.
     sp_match_haystack: Option<Value>,
     temp_stack: Vec<Value>,
+    /// Whether the method_missing dispatch currently being set up came
+    /// from a "variable call" (bare identifier). Consumed
+    /// (read-and-cleared) by the default `BasicObject#method_missing`,
+    /// which raises NameError for a vcall and NoMethodError otherwise,
+    /// mirroring CRuby's call-status VCALL flag. Every method_missing
+    /// dispatch site overwrites it, so it never carries stale state
+    /// into a later dispatch.
+    method_missing_vcall: bool,
     require_level: usize,
     /// Stack of canonical paths currently being executed via `require` /
     /// autoload. Used so that `Module#autoload :Foo, path` can detect
@@ -162,6 +170,7 @@ impl std::default::Default for Executor {
             sp_match_regex: None,
             sp_match_haystack: None,
             temp_stack: vec![],
+            method_missing_vcall: false,
             require_level: 0,
             loading_paths: vec![],
             catch_tags: vec![],
@@ -1023,6 +1032,18 @@ impl Executor {
         self.exception.as_ref()
     }
 
+    /// Read-and-clear the vcall marker for the method_missing dispatch
+    /// currently being executed (see the field docs).
+    pub(crate) fn take_method_missing_vcall(&mut self) -> bool {
+        std::mem::take(&mut self.method_missing_vcall)
+    }
+
+    /// Mark the method_missing dispatch being set up as a plain
+    /// (non-vcall) one.
+    pub(crate) fn reset_method_missing_vcall(&mut self) {
+        self.method_missing_vcall = false;
+    }
+
     pub(crate) fn take_ex_obj(&mut self, globals: &mut Globals) -> Value {
         let mut err = self.take_error();
         let explicit_cause = err.explicit_cause;
@@ -1819,6 +1840,7 @@ impl Executor {
             Ok(id) => id,
             Err(original_err) => {
                 // Fall back to method_missing, matching CRuby behavior.
+                self.method_missing_vcall = false;
                 match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
                     Ok(mm_func_id) => {
                         let mut mm_args = Vec::with_capacity(args.len() + 1);
@@ -1866,6 +1888,7 @@ impl Executor {
             Ok(func_id) => self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args),
             Err(original_err) => {
                 // Fall back to method_missing, matching CRuby behavior.
+                self.method_missing_vcall = false;
                 match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
                     Ok(mm_func_id) => {
                         let mut mm_args = Vec::with_capacity(args.len() + 1);
@@ -1908,6 +1931,7 @@ impl Executor {
     ) -> Option<Value> {
         // Extract all needed fields from callsite before we mutably borrow self/globals.
         let cs = &globals.store[callsite];
+        self.method_missing_vcall = cs.vcall;
         let cs_name = cs.name;
         let cs_args = cs.args;
         let cs_pos_num = cs.pos_num;

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -404,10 +404,14 @@ impl Store {
         match info.owner_class().get(0) {
             Some(owner) => {
                 if let Some(obj) = self[*owner].get_module().is_singleton() {
-                    if let Some(class) = obj.is_class() {
+                    if let Some(class) = obj.is_class_or_module() {
                         format!("{}.{name}", class.id().get_name(self))
                     } else {
-                        format!("{}.{name}", obj.debug_tos(self))
+                        // CRuby names a plain object's singleton
+                        // method by the bare method name (only
+                        // class/module singletons get the
+                        // `Owner.name` form).
+                        name
                     }
                 } else {
                     format!("{}#{name}", owner.get_name(self))
@@ -665,6 +669,7 @@ impl Store {
         dst: Option<SlotId>,
         forwarding: bool,
         bypass_visibility: bool,
+        vcall: bool,
     ) -> CallSiteId {
         let id = CallSiteId(self.callsite_info.len() as u32);
         self.callsite_info.push(CallSiteInfo {
@@ -683,6 +688,7 @@ impl Store {
             dst,
             forwarding,
             bypass_visibility,
+            vcall,
         });
         id
     }
@@ -1476,6 +1482,10 @@ pub struct CallSiteInfo {
     /// `initialize` while keeping the natural forwarding-call shape
     /// (which the D1 forwarding-rest deferral can specialize).
     pub(crate) bypass_visibility: bool,
+    /// A "variable call" (bare identifier, no receiver / args /
+    /// parens): a failed lookup raises NameError instead of
+    /// NoMethodError.
+    pub(crate) vcall: bool,
 }
 
 impl CallSiteInfo {

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -490,6 +490,7 @@ pub(crate) fn method_to_proc_body(
     if let Some(target) = method.method_missing_name() {
         // Mirror `Method#call`: dispatch `receiver.method_missing(name, …)`
         // by name so a later `method_missing` redefinition is honored.
+        vm.reset_method_missing_vcall();
         let mut mm_args = vec![Value::symbol(target)];
         mm_args.extend(args);
         return vm.invoke_method_inner(

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -4139,6 +4139,15 @@ impl<'pr> Lowerer<'pr> {
             });
         }
 
+        // A "variable call" — a bare identifier with no receiver,
+        // arguments, or parentheses (`foo` as opposed to `foo()` /
+        // `self.foo`). Lowered to its own node kind because a failed
+        // lookup must raise NameError ("undefined local variable or
+        // method ...") instead of NoMethodError.
+        if node.is_variable_call() {
+            return Ok(Node::new_identifier(method, loc));
+        }
+
         let mut arglist = crate::ast::ArgList::default();
         arglist.args = args;
         arglist.kw_args = kw_args;

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -2953,3 +2953,37 @@ fn safe_nav_assign_jit() {
         "class C; attr_accessor :x; end",
     );
 }
+
+#[test]
+fn vcall_raises_name_error() {
+    // A bare identifier (a "variable call" — could as well have been
+    // a local variable) raises NameError when undefined; an
+    // unambiguous method call raises NoMethodError.
+    run_test(
+        r#"
+        res = []
+        check = proc do |blk|
+          begin
+            blk.call
+            "no error"
+          rescue NoMethodError => e
+            "NoMethodError"
+          rescue NameError => e
+            "NameError: #{e.name}"
+          end
+        end
+        res << check.call(proc { some_undefined_bare_name })
+        res << check.call(proc { some_undefined_bare_name() })
+        res << check.call(proc { self.some_undefined_bare_name })
+        res << check.call(proc { eval("_9999") })
+        # A user-defined method_missing still catches vcalls.
+        o = Object.new
+        def o.method_missing(name, *args) = "mm:#{name}"
+        res << o.instance_eval { completely_undefined }
+        # ...and the default method_missing after it stays NoMethodError
+        # for a plain call shape.
+        res << check.call(proc { self.another_undefined_one })
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -602,3 +602,57 @@ fn rescue_clause_match_jit() {
         "#,
     );
 }
+
+#[test]
+fn rescue_splat_clause_requires_class_or_module() {
+    run_test(
+        r#"
+        res = []
+        [[42], [RuntimeError], [TypeError, RuntimeError], []].each do |list|
+          begin
+            begin
+              raise "boom"
+            rescue *list
+              res << "caught"
+            rescue RuntimeError
+              res << "unmatched"
+            end
+          rescue TypeError => e
+            res << e.message
+          end
+        end
+        # An empty rescue body plus no exception: the clause list is
+        # never evaluated, so an invalid element does not raise.
+        begin
+          res << :fine
+        rescue *[42]
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn singleton_method_backtrace_naming() {
+    // CRuby names a plain object's singleton method by the bare
+    // method name in backtraces; class/module singletons get the
+    // `Owner.name` form. Compare only the method-name part (paths
+    // and line numbers of the harness temp files differ).
+    run_test(
+        r#"
+        res = []
+        o = Object.new
+        def o.sing_meth = raise("x")
+        module BTM; def self.mod_meth = raise("y"); end
+        class BTC; def self.cls_meth = raise("z"); end
+        [proc { o.sing_meth }, proc { BTM.mod_meth }, proc { BTC.cls_meth }].each do |p|
+          begin
+            p.call
+          rescue => e
+            res << e.backtrace.first.split(":in ").last
+          end
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/yield.rs
+++ b/monoruby/tests/yield.rs
@@ -227,3 +227,32 @@ fn block_auto_splat_to_ary_type_error() {
         "#,
     );
 }
+
+#[test]
+fn yield_outside_method_is_a_syntax_error() {
+    run_test_once(
+        r#"
+        res = []
+        obj = Object.new
+        ["class << obj; yield; end",
+         "module YSM; yield; end",
+         "class YSC; yield; end",
+         "1.times { yield }",
+         "yield"].each do |code|
+          begin
+            eval(code)
+            res << "no error"
+          rescue SyntaxError
+            res << "SyntaxError"
+          rescue LocalJumpError
+            res << "LocalJumpError"
+          end
+        end
+        # yield in a method (and in a block inside a method) stays legal.
+        eval("def ytm1; yield; end")
+        eval("def ytm2; 1.times { yield }; end")
+        res << eval("defined?(yield)").inspect
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Third batch of ruby/spec `language` fixes (follow-up to #861 / #862), continuing down the classified failure list in cost/benefit order. Four independent fixes:

### 1. Failed variable calls raise NameError

A bare identifier with no receiver/arguments/parentheses (prism's *variable call*) could as well have been a local variable, so CRuby's default `method_missing` raises `NameError` (`undefined local variable or method '...'`) for it, while `foo()` / `self.foo` stay `NoMethodError`. The lowerer now maps `is_variable_call()` CallNodes to `NodeKind::Ident` (previously an unused leftover node kind), bytecodegen marks the callsite as a vcall (new `CallSiteInfo::vcall` flag, threaded like `bypass_visibility`), and each method_missing dispatch records the flag on the `Executor` for the default `BasicObject#method_missing` to consume — mirroring CRuby's call-status VCALL flag. Every dispatch site overwrites the flag, so no stale state can leak between dispatches; user-defined `method_missing` is unaffected.

### 2. `yield` outside a method body is a compile-time SyntaxError

CRuby rejects `yield` at parse time when no method could supply a block: class/module/sclass bodies, the top level, and blocks belonging to any of those (`eval("module M; yield; end")` → SyntaxError "Invalid yield"). monoruby compiled these to a runtime LocalJumpError. `gen_yield` now checks the mother scope's `FuncType`; `defined?(yield)` compiles to its own instruction and still returns nil quietly.

### 3. Splatted rescue clauses are validated

`rescue *list` now raises `TypeError: class or module required for rescue clause` for non-Class/Module elements, closing the gap noted as future work in #862 (the splat form previously matched through the unvalidated case/when `array_teq` helper). The clause compiles to a rescue-splat variant of `ArrayTEq` (opcode 44); both VM backends share the opcode-40 handler through a parameterized generator, dispatching to `rescue_array_teq` (per-element validation + funcall `===`). Like scalar `RescueTEq` (157), the opcode only ever executes inside exception handlers, which the JIT's BB graph never visits, so its decode arm documents that invariant instead of lowering.

### 4. Backtrace naming for object singleton methods

CRuby names a plain object's singleton method by the bare method name in backtraces (`in 'foo'`), and module singletons as `M.foo`; monoruby printed `#<Object:0x...>.foo` for both. `func_description` now distinguishes class/module singletons from plain-object singletons.

## ruby/spec impact (language category)

111 → 104 failing examples:
- `numbered_parameters_spec.rb`: 2 → 0 failing
- `yield_spec.rb`: 4 → 1 failing
- `class_spec.rb`: block-of-original-scope example fixed
- `rescue_spec.rb`: splatted-clause TypeError example fixed

## Test plan

- `cargo test` — full suite green, with new integration tests: vcall NameError shapes (bare/parens/receiver/eval/custom-method_missing), invalid-yield contexts, rescue-splat validation incl. the not-evaluated-without-exception case, and backtrace naming for the three singleton shapes.
- Manual diff scripts for all four areas verified identical output against CRuby 4.0.2.
- aarch64: the rescue-splat VM handler is generated by the same parameterized routine as the existing opcode-40 handler; verified by the darwin CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_