### PR TITLE
CRuby super semantics (block forwarding, method_missing fallback, define_method guard) and eval-site def scoping

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -154,17 +154,29 @@ fn bo_method_missing(
     let args = lfp.arg(0).as_array();
     let name = args[0].expect_symbol_or_string(globals)?;
     let recv = lfp.self_val();
-    // A failed "variable call" (bare identifier — could as well have
-    // been a local variable) raises NameError, not NoMethodError,
-    // mirroring CRuby's default method_missing on a VCALL.
-    if vm.take_method_missing_vcall() {
-        return Err(MonorubyErr::nameerr_with_name(
-            format!(
-                "undefined local variable or method `{name}' for {}",
-                recv.to_s(&globals.store)
-            ),
-            name,
-        ));
+    // The call style shapes the error, mirroring CRuby's default
+    // method_missing: a failed "variable call" (bare identifier —
+    // could as well have been a local variable) raises NameError, and
+    // a failed `super` raises the super-flavored NoMethodError.
+    use crate::executor::MethodMissingStyle;
+    match vm.take_method_missing_style() {
+        MethodMissingStyle::VCall => {
+            return Err(MonorubyErr::nameerr_with_name(
+                format!(
+                    "undefined local variable or method `{name}' for {}",
+                    recv.to_s(&globals.store)
+                ),
+                name,
+            ));
+        }
+        MethodMissingStyle::Super => {
+            return Err(MonorubyErr::super_method_not_found(
+                &globals.store,
+                name,
+                recv,
+            ));
+        }
+        MethodMissingStyle::Plain => {}
     }
     // Reaching the default `method_missing` while the method actually
     // exists means the call violated visibility (a private method called

--- a/monoruby/src/bytecodegen/method_call/arguments.rs
+++ b/monoruby/src/bytecodegen/method_call/arguments.rs
@@ -22,7 +22,14 @@ impl<'a> BytecodeGen<'a> {
         dst: Option<BcReg>,
         loc: Loc,
     ) -> Result<CallSite> {
-        if let Some(arglist) = arglist {
+        if let Some(mut arglist) = arglist {
+            // `super(args)` with no explicit block still forwards the
+            // calling method's block, exactly like zsuper — only a
+            // literal block or an explicit `&blk` / `&nil` argument
+            // overrides it.
+            if arglist.block.is_none() && !arglist.delegate_block {
+                arglist.delegate_block = true;
+            }
             self.handle_arguments(arglist, None, BcReg::Self_, dst, loc)
         } else {
             Ok(self.handle_super_forward(dst, loc))

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -35,7 +35,7 @@ pub(super) extern "C" fn find_method(
         let is_func_call = globals[callid].is_func_call();
         vm.find_method(globals, recv, func_name, is_func_call)
     } else {
-        find_super(vm, globals)
+        find_super(vm, globals, callid)
     }
     .map_err(|err| vm.set_error(err))
     .ok();
@@ -54,8 +54,20 @@ pub(super) extern "C" fn find_method(
     ((cache_class.u32() as u64) << 32) | fid.map_or(0, |f| f.get()) as u64
 }
 
-fn find_super(vm: &mut Executor, globals: &mut Globals) -> Result<FuncId> {
+fn find_super(vm: &mut Executor, globals: &mut Globals, callid: CallSiteId) -> Result<FuncId> {
     let func_id = vm.method_func_id();
+    // zsuper (implicit-argument `super`) forwards the frame's
+    // arguments by the *definition-time* parameter layout, which is
+    // meaningless for a method created by define_method (the block's
+    // captured outer frame is not this call's frame). CRuby raises
+    // RuntimeError at call time; `super()` / explicit arguments are
+    // fine. zsuper is the only super shape compiled with the
+    // `forwarding` flag set on its callsite.
+    if globals[callid].forwarding && globals.store[func_id].is_block_style() {
+        return Err(MonorubyErr::runtimeerr(
+            "implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly.",
+        ));
+    }
     let self_val = vm.cfp().lfp().self_val();
     let func_name = globals.store[func_id].name().unwrap();
     let self_class = self_val.class();
@@ -721,22 +733,18 @@ pub(crate) extern "C" fn invoke_method_missing(
     callsite: CallSiteId,
 ) -> Option<Value> {
     if globals[callsite].name.is_none() {
-        // A super call: CRuby never falls through to method_missing when no
-        // superclass method is found.
-        //
-        // On the first (uncached) miss, `find_super` has just set the error.
-        // But once the inline cache is warm (class matches, fid slot = 0),
-        // the VM fast path jumps straight here without calling `find_method`,
-        // so no error is set yet — set it now, mirroring `find_super`.
-        if vm.exception().is_none() {
-            let func_id = vm.method_func_id();
-            let self_val = vm.cfp().lfp().self_val();
-            let func_name = globals.store[func_id].name().unwrap();
-            vm.set_error(MonorubyErr::super_method_not_found(
-                globals, func_name, self_val,
-            ));
+        // A super call that found no superclass method: like CRuby,
+        // fall through to method_missing with the calling method's
+        // name (the default method_missing then raises the
+        // super-flavored NoMethodError). One exception: the
+        // define_method-zsuper RuntimeError from `find_super` is a
+        // hard error, not a missing method.
+        if vm
+            .exception()
+            .is_some_and(|err| !matches!(err.kind(), MonorubyErrKind::NotMethod { .. }))
+        {
+            return None;
         }
-        return None;
     }
     vm.discard_error();
     vm.invoke_method_missing(globals, receiver, lfp, callsite)

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1700,7 +1700,21 @@ impl Executor {
         // shared cref stack), and its visibility resets to public. A `def`
         // in any other frame (class/module body, `class_eval` /
         // `instance_eval` block, or the top level) uses the runtime cref.
-        let in_method_body = globals.store[self.cfp().lfp().func_id()].is_method();
+        let in_method_body = {
+            let mut fid = self.cfp().lfp().func_id();
+            // A `def` in eval'd source behaves as if written at the
+            // eval site, so walk out of def-transparent eval frames
+            // (receiver-anchored `class_eval` / `instance_eval`
+            // string bodies are not transparent — see
+            // `ISeqInfo::is_eval`).
+            while let Some(iseq) = globals.store[fid].is_iseq()
+                && globals.store[iseq].is_eval
+                && let Some(outer) = globals.store[iseq].outer
+            {
+                fid = globals.store[outer].func_id();
+            }
+            globals.store[fid].is_method()
+        };
         let current_func = self.definition_func_id(globals);
         if let Some(iseq) = globals.store[func].is_iseq() {
             // Inherit the enclosing method's lexical context. The

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -84,6 +84,19 @@ pub(crate) const EXECUTOR_STACK_LIMIT: i64 = std::mem::offset_of!(Executor, stac
 ///
 /// Bytecode interpreter.
 ///
+/// How a call that fell through to method_missing was spelled — see
+/// `Executor::method_missing_style`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum MethodMissingStyle {
+    /// Ordinary call (`foo()`, `x.foo`).
+    #[default]
+    Plain,
+    /// Variable call: bare identifier with no receiver/args/parens.
+    VCall,
+    /// A `super` call that found no superclass method.
+    Super,
+}
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct Executor {
@@ -123,14 +136,15 @@ pub struct Executor {
     /// never mis-attribute a haystack — it only falls back to copying.
     sp_match_haystack: Option<Value>,
     temp_stack: Vec<Value>,
-    /// Whether the method_missing dispatch currently being set up came
-    /// from a "variable call" (bare identifier). Consumed
-    /// (read-and-cleared) by the default `BasicObject#method_missing`,
-    /// which raises NameError for a vcall and NoMethodError otherwise,
-    /// mirroring CRuby's call-status VCALL flag. Every method_missing
-    /// dispatch site overwrites it, so it never carries stale state
-    /// into a later dispatch.
-    method_missing_vcall: bool,
+    /// How the method_missing dispatch currently being set up was
+    /// called. Consumed (read-and-cleared) by the default
+    /// `BasicObject#method_missing`, which raises NameError for a
+    /// vcall, the super-flavored NoMethodError for a failed `super`,
+    /// and a plain NoMethodError otherwise — mirroring CRuby's
+    /// call-status flags. Every method_missing dispatch site
+    /// overwrites it, so it never carries stale state into a later
+    /// dispatch.
+    method_missing_style: MethodMissingStyle,
     require_level: usize,
     /// Stack of canonical paths currently being executed via `require` /
     /// autoload. Used so that `Module#autoload :Foo, path` can detect
@@ -170,7 +184,7 @@ impl std::default::Default for Executor {
             sp_match_regex: None,
             sp_match_haystack: None,
             temp_stack: vec![],
-            method_missing_vcall: false,
+            method_missing_style: MethodMissingStyle::Plain,
             require_level: 0,
             loading_paths: vec![],
             catch_tags: vec![],
@@ -1032,16 +1046,15 @@ impl Executor {
         self.exception.as_ref()
     }
 
-    /// Read-and-clear the vcall marker for the method_missing dispatch
-    /// currently being executed (see the field docs).
-    pub(crate) fn take_method_missing_vcall(&mut self) -> bool {
-        std::mem::take(&mut self.method_missing_vcall)
+    /// Read-and-clear the call-style marker for the method_missing
+    /// dispatch currently being executed (see the field docs).
+    pub(crate) fn take_method_missing_style(&mut self) -> MethodMissingStyle {
+        std::mem::take(&mut self.method_missing_style)
     }
 
-    /// Mark the method_missing dispatch being set up as a plain
-    /// (non-vcall) one.
+    /// Mark the method_missing dispatch being set up as a plain one.
     pub(crate) fn reset_method_missing_vcall(&mut self) {
-        self.method_missing_vcall = false;
+        self.method_missing_style = MethodMissingStyle::Plain;
     }
 
     pub(crate) fn take_ex_obj(&mut self, globals: &mut Globals) -> Value {
@@ -1840,7 +1853,7 @@ impl Executor {
             Ok(id) => id,
             Err(original_err) => {
                 // Fall back to method_missing, matching CRuby behavior.
-                self.method_missing_vcall = false;
+                self.method_missing_style = MethodMissingStyle::Plain;
                 match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
                     Ok(mm_func_id) => {
                         let mut mm_args = Vec::with_capacity(args.len() + 1);
@@ -1888,7 +1901,7 @@ impl Executor {
             Ok(func_id) => self.invoke_func_inner(globals, func_id, receiver, args, bh, kw_args),
             Err(original_err) => {
                 // Fall back to method_missing, matching CRuby behavior.
-                self.method_missing_vcall = false;
+                self.method_missing_style = MethodMissingStyle::Plain;
                 match self.find_method(globals, receiver, IdentId::METHOD_MISSING, true) {
                     Ok(mm_func_id) => {
                         let mut mm_args = Vec::with_capacity(args.len() + 1);
@@ -1931,7 +1944,13 @@ impl Executor {
     ) -> Option<Value> {
         // Extract all needed fields from callsite before we mutably borrow self/globals.
         let cs = &globals.store[callsite];
-        self.method_missing_vcall = cs.vcall;
+        self.method_missing_style = if cs.name.is_none() {
+            MethodMissingStyle::Super
+        } else if cs.vcall {
+            MethodMissingStyle::VCall
+        } else {
+            MethodMissingStyle::Plain
+        };
         let cs_name = cs.name;
         let cs_args = cs.args;
         let cs_pos_num = cs.pos_num;

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -760,6 +760,11 @@ impl Globals {
                 if let Some(class_id) = receiver_class {
                     if let Some(info) = self.store.iseq_mut(fid) {
                         info.lexical_context.push(class_id);
+                        // A receiver-anchored eval (`class_eval` /
+                        // `instance_eval` with a string) defines
+                        // methods on its receiver through the runtime
+                        // cref, not at the eval site.
+                        info.is_eval = false;
                     }
                 }
                 #[cfg(feature = "emit-bc")]

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -581,7 +581,10 @@ impl Store {
         // a lambda). eval bodies and lambdas are otherwise both
         // method-style (no own params), so this flag is what keeps their
         // non-local-vs-local `return` semantics apart.
-        self.new_block(outer, compile_info, true, loc, result.source_info)
+        let fid = self.new_block(outer, compile_info, true, loc, result.source_info)?;
+        let iseq = self[fid].is_iseq().unwrap();
+        self[iseq].is_eval = true;
+        Ok(fid)
     }
 
     pub(crate) fn new_builtin_func(

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -93,6 +93,16 @@ pub struct ISeqInfo {
     ///
     pub outer: Option<ISeqId>,
     ///
+    /// Whether this ISeq is a `def`-transparent eval frame: a `def`
+    /// in `eval`'d (or `binding.eval`'d) source behaves as if written
+    /// at the eval site, so the definee search walks out of this
+    /// frame. `class_eval` / `instance_eval` string bodies are *not*
+    /// transparent — they anchor `def` to their receiver (via the
+    /// runtime cref the builtin pushes), and reset this flag in
+    /// `compile_script_eval`.
+    ///
+    pub(crate) is_eval: bool,
+    ///
     /// Name of this function.
     ///
     name: Option<IdentId>,
@@ -212,6 +222,7 @@ impl ISeqInfo {
             func_id: id,
             mother,
             outer,
+            is_eval: false,
             name,
             bytecode: None,
             loc,

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3052,3 +3052,47 @@ fn zsuper_from_define_method_is_a_runtime_error() {
         "#,
     );
 }
+
+#[test]
+fn def_in_eval_uses_eval_site_scope() {
+    // A def in eval'd source behaves as if written at the eval site:
+    // inside a method it defines a public method on the method's
+    // owner (even when the whole thing runs under instance_exec,
+    // whose receiver cref must not capture it), while class_eval /
+    // instance_eval string bodies keep anchoring to their receiver.
+    run_test(
+        r#"
+        res = []
+        class EvalDefIM
+          def make
+            eval "def eval_defined_m; self; end", binding
+            eval_defined_m
+          end
+        end
+        env = Object.new
+        env.instance_exec do
+          o = EvalDefIM.new
+          res = [o.make == o, EvalDefIM.new.eval_defined_m.class.to_s,
+                 EvalDefIM.public_method_defined?(:eval_defined_m)]
+        end
+        class EvalDefCM
+          class << self
+            def make_c
+              eval "def eval_defined_cm; self; end"
+              eval_defined_cm
+            end
+          end
+        end
+        res << (EvalDefCM.make_c == EvalDefCM)
+        class EvalDefTarget; end
+        EvalDefTarget.class_eval "def ce_string_m; :ce; end"
+        res << EvalDefTarget.new.ce_string_m
+        obj = Object.new
+        obj.instance_eval "def ie_string_m; :ie; end"
+        res << obj.ie_string_m
+        eval "def toplevel_eval_def_m; :t; end"
+        res << Object.private_method_defined?(:toplevel_eval_def_m)
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -2987,3 +2987,68 @@ fn vcall_raises_name_error() {
         "#,
     );
 }
+
+#[test]
+fn super_forwards_callers_block() {
+    // `super(args)` with no explicit block forwards the calling
+    // method's block, exactly like zsuper; a literal block or an
+    // explicit `&nil` overrides it.
+    run_test(
+        r#"
+        c1 = Class.new { def m; block_given? ? yield : :noblock; end }
+        c2 = Class.new(c1) { def m(v); super(); end }
+        c3 = Class.new(c1) { def m(v); ary = []; 1.times { ary << super() }; ary; end }
+        c4 = Class.new(c1) { def m(v); super(&nil); end }
+        c5 = Class.new(c1) { def m(v); super() { :literal }; end }
+        [
+          c2.new.m(1) { :b1 },
+          c3.new.m(1) { :b2 },
+          c4.new.m(1) { :b3 },
+          c5.new.m(1) { :b4 },
+        ]
+        "#,
+    );
+}
+
+#[test]
+fn super_miss_calls_method_missing() {
+    run_test(
+        r#"
+        res = []
+        klass = Class.new do
+          def method_missing(name, *args) = "mm: #{name} #{args.inspect}"
+          def probe(x) = super
+        end
+        res << klass.new.probe(7)
+        plain = Class.new { def probe(x) = super }
+        begin
+          plain.new.probe(1)
+        rescue NoMethodError => e
+          # monoruby quotes method names backtick-style; normalize.
+          res << e.message.lines.first.split(" for ").first.tr("`", "'")
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn zsuper_from_define_method_is_a_runtime_error() {
+    run_test(
+        r#"
+        parent = Class.new { def m(a) = "parent #{a}" }
+        res = []
+        c1 = Class.new(parent)
+        c1.send(:define_method, :m) { |x| begin; super; rescue RuntimeError => e; "RuntimeError"; end }
+        res << c1.new.m(1)
+        # Explicit arguments stay allowed.
+        c2 = Class.new(parent)
+        c2.send(:define_method, :m) { |x| super(x * 2) }
+        res << c2.new.m(21)
+        # zsuper in a plain block inside a normal method is still fine.
+        c3 = Class.new(parent) { def m(a); r = nil; 1.times { r = super }; r; end }
+        res << c3.new.m(5)
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Fourth batch of ruby/spec `language` fixes (follow-up to #861/#862/#863), continuing down the classified failure list in cost/benefit order.

### 1. `super` dispatch semantics (3 fixes)

- **Block forwarding**: `super(args)` with no explicit block now forwards the calling method's block, exactly like zsuper; a literal block or an explicit `&blk` / `&nil` argument still overrides it. (Previously the explicit-args form silently dropped the block, so `def m(v); super(); end` over a yielding parent raised LocalJumpError.)
- **method_missing fallback**: a `super` call that finds no superclass method now falls through to `method_missing` with the calling method's name — the removed short-circuit asserted CRuby never does this, but it does. The default `BasicObject#method_missing` raises the super-flavored NoMethodError (`super: no superclass method ...`); the vcall marker introduced in #863 grew into a three-state `MethodMissingStyle` (Plain / VCall / Super) to carry the distinction.
- **define_method zsuper guard**: zsuper from a method defined by `define_method` raises CRuby's RuntimeError (`implicit argument passing of super from method defined by define_method() is not supported...`) instead of forwarding arguments by the block's definition-time frame layout and failing with a confusing ArgumentError. Detected at super dispatch: zsuper is the only super shape compiled with the callsite `forwarding` flag, and the executing method is block-style. `super()` / explicit arguments keep working, as does zsuper in a plain block inside a normal method.

### 2. `def` in eval'd source defines at the eval site

CRuby shares the caller's cref with eval'd code, so `eval("def m; end")` inside a method defines a **public** method on the method's owner. monoruby computed the def target from the immediate frame — the eval body itself — so the def fell through to the runtime-cref path and landed on Object (or on an active `instance_exec` receiver) as a **private** method.

Eval-compiled iseqs are now marked def-transparent (`ISeqInfo::is_eval`) and the definee computation walks out of them. `class_eval` / `instance_eval` string bodies are receiver-anchored (they already compile with `receiver_class`; `compile_script_eval` resets the flag), so they keep defining on their receiver through the runtime cref the builtin pushes.

## ruby/spec impact (language category)

104 → 98 failing examples:
- `super_spec.rb`: 6 → 2 failing (both block-forwarding examples, the method_missing example, and the define_method example)
- `def_spec.rb`: both `A method definition in an eval` examples fixed

## Test plan

- `cargo test --features stress-spill-pool,gc-stress` (the CI feature set) — full suite green.
- New integration tests: super block forwarding (zsuper/`super()`/`&nil`/literal-block shapes, including from an inner block), super-miss → method_missing (user-defined and default), define_method zsuper RuntimeError alongside the still-legal shapes, and eval-site def scoping (method body under `instance_exec`, sclass method, `class_eval`/`instance_eval` strings, toplevel eval).
- Manual diff scripts for both areas verified identical output against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_