### PR TITLE
Class metaclasses are classed by Class's metaclass, and a caught throw restores $!

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2667,6 +2667,7 @@ fn catch_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         None => Value::object(OBJECT_CLASS),
     };
     let bh = lfp.expect_block()?;
+    let saved_errinfo = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
     vm.push_catch_tag(tag);
     let res = vm.invoke_block_once(globals, bh, &[tag]);
     vm.pop_catch_tag();
@@ -2675,6 +2676,10 @@ fn catch_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         Err(err) => {
             if let MonorubyErrKind::Throw(throw_tag, throw_val) = err.kind() {
                 if tag.id() == throw_tag.id() {
+                    // A caught throw restores `$!` to its value at
+                    // catch entry: throwing from inside a rescue must
+                    // not leak the in-flight exception.
+                    globals.set_gvar(IdentId::get_id("$!"), saved_errinfo);
                     return Ok(*throw_val);
                 }
             }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -770,7 +770,13 @@ impl ClassInfoTable {
         let original_obj = self.get_module(original);
         if original_obj.as_val().ty() == Some(ObjTy::CLASS) {
             let class = self[original_obj.as_val().class()].get_module();
-            if original_obj.is_singleton().is_none() && class.is_singleton().is_some() {
+            // The metaclass exists iff the class field already points
+            // at a singleton attached to us. (Checking attachment —
+            // not just singleton-ness — matters for metaclasses of
+            // metaclasses, whose class field starts out pointing at a
+            // singleton attached to something else.)
+            if class.is_singleton().is_some_and(|attached| attached.id() == original_obj.as_val().id())
+            {
                 return class;
             }
             let super_singleton = match original_obj.superclass_id() {
@@ -780,10 +786,21 @@ impl ClassInfoTable {
             let mut original_obj = original_obj.as_val();
             let mut singleton = self.new_singleton_class(super_singleton, original_obj, class.id());
             original_obj.change_class(singleton.id());
+            // MRI's eigenclass model: the class of a metaclass is the
+            // metaclass of the class's class — so S(A).class is
+            // S(Class), which is what makes
+            // `A.singleton_class.is_a?(Class.singleton_class)` hold.
+            // Class's own metaclass is its own class (the
+            // self-referential root that terminates the recursion).
             let class_class = if class.id() == original {
                 singleton.id()
+            } else if class.is_singleton().is_some() {
+                // Building a metaclass of a metaclass: keep the
+                // previous one-level model (MRI's full
+                // meta-metaclass tower is not modeled).
+                class.id()
             } else {
-                self.get_module(class.id()).id()
+                self.get_metaclass(class.id()).id()
             };
             singleton.change_class(class_class);
             #[cfg(debug_assertions)]
@@ -819,7 +836,15 @@ impl ClassInfoTable {
         }
         let mut singleton = self.new_singleton_class(org_class, obj, org_class.id());
         obj.change_class(singleton.id());
-        let singleton_meta = org_class.get_real_class().as_val().class();
+        // MRI's eigenclass model: a module's metaclass is classed by
+        // Module's metaclass (classes route through `get_metaclass`,
+        // which does the same with Class). A plain object's singleton
+        // class keeps pointing at the receiver's real class's class.
+        let singleton_meta = if obj.is_class_or_module().is_some() {
+            self.get_metaclass(org_class.id()).id()
+        } else {
+            org_class.get_real_class().as_val().class()
+        };
         singleton.change_class(singleton_meta);
         #[cfg(debug_assertions)]
         {

--- a/monoruby/tests/class_chain.rs
+++ b/monoruby/tests/class_chain.rs
@@ -147,3 +147,30 @@ fn superclass_must_be_a_class() {
         "#,
     );
 }
+
+#[test]
+fn metaclass_is_classed_by_class_metaclass() {
+    // MRI's eigenclass model (one level deep): the class of a class's
+    // metaclass is Class's metaclass, a module's metaclass is classed
+    // by Module's metaclass, and Class's own metaclass is its own
+    // class. `.class` still reports Class everywhere (it skips
+    // singletons), and plain objects' singleton classes are untouched.
+    run_test(
+        r#"
+        class MCA; end
+        class MCH < MCA; end
+        module MCM; end
+        [
+          MCA.singleton_class.is_a?(Class.singleton_class),
+          MCM.singleton_class.is_a?(Module.singleton_class),
+          MCH.singleton_class.superclass == MCA.singleton_class,
+          MCA.singleton_class.class.to_s,
+          MCM.singleton_class.class.to_s,
+          Object.new.singleton_class.class.to_s,
+          Class.singleton_class.class == Class.singleton_class,
+          MCA.singleton_class.is_a?(Class),
+          MCA.new.singleton_class.is_a?(Class),
+        ]
+        "#,
+    );
+}

--- a/monoruby/tests/class_chain.rs
+++ b/monoruby/tests/class_chain.rs
@@ -170,6 +170,10 @@ fn metaclass_is_classed_by_class_metaclass() {
           Class.singleton_class.class == Class.singleton_class,
           MCA.singleton_class.is_a?(Class),
           MCA.new.singleton_class.is_a?(Class),
+          # Metaclass of a metaclass: keeps the one-level class
+          # pointer and must neither loop nor recreate on each call.
+          MCA.singleton_class.singleton_class.to_s,
+          MCA.singleton_class.singleton_class.equal?(MCA.singleton_class.singleton_class),
         ]
         "#,
     );

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -656,3 +656,29 @@ fn singleton_method_backtrace_naming() {
         "#,
     );
 }
+
+#[test]
+fn caught_throw_restores_errinfo() {
+    run_test(
+        r#"
+        res = []
+        catch(:a) do
+          begin
+            raise "boom"
+          rescue
+            throw :a
+          end
+        end
+        res << $!.inspect
+        # An uncaught tag propagating out of an inner catch leaves the
+        # in-flight exception alone until the matching catch.
+        begin
+          raise "outer"
+        rescue
+          catch(:m) { catch(:inner) { throw :m } }
+          res << $!.message
+        end
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Fifth batch of ruby/spec `language` fixes (follow-up to #861–#864).

### 1. The class of a class's metaclass is Class's metaclass

MRI's eigenclass model, implemented one level deep: `get_metaclass` now points the new metaclass's class field at Class's metaclass (created on demand; Class's own metaclass stays self-referential, terminating the chain), and `get_singleton` does the same for modules via Module's metaclass. This is what makes `A.singleton_class.is_a?(Class.singleton_class)` hold. Plain objects' singleton classes are untouched, and `.class` still reports `Class` everywhere since it skips singletons.

Two structural details:

- **Existence check by attachment**: `get_metaclass` now recognizes an existing metaclass by the class field being a singleton *attached to the receiver*, not by mere singleton-ness. This memoizes metaclasses of metaclasses (each call previously created a fresh one) and keeps the new on-demand creation from recursing unboundedly.
- **One level only**: metaclasses of metaclasses keep the previous class pointer; MRI's full meta-metaclass tower (`rb_make_metametaclass`) is deliberately not modeled. The `same level of Class's singleton class` example stays failing (as before).

### 2. A caught throw restores `$!` to its catch-entry value

Throwing out of a rescue clause leaked the in-flight exception into `$!` after the matching `catch` returned; CRuby clears it back to the pre-catch state.

## ruby/spec impact (language category)

98 → 95 failing examples:
- `singleton_class_spec.rb`: `is a subclass of Class's singleton class` and `is a subclass of the same level of superclass's singleton class` fixed
- `throw_spec.rb`: now fully green

## Test plan

- `cargo test --features stress-spill-pool,gc-stress` (the CI feature set) — full suite green.
- New integration tests: the one-level eigenclass model (class/module/plain-object receivers, `.class` reporting, self-referential root, metaclass superclass chain) and `$!` restoration across caught/uncaught throws.
- Manual diff scripts verified identical output against CRuby 4.0.2 (the only remaining divergence is the unmodeled meta-metaclass case noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_