### PR TITLE
Restore $! per begin region on non-local rescue exits; empty-message Exception#inspect

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -535,7 +535,17 @@ struct BytecodeGen<'a> {
     /// loop information.
     loops: Vec<LoopInfo>, // (kind, label for exit, return register)
     /// ensure clause information.
-    ensure: Vec<Option<Node>>,
+    /// Lexical nesting depth of rescue clauses currently being
+    /// compiled: non-local exits restore `$!` only when they leave a
+    /// rescue clause (`$!` cannot have changed elsewhere).
+    rescue_depth: usize,
+    /// One entry per enclosing `begin` region (innermost last): the
+    /// region's `ensure` body (if any) and its `$!`-on-entry save slot
+    /// (present when the region has rescue clauses). Non-local exits
+    /// (`return`, `break`, `next`) crossing a region restore `$!` from
+    /// the slot and run the ensure body, innermost first — mirroring
+    /// CRuby's per-frame errinfo restore during unwinding.
+    ensure: Vec<(Option<Node>, Option<BcReg>)>,
     /// The name of the block param.
     block_param: Option<IdentId>,
     /// The label for redo.
@@ -550,7 +560,7 @@ struct BytecodeGen<'a> {
     /// Source info.
     sourceinfo: SourceInfoRef,
     /// Nesting depth of rescue blocks (for clearing $! on return).
-    rescue_depth: usize,
+
     /// Exception jump table.
     exception_table: Vec<ExceptionEntry>,
     /// Merge info.
@@ -591,13 +601,14 @@ impl<'a> BytecodeGen<'a> {
             labels: BytecodeLabels::new(), // The first label is for redo.
             loops: vec![],
             ensure: vec![],
+            rescue_depth: 0,
             block_param,
             redo_label: Label(0),
             retry_labels: vec![],
             temp: 0,
             temp_num: 0,
             sourceinfo,
-            rescue_depth: 0,
+
             exception_table: vec![],
             merge_info: HashMap::default(),
         };
@@ -806,9 +817,22 @@ impl<'a> BytecodeGen<'a> {
     /// Used by `break` / `next` so exiting the loop iteration still runs
     /// the `ensure` blocks it jumps out of.
     fn gen_loop_pending_ensures(&mut self, ensure_depth: usize) -> Result<()> {
-        let pending: Vec<Option<Node>> =
-            self.ensure[ensure_depth..].iter().rev().cloned().collect();
-        for ensure in pending {
+        let in_rescue = self.rescue_depth > 0;
+        let pending: Vec<_> = self.ensure[ensure_depth..].iter().rev().cloned().collect();
+        for (ensure, errinfo_save) in pending {
+            // Same unwinding protocol as `emit_ret`: restore the
+            // region's `$!` before running its ensure body.
+            if let Some(save) = errinfo_save
+                && in_rescue
+            {
+                self.emit(
+                    BytecodeInst::StoreGvar {
+                        val: save,
+                        name: IdentId::get_id("$!"),
+                    },
+                    Loc::default(),
+                );
+            }
             if let Some(ensure) = ensure {
                 self.gen_expr(ensure, UseMode2::NotUse)?;
             }
@@ -1046,25 +1070,33 @@ impl<'a> BytecodeGen<'a> {
         // a `return` appears inside an `ensure` block.  Without this, the
         // `return` in the ensure body would call `emit_ret` again, which would
         // re-generate the same ensure block, leading to unbounded recursion.
+        let in_rescue = self.rescue_depth > 0;
         let ensures: Vec<_> = std::mem::take(&mut self.ensure);
-        let ensure_nodes: Vec<_> = ensures.iter().rev().filter_map(|e| e.clone()).collect();
-        for ensure in ensure_nodes.into_iter() {
-            self.gen_expr(ensure.clone(), UseMode2::NotUse)?;
+        let pending: Vec<_> = ensures.iter().rev().cloned().collect();
+        for (ensure, errinfo_save) in pending {
+            // When leaving a rescue clause, restore `$!` to the
+            // region's entry value *before* its ensure body runs (a
+            // nested region's ensure must see the outer exception, not
+            // the one just rescued), and emit it even without an
+            // ensure body so the value is right after this method
+            // returns. Exits from elsewhere can't have changed `$!`.
+            if let Some(save) = errinfo_save
+                && in_rescue
+            {
+                self.emit(
+                    BytecodeInst::StoreGvar {
+                        val: save,
+                        name: IdentId::get_id("$!"),
+                    },
+                    Loc::default(),
+                );
+            }
+            if let Some(ensure) = ensure {
+                self.gen_expr(ensure, UseMode2::NotUse)?;
+            }
         }
         self.ensure = ensures;
-        // Clear $! when returning from within a rescue block.
-        if self.rescue_depth > 0 {
-            let tmp = self.push().into();
-            self.emit_nil(tmp);
-            self.emit(
-                BytecodeInst::StoreGvar {
-                    val: tmp,
-                    name: IdentId::get_id("$!"),
-                },
-                Loc::default(),
-            );
-            self.pop();
-        }
+
         let ret = match src {
             Some(ret) => ret,
             None => self.pop().into(),

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -23,6 +23,22 @@ impl<'a> BytecodeGen<'a> {
                 let res = defined_str(&node);
                 // CRuby returns a frozen String from `defined?`.
                 self.emit_frozen_string(dst, res);
+                // The definedness probes below may raise-and-swallow
+                // (a raising receiver evaluates under an exception
+                // entry that routes to `nil_label`), and the VM's
+                // rescue-entry path sets `$!` as a side effect. CRuby
+                // leaves `$!` untouched by `defined?`, so save it
+                // around the whole expression and restore on both
+                // exits. An anonymous local (not a temp) survives the
+                // probe region without being reused as scratch.
+                let errinfo_save: BcReg = self.add_local(None).into();
+                self.emit(
+                    BytecodeInst::LoadGvar {
+                        dst: errinfo_save,
+                        name: IdentId::get_id("$!"),
+                    },
+                    Loc::default(),
+                );
                 let exit_label = self.new_label();
                 let nil_label = self.new_label();
                 self.check_defined(node, nil_label, dst, true)?;
@@ -30,6 +46,13 @@ impl<'a> BytecodeGen<'a> {
                 self.apply_label(nil_label);
                 self.emit_nil(dst);
                 self.apply_label(exit_label);
+                self.emit(
+                    BytecodeInst::StoreGvar {
+                        val: errinfo_save,
+                        name: IdentId::get_id("$!"),
+                    },
+                    Loc::default(),
+                );
             }
         }
         Ok(())

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -416,7 +416,6 @@ impl<'a> BytecodeGen<'a> {
         ensure: Option<Box<Node>>,
         use_mode: UseMode2,
     ) -> Result<()> {
-        self.ensure.push(ensure.as_deref().cloned());
         let base = self.temp;
         // When this begin has rescue clauses, capture the `$!` active on
         // entry into a hidden local. CRuby restores `$!` to its previous
@@ -438,6 +437,7 @@ impl<'a> BytecodeGen<'a> {
         } else {
             None
         };
+        self.ensure.push((ensure.as_deref().cloned(), errinfo_save));
         let ensure_label = self.new_label();
         let body_use = if else_.is_some() {
             // if else_ exists, rescue must also exists.

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -609,7 +609,13 @@ impl RValue {
                 ObjTy::EXCEPTION => {
                     let class_name = store.get_class_name(self.class());
                     let msg = self.as_exception().message();
-                    format!("#<{class_name}: {msg}>")
+                    // CRuby: an empty message inspects as just the
+                    // class name.
+                    if msg.is_empty() {
+                        class_name
+                    } else {
+                        format!("#<{class_name}: {msg}>")
+                    }
                 }
                 ObjTy::REGEXP => self.as_regex().inspect(),
                 ObjTy::MATCHDATA => self.as_match_data().inspect(),

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -782,3 +782,29 @@ fn break_next_from_rescue_in_while_restores_errinfo() {
         "#,
     );
 }
+
+#[test]
+fn defined_probe_leaves_errinfo_untouched() {
+    // A raising receiver inside defined? is swallowed by the probe's
+    // exception entry; the VM's rescue-entry path must not leak the
+    // swallowed exception into `$!` (a later bare `raise` would
+    // re-raise it).
+    run_test(
+        r#"
+        h = {}
+        res = [defined?(h[]), $!.inspect]
+        begin
+          raise "outer"
+        rescue
+          res << defined?(1.zzz_probe.chain) << $!.message
+        end
+        err = begin
+          Object.new.instance_eval("raise", "a_file", 10)
+        rescue => e
+          e
+        end
+        res << err.backtrace.first.split(":")[0..1]
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -682,3 +682,68 @@ fn caught_throw_restores_errinfo() {
         "#,
     );
 }
+
+#[test]
+fn return_from_rescue_restores_errinfo() {
+    // A return leaving a rescue clause restores `$!` to each crossed
+    // begin region's entry value, innermost first, running ensure
+    // bodies against the restored value — so implicit exception-cause
+    // chaining keeps working after the method returns.
+    run_test(
+        r#"
+        def restore_check(log)
+          outer = StandardError.new "outer"
+          inner = StandardError.new "inner"
+          begin
+            raise outer
+          rescue
+            log << ($! == outer)
+            begin
+              raise inner
+            rescue
+              log << ($! == inner)
+              return
+            ensure
+              log << ($! == outer ? :outer : :wrong)
+            end
+          end
+        end
+        log = []
+        restore_check(log)
+        log << $!.inspect
+        begin
+          raise "original"
+        rescue
+          helper = proc do
+            begin
+              Object.new.missing_thing
+            rescue Exception => e
+              e
+            end
+          end
+          e1 = helper.call
+          log << [e1.class.to_s, e1.cause.class.to_s]
+          begin
+            no_such()
+          rescue NoMethodError => e2
+            log << e2.cause.class.to_s
+          end
+        end
+        log
+        "#,
+    );
+}
+
+#[test]
+fn exception_inspect_formats() {
+    run_test(
+        r#"
+        res = []
+        begin; raise; rescue => e; res << e.inspect << e.message; end
+        begin; raise RuntimeError; rescue => e; res << e.inspect; end
+        begin; raise RuntimeError, ""; rescue => e; res << e.inspect; end
+        begin; raise "msg"; rescue => e; res << e.inspect; end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/rescue.rs
+++ b/monoruby/tests/rescue.rs
@@ -747,3 +747,38 @@ fn exception_inspect_formats() {
         "#,
     );
 }
+
+#[test]
+fn break_next_from_rescue_in_while_restores_errinfo() {
+    // break / next leaving a rescue clause inside a `while` loop use
+    // the same per-region restore protocol as return: the region's
+    // ensure runs against the restored (outer) `$!`.
+    run_test(
+        r#"
+        def brk_while(log)
+          outer = StandardError.new "outer"
+          begin
+            raise outer
+          rescue
+            i = 0
+            while i < 3
+              begin
+                raise "inner #{i}"
+              rescue
+                break if i == 2
+                i += 1
+                next
+              ensure
+                log << $!&.message
+              end
+            end
+            log << $!.message
+          end
+        end
+        log = []
+        brk_while(log)
+        log << $!.inspect
+        log
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Sixth batch of ruby/spec `language` fixes (follow-up to #861–#865).

### `$!` restore on non-local exits from rescue clauses

A `return` (or a `while`-loop `break`/`next`) leaving a rescue clause **cleared `$!` to nil**. CRuby instead restores it to each crossed begin region's entry value, innermost first, running ensure bodies against the restored value:

- a nested region's `ensure` sees the *outer* exception, not the one just rescued;
- after the method returns, an enclosing handler's `$!` is intact — which is what implicit exception-**cause** chaining reads. The visible symptom: once any method had returned from inside a rescue, a subsequently raised NoMethodError (or any implicit raise) inside an outer rescue had `cause: nil`.

Implementation: the per-region ensure stack now carries the `$!`-on-entry save slot that the normal rescue-completion path already used, and the lexical unwind emitters (`emit_ret`, `gen_loop_pending_ensures`) interleave restore-then-ensure per region when the exit leaves a rescue clause. Exits from elsewhere can't have changed `$!` and emit nothing (this also keeps the emitted shape away from a JIT abstract-state edge we hit with unconditional restores).

**Known gap (future work)**: non-local exits that unwind through the runtime — `return`/`break` crossing a *block* frame — still miss the restore; that needs the exception-table/unwinder to carry the save slot.

### `defined?` probes no longer leak the swallowed exception into `$!`

Uncovered by the change above (the first darwin run of this PR): a raising receiver inside `defined?` — e.g. mspec's platform guard evaluating `defined?(RbConfig::SIZEOF[])` — is swallowed by the probe's exception entry, but the VM's rescue-entry path set `$!` as a side effect. CRuby leaves `$!` untouched by `defined?`. Previously the leak was masked by return-from-rescue clearing `$!` to nil; with the restore semantics the stale value survived, and a later bare `raise` re-raised it (darwin: `instance_eval("raise")` backtraces pointing into the platform guard — arch-divergent only because darwin's RbConfig makes that probe raise). `defined?` now saves `$!` around the whole expression and restores it on both exits.

### `Exception#inspect` with an empty message

Prints just the class name (`RuntimeError`), matching CRuby, instead of `#<RuntimeError: >`. Notably this is what a bare `raise` produces.

## ruby/spec impact (language category)

95 → 93 failing examples:
- `send_spec.rb`: `raises NoMethodError with $! as a cause` fixed
- `predefined_spec.rb`: `$! should be set to the value of $! before the begin after a rescue which returns` fixed

## Test plan

- `cargo test --features stress-spill-pool,gc-stress` (the CI feature set) — full suite green.
- New integration tests: the nested return-from-rescue shape (ensure ordering + restored `$!` + cause chaining afterwards), break/next-from-rescue in `while` loops, the raising-`defined?`-probe shapes (including the `instance_eval("raise", file, line)` scenario from the darwin failure), and the empty/class-only/plain-message inspect forms.
- Manual diff scripts verified identical output against CRuby 4.0.2 for the lexical-exit shapes; the block-frame-crossing shapes remain divergent (pre-existing, noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK