### PR TITLE
CRuby-compatible warnings for special globals ($/-family deprecation, $=, uninitialized reads)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -423,6 +423,14 @@ module Kernel
     nil
   end
   module_function :warn
+
+  # Internal: deprecation warnings raised from the Rust runtime (e.g.
+  # assigning non-nil to $/). Routed through Kernel#warn so the
+  # :deprecated category gating and Warning.warn overrides apply.
+  def __warn_deprecated(msg)
+    warn(msg, category: :deprecated)
+  end
+  module_function :__warn_deprecated
 end
 
 module Process

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -114,7 +114,31 @@ impl GvarTable {
     /// This takes `&mut Executor` and `&mut Globals` because hooked variables
     /// may need to mutate runtime state (e.g. `$~` writes).
     pub fn get(vm: &mut Executor, globals: &mut Globals, name: IdentId) -> Value {
-        Self::lookup(vm, globals, name).unwrap_or_default()
+        match Self::lookup(vm, globals, name) {
+            Some(v) => v,
+            None => {
+                // Reading a never-assigned ordinary global warns in
+                // verbose mode. Restricted to plain identifier names:
+                // punctuation/dash specials read as nil silently, and
+                // hidden internals (`$__flip_flop_N`, …) and hooked
+                // entries whose getter reported "not present" (`$1`
+                // with no match) must not warn either.
+                if !globals.gvars.index.contains_key(&name) {
+                    let n = name.get_name();
+                    if !n.starts_with("$__")
+                        && n[1..].starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+                        && n != "$FILENAME"
+                        && verbose_mode(globals)
+                    {
+                        let _ = vm.ruby_warn(
+                            globals,
+                            &format!("warning: global variable '{n}' not initialized"),
+                        );
+                    }
+                }
+                Value::nil()
+            }
+        }
     }
 
     /// Internal lookup that propagates the hook getter's "exists or not"
@@ -268,6 +292,47 @@ impl GvarTable {
     }
 }
 
+/// `$VERBOSE` is exactly `true` (nil = quiet, false = normal).
+fn verbose_mode(globals: &mut Globals) -> bool {
+    globals
+        .get_gvar(IdentId::get_id("$VERBOSE"))
+        .is_some_and(|v| v.as_bool())
+}
+
+/// Deprecation warning for the record/field separator globals (nil
+/// assignments are fine).
+fn warn_deprecated_separator(vm: &mut Executor, globals: &mut Globals, name: &str, val: Value) {
+    if !val.is_nil() {
+        warn_deprecated(vm, globals, &format!("warning: non-nil '{name}' is deprecated"));
+    }
+}
+
+/// Emit a deprecation warning through `Kernel#__warn_deprecated` so
+/// CRuby's gating applies: silent unless `Warning[:deprecated]` is
+/// enabled or `$VERBOSE` is true, and a user-overridden Warning.warn
+/// takes effect. The helper lives in startup.rb, so warnings during
+/// bootstrap (before it exists) stay silent, and a failing warning
+/// never turns the triggering operation into an error.
+fn warn_deprecated(vm: &mut Executor, globals: &mut Globals, msg: &str) {
+    let main = globals.main_object;
+    if globals
+        .store
+        .check_method(main, IdentId::get_id("__warn_deprecated"))
+        .is_none()
+    {
+        return;
+    }
+    let msg = Value::string(msg.to_string());
+    let _ = vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("__warn_deprecated"),
+        main,
+        &[msg],
+        None,
+        None,
+    );
+}
+
 /// CRuby installs setter hooks on a number of special globals that
 /// validate or coerce the assigned value, or reject the write outright.
 /// monoruby keeps most of them as plain [`GvarEntry::Simple`] storage
@@ -317,11 +382,16 @@ fn write_special_check(
         // (registered in `init_builtin_gvars`), but the alias name
         // still reaches this check, so match it too for the error
         // message's sake.
-        "$/" | "$-0" => frozen_string_or_nil(&n, val),
+        "$/" | "$-0" => {
+            let val = frozen_string_or_nil(&n, val)?;
+            warn_deprecated_separator(vm, globals, &n, val);
+            Ok(val)
+        }
         // Output record / field separators: String or nil, stored
         // as-is (CRuby does not copy these).
         "$\\" | "$," => {
             if val.is_nil() || val.is_rstring().is_some() {
+                warn_deprecated_separator(vm, globals, &n, val);
                 Ok(val)
             } else {
                 Err(MonorubyErr::typeerr(format!(
@@ -332,6 +402,7 @@ fn write_special_check(
         // The input field separator additionally accepts a Regexp.
         "$;" => {
             if val.is_nil() || val.is_rstring().is_some() || val.is_regex().is_some() {
+                warn_deprecated_separator(vm, globals, &n, val);
                 Ok(val)
             } else {
                 Err(MonorubyErr::typeerr(format!(
@@ -633,6 +704,38 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     // restores `$.` verbatim — a nil default would blow up the
     // restore.
     globals.set_gvar(IdentId::get_id("$."), Value::integer(0));
+
+    // `$=` (the pre-1.9 case-insensitivity toggle) is a defunct
+    // special: it reads as false and assignments are ignored, with a
+    // verbose-mode warning on both, matching CRuby.
+    fn get_ignorecase(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        warn_deprecated(vm, globals, "warning: variable $= is no longer effective");
+        Some(Value::bool(false))
+    }
+
+    fn set_ignorecase(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        _name: IdentId,
+        _val: Value,
+    ) -> Result<()> {
+        warn_deprecated(
+            vm,
+            globals,
+            "warning: variable $= is no longer effective; ignored",
+        );
+        Ok(())
+    }
+
+    globals.define_hooked_variable(
+        IdentId::get_id("$="),
+        get_ignorecase,
+        Some(set_ignorecase),
+    );
 
     // --- Command-line flag mirrors -------------------------------------------
 

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -924,7 +924,23 @@ impl<'pr> Lowerer<'pr> {
                     kind: NodeKind::GlobalVar(constant_name(&n.name())?),
                     loc: location_to_loc(&n.name_loc()),
                 };
-                self.build_short_circuit_assign(BinOp::LOr, target, &n.value(), loc)?
+                // `$x ||= v` must not fire the verbose-mode
+                // "uninitialized global" warning for its read (CRuby
+                // treats lazy initialization as fine), so guard the
+                // short-circuit read behind a definedness check:
+                // if defined?($x) then $x ||= v else $x = v end
+                let assign = Node::new_mul_assign(
+                    vec![target.clone()],
+                    vec![self.lower_node(&n.value())?],
+                );
+                let or_assign =
+                    self.build_short_circuit_assign(BinOp::LOr, target.clone(), &n.value(), loc)?;
+                Node::new_if(
+                    Node::new(NodeKind::Defined(Box::new(target)), loc),
+                    or_assign,
+                    assign,
+                    loc,
+                )
             }
             prism::Node::GlobalVariableAndWriteNode { .. } => {
                 let n = node.as_global_variable_and_write_node().unwrap();

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1338,7 +1338,23 @@ impl<'pr> Lowerer<'pr> {
             },
             prism::Node::DefinedNode { .. } => {
                 let n = node.as_defined_node().unwrap();
-                let inner = self.lower_node(&n.value())?;
+                let value = n.value();
+                // `defined?($x ||= v)` must classify as "assignment", so
+                // lower the or-write directly (without the definedness
+                // guard used for evaluation, which would make it an If
+                // node and classify as "expression"). defined? never
+                // evaluates assignments, so the uninitialized-global
+                // warning the guard suppresses cannot fire here.
+                let inner = if let Some(gw) = value.as_global_variable_or_write_node() {
+                    let target = Node {
+                        kind: NodeKind::GlobalVar(constant_name(&gw.name())?),
+                        loc: location_to_loc(&gw.name_loc()),
+                    };
+                    let inner_loc = location_to_loc(&value.location());
+                    self.build_short_circuit_assign(BinOp::LOr, target, &gw.value(), inner_loc)?
+                } else {
+                    self.lower_node(&value)?
+                };
                 Node {
                     kind: NodeKind::Defined(Box::new(inner)),
                     loc,

--- a/monoruby/tests/predefined_gvar.rs
+++ b/monoruby/tests/predefined_gvar.rs
@@ -168,3 +168,42 @@ fn load_path_aliases_share_identity() {
         "#,
     );
 }
+
+#[test]
+fn gvar_warnings() {
+    // Deprecation warnings for the separator globals and $= are gated
+    // on Warning[:deprecated] (or $VERBOSE == true); the
+    // uninitialized-global warning on $VERBOSE only. `||=` lazy
+    // initialization never warns. Warnings are routed through
+    // Kernel#warn / Warning.warn, so a captured $stderr sees them.
+    run_test_once(
+        r#"
+        def cap
+          saved = $stderr
+          buf = +""
+          io = Object.new
+          io.define_singleton_method(:write) { |*a| a.each { |x| buf << x.to_s } }
+          $stderr = io
+          yield
+          buf
+        ensure
+          $stderr = saved
+        end
+        res = []
+        Warning[:deprecated] = true
+        res << cap { $/ = "x"; $/ = "\n" }.scan(/warning: [^\n]+/)
+        res << cap { $, = "y"; $, = nil }.scan(/warning: [^\n]+/)
+        res << cap { $; = "z"; $; = nil }.scan(/warning: [^\n]+/)
+        res << cap { a = $= }.scan(/no longer effective[^\n]*/)
+        res << cap { $= = 1 }.scan(/no longer effective[^\n]*/)
+        Warning[:deprecated] = false
+        res << cap { $\ = "w"; $\ = nil }.empty?
+        saved_verbose = $VERBOSE
+        $VERBOSE = true
+        res << cap { $completely_uninit_gvar_zz }.scan(/warning: [^\n]+/)
+        res << cap { $lazy_init_gvar_zz ||= 5 }.empty?
+        $VERBOSE = saved_verbose
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Iteration 7 of the ruby/spec `language` cleanup: implement CRuby-compatible **warning emission** around the special global variables, which several `predefined_spec.rb` and `variables_spec.rb` examples assert via mspec's `complain` matcher.

### Deprecation warnings for the `$/`-family separator globals
Assigning `$/`, `$-0`, `$\`, `$,`, or `$;` now emits `'$/' is deprecated`-style warnings, matching CRuby. The warnings are routed through a new `Kernel#__warn_deprecated` helper (defined in `builtins/startup.rb`) that delegates to `Kernel#warn(msg, category: :deprecated)` — so they are correctly **gated on `Warning[:deprecated]`**, not on `$VERBOSE`. mspec enables `Warning[:deprecated]` globally, which is why these specs observe the warnings while normal scripts stay quiet by default.

### `$=` (ignorecase) hooked accessors
`$=` is now a hooked global: reading it returns `false` with a deprecation warning, and assignment is ignored with a `'$=' is deprecated; ignored` warning, matching CRuby's vestigial treatment.

### Uninitialized global variable reads warn under `$VERBOSE`
Reading a never-assigned plain global (e.g. `$undefined_var`) now emits `warning: global variable '$undefined_var' not initialized` when `$VERBOSE` is exactly `true`. Internal `$__`-prefixed globals (used by desugared flip-flops and END blocks) and hooked specials are exempt. `$x ||= val` lazy initialization does **not** warn — the or-assign is wrapped in a `defined?` guard in the prism backend, matching CRuby's behavior of not warning on conditional-assignment reads.

## ruby/spec impact (language category)

**93 → ~85 failing examples.** Fixes the warning-asserting examples in `predefined_spec.rb` ($/-family deprecation ×5, `$=` read/write ×2) and `variables_spec.rb` (uninitialized global read warning ×1).

## Test plan

- New `gvar_warnings` test in `tests/predefined_gvar.rs` covering deprecation gating, `$=` behavior, uninitialized-read warnings, and the `||=` exemption (output compared against CRuby 4.0.2).
- Full stress suite green: `cargo test --features stress-spill-pool,gc-stress` (exit 0).
- Minor patch-coverage movement is expected and per instruction can be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_