### PR TITLE
ruby2_keywords: flagged-hash keyword forwarding

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -304,15 +304,6 @@ class Hash
     self
   end
 
-  def self.ruby2_keywords_hash?(h)
-    raise TypeError, "no implicit conversion of #{h.class} into Hash" unless h.is_a?(Hash)
-    false
-  end
-
-  def self.ruby2_keywords_hash(h)
-    raise TypeError, "no implicit conversion of #{h.class} into Hash" unless h.is_a?(Hash)
-    h.dup
-  end
 end
 
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -13,6 +13,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.store[HASH_CLASS].set_alloc_func(hash_alloc_func);
     globals.define_builtin_class_func_rest(HASH_CLASS, "[]", hash_bracket);
     globals.define_builtin_class_func(HASH_CLASS, "try_convert", try_convert, 1);
+    globals.define_builtin_class_func(HASH_CLASS, "ruby2_keywords_hash", ruby2_keywords_hash, 1);
+    globals.define_builtin_class_func(HASH_CLASS, "ruby2_keywords_hash?", ruby2_keywords_hash_p, 1);
 
     globals.define_private_builtin_func_with(HASH_CLASS, "initialize", initialize, 0, 1, false);
     globals.define_builtin_func_with(HASH_CLASS, "default", default, 0, 1, false);
@@ -347,6 +349,58 @@ fn hash_from_array_pairs(
 /// Tries to convert obj into a Hash, using to_hash method.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Hash/s/try_convert.html]
+///
+/// ### Hash.ruby2_keywords_hash
+/// - ruby2_keywords_hash(hash) -> Hash
+///
+/// Returns a duplicate of `hash` carrying the ruby2_keywords flag
+/// (a `*rest` splat whose final element carries the flag turns it
+/// back into keywords at dispatch).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Hash/s/ruby2_keywords_hash.html]
+#[monoruby_builtin]
+fn ruby2_keywords_hash(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let h = lfp.arg(0);
+    if h.try_hash_ty().is_none() {
+        return Err(MonorubyErr::typeerr(format!(
+            "no implicit conversion of {} into Hash",
+            h.get_real_class_name(&globals.store)
+        )));
+    }
+    // A full dup: preserves the receiver's class (Hash subclass) and
+    // instance variables, exactly like the generic Object#dup path.
+    let dup = h.dup();
+    dup.try_hash_ty().unwrap().set_ruby2_keywords_flag();
+    Ok(dup)
+}
+
+///
+/// ### Hash.ruby2_keywords_hash?
+/// - ruby2_keywords_hash?(hash) -> bool
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Hash/s/ruby2_keywords_hash=3f.html]
+#[monoruby_builtin]
+fn ruby2_keywords_hash_p(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let h = lfp.arg(0);
+    if h.try_hash_ty().is_none() {
+        return Err(MonorubyErr::typeerr(format!(
+            "no implicit conversion of {} into Hash",
+            h.get_real_class_name(&globals.store)
+        )));
+    }
+    Ok(Value::bool(h.as_hashmap_inner().ruby2_keywords_flag()))
+}
+
 #[monoruby_builtin]
 fn try_convert(
     vm: &mut Executor,

--- a/monoruby/src/builtins/main_object.rs
+++ b/monoruby/src/builtins/main_object.rs
@@ -128,18 +128,17 @@ fn main_using(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// - ruby2_keywords(*method_names) -> nil
 ///
-/// CRuby uses this to flag a method as a ruby2_keywords-style
-/// keyword-passthrough method. monoruby doesn't propagate keyword
-/// splat metadata, so this is a private no-op — the spec only asserts
-/// that `main` responds to a private `ruby2_keywords` method.
+/// A top-level `ruby2_keywords def m(*args)` marks the method (defined
+/// as a private method of Object) exactly like `Module#ruby2_keywords`.
 #[monoruby_builtin]
 fn main_ruby2_keywords(
-    _: &mut Executor,
-    _: &mut Globals,
-    _lfp: Lfp,
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    Ok(Value::nil())
+    let names = lfp.arg(0).as_array().iter().cloned().collect::<Vec<_>>();
+    super::module::ruby2_keywords_mark(vm, globals, OBJECT_CLASS, &names)
 }
 
 ///

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2812,8 +2812,20 @@ fn ruby2_keywords(
     _: BytecodePtr,
 ) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
-    let args = lfp.arg(0).as_array();
-    for arg in args.iter() {
+    let names = lfp.arg(0).as_array().iter().cloned().collect::<Vec<_>>();
+    ruby2_keywords_mark(vm, globals, class_id, &names)
+}
+
+/// Shared body of `Module#ruby2_keywords` and `main.ruby2_keywords`:
+/// validate each name, mark compatible methods (and the underlying
+/// block of a define_method proc-method), warn about incompatible ones.
+pub(super) fn ruby2_keywords_mark(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    class_id: ClassId,
+    names: &[Value],
+) -> Result<Value> {
+    for arg in names.iter() {
         // expect_symbol_or_string accepts Symbol and String (and rejects
         // anything else with TypeError "<obj> is not a symbol nor a
         // string"). We don't honour `to_str` here — CRuby's
@@ -2826,20 +2838,30 @@ fn ruby2_keywords(
                 class_id.get_name(&globals.store)
             )));
         }
-        // Even though we don't track the ruby2_keywords flag, we still
-        // emit the CRuby compatibility warning when the target method
-        // signature is incompatible (i.e. the method has no positional
-        // splat, has explicit keywords, or has a keyword splat — none
-        // of which can be marked ruby2_keywords by CRuby either). The
-        // message format mirrors CRuby's "Skipping set of
-        // ruby2_keywords flag for <name> (...)".
-        if let Ok((func_id, _, _)) = globals.store.find_method_for_class(class_id, name)
-            && let Some(reason) = ruby2_keywords_skip_reason(globals, func_id)
-        {
-            let msg = format!(
-                "Skipping set of ruby2_keywords flag for {name} ({reason})",
-            );
-            crate::value::emit_verbose_warning(vm, globals, &msg)?;
+        // Mark the method when its signature is compatible (a `*rest`,
+        // no keyword params / `**kw`, no post-rest requireds);
+        // otherwise emit CRuby's "Skipping set of ruby2_keywords flag
+        // for <name> (...)" compatibility warning.
+        if let Ok((func_id, _, _)) = globals.store.find_method_for_class(class_id, name) {
+            match ruby2_keywords_skip_reason(globals, func_id) {
+                Some(reason) => {
+                    let msg = format!(
+                        "Skipping set of ruby2_keywords flag for {name} ({reason})",
+                    );
+                    crate::value::emit_verbose_warning(vm, globals, &msg)?;
+                }
+                None => {
+                    globals.store[func_id].set_ruby2_keywords();
+                    // A define_method proc-method dispatches with the
+                    // *block's* FuncId in the frame (the wrapper jumps
+                    // straight to the block code), so the argument
+                    // marshaler consults that FuncInfo — mark it too.
+                    if let crate::globals::FuncKind::Proc(proc) = &globals.store[func_id].kind {
+                        let block_fid = proc.func_id();
+                        globals.store[block_fid].set_ruby2_keywords();
+                    }
+                }
+            }
         }
     }
     Ok(Value::nil())

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -248,10 +248,27 @@ pub(crate) fn proc_curry_body(
     }
 }
 
-/// `Proc#ruby2_keywords` — no-op marker that returns self.
+/// `Proc#ruby2_keywords` — mark the proc's underlying function so its
+/// `*rest` packs passed keywords as a ruby2_keywords-flagged trailing
+/// hash. The flag lives on the shared function, so it applies across
+/// `dup` (CRuby behavior). Incompatible signatures (no `*rest`,
+/// keywords, `**kw`, or post-rest params) get CRuby's single combined
+/// "Skipping set of ruby2_keywords flag for proc (...)" warning.
 #[monoruby_builtin]
-fn ruby2_keywords(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(lfp.self_val())
+fn ruby2_keywords(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let fid = self_.as_proc_inner().func_id();
+    let info = &globals.store[fid];
+    if info.no_keyword() && info.is_rest() && info.post_num() == 0 {
+        globals.store[fid].set_ruby2_keywords();
+    } else {
+        crate::value::emit_verbose_warning(
+            vm,
+            globals,
+            "Skipping set of ruby2_keywords flag for proc (proc accepts keywords or post arguments or proc does not accept argument splat)",
+        )?;
+    }
+    Ok(self_)
 }
 
 ///

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -30,7 +30,7 @@ pub(crate) fn set_frame_arguments_simple(
     positional_simple(vm, globals, callee_fid, src, pos_num, callee_lfp)?;
     let callee = &globals.store[callee_fid];
     if !callee.no_keyword() {
-        handle_keyword(vm, globals, callee_fid, callid, callee_lfp, caller_lfp)?;
+        handle_keyword(vm, globals, callee_fid, callid, callee_lfp, caller_lfp, None)?;
     }
 
     Ok(())
@@ -313,7 +313,14 @@ fn set_callee_frame_arguments(
         if h.is_empty() {
             None
         } else {
-            Some(Value::hash(h))
+            let mut inner = crate::value::rvalue::HashmapInner::new(h);
+            // A ruby2_keywords-marked callee packs its keywords as a
+            // *flagged* trailing hash, so a later `*rest` splat can
+            // restore them as keywords.
+            if globals[callee_fid].ruby2_keywords() {
+                inner.set_ruby2_keywords_flag();
+            }
+            Some(Value::hash_from_inner(inner))
         }
     } else {
         None
@@ -332,6 +339,26 @@ fn set_callee_frame_arguments(
     } else {
         None
     };
+    // ruby2_keywords handling: when the call site passes no keywords of
+    // its own and a splat's expanded tail ends with a ruby2_keywords-
+    // flagged hash, that hash is "keywords in flight" (CRuby):
+    //   - a callee accepting keywords binds it as its keywords;
+    //   - a ruby2_keywords-marked callee keeps it as the flagged
+    //     trailing positional (same object — the chain continues);
+    //   - any other callee receives an *unflagged copy* as the trailing
+    //     positional (the chain ends).
+    let r2k_promote = !globals[callid].kw_may_exists();
+    let callee_takes_kw = !globals[callee_fid].no_keyword();
+    let callee_r2k = globals[callee_fid].ruby2_keywords();
+    let mut r2k_kw: Option<Value> = None;
+    fn r2k_hash(v: Value) -> bool {
+        v.try_hash_ty().is_some() && v.as_hashmap_inner().ruby2_keywords_flag()
+    }
+    fn r2k_unflagged_copy(v: Value) -> Value {
+        let dup = v.dup();
+        dup.try_hash_ty().unwrap().unset_ruby2_keywords_flag();
+        dup
+    }
     let splat_pos = &globals[callid].splat_pos;
     if let Some(coerced) = coerced {
         let ary = coerced.try_array_ty().unwrap();
@@ -354,7 +381,22 @@ fn set_callee_frame_arguments(
         && splat_pos == &[0]
         && let Some(ary) = unsafe { *src }.try_array_ty()
     {
-        fill_positional_args1(dst, &globals[callee_fid], ary.as_ref())?;
+        let slice: &[Value] = ary.as_ref();
+        if r2k_promote && let [head @ .., last] = slice && r2k_hash(*last) {
+            if callee_takes_kw {
+                r2k_kw = Some(*last);
+                fill_positional_args1(dst, &globals[callee_fid], head)?;
+            } else if callee_r2k {
+                fill_positional_args1(dst, &globals[callee_fid], slice)?;
+            } else {
+                let mut buf: smallvec::SmallVec<[Value; 8]> =
+                    smallvec::SmallVec::from_slice(head);
+                buf.push(r2k_unflagged_copy(*last));
+                fill_positional_args1(dst, &globals[callee_fid], &buf)?;
+            }
+        } else {
+            fill_positional_args1(dst, &globals[callee_fid], slice)?;
+        }
     } else {
         // Forwarding (`g(x, ...)` / `super(x, ...)`) and other splat
         // calls land here. The expanded positional sequence is almost
@@ -381,6 +423,21 @@ fn set_callee_frame_arguments(
         if let Some(v) = ex {
             buf.push(v);
         }
+        // Only a hash that arrived via a splat expansion is "in
+        // flight" (`ex` is only built when the call site passes its
+        // own keywords, which `r2k_promote` already excludes).
+        if r2k_promote
+            && !splat_pos.is_empty()
+            && let Some(&last) = buf.last()
+            && r2k_hash(last)
+        {
+            if callee_takes_kw {
+                r2k_kw = Some(last);
+                buf.pop();
+            } else if !callee_r2k {
+                *buf.last_mut().unwrap() = r2k_unflagged_copy(last);
+            }
+        }
 
         fill_positional_args1(dst, &globals[callee_fid], &buf)?;
     }
@@ -389,7 +446,7 @@ fn set_callee_frame_arguments(
     let callee = &globals.store[callee_fid];
     let caller = &globals.store[callid];
     if !callee.no_keyword() || !caller.kw_may_exists() {
-        handle_keyword(vm, globals, callee_fid, callid, callee_lfp, caller_lfp)?;
+        handle_keyword(vm, globals, callee_fid, callid, callee_lfp, caller_lfp, r2k_kw)?;
     }
     Ok(())
 }
@@ -639,6 +696,7 @@ fn handle_keyword(
     caller: CallSiteId,
     callee_lfp: Lfp,
     caller_lfp: Lfp,
+    r2k_kw: Option<Value>,
 ) -> Result<()> {
     // `**nil` accepts no keywords: any actual keyword raises.
     if globals[callee].forbid_keyword() {
@@ -649,7 +707,7 @@ fn handle_keyword(
     }
     let mut unknowns = ordinary_keyword(globals, callee, caller, callee_lfp, caller_lfp)?;
     unknowns.extend(hash_splat_and_kw_rest(
-        vm, globals, callee, caller, callee_lfp, caller_lfp,
+        vm, globals, callee, caller, callee_lfp, caller_lfp, r2k_kw,
     )?);
     // A missing required keyword is reported before any unknown keyword,
     // matching CRuby (`m(a: 1)` for `def m(x:)` raises "missing keyword: :x",
@@ -831,6 +889,9 @@ fn ordinary_keyword(
 /// `**hash` keys the callee doesn't declare (empty when it has a
 /// `**kwrest`); reported by the caller after the missing-keyword check.
 ///
+/// `r2k_kw` is an additional keyword-hash source: a ruby2_keywords-
+/// flagged hash promoted from the tail of a `*args` splat. It behaves
+/// exactly like one more `**hash` at the call site.
 fn hash_splat_and_kw_rest(
     vm: &mut Executor,
     globals: &mut Globals,
@@ -838,6 +899,7 @@ fn hash_splat_and_kw_rest(
     caller: CallSiteId,
     mut callee_lfp: Lfp,
     caller_lfp: Lfp,
+    r2k_kw: Option<Value>,
 ) -> Result<Vec<String>> {
     if globals[callee].no_keyword() {
         return Ok(vec![]);
@@ -856,6 +918,7 @@ fn hash_splat_and_kw_rest(
     for h in hash_splat_pos
         .iter()
         .map(|pos| caller_lfp.register(*pos).unwrap())
+        .chain(r2k_kw)
     {
         if h.is_nil() {
             continue;
@@ -894,7 +957,7 @@ fn hash_splat_and_kw_rest(
     }
 
     if let Some(rest) = globals[callee].kw_rest() {
-        if !globals[caller].kw_may_exists() {
+        if !globals[caller].kw_may_exists() && r2k_kw.is_none() {
             // no keyword arguments
             unsafe { callee_lfp.set_register(rest, Some(Value::nil())) }
         } else {
@@ -910,6 +973,7 @@ fn hash_splat_and_kw_rest(
             for h in hash_splat_pos
                 .iter()
                 .map(|pos| caller_lfp.register(*pos).unwrap())
+                .chain(r2k_kw)
             {
                 // A nil hash-splat is `**nil` — no keyword arguments.
                 // (The other hash-splat readers already skip nil; this
@@ -1028,7 +1092,14 @@ fn invoker_arguments_inner(
     } else if info.kw_names().is_empty()
         && let Some(kw_arg) = kw_arg
     {
-        Some(kw_arg.into())
+        // Folding the keywords into a trailing positional hash: a
+        // ruby2_keywords-marked callee flags it so a later `*rest`
+        // splat can restore them as keywords.
+        let v: Value = kw_arg.into();
+        if info.ruby2_keywords() {
+            v.try_hash_ty().unwrap().set_ruby2_keywords_flag();
+        }
+        Some(v)
     } else if let Some(kw_arg) = kw_arg {
         let mut s = "unknown keywords: ".to_string();
         for (i, (name, _)) in kw_arg.iter().enumerate() {

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -735,6 +735,11 @@ struct FuncExt {
     params: ParamsInfo,
     /// the `Effect`` of this function.
     effect: Effect,
+    /// Marked by `Module#ruby2_keywords` / `Proc#ruby2_keywords`: the
+    /// method's `*rest` packs any passed keywords as a trailing Hash
+    /// carrying the ruby2_keywords flag, so a later `*rest` splat can
+    /// turn them back into keywords.
+    ruby2_keywords: bool,
     #[cfg(feature = "perf")]
     wrapper: Option<(monoasm::CodePtr, usize, monoasm::CodePtr, usize)>,
 }
@@ -797,6 +802,7 @@ impl FuncInfo {
                 entry: None,
                 params,
                 effect,
+                ruby2_keywords: false,
                 #[cfg(feature = "perf")]
                 wrapper: None,
             }),
@@ -1097,6 +1103,15 @@ impl FuncInfo {
 
     pub(crate) fn no_keyword(&self) -> bool {
         self.kw_names().is_empty() && self.kw_rest().is_none()
+    }
+
+    /// See `FuncExt::ruby2_keywords`.
+    pub(crate) fn ruby2_keywords(&self) -> bool {
+        self.ext.ruby2_keywords
+    }
+
+    pub(crate) fn set_ruby2_keywords(&mut self) {
+        self.ext.ruby2_keywords = true;
     }
 
     /// `**nil` — the definition explicitly forbids keyword arguments.

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -60,6 +60,16 @@ impl Hashmap {
         *self.0.as_hashmap_inner_mut() = inner;
         self.0.write_barrier_bulk();
     }
+
+    /// Set / clear the ruby2_keywords flag (a plain bool — no GC edge,
+    /// so no write barrier is needed).
+    pub(crate) fn set_ruby2_keywords_flag(&mut self) {
+        self.0.as_hashmap_inner_mut().set_ruby2_keywords_flag();
+    }
+
+    pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
+        self.0.as_hashmap_inner_mut().unset_ruby2_keywords_flag();
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,6 +100,13 @@ pub struct HashmapInner {
     /// a traversal holding a shared borrow of the hash (for iteration) can
     /// still record its presence here.
     iter_lev: std::cell::Cell<u32>,
+    /// CRuby's Hash ruby2_keywords flag: set on the hash a
+    /// `ruby2_keywords`-marked method packs its keywords into (and by
+    /// `Hash.ruby2_keywords_hash`). A later `*args` splat whose final
+    /// element carries this flag turns it back into keywords at
+    /// dispatch. Cleared by `clone` (`Hash#dup` drops the flag, as
+    /// CRuby; `Hash.ruby2_keywords_hash` re-sets it on its dup).
+    r2k: bool,
 }
 
 impl Clone for HashmapInner {
@@ -100,6 +117,7 @@ impl Clone for HashmapInner {
             default: self.default.clone(),
             content: self.content.clone(),
             iter_lev: std::cell::Cell::new(0),
+            r2k: false,
         }
     }
 }
@@ -172,6 +190,7 @@ impl HashmapInner {
             default: HashDefault::default(),
             content: HashContent::new(map),
             iter_lev: std::cell::Cell::new(0),
+            r2k: false,
         }
     }
 
@@ -180,6 +199,7 @@ impl HashmapInner {
             default: HashDefault::Value(default),
             content: HashContent::new(map),
             iter_lev: std::cell::Cell::new(0),
+            r2k: false,
         }
     }
 
@@ -188,7 +208,21 @@ impl HashmapInner {
             default: HashDefault::Proc(default_proc),
             content: HashContent::new(map),
             iter_lev: std::cell::Cell::new(0),
+            r2k: false,
         }
+    }
+
+    /// CRuby's Hash ruby2_keywords flag (see the field doc).
+    pub(crate) fn ruby2_keywords_flag(&self) -> bool {
+        self.r2k
+    }
+
+    pub(crate) fn set_ruby2_keywords_flag(&mut self) {
+        self.r2k = true;
+    }
+
+    pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
+        self.r2k = false;
     }
 
     pub fn defalut_value(&self) -> Option<Value> {

--- a/monoruby/tests/ruby2_keywords.rs
+++ b/monoruby/tests/ruby2_keywords.rs
@@ -1,0 +1,141 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn hash_ruby2_keywords_hash_flag() {
+    run_test_once(
+        r#"
+        h = Hash.ruby2_keywords_hash(a: 1)
+        res = [Hash.ruby2_keywords_hash?(h), Hash.ruby2_keywords_hash?({a: 1}), h == {a: 1}]
+        # positional pass keeps identity and flag
+        def bar(a); a; end
+        res << bar(h).equal?(h) << Hash.ruby2_keywords_hash?(h)
+        # dup drops the flag; subclass and ivars are preserved
+        res << Hash.ruby2_keywords_hash?(h.dup)
+        klass = Class.new(Hash)
+        sub = klass.new
+        sub[:a] = 1
+        sub.instance_variable_set(:@x, 42)
+        marked = Hash.ruby2_keywords_hash(sub)
+        res << marked.class.equal?(klass) << marked.instance_variable_get(:@x)
+        res
+        "#,
+    );
+}
+
+#[test]
+fn ruby2_keywords_delegation() {
+    run_test_once(
+        r#"
+        def target(*args, **kw); [args, kw]; end
+        class << self
+          ruby2_keywords def m_call(*args); target(*args); end
+        end
+        res = []
+        empty = {}
+        res << m_call(**empty) << Hash.ruby2_keywords_hash?(empty)
+        res << m_call(empty) << m_call(a: 1) << m_call({a: 1})
+
+        class R2KSuperTgt; def t(*args, **kw); [args, kw]; end; end
+        class R2KSuperSub < R2KSuperTgt
+          ruby2_keywords def t(*args); super(*args); end
+        end
+        class R2KZSuperSub < R2KSuperTgt
+          ruby2_keywords def t(*args); super; end
+        end
+        res << R2KSuperSub.new.t(a: 1) << R2KSuperSub.new.t({a: 1})
+        res << R2KZSuperSub.new.t(a: 1) << R2KZSuperSub.new.t({a: 1})
+
+        class << self
+          def y(args, &blk); yield(*args); end
+          ruby2_keywords def m_yield(*outer)
+            y(outer, &-> *args, **kwargs { target(*args, **kwargs) })
+          end
+        end
+        res << m_yield(a: 1) << m_yield({a: 1})
+        res
+        "#,
+    );
+}
+
+#[test]
+fn ruby2_keywords_flag_propagation_rules() {
+    run_test_once(
+        r#"
+        h = Hash.ruby2_keywords_hash(a: 1)
+        res = []
+        # splat into an unmarked no-keyword callee: unflagged copy
+        def take(*args); args; end
+        r = take(*[1, h])
+        res << Hash.ruby2_keywords_hash?(r.last) << r.last.equal?(h) << r.last
+        def take2(a, b); [a, b]; end
+        r2 = take2(*[1, h])
+        res << Hash.ruby2_keywords_hash?(r2[1]) << r2[1].equal?(h)
+        # splat into a marked callee: same object, flag kept
+        ruby2_keywords def marked(*args); args; end
+        r4 = marked(*[1, h])
+        res << Hash.ruby2_keywords_hash?(r4.last) << r4.last.equal?(h)
+        # splat into a keyword-accepting callee: becomes the keywords
+        def kw_target(*args, **kw); [args, kw]; end
+        res << kw_target(*[1, h])
+        res
+        "#,
+    );
+}
+
+#[test]
+fn proc_ruby2_keywords() {
+    run_test_once(
+        r#"
+        res = []
+        f = -> *a { a.last }
+        res << f.ruby2_keywords.equal?(f)
+        res << Hash.ruby2_keywords_hash?(f.call(1, 2, a: "a"))
+        f1 = -> *a { a.last }
+        f1.ruby2_keywords
+        f2 = f1.dup
+        res << Hash.ruby2_keywords_hash?(f2.call(1, a: "a"))
+        # incompatible signature warns (message compared via capture)
+        saved = $stderr
+        buf = +""
+        io = Object.new
+        io.define_singleton_method(:write) { |*x| x.each { |v| buf << v.to_s }; nil }
+        $stderr = io
+        (-> a, b { }).ruby2_keywords
+        $stderr = saved
+        res << (buf =~ /Skipping set of ruby2_keywords flag for proc/ ? "warned" : "silent")
+        # define_method + ruby2_keywords by name
+        klass = Class.new do
+          def bar(a, foo: nil); [a, foo]; end
+          def self.setup
+            send :define_method, :foo, &make_proc
+            send :ruby2_keywords, :foo
+          end
+          def self.make_proc = proc { |a, *args| bar(a, *args) }
+        end
+        klass.setup
+        res << klass.new.foo(1, foo: 2)
+        res
+        "#,
+    );
+}
+
+#[test]
+fn ruby2_keywords_jit_tier() {
+    // Hot loop so the JIT compiles the marked method and the delegation
+    // call; the flagged-hash promotion happens on the IC-miss/argument
+    // marshaling path and must keep working under the JIT.
+    run_test(
+        r#"
+        def target(*args, **kw); [args, kw]; end
+        class << self
+          ruby2_keywords def m(*args); target(*args); end
+        end
+        res = []
+        40.times do |i|
+          res << m(a: i) << m({b: i})
+        end
+        res.last(4)
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Iteration 10 of the ruby/spec `language` cleanup: a full implementation of CRuby's **ruby2_keywords** protocol (previously `Module#ruby2_keywords` / `Proc#ruby2_keywords` were no-ops and `Hash.ruby2_keywords_hash` a plain dup). This is the pre-3.0-style argument-delegation mechanism many gems still rely on.

### Data model
- `HashmapInner` gains an `r2k` flag. `clone` clears it (`Hash#dup` drops the flag — verified against CRuby). `Hash.ruby2_keywords_hash` / `ruby2_keywords_hash?` are now real Rust builtins; the dup path preserves subclass and instance variables like `Object#dup`.
- `FuncInfo` gains a `ruby2_keywords` mark, set by `Module#ruby2_keywords` (also marking the underlying block of a `define_method` proc-method, since the runtime frame carries the block's FuncId), top-level `main.ruby2_keywords` (was a no-op stub), and `Proc#ruby2_keywords` (shared FuncInfo, so the mark applies across `Proc#dup`, as CRuby; incompatible signatures get CRuby's combined "Skipping set of ruby2_keywords flag for proc (…)" warning).

### Semantics (verified point-by-point against CRuby 4.0.2)
- **Callee side**: a marked method packs passed keywords into a **flagged** trailing hash in its `*rest` — on both the generic argument-marshaling path and the invoker path (`Proc#call`).
- **Caller side**: a splat tail carrying the flag is "keywords in flight":
  - a keyword-accepting callee binds it as its keywords (threaded through `handle_keyword` / `hash_splat_and_kw_rest` as one extra `**hash` source);
  - a marked callee receives the **same flagged object** — the delegation chain continues (identity verified: `marked(*[1, h]).last.equal?(h)`);
  - any other callee receives an **unflagged copy** — the chain ends (matches CRuby's observable copy/unflag behavior, e.g. through an unmarked `*args` or a plain positional binding).

This makes all delegation shapes work: `target(*args)`, `super(*args)`, zsuper, `yield(*args)` into a kw-accepting block, and `define_method(name, &proc)` + `ruby2_keywords :name`.

## ruby/spec impact

- language: **61 → 55 failing examples** (`keyword_arguments_spec` 6 → 0, no regressions elsewhere in the per-file sweep)
- core/proc/ruby2_keywords_spec: 6 → 0
- core/hash/ruby2_keywords_hash_spec: clean (including the subclass/ivar-preserving dup, which the initial Rust port of the old Ruby stub would have regressed)

## Test plan

- New `tests/ruby2_keywords.rs` (5 tests, compared against CRuby 4.0.2): flag lifecycle incl. dup/subclass/ivars, the full delegation matrix (call/super/zsuper/yield/define_method), the three-way propagation rules (unflagged copy vs identity vs keyword binding), `Proc#ruby2_keywords` incl. the skip warning, and a JIT-tier test (40 hot iterations).
- Full stress suite green: `cargo test --features stress-spill-pool,gc-stress`.
- Minor patch-coverage movement can be ignored per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_