### PR TITLE
break from a materialized Proc raises LocalJumpError (CRuby catch-table semantics)

### DIFF
--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -63,7 +63,9 @@ fn invoke_body(
         m.restore_svar_slot(None);
     }
 
+    vm.push_break_barrier(vm.cfp());
     let result = vm.invoke_proc(globals, &block, &args);
+    vm.pop_break_barrier();
 
     if let Some(m) = home_mfp {
         m.restore_svar_slot(saved);
@@ -76,6 +78,9 @@ fn invoke_body(
         Ok(v) => Ok(v),
         Err(err) if matches!(err.kind(), MonorubyErrKind::MethodReturn(..)) => {
             Err(MonorubyErr::localjumperr("unexpected return"))
+        }
+        Err(err) if matches!(err.kind(), MonorubyErrKind::BlockBreak(..)) => {
+            Err(MonorubyErr::localjumperr("break from proc-closure"))
         }
         Err(err) => Err(err),
     }

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -673,6 +673,8 @@ impl<'a> BytecodeGen<'a> {
             Some(ret) => self.slot_id(&ret).0,
         };
         let callid = self.new_callsite(callsite, bc_pos)?;
+        self.store
+            .new_callsite_map_entry(self.iseq_id, bc_pos, callid);
         let op1 = enc_wl(opcode, ret, callid.get());
         let op2 = enc_www(
             0,

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -94,6 +94,7 @@ pub(super) extern "C" fn handle_error(
             }
             let pc = pc - bc_base;
             let mut lfp = vm.cfp().lfp();
+            let iseq_id = *info;
             let info = &globals.store[*info];
             // check exception table.
             // First, we check method_return.
@@ -134,6 +135,74 @@ pub(super) extern "C" fn handle_error(
                     ErrorReturn::return_err()
                 };
             }
+            // `break` escaping a block (see `MonorubyErrKind::BlockBreak`):
+            // stop at the block's defining frame. If that frame's
+            // in-progress call site is the one that received this block
+            // literal, resume it with the call returning the break value
+            // (CRuby's BREAK catch table). Otherwise the block escaped as
+            // a Proc — degrade to LocalJumpError and let the normal
+            // rescue machinery below handle it in this very frame.
+            let block_break = match vm.exception().unwrap().kind() {
+                MonorubyErrKind::BlockBreak(val, block_fid, outer) => {
+                    Some((*val, *block_fid, *outer))
+                }
+                _ => None,
+            };
+            if let Some((val, block_fid, outer)) = block_break {
+                if lfp != outer {
+                    // An intermediate frame: run its ensure body (the
+                    // break passes through it), then keep unwinding.
+                    if let Some((_, Some(ensure), _)) = info.get_exception_dest(pc) {
+                        vm.defer_unwind(lfp);
+                        return ErrorReturn::goto(bc_base + ensure);
+                    }
+                    vm.discard_deferred_unwind(lfp);
+                    return ErrorReturn::return_err();
+                }
+                // The defining frame: check the call site *before* any
+                // ensure handling — a matching break resumes right after
+                // the call, still inside the same begin region, so this
+                // frame's ensure must NOT run now (it runs when control
+                // leaves the region normally).
+                // The suspended pc may point at the call instruction or
+                // its trailing InlineCache slot — check both.
+                let mut candidates = vec![pc];
+                if pc.to_usize() > 0 {
+                    candidates.push(pc + (-1i64));
+                }
+                let call_pos = candidates.into_iter().find(|cand| {
+                    globals.store.get_callsite_id(iseq_id, *cand).is_some_and(|id| {
+                        globals.store[id].block_fid == Some(block_fid)
+                    })
+                });
+                if let Some(call_pos) = call_pos {
+                    let dst = {
+                        let id = globals.store.get_callsite_id(iseq_id, call_pos).unwrap();
+                        globals.store[id].dst
+                    };
+                    vm.take_error();
+                    vm.discard_deferred_unwind(lfp);
+                    if let Some(dst) = dst {
+                        unsafe { lfp.set_register(dst, Some(val)) };
+                    }
+                    // Skip the call instruction + its InlineCache slot.
+                    return ErrorReturn::goto(bc_base + call_pos + 2isize);
+                }
+                // Defining frame reached via a materialized Proc: the
+                // original receiving call is gone.
+                #[cfg(feature = "emit-bc")]
+                eprintln!(
+                    "block-break no-match: pc={pc:?} candidates checked, block_fid={block_fid:?}, map={:?}",
+                    (0..40).filter_map(|i| globals.store.get_callsite_id(iseq_id, crate::bytecodegen::BcIndex::from(i)).map(|id| (i, globals.store[id].block_fid))).collect::<Vec<_>>()
+                );
+                vm.take_error();
+                vm.set_error(MonorubyErr::new(
+                    MonorubyErrKind::LocalJump,
+                    "break from proc-closure".to_string(),
+                ));
+                // fall through to the ordinary exception handling below
+                // (rescue table of this frame, or propagate).
+            }
             let sourceinfo = info.sourceinfo.clone();
             let loc = info.sourcemap[pc.to_usize()];
             let fid = info.func_id();
@@ -167,7 +236,9 @@ pub(super) extern "C" fn handle_error(
                     ErrorReturn::return_err()
                 };
             }
-            if let MonorubyErrKind::Throw(..) = vm.exception().unwrap().kind() {
+            if let MonorubyErrKind::Throw(..) | MonorubyErrKind::BlockBreak(..) =
+                vm.exception().unwrap().kind()
+            {
                 return ErrorReturn::return_err();
             }
             vm.push_internal_error_location(meta.func_id());

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1698,19 +1698,49 @@ pub(super) extern "C" fn err_method_return(vm: &mut Executor, globals: &mut Glob
     vm.set_error(MonorubyErr::method_return(val, target_lfp));
 }
 
-pub(super) extern "C" fn err_block_break(vm: &mut Executor, _globals: &mut Globals, val: Value) {
-    let caller = match vm.cfp().caller() {
-        Some(caller) => caller,
-        None => {
-            vm.set_error(MonorubyErr::new(
-                MonorubyErrKind::LocalJump,
-                "illegal break from block".to_string(),
-            ));
-            return;
+pub(super) extern "C" fn err_block_break(vm: &mut Executor, globals: &mut Globals, val: Value) {
+    // In a lambda (including a block promoted by Kernel#lambda), break
+    // is local: it exits the lambda itself, like return.
+    let lfp = vm.cfp().lfp();
+    if !globals[lfp.func_id()].is_block_style() {
+        vm.set_error(MonorubyErr::method_return(val, lfp));
+        return;
+    }
+    // `break` escapes to the invocation of the call that received this
+    // block literal (CRuby's BREAK catch-table semantics): the unwinder
+    // stops at the block's *defining* frame and resumes it only when
+    // its in-progress call site is the one carrying this block; any
+    // other route (a materialized Proc invoked later, a re-yield of a
+    // captured proc) is a LocalJumpError. Pre-check that the defining
+    // frame is on this stack at all, so a proc whose creation scope has
+    // returned (or lives on another thread/fiber stack) fails fast.
+    let block_fid = lfp.func_id();
+    let outer_reachable = |vm: &Executor, outer: Lfp| {
+        let barrier = vm.break_barrier();
+        let mut cfp = Some(vm.cfp());
+        while let Some(f) = cfp {
+            if Some(f) == barrier {
+                // Crossing a synchronous thread-body boundary: the
+                // defining frame belongs to the spawning "thread".
+                return false;
+            }
+            if f.lfp() == outer {
+                return true;
+            }
+            cfp = f.prev();
         }
+        false
     };
-    let target_lfp = caller.lfp();
-    vm.set_error(MonorubyErr::method_return(val, target_lfp));
+    if let Some(outer) = lfp.outer()
+        && outer_reachable(vm, outer)
+    {
+        vm.set_error(MonorubyErr::block_break(val, block_fid, outer));
+    } else {
+        vm.set_error(MonorubyErr::new(
+            MonorubyErrKind::LocalJump,
+            "break from proc-closure".to_string(),
+        ));
+    }
 }
 
 pub(super) extern "C" fn err_retry(vm: &mut Executor) {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -135,6 +135,13 @@ pub struct Executor {
     /// actually borrows from this Value's buffer, so a stale stash can
     /// never mis-attribute a haystack — it only falls back to copying.
     sp_match_haystack: Option<Value>,
+    /// Stack of `break` barriers: the CFP at each synchronous
+    /// thread-body invocation (`Thread#__invoke_body`). A `break`
+    /// escaping a block must not resolve its defining frame *across*
+    /// such a boundary — the body runs on the spawning code's machine
+    /// stack, but semantically it is another thread's stack (CRuby:
+    /// break in a thread body is an immediate LocalJumpError).
+    break_barriers: Vec<Cfp>,
     temp_stack: Vec<Value>,
     /// How the method_missing dispatch currently being set up was
     /// called. Consumed (read-and-cleared) by the default
@@ -183,6 +190,7 @@ impl std::default::Default for Executor {
             toplevel_visibility: Visibility::Private,
             sp_match_regex: None,
             sp_match_haystack: None,
+            break_barriers: Vec::new(),
             temp_stack: vec![],
             method_missing_style: MethodMissingStyle::Plain,
             require_level: 0,
@@ -2856,6 +2864,18 @@ impl Executor {
     /// call should associate with the captures.
     pub(crate) fn set_match_regex(&mut self, regex: Value) {
         self.sp_match_regex = Some(regex);
+    }
+
+    pub(crate) fn push_break_barrier(&mut self, cfp: Cfp) {
+        self.break_barriers.push(cfp);
+    }
+
+    pub(crate) fn pop_break_barrier(&mut self) {
+        self.break_barriers.pop();
+    }
+
+    pub(crate) fn break_barrier(&self) -> Option<Cfp> {
+        self.break_barriers.last().copied()
     }
 
     /// Stash the subject String `Value` about to be matched, enabling

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -110,6 +110,10 @@ impl MonorubyErr {
                 v.mark(alloc);
                 lfp.mark(alloc);
             }
+            MonorubyErrKind::BlockBreak(v, _, lfp) => {
+                v.mark(alloc);
+                lfp.mark(alloc);
+            }
             // Kernel#throw: carries the tag and value.
             MonorubyErrKind::Throw(tag, val) => {
                 tag.mark(alloc);
@@ -221,6 +225,7 @@ impl MonorubyErr {
             MonorubyErrKind::SystemExit(..) => "SystemExit",
             MonorubyErrKind::Other(class_id) => return class_id.get_name(store),
             MonorubyErrKind::MethodReturn(..) => "MethodReturn",
+            MonorubyErrKind::BlockBreak(..) => "BlockBreak",
             MonorubyErrKind::Throw(..) => "UncaughtThrowError",
             MonorubyErrKind::Retry => "Retry",
             MonorubyErrKind::Redo => "Redo",
@@ -236,6 +241,7 @@ impl MonorubyErr {
     pub fn is_stop_iteration(&self, store: &Store) -> bool {
         match &self.kind {
             MonorubyErrKind::MethodReturn(..)
+            | MonorubyErrKind::BlockBreak(..)
             | MonorubyErrKind::Throw(..)
             | MonorubyErrKind::Retry
             | MonorubyErrKind::Redo => false,
@@ -277,6 +283,7 @@ impl MonorubyErr {
             MonorubyErrKind::Other(class_id) => *class_id,
             MonorubyErrKind::Fatal => FATAL_ERROR_CLASS,
             MonorubyErrKind::MethodReturn(..)
+            | MonorubyErrKind::BlockBreak(..)
             | MonorubyErrKind::Throw(..)
             | MonorubyErrKind::Retry
             | MonorubyErrKind::Redo => {
@@ -389,6 +396,13 @@ impl MonorubyErr {
     pub(crate) fn method_return(val: Value, target_lfp: Lfp) -> MonorubyErr {
         MonorubyErr::new(
             MonorubyErrKind::MethodReturn(val, target_lfp),
+            String::new(),
+        )
+    }
+
+    pub(crate) fn block_break(val: Value, block_fid: FuncId, outer: Lfp) -> MonorubyErr {
+        MonorubyErr::new(
+            MonorubyErrKind::BlockBreak(val, block_fid, outer),
             String::new(),
         )
     }
@@ -1012,6 +1026,14 @@ pub enum MonorubyErrKind {
     SystemExit(u8),
     Other(ClassId),
     MethodReturn(Value, Lfp),
+    /// `break` escaping a block: carries the break value, the block's
+    /// FuncId, and the block's outer (defining) frame. The unwinder
+    /// resumes the defining frame's in-progress call *if* that call is
+    /// the one that received this block literal (checked against the
+    /// frame's current call site); otherwise it degrades to
+    /// LocalJumpError ("break from proc-closure"). Mirrors CRuby's
+    /// BREAK catch-table mechanism.
+    BlockBreak(Value, FuncId, Lfp),
     Retry,
     Redo,
     /// Kernel#throw — carries (tag, value). Not catchable by `rescue`;

--- a/monoruby/tests/break_proc.rs
+++ b/monoruby/tests/break_proc.rs
@@ -1,0 +1,121 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn break_valid_paths() {
+    // break escapes the invocation of the call that received the block
+    // literal — direct iteration, &b forwarding while the receiving
+    // call is active, and Ruby-defined iterators are all valid.
+    run_test_once(
+        r#"
+        res = []
+        res << [1,2].each { break :direct }
+        def fwd(&b); r = [1,2].each(&b); [:fwd_after, r]; end
+        res << (fwd { break :forwarded })
+        res << [1,2].map { break :mapped }
+        res << ([1,2].to_enum.each { break :enum })
+        res << ({x: 1}.each_pair { break :hash })
+        res << ([3,1].sort { |a,b| break :sorted })
+        res << ([1,2].each_with_object([]) { break :ewo })
+        h = [1].each { [2].each { break :nested } }
+        res << h
+        res
+        "#,
+    );
+}
+
+#[test]
+fn break_from_captured_proc_raises() {
+    // A block materialized into a Proc and invoked outside its original
+    // receiving call raises LocalJumpError, even while the defining
+    // scope is still active (CRuby's BREAK catch-table semantics).
+    run_test_once(
+        r#"
+        def cap(&b); b; end
+        res = []
+        def use_call
+          b = cap { break :x }
+          b.call
+          :no_error
+        rescue LocalJumpError => e
+          [:lje, e.message]
+        end
+        res << use_call
+        def yielder; yield; end
+        def use_reyield
+          b = cap { break :y }
+          [:got, yielder(&b)]
+        rescue LocalJumpError => e
+          [:lje2, e.message]
+        end
+        res << use_reyield
+        begin
+          proc { break :z }.call
+        rescue LocalJumpError => e
+          res << [:lje3, e.message]
+        end
+        # lambda break is local
+        res << lambda { break :local }.call
+        res
+        "#,
+    );
+}
+
+#[test]
+fn break_ensure_interaction() {
+    run_test_once(
+        r#"
+        class BT
+          def one; two { yield }; end
+          def two
+            yield
+          ensure
+            $sp << :two_ensure
+          end
+          def three
+            begin
+              one { break }
+              $sp << :three_post
+            ensure
+              $sp << :three_ensure
+            end
+          end
+        end
+        $sp = []
+        BT.new.three
+        $sp
+        "#,
+    );
+}
+
+#[test]
+fn break_in_thread_body_raises() {
+    run_test_once(
+        r#"
+        t = Thread.new do
+          begin
+            break :break
+          rescue LocalJumpError => e
+            e
+          end
+        end
+        v = t.value
+        [v.class.to_s, v.instance_of?(LocalJumpError)]
+        "#,
+    );
+}
+
+#[test]
+fn break_jit_tier() {
+    // Hot loop: break through iteration keeps working under the JIT.
+    run_test(
+        r#"
+        def find_first(arr)
+          arr.each { |x| break x if x > 2 }
+        end
+        res = []
+        40.times { res << find_first([1, 2, 3, 4]) }
+        res.last(2)
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Iteration 11 of the ruby/spec `language` cleanup: correct `break` escape semantics. Previously a `break` in a block captured as a Proc and invoked later (via `Proc#call`, or re-yielded with `&b`) silently "succeeded"; CRuby raises `LocalJumpError` in those cases, even while the defining scope is still active.

### The model (mirrors CRuby's BREAK catch table)

`break` escapes to **the invocation of the call that received the block literal**. Verified point-by-point against CRuby: direct iteration and `&b` forwarding (while the receiving call is active) stay valid; a captured Proc invoked any other way is `break from proc-closure`.

### Implementation

- New internal error kind `BlockBreak(value, block FuncId, outer Lfp)` raised by `err_block_break` (with an up-front fast path routing lambda-local `break` to a plain method return, and a pre-check that the defining frame is reachable on the current stack — a scope that has already returned fails immediately).
- The unwinder stops at the block's **defining frame**: if its suspended pc sits on the call site that carries this block literal, the frame resumes right after that call with the break value written to the call's destination register. That call-site check needed the iseq `callsite_map` to also record `MethodCall`/`Super`/`Yield` instructions (previously only operator call sites were mapped).
- **Ensure interaction** (covered by existing specs, kept green): intermediate frames run their `ensure` bodies as the break passes through; the defining frame's own `ensure` does *not* run on a matching break, since control stays inside the begin region (`bt2.three` → `[:two_ensure, :three_post, :three_ensure]`).
- **Thread bodies**: monoruby runs them synchronously on the spawning stack, so `Thread#__invoke_body` brackets the body with a break barrier (`Executor::break_barriers`) — a `break` in a thread body never resolves its defining frame across the boundary and raises the `LocalJumpError` *at the break site*, rescuable inside the body (as the spec requires).

Internal block-consuming machinery (Enumerator, Ruby-defined Enumerable methods, `sort`, `each_with_object`, …) keeps working unchanged: during a live iteration the defining frame's pc *is* at the receiving call site, so those breaks stay valid by construction.

## ruby/spec impact

- language: **55 → 50 failing examples** (`break_spec` 5 → 0: the three captured-block cases, the thread case, and the super-conversion case; the ensure-interaction examples stay green).
- No regressions in the per-file language sweep; `core/proc`, `core/enumerator`, `core/enumerable`, `core/kernel/loop` failures verified byte-identical to a master-built binary.

## Test plan

- New `tests/break_proc.rs` (5 tests, compared against CRuby 4.0.2): valid paths (direct/forwarded/Ruby-iterator/enumerator/nested), captured-proc LocalJumpError cases incl. messages, the ensure-ordering case, break-in-thread-body, and a JIT-tier test.
- Full stress suite green: `cargo test --features stress-spill-pool,gc-stress`.
- Minor patch-coverage movement can be ignored per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_