### PR TITLE
Fiber-local read-only $!; $_ from StringIO#gets; $0 keeps the given path; set_backtrace accepts Locations

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -4,36 +4,15 @@ class Enumerator
   include Enumerable
 end
 
-class CallerLocation
-  def initialize(path, lineno, label)
-    @path = path
-    @lineno = lineno
-    @label = label
-  end
-  attr_reader :path, :lineno, :label
-
-  def base_label
-    l = @label
-    l = $1 while l =~ /\Ablock in (.+)\z/
-    l
-  end
-
-  def to_s
-    "#{@path}:#{@lineno}:in '#{@label}'"
-  end
-  alias inspect to_s
-end
-
+# `caller_locations` returns the same `Thread::Backtrace::Location`
+# objects as `Exception#backtrace_locations` (defined in startup.rb),
+# each parsed lazily from its `caller` frame string.
 def caller_locations(start = 1, length = nil)
   frames = caller(start + 1)
   return nil if frames.nil?
   frames = frames[0, length] if length
   frames.map do |frame|
-    if frame =~ /\A(.+):(\d+):in ['`](.+)'\z/
-      CallerLocation.new($1, $2.to_i, $3)
-    else
-      CallerLocation.new(frame, 0, "")
-    end
+    Thread::Backtrace::Location.new(frame)
   end
 end
 

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -888,12 +888,37 @@ class Thread
   class Backtrace
     class Location
       def initialize(frame)
-        @frame = frame
+        @frame = frame.to_s
+        if @frame =~ /\A(.+):(\d+):in ['`](.+)'\z/
+          @path = $1
+          @lineno = $2.to_i
+          @label = $3
+        else
+          @path = @frame
+          @lineno = 0
+          @label = ""
+        end
       end
 
-      def path
+      attr_reader :path, :lineno, :label
+
+      def base_label
+        l = @label
+        l = $1 while l =~ /\Ablock (?:\(\d+ levels\) )?in (.+)\z/
+        l
+      end
+
+      # CRuby returns nil for frames without a real file (eval'd code,
+      # internal frames).
+      def absolute_path
+        return nil if @path.start_with?("(") || @path.start_with?("<")
+        File.expand_path(@path)
+      end
+
+      def to_s
         @frame
       end
+      alias inspect to_s
     end
   end
 end
@@ -910,6 +935,18 @@ class Exception
     return nil if bt.nil?
     bt.map do |frame|
       Thread::Backtrace::Location.new(frame)
+    end
+  end
+
+  # CRuby 3.4+: `set_backtrace` (and thus `$@ =`) also accepts an Array
+  # of `Thread::Backtrace::Location`, stored as their string forms. Mixed
+  # or otherwise invalid arrays fall through to the native checker, which
+  # raises the usual TypeError.
+  def set_backtrace(bt)
+    if bt.is_a?(Array) && !bt.empty? && bt.all? { |e| Thread::Backtrace::Location === e }
+      __set_backtrace(bt.map(&:to_s))
+    else
+      __set_backtrace(bt)
     end
   end
 

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -118,6 +118,10 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(EXCEPTION_CLASS, "message", message, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "backtrace", backtrace, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "set_backtrace", set_backtrace, 1);
+    // Internal alias: `startup.rb` redefines `set_backtrace` with a Ruby
+    // wrapper that also accepts `Thread::Backtrace::Location` arrays
+    // (CRuby 3.4+) by converting them to strings, then delegates here.
+    globals.define_builtin_func(EXCEPTION_CLASS, "__set_backtrace", set_backtrace, 1);
     globals.define_builtin_func(EXCEPTION_CLASS, "cause", cause, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "==", exception_eq, 1);
     globals.define_builtin_func_with(
@@ -361,14 +365,14 @@ fn set_backtrace(
         for elem in ary.iter() {
             if elem.is_str().is_none() {
                 return Err(MonorubyErr::typeerr(
-                    "backtrace must be an Array of String",
+                    "backtrace must be an Array of String or an Array of Thread::Backtrace::Location",
                 ));
             }
         }
         arg
     } else {
         return Err(MonorubyErr::typeerr(
-            "backtrace must be an Array of String or a String",
+            "backtrace must be an Array of String or an Array of Thread::Backtrace::Location",
         ));
     };
     globals

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -203,6 +203,12 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "__instance_ty", instance_ty, 0);
     globals.define_builtin_func(
         kernel_class,
+        "__set_lastline_in_caller",
+        set_lastline_in_caller,
+        1,
+    );
+    globals.define_builtin_func(
+        kernel_class,
         "__enum_yield",
         super::enumerator::yielder_yield,
         1,
@@ -558,6 +564,26 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
 }
 
 ///
+/// ### Kernel.#__set_lastline_in_caller (monoruby intrinsic)
+///
+/// Sets `$_` in the method scope of the frame that called the invoking
+/// Ruby method. Used by Ruby-implemented IO-like stubs (`stringio.rb`)
+/// whose `gets`/`readline` must publish `$_` to their caller the way
+/// CRuby's C readers do via `rb_lastline_set`. Returns its argument.
+///
+#[monoruby_builtin]
+fn set_lastline_in_caller(
+    vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let val = lfp.arg(0);
+    vm.set_last_read_line_in_caller(val);
+    Ok(val)
+}
+
+///
 /// ### Kernel.#print
 ///
 /// - print(*arg) -> nil
@@ -700,7 +726,7 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 "only cause is given with no arguments",
             ));
         }
-        let ex = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+        let ex = vm.errinfo();
         if let Some(inner) = ex.is_exception() {
             return Err(MonorubyErr::new_from_exception(inner).with_original(ex));
         } else {
@@ -2667,7 +2693,7 @@ fn catch_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         None => Value::object(OBJECT_CLASS),
     };
     let bh = lfp.expect_block()?;
-    let saved_errinfo = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+    let saved_errinfo = vm.errinfo();
     vm.push_catch_tag(tag);
     let res = vm.invoke_block_once(globals, bh, &[tag]);
     vm.pop_catch_tag();
@@ -2679,7 +2705,7 @@ fn catch_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                     // A caught throw restores `$!` to its value at
                     // catch entry: throwing from inside a rescue must
                     // not leak the in-flight exception.
-                    globals.set_gvar(IdentId::get_id("$!"), saved_errinfo);
+                    vm.set_errinfo(saved_errinfo);
                     return Ok(*throw_val);
                 }
             }

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -836,7 +836,7 @@ impl<'a> BytecodeGen<'a> {
                 self.emit(
                     BytecodeInst::StoreGvar {
                         val: save,
-                        name: IdentId::get_id("$!"),
+                        name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                     },
                     Loc::default(),
                 );
@@ -1094,7 +1094,7 @@ impl<'a> BytecodeGen<'a> {
                 self.emit(
                     BytecodeInst::StoreGvar {
                         val: save,
-                        name: IdentId::get_id("$!"),
+                        name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                     },
                     Loc::default(),
                 );

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -35,7 +35,7 @@ impl<'a> BytecodeGen<'a> {
                 self.emit(
                     BytecodeInst::LoadGvar {
                         dst: errinfo_save,
-                        name: IdentId::get_id("$!"),
+                        name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                     },
                     Loc::default(),
                 );
@@ -49,7 +49,7 @@ impl<'a> BytecodeGen<'a> {
                 self.emit(
                     BytecodeInst::StoreGvar {
                         val: errinfo_save,
-                        name: IdentId::get_id("$!"),
+                        name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                     },
                     Loc::default(),
                 );

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -429,7 +429,7 @@ impl<'a> BytecodeGen<'a> {
             self.emit(
                 BytecodeInst::LoadGvar {
                     dst: reg,
-                    name: IdentId::get_id("$!"),
+                    name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                 },
                 Loc::default(),
             );
@@ -578,7 +578,7 @@ impl<'a> BytecodeGen<'a> {
                     self.emit(
                         BytecodeInst::StoreGvar {
                             val: errinfo_save.expect("rescue clause without errinfo save slot"),
-                            name: IdentId::get_id("$!"),
+                            name: IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
                         },
                         Loc::default(),
                     );

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -221,7 +221,7 @@ pub(super) extern "C" fn handle_error(
             }
             if let Some((Some(rescue), _, err_reg)) = info.get_exception_dest(pc) {
                 let err_val = vm.take_ex_obj(globals);
-                globals.set_gvar(IdentId::get_id("$!"), err_val);
+                vm.set_errinfo(err_val);
                 if let Some(err_reg) = err_reg {
                     unsafe { lfp.set_register(err_reg, Some(err_val)) };
                 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -165,6 +165,14 @@ pub struct Executor {
     catch_tags: Vec<u64>,
     /// error information.
     exception: Option<MonorubyErr>,
+    /// The exception currently being handled — the value of `$!`. CRuby
+    /// keeps errinfo per execution context (Fiber), so it lives here
+    /// rather than in the process-global gvar table; each Fiber owns its
+    /// own `Executor`, which gives `$!` its fiber-local semantics. Ruby
+    /// code reads it through the read-only `$!` gvar hook and the VM /
+    /// bytecodegen save-restore protocol writes it through the internal
+    /// `$(errinfo)` hook (see `globals/gvar.rs`).
+    errinfo: Value,
     /// Non-local control-flow errors (`MethodReturn` / `Throw`) that were
     /// temporarily moved out of `exception` so an `ensure` body can run
     /// with an empty error slot, keyed by the LFP of the frame whose
@@ -197,6 +205,7 @@ impl std::default::Default for Executor {
             loading_paths: vec![],
             catch_tags: vec![],
             exception: None,
+            errinfo: Value::nil(),
             deferred_unwind: vec![],
         }
     }
@@ -229,6 +238,9 @@ impl alloc::GC<RValue> for Executor {
         if let Some(err) = &self.exception {
             err.mark(alloc);
         }
+        // `$!` — the exception being handled survives as long as this
+        // execution context (fiber) does.
+        self.errinfo.mark(alloc);
         // Transient per-match stashes: live across the MatchData
         // allocation in `save_capture_special_variables`, which can
         // trigger GC.
@@ -282,7 +294,7 @@ impl Executor {
             }
         }
         // Clear stale $! that may have been set during startup/gem loading.
-        globals.set_gvar(IdentId::get_id("$!"), Value::nil());
+        executor.set_errinfo(Value::nil());
         // Same for $~ (and the back-ref family $&/$'/$`/$N derived from
         // it): certain Hash#[]= calls in startup.rb (notably
         // `RbConfig::CONFIG['rubylibprefix'] = ...`) currently set $~
@@ -992,6 +1004,15 @@ impl Executor {
         self.exception = None
     }
 
+    /// The exception currently being handled (`$!`), fiber-local.
+    pub(crate) fn errinfo(&self) -> Value {
+        self.errinfo
+    }
+
+    pub(crate) fn set_errinfo(&mut self, val: Value) {
+        self.errinfo = val;
+    }
+
     ///
     /// Move the current in-flight error out of `exception` and stash it as
     /// the deferred unwind for frame *lfp*, so the frame's `ensure` body
@@ -1190,9 +1211,7 @@ impl Executor {
             return v;
         }
         if globals.store.get_ivar(v, cause_id).is_none() {
-            let active = globals
-                .get_gvar(IdentId::get_id("$!"))
-                .unwrap_or_default();
+            let active = self.errinfo;
             if !active.is_nil() && active.id() != v.id() {
                 let _ = globals.store.set_ivar(v, cause_id, active);
             }
@@ -2978,6 +2997,49 @@ impl Executor {
         if let Some(c) = self.svar_container_create() {
             c.as_array()[SVAR_LASTLINE] = val;
         }
+    }
+
+    /// `$_` writer targeting the *caller of the calling Ruby method*.
+    ///
+    /// Ruby-implemented IO-like stubs (e.g. `stdlib/stringio.rb`) must set
+    /// `$_` in the scope that invoked their `gets`, the way CRuby's
+    /// C-implemented readers do via `rb_lastline_set`. A plain `$_ = line`
+    /// inside the stub would land on the stub's own method frame and be
+    /// lost on return, so the stub calls the `__set_lastline_in_caller`
+    /// intrinsic, which resolves frames as: skip the intrinsic's native
+    /// frame, pop out of the stub method (including any of its blocks),
+    /// then write to the method scope of the frame that called the stub.
+    pub(crate) fn set_last_read_line_in_caller(&mut self, val: Value) {
+        let Some(mut cfp) = self.cfp else { return };
+        // Skip the intrinsic's own native frame (and any native wrappers).
+        while cfp.lfp().meta().is_native() {
+            let Some(prev) = cfp.prev() else { return };
+            cfp = prev;
+        }
+        // The stub may call the intrinsic from inside one of its own
+        // blocks; unwind to the stub's method frame first.
+        let stub_mfp = cfp.lfp().mfp();
+        while cfp.lfp() != stub_mfp {
+            let Some(prev) = cfp.prev() else { return };
+            cfp = prev;
+        }
+        // Step out of the stub method, skipping natives (`Method#call`,
+        // `send`, ... trampolines), to the frame that invoked it.
+        let Some(mut cfp) = cfp.prev() else { return };
+        while cfp.lfp().meta().is_native() {
+            let Some(prev) = cfp.prev() else { return };
+            cfp = prev;
+        }
+        let mfp = cfp.lfp().mfp();
+        let c = match mfp.svar() {
+            Some(v) => v,
+            None => {
+                let arr = Value::array2(Value::nil(), Value::nil());
+                mfp.set_svar_slot_value(arr);
+                arr
+            }
+        };
+        c.as_array()[SVAR_LASTLINE] = val;
     }
 
     /// `MatchData#[]` semantics for `$n` access (0 = full match,

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -593,7 +593,7 @@ impl Executor {
                 // `$!.message` at_exit specs rely on).
                 self.set_error(err);
                 let err_val = self.take_ex_obj(globals);
-                globals.set_gvar(IdentId::get_id("$!"), err_val);
+                self.set_errinfo(err_val);
                 handler_failed = true;
             }
         }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -99,6 +99,12 @@ pub(crate) fn noinline_gen(
 pub(crate) const GLOBALS_FUNCINFO: usize =
     std::mem::offset_of!(Globals, store.functions.info) + MONOVEC_PTR;
 
+/// Internal gvar name used by bytecodegen to save/restore `$!`
+/// (`Executor::errinfo`). `$!` itself is read-only from Ruby, so the
+/// generated save/restore code writes through this hooked alias instead;
+/// the parentheses make the name unspellable in Ruby source.
+pub(crate) const ERRINFO_INTERNAL_GVAR: &str = "$(errinfo)";
+
 #[derive(Clone, Debug)]
 pub(crate) struct ExternalContext {
     scope: Vec<(

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -460,6 +460,40 @@ fn write_special_check(
 /// names by hand.
 ///
 pub fn init_builtin_gvars(globals: &mut Globals) {
+    // --- Exception being handled (`$!`) ---------------------------------------
+
+    // `$!` is per execution context in CRuby — each Fiber sees its own
+    // errinfo — so it is backed by `Executor::errinfo` rather than the
+    // process-global gvar table, and it is read-only from Ruby. The VM's
+    // rescue-entry path writes the field directly; the bytecodegen
+    // save/restore protocol (rescue-exit restore, `defined?` probes)
+    // writes it through the internal `$(errinfo)` hook, whose name cannot
+    // be spelled in Ruby source.
+    fn get_errinfo(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        Some(vm.errinfo())
+    }
+
+    fn set_errinfo_internal(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+        val: Value,
+    ) -> Result<()> {
+        vm.set_errinfo(val);
+        Ok(())
+    }
+
+    globals.define_hooked_variable(IdentId::get_id("$!"), get_errinfo, None);
+    globals.define_hooked_variable(
+        IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),
+        get_errinfo,
+        Some(set_errinfo_internal),
+    );
+
     // --- Regexp-related special variables -----------------------------------
 
     // $~ is always considered defined (CRuby parses it as a regular global
@@ -662,7 +696,7 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
         globals: &mut Globals,
         _name: IdentId,
     ) -> Option<Value> {
-        let err = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+        let err = vm.errinfo();
         if err.is_nil() {
             return Some(Value::nil());
         }
@@ -682,7 +716,7 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
         _name: IdentId,
         val: Value,
     ) -> Result<()> {
-        let err = globals.get_gvar(IdentId::get_id("$!")).unwrap_or_default();
+        let err = vm.errinfo();
         if err.is_nil() {
             return Err(MonorubyErr::argumenterr("$! not set"));
         }

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -142,7 +142,10 @@ fn main() {
     globals.set_gvar(monoruby::IdentId::get_id("$*"), argv);
     let (code, path) = if let Some(file_name) = first {
         match read_source_file(&std::path::PathBuf::from(&file_name)) {
-            Ok(res) => res,
+            // Keep the path exactly as given on the command line: CRuby
+            // reports `$0` / `__FILE__` for the main script verbatim
+            // (relative stays relative), not canonicalized.
+            Ok((code, _resolved)) => (code, std::path::PathBuf::from(&file_name)),
             Err(err) => {
                 // No VM frame exists yet, so a `MonorubyErr` here would
                 // carry no trace and cannot be displayed as a normal

--- a/monoruby/stdlib/stringio.rb
+++ b/monoruby/stdlib/stringio.rb
@@ -217,7 +217,9 @@ class StringIO
 
   def gets(sep = "\n", limit = nil)
     _check_readable
-    return nil if eof?
+    # CRuby's StringIO#gets publishes the line it read (or nil at EOF)
+    # as the caller's `$_`, like Kernel#gets.
+    return __set_lastline_in_caller(nil) if eof?
 
     if sep.is_a?(Integer)
       limit = sep
@@ -233,7 +235,7 @@ class StringIO
       while @pos < @string.length && @string[@pos] == "\n"
         @pos += 1
       end
-      return nil if eof?
+      return __set_lastline_in_caller(nil) if eof?
       idx = @string.index("\n\n", @pos)
       if idx
         line = @string[@pos..idx]
@@ -263,11 +265,13 @@ class StringIO
     end
 
     @lineno += 1
-    line
+    __set_lastline_in_caller(line)
   end
 
   def readline(*args)
     line = gets(*args)
+    # `gets` set `$_` in *this* frame; re-publish it to our caller.
+    __set_lastline_in_caller(line)
     raise EOFError, "end of file reached" if line.nil?
     line
   end

--- a/monoruby/tests/predefined_gvar.rs
+++ b/monoruby/tests/predefined_gvar.rs
@@ -306,3 +306,135 @@ fn shared_substring_snapshot_window() {
         "#,
     );
 }
+
+#[test]
+fn errinfo_fiber_local_and_read_only() {
+    // `$!` is backed by the per-fiber Executor: an exception rescued
+    // (and suspended) inside a Fiber must not leak into the parent
+    // fiber's `$!`, and assigning `$!` raises NameError.
+    run_test_once(
+        r#"
+        res = []
+        Fiber.new do
+          raise "hi"
+        rescue
+          Fiber.yield
+        end.resume
+        res << $!
+        Fiber.new do
+          raise "yo"
+        rescue
+          Fiber.yield
+        end.resume
+        res << $@
+        begin
+          eval("$! = []")
+        rescue NameError => e
+          res << e.message
+        end
+        res << ($! ? "leaked" : "clean")
+        res
+        "#,
+    );
+}
+
+#[test]
+fn errinfo_rescue_save_restore() {
+    // The bytecodegen `$!` save/restore protocol (now routed through the
+    // internal errinfo hook) still restores the outer exception when a
+    // nested rescue completes, when a rescue exits via `return`, and
+    // around `ensure` bodies; bare `raise` re-raises `$!`.
+    run_test(
+        r#"
+        res = []
+        def f(res)
+          begin
+            raise "x"
+          rescue
+            return 1
+          ensure
+            res << $!.class.to_s
+          end
+        end
+        f(res)
+        res << $!.inspect
+        begin
+          raise "outer"
+        rescue
+          begin
+            raise "inner"
+          rescue
+          end
+          res << $!.message
+        end
+        begin
+          begin
+            raise "again"
+          rescue
+            raise
+          end
+        rescue => e
+          res << e.message
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
+fn lastline_set_by_stringio_gets() {
+    // StringIO#gets / #readline publish `$_` to their caller's method
+    // scope (CRuby sets it via rb_lastline_set from C), including nil at
+    // EOF, and a read inside a block lands on the enclosing method scope.
+    run_test_once(
+        r#"
+        require 'stringio'
+        res = []
+        sio = StringIO.new("foo\nbar\n", "r")
+        res << sio.gets
+        res << $_
+        res << sio.gets
+        res << $_
+        res << sio.gets
+        res << $_
+        obj = Object.new
+        def obj.run; yield; end
+        sio2 = StringIO.new("a\nb\n", "r")
+        obj.run { sio2.gets }
+        res << $_
+        sio3 = StringIO.new("x\n", "r")
+        sio3.readline
+        res << $_
+        res
+        "#,
+    );
+}
+
+#[test]
+fn set_backtrace_accepts_locations() {
+    // CRuby 3.4+: `Exception#set_backtrace` (and `$@ =`) accept an Array
+    // of `Thread::Backtrace::Location`, stored as their string forms;
+    // mixed / invalid arrays raise TypeError with CRuby's message.
+    run_test_once(
+        r#"
+        def probe = caller_locations
+        locs = probe
+        e = RuntimeError.new("x")
+        e.set_backtrace(locs)
+        res = [e.backtrace == locs.map(&:to_s)]
+        res << (e.backtrace_locations.map(&:lineno) == locs.map(&:lineno))
+        begin
+          e.set_backtrace(["a", :b])
+        rescue TypeError => te
+          res << te.message
+        end
+        begin
+          raise "z"
+        rescue
+          $@ = locs
+          res << ($!.backtrace == locs.map(&:to_s))
+        end
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Iteration 14 of the ruby/spec language-category fix loop, focused on predefined variables. Language failures: **43 → 36** (`predefined_spec` 12 → 5).

### Fixes

1. **`$!` / `$@` are Fiber-local and `$!` is read-only** — `$!` now lives in `Executor::errinfo` (each Fiber owns its own `Executor`, which gives CRuby's fiber-local errinfo semantics) instead of the process-global gvar table, and is registered as a hooked gvar with no setter, so `$! = []` raises `NameError: $! is a read-only variable`. The bytecodegen save/restore protocol (rescue-exit restore, ensure-entry restore, `defined?` probes) writes through an internal `$(errinfo)` hook whose name cannot be spelled in Ruby source; the VM/JIT rescue-entry path and `Kernel#catch` write the field directly. `$@` reads/writes delegate to the same field.

2. **`$_` is published by `StringIO#gets` / `#readline`** — a new `__set_lastline_in_caller` intrinsic writes `$_` into the method scope of the frame that called the invoking Ruby method (the way CRuby's C readers use `rb_lastline_set`), including `nil` at EOF, and lands on the enclosing method scope when the read happens inside a block.

3. **`$0` / `__FILE__` keep the command-line spelling** — the main script path is no longer canonicalized for display, so `monoruby fixtures/x.rb` reports the relative path like CRuby.

4. **`Exception#set_backtrace` / `$@=` accept `Thread::Backtrace::Location` arrays (CRuby 3.4+)** — `Thread::Backtrace::Location` got a real implementation (`path`/`lineno`/`label`/`base_label`/`absolute_path`/`to_s`), `caller_locations` now returns it (replacing the ad-hoc `CallerLocation`), and invalid arrays raise CRuby's exact TypeError message.

### Remaining predefined failures (deferred)

- `$!` cleared on non-local return from a rescue clause (2) — needs rescue-clause ranges in the exception table for a runtime unwind restore.
- RbConfig `sitelibdir` staleness, `$0=` process-title, `resolve_feature_path` `.so` (3) — environment/stub design questions.

### Tests

- 4 new integration tests in `monoruby/tests/predefined_gvar.rs` (fiber-local/read-only `$!`, rescue save/restore protocol, StringIO `$_`, Location `set_backtrace`).
- Full `cargo test` green locally.

Minor coverage drops on fallback branches can be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_