### PR TITLE
Bare regexp matches $_; splat calls BasicObject#to_a; sclass return; redo runs ensure; invalid-UTF-8 message

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -534,6 +534,9 @@ struct BytecodeGen<'a> {
     /// method (non-local); a lambda's are local. Both have an `outer`,
     /// so this is what distinguishes them.
     block_style: bool,
+    /// Whether this iseq is a singleton-class body (`class << obj`),
+    /// whose `return` exits the enclosing method like a block's.
+    singleton_classdef: bool,
     /// bytecode IR.
     ir: Vec<(BytecodeInst, Loc)>,
     /// the temp stack pointer for each bytecode instruction.
@@ -596,6 +599,7 @@ impl<'a> BytecodeGen<'a> {
         let func_id = info.func_id();
         let sourceinfo = info.sourceinfo.clone();
         let outer = info.outer;
+        let singleton_classdef = info.singleton_classdef;
         let block_style = store[func_id].is_block_style();
         let mut codegen = Self {
             store,
@@ -604,6 +608,7 @@ impl<'a> BytecodeGen<'a> {
             mother: (mother, mother_params, mother_outer),
             outer,
             block_style,
+            singleton_classdef,
             ir: vec![],
             sp: vec![],
             labels: BytecodeLabels::new(), // The first label is for redo.
@@ -771,6 +776,14 @@ impl<'a> BytecodeGen<'a> {
         self.outer.is_some() && self.block_style
     }
 
+    /// `return` transfers control out of the enclosing method rather
+    /// than this frame: true in a real block and in a singleton-class
+    /// body (`class << obj; return; end` returns from the method
+    /// executing the sclass expression — CRuby).
+    fn return_escapes(&self) -> bool {
+        self.is_escaping_block() || self.singleton_classdef
+    }
+
     fn add_method(
         &mut self,
         name: Option<IdentId>,
@@ -787,9 +800,11 @@ impl<'a> BytecodeGen<'a> {
         name: Option<IdentId>,
         compile_info: CompileInfo,
         loc: Loc,
+        is_singleton: bool,
     ) -> Result<FuncId> {
         let sourceinfo = self.sourceinfo.clone();
-        self.store.new_classdef(name, compile_info, loc, sourceinfo)
+        self.store
+            .new_classdef(name, compile_info, loc, sourceinfo, is_singleton)
     }
 
     fn add_block(&mut self, outer: ISeqId, compile_info: CompileInfo, loc: Loc) -> Result<FuncId> {
@@ -1073,11 +1088,14 @@ impl<'a> BytecodeGen<'a> {
         self.sp.push(BcTemp(self.temp));
     }
 
-    fn emit_ret(&mut self, src: Option<BcReg>) -> Result<()> {
+    /// Emit every currently-open `ensure` body (innermost first) with
+    /// the `$!` restore protocol — for exits that leave all of this
+    /// frame's begin regions at once (`return`, block-level `redo`).
+    fn gen_all_pending_ensures(&mut self) -> Result<()> {
         // Temporarily take the ensure stack to avoid infinite recursion when
-        // a `return` appears inside an `ensure` block.  Without this, the
-        // `return` in the ensure body would call `emit_ret` again, which would
-        // re-generate the same ensure block, leading to unbounded recursion.
+        // the exit appears inside an `ensure` block.  Without this, a
+        // `return` in the ensure body would recurse into the same ensure
+        // block, leading to unbounded regeneration.
         let in_rescue = self.rescue_depth > 0;
         let ensures: Vec<_> = std::mem::take(&mut self.ensure);
         let pending: Vec<_> = ensures.iter().rev().cloned().collect();
@@ -1104,6 +1122,11 @@ impl<'a> BytecodeGen<'a> {
             }
         }
         self.ensure = ensures;
+        Ok(())
+    }
+
+    fn emit_ret(&mut self, src: Option<BcReg>) -> Result<()> {
+        self.gen_all_pending_ensures()?;
 
         let ret = match src {
             Some(ret) => ret,

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -319,7 +319,7 @@ impl<'a> BytecodeGen<'a> {
                 self.gen_method_call(method, None, arglist, safe_nav, false, UseMode2::Store(dst), loc)?;
             }
             NodeKind::Return(box val) => {
-                if self.is_escaping_block() {
+                if self.return_escapes() {
                     return self.gen_method_return(val, UseMode2::Store(dst));
                 } else {
                     return self.gen_return(val, UseMode2::Store(dst));
@@ -847,10 +847,19 @@ impl<'a> BytecodeGen<'a> {
                 if use_mode == UseMode2::Push {
                     self.push();
                 }
-                let LoopInfo { redo_dest, .. } = match self.loops.last() {
-                    Some(data) => data,
+                let LoopInfo {
+                    redo_dest,
+                    ensure_depth,
+                    ..
+                } = match self.loops.last() {
+                    Some(data) => data.clone(),
                     None => {
                         if self.is_block() {
+                            // Restarting the block body exits every open
+                            // begin/ensure region — run their ensure
+                            // bodies first (same unwinding protocol as a
+                            // block-local return).
+                            self.gen_all_pending_ensures()?;
                             self.emit(BytecodeInst::Redo(self.redo_label), loc);
                             return Ok(());
                         } else {
@@ -858,11 +867,14 @@ impl<'a> BytecodeGen<'a> {
                         }
                     }
                 };
+                // Run `ensure` blocks nested inside the loop before
+                // re-executing the body.
+                self.gen_loop_pending_ensures(ensure_depth)?;
                 // Use the `Redo` op (a `goto` via the error path) rather than a
                 // plain `Br`: its target can sit in the middle of the loop body
                 // (skipping the condition) without the JIT seeing a second
                 // back-edge into the loop, which its loop analysis can't merge.
-                self.emit(BytecodeInst::Redo(*redo_dest), loc);
+                self.emit(BytecodeInst::Redo(redo_dest), loc);
                 return Ok(());
             }
             NodeKind::Retry => {
@@ -880,7 +892,7 @@ impl<'a> BytecodeGen<'a> {
                 return Ok(());
             }
             NodeKind::Return(box val) => {
-                if self.is_escaping_block() {
+                if self.return_escapes() {
                     self.gen_method_return(val, use_mode)?;
                 } else {
                     self.gen_return(val, use_mode)?;
@@ -2084,7 +2096,7 @@ impl<'a> BytecodeGen<'a> {
             None
         };
         let compile_info = Store::handle_args(info, vec![])?;
-        let func_id = self.add_classdef(Some(name), compile_info, loc)?;
+        let func_id = self.add_classdef(Some(name), compile_info, loc, false)?;
         let superclass = match superclass {
             Some(box superclass) => Some(self.push_expr(superclass)?.into()),
             None => None,
@@ -2129,7 +2141,7 @@ impl<'a> BytecodeGen<'a> {
         loc: Loc,
     ) -> Result<()> {
         let compile_info = Store::handle_args(info, vec![])?;
-        let func_id = self.add_classdef(None, compile_info, loc)?;
+        let func_id = self.add_classdef(None, compile_info, loc, true)?;
         let old = self.temp;
         let base = self.gen_expr_reg(base)?;
         self.temp = old;

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1705,7 +1705,22 @@ pub(super) extern "C" fn err_method_return(vm: &mut Executor, globals: &mut Glob
     // is decided here from the frame's *current* style: a real block
     // returns non-locally to its home method (`outermost_lfp`), a lambda
     // returns from its own frame.
-    let cfp = vm.cfp();
+    let mut cfp = vm.cfp();
+    // A `return` written in a singleton-class body (`class << obj`) —
+    // the only class-body position bytecodegen compiles to a
+    // method-return — exits the method executing the sclass expression.
+    // The body runs as a direct call from that frame, so hop to the
+    // caller (skipping nested class bodies and native trampolines) and
+    // resolve the target as if the return were written there.
+    while globals[cfp.lfp().func_id()].is_classdef() {
+        let Some(prev) = cfp.prev() else { break };
+        cfp = prev;
+        while cfp.lfp().meta().is_native() {
+            let Some(prev) = cfp.prev() else { break };
+            cfp = prev;
+        }
+    }
+    let cfp = cfp;
     let target_lfp = if globals[cfp.lfp().func_id()].is_block_style() {
         let target = cfp.outermost_lfp();
         // A synchronous thread-body boundary (see
@@ -1844,31 +1859,30 @@ pub(super) extern "C" fn to_a(
     if src.is_nil() {
         return Some(Value::array_empty());
     }
-    // An object that does not even respond to `#respond_to?` (a bare
-    // `BasicObject`) cannot be coerced: treat it like a value without
-    // `#to_a` and wrap it in a one-element array, matching CRuby, rather
-    // than raising `NoMethodError`.
-    if globals
+    // Like `#to_ary` destructuring above, CRuby gates the `#to_a` call on
+    // `respond_to?(:to_a, true)` (a user may override it), not a raw
+    // method-table lookup. An object without `#respond_to?` (a bare
+    // `BasicObject`) falls back to the raw lookup — CRuby's
+    // `rb_check_funcall` still calls a `to_a` defined on it.
+    let responds = if globals
         .check_method(src, IdentId::get_id("respond_to?"))
         .is_none()
     {
-        return Some(Value::array1(src));
-    }
-    // Like `#to_ary` destructuring above, CRuby gates the `#to_a` call on
-    // `respond_to?(:to_a, true)` (a user may override it), not a raw
-    // method-table lookup.
-    let responds = match vm.invoke_method_inner(
-        globals,
-        IdentId::get_id("respond_to?"),
-        src,
-        &[Value::symbol(IdentId::TO_A), Value::bool(true)],
-        None,
-        None,
-    ) {
-        Ok(v) => v.as_bool(),
-        Err(err) => {
-            vm.set_error(err);
-            return None;
+        globals.check_method(src, IdentId::TO_A).is_some()
+    } else {
+        match vm.invoke_method_inner(
+            globals,
+            IdentId::get_id("respond_to?"),
+            src,
+            &[Value::symbol(IdentId::TO_A), Value::bool(true)],
+            None,
+            None,
+        ) {
+            Ok(v) => v.as_bool(),
+            Err(err) => {
+                vm.set_error(err);
+                return None;
+            }
         }
     };
     if responds {

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -501,10 +501,11 @@ impl Store {
         compile_info: CompileInfo,
         loc: Loc,
         sourceinfo: SourceInfoRef,
+        is_singleton: bool,
     ) -> Result<FuncId> {
         let func_id = self.functions.next_func_id();
         self.functions.add_compile_info(compile_info);
-        let info = ISeqInfo::new_method(
+        let mut info = ISeqInfo::new_method(
             func_id,
             self.next_iseq_id(),
             name,
@@ -512,6 +513,7 @@ impl Store {
             loc,
             sourceinfo,
         );
+        info.singleton_classdef = is_singleton;
         let iseq = self.new_iseq(info);
         let info = FuncInfo::new_classdef_iseq(name, func_id, iseq);
         self.functions.info.push(info);

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -203,6 +203,13 @@ pub struct ISeqInfo {
     /// use — CRuby still warns).
     ///
     pub(crate) uses_block: bool,
+    ///
+    /// `true` when this iseq is a singleton-class body (`class << obj`).
+    /// A `return` written in such a body exits the *enclosing method*
+    /// (CRuby), so bytecodegen emits a method-return there — unlike a
+    /// plain class/module body, where `return` is invalid.
+    ///
+    pub(crate) singleton_classdef: bool,
 }
 
 impl std::fmt::Debug for ISeqInfo {
@@ -264,6 +271,7 @@ impl ISeqInfo {
             hint: ISeqHint::Normal,
             uses_block: false,
             nested_definee: None,
+            singleton_classdef: false,
         }
     }
 

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -153,6 +153,15 @@ fn main() {
                 // (`ruby: No such file or directory -- t.rb (LoadError)`).
                 // `io::Error`'s Display appends ` (os error N)`, which
                 // CRuby's strerror-based message doesn't have — strip it.
+                // A source that is not valid UTF-8 (e.g. UTF-16 with a
+                // BOM) is CRuby's `invalid multibyte char` SyntaxError,
+                // not an IO-level message.
+                if err.kind() == std::io::ErrorKind::InvalidData {
+                    eprintln!(
+                        "monoruby: {file_name}: invalid multibyte char (UTF-8) (SyntaxError)"
+                    );
+                    std::process::exit(1);
+                }
                 let msg = err.to_string();
                 let msg = msg.split(" (os error ").next().unwrap();
                 eprintln!("monoruby: {msg} -- {file_name} (LoadError)");

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -791,29 +791,31 @@ impl<'pr> Lowerer<'pr> {
                     &node.as_interpolated_regular_expression_node().unwrap(),
                 )?,
             prism::Node::MatchLastLineNode { .. } => {
-                // `if /pat/` (implicit match against `$_`) — ruruby
-                // doesn't have a dedicated node for this either; the
-                // regex literal is parsed the same way and the
-                // implicit match is recognised at bytecodegen.
+                // `if /pat/` — a regexp literal in a conditional matches
+                // the last read line implicitly. Desugar to
+                // `/pat/ =~ $_` (nil / position result gives the
+                // conditional its truthiness, and `$~` is set).
                 let n = node.as_match_last_line_node().unwrap();
                 let part = Node {
                     kind: regex_body_to_string(n.unescaped(), location_to_loc(&n.location()))?,
                     loc: location_to_loc(&n.location()),
                 };
                 let flags = regex_flags_from_closing(&n.closing_loc());
-                Node {
+                let regex = Node {
                     kind: NodeKind::RegExp(vec![part], flags, true),
                     loc,
-                }
+                };
+                match_last_line(regex, loc)
             }
             prism::Node::InterpolatedMatchLastLineNode { .. } => {
                 let n = node.as_interpolated_match_last_line_node().unwrap();
                 let parts = self.lower_interp_parts(n.parts())?;
                 let flags = regex_flags_from_closing(&n.closing_loc());
-                Node {
+                let regex = Node {
                     kind: NodeKind::RegExp(parts, flags, false),
                     loc,
-                }
+                };
+                match_last_line(regex, loc)
             }
             prism::Node::MatchWriteNode { .. } => {
                 // `/(?<name>...)/ =~ value` — Prism wraps the `=~`
@@ -4429,6 +4431,28 @@ fn regex_flags_from_closing(closing: &Location<'_>) -> String {
         .filter(|b| matches!(b, b'i' | b'm' | b'x' | b'n' | b'u' | b'e' | b's'))
         .map(|b| b as char)
         .collect()
+}
+
+/// Wrap a regexp-literal node as `<regex> =~ $_` — the implicit
+/// last-read-line match a bare regexp literal performs in a conditional
+/// (prism's `MatchLastLineNode` / `InterpolatedMatchLastLineNode`).
+fn match_last_line(regex: Node, loc: crate::ast::Loc) -> Node {
+    let lastline = Node {
+        kind: NodeKind::GlobalVar("$_".to_string()),
+        loc,
+    };
+    Node {
+        kind: NodeKind::MethodCall {
+            receiver: Box::new(regex),
+            method: "=~".to_owned(),
+            arglist: Box::new(crate::ast::ArgList {
+                args: vec![lastline],
+                ..Default::default()
+            }),
+            safe_nav: false,
+        },
+        loc,
+    }
 }
 
 fn binop_from_name(name: &str) -> Option<BinOp> {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -334,6 +334,7 @@ fn try_prism_inner(
             let msg = w.message();
             let verbose_only = if msg == "END in method; use at_exit"
                 || msg == "integer literal in flip-flop"
+                || msg == "regex literal in condition"
             {
                 false
             } else if msg == "possibly useless use of defined? in void context"

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -1,0 +1,100 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn bare_regexp_in_conditional_matches_lastline() {
+    // A regexp literal in a conditional matches `$_` implicitly
+    // (prism's MatchLastLineNode), setting `$~` — including the
+    // interpolated form.
+    run_test_once(
+        r#"
+        $_ = "hello"
+        res = []
+        res << (/ell/ ? :match : :nomatch)
+        res << (/xyz/ ? :match : :nomatch)
+        x = "ll"
+        res << (/he#{x}/ ? :match : :nomatch)
+        res << $~[0]
+        res
+        "#,
+    );
+}
+
+#[test]
+fn splat_calls_to_a_on_basic_object() {
+    // The splat coercion falls back to a raw `to_a` lookup when the
+    // object has no `respond_to?` (a bare BasicObject) — CRuby's
+    // rb_check_funcall still calls it. Objects without `to_a` wrap.
+    run_test_once(
+        r#"
+        splat = BasicObject.new
+        def splat.to_a; [2, 3, 4]; end
+        a = [1, *splat]
+        o = Object.new
+        [a.size, a[1], a[3], [9, *o].size, [*nil]]
+        "#,
+    );
+}
+
+#[test]
+fn sclass_return_exits_enclosing_method() {
+    // `return` in a singleton-class body returns from the method
+    // executing the sclass expression (CRuby), including through a
+    // block, and still runs the sclass path when no return triggers.
+    run_test_once(
+        r#"
+        def m1
+          obj = Object.new
+          class << obj
+            return :inner
+          end
+          :outer
+        end
+        def m2(flag)
+          obj = Object.new
+          class << obj
+            return :early if flag
+          end
+          :late
+        end
+        [m1, m2(true), m2(false)]
+        "#,
+    );
+}
+
+#[test]
+fn redo_runs_pending_ensures() {
+    // `redo` exits the begin/ensure regions it is written inside —
+    // their ensure bodies run before the body restarts, both in a
+    // block (no local loop) and in a `while` loop.
+    run_test_once(
+        r#"
+        r = []
+        c = {}
+        [1, 2, 3].each do |i|
+          begin
+            r << i * 10
+            redo if c[i].nil? && i == 1 && (c[i] = true)
+          ensure
+            r << i * 100
+          end
+        end
+        w = []
+        done = false
+        i = 0
+        while i < 2
+          i += 1
+          begin
+            w << i
+            unless done
+              done = true
+              redo
+            end
+          ensure
+            w << -i
+          end
+        end
+        [r, w]
+        "#,
+    );
+}

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -50,14 +50,19 @@ fn sclass_return_exits_enclosing_method() {
           end
           :outer
         end
-        def m2(flag)
+        def m2
           obj = Object.new
+          # A class body opens a fresh local scope, so gate on a global.
           class << obj
-            return :early if flag
+            return :early if $sclass_flag
           end
           :late
         end
-        [m1, m2(true), m2(false)]
+        $sclass_flag = true
+        a = m2
+        $sclass_flag = false
+        b = m2
+        [m1, a, b]
         "#,
     );
 }


### PR DESCRIPTION
## Summary

Iteration 15 of the ruby/spec language-category fix loop — a batch of single-spec fixes. Language failures: **36 → 30** (array, class, redo, regexp, source_encoding ×2 all green).

### Fixes

1. **Bare regexp literal in a conditional matches `$_`** — prism's `MatchLastLineNode` / `InterpolatedMatchLastLineNode` now desugar to `/re/ =~ $_` (previously the regexp literal evaluated as an always-truthy object), and prism's `regex literal in condition` warning is forwarded with CRuby's wording.

2. **Splat coerces a `BasicObject` via `to_a`** — the splat runtime falls back to a raw `to_a` method lookup when the object has no `respond_to?`, matching CRuby's `rb_check_funcall`; objects without `to_a` still wrap in a one-element array.

3. **`return` in a singleton-class body exits the enclosing method** — bytecodegen emits a method-return in `class << obj` bodies (new `ISeqInfo::singleton_classdef` flag; plain class/module bodies are unchanged), and `err_method_return` resolves the unwind target through the dynamic caller chain past class bodies and native trampolines.

4. **`redo` runs the `ensure` bodies of the regions it exits** — both the block-level `redo` (restarting the whole block body) and the loop-level `redo` now emit pending ensure bodies (with the `$!` restore protocol) before jumping back; the block case shares a new `gen_all_pending_ensures` helper with `emit_ret`.

5. **Invalid-UTF-8 main script reports CRuby's message** — `monoruby: <file>: invalid multibyte char (UTF-8) (SyntaxError)` instead of the raw `io::Error` text (fixes both UTF-16-BOM source_encoding specs).

### Tests

- 4 new integration tests in `monoruby/tests/language_fixes.rs` (regexp-in-conditional incl. interpolated form, BasicObject splat, sclass return incl. conditional/no-return paths, redo+ensure in block and while loop).
- Full `cargo test` green locally.

Minor coverage drops on fallback branches can be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_