### PR TITLE
Restore $! when a non-local exit leaves a rescue clause

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -371,6 +371,14 @@ struct ExceptionEntry {
     rescue: Option<Label>,
     ensure: Option<Label>,
     err_reg: Option<BcReg>,
+    /// The code range of this region's rescue clauses (matching code +
+    /// clause bodies). A non-local exit (`return` from a block /
+    /// `break`) whose frame is suspended inside this range must restore
+    /// `$!` from `errinfo_save` at runtime — the bytecodegen inline
+    /// restore only covers local exits.
+    rescue_range: Option<std::ops::Range<Label>>,
+    /// The hidden local holding `$!` as of region entry.
+    errinfo_save: Option<BcReg>,
 }
 
 ///

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -77,7 +77,9 @@ impl<'a> BytecodeGen<'a> {
                                 rescue: Some(nil_label),
                                 ensure: None,
                                 err_reg: None,
-                            });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                         } else {
                             self.check_defined(b, nil_label, ret, false)?;
                         }
@@ -133,7 +135,9 @@ impl<'a> BytecodeGen<'a> {
                         rescue: Some(nil_label),
                         ensure: None,
                         err_reg: None,
-                    });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                     // `ret` already holds "method"; the operator method
                     // (`!`, `-@`, …) is defined on every object, so there is
                     // nothing more to check.
@@ -189,7 +193,9 @@ impl<'a> BytecodeGen<'a> {
                         rescue: Some(nil_label),
                         ensure: None,
                         err_reg: None,
-                    });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                 } else {
                     self.check_defined(l, nil_label, ret, false)?;
                 }
@@ -245,7 +251,9 @@ impl<'a> BytecodeGen<'a> {
                         rescue: Some(nil_label),
                         ensure: None,
                         err_reg: None,
-                    });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                 } else {
                     self.check_defined(r, nil_label, ret, false)?;
                 }
@@ -282,7 +290,9 @@ impl<'a> BytecodeGen<'a> {
                         rescue: Some(nil_label),
                         ensure: None,
                         err_reg: None,
-                    });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                 } else {
                     self.check_defined(b, nil_label, ret, false)?;
                 }
@@ -313,7 +323,9 @@ impl<'a> BytecodeGen<'a> {
                         rescue: Some(nil_label),
                         ensure: None,
                         err_reg: None,
-                    });
+                rescue_range: None,
+                errinfo_save: None,
+            });
                     Some(base)
                 } else {
                     None

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -67,6 +67,8 @@ impl<'a> BytecodeGen<'a> {
             rescue,
             ensure,
             err_reg,
+            rescue_range,
+            errinfo_save,
         } in std::mem::take(&mut self.exception_table)
         {
             if rescue.is_none() && ensure.is_none() {
@@ -77,8 +79,10 @@ impl<'a> BytecodeGen<'a> {
             let rescue = rescue.map(|l| self[l]);
             let ensure = ensure.map(|l| self[l]);
             let err_reg = err_reg.map(|reg| self.slot_id(&reg));
+            let rescue_range = rescue_range.map(|r| self[r.start]..self[r.end]);
+            let errinfo_save = errinfo_save.map(|reg| self.slot_id(&reg));
             self.iseq_mut()
-                .exception_push(start..end, rescue, ensure, err_reg);
+                .exception_push(start..end, rescue, ensure, err_reg, rescue_range, errinfo_save);
         }
 
         let sp: Vec<_> = std::mem::take(&mut self.sp)

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -635,6 +635,12 @@ impl<'a> BytecodeGen<'a> {
                     None
                 },
                 err_reg: Some(err_reg),
+                // A frame suspended anywhere in the rescue-clause span
+                // (matching code + clause bodies) has `$!` set to the
+                // caught exception; a non-local exit passing through
+                // must restore it from the region-entry save.
+                rescue_range: Some(rescue_pos..no_match_pos),
+                errinfo_save,
             });
             // An exception (or `return` / `throw`) raised while matching a
             // rescue clause or running a matched clause's body must still run
@@ -648,6 +654,8 @@ impl<'a> BytecodeGen<'a> {
                     rescue: Some(no_match_pos),
                     ensure: Some(ensure_label),
                     err_reg: Some(err_reg),
+                    rescue_range: None,
+                    errinfo_save: None,
                 });
             }
         } else {
@@ -680,6 +688,8 @@ impl<'a> BytecodeGen<'a> {
                     rescue: Some(rescue_pos),
                     ensure: Some(ensure_label),
                     err_reg: Some(err_reg),
+                    rescue_range: None,
+                    errinfo_save: None,
                 });
             } else {
                 self.exception_table.push(ExceptionEntry {
@@ -687,6 +697,8 @@ impl<'a> BytecodeGen<'a> {
                     rescue: None,
                     ensure: None,
                     err_reg: None,
+                    rescue_range: None,
+                    errinfo_save: None,
                 });
             }
         }

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -65,6 +65,23 @@ impl ErrorReturn {
     }
 }
 
+/// Restore `$!` from the region-entry saves of every rescue clause the
+/// suspended *pc* sits inside (innermost first; the outermost save
+/// wins) — used when a non-local exit (`return` from a block, `break`)
+/// leaves a frame whose execution stopped inside a rescue clause.
+fn restore_errinfo_on_exit(
+    vm: &mut Executor,
+    info: &crate::globals::ISeqInfo,
+    pc: crate::bytecodegen::BcIndex,
+    lfp: Lfp,
+) {
+    for slot in info.errinfo_restore_slots(pc) {
+        if let Some(v) = lfp.register(slot) {
+            vm.set_errinfo(v);
+        }
+    }
+}
+
 pub(super) extern "C" fn handle_error(
     vm: &mut Executor,
     globals: &mut Globals,
@@ -103,6 +120,13 @@ pub(super) extern "C" fn handle_error(
                 _ => None,
             };
             if let Some((val, target_lfp)) = method_return {
+                // Leaving a frame suspended inside a rescue clause
+                // (whether passing through or returning from it)
+                // restores `$!` to the region-entry save — the inline
+                // bytecodegen restore only covers local exits. Not
+                // needed on the error path: a propagating exception
+                // overwrites `$!` wherever it is caught.
+                restore_errinfo_on_exit(vm, info, pc, lfp);
                 return if let Some((_, Some(ensure), _)) = info.get_exception_dest(pc) {
                     // Suspend the non-local return across the ensure body so
                     // the body can `raise` (set_error) without tripping the
@@ -156,6 +180,11 @@ pub(super) extern "C" fn handle_error(
                 if lfp != outer {
                     // An intermediate frame: run its ensure body (the
                     // break passes through it), then keep unwinding.
+                    // Same `$!` restore as the MethodReturn path — but
+                    // only for frames being *exited*; the defining
+                    // frame below resumes inside its rescue clause and
+                    // must keep the caught exception in `$!`.
+                    restore_errinfo_on_exit(vm, info, pc, lfp);
                     if let Some((_, Some(ensure), _)) = info.get_exception_dest(pc) {
                         vm.defer_unwind(lfp);
                         return ErrorReturn::goto(bc_base + ensure);

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -12,6 +12,12 @@ struct ExceptionMapEntry {
     rescue_pc: Option<BcIndex>,      // rescue destination pc
     ensure_pc: Option<BcIndex>,      // ensure destination pc
     error_slot: Option<SlotId>,      // a slot where an error object is assigned
+    // The region's rescue-clause span (matching code + clause bodies).
+    // A frame suspended in it has `$!` set to the caught exception; a
+    // non-local exit (block `return` / `break`) unwinding this frame
+    // restores `$!` from `errinfo_slot` (the region-entry save).
+    rescue_range: Option<std::ops::Range<BcIndex>>,
+    errinfo_slot: Option<SlotId>,
 }
 
 impl ExceptionMapEntry {
@@ -20,12 +26,16 @@ impl ExceptionMapEntry {
         rescue_pc: Option<BcIndex>,
         ensure_pc: Option<BcIndex>,
         error_slot: Option<SlotId>,
+        rescue_range: Option<std::ops::Range<BcIndex>>,
+        errinfo_slot: Option<SlotId>,
     ) -> Self {
         ExceptionMapEntry {
             range,
             rescue_pc,
             ensure_pc,
             error_slot,
+            rescue_range,
+            errinfo_slot,
         }
     }
 }
@@ -491,9 +501,34 @@ impl ISeqInfo {
         rescue: Option<BcIndex>,
         ensure: Option<BcIndex>,
         err_reg: Option<SlotId>,
+        rescue_range: Option<std::ops::Range<BcIndex>>,
+        errinfo_slot: Option<SlotId>,
     ) {
+        self.exception_map.push(ExceptionMapEntry::new(
+            range,
+            rescue,
+            ensure,
+            err_reg,
+            rescue_range,
+            errinfo_slot,
+        ));
+    }
+
+    /// `$!` save slots of every rescue-clause span covering *pc*,
+    /// innermost first (entries are pushed inner regions first).
+    /// A non-local exit unwinding a frame suspended at *pc* restores
+    /// them in order — the last (outermost) save wins.
+    pub(crate) fn errinfo_restore_slots(&self, pc: BcIndex) -> Vec<SlotId> {
         self.exception_map
-            .push(ExceptionMapEntry::new(range, rescue, ensure, err_reg));
+            .iter()
+            .filter_map(|e| {
+                if e.rescue_range.as_ref().is_some_and(|r| r.contains(&pc)) {
+                    e.errinfo_slot
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     pub(crate) fn has_exception_handler(&self) -> bool {

--- a/monoruby/tests/predefined_gvar.rs
+++ b/monoruby/tests/predefined_gvar.rs
@@ -438,3 +438,64 @@ fn set_backtrace_accepts_locations() {
         "#,
     );
 }
+
+#[test]
+fn errinfo_cleared_on_non_local_return() {
+    // A non-local exit (`return` from a block, `break`) leaving a
+    // frame suspended inside a rescue clause restores `$!` to the
+    // region-entry save at runtime; a `break` that *resumes* inside
+    // the rescue clause keeps the caught exception in `$!`.
+    run_test_once(
+        r#"
+        res = []
+        obj = Class.new do
+          def method_missing(*args)
+            yield
+          end
+          def bar
+            e = StandardError.new 'foo'
+            begin
+              raise e
+            rescue
+              foo(e) { return }
+            end
+          end
+        end.new
+        obj.bar
+        res << $!
+        def foo2
+          [1].each do
+            begin
+              raise StandardError.new('err')
+            rescue => e
+              return
+            end
+          end
+        end
+        foo2
+        res << $!
+        def brk
+          [1].each do
+            begin
+              raise "b"
+            rescue
+              break
+            end
+          end
+        end
+        brk
+        res << $!
+        def keep
+          begin
+            raise "k"
+          rescue
+            [1].each { break }
+            return $!.message
+          end
+        end
+        res << keep
+        res << $!
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

Iteration 19 of the ruby/spec language-category fix loop. Language failures: **24 → 22** (`predefined_spec` 5 → 3 — both "$! should be cleared when an exception is rescued even when a non-local return" specs green).

### Fix

The bytecodegen inline `$!` restore only covers *local* exits from a rescue clause. A `return` written in a block (or a `break`) unwinds through the runtime unwinder, so `$!` was left holding the rescued exception after the enclosing method returned.

- **Exception map** — each begin region now records its rescue-clause span (matching code + clause bodies) and the region-entry `$!` save slot (`ExceptionMapEntry::{rescue_range, errinfo_slot}`; the save slot register is already maintained by the existing bytecodegen protocol).
- **Runtime restore** — `handle_error` restores `$!` from those saves (innermost to outermost, so the outermost entry value wins) whenever a `MethodReturn` passes through or stops at a frame suspended inside a rescue clause, and when a `BlockBreak` exits an intermediate frame.
- **Break-resume untouched** — a `break` whose defining frame resumes *inside* the rescue clause (the caught call site) keeps the caught exception in `$!`, matching CRuby.

### Tests

- New integration test `errinfo_cleared_on_non_local_return` (method_missing + block return, direct block return, break through rescue, break-resume keeping `$!`).
- Full `cargo test` green locally.

Minor coverage drops on fallback branches can be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_