### PR TITLE
Constant lookup recovers the runtime cref in singleton-class bodies

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -792,6 +792,22 @@ impl<'a> BytecodeGen<'a> {
         self.is_escaping_block() || self.singleton_classdef
     }
 
+    /// The lexical chain of the iseq currently being compiled passes
+    /// through a `class << obj` body. Propagated onto every nested
+    /// def/classdef/block so runtime constant lookup knows when the
+    /// statically stamped cref can be stale.
+    fn in_singleton_lexical(&self) -> bool {
+        self.singleton_classdef || self.iseq().in_singleton_lexical
+    }
+
+    fn propagate_singleton_lexical(&mut self, fid: FuncId) {
+        if self.in_singleton_lexical() {
+            if let Some(iseq) = self.store[fid].is_iseq() {
+                self.store[iseq].in_singleton_lexical = true;
+            }
+        }
+    }
+
     fn add_method(
         &mut self,
         name: Option<IdentId>,
@@ -799,8 +815,11 @@ impl<'a> BytecodeGen<'a> {
         loc: Loc,
     ) -> Result<FuncId> {
         let sourceinfo = self.sourceinfo.clone();
-        self.store
-            .new_iseq_method(name, compile_info, loc, sourceinfo, false)
+        let fid = self
+            .store
+            .new_iseq_method(name, compile_info, loc, sourceinfo, false)?;
+        self.propagate_singleton_lexical(fid);
+        Ok(fid)
     }
 
     fn add_classdef(
@@ -811,20 +830,29 @@ impl<'a> BytecodeGen<'a> {
         is_singleton: bool,
     ) -> Result<FuncId> {
         let sourceinfo = self.sourceinfo.clone();
-        self.store
-            .new_classdef(name, compile_info, loc, sourceinfo, is_singleton)
+        let fid = self
+            .store
+            .new_classdef(name, compile_info, loc, sourceinfo, is_singleton)?;
+        self.propagate_singleton_lexical(fid);
+        Ok(fid)
     }
 
     fn add_block(&mut self, outer: ISeqId, compile_info: CompileInfo, loc: Loc) -> Result<FuncId> {
         let sourceinfo = self.sourceinfo.clone();
-        self.store
-            .new_block(outer, compile_info, true, loc, sourceinfo)
+        let fid = self
+            .store
+            .new_block(outer, compile_info, true, loc, sourceinfo)?;
+        self.propagate_singleton_lexical(fid);
+        Ok(fid)
     }
 
     fn add_lambda(&mut self, outer: ISeqId, compile_info: CompileInfo, loc: Loc) -> Result<FuncId> {
         let sourceinfo = self.sourceinfo.clone();
-        self.store
-            .new_block(outer, compile_info, false, loc, sourceinfo)
+        let fid = self
+            .store
+            .new_block(outer, compile_info, false, loc, sourceinfo)?;
+        self.propagate_singleton_lexical(fid);
+        Ok(fid)
     }
 
     fn loop_push(

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -78,6 +78,14 @@ impl<'a> JitContext<'a> {
             if cache.version as u64 != self.const_version() {
                 return Ok(CompileResult::Recompile(RecompileReason::NotCached));
             }
+            // A self-dependent resolution (singleton-cref frame) is only
+            // foldable when this compilation's self class matches — the
+            // dispatch guard then pins it at runtime.
+            if let Some(sc) = cache.self_class {
+                if sc != self.self_class() {
+                    return Ok(CompileResult::Recompile(RecompileReason::NotCached));
+                }
+            }
             let base_slot = self.store[id].base;
             if let Some(slot) = base_slot {
                 if let Some(base_class) = cache.base_class {

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -81,9 +81,22 @@ impl<'a> JitContext<'a> {
             // A self-dependent resolution (singleton-cref frame) is only
             // foldable when this compilation's self class matches — the
             // dispatch guard then pins it at runtime.
-            if let Some(sc) = cache.self_class {
-                if sc != self.self_class() {
-                    return Ok(CompileResult::Recompile(RecompileReason::NotCached));
+            match cache.self_class {
+                Some(sc) => {
+                    if sc != self.store.const_self_key_for_class(self.self_class()) {
+                        return Ok(CompileResult::Recompile(RecompileReason::NotCached));
+                    }
+                }
+                None => {
+                    // Constant sites in singleton-lexical methods are
+                    // always filled with a Some key (resolution there is
+                    // self-class dependent), so a None entry can only
+                    // predate this receiver's resolution — let the VM
+                    // re-resolve rather than fold a value whose validity
+                    // rests on a re-stampable static cref.
+                    if self.iseq().in_singleton_lexical {
+                        return Ok(CompileResult::Recompile(RecompileReason::NotCached));
+                    }
                 }
             }
             let base_slot = self.store[id].base;

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -863,11 +863,15 @@ pub(crate) extern "C" fn vm_check_constant(
     site_id: ConstSiteId,
     const_version: usize,
 ) -> Option<Value> {
+    let self_key = const_self_key(vm, globals);
     if let Some(cache) = &globals.store[site_id].cache {
         let base_class = globals.store[site_id]
             .base
             .map(|base| unsafe { vm.get_slot(base) }.unwrap());
-        if cache.version == const_version && cache.base_class == base_class {
+        if cache.version == const_version
+            && cache.base_class == base_class
+            && cache.self_class == self_key
+        {
             return Some(cache.value);
         };
     }
@@ -878,6 +882,7 @@ pub(crate) extern "C" fn vm_check_constant(
             globals.store[site_id].cache = Some(ConstCache {
                 version: const_version,
                 base_class,
+                self_class: self_key,
                 value,
             });
             Some(value)
@@ -886,17 +891,27 @@ pub(crate) extern "C" fn vm_check_constant(
     }
 }
 
+/// The self-dependence key for the constant cache — see
+/// `Executor::const_lexical_self_key`.
+fn const_self_key(vm: &Executor, globals: &Globals) -> Option<ClassId> {
+    vm.const_lexical_self_key(globals, vm.method_func_id())
+}
+
 pub(crate) extern "C" fn vm_get_constant(
     vm: &mut Executor,
     globals: &mut Globals,
     site_id: ConstSiteId,
     const_version: usize,
 ) -> Option<Value> {
+    let self_key = const_self_key(vm, globals);
     if let Some(cache) = &globals.store[site_id].cache {
         let base_class = globals.store[site_id]
             .base
             .map(|base| unsafe { vm.get_slot(base) }.unwrap());
-        if cache.version == const_version && cache.base_class == base_class {
+        if cache.version == const_version
+            && cache.base_class == base_class
+            && cache.self_class == self_key
+        {
             return Some(cache.value);
         };
     }
@@ -905,6 +920,7 @@ pub(crate) extern "C" fn vm_get_constant(
             globals.store[site_id].cache = Some(ConstCache {
                 version: const_version,
                 base_class,
+                self_class: self_key,
                 value,
             });
             Some(value)

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -355,6 +355,8 @@ impl Executor {
         } else {
             current_func.lexical_class(globals)
         };
+        // Ancestor-phase lookup starts at the *runtime* cref too.
+        let lexical_class = self.runtime_innermost_cref(globals, lexical_class, current_func);
         let module = globals[lexical_class].get_module();
         match self.get_constant_superclass(globals, module, name)? {
             Some(v) => return Ok(Some(v)),
@@ -482,7 +484,14 @@ impl Executor {
             Some(iseq) => iseq,
             None => return false,
         };
+        let mut first = true;
         for module in globals.store[iseq].lexical_context.iter().rev().copied() {
+            let module = if first {
+                first = false;
+                self.runtime_innermost_cref(globals, module, current_func)
+            } else {
+                module
+            };
             if Self::probe_constant_at(globals, module, name) {
                 return true;
             }
@@ -585,6 +594,100 @@ impl Executor {
         Self::probe_constant_superclass_qualified(globals, globals.store[parent].get_module(), name)
     }
 
+    /// Recover the *runtime* innermost cref when the statically stamped
+    /// one is stale. A `def` inside a re-executed class body (most
+    /// notably inside `class << obj`, or a `class X` nested in one)
+    /// shares its iseq across executions while `enter_classdef`
+    /// re-stamps the static `lexical_context` per execution (last write
+    /// wins) — so the recorded innermost class may belong to a
+    /// *different* execution. Detection: the stamped class is no longer
+    /// on the receiver's ancestor chain. Recovery: the runtime cref is
+    /// the ancestor that owns the executing method (for a plain `def`
+    /// in a class body, the innermost cref IS the defining class).
+    pub(crate) fn runtime_innermost_cref(
+        &self,
+        globals: &Globals,
+        statically: ClassId,
+        current_func: FuncId,
+    ) -> ClassId {
+        // Staleness is only possible when the def is lexically nested
+        // (at any depth) inside a `class << obj` body — every other
+        // classdef form re-opens the same class on re-execution, so
+        // the stamp cannot go stale. Never substitute otherwise: a
+        // singleton def (`def a.meth`) legitimately has a cref that is
+        // unrelated to the receiver's ancestry.
+        if !globals.store[current_func]
+            .is_iseq()
+            .is_some_and(|iseq| globals.store[iseq].in_singleton_lexical)
+        {
+            return statically;
+        }
+        let self_val = self.cfp().lfp().self_val();
+        if Self::static_cref_plausible(globals, self_val, statically) {
+            return statically;
+        }
+        let self_class = self_val.class();
+        let mut module = Some(globals.store[self_class].get_module());
+        while let Some(m) = module {
+            if globals.store.class_owns_func(m.id(), current_func) {
+                return m.id();
+            }
+            module = m.superclass();
+        }
+        statically
+    }
+
+    /// Is `statically` a plausible innermost cref for this receiver?
+    /// True when it lies on the receiver's class ancestry (a plain
+    /// `def` in a class body), or — for a class/module receiver — on
+    /// the receiver's *own* ancestry: a singleton method (`def M.f`,
+    /// `class << self` inside `module M`) runs with self == M while
+    /// its cref is M or an enclosing module, neither of which appears
+    /// among the metaclass's ancestors.
+    fn static_cref_plausible(globals: &Globals, self_val: Value, statically: ClassId) -> bool {
+        if Self::class_in_ancestors(globals, self_val.class(), statically) {
+            return true;
+        }
+        if let Some(m) = self_val.is_class_or_module() {
+            if Self::class_in_ancestors(globals, m.id(), statically) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn class_in_ancestors(globals: &Globals, start: ClassId, target: ClassId) -> bool {
+        let mut module = Some(globals.store[start].get_module());
+        while let Some(m) = module {
+            if m.id() == target {
+                return true;
+            }
+            module = m.superclass();
+        }
+        false
+    }
+
+    /// The self-dependence key for the constant cache: `Some(self's
+    /// class)` when [`Self::runtime_innermost_cref`] would substitute —
+    /// the cached result is then only valid for the same self class.
+    pub(crate) fn const_lexical_self_key(
+        &self,
+        globals: &Globals,
+        current_func: FuncId,
+    ) -> Option<ClassId> {
+        let iseq = globals.store[current_func].is_iseq()?;
+        if !globals.store[iseq].in_singleton_lexical {
+            return None;
+        }
+        let statically = *globals.store[iseq].lexical_context.last()?;
+        let self_val = self.cfp().lfp().self_val();
+        if Self::static_cref_plausible(globals, self_val, statically) {
+            None
+        } else {
+            Some(self_val.class())
+        }
+    }
+
     fn search_lexical_stack(
         &mut self,
         globals: &mut Globals,
@@ -602,12 +705,15 @@ impl Executor {
             Some(iseq) => iseq,
             None => return Ok(None),
         };
-        let stack = globals.store[iseq]
+        let mut stack = globals.store[iseq]
             .lexical_context
             .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>();
+        if let Some(first) = stack.first_mut() {
+            *first = self.runtime_innermost_cref(globals, *first, current_func);
+        }
         for module in stack {
             if globals.store.get_constant(module, name).is_some() {
                 // Trigger autoload / read the value. If the autoload

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -630,6 +630,21 @@ impl Executor {
         let mut module = Some(globals.store[self_class].get_module());
         while let Some(m) = module {
             if globals.store.class_owns_func(m.id(), current_func) {
+                // For a plain `def` the owner IS the cref. For a
+                // singleton def (`def self.f` in a class body nested
+                // under `class << obj`) the owner is the metaclass
+                // while the cref is the attached class itself — the
+                // stamped entry being a non-singleton class tells the
+                // two forms apart.
+                if globals.store[statically].get_module().is_singleton().is_none() {
+                    if let Some(attached) = globals.store[m.id()]
+                        .get_module()
+                        .is_singleton()
+                        .and_then(|v| v.is_class_or_module())
+                    {
+                        return attached.id();
+                    }
+                }
                 return m.id();
             }
             module = m.superclass();
@@ -645,31 +660,33 @@ impl Executor {
     /// its cref is M or an enclosing module, neither of which appears
     /// among the metaclass's ancestors.
     fn static_cref_plausible(globals: &Globals, self_val: Value, statically: ClassId) -> bool {
-        if Self::class_in_ancestors(globals, self_val.class(), statically) {
+        if globals
+            .store
+            .static_cref_plausible_for_class(self_val.class(), statically)
+        {
             return true;
         }
+        // Checked directly on the value as well: a class/module
+        // receiver whose metaclass has not been materialized has a
+        // plain class (`Class`/`Module`) that carries no attachment.
         if let Some(m) = self_val.is_class_or_module() {
-            if Self::class_in_ancestors(globals, m.id(), statically) {
+            if globals.store.class_in_ancestors(m.id(), statically) {
                 return true;
             }
-        }
-        false
-    }
-
-    fn class_in_ancestors(globals: &Globals, start: ClassId, target: ClassId) -> bool {
-        let mut module = Some(globals.store[start].get_module());
-        while let Some(m) = module {
-            if m.id() == target {
-                return true;
-            }
-            module = m.superclass();
         }
         false
     }
 
     /// The self-dependence key for the constant cache: `Some(self's
-    /// class)` when [`Self::runtime_innermost_cref`] would substitute —
-    /// the cached result is then only valid for the same self class.
+    /// class)` for any method lexically nested under `class << obj`.
+    /// Resolution there goes through [`Self::runtime_innermost_cref`],
+    /// which depends only on self's class, so the cached result is
+    /// valid exactly for the same self class. The key must NOT be
+    /// weakened to `None` when the static stamp happens to be
+    /// plausible for the current receiver: plausibility is relative
+    /// to the *current* stamp, and a later re-execution of the
+    /// `class << obj` body re-stamps it, silently invalidating what a
+    /// `None`-keyed entry resolved against.
     pub(crate) fn const_lexical_self_key(
         &self,
         globals: &Globals,
@@ -679,13 +696,15 @@ impl Executor {
         if !globals.store[iseq].in_singleton_lexical {
             return None;
         }
-        let statically = *globals.store[iseq].lexical_context.last()?;
+        // For a class/module receiver (a classdef body, or `def
+        // self.f`), key by the module's own id: its metaclass may be
+        // unmaterialized, in which case `.class()` is the shared
+        // `Class`/`Module` and would alias distinct receivers.
         let self_val = self.cfp().lfp().self_val();
-        if Self::static_cref_plausible(globals, self_val, statically) {
-            None
-        } else {
-            Some(self_val.class())
-        }
+        Some(match self_val.is_class_or_module() {
+            Some(m) => m.id(),
+            None => self_val.class(),
+        })
     }
 
     fn search_lexical_stack(

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1383,6 +1383,12 @@ impl ClassInfoTable {
 pub struct ConstCache {
     pub version: usize,
     pub base_class: Option<Value>,
+    /// `Some` when the resolution depended on the receiver (the frame's
+    /// `self` had a singleton class — a `def` in a `class << obj` body
+    /// resolves constants against the *runtime* singleton cref, see
+    /// `Executor::substitute_singleton_cref`). The cache only hits for
+    /// the same self class.
+    pub self_class: Option<ClassId>,
     pub value: Value,
 }
 

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -514,6 +514,11 @@ impl Store {
             sourceinfo,
         );
         info.singleton_classdef = is_singleton;
+        // The body itself resolves constants through a per-execution
+        // singleton class, so it needs the self-keyed constant cache
+        // just like defs nested inside it (bytecodegen additionally
+        // propagates the flag onto those).
+        info.in_singleton_lexical = is_singleton;
         let iseq = self.new_iseq(info);
         let info = FuncInfo::new_classdef_iseq(name, func_id, iseq);
         self.functions.info.push(info);

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -863,6 +863,17 @@ impl ClassInfoTable {
     ///
     /// If not exists, create a new singleton class.
     ///
+
+    /// Whether *class_id*'s own method table contains an entry bound to
+    /// *fid* (under any name). Used to recover the runtime cref of a
+    /// method whose static lexical stamp went stale.
+    pub(crate) fn class_owns_func(&self, class_id: ClassId, fid: FuncId) -> bool {
+        self[class_id]
+            .methods
+            .values()
+            .any(|e| e.func_id() == Some(fid))
+    }
+
     pub(crate) fn has_singleton(&self, obj: Value) -> Option<Module> {
         let org_class = self[obj.class()].get_module();
         if org_class.is_singleton().is_some() {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -874,6 +874,65 @@ impl ClassInfoTable {
             .any(|e| e.func_id() == Some(fid))
     }
 
+    /// Is `target` on the superclass chain of `start` (including
+    /// `start` itself)?
+    pub(crate) fn class_in_ancestors(&self, start: ClassId, target: ClassId) -> bool {
+        let mut module = Some(self[start].get_module());
+        while let Some(m) = module {
+            if m.id() == target {
+                return true;
+            }
+            module = m.superclass();
+        }
+        false
+    }
+
+    /// The JIT-side counterpart of `Executor::const_lexical_self_key`'s
+    /// key computation: the VM keys a class/module receiver by the
+    /// module's own id, and such a receiver reaches the JIT as its
+    /// singleton class — map it back through the attachment. Any
+    /// other class keys as itself.
+    pub(crate) fn const_self_key_for_class(&self, self_class: ClassId) -> ClassId {
+        match self[self_class]
+            .get_module()
+            .is_singleton()
+            .and_then(|v| v.is_class_or_module())
+        {
+            Some(attached) => attached.id(),
+            None => self_class,
+        }
+    }
+
+    /// Class-keyed variant of the runtime-cref plausibility check:
+    /// the statically stamped innermost cref is plausible for a
+    /// receiver of class `self_class` when it lies on that class's
+    /// ancestry, or — when `self_class` is the singleton class of a
+    /// class/module — on the attached module's own ancestry (a
+    /// singleton method runs with self == the module while its cref
+    /// is the module or an enclosing scope). Receivers that find the
+    /// stamp plausible all resolve constants identically, so the JIT
+    /// may fold a cache entry filled through the static cref exactly
+    /// when this holds for the compiled self class.
+    pub(crate) fn static_cref_plausible_for_class(
+        &self,
+        self_class: ClassId,
+        statically: ClassId,
+    ) -> bool {
+        if self.class_in_ancestors(self_class, statically) {
+            return true;
+        }
+        if let Some(attached) = self[self_class]
+            .get_module()
+            .is_singleton()
+            .and_then(|v| v.is_class_or_module())
+        {
+            if self.class_in_ancestors(attached.id(), statically) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn has_singleton(&self, obj: Value) -> Option<Module> {
         let org_class = self[obj.class()].get_module();
         if org_class.is_singleton().is_some() {

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -220,6 +220,16 @@ pub struct ISeqInfo {
     /// plain class/module body, where `return` is invalid.
     ///
     pub(crate) singleton_classdef: bool,
+    ///
+    /// `true` when this iseq's *lexical* chain passes through a
+    /// singleton-class body (`class << obj`) — the iseq itself, or a
+    /// def/classdef/block nested (at any depth) inside one. Only such
+    /// code can observe a stale statically-stamped `lexical_context`
+    /// (each execution of `class << obj` yields a distinct class while
+    /// the shared iseq's stamp is last-write-wins), so the runtime
+    /// cref recovery in constant lookup is gated on this flag.
+    ///
+    pub(crate) in_singleton_lexical: bool,
 }
 
 impl std::fmt::Debug for ISeqInfo {
@@ -282,6 +292,7 @@ impl ISeqInfo {
             uses_block: false,
             nested_definee: None,
             singleton_classdef: false,
+            in_singleton_lexical: false,
         }
     }
 

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -249,6 +249,64 @@ fn interpolation_and_eval_source_encoding() {
 }
 
 #[test]
+fn sclass_constants_resolve_per_object() {
+    // A `def` inside `class << obj` shares its iseq across executions
+    // while each execution owns a distinct singleton class. Constant
+    // lookup must use the *runtime* cref (the receiver's singleton
+    // class / the per-execution nested class), not the last-stamped
+    // static one — including through the inline constant cache and
+    // the JIT (run_test warms both).
+    run_test(
+        r##"
+        $r = []
+        # Constants stored directly in the singleton class.
+        2.times do |i|
+          $i = i
+          obj = Object.new
+          class << obj
+            CONST = ($i + 1)
+            def foo
+              CONST
+            end
+          end
+          10.times { $r << obj.foo }
+        end
+        # A class nested inside `class << obj` is distinct per
+        # execution; its methods must see their own class's constants.
+        $classes = []
+        2.times do |i|
+          $i = i
+          obj = Object.new
+          class << obj
+            class X
+              $classes << self
+              CONST2 = ($i + 1)
+              def foo
+                CONST2
+              end
+            end
+            10.times { $r << X.new.foo }
+          end
+        end
+        $r << ($classes[0] != $classes[1])
+        # A singleton def (`def a.meth`) still resolves through its
+        # lexical scope, not the receiver's ancestry.
+        module CSPO_M
+          CONST3 = :lexical
+          class CSPO_A
+            CONST3 = :receiver
+          end
+          a = CSPO_A.new
+          def a.bar; CONST3; end
+          CSPO_OBJ = a
+        end
+        10.times { $r << CSPO_M::CSPO_OBJ.bar }
+        $r
+        "##,
+    );
+}
+
+#[test]
 fn binary_source_bytes_survive_load_and_eval() {
     // The source pipeline carries raw bytes: a `# encoding: big5`
     // source whose literals hold non-UTF-8 bytes round-trips through

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -307,6 +307,99 @@ fn sclass_constants_resolve_per_object() {
 }
 
 #[test]
+fn sclass_constants_cover_lookup_paths() {
+    // Exercises every runtime-cref recovery path: `defined?` (the
+    // probe/check-constant route), the ancestor-chain fallback when
+    // the constant lives on the receiver's class rather than the
+    // lexical scope, `def self.f` inside a class nested under
+    // `class << obj` (owner is the metaclass, cref is the attached
+    // class), and three receivers interleaved so the JIT compiles
+    // against a constant cache filled for a different self class.
+    run_test(
+        r##"
+        $r = []
+        TOPC9 = :top
+        # defined?(CONST) resolves through the runtime cref too. The
+        # calls happen AFTER the loop so the earlier receivers see a
+        # stale static stamp. The TOPC9 probe misses the singleton
+        # class and walks out to the enclosing lexical scope.
+        dobjs = []
+        2.times do |i|
+          $i = i
+          obj = Object.new
+          class << obj
+            CONST_D = $i + 10
+            def dcheck
+              [defined?(CONST_D), CONST_D, defined?(TOPC9)]
+            end
+          end
+          dobjs << obj
+        end
+        10.times { dobjs.each { |o| $r << o.dcheck } }
+        # Lexical miss falls back to the runtime singleton class's
+        # ancestors: the constant lives on each receiver's class. A
+        # body-level read takes the same route without any `def`.
+        class CCLP_A; CONST_F = :a; end
+        class CCLP_B; CONST_F = :b; end
+        fobjs = [CCLP_A.new, CCLP_B.new]
+        fobjs.each do |obj|
+          class << obj
+            $r << CONST_F
+            def fb; CONST_F; end
+          end
+        end
+        10.times { fobjs.each { |o| $r << o.fb } }
+        # `def self.f` in a class nested under `class << obj`: the
+        # method's owner is the metaclass, but constants resolve in
+        # the attached per-execution class.
+        $classes2 = []
+        2.times do |i|
+          $i = i
+          obj = Object.new
+          class << obj
+            CONST_OUTER = :o
+            class Y
+              $classes2 << self
+              CONST_S = $i + 100
+              def self.sfoo
+                # The probe misses Y and hits the enclosing singleton
+                # class, one lexical level out.
+                [CONST_S, defined?(CONST_OUTER)]
+              end
+            end
+          end
+        end
+        10.times { $classes2.each { |c| $r << c.sfoo } }
+        $r << ($classes2[0] != $classes2[1])
+        # `||=` on a constant in the body takes the definedness-check
+        # route; re-opening the same singleton class hits its cache.
+        qobj = Object.new
+        3.times do
+          class << qobj
+            CONST_Q ||= :q
+            $r << CONST_Q
+          end
+        end
+        # Three receivers interleaved: the constant cache flips
+        # between self classes while each method body gets JIT
+        # compiled, forcing the cache-key mismatch recompile path.
+        objs = []
+        3.times do |i|
+          $i = i
+          o = Object.new
+          class << o
+            CONST_J = $i
+            def jfoo; CONST_J; end
+          end
+          objs << o
+        end
+        30.times { objs.each_with_index { |o, i| $r << (o.jfoo == i) } }
+        $r
+        "##,
+    );
+}
+
+#[test]
 fn binary_source_bytes_survive_load_and_eval() {
     // The source pipeline carries raw bytes: a `# encoding: big5`
     // source whose literals hold non-UTF-8 bytes round-trips through


### PR DESCRIPTION
## Summary

Iteration 23 of the ruby/spec language-category improvements. Fixes constant resolution for methods defined inside `class << obj` bodies, clearing the remaining 3 failures in `language/constants_spec.rb` (language category overall: **10 → 7**).

## Problem

```ruby
2.times do |i|
  obj = Object.new
  class << obj
    CONST = i + 1
    def foo; CONST; end
  end
  p obj.foo   # CRuby: 1, 2 / monoruby (before): 2, 2
end
```

Each execution of `class << obj` creates a distinct singleton class, but the `def`s in the body share their iseq across executions. `enter_classdef` re-stamps the shared iseq's static `lexical_context` per execution (last write wins), so methods defined by earlier executions resolved constants against a later execution's class. The same applies to a `class X` nested inside `class << obj` (which is likewise a distinct class per execution).

## Fix

- **`Executor::runtime_innermost_cref`**: when the statically stamped innermost lexical entry is not on the receiver's ancestor chain, substitute the ancestor that owns the executing method (the defining class), recovering the runtime cref. Applied in `search_lexical_stack`, `probe_lexical_stack`, and the superclass-fallback lexical class. A metaclass owner is mapped back to its attached class, so `def self.f` in a class nested under `class << obj` resolves constants in the class rather than the metaclass.
- **`ISeqInfo::in_singleton_lexical`** (new, transitive flag): set on the sclass body iseq and propagated by bytecodegen onto every nested def/classdef/block. Staleness can only arise on lexical chains passing through `class << obj`, so the substitution is gated on this flag — singleton defs (`def a.meth`, `def M.f`) keep their purely lexical cref.
- **Self-keyed inline constant cache**: `ConstCache` gains a `self_class: Option<ClassId>` key. Constant sites in singleton-lexical iseqs (including the sclass body itself and the `||=` definedness route) always key the cache by self — a class/module receiver by its own id, since its metaclass may be unmaterialized. The VM includes the key in the hit condition; the JIT compares it against its compile-time self class (mapped back through the singleton attachment) and requests recompilation instead of folding a value cached for a different self, and never folds a `None`-keyed entry in such methods (its validity is relative to a re-stampable static cref).

## Tests

- `language/constants_spec.rb`: 100 examples, **0 failures** (was 3 failures)
- language category overall: 10 → **7** failures (remaining: super 2 / ensure 1 / rescue 1 / symbol 1 / predefined 1 / pattern_matching 1)
- full `cargo test` suite green
- New integration tests `sclass_constants_resolve_per_object` and `sclass_constants_cover_lookup_paths`: per-object constants in singleton classes, nested classes, `def self.f`, `defined?` probes, ancestor fallback, `||=` cache hits, body-level reads, stale-stamp calls after re-execution, and three interleaved receivers churning the cache while the JIT compiles (JIT warm-up included via `run_test`)
- Patch coverage 96.3% (75.8% before the second commit; the tests written for coverage exposed two real cache-validity bugs, fixed in that commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK