### PR TITLE
Implement pattern matching (case/in, `=>`, `in`) as a prism-lowerer desugar

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -281,6 +281,21 @@ class Regexp
   NOENCODING = 32
 end
 
+# Raised when a `case/in` exhausts its branches or an `expr => pattern`
+# match fails (the pattern-matching desugar references these by name).
+class NoMatchingPatternError < StandardError
+end
+
+class NoMatchingPatternKeyError < NoMatchingPatternError
+  def initialize(message = nil, matchee: nil, key: nil)
+    @matchee = matchee
+    @key = key
+    super(message)
+  end
+
+  attr_reader :matchee, :key
+end
+
 class Module
   # Partial ordering on the include / inherit graph, matching CRuby's
   # `rb_mod_cmp`:

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -400,14 +400,26 @@ fn instance_eval_inner(
             1
         };
         let src_encoding = crate::builtins::eval_src_encoding(args[0]);
+        // CRuby's instance_eval cref is the receiver's *singleton*
+        // class: `def` inside the string lands there, and class
+        // variables skip it (singleton cref) and resolve in the
+        // caller's scope.
+        let receiver_class = globals.store.get_singleton(self_val)?.id();
         let fid = globals.compile_script_eval(
             expr,
             path,
             caller_cfp,
-            Some(self_val.class()),
+            Some(receiver_class),
             lineno,
             src_encoding,
         )?;
+        // Constant lookup inside the body checks the receiver's class
+        // between the singleton class and the caller's lexical scopes
+        // (CRuby); see `ISeqInfo::instance_eval_class`.
+        let real_class = self_val.real_class(&globals.store).id();
+        if let Some(info) = globals.store.iseq_mut(fid) {
+            info.instance_eval_class = Some(real_class);
+        }
         vm.flush_compile_warnings(globals);
         let proc = ProcData::new(caller_cfp.lfp(), fid);
         vm.invoke_block_with_self(globals, &proc, self_val, &[])

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1538,15 +1538,29 @@ impl Executor {
     ///
     /// Get the parent module of the current context.
     ///
+    /// Walks outward from the innermost running func along the static
+    /// mother chain: a plain block defers to its enclosing method, but
+    /// a receiver-anchored eval body (`class_eval("...")`) carries its
+    /// own stamped `lexical_context` even though it *runs* as a block,
+    /// so the runtime method frame must not be consulted directly.
     fn get_parent(&self, globals: &Globals) -> Result<Module> {
-        let fid = self.cfp().method_func_id();
-        let parent = globals.store.iseq(fid).lexical_context.last().cloned();
-        match parent {
-            Some(parent) => Ok(globals[parent].get_module()),
-            None => Err(MonorubyErr::runtimeerr(
-                "class variable access from toplevel",
-            )),
+        let fid = self.cfp().lfp().func_id();
+        if let Some(mut iseq_id) = globals.store[fid].is_iseq() {
+            loop {
+                let iseq = &globals.store[iseq_id];
+                if let Some(parent) = iseq.lexical_context.last() {
+                    return Ok(globals[*parent].get_module());
+                }
+                let (mother, _) = iseq.mother();
+                if mother == iseq_id {
+                    break;
+                }
+                iseq_id = mother;
+            }
         }
+        Err(MonorubyErr::runtimeerr(
+            "class variable access from toplevel",
+        ))
     }
 }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1543,13 +1543,22 @@ impl Executor {
     /// a receiver-anchored eval body (`class_eval("...")`) carries its
     /// own stamped `lexical_context` even though it *runs* as a block,
     /// so the runtime method frame must not be consulted directly.
+    ///
+    /// Singleton-class cref entries are skipped (CRuby's
+    /// `vm_get_cvar_base`): `class << obj` bodies, `def self.f`, and
+    /// `instance_eval("...")` — whose eval iseq is stamped with the
+    /// receiver's singleton class — all resolve class variables in the
+    /// enclosing non-singleton scope (or fail with the toplevel error).
     fn get_parent(&self, globals: &Globals) -> Result<Module> {
         let fid = self.cfp().lfp().func_id();
         if let Some(mut iseq_id) = globals.store[fid].is_iseq() {
             loop {
                 let iseq = &globals.store[iseq_id];
-                if let Some(parent) = iseq.lexical_context.last() {
-                    return Ok(globals[*parent].get_module());
+                for parent in iseq.lexical_context.iter().rev() {
+                    let module = globals[*parent].get_module();
+                    if module.is_singleton().is_none() {
+                        return Ok(module);
+                    }
                 }
                 let (mother, _) = iseq.mother();
                 if mother == iseq_id {

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -337,6 +337,15 @@ impl Executor {
             if let Some(v) = self.search_lexical_stack(globals, name, frame_func)? {
                 return Ok(Some(v));
             }
+            // instance_eval("...") checks the receiver's class between
+            // the singleton class and the caller's lexical scopes.
+            if let Some(c) = Self::instance_eval_class(globals, frame_func) {
+                if globals.store.get_constant(c, name).is_some() {
+                    if let Some(v) = self.get_constant(globals, c, name)? {
+                        return Ok(Some(v));
+                    }
+                }
+            }
         }
         // Then search the enclosing method's lexical_context.
         if let Some(v) = self.search_lexical_stack(globals, name, current_func)? {
@@ -372,6 +381,14 @@ impl Executor {
             }
         }
         Ok(None)
+    }
+
+    /// The receiver's class for an `instance_eval("...")` frame func —
+    /// see `ISeqInfo::instance_eval_class`.
+    fn instance_eval_class(globals: &Globals, frame_func: FuncId) -> Option<ClassId> {
+        globals.store[frame_func]
+            .is_iseq()
+            .and_then(|iseq| globals.store[iseq].instance_eval_class)
     }
 
     /// Non-triggering probe of a constant directly on `class_id` —
@@ -534,8 +551,17 @@ impl Executor {
             // contexts (innermost first), then the enclosing class's
             // ancestor chain — all non-triggering.
             let frame_func = self.cfp().lfp().func_id();
-            if frame_func != current_func && self.probe_lexical_stack(globals, name, frame_func) {
-                return true;
+            if frame_func != current_func {
+                if self.probe_lexical_stack(globals, name, frame_func) {
+                    return true;
+                }
+                // instance_eval("...") checks the receiver's class
+                // between the singleton class and the caller's scopes.
+                if let Some(c) = Self::instance_eval_class(globals, frame_func) {
+                    if Self::probe_constant_at(globals, c, name) {
+                        return true;
+                    }
+                }
             }
             if self.probe_lexical_stack(globals, name, current_func) {
                 return true;

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -230,6 +230,16 @@ pub struct ISeqInfo {
     /// cref recovery in constant lookup is gated on this flag.
     ///
     pub(crate) in_singleton_lexical: bool,
+    ///
+    /// `Some(receiver.class)` for an `instance_eval("...")` body.
+    /// CRuby resolves unqualified constants there in a blended order:
+    /// receiver singleton class → **receiver class** → caller lexical
+    /// scopes → receiver ancestors. The middle step exists only for
+    /// string instance_eval (a plain `class << obj` body skips it), so
+    /// it is carried here rather than in `lexical_context`, which
+    /// keeps it invisible to class-variable resolution as well.
+    ///
+    pub(crate) instance_eval_class: Option<ClassId>,
 }
 
 impl std::fmt::Debug for ISeqInfo {
@@ -293,6 +303,7 @@ impl ISeqInfo {
             nested_definee: None,
             singleton_classdef: false,
             in_singleton_lexical: false,
+            instance_eval_class: None,
         }
     }
 

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -440,6 +440,10 @@ struct Lowerer<'pr> {
     /// top-level return is ignored" — a return in an eval belongs to
     /// the surrounding frame, not the script's top level).
     eval_parse: bool,
+    /// Monotonic counter for hidden locals synthesized by the pattern
+    /// matching desugar (`%pm<n>` — `%` is not spellable, so they never
+    /// surface in `local_variables`).
+    pm_temp: usize,
 }
 
 /// See [`Lowerer::scope_wraps`].
@@ -462,7 +466,14 @@ impl<'pr> Lowerer<'pr> {
             scope_wraps: Vec::new(),
             warnings: Vec::new(),
             eval_parse: false,
+            pm_temp: 0,
         }
+    }
+
+    /// A fresh hidden local name for the pattern-matching desugar.
+    fn pm_temp_name(&mut self) -> String {
+        self.pm_temp += 1;
+        format!("%pm{}", self.pm_temp)
     }
 
     /// Enter a prism scope (def/class/block/lambda body): bumps the
@@ -1538,6 +1549,58 @@ impl<'pr> Lowerer<'pr> {
                     },
                     loc,
                 }
+            }
+            prism::Node::CaseMatchNode { .. } => {
+                let n = node.as_case_match_node().unwrap();
+                self.lower_case_match(&n, loc)?
+            }
+            prism::Node::MatchPredicateNode { .. } => {
+                // `expr in pattern` — strict boolean result.
+                let n = node.as_match_predicate_node().unwrap();
+                let subj_name = self.pm_temp_name();
+                let subj_assign = pm_assign(
+                    pm_lvar(&subj_name, loc),
+                    self.lower_node(&n.value())?,
+                );
+                let subject = pm_lvar(&subj_name, loc);
+                let matched = self.lower_pattern(&n.pattern(), &subject, None)?;
+                Node::new_comp_stmt(
+                    vec![
+                        subj_assign,
+                        Node::new_if(
+                            matched,
+                            Node::new_bool(true, loc),
+                            Node::new_bool(false, loc),
+                            loc,
+                        ),
+                    ],
+                    loc,
+                )
+            }
+            prism::Node::MatchRequiredNode { .. } => {
+                // `expr => pattern` — raises NoMatchingPatternError on
+                // mismatch, evaluates to nil.
+                let n = node.as_match_required_node().unwrap();
+                let subj_name = self.pm_temp_name();
+                let subj_assign = pm_assign(
+                    pm_lvar(&subj_name, loc),
+                    self.lower_node(&n.value())?,
+                );
+                let subject = pm_lvar(&subj_name, loc);
+                let matched = self.lower_pattern(&n.pattern(), &subject, None)?;
+                Node::new_comp_stmt(
+                    vec![
+                        subj_assign,
+                        Node::new_if(
+                            matched,
+                            Node::new_nil(loc),
+                            pm_raise_no_matching_pattern(&subject, loc),
+                            loc,
+                        ),
+                        Node::new_nil(loc),
+                    ],
+                    loc,
+                )
             }
             prism::Node::InstanceVariableReadNode { .. } => {
                 let n = node.as_instance_variable_read_node().unwrap();
@@ -3037,6 +3100,506 @@ impl<'pr> Lowerer<'pr> {
     /// `Local/Instance/Global/ClassVar/Const` shapes ruruby's parser
     /// would have produced for the LHS. Used by both `MultiWriteNode`
     /// and the rescue-target lowerer.
+    // ----------------------------------------------------------------
+    // Pattern matching (`case/in`, `expr => pat`, `expr in pat`)
+    //
+    // Desugared entirely into the core AST: `===` dispatch for value
+    // patterns, `deconstruct` / `deconstruct_keys` calls for array and
+    // hash patterns, local assignments for bindings, and
+    // `raise NoMatchingPatternError` for exhaustion. Each pattern
+    // compiles to a boolean expression (side-effecting bindings on the
+    // way), so the whole construct becomes an if/elsif chain and JITs
+    // like ordinary code — no VM support needed.
+    // ----------------------------------------------------------------
+
+    fn lower_case_match(
+        &mut self,
+        n: &prism::CaseMatchNode<'pr>,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        let subj_name = self.pm_temp_name();
+        let cache_name = self.pm_temp_name();
+        let subject = pm_lvar(&subj_name, loc);
+        // `case/in` always has a predicate (a case-less `case` cannot
+        // have `in` branches).
+        let predicate = n.predicate().unwrap();
+        let subj_assign = pm_assign(pm_lvar(&subj_name, loc), self.lower_node(&predicate)?);
+        // Reset the per-case `deconstruct` cache: the hidden local
+        // survives across executions of an enclosing loop.
+        let cache_reset = pm_assign(pm_lvar(&cache_name, loc), Node::new_nil(loc));
+        let mut chain = match n.else_clause() {
+            Some(e) => {
+                let stmts = e.statements();
+                self.lower_optional_statements(stmts.as_ref(), location_to_loc(&e.location()))?
+            }
+            None => pm_raise_no_matching_pattern(&subject, loc),
+        };
+        let conditions: Vec<_> = n.conditions().iter().collect();
+        for c in conditions.into_iter().rev() {
+            let in_node = match &c {
+                prism::Node::InNode { .. } => c.as_in_node().unwrap(),
+                other => return Err(self.unsupported("case/in branch", other)),
+            };
+            let branch_loc = location_to_loc(&c.location());
+            let pattern = in_node.pattern();
+            let mut cond = self.lower_in_pattern(&pattern, &subject, Some(&cache_name))?;
+            if let Some((guard, positive)) = split_pattern_guard(&pattern) {
+                let mut g = self.lower_node(&guard)?;
+                if !positive {
+                    g = Node::new_unop(UnOp::Not, g, location_to_loc(&guard.location()));
+                }
+                cond = pm_and(cond, g);
+            }
+            let body = match in_node.statements() {
+                Some(s) => {
+                    let body_loc = location_to_loc(&s.location());
+                    self.lower_statements_compact(&s, body_loc)?
+                }
+                None => Node::new_nil(branch_loc),
+            };
+            chain = Node::new_if(cond, body, chain, branch_loc);
+        }
+        Ok(Node::new_comp_stmt(
+            vec![subj_assign, cache_reset, chain],
+            loc,
+        ))
+    }
+
+    /// Lower an `in` clause's pattern, skipping over a guard wrapper
+    /// (handled separately by the caller).
+    fn lower_in_pattern(
+        &mut self,
+        pattern: &prism::Node<'pr>,
+        subject: &Node,
+        cache: Option<&str>,
+    ) -> Result<Node, MonorubyErr> {
+        match pattern_guard_body(pattern) {
+            Some(inner) => self.lower_pattern(&inner, subject, cache),
+            None => self.lower_pattern(pattern, subject, cache),
+        }
+    }
+
+    /// Compile one pattern against `subject` (a re-readable expression:
+    /// a hidden local or an element access) into a boolean expression.
+    /// `cache` names the per-case hidden local memoizing the top-level
+    /// subject's `deconstruct` result across branches (CRuby calls
+    /// `#deconstruct` once per case subject but `#deconstruct_keys`
+    /// per pattern).
+    fn lower_pattern(
+        &mut self,
+        pat: &prism::Node<'pr>,
+        subject: &Node,
+        cache: Option<&str>,
+    ) -> Result<Node, MonorubyErr> {
+        let loc = location_to_loc(&pat.location());
+        Ok(match pat {
+            prism::Node::ArrayPatternNode { .. } => {
+                let n = pat.as_array_pattern_node().unwrap();
+                self.lower_array_pattern(&n, subject, cache, loc)?
+            }
+            prism::Node::FindPatternNode { .. } => {
+                let n = pat.as_find_pattern_node().unwrap();
+                self.lower_find_pattern(&n, subject, cache, loc)?
+            }
+            prism::Node::HashPatternNode { .. } => {
+                let n = pat.as_hash_pattern_node().unwrap();
+                self.lower_hash_pattern(&n, subject, loc)?
+            }
+            prism::Node::CapturePatternNode { .. } => {
+                // `pat => name` — match, then bind.
+                let n = pat.as_capture_pattern_node().unwrap();
+                let matched = self.lower_pattern(&n.value(), subject, cache)?;
+                let target = self.lower_assign_target(&n.target().as_node())?;
+                pm_and(matched, pm_bind(target, subject.clone(), loc))
+            }
+            prism::Node::AlternationPatternNode { .. } => {
+                let n = pat.as_alternation_pattern_node().unwrap();
+                let l = self.lower_pattern(&n.left(), subject, cache)?;
+                let r = self.lower_pattern(&n.right(), subject, cache)?;
+                pm_or(l, r)
+            }
+            prism::Node::PinnedVariableNode { .. } => {
+                let n = pat.as_pinned_variable_node().unwrap();
+                pm_teq(self.lower_node(&n.variable())?, subject.clone())
+            }
+            prism::Node::PinnedExpressionNode { .. } => {
+                let n = pat.as_pinned_expression_node().unwrap();
+                pm_teq(self.lower_node(&n.expression())?, subject.clone())
+            }
+            prism::Node::LocalVariableTargetNode { .. } => {
+                // `in name` — binds unconditionally.
+                let target = self.lower_assign_target(pat)?;
+                pm_bind(target, subject.clone(), loc)
+            }
+            prism::Node::ImplicitNode { .. } => {
+                let n = pat.as_implicit_node().unwrap();
+                self.lower_pattern(&n.value(), subject, cache)?
+            }
+            // Value pattern: any literal/const/range/regexp/pin —
+            // `pattern === subject`.
+            _ => pm_teq(self.lower_node(pat)?, subject.clone()),
+        })
+    }
+
+    /// `subject.deconstruct` with the TypeError contract, optionally
+    /// memoized in the per-case cache local. Produces a check node
+    /// that assigns the hidden local `d_name` and evaluates truthy
+    /// (or raises TypeError).
+    fn pm_deconstructed(
+        &mut self,
+        subject: &Node,
+        d_name: &str,
+        cache: Option<&str>,
+        loc: Loc,
+    ) -> Node {
+        let decon = Node::new_mcall_noarg(subject.clone(), "deconstruct".to_string(), false, loc);
+        let type_check = |d: Node| {
+            Node::new_if(
+                pm_teq(pm_const("Array", loc), d),
+                Node::new_bool(true, loc),
+                pm_raise_type_error("deconstruct must return Array", loc),
+                loc,
+            )
+        };
+        match cache {
+            Some(c) => {
+                // if %cache.nil?
+                //   %d = subject.deconstruct
+                //   (TypeError check)
+                //   %cache = %d
+                // else
+                //   %d = %cache
+                // end
+                // true
+                let fill = Node::new_comp_stmt(
+                    vec![
+                        pm_assign(pm_lvar(d_name, loc), decon),
+                        type_check(pm_lvar(d_name, loc)),
+                        pm_assign(pm_lvar(c, loc), pm_lvar(d_name, loc)),
+                    ],
+                    loc,
+                );
+                let reuse = pm_assign(pm_lvar(d_name, loc), pm_lvar(c, loc));
+                Node::new_comp_stmt(
+                    vec![
+                        Node::new_if(
+                            Node::new_mcall_noarg(pm_lvar(c, loc), "nil?".to_string(), false, loc),
+                            fill,
+                            reuse,
+                            loc,
+                        ),
+                        Node::new_bool(true, loc),
+                    ],
+                    loc,
+                )
+            }
+            None => Node::new_comp_stmt(
+                vec![
+                    pm_assign(pm_lvar(d_name, loc), decon),
+                    type_check(pm_lvar(d_name, loc)),
+                ],
+                loc,
+            ),
+        }
+    }
+
+    fn lower_array_pattern(
+        &mut self,
+        n: &prism::ArrayPatternNode<'pr>,
+        subject: &Node,
+        cache: Option<&str>,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        let mut checks: Vec<Node> = vec![];
+        if let Some(c) = n.constant() {
+            checks.push(pm_teq(self.lower_node(&c)?, subject.clone()));
+        }
+        checks.push(pm_respond_to(subject, "deconstruct", loc));
+        let d_name = self.pm_temp_name();
+        checks.push(self.pm_deconstructed(subject, &d_name, cache, loc));
+        let d = |loc| pm_lvar(&d_name, loc);
+        let req_len = n.requireds().iter().count();
+        let posts_len = n.posts().iter().count();
+        let fixed = (req_len + posts_len) as i64;
+        let has_rest = n.rest().is_some();
+        let size = Node::new_mcall_noarg(d(loc), "size".to_string(), false, loc);
+        checks.push(Node::new_binop(
+            BinOp::Cmp(if has_rest { CmpKind::Ge } else { CmpKind::Eq }),
+            size,
+            Node::new_integer(fixed, loc),
+        ));
+        for (i, p) in n.requireds().iter().enumerate() {
+            let elem = Node::new_array_member(d(loc), vec![Node::new_integer(i as i64, loc)], loc);
+            checks.push(self.lower_pattern(&p, &elem, None)?);
+        }
+        if let Some(rest) = n.rest() {
+            // `*name` binds the middle slice; a bare `*` and the
+            // trailing-comma `ImplicitRestNode` just allow extra
+            // elements.
+            if let prism::Node::SplatNode { .. } = &rest {
+                let sp = rest.as_splat_node().unwrap();
+                if let Some(expr) = sp.expression() {
+                    let target = self.lower_assign_target(&expr)?;
+                    let size =
+                        Node::new_mcall_noarg(d(loc), "size".to_string(), false, loc);
+                    let slice_len = Node::new_binop(
+                        BinOp::Sub,
+                        size,
+                        Node::new_integer(fixed, loc),
+                    );
+                    let slice = Node::new_array_member(
+                        d(loc),
+                        vec![Node::new_integer(req_len as i64, loc), slice_len],
+                        loc,
+                    );
+                    checks.push(pm_bind(target, slice, loc));
+                }
+            }
+        }
+        for (j, p) in n.posts().iter().enumerate() {
+            let size = Node::new_mcall_noarg(d(loc), "size".to_string(), false, loc);
+            let idx = Node::new_binop(
+                BinOp::Sub,
+                size,
+                Node::new_integer((posts_len - j) as i64, loc),
+            );
+            let elem = Node::new_array_member(d(loc), vec![idx], loc);
+            checks.push(self.lower_pattern(&p, &elem, None)?);
+        }
+        Ok(pm_and_all(checks, loc))
+    }
+
+    fn lower_find_pattern(
+        &mut self,
+        n: &prism::FindPatternNode<'pr>,
+        subject: &Node,
+        cache: Option<&str>,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        let mut checks: Vec<Node> = vec![];
+        if let Some(c) = n.constant() {
+            checks.push(pm_teq(self.lower_node(&c)?, subject.clone()));
+        }
+        checks.push(pm_respond_to(subject, "deconstruct", loc));
+        let d_name = self.pm_temp_name();
+        checks.push(self.pm_deconstructed(subject, &d_name, cache, loc));
+        let d = |loc| pm_lvar(&d_name, loc);
+        let k = n.requireds().iter().count() as i64;
+        // %i = 0
+        // %found = false
+        // while %i <= %d.size - K
+        //   if (required matches at offset %i)
+        //     pre = %d[0, %i]; post = %d[%i + K, %d.size]
+        //     %found = true
+        //     break
+        //   end
+        //   %i = %i + 1
+        // end
+        // %found
+        let i_name = self.pm_temp_name();
+        let found_name = self.pm_temp_name();
+        let i = |loc| pm_lvar(&i_name, loc);
+        let found = |loc| pm_lvar(&found_name, loc);
+        let mut arm: Vec<Node> = vec![];
+        let mut elem_checks: Vec<Node> = vec![];
+        for (j, p) in n.requireds().iter().enumerate() {
+            let idx = if j == 0 {
+                i(loc)
+            } else {
+                Node::new_binop(BinOp::Add, i(loc), Node::new_integer(j as i64, loc))
+            };
+            let elem = Node::new_array_member(d(loc), vec![idx], loc);
+            elem_checks.push(self.lower_pattern(&p, &elem, None)?);
+        }
+        if let Some(expr) = n.left().expression() {
+            let target = self.lower_assign_target(&expr)?;
+            let slice =
+                Node::new_array_member(d(loc), vec![Node::new_integer(0, loc), i(loc)], loc);
+            arm.push(pm_assign(target, slice));
+        }
+        if let prism::Node::SplatNode { .. } = &n.right() {
+            let sp = n.right().as_splat_node().unwrap();
+            if let Some(expr) = sp.expression() {
+                let target = self.lower_assign_target(&expr)?;
+                let from = Node::new_binop(BinOp::Add, i(loc), Node::new_integer(k, loc));
+                let size = Node::new_mcall_noarg(d(loc), "size".to_string(), false, loc);
+                let slice = Node::new_array_member(d(loc), vec![from, size], loc);
+                arm.push(pm_assign(target, slice));
+            }
+        }
+        arm.push(pm_assign(found(loc), Node::new_bool(true, loc)));
+        arm.push(Node {
+            kind: NodeKind::Break(Box::new(Node::new_nil(loc))),
+            loc,
+        });
+        let size = Node::new_mcall_noarg(d(loc), "size".to_string(), false, loc);
+        let while_cond = Node::new_binop(
+            BinOp::Cmp(CmpKind::Le),
+            i(loc),
+            Node::new_binop(BinOp::Sub, size, Node::new_integer(k, loc)),
+        );
+        let body = Node::new_comp_stmt(
+            vec![
+                Node::new_if(
+                    pm_and_all(elem_checks, loc),
+                    Node::new_comp_stmt(arm, loc),
+                    Node::new_nil(loc),
+                    loc,
+                ),
+                pm_assign(
+                    i(loc),
+                    Node::new_binop(BinOp::Add, i(loc), Node::new_integer(1, loc)),
+                ),
+            ],
+            loc,
+        );
+        checks.push(Node::new_comp_stmt(
+            vec![
+                pm_assign(i(loc), Node::new_integer(0, loc)),
+                pm_assign(found(loc), Node::new_bool(false, loc)),
+                Node::new_while(while_cond, body, true, loc),
+                found(loc),
+            ],
+            loc,
+        ));
+        Ok(pm_and_all(checks, loc))
+    }
+
+    fn lower_hash_pattern(
+        &mut self,
+        n: &prism::HashPatternNode<'pr>,
+        subject: &Node,
+        loc: Loc,
+    ) -> Result<Node, MonorubyErr> {
+        // Collect (symbol-name, value-pattern) pairs first — the keys
+        // double as the `deconstruct_keys` argument.
+        let mut pairs: Vec<(String, Option<prism::Node<'pr>>)> = vec![];
+        for e in n.elements().iter() {
+            let assoc = match &e {
+                prism::Node::AssocNode { .. } => e.as_assoc_node().unwrap(),
+                other => return Err(self.unsupported("hash pattern element", other)),
+            };
+            let key = assoc.key();
+            let name = match &key {
+                prism::Node::SymbolNode { .. } => {
+                    let sym = key.as_symbol_node().unwrap();
+                    String::from_utf8_lossy(sym.unescaped()).into_owned()
+                }
+                other => return Err(self.unsupported("hash pattern key", other)),
+            };
+            // `a:` alone wraps its implicit binding in ImplicitNode.
+            pairs.push((name, Some(assoc.value())));
+        }
+        // rest: None | AssocSplatNode (`**` / `**rest`) |
+        // NoKeywordsParameterNode (`**nil`).
+        let mut no_extra_keys = false;
+        let mut rest_target: Option<prism::Node<'pr>> = None;
+        let mut pass_nil = pairs.is_empty();
+        if let Some(rest) = n.rest() {
+            match &rest {
+                prism::Node::AssocSplatNode { .. } => {
+                    let sp = rest.as_assoc_splat_node().unwrap();
+                    if let Some(v) = sp.value() {
+                        // `**rest` — deconstruct_keys receives nil.
+                        rest_target = Some(v);
+                        pass_nil = true;
+                    }
+                    // bare `**` — keys are still passed (CRuby).
+                }
+                prism::Node::NoKeywordsParameterNode { .. } => {
+                    no_extra_keys = true;
+                    pass_nil = true;
+                }
+                other => return Err(self.unsupported("hash pattern rest", other)),
+            }
+        } else if pairs.is_empty() {
+            // `in {}` matches only an empty hash.
+            no_extra_keys = true;
+        }
+        let mut checks: Vec<Node> = vec![];
+        if let Some(c) = n.constant() {
+            checks.push(pm_teq(self.lower_node(&c)?, subject.clone()));
+        }
+        checks.push(pm_respond_to(subject, "deconstruct_keys", loc));
+        let h_name = self.pm_temp_name();
+        let h = |loc| pm_lvar(&h_name, loc);
+        let keys_arg = if pass_nil {
+            Node::new_nil(loc)
+        } else {
+            Node::new_array(
+                pairs
+                    .iter()
+                    .map(|(name, _)| Node::new_symbol(name.clone(), loc))
+                    .collect(),
+                loc,
+            )
+        };
+        let decon = Node::new_mcall(
+            subject.clone(),
+            "deconstruct_keys".to_string(),
+            crate::ast::ArgList::from_args(vec![keys_arg]),
+            false,
+            loc,
+        );
+        checks.push(Node::new_comp_stmt(
+            vec![
+                pm_assign(h(loc), decon),
+                Node::new_if(
+                    pm_teq(pm_const("Hash", loc), h(loc)),
+                    Node::new_bool(true, loc),
+                    pm_raise_type_error("deconstruct_keys must return Hash", loc),
+                    loc,
+                ),
+            ],
+            loc,
+        ));
+        for (name, value) in &pairs {
+            checks.push(Node::new_mcall(
+                h(loc),
+                "key?".to_string(),
+                crate::ast::ArgList::from_args(vec![Node::new_symbol(name.clone(), loc)]),
+                false,
+                loc,
+            ));
+            if let Some(v) = value {
+                let elem = Node::new_array_member(
+                    h(loc),
+                    vec![Node::new_symbol(name.clone(), loc)],
+                    loc,
+                );
+                checks.push(self.lower_pattern(v, &elem, None)?);
+            }
+        }
+        if no_extra_keys {
+            checks.push(Node::new_binop(
+                BinOp::Cmp(CmpKind::Eq),
+                Node::new_mcall_noarg(h(loc), "size".to_string(), false, loc),
+                Node::new_integer(pairs.len() as i64, loc),
+            ));
+        }
+        if let Some(target) = rest_target {
+            // rest = %h.dup minus the matched keys.
+            let target = self.lower_assign_target(&target)?;
+            let rest_read = target.clone();
+            let mut stmts = vec![pm_assign(
+                target,
+                Node::new_mcall_noarg(h(loc), "dup".to_string(), false, loc),
+            )];
+            for (name, _) in &pairs {
+                stmts.push(Node::new_mcall(
+                    rest_read.clone(),
+                    "delete".to_string(),
+                    crate::ast::ArgList::from_args(vec![Node::new_symbol(name.clone(), loc)]),
+                    false,
+                    loc,
+                ));
+            }
+            stmts.push(Node::new_bool(true, loc));
+            checks.push(Node::new_comp_stmt(stmts, loc));
+        }
+        Ok(pm_and_all(checks, loc))
+    }
+
     fn lower_assign_target(&mut self, node: &prism::Node<'pr>) -> Result<Node, MonorubyErr> {
         let loc = location_to_loc(&node.location());
         Ok(match node {
@@ -4470,6 +5033,110 @@ fn match_last_line(regex: Node, loc: crate::ast::Loc) -> Node {
         },
         loc,
     }
+}
+
+// ---- pattern-matching desugar helpers ----
+
+fn pm_lvar(name: &str, loc: Loc) -> Node {
+    Node::new_lvar(name.to_string(), 0, loc)
+}
+
+fn pm_assign(target: Node, value: Node) -> Node {
+    Node::new_mul_assign(vec![target], vec![value])
+}
+
+/// An unconditional binding as a truthy check: `(target = value; true)`.
+fn pm_bind(target: Node, value: Node, loc: Loc) -> Node {
+    Node::new_comp_stmt(vec![pm_assign(target, value), Node::new_bool(true, loc)], loc)
+}
+
+fn pm_and(l: Node, r: Node) -> Node {
+    Node::new_binop(BinOp::LAnd, l, r)
+}
+
+fn pm_or(l: Node, r: Node) -> Node {
+    Node::new_binop(BinOp::LOr, l, r)
+}
+
+fn pm_and_all(checks: Vec<Node>, loc: Loc) -> Node {
+    let mut it = checks.into_iter();
+    match it.next() {
+        Some(first) => it.fold(first, pm_and),
+        None => Node::new_bool(true, loc),
+    }
+}
+
+/// `pattern === subject`.
+fn pm_teq(pattern: Node, subject: Node) -> Node {
+    Node::new_binop(BinOp::Cmp(CmpKind::TEq), pattern, subject)
+}
+
+fn pm_const(name: &str, loc: Loc) -> Node {
+    Node::new_const(name.to_string(), false, None, vec![], loc)
+}
+
+fn pm_respond_to(subject: &Node, method: &str, loc: Loc) -> Node {
+    Node::new_mcall(
+        subject.clone(),
+        "respond_to?".to_string(),
+        crate::ast::ArgList::from_args(vec![Node::new_symbol(method.to_string(), loc)]),
+        false,
+        loc,
+    )
+}
+
+fn pm_raise_no_matching_pattern(subject: &Node, loc: Loc) -> Node {
+    let msg = Node::new_mcall_noarg(subject.clone(), "inspect".to_string(), false, loc);
+    Node::new_fcall(
+        "raise".to_string(),
+        crate::ast::ArgList::from_args(vec![pm_const("NoMatchingPatternError", loc), msg]),
+        false,
+        loc,
+    )
+}
+
+fn pm_raise_type_error(msg: &str, loc: Loc) -> Node {
+    Node::new_fcall(
+        "raise".to_string(),
+        crate::ast::ArgList::from_args(vec![
+            pm_const("TypeError", loc),
+            Node {
+                kind: NodeKind::String(msg.to_string()),
+                loc,
+            },
+        ]),
+        false,
+        loc,
+    )
+}
+
+/// A guard on an `in` clause reaches us as an `IfNode` / `UnlessNode`
+/// wrapping the pattern (patterns proper cannot contain conditionals,
+/// so the wrapper is unambiguous). Returns the guard predicate and its
+/// polarity, if present.
+fn split_pattern_guard<'pr>(pattern: &prism::Node<'pr>) -> Option<(prism::Node<'pr>, bool)> {
+    match pattern {
+        prism::Node::IfNode { .. } => {
+            let n = pattern.as_if_node().unwrap();
+            Some((n.predicate(), true))
+        }
+        prism::Node::UnlessNode { .. } => {
+            let n = pattern.as_unless_node().unwrap();
+            Some((n.predicate(), false))
+        }
+        _ => None,
+    }
+}
+
+/// The actual pattern inside a guard wrapper (see
+/// [`split_pattern_guard`]); `None` when the node is not a guard.
+fn pattern_guard_body<'pr>(pattern: &prism::Node<'pr>) -> Option<prism::Node<'pr>> {
+    let statements = match pattern {
+        prism::Node::IfNode { .. } => pattern.as_if_node().unwrap().statements(),
+        prism::Node::UnlessNode { .. } => pattern.as_unless_node().unwrap().statements(),
+        _ => return None,
+    };
+    statements.and_then(|s| s.body().iter().next())
 }
 
 fn binop_from_name(name: &str) -> Option<BinOp> {

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -271,6 +271,11 @@ fn eval_cref_semantics() {
           end
         end
         $r << ECS_CS::C.new.get_const(ECS_Recv.new)
+        # The defined? probe takes the same blended route.
+        recv = ECS_Recv.new
+        $r << recv.instance_eval("defined?(FOO9)")
+        $r << recv.instance_eval("defined?(NOT_DEFINED_ANYWHERE9)").inspect
+        $r << recv.instance_eval("FOO9") rescue $r << :e1
         obj2 = Object.new
         begin
           class << obj2

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -249,6 +249,80 @@ fn interpolation_and_eval_source_encoding() {
 }
 
 #[test]
+fn pattern_matching_desugar() {
+    // case/in, `expr => pat`, and `expr in pat` are desugared in the
+    // prism lowerer to ===/deconstruct/deconstruct_keys calls, local
+    // bindings, and NoMatchingPatternError raises. run_test warms the
+    // JIT, so the generated code is exercised in both tiers.
+    run_test(
+        r##"
+        $r = []
+        # array / find / hash / alternation / pin / capture / guard
+        [[0, 1, 2], {name: "Alice", age: 30}, 5, [1, 2, 3, 4, 5], "s"].each do |v|
+          case v
+          in [0, *rest]
+            $r << [:arr, rest]
+          in {name: String => n, age: Integer => a}
+            $r << [:hash, n, a]
+          in Integer | Float if v > 4
+            $r << :num
+          in [*pre, 3, *post]
+            $r << [:find, pre, post]
+          in String => s
+            $r << [:str, s]
+          end
+        end
+        # one-line forms
+        $r << (1 in Integer)
+        $r << ({a: 1} in {a: 0.. => x})
+        {b: 7} => {b:}
+        $r << b
+        # pin expression, deconstruct_keys arguments, **rest
+        obj = Object.new
+        def obj.deconstruct_keys(keys)
+          $r << keys
+          {a: 1, b: 2, c: 3}
+        end
+        case obj
+        in {a: ^(2 - 1), **rest}
+          $r << rest
+        end
+        # exhaustion raises with the subject's inspect in the message
+        begin
+          case [9, 9]
+          in [0]
+          end
+        rescue NoMatchingPatternError => e
+          $r << e.message.include?("[9, 9]")
+        end
+        # deconstruct is cached across branches of one case, but the
+        # cache resets between executions of the enclosing loop
+        $decon_calls = 0
+        arr = Object.new
+        def arr.deconstruct
+          $decon_calls += 1
+          [1]
+        end
+        2.times do
+          case arr
+          in [0]
+            $r << :zero
+          in [1, *]
+            $r << :one
+          end
+        end
+        $r << $decon_calls
+        # nested patterns and variable scope after the case
+        case {status: [:ok, 200]}
+        in {status: [Symbol => s, Integer => code]} if code < 300
+          $r << [s, code]
+        end
+        $r
+        "##,
+    );
+}
+
+#[test]
 fn sclass_constants_resolve_per_object() {
     // A `def` inside `class << obj` shares its iseq across executions
     // while each execution owns a distinct singleton class. Constant

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -249,6 +249,43 @@ fn interpolation_and_eval_source_encoding() {
 }
 
 #[test]
+fn eval_cref_semantics() {
+    // Class-variable and constant crefs of receiver-anchored string
+    // evals: class_eval sees the module's cvars; instance_eval skips
+    // its singleton cref for cvars (caller's scope wins) but checks
+    // the receiver's class for constants between the singleton class
+    // and the caller's lexical scopes; a `class << obj` body at the
+    // toplevel has no cvar scope at all.
+    run_test_once(
+        r##"
+        $r = []
+        m = Module.new
+        $r << m.class_eval("@@cv1 = 39; @@cv1")
+        class ECS_Recv; FOO9 = :receiver_class; end
+        module ECS_CS
+          @@cv2 = :caller
+          FOO9 = :caller_class
+          class C
+            def get_const(obj) = obj.instance_eval("FOO9")
+            def get_cvar(obj) = obj.instance_eval("@@cv2") rescue :err
+          end
+        end
+        $r << ECS_CS::C.new.get_const(ECS_Recv.new)
+        obj2 = Object.new
+        begin
+          class << obj2
+            @@cv3 = 1
+          end
+          $r << :sclass_ok
+        rescue RuntimeError => e
+          $r << e.message
+        end
+        $r
+        "##,
+    );
+}
+
+#[test]
 fn pattern_matching_desugar() {
     // case/in, `expr => pat`, and `expr in pat` are desugared in the
     // prism lowerer to ===/deconstruct/deconstruct_keys calls, local


### PR DESCRIPTION
## Summary

Iteration 24 of the ruby/spec language-category work. Implements Ruby pattern matching — `case/in`, rightward assignment `expr => pattern`, and the boolean form `expr in pattern` — entirely as a desugar in the prism lowerer. `language/pattern_matching_spec.rb` goes from a file-level parse abort (`unsupported node MatchRequiredNode`) to **113 examples, 110 passing**.

## Approach: no VM changes

`CaseMatchNode` / `MatchRequiredNode` / `MatchPredicateNode` compile into the existing AST — `===` dispatch, `deconstruct` / `deconstruct_keys` calls, local assignments, and `raise NoMatchingPatternError` — so the construct becomes an ordinary if/elsif chain and **JITs like normal code**, with no new bytecode, no per-arch backend work.

- **Value patterns** (literals, ranges, constants, regexps, lambdas) become `pattern === subject`; pins (`^x`, `^@ivar`, `^$g`, `^(expr)`) evaluate the pinned expression and match the same way.
- **Array/find patterns** check the optional constant first (CRuby order), then `respond_to?(:deconstruct)`, call `deconstruct` (TypeError with CRuby's message unless an Array comes back), check length, and match elements; splats bind slices. Find patterns (`[*pre, x, *post]`) scan with a hidden-local while loop. The deconstruct result is **memoized per case subject across branches**, and the memo resets each time the case executes (CRuby calls `#deconstruct` once per case but `#deconstruct_keys` per pattern — both verified by the spec).
- **Hash patterns** pass the pattern's keys to `deconstruct_keys` (`nil` when `**rest`/`**nil` needs the full set), check `key?` per key, match values, enforce exact keys for `**nil` and `{}`, and build `**rest` by dup-and-delete.
- **Captures** (`pat => x`) and bare bindings assign through the normal assign-target path, so prism-declared pattern locals get correct scoping/depth; hidden temporaries use unspellable `%pm<n>` names (the established `%match` idiom).
- **Guards** arrive as an `If`/`Unless` wrapper around the pattern node and become `match && guard` / `match && !guard`, evaluated only if the pattern matched.
- Exhausted `case/in` raises `NoMatchingPatternError` (message contains the subject's `inspect`); `expr => pat` raises on mismatch and evaluates to `nil`; `expr in pat` yields a strict boolean. Syntax-level rules (binding in alternation, duplicate hash-pattern keys, non-symbol keys, expressions in patterns) already surface as `SyntaxError` through prism's own diagnostics.
- `NoMatchingPatternError` / `NoMatchingPatternKeyError` are defined in `startup.rb`.

## Bonus fixes: cvar / constant crefs of receiver-anchored string evals

Enabling the spec's "supports pinning class variables" example led to a small series of cref fixes for `class_eval("...")` / `instance_eval("...")`, verified against CRuby and by `core/basicobject` (now **172 examples, 0 failures**):

- `Executor::get_parent` resolved the cvar cref via the runtime method frame, but a receiver-anchored eval body *runs* as a block while carrying its own stamped `lexical_context`. It now walks the static mother chain from the innermost running func — so `@@cvar` works inside `class_eval("...")`.
- Singleton-class cref entries are skipped for cvars (CRuby's `vm_get_cvar_base`): `instance_eval("...")` resolves class variables in the caller's scope, and a toplevel `class << obj` body raises the "class variable access from toplevel" error like CRuby.
- `instance_eval("...")` stamps the receiver's *singleton* class as its eval cref (previously the receiver's class), and constants keep CRuby's blended lookup order — singleton class → receiver's class → caller's lexical scopes → receiver's ancestors — via a new `ISeqInfo::instance_eval_class` annotation probed between the frame's and the caller's lexical stacks. Carrying it outside `lexical_context` keeps it invisible to cvar resolution, and plain `class << obj` bodies keep the ordinary constant order.

## Tests

- `language/pattern_matching_spec.rb`: **0 → 110 passing** (113 examples). The 3 remaining errors all need `Module#refine`, which monoruby doesn't implement at all — a pre-existing platform gap this PR merely uncovers (the raw language-category count therefore moves 7 → 9 while 110 previously-unrunnable examples now pass).
- `core/basicobject`: 172 examples, 0 failures (fixed the 4 instance_eval cvar/constant regressions caught by CI on the first push).
- Full language sweep: no regressions in any other file.
- Full `cargo test` suite green.
- New integration tests: `pattern_matching_desugar` (array/find/hash/alternation/pin/capture/guard patterns, one-line forms, `deconstruct_keys` arguments, deconstruct caching + reset, exhaustion raising, nested patterns — with JIT warm-up) and `eval_cref_semantics` (class_eval cvars, instance_eval cvar skip + blended constant order incl. the `defined?` probe route, toplevel sclass cvar error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK