### PR TITLE
Add setup-monoruby GitHub Action (ruby/setup-ruby style)

### DIFF
--- a/.github/workflows/setup-monoruby.yml
+++ b/.github/workflows/setup-monoruby.yml
@@ -1,0 +1,64 @@
+# Smoke-tests the root action.yml (the "Setup monoruby" composite action) on
+# both hosted-runner architectures. Runs when the action or this workflow
+# changes, and on demand.
+name: setup-monoruby action
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - action.yml
+      - .github/workflows/setup-monoruby.yml
+  pull_request:
+    branches: [master]
+    paths:
+      - action.yml
+      - .github/workflows/setup-monoruby.yml
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # First run per revision × OS builds from source; cached runs finish in
+    # a couple of minutes.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup monoruby
+        id: setup
+        uses: ./
+
+      - name: Report action outputs
+        run: |
+          echo "cache-hit:        ${{ steps.setup.outputs.cache-hit }}"
+          echo "monoruby-version: ${{ steps.setup.outputs.monoruby-version }}"
+          echo "ruby-version:     ${{ steps.setup.outputs.ruby-version }}"
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+
+          # The binary is on PATH and identifies itself as monoruby.
+          monoruby --version | grep -q '^monoruby '
+          monoruby -e 'puts RUBY_DESCRIPTION' | grep -q '^monoruby '
+
+          # The vendored stdlib was installed alongside the binary
+          # (pure-Ruby json replacement ships in monoruby/stdlib).
+          test "$(monoruby -e 'require "json"; puts JSON.generate({"a" => 1})')" = '{"a":1}'
+
+          # Run something hot enough to go through the JIT tier.
+          cat > fib.rb <<'RUBY'
+          def fib(n)
+            n < 2 ? n : fib(n - 1) + fib(n - 2)
+          end
+          puts fib(28)
+          RUBY
+          test "$(monoruby fib.rb)" = "317811"
+
+          # Script arguments arrive in ARGV.
+          test "$(monoruby -e 'puts ARGV.join(",")' -- one two)" = "one,two"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ or
 > bin/irm
 ```
 
+## Using monoruby in GitHub Actions
+
+This repository doubles as a `setup-monoruby` action (see `action.yml`),
+modeled after [ruby/setup-ruby](https://github.com/ruby/setup-ruby). The ref
+after `@` selects the monoruby version to install:
+
+```yaml
+steps:
+  - uses: sisshiki1969/monoruby@master # or a release tag
+  - run: monoruby my_script.rb
+```
+
+Since no prebuilt binaries are published yet, the action builds monoruby from
+source on the first run for each monoruby revision × runner OS/arch and caches
+the resulting binary and runtime tree with `actions/cache`, so subsequent runs
+restore in seconds. Pinning a release tag keeps the cache stable; tracking
+`@master` rebuilds on every upstream push. Linux (x64/arm64) and macOS
+(Apple Silicon) hosted runners are supported.
+
+Inputs and outputs:
+
+| Name                     | Kind   | Description                                                     |
+| ------------------------ | ------ | --------------------------------------------------------------- |
+| `cache` (`'true'`)       | input  | Set to `'false'` to always build from source                    |
+| `cache-version` (`'v1'`) | input  | Mixed into the cache key; bump to discard existing caches       |
+| `cache-hit`              | output | `'true'` if the binary was restored from cache                  |
+| `monoruby-version`       | output | Output of `monoruby --version`                                  |
+| `ruby-version`           | output | `RUBY_VERSION` reported by the installed monoruby               |
+
 ## Benchmark
 
 ### 1. Optcarrot banechmark

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,134 @@
+# Setup monoruby — a composite GitHub Action, modeled after ruby/setup-ruby.
+#
+# Usage (the ref after `@` selects the monoruby version to install):
+#
+#   steps:
+#     - uses: sisshiki1969/monoruby@v3.0.1   # or @master for the latest
+#     - run: monoruby my_script.rb
+#
+# No prebuilt binaries are published yet, so the action builds monoruby from
+# the very source tree GitHub checked out for the action itself
+# (`$GITHUB_ACTION_PATH`) and installs it with `cargo install`. The built
+# binary and its runtime tree (`~/.monoruby/v*`, laid down by build.rs) are
+# cached keyed on the source fingerprint, so only the first run for a given
+# monoruby revision × runner OS/arch pays the compile time (~10-20 min);
+# subsequent runs restore in seconds. Pinning a tag keeps the cache stable;
+# tracking `@master` rebuilds on every upstream push.
+#
+# Works on Linux (x64/arm64) and macOS (Apple Silicon) hosted runners. The
+# runner needs `rustup` and (on macOS) Homebrew, both preinstalled on GitHub
+# hosted images.
+
+name: "Setup monoruby"
+description: >
+  Build (with caching) and install monoruby, a Ruby implementation written in
+  Rust with a JIT compiler, and add it to PATH.
+author: "sisshiki1969"
+branding:
+  icon: "zap"
+  color: "red"
+
+inputs:
+  cache:
+    description: >
+      Cache the built monoruby binary and its runtime tree with actions/cache.
+      Set to 'false' to always build from source.
+    required: false
+    default: "true"
+  cache-version:
+    description: >
+      Arbitrary string mixed into the cache key. Bump it to discard existing
+      caches (e.g. after a runner image change).
+    required: false
+    default: "v1"
+
+outputs:
+  cache-hit:
+    description: >
+      'true' if the prebuilt binary was restored from cache ('' when caching
+      is disabled).
+    value: ${{ steps.cache.outputs.cache-hit }}
+  monoruby-version:
+    description: The installed monoruby crate version (output of `monoruby --version`).
+    value: ${{ steps.verify.outputs.monoruby-version }}
+  ruby-version:
+    description: The RUBY_VERSION the installed monoruby reports.
+    value: ${{ steps.verify.outputs.ruby-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute source fingerprint
+      id: key
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "$GITHUB_ACTION_PATH"
+        # `uses: owner/repo@ref` extracts a tarball without .git, so fall back
+        # to hashing every build input (sources + lockfile + toolchain pin).
+        if fp=$(git rev-parse HEAD 2>/dev/null); then
+          :
+        else
+          sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi; }
+          fp=$(find Cargo.lock Cargo.toml rust-toolchain.toml \
+                    monoruby monoruby_attr rubymap hashbrown ruby_traits \
+                    -type f -not -path '*/target/*' -print0 \
+               | LC_ALL=C sort -z | xargs -0 cat | sha | cut -d' ' -f1)
+        fi
+        echo "fingerprint=$fp" >> "$GITHUB_OUTPUT"
+        echo "monoruby source fingerprint: $fp"
+
+    - name: Restore cached monoruby
+      id: cache
+      if: inputs.cache == 'true'
+      uses: actions/cache@v4
+      with:
+        # ~/.monoruby/v* is the per-version runtime tree (vendored stdlib +
+        # Ruby-level builtins) that build.rs installs; the binary bakes in its
+        # absolute path, so both must travel together. The version-independent
+        # host-gem caches (~/.monoruby/{library_path,gem_path}) are left out —
+        # ruby_probe.rs regenerates them at runtime against the runner's own
+        # host Ruby.
+        path: |
+          ~/.cargo/bin/monoruby
+          ~/.monoruby/v*
+        key: setup-monoruby-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.key.outputs.fingerprint }}
+
+    - name: Build and install monoruby
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        # Install the nightly toolchain pinned by rust-toolchain.toml; the
+        # rustup shim then picks it up automatically because cargo runs from
+        # the source tree.
+        channel=$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml)
+        echo "Installing Rust toolchain: $channel"
+        rustup toolchain install "$channel" --profile minimal --no-self-update
+
+        # aarch64-macOS builds libffi-sys against the system libffi; the
+        # Homebrew keg is keg-only, so pkg-config needs its prefix.
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          brew install libffi pkg-config
+          export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+        fi
+
+        # build.rs installs the vendored stdlib + Ruby builtins into
+        # ~/.monoruby/v<version>/ as part of this build.
+        cargo install --path monoruby --locked --force
+
+    - name: Add monoruby to PATH
+      shell: bash
+      run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+    - name: Verify installation
+      id: verify
+      shell: bash
+      run: |
+        set -euo pipefail
+        monoruby --version
+        monoruby -e 'puts RUBY_DESCRIPTION'
+        echo "monoruby-version=$(monoruby --version)" >> "$GITHUB_OUTPUT"
+        echo "ruby-version=$(monoruby -e 'puts RUBY_VERSION')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Turns the repository root into a `setup-monoruby` composite action, modeled after [ruby/setup-ruby](https://github.com/ruby/setup-ruby), so any workflow can install monoruby with:

```yaml
steps:
  - uses: sisshiki1969/monoruby@v3.0.1   # or @master
  - run: monoruby my_script.rb
```

Since releases don't ship prebuilt binaries yet, the action **builds from source with caching**:

1. The ref after `@` selects the version — GitHub's checkout of the action itself (`$GITHUB_ACTION_PATH`) *is* the monoruby source tree at that ref, so no extra clone is needed.
2. A source fingerprint (git SHA, or a content hash of all build inputs for tarball-extracted actions) keys an `actions/cache` entry holding `~/.cargo/bin/monoruby` **and** the `~/.monoruby/v*` runtime tree that `build.rs` installs (the binary bakes in its absolute path, so they must travel together). The version-independent host-gem caches (`~/.monoruby/{library_path,gem_path}`) are deliberately excluded — `ruby_probe.rs` regenerates them at runtime.
3. On cache miss only: install the nightly pinned by `rust-toolchain.toml`, add libffi/pkg-config on macOS (matching the existing `darwin` CI job), and `cargo install --path monoruby --locked`.

First run per monoruby revision × runner OS/arch pays the compile; subsequent runs restore in seconds. Pinning a tag keeps the cache stable; `@master` rebuilds on every upstream push.

## Changes

- **`action.yml`** — the composite action, with inputs `cache` / `cache-version` and outputs `cache-hit` / `monoruby-version` / `ruby-version`
- **`.github/workflows/setup-monoruby.yml`** — smoke-tests the action on `ubuntu-latest` and `macos-latest`: `--version` / `RUBY_DESCRIPTION` checks, `require "json"` against the vendored stdlib, a JIT-warm `fib(28)`, and ARGV passing; triggered on changes to the action and via `workflow_dispatch`
- **`README.md`** — new "Using monoruby in GitHub Actions" section documenting usage, inputs, and outputs

## Verification

- Built monoruby with the pinned `nightly-2026-05-18` toolchain and ran every smoke-test command against the resulting binary: `monoruby 0.3.0`, `RUBY_VERSION` = 4.0.2, `fib(28)` = 317811, JSON round-trip and ARGV output all match.
- Exercised both fingerprint paths (git SHA and content-hash fallback, ~0.1 s) and the `rust-toolchain.toml` channel extraction.
- YAML syntax validated for both new files.

The `setup-monoruby action` workflow on this PR runs the full end-to-end path (source build + cache) on both runner OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kt9S3FqhZ2aX6zHfxZzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kt9S3FqhZ2aX6zHfxZzL)_