### PR TITLE
Symbol literals take the source encoding

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -118,8 +118,8 @@ impl<'a> BytecodeGen<'a> {
             NodeKind::SelfValue => self.emit_mov(dst, BcReg::Self_),
             NodeKind::Integer(i) => self.emit_integer(dst, i),
             NodeKind::Symbol(sym) => {
-                let sym = IdentId::get_id_from_string(sym);
-                self.emit_symbol(dst, sym)
+                let val = Value::symbol_from_source_str(&sym, self.source_encoding());
+                self.emit_symbol(dst, val.as_symbol())
             }
             NodeKind::Bignum(bigint) => self.emit_bigint(dst, bigint),
             NodeKind::Float(f) => self.emit_float(dst, f),

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -756,6 +756,18 @@ impl Value {
         Value::symbol(id)
     }
 
+    /// A symbol literal takes its source file's encoding: a non-ASCII
+    /// symbol in a non-UTF-8 source (e.g. `# encoding: binary`) is
+    /// interned per (bytes, encoding) — distinct from the same bytes
+    /// in a UTF-8 source — and `Symbol#{to_s,encoding}` report the
+    /// recorded encoding (CRuby).
+    pub(crate) fn symbol_from_source_str(s: &str, src_enc: Encoding) -> Self {
+        if s.is_ascii() || matches!(src_enc, Encoding::Utf8 | Encoding::UsAscii) {
+            return Self::symbol_from_str(s);
+        }
+        Value::symbol(IdentId::get_id_from_bytes(s.as_bytes().to_vec(), src_enc))
+    }
+
     fn fixnum(num: i64) -> Self {
         Immediate::fixnum(num).into()
     }
@@ -2732,7 +2744,7 @@ impl Value {
             }
             NodeKind::Bool(b) => Value::bool(*b),
             NodeKind::Nil => Value::nil(),
-            NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
+            NodeKind::Symbol(sym) => Value::symbol_from_source_str(sym, src_enc),
             NodeKind::String(s) => Value::string_from_source_str(s, src_enc),
             NodeKind::Bytes(b) => Value::string_from_source_bytes(b, src_enc),
             NodeKind::EncodedString(b, name) => {
@@ -2860,7 +2872,7 @@ impl Value {
             }
             NodeKind::Bool(b) => Value::bool(*b),
             NodeKind::Nil => Value::nil(),
-            NodeKind::Symbol(sym) => Value::symbol_from_str(sym),
+            NodeKind::Symbol(sym) => Value::symbol_from_source_str(sym, src_enc),
             NodeKind::String(s) => Value::string_from_source_str(s, src_enc),
             NodeKind::Bytes(b) => Value::string_from_source_bytes(b, src_enc),
             NodeKind::EncodedString(b, name) => {

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -249,6 +249,28 @@ fn interpolation_and_eval_source_encoding() {
 }
 
 #[test]
+fn symbol_literal_takes_source_encoding() {
+    // A non-ASCII symbol literal in a binary-encoded source reports
+    // ASCII-8BIT and is a distinct symbol from the same bytes in a
+    // UTF-8 source (per-(bytes, encoding) identity — CRuby).
+    run_test_once(
+        r##"
+        require "tmpdir"
+        path = File.join(Dir.tmpdir, "mrb_binsym_#{Process.pid}.rb")
+        File.binwrite(path, (+"# encoding: binary\n").force_encoding("binary") +
+          "$binsym = :il_était\n".b +
+          "$binsym_frozen = [:il_était].first\n".b)
+        load path
+        File.delete(path)
+        utf8 = :il_était
+        [$binsym.encoding.name, $binsym.to_s.bytes,
+         $binsym_frozen.encoding.name,
+         utf8.encoding.name, ($binsym == utf8)]
+        "##,
+    );
+}
+
+#[test]
 fn eval_cref_semantics() {
     // Class-variable and constant crefs of receiver-anchored string
     // evals: class_eval sees the module's cvars; instance_eval skips


### PR DESCRIPTION
## Summary

Iteration 25 of the ruby/spec language-category work. A non-ASCII symbol literal in a non-UTF-8 source (e.g. a `# encoding: binary` magic comment) now takes the source encoding, clearing the last `language/symbol_spec.rb` failure (language category: **9 → 8**).

## Fix

The runtime side already existed: `IdentId::get_id_from_bytes(bytes, enc)` interns per (bytes, encoding) — CRuby's symbol identity — and records the encoding in `enc_map`, which `Symbol#{to_s,name,encoding,inspect}` consume; `String#to_sym` used it, but the *literal* path bypassed it and always interned as UTF-8. A new `Value::symbol_from_source_str(s, src_enc)` routes non-ASCII literals from non-UTF-8 sources through that channel, applied at both literal sites (bytecode emission and the frozen-literal `from_const_ast` path). ASCII symbols and UTF-8 sources keep the existing fast path, so nothing changes for ordinary code.

As a side effect the identity semantics are now CRuby-correct too: `:il_était` from a binary source and from a UTF-8 source are *distinct* symbols.

## Not fixed: `resolve_feature_path('etc')` (predefined_spec, 1 failure)

Examined and deliberately left: the spec expects `[:so, ".../etc.so"]`, but monoruby intentionally ships pure-Ruby replacements for C-extension stdlibs, so `require 'etc'` genuinely loads an `etc.rb` and `resolve_feature_path` honestly reports `:rb`. Faking `:so` would misreport what monoruby actually loads; this looks inherent to the stdlib-replacement design.

## Tests

- `language/symbol_spec.rb`: 14 examples, **0 failures** (was 1)
- Full language sweep: no regressions (remaining 8: refinements 3 (`Module#refine` unimplemented), super 2, ensure 1, rescue 1, predefined 1)
- Full `cargo test` suite green
- New integration test `symbol_literal_takes_source_encoding` (binary-source literal via `load`, frozen-literal array path, encoding names, byte round-trip, cross-encoding distinctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_