### PR TITLE
setup-monoruby: prebuilt release assets with rolling x86-64 nightly

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,7 +1,12 @@
 # Builds prebuilt monoruby binaries and attaches them to a GitHub release,
 # so the setup-monoruby action (root action.yml) can download them instead of
-# compiling from source. Runs automatically when a release is published, and
-# manually via workflow_dispatch to backfill an existing release tag.
+# compiling from source. Three triggers:
+#
+#   * push to master   — rolling nightly: the `latest` tag is force-moved to
+#                        the pushed commit and the assets on the `latest`
+#                        prerelease are replaced (serves `@master`/`@latest`)
+#   * release published — assets for that release tag (serves `@v…`)
+#   * workflow_dispatch — backfill an existing release tag
 #
 # Each asset is a tarball named monoruby-<tag>-<target>.tar.gz containing:
 #
@@ -18,6 +23,8 @@
 name: release binaries
 
 on:
+  push:
+    branches: [master]
   release:
     types: [published]
   workflow_dispatch:
@@ -27,10 +34,46 @@ on:
         required: true
 
 permissions:
-  contents: write # upload assets to the release
+  contents: write # move the latest tag, create/edit the release, upload assets
+
+# One run per target tag; a newer master push supersedes an in-flight
+# nightly build.
+concurrency:
+  group: release-binaries-${{ github.event_name == 'push' && 'latest' || github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: true
 
 jobs:
+  # Rolling nightly bookkeeping (push events only): move the `latest` tag to
+  # the pushed commit and make sure the `latest` prerelease exists, so the
+  # matrix jobs have a release to upload onto.
+  prepare-latest:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Move latest tag and upsert the nightly prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git tag -f latest "$GITHUB_SHA"
+          git push -f origin latest
+          notes="Rolling nightly build of master, replaced on every push. Currently ${GITHUB_SHA}. Consumed by the setup-monoruby action (see action.yml) for \`@master\` / \`@latest\` refs."
+          if gh release view latest --json id >/dev/null 2>&1; then
+            gh release edit latest --prerelease --title "Nightly build (latest master)" --notes "$notes"
+          else
+            gh release create latest --prerelease --title "Nightly build (latest master)" --notes "$notes"
+          fi
+
   build:
+    needs: prepare-latest
+    # Run when prepare-latest succeeded (push) or was skipped (release /
+    # dispatch), but never build the `latest` tag from a release event — the
+    # nightly is owned by the push path.
+    if: >-
+      always() &&
+      (needs.prepare-latest.result == 'success' || needs.prepare-latest.result == 'skipped') &&
+      !(github.event_name == 'release' && github.event.release.tag_name == 'latest')
     strategy:
       fail-fast: false
       matrix:
@@ -43,11 +86,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
-      TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+      TAG: ${{ github.event_name == 'push' && 'latest' || github.event.release.tag_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+          # Nightly builds pin the pushed commit (not the moving tag);
+          # release/dispatch builds check out the release tag.
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.release.tag_name || inputs.tag }}
 
       - name: Install pinned Rust toolchain
         run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,100 @@
+# Builds prebuilt monoruby binaries and attaches them to a GitHub release,
+# so the setup-monoruby action (root action.yml) can download them instead of
+# compiling from source. Runs automatically when a release is published, and
+# manually via workflow_dispatch to backfill an existing release tag.
+#
+# Each asset is a tarball named monoruby-<tag>-<target>.tar.gz containing:
+#
+#   bin/monoruby, bin/irm      release binaries
+#   monoruby-home/v<version>/  the runtime tree build.rs installed
+#                              (vendored stdlib + Ruby builtins + stubs)
+#
+# The binary bakes in the *build* machine's install-root path
+# (~/.monoruby/v<version>); binaries built after the runtime
+# MONORUBY_INSTALL_ROOT override landed are relocatable via that env var,
+# and the action sets it after extraction. GitHub-hosted runners share the
+# same $HOME per OS anyway, so even override-less binaries (backfills of
+# older tags) work there.
+name: release binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build assets for (e.g. v3.0.1)"
+        required: true
+
+permissions:
+  contents: write # upload assets to the release
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ubuntu-22.04 keeps the glibc floor low enough for every
+          # currently-hosted Linux runner image.
+          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
+          - os: macos-latest # arm64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    env:
+      TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+
+      - name: Install pinned Rust toolchain
+        run: |
+          channel=$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml)
+          rustup toolchain install "$channel" --profile minimal --no-self-update
+
+      - name: Install libffi + pkg-config (macOS)
+        # The aarch64-macOS dep block in monoruby/Cargo.toml builds libffi-sys
+        # against the system libffi; the Homebrew keg is keg-only, so
+        # pkg-config needs its prefix.
+        if: runner.os == 'macOS'
+        run: |
+          brew install libffi pkg-config
+          echo "PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig" >> "$GITHUB_ENV"
+
+      - name: Build monoruby
+        run: cargo install --path monoruby --locked --force
+
+      - name: Package tarball
+        id: package
+        run: |
+          set -euo pipefail
+          target=$(rustc -vV | sed -n 's/^host: //p')
+          asset="monoruby-${TAG}-${target}.tar.gz"
+
+          pkg="$RUNNER_TEMP/pkg"
+          mkdir -p "$pkg/bin" "$pkg/monoruby-home"
+          cp "$HOME/.cargo/bin/monoruby" "$HOME/.cargo/bin/irm" "$pkg/bin/"
+          # The per-version runtime tree build.rs just installed; exclude the
+          # version-independent host-probe caches (library_path/gem_path),
+          # which consumers regenerate at runtime.
+          cp -R "$HOME"/.monoruby/v* "$pkg/monoruby-home/"
+
+          tar -C "$pkg" -czf "$RUNNER_TEMP/$asset" bin monoruby-home
+          echo "asset=$RUNNER_TEMP/$asset" >> "$GITHUB_OUTPUT"
+
+          # Sanity-check the packaged pair the way the action will consume it:
+          # extracted to a fresh location, wired up via MONORUBY_INSTALL_ROOT.
+          check="$RUNNER_TEMP/check"
+          mkdir -p "$check"
+          tar -C "$check" -xzf "$RUNNER_TEMP/$asset"
+          vdir=$(basename "$check"/monoruby-home/v*)
+          out=$(MONORUBY_INSTALL_ROOT="$check/monoruby-home/$vdir" \
+                "$check/bin/monoruby" -e 'require "json"; puts JSON.generate({"ok" => 1})')
+          test "$out" = '{"ok":1}'
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$TAG" "${{ steps.package.outputs.asset }}" --clobber

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,7 +6,13 @@
 #                        the pushed commit and the assets on the `latest`
 #                        prerelease are replaced (serves `@master`/`@latest`)
 #   * release published — assets for that release tag (serves `@v…`)
-#   * workflow_dispatch — backfill an existing release tag
+#   * workflow_dispatch — build assets for an existing tag on demand
+#
+# Automatic triggers (push / release) build x86-64 Linux only, to keep the
+# per-push runner cost at one job. Other architectures (Linux arm64, macOS
+# arm64) are built on demand: dispatch the workflow with the wanted tag
+# (`latest` or a release tag) and target selection. Platforms without an
+# asset simply fall back to the action's source-build path.
 #
 # Each asset is a tarball named monoruby-<tag>-<target>.tar.gz containing:
 #
@@ -30,8 +36,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to build assets for (e.g. v3.0.1)"
+        description: "Tag to build assets for: a release tag (e.g. v3.0.1) or `latest`"
         required: true
+      targets:
+        description: "Which architectures to build"
+        type: choice
+        default: all
+        options:
+          - all
+          - x86_64-linux
+          - aarch64-linux
+          - aarch64-macos
 
 permissions:
   contents: write # move the latest tag, create/edit the release, upload assets
@@ -65,6 +80,18 @@ jobs:
             gh release create latest --prerelease --title "Nightly build (latest master)" --notes "$notes"
           fi
 
+          # Only the x86-64 Linux asset is rebuilt per push; drop other-arch
+          # assets (from earlier on-demand dispatches) so a stale binary is
+          # never served for the new commit — those platforms fall back to
+          # the action's source build until re-dispatched. The x86-64 asset
+          # stays up (one-build lag) until the build job clobbers it.
+          for a in $(gh release view latest --json assets -q '.assets[].name'); do
+            case "$a" in
+              monoruby-latest-x86_64-unknown-linux-gnu.tar.gz) ;;
+              *) gh release delete-asset latest "$a" -y ;;
+            esac
+          done
+
   build:
     needs: prepare-latest
     # Run when prepare-latest succeeded (push) or was skipped (release /
@@ -77,12 +104,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # ubuntu-22.04 keeps the glibc floor low enough for every
-          # currently-hosted Linux runner image.
-          - os: ubuntu-22.04
-          - os: ubuntu-22.04-arm
-          - os: macos-latest # arm64-apple-darwin
+        # Automatic triggers (push / release) build x86-64 Linux only;
+        # workflow_dispatch picks runners from its `targets` input.
+        # ubuntu-22.04 keeps the glibc floor low enough for every
+        # currently-hosted Linux runner image; macos-latest is
+        # arm64-apple-darwin.
+        os: ${{ fromJSON(
+          github.event_name != 'workflow_dispatch' && '["ubuntu-22.04"]'
+          || inputs.targets == 'x86_64-linux'      && '["ubuntu-22.04"]'
+          || inputs.targets == 'aarch64-linux'     && '["ubuntu-22.04-arm"]'
+          || inputs.targets == 'aarch64-macos'     && '["macos-latest"]'
+          ||                                          '["ubuntu-22.04", "ubuntu-22.04-arm", "macos-latest"]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:

--- a/.github/workflows/setup-monoruby.yml
+++ b/.github/workflows/setup-monoruby.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Report action outputs
         run: |
+          echo "prebuilt:         ${{ steps.setup.outputs.prebuilt }}"
           echo "cache-hit:        ${{ steps.setup.outputs.cache-hit }}"
           echo "monoruby-version: ${{ steps.setup.outputs.monoruby-version }}"
           echo "ruby-version:     ${{ steps.setup.outputs.ruby-version }}"

--- a/README.md
+++ b/README.md
@@ -75,26 +75,28 @@ steps:
   - run: monoruby my_script.rb
 ```
 
-For release tags, the action first tries to download a prebuilt binary
-attached to that GitHub release (built by the `release binaries` workflow),
-which installs in seconds. When no asset exists for the tag/platform — or the
-ref is a branch or SHA — it falls back to building monoruby from source on the
-first run for each monoruby revision × runner OS/arch and caches the resulting
-binary and runtime tree with `actions/cache`, so subsequent runs restore in
-seconds. Pinning a release tag keeps the cache stable; tracking `@master`
-rebuilds on every upstream push. Linux (x64/arm64) and macOS (Apple Silicon)
-hosted runners are supported.
+The action first tries to download a prebuilt binary attached to a GitHub
+release (built by the `release binaries` workflow), which installs in seconds:
+release tags use their own release's assets, while `@master` / `@latest` use
+the rolling `latest` nightly prerelease, whose assets are rebuilt on every
+master push (so they can lag a just-pushed HEAD by one build, ~15 min). When
+no asset exists for the ref/platform — or `prefer-prebuilt: 'false'` is set —
+it falls back to building monoruby from source on the first run for each
+monoruby revision × runner OS/arch and caches the resulting binary and runtime
+tree with `actions/cache`, so subsequent runs restore in seconds. Linux
+(x64/arm64) and macOS (Apple Silicon) hosted runners are supported.
 
 Inputs and outputs:
 
-| Name                     | Kind   | Description                                                     |
-| ------------------------ | ------ | --------------------------------------------------------------- |
-| `cache` (`'true'`)       | input  | Set to `'false'` to always build from source                    |
-| `cache-version` (`'v1'`) | input  | Mixed into the cache key; bump to discard existing caches       |
-| `prebuilt`               | output | `'true'` if a prebuilt release asset was used                   |
-| `cache-hit`              | output | `'true'` if the built binary was restored from cache            |
-| `monoruby-version`       | output | Output of `monoruby --version`                                  |
-| `ruby-version`           | output | `RUBY_VERSION` reported by the installed monoruby               |
+| Name                        | Kind   | Description                                                            |
+| --------------------------- | ------ | ---------------------------------------------------------------------- |
+| `prefer-prebuilt` (`'true'`)| input  | Set to `'false'` to skip release assets and build the exact ref        |
+| `cache` (`'true'`)          | input  | Set to `'false'` to disable the source-build cache                     |
+| `cache-version` (`'v1'`)    | input  | Mixed into the cache key; bump to discard existing caches              |
+| `prebuilt`                  | output | `'true'` if a prebuilt release asset was used                          |
+| `cache-hit`                 | output | `'true'` if the built binary was restored from cache                   |
+| `monoruby-version`          | output | Output of `monoruby --version`                                         |
+| `ruby-version`              | output | `RUBY_VERSION` reported by the installed monoruby                      |
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,15 @@ steps:
   - run: monoruby my_script.rb
 ```
 
-Since no prebuilt binaries are published yet, the action builds monoruby from
-source on the first run for each monoruby revision × runner OS/arch and caches
-the resulting binary and runtime tree with `actions/cache`, so subsequent runs
-restore in seconds. Pinning a release tag keeps the cache stable; tracking
-`@master` rebuilds on every upstream push. Linux (x64/arm64) and macOS
-(Apple Silicon) hosted runners are supported.
+For release tags, the action first tries to download a prebuilt binary
+attached to that GitHub release (built by the `release binaries` workflow),
+which installs in seconds. When no asset exists for the tag/platform — or the
+ref is a branch or SHA — it falls back to building monoruby from source on the
+first run for each monoruby revision × runner OS/arch and caches the resulting
+binary and runtime tree with `actions/cache`, so subsequent runs restore in
+seconds. Pinning a release tag keeps the cache stable; tracking `@master`
+rebuilds on every upstream push. Linux (x64/arm64) and macOS (Apple Silicon)
+hosted runners are supported.
 
 Inputs and outputs:
 
@@ -88,7 +91,8 @@ Inputs and outputs:
 | ------------------------ | ------ | --------------------------------------------------------------- |
 | `cache` (`'true'`)       | input  | Set to `'false'` to always build from source                    |
 | `cache-version` (`'v1'`) | input  | Mixed into the cache key; bump to discard existing caches       |
-| `cache-hit`              | output | `'true'` if the binary was restored from cache                  |
+| `prebuilt`               | output | `'true'` if a prebuilt release asset was used                   |
+| `cache-hit`              | output | `'true'` if the built binary was restored from cache            |
 | `monoruby-version`       | output | Output of `monoruby --version`                                  |
 | `ruby-version`           | output | `RUBY_VERSION` reported by the installed monoruby               |
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ steps:
 The action first tries to download a prebuilt binary attached to a GitHub
 release (built by the `release binaries` workflow), which installs in seconds:
 release tags use their own release's assets, while `@master` / `@latest` use
-the rolling `latest` nightly prerelease, whose assets are rebuilt on every
-master push (so they can lag a just-pushed HEAD by one build, ~15 min). When
-no asset exists for the ref/platform — or `prefer-prebuilt: 'false'` is set —
-it falls back to building monoruby from source on the first run for each
-monoruby revision × runner OS/arch and caches the resulting binary and runtime
-tree with `actions/cache`, so subsequent runs restore in seconds. Linux
-(x64/arm64) and macOS (Apple Silicon) hosted runners are supported.
+the rolling `latest` nightly prerelease, rebuilt on every master push (so it
+can lag a just-pushed HEAD by one build, ~15 min). Automatic builds cover
+x86-64 Linux only; assets for Linux arm64 and macOS arm64 are published on
+demand by dispatching the `release binaries` workflow with the wanted tag and
+targets. When no asset exists for the ref/platform — or
+`prefer-prebuilt: 'false'` is set — the action falls back to building monoruby
+from source on the first run for each monoruby revision × runner OS/arch and
+caches the resulting binary and runtime tree with `actions/cache`, so
+subsequent runs restore in seconds. Linux (x64/arm64) and macOS (Apple
+Silicon) hosted runners are supported either way.
 
 Inputs and outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,21 @@
 #     - uses: sisshiki1969/monoruby@v3.0.1   # or @master for the latest
 #     - run: monoruby my_script.rb
 #
-# No prebuilt binaries are published yet, so the action builds monoruby from
-# the very source tree GitHub checked out for the action itself
-# (`$GITHUB_ACTION_PATH`) and installs it with `cargo install`. The built
-# binary and its runtime tree (`~/.monoruby/v*`, laid down by build.rs) are
-# cached keyed on the source fingerprint, so only the first run for a given
-# monoruby revision × runner OS/arch pays the compile time (~10-20 min);
-# subsequent runs restore in seconds. Pinning a tag keeps the cache stable;
-# tracking `@master` rebuilds on every upstream push.
+# Install strategy, in order:
+#
+# 1. Prebuilt release asset — when the action ref is a release tag (v*), try
+#    downloading monoruby-<tag>-<target>.tar.gz from that GitHub release
+#    (uploaded by .github/workflows/release-binaries.yml). Extraction takes
+#    seconds and needs no toolchain.
+# 2. Source build with caching — otherwise (branch/SHA refs, releases
+#    without assets for this platform, or a failed download), build monoruby
+#    from the very source tree GitHub checked out for the action itself
+#    (`$GITHUB_ACTION_PATH`) and install it with `cargo install`. The built
+#    binary and its runtime tree (`~/.monoruby/v*`, laid down by build.rs)
+#    are cached keyed on the source fingerprint, so only the first run for a
+#    given monoruby revision × runner OS/arch pays the compile time;
+#    subsequent runs restore in seconds. Pinning a tag keeps the cache
+#    stable; tracking `@master` rebuilds on every upstream push.
 #
 # Works on Linux (x64/arm64) and macOS (Apple Silicon) hosted runners. The
 # runner needs `rustup` and (on macOS) Homebrew, both preinstalled on GitHub
@@ -43,10 +50,15 @@ inputs:
     default: "v1"
 
 outputs:
+  prebuilt:
+    description: >
+      'true' if a prebuilt release asset was downloaded instead of building
+      from source.
+    value: ${{ steps.prebuilt.outputs.ok }}
   cache-hit:
     description: >
-      'true' if the prebuilt binary was restored from cache ('' when caching
-      is disabled).
+      'true' if the built binary was restored from cache ('' when caching is
+      disabled or a prebuilt asset was used).
     value: ${{ steps.cache.outputs.cache-hit }}
   monoruby-version:
     description: The installed monoruby crate version (output of `monoruby --version`).
@@ -58,7 +70,61 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Try prebuilt release asset
+      id: prebuilt
+      shell: bash
+      env:
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPO: ${{ github.action_repository }}
+      run: |
+        set -euo pipefail
+        ok=false
+        repo="${ACTION_REPO:-sisshiki1969/monoruby}"
+
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          Linux-X64)    target=x86_64-unknown-linux-gnu ;;
+          Linux-ARM64)  target=aarch64-unknown-linux-gnu ;;
+          macOS-ARM64)  target=aarch64-apple-darwin ;;
+          macOS-X64)    target=x86_64-apple-darwin ;;
+          *)            target= ;;
+        esac
+
+        # Only release tags have assets; branch/SHA refs go straight to the
+        # source build. A missing asset (older release, unbuilt platform)
+        # 404s and falls through the same way.
+        if [[ -n "$target" && "${ACTION_REF:-}" =~ ^v[0-9] ]]; then
+          asset="monoruby-${ACTION_REF}-${target}.tar.gz"
+          url="https://github.com/${repo}/releases/download/${ACTION_REF}/${asset}"
+          tmp="$RUNNER_TEMP/setup-monoruby-prebuilt"
+          mkdir -p "$tmp"
+          echo "Trying prebuilt asset: $url"
+          if curl -fsSL --retry 3 -o "$tmp/$asset" "$url"; then
+            tar -C "$tmp" -xzf "$tmp/$asset"
+            mkdir -p "$HOME/.cargo/bin" "$HOME/.monoruby"
+            install -m 755 "$tmp/bin/monoruby" "$HOME/.cargo/bin/monoruby"
+            install -m 755 "$tmp/bin/irm" "$HOME/.cargo/bin/irm"
+            cp -R "$tmp"/monoruby-home/v* "$HOME/.monoruby/"
+            vdir=$(basename "$tmp"/monoruby-home/v*)
+            # Relocate the baked install root to this machine's tree (a
+            # runtime override; no-op on binaries predating it, which rely
+            # on hosted runners sharing the same $HOME per OS instead).
+            export MONORUBY_INSTALL_ROOT="$HOME/.monoruby/$vdir"
+            if out=$("$HOME/.cargo/bin/monoruby" -e 'require "json"; puts 1' 2>/dev/null) \
+               && [[ "$out" == "1" ]]; then
+              echo "MONORUBY_INSTALL_ROOT=$MONORUBY_INSTALL_ROOT" >> "$GITHUB_ENV"
+              ok=true
+              echo "Prebuilt asset works; skipping source build."
+            else
+              echo "Prebuilt asset failed its sanity check; falling back to source build."
+            fi
+          else
+            echo "No prebuilt asset for this release/platform; falling back to source build."
+          fi
+        fi
+        echo "ok=$ok" >> "$GITHUB_OUTPUT"
+
     - name: Compute source fingerprint
+      if: steps.prebuilt.outputs.ok != 'true'
       id: key
       shell: bash
       run: |
@@ -80,7 +146,7 @@ runs:
 
     - name: Restore cached monoruby
       id: cache
-      if: inputs.cache == 'true'
+      if: inputs.cache == 'true' && steps.prebuilt.outputs.ok != 'true'
       uses: actions/cache@v4
       with:
         # ~/.monoruby/v* is the per-version runtime tree (vendored stdlib +
@@ -95,7 +161,7 @@ runs:
         key: setup-monoruby-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.key.outputs.fingerprint }}
 
     - name: Build and install monoruby
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.prebuilt.outputs.ok != 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,14 @@
 #
 # 1. Prebuilt release asset — when the action ref is a release tag (v*), try
 #    downloading monoruby-<tag>-<target>.tar.gz from that GitHub release
-#    (uploaded by .github/workflows/release-binaries.yml). Extraction takes
-#    seconds and needs no toolchain.
-# 2. Source build with caching — otherwise (branch/SHA refs, releases
+#    (uploaded by .github/workflows/release-binaries.yml). `@master` and
+#    `@latest` map to the rolling `latest` nightly prerelease, whose assets
+#    are replaced on every master push — so a `@master` consumer gets the
+#    most recent nightly binary, which can lag the just-pushed HEAD by one
+#    build (~15 min). Extraction takes seconds and needs no toolchain; set
+#    the `prefer-prebuilt: 'false'` input to skip this tier and build the
+#    exact checked-out ref instead.
+# 2. Source build with caching — otherwise (other branch/SHA refs, releases
 #    without assets for this platform, or a failed download), build monoruby
 #    from the very source tree GitHub checked out for the action itself
 #    (`$GITHUB_ACTION_PATH`) and install it with `cargo install`. The built
@@ -36,6 +41,13 @@ branding:
   color: "red"
 
 inputs:
+  prefer-prebuilt:
+    description: >
+      Try a prebuilt release asset before building from source. Set to
+      'false' to always build the exact checked-out ref (e.g. when `@master`
+      must not lag behind the rolling nightly binary).
+    required: false
+    default: "true"
   cache:
     description: >
       Cache the built monoruby binary and its runtime tree with actions/cache.
@@ -76,6 +88,7 @@ runs:
       env:
         ACTION_REF: ${{ github.action_ref }}
         ACTION_REPO: ${{ github.action_repository }}
+        PREFER_PREBUILT: ${{ inputs.prefer-prebuilt }}
       run: |
         set -euo pipefail
         ok=false
@@ -89,12 +102,21 @@ runs:
           *)            target= ;;
         esac
 
-        # Only release tags have assets; branch/SHA refs go straight to the
-        # source build. A missing asset (older release, unbuilt platform)
-        # 404s and falls through the same way.
-        if [[ -n "$target" && "${ACTION_REF:-}" =~ ^v[0-9] ]]; then
-          asset="monoruby-${ACTION_REF}-${target}.tar.gz"
-          url="https://github.com/${repo}/releases/download/${ACTION_REF}/${asset}"
+        # Map the action ref to a release tag carrying assets: release tags
+        # map to themselves, master/latest to the rolling `latest` nightly
+        # prerelease (replaced on every master push). Other branch/SHA refs
+        # go straight to the source build, as does a missing asset (older
+        # release, unbuilt platform), which 404s and falls through.
+        tag=
+        if [[ "${ACTION_REF:-}" =~ ^v[0-9] ]]; then
+          tag="$ACTION_REF"
+        elif [[ "${ACTION_REF:-}" == "master" || "${ACTION_REF:-}" == "latest" ]]; then
+          tag="latest"
+        fi
+
+        if [[ "$PREFER_PREBUILT" == "true" && -n "$target" && -n "$tag" ]]; then
+          asset="monoruby-${tag}-${target}.tar.gz"
+          url="https://github.com/${repo}/releases/download/${tag}/${asset}"
           tmp="$RUNNER_TEMP/setup-monoruby-prebuilt"
           mkdir -p "$tmp"
           echo "Trying prebuilt asset: $url"

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -47,8 +47,18 @@ pub static WARNING: std::sync::LazyLock<AtomicU8> = std::sync::LazyLock::new(|| 
 /// builds and multiple checkouts from clobbering one shared tree. The
 /// host-derived runtime caches (`library_path` / `gem_path`) live at the
 /// top-level `~/.monoruby/` instead, since they are version-independent.
+///
+/// The baked path embeds the *build* machine's `$HOME`, so a prebuilt
+/// binary running under a different home (distributed release binaries,
+/// containers) would point at a tree that doesn't exist there. Setting
+/// `MONORUBY_INSTALL_ROOT` in the *runtime* environment overrides the
+/// baked path and makes the binary relocatable: point it at wherever the
+/// matching `v<version>` tree was extracted.
 pub(crate) fn install_root() -> PathBuf {
-    PathBuf::from(env!("MONORUBY_INSTALL_ROOT"))
+    match std::env::var_os("MONORUBY_INSTALL_ROOT") {
+        Some(root) if !root.is_empty() => PathBuf::from(root),
+        _ => PathBuf::from(env!("MONORUBY_INSTALL_ROOT")),
+    }
 }
 
 pub(crate) fn ruby_platform() -> &'static str {

--- a/monoruby/tests/install_root.rs
+++ b/monoruby/tests/install_root.rs
@@ -1,0 +1,55 @@
+//! The runtime `MONORUBY_INSTALL_ROOT` override (see `globals::install_root`)
+//! that makes distributed binaries relocatable: it must take precedence over
+//! the build-time baked path, while an unset or empty variable keeps the
+//! baked-path behaviour. Exercised through the built binary with a
+//! per-child environment, so the test process's own env is never mutated
+//! (spawned interpreters in parallel tests read it).
+
+use std::process::Command;
+
+/// `require` something from the vendored stdlib tree; only resolvable when
+/// the install root actually points at an installed `v<version>` tree.
+fn require_json(install_root: Option<&str>) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    cmd.args(["-e", r#"require "json"; puts JSON.generate({"ok" => 1})"#]);
+    if let Some(root) = install_root {
+        cmd.env("MONORUBY_INSTALL_ROOT", root);
+    } else {
+        cmd.env_remove("MONORUBY_INSTALL_ROOT");
+    }
+    cmd.output().unwrap()
+}
+
+fn assert_ok(out: &std::process::Output, case: &str) {
+    assert!(out.status.success(), "{case}: {out:?}");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "{\"ok\":1}\n", "{case}");
+}
+
+#[test]
+fn baked_path_used_when_env_unset() {
+    assert_ok(&require_json(None), "unset env should use the baked path");
+}
+
+#[test]
+fn empty_env_is_ignored() {
+    assert_ok(&require_json(Some("")), "empty env should use the baked path");
+}
+
+#[test]
+fn env_override_is_honoured() {
+    // Pointing the override at the installed tree explicitly must work
+    // (the env-var arm, not the baked default)…
+    let baked = env!("MONORUBY_INSTALL_ROOT");
+    assert_ok(
+        &require_json(Some(baked)),
+        "explicit valid override should resolve requires",
+    );
+
+    // …and pointing it somewhere bogus must actually be honoured, i.e. the
+    // stdlib becomes unresolvable instead of silently falling back.
+    let out = require_json(Some("/nonexistent/monoruby-install-root"));
+    assert!(
+        !out.status.success(),
+        "bogus override must not fall back to the baked path: {out:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #884: the `setup-monoruby` action now installs **prebuilt binaries in seconds** instead of compiling, whenever a matching release asset exists, with the cached source build kept as the automatic fallback.

```yaml
- uses: sisshiki1969/monoruby@master   # rolling nightly asset
- uses: sisshiki1969/monoruby@v3.0.2   # that release's asset
```

## How it works

**New workflow `.github/workflows/release-binaries.yml`** publishes `monoruby-<tag>-<target>.tar.gz` assets (binaries + the `~/.monoruby/v<version>` runtime tree, sanity-checked post-packaging by extracting to a fresh location and requiring `json`):

- **Rolling nightly** — every master push force-moves the `latest` tag, upserts the "Nightly build (latest master)" prerelease, and replaces its asset. A concurrency group cancels an in-flight nightly when a newer push lands; nightly builds pin the pushed SHA, not the moving tag.
- **Releases** — publishing a release builds assets for its tag; `workflow_dispatch` backfills existing tags.
- **Automatic builds are x86-64 Linux only** (one runner per push). Linux arm64 / macOS arm64 assets are built on demand via `workflow_dispatch` (`targets` input: all / x86_64-linux / aarch64-linux / aarch64-macos). Each nightly deletes stale other-arch assets left by earlier dispatches so an old binary is never served for a new commit — those platforms fall back to the source build until re-dispatched.

**`action.yml`** gains a first install tier: release-tag refs download their own release's asset, `@master`/`@latest` download the nightly, everything else (other branches, SHAs, missing assets, failed sanity check) falls through to the existing fingerprint-cached source build. New input `prefer-prebuilt: 'false'` forces building the exact checked-out ref (a nightly asset can lag a just-pushed HEAD by one build, ~15 min); new output `prebuilt` reports which tier ran.

**One small runtime change (`globals.rs`)**: `install_root()` now honours a runtime `MONORUBY_INSTALL_ROOT` env var over the build-time baked path (which embeds the build machine's `$HOME`), making distributed binaries relocatable; the action exports it to point at the extracted tree. Empty/unset values keep the baked-path behaviour, so existing usage is unchanged.

## Verification

- Built locally with the pinned nightly and exercised the override: unset/empty env keeps today's behaviour, a bogus path fails `require` (proving the override is honoured), and a packaged tarball extracted to a different location **with the original tree removed** still passes `require "json"` via the override.
- Unit-tested the ref→tag mapping (`v3.0.1`→itself, `master`/`latest`→`latest`, `main`/SHA/other branches→source build).
- Validated all workflow YAML, including the multiline `fromJSON` matrix expression evaluating to the right runner set per trigger/target selection.

After merging: the first master push will create the `latest` prerelease and its x86-64 Linux asset automatically; dispatch `release binaries` with a tag + targets to add other architectures or backfill existing releases (e.g. `v3.0.1` — note pre-override binaries rely on hosted runners' shared `$HOME`, which the sanity check enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kt9S3FqhZ2aX6zHfxZzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kt9S3FqhZ2aX6zHfxZzL)_