### PR TITLE
super resolves the called name and chain occurrence via the cont-frame pc

### DIFF
--- a/doc/super_resolution.md
+++ b/doc/super_resolution.md
@@ -1,0 +1,305 @@
+# super のメソッド名解決と呼び出し元 PC を用いた実装
+
+`super` は「いま実行中のメソッドと**同じ名前**のメソッドを、祖先チェーンの
+**現在位置より先**から探して呼ぶ」命令である。単純に見えるが、「同じ名前とは
+どの名前か」「現在位置とはどこか」の 2 点が自明でなく、CRuby は両方をメソッド
+エントリ(callable method entry)に持たせて解決している。monoruby はフレームに
+メソッドエントリを持たない(FuncId しか持たない)ため、同じ情報を
+**呼び出し元 PC(cont-frame スロット)から復元**する。本書はその機構を説明する。
+
+対象ソース:
+
+- `monoruby/src/codegen/runtime.rs` — `entered_by` / `super_run` /
+  `super_resolution` / `find_super` / `defined_super` / `find_method`
+- `monoruby/src/globals/store/class.rs` — `body_dispatched_by` /
+  `super_occurrences` / `check_super` / `check_super_at` /
+  `change_method_visibility_for_class`
+- `monoruby/src/globals/store.rs` — `MethodTableEntry`
+- `monoruby/src/codegen/jitgen/compile/method_call.rs` — JIT 側の
+  ambiguous-super ガード
+
+---
+
+## 1. CRuby の意味論
+
+CRuby では、メソッド呼び出しのたびに **callable method entry (cme)** が
+フレームに紐付く。cme は以下を保持する:
+
+| フィールド | 意味 | super での役割 |
+|---|---|---|
+| `called_id` | 呼び出しに使われた名前 | (直接は使わない) |
+| `def->original_id` | 定義時の名前 | **super はこの名前で検索する** |
+| `defined_class` | メソッドが見つかった ICLASS(チェーン上の位置) | **この位置の直後から検索を始める** |
+
+この 2 つの情報がどう効くかを、問題になるケースごとに見る。
+
+### 1.1 一つの本体が複数の名前を持つ場合(define_method)
+
+```ruby
+sub = Class.new(sup) do
+  [:a, :b].each do |name|
+    define_method(name) { super() }
+  end
+end
+```
+
+`define_method` は呼び出しごとに**独立したメソッドエントリ**を作る
+(`original_id` はそれぞれ `:a` / `:b`)。ブロック本体は共有されていても、
+`sub.new.a` の super は `:a` を、`sub.new.b` の super は `:b` を検索する。
+つまり super の検索名は「本体に焼き付いた名前」ではなく
+「**その呼び出しでディスパッチされたエントリの original_id**」である。
+
+### 1.2 alias の場合
+
+```ruby
+class Alias3 < Alias2
+  alias_method :name3, :name   # Alias2#name を :name3 として登録
+end
+Alias3.new.name3   # 中の super は :name で検索される
+```
+
+alias が作るエントリは `original_id = :name` を保持する。`name3` で呼ばれても
+super は **元の定義名 `:name`** で検索する。さらに `defined_class` は
+**元の定義位置(Alias2)** を指すため、super は Alias2 の直後
+(= Alias1)から探し始める。alias を登録した Alias3 は位置として数えない。
+
+### 1.3 同じ本体がチェーンに複数回現れる場合
+
+```ruby
+class Base
+  def self.whatever
+    mod = Module.new do
+      def a(ary); ary << "anon"; super; end
+    end
+    include mod
+  end
+  def a(ary); ary << "non-anon"; end
+end
+class Twice < Base
+  whatever   # 匿名モジュール 1 個目
+  whatever   # 2 個目(同じ `def a` バイトコードの再実行)
+end
+Twice.new.a([])  #=> ["anon", "anon", "non-anon"]
+```
+
+チェーンは `Twice → mod2 → mod1 → Base`。mod2#a の super は mod1#a
+(**同じ本体!**)を呼び、mod1#a の super が Base#a を呼ぶ。CRuby では各
+フレームの cme が異なる `defined_class`(mod2 の ICLASS / mod1 の ICLASS)を
+持つため、同じ本体でも「チェーン上のどの出現か」を区別できる。
+
+### 1.4 可視性の再宣言は「位置」ではない
+
+```ruby
+class C
+  include A   # private def derp(msg)
+  include B   # private def derp; super('...'); end
+  public :derp
+end
+```
+
+`public :derp` は C に **ZSUPER メソッドエントリ**(可視性だけを上書きする
+委譲エントリ)を作る。これは定義ではないので、B#derp の super の起点は
+あくまで B の位置であり、C を位置として数えて B 自身へ再入してはならない。
+
+---
+
+## 2. monoruby の表現とギャップ
+
+monoruby のフレーム(LFP/CFP)が持つメソッド識別情報は **FuncId のみ**である。
+`FuncInfo` には名前が 1 つ焼き付く(`FuncInfo::name()`)が、これは
+「最初に登録されたときの名前」であり、上記 1.1〜1.3 の情報をすべて失う:
+
+- define_method で複数名に登録された本体 → 名前は最初の 1 つだけ
+- 同じ `def` バイトコードの再実行 → 同一 FuncId がチェーンの複数位置に登録
+  され、フレームからはどの出現か分からない
+- alias → FuncId は共有(エントリ側に `original_name` は残る)
+
+一方、メソッドテーブル側(`MethodTableEntry`)には必要な情報が揃っている:
+
+```rust
+pub(crate) struct MethodTableEntry {
+    owner: ClassId,
+    func_id: Option<FuncId>,
+    visibility: Visibility,
+    is_basic_op: bool,
+    original_name: IdentId,     // alias / define_method(Method) 経由の元定義名
+    visibility_shadow: bool,    // `public :inherited` 型の可視性シャドウ
+}
+```
+
+欠けているのは「**このフレームはどのエントリでディスパッチされたか**」という
+動的情報だけである。これを呼び出し元 PC から復元する。
+
+---
+
+## 3. 呼び出し元 PC(cont-frame スロット)
+
+### 3.1 スロットの位置と書き込み
+
+すべての呼び出しで、callee フレームの **CFP+24**(`Cfp::caller_pc_slot`,
+`executor/frame.rs`)に「呼び出し元の**コールサイト**のバイトコード PC」が
+入る。書き込み経路は 3 つ:
+
+1. **VM tier** — `push_cont_frame`(`arch/x86_64/vmgen/method_call.rs`):
+   `subq rsp, 8; pushq r13; subq [rsp], 16`。ディスパッチ時の r13 は
+   コールサイト + 16(send は 2 バイトコード単位 = 32 バイト)なので
+   16 を引いてコールサイト先頭を保存する。aarch64 は最初からコールサイト PC を
+   保存する。
+2. **JIT tier**(#889) — cont-frame 16 バイト領域は cont モードの
+   `FprSave` が予約済み(xmm 退避はその上に置かれる)なので、
+   `AsmInst::ContFramePc` が `movq [rsp], pc`(a64: `str x10, [sp]`)を
+   send / specialized send / yield / specialized yield の 4 箇所すべてで発行する。
+3. **invoker / native 経路** — 書かれない(ゴミが残る)。読む側が必ず検証する。
+
+### 3.2 読み出しと検証
+
+読み手(`Kernel#caller` と本機構)は共通のパターンで検証する
+(`runtime.rs::entered_by`):
+
+```
+slot != 0 かつ slot % 8 == 0
+→ BytecodePtr として解釈
+→ 呼び出し元フレーム(cfp.prev())の iseq の範囲内か(contains_pc)
+→ その位置のオペコードが send 系か
+```
+
+send 系オペコード(`bytecodegen/encode.rs`):
+
+| opcode | 命令 |
+|---|---|
+| 30 / 31 | メソッド呼び出し(simple / generic) |
+| 32 / 33 | **super** |
+| 34 / 35 | yield |
+
+30〜33 の第 1 ワード下位 32 ビットが **CallSiteId** であり、
+`CallSiteInfo::name` から「**呼び出しに使われた名前**」が得られる。
+検証に失敗した場合(invoker 境界など)は `None` を返し、後述の
+フォールバックに落ちる。
+
+---
+
+## 4. 解決アルゴリズム(`find_super`)
+
+`super` 実行時、ランタイムは次の 2 つを復元する
+(`runtime.rs::super_resolution`)。
+
+### 4.1 呼び出し名の復元 → original_name への写像
+
+1. メソッドフレームを特定する。ブロック内の super は外側メソッドに属するため、
+   `lfp.outermost()`(proc-method 境界で停止する外側連鎖)でメソッド LFP を
+   求め、その LFP を実行している CFP まで下る。
+2. そのフレームの cont-frame スロットを `entered_by` で復号し、通常 send
+   (opcode 30/31)なら CallSiteId → `CallSiteInfo::name` =
+   **呼ばれた名前** を得る。
+3. 呼ばれた名前をレシーバクラスのメソッドテーブルで引き、
+   **そのエントリが本当にこのフレームの本体へディスパッチするか**検証する:
+   - `entry.func_id == 実行中 FuncId`、または
+   - エントリが proc-method ラッパー(`FuncKind::Proc`)で
+     `proc.func_id() == 実行中 FuncId`
+     (define_method はラッパー FuncId を登録するが、実行フレームには
+     ブロック本体の FuncId が乗るため)。
+4. 検証に通れば **`entry.original_name`** を検索名とする。これで
+   define_method 複数名(1.1: original_name = 各インストール名)と
+   alias(1.2: original_name = 元定義名)の両方が CRuby と一致する。
+5. 復元できない場合は従来どおり `FuncInfo::name()`(焼き付け名)に
+   フォールバックする。
+
+### 4.2 出現インデックス(occurrence)の復元
+
+同じ本体がチェーンに複数回現れるケース(1.3)のために、
+「このフレームはその本体の**何番目の出現**か」を数える
+(`runtime.rs::super_run`):
+
+```
+k = 1, cfp = メソッドフレーム
+loop:
+  entered_by(cfp) が super オペコード(32/33)で、かつ
+  呼び出し元フレームが 同じ本体(method_func_id 一致)を
+  同じレシーバ(self 一致)で実行している
+    → k += 1 して呼び出し元へ(super 連鎖の 1 ホップ)
+  通常 send → 連鎖の底。 (k, そのコールサイト, exact=true)
+  別本体からの super → (k, なし, exact=true)
+  復号失敗 → (k, なし, exact=false)
+```
+
+super 連鎖であることをオペコードで確認するのが重要で、単なる再帰呼び出し
+(`obj.a` を a の中から呼ぶ)は連鎖を切る。再帰はディスパッチをチェーン先頭から
+やり直すので、出現カウントもリセットされるのが正しい。
+
+### 4.3 チェーン検索(`check_super_at`)
+
+```rust
+check_super_at(self_class, current_fid, name, occurrence: Option<usize>)
+```
+
+チェーンを歩き、**定義位置**を `body_dispatched_by` で判定する:
+
+> クラス/モジュール m の**自身の**メソッドテーブルが `name` を実行中本体へ
+> ディスパッチする(直接、または proc-method ラッパー経由)。ただし
+> `visibility_shadow` エントリは除外。
+
+- 名前で引く(FuncId の登録位置全部ではなく)ことで alias 登録先(1.2)を
+  位置から除外する。
+- `visibility_shadow` の除外が 1.4 に対応する。owner 登録の有無では判定
+  できない(同じクラスへの `alias_method` が owner を汚染するため)。
+
+`occurrence = Some(k)` なら **k 番目**の定義位置から先を検索し、見つかった
+ものを(**同一 FuncId でも**)返す — これが 1.3 の「同じ本体へ super する」
+挙動である。`None`(復号失敗時)なら従来のヒューリスティック
+「同一 FuncId が見つかったら次の出現まで歩き続ける」で前進を保証する。
+
+名前ベースの位置が 1 つも見つからない場合(stale な可視性シャドウが
+差し替え済みの旧本体をディスパッチした場合など)は、#890 以前の
+**owner 登録ベースの走査**にフォールバックし、それも失敗したら
+レシーバクラスからの直接検索(UnboundMethod#bind 対応)を試す。
+
+---
+
+## 5. キャッシュとの整合
+
+super の解決結果はコールサイトのインラインキャッシュに
+(レシーバクラス, FuncId) で刻まれるが、上記のとおり super の正解は
+**フレーム依存**になり得る(同一コールサイト・同一レシーバクラスでも、
+呼び名や出現位置で行き先が変わる)。そのため:
+
+- **VM**: `find_super` が cacheable フラグを返す。
+  `!is_block_style && super_occurrences(...) <= 1` のときだけキャッシュ可。
+  不可なら `find_method` はキャッシュタグに **ClassId 0** を返す
+  (`ClassId` は `NonZeroU32` なので実クラスと一致せず、そのサイトは
+  毎回スローパスで再解決される)。
+- **JIT**(`jitgen/compile/method_call.rs`): コンパイル時に同じ条件
+  (mother FuncId が block-style、または出現数 > 1)を検出したら、その
+  super サイトは **plain-deopt**(VM 実行)にする。`Recompile` にすると
+  VM がキャッシュを温めない(タグ 0)ため再コンパイルが収束しない。
+- コンパイル時/キャッシュ更新用の `check_super`(3 引数版)は、出現数 > 1
+  なら `None` を返して辞退する。
+
+`defined?(super)` (`defined_super`) も同じ `super_resolution` +
+`check_super_at` を使い、実行時セマンティクスと一致させている。
+
+---
+
+## 6. 既知の限界
+
+- **invoker 境界**: `Method#call` / `send` / Fiber などで入ったフレームは
+  cont-frame スロットが無効なので、呼び出し名の復元も出現カウントも
+  フォールバックに落ちる(焼き付け名 + 旧ヒューリスティック)。
+  define_method 複数名のメソッドを `send` で呼ぶと、super の検索名は
+  焼き付け名になる。
+- **可視性シャドウの staleness**: `public :derp` はシャドウエントリに
+  継承先の FuncId をコピーするため、その後に継承元が再定義されると
+  シャドウが旧本体をディスパッチする(CRuby の ZSUPER エントリは委譲なので
+  この問題がない)。可視性を再宣言すればスーパークラス解決で再同期される。
+  super 解決側は owner-walk フォールバックで旧本体からでも前進できる。
+- 出現カウントは「連続する super 連鎖」を前提にしており、途中に
+  invoker 境界が挟まると `exact=false` となり旧ヒューリスティックに
+  切り替わる(過小カウントによる無限 super ループを防ぐため)。
+
+## 7. 関連 PR
+
+- #887 — VM tier がコールサイト PC を cont-frame スロットに保存、
+  `Kernel#caller` の行番号解決
+- #888 — specialized JIT 呼び出しの lazy 解決(#889 で置換)
+- #889 — JIT/specialized 呼び出しも eager にコールサイト PC を保存
+  (`AsmInst::ContFramePc`)
+- #890 — 本書の super 解決機構

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -18,6 +18,26 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let callsite = &self.store[callid];
         let recv_class = state.class(callsite.recv);
+        // A frame-dependent `super` site (the method body occupies several
+        // positions in the receiver's ancestor chain, or is a define_method
+        // block whose super name follows the called name) cannot be resolved
+        // to one target at compile time — and the VM never warms its inline
+        // cache for such sites (see `runtime::find_method`). Plain-deopt to
+        // the VM, which re-resolves per call; recompiling would never
+        // stabilize.
+        if callsite.name.is_none() {
+            let mother_fid = self.store[self.iseq().mother().0].func_id();
+            let ambiguous = self.store[mother_fid].is_block_style()
+                || match (recv_class, self.store[mother_fid].name()) {
+                    (Some(rc), Some(name)) => {
+                        self.store.super_occurrences(rc, mother_fid, name) > 1
+                    }
+                    _ => false,
+                };
+            if ambiguous {
+                return Ok(CompileResult::Deopt);
+            }
+        }
         let (recv_class, func_id) = if let Some(recv_class) = recv_class {
             // the receiver class is known.
             if let Some(func_id) = self.jit_check_call(recv_class, callsite.name) {

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -31,16 +31,30 @@ pub(super) extern "C" fn find_method(
     recv: Value,
 ) -> u64 {
     let name = globals[callid].name;
+    let mut cacheable = true;
     let fid = if let Some(func_name) = name {
         let is_func_call = globals[callid].is_func_call();
         vm.find_method(globals, recv, func_name, is_func_call)
     } else {
-        find_super(vm, globals, callid)
+        find_super(vm, globals, callid).map(|(fid, c)| {
+            cacheable = c;
+            fid
+        })
     }
     .map_err(|err| vm.set_error(err))
     .ok();
     if let Some(f) = fid {
         warn_unused_block(vm, globals, callid, f);
+    }
+    // A super target can be frame-dependent, not just receiver-class-
+    // dependent: when the method body occupies several positions in the
+    // receiver's ancestor chain (each occurrence supers to the next), or
+    // when the body is a define_method block (its super name follows the
+    // name the method was *called* under, and one body may be installed
+    // under several names). Tag the cache with 0 — never a valid ClassId
+    // — so the callsite re-resolves on every execution.
+    if !cacheable {
+        return fid.map_or(0, |f| f.get()) as u64;
     }
     let cache_class = {
         let ic_class = recv.class_for_ic();
@@ -154,7 +168,135 @@ fn strict_unused_block_category(vm: &mut Executor, globals: &mut Globals) -> boo
     }
 }
 
-fn find_super(vm: &mut Executor, globals: &mut Globals, callid: CallSiteId) -> Result<FuncId> {
+/// Classify the call instruction that created the frame `cfp`: read the
+/// frame's cont-frame slot (the caller's suspended call-site pc, written
+/// eagerly by both the VM and the JIT), validate it against the caller
+/// frame's bytecode span, and decode the send-family opcode there.
+///
+/// Returns `(is_super, callid)`, or `None` when the slot is absent or
+/// garbage (invoker boundary, native caller) or the instruction is not a
+/// send/super (e.g. a yield).
+fn entered_by(globals: &Globals, cfp: executor::Cfp) -> Option<(bool, CallSiteId)> {
+    let slot = cfp.caller_pc_slot();
+    if slot == 0 || slot % 8 != 0 {
+        return None;
+    }
+    let caller = cfp.prev()?;
+    let iseq = globals.store[caller.lfp().func_id()].is_iseq()?;
+    // SAFETY: validated against the bytecode span below.
+    let pc = unsafe { crate::bytecode::BytecodePtr::from_raw(slot as *mut _)? };
+    if !globals.store[iseq].contains_pc(pc) {
+        return None;
+    }
+    // Send-family opcodes (bytecodegen/encode.rs): 30/31 = method call,
+    // 32/33 = super, 34/35 = yield. op1's low 32 bits carry the CallSiteId.
+    match pc.opcode() {
+        30..=31 => Some((false, CallSiteId(pc.op1() as u32))),
+        32..=33 => Some((true, CallSiteId(pc.op1() as u32))),
+        _ => None,
+    }
+}
+
+/// The calling frame's 1-based position in the run of consecutive
+/// super-linked frames executing the same method body on the same
+/// receiver — i.e. which occurrence of the body in the receiver's
+/// ancestor chain this frame corresponds to — plus the send callsite
+/// that entered the bottom of the run.
+///
+/// Returns `(k, entry_callid, exact)`. `entry_callid` is `Some` only
+/// when the run's bottom frame was entered by a plain method call
+/// (its callsite name is the name the method was invoked under).
+/// `exact` is `false` when a link could not be decoded (invoker
+/// boundary etc.), in which case `k` is a lower bound and callers
+/// should fall back to frame-independent resolution.
+fn super_run(vm: &Executor, globals: &Globals, method_fid: FuncId) -> (usize, Option<CallSiteId>, bool) {
+    // `super` in a block resolves against the enclosing method: locate
+    // the frame executing the method body (the outermost lfp, stopping
+    // at a proc-method boundary, mirroring `method_func_id`).
+    let home = vm.cfp().lfp().outermost().0;
+    let mut cfp = vm.cfp();
+    while cfp.lfp() != home {
+        match cfp.prev() {
+            Some(prev) => cfp = prev,
+            None => return (1, None, false),
+        }
+    }
+    let self_val = home.self_val();
+    let mut k = 1;
+    loop {
+        match entered_by(globals, cfp) {
+            Some((true, _)) => {
+                // Entered via `super`. If the caller frame executes the
+                // same body on the same receiver, this frame is the next
+                // occurrence of that body in the ancestor chain.
+                let Some(caller) = cfp.prev() else {
+                    return (k, None, false);
+                };
+                if caller.method_func_id() == method_fid && caller.lfp().self_val() == self_val {
+                    k += 1;
+                    cfp = caller;
+                    continue;
+                }
+                // `super` from a different method (an ordinary super
+                // chain hop): the run ends here; the called name is not
+                // recoverable from this link.
+                return (k, None, true);
+            }
+            Some((false, callid)) => return (k, Some(callid), true),
+            None => return (k, None, false),
+        }
+    }
+}
+
+/// Resolve the name and chain position for a `super` dispatch from the
+/// current frame.
+///
+/// - The *name*: CRuby resolves `super` under the method entry's
+///   original name for the name the method was **called** with — which
+///   differs from the `FuncInfo`-stamped name when one body is
+///   installed under several names (`define_method` in a loop) or
+///   aliased. Recover the called name from the caller's callsite (via
+///   the cont-frame pc), map it through the method table (accepting a
+///   proc-method wrapper whose inner proc is the running body), and
+///   take that entry's original name. Falls back to the stamped name.
+/// - The *occurrence*: `Some(k)` when the frame's position among
+///   consecutive same-body super frames could be decoded exactly (see
+///   `super_run`), for positional resolution in `check_super_at`.
+fn super_resolution(
+    vm: &Executor,
+    globals: &Globals,
+    func_id: FuncId,
+    self_class: ClassId,
+) -> (IdentId, Option<usize>) {
+    let (k, entry_callid, exact) = super_run(vm, globals, func_id);
+    let func_name = entry_callid
+        .and_then(|callid| globals.store[callid].name)
+        .and_then(|called| {
+            let entry = globals.store.check_method_for_class(self_class, called)?;
+            let entry_fid = entry.func_id()?;
+            let dispatches_here = entry_fid == func_id
+                || matches!(&globals.store[entry_fid].kind,
+                    crate::globals::FuncKind::Proc(p) if p.func_id() == func_id);
+            if dispatches_here {
+                Some(entry.original_name())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| globals.store[func_id].name().unwrap());
+    (func_name, exact.then_some(k))
+}
+
+/// Resolve a `super` dispatch from the current frame. The second element
+/// of the result is whether the resolution is *frame-independent* (safe to
+/// stamp into the callsite's inline cache): false for a define_method body
+/// (the super name follows the called name) or a body occupying several
+/// ancestor-chain positions (each occurrence supers to a different target).
+fn find_super(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    callid: CallSiteId,
+) -> Result<(FuncId, bool)> {
     let func_id = vm.method_func_id();
     // zsuper (implicit-argument `super`) forwards the frame's
     // arguments by the *definition-time* parameter layout, which is
@@ -169,10 +311,18 @@ fn find_super(vm: &mut Executor, globals: &mut Globals, callid: CallSiteId) -> R
         ));
     }
     let self_val = vm.cfp().lfp().self_val();
-    let func_name = globals.store[func_id].name().unwrap();
     let self_class = self_val.class();
-    match globals.store.check_super(self_class, func_id, func_name) {
-        Some(func_id) => Ok(func_id),
+    let (func_name, occurrence) = super_resolution(vm, globals, func_id, self_class);
+    let cacheable = !globals.store[func_id].is_block_style()
+        && globals
+            .store
+            .super_occurrences(self_class, func_id, func_name)
+            <= 1;
+    match globals
+        .store
+        .check_super_at(self_class, func_id, func_name, occurrence)
+    {
+        Some(func_id) => Ok((func_id, cacheable)),
         None => Err(MonorubyErr::super_method_not_found(
             globals, func_name, self_val,
         )),
@@ -1687,9 +1837,12 @@ pub(super) extern "C" fn defined_method(
 pub(super) extern "C" fn defined_super(vm: &mut Executor, globals: &mut Globals) -> Value {
     let func_id = vm.method_func_id();
     let self_val = vm.cfp().lfp().self_val();
-    let name = globals.store[func_id].name().unwrap();
     let self_class = self_val.class();
-    if globals.check_super(self_class, func_id, name).is_some() {
+    let (name, occurrence) = super_resolution(vm, globals, func_id, self_class);
+    if globals
+        .check_super_at(self_class, func_id, name, occurrence)
+        .is_some()
+    {
         defined_frozen_str("super")
     } else {
         Value::nil()

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -26,6 +26,12 @@ pub(crate) struct MethodTableEntry {
     /// `Method#inspect` can recover it. For a plainly-defined method
     /// (`def`, `attr_*`, builtin) this equals the entry's own name.
     original_name: IdentId,
+    /// This entry only re-declares an *inherited* method's visibility
+    /// (`public :inherited_method` in a subclass): it shares the
+    /// inherited `func_id` so visibility introspection works, but it is
+    /// not a definition — `super` resolution must not treat the class
+    /// as a position of the method body (`Store::body_dispatched_by`).
+    visibility_shadow: bool,
 }
 
 impl MethodTableEntry {
@@ -47,6 +53,10 @@ impl MethodTableEntry {
 
     pub fn is_basic_op(&self) -> bool {
         self.is_basic_op
+    }
+
+    pub fn is_visibility_shadow(&self) -> bool {
+        self.visibility_shadow
     }
 
     pub fn is_public(&self) -> bool {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -1824,6 +1824,7 @@ impl Store {
                 visibility,
                 is_basic_op,
                 original_name,
+                visibility_shadow: false,
             },
         );
         #[cfg(feature = "perf")]
@@ -1854,6 +1855,7 @@ impl Store {
                 visibility,
                 is_basic_op: false,
                 original_name: name,
+                visibility_shadow: false,
             },
         );
     }
@@ -2000,9 +2002,24 @@ impl Store {
             // friends treat as "no method present" — so the spec's
             // `m.private_instance_methods.include?(:foo)` would be false.
             let (func_id, inherited_vis, _) = self.find_method_for_class(class_id, *name)?;
+            // A visibility shadow copies the *inherited* func_id, which goes
+            // stale if the inherited method has since been redefined. Resolve
+            // the current inherited definition from the superclass (the
+            // shadow's own entry would just resolve to itself) so a repeated
+            // visibility declaration re-syncs the copy.
+            let inherited_fid = self
+                .get_module(class_id)
+                .superclass()
+                .and_then(|sup| self.search_method(sup, *name))
+                .and_then(|e| e.func_id());
             match self.classes[class_id].methods.get_mut(name) {
                 Some(entry) => {
                     entry.visibility = visibility;
+                    if entry.visibility_shadow
+                        && let Some(fid) = inherited_fid
+                    {
+                        entry.func_id = Some(fid);
+                    }
                     Globals::class_version_inc();
                 }
                 None => {
@@ -2038,6 +2055,7 @@ impl Store {
                             visibility,
                             is_basic_op: false,
                             original_name,
+                            visibility_shadow: true,
                         },
                     );
                 }
@@ -2135,21 +2153,33 @@ impl Store {
     }
 
     ///
-    /// Whether *class_id*'s own method table dispatches *name* to the method
-    /// body *fid* — directly, or through a proc-method wrapper (a
-    /// `define_method`-installed entry whose wrapper jumps straight into the
-    /// block body, so the running frame carries the block's FuncId).
+    /// Whether *class_id* is a *definition position* of the method body *fid*
+    /// under *name*: its own method table dispatches *name* to the body —
+    /// directly, or through a proc-method wrapper (a `define_method`-installed
+    /// entry whose wrapper jumps straight into the block body, so the running
+    /// frame carries the block's FuncId).
     ///
     /// This identifies the ancestor-chain positions that "own" an executing
-    /// frame for `super` purposes. Matching on the *name*'s own entry (rather
-    /// than any registration of the fid) mirrors CRuby's alias semantics: an
-    /// `alias_method`-created entry re-registers the fid in the aliasing
-    /// class, but `super` from the aliased method still resolves from the
-    /// *original* definition's position (the alias entry maps the alias name,
-    /// not the original name searched here).
+    /// frame for `super` purposes:
+    /// - Matching on the *name*'s own entry (rather than any registration of
+    ///   the fid) mirrors CRuby's alias semantics: an `alias_method`-created
+    ///   entry re-registers the fid in the aliasing class, but `super` from
+    ///   the aliased method still resolves from the *original* definition's
+    ///   position (the alias entry maps the alias name, not the original name
+    ///   searched here).
+    /// - A *visibility-shadow* entry (`public :inherited_method` in a
+    ///   subclass shares the inherited fid in the subclass's table purely to
+    ///   re-declare visibility) is not a position — or `super` in the
+    ///   inherited method would re-enter itself.
     ///
     fn body_dispatched_by(&self, class_id: ClassId, name: IdentId, fid: FuncId) -> bool {
-        let Some(entry_fid) = self[class_id].methods.get(&name).and_then(|e| e.func_id()) else {
+        let Some(entry) = self[class_id].methods.get(&name) else {
+            return false;
+        };
+        if entry.is_visibility_shadow() {
+            return false;
+        }
+        let Some(entry_fid) = entry.func_id() else {
             return false;
         };
         entry_fid == fid
@@ -2252,16 +2282,39 @@ impl Store {
             }
             module = m.superclass();
         }
-        // The method's defining module is not in the receiver's
-        // ancestor chain — e.g. a Module's UnboundMethod bound to an
-        // unrelated object via `#bind` / `#bind_call`. CRuby resolves
-        // `super` against the receiver's actual class hierarchy here.
-        if matched == 0
-            && let Some(entry) = self.search_method(self.get_module(self_class), name)
-            && let Some(fid) = entry.func_id()
-            && fid != current_func_id
-        {
-            return Some(fid);
+        if matched == 0 {
+            // No name-based position matched. This happens when the *entry*
+            // that dispatched the frame no longer maps the name to the body —
+            // e.g. a visibility shadow whose copied func_id went stale after
+            // the inherited method was redefined. Fall back to the legacy
+            // owner-registration walk, which tolerates such staleness.
+            let owner = self[current_func_id].owner_class();
+            let mut owner_matched = false;
+            let mut module = Some(self.get_module(self_class));
+            while let Some(m) = module {
+                if !m.has_origin() && owner.contains(&m.id()) {
+                    owner_matched = true;
+                    if let Some(super_module) = m.superclass()
+                        && let Some(entry) = self.search_method(super_module, name)
+                        && let Some(super_fid) = entry.func_id()
+                        && super_fid != current_func_id
+                    {
+                        return Some(super_fid);
+                    }
+                }
+                module = m.superclass();
+            }
+            // The method's defining module is not in the receiver's
+            // ancestor chain — e.g. a Module's UnboundMethod bound to an
+            // unrelated object via `#bind` / `#bind_call`. CRuby resolves
+            // `super` against the receiver's actual class hierarchy here.
+            if !owner_matched
+                && let Some(entry) = self.search_method(self.get_module(self_class), name)
+                && let Some(fid) = entry.func_id()
+                && fid != current_func_id
+            {
+                return Some(fid);
+            }
         }
         None
     }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2135,15 +2135,65 @@ impl Store {
     }
 
     ///
+    /// Whether *class_id*'s own method table dispatches *name* to the method
+    /// body *fid* — directly, or through a proc-method wrapper (a
+    /// `define_method`-installed entry whose wrapper jumps straight into the
+    /// block body, so the running frame carries the block's FuncId).
+    ///
+    /// This identifies the ancestor-chain positions that "own" an executing
+    /// frame for `super` purposes. Matching on the *name*'s own entry (rather
+    /// than any registration of the fid) mirrors CRuby's alias semantics: an
+    /// `alias_method`-created entry re-registers the fid in the aliasing
+    /// class, but `super` from the aliased method still resolves from the
+    /// *original* definition's position (the alias entry maps the alias name,
+    /// not the original name searched here).
+    ///
+    fn body_dispatched_by(&self, class_id: ClassId, name: IdentId, fid: FuncId) -> bool {
+        let Some(entry_fid) = self[class_id].methods.get(&name).and_then(|e| e.func_id()) else {
+            return false;
+        };
+        entry_fid == fid
+            || matches!(&self[entry_fid].kind, FuncKind::Proc(p) if p.func_id() == fid)
+    }
+
+    ///
+    /// Count how many positions in *self_class*'s ancestor chain dispatch
+    /// *name* to the method body *current_func_id* from their own method
+    /// table.
+    ///
+    /// A count > 1 means a frame-independent `super` resolution for this
+    /// method is ambiguous: the same method body appears more than once in
+    /// the chain (e.g. two anonymous modules built from the same `def`
+    /// bytecode, or one module both prepended and included), and each
+    /// occurrence must resolve `super` to a different target. Cached /
+    /// compile-time resolvers must decline in that case; the runtime resolves
+    /// per call via `check_super_at` with the frame's occurrence index.
+    ///
+    pub(crate) fn super_occurrences(
+        &self,
+        self_class: ClassId,
+        current_func_id: FuncId,
+        name: IdentId,
+    ) -> usize {
+        let mut n = 0;
+        let mut module = Some(self.get_module(self_class));
+        while let Some(m) = module {
+            if !m.has_origin() && self.body_dispatched_by(m.id(), name, current_func_id) {
+                n += 1;
+            }
+            module = m.superclass();
+        }
+        n
+    }
+
+    ///
     /// Check whether a super method for *current_func_id* exists in the ancestor chain.
     ///
-    /// Walks the ancestor chain of *self_class* to find the module with *owner* ClassId,
-    /// then searches for the method *name* starting from its superclass.
-    ///
-    /// When the same module appears multiple times in the ancestor chain (e.g., through
-    /// include + include-via-module, or include + prepend), this method skips duplicate
-    /// entries by checking if the found super method has the same func_id as the current
-    /// method being executed.
+    /// Frame-independent (cacheable) variant: returns `None` when the method
+    /// body occupies more than one position in the chain, because the correct
+    /// target then depends on which occurrence the calling frame is executing
+    /// (see `super_occurrences`) — the runtime resolves those via
+    /// `check_super_at`.
     ///
     pub(crate) fn check_super(
         &self,
@@ -2151,22 +2201,54 @@ impl Store {
         current_func_id: FuncId,
         name: IdentId,
     ) -> Option<FuncId> {
-        let owner = self[current_func_id].owner_class();
+        if self.super_occurrences(self_class, current_func_id, name) > 1 {
+            return None;
+        }
+        self.check_super_at(self_class, current_func_id, name, None)
+    }
+
+    ///
+    /// Check whether a super method for *current_func_id* exists in the ancestor chain.
+    ///
+    /// Walks the ancestor chain of *self_class* to find the modules where the
+    /// current method is registered, then searches for the method *name*
+    /// starting from the superclass of the matched position.
+    ///
+    /// `occurrence`:
+    /// - `Some(k)` — positional resolution: the calling frame is the k-th
+    ///   consecutive super-linked frame executing this method body, so search
+    ///   from the k-th matched position's superclass. The result may be
+    ///   *current_func_id* itself — that is the legitimate next occurrence of
+    ///   the same body in the chain (e.g. a chain of anonymous modules built
+    ///   from one `def`).
+    /// - `None` — the frame's occurrence could not be determined: fall back to
+    ///   the legacy heuristic that skips a same-func_id hit and keeps walking
+    ///   to the next matched position (guarantees progress, may skip a
+    ///   legitimate duplicate hop).
+    ///
+    pub(crate) fn check_super_at(
+        &self,
+        self_class: ClassId,
+        current_func_id: FuncId,
+        name: IdentId,
+        occurrence: Option<usize>,
+    ) -> Option<FuncId> {
         let mut module = Some(self.get_module(self_class));
-        let mut matched_owner = false;
+        let mut matched = 0usize;
         while let Some(m) = module {
-            if !m.has_origin() && owner.contains(&m.id()) {
-                matched_owner = true;
-                if let Some(super_module) = m.superclass()
+            if !m.has_origin() && self.body_dispatched_by(m.id(), name, current_func_id) {
+                matched += 1;
+                if occurrence.is_none_or(|k| matched >= k)
+                    && let Some(super_module) = m.superclass()
                     && let Some(entry) = self.search_method(super_module, name)
                     && let Some(super_fid) = entry.func_id()
-                    && super_fid != current_func_id
+                    && (occurrence.is_some() || super_fid != current_func_id)
                 {
                     return Some(super_fid);
                 }
-                // Same func_id as the current method: a duplicate iclass
-                // of the same module in the chain — keep walking to the
-                // next occurrence.
+                // Legacy mode found the same func_id: a duplicate position of
+                // the same body in the chain — keep walking to the next
+                // occurrence.
             }
             module = m.superclass();
         }
@@ -2174,7 +2256,7 @@ impl Store {
         // ancestor chain — e.g. a Module's UnboundMethod bound to an
         // unrelated object via `#bind` / `#bind_call`. CRuby resolves
         // `super` against the receiver's actual class hierarchy here.
-        if !matched_owner
+        if matched == 0
             && let Some(entry) = self.search_method(self.get_module(self_class), name)
             && let Some(fid) = entry.func_id()
             && fid != current_func_id

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -1548,3 +1548,38 @@ fn super_from_alias_resolves_from_original_position() {
         "##,
     );
 }
+
+#[test]
+fn super_skips_visibility_shadow_entries() {
+    // `public :derp` in the including class shares the inherited fid in
+    // its own method table purely to re-declare visibility. That shadow
+    // is not a definition position: super from the inherited method must
+    // resolve from the defining module's position, not re-enter itself.
+    // (core/method/super_method_spec.rb "after changing an inherited
+    // methods visibility".)
+    run_test(
+        r##"
+        module SVSE_A
+          private
+          def derp(message)
+            'A'
+          end
+        end
+        module SVSE_B
+          private
+          def derp
+            'B' + super('superclass')
+          end
+        end
+        class SVSE_C
+          include SVSE_A
+          include SVSE_B
+          public :derp
+          alias_method :meow, :derp
+        end
+        r = []
+        20.times { r << SVSE_C.new.derp }
+        r.uniq
+        "##,
+    );
+}

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -1446,3 +1446,105 @@ fn caller_lines_survive_specialized_frame_eviction() {
         "##,
     );
 }
+
+#[test]
+fn super_uses_called_name_for_multi_name_define_method() {
+    // One block body installed under two names via define_method:
+    // `super()` must dispatch under the name the method was *called*
+    // with, recovered from the caller's callsite via the cont-frame pc
+    // (the body's stamped name is whichever define_method ran first).
+    // run_test warms the JIT: such super sites must stay uncached /
+    // deopt to the VM, or one target would be reused for both names.
+    run_test(
+        r##"
+        sup = Class.new do
+          def a; "a"; end
+          def b; "b"; end
+        end
+        sub = Class.new(sup) do
+          [:a, :b].each do |name|
+            define_method name do
+              super()
+            end
+          end
+        end
+        r = []
+        20.times do
+          r << sub.new.a
+          r << sub.new.b
+        end
+        r.uniq
+        "##,
+    );
+}
+
+#[test]
+fn super_chains_through_duplicate_method_bodies() {
+    // Two anonymous modules built by re-running the same `def` bytecode
+    // share one FuncId, so the body occupies two ancestor-chain
+    // positions. Each frame's occurrence index (counted over the
+    // consecutive super-linked frames via the cont-frame pc) selects
+    // the position to continue from — super must visit *both* modules
+    // before the base class, on every (JIT-warmed) call.
+    // run_test re-executes the snippet in one interpreter; guard the
+    // definitions so the chain doesn't grow two modules per repeat.
+    run_test(
+        r##"
+        unless defined?(SCDMB_Twice)
+          class SCDMB_Base
+            def self.whatever
+              mod = Module.new do
+                def a(array)
+                  array << "anon"
+                  super
+                end
+              end
+              include mod
+            end
+            def a(array)
+              array << "non-anon"
+            end
+          end
+          class SCDMB_Twice < SCDMB_Base
+            whatever
+            whatever
+          end
+        end
+        r = []
+        20.times do
+          r << SCDMB_Twice.new.a([])
+        end
+        r.uniq
+        "##,
+    );
+}
+
+#[test]
+fn super_from_alias_resolves_from_original_position() {
+    // `alias_method` re-registers the body in the aliasing class, but
+    // super from the aliased method must resolve from the *original*
+    // definition's chain position (the called name maps through the
+    // alias entry's original_name) — not re-enter the same body.
+    run_test(
+        r##"
+        class SFAR_A
+          def name
+            [:alias1]
+          end
+        end
+        class SFAR_B < SFAR_A
+          def name
+            [:alias2] + super
+          end
+        end
+        class SFAR_C < SFAR_B
+          alias_method :name3, :name
+        end
+        r = []
+        20.times do
+          r << SFAR_C.new.name3
+        end
+        r.uniq
+        "##,
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the two remaining `language/super_spec.rb` failures by resolving `super` with the **called name** and the frame's **ancestor-chain occurrence index**, both recovered through the cont-frame call-site pc that #887–#889 made eagerly available on every dispatch tier.

## The two failures

1. **"supers up appropriate name even if used for multiple method names"** — `define_method` in a loop installs one block body under several names; the body's `FuncInfo` carries only the first-stamped name, so `super()` always dispatched under that one name.
2. **"invokes methods from a chain of anonymous modules"** — re-running the same `def` bytecode (two anonymous modules from one `include mod` helper) registers one FuncId at two chain positions; the old "skip a same-FuncId hit" heuristic collapsed the chain and skipped the second module.

## How it works

- **Called-name recovery** (`super_resolution` in `runtime.rs`): read the frame's cont-frame slot → validate the pc against the caller's bytecode span → decode the send opcode (30/31 = call, 32/33 = super) → take the callsite's name → map it through the receiver's method table, accepting a proc-method wrapper whose inner proc is the running body → resolve under that entry's `original_name`. The `original_name` hop also preserves CRuby's alias semantics (super from an aliased method resolves under the original definition name).
- **Occurrence counting** (`super_run` + `Store::check_super_at`): count the consecutive super-linked frames executing the same body on the same receiver (each link validated via the cont-frame pc), and continue the ancestor walk from that occurrence's chain position — so a duplicated body legitimately supers into itself before reaching the base. When a link can't be decoded (invoker boundary), fall back to the legacy skip heuristic.
- **Chain-position predicate** (`body_dispatched_by`): a position counts only if the module's *own* table dispatches the resolved name to the running body — an `alias_method` re-registration must not count (the three alias super_specs pin this down; they went red under a fid-registration predicate and are green with this one).
- **Cache discipline**: frame-dependent super targets must not be cached per receiver class. `find_super` reports cacheability; `find_method` tags the inline cache with class 0 (a `ClassId` is `NonZeroU32`, so the tag never matches and the site re-resolves per call); the JIT plain-deopts ambiguous super sites to the VM instead of recompiling (the cache never warms, so recompiling would never stabilize).

## Verification

- `language/super_spec.rb`: **61 examples, 0 failures** (was 2 failures; the 3 alias specs stay green).
- Full ruby/spec `language` category: 31 F / 14 E — exactly the baseline minus the two fixed specs, nothing else moved.
- Full `cargo test` green; three new JIT-warmed regression tests in `tests/add_coverage.rs` (multi-name define_method, duplicate-body chain, alias-position resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_