### PR TITLE
Implement CRuby-compatible command-line option processing

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -151,10 +151,10 @@ fi
 if [ -d "../spec" ] && [ -d "../mspec" ]; then
   echo "Running ruby/spec for coverage..."
   cd ../spec
-  for cat in basicobject true false nil integer float comparable math builtin_constants class numeric rational struct symbol range set systemexit method unboundmethod; do
-    phase "ruby/spec core/$cat"
-    echo "=== core/$cat ==="
-    ../mspec/bin/mspec core/$cat -t "$MONORUBY"
+  for cat in core/basicobject core/true core/false core/nil core/integer core/float core/comparable core/math core/builtin_constants core/class core/numeric core/rational core/struct core/symbol core/range core/set core/systemexit core/method core/unboundmethod command_line; do
+    phase "ruby/spec $cat"
+    echo "=== $cat ==="
+    ../mspec/bin/mspec $cat -t "$MONORUBY"
   done
   cd "$OLDPWD"
 fi

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1016,13 +1016,27 @@ class Exception
   end
 
   def full_message(highlight: nil, order: :top)
-    msg = "#{self.class}: #{message}"
+    # CRuby's first line is `bt[0]: <detailed_message>` (i.e.
+    # "message (ClassName)"), followed by `\tfrom <frame>` lines.
+    # `--backtrace-limit=N` truncates the from-lines to N entries plus
+    # a `\t ... K levels...` marker, exactly like the top-level
+    # uncaught-error report.
+    msg = detailed_message(highlight: highlight ? true : false)
     bt = backtrace
     if bt && !bt.empty?
+      rest = bt[1..]
+      limit = Kernel.__backtrace_limit
+      trailer = nil
+      if limit && rest.size > limit
+        trailer = "\t ... #{rest.size - limit} levels...\n"
+        rest = rest[0, limit]
+      end
+      lines = rest.map { |l| "\tfrom #{l}\n" }
+      lines << trailer if trailer
       if order == :top
-        "#{bt[0]}: #{msg}\n" + bt[1..].map{|l| "\tfrom #{l}\n"}.join
+        "#{bt[0]}: #{msg}\n" + lines.join
       else
-        bt.reverse.map{|l| "\tfrom #{l}\n"}.join + "#{bt[0]}: #{msg}\n"
+        lines.reverse.join + "#{bt[0]}: #{msg}\n"
       end
     else
       msg + "\n"

--- a/monoruby/builtins/string.rb
+++ b/monoruby/builtins/string.rb
@@ -202,9 +202,8 @@ class String
     self
   end
 
-  def +@
-    frozen? ? dup : self
-  end
+  # +@ is a Rust builtin (it must detect chilled strings, which have
+  # no Ruby-level predicate).
   def -@
     frozen? ? self : dup.freeze
   end

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -3029,6 +3029,29 @@ fn enc_find(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         return Ok(arg0);
     }
     let name = arg0.coerce_to_string(vm, globals)?;
+    // Special names resolved at query time: the filesystem/locale
+    // encodings follow `default_external`, and "internal" may be nil.
+    match name.as_str() {
+        "external" | "filesystem" | "locale" => {
+            let ext = globals
+                .get_gvar(IdentId::get_id("$DEFAULT_EXTERNAL"))
+                .filter(|v| !v.is_nil())
+                .unwrap_or_else(|| {
+                    globals
+                        .store
+                        .get_constant_noautoload(enc_class, IdentId::UTF_8)
+                        .unwrap_or(Value::nil())
+                });
+            return Ok(ext);
+        }
+        "internal" => {
+            let int = globals
+                .get_gvar(IdentId::get_id("$DEFAULT_INTERNAL"))
+                .unwrap_or(Value::nil());
+            return Ok(int);
+        }
+        _ => {}
+    }
     // First, try an exact (separator/case-insensitive) match against
     // the canonical name of every registered encoding. This lets
     // `Encoding.find(e.name)` round-trip for *every* encoding in

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -614,7 +614,15 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             } else if let Some(rs) = v.is_rstring() {
                 String::from_utf8_lossy(rs.as_bytes()).into_owned()
             } else {
-                v.to_s(globals)
+                // Stringify through the value's (possibly Ruby-defined)
+                // `to_s`, matching CRuby's `rb_obj_as_string`; fall back
+                // to the Rust-side formatter when `to_s` misbehaves.
+                let sv =
+                    vm.invoke_method_inner(globals, IdentId::get_id("to_s"), v, &[], None, None)?;
+                match sv.is_rstring() {
+                    Some(rs) => String::from_utf8_lossy(rs.as_bytes()).into_owned(),
+                    None => v.to_s(globals),
+                }
             };
             let needs_newline = !s.ends_with('\n');
             let write_str = if needs_newline {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -504,7 +504,7 @@ fn kernel_block_given(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/puts.html]
 #[monoruby_builtin]
-fn puts(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     fn decompose(collector: &mut Vec<Value>, val: Value) {
         match val.try_array_ty() {
             Some(ary) => {
@@ -518,8 +518,22 @@ fn puts(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         decompose(&mut collector, v);
     }
 
+    let to_s_id = IdentId::get_id("to_s");
     for v in collector {
-        globals.print_value(v)?;
+        // Non-String values stringify through their (possibly
+        // user- or Ruby-defined) `to_s` method, matching CRuby's
+        // `rb_obj_as_string`; the Rust-side fallback only handles
+        // objects whose `to_s` returns a non-String.
+        if v.is_rstring().is_some() {
+            globals.print_value(v)?;
+        } else {
+            let s = vm.invoke_method_inner(globals, to_s_id, v, &[], None, None)?;
+            if s.is_rstring().is_some() {
+                globals.print_value(s)?;
+            } else {
+                globals.print_value(v)?;
+            }
+        }
         globals.write_stdout(b"\n")?;
     }
     globals.flush_stdout()?;
@@ -532,20 +546,150 @@ fn puts(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// - gets([NOT SUPPORTED]rs = $/) -> String | nil
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/gets.html]
+/// Where `Kernel#gets` currently reads from. CRuby's `gets` is
+/// `ARGF.gets`: when `ARGV` holds file names they are consumed (shifted
+/// off `ARGV`) and read in order; only an initially-empty `ARGV` reads
+/// stdin. `Kernel#gets` is only ever called from the single Ruby
+/// thread, so a process-global is fine.
+enum ArgfSource {
+    /// Not yet decided — first `gets` call picks stdin or the ARGV files.
+    Uninit,
+    Stdin,
+    File(std::io::BufReader<std::fs::File>),
+    /// All ARGV files exhausted.
+    Done,
+}
+
+static ARGF_SOURCE: std::sync::Mutex<ArgfSource> = std::sync::Mutex::new(ArgfSource::Uninit);
+
+/// Shift the next file name off `ARGV`, if any.
+fn shift_argv(globals: &mut Globals) -> Option<String> {
+    let argv = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ARGV"))?;
+    let mut ary = argv.try_array_ty()?;
+    if ary.is_empty() {
+        return None;
+    }
+    let first = ary[0];
+    let name = first
+        .is_rstring_inner()
+        .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())?;
+    ary.remove(0);
+    Some(name)
+}
+
+/// Read one record (up to and including the separator) from `reader`
+/// into `buffer`. `sep` is the raw `$/` value: `None` slurps the whole
+/// input, `Some(b"")` is paragraph mode.
+fn read_record(
+    reader: &mut dyn std::io::BufRead,
+    sep: &Option<Vec<u8>>,
+    buffer: &mut Vec<u8>,
+) -> std::io::Result<usize> {
+    use std::io::Read;
+    match sep {
+        None => reader.read_to_end(buffer),
+        Some(sep) if sep.is_empty() => {
+            // Paragraph mode: skip leading blank lines, then read
+            // up to (and including) an empty line.
+            let mut line: Vec<u8> = Vec::new();
+            loop {
+                line.clear();
+                if reader.read_until(b'\n', &mut line)? == 0 {
+                    return Ok(buffer.len());
+                }
+                if line != b"\n" {
+                    buffer.extend_from_slice(&line);
+                    break;
+                }
+            }
+            loop {
+                line.clear();
+                if reader.read_until(b'\n', &mut line)? == 0 {
+                    return Ok(buffer.len());
+                }
+                buffer.extend_from_slice(&line);
+                if line == b"\n" {
+                    return Ok(buffer.len());
+                }
+            }
+        }
+        Some(sep) => {
+            let last = *sep.last().unwrap();
+            loop {
+                if reader.read_until(last, buffer)? == 0 {
+                    return Ok(buffer.len());
+                }
+                if buffer.ends_with(sep) {
+                    return Ok(buffer.len());
+                }
+            }
+        }
+    }
+}
+
 #[monoruby_builtin]
 fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut buffer = String::new();
-    let n = match std::io::stdin().read_line(&mut buffer) {
-        Ok(n) => n,
-        Err(_) => {
-            vm.set_last_read_line(Value::nil());
-            return Ok(Value::nil());
+    // Honour the input record separator `$/` (set by the `-0`
+    // command-line switch or by assignment): nil slurps the whole
+    // input, "" is paragraph mode, any other string reads up to and
+    // including that byte sequence.
+    let sep: Option<Vec<u8>> = match globals.get_gvar(IdentId::get_id("$/")) {
+        Some(v) if v.is_nil() => None,
+        Some(v) => match v.is_rstring_inner() {
+            Some(s) => Some(s.as_bytes().to_vec()),
+            None => Some(b"\n".to_vec()),
+        },
+        None => Some(b"\n".to_vec()),
+    };
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut source = ARGF_SOURCE.lock().unwrap();
+    let n = loop {
+        match &mut *source {
+            ArgfSource::Uninit => match shift_argv(globals) {
+                Some(name) if name != "-" => match std::fs::File::open(&name) {
+                    Ok(f) => *source = ArgfSource::File(std::io::BufReader::new(f)),
+                    Err(_) => {
+                        return Err(MonorubyErr::runtimeerr(format!(
+                            "No such file or directory @ rb_sysopen - {name}"
+                        )));
+                    }
+                },
+                Some(_) | None => *source = ArgfSource::Stdin,
+            },
+            ArgfSource::Stdin => {
+                let stdin = std::io::stdin();
+                let mut lock = stdin.lock();
+                break read_record(&mut lock, &sep, &mut buffer).unwrap_or(0);
+            }
+            ArgfSource::File(reader) => {
+                let n = read_record(reader, &sep, &mut buffer).unwrap_or(0);
+                if n > 0 {
+                    break n;
+                }
+                // Current file exhausted: move on to the next ARGV
+                // entry, or report end-of-input when none remain.
+                match shift_argv(globals) {
+                    Some(name) if name != "-" => match std::fs::File::open(&name) {
+                        Ok(f) => *source = ArgfSource::File(std::io::BufReader::new(f)),
+                        Err(_) => {
+                            return Err(MonorubyErr::runtimeerr(format!(
+                                "No such file or directory @ rb_sysopen - {name}"
+                            )));
+                        }
+                    },
+                    Some(_) => *source = ArgfSource::Stdin,
+                    None => *source = ArgfSource::Done,
+                }
+            }
+            ArgfSource::Done => break 0,
         }
     };
-    // `read_line` returns `Ok(0)` only at end-of-input. CRuby's
-    // `gets` then returns nil (and `while gets` terminates); returning
-    // the empty buffer string here would loop forever since "" is
-    // truthy.
+    drop(source);
+    // Zero bytes read means end-of-input. CRuby's `gets` then returns
+    // nil (and `while gets` terminates); returning the empty buffer
+    // string here would loop forever since "" is truthy.
     if n == 0 {
         vm.set_last_read_line(Value::nil());
         return Ok(Value::nil());
@@ -558,7 +702,7 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
         .unwrap_or(0)
         + 1;
     globals.set_gvar(IdentId::get_id("$."), Value::integer(lineno));
-    let s = Value::string(buffer);
+    let s = Value::string_from_vec(buffer);
     vm.set_last_read_line(s);
     Ok(s)
 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -207,6 +207,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         set_lastline_in_caller,
         1,
     );
+    globals.define_builtin_func(kernel_class, "__backtrace_limit", backtrace_limit, 0);
     globals.define_builtin_func(
         kernel_class,
         "__enum_yield",
@@ -704,6 +705,26 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
     let s = Value::string_from_vec(buffer);
     vm.set_last_read_line(s);
     Ok(s)
+}
+
+///
+/// ### Kernel.#__backtrace_limit (monoruby intrinsic)
+///
+/// The `--backtrace-limit=N` command-line value, or nil. Used by
+/// `Exception#full_message` (startup.rb) to truncate caller frames the
+/// way the top-level uncaught-error report does.
+///
+#[monoruby_builtin]
+fn backtrace_limit(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(match crate::globals::backtrace_limit() {
+        Some(n) => Value::integer(n as i64),
+        None => Value::nil(),
+    })
 }
 
 ///

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -587,7 +587,6 @@ fn read_record(
     sep: &Option<Vec<u8>>,
     buffer: &mut Vec<u8>,
 ) -> std::io::Result<usize> {
-    use std::io::Read;
     match sep {
         None => reader.read_to_end(buffer),
         Some(sep) if sep.is_empty() => {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -208,6 +208,8 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         1,
     );
     globals.define_builtin_func(kernel_class, "__backtrace_limit", backtrace_limit, 0);
+    globals.define_builtin_module_func_with(kernel_class, "chomp", chomp, 0, 1, false);
+    globals.define_builtin_module_func(kernel_class, "chop", chop, 0);
     globals.define_builtin_func(
         kernel_class,
         "__enum_yield",
@@ -705,6 +707,52 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
     let s = Value::string_from_vec(buffer);
     vm.set_last_read_line(s);
     Ok(s)
+}
+
+///
+/// ### Kernel.#chomp / Kernel.#chop
+///
+/// - chomp(rs = $/) -> String
+/// - chop -> String
+///
+/// `$_ = $_.chomp(rs)` / `$_ = $_.chop` in the calling scope — the
+/// `-n`/`-p` loop companions. `$_` must hold a String (TypeError
+/// otherwise, like CRuby).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/chomp.html]
+#[monoruby_builtin]
+fn chomp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let line = vm.get_last_read_line();
+    if line.is_rstring().is_none() {
+        return Err(MonorubyErr::typeerr(format!(
+            "$_ value need to be String ({} given)",
+            line.get_real_class_name(&globals.store)
+        )));
+    }
+    let rs = match lfp.try_arg(0) {
+        Some(rs) => rs,
+        None => globals
+            .get_gvar(IdentId::get_id("$/"))
+            .unwrap_or_else(|| Value::string_from_str("\n")),
+    };
+    let res = vm.invoke_method_inner(globals, IdentId::get_id("chomp"), line, &[rs], None, None)?;
+    vm.set_last_read_line(res);
+    Ok(res)
+}
+
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/chop.html]
+#[monoruby_builtin]
+fn chop(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let line = vm.get_last_read_line();
+    if line.is_rstring().is_none() {
+        return Err(MonorubyErr::typeerr(format!(
+            "$_ value need to be String ({} given)",
+            line.get_real_class_name(&globals.store)
+        )));
+    }
+    let res = vm.invoke_method_inner(globals, IdentId::get_id("chop"), line, &[], None, None)?;
+    vm.set_last_read_line(res);
+    Ok(res)
 }
 
 ///

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2149,7 +2149,7 @@ fn instance_method(
         .map_err(|_| {
             MonorubyErr::nameerr_with_name(
                 format!(
-                    "undefined method `{}' for class `{}'",
+                    "undefined method '{}' for class '{}'",
                     method_name.get_name(),
                     klass.id().get_name(&globals.store),
                 ),
@@ -2182,7 +2182,7 @@ fn public_instance_method(
             .map_err(|_| {
                 MonorubyErr::nameerr_with_name(
                     format!(
-                        "undefined method `{}' for class `{}'",
+                        "undefined method '{}' for class '{}'",
                         method_name.get_name(),
                         klass.id().get_name(&globals.store),
                     ),
@@ -2325,7 +2325,7 @@ fn undefined_method_for_kind(
         class_id.get_name(&globals.store)
     };
     MonorubyErr::nameerr(format!(
-        "undefined method `{}' for {kind} `{display}'",
+        "undefined method '{}' for {kind} '{display}'",
         method.get_name(),
     ))
 }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -27,6 +27,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.store[STRING_CLASS].set_alloc_func(string_alloc_func);
     globals.define_builtin_class_func(STRING_CLASS, "try_convert", string_try_convert, 1);
     globals.define_builtin_func(STRING_CLASS, "+", add, 1);
+    globals.define_builtin_func(STRING_CLASS, "+@", uplus, 0);
     globals.define_builtin_func(STRING_CLASS, "*", mul, 1);
     globals.define_builtin_func(STRING_CLASS, "hash", hash, 0);
     globals.define_builtin_inline_funcs(
@@ -326,6 +327,28 @@ fn string_try_convert(
 /// ### String#+
 ///
 /// - self + other -> String
+///
+/// ### String#+@
+///
+/// - +self -> String
+///
+/// Frozen receiver: a mutable dup. Chilled receiver (a literal from a
+/// pragma-less file): a dup with the chill cleared, so the recommended
+/// `+"literal"` migration idiom mutates without warning, like CRuby.
+/// Otherwise: self.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/String/i/=2b=40.html]
+#[monoruby_builtin]
+fn uplus(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let s = lfp.self_val();
+    if s.is_frozen() || s.is_chilled() {
+        // `dup` clears both the frozen and chilled flags.
+        Ok(s.dup())
+    } else {
+        Ok(s)
+    }
+}
+
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=2b.html]
 #[monoruby_builtin]

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1313,15 +1313,54 @@ impl<'a> BytecodeGen<'a> {
     /// Emit a shared, frozen, deduplicated string literal for a
     /// `# frozen_string_literal: true` file. Literals with identical
     /// `(bytes, encoding)` resolve to the same object program-wide.
-    fn emit_frozen_interned(&mut self, dst: BcReg, bytes: &[u8], enc: crate::value::Encoding) {
+    fn emit_frozen_interned(
+        &mut self,
+        dst: BcReg,
+        bytes: &[u8],
+        enc: crate::value::Encoding,
+        loc: Loc,
+    ) {
         let v = self.store.intern_frozen_str(bytes, enc);
+        self.record_literal_origin(v, loc);
         self.emit(BytecodeInst::FrozenLiteral(dst, v), Loc::default());
     }
 
-    fn emit_string(&mut self, dst: BcReg, s: String) {
+    /// Under `--debug-frozen-string-literal`, remember where a
+    /// frozen/chilled string literal appears in the source so mutation
+    /// errors/warnings can point at it ("created at file:line").
+    fn record_literal_origin(&self, v: Value, loc: Loc) {
+        if crate::value::debug_frozen_string_log() {
+            let origin = format!(
+                "{}:{}",
+                self.sourceinfo.file_name(),
+                self.sourceinfo.get_line(&loc)
+            );
+            crate::value::record_string_origin(v.id(), origin);
+        }
+    }
+
+    /// Mark a pragma-less file's string-literal template as "chilled":
+    /// every runtime copy warns on first mutation (CRuby 3.4's
+    /// migration path towards frozen-by-default literals). monoruby's
+    /// own runtime Ruby (builtins / stdlib stubs under the install
+    /// root) is exempt — CRuby's counterparts all carry explicit
+    /// pragmas, and a user enabling `Warning[:deprecated]` must not
+    /// see warnings pointing into interpreter internals.
+    fn chill_literal_template(&self, mut v: Value, loc: Loc) -> Value {
+        if self.sourceinfo.frozen_string_literal.is_none()
+            && !std::path::Path::new(self.sourceinfo.file_name().as_ref())
+                .starts_with(crate::globals::install_root())
+        {
+            v.set_chilled_literal();
+            self.record_literal_origin(v, loc);
+        }
+        v
+    }
+
+    fn emit_string(&mut self, dst: BcReg, s: String, loc: Loc) {
         let enc = self.source_encoding();
         if self.frozen_string_literal() {
-            self.emit_frozen_interned(dst, s.as_bytes(), enc);
+            self.emit_frozen_interned(dst, s.as_bytes(), enc, loc);
             return;
         }
         // String literals become long-lived templates: `Literal`
@@ -1329,7 +1368,8 @@ impl<'a> BytecodeGen<'a> {
         // every execution, and the clone preserves the template's
         // `cr`. Pre-classify here so each clone gets `cr` for free
         // instead of re-running classify on first use.
-        self.emit_literal(dst, Value::string_from_source_str(&s, enc));
+        let v = self.chill_literal_template(Value::string_from_source_str(&s, enc), loc);
+        self.emit_literal(dst, v);
     }
 
     /// Emit a shared, frozen string literal (e.g. the result of
@@ -1343,7 +1383,7 @@ impl<'a> BytecodeGen<'a> {
         self.emit(BytecodeInst::FrozenLiteral(dst, v), Loc::default());
     }
 
-    fn emit_bytes(&mut self, dst: BcReg, b: Vec<u8>) {
+    fn emit_bytes(&mut self, dst: BcReg, b: Vec<u8>, loc: Loc) {
         // `NodeKind::Bytes` comes from source literals containing `\xNN`
         // escapes. Tag with the file's `# encoding:` magic-comment value
         // (defaulting to UTF-8 — Ruby's default source encoding since
@@ -1352,10 +1392,11 @@ impl<'a> BytecodeGen<'a> {
         // false but byte-level operations still work, matching CRuby.
         let enc = self.source_encoding();
         if self.frozen_string_literal() {
-            self.emit_frozen_interned(dst, &b, enc);
+            self.emit_frozen_interned(dst, &b, enc, loc);
             return;
         }
-        self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
+        let v = self.chill_literal_template(Value::string_from_source_bytes(&b, enc), loc);
+        self.emit_literal(dst, v);
     }
 
     /// Emit a string literal whose encoding was *forced* by prism —
@@ -1364,14 +1405,15 @@ impl<'a> BytecodeGen<'a> {
     /// override the lowerer extracted from prism's flags
     /// (`"UTF-8"` / `"ASCII-8BIT"`); falls back to UTF-8 if monoruby
     /// doesn't recognise the alias (shouldn't happen for these two).
-    fn emit_encoded_string(&mut self, dst: BcReg, b: Vec<u8>, enc_name: &'static str) {
+    fn emit_encoded_string(&mut self, dst: BcReg, b: Vec<u8>, enc_name: &'static str, loc: Loc) {
         let enc = crate::value::Encoding::try_from_str(enc_name)
             .unwrap_or(crate::value::Encoding::Utf8);
         if self.frozen_string_literal() {
-            self.emit_frozen_interned(dst, &b, enc);
+            self.emit_frozen_interned(dst, &b, enc, loc);
             return;
         }
-        self.emit_literal(dst, Value::string_from_source_bytes(&b, enc));
+        let v = self.chill_literal_template(Value::string_from_source_bytes(&b, enc), loc);
+        self.emit_literal(dst, v);
     }
 
     fn emit_array(&mut self, dst: BcReg, src: BcReg, len: usize, splat: Vec<usize>, loc: Loc) {

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -126,9 +126,9 @@ impl<'a> BytecodeGen<'a> {
             NodeKind::Imaginary(r) => self.emit_imaginary(dst, r.into()),
             NodeKind::Rational(n, d) => self.emit_rational(dst, &n, &d),
             NodeKind::RImaginary(n, d) => self.emit_rimaginary(dst, &n, &d),
-            NodeKind::String(s) => self.emit_string(dst, s),
-            NodeKind::Bytes(b) => self.emit_bytes(dst, b),
-            NodeKind::EncodedString(b, enc) => self.emit_encoded_string(dst, b, enc),
+            NodeKind::String(s) => self.emit_string(dst, s, loc),
+            NodeKind::Bytes(b) => self.emit_bytes(dst, b, loc),
+            NodeKind::EncodedString(b, enc) => self.emit_encoded_string(dst, b, enc, loc),
             NodeKind::Array(nodes, false) => self.gen_array(dst, nodes, loc)?,
             NodeKind::Hash(nodes, splat) => self.gen_hash(dst, nodes, splat, loc)?,
             NodeKind::RegExp(nodes, op, false) => self.gen_regexp(dst, nodes, op, loc)?,
@@ -954,7 +954,11 @@ impl<'a> BytecodeGen<'a> {
                 let arg = self.sp();
                 if seed {
                     let r = self.push().into();
-                    self.emit_string(r, String::new());
+                    // Plain (never chilled/frozen) seed: the concat
+                    // result is a fresh mutable string in CRuby, even
+                    // under a frozen_string_literal pragma.
+                    let enc = self.source_encoding();
+                    self.emit_literal(r, Value::string_from_source_str("", enc));
                 }
                 for expr in nodes {
                     self.push_expr(expr)?;

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1745,7 +1745,24 @@ pub(super) extern "C" fn err_method_return(vm: &mut Executor, globals: &mut Glob
     }
     let cfp = cfp;
     let target_lfp = if globals[cfp.lfp().func_id()].is_block_style() {
-        let target = cfp.outermost_lfp();
+        // Walk the outer chain to the nearest *method-style* frame: a
+        // real method or the toplevel ends the walk (not block-style),
+        // and so do a lambda (`->`/`Kernel#lambda` promote the block
+        // via `set_method_style`) and a `define_method` body
+        // (`is_proc_method`), both of which catch `return` themselves.
+        // CRuby: `-> { [1].each { return 5 } }.call` (and `return`
+        // eval'ed inside a lambda) returns from the lambda, not from
+        // the method that lexically encloses it.
+        let target = {
+            let mut lfp = cfp.lfp();
+            while globals[lfp.func_id()].is_block_style() && !lfp.meta().is_proc_method() {
+                match lfp.outer() {
+                    Some(outer) => lfp = outer,
+                    None => break,
+                }
+            }
+            lfp
+        };
         // A synchronous thread-body boundary (see
         // `Executor::break_barriers`) also stops non-local returns: a
         // bare `return` in a thread body raises LocalJumpError at the

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -24,6 +24,18 @@ pub use store::*;
 
 pub static WARNING: std::sync::LazyLock<AtomicU8> = std::sync::LazyLock::new(|| AtomicU8::new(0u8));
 
+/// `--backtrace-limit=N` (-1 = unlimited). Read by the uncaught-error
+/// reporter and `Exception#full_message`.
+static BACKTRACE_LIMIT: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(-1);
+
+/// The `--backtrace-limit` value, if one was given on the command line.
+pub(crate) fn backtrace_limit() -> Option<usize> {
+    match BACKTRACE_LIMIT.load(std::sync::atomic::Ordering::Relaxed) {
+        n if n >= 0 => Some(n as usize),
+        _ => None,
+    }
+}
+
 /// The `<arch>-<os>` platform string monoruby reports as `RUBY_PLATFORM`.
 ///
 /// This is also the name of the arch-specific subdirectory inside the
@@ -1011,6 +1023,12 @@ impl Globals {
 
     pub fn get_load_path(&self) -> Value {
         self.load_path
+    }
+
+    /// Cap the number of backtrace frames printed for uncaught errors
+    /// and `Exception#full_message` (`--backtrace-limit=N`).
+    pub fn set_backtrace_limit(limit: i64) {
+        BACKTRACE_LIMIT.store(limit, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// The `RUBY_DESCRIPTION` string (e.g. `monoruby 0.3.0 [x86_64-linux]`),

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -676,11 +676,36 @@ impl Globals {
         code: impl Into<Vec<u8>>,
         path: &std::path::Path,
     ) -> Result<Value> {
+        self.run_with_prelude(requires, "", code, path)
+    }
+
+    ///
+    /// Like [`Globals::run_with_requires`], but first evaluates
+    /// *prelude* (Ruby source synthesized from command-line switches:
+    /// `Warning[:...]` category overrides, `-E`/`-U`/`-K` encoding
+    /// defaults, `-0`/`-l`/`-F` separator globals, …) inside the same
+    /// `Executor`, before the `-r` requires and the script itself.
+    /// An empty *prelude* is skipped entirely.
+    ///
+    pub fn run_with_prelude(
+        &mut self,
+        requires: &[String],
+        prelude: &str,
+        code: impl Into<Vec<u8>>,
+        path: &std::path::Path,
+    ) -> Result<Value> {
         let code: Vec<u8> = code.into();
         let program_name = path.to_string_lossy().to_string();
         let mut executor = Executor::init(self, &program_name)?;
         executor.init_stack_limit(self);
         let res = (|| {
+            if !prelude.is_empty() {
+                executor.exec_script(
+                    self,
+                    prelude.as_bytes().to_vec(),
+                    std::path::Path::new("<internal:cli>"),
+                )?;
+            }
             for lib in requires {
                 executor.require(self, std::path::Path::new(lib), false)?;
             }
@@ -988,8 +1013,39 @@ impl Globals {
         self.load_path
     }
 
+    /// The `RUBY_DESCRIPTION` string (e.g. `monoruby 0.3.0 [x86_64-linux]`),
+    /// printed by the `-v` / `--version` command-line switches.
+    pub fn ruby_description(&self) -> String {
+        self.top_string_constant("RUBY_DESCRIPTION")
+            .unwrap_or_else(|| format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")))
+    }
+
+    /// The `RUBY_COPYRIGHT` string, printed by `--copyright`.
+    pub fn ruby_copyright(&self) -> String {
+        self.top_string_constant("RUBY_COPYRIGHT")
+            .unwrap_or_else(|| format!("{} - Copyright (C) monochrome", env!("CARGO_PKG_NAME")))
+    }
+
+    fn top_string_constant(&self, name: &str) -> Option<String> {
+        self.store
+            .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id(name))
+            .and_then(|v| {
+                v.is_rstring_inner()
+                    .map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+            })
+    }
+
     pub fn extend_load_path(&mut self, iter: impl Iterator<Item = String>) {
         self.load_path.as_array().extend(iter.map(Value::string));
+    }
+
+    /// Insert directories at the *front* of `$LOAD_PATH` (before the
+    /// vendored-stdlib defaults), preserving the iterator's order.
+    /// Used for `-I`, `RUBYOPT -I`, and `RUBYLIB`, which CRuby all
+    /// places ahead of the built-in paths.
+    pub fn prepend_load_path(&mut self, iter: impl Iterator<Item = String>) {
+        let dirs: Vec<Value> = iter.map(Value::string).collect();
+        self.load_path.as_array().insert_many(0, dirs);
     }
 
     pub(crate) fn get_loaded_features(&self) -> Value {

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -844,12 +844,19 @@ impl MonorubyErr {
     }
 
     pub(crate) fn cant_modify_frozen(store: &Store, val: Value) -> MonorubyErr {
+        // Under --debug-frozen-string-literal, point at the string
+        // literal's creation site (CRuby: `..., created at file:line`).
+        let created = match crate::value::string_origin(val.id()) {
+            Some(origin) => format!(", created at {origin}"),
+            None => String::new(),
+        };
         MonorubyErr::new(
             MonorubyErrKind::Frozen(Some(val.id())),
             format!(
-                "can't modify frozen {}: {}",
+                "can't modify frozen {}: {}{}",
                 val.get_real_class_name(store),
                 val.inspect(store),
+                created,
             ),
         )
     }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -448,6 +448,10 @@ impl MonorubyErr {
         } else if let Some(m) = obj.is_class_or_module() {
             let kind = if m.is_module() { "module" } else { "class" };
             format!("{kind} {}", obj.to_s(store))
+        } else if store[obj.class()].get_module().is_singleton().is_some() {
+            // A receiver with a singleton class keeps the address form
+            // (`for #<Object:0x…>`) in CRuby, not `an instance of …`.
+            obj.to_s(store)
         } else {
             format!("an instance of {}", obj.get_real_class_name(store))
         }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -431,13 +431,38 @@ impl MonorubyErr {
         MonorubyErr::new(MonorubyErrKind::Redo, String::new())
     }
 
+    ///
+    /// CRuby 3.4+ receiver description for NoMethodError messages
+    /// (unchanged in 4.0; verified against CRuby 4.0.2):
+    /// `nil` / `true` / `false` verbatim, `class Foo` / `module Foo`
+    /// (anonymous ones fall back to their `#<Class:0x…>` display), and
+    /// `an instance of Foo` for everything else.
+    ///
+    fn receiver_description(store: &Store, obj: Value) -> String {
+        if obj.is_nil() {
+            "nil".to_string()
+        } else if obj == Value::bool(true) {
+            "true".to_string()
+        } else if obj == Value::bool(false) {
+            "false".to_string()
+        } else if let Some(m) = obj.is_class_or_module() {
+            let kind = if m.is_module() { "module" } else { "class" };
+            format!("{kind} {}", obj.to_s(store))
+        } else {
+            format!("an instance of {}", obj.get_real_class_name(store))
+        }
+    }
+
     pub(crate) fn method_not_found(store: &Store, name: IdentId, obj: Value) -> MonorubyErr {
         MonorubyErr::new(
             MonorubyErrKind::NotMethod {
                 name: Some(name),
                 receiver: Some(obj.id()),
             },
-            format!("undefined method `{name}' for {}", obj.to_s(store)),
+            format!(
+                "undefined method '{name}' for {}",
+                Self::receiver_description(store, obj)
+            ),
         )
     }
 
@@ -453,8 +478,8 @@ impl MonorubyErr {
                 receiver: Some(obj.id()),
             },
             format!(
-                "super: no superclass method `{name}' for {}",
-                obj.to_s(store)
+                "super: no superclass method '{name}' for {}",
+                Self::receiver_description(store, obj)
             ),
         )
     }
@@ -470,7 +495,7 @@ impl MonorubyErr {
                 receiver: None,
             },
             format!(
-                "undefined method `{name}' for {}",
+                "undefined method '{name}' for {}",
                 store.get_class_name(class)
             ),
         )
@@ -483,9 +508,8 @@ impl MonorubyErr {
                 receiver: Some(obj.id()),
             },
             format!(
-                "private method `{name}' called for {}:{}",
-                obj.to_s(store),
-                obj.get_real_class_name(store)
+                "private method '{name}' called for {}",
+                Self::receiver_description(store, obj)
             ),
         )
     }
@@ -497,9 +521,8 @@ impl MonorubyErr {
                 receiver: Some(obj.id()),
             },
             format!(
-                "protected method `{name}' called for {}:{}",
-                obj.to_s(store),
-                obj.get_real_class_name(store)
+                "protected method '{name}' called for {}",
+                Self::receiver_description(store, obj)
             ),
         )
     }
@@ -594,7 +617,7 @@ impl MonorubyErr {
 
     pub(crate) fn undefined_method(method_name: IdentId, class_name: String) -> MonorubyErr {
         Self::nameerr(format!(
-            "undefined method `{}' for class `{}'",
+            "undefined method '{}' for class '{}'",
             method_name.get_name(),
             class_name,
         ))

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -153,20 +153,22 @@ impl MonorubyErr {
     }
 
     pub fn show_error_message_and_all_loc(&self, store: &Store) {
-        let mut loc_flag = self.show_error_message_and_loc(store);
+        self.show_error_message_and_loc(store);
         if self.trace.len() > 1 {
-            for (source_loc, func_id) in &self.trace[1..] {
+            // CRuby prints each caller frame as `\tfrom <location>`,
+            // honouring `--backtrace-limit=N`: after N frames the rest
+            // collapse into `\t ... K levels...`.
+            let rest = &self.trace[1..];
+            let limit = crate::globals::backtrace_limit().unwrap_or(usize::MAX);
+            for (i, (source_loc, func_id)) in rest.iter().enumerate() {
+                if i >= limit {
+                    eprintln!("\t ... {} levels...", rest.len() - i);
+                    break;
+                }
                 if let Some((loc, source)) = source_loc {
-                    eprintln!(
-                        "        from: {}",
-                        store.location(func_id.clone(), source, *loc)
-                    );
-                    if !loc_flag {
-                        source.show_loc(loc);
-                        loc_flag = true;
-                    }
+                    eprintln!("\tfrom {}", store.location(func_id.clone(), source, *loc));
                 } else {
-                    eprintln!("        {}", store.internal_location(func_id.unwrap()))
+                    eprintln!("\tfrom {}", store.internal_location(func_id.unwrap()))
                 }
             }
         }
@@ -181,8 +183,13 @@ impl MonorubyErr {
                     "{}: {error_message}",
                     store.location(func_id.clone(), source, *loc),
                 );
-                source.show_loc(loc);
-                loc_flag = true;
+                // CRuby's runtime-error report is the compact
+                // `file:line:in 'method': message` form; only syntax
+                // errors keep the source excerpt with a caret.
+                if matches!(self.kind, MonorubyErrKind::Syntax) {
+                    source.show_loc(loc);
+                    loc_flag = true;
+                }
             } else if let Some(func_id) = func_id {
                 eprintln!("{}: {error_message}", store.internal_location(*func_id),);
             } else {

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -835,20 +835,42 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
 
     // --- Command-line flag mirrors -------------------------------------------
 
-    // `$-a`, `$-l`, `$-p` mirror the corresponding CLI switches, none of
-    // which monoruby implements, so they read as `false` and are
+    // `$-a`, `$-l`, `$-p` mirror the corresponding CLI switches (set by
+    // `set_cli_flag_gvars` during option processing in `main`) and are
     // read-only like in CRuby.
-    fn get_false(
+    fn get_cli_flag(
         _vm: &mut Executor,
         _globals: &mut Globals,
-        _name: IdentId,
+        name: IdentId,
     ) -> Option<Value> {
-        Some(Value::bool(false))
+        let idx = match name.get_name().as_str() {
+            "$-a" => 0,
+            "$-l" => 1,
+            _ => 2,
+        };
+        Some(Value::bool(CLI_FLAGS[idx].load(std::sync::atomic::Ordering::Relaxed)))
     }
 
     for flag in ["$-a", "$-l", "$-p"] {
-        globals.define_hooked_variable(IdentId::get_id(flag), get_false, None);
+        globals.define_hooked_variable(IdentId::get_id(flag), get_cli_flag, None);
     }
+}
+
+/// Backing store for the `$-a` / `$-l` / `$-p` command-line flag
+/// mirrors, in that order.
+static CLI_FLAGS: [std::sync::atomic::AtomicBool; 3] = [
+    std::sync::atomic::AtomicBool::new(false),
+    std::sync::atomic::AtomicBool::new(false),
+    std::sync::atomic::AtomicBool::new(false),
+];
+
+/// Record the `-a` / `-l` / `-p` command-line switches so their gvar
+/// mirrors read back `true`.
+pub fn set_cli_flag_gvars(auto_split: bool, line_ending: bool, print_loop: bool) {
+    use std::sync::atomic::Ordering;
+    CLI_FLAGS[0].store(auto_split, Ordering::Relaxed);
+    CLI_FLAGS[1].store(line_ending, Ordering::Relaxed);
+    CLI_FLAGS[2].store(print_loop, Ordering::Relaxed);
 }
 
 // ============================================================================

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -394,7 +394,14 @@ impl Store {
             if mother != iseq_id {
                 return format!("block in {}", self.func_description(self[mother].func_id()));
             } else {
-                iseq.name()
+                // The toplevel frame's internal name is `/main`
+                // (`IdentId::_MAIN`); CRuby displays it as `<main>`.
+                let name = iseq.name();
+                if name == "/main" {
+                    "<main>".to_string()
+                } else {
+                    name
+                }
             }
         } else {
             if let Some(name) = info.name() {

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -63,6 +63,7 @@ pub use executor::Executor;
 pub use executor::frame_leak_stats;
 pub use executor::install_panic_hook;
 pub use globals::OBJECT_CLASS;
+pub use globals::set_cli_flag_gvars;
 pub use globals::{load_file, read_source_file};
 pub use globals::{Globals, MonorubyErr, MonorubyErrKind};
 pub use value::*;

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -962,10 +962,18 @@ fn main() {
         }
     }
 
+    let from_exec = !opts.exec.is_empty();
     match globals.run_with_prelude(&requires, &prelude, code, &path) {
         Ok(_val) => {
+            // Debug builds echo the result value of `-e` one-liners to
+            // stderr (script files stay silent, as before, so specs
+            // that capture stderr aren't polluted).
             #[cfg(debug_assertions)]
-            eprintln!("=> {:?}", _val)
+            if from_exec {
+                eprintln!("=> {:?}", _val)
+            }
+            #[cfg(not(debug_assertions))]
+            let _ = from_exec;
         }
         Err(err) => {
             handle_error(err, &globals);

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -1,4 +1,6 @@
+use std::ffi::{OsStr, OsString};
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use monoruby::*;
 
@@ -17,68 +19,26 @@ fn handle_error(err: MonorubyErr, globals: &Globals) -> ! {
     std::process::exit(1);
 }
 
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum ParserKind {
-    Prism,
-}
-
-#[derive(clap::Parser, Debug)]
-#[command(author, about, long_about = None)]
-struct CommandLineArgs {
-    /// one line of script. several -e's allowed. Omit [programfile]
-    /// (OsString so a `# encoding:`-tagged script with non-UTF-8 bytes
-    /// in its literals reaches the parser unmangled).
-    #[arg(short, num_args = 0..)]
-    exec: Vec<std::ffi::OsString>,
-    /// print the version number, then exit
-    #[arg(short, long)]
-    version: bool,
-    /// switch for just-in-time compilation.
-    #[arg(long)]
-    no_jit: bool,
-    /// switch for loading gems.
-    #[arg(long)]
-    disable_gems: bool,
-    /// switch for garbage collection.
-    #[arg(long)]
-    no_gc: bool,
-    /// dump the parsed ruby-prism AST and exit.
-    #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "prism", value_name = "PARSER")]
-    ast: Option<ParserKind>,
-    /// require the library before executing your script.
-    #[arg(short = 'r', value_name = "library")]
-    require: Vec<String>,
-    /// specify $LOAD_PATH directory (may be used more than once).
-    #[arg(short = 'I')]
-    directory: Vec<String>,
-    /// set warning level; 0=silence, 1=medium, 2=verbose.
-    #[arg(short = 'W', default_value = "1")]
-    warning: u8,
-    /// File name.
-    #[arg(num_args = 0.., trailing_var_arg = true)]
-    file: Vec<String>,
-}
-
 /// Raw bytes of an OS-native CLI argument (Unix: no conversion).
-fn os_bytes(s: &std::ffi::OsStr) -> &[u8] {
+fn os_bytes(s: &OsStr) -> &[u8] {
     std::os::unix::ffi::OsStrExt::as_bytes(s)
 }
 
-fn dump_ast(code: &[u8], _path: &std::path::Path, kind: ParserKind, _globals: &Globals) {
-    match kind {
-        ParserKind::Prism => {
-            let result = ruby_prism::parse(code);
-            for diag in result.errors() {
-                eprintln!(
-                    "prism error at {}..{}: {}",
-                    diag.location().start_offset(),
-                    diag.location().end_offset(),
-                    diag.message(),
-                );
-            }
-            eprintln!("{:#?}", result.node());
-        }
+fn os_from_bytes(b: &[u8]) -> OsString {
+    <OsStr as std::os::unix::ffi::OsStrExt>::from_bytes(b).to_os_string()
+}
+
+fn dump_ast(code: &[u8]) {
+    let result = ruby_prism::parse(code);
+    for diag in result.errors() {
+        eprintln!(
+            "prism error at {}..{}: {}",
+            diag.location().start_offset(),
+            diag.location().end_offset(),
+            diag.message(),
+        );
     }
+    eprintln!("{:#?}", result.node());
 }
 
 /// Phase-0 measurement: print the heap-frame leak tally at process
@@ -94,100 +54,921 @@ impl Drop for FrameStatsGuard {
     }
 }
 
-fn main() {
-    use clap::Parser;
-    install_panic_hook();
-    let _frame_stats = FrameStatsGuard;
-    let mut finish_flag = false;
-    let args = CommandLineArgs::parse();
-    let mut globals = Globals::new(args.warning, args.no_jit, args.disable_gems);
-    Globals::gc_enable(!args.no_gc);
-    let lib = args.directory.iter().map(|s| {
-        std::path::Path::new(s)
-            .canonicalize()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| s.clone())
-    });
-    globals.extend_load_path(lib);
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopMode {
+    #[default]
+    None,
+    /// `-n`: wrap the script in `while gets ... end`.
+    Gets,
+    /// `-p`: same as `-n`, plus `print $_` at the end of each iteration.
+    GetsPrint,
+}
 
-    if args.version {
-        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-        finish_flag = true;
+/// Parsed command-line switches. Filled once from the actual command
+/// line and once more from `RUBYOPT` (which permits only a subset of
+/// switches); the two are merged with command-line priority.
+#[derive(Default, Debug)]
+struct Opts {
+    /// `-e` one-liners, joined by newlines into a single program.
+    exec: Vec<OsString>,
+    /// `-r` libraries.
+    requires: Vec<String>,
+    /// `-I` load-path directories.
+    includes: Vec<String>,
+    /// Explicit `-W<level>` (0/1/2). `None` when only `-w`/`-v` given.
+    warning_level: Option<u8>,
+    /// `-W:<category>` / `-W:no-<category>` toggles, in order.
+    warn_categories: Vec<(String, bool)>,
+    /// `-w` / `-v` / `--verbose`.
+    verbose: bool,
+    /// `-v`: print the version banner (and exit if no program).
+    print_version: bool,
+    /// `--version`: print the version banner and exit.
+    version_only: bool,
+    /// `--copyright`.
+    copyright: bool,
+    /// `-h` / `--help`.
+    help: bool,
+    /// `-d` / `--debug`.
+    debug: bool,
+    /// `-c`: syntax check only.
+    syntax_check: bool,
+    /// `-C dir` / `-X dir`, applied in order.
+    chdir: Vec<String>,
+    /// `-s`: parse `-switch[=value]` args after the script name into globals.
+    dash_s: bool,
+    loop_mode: LoopMode,
+    /// `-a`.
+    auto_split: bool,
+    /// `-l`.
+    line_ending: bool,
+    /// `-0[octal]`: the raw octal digits ("" for a bare `-0`).
+    record_sep: Option<String>,
+    /// `-F pattern`.
+    field_sep: Option<String>,
+    /// `-x[dir]`.
+    dash_x: bool,
+    x_dir: Option<String>,
+    /// `-S`: search RUBYPATH / PATH for the script.
+    search_path: bool,
+    /// `-E ext[:int]` / `--encoding` / `--external-encoding`.
+    external_enc: Option<String>,
+    /// `-E ext:int` / `-E :int` / `--internal-encoding`.
+    internal_enc: Option<String>,
+    /// `-U`.
+    set_internal_utf8: bool,
+    /// `-K<code>`.
+    kcode: Option<char>,
+    /// `--backtrace-limit=N` (accepted; truncation not yet implemented).
+    #[allow(dead_code)]
+    backtrace_limit: Option<i64>,
+    /// `--enable[-=]FEATURE` / `--disable[-=]FEATURE`, in order.
+    features: Vec<(String, bool)>,
+    /// monoruby-specific switches.
+    no_jit: bool,
+    no_gc: bool,
+    ast: bool,
+    /// Script name + program arguments (everything after the switches).
+    args: Vec<OsString>,
+}
+
+enum ParseFail {
+    /// Unknown or unsupported switch.
+    InvalidOption(String),
+    /// A switch that requires an argument was given none.
+    MissingArg(String),
+    /// A switch that is not permitted in RUBYOPT.
+    Forbidden(String),
+    /// Pre-formatted whole message.
+    Message(String),
+}
+
+impl ParseFail {
+    fn switch(&self) -> &str {
+        match self {
+            ParseFail::InvalidOption(s)
+            | ParseFail::MissingArg(s)
+            | ParseFail::Forbidden(s)
+            | ParseFail::Message(s) => s,
+        }
     }
+}
 
-    if !args.exec.is_empty() {
-        let path = std::path::Path::new("-e");
-        let argv = Value::array_from_iter(args.file.iter().cloned().map(Value::string));
-        globals.set_constant_by_str(OBJECT_CLASS, "ARGV", argv);
-        globals.set_gvar(monoruby::IdentId::get_id("$*"), argv);
-        if let Some(kind) = args.ast {
-            for code in args.exec {
-                dump_ast(os_bytes(&code), path, kind, &globals);
+/// Take an option's value: the rest of the current token if non-empty,
+/// otherwise the next token.
+fn take_value(
+    bytes: &[u8],
+    idx: usize,
+    tokens: &[OsString],
+    i: &mut usize,
+    switch: &str,
+) -> Result<OsString, ParseFail> {
+    if idx < bytes.len() {
+        Ok(os_from_bytes(&bytes[idx..]))
+    } else if *i < tokens.len() {
+        let v = tokens[*i].clone();
+        *i += 1;
+        Ok(v)
+    } else {
+        Err(ParseFail::MissingArg(switch.to_string()))
+    }
+}
+
+fn lossy(s: &OsStr) -> String {
+    s.to_string_lossy().into_owned()
+}
+
+/// Short switches permitted inside RUBYOPT (CRuby's `moreswitches` set).
+const RUBYOPT_SHORT: &str = "dEIKrTUvwW";
+
+fn parse_switches(tokens: &[OsString], opts: &mut Opts, rubyopt: bool) -> Result<(), ParseFail> {
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = tokens[i].clone();
+        let bytes = os_bytes(&tok);
+        if bytes == b"--" {
+            if rubyopt {
+                return Err(ParseFail::Forbidden("--".to_string()));
             }
+            opts.args.extend(tokens[i + 1..].iter().cloned());
+            return Ok(());
+        }
+        if bytes.starts_with(b"--") {
+            i += 1;
+            parse_long(&lossy(&tok), tokens, &mut i, opts, rubyopt)?;
+            continue;
+        }
+        if bytes.len() >= 2 && bytes[0] == b'-' {
+            i += 1;
+            parse_short_cluster(bytes, tokens, &mut i, opts, rubyopt)?;
+            continue;
+        }
+        // Not a switch: the script name; everything after it is ARGV.
+        if rubyopt {
+            return Err(ParseFail::Forbidden(lossy(&tok)));
+        }
+        opts.args.extend(tokens[i..].iter().cloned());
+        return Ok(());
+    }
+    Ok(())
+}
+
+fn parse_long(
+    s: &str,
+    tokens: &[OsString],
+    i: &mut usize,
+    opts: &mut Opts,
+    rubyopt: bool,
+) -> Result<(), ParseFail> {
+    let (name, mut value) = match s.split_once('=') {
+        Some((n, v)) => (n.to_string(), Some(v.to_string())),
+        None => (s.to_string(), None),
+    };
+    let mut next_value = |value: Option<String>| -> Result<String, ParseFail> {
+        if let Some(v) = value {
+            Ok(v)
+        } else if *i < tokens.len() {
+            let v = lossy(&tokens[*i]);
+            *i += 1;
+            Ok(v)
         } else {
-            // Multiple `-e` options form a single program (joined by
-            // newlines), matching CRuby, so `-r` libraries and `at_exit`
-            // handlers are processed once around the combined script.
-            let code: Vec<u8> = args
-                .exec
-                .iter()
-                .map(|s| os_bytes(s))
-                .collect::<Vec<_>>()
-                .join(&b'\n');
-            match globals.run_with_requires(&args.require, code, path) {
-                Ok(_val) => {
-                    #[cfg(debug_assertions)]
-                    eprintln!("=> {:?}", _val)
+            Err(ParseFail::MissingArg(name.clone()))
+        }
+    };
+    // --enable-FEATURE / --disable-FEATURE (also --enable=F / --disable=F,
+    // comma-separated lists allowed). This arm also covers the historic
+    // monoruby spelling `--disable-gems`.
+    for (prefix, on) in [("--enable", true), ("--disable", false)] {
+        if name == prefix || name.starts_with(&format!("{prefix}-")) {
+            let list = if name == prefix {
+                next_value(value.take())?
+            } else {
+                name[prefix.len() + 1..].to_string()
+            };
+            for feat in list.split(',') {
+                opts.features.push((feat.to_string(), on));
+            }
+            return Ok(());
+        }
+    }
+    if rubyopt
+        && !matches!(
+            name.as_str(),
+            "--debug"
+                | "--verbose"
+                | "--encoding"
+                | "--external-encoding"
+                | "--internal-encoding"
+        )
+    {
+        return Err(ParseFail::Forbidden(name));
+    }
+    match name.as_str() {
+        "--version" => opts.version_only = true,
+        "--copyright" => opts.copyright = true,
+        "--help" => opts.help = true,
+        "--verbose" => opts.verbose = true,
+        "--debug" => opts.debug = true,
+        "--no-jit" => opts.no_jit = true,
+        "--no-gc" => opts.no_gc = true,
+        "--ast" => {
+            // Optional value (historically `--ast=prism`); ignore it.
+            opts.ast = true;
+        }
+        "--encoding" => {
+            let v = next_value(value)?;
+            parse_encoding_spec(&v, opts)?;
+        }
+        "--external-encoding" => opts.external_enc = Some(next_value(value)?),
+        "--internal-encoding" => opts.internal_enc = Some(next_value(value)?),
+        "--backtrace-limit" => {
+            let v = next_value(value)?;
+            opts.backtrace_limit = v.parse::<i64>().ok();
+        }
+        _ => return Err(ParseFail::InvalidOption(name)),
+    }
+    Ok(())
+}
+
+/// `ext[:int]` for `-E` / `--encoding`. A third component is an error.
+fn parse_encoding_spec(spec: &str, opts: &mut Opts) -> Result<(), ParseFail> {
+    let parts: Vec<&str> = spec.split(':').collect();
+    if parts.len() > 2 {
+        return Err(ParseFail::Message(format!(
+            "monoruby: extra argument for --encoding: {} (RuntimeError)",
+            parts[2]
+        )));
+    }
+    if let Some(ext) = parts.first()
+        && !ext.is_empty()
+    {
+        opts.external_enc = Some(ext.to_string());
+    }
+    if let Some(int) = parts.get(1)
+        && !int.is_empty()
+    {
+        opts.internal_enc = Some(int.to_string());
+    }
+    Ok(())
+}
+
+fn parse_short_cluster(
+    bytes: &[u8],
+    tokens: &[OsString],
+    i: &mut usize,
+    opts: &mut Opts,
+    rubyopt: bool,
+) -> Result<(), ParseFail> {
+    let mut idx = 1;
+    while idx < bytes.len() {
+        let c = bytes[idx] as char;
+        idx += 1;
+        if rubyopt && !RUBYOPT_SHORT.contains(c) {
+            return Err(ParseFail::Forbidden(format!("-{c}")));
+        }
+        match c {
+            'e' => {
+                let v = take_value(bytes, idx, tokens, i, "-e")?;
+                opts.exec.push(v);
+                return Ok(());
+            }
+            'r' => {
+                let v = take_value(bytes, idx, tokens, i, "-r")?;
+                opts.requires.push(lossy(&v));
+                return Ok(());
+            }
+            'I' => {
+                let v = take_value(bytes, idx, tokens, i, "-I")?;
+                opts.includes.push(lossy(&v));
+                return Ok(());
+            }
+            'C' | 'X' => {
+                let v = take_value(bytes, idx, tokens, i, "-C")?;
+                opts.chdir.push(lossy(&v));
+                return Ok(());
+            }
+            'F' => {
+                let v = take_value(bytes, idx, tokens, i, "-F")?;
+                opts.field_sep = Some(lossy(&v));
+                return Ok(());
+            }
+            'E' => {
+                let v = take_value(bytes, idx, tokens, i, "-E")?;
+                parse_encoding_spec(&lossy(&v), opts)?;
+                return Ok(());
+            }
+            'K' => {
+                if idx < bytes.len() {
+                    opts.kcode = Some(bytes[idx] as char);
+                    idx += 1;
                 }
-                Err(err) => {
-                    handle_error(err, &globals);
+            }
+            'W' => {
+                if idx < bytes.len() && bytes[idx] == b':' {
+                    let cat = String::from_utf8_lossy(&bytes[idx + 1..]).into_owned();
+                    let (name, on) = match cat.strip_prefix("no-") {
+                        Some(rest) => (rest.to_string(), false),
+                        None => (cat, true),
+                    };
+                    opts.warn_categories.push((name, on));
+                    return Ok(());
+                }
+                if idx < bytes.len() && bytes[idx].is_ascii_digit() {
+                    opts.warning_level = Some((bytes[idx] - b'0').min(2));
+                    idx += 1;
+                } else {
+                    opts.warning_level = Some(2);
+                }
+            }
+            '0' => {
+                let start = idx;
+                while idx < bytes.len() && (b'0'..=b'7').contains(&bytes[idx]) {
+                    idx += 1;
+                }
+                opts.record_sep = Some(String::from_utf8_lossy(&bytes[start..idx]).into_owned());
+            }
+            'x' => {
+                opts.dash_x = true;
+                if idx < bytes.len() {
+                    opts.x_dir = Some(String::from_utf8_lossy(&bytes[idx..]).into_owned());
+                }
+                return Ok(());
+            }
+            'T' => {
+                // Historic taint level: swallow the digits, ignore.
+                while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+                    idx += 1;
+                }
+            }
+            'v' => {
+                opts.print_version = true;
+                opts.verbose = true;
+            }
+            'w' => opts.verbose = true,
+            'd' => opts.debug = true,
+            'c' => opts.syntax_check = true,
+            'a' => opts.auto_split = true,
+            'l' => opts.line_ending = true,
+            'n' => {
+                if opts.loop_mode == LoopMode::None {
+                    opts.loop_mode = LoopMode::Gets;
+                }
+            }
+            'p' => opts.loop_mode = LoopMode::GetsPrint,
+            's' => opts.dash_s = true,
+            'S' => opts.search_path = true,
+            'U' => opts.set_internal_utf8 = true,
+            'h' => opts.help = true,
+            _ => return Err(ParseFail::InvalidOption(format!("-{c}"))),
+        }
+    }
+    Ok(())
+}
+
+fn fail_cli(f: ParseFail) -> ! {
+    match f {
+        ParseFail::Message(msg) => eprintln!("{msg}"),
+        ParseFail::MissingArg(sw) => {
+            eprintln!("monoruby: missing argument for {sw} (RuntimeError)")
+        }
+        ParseFail::InvalidOption(sw) | ParseFail::Forbidden(sw) => {
+            eprintln!("monoruby: invalid option {sw}  (-h will show valid options) (RuntimeError)")
+        }
+    }
+    std::process::exit(1);
+}
+
+fn fail_rubyopt(f: ParseFail) -> ! {
+    eprintln!(
+        "monoruby: invalid switch in RUBYOPT: {} (RuntimeError)",
+        f.switch()
+    );
+    std::process::exit(1);
+}
+
+/// `File.expand_path` semantics minus `~`: absolutize against the CWD
+/// and remove `.` / `..` segments lexically (never resolving symlinks).
+fn expand_path(p: &str) -> String {
+    let path = Path::new(p);
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("/"))
+            .join(path)
+    };
+    let mut out = PathBuf::new();
+    for comp in abs.components() {
+        use std::path::Component::*;
+        match comp {
+            CurDir => {}
+            ParentDir => {
+                out.pop();
+            }
+            c => out.push(c.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
+
+/// `-S`: look the script up in RUBYPATH, then PATH.
+fn search_script_in_path(name: &str) -> Option<PathBuf> {
+    for var in ["RUBYPATH", "PATH"] {
+        if let Ok(dirs) = std::env::var(var) {
+            for dir in dirs.split(':') {
+                if dir.is_empty() {
+                    continue;
+                }
+                let cand = Path::new(dir).join(name);
+                if cand.is_file() {
+                    return Some(cand);
                 }
             }
         }
+    }
+    None
+}
+
+/// `-x` (and the automatic variant triggered by a non-ruby `#!` first
+/// line): strip everything before the first `#!`-line that mentions
+/// `ruby`, replacing it with blank lines so line numbers stay stable.
+/// With `forced` set, not finding such a line is an error.
+fn preprocess_shebang(code: Vec<u8>, forced: bool) -> Result<Vec<u8>, String> {
+    fn contains(hay: &[u8], needle: &[u8]) -> bool {
+        hay.windows(needle.len()).any(|w| w == needle)
+    }
+    if !forced {
+        let first_line = code.split(|&b| b == b'\n').next().unwrap_or(&[]);
+        if !(first_line.starts_with(b"#!") && !contains(first_line, b"ruby")) {
+            return Ok(code);
+        }
+    }
+    let mut offset = 0;
+    let mut lineno = 0;
+    while offset < code.len() {
+        let end = code[offset..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| offset + p + 1)
+            .unwrap_or(code.len());
+        let line = &code[offset..end];
+        if line.starts_with(b"#!") && contains(line, b"ruby") {
+            let mut new_code = vec![b'\n'; lineno + 1];
+            new_code.extend_from_slice(&code[end..]);
+            return Ok(new_code);
+        }
+        offset = end;
+        lineno += 1;
+    }
+    if forced {
+        Err("no Ruby script found in input".to_string())
+    } else {
+        Ok(code)
+    }
+}
+
+/// Emit a Ruby double-quoted string literal evaluating to `s`'s bytes.
+fn ruby_str_lit(s: &str) -> String {
+    let mut out = String::from("\"");
+    for &b in s.as_bytes() {
+        match b {
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'#' => out.push_str("\\#"),
+            0x20..=0x7e => out.push(b as char),
+            _ => out.push_str(&format!("\\x{b:02X}")),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn print_usage() {
+    println!(
+        "Usage: monoruby [switches] [--] [programfile] [arguments]
+  -0[octal]       specify record separator (\\0, if no argument)
+  -a              autosplit mode with -n or -p (splits $_ into $F)
+  -c              check syntax only
+  -Cdirectory     cd to directory before executing your script
+  -d, --debug     set debugging flags (set $DEBUG to true)
+  -e 'command'    one line of script. Several -e's allowed. Omit [programfile]
+  -Eex[:in], --encoding=ex[:in]
+                  specify the default external and internal character encodings
+  -Fpattern       split() pattern for autosplit (-a)
+  -Idirectory     specify $LOAD_PATH directory (may be used more than once)
+  -l              enable line ending processing
+  -n              assume 'while gets(); ... end' loop around your script
+  -p              assume loop like -n but print line also like sed
+  -rlibrary       require the library before executing your script
+  -s              enable some switch parsing for switches after script name
+  -S              look for the script using PATH environment variable
+  -U              set the internal encoding to UTF-8
+  -v              print the version number, then turn on verbose mode
+  -w              turn warnings on for your script
+  -W[level=2|:category]
+                  set warning level; 0=silence, 1=medium, 2=verbose
+  -x[directory]   strip off text before #!ruby line and perhaps cd to directory
+  -h              show this message, --help for more options
+  --ast           dump the parsed ruby-prism AST and exit
+  --no-jit        disable just-in-time compilation
+  --no-gc         disable garbage collection
+  --enable=feature[,...], --disable=feature[,...]
+                  enable or disable features (gems, did_you_mean, rubyopt,
+                  frozen-string-literal, all)"
+    );
+}
+
+fn main() {
+    install_panic_hook();
+    let _frame_stats = FrameStatsGuard;
+    let tokens: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let mut opts = Opts::default();
+    if let Err(f) = parse_switches(&tokens, &mut opts, false) {
+        fail_cli(f);
+    }
+
+    // `-E ext:int` and `-U` conflict — but only when both come from the
+    // actual command line (an `-U` in RUBYOPT is overridden silently).
+    if opts.set_internal_utf8
+        && let Some(int) = &opts.internal_enc
+    {
+        eprintln!(
+            "monoruby: -U is incompatible with the internal encoding already set to {int} (RuntimeError)"
+        );
+        std::process::exit(1);
+    }
+
+    // RUBYOPT (unless --disable-rubyopt).
+    let rubyopt_enabled = opts
+        .features
+        .iter()
+        .rev()
+        .find(|(f, _)| f == "rubyopt" || f == "all")
+        .map(|(_, on)| *on)
+        .unwrap_or(true);
+    let mut ropts = Opts::default();
+    if rubyopt_enabled
+        && let Some(val) = std::env::var_os("RUBYOPT")
+    {
+        let rtokens: Vec<OsString> = val
+            .to_string_lossy()
+            .split_whitespace()
+            .map(OsString::from)
+            .collect();
+        if let Err(f) = parse_switches(&rtokens, &mut ropts, true) {
+            fail_rubyopt(f);
+        }
+    }
+
+    // Merge RUBYOPT with command-line priority.
+    opts.requires.extend(ropts.requires);
+    opts.includes.extend(ropts.includes);
+    opts.print_version |= ropts.print_version;
+    opts.debug |= ropts.debug;
+    if opts.external_enc.is_none() {
+        opts.external_enc = ropts.external_enc;
+    }
+    if opts.internal_enc.is_none() {
+        opts.internal_enc = ropts.internal_enc;
+    }
+    opts.set_internal_utf8 |= ropts.set_internal_utf8;
+    if opts.kcode.is_none() {
+        opts.kcode = ropts.kcode;
+    }
+    // Explicit command-line settings win; otherwise RUBYOPT applies.
+    let warning_level = opts
+        .warning_level
+        .or(if opts.verbose || opts.debug { Some(2) } else { None })
+        .or(ropts.warning_level)
+        .or(if ropts.verbose || ropts.debug {
+            Some(2)
+        } else {
+            None
+        })
+        .unwrap_or(1);
+    // RUBYOPT categories first so command-line ones override them.
+    let mut warn_categories = ropts.warn_categories;
+    warn_categories.extend(std::mem::take(&mut opts.warn_categories));
+    let mut features = ropts.features;
+    features.extend(std::mem::take(&mut opts.features));
+
+    // Resolve --enable/--disable features.
+    let mut gems = true;
+    let mut did_you_mean = false;
+    let mut frozen_string_literal: Option<bool> = None;
+    for (name, on) in &features {
+        match name.as_str() {
+            "gems" | "gem" => gems = *on,
+            "did_you_mean" => did_you_mean = *on,
+            "rubyopt" => {}
+            "frozen-string-literal" | "frozen_string_literal" => {
+                frozen_string_literal = Some(*on)
+            }
+            "error_highlight" | "syntax_suggest" | "jit" | "yjit" | "zjit" | "rjit" => {}
+            "all" => {
+                gems = *on;
+                did_you_mean = *on;
+                frozen_string_literal = Some(*on);
+            }
+            other => eprintln!(
+                "monoruby: warning: unknown argument for --{}: `{}'",
+                if *on { "enable" } else { "disable" },
+                other
+            ),
+        }
+    }
+    if let Some(f) = frozen_string_literal {
+        parser::set_frozen_string_literal_default(f);
+    }
+
+    // -C / -X (and the -x variant with a directory).
+    for dir in opts.chdir.iter().chain(opts.x_dir.iter()) {
+        if let Err(err) = std::env::set_current_dir(dir) {
+            let msg = err.to_string();
+            let msg = msg.split(" (os error ").next().unwrap();
+            eprintln!("monoruby: Can't chdir to {dir} ({msg})");
+            std::process::exit(1);
+        }
+    }
+
+    let mut globals = Globals::new(warning_level, opts.no_jit, !gems);
+    Globals::gc_enable(!opts.no_gc);
+
+    if opts.help {
+        print_usage();
+        return;
+    }
+    if opts.version_only {
+        println!("{}", globals.ruby_description());
+        return;
+    }
+    if opts.copyright {
+        println!("{}", globals.ruby_copyright());
+        return;
+    }
+    if opts.print_version {
+        println!("{}", globals.ruby_description());
+    }
+
+    // $LOAD_PATH front: -I dirs (expanded, symlinks untouched), then
+    // RUBYOPT -I dirs (already appended above), then RUBYLIB.
+    let mut front: Vec<String> = opts.includes.iter().map(|d| expand_path(d)).collect();
+    if let Ok(rubylib) = std::env::var("RUBYLIB") {
+        front.extend(
+            rubylib
+                .split(':')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
+        );
+    }
+    globals.prepend_load_path(front.into_iter());
+
+    let mut requires = Vec::new();
+    if did_you_mean {
+        requires.push("did_you_mean".to_string());
+    }
+    requires.append(&mut opts.requires);
+
+    // Determine the program source.
+    let mut prog_args = std::mem::take(&mut opts.args);
+    let (code, path): (Vec<u8>, PathBuf) = if !opts.exec.is_empty() {
+        // Multiple `-e` options form a single program (joined by
+        // newlines), matching CRuby, so `-r` libraries and `at_exit`
+        // handlers are processed once around the combined script.
+        let code: Vec<u8> = opts
+            .exec
+            .iter()
+            .map(|s| os_bytes(s))
+            .collect::<Vec<_>>()
+            .join(&b'\n');
+        (code, PathBuf::from("-e"))
+    } else {
+        let first = if prog_args.is_empty() {
+            None
+        } else {
+            Some(prog_args.remove(0))
+        };
+        match first {
+            Some(f) if os_bytes(&f) != b"-" => {
+                let file_name = lossy(&f);
+                let script_path = if opts.search_path {
+                    match search_script_in_path(&file_name) {
+                        Some(p) => p,
+                        None => {
+                            eprintln!(
+                                "monoruby: No such file or directory -- {file_name} (LoadError)"
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                } else {
+                    PathBuf::from(&file_name)
+                };
+                match read_source_file(&script_path) {
+                    // Keep the path exactly as given on the command line: CRuby
+                    // reports `$0` / `__FILE__` for the main script verbatim
+                    // (relative stays relative), not canonicalized.
+                    Ok((code, _resolved)) => (code, script_path),
+                    Err(err) => {
+                        // No VM frame exists yet, so a `MonorubyErr` here would
+                        // carry no trace and cannot be displayed as a normal
+                        // exception. Print CRuby's one-liner instead
+                        // (`ruby: No such file or directory -- t.rb (LoadError)`).
+                        // `io::Error`'s Display appends ` (os error N)`, which
+                        // CRuby's strerror-based message doesn't have — strip it.
+                        let msg = err.to_string();
+                        let msg = msg.split(" (os error ").next().unwrap();
+                        eprintln!("monoruby: {msg} -- {file_name} (LoadError)");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            other => {
+                if opts.print_version {
+                    // `-v` with no program: the banner is the whole output.
+                    return;
+                }
+                let _ = other;
+                // Read stdin as raw bytes: a script piped in may contain
+                // non-UTF-8 bytes (e.g. a `# encoding:`-tagged source with
+                // high bytes in a string literal); the whole source pipeline
+                // carries bytes, so they round-trip into literals verbatim.
+                let mut bytes = Vec::new();
+                std::io::stdin()
+                    .read_to_end(&mut bytes)
+                    .expect("failed to read stdin");
+                (bytes, PathBuf::from("-"))
+            }
+        }
+    };
+
+    // `-x` / a non-ruby `#!` first line: strip the leading garbage.
+    let code = match preprocess_shebang(code, opts.dash_x) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("monoruby: {msg} (LoadError)");
+            std::process::exit(1);
+        }
+    };
+
+    // `-s`: consume `-switch[=value]` program arguments into globals.
+    if opts.dash_s {
+        while !prog_args.is_empty() {
+            let arg = lossy(&prog_args[0]);
+            if !arg.starts_with('-') || arg == "-" {
+                break;
+            }
+            prog_args.remove(0);
+            if arg == "--" {
+                break;
+            }
+            let body = &arg[1..];
+            let (name, value) = match body.split_once('=') {
+                Some((n, v)) => (n.to_string(), Some(v.to_string())),
+                None => (body.to_string(), None),
+            };
+            let name = name.replace('-', "_");
+            if name.is_empty()
+                || !name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                eprintln!("monoruby: invalid name for global variable - {arg} (NameError)");
+                std::process::exit(1);
+            }
+            let val = match value {
+                Some(v) => Value::string(v),
+                None => Value::bool(true),
+            };
+            globals.set_gvar(monoruby::IdentId::get_id(&format!("${name}")), val);
+        }
+    }
+
+    let argv = Value::array_from_iter(prog_args.iter().map(|s| Value::string(lossy(s))));
+    globals.set_constant_by_str(OBJECT_CLASS, "ARGV", argv);
+    globals.set_gvar(monoruby::IdentId::get_id("$*"), argv);
+
+    if opts.ast {
+        dump_ast(&code);
         return;
     }
 
-    let mut iter = args.file.into_iter();
-    let first = iter.next();
-    let argv = Value::array_from_iter(iter.map(Value::string));
-    globals.set_constant_by_str(OBJECT_CLASS, "ARGV", argv);
-    globals.set_gvar(monoruby::IdentId::get_id("$*"), argv);
-    let (code, path) = if let Some(file_name) = first {
-        match read_source_file(&std::path::PathBuf::from(&file_name)) {
-            // Keep the path exactly as given on the command line: CRuby
-            // reports `$0` / `__FILE__` for the main script verbatim
-            // (relative stays relative), not canonicalized.
-            Ok((code, _resolved)) => (code, std::path::PathBuf::from(&file_name)),
+    if opts.syntax_check {
+        match parser::parse_program(code, path.as_path()) {
+            Ok(_) => {
+                println!("Syntax OK");
+                return;
+            }
             Err(err) => {
-                // No VM frame exists yet, so a `MonorubyErr` here would
-                // carry no trace and cannot be displayed as a normal
-                // exception. Print CRuby's one-liner instead
-                // (`ruby: No such file or directory -- t.rb (LoadError)`).
-                // `io::Error`'s Display appends ` (os error N)`, which
-                // CRuby's strerror-based message doesn't have — strip it.
-                let msg = err.to_string();
-                let msg = msg.split(" (os error ").next().unwrap();
-                eprintln!("monoruby: {msg} -- {file_name} (LoadError)");
+                err.show_error_message_and_all_loc(&globals.store);
                 std::process::exit(1);
             }
         }
-    } else {
-        if finish_flag {
-            return;
+    }
+
+    // `-n` / `-p`: arm the implicit `while gets ... end` wrap for the
+    // main script's parse (consumed by path match, so `require`d files
+    // are unaffected).
+    if opts.loop_mode != LoopMode::None {
+        parser::set_cli_loop_wrap(
+            path.clone(),
+            parser::CliLoopWrap {
+                print_last: opts.loop_mode == LoopMode::GetsPrint,
+                auto_split: opts.auto_split,
+                chomp: opts.line_ending,
+            },
+        );
+    }
+
+    // Ruby prelude synthesized from the remaining switches; runs inside
+    // the interpreter before `-r` requires and the script itself.
+    let mut prelude = String::new();
+    if let Some(enc) = &opts.external_enc {
+        prelude.push_str(&format!(
+            "Encoding.default_external = {}\n",
+            ruby_str_lit(enc)
+        ));
+    }
+    let internal_enc = opts.internal_enc.clone().or_else(|| {
+        opts.set_internal_utf8
+            .then(|| "UTF-8".to_string())
+    });
+    if let Some(enc) = &internal_enc {
+        prelude.push_str(&format!(
+            "Encoding.default_internal = {}\n",
+            ruby_str_lit(enc)
+        ));
+    }
+    if let Some(k) = opts.kcode {
+        let enc = match k {
+            'e' | 'E' => Some("EUC-JP"),
+            'u' | 'U' => Some("UTF-8"),
+            's' | 'S' => Some("Windows-31J"),
+            'a' | 'A' | 'n' | 'N' => Some("ASCII-8BIT"),
+            _ => None, // unknown codes are ignored, like CRuby
+        };
+        if let Some(enc) = enc {
+            prelude.push_str(&format!(
+                "Encoding.default_external = {}\n",
+                ruby_str_lit(enc)
+            ));
+            // `-K` also sets the main script's *source* encoding
+            // (`__ENCODING__`); a magic comment still wins.
+            parser::set_cli_source_encoding(path.clone(), enc.to_string());
         }
-        // Read stdin as raw bytes: a script piped in may contain
-        // non-UTF-8 bytes (e.g. a `# encoding:`-tagged source with
-        // high bytes in a string literal); the whole source pipeline
-        // carries bytes, so they round-trip into literals verbatim.
-        let mut bytes = Vec::new();
-        std::io::stdin()
-            .read_to_end(&mut bytes)
-            .expect("failed to read stdin");
-        (bytes, std::path::PathBuf::from("-"))
-    };
-    if let Some(kind) = args.ast {
-        dump_ast(&code, &path, kind, &globals);
-    } else if let Err(err) = globals.run_with_requires(&args.require, code, &path) {
-        handle_error(err, &globals);
+    }
+    if let Some(digits) = &opts.record_sep {
+        let lit = if digits.is_empty() {
+            // Bare `-0`: NUL separator.
+            Some("\"\\x00\"".to_string())
+        } else {
+            match u32::from_str_radix(digits, 8) {
+                Ok(0) => Some("\"\"".to_string()), // -00: paragraph mode
+                Ok(n) if n > 0o377 => None,        // -0777: slurp (nil)
+                Ok(n) => Some(format!("\"\\x{:02X}\"", n as u8)),
+                Err(_) => None,
+            }
+        };
+        match lit {
+            Some(lit) => prelude.push_str(&format!("$/ = {lit}\n")),
+            None => prelude.push_str("$/ = nil\n"),
+        }
+    }
+    if opts.line_ending {
+        prelude.push_str("$\\ = $/\n");
+    }
+    monoruby::set_cli_flag_gvars(
+        opts.auto_split,
+        opts.line_ending,
+        opts.loop_mode == LoopMode::GetsPrint,
+    );
+    if let Some(pat) = &opts.field_sep {
+        prelude.push_str(&format!("$; = Regexp.new({})\n", ruby_str_lit(pat)));
+    }
+    if opts.debug {
+        prelude.push_str("$DEBUG = true\n");
+    }
+    // Verbose mode turns deprecation warnings on by default; explicit
+    // -W:categories (applied afterwards) can override this.
+    if warning_level >= 2 {
+        prelude.push_str("Warning[:deprecated] = true\n");
+    }
+    for (cat, on) in &warn_categories {
+        match cat.as_str() {
+            "deprecated" | "experimental" | "performance" | "strict_unused_block" => {
+                prelude.push_str(&format!("Warning[:{cat}] = {on}\n"));
+            }
+            other => eprintln!("monoruby: warning: unknown warning category: `{other}'"),
+        }
+    }
+
+    match globals.run_with_prelude(&requires, &prelude, code, &path) {
+        Ok(_val) => {
+            #[cfg(debug_assertions)]
+            eprintln!("=> {:?}", _val)
+        }
+        Err(err) => {
+            handle_error(err, &globals);
+        }
     }
 }

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -979,10 +979,11 @@ fn main() {
     match globals.run_with_prelude(&requires, &prelude, code, &path) {
         Ok(_val) => {
             // Debug builds echo the result value of `-e` one-liners to
-            // stderr (script files stay silent, as before, so specs
-            // that capture stderr aren't polluted).
+            // stderr — but only on an interactive terminal, so test
+            // harnesses (mspec, `diff`-based CI checks) that capture a
+            // piped stderr never see it.
             #[cfg(debug_assertions)]
-            if from_exec {
+            if from_exec && std::io::IsTerminal::is_terminal(&std::io::stderr()) {
                 eprintln!("=> {:?}", _val)
             }
             #[cfg(not(debug_assertions))]

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -119,8 +119,7 @@ struct Opts {
     set_internal_utf8: bool,
     /// `-K<code>`.
     kcode: Option<char>,
-    /// `--backtrace-limit=N` (accepted; truncation not yet implemented).
-    #[allow(dead_code)]
+    /// `--backtrace-limit=N`.
     backtrace_limit: Option<i64>,
     /// `--enable[-=]FEATURE` / `--disable[-=]FEATURE`, in order.
     features: Vec<(String, bool)>,
@@ -693,6 +692,9 @@ fn main() {
 
     let mut globals = Globals::new(warning_level, opts.no_jit, !gems);
     Globals::gc_enable(!opts.no_gc);
+    if let Some(limit) = opts.backtrace_limit.or(ropts.backtrace_limit) {
+        Globals::set_backtrace_limit(limit);
+    }
 
     if opts.help {
         print_usage();

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -121,6 +121,8 @@ struct Opts {
     kcode: Option<char>,
     /// `--backtrace-limit=N`.
     backtrace_limit: Option<i64>,
+    /// `--debug-frozen-string-literal` (also implied by `--debug`/`-d`).
+    debug_frozen_string_literal: bool,
     /// `--enable[-=]FEATURE` / `--disable[-=]FEATURE`, in order.
     features: Vec<(String, bool)>,
     /// monoruby-specific switches.
@@ -254,6 +256,7 @@ fn parse_long(
         && !matches!(
             name.as_str(),
             "--debug"
+                | "--debug-frozen-string-literal"
                 | "--verbose"
                 | "--encoding"
                 | "--external-encoding"
@@ -268,6 +271,7 @@ fn parse_long(
         "--help" => opts.help = true,
         "--verbose" => opts.verbose = true,
         "--debug" => opts.debug = true,
+        "--debug-frozen-string-literal" => opts.debug_frozen_string_literal = true,
         "--no-jit" => opts.no_jit = true,
         "--no-gc" => opts.no_gc = true,
         "--ast" => {
@@ -694,6 +698,13 @@ fn main() {
     Globals::gc_enable(!opts.no_gc);
     if let Some(limit) = opts.backtrace_limit.or(ropts.backtrace_limit) {
         Globals::set_backtrace_limit(limit);
+    }
+    if opts.debug
+        || ropts.debug
+        || opts.debug_frozen_string_literal
+        || ropts.debug_frozen_string_literal
+    {
+        monoruby::set_debug_frozen_string_log();
     }
 
     if opts.help {

--- a/monoruby/src/parser/mod.rs
+++ b/monoruby/src/parser/mod.rs
@@ -10,11 +10,81 @@
 //! [`crate::globals::MonorubyErr`].
 
 use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicI8, Ordering};
 
 use crate::ast::{LvarCollector, ParseResult};
 use crate::globals::MonorubyErr;
 
 mod prism_backend;
+
+/// Implicit `while gets ... end` wrap requested by the `-n` / `-p`
+/// command-line switches. Applied to exactly one parse — the main
+/// script, identified by its path (`-e` scripts parse as `"-e"`) — and
+/// consumed on first match so `require`d files and `eval`s are never
+/// wrapped.
+#[derive(Debug, Clone, Copy)]
+pub struct CliLoopWrap {
+    /// `-p`: `print $_` at the end of each iteration.
+    pub print_last: bool,
+    /// `-a`: `$F = $_.split` at the top of each iteration.
+    pub auto_split: bool,
+    /// `-l`: `$_ = $_.chomp($/)` at the top of each iteration.
+    pub chomp: bool,
+}
+
+static CLI_LOOP_WRAP: Mutex<Option<(PathBuf, CliLoopWrap)>> = Mutex::new(None);
+
+/// Arm the `-n` / `-p` loop wrap for the main script at `path`.
+pub fn set_cli_loop_wrap(path: PathBuf, wrap: CliLoopWrap) {
+    *CLI_LOOP_WRAP.lock().unwrap() = Some((path, wrap));
+}
+
+/// Consume the armed loop wrap if `path` is the main script.
+pub(crate) fn take_cli_loop_wrap(path: &std::path::Path) -> Option<CliLoopWrap> {
+    let mut guard = CLI_LOOP_WRAP.lock().unwrap();
+    if matches!(&*guard, Some((p, _)) if p == path) {
+        guard.take().map(|(_, w)| w)
+    } else {
+        None
+    }
+}
+
+/// Default *source* encoding for the main script, set by the `-K`
+/// command-line switch. Like the loop wrap above, it is armed for a
+/// single path (the main script) and consumed on first match; a
+/// `# encoding:` magic comment in the file still wins.
+static CLI_SOURCE_ENCODING: Mutex<Option<(PathBuf, String)>> = Mutex::new(None);
+
+pub fn set_cli_source_encoding(path: PathBuf, enc: String) {
+    *CLI_SOURCE_ENCODING.lock().unwrap() = Some((path, enc));
+}
+
+pub(crate) fn take_cli_source_encoding(path: &std::path::Path) -> Option<String> {
+    let mut guard = CLI_SOURCE_ENCODING.lock().unwrap();
+    if matches!(&*guard, Some((p, _)) if p == path) {
+        guard.take().map(|(_, e)| e)
+    } else {
+        None
+    }
+}
+
+/// Process-wide default for the `frozen_string_literal` pragma, set by
+/// the `--enable/--disable-frozen-string-literal` command-line flags.
+/// A per-file magic comment still wins. -1 = unset, 0 = false, 1 = true.
+static FROZEN_STRING_LITERAL_DEFAULT: AtomicI8 = AtomicI8::new(-1);
+
+pub fn set_frozen_string_literal_default(default: bool) {
+    FROZEN_STRING_LITERAL_DEFAULT.store(default as i8, Ordering::Relaxed);
+}
+
+pub(crate) fn frozen_string_literal_default() -> Option<bool> {
+    match FROZEN_STRING_LITERAL_DEFAULT.load(Ordering::Relaxed) {
+        0 => Some(false),
+        1 => Some(true),
+        _ => None,
+    }
+}
 
 pub fn parse_program(
     code: impl Into<Vec<u8>>,

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -31,8 +31,8 @@ use ruby_prism::{
 };
 
 use crate::ast::{
-    BinOp, BlockInfo, CmpKind, DestructEntry, Loc, LvarCollector, NReal, Node, NodeKind, ParamKind,
-    ParseResult, SourceInfoRef, UnOp,
+    ArgList, BinOp, BlockInfo, CmpKind, DestructEntry, Loc, LvarCollector, NReal, Node, NodeKind,
+    ParamKind, ParseResult, SourceInfoRef, UnOp,
 };
 use crate::globals::{ExternalContext, MonorubyErr};
 use crate::id_table::IdentId;
@@ -253,7 +253,10 @@ fn detect_frozen_string_literal(code: &[u8]) -> Option<bool> {
 /// Scan a comment body for `frozen_string_literal` immediately followed
 /// (after optional blanks) by `:` or `=` and a `true`/`false` value.
 fn parse_frozen_directive(comment: &str) -> Option<bool> {
-    let lower = comment.to_ascii_lowercase();
+    // CRuby treats `-` and `_` in magic-comment names as equivalent
+    // (`# frozen-string-literal: false` appears in the stock
+    // `rbconfig.rb`), so normalize before matching.
+    let lower = comment.to_ascii_lowercase().replace('-', "_");
     let lb = lower.as_bytes();
     let key = "frozen_string_literal";
     let mut from = 0;
@@ -291,6 +294,11 @@ fn try_prism_inner(
     default_encoding: Option<String>,
 ) -> Result<ParseResult, MonorubyErr> {
     let path_display = path.display().to_string();
+    // `-n` / `-p`: the main script (and only the main script) gets its
+    // top-level statements wrapped in an implicit `while gets ... end`.
+    let cli_loop_wrap = super::take_cli_loop_wrap(&path);
+    // `-K`: default source encoding for the main script.
+    let cli_source_encoding = super::take_cli_source_encoding(&path);
 
     let result = match options.as_ref() {
         Some(opts) => prism::parse_with_options(code, opts),
@@ -307,9 +315,13 @@ fn try_prism_inner(
     // A magic comment wins; otherwise fall back to the caller-supplied
     // default (the eval'd string's own encoding — CRuby uses it as the
     // eval source encoding when no `# encoding:` comment is present).
-    let source_encoding: Option<String> =
-        detect_source_encoding(code).or(default_encoding);
-    let frozen_string_literal: Option<bool> = detect_frozen_string_literal(code);
+    let source_encoding: Option<String> = detect_source_encoding(code)
+        .or(cli_source_encoding)
+        .or(default_encoding);
+    // Per-file magic comment wins; otherwise fall back to the
+    // `--enable/--disable-frozen-string-literal` process default.
+    let frozen_string_literal: Option<bool> = detect_frozen_string_literal(code)
+        .or_else(super::frozen_string_literal_default);
 
     // SourceInfo's copy of the source is display-only (error carets,
     // `get_line`), so a binary source with invalid UTF-8 bytes is
@@ -373,6 +385,7 @@ fn try_prism_inner(
     let mut lowerer = Lowerer::new(code, path_display, source_info.clone());
     lowerer.line_offset = line_offset;
     lowerer.eval_parse = options.is_some();
+    lowerer.cli_loop_wrap = cli_loop_wrap;
     if let Some(seed) = seed_lvars {
         // For `binding.eval`, monoruby preloads a `LvarCollector`
         // with the binding's existing locals so any *new* names the
@@ -444,6 +457,9 @@ struct Lowerer<'pr> {
     /// matching desugar (`%pm<n>` — `%` is not spellable, so they never
     /// surface in `local_variables`).
     pm_temp: usize,
+    /// `-n` / `-p` command-line switches: wrap the program body in an
+    /// implicit `while gets ... end` (see `lower_program`).
+    cli_loop_wrap: Option<super::CliLoopWrap>,
 }
 
 /// See [`Lowerer::scope_wraps`].
@@ -467,6 +483,7 @@ impl<'pr> Lowerer<'pr> {
             warnings: Vec::new(),
             eval_parse: false,
             pm_temp: 0,
+            cli_loop_wrap: None,
         }
     }
 
@@ -580,15 +597,76 @@ impl<'pr> Lowerer<'pr> {
                 stmts.push(self.lower_node(&n)?);
             }
         }
+        let mut main_stmts = Vec::new();
         for n in body.body().iter() {
             if n.as_pre_execution_node().is_none() {
-                stmts.push(self.lower_node(&n)?);
+                main_stmts.push(self.lower_node(&n)?);
             }
+        }
+        if let Some(wrap) = self.cli_loop_wrap {
+            // `-n` / `-p`: run the (non-BEGIN) program body inside an
+            // implicit `while gets ... end` — CRuby wraps at the AST
+            // level too, which is why BEGIN blocks still parse and run
+            // once, before the loop.
+            stmts.push(Self::build_cli_loop(wrap, main_stmts, loc));
+        } else {
+            stmts.append(&mut main_stmts);
         }
         Ok(Node {
             kind: NodeKind::CompStmt(stmts),
             loc,
         })
+    }
+
+    /// Build the `-n` / `-p` implicit loop:
+    ///
+    /// ```text
+    /// while gets
+    ///   $_ = $_.chomp($/)   # -l
+    ///   $F = $_.split       # -a
+    ///   <program body>
+    ///   print $_            # -p
+    /// end
+    /// ```
+    fn build_cli_loop(wrap: super::CliLoopWrap, body_stmts: Vec<Node>, loc: Loc) -> Node {
+        let gvar = |name: &str| Node {
+            kind: NodeKind::GlobalVar(name.to_string()),
+            loc,
+        };
+        let assign = |target: Node, value: Node| Node {
+            kind: NodeKind::MulAssign(vec![target], vec![value]),
+            loc,
+        };
+        let mut stmts = Vec::new();
+        if wrap.chomp {
+            let chomp = Node::new_mcall(
+                gvar("$_"),
+                "chomp".to_string(),
+                ArgList::from_args(vec![gvar("$/")]),
+                false,
+                loc,
+            );
+            stmts.push(assign(gvar("$_"), chomp));
+        }
+        if wrap.auto_split {
+            let split = Node::new_mcall_noarg(gvar("$_"), "split".to_string(), false, loc);
+            stmts.push(assign(gvar("$F"), split));
+        }
+        stmts.extend(body_stmts);
+        if wrap.print_last {
+            stmts.push(Node::new_fcall(
+                "print".to_string(),
+                ArgList::from_args(vec![gvar("$_")]),
+                false,
+                loc,
+            ));
+        }
+        let cond = Node::new_fcall_noarg("gets".to_string(), false, loc);
+        let body = Node {
+            kind: NodeKind::CompStmt(stmts),
+            loc,
+        };
+        Node::new_while(cond, body, true, loc)
     }
 
     fn collect_locals(&mut self, locals: &ConstantList<'pr>) -> Result<(), MonorubyErr> {

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -238,7 +238,9 @@ fn run_ruby(globals: &mut Globals, code: &str) -> Value {
     let res = match std::process::Command::new(&*RUBY)
         .arg("-E")
         .arg("UTF-8")
-        .arg("--disable-gem")
+        // Skip rubygems boot (~5x faster startup across ~4000 differential
+        // spawns) and ignore any ambient RUBYOPT for hermeticity.
+        .arg("--disable=gems,rubyopt")
         .arg(tmpfile.path())
         .output()
     {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -621,6 +621,19 @@ impl Value {
         self.rvalue_mut().clear_chilled()
     }
 
+    /// True for chilled strings born from source literals (as opposed
+    /// to `Symbol#to_s` results) — their mutation warning differs.
+    pub(crate) fn is_chilled_literal(&self) -> bool {
+        match self.try_rvalue() {
+            Some(rv) => rv.is_chilled_literal(),
+            None => false,
+        }
+    }
+
+    pub(crate) fn set_chilled_literal(&mut self) {
+        self.rvalue_mut().set_chilled_literal()
+    }
+
     ///
     /// Ensure `self` (a String) is mutable. If it is "chilled", emit a
     /// one-shot deprecation warning (gated by `Warning[:deprecated]`), clear
@@ -633,9 +646,17 @@ impl Value {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<()> {
-        if self.is_chilled() {
+        // A chilled string that was later `freeze`d raises FrozenError
+        // without the chilled warning (CRuby behaves the same).
+        if self.is_chilled() && !self.is_frozen() {
+            let literal_born = self.is_chilled_literal();
+            let origin = string_origin(self.id());
             self.clear_chilled();
-            emit_chilled_string_mutation_warning(vm, globals, *self)?;
+            if literal_born {
+                emit_chilled_literal_mutation_warning(vm, globals, origin)?;
+            } else {
+                emit_chilled_string_mutation_warning(vm, globals, *self)?;
+            }
         }
         self.ensure_not_frozen(&globals.store)
     }
@@ -703,7 +724,19 @@ impl Value {
     }
 
     pub(crate) extern "C" fn value_deep_copy(val: Value) -> Self {
-        val.deep_copy()
+        let mut v = val.deep_copy();
+        // A string-literal template in a pragma-less file is marked
+        // chilled; each per-execution copy inherits the mark (and,
+        // under --debug-frozen-string-literal, the creation site).
+        if val.is_chilled_literal() {
+            v.set_chilled_literal();
+            if debug_frozen_string_log()
+                && let Some(origin) = string_origin(val.id())
+            {
+                record_string_origin(v.id(), origin);
+            }
+        }
+        v
     }
 
     pub(crate) fn dup(&self) -> Self {
@@ -1407,6 +1440,107 @@ impl Value {
         }
         s
     }
+}
+
+/// `--debug` / `--debug-frozen-string-literal`: record where frozen and
+/// chilled string literals were created so mutation errors/warnings can
+/// point at the definition site.
+static DEBUG_FROZEN_STRING_LOG: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Creation sites (`file:line`) of frozen/chilled string literals,
+/// keyed by `Value::id()`. Only populated under
+/// `--debug-frozen-string-literal`, so unbounded growth is confined to
+/// debug runs.
+static STRING_LITERAL_ORIGIN: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<u64, String>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Turn on frozen/chilled-literal creation-site tracking
+/// (`--debug` / `--debug-frozen-string-literal`).
+pub fn set_debug_frozen_string_log() {
+    DEBUG_FROZEN_STRING_LOG.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub(crate) fn debug_frozen_string_log() -> bool {
+    DEBUG_FROZEN_STRING_LOG.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+pub(crate) fn record_string_origin(id: u64, origin: String) {
+    STRING_LITERAL_ORIGIN.lock().unwrap().insert(id, origin);
+}
+
+pub(crate) fn string_origin(id: u64) -> Option<String> {
+    if !debug_frozen_string_log() {
+        return None;
+    }
+    STRING_LITERAL_ORIGIN.lock().unwrap().get(&id).cloned()
+}
+
+///
+/// Emit the CRuby-compatible warning for mutating a chilled string
+/// literal (a literal in a file without a `frozen_string_literal`
+/// pragma). Gated by `Warning[:deprecated]`, like CRuby's
+/// `rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, ...)`. Under
+/// `--debug-frozen-string-literal` a second line points at the
+/// literal's creation site.
+///
+pub(crate) fn emit_chilled_literal_mutation_warning(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    origin: Option<String>,
+) -> Result<()> {
+    if !warning_deprecated_on(vm, globals)? {
+        return Ok(());
+    }
+    let msg = if debug_frozen_string_log() {
+        let mut msg = "warning: literal string will be frozen in the future\n".to_string();
+        if let Some(origin) = origin {
+            msg.push_str(&format!("{origin}: warning: the string was created here\n"));
+        }
+        msg
+    } else {
+        "warning: literal string will be frozen in the future \
+         (run with --debug-frozen-string-literal for more information)\n"
+            .to_string()
+    };
+    let stderr = globals
+        .get_gvar(IdentId::get_id("$stderr"))
+        .unwrap_or(Value::nil());
+    if stderr.is_nil() {
+        return Ok(());
+    }
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("write"),
+        stderr,
+        &[Value::string(msg)],
+        None,
+        None,
+    )?;
+    Ok(())
+}
+
+/// `Warning[:deprecated]`, or `false` when the Warning module isn't
+/// loaded yet (bootstrap).
+fn warning_deprecated_on(vm: &mut Executor, globals: &mut Globals) -> Result<bool> {
+    let warning_val = match globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Warning"))
+    {
+        Some(v) => v,
+        None => return Ok(false),
+    };
+    let dep_sym = Value::symbol(IdentId::get_id("deprecated"));
+    let dep = vm.invoke_method_inner(
+        globals,
+        IdentId::_INDEX,
+        warning_val,
+        &[dep_sym],
+        None,
+        None,
+    )?;
+    Ok(!(dep.is_nil() || dep == Value::bool(false)))
 }
 
 ///

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -55,6 +55,9 @@ mod string;
 mod struct_inner;
 
 pub const OBJECT_INLINE_IVAR: usize = 6;
+/// Header flag bit 8: marks a chilled string as literal-born (see
+/// `Header::is_chilled_literal`).
+const CHILLED_LITERAL_BIT: u16 = 0b1_0000_0000;
 pub const RVALUE_OFFSET_FLAG: usize = std::mem::offset_of!(RValue, header.meta.flag);
 pub const RVALUE_OFFSET_TY: usize = std::mem::offset_of!(RValue, header.meta.ty);
 pub const RVALUE_OFFSET_CLASS: usize = std::mem::offset_of!(RValue, header.meta.class);
@@ -991,6 +994,14 @@ impl RValue {
         self.header.clear_chilled()
     }
 
+    pub(crate) fn is_chilled_literal(&self) -> bool {
+        self.header.is_chilled_literal()
+    }
+
+    pub(crate) fn set_chilled_literal(&mut self) {
+        self.header.set_chilled_literal()
+    }
+
     // --- Generational GC flags ---
     //
     // Reserved accessors for the generational collector. They are wired
@@ -1272,7 +1283,7 @@ impl RValue {
     pub(super) fn dup(&self) -> Self {
         let mut header = self.header;
         // dup does not copy the frozen or chilled flag (clone does).
-        unsafe { header.meta.flag &= !0b110 };
+        unsafe { header.meta.flag &= !(0b110 | CHILLED_LITERAL_BIT) };
         RValue {
             header,
             var_table: self.var_table.clone(),
@@ -2298,9 +2309,11 @@ impl Header {
     ///
     /// A "chilled" string behaves like a mutable String but emits a
     /// deprecation warning (gated by `Warning[:deprecated]`) the first time
-    /// it is mutated. monoruby only produces chilled strings from
-    /// `Symbol#to_s`; the flag is cleared on first mutation so the warning
-    /// fires at most once per string. Currently only Strings are chilled.
+    /// it is mutated. monoruby produces chilled strings from `Symbol#to_s`
+    /// and from source string literals in files without a
+    /// `frozen_string_literal` pragma (bit 8 marks the latter kind, whose
+    /// warning wording differs). The flags are cleared on first mutation so
+    /// the warning fires at most once per string. Only Strings are chilled.
     ///
     fn is_chilled(&self) -> bool {
         unsafe { self.meta.flag & 0b100 != 0 }
@@ -2311,7 +2324,15 @@ impl Header {
     }
 
     fn clear_chilled(&mut self) {
-        unsafe { self.meta.flag &= !0b100 }
+        unsafe { self.meta.flag &= !(0b100 | CHILLED_LITERAL_BIT) }
+    }
+
+    fn is_chilled_literal(&self) -> bool {
+        unsafe { self.meta.flag & CHILLED_LITERAL_BIT != 0 }
+    }
+
+    fn set_chilled_literal(&mut self) {
+        unsafe { self.meta.flag |= 0b100 | CHILLED_LITERAL_BIT }
     }
 
     // --- Generational GC flags (flag bits 3..5) ---

--- a/monoruby/tests/begin_end.rs
+++ b/monoruby/tests/begin_end.rs
@@ -7,11 +7,13 @@ use std::process::Command;
 
 fn run_both(script: &str) {
     let mono = Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env_remove("RUBYOPT")
         .args(["-e", script])
         .output()
         .unwrap();
     let ruby = Command::new("ruby")
-        .args(["-e", script])
+        // Match the main harness: skip rubygems boot and ambient RUBYOPT.
+        .args(["--disable=gems,rubyopt", "-e", script])
         .output()
         .unwrap();
     assert_eq!(

--- a/monoruby/tests/command_line.rs
+++ b/monoruby/tests/command_line.rs
@@ -1,0 +1,348 @@
+//! Integration coverage for CRuby-compatible command-line option
+//! processing (see `src/main.rs`). Everything here spawns the real
+//! binary: option parsing is a process-boundary concern that
+//! in-process `run_test` can't reach.
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+fn monoruby() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    // Isolate from the invoking environment.
+    cmd.env_remove("RUBYOPT")
+        .env_remove("RUBYLIB")
+        .env_remove("RUBYPATH");
+    cmd
+}
+
+fn run(cmd: &mut Command) -> Output {
+    cmd.output().expect("failed to spawn monoruby")
+}
+
+fn run_with_stdin(cmd: &mut Command, input: &str) -> Output {
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn monoruby");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().expect("wait failed")
+}
+
+fn stdout_of(cmd: &mut Command) -> String {
+    let out = run(cmd);
+    assert!(
+        out.status.success(),
+        "monoruby exited with {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn write_temp(name: &str, body: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(name);
+    std::fs::write(&path, body).expect("write temp file");
+    path
+}
+
+#[test]
+fn version_switches() {
+    // `-v` alone prints the version banner and exits without reading
+    // stdin or a script.
+    let out = stdout_of(monoruby().arg("-v"));
+    assert!(out.starts_with("monoruby "), "banner: {out}");
+    // `--version` prints the banner even when a program is given.
+    let out = stdout_of(monoruby().args(["--version", "-e", "puts :not_run"]));
+    assert!(out.starts_with("monoruby "));
+    assert!(!out.contains("not_run"));
+    // `-v` with a program prints the banner, then runs it.
+    let out = stdout_of(monoruby().args(["-v", "-e", "puts :ran"]));
+    assert!(out.starts_with("monoruby "));
+    assert!(out.contains("ran"));
+    let out = stdout_of(monoruby().arg("--copyright"));
+    assert!(out.contains("Copyright"), "copyright: {out}");
+    let out = stdout_of(monoruby().arg("-h"));
+    assert!(out.contains("Usage: monoruby"));
+}
+
+#[test]
+fn invalid_option_is_reported() {
+    let out = run(monoruby().args(["-Z", "-e", "puts 1"]));
+    assert_eq!(out.status.code(), Some(1));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("invalid option -Z"), "stderr: {err}");
+}
+
+#[test]
+fn dash_n_loop_and_autosplit() {
+    let out = run_with_stdin(monoruby().args(["-n", "-e", "puts $_.upcase"]), "ab\ncd\n");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "AB\nCD\n");
+
+    // -p prints $_ after each iteration; BEGIN runs once.
+    let out = run_with_stdin(
+        monoruby().args(["-p", "-e", "BEGIN { puts :begin }; $_ = $_.chomp + \"!\\n\""]),
+        "x\ny\n",
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "begin\nx!\ny!\n");
+
+    // -a splits into $F; -F sets the pattern; clustered `-naF:`.
+    let out = run_with_stdin(monoruby().args(["-naF:", "-e", "puts $F[1]"]), "a:b:c\nd:e:f\n");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "b\ne\n");
+
+    // -l chomps each line and mirrors into $-l / $\.
+    let out = run_with_stdin(
+        monoruby().args(["-n", "-l", "-e", "puts [$_.end_with?(\"\\n\"), $-l, $\\ == $/].inspect"]),
+        "q\n",
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "[false, true, true]\n"
+    );
+}
+
+#[test]
+fn dash_zero_record_separator() {
+    let out = run(monoruby().args(["-072", "-e", "puts $/, $-0, $/.frozen?"]));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), ":\n:\ntrue\n");
+    // -0777 slurps (nil separator); gets reads everything. (`lines`
+    // would itself split on the now-nil `$/`, so measure bytes.)
+    let out = run_with_stdin(
+        monoruby().args(["-0777", "-n", "-e", "puts $_.bytesize"]),
+        "a\nb\nc\n",
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "6\n");
+}
+
+#[test]
+fn kernel_chomp_and_chop() {
+    let out = run(monoruby().args(["-e", "$_ = \"ab\\n\"; chomp; print $_, \"|\"; $_ = \"xyz\"; chop; puts $_"]));
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "ab|xy\n");
+    // chomp with nil $_ is a TypeError.
+    let out = run(monoruby().args(["-e", "chomp"]));
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("TypeError"));
+}
+
+#[test]
+fn dash_s_switch_globals() {
+    // `--long-name` keeps one leading dash converted: `$_long_name`
+    // (matching CRuby's `--name=blah` → `$_name`).
+    let script = write_temp("cli_dash_s.rb", "p [$flag, $_long_name, ARGV]\n");
+    let out = stdout_of(monoruby().args([
+        "-s",
+        script.to_str().unwrap(),
+        "-flag",
+        "--long-name=v",
+        "rest",
+    ]));
+    assert_eq!(out, "[true, \"v\", [\"rest\"]]\n");
+}
+
+#[test]
+fn syntax_check() {
+    let ok = write_temp("cli_ok.rb", "puts 1\n");
+    let out = stdout_of(monoruby().args(["-c", ok.to_str().unwrap()]));
+    assert_eq!(out, "Syntax OK\n");
+    let out = stdout_of(monoruby().args(["-c", "-e", "puts 1", "-e", "hello world"]));
+    assert_eq!(out, "Syntax OK\n");
+    let bad = write_temp("cli_bad.rb", "def f(\n");
+    let out = run(monoruby().args(["-c", bad.to_str().unwrap()]));
+    assert_eq!(out.status.code(), Some(1));
+}
+
+#[test]
+fn chdir_switch() {
+    let out = stdout_of(monoruby().args(["-C", "/tmp", "-e", "print Dir.pwd"]));
+    assert!(out.ends_with("tmp"), "pwd: {out}");
+    // Attached form, and -X as an alias.
+    let out = stdout_of(monoruby().args(["-C/tmp", "-e", "print 1"]));
+    assert_eq!(out, "1");
+    let out = run(monoruby().args(["-C", "/no/such/dir", "-e", "puts 1"]));
+    assert_eq!(out.status.code(), Some(1));
+}
+
+#[test]
+fn dash_x_shebang_scan() {
+    let script = write_temp(
+        "cli_embedded.txt",
+        "leading garbage\nmore garbage\n#!ruby\nputs :embedded\n",
+    );
+    let out = stdout_of(monoruby().args(["-x", script.to_str().unwrap()]));
+    assert_eq!(out, "embedded\n");
+    // Automatic scan when the first line is a non-ruby shebang.
+    let script = write_temp(
+        "cli_hybrid.sh",
+        "#!/bin/sh\n#!ruby\nputs :hybrid\n",
+    );
+    let out = stdout_of(monoruby().arg(script.to_str().unwrap()));
+    assert_eq!(out, "hybrid\n");
+    // No #!ruby line under -x is a LoadError.
+    let script = write_temp("cli_noruby.txt", "#!/bin/sh\necho no\n");
+    let out = run(monoruby().args(["-x", script.to_str().unwrap()]));
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no Ruby script found in input")
+    );
+}
+
+#[test]
+fn dash_upper_s_path_search() {
+    let dir = std::env::temp_dir().join("cli_s_bin");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("launcher_test.rb"), "puts :launched\n").unwrap();
+    let out = stdout_of(
+        monoruby()
+            .env("RUBYPATH", dir.to_str().unwrap())
+            .args(["-S", "launcher_test.rb"]),
+    );
+    assert_eq!(out, "launched\n");
+    let out = run(monoruby().args(["-S", "no_such_launcher_xyz"]));
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("LoadError"));
+}
+
+#[test]
+fn rubyopt_processing() {
+    let out = stdout_of(monoruby().env("RUBYOPT", "-w").args(["-e", "p $VERBOSE"]));
+    assert_eq!(out, "true\n");
+    // Command-line -W0 overrides RUBYOPT.
+    let out = stdout_of(
+        monoruby()
+            .env("RUBYOPT", "-W2")
+            .args(["-W0", "-e", "p $VERBOSE"]),
+    );
+    assert_eq!(out, "nil\n");
+    // Forbidden switch in RUBYOPT.
+    let out = run(monoruby().env("RUBYOPT", "-p").args(["-e", "puts 1"]));
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("invalid switch in RUBYOPT: -p")
+    );
+    // --disable-rubyopt skips processing entirely.
+    let out = stdout_of(
+        monoruby()
+            .env("RUBYOPT", "-w")
+            .args(["--disable-rubyopt", "-e", "p $VERBOSE"]),
+    );
+    assert_eq!(out, "false\n");
+}
+
+#[test]
+fn rubylib_and_dash_i_load_path() {
+    let out = stdout_of(
+        monoruby()
+            .env("RUBYLIB", "/rubylib/dir")
+            .args(["-I", "/dash/i/dir", "-e", "puts $LOAD_PATH[0..1]"]),
+    );
+    assert_eq!(out, "/dash/i/dir\n/rubylib/dir\n");
+}
+
+#[test]
+fn warning_switches() {
+    let out = stdout_of(monoruby().args(["-W:deprecated", "-e", "p Warning[:deprecated]"]));
+    assert_eq!(out, "true\n");
+    let out = stdout_of(monoruby().args(["-w", "-W:no-deprecated", "-e", "p Warning[:deprecated]"]));
+    assert_eq!(out, "false\n");
+    let out = stdout_of(monoruby().args(["-d", "-e", "p [$DEBUG, $-d, $VERBOSE]"]));
+    assert_eq!(out, "[true, true, true]\n");
+}
+
+#[test]
+fn encoding_switches() {
+    let out = stdout_of(monoruby().args(["-E", "euc-jp", "-e", "p Encoding.default_external"]));
+    assert_eq!(out, "#<Encoding:EUC-JP>\n");
+    let out = stdout_of(monoruby().args(["-U", "-e", "p Encoding.default_internal"]));
+    assert_eq!(out, "#<Encoding:UTF-8>\n");
+    let out = stdout_of(monoruby().args(["-Ke", "-e", "p Encoding.default_external"]));
+    assert_eq!(out, "#<Encoding:EUC-JP>\n");
+    // -U conflicts with an explicit internal encoding on the command line.
+    let out = run(monoruby().args(["-Eascii:ascii", "-U", "-e", "puts 1"]));
+    assert_eq!(out.status.code(), Some(1));
+    // A third encoding component is rejected.
+    let out = run(monoruby().args(["--encoding", "a:b:c", "-e", "puts 1"]));
+    assert_eq!(out.status.code(), Some(1));
+}
+
+#[test]
+fn feature_switches() {
+    let out = stdout_of(monoruby().args([
+        "--enable-frozen-string-literal",
+        "-e",
+        "p 'x'.frozen?",
+    ]));
+    assert_eq!(out, "true\n");
+    let out = stdout_of(monoruby().args([
+        "--disable=frozen-string-literal",
+        "-e",
+        "p 'x'.frozen?",
+    ]));
+    assert_eq!(out, "false\n");
+    let out = run(monoruby().args(["--enable=bogus-feature", "-e", "puts 1"]));
+    assert!(out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("unknown argument for --enable")
+    );
+}
+
+#[test]
+fn backtrace_limit_truncates_report() {
+    let script = write_temp(
+        "cli_bt.rb",
+        "def a; raise 'boom'; end\ndef b; a; end\ndef c; b; end\ndef d; c; end\nd\n",
+    );
+    let out = run(monoruby().args(["--backtrace-limit=1", script.to_str().unwrap()]));
+    assert_eq!(out.status.code(), Some(1));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("boom (RuntimeError)"), "stderr: {err}");
+    assert!(err.contains("levels..."), "stderr: {err}");
+    // Exception#full_message honours the limit too.
+    let script = write_temp(
+        "cli_bt_fm.rb",
+        "def a; raise 'boom'; end\ndef b; a; end\ndef c; b; end\ndef d; c; end\n\
+         begin; d; rescue => e; puts e.full_message; end\n",
+    );
+    let out = run(monoruby().args(["--backtrace-limit=1", script.to_str().unwrap()]));
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.contains("boom (RuntimeError)"), "stdout: {text}");
+    assert!(text.contains("levels..."), "stdout: {text}");
+}
+
+#[test]
+fn stdin_script_via_dash() {
+    let out = run_with_stdin(monoruby().arg("-"), "puts :from_stdin\n");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "from_stdin\n");
+}
+
+#[test]
+fn double_dash_ends_switches() {
+    let out = run_with_stdin(
+        monoruby().args(["-e", "p ARGV", "--", "-n", "x"]),
+        "",
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "[\"-n\", \"x\"]\n");
+}
+
+#[test]
+fn gets_honours_record_separator() {
+    // Paragraph mode: the first record is "a\nb\n\n" (5 bytes; `lines`
+    // would split on the paragraph `$/`, so measure bytes).
+    let out = run_with_stdin(
+        monoruby().args(["-e", "$/ = \"\"; puts gets.bytesize"]),
+        "a\nb\n\n\nc\n",
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "5\n");
+    // Custom multi-byte separator.
+    let out = run_with_stdin(
+        monoruby().args(["-e", "$/ = \"--\"; print gets"]),
+        "one--two--",
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "one--");
+}


### PR DESCRIPTION
## Summary

Running ruby/spec's **command_line** category against monoruby (with CRuby 4.0.2 as the reference) showed **146 failures + 1 error out of 175 examples**, almost all rooted in the clap-based CLI rejecting CRuby's switches with exit status 2. This PR replaces the CLI with a hand-rolled CRuby-style option parser, wires up the semantics the specs exercise, aligns the uncaught-error report with CRuby, and implements chilled string literals.

**Result: 175 examples, 0 failures** (command_line category, release build).

## Changes

### Option parser (`main.rs`)
- Clustered short switches with attached values (`-naF:`, `-072`, `-Ke`, `-ne '...'`), `--` terminator, CRuby-style `invalid option` errors (exit 1).
- `-v` / `--version` / `--copyright` print `RUBY_DESCRIPTION` / `RUBY_COPYRIGHT`; `-v` alone exits without reading stdin.
- `-w` / `-W[level]` / `-W:category` wired to `$VERBOSE` and `Warning[]`; `-d`/`--debug` sets `$DEBUG` and `$VERBOSE`.
- `-c` syntax check, `-s` switch-to-global parsing, `-C`/`-X` chdir, `-x[dir]` shebang scan (plus the automatic scan when the first line is a non-ruby `#!`), `-S` RUBYPATH/PATH lookup.
- `RUBYOPT` processing with CRuby's allowed-switch subset (`invalid switch in RUBYOPT` otherwise); `RUBYLIB` prepended to `$LOAD_PATH`; `-I` now *prepends* with `File.expand_path` semantics (no symlink resolution).
- `--enable`/`--disable` features: `gems`, `did_you_mean`, `rubyopt`, `frozen-string-literal`, `all` (unknown features warn); `--disable-gems` keeps working via the generic feature path.
- `-E`/`-U`/`-K`/`--encoding`/`--external-encoding`/`--internal-encoding` set the default external/internal encodings; `-U` vs `-E ext:int` conflict rejected like CRuby.

### `-n` / `-p` loop (`parser/`)
The implicit `while gets ... end` wrap is synthesized **at the AST level** in the prism lowerer (armed per main-script path, consumed on first match), so `BEGIN`/`END` blocks still hoist and run exactly once. `-a` adds `$F = $_.split`, `-l` adds `$_ = $_.chomp($/)` and `$\ = $/`, `-p` appends `print $_`.

### Error report alignment + `--backtrace-limit`
- Uncaught runtime errors now print CRuby's compact report (`file:line:in 'meth': msg (Class)` + TAB-indented `from` frames); the source excerpt with a caret is kept for SyntaxError only, matching CRuby.
- `--backtrace-limit=N` truncates frames to N plus `... K levels...`, both in the top-level report and in `Exception#full_message` (which now uses `detailed_message`, i.e. `msg (Class)`).
- The toplevel frame displays as `<main>` (CRuby) instead of the internal `/main` name.

### Chilled string literals (CRuby 3.4 migration path)
- String literals in pragma-less files are chilled: first mutation warns `literal string will be frozen in the future ...` (gated by `Warning[:deprecated]`). The template is flag-marked at bytecode emission; `Value::value_deep_copy` propagates the mark, covering the VM and both JIT backends through the single shared runtime hook.
- `--debug` / `--debug-frozen-string-literal` records literal creation sites: FrozenError gains `, created at file:line`; the chilled warning is followed by `file:line: warning: the string was created here`.
- `String#+@` is now a Rust builtin that dups frozen *and chilled* receivers, so the `+"literal"` idiom mutates silently, like CRuby.
- monoruby's own runtime Ruby (builtins / stdlib stubs under the install root) is exempt from chilling — CRuby's stdlib counterparts all carry explicit pragmas.

### Runtime support
- `Kernel#gets` honours `$/` (nil = slurp, `""` = paragraph mode) and reads `ARGV` files ARGF-style before falling back to stdin.
- `IO#puts` stringifies non-String values through their `to_s` method.
- `$-a` / `$-l` / `$-p` gvar mirrors reflect the actual CLI switches (still read-only).
- `Encoding.find` resolves `filesystem` / `locale` / `external` / `internal`.
- The hyphenated `# frozen-string-literal:` magic-comment spelling (used by the stock `rbconfig.rb`) is now recognized.

## Testing
- ruby/spec command_line: 146 failures + 1 error → **0 failures** (release build, CRuby 4.0.2 reference).
- ruby/spec core/string + core/set: 171 → 168 failures (3 fixed by chilled literals), no new errors.
- `cargo test --lib --tests`: all 30 suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK