### PR TITLE
DATA constant and main-script TOPLEVEL_BINDING

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1680,7 +1680,10 @@ class Encoding
   end
 end
 
-TOPLEVEL_BINDING = binding
+# TOPLEVEL_BINDING is defined by the runtime (Executor::init): a Binding
+# over an empty, outer-less frame that the *main script* is then executed
+# in (Executor::exec_main_script), so it exposes exactly the main script's
+# locals — not this file's.
 
 require_relative 'comparable'
 

--- a/monoruby/src/ast.rs
+++ b/monoruby/src/ast.rs
@@ -62,6 +62,10 @@ pub struct ParseResult {
     /// Transferred into `Store::compile_warnings` by the bytecodegen
     /// entry points and emitted by `Executor::flush_compile_warnings`.
     pub warnings: Vec<(String, bool)>,
+    /// Byte offset of the first byte after the `__END__` line, when the
+    /// source has one (prism's `data_loc`). The main-script runner uses
+    /// it to define the `DATA` constant; ignored everywhere else.
+    pub data_offset: Option<usize>,
 }
 
 /// One `rescue` clause of a `begin`/`rescue` (or modifier `rescue`).

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2932,6 +2932,10 @@ fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) 
     }
     globals.store[fid]
         .name()
+        // The main script's body carries the internal `/main` label (and,
+        // running inside TOPLEVEL_BINDING, a proc_method-tagged frame) —
+        // but the top level is not a method: report nil, as CRuby does.
+        .filter(|sym| *sym != IdentId::_MAIN)
         .map_or(Ok(Value::nil()), |sym| Ok(Value::symbol(sym)))
 }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -293,6 +293,20 @@ impl Executor {
                 executor.load_gems(globals);
             }
         }
+        // TOPLEVEL_BINDING: a Binding over an empty, outer-less heap frame
+        // on the main object. The main script is executed *inside* this
+        // binding (`exec_main_script`), which is what gives it CRuby's
+        // semantics: empty while `-r` requires run, then exactly the main
+        // script's locals — live, and shared with dynamically-set Binding
+        // variables. Created here (not in startup.rb) so no startup locals
+        // leak into its scope chain.
+        {
+            let res = crate::parser::parse_program("", "(toplevel)")?;
+            let fid = bytecodegen::bytecode_compile_script(globals, res)?;
+            let lfp = Lfp::heap_frame(globals.main_object, globals.store[fid].meta());
+            let binding = Value::new_binding(lfp, None);
+            globals.set_constant_by_str(OBJECT_CLASS, "TOPLEVEL_BINDING", binding);
+        }
         // Clear stale $! that may have been set during startup/gem loading.
         executor.set_errinfo(Value::nil());
         // Same for $~ (and the back-ref family $&/$'/$`/$N derived from
@@ -485,10 +499,76 @@ impl Executor {
         code: impl Into<Vec<u8>>,
         path: &std::path::Path,
     ) -> Result<Value> {
-        let fid = match crate::parser::parse_program(code, path) {
-            Ok(res) => bytecodegen::bytecode_compile_script(globals, res),
-            Err(err) => Err(err),
-        }?;
+        self.exec_script_inner(globals, code, path, false)
+    }
+
+    ///
+    /// Execute the *main* script. In addition to `exec_script`, when the
+    /// source contains `__END__` this defines the `DATA` constant: a
+    /// read-only `File` on the script, positioned just past the `__END__`
+    /// line. Only the main script does this — a required file's `__END__`
+    /// must not (re)define `DATA` — hence the separate entry point.
+    ///
+    pub fn exec_main_script(
+        &mut self,
+        globals: &mut Globals,
+        code: impl Into<Vec<u8>>,
+        path: &std::path::Path,
+    ) -> Result<Value> {
+        // Execute inside TOPLEVEL_BINDING (see `Executor::init`), so the
+        // binding exposes the main script's locals. Falls back to a plain
+        // toplevel run when the constant is unavailable
+        // (MONORUBY_SKIP_STARTUP bring-up).
+        let binding = globals
+            .store
+            .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("TOPLEVEL_BINDING"))
+            .and_then(crate::value::rvalue::Binding::try_new);
+        let Some(binding) = binding else {
+            return self.exec_script_inner(globals, code, path, true);
+        };
+        let code: Vec<u8> = code.into();
+        let data_offset = globals.compile_main_script_binding(
+            code,
+            path.to_string_lossy().into_owned(),
+            binding,
+        )?;
+        self.flush_compile_warnings(globals);
+        self.define_data(globals, path, data_offset);
+        self.invoke_binding(globals, binding.binding().unwrap())
+    }
+
+    /// Define the `DATA` constant: a read-only `File` on the main script,
+    /// positioned at *offset* (just past its `__END__` line). No-op when
+    /// the source has no `__END__` or no backing file (`-e`, stdin),
+    /// matching CRuby.
+    fn define_data(
+        &mut self,
+        globals: &mut Globals,
+        path: &std::path::Path,
+        data_offset: Option<usize>,
+    ) {
+        if let Some(offset) = data_offset
+            && let Ok(mut file) = std::fs::File::open(path)
+        {
+            use std::io::Seek;
+            let _ = file.seek(std::io::SeekFrom::Start(offset as u64));
+            let data = Value::new_file(file, path.to_string_lossy().into_owned(), true, false);
+            globals.set_constant_by_str(OBJECT_CLASS, "DATA", data);
+        }
+    }
+
+    fn exec_script_inner(
+        &mut self,
+        globals: &mut Globals,
+        code: impl Into<Vec<u8>>,
+        path: &std::path::Path,
+        is_main: bool,
+    ) -> Result<Value> {
+        let res = crate::parser::parse_program(code, path)?;
+        if is_main {
+            self.define_data(globals, path, res.data_offset);
+        }
+        let fid = bytecodegen::bytecode_compile_script(globals, res)?;
         self.flush_compile_warnings(globals);
         self.eval_toplevel(globals, fid)
     }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -925,6 +925,9 @@ impl Globals {
         if main_style {
             self.store[fid].set_method_style();
             self.store[fid].set_proc_method();
+            // Backtraces must label the main script `<main>`, not
+            // `block in <main>` (see `func_description`).
+            self.store[fid].set_name(IdentId::_MAIN);
         }
         self.new_binding_frame(fid, binding.self_val(), binding);
         Ok(data_offset)

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -721,7 +721,7 @@ impl Globals {
             for lib in requires {
                 executor.require(self, std::path::Path::new(lib), false)?;
             }
-            executor.exec_script(self, code, path)
+            executor.exec_main_script(self, code, path)
         })();
         // Run `at_exit` handlers and `ObjectSpace` finalizers before the
         // process leaves. This must happen even when `res` is a
@@ -842,6 +842,9 @@ impl Globals {
         }
     }
 
+    /// Returns the byte offset of the source's `DATA` content (just past
+    /// its `__END__` line) when present — used by the main-script runner;
+    /// other callers ignore it.
     pub fn compile_script_binding(
         &mut self,
         code: Vec<u8>,
@@ -849,7 +852,35 @@ impl Globals {
         binding: Binding,
         lineno: i64,
         src_encoding: Option<String>,
-    ) -> Result<()> {
+    ) -> Result<Option<usize>> {
+        self.compile_script_binding_inner(code, path, binding, lineno, src_encoding, false)
+    }
+
+    /// `compile_script_binding` for the *main script* run inside
+    /// TOPLEVEL_BINDING (`Executor::exec_main_script`). The compiled body
+    /// gets a method-style, proc-method Meta — like a `define_method`
+    /// body — so a toplevel `return` (bare or from a block) unwinds to
+    /// the script frame and terminates the script, instead of walking the
+    /// binding's outer chain to a frame that is not on the stack and
+    /// raising LocalJumpError.
+    pub(crate) fn compile_main_script_binding(
+        &mut self,
+        code: Vec<u8>,
+        path: impl Into<PathBuf>,
+        binding: Binding,
+    ) -> Result<Option<usize>> {
+        self.compile_script_binding_inner(code, path, binding, 1, None, true)
+    }
+
+    fn compile_script_binding_inner(
+        &mut self,
+        code: Vec<u8>,
+        path: impl Into<PathBuf>,
+        binding: Binding,
+        lineno: i64,
+        src_encoding: Option<String>,
+        main_style: bool,
+    ) -> Result<Option<usize>> {
         let line_offset = lineno - 1;
         let outer_fid = binding.outer_fid();
         let outer = match self.store[outer_fid].is_iseq() {
@@ -872,25 +903,31 @@ impl Globals {
             None
         };
 
-        let fid = match crate::parser::parse_program_binding(
+        let (fid, data_offset) = match crate::parser::parse_program_binding(
             code,
             path,
             context.clone(),
             Some(&external_context),
             line_offset,
             src_encoding,
+            main_style,
         ) {
             Ok(res) => {
+                let data_offset = res.data_offset;
                 let res =
                     bytecodegen::bytecode_compile_eval(self, res, outer, Loc::default(), context);
                 #[cfg(feature = "emit-bc")]
                 self.dump_bc();
-                res
+                res.map(|fid| (fid, data_offset))
             }
             Err(err) => Err(err),
         }?;
+        if main_style {
+            self.store[fid].set_method_style();
+            self.store[fid].set_proc_method();
+        }
         self.new_binding_frame(fid, binding.self_val(), binding);
-        Ok(())
+        Ok(data_offset)
     }
 
     pub(crate) fn get_func_data(&mut self, func_id: FuncId) -> &FuncData {

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -402,6 +402,13 @@ impl Store {
             let iseq = &self[iseq_id];
             let mother = iseq.mother().0;
             if mother != iseq_id {
+                // The main script executes inside TOPLEVEL_BINDING, so its
+                // body is technically a block of the empty toplevel frame —
+                // but it *is* the program's top level. It is the only block
+                // fid stamped `_MAIN` (`compile_main_script_binding`).
+                if info.name() == Some(IdentId::_MAIN) {
+                    return "<main>".to_string();
+                }
                 return format!("block in {}", self.func_description(self[mother].func_id()));
             } else {
                 // The toplevel frame's internal name is `/main`

--- a/monoruby/src/parser/mod.rs
+++ b/monoruby/src/parser/mod.rs
@@ -121,6 +121,7 @@ pub(crate) fn parse_program_binding(
     extern_context: Option<&crate::globals::ExternalContext>,
     line_offset: i64,
     default_encoding: Option<String>,
+    main_script: bool,
 ) -> Result<ParseResult, MonorubyErr> {
     prism_backend::parse_program_binding(
         code,
@@ -129,5 +130,6 @@ pub(crate) fn parse_program_binding(
         extern_context,
         line_offset,
         default_encoding,
+        main_script,
     )
 }

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -53,7 +53,7 @@ const ANON_KWREST_NAME: &str = "**";
 const FOR_INDEX_NAME: &str = "(for)";
 
 pub(super) fn parse_program(code: Vec<u8>, path: PathBuf) -> Result<ParseResult, MonorubyErr> {
-    try_prism_inner(&code, path, None, None, 0, None)
+    try_prism_inner(&code, path, None, None, 0, None, false)
 }
 
 pub(super) fn parse_program_eval(
@@ -64,7 +64,7 @@ pub(super) fn parse_program_eval(
     default_encoding: Option<String>,
 ) -> Result<ParseResult, MonorubyErr> {
     let options = build_prism_options(extern_context, None, line_offset);
-    try_prism_inner(&code, path, Some(options), None, line_offset, default_encoding)
+    try_prism_inner(&code, path, Some(options), None, line_offset, default_encoding, false)
 }
 
 pub(super) fn parse_program_binding(
@@ -74,9 +74,18 @@ pub(super) fn parse_program_binding(
     extern_context: Option<&ExternalContext>,
     line_offset: i64,
     default_encoding: Option<String>,
+    main_script: bool,
 ) -> Result<ParseResult, MonorubyErr> {
     let options = build_prism_options(extern_context, context.as_ref(), line_offset);
-    try_prism_inner(&code, path, Some(options), context, line_offset, default_encoding)
+    try_prism_inner(
+        &code,
+        path,
+        Some(options),
+        context,
+        line_offset,
+        default_encoding,
+        main_script,
+    )
 }
 
 /// Build a `prism::Options` for an eval/binding parse. Prism's
@@ -292,6 +301,7 @@ fn try_prism_inner(
     seed_lvars: Option<LvarCollector>,
     line_offset: i64,
     default_encoding: Option<String>,
+    main_script: bool,
 ) -> Result<ParseResult, MonorubyErr> {
     let path_display = path.display().to_string();
     // `-n` / `-p`: the main script (and only the main script) gets its
@@ -304,6 +314,7 @@ fn try_prism_inner(
         Some(opts) => prism::parse_with_options(code, opts),
         None => prism::parse(code),
     };
+    let data_loc_start = result.data_loc().map(|loc| loc.start_offset());
 
     // Detect the source encoding from the `# coding:` / `# encoding:`
     // magic comment ourselves rather than via prism's `magic_comments()`
@@ -384,7 +395,10 @@ fn try_prism_inner(
 
     let mut lowerer = Lowerer::new(code, path_display, source_info.clone());
     lowerer.line_offset = line_offset;
-    lowerer.eval_parse = options.is_some();
+    // The main script parses with binding scopes (it executes inside
+    // TOPLEVEL_BINDING) but *is* a script top level — keep script-level
+    // warnings like "argument of top-level return is ignored".
+    lowerer.eval_parse = options.is_some() && !main_script;
     lowerer.cli_loop_wrap = cli_loop_wrap;
     if let Some(seed) = seed_lvars {
         // For `binding.eval`, monoruby preloads a `LvarCollector`
@@ -405,11 +419,22 @@ fn try_prism_inner(
     warnings.append(&mut lowerer.warnings);
     let lvar_collector = lowerer.into_lvars();
 
+    // `data_loc` spans from the `__END__` marker to EOF; `DATA` content
+    // starts after the marker's line terminator (or at EOF when the file
+    // ends right at `__END__` with no newline).
+    let data_offset = data_loc_start.map(|start| {
+        match code[start..].iter().position(|&b| b == b'\n') {
+            Some(i) => start + i + 1,
+            None => code.len(),
+        }
+    });
+
     Ok(ParseResult {
         node: body,
         lvar_collector,
         source_info,
         warnings,
+        data_offset,
     })
 }
 

--- a/monoruby/tests/main_script.rs
+++ b/monoruby/tests/main_script.rs
@@ -1,0 +1,118 @@
+//! Integration coverage for *main script* semantics: the `DATA` constant
+//! and `TOPLEVEL_BINDING`. Both are properties of how the main program is
+//! executed (`Executor::exec_main_script` runs it inside the
+//! TOPLEVEL_BINDING binding; a `__END__` marker opens `DATA` on the
+//! script file), so they can only be exercised by spawning the real
+//! binary — `run_test` runs its code in-process with a "." path.
+
+use std::io::Write;
+use std::process::Command;
+
+fn monoruby() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    cmd.arg("--disable-gems");
+    cmd
+}
+
+fn write_temp(name: &str, body: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(name);
+    let mut f = std::fs::File::create(&path).expect("create temp file");
+    f.write_all(body.as_bytes()).expect("write temp file");
+    path
+}
+
+fn stdout_of(cmd: &mut Command) -> String {
+    let out = cmd.output().expect("failed to spawn monoruby");
+    assert!(
+        out.status.success(),
+        "monoruby exited with {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// `DATA` is a File on the main script positioned just past `__END__`;
+/// `rewind` seeks to the head of the script itself. A required file's
+/// `__END__` must not (re)define it.
+#[test]
+fn data_constant_reads_past_end_marker() {
+    let lib = write_temp("monoruby_main_data_lib.rb", "__END__\nfrom lib\n");
+    let script = write_temp(
+        "monoruby_main_data.rb",
+        "require_relative 'monoruby_main_data_lib'\n\
+         print DATA.read\n\
+         DATA.rewind\n\
+         print DATA.gets\n\
+         __END__\ndata body\n",
+    );
+    let out = stdout_of(monoruby().arg(&script));
+    assert_eq!(
+        out,
+        "data body\nrequire_relative 'monoruby_main_data_lib'\n"
+    );
+    let _ = std::fs::remove_file(script);
+    let _ = std::fs::remove_file(lib);
+}
+
+/// Without `__END__` in the main script, `DATA` is not defined — even
+/// when a required file has one.
+#[test]
+fn data_constant_absent_without_end_marker() {
+    let script = write_temp(
+        "monoruby_main_nodata.rb",
+        "puts Object.const_defined?(:DATA)\n",
+    );
+    let out = stdout_of(monoruby().arg(&script));
+    assert_eq!(out, "false\n");
+    let _ = std::fs::remove_file(script);
+}
+
+/// TOPLEVEL_BINDING exposes exactly the main script's locals: empty
+/// while a `-r` require runs, then the script's parse-time locals with
+/// live values, merged with dynamically-set Binding variables.
+#[test]
+fn toplevel_binding_tracks_main_script_locals() {
+    let lib = write_temp(
+        "monoruby_main_tb_lib.rb",
+        "p TOPLEVEL_BINDING.local_variables\n\
+         TOPLEVEL_BINDING.local_variable_set(:from_lib, 40)\n",
+    );
+    let script = write_temp(
+        "monoruby_main_tb.rb",
+        "p TOPLEVEL_BINDING.local_variables.sort\n\
+         p TOPLEVEL_BINDING.local_variable_get(:a)\n\
+         a = 1\n\
+         p TOPLEVEL_BINDING.local_variable_get(:a)\n\
+         p TOPLEVEL_BINDING.local_variable_get(:from_lib) + eval('a', TOPLEVEL_BINDING) + 1\n",
+    );
+    let out = stdout_of(monoruby().arg("-r").arg(&lib).arg(&script));
+    assert_eq!(out, "[]\n[:a, :from_lib]\nnil\n1\n42\n");
+    let _ = std::fs::remove_file(script);
+    let _ = std::fs::remove_file(lib);
+}
+
+/// A toplevel `return` — bare or from inside a block — terminates the
+/// main script (no LocalJumpError), and `return <arg>` warns that the
+/// argument is ignored without affecting the exit status.
+#[test]
+fn toplevel_return_terminates_main_script() {
+    let script = write_temp(
+        "monoruby_main_return.rb",
+        "puts 'a'\n1.times { return }\nputs 'b'\n",
+    );
+    let out = stdout_of(monoruby().arg(&script));
+    assert_eq!(out, "a\n");
+    let _ = std::fs::remove_file(script);
+
+    let script = write_temp("monoruby_main_return_arg.rb", "return 3\n");
+    let out = monoruby().arg(&script).output().expect("spawn");
+    assert!(out.status.success(), "exit status must be 0, not 3");
+    assert!(
+        String::from_utf8_lossy(&out.stderr)
+            .contains("warning: argument of top-level return is ignored"),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_file(script);
+}


### PR DESCRIPTION
## Summary

Fixes **11 language specs** (31F → 20F in the `language` category): all 7 `The DATA constant` failures and all 4 `The TOPLEVEL_BINDING constant` failures.

## DATA

prism's `data_loc` is surfaced as `ParseResult::data_offset` (the byte just past the `__END__` line, or EOF when the file ends at the marker with no newline). The main-script runner opens the script file read-only, seeks to that offset, and defines `DATA`. Only the main script does this — a required file's `__END__` must not (re)define it — and `-e`/stdin sources (no backing file) get none, matching CRuby.

## TOPLEVEL_BINDING

Previously defined in `startup.rb` as that file's own toplevel binding — it leaked 21 startup locals into `local_variables` and never reflected the main script. Now:

- `Executor::init` creates it as a Binding over an **empty, outer-less heap frame** (no startup locals anywhere in its scope chain).
- `Executor::exec_main_script` executes the main script **inside** that binding, through the existing binding-eval machinery (compile with the binding's scopes, run on the grown binding frame). This is what produces CRuby's semantics end-to-end: empty while `-r` requires run; then exactly the main script's parse-time locals, live (`local_variable_get(:a)` is `nil` before `a = 1`, `3` after reassignment); merged with dynamically-set Binding variables; excluding locals from required files and `eval`.

Two main-script-specific knobs on the shared binding-eval path:

- The compiled body gets a **method-style + proc-method Meta** (like a `define_method` body), so a toplevel `return` — bare, or from inside a block (`1.times { return }`, `proc { return }.call`) — unwinds to the script frame and terminates the script, instead of walking the binding's outer chain to a frame that isn't on the stack and raising LocalJumpError.
- The parse is flagged `main_script`, keeping script-level parse behaviours that eval parses suppress — concretely the runtime `warning: argument of top-level return is ignored`, pinned by the existing `return_spec` example.

## Verification

- `language`: **20F / 14E** — exactly the previous baseline minus the 11 fixed specs; nothing else moved (including all `return` at-top-level specs).
- All CI core spec categories (`basicobject` … `unboundmethod`, plus `symbol`/`range`/`set`): 0F/0E, except `core/range` which fails identically on master with a current ruby/spec checkout (pre-existing, unrelated).
- Full `cargo test` green — every `run_test`-based test already executes through the new binding-main path, since the harness enters via `Globals::run`. One nonblock-IO test flaked once under full-suite load and passes standalone and on rerun.
- New spawn-based integration tests (`tests/main_script.rs`): DATA read/rewind + required-file isolation, absence without `__END__`, the binding's locals lifecycle across `-r`/dynamic sets/live updates, and toplevel-return termination + warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_