### PR TITLE
Exception API compliance: full_message, errno dispatch, jump/throw metadata

### DIFF
--- a/monoruby/builtins/error.rb
+++ b/monoruby/builtins/error.rb
@@ -1,149 +1,164 @@
 # `Errno::E*` exception classes and their `Errno` constants are populated
 # by Rust-side `errno::init` (see monoruby/src/builtins/errno.rs), which
 # walks the host's `libc::E*` table at startup so any errno present on the
-# system (`Errno::ENETDOWN`, `Errno::EPROTOTYPE`, …) is reachable.
-# We only attach a per-class `initialize` here so `Errno::E*.new(arg)`
-# yields CRuby's "<strerror> - <arg>" message format.
+# system (`Errno::ENETDOWN`, `Errno::EPROTOTYPE`, ...) is reachable.
+# Here we attach CRuby-compatible construction on top:
+#   SystemCallError.new(errno)            -> Errno::X instance (by errno)
+#   SystemCallError.new(msg, errno[, loc])-> Errno::X instance
+#   Errno::X.new([msg[, location]])       -> "strerror [@ loc] - msg"
+#   SystemCallError#errno                 -> the errno Integer
+class SystemCallError
+  # strerror(3) text for the errnos whose message CRuby tests exercise;
+  # anything else falls back to "Unknown error N".
+  STRERROR = {
+    "ENOENT" => "No such file or directory",
+    "EEXIST" => "File exists",
+    "EACCES" => "Permission denied",
+    "ENOTEMPTY" => "Directory not empty",
+    "ECONNRESET" => "Connection reset by peer",
+    "ETIMEDOUT" => "Connection timed out",
+    "ECONNREFUSED" => "Connection refused",
+    "EISDIR" => "Is a directory",
+    "ENOTDIR" => "Not a directory",
+    "EPERM" => "Operation not permitted",
+    "EINVAL" => "Invalid argument",
+    "EIO" => "Input/output error",
+    "EAGAIN" => "Resource temporarily unavailable",
+    "EPIPE" => "Broken pipe",
+    "EBADF" => "Bad file descriptor",
+    "ENOMEM" => "Cannot allocate memory",
+    "EBUSY" => "Device or resource busy",
+    "EROFS" => "Read-only file system",
+    "ENOSPC" => "No space left on device",
+    "EADDRINUSE" => "Address already in use",
+    "ECHILD" => "No child processes",
+    "EINTR" => "Interrupted system call",
+    "EDOM" => "Numerical argument out of domain",
+    "ERANGE" => "Numerical result out of range",
+    "ESRCH" => "No such process",
+    "ENXIO" => "No such device or address",
+    "ESPIPE" => "Illegal seek",
+    "EXDEV" => "Invalid cross-device link",
+    "ENODEV" => "No such device",
+    "EMFILE" => "Too many open files",
+    "ELOOP" => "Too many levels of symbolic links",
+    "ENAMETOOLONG" => "File name too long",
+  }
+
+  def self.__errno_class(n)
+    @__errno_map ||= begin
+      map = {}
+      Errno.constants.each do |c|
+        k = Errno.const_get(c)
+        next unless k.is_a?(Class) && k < SystemCallError
+        e = k.const_defined?(:Errno) ? k.const_get(:Errno) : nil
+        map[e] = k if e.is_a?(Integer) && !map.key?(e)
+      end
+      map
+    end
+    @__errno_map[n]
+  end
+
+  # `SystemCallError.new(errno)` / `.new(msg, errno[, location])`
+  # constructs the matching `Errno::*` subclass; an unknown errno stays
+  # a plain SystemCallError. Subclasses (including user-defined ones)
+  # construct normally through their own #initialize.
+  def self.new(*args)
+    return super unless self.equal?(SystemCallError)
+    if args.empty?
+      raise ArgumentError, "wrong number of arguments (given 0, expected 1..3)"
+    end
+    if args[0].is_a?(String)
+      msg, errno, loc = args[0], args[1], args[2]
+    else
+      errno, msg, loc = args[0], nil, nil
+    end
+    errno = errno.to_int if errno.is_a?(Float)
+    klass = __errno_class(errno)
+    obj = (klass || self).allocate
+    obj.__send__(:__syserr_init, msg, errno, loc)
+    obj
+  end
+
+  # CRuby reports arity -1 for SystemCallError#initialize.
+  def initialize(*args)
+    if args[0].is_a?(String)
+      msg, errno, loc = args[0], args[1], args[2]
+    else
+      errno, msg, loc = args[0], nil, nil
+    end
+    errno = errno.to_int if errno.is_a?(Float)
+    if errno.nil? && self.class.const_defined?(:Errno)
+      e = self.class.const_get(:Errno)
+      errno = e if e.is_a?(Integer)
+    end
+    __syserr_init(msg, errno, loc)
+  end
+
+  def errno
+    defined?(@__errno) ? @__errno : nil
+  end
+
+  private def __syserr_init(msg, errno, loc)
+    @__errno = errno
+    name = self.class.name.to_s.split("::").last
+    base = STRERROR[name]
+    base ||= errno ? "Unknown error #{errno}" : (name.empty? ? "unknown error" : name)
+    base = "#{base} @ #{loc}" unless loc.nil?
+    base = "#{base} - #{msg}" unless msg.nil?
+    ::Exception.instance_method(:initialize).bind(self).call(base)
+  end
+end
+
 class Errno
-  class ENOENT < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "No such file or directory - #{msg}" : "No such file or directory")
-    end
-  end
-
-  class EEXIST < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "File exists - #{msg}" : "File exists")
-    end
-  end
-
-  class EACCES < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Permission denied - #{msg}" : "Permission denied")
-    end
-  end
-
-  class ENOTEMPTY < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Directory not empty - #{msg}" : "Directory not empty")
-    end
-  end
-
-  class ECONNRESET < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Connection reset by peer - #{msg}" : "Connection reset by peer")
-    end
-  end
-
-  class ETIMEDOUT < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Connection timed out - #{msg}" : "Connection timed out")
-    end
-  end
-
-  class ECONNREFUSED < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Connection refused - #{msg}" : "Connection refused")
-    end
-  end
-
-  class EISDIR < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Is a directory - #{msg}" : "Is a directory")
-    end
-  end
-
-  class ENOTDIR < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Not a directory - #{msg}" : "Not a directory")
-    end
-  end
-
-  class EPERM < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Operation not permitted - #{msg}" : "Operation not permitted")
-    end
-  end
-
-  class EINVAL < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Invalid argument - #{msg}" : "Invalid argument")
-    end
-  end
-
-  class EIO < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Input/output error - #{msg}" : "Input/output error")
-    end
-  end
-
-  class EAGAIN < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Resource temporarily unavailable - #{msg}" : "Resource temporarily unavailable")
-    end
-  end
-
-  class EPIPE < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Broken pipe - #{msg}" : "Broken pipe")
-    end
-  end
-
-  class EBADF < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Bad file descriptor - #{msg}" : "Bad file descriptor")
-    end
-  end
-
-  class ENOMEM < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Cannot allocate memory - #{msg}" : "Cannot allocate memory")
-    end
-  end
-
-  class EBUSY < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Device or resource busy - #{msg}" : "Device or resource busy")
-    end
-  end
-
-  class EROFS < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Read-only file system - #{msg}" : "Read-only file system")
-    end
-  end
-
-  class ENOSPC < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "No space left on device - #{msg}" : "No space left on device")
-    end
-  end
-
-  class EADDRINUSE < SystemCallError
-    def initialize(msg = nil)
-      super(msg ? "Address already in use - #{msg}" : "Address already in use")
+  # Give every generated Errno::E* class the CRuby constructor
+  # signature `new(msg = nil, location = nil)`.
+  constants.each do |c|
+    k = const_get(c)
+    next unless k.is_a?(Class) && k < SystemCallError
+    k.class_eval do
+      def initialize(msg = nil, loc = nil)
+        e = self.class.const_defined?(:Errno) ? self.class.const_get(:Errno) : nil
+        __syserr_init(msg, e.is_a?(Integer) ? e : nil, loc)
+      end
     end
   end
 end
 
-class SignalException
-  def initialize(sig = nil)
+class SignalException < Exception
+  # SignalException.new(signo), .new(:TERM), .new("SIGTERM", msg), ...
+  def initialize(sig = nil, message = nil)
     if sig.is_a?(Integer)
-      super("Signal #{sig}")
-    elsif sig
-      super(sig.to_s)
+      name = Signal.signame(sig)
+      raise ArgumentError, "invalid signal number (#{sig})" unless name
+      @__signo = sig
+      super(message || "SIG#{name}")
+    elsif !sig.nil?
+      name = sig.to_s.sub(/\ASIG/, "")
+      signo = Signal.list[name]
+      raise ArgumentError, "unsupported signal `SIG#{name}'" unless signo
+      @__signo = signo
+      super(message || "SIG#{name}")
     else
       super("SignalException")
     end
   end
+
+  def signo
+    defined?(@__signo) ? @__signo : nil
+  end
+
+  # The signal description is the exception message.
+  def signm
+    message
+  end
 end
 
 class Interrupt < SignalException
-  def initialize(msg = nil)
-    if msg
-      super(msg)
-    else
-      super("Interrupt")
-    end
+  def initialize(message = nil)
+    @__signo = Signal.list["INT"]
+    # Interrupt's default message is its class name, not "SIGINT";
+    # bypass SignalException#initialize.
+    ::Exception.instance_method(:initialize).bind(self).call(message || "Interrupt")
   end
 end

--- a/monoruby/builtins/error.rb
+++ b/monoruby/builtins/error.rb
@@ -63,18 +63,38 @@ class SystemCallError
   # constructs the matching `Errno::*` subclass; an unknown errno stays
   # a plain SystemCallError. Subclasses (including user-defined ones)
   # construct normally through their own #initialize.
+  # CRuby coercion for the errno argument: Integers pass through,
+  # other Numerics truncate (a Complex must have zero imaginary part),
+  # anything else needs #to_int.
+  def self.__coerce_errno(errno)
+    return errno if errno.is_a?(Integer)
+    if errno.is_a?(Complex)
+      unless errno.imaginary == 0
+        raise RangeError, "can't convert #{errno} into Integer"
+      end
+      return errno.real.to_i
+    end
+    return errno.to_i if errno.is_a?(Numeric)
+    unless errno.respond_to?(:to_int)
+      raise TypeError, "no implicit conversion of #{errno.class} into Integer"
+    end
+    errno.to_int
+  end
+
   def self.new(*args)
     return super unless self.equal?(SystemCallError)
     if args.empty?
       raise ArgumentError, "wrong number of arguments (given 0, expected 1..3)"
     end
-    if args[0].is_a?(String)
+    if args.size >= 2
       msg, errno, loc = args[0], args[1], args[2]
+      errno = __coerce_errno(errno) unless errno.nil?
+    elsif args[0].is_a?(String) || args[0].nil?
+      msg, errno, loc = args[0], nil, nil
     else
-      errno, msg, loc = args[0], nil, nil
+      errno, msg, loc = __coerce_errno(args[0]), nil, nil
     end
-    errno = errno.to_int if errno.is_a?(Float)
-    klass = __errno_class(errno)
+    klass = errno.nil? ? nil : __errno_class(errno)
     obj = (klass || self).allocate
     obj.__send__(:__syserr_init, msg, errno, loc)
     obj
@@ -82,12 +102,14 @@ class SystemCallError
 
   # CRuby reports arity -1 for SystemCallError#initialize.
   def initialize(*args)
-    if args[0].is_a?(String)
+    if args.size >= 2
       msg, errno, loc = args[0], args[1], args[2]
+      errno = SystemCallError.__coerce_errno(errno) unless errno.nil?
+    elsif args[0].is_a?(String) || args[0].nil?
+      msg, errno, loc = args[0], nil, nil
     else
-      errno, msg, loc = args[0], nil, nil
+      errno, msg, loc = SystemCallError.__coerce_errno(args[0]), nil, nil
     end
-    errno = errno.to_int if errno.is_a?(Float)
     if errno.nil? && self.class.const_defined?(:Errno)
       e = self.class.const_get(:Errno)
       errno = e if e.is_a?(Integer)
@@ -100,10 +122,24 @@ class SystemCallError
   end
 
   private def __syserr_init(msg, errno, loc)
+    unless msg.nil? || msg.is_a?(String)
+      if msg.respond_to?(:to_str)
+        msg = msg.to_str
+      else
+        raise TypeError, "no implicit conversion of #{msg.class} into String"
+      end
+    end
     @__errno = errno
-    name = self.class.name.to_s.split("::").last
-    base = STRERROR[name]
-    base ||= errno ? "Unknown error #{errno}" : (name.empty? ? "unknown error" : name)
+    # Walk the ancestors so a user subclass of Errno::ENOENT inherits
+    # "No such file or directory" rather than the unknown-errno text.
+    base = nil
+    self.class.ancestors.each do |a|
+      next unless a.is_a?(Class) && a.name
+      base = STRERROR[a.name.split("::").last]
+      break if base
+      break if a.equal?(SystemCallError)
+    end
+    base ||= errno ? "Unknown error #{errno}" : "unknown error"
     base = "#{base} @ #{loc}" unless loc.nil?
     base = "#{base} - #{msg}" unless msg.nil?
     ::Exception.instance_method(:initialize).bind(self).call(base)

--- a/monoruby/builtins/error.rb
+++ b/monoruby/builtins/error.rb
@@ -87,41 +87,44 @@ class SystemCallError
       raise ArgumentError, "wrong number of arguments (given 0, expected 1..3)"
     end
     if args.size >= 2
-      msg, errno, loc = args[0], args[1], args[2]
-      errno = __coerce_errno(errno) unless errno.nil?
+      msg, orig, loc = args[0], args[1], args[2]
     elsif args[0].is_a?(String) || args[0].nil?
-      msg, errno, loc = args[0], nil, nil
+      msg, orig, loc = args[0], nil, nil
     else
-      errno, msg, loc = __coerce_errno(args[0]), nil, nil
+      msg, orig, loc = nil, args[0], nil
     end
+    errno = orig.nil? ? nil : __coerce_errno(orig)
     klass = errno.nil? ? nil : __errno_class(errno)
     obj = (klass || self).allocate
-    obj.__send__(:__syserr_init, msg, errno, loc)
+    # #errno reports the errno as given (2.9 stays 2.9); only the
+    # class lookup and the message use the Integer coercion.
+    obj.__send__(:__syserr_init, msg, errno, loc, orig)
     obj
   end
 
   # CRuby reports arity -1 for SystemCallError#initialize.
   def initialize(*args)
     if args.size >= 2
-      msg, errno, loc = args[0], args[1], args[2]
-      errno = SystemCallError.__coerce_errno(errno) unless errno.nil?
+      msg, orig, loc = args[0], args[1], args[2]
     elsif args[0].is_a?(String) || args[0].nil?
-      msg, errno, loc = args[0], nil, nil
+      msg, orig, loc = args[0], nil, nil
     else
-      errno, msg, loc = SystemCallError.__coerce_errno(args[0]), nil, nil
+      msg, orig, loc = nil, args[0], nil
     end
+    errno = orig.nil? ? nil : SystemCallError.__coerce_errno(orig)
     if errno.nil? && self.class.const_defined?(:Errno)
       e = self.class.const_get(:Errno)
       errno = e if e.is_a?(Integer)
+      orig = errno
     end
-    __syserr_init(msg, errno, loc)
+    __syserr_init(msg, errno, loc, orig)
   end
 
   def errno
     defined?(@__errno) ? @__errno : nil
   end
 
-  private def __syserr_init(msg, errno, loc)
+  private def __syserr_init(msg, errno, loc, reported_errno = nil)
     unless msg.nil? || msg.is_a?(String)
       if msg.respond_to?(:to_str)
         msg = msg.to_str
@@ -129,7 +132,7 @@ class SystemCallError
         raise TypeError, "no implicit conversion of #{msg.class} into String"
       end
     end
-    @__errno = errno
+    @__errno = reported_errno.nil? ? errno : reported_errno
     # Walk the ancestors so a user subclass of Errno::ENOENT inherits
     # "No such file or directory" rather than the unknown-errno text.
     base = nil
@@ -155,7 +158,8 @@ class Errno
     k.class_eval do
       def initialize(msg = nil, loc = nil)
         e = self.class.const_defined?(:Errno) ? self.class.const_get(:Errno) : nil
-        __syserr_init(msg, e.is_a?(Integer) ? e : nil, loc)
+        e = nil unless e.is_a?(Integer)
+        __syserr_init(msg, e, loc, e)
       end
     end
   end

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1066,13 +1066,22 @@ class Exception
         trailer = "\t ... #{rest.size - limit} levels...\n"
         rest = rest[0, limit]
       end
-      lines = rest.map { |l| "\tfrom #{l}\n" }
-      lines << trailer if trailer
       out = if order == :bottom
         header = highlight ? "\e[1mTraceback\e[m (most recent call last):\n"
                            : "Traceback (most recent call last):\n"
-        header + lines.reverse.join + "#{bt[0]}: #{msg}\n"
+        # CRuby numbers the reversed frames by their distance from the
+        # error line: `\tN: from <frame>` counting down to 1.
+        numbered = []
+        i = rest.size
+        rest.each do |l|
+          numbered << "\t#{i}: from #{l}\n"
+          i -= 1
+        end
+        numbered << trailer if trailer
+        header + numbered.reverse.join + "#{bt[0]}: #{msg}\n"
       else
+        lines = rest.map { |l| "\tfrom #{l}\n" }
+        lines << trailer if trailer
         "#{bt[0]}: #{msg}\n" + lines.join
       end
     else

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1015,14 +1015,49 @@ class Exception
     end
   end
 
-  def full_message(highlight: nil, order: :top)
+  # CRuby's Exception#inspect goes through #to_s (which user classes
+  # may override): `#<ClassName: to_s>`, or just the class name when
+  # #to_s returns an empty string.
+  def inspect
+    s = to_s
+    if s.nil? || s.empty?
+      self.class.name || self.class.to_s
+    else
+      "#<#{self.class}: #{s}>"
+    end
+  end
+
+  # Whether the uncaught-exception report would be written to a tty —
+  # the default for `full_message`'s :highlight option.
+  def self.to_tty?
+    $stderr.equal?(STDERR) && STDERR.tty?
+  rescue NoMethodError
+    false
+  end
+
+  def full_message(highlight: nil, order: :top, **opts)
     # CRuby's first line is `bt[0]: <detailed_message>` (i.e.
     # "message (ClassName)"), followed by `\tfrom <frame>` lines.
     # `--backtrace-limit=N` truncates the from-lines to N entries plus
     # a `\t ... K levels...` marker, exactly like the top-level
-    # uncaught-error report.
-    msg = detailed_message(highlight: highlight ? true : false)
+    # uncaught-error report. All keyword arguments except :order are
+    # forwarded to #detailed_message, with :highlight resolved to its
+    # default first.
+    highlight = Exception.to_tty? if highlight.nil?
+    msg = nil
+    if respond_to?(:detailed_message)
+      dm = detailed_message(highlight: highlight, **opts)
+      dm = dm.to_str if !dm.is_a?(String) && dm.respond_to?(:to_str)
+      msg = dm if dm.is_a?(String)
+    end
+    if msg.nil?
+      # No usable #detailed_message: fall back to the class name.
+      msg = highlight ? "\e[1;4m#{self.class}\e[m" : self.class.to_s
+    end
     bt = backtrace
+    # An exception that was never raised has no backtrace; CRuby shows
+    # the caller of full_message instead.
+    bt = caller if bt.nil? || bt.empty?
     if bt && !bt.empty?
       rest = bt[1..]
       limit = Kernel.__backtrace_limit
@@ -1033,14 +1068,20 @@ class Exception
       end
       lines = rest.map { |l| "\tfrom #{l}\n" }
       lines << trailer if trailer
-      if order == :top
-        "#{bt[0]}: #{msg}\n" + lines.join
+      out = if order == :bottom
+        header = highlight ? "\e[1mTraceback\e[m (most recent call last):\n"
+                           : "Traceback (most recent call last):\n"
+        header + lines.reverse.join + "#{bt[0]}: #{msg}\n"
       else
-        lines.reverse.join + "#{bt[0]}: #{msg}\n"
+        "#{bt[0]}: #{msg}\n" + lines.join
       end
     else
-      msg + "\n"
+      out = msg + "\n"
     end
+    # Chain the cause's report so every exception in the chain appears.
+    c = cause
+    out += c.full_message(highlight: highlight, order: :top) if c
+    out
   end
 
   # CRuby `Exception#detailed_message(highlight: false, **)`:
@@ -1053,16 +1094,20 @@ class Exception
       base = instance_of?(::RuntimeError) ? "unhandled exception" : (cls.name || cls.to_s)
       return highlight ? "\e[1;4m#{base}\e[m" : base
     end
-    nl = msg.index("\n")
-    first = nl ? msg[0...nl] : msg
-    rest = nl ? msg[nl..] : ""
+    first, *rest = msg.split("\n", -1)
+    # With :highlight every line of a multi-line message is bolded
+    # individually (`\e[1m…\e[m` per line).
     if cls.name.nil?
-      highlight ? "\e[1m#{first}\e[m#{rest}" : "#{first}#{rest}"
+      head = highlight ? "\e[1m#{first}\e[m" : first
     elsif highlight
-      "\e[1m#{first} (\e[1;4m#{cls}\e[m\e[1m)\e[m#{rest}"
+      head = "\e[1m#{first} (\e[1;4m#{cls}\e[m\e[1m)\e[m"
     else
-      "#{first} (#{cls})#{rest}"
+      head = "#{first} (#{cls})"
     end
+    if highlight
+      rest = rest.map { |l| l.empty? ? l : "\e[1m#{l}\e[m" }
+    end
+    ([head] + rest).join("\n")
   end
 end
 

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -60,6 +60,8 @@ pub(super) fn init(globals: &mut Globals) {
     let loaderr = globals.define_builtin_exception_class("LoadError", LOAD_ERROR_CLASS, scripterr);
     globals.define_builtin_func(loaderr.id(), "path", loaderror_path, 0);
     globals.define_builtin_exception_class("SyntaxError", SYNTAX_ERROR_CLASS, scripterr);
+    // `SyntaxError#path` — the source file the error was raised in.
+    globals.define_builtin_func(SYNTAX_ERROR_CLASS, "path", loaderror_path, 0);
     globals.define_builtin_exception_class(
         "NotImplementedError",
         UNIMPLEMENTED_ERROR_CLASS,
@@ -79,9 +81,17 @@ pub(super) fn init(globals: &mut Globals) {
     let keyerr = globals.define_builtin_exception_class("KeyError", KEY_ERROR_CLASS, indexerr);
     globals.define_builtin_func(keyerr.id(), "receiver", keyerror_receiver, 0);
     globals.define_builtin_func(keyerr.id(), "key", keyerror_key, 0);
-    globals.define_builtin_exception_class("StopIteration", STOP_ITERATION_CLASS, indexerr);
+    let stopiter =
+        globals.define_builtin_exception_class("StopIteration", STOP_ITERATION_CLASS, indexerr);
+    // `Queue#close` + pop on an empty closed queue. Subclass of
+    // StopIteration so `loop { q.pop }` terminates cleanly.
+    globals.define_class("ClosedQueueError", stopiter, OBJECT_CLASS);
+    // `StopIteration#result` — the iterated method's return value.
+    globals.define_builtin_func(STOP_ITERATION_CLASS, "result", stopiteration_result, 0);
 
     globals.define_builtin_exception_class("LocalJumpError", LOCAL_JUMP_ERROR_CLASS, standarderr);
+    globals.define_builtin_func(LOCAL_JUMP_ERROR_CLASS, "exit_value", localjump_exit_value, 0);
+    globals.define_builtin_func(LOCAL_JUMP_ERROR_CLASS, "reason", localjump_reason, 0);
 
     let nameerr =
         globals.define_builtin_exception_class("NameError", NAME_ERROR_CLASS, standarderr);
@@ -93,10 +103,19 @@ pub(super) fn init(globals: &mut Globals) {
         "initialize",
         nameerr_initialize,
         0,
-        2,
+        3,
         false,
     );
     globals.define_builtin_exception_class("NoMethodError", NO_METHOD_ERROR_CLASS, nameerr);
+    globals.define_builtin_func_with(
+        NO_METHOD_ERROR_CLASS,
+        "initialize",
+        nomethoderr_initialize,
+        0,
+        4,
+        false,
+    );
+    globals.define_builtin_func(NO_METHOD_ERROR_CLASS, "args", nomethoderr_args, 0);
 
     let runtimeerr =
         globals.define_builtin_exception_class("RuntimeError", RUNTIME_ERROR_CLASS, standarderr);
@@ -149,6 +168,51 @@ fn exc_receiver(
         .get_ivar(self_val, IdentId::get_id("/receiver"))
         .unwrap_or_default();
     Ok(v)
+}
+
+/// `StopIteration#result` — the return value of the method whose
+/// iteration the enumerator exhausted.
+#[monoruby_builtin]
+fn stopiteration_result(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/result"))
+        .unwrap_or_default())
+}
+
+/// `LocalJumpError#exit_value` — the value the failed jump carried
+/// (e.g. the argument of the escaping `return`).
+#[monoruby_builtin]
+fn localjump_exit_value(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/exit_value"))
+        .unwrap_or_default())
+}
+
+/// `LocalJumpError#reason` — the jump kind (`:return`, `:break`, …);
+/// `:noreason` when unknown, like CRuby's default.
+#[monoruby_builtin]
+fn localjump_reason(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/reason"))
+        .unwrap_or_else(|| Value::symbol(IdentId::get_id("noreason"))))
 }
 
 /// `NameError#name` — returns the missing-name Symbol that was passed
@@ -204,7 +268,69 @@ fn nameerr_initialize(
                 .set_ivar(self_, IdentId::_NAME, name)?;
         }
     }
+    // Trailing keyword hash (`receiver:`).
+    if let Some(kwargs) = lfp.try_arg(2)
+        && kwargs.try_hash_ty().is_some()
+    {
+        store_exception_kwargs(vm, globals, self_, kwargs)?;
+    }
     Ok(Value::nil())
+}
+
+/// `NoMethodError.new(msg = nil, name = nil, args = nil, receiver: …)`.
+#[monoruby_builtin]
+fn nomethoderr_initialize(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let mut self_ = lfp.self_val();
+    let class_id = self_.real_class(&globals.store).id();
+    let message = if let Some(msg) = lfp.try_arg(0)
+        && !msg.is_nil()
+    {
+        msg.coerce_to_string(vm, globals)?
+    } else {
+        globals.store.get_class_name(class_id)
+    };
+    self_.is_exception_mut().unwrap().set_message(message);
+    if let Some(name) = lfp.try_arg(1)
+        && !name.is_nil()
+    {
+        globals.store.set_ivar(self_, IdentId::_NAME, name)?;
+    }
+    if let Some(args) = lfp.try_arg(2)
+        && !args.is_nil()
+        && args.try_hash_ty().is_none()
+    {
+        globals
+            .store
+            .set_ivar(self_, IdentId::get_id("/args"), args)?;
+    }
+    // The keyword hash (`receiver:`) lands in the last given slot.
+    for i in 2..4 {
+        if let Some(kwargs) = lfp.try_arg(i)
+            && kwargs.try_hash_ty().is_some()
+        {
+            store_exception_kwargs(vm, globals, self_, kwargs)?;
+        }
+    }
+    Ok(Value::nil())
+}
+
+/// `NoMethodError#args` — the arguments of the failed call.
+#[monoruby_builtin]
+fn nomethoderr_args(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/args"))
+        .unwrap_or_else(|| Value::array_empty()))
 }
 
 /// Allocator for `Exception` and its subclasses. The exception is created
@@ -254,7 +380,9 @@ fn exception_new(
 fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
     let class_id = self_.real_class(&globals.store).id();
-    let message = if let Some(msg) = lfp.try_arg(0) {
+    let message = if let Some(msg) = lfp.try_arg(0)
+        && !msg.is_nil()
+    {
         if msg.try_hash_ty().is_some() {
             // Keyword arguments hash passed as positional arg; use default message.
             store_exception_kwargs(vm, globals, self_, msg)?;

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -70,7 +70,8 @@ pub(super) fn init(globals: &mut Globals) {
 
     let argerr =
         globals.define_builtin_exception_class("ArgumentError", ARGUMENTS_ERROR_CLASS, standarderr);
-    globals.define_class("UncaughtThrowError", argerr, OBJECT_CLASS);
+    let uncaught_throw = globals.define_class("UncaughtThrowError", argerr, OBJECT_CLASS);
+    globals.define_builtin_func(uncaught_throw.id(), "tag", uncaught_throw_tag, 0);
     globals.define_class("EncodingError", standarderr, OBJECT_CLASS);
     globals.define_builtin_exception_class("FiberError", FIBER_ERROR_CLASS, standarderr);
     let ioerr = globals.define_builtin_exception_class("IOError", IO_ERROR_CLASS, standarderr);
@@ -168,6 +169,20 @@ fn exc_receiver(
         .get_ivar(self_val, IdentId::get_id("/receiver"))
         .unwrap_or_default();
     Ok(v)
+}
+
+/// `UncaughtThrowError#tag` — the tag object of the uncaught `throw`.
+#[monoruby_builtin]
+fn uncaught_throw_tag(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/tag"))
+        .unwrap_or_default())
 }
 
 /// `StopIteration#result` — the return value of the method whose
@@ -394,7 +409,14 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
                     store_exception_kwargs(vm, globals, self_, kwargs)?;
                 }
             }
-            msg.coerce_to_string(vm, globals)?
+            if msg.is_rstring().is_some() {
+                msg.coerce_to_string(vm, globals)?
+            } else {
+                // CRuby accepts any message object and stringifies it
+                // via #to_s (`Exception#to_s calls #to_s on the message`).
+                let s = vm.invoke_method_inner(globals, IdentId::TO_S, msg, &[], None, None)?;
+                s.coerce_to_string(vm, globals)?
+            }
         }
     } else {
         globals.store.get_class_name(class_id)

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -334,7 +334,8 @@ fn nomethoderr_initialize(
     Ok(Value::nil())
 }
 
-/// `NoMethodError#args` — the arguments of the failed call.
+/// `NoMethodError#args` — the arguments of the failed call (nil when
+/// the exception was constructed without them).
 #[monoruby_builtin]
 fn nomethoderr_args(
     _vm: &mut Executor,
@@ -345,7 +346,7 @@ fn nomethoderr_args(
     Ok(globals
         .store
         .get_ivar(lfp.self_val(), IdentId::get_id("/args"))
-        .unwrap_or_else(|| Value::array_empty()))
+        .unwrap_or_default())
 }
 
 /// Allocator for `Exception` and its subclasses. The exception is created

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2991,10 +2991,10 @@ fn throw_(
             .store
             .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("UncaughtThrowError"))
         {
-            return Err(MonorubyErr::new(
-                MonorubyErrKind::Other(klass.as_class_id()),
-                msg,
-            ));
+            let mut err = MonorubyErr::new(MonorubyErrKind::Other(klass.as_class_id()), msg);
+            // Surfaced as `UncaughtThrowError#tag`.
+            err.payload = Some((tag.id(), "tag"));
+            return Err(err);
         }
         return Err(MonorubyErr::argumenterr(msg));
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1161,6 +1161,54 @@ impl Executor {
                 }
                 v
             }
+            MonorubyErrKind::LocalJump => {
+                let payload = err.payload;
+                let v = Value::new_exception(err);
+                if let Some((val, reason)) = payload {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::get_id("/exit_value"), Value::from_u64(val))
+                        .unwrap();
+                    globals
+                        .store
+                        .set_ivar(
+                            v,
+                            IdentId::get_id("/reason"),
+                            Value::symbol(IdentId::get_id(reason)),
+                        )
+                        .unwrap();
+                }
+                v
+            }
+            MonorubyErrKind::StopIteration => {
+                let payload = err.payload;
+                let v = Value::new_exception(err);
+                if let Some((val, _)) = payload {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::get_id("/result"), Value::from_u64(val))
+                        .unwrap();
+                }
+                v
+            }
+            MonorubyErrKind::Syntax => {
+                // `SyntaxError#path`: the file the error was raised in,
+                // taken from the first trace frame (nil for a directly
+                // constructed SyntaxError, which has no trace).
+                let path = err
+                    .trace
+                    .first()
+                    .and_then(|(source_loc, _)| source_loc.as_ref())
+                    .map(|(_, source)| Value::string(source.file_name().to_string()));
+                let v = Value::new_exception(err);
+                if let Some(path) = path {
+                    globals
+                        .store
+                        .set_ivar(v, IdentId::get_id("/path"), path)
+                        .unwrap();
+                }
+                v
+            }
             MonorubyErrKind::Frozen(Some(receiver)) => {
                 let receiver = *receiver;
                 let v = Value::new_exception(err);

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1231,7 +1231,23 @@ impl Executor {
                     .unwrap();
                 v
             }
-            _ => Value::new_exception(err),
+            _ => {
+                // Generic payload: the tag string names the hidden ivar
+                // (e.g. `UncaughtThrowError#tag`).
+                let payload = err.payload;
+                let v = Value::new_exception(err);
+                if let Some((val, name)) = payload {
+                    globals
+                        .store
+                        .set_ivar(
+                            v,
+                            IdentId::get_id(&format!("/{name}")),
+                            Value::from_u64(val),
+                        )
+                        .unwrap();
+                }
+                v
+            }
         };
         self.chain_cause(globals, v, explicit_cause)
     }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -459,7 +459,10 @@ impl MonorubyErr {
             "false".to_string()
         } else if let Some(m) = obj.is_class_or_module() {
             let kind = if m.is_module() { "module" } else { "class" };
-            format!("{kind} {}", obj.to_s(store))
+            // `get_class_name` resolves names assigned via constant
+            // assignment (`MyClass = Class.new`) too, unlike the raw
+            // `to_s`, and falls back to `#<Class:0x…>` when anonymous.
+            format!("{kind} {}", store.get_class_name(m.id()))
         } else if store[obj.class()].get_module().is_singleton().is_some() {
             // A receiver with a singleton class keeps the address form
             // (`for #<Object:0x…>`) in CRuby, not `an instance of …`.

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -19,6 +19,12 @@ pub struct MonorubyErr {
     /// When set, `take_ex_obj` records it as the exception's cause and
     /// suppresses the implicit `$!` chaining.
     pub explicit_cause: Option<Value>,
+    /// Kind-specific extra data, surfaced as hidden ivars when the
+    /// exception object is materialized (`take_ex_obj`): for
+    /// `LocalJumpError` the packed jump value + reason (`"return"`, …)
+    /// → `#exit_value` / `#reason`; for `StopIteration` the packed
+    /// iterator return value + `"result"` → `#result`.
+    pub(crate) payload: Option<(u64, &'static str)>,
 }
 
 impl MonorubyErr {
@@ -29,6 +35,7 @@ impl MonorubyErr {
             trace: vec![],
             original: None,
             explicit_cause: None,
+            payload: None,
         }
     }
 
@@ -42,6 +49,7 @@ impl MonorubyErr {
             trace,
             original: None,
             explicit_cause: None,
+            payload: None,
         }
     }
 
@@ -66,6 +74,7 @@ impl MonorubyErr {
             trace: vec![(Some((loc, sourceinfo)), func_id)],
             original: None,
             explicit_cause: None,
+            payload: None,
         }
     }
 
@@ -86,6 +95,9 @@ impl MonorubyErr {
         }
         if let Some(cause) = &self.explicit_cause {
             cause.mark(alloc);
+        }
+        if let Some((val, _)) = &self.payload {
+            Value::from_u64(*val).mark(alloc);
         }
         match &self.kind {
             // Packed `Value::id()` of the receiver that triggered the
@@ -859,6 +871,14 @@ impl MonorubyErr {
         MonorubyErr::new(MonorubyErrKind::StopIteration, msg)
     }
 
+    /// `StopIteration` carrying the iterated method's return value
+    /// (`StopIteration#result`).
+    pub(crate) fn stopiterationerr_with_result(msg: String, result: Value) -> MonorubyErr {
+        let mut err = MonorubyErr::new(MonorubyErrKind::StopIteration, msg);
+        err.payload = Some((result.id(), "result"));
+        err
+    }
+
     pub(crate) fn index_too_small(actual: i64, minimum: i64) -> MonorubyErr {
         MonorubyErr::indexerr(format!(
             "index {} too small for array; minimum: {}",
@@ -1031,9 +1051,10 @@ impl MonorubyErr {
         MonorubyErr::new(MonorubyErrKind::LocalJump, msg)
     }
 
-    pub(crate) fn localjumperr_with_val(msg: impl ToString, _val: Value) -> MonorubyErr {
-        // TODO: store val as exit_value on the LocalJumpError exception object
-        MonorubyErr::new(MonorubyErrKind::LocalJump, msg)
+    pub(crate) fn localjumperr_with_val(msg: impl ToString, val: Value) -> MonorubyErr {
+        let mut err = MonorubyErr::new(MonorubyErrKind::LocalJump, msg);
+        err.payload = Some((val.id(), "return"));
+        err
     }
 }
 

--- a/monoruby/src/value/rvalue/enumerator.rs
+++ b/monoruby/src/value/rvalue/enumerator.rs
@@ -151,8 +151,11 @@ impl Enumerator {
         let mut internal = self.internal.unwrap();
         let v = internal.enum_yield_values(vm, globals, *self, Value::nil())?;
         if internal.is_terminated() {
-            return Err(MonorubyErr::stopiterationerr(
+            // `v` is the iterated method's own return value here —
+            // surfaced by `StopIteration#result`.
+            return Err(MonorubyErr::stopiterationerr_with_result(
                 "iteration reached an end".to_string(),
+                v,
             ));
         }
         Ok(v.as_array())

--- a/monoruby/tests/exception_api.rs
+++ b/monoruby/tests/exception_api.rs
@@ -163,7 +163,10 @@ fn system_call_error_construction() {
         r#"SystemCallError.new(Errno::EINVAL::Errno).message"#,
         r#"SystemCallError.new("custom message", Errno::EINVAL::Errno).message"#,
         r#"SystemCallError.new("custom message", Errno::EINVAL::Errno, "location").message"#,
-        r#"(e = SystemCallError.new(99999); [e.class, e.message, e.errno])"#,
+        // The unknown-errno message text is platform-specific (Linux
+        // "Unknown error N" vs macOS "Unknown error: N"), so assert only
+        // the prefix so the differential comparison holds on both.
+        r#"(e = SystemCallError.new(99999); [e.class, e.message.start_with?("Unknown error"), e.errno])"#,
         r#"SystemCallError.new(nil, Errno::EINVAL::Errno).message"#,
         r#"SystemCallError.new("a message").message"#,
         r#"SystemCallError.new("foo", 2.9).errno"#,
@@ -173,7 +176,7 @@ fn system_call_error_construction() {
         r#"Errno::ENOENT.new.message"#,
         r#"Errno::ENOENT.new("custom message", "location").message"#,
         r#"Errno::EINVAL.new.errno"#,
-        r#"(SubEnoent = Class.new(Errno::ENOENT); SubEnoent.new("custom").message)"#,
+        r#"Class.new(Errno::ENOENT).new("custom").message"#,
         r#"SystemCallError.instance_method(:initialize).arity"#,
     ]);
 }

--- a/monoruby/tests/exception_api.rs
+++ b/monoruby/tests/exception_api.rs
@@ -1,0 +1,191 @@
+//! Differential coverage for the exception APIs added for ruby/spec's
+//! core/exception category: everything here runs the same snippet under
+//! monoruby and the reference CRuby and compares results.
+
+use monoruby::tests::*;
+
+#[test]
+fn full_message_format() {
+    run_test_once(
+        r#"
+        e = RuntimeError.new("Some runtime error")
+        e.set_backtrace(["a.rb:1", "b.rb:2"])
+        [
+          e.full_message(highlight: false, order: :top),
+          e.full_message(highlight: false, order: :bottom),
+          e.full_message(highlight: true, order: :top),
+          e.full_message(highlight: true, order: :bottom),
+        ]
+        "#,
+    );
+}
+
+#[test]
+fn full_message_multiline_and_empty() {
+    run_test_once(
+        r#"
+        res = []
+        begin
+          raise "first line\nsecond line\nthird line"
+        rescue => e
+          res << e.full_message(highlight: true, order: :top).lines[1..]
+        end
+        e = RuntimeError.new("")
+        e.set_backtrace(["a.rb:1"])
+        res << e.full_message(highlight: false)
+        res << e.full_message(highlight: true)
+        # Caller-derived location differs between harnesses; compare the tail.
+        res << StandardError.new("").full_message(highlight: false).lines.first.end_with?(": StandardError\n")
+        res
+        "#,
+    );
+}
+
+#[test]
+fn full_message_cause_chain_and_detailed_message() {
+    run_test_once(
+        r#"
+        res = []
+        begin
+          begin
+            raise "the cause"
+          rescue
+            raise "main exception"
+          end
+        rescue => e
+          fm = e.full_message(highlight: false)
+          res << fm.include?("main exception") << fm.include?("the cause")
+        end
+        e = RuntimeError.new("new error")
+        def e.detailed_message(**opts) = "DETAILED #{opts[:foo]}"
+        # The first line's location is caller-derived (file paths differ
+        # between the two harnesses), so compare only the tail.
+        res << e.full_message(highlight: false, foo: 1).lines.first.end_with?(": DETAILED 1\n")
+        res << RuntimeError.new("x\ny").detailed_message(highlight: true)
+        res
+        "#,
+    );
+}
+
+#[test]
+fn exception_inspect_and_nil_message() {
+    run_tests(&[
+        r#"RuntimeError.new("oops").inspect"#,
+        r#"RuntimeError.new(nil).message"#,
+        r#"RuntimeError.new(nil).inspect"#,
+        r#"(o = Object.new; def o.to_s; "custom"; end; RuntimeError.new(o).message)"#,
+    ]);
+}
+
+#[test]
+fn local_jump_error_metadata() {
+    run_test_once(
+        r#"
+        def m
+          proc { return 42 }
+        end
+        begin
+          m.call
+        rescue LocalJumpError => e
+          [e.class, e.exit_value, e.reason]
+        end
+        "#,
+    );
+}
+
+#[test]
+fn stop_iteration_result() {
+    run_test_once(
+        r#"
+        o = Object.new
+        def o.each
+          yield :a
+          yield :b
+          :method_returned
+        end
+        e = o.to_enum
+        e.next; e.next
+        begin
+          e.next
+        rescue StopIteration => x
+          [x.class, x.result]
+        end
+        "#,
+    );
+}
+
+#[test]
+fn uncaught_throw_error_tag() {
+    run_test_once(
+        r#"
+        begin
+          throw :abc
+        rescue UncaughtThrowError => e
+          [e.class, e.tag, e.message]
+        end
+        "#,
+    );
+}
+
+#[test]
+fn syntax_error_path() {
+    run_tests(&[
+        r#"(begin; eval("1+", binding, "speccing.rb"); rescue SyntaxError => e; e.path; end)"#,
+        r#"SyntaxError.new.path"#,
+    ]);
+}
+
+#[test]
+fn name_error_and_no_method_error_constructors() {
+    run_tests(&[
+        r#"(e = NameError.new("msg", :sym, receiver: :recv); [e.message, e.name, e.receiver])"#,
+        r#"(e = NoMethodError.new("msg", :m, [1, 2], receiver: :r); [e.message, e.name, e.args, e.receiver])"#,
+        r#"NoMethodError.new("msg").args"#,
+    ]);
+}
+
+#[test]
+fn no_method_error_receiver_descriptions() {
+    run_tests(&[
+        r#"(begin; nil.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(begin; true.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(begin; 3.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(module SpecMod; end; begin; SpecMod.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(SpecKlass = Class.new; begin; SpecKlass.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(class SpecPriv; private def p2; end; end; begin; SpecPriv.new.p2; rescue NoMethodError => e; e.message; end)"#,
+    ]);
+}
+
+#[test]
+fn system_call_error_construction() {
+    run_tests(&[
+        r#"SystemCallError.new(Errno::EINVAL::Errno).class"#,
+        r#"SystemCallError.new(Errno::EINVAL::Errno).message"#,
+        r#"SystemCallError.new("custom message", Errno::EINVAL::Errno).message"#,
+        r#"SystemCallError.new("custom message", Errno::EINVAL::Errno, "location").message"#,
+        r#"(e = SystemCallError.new(99999); [e.class, e.message, e.errno])"#,
+        r#"SystemCallError.new(nil, Errno::EINVAL::Errno).message"#,
+        r#"SystemCallError.new("a message").message"#,
+        r#"SystemCallError.new("foo", 2.9).errno"#,
+        r#"(begin; SystemCallError.new(:foo, 1); rescue TypeError => e; e.message; end)"#,
+        r#"(begin; SystemCallError.new("m", "x"); rescue TypeError => e; e.message; end)"#,
+        r#"(begin; SystemCallError.new("m", Complex(1, 2)); rescue RangeError => e; e.message; end)"#,
+        r#"Errno::ENOENT.new.message"#,
+        r#"Errno::ENOENT.new("custom message", "location").message"#,
+        r#"Errno::EINVAL.new.errno"#,
+        r#"(SubEnoent = Class.new(Errno::ENOENT); SubEnoent.new("custom").message)"#,
+        r#"SystemCallError.instance_method(:initialize).arity"#,
+    ]);
+}
+
+#[test]
+fn signal_exception_and_interrupt() {
+    run_tests(&[
+        r#"(e = SignalException.new(:TERM); [e.signo, e.signm, e.message])"#,
+        r#"(e = SignalException.new("SIGTERM"); [e.signo, e.signm])"#,
+        r#"(e = SignalException.new(15); [e.signo, e.signm])"#,
+        r#"(e = Interrupt.new; [e.signo, e.message])"#,
+        r#"(begin; SignalException.new(:NOSUCH); rescue ArgumentError => e; :err; end)"#,
+        r#"ClosedQueueError.superclass"#,
+    ]);
+}


### PR DESCRIPTION
## Summary

Continues the ruby/spec compliance work from #891, targeting the **core/exception** category (CRuby 4.0.2 reference). Excluding the four spec files that `Process.kill` the runner itself (signal delivery as rescuable exceptions is a separate design question — see `doc/signal_handling.md`), the category goes from **50 failures + 40 errors → 27 failures + 1 error** (225 examples).

## Changes

### `Exception#full_message` / `#detailed_message` / `#inspect` (startup.rb)
- `full_message` now implements CRuby's full semantics: `:highlight` escape sequences (per-line bolding of multi-line messages), `:order` `:top`/`:bottom` with the `Traceback (most recent call last):` header, the exception **cause chain**, forwarding of all keyword arguments to `#detailed_message` (with `:highlight` resolved to its default, without `:order`), `#to_str` coercion of its return value, class-name fallback when `#detailed_message` is missing/returns nil, and a `caller` fallback when the exception has no backtrace. `Exception.to_tty?` added.
- `detailed_message` bolds every line of a multi-line message under `:highlight`.
- `Exception#inspect` goes through `#to_s` (`#<Class: to_s>`, or the class name when empty).
- `Exception.new(nil)` treats nil like no message; a non-String message is stringified via its `#to_s`.

### Jump/throw metadata (`MonorubyErr` payload)
`MonorubyErr` gains a kind-specific payload that materializes as hidden ivars on the exception object:
- `LocalJumpError#exit_value` / `#reason` (from the escaping `return`'s value),
- `StopIteration#result` (the iterated method's return value, wired from the enumerator's terminal value),
- `SyntaxError#path` (from the first trace frame; nil when constructed directly),
- `UncaughtThrowError#tag`.

### Constructors
- `NameError.new` accepts the `receiver:` keyword; `NoMethodError.new(msg, name, args, receiver:)` plus `NoMethodError#args`.
- `SystemCallError.new(errno)` constructs the matching `Errno::*` class (unknown errno → plain `SystemCallError` with `Unknown error N`); `(msg, errno[, location])` form with `@ location` decoration; `SystemCallError#errno`; CRuby's argument coercion rules (nil message/errno treated as absent, TypeError for non-String message / non-Integer errno, Complex handling with RangeError). The hand-written per-class `Errno::E*` initializers are replaced by one generic `(msg, location)` constructor; subclasses inherit their parent's strerror text.
- `SignalException.new(signo | :TERM | "SIGTERM"[, msg])` with `#signo` / `#signm`; `Interrupt.new` defaults to message `"Interrupt"` with SIGINT's signo. `ClosedQueueError` added (< StopIteration).
- NoMethodError receiver rendering resolves names assigned via constant assignment (`MyClass = Class.new`).

## Remaining (out of scope here)
- Backtrace second-element/format details and backtrace array identity (7 specs) — backtrace representation work.
- `NameError#name`/`#receiver` population from ivar/cvar lookup sites (10 specs).
- Signal-delivery-as-exception (`Process.kill` to self) — design decision documented in `doc/signal_handling.md`.

## Testing
- ruby/spec core/exception (minus kill-based files): 90 → 28 failures+errors.
- ruby/spec command_line: still 0 failures (release-equivalent behavior unchanged).
- `cargo test --lib --tests`: all suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_