### PR TITLE
NameError/NoMethodError metadata at raise sites; SystemExit exit status

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -22,7 +22,7 @@ mod gc;
 mod hash;
 mod io;
 mod json;
-mod kernel;
+pub(crate) mod kernel;
 mod main_object;
 mod marshal;
 mod match_data;

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -164,11 +164,12 @@ fn exc_receiver(
     _: BytecodePtr,
 ) -> Result<Value> {
     let self_val = lfp.self_val();
-    let v = globals
-        .store
-        .get_ivar(self_val, IdentId::get_id("/receiver"))
-        .unwrap_or_default();
-    Ok(v)
+    // CRuby raises ArgumentError when the NameError carries no receiver
+    // (e.g. `NameError.new.receiver`), rather than returning nil.
+    match globals.store.get_ivar(self_val, IdentId::get_id("/receiver")) {
+        Some(v) => Ok(v),
+        None => Err(MonorubyErr::argumenterr("no receiver is available")),
+    }
 }
 
 /// `UncaughtThrowError#tag` — the tag object of the uncaught `throw`.

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -925,6 +925,29 @@ fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) ->
 /// - fail(error_type, message = nil, [NOT SUPPORTED] backtrace = caller(0), [NOT SUPPORTED] cause: $!) -> ()
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/fail.html]
+/// A `SystemExit` (or subclass) exception object carries its exit code
+/// in the `/status` ivar, but `MonorubyErrKind::SystemExit` is baked to
+/// 0 at construction (`from_class_id`). When such an object is raised,
+/// sync the kind's status from the ivar so the process exits with the
+/// requested code (`raise SystemExit.new(7)` → exit 7).
+fn fix_system_exit_status(globals: &mut Globals, err: &mut MonorubyErr, ex: Value) {
+    // Both `SystemExit` itself (kind already `SystemExit`) and any user
+    // subclass (kind `Other`, but a SystemExit descendant) exit the
+    // process silently with the requested code.
+    let is_system_exit = matches!(err.kind, MonorubyErrKind::SystemExit(_)) || {
+        let se = globals.store[SYSTEM_EXIT_ERROR_CLASS].get_module();
+        se.is_ancestor_of(globals.store[ex.class()].get_module())
+    };
+    if is_system_exit {
+        let status = globals
+            .store
+            .get_ivar(ex, IdentId::get_id("/status"))
+            .and_then(|v| v.try_fixnum())
+            .unwrap_or(0);
+        err.kind = MonorubyErrKind::SystemExit(status as u8);
+    }
+}
+
 #[monoruby_builtin]
 fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // `cause:` kwarg is at slot 3 (positional_max=3 for the shared
@@ -940,13 +963,16 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         }
         let ex = vm.errinfo();
         if let Some(inner) = ex.is_exception() {
-            return Err(MonorubyErr::new_from_exception(inner).with_original(ex));
+            let mut err = MonorubyErr::new_from_exception(inner);
+            fix_system_exit_status(globals, &mut err, ex);
+            return Err(err.with_original(ex));
         } else {
             return Err(MonorubyErr::runtimeerr(""));
         }
     }
     if let Some(ex) = lfp.arg(0).is_exception() {
         let mut err = MonorubyErr::new_from_exception(ex);
+        fix_system_exit_status(globals, &mut err, lfp.arg(0));
         if let Some(arg1) = lfp.try_arg(1) {
             if arg1.try_hash_ty().is_none() {
                 // A message override makes CRuby return a *new* exception
@@ -970,7 +996,9 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             }
             let ex =
                 vm.invoke_method_inner(globals, IdentId::NEW, klass.as_val(), &args, None, None)?;
-            let err = MonorubyErr::new_from_exception(ex.is_exception().unwrap()).with_original(ex);
+            let mut err = MonorubyErr::new_from_exception(ex.is_exception().unwrap());
+            fix_system_exit_status(globals, &mut err, ex);
+            let err = err.with_original(ex);
             return Err(apply_cause(globals, err, Some(ex), cause_kwarg)?);
         }
     } else if let Some(message) = lfp.arg(0).is_rstring() {
@@ -4396,7 +4424,32 @@ fn is_valid_ivar_name(s: &str) -> bool {
 /// semantics: Symbol/String are used directly, anything else is
 /// coerced via `#to_str` (TypeError otherwise), and the resulting
 /// name must be a valid instance-variable name (NameError otherwise).
-fn ivar_name_id(vm: &mut Executor, globals: &mut Globals, arg: Value) -> Result<IdentId> {
+/// Build a `NameError` for the `instance_variable_*` / `class_variable_*`
+/// reflection methods, carrying `name_value` verbatim as `#name` (CRuby
+/// preserves the exact argument object, which the spec checks with
+/// `equal?`) and `receiver` as `#receiver`. The exception object is
+/// pre-materialized and attached as the error's `original` so those
+/// ivars survive being caught.
+pub(crate) fn name_error_reflection(
+    globals: &mut Globals,
+    msg: String,
+    name_value: Value,
+    receiver: Value,
+) -> MonorubyErr {
+    let exc = Value::new_exception_from(msg.clone(), NAME_ERROR_CLASS);
+    let _ = globals.store.set_ivar(exc, IdentId::_NAME, name_value);
+    let _ = globals
+        .store
+        .set_ivar(exc, IdentId::get_id("/receiver"), receiver);
+    MonorubyErr::nameerr(msg).with_original(exc)
+}
+
+fn ivar_name_id(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    receiver: Value,
+    arg: Value,
+) -> Result<IdentId> {
     let name = if let Some(sym) = arg.try_symbol() {
         sym.get_name().to_string()
     } else if let Some(s) = arg.is_str() {
@@ -4411,9 +4464,16 @@ fn ivar_name_id(vm: &mut Executor, globals: &mut Globals, arg: Value) -> Result<
         return Err(MonorubyErr::is_not_symbol_nor_string(&globals.store, arg));
     };
     if !is_valid_ivar_name(&name) {
-        return Err(MonorubyErr::nameerr(format!(
-            "'{name}' is not allowed as an instance variable name"
-        )));
+        // CRuby surfaces the given name and the receiver on this
+        // NameError (`#name` / `#receiver`); `#name` is the *exact*
+        // argument object (a String/Symbol), which the spec checks with
+        // `equal?`, so carry the original `arg` value.
+        return Err(name_error_reflection(
+            globals,
+            format!("'{name}' is not allowed as an instance variable name"),
+            arg,
+            receiver,
+        ));
     }
     Ok(IdentId::get_id(&name))
 }
@@ -4431,7 +4491,7 @@ fn iv_defined(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let id = ivar_name_id(vm, globals, lfp.arg(0))?;
+    let id = ivar_name_id(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let b = globals.store.get_ivar(lfp.self_val(), id).is_some();
     Ok(Value::bool(b))
 }
@@ -4444,7 +4504,7 @@ fn iv_defined(
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_set.html]
 #[monoruby_builtin]
 fn iv_set(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = ivar_name_id(vm, globals, lfp.arg(0))?;
+    let id = ivar_name_id(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let val = lfp.arg(1);
     globals.store.set_ivar(lfp.self_val(), id, val)?;
     Ok(val)
@@ -4458,7 +4518,7 @@ fn iv_set(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/instance_variable_get.html]
 #[monoruby_builtin]
 fn iv_get(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = ivar_name_id(vm, globals, lfp.arg(0))?;
+    let id = ivar_name_id(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let v = globals
         .store
         .get_ivar(lfp.self_val(), id)
@@ -4490,7 +4550,7 @@ fn iv(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/remove_instance_variable.html]
 #[monoruby_builtin]
 fn iv_remove(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let id = ivar_name_id(vm, globals, lfp.arg(0))?;
+    let id = ivar_name_id(vm, globals, lfp.self_val(), lfp.arg(0))?;
     match globals.store.remove_ivar(lfp.self_val(), id) {
         Some(val) => Ok(val),
         None => Err(MonorubyErr::nameerr(format!(

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -2525,7 +2525,7 @@ fn class_variable_set(
     let self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
     let class_id = self_val.as_class_id();
-    let name = coerce_to_class_var_name(vm, globals, lfp.arg(0))?;
+    let name = coerce_to_class_var_name(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let val = lfp.arg(1);
     // A class variable is shared with ancestors: if a superclass already
     // defines it, update *that* definition instead of shadowing a fresh copy
@@ -2556,7 +2556,7 @@ fn class_variable_get(
     _: BytecodePtr,
 ) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
-    let name = coerce_to_class_var_name(vm, globals, lfp.arg(0))?;
+    let name = coerce_to_class_var_name(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let module = globals.store[class_id].get_module();
     globals.get_class_variable(module, name).map(|(_, v)| v)
 }
@@ -2575,7 +2575,7 @@ fn class_variable_defined(
     _: BytecodePtr,
 ) -> Result<Value> {
     let class_id = lfp.self_val().as_class_id();
-    let name = coerce_to_class_var_name(vm, globals, lfp.arg(0))?;
+    let name = coerce_to_class_var_name(vm, globals, lfp.self_val(), lfp.arg(0))?;
     let module = globals.store[class_id].get_module();
     Ok(Value::bool(globals.get_class_variable(module, name).is_ok()))
 }
@@ -2587,14 +2587,20 @@ fn class_variable_defined(
 fn coerce_to_class_var_name(
     vm: &mut Executor,
     globals: &mut Globals,
+    receiver: Value,
     name_arg: Value,
 ) -> Result<IdentId> {
     let id = name_arg.coerce_to_symbol_or_string(vm, globals)?;
     let s = id.get_name();
     if !s.starts_with("@@") || s.len() <= 2 {
-        return Err(MonorubyErr::nameerr(format!(
-            "`{s}' is not allowed as a class variable name"
-        )));
+        // CRuby carries the given name (the exact argument object, so the
+        // spec's `equal?` holds) and the receiver on this NameError.
+        return Err(crate::builtins::kernel::name_error_reflection(
+            globals,
+            format!("`{s}' is not allowed as a class variable name"),
+            name_arg,
+            receiver,
+        ));
     }
     Ok(id)
 }

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -161,12 +161,15 @@ fn bo_method_missing(
     use crate::executor::MethodMissingStyle;
     match vm.take_method_missing_style() {
         MethodMissingStyle::VCall => {
-            return Err(MonorubyErr::nameerr_with_name(
+            // CRuby 4.0: `undefined local variable or method 'name' for
+            // <recv>` (single quotes), carrying the receiver on `#receiver`.
+            return Err(MonorubyErr::nameerr_with_name_receiver(
                 format!(
-                    "undefined local variable or method `{name}' for {}",
+                    "undefined local variable or method '{name}' for {}",
                     recv.to_s(&globals.store)
                 ),
                 name,
+                recv,
             ));
         }
         MethodMissingStyle::Super => {
@@ -194,7 +197,38 @@ fn bo_method_missing(
         },
         _ => MonorubyErr::method_not_found(&globals.store, name, recv),
     };
+    // A genuine NoMethodError (not a visibility NameError) carries the
+    // call arguments on `#args`. `args[0]` is the method name; the rest
+    // are the arguments the missing method was called with.
+    if matches!(err.kind(), MonorubyErrKind::NotMethod { .. }) {
+        let call_args = Value::array_from_iter(args.iter().skip(1).cloned());
+        return Err(no_method_error_with_args(globals, err, call_args));
+    }
     Err(err)
+}
+
+/// Re-materialize a NoMethodError so it also carries `#args`. The
+/// `NotMethod` error's name / receiver are transferred onto a
+/// pre-built exception object (via `take_ex_obj`'s standard path) and
+/// the arguments array is attached as the hidden `/args` ivar.
+fn no_method_error_with_args(globals: &mut Globals, err: MonorubyErr, call_args: Value) -> MonorubyErr {
+    let (name, receiver) = match err.kind() {
+        MonorubyErrKind::NotMethod { name, receiver } => (*name, *receiver),
+        _ => (None, None),
+    };
+    let exc = Value::new_exception_from(err.message().to_string(), NO_METHOD_ERROR_CLASS);
+    if let Some(name) = name {
+        let _ = globals.store.set_ivar(exc, IdentId::_NAME, Value::symbol(name));
+    }
+    if let Some(receiver) = receiver {
+        let _ = globals
+            .store
+            .set_ivar(exc, IdentId::get_id("/receiver"), Value::from_u64(receiver));
+    }
+    let _ = globals
+        .store
+        .set_ivar(exc, IdentId::get_id("/args"), call_args);
+    err.with_original(exc)
 }
 
 ///

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -146,7 +146,10 @@ impl Executor {
     ) -> Result<Value> {
         match self.get_constant(globals, class_id, name)? {
             Some(v) => Ok(v),
-            None => Err(MonorubyErr::uninitialized_constant(name)),
+            None => {
+                let receiver = globals.store[class_id].get_module().as_val();
+                Err(MonorubyErr::uninitialized_constant_in(name, receiver))
+            }
         }
     }
 
@@ -178,6 +181,9 @@ impl Executor {
         mut module: Module,
         name: IdentId,
     ) -> Result<(Value, ClassId)> {
+        // The starting module is the one CRuby reports as
+        // `NameError#receiver`, not whichever ancestor the walk ends on.
+        let receiver = module.as_val();
         loop {
             // Snapshot whether the class has the constant before triggering
             // autoload, since `get_constant` may transition the entry from
@@ -201,7 +207,7 @@ impl Executor {
                 },
             };
         }
-        Err(MonorubyErr::uninitialized_constant(name))
+        Err(MonorubyErr::uninitialized_constant_in(name, receiver))
     }
 
     /// Ancestor-chain lookup for the segment of a **qualified** reference
@@ -272,7 +278,15 @@ impl Executor {
         ) {
             Ok(v) => Ok(v),
             Err(e) if matches!(e.kind, MonorubyErrKind::Name(..)) => {
-                Err(MonorubyErr::nameerr_with_name(e.message, name))
+                // The default `Module#const_missing` raises a bare
+                // NameError; re-attach the name and the receiver (the
+                // module the lookup started on — `Object` for a bare
+                // top-level reference) that CRuby reports.
+                Err(MonorubyErr::nameerr_with_name_receiver(
+                    e.message,
+                    name,
+                    module.as_val(),
+                ))
             }
             Err(e) => Err(e),
         }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -621,13 +621,26 @@ impl MonorubyErr {
     }
 
     pub(crate) fn uninitialized_constant(name: IdentId) -> MonorubyErr {
-        Self::nameerr(format!("uninitialized constant {name}"))
+        Self::nameerr_with_name(format!("uninitialized constant {name}"), name)
     }
 
-    pub(crate) fn uninitialized_cvar(name: IdentId, class_name: String) -> MonorubyErr {
-        Self::nameerr(format!(
-            "uninitialized class variable {name} in {class_name}"
-        ))
+    /// As [`Self::uninitialized_constant`], but also records the module
+    /// the constant was looked up on as `NameError#receiver` (CRuby
+    /// reports the namespace class, or `Object` for a bare reference).
+    pub(crate) fn uninitialized_constant_in(name: IdentId, receiver: Value) -> MonorubyErr {
+        Self::nameerr_with_name_receiver(format!("uninitialized constant {name}"), name, receiver)
+    }
+
+    pub(crate) fn uninitialized_cvar(
+        name: IdentId,
+        class_name: String,
+        receiver: Value,
+    ) -> MonorubyErr {
+        Self::nameerr_with_name_receiver(
+            format!("uninitialized class variable {name} in {class_name}"),
+            name,
+            receiver,
+        )
     }
 
     pub(crate) fn identifier_must_be_constant(name: &str) -> MonorubyErr {

--- a/monoruby/src/globals/store/class/constants.rs
+++ b/monoruby/src/globals/store/class/constants.rs
@@ -577,6 +577,7 @@ impl Globals {
             None => Err(MonorubyErr::uninitialized_cvar(
                 name,
                 parent.id().get_name(&self.store),
+                parent.as_val(),
             )),
         }
     }

--- a/monoruby/tests/name_error_api.rs
+++ b/monoruby/tests/name_error_api.rs
@@ -1,0 +1,83 @@
+//! Differential coverage for `NameError#name` / `#receiver`,
+//! `NoMethodError#args`, and `SystemExit` exit-status propagation added
+//! for ruby/spec's core/exception category. Each snippet runs under both
+//! monoruby and the reference CRuby and the results are compared.
+
+use monoruby::tests::*;
+
+#[test]
+fn name_error_receiver_from_raise_sites() {
+    run_tests(&[
+        // Undefined constant, bare (receiver == Object).
+        r#"(begin; NoSuchConstXyz; rescue NameError => e; [e.name, e.receiver.equal?(Object)]; end)"#,
+        // Undefined constant, namespaced (receiver == the namespace class).
+        r#"(module NsA; class RcA; end; end; begin; NsA::RcA::Nope; rescue NameError => e; [e.name, e.receiver.equal?(NsA::RcA)]; end)"#,
+        // Undefined class variable read in a method (receiver == class).
+        r#"(class CvA; def f; @@nope; end; end; begin; CvA.new.f; rescue NameError => e; [e.name, e.receiver.equal?(CvA)]; end)"#,
+        // Bareword undefined local variable or method (receiver == self).
+        r#"(begin; totally_undefined_thing; rescue NameError => e; [e.name, e.receiver.equal?(self)]; end)"#,
+    ]);
+}
+
+#[test]
+fn name_error_receiver_argument_error_when_absent() {
+    run_test_once(
+        r#"
+        begin
+          NameError.new.receiver
+          :no_raise
+        rescue ArgumentError
+          :arg_error
+        end
+        "#,
+    );
+}
+
+#[test]
+fn name_error_reflection_name_identity() {
+    // CRuby preserves the exact argument object as #name (checked with
+    // equal?) for the reflection methods.
+    run_tests(&[
+        r#"(n = "bad_ivar_name"; begin; Object.new.instance_variable_get(n); rescue NameError => e; [e.name.equal?(n), e.receiver.class]; end)"#,
+        r#"(n = "bad_cvar_name"; begin; Object.class_variable_get(n); rescue NameError => e; [e.name.equal?(n), e.receiver.equal?(Object)]; end)"#,
+    ]);
+}
+
+#[test]
+fn no_method_error_args_and_dup() {
+    run_test_once(
+        r#"
+        receiver = Object.new
+        begin
+          receiver.foo(:one, :two)
+        rescue NoMethodError => e
+          d = e.dup
+          [d.name, d.receiver.equal?(receiver), d.args]
+        end
+        "#,
+    );
+    // No-argument missing call yields an empty args array.
+    run_test_once(
+        r#"
+        begin
+          Object.new.no_such_method
+        rescue NoMethodError => e
+          e.args
+        end
+        "#,
+    );
+}
+
+#[test]
+fn name_error_dup_copies_name_and_receiver() {
+    run_test_once(
+        r#"
+        begin
+          undefined_local_or_method
+        rescue NameError => e
+          d = e.dup
+          [d.name, d.receiver.equal?(self)]
+        end
+        "#,
+    );
+}

--- a/monoruby/tests/system_exit_status.rs
+++ b/monoruby/tests/system_exit_status.rs
@@ -1,0 +1,39 @@
+//! `SystemExit` (and subclasses) propagate their exit code to the
+//! process when raised — a process-boundary behavior, so these spawn the
+//! real binary and inspect the exit status.
+
+use std::process::Command;
+
+fn exit_code(script: &str) -> Option<i32> {
+    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env_remove("RUBYOPT")
+        .args(["-e", script])
+        .output()
+        .expect("spawn monoruby")
+        .status
+        .code()
+}
+
+#[test]
+fn system_exit_new_status() {
+    assert_eq!(exit_code("raise SystemExit.new(7)"), Some(7));
+    assert_eq!(exit_code("raise SystemExit.new(0)"), Some(0));
+    assert_eq!(exit_code("raise SystemExit.new(true)"), Some(0));
+    assert_eq!(exit_code("raise SystemExit.new(false)"), Some(1));
+}
+
+#[test]
+fn system_exit_subclass_status() {
+    assert_eq!(
+        exit_code("class CustomExit < SystemExit; end; raise CustomExit.new(8)"),
+        Some(8)
+    );
+}
+
+#[test]
+fn kernel_exit_and_plain_raise() {
+    assert_eq!(exit_code("exit 3"), Some(3));
+    assert_eq!(exit_code("exit"), Some(0));
+    // A plain RuntimeError still exits 1.
+    assert_eq!(exit_code("raise 'boom'"), Some(1));
+}


### PR DESCRIPTION
## Summary

Continues the ruby/spec compliance work (#891, #893), targeting the remaining **core/exception** failures around `NameError` / `NoMethodError` introspection and `SystemExit` exit-status propagation (CRuby 4.0.2 reference). Excluding the four spec files that `Process.kill` the runner itself, the category goes from **28 → 13 failures**.

## Changes

### `NameError#name` / `#receiver` at the actual raise sites
Previously these were only populated when a NameError was constructed manually (`NameError.new(..., receiver:)`). Now the runtime raise sites carry them:
- **Undefined constant** — `#receiver` is the namespace module the lookup started on (`Object` for a bare reference), threaded through `get_constant_checked`, `const_missing`'s re-wrap, and the superclass walk.
- **Undefined class variable** — `#receiver` is the looked-up class.
- **Bareword** `undefined local variable or method` — `#receiver` is `self`; the message also adopts CRuby 4.0's single-quote form.
- **`instance_variable_get` / `class_variable_get` with an invalid name** — `#name` is the *exact* argument object (the spec checks it with `equal?`, so a pre-materialized exception object carries the original `String`/`Symbol`), and `#receiver` is `self`.
- **`NameError#receiver`** raises `ArgumentError "no receiver is available"` when no receiver was recorded, matching CRuby (instead of returning nil).

### `NoMethodError#args`
Populated from the failed call's arguments at the `method_missing` raise site (empty array for a no-arg call), so `#args` and `Exception#dup` round-trip.

### `SystemExit` exit status
`MonorubyErrKind::SystemExit`'s status was baked to 0 by `from_class_id`, so `raise SystemExit.new(7)` exited 0. Raising a SystemExit-family object now syncs the status from the object's `/status` ivar — `raise SystemExit.new(7)` exits 7, and a user `CustomExit < SystemExit` exits with its own status. Detection covers subclasses via an ancestor check.

## Testing
- ruby/spec core/exception (minus kill-based files): 28 → 13 failures.
- New differential tests: `tests/name_error_api.rs` (5, comparing against CRuby) and `tests/system_exit_status.rs` (3, spawning the binary to assert exit codes).
- `cargo test --lib --tests`: all suites green locally.

## Remaining (out of scope here)
- `Exception#backtrace` second-element/format details and backtrace-array identity (~7 specs) — backtrace representation work.
- `NoMethodError#message` calling the receiver's overridden `#name`/`#inspect` lazily (3 specs) — requires deferring message construction.
- Signal-delivery-as-exception (`Process.kill` to self) — design decision in `doc/signal_handling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_