### PR TITLE
NoMethodError#message renders the receiver via its Ruby-level #name

### DIFF
--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -187,24 +187,80 @@ fn bo_method_missing(
     // CRuby reports these as "private/protected method … called" rather
     // than "undefined method".
     use crate::executor::Visibility;
-    let err = match globals.store.check_method_for_class(recv.class(), name) {
+    // `undefined` marks a genuine missing method (as opposed to a
+    // visibility violation), which alone gets the Ruby-`#name`-based
+    // receiver rendering and the `#args` payload.
+    let (err, undefined) = match globals.store.check_method_for_class(recv.class(), name) {
         Some(entry) if entry.func_id().is_some() => match entry.visibility() {
-            Visibility::Private => MonorubyErr::private_method_called(&globals.store, name, recv),
-            Visibility::Protected => {
-                MonorubyErr::protected_method_called(&globals.store, name, recv)
+            Visibility::Private => {
+                (MonorubyErr::private_method_called(&globals.store, name, recv), false)
             }
-            _ => MonorubyErr::method_not_found(&globals.store, name, recv),
+            Visibility::Protected => (
+                MonorubyErr::protected_method_called(&globals.store, name, recv),
+                false,
+            ),
+            _ => (MonorubyErr::method_not_found(&globals.store, name, recv), true),
         },
-        _ => MonorubyErr::method_not_found(&globals.store, name, recv),
+        _ => (MonorubyErr::method_not_found(&globals.store, name, recv), true),
     };
-    // A genuine NoMethodError (not a visibility NameError) carries the
-    // call arguments on `#args`. `args[0]` is the method name; the rest
-    // are the arguments the missing method was called with.
-    if matches!(err.kind(), MonorubyErrKind::NotMethod { .. }) {
+    // A genuine NoMethodError carries the call arguments on `#args`
+    // (`args[0]` is the method name; the rest are the call arguments)
+    // and renders the receiver via its Ruby-level `#name` — CRuby calls
+    // it, so a class with an overridden `def self.name` shows that name.
+    if undefined {
+        let mut err = err;
+        if let Ok(desc) = nme_receiver_description(vm, globals, recv) {
+            err.set_msg(format!("undefined method '{name}' for {desc}"));
+        }
         let call_args = Value::array_from_iter(args.iter().skip(1).cloned());
         return Err(no_method_error_with_args(globals, err, call_args));
     }
     Err(err)
+}
+
+/// CRuby's receiver rendering for a NoMethodError message, using the
+/// Ruby-level `#name` (never `#inspect`): `class <Name>` / `module
+/// <Name>` for a named class/module (anonymous → its `#<Class:0x…>`
+/// form), the object's own string form for a receiver that has a
+/// singleton class, and `an instance of <Class#name>` otherwise.
+fn nme_receiver_description(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    recv: Value,
+) -> Result<String> {
+    if recv.is_nil() {
+        return Ok("nil".to_string());
+    } else if recv == Value::bool(true) {
+        return Ok("true".to_string());
+    } else if recv == Value::bool(false) {
+        return Ok("false".to_string());
+    }
+    let name_id = IdentId::get_id("name");
+    if let Some(m) = recv.is_class_or_module() {
+        let kind = if m.is_module() { "module" } else { "class" };
+        let name = vm.invoke_method_inner(globals, name_id, recv, &[], None, None)?;
+        let s = match name.is_str() {
+            Some(s) => s.to_string(),
+            None => globals.store.get_class_name(m.id()),
+        };
+        return Ok(format!("{kind} {s}"));
+    }
+    // A receiver with its own singleton class renders as its object form.
+    if globals.store[recv.class()]
+        .get_module()
+        .is_singleton()
+        .is_some()
+    {
+        return Ok(recv.to_s(&globals.store));
+    }
+    let cls = recv.class();
+    let cls_val = globals.store[cls].get_module().as_val();
+    let name = vm.invoke_method_inner(globals, name_id, cls_val, &[], None, None)?;
+    let s = match name.is_str() {
+        Some(s) => s.to_string(),
+        None => globals.store.get_class_name(cls),
+    };
+    Ok(format!("an instance of {s}"))
 }
 
 /// Re-materialize a NoMethodError so it also carries `#args`. The

--- a/monoruby/tests/no_method_error_message.rs
+++ b/monoruby/tests/no_method_error_message.rs
@@ -1,0 +1,53 @@
+//! Differential coverage for `NoMethodError#message`'s receiver
+//! rendering, which calls the receiver's (or its class's) Ruby-level
+//! `#name` — a class with an overridden `def self.name` shows that name.
+//! Each snippet is compared against the reference CRuby.
+
+use monoruby::tests::*;
+
+#[test]
+fn message_uses_ruby_name_for_named_class_and_module() {
+    run_tests(&[
+        r#"(k = Class.new { def self.name; "MyClass"; end }; begin; k.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(m = Module.new { def self.name; "MyModule"; end }; begin; m.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(k = Class.new { def self.name; "MyClass"; end }; begin; k.new.bar; rescue NoMethodError => e; e.message; end)"#,
+    ]);
+}
+
+#[test]
+fn message_receiver_special_forms() {
+    run_tests(&[
+        r#"(begin; nil.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(begin; true.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(begin; false.foo; rescue NoMethodError => e; e.message; end)"#,
+        r#"(begin; 3.foo; rescue NoMethodError => e; e.message; end)"#,
+    ]);
+}
+
+#[test]
+fn message_does_not_call_inspect() {
+    // Building the message must go through #name, never the receiver's
+    // #inspect.
+    run_test_once(
+        r#"
+        called = false
+        klass = Class.new do
+          define_method(:inspect) { called = true; "X" }
+        end
+        begin
+          klass.new.bar
+        rescue NoMethodError => e
+          e.message
+        end
+        called
+        "#,
+    );
+}
+
+#[test]
+fn private_and_protected_messages_unchanged() {
+    run_tests(&[
+        r#"(class SpecPrivC; private def priv; end; end; begin; SpecPrivC.new.priv; rescue NoMethodError => e; e.message; end)"#,
+        r#"(class SpecProtC; protected def prot; end; end; begin; SpecProtC.new.prot; rescue NoMethodError => e; e.message; end)"#,
+    ]);
+}


### PR DESCRIPTION
## Summary

Continues the ruby/spec compliance work (#891, #893, #894), closing the `NoMethodError#message` receiver-rendering gap in the **core/exception** category (CRuby 4.0.2 reference). Excluding the four spec files that `Process.kill` the runner itself, the category goes from **13 → 10 failures**.

## Change

CRuby builds a `NoMethodError` message by calling the receiver's — or, for an ordinary object, its class's — Ruby-level `#name`. So a class/module with an overridden `def self.name` shows that name rather than its anonymous `#<Class:0x…>` form. monoruby baked the message from the *internal* class name at raise time, which is wrong for that case.

The message is now rebuilt in the default `method_missing` handler (which has an `Executor`) for genuine `undefined method` errors:

- **class / module receiver** → `class <#name>` / `module <#name>` (anonymous → the `#<Class:0x…>` form);
- **receiver with its own singleton class** → its object string form (`for #<Klass:0x…>`);
- **ordinary object** → `an instance of <class #name>`.

The rendering goes through `#name` only, never `#inspect` (a spec asserts `#inspect` is not called during message building). Visibility errors (`private`/`protected method … called`) keep their own message and are excluded via an `undefined` flag, so only real missing-method errors are re-rendered (and carry `#args`).

## Testing
- ruby/spec core/exception (minus kill-based files): 13 → 10 failures.
- New differential tests: `tests/no_method_error_message.rs` (4, comparing against CRuby — named class/module/instance, nil/true/false/Integer receivers, the no-`#inspect` guarantee, and unchanged private/protected messages).
- `cargo test --lib --tests`: green (a couple of transient `LoadError`/timeout flakes from concurrent `build.rs` reinstalls during local iteration, not from this change).

## Remaining (out of scope here)
- `Exception#backtrace` second-element/format details and backtrace-array identity (~7 specs) and top-level cause printing (2) — both need backtrace-representation work.
- Signal-delivery-as-exception (`Process.kill` to self) — design decision in `doc/signal_handling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_