### PR TITLE
Interpolated regexp modifiers: options via a leading operand, not (?imx)

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -2231,4 +2231,26 @@ mod tests {
               .map { |r| r.source.encoding.to_s }"#,
         );
     }
+
+    #[test]
+    fn regexp_interpolation_encoding_modifiers() {
+        // An interpolated regexp with an `n`/`u`/`e`/`s` encoding modifier
+        // must not feed the letter into an Onigmo group option (`(?n)` —
+        // which used to raise "undefined group option"); the modifier fixes
+        // the declared encoding while the interpolated bytes form the source.
+        run_test(
+            r#"x = "a"
+               [ /#{x}/n, /#{x}/u, /#{x}/e, /#{x}/s, /#{x}/ ]
+                 .map { |r| r.encoding.to_s }"#,
+        );
+        // `i`/`m`/`x` still lower to an inline `(?imx)` group and the
+        // interpolated fragments still form the source verbatim.
+        run_test(
+            r#"x = "b"
+               r = /a#{x}c/imx
+               [r.source, (r =~ "xABCx"), r.match("aBc")[0]]"#,
+        );
+        // A modifier combined with `i`, and with a leading empty fragment.
+        run_test(r#"x = "Z"; (/#{x}/i =~ "qzq")"#);
+    }
 }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1945,11 +1945,45 @@ impl<'a> BytecodeGen<'a> {
     fn gen_regexp(&mut self, ret: BcReg, nodes: Vec<Node>, option: String, loc: Loc) -> Result<()> {
         let mut len = nodes.len();
         let arg = self.sp();
-        if !option.is_empty() {
-            let r = self.push().into();
-            self.emit_literal(r, Value::string(format!("(?{option})")));
-            len += 1;
+        // The interpolated-regexp source is assembled at run time by
+        // `runtime::concatenate_regexp`. Decode the literal-syntax modifier
+        // letters into the same option word `const_regexp` builds, and pass
+        // it as a leading Fixnum operand rather than as an inline `(?imx)`
+        // source prefix. Two reasons:
+        //   - `n`/`u`/`e`/`s` are encoding selectors, *not* valid Onigmo
+        //     group options — `(?n)` makes Onigmo raise "undefined group
+        //     option". They must set the regexp's `KCODE_*` / `NOENCODING`
+        //     bits instead.
+        //   - Even the valid `i`/`m`/`x` must not sit in the source: CRuby's
+        //     `Regexp#source` for `/a#{x}/im` is `"a…"`, not `"(?im-x:a…)"`.
+        //     Passing them as real Onigmo option bits keeps `#source` clean.
+        // `concatenate_regexp` (the sole consumer of `ConcatRegexp`) peels
+        // this operand off and hands the bits to the regexp builder.
+        let mut opt: i64 = 0;
+        if option.contains('i') {
+            opt |= onigmo_regex::ONIG_OPTION_IGNORECASE as i64;
         }
+        if option.contains('x') {
+            opt |= onigmo_regex::ONIG_OPTION_EXTEND as i64;
+        }
+        if option.contains('m') {
+            opt |= onigmo_regex::ONIG_OPTION_MULTILINE as i64;
+        }
+        if option.contains('n') {
+            opt |= RegexpInner::NOENCODING as i64;
+        } else if option.contains('u') {
+            opt |= RegexpInner::KCODE_UTF8 as i64;
+        } else if option.contains('e') {
+            opt |= RegexpInner::KCODE_EUCJP as i64;
+        } else if option.contains('s') {
+            opt |= RegexpInner::KCODE_SJIS as i64;
+        }
+        // Always the first operand (even when 0) so the run-time layout is
+        // uniform: operand 0 is the option word, the rest are source
+        // fragments.
+        let r = self.push().into();
+        self.emit_literal(r, Value::integer(opt));
+        len += 1;
         for expr in nodes {
             self.push_expr(expr)?;
         }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -748,6 +748,17 @@ pub(super) extern "C" fn concatenate_regexp(
     len: usize,
 ) -> Option<Value> {
     use crate::value::rvalue::Encoding;
+    // Operand 0 is the literal-syntax option word (Onigmo `i`/`m`/`x` bits
+    // plus the `NOENCODING` / `KCODE_*` encoding-selector bits for
+    // `n`/`u`/`e`/`s`), emitted by `gen_regexp` as a Fixnum (0 = none).
+    // `gen_regexp` is the sole producer of `ConcatRegexp`, so this leading
+    // operand is always present. Operands are read *downward* from `arg`
+    // (`concatenate_string_inner` walks `arg.sub(i)`), so operand 0 is at
+    // `*arg` and the source fragments start one slot below.
+    // SAFETY: `arg` points at operand 0 of `len` (>= 1) operand `Value`s.
+    let option = unsafe { (*arg).try_fixnum().unwrap_or(0) } as u32;
+    let arg = unsafe { arg.sub(1) };
+    let len = len - 1;
     // Build the interpolated source as a String first, so each operand's
     // bytes and encoding combine under the same rules as `"#{}"` — a
     // non-ASCII embedded String (e.g. EUC-JP) then upgrades the regexp's
@@ -766,16 +777,34 @@ pub(super) extern "C" fn concatenate_regexp(
     // best-effort UTF-8 view while the raw bytes + encoding drive
     // `Regexp#source` / `#encoding`.
     let reg_str = String::from_utf8_lossy(&bytes).into_owned();
-    let onig_enc = if enc == Encoding::Ascii8 {
+    // Split the encoding-selector bits out of the option word into the
+    // KCODE the resolver reads (mirroring `const_regexp`); the Onigmo
+    // `i`/`m`/`x` bits stay in `option` and `with_option_kcode_source`
+    // strips the Ruby-only bits before handing the mask to Onigmo. With an
+    // encoding modifier the declared encoding is fixed by it regardless of
+    // the interpolated content's encoding; without one it is derived from
+    // that content as before.
+    let kcode = if option & RegexpInner::KCODE_MASK != 0 {
+        Some(option & RegexpInner::KCODE_MASK)
+    } else {
+        None
+    };
+    let onig_enc = if option & RegexpInner::NOENCODING != 0 {
+        // `/n`: ASCII / BINARY matching.
+        onigmo_regex::OnigmoEncoding::ASCII
+    } else if kcode.is_some() {
+        // `/u` `/e` `/s`: match against the best-effort UTF-8 view.
+        onigmo_regex::OnigmoEncoding::UTF8
+    } else if enc == Encoding::Ascii8 {
         onigmo_regex::OnigmoEncoding::ASCII
     } else {
         onigmo_regex::OnigmoEncoding::UTF8
     };
     let inner = match RegexpInner::with_option_kcode_source(
         reg_str,
-        0,
+        option,
         onig_enc,
-        None,
+        kcode,
         Some(enc),
         Some(bytes),
     ) {


### PR DESCRIPTION
## Summary

Fixes the largest remaining cluster of ruby/spec `language/regexp` failures: interpolated regexps with an encoding modifier (`/#{x}/n`, `/u`, `/e`, `/s`) crashed, and even valid `i`/`m`/`x` modifiers polluted `Regexp#source`.

## The bug

An interpolated regexp (`/#{expr}/flags`) is assembled at run time by `runtime::concatenate_regexp`. The compiler (`gen_regexp`) was carrying the literal-syntax modifier letters into that assembled source as a `(?imxn…)` inline prefix. Two problems:

1. **`n`/`u`/`e`/`s` are encoding selectors, not Onigmo group options.** `/#{x}/n` produced the source `(?n)…`, and Onigmo raised `undefined group option` — aborting *every* interpolated regexp with an encoding modifier (11 ruby/spec language errors: the `/n /e /s` interpolation cases and "allows escape sequences in interpolated regexps").
2. **Even the valid `i`/`m`/`x` leaked into `Regexp#source`.** `/a#{x}/im.source` reported `"(?im-x:a…)"` where CRuby reports `"a…"`.

## The fix

`gen_regexp` now decodes the modifier letters into the same option word `const_regexp` already builds — Onigmo `i`/`m`/`x` bits plus the `NOENCODING` / `KCODE_*` encoding bits for `n`/`u`/`e`/`s` — and emits it as a **leading `Fixnum` operand** of the `ConcatRegexp` instruction. `gen_regexp` is the sole producer and `concatenate_regexp` the sole consumer of that instruction, so the operand layout is private and needs no bytecode/JIT signature change. `concatenate_regexp` peels the operand off (operands are read downward from the base slot), applies the Onigmo options for real, and fixes the declared encoding from the KCODE bits (mirroring `const_regexp`). No inline prefix is emitted, so `#source` stays verbatim.

## Verification

- ruby/spec `language`: **38 → 27** failing (−11).
- The two remaining `/s`-interpolation cases now fail identically to the pre-existing *non-interpolated* `/s` match — a Shift_JIS byte-offset limitation through the lossy-UTF-8 matcher view (capture-encoding, a separate workstream), not the former crash.
- Full `cargo test` green; new regression test `regexp_interpolation_encoding_modifiers` covers the four encoding modifiers' declared encoding, `#source` cleanliness under `imx`, and matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_