### PR TITLE
Numbered capture variables beyond $9, and too-big-index handling

### DIFF
--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -77,6 +77,27 @@ pub struct GvarTable {
 /// giving up.
 const ALIAS_MAX_DEPTH: usize = 16;
 
+/// Resolve a numbered back-reference name (`$1`, `$10`, `$4294967296`, …)
+/// against the current match. `$1`..`$9` are pre-registered as hooks, so
+/// this is reached for `$10` and above (and as the shared logic behind the
+/// low ones). Returns `None` when `name` isn't a `$<digits>` form or the
+/// index is out of range / too large to be a real capture (CRuby then
+/// reads it as `nil`).
+fn numbered_backref(vm: &mut Executor, name: IdentId) -> Option<Value> {
+    let s = name.get_name();
+    let rest = s.strip_prefix('$')?;
+    // Must be a non-empty run of ASCII digits — punctuation specials
+    // (`$&`, `$~`, …) and named globals are handled elsewhere.
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    // An index too large for a capture slot is always `nil` (CRuby warns
+    // at parse time and yields nil). `parse` overflowing `i64` counts as
+    // such a too-big index.
+    let n = rest.parse::<i64>().ok()?;
+    vm.get_special_matches(n)
+}
+
 impl GvarTable {
     pub fn new() -> Self {
         Self::default()
@@ -146,7 +167,14 @@ impl GvarTable {
     /// (which may itself be `nil`, e.g. `$~` after no match); `None` means
     /// the variable does not exist.
     fn lookup(vm: &mut Executor, globals: &mut Globals, name: IdentId) -> Option<Value> {
-        let id = globals.gvars.index.get(&name).copied()?;
+        let id = match globals.gvars.index.get(&name).copied() {
+            Some(id) => id,
+            // `$10`, `$11`, … — numbered capture references beyond the
+            // pre-registered `$1`..`$9`. They can be arbitrarily large, so
+            // they aren't pre-registered; resolve them against the current
+            // match here (mirroring the `$1`..`$9` hook's getter).
+            None => return numbered_backref(vm, name),
+        };
         let id = globals.gvars.resolve(id);
         match &globals.gvars.entries[id.index()] {
             GvarEntry::Simple(v) => Some(*v),

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1757,8 +1757,35 @@ impl<'pr> Lowerer<'pr> {
                 // global variables ($1 lookups eventually go through
                 // the regex match data); match that.
                 let n = node.as_numbered_reference_read_node().unwrap();
+                // `number()` is a `u32`, so a too-big reference like
+                // `$4294967296` wraps to 0 — which would masquerade as
+                // `$0` (the program name). A real `$0` is never a
+                // *numbered* reference, so `number() == 0` can only be
+                // that overflow; recover the true digits from the source
+                // so the name resolves to `nil` (an out-of-range capture)
+                // instead of the program name. prism has already emitted
+                // the "too big for a number variable" warning.
+                let name = if n.number() == 0 {
+                    let raw = node.location().as_slice();
+                    let name = String::from_utf8_lossy(raw).into_owned();
+                    // CRuby's parser warns (default level) that the
+                    // reference is unusable and always nil.
+                    let line = source_line_for_offset(self.source, node.location().start_offset())
+                        as i64
+                        + self.line_offset;
+                    self.warnings.push((
+                        format!(
+                            "{}:{}: warning: '{}' is too big for a number variable, always nil",
+                            self.path, line, name
+                        ),
+                        false,
+                    ));
+                    name
+                } else {
+                    format!("${}", n.number())
+                };
                 Node {
-                    kind: NodeKind::GlobalVar(format!("${}", n.number())),
+                    kind: NodeKind::GlobalVar(name),
                     loc,
                 }
             }

--- a/monoruby/tests/predefined_gvar.rs
+++ b/monoruby/tests/predefined_gvar.rs
@@ -132,6 +132,26 @@ fn match_data_assignment() {
 }
 
 #[test]
+fn numbered_capture_variables() {
+    // `$10`..`$N` beyond the pre-registered `$1`..`$9` resolve against
+    // the current match; an out-of-range or too-big index reads as nil
+    // (and does not masquerade as `$0`, the program name).
+    run_test_once(
+        r#"
+        res = []
+        "1234567890" =~ /(1)(2)(3)(4)(5)(6)(7)(8)(9)(0)/
+        res << [$1, $9, $10, $11]
+        res << [defined?($10), defined?($11)]
+        "abc" =~ /(a)(b)(c)/
+        res << $100
+        # A too-big numbered reference is always nil (never the program name).
+        res << eval("$4294967296")
+        res
+        "#,
+    );
+}
+
+#[test]
 fn errinfo_backtrace_gvar() {
     run_test_once(
         r#"


### PR DESCRIPTION
## Summary

Two `language/regexp/back-references` fixes for numbered capture variables.

## `$10` and beyond

`$10`, `$11`, … (numbered back-references past `$1`–`$9`) read as `nil`. Only `$1`–`$9` were pre-registered as hooked globals, so higher-numbered names fell through to the unregistered-global path and returned `nil`. `GvarTable::lookup` now routes any unregistered `$<digits>` name to the current match (`numbered_backref`), so `$10` returns the 10th capture and an out-of-range index reads as `nil` — matching the existing `$1`–`$9` getter.

## `$4294967296` (too-big index)

A too-big reference also mis-resolved: prism's `NumberedReferenceReadNode::number()` is a `u32`, so `$4294967296` (2³²) wrapped to `0` and masqueraded as `$0` — the **program name**. A genuine `$0` is never a *numbered* reference, so `number() == 0` can only be that overflow. The parser now recovers the true digits from the source span (which resolves to `nil`, an out-of-range capture) and emits CRuby's default-level parse warning `'$4294967296' is too big for a number variable, always nil`.

## Verification

- ruby/spec `language`: **22 → 20** failing — the two `back-references` numbered examples ("saves captures in numbered `$[1-N]` variables" and "returns nil for numbered variable with too large index"). The remaining `back-references` failure is the cross-thread capture case (monoruby's single-threaded `Thread` surface — unrelated).
- `$0` and the `$1`–`$9` fast path are unaffected.
- Full `cargo test` green; new regression test `numbered_capture_variables` covers `$10`/`$11`, `defined?`, out-of-range `$100`, and the `$4294967296` overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_