### PR TITLE
Regexp: last encoding specifier wins; uninitialized encoding is BINARY

### DIFF
--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1438,7 +1438,13 @@ fn named_captures(
 /// distinguish.
 fn regexp_encoding_value(globals: &Globals, regex: &RegexpInner) -> Value {
     let enc_class = encoding::encoding_class(globals);
-    let encoding = regex.declared_encoding();
+    // An allocated-but-uninitialized Regexp (`Regexp.allocate`) has no
+    // source yet; CRuby reports its encoding as BINARY (ASCII-8BIT).
+    let encoding = if regex.initialized() {
+        regex.declared_encoding()
+    } else {
+        crate::value::Encoding::Ascii8
+    };
     let const_name = encoding::encoding_constant_name(encoding);
     globals
         .store
@@ -2298,6 +2304,27 @@ mod tests {
         );
         // union keeps BINARY when a part is BINARY-with-non-ASCII.
         run_test(r#"Regexp.union(/abc/, /[\x00-\x7f]/n, /[\x80-\xBF]/n).encoding.to_s"#);
+    }
+
+    #[test]
+    fn regexp_encoding_specifier_last_wins() {
+        // Several encoding specifiers on one literal: the last in source
+        // order wins (`/foo/ensuens` selects `s`), for the declared
+        // encoding and for `==`.
+        run_test(
+            r#"[ /foo/ensuensuens.encoding.to_s,
+                /foo/ensuensuens == /foo/s,
+                /foo/sn.encoding.to_s,
+                /foo/ns.encoding.to_s ]"#,
+        );
+        // ...and through interpolation (the same "last wins" decode).
+        run_test(r#"x = "o"; [ /fo#{x}/ensuens.encoding.to_s, /fo#{x}/su.encoding.to_s ]"#);
+    }
+
+    #[test]
+    fn regexp_uninitialized_encoding_is_binary() {
+        // `Regexp.allocate` has no source yet; its encoding is BINARY.
+        run_test(r#"Regexp.allocate.encoding.to_s"#);
     }
 
     #[test]

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+/// Decode the encoding-selector modifier letters (`n`/`u`/`e`/`s`) of a
+/// regexp literal into the corresponding `NOENCODING` / `KCODE_*` bit.
+///
+/// When several appear, CRuby's "last specifier wins" rule applies
+/// (`/foo/ensuens` selects `s`), so the scan runs right-to-left and stops
+/// at the first (i.e. source-order last) selector. Returns 0 when none is
+/// present.
+fn regexp_encoding_bits(option: &str) -> u32 {
+    option
+        .chars()
+        .rev()
+        .find_map(|c| match c {
+            'n' => Some(RegexpInner::NOENCODING),
+            'u' => Some(RegexpInner::KCODE_UTF8),
+            'e' => Some(RegexpInner::KCODE_EUCJP),
+            's' => Some(RegexpInner::KCODE_SJIS),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
 ///
 /// Maximum number of elements (Array) / entries (Hash) of a collection
 /// literal that are evaluated into consecutive temporary registers at once.
@@ -1969,15 +1990,8 @@ impl<'a> BytecodeGen<'a> {
         if option.contains('m') {
             opt |= onigmo_regex::ONIG_OPTION_MULTILINE as i64;
         }
-        if option.contains('n') {
-            opt |= RegexpInner::NOENCODING as i64;
-        } else if option.contains('u') {
-            opt |= RegexpInner::KCODE_UTF8 as i64;
-        } else if option.contains('e') {
-            opt |= RegexpInner::KCODE_EUCJP as i64;
-        } else if option.contains('s') {
-            opt |= RegexpInner::KCODE_SJIS as i64;
-        }
+        // Encoding selector honours "last wins" (`regexp_encoding_bits`).
+        opt |= regexp_encoding_bits(&option) as i64;
         // Always the first operand (even when 0) so the run-time layout is
         // uniform: operand 0 is the option word, the rest are source
         // fragments.
@@ -2032,7 +2046,8 @@ impl<'a> BytecodeGen<'a> {
 
     fn const_regexp(&self, nodes: Vec<Node>, option: String, loc: Loc) -> Result<Value> {
         let mut string = String::new();
-        let encoding = if option.contains('n') {
+        let enc_bits = regexp_encoding_bits(&option);
+        let encoding = if enc_bits & RegexpInner::NOENCODING != 0 {
             onigmo_regex::OnigmoEncoding::ASCII
         } else {
             onigmo_regex::OnigmoEncoding::UTF8
@@ -2042,7 +2057,9 @@ impl<'a> BytecodeGen<'a> {
         // `KCODE_*` / `NOENCODING` bits used by
         // `with_option_kcode` to derive the declared (CRuby-
         // visible) encoding for `Regexp#encoding` /
-        // `Regexp#fixed_encoding?`.
+        // `Regexp#fixed_encoding?`. The encoding selector honours
+        // "last wins" (`regexp_encoding_bits`); `i`/`m`/`x` are order-
+        // independent flags.
         let mut opt = onigmo_regex::ONIG_OPTION_NONE;
         if option.contains('i') {
             opt |= onigmo_regex::ONIG_OPTION_IGNORECASE;
@@ -2053,18 +2070,9 @@ impl<'a> BytecodeGen<'a> {
         if option.contains('m') {
             opt |= onigmo_regex::ONIG_OPTION_MULTILINE;
         }
-        if option.contains('n') {
-            opt |= RegexpInner::NOENCODING;
-        }
-        let kcode = if option.contains('u') {
-            opt |= RegexpInner::KCODE_UTF8;
-            Some(RegexpInner::KCODE_UTF8)
-        } else if option.contains('e') {
-            opt |= RegexpInner::KCODE_EUCJP;
-            Some(RegexpInner::KCODE_EUCJP)
-        } else if option.contains('s') {
-            opt |= RegexpInner::KCODE_SJIS;
-            Some(RegexpInner::KCODE_SJIS)
+        opt |= enc_bits;
+        let kcode = if enc_bits & RegexpInner::KCODE_MASK != 0 {
+            Some(enc_bits & RegexpInner::KCODE_MASK)
         } else {
             None
         };


### PR DESCRIPTION
## Summary

Two more `language/regexp/encoding` fixes.

## Last encoding specifier wins

Multiple encoding specifiers on one literal (`/foo/ensuens`) must select the **last** in source order (CRuby's rule). The decode instead picked by a fixed `n > u > e > s` priority, so `/foo/ensuensuens` came out US-ASCII (from the leading `n`) rather than Windows-31J (the trailing `s`), and `/foo/ensuensuens == /foo/s` was false.

The selector is now factored into `regexp_encoding_bits`, which scans the modifier string right-to-left and returns the first (source-order last) `NOENCODING` / `KCODE_*` bit. Both the literal (`const_regexp`) and interpolated (`gen_regexp`) paths use it, so `i`/`m`/`x` stay order-independent flags while the encoding selector honours last-wins.

## Uninitialized encoding is BINARY

`Regexp.allocate.encoding` returned US-ASCII. An allocated-but-uninitialized Regexp has no source, so CRuby reports BINARY (ASCII-8BIT) — `Regexp#encoding` now special-cases the uninitialized state.

## Verification

- ruby/spec `language`: **20 → 18** failing ("selects last of multiple encoding specifiers" and "uses BINARY when is not initialized").
- Single specifiers and `==` for ordinary literals are unchanged.
- Full `cargo test` green; new regression tests `regexp_encoding_specifier_last_wins` (static + interpolated, `==`, `sn`/`ns` order) and `regexp_uninitialized_encoding_is_binary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_