### PR TITLE
String#scan: yield the zero-width matches captures_iter drops

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -8633,6 +8633,13 @@ mod tests {
             // even when the block clobbers it.
             r##""hello".scan(/./) { "ok".match(/./) }; [$~[0], $~.string]"##,
             r##""hello.".scan("l") { }; [$~.begin(0), $~[0]]"##,
+            // Empty matches on a multibyte string advance by one scalar, not
+            // one byte (the char-boundary loop in both scan forms).
+            r##""あいう".scan(//)"##,
+            r##"r = []; "あいう".scan(//) { |m| r << m }; r"##,
+            // Block form with multiple capture groups (the `len =>` arm).
+            r##"r = []; "aXbXc".scan(/(.)(X)/) { |a, b| r << [a, b] }; r"##,
+            r##"r = []; "あXいXう".scan(/(.)(X)/) { |a, b| r << [a, b] }; r"##,
             r##"
         "abcdefgdddefjklefl".match(/d*ef/) {
             |matched| matched.to_s

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2961,14 +2961,28 @@ fn scan_block_loop(
     // change after each block call to raise "string modified" like CRuby.
     let given = subject.as_rstring_inner().check_utf8()?;
     let recv_len = recv.as_rstring_inner().len();
-    for cap in re.captures_iter(given) {
-        let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
-        vm.save_capture_special_variables(&cap, given);
+    // Manual walk (as in the no-block `RegexpInner::scan` and
+    // `replace_repeat`) so zero-width matches the CRuby scan yields —
+    // between two non-empty matches, and at end-of-string after a
+    // non-empty one — are not dropped by `captures_iter`.
+    // `captures_from_pos` already stores each match into `$~` (and clears
+    // it on the terminal no-match), so the block sees the current match's
+    // `$~`. Keep the last match to restore `$~` after the loop: the block
+    // body may clobber it, and the terminal no-match clears it, but CRuby
+    // leaves `$~` set to the scan's final match (nil if there was none).
+    let mut last_captures: Option<onigmo_regex::Captures> = None;
+    let mut pos = 0usize;
+    while pos <= given.len() {
+        let cap = match re.captures_from_pos(given, pos, vm)? {
+            Some(c) => c,
+            None => break,
+        };
+        let m = cap.get(0).unwrap();
+        let (start, end) = (m.start(), m.end());
         match cap.len() {
             0 => unreachable!(),
             1 => {
-                let m = cap.get(0).unwrap();
-                let val = string_substring(subject, m.start(), m.end());
+                let val = string_substring(subject, start, end);
                 vm.invoke_block(globals, data, &[val])?;
             }
             len => {
@@ -2984,6 +2998,21 @@ fn scan_block_loop(
             }
         }
         check_string_not_modified(recv, recv_len)?;
+        last_captures = Some(cap);
+        pos = if end > start {
+            end
+        } else if start >= given.len() {
+            given.len() + 1
+        } else {
+            let mut next = start + 1;
+            while next < given.len() && !given.is_char_boundary(next) {
+                next += 1;
+            }
+            next
+        };
+    }
+    if let Some(c) = last_captures {
+        vm.save_capture_special_variables(&c, given);
     }
     Ok(())
 }
@@ -8594,6 +8623,16 @@ mod tests {
             r##"
         "test".scan(/(z)?e/)
         "##,
+            // Zero-width matches CRuby yields but `captures_iter` dropped:
+            // the empty match at end-of-string after a non-empty one
+            // (`(?~foo)`), and the empties between/around non-empty runs.
+            r##"[Regexp.new("(?~foo)"), /[^,]*/, /x?/, /\w*/].map { |re| "foo".scan(re) }"##,
+            r##""a,b,,c".scan(/[^,]*/)"##,
+            r##"r = []; "foo".scan(Regexp.new("(?~foo)")) { |m| r << m }; [r, $&]"##,
+            // $~ after a block scan is the last scan match (nil if none),
+            // even when the block clobbers it.
+            r##""hello".scan(/./) { "ok".match(/./) }; [$~[0], $~.string]"##,
+            r##""hello.".scan("l") { }; [$~.begin(0), $~[0]]"##,
             r##"
         "abcdefgdddefjklefl".match(/d*ef/) {
             |matched| matched.to_s

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1227,16 +1227,26 @@ impl RegexpInner {
         given: &str,
     ) -> Result<Vec<Value>> {
         let mut ary = vec![];
-        let mut last_captures = None;
+        let mut last_captures: Option<Captures> = None;
         vm.clear_capture_special_variables();
-        for cap in self.regex.captures_iter(given) {
-            let cap = cap.map_err(|err| MonorubyErr::regexerr(format!("{err}")))?;
+        // Walk the haystack manually rather than via `captures_iter`, which
+        // drops zero-width matches the CRuby scan is expected to yield — the
+        // empty position between two non-empty matches, and the empty match
+        // at end-of-string after a non-empty one (e.g.
+        // `"foo".scan(/(?~foo)/) == ["fo", "o", ""]`). Same loop as
+        // `replace_repeat`: advance past a non-empty match, and by one
+        // Unicode scalar past an empty one (past EOS to terminate).
+        let mut pos = 0usize;
+        while pos <= given.len() {
+            let cap = match self.captures_from_pos(given, pos, vm)? {
+                Some(c) => c,
+                None => break,
+            };
+            let m = cap.get(0).unwrap();
+            let (start, end) = (m.start(), m.end());
             match cap.len() {
                 0 => unreachable!(),
-                1 => {
-                    let m = cap.get(0).unwrap();
-                    ary.push(string_substring(subject, m.start(), m.end()));
-                }
+                1 => ary.push(string_substring(subject, start, end)),
                 len => {
                     let mut vec = vec![];
                     for i in 1..len {
@@ -1249,6 +1259,17 @@ impl RegexpInner {
                 }
             }
             last_captures = Some(cap);
+            pos = if end > start {
+                end
+            } else if start >= given.len() {
+                given.len() + 1
+            } else {
+                let mut next = start + 1;
+                while next < given.len() && !given.is_char_boundary(next) {
+                    next += 1;
+                }
+                next
+            };
         }
 
         if let Some(c) = last_captures {


### PR DESCRIPTION
## Summary

`String#scan` (both the array and block forms) iterated with the bundled Onigmo `captures_iter`, which skips zero-width matches CRuby's scan yields: the empty position between two non-empty matches, and the empty match at end-of-string after a non-empty one. So `"foo".scan(/(?~foo)/)` returned `["fo", "o"]` instead of `["fo", "o", ""]`.

## The fix

Walk the haystack manually with `captures_from_pos`, advancing past a non-empty match and by one Unicode scalar past an empty one (past EOS to terminate) — the exact loop `replace_repeat` (`gsub`) already uses for the same reason. The no-block `RegexpInner::scan` and the block-form `scan_block_loop` now share this shape.

The block form additionally restores `$~` to the last scan match after the loop: `captures_from_pos` clears `$~` on the terminal no-match, and the block body may clobber it, but CRuby leaves `$~` set to the scan's final match (`nil` if there was none).

## Verification

- ruby/spec `language`: **16 → 15** failing ("supports `(?~)` (absent operator)").
- `core/string/scan_spec.rb`: **2 → 1** failing with **no new errors** (I checked master: it was 2 failures / 0 errors; the remaining one is a pre-existing block-arg-array issue, unrelated). Empty-match sweeps like `"a,b,,c".scan(/[^,]*/)` and the `$~`-after-block cases now match CRuby.
- Full `cargo test` green; new empty-match + `$~`-restore cases added to `scan_index_group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_