### PR TITLE
Security-spec hardening: pack count overflow, File#path after close, NUL path rejection

### DIFF
--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -235,14 +235,17 @@ fn glob(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             .as_array_inner()
             .iter()
             .map(|v| {
-                let s = v.coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
+                let s = v
+                    .coerce_to_path_rstring_allow_nul(vm, globals)?
+                    .to_str()?
+                    .to_string();
                 reject_array_pattern_nul(&s)?;
                 Ok(s)
             })
             .collect::<Result<_>>()?
     } else {
         let s = pat_val
-            .coerce_to_path_rstring(vm, globals)?
+            .coerce_to_path_rstring_allow_nul(vm, globals)?
             .to_str()?
             .to_string();
         reject_single_pattern_nul(&s)?;
@@ -296,7 +299,10 @@ fn glob2(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let patterns: Vec<String> = pat_val
         .iter()
         .map(|v| {
-            let s = v.coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
+            let s = v
+                .coerce_to_path_rstring_allow_nul(vm, globals)?
+                .to_str()?
+                .to_string();
             if single {
                 reject_single_pattern_nul(&s)?;
             } else {

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -524,7 +524,7 @@ fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                 seen.pop();
             }
             None => {
-                let s = val.coerce_to_path_rstring(vm, globals)?;
+                let s = val.coerce_to_path_rstring_allow_nul(vm, globals)?;
                 let s = s.to_str()?.to_string();
                 if s.as_bytes().contains(&0) {
                     return Err(MonorubyErr::argumenterr("string contains null byte"));

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -561,7 +561,7 @@ pub(super) fn init_io_encodings(
 
 /// Allocator for `IO` and its subclasses.
 pub(crate) extern "C" fn io_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
-    Value::new_io_with_class(IoInner::Closed, class_id)
+    Value::new_io_with_class(IoInner::Closed(None), class_id)
 }
 
 ///
@@ -808,11 +808,11 @@ fn close_write(
             popen.writer = None;
             popen.reader.is_none()
         }
-        IoInner::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+        IoInner::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
         _ => return Err(MonorubyErr::ioerr("closing non-duplex IO for writing")),
     };
     if fully_closed {
-        *io = IoInner::Closed;
+        *io = IoInner::Closed(None);
     }
     Ok(Value::nil())
 }
@@ -833,11 +833,11 @@ fn close_read(
             popen.reader = None;
             popen.writer.is_none()
         }
-        IoInner::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+        IoInner::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
         _ => return Err(MonorubyErr::ioerr("closing non-duplex IO for reading")),
     };
     if fully_closed {
-        *io = IoInner::Closed;
+        *io = IoInner::Closed(None);
     }
     Ok(Value::nil())
 }
@@ -4234,6 +4234,46 @@ mod tests {
             ensure
               File.unlink(path) rescue nil
             end
+            "#,
+        );
+    }
+
+    #[test]
+    fn file_path_survives_close_and_nul_paths_rejected() {
+        // security/cve_2018_6914 + cve_2018_8779: tempfile.rb's cleanup
+        // runs `File.unlink(file.path)` on a *closed* file, so `File#path`
+        // must stay readable after close (CRuby keeps it; we previously
+        // returned nil, giving "no implicit conversion of NilClass").
+        run_test(
+            r#"
+            f = File.open("Cargo.toml")
+            f.close
+            [f.path, f.closed?]
+            "#,
+        );
+        // Tempfile#close! end-to-end (unlink of the closed file).
+        run_test_once(
+            r#"
+            require "tempfile"
+            t = Tempfile.new("mrb_sec")
+            path = t.path
+            t.close!
+            [path.nil?, File.exist?(path)]
+            "#,
+        );
+        // security/cve_2018_8780: a NUL byte anywhere in a path raises
+        // ArgumentError up front (previously an opaque RuntimeError from
+        // the failed CString conversion).
+        run_test(
+            r#"
+            %w[entries foreach children].map { |m|
+              begin
+                Dir.send(m, "/tmp\0x")
+                :no_raise
+              rescue ArgumentError => e
+                e.message
+              end
+            } + [begin; File.open("/tmp\0x"); :no_raise; rescue ArgumentError => e; e.message; end]
             "#,
         );
     }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -9882,6 +9882,38 @@ mod tests {
     }
 
     #[test]
+    fn pack_template_huge_count_raises_rangeerror() {
+        // security/cve_2018_8778: an overflow-scale count in a pack/unpack
+        // template raises RangeError "pack length too big" (CRuby caps the
+        // count at a C long). Previously the unchecked digit accumulation
+        // overflowed usize and aborted the process via a non-unwinding
+        // panic. In-range templates keep working.
+        run_test(
+            r#"
+            r = []
+            [["@99999999999999999999999999", :unpack],
+             ["a99999999999999999999999999", :unpack],
+             ["@18446744073709551615",       :unpack]].each do |tmpl, _|
+              begin
+                "a".unpack(tmpl)
+                r << :no_raise
+              rescue RangeError => e
+                r << e.message
+              end
+            end
+            begin
+              [1].pack("C99999999999999999999999999")
+              r << :no_raise
+            rescue RangeError => e
+              r << e.message
+            end
+            r << "ab".unpack("@1a1")
+            r
+            "#,
+        );
+    }
+
+    #[test]
     fn pack_template_comments() {
         // # starts a comment until end of line
         run_test(r#"[65, 66].pack("C # first byte\nC")"#);

--- a/monoruby/src/value/coerce.rs
+++ b/monoruby/src/value/coerce.rs
@@ -428,6 +428,26 @@ impl Value {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<RString> {
+        let rs = self.coerce_to_path_rstring_allow_nul(vm, globals)?;
+        // CRuby rejects NUL in paths up front (CVE-2018-8780 hardening):
+        // `ArgumentError: path name contains null byte`. Without this the
+        // failed CString conversion surfaced as an opaque
+        // RuntimeError("Unknown error - …").
+        if rs.as_bytes().contains(&0) {
+            return Err(MonorubyErr::argumenterr("path name contains null byte"));
+        }
+        Ok(rs)
+    }
+
+    /// `coerce_to_path_rstring` without the NUL-byte rejection, for the
+    /// callers that carry their own CRuby-specific NUL message:
+    /// `Dir.glob` ("nul-separated glob pattern is deprecated") and
+    /// `File.join` ("string contains null byte").
+    pub(crate) fn coerce_to_path_rstring_allow_nul(
+        &self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<RString> {
         // CRuby's path coercion (`rb_get_path`) prefers `#to_path`, only
         // falling back to `#to_str` when `#to_path` is absent
         // (core/dir/chdir_spec.rb "prefers #to_path over #to_str").

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -136,7 +136,10 @@ pub enum IoInner {
     Stderr,
     File(Rc<FileDescriptor>),
     Popen(Rc<PopenDescriptor>),
-    Closed,
+    /// Closed stream. Retains the filesystem path of a path-backed File
+    /// (CRuby keeps `File#path` readable after close; tempfile.rb relies
+    /// on `File.unlink(file.path)` from its cleanup/finalizer paths).
+    Closed(Option<String>),
 }
 
 /// Outcome of a non-blocking `IO#read_nonblock`.
@@ -160,7 +163,7 @@ impl std::clone::Clone for IoInner {
             Self::Stderr => Self::Stderr,
             Self::File(file) => Self::File(file.clone()),
             Self::Popen(popen) => Self::Popen(popen.clone()),
-            Self::Closed => Self::Closed,
+            Self::Closed(p) => Self::Closed(p.clone()),
         }
     }
 }
@@ -173,7 +176,7 @@ impl std::fmt::Display for IoInner {
             Self::Stderr => write!(f, "#<IO:<STDERR>>"),
             Self::File(file) => write!(f, "#<File:{}>", file.name),
             Self::Popen(_) => write!(f, "#<IO:popen>"),
-            Self::Closed => write!(f, "#<IO:(closed)>"),
+            Self::Closed(..) => write!(f, "#<IO:(closed)>"),
         }
     }
 }
@@ -194,20 +197,20 @@ impl IoInner {
                 }
                 return Ok(());
             }
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
         };
         res.map_err(|err| MonorubyErr::runtimeerr(err.to_string()))
     }
 
     pub fn is_closed(&self) -> bool {
-        matches!(self, Self::Closed)
+        matches!(self, Self::Closed(..))
     }
 
     /// Whether the stream may be read from.
     pub fn is_readable(&self) -> bool {
         match self {
             Self::Stdin => true,
-            Self::Stdout | Self::Stderr | Self::Closed => false,
+            Self::Stdout | Self::Stderr | Self::Closed(..) => false,
             Self::File(f) => f.readable,
             Self::Popen(p) => p.reader.is_some(),
         }
@@ -217,7 +220,7 @@ impl IoInner {
     pub fn is_writable(&self) -> bool {
         match self {
             Self::Stdout | Self::Stderr => true,
-            Self::Stdin | Self::Closed => false,
+            Self::Stdin | Self::Closed(..) => false,
             Self::File(f) => f.writable,
             Self::Popen(p) => p.writer.is_some(),
         }
@@ -267,7 +270,14 @@ impl IoInner {
         } else {
             None
         };
-        *self = Self::Closed;
+        // Retain a path-backed File's path across close: CRuby keeps
+        // `File#path` readable after close (tempfile.rb's cleanup calls
+        // `File.unlink(file.path)` on a closed file).
+        let retained = match &*self {
+            Self::File(file) if file.has_path => Some(file.name.clone()),
+            _ => None,
+        };
+        *self = Self::Closed(retained);
         Ok(popen_result)
     }
 
@@ -384,7 +394,7 @@ impl IoInner {
                 Ok(())
             }
             // `ensure_writable` already rejected non-writable streams.
-            Self::Stdin | Self::Closed => unreachable!(),
+            Self::Stdin | Self::Closed(..) => unreachable!(),
         }
     }
 
@@ -411,7 +421,7 @@ impl IoInner {
     /// ungets behave LIFO while a single multi-byte unget preserves order.
     pub fn unget(&mut self, bytes: &[u8]) -> Result<()> {
         match self {
-            Self::Closed => Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin | Self::Stdout | Self::Stderr => {
                 Err(MonorubyErr::ioerr("not opened for reading"))
             }
@@ -467,7 +477,7 @@ impl IoInner {
 
     fn read_underlying(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
         match self {
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin => {
                 if let Some(length) = length {
                     let buf = match std::io::stdin().bytes().take(length).collect() {
@@ -551,7 +561,7 @@ impl IoInner {
         }
         let need = maxlen - out.len();
         let chunk = match self {
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdout | Self::Stderr => {
                 return Err(MonorubyErr::ioerr("not opened for reading"));
             }
@@ -701,7 +711,7 @@ impl IoInner {
         }
         let need = maxlen - out.len();
         match self {
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdout | Self::Stderr => {
                 return Err(MonorubyErr::ioerr("not opened for reading"));
             }
@@ -761,7 +771,7 @@ impl IoInner {
 
     fn read_line_underlying(&mut self) -> Result<Option<String>> {
         match self {
-            Self::Closed => return Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin => {
                 let mut buf = String::new();
                 std::io::stdin()
@@ -818,7 +828,7 @@ impl IoInner {
                     Err(MonorubyErr::ioerr("closed stream"))
                 }
             }
-            Self::Closed => Err(MonorubyErr::ioerr("closed stream")),
+            Self::Closed(..) => Err(MonorubyErr::ioerr("closed stream")),
         }
     }
 
@@ -843,7 +853,7 @@ impl IoInner {
         };
         match self {
             Self::File(file) => Rc::get_mut(file).unwrap().reader.seek(seek_from),
-            Self::Closed => Err(std::io::Error::from_raw_os_error(9)), // EBADF
+            Self::Closed(..) => Err(std::io::Error::from_raw_os_error(9)), // EBADF
             _ => Err(std::io::Error::from_raw_os_error(ESPIPE)),
         }
     }
@@ -853,7 +863,7 @@ impl IoInner {
             Self::Stdin => std::io::stdin().is_terminal(),
             Self::Stdout => std::io::stdout().is_terminal(),
             Self::Stderr => std::io::stderr().is_terminal(),
-            Self::File(_) | Self::Popen(_) | Self::Closed => false,
+            Self::File(_) | Self::Popen(_) | Self::Closed(..) => false,
         }
     }
 
@@ -875,7 +885,8 @@ impl IoInner {
             Self::Stdout => Some("<STDOUT>".to_string()),
             Self::Stderr => Some("<STDERR>".to_string()),
             Self::File(file) if file.has_path => Some(file.name.clone()),
-            Self::File(_) | Self::Popen(_) | Self::Closed => None,
+            Self::Closed(p) => p.clone(),
+            Self::File(_) | Self::Popen(_) => None,
         }
     }
 

--- a/monoruby/src/value/rvalue/string/pack.rs
+++ b/monoruby/src/value/rvalue/string/pack.rs
@@ -1268,10 +1268,20 @@ fn parse_template(template: &str, is_unpack: bool) -> Result<Vec<TemplateNode>> 
                 explicit_count: true,
             });
         } else if let Some(d1) = iter.next_if(|c| c.is_ascii_digit()) {
-            let mut count = (d1 as u32 - '0' as u32) as usize;
+            // Accumulate the count with checked arithmetic capped at
+            // i64::MAX (CRuby uses a C `long`): an overflowing count like
+            // "@99999999999999999999999999" raises RangeError "pack length
+            // too big" in CRuby. The unchecked version overflowed usize and
+            // panicked (non-unwinding -> process abort) in debug builds.
+            let too_big = || MonorubyErr::rangeerr("pack length too big");
+            let mut count = (d1 as u32 - '0' as u32) as i64;
             while let Some(d) = iter.next_if(|c| c.is_ascii_digit()) {
-                count = count * 10 + (d as u32 - '0' as u32) as usize;
+                count = count
+                    .checked_mul(10)
+                    .and_then(|c| c.checked_add((d as u32 - '0' as u32) as i64))
+                    .ok_or_else(too_big)?;
             }
+            let count = count as usize;
             temp.push(TemplateNode {
                 template,
                 endian,

--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -36,7 +36,28 @@ end
 class TCPSocket < IPSocket; end
 class TCPServer < TCPSocket; end
 class UDPSocket < IPSocket; end
-class UNIXSocket < BasicSocket; end
+class UNIXSocket < BasicSocket
+  # Real UNIX-domain sockets are unsupported, but the path argument is
+  # validated like CRuby's (CVE-2018-8779): a NUL byte must raise
+  # ArgumentError *before* any bind/connect would happen. Valid paths
+  # fail with an explicit unsupported-feature error instead of the
+  # previous misleading NoMethodError.
+  def self.open(path, *rest, &blk)
+    new(path, *rest, &blk)
+  end
+
+  def initialize(path, *)
+    path = path.to_path if path.respond_to?(:to_path)
+    path = path.to_str  if path.respond_to?(:to_str)
+    unless path.is_a?(String)
+      raise TypeError, "no implicit conversion of #{path.class} into String"
+    end
+    if path.include?("\0")
+      raise ArgumentError, "path name contains null byte"
+    end
+    raise SocketError, "UNIX domain sockets are not supported in monoruby"
+  end
+end
 class UNIXServer < UNIXSocket; end
 
 class SocketError < StandardError; end


### PR DESCRIPTION
## Summary

Fixes for the ruby/spec **security** category: **19 red → 9 red** (13 files, 34 examples; remaining: 8 failures + 1 error, all deferred items listed below).

### 1. pack/unpack template count overflow → process abort (CVE-2018-8778 specs)

`"a".unpack("@99999999999999999999999999")` overflowed `usize` during digit accumulation in `parse_template` (pack.rs), which is a non-unwinding panic in the VM → **process abort**. Counts are now accumulated with checked `i64` arithmetic (CRuby uses a C `long`); overflow raises `RangeError: pack length too big`, matching CRuby.

### 2. `File#path` after close returned nil (CVE-2018-6914 specs)

CRuby keeps `File#path` readable after `close`; tempfile.rb's cleanup relies on it (`File.unlink(file.path)` on a closed file). `IoInner::Closed` is now `Closed(Option<String>)` and retains a path-backed File's path across close. This fixes `Tempfile#close!` end-to-end and 4 Tempfile-based security specs, which previously died with `no implicit conversion of NilClass into String`.

### 3. NUL bytes in paths → opaque RuntimeError (CVE-2018-8780 specs)

`coerce_to_path_rstring` now rejects paths containing `"\0"` with `ArgumentError: path name contains null byte` up front (previously the failed CString conversion surfaced as `RuntimeError: Unknown error - ...`). Covers `Dir.entries/foreach/children/mkdir/...`, `File.open`, etc.

Two callers keep their own CRuby-specific NUL messages via a new `coerce_to_path_rstring_allow_nul`:
- `Dir.glob` single-pattern form: `nul-separated glob pattern is deprecated`
- `File.join`: `string contains null byte`

### 4. UNIXSocket stub argument validation (CVE-2018-8779 specs)

The `UNIXSocket`/`UNIXServer` stubs (stdlib/socket.rb) gained a minimal `open`/`new` that coerces the path (`#to_path`/`#to_str`), raises `TypeError` for non-strings and `ArgumentError: path name contains null byte` for NUL bytes, then raises `SocketError` explaining UNIX-domain sockets are unsupported (previously a misleading `NoMethodError`).

## Deferred (remaining 9 red in security)

- **8 failures**: `$SAFE`-era `Hash#hash` specs requiring per-process hash seed randomization — needs a seeded hasher through rubymap/Value hash paths; larger change, proposed separately.
- **1 error**: `String#gsub` on BINARY (ASCII-8BIT) strings with invalid UTF-8 — the regexp pipeline is `&str`/UTF-8-based; needs byte-based Onigmo matching.

## Testing

- `cargo test -p monoruby --lib`: **1838 passed, 0 failed**.
- New regression tests: `pack_template_huge_count_raises_rangeerror` (string.rs), `file_path_survives_close_and_nul_paths_rejected` (io.rs) — both differential against CRuby 4.0.2.
- ruby/spec sweep with the release binary: security 19 red → 9 red; `command_line` 0 failures / 0 errors; `core/io`, `core/file`, `core/dir` tallies unchanged (all remaining failures are pre-existing gaps — `IO::Buffer`, integer-mode `File.open`, Thread-based specs, etc.).
- CRuby-vs-monoruby one-liner batteries for every changed behavior (double-close, closed-stream messages, glob/join NUL messages) all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_