### PR TITLE
Per-process hash seed randomization (CVE-2011-4815) and Fixnum-safe #hash digests

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -661,8 +661,18 @@ fn to_h(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/hash.html]
 #[monoruby_builtin]
 fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let h = lfp.self_val().calculate_hash(vm, globals)?;
-    Ok(Value::integer_from_u64(h))
+    // Outer-recursion collapse (CRuby rb_exec_recursive_outer): every
+    // structure that is cyclic — at any depth — hashes to the same
+    // sentinel, so `rec.hash == [{x: rec}].hash` when rec.eql?([{x: rec}]).
+    // The *unregistered* variant is used because `ruby_hash`'s Array arm
+    // registers self in the recursion guard itself.
+    crate::value::exec_recursive_outer_unregistered(
+        || {
+            let h = lfp.self_val().calculate_hash(vm, globals)?;
+            Ok(Value::from_hash_digest(h))
+        },
+        Value::integer(0),
+    )
 }
 
 ///

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -645,7 +645,10 @@ fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let recursive_marker = Value::integer(0);
-    crate::value::exec_recursive(
+    // Outer-recursion collapse (CRuby rb_exec_recursive_outer): a cycle
+    // detected at any depth collapses the *outermost* #hash to the
+    // sentinel, so `h.hash == {x: h}.hash` when h[:x] = h (h.eql?(x: h)).
+    crate::value::exec_recursive_outer(
         self_val.id(),
         || {
             let h = self_val.as_hash();
@@ -672,7 +675,9 @@ fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 let vpart = vh.wrapping_mul(VAL_MIX).rotate_left(13);
                 acc = acc.wrapping_add(kpart ^ vpart);
             }
-            Ok(Value::integer(acc))
+            // Fold into Fixnum range: a Bignum digest would degrade to 0
+            // when this hash is itself an element of an outer Hash.
+            Ok(Value::from_hash_digest(acc as u64))
         },
         recursive_marker,
     )

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -4237,7 +4237,14 @@ fn class(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/Object/i/hash.html]
 #[monoruby_builtin]
 fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(Value::integer(lfp.self_val().id() as _))
+    // Digest the identity (tagged bits for immediates, address for heap
+    // objects) through the per-process seeded hasher (CVE-2011-4815): a
+    // Fixnum/Symbol's raw id is identical in every process, so returning it
+    // directly would make `14.hash` predictable across processes.
+    use std::hash::{Hash, Hasher};
+    let mut s = crate::value::seeded_hasher();
+    lfp.self_val().id().hash(&mut s);
+    Ok(Value::from_hash_digest(s.finish()))
 }
 
 ///

--- a/monoruby/src/builtins/method.rs
+++ b/monoruby/src/builtins/method.rs
@@ -750,8 +750,7 @@ fn method_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let h = fid
         .wrapping_mul(0x100000001b3i64)
         .wrapping_add(recv.rotate_left(13));
-    // Mask sign bit so we always return a non-negative Fixnum-friendly value.
-    Ok(Value::integer(h & 0x7fff_ffff_ffff_ffff))
+    Ok(Value::from_hash_digest(h as u64))
 }
 
 ///
@@ -767,7 +766,7 @@ fn umethod_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let h = fid
         .wrapping_mul(0x100000001b3i64)
         .wrapping_add(owner_id.rotate_left(13));
-    Ok(Value::integer(h & 0x7fff_ffff_ffff_ffff))
+    Ok(Value::from_hash_digest(h as u64))
 }
 
 ///

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -515,10 +515,10 @@ fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<V
     use std::hash::{Hash, Hasher};
     let self_val = lfp.self_val();
     let c = self_val.as_complex();
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut hasher = crate::value::seeded_hasher();
     c.re().hash(&mut hasher);
     c.im().hash(&mut hasher);
-    Ok(Value::integer(hasher.finish() as i64))
+    Ok(Value::from_hash_digest(hasher.finish()))
 }
 
 ///

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -43,6 +43,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_cfunc_ff_f(FLOAT_CLASS, "/", div, div_ff_f, 1);
     globals.define_builtin_cfunc_ff_f(FLOAT_CLASS, "%", rem, rem_ff_f, 1);
     globals.define_builtin_cfunc_ff_f(FLOAT_CLASS, "**", pow, pow_ff_f, 1);
+    globals.define_builtin_func(FLOAT_CLASS, "hash", hash, 0);
     globals.define_builtin_func(FLOAT_CLASS, "div", div_floor, 1);
     globals.define_builtin_func(FLOAT_CLASS, "modulo", rem, 1);
     globals.define_builtin_func(FLOAT_CLASS, "divmod", divmod, 1);
@@ -223,6 +224,32 @@ fn float_toi(
 /// - to_i -> Integer
 /// - [NOT SUPPORTED]truncate(ndigits = 0) -> Integer | Float
 ///
+///
+/// ### Float#hash
+///
+/// - hash -> Integer
+///
+/// Digests the numeric value through the per-process seeded hasher
+/// (CVE-2011-4815). Hashes the canonical bit pattern (±0.0 normalized to
+/// +0.0, matching `0.0.eql?(-0.0)`) so a flonum and an equal heap-allocated
+/// Float agree. Without this, `Float#hash` fell back to `Kernel#hash`:
+/// flonum tags are identical in every process, and equal heap Floats
+/// hashed by address.
+#[monoruby_builtin]
+fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    use std::hash::{Hash, Hasher};
+    let mut f = match lfp.self_val().unpack() {
+        RV::Float(f) => f,
+        _ => unreachable!(),
+    };
+    if f == 0.0 {
+        f = 0.0;
+    }
+    let mut s = crate::value::seeded_hasher();
+    f.to_bits().hash(&mut s);
+    Ok(Value::from_hash_digest(s.finish()))
+}
+
 /// [https://docs.ruby-lang.org/ja/latest/method/Float/i/to_i.html]
 #[monoruby_builtin]
 fn toi(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -11,6 +11,7 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_class("Integer", INTEGER_CLASS, numeric, OBJECT_CLASS, None);
     globals.store[INTEGER_CLASS].clear_alloc_func();
     globals.define_builtin_func_with(INTEGER_CLASS, "chr", chr, 0, 1, false);
+    globals.define_builtin_func(INTEGER_CLASS, "hash", hash, 0);
     // `next` is a true alias of `succ`.
     globals.define_builtin_inline_funcs(
         INTEGER_CLASS,
@@ -289,6 +290,28 @@ fn downto(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
 /// - chr -> String
 /// - chr(encoding) -> String
 ///
+///
+/// ### Integer#hash
+///
+/// - hash -> Integer
+///
+/// Digests the numeric value through the per-process seeded hasher
+/// (CVE-2011-4815). Without an Integer-specific `#hash`, small integers
+/// fell back to `Kernel#hash` on the tagged immediate — identical in every
+/// process — and equal Bignums hashed by heap address, so two equal
+/// Bignums disagreed.
+#[monoruby_builtin]
+fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    use std::hash::{Hash, Hasher};
+    let mut s = crate::value::seeded_hasher();
+    match lfp.self_val().unpack() {
+        RV::Fixnum(i) => i.hash(&mut s),
+        RV::BigInt(b) => b.hash(&mut s),
+        _ => unreachable!(),
+    }
+    Ok(Value::from_hash_digest(s.finish()))
+}
+
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/chr.html]
 #[monoruby_builtin]
 fn chr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {

--- a/monoruby/src/builtins/numeric/rational.rs
+++ b/monoruby/src/builtins/numeric/rational.rs
@@ -571,10 +571,10 @@ fn negative_(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use std::hash::{Hash, Hasher};
     let r = self_rat(lfp);
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut hasher = crate::value::seeded_hasher();
     r.num().hash(&mut hasher);
     r.den().hash(&mut hasher);
-    Ok(Value::integer(hasher.finish() as i64))
+    Ok(Value::from_hash_digest(hasher.finish()))
 }
 
 #[monoruby_builtin]

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -157,7 +157,7 @@ fn proc_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     let h = (proc.func_id().get() as u64)
         .wrapping_mul(31)
         .wrapping_add(proc.self_val().id());
-    Ok(Value::integer(h as i64))
+    Ok(Value::from_hash_digest(h))
 }
 
 ///

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -800,10 +800,10 @@ fn regexp_hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     use std::hash::{Hash, Hasher};
     let self_ = lfp.self_val();
     let re = self_.as_regexp_inner();
-    let mut h = std::collections::hash_map::DefaultHasher::new();
+    let mut h = crate::value::seeded_hasher();
     re.source_bytes().hash(&mut h);
     (re.raw_option() & REGEXP_EQ_OPTION_MASK).hash(&mut h);
-    Ok(Value::integer(h.finish() as i64))
+    Ok(Value::from_hash_digest(h.finish()))
 }
 
 /// ### Regexp#===

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1375,25 +1375,25 @@ fn reset(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn set_hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use crate::RubyHash;
-    use std::collections::hash_map::DefaultHasher;
     use std::hash::Hasher;
     // Hash every element through `Value::ruby_hash`, which is content-based
     // (e.g. strings hash by bytes, not by object identity). Combine with
     // XOR so the result is order-independent — two Sets with the same
     // members always hash equal regardless of insertion order.
     //
-    // `DefaultHasher::new()` uses fixed keys, so the result is stable
-    // across processes with the same element hashes.
+    // The per-process seeded hasher keeps element digests consistent
+    // within a process while randomizing them across processes
+    // (CVE-2011-4815).
     let keys = set_keys(lfp.self_val());
-    // Seed mixed in to distinguish an empty Set from other empty
+    // Constant mixed in to distinguish an empty Set from other empty
     // aggregates that XOR-combine to 0.
     let mut combined: u64 = 0x5e7_5e7_5e7_5e7;
     for k in keys {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = crate::value::seeded_hasher();
         k.ruby_hash(&mut hasher, vm, globals)?;
         combined ^= hasher.finish();
     }
-    Ok(Value::integer(combined as i64))
+    Ok(Value::from_hash_digest(combined))
 }
 
 #[cfg(test)]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -397,7 +397,7 @@ fn mul(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let h = lfp.self_val().calculate_hash(vm, globals)?;
-    Ok(Value::integer_from_u64(h))
+    Ok(Value::from_hash_digest(h))
 }
 
 

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -660,7 +660,7 @@ fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     crate::value::exec_recursive_outer(
         id,
         || {
-            let mut hasher = std::hash::DefaultHasher::new();
+            let mut hasher = crate::value::seeded_hasher();
             hasher.write_u64(class_hash);
             if let Some(s) = self_val.try_struct() {
                 for i in 0..s.len() {
@@ -669,9 +669,7 @@ fn hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                     hasher.write_u64(h);
                 }
             }
-            Ok(Value::integer(
-                (hasher.finish() & 0x7fff_ffff_ffff_ffff) as i64,
-            ))
+            Ok(Value::from_hash_digest(hasher.finish()))
         },
         // On any recursion at any depth, the outer call returns this
         // sentinel, so two structs that cycle at different depths still

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -2723,10 +2723,10 @@ fn hash(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<V
         TimeInner::Local(t) => (t.with_timezone(&Utc).timestamp(), t.nanosecond()),
         TimeInner::Utc(t) => (t.timestamp(), t.nanosecond()),
     };
-    let mut hasher = std::hash::DefaultHasher::new();
+    let mut hasher = crate::value::seeded_hasher();
     secs.hash(&mut hasher);
     nsec.hash(&mut hasher);
-    Ok(Value::integer_from_u64(hasher.finish()))
+    Ok(Value::from_hash_digest(hasher.finish()))
 }
 
 impl std::ops::Sub<Self> for TimeInner {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -274,6 +274,41 @@ where
     result
 }
 
+/// Like [`exec_recursive_outer`], but does **not** register an id in the
+/// recursion guard: the callee is expected to register the ids it visits
+/// itself (e.g. `calculate_hash` → `ruby_hash`, whose Array/Hash arms
+/// insert into the same `HASH_RECURSION_GUARD`). Only the outer-collapse
+/// bookkeeping (depth counter + hit flag) is provided, so a cycle detected
+/// anywhere inside `f` still collapses the outermost call to
+/// `on_recursive`. Registering the id here as well would immediately
+/// self-collide with the callee's own registration.
+pub(crate) fn exec_recursive_outer_unregistered<T, F>(f: F, on_recursive: T) -> Result<T>
+where
+    F: FnOnce() -> Result<T>,
+{
+    let is_outer = OUTER_RECURSION_DEPTH.with(|d| {
+        let was = *d.borrow() == 0;
+        *d.borrow_mut() += 1;
+        was
+    });
+    if is_outer {
+        OUTER_RECURSION_HIT.with(|h| *h.borrow_mut() = false);
+    }
+    let result = f();
+    OUTER_RECURSION_DEPTH.with(|d| *d.borrow_mut() -= 1);
+    if is_outer {
+        let hit = OUTER_RECURSION_HIT.with(|h| {
+            let v = *h.borrow();
+            *h.borrow_mut() = false;
+            v
+        });
+        if hit {
+            return Ok(on_recursive);
+        }
+    }
+    result
+}
+
 /// Execute `f` with recursion protection for paired operations (==, <=>, eql?).
 ///
 /// Uses a `(lhs_id, rhs_id)` pair to detect when the same pair of containers
@@ -331,6 +366,11 @@ impl RubyHash<Executor, Globals, MonorubyErr> for Value {
                         let is_recursive =
                             HASH_RECURSION_GUARD.with(|guard| !guard.borrow_mut().insert(id));
                         if is_recursive {
+                            // Surface the cycle to any enclosing
+                            // `exec_recursive_outer` frame (CRuby's
+                            // rb_exec_recursive_outer semantics: the
+                            // outermost `#hash` collapses to the sentinel).
+                            OUTER_RECURSION_HIT.with(|h| *h.borrow_mut() = true);
                             0u64.hash(state);
                             return Ok(());
                         }
@@ -451,11 +491,37 @@ impl RubyEql<Executor, Globals, MonorubyErr> for Value {
     }
 }
 
+/// Per-process random hash state (CVE-2011-4815 hardening).
+///
+/// Every Ruby-visible `#hash` digest is produced by a SipHash keyed with
+/// this state, so hash values are consistent within a process but differ
+/// between processes, preventing precomputed hash-flooding attacks.
+/// Internal hash *tables* (rubymap / HashMap) key their own hashers and are
+/// unaffected.
+static HASH_STATE: std::sync::LazyLock<std::collections::hash_map::RandomState> =
+    std::sync::LazyLock::new(std::collections::hash_map::RandomState::new);
+
+/// A hasher keyed with the per-process random [`HASH_STATE`]. Use this for
+/// any digest returned to Ruby via `#hash`.
+pub(crate) fn seeded_hasher() -> std::collections::hash_map::DefaultHasher {
+    use std::hash::BuildHasher;
+    HASH_STATE.build_hasher()
+}
+
 impl Value {
     pub fn calculate_hash(self, e: &mut Executor, g: &mut Globals) -> Result<u64> {
-        let mut s = std::hash::DefaultHasher::new();
+        let mut s = seeded_hasher();
         RubyHash::ruby_hash(&self, &mut s, e, g)?;
         Ok(s.finish())
+    }
+
+    /// Convert a 64-bit `#hash` digest into a Ruby Integer, folding it
+    /// into Fixnum (i63) range. Ruby-visible hash digests must stay
+    /// Fixnums: CRuby hash values are always Fixnums (a C `long`), and
+    /// `Hash#hash`'s pair mixing reads element digests back with
+    /// `try_fixnum` — a Bignum digest would silently degrade to 0 there.
+    pub(crate) fn from_hash_digest(h: u64) -> Self {
+        Value::integer((h as i64) >> 1)
     }
 }
 

--- a/monoruby/tests/hash_seed.rs
+++ b/monoruby/tests/hash_seed.rs
@@ -1,0 +1,65 @@
+//! Integration coverage for per-process hash-seed randomization
+//! (CVE-2011-4815): Ruby-visible `#hash` digests must differ between
+//! processes (hash-flooding hardening) while staying consistent within
+//! one. Cross-process comparison requires spawning the real binary twice —
+//! the in-process `run_test` harness can only observe a single seed.
+
+use std::process::{Command, Output};
+
+fn monoruby(script: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env_remove("RUBYOPT")
+        .env_remove("RUBYLIB")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .expect("failed to spawn monoruby")
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// One `#hash` digest per line for every class the CVE-2011-4815 specs
+/// cover (small/large Integer, Float, Rational, Complex, String, Symbol,
+/// Array, Hash) plus nil.
+const DIGESTS: &str = r##"[14, 10**30, 3.14, Rational(1, 2), Complex(1, 2),
+ "abc", :a, [1, 2, 3], {a: 1, b: 2}, nil].each { |v| puts v.hash }"##;
+
+#[test]
+fn hash_digests_differ_between_processes() {
+    let a = monoruby(DIGESTS);
+    let b = monoruby(DIGESTS);
+    assert!(a.status.success() && b.status.success());
+    let (a, b) = (stdout(&a), stdout(&b));
+    let pairs: Vec<(&str, &str)> = a.lines().zip(b.lines()).collect();
+    assert_eq!(pairs.len(), 10);
+    // Every single digest must differ — one colliding class would mean its
+    // `#hash` bypasses the seeded hasher (astronomically unlikely to
+    // collide by chance: 10 independent 1-in-2^64 events).
+    for (i, (x, y)) in pairs.iter().enumerate() {
+        assert_ne!(x, y, "digest #{i} identical across processes");
+    }
+}
+
+#[test]
+fn hash_digests_consistent_within_process() {
+    // eql?-equal values must hash equal within one process, including the
+    // heap-allocated representations (Bignum, subnormal Float) that used
+    // to fall back to address-based Kernel#hash.
+    let out = monoruby(
+        r##"checks = {
+             fixnum: 14.hash == (7 + 7).hash,
+             bignum: (10**30).hash == (10**30).hash,
+             heap_float: (1e-320).hash == (1e-320).hash,
+             negative_zero: 0.0.hash == (-0.0).hash,
+             string: "abc".hash == "ab#{:c}".hash,
+             symbol: :a.hash == "a".to_sym.hash,
+             bignum_key: { 10**30 => 1 }[10**30] == 1,
+           }
+           bad = checks.reject { |_, v| v }
+           puts bad.empty? ? "ok" : "failed: #{bad.keys.inspect}""##,
+    );
+    assert_eq!(stdout(&out), "ok\n");
+    assert!(out.status.success());
+}


### PR DESCRIPTION
## Summary

Implements per-process hash seed randomization, fixing the remaining **8 failures** in the ruby/spec **security** category (CVE-2011-4815 hash-flooding specs). Security is now **0 failures / 1 error** (the one error is the deferred BINARY-regexp item). Also fixes a latent Bignum-digest degradation bug and CRuby-incompatible recursive-hash semantics found along the way, improving core/hash (9 → 7 failures) and core/array (20 → 19).

### 1. Per-process seeded hasher (CVE-2011-4815)

All Ruby-visible `#hash` digests are now produced by a SipHash keyed with per-process random state (`std::collections::hash_map::RandomState`, initialized once via `LazyLock`), so digests differ between processes while staying consistent within one. Previously:

- `Value::calculate_hash` used `DefaultHasher::new()` — **fixed keys**, fully deterministic across processes (String/Array/Hash/…).
- Integer (small), Float (flonum), and Symbol had no `#hash` at all and fell back to `Kernel#hash`, which returned the **raw tagged value** (`14.hash == 29` in every process).

`Kernel#hash` now digests the identity through the seeded hasher; `Rational`, `Complex`, `Time`, `Struct`, `Regexp`, and `Set` `#hash` are re-keyed the same way. Internal hash *tables* (rubymap) key their own hashers and are unaffected.

### 2. New value-based `Integer#hash` / `Float#hash`

Equal Bignums (and equal heap-allocated Floats, e.g. subnormals) previously hashed by heap address via `Kernel#hash`, violating the `eql?`/`hash` contract: `(10**30).hash != (10**30).hash`. Both classes now digest the numeric value; Float hashes its canonical bit pattern with ±0.0 normalized (matching `0.0.eql?(-0.0)`).

### 3. Fixnum-safe digests (`Value::from_hash_digest`)

`Hash#hash`'s pair mixing reads element digests back with `try_fixnum().unwrap_or(0)`, but digest constructors (`integer_from_u64`, `Value::integer(u64 as i64)`) produced a **Bignum with ~1/2 probability**, silently degrading that element's contribution to 0 — a pre-existing bug that the fixed seed masked deterministically, and that randomization turned into flaky spec failures. All `#hash` digests are now folded into Fixnum (i63) range via a shared `Value::from_hash_digest` (CRuby hash values are always a C `long` Fixnum).

### 4. Outer-recursion collapse for `Hash#hash` / `Array#hash`

CRuby's `Hash#hash`/`Array#hash` use `rb_exec_recursive_outer`: a cycle detected at *any* depth collapses the *outermost* `#hash` to the sentinel, so `h.hash == {x: h}.hash == {x: {x: h}}.hash` when `h[:x] = h` (required because `h.eql?(x: h)`). monoruby used a plain inner-recursion sentinel, failing those specs. `Hash#hash` now uses `exec_recursive_outer`; `Array#hash` uses a new *unregistered* variant (its id is registered by `ruby_hash` itself), and `ruby_hash`'s recursion arm surfaces the hit to the enclosing outer frame. This fixes the previously-failing core/hash "returns the same hash for recursive hashes" and core/array "returns the same hash for equal recursive arrays through hashes" specs.

## Testing

- `cargo test -p monoruby` (lib + all integration tests): **1838 + 263 passed, 0 failed**.
- New `tests/hash_seed.rs`: cross-process randomization (10 digests, all must differ between two spawned processes) and within-process `eql?`/`hash` contract (Bignum, subnormal Float, ±0.0, symbols, Bignum Hash keys).
- ruby/spec with the release binary:
  - **security: 8 failures + 1 error → 0 failures + 1 error** (remaining error is the deferred BINARY-string regexp item)
  - core/hash: 9 → 7 failures; core/array: 20 → 19 (recursive-hash specs fixed; the rest are pre-existing, unrelated gaps)
  - core/integer, core/float, core/symbol, core/struct, core/method, core/set, core/string/hash_spec, core/time/hash_spec: **all 0 failures / 0 errors**
  - core/proc: unchanged (4 failures / 1 error, parameter-introspection and `to_proc`, unrelated)
- Manual CRuby 4.0.2 differential battery for recursive hashes and hash contracts: all match.

## Deferred

- BINARY (ASCII-8BIT) string regexp matching (1 security error) — needs byte-based Onigmo matching through the `&str`/UTF-8 regexp pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_