### PR TITLE
Fix native builtin frame under-reservation with many keyword names (#920)

### DIFF
--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -306,14 +306,11 @@ mod tests {
     // clobbered the return address (jump to null before the builtin body).
     #[test]
     fn native_kw_frame_offset_covers_reg_num() {
-        extern "C" fn dummy(
-            _: &mut Executor,
-            _: &mut Globals,
-            _: Lfp,
-            _: BytecodePtr,
-        ) -> Option<Value> {
-            None
-        }
+        // Never invoked — only used as a fn pointer to construct the
+        // `FuncInfo`. Kept on one line so the uncovered body is a single
+        // region.
+        #[rustfmt::skip]
+        extern "C" fn dummy(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Option<Value> { None }
         // min=1, max=3, 9 keyword names, kw_rest → reg_num = 1 + 3 + 9 + 1 = 14.
         let info = FuncInfo::new_native(
             FuncId::new(1),

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -298,6 +298,59 @@ mod tests {
         assert_eq!(8, std::mem::size_of::<BytecodePtr>());
         assert_eq!(8, std::mem::size_of::<Meta>());
     }
+
+    // #920: a native func registered with many keyword names must reserve
+    // stack (`ofs`) for the whole callee frame — `reg_num` slots — not just
+    // the positional args. `ofs` derived from `max` (positional only)
+    // under-reserved the frame, so the argument-setup call overran it and
+    // clobbered the return address (jump to null before the builtin body).
+    #[test]
+    fn native_kw_frame_offset_covers_reg_num() {
+        extern "C" fn dummy(
+            _: &mut Executor,
+            _: &mut Globals,
+            _: Lfp,
+            _: BytecodePtr,
+        ) -> Option<Value> {
+            None
+        }
+        // min=1, max=3, 9 keyword names, kw_rest → reg_num = 1 + 3 + 9 + 1 = 14.
+        let info = FuncInfo::new_native(
+            FuncId::new(1),
+            "readlines".to_string(),
+            dummy,
+            1,
+            3,
+            false,
+            &[
+                "chomp",
+                "mode",
+                "encoding",
+                "external_encoding",
+                "internal_encoding",
+                "binmode",
+                "textmode",
+                "autoclose",
+                "open_args",
+            ],
+            true,
+        );
+        let reg_num = info.data.meta.reg_num();
+        assert_eq!(14, reg_num);
+        // `ofs` must be the value derived from `reg_num` (not from `max`,
+        // which would be 3 and under-reserve the frame).
+        let mut expected = FuncData::default();
+        expected.set_offset(reg_num);
+        assert_eq!(expected.ofs, info.data.ofs);
+        // The reserved stack (see `push_stack_offset`: `ofs * 16 + 8`) must
+        // span the whole frame down to the last register slot.
+        let reserved = info.data.ofs as usize * 16 + 8;
+        let needed = reg_num as usize * 8 + (RSP_LOCAL_FRAME + LFP_SELF) as usize;
+        assert!(
+            reserved >= needed,
+            "reserved {reserved} < needed {needed} (reg_num {reg_num})"
+        );
+    }
 }
 
 pub(crate) struct Funcs {
@@ -791,7 +844,19 @@ impl FuncInfo {
             max,
             _padding: 0,
         };
-        data.set_offset(max);
+        // The stack reservation (`ofs`) must cover the *whole* callee
+        // frame — `reg_num` slots — not just the positional args. For a
+        // native func `meta.reg_num` is already final here (it counts
+        // self + positional + keyword names + kw_rest), and unlike an
+        // ISeq it is never re-set later via `set_reg_num`. Deriving `ofs`
+        // from `max` (positional only) under-reserved the frame for a
+        // native registered with many keyword names, so the argument
+        // setup call (`vm_handle_arguments`) overlapped and clobbered the
+        // keyword slots / return address, jumping to a null address
+        // before the builtin body ran (#920). For an ISeq `reg_num` is 0
+        // here and `set_reg_num` recomputes `ofs` after compilation, so
+        // `max` remains the placeholder in that case.
+        data.set_offset(max.max(meta.reg_num()));
         Self {
             data,
             kind,


### PR DESCRIPTION
Fixes #920.

## Problem

A builtin registered via `define_builtin_*_with_kw` with a large keyword list segfaults **before its body runs** — the generated call sequence jumps to a null address. Per the issue's repro, registering `IO.readlines` with 9 keyword names + `kw_rest` (frame = `1 self + 3 positional + 9 kw + 1 kw_rest = 14` slots) crashes on `IO.readlines("Cargo.toml")`. Short keyword lists (the in-tree max of 3 names) work, which is why it stayed hidden.

## Root cause

`FuncInfo::new_with_effect` derived the callee-frame stack reservation `ofs` from **`max`** (positional args only):

```rust
let max = params.max_positional_args() as u16;   // 3 for readlines
data.set_offset(max);                            // ignores keyword/kw_rest slots
```

But `meta.reg_num` already counts self + positional + keyword names + kw_rest (14). A native func never re-runs `set_reg_num` (unlike an ISeq, whose `ofs` is recomputed after bytecode compilation), so `ofs` stayed sized for the positional args alone.

`push_stack_offset` reserves `ofs * 16 + 8` bytes before the argument-setup call. With `ofs` derived from `max=3` it reserved ~120 bytes, but the 14-slot frame spans ~216 bytes. The C call `vm_handle_arguments` then overlapped and clobbered the keyword slots and the return address, returning to a null address. With ≤3 keyword names the frame happened to fit within the reservation's slack.

## Fix

Reserve for the whole frame:

```rust
data.set_offset(max.max(meta.reg_num()));
```

For a native func `reg_num` is final at construction; for an ISeq it is `0` here and `set_reg_num` recomputes `ofs` after compilation, so `max` stays the placeholder there — no change for ISeqs. The fix is in the arch-neutral `FuncData`, so both x86-64 and aarch64 benefit.

## Verification

- Applied the issue's exact 9-keyword `IO.readlines` registration and confirmed the crash, then confirmed the fix eliminates it — in the VM path, with keywords actually passed, with unknown keywords falling into `kw_rest`, JIT-warmed (30×), and in release. (The temporary registration change was reverted; `IO.readlines` keeps its shipped `&[]` interface.)
- Added a regression unit test (`native_kw_frame_offset_covers_reg_num`) asserting `ofs` is derived from `reg_num` (= 14), not `max` (= 3), and that the reservation spans the whole frame. It fails against the old `set_offset(max)`.
- Full `cargo test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_