### PR TITLE
Tier 1 fixes: Array#fill/#cycle validation, Hash.new(capacity:), slice_before size

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -207,6 +207,7 @@ class Array
       unless no_n || n.nil? || n.is_a?(Integer)
         raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
         n = n.to_int
+        raise TypeError, "can't convert to Integer" unless n.is_a?(Integer)
       end
       # Size hint:
       #   * empty array            -> 0
@@ -236,6 +237,7 @@ class Array
       unless n.is_a?(Integer)
         raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
         n = n.to_int
+        raise TypeError, "can't convert to Integer" unless n.is_a?(Integer)
       end
       n.times do
         each { |x| yield x }

--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -1059,7 +1059,11 @@ module Enumerable
       end
     end
     res << current if current
-    res.each
+    # `slice_before` always returns an Enumerator whose `size` is nil
+    # (the chunk count is not derivable from the source size). `res.each`
+    # would report `res.size`, so wrap the chunks in an `Enumerator.new`,
+    # which reports a nil size.
+    ::Enumerator.new { |y| res.each { |chunk| y << chunk } }
   end
 
   # Mirror of `slice_before`: the boundary fires *after* an element

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1334,6 +1334,11 @@ fn fill(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 
     if let Some(bh) = lfp.block() {
         // Block form: fill {}, fill(start) {}, fill(start, length) {}, fill(range) {}
+        // The value comes from the block, so at most two positional args
+        // (start, length) are allowed — a third is an ArgumentError.
+        if lfp.try_arg(2).is_some() {
+            return Err(MonorubyErr::wrong_number_of_arg_range(3, 0..=2));
+        }
         let data = vm.get_block_data(globals, bh)?;
         let (start, end_idx) = if let Some(arg0) = lfp.try_arg(0) {
             if let Some(range) = arg0.is_range() {
@@ -1385,7 +1390,10 @@ fn fill(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             return Err(MonorubyErr::wrong_number_of_arg_range(0, 1..=3));
         };
         if let Some(arg1) = lfp.try_arg(1) {
-            if let Some(range) = arg1.is_range() {
+            // The range form is `fill(val, range)` only — with a third
+            // (length) argument, `arg1` is a start index, so a Range there
+            // is a TypeError (Range has no `#to_int`), matching CRuby.
+            if let Some(range) = arg1.is_range().filter(|_| lfp.try_arg(2).is_none()) {
                 // fill(val, range) -> self
                 let (start, end_idx) = fill_range_indices(vm, globals, &ary, range)?;
                 if end_idx > ary.len() {
@@ -1395,43 +1403,42 @@ fn fill(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                     ary[i] = val;
                 }
             } else {
-                // fill(val, start, length = nil) -> self
-                let start = arg1.coerce_to_int_i64(vm, globals)?;
+                // fill(val, start, length = nil) -> self.
+                // A `nil` start means 0 (CRuby coerces nil to 0 here,
+                // rather than raising as `Integer(nil)` would).
+                let start = if arg1.is_nil() {
+                    0i64
+                } else {
+                    arg1.coerce_to_int_i64(vm, globals)?
+                };
                 let start = if start < 0 {
                     let s = ary.len() as i64 + start;
                     if s < 0 { 0i64 } else { s }
                 } else {
                     start
                 } as usize;
-                if let Some(len_val) = lfp.try_arg(2) {
-                    if len_val.is_nil() {
-                        // nil length means fill to end
-                        if start > ary.len() {
-                            fill_resize(&mut ary, start)?;
-                        }
-                        let len = ary.len();
-                        for i in start..len {
-                            ary[i] = val;
-                        }
-                    } else {
-                        let len = len_val.coerce_to_int_i64(vm, globals)?;
-                        if len <= 0 {
-                            return Ok(ary.into());
-                        }
-                        let end_idx = start
-                            .checked_add(len as usize)
-                            .ok_or_else(|| MonorubyErr::argumenterr("argument too big"))?;
-                        if end_idx > ary.len() {
-                            fill_resize(&mut ary, end_idx)?;
-                        }
-                        for i in start..end_idx {
-                            ary[i] = val;
-                        }
+                // Only an *explicit* length extends the array; the
+                // start-only and `nil`-length forms fill existing elements
+                // from `start` to the end and never grow it (so a `start`
+                // past the end is a no-op). `start..len` is an empty range
+                // when `start >= len`, so no bounds check is needed.
+                if let Some(len_val) = lfp.try_arg(2)
+                    && !len_val.is_nil()
+                {
+                    let len = len_val.coerce_to_int_i64(vm, globals)?;
+                    if len <= 0 {
+                        return Ok(ary.into());
+                    }
+                    let end_idx = start
+                        .checked_add(len as usize)
+                        .ok_or_else(|| MonorubyErr::argumenterr("argument too big"))?;
+                    if end_idx > ary.len() {
+                        fill_resize(&mut ary, end_idx)?;
+                    }
+                    for i in start..end_idx {
+                        ary[i] = val;
                     }
                 } else {
-                    if start > ary.len() {
-                        fill_resize(&mut ary, start)?;
-                    }
                     let len = ary.len();
                     for i in start..len {
                         ary[i] = val;
@@ -6097,6 +6104,46 @@ mod tests {
             "[].cycle(2).size",
         ]);
         run_test_no_result_check("[1, 2].cycle.size");
+        // A `to_int` that returns a non-Integer is a TypeError, not a
+        // downstream NoMethodError.
+        run_test(
+            r#"
+            o = Object.new
+            def o.to_int; "2"; end
+            begin; [1, 2].cycle(o) { |x| }; rescue TypeError; :type_error; end
+            "#,
+        );
+    }
+
+    #[test]
+    fn fill_start_length_edge_cases() {
+        run_tests(&[
+            // No length / nil length never grows the array; a start past
+            // the end is a no-op (only an explicit length extends).
+            r#"[].fill("a", 1)"#,
+            r#"[1, 2, 3].fill("x", 5)"#,
+            r#"[1, 2, 3].fill("x", 5, nil)"#,
+            r#"[].fill("a", 1, nil)"#,
+            r#"[].fill("a", 1, 2)"#,
+            // nil start means 0.
+            r#"[1, 2, 3].fill("y", nil)"#,
+            // A block with three positional args is an ArgumentError.
+            r#"begin; [1, 2].fill(1, 2, 3) { |i| i }; rescue ArgumentError; :ae; end"#,
+            // A Range start plus a length argument is a TypeError.
+            r#"begin; [1, 2, 3].fill("x", 1..2, 5); rescue TypeError; :te; end"#,
+        ]);
+    }
+
+    #[test]
+    fn slice_before_enumerator_size_is_nil() {
+        // The chunk count isn't derivable from the source size, so the
+        // returned Enumerator reports a nil size (CRuby parity); the
+        // chunks themselves are still produced.
+        run_tests(&[
+            "[1, 2, 3].slice_before(2).size.inspect",
+            "[1, 2, 3, 4].slice_before { |x| x.even? }.to_a",
+            "[1, 2, 3].slice_before(2).to_a",
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -8,8 +8,24 @@ use jitgen::{AbstractState, JitContext};
 
 pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_under_obj("Hash", HASH_CLASS, ObjTy::HASH);
-    let hash_meta = globals.store.get_metaclass(HASH_CLASS).id();
-    globals.define_builtin_funcs_with_effect(hash_meta, "new", &[], new, 0, 0, true, Effect::CAPTURE);
+    // `Hash.new(ifnone = nil, capacity: nil)` / `Hash.new { … }`. The
+    // Ruby 3.4+ `capacity:` keyword is accepted (and ignored — monoruby's
+    // Hash has no pre-sizing); `kw_rest = false` makes any *other* keyword
+    // an ArgumentError. Positional args stay a `rest` so they are
+    // forwarded verbatim to `#initialize` — a `Hash` subclass may override
+    // `initialize` to take any arity, and the plain-`Hash` arity check
+    // (0..1) lives there. (The previous `Effect::CAPTURE` flag was never
+    // consumed anywhere, so dropping it changes no behavior.)
+    globals.define_builtin_class_func_with_kw(
+        HASH_CLASS,
+        "new",
+        new,
+        0,
+        0,
+        true,
+        &["capacity"],
+        false,
+    );
     globals.store[HASH_CLASS].set_alloc_func(hash_alloc_func);
     globals.define_builtin_class_func_rest(HASH_CLASS, "[]", hash_bracket);
     globals.define_builtin_class_func(HASH_CLASS, "try_convert", try_convert, 1);
@@ -150,6 +166,10 @@ pub(super) fn init(globals: &mut Globals) {
 fn new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class = lfp.self_val().as_class_id();
     let obj = Value::hash_with_class_and_default(class, Value::nil());
+    // Forward the positional args verbatim to `#initialize` (arity is
+    // validated there, so a subclass can override it). The `capacity:`
+    // keyword is bound by the registration and ignored; unknown keywords
+    // are already rejected before we get here.
     vm.invoke_method_inner(
         globals,
         IdentId::INITIALIZE,
@@ -3636,6 +3656,23 @@ mod tests {
         run_test_error("Hash.new(5) { 0 }");
         // More than one positional: ArgumentError
         run_test_error("Hash.new(5, 6)");
+    }
+
+    #[test]
+    fn hash_new_capacity_keyword() {
+        run_tests(&[
+            // `capacity:` (Ruby 3.4+) is accepted and ignored.
+            "Hash.new(capacity: 42).default.inspect",
+            "Hash.new(5, capacity: 42).default",
+            "(Hash.new(capacity: 42) { 1 }).default_proc.is_a?(Proc)",
+            "Hash.new(capacity: -42).default.inspect",
+            // A braced Hash stays a positional default, not keywords.
+            "Hash.new({ foo: 1 }).default",
+        ]);
+        // Any other keyword is an ArgumentError.
+        run_test_error("Hash.new(unknown: true)");
+        run_test_error("Hash.new(1, unknown: true)");
+        run_test_error("Hash.new(unknown: true) { 0 }");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tier 1 batch (part 2) from the core/array·regexp·enumerable·hash failure analysis — a set of small correctness fixes.

- **`Array#fill`** — with a block, a third positional argument now raises `ArgumentError` (the value comes from the block). A `Range` start combined with a length argument raises `TypeError`. A `nil` start means `0`. The start-only and `nil`-length forms fill existing elements from `start` to the end **without growing** the array (a start past the end is a no-op); only an *explicit* length extends it.
- **`Array#cycle`** — a `#to_int` that returns a non-Integer now raises `TypeError` instead of a downstream `NoMethodError`.
- **`Hash.new`** — accept the Ruby 3.4+ `capacity:` keyword (ignored — monoruby's Hash has no pre-sizing) and reject any other keyword with `ArgumentError`, via `kw_names=["capacity"], kw_rest=false`. Positional args stay a `rest` forwarded verbatim to `#initialize`, so a `Hash` subclass overriding `initialize` still works and the plain-`Hash` arity check stays there. (Drops the never-consumed `Effect::CAPTURE` flag — verified it is read nowhere.)
- **`Enumerable#slice_before`** — return an `Enumerator` whose `size` is `nil` (the chunk count isn't derivable from the source size) instead of `res.each`, whose size is the chunk count.

## Verification

- ruby/spec: `core/array` **19F/8E → 16F/6E**, `core/hash` **7F/3E → 6F/2E**, `core/enumerable` **6F → 4F** (9 examples fixed).
- Added unit tests `fill_start_length_edge_cases`, `slice_before_enumerator_size_is_nil`, `hash_new_capacity_keyword`, and extended `cycle_to_int_and_size`. Full `cargo test` green (including the `hash_initialize_subclass_args` forwarding case).

All fixes are arch-neutral. Deferred to a possible follow-up (they need deeper changes): `Enumerable#grep_v` setting `$~` in the block (caller-binding `$~` propagation) and the `given block not used` warning `file:line` prefix for `Array.new`/`inject` (Rust-side caller-location formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_