### PR TITLE
Array#pack: fix H/h, X*, w Bignum, u line length, and :buffer offset

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5491,6 +5491,55 @@ mod tests {
     }
 
     #[test]
+    fn pack_hex_alpha_and_x_star() {
+        run_tests(&[
+            // H/h: an ASCII letter contributes `(c + 9) & 0x0F`, so a
+            // non-hex letter like 'H' (⇒ 1) wraps like a-f/A-F do.
+            r#"["H"].pack("H")"#,
+            r#"["H"].pack("h")"#,
+            r#"["z"].pack("H")"#,
+            r#"["G"].pack("h")"#,
+            // Non-letters keep using their low nibble.
+            r#"[":"].pack("H")"#,
+            r#"["^"].pack("H")"#,
+            // `X*` is a no-op; `X`/`Xn` remove bytes.
+            r#"[1, 2, 3].pack("C2X*C")"#,
+            r#"[1, 2, 3].pack("C3X")"#,
+            r#"[1, 2, 3].pack("C3X2")"#,
+        ]);
+    }
+
+    #[test]
+    fn pack_w_bignum_and_u_line_length() {
+        run_tests(&[
+            // `w` (BER) handles Bignums, not just longs.
+            r#"[2 ** 65].pack("w").bytes"#,
+            r#"[0].pack("w").bytes"#,
+            r#"[9999].pack("w").bytes"#,
+            r#"[2 ** 128 + 12345].pack("w").bytes"#,
+            // `u` per-line byte count floors to a multiple of 3.
+            r#"["abcdefghijklm"].pack("u7")"#,
+            r#"["abcdefghijklmnop"].pack("u5")"#,
+            r#"["abcdefghijklmnop"].pack("u9")"#,
+        ]);
+    }
+
+    #[test]
+    fn pack_buffer_offset_and_type() {
+        run_tests(&[
+            // The buffer seeds the output; `@` rewinds within it.
+            r#"[65, 66, 67].pack("@3ccc", buffer: "123456".dup)"#,
+            r#"[65, 66, 67].pack("@6ccc", buffer: "123".dup)"#,
+            r#"[65, 66, 67].pack("@3ccc", buffer: "1234567890".dup)"#,
+            r#"[65, 66, 67].pack("ccc", buffer: "123".dup)"#,
+            // Returns the same buffer object.
+            r#"b = +"x"; [65].pack("C", buffer: b).equal?(b)"#,
+            // A non-String buffer is a TypeError with CRuby's message.
+            r#"begin; [1].pack("C", buffer: []); rescue TypeError => e; e.message; end"#,
+        ]);
+    }
+
+    #[test]
     fn pack_base64_uuencode_nil_raises() {
         // `m` and `u` reject nil with TypeError (used to silently
         // treat nil as "").

--- a/monoruby/src/value/rvalue/string/pack.rs
+++ b/monoruby/src/value/rvalue/string/pack.rs
@@ -554,18 +554,23 @@ pub(crate) fn pack(
     buffer: Option<Value>,
 ) -> Result<Value> {
     let template = parse_template(template, false)?;
-    // Validate buffer: keyword if provided.
+    // Validate the `buffer:` keyword and seed the output with its current
+    // bytes: pack writes *into* the buffer (appending at the end, or
+    // overwriting from an `@` offset), then the buffer's whole content
+    // becomes the result.
+    let mut packed = Vec::new();
     if let Some(buf_val) = buffer {
         buf_val.ensure_not_frozen(&globals.store)?;
-        if buf_val.is_rstring_inner().is_none() {
-            return Err(MonorubyErr::no_implicit_conversion(
-                globals,
-                buf_val,
-                STRING_CLASS,
-            ));
+        match buf_val.is_rstring_inner() {
+            Some(inner) => packed.extend_from_slice(inner.as_bytes()),
+            None => {
+                return Err(MonorubyErr::typeerr(format!(
+                    "buffer must be String, not {}",
+                    buf_val.get_real_class_name(&globals.store)
+                )));
+            }
         }
     }
-    let mut packed = Vec::new();
     let template_is_empty = template.is_empty();
     let mut iter = ary.iter();
 
@@ -728,10 +733,14 @@ pub(crate) fn pack(
                 }
             }
             Template::Back => {
-                let count = repeat.unwrap_or(1);
-                for _ in 0..count {
-                    if packed.pop().is_none() {
-                        return Err(MonorubyErr::argumenterr("X outside of string"));
+                // `X*` (`repeat == None`) is a no-op in CRuby, unlike other
+                // directives where `*` means "all"; only `X`/`Xn` (a count)
+                // removes bytes.
+                if let Some(count) = repeat {
+                    for _ in 0..count {
+                        if packed.pop().is_none() {
+                            return Err(MonorubyErr::argumenterr("X outside of string"));
+                        }
                     }
                 }
             }
@@ -760,16 +769,17 @@ pub(crate) fn pack(
                     let mut nibble_i = 0;
                     for i in 0..count {
                         let nibble = if i < s.len() {
-                            match s[i] {
-                                b'0'..=b'9' => s[i] - b'0',
-                                b'a'..=b'f' => s[i] - b'a' + 10,
-                                b'A'..=b'F' => s[i] - b'A' + 10,
-                                // CRuby: non-hex chars contribute
-                                // their low nibble (`s[i] & 0x0F`),
-                                // not zero. e.g. `["^"].pack("H")`
-                                // ⇒ `"\xE0"` (`^` is 0x5E, low
-                                // nibble 0xE).
-                                b => b & 0x0F,
+                            // CRuby (pack.c): an ASCII letter contributes
+                            // `(c + 9) & 0x0F` — so the hex digits a-f/A-F
+                            // map to 10-15, and any other letter (g-z, G-Z,
+                            // e.g. `H` ⇒ 1) wraps the same way. Every
+                            // non-letter (digits and punctuation) uses its
+                            // low nibble `c & 0x0F` directly.
+                            let c = s[i];
+                            if c.is_ascii_alphabetic() {
+                                c.wrapping_add(9) & 0x0F
+                            } else {
+                                c & 0x0F
                             }
                         } else {
                             0
@@ -990,30 +1000,18 @@ pub(crate) fn pack(
                 text_encoding = promote_text(text_encoding, Encoding::Utf8);
             }
             Template::BerCompressedInt => {
-                // 'w' — BER compressed integer
+                // 'w' — BER compressed integer (handles Bignums too).
                 if let Some(count) = repeat {
                     for _ in 0..count {
                         if let Some(value) = iter.next() {
-                            let i = value.coerce_to_int_i64(vm, globals)?;
-                            if i < 0 {
-                                return Err(MonorubyErr::argumenterr(
-                                    "can't compress negative numbers",
-                                ));
-                            }
-                            ber_encode(&mut packed, i as u64);
+                            ber_encode_value(&mut packed, vm, globals, *value)?;
                         } else {
                             return Err(MonorubyErr::argumenterr("too few arguments"));
                         }
                     }
                 } else {
                     while let Some(value) = iter.next() {
-                        let i = value.coerce_to_int_i64(vm, globals)?;
-                        if i < 0 {
-                            return Err(MonorubyErr::argumenterr(
-                                "can't compress negative numbers",
-                            ));
-                        }
-                        ber_encode(&mut packed, i as u64);
+                        ber_encode_value(&mut packed, vm, globals, *value)?;
                     }
                 }
             }
@@ -1101,10 +1099,16 @@ pub(crate) fn pack(
         };
     }
     if let Some(mut buf_val) = buffer {
-        // Append the packed data to the provided buffer string.
+        // `packed` was seeded with the buffer's original bytes and then
+        // written into (possibly rewound by `@`), so it is the full
+        // desired content. Write it back in place, preserving the buffer's
+        // identity and encoding.
+        let enc = buf_val.as_rstring_inner().encoding();
+        let orig_len = buf_val.as_rstring_inner().len();
+        let repl = RStringInner::from_encoding_scanned(&packed, enc);
         buf_val
             .as_rstring_inner_mut()
-            .extend_from_slice_checked(&packed)?;
+            .bytesplice_with(0, orig_len, &repl, &globals.store)?;
         Ok(buf_val)
     } else if template_is_empty && packed.is_empty() {
         // Empty format string produces US-ASCII encoded empty string.
@@ -1591,7 +1595,14 @@ fn hex_val(c: u8) -> Option<u8> {
 
 fn uu_encode(data: &[u8], line_len: usize) -> String {
     let mut result = String::new();
-    let bytes_per_line = if line_len == 0 { 45 } else { line_len.min(45) };
+    // uuencode emits 4 output chars per 3 input bytes, so the per-line
+    // input count is floored to a multiple of 3 (CRuby: `u7` ⇒ 6 bytes
+    // per line, `u5` ⇒ 3). A count of 0 means the default 45.
+    let bytes_per_line = if line_len == 0 {
+        45
+    } else {
+        (line_len.min(45) / 3) * 3
+    };
 
     for chunk in data.chunks(bytes_per_line) {
         // length byte
@@ -1787,6 +1798,47 @@ fn unpack_sleb128(b: &mut ByteIter) -> SlebOutcome {
 }
 
 // --- BER compressed integer encoding/decoding ---
+
+/// BER-compress one `w` argument. Uses the arbitrary-precision path for a
+/// Bignum (which doesn't fit a `u64`); otherwise coerces via `#to_int`.
+fn ber_encode_value(
+    buf: &mut Vec<u8>,
+    vm: &mut Executor,
+    globals: &mut Globals,
+    value: Value,
+) -> Result<()> {
+    if let RV::BigInt(big) = value.unpack() {
+        use num::Signed;
+        if big.is_negative() {
+            return Err(MonorubyErr::argumenterr("can't compress negative numbers"));
+        }
+        ber_encode_bigint(buf, big);
+    } else {
+        let i = value.coerce_to_int_i64(vm, globals)?;
+        if i < 0 {
+            return Err(MonorubyErr::argumenterr("can't compress negative numbers"));
+        }
+        ber_encode(buf, i as u64);
+    }
+    Ok(())
+}
+
+/// BER-compress a non-negative arbitrary-precision integer: base-128,
+/// big-endian, with the high bit set on every group but the last.
+fn ber_encode_bigint(buf: &mut Vec<u8>, val: &num::BigInt) {
+    use num::{ToPrimitive, Zero};
+    let mask = num::BigInt::from(0x7Fu8);
+    let mut v = val.clone();
+    let mut tmp = Vec::new();
+    tmp.push((&v & &mask).to_u8().unwrap());
+    v >>= 7u32;
+    while !v.is_zero() {
+        tmp.push((&v & &mask).to_u8().unwrap() | 0x80);
+        v >>= 7u32;
+    }
+    tmp.reverse();
+    buf.extend_from_slice(&tmp);
+}
 
 fn ber_encode(buf: &mut Vec<u8>, mut val: u64) {
     if val == 0 {


### PR DESCRIPTION
## Summary

Tier 2 batch (Array#pack). Fixes all remaining `Array#pack` failures from the core/array analysis — 9 examples.

- **H/h** — an ASCII letter now contributes `(c + 9) & 0x0F` (CRuby's rule), so hex digits `a-f`/`A-F` still map to 10–15 and any other letter wraps the same way (`["H"].pack("H") == "\x10"`, not `"\x80"`). Non-letters keep their low nibble.
- **X\*** — `X*` is now a no-op (in CRuby, unlike other directives where `*` means "all"); only `X`/`Xn` remove bytes.
- **w** — BER compression handles Bignums (base-128, arbitrary precision) instead of raising `RangeError` when the value exceeds a C `long`.
- **u** — the per-line byte count floors to a multiple of 3 (`u7` ⇒ 6 bytes/line), since uuencode emits 4 output chars per 3 input bytes.
- **:buffer** — the buffer now **seeds** the packed output, so `@` offsets rewind within the existing content and the whole result is written back in place (preserving the buffer's identity). A non-String buffer raises `TypeError: buffer must be String, not X`.

## Verification

- ruby/spec `core/array/pack`: **9 failures/errors → 0**.
- Added unit tests `pack_hex_alpha_and_x_star`, `pack_w_bignum_and_u_line_length`, `pack_buffer_offset_and_type`; full `cargo test` green.

All fixes are arch-neutral (in the shared `pack.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_