### PR TITLE
Hash#transform_keys! key-conflict/break, and Hash#== compare_by_identity

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -87,16 +87,25 @@ class Hash
   def transform_keys!(hash = nil, &block)
     return to_enum(:transform_keys!) { size } unless block || hash
     raise FrozenError.new("can't modify frozen Hash: #{inspect}", receiver: self) if frozen?
-    if hash
-      keys.each do |k|
-        if hash.key?(k)
-          self[hash[k]] = delete(k)
-        elsif block
-          self[block.call(k)] = delete(k)
-        end
+    # Snapshot the original pairs up front so a new key that collides with
+    # a not-yet-processed original key can't corrupt its value, and track
+    # the keys we produce so we never delete one we just created (e.g.
+    # `{a:1,b:2}.transform_keys!(&:succ)` must not let `a`→`b` clobber the
+    # original `b`). A `break` in the block exits mid-loop, leaving the
+    # partial in-place result — matching CRuby.
+    new_keys = {}
+    new_keys.compare_by_identity if compare_by_identity?
+    to_a.each do |k, v|
+      nk = if hash&.key?(k)
+        hash[k]
+      elsif block
+        block.call(k)
+      else
+        k
       end
-    else
-      keys.each { |k| self[block.call(k)] = delete(k) }
+      delete(k) unless new_keys.key?(k)
+      self[nk] = v
+      new_keys[nk] = true
     end
     self
   end

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -594,6 +594,12 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     if lhs.len() != rhs.len() {
         return Ok(Value::bool(false));
     }
+    // Two *non-empty* hashes that differ only in `compare_by_identity` are
+    // not equal (their key-equality semantics differ). Two empty hashes
+    // are equal regardless of the flag, matching CRuby.
+    if lhs.len() != 0 && lhs.is_compare_by_identity() != rhs.is_compare_by_identity() {
+        return Ok(Value::bool(false));
+    }
     crate::value::exec_recursive_paired(self_val.id(), rhs_v.id(), || {
         for (k, lhs_value) in lhs.iter() {
             if let Some(rhs_value) = rhs.get(k, vm, globals)?
@@ -627,6 +633,12 @@ fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         return Ok(Value::bool(false));
     };
     if lhs.len() != rhs.len() {
+        return Ok(Value::bool(false));
+    }
+    // Two *non-empty* hashes that differ only in `compare_by_identity` are
+    // not equal (their key-equality semantics differ). Two empty hashes
+    // are equal regardless of the flag, matching CRuby.
+    if lhs.len() != 0 && lhs.is_compare_by_identity() != rhs.is_compare_by_identity() {
         return Ok(Value::bool(false));
     }
     let eql_id = IdentId::EQL_;
@@ -3986,6 +3998,35 @@ mod tests {
             r#"{1.0 => "x"}.eql?({1.0 => "x"})"#,
             // Equal values via `eql?` semantics.
             r#"{1 => "a"}.eql?({1 => "a"})"#,
+        ]);
+    }
+
+    #[test]
+    fn hash_eq_compare_by_identity_flag() {
+        run_tests(&[
+            // Non-empty hashes differing only in compare_by_identity are
+            // not equal; two empty hashes are equal regardless.
+            r#"{1 => 2} == {1 => 2}.compare_by_identity"#,
+            r#"{1 => 2}.compare_by_identity == {1 => 2}"#,
+            r#"{1 => 2}.eql?({1 => 2}.compare_by_identity)"#,
+            r#"{}.compare_by_identity == {}"#,
+            r#"({} == {}.compare_by_identity)"#,
+            r#"{1 => 2}.compare_by_identity == {1 => 2}.compare_by_identity"#,
+        ]);
+    }
+
+    #[test]
+    fn hash_transform_keys_bang_conflicts_and_break() {
+        run_tests(&[
+            // New keys that collide with not-yet-processed original keys
+            // must not corrupt them, and the produced keys aren't deleted.
+            r#"{a: 1, b: 2, c: 3, d: 4}.transform_keys!(&:succ)"#,
+            r#"{a: 1, b: 2}.transform_keys!({a: :x})"#,
+            r#"{a: 1, b: 2}.transform_keys!({a: :b})"#,
+            // A break leaves the partial in-place result.
+            r#"h = {a: 1, b: 2, c: 3, d: 4}; h.transform_keys! { |k| break if k == :c; k.succ }; h"#,
+            // Enumerator when neither a block nor a hash is given.
+            r#"{a: 1}.transform_keys!.class.name"#,
         ]);
     }
 


### PR DESCRIPTION
## Summary

Tier 2 batch (Hash correctness).

- **`Hash#transform_keys!`** — computing a new key that collided with a not-yet-processed original key corrupted its value: `{a:1,b:2,c:3,d:4}.transform_keys!(&:succ)` returned `{e:1}` instead of `{b:1,c:2,d:3,e:4}`. Rewritten to snapshot the original pairs up front (so values aren't re-read from an already-mutated hash) and to track the keys it produces, so a freshly-created key is never deleted when its name later comes up as an original key. A `break` in the block still leaves the partial in-place result, matching CRuby.
- **`Hash#==` / `#eql?`** — two *non-empty* hashes that differ only in `compare_by_identity` are no longer considered equal (their key-equality semantics differ); two **empty** hashes stay equal regardless of the flag.

## Verification

- ruby/spec `core/hash`: `transform_keys_spec.rb` and `compare_by_identity_spec.rb` now pass — **4 examples fixed**.
- Added unit tests `hash_transform_keys_bang_conflicts_and_break` and `hash_eq_compare_by_identity_flag`; full `cargo test` green.

Deferred (need deeper iteration-safety work, with a perf trade-off): `Hash#delete`/`#shift` while iterating a big hash — monoruby's `each` isn't delete-safe (a live-map deletion skips the next entry) and `shift` is blocked by the iteration guard. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_