### PR TITLE
Array#<=>: return the raw element comparison result

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1097,12 +1097,15 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         || {
             for (i, lhs) in lhs.iter().enumerate() {
                 if let Some(rhs) = rhs.get(i) {
-                    match vm.compare_values_inner(globals, *lhs, *rhs)? {
-                        Some(res) if res != Ordering::Equal => {
-                            return Ok(Value::integer(res as i64));
-                        }
-                        Some(_) => {} // Equal, continue
-                        None => return Ok(Value::nil()),
+                    // Compare each pair with the element's own `<=>` and
+                    // return the *raw* result of the first pair that isn't
+                    // exactly the Fixnum `0` — CRuby returns whatever the
+                    // element comparison produced (`nil`, `±1`, or even a
+                    // non-Integer like a String), not a normalized value.
+                    let res =
+                        vm.invoke_method_inner(globals, IdentId::_CMP, *lhs, &[*rhs], None, None)?;
+                    if res.try_fixnum() != Some(0) {
+                        return Ok(res);
                     }
                 } else {
                     return Ok(Value::integer(Ordering::Greater as i64));
@@ -6267,6 +6270,25 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn cmp_returns_raw_element_result() {
+        run_tests(&[
+            r#"[1, 2, 3] <=> [1, 2, 3]"#,
+            r#"[1, 2, 3] <=> [1, 2, 4]"#,
+            r#"[1, 2, 3] <=> [1, 2]"#,
+            r#"[1, 2] <=> [1, 2, 3]"#,
+            // The first non-zero element `<=>` result is returned raw —
+            // including `nil` and non-Integer values — and later elements
+            // are not compared.
+            r#"a = Object.new; def a.<=>(o); "foobar"; end; [1, a, 1] <=> [1, a, 1]"#,
+            r#"a = Object.new; def a.<=>(o); nil; end; ([1, a] <=> [1, a]).inspect"#,
+            r#"a = Object.new; def a.<=>(o); 1; end; [a] <=> [a]"#,
+            // A non-Array, non-coercible rhs is nil.
+            r#"([1, 2] <=> 5).inspect"#,
+        ]);
+    }
+
     #[test]
     fn subclass_return_types() {
         run_test_with_prelude("C[1,2,3].sort.class", "class C < Array; end");


### PR DESCRIPTION
## Summary

Tier 2 (Array coercion). Fixes `core/array/comparison_spec.rb`.

CRuby's `Array#<=>` compares element by element with each element's own `<=>` and returns the result of the first pair that isn't exactly the Fixnum `0` — **verbatim**. monoruby routed each pair through `compare_values_inner`, which normalizes to an `Ordering`/`nil`, so a non-Integer element result (e.g. a mock returning `"foobar"`) collapsed to `nil` instead of being returned as-is, and a `nil` result was indistinguishable from a non-comparable one.

The fix invokes `<=>` on each element pair directly and returns the raw value of the first non-`0` comparison (`nil`, `±1`, or any object), leaving later elements uncompared. Length comparison and the argument's `to_ary` coercion are unchanged.

## Verification

- ruby/spec `core/array/comparison_spec.rb`: **1 failure → 0** ("calls `<=>` left to right and return first non-0 result").
- Added unit test `cmp_returns_raw_element_result`; full `cargo test` green.

Remaining Array-coercion items for follow-up: `Array#flatten`/`#product` calling `#to_ary` via `method_missing`, and `Array#hash` calling `#to_int` on each element's `#hash` result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_