### PR TITLE
Test harness: reconstruct non-finite Floats from CRuby output (#930)

### DIFF
--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -317,3 +317,23 @@ fn find_ruby() -> String {
     }
     "ruby".to_string() // last resort — will fail with a clear error message
 }
+
+#[cfg(test)]
+mod harness_tests {
+    use super::*;
+
+    #[test]
+    fn nonfinite_floats_reconstruct() {
+        // issue #930: CRuby's `p` prints non-finite Floats as the bare
+        // words Infinity / -Infinity / NaN; reconstructing the expected
+        // value from that output used to panic on the unresolved
+        // "constant" instead of comparing.
+        run_test_once(r#"[1.0, 1.0 / 0.0]"#);
+        run_test_once(r#"[1.0, -1.0 / 0.0]"#);
+        run_test_once(r#"[1.0, 0.0 / 0.0]"#);
+        run_test_once(r#"[Float::INFINITY, -Float::INFINITY]"#);
+        run_test_once(r#"{ a: 1.0 / 0.0, b: -1.0 / 0.0 }"#);
+        run_test_once(r#"(1.0 / 0.0)..(1.0 / 0.0)"#);
+        run_test_once(r#"[[Float::INFINITY], { x: -Float::INFINITY }]"#);
+    }
+}

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -531,6 +531,15 @@ impl Value {
         if lhs == rhs {
             return;
         }
+        // NaNs of any sign/payload count as equal for assertion purposes:
+        // e.g. x86's 0.0/0.0 yields a negative quiet NaN while a
+        // reconstructed f64::NAN is positive, so bit comparison misses.
+        if let (RV::Float(a), RV::Float(b)) = (lhs.unpack(), rhs.unpack())
+            && a.is_nan()
+            && b.is_nan()
+        {
+            return;
+        }
         match (lhs.try_rvalue(), rhs.try_rvalue()) {
             (Some(lhs), Some(rhs)) => {
                 if RValue::eq(store, lhs, rhs) {
@@ -2978,10 +2987,25 @@ impl Value {
                 assert_eq!(false, *toplevel);
                 assert_eq!(None, *parent);
                 if prefix.len() == 0 {
+                    // CRuby's `p` prints non-finite Floats as the bare
+                    // words `Infinity` / `NaN` (and `-Infinity`, which
+                    // arrives as UnOp(Neg, Const("Infinity"))). They are
+                    // not constants — map them to the float values when
+                    // reconstructing the expected result (issue #930).
+                    match name.as_str() {
+                        "Infinity" => return Value::float(f64::INFINITY),
+                        "NaN" => return Value::float(f64::NAN),
+                        _ => {}
+                    }
                     let constant = IdentId::get_id(name);
                     globals
                         .get_constant_noautoload(OBJECT_CLASS, constant)
-                        .unwrap()
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "test harness: cannot reconstruct CRuby output: \
+                                 unresolved constant `{name}`"
+                            )
+                        })
                 } else {
                     let mut module = globals
                         .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id(&prefix[0]))
@@ -3029,6 +3053,18 @@ impl Value {
                 }
                 Value::hash(map)
             }
+            NodeKind::UnOp(crate::ast::UnOp::Neg, box inner) => {
+                let v = Self::from_ast_inner(inner, vm, globals, src_enc);
+                match v.unpack() {
+                    RV::Float(f) => Value::float(-f),
+                    RV::Fixnum(i) => Value::integer(-i),
+                    RV::BigInt(b) => Value::bigint(-b.clone()),
+                    _ => panic!(
+                        "test harness: cannot reconstruct negated CRuby output: {:?}",
+                        node.kind
+                    ),
+                }
+            }
             NodeKind::BinOp(crate::ast::BinOp::Div, box lhs, box rhs) => {
                 // CRuby's `p` outputs rationals as `(num/den)`, which parses as BinOp(Div).
                 match (&lhs.kind, &rhs.kind) {
@@ -3040,7 +3076,19 @@ impl Value {
                             unreachable!("{:?}", node.kind)
                         }
                     }
-                    _ => unreachable!("{:?}", node.kind),
+                    _ => {
+                        let l = Self::from_ast_inner(lhs, vm, globals, src_enc);
+                        let r = Self::from_ast_inner(rhs, vm, globals, src_enc);
+                        match (l.unpack(), r.unpack()) {
+                            (RV::Float(a), RV::Float(b)) => Value::float(a / b),
+                            (RV::Fixnum(a), RV::Fixnum(b)) if b != 0 => Value::rational(a, b),
+                            _ => panic!(
+                                "test harness: cannot reconstruct division in \
+                                 CRuby output: {:?}",
+                                node.kind
+                            ),
+                        }
+                    }
                 }
             }
             NodeKind::BinOp(crate::ast::BinOp::Add, box lhs, box rhs) => {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -2049,7 +2049,16 @@ impl RValue {
                     });
                     true
                 }
-                (ObjTy::RANGE, ObjTy::RANGE) => lhs.as_range() == rhs.as_range(),
+                (ObjTy::RANGE, ObjTy::RANGE) => {
+                    // Compare the endpoints structurally: a heap Float
+                    // endpoint (e.g. Infinity, which no flonum encodes)
+                    // must match by value, not by object identity.
+                    let l = lhs.as_range();
+                    let r = rhs.as_range();
+                    Value::assert_eq(store, l.start(), r.start());
+                    Value::assert_eq(store, l.end(), r.end());
+                    l.exclude_end() == r.exclude_end()
+                }
                 (ObjTy::HASH, ObjTy::HASH) => {
                     let lhs = lhs.as_hashmap();
                     let rhs = rhs.as_hashmap();


### PR DESCRIPTION
## Summary

Fixes #930: a `run_test*` case whose result contains a non-finite Float (`Infinity` / `-Infinity` / `NaN`) inside a collection panicked in the harness instead of comparing against CRuby, because CRuby's `p` prints those as bare words that re-parse as constant reads, and `from_ast_inner` hit `get_constant_noautoload(..).unwrap()` on the nonexistent constant.

### Reconstruction (`Value::from_ast_inner`)

- Bare `Infinity` / `NaN` map to `f64::INFINITY` / `f64::NAN`; a new `UnOp(Neg)` arm covers `-Infinity` (and any negated numeric literal).
- The rational `Div` arm's `unreachable!()` is replaced with a fallback that reconstructs the operands (float division, integer→rational), and the remaining constant-lookup failure panics with a descriptive `cannot reconstruct CRuby output: unresolved constant` message instead of a bare unwrap — per the issue's "fail gracefully" ask.

### Comparison (two follow-on latent bugs the repros exposed)

- **`Value::assert_eq`**: NaNs of any sign/payload now compare equal for assertion purposes. This is load-bearing on x86: `0.0/0.0` computes a *negative* quiet NaN (`0xfff8…`) while the reconstructed `f64::NAN` is positive (`0x7ff8…`), so flonum bit comparison misses even though both sides are "NaN".
- **`RValue::eq`**: Range endpoints compare structurally through `Value::assert_eq` — `Infinity` has no flonum encoding, so an `Infinity..Infinity` range holds heap Floats that the previous `RangeInner ==` compared by object identity.

## Testing

- New `harness_tests::nonfinite_floats_reconstruct` covering the issue's repros plus hash/range/nested-collection variants and both spellings (`1.0/0.0` and `Float::INFINITY`) — panicked before, green now.
- `cargo test -p monoruby --lib`: full suite green.

This unblocks differential coverage for `Array#sum` / `Enumerable#sum` / minmax-style methods over non-finite floats (the cases PR #929 had to keep out of `run_test*`).

Closes #930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_