### PR TITLE
Tier 2 Array fixes: product coercion, []= range semantics, #hash numeric elements

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5277,6 +5277,21 @@ mod tests {
     }
 
     #[test]
+    fn product_coerces_arg_via_method_missing() {
+        // An argument that answers `#to_ary` only through `method_missing`
+        // (no defined `to_ary`) is still coerced, matching CRuby.
+        run_test(
+            r#"
+            ar = Object.new
+            def ar.method_missing(name, *a); name == :to_ary ? [2, 3] : super; end
+            [1].product(ar)
+            "#,
+        );
+        // A non-coercible argument is still a TypeError.
+        run_test(r#"begin; [1].product(5); rescue TypeError; :te; end"#);
+    }
+
+    #[test]
     fn intersect() {
         run_tests(&[
             r#"

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1218,23 +1218,39 @@ fn index_assign(
         if let Some(idx) = i.try_fixnum() {
             ary.set_index(idx, val)
         } else if let Some(range) = i.is_range() {
-            let start = ary.get_array_index_nil_or(vm, globals, range.start(), 0)?;
+            // Resolve the start. A negative start that is still out of bounds
+            // after wrapping raises RangeError (unlike a bare negative Integer
+            // index, which raises IndexError).
+            let start = if range.start().is_nil() {
+                0
+            } else {
+                let s = range.start().coerce_to_int_i64(vm, globals)?;
+                let s = if s < 0 { s + ary.len() as i64 } else { s };
+                if s < 0 {
+                    return Err(MonorubyErr::rangeerr(format!(
+                        "{} out of range",
+                        i.to_s(&globals.store)
+                    )));
+                }
+                s as usize
+            };
+            // Resolve the length. Unlike the start, a negative end that is out
+            // of bounds is not an error: it simply yields a zero-length
+            // (insertion) replacement at `start`.
             let len = if range.end().is_nil() {
                 // endless range: length is from start to end of array
                 ary.len().checked_sub(start)
             } else {
-                let end = ary.get_array_index_nil_or(vm, globals, range.end(), ary.len())?;
-                if range.exclude_end() {
-                    end.checked_sub(start)
-                } else {
-                    (end + 1).checked_sub(start)
-                }
+                let e = range.end().coerce_to_int_i64(vm, globals)?;
+                let e = if e < 0 { e + ary.len() as i64 } else { e };
+                let e = if range.exclude_end() { e } else { e + 1 };
+                usize::try_from(e - start as i64).ok()
             };
             if let Some(len) = len {
-                ary.set_index2(start as usize, len as usize, val)
+                ary.set_index2(start, len, val)
             } else {
                 // end < start: treat as zero-length replacement at start
-                ary.set_index2(start as usize, 0, val)
+                ary.set_index2(start, 0, val)
             }
         } else {
             let idx = i.coerce_to_int_i64(vm, globals)?;
@@ -5793,6 +5809,22 @@ mod tests {
             r##"a = [1,2,3]; a[-3, 0] = [:a]; a"##,
         ]);
         run_test_error(r##"a = [1,2,3]; a[-4, 1] = []"##);
+    }
+
+    #[test]
+    fn index_assign_range_out_of_bounds() {
+        // A negative range start that is still out of bounds after wrapping
+        // raises RangeError (not IndexError).
+        run_test(r##"a = [1,2,3,4]; begin; a[-5..-5] = ""; rescue RangeError; :re; end"##);
+        run_test(r##"a = [1,2,3,4]; begin; a[-5...-4] = ""; rescue RangeError; :re; end"##);
+        run_test(r##"a = [1,2,3,4]; begin; a[-5..10] = ""; rescue RangeError; :re; end"##);
+        // A beginless range whose negative end is out of bounds inserts at the
+        // beginning rather than raising.
+        run_tests(&[
+            r##"a = [1,2,3]; a[(..-7)] = [4]; a"##,
+            r##"a = [1,2,3]; a[(...-10)] = [6]; a"##,
+            r##"a = [1,2,3,4]; a[0..-9] = [1]; a"##,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5289,6 +5289,10 @@ mod tests {
         );
         // A non-coercible argument is still a TypeError.
         run_test(r#"begin; [1].product(5); rescue TypeError; :te; end"#);
+        // An argument whose `#to_ary` returns a non-Array raises a TypeError.
+        run_test(
+            r#"ar = Object.new; def ar.to_ary; 5; end; begin; [1].product(ar); rescue TypeError; :te2; end"#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5293,6 +5293,33 @@ mod tests {
     }
 
     #[test]
+    fn hash_mixes_element_hash_value() {
+        // Array#hash sends `#hash` to each element and mixes the resulting
+        // integer, so an element whose `#hash` returns another object is
+        // coerced via `#to_int` and hashes identically to the underlying
+        // value. A numeric element must therefore mix its `Integer#hash` /
+        // `Float#hash` digest (of the value), not its raw tagged bits.
+        run_test(
+            r#"
+            x = 1.hash
+            o = Object.new
+            o.define_singleton_method(:hash) { x }
+            [1].hash == [o].hash
+            "#,
+        );
+        run_test(
+            r#"
+            x = 2.5.hash
+            o = Object.new
+            o.define_singleton_method(:hash) { x }
+            [2.5].hash == [o].hash
+            "#,
+        );
+        // Structural equality still implies hash equality for numeric content.
+        run_test(r#"[[1, 2.0, 3].hash == [1, 2.0, 3].hash, [1].hash != [2].hash]"#);
+    }
+
+    #[test]
     fn product_coerces_arg_via_method_missing() {
         // An argument that answers `#to_ary` only through `method_missing`
         // (no defined `to_ary`) is still coerced, matching CRuby.

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -343,7 +343,39 @@ impl RubyHash<Executor, Globals, MonorubyErr> for Value {
         g: &mut Globals,
     ) -> Result<()> {
         match self.try_rvalue() {
-            None => self.0.hash(state),
+            None => {
+                use std::hash::{Hash, Hasher};
+                match self.unpack() {
+                    // `Integer#hash`/`Float#hash` digest the numeric *value*
+                    // (not the tagged bits), so a numeric element must mix the
+                    // same digest whether reached here or through a Ruby-level
+                    // `#hash` result that Array#hash/Hash#hash coerce via
+                    // `#to_int` (see the "calls to_int on result of calling
+                    // hash on each element" core/array spec). Reproduce the
+                    // reduction inline rather than dispatching `#hash`: this
+                    // path also backs internal Hash bucketing and must not
+                    // re-enter the interpreter. Numeric keys only ever use the
+                    // Value-keyed `Map` variant, so both insert and lookup
+                    // reach this arm — bucketing stays self-consistent.
+                    RV::Fixnum(i) => {
+                        let mut s = crate::value::seeded_hasher();
+                        i.hash(&mut s);
+                        ((s.finish() as i64) >> 1).hash(state);
+                    }
+                    RV::Float(f) => {
+                        let mut s = crate::value::seeded_hasher();
+                        // Float#hash normalises -0.0 to +0.0 before hashing.
+                        let f = if f == 0.0 { 0.0 } else { f };
+                        f.to_bits().hash(&mut s);
+                        ((s.finish() as i64) >> 1).hash(state);
+                    }
+                    // nil / true / false / Symbol hash by identity. This keeps
+                    // parity with `IdentKey` (used for symbol-keyed Hash
+                    // bucketing), which digests `id()`; changing it here would
+                    // desynchronise the two hash functions for Symbol keys.
+                    _ => self.0.hash(state),
+                }
+            }
             // SAFETY: The RValue pointer is valid and the type checking via ty()
             // ensures we're accessing the correct variant of the union.
             Some(lhs) => unsafe {

--- a/monoruby/src/value/coerce.rs
+++ b/monoruby/src/value/coerce.rs
@@ -35,18 +35,30 @@ impl Value {
     ) -> Result<Array> {
         if let Some(ary) = self.try_array_ty() {
             return Ok(ary);
-        } else if let Some(fid) = globals.check_method(*self, IdentId::TO_ARY) {
-            let result = vm.invoke_func_inner(globals, fid, *self, &[], None, None)?;
-            if let Some(ary) = result.try_array_ty() {
-                return Ok(ary);
-            }
-            return Err(MonorubyErr::cant_convert_error_ary(globals, *self, result));
         }
-        Err(MonorubyErr::no_implicit_conversion(
-            globals,
-            *self,
-            ARRAY_CLASS,
-        ))
+        // Direct method lookup fast path, then fall back to
+        // `invoke_method_inner` which handles `method_missing` (a receiver
+        // that answers `to_ary` only through `method_missing` still
+        // coerces — matching CRuby; mirrors `coerce_to_int`).
+        let result = if let Some(fid) = globals.check_method(*self, IdentId::TO_ARY) {
+            vm.invoke_func_inner(globals, fid, *self, &[], None, None)?
+        } else {
+            match vm.invoke_method_inner(globals, IdentId::TO_ARY, *self, &[], None, None) {
+                Ok(result) => result,
+                Err(_) => {
+                    return Err(MonorubyErr::no_implicit_conversion(
+                        globals,
+                        *self,
+                        ARRAY_CLASS,
+                    ));
+                }
+            }
+        };
+        if let Some(ary) = result.try_array_ty() {
+            Ok(ary)
+        } else {
+            Err(MonorubyErr::cant_convert_error_ary(globals, *self, result))
+        }
     }
 
     ///


### PR DESCRIPTION
## Summary

Three independent Tier-2 `core/array` fixes.

### 1. `Array#product`: coerce arguments via `method_missing`

`Value::coerce_to_array` looked up `#to_ary` with `check_method`, which requires a *defined* method, so an argument that answers `to_ary` only through a bare `method_missing` failed with "no implicit conversion of X into Array". CRuby coerces it — `[1].product(ar) == [[1,2],[1,3]]`.

The fix mirrors the existing `coerce_to_int` pattern in the same file: keep the direct-lookup fast path, then fall back to `invoke_method_inner(:to_ary)` (which dispatches through `method_missing`). A failed send is still "no implicit conversion"; a non-Array result is still a `TypeError`. This affects every `coerce_to_array` caller (`Array#product`, `#+`, …).

Note: `Array#flatten`'s own `method_missing` example uses a separate coercion path (`try_convert_to_array`) with `respond_to?`/`respond_to_missing?` gating that other flatten specs rely on; that mspec-mock case is more delicate and left for a follow-up.

### 2. `Array#[]=` with a Range: `RangeError` for out-of-bounds start, clamp negative end

For a Range index, CRuby raises `RangeError` (not `IndexError`) when the range start is negative and still out of bounds after wrapping (`a[-5..-5] = ""` on a 4-element array). The range *end*, in contrast, may go out of bounds without error: a negative end below the array size simply yields a zero-length (insertion) replacement at the start, so `a[(..-7)] = [4]` inserts at the beginning. The Range branch of `index_assign` now resolves start and end independently with these distinct semantics.

### 3. `Array#hash` / `Hash#hash`: mix numeric elements by their `#hash` value

CRuby sends `#hash` to each element and mixes the resulting Integer (coercing via `#to_int` when needed). `Integer#hash`/`Float#hash` digest the numeric *value*, not the tagged immediate bits, so a numeric element hashed through the immediate fast path in `Value::ruby_hash` disagreed with the same value surfaced through a Ruby-level `#hash` — making `[1].hash != [obj_whose_hash_returns_1.hash].hash`.

Fixnum/Flonum elements now reproduce `Integer#hash`/`Float#hash` inline (no method dispatch — this path also backs internal Hash bucketing and must not re-enter the interpreter). Symbol/nil/true/false keep identity-based hashing so they stay in sync with `IdentKey`, the separate hash function used for symbol-keyed Hash bucketing.

## Verification

- ruby/spec: `core/array/product_spec.rb` `:method_missing` (1 error → 0); `core/array/element_set_spec.rb` (2 errors → 0); `core/array/hash_spec.rb` "calls to_int on result of calling hash on each element" (1 failure → 0).
- `core/array`, `core/hash`, `core/set` re-run: no new failures; all remaining ones pre-existing/unrelated.
- Added unit tests `product_coerces_arg_via_method_missing`, `index_assign_range_out_of_bounds`, `hash_mixes_element_hash_value`; full `cargo test -p monoruby --lib` green (1866 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_