### PR TITLE
spec-core monitor: escalate hung batches to SIGKILL and surface timed-out files

### DIFF
--- a/.github/spec-pages/index.html
+++ b/.github/spec-pages/index.html
@@ -94,6 +94,18 @@
   </table>
 </section>
 
+<section>
+  <h2>Timed-out spec files (latest run)</h2>
+  <p class="meta">
+    Spec files whose individual run exceeded the 60-second timeout and was
+    killed — typically hangs waiting on real thread concurrency. Their
+    examples are not included in the tallies above.
+    Source: <a href="data/timeouts.csv">timeouts.csv</a>,
+    <a href="data/history_timeouts.csv">history_timeouts.csv</a>.
+  </p>
+  <ul id="timeoutList"></ul>
+</section>
+
 <script>
 const SPEC_BASE = "https://github.com/ruby/spec/tree/master/core/";
 const specUrl = cat => SPEC_BASE + encodeURIComponent(cat);
@@ -116,6 +128,29 @@ async function loadCsv(path) {
 (async () => {
   const total = await loadCsv('data/history_total.csv');
   const hist = await loadCsv('data/history.csv');
+  const timeouts = await loadCsv('data/timeouts.csv');
+
+  // ------- Timed-out spec files (latest run) -------
+  {
+    const ul = document.getElementById('timeoutList');
+    if (!timeouts.length) {
+      const li = document.createElement('li');
+      li.textContent = 'none recorded';
+      li.style.color = '#666';
+      ul.appendChild(li);
+    } else {
+      for (const t of timeouts) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = 'https://github.com/ruby/spec/blob/master/' + t.file;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = t.file;
+        li.appendChild(a);
+        ul.appendChild(li);
+      }
+    }
+  }
 
   // ------- shared date range over the run timestamps -------
   const allStamps = [...new Set(total.map(r => r.timestamp))].sort();

--- a/.github/workflows/spec-core.yml
+++ b/.github/workflows/spec-core.yml
@@ -85,6 +85,39 @@ jobs:
               | awk '{s+=$1} END {print s+0}'
           }
 
+          TIMEOUTS="$OUT/timeouts.csv"
+          echo "category,file" > "$TIMEOUTS"
+
+          # Run a batch of spec files under a hard deadline. `-k 5` matters:
+          # monoruby installs its own SIGTERM handler (deferred to a VM poll
+          # point), so a process stuck in a blocking read never dies to the
+          # plain TERM that `timeout` sends -- without the KILL escalation a
+          # single hung spec stalls the whole job until timeout-minutes.
+          # Exit 124 = killed by TERM, 137 = needed the KILL.
+          run_specs () {
+            timeout -k 5 60 ../mspec/bin/mspec "$@" -t monoruby -f s >> "$LOG" 2>&1
+            local rc=$?
+            [ $rc -eq 124 ] || [ $rc -eq 137 ]
+          }
+
+          # A killed batch prints no summary line, so none of its 10 files
+          # get tallied. Rerun them one by one: completing files are counted
+          # after all, and the hanging file(s) are pinned down and recorded.
+          run_batch () {
+            [ ${#BATCH[@]} -eq 0 ] && return
+            if run_specs "${BATCH[@]}"; then
+              echo "### batch timed out; rerunning ${#BATCH[@]} files individually" >> "$LOG"
+              local f
+              for f in "${BATCH[@]}"; do
+                if run_specs "$f"; then
+                  echo "$cat,$f" >> "$TIMEOUTS"
+                  echo "### TIMEOUT: $f" >> "$LOG"
+                fi
+              done
+            fi
+            BATCH=()
+          }
+
           T_FILES=0; T_EX=0; T_FAIL=0; T_ERR=0
 
           for cat in $(ls core/ | sort); do
@@ -94,9 +127,12 @@ jobs:
             LOG="$OUT/logs/core_${cat}.log"
             : > "$LOG"
 
-            echo "$SPECS" | xargs -n 10 bash -c '
-              timeout 60 ../mspec/bin/mspec "$@" -t monoruby -f s
-            ' _ >> "$LOG" 2>&1 || true
+            BATCH=()
+            while IFS= read -r f; do
+              BATCH+=("$f")
+              [ ${#BATCH[@]} -ge 10 ] && run_batch
+            done <<< "$SPECS"
+            run_batch
 
             EX=$(sum_field "$LOG" 'examples?')
             FAIL=$(sum_field "$LOG" 'failures?')
@@ -126,6 +162,18 @@ jobs:
             T_RATE="0.00"
           fi
           echo "| **TOTAL** | **$T_FILES** | **$T_EX** | **$T_PASS** | **$T_FAIL** | **$T_ERR** | **${T_RATE}%** |" >> "$REPORT"
+
+          N_TIMEOUT=$(($(wc -l < "$TIMEOUTS") - 1))
+          if [ "$N_TIMEOUT" -gt 0 ]; then
+            {
+              echo ""
+              echo "### Timed-out spec files ($N_TIMEOUT)"
+              echo ""
+              echo "Killed after 60s; their examples are not included in the tallies above."
+              echo ""
+              tail -n +2 "$TIMEOUTS" | awk -F, '{print "- `" $2 "`"}'
+            } >> "$REPORT"
+          fi
 
           cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
 
@@ -199,6 +247,20 @@ jobs:
 
           echo "$TIMESTAMP,$SHORT_SHA,$TOTAL_EX,$TOTAL_PASS,$TOTAL_FAIL,$TOTAL_ERR,$TOTAL_RATE" \
             >> spec/data/history_total.csv
+
+          # Latest run's timed-out spec files (shown on the site), plus a
+          # timestamped history of them.
+          if [ -f "$GITHUB_WORKSPACE/spec-results/timeouts.csv" ]; then
+            cp "$GITHUB_WORKSPACE/spec-results/timeouts.csv" spec/data/timeouts.csv
+          else
+            echo "category,file" > spec/data/timeouts.csv
+          fi
+          if [ ! -f spec/data/history_timeouts.csv ]; then
+            echo "timestamp,commit,category,file" > spec/data/history_timeouts.csv
+          fi
+          tail -n +2 spec/data/timeouts.csv \
+            | awk -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" -F, 'BEGIN{OFS=","} {print ts,sha,$0}' \
+            >> spec/data/history_timeouts.csv
 
           cp "$GITHUB_WORKSPACE/.github/spec-pages/index.html" spec/index.html
           cp "$GITHUB_WORKSPACE/.github/portal/index.html" index.html


### PR DESCRIPTION
## Problem

Every "ruby/spec core monitor" run since the signal-handling change (a5157791, #925) has been **cancelled at the 180-minute job limit** (the last success was e162b6c5; runs used to finish in ~6 minutes).

Root cause chain, confirmed from the `spec-core-results` artifact of run 29455161594 and reproduced locally:

1. `core/io/copy_stream_spec.rb`'s "destination that does partial reads" example runs `IO.copy_stream` inside `Thread.new` while the main thread reads the destination pipe. Under the single-threaded runtime the thread body never runs, so the main thread blocks forever in `read(1)`. (This hang predates the `IO.copy_stream` implementation and is tagged `fails:` in `spec/tags` — which is why rubyspec-stats, which applies the tags via `mspec ci`, is unaffected.)
2. Since a5157791 monoruby installs its own SIGTERM handler that defers the signal to a VM poll point. A process stuck in a blocking read never reaches a poll point (Rust std's `read_to_end`/`Bytes` silently retry `EINTR`), so the plain TERM that `timeout 60` sends no longer kills it. Verified locally: a monoruby blocked in a pipe read survives `timeout`'s TERM and dies only to SIGKILL, while a blocked write still dies to TERM.
3. `timeout` without `-k` never escalates, so it waits on the unkillable child forever. The artifact shows categories `argf`…`integer` finishing in ~35 s, then `core_io.log` frozen mid-`copy_stream_spec` for ~3 h until the job limit.

## Fix

- **`timeout -k 5 60`**: TERM at 60 s as before, KILL 5 s later if ignored. A hung spec can never stall the job again, regardless of runtime signal semantics.
- **Individual rerun of timed-out batches**: a killed batch prints no summary line, so previously all 10 files of a hung batch were silently dropped from the tallies. Now the batch's files are rerun one by one — completing files get tallied, and the specific hanging file(s) are recorded in `timeouts.csv`.
- **Timed-out files are now visible**:
  - a "Timed-out spec files" section in the step-summary report,
  - `spec/data/timeouts.csv` (latest run) and `spec/data/history_timeouts.csv` on gh-pages,
  - a new "Timed-out spec files (latest run)" section on the spec history page, linking each file to its ruby/spec source.

## Verification

Ran the new runner logic locally on `core/io` (the category that hangs in CI): the category completes instead of stalling, tallies 1402 examples (more than before — the innocent files that shared a batch with a hanging file are now counted), and `timeouts.csv` pins down exactly the two known hang files:

```
category,file
io,core/io/copy_stream_spec.rb
io,core/io/select_spec.rb
```

Expected job duration stays in the ~6–10 minute range: each hung batch now costs ~130 s (65 s batch + individual reruns) instead of 60 s, and only a couple of batches hang.

Follow-up (separate PR): make blocking reads observe pending signals on `EINTR` so SIGTERM interrupts them like CRuby, instead of std's silent retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_