### PR TITLE
Hash#each/#shift: tolerate deletion and shifting during iteration

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1017,7 +1017,15 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     let hash = lfp.self_val().as_hash();
     let data = vm.get_block_data(globals, bh)?;
     let _iter_guard = hash.iter_guard();
-    for (k, v) in hash.iter() {
+    // Snapshot the stored (key, value) pairs before yielding so the traversal
+    // tolerates deletion during iteration (CRuby allows `h.each { h.delete(k) }`
+    // / `h.shift`). Yielding the snapshotted pairs directly — rather than
+    // re-looking-up each key — is essential: a key's `#hash` may legitimately
+    // differ from its stored slot (e.g. `Hash#rehash`, mutable keys), and a
+    // re-lookup would then miss it. Adding a *new* key still raises via the
+    // iteration guard on `insert`.
+    let pairs: Vec<(Value, Value)> = hash.iter().collect();
+    for (k, v) in pairs {
         vm.invoke_block(globals, &data, &[Value::array2(k, v)])?;
     }
     Ok(lfp.self_val())
@@ -3487,6 +3495,38 @@ mod tests {
         "##,
             r##"
         [Hash.new("default").shift, Hash.new.shift]
+        "##,
+        ]);
+    }
+
+    #[test]
+    fn mutate_during_iteration() {
+        run_tests(&[
+            // Deleting the current key while iterating visits every original
+            // entry and empties the hash (CRuby allows this).
+            r##"
+        h = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10,
+              k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20 }
+        visited = []
+        h.each_pair { |k, v| visited << k; h.delete(k) }
+        [visited, h]
+        "##,
+            // Shifting entries while iterating is likewise allowed.
+            r##"
+        h = { a: 1, b: 2, c: 3 }
+        visited = []
+        shifted = []
+        h.each_pair { |k, v| visited << k; shifted << h.shift }
+        [visited, shifted, h]
+        "##,
+            // Adding a new key mid-iteration still raises.
+            r##"
+        h = { a: 1 }
+        begin
+          h.each { |k, v| h[:b] = 2 }
+        rescue RuntimeError
+          :raised
+        end
         "##,
         ]);
     }

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -346,7 +346,10 @@ impl HashmapInner {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Option<(Value, Value)>> {
-        self.check_iter()?;
+        // Shifting an entry during iteration is allowed, like `delete` — CRuby
+        // permits `h.each { h.shift }` (see ruby/spec core/hash/shift_spec.rb
+        // "allows shifting entries while iterating"). Only *adding* a key is
+        // rejected mid-iteration.
         self.content.shift(vm, globals)
     }
 


### PR DESCRIPTION
## Summary

Tier 2 (`core/hash` iteration safety). CRuby permits removing entries from a Hash while iterating it — `h.each { h.delete(k) }` and `h.each { h.shift }` both visit every originally-present entry and leave the hash empty. monoruby raised or skipped entries instead:

- `Hash#each` / `#each_pair` iterated the live map by index, so a `delete` (which compacts the backing store) shifted the next entry into the current slot and the iterator stepped over it — visiting only every *other* key.
- `Hash#shift` called `check_iter`, raising `"can't modify hash during iteration"`, even though shifting (like deleting) is allowed.

## Fix

- **`each`**: snapshot the stored `(key, value)` pairs before yielding. This decouples the traversal from the live map's compaction on delete, so every originally-present entry is visited. Crucially, it yields the *stored* pairs directly rather than re-looking-up each key — a key's `#hash` may legitimately differ from its stored slot (mutable keys, `Hash#rehash`), and a re-lookup would then miss it.
- **`shift`**: drop the `check_iter` guard, matching `delete`/`remove` which already allow removal mid-iteration.

Adding a *new* key mid-iteration still raises, via the existing guard on `insert`.

## Verification

- ruby/spec: `core/hash/delete_spec.rb` "allows removing a key while iterating for big hashes" (FAILED → pass); `core/hash/shift_spec.rb` "allows shifting entries while iterating" (ERROR → pass).
- `core/hash` category: **3 failures / 2 errors → 2 failures / 1 error**, with no new failures (`rehash`, `each`, `to_a`, `select`, `reject`, enumerable-over-hash all still green). Remaining ones are pre-existing/unrelated (mock-collision `[]=`, `each_pair` child-class arg expansion, `inspect` under changed encoding).
- Added unit test `mutate_during_iteration` (delete, shift, and the still-raising add-key case); full `cargo test -p monoruby --lib` green (1868 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_