### PR TITLE
Signal-interruptible blocking IO: SIGTERM kills a blocked read like CRuby

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1147,18 +1147,19 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 #[monoruby_builtin]
 fn write(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let data = lfp.arg(0).as_array();
-    let mut self_ = lfp.self_val();
     let mut count = 0i64;
     for s in data.iter() {
-        if let Some(bytes) = s.is_rstring_inner() {
-            count += bytes.len() as i64;
-            self_.as_io_inner_mut().write(bytes)?;
+        let bytes = if let Some(bytes) = s.is_rstring_inner() {
+            bytes.to_vec()
         } else {
             let s_str = vm.invoke_tos(globals, *s)?;
-            let bytes = s_str.expect_bytes(&globals.store)?;
-            count += bytes.len() as i64;
-            self_.as_io_inner_mut().write(bytes)?;
-        }
+            s_str.expect_bytes(&globals.store)?.to_vec()
+        };
+        count += bytes.len() as i64;
+        let mut done = 0;
+        super::io::blocking_region(vm, globals, || {
+            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+        })?;
     }
     Ok(Value::integer(count))
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -872,15 +872,16 @@ pub(crate) extern "C" fn io_alloc_func(class_id: ClassId, _: &mut Globals) -> Va
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/=3c=3c.html]
 #[monoruby_builtin]
 fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    if let Some(b) = lfp.arg(0).try_bytes() {
-        io.write(b.as_bytes())?;
+    let bytes = if let Some(b) = lfp.arg(0).try_bytes() {
+        b.as_bytes().to_vec()
     } else {
-        let s = vm.to_s(globals, lfp.arg(0))?;
-        io.write(s.as_bytes())?;
+        vm.to_s(globals, lfp.arg(0))?.into_bytes()
     };
-    io.flush()?;
+    let mut done = 0;
+    blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+    })?;
+    lfp.self_val().as_io_inner_mut().flush()?;
     Ok(lfp.self_val())
 }
 
@@ -983,12 +984,13 @@ fn print(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn printf(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let format_str = lfp.arg(0).coerce_to_string(vm, globals)?;
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
     let args = lfp.arg(1).as_array();
 
     let buf = vm.format_by_args(globals, &format_str, &args)?;
-    io.write(buf.as_bytes())?;
+    let mut done = 0;
+    blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().write(buf.as_bytes(), &mut done)
+    })?;
 
     Ok(Value::nil())
 }
@@ -1115,6 +1117,46 @@ fn bump_lineno(globals: &mut Globals, io: Value) -> Result<()> {
     Ok(())
 }
 
+/// Run a blocking IO operation with CRuby-like interrupt semantics.
+///
+/// The interruptible read primitives (see value/rvalue/io.rs) surface
+/// "EINTR with a pending signal" as the internal
+/// `MonorubyErr::signal_interrupt` marker instead of silently retrying the
+/// syscall (which is what makes a blocked read un-killable by SIGTERM).
+/// This wrapper catches the marker and runs the VM poll point: the default
+/// disposition raises the converted `SignalException` out of the read,
+/// while a `Signal.trap` handler runs and — when it returns normally —
+/// the operation is restarted (bytes consumed before the interrupt were
+/// pushed back by the primitives, so no data is lost).
+///
+/// A signal that was already pending on entry is drained up front: it was
+/// delivered before the syscall (re-)entered the kernel, so it can never
+/// EINTR it, and the operation could otherwise block forever with the
+/// signal sitting in the bitmap (same reasoning as `Kernel#sleep`).
+pub(crate) fn blocking_region<T>(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    mut f: impl FnMut() -> Result<T>,
+) -> Result<T> {
+    loop {
+        if crate::codegen::signal_table::PENDING_SIGNALS.load(std::sync::atomic::Ordering::Relaxed)
+            != 0
+            && crate::executor::execute_gc(vm, globals).is_none()
+        {
+            return Err(vm.take_error());
+        }
+        match f() {
+            Err(err) if err.is_signal_interrupt() => {
+                if crate::executor::execute_gc(vm, globals).is_none() {
+                    return Err(vm.take_error());
+                }
+                // A trap handler handled the signal; restart the operation.
+            }
+            res => return res,
+        }
+    }
+}
+
 /// Shared body of `IO#gets` / `IO#readline`: read one line per the parsed
 /// arguments, update lineno / `$.` / `$_`, and return the tagged String
 /// (nil at EOF).
@@ -1122,9 +1164,11 @@ fn gets_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
     let (sep, limit, chomp) = getline_args(vm, globals, lfp, 2)?;
     let mut self_ = lfp.self_val();
     let complete_utf8 = io_completes_utf8(globals, self_);
-    let line = self_
-        .as_io_inner_mut()
-        .getline(sep.as_deref(), limit, complete_utf8)?;
+    let line = blocking_region(vm, globals, || {
+        lfp.self_val()
+            .as_io_inner_mut()
+            .getline(sep.as_deref(), limit, complete_utf8)
+    })?;
     match line {
         Some(mut buf) => {
             if chomp {
@@ -1372,7 +1416,9 @@ fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         }
         _ => None,
     };
-    let buf = lfp.self_val().as_io_inner_mut().read(length)?;
+    let buf = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().read(length)
+    })?;
     let eof_nil = buf.is_empty() && length.is_some() && length != Some(0);
     match outbuf {
         Some(mut out) => {
@@ -1552,11 +1598,11 @@ fn io_class_readlines(
         vm.temp_push(io_val);
         vm.temp_array_new(None);
         let result = (|| {
-            while let Some(mut buf) =
+            while let Some(mut buf) = blocking_region(vm, globals, || {
                 io_val
                     .as_io_inner_mut()
-                    .getline(sep.as_deref(), limit, complete_utf8)?
-            {
+                    .getline(sep.as_deref(), limit, complete_utf8)
+            })? {
                 if chomp {
                     chomp_line(&mut buf, sep.as_deref(), limit);
                 }
@@ -1730,11 +1776,11 @@ fn io_foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
         vm.temp_push(io_val);
         let mut lineno = 0i64;
         let result = (|| {
-            while let Some(mut buf) =
+            while let Some(mut buf) = blocking_region(vm, globals, || {
                 io_val
                     .as_io_inner_mut()
-                    .getline(sep.as_deref(), limit, complete_utf8)?
-            {
+                    .getline(sep.as_deref(), limit, complete_utf8)
+            })? {
                 if chomp {
                     chomp_line(&mut buf, sep.as_deref(), limit);
                 }
@@ -2160,11 +2206,11 @@ fn io_readlines(
     let mut self_ = lfp.self_val();
     let complete_utf8 = io_completes_utf8(globals, self_);
     let mut lines = Vec::new();
-    while let Some(mut buf) =
-        self_
+    while let Some(mut buf) = blocking_region(vm, globals, || {
+        lfp.self_val()
             .as_io_inner_mut()
-            .getline(sep.as_deref(), limit, complete_utf8)?
-    {
+            .getline(sep.as_deref(), limit, complete_utf8)
+    })? {
         if chomp {
             chomp_line(&mut buf, sep.as_deref(), limit);
         }
@@ -2397,8 +2443,8 @@ fn io_rewind(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/eof.html]
 #[monoruby_builtin]
 fn io_eof_(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
@@ -2408,7 +2454,10 @@ fn io_eof_(
         return Ok(Value::bool(false));
     }
     // Read 1 byte; if empty, we're at EOF. Then push it back via seek(-1).
-    let buf = io.read(Some(1))?;
+    let buf = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().read(Some(1))
+    })?;
+    let io = self_.as_io_inner_mut();
     if buf.is_empty() {
         return Ok(Value::bool(true));
     }
@@ -2428,14 +2477,14 @@ fn io_eof_(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/getbyte.html]
 #[monoruby_builtin]
 fn io_getbyte(
-    _vm: &mut Executor,
-    _globals: &mut Globals,
+    vm: &mut Executor,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
-    let buf = io.read(Some(1))?;
+    let buf = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().read(Some(1))
+    })?;
     if buf.is_empty() {
         Ok(Value::nil())
     } else {
@@ -2466,13 +2515,28 @@ fn read_one_char(io: &mut IoInner) -> Result<Vec<u8>> {
     };
     let mut buf = first;
     while buf.len() < total {
-        let next = io.read(Some(total - buf.len()))?;
+        let next = read_more_char_bytes(io, &buf, total)?;
         if next.is_empty() {
             break;
         }
         buf.extend_from_slice(&next);
     }
     Ok(buf)
+}
+
+/// Continuation read for `read_one_char{,_enc}`: on a signal interrupt,
+/// push the partial character bytes back so the retried getc re-reads a
+/// whole character.
+fn read_more_char_bytes(io: &mut IoInner, acc: &[u8], total: usize) -> Result<Vec<u8>> {
+    match io.read(Some(total - acc.len())) {
+        Err(err) => {
+            if err.is_signal_interrupt() && !acc.is_empty() {
+                let _ = io.unget(acc);
+            }
+            Err(err)
+        }
+        ok => ok,
+    }
 }
 
 /// Per-encoding character width from the lead byte (mirrors
@@ -2512,7 +2576,7 @@ fn read_one_char_enc(io: &mut IoInner, enc: crate::value::Encoding) -> Result<Ve
     let total = char_width_from_lead(enc, first[0]);
     let mut buf = first;
     while buf.len() < total {
-        let next = io.read(Some(total - buf.len()))?;
+        let next = read_more_char_bytes(io, &buf, total)?;
         if next.is_empty() {
             break;
         }
@@ -2532,15 +2596,17 @@ fn read_one_char_enc(io: &mut IoInner, enc: crate::value::Encoding) -> Result<Ve
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/getc.html]
 #[monoruby_builtin]
 fn io_getc(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_ = lfp.self_val();
+    let self_ = lfp.self_val();
     let ext_obj = read_io_encoding(globals, self_, false);
     let ext = enc_obj_to_enum(globals, ext_obj).unwrap_or(crate::value::Encoding::Utf8);
-    let buf = read_one_char_enc(self_.as_io_inner_mut(), ext)?;
+    let buf = blocking_region(vm, globals, || {
+        read_one_char_enc(lfp.self_val().as_io_inner_mut(), ext)
+    })?;
     if buf.is_empty() {
         Ok(Value::nil())
     } else {
@@ -2775,8 +2841,6 @@ fn io_write_method(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_ = lfp.self_val();
-    let io = self_.as_io_inner_mut();
     let args = lfp.arg(0).as_array();
     let mut total = 0i64;
     for v in args.iter().cloned() {
@@ -2787,7 +2851,10 @@ fn io_write_method(
             s.into_bytes()
         };
         total += bytes.len() as i64;
-        io.write(&bytes)?;
+        let mut done = 0;
+        blocking_region(vm, globals, || {
+            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+        })?;
     }
     Ok(Value::integer(total))
 }
@@ -2813,16 +2880,36 @@ fn io_syswrite(
         s.into_bytes()
     };
     let fd = io.fileno()?;
-    // SAFETY: fd is a valid file descriptor, bytes is a valid buffer.
-    let written = unsafe { libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len()) };
-    if written < 0 {
+    let written = loop {
+        // Signal handlers are installed without SA_RESTART; run the VM
+        // poll point on EINTR (raise the SignalException or run the trap
+        // handler and retry), like the buffered write path.
+        if crate::codegen::signal_table::PENDING_SIGNALS
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0
+            && crate::executor::execute_gc(vm, globals).is_none()
+        {
+            return Err(vm.take_error());
+        }
+        // SAFETY: fd is a valid file descriptor, bytes is a valid buffer.
+        let written =
+            unsafe { libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len()) };
+        if written >= 0 {
+            break written;
+        }
         let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            if crate::executor::execute_gc(vm, globals).is_none() {
+                return Err(vm.take_error());
+            }
+            continue;
+        }
         return Err(MonorubyErr::errno_with_msg(
             &globals.store,
             &err,
             "syswrite",
         ));
-    }
+    };
     Ok(Value::integer(written as i64))
 }
 
@@ -2961,7 +3048,9 @@ fn io_sysread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             None => Value::string_from_vec(vec![]),
         });
     }
-    let buf = lfp.self_val().as_io_inner_mut().sysread(maxlen as usize)?;
+    let buf = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().sysread(maxlen as usize)
+    })?;
     if buf.is_empty() {
         if let Some(mut v) = buffer {
             let enc = v.as_rstring_inner().encoding();
@@ -3018,7 +3107,9 @@ fn io_readpartial(
             None => Value::string_from_vec(vec![]),
         });
     }
-    let buf = lfp.self_val().as_io_inner_mut().readpartial(maxlen as usize)?;
+    let buf = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().readpartial(maxlen as usize)
+    })?;
     if buf.is_empty() {
         if let Some(mut v) = buffer {
             let enc = v.as_rstring_inner().encoding();
@@ -3288,58 +3379,77 @@ fn io_select(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         let mut writefds: libc::fd_set = std::mem::zeroed();
         let mut errorfds: libc::fd_set = std::mem::zeroed();
 
-        libc::FD_ZERO(&mut readfds);
-        libc::FD_ZERO(&mut writefds);
-        libc::FD_ZERO(&mut errorfds);
-
-        for &fd in &read_fds {
-            libc::FD_SET(fd, &mut readfds);
-        }
-        for &fd in &write_fds {
-            libc::FD_SET(fd, &mut writefds);
-        }
-        for &fd in &error_fds {
-            libc::FD_SET(fd, &mut errorfds);
-        }
-
+        // On Linux, select(2) updates the timeval to the time not slept,
+        // so re-entering after an EINTR (below) continues with the
+        // remaining timeout rather than starting over.
         let mut tv_storage = timeout.unwrap_or(libc::timeval {
             tv_sec: 0,
             tv_usec: 0,
         });
-        let timeout_ptr = if timeout.is_some() {
-            &mut tv_storage as *mut libc::timeval
-        } else {
-            std::ptr::null_mut()
+
+        let ret = loop {
+            // select(2) mutates the fd sets, so rebuild them each attempt.
+            libc::FD_ZERO(&mut readfds);
+            libc::FD_ZERO(&mut writefds);
+            libc::FD_ZERO(&mut errorfds);
+
+            for &fd in &read_fds {
+                libc::FD_SET(fd, &mut readfds);
+            }
+            for &fd in &write_fds {
+                libc::FD_SET(fd, &mut writefds);
+            }
+            for &fd in &error_fds {
+                libc::FD_SET(fd, &mut errorfds);
+            }
+
+            let timeout_ptr = if timeout.is_some() {
+                &mut tv_storage as *mut libc::timeval
+            } else {
+                std::ptr::null_mut()
+            };
+
+            let ret = libc::select(
+                nfds,
+                if read_fds.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    &mut readfds
+                },
+                if write_fds.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    &mut writefds
+                },
+                if error_fds.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    &mut errorfds
+                },
+                timeout_ptr,
+            );
+
+            if ret < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::EINTR) {
+                    // A signal interrupted the wait: run the VM poll
+                    // point (raise the converted SignalException, or run
+                    // the trap handler and retry the select), matching
+                    // CRuby, which restarts select after processing
+                    // interrupts instead of surfacing Errno::EINTR.
+                    if crate::executor::execute_gc(vm, globals).is_none() {
+                        return Err(vm.take_error());
+                    }
+                    continue;
+                }
+                return Err(MonorubyErr::errno_with_msg(
+                    &globals.store,
+                    &err,
+                    "select(2)",
+                ));
+            }
+            break ret;
         };
-
-        let ret = libc::select(
-            nfds,
-            if read_fds.is_empty() {
-                std::ptr::null_mut()
-            } else {
-                &mut readfds
-            },
-            if write_fds.is_empty() {
-                std::ptr::null_mut()
-            } else {
-                &mut writefds
-            },
-            if error_fds.is_empty() {
-                std::ptr::null_mut()
-            } else {
-                &mut errorfds
-            },
-            timeout_ptr,
-        );
-
-        if ret < 0 {
-            let err = std::io::Error::last_os_error();
-            return Err(MonorubyErr::errno_with_msg(
-                &globals.store,
-                &err,
-                "select(2)",
-            ));
-        }
 
         if ret == 0 {
             return Ok(Value::nil());
@@ -3432,7 +3542,7 @@ fn set_encoding(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/set_encoding_by_bom.html]
 #[monoruby_builtin]
 fn set_encoding_by_bom(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
@@ -3472,7 +3582,9 @@ fn set_encoding_by_bom(
     }
     // Read up to 4 bytes — enough to disambiguate every BOM (and to
     // tell UTF-16LE from UTF-32LE, which share the FF FE prefix).
-    let head = self_.as_io_inner_mut().read(Some(4))?;
+    let head = blocking_region(vm, globals, || {
+        lfp.self_val().as_io_inner_mut().read(Some(4))
+    })?;
     let (consume, enc_name): (usize, &str) = match head.first() {
         Some(0xEF) if head.len() >= 3 && head[1] == 0xBB && head[2] == 0xBF => (3, "UTF-8"),
         Some(0x00) if head.len() >= 4 && head[1] == 0x00 && head[2] == 0xFE && head[3] == 0xFF => {
@@ -4120,8 +4232,12 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                     // Flush per chunk: copy_stream must not buffer (a
                     // pipe reader on the other side expects the data
                     // immediately — Rust's stdout is block-buffered).
-                    v.as_io_inner_mut().write(chunk)?;
-                    v.as_io_inner_mut().flush()
+                    let mut vv = *v;
+                    let mut done = 0;
+                    blocking_region(vm, globals, || {
+                        vv.as_io_inner_mut().write(chunk, &mut done)
+                    })?;
+                    vv.as_io_inner_mut().flush()
                 }
                 _ => unreachable!(),
             }
@@ -4174,7 +4290,9 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                     if want == 0 {
                         break;
                     }
-                    let chunk = v.as_io_inner_mut().readpartial(want)?;
+                    let mut vv = *v;
+                    let chunk =
+                        blocking_region(vm, globals, || vv.as_io_inner_mut().readpartial(want))?;
                     if chunk.is_empty() {
                         break;
                     }

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -681,19 +681,32 @@ fn do_waitpid(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<(i32
         0
     };
     let mut status: i32 = 0;
-    // SAFETY: waitpid is a POSIX system call.
-    let ret = unsafe { libc::waitpid(pid, &mut status, flags) };
-    if ret == -1 {
+    let ret = loop {
+        // SAFETY: waitpid is a POSIX system call.
+        let ret = unsafe { libc::waitpid(pid, &mut status, flags) };
+        if ret != -1 {
+            break ret;
+        }
+        let err = std::io::Error::last_os_error();
+        // Signal handlers are installed without SA_RESTART, so a signal
+        // delivered while blocked in waitpid EINTRs it. Run the VM poll
+        // point (raise the converted SignalException, or run the trap
+        // handler) and retry the wait, matching CRuby.
+        if err.raw_os_error() == Some(libc::EINTR) {
+            if crate::executor::execute_gc(vm, globals).is_none() {
+                return Err(vm.take_error());
+            }
+            continue;
+        }
         // Map the OS errno to the proper `Errno::E*` (a SystemCallError),
         // matching CRuby — e.g. `Errno::ECHILD` ("No child processes") when
         // there is no child to reap, rather than a bare RuntimeError.
-        let err = std::io::Error::last_os_error();
         let msg = match err.raw_os_error() {
             Some(errno) => crate::builtins::errno::strerror(errno),
             None => err.to_string(),
         };
         return Err(MonorubyErr::from_io_err(&globals.store, &err, msg));
-    }
+    };
     let status_class = vm.get_qualified_constant(globals, OBJECT_CLASS, &["Process", "Status"])?;
     let status_obj = vm.invoke_method_inner(
         globals,

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1083,15 +1083,16 @@ impl Codegen {
         let Some(codeptr) = self.signal_stubs.get(&signo) else {
             return false;
         };
+        // No SA_RESTART, deliberately (like CRuby): a signal must EINTR a
+        // blocking syscall so the interpreter can reach a poll point and
+        // convert the pending signal. With SA_RESTART, a read(2) that has
+        // transferred 0 bytes is transparently restarted by the kernel and
+        // a process blocked on an idle pipe can never be terminated by
+        // SIGTERM. The blocking primitives (value/rvalue/io.rs, sleep,
+        // waitpid, select) all retry bare EINTRs themselves.
         // SAFETY: codeptr is a stable pointer into the finalized JIT
-        // buffer; SA_RESTART matches the startup install.
-        unsafe {
-            Self::sigaction_to(
-                signo,
-                codeptr.as_ptr() as libc::sighandler_t,
-                libc::SA_RESTART,
-            )
-        }
+        // buffer.
+        unsafe { Self::sigaction_to(signo, codeptr.as_ptr() as libc::sighandler_t, 0) }
     }
 
     /// Set `signo` to `SIG_IGN` (silently discard).

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -1,5 +1,10 @@
 use crate::ast::{Loc, ParseErr, ParseErrKind, SourceInfoRef};
 
+/// Reserved message of the internal [`MonorubyErr::signal_interrupt`]
+/// marker error. Chosen to be unmistakable if a bug ever lets it leak to
+/// Ruby as a RuntimeError.
+pub(crate) const SIGNAL_INTERRUPT_MSG: &str = "__monoruby_signal_interrupt__";
+
 use super::*;
 
 ///
@@ -994,6 +999,24 @@ impl MonorubyErr {
 
     pub(crate) fn interrupt(msg: impl ToString) -> MonorubyErr {
         MonorubyErr::new(MonorubyErrKind::Other(INTERRUPT_CLASS), msg)
+    }
+
+    /// Internal marker: a blocking IO primitive observed `EINTR` while an
+    /// async signal handler had recorded a pending signal. This never
+    /// surfaces to Ruby — callers holding an `Executor` (the IO builtins,
+    /// via `blocking_region` in builtins/io.rs) intercept it with
+    /// [`MonorubyErr::is_signal_interrupt`], run the VM poll point (which
+    /// raises the converted `SignalException` or runs the `Signal.trap`
+    /// handler), and restart the operation when the handler returned
+    /// normally.
+    pub(crate) fn signal_interrupt() -> MonorubyErr {
+        MonorubyErr::new(MonorubyErrKind::Runtime, SIGNAL_INTERRUPT_MSG)
+    }
+
+    /// Whether this error is the internal [`MonorubyErr::signal_interrupt`]
+    /// marker.
+    pub(crate) fn is_signal_interrupt(&self) -> bool {
+        self.kind == MonorubyErrKind::Runtime && self.message() == SIGNAL_INTERRUPT_MSG
     }
 
     /// Construct a FatalError. Used when a Rust `panic!` is caught at an

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -52,6 +52,123 @@ fn encode_wait_status(status: &std::process::ExitStatus) -> i32 {
     status.into_raw()
 }
 
+/// Whether an async signal handler has recorded a pending signal that the
+/// VM has not yet drained at a poll point.
+fn signal_pending() -> bool {
+    crate::codegen::signal_table::PENDING_SIGNALS.load(std::sync::atomic::Ordering::Relaxed) != 0
+}
+
+/// Map an io error out of the interruptible primitives below:
+/// `Interrupted` (EINTR with a signal pending) becomes the internal
+/// signal-interrupt marker so the IO builtins can run the VM poll point;
+/// anything else goes through `f` (the call site's existing mapping).
+fn map_read_err(e: std::io::Error, f: impl FnOnce(String) -> MonorubyErr) -> MonorubyErr {
+    if e.kind() == std::io::ErrorKind::Interrupted {
+        MonorubyErr::signal_interrupt()
+    } else {
+        f(e.to_string())
+    }
+}
+
+/// One read through `reader`, like `Read::read` but signal-aware: a bare
+/// `EINTR` (no pending signal — e.g. SIGCHLD with SA_RESTART unset on
+/// another handler) is retried, while `EINTR` with a pending signal is
+/// surfaced as `Interrupted` so the caller can reach a VM poll point.
+/// Rust std's own helpers (`read_to_end`, `Bytes`, `read_until`) retry
+/// `Interrupted` unconditionally, which is exactly what makes a blocked
+/// read un-killable by SIGTERM — never use them on fds that can block.
+fn read_step(reader: &mut impl Read, buf: &mut [u8]) -> std::io::Result<usize> {
+    loop {
+        match reader.read(buf) {
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted && !signal_pending() => continue,
+            r => return r,
+        }
+    }
+}
+
+/// Signal-interruptible replacement for `bytes().take(len).collect()`:
+/// append up to `len` bytes to `out`, stopping early at EOF. On
+/// `Interrupted`, bytes read so far remain in `out` so the caller can
+/// preserve them (pushback) before surfacing the interrupt.
+fn read_upto(reader: &mut impl Read, len: usize, out: &mut Vec<u8>) -> std::io::Result<()> {
+    let mut buf = [0u8; 8192];
+    while out.len() < len {
+        // A signal delivered while we were in userspace (e.g. right after
+        // the previous chunk) sets the pending bit without EINTR-ing
+        // anything; entering a blocking read with the bit already set
+        // would block unkillably. Check before every kernel entry.
+        if signal_pending() {
+            return Err(std::io::ErrorKind::Interrupted.into());
+        }
+        let want = (len - out.len()).min(buf.len());
+        match read_step(reader, &mut buf[..want])? {
+            0 => break,
+            n => out.extend_from_slice(&buf[..n]),
+        }
+    }
+    Ok(())
+}
+
+/// Signal-interruptible replacement for `read_to_end`. On `Interrupted`,
+/// bytes read so far remain in `out`.
+fn read_all(reader: &mut impl Read, out: &mut Vec<u8>) -> std::io::Result<()> {
+    let mut buf = [0u8; 8192];
+    loop {
+        // See `read_upto` on why this is checked before every kernel entry.
+        if signal_pending() {
+            return Err(std::io::ErrorKind::Interrupted.into());
+        }
+        match read_step(reader, &mut buf)? {
+            0 => return Ok(()),
+            n => out.extend_from_slice(&buf[..n]),
+        }
+    }
+}
+
+/// Signal-interruptible replacement for `BufRead::read_until`. Returns the
+/// number of bytes appended to `out`; on `Interrupted`, bytes read so far
+/// remain in `out`.
+fn read_until_step(
+    reader: &mut impl BufRead,
+    delim: u8,
+    out: &mut Vec<u8>,
+) -> std::io::Result<usize> {
+    let mut total = 0;
+    loop {
+        // See `read_upto` on why this is checked before every kernel entry.
+        if signal_pending() {
+            return Err(std::io::ErrorKind::Interrupted.into());
+        }
+        let (found, used) = {
+            let avail = match reader.fill_buf() {
+                Ok(a) => a,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    if signal_pending() {
+                        return Err(e);
+                    }
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+            match avail.iter().position(|&b| b == delim) {
+                Some(i) => {
+                    out.extend_from_slice(&avail[..=i]);
+                    (true, i + 1)
+                }
+                None => {
+                    out.extend_from_slice(avail);
+                    (false, avail.len())
+                }
+            }
+        };
+        reader.consume(used);
+        total += used;
+        if found || used == 0 {
+            return Ok(total);
+        }
+    }
+}
+
 /// Pull up to `need` bytes from a buffered reader for `readpartial`.
 /// When `no_block` is set (ungetc pushback already produced data),
 /// only the bytes already sitting in the internal buffer are taken;
@@ -64,7 +181,18 @@ fn read_partial_chunk<T: Read>(
     let avail: &[u8] = if no_block {
         reader.buffer()
     } else {
-        reader.fill_buf().map_err(|e| MonorubyErr::ioerr(e.to_string()))?
+        loop {
+            match reader.fill_buf() {
+                Ok(_) => break,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    if signal_pending() {
+                        return Err(MonorubyErr::signal_interrupt());
+                    }
+                }
+                Err(e) => return Err(MonorubyErr::ioerr(e.to_string())),
+            }
+        }
+        reader.buffer()
     };
     let n = avail.len().min(need);
     let chunk = avail[..n].to_vec();
@@ -389,34 +517,69 @@ impl IoInner {
         }))
     }
 
-    pub fn write(&mut self, data: &[u8]) -> Result<()> {
+    /// Write all of `data[*progress..]`, advancing `*progress` past every
+    /// byte accepted by the kernel (fixing silent short writes on pipes).
+    ///
+    /// Signal-interruptible: a bare `EINTR` is retried, while `EINTR`
+    /// with a pending signal surfaces the internal signal-interrupt
+    /// marker. Because `*progress` records exactly what was flushed, the
+    /// builtin's `blocking_region` retry after a `Signal.trap` handler
+    /// resumes mid-buffer without duplicating output.
+    pub fn write(&mut self, data: &[u8], progress: &mut usize) -> Result<()> {
         self.ensure_writable()?;
-        match self {
-            Self::Stdout => match std::io::stdout().write(data) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(MonorubyErr::rangeerr(e.to_string())),
-            },
-            Self::Stderr => match std::io::stderr().write(data) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(MonorubyErr::rangeerr(e.to_string())),
-            },
-            Self::File(file) => {
-                let _ = Rc::get_mut(file)
-                    .unwrap()
-                    .reader
-                    .get_mut()
-                    .write(data)
-                    .map_err(|e| MonorubyErr::rangeerr(e.to_string()))?;
-                Ok(())
+        fn write_all(
+            writer: &mut impl Write,
+            data: &[u8],
+            progress: &mut usize,
+            map: impl Fn(String) -> MonorubyErr,
+        ) -> Result<()> {
+            while *progress < data.len() {
+                // A blocking pipe write that already transferred bytes
+                // returns the partial count on a signal instead of EINTR,
+                // and a signal can also land while we are in userspace
+                // between chunks; either way the pending bit is set and
+                // re-entering write(2) would block unkillably. Check
+                // before every kernel entry.
+                if signal_pending() {
+                    return Err(MonorubyErr::signal_interrupt());
+                }
+                match writer.write(&data[*progress..]) {
+                    Ok(0) => return Err(map("write returned 0".to_string())),
+                    Ok(n) => *progress += n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        if signal_pending() {
+                            return Err(MonorubyErr::signal_interrupt());
+                        }
+                    }
+                    Err(e) => return Err(map(e.to_string())),
+                }
             }
+            Ok(())
+        }
+        match self {
+            Self::Stdout => write_all(
+                &mut std::io::stdout(),
+                data,
+                progress,
+                MonorubyErr::rangeerr,
+            ),
+            Self::Stderr => write_all(
+                &mut std::io::stderr(),
+                data,
+                progress,
+                MonorubyErr::rangeerr,
+            ),
+            Self::File(file) => write_all(
+                Rc::get_mut(file).unwrap().reader.get_mut(),
+                data,
+                progress,
+                MonorubyErr::rangeerr,
+            ),
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
                 // `ensure_writable` guaranteed the writer is present.
                 let writer = popen.writer.as_mut().unwrap();
-                writer
-                    .write(data)
-                    .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
-                Ok(())
+                write_all(writer, data, progress, MonorubyErr::ioerr)
             }
             // `ensure_writable` already rejected non-writable streams.
             Self::Stdin | Self::Closed(..) => unreachable!(),
@@ -501,22 +664,33 @@ impl IoInner {
     }
 
     fn read_underlying(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
+        // On a signal interrupt (`Interrupted` out of the read helpers),
+        // bytes already consumed from the fd are pushed back so that the
+        // retried read (after a `Signal.trap` handler ran) returns them
+        // first and no data is lost. `pushback` is `None` for Stdin, which
+        // has no pushback cell — an interrupted stdin read may drop the
+        // partial data, like the pre-existing ungetc limitation there.
+        let interrupted =
+            |partial: Vec<u8>, pushback: Option<&RefCell<Vec<u8>>>| -> MonorubyErr {
+                if !partial.is_empty()
+                    && let Some(cell) = pushback
+                {
+                    cell.borrow_mut().splice(0..0, partial);
+                }
+                MonorubyErr::signal_interrupt()
+            };
         match self {
             Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
             Self::Stdin => {
-                if let Some(length) = length {
-                    let buf = match std::io::stdin().bytes().take(length).collect() {
-                        Ok(buf) => buf,
-                        Err(e) => return Err(MonorubyErr::runtimeerr(e.to_string())),
-                    };
-                    Ok(buf)
+                let mut buf = vec![];
+                let res = if let Some(length) = length {
+                    read_upto(&mut std::io::stdin(), length, &mut buf)
                 } else {
-                    let mut buf = vec![];
-                    match std::io::stdin().read_to_end(&mut buf) {
-                        Ok(_) => {}
-                        Err(e) => return Err(MonorubyErr::runtimeerr(e.to_string())),
-                    }
-                    Ok(buf)
+                    read_all(&mut std::io::stdin(), &mut buf)
+                };
+                match res {
+                    Ok(()) => Ok(buf),
+                    Err(e) => Err(map_read_err(e, MonorubyErr::runtimeerr)),
                 }
             }
             Self::Stdout => Err(MonorubyErr::argumenterr("can't read from $stdin")),
@@ -525,22 +699,20 @@ impl IoInner {
                 if !file.readable {
                     return Err(MonorubyErr::ioerr("not opened for reading"));
                 }
-                // `&mut *...reader` peels the ManuallyDrop wrapper to yield
-                // `&mut BufReader<File>`, which is needed because `Read::bytes`
-                // takes `self` by value and would otherwise try to move out of
-                // the ManuallyDrop.
-                let file = &mut *Rc::get_mut(file).unwrap().reader;
-                if let Some(length) = length {
-                    let buf = match file.bytes().take(length).collect() {
-                        Ok(buf) => buf,
-                        Err(e) => return Err(MonorubyErr::runtimeerr(e.to_string())),
-                    };
-                    Ok(buf)
+                let file = Rc::get_mut(file).unwrap();
+                let reader = &mut *file.reader;
+                let mut buf = vec![];
+                let res = if let Some(length) = length {
+                    read_upto(reader, length, &mut buf)
                 } else {
-                    let mut buf = vec![];
-                    file.read_to_end(&mut buf)
-                        .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
-                    Ok(buf)
+                    read_all(reader, &mut buf)
+                };
+                match res {
+                    Ok(()) => Ok(buf),
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        Err(interrupted(buf, Some(&file.pushback)))
+                    }
+                    Err(e) => Err(MonorubyErr::runtimeerr(e.to_string())),
                 }
             }
             Self::Popen(popen) => {
@@ -549,16 +721,18 @@ impl IoInner {
                     .reader
                     .as_mut()
                     .ok_or_else(|| MonorubyErr::ioerr("not opened for reading"))?;
-                if let Some(length) = length {
-                    let buf: std::result::Result<Vec<u8>, _> =
-                        reader.bytes().take(length).collect();
-                    buf.map_err(|e| MonorubyErr::ioerr(e.to_string()))
+                let mut buf = vec![];
+                let res = if let Some(length) = length {
+                    read_upto(reader, length, &mut buf)
                 } else {
-                    let mut buf = vec![];
-                    reader
-                        .read_to_end(&mut buf)
-                        .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
-                    Ok(buf)
+                    read_all(reader, &mut buf)
+                };
+                match res {
+                    Ok(()) => Ok(buf),
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        Err(interrupted(buf, Some(&popen.pushback)))
+                    }
+                    Err(e) => Err(MonorubyErr::ioerr(e.to_string())),
                 }
             }
         }
@@ -575,7 +749,7 @@ impl IoInner {
     /// Returns an empty `Vec` only at end of file (the caller raises
     /// `EOFError`).
     pub fn sysread(&mut self, maxlen: usize) -> Result<Vec<u8>> {
-        use std::io::{Read, Seek, SeekFrom};
+        use std::io::{Seek, SeekFrom};
         let mut out = if self.pushback_len() > 0 {
             self.take_pushback(Some(maxlen))
         } else {
@@ -592,9 +766,8 @@ impl IoInner {
             }
             Self::Stdin => {
                 let mut buf = vec![0u8; need];
-                let n = std::io::stdin()
-                    .read(&mut buf)
-                    .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
+                let n = read_step(&mut std::io::stdin(), &mut buf)
+                    .map_err(|e| map_read_err(e, MonorubyErr::runtimeerr))?;
                 buf.truncate(n);
                 buf
             }
@@ -602,7 +775,8 @@ impl IoInner {
                 if !file.readable {
                     return Err(MonorubyErr::ioerr("not opened for reading"));
                 }
-                let reader = &mut *Rc::get_mut(file).unwrap().reader;
+                let fdesc = Rc::get_mut(file).unwrap();
+                let reader = &mut *fdesc.reader;
                 // Sync the underlying fd to the logical position and
                 // discard the BufReader buffer. Best-effort: pipe /
                 // socket fds (also stored as `File`) are not seekable
@@ -610,24 +784,38 @@ impl IoInner {
                 // below simply returns whatever is available.
                 let _ = reader.seek(SeekFrom::Current(0));
                 let mut buf = vec![0u8; need];
-                let n = reader
-                    .get_mut()
-                    .read(&mut buf)
-                    .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?;
+                let n = match read_step(reader.get_mut(), &mut buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        // Preserve pushback bytes already drained into
+                        // `out` for the retry after the trap handler.
+                        if !out.is_empty() {
+                            fdesc.pushback.borrow_mut().splice(0..0, out);
+                        }
+                        return Err(MonorubyErr::signal_interrupt());
+                    }
+                    Err(e) => return Err(MonorubyErr::runtimeerr(e.to_string())),
+                };
                 buf.truncate(n);
                 buf
             }
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
-                let reader = popen
-                    .reader
-                    .as_mut()
-                    .ok_or_else(|| MonorubyErr::ioerr("not opened for reading"))?;
+                let reader = match popen.reader.as_mut() {
+                    Some(r) => r,
+                    None => return Err(MonorubyErr::ioerr("not opened for reading")),
+                };
                 let mut buf = vec![0u8; need];
-                let n = reader
-                    .get_mut()
-                    .read(&mut buf)
-                    .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
+                let n = match read_step(reader.get_mut(), &mut buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        if !out.is_empty() {
+                            popen.pushback.borrow_mut().splice(0..0, out);
+                        }
+                        return Err(MonorubyErr::signal_interrupt());
+                    }
+                    Err(e) => return Err(MonorubyErr::ioerr(e.to_string())),
+                };
                 buf.truncate(n);
                 buf
             }
@@ -802,21 +990,35 @@ impl IoInner {
 
     fn read_line_bytes_underlying(&mut self) -> Result<Option<Vec<u8>>> {
         let mut buf = Vec::new();
+        // See `read_underlying`: on a signal interrupt, push already-read
+        // bytes back so the retried getline sees them first.
+        let interrupted =
+            |partial: Vec<u8>, pushback: Option<&RefCell<Vec<u8>>>| -> MonorubyErr {
+                if !partial.is_empty()
+                    && let Some(cell) = pushback
+                {
+                    cell.borrow_mut().splice(0..0, partial);
+                }
+                MonorubyErr::signal_interrupt()
+            };
         let size = match self {
             Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
-            Self::Stdin => std::io::stdin()
-                .lock()
-                .read_until(b'\n', &mut buf)
-                .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?,
+            Self::Stdin => read_until_step(&mut std::io::stdin().lock(), b'\n', &mut buf)
+                .map_err(|e| map_read_err(e, MonorubyErr::runtimeerr))?,
             Self::Stdout => return Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => return Err(MonorubyErr::argumenterr("can't read from $stderr")),
             Self::File(file) => {
                 if !file.readable {
                     return Err(MonorubyErr::ioerr("not opened for reading"));
                 }
-                let file = &mut *Rc::get_mut(file).unwrap().reader;
-                file.read_until(b'\n', &mut buf)
-                    .map_err(|e| MonorubyErr::runtimeerr(e.to_string()))?
+                let file = Rc::get_mut(file).unwrap();
+                match read_until_step(&mut *file.reader, b'\n', &mut buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        return Err(interrupted(buf, Some(&file.pushback)));
+                    }
+                    Err(e) => return Err(MonorubyErr::runtimeerr(e.to_string())),
+                }
             }
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
@@ -824,9 +1026,13 @@ impl IoInner {
                     .reader
                     .as_mut()
                     .ok_or_else(|| MonorubyErr::ioerr("not opened for reading"))?;
-                reader
-                    .read_until(b'\n', &mut buf)
-                    .map_err(|e| MonorubyErr::ioerr(e.to_string()))?
+                match read_until_step(reader, b'\n', &mut buf) {
+                    Ok(n) => n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        return Err(interrupted(buf, Some(&popen.pushback)));
+                    }
+                    Err(e) => return Err(MonorubyErr::ioerr(e.to_string())),
+                }
             }
         };
         if size == 0 {
@@ -838,6 +1044,22 @@ impl IoInner {
     /// Read one byte (pushback-aware). `None` at EOF.
     fn read1(&mut self) -> Result<Option<u8>> {
         Ok(self.read(Some(1))?.first().copied())
+    }
+
+    /// `read1` for the getline accumulation loops: on a signal interrupt,
+    /// push the bytes accumulated so far (`acc`) back into the pushback
+    /// buffer so the getline retried after a `Signal.trap` handler
+    /// re-reads them and no data is lost.
+    fn read1_preserving(&mut self, acc: &[u8]) -> Result<Option<u8>> {
+        match self.read1() {
+            Err(err) => {
+                if err.is_signal_interrupt() && !acc.is_empty() {
+                    let _ = self.unget(acc);
+                }
+                Err(err)
+            }
+            ok => ok,
+        }
     }
 
     /// General line reader implementing CRuby's `IO#gets` semantics:
@@ -879,7 +1101,7 @@ impl IoInner {
                 // Paragraph mode: skip the blank lines between paragraphs.
                 let mut buf = Vec::new();
                 loop {
-                    match self.read1()? {
+                    match self.read1_preserving(&buf)? {
                         None => return Ok(None),
                         Some(b'\n') => continue,
                         Some(b) => {
@@ -898,7 +1120,7 @@ impl IoInner {
                         }
                         break;
                     }
-                    match self.read1()? {
+                    match self.read1_preserving(&buf)? {
                         None => break,
                         Some(b) => {
                             buf.push(b);
@@ -914,7 +1136,7 @@ impl IoInner {
                     // positioned at the start of the next paragraph
                     // (CRuby's swallow(io, '\n')).
                     loop {
-                        match self.read1()? {
+                        match self.read1_preserving(&buf)? {
                             Some(b'\n') => continue,
                             Some(b) => {
                                 let _ = self.unget(&[b]);
@@ -941,7 +1163,7 @@ impl IoInner {
                         }
                         break;
                     }
-                    match self.read1()? {
+                    match self.read1_preserving(&buf)? {
                         None => break,
                         Some(b) => {
                             buf.push(b);
@@ -971,7 +1193,7 @@ impl IoInner {
             if utf8_missing_bytes(buf) == 0 {
                 return Ok(());
             }
-            match self.read1()? {
+            match self.read1_preserving(buf)? {
                 None => return Ok(()),
                 Some(b) => buf.push(b),
             }


### PR DESCRIPTION
## Problem

Follow-up to #935. Since the signal-handling change (a5157791), a monoruby process blocked in `read(2)`/`write(2)`/`select(2)` could not be terminated by SIGTERM at all — only SIGKILL worked. Two independent causes:

1. Signal stubs were installed **with `SA_RESTART`**, so a blocking syscall that had transferred 0 bytes was transparently restarted by the kernel and never returned EINTR.
2. Even without `SA_RESTART`, the read paths used Rust std helpers (`Bytes`, `read_to_end`, `read_until`) that **silently retry `ErrorKind::Interrupted`**, so the interpreter never reached the poll point that converts pending signals.

CRuby dies to SIGTERM in the same situation (the pending interrupt is checked when the blocking region is interrupted); this is what made the hang-prone specs stall CI batches un-killably.

## Fix

- **Install signal stubs without `SA_RESTART`**, like CRuby, so signals EINTR blocking syscalls.
- **Signal-aware IO primitives** (`value/rvalue/io.rs`): replacements for the EINTR-swallowing std helpers surface "EINTR with a pending signal" as an internal marker error, and check the pending bit **before every kernel entry**. The latter matters: a blocking pipe write that has already transferred bytes returns the *partial count* on a signal instead of EINTR (verified with strace), so an EINTR-only check deadlocks on the very next `write(2)`.
- **`blocking_region()` wrapper** in the IO builtins catches the marker and runs the VM poll point: the default disposition raises the converted `SignalException` out of the blocking call, while a `Signal.trap` handler runs and the operation **restarts with no data loss** — partial reads are pushed back through the ungetc buffer, and writes track progress and resume mid-buffer (which also fixes silent short writes on pipes).
- `IO.select` retries after a trap handler instead of raising `Errno::EINTR`; `Process.wait`/`waitpid` and `IO#syswrite` poll on EINTR the same way.

## Verification

- All 8 blocking scenarios — `read`, `gets`, `IO.select`, `readpartial`, `sysread`, `getc`, `each_line`, blocked pipe `write` — now die to a single `timeout 5` SIGTERM (exit 124; previously all required `-k` SIGKILL / exit 137).
- Rescuable and CRuby-identical: `begin; r.gets; rescue SignalException => e` → `SIGTERM`, same output as CRuby 4.0.2.
- Trap-and-resume, byte-identical to CRuby: a `gets` blocked on a FIFO interrupted by USR1 runs the trap handler, resumes, and returns the full line.
- `cargo test --lib` passes (full CRuby-differential suite).
- The spec-core CI simulation on `core/io` still pins exactly the two known Thread-dependent hangs (`copy_stream_spec.rb`, `select_spec.rb`) and now tallies **1602 examples, up from 1402** — with TERM effective, the non-hanging examples in a timed-out file complete and get counted instead of dying with the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_