### PR TITLE
Hash#map: arity-adaptive, correct for #each-overriding subclasses

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -201,10 +201,20 @@ class Hash
   def map(&blk)
     return to_enum(:map) { size } unless blk
     result = []
-    if blk.arity == 1
-      each { |pair| result << blk.call(pair) }
-    else
-      each { |pair| result << blk.call(*pair) }
+    # Capture every value `each` yields. A plain Hash yields a single
+    # [k, v] pair, but a subclass may override `each` to `yield k, v` as
+    # two separate values (or `yield [k, v]` as one) — normalise both.
+    # An arity-1 block/proc sees the element as-is (the pair for a plain
+    # Hash, the first value for a two-value yield); anything else has the
+    # pair splatted, so a strict arity-2 block/Method receives k and v
+    # (matches CRuby rb_yield_values2 / the enumerable map specs).
+    each do |*vs|
+      if blk.arity == 1
+        result << blk.call(vs[0])
+      else
+        pair = vs.size == 1 ? vs[0] : vs
+        result << blk.call(*pair)
+      end
     end
     result
   end

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4400,4 +4400,47 @@ mod tests {
             r#"[[1, 2]].map { |k| k }"#,
         ]);
     }
+
+    #[test]
+    fn hash_map_arity_and_subclass() {
+        run_tests(&[
+            // Plain Hash#map: a two-param block sees k, v; a one-param block
+            // sees the [k, v] pair.
+            r#"{a: 1, b: 2}.map { |k, v| [k, v] }"#,
+            r#"{a: 1, b: 2}.map { |x| x }"#,
+            // A strict arity-2 Method (no auto-splat) still receives k and v.
+            r#"
+            c = Class.new { def register(a, b); [a, b]; end }
+            m = c.new.method(:register)
+            {1 => "a", 2 => "b"}.map(&m)
+            "#,
+        ]);
+        // A subclass overriding #each to `yield k, v` (two values) maps
+        // correctly for both block arities.
+        run_test(
+            r#"
+            cls = Class.new(Hash) do
+              def each
+                super { |k, v| yield k, v }
+              end
+            end
+            o = cls.new
+            o["x"] = "y"
+            [o.map { |k, v| [k, v] }, o.map { |z| z }]
+            "#,
+        );
+        // A subclass overriding #each to `yield [k, v]` (one array) too.
+        run_test(
+            r#"
+            cls = Class.new(Hash) do
+              def each
+                super { |k, v| yield [k, v] }
+              end
+            end
+            o = cls.new
+            o["x"] = "y"
+            o.map { |k, v| [k, v] }
+            "#,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Tier 2 (`core/hash`). Fixes `core/hash/each_pair_spec.rb` "properly expands (or not) child class's 'each'-yielded args".

`Hash#map` assumed `each` yields a single `[k, v]` array and captured it with a one-parameter collector block (`each { |pair| ... }`). A subclass that overrides `each` to `yield k, v` (two separate values) then had `pair` bind only the key, so the value was lost — `subclass.map { |k, v| [k, v] }` returned `[[k, nil]]`.

## Fix

Capture all yielded values with `|*vs|` and normalise the pair:

- A plain Hash yields one `[k, v]` array; a subclass may yield two values (or one array).
- An arity-1 block/proc receives the element **as-is** — the pair for a plain Hash, the first value for a two-value yield (matching CRuby, where `yield k, v` to a `{ |x| }` block binds `x = k`).
- Otherwise the pair is splatted, so a strict arity-2 block or bound `Method` still receives `k` and `v`.

This preserves the pre-existing behaviour that a bound `Method` of arity 2 works (the `core/enumerable/map_spec.rb` "yields 2 arguments for a Hash when block arity is 2" case) — my first attempt with a plain `yield(*vs)` regressed that, since a plain Hash yields the pair as a single array a strict Method won't auto-splat.

## Verification

- ruby/spec: `core/hash/each_pair_spec.rb` (FAILED → all 12 pass); `core/enumerable/map_spec.rb` Hash-arity-2 case stays green (no regression).
- `core/hash` category: **2 failures / 1 error → 1 failure / 1 error**; remaining two are pre-existing/unrelated (mock-collision `[]=`, `inspect` under changed encoding).
- Verified directly: plain Hash `|k,v|`/`|x|`, arity-2 `Method`, and subclasses overriding `each` with both `yield k, v` and `yield [k, v]`.
- Added unit test `hash_map_arity_and_subclass`; full `cargo test -p monoruby --lib` green (1869 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_