### PR TITLE
Native "given block not used" warnings: include the caller location

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -456,7 +456,7 @@ extern "C" fn array_dup_extern(val: Value, globals: &Globals) -> Value {
 fn count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     if let Some(arg0) = lfp.try_arg(0) {
         if lfp.block().is_some() {
-            vm.ruby_warn(globals, "warning: given block not used")?;
+            vm.ruby_warn_caller(globals, "warning: given block not used")?;
         }
         let mut count = 0;
         let ary = lfp.self_val();
@@ -1663,7 +1663,9 @@ fn inject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         return vm.invoke_block_fold1(globals, bh, iter, res);
     }
     if lfp.block().is_some() && lfp.try_arg(1).is_some() {
-        vm.ruby_warn(globals, "warning: given block not used")?;
+        // CRuby emits this with an implicit `uplevel: 1`, so the message is
+        // prefixed with the location of the `inject` call site.
+        vm.ruby_warn_caller(globals, "warning: given block not used")?;
     }
     // The `inject(sym)` form may consume the first element as the
     // initial accumulator; track where the remaining elements start.
@@ -2993,7 +2995,7 @@ fn all_any_inner(
     if let Some(pattern) = lfp.try_arg(0) {
         // Pattern form: all?(pattern) / any?(pattern) — block is ignored
         if lfp.block().is_some() {
-            vm.ruby_warn(globals, "warning: given block not used")?;
+            vm.ruby_warn_caller(globals, "warning: given block not used")?;
         }
         let mut i = 0;
         while i < self_val.as_array().len() {
@@ -3980,7 +3982,7 @@ fn find_index(
     let self_val = lfp.self_val();
     if let Some(arg0) = lfp.try_arg(0) {
         if lfp.block().is_some() {
-            vm.ruby_warn(globals, "warning: given block not used")?;
+            vm.ruby_warn_caller(globals, "warning: given block not used")?;
         }
         let func_id = vm.find_method(globals, arg0, IdentId::_EQ, false)?;
         let mut i = 0;
@@ -6568,6 +6570,11 @@ mod tests {
             r#"[1, 2, 3].none?(String) { |x| true }"#,
             r#"[1, 2, 3].one?(Integer) { |x| false }"#,
             r#"[1, 2, 3].count(2) { |x| true }"#,
+            // inject(init, sym) ignores the block (a warning goes to stderr,
+            // checked by ruby/spec; here we confirm the result is the folded
+            // value, not the block's).
+            r#"[1, 2, 3].inject(10, :-) { raise "never" }"#,
+            r#"[1, 2, 3, 4].inject(0, :+) { 99 }"#,
         ]);
     }
 }

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -637,6 +637,60 @@ impl Executor {
         Ok(())
     }
 
+    ///
+    /// The `"file:line"` of the nearest Ruby (iseq) caller of the current
+    /// native builtin frame.
+    ///
+    /// Used for CRuby-style warnings that prefix the caller's location
+    /// (e.g. `Array#inject`'s "given block not used", emitted with an
+    /// implicit `uplevel: 1`). Returns `None` when no iseq caller is found.
+    ///
+    pub(crate) fn nearest_caller_location(&self, store: &Store) -> Option<String> {
+        // Walk callers via each inner frame's saved call-site pc, exactly
+        // like `Kernel#caller` / `complete_backtrace_for_rescue`, skipping
+        // native frames until the first Ruby (iseq) caller.
+        let mut inner_cfp = self.cfp();
+        let mut cfp = inner_cfp.prev()?;
+        loop {
+            let func_id = cfp.lfp().func_id();
+            if let Some(iseq_id) = store[func_id].is_iseq() {
+                let info = &store[iseq_id];
+                let loc = {
+                    let slot = inner_cfp.caller_pc_slot();
+                    if slot != 0
+                        && slot % 8 == 0
+                        && let Some(pc) =
+                            unsafe { crate::bytecode::BytecodePtr::from_raw(slot as *mut _) }
+                        && info.contains_pc(pc)
+                    {
+                        info.sourcemap[info.get_pc_index(Some(pc)).to_usize()]
+                    } else {
+                        info.loc
+                    }
+                };
+                return Some(format!(
+                    "{}:{}",
+                    info.sourceinfo.file_name(),
+                    info.sourceinfo.get_line(&loc)
+                ));
+            }
+            inner_cfp = cfp;
+            cfp = cfp.prev()?;
+        }
+    }
+
+    ///
+    /// Like [`Self::ruby_warn`], but prefixes the message with the nearest
+    /// Ruby caller's `"file:line: "` (CRuby's `rb_warn` / `warn(uplevel: 1)`
+    /// behaviour). Falls back to the bare message when no caller is found.
+    ///
+    pub(crate) fn ruby_warn_caller(&mut self, globals: &mut Globals, msg: &str) -> Result<()> {
+        match self.nearest_caller_location(&globals.store) {
+            Some(loc) => self.ruby_warn(globals, &format!("{loc}: {msg}")),
+            None => self.ruby_warn(globals, msg),
+        }
+    }
+
     pub(crate) fn compare_values(
         &mut self,
         globals: &mut Globals,


### PR DESCRIPTION
## Summary

Tier 2 (`core/enumerable`). Fixes `core/enumerable/inject_spec.rb` "ignores the block if two arguments".

CRuby emits the "given block not used" warning through `rb_warn`, which prefixes the message with the call site's `file:line:` (equivalent to an implicit `uplevel: 1`). monoruby's native `Array#inject` / `#count` / `#all?` / `#any?` / `#find_index` emitted it via `ruby_warn`, which writes only the bare message — so a spec asserting `-> { [1,2,3].inject(10, :-) { } }.should complain(/…:NN: warning: given block not used/)` failed on the missing location. (The Ruby-level `Enumerable#inject` path already produces the location via `warn ..., uplevel: 1`; only the native Array fast paths were missing it.)

## Fix

- Add `Executor::nearest_caller_location`, which walks caller frames exactly like `Kernel#caller` / the rescue-backtrace builder (decoding each inner frame's saved call-site pc), skipping native frames to the first Ruby (iseq) caller, and returns its `"file:line"`.
- Add `Executor::ruby_warn_caller`, which prefixes the message with that location (falling back to the bare message when no caller is found).
- Route the native ignored-block warnings (`inject`, `count`, `all?`/`any?`, `find_index`) through it.

`Array#initialize`'s warning is intentionally left on the bare `ruby_warn`: its warn *condition* already differs from CRuby (a separate pre-existing issue — CRuby doesn't warn for `Array.new(ary) { }` where monoruby does), so fixing its wording is out of scope here.

## Verification

- ruby/spec: `core/enumerable/inject_spec.rb` "ignores the block if two arguments" (FAILED → pass); `core/array/{count,all,any,find_index}_spec.rb` stay green.
- `core/enumerable`: **4 failures → 3** (the remaining three — `grep_v` `$~`, `inject` collection-growth, `map` arity reporting — are pre-existing and unrelated).
- Verified `inject`/`count`/`find_index`/`all?`/`any?` warnings now match CRuby's `file:line: warning: given block not used` byte-for-byte.
- Added unit coverage for the block-ignored `inject` result; full `cargo test -p monoruby --lib` green (1869 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_