### PR TITLE
Array#inject: re-read the receiver each step (tolerate growth)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1648,25 +1648,45 @@ fn zip(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerable/i/inject.html]
 #[monoruby_builtin]
 fn inject(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let self_ = lfp.self_val().as_array();
-    let mut iter = self_.iter().cloned();
     // A block is used only for the 0/1-argument forms. With two
     // arguments (init, sym) the block is ignored (CRuby warns).
     if let Some(bh) = lfp.block()
         && lfp.try_arg(1).is_none()
     {
-        let res = if lfp.try_arg(0).is_none() {
-            iter.next().unwrap_or_default()
+        // Fold with the block, re-reading the receiver by index each step so
+        // that growing the array inside the block is tolerated: CRuby visits
+        // the appended elements too (and a shrink simply stops early). A
+        // snapshot iterator would miss them.
+        let self_val = lfp.self_val();
+        let data = vm.get_block_data(globals, bh)?;
+        let (mut res, mut i) = if lfp.try_arg(0).is_none() {
+            let ary = self_val.as_array();
+            if ary.len() == 0 {
+                return Ok(Value::nil());
+            }
+            (ary[0], 1usize)
         } else {
-            lfp.arg(0)
+            (lfp.arg(0), 0usize)
         };
-        return vm.invoke_block_fold1(globals, bh, iter, res);
+        loop {
+            let elem = {
+                let ary = self_val.as_array();
+                if i >= ary.len() {
+                    break;
+                }
+                ary[i]
+            };
+            i += 1;
+            res = vm.invoke_block(globals, &data, &[res, elem])?;
+        }
+        return Ok(res);
     }
     if lfp.block().is_some() && lfp.try_arg(1).is_some() {
         // CRuby emits this with an implicit `uplevel: 1`, so the message is
         // prefixed with the location of the `inject` call site.
         vm.ruby_warn_caller(globals, "warning: given block not used")?;
     }
+    let self_ = lfp.self_val().as_array();
     // The `inject(sym)` form may consume the first element as the
     // initial accumulator; track where the remaining elements start.
     // A non-Symbol/String method name is coerced via `#to_str`.
@@ -6575,6 +6595,23 @@ mod tests {
             // value, not the block's).
             r#"[1, 2, 3].inject(10, :-) { raise "never" }"#,
             r#"[1, 2, 3, 4].inject(0, :+) { 99 }"#,
+            // inject with a block re-reads the receiver each step, so
+            // appending inside the block is tolerated and the new elements
+            // are folded in (CRuby).
+            r#"
+            a = [:a, :b, :c]
+            i = 0
+            visited = []
+            a.inject(nil) { |_, e| visited << e; a << i if i < 5; i += 1 }
+            visited
+            "#,
+            // The no-initial-value block form uses the first element as the
+            // seed and still tolerates growth.
+            r#"
+            a = [1, 2, 3]
+            n = 0
+            a.inject { |s, e| a << 10 if n < 2; n += 1; s + e }
+            "#,
         ]);
     }
 }

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -6612,6 +6612,8 @@ mod tests {
             n = 0
             a.inject { |s, e| a << 10 if n < 2; n += 1; s + e }
             "#,
+            // No initial value and an empty receiver yields nil.
+            r#"[].inject { |s, e| s + e }"#,
         ]);
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2602,20 +2602,6 @@ impl Executor {
         Ok(v)
     }
 
-    pub(crate) fn invoke_block_fold1(
-        &mut self,
-        globals: &mut Globals,
-        bh: BlockHandler,
-        iter: impl Iterator<Item = Value>,
-        mut res: Value,
-    ) -> Result<Value> {
-        let data = self.get_block_data(globals, bh)?;
-        for elem in iter {
-            res = self.invoke_block(globals, &data, &[res, elem])?;
-        }
-        Ok(res)
-    }
-
     ///
     /// Invoke proc.
     ///


### PR DESCRIPTION
## Summary

Tier 2 (`core/enumerable`). Fixes `core/enumerable/inject_spec.rb` "tolerates increasing a collection size during iterating Array".

CRuby's `inject`/`reduce` over an Array re-reads the collection as it iterates, so appending to the array inside the fold block visits the newly-added elements too (and shrinking it simply stops early). monoruby's native `Array#inject` folded over a snapshot iterator (`self.iter().cloned()`), so elements appended during the block were never seen — `array.inject(nil) { |_, e| array << … }` stopped after the original elements.

## Fix

Rewrite the block form (0/1-argument) as an index loop that re-reads `self` and its current length on every step (the same pattern `Array#sum` already uses), matching CRuby's growth tolerance. The two-argument `(init, sym)` form and the `inject(:+)` Fixnum fast path are unchanged. The now-unused `Executor::invoke_block_fold1` helper is removed.

## Verification

- ruby/spec: `core/enumerable/inject_spec.rb` now fully green (18 examples, was 1 failure); `core/array/inject_spec.rb` / `reduce_spec.rb` stay green.
- `core/enumerable`: **3 failures → 2** (the remaining two — `grep_v` `$~` frame-scoping and `map` block-arity reporting — are architectural and unrelated).
- Verified all inject forms: `inject(:+)`, `inject(init) { }`, no-init `inject { }`, empty/single-element receivers, and growth in both the init and no-init block forms.
- Added unit coverage for the growth cases; full `cargo test -p monoruby --lib` green (1869 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_