### PR TITLE
Green threads (M:1): scheduler core and a minimal real Thread

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -758,78 +758,22 @@ class Fiber
 end
 
 class Thread
-  # monoruby runs on a single OS thread and does NOT provide concurrency.
-  # `Thread` exists only so that RubyGems / Bundler — and the little stdlib
-  # that references it — load and run. `Thread.new` / `Thread.start` store
-  # the block and run it lazily, on the *single* main thread, the first time
-  # its result is demanded via `#value` (used by rubygems' request_set and
-  # by `Class#subclasses`-style specs).
+  # monoruby threads are cooperative green threads multiplexed on the one
+  # OS thread by the native scheduler (src/scheduler.rs). The native side
+  # provides: Thread.new / .start / .fork (queue a body), .current /
+  # .main / .list / .pass / .stop, and #join / #value / #status /
+  # #alive? / #stop? / #wakeup / #run. Blocking APIs park the calling
+  # thread on the scheduler; a body starts running the first time any
+  # thread reaches a blocking point.
   #
-  # APIs that presuppose a real scheduler observing a *running* body — `#join`,
-  # `#kill`, `#run`, `#wakeup`, `#raise`, `#status`, `#alive?`, `#stop?`,
-  # `Thread.pass`, `Thread.stop`, `#report_on_exception`, ... — are deliberately
-  # NOT defined. On one OS thread they could only hang (a body never runs on
-  # its own, so a `Thread.pass until flag` / `#join` waiting on it spins
-  # forever) or report fictional state, so they fail fast with NoMethodError
-  # instead of hanging a ruby/spec run. `#value` is the one body-runner kept
-  # (it terminates or fails fast — a body that blocks forever on another
-  # thread instead runs to a no-op here); the hang-prone waiting/observation
-  # APIs above are gone. The rest of the kept surface is exactly what RubyGems
-  # / Bundler touch: identity (`current`), a name, thread-/fiber-local storage,
-  # an interrupt-mask no-op, and the Mutex / Queue / ConditionVariable shells
-  # (all trivial — there is nothing to contend for).
+  # This Ruby side keeps only the pure-bookkeeping surface: a name,
+  # thread-/fiber-local storage, and an interrupt-mask no-op (real
+  # asynchronous interruption — #raise / #kill — is not implemented yet,
+  # so there is nothing to mask).
 
-  def initialize(*args, &block)
-    @block = block
-    @args = args
-    @ran = false
-    @value = nil
-    @exception = nil
-    @fiber_locals = {}
-    @thread_variables = {}
-    @name = nil
-  end
-
-  def self.current
-    @@current
-  end
-  @@current = new
-
-  # Run the stored block (once) on the main thread and return its value.
-  # monoruby is single-threaded, so this is where a `Thread.new` body
-  # actually executes. Re-raises a body that raised (matching CRuby's
-  # `#value`). `#join` and the status/observation APIs are intentionally
-  # absent — see the class comment.
-  def value
-    __run
-    raise @exception if @exception
-    @value
-  end
-
-  def __run
-    return if @ran
-    @ran = true
-    begin
-      # Route through the native helper so a bare `return` / `break` in the
-      # body raises LocalJumpError (as in CRuby) rather than escaping the
-      # synchronously-run block.
-      @value = @block ? __invoke_body(@block, @args) : nil
-    rescue => e
-      @exception = e
-    end
-    self
-  end
-  private :__run
-  private :__invoke_body
-
-  # `Thread.start` is an alias of `Thread.new` in CRuby.
-  def self.start(*args, &block)
-    new(*args, &block)
-  end
-
-  # With a single thread there is nothing to mask against asynchronous
-  # interruption, so just run the block (used by Bundler's connection_pool
-  # and by timeout).
+  # Interrupt masking: monoruby delivers no asynchronous interrupts yet,
+  # so just run the block (used by Bundler's connection_pool and by
+  # timeout).
   def self.handle_interrupt(mask)
     yield
   end
@@ -842,20 +786,22 @@ class Thread
 
   attr_accessor :name
 
+  # Thread objects are native (ObjTy::THREAD) and no longer run a Ruby
+  # initialize, so the local-storage tables are created lazily.
   def [](key)
-    @fiber_locals[key]
+    @fiber_locals && @fiber_locals[key]
   end
 
   def []=(key, value)
-    @fiber_locals[key] = value
+    (@fiber_locals ||= {})[key] = value
   end
 
   def thread_variable_get(key)
-    @thread_variables[key]
+    @thread_variables && @thread_variables[key]
   end
 
   def thread_variable_set(key, value)
-    @thread_variables[key] = value
+    (@thread_variables ||= {})[key] = value
   end
 
   # The object returned by `Process.detach`. Reaping one specific child via
@@ -865,11 +811,20 @@ class Thread
   # (`Errno::ECHILD`) yields nil, matching CRuby. This is what keeps Open3's
   # `wait_thr.value` / `wait_thr.join` working.
   class Waiter < Thread
-    def initialize(pid)
-      super()
+    # The native Thread.new requires a block (it queues a green thread);
+    # a Waiter is an inert shell around one specific child pid, so build
+    # it via allocate.
+    def self.new(pid)
+      w = allocate
+      w.__send__(:__init_waiter, pid)
+      w
+    end
+
+    def __init_waiter(pid)
       @pid = pid
       self[:pid] = pid
     end
+    private :__init_waiter
 
     attr_reader :pid
 

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -72,6 +72,16 @@ fn fiber_yield(
     vm.yield_fiber(val)
 }
 
+/// Out-of-line error path for the inlined `Fiber.yield`: yielding with
+/// no parent fiber (the main fiber, or a green thread's root) raises
+/// FiberError instead of switching through a null parent pointer.
+pub(crate) extern "C" fn fiber_yield_no_parent(vm: &mut Executor) -> Option<Value> {
+    vm.set_error(MonorubyErr::fibererr(
+        "attempt to yield on a not resumed fiber".to_string(),
+    ));
+    None
+}
+
 fn fiber_yield_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -106,7 +116,6 @@ fn fiber_yield_inline(
     let using_fpr = state.get_using_fpr(ir);
     let error = ir.new_error(state);
     ir.fpr_save(using_fpr);
-    // TODO: we must check if the parent fiber exits.
     if pos_num == 0 {
         ir.inline(move |r#gen, _, _, _| r#gen.emit_fiber_yield_value_nil());
     } else if pos_num == 1 {
@@ -118,7 +127,8 @@ fn fiber_yield_inline(
     }
     ir.inline(move |r#gen, _, _, _| {
         let yield_fiber = r#gen.yield_fiber as *const () as u64;
-        r#gen.emit_fiber_yield_call(yield_fiber)
+        let no_parent = fiber_yield_no_parent as *const () as u64;
+        r#gen.emit_fiber_yield_call(yield_fiber, no_parent)
     });
     ir.fpr_restore(using_fpr);
     ir.handle_error(error);

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2820,6 +2820,25 @@ fn command(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn sleep(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let now = std::time::Instant::now();
+    // With other live green threads, sleeping must yield to the
+    // scheduler so they run during the wait (and a no-duration sleep
+    // parks until Thread#wakeup instead of returning immediately).
+    if crate::scheduler::has_other_live_threads() {
+        let dur = match lfp.try_arg(0) {
+            Some(sec) => {
+                let sec = sec.coerce_to_f64(vm, globals)?;
+                if sec.is_nan() || sec < 0.0 {
+                    return Err(MonorubyErr::argumenterr(
+                        "time interval must not be negative or NaN",
+                    ));
+                }
+                Some(std::time::Duration::from_secs_f64(sec))
+            }
+            None => None,
+        };
+        let elapsed = crate::scheduler::sleep(vm, globals, dur)?;
+        return Ok(Value::integer(elapsed.as_secs() as i64));
+    }
     if let Some(sec) = lfp.try_arg(0) {
         let sec = sec.coerce_to_f64(vm, globals)?;
         if sec.is_nan() || sec < 0.0 {

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -1,88 +1,278 @@
 use super::*;
+use crate::scheduler;
+use crate::value::rvalue::{ThreadInner, ThreadState};
 
 //
 // Thread class
 //
-// monoruby runs Ruby code on a single OS thread and does not provide
-// concurrency. Most of `Thread` lives in monoruby/builtins/startup.rb as
-// plain Ruby: `Thread.new` stores its block and runs it lazily on `#value`,
-// on the main thread. The kept surface is what RubyGems / Bundler touch
-// plus `#value`; the hang-prone waiting/observation APIs (#join, #status,
-// Thread.pass, ...) are intentionally absent so they fail fast instead of
-// hanging. Only the one piece that needs native support lives here:
-// `__invoke_body`, which runs a thread body with CRuby-compatible
-// return/break and thread-local `$~`/`$_` semantics.
+// monoruby threads are cooperative green threads multiplexed on the one
+// OS thread by the scheduler (src/scheduler.rs). `Thread.new` queues the
+// body; it starts running the first time any thread reaches a blocking
+// point (`sleep`, `#join`, `Thread.pass`, ...). Blocking APIs park the
+// calling thread on the scheduler instead of blocking the process.
+//
+// Ruby-level surface that is pure bookkeeping (name, thread/fiber-local
+// storage, `Thread::Waiter` for `Process.detach`) stays in
+// monoruby/builtins/startup.rb.
 
 pub(super) fn init(globals: &mut Globals) {
-    let klass = globals.define_class_under_obj("Thread").id();
-    globals.define_builtin_func(klass, "__invoke_body", invoke_body, 2);
+    globals
+        .store
+        .define_builtin_class_under_obj("Thread", THREAD_CLASS, ObjTy::THREAD);
+    globals.store[THREAD_CLASS].set_alloc_func(thread_alloc_func);
+
+    globals.define_builtin_class_func_rest(THREAD_CLASS, "new", thread_new);
+    globals.define_builtin_class_func_rest(THREAD_CLASS, "start", thread_new);
+    globals.define_builtin_class_func_rest(THREAD_CLASS, "fork", thread_new);
+    globals.define_builtin_class_func(THREAD_CLASS, "current", thread_current, 0);
+    globals.define_builtin_class_func(THREAD_CLASS, "main", thread_main, 0);
+    globals.define_builtin_class_func(THREAD_CLASS, "pass", thread_pass, 0);
+    globals.define_builtin_class_func(THREAD_CLASS, "list", thread_list, 0);
+    globals.define_builtin_class_func(THREAD_CLASS, "stop", thread_stop, 0);
+
+    globals.define_builtin_func_with(THREAD_CLASS, "join", thread_join, 0, 1, false);
+    globals.define_builtin_func(THREAD_CLASS, "value", thread_value, 0);
+    globals.define_builtin_func(THREAD_CLASS, "status", thread_status, 0);
+    globals.define_builtin_func(THREAD_CLASS, "alive?", thread_alive, 0);
+    globals.define_builtin_func(THREAD_CLASS, "stop?", thread_stop_p, 0);
+    globals.define_builtin_func(THREAD_CLASS, "wakeup", thread_wakeup, 0);
+    globals.define_builtin_func(THREAD_CLASS, "run", thread_run, 0);
+}
+
+/// Allocator: an inert shell (never scheduled). Exists for Ruby-level
+/// subclasses with their own life cycle — `Thread::Waiter.allocate` from
+/// `Process.detach` — not for user `Thread.allocate` + `#run`.
+pub(crate) extern "C" fn thread_alloc_func(class_id: ClassId, _: &mut Globals) -> Value {
+    Value::new_thread(class_id, ThreadInner::shell())
 }
 
 ///
-/// ### Thread#__invoke_body(block, args)
+/// ### Thread.new
 ///
-/// Runs a thread body block. Used by `Thread#__run` in startup.rb. Emulates
-/// two thread semantics that monoruby's synchronous, single-threaded model
-/// would otherwise break:
+/// - new(*args) {|*args| ... } -> Thread
 ///
-/// 1. **`return` / `break` → `LocalJumpError`.** CRuby runs each thread on
-///    its own stack, so a `return` (or `break`) written directly in a
-///    `Thread.new { ... }` block has no enclosing frame to jump to and
-///    raises `LocalJumpError`. monoruby runs the body synchronously on the
-///    caller's stack, so the block's home frame is still live and the jump
-///    would otherwise escape the body. Catch the escaping `MethodReturn` /
-///    `BlockBreak` here and convert it.
+/// Creates a green thread running the block and queues it; the body gets
+/// its first time slice at the next blocking point of any thread.
 ///
-/// 2. **Thread-local `$~` / `$_`.** These special variables are frame-local,
-///    stored on the block's lexical home method frame — which, run
-///    synchronously, is shared with the code that spawned the thread. Save
-///    that frame's svar container, run the body against a fresh (empty) one,
-///    and restore it, so the body's `$~` / `$_` neither leak out to nor
-///    inherit from the spawning thread (matching CRuby's thread-local
-///    semantics).
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/new.html]
 #[monoruby_builtin]
-fn invoke_body(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let block = Proc::new(lfp.arg(0));
-    let args = lfp.arg(1).as_array();
-
-    // Isolate the block's home method frame's `$~`/`$_` container for the
-    // duration of the body (item 2 above). The saved container is kept
-    // reachable for the GC via the temp stack while it is off the frame.
-    let home_mfp = block.outer_lfp().map(|o| o.mfp());
-    let saved = home_mfp.and_then(|m| m.svar_slot_value());
-    if let Some(m) = home_mfp {
-        if let Some(s) = saved {
-            vm.temp_push(s);
+fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let bh = match lfp.block() {
+        Some(bh) => bh,
+        None => {
+            return Err(MonorubyErr::threaderr(
+                &globals.store,
+                "must be called with a block",
+            ));
         }
-        m.restore_svar_slot(None);
+    };
+    let proc = vm.generate_proc(globals, bh, pc)?;
+    let args = lfp.arg(0).as_array().to_vec();
+    let class_id = lfp.self_val().as_class_id();
+    let thread = Value::new_thread(class_id, ThreadInner::new(proc, args));
+    scheduler::spawn(vm, thread);
+    Ok(thread)
+}
+
+///
+/// ### Thread.current
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/current.html]
+#[monoruby_builtin]
+fn thread_current(vm: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(scheduler::current_thread(vm))
+}
+
+///
+/// ### Thread.main
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/main.html]
+#[monoruby_builtin]
+fn thread_main(vm: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(scheduler::main_thread(vm))
+}
+
+///
+/// ### Thread.pass
+///
+/// Gives every runnable thread a chance to run, then returns nil.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/pass.html]
+#[monoruby_builtin]
+fn thread_pass(vm: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    scheduler::pass(vm, globals)?;
+    Ok(Value::nil())
+}
+
+///
+/// ### Thread.list
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/list.html]
+#[monoruby_builtin]
+fn thread_list(vm: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::array_from_vec(scheduler::thread_list(vm)))
+}
+
+///
+/// ### Thread.stop
+///
+/// Parks the current thread until another thread wakes it with
+/// `#wakeup` / `#run`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/stop.html]
+#[monoruby_builtin]
+fn thread_stop(vm: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    scheduler::sleep(vm, globals, None)?;
+    Ok(Value::nil())
+}
+
+fn join_timeout(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Option<std::time::Duration>> {
+    match lfp.try_arg(0) {
+        None => Ok(None),
+        Some(v) if v.is_nil() => Ok(None),
+        Some(v) => {
+            let secs = v.coerce_to_f64(vm, globals)?;
+            if secs.is_nan() || secs < 0.0 {
+                return Err(MonorubyErr::argumenterr(
+                    "time interval must not be negative or NaN",
+                ));
+            }
+            Ok(Some(std::time::Duration::from_secs_f64(secs)))
+        }
     }
+}
 
-    vm.push_break_barrier(vm.cfp());
-    let result = vm.invoke_proc(globals, &block, &args);
-    vm.pop_break_barrier();
-
-    if let Some(m) = home_mfp {
-        m.restore_svar_slot(saved);
-        if saved.is_some() {
-            vm.temp_pop();
-        }
+///
+/// ### Thread#join
+///
+/// - join -> self
+/// - join(limit) -> self | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/join.html]
+#[monoruby_builtin]
+fn thread_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let timeout = join_timeout(vm, globals, lfp)?;
+    let dead = scheduler::join(vm, globals, self_, timeout)?;
+    if !dead {
+        return Ok(Value::nil());
     }
-
-    match result {
-        Ok(v) => Ok(v),
-        Err(err) if matches!(err.kind(), MonorubyErrKind::MethodReturn(..)) => {
-            Err(MonorubyErr::localjumperr("unexpected return"))
-        }
-        Err(err) if matches!(err.kind(), MonorubyErrKind::BlockBreak(..)) => {
-            Err(MonorubyErr::localjumperr("break from proc-closure"))
-        }
-        Err(err) => Err(err),
+    // A thread that terminated with an exception re-raises it in the
+    // joiner (CRuby).
+    if let Some(err) = self_.as_thread_inner().exception.clone() {
+        return Err(err);
     }
+    Ok(self_)
+}
+
+///
+/// ### Thread#value
+///
+/// Joins the thread and returns the body's value, re-raising a
+/// terminating exception.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/value.html]
+#[monoruby_builtin]
+fn thread_value(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    scheduler::join(vm, globals, self_, None)?;
+    let inner = self_.as_thread_inner();
+    if let Some(err) = inner.exception.clone() {
+        return Err(err);
+    }
+    Ok(inner.result.unwrap_or_default())
+}
+
+///
+/// ### Thread#status
+///
+/// "run" | "sleep" | false (normal termination) | nil (terminated with
+/// exception).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/status.html]
+#[monoruby_builtin]
+fn thread_status(vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let inner = self_.as_thread_inner();
+    Ok(match inner.state() {
+        ThreadState::Dead => {
+            if inner.exception.is_some() {
+                Value::nil()
+            } else {
+                Value::bool(false)
+            }
+        }
+        ThreadState::Sleeping | ThreadState::Joining => Value::string_from_str("sleep"),
+        ThreadState::Created | ThreadState::Runnable => {
+            // The current thread reports "run"; queued-but-not-yet-run
+            // threads also report "run" (CRuby: runnable == "run").
+            let _ = vm;
+            Value::string_from_str("run")
+        }
+    })
+}
+
+///
+/// ### Thread#alive?
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/alive=3f.html]
+#[monoruby_builtin]
+fn thread_alive(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(!lfp.self_val().as_thread_inner().is_dead()))
+}
+
+///
+/// ### Thread#stop?
+///
+/// True when the thread is dead or parked.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/stop=3f.html]
+#[monoruby_builtin]
+fn thread_stop_p(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let state = lfp.self_val().as_thread_inner().state();
+    Ok(Value::bool(matches!(
+        state,
+        ThreadState::Dead | ThreadState::Sleeping | ThreadState::Joining
+    )))
+}
+
+///
+/// ### Thread#wakeup
+///
+/// Marks a sleeping thread eligible to run. Raises ThreadError on a dead
+/// thread.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/wakeup.html]
+#[monoruby_builtin]
+fn thread_wakeup(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    if !scheduler::wakeup(self_) {
+        return Err(MonorubyErr::threaderr(
+            &globals.store,
+            "killed thread",
+        ));
+    }
+    Ok(self_)
+}
+
+///
+/// ### Thread#run
+///
+/// Wakes the thread and gives it (and other runnable threads) a chance
+/// to run immediately.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/run.html]
+#[monoruby_builtin]
+fn thread_run(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    if !scheduler::wakeup(self_) {
+        return Err(MonorubyErr::threaderr(
+            &globals.store,
+            "killed thread",
+        ));
+    }
+    scheduler::pass(vm, globals)?;
+    Ok(self_)
 }
 
 #[cfg(test)]
@@ -90,9 +280,7 @@ mod tests {
     use crate::tests::*;
 
     #[test]
-    fn thread_value_runs_block_lazily() {
-        // monoruby is single-threaded: Thread.new stores the block and runs
-        // it lazily on #value, on the main thread.
+    fn thread_new_join_value() {
         run_test(r#"Thread.new { 42 }.value"#);
         run_test(
             r#"
@@ -105,7 +293,120 @@ mod tests {
         run_test_once(
             r#"
             t = Thread.new { 3 * 4 }
-            [t.is_a?(Thread), t.value]
+            [t.is_a?(Thread), t.value, t.join == t, t.alive?, t.status]
+            "#,
+        );
+        run_test_once(r#"Thread.new(1, 2, 3) { |a, b, c| a + b + c }.value"#);
+    }
+
+    #[test]
+    fn thread_concurrency_with_queue_like_handoff() {
+        // The spawned thread must not run at Thread.new time; it runs
+        // when the main thread blocks (join), and both make progress.
+        run_test_once(
+            r#"
+            order = []
+            t = Thread.new { order << :thread }
+            order << :main
+            t.join
+            order
+            "#,
+        );
+        // Two threads interleave at sleep points.
+        run_test_once(
+            r#"
+            log = []
+            t1 = Thread.new { 3.times { |i| log << [:a, i]; sleep 0.01 } }
+            t2 = Thread.new { 3.times { |i| log << [:b, i]; sleep 0.01 } }
+            t1.join
+            t2.join
+            log.sort
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_status_and_pass() {
+        run_test_once(
+            r#"
+            t = Thread.new { sleep }
+            Thread.pass while t.status != "sleep"
+            st = t.status
+            t.wakeup
+            t.join
+            [st, t.status, t.stop?, t.alive?]
+            "#,
+        );
+        run_test_once(r#"Thread.pass"#);
+        run_test_once(r#"[Thread.current == Thread.main, Thread.current.alive?]"#);
+        run_test_once(r#"Thread.current.status"#);
+    }
+
+    #[test]
+    fn thread_exception_propagates_on_join() {
+        run_test(
+            r#"
+            t = Thread.new { raise ArgumentError, "boom" }
+            begin
+              t.join
+              :no_error
+            rescue ArgumentError => e
+              e.message
+            end
+            "#,
+        );
+        run_test(
+            r#"
+            t = Thread.new { raise "boom" }
+            Thread.pass until t.status.nil?
+            [t.status, t.alive?]
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_join_timeout() {
+        run_test_once(
+            r#"
+            t = Thread.new { sleep }
+            r = t.join(0.05)
+            t.wakeup
+            t.join
+            [r, t.status]
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_join_self_raises() {
+        run_test_error(r#"Thread.current.join"#);
+        run_test_error(r#"Thread.new"#);
+    }
+
+    #[test]
+    fn thread_sleep_interleaves_with_main() {
+        run_test_once(
+            r#"
+            v = []
+            t = Thread.new { v << 1; sleep 0.05; v << 3 }
+            sleep 0.01   # let t run its first leg
+            v << 2
+            t.join
+            v
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_body_bare_return_raises_localjumperror() {
+        run_test(
+            r#"
+            begin
+              Thread.new { return }.value
+              :no_error
+            rescue LocalJumpError
+              :local_jump
+            end
             "#,
         );
     }
@@ -122,29 +423,34 @@ mod tests {
     }
 
     #[test]
-    fn thread_body_bare_return_raises_localjumperror() {
-        // A bare top-level `return` in a thread body is a LocalJumpError in
-        // CRuby. monoruby runs the body synchronously on #value, so the
-        // `__invoke_body` conversion must reproduce that.
+    fn thread_fiber_yield_at_thread_root_errors() {
+        // Fiber.yield at a thread root has no parent fiber: FiberError,
+        // exactly like at the main fiber.
         run_test(
             r#"
-            begin
-              Thread.new { return }.value
-              :no_error
-            rescue LocalJumpError
-              :local_jump
-            end
+            t = Thread.new { Fiber.yield rescue $!.class.to_s }
+            t.value
             "#,
         );
-        // A bare `break` in a thread body is likewise a LocalJumpError.
-        run_test(
+    }
+
+    #[test]
+    fn thread_nested_fiber_inside_thread() {
+        // A fiber created inside a green thread keeps its own resume
+        // chain across scheduler switches.
+        // NOTE: resume(arg) with a one-param fiber block hits a
+        // pre-existing (master) destructure bug, so this test passes the
+        // value through the yield instead.
+        run_test_once(
             r#"
-            begin
-              Thread.new { break :b }.value
-              :no_error
-            rescue LocalJumpError
-              :local_jump
+            t = Thread.new do
+              f = Fiber.new { Fiber.yield 1; :done }
+              a = f.resume
+              sleep 0.01
+              b = f.resume
+              [a, b]
             end
+            t.value
             "#,
         );
     }

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -59,6 +59,18 @@ pub(crate) type BlockInvoker = extern "C" fn(
 
 pub(crate) type BindingInvoker = extern "C" fn(&mut Executor, &mut Globals, Lfp) -> Option<Value>;
 
+/// First activation of a green thread: the executor passed first IS the
+/// thread's own executor (its `rsp_save` holds the fresh stack top); the
+/// calling scheduler context is saved into the `SCHED_RSP` slot.
+pub(crate) type ThreadInvoker = extern "C" fn(
+    &mut Executor,
+    &mut Globals,
+    &ProcData,
+    Value,
+    *const Value,
+    usize,
+) -> Option<Value>;
+
 pub(crate) type FiberInvoker = extern "C" fn(
     &mut Executor,
     &mut Globals,
@@ -655,6 +667,9 @@ pub struct Codegen {
     pub(crate) fiber_invoker_with_self: FiberInvoker,
     pub(crate) resume_fiber: extern "C" fn(*mut Executor, &mut Executor, Value) -> Option<Value>,
     pub(crate) yield_fiber: extern "C" fn(*mut Executor, Value) -> Option<Value>,
+    pub(crate) thread_invoker: ThreadInvoker,
+    pub(crate) switch_to_scheduler: extern "C" fn(*mut Executor, Value) -> Option<Value>,
+    pub(crate) scheduler_resume: extern "C" fn(*mut Executor, Value) -> Option<Value>,
     pub(crate) startup_flag: bool,
     /// (§9a-ii) When `Some`, `encode_linst*` and the per-arch fallthrough buffer
     /// the lowered `LInst`s here instead of emitting, so the region driver
@@ -937,6 +952,9 @@ impl Codegen {
         let fiber_invoker_with_self = jit.fiber_invoker_with_self();
         let resume_fiber = jit.resume_fiber();
         let yield_fiber = jit.yield_fiber();
+        let thread_invoker = jit.thread_invoker();
+        let switch_to_scheduler = jit.switch_to_scheduler();
+        let scheduler_resume = jit.scheduler_resume();
 
         let mut codegen = Self {
             jit,
@@ -967,6 +985,9 @@ impl Codegen {
             fiber_invoker_with_self,
             resume_fiber,
             yield_fiber,
+            thread_invoker,
+            switch_to_scheduler,
+            scheduler_resume,
             startup_flag: false,
             lir_buf: None,
             #[cfg(any(feature = "jit-log", feature = "jit-debug"))]

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3916,14 +3916,29 @@ impl Codegen {
     /// method's own LR is saved: the invoker's a64_push_callee_save stashes the
     /// *post-blr* x30, not ours, so we restore the real return address after the
     /// fiber resumes back here.
-    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64) {
+    /// A yield with no parent fiber (main fiber / a green thread's root)
+    /// must not reach the switch stub — it would load SP through a null
+    /// `parent_fiber` — so route it to the error helper instead (returns
+    /// None with a FiberError set; the inline's handle_error picks it up).
+    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64, no_parent: u64) {
+        let none = self.jit.label();
+        let exit = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;          // vm (EXEC)
             mov x1, x3;           // value (Rsi)
+            ldr x9, [x0, #(EXECUTOR_PARENT_FIBER as u32)];
+            cbz x9, none;
             mov x9, (yield_fiber);
             str x30, [sp, #-16]!;
             blr x9;
             ldr x30, [sp], #16;
+            b exit;
+        none:
+            mov x9, (no_parent);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        exit:
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/invoker.rs
+++ b/monoruby/src/codegen/arch/aarch64/invoker.rs
@@ -433,6 +433,99 @@ impl JitModule {
         self.a64_fiber_invoker(true)
     }
 
+    /// First activation of a green thread. In: x0 thread_vm, x1 globals,
+    /// x2 &ProcData, x3 (unused), x4 args, x5 len. Saves the scheduler
+    /// context into the process-global `SCHED_RSP` slot, switches onto the
+    /// thread's fresh stack, runs the body, and switches back on
+    /// termination. `parent_fiber` is deliberately left `None` so
+    /// `Fiber.yield` at the thread root takes the existing error paths.
+    /// (Mirrors x86 thread_invoker.)
+    pub(in crate::codegen) fn thread_invoker(&mut self) -> ThreadInvoker {
+        let codeptr = self.jit.get_current_address();
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        self.a64_push_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (sched_rsp);
+            mov x11, sp;
+            str x11, [x10];  // SCHED_RSP = scheduler context
+            ldr x10, [x0, #(EXECUTOR_RSP_SAVE as u32)];
+            mov sp, x10;  // SP = thread's fresh stack top
+            mov x(EXEC.0), x0;
+            mov x(GLOBALS.0), x1;
+        );
+        self.a64_block_frame_setup(false);
+        monoasm_arm64!(&mut self.jit,
+            mov x7, (0);  // thread bodies carry no keyword args
+        );
+        self.a64_invoker_args_and_call(true);
+        // body completed: mark terminated, switch back to the scheduler.
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (u64::MAX);  // -1 = terminated
+            str x10, [x(EXEC.0), #(EXECUTOR_RSP_SAVE as u32)];
+            mov x10, (sched_rsp);
+            ldr x10, [x10];
+            mov sp, x10;
+        );
+        self.a64_pop_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            ret;
+        // SAFETY: codeptr is an extern "C" fn with the ThreadInvoker ABI.
+        );
+        unsafe { std::mem::transmute_copy::<*mut u8, ThreadInvoker>(&codeptr.as_ptr()) }
+    }
+
+    /// Switch from the running green thread to the scheduler context in
+    /// `SCHED_RSP`. In: x0 current executor, x1 value (returned to the
+    /// scheduler's pending resume call). `parent_fiber` is untouched.
+    /// (Mirrors x86 switch_to_scheduler.)
+    pub(in crate::codegen) fn switch_to_scheduler(
+        &mut self,
+    ) -> extern "C" fn(*mut Executor, Value) -> Option<Value> {
+        let codeptr = self.jit.get_current_address();
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        self.a64_push_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            mov x10, sp;
+            str x10, [x0, #(EXECUTOR_RSP_SAVE as u32)];  // save current context
+            mov x10, (sched_rsp);
+            ldr x10, [x10];
+            mov sp, x10;  // SP = scheduler context
+        );
+        self.a64_pop_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x1;
+            ret;
+        // SAFETY: codeptr matches the switch_to_scheduler ABI.
+        );
+        unsafe { std::mem::transmute_copy(&codeptr.as_ptr()) }
+    }
+
+    /// Resume a parked green thread. In: x0 thread executor, x1 value
+    /// (returned to the thread's pending switch_to_scheduler call). The
+    /// scheduler context is saved into `SCHED_RSP`.
+    /// (Mirrors x86 scheduler_resume.)
+    pub(in crate::codegen) fn scheduler_resume(
+        &mut self,
+    ) -> extern "C" fn(*mut Executor, Value) -> Option<Value> {
+        let codeptr = self.jit.get_current_address();
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        self.a64_push_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (sched_rsp);
+            mov x11, sp;
+            str x11, [x10];  // SCHED_RSP = scheduler context
+            ldr x10, [x0, #(EXECUTOR_RSP_SAVE as u32)];
+            mov sp, x10;  // SP = thread context
+        );
+        self.a64_pop_callee_save();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x1;
+            ret;
+        // SAFETY: codeptr matches the scheduler_resume ABI.
+        );
+        unsafe { std::mem::transmute_copy(&codeptr.as_ptr()) }
+    }
+
     /// Resume a suspended fiber. In: x0 parent_vm, x1 child_vm, x2 value.
     /// Save the parent context, switch onto the child's saved stack, and
     /// return (the child resumes where it last yielded). x86 resume_fiber.

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -182,11 +182,24 @@ impl Codegen {
     }
 
     /// `Fiber.yield`: call `yield_fiber(vm, value)` (value already in rsi).
-    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64) {
+    /// A yield with no parent fiber (main fiber / a green thread's root)
+    /// must not reach the switch stub — it would load rsp through a null
+    /// `parent_fiber` — so route it to the error helper instead (returns
+    /// None with a FiberError set; the inline's handle_error picks it up).
+    pub(crate) fn emit_fiber_yield_call(&mut self, yield_fiber: u64, no_parent: u64) {
+        let none = self.jit.label();
+        let exit = self.jit.label();
         monoasm! { &mut self.jit,
             movq rdi, rbx;
+            cmpq [rdi + (EXECUTOR_PARENT_FIBER)], 0;
+            jeq  none;
             movq rax, (yield_fiber);
             call rax;
+            jmp  exit;
+        none:
+            movq rax, (no_parent);
+            call rax;
+        exit:
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/invoker.rs
+++ b/monoruby/src/codegen/arch/x86_64/invoker.rs
@@ -253,6 +253,128 @@ impl JitModule {
         unsafe { std::mem::transmute(codeptr.as_ptr()) }
     }
 
+    ///
+    /// First activation of a green thread.
+    ///
+    /// Like `fiber_invoker`, but for the scheduler: the calling context
+    /// (the scheduler loop, always on the main thread's stack) is saved
+    /// into the process-global `SCHED_RSP` slot instead of an Executor
+    /// field, and the child's `parent_fiber` is deliberately left `None`
+    /// so `Fiber.yield` at a thread's root correctly takes the existing
+    /// "can't yield from main fiber" error paths (Rust and JIT-inline
+    /// alike). On body termination, control switches back to the
+    /// scheduler context.
+    ///
+    pub(in crate::codegen) fn thread_invoker(&mut self) -> ThreadInvoker {
+        let codeptr = self.jit.get_current_address();
+
+        #[cfg(feature = "perf")]
+        let pair = self.get_address_pair();
+
+        // rdi: &mut Executor (the thread's own executor; rsp_save = fresh stack top)
+        // rsi: &mut Globals
+        // rdx: &ProcData
+        // rcx: (unused)
+        // r8:  *args: *const Value
+        // r9:  len: usize
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        let error_exit = self.jit.label();
+        self.push_callee_save();
+        monoasm! { &mut self.jit,
+            movq rax, (sched_rsp);
+            movq [rax], rsp;                       // SCHED_RSP <- scheduler context
+            movq rsp, [rdi + (EXECUTOR_RSP_SAVE)]; // rsp <- fresh thread stack top
+            movq rbx, rdi;
+            movq r12, rsi;
+            xorq r10, r10;
+        }
+        self.invoker_frame_setup(true, false);
+        self.invoker_args_setup(&error_exit, true);
+        self.call_invoker();
+        monoasm! { &mut self.jit,
+            movq [rbx + (EXECUTOR_RSP_SAVE)], (-1); // mark terminated
+            movq rcx, (sched_rsp);
+            movq rsp, [rcx];                        // back to the scheduler context
+        error_exit:
+        }
+        self.pop_callee_save();
+        monoasm! { &mut self.jit,
+            ret;
+        };
+
+        #[cfg(feature = "perf")]
+        self.perf_info(pair, "thread-invoker");
+
+        unsafe { std::mem::transmute(codeptr.as_ptr()) }
+    }
+
+    ///
+    /// Switch from the currently running green thread to the scheduler
+    /// context saved in `SCHED_RSP`. The scheduler's pending
+    /// `scheduler_resume`/`thread_invoker` call returns `val`.
+    ///
+    /// `parent_fiber` is untouched, so a fiber nested inside a green
+    /// thread keeps its resume chain intact across a scheduler switch.
+    ///
+    pub(in crate::codegen) fn switch_to_scheduler(
+        &mut self,
+    ) -> extern "C" fn(*mut Executor, Value) -> Option<Value> {
+        let codeptr = self.jit.get_current_address();
+
+        #[cfg(feature = "perf")]
+        let pair = self.get_address_pair();
+
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        self.push_callee_save();
+        monoasm! { &mut self.jit,
+            movq [rdi + (EXECUTOR_RSP_SAVE)], rsp; // save current context
+            movq rax, (sched_rsp);
+            movq rsp, [rax];                       // rsp <- scheduler context
+        }
+        self.pop_callee_save();
+        monoasm! { &mut self.jit,
+            movq rax, rsi;
+            ret;
+        };
+
+        #[cfg(feature = "perf")]
+        self.perf_info(pair, "switch-to-scheduler");
+
+        unsafe { std::mem::transmute(codeptr.as_ptr()) }
+    }
+
+    ///
+    /// Resume a parked green thread (its context in `[rdi + rsp_save]`),
+    /// saving the scheduler context into `SCHED_RSP`. The thread's
+    /// pending `switch_to_scheduler` call returns `val`.
+    ///
+    pub(in crate::codegen) fn scheduler_resume(
+        &mut self,
+    ) -> extern "C" fn(*mut Executor, Value) -> Option<Value> {
+        let codeptr = self.jit.get_current_address();
+
+        #[cfg(feature = "perf")]
+        let pair = self.get_address_pair();
+
+        let sched_rsp = crate::scheduler::sched_rsp_addr();
+        self.push_callee_save();
+        monoasm! { &mut self.jit,
+            movq rax, (sched_rsp);
+            movq [rax], rsp;                       // SCHED_RSP <- scheduler context
+            movq rsp, [rdi + (EXECUTOR_RSP_SAVE)]; // rsp <- thread context
+        }
+        self.pop_callee_save();
+        monoasm! { &mut self.jit,
+            movq rax, rsi;
+            ret;
+        };
+
+        #[cfg(feature = "perf")]
+        self.perf_info(pair, "scheduler-resume");
+
+        unsafe { std::mem::transmute(codeptr.as_ptr()) }
+    }
+
     pub(in crate::codegen) fn resume_fiber(
         &mut self,
     ) -> extern "C" fn(*mut Executor, &mut Executor, Value) -> Option<Value> {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -301,6 +301,9 @@ impl Executor {
         // `$-d` is its alias.
         globals.set_gvar(IdentId::get_id("$DEBUG"), Value::bool(false));
         globals.alias_global_variable(IdentId::get_id("$-d"), IdentId::get_id("$DEBUG"));
+        // A fresh interpreter must not see green-thread state left over
+        // from a previous interpreter on this OS thread (test harness).
+        crate::scheduler::reset();
         let mut executor = Self::default();
         // Bring-up/testing aid (used by the in-progress aarch64 VM port): skip
         // loading startup.rb + gems so a trivial program can exercise the VM
@@ -3665,6 +3668,10 @@ impl<'a, 'b> alloc::GC<RValue> for Root<'a, 'b> {
         unsafe { crate::builtins::YIELDER.unwrap().mark(alloc) };
         self.globals.mark(alloc);
         self.executor.mark(alloc);
+        // Green threads: every live thread's stack frames (and the main
+        // thread's, while a green thread is the one triggering GC) are
+        // reachable only through the scheduler registry.
+        crate::scheduler::mark(alloc);
     }
 }
 

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -1056,6 +1056,19 @@ impl MonorubyErr {
 
     /// `EOFError` (a subclass of `IOError` defined in Ruby). Falls
     /// back to a plain `IOError` if the class can't be resolved.
+    /// `ThreadError` (defined in Ruby in startup.rb). Falls back to a
+    /// plain `RuntimeError` if the class can't be resolved.
+    pub(crate) fn threaderr(store: &Store, msg: impl ToString) -> MonorubyErr {
+        let cid = store
+            .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ThreadError"))
+            .and_then(|v| v.is_class_or_module())
+            .map(|m| m.id());
+        match cid {
+            Some(cid) => MonorubyErr::new(MonorubyErrKind::Other(cid), msg.to_string()),
+            None => MonorubyErr::new(MonorubyErrKind::Runtime, msg.to_string()),
+        }
+    }
+
     pub(crate) fn eoferr(store: &Store, msg: impl ToString) -> MonorubyErr {
         let cid = store
             .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("EOFError"))

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -76,6 +76,7 @@ pub const ARITHMETIC_SEQUENCE_CLASS: ClassId = ClassId::new(55);
 pub const SIGNAL_EXCEPTION_CLASS: ClassId = ClassId::new(56);
 pub const INTERRUPT_CLASS: ClassId = ClassId::new(57);
 pub const IO_BUFFER_CLASS: ClassId = ClassId::new(58);
+pub const THREAD_CLASS: ClassId = ClassId::new(59);
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -50,6 +50,7 @@ mod globals;
 mod id_table;
 pub mod parser;
 mod ruby_probe;
+mod scheduler;
 pub mod tests;
 mod value;
 mod watchdog;

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -1,0 +1,614 @@
+//! Green-thread scheduler.
+//!
+//! monoruby multiplexes Ruby `Thread`s cooperatively on the one OS
+//! thread (M:1). Each green thread owns a dedicated machine stack and an
+//! `Executor` (see value/rvalue/thread.rs); context switches reuse the
+//! fiber machinery's `rsp_save` swap, with three dedicated stubs
+//! (`thread_invoker` / `switch_to_scheduler` / `scheduler_resume` in
+//! codegen/arch/*/invoker.rs) that never touch `parent_fiber`, so a
+//! thread root keeps `parent_fiber == None` and `Fiber.yield` at a
+//! thread root takes the pre-existing error paths unchanged.
+//!
+//! ## Topology
+//!
+//! The scheduler loop (`scheduler_run`) only ever runs in the *main*
+//! thread's context, event-loop style:
+//!
+//! - When the **main thread** blocks (`sleep`, `join`, ...), it calls
+//!   `scheduler_run` as an ordinary function on its own stack. The loop
+//!   dispatches runnable green threads until main is runnable again,
+//!   then returns.
+//! - When a **green thread** blocks, it records how it must be woken,
+//!   then switches to the scheduler context saved in the process-global
+//!   `SCHED_RSP` slot — i.e. control returns *out of* the loop's pending
+//!   dispatch call, and the loop picks the next runnable thread.
+//! - A green thread body that terminates switches back the same way
+//!   (the `thread_invoker` epilogue), and the loop finalizes it.
+//!
+//! Because the loop always saves its context into `SCHED_RSP` right
+//! before transferring control (both stubs do this), the slot always
+//! holds the correct scheduler context, and only one loop instance can
+//! ever be live (green threads never call `scheduler_run`).
+//!
+//! ## Switching discipline
+//!
+//! - Context switches happen only at VM safepoints (inside builtins), so
+//!   every suspended thread's frames are GC-complete.
+//! - `SCHEDULER` is a `RefCell`: it is never borrowed across a context
+//!   switch, and no Ruby allocation happens while it is borrowed (GC
+//!   marking re-enters it).
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use crate::alloc::GC;
+use crate::value::rvalue::{ThreadInner, ThreadState};
+use crate::*;
+
+thread_local! {
+    pub(crate) static SCHEDULER: RefCell<Scheduler> = RefCell::new(Scheduler::new());
+}
+
+/// The scheduler loop's saved machine context. Written by the context
+/// switch stubs; read back when a green thread parks or terminates.
+/// A single slot suffices because only one scheduler loop can be live
+/// (it only runs in the main thread's context).
+static mut SCHED_RSP: u64 = 0;
+
+/// Absolute address of `SCHED_RSP`, baked into the context switch stubs.
+pub(crate) fn sched_rsp_addr() -> u64 {
+    &raw mut SCHED_RSP as u64
+}
+
+pub(crate) struct Scheduler {
+    /// All live (non-terminated) thread objects, including main — a GC
+    /// root. Dead threads are pruned at finalization (user references
+    /// keep them alive from the frames that hold them).
+    threads: Vec<Value>,
+    /// Runnable green threads, FIFO. (The running thread and the main
+    /// thread are not queued here.)
+    ready: VecDeque<Value>,
+    /// Parked-with-deadline threads: `(deadline, thread)`. `None` means
+    /// "sleep until woken" (`sleep` without duration / `Thread.stop`).
+    /// Kept unsorted (n is small); stale entries — threads woken through
+    /// another path first — are skipped on expiry by re-checking state.
+    sleepers: Vec<(Option<Instant>, Value)>,
+    /// The thread currently executing. `None` until the main thread
+    /// object is lazily created.
+    current: Option<Value>,
+    main: Option<Value>,
+    /// The main thread's `Executor`, refreshed at every `scheduler_run`
+    /// entry. Only dereferenced (for GC marking) while `in_scheduler` —
+    /// i.e. exactly while green threads can be the GC trigger and main's
+    /// frames would otherwise be unreachable.
+    main_exec: Option<std::ptr::NonNull<Executor>>,
+    in_scheduler: bool,
+}
+
+impl Scheduler {
+    fn new() -> Self {
+        Self {
+            threads: vec![],
+            ready: VecDeque::new(),
+            sleepers: vec![],
+            current: None,
+            main: None,
+            main_exec: None,
+            in_scheduler: false,
+        }
+    }
+
+    pub(crate) fn mark(&self, alloc: &mut crate::alloc::Allocator<RValue>) {
+        for t in &self.threads {
+            t.mark(alloc);
+        }
+        // `current`/`main` and queue members are subsets of `threads`
+        // except during pruning, so mark them too for safety.
+        if let Some(t) = self.current {
+            t.mark(alloc);
+        }
+        if let Some(t) = self.main {
+            t.mark(alloc);
+        }
+        for t in &self.ready {
+            t.mark(alloc);
+        }
+        for (_, t) in &self.sleepers {
+            t.mark(alloc);
+        }
+        if self.in_scheduler
+            && let Some(main_exec) = self.main_exec
+        {
+            // SAFETY: refreshed at scheduler_run entry; the main
+            // executor outlives the loop that set it.
+            unsafe { main_exec.as_ref().mark(alloc) };
+        }
+    }
+}
+
+/// Reset all scheduler state. Called when a fresh interpreter starts
+/// (`Executor::init`) so state from a previous interpreter on the same
+/// OS thread (e.g. the test harness) cannot leak across.
+pub(crate) fn reset() {
+    SCHEDULER.with(|s| *s.borrow_mut() = Scheduler::new());
+}
+
+/// GC root hook (called from `Root::mark`).
+pub(crate) fn mark(alloc: &mut crate::alloc::Allocator<RValue>) {
+    SCHEDULER.with(|s| s.borrow().mark(alloc));
+}
+
+/// The `Thread` object for the currently running thread, creating the
+/// main thread object lazily on first use.
+pub(crate) fn current_thread(vm: &mut Executor) -> Value {
+    ensure_main(vm);
+    SCHEDULER.with(|s| s.borrow().current.unwrap())
+}
+
+/// The main thread's `Thread` object.
+pub(crate) fn main_thread(vm: &mut Executor) -> Value {
+    ensure_main(vm);
+    SCHEDULER.with(|s| s.borrow().main.unwrap())
+}
+
+/// All alive threads (`Thread.list`).
+pub(crate) fn thread_list(vm: &mut Executor) -> Vec<Value> {
+    ensure_main(vm);
+    SCHEDULER.with(|s| s.borrow().threads.clone())
+}
+
+/// Whether any *other* live thread exists (i.e. whether blocking
+/// operations must go through the scheduler instead of really blocking).
+pub(crate) fn has_other_live_threads() -> bool {
+    SCHEDULER.with(|s| {
+        let s = s.borrow();
+        let cur = s.current;
+        s.threads
+            .iter()
+            .any(|t| Some(*t) != cur && !t.as_thread_inner().is_dead())
+    })
+}
+
+fn ensure_main(vm: &mut Executor) {
+    let need = SCHEDULER.with(|s| s.borrow().main.is_none());
+    if need {
+        // Allocate before borrowing (allocation can trigger GC, which
+        // re-enters the scheduler to mark it).
+        let main = Value::new_thread(THREAD_CLASS, ThreadInner::main());
+        SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            if s.main.is_none() {
+                s.threads.push(main);
+                s.main = Some(main);
+                s.current = Some(main);
+            }
+        });
+    }
+    let _ = vm;
+}
+
+fn is_current_main() -> bool {
+    SCHEDULER.with(|s| {
+        let s = s.borrow();
+        s.current.is_some() && s.current == s.main
+    })
+}
+
+/// Register a freshly created thread object and queue it for execution.
+pub(crate) fn spawn(vm: &mut Executor, thread: Value) {
+    ensure_main(vm);
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.threads.push(thread);
+        s.ready.push_back(thread);
+    });
+}
+
+/// Wake a thread parked in `sleep` (`Thread#wakeup` / `#run`). Returns
+/// false if the thread is dead.
+pub(crate) fn wakeup(thread: Value) -> bool {
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        let mut t = thread;
+        let inner = t.as_thread_inner_mut();
+        match inner.state() {
+            ThreadState::Dead => false,
+            ThreadState::Sleeping => {
+                inner.state = ThreadState::Runnable;
+                if Some(thread) != s.main {
+                    s.ready.push_back(thread);
+                }
+                true
+            }
+            // Runnable / Created / Joining: nothing to do (CRuby's
+            // wakeup only interrupts sleep).
+            _ => true,
+        }
+    })
+}
+
+/// `Kernel#sleep` / `Thread.stop` through the scheduler. `dur == None`
+/// sleeps until `#wakeup`. Returns the elapsed time.
+pub(crate) fn sleep(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    dur: Option<Duration>,
+) -> Result<Duration> {
+    ensure_main(vm);
+    let start = Instant::now();
+    let deadline = dur.map(|d| start + d);
+    if is_current_main() {
+        SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            let mut main = s.main.unwrap();
+            main.as_thread_inner_mut().state = ThreadState::Sleeping;
+            s.sleepers.push((deadline, main));
+        });
+        scheduler_run(vm, globals)?;
+    } else {
+        let cur = SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            let mut cur = s.current.unwrap();
+            cur.as_thread_inner_mut().state = ThreadState::Sleeping;
+            s.sleepers.push((deadline, cur));
+            cur
+        });
+        park_switch(vm, cur)?;
+    }
+    Ok(start.elapsed())
+}
+
+/// `Thread.pass`: give every currently runnable thread a chance to run.
+pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+    ensure_main(vm);
+    if is_current_main() {
+        // Dispatch the threads that are ready *now* (not the ones they
+        // enqueue), then come back to main. Like `scheduler_run`, the
+        // main thread's frames must stay GC-reachable while a green
+        // thread is the one triggering a collection, so publish the main
+        // executor for the duration.
+        SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            s.main_exec = Some(std::ptr::NonNull::from(&mut *vm));
+            s.in_scheduler = true;
+        });
+        let n = SCHEDULER.with(|s| s.borrow().ready.len());
+        let mut result = Ok(());
+        for _ in 0..n {
+            let t = SCHEDULER.with(|s| s.borrow_mut().ready.pop_front());
+            match t {
+                Some(t) => {
+                    if let Err(err) = dispatch(globals, t) {
+                        result = Err(err);
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            s.in_scheduler = false;
+            let main = s.main.unwrap();
+            s.current = Some(main);
+        });
+        result
+    } else {
+        let cur = SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            let cur = s.current.unwrap();
+            // Stay runnable; go to the back of the queue.
+            s.ready.push_back(cur);
+            cur
+        });
+        park_switch(vm, cur)
+    }
+}
+
+/// `Thread#join` (also backs `#value`): park until `target` terminates
+/// or the timeout expires. Returns whether the target is dead.
+pub(crate) fn join(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    target: Value,
+    timeout: Option<Duration>,
+) -> Result<bool> {
+    ensure_main(vm);
+    let cur = SCHEDULER.with(|s| s.borrow().current.unwrap());
+    if target == cur {
+        return Err(MonorubyErr::threaderr(
+            &globals.store,
+            "Target thread must not be current thread",
+        ));
+    }
+    let deadline = timeout.map(|d| Instant::now() + d);
+    loop {
+        if target.as_thread_inner().is_dead() {
+            return Ok(true);
+        }
+        if let Some(dl) = deadline
+            && Instant::now() >= dl
+        {
+            return Ok(false);
+        }
+        if is_current_main() {
+            SCHEDULER.with(|s| {
+                let mut s = s.borrow_mut();
+                let mut main = s.main.unwrap();
+                main.as_thread_inner_mut().state = ThreadState::Joining;
+                let mut target = target;
+                target.as_thread_inner_mut().joiners.push(main);
+                if deadline.is_some() {
+                    s.sleepers.push((deadline, main));
+                }
+            });
+            scheduler_run(vm, globals)?;
+        } else {
+            SCHEDULER.with(|s| {
+                let mut s = s.borrow_mut();
+                let mut cur = s.current.unwrap();
+                cur.as_thread_inner_mut().state = ThreadState::Joining;
+                let mut target = target;
+                target.as_thread_inner_mut().joiners.push(cur);
+                if deadline.is_some() {
+                    s.sleepers.push((deadline, cur));
+                }
+            });
+            park_switch(vm, cur)?;
+        }
+    }
+}
+
+/// Park the current green thread: record the context to resume, then
+/// switch to the scheduler. Returns when the scheduler resumes us.
+fn park_switch(vm: &mut Executor, mut cur: Value) -> Result<()> {
+    cur.as_thread_inner_mut().resume_exec = Some(std::ptr::NonNull::from(&mut *vm));
+    let switch = CODEGEN.with(|c| c.borrow().switch_to_scheduler);
+    match switch(vm as *mut _, Value::nil()) {
+        Some(_) => Ok(()),
+        // Reserved for asynchronous interrupt injection (Thread#raise /
+        // #kill): a resume that sets an error instead of a value.
+        None => Err(vm.take_error()),
+    }
+}
+
+/// The scheduler loop. Only ever called in the main thread's context,
+/// while the main thread is parked; returns when main is runnable again.
+fn scheduler_run(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.main_exec = Some(std::ptr::NonNull::from(&mut *vm));
+        s.in_scheduler = true;
+    });
+    let result = scheduler_loop(vm, globals);
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.in_scheduler = false;
+        let main = s.main.unwrap();
+        s.current = Some(main);
+    });
+    result
+}
+
+fn scheduler_loop(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+    loop {
+        wake_due_sleepers();
+        let (main_ready, next) = SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            let main_ready =
+                s.main.unwrap().as_thread_inner().state() == ThreadState::Runnable;
+            let next = if main_ready { None } else { s.ready.pop_front() };
+            (main_ready, next)
+        });
+        if main_ready {
+            return Ok(());
+        }
+        if let Some(t) = next {
+            dispatch(globals, t)?;
+            continue;
+        }
+        // Nothing runnable: sleep until the nearest deadline, or report
+        // deadlock when no thread can ever become runnable again.
+        match nearest_deadline() {
+            Some(deadline) => interruptible_sleep_until(vm, globals, deadline)?,
+            None => {
+                return Err(MonorubyErr::fatal(
+                    "No live threads left. Deadlock?".to_string(),
+                ));
+            }
+        }
+    }
+}
+
+fn wake_due_sleepers() {
+    let now = Instant::now();
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        let mut due = vec![];
+        s.sleepers.retain(|(deadline, t)| {
+            let mut t = *t;
+            let state = t.as_thread_inner().state();
+            // Entries whose thread was already woken (or died) through
+            // another path are stale — drop them.
+            if !matches!(state, ThreadState::Sleeping | ThreadState::Joining) {
+                return false;
+            }
+            match deadline {
+                Some(dl) if *dl <= now => {
+                    due.push(t);
+                    false
+                }
+                _ => true,
+            }
+        });
+        let main = s.main;
+        for mut t in due {
+            t.as_thread_inner_mut().state = ThreadState::Runnable;
+            if Some(t) != main {
+                s.ready.push_back(t);
+            }
+        }
+    });
+}
+
+fn nearest_deadline() -> Option<Instant> {
+    SCHEDULER.with(|s| {
+        s.borrow()
+            .sleepers
+            .iter()
+            .filter_map(|(dl, _)| *dl)
+            .min()
+    })
+}
+
+/// Sleep the whole process until `deadline`, staying signal-responsive:
+/// an EINTR runs the VM poll point (converting pending signals / running
+/// trap handlers) and the sleep resumes for the remainder.
+fn interruptible_sleep_until(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    deadline: Instant,
+) -> Result<()> {
+    loop {
+        if crate::codegen::signal_table::PENDING_SIGNALS.load(std::sync::atomic::Ordering::Relaxed)
+            != 0
+            && crate::executor::execute_gc(vm, globals).is_none()
+        {
+            return Err(vm.take_error());
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(());
+        }
+        let remaining = deadline - now;
+        let ts = libc::timespec {
+            tv_sec: remaining.as_secs() as libc::time_t,
+            tv_nsec: remaining.subsec_nanos() as libc::c_long,
+        };
+        // SAFETY: plain POSIX nanosleep on a valid timespec.
+        let r = unsafe { libc::nanosleep(&ts, std::ptr::null_mut()) };
+        if r == 0 {
+            return Ok(());
+        }
+        if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+            return Ok(());
+        }
+        if crate::executor::execute_gc(vm, globals).is_none() {
+            return Err(vm.take_error());
+        }
+    }
+}
+
+/// Run one green thread until it parks or terminates.
+fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
+    enum Entry {
+        Invoke(ProcData, *const Value, usize, *mut Executor),
+        Resume(*mut Executor),
+    }
+    let entry = SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.current = Some(thread);
+        let inner = thread.as_thread_inner_mut();
+        if inner.state() == ThreadState::Created {
+            inner.state = ThreadState::Runnable;
+            inner.initialize_stack();
+            let proc_data = ProcData::from_proc(inner.proc().unwrap());
+            let args = inner.args();
+            let (ptr, len) = (args.as_ptr(), args.len());
+            Entry::Invoke(proc_data, ptr, len, inner.handle() as *mut Executor)
+        } else {
+            inner.state = ThreadState::Runnable;
+            Entry::Resume(inner.resume_exec.take().unwrap().as_ptr())
+        }
+    });
+    // The switch itself happens with no scheduler borrow held.
+    let ret = match entry {
+        Entry::Invoke(proc_data, args, len, handle) => {
+            let invoker = CODEGEN.with(|c| c.borrow().thread_invoker);
+            // SAFETY: `handle`/`args` point into the THREAD RValue,
+            // which is rooted by the scheduler registry for the whole
+            // run; the RValue arena does not move objects.
+            invoker(
+                unsafe { &mut *handle },
+                globals,
+                &proc_data,
+                Value::nil(),
+                args,
+                len,
+            )
+        }
+        Entry::Resume(exec) => {
+            let resume = CODEGEN.with(|c| c.borrow().scheduler_resume);
+            resume(exec, Value::nil())
+        }
+    };
+    // Control is back in the scheduler context.
+    if thread.as_thread_inner().body_terminated() {
+        finalize(globals, thread, ret);
+    }
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.current = s.main;
+    });
+    Ok(())
+}
+
+/// A green thread's body finished: record the outcome, wake joiners,
+/// prune the registry.
+fn finalize(globals: &mut Globals, mut thread: Value, ret: Option<Value>) {
+    let woken = SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        let inner = thread.as_thread_inner_mut();
+        inner.state = ThreadState::Dead;
+        match ret {
+            Some(v) => inner.result = Some(v),
+            None => {
+                let err = inner.take_error();
+                // A bare `return` / `break` escaping a thread body has no
+                // enclosing frame on the thread's own stack: LocalJumpError
+                // (CRuby).
+                let err = match err.kind() {
+                    MonorubyErrKind::MethodReturn(..) => {
+                        MonorubyErr::localjumperr("unexpected return")
+                    }
+                    MonorubyErrKind::BlockBreak(..) => {
+                        MonorubyErr::localjumperr("break from proc-closure")
+                    }
+                    _ => err,
+                };
+                inner.exception = Some(err);
+            }
+        }
+        let joiners = std::mem::take(&mut inner.joiners);
+        let main = s.main;
+        let mut main_woken = false;
+        for mut j in joiners {
+            let ji = j.as_thread_inner_mut();
+            if ji.state() == ThreadState::Joining {
+                ji.state = ThreadState::Runnable;
+                if Some(j) == main {
+                    main_woken = true;
+                } else {
+                    s.ready.push_back(j);
+                }
+            }
+        }
+        s.threads.retain(|t| *t != thread);
+        main_woken
+    });
+    let _ = woken;
+    // `Thread#report_on_exception` default: surface a terminating
+    // exception on stderr (CRuby prints it when the thread dies).
+    let msg = {
+        let inner = thread.as_thread_inner();
+        inner
+            .exception
+            .as_ref()
+            .map(|err| format!("{} ({})", err.message(), err.class_name(&globals.store)))
+    };
+    if let Some(msg) = msg {
+        eprintln!("warning: thread terminated with exception (report_on_exception is true):");
+        eprintln!("{msg}");
+    }
+}

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1401,6 +1401,14 @@ impl Value {
         RValue::new_fiber(proc).pack()
     }
 
+    pub(crate) fn new_thread(class_id: ClassId, inner: crate::value::rvalue::ThreadInner) -> Self {
+        RValue::new_thread(class_id, inner).pack()
+    }
+
+    pub(crate) fn is_thread(&self) -> bool {
+        self.ty() == Some(ObjTy::THREAD)
+    }
+
     pub(crate) fn new_enumerator(
         obj: Value,
         method: IdentId,
@@ -2892,6 +2900,18 @@ impl Value {
     pub fn as_umethod(&self) -> &UMethodInner {
         assert_eq!(ObjTy::UMETHOD, self.rvalue().ty());
         self.rvalue().as_umethod()
+    }
+
+    pub(crate) fn as_thread_inner(&self) -> &crate::value::rvalue::ThreadInner {
+        assert_eq!(self.ty(), Some(ObjTy::THREAD));
+        // SAFETY: type checked immediately above.
+        unsafe { self.rvalue().as_thread() }
+    }
+
+    pub(crate) fn as_thread_inner_mut(&mut self) -> &mut crate::value::rvalue::ThreadInner {
+        assert_eq!(self.ty(), Some(ObjTy::THREAD));
+        // SAFETY: type checked immediately above.
+        unsafe { self.rvalue_mut().as_thread_mut() }
     }
 
     pub fn as_fiber_inner(&self) -> &FiberInner {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -19,6 +19,7 @@ pub use complex::ComplexInner;
 pub use enumerator::*;
 pub use exception::ExceptionInner;
 pub use fiber::*;
+pub use thread::*;
 pub use hash::*;
 pub use io::{fd_is_owned, IoInner, NonblockRead, NonblockWrite};
 pub use ivar_table::*;
@@ -43,6 +44,7 @@ mod complex;
 mod enumerator;
 mod exception;
 mod fiber;
+mod thread;
 mod hash;
 mod io;
 mod ivar_table;
@@ -106,6 +108,7 @@ impl std::fmt::Debug for ObjTy {
                 24 => "STRUCT",
                 25 => "ARITHMETIC_SEQUENCE",
                 26 => "IO_BUFFER",
+                27 => "THREAD",
                 _ => return write!(f, "INVALID({ty})"),
             }
         )
@@ -145,6 +148,7 @@ impl ObjTy {
     pub const STRUCT: Self = Self(std::num::NonZeroU8::new(24).unwrap());
     pub const ARITHMETIC_SEQUENCE: Self = Self(std::num::NonZeroU8::new(25).unwrap());
     pub const IO_BUFFER: Self = Self(std::num::NonZeroU8::new(26).unwrap());
+    pub const THREAD: Self = Self(std::num::NonZeroU8::new(27).unwrap());
 }
 
 #[repr(C)]
@@ -167,6 +171,9 @@ pub union ObjKind {
     method: ManuallyDrop<MethodInner>,
     umethod: ManuallyDrop<UMethodInner>,
     fiber: ManuallyDrop<FiberInner>,
+    /// Boxed: ThreadInner (scheduler bookkeeping, saved error, joiner
+    /// list) is far larger than the RValue cell.
+    thread: ManuallyDrop<Box<ThreadInner>>,
     enumerator: ManuallyDrop<Box<EnumeratorInner>>,
     generator: ManuallyDrop<GeneratorInner>,
     binding: ManuallyDrop<BindingInner>,
@@ -409,6 +416,12 @@ impl ObjKind {
         }
     }
 
+    fn thread(inner: ThreadInner) -> Self {
+        Self {
+            thread: ManuallyDrop::new(Box::new(inner)),
+        }
+    }
+
     fn fiber(proc: Proc) -> Self {
         Self {
             fiber: ManuallyDrop::new(FiberInner::new(proc)),
@@ -525,6 +538,7 @@ impl std::fmt::Debug for RValue {
                             ObjTy::IO => format!("{:?}", self.kind.io),
                             ObjTy::METHOD => format!("{:?}", self.kind.method),
                             ObjTy::FIBER => format!("{:?}", self.kind.fiber),
+                            ObjTy::THREAD => format!("{:?}", self.kind.thread),
                             ObjTy::ENUMERATOR => format!("{:?}", self.kind.enumerator),
                             ObjTy::GENERATOR => format!("{:?}", self.kind.generator),
                             ObjTy::COMPLEX => format!("{:?}", self.kind.complex),
@@ -773,6 +787,7 @@ impl alloc::GCBox for RValue {
                 ObjTy::HASH => ManuallyDrop::drop(&mut self.kind.hash),
                 ObjTy::REGEXP => ManuallyDrop::drop(&mut self.kind.regexp),
                 ObjTy::FIBER => ManuallyDrop::drop(&mut self.kind.fiber),
+                ObjTy::THREAD => ManuallyDrop::drop(&mut self.kind.thread),
                 ObjTy::ENUMERATOR => ManuallyDrop::drop(&mut self.kind.enumerator),
                 ObjTy::GENERATOR => ManuallyDrop::drop(&mut self.kind.generator),
                 ObjTy::BINDING => ManuallyDrop::drop(&mut self.kind.binding),
@@ -859,6 +874,7 @@ impl alloc::GCBox for RValue {
                 ObjTy::EXCEPTION => self.as_exception().mark(alloc),
                 ObjTy::METHOD => self.as_method().mark(alloc),
                 ObjTy::FIBER => self.as_fiber().mark(alloc),
+                ObjTy::THREAD => self.as_thread().mark(alloc),
                 ObjTy::ENUMERATOR => self.as_enumerator().mark(alloc),
                 ObjTy::GENERATOR => self.as_generator().mark(alloc),
                 ObjTy::BINDING => self.as_binding().mark(alloc),
@@ -1935,6 +1951,14 @@ impl RValue {
         }
     }
 
+    pub(super) fn new_thread(class_id: ClassId, inner: ThreadInner) -> Self {
+        RValue {
+            header: Header::new(class_id, ObjTy::THREAD),
+            kind: ObjKind::thread(inner),
+            var_table: None,
+        }
+    }
+
     pub(super) fn new_fiber(proc: Proc) -> Self {
         RValue {
             header: Header::new(FIBER_CLASS, ObjTy::FIBER),
@@ -2234,6 +2258,16 @@ impl RValue {
     pub(crate) fn as_umethod(&self) -> &UMethodInner {
         assert_eq!(self.ty(), ObjTy::UMETHOD);
         unsafe { &self.kind.umethod }
+    }
+
+    pub(super) unsafe fn as_thread(&self) -> &ThreadInner {
+        assert_eq!(self.ty(), ObjTy::THREAD);
+        unsafe { &self.kind.thread }
+    }
+
+    pub(super) unsafe fn as_thread_mut(&mut self) -> &mut ThreadInner {
+        assert_eq!(self.ty(), ObjTy::THREAD);
+        unsafe { &mut self.kind.thread }
     }
 
     pub(super) unsafe fn as_fiber(&self) -> &FiberInner {

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -1,0 +1,193 @@
+use super::*;
+
+/// Green-thread control block.
+///
+/// monoruby threads are cooperative green threads multiplexed on the one
+/// OS thread (see scheduler.rs). Each thread owns a dedicated machine
+/// stack and an `Executor` — exactly like a `FiberInner` — but is
+/// scheduled by the global scheduler instead of an explicit
+/// resume/yield parent chain. `parent_fiber` of a thread root is always
+/// `None`, so `Fiber.yield` at a thread's root takes the pre-existing
+/// "can't yield from main fiber" error paths unchanged.
+#[derive(Debug)]
+pub struct ThreadInner {
+    /// The thread's own VM context. `None` for the main thread, whose
+    /// `Executor` is owned by the embedder (marked via the scheduler's
+    /// live `main_exec` pointer while green threads run).
+    handle: Option<Box<Executor>>,
+    /// The body block. `None` for the main thread and for bare
+    /// `Thread.allocate` shells (e.g. `Thread::Waiter`).
+    proc: Option<Proc>,
+    /// Arguments passed to `Thread.new`, delivered to the body block.
+    args: Vec<Value>,
+    /// Dedicated machine stack, lazily allocated at first activation.
+    stack: Option<std::ptr::NonNull<u8>>,
+    pub(crate) state: ThreadState,
+    /// The executor context the scheduler must resume — the thread root,
+    /// or a fiber nested inside the thread that parked on its behalf.
+    /// Only valid while parked.
+    pub(crate) resume_exec: Option<std::ptr::NonNull<Executor>>,
+    /// Body result (threads terminated normally).
+    pub(crate) result: Option<Value>,
+    /// Terminating exception (re-raised by `#join` / `#value`).
+    pub(crate) exception: Option<MonorubyErr>,
+    /// Threads parked in `#join` on this thread.
+    pub(crate) joiners: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ThreadState {
+    /// Not yet activated (no stack, body not started).
+    Created,
+    /// Runnable: in the ready queue, or the currently running thread.
+    Runnable,
+    /// Parked in `Kernel#sleep` / `Thread.stop` (deadline in the
+    /// scheduler's sleeper list; `None` deadline = until woken).
+    Sleeping,
+    /// Parked in `#join` / `#value` waiting on another thread.
+    Joining,
+    /// Terminated (body returned, raised, or was killed).
+    Dead,
+}
+
+const THREAD_STACK_SIZE: usize = 1024 * 256;
+
+impl Drop for ThreadInner {
+    fn drop(&mut self) {
+        use std::alloc::*;
+        if let Some(stack) = self.stack {
+            let layout = Layout::from_size_align(THREAD_STACK_SIZE, 4096).unwrap();
+            unsafe {
+                libc::mprotect(stack.as_ptr() as _, 4096, libc::PROT_WRITE);
+                dealloc(stack.as_ptr(), layout);
+            }
+            self.stack = None;
+        }
+    }
+}
+
+impl alloc::GC<RValue> for ThreadInner {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        if let Some(handle) = &self.handle {
+            handle.mark(alloc);
+        }
+        if let Some(proc) = &self.proc {
+            proc.mark(alloc);
+        }
+        for v in &self.args {
+            v.mark(alloc);
+        }
+        if let Some(v) = self.result {
+            v.mark(alloc);
+        }
+        if let Some(err) = &self.exception {
+            err.mark(alloc);
+        }
+        for v in &self.joiners {
+            v.mark(alloc);
+        }
+    }
+}
+
+impl ThreadInner {
+    /// A schedulable green thread with a body.
+    pub(crate) fn new(proc: Proc, args: Vec<Value>) -> Self {
+        Self {
+            handle: Some(Box::new(Executor::default())),
+            proc: Some(proc),
+            args,
+            stack: None,
+            state: ThreadState::Created,
+            resume_exec: None,
+            result: None,
+            exception: None,
+            joiners: vec![],
+        }
+    }
+
+    /// The control block representing the main thread. Its `Executor` is
+    /// the embedder's; the scheduler marks it through `main_exec`.
+    pub(crate) fn main() -> Self {
+        Self {
+            handle: None,
+            proc: None,
+            args: vec![],
+            stack: None,
+            state: ThreadState::Runnable,
+            resume_exec: None,
+            result: None,
+            exception: None,
+            joiners: vec![],
+        }
+    }
+
+    /// An inert shell for `Thread.allocate` (never scheduled). Used by
+    /// Ruby-level subclasses with their own life cycle, e.g.
+    /// `Thread::Waiter` returned by `Process.detach`.
+    pub(crate) fn shell() -> Self {
+        Self {
+            handle: None,
+            proc: None,
+            args: vec![],
+            stack: None,
+            state: ThreadState::Dead,
+            resume_exec: None,
+            result: None,
+            exception: None,
+            joiners: vec![],
+        }
+    }
+
+    pub(crate) fn is_main(&self) -> bool {
+        self.handle.is_none() && self.proc.is_none() && self.state != ThreadState::Dead
+    }
+
+    pub(crate) fn state(&self) -> ThreadState {
+        self.state
+    }
+
+    pub(crate) fn is_dead(&self) -> bool {
+        self.state == ThreadState::Dead
+    }
+
+    pub(crate) fn proc(&self) -> Option<&Proc> {
+        self.proc.as_ref()
+    }
+
+    pub(crate) fn args(&self) -> &[Value] {
+        &self.args
+    }
+
+    pub(crate) fn handle(&mut self) -> &mut Executor {
+        self.handle.as_mut().unwrap()
+    }
+
+    /// Whether the body has terminated (mirrors `FiberState::Terminated`).
+    pub(crate) fn body_terminated(&self) -> bool {
+        matches!(
+            self.handle.as_deref().map(|h| h.fiber_state()),
+            Some(FiberState::Terminated)
+        )
+    }
+
+    /// Allocate the dedicated stack and point the executor at its top.
+    /// Must be called exactly once, at first activation.
+    pub(crate) fn initialize_stack(&mut self) {
+        use std::alloc::*;
+        assert!(self.stack.is_none());
+        let layout = Layout::from_size_align(THREAD_STACK_SIZE, 4096).unwrap();
+        unsafe {
+            let stack_bottom = alloc(layout);
+            libc::mprotect(stack_bottom as _, 4096, libc::PROT_NONE);
+            let stack_top = stack_bottom.add(THREAD_STACK_SIZE);
+            self.stack = Some(std::ptr::NonNull::new(stack_bottom).unwrap());
+            let handle = self.handle.as_mut().unwrap();
+            handle.save_rsp(stack_top);
+            handle.set_stack_limit(stack_top);
+        }
+    }
+
+    pub(crate) fn take_error(&mut self) -> MonorubyErr {
+        self.handle.as_mut().unwrap().take_error()
+    }
+}


### PR DESCRIPTION
First step of the multithreading plan discussed earlier: cooperative green threads multiplexed on the one OS thread, built on the existing fiber machinery. Targets the `thread` integration branch.

## Design

**Thread = fiber-shaped context + scheduler.** Each `Thread` owns a dedicated 256 KiB machine stack and an `Executor` (`ThreadInner`, modeled on `FiberInner`). Context switches reuse the `rsp_save` swap via three new stubs per arch (`thread_invoker` / `switch_to_scheduler` / `scheduler_resume`, x86_64 + aarch64). The stubs deliberately never touch `parent_fiber`, so:

- a thread root keeps `parent_fiber == None`, and `Fiber.yield` at a thread root takes the pre-existing "can't yield" error paths **unchanged** (verified under JIT too — see the bug fix below);
- a fiber nested inside a green thread keeps its resume chain intact across scheduler switches (covered by a test).

**Event-loop topology.** The scheduler loop (`src/scheduler.rs`) only ever runs in the main thread's context: main parks by *calling* `scheduler_run` on its own stack; green threads park by *switching* to the scheduler context saved in the process-global `SCHED_RSP` slot. A dying thread body switches back the same way (thread_invoker epilogue), so only one loop instance can ever be live and one context slot suffices. Deadlock (nothing runnable, no deadline) raises fatal `No live threads left. Deadlock?` like CRuby.

**GC.** The scheduler registry (all live Thread objects, including main) is a new GC root; while green threads run, the main thread's frames stay reachable through a published main-executor pointer (`in_scheduler` guard). Switches happen only at VM safepoints inside builtins, so every suspended thread's frames are GC-complete — same invariant the fiber machinery already relies on.

## API surface

- `Thread.new/start/fork` (body queued; first runs at the next blocking point — spec-compatible with `deque.rb`'s "spawned thread must not complete first" assumption), `Thread.current/main/list/pass/stop`
- `#join(timeout)` / `#value` (re-raise a terminating exception), `#status` / `#alive?` / `#stop?`, `#wakeup` / `#run`
- `Kernel#sleep` yields to the scheduler when other threads are live; no-duration sleep parks until `#wakeup`
- Thread name and thread-/fiber-local storage stay in startup.rb; `Thread::Waiter` (`Process.detach`) now builds on `allocate`
- Bare `return`/`break` escaping a body → `LocalJumpError`; a terminating exception is reported on stderr (report_on_exception) and re-raised on join

## Bugs found & fixed along the way

- **Latent JIT SEGV (pre-existing `TODO`)**: the inlined `Fiber.yield` had no parent-fiber null check and switched rsp through a null pointer when a JIT-compiled main-fiber/thread-root yield executed. Both arches now route the no-parent case to a `FiberError` helper through the inline's existing error path.
- **Scheduler GC hole (own bug, caught by mspec)**: `Thread.pass` on the main thread dispatched green threads without publishing the main executor, so a GC triggered inside a green thread could free objects held only by main's frames (use-after-free in mspec's runner). `pass` now publishes it exactly like `scheduler_run`.

## Verification

- `cargo test --lib`: **1877 + 86 + 116 passed, 0 failed** (full CRuby-differential suite; includes 12 new thread tests: interleaving, status polling, wakeup, join timeout, exception propagation, deadlock, fiber-in-thread, GC under threads).
- ruby/spec `core/thread` with this runtime: **234 examples now execute, 30 pass** (wakeup/current/pass/main/stop_p specs at 100%); on master the entire category tallies **0 examples** (every file dies in fixture loading). Most remaining errors need `#kill`/`#raise` and real Mutex/Queue — the next PRs.
- Interleaving order matches CRuby exactly on the sleep-based scheduling tests.

## Known limitations (follow-up PRs on `thread`)

1. Mutex/Queue/SizedQueue/ConditionVariable are still the no-op stubs (PR2).
2. No asynchronous interrupt delivery — `Thread#raise/#kill/handle_interrupt` (PR3).
3. Blocking IO does not yet yield to the scheduler (PR4: hook `blocking_region` into an fd poller).
4. Signals convert on whichever thread polls (CRuby delivers to main).
5. `Thread.new` on a subclass does not run a Ruby `initialize` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_