### PR TITLE
Real Mutex / Queue / SizedQueue / ConditionVariable on green threads

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -850,35 +850,131 @@ class Thread
     end
   end
 
+  # Green threads switch only at blocking points (sleep / Thread.stop /
+  # join / pass), so plain Ruby code is atomic with respect to the
+  # scheduler — no preemption can occur between two non-blocking
+  # statements. That makes these synchronization primitives correct as
+  # pure Ruby built on Thread.stop / Kernel#sleep (park) and
+  # Thread#wakeup (unpark): every "test then enqueue then park" sequence
+  # below is uninterruptible up to the park itself.
+
   class Mutex
-    def synchronize
-      yield
+    def locked?
+      !!@owner
     end
-    
+
     def owned?
-      false
+      @owner == Thread.current
+    end
+
+    def try_lock
+      if @owner
+        false
+      else
+        @owner = Thread.current
+        true
+      end
+    end
+
+    def lock
+      raise ThreadError, "deadlock; recursive locking" if owned?
+      until try_lock
+        (@waiters ||= []) << Thread.current
+        begin
+          Thread.stop
+        ensure
+          @waiters.delete(Thread.current)
+        end
+      end
+      self
+    end
+
+    def unlock
+      unless @owner
+        raise ThreadError, "Attempt to unlock a mutex which is not locked"
+      end
+      unless owned?
+        raise ThreadError, "Attempt to unlock a mutex which is locked by another thread"
+      end
+      @owner = nil
+      # Hand the next waiter a chance; it re-contends in its lock loop.
+      if @waiters
+        while (w = @waiters.shift)
+          if w.alive?
+            w.wakeup
+            break
+          end
+        end
+      end
+      self
+    end
+
+    def synchronize
+      raise ThreadError, "must be called with a block" unless block_given?
+      lock
+      begin
+        yield
+      ensure
+        unlock
+      end
+    end
+
+    # Atomically release the mutex, sleep, and re-acquire it on wake
+    # (including on an exception raised into the sleeper).
+    def sleep(timeout = nil)
+      raise ThreadError, "Attempt to unlock a mutex which is not locked" unless owned?
+      unlock
+      begin
+        timeout ? Kernel.sleep(timeout) : Thread.stop
+      ensure
+        lock
+      end
     end
   end
 
   class Queue
     def initialize
       @items = []
+      @waiters = []
+      @closed = false
     end
 
     def push(item)
+      raise ClosedQueueError, "queue closed" if @closed
       @items.push(item)
+      __wake_one(@waiters)
       self
     end
     alias << push
     alias enq push
 
     def pop(non_block = false, timeout: nil)
-      if @items.empty?
-        raise ThreadError, "queue empty" if non_block
-        # With timeout, return nil (no threading in monoruby)
-        return nil
+      if non_block
+        raise ThreadError, "queue empty" if @items.empty? && !@closed
+        return @items.shift
       end
-      @items.shift
+      deadline = timeout && Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        return @items.shift unless @items.empty?
+        return nil if @closed
+        if deadline
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          return nil if remaining <= 0
+          @waiters << Thread.current
+          begin
+            Kernel.sleep(remaining)
+          ensure
+            @waiters.delete(Thread.current)
+          end
+        else
+          @waiters << Thread.current
+          begin
+            Thread.stop
+          ensure
+            @waiters.delete(Thread.current)
+          end
+        end
+      end
     end
     alias shift pop
     alias deq pop
@@ -897,33 +993,101 @@ class Thread
       self
     end
 
+    # Closing wakes every parked consumer/producer: consumers drain the
+    # remaining items then get nil; producers raise ClosedQueueError.
     def close
+      return self if @closed
       @closed = true
+      __wake_all(@waiters)
+      __wake_all(@push_waiters) if defined?(@push_waiters) && @push_waiters
       self
     end
 
     def closed?
-      @closed || false
+      @closed
     end
 
     def num_waiting
-      0
+      @waiters.size + (defined?(@push_waiters) && @push_waiters ? @push_waiters.size : 0)
+    end
+
+    private
+
+    def __wake_one(waiters)
+      while (w = waiters.shift)
+        if w.alive?
+          w.wakeup
+          return
+        end
+      end
+    end
+
+    def __wake_all(waiters)
+      until waiters.empty?
+        __wake_one(waiters)
+      end
     end
   end
 
   class SizedQueue < Queue
-    def initialize(max = nil)
+    def initialize(max)
+      max = max.to_int if !max.is_a?(Integer) && max.respond_to?(:to_int)
+      raise ArgumentError, "queue size must be positive" unless max.is_a?(Integer) && max > 0
       super()
       @max = max
+      @push_waiters = []
     end
 
-    def max
-      @max
-    end
+    attr_reader :max
 
     def max=(new_max)
+      raise ArgumentError, "queue size must be positive" unless new_max.is_a?(Integer) && new_max > 0
+      grew = new_max > @max
       @max = new_max
+      __wake_all(@push_waiters) if grew
+      new_max
     end
+
+    def push(item, non_block = false, timeout: nil)
+      deadline = timeout && Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        raise ClosedQueueError, "queue closed" if @closed
+        if @items.size < @max
+          @items.push(item)
+          __wake_one(@waiters)
+          return self
+        end
+        raise ThreadError, "queue full" if non_block
+        if deadline
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          return nil if remaining <= 0
+          @push_waiters << Thread.current
+          begin
+            Kernel.sleep(remaining)
+          ensure
+            @push_waiters.delete(Thread.current)
+          end
+        else
+          @push_waiters << Thread.current
+          begin
+            Thread.stop
+          ensure
+            @push_waiters.delete(Thread.current)
+          end
+        end
+      end
+    end
+    alias << push
+    alias enq push
+
+    def pop(non_block = false, timeout: nil)
+      v = super
+      # Popping frees a slot: let one parked producer through.
+      __wake_one(@push_waiters)
+      v
+    end
+    alias shift pop
+    alias deq pop
   end
 
   class ConditionVariable
@@ -931,15 +1095,38 @@ class Thread
       @waiters = []
     end
 
+    # Atomically release `mutex` and park until signaled (or the timeout
+    # elapses), then re-acquire `mutex` before returning — also on an
+    # exception raised into the waiter.
     def wait(mutex, timeout = nil)
+      @waiters << Thread.current
+      begin
+        mutex.unlock
+        begin
+          timeout ? Kernel.sleep(timeout) : Thread.stop
+        ensure
+          mutex.lock
+        end
+      ensure
+        @waiters.delete(Thread.current)
+      end
       self
     end
 
     def signal
+      while (w = @waiters.shift)
+        if w.alive?
+          w.wakeup
+          break
+        end
+      end
       self
     end
 
     def broadcast
+      until @waiters.empty?
+        signal
+      end
       self
     end
   end
@@ -984,6 +1171,9 @@ end
 
 # Top-level aliases (CRuby compatibility)
 class ThreadError < StandardError; end unless defined?(::ThreadError)
+# Raised by push/pop on a closed queue (CRuby: subclass of StopIteration,
+# so `loop { q.pop }` exits cleanly when the queue is closed).
+class ClosedQueueError < StopIteration; end unless defined?(::ClosedQueueError)
 Queue = Thread::Queue
 SizedQueue = Thread::SizedQueue
 ConditionVariable = Thread::ConditionVariable

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -423,6 +423,138 @@ mod tests {
     }
 
     #[test]
+    fn mutex_lock_unlock_contention() {
+        run_test_once(
+            r#"
+            m = Mutex.new
+            counter = 0
+            ts = 4.times.map do
+              Thread.new { 50.times { m.synchronize { c = counter; sleep 0.0001; counter = c + 1 } } }
+            end
+            ts.each(&:join)
+            counter
+            "#,
+        );
+        run_test_once(
+            r#"
+            m = Mutex.new
+            r = [m.locked?, m.try_lock, m.locked?, m.owned?, m.try_lock]
+            m.unlock
+            r << m.locked?
+            begin; m.unlock; rescue ThreadError; r << :not_locked; end
+            m.lock
+            begin; m.lock; rescue ThreadError; r << :recursive; end
+            m.unlock
+            r
+            "#,
+        );
+        run_test_once(
+            r#"
+            m = Mutex.new
+            slept = false
+            t = Thread.new { m.synchronize { m.sleep(0.01); slept = m.owned? } }
+            t.join
+            [slept, m.locked?]
+            "#,
+        );
+    }
+
+    #[test]
+    fn queue_producer_consumer() {
+        run_test_once(
+            r#"
+            q = Queue.new
+            prod = Thread.new { 5.times { |i| q.push i }; q.close }
+            out = []
+            while v = q.pop
+              out << v
+            end
+            prod.join
+            [out, q.closed?, q.pop]
+            "#,
+        );
+        run_test_once(
+            r#"
+            q = Queue.new
+            r = [q.pop(timeout: 0.02)]
+            begin; q.pop(true); rescue ThreadError; r << :empty; end
+            q.push 1
+            q.close
+            begin; q.push 2; rescue ClosedQueueError; r << :closed; end
+            r << q.pop << q.pop
+            r
+            "#,
+        );
+        run_test_once(
+            r#"
+            q = Queue.new
+            t = Thread.new { q.pop }
+            Thread.pass until q.num_waiting == 1
+            q.push :v
+            [t.value, q.num_waiting]
+            "#,
+        );
+    }
+
+    #[test]
+    fn sized_queue_backpressure() {
+        run_test_once(
+            r#"
+            q = SizedQueue.new(2)
+            pushed = 0
+            t = Thread.new { 5.times { |i| q.push(i); pushed += 1 } }
+            Thread.pass until q.num_waiting == 1
+            first = pushed
+            3.times { q.pop }
+            t.join
+            [q.max, first, pushed, q.size]
+            "#,
+        );
+        run_test_once(
+            r#"
+            begin; SizedQueue.new(0); rescue ArgumentError; :nonpositive; end
+            "#,
+        );
+    }
+
+    #[test]
+    fn condition_variable_wait_signal() {
+        run_test_once(
+            r#"
+            m = Mutex.new
+            cv = ConditionVariable.new
+            log = []
+            t = Thread.new do
+              m.synchronize { log << :waiting; cv.wait(m); log << :woken; m.owned? }
+            end
+            Thread.pass until m.synchronize { log.include?(:waiting) }
+            m.synchronize { cv.signal }
+            [t.value, log]
+            "#,
+        );
+        run_test_once(
+            r#"
+            m = Mutex.new
+            cv = ConditionVariable.new
+            woken = 0
+            ts = 3.times.map { Thread.new { m.synchronize { cv.wait(m); woken += 1 } } }
+            Thread.pass until ts.all? { |t| t.status == "sleep" }
+            m.synchronize { cv.broadcast }
+            ts.each(&:join)
+            woken
+            "#,
+        );
+        run_test_once(
+            r#"
+            m = Mutex.new
+            cv = ConditionVariable.new
+            m.synchronize { cv.wait(m, 0.02) }
+            :timeout_ok
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_fiber_yield_at_thread_root_errors() {
         // Fiber.yield at a thread root has no parent fiber: FiberError,
         // exactly like at the main fiber.


### PR DESCRIPTION
PR2 of the green-thread series (follows #941). Replaces the no-op synchronization stubs with real blocking primitives.

## Approach: pure Ruby on the scheduler's park/wake

Green threads switch only at blocking points (`sleep` / `Thread.stop` / `#join` / `Thread.pass`), so plain Ruby code is **atomic with respect to the scheduler** — no preemption can occur between two non-blocking statements. Every "test condition → enqueue self → park" sequence is therefore race-free by construction, and the whole layer is implemented in `startup.rb` on top of #941's `Thread.stop` / `Kernel#sleep` (park) and `Thread#wakeup` (unpark) — **zero new native code**.

- **Mutex** — `lock`/`unlock`/`try_lock`/`synchronize`/`locked?`/`owned?` with a waiter queue and CRuby's error messages (recursive locking; unlock of an unlocked / foreign mutex). `Mutex#sleep` atomically releases and re-acquires, also when an exception is raised into the sleeper (ensure-protected).
- **Queue** — blocking `pop` with a waiter queue; `pop(true)` raises ThreadError; `pop(timeout:)` returns nil on expiry; `close` wakes every waiter (consumers drain remaining items then get nil, producers raise `ClosedQueueError`); `num_waiting`.
- **SizedQueue** — bounded `push` with its own waiter queue (back-pressure), `push(true)` / `push(timeout:)`, `max=` growth wakes parked producers, positive-size validation.
- **ConditionVariable** — `wait(mutex, timeout)` releases and re-acquires the mutex around the park (ensure-protected, so a kill/raise into the waiter still relocks once PR3 lands); `signal` skips dead waiters; `broadcast`.
- New `ClosedQueueError < StopIteration` (so `loop { q.pop }` terminates on close, as in CRuby).

Deadlock among parked threads is caught by #941's scheduler (fatal `No live threads left. Deadlock?`).

## Verification

- `cargo test --lib`: **1881 + 86 + 116 passed, 0 failed** — includes 4 new differential test groups (mutex contention with 4 threads × 50 increments around a sleep point, queue producer/consumer + close/timeout/num_waiting, SizedQueue back-pressure, condvar wait/signal/broadcast/timeout), all compared against CRuby 4.0.2.
- ruby/spec (was 0 examples executing for all of these on master):

| Category | Examples | Pass | vs. #941 alone |
|---|---:|---:|---|
| core/mutex | 35 | **25** | (category previously all-error) |
| core/queue | 25 | **15** | 〃 |
| core/sizedqueue | 40 | **30** | 〃 |
| core/conditionvariable | 11 | **5** | was 0% on the monitor |
| core/thread | 225 | 36 | fixtures using Mutex now load |

Most remaining failures/errors need `Thread#kill` / `#raise` (asynchronous interrupt delivery — PR3) or `Thread#exit`-style cleanup used by spec fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_