### PR TITLE
Thread.handle_interrupt masking and Thread.pending_interrupt?

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -771,13 +771,6 @@ class Thread
   # asynchronous interruption — #raise / #kill — is not implemented yet,
   # so there is nothing to mask).
 
-  # Interrupt masking: monoruby delivers no asynchronous interrupts yet,
-  # so just run the block (used by Bundler's connection_pool and by
-  # timeout).
-  def self.handle_interrupt(mask)
-    yield
-  end
-
   def self.each_caller_location
     caller_locations(1).each do |loc|
       yield loc

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::scheduler;
-use crate::value::rvalue::{PendingInterrupt, ThreadInner, ThreadState};
+use crate::value::rvalue::{InterruptTiming, PendingInterrupt, ThreadInner, ThreadState};
 
 //
 // Thread class
@@ -43,6 +43,145 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(THREAD_CLASS, "terminate", thread_kill, 0);
     globals.define_builtin_class_func(THREAD_CLASS, "kill", thread_class_kill, 1);
     globals.define_builtin_class_func(THREAD_CLASS, "exit", thread_class_exit, 0);
+    globals.define_builtin_class_func(THREAD_CLASS, "handle_interrupt", handle_interrupt, 1);
+    globals.define_builtin_class_func_with(
+        THREAD_CLASS,
+        "pending_interrupt?",
+        class_pending_interrupt_p,
+        0,
+        1,
+        false,
+    );
+    globals.define_builtin_func_with(
+        THREAD_CLASS,
+        "pending_interrupt?",
+        pending_interrupt_p,
+        0,
+        1,
+        false,
+    );
+}
+
+/// Parse a `{Class => :immediate | :on_blocking | :never}` mask hash.
+fn parse_interrupt_mask(
+    globals: &mut Globals,
+    hash: Value,
+) -> Result<Vec<(Value, InterruptTiming)>> {
+    let Some(h) = hash.try_hash_ty() else {
+        return Err(MonorubyErr::argumenterr("unknown mask signature"));
+    };
+    let mut mask = vec![];
+    let _guard = h.iter_guard();
+    for (k, v) in h.iter() {
+        if k.is_class_or_module().is_none() {
+            return Err(MonorubyErr::typeerr(
+                "class or module required for rescue clause",
+            ));
+        }
+        let timing = match v.try_symbol().map(|id| id.get_name()) {
+            Some(name) if name == "immediate" => InterruptTiming::Immediate,
+            Some(name) if name == "on_blocking" => InterruptTiming::OnBlocking,
+            Some(name) if name == "never" => InterruptTiming::Never,
+            _ => return Err(MonorubyErr::argumenterr("unknown mask signature")),
+        };
+        mask.push((k, timing));
+    }
+    let _ = globals;
+    Ok(mask)
+}
+
+///
+/// ### Thread.handle_interrupt
+///
+/// - handle_interrupt(hash) { ... } -> object
+///
+/// Runs the block under an interrupt mask (`Class => :immediate /
+/// :on_blocking / :never`). Pending interrupts allowed by the new mask
+/// fire on entry; interrupts deferred by the mask fire at block exit
+/// (under the outer mask).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/handle_interrupt.html]
+#[monoruby_builtin]
+fn handle_interrupt(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let bh = lfp.expect_block()?;
+    let mask = parse_interrupt_mask(globals, lfp.arg(0))?;
+    let cur = scheduler::current_thread(vm);
+    scheduler::push_interrupt_mask(vm, mask);
+    // Entry delivery point (non-blocking): a pending interrupt the new
+    // mask allows fires before the block runs.
+    let res = match scheduler::deliver_pending_now(globals, cur, false) {
+        Err(err) => Err(err),
+        Ok(()) => vm.invoke_block_once(globals, bh, &[]),
+    };
+    scheduler::pop_interrupt_mask(vm);
+    // Exit delivery point, under the outer mask: interrupts the block's
+    // mask deferred fire here — even when the block itself raised, and
+    // the delivered interrupt takes precedence over the block's own
+    // exception (CRuby).
+    scheduler::deliver_pending_now(globals, cur, false)?;
+    res
+}
+
+fn pending_filter(globals: &Globals, lfp: Lfp) -> Result<Option<Module>> {
+    match lfp.try_arg(0) {
+        None => Ok(None),
+        Some(v) => match v.is_class_or_module() {
+            Some(m) => Ok(Some(m)),
+            None => {
+                let _ = globals;
+                Err(MonorubyErr::typeerr(
+                    "class or module required for rescue clause",
+                ))
+            }
+        },
+    }
+}
+
+///
+/// ### Thread.pending_interrupt?
+///
+/// Whether the current thread has queued asynchronous interrupts
+/// (optionally filtered by exception class).
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/pending_interrupt=3f.html]
+#[monoruby_builtin]
+fn class_pending_interrupt_p(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let filter = pending_filter(globals, lfp)?;
+    let cur = scheduler::current_thread(vm);
+    Ok(Value::bool(scheduler::pending_interrupt_p(
+        &globals.store,
+        cur,
+        filter,
+    )))
+}
+
+///
+/// ### Thread#pending_interrupt?
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/pending_interrupt=3f.html]
+#[monoruby_builtin]
+fn pending_interrupt_p(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let filter = pending_filter(globals, lfp)?;
+    Ok(Value::bool(scheduler::pending_interrupt_p(
+        &globals.store,
+        lfp.self_val(),
+        filter,
+    )))
 }
 
 /// Build the exception for an asynchronous `Thread#raise` from its
@@ -587,6 +726,94 @@ mod tests {
             res
             "#,
         );
+    }
+
+    #[test]
+    fn thread_handle_interrupt_masking() {
+        // Shared driver mirroring ruby/spec's handle_interrupt fixture:
+        // raise into a thread inside a handle_interrupt block, observe
+        // whether it fires inside (:interrupted) or at exit (:deferred).
+        const DRIVER: &str = r#"
+            def run_masked(timing, blocking = true)
+              klass = Class.new(RuntimeError)
+              pad = []
+              in_hi = Queue.new
+              cont = Queue.new
+              th = Thread.new do
+                begin
+                  Thread.handle_interrupt(klass => timing) do
+                    begin
+                      in_hi << true
+                      if blocking
+                        Thread.pass
+                        cont.pop
+                      else
+                        begin
+                          cont.pop(true)
+                        rescue ThreadError
+                          Thread.pass
+                          retry
+                        end
+                      end
+                    rescue klass
+                      pad << :interrupted
+                    end
+                  end
+                rescue klass
+                  pad << :deferred
+                end
+              end
+              in_hi.pop
+              Thread.pass while blocking && !th.stop?
+              th.raise klass, "interrupt"
+              cont << true
+              th.join
+              pad
+            end
+        "#;
+        run_test_once(&format!("{DRIVER}\nrun_masked(:never)"));
+        run_test_once(&format!("{DRIVER}\nrun_masked(:on_blocking)"));
+        // Thread.pass is NOT a blocking call: :on_blocking defers when
+        // the block never really blocks.
+        run_test_once(&format!("{DRIVER}\nrun_masked(:on_blocking, false)"));
+        run_test_once(&format!("{DRIVER}\nrun_masked(:immediate)"));
+        // Entry delivery: unmasking with pending interrupts fires them
+        // before the block runs; pending_interrupt? reflects the queue.
+        run_test_once(
+            r#"
+            Thread.handle_interrupt(RuntimeError => :never) do
+              current = Thread.current
+              Thread.new { current.raise "interrupt immediate" }.join
+              a = Thread.pending_interrupt?
+              b = begin
+                Thread.handle_interrupt(RuntimeError => :immediate) { :not_reached }
+              rescue RuntimeError => e
+                e.message
+              end
+              [a, b, Thread.pending_interrupt?]
+            end
+            "#,
+        );
+        // Class-filtered pending_interrupt? and hierarchy matching.
+        run_test_once(
+            r#"
+            Thread.handle_interrupt(StandardError => :never) do
+              current = Thread.current
+              Thread.new { current.raise ArgumentError, "x" }.join
+              r = [Thread.pending_interrupt?, Thread.pending_interrupt?(ArgumentError),
+                   Thread.pending_interrupt?(TypeError)]
+              begin
+                Thread.handle_interrupt(Exception => :immediate) {}
+              rescue ArgumentError
+                r << :fired
+              end
+              r
+            end rescue nil
+            "#,
+        );
+        // Invalid mask arguments.
+        run_test_error(r#"Thread.handle_interrupt(RuntimeError => :sometimes) {}"#);
+        run_test_error(r#"Thread.handle_interrupt(1 => :never) {}"#);
     }
 
     #[test]

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -691,7 +691,7 @@ impl ClassInfo {
 }
 
 impl ClassInfoTable {
-    fn get_module(&self, class_id: ClassId) -> Module {
+    pub(crate) fn get_module(&self, class_id: ClassId) -> Module {
         self[class_id].object.unwrap()
     }
 

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -43,7 +43,7 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use crate::alloc::GC;
-use crate::value::rvalue::{PendingInterrupt, ThreadInner, ThreadState};
+use crate::value::rvalue::{InterruptTiming, PendingInterrupt, ThreadInner, ThreadState};
 use crate::*;
 
 thread_local! {
@@ -251,6 +251,11 @@ pub(crate) fn sleep(
     dur: Option<Duration>,
 ) -> Result<Duration> {
     ensure_main(vm);
+    // A pending interrupt allowed at blocking points fires *instead of*
+    // parking (also the case where it was queued while running).
+    let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
+    deliver_pending_now(globals, cur0, true)?;
+    set_park_blocking(cur0, true);
     let start = Instant::now();
     // An enormous duration (e.g. sleep(2**62)) must not overflow Instant
     // arithmetic — treat it as "sleep until woken".
@@ -263,7 +268,7 @@ pub(crate) fn sleep(
             s.sleepers.push((deadline, main));
         });
         scheduler_run(vm, globals)?;
-        take_main_pending()?;
+        take_main_pending(globals, true)?;
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -280,6 +285,11 @@ pub(crate) fn sleep(
 /// `Thread.pass`: give every currently runnable thread a chance to run.
 pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
     ensure_main(vm);
+    // `Thread.pass` is a delivery point for `:immediate` interrupts but
+    // NOT for `:on_blocking` ones (it is not a blocking call).
+    let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
+    deliver_pending_now(globals, cur0, false)?;
+    set_park_blocking(cur0, false);
     if is_current_main() {
         // Dispatch the threads that are ready *now* (not the ones they
         // enqueue), then come back to main. Like `scheduler_run`, the
@@ -312,7 +322,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             s.current = Some(main);
         });
         result?;
-        take_main_pending()
+        take_main_pending(globals, false)
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -343,6 +353,8 @@ pub(crate) fn join(
     }
     let deadline = timeout.map(|d| Instant::now() + d);
     loop {
+        deliver_pending_now(globals, cur, true)?;
+        set_park_blocking(cur, true);
         if target.as_thread_inner().is_dead() {
             return Ok(true);
         }
@@ -363,7 +375,7 @@ pub(crate) fn join(
                 }
             });
             scheduler_run(vm, globals)?;
-            take_main_pending()?;
+            take_main_pending(globals, true)?;
         } else {
             SCHEDULER.with(|s| {
                 let mut s = s.borrow_mut();
@@ -380,6 +392,117 @@ pub(crate) fn join(
     }
 }
 
+/// The effective `handle_interrupt` timing for `thread`'s queued pending
+/// interrupt. Kill is unmaskable. For a raise, the innermost mask entry
+/// whose class covers the exception's class wins; default `Immediate`.
+fn pending_timing(store: &Store, thread: Value) -> Option<InterruptTiming> {
+    let inner = thread.as_thread_inner();
+    let pending = inner.pending.as_ref()?;
+    let exc_class = match pending {
+        PendingInterrupt::Kill => return Some(InterruptTiming::Immediate),
+        PendingInterrupt::Raise(err) => err.class_id(),
+    };
+    for frame in inner.masks.iter().rev() {
+        for (mask_class, timing) in frame {
+            let Some(mask_module) = mask_class.is_class_or_module() else {
+                continue;
+            };
+            // Class-hierarchy match: the exception class or any of its
+            // superclasses equals the mask class.
+            let mut m = Some(store.get_module(exc_class));
+            while let Some(cur) = m {
+                if cur.id() == mask_module.id() {
+                    return Some(*timing);
+                }
+                m = cur.superclass();
+            }
+        }
+    }
+    Some(InterruptTiming::Immediate)
+}
+
+/// Take `thread`'s pending interrupt and turn it into the error to raise.
+fn take_pending_as_error(mut thread: Value) -> Option<MonorubyErr> {
+    let inner = thread.as_thread_inner_mut();
+    match inner.pending.take()? {
+        PendingInterrupt::Kill => {
+            inner.killed = true;
+            Some(kill_unwind_error())
+        }
+        PendingInterrupt::Raise(err) => Some(err),
+    }
+}
+
+/// Deliver the current thread's pending interrupt *now* if its mask
+/// timing allows delivery in this context (`at_blocking`: a real
+/// blocking operation vs `Thread.pass` / handle_interrupt boundaries).
+/// Called at every park entry and at handle_interrupt entry/exit.
+pub(crate) fn deliver_pending_now(
+    globals: &mut Globals,
+    thread: Value,
+    at_blocking: bool,
+) -> Result<()> {
+    let allowed = match pending_timing(&globals.store, thread) {
+        None => false,
+        Some(InterruptTiming::Immediate) => true,
+        Some(InterruptTiming::OnBlocking) => at_blocking,
+        Some(InterruptTiming::Never) => false,
+    };
+    if allowed
+        && let Some(err) = take_pending_as_error(thread)
+    {
+        // Killing the main thread terminates the process.
+        let is_main = SCHEDULER.with(|s| s.borrow().main) == Some(thread);
+        if is_main && thread.as_thread_inner().killed {
+            let mut t = thread;
+            t.as_thread_inner_mut().killed = false;
+            return Err(MonorubyErr::new(MonorubyErrKind::SystemExit(0), "exit"));
+        }
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Whether `thread` has a queued pending interrupt (optionally filtered
+/// by exception class) — `Thread.pending_interrupt?`.
+pub(crate) fn pending_interrupt_p(store: &Store, thread: Value, filter: Option<Module>) -> bool {
+    let inner = thread.as_thread_inner();
+    let Some(pending) = inner.pending.as_ref() else {
+        return false;
+    };
+    let Some(filter) = filter else { return true };
+    let exc_class = match pending {
+        PendingInterrupt::Kill => return true,
+        PendingInterrupt::Raise(err) => err.class_id(),
+    };
+    let mut m = Some(store.get_module(exc_class));
+    while let Some(cur) = m {
+        if cur.id() == filter.id() {
+            return true;
+        }
+        m = cur.superclass();
+    }
+    false
+}
+
+/// Record whether the thread's imminent park is a blocking operation
+/// (vs `Thread.pass`) — consulted when a queued `:on_blocking` interrupt
+/// is delivered at resume.
+fn set_park_blocking(mut thread: Value, blocking: bool) {
+    thread.as_thread_inner_mut().park_blocking = blocking;
+}
+
+/// Push / pop a `handle_interrupt` mask frame on the current thread.
+pub(crate) fn push_interrupt_mask(vm: &mut Executor, mask: Vec<(Value, InterruptTiming)>) {
+    let mut cur = current_thread(vm);
+    cur.as_thread_inner_mut().masks.push(mask);
+}
+
+pub(crate) fn pop_interrupt_mask(vm: &mut Executor) {
+    let mut cur = current_thread(vm);
+    cur.as_thread_inner_mut().masks.pop();
+}
+
 /// Queue an asynchronous interrupt (`Thread#kill` / `#raise`) for
 /// `target` and wake it if parked. An interrupt aimed at the *current*
 /// thread is returned as `Err` for the caller to raise in place.
@@ -394,39 +517,40 @@ pub(crate) fn interrupt(
     // (allocation can trigger GC, which re-enters it for marking).
     let cur = SCHEDULER.with(|s| s.borrow().current.unwrap());
     if target == cur {
-        return Err(match int {
-            PendingInterrupt::Kill => {
-                if SCHEDULER.with(|s| s.borrow().main) == Some(target) {
-                    // Killing the main thread terminates the process.
-                    MonorubyErr::new(MonorubyErrKind::SystemExit(0), "exit")
-                } else {
-                    target.as_thread_inner_mut().killed = true;
-                    kill_unwind_error()
-                }
-            }
-            PendingInterrupt::Raise(err) => err,
-        });
+        // Self-targeted interrupts honor the current handle_interrupt
+        // mask: only `:immediate` delivers in place, everything else is
+        // queued for a later delivery point.
+        target.as_thread_inner_mut().pending = Some(int);
+        if pending_timing(&globals.store, target) == Some(InterruptTiming::Immediate) {
+            return deliver_pending_now(globals, target, false);
+        }
+        return Ok(());
     }
     if target.as_thread_inner().is_dead() {
         // CRuby: killing a dead thread is a no-op; raising into one is
         // also accepted (the exception is simply lost).
         return Ok(());
     }
-    SCHEDULER.with(|s| {
-        let mut s = s.borrow_mut();
-        let inner = target.as_thread_inner_mut();
-        inner.pending = Some(int);
-        // Wake a parked target so delivery happens promptly.
-        if matches!(
-            inner.state(),
-            ThreadState::Sleeping | ThreadState::Joining | ThreadState::IoWaiting
-        ) {
-            inner.state = ThreadState::Runnable;
-            if Some(target) != s.main {
-                s.ready.push_back(target);
+    target.as_thread_inner_mut().pending = Some(int);
+    // Wake a parked target so delivery happens promptly — unless the
+    // target's handle_interrupt mask defers it (`:never`); a parked
+    // thread counts as blocking, so `:on_blocking` wakes too.
+    let wake = pending_timing(&globals.store, target) != Some(InterruptTiming::Never);
+    if wake {
+        SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            let inner = target.as_thread_inner_mut();
+            if matches!(
+                inner.state(),
+                ThreadState::Sleeping | ThreadState::Joining | ThreadState::IoWaiting
+            ) {
+                inner.state = ThreadState::Runnable;
+                if Some(target) != s.main {
+                    s.ready.push_back(target);
+                }
             }
-        }
-    });
+        });
+    }
     Ok(())
 }
 
@@ -440,20 +564,10 @@ fn kill_unwind_error() -> MonorubyErr {
 
 /// Deliver a pending interrupt queued for the *main* thread. Called
 /// after the scheduler returns control to a main-thread park.
-fn take_main_pending() -> Result<()> {
-    let pending = SCHEDULER.with(|s| {
-        let s = s.borrow();
-        let mut main = s.main.unwrap();
-        main.as_thread_inner_mut().pending.take()
-    });
-    match pending {
-        None => Ok(()),
-        // Killing the main thread terminates the process (CRuby).
-        Some(PendingInterrupt::Kill) => {
-            Err(MonorubyErr::new(MonorubyErrKind::SystemExit(0), "exit"))
-        }
-        Some(PendingInterrupt::Raise(err)) => Err(err),
-    }
+fn take_main_pending(globals: &mut Globals, at_blocking: bool) -> Result<()> {
+    let main = SCHEDULER.with(|s| s.borrow().main.unwrap());
+    // The handle_interrupt mask still applies at this delivery point.
+    deliver_pending_now(globals, main, at_blocking)
 }
 
 /// Park the current thread until `fd` reports one of `events` (or the
@@ -477,6 +591,9 @@ pub(crate) fn wait_fds(
     deadline: Option<Instant>,
 ) -> Result<()> {
     ensure_main(vm);
+    let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
+    deliver_pending_now(globals, cur0, true)?;
+    set_park_blocking(cur0, true);
     if is_current_main() {
         SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -492,7 +609,7 @@ pub(crate) fn wait_fds(
         let result = scheduler_run(vm, globals);
         unregister_io_waiter(SCHEDULER.with(|s| s.borrow().main.unwrap()));
         result?;
-        take_main_pending()
+        take_main_pending(globals, true)
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -739,12 +856,21 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
     }
     // The kill tag allocates; do it outside the scheduler borrow.
     let kill_err = kill_unwind_error();
+    // Whether the queued interrupt (if any) may be delivered at this
+    // resume, per the target's handle_interrupt mask. The park kind
+    // (blocking vs Thread.pass) was recorded at park time.
+    let deliverable = match pending_timing(&globals.store, thread) {
+        None => false,
+        Some(InterruptTiming::Immediate) => true,
+        Some(InterruptTiming::OnBlocking) => thread.as_thread_inner().park_blocking,
+        Some(InterruptTiming::Never) => false,
+    };
     let entry = SCHEDULER.with(|s| {
         let mut s = s.borrow_mut();
         s.current = Some(thread);
         let inner = thread.as_thread_inner_mut();
-        let pending = inner.pending.take();
         if inner.state() == ThreadState::Created {
+            let pending = inner.pending.take();
             match pending {
                 Some(PendingInterrupt::Kill) => return Entry::Skip(None),
                 Some(PendingInterrupt::Raise(err)) => return Entry::Skip(Some(err)),
@@ -759,7 +885,13 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
         } else {
             inner.state = ThreadState::Runnable;
             let exec = inner.resume_exec.take().unwrap().as_ptr();
-            match pending {
+            if !deliverable {
+                // A masked pending interrupt stays queued; resume the
+                // thread normally (it re-parks or delivers later at an
+                // allowed point).
+                return Entry::Resume(exec);
+            }
+            match inner.pending.take() {
                 None => Entry::Resume(exec),
                 Some(int) => {
                     let err = match int {

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -13,6 +13,19 @@ pub(crate) enum PendingInterrupt {
     Raise(MonorubyErr),
 }
 
+/// `Thread.handle_interrupt` timing for one mask entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InterruptTiming {
+    /// Deliver as soon as a delivery point is reached (the default).
+    Immediate,
+    /// Deliver only at blocking operations (parks) — `Thread.pass` and
+    /// `handle_interrupt` boundaries do not count.
+    OnBlocking,
+    /// Defer while the mask is in effect; the `handle_interrupt` block
+    /// exit is the delivery point.
+    Never,
+}
+
 /// Green-thread control block.
 ///
 /// monoruby threads are cooperative green threads multiplexed on the one
@@ -52,6 +65,14 @@ pub struct ThreadInner {
     /// Set when a kill was delivered: the terminating `Throw` unwind is
     /// then a clean death, not an exception (see scheduler finalize).
     pub(crate) killed: bool,
+    /// `Thread.handle_interrupt` mask stack (innermost last). Each frame
+    /// is the `{Class => timing}` pairs of one handle_interrupt block.
+    pub(crate) masks: Vec<Vec<(Value, InterruptTiming)>>,
+    /// Whether the thread's current/last park was a *blocking* operation
+    /// (sleep / join / fd wait / queue pop) as opposed to `Thread.pass`.
+    /// Consulted when delivering a pending interrupt masked
+    /// `:on_blocking`.
+    pub(crate) park_blocking: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,6 +131,11 @@ impl alloc::GC<RValue> for ThreadInner {
         if let Some(PendingInterrupt::Raise(err)) = &self.pending {
             err.mark(alloc);
         }
+        for frame in &self.masks {
+            for (class, _) in frame {
+                class.mark(alloc);
+            }
+        }
     }
 }
 
@@ -128,6 +154,8 @@ impl ThreadInner {
             joiners: vec![],
             pending: None,
             killed: false,
+            masks: vec![],
+            park_blocking: false,
         }
     }
 
@@ -146,6 +174,8 @@ impl ThreadInner {
             joiners: vec![],
             pending: None,
             killed: false,
+            masks: vec![],
+            park_blocking: false,
         }
     }
 
@@ -165,6 +195,8 @@ impl ThreadInner {
             joiners: vec![],
             pending: None,
             killed: false,
+            masks: vec![],
+            park_blocking: false,
         }
     }
 


### PR DESCRIPTION
PR5 of the green-thread series (follows #941–#944). Adds asynchronous-interrupt **masking** on top of #943's delivery queue — the mechanism that lets code protect critical sections (resource acquisition, ensure bodies) from `Thread#raise`/Ctrl-C tearing them apart, used by `Timeout` and Bundler's connection_pool.

## Semantics implemented

`Thread.handle_interrupt(Class => timing) { ... }` with the three timings:

- **`:immediate`** — deliver at any delivery point (the default behavior).
- **`:on_blocking`** — deliver only at real blocking operations. Notably, **`Thread.pass` is not a blocking call**: an `:on_blocking` block that only spins with `Thread.pass` defers to block exit (this exact distinction is asserted by ruby/spec, and is implemented via a `park_blocking` flag recorded at park time).
- **`:never`** — defer entirely; a parked target is not even woken by `Thread#raise`.

Masks nest (innermost wins) and match by class hierarchy. Kill is unmaskable. Delivery points: every park entry (sleep / join / fd wait — instead of parking), resume of a parked thread (mask re-checked at delivery time, since it may have changed), `Thread.pass` (`:immediate` only), and `handle_interrupt` entry/exit:

- **Entry**: un-masking with pending interrupts fires them before the block runs.
- **Exit**: interrupts the block's mask deferred fire under the outer mask — **even when the block itself raised, and the delivered interrupt takes precedence over the block's own exception** (CRuby semantics; missing this initially made the pending interrupt leak into subsequent code, caught by the spec's before-hook sanity check).

Plus `Thread.pending_interrupt?` / `Thread#pending_interrupt?` with the optional hierarchy-matched class filter, and mask-hash validation (`ArgumentError: unknown mask signature` / `TypeError` on non-class keys).

## Verification

- Differential vs CRuby 4.0.2 — identical on all five masking scenarios (never-defer, on_blocking at a real block, on_blocking deferring across `Thread.pass` spins, immediate, entry-delivery + `pending_interrupt?` transitions).
- ruby/spec: **`core/thread/handle_interrupt_spec.rb` + `pending_interrupt_spec.rb` pass completely (10 examples, 0F 0E)**.
- core/thread whole category: **83 pass** (was 66 after #943; category was 0-examples on master).
- `cargo test --lib`: **1886 + 86 + 116 passed, 0 failed** (2 new differential test groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_