### PR TITLE
Fix fd-waiter starvation and cross-thread &amp;block abort behind the core/thread stall (#950)

### DIFF
--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -866,6 +866,92 @@ mod tests {
     }
 
     #[test]
+    fn thread_fd_waiters_not_starved_by_busy_threads() {
+        // A busy thread that never blocks (only `Thread.pass`es) keeps the
+        // ready queue non-empty forever; fd-parked threads must still be
+        // woken when their fd becomes ready (issue #950: the scheduler
+        // only polled fds in its idle branch, live-locking this pattern).
+        run_test_once(
+            r#"
+            r, w = IO.pipe
+            stop = false
+            busy = Thread.new { Thread.pass until stop }
+            t = Thread.new { r.read(2) }
+            w.write "hi"
+            v = t.value
+            stop = true
+            busy.join
+            v
+            "#,
+        );
+        // Main spinning in `Thread.pass while …` never reaches the
+        // scheduler's idle branch either; fd waiters must be promoted
+        // from the pass path too.
+        run_test_once(
+            r#"
+            r, w = IO.pipe
+            t = Thread.new { r.read(2) }
+            feeder = Thread.new { w.write "ok" }
+            Thread.pass while t.alive?
+            feeder.join
+            t.value
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_block_param_of_cross_thread_frame() {
+        // Reading a `&block` parameter (lazily materialized by monoruby)
+        // from inside a green thread: the parameter's lexical home is a
+        // heap-promoted frame owned by the *main* thread's frame chain.
+        // Used to abort the whole process on `parent_fiber.unwrap()` while
+        // searching the green thread's own chain for it (issue #950).
+        run_test_once(
+            r#"
+            def go(&block)
+              t = Thread.new { block.call { :x } }
+              t.value
+            end
+            go { |&pause| pause.call }
+            "#,
+        );
+        // The ruby/spec kernel_raise pattern that surfaced it: Thread#raise
+        // into a thread parked via a block-provided pause, then join.
+        run_test_once(
+            r#"
+            class BlockRaiser
+              def self.raise_in_thread(*args, &block)
+                t = Thread.new do
+                  Thread.current.report_on_exception = false
+                  if block_given?
+                    block.call do
+                      sleep
+                    end
+                  else
+                    sleep
+                  end
+                end
+                Thread.pass until t.stop?
+                t.raise(*args)
+                begin
+                  t.join
+                ensure
+                  t.kill if t.alive?
+                  Thread.pass while t.alive?
+                end
+              end
+            end
+            begin; raise "raised"; rescue => e; end
+            begin
+              BlockRaiser.raise_in_thread(e) { |&pause| pause.call }
+            rescue => reraised
+            end
+            [reraised.class, reraised == e]
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_handle_interrupt_masking() {
         // Shared driver mirroring ruby/spec's handle_interrupt fixture:
         // raise into a thread inside a handle_interrupt block, observe

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -441,10 +441,37 @@ pub(super) extern "C" fn block_arg(
     if bh.get().is_nil() {
         return Some(Value::nil());
     }
-    let mut cfp = vm.cfp();
-    while cfp.lfp() != lfp {
-        cfp = Executor::prev_cfp(vm, cfp).1;
+    // Already-materialized Proc: return it directly, *without* locating
+    // the owner frame's Cfp. This is not just a shortcut: when the owner
+    // frame belongs to a different execution context — e.g. a `&block`
+    // parameter read from inside a green thread whose lexical home is a
+    // heap-promoted frame on the *main* thread's chain — the dynamic-chain
+    // search below can never find it (and walking past a thread root used
+    // to panic on `parent_fiber.unwrap()`, aborting the whole process; see
+    // issue #950). Cross-context handlers are always materialized when
+    // their frame escapes to the heap (`materialize_escaped_block_handlers`),
+    // so this early return covers exactly those cases.
+    if let Some(proc) = bh.try_proc() {
+        return Some(proc.into());
     }
+    // Proxy handler: its (fid, depth) is relative to the frame that owns
+    // it, so locate that frame's Cfp on the current chain (crossing into
+    // parent fibers). A proxy owner is always on the current chain — an
+    // escaped frame would have had its handler materialized above — but
+    // walk defensively rather than aborting the process on a violation.
+    let mut owner = (&*vm, vm.cfp());
+    while owner.1.lfp() != lfp {
+        match Executor::try_prev_cfp(owner.0, owner.1) {
+            Some(prev) => owner = prev,
+            None => {
+                vm.set_error(MonorubyErr::fatal(
+                    "[BUG] block handler owner frame is not on the current frame chain",
+                ));
+                return None;
+            }
+        }
+    }
+    let cfp = owner.1;
     match vm.generate_proc_inner(globals, cfp, bh, pc) {
         Ok(val) => Some(val.into()),
         Err(err) => {

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -194,7 +194,7 @@ impl Executor {
     /// Try to get the previous CFP, returning `None` if there is no previous
     /// frame and no parent fiber (i.e. the Proc's enclosing method has already
     /// returned — "detached context").
-    fn try_prev_cfp(vm: &Executor, cfp: Cfp) -> Option<(&Executor, Cfp)> {
+    pub(crate) fn try_prev_cfp(vm: &Executor, cfp: Cfp) -> Option<(&Executor, Cfp)> {
         match cfp.prev() {
             Some(prev) => Some((vm, prev)),
             None => {

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -301,18 +301,27 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             s.main_exec = Some(std::ptr::NonNull::from(&mut *vm));
             s.in_scheduler = true;
         });
-        let n = SCHEDULER.with(|s| s.borrow().ready.len());
-        let mut result = Ok(());
-        for _ in 0..n {
-            let t = SCHEDULER.with(|s| s.borrow_mut().ready.pop_front());
-            match t {
-                Some(t) => {
-                    if let Err(err) = dispatch(globals, t) {
-                        result = Err(err);
-                        break;
+        // Same fd-waiter promotion as `scheduler_loop`: a main thread
+        // spinning in `Thread.pass while …` never reaches the scheduler's
+        // idle branch, so fd-parked green threads would otherwise starve.
+        let mut result = if prune_io_waiters() {
+            poll_io_waiters(vm, globals, Some(Instant::now()))
+        } else {
+            Ok(())
+        };
+        if result.is_ok() {
+            let n = SCHEDULER.with(|s| s.borrow().ready.len());
+            for _ in 0..n {
+                let t = SCHEDULER.with(|s| s.borrow_mut().ready.pop_front());
+                match t {
+                    Some(t) => {
+                        if let Err(err) = dispatch(globals, t) {
+                            result = Err(err);
+                            break;
+                        }
                     }
+                    None => break,
                 }
-                None => break,
             }
         }
         SCHEDULER.with(|s| {
@@ -669,6 +678,16 @@ fn scheduler_run(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
 fn scheduler_loop(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
     loop {
         wake_due_sleepers();
+        // Promote fd-parked threads whose fd is already ready *before*
+        // picking the next runnable thread. Without this zero-timeout
+        // check, fd waiters are only polled in the idle branch below —
+        // and a busy thread that never blocks (e.g. `loop { Thread.pass }`)
+        // keeps the ready queue non-empty forever, starving every fd
+        // waiter (a live-lock: the busy thread spins, the fd waiter —
+        // possibly main — never wakes even though its fd is long ready).
+        if prune_io_waiters() {
+            poll_io_waiters(vm, globals, Some(Instant::now()))?;
+        }
         let (main_ready, next) = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
             let main_ready =
@@ -686,13 +705,7 @@ fn scheduler_loop(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
         // Nothing runnable: wait for fd readiness and/or the nearest
         // deadline. Only when no thread can ever become runnable again
         // (no sleeper, no fd waiter) is it a deadlock.
-        let has_io = SCHEDULER.with(|s| {
-            let mut s = s.borrow_mut();
-            // Prune stale entries (threads woken through another path).
-            s.io_waiters
-                .retain(|(_, _, t)| t.as_thread_inner().state() == ThreadState::IoWaiting);
-            !s.io_waiters.is_empty()
-        });
+        let has_io = prune_io_waiters();
         match (has_io, nearest_deadline()) {
             (true, deadline) => poll_io_waiters(vm, globals, deadline)?,
             (false, Some(deadline)) => interruptible_sleep_until(vm, globals, deadline)?,
@@ -703,6 +716,17 @@ fn scheduler_loop(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             }
         }
     }
+}
+
+/// Drop io_waiter entries whose thread was woken (or died) through
+/// another path; returns whether any fd waiter remains.
+fn prune_io_waiters() -> bool {
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.io_waiters
+            .retain(|(_, _, t)| t.as_thread_inner().state() == ThreadState::IoWaiting);
+        !s.io_waiters.is_empty()
+    })
 }
 
 fn wake_due_sleepers() {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -755,7 +755,19 @@ impl RValue {
 
 impl alloc::GC<RValue> for RValue {
     fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
-        assert!(self.header.is_live());
+        // A dead object reached from a root means a stale edge somewhere
+        // in the root set — abort like the old `assert!`, but dump the
+        // object header and the mark chain first so a rare failure in CI
+        // (see issue #950) identifies the offending root path.
+        if !self.header.is_live() {
+            eprintln!(
+                "DEAD RVALUE reached in mark: {:p} meta={:?}",
+                self as *const _,
+                unsafe { self.header.meta }
+            );
+            eprintln!("{}", std::backtrace::Backtrace::force_capture());
+            std::process::abort();
+        }
         if alloc.gc_check_and_mark(self) {
             return;
         }


### PR DESCRIPTION
## Summary

Investigating #950 turned up **two concrete green-thread bugs**, either of which stalls/aborts the full ruby/spec `core/thread` run. With both fixed, the suite runs to completion with **no aborts and no GC liveness assertions** (313 examples across 44 files; details below).

### 1. fd-waiter starvation live-lock (scheduler.rs)

The scheduler polled fd-parked threads **only in its idle branch**. Any thread that never blocks — e.g. a `loop { Thread.pass }` fixture thread leaked by an earlier spec — keeps the ready queue non-empty forever, so the idle branch is never reached and fd waiters are never woken even though their fd has long been ready. Observed live: the mspec runner's main thread parked in `IO#read` on a popen pipe whose child had already exited (zombie), while a leaked busy thread spun at 100% CPU with **zero syscalls**.

Fix: promote ready fd-waiters with a zero-timeout `poll(2)` at the top of every scheduler-loop iteration, and from the `Thread.pass` main path (a main thread spinning in `Thread.pass while …` never enters the scheduler's idle branch at all).

### 2. Cross-thread `&block` materialization aborts the process (runtime.rs)

`block_arg` located the frame owning a block handler by walking the **current** execution context's dynamic frame chain — *before* checking whether the handler is an already-materialized Proc. monoruby materializes `&block` parameters lazily, so reading one from inside a green thread whose lexical home frame is a heap-promoted frame owned by the **main** thread's chain walked past the green thread's root and hit `parent_fiber.unwrap()` → Rust panic → process abort at the `extern "C"` boundary. Deterministic three-line reproduction (matches ruby/spec's `kernel_raise` shared examples exercised via `Thread#raise`):

```ruby
def go(&block)
  t = Thread.new { block.call { :x } }
  t.value
end
go { |&pause| pause.call }   # aborted the process; now returns :x like CRuby
```

Fix: return an already-materialized Proc before any chain search — an escaped (heap-promoted) frame always has its handlers materialized (`materialize_escaped_block_handlers`), so the cross-context case is fully covered — and make the remaining proxy-handler search use the non-panicking `try_prev_cfp`, surfacing a `[BUG]` error instead of aborting on an invariant violation.

### Forensics for the original assert

The `assert!(self.header.is_live())` in `RValue::mark` did not re-fire in any of today's instrumented full-suite runs (it is timing-dependent and was likely a downstream casualty of the aborts/live-locks above). The assert is upgraded to dump the dead object's header and the full mark chain before aborting, so if it ever recurs in CI the offending GC root path is identified directly.

## Verification

- New differential regression tests: fd-waiter promotion under a busy thread (both scheduler-loop and `Thread.pass`-spin variants) and the cross-thread `&block` patterns (micro + the kernel_raise-style scenario). Both hang or abort without the fixes.
- Full suite: **1889 passed, 0 failed**.
- ruby/spec `core/thread` (44 files, `list_spec` excluded): runs to completion, 313 examples, 0 aborts, 0 GC asserts — previously the run aborted mid-way and then live-locked until killed. `list_spec`'s last example still spins by design: its `begin … end while spawner.alive?` loop contains no blocking call, which is the documented no-timeslice-preemption limitation (doc/threads.md §8-1), out of scope here.

Closes #950 (the two root causes found; the assert path now self-diagnoses if it ever recurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_