### PR TITLE
CI: auto-detect spec timeouts, bisect culprit examples, and PR tag updates

### DIFF
--- a/.github/scripts/bisect-spec-timeouts.sh
+++ b/.github/scripts/bisect-spec-timeouts.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Identify the culprit example(s) inside spec files that exceeded the
+# core monitor's per-file budget, and register them as `fails` tags.
+#
+# For each `category,file` row of the input timeouts.csv, every example
+# of the file is run individually under a hard deadline. An example is a
+# culprit when it either times out (a genuine hang: exit 124/137) or
+# takes longer than SLOW_SECS by itself (a near-budget burner like a
+# ~55s blocking wait — no single hang, but the file cannot fit the
+# budget with it). Culprits are appended (deduplicated) to the repo's
+# tag files, which both rubyspec-stats and the monitor exclude.
+#
+# A file with no individual culprit (purely cumulative slowness) is
+# reported as such and left untagged — that calls for a budget change,
+# not an exclusion.
+#
+# Usage:
+#   bisect-spec-timeouts.sh TIMEOUTS_CSV SPEC_DIR MSPEC RUBY_CMD TAGS_DIR OUT_CSV
+#
+#   TIMEOUTS_CSV  monitor output: "category,file" rows (with header)
+#   SPEC_DIR      ruby/spec checkout (file paths are relative to it)
+#   MSPEC         path to mspec launcher (bin/mspec)
+#   RUBY_CMD      the monoruby binary to test
+#   TAGS_DIR      tag tree root to update (e.g. <repo>/spec/tags)
+#   OUT_CSV       report written here: category,file,example,seconds,verdict
+
+set -uo pipefail
+
+TIMEOUTS_CSV=$1
+SPEC_DIR=$2
+MSPEC=$3
+RUBY_CMD=$4
+TAGS_DIR=$5
+OUT_CSV=$6
+
+# Per-example hard deadline (mirrors the monitor's per-file budget) and
+# the "too slow to share a file budget" threshold.
+EX_BUDGET=${EX_BUDGET:-60}
+SLOW_SECS=${SLOW_SECS:-30}
+# Wall-clock cap per file: a pathological file (every example hanging)
+# must not eat the whole job. Whatever was found so far is kept.
+FILE_CAP_SECS=${FILE_CAP_SECS:-900}
+
+echo "category,file,example,seconds,verdict" > "$OUT_CSV"
+
+# A pre-rendered markdown twin of OUT_CSV (descriptions may contain
+# commas, so consumers should not re-parse the CSV with naive splits).
+OUT_MD="${OUT_CSV%.csv}.md"
+{
+  echo "| Category | File | Example | Seconds | Verdict |"
+  echo "| --- | --- | --- | ---: | --- |"
+} > "$OUT_MD"
+
+record () {
+  # record CATEGORY FILE DESC SECONDS VERDICT
+  echo "$1,$2,\"$3\",$4,$5" >> "$OUT_CSV"
+  echo "| $1 | \`$2\` | $3 | $4 | $5 |" >> "$OUT_MD"
+}
+
+# Full example descriptions, one per line, via a dry run. specdoc prints
+# the full joined describe context as a header line and each example as
+# "- <it>"; a tag needs "<header> <it>". The dry run executes no example
+# bodies but does load the file, so it gets a deadline too.
+list_examples () {
+  local file=$1
+  timeout -k 5 60 "$MSPEC" run --dry-run -f s "$file" -t "$RUBY_CMD" 2>/dev/null \
+    | awk '
+        /^- /            { if (ctx != "") print ctx " " substr($0, 3); next }
+        /^[[:space:]]*$/ { next }
+                         { ctx = $0 }
+      '
+}
+
+n_tagged=0
+
+while IFS=, read -r cat file; do
+  [ "$cat" = "category" ] && continue
+  [ -z "${file:-}" ] && continue
+
+  echo "== bisecting $file"
+  examples=$(cd "$SPEC_DIR" && list_examples "$file")
+  if [ -z "$examples" ]; then
+    record "$cat" "$file" "" 0 dry-run-failed
+    echo "   dry run produced no examples (file-level hang?) — needs manual attention"
+    continue
+  fi
+
+  # spec/tags/<category-path>/<name>_tags.txt, mirroring mspec's
+  # default tags_patterns derivation.
+  tagfile="$TAGS_DIR/$(dirname "$file")/$(basename "$file" _spec.rb)_tags.txt"
+
+  file_start=$SECONDS
+  found_any=0
+  while IFS= read -r desc; do
+    [ -z "$desc" ] && continue
+    if [ $((SECONDS - file_start)) -ge "$FILE_CAP_SECS" ]; then
+      record "$cat" "$file" "" $((SECONDS - file_start)) file-cap-reached
+      echo "   per-file bisect cap reached; remaining examples unchecked"
+      break
+    fi
+    ex_start=$SECONDS
+    (cd "$SPEC_DIR" && timeout -k 5 "$EX_BUDGET" \
+      "$MSPEC" run "$file" -e "$desc" -t "$RUBY_CMD" > /dev/null 2>&1)
+    rc=$?
+    dur=$((SECONDS - ex_start))
+    verdict=""
+    if [ $rc -eq 124 ] || [ $rc -eq 137 ]; then
+      verdict="hang"
+    elif [ "$dur" -ge "$SLOW_SECS" ]; then
+      verdict="slow"
+    fi
+    if [ -n "$verdict" ]; then
+      found_any=1
+      record "$cat" "$file" "$desc" "$dur" "$verdict"
+      echo "   $verdict (${dur}s): $desc"
+      mkdir -p "$(dirname "$tagfile")"
+      if ! grep -qxF "fails:$desc" "$tagfile" 2>/dev/null; then
+        echo "fails:$desc" >> "$tagfile"
+        n_tagged=$((n_tagged + 1))
+      fi
+    fi
+  done <<< "$examples"
+
+  if [ "$found_any" -eq 0 ]; then
+    record "$cat" "$file" "" $((SECONDS - file_start)) cumulative-only
+    echo "   no individual culprit — cumulative slowness; not tagged"
+  fi
+done < "$TIMEOUTS_CSV"
+
+echo "new tags added: $n_tagged"
+echo "n_tagged=$n_tagged" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/.github/workflows/spec-core.yml
+++ b/.github/workflows/spec-core.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   core-specs:
@@ -46,6 +47,17 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/ruby/spec.git ../spec
           git clone --depth 1 https://github.com/ruby/mspec.git ../mspec
+
+      - name: Install spec tags
+        # mspec derives each spec's tag file as <spec-root>/tags/<path>,
+        # so the repo's tags (hanging / over-budget examples, see
+        # doc/ruby_spec_skip_tags.md) are copied into the checkout and
+        # excluded from the runs below via --excl-tag fails. Without
+        # this, every already-known hanging example re-times-out on
+        # every monitor run.
+        run: |
+          mkdir -p ../spec/tags
+          [ -d spec/tags ] && cp -R spec/tags/. ../spec/tags/ || true
 
       - name: Run core specs per subcategory
         id: run
@@ -95,7 +107,7 @@ jobs:
           # single hung spec stalls the whole job until timeout-minutes.
           # Exit 124 = killed by TERM, 137 = needed the KILL.
           run_specs () {
-            timeout -k 5 60 ../mspec/bin/mspec "$@" -t monoruby -f s >> "$LOG" 2>&1
+            timeout -k 5 60 ../mspec/bin/mspec "$@" --excl-tag fails -t monoruby -f s >> "$LOG" 2>&1
             local rc=$?
             [ $rc -eq 124 ] || [ $rc -eq 137 ]
           }
@@ -184,6 +196,74 @@ jobs:
             echo "total_err=$T_ERR"
             echo "total_rate=$T_RATE"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Identify timed-out examples and update tags
+        id: bisect
+        shell: bash
+        run: |
+          set -uo pipefail
+          TIMEOUTS="$GITHUB_WORKSPACE/spec-results/timeouts.csv"
+          OUTCSV="$GITHUB_WORKSPACE/spec-results/timeout_culprits.csv"
+          N=$(($(wc -l < "$TIMEOUTS") - 1))
+          if [ "$N" -le 0 ]; then
+            echo "no timed-out files — nothing to bisect"
+            echo "n_tagged=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          .github/scripts/bisect-spec-timeouts.sh \
+            "$TIMEOUTS" \
+            "$(cd "$GITHUB_WORKSPACE/../spec" && pwd)" \
+            "$(cd "$GITHUB_WORKSPACE/../mspec" && pwd)/bin/mspec" \
+            monoruby \
+            "$GITHUB_WORKSPACE/spec/tags" \
+            "$OUTCSV"
+          {
+            echo ""
+            echo "### Timeout bisection"
+            echo ""
+            cat "${OUTCSV%.csv}.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open a PR for the new tags
+        if: steps.bisect.outputs.n_tagged != '' && steps.bisect.outputs.n_tagged != '0' && (github.event_name == 'schedule' || github.ref == 'refs/heads/master')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          BRANCH=auto/spec-timeout-tags
+          # A fixed branch keeps this idempotent: reruns before the PR
+          # merges regenerate the same tag set and force-push it, updating
+          # the existing PR instead of stacking new ones.
+          git checkout -B "$BRANCH"
+          git add spec/tags
+          git commit -m "spec: auto-tag hanging / over-budget examples
+
+          Added by the core monitor's timeout bisection
+          (.github/scripts/bisect-spec-timeouts.sh) for run
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+          for i in 1 2 3 4; do
+            git push -f -u origin "$BRANCH" && break
+            sleep $((2 ** i))
+          done
+
+          BODY_FILE="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "The core monitor detected spec files exceeding the 60s per-file budget and bisected them example-by-example ([run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}))."
+            echo ""
+            cat "$GITHUB_WORKSPACE/spec-results/timeout_culprits.md"
+            echo ""
+            echo "- \`hang\`: the example alone hit the ${EX_BUDGET:-60}s deadline (exit 124/137)."
+            echo "- \`slow\`: the example alone took ≥ ${SLOW_SECS:-30}s — it cannot share a 60s file budget."
+            echo "- \`cumulative-only\` rows (if any) were **not** tagged: no single culprit; the file needs a budget review instead."
+            echo ""
+            echo "Please review whether each culprit reflects a known limitation (see doc/ruby_spec_skip_tags.md) or a regression to fix instead of tagging."
+          } > "$BODY_FILE"
+          gh pr create --base master --head "$BRANCH" \
+            --title "spec: auto-tag hanging / over-budget examples (monitor bisection)" \
+            --body-file "$BODY_FILE" \
+            || gh pr edit "$BRANCH" --body-file "$BODY_FILE"
 
       - name: Upload results
         if: always()

--- a/doc/ruby_spec_skip_tags.md
+++ b/doc/ruby_spec_skip_tags.md
@@ -277,3 +277,32 @@ example 単位で切り分け、各ファイルとも**犯人1例**を `fails` t
   約 55 秒（内部期待のタイムアウトまで）ブロックし、単独でファイル予算を
   ほぼ使い切る。`flock(2)` の LOCK_NB + リトライによるスケジューラ統合で
   解除できる。
+
+## タイムアウトの自動検知・自動タグ付け（spec-core モニタ）
+
+上記のような「グリーンスレッド化で新たにハングする example」を手作業で
+切り分ける運用を自動化した。仕組み（`.github/workflows/spec-core.yml` +
+`.github/scripts/bisect-spec-timeouts.sh`）:
+
+1. **モニタ自身が tags を適用**: リポジトリの `spec/tags/` を ruby/spec
+   チェックアウトへコピーし、全ラン `--excl-tag fails` で実行する。
+   タグ済みのハング example が毎回 60 秒予算を食い潰すのを防ぐ
+   （統計上は tagged として除外カウントされる）。
+2. **検知**: 従来どおり、ファイル単位 `timeout -k 5 60` で完走しなかった
+   ファイルが `timeouts.csv` に記録される。
+3. **同定**: `bisect-spec-timeouts.sh` が各タイムアウトファイルの example
+   一覧を `mspec --dry-run -f s` で取得し（describe の連結 = tag 名）、
+   1 example ずつ `timeout -k 5 60` 付きで個別実行。
+   - exit 124/137 → `hang`（真のハング）
+   - 単独で 30 秒以上 → `slow`（単独で予算を圧迫する近予算バーナー）
+   - どちらも該当なし → `cumulative-only`（合算超過。タグ付けせず
+     予算見直し対象として報告のみ）
+   - 病的ケース対策: dry-run にも 60 秒、1 ファイルの bisect に
+     900 秒の上限。
+4. **タグ更新と PR**: 見つかった culprit を `spec/tags/<cat>/<file>_tags.txt`
+   へ重複排除で追記し、差分があれば固定ブランチ `auto/spec-timeout-tags`
+   に commit して PR を自動作成する（既存 PR があれば force-push +
+   body 更新で同じ PR が更新される＝冪等）。**マージは人間が判断する**:
+   tag が妥当（既知の制限）か、退行として修正すべきかのレビューを挟む。
+   結果テーブルはラン summary・PR body・artifact
+   （`timeout_culprits.{csv,md}`）に出力される。


### PR DESCRIPTION
## Summary

Closes the loop on hanging specs: the core monitor now detects per-file timeouts, **identifies the culprit example automatically**, and opens a PR updating `spec/tags/` — the manual bisection done for #954 becomes a CI mechanism.

### 1. The monitor applies the repo tags (`spec-core.yml`)

`spec/tags/` is copied into the ruby/spec checkout and every run uses `--excl-tag fails`. Without this, already-tagged hanging examples burn the 60s per-file budget on every run and re-appear in `timeouts.csv` forever. (Tagged examples now show up as `tagged` in mspec summaries and are excluded from the tallies.)

### 2. Timeout bisection (`.github/scripts/bisect-spec-timeouts.sh`)

For each `timeouts.csv` row, the script:

- lists the file's examples via `mspec --dry-run -f s` — the specdoc header (joined describe context) + it-text is exactly the full example name a tag needs, so shared/nested describes are handled correctly;
- runs **every example individually** under `timeout -k 5 60`:
  - exit 124/137 → `hang` (a genuine hang),
  - ≥ 30s alone → `slow` (a near-budget burner that cannot share a 60s file budget — the `file/flock` pattern),
  - neither → the file is reported `cumulative-only` and left **untagged** (that calls for a budget review, not an exclusion);
- appends culprits to `spec/tags/<cat>/<file>_tags.txt` with dedup.

Pathological cases are bounded: the dry-run gets its own 60s deadline (file-level hang → `dry-run-failed`, flagged for manual attention) and each file's bisect is capped at 900s.

### 3. Automatic PR

If any tag was added, the workflow commits to the fixed branch `auto/spec-timeout-tags` and creates a PR (or force-updates the existing one — idempotent across reruns). **Merging stays a human decision**: a new hang may be a regression to fix rather than a limitation to tag. The culprit table is published in the run summary, the PR body, and the artifacts (`timeout_culprits.{csv,md}`).

`doc/ruby_spec_skip_tags.md` documents the mechanism.

## Verification

- End-to-end test against the five real timeout files from #954: the script identified **exactly the same five culprit examples** as the manual bisection, generating tag lines byte-identical to the ones merged in #954 (`new tags added: 5`), in ~7 minutes total. Dedup verified (running against the repo's existing tags adds 0).
- `mspec ci` / `--excl-tag fails` exclusion of these tags was already verified in #954 (all five files complete in seconds with `1 tagged` each).
- Workflow YAML validated; the bisect script passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_