### PR TITLE
Forward SystemExit / abort_on_exception thread deaths to the main thread

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -789,6 +789,28 @@ class Thread
     @report_on_exception = flag
   end
 
+  # When set (per-thread, or the Thread global default), an exception
+  # that terminates this thread is re-raised in the main thread (read by
+  # the native finalizer, which also suppresses the report in that case,
+  # as in CRuby). Default false.
+  def abort_on_exception
+    @abort_on_exception.nil? ? false : @abort_on_exception
+  end
+
+  def abort_on_exception=(flag)
+    @abort_on_exception = flag
+  end
+
+  class << self
+    def abort_on_exception
+      @abort_on_exception.nil? ? false : @abort_on_exception
+    end
+
+    def abort_on_exception=(flag)
+      @abort_on_exception = flag
+    end
+  end
+
   # Thread objects are native (ObjTy::THREAD) and no longer run a Ruby
   # initialize, so the local-storage tables are created lazily.
   def [](key)

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -866,6 +866,68 @@ mod tests {
     }
 
     #[test]
+    fn thread_exception_forwarding_to_main() {
+        // SystemExit escaping a thread is re-raised in the main thread
+        // (CRuby: `exit` from a thread terminates the process through
+        // main). Previously main slept forever and the scheduler's
+        // deadlock detector aborted with an uncatchable FatalError —
+        // which killed entire mspec runs at core/kernel/exit_spec.rb.
+        run_test_once(
+            r#"
+            r = []
+            ready = false
+            t = Thread.new {
+              Thread.pass until ready
+              begin
+                exit 42
+              rescue SystemExit => e
+                r << :in_thread
+                raise e
+              end
+            }
+            begin
+              ready = true
+              sleep
+            rescue SystemExit
+              r << :in_main
+            end
+            r << (begin; t.value; rescue SystemExit; :value_raises; end)
+            r
+            "#,
+        );
+        // Thread#abort_on_exception: the terminating exception is
+        // forwarded to main (net-http's spec fixture server threads set
+        // this; the method was missing entirely).
+        run_test_once(
+            r#"
+            t = Thread.new { Thread.current.abort_on_exception = true; sleep 0.02; raise "boom" }
+            v = begin
+              sleep
+            rescue => e
+              e.message
+            end
+            t.join rescue nil
+            [v, t.abort_on_exception]
+            "#,
+        );
+        // Thread.abort_on_exception (the global default) does the same.
+        run_test_once(
+            r#"
+            Thread.abort_on_exception = true
+            t = Thread.new { sleep 0.02; raise ArgumentError, "global" }
+            v = begin
+              sleep
+            rescue ArgumentError => e
+              e.message
+            end
+            Thread.abort_on_exception = false
+            t.join rescue nil
+            [v, Thread.abort_on_exception]
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_fd_waiters_not_starved_by_busy_threads() {
         // A busy thread that never blocks (only `Thread.pass`es) keeps the
         // ready queue non-empty forever; fd-parked threads must still be

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -1045,10 +1045,27 @@ fn finalize_common(globals: &mut Globals, mut thread: Value) {
         }
         s.threads.retain(|t| *t != thread);
     });
+    // A `SystemExit` that escapes any thread terminates the process: CRuby
+    // re-raises it in the main thread (`Kernel#exit` from a thread exits
+    // the interpreter once main handles it). The same forwarding applies
+    // to *any* terminating exception when the thread — or the `Thread`
+    // global default — has `abort_on_exception` set. The exception stays
+    // recorded on the dead thread too (`#join` / `#value` re-raise it).
+    forward_exception_to_main(globals, thread);
     // `Thread#report_on_exception` (default true): surface a terminating
     // exception on stderr (CRuby prints it when the thread dies). An
     // explicit `t.report_on_exception = false` (ivar set by the Ruby-side
-    // accessor) suppresses it; a kill never reports.
+    // accessor) suppresses it; a kill never reports, and neither does a
+    // `SystemExit` (CRuby reports an abort_on_exception forwarding, but
+    // never a SystemExit — that is the process exiting, not a crash).
+    if thread
+        .as_thread_inner()
+        .exception
+        .as_ref()
+        .is_some_and(|err| matches!(err.kind(), MonorubyErrKind::SystemExit(_)))
+    {
+        return;
+    }
     let report = globals
         .store
         .get_ivar(thread, IdentId::get_id("@report_on_exception"))
@@ -1068,4 +1085,51 @@ fn finalize_common(globals: &mut Globals, mut thread: Value) {
         eprintln!("warning: thread terminated with exception (report_on_exception is true):");
         eprintln!("{msg}");
     }
+}
+
+/// Queue a dead thread's terminating exception as a pending interrupt on
+/// the main thread (waking it if parked) when CRuby semantics call for
+/// it: always for `SystemExit`, and for any exception when the thread or
+/// the `Thread` global default has `abort_on_exception` set.
+fn forward_exception_to_main(globals: &mut Globals, thread: Value) -> bool {
+    let Some(err) = ({
+        let inner = thread.as_thread_inner();
+        inner.exception.clone()
+    }) else {
+        return false;
+    };
+    let forward = matches!(err.kind(), MonorubyErrKind::SystemExit(_)) || {
+        let ivar = IdentId::get_id("@abort_on_exception");
+        let per_thread = globals
+            .store
+            .get_ivar(thread, ivar)
+            .map(|v| v.as_bool())
+            .unwrap_or(false);
+        let global_default = globals
+            .store
+            .get_ivar(globals.store.get_module(THREAD_CLASS).as_val(), ivar)
+            .map(|v| v.as_bool())
+            .unwrap_or(false);
+        per_thread || global_default
+    };
+    if !forward {
+        return false;
+    }
+    let Some(mut main) = SCHEDULER.with(|s| s.borrow().main) else {
+        return false;
+    };
+    if main == thread {
+        return false;
+    }
+    main.as_thread_inner_mut().pending = Some(PendingInterrupt::Raise(err));
+    // Wake a parked main so delivery happens promptly (mirrors
+    // `interrupt`); delivery itself still honors handle_interrupt masks.
+    let inner = main.as_thread_inner_mut();
+    if matches!(
+        inner.state(),
+        ThreadState::Sleeping | ThreadState::Joining | ThreadState::IoWaiting
+    ) {
+        inner.state = ThreadState::Runnable;
+    }
+    true
 }


### PR DESCRIPTION
## Summary

Fixes the **core = 0%** regression in rubyspec-stats ([run 29558787899](https://github.com/sisshiki1969/rubyspec-stats/actions/runs/29558787899)), plus the missing method behind the wall of library errors. Two CRuby-semantics gaps exposed by green threads:

### 1. `SystemExit` escaping a thread must be re-raised in the main thread

`Kernel#exit` from a thread terminates the process *through main* in CRuby. monoruby recorded the SystemExit on the dead thread only, so in `core/kernel/exit_spec.rb` ("raises the SystemExit in the main thread…") main slept forever, the scheduler's deadlock detector fired its **uncatchable FatalError**, and the whole `mspec-ci` runner died mid-suite:

```
exit (SystemExit)
spec/ruby/shared/process/exit.rb:70: No live threads left. Deadlock? (FatalError)
  … from spec/ruby/core/kernel/exit_spec.rb:5 … mspec-ci:7
```

→ `core.yml` came out empty (`--- {}`, 0%), where the previous run had 22611 examples (~88% pass).

### 2. `Thread#abort_on_exception` / `Thread.abort_on_exception` didn't exist

net-http's spec fixture server threads execute `Thread.current.abort_on_exception = true` as their first statement, so every server thread died instantly with NoMethodError (the wall of `undefined method 'abort_on_exception='` warnings in the library run). Implemented as startup.rb accessors (mirroring `report_on_exception`) plus real abort semantics via the same forwarding path. (Note: library's ~3654 errors largely **predate** green threads — remaining net-http errors come from pre-existing socket gaps like `TCPServer#addr` — so this removes the new noise but is not a full library fix.)

### Implementation

One new hook in thread finalization (`forward_exception_to_main`): when a dead thread's terminating exception is a `SystemExit` (always) or the thread/global `abort_on_exception` flag is set, the exception is queued as a pending `Raise` on the main thread and main is woken if parked. Delivery goes through the normal pending-interrupt path, so `handle_interrupt` masks are honored; the exception also stays recorded on the dead thread (`#join`/`#value` re-raise it, as the spec asserts); the `report_on_exception` warning is suppressed only for `SystemExit` (CRuby reports abort_on_exception forwardings but never SystemExit).

## Verification

- `core/kernel/exit_spec.rb` + `core/process/exit_spec.rb`: 32 examples, 6F, **0 errors** — previously the FatalError abort killed the runner.
- A full `mspec ci core` run proceeds past the old crash point (in progress locally at time of writing; the crash reproduced deterministically before).
- 3 new differential tests (SystemExit forwarding incl. `t.value` re-raise; instance and global `abort_on_exception`) — stdout matches CRuby exactly.
- Full suite: **1890 passed, 0 failed**.

## Note for rubyspec-stats

Restoring core stats also needs a budget bump on the rubyspec-stats side: with real green threads, thread/mutex/queue specs now actually sleep, so `core` no longer fits the `timeout 90` category budget there (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_