### PR TITLE
Fiber.new(blocking: false) raises NotImplementedError

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -733,6 +733,7 @@ class Fiber
     @@scheduler = scheduler
   end
 
+
   def self.current_scheduler
     # CRuby: nil when the current fiber is blocking. monoruby fibers
     # are always blocking, so this is always nil.

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -39,6 +39,23 @@ fn fiber_new(
     pc: BytecodePtr,
 ) -> Result<Value> {
     let bh = lfp.expect_block()?;
+    // CRuby's `Fiber.new` keywords (`blocking:`, `storage:`) arrive as a
+    // trailing hash. monoruby has no fiber scheduler, so an explicitly
+    // requested non-blocking fiber would silently act as a blocking one —
+    // `sleep` inside it then parks the whole thread forever, and under
+    // mspec that ends in the scheduler's uncatchable deadlock FatalError,
+    // killing the entire run (core/kernel/sleep_spec.rb). Fail loudly so
+    // fiber-scheduler specs count as ordinary errors instead.
+    if let Some(arg) = lfp.try_arg(0)
+        && let Some(h) = arg.try_hash_ty()
+        && let Some(v) = h.get(Value::symbol(IdentId::get_id("blocking")), vm, globals)?
+        && !v.as_bool()
+    {
+        return Err(MonorubyErr::not_implemented_err(
+            &globals.store,
+            "monoruby does not support non-blocking fibers (fiber scheduler)",
+        ));
+    }
     let proc = vm.generate_proc(globals, bh, pc)?;
     Ok(Value::new_fiber(proc))
 }
@@ -294,6 +311,29 @@ mod tests {
     /// `set_scheduler` validates the scheduler interface
     /// (`#block`, `#kernel_sleep`, …), which monoruby's stub does
     /// not enforce. Interface validation is intentional follow-up.
+    /// Explicitly requesting a non-blocking fiber (the fiber-scheduler
+    /// protocol) raises NotImplementedError instead of silently creating
+    /// a blocking fiber whose `sleep` would park the thread forever.
+    /// Intentional CRuby divergence (CRuby accepts it), so no
+    /// differential comparison here.
+    #[test]
+    fn fiber_new_nonblocking_not_implemented() {
+        let v = run_test_no_result_check(
+            r##"
+            r = begin
+              Fiber.new(blocking: false) { }
+              :accepted
+            rescue NotImplementedError
+              :not_implemented
+            end
+            # blocking: true and plain Fiber.new keep working.
+            f = Fiber.new(blocking: true) { :ok }
+            [r, f.resume]
+            "##,
+        );
+        assert!(format!("{v:?}").contains("[:not_implemented, :ok]"));
+    }
+
     #[test]
     fn fiber_scheduler_blocking() {
         run_test_once(

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -1082,6 +1082,17 @@ impl MonorubyErr {
     /// back to a plain `IOError` if the class can't be resolved.
     /// `ThreadError` (defined in Ruby in startup.rb). Falls back to a
     /// plain `RuntimeError` if the class can't be resolved.
+    pub(crate) fn not_implemented_err(store: &Store, msg: impl ToString) -> MonorubyErr {
+        let cid = store
+            .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("NotImplementedError"))
+            .and_then(|v| v.is_class_or_module())
+            .map(|m| m.id());
+        match cid {
+            Some(cid) => MonorubyErr::new(MonorubyErrKind::Other(cid), msg.to_string()),
+            None => MonorubyErr::new(MonorubyErrKind::Runtime, msg.to_string()),
+        }
+    }
+
     pub(crate) fn threaderr(store: &Store, msg: impl ToString) -> MonorubyErr {
         let cid = store
             .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ThreadError"))


### PR DESCRIPTION
## Summary

The second whole-runner killer in the rubyspec-stats core category (after the `exit_spec` one fixed in #956): `core/kernel/sleep_spec.rb`'s fiber-scheduler examples create `Fiber.new(blocking: false)` fibers and `sleep` inside them. monoruby has no fiber scheduler, so the fiber silently acts as a blocking one — the `sleep` parks the whole thread forever, the scheduler's deadlock detector fires its **uncatchable FatalError**, and the entire `mspec-ci` run dies:

```
core/kernel/sleep_spec.rb:92: No live threads left. Deadlock? (FatalError)
  … from mspec-ci:7
```

Fix: reject an explicitly requested non-blocking fiber loudly in the native `fiber_new` (CRuby's keywords arrive as a trailing hash) with `NotImplementedError: monoruby does not support non-blocking fibers (fiber scheduler)`. Fiber-scheduler specs then count as ordinary errors instead of aborting the suite. `blocking: true` and plain `Fiber.new` are unchanged. This is an intentional, documented CRuby divergence (CRuby accepts it), asserted by a non-differential test.

Also adds the `MonorubyErr::not_implemented_err` helper (resolves `NotImplementedError` like `threaderr` does).

**Note**: a first attempt implemented the guard as a startup.rb wrapper around `Fiber.new`; that exposed what looks like a separate JIT miscompile — `&block` forwarding through an aliased native class method made `fiber_closure` return nil after JIT warm-up. The guard therefore lives natively; the JIT issue is worth its own investigation.

## Verification

- `core/kernel/sleep_spec.rb`: completes with 15 examples / 3 errors (the fiber-scheduler ones) — previously aborted the whole run.
- Fiber tests: 12 passed (including the new guard test); full suite: **1891 passed, 0 failed**.

## Remaining core blocker

With #956 + this + the rubyspec-stats budget bump (sisshiki1969/rubyspec-stats#26), the last known core killer is a **nondeterministic GC use-after-free** (`Array#all?` on an `INVALID(68)` RValue inside mspec's `ContextState#protect`, reproduced locally twice at ~65–83s into a full-core release run) — the original issue #950 signature. Under investigation next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_