### PR TITLE
Detect fast-crash examples in bisect-spec-timeouts.sh

### DIFF
--- a/.github/scripts/bisect-spec-timeouts.sh
+++ b/.github/scripts/bisect-spec-timeouts.sh
@@ -4,11 +4,14 @@
 #
 # For each `category,file` row of the input timeouts.csv, every example
 # of the file is run individually under a hard deadline. An example is a
-# culprit when it either times out (a genuine hang: exit 124/137) or
-# takes longer than SLOW_SECS by itself (a near-budget burner like a
-# ~55s blocking wait — no single hang, but the file cannot fit the
-# budget with it). Culprits are appended (deduplicated) to the repo's
-# tag files, which both rubyspec-stats and the monitor exclude.
+# culprit when it either times out (a genuine hang: exit 124/137),
+# crashes the interpreter fast (Ruby-level FatalError such as the
+# deadlock detector, native SIGSEGV/SIGABRT, or a Rust panic — spotted
+# by scanning the example's own stderr), or takes longer than SLOW_SECS
+# by itself (a near-budget burner like a ~55s blocking wait — no single
+# hang, but the file cannot fit the budget with it). Culprits are
+# appended (deduplicated) to the repo's tag files, which both
+# rubyspec-stats and the monitor exclude.
 #
 # A file with no individual culprit (purely cumulative slowness) is
 # reported as such and left untagged — that calls for a budget change,
@@ -99,13 +102,17 @@ while IFS=, read -r cat file; do
       break
     fi
     ex_start=$SECONDS
-    (cd "$SPEC_DIR" && timeout -k 5 "$EX_BUDGET" \
-      "$MSPEC" run "$file" -e "$desc" -t "$RUBY_CMD" > /dev/null 2>&1)
+    out=$(cd "$SPEC_DIR" && timeout -k 5 "$EX_BUDGET" \
+      "$MSPEC" run "$file" -e "$desc" -t "$RUBY_CMD" 2>&1)
     rc=$?
     dur=$((SECONDS - ex_start))
     verdict=""
     if [ $rc -eq 124 ] || [ $rc -eq 137 ]; then
       verdict="hang"
+    elif printf '%s' "$out" | grep -qE 'FatalError|Segmentation fault|Aborted|panicked at'; then
+      # Ruby-level fatal (Deadlock detector), native crash, or Rust panic —
+      # the process died fast, before mspec could record a normal failure.
+      verdict="crash"
     elif [ "$dur" -ge "$SLOW_SECS" ]; then
       verdict="slow"
     fi


### PR DESCRIPTION
## Summary

The bisecter previously only tagged an example if `timeout -k 5 60` killed it (exit 124/137) or the wall clock exceeded `SLOW_SECS`. Ruby-level fatal errors that abort the process fast — most notably monoruby's own deadlock detector on specs like `core/kernel/exit_spec.rb`, but also segfaults / aborts / Rust panics — exit with an ordinary non-zero code and finish well under `SLOW_SECS`, so no culprit was recorded and the file kept blowing up in rubyspec-stats.

Capture the example's stderr (previously discarded) and treat a match for `FatalError` / `Segmentation fault` / `Aborted` / `panicked at` as a `crash` verdict — same tagging path as `hang` / `slow`.

## Trigger case

`spec/ruby/core/kernel/exit_spec.rb` → shared `it "raises the SystemExit in the main thread ..."` at `shared/process/exit.rb:70` spawns a Thread + main-thread `sleep`. In monoruby's cooperative single-OS-thread model the main thread can never yield, so the deadlock detector fires within milliseconds: `No live threads left. Deadlock? (FatalError)` — process dies with exit 1, ~<1s wall time, previously undetected. In rubyspec-stats this crashes mspec-ci mid-run, leaves `stats.yml` empty, and the site's monoruby column shows 0/22649 for core.

## Test plan

- [ ] Rerun the tag workflow on a branch that reintroduces `core/kernel/exit_spec.rb` — the deadlock `it` should now be picked up and appended to `spec/tags/ruby/core/kernel/exit_tags.txt` as `fails:Kernel#exit raises the SystemExit in the main thread if it reaches the top-level handler of another thread`.