### PR TITLE
Fix GC use-after-free when main parks inside a fiber; Queue timeout: validation

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -974,7 +974,33 @@ class Thread
     alias << push
     alias enq push
 
+    # CRuby-compatible `timeout:` validation, shared by Queue#pop,
+    # SizedQueue#pop and SizedQueue#push. `false` must NOT be treated as
+    # "no timeout": without the type check it fell through to the
+    # unbounded `Thread.stop` branch and blocked forever.
+    def __check_timeout(timeout, non_block)
+      return nil if timeout.nil?
+      raise ArgumentError, "can't set a timeout if non_block is enabled" if non_block
+      return timeout if Numeric === timeout
+      case timeout
+      when true, false, String
+        desc = String === timeout ? "string" : timeout.inspect
+        raise TypeError, "no implicit conversion to float from #{desc}"
+      end
+      unless timeout.respond_to?(:to_f)
+        raise TypeError, "can't convert #{timeout.class} into Float"
+      end
+      f = timeout.to_f
+      unless Float === f
+        raise TypeError,
+              "can't convert #{timeout.class} to Float (#{timeout.class}#to_f gives #{f.class})"
+      end
+      f
+    end
+    private :__check_timeout
+
     def pop(non_block = false, timeout: nil)
+      timeout = __check_timeout(timeout, non_block)
       if non_block
         raise ThreadError, "queue empty" if @items.empty? && !@closed
         return @items.shift
@@ -1075,6 +1101,7 @@ class Thread
     end
 
     def push(item, non_block = false, timeout: nil)
+      timeout = __check_timeout(timeout, non_block)
       deadline = timeout && Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
       loop do
         raise ClosedQueueError, "queue closed" if @closed

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -386,6 +386,15 @@ pub(crate) fn free_log_enabled() -> bool {
     *ON.get_or_init(|| std::env::var_os("MONORUBY_GC_FREE_LOG").is_some())
 }
 
+/// Forensics: `MONORUBY_GC_ALL_MAJOR=1` forces every collection to be a
+/// Major (full-heap) GC. A generational bug (missed write barrier /
+/// remembered-set entry) disappears under this switch; a plain root-scan
+/// bug does not. Diagnostic only — never enable in production.
+fn all_major_forced() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("MONORUBY_GC_ALL_MAJOR").is_some())
+}
+
 /// Stale-object crash forensics: report when (and by which GC kind) the
 /// heap slot behind `v` was last freed, per the `MONORUBY_GC_FREE_LOG`
 /// ring buffer. Called from assertion sites right before panicking on a
@@ -418,10 +427,41 @@ pub(crate) fn report_stale_object(site: &str, v: crate::Value) {
                 a.gc_counter(),
             ),
         }
+        // Who still holds a reference to the freed slot? An `old=true,
+        // remembered=false` holder is the signature of a missed write
+        // barrier; no holder at all means the reference lived outside the
+        // heap (frame slot, Rust local, JIT register).
+        let holders = a.find_holders(addr);
+        if holders.is_empty() {
+            eprintln!(
+                "[{site}]   no heap holder contains this address — held outside the heap"
+            );
+        }
+        for (h, marked, old, remembered) in holders {
+            // SAFETY: forensics-only read of a heap cell header.
+            let ty = unsafe { &*(h as *const crate::value::rvalue::RValue) }.ty();
+            eprintln!(
+                "[{site}]   holder {h:016x} ty={ty:?} marked={marked} old={old} remembered={remembered}"
+            );
+        }
     });
 }
 
 const FREE_LOG_CAP: usize = 1 << 21;
+
+/// Forensics: a single heap address to trace (`MONORUBY_GC_TRACK=0x…`).
+/// Every allocation returning it, every mark reaching it (with the mark
+/// chain via backtrace), and every sweep freeing it are reported. Used
+/// with ASLR disabled (`setarch -R`) so the address reproduces across
+/// runs: run once to learn the victim address from the stale-object
+/// report, re-run tracking it.
+pub(crate) fn tracked_addr() -> Option<usize> {
+    static ADDR: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    *ADDR.get_or_init(|| {
+        let v = std::env::var("MONORUBY_GC_TRACK").ok()?;
+        usize::from_str_radix(v.trim_start_matches("0x"), 16).ok()
+    })
+}
 
 /// Fast hasher for the heap-frame registry. Keys are LFP addresses
 /// (8-byte-aligned `usize`s). The default SipHash is far too slow for
@@ -740,6 +780,15 @@ impl<T: GCBox> Allocator<T> {
                 std::ptr::write(gcbox, data)
             }
             self.free_list_count -= 1;
+            if let Some(addr) = tracked_addr()
+                && gcbox as usize == addr
+            {
+                eprintln!(
+                    "[GC-TRACK] allocated (free list) after GC #{}:\n{}",
+                    self.total_gc_counter,
+                    std::backtrace::Backtrace::force_capture()
+                );
+            }
             return gcbox;
         }
 
@@ -810,7 +859,7 @@ impl<T: GCBox> Allocator<T> {
             return;
         }
         // A pending `GC.start` request forces a Major collection.
-        let kind = if GC_FORCE_MAJOR.swap(false, Ordering::Relaxed) {
+        let kind = if GC_FORCE_MAJOR.swap(false, Ordering::Relaxed) || all_major_forced() {
             GcKind::Major
         } else {
             self.decide_gc_kind()
@@ -950,6 +999,16 @@ impl<T: GCBox> Allocator<T> {
     /// If not yet, mark it and return false.
     pub(crate) fn gc_check_and_mark(&mut self, ptr: &T) -> bool {
         let p = ptr as *const T;
+        if let Some(addr) = tracked_addr()
+            && p as usize == addr
+        {
+            eprintln!(
+                "[GC-TRACK] mark hit at GC #{} ({}):\n{}",
+                self.total_gc_counter,
+                if self.current_kind == 0 { "Minor" } else { "Major" },
+                std::backtrace::Backtrace::force_capture()
+            );
+        }
         let page_ptr = self.get_page(p);
 
         let index = unsafe { (*page_ptr).get_index(p) };
@@ -1026,6 +1085,49 @@ impl<T: GCBox> Allocator<T> {
         let index = unsafe { (*page_ptr).get_index(ptr) };
         let bit_mask = 1 << (index % 64);
         unsafe { (*page_ptr).old_bits[index / 64] & bit_mask != 0 }
+    }
+
+    ///
+    /// Forensics (stale-object reports): scan every heap cell's raw words
+    /// for `addr` and return each holder cell's address together with its
+    /// `(marked, old, remembered)` status. A holder that is `old` but not
+    /// `remembered` is the signature of a missed write barrier. Linear in
+    /// heap size; only called right before a stale-object panic.
+    ///
+    pub(crate) fn find_holders(&self, addr: usize) -> Vec<(usize, bool, bool, bool)> {
+        let words = std::mem::size_of::<T>() / std::mem::size_of::<usize>();
+        let mut out = Vec::new();
+        let mut scan_page = |page: &Page<T>, len: usize| {
+            for index in 0..len {
+                let cell = page.get_cell(index) as usize;
+                if cell == addr {
+                    continue;
+                }
+                // SAFETY: forensics-only raw read of an initialized heap
+                // cell (free-list cells are initialized too — their header
+                // holds the next-pointer).
+                let hit = (0..words)
+                    .any(|w| unsafe { (cell as *const usize).add(w).read() } == addr);
+                if hit {
+                    let bit = 1u64 << (index % 64);
+                    let marked = page.mark_bits[index / 64] & bit != 0;
+                    let old = page.old_bits[index / 64] & bit != 0;
+                    let remembered = self
+                        .remembered
+                        .iter()
+                        .any(|r| r.as_ptr() as usize == cell);
+                    out.push((cell, marked, old, remembered));
+                }
+            }
+        };
+        for page in &self.pages {
+            scan_page(unsafe { page.as_ref() }, DATA_LEN);
+        }
+        scan_page(
+            unsafe { self.current_page.as_ref() },
+            self.used_in_current,
+        );
+        out
     }
 }
 
@@ -1233,6 +1335,9 @@ impl<T: GCBox> Allocator<T> {
 
     /// Append one freed-slot record to the forensics ring buffer.
     fn push_free_log(&mut self, addr: usize, gc: u32, kind: u8) {
+        if tracked_addr() == Some(addr) {
+            eprintln!("[GC-TRACK] freed by sweep of GC #{gc} (kind {kind})");
+        }
         if self.free_log.len() < FREE_LOG_CAP {
             self.free_log.push((addr, gc, kind, false));
         } else {

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -366,7 +366,62 @@ pub struct Allocator<T> {
     /// freed (a one-cycle grace covering the promote→root-store
     /// window).
     heap_frames: std::collections::HashMap<usize, FrameRec, AddrHashBuilder>,
+    /// Use-after-free forensics (enabled by `MONORUBY_GC_FREE_LOG=1`):
+    /// ring buffer of `(address, total_gc_counter, kind, was_old)` for
+    /// every slot the sweep frees. When a stale-object assertion fires
+    /// (e.g. `Value::as_array` on an `INVALID` header), the crash site
+    /// looks the address up to learn *which* GC freed the object — a
+    /// Minor implicates the write barrier / remembered set, a Major the
+    /// root set.
+    free_log: Vec<(usize, u32, u8, bool)>,
+    /// Write cursor into `free_log` once it reached capacity.
+    free_log_pos: usize,
+    /// `GcKind` of the collection currently sweeping (forensics tag).
+    current_kind: u8,
 }
+
+/// Whether `MONORUBY_GC_FREE_LOG=1` forensics are enabled (cached).
+pub(crate) fn free_log_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("MONORUBY_GC_FREE_LOG").is_some())
+}
+
+/// Stale-object crash forensics: report when (and by which GC kind) the
+/// heap slot behind `v` was last freed, per the `MONORUBY_GC_FREE_LOG`
+/// ring buffer. Called from assertion sites right before panicking on a
+/// dead/reused RValue; no-op unless the log is enabled.
+pub(crate) fn report_stale_object(site: &str, v: crate::Value) {
+    if !free_log_enabled() {
+        return;
+    }
+    if v.is_packed_value() {
+        eprintln!(
+            "[{site}] stale-object report: value {:016x} is not a heap pointer",
+            v.id()
+        );
+        return;
+    }
+    let addr = v.id() as usize;
+    let _ = ALLOC.try_with(|a| {
+        let Ok(a) = a.try_borrow() else {
+            eprintln!("[{site}] stale-object report: allocator busy");
+            return;
+        };
+        match a.lookup_free_log(addr) {
+            Some((gc, kind)) => eprintln!(
+                "[{site}] stale object {addr:016x}: freed by GC #{gc} ({}) — current GC #{}",
+                if kind == 0 { "Minor" } else { "Major" },
+                a.gc_counter(),
+            ),
+            None => eprintln!(
+                "[{site}] stale object {addr:016x}: no free record (never swept while logging, or evicted) — current GC #{}",
+                a.gc_counter(),
+            ),
+        }
+    });
+}
+
+const FREE_LOG_CAP: usize = 1 << 21;
 
 /// Fast hasher for the heap-frame registry. Keys are LFP addresses
 /// (8-byte-aligned `usize`s). The default SipHash is far too slow for
@@ -456,6 +511,9 @@ impl<T: GCBox> Allocator<T> {
             alloc_flag: None,
             gc_enabled: true,
             heap_frames: std::collections::HashMap::default(),
+            free_log: Vec::new(),
+            free_log_pos: 0,
+            current_kind: 0,
         }
     }
 
@@ -758,6 +816,10 @@ impl<T: GCBox> Allocator<T> {
             self.decide_gc_kind()
         };
         self.total_gc_counter += 1;
+        self.current_kind = match kind {
+            GcKind::Minor => 0,
+            GcKind::Major => 1,
+        };
         match kind {
             GcKind::Minor => {
                 self.minor_gc_count += 1;
@@ -1101,6 +1163,7 @@ impl<T: GCBox> Allocator<T> {
             mut map: u64,
             ptr: &mut *mut T,
             head: &mut *mut T,
+            log: &mut Option<Vec<usize>>,
         ) -> usize {
             let mut c = 0;
             let min = map.trailing_ones() as usize;
@@ -1115,6 +1178,9 @@ impl<T: GCBox> Allocator<T> {
                         (**ptr).set_next_none();
                         c += 1;
                     }
+                    if let Some(log) = log {
+                        log.push(*ptr as usize);
+                    }
                 }
                 *ptr = unsafe { (*ptr).add(1) };
                 map >>= 1;
@@ -1125,12 +1191,17 @@ impl<T: GCBox> Allocator<T> {
         let mut c = 0;
         let mut anchor = T::new_invalid();
         let head = &mut ((&mut anchor) as *mut T);
+        let mut log = if free_log_enabled() {
+            Some(Vec::new())
+        } else {
+            None
+        };
 
         for pinfo in self.pages.iter_mut() {
             unsafe {
                 let mut ptr = pinfo.as_ref().get_first_cell();
                 for map in pinfo.as_mut().mark_bits.iter() {
-                    c += sweep_bits(64, *map, &mut ptr, head);
+                    c += sweep_bits(64, *map, &mut ptr, head, &mut log);
                 }
             }
         }
@@ -1142,15 +1213,48 @@ impl<T: GCBox> Allocator<T> {
         let bitmap = unsafe { self.current_page.as_mut().mark_bits };
 
         for map in bitmap.iter().take(i) {
-            c += sweep_bits(64, *map, &mut ptr, head);
+            c += sweep_bits(64, *map, &mut ptr, head, &mut log);
         }
 
         if i < SIZE - 1 {
-            c += sweep_bits(bit, bitmap[i], &mut ptr, head);
+            c += sweep_bits(bit, bitmap[i], &mut ptr, head, &mut log);
         }
 
         self.free = anchor.next();
         self.free_list_count = c;
+        if let Some(log) = log {
+            let gc = self.total_gc_counter as u32;
+            let kind = self.current_kind;
+            for addr in log {
+                self.push_free_log(addr, gc, kind);
+            }
+        }
+    }
+
+    /// Append one freed-slot record to the forensics ring buffer.
+    fn push_free_log(&mut self, addr: usize, gc: u32, kind: u8) {
+        if self.free_log.len() < FREE_LOG_CAP {
+            self.free_log.push((addr, gc, kind, false));
+        } else {
+            self.free_log[self.free_log_pos] = (addr, gc, kind, false);
+            self.free_log_pos = (self.free_log_pos + 1) % FREE_LOG_CAP;
+        }
+    }
+
+    /// Most recent forensics record for `addr` (see `free_log`), plus the
+    /// current GC counter for "how long ago" context.
+    pub(crate) fn lookup_free_log(&self, addr: usize) -> Option<(u32, u8)> {
+        let newest = self
+            .free_log
+            .iter()
+            .filter(|(a, ..)| *a == addr)
+            .max_by_key(|(_, gc, ..)| *gc)?;
+        Some((newest.1, newest.2))
+    }
+
+    /// Current value of the GC cycle counter (forensics context).
+    pub(crate) fn gc_counter(&self) -> usize {
+        self.total_gc_counter
     }
 
     ///

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -962,6 +962,39 @@ mod tests {
     }
 
     #[test]
+    fn thread_gc_while_main_parked_inside_fiber() {
+        // Main parks *inside a fiber* (`sleep` in an Enumerator body); a
+        // green thread then runs and triggers GC. The scheduler used to
+        // publish the parking (fiber) executor as `main_exec`, so the GC
+        // marked only the fiber's frame chain — every object referenced
+        // solely from the main thread's root frames (here `arr`, and the
+        // Enumerator itself) was freed and later used: a use-after-free
+        // that killed full ruby/spec core runs.
+        // `arr` must live in a frame that is NOT on the fiber block's
+        // lexical outer chain (the outer chain is marked through the
+        // fiber's own frames); only the cfp chain of the main root
+        // executor reaches it.
+        run_test_once(
+            r#"
+            def make_enum
+              Enumerator.new { |y| sleep 0.05; y << :done }
+            end
+
+            def hold_and_wait(e)
+              arr = Array.new(64) { |i| [i, i.to_s] }
+              v = e.next
+              [v, arr.all? { |a| a[0] == a[1].to_i }, arr.size]
+            end
+
+            t = Thread.new { 20.times { GC.start; Thread.pass } }
+            r = hold_and_wait(make_enum)
+            t.join
+            r
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_block_param_of_cross_thread_frame() {
         // Reading a `&block` parameter (lazily materialized by monoruby)
         // from inside a green thread: the parameter's lexical home is a

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -962,6 +962,35 @@ mod tests {
     }
 
     #[test]
+    fn queue_pop_timeout_validation() {
+        // `timeout:` must be nil or Numeric. `false` in particular must
+        // not be treated as "no timeout" — it used to fall through to the
+        // unbounded park branch and block forever (deadlock FatalError in
+        // ruby/spec shared/queue/deque.rb).
+        run_test_once(
+            r#"
+            q = Thread::Queue.new
+            r = []
+            begin; q.pop(timeout: "1"); rescue TypeError => e; r << e.message; end
+            begin; q.pop(timeout: false); rescue TypeError => e; r << e.message; end
+            begin; q.pop(timeout: true); rescue TypeError => e; r << e.message; end
+            begin; q.pop(true, timeout: 1); rescue ArgumentError => e; r << e.message; end
+            begin; q.pop(timeout: :sym); rescue TypeError => e; r << e.message; end
+            sq = Thread::SizedQueue.new(1)
+            begin; sq.push(1, timeout: "1"); rescue TypeError => e; r << e.message; end
+            class TimeoutConv; def to_f; 0.001; end; end
+            class TimeoutBad; def to_f; "x"; end; end
+            begin; q.pop(timeout: TimeoutBad.new); rescue TypeError => e; r << e.message; end
+            q << 1
+            r << q.pop(timeout: TimeoutConv.new)
+            q << 2
+            r << q.pop(timeout: 5)
+            r
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_gc_while_main_parked_inside_fiber() {
         // Main parks *inside a fiber* (`sleep` in an Enumerator body); a
         // green thread then runs and triggers GC. The scheduler used to

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3730,12 +3730,35 @@ pub(crate) extern "C" fn execute_gc(
             }
         }
     }
+    // Forensics (`MONORUBY_GC_BREAK=N`): dump the trigger context of GC
+    // #N — who called into the collector, from which executor, and what
+    // the scheduler state was — right before that collection runs.
+    let triggering_executor = executor as *const Executor;
     // Get root Executor.
+    let mut fiber_depth = 0usize;
     while let Some(mut parent) = executor.parent_fiber {
         // SAFETY: parent_fiber is guaranteed to be a valid pointer to an Executor
         // that outlives this borrow. The parent fiber structure is maintained correctly.
         executor = unsafe { parent.as_mut() };
+        fiber_depth += 1;
+    }
+    if let Some(break_at) = gc_break_at()
+        && alloc::ALLOC.with(|a| a.borrow().gc_counter()) + 1 == break_at
+    {
+        eprintln!(
+            "[GC-BREAK] GC #{break_at}: trigger_exec={:016x} root_exec={:016x} fiber_depth={fiber_depth}",
+            triggering_executor as usize, executor as *const Executor as usize,
+        );
+        eprintln!("[GC-BREAK] scheduler: {}", crate::scheduler::dump_state_for_gc());
+        eprintln!("[GC-BREAK] backtrace:\n{}", std::backtrace::Backtrace::force_capture());
     }
     alloc::ALLOC.with(|alloc| alloc.borrow_mut().gc(&Root { globals, executor }));
     Some(Value::nil())
+}
+
+/// Forensics: the GC ordinal to dump trigger context for
+/// (`MONORUBY_GC_BREAK=N`), cached.
+fn gc_break_at() -> Option<usize> {
+    static AT: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    *AT.get_or_init(|| std::env::var("MONORUBY_GC_BREAK").ok()?.parse().ok())
 }

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -160,16 +160,34 @@ pub(crate) fn dump_state_for_gc() -> String {
     SCHEDULER.with(|s| {
         let s = s.borrow();
         format!(
-            "in_scheduler={} main_exec={:?} current={:016x} main={:016x} threads={} ready={} sleepers={} io_waiters={}",
+            "in_scheduler={} main_exec={:?} main_exec_parent_fiber={:?} current={:016x} main={:016x} threads={} ready={} sleepers={} io_waiters={}",
             s.in_scheduler,
             s.main_exec,
+            // SAFETY: forensics-only read; main_exec is live while set.
+            s.main_exec
+                .map(|e| unsafe { e.as_ref().parent_fiber() }),
             s.current.map(|v| v.id()).unwrap_or(0),
             s.main.map(|v| v.id()).unwrap_or(0),
             s.threads.len(),
             s.ready.len(),
             s.sleepers.len(),
             s.io_waiters.len(),
-        )
+        ) + &s
+            .main
+            .map(|m| {
+                let inner = m.as_thread_inner();
+                format!(
+                    " main_state={:?} main_resume_exec={:?} main_resume_parent_fiber={:?}",
+                    inner.state,
+                    inner.resume_exec,
+                    // SAFETY: forensics-only read; resume_exec is live
+                    // while the thread is parked.
+                    inner
+                        .resume_exec
+                        .map(|e| unsafe { e.as_ref().parent_fiber() }),
+                )
+            })
+            .unwrap_or_default()
     })
 }
 
@@ -317,7 +335,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
         // executor for the duration.
         SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
-            s.main_exec = Some(std::ptr::NonNull::from(&mut *vm));
+            s.main_exec = Some(root_exec(vm));
             s.in_scheduler = true;
         });
         // Same fd-waiter promotion as `scheduler_loop`: a main thread
@@ -676,12 +694,34 @@ fn park_switch(vm: &mut Executor, mut cur: Value) -> Result<()> {
     }
 }
 
+/// The thread-root executor of `vm`'s fiber-parent chain.
+///
+/// GC root marking must always start from the thread-root executor: a
+/// fiber's frame chain is reached *from* the frame that holds the Fiber
+/// object (the resumer), never the other way round — `Executor::mark`
+/// walks only its own cfp chain and does not cross fiber boundaries.
+/// `execute_gc` performs this same walk for the triggering executor;
+/// capturing `main_exec` from a park that happened *inside* a fiber
+/// (e.g. `sleep` in an Enumerator body) without the walk would publish
+/// the fiber's executor instead, leaving every frame of the main
+/// thread's root chain invisible to a green-thread-triggered GC — a
+/// use-after-free of anything referenced only by those frames.
+fn root_exec(vm: &mut Executor) -> std::ptr::NonNull<Executor> {
+    let mut cur = std::ptr::NonNull::from(&mut *vm);
+    // SAFETY: `parent_fiber` links point at live executors while the
+    // child fiber is running (the resumer is suspended on its stack).
+    while let Some(parent) = unsafe { cur.as_ref().parent_fiber() } {
+        cur = parent;
+    }
+    cur
+}
+
 /// The scheduler loop. Only ever called in the main thread's context,
 /// while the main thread is parked; returns when main is runnable again.
 fn scheduler_run(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
     SCHEDULER.with(|s| {
         let mut s = s.borrow_mut();
-        s.main_exec = Some(std::ptr::NonNull::from(&mut *vm));
+        s.main_exec = Some(root_exec(vm));
         s.in_scheduler = true;
     });
     let result = scheduler_loop(vm, globals);

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -154,6 +154,25 @@ pub(crate) fn mark(alloc: &mut crate::alloc::Allocator<RValue>) {
     SCHEDULER.with(|s| s.borrow().mark(alloc));
 }
 
+/// Forensics (`MONORUBY_GC_BREAK`): one-line dump of the scheduler state
+/// as seen by the GC root scan.
+pub(crate) fn dump_state_for_gc() -> String {
+    SCHEDULER.with(|s| {
+        let s = s.borrow();
+        format!(
+            "in_scheduler={} main_exec={:?} current={:016x} main={:016x} threads={} ready={} sleepers={} io_waiters={}",
+            s.in_scheduler,
+            s.main_exec,
+            s.current.map(|v| v.id()).unwrap_or(0),
+            s.main.map(|v| v.id()).unwrap_or(0),
+            s.threads.len(),
+            s.ready.len(),
+            s.sleepers.len(),
+            s.io_waiters.len(),
+        )
+    })
+}
+
 /// The `Thread` object for the currently running thread, creating the
 /// main thread object lazily on first use.
 pub(crate) fn current_thread(vm: &mut Executor) -> Value {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -2388,7 +2388,10 @@ impl Value {
     }
 
     pub(crate) fn as_array(self) -> Array {
-        assert_eq!(self.ty(), Some(ObjTy::ARRAY));
+        if self.ty() != Some(ObjTy::ARRAY) {
+            crate::alloc::report_stale_object("Value::as_array", self);
+            panic!("as_array: not an ARRAY: ty={:?}", self.ty());
+        }
         Array::new_unchecked(self)
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the two bugs that prevented full `ruby/spec` **core** runs from completing (the last blockers for monoruby's core stats on rubyspec-stats), and adds the GC forensics tooling used to find them.

### 1. GC use-after-free: `main_exec` captured the parking fiber's executor (the issue #950 crash signature)

When the main thread parked from **inside a fiber** (e.g. `sleep` in an `Enumerator` body — happens on every full core run around `kernel/sleep_spec.rb`), `scheduler_run`/`pass` published the *fiber's* executor as `main_exec`. A GC triggered by a green thread then marked only the fiber's frame chain: `Executor::mark` never crosses fiber boundaries, and the walk to the root executor that `execute_gc` performs was skipped by the capture. Every object referenced solely from the main thread's root frames was swept while main was parked and used after resume — deterministically killing full core runs ~70s in with:

```
[Value::as_array] stale object …: freed by GC #N (Minor) — current GC #N
as_array: not an ARRAY: ty=Some(INVALID(…))   # in mspec ContextState#protect → Array#all?
```

**Fix**: walk `parent_fiber` to the thread-root executor at capture (the same invariant `execute_gc` and `ThreadInner.handle` already follow); the fiber's own chain stays reachable through the Fiber object held by its resumer's frame.

**Regression test**: main parks inside an Enumerator whose lexical outer chain does not cover the victim's frame, while a green thread runs `GC.start`. Reproducibly SIGABRTs before the fix, passes after.

### 2. `Queue#pop(timeout: false)` blocked forever → core/queue hang

`timeout:` was used as a plain truthy/falsy switch, so `false` fell through to the unbounded `Thread.stop` branch — `shared/queue/deque.rb` then died with a deadlock FatalError and the core run stalled at `core/queue/pop_spec.rb` until the CI budget killed the category.

**Fix**: CRuby 4.0.2-compatible validation shared by `Queue#pop` / `SizedQueue#pop` / `SizedQueue#push`: nil = no timeout; Numeric used as-is; `true`/`false`/String raise `TypeError` (new-style "no implicit conversion to float from …" messages); other objects convert via `#to_f` with CRuby's exact error messages; `non_block` + `timeout` raises `ArgumentError`. Covered by a differential test.

### 3. GC forensics (all env-gated, zero cost when off)

- `MONORUBY_GC_FREE_LOG=1` + `find_holders()`: stale-object reports now also scan the heap for cells still holding the freed address, with `(marked, old, remembered)` status — distinguishes missed-write-barrier from out-of-heap references.
- `MONORUBY_GC_TRACK=0x<addr>`: trace one heap slot's mark/alloc/free with backtraces (for ASLR-disabled repros).
- `MONORUBY_GC_ALL_MAJOR=1`: force full-heap collections to discriminate generational bugs from root-scan bugs.
- `MONORUBY_GC_BREAK=N`: dump GC #N's trigger context (backtrace, executor identity, fiber depth, scheduler state) — this is what exposed the fiber-parked capture directly.

## Verification

- Former deterministic repro (`--no-jit`, core categories a..kernel, 3/3 crash at ~20s): **3/3 clean** after the fix.
- Full `mspec ci core`: **completes in ~146s** (22,670 examples, 87,244 expectations) — previously crashed ~70s in, or stalled at the queue hang until timeout. Well within the rubyspec-stats 1200s budget.
- `core/queue` + `core/sizedqueue`: complete in 0.3s (no hang).
- Full unit test suite: **1893 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_