### PR TITLE
Mutex#sleep semantics + ConditionVariable#wait/#marshal_dump

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -990,15 +990,22 @@ class Thread
     end
 
     # Atomically release the mutex, sleep, and re-acquire it on wake
-    # (including on an exception raised into the sleeper).
+    # (including on an exception raised into the sleeper). Returns the
+    # rounded number of seconds actually slept, as in CRuby. A negative
+    # duration is an ArgumentError (validated before the ownership check).
     def sleep(timeout = nil)
+      if timeout && timeout < 0
+        raise ArgumentError, "time interval must not be negative"
+      end
       raise ThreadError, "Attempt to unlock a mutex which is not locked" unless owned?
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       unlock
       begin
         timeout ? Kernel.sleep(timeout) : Thread.stop
       ensure
         lock
       end
+      (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round
     end
   end
 
@@ -1202,16 +1209,20 @@ class Thread
     def wait(mutex, timeout = nil)
       @waiters << Thread.current
       begin
-        mutex.unlock
-        begin
-          timeout ? Kernel.sleep(timeout) : Thread.stop
-        ensure
-          mutex.lock
-        end
+        # Delegate to Mutex#sleep so the mutex is atomically released,
+        # the caller parks, and the mutex is re-acquired on wake — exactly
+        # as CRuby does (which is why `#wait` calls `#sleep` on its arg).
+        mutex.sleep(timeout)
       ensure
         @waiters.delete(Thread.current)
       end
       self
+    end
+
+    # ConditionVariable holds runtime synchronization state that cannot be
+    # serialized; CRuby raises TypeError from Marshal.
+    def marshal_dump
+      raise TypeError, "can't dump #{self.class}"
     end
 
     def signal


### PR DESCRIPTION
## Summary

Fixes 5 `core/{mutex,conditionvariable}` ruby/spec fail/errors by filling in Mutex/ConditionVariable API gaps (pure-Ruby, in `builtins/startup.rb`). No changes to the locking/parking core.

| Category | Before | After |
|---|---|---|
| core/mutex | 3 fail / 1 error | 1 fail / 0 error* |
| core/conditionvariable | 1 fail / 4 error | 0 fail / 2 error |

\* plus the pre-existing `owned? is held per Fiber` failure and the timing-flaky `does not raise deadlock if a fiber's attempt to lock was interrupted` case (see below).

## Changes

**`Mutex#sleep`**
- raises `ArgumentError` for a negative duration, validated *before* the ownership check so it takes precedence over the not-owned `ThreadError` (spec: negative duration raises `ArgumentError` whether or not the mutex is held)
- returns the rounded number of seconds actually slept (monotonic-clock measured), matching CRuby, instead of `nil`

**`ConditionVariable#wait`**
- delegates the atomic release / park / re-acquire to `Mutex#sleep`, which is why CRuby's `#wait` invokes `#sleep` on the object it's given (a spec asserts exactly this with a mock)

**`ConditionVariable#marshal_dump`**
- raises `TypeError` (`can't dump …`) — the condvar's runtime state isn't serializable

## Testing

- `mspec run core/mutex core/conditionvariable` — counts above
- `cargo test -p monoruby --lib -- builtins::thread builtins::fiber` — 40 pass
- adjacent `library/monitor` failures are pre-existing and unrelated

## Deferred (need threading/fiber-model changes, not in this PR)

- **`Mutex#owned?` per-Fiber** — needs per-Fiber ownership identity; this branch's `Fiber.current` returns the same object across threads/fibers, so it can't key ownership (verified). Left on `Thread.current`.
- **`Mutex#locked?` release-on-termination** — a thread must release held mutexes when it dies; hacking `try_lock` with `.alive?` would break its deliberate safepoint-free atomicity.
- **`ConditionVariable#wait` re-lock on kill-after-signal** and **`Thread#backtrace` for a parked thread** — deeper concurrency/introspection work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_