### PR TITLE
socket stub: raise SocketError from TCPSocket/TCPServer instantiation (fixes rubyspec-stats library 0%)

### DIFF
--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -33,7 +33,19 @@ class IPSocket < BasicSocket
   def self.getaddress(host); host; end
 end
 
-class TCPSocket < IPSocket; end
+# Real TCP sockets are unsupported. Fail loudly at instantiation, like
+# UNIXSocket below: a silent do-nothing socket object lets code run on
+# until it dies far from the cause. The ruby/spec net-http fixture is
+# the concrete case — it builds a TCPServer, then spawns a server
+# thread with `abort_on_exception = true`; with a do-nothing server
+# object the thread died on a missing method and the exception was
+# forwarded to (and killed) the main thread, aborting the whole mspec
+# run. Raising here surfaces in the spec's own setup instead.
+class TCPSocket < IPSocket
+  def initialize(*)
+    raise SocketError, "TCP sockets are not supported in monoruby"
+  end
+end
 class TCPServer < TCPSocket; end
 class UDPSocket < IPSocket; end
 class UNIXSocket < BasicSocket


### PR DESCRIPTION
# Summary

rubyspec-stats' library stage went back to 0% after the preemption merge (#962). This was **not a hang** — the mspec runner **aborted mid-run**:

1. ruby/spec's net-http fixture (`library/net-http/http/fixtures/http_server.rb`) builds a `TCPServer`, then spawns a server thread with `Thread.current.abort_on_exception = true`.
2. monoruby's `TCPServer` stub was an empty class, so `TCPServer.new` silently succeeded and the thread died later on the missing `TCPServer#closed?` (`NoMethodError`).
3. Since #962, `abort_on_exception` forwarding works (CRuby semantics), so that `NoMethodError` was forwarded to the main thread — the mspec runner — and killed it. mspec aborted at the next spec file with *"was executed but did not reset the current example"* and published truncated/empty stats → library 0%. (Dozens of `#<Thread:… run> terminated with exception` report lines in the CI log are the same thread deaths, surfaced by the now-CRuby-format `report_on_exception` output.)

Before #962 the fixture thread died silently, the net-http specs failed normally, and the category completed — which is why this only appeared now.

# Fix

Make the `TCPSocket` stub (and thus `TCPServer`) raise `SocketError, "TCP sockets are not supported in monoruby"` at instantiation, exactly like the `UNIXSocket` stub already does. The fixture now fails in the spec's own `before` setup on the main thread; mspec records ordinary errors and the run completes.

# Verification

- `mspec ci library` locally: previously aborted at `library/openssl/fixed_length_secure_compare_spec.rb`; now completes — 1516 files, 4239 examples, 606 failures, 3658 errors, 6 tagged (77 s), no abort, no report flood.
- The CI-style `--format yaml --output stats.yml` run emits a complete stats file including the trailing totals block, so the library percentage will be computed again.
- `require "socket"` still resolves all stub constants; `TCPServer.new` / `TCPSocket.new` raise `SocketError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_