### PR TITLE
Real TCP sockets + JIT specialized-call capture fix: library category completes (1805s hang → 34s)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -791,6 +791,13 @@ class Thread
     @report_on_exception = flag
   end
 
+  # The group this thread was added to (ThreadGroup#add), defaulting to
+  # ThreadGroup::Default. The timeout gem consults
+  # `watcher.group.enclosed?` when it spawns its watchdog thread.
+  def group
+    @__thread_group || ThreadGroup::Default
+  end
+
   # CRuby's Thread#to_s: `#<Thread:0xADDR[@name] status>` (the spawn
   # file:line is not tracked). ruby/spec interpolates this into the
   # report_on_exception output matchers, so the `#<Thread:` prefix and
@@ -1311,6 +1318,42 @@ class ThreadError < StandardError; end unless defined?(::ThreadError)
 class ClosedQueueError < StopIteration; end unless defined?(::ClosedQueueError)
 Queue = Thread::Queue
 SizedQueue = Thread::SizedQueue
+
+# Thread groups. Threads carry their group in an ivar (nil = Default);
+# scheduling is untouched — groups are pure bookkeeping, which matches
+# their CRuby role. The timeout gem needs `Thread#group`,
+# `ThreadGroup#enclosed?` and `ThreadGroup::Default.add`.
+class ThreadGroup
+  def initialize
+    @enclosed = false
+  end
+
+  def enclose
+    @enclosed = true
+    self
+  end
+
+  def enclosed?
+    @enclosed
+  end
+
+  def add(thread)
+    if @enclosed
+      raise ThreadError, "can't move to the enclosed thread group"
+    end
+    if thread.group.enclosed?
+      raise ThreadError, "can't move from the enclosed thread group"
+    end
+    thread.instance_variable_set(:@__thread_group, self)
+    self
+  end
+
+  def list
+    Thread.list.select { |t| t.group == self }
+  end
+
+  Default = new
+end
 ConditionVariable = Thread::ConditionVariable
 
 class Exception

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -39,6 +39,7 @@ mod random;
 mod range;
 mod regexp;
 mod set;
+mod socket;
 mod string;
 pub(crate) mod struct_class;
 mod symbol;
@@ -129,6 +130,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     io_buffer::init(globals);
     struct_class::init(globals);
     file::init(globals);
+    socket::init(globals);
     fiddle::init(globals);
     ffi::init(globals);
     marshal::init(globals);

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -7212,4 +7212,25 @@ mod tests {
             r##"require "stringio""##,
         );
     }
+
+    #[test]
+    fn io_wait_readable_writable() {
+        run_test_once(
+            r#"
+            require "io/wait"
+            r, w = IO.pipe
+            res = []
+            res << r.wait_readable(0)          # no data yet -> nil
+            w.write "x"
+            res << (r.wait_readable(1) == r)
+            res << (w.wait_writable(1) == w)
+            res << (r.wait(1, :read) == r)
+            res << (r.read(0))                 # length 0 never blocks
+            res << (r.read(1))
+            r.close
+            w.close
+            res
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -1222,7 +1222,12 @@ pub(crate) fn blocking_io_region<T>(
 /// to run (an fd left permanently non-blocking by `read_nonblock` /
 /// `write_nonblock`). Signal-interruptible: `EINTR` (and a signal already
 /// pending on entry) runs the VM poll point, then re-polls.
-fn wait_fd_single(vm: &mut Executor, globals: &mut Globals, fd: i32, events: i16) -> Result<()> {
+pub(crate) fn wait_fd_single(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    fd: i32,
+    events: i16,
+) -> Result<()> {
     loop {
         if crate::codegen::signal_table::PENDING_SIGNALS.load(std::sync::atomic::Ordering::Relaxed)
             != 0
@@ -1510,9 +1515,18 @@ fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         }
         _ => None,
     };
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
-        lfp.self_val().as_io_inner_mut().read(length)
-    })?;
+    let buf = if length == Some(0) {
+        // `read(0)` never blocks and returns "" (CRuby) — entering the
+        // blocking region would park on POLLIN waiting for data that a
+        // zero-length read must not consume (the net-http fixture calls
+        // `client.read(0)` for `Content-Length: 0` requests).
+        lfp.self_val().as_io_inner().ensure_readable()?;
+        Vec::new()
+    } else {
+        blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+            lfp.self_val().as_io_inner_mut().read(length)
+        })?
+    };
     let eof_nil = buf.is_empty() && length.is_some() && length != Some(0);
     match outbuf {
         Some(mut out) => {
@@ -4009,6 +4023,45 @@ fn ensure_io_open(self_val: Value) -> Result<()> {
 /// `POLLIN`/`POLLPRI`/`POLLOUT`) and a timeout in milliseconds. Returns the
 /// revents from the kernel, or 0 on timeout. Closed / invalid fds raise
 /// `IOError: closed stream`.
+/// Green-thread-aware fd wait for the `IO#wait*` family: when other green
+/// threads are live, park on the scheduler's fd poller (deadline-bounded)
+/// instead of issuing a process-blocking poll(2) — a plain poll freezes
+/// every other green thread for the whole timeout, and the peer this wait
+/// is waiting *for* is typically one of them (e.g. net/protocol's
+/// `rbuf_fill` waiting on a spec's in-process server thread). Returns the
+/// ready revents, 0 on timeout.
+fn wait_single_fd_events(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    self_val: Value,
+    events: i16,
+    timeout_ms: i32,
+) -> Result<i16> {
+    if !crate::scheduler::has_other_live_threads() {
+        return poll_single_fd(self_val, events, timeout_ms);
+    }
+    let deadline = if timeout_ms >= 0 {
+        Some(std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms as u64))
+    } else {
+        None
+    };
+    loop {
+        // Zero-timeout probe; also raises IOError once the stream is
+        // closed (including by another thread while we were parked).
+        let revents = poll_single_fd(self_val, events, 0)?;
+        if revents != 0 {
+            return Ok(revents);
+        }
+        if let Some(dl) = deadline
+            && std::time::Instant::now() >= dl
+        {
+            return Ok(0);
+        }
+        let fd = self_val.as_io_inner().wait_fd_for(events)?;
+        crate::scheduler::wait_fd(vm, globals, fd, events, deadline)?;
+    }
+}
+
 fn poll_single_fd(self_val: Value, events: i16, timeout_ms: i32) -> Result<i16> {
     if self_val.as_io_inner().is_closed() {
         return Err(MonorubyErr::ioerr("closed stream"));
@@ -4068,7 +4121,7 @@ fn io_wait(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let args = lfp.arg(0).as_array();
 
     if args.is_empty() {
-        let revents = poll_single_fd(self_val, libc::POLLIN as i16, -1)?;
+        let revents = wait_single_fd_events(vm, globals, self_val, libc::POLLIN as i16, -1)?;
         return if revents == 0 {
             Ok(Value::nil())
         } else {
@@ -4135,7 +4188,7 @@ fn io_wait(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         poll_events |= libc::POLLOUT as i16;
     }
 
-    let revents = poll_single_fd(self_val, poll_events, timeout_ms)?;
+    let revents = wait_single_fd_events(vm, globals, self_val, poll_events, timeout_ms)?;
 
     if has_symbol {
         let ready = (revents & libc::POLLIN as i16) != 0
@@ -4178,7 +4231,7 @@ fn io_wait_readable(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let timeout_ms = parse_wait_timeout(vm, globals, lfp.try_arg(0))?;
-    let revents = poll_single_fd(self_val, libc::POLLIN as i16, timeout_ms)?;
+    let revents = wait_single_fd_events(vm, globals, self_val, libc::POLLIN as i16, timeout_ms)?;
     if revents == 0 {
         return Ok(Value::nil());
     }
@@ -4199,7 +4252,7 @@ fn io_wait_writable(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let timeout_ms = parse_wait_timeout(vm, globals, lfp.try_arg(0))?;
-    let revents = poll_single_fd(self_val, libc::POLLOUT as i16, timeout_ms)?;
+    let revents = wait_single_fd_events(vm, globals, self_val, libc::POLLOUT as i16, timeout_ms)?;
     if revents == 0 {
         return Ok(Value::nil());
     }
@@ -4220,7 +4273,7 @@ fn io_wait_priority(
 ) -> Result<Value> {
     let self_val = lfp.self_val();
     let timeout_ms = parse_wait_timeout(vm, globals, lfp.try_arg(0))?;
-    let revents = poll_single_fd(self_val, libc::POLLPRI as i16, timeout_ms)?;
+    let revents = wait_single_fd_events(vm, globals, self_val, libc::POLLPRI as i16, timeout_ms)?;
     if revents == 0 {
         return Ok(Value::nil());
     }

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -265,16 +265,74 @@ fn sockaddr_in(addr_be: u32, port: u16) -> libc::sockaddr_in {
     sin
 }
 
+/// `socket(2)` with close-on-exec (and optionally non-blocking) set.
+/// Linux sets both atomically via `SOCK_CLOEXEC` / `SOCK_NONBLOCK`;
+/// macOS/BSD have neither flag, so fall back to `fcntl(2)` after
+/// creation (a benign race in a green-thread runtime — nothing forks
+/// between the two calls).
+fn cloexec_socket(domain: i32, ty: i32, proto: i32, nonblock: bool) -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        let mut ty = ty | libc::SOCK_CLOEXEC;
+        if nonblock {
+            ty |= libc::SOCK_NONBLOCK;
+        }
+        // SAFETY: plain socket(2).
+        unsafe { libc::socket(domain, ty, proto) }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // SAFETY: plain socket(2), then fcntl on the fd we just created.
+        unsafe {
+            let fd = libc::socket(domain, ty, proto);
+            if fd >= 0 {
+                libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
+                if nonblock {
+                    let flags = libc::fcntl(fd, libc::F_GETFL);
+                    if flags >= 0 {
+                        libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+                    }
+                }
+            }
+            fd
+        }
+    }
+}
+
+/// `accept(2)` returning a close-on-exec, *blocking* connection fd.
+/// Linux uses `accept4(2)`; macOS/BSD fall back to `accept(2)` +
+/// `fcntl(2)`, also clearing `O_NONBLOCK` — BSD-family accepted fds
+/// inherit the listener's non-blocking flag (Linux ones do not), and
+/// the IO layer expects blocking-mode sockets.
+fn cloexec_accept(fd: i32) -> i32 {
+    #[cfg(target_os = "linux")]
+    // SAFETY: accept4 on the caller's listener fd; out params unused (NULL).
+    unsafe {
+        libc::accept4(
+            fd,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            libc::SOCK_CLOEXEC,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    // SAFETY: accept on the caller's listener fd; fcntl on the fresh fd.
+    unsafe {
+        let conn = libc::accept(fd, std::ptr::null_mut(), std::ptr::null_mut());
+        if conn >= 0 {
+            libc::fcntl(conn, libc::F_SETFD, libc::FD_CLOEXEC);
+            let flags = libc::fcntl(conn, libc::F_GETFL);
+            if flags >= 0 {
+                libc::fcntl(conn, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+            }
+        }
+        conn
+    }
+}
+
 /// A new non-blocking, close-on-exec TCP socket fd.
 fn new_tcp_fd(store: &Store) -> Result<i32> {
-    // SAFETY: plain socket(2).
-    let fd = unsafe {
-        libc::socket(
-            libc::AF_INET,
-            libc::SOCK_STREAM | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
-            0,
-        )
-    };
+    let fd = cloexec_socket(libc::AF_INET, libc::SOCK_STREAM, 0, true);
     if fd < 0 {
         return Err(last_errno_err(store, "socket(2)"));
     }
@@ -431,17 +489,9 @@ fn tcp_server_accept(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Byte
             }));
         }
         let fd = self_.as_io_inner().fileno()?;
-        // SAFETY: accept4 on our listener fd; out params unused (NULL).
-        let conn = unsafe {
-            libc::accept4(
-                fd,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                libc::SOCK_CLOEXEC,
-            )
-        };
+        let conn = cloexec_accept(fd);
         if conn >= 0 {
-            // SAFETY: conn is a fresh, owned fd from accept4.
+            // SAFETY: conn is a fresh, owned fd from accept.
             let file = unsafe { std::fs::File::from_raw_fd(conn) };
             return Ok(Value::new_socket(
                 file,
@@ -637,8 +687,7 @@ fn socket_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
         Some(v) if !v.is_nil() => v.coerce_to_i64(&globals.store)? as i32,
         _ => 0,
     };
-    // SAFETY: plain socket(2).
-    let fd = unsafe { libc::socket(domain, stype | libc::SOCK_CLOEXEC, proto) };
+    let fd = cloexec_socket(domain, stype, proto, false);
     if fd < 0 {
         return Err(last_errno_err(&globals.store, "socket(2)"));
     }

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -940,3 +940,195 @@ fn shutdown_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     }
     Ok(Value::integer(0))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    #[test]
+    fn tcp_echo_roundtrip() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            t = Thread.new { c = s.accept; c.write(c.gets); c.close }
+            k = TCPSocket.new("127.0.0.1", port)
+            k.puts "hello"
+            res = k.gets
+            k.close
+            t.join
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn tcp_open_block_and_connect_timeout() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            t = Thread.new { c = s.accept; c.write("pong\n"); c.close }
+            res = TCPSocket.open("127.0.0.1", port, connect_timeout: 5) { |k| k.gets }
+            t.join
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn tcp_addr_and_peeraddr() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            t = Thread.new { c = s.accept; sleep 0.2; c.close }
+            k = TCPSocket.new("127.0.0.1", port)
+            res = [
+              s.addr.values_at(0, 2, 3),
+              s.addr[1].is_a?(Integer),
+              k.peeraddr.values_at(0, 2, 3),
+              k.peeraddr[1] == port,
+              k.addr[0],
+              IPSocket.getaddress("127.0.0.1"),
+            ]
+            k.close
+            t.join
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn tcp_connect_refused() {
+        run_test_once(
+            r#"
+            require "socket"
+            # Grab a port that is momentarily free, then connect after closing.
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            s.close
+            begin
+              TCPSocket.new("127.0.0.1", port)
+              "connected"
+            rescue Errno::ECONNREFUSED
+              "refused"
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn accept_closed_in_another_thread() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            t = Thread.new do
+              begin
+                s.accept
+                "accepted"
+              rescue IOError => e
+                e.message
+              end
+            end
+            sleep 0.2
+            s.close
+            t.value
+            "#,
+        );
+    }
+
+    #[test]
+    fn shutdown_write_gives_server_eof() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            t = Thread.new { c = s.accept; got = c.read; c.write(got.upcase); c.close; got }
+            k = TCPSocket.new("127.0.0.1", port)
+            k.write "chunked body"
+            k.shutdown(Socket::SHUT_WR)
+            res = [k.read, t.value]
+            k.close
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn socket_new_and_constants() {
+        run_test_once(
+            r#"
+            require "socket"
+            sock = Socket.new(:INET, :STREAM)
+            res = [
+              sock.is_a?(Socket),
+              sock.is_a?(BasicSocket),
+              sock.close,
+              Socket::AF_INET == Socket::Constants::AF_INET,
+              Socket::SOCK_STREAM.is_a?(Integer),
+              Socket::SOL_SOCKET.is_a?(Integer),
+              Socket::SOMAXCONN >= 1,
+              TCPSocket.superclass,
+              TCPServer.superclass,
+              BasicSocket.superclass,
+              SocketError.superclass,
+            ]
+            res
+            "#,
+        );
+    }
+
+    // getsockopt returns a plain Integer in monoruby (CRuby wraps it in
+    // Socket::Option), so assert monoruby's behavior directly instead of
+    // comparing with CRuby.
+    #[test]
+    fn set_and_getsockopt() {
+        let v = run_test_no_result_check(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            s.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+            on = s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE)
+            s.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, false)
+            off = s.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE)
+            s.close
+            [on != 0, off].inspect
+            "#,
+        );
+        assert_eq!("[true, 0]", v.as_str());
+    }
+
+    #[test]
+    fn gets_read_partial_across_packets() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            t = Thread.new do
+              c = s.accept
+              c.write "line one\n"
+              sleep 0.1
+              c.write "line two\nrest"
+              c.close
+            end
+            k = TCPSocket.new("127.0.0.1", port)
+            res = [k.gets, k.gets, k.read]
+            k.close
+            t.join
+            s.close
+            res
+            "#,
+        );
+    }
+}

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -1,0 +1,893 @@
+use super::*;
+use std::os::fd::FromRawFd;
+
+//
+// TCP sockets: BasicSocket / IPSocket / TCPSocket / TCPServer / Socket.
+//
+// A socket is an ordinary IO object (`ObjTy::IO` wrapping the socket fd,
+// classed as TCPSocket / TCPServer), so the entire IO surface —
+// read/gets/write/print/puts/close/closed?/fileno/eof?, and crucially the
+// green-thread blocking-IO emulation (mid-operation would-block parks the
+// calling thread on the scheduler's fd poller) — applies to sockets
+// unchanged via class inheritance. This module adds only the
+// socket-specific surface: the constructors (socket/bind/listen/connect),
+// `accept`, addresses, socket options, and `shutdown`.
+//
+// Blocking discipline (M:1 green threads):
+// - the listener fd is permanently non-blocking; `accept` retries around
+//   `EAGAIN`, parking on the fd poller (or a plain poll(2) when no other
+//   green thread could run).
+// - `connect` is issued non-blocking (`EINPROGRESS`), parks on POLLOUT,
+//   then reads `SO_ERROR`; the fd is restored to blocking mode afterwards
+//   so the ordinary IO paths see a plain blocking stream.
+//
+
+pub(super) fn init(globals: &mut Globals) {
+    let io_class = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("IO"))
+        .unwrap()
+        .as_class();
+    let standard_error = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("StandardError"))
+        .unwrap()
+        .as_class();
+
+    let basic = globals.define_class("BasicSocket", io_class, OBJECT_CLASS);
+    let basic_id = basic.id();
+    let ipsocket = globals.define_class("IPSocket", basic, OBJECT_CLASS);
+    let ip_id = ipsocket.id();
+    let tcpsocket = globals.define_class("TCPSocket", ipsocket, OBJECT_CLASS);
+    let tcps_id = tcpsocket.id();
+    let tcpserver = globals.define_class("TCPServer", tcpsocket, OBJECT_CLASS);
+    let tsrv_id = tcpserver.id();
+    let socket_class = globals.define_class("Socket", basic, OBJECT_CLASS);
+    let sock_id = socket_class.id();
+    globals.define_class("SocketError", standard_error, OBJECT_CLASS);
+
+    // Socket::Constants, and the same constants directly on Socket
+    // (CRuby's Socket includes Socket::Constants).
+    let consts_id = globals
+        .define_class("Constants", None, sock_id)
+        .id();
+    for (name, v) in SOCKET_CONSTANTS {
+        let id = IdentId::get_id(name);
+        globals.set_constant(sock_id, id, Value::integer(*v));
+        globals.set_constant(consts_id, id, Value::integer(*v));
+    }
+
+    globals.define_builtin_class_func_with(tsrv_id, "new", tcp_server_new, 1, 2, false);
+    globals.define_builtin_class_func_with(tsrv_id, "open", tcp_server_new, 1, 2, false);
+    globals.define_builtin_func(tsrv_id, "accept", tcp_server_accept, 0);
+    globals.define_builtin_func(tsrv_id, "listen", socket_listen, 1);
+
+    // `connect_timeout:` / `open_timeout:` (net/http and Socket.tcp pass
+    // them) are accepted; nil/absent means wait indefinitely.
+    globals.define_builtin_class_func_with_kw(
+        tcps_id,
+        "new",
+        tcp_socket_new,
+        2,
+        4,
+        false,
+        &["connect_timeout", "open_timeout"],
+        false,
+    );
+    globals.define_builtin_class_func_with_kw(
+        tcps_id,
+        "open",
+        tcp_socket_new,
+        2,
+        4,
+        false,
+        &["connect_timeout", "open_timeout"],
+        false,
+    );
+
+    // Socket.new(domain, type, protocol = 0): a real socket(2). Without
+    // this, `Socket.new(Socket::AF_INET, ...)` fell through to the
+    // inherited `IO.new(2, ...)` — which took *ownership of stderr*
+    // (AF_INET == 2 read as an fd) and closed it later, cascading into
+    // fd-2 reuse chaos across a whole mspec process.
+    globals.define_builtin_class_func_with(sock_id, "new", socket_new, 2, 3, false);
+    globals.define_builtin_class_func_with(sock_id, "open", socket_new, 2, 3, false);
+
+    globals.define_builtin_class_func(ip_id, "getaddress", ip_getaddress, 1);
+    globals.define_builtin_func_with(ip_id, "addr", socket_addr, 0, 1, false);
+    globals.define_builtin_func_with(ip_id, "peeraddr", socket_peeraddr, 0, 1, false);
+
+    globals.define_builtin_func(basic_id, "setsockopt", setsockopt, 3);
+    globals.define_builtin_func(basic_id, "getsockopt", getsockopt, 2);
+    globals.define_builtin_func_with(basic_id, "shutdown", shutdown_, 0, 1, false);
+}
+
+/// The socket constants exposed as `Socket::X` / `Socket::Constants::X`.
+/// Values come from libc so they are correct per target OS.
+const SOCKET_CONSTANTS: &[(&str, i64)] = &[
+    ("AF_UNSPEC", libc::AF_UNSPEC as i64),
+    ("AF_INET", libc::AF_INET as i64),
+    ("AF_INET6", libc::AF_INET6 as i64),
+    ("AF_UNIX", libc::AF_UNIX as i64),
+    ("PF_UNSPEC", libc::PF_UNSPEC as i64),
+    ("PF_INET", libc::PF_INET as i64),
+    ("PF_INET6", libc::PF_INET6 as i64),
+    ("PF_UNIX", libc::PF_UNIX as i64),
+    ("SOCK_STREAM", libc::SOCK_STREAM as i64),
+    ("SOCK_DGRAM", libc::SOCK_DGRAM as i64),
+    ("SOCK_RAW", libc::SOCK_RAW as i64),
+    ("SOCK_SEQPACKET", libc::SOCK_SEQPACKET as i64),
+    ("SOL_SOCKET", libc::SOL_SOCKET as i64),
+    ("IPPROTO_IP", libc::IPPROTO_IP as i64),
+    ("IPPROTO_TCP", libc::IPPROTO_TCP as i64),
+    ("IPPROTO_UDP", libc::IPPROTO_UDP as i64),
+    ("IPPROTO_IPV6", libc::IPPROTO_IPV6 as i64),
+    ("TCP_NODELAY", libc::TCP_NODELAY as i64),
+    ("SO_REUSEADDR", libc::SO_REUSEADDR as i64),
+    ("SO_REUSEPORT", libc::SO_REUSEPORT as i64),
+    ("SO_KEEPALIVE", libc::SO_KEEPALIVE as i64),
+    ("SO_ERROR", libc::SO_ERROR as i64),
+    ("SO_LINGER", libc::SO_LINGER as i64),
+    ("SO_RCVBUF", libc::SO_RCVBUF as i64),
+    ("SO_SNDBUF", libc::SO_SNDBUF as i64),
+    ("SO_TYPE", libc::SO_TYPE as i64),
+    ("SO_BROADCAST", libc::SO_BROADCAST as i64),
+    ("SO_OOBINLINE", libc::SO_OOBINLINE as i64),
+    ("SHUT_RD", libc::SHUT_RD as i64),
+    ("SHUT_WR", libc::SHUT_WR as i64),
+    ("SHUT_RDWR", libc::SHUT_RDWR as i64),
+    ("MSG_PEEK", libc::MSG_PEEK as i64),
+    ("MSG_OOB", libc::MSG_OOB as i64),
+    ("MSG_WAITALL", libc::MSG_WAITALL as i64),
+    ("INADDR_ANY", 0),
+    ("INADDR_LOOPBACK", 0x7f00_0001),
+    ("INADDR_BROADCAST", 0xffff_ffff),
+    ("IPV6_V6ONLY", libc::IPV6_V6ONLY as i64),
+    ("SOMAXCONN", libc::SOMAXCONN as i64),
+];
+
+/// `SocketError` with the given message.
+fn socket_error(store: &Store, msg: impl Into<String>) -> MonorubyErr {
+    let cid = store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("SocketError"))
+        .and_then(|v| v.is_class_or_module())
+        .map(|m| m.id());
+    match cid {
+        Some(cid) => MonorubyErr::new(MonorubyErrKind::Other(cid), msg.into()),
+        None => MonorubyErr::runtimeerr(msg.into()),
+    }
+}
+
+/// The appropriate `Errno::E*` for the current `errno`.
+fn last_errno_err(store: &Store, ctx: &str) -> MonorubyErr {
+    let err = std::io::Error::last_os_error();
+    let msg = format!("{} - {}", err, ctx);
+    MonorubyErr::from_io_err(store, &err, msg)
+}
+
+fn errno_err(store: &Store, errno: i32, ctx: &str) -> MonorubyErr {
+    let err = std::io::Error::from_raw_os_error(errno);
+    let msg = format!("{} - {}", err, ctx);
+    MonorubyErr::from_io_err(store, &err, msg)
+}
+
+/// host argument: nil → None, String → Some. Anything else is CRuby's
+/// implicit-conversion TypeError.
+fn value_to_host(globals: &Globals, v: Value) -> Result<Option<String>> {
+    if v.is_nil() {
+        return Ok(None);
+    }
+    match v.is_str() {
+        Some(s) if s.is_empty() => Ok(None),
+        Some(s) => Ok(Some(s.to_string())),
+        None => Err(MonorubyErr::typeerr(format!(
+            "no implicit conversion of {} into String",
+            globals.store.get_class_name(v.class())
+        ))),
+    }
+}
+
+/// port argument: Integer, or a numeric String ("0", "8080").
+fn value_to_port(globals: &Globals, v: Value) -> Result<u16> {
+    if let Some(i) = v.try_fixnum() {
+        if (0..=65535).contains(&i) {
+            return Ok(i as u16);
+        }
+        return Err(socket_error(&globals.store, "getaddrinfo: Servname not supported"));
+    }
+    if let Some(s) = v.is_str()
+        && let Ok(i) = s.trim().parse::<u16>()
+    {
+        return Ok(i);
+    }
+    Err(socket_error(
+        &globals.store,
+        "getaddrinfo: Servname not supported for ai_socktype",
+    ))
+}
+
+/// Resolve `host` to an IPv4 address (network byte order). `for_bind`
+/// selects the nil default: INADDR_ANY for servers, loopback for clients.
+fn resolve_ipv4(store: &Store, host: Option<&str>, for_bind: bool) -> Result<u32> {
+    let host = match host {
+        None => {
+            return Ok(if for_bind {
+                u32::to_be(libc::INADDR_ANY)
+            } else {
+                u32::to_be(libc::INADDR_LOOPBACK)
+            });
+        }
+        Some(h) => h,
+    };
+    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+        return Ok(u32::from_ne_bytes(ip.octets()));
+    }
+    // Name lookup via getaddrinfo(3), IPv4/stream only. Local names
+    // (localhost, /etc/hosts entries) resolve without network traffic;
+    // anything slower is accepted as a blocking call, like CRuby without
+    // the resolv replacement.
+    let c_host = std::ffi::CString::new(host)
+        .map_err(|_| socket_error(store, "getaddrinfo: Name or service not known"))?;
+    // SAFETY: hints is a plain zeroed struct we fill; res is an out
+    // pointer freed with freeaddrinfo on success.
+    unsafe {
+        let mut hints: libc::addrinfo = std::mem::zeroed();
+        hints.ai_family = libc::AF_INET;
+        hints.ai_socktype = libc::SOCK_STREAM;
+        let mut res: *mut libc::addrinfo = std::ptr::null_mut();
+        let rc = libc::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut res);
+        if rc != 0 {
+            let msg = std::ffi::CStr::from_ptr(libc::gai_strerror(rc)).to_string_lossy();
+            return Err(socket_error(store, format!("getaddrinfo: {msg}")));
+        }
+        let mut cur = res;
+        while !cur.is_null() {
+            let ai = &*cur;
+            if ai.ai_family == libc::AF_INET && !ai.ai_addr.is_null() {
+                let sin = &*(ai.ai_addr as *const libc::sockaddr_in);
+                let addr = sin.sin_addr.s_addr;
+                libc::freeaddrinfo(res);
+                return Ok(addr);
+            }
+            cur = ai.ai_next;
+        }
+        libc::freeaddrinfo(res);
+        Err(socket_error(store, "getaddrinfo: Name or service not known"))
+    }
+}
+
+fn sockaddr_in(addr_be: u32, port: u16) -> libc::sockaddr_in {
+    // SAFETY: sockaddr_in is plain-old-data; zeroing is a valid initial state.
+    let mut sin: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+    sin.sin_family = libc::AF_INET as libc::sa_family_t;
+    sin.sin_port = port.to_be();
+    sin.sin_addr = libc::in_addr { s_addr: addr_be };
+    sin
+}
+
+/// A new non-blocking, close-on-exec TCP socket fd.
+fn new_tcp_fd(store: &Store) -> Result<i32> {
+    // SAFETY: plain socket(2).
+    let fd = unsafe {
+        libc::socket(
+            libc::AF_INET,
+            libc::SOCK_STREAM | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+            0,
+        )
+    };
+    if fd < 0 {
+        return Err(last_errno_err(store, "socket(2)"));
+    }
+    Ok(fd)
+}
+
+/// Clear O_NONBLOCK: connected/accepted stream sockets are handed to the
+/// generic IO layer in blocking mode (the blocking-IO emulation flips the
+/// flag per operation as needed).
+fn set_blocking(fd: i32) {
+    // SAFETY: fcntl on an fd we own; best-effort.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags >= 0 {
+            libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+        }
+    }
+}
+
+/// Park until `fd` reports `events`: on the scheduler's fd poller when
+/// another green thread could run, else a plain signal-interruptible
+/// poll(2).
+fn park_on_fd(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    fd: i32,
+    events: i16,
+    deadline: Option<std::time::Instant>,
+) -> Result<()> {
+    if crate::scheduler::has_other_live_threads() {
+        crate::scheduler::wait_fd(vm, globals, fd, events, deadline)
+    } else if deadline.is_some() {
+        // Deadline-limited single-thread wait: poll with a timeout.
+        loop {
+            let remain = deadline
+                .unwrap()
+                .saturating_duration_since(std::time::Instant::now());
+            if remain.is_zero() {
+                return Ok(());
+            }
+            let mut pfd = libc::pollfd {
+                fd,
+                events,
+                revents: 0,
+            };
+            // SAFETY: one pollfd, length 1.
+            let ret = unsafe { libc::poll(&mut pfd, 1, remain.as_millis().min(i32::MAX as u128) as i32) };
+            if ret >= 0 {
+                return Ok(());
+            }
+            let e = std::io::Error::last_os_error();
+            if e.kind() != std::io::ErrorKind::Interrupted {
+                return Err(MonorubyErr::from_io_err(&globals.store, &e, "poll(2)".into()));
+            }
+            if crate::executor::execute_gc(vm, globals).is_none() {
+                return Err(vm.take_error());
+            }
+        }
+    } else {
+        crate::builtins::io::wait_fd_single(vm, globals, fd, events)
+    }
+}
+
+/// The `TCPSocket` class (accepted connections are TCPSocket even when
+/// accepted on a TCPServer subclass).
+fn tcpsocket_class(store: &Store) -> ClassId {
+    store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("TCPSocket"))
+        .unwrap()
+        .as_class()
+        .id()
+}
+
+///
+/// ### TCPServer.new
+///
+/// - new([host,] port) -> TCPServer
+///
+/// Binds an IPv4 listener. The listener fd is left permanently
+/// non-blocking for `accept`'s park-and-retry loop.
+#[monoruby_builtin]
+fn tcp_server_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let (host, port) = match lfp.try_arg(1) {
+        Some(p) => (
+            value_to_host(globals, lfp.arg(0))?,
+            value_to_port(globals, p)?,
+        ),
+        None => (None, value_to_port(globals, lfp.arg(0))?),
+    };
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), true)?;
+    let fd = new_tcp_fd(&globals.store)?;
+    let sin = sockaddr_in(addr, port);
+    // SAFETY: fd is a fresh socket we own; sin is a valid sockaddr_in.
+    unsafe {
+        let one: i32 = 1;
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_REUSEADDR,
+            &one as *const i32 as *const libc::c_void,
+            std::mem::size_of::<i32>() as libc::socklen_t,
+        );
+        if libc::bind(
+            fd,
+            &sin as *const libc::sockaddr_in as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ) < 0
+        {
+            let err = last_errno_err(&globals.store, &format!("bind(2) for {:?} port {}",
+                host.as_deref().unwrap_or("0.0.0.0"), port));
+            libc::close(fd);
+            return Err(err);
+        }
+        if libc::listen(fd, libc::SOMAXCONN) < 0 {
+            let err = last_errno_err(&globals.store, "listen(2)");
+            libc::close(fd);
+            return Err(err);
+        }
+    }
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let res = Value::new_socket(file, "TCPServer".into(), class_id);
+    if let Some(bh) = lfp.block() {
+        // `TCPServer.open(...) { |server| ... }` closes at block exit,
+        // like IO.open.
+        let r = vm.invoke_block_once(globals, bh, &[res]);
+        return super::file::block_close(vm, globals, res, r);
+    }
+    Ok(res)
+}
+
+///
+/// ### TCPServer#accept
+///
+/// - accept -> TCPSocket
+///
+/// Parks the calling green thread until a connection arrives. Raises
+/// IOError when the server is closed (also from another thread while
+/// parked — the poller wakes on the dead fd and the closed check re-runs).
+#[monoruby_builtin]
+fn tcp_server_accept(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let mut parked = false;
+    loop {
+        if self_.as_io_inner().is_closed() {
+            // CRuby: "closed stream" for an accept on an already-closed
+            // server; "stream closed in another thread" when the close
+            // happened while this accept was parked.
+            return Err(MonorubyErr::ioerr(if parked {
+                "stream closed in another thread"
+            } else {
+                "closed stream"
+            }));
+        }
+        let fd = self_.as_io_inner().fileno()?;
+        // SAFETY: accept4 on our listener fd; out params unused (NULL).
+        let conn = unsafe {
+            libc::accept4(
+                fd,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                libc::SOCK_CLOEXEC,
+            )
+        };
+        if conn >= 0 {
+            // SAFETY: conn is a fresh, owned fd from accept4.
+            let file = unsafe { std::fs::File::from_raw_fd(conn) };
+            return Ok(Value::new_socket(
+                file,
+                "TCPSocket".into(),
+                tcpsocket_class(&globals.store),
+            ));
+        }
+        let errno = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+        match errno {
+            libc::EAGAIN | libc::EINTR | libc::ECONNABORTED => {
+                // Reach a poll point first (signal / preemption /
+                // Thread#kill), then park until the fd is readable.
+                if crate::executor::execute_gc(vm, globals).is_none() {
+                    return Err(vm.take_error());
+                }
+                if errno == libc::EAGAIN {
+                    parked = true;
+                    park_on_fd(vm, globals, fd, libc::POLLIN, None)?;
+                }
+            }
+            _ => return Err(errno_err(&globals.store, errno, "accept(2)")),
+        }
+    }
+}
+
+///
+/// ### TCPServer#listen
+///
+/// - listen(backlog) -> 0
+///
+#[monoruby_builtin]
+fn socket_listen(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let backlog = lfp.arg(0).coerce_to_i64(&globals.store)? as i32;
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: listen(2) on our fd.
+    if unsafe { libc::listen(fd, backlog) } < 0 {
+        return Err(last_errno_err(&globals.store, "listen(2)"));
+    }
+    Ok(Value::integer(0))
+}
+
+///
+/// ### TCPSocket.new
+///
+/// - new(host, port, local_host = nil, local_port = nil, connect_timeout: nil, open_timeout: nil) -> TCPSocket
+///
+/// Non-blocking connect: `EINPROGRESS`, park on POLLOUT (bounded by
+/// `connect_timeout` / `open_timeout`), then check `SO_ERROR`. The fd is
+/// restored to blocking mode before it is handed to the IO layer.
+#[monoruby_builtin]
+fn tcp_socket_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let host = value_to_host(globals, lfp.arg(0))?;
+    let port = value_to_port(globals, lfp.arg(1))?;
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), false)?;
+    // kw slots: arg(4) = connect_timeout, arg(5) = open_timeout. CRuby
+    // treats open_timeout as an overall bound (resolution + connect);
+    // resolution is synchronous here, so both bound the connect wait.
+    let mut timeout = None;
+    for slot in [4, 5] {
+        if let Some(v) = lfp.try_arg(slot)
+            && !v.is_nil()
+        {
+            let secs = v.coerce_to_f64(vm, globals)?;
+            let d = std::time::Duration::from_secs_f64(secs.max(0.0));
+            timeout = Some(timeout.map_or(d, |t: std::time::Duration| t.min(d)));
+        }
+    }
+    let fd = new_tcp_fd(&globals.store)?;
+    // Optional local bind (local_host, local_port).
+    if let Some(lh) = lfp.try_arg(2)
+        && (!lh.is_nil() || lfp.try_arg(3).is_some_and(|v| !v.is_nil()))
+    {
+        let lhost = value_to_host(globals, lh)?;
+        let lport = match lfp.try_arg(3) {
+            Some(v) if !v.is_nil() => value_to_port(globals, v)?,
+            _ => 0,
+        };
+        let laddr = resolve_ipv4(&globals.store, lhost.as_deref(), true)?;
+        let lsin = sockaddr_in(laddr, lport);
+        // SAFETY: bind(2) on our fresh fd.
+        if unsafe {
+            libc::bind(
+                fd,
+                &lsin as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            )
+        } < 0
+        {
+            let err = last_errno_err(&globals.store, "bind(2)");
+            // SAFETY: closing the fd we just opened.
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+    }
+    let sin = sockaddr_in(addr, port);
+    // SAFETY: connect(2) on our fresh non-blocking fd.
+    let rc = unsafe {
+        libc::connect(
+            fd,
+            &sin as *const libc::sockaddr_in as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        let errno = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+        if errno != libc::EINPROGRESS && errno != libc::EINTR {
+            // SAFETY: closing the fd we just opened.
+            unsafe { libc::close(fd) };
+            return Err(errno_err(&globals.store, errno, &connect_ctx(host.as_deref(), port)));
+        }
+        let deadline = timeout.map(|t| std::time::Instant::now() + t);
+        loop {
+            if let Err(e) = park_on_fd(vm, globals, fd, libc::POLLOUT, deadline) {
+                // SAFETY: closing the fd we own.
+                unsafe { libc::close(fd) };
+                return Err(e);
+            }
+            // Connection settled (or deadline passed): read SO_ERROR.
+            let mut soerr: i32 = 0;
+            let mut len = std::mem::size_of::<i32>() as libc::socklen_t;
+            // SAFETY: getsockopt out-params sized to an i32.
+            unsafe {
+                libc::getsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_ERROR,
+                    &mut soerr as *mut i32 as *mut libc::c_void,
+                    &mut len,
+                );
+            }
+            if soerr == 0 {
+                // Either connected, or still in progress after a spurious
+                // wake. Distinguish with a zero-timeout POLLOUT check.
+                let mut pfd = libc::pollfd {
+                    fd,
+                    events: libc::POLLOUT,
+                    revents: 0,
+                };
+                // SAFETY: one pollfd, length 1, timeout 0.
+                let ready = unsafe { libc::poll(&mut pfd, 1, 0) };
+                if ready > 0 {
+                    break;
+                }
+                if let Some(dl) = deadline
+                    && std::time::Instant::now() >= dl
+                {
+                    // SAFETY: closing the fd we own.
+                    unsafe { libc::close(fd) };
+                    return Err(errno_err(
+                        &globals.store,
+                        libc::ETIMEDOUT,
+                        &connect_ctx(host.as_deref(), port),
+                    ));
+                }
+                continue;
+            }
+            // SAFETY: closing the fd we own.
+            unsafe { libc::close(fd) };
+            return Err(errno_err(&globals.store, soerr, &connect_ctx(host.as_deref(), port)));
+        }
+    }
+    set_blocking(fd);
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let res = Value::new_socket(file, "TCPSocket".into(), class_id);
+    if let Some(bh) = lfp.block() {
+        // `TCPSocket.open(...) { |sock| ... }` closes at block exit, like
+        // IO.open — the net-http spec fixture stops its server exactly
+        // this way (connect, write "CLOSE", implicit close).
+        let r = vm.invoke_block_once(globals, bh, &[res]);
+        return super::file::block_close(vm, globals, res, r);
+    }
+    Ok(res)
+}
+
+///
+/// ### Socket.new
+///
+/// - new(domain, type, protocol = 0) -> Socket
+///
+/// Accepts Integer constants or their Symbol/String shorthand
+/// (`:INET` / `"AF_INET"`, `:STREAM` / `"SOCK_STREAM"`).
+#[monoruby_builtin]
+fn socket_new(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let domain = family_const(&globals.store, lfp.arg(0))?;
+    let stype = type_const(&globals.store, lfp.arg(1))?;
+    let proto = match lfp.try_arg(2) {
+        Some(v) if !v.is_nil() => v.coerce_to_i64(&globals.store)? as i32,
+        _ => 0,
+    };
+    // SAFETY: plain socket(2).
+    let fd = unsafe { libc::socket(domain, stype | libc::SOCK_CLOEXEC, proto) };
+    if fd < 0 {
+        return Err(last_errno_err(&globals.store, "socket(2)"));
+    }
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    Ok(Value::new_socket(file, "Socket".into(), class_id))
+}
+
+/// Address-family argument: Integer, or `:INET` / `"AF_INET"` style.
+fn family_const(store: &Store, v: Value) -> Result<i32> {
+    named_const(store, v, "AF_")
+}
+
+/// Socket-type argument: Integer, or `:STREAM` / `"SOCK_STREAM"` style.
+fn type_const(store: &Store, v: Value) -> Result<i32> {
+    named_const(store, v, "SOCK_")
+}
+
+fn named_const(store: &Store, v: Value, prefix: &str) -> Result<i32> {
+    if let Some(i) = v.try_fixnum() {
+        return Ok(i as i32);
+    }
+    let name = if let Some(s) = v.is_str() {
+        s.to_string()
+    } else if let Some(id) = v.try_symbol() {
+        id.get_name()
+    } else {
+        return Err(MonorubyErr::typeerr(
+            "socket domain/type should be an Integer, String or Symbol".to_string(),
+        ));
+    };
+    let upper = name.to_uppercase();
+    for cand in [upper.clone(), format!("{prefix}{upper}")] {
+        if let Some((_, val)) = SOCKET_CONSTANTS.iter().find(|(n, _)| *n == cand) {
+            return Ok(*val as i32);
+        }
+    }
+    Err(socket_error(store, format!("unknown socket domain/type: {name}")))
+}
+
+fn connect_ctx(host: Option<&str>, port: u16) -> String {
+    format!(
+        "connect(2) for \"{}\" port {}",
+        host.unwrap_or("127.0.0.1"),
+        port
+    )
+}
+
+///
+/// ### IPSocket.getaddress
+///
+/// - getaddress(host) -> String
+///
+#[monoruby_builtin]
+fn ip_getaddress(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let host = value_to_host(globals, lfp.arg(0))?;
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), false)?;
+    Ok(Value::string(
+        std::net::Ipv4Addr::from(u32::from_be(addr)).to_string(),
+    ))
+}
+
+/// `["AF_INET", port, numeric_ip, numeric_ip]` for getsockname /
+/// getpeername (numeric form — monoruby always behaves as
+/// `do_not_reverse_lookup = true`).
+fn addr_common(store: &Store, io: Value, peer: bool) -> Result<Value> {
+    let fd = io.as_io_inner().fileno()?;
+    // SAFETY: out-params sized to a sockaddr_in.
+    let (sin, rc) = unsafe {
+        let mut sin: libc::sockaddr_in = std::mem::zeroed();
+        let mut len = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+        let p = &mut sin as *mut libc::sockaddr_in as *mut libc::sockaddr;
+        let rc = if peer {
+            libc::getpeername(fd, p, &mut len)
+        } else {
+            libc::getsockname(fd, p, &mut len)
+        };
+        (sin, rc)
+    };
+    if rc < 0 {
+        return Err(last_errno_err(
+            store,
+            if peer { "getpeername(2)" } else { "getsockname(2)" },
+        ));
+    }
+    let ip = std::net::Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr)).to_string();
+    let port = u16::from_be(sin.sin_port) as i64;
+    Ok(Value::array_from_vec(vec![
+        Value::string("AF_INET".to_string()),
+        Value::integer(port),
+        Value::string(ip.clone()),
+        Value::string(ip),
+    ]))
+}
+
+///
+/// ### IPSocket#addr
+///
+#[monoruby_builtin]
+fn socket_addr(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    addr_common(&globals.store, lfp.self_val(), false)
+}
+
+///
+/// ### IPSocket#peeraddr
+///
+#[monoruby_builtin]
+fn socket_peeraddr(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    addr_common(&globals.store, lfp.self_val(), true)
+}
+
+/// level / optname arguments: Integer, or Symbol/String constant name with
+/// the usual CRuby prefix shorthand (`:REUSEADDR` == `SO_REUSEADDR`,
+/// `:TCP` == `IPPROTO_TCP`, ...).
+fn opt_const(store: &Store, v: Value) -> Result<i32> {
+    if let Some(i) = v.try_fixnum() {
+        return Ok(i as i32);
+    }
+    let name = if let Some(s) = v.is_str() {
+        s.to_string()
+    } else if let Some(id) = v.try_symbol() {
+        id.get_name()
+    } else {
+        return Err(MonorubyErr::typeerr(
+            "socket option should be an Integer, String or Symbol".to_string(),
+        ));
+    };
+    let upper = name.to_uppercase();
+    for cand in [
+        upper.clone(),
+        format!("SO_{upper}"),
+        format!("SOL_{upper}"),
+        format!("IPPROTO_{upper}"),
+        format!("TCP_{upper}"),
+    ] {
+        if let Some((_, val)) = SOCKET_CONSTANTS.iter().find(|(n, _)| *n == cand) {
+            return Ok(*val as i32);
+        }
+    }
+    Err(socket_error(store, format!("unknown socket option: {name}")))
+}
+
+///
+/// ### BasicSocket#setsockopt
+///
+/// - setsockopt(level, optname, optval) -> 0
+///
+#[monoruby_builtin]
+fn setsockopt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let level = opt_const(&globals.store, lfp.arg(0))?;
+    let optname = opt_const(&globals.store, lfp.arg(1))?;
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    let v = lfp.arg(2);
+    let bytes: Vec<u8> = if let Some(i) = v.try_fixnum() {
+        (i as i32).to_ne_bytes().to_vec()
+    } else if let Some(s) = v.is_rstring() {
+        // Raw struct form (e.g. a packed linger).
+        s.to_vec()
+    } else {
+        // true / false (and anything else truthy) as a boolean int option.
+        (if v.as_bool() { 1i32 } else { 0i32 })
+            .to_ne_bytes()
+            .to_vec()
+    };
+    // SAFETY: setsockopt with a length-matched byte buffer.
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            optname,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(last_errno_err(&globals.store, "setsockopt(2)"));
+    }
+    Ok(Value::integer(0))
+}
+
+///
+/// ### BasicSocket#getsockopt
+///
+/// - getsockopt(level, optname) -> Integer
+///
+/// Returns the option's raw int value (CRuby returns a Socket::Option;
+/// the common `.int` / `.bool` consumers can use the Integer directly).
+#[monoruby_builtin]
+fn getsockopt(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let level = opt_const(&globals.store, lfp.arg(0))?;
+    let optname = opt_const(&globals.store, lfp.arg(1))?;
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    let mut val: i32 = 0;
+    let mut len = std::mem::size_of::<i32>() as libc::socklen_t;
+    // SAFETY: out-params sized to an i32.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            level,
+            optname,
+            &mut val as *mut i32 as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc < 0 {
+        return Err(last_errno_err(&globals.store, "getsockopt(2)"));
+    }
+    Ok(Value::integer(val as i64))
+}
+
+///
+/// ### BasicSocket#shutdown
+///
+/// - shutdown(how = Socket::SHUT_RDWR) -> 0
+///
+#[monoruby_builtin]
+fn shutdown_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let how = match lfp.try_arg(0) {
+        None => libc::SHUT_RDWR,
+        Some(v) => {
+            if let Some(i) = v.try_fixnum() {
+                i as i32
+            } else {
+                let name = if let Some(s) = v.is_str() {
+                    s.to_uppercase()
+                } else if let Some(id) = v.try_symbol() {
+                    id.get_name().to_uppercase()
+                } else {
+                    return Err(MonorubyErr::typeerr("bad shutdown argument".to_string()));
+                };
+                match name.trim_start_matches("SHUT_") {
+                    "RD" => libc::SHUT_RD,
+                    "WR" => libc::SHUT_WR,
+                    "RDWR" => libc::SHUT_RDWR,
+                    _ => {
+                        return Err(socket_error(
+                            &globals.store,
+                            format!("unknown shutdown argument: {name}"),
+                        ));
+                    }
+                }
+            }
+        }
+    };
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: shutdown(2) on our fd.
+    if unsafe { libc::shutdown(fd, how) } < 0 {
+        return Err(last_errno_err(&globals.store, "shutdown(2)"));
+    }
+    Ok(Value::integer(0))
+}

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -578,17 +578,34 @@ mod tests {
 
     #[test]
     fn thread_concurrency_with_queue_like_handoff() {
-        // The spawned thread must not run at Thread.new time; it runs
-        // when the main thread blocks (join), and both make progress.
+        // Both threads make progress and join works. The relative order
+        // of `:thread` vs. a main-side append *before* the join is
+        // deliberately not asserted against CRuby: monoruby's
+        // `Thread.new` eagerly runs the new thread's first slice (so
+        // fixture-style server threads reach their accept/park before
+        // `new` returns), whereas CRuby's GVL usually lets the creator
+        // continue first. Sequencing after `join` is identical on both.
         run_test_once(
             r#"
             order = []
             t = Thread.new { order << :thread }
-            order << :main
             t.join
+            order << :main
             order
             "#,
         );
+        // monoruby-specific eager-start guarantee: the body has run to
+        // its first blocking point (here: completion) before Thread.new
+        // returns.
+        let v = run_test_no_result_check(
+            r#"
+            order = []
+            Thread.new { order << :thread }
+            order << :main
+            order.inspect
+            "#,
+        );
+        assert_eq!("[:thread, :main]", v.as_str());
         // Two threads interleave at sleep points.
         run_test_once(
             r#"

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -291,8 +291,15 @@ pub(crate) extern "C" fn thread_alloc_func(class_id: ClassId, _: &mut Globals) -
 ///
 /// - new(*args) {|*args| ... } -> Thread
 ///
-/// Creates a green thread running the block and queues it; the body gets
-/// its first time slice at the next blocking point of any thread.
+/// Creates a green thread running the block, queues it, and immediately
+/// yields one time slice so the body starts before `new` returns (up to
+/// its first park). CRuby starts a new thread concurrently right away;
+/// deferring the first slice to "whenever anything next blocks" leaves a
+/// spawned-but-never-started thread behind whenever the spawner never
+/// blocks again — the thread then fires much later against torn-down
+/// state (ruby/spec's socket files: a stale accept thread from a
+/// finished example stole the next example's connection through a reused
+/// fd, deadlocking the file).
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/new.html]
 #[monoruby_builtin]
@@ -311,6 +318,10 @@ fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
     let class_id = lfp.self_val().as_class_id();
     let thread = Value::new_thread(class_id, ThreadInner::new(proc, args));
     scheduler::spawn(vm, thread);
+    // The eager first slice must keep `thread` (and this frame's Values)
+    // rooted: `pass` is a scheduler entry (GC-safe park point), and
+    // `thread` is reachable via the scheduler registry.
+    scheduler::pass(vm, globals)?;
     Ok(thread)
 }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -673,6 +673,17 @@ impl<'a> JitContext<'a> {
             None,
             callid,
         )?;
+        // The call site passes a block literal: if the callee heapifies
+        // its *own* frame during the call (`Proc.new` / `lambda` /
+        // `binding`), `materialize_escaped_block_handlers` turns the
+        // passed block handler into a Proc — whose home is THIS frame —
+        // and promotes this frame to the heap as well. Mirror the
+        // generic-send rule (see `compile_method_call`): drop the
+        // no-capture invariant so the result store below goes via the
+        // LFP and `immediate_evict` emits a capture guard.
+        if self.store[callid].block_fid.is_some() {
+            state.unset_no_capture_guard(self);
+        }
         let evict = ir.new_evict();
         state.send_specialized(
             ir,
@@ -1270,6 +1281,41 @@ impl AbstractState {
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    /// Regression test: a specialized (inlined-compiled) callee that
+    /// captures its own frame (`Proc.new` with a literal block) while the
+    /// call site passes a block literal. Materializing the escaped block
+    /// handler promotes the *caller's* frame to the heap mid-call
+    /// (`materialize_escaped_block_handlers`), so the caller's result
+    /// store must go via the LFP — an rbp-relative store lands on the
+    /// abandoned stack frame and the result reads back as nil after the
+    /// capture deopt. This is the `Timeout.timeout` shape: its `perform`
+    /// proc's non-local `return yield(sec)` silently became nil once the
+    /// caller was JIT-compiled, so `Net::HTTP#connect` saw a nil socket.
+    #[test]
+    fn specialized_call_result_survives_transitive_capture() {
+        run_test(
+            r#"
+            def tmo(klass)
+              perform = Proc.new do
+                begin
+                  return :tok
+                ensure
+                  @x = 1
+                end
+              end
+              if klass
+                perform.call
+              else
+                dummy(&perform)
+              end
+            end
+            res = []
+            50.times { |n| res << (tmo(RuntimeError) { :blk }) }
+            res
+            "#,
+        );
+    }
 
     /// Regression test for issue #405. After JIT compilation of a block
     /// passed to `Array#map`, calls inside the block that raise and are

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -386,21 +386,51 @@ impl AbstractFrame {
                 // returns are tainted to `Value` upstream by
                 // `taint_for_unmodeled_rescue`, so what arrives here is
                 // a true compile-time constant — safe to fold into the
-                // caller's abstract state.
+                // caller's abstract state. (No machine store happens, so
+                // a capture during the call is harmless here: deopt
+                // write-backs address slots via the LFP.)
                 ReturnValue::Const(v) => {
                     self.def_C(dst, v);
                 }
                 ReturnValue::Class(class) => {
-                    self.def_reg2acc_class(ir, GP::Rax, dst, class);
+                    self.def_return_store_guarded(ir, GP::Rax, dst, slot::Guarded::from_class(class));
                 }
                 ReturnValue::Value => {
-                    self.def_rax2acc(ir, dst);
+                    self.def_return_store_guarded(ir, GP::Rax, dst, slot::Guarded::Value);
                 }
             }
             CompileResult::Continue
         } else {
             ir.push(AsmInst::Unreachable);
             CompileResult::Cease
+        }
+    }
+
+    /// Store a specialized-call / specialized-yield result from `src`.
+    /// On the fast path (`no_capture_guard` holds) this is the ordinary
+    /// rbp-relative slot store. When the invariant is broken — the callee
+    /// may have moved this frame to the heap during the call, e.g. by
+    /// capturing its own frame with `Proc.new`, which makes
+    /// `materialize_escaped_block_handlers` promote this frame too when
+    /// the call site passed a block literal — the store must go via the
+    /// LFP (r14, reloaded from `cfp.lfp` after the call) so it lands on
+    /// whichever frame is live, exactly like `def_rax2acc_capturing`.
+    /// The `GuardCapture` deopt that `immediate_evict` emits afterwards
+    /// only re-homes register residents, never an rbp-stored `S` slot.
+    fn def_return_store_guarded(
+        &mut self,
+        ir: &mut AsmIr,
+        src: GP,
+        dst: impl Into<Option<SlotId>>,
+        guarded: slot::Guarded,
+    ) {
+        if let Some(dst) = dst.into() {
+            if self.no_capture_guard() {
+                ir.reg2stack(src, dst);
+            } else {
+                ir.reg2lfp_stack(src, dst);
+            }
+            self.def_S_guarded(dst, guarded);
         }
     }
 

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -103,6 +103,15 @@ pub(crate) struct Scheduler {
     /// it stays true while a *dispatched thread* runs, which is exactly
     /// when preemption must be allowed.
     machinery: bool,
+    /// Pre-rendered report_on_exception texts queued by thread
+    /// finalization (machinery context, where invoking Ruby is
+    /// forbidden), delivered through the Ruby-level `$stderr` at the next
+    /// safepoint in a normal context (`flush_pending_reports`).
+    pending_reports: Vec<String>,
+    /// Re-entrancy latch for `flush_pending_reports`: the `$stderr.write`
+    /// invoke can itself park (full pipe), and the park entry is a flush
+    /// point.
+    flushing_reports: bool,
 }
 
 impl Scheduler {
@@ -117,6 +126,8 @@ impl Scheduler {
             main_exec: None,
             in_scheduler: false,
             machinery: false,
+            pending_reports: vec![],
+            flushing_reports: false,
         }
     }
 
@@ -348,6 +359,7 @@ pub(crate) fn sleep(
     dur: Option<Duration>,
 ) -> Result<Duration> {
     ensure_main(vm);
+    flush_pending_reports(vm, globals);
     // A pending interrupt allowed at blocking points fires *instead of*
     // parking (also the case where it was queued while running).
     let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
@@ -376,6 +388,7 @@ pub(crate) fn sleep(
             s.sleepers.push((deadline, main));
         });
         scheduler_run(vm, globals)?;
+        flush_pending_reports(vm, globals);
         take_main_pending(globals, true)?;
     } else {
         let cur = SCHEDULER.with(|s| {
@@ -393,6 +406,7 @@ pub(crate) fn sleep(
 /// `Thread.pass`: give every currently runnable thread a chance to run.
 pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
     ensure_main(vm);
+    flush_pending_reports(vm, globals);
     // `Thread.pass` is a delivery point for `:immediate` interrupts but
     // NOT for `:on_blocking` ones (it is not a blocking call).
     let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
@@ -429,7 +443,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
                 let t = SCHEDULER.with(|s| s.borrow_mut().ready.pop_front());
                 match t {
                     Some(t) => {
-                        if let Err(err) = dispatch(vm, globals, t) {
+                        if let Err(err) = dispatch(globals, t) {
                             result = Err(err);
                             break;
                         }
@@ -446,6 +460,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             s.current = Some(main);
         });
         result?;
+        flush_pending_reports(vm, globals);
         take_main_pending(globals, false)
     } else {
         let cur = SCHEDULER.with(|s| {
@@ -477,6 +492,7 @@ pub(crate) fn join(
     }
     let deadline = timeout.map(|d| Instant::now() + d);
     loop {
+        flush_pending_reports(vm, globals);
         deliver_pending_now(globals, cur, true)?;
         set_park_blocking(cur, true);
         if target.as_thread_inner().is_dead() {
@@ -755,6 +771,7 @@ pub(crate) fn wait_fds(
         let result = scheduler_run(vm, globals);
         unregister_io_waiter(SCHEDULER.with(|s| s.borrow().main.unwrap()));
         result?;
+        flush_pending_reports(vm, globals);
         take_main_pending(globals, true)
     } else {
         let cur = SCHEDULER.with(|s| {
@@ -860,7 +877,7 @@ fn scheduler_loop(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             return Ok(());
         }
         if let Some(t) = next {
-            dispatch(vm, globals, t)?;
+            dispatch(globals, t)?;
             continue;
         }
         // Nothing runnable: wait for fd readiness and/or the nearest
@@ -1028,7 +1045,7 @@ fn interruptible_sleep_until(
 }
 
 /// Run one green thread until it parks or terminates.
-fn dispatch(vm: &mut Executor, globals: &mut Globals, mut thread: Value) -> Result<()> {
+fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
     enum Entry {
         Invoke(ProcData, *const Value, usize, *mut Executor),
         Resume(*mut Executor),
@@ -1132,7 +1149,7 @@ fn dispatch(vm: &mut Executor, globals: &mut Globals, mut thread: Value) -> Resu
             ret
         }
         Entry::Skip(err) => {
-            finalize_unstarted(vm, globals, thread, err);
+            finalize_unstarted(globals, thread, err);
             SCHEDULER.with(|s| {
                 let mut s = s.borrow_mut();
                 s.current = s.main;
@@ -1142,7 +1159,7 @@ fn dispatch(vm: &mut Executor, globals: &mut Globals, mut thread: Value) -> Resu
     };
     // Control is back in the scheduler context.
     if thread.as_thread_inner().body_terminated() {
-        finalize(vm, globals, thread, ret);
+        finalize(globals, thread, ret);
     }
     SCHEDULER.with(|s| {
         let mut s = s.borrow_mut();
@@ -1154,24 +1171,19 @@ fn dispatch(vm: &mut Executor, globals: &mut Globals, mut thread: Value) -> Resu
 /// A thread killed or raised-into before its body ever ran: mark it
 /// dead without running the body (CRuby semantics for an unstarted
 /// target), record the raise as its terminating exception, wake joiners.
-fn finalize_unstarted(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    mut thread: Value,
-    err: Option<MonorubyErr>,
-) {
+fn finalize_unstarted(globals: &mut Globals, mut thread: Value, err: Option<MonorubyErr>) {
     {
         let inner = thread.as_thread_inner_mut();
         inner.killed = err.is_none();
         inner.exception = err;
         inner.result = None;
     }
-    finalize_common(vm, globals, thread);
+    finalize_common(globals, thread);
 }
 
 /// A green thread's body finished: record the outcome, wake joiners,
 /// prune the registry.
-fn finalize(vm: &mut Executor, globals: &mut Globals, mut thread: Value, ret: Option<Value>) {
+fn finalize(globals: &mut Globals, mut thread: Value, ret: Option<Value>) {
     {
         let inner = thread.as_thread_inner_mut();
         match ret {
@@ -1200,22 +1212,24 @@ fn finalize(vm: &mut Executor, globals: &mut Globals, mut thread: Value, ret: Op
             }
         }
     }
-    finalize_common(vm, globals, thread);
+    finalize_common(globals, thread);
 }
 
 /// Shared tail of thread termination: mark dead, wake joiners, report an
 /// unhandled exception per report_on_exception, prune the registry.
-fn finalize_common(vm: &mut Executor, globals: &mut Globals, mut thread: Value) {
+fn finalize_common(globals: &mut Globals, mut thread: Value) {
     // Undelivered interrupts die with the thread (CRuby drops the
     // remaining pending_interrupt_queue too) — e.g. the kill queued
     // behind the raise the thread just died from.
     thread.as_thread_inner_mut().pending.clear();
-    // Report before marking the thread dead: CRuby reports while the
-    // dying thread still has status "run" (ruby/spec matches the status
-    // word in the inspect header), and the registry entry still roots
-    // the thread (and its recorded exception) across the report's
-    // allocation / Ruby invocation.
-    report_exception(vm, globals, thread);
+    // Render the report_on_exception text now (pure Rust — this is the
+    // scheduler machinery context, where invoking Ruby is forbidden: the
+    // `$stderr.write` could park and re-enter the scheduler, corrupting
+    // the saved context; observed as a SIGSEGV in `dispatch`'s epilogue).
+    // The text is queued and written at the next normal-context
+    // safepoint by `flush_pending_reports`. Rendered before the thread
+    // is marked dead so the header shows status "run", like CRuby.
+    queue_exception_report(globals, thread);
     SCHEDULER.with(|s| {
         let mut s = s.borrow_mut();
         let inner = thread.as_thread_inner_mut();
@@ -1244,16 +1258,13 @@ fn finalize_common(vm: &mut Executor, globals: &mut Globals, mut thread: Value) 
 }
 
 /// `Thread#report_on_exception` (instance flag, falling back to the
-/// `Thread` class-level default; both default true): surface a
-/// terminating exception when the thread dies. A kill never reports, and
-/// neither does a `SystemExit` (CRuby reports an abort_on_exception
-/// forwarding, but never a SystemExit — that is the process exiting, not
-/// a crash). The report goes through the Ruby-level `$stderr` — CRuby
-/// writes it with `rb_write_error_str`, which honours a replaced
-/// `$stderr`; mspec's `output` matcher relies on exactly that. Errors
-/// during the report (broken `$stderr`, raising `inspect`) are swallowed:
-/// a report must never alter the program's outcome.
-fn report_exception(vm: &mut Executor, globals: &mut Globals, thread: Value) {
+/// `Thread` class-level default; both default true): render the report
+/// for a thread that died with an unhandled exception and queue it for
+/// delivery. A kill never reports, and neither does a `SystemExit`
+/// (CRuby reports an abort_on_exception forwarding, but never a
+/// SystemExit — that is the process exiting, not a crash). Pure Rust —
+/// no Ruby is invoked here (see the caller comment).
+fn queue_exception_report(globals: &mut Globals, thread: Value) {
     let exc = {
         let inner = thread.as_thread_inner();
         match &inner.exception {
@@ -1281,33 +1292,55 @@ fn report_exception(vm: &mut Executor, globals: &mut Globals, thread: Value) {
     if !report {
         return;
     }
-    // `#<Thread:0x... dead> terminated with exception (...)`: the header
-    // uses Thread#inspect (the spec matchers key on the `Thread` word and
-    // interpolate `t.inspect`).
-    let insp = vm
-        .invoke_method_inner(
-            globals,
-            IdentId::get_id("inspect"),
-            thread,
-            &[],
-            None,
-            None,
-        )
-        .ok()
-        .and_then(|v| v.is_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| format!("#<Thread:0x{:016x} dead>", thread.id()));
-    let text = format!("{insp} terminated with exception (report_on_exception is true):\n{exc}\n");
-    let stderr = globals
-        .get_gvar(IdentId::get_id("$stderr"))
+    // The header mirrors Thread#inspect (`#<Thread:0xADDR[@name] run>`)
+    // without calling it — the spec matchers key on the `Thread` word and
+    // interpolate `t.inspect` taken while the thread was running.
+    let name = globals
+        .store
+        .get_ivar(thread, IdentId::get_id("@name"))
+        .and_then(|v| v.is_str().map(|s| format!("@{s}")))
         .unwrap_or_default();
-    let _ = vm.invoke_method_inner(
-        globals,
-        IdentId::get_id("write"),
-        stderr,
-        &[Value::string(text)],
-        None,
-        None,
+    let text = format!(
+        "#<Thread:0x{:016x}{} run> terminated with exception (report_on_exception is true):\n{}\n",
+        thread.id(),
+        name,
+        exc
     );
+    SCHEDULER.with(|s| s.borrow_mut().pending_reports.push(text));
+}
+
+/// Write queued report_on_exception texts through the Ruby-level
+/// `$stderr` — CRuby uses `rb_write_error_str`, which honours a replaced
+/// `$stderr`; mspec's `output` matcher relies on exactly that. Called
+/// from normal (non-machinery) contexts only: the write invokes Ruby and
+/// may legitimately park. Errors are swallowed — a report must never
+/// alter the program's outcome.
+pub(crate) fn flush_pending_reports(vm: &mut Executor, globals: &mut Globals) {
+    loop {
+        let Some(text) = SCHEDULER.with(|s| {
+            let mut s = s.borrow_mut();
+            if s.flushing_reports || s.pending_reports.is_empty() {
+                None
+            } else {
+                s.flushing_reports = true;
+                Some(s.pending_reports.remove(0))
+            }
+        }) else {
+            return;
+        };
+        let stderr = globals
+            .get_gvar(IdentId::get_id("$stderr"))
+            .unwrap_or_default();
+        let _ = vm.invoke_method_inner(
+            globals,
+            IdentId::get_id("write"),
+            stderr,
+            &[Value::string(text)],
+            None,
+            None,
+        );
+        SCHEDULER.with(|s| s.borrow_mut().flushing_reports = false);
+    }
 }
 
 /// Queue a dead thread's terminating exception as a pending interrupt on

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1293,6 +1293,10 @@ impl Value {
         RValue::new_file(file, name, readable, writable).pack()
     }
 
+    pub(crate) fn new_socket(file: std::fs::File, name: String, class_id: ClassId) -> Self {
+        RValue::new_socket(file, name, class_id).pack()
+    }
+
     pub fn range(start: Value, end: Value, exclude_end: bool) -> Self {
         // Range objects are frozen since Ruby 3.0.
         let mut v = RValue::new_range(start, end, exclude_end).pack();

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1851,6 +1851,18 @@ impl RValue {
         }
     }
 
+    /// A socket IO (TCPSocket / TCPServer / …): an ordinary `ObjTy::IO`
+    /// RValue over the socket fd, classed as the given socket class so the
+    /// whole IO method surface applies to it via inheritance.
+    pub(super) fn new_socket(file: std::fs::File, name: String, class_id: ClassId) -> Self {
+        let inner = IoInner::socket(file, name);
+        RValue {
+            header: Header::new(class_id, ObjTy::IO),
+            kind: ObjKind::io(inner),
+            var_table: None,
+        }
+    }
+
     pub(super) fn new_time(time: TimeInner) -> Self {
         RValue {
             header: Header::new(TIME_CLASS, ObjTy::TIME),

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -530,6 +530,22 @@ impl IoInner {
         }))
     }
 
+    /// Wrap a socket fd (connected stream or listener). Like [`Self::file`]
+    /// but with no filesystem path (`IO#path` is nil for sockets) and
+    /// always opened read/write; `name` only feeds `Display`/inspect.
+    pub(super) fn socket(file: std::fs::File, name: String) -> Self {
+        register_owned_fd(file.as_raw_fd());
+        Self::File(Rc::new(FileDescriptor {
+            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
+            name,
+            has_path: false,
+            readable: true,
+            writable: true,
+            autoclose: Cell::new(true),
+            pushback: RefCell::new(Vec::new()),
+        }))
+    }
+
     pub(crate) fn popen(mut child: std::process::Child) -> Self {
         let reader = child.stdout.take().map(std::io::BufReader::new);
         let writer = child.stdin.take();

--- a/monoruby/stdlib/openssl.rb
+++ b/monoruby/stdlib/openssl.rb
@@ -129,6 +129,11 @@ module OpenSSL
   end
 
   module SSL
+    # net/http's rescue clauses name these even for plain-HTTP requests;
+    # a missing constant turns any transport error into a NameError.
+    class SSLError < OpenSSLError; end
+    class SSLErrorWaitReadable < SSLError; end
+    class SSLErrorWaitWritable < SSLError; end
     class SSLContext
       def initialize(*); end
       def set_params(*); end

--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -1,59 +1,87 @@
-# Minimal Socket / BasicSocket / IPSocket stub for monoruby.
+# Ruby-level remainder of the socket library for monoruby.
 #
-# The real socket C extension is unsupported. ActiveSupport loads socket.rb
-# via `core_ext/object/json.rb` (for IPAddr → JSON serialization) and
-# ipaddr.rb autoloads it too, but none of that actually requires a working
-# socket during class loading. Provide empty classes so the constant
-# references resolve.
+# The real TCP surface — BasicSocket < IO, IPSocket, TCPSocket, TCPServer,
+# Socket, Socket::Constants, SocketError — is implemented natively
+# (src/builtins/socket.rs): sockets are IO objects over the socket fd, so
+# the whole IO method set (read/gets/write/close/closed?/…, including the
+# green-thread blocking-IO emulation) applies to them by inheritance, and
+# accept/connect park the calling green thread on the scheduler's fd
+# poller. This file adds only pure-Ruby bookkeeping and the stubs for the
+# protocols that remain unsupported (UNIX domain, UDP).
 
 class BasicSocket
-  def self.do_not_reverse_lookup; true; end
-  def self.do_not_reverse_lookup=(v); v; end
+  # monoruby always returns numeric addresses (as if
+  # do_not_reverse_lookup were true); the accessors exist for
+  # compatibility.
+  @do_not_reverse_lookup = true
+  def self.do_not_reverse_lookup
+    @do_not_reverse_lookup.nil? ? true : @do_not_reverse_lookup
+  end
+
+  def self.do_not_reverse_lookup=(v)
+    @do_not_reverse_lookup = v
+  end
+
+  def do_not_reverse_lookup
+    @do_not_reverse_lookup.nil? ? BasicSocket.do_not_reverse_lookup : @do_not_reverse_lookup
+  end
+
+  def do_not_reverse_lookup=(v)
+    @do_not_reverse_lookup = v
+  end
 end
 
-class Socket < BasicSocket
-  AF_INET = 2
-  AF_INET6 = 10
-  AF_UNIX = 1
-  SOCK_STREAM = 1
-  SOCK_DGRAM = 2
-  INADDR_ANY = "0.0.0.0"
-
-  class Constants; end
+class Socket
+  # The high-level connect helper the net/* libraries use. Delegates to
+  # the native TCPSocket; extra keywords accepted for compatibility
+  # (resolv_timeout / fast_fallback are meaningless for a blocking
+  # single-resolver connect).
+  def self.tcp(host, port, local_host = nil, local_port = nil,
+               connect_timeout: nil, resolv_timeout: nil,
+               open_timeout: nil, fast_fallback: nil)
+    timeout = connect_timeout || open_timeout
+    sock = TCPSocket.new(host, port, local_host, local_port,
+                         connect_timeout: timeout)
+    if block_given?
+      begin
+        yield sock
+      ensure
+        sock.close unless sock.closed?
+      end
+    else
+      sock
+    end
+  end
 
   def self.gethostname
-    "localhost"
+    require "etc" rescue nil
+    (Etc.uname[:nodename] rescue nil) || "localhost"
   end
 
-  def self.getaddrinfo(*_); []; end
-  def self.ip_address_list; []; end
+  def self.getaddrinfo(*_)
+    []
+  end
+
+  def self.ip_address_list
+    []
+  end
 end
 
-class IPSocket < BasicSocket
-  def self.getaddress(host); host; end
-end
-
-# Real TCP sockets are unsupported. Fail loudly at instantiation, like
-# UNIXSocket below: a silent do-nothing socket object lets code run on
-# until it dies far from the cause. The ruby/spec net-http fixture is
-# the concrete case — it builds a TCPServer, then spawns a server
-# thread with `abort_on_exception = true`; with a do-nothing server
-# object the thread died on a missing method and the exception was
-# forwarded to (and killed) the main thread, aborting the whole mspec
-# run. Raising here surfaces in the spec's own setup instead.
-class TCPSocket < IPSocket
+class UDPSocket < IPSocket
+  # UDP is not implemented. Fail loudly at instantiation (see UNIXSocket
+  # below): a silent do-nothing socket lets code run on until it dies far
+  # from the cause.
   def initialize(*)
-    raise SocketError, "TCP sockets are not supported in monoruby"
+    raise SocketError, "UDP sockets are not supported in monoruby"
   end
 end
-class TCPServer < TCPSocket; end
-class UDPSocket < IPSocket; end
+
 class UNIXSocket < BasicSocket
   # Real UNIX-domain sockets are unsupported, but the path argument is
   # validated like CRuby's (CVE-2018-8779): a NUL byte must raise
   # ArgumentError *before* any bind/connect would happen. Valid paths
-  # fail with an explicit unsupported-feature error instead of the
-  # previous misleading NoMethodError.
+  # fail with an explicit unsupported-feature error instead of a
+  # misleading NoMethodError.
   def self.open(path, *rest, &blk)
     new(path, *rest, &blk)
   end
@@ -71,8 +99,6 @@ class UNIXSocket < BasicSocket
   end
 end
 class UNIXServer < UNIXSocket; end
-
-class SocketError < StandardError; end
 
 class Addrinfo
   def self.tcp(host, port); new; end


### PR DESCRIPTION
## Summary

This PR implements real TCP sockets (replacing the `SocketError` stub) and fixes the deep bugs that surfaced once net/http, net-ftp and the socket specs actually started exercising the runtime. The headline result: the ruby/spec **library** category goes from a hard 1805s timeout (reported as 0% on rubyspec-stats) to **finishing in 34s** — 4840 examples, ~1771 passing (~37%).

### TCP sockets (`builtins/socket.rs`, `stdlib/socket.rb`)

Sockets are ordinary `ObjTy::IO` RValues (`IoInner` over the socket fd, classed `TCPSocket` / `TCPServer` / `Socket`), so the whole IO surface — `read`/`gets`/`write`/`close`/`closed?`, green-thread would-block parking — works by inheritance.

- `BasicSocket < IO`, `IPSocket`, `TCPSocket`, `TCPServer`, `Socket`, `SocketError`, `Socket::Constants` (AF_*/SOCK_*/SOL_*/IPPROTO_*/SO_*/TCP_*/SHUT_*/MSG_*/INADDR_*/SOMAXCONN)
- `TCPServer#accept` parks on the fd poller; CRuby-compatible `IOError` messages for close-while-parked (including close from another thread)
- `TCPSocket.new/open` with `connect_timeout:`/`open_timeout:` keywords, optional local bind, non-blocking connect (EINPROGRESS → park POLLOUT → SO_ERROR), block form closes after the block
- `Socket.new(domain, type, protocol)` is a real `socket(2)` — previously `Socket.new(Socket::AF_INET, …)` fell through to `IO.new(2, …)` and **took ownership of stderr** (AF_INET == 2), closing it mid-run
- `BasicSocket#setsockopt/#getsockopt/#shutdown`, `IPSocket#addr/#peeraddr/.getaddress`
- `OpenSSL::SSL::SSLError` (+WaitReadable/WaitWritable) added to the openssl stub — net/http's rescue clauses name them even for plain HTTP

### JIT: specialized-call results stored via the LFP when the frame may be captured

The library hang was ultimately a **JIT miscompilation**, not a socket bug: a specialized (inline-compiled) callee that captures its own frame (`Timeout.timeout` doing `Proc.new`) makes `materialize_escaped_block_handlers` promote the **caller's** frame to the heap too when the call site passed a block literal. The caller's result store was rbp-relative, landing on the abandoned stack frame; after the capture deopt the interpreter read nil. In net/http this made `timeouted_connect` return nil (~38 calls in, at JIT warm-up), leaked the accepted connection inside `Net::HTTP.start`'s connect window, wedged the spec fixture server in `gets`, and hung the category — only in full-category runs, which is why single files always passed.

Fix (arch-neutral): `specialized_iseq` drops the no-capture invariant when the call site passes a block literal (mirroring the generic-send rule), and `def_rax2acc_return` stores via `RegToLfpStack` when the invariant is unset. Regression test included (distilled `Timeout.timeout` shape).

### Supporting runtime fixes

- **Scheduler**: `report_on_exception` output is now queued as pre-rendered strings in `finalize` (machinery context) and flushed via `$stderr.write` only at normal-context safepoints — invoking Ruby from machinery context could re-enter the scheduler and corrupt the saved native context (alien-rbp SEGV, latent in the pending-interrupt-queue commit)
- **Thread.new** runs the new thread's first slice eagerly, so fixture-style server threads reach their `accept` park before `new` returns — fixes cross-example fd-reuse/connection-theft deadlocks in the socket specs
- **ThreadGroup + Thread#group** (the timeout gem's watcher-thread setup requires them)
- **IO#wait / #wait_readable / #wait_writable** park on the fd poller instead of `libc::poll`-blocking the whole process; **IO#read(0)** returns immediately (net/http calls `read(0)` for empty bodies)

## Results

| Suite | Before | After |
|---|---|---|
| library/net-http | 905s hard hang | 2.3s, 377 examples (3F/4E) |
| library/socket | 605s timeout | ~1s, 634 examples |
| library/net-ftp | 73 examples | 461 examples (matches CRuby) |
| **library (full)** | **1805s timeout** | **34s, 4840 examples, ~1771 passing** |
| core (full) | 993F / 1277E | 991F / 1277E |
| cargo test | 1898/1898 | 1898/1898 (normal + gc-stress) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_