### PR TITLE
More socket tests: constructor variants, error paths, shutdown symbol form

### DIFF
--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -1131,4 +1131,59 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn constructor_variants_and_errors() {
+        run_test_once(
+            r#"
+            require "socket"
+            res = []
+            # unknown host -> SocketError
+            begin
+              TCPSocket.new("no-such-host.invalid", 80)
+              res << "connected"
+            rescue SocketError
+              res << "SocketError"
+            end
+            # TCPServer.new(port) form; listen; numeric addr
+            s = TCPServer.new(0)
+            res << s.addr[0]
+            s2 = TCPServer.new("127.0.0.1", 0)
+            res << s2.listen(5)
+            res << s2.addr(:numeric).values_at(0, 2, 3)
+            # Socket.new with String family/type and explicit protocol
+            sock = Socket.new("INET", "STREAM", 0)
+            res << sock.is_a?(Socket)
+            sock.close
+            # 4-arg TCPSocket.new with local bind
+            port = s2.addr[1]
+            t = Thread.new { c = s2.accept; c.close }
+            k = TCPSocket.new("127.0.0.1", port, "127.0.0.1", 0)
+            res << k.addr[2]
+            k.close
+            t.join
+            s.close
+            s2.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn shutdown_symbol_and_eof_read() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = TCPServer.new("127.0.0.1", 0)
+            got = nil
+            t = Thread.new { c = s.accept; got = c.read; c.close }
+            k = TCPSocket.new("127.0.0.1", s.addr[1])
+            k.shutdown(:WR)
+            t.join
+            k.close
+            s.close
+            got
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -1145,9 +1145,11 @@ mod tests {
             rescue SocketError
               res << "SocketError"
             end
-            # TCPServer.new(port) form; listen; numeric addr
+            # TCPServer.new(port) form; listen; numeric addr. (Do not
+            # assert s.addr[0]: with the host omitted, CRuby binds the
+            # IPv6 wildcard on macOS — AF_INET6 — but AF_INET on Linux.)
             s = TCPServer.new(0)
-            res << s.addr[0]
+            res << s.addr[1].is_a?(Integer)
             s2 = TCPServer.new("127.0.0.1", 0)
             res << s2.listen(5)
             res << s2.addr(:numeric).values_at(0, 2, 3)


### PR DESCRIPTION
## Summary

Follow-up to #964, covering the socket paths codecov flagged as unexercised by `cargo test` (patch coverage was 77.1% at merge). Two new tests in `builtins/socket.rs`, all output-compared against CRuby:

- **`constructor_variants_and_errors`**: unknown host → `SocketError`, `TCPServer.new(port)` single-arg form, `TCPServer#listen`, `addr(:numeric)`, `Socket.new` with String family/type + explicit protocol (`Socket.new("INET", "STREAM", 0)`), and the 4-arg `TCPSocket.new(host, port, local_host, local_port)` local-bind form
- **`shutdown_symbol_and_eof_read`**: `shutdown(:WR)` symbol form, observed as EOF (`""`) by the peer's `read`

## Testing

All 11 socket tests pass locally (`cargo test --lib socket::tests`), each comparing monoruby output against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_