### PR TITLE
Mutex: release a lock abandoned by a terminated thread

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -928,7 +928,10 @@ class Thread
 
   class Mutex
     def locked?
-      !!@owner
+      # A thread releases its locks when it terminates (CRuby semantics), so
+      # an owner that is no longer alive means the lock has been abandoned
+      # and the mutex is effectively unlocked.
+      (o = @owner) ? o.alive? : false
     end
 
     def owned?
@@ -954,6 +957,16 @@ class Thread
     def lock
       raise ThreadError, "deadlock; recursive locking" if owned?
       until try_lock
+        # Reclaim a lock abandoned by a terminated owner (a dead thread
+        # never unlocks or wakes waiters, so a contender must take it over
+        # rather than park forever). Clearing @owner is idempotent under a
+        # race — concurrent reclaimers write the same nil — and the actual
+        # acquisition still goes through try_lock's atomic test-and-set, so
+        # no two threads can both win.
+        if (o = @owner) && !o.alive?
+          @owner = nil
+          next
+        end
         (@waiters ||= []) << Thread.current
         begin
           Thread.stop


### PR DESCRIPTION
## Summary

Implements CRuby's "a thread releases its locks when it terminates" semantics for `Mutex`, fixing `core/mutex`'s `Mutex#locked? returns the status of the lock`.

The fix is *lazy* so it never touches `Mutex#try_lock`'s deliberately safepoint-free atomic test-and-set:

- **`Mutex#locked?`** reports an owner that is no longer `alive?` as unlocked.
- **`Mutex#lock`** reclaims a lock whose owner has died — a dead thread never unlocks or wakes waiters, so a contender clears the stale `@owner` and re-contends through `try_lock` instead of parking forever. Clearing `@owner` is idempotent under a race (concurrent reclaimers write the same `nil`), and acquisition still goes through `try_lock`, so no two threads can both win.

## Testing

- `core/mutex`: 2 failures → 1 (the remaining `owned? is held per Fiber` needs per-Fiber ownership identity — see below). Stable across repeated runs.
- No regressions in `core/conditionvariable`; `cargo test -p monoruby --lib -- builtins::thread builtins::fiber` (40) pass.

## Not included (need VM/model-level changes)

- **`Mutex#owned?` per-Fiber** — this runtime's `Fiber.current` returns one shared object across fibers/threads, so it can't key ownership.
- **`ConditionVariable#wait` re-lock on kill-after-signal** — needs real async-interrupt masking (`Thread.handle_interrupt` is currently a no-op).
- **`Thread#backtrace` for a parked thread** — needs cross-thread Ruby-stack introspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_