### PR TITLE
Mutex#owned? is per-Fiber (real Fiber.current identity)

### DIFF
--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -664,9 +664,12 @@ end
 class Fiber
   @@main_fiber = nil
   def self.current
-    # Return the main fiber (monoruby is single-threaded and doesn't track
-    # the current fiber across resume/yield).
-    @@main_fiber ||= Fiber.new {}
+    # Inside a fiber body the executor knows which Fiber it is running as;
+    # at a thread's root context there is none, so fall back to a shared
+    # main-fiber object (distinct from any explicit Fiber, which is all that
+    # per-Fiber mutex ownership needs — cross-thread checks key on the
+    # Thread).
+    __current_fiber || (@@main_fiber ||= Fiber.new {})
   end
 
   # --- Fiber-local storage (CRuby 3.2+) --------------------------------
@@ -935,7 +938,10 @@ class Thread
     end
 
     def owned?
-      @owner == Thread.current
+      # Ownership is per-Fiber (CRuby): the same Thread's other Fibers do not
+      # own a mutex this Fiber locked. The Thread test also makes a cross-
+      # thread check false regardless of Fiber identity.
+      @owner == Thread.current && @owner_fiber == Fiber.current
     end
 
     def try_lock
@@ -946,16 +952,23 @@ class Thread
       # back-edges, hence no safepoint can interleave another thread
       # between the test and the set.
       cur = Thread.current
+      cur_fiber = Fiber.current
       if @owner
         false
       else
         @owner = cur
+        @owner_fiber = cur_fiber
         true
       end
     end
 
     def lock
-      raise ThreadError, "deadlock; recursive locking" if owned?
+      # Deadlock detection is per-Thread, not per-Fiber: a mutex already held
+      # by THIS thread (in any fiber) can only be released by this thread, so
+      # trying to acquire it again — recursively or from a sibling fiber —
+      # would park the one thread that could release it. Raise rather than
+      # hang. (Ownership *reported* by #owned? is still per-Fiber.)
+      raise ThreadError, "deadlock; recursive locking" if @owner == Thread.current
       until try_lock
         # Reclaim a lock abandoned by a terminated owner (a dead thread
         # never unlocks or wakes waiters, so a contender must take it over
@@ -981,7 +994,10 @@ class Thread
       unless @owner
         raise ThreadError, "Attempt to unlock a mutex which is not locked"
       end
-      unless owned?
+      # Thread-level check (not the per-Fiber #owned?): keeps the hot unlock
+      # path free of the extra Fiber.current safepoint, and every unlock spec
+      # exercises the cross-thread case anyway.
+      unless @owner == Thread.current
         raise ThreadError, "Attempt to unlock a mutex which is locked by another thread"
       end
       @owner = nil

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -23,6 +23,18 @@ pub(super) fn init(globals: &mut Globals) {
         inline_gen2!(fiber_yield_inline),
     );
     globals.define_builtin_func_rest(FIBER_CLASS, "resume", resume);
+    // Backs `Fiber.current`: the fiber running on this executor, or nil at a
+    // thread's root context (the Ruby wrapper substitutes the main fiber).
+    globals.define_builtin_class_func(FIBER_CLASS, "__current_fiber", current_fiber, 0);
+}
+
+///
+/// The `Fiber` currently executing on this executor, or `nil` at a thread's
+/// root context. Not a public API — `Fiber.current` (startup.rb) wraps it.
+///
+#[monoruby_builtin]
+fn current_fiber(vm: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(vm.current_fiber().unwrap_or_default())
 }
 
 ///

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -205,6 +205,11 @@ pub struct Executor {
     /// frame (a fresh deferral for a frame that already has one means the
     /// previous inner-ensure unwind was bypassed and is abandoned).
     deferred_unwind: Vec<(Lfp, MonorubyErr)>,
+    /// The `Fiber` object whose body is currently executing on this
+    /// `Executor`, or `None` for a thread's root context (which falls back
+    /// to the shared main-fiber object). Exposed as `Fiber.current` so that
+    /// mutex ownership can be tracked per-Fiber, as in CRuby.
+    current_fiber: Option<Value>,
 }
 
 impl std::default::Default for Executor {
@@ -227,6 +232,7 @@ impl std::default::Default for Executor {
             exception: None,
             errinfo: Value::nil(),
             deferred_unwind: vec![],
+            current_fiber: None,
         }
     }
 }
@@ -261,6 +267,10 @@ impl alloc::GC<RValue> for Executor {
         // `$!` — the exception being handled survives as long as this
         // execution context (fiber) does.
         self.errinfo.mark(alloc);
+        // The `Fiber` object this executor is running as (`Fiber.current`).
+        if let Some(f) = self.current_fiber {
+            f.mark(alloc);
+        }
         // Transient per-match stashes: live across the MatchData
         // allocation in `save_capture_special_variables`, which can
         // trigger GC.
@@ -488,6 +498,18 @@ impl Executor {
 
     pub fn parent_fiber(&self) -> Option<std::ptr::NonNull<Executor>> {
         self.parent_fiber
+    }
+
+    /// The `Fiber` object this executor runs as (`Fiber.current`), or `None`
+    /// for a thread's root context.
+    pub fn current_fiber(&self) -> Option<Value> {
+        self.current_fiber
+    }
+
+    /// Record the `Fiber` object whose body runs on this executor. Set once,
+    /// when the fiber is first invoked.
+    pub(crate) fn set_current_fiber(&mut self, fiber: Value) {
+        self.current_fiber = Some(fiber);
     }
 
     /// `$&` — the last successful match (derived from the current

--- a/monoruby/src/value/rvalue/fiber.rs
+++ b/monoruby/src/value/rvalue/fiber.rs
@@ -169,9 +169,13 @@ impl Fiber {
         arg: &[Value],
     ) -> Result<Value> {
         assert_eq!(FiberState::Created, self.state());
+        // The fiber's body runs on its own executor; record the Fiber object
+        // there so `Fiber.current` resolves to it (per-Fiber identity).
+        let fiber_val = self.0;
         self.initialize();
         let proc = ProcData::from_proc(&self.proc);
         let handle = &mut self.handle;
+        handle.set_current_fiber(fiber_val);
         match (globals.invokers.fiber)(
             vm,
             globals,


### PR DESCRIPTION
## Summary

Implements CRuby's per-Fiber `Mutex` ownership, fixing `core/mutex`'s `Mutex#owned? is held per Fiber`. In CRuby a mutex locked in one Fiber is not owned by another Fiber, even within the same Thread — but monoruby's `Fiber.current` returned a single shared object, so `owned?` could not distinguish fibers.

## Changes

**VM — real per-Fiber identity for `Fiber.current`:**
- `Executor` records the `Fiber` object whose body runs on it (set when the fiber is invoked; GC-marked).
- New `Fiber.__current_fiber` exposes it; `Fiber.current` returns it inside a fiber body and falls back to the shared main fiber at a thread's root context (cross-thread checks key on the Thread, so a shared root object is sufficient).

**Mutex:**
- `try_lock` records the owning Fiber alongside the owning Thread — hoisted **before** the atomic test-and-set, so try_lock's straight-line (safepoint-free) region is preserved.
- `owned?` now checks both Thread and Fiber.
- `lock`'s deadlock detection and `unlock`'s owner check stay **per-Thread**: a mutex held by any fiber of this thread can only be released by this thread, so re-acquiring it (recursively or from a sibling fiber) must raise rather than park the one thread that could release it. Keeping the hot `unlock` path free of the extra `Fiber.current` call also avoids perturbing the interrupt-timing-sensitive lock specs.

## Testing

- `core/mutex/owned_spec.rb` passes; full `core/mutex` is green run-to-run except the pre-existing timing-flaky `does not raise deadlock … interrupted` spec — which is **already flaky on master** (observed FAIL/FAIL/PASS) and is, if anything, *less* flaky here since `unlock` lost a safepoint.
- No regressions in `core/{conditionvariable,fiber,queue}` or the `builtins::{thread,fiber}` unit tests (40 pass).
- Verified the fiber initial-block-arg quirk (`Fiber.new{|x|…}.resume(5)` sees `[5]`) is pre-existing on clean master, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_