### PR TITLE
Range: min(n)/max(n), succ-order string iteration, Time/#to_str include?, r_cover_range_p port — core/range 48 failures → 0

### DIFF
--- a/monoruby/builtins/range.rb
+++ b/monoruby/builtins/range.rb
@@ -57,6 +57,15 @@ class Range
         if seq_mode
           cur_len = i.is_a?(Symbol) ? i.to_s.length : i.length
           break if cur_len > end_len
+          # succ order sorts first by length, then lexicographically —
+          # `"b" < "ab"` in succ order even though `"b" > "ab"` as
+          # strings ("a".."ab" runs a..z then aa, ab). While shorter
+          # than the end, keep stepping without the lex comparison.
+          if cur_len < end_len
+            yield i
+            i = i.succ
+            next
+          end
         end
         c = (i <=> e)
         break if c.nil?
@@ -212,31 +221,134 @@ class Range
   def include?(val)
     b = self.begin
     e = self.end
-    # Fully-open range: accept Numeric val, reject anything else as
-    # "inclusion undecidable".
+    # Fully-open range: accept "linear" values (CRuby's linear_object_p:
+    # Numeric and Time), reject anything else as "inclusion
+    # undecidable".
     if b.nil? && e.nil?
-      return true if val.is_a?(Numeric)
+      return true if val.is_a?(Numeric) || val.is_a?(Time)
       raise TypeError, "cannot determine inclusion in beginless/endless ranges"
     end
-    # Numeric-backed range uses cover? (continuous semantics).
-    if b.is_a?(Numeric) || e.is_a?(Numeric)
+    # A range with a linear endpoint uses cover? (continuous semantics).
+    if b.is_a?(Numeric) || e.is_a?(Numeric) || b.is_a?(Time) || e.is_a?(Time)
       return cover?(val)
     end
-    # Non-numeric ranges with a nil endpoint cannot decide inclusion.
+    # Non-linear ranges with a nil endpoint cannot decide inclusion.
     if b.nil? || e.nil?
       raise TypeError, "cannot determine inclusion in beginless/endless ranges"
     end
-    # Both endpoints present and non-numeric: use succ iteration if possible.
+    # String ranges convert the argument with #to_str first (CRuby's
+    # rb_check_string_type in rb_str_include_range_p).
+    if b.is_a?(String) && e.is_a?(String) && !val.is_a?(String)
+      return false unless val.respond_to?(:to_str)
+      conv = val.to_str
+      unless conv.is_a?(String)
+        raise TypeError,
+              "can't convert #{val.class} to String (#{val.class}#to_str gives #{conv.class})"
+      end
+      val = conv
+    end
+    # Both endpoints present and non-linear: use succ iteration if possible.
     if b.respond_to?(:succ)
       self.each do |x|
         return true if x == val
       end
       return false
     end
-    # Non-succ types (e.g., Time): fall back to cover? semantics.
+    # Non-succ types: fall back to cover? semantics.
     cover?(val)
   end
   alias member? include?
+
+  # The n argument of min(n)/max(n): #to_int conversion + validation.
+  def __minmax_n(n)
+    unless n.is_a?(Integer)
+      unless n.respond_to?(:to_int)
+        raise TypeError, "no implicit conversion of #{n.class} into Integer"
+      end
+      conv = n.to_int
+      unless conv.is_a?(Integer)
+        raise TypeError,
+              "can't convert #{n.class} to Integer (#{n.class}#to_int gives #{conv.class})"
+      end
+      n = conv
+    end
+    raise ArgumentError, "negative array size (or size too big)" if n < 0
+    n
+  end
+
+  def min(n = nil, &block)
+    raise RangeError, "cannot get the minimum of beginless range" if self.begin.nil?
+    if block
+      if self.end.nil?
+        raise RangeError, "cannot get the minimum of endless range with custom comparison method"
+      end
+      return __builtin_min(&block) if n.nil?
+      return to_a.sort(&block).first(__minmax_n(n))
+    end
+    return __builtin_min if n.nil?
+    n = __minmax_n(n)
+    # min(n) == the first n elements in iteration order: works lazily for
+    # endless Integer ranges, yields [] for empty/backward ones, and
+    # raises TypeError via #each when the begin has no #succ (Float,
+    # Time, Array, ...).
+    res = []
+    each do |x|
+      break if res.size == n
+      res << x
+    end
+    res
+  end
+
+  def max(n = nil, &block)
+    e = self.end
+    raise RangeError, "cannot get the maximum of endless range" if e.nil?
+    if block
+      if self.begin.nil?
+        raise RangeError, "cannot get the maximum of beginless range with custom comparison method"
+      end
+      return __builtin_max(&block) if n.nil?
+      return to_a.sort(&block).last(__minmax_n(n)).reverse
+    end
+    if n.nil?
+      if exclude_end? && !e.is_a?(Numeric)
+        # CRuby's Enumerable fallback: an exclusive range with a
+        # non-numeric, succ-iterable end is iterated to its rightmost
+        # element (the numeric fast path below instead raises
+        # "cannot exclude non Integer end value" for e.g. Float ends —
+        # which cover?'s range-argument rescue relies on).
+        if self.begin.nil?
+          raise RangeError, "cannot get the maximum of beginless range with custom comparison method"
+        end
+        m = nil
+        each { |x| m = x }
+        return m
+      end
+      return __builtin_max
+    end
+    n = __minmax_n(n)
+    if e.is_a?(Integer)
+      # Arithmetic from the top: handles beginless ends and huge spans
+      # ((0...2**64).max(2)) without iterating from the start.
+      hi = exclude_end? ? e - 1 : e
+      b = self.begin
+      lo = hi - n + 1
+      unless b.nil?
+        c = (b <=> hi)
+        return [] if c.nil? || c > 0
+        lo = b if b.is_a?(Integer) && lo < b
+      end
+      res = []
+      v = hi
+      while v >= lo
+        res << v
+        v -= 1
+      end
+      return res
+    end
+    # Non-Integer end: materialize the range (raises TypeError via #each
+    # for begins that cannot be iterated — Float, Time, Array, nil).
+    to_a.last(n).reverse
+  end
 
   def lazy
     Enumerator::Lazy.new(self)
@@ -521,37 +633,57 @@ class Range
     true
   end
 
+  # Port of CRuby's r_cover_range_p (range.c).
   def __cover_range_q(val)
-    s_b = self.begin
     s_e = self.end
     v_b = val.begin
     v_e = val.end
 
-    return false if v_b.nil? && !s_b.nil?
+    return false if v_b.nil? && !self.begin.nil?
     return false if v_e.nil? && !s_e.nil?
 
-    if !s_b.nil? && !v_b.nil?
-      c = (s_b <=> v_b)
+    # An empty or backward other is never covered.
+    if !v_b.nil? && !v_e.nil?
+      c = (v_b <=> v_e)
       return false if c.nil?
-      return false if c > 0
+      return false if c > (val.exclude_end? ? -1 : 0)
     end
 
-    # Normalise exclusive Integer endpoints to inclusive (so `...11`
-    # matches `..10`), then compare and handle equality for strict Floats.
-    if !s_e.nil? && !v_e.nil?
-      s_eff = (self.exclude_end? && s_e.is_a?(Integer)) ? s_e - 1 : s_e
-      v_eff = (val.exclude_end?  && v_e.is_a?(Integer)) ? v_e - 1 : v_e
-      c = (v_eff <=> s_eff)
-      return false if c.nil?
-      return false if c > 0
-      if c == 0
-        s_strict = self.exclude_end? && !s_e.is_a?(Integer)
-        v_strict = val.exclude_end?  && !v_e.is_a?(Integer)
-        return false if s_strict && !v_strict
-      end
+    return false if !v_b.nil? && !__cover_val_q(v_b)
+
+    if !v_e.nil? && !s_e.nil?
+      cmp_end = (s_e <=> v_e)
+      return false if cmp_end.nil?
+    elsif s_e.nil? && !v_e.nil?
+      # self is endless, other is bounded: self's end (+∞) is greater,
+      # so even an exclusive self covers other's end.
+      cmp_end = 1
+    else
+      # Both ends nil (a bounded self with an endless other already
+      # returned false above): equal.
+      cmp_end = 0
     end
 
-    true
+    if exclude_end? == val.exclude_end?
+      return cmp_end >= 0
+    elsif exclude_end?
+      return cmp_end > 0
+    elsif cmp_end >= 0
+      return true
+    end
+
+    # self is inclusive, other is exclusive, and other's raw endpoint
+    # lies past self.end: other may still be covered if its actual
+    # maximum element is — e.g. (1..2).cover?(1...3), or a generic
+    # succ-iterable other whose rightmost value <= self.end.
+    v_max = begin
+      val.max
+    rescue TypeError
+      nil
+    end
+    return false if v_max.nil?
+    c = (s_e <=> v_max)
+    !c.nil? && c >= 0
   end
 
   def __range_empty_q(r)

--- a/monoruby/builtins/range.rb
+++ b/monoruby/builtins/range.rb
@@ -52,7 +52,15 @@ class Range
           return self
         end
       end
-      end_len = (e.is_a?(Symbol) ? e.to_s.length : e.length) if seq_mode
+      if seq_mode
+        end_len = e.is_a?(Symbol) ? e.to_s.length : e.length
+        # CRuby's rb_str_upto_each gates on a plain lexicographic
+        # compare before iterating: ("z".."aa") is empty even though
+        # succ order would reach "aa" — only ranges with beg <= end
+        # as strings iterate at all.
+        c0 = (i <=> e)
+        return self if c0.nil? || c0 > 0 || (excl && c0 == 0)
+      end
       loop do
         if seq_mode
           cur_len = i.is_a?(Symbol) ? i.to_s.length : i.length

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -30,6 +30,10 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(RANGE_CLASS, "entries", &["to_a"], toa, 0);
     globals.define_builtin_func(RANGE_CLASS, "min", min, 0);
     globals.define_builtin_func(RANGE_CLASS, "max", max, 0);
+    // Fast paths kept reachable from the Ruby-level min/max overrides
+    // (builtins/range.rb), which add the `min(n)` / `max(n)` forms.
+    globals.define_builtin_func(RANGE_CLASS, "__builtin_min", min, 0);
+    globals.define_builtin_func(RANGE_CLASS, "__builtin_max", max, 0);
     globals.define_builtin_func(RANGE_CLASS, "count", count, 0);
     globals.define_builtin_func(RANGE_CLASS, "minmax", minmax, 0);
 }
@@ -1092,6 +1096,63 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn min_max_with_integer_argument() {
+        run_tests2(&[
+            "(1..10).min(2)",
+            "(1..10).max(2)",
+            "(1...10).max(2)",
+            "(0...2**64).max(2)",
+            "('f'..'l').min(2)",
+            "('a'...'f').max(2)",
+            "(..1).max(2)",
+            "(...1).max(2)",
+            "(100..10).min(2)",
+            "(5...5).min(2)",
+            "(5..5).max(2)",
+            "(1..).min(2)",
+            "(1..3).max(10)",
+            "(1..5).min(2) {|a,b| b<=>a}",
+            "(1..5).max(2) {|a,b| b<=>a}",
+            "(1..10).min(0)",
+        ]);
+        run_test_error("(1..).max(2)");
+        run_test_error("(..1).min(2)");
+        run_test_error("(1.0..2.0).min(2)");
+        run_test_error("(..1.0).max(2)");
+        run_test_error("(0..2).min(-1)");
+        run_test_error("(0..2).max('x')");
+    }
+
+    #[test]
+    fn string_range_succ_order_iteration() {
+        // succ order sorts by length first: "a".."ab" runs a..z, aa, ab.
+        run_tests2(&[
+            r#"("a".."ab").to_a"#,
+            r#"("z".."aa").to_a"#,
+            r#"("a".."ab").include?("b")"#,
+            r#"("a".."ab").include?("ac")"#,
+            r#"o = Object.new; def o.to_str; "b"; end; ("a".."aa").include?(o)"#,
+            r#"t = Time.at(0); [(t..).include?(t + 1), (nil..nil).include?(t)]"#,
+        ]);
+    }
+
+    #[test]
+    fn cover_range_argument_edge_cases() {
+        run_tests2(&[
+            "(1...1).cover?(1...1)",
+            "(1..3).cover?(2...2)",
+            "(1..3).cover?(3..1)",
+            "(nil...nil).cover?(4..6)",
+            "(nil...nil).cover?(1..)",
+            "(1...).cover?(1..)",
+            "(1..10).cover?(4...11)",
+            "(..10).cover?(4...11)",
+            "(0..10.0).cover?(5...11.0)",
+            "(..10.0).cover?(...11.0)",
+        ]);
+    }
 
     #[test]
     fn range_basics_to_s_inspect_each_map_flat_map() {


### PR DESCRIPTION
## Summary

core/range goes from **13 failures / 35 errors to 0 / 0** (606 examples, full pass). Four root causes, all fixed at the Ruby level (`builtins/range.rb`); the Rust side only gains `__builtin_min` / `__builtin_max` alias registrations and unit tests.

### 1. `Range#min(n)` / `#max(n)` — 32 of the 48 failures
The Rust builtins are arity 0, so every integer-argument spec raised `ArgumentError`. Now:
- `min(n)` takes the first n elements of the iteration — lazy, so `(1..).min(2)` works; empty/backward ranges yield `[]`; non-succ begins (Float, Time, Array) raise `TypeError` via `#each`
- `max(n)` computes arithmetically from an Integer end — handles beginless ends (`(..1).max(2) == [1, 0]`) and huge spans (`(0...2**64).max(2)`) without iterating — and materializes the range otherwise (`('f'..'l').max(2) == ['l', 'k']`)
- block + n forms sort with the comparator; `n` goes through `#to_int` with CRuby's TypeError/ArgumentError validation
- endless `max(n)` / beginless `min(n)` raise `RangeError`; the no-arg fast paths still hit the Rust builtins

### 2. String/Symbol iteration used lexicographic order, not succ order
`("a".."ab").to_a` returned `["a"]` — the seq loop stopped at `"b" > "ab"`. Ported CRuby's `rb_str_upto_each` rules: a lexicographic gate before iterating (`("z".."aa")` is empty), then length-first stepping (while the current element is shorter than the end, step without comparing), so `("a".."ab")` runs a..z, aa, ab (28 elements).

### 3. `Range#include?`: Time linearity and `#to_str` conversion
- Time is now a linear object (CRuby's `linear_object_p`): `(t..).include?(t + 1)` uses cover? semantics instead of raising TypeError; fully-open ranges accept Time
- String ranges convert the argument with `#to_str` first (`rb_check_string_type`), raising TypeError when `#to_str` returns a non-String

### 4. `cover?(Range)` ported faithfully from CRuby's `r_cover_range_p`
Empty and backward others are never covered; an endless self covers any bounded other end; the inclusive-self/exclusive-other case falls back to `other.max` (rescuing TypeError), so succ-iterable others whose rightmost value fits are covered while non-iterable (Float-ended) ones are not. To support that split, no-arg `max` on an exclusive range with a non-numeric succ-iterable end now iterates (CRuby's Enumerable fallback) instead of raising `cannot exclude non Integer end value`.

## Testing

- core/range: **606 examples, 0 failures, 0 errors** (was 13F/35E)
- `cargo test`: 1910/1910, including 3 new CRuby-compared test batches (min/max integer argument, succ-order iteration, cover? edge cases)
- No regressions: failure sets of core/{enumerable, comparable, set, string, integer, array, symbol, enumerator} are unchanged vs. baseline (zero new failing examples)
- core/set was verified separately: already 0F/0E standalone (162 examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_