### PR TITLE
Time: include Comparable; Time#to_s returns US-ASCII

### DIFF
--- a/monoruby/builtins/builtins.rb
+++ b/monoruby/builtins/builtins.rb
@@ -726,6 +726,7 @@ class Set
   alias eql? ==
 end
 class Time
+  include Comparable
   alias asctime ctime
 end
 class Encoding

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -2353,7 +2353,11 @@ fn to_s(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         TimeInner::Utc(t) => t.format("%Y-%m-%d %H:%M:%S UTC"),
     }
     .to_string();
-    Ok(Value::string(s))
+    let mut v = Value::string(s);
+    // CRuby returns `Time#to_s` as a US-ASCII string (like `#inspect`).
+    v.as_rstring_inner_mut()
+        .set_encoding(crate::value::Encoding::UsAscii);
+    Ok(v)
 }
 
 ///


### PR DESCRIPTION
## Summary

Two safe, contained `core/time` correctness fixes (60 → 58 failures, no regressions):

- **`Time` includes `Comparable`** — `Time.include?(Comparable)` is now true, and `Comparable#between?` / `#clamp` work. Time's native `<`, `<=`, `>`, `>=`, `<=>` still take precedence, so comparison behavior is unchanged.
- **`Time#to_s` returns a US-ASCII string**, matching CRuby (`Time#inspect` already did).

## Testing

- `core/time`: the two targeted specs now pass; `cargo test -p monoruby --lib -- builtins::time` (43) pass; no regressions elsewhere in the category.

## Context — why the rest is out of scope

A survey of the remaining ~58 `core/time` failures shows they cluster into a few **model-level** features on the actively-developed Time code, which I deliberately left for a dedicated effort:

- **Dynamic local timezone** (~25 specs): monoruby's `chrono::Local` reads `TZ` once at process start, but the specs change `ENV['TZ']` mid-process (`with_timezone`), so offsets stay at 0 and `Time#zone` returns `nil`. A faithful fix needs per-call `tzset` + libc offset/zone-name lookup and storing the zone name.
- **Rational / sub-nanosecond subseconds** (~10 specs): `Time#subsec` should return a `Rational`, and precision beyond nanoseconds (chrono's limit) is required by some specs.
- **Timezone-object protocol** (~10 specs): `Time.new`/`Time.now` with a `zone:` object implementing `utc_to_local`/`local_to_utc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK

---
_Generated by [Claude Code](https://claude.ai/code/session_013XLHRVwyWsn5Pp8zgNcZaK)_