### PR TITLE
jit/vm: restore the fast Index/StoreIndex opcode for `self[i]` (#844 perf regression)

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1703,23 +1703,16 @@ impl<'a> BytecodeGen<'a> {
                         splat_pos,
                     }
                 } else if index.len() == 1 {
+                    // `self[i] = v` uses the fast `StoreIndex` opcode like any
+                    // other single-index assign; a literal `self` base stays
+                    // `BcReg::Self_` (slot 0) so the VM records the receiver as
+                    // self and lets `set_index` reach a private `#[]=` (see
+                    // `runtime::set_index`). `x = self; x[i] = v` keeps a temp
+                    // base, so it still enforces visibility.
                     let base = self.eval_index_base(base)?;
                     let index = self.push_expr(index[0].clone())?;
                     self.push(); // register for src.
-                    if base == BcReg::Self_ {
-                        // `self[i] = v` must reach a private `#[]=` via the
-                        // explicit-`self` receiver. Route it through the
-                        // general `#[]=` call site (`Index2`) rather than the
-                        // `StoreIndex` fast-path opcode, which always enforces
-                        // visibility.
-                        LvalueKind::Index2 {
-                            base,
-                            index1: index,
-                            num: 1,
-                        }
-                    } else {
-                        LvalueKind::Index { base, index }
-                    }
+                    LvalueKind::Index { base, index }
                 } else {
                     let base = self.eval_index_base(base)?;
                     let index1 = self.push_expr(index[0].clone())?;

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -172,11 +172,12 @@ impl<'a> BytecodeGen<'a> {
                 box base,
                 mut index,
             } => {
-                // A `self[..]` read must go through the general `#[]` call
-                // site (not the `Index` fast-path opcode, which always
-                // enforces visibility) so a private `#[]` is reachable via
-                // the explicit-`self` receiver, matching CRuby.
-                if index.len() == 1 && !index[0].is_splat() && base.kind != NodeKind::SelfValue {
+                // `self[i]` uses the fast `Index` opcode like any other
+                // single-index read; `gen_index` keeps a literal `self` base as
+                // slot 0, so the VM passes `is_func_call` to `get_index` and a
+                // private `#[]` stays reachable (matching CRuby) with no slow
+                // call-site detour for the common public case.
+                if index.len() == 1 && !index[0].is_splat() {
                     self.gen_index(Some(dst), base, index.remove(0), loc)?;
                 } else {
                     let arglist = ArgList::from_args(index);
@@ -484,11 +485,10 @@ impl<'a> BytecodeGen<'a> {
                 box base,
                 mut index,
             } => {
-                // A `self[..]` read must go through the general `#[]` call
-                // site (not the `Index` fast-path opcode, which always
-                // enforces visibility) so a private `#[]` is reachable via
-                // the explicit-`self` receiver, matching CRuby.
-                if index.len() == 1 && !index[0].is_splat() && base.kind != NodeKind::SelfValue {
+                // `self[i]` uses the fast `Index` opcode; a literal `self` base
+                // stays slot 0 so the VM passes `is_func_call` to `get_index`
+                // and a private `#[]` stays reachable. See the read arm above.
+                if index.len() == 1 && !index[0].is_splat() {
                     self.gen_index(None, base, index.remove(0), loc)?;
                 } else {
                     let arglist = ArgList::from_args(index);
@@ -1669,7 +1669,16 @@ impl<'a> BytecodeGen<'a> {
 
     fn gen_index(&mut self, ret: Option<BcReg>, base: Node, index: Node, loc: Loc) -> Result<()> {
         let old = self.temp;
-        let base = self.gen_expr_reg(base)?;
+        // Keep a literal `self` base as `BcReg::Self_` (slot 0, no temp) so the
+        // emitted `Index` opcode records the receiver as self: the VM reads
+        // base-slot == 0 and passes `is_func_call = true` to `get_index`, which
+        // lets `self[i]` reach a private `#[]` (matching CRuby) while a plain
+        // `obj[i]` — or `x = self; x[i]` — still enforces visibility.
+        let base = if base.kind == NodeKind::SelfValue {
+            BcReg::Self_
+        } else {
+            self.gen_expr_reg(base)?
+        };
         let index = self.gen_expr_reg(index)?;
         self.temp = old;
         let ret = match ret {

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -707,15 +707,20 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
-            ldrh x2, [x(PC.0), #(2)];
+            ldrh x2, [x(PC.0), #(2)];  // base slot
+            // is_func_call = (base slot == self, slot 0): a literal `self[i]`
+            // reaches a private `#[]`; any other receiver enforces visibility.
+            cmp x2, #(0);
         );
+        self.jit.cset(X5, Cond::Eq); // x5 <- (base slot == 0)
         self.a64_slot_value(X2); // base
         monoasm_arm64!(&mut self.jit,
             ldrh x3, [x(PC.0)];
         );
         self.a64_slot_value(X3); // idx
         monoasm_arm64!(&mut self.jit,
-            add x4, x(PC.0), #(8);  // &cache
+            add x4, x(PC.0), #(8);  // &cache (8-aligned)
+            orr x4, x4, x5;         // fold is_func_call into bit 0
             mov x9, (runtime::get_index as *const () as u64);
             blr x9;
         );
@@ -731,8 +736,12 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
-            ldrh x2, [x(PC.0), #(2)];
+            ldrh x2, [x(PC.0), #(2)];  // base slot
+            // is_func_call = (base slot == self, slot 0): `self[i] = v` reaches
+            // a private `#[]=`; any other receiver enforces visibility.
+            cmp x2, #(0);
         );
+        self.jit.cset(X6, Cond::Eq); // x6 <- (base slot == 0)
         self.a64_slot_value(X2); // base
         monoasm_arm64!(&mut self.jit,
             ldrh x3, [x(PC.0)];
@@ -743,7 +752,8 @@ impl Codegen {
         );
         self.a64_slot_value(X4); // src
         monoasm_arm64!(&mut self.jit,
-            add x5, x(PC.0), #(8);  // &cache
+            add x5, x(PC.0), #(8);  // &cache (8-aligned)
+            orr x5, x5, x6;         // fold is_func_call into bit 0
             mov x9, (runtime::set_index as *const () as u64);
             blr x9;
             cbz x0, raise;

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -1019,6 +1019,15 @@ impl Codegen {
     fn vm_index(&mut self) -> CodePtr {
         let label = self.jit.get_current_address();
         self.fetch3();
+        // is_func_call = (base slot == self, slot 0): a literal `self[i]`
+        // reaches a private `#[]`; any other receiver enforces visibility.
+        // rdi still holds the base *slot* here, before it becomes a value.
+        // The bit rides in `class_slot`'s low bit (8-aligned → free).
+        monoasm! { &mut self.jit,
+            xorq rax, rax;
+            testq rdi, rdi;
+            seteq rax;     // rax <- (base slot == 0)
+        };
         self.vm_get_slot_value(GP::Rdi);
         self.vm_get_slot_value(GP::Rsi);
         monoasm! { &mut self.jit,
@@ -1026,7 +1035,8 @@ impl Codegen {
             movq rcx, rsi; // idx: Value
             movq rdi, rbx; // &mut Interp
             movq rsi, r12; // &mut Globals
-            lea  r8, [r13 - 8]; // &mut ClassId
+            lea  r8, [r13 - 8]; // &mut ClassIdSlot
+            orq  r8, rax;  // fold is_func_call into bit 0
             movq rax, (runtime::get_index);
             call rax;
         };
@@ -1039,6 +1049,14 @@ impl Codegen {
     fn vm_index_assign(&mut self) -> CodePtr {
         let label = self.jit.get_current_address();
         self.fetch3();
+        // is_func_call = (base slot == self, slot 0): `self[i] = v` reaches a
+        // private `#[]=`. rdi still holds the base *slot* here. The bit rides
+        // in `class_slot`'s low bit (8-aligned → free).
+        monoasm! { &mut self.jit,
+            xorq rax, rax;
+            testq rdi, rdi;
+            seteq rax;     // rax <- (base slot == 0)
+        };
         self.vm_get_slot_value(GP::R15);
         self.vm_get_slot_value(GP::Rdi);
         self.vm_get_slot_value(GP::Rsi);
@@ -1048,7 +1066,8 @@ impl Codegen {
             movq r8, r15;  // src: Value
             movq rdi, rbx; // &mut Interp
             movq rsi, r12; // &mut Globals
-            lea  r9, [r13 - 8];
+            lea  r9, [r13 - 8]; // &mut ClassIdSlot
+            orq  r9, rax;  // fold is_func_call into bit 0
             movq rax, (runtime::set_index);
             call rax;
         };

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -13,11 +13,11 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(lhs_class) = base_class {
-            // The `Index` fast-path calls `#[]` directly, bypassing the
-            // `is_func_call = false` visibility gate the VM's `get_index`
-            // applies. Bail to the interpreter for a non-public `#[]` so its
-            // `NoMethodError` still fires (a literal `self[i]` reaches a
-            // private `#[]` through the ordinary call site, not here).
+            // The JIT `Index` fast-path calls `#[]` directly without a
+            // visibility check. Bail to the interpreter for a non-public
+            // `#[]`: the VM's `get_index` receives the `is_func_call` bit
+            // (base-slot == self) and so raises `NoMethodError` for a plain
+            // `obj[i]` while letting an explicit-`self` `self[i]` through.
             if !self.jit_index_method_is_public(lhs_class, IdentId::_INDEX) {
                 return Ok(CompileResult::Deopt);
             }
@@ -48,11 +48,12 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(recv_class) = base_class {
-            // The `IndexAssign` fast-path calls `#[]=` directly, bypassing the
-            // `is_func_call = false` visibility gate the VM's `set_index`
-            // applies. Bail to the interpreter for a non-public `#[]=` so its
-            // `NoMethodError` still fires (a literal `self[i] = v` reaches a
-            // private `#[]=` through the ordinary call site, not here).
+            // The JIT `IndexAssign` fast-path calls `#[]=` directly without a
+            // visibility check. Bail to the interpreter for a non-public
+            // `#[]=`: the VM's `set_index` receives the `is_func_call` bit
+            // (base-slot == self) and so raises `NoMethodError` for a plain
+            // `obj[i] = v` while letting an explicit-`self` `self[i] = v`
+            // through.
             if !self.jit_index_method_is_public(recv_class, IdentId::_INDEX_ASSIGN) {
                 return Ok(CompileResult::Deopt);
             }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1299,8 +1299,17 @@ pub(super) extern "C" fn get_index(
     globals: &mut Globals,
     base: Value,
     index: Value,
-    class_slot: &mut ClassIdSlot,
+    // Bit 0 carries `is_func_call`: the VM sets it when the base operand is
+    // slot 0 (a literal `self[i]`), which reaches a private `#[]`; it is clear
+    // for any other receiver, which enforces visibility. The slot lives
+    // 8-aligned in the bytecode stream, so bit 0 is free. Only consulted on
+    // the user-class fallback below — Array/Hash slice with no visibility gate.
+    class_slot: *mut ClassIdSlot,
 ) -> Option<Value> {
+    let is_func_call = (class_slot as usize) & 1 != 0;
+    // SAFETY: the VM passes `&ClassIdSlot | is_func_call`; clearing bit 0
+    // restores the original 8-aligned slot pointer.
+    let class_slot = unsafe { &mut *(((class_slot as usize) & !1) as *mut ClassIdSlot) };
     let base_classid = base.class();
     class_slot.base = base_classid;
     class_slot.idx = index.class();
@@ -1404,7 +1413,7 @@ pub(super) extern "C" fn get_index(
         }
         _ => {}
     }
-    vm.invoke_method_simple(globals, IdentId::_INDEX, base, &[index])
+    vm.invoke_method(globals, IdentId::_INDEX, is_func_call, base, &[index], None, None)
 }
 
 pub(super) extern "C" fn set_index(
@@ -1413,8 +1422,14 @@ pub(super) extern "C" fn set_index(
     base: Value,
     index: Value,
     src: Value,
-    class_slot: &mut ClassIdSlot,
+    // Bit 0 carries `is_func_call` — see `get_index`. `self[i] = v` reaches a
+    // private `#[]=`; any other receiver enforces visibility.
+    class_slot: *mut ClassIdSlot,
 ) -> Option<Value> {
+    let is_func_call = (class_slot as usize) & 1 != 0;
+    // SAFETY: the VM passes `&ClassIdSlot | is_func_call`; clearing bit 0
+    // restores the original 8-aligned slot pointer.
+    let class_slot = unsafe { &mut *(((class_slot as usize) & !1) as *mut ClassIdSlot) };
     let base_classid = base.class();
     class_slot.base = base_classid;
     class_slot.idx = index.class();
@@ -1434,7 +1449,15 @@ pub(super) extern "C" fn set_index(
             }
         };
     }
-    vm.invoke_method_simple(globals, IdentId::_INDEX_ASSIGN, base, &[index, src])
+    vm.invoke_method(
+        globals,
+        IdentId::_INDEX_ASSIGN,
+        is_func_call,
+        base,
+        &[index, src],
+        None,
+        None,
+    )
 }
 
 /*///


### PR DESCRIPTION
## What

#844 (`bytecodegen: self[i] reaches a private #[] / #[]=`) routed `self[i]` / `self[i] = v` through the general `#[]` / `#[]=` **call site** so an explicit-`self` receiver reaches a private `#[]` (matching CRuby). But the Ruby-implemented builtins in [`builtins/array.rb`](monoruby/builtins/array.rb) (`each`, `map`, `each_with_index`, `map!`, binary search, …) use `self[i]` in their hot loops, so every element access became a full method dispatch.

On the **real doom game (Gosu)**, the per-frame framebuffer→RGBA conversion `fb.map { |idx| pal[idx] }.join` — which `bin/doom --bench` never runs — slowed **~40%**. `Array#map` (Ruby) does `res[i] = yield(self[i])`, and that `self[i]` read went to the slow call site.

Found by bisecting a deterministic 64000-element map+join micro-bench (immune to the debug-build timing noise): `423d0e22` (#844) is the first bad commit; the slowdown appears in **both `--jit` and `--no-jit`** (VM/bytecode level).

## Fix

Restore the fast `Index`/`StoreIndex` opcode for single-index `self[i]` / `self[i] = v` **without losing #844's visibility semantics**:

- bytecodegen keeps a literal `self` base as `BcReg::Self_` (slot 0) so the emitted opcode records the receiver as self; a temp base (`x = self; x[i]`) does not.
- The VM (`vm_index` / `vm_index_assign`, **x86-64 + aarch64**) computes `is_func_call = (base slot == 0)` and folds it into the **low bit of the `class_slot` pointer** argument — the slot is 8-aligned in the bytecode stream, so bit 0 is free. This avoids a 7th integer argument to `set_index`, which already uses all six System V arg registers.
- `runtime::get_index` / `set_index` mask the bit back out and pass `is_func_call` to `invoke_method`: a literal `self[i]` reaches a private `#[]` / `#[]=`, while `obj[i]` and `x = self; x[i]` still enforce visibility.
- The JIT `Index`/`IndexAssign` fast path is unchanged: it still bails to the interpreter on a non-public `#[]`, which now lands in the `is_func_call`-aware runtime.

## Perf

| path | before (#844+) | after |
|---|---|---|
| read `self[i]` (fbconv) — jit | 5.3 ms | **4.30 ms** |
| read — no-jit | 17.4 ms | **12.4 ms** |
| write `self[i]=` — jit | 1.28 ms | **0.23 ms** |

(pre-#844 baseline was 4.3 ms / 11.7 ms — fully recovered.)

## Correctness

- `object.rs::self_index_private_visibility` — literal `self[i]` / `self[i]=` / `self[i] op= v` reach a private `#[]` / `#[]=` ✅
- `object.rs::non_self_index_private_visibility` — `obj[i]` and `x = self; x[i]` raise `NoMethodError` ✅
- object/array/hash/string/struct/json suites pass (remaining full-suite blips are the known nextest parallel ruby-spawn flakiness — all pass in isolation).

## Notes

Built + tested on **arm64-darwin (aarch64 backend)**. The **x86-64 backend was not compile-checked locally** (no cross C toolchain for `cargo check --target x86_64`); the x86 asm mirrors the aarch64 change and uses only mnemonics already exercised elsewhere (`seteq rax`, `orq`, `lea`) — relies on CI (Linux/x86-64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)