### PR TITLE
$? / Process.last_status is per-thread; Kernel#system sets $? — fixes the flaky full-core mspec abort/hang

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -1359,7 +1359,7 @@ fn close(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             None,
             None,
         )?;
-        globals.set_gvar(IdentId::get_id("$?"), status_obj);
+        crate::scheduler::set_last_status(vm, status_obj);
     }
     Ok(Value::nil())
 }
@@ -2235,7 +2235,7 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
                     None,
                     None,
                 ) {
-                    globals.set_gvar(IdentId::get_id("$?"), status_obj);
+                    crate::scheduler::set_last_status(vm, status_obj);
                 }
             }
         }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2509,10 +2509,36 @@ fn system(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
             args.push(v.coerce_to_string(vm, globals)?);
         }
     }
-    Ok(match Command::new(program).args(&args).status() {
-        Ok(status) => Value::bool(status.success()),
-        Err(_) => Value::nil(),
-    })
+    let mut child = match Command::new(program).args(&args).spawn() {
+        Ok(child) => child,
+        Err(_) => return Ok(Value::nil()),
+    };
+    let pid = child.id();
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(_) => return Ok(Value::nil()),
+    };
+    // Set `$?` / Process.last_status from the raw wait(2) status, like
+    // CRuby does after #system.
+    {
+        use std::os::unix::process::ExitStatusExt;
+        let raw = status.into_raw();
+        if let Ok(status_class) =
+            vm.get_qualified_constant(globals, OBJECT_CLASS, &["Process", "Status"])
+        {
+            if let Ok(status_obj) = vm.invoke_method_inner(
+                globals,
+                IdentId::NEW,
+                status_class,
+                &[Value::integer(raw as i64), Value::integer(pid as i64)],
+                None,
+                None,
+            ) {
+                crate::scheduler::set_last_status(vm, status_obj);
+            }
+        }
+    }
+    Ok(Value::bool(status.success()))
 }
 
 ///
@@ -2808,7 +2834,7 @@ fn command(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                     None,
                     None,
                 ) {
-                    globals.set_gvar(IdentId::get_id("$?"), status_obj);
+                    crate::scheduler::set_last_status(vm, status_obj);
                 }
             }
             Ok(Value::string_from_vec(output.stdout))

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -645,7 +645,7 @@ fn process_wait(
     _: BytecodePtr,
 ) -> Result<Value> {
     let (pid, status) = do_waitpid(vm, globals, lfp)?;
-    globals.set_gvar(IdentId::get_id("$?"), status);
+    crate::scheduler::set_last_status(vm, status);
     Ok(Value::integer(pid as i64))
 }
 
@@ -662,7 +662,7 @@ fn process_wait2(
     _: BytecodePtr,
 ) -> Result<Value> {
     let (pid, status) = do_waitpid(vm, globals, lfp)?;
-    globals.set_gvar(IdentId::get_id("$?"), status);
+    crate::scheduler::set_last_status(vm, status);
     Ok(Value::array_from_vec(vec![
         Value::integer(pid as i64),
         status,
@@ -727,13 +727,12 @@ fn do_waitpid(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<(i32
 /// [https://docs.ruby-lang.org/ja/latest/method/Process/m/last_status.html]
 #[monoruby_builtin]
 fn last_status(
-    _vm: &mut Executor,
-    globals: &mut Globals,
+    vm: &mut Executor,
+    _globals: &mut Globals,
     _lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let val = globals.get_gvar(IdentId::get_id("$?"));
-    Ok(val.unwrap_or_default())
+    Ok(crate::scheduler::last_status(vm).unwrap_or_default())
 }
 
 /// Canonical signal name ↔ host signo table, built from the running

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -577,6 +577,19 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     }
     globals.define_hooked_variable(IdentId::get_id("$$"), get_pid, None);
 
+    // `$?` — the last child status, kept per thread (CRuby: a fresh
+    // thread sees nil until it reaps a child of its own). Always
+    // defined, wrapping nil, like `$~`. Read-only from Ruby; Rust
+    // writers go through `scheduler::set_last_status`.
+    fn get_last_status(
+        vm: &mut Executor,
+        _globals: &mut Globals,
+        _name: IdentId,
+    ) -> Option<Value> {
+        Some(crate::scheduler::last_status(vm).unwrap_or_default())
+    }
+    globals.define_hooked_variable(IdentId::get_id("$?"), get_last_status, None);
+
     globals.define_hooked_variable(IdentId::get_id("$!"), get_errinfo, None);
     globals.define_hooked_variable(
         IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -253,6 +253,20 @@ pub(crate) fn main_thread(vm: &mut Executor) -> Value {
     SCHEDULER.with(|s| s.borrow().main.unwrap())
 }
 
+/// `$?` / `Process.last_status` of the current thread (CRuby keeps the
+/// last child status per thread).
+pub(crate) fn last_status(vm: &mut Executor) -> Option<Value> {
+    let thread = current_thread(vm);
+    thread.as_thread_inner().last_status
+}
+
+/// Record a reaped child's `Process::Status` as the current thread's
+/// `$?` / `Process.last_status`.
+pub(crate) fn set_last_status(vm: &mut Executor, status: Value) {
+    let mut thread = current_thread(vm);
+    thread.as_thread_inner_mut().last_status = Some(status);
+}
+
 /// All alive threads (`Thread.list`).
 pub(crate) fn thread_list(vm: &mut Executor) -> Vec<Value> {
     ensure_main(vm);

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -84,6 +84,10 @@ pub struct ThreadInner {
     /// Mutex / ConditionVariable / Queue in builtins/startup.rb all park
     /// through patterns that need this.
     pub(crate) park_permit: bool,
+    /// `$?` / `Process.last_status` for this thread. CRuby keeps the
+    /// last child status per thread, so a fresh thread sees `nil` until
+    /// it reaps a child of its own.
+    pub(crate) last_status: Option<Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,6 +153,9 @@ impl alloc::GC<RValue> for ThreadInner {
                 class.mark(alloc);
             }
         }
+        if let Some(v) = self.last_status {
+            v.mark(alloc);
+        }
     }
 }
 
@@ -170,6 +177,7 @@ impl ThreadInner {
             masks: vec![],
             park_blocking: false,
             park_permit: false,
+            last_status: None,
         }
     }
 
@@ -191,6 +199,7 @@ impl ThreadInner {
             masks: vec![],
             park_blocking: false,
             park_permit: false,
+            last_status: None,
         }
     }
 
@@ -213,6 +222,7 @@ impl ThreadInner {
             masks: vec![],
             park_blocking: false,
             park_permit: false,
+            last_status: None,
         }
     }
 


### PR DESCRIPTION
## What

Fixes the rubyspec-stats core-specs hang ([run 29694365372](https://github.com/sisshiki1969/rubyspec-stats/actions/runs/29694365372/job/88212438568), stuck >40 min where the previous green run took 73 s).

## Diagnosis

Reproduced locally: a full `mspec ci core` run intermittently aborts with

```
core/process/setpgrp_spec.rb was executed but did not reset the current example:
Process.setpgrp and Process.getpgrp (RuntimeError)
```

preceded by an async thread failure:

```
#<Thread ...> terminated with exception (report_on_exception is true):
Expected #<Process::Status: pid 27540 exit 0> == #<NilClass> to be truthy but was false
```

That failing thread is `core/process/last_status_spec.rb`:

```ruby
Thread.new do
  Process.last_status.should == nil   # $? is per-thread in CRuby
end.join
```

monoruby stored `$?` in the global-variable table, so a fresh thread saw the status of a child reaped earlier by the main thread — the expectation failed inside the thread every run, and depending on delivery timing the failure could corrupt the surrounding mspec state a few files later (abort locally, hang on the slower CI runner). Bisect note: single-run bisecting first pointed at later commits, but re-running showed the abort is timing-dependent — the trigger spec has been failing all along; recent master timing shifts just raised the trip probability.

## Changes

- `ThreadInner` grows a GC-marked `last_status` slot; `scheduler::{last_status, set_last_status}` access the current thread's slot.
- `$?` becomes a hooked, **read-only** global backed by that slot (assignment still raises `NameError`, `defined?($?)` still reports `"global-variable"`, `$CHILD_STATUS` aliasing unchanged).
- `Process.wait`/`wait2`, backticks, and the IO status writers store through the new helper instead of the gvar table.
- **Bonus:** `Kernel#system` now sets `$?` from the raw wait status (it previously never set it at all) — `spawn` + `wait` instead of `Command::status` so the child pid is available for `Process::Status`.

## Verification

- Behavior matches CRuby 4.0.2 exactly for: fresh-thread `nil`, per-thread isolation (`system` in a thread doesn't clobber main's `$?` and vice versa), `exitstatus` after `system`/backticks (incl. `exit 42`), read-only `NameError`, `defined?($?)`, `English`'s `$CHILD_STATUS`.
- `core/process/last_status_spec.rb`: 3/3 (was 2/3 — the threaded example failed).
- `cargo test`: 1913/1913.
- Full `mspec ci core` stress ×4 with this fix: all complete, 970–972F/1237E (unpatched master in the same environment: intermittent abort at `setpgrp_spec`), and the chronic async thread-exception count drops 19 → 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_