### PR TITLE
Operator method visibility (VM + JIT) + test-helper consolidation

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5316,29 +5316,27 @@ mod tests {
 
     #[test]
     fn hash_mixes_element_hash_value() {
-        // Array#hash sends `#hash` to each element and mixes the resulting
-        // integer, so an element whose `#hash` returns another object is
-        // coerced via `#to_int` and hashes identically to the underlying
-        // value. A numeric element must therefore mix its `Integer#hash` /
-        // `Float#hash` digest (of the value), not its raw tagged bits.
-        run_test(
+        run_tests(&[
+            // Array#hash sends `#hash` to each element and mixes the resulting
+            // integer, so an element whose `#hash` returns another object is
+            // coerced via `#to_int` and hashes identically to the underlying
+            // value. A numeric element must therefore mix its `Integer#hash` /
+            // `Float#hash` digest (of the value), not its raw tagged bits.
             r#"
             x = 1.hash
             o = Object.new
             o.define_singleton_method(:hash) { x }
             [1].hash == [o].hash
             "#,
-        );
-        run_test(
             r#"
             x = 2.5.hash
             o = Object.new
             o.define_singleton_method(:hash) { x }
             [2.5].hash == [o].hash
             "#,
-        );
-        // Structural equality still implies hash equality for numeric content.
-        run_test(r#"[[1, 2.0, 3].hash == [1, 2.0, 3].hash, [1].hash != [2].hash]"#);
+            // Structural equality still implies hash equality for numeric content.
+            r#"[[1, 2.0, 3].hash == [1, 2.0, 3].hash, [1].hash != [2].hash]"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2203,7 +2203,7 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                 sum = Value::float(f + comp);
             }
             comp = 0.0;
-            sum = executor::op::add_values(vm, globals, sum, v).ok_or_else(|| vm.take_error())?;
+            sum = executor::op::add_values(vm, globals, sum, v, false).ok_or_else(|| vm.take_error())?;
         }
     }
     if comp != 0.0

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -421,6 +421,8 @@ pub(crate) extern "C" fn not_match_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    // `!~` keeps its existing (funcall) dispatch; the flag is nominal here.
+    _is_func_call: bool,
 ) -> Option<Value> {
     match not_match_inner(vm, globals, lhs, rhs) {
         Ok(v) => Some(v),
@@ -459,9 +461,10 @@ fn kernel_not_match(
     let CallSiteInfo {
         recv, args, dst, ..
     } = *callsite;
+    let is_func_call = callsite.is_func_call();
     state.write_back_recv_and_callargs(ir, callsite);
     let error = ir.new_error(state);
-    ir.generic_binop(state, recv, args, not_match_values);
+    ir.generic_binop(state, recv, args, not_match_values, is_func_call);
     ir.handle_error(error);
     // The dispatched `=~` can run arbitrary Ruby; invalidate cached
     // guards so subsequent instructions re-establish them.

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -2763,15 +2763,15 @@ mod tests {
 
     #[test]
     fn marshal_dump_regexp() {
-        // Regexp now round-trips through the '/' dump tag.
-        run_test(r#"Marshal.dump(/foo/im).bytes"#);
-        run_test(
+        run_tests(&[
+            // Regexp now round-trips through the '/' dump tag.
+            r#"Marshal.dump(/foo/im).bytes"#,
             r#"
             r = Marshal.load(Marshal.dump(/foo/im))
             [r.source, r.options]
             "#,
-        );
-        run_test(r#"Marshal.load(Marshal.dump(/foo/n)).source"#);
+            r#"Marshal.load(Marshal.dump(/foo/n)).source"#,
+        ]);
     }
 
     #[test]
@@ -2866,29 +2866,31 @@ mod tests {
 
     #[test]
     fn marshal_load_freeze() {
-        // `freeze: true` deep-freezes reconstructed objects but leaves
-        // classes/modules mutable.
-        run_test(r#"Marshal.load(Marshal.dump("foo"), freeze: true).frozen?"#);
-        run_test(r#"Marshal.load(Marshal.dump([1, 2, 3]), freeze: true).frozen?"#);
-        run_test(r#"Marshal.load(Marshal.dump({foo: 42}), freeze: true).frozen?"#);
-        run_test(
+        run_tests(&[
+            // `freeze: true` deep-freezes reconstructed objects but leaves
+            // classes/modules mutable.
+            r#"Marshal.load(Marshal.dump("foo"), freeze: true).frozen?"#,
+            r#"Marshal.load(Marshal.dump([1, 2, 3]), freeze: true).frozen?"#,
+            r#"Marshal.load(Marshal.dump({foo: 42}), freeze: true).frozen?"#,
             r#"
             o = Object.new
             a = Marshal.load(Marshal.dump([o]), freeze: true)
             [a.frozen?, a[0].frozen?]
             "#,
-        );
-        run_test(r#"Marshal.load(Marshal.dump(String), freeze: true).frozen?"#);
-        run_test(r#"Marshal.load(Marshal.dump("bar")).frozen?"#);
+            r#"Marshal.load(Marshal.dump(String), freeze: true).frozen?"#,
+            r#"Marshal.load(Marshal.dump("bar")).frozen?"#,
+        ]);
     }
 
     #[test]
     fn marshal_load_float_mantissa_extension() {
-        // CRuby appends a legacy '\0' + mantissa blob after the decimal
-        // text; the load path must parse the textual prefix and ignore
-        // the trailing raw bytes.
-        run_test(r#"Marshal.load("\x04\bf\v1.3\x00\xcc\xcd")"#);
-        run_test(r#"Marshal.load(Marshal.dump(1.3)) == 1.3"#);
+        run_tests(&[
+            // CRuby appends a legacy '\0' + mantissa blob after the decimal
+            // text; the load path must parse the textual prefix and ignore
+            // the trailing raw bytes.
+            r#"Marshal.load("\x04\bf\v1.3\x00\xcc\xcd")"#,
+            r#"Marshal.load(Marshal.dump(1.3)) == 1.3"#,
+        ]);
     }
 
     #[test]
@@ -2934,39 +2936,33 @@ mod tests {
 
     #[test]
     fn marshal_builtin_ivars() {
-        // Array / Hash / String carrying user instance variables dump
-        // with an 'I' wrapper and round-trip.
-        run_test(
+        run_tests(&[
+            // Array / Hash / String carrying user instance variables dump
+            // with an 'I' wrapper and round-trip.
             r#"
             a = [1, 2]
             a.instance_variable_set(:@foo, 5)
             Marshal.dump(a).bytes
             "#,
-        );
-        run_test(
             r#"
             a = [1, 2]
             a.instance_variable_set(:@foo, 5)
             r = Marshal.load(Marshal.dump(a))
             [r, r.instance_variable_get(:@foo)]
             "#,
-        );
-        run_test(
             r#"
             h = {a: 1}
             h.instance_variable_set(:@foo, 5)
             r = Marshal.load(Marshal.dump(h))
             [r, r.instance_variable_get(:@foo)]
             "#,
-        );
-        run_test(
             r#"
             s = "str"
             s.instance_variable_set(:@foo, 5)
             r = Marshal.load(Marshal.dump(s))
             [r, r.instance_variable_get(:@foo)]
             "#,
-        );
+        ]);
     }
 
     #[test]
@@ -3067,52 +3063,44 @@ mod tests {
 
     #[test]
     fn marshal_load_proc_containers() {
-        // The proc visits hash keys/values and struct members, and works
-        // together with freeze: true.
-        run_test(
+        run_tests(&[
+            // The proc visits hash keys/values and struct members, and works
+            // together with freeze: true.
             r#"
             ret = []
             Marshal.load(Marshal.dump({a: 1, b: 2}), proc { |o| ret << o.inspect; o })
             ret
             "#,
-        );
-        run_test(
             r#"
             S = Struct.new(:a, :b)
             ret = []
             Marshal.load(Marshal.dump(S.new(1, 2)), proc { |o| ret << o.inspect; o })
             ret.size
             "#,
-        );
-        run_test(
             r#"
             ret = []
             r = Marshal.load(Marshal.dump([1, "x"]), proc { |o| ret << o.frozen?; o }, freeze: true)
             [r.frozen?, ret.last]
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_load_proc() {
-        // The load proc is called on every reconstructed value, children
-        // before their parent.
-        run_test(
+        run_tests(&[
+            // The load proc is called on every reconstructed value, children
+            // before their parent.
             r#"
             ret = []
             Marshal.load(Marshal.dump([1, 2]), proc { |o| ret << o.inspect; o })
             ret
             "#,
-        );
-        run_test(
             r#"
             ret = []
             Marshal.load(Marshal.dump([[1], 2]), proc { |o| ret << o.inspect; o })
             ret
             "#,
-        );
-        // A self-reference into an object still being built is not visited.
-        run_test(
+            // A self-reference into an object still being built is not visited.
             r#"
             a = [1]
             a << a
@@ -3120,51 +3108,49 @@ mod tests {
             Marshal.load(Marshal.dump(a), proc { |o| ret << o.inspect; o })
             ret.size
             "#,
-        );
-        // Object links are visited; symbol links are not.
-        run_test(
+            // Object links are visited; symbol links are not.
             r#"
             s = "x"
             ret = []
             Marshal.load(Marshal.dump([s, s]), proc { |o| ret << o.inspect; o })
             ret
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_restore_alias() {
-        // Marshal.restore is the very same method object as Marshal.load.
-        run_test(r#"Marshal.method(:restore) == Marshal.method(:load)"#);
-        run_test(r#"Marshal.restore(Marshal.dump([1, 2, 3]))"#);
+        run_tests(&[
+            // Marshal.restore is the very same method object as Marshal.load.
+            r#"Marshal.method(:restore) == Marshal.method(:load)"#,
+            r#"Marshal.restore(Marshal.dump([1, 2, 3]))"#,
+        ]);
     }
 
     #[test]
     fn marshal_range_bytes() {
-        // Range dumps as an 'o' object with :excl, :begin, :end (in that
-        // order) and round-trips.
-        run_test(r#"Marshal.dump(1..10).bytes"#);
-        run_test(r#"Marshal.dump(1...5).bytes"#);
-        run_test(
+        run_tests(&[
+            // Range dumps as an 'o' object with :excl, :begin, :end (in that
+            // order) and round-trips.
+            r#"Marshal.dump(1..10).bytes"#,
+            r#"Marshal.dump(1...5).bytes"#,
             r#"
             r = Marshal.load(Marshal.dump(1...5))
             [r.begin, r.end, r.exclude_end?]
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_struct_ivars() {
-        // A Struct that carries user ivars dumps with an 'I' wrapper.
-        run_test(
+        run_tests(&[
+            // A Struct that carries user ivars dumps with an 'I' wrapper.
             r#"
             S = Struct.new(:a, :b)
             s = S.new(1, 2)
             s.instance_variable_set(:@x, 9)
             Marshal.dump(s).bytes
             "#,
-        );
-        run_test(
             r#"
             S2 = Struct.new(:a, :b)
             s = S2.new(1, 2)
@@ -3172,28 +3158,26 @@ mod tests {
             r = Marshal.load(Marshal.dump(s))
             [r.a, r.b, r.instance_variable_get(:@x)]
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_symbol_load_encoding() {
-        // A plain non-ASCII symbol loads as binary; an 'I'-wrapped one
-        // loads under its recorded encoding (and a UTF-8 one is identity-
-        // equal to the same literal symbol).
-        run_test(r#"Marshal.load("\x04\b:\b\xE2\x86\x92".b).encoding.to_s"#);
-        run_test(
+        run_tests(&[
+            // A plain non-ASCII symbol loads as binary; an 'I'-wrapped one
+            // loads under its recorded encoding (and a UTF-8 one is identity-
+            // equal to the same literal symbol).
+            r#"Marshal.load("\x04\b:\b\xE2\x86\x92".b).encoding.to_s"#,
             r#"
             s = Marshal.load("\x04\bI:\b\xE2\x86\x92\x06:\x06ET".b)
             [s.to_s, s.encoding.to_s, s == "→".to_sym]
             "#,
-        );
-        // Two UTF-8 symbols sharing the encoding link.
-        run_test(
+            // Two UTF-8 symbols sharing the encoding link.
             r#"
             dump = "\x04\b[\aI:\t\xE2\x82\xACa\x06:\x06ETI:\t\xE2\x82\xACb\x06;\x06T".b
             Marshal.load(dump).map { |s| [s.to_s, s.encoding.to_s] }
             "#,
-        );
+        ]);
     }
 
     #[test]
@@ -3209,63 +3193,55 @@ mod tests {
 
     #[test]
     fn marshal_numeric_edges() {
-        // Float special values and a large Bignum round-trip.
-        run_test(r#"Marshal.load(Marshal.dump(Float::INFINITY)) == Float::INFINITY"#);
-        run_test(r#"Marshal.load(Marshal.dump(-Float::INFINITY)) == -Float::INFINITY"#);
-        run_test(r#"Marshal.load(Marshal.dump(Float::NAN)).nan?"#);
-        run_test(r#"Marshal.load(Marshal.dump(0.0)) == 0.0"#);
-        run_test(r#"Marshal.load(Marshal.dump(-0.0)).to_s"#);
-        run_test(r#"Marshal.load(Marshal.dump(10 ** 100)) == 10 ** 100"#);
-        run_test(r#"Marshal.load(Marshal.dump(-(2 ** 80))) == -(2 ** 80)"#);
+        run_tests(&[
+            // Float special values and a large Bignum round-trip.
+            r#"Marshal.load(Marshal.dump(Float::INFINITY)) == Float::INFINITY"#,
+            r#"Marshal.load(Marshal.dump(-Float::INFINITY)) == -Float::INFINITY"#,
+            r#"Marshal.load(Marshal.dump(Float::NAN)).nan?"#,
+            r#"Marshal.load(Marshal.dump(0.0)) == 0.0"#,
+            r#"Marshal.load(Marshal.dump(-0.0)).to_s"#,
+            r#"Marshal.load(Marshal.dump(10 ** 100)) == 10 ** 100"#,
+            r#"Marshal.load(Marshal.dump(-(2 ** 80))) == -(2 ** 80)"#,
+        ]);
     }
 
     #[test]
     fn marshal_time_zone_offset() {
-        // A UTC time dumps `:zone "UTC"` and reloads as UTC.
-        run_test(
+        run_tests(&[
+            // A UTC time dumps `:zone "UTC"` and reloads as UTC.
             r#"
             t = Time.utc(2012, 1, 1)
             r = Marshal.load(Marshal.dump(t))
             [r.utc?, r.year, r.month, r.day]
             "#,
-        );
-        // A fixed-offset time records `:offset` and keeps it on reload.
-        run_test(
+            // A fixed-offset time records `:offset` and keeps it on reload.
             r#"
             t = Time.new(2007, 11, 1, 15, 25, 0, "+09:00")
             Marshal.load(Marshal.dump(t)).utc_offset
             "#,
-        );
-        // Sub-microsecond nanoseconds survive via the :nano_num ivar.
-        run_test(
+            // Sub-microsecond nanoseconds survive via the :nano_num ivar.
             r#"
             t = Time.now
             Marshal.load(Marshal.dump(t)).nsec == t.nsec
             "#,
-        );
-        // Time carrying a user ivar round-trips it, without leaking the
-        // internal :offset/:zone ivars.
-        run_test(
+            // Time carrying a user ivar round-trips it, without leaking the
+            // internal :offset/:zone ivars.
             r#"
             t = Time.now
             t.instance_variable_set(:@foo, "bar")
             r = Marshal.load(Marshal.dump(t))
             [r.instance_variable_get(:@foo), r.instance_variables.include?(:@zone)]
             "#,
-        );
-        run_test(
             r#"
             Marshal.load(Marshal.dump(Time.now)).instance_variables.empty?
             "#,
-        );
-        // A UTC time also keeps its nanoseconds (Utc branch of the loader).
-        run_test(
+            // A UTC time also keeps its nanoseconds (Utc branch of the loader).
             r#"
             t = Time.now.utc
             r = Marshal.load(Marshal.dump(t))
             [r.utc?, r.nsec == t.nsec]
             "#,
-        );
+        ]);
     }
 
     #[test]
@@ -3325,17 +3301,15 @@ mod tests {
 
     #[test]
     fn marshal_object_non_ascii_ivar() {
-        // An instance-variable name with non-ASCII bytes is written as an
-        // encoding-wrapped symbol key and read back through `read_symbol`.
-        run_test(
+        run_tests(&[
+            // An instance-variable name with non-ASCII bytes is written as an
+            // encoding-wrapped symbol key and read back through `read_symbol`.
             r#"
             o = Object.new
             ivar = "@é".dup.force_encoding("UTF-8").to_sym
             o.instance_variable_set(ivar, 1)
             Marshal.dump(o).bytes
             "#,
-        );
-        run_test(
             r#"
             o = Object.new
             ivar = "@é".dup.force_encoding("UTF-8").to_sym
@@ -3343,7 +3317,7 @@ mod tests {
             r = Marshal.load(Marshal.dump(o))
             [r.instance_variables.map(&:to_s), r.instance_variable_get(ivar)]
             "#,
-        );
+        ]);
     }
 
     #[test]
@@ -3365,11 +3339,13 @@ mod tests {
 
     #[test]
     fn marshal_symbol_encoding() {
-        // A UTF-8 symbol carries an encoding ivar; a binary one does not.
-        run_test(r#"Marshal.dump("→".to_sym).bytes"#);
-        run_test(r#"Marshal.dump("→".dup.force_encoding("binary").to_sym).bytes"#);
-        run_test(r#"Marshal.dump([:"→", :"→"]).bytes"#);
-        run_test(r#"Marshal.load(Marshal.dump("→".to_sym)).to_s"#);
+        run_tests(&[
+            // A UTF-8 symbol carries an encoding ivar; a binary one does not.
+            r#"Marshal.dump("→".to_sym).bytes"#,
+            r#"Marshal.dump("→".dup.force_encoding("binary").to_sym).bytes"#,
+            r#"Marshal.dump([:"→", :"→"]).bytes"#,
+            r#"Marshal.load(Marshal.dump("→".to_sym)).to_s"#,
+        ]);
     }
 
     #[test]
@@ -3509,58 +3485,54 @@ mod tests {
 
     #[test]
     fn marshal_rational_complex() {
-        // Rational / Complex serialize via the 'U' (marshal_dump) tag and
-        // round-trip through their Kernel constructors.
-        run_test(r#"Marshal.dump(Rational(2, 3)).bytes"#);
-        run_test(r#"Marshal.dump(Complex(2, 5)).bytes"#);
-        run_test(r#"Marshal.load(Marshal.dump(Rational(2, 3)))"#);
-        run_test(r#"Marshal.load(Marshal.dump(Complex(2, 5)))"#);
-        run_test(
+        run_tests(&[
+            // Rational / Complex serialize via the 'U' (marshal_dump) tag and
+            // round-trip through their Kernel constructors.
+            r#"Marshal.dump(Rational(2, 3)).bytes"#,
+            r#"Marshal.dump(Complex(2, 5)).bytes"#,
+            r#"Marshal.load(Marshal.dump(Rational(2, 3)))"#,
+            r#"Marshal.load(Marshal.dump(Complex(2, 5)))"#,
             r#"
             r = Rational(2, 3)
             Marshal.load(Marshal.dump([r, r]))
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_dump_string_encoding() {
-        // US-ASCII strings carry a `:E false` ivar; UTF-8 carries
-        // `:E true`; binary strings carry no ivar.
-        run_test(r#"Marshal.dump("abc".force_encoding("US-ASCII")).bytes"#);
-        run_test(r#"Marshal.dump("abc".force_encoding("BINARY")).bytes"#);
-        run_test(r#"Marshal.dump("abc").bytes"#);
-        run_test(
+        run_tests(&[
+            // US-ASCII strings carry a `:E false` ivar; UTF-8 carries
+            // `:E true`; binary strings carry no ivar.
+            r#"Marshal.dump("abc".force_encoding("US-ASCII")).bytes"#,
+            r#"Marshal.dump("abc".force_encoding("BINARY")).bytes"#,
+            r#"Marshal.dump("abc").bytes"#,
             r#"
             s = Marshal.load(Marshal.dump("abc".force_encoding("US-ASCII")))
             s.encoding.to_s
             "#,
-        );
+        ]);
     }
 
     #[test]
     fn marshal_dump_object_links() {
-        // Repeated non-immediate objects share one link slot.
-        run_test(
+        run_tests(&[
+            // Repeated non-immediate objects share one link slot.
             r#"
             s = "string"
             Marshal.dump([s, s]).bytes
             "#,
-        );
-        run_test(
             r#"
             s = "abc"
             a = Marshal.load(Marshal.dump([s, s]))
             a[0].equal?(a[1])
             "#,
-        );
-        run_test(
             r#"
             a = [1]
             arr = Marshal.load(Marshal.dump([a, a, a]))
             [arr[0].equal?(arr[1]), arr[1].equal?(arr[2])]
             "#,
-        );
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -868,7 +868,7 @@ mod tests {
     // change the MatchData or `$~`.
     #[test]
     fn match_data_haystack_snapshot() {
-        run_test(
+        run_tests(&[
             r##"
         s = "hello world foo bar baz " * 10
         m = s.match(/world (\w+)/)
@@ -878,8 +878,6 @@ mod tests {
         after = [m[0], m[1], m.pre_match.bytesize, m.string]
         [before == after, m.string.include?("world"), s.getbyte(6)]
         "##,
-        );
-        run_test(
             r##"
         big = "x" * 100 + "needle" + "y" * 100
         rest = big.byteslice(50..)
@@ -887,16 +885,14 @@ mod tests {
         big.setbyte(150, 33)
         [mt[0], mt.pre_match.bytesize, mt.post_match.bytesize]
         "##,
-        );
-        // Subjects that die before the MatchData does (the snapshot
-        // must keep the haystack alive through GC).
-        run_test(
+            // Subjects that die before the MatchData does (the snapshot
+            // must keep the haystack alive through GC).
             r##"
         mds = 20.times.map { |i| ("p#{i} " + "x" * 64 + " needle#{i}").match(/needle\d+/) }
         GC.start
         mds.each_with_index.map { |m, i| m[0] == "needle#{i}" && m.string.start_with?("p#{i}") }.all?
         "##,
-        );
+        ]);
     }
 
     #[test]
@@ -1137,24 +1133,18 @@ mod tests {
 
     #[test]
     fn match_data_result_encoding() {
-        // Capture / pre_match / post_match strings inherit the subject's
-        // encoding (not a fixed UTF-8/ASCII-8BIT auto-detection).
-        run_test(
+        run_tests(&[
+            // Capture / pre_match / post_match strings inherit the subject's
+            // encoding (not a fixed UTF-8/ASCII-8BIT auto-detection).
             r#"s = "abc".dup.force_encoding(Encoding::EUC_JP); \
                m = s.match(/b/); [m.pre_match.encoding.to_s, m.post_match.encoding.to_s]"#,
-        );
-        run_test(
             r#"s = "abc".dup.force_encoding(Encoding::ISO_8859_1); \
                s.match(/a/).pre_match.encoding.to_s"#,
-        );
-        run_test(
             r#"md = "haystack".dup.force_encoding("euc-jp").match(/(?<t>t(?<a>ack))/u); \
                [md[:t].encoding.to_s, md[1].encoding.to_s]"#,
-        );
-        run_test(
             r#"s = "abc".dup.force_encoding(Encoding::EUC_JP); \
                s.match(/(b)(c)/).captures.map { |x| x.encoding.to_s }"#,
-        );
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/numeric.rs
+++ b/monoruby/src/builtins/numeric.rs
@@ -42,7 +42,7 @@ macro_rules! binop {
         paste! {
             #[monoruby_builtin]
             fn $op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-                match super::op::[<$op _values>](vm, globals, lfp.self_val(), lfp.arg(0)) {
+                match super::op::[<$op _values>](vm, globals, lfp.self_val(), lfp.arg(0), false) {
                     Some(val) => Ok(val),
                     None => {
                         let err = vm.take_error();
@@ -124,7 +124,7 @@ macro_rules! unop {
         paste! {
             #[monoruby_builtin]
             fn $op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-                match super::op::[<$op _value>](vm, globals, lfp.self_val()) {
+                match super::op::[<$op _value>](vm, globals, lfp.self_val(), false) {
                     Some(val) => Ok(val),
                     None => {
                         let err = vm.take_error();
@@ -153,7 +153,7 @@ unop!(neg, bitnot);
 #[monoruby_builtin]
 fn angle(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let is_negative = match super::op::cmp_lt_values(vm, globals, self_val, Value::integer(0)) {
+    let is_negative = match super::op::cmp_lt_values(vm, globals, self_val, Value::integer(0), false) {
         Some(v) => v == Value::bool(true),
         None => return Err(vm.take_error()),
     };

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -393,7 +393,7 @@ fn cmp(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3e=3d.html]
 #[monoruby_builtin]
 fn ge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    crate::executor::op::cmp_ge_values(vm, globals, lfp.self_val(), lfp.arg(0))
+    crate::executor::op::cmp_ge_values(vm, globals, lfp.self_val(), lfp.arg(0), false)
         .ok_or_else(|| vm.take_error())
 }
 
@@ -405,7 +405,7 @@ fn ge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3e.html]
 #[monoruby_builtin]
 fn gt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    crate::executor::op::cmp_gt_values(vm, globals, lfp.self_val(), lfp.arg(0))
+    crate::executor::op::cmp_gt_values(vm, globals, lfp.self_val(), lfp.arg(0), false)
         .ok_or_else(|| vm.take_error())
 }
 
@@ -417,7 +417,7 @@ fn gt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3c=3d.html]
 #[monoruby_builtin]
 fn le(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    crate::executor::op::cmp_le_values(vm, globals, lfp.self_val(), lfp.arg(0))
+    crate::executor::op::cmp_le_values(vm, globals, lfp.self_val(), lfp.arg(0), false)
         .ok_or_else(|| vm.take_error())
 }
 
@@ -429,7 +429,7 @@ fn le(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3c.html]
 #[monoruby_builtin]
 fn lt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    crate::executor::op::cmp_lt_values(vm, globals, lfp.self_val(), lfp.arg(0))
+    crate::executor::op::cmp_lt_values(vm, globals, lfp.self_val(), lfp.arg(0), false)
         .ok_or_else(|| vm.take_error())
 }
 

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -799,7 +799,7 @@ macro_rules! cmpop {
             fn $op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
                 let lhs = lfp.self_val();
                 let rhs = lfp.arg(0);
-                match crate::executor::op::[<cmp_ $op _values>](vm, globals, lhs, rhs) {
+                match crate::executor::op::[<cmp_ $op _values>](vm, globals, lhs, rhs, false) {
                     Some(res) => Ok(res),
                     None => {
                         let err = vm.take_error();
@@ -825,7 +825,7 @@ cmpop!(ge, gt, le, lt);
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3e=3e.html]
 #[monoruby_builtin]
 fn shr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    super::op::shr_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+    super::op::shr_values(vm, globals, lfp.self_val(), lfp.arg(0), false).ok_or_else(|| vm.take_error())
 }
 
 /// Constant-fold `lhs >> rhs` for two i63 fixnums.
@@ -968,7 +968,7 @@ fn shl_overflow_zero(r#gen: &mut Codegen, deopt: &DestLabel) {
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=3c=3c.html]
 #[monoruby_builtin]
 fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    super::op::shl_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+    super::op::shl_values(vm, globals, lfp.self_val(), lfp.arg(0), false).ok_or_else(|| vm.take_error())
 }
 
 fn integer_shl(
@@ -1045,7 +1045,7 @@ fn integer_shl(
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=25.html]
 #[monoruby_builtin]
 fn int_rem(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    super::op::rem_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+    super::op::rem_values(vm, globals, lfp.self_val(), lfp.arg(0), false).ok_or_else(|| vm.take_error())
 }
 
 fn integer_rem(
@@ -1156,7 +1156,7 @@ fn integer_rem_float_rhs(
 /// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/=2a=2a.html]
 #[monoruby_builtin]
 fn int_pow(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    super::op::pow_values(vm, globals, lfp.self_val(), lfp.arg(0)).ok_or_else(|| vm.take_error())
+    super::op::pow_values(vm, globals, lfp.self_val(), lfp.arg(0), false).ok_or_else(|| vm.take_error())
 }
 
 fn integer_pow(

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -624,10 +624,12 @@ mod tests {
 
     #[test]
     fn basicobject_equal_is_alias_of_eq() {
-        // ruby/spec core/basicobject/equal_spec.rb: `equal?` must be the same
-        // method entry as `==` on BasicObject.
-        run_test("BasicObject.instance_method(:equal?) == BasicObject.instance_method(:==)");
-        run_test("BasicObject.public_instance_methods(false).include?(:equal?)");
+        run_tests(&[
+            // ruby/spec core/basicobject/equal_spec.rb: `equal?` must be the same
+            // method entry as `==` on BasicObject.
+            "BasicObject.instance_method(:equal?) == BasicObject.instance_method(:==)",
+            "BasicObject.public_instance_methods(false).include?(:equal?)",
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -713,16 +713,16 @@ mod tests {
 
     #[test]
     fn proc_to_s() {
-        // The address differs per run, so check the stable invariants
-        // (CRuby: `#<Proc:0xADDR FILE:LINE [(lambda)]>`, BINARY encoding;
-        // `inspect` == `to_s`; `:sym.to_proc` shows `(&:sym)`).
-        run_test(r#"proc { }.to_s.encoding.to_s"#);
-        run_test(
+        run_tests(&[
+            // The address differs per run, so check the stable invariants
+            // (CRuby: `#<Proc:0xADDR FILE:LINE [(lambda)]>`, BINARY encoding;
+            // `inspect` == `to_s`; `:sym.to_proc` shows `(&:sym)`).
+            r#"proc { }.to_s.encoding.to_s"#,
             r##"[proc { }.to_s.start_with?("#<Proc:0x"),
                (-> () {}).to_s.include?(" (lambda)"),
                :foo.to_proc.to_s.include?("(&:foo)"),
                proc { }.inspect.start_with?("#<Proc:0x")]"##,
-        );
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1675,19 +1675,17 @@ mod tests {
 
     #[test]
     fn divide_enumerator_arity() {
-        // Arity-2 via the no-block Enumerator: graph/SCC grouping.
-        run_test(
+        run_tests(&[
+            // Arity-2 via the no-block Enumerator: graph/SCC grouping.
             r#"Set[1,2,3,4].divide.each { |a, b| (a + b).even? } == Set[Set[1, 3], Set[2, 4]]"#,
-        );
-        // Arity-1 via the no-block Enumerator: classify grouping.
-        run_test(r#"Set[1,2,3,4].divide.each { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#);
-        // No block -> Enumerator.
-        run_test(r#"Set[1,2,3,4].divide.is_a?(Enumerator)"#);
-        // Direct (non-enumerator) arity-2 / arity-1 still correct.
-        run_test(
+            // Arity-1 via the no-block Enumerator: classify grouping.
+            r#"Set[1,2,3,4].divide.each { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#,
+            // No block -> Enumerator.
+            r#"Set[1,2,3,4].divide.is_a?(Enumerator)"#,
+            // Direct (non-enumerator) arity-2 / arity-1 still correct.
             r#"Set[1,3,4,6,9,10,11].divide { |x, y| (x - y).abs == 1 }.map { |s| s.to_a.sort }.sort"#,
-        );
-        run_test(r#"Set[1,2,3,4].divide { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#);
+            r#"Set[1,2,3,4].divide { |x| x % 2 }.map { |s| s.to_a.sort }.sort"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -9585,11 +9585,23 @@ mod tests {
     }
 
     #[test]
-    fn string_casecmp_invalid_utf8() {
-        run_test(r#""\xc3".casecmp("\xe3")"#);
-        run_test(r#""\xc3".casecmp("\xc3")"#);
-        run_test(r#""a".casecmp("A")"#);
-        run_test(r#""abc".casecmp("ABC")"#);
+    fn string_casecmp() {
+        run_tests(&[
+            // string_casecmp_invalid_utf8
+            r#""\xc3".casecmp("\xe3")"#,
+            r#""\xc3".casecmp("\xc3")"#,
+            r#""a".casecmp("A")"#,
+            r#""abc".casecmp("ABC")"#,
+            // string_casecmp_p_encoding
+            // Binary vs binary: ASCII-only case-insensitive comparison
+            r#""\x41".b.casecmp?("\x61".b)"#,
+            // Binary vs binary: non-ASCII bytes are compared as-is
+            r#""\xC3".b.casecmp?("\xE3".b)"#,
+            // Binary vs UTF-8: incompatible encodings return nil
+            r#""\xC3".b.casecmp?("abc")"#,
+            // UTF-8 vs UTF-8: Unicode case folding
+            r#""ä".casecmp?("Ä")"#,
+        ]);
     }
 
     #[test]
@@ -9604,100 +9616,90 @@ mod tests {
     }
 
     #[test]
-    fn string_casecmp_p_encoding() {
-        // Binary vs binary: ASCII-only case-insensitive comparison
-        run_test(r#""\x41".b.casecmp?("\x61".b)"#);
-        // Binary vs binary: non-ASCII bytes are compared as-is
-        run_test(r#""\xC3".b.casecmp?("\xE3".b)"#);
-        // Binary vs UTF-8: incompatible encodings return nil
-        run_test(r#""\xC3".b.casecmp?("abc")"#);
-        // UTF-8 vs UTF-8: Unicode case folding
-        run_test(r#""ä".casecmp?("Ä")"#);
-    }
-
-    #[test]
     fn string_xnn_literal_is_utf8() {
-        // Source-file `\xNN` escapes inherit the source (UTF-8) encoding
-        // regardless of whether the resulting bytes form valid UTF-8,
-        // matching CRuby.
-        run_test(r#""\xC3\xA9".encoding.name"#);
-        run_test(r#""\xC3\xA9".valid_encoding?"#);
-        run_test(r#""\xA9".encoding.name"#);
-        run_test(r#""\xA9".valid_encoding?"#);
-        run_test(r#""\xe3\x81\x82".encoding.name"#);
-        run_test(r#""\xe3\x81\x82".valid_encoding?"#);
+        run_tests(&[
+            // Source-file `\xNN` escapes inherit the source (UTF-8) encoding
+            // regardless of whether the resulting bytes form valid UTF-8,
+            // matching CRuby.
+            r#""\xC3\xA9".encoding.name"#,
+            r#""\xC3\xA9".valid_encoding?"#,
+            r#""\xA9".encoding.name"#,
+            r#""\xA9".valid_encoding?"#,
+            r#""\xe3\x81\x82".encoding.name"#,
+            r#""\xe3\x81\x82".valid_encoding?"#,
+        ]);
     }
 
     #[test]
     fn string_multibyte_char_boundary_check() {
-        // é (UTF-8 0xC3 0xA9) is a single character; start_with?/end_with?
-        // on a mid-character byte must return false even though the byte
-        // literally matches.
-        run_test(r#""\xC3\xA9".start_with?("\xC3")"#);
-        run_test(r#""\xC3\xA9".end_with?("\xA9")"#);
-        // 3-byte sequence for あ (UTF-8 0xE3 0x81 0x82)
-        run_test(r#""\xe3\x81\x82".end_with?("\x82")"#);
-        run_test(r#""\xe3\x81\x82".start_with?("\xe3")"#);
-        // Full-character match still succeeds.
-        run_test(r#""\xC3\xA9".start_with?("\xC3\xA9")"#);
-        run_test(r#""\xC3\xA9".end_with?("\xC3\xA9")"#);
+        run_tests(&[
+            // é (UTF-8 0xC3 0xA9) is a single character; start_with?/end_with?
+            // on a mid-character byte must return false even though the byte
+            // literally matches.
+            r#""\xC3\xA9".start_with?("\xC3")"#,
+            r#""\xC3\xA9".end_with?("\xA9")"#,
+            // 3-byte sequence for あ (UTF-8 0xE3 0x81 0x82)
+            r#""\xe3\x81\x82".end_with?("\x82")"#,
+            r#""\xe3\x81\x82".start_with?("\xe3")"#,
+            // Full-character match still succeeds.
+            r#""\xC3\xA9".start_with?("\xC3\xA9")"#,
+            r#""\xC3\xA9".end_with?("\xC3\xA9")"#,
+        ]);
     }
 
     #[test]
     fn string_index_at_end() {
-        run_test(r#""blablabla".index("", 9)"#);
-        run_test(r#""blablabla".index("", 10)"#);
-        run_test(r#""abc".index("", 3)"#);
-        run_test(r#""abc".index("", 0)"#);
+        run_tests(&[
+            r#""blablabla".index("", 9)"#,
+            r#""blablabla".index("", 10)"#,
+            r#""abc".index("", 3)"#,
+            r#""abc".index("", 0)"#,
+        ]);
     }
 
     #[test]
     fn string_rindex_zero_width() {
-        run_test(r#""blablabla".rindex(/.{0}/)"#);
-        run_test(r#""blablabla".rindex(/.*/)"#);
-        run_test(r#""hello".rindex(/.{0}/)"#);
+        run_tests(&[
+            r#""blablabla".rindex(/.{0}/)"#,
+            r#""blablabla".rindex(/.*/)"#,
+            r#""hello".rindex(/.{0}/)"#,
+        ]);
     }
 
     #[test]
-    fn string_rindex_string_basic() {
-        run_test(r#""hello".rindex("l")"#);
-        run_test(r#""hello".rindex("ll")"#);
-        run_test(r#""hello".rindex("z")"#);
-        run_test(r#""ababab".rindex("ab")"#);
-        run_test(r#""hello".rindex("hello")"#);
-        // Long haystack with many occurrences: the previous
-        // implementation paid a regex match per char boundary.
-        run_test(r#"("foo bar baz " * 50).rindex("bar")"#);
-    }
-
-    #[test]
-    fn string_rindex_string_with_pos() {
-        // pos clamps the maximum match-start position.
-        run_test(r#""hello".rindex("l", 2)"#);
-        run_test(r#""hello".rindex("l", 1)"#);
-        run_test(r#""hello".rindex("l", 100)"#); // positive clamp
-        run_test(r#""hello".rindex("hello", -1)"#); // negative-but-in-range
-        run_test(r#""hello".rindex("a", -100)"#); // negative overflow → nil
-        run_test(r#""ababab".rindex("ab", 3)"#);
-    }
-
-    #[test]
-    fn string_rindex_string_empty_needle() {
-        // Empty needle returns `pos` (capped at char_len).
-        run_test(r#""hello".rindex("")"#);
-        run_test(r#""hello".rindex("", 3)"#);
-        run_test(r#""hello".rindex("", 100)"#);
-        run_test(r#""".rindex("")"#);
-    }
-
-    #[test]
-    fn string_rindex_string_utf8() {
-        // Char-level positions on multibyte strings.
-        run_test(r#""あいうあいう".rindex("いう")"#);
-        run_test(r#""あいうあいう".rindex("いう", 2)"#);
-        run_test(r#""あいうあいう".rindex("い")"#);
-        // Match at the start.
-        run_test(r#""あいう".rindex("あ")"#);
+    fn string_rindex_string() {
+        run_tests(&[
+            // string_rindex_string_basic
+            r#""hello".rindex("l")"#,
+            r#""hello".rindex("ll")"#,
+            r#""hello".rindex("z")"#,
+            r#""ababab".rindex("ab")"#,
+            r#""hello".rindex("hello")"#,
+            // Long haystack with many occurrences: the previous
+            // implementation paid a regex match per char boundary.
+            r#"("foo bar baz " * 50).rindex("bar")"#,
+            // string_rindex_string_with_pos
+            // pos clamps the maximum match-start position.
+            r#""hello".rindex("l", 2)"#,
+            r#""hello".rindex("l", 1)"#,
+            r#""hello".rindex("l", 100)"#, // positive clamp
+            r#""hello".rindex("hello", -1)"#, // negative-but-in-range
+            r#""hello".rindex("a", -100)"#, // negative overflow → nil
+            r#""ababab".rindex("ab", 3)"#,
+            // string_rindex_string_empty_needle
+            // Empty needle returns `pos` (capped at char_len).
+            r#""hello".rindex("")"#,
+            r#""hello".rindex("", 3)"#,
+            r#""hello".rindex("", 100)"#,
+            r#""".rindex("")"#,
+            // string_rindex_string_utf8
+            // Char-level positions on multibyte strings.
+            r#""あいうあいう".rindex("いう")"#,
+            r#""あいうあいう".rindex("いう", 2)"#,
+            r#""あいうあいう".rindex("い")"#,
+            // Match at the start.
+            r#""あいう".rindex("あ")"#,
+        ]);
     }
 
     #[test]
@@ -10127,9 +10129,11 @@ mod tests {
 
     #[test]
     fn string_index_with_string() {
-        // String#[] with a String argument should return substring or nil
-        run_test(r#""abcde"["bc"]"#);
-        run_test(r#""abcde"["xy"]"#);
+        run_tests(&[
+            // String#[] with a String argument should return substring or nil
+            r#""abcde"["bc"]"#,
+            r#""abcde"["xy"]"#,
+        ]);
     }
 
     #[test]
@@ -10179,50 +10183,44 @@ mod tests {
     }
 
     #[test]
-    fn string_byterindex_basics() {
-        // String pattern, default offset (= bytesize): last occurrence.
-        run_test(r#""blablabla".byterindex("a")"#);
-        run_test(r#""blablabla".byterindex("la")"#);
-        run_test(r#""blablabla".byterindex("bla")"#);
-        run_test(r#""blablabla".byterindex("abla")"#);
-        run_test(r#""blablabla".byterindex("blablabla")"#);
-        // No match.
-        run_test(r#""blablabla".byterindex("z")"#);
-        run_test(r#""blablabla".byterindex("blablablabla")"#);
-        // Empty pattern returns the offset (or bytesize if not given).
-        run_test(r#""blablabla".byterindex("")"#);
-        run_test(r#""blablabla".byterindex("", 0)"#);
-        run_test(r#""blablabla".byterindex("", 5)"#);
-        run_test(r#""blablabla".byterindex("", 10)"#); // clamped
-    }
-
-    #[test]
-    fn string_byterindex_with_offset() {
-        run_test(r#""blablabla".byterindex("blab", 0)"#);
-        run_test(r#""blablabla".byterindex("blab", 3)"#);
-        run_test(r#""blablabla".byterindex("blab", 6)"#);
-        // Negative offset: counts from end.
-        run_test(r#""blablabla".byterindex("bla", -1)"#);
-        run_test(r#""blablabla".byterindex("bla", -100)"#); // out of range -> nil
-    }
-
-    #[test]
-    fn string_byterindex_regex() {
-        run_test(r#""blablabla".byterindex(/bla/)"#);
-        run_test(r#""blablabla".byterindex(/.{1}/)"#);
-        run_test(r#""blablabla".byterindex(/.l./)"#);
-        run_test(r#""blablabla".byterindex(/bla|a/)"#);
-        // Anchors.
-        run_test(r#""blablabla".byterindex(/\A/)"#);
-        run_test(r#""blablabla".byterindex(/\z/)"#);
-        run_test(r#""blablabla\n".byterindex(/\Z/)"#);
-    }
-
-    #[test]
-    fn string_byterindex_multibyte() {
-        run_test(r#""ありがりがとう".byterindex("が")"#); // 12
-        run_test(r#""ありがりがとう".byterindex(/が/)"#); // 12
-        run_test(r#""ありがりがとう".byterindex("が", 9)"#); // 6
+    fn string_byterindex() {
+        run_tests(&[
+            // string_byterindex_basics
+            // String pattern, default offset (= bytesize): last occurrence.
+            r#""blablabla".byterindex("a")"#,
+            r#""blablabla".byterindex("la")"#,
+            r#""blablabla".byterindex("bla")"#,
+            r#""blablabla".byterindex("abla")"#,
+            r#""blablabla".byterindex("blablabla")"#,
+            // No match.
+            r#""blablabla".byterindex("z")"#,
+            r#""blablabla".byterindex("blablablabla")"#,
+            // Empty pattern returns the offset (or bytesize if not given).
+            r#""blablabla".byterindex("")"#,
+            r#""blablabla".byterindex("", 0)"#,
+            r#""blablabla".byterindex("", 5)"#,
+            r#""blablabla".byterindex("", 10)"#, // clamped
+            // string_byterindex_with_offset
+            r#""blablabla".byterindex("blab", 0)"#,
+            r#""blablabla".byterindex("blab", 3)"#,
+            r#""blablabla".byterindex("blab", 6)"#,
+            // Negative offset: counts from end.
+            r#""blablabla".byterindex("bla", -1)"#,
+            r#""blablabla".byterindex("bla", -100)"#, // out of range -> nil
+            // string_byterindex_regex
+            r#""blablabla".byterindex(/bla/)"#,
+            r#""blablabla".byterindex(/.{1}/)"#,
+            r#""blablabla".byterindex(/.l./)"#,
+            r#""blablabla".byterindex(/bla|a/)"#,
+            // Anchors.
+            r#""blablabla".byterindex(/\A/)"#,
+            r#""blablabla".byterindex(/\z/)"#,
+            r#""blablabla\n".byterindex(/\Z/)"#,
+            // string_byterindex_multibyte
+            r#""ありがりがとう".byterindex("が")"#, // 12
+            r#""ありがりがとう".byterindex(/が/)"#, // 12
+            r#""ありがりがとう".byterindex("が", 9)"#, // 6
+        ]);
     }
 
     #[test]
@@ -10244,27 +10242,29 @@ mod tests {
     }
 
     #[test]
-    fn string_to_c() {
-        run_test(r#""1+2i".to_c.inspect"#);
-        run_test(r#""3".to_c.inspect"#);
-        run_test(r#""i".to_c.inspect"#);
-        run_test(r#""".to_c.inspect"#);
-        run_test(r#""-3+4i".to_c.inspect"#);
-    }
-
-    #[test]
-    fn string_to_r() {
-        run_test(r#""1/3".to_r.inspect"#);
-        run_test(r#""0.5".to_r.inspect"#);
-        run_test(r#""1".to_r.inspect"#);
-        run_test(r#""".to_r.inspect"#);
+    fn string_to_c_r() {
+        run_tests(&[
+            // string_to_c
+            r#""1+2i".to_c.inspect"#,
+            r#""3".to_c.inspect"#,
+            r#""i".to_c.inspect"#,
+            r#""".to_c.inspect"#,
+            r#""-3+4i".to_c.inspect"#,
+            // string_to_r
+            r#""1/3".to_r.inspect"#,
+            r#""0.5".to_r.inspect"#,
+            r#""1".to_r.inspect"#,
+            r#""".to_r.inspect"#,
+        ]);
     }
 
     #[test]
     fn slice_bang_with_string() {
-        run_test(r#"s = "hello world"; s.slice!("world"); s"#);
-        run_test(r#"s = "hello"; s.slice!("xyz")"#);
-        run_test(r#"s = "abcabc"; s.slice!("bc"); s"#);
+        run_tests(&[
+            r#"s = "hello world"; s.slice!("world"); s"#,
+            r#"s = "hello"; s.slice!("xyz")"#,
+            r#"s = "abcabc"; s.slice!("bc"); s"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -451,19 +451,21 @@ mod tests {
 
     #[test]
     fn defined_logical_and_match_ops() {
-        // `&&` / `||` / `and` / `or` are expressions (operands not
-        // checked); `=~` / `!~` are method calls. Previously these
-        // panicked (`unimplemented!`) and aborted the process.
-        run_test(r#"a = 1; b = 2; defined?(a && b)"#);
-        run_test(r#"defined?(1 || 2)"#);
-        run_test(r#"a = 1; defined?(a and 2)"#);
-        run_test(r#"defined?(1 or 2)"#);
-        run_test(r#"defined?(undef_x && 1)"#);
-        run_test(r#"defined?(undef_x || undef_y)"#);
-        run_test(r#"defined?("x" =~ /x/)"#);
-        run_test(r#"defined?(1 =~ 2).inspect"#);
-        run_test(r#"defined?(1 !~ 2)"#);
-        run_test(r#"defined?(undef_x =~ /a/).inspect"#);
+        run_tests(&[
+            // `&&` / `||` / `and` / `or` are expressions (operands not
+            // checked); `=~` / `!~` are method calls. Previously these
+            // panicked (`unimplemented!`) and aborted the process.
+            r#"a = 1; b = 2; defined?(a && b)"#,
+            r#"defined?(1 || 2)"#,
+            r#"a = 1; defined?(a and 2)"#,
+            r#"defined?(1 or 2)"#,
+            r#"defined?(undef_x && 1)"#,
+            r#"defined?(undef_x || undef_y)"#,
+            r#"defined?("x" =~ /x/)"#,
+            r#"defined?(1 =~ 2).inspect"#,
+            r#"defined?(1 !~ 2)"#,
+            r#"defined?(undef_x =~ /a/).inspect"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -2275,9 +2275,9 @@ mod tests {
 
     #[test]
     fn next_and_break_run_loop_ensures() {
-        // `next` / `break` inside `begin/ensure` nested in a `while`/`until`
-        // loop must run the enclosing `ensure` blocks (innermost first).
-        run_test(
+        run_tests(&[
+            // `next` / `break` inside `begin/ensure` nested in a `while`/`until`
+            // loop must run the enclosing `ensure` blocks (innermost first).
             r#"
             log = []; x = true
             while x
@@ -2294,8 +2294,6 @@ mod tests {
             end
             log
             "#,
-        );
-        run_test(
             r#"
             log = []; x = 1
             until false
@@ -2309,7 +2307,7 @@ mod tests {
             end
             log
             "#,
-        );
+        ]);
     }
 
     #[test]

--- a/monoruby/src/codegen/arch/aarch64/compile.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile.rs
@@ -3608,6 +3608,7 @@ impl Codegen {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
@@ -3622,6 +3623,7 @@ impl Codegen {
         self.a64_frame_load(2, lfp, off_l); // x2 = lhs
         self.a64_frame_load(3, lfp, off_r); // x3 = rhs
         monoasm_arm64!(&mut self.jit,
+            mov x4, (is_func_call as u64); // is_func_call
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;
@@ -3801,6 +3803,7 @@ impl Codegen {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) -> bool {
         let lfp = GP::R14.a64().0; // x22
@@ -3842,6 +3845,7 @@ impl Codegen {
         slow:
             mov x0, x19;                 // vm
             mov x1, x20;                 // globals (x2=lhs, x3=rhs intact)
+            mov x4, (is_func_call as u64); // is_func_call
         );
         // Save the live FP pool only on the slow path: the C call clobbers the
         // caller-saved d2.. pool regs, but the inline fast path above (which

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -279,6 +279,11 @@ impl Codegen {
         );
         self.a64_slot_value(X2); // reload src (get_class clobbered x2)
         monoasm_arm64!(&mut self.jit,
+            // is_func_call = (operand slot == self slot 0). The operand slot is
+            // the `[PC+2]` bytecode operand; passed in x3 (4th C-arg).
+            ldrh x3, [x(PC.0), #(2)];
+            cmp x3, #(0);
+            cset x3, eq;
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x9, (abs);
@@ -1983,9 +1988,14 @@ impl Codegen {
         // survive get_class), clobbers x0/x1/x2 and x10/x11/x12.
         self.a64_save_binary_class();
         monoasm_arm64!(&mut self.jit,
-        // cmp_*_values(vm, globals, lhs=X13, rhs=X14) -> Option<Value>
+        // cmp_*_values(vm, globals, lhs=X13, rhs=X14, is_func_call) -> Option<Value>
             mov x2, x13;  // lhs
             mov x3, x14;  // rhs
+            // is_func_call = (lhs slot == self slot 0); the lhs slot is the
+            // `[PC+2]` bytecode operand. Passed in x4 (5th C-arg).
+            ldrh x4, [x(PC.0), #(2)];
+            cmp x4, #(0);
+            cset x4, eq;
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x9, (cmp_fn);
@@ -2133,6 +2143,11 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             mov x2, x13;  // lhs
             mov x3, x14;  // rhs
+            // is_func_call = (lhs slot == self slot 0). The lhs slot is the
+            // `[PC+2]` bytecode operand; passed in x4 (5th C-arg).
+            ldrh x4, [x(PC.0), #(2)];
+            cmp x4, #(0);
+            cset x4, eq;
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x9, (func as u64);
@@ -2362,6 +2377,11 @@ impl Codegen {
         monoasm_arm64!(&mut self.jit,
             mov x2, x13;
             mov x3, x14;
+            // is_func_call = (lhs slot == self slot 0); the lhs slot is the
+            // `[PC+2]` bytecode operand. Passed in x4 (5th C-arg).
+            ldrh x4, [x(PC.0), #(2)];
+            cmp x4, #(0);
+            cset x4, eq;
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x9, (cmp_fn);

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1217,6 +1217,7 @@ impl Codegen {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) {
         self.fpr_save(using_fpr);
@@ -1225,6 +1226,7 @@ impl Codegen {
         monoasm!( &mut self.jit,
             movq rdi, rbx;
             movq rsi, r12;
+            movq r8, (is_func_call as u64);
             movq rax, (func);
             call rax;
         );
@@ -1251,6 +1253,7 @@ impl Codegen {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) {
         self.load_rdx(lhs);
@@ -1291,6 +1294,7 @@ impl Codegen {
         monoasm!( &mut self.jit,
             movq rdi, rbx;
             movq rsi, r12;
+            movq r8, (is_func_call as u64);
             movq rax, (func);
             call rax;
         );
@@ -1824,9 +1828,10 @@ impl Codegen {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) -> bool {
-        self.generic_binop(lhs, rhs, func, using_fpr);
+        self.generic_binop(lhs, rhs, func, is_func_call, using_fpr);
         true
     }
 
@@ -1855,9 +1860,10 @@ impl Codegen {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     ) -> bool {
-        self.opt_eq_cmp(lhs, rhs, kind, func, using_fpr);
+        self.opt_eq_cmp(lhs, rhs, kind, func, is_func_call, using_fpr);
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -651,7 +651,7 @@ impl Codegen {
             movzxw rax, [r13 - 14];
             xorq  r8, r8;
             testq rax, rax;
-            seteq r8b;
+            seteq r8;
         };
         self.call_binop(func);
         self.vm_handle_error();

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -626,6 +626,15 @@ impl Codegen {
     fn vm_generic_unop(&mut self, generic: &DestLabel, func: UnaryOpFn) {
         self.jit.bind_label(generic.clone());
         self.vm_save_lhs_class();
+        // is_func_call = (operand slot == self slot 0); the operand slot is the
+        // `:2` bytecode operand at [r13 - 14]. Passed to the helper in rcx (the
+        // 4th C-arg) for its method-visibility fallback.
+        monoasm! { &mut self.jit,
+            movzxw rax, [r13 - 14];
+            xorq  rcx, rcx;
+            testq rax, rax;
+            seteq cl;
+        };
         self.call_unop(func);
         self.vm_handle_error();
         self.vm_store_r15(GP::Rax);
@@ -635,6 +644,15 @@ impl Codegen {
     fn vm_generic_binop(&mut self, generic: &DestLabel, func: BinaryOpFn) {
         self.jit.bind_label(generic.clone());
         self.vm_save_binary_class();
+        // is_func_call = (lhs slot == self slot 0); the lhs slot is the `:2`
+        // bytecode operand at [r13 - 14]. Passed to the helper in r8 (the 5th
+        // C-arg) for its method-visibility fallback.
+        monoasm! { &mut self.jit,
+            movzxw rax, [r13 - 14];
+            xorq  r8, r8;
+            testq rax, rax;
+            seteq r8b;
+        };
         self.call_binop(func);
         self.vm_handle_error();
         self.vm_store_r15(GP::Rax);

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -704,12 +704,14 @@ impl AsmIr {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
     ) {
         let using_fpr = state.using_fpr_offset();
         self.push(AsmInst::GenericBinOp {
             lhs,
             rhs,
             func,
+            is_func_call,
             using_fpr,
         });
     }
@@ -729,6 +731,7 @@ impl AsmIr {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
     ) {
         let using_fpr = state.using_fpr_offset();
         self.push(AsmInst::OptEqCmp {
@@ -736,6 +739,7 @@ impl AsmIr {
             rhs,
             kind,
             func,
+            is_func_call,
             using_fpr,
         });
     }
@@ -1755,6 +1759,10 @@ pub(super) enum AsmInst {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        /// Call site's func-call flag, passed to the helper for its
+        /// method-visibility fallback (a private operator is callable
+        /// only from a func-call site).
+        is_func_call: bool,
         using_fpr: UsingFpr,
     },
 
@@ -1769,6 +1777,7 @@ pub(super) enum AsmInst {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     },
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -800,11 +800,11 @@ impl Codegen {
                 self.encode_linst(LInst::DefinedIvar { dst, name, using_fpr })
             }
             // Generic binary-op / Array=== runtime calls.
-            AsmInst::GenericBinOp { lhs, rhs, func, using_fpr } => {
-                self.encode_linst(LInst::GenericBinOp { lhs, rhs, func, using_fpr })
+            AsmInst::GenericBinOp { lhs, rhs, func, is_func_call, using_fpr } => {
+                self.encode_linst(LInst::GenericBinOp { lhs, rhs, func, is_func_call, using_fpr })
             }
-            AsmInst::OptEqCmp { lhs, rhs, kind, func, using_fpr } => {
-                self.encode_linst(LInst::OptEqCmp { lhs, rhs, kind, func, using_fpr })
+            AsmInst::OptEqCmp { lhs, rhs, kind, func, is_func_call, using_fpr } => {
+                self.encode_linst(LInst::OptEqCmp { lhs, rhs, kind, func, is_func_call, using_fpr })
             }
             AsmInst::ArrayTEq { lhs, rhs, using_fpr } => {
                 self.encode_linst(LInst::ArrayTEq { lhs, rhs, using_fpr })
@@ -1289,11 +1289,11 @@ impl Codegen {
             LInst::DefinedIvar { dst, name, using_fpr } => {
                 self.emit_defined_ivar(dst, name, using_fpr);
             }
-            LInst::GenericBinOp { lhs, rhs, func, using_fpr } => {
-                self.emit_generic_binop(lhs, rhs, func, using_fpr);
+            LInst::GenericBinOp { lhs, rhs, func, is_func_call, using_fpr } => {
+                self.emit_generic_binop(lhs, rhs, func, is_func_call, using_fpr);
             }
-            LInst::OptEqCmp { lhs, rhs, kind, func, using_fpr } => {
-                self.emit_opt_eq_cmp(lhs, rhs, kind, func, using_fpr);
+            LInst::OptEqCmp { lhs, rhs, kind, func, is_func_call, using_fpr } => {
+                self.emit_opt_eq_cmp(lhs, rhs, kind, func, is_func_call, using_fpr);
             }
             LInst::ArrayTEq { lhs, rhs, using_fpr } => {
                 self.emit_array_teq(lhs, rhs, using_fpr);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -1094,28 +1094,42 @@ impl<'a> JitContext<'a> {
     }
 
     ///
-    /// Whether *name* resolves to a **public** method on *class_id* at compile
-    /// time (or is not defined at all, i.e. no visibility constraint applies
-    /// here — that case is handled elsewhere).
+    /// Whether CRuby method visibility forbids compiling this call site inline,
+    /// so it must instead deopt to the VM. Applied at the single dispatch choke
+    /// point (`compile_method_call`), it covers both operator dispatch (`#[]`,
+    /// `#[]=`, arithmetic / comparison / unary operators) and ordinary method
+    /// calls whose receiver class is resolved at compile time.
     ///
-    /// The `Index` / `IndexAssign` fast paths call the resolved `#[]` / `#[]=`
-    /// directly, without the `is_func_call = false` visibility gate that the
-    /// VM's `get_index` / `set_index` apply. A non-public `#[]` / `#[]=` must
-    /// therefore not be compiled inline (it would be reachable from JIT while
-    /// the interpreter correctly raises `NoMethodError`); such sites bail to
-    /// the interpreter instead.
+    /// A `Private` method reached without a func-call receiver (`recv` is not
+    /// the literal `self` slot and the site is not a visibility-bypassing send)
+    /// is never a valid call, so such a site is handed to the VM, which raises
+    /// `NoMethodError`. `Public` methods, func-call sites, and `super`
+    /// (`name == None`, which bypasses visibility) are always inlinable.
     ///
-    fn jit_index_method_is_public(&self, class_id: ClassId, name: IdentId) -> bool {
-        let class_version = self.class_version();
-        match self
-            .store
-            .check_method_for_class_with_version(class_id, name, class_version)
-        {
-            Some(entry) => entry.visibility() == Visibility::Public,
-            // Not defined here: let the ordinary `MethodNotFound` path handle
-            // it rather than forcing a deopt.
-            None => true,
+    /// `Protected` is intentionally *not* blocked here: the protected receiver
+    /// `kind_of?` test depends on the runtime `self`, which the compiler cannot
+    /// pin (the same method body may run with different `self`s), and a hot
+    /// site was already validated by the VM. Deopting every protected call
+    /// would regress valid protected dispatch for no correctness gain the JIT
+    /// can guarantee statically; protected enforcement stays with the VM.
+    ///
+    fn jit_visibility_blocks(&self, recv_class: ClassId, callid: CallSiteId) -> bool {
+        let callsite = &self.store[callid];
+        // `super` (no method name) bypasses visibility.
+        let Some(name) = callsite.name else {
+            return false;
+        };
+        // A func-call receiver (literal `self` / visibility-bypassing send)
+        // may call private and protected methods.
+        if callsite.is_func_call() {
+            return false;
         }
+        let class_version = self.class_version();
+        matches!(
+            self.store
+                .check_method_for_class_with_version(recv_class, name, class_version),
+            Some(entry) if entry.visibility() == Visibility::Private
+        )
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -958,11 +958,11 @@ impl<'a> JitContext<'a> {
         name: impl Into<IdentId>,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
-        if let Some(func_id) = self.jit_check_method(recv_class, name.into()) {
+        if let Some((func_id, visibility)) = self.jit_check_method(recv_class, name.into()) {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, recv);
             assert_eq!(self.store[callid].pos_num, 0);
-            self.compile_method_call(state, ir, recv_class, None, func_id, callid, false)
+            self.compile_method_call(state, ir, recv_class, None, func_id, visibility, callid, false)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::MethodNotFound))
         }
@@ -980,7 +980,7 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
         recompile_on_recv_miss: bool,
     ) -> JitResult<CompileResult> {
-        if let Some(fid) = self.jit_check_method(lhs_class, name.into()) {
+        if let Some((fid, visibility)) = self.jit_check_method(lhs_class, name.into()) {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, lhs);
             assert_eq!(self.store[callid].args, rhs);
@@ -991,6 +991,7 @@ impl<'a> JitContext<'a> {
                 lhs_class,
                 rhs_class,
                 fid,
+                visibility,
                 callid,
                 recompile_on_recv_miss,
             )
@@ -1011,13 +1012,13 @@ impl<'a> JitContext<'a> {
         name: impl Into<IdentId>,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
-        if let Some(fid) = self.jit_check_method(recv_class, name.into()) {
+        if let Some((fid, visibility)) = self.jit_check_method(recv_class, name.into()) {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, recv);
             assert_eq!(self.store[callid].args, idx);
             assert_eq!(self.store[callid].args + 1usize, src);
             assert_eq!(self.store[callid].pos_num, 2);
-            self.compile_method_call(state, ir, recv_class, idx_class, fid, callid, false)
+            self.compile_method_call(state, ir, recv_class, idx_class, fid, visibility, callid, false)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::MethodNotFound))
         }
@@ -1073,24 +1074,32 @@ impl<'a> JitContext<'a> {
     ///
     /// Check whether a method or `super` of class *class_id* exists in compile time.
     ///
-    fn jit_check_call(&mut self, recv_class: ClassId, name: Option<IdentId>) -> Option<FuncId> {
+    fn jit_check_call(
+        &mut self,
+        recv_class: ClassId,
+        name: Option<IdentId>,
+    ) -> Option<(FuncId, Visibility)> {
         if let Some(name) = name {
             // for method call
             self.jit_check_method(recv_class, name)
         } else {
-            // for super
-            self.jit_check_super(recv_class)
+            // for super: `super` bypasses visibility, so report it as Public.
+            Some((self.jit_check_super(recv_class)?, Visibility::Public))
         }
     }
 
     ///
-    /// Check whether a method *name* of class *class_id* exists in compile time.
+    /// Resolve method *name* of class *class_id* at compile time to its target
+    /// `FuncId` **and** visibility in a single method-table probe, so callers
+    /// need not look the entry up twice (once for the target, once for the
+    /// visibility gate in `compile_method_call`).
     ///
-    fn jit_check_method(&self, class_id: ClassId, name: IdentId) -> Option<FuncId> {
+    fn jit_check_method(&self, class_id: ClassId, name: IdentId) -> Option<(FuncId, Visibility)> {
         let class_version = self.class_version();
-        self.store
-            .check_method_for_class_with_version(class_id, name, class_version)?
-            .func_id()
+        let entry = self
+            .store
+            .check_method_for_class_with_version(class_id, name, class_version)?;
+        Some((entry.func_id()?, entry.visibility()))
     }
 
     ///
@@ -1103,8 +1112,8 @@ impl<'a> JitContext<'a> {
     /// A `Private` method reached without a func-call receiver (`recv` is not
     /// the literal `self` slot and the site is not a visibility-bypassing send)
     /// is never a valid call, so such a site is handed to the VM, which raises
-    /// `NoMethodError`. `Public` methods, func-call sites, and `super`
-    /// (`name == None`, which bypasses visibility) are always inlinable.
+    /// `NoMethodError`. `Public` methods, func-call sites, and `super` (which
+    /// `jit_check_call` resolves as `Public`) are always inlinable.
     ///
     /// `Protected` is intentionally *not* blocked here: the protected receiver
     /// `kind_of?` test depends on the runtime `self`, which the compiler cannot
@@ -1113,23 +1122,13 @@ impl<'a> JitContext<'a> {
     /// would regress valid protected dispatch for no correctness gain the JIT
     /// can guarantee statically; protected enforcement stays with the VM.
     ///
-    fn jit_visibility_blocks(&self, recv_class: ClassId, callid: CallSiteId) -> bool {
-        let callsite = &self.store[callid];
-        // `super` (no method name) bypasses visibility.
-        let Some(name) = callsite.name else {
-            return false;
-        };
+    /// *visibility* is the target method's visibility resolved alongside its
+    /// `FuncId` (see `jit_check_method`), so this gate performs no lookup.
+    ///
+    fn jit_visibility_blocks(&self, callid: CallSiteId, visibility: Visibility) -> bool {
         // A func-call receiver (literal `self` / visibility-bypassing send)
         // may call private and protected methods.
-        if callsite.is_func_call() {
-            return false;
-        }
-        let class_version = self.class_version();
-        matches!(
-            self.store
-                .check_method_for_class_with_version(recv_class, name, class_version),
-            Some(entry) if entry.visibility() == Visibility::Private
-        )
+        visibility == Visibility::Private && !self.store[callid].is_func_call()
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -160,7 +160,11 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
                 state.flush_gp(ir);
                 if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, false);
+                    let is_func_call = self
+                        .store
+                        .get_callsite_id(self.iseq_id(), bc_pos)
+                        .is_some_and(|c| self.store[c].is_func_call());
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, false, is_func_call);
                     state.def_rax2acc(ir, dst);
                     Ok(CompileResult::Continue)
                 } else {
@@ -198,6 +202,9 @@ impl<'a> JitContext<'a> {
         // matching) dispatches `===` with funcall semantics; a plain
         // `BinCmp` (`a === b`) is a public-only call.
         case_semantics: bool,
+        // The call site's func-call flag: for `==`/`!=`/`<=>`/plain `===`
+        // a private operator is callable only from `self OP x`.
+        is_func_call: bool,
     ) {
         state.write_back_slots(ir, &[lhs, rhs]);
         // §9 9d-B: the generic comparison emits a C-ABI call; flush any
@@ -209,12 +216,13 @@ impl<'a> JitContext<'a> {
         // generic C-call (Part 3-B).
         match kind {
             CmpKind::Eq | CmpKind::Ne => {
-                ir.opt_eq_cmp(state, lhs, rhs, kind, cmp_generic_fn(kind))
+                ir.opt_eq_cmp(state, lhs, rhs, kind, cmp_generic_fn(kind), is_func_call)
             }
             CmpKind::TEq if case_semantics => {
-                ir.generic_binop(state, lhs, rhs, crate::executor::op::cmp_teq_case_values)
+                // case/when `===` is funcall regardless (the helper forces it).
+                ir.generic_binop(state, lhs, rhs, crate::executor::op::cmp_teq_case_values, true)
             }
-            _ => ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind)),
+            _ => ir.generic_binop(state, lhs, rhs, cmp_generic_fn(kind), is_func_call),
         }
         ir.handle_error(error);
         // The C helper can run arbitrary Ruby (user-defined `==`,
@@ -273,7 +281,11 @@ impl<'a> JitContext<'a> {
             BinaryOpType::Other(Some(lhs_class), rhs_class) => {
                 state.flush_gp(ir);
                 if polymorphic {
-                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, true);
+                    let is_func_call = self
+                        .store
+                        .get_callsite_id(self.iseq_id(), bc_pos)
+                        .is_some_and(|c| self.store[c].is_func_call());
+                    self.emit_generic_cmp(state, ir, kind, lhs, rhs, true, is_func_call);
                     let src_idx = bc_pos + 1;
                     self.gen_cond_br(state, ir, src_idx, dest_bb, brkind);
                     return Ok(CompileResult::Continue);

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -13,14 +13,11 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(lhs_class) = base_class {
-            // The JIT `Index` fast-path calls `#[]` directly without a
-            // visibility check. Bail to the interpreter for a non-public
-            // `#[]`: the VM's `get_index` receives the `is_func_call` bit
-            // (base-slot == self) and so raises `NoMethodError` for a plain
-            // `obj[i]` while letting an explicit-`self` `self[i]` through.
-            if !self.jit_index_method_is_public(lhs_class, IdentId::_INDEX) {
-                return Ok(CompileResult::Deopt);
-            }
+            // Visibility (`#[]` may be private) is enforced in the shared
+            // `compile_method_call` choke point (`jit_visibility_blocks`),
+            // using the call site's func-call flag: a plain `obj[i]` deopts to
+            // the VM (which raises `NoMethodError`) while an explicit-`self`
+            // `self[i]` compiles inline.
             return self.call_binary_method(
                 state,
                 ir,
@@ -48,15 +45,11 @@ impl<'a> JitContext<'a> {
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
         if let Some(recv_class) = base_class {
-            // The JIT `IndexAssign` fast-path calls `#[]=` directly without a
-            // visibility check. Bail to the interpreter for a non-public
-            // `#[]=`: the VM's `set_index` receives the `is_func_call` bit
-            // (base-slot == self) and so raises `NoMethodError` for a plain
-            // `obj[i] = v` while letting an explicit-`self` `self[i] = v`
-            // through.
-            if !self.jit_index_method_is_public(recv_class, IdentId::_INDEX_ASSIGN) {
-                return Ok(CompileResult::Deopt);
-            }
+            // Visibility (`#[]=` may be private) is enforced in the shared
+            // `compile_method_call` choke point (`jit_visibility_blocks`),
+            // using the call site's func-call flag: a plain `obj[i] = v` deopts
+            // to the VM (which raises `NoMethodError`) while an explicit-`self`
+            // `self[i] = v` compiles inline.
             return self.call_ternary_method(
                 state,
                 ir,

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -119,6 +119,16 @@ impl<'a> JitContext<'a> {
         // compiled BinCmp sites, which have such a path (Part B).
         recompile_on_recv_miss: bool,
     ) -> JitResult<CompileResult> {
+        // CRuby method visibility. This is the single dispatch choke point for
+        // operators (`#[]`, `#[]=`, arithmetic / comparison / unary) and for
+        // ordinary calls whose receiver class is known at compile time, so the
+        // visibility gate lives here rather than in each caller. A private
+        // method reached without a func-call receiver deopts to the VM, which
+        // raises `NoMethodError` (a plain `obj[i]` / `obj + x` while an
+        // explicit-`self` `self[i]` / `self + x` compiles inline).
+        if self.jit_visibility_blocks(recv_class, callid) {
+            return Ok(CompileResult::Deopt);
+        }
         let callsite = &self.store[callid];
         self.inline_method_cache
             .push((recv_class, callsite.name, func_id));

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -38,10 +38,10 @@ impl<'a> JitContext<'a> {
                 return Ok(CompileResult::Deopt);
             }
         }
-        let (recv_class, func_id) = if let Some(recv_class) = recv_class {
+        let (recv_class, func_id, visibility) = if let Some(recv_class) = recv_class {
             // the receiver class is known.
-            if let Some(func_id) = self.jit_check_call(recv_class, callsite.name) {
-                (recv_class, func_id)
+            if let Some((func_id, visibility)) = self.jit_check_call(recv_class, callsite.name) {
+                (recv_class, func_id, visibility)
             } else {
                 return Ok(CompileResult::Recompile(RecompileReason::MethodNotFound));
             }
@@ -52,18 +52,21 @@ impl<'a> JitContext<'a> {
                     if cache.version != self.class_version() {
                         // the inline method cache is invalid.
                         let recv_class = cache.recv_class;
-                        let func_id =
-                            if let Some(fid) = self.jit_check_call(recv_class, callsite.name) {
-                                fid
+                        let (func_id, visibility) =
+                            if let Some(x) = self.jit_check_call(recv_class, callsite.name) {
+                                x
                             } else {
                                 return Ok(CompileResult::Recompile(
                                     RecompileReason::MethodNotFound,
                                 ));
                             };
-                        (recv_class, func_id)
+                        (recv_class, func_id, visibility)
                     } else {
-                        // the inline method cache is valid.
-                        (cache.recv_class, cache.func_id)
+                        // The inline method cache is valid: the VM already
+                        // enforced visibility when it warmed the cache (a
+                        // private non-func-call call never caches successfully),
+                        // so no compile-time visibility gate is needed here.
+                        (cache.recv_class, cache.func_id, Visibility::Public)
                     }
                 }
                 // The VM resolved this call to `method_missing` and the cached
@@ -98,11 +101,17 @@ impl<'a> JitContext<'a> {
                 None
             }
         };
-        self.compile_method_call(state, ir, recv_class, arg_class, func_id, callid, false)
+        self.compile_method_call(
+            state, ir, recv_class, arg_class, func_id, visibility, callid, false,
+        )
     }
 
     ///
     /// Compile TraceIr::MethodCall with inline method cache info.
+    ///
+    /// *visibility* is the resolved method's visibility, obtained together with
+    /// *func_id* in the same method-table probe (see `jit_check_call`), so the
+    /// visibility gate below costs no extra lookup.
     ///
     #[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
     pub(super) fn compile_method_call(
@@ -112,6 +121,7 @@ impl<'a> JitContext<'a> {
         recv_class: ClassId,
         arg_class: Option<ClassId>,
         func_id: FuncId,
+        visibility: Visibility,
         callid: CallSiteId,
         // When the receiver-class guard misses, recompile (so the
         // site flips to the non-deopting polymorphic path) instead
@@ -126,7 +136,7 @@ impl<'a> JitContext<'a> {
         // method reached without a func-call receiver deopts to the VM, which
         // raises `NoMethodError` (a plain `obj[i]` / `obj + x` while an
         // explicit-`self` `self[i]` / `self + x` compiles inline).
-        if self.jit_visibility_blocks(recv_class, callid) {
+        if self.jit_visibility_blocks(callid, visibility) {
             return Ok(CompileResult::Deopt);
         }
         let callsite = &self.store[callid];

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -773,6 +773,7 @@ pub(in crate::codegen) enum LInst {
         lhs: SlotId,
         rhs: SlotId,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     },
     OptEqCmp {
@@ -780,6 +781,7 @@ pub(in crate::codegen) enum LInst {
         rhs: SlotId,
         kind: CmpKind,
         func: crate::executor::BinaryOpFn,
+        is_func_call: bool,
         using_fpr: UsingFpr,
     },
     ArrayTEq {

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -543,17 +543,20 @@ fn array_teq_impl(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
-    teq: extern "C" fn(&mut Executor, &mut Globals, Value, Value) -> Option<Value>,
+    teq: crate::executor::BinaryOpFn,
 ) -> Option<Value> {
+    // case/when and rescue `===` dispatch with funcall semantics; the
+    // `cmp_teq_case_values` / `cmp_teq_rescue_values` helpers force it
+    // regardless, so the flag passed here is nominal.
     if let Some(lhs_ary) = lhs.try_array_ty() {
         for lhs in lhs_ary.iter().cloned() {
-            if teq(vm, globals, lhs, rhs)?.as_bool() {
+            if teq(vm, globals, lhs, rhs, true)?.as_bool() {
                 return Some(Value::bool(true));
             }
         }
         Some(Value::bool(false))
     } else {
-        teq(vm, globals, lhs, rhs)
+        teq(vm, globals, lhs, rhs, true)
     }
 }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -55,8 +55,15 @@ pub fn terminate_with_signal(signo: i32) -> ! {
     std::process::exit(1);
 }
 
-pub type BinaryOpFn = extern "C" fn(&mut Executor, &mut Globals, Value, Value) -> Option<Value>;
-pub type UnaryOpFn = extern "C" fn(&mut Executor, &mut Globals, Value) -> Option<Value>;
+/// Runtime helper for a binary operator's generic (non-fast-path) dispatch.
+/// The trailing `is_func_call` carries the call site's func-call flag
+/// (`recv` is the literal `self` slot / a visibility-bypassing send) so the
+/// method-visibility fallback matches CRuby: a private operator is callable
+/// only from a func-call site. The VM generic path computes it from the lhs
+/// slot (== 0) and the JIT passes the call site's compile-time constant.
+pub type BinaryOpFn =
+    extern "C" fn(&mut Executor, &mut Globals, Value, Value, bool) -> Option<Value>;
+pub type UnaryOpFn = extern "C" fn(&mut Executor, &mut Globals, Value, bool) -> Option<Value>;
 
 pub(crate) const RSP_LOCAL_FRAME: i32 = 40;
 pub(crate) const RSP_CFP: i32 = 24;
@@ -2289,14 +2296,29 @@ impl Executor {
         Ok(self.invoke_eq_raw(globals, lhs, rhs)?.as_bool())
     }
 
-    /// Dispatch `lhs == rhs` and return the method's value untouched.
+    /// Dispatch `lhs == rhs` and return the method's value untouched. Uses
+    /// funcall semantics (private `==` allowed) — for the visibility-aware
+    /// top-level `a == b` dispatch use [`Self::invoke_eq_raw_vis`].
     pub(crate) fn invoke_eq_raw(
         &mut self,
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
     ) -> Result<Value> {
-        let func_id = self.find_method(globals, lhs, IdentId::_EQ, true)?;
+        self.invoke_eq_raw_vis(globals, lhs, rhs, true)
+    }
+
+    /// Dispatch `lhs == rhs`, enforcing the receiver's `==` visibility per the
+    /// call site's func-call flag (a private `==` is callable only from a
+    /// func-call site).
+    pub(crate) fn invoke_eq_raw_vis(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+        is_func_call: bool,
+    ) -> Result<Value> {
+        let func_id = self.find_method(globals, lhs, IdentId::_EQ, is_func_call)?;
         self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)
     }
 

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -61,7 +61,8 @@ macro_rules! cmp_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
                 let b = match (lhs.unpack(), rhs.unpack()) {
                     (RV::Fixnum(lhs), RV::Fixnum(rhs)) => lhs.$op(&rhs),
@@ -137,7 +138,10 @@ macro_rules! cmp_values {
                         return None;
                     }
                     _ => {
-                        return vm.invoke_method_simple(globals, $op_str, lhs, &[rhs]);
+                        // Original receiver `lhs`: honor the call site's
+                        // func-call flag so a private relational operator is
+                        // callable only from `self OP x` (matches CRuby).
+                        return vm.invoke_method(globals, $op_str, is_func_call, lhs, &[rhs], None, None);
                     }
                 };
                 Some(Value::bool(b))
@@ -149,9 +153,10 @@ macro_rules! cmp_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
-                vm.invoke_method_simple(globals, $op_str, lhs, &[rhs])
+                vm.invoke_method(globals, $op_str, is_func_call, lhs, &[rhs], None, None)
             }
         }
     };
@@ -182,6 +187,22 @@ impl Executor {
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
+    ) -> Result<Value> {
+        // Internal callers (`Array#==`, `Hash#==`, …) compare with funcall
+        // semantics, matching CRuby's `rb_equal`.
+        self.eq_values_vis(globals, lhs, rhs, true)
+    }
+
+    /// `==` dispatch honoring the call site's func-call flag for a
+    /// user-defined `==` (a private `==` is callable only from a func-call
+    /// site). The numeric/String *reverse* dispatches keep funcall semantics
+    /// (`rb_equal`), so only the direct receiver dispatch consults the flag.
+    pub(crate) fn eq_values_vis(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+        is_func_call: bool,
     ) -> Result<Value> {
         let b = match (lhs.unpack(), rhs.unpack()) {
             (RV::Nil, RV::Nil) => true,
@@ -240,7 +261,7 @@ impl Executor {
                     return Ok(Value::bool(self.invoke_eq(globals, rhs, lhs)?));
                 }
             }
-            _ => return self.invoke_eq_raw(globals, lhs, rhs),
+            _ => return self.invoke_eq_raw_vis(globals, lhs, rhs, is_func_call),
         };
         Ok(Value::bool(b))
     }
@@ -259,8 +280,9 @@ impl Executor {
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
+        is_func_call: bool,
     ) -> Result<Value> {
-        self.invoke_eq_raw(globals, lhs, rhs)
+        self.invoke_eq_raw_vis(globals, lhs, rhs, is_func_call)
     }
 
     ///
@@ -275,18 +297,34 @@ impl Executor {
         lhs: Value,
         rhs: Value,
     ) -> Result<Value> {
+        // Internal callers use funcall semantics, matching `rb_equal`-style `!=`.
+        self.ne_values_vis(globals, lhs, rhs, true)
+    }
+
+    /// `!=` dispatch honoring the call site's func-call flag for a redefined
+    /// `!=` (or the private-`==` it negates).
+    pub(crate) fn ne_values_vis(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+        is_func_call: bool,
+    ) -> Result<Value> {
         // Check if the receiver has a custom != method (not a basic op /
-        // the default BasicObject#!=). If so, dispatch to it directly
-        // instead of negating ==. `custom_neq` is memoized per
+        // the default BasicObject#!=). If so, dispatch to it (honoring its
+        // visibility) instead of negating ==. `custom_neq` is memoized per
         // class_version, so the common unredefined case costs a load
         // instead of a method-table probe per comparison.
         let class_id = lhs.class();
-        if let Some(entry) = globals.store.custom_neq(class_id, Globals::class_version()) {
-            if let Some(func_id) = entry.func_id() {
-                return self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None);
-            }
+        if globals
+            .store
+            .custom_neq(class_id, Globals::class_version())
+            .is_some()
+        {
+            let func_id = self.find_method(globals, lhs, IdentId::_NEQ, is_func_call)?;
+            return self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None);
         }
-        Ok(Value::bool(!self.eq_values_bool(globals, lhs, rhs)?))
+        Ok(Value::bool(!self.eq_values_vis(globals, lhs, rhs, is_func_call)?.as_bool()))
     }
 
     pub(crate) fn ne_values_bool(
@@ -303,8 +341,9 @@ impl Executor {
         globals: &mut Globals,
         lhs: Value,
         rhs: Value,
+        is_func_call: bool,
     ) -> Result<Value> {
-        let func_id = self.find_method(globals, lhs, IdentId::_NEQ, true)?;
+        let func_id = self.find_method(globals, lhs, IdentId::_NEQ, is_func_call)?;
         self.invoke_func_inner(globals, func_id, lhs, &[rhs], None, None)
     }
 }
@@ -318,9 +357,10 @@ macro_rules! eq_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
-                match vm.[<$op _values>](globals, lhs, rhs) {
+                match vm.[<$op _values_vis>](globals, lhs, rhs, is_func_call) {
                     Ok(v) => Some(v),
                     Err(err) => {
                         vm.set_error(err);
@@ -335,9 +375,10 @@ macro_rules! eq_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
-                match vm.[<$op _values_no_opt>](globals, lhs, rhs) {
+                match vm.[<$op _values_no_opt>](globals, lhs, rhs, is_func_call) {
                     Ok(v) => Some(v),
                     Err(err) => {
                         vm.set_error(err);
@@ -398,25 +439,29 @@ fn cmp_values() {
     }
 }
 
+/// Plain `a === b` (the non-optimizable TEq opcode): a public-only call,
+/// except when the receiver is the literal `self` — the call site's
+/// func-call flag carries that, so `self === b` may reach a private `===`.
 pub(crate) extern "C" fn cmp_teq_values(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
-    cmp_teq_values_impl(vm, globals, lhs, rhs, false)
+    cmp_teq_values_impl(vm, globals, lhs, rhs, is_func_call)
 }
 
 /// `===` dispatch for the *optimizable* TEq opcode, which bytecodegen
 /// only emits for case/when and rescue matching: CRuby dispatches
 /// those `===` calls with funcall semantics, so a private `===` is
-/// allowed (an explicit `a === b` compiles to the non-optimizable
-/// opcode and stays a public-only call).
+/// allowed regardless of the receiver (`is_func_call` is unused).
 pub(crate) extern "C" fn cmp_teq_case_values(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    _is_func_call: bool,
 ) -> Option<Value> {
     cmp_teq_values_impl(vm, globals, lhs, rhs, true)
 }
@@ -424,12 +469,13 @@ pub(crate) extern "C" fn cmp_teq_case_values(
 /// `===` dispatch for rescue-clause matching (the RescueTEq opcode):
 /// the clause must be a Class or Module — CRuby raises TypeError
 /// before any `===` dispatch — and the call itself has funcall
-/// semantics like case/when.
+/// semantics like case/when (`is_func_call` is unused).
 pub(crate) extern "C" fn cmp_teq_rescue_values(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    _is_func_call: bool,
 ) -> Option<Value> {
     if lhs.is_class_or_module().is_none() {
         vm.set_error(MonorubyErr::typeerr(
@@ -491,8 +537,9 @@ pub(crate) extern "C" fn cmp_teq_values_no_opt(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
-    vm.invoke_method_simple(globals, IdentId::_TEQ, lhs, &[rhs])
+    vm.invoke_method(globals, IdentId::_TEQ, is_func_call, lhs, &[rhs], None, None)
 }
 
 pub(crate) fn cmp_teq_values_bool(
@@ -760,8 +807,9 @@ macro_rules! unop_value_no_opt {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
-                vm.invoke_method_simple(globals, $op_str, lhs, &[])
+                vm.invoke_method(globals, $op_str, is_func_call, lhs, &[], None, None)
             }
         }
     };
@@ -782,6 +830,7 @@ pub(crate) extern "C" fn neg_value(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match lhs.unpack() {
         RV::Fixnum(lhs) => match lhs.checked_neg() {
@@ -799,11 +848,11 @@ pub(crate) extern "C" fn neg_value(
             } else {
                 // Custom Numeric components: dispatch `-@` to each part via
                 // `Complex#-@` (`neg_op`, not `neg_value`), so no recursion.
-                return vm.invoke_method_simple(globals, IdentId::_UMINUS, lhs, &[]);
+                return vm.invoke_method(globals, IdentId::_UMINUS, is_func_call, lhs, &[], None, None);
             }
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_UMINUS, lhs, &[]);
+            return vm.invoke_method(globals, IdentId::_UMINUS, is_func_call, lhs, &[], None, None);
         }
     };
     Some(v)
@@ -813,13 +862,14 @@ pub(crate) extern "C" fn pos_value(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match lhs.unpack() {
         RV::Fixnum(lhs) => Value::integer(lhs),
         RV::BigInt(lhs) => Value::bigint(lhs.clone()),
         RV::Float(lhs) => Value::float(lhs),
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_UPLUS, lhs, &[]);
+            return vm.invoke_method(globals, IdentId::_UPLUS, is_func_call, lhs, &[], None, None);
         }
     };
     Some(v)
@@ -829,6 +879,7 @@ pub(crate) extern "C" fn not_value(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match lhs.unpack() {
         RV::Fixnum(_)
@@ -840,7 +891,7 @@ pub(crate) extern "C" fn not_value(
         | RV::Bool(true) => Value::bool(false),
         RV::Bool(false) | RV::Nil => Value::bool(true),
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_NOT, lhs, &[]);
+            return vm.invoke_method(globals, IdentId::_NOT, is_func_call, lhs, &[], None, None);
         }
     };
     Some(v)
@@ -850,12 +901,13 @@ pub(crate) extern "C" fn bitnot_value(
     vm: &mut Executor,
     globals: &mut Globals,
     lhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match lhs.unpack() {
         RV::Fixnum(lhs) => Value::integer(!lhs),
         RV::BigInt(lhs) => Value::bigint(!lhs),
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_BNOT, lhs, &[]);
+            return vm.invoke_method(globals, IdentId::_BNOT, is_func_call, lhs, &[], None, None);
         }
     };
     Some(v)

--- a/monoruby/src/executor/op/binary_ops.rs
+++ b/monoruby/src/executor/op/binary_ops.rs
@@ -187,7 +187,8 @@ macro_rules! binop_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
                 match (RealKind::try_from(lhs), RealKind::try_from(rhs)) {
                     (Some(lhs), Some(rhs)) => return Some((lhs.$op(rhs)).into()),
@@ -232,7 +233,10 @@ macro_rules! binop_values {
                         return complex_real_op(vm, globals, $op_str, lhs, rhs);
                     }
                     _ => {
-                        return vm.invoke_method_simple(globals, $op_str, lhs, &[rhs]);
+                        // Original receiver `lhs`: honor the call site's
+                        // func-call flag (a private operator is callable only
+                        // from `self OP x`).
+                        return vm.invoke_method(globals, $op_str, is_func_call, lhs, &[rhs], None, None);
                     }
                 };
                 Some(v)
@@ -252,9 +256,10 @@ macro_rules! binop_values_no_opt {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
-                vm.invoke_method_simple(globals, $op_str, lhs, &[rhs])
+                vm.invoke_method(globals, $op_str, is_func_call, lhs, &[rhs], None, None)
             }
         }
     };
@@ -275,6 +280,7 @@ pub(crate) extern "C" fn div_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     match (RealKind::try_from(lhs), RealKind::try_from(rhs)) {
         (Some(lhs), Some(rhs)) => {
@@ -297,7 +303,7 @@ pub(crate) extern "C" fn div_values(
         (RV::Fixnum(_) | RV::BigInt(_), _) => {
             try_coerce_and_apply(vm, globals, IdentId::_DIV, lhs, rhs, "Integer")
         }
-        _ => vm.invoke_method_simple(globals, IdentId::_DIV, lhs, &[rhs]),
+        _ => vm.invoke_method(globals, IdentId::_DIV, is_func_call, lhs, &[rhs], None, None),
     }
 }
 
@@ -306,6 +312,7 @@ pub(crate) extern "C" fn rem_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     match (RealKind::try_from(lhs), RealKind::try_from(rhs)) {
         (Some(lhs), Some(rhs)) => {
@@ -352,7 +359,7 @@ pub(crate) extern "C" fn rem_values(
             return try_coerce_and_apply(vm, globals, IdentId::_REM, lhs, rhs, "Complex");
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_REM, lhs, &[rhs]);
+            return vm.invoke_method(globals, IdentId::_REM, is_func_call, lhs, &[rhs], None, None);
         }
     };
     Some(v)
@@ -449,6 +456,7 @@ pub(crate) extern "C" fn pow_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match (lhs.unpack(), rhs.unpack()) {
         (RV::Fixnum(lhs), RV::Fixnum(rhs)) => pow_ii(lhs, rhs, vm)?,
@@ -535,7 +543,7 @@ pub(crate) extern "C" fn pow_values(
             return try_coerce_and_apply(vm, globals, IdentId::_POW, lhs, rhs, "Float");
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_POW, lhs, &[rhs]);
+            return vm.invoke_method(globals, IdentId::_POW, is_func_call, lhs, &[rhs], None, None);
         }
     };
     Some(v)
@@ -548,7 +556,8 @@ macro_rules! int_binop_values {
                 vm: &mut Executor,
                 globals: &mut Globals,
                 lhs: Value,
-                rhs: Value
+                rhs: Value,
+                is_func_call: bool,
             ) -> Option<Value> {
                 let v = match (lhs.unpack(), rhs.unpack()) {
                     (RV::Fixnum(lhs), RV::Fixnum(rhs)) => Value::integer(lhs.$op(&rhs)),
@@ -561,7 +570,7 @@ macro_rules! int_binop_values {
                         return try_coerce_and_apply_bit(vm, globals, $op_str, lhs, rhs);
                     }
                     _ => {
-                        return vm.invoke_method_simple(globals, $op_str, lhs, &[rhs]);
+                        return vm.invoke_method(globals, $op_str, is_func_call, lhs, &[rhs], None, None);
                     }
                 };
                 Some(v)
@@ -585,6 +594,7 @@ pub(crate) extern "C" fn shr_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match (lhs.unpack(), rhs.unpack()) {
         (RV::Fixnum(lhs), RV::Fixnum(rhs)) => {
@@ -626,7 +636,7 @@ pub(crate) extern "C" fn shr_values(
         (RV::Fixnum(_) | RV::BigInt(_), _) => {
             // >> requires to_int conversion (not coerce), supports BigInt shift amounts
             match rhs.coerce_to_int(vm, globals) {
-                Ok(rhs_int) => return shr_values(vm, globals, lhs, rhs_int).into(),
+                Ok(rhs_int) => return shr_values(vm, globals, lhs, rhs_int, is_func_call).into(),
                 Err(_) => {
                     vm.set_error(MonorubyErr::typeerr(format!(
                         "{} can't be coerced into Integer",
@@ -637,7 +647,7 @@ pub(crate) extern "C" fn shr_values(
             }
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_SHR, lhs, &[rhs]);
+            return vm.invoke_method(globals, IdentId::_SHR, is_func_call, lhs, &[rhs], None, None);
         }
     };
     Some(v)
@@ -648,6 +658,7 @@ pub(crate) extern "C" fn shl_values(
     globals: &mut Globals,
     lhs: Value,
     rhs: Value,
+    is_func_call: bool,
 ) -> Option<Value> {
     let v = match (lhs.unpack(), rhs.unpack()) {
         (RV::Fixnum(lhs), RV::Fixnum(rhs)) => {
@@ -693,7 +704,7 @@ pub(crate) extern "C" fn shl_values(
         (RV::Fixnum(_) | RV::BigInt(_), _) => {
             // << requires to_int conversion (not coerce), supports BigInt shift amounts
             match rhs.coerce_to_int(vm, globals) {
-                Ok(rhs_int) => return shl_values(vm, globals, lhs, rhs_int).into(),
+                Ok(rhs_int) => return shl_values(vm, globals, lhs, rhs_int, is_func_call).into(),
                 Err(_) => {
                     vm.set_error(MonorubyErr::typeerr(format!(
                         "{} can't be coerced into Integer",
@@ -704,7 +715,7 @@ pub(crate) extern "C" fn shl_values(
             }
         }
         _ => {
-            return vm.invoke_method_simple(globals, IdentId::_SHL, lhs, &[rhs]);
+            return vm.invoke_method(globals, IdentId::_SHL, is_func_call, lhs, &[rhs], None, None);
         }
     };
     Some(v)


### PR DESCRIPTION
## Summary

Two independent pieces of work on the same branch.

### 1. Method visibility for operators (VM + JIT)

CRuby enforces method visibility on **every** operator — unary (`-@ +@ ! ~`), binary (arithmetic / relational / `<=>` / `==` / `!=` / `===`), and the indexing forms `[]` / `[]=`. A private operator is callable only from a *func-call* site (a literal-`self` receiver or a visibility-bypassing send). monoruby did not match this:

- **JIT** resolved operator dispatch (and ordinary calls with a statically-known receiver class) straight to the target method with no visibility check, so e.g. a private `obj + x` / `obj[i]` compiled to a direct call and returned a value where CRuby raises `NoMethodError`. `#[]` / `#[]=` had an ad-hoc `jit_index_method_is_public` pre-check.
- **VM** was inconsistent: arithmetic/relational/`<=>`/unary helpers hard-coded `is_func_call = false` (so `self + x` on a private operator wrongly raised), while `==` / `!=` used funcall semantics unconditionally (so `obj == x` on a private `==` was wrongly allowed).

Changes:

- **JIT** — enforce visibility once at the single dispatch choke point `compile_method_call` (`jit_visibility_blocks`), covering operators *and* ordinary calls; this also closes a pre-existing hole where a statically-resolved `obj.priv` was miscompiled. `jit_check_method` / `jit_check_call` now return `(FuncId, Visibility)` from one method-table probe, so the gate costs no extra lookup. Protected is deferred to the VM (its `kind_of?` test depends on the runtime `self`).
- **VM** — add a trailing `is_func_call: bool` to `BinaryOpFn` / `UnaryOpFn`; the leaf helpers route their generic method-dispatch fallback through `invoke_method(.., is_func_call, ..)`. `==` / `!=` keep the shared `eq_values` / `ne_values` primitives at funcall for internal callers (Array#==, Hash#==, numeric reverse dispatch) and add `_vis` variants for the top-level `a == b`. The VM computes the flag in the generic (non-fast-path) path from the lhs/operand bytecode slot (`== 0`) on both x86_64 and aarch64 (including the separate aarch64 `a64_op_cmp` / `a64_op_cmp_no_opt` comparison handlers); the fixnum fast paths are untouched. The JIT passes the site's compile-time-constant flag through `AsmInst::GenericBinOp` / `OptEqCmp`.

VM and JIT operator visibility now match CRuby exactly, including `self OP x` (private, allowed) inside loops and blocks and `obj == x` (private, raises).

### 2. Test-helper consolidation

Fold groups of independent single-expression `run_test(...)` calls (one reference-`ruby` spawn apiece) into a single `run_tests(&[...])` (one spawn per test), and merge a few tightly-related test families. Applied only to pure, side-effect-free tests (string, marshal, match_data, array#hash, Set#divide, `defined?`, control-flow, Proc#to_s, BasicObject#equal?); expressions and comments are preserved verbatim. Files with process-shared side effects (file / io / gc / thread / random) were intentionally left alone.

## Testing

- Full `cargo nextest run` suite green on aarch64 (the only failures were the known parallel ruby-spawn flakes, which pass in isolation).
- Operator visibility verified against CRuby across the full matrix (obj-receiver private → `NoMethodError`; `self` / func-call private → allowed) in both VM and JIT-warmed runs.
- All consolidated tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)