### PR TITLE
CHILLED_LITERAL_BIT moves to flag bit 7, out of the generational-GC age field (fixes #975)

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -234,7 +234,8 @@ struct Metadata {          // rvalue.rs:2373
 | 4 | `0b0001_0000` | WB_UNPROTECTED(shady 用に予約。現状**未使用** — §7.3) |
 | 5 | `0b0010_0000` | **REMEMBERED**(remembered set に登録済み) |
 | 6 | `0b0100_0000` | **WB_PENDING / armed**(old かつ未 remembered = 書き込みバリアの slow path 対象) |
-| 8..15 | 上位バイト | **age**(生存回数;`RGENGC_OLD_AGE` で昇格) |
+| 7 | `0b1000_0000` | CHILLED_LITERAL(リテラル由来の chilled 文字列;警告文言の出し分け用) |
+| 8..15 | 上位バイト | **age**(生存回数;`RGENGC_OLD_AGE` で昇格。上位バイトは age 専用 — 下位バイトのフラグはここに置かないこと) |
 
 新規オブジェクトは `flag == 1` なので、OLD / REMEMBERED / WB_PENDING はすべて 0
 (= young・バリア対象外)、age は 0 から始まる。

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -60,9 +60,12 @@ mod string;
 mod struct_inner;
 
 pub const OBJECT_INLINE_IVAR: usize = 6;
-/// Header flag bit 8: marks a chilled string as literal-born (see
-/// `Header::is_chilled_literal`).
-const CHILLED_LITERAL_BIT: u16 = 0b1_0000_0000;
+/// Header flag bit 7: marks a chilled string as literal-born (see
+/// `Header::is_chilled_literal`). Must stay inside the low byte — the
+/// high byte (bits 8..15) is the generational-GC age field, which
+/// `set_age` overwrites wholesale (issue #975: this bit previously sat
+/// on bit 8 and corrupted / was corrupted by the age counter).
+const CHILLED_LITERAL_BIT: u16 = 0b1000_0000;
 pub const RVALUE_OFFSET_FLAG: usize = std::mem::offset_of!(RValue, header.meta.flag);
 pub const RVALUE_OFFSET_TY: usize = std::mem::offset_of!(RValue, header.meta.ty);
 pub const RVALUE_OFFSET_CLASS: usize = std::mem::offset_of!(RValue, header.meta.class);
@@ -2542,5 +2545,58 @@ impl Header {
 
     fn change_class(&mut self, class: ClassId) {
         self.meta.class = Some(class);
+    }
+}
+
+#[cfg(test)]
+mod header_flag_tests {
+    use super::*;
+
+    fn string_header() -> Header {
+        Header::new(STRING_CLASS, ObjTy::STRING)
+    }
+
+    // Issue #975: CHILLED_LITERAL_BIT must not overlap the generational-GC
+    // age field (flag bits 8..15).
+    #[test]
+    fn chilled_literal_bit_is_outside_the_age_byte() {
+        assert_eq!(CHILLED_LITERAL_BIT & 0xff00, 0);
+    }
+
+    #[test]
+    fn chilled_literal_survives_aging() {
+        let mut h = string_header();
+        h.set_chilled_literal();
+        assert_eq!(h.age(), 0, "a fresh chilled literal must be age 0");
+        for age in 1..=3 {
+            h.set_age(age);
+            assert!(h.is_chilled(), "aging cleared the chilled bit");
+            assert!(h.is_chilled_literal(), "aging cleared the literal bit");
+            assert_eq!(h.age(), age);
+        }
+    }
+
+    #[test]
+    fn clear_chilled_keeps_the_age() {
+        let mut h = string_header();
+        h.set_chilled_literal();
+        h.set_age(3);
+        h.clear_chilled();
+        assert!(!h.is_chilled());
+        assert!(!h.is_chilled_literal());
+        assert_eq!(h.age(), 3, "clear_chilled corrupted the age counter");
+    }
+
+    // A `Symbol#to_s` chilled string (chilled, not literal-born) must not
+    // turn into a "literal" one merely by surviving collections.
+    #[test]
+    fn aged_symbol_to_s_string_is_not_literal() {
+        let mut h = string_header();
+        h.set_chilled();
+        for age in [1, 3] {
+            h.set_age(age);
+            assert!(h.is_chilled());
+            assert!(!h.is_chilled_literal(), "odd age misread as literal-born");
+        }
     }
 }


### PR DESCRIPTION
Fixes #975.

## What

`CHILLED_LITERAL_BIT` sat on flag bit 8, which is also the low bit of the generational-GC age counter (bits 8..15, written wholesale by `set_age`). As the issue lays out, the overlap caused: chilled literal strings promoted one collection early (born with `age() == 1`), the literal-born marker erased by the first aging pass (mutation warning degraded to the `Symbol#to_s` wording), odd-aged `Symbol#to_s` strings misread as literal-born (warning degraded the other way), and `clear_chilled` dropping the age's low bit.

## Change

The one-line move proposed in the issue — bit 7 was unused:

```rust
const CHILLED_LITERAL_BIT: u16 = 0b1000_0000;   // bit 7
```

Safety of the move, verified across both backends: every low-byte flag consumer is a masked bit test, never an exact byte compare — the JIT write-barrier fast path tests only bit 6 (`testb ..., 0x40` / `tbz x9, #6`), the frozen/chilled guards test `0b10` / `0b110`, and `dup`'s flag clearing is mask-based. No machine-code path hardcodes the old bit-8 value.

Also updated the `flag: u16` bit table in `doc/gc.md` (bit-7 row + a note that the high byte is reserved for age), and the constant's comment now states the low-byte requirement.

## Tests

New `header_flag_tests` module pins the invariants directly on `Header`:

- the bit lies outside the age byte (`& 0xff00 == 0`)
- a fresh chilled literal is age 0, and aging through 1..3 preserves both chilled bits
- `clear_chilled` preserves the age counter
- an aged (odd-age) `Symbol#to_s` string never reads back as literal-born

Ruby-level check against CRuby 4.0.2: after `3.times { GC.start }`, both mutation-warning wordings (`literal string will be frozen...` vs `string returned by :sym.to_s will be frozen...`) now match CRuby exactly; before the fix the literal wording was lost after the first collection.

`cargo test`: 1909/1909.

## Observation (out of scope)

While auditing the flag consumers I noticed `RValue::dup`/`clone` copy the source header's high byte and GC bits (age, OLD, REMEMBERED) into the newborn copy, so a dup of an old object starts life flagged old/aged instead of young. That predates this change and is orthogonal to the bit conflict, so it is left untouched here — happy to file it separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpzdoFu46d2ChJpSzeWsNK)_