### PR TITLE
Array#pack: restore O(appended) buffer: appends; fix @* to mean @0

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5650,6 +5650,31 @@ mod tests {
     }
 
     #[test]
+    fn pack_buffer_append_fast_path() {
+        run_tests(&[
+            // Append-only templates (no `@`/`X`) take the fast path that
+            // extends the buffer in place instead of rebuilding it.
+            r#"[65, 66].pack("cc", buffer: "abc".dup)"#,
+            r#"[3.14].pack("E", buffer: "".b).bytes"#,
+            r#"b = "".b; 100.times { [3.14].pack("E", buffer: b) }; b.bytesize"#,
+            // The buffer's encoding is preserved; appending a byte that is
+            // invalid in it degrades valid_encoding?, appending ASCII keeps it.
+            r#"b = "あ".dup; [255].pack("C", buffer: b); [b.encoding.to_s, b.valid_encoding?]"#,
+            r#"b = "あ".dup; [65].pack("C", buffer: b); [b, b.valid_encoding?]"#,
+            // `X` with a count reaches back into the buffer's own bytes
+            // (the seeded slow path).
+            r#"[65].pack("X2C", buffer: "12345".dup)"#,
+            // `X*` is a no-op (count 0) and keeps the fast path.
+            r#"[65].pack("X*C", buffer: "123".dup)"#,
+            // `@*` means `@0` in CRuby: rewind to position 0, discarding
+            // the seeded buffer content.
+            r#"[65].pack("@*C", buffer: "123".dup)"#,
+            r#"["ab", 65].pack("a2@*C")"#,
+            r#"["abc"].pack("a3@*")"#,
+        ]);
+    }
+
+    #[test]
     fn pack_buffer_offset_and_type() {
         run_tests(&[
             // The buffer seeds the output; `@` rewinds within it.

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -2055,6 +2055,40 @@ impl RStringInner {
         self.cr.set(CodeRange::Unknown);
     }
 
+    /// Append raw bytes without validation, merging the cached code range
+    /// in O(`slice`): the slice is classified standalone under the
+    /// receiver's encoding and combined with the cached cr, so hot append
+    /// loops (e.g. `Array#pack` with `buffer:`) stay linear and a later
+    /// `code_range()` query doesn't rescan the whole string. Unlike
+    /// `extend_from_slice_checked`, bytes invalid in the receiver's
+    /// encoding are permitted — the cr just degrades to Unknown (a later
+    /// query classifies to Broken), matching pack's semantics of writing
+    /// arbitrary binary into a text-tagged buffer.
+    pub fn extend_from_slice_merge_cr(&mut self, slice: &[u8]) {
+        if slice.is_empty() {
+            return;
+        }
+        let slice_cr = if self.ty.is_ascii_compatible() && slice.iter().all(|&b| b < 0x80) {
+            CodeRange::SevenBit
+        } else {
+            self.ty.classify(slice)
+        };
+        // Both sides classifying SevenBit/Valid standalone makes the
+        // concatenation Valid: a SevenBit/Valid receiver ends on a
+        // complete character, and the appended part is a well-formed
+        // sequence from its first byte. Anything else (either side
+        // Broken/Unknown) is left Unknown for lazy reclassification.
+        let new_cr = match (self.cr.get(), slice_cr) {
+            (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
+            (CodeRange::SevenBit | CodeRange::Valid, CodeRange::SevenBit | CodeRange::Valid) => {
+                CodeRange::Valid
+            }
+            _ => CodeRange::Unknown,
+        };
+        self.owned_mut().extend_from_slice(slice);
+        self.cr.set(new_cr);
+    }
+
     pub fn repeat(&self, len: usize) -> RStringInner {
         // Repetition of a classified buffer trivially preserves cr:
         // SevenBit/Valid stay so under concatenation of identical
@@ -3086,6 +3120,35 @@ mod encoding_tests {
         let s = RStringInner::with_encoding_capacity(Encoding::Utf16Le, 0);
         assert_eq!(s.cr.get(), CodeRange::SevenBit);
         assert_eq!(s.encoding(), Encoding::Utf16Le);
+    }
+
+    #[test]
+    fn extend_from_slice_merge_cr_merges_in_o1_queries() {
+        // SevenBit + SevenBit stays SevenBit.
+        let mut s = RStringInner::from_str_scanned("abc");
+        s.extend_from_slice_merge_cr(b"def");
+        assert_eq!(s.cr.get(), CodeRange::SevenBit);
+
+        // SevenBit + valid multi-byte UTF-8 → Valid.
+        s.extend_from_slice_merge_cr("あ".as_bytes());
+        assert_eq!(s.cr.get(), CodeRange::Valid);
+
+        // Appending bytes invalid in the receiver's encoding degrades to
+        // Unknown, and a later query classifies the truth (Broken).
+        s.extend_from_slice_merge_cr(b"\xff");
+        assert_eq!(s.cr.get(), CodeRange::Unknown);
+        assert_eq!(s.code_range(), CodeRange::Broken);
+
+        // Ascii8 receiver: high bytes are Valid, so the merge keeps an
+        // O(1)-queryable cr.
+        let mut b = RStringInner::from_encoding_scanned(b"ab", Encoding::Ascii8);
+        b.extend_from_slice_merge_cr(b"\xff\xfe");
+        assert_eq!(b.cr.get(), CodeRange::Valid);
+
+        // Empty append is a no-op.
+        let mut e = RStringInner::from_str_scanned("x");
+        e.extend_from_slice_merge_cr(b"");
+        assert_eq!(e.cr.get(), CodeRange::SevenBit);
     }
 
     #[test]

--- a/monoruby/src/value/rvalue/string/pack.rs
+++ b/monoruby/src/value/rvalue/string/pack.rs
@@ -554,15 +554,33 @@ pub(crate) fn pack(
     buffer: Option<Value>,
 ) -> Result<Value> {
     let template = parse_template(template, false)?;
-    // Validate the `buffer:` keyword and seed the output with its current
-    // bytes: pack writes *into* the buffer (appending at the end, or
-    // overwriting from an `@` offset), then the buffer's whole content
-    // becomes the result.
+    // Validate the `buffer:` keyword. pack writes *into* the buffer
+    // (appending at the end, or overwriting from an `@` offset), then the
+    // buffer's whole content becomes the result. `@`/`X` (with a count)
+    // are the only directives that can reach back into bytes that were
+    // already in the buffer, so only they force working on a full copy of
+    // it (`seed_buffer`). For every other template, `packed` holds just
+    // the freshly packed bytes, appended to the buffer at the end —
+    // protobuf-style encoders call `pack("E", buffer: buff)` on an
+    // ever-growing buffer, and copying + re-scanning the whole buffer per
+    // call made encoding quadratic in the message size.
+    let seed_buffer = buffer.is_some()
+        && template.iter().any(|t| match t.template {
+            // `X*` is a no-op (CRuby: `*` is count 0 for `X`); `@` always
+            // repositions — `@*` means `@0`.
+            Template::Back => t.repeat.is_some(),
+            Template::AtPos => true,
+            _ => false,
+        });
     let mut packed = Vec::new();
     if let Some(buf_val) = buffer {
         buf_val.ensure_not_frozen(&globals.store)?;
         match buf_val.is_rstring_inner() {
-            Some(inner) => packed.extend_from_slice(inner.as_bytes()),
+            Some(inner) => {
+                if seed_buffer {
+                    packed.extend_from_slice(inner.as_bytes());
+                }
+            }
             None => {
                 return Err(MonorubyErr::typeerr(format!(
                     "buffer must be String, not {}",
@@ -745,15 +763,15 @@ pub(crate) fn pack(
                 }
             }
             Template::AtPos => {
-                // '@' — move to absolute position, padding with nulls if needed
-                if let Some(pos) = repeat {
-                    if pos > packed.len() {
-                        packed.resize(pos, 0);
-                    } else {
-                        packed.truncate(pos);
-                    }
+                // '@' — move to absolute position, padding with nulls if
+                // needed. CRuby (pack.c) treats `*` as count 0 for
+                // `@`/`X`/`x`, so `@*` rewinds to position 0.
+                let pos = repeat.unwrap_or(0);
+                if pos > packed.len() {
+                    packed.resize(pos, 0);
+                } else {
+                    packed.truncate(pos);
                 }
-                // @* does nothing meaningful for pack
             }
             Template::Hex => {
                 // 'h' (low nibble first) / 'H' (high nibble first) — hex string
@@ -1099,16 +1117,24 @@ pub(crate) fn pack(
         };
     }
     if let Some(mut buf_val) = buffer {
-        // `packed` was seeded with the buffer's original bytes and then
-        // written into (possibly rewound by `@`), so it is the full
-        // desired content. Write it back in place, preserving the buffer's
-        // identity and encoding.
-        let enc = buf_val.as_rstring_inner().encoding();
-        let orig_len = buf_val.as_rstring_inner().len();
-        let repl = RStringInner::from_encoding_scanned(&packed, enc);
-        buf_val
-            .as_rstring_inner_mut()
-            .bytesplice_with(0, orig_len, &repl, &globals.store)?;
+        if seed_buffer {
+            // `packed` was seeded with the buffer's original bytes and then
+            // written into (possibly rewound by `@`), so it is the full
+            // desired content. Write it back in place, preserving the
+            // buffer's identity and encoding.
+            let enc = buf_val.as_rstring_inner().encoding();
+            let orig_len = buf_val.as_rstring_inner().len();
+            let repl = RStringInner::from_encoding_scanned(&packed, enc);
+            buf_val
+                .as_rstring_inner_mut()
+                .bytesplice_with(0, orig_len, &repl, &globals.store)?;
+        } else {
+            // No `@`/`X` in the template: everything in `packed` is new
+            // output that belongs after the buffer's existing bytes.
+            buf_val
+                .as_rstring_inner_mut()
+                .extend_from_slice_merge_cr(&packed);
+        }
         Ok(buf_val)
     } else if template_is_empty && packed.is_empty() {
         // Empty format string produces US-ASCII encoded empty string.


### PR DESCRIPTION
## Summary

d413b92 ("Array#pack: fix H/h, X*, w Bignum, u line length, and :buffer offset", #926) caused a severe performance regression in the protoboeuf-encode benchmark. This PR restores linear-time `pack(buffer:)` appends and, along the way, fixes a CRuby incompatibility in the `@*` directive discovered while testing the boundary cases.

## Root cause

Since d413b92, `Array#pack` with the `buffer:` keyword:

1. seeds the working vec with a full copy of the buffer's bytes,
2. rebuilds an `RStringInner` from the final content via `from_encoding_scanned` (a full encoding rescan of the whole buffer), and
3. writes it back with `bytesplice_with(0, orig_len, …)` (a full-content replacement)

— three O(buffer) passes per call. Protobuf-style encoders append a few bytes at a time into one ever-growing buffer (protoboeuf's generated code calls `[val].pack("E", buffer: buff)` per double field), so encoding a message degenerated from O(n) to O(n²).

## Fix

Only `@` and `X`-with-a-count can reach back into bytes that were already in the buffer. When the template contains neither (the overwhelmingly common case), skip the seed copy entirely: `packed` holds just the freshly packed bytes, and they are appended to the buffer at the end via the new `RStringInner::extend_from_slice_merge_cr`, which classifies only the appended slice and merges it with the cached code range in O(appended) — so later `code_range()` queries stay O(1). Templates that do rewind keep the seeded full-rebuild path unchanged.

## CRuby compatibility fix: `@*`

CRuby's pack.c treats `*` as count 0 for `@`/`X`/`x`, so `@*` rewinds to absolute position 0 (e.g. `["ab", 65].pack("a2@*C")` → `"A"`), while `X*` (also count 0) is a no-op. monoruby treated `@*` as a no-op; it now truncates to position 0, matching CRuby with and without `buffer:`.

## Benchmarks (release build, x86-64 Linux)

| Benchmark | d413b92^ (pre-regression) | master (regressed) | this PR |
|---|---|---|---|
| `[3.14].pack("E", buffer: buff)` ×100k into one growing buffer | 0.042s | 9.57s | **0.034s** |
| protoboeuf-style encode (23 KB nested message) ×100 | 0.094s | 0.171s | **0.080s** |

Scaling is linear again (regressed code was ~4× slower per size doubling). Both cases are now faster than the pre-regression baseline, because the incremental code-range merge is cheaper than the old path's UTF-8 validation of every appended slice.

## Tests

- New `pack_buffer_append_fast_path` CRuby-comparison tests covering the append fast path (plain appends, encoding/`valid_encoding?` behavior of the buffer) and the seeded slow path (`X2`, `@*` rewind), plus unbuffered `@*` cases.
- New unit test for `extend_from_slice_merge_cr` code-range merging.
- Full test suite passes: 1912 passed, 0 failed (against CRuby 4.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)