### PR TITLE
bytecodegen: keep the trivial-method hint for scalar-literal param defaults

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -454,6 +454,29 @@ pub(crate) struct OptionalInfo {
     initializer: Node,
 }
 
+/// Whether a parameter-default expression is a scalar literal, i.e. its
+/// evaluation can have no observable effect beyond writing the parameter's
+/// local slot. Anything else is treated as effectful for the
+/// trivial-method hint: constant lookups can raise `NameError`,
+/// interpolation and composite literals can run arbitrary user code.
+fn default_expr_is_pure(node: &Node) -> bool {
+    matches!(
+        node.kind,
+        NodeKind::Nil
+            | NodeKind::Bool(_)
+            | NodeKind::Integer(_)
+            | NodeKind::Bignum(_)
+            | NodeKind::Float(_)
+            | NodeKind::Imaginary(_)
+            | NodeKind::Rational(..)
+            | NodeKind::RImaginary(..)
+            | NodeKind::String(_)
+            | NodeKind::Bytes(_)
+            | NodeKind::EncodedString(..)
+            | NodeKind::Symbol(_)
+    )
+}
+
 impl OptionalInfo {
     pub fn new(local: BcLocal, initializer: Node) -> Self {
         Self { local, initializer }
@@ -688,9 +711,22 @@ impl<'a> BytecodeGen<'a> {
         // observable side effects. Optional- and keyword-parameter default
         // expressions can run arbitrary user code (e.g.
         // `def f(a = ($x = 1)); 1; end` — calling `f` must still assign
-        // `$x`), so their presence disqualifies the method from the hint.
-        let prologue_has_side_effects = !info.optional_info.is_empty()
-            || info.keyword_initializers.iter().any(|i| i.is_some());
+        // `$x`), so a default that isn't a scalar literal disqualifies the
+        // method from the hint. Literal defaults (the overwhelmingly common
+        // `arg = false` / `arg = nil` shape — e.g. the default
+        // `respond_to_missing?(name, include_all = false)`, whose
+        // `ConstReturn` hint the JIT folds `respond_to?` misses through)
+        // only write a local slot no trivial body can observe, so they keep
+        // the hint.
+        let prologue_has_side_effects = info
+            .optional_info
+            .iter()
+            .any(|o| !default_expr_is_pure(&o.initializer))
+            || info
+                .keyword_initializers
+                .iter()
+                .flatten()
+                .any(|i| !default_expr_is_pure(i));
         for OptionalInfo { local, initializer } in info.optional_info {
             let local = local.into();
             let next = self.new_label();

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -100,6 +100,64 @@ fn optional_default_side_effect_trivial_body() {
 }
 
 #[test]
+fn optional_literal_default_trivial_body() {
+    // Scalar-literal defaults have no observable effect, so a trivial body
+    // keeps the constant-return hint (the default `respond_to_missing?
+    // (name, include_all = false)` relies on this — dropping its hint made
+    // `respond_to?` on missing methods quadratically slower to fold in the
+    // JIT). These tests pin the *semantics*: literal defaults, trivial
+    // bodies, with and without supplied arguments.
+    run_test(
+        r#"
+        def f(a = false); 1; end
+        [f, f(:x)]
+        "#,
+    );
+    run_test(
+        r#"
+        def f(a = nil, b = :sym, c = "s"); nil; end
+        [f, f(1), f(1, 2, 3)]
+        "#,
+    );
+    run_test(
+        r#"
+        class C
+          def f(a = 42); self; end
+        end
+        c = C.new
+        c.f.equal?(c)
+        "#,
+    );
+    run_test(
+        r#"
+        def f(k: false, j: 1.5); true; end
+        [f, f(k: :x, j: nil)]
+        "#,
+    );
+    // A literal default mixed with an effectful one: the hint must still
+    // be dropped and the effectful default must run.
+    run_test(
+        r#"
+        def f(a = false, b = ($x = 7)); 1; end
+        f
+        $x
+        "#,
+    );
+    // respond_to? consults the default respond_to_missing? (whose
+    // include_all default is a literal): both outcomes stay correct.
+    run_test(
+        r#"
+        class D
+          def m; end
+          private def p_m; end
+        end
+        d = D.new
+        [d.respond_to?(:m), d.respond_to?(:absent), d.respond_to?(:p_m), d.respond_to?(:p_m, true)]
+        "#,
+    );
+}
+
+#[test]
 fn method_rest() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
## Summary

4eadc24 ("bytecodegen: don't const-fold methods with side-effecting param defaults", #834) caused a severe performance regression in the respond_to benchmark. This PR keeps that commit's correctness fix while restoring the trivial-method hint for the harmless (and overwhelmingly common) case: parameter defaults that are scalar literals.

## Root cause

4eadc24 disqualifies a method from the `ConstReturn`/`SelfReturn` hint whenever it has *any* optional or keyword parameter — the check looked at the parameters' presence, not at their default expressions:

```rust
let prologue_has_side_effects = !info.optional_info.is_empty()
    || info.keyword_initializers.iter().any(|i| i.is_some());
```

The default `Kernel#respond_to_missing?` is defined as

```ruby
private def respond_to_missing?(name, include_all = false)
  false
end
```

so it lost its `ConstReturn(false)` hint even though its default is a pure literal. That hint is what the JIT's `respond_to?` intrinsic (`object_respond_to`) uses to fold `respond_to?(:missing)` to `false`; without it, every probe of a missing method emits a full builtin call — two runtime method lookups plus a native→VM `invoke_func_inner` of `respond_to_missing?` per iteration. The wrapper-level immediate-return fast path and the generic JIT call fold were lost for such methods as well.

Measured on 5M `respond_to?` probes of a missing method (release, x86-64 Linux): 0.27s before 4eadc24 → **0.70s** after (2.6×). Causal proof: on the regressed build, redefining `respond_to_missing?` identically but *without* the default value (`def respond_to_missing?(name, include_all)`) brings the time right back down — the default's mere presence is the trigger.

## Fix

Disqualify the hint only when a default expression is **not** a scalar literal (`nil`, booleans, numeric literals, symbols, non-interpolated strings). A scalar-literal default only writes the parameter's local slot, which no trivial (constant/`self`) body can observe, so skipping the prologue is sound. Everything else stays disqualified: constant lookups can raise `NameError`, interpolation and composite literals can run arbitrary user code.

## Benchmarks (release build, x86-64 Linux, 5M iterations)

| Case | pre-4eadc24 | master (regressed) | this PR |
|---|---|---|---|
| `respond_to?` missing method | 0.267s | 0.702s | **0.303s** |
| `respond_to?` existing method | 0.285s | 0.313s | 0.312s |

(For reference, CRuby 4.0.2 --yjit runs the missing-method case in 0.143s; the interpreter in 0.377s.)

## Tests

- New `optional_literal_default_trivial_body` tests: literal defaults with trivial bodies (positional and keyword, with and without supplied args), a literal default mixed with an effectful one (hint must still drop, effect must still run), and `respond_to?` over public/private/missing methods.
- All side-effecting-default tests introduced by 4eadc24 still pass.
- Arity errors on over-supplied hinted methods match CRuby (`wrong number of arguments (given 2, expected 0..1)`).
- Full suite: 1912 lib + 114 method_call integration tests, 0 failures (against CRuby 4.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ)_