### PR TITLE
socket: UDP/UNIX domain + message-level APIs on the park_on_fd discipline

### DIFF
--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -3237,7 +3237,8 @@ fn io_readpartial(
 
 /// Resolve a nested `IO::<name>` exception class id (for the
 /// `*WaitReadable` / `*WaitWritable` classes defined in startup.rb).
-fn io_wait_class(globals: &Globals, name: &str) -> Option<ClassId> {
+/// Shared with the socket builtins' `*_nonblock` methods.
+pub(super) fn io_wait_class(globals: &Globals, name: &str) -> Option<ClassId> {
     let io = globals
         .store
         .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("IO"))?

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -2447,12 +2447,13 @@ mod tests {
             # 3-arg packed-sockaddr form
             res << c.send("aa", 0, Socket.pack_sockaddr_in(port, "127.0.0.1"))
             res << srv.recvfrom(2).first
+            # Addrinfo destination (while still disconnected — an explicit
+            # destination on a connected UDP socket is EISCONN on BSD/macOS)
+            res << c.send("cc", 0, srv.connect_address)
+            res << srv.recvfrom(2).first
             # connected 2-arg form
             c.connect("127.0.0.1", port)
             res << c.send("bb", 0)
-            res << srv.recvfrom(2).first
-            # send with Addrinfo destination via BasicSocket#send wrapper
-            res << c.send("cc", 0, srv.connect_address)
             res << srv.recvfrom(2).first
             c.close; srv.close
             res

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -44,6 +44,12 @@ pub(super) fn init(globals: &mut Globals) {
     let tsrv_id = tcpserver.id();
     let socket_class = globals.define_class("Socket", basic, OBJECT_CLASS);
     let sock_id = socket_class.id();
+    let udpsocket = globals.define_class("UDPSocket", ipsocket, OBJECT_CLASS);
+    let udp_id = udpsocket.id();
+    let unixsocket = globals.define_class("UNIXSocket", basic, OBJECT_CLASS);
+    let unix_id = unixsocket.id();
+    let unixserver = globals.define_class("UNIXServer", unixsocket, OBJECT_CLASS);
+    let usrv_id = unixserver.id();
     globals.define_class("SocketError", standard_error, OBJECT_CLASS);
 
     // Socket::Constants, and the same constants directly on Socket
@@ -100,6 +106,71 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(basic_id, "setsockopt", setsockopt, 3);
     globals.define_builtin_func(basic_id, "getsockopt", getsockopt, 2);
     globals.define_builtin_func_with(basic_id, "shutdown", shutdown_, 0, 1, false);
+
+    // Datagram/message primitives (park-and-retry blocking discipline).
+    globals.define_builtin_func_with(basic_id, "recv", basic_recv, 1, 3, false);
+    globals.define_builtin_func_with_kw(
+        basic_id,
+        "recv_nonblock",
+        basic_recv_nonblock,
+        1,
+        3,
+        false,
+        &["exception"],
+        false,
+    );
+    globals.define_builtin_func_with(basic_id, "send", basic_send, 2, 3, false);
+    // Same native under an internal name so stdlib/socket.rb can wrap
+    // `send` (Addrinfo destination coercion) without recursing.
+    globals.define_builtin_func_with(basic_id, "__send_raw", basic_send, 2, 3, false);
+    // Wrap an existing fd in the receiver socket class (Socket.for_fd,
+    // UNIXSocket.for_fd, ... — overrides the generic IO.for_fd).
+    globals.define_builtin_class_func(basic_id, "for_fd", socket_for_fd, 1);
+    globals.define_builtin_func_with(basic_id, "__recvfrom_raw", recvfrom_raw, 3, 3, false);
+    globals.define_builtin_func_with(basic_id, "__recvmsg_raw", recvmsg_raw, 3, 3, false);
+    globals.define_builtin_func_with(basic_id, "__sendmsg_raw", sendmsg_raw, 4, 4, false);
+    globals.define_builtin_func(basic_id, "__sockname_raw", sockname_raw, 0);
+    globals.define_builtin_func(basic_id, "__peername_raw", peername_raw, 0);
+    globals.define_builtin_func_with(basic_id, "__accept_raw", accept_raw, 1, 1, false);
+
+    // Generic sockaddr-level Socket surface.
+    globals.define_builtin_func(sock_id, "bind", socket_bind, 1);
+    globals.define_builtin_func_with_kw(
+        sock_id,
+        "connect",
+        socket_connect,
+        1,
+        1,
+        false,
+        &["timeout"],
+        false,
+    );
+    globals.define_builtin_func(sock_id, "listen", socket_listen, 1);
+    globals.define_builtin_class_func_with(sock_id, "pack_sockaddr_in", pack_sockaddr_in, 2, 2, false);
+    globals.define_builtin_class_func_with(sock_id, "sockaddr_in", pack_sockaddr_in, 2, 2, false);
+    globals.define_builtin_class_func(sock_id, "unpack_sockaddr_in", unpack_sockaddr_in, 1);
+    globals.define_builtin_class_func(sock_id, "pack_sockaddr_un", pack_sockaddr_un, 1);
+    globals.define_builtin_class_func(sock_id, "sockaddr_un", pack_sockaddr_un, 1);
+    globals.define_builtin_class_func(sock_id, "unpack_sockaddr_un", unpack_sockaddr_un, 1);
+    globals.define_builtin_class_func_with(sock_id, "pair", socket_pair, 2, 3, false);
+    globals.define_builtin_class_func_with(sock_id, "socketpair", socket_pair, 2, 3, false);
+
+    globals.define_builtin_func(tsrv_id, "sysaccept", tcp_server_sysaccept, 0);
+
+    // UDP: real datagram sockets (previously a raising stub).
+    globals.define_builtin_class_func_with(udp_id, "new", udp_socket_new, 0, 1, false);
+    globals.define_builtin_class_func_with(udp_id, "open", udp_socket_new, 0, 1, false);
+    globals.define_builtin_func(udp_id, "bind", udp_bind, 2);
+    globals.define_builtin_func(udp_id, "connect", udp_connect, 2);
+    globals.define_builtin_func_with(udp_id, "send", udp_send, 2, 4, false);
+
+    // UNIX domain sockets (previously a raising stub).
+    globals.define_builtin_class_func(unix_id, "new", unix_socket_new, 1);
+    globals.define_builtin_class_func_with(unix_id, "pair", unix_pair, 0, 2, false);
+    globals.define_builtin_class_func_with(unix_id, "socketpair", unix_pair, 0, 2, false);
+    globals.define_builtin_func(unix_id, "path", unix_path, 0);
+    globals.define_builtin_class_func(usrv_id, "new", unix_server_new, 1);
+    globals.define_builtin_func(usrv_id, "listen", socket_listen, 1);
 }
 
 /// The socket constants exposed as `Socket::X` / `Socket::Constants::X`.
@@ -941,6 +1012,1128 @@ fn shutdown_(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     Ok(Value::integer(0))
 }
 
+//
+// Generic message-level socket surface: recv/send (+_nonblock), the raw
+// primitives behind recvfrom/recvmsg/sendmsg/accept/local_address (the
+// Ruby layer in stdlib/socket.rb wraps them into Addrinfo-shaped
+// results), UDP and UNIX-domain sockets, and sockaddr pack/unpack.
+//
+// Blocking discipline is uniform with `accept`/`connect` above: every
+// potentially blocking attempt is issued non-blocking (`MSG_DONTWAIT`,
+// or an O_NONBLOCK listener fd), and a would-block result parks the
+// calling green thread on the scheduler's fd poller via `park_on_fd` —
+// so `Thread#status` reports `"sleep"` while blocked (ruby/spec's
+// `block_caller` matcher spins on exactly that).
+//
+
+/// Retry a would-block-signalling syscall attempt around the scheduler.
+/// `attempt(fd)` returns `Ok(v)` on success or `Err(errno)`; `EAGAIN`
+/// parks on `events` (after a poll point — signals / preemption /
+/// `Thread#kill` land there), `EINTR` just re-runs the poll point, and
+/// anything else surfaces as the matching `Errno::E*`. Closed-ness is
+/// re-checked every round so a cross-thread `close` wakes the parked
+/// thread into an IOError, mirroring `TCPServer#accept`.
+fn park_retry<T>(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    io: Value,
+    events: i16,
+    ctx: &str,
+    mut attempt: impl FnMut(i32) -> std::result::Result<T, i32>,
+) -> Result<T> {
+    let mut parked = false;
+    loop {
+        if io.as_io_inner().is_closed() {
+            return Err(MonorubyErr::ioerr(if parked {
+                "stream closed in another thread"
+            } else {
+                "closed stream"
+            }));
+        }
+        let fd = io.as_io_inner().fileno()?;
+        match attempt(fd) {
+            Ok(v) => return Ok(v),
+            Err(errno) => match errno {
+                libc::EAGAIN | libc::EINTR => {
+                    if crate::executor::execute_gc(vm, globals).is_none() {
+                        return Err(vm.take_error());
+                    }
+                    if errno == libc::EAGAIN {
+                        parked = true;
+                        park_on_fd(vm, globals, fd, events, None)?;
+                    }
+                }
+                _ => return Err(errno_err(&globals.store, errno, ctx)),
+            },
+        }
+    }
+}
+
+fn last_errno() -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or(libc::EIO)
+}
+
+/// One `recvfrom(2)` attempt (non-blocking via `MSG_DONTWAIT`).
+/// Returns `(data, sender_sockaddr_bytes)`; the sockaddr is empty for
+/// connected stream sockets.
+fn recvfrom_attempt(fd: i32, maxlen: usize, flags: i32) -> std::result::Result<(Vec<u8>, Vec<u8>), i32> {
+    let mut buf = vec![0u8; maxlen.max(1)];
+    let mut sa = [0u8; 128];
+    let mut sa_len = sa.len() as libc::socklen_t;
+    // SAFETY: buf/sa are live locals sized to the lengths passed.
+    let n = unsafe {
+        libc::recvfrom(
+            fd,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            maxlen,
+            flags | libc::MSG_DONTWAIT,
+            sa.as_mut_ptr() as *mut libc::sockaddr,
+            &mut sa_len,
+        )
+    };
+    if n < 0 {
+        return Err(last_errno());
+    }
+    buf.truncate(n as usize);
+    Ok((buf, sa[..sa_len as usize].to_vec()))
+}
+
+/// Whether `fd` is a stream-type socket (`SO_TYPE == SOCK_STREAM`).
+/// A zero-byte `recvfrom(2)` on a stream socket means EOF (peer
+/// shutdown) and surfaces as `nil` in Ruby, while on a datagram socket
+/// it is a legitimate empty datagram (`""`).
+fn is_stream_socket(fd: i32) -> bool {
+    let mut ty: i32 = 0;
+    let mut len = std::mem::size_of::<i32>() as libc::socklen_t;
+    // SAFETY: getsockopt out-params sized to an i32.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            &mut ty as *mut i32 as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    rc == 0 && ty == libc::SOCK_STREAM
+}
+
+/// Write `data` into the supplied output buffer (preserving its identity
+/// and encoding) or build a fresh binary string.
+fn data_to_result(data: Vec<u8>, outbuf: Option<Value>) -> Value {
+    match outbuf {
+        Some(mut v) => {
+            let enc = v.as_rstring_inner().encoding();
+            *v.as_rstring_inner_mut() = RStringInner::from_encoding(&data, enc);
+            v
+        }
+        None => Value::bytes(data),
+    }
+}
+
+/// The `(maxlen, flags = 0, outbuf = nil)` argument triple shared by
+/// `recv` / `recv_nonblock`.
+fn recv_args(vm: &mut Executor, globals: &mut Globals, lfp: &Lfp) -> Result<(usize, i32, Option<Value>)> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    if maxlen < 0 {
+        return Err(MonorubyErr::argumenterr(format!("negative length {} given", maxlen)));
+    }
+    let flags = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => v.coerce_to_i64(&globals.store)? as i32,
+        _ => 0,
+    };
+    let outbuf = match lfp.try_arg(2) {
+        Some(v) if !v.is_nil() => Some(v.coerce_to_rstring(vm, globals)?.as_val()),
+        _ => None,
+    };
+    Ok((maxlen as usize, flags, outbuf))
+}
+
+///
+/// ### BasicSocket#recv
+///
+/// - recv(maxlen, flags = 0, outbuf = nil) -> String
+///
+/// Parks the calling green thread until data (or EOF) arrives.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/BasicSocket/i/recv.html]
+#[monoruby_builtin]
+fn basic_recv(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let (maxlen, flags, outbuf) = recv_args(vm, globals, &lfp)?;
+    let (data, _) = park_retry(vm, globals, lfp.self_val(), libc::POLLIN, "recvfrom(2)", |fd| {
+        recvfrom_attempt(fd, maxlen, flags)
+    })?;
+    if data.is_empty() && maxlen > 0 && is_stream_socket(lfp.self_val().as_io_inner().fileno()?) {
+        return Ok(Value::nil());
+    }
+    Ok(data_to_result(data, outbuf))
+}
+
+///
+/// ### BasicSocket#recv_nonblock
+///
+/// - recv_nonblock(maxlen, flags = 0, outbuf = nil, exception: true) -> String | :wait_readable
+///
+#[monoruby_builtin]
+fn basic_recv_nonblock(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let (maxlen, flags, outbuf) = recv_args(vm, globals, &lfp)?;
+    let exception = lfp.try_arg(3).map_or(true, |v| v.as_bool());
+    if lfp.self_val().as_io_inner().is_closed() {
+        return Err(MonorubyErr::ioerr("closed stream"));
+    }
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    match recvfrom_attempt(fd, maxlen, flags) {
+        Ok((data, _)) => Ok(data_to_result(data, outbuf)),
+        Err(errno) if errno == libc::EAGAIN => {
+            if exception {
+                let cid = super::io::io_wait_class(globals, "EAGAINWaitReadable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitReadable not defined"))?;
+                Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - recvfrom(2) would block".to_string(),
+                ))
+            } else {
+                Ok(Value::symbol(IdentId::get_id("wait_readable")))
+            }
+        }
+        Err(errno) => Err(errno_err(&globals.store, errno, "recvfrom(2)")),
+    }
+}
+
+///
+/// ### BasicSocket#send
+///
+/// - send(mesg, flags, dest_sockaddr = nil) -> Integer
+///
+/// Parks on POLLOUT when the kernel send buffer is full. An unconnected
+/// datagram socket without `dest_sockaddr` surfaces
+/// `Errno::EDESTADDRREQ`, as CRuby does.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/BasicSocket/i/send.html]
+#[monoruby_builtin]
+fn basic_send(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mesg = lfp.arg(0).coerce_to_rstring(vm, globals)?.as_val();
+    let bytes = mesg.as_rstring_inner().as_bytes().to_vec();
+    let flags = lfp.arg(1).coerce_to_i64(&globals.store)? as i32;
+    let dest: Option<Vec<u8>> = match lfp.try_arg(2) {
+        Some(v) if !v.is_nil() => match v.is_rstring_inner() {
+            Some(s) => Some(s.as_bytes().to_vec()),
+            None => {
+                return Err(MonorubyErr::typeerr(
+                    "dest_sockaddr should be a packed sockaddr String".to_string(),
+                ));
+            }
+        },
+        _ => None,
+    };
+    let n = park_retry(vm, globals, lfp.self_val(), libc::POLLOUT, "sendto(2)", |fd| {
+        // SAFETY: bytes/dest are live locals sized to the lengths passed.
+        let n = unsafe {
+            match &dest {
+                Some(sa) => libc::sendto(
+                    fd,
+                    bytes.as_ptr() as *const libc::c_void,
+                    bytes.len(),
+                    flags | libc::MSG_DONTWAIT,
+                    sa.as_ptr() as *const libc::sockaddr,
+                    sa.len() as libc::socklen_t,
+                ),
+                None => libc::send(
+                    fd,
+                    bytes.as_ptr() as *const libc::c_void,
+                    bytes.len(),
+                    flags | libc::MSG_DONTWAIT,
+                ),
+            }
+        };
+        if n < 0 { Err(last_errno()) } else { Ok(n) }
+    })?;
+    Ok(Value::integer(n as i64))
+}
+
+///
+/// ### BasicSocket#__recvfrom_raw (stdlib/socket.rb internal)
+///
+/// - __recvfrom_raw(maxlen, flags, blocking) -> [String, sockaddr_bytes]
+///
+/// The primitive behind `Socket#recvfrom` / `IPSocket#recvfrom` /
+/// `UNIXSocket#recvfrom` and their `_nonblock` variants; the Ruby layer
+/// shapes the sender address.
+#[monoruby_builtin]
+fn recvfrom_raw(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?.max(0) as usize;
+    let flags = lfp.arg(1).coerce_to_i64(&globals.store)? as i32;
+    let blocking = lfp.arg(2).as_bool();
+    let (data, sa) = if blocking {
+        park_retry(vm, globals, lfp.self_val(), libc::POLLIN, "recvfrom(2)", |fd| {
+            recvfrom_attempt(fd, maxlen, flags)
+        })?
+    } else {
+        let fd = lfp.self_val().as_io_inner().fileno()?;
+        match recvfrom_attempt(fd, maxlen, flags) {
+            Ok(v) => v,
+            Err(errno) if errno == libc::EAGAIN => {
+                let cid = super::io::io_wait_class(globals, "EAGAINWaitReadable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitReadable not defined"))?;
+                return Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - recvfrom(2) would block".to_string(),
+                ));
+            }
+            Err(errno) => return Err(errno_err(&globals.store, errno, "recvfrom(2)")),
+        }
+    };
+    if data.is_empty() && maxlen > 0 && is_stream_socket(lfp.self_val().as_io_inner().fileno()?) {
+        return Ok(Value::nil());
+    }
+    Ok(Value::array_from_vec(vec![Value::bytes(data), Value::bytes(sa)]))
+}
+
+/// One `recvmsg(2)` attempt (non-blocking via `MSG_DONTWAIT`).
+fn recvmsg_attempt(fd: i32, maxlen: usize, flags: i32) -> std::result::Result<(Vec<u8>, Vec<u8>, i32), i32> {
+    let mut buf = vec![0u8; maxlen.max(1)];
+    let mut sa = [0u8; 128];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: maxlen,
+    };
+    // SAFETY: msghdr is plain-old-data; zeroing is a valid initial state.
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_name = sa.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_namelen = sa.len() as libc::socklen_t;
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    // SAFETY: msg points at live locals set up above.
+    let n = unsafe { libc::recvmsg(fd, &mut msg, flags | libc::MSG_DONTWAIT) };
+    if n < 0 {
+        return Err(last_errno());
+    }
+    buf.truncate(n as usize);
+    Ok((buf, sa[..msg.msg_namelen as usize].to_vec(), msg.msg_flags))
+}
+
+///
+/// ### BasicSocket#__recvmsg_raw (stdlib/socket.rb internal)
+///
+/// - __recvmsg_raw(maxlen, flags, blocking) -> [String, sockaddr_bytes, rflags]
+///
+#[monoruby_builtin]
+fn recvmsg_raw(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let maxlen = lfp.arg(0).coerce_to_int_i64(vm, globals)?.max(0) as usize;
+    let flags = lfp.arg(1).coerce_to_i64(&globals.store)? as i32;
+    let blocking = lfp.arg(2).as_bool();
+    let (data, sa, rflags) = if blocking {
+        park_retry(vm, globals, lfp.self_val(), libc::POLLIN, "recvmsg(2)", |fd| {
+            recvmsg_attempt(fd, maxlen, flags)
+        })?
+    } else {
+        let fd = lfp.self_val().as_io_inner().fileno()?;
+        match recvmsg_attempt(fd, maxlen, flags) {
+            Ok(v) => v,
+            Err(errno) if errno == libc::EAGAIN => {
+                let cid = super::io::io_wait_class(globals, "EAGAINWaitReadable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitReadable not defined"))?;
+                return Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - recvmsg(2) would block".to_string(),
+                ));
+            }
+            Err(errno) => return Err(errno_err(&globals.store, errno, "recvmsg(2)")),
+        }
+    };
+    if data.is_empty() && maxlen > 0 && is_stream_socket(lfp.self_val().as_io_inner().fileno()?) {
+        return Ok(Value::nil());
+    }
+    Ok(Value::array_from_vec(vec![
+        Value::bytes(data),
+        Value::bytes(sa),
+        Value::integer(rflags as i64),
+    ]))
+}
+
+///
+/// ### BasicSocket#__sendmsg_raw (stdlib/socket.rb internal)
+///
+/// - __sendmsg_raw(mesg, flags, dest_sockaddr_or_nil, blocking) -> Integer
+///
+#[monoruby_builtin]
+fn sendmsg_raw(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mesg = lfp.arg(0).coerce_to_rstring(vm, globals)?.as_val();
+    let bytes = mesg.as_rstring_inner().as_bytes().to_vec();
+    let flags = lfp.arg(1).coerce_to_i64(&globals.store)? as i32;
+    let dest: Option<Vec<u8>> = match lfp.try_arg(2) {
+        Some(v) if !v.is_nil() => match v.is_rstring_inner() {
+            Some(s) => Some(s.as_bytes().to_vec()),
+            None => {
+                return Err(MonorubyErr::typeerr(
+                    "dest_sockaddr should be a packed sockaddr String".to_string(),
+                ));
+            }
+        },
+        _ => None,
+    };
+    let blocking = lfp.arg(3).as_bool();
+    let attempt = |fd: i32| -> std::result::Result<isize, i32> {
+        let mut iov = libc::iovec {
+            iov_base: bytes.as_ptr() as *mut libc::c_void,
+            iov_len: bytes.len(),
+        };
+        // SAFETY: msghdr is plain-old-data; zeroing is a valid initial state.
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        if let Some(sa) = &dest {
+            msg.msg_name = sa.as_ptr() as *mut libc::c_void;
+            msg.msg_namelen = sa.len() as libc::socklen_t;
+        }
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        // SAFETY: msg points at live locals set up above.
+        let n = unsafe { libc::sendmsg(fd, &msg, flags | libc::MSG_DONTWAIT) };
+        if n < 0 { Err(last_errno()) } else { Ok(n) }
+    };
+    let n = if blocking {
+        park_retry(vm, globals, lfp.self_val(), libc::POLLOUT, "sendmsg(2)", attempt)?
+    } else {
+        let fd = lfp.self_val().as_io_inner().fileno()?;
+        match attempt(fd) {
+            Ok(n) => n,
+            Err(errno) if errno == libc::EAGAIN => {
+                let cid = super::io::io_wait_class(globals, "EAGAINWaitWritable")
+                    .ok_or_else(|| MonorubyErr::ioerr("IO::EAGAINWaitWritable not defined"))?;
+                return Err(MonorubyErr::new(
+                    MonorubyErrKind::Other(cid),
+                    "Resource temporarily unavailable - sendmsg(2) would block".to_string(),
+                ));
+            }
+            Err(errno) => return Err(errno_err(&globals.store, errno, "sendmsg(2)")),
+        }
+    };
+    Ok(Value::integer(n as i64))
+}
+
+/// Generic getsockname/getpeername returning the raw sockaddr bytes.
+fn name_raw(store: &Store, io: Value, peer: bool) -> Result<Value> {
+    let fd = io.as_io_inner().fileno()?;
+    let mut sa = [0u8; 128];
+    let mut len = sa.len() as libc::socklen_t;
+    // SAFETY: out-params sized to the local buffer.
+    let rc = unsafe {
+        let p = sa.as_mut_ptr() as *mut libc::sockaddr;
+        if peer {
+            libc::getpeername(fd, p, &mut len)
+        } else {
+            libc::getsockname(fd, p, &mut len)
+        }
+    };
+    if rc < 0 {
+        return Err(last_errno_err(store, if peer { "getpeername(2)" } else { "getsockname(2)" }));
+    }
+    Ok(Value::bytes(sa[..len as usize].to_vec()))
+}
+
+/// ### BasicSocket#__sockname_raw (stdlib/socket.rb internal)
+#[monoruby_builtin]
+fn sockname_raw(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    name_raw(&globals.store, lfp.self_val(), false)
+}
+
+/// ### BasicSocket#__peername_raw (stdlib/socket.rb internal)
+#[monoruby_builtin]
+fn peername_raw(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    name_raw(&globals.store, lfp.self_val(), true)
+}
+
+/// Put `fd` in non-blocking mode (sticky — every blocking path here
+/// parks around EAGAIN, so the mode is transparent to Ruby code).
+fn set_nonblocking(fd: i32) {
+    // SAFETY: fcntl on an fd we own; best-effort.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags >= 0 {
+            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+    }
+}
+
+/// `accept(2)` capturing the peer sockaddr; the new fd is made
+/// close-on-exec and blocking (see `cloexec_accept`).
+fn accept_addr_attempt(fd: i32) -> std::result::Result<(i32, Vec<u8>), i32> {
+    let mut sa = [0u8; 128];
+    let mut len = sa.len() as libc::socklen_t;
+    // SAFETY: accept on the caller's listener fd with length-matched
+    // out-params; fcntl on the fresh fd.
+    let conn = unsafe {
+        let conn = libc::accept(fd, sa.as_mut_ptr() as *mut libc::sockaddr, &mut len);
+        if conn >= 0 {
+            libc::fcntl(conn, libc::F_SETFD, libc::FD_CLOEXEC);
+            let flags = libc::fcntl(conn, libc::F_GETFL);
+            if flags >= 0 {
+                libc::fcntl(conn, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+            }
+        }
+        conn
+    };
+    if conn < 0 {
+        return Err(last_errno());
+    }
+    Ok((conn, sa[..len as usize].to_vec()))
+}
+
+///
+/// ### BasicSocket#__accept_raw (stdlib/socket.rb internal)
+///
+/// - __accept_raw(klass_or_nil) -> [Socket-like, sockaddr_bytes] | [Integer, sockaddr_bytes]
+///
+/// The blocking primitive behind `Socket#accept` / `UNIXServer#accept`
+/// and their `sysaccept` variants: parks until a connection arrives,
+/// then wraps the fd in an instance of `klass` (or returns the raw fd
+/// when `klass` is nil). The listener fd is switched to non-blocking on
+/// first use, like `TCPServer`'s permanently non-blocking listener.
+#[monoruby_builtin]
+fn accept_raw(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let klass = lfp.arg(0);
+    set_nonblocking(self_.as_io_inner().fileno()?);
+    let (conn, sa) = park_retry(vm, globals, self_, libc::POLLIN, "accept(2)", |fd| {
+        match accept_addr_attempt(fd) {
+            // ECONNABORTED: the peer went away between the poll wake and
+            // the accept — just wait for the next connection.
+            Err(errno) if errno == libc::ECONNABORTED => Err(libc::EINTR),
+            other => other,
+        }
+    })?;
+    let first = if klass.is_nil() {
+        Value::integer(conn as i64)
+    } else {
+        let class_id = klass.as_class().id();
+        let name = globals.store.get_class_name(class_id);
+        // SAFETY: conn is a fresh, owned fd from accept.
+        let file = unsafe { std::fs::File::from_raw_fd(conn) };
+        Value::new_socket(file, name, class_id)
+    };
+    Ok(Value::array_from_vec(vec![first, Value::bytes(sa)]))
+}
+
+///
+/// ### BasicSocket.for_fd
+///
+/// - for_fd(fd) -> instance of the receiver class
+///
+/// Takes ownership of an existing socket fd (e.g. one returned by
+/// `sysaccept`) and wraps it in the receiver class.
+#[monoruby_builtin]
+fn socket_for_fd(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let fd = lfp.arg(0).coerce_to_i64(&globals.store)? as i32;
+    if fd < 0 {
+        return Err(MonorubyErr::argumenterr(format!("invalid fd: {fd}")));
+    }
+    let class_id = lfp.self_val().as_class().id();
+    let name = globals.store.get_class_name(class_id);
+    // SAFETY: per for_fd's contract the caller transfers ownership of fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    Ok(Value::new_socket(file, name, class_id))
+}
+
+///
+/// ### TCPServer#sysaccept
+///
+/// - sysaccept -> Integer
+///
+#[monoruby_builtin]
+fn tcp_server_sysaccept(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let (conn, _) = park_retry(vm, globals, self_, libc::POLLIN, "accept(2)", |fd| {
+        match accept_addr_attempt(fd) {
+            Err(errno) if errno == libc::ECONNABORTED => Err(libc::EINTR),
+            other => other,
+        }
+    })?;
+    Ok(Value::integer(conn as i64))
+}
+
+///
+/// ### Socket#bind
+///
+/// - bind(sockaddr) -> 0
+///
+#[monoruby_builtin]
+fn socket_bind(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sa = match lfp.arg(0).is_rstring_inner() {
+        Some(s) => s.as_bytes().to_vec(),
+        None => {
+            return Err(MonorubyErr::typeerr(
+                "bind argument should be a packed sockaddr String".to_string(),
+            ));
+        }
+    };
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: bind(2) with a length-matched byte buffer.
+    if unsafe { libc::bind(fd, sa.as_ptr() as *const libc::sockaddr, sa.len() as libc::socklen_t) } < 0 {
+        return Err(last_errno_err(&globals.store, "bind(2)"));
+    }
+    Ok(Value::integer(0))
+}
+
+/// Park until a non-blocking `connect(2)` on `fd` settles, then check
+/// `SO_ERROR` (the same discipline as `TCPSocket.new`).
+fn wait_connect_settled(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    fd: i32,
+    deadline: Option<std::time::Instant>,
+    ctx: &str,
+) -> Result<()> {
+    loop {
+        park_on_fd(vm, globals, fd, libc::POLLOUT, deadline)?;
+        let mut soerr: i32 = 0;
+        let mut len = std::mem::size_of::<i32>() as libc::socklen_t;
+        // SAFETY: getsockopt out-params sized to an i32.
+        unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_ERROR,
+                &mut soerr as *mut i32 as *mut libc::c_void,
+                &mut len,
+            );
+        }
+        if soerr != 0 {
+            return Err(errno_err(&globals.store, soerr, ctx));
+        }
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: one pollfd, length 1, timeout 0.
+        let ready = unsafe { libc::poll(&mut pfd, 1, 0) };
+        if ready > 0 {
+            return Ok(());
+        }
+        if let Some(dl) = deadline
+            && std::time::Instant::now() >= dl
+        {
+            return Err(errno_err(&globals.store, libc::ETIMEDOUT, ctx));
+        }
+    }
+}
+
+///
+/// ### Socket#connect
+///
+/// - connect(sockaddr, timeout: nil) -> 0
+///
+/// Non-blocking connect parking on POLLOUT, like `TCPSocket.new`.
+#[monoruby_builtin]
+fn socket_connect(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sa = match lfp.arg(0).is_rstring_inner() {
+        Some(s) => s.as_bytes().to_vec(),
+        None => {
+            return Err(MonorubyErr::typeerr(
+                "connect argument should be a packed sockaddr String".to_string(),
+            ));
+        }
+    };
+    let deadline = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => {
+            let secs = v.coerce_to_f64(vm, globals)?;
+            Some(std::time::Instant::now() + std::time::Duration::from_secs_f64(secs.max(0.0)))
+        }
+        _ => None,
+    };
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    set_nonblocking(fd);
+    // SAFETY: connect(2) with a length-matched byte buffer.
+    let rc = unsafe { libc::connect(fd, sa.as_ptr() as *const libc::sockaddr, sa.len() as libc::socklen_t) };
+    if rc < 0 {
+        let errno = last_errno();
+        match errno {
+            libc::EINPROGRESS | libc::EINTR | libc::EAGAIN => {
+                wait_connect_settled(vm, globals, fd, deadline, "connect(2)")?;
+            }
+            _ => {
+                set_blocking(fd);
+                return Err(errno_err(&globals.store, errno, "connect(2)"));
+            }
+        }
+    }
+    set_blocking(fd);
+    Ok(Value::integer(0))
+}
+
+///
+/// ### Socket.pack_sockaddr_in / Socket.sockaddr_in
+///
+/// - pack_sockaddr_in(port, host) -> String
+///
+#[monoruby_builtin]
+fn pack_sockaddr_in(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let port = match lfp.arg(0).try_fixnum() {
+        Some(i) if (0..=65535).contains(&i) => i as u16,
+        _ => value_to_port(globals, lfp.arg(0))?,
+    };
+    let host = value_to_host(globals, lfp.arg(1))?;
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), true)?;
+    let sin = sockaddr_in(addr, port);
+    // SAFETY: viewing a POD struct as bytes.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            &sin as *const libc::sockaddr_in as *const u8,
+            std::mem::size_of::<libc::sockaddr_in>(),
+        )
+    };
+    Ok(Value::bytes(bytes.to_vec()))
+}
+
+/// Read a `sockaddr_in` out of packed bytes, validating family.
+fn sockaddr_in_from_bytes(bytes: &[u8]) -> Result<libc::sockaddr_in> {
+    if bytes.len() < std::mem::size_of::<libc::sockaddr_in>() {
+        return Err(MonorubyErr::argumenterr("not an AF_INET sockaddr".to_string()));
+    }
+    // SAFETY: length checked; sockaddr_in is plain-old-data.
+    let sin: libc::sockaddr_in =
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const libc::sockaddr_in) };
+    if sin.sin_family != libc::AF_INET as libc::sa_family_t {
+        return Err(MonorubyErr::argumenterr("not an AF_INET sockaddr".to_string()));
+    }
+    Ok(sin)
+}
+
+///
+/// ### Socket.unpack_sockaddr_in
+///
+/// - unpack_sockaddr_in(sockaddr) -> [port, ip_address]
+///
+#[monoruby_builtin]
+fn unpack_sockaddr_in(_: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let v = lfp.arg(0);
+    let bytes = v
+        .is_rstring_inner()
+        .ok_or_else(|| MonorubyErr::typeerr("sockaddr should be a String".to_string()))?
+        .as_bytes()
+        .to_vec();
+    let sin = sockaddr_in_from_bytes(&bytes)?;
+    let ip = std::net::Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr)).to_string();
+    Ok(Value::array_from_vec(vec![
+        Value::integer(u16::from_be(sin.sin_port) as i64),
+        Value::string(ip),
+    ]))
+}
+
+/// Longest path that fits `sun_path` with a trailing NUL.
+const UNIX_PATH_MAX: usize = 107;
+
+fn unix_path_bytes(globals: &Globals, v: Value) -> Result<Vec<u8>> {
+    let path = match v.is_str() {
+        Some(s) => s.to_string(),
+        None => {
+            return Err(MonorubyErr::typeerr(format!(
+                "no implicit conversion of {} into String",
+                globals.store.get_class_name(v.class())
+            )));
+        }
+    };
+    if path.as_bytes().contains(&0) {
+        return Err(MonorubyErr::argumenterr("path name contains null byte".to_string()));
+    }
+    if path.len() > UNIX_PATH_MAX {
+        return Err(MonorubyErr::argumenterr(format!(
+            "too long unix socket path ({} bytes given but {} bytes max)",
+            path.len(),
+            UNIX_PATH_MAX
+        )));
+    }
+    Ok(path.into_bytes())
+}
+
+fn sockaddr_un_from_path(path: &[u8]) -> libc::sockaddr_un {
+    // SAFETY: sockaddr_un is plain-old-data; zeroing is a valid initial state.
+    let mut sun: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (i, b) in path.iter().enumerate() {
+        sun.sun_path[i] = *b as libc::c_char;
+    }
+    sun
+}
+
+///
+/// ### Socket.pack_sockaddr_un / Socket.sockaddr_un
+///
+/// - pack_sockaddr_un(path) -> String
+///
+#[monoruby_builtin]
+fn pack_sockaddr_un(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let sun = sockaddr_un_from_path(&path);
+    // SAFETY: viewing a POD struct as bytes.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            &sun as *const libc::sockaddr_un as *const u8,
+            std::mem::size_of::<libc::sockaddr_un>(),
+        )
+    };
+    Ok(Value::bytes(bytes.to_vec()))
+}
+
+///
+/// ### Socket.unpack_sockaddr_un
+///
+/// - unpack_sockaddr_un(sockaddr) -> String
+///
+#[monoruby_builtin]
+fn unpack_sockaddr_un(_: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let v = lfp.arg(0);
+    let bytes = v
+        .is_rstring_inner()
+        .ok_or_else(|| MonorubyErr::typeerr("sockaddr should be a String".to_string()))?
+        .as_bytes()
+        .to_vec();
+    let path = sun_path_from_bytes(&bytes)
+        .ok_or_else(|| MonorubyErr::argumenterr("not an AF_UNIX sockaddr".to_string()))?;
+    Ok(Value::string_from_vec(path))
+}
+
+/// Extract the NUL-terminated `sun_path` out of packed AF_UNIX sockaddr
+/// bytes; `None` when the family doesn't match.
+fn sun_path_from_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
+    let path_off = std::mem::offset_of!(libc::sockaddr_un, sun_path);
+    if bytes.len() < path_off {
+        return None;
+    }
+    // SAFETY: header length checked; sockaddr_un is plain-old-data and a
+    // short input only leaves the zeroed tail in place.
+    let sun: libc::sockaddr_un = unsafe {
+        let mut tmp: libc::sockaddr_un = std::mem::zeroed();
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            &mut tmp as *mut libc::sockaddr_un as *mut u8,
+            bytes.len().min(std::mem::size_of::<libc::sockaddr_un>()),
+        );
+        tmp
+    };
+    if sun.sun_family != libc::AF_UNIX as libc::sa_family_t {
+        return None;
+    }
+    let path: Vec<u8> = sun
+        .sun_path
+        .iter()
+        .take(bytes.len().saturating_sub(path_off))
+        .take_while(|&&c| c != 0)
+        .map(|&c| c as u8)
+        .collect();
+    Some(path)
+}
+
+/// Make both socketpair fds close-on-exec.
+fn cloexec_pair(fds: [i32; 2]) {
+    for fd in fds {
+        // SAFETY: fcntl on fds we own; best-effort.
+        unsafe {
+            libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
+        }
+    }
+}
+
+///
+/// ### Socket.pair / Socket.socketpair
+///
+/// - pair(family, type, protocol = 0) -> [Socket, Socket]
+///
+#[monoruby_builtin]
+fn socket_pair(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let family = family_const(&globals.store, lfp.arg(0))?;
+    let stype = type_const(&globals.store, lfp.arg(1))?;
+    let proto = match lfp.try_arg(2) {
+        Some(v) if !v.is_nil() => v.coerce_to_i64(&globals.store)? as i32,
+        _ => 0,
+    };
+    make_pair(globals, family, stype, proto, lfp.self_val().as_class().id())
+}
+
+///
+/// ### UNIXSocket.pair / UNIXSocket.socketpair
+///
+/// - pair(type = :STREAM, protocol = 0) -> [UNIXSocket, UNIXSocket]
+///
+#[monoruby_builtin]
+fn unix_pair(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let stype = match lfp.try_arg(0) {
+        Some(v) if !v.is_nil() => type_const(&globals.store, v)?,
+        _ => libc::SOCK_STREAM,
+    };
+    let proto = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => v.coerce_to_i64(&globals.store)? as i32,
+        _ => 0,
+    };
+    make_pair(globals, libc::AF_UNIX, stype, proto, lfp.self_val().as_class().id())
+}
+
+fn make_pair(globals: &Globals, family: i32, stype: i32, proto: i32, class_id: ClassId) -> Result<Value> {
+    let mut fds = [0i32; 2];
+    // SAFETY: socketpair(2) with a two-slot out array.
+    if unsafe { libc::socketpair(family, stype, proto, fds.as_mut_ptr()) } < 0 {
+        return Err(last_errno_err(&globals.store, "socketpair(2)"));
+    }
+    cloexec_pair(fds);
+    let name = globals.store.get_class_name(class_id);
+    // SAFETY: both fds are fresh, owned socketpair fds.
+    let (a, b) = unsafe {
+        (
+            Value::new_socket(std::fs::File::from_raw_fd(fds[0]), name.clone(), class_id),
+            Value::new_socket(std::fs::File::from_raw_fd(fds[1]), name, class_id),
+        )
+    };
+    Ok(Value::array_from_vec(vec![a, b]))
+}
+
+///
+/// ### UDPSocket.new
+///
+/// - new(address_family = Socket::AF_INET) -> UDPSocket
+///
+#[monoruby_builtin]
+fn udp_socket_new(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let family = match lfp.try_arg(0) {
+        Some(v) if !v.is_nil() => family_const(&globals.store, v)?,
+        _ => libc::AF_INET,
+    };
+    let fd = cloexec_socket(family, libc::SOCK_DGRAM, 0, false);
+    if fd < 0 {
+        return Err(last_errno_err(&globals.store, "socket(2)"));
+    }
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    Ok(Value::new_socket(file, "UDPSocket".into(), class_id))
+}
+
+///
+/// ### UDPSocket#bind
+///
+/// - bind(host, port) -> 0
+///
+#[monoruby_builtin]
+fn udp_bind(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let host = value_to_host(globals, lfp.arg(0))?;
+    let port = value_to_port(globals, lfp.arg(1))?;
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), true)?;
+    let sin = sockaddr_in(addr, port);
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: bind(2) with a valid sockaddr_in.
+    if unsafe {
+        libc::bind(
+            fd,
+            &sin as *const libc::sockaddr_in as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        )
+    } < 0
+    {
+        return Err(last_errno_err(&globals.store, "bind(2)"));
+    }
+    Ok(Value::integer(0))
+}
+
+///
+/// ### UDPSocket#connect
+///
+/// - connect(host, port) -> 0
+///
+/// Datagram connect just records the default peer — no handshake, so no
+/// parking is needed.
+#[monoruby_builtin]
+fn udp_connect(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let host = value_to_host(globals, lfp.arg(0))?;
+    let port = value_to_port(globals, lfp.arg(1))?;
+    let addr = resolve_ipv4(&globals.store, host.as_deref(), false)?;
+    let sin = sockaddr_in(addr, port);
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: connect(2) with a valid sockaddr_in.
+    if unsafe {
+        libc::connect(
+            fd,
+            &sin as *const libc::sockaddr_in as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        )
+    } < 0
+    {
+        return Err(last_errno_err(&globals.store, "connect(2)"));
+    }
+    Ok(Value::integer(0))
+}
+
+///
+/// ### UDPSocket#send
+///
+/// - send(mesg, flags) -> Integer                     (connected)
+/// - send(mesg, flags, sockaddr_to) -> Integer
+/// - send(mesg, flags, host, port) -> Integer
+///
+#[monoruby_builtin]
+fn udp_send(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mesg = lfp.arg(0).coerce_to_rstring(vm, globals)?.as_val();
+    let bytes = mesg.as_rstring_inner().as_bytes().to_vec();
+    let flags = lfp.arg(1).coerce_to_i64(&globals.store)? as i32;
+    let dest: Option<Vec<u8>> = match (lfp.try_arg(2), lfp.try_arg(3)) {
+        (Some(host), Some(port)) if !port.is_nil() => {
+            let host = value_to_host(globals, host)?;
+            let port = value_to_port(globals, port)?;
+            let addr = resolve_ipv4(&globals.store, host.as_deref(), false)?;
+            let sin = sockaddr_in(addr, port);
+            // SAFETY: viewing a POD struct as bytes.
+            let sa = unsafe {
+                std::slice::from_raw_parts(
+                    &sin as *const libc::sockaddr_in as *const u8,
+                    std::mem::size_of::<libc::sockaddr_in>(),
+                )
+            };
+            Some(sa.to_vec())
+        }
+        (Some(sa), _) if !sa.is_nil() => match sa.is_rstring_inner() {
+            Some(s) => Some(s.as_bytes().to_vec()),
+            None => {
+                return Err(MonorubyErr::typeerr(
+                    "sockaddr_to should be a packed sockaddr String".to_string(),
+                ));
+            }
+        },
+        _ => None,
+    };
+    let n = park_retry(vm, globals, lfp.self_val(), libc::POLLOUT, "sendto(2)", |fd| {
+        // SAFETY: bytes/dest are live locals sized to the lengths passed.
+        let n = unsafe {
+            match &dest {
+                Some(sa) => libc::sendto(
+                    fd,
+                    bytes.as_ptr() as *const libc::c_void,
+                    bytes.len(),
+                    flags | libc::MSG_DONTWAIT,
+                    sa.as_ptr() as *const libc::sockaddr,
+                    sa.len() as libc::socklen_t,
+                ),
+                None => libc::send(
+                    fd,
+                    bytes.as_ptr() as *const libc::c_void,
+                    bytes.len(),
+                    flags | libc::MSG_DONTWAIT,
+                ),
+            }
+        };
+        if n < 0 { Err(last_errno()) } else { Ok(n) }
+    })?;
+    Ok(Value::integer(n as i64))
+}
+
+///
+/// ### UNIXSocket.new
+///
+/// - new(path) -> UNIXSocket
+///
+/// Connects to a UNIX-domain stream server. A full backlog (EAGAIN from
+/// a non-blocking AF_UNIX connect) parks briefly on POLLOUT and retries.
+#[monoruby_builtin]
+fn unix_socket_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let sun = sockaddr_un_from_path(&path);
+    let fd = cloexec_socket(libc::AF_UNIX, libc::SOCK_STREAM, 0, true);
+    if fd < 0 {
+        return Err(last_errno_err(&globals.store, "socket(2)"));
+    }
+    let sa_len = std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t;
+    loop {
+        // SAFETY: connect(2) with a valid sockaddr_un.
+        let rc = unsafe { libc::connect(fd, &sun as *const libc::sockaddr_un as *const libc::sockaddr, sa_len) };
+        if rc == 0 {
+            break;
+        }
+        let errno = last_errno();
+        match errno {
+            libc::EINPROGRESS => {
+                if let Err(e) = wait_connect_settled(vm, globals, fd, None, "connect(2)") {
+                    // SAFETY: closing the fd we own.
+                    unsafe { libc::close(fd) };
+                    return Err(e);
+                }
+                break;
+            }
+            // Backlog full on AF_UNIX: retry after a bounded park.
+            libc::EAGAIN | libc::EINTR => {
+                if crate::executor::execute_gc(vm, globals).is_none() {
+                    // SAFETY: closing the fd we own.
+                    unsafe { libc::close(fd) };
+                    return Err(vm.take_error());
+                }
+                if errno == libc::EAGAIN {
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+                    if let Err(e) = park_on_fd(vm, globals, fd, libc::POLLOUT, Some(deadline)) {
+                        // SAFETY: closing the fd we own.
+                        unsafe { libc::close(fd) };
+                        return Err(e);
+                    }
+                }
+            }
+            _ => {
+                // SAFETY: closing the fd we own.
+                unsafe { libc::close(fd) };
+                return Err(errno_err(&globals.store, errno, "connect(2)"));
+            }
+        }
+    }
+    set_blocking(fd);
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    Ok(Value::new_socket(file, "UNIXSocket".into(), class_id))
+}
+
+///
+/// ### UNIXServer.new
+///
+/// - new(path) -> UNIXServer
+///
+/// Binds and listens on a UNIX-domain stream socket. The listener fd is
+/// left non-blocking for `accept`'s park-and-retry loop.
+#[monoruby_builtin]
+fn unix_server_new(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let sun = sockaddr_un_from_path(&path);
+    let fd = cloexec_socket(libc::AF_UNIX, libc::SOCK_STREAM, 0, true);
+    if fd < 0 {
+        return Err(last_errno_err(&globals.store, "socket(2)"));
+    }
+    let sa_len = std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t;
+    // SAFETY: bind/listen on the fresh fd we own.
+    unsafe {
+        if libc::bind(fd, &sun as *const libc::sockaddr_un as *const libc::sockaddr, sa_len) < 0 {
+            let err = last_errno_err(&globals.store, "bind(2)");
+            libc::close(fd);
+            return Err(err);
+        }
+        if libc::listen(fd, libc::SOMAXCONN) < 0 {
+            let err = last_errno_err(&globals.store, "listen(2)");
+            libc::close(fd);
+            return Err(err);
+        }
+    }
+    let class_id = lfp.self_val().as_class().id();
+    // SAFETY: fd is a fresh, owned socket fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    Ok(Value::new_socket(file, "UNIXServer".into(), class_id))
+}
+
+///
+/// ### UNIXSocket#path
+///
+/// - path -> String
+///
+/// The bound path for a server-side socket, `""` for a client.
+#[monoruby_builtin]
+fn unix_path(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sa = name_raw(&globals.store, lfp.self_val(), false)?;
+    let path = sun_path_from_bytes(sa.as_rstring_inner().as_bytes()).unwrap_or_default();
+    Ok(Value::string_from_vec(path))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
@@ -1000,6 +2193,151 @@ mod tests {
             k.close
             t.join
             s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn udp_roundtrip_and_recvfrom() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = UDPSocket.new
+            s.bind("127.0.0.1", 0)
+            port = s.addr[1]
+            c = UDPSocket.new
+            c.send("ping", 0, "127.0.0.1", port)
+            msg, addr = s.recvfrom(10)
+            res = [msg, addr[0], addr[3], addr[1].is_a?(Integer)]
+            c.close
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn socket_generic_accept_connect() {
+        run_test_once(
+            r#"
+            require "socket"
+            srv = Socket.new(:INET, :STREAM)
+            srv.setsockopt(:SOCKET, :REUSEADDR, true)
+            srv.bind(Socket.pack_sockaddr_in(0, "127.0.0.1"))
+            srv.listen(5)
+            port = srv.local_address.ip_port
+            cli = Socket.new(:INET, :STREAM)
+            t = Thread.new { cli.connect(Socket.pack_sockaddr_in(port, "127.0.0.1")) }
+            conn, ai = srv.accept
+            t.join
+            res = [conn.class.to_s, ai.class.to_s, ai.ip_address, ai.ip_port.is_a?(Integer)]
+            conn.close; cli.close; srv.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn unix_pair_recv_send_and_recvmsg() {
+        run_test_once(
+            r#"
+            require "socket"
+            a, b = UNIXSocket.pair
+            a.send("hello", 0)
+            got = b.recv(5)
+            b.sendmsg("world")
+            data, ai, _fl = a.recvmsg(5)
+            res = [got, data, ai.class.to_s, a.class.to_s]
+            a.close; b.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn unix_server_client_roundtrip() {
+        run_test_once(
+            r#"
+            require "socket"
+            require "tmpdir"
+            path = File.join(Dir.mktmpdir, "s.sock")
+            srv = UNIXServer.new(path)
+            t = Thread.new { c = srv.accept; c.write(c.gets); c.close }
+            k = UNIXSocket.new(path)
+            k.puts "unix!"
+            res = [k.gets, srv.path]
+            k.close
+            t.join
+            srv.close
+            res.map { |s| s.sub(File.dirname(path), "") }
+            "#,
+        );
+    }
+
+    #[test]
+    fn recv_returns_nil_at_stream_eof() {
+        run_test_once(
+            r#"
+            require "socket"
+            a, b = UNIXSocket.pair
+            a.close
+            res = b.recv(10)
+            b.close
+            res.inspect
+            "#,
+        );
+    }
+
+    #[test]
+    fn pack_unpack_sockaddr() {
+        run_test_once(
+            r#"
+            require "socket"
+            sa = Socket.pack_sockaddr_in(8080, "127.0.0.1")
+            un = Socket.pack_sockaddr_un("/tmp/x.sock")
+            [
+              Socket.unpack_sockaddr_in(sa),
+              Socket.unpack_sockaddr_un(un),
+              sa.encoding.to_s,
+              begin; Socket.unpack_sockaddr_in(un); rescue ArgumentError => e; :bad_family; end,
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn blocked_socket_ops_report_sleep_status() {
+        // The exact discipline ruby/spec's `block_caller` matcher spins
+        // on: a thread blocked in a socket op must report status
+        // "sleep", and Thread#kill must be able to reap it.
+        run_test_once(
+            r#"
+            require "socket"
+            require "tmpdir"
+            res = []
+            probe = lambda do |&blk|
+              t = Thread.new(&blk)
+              st = nil
+              5000.times do
+                st = t.status
+                break if st == "sleep" || st == false || st.nil?
+                Thread.pass
+              end
+              t.kill
+              t.join
+              st
+            end
+            s = TCPServer.new("127.0.0.1", 0)
+            res << probe.call { s.accept }
+            u = UDPSocket.new
+            u.bind("127.0.0.1", 0)
+            res << probe.call { u.recvfrom(10) }
+            a, b = UNIXSocket.pair
+            res << probe.call { a.recv(4) }
+            res << probe.call { a.recvmsg }
+            res << probe.call { Socket.tcp_server_loop("127.0.0.1", 0) { } }
+            [s, u, a, b].each(&:close)
             res
             "#,
         );

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -334,6 +334,13 @@ fn resolve_ipv4(store: &Store, host: Option<&str>, for_bind: bool) -> Result<u32
 fn sockaddr_in(addr_be: u32, port: u16) -> libc::sockaddr_in {
     // SAFETY: sockaddr_in is plain-old-data; zeroing is a valid initial state.
     let mut sin: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+    // BSD-family sockaddrs carry a length prefix; CRuby fills it in the
+    // packed form (e.g. Socket.pack_sockaddr_in's first byte is 16 on
+    // macOS), so match that for byte-identical sockaddr strings.
+    #[cfg(not(target_os = "linux"))]
+    {
+        sin.sin_len = std::mem::size_of::<libc::sockaddr_in>() as u8;
+    }
     sin.sin_family = libc::AF_INET as libc::sa_family_t;
     sin.sin_port = port.to_be();
     sin.sin_addr = libc::in_addr { s_addr: addr_be };
@@ -1788,6 +1795,11 @@ fn unix_path_bytes(globals: &Globals, v: Value, allow_nul: bool) -> Result<Vec<u
 fn sockaddr_un_from_path(path: &[u8]) -> libc::sockaddr_un {
     // SAFETY: sockaddr_un is plain-old-data; zeroing is a valid initial state.
     let mut sun: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    // See sockaddr_in: CRuby sets the BSD length prefix (106 on macOS).
+    #[cfg(not(target_os = "linux"))]
+    {
+        sun.sun_len = std::mem::size_of::<libc::sockaddr_un>() as u8;
+    }
     sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
     for (i, b) in path.iter().enumerate() {
         sun.sun_path[i] = *b as libc::c_char;

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -163,6 +163,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(udp_id, "bind", udp_bind, 2);
     globals.define_builtin_func(udp_id, "connect", udp_connect, 2);
     globals.define_builtin_func_with(udp_id, "send", udp_send, 2, 4, false);
+    // Same native under an internal name so stdlib/socket.rb can wrap
+    // `send` (Addrinfo destination coercion) without recursing.
+    globals.define_builtin_func_with(udp_id, "__udp_send_raw", udp_send, 2, 4, false);
 
     // UNIX domain sockets (previously a raising stub).
     globals.define_builtin_class_func(unix_id, "new", unix_socket_new, 1);
@@ -1724,7 +1727,11 @@ fn unpack_sockaddr_in(_: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: Byt
 /// Longest path that fits `sun_path` with a trailing NUL.
 const UNIX_PATH_MAX: usize = 107;
 
-fn unix_path_bytes(globals: &Globals, v: Value) -> Result<Vec<u8>> {
+/// Validate a UNIX socket path argument. `allow_nul` distinguishes
+/// `Socket.pack_sockaddr_un` (CRuby packs NUL-containing paths — used
+/// for Linux abstract addresses) from `UNIXSocket.new`/`UNIXServer.new`
+/// (a NUL must raise before any bind/connect — CVE-2018-8779).
+fn unix_path_bytes(globals: &Globals, v: Value, allow_nul: bool) -> Result<Vec<u8>> {
     let path = match v.is_str() {
         Some(s) => s.to_string(),
         None => {
@@ -1734,7 +1741,7 @@ fn unix_path_bytes(globals: &Globals, v: Value) -> Result<Vec<u8>> {
             )));
         }
     };
-    if path.as_bytes().contains(&0) {
+    if !allow_nul && path.as_bytes().contains(&0) {
         return Err(MonorubyErr::argumenterr("path name contains null byte".to_string()));
     }
     if path.len() > UNIX_PATH_MAX {
@@ -1764,7 +1771,7 @@ fn sockaddr_un_from_path(path: &[u8]) -> libc::sockaddr_un {
 ///
 #[monoruby_builtin]
 fn pack_sockaddr_un(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let path = unix_path_bytes(globals, lfp.arg(0), true)?;
     let sun = sockaddr_un_from_path(&path);
     // SAFETY: viewing a POD struct as bytes.
     let bytes = unsafe {
@@ -2033,7 +2040,7 @@ fn udp_send(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 /// a non-blocking AF_UNIX connect) parks briefly on POLLOUT and retries.
 #[monoruby_builtin]
 fn unix_socket_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let path = unix_path_bytes(globals, lfp.arg(0), false)?;
     let sun = sockaddr_un_from_path(&path);
     let fd = cloexec_socket(libc::AF_UNIX, libc::SOCK_STREAM, 0, true);
     if fd < 0 {
@@ -2095,7 +2102,7 @@ fn unix_socket_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Byteco
 /// left non-blocking for `accept`'s park-and-retry loop.
 #[monoruby_builtin]
 fn unix_server_new(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = unix_path_bytes(globals, lfp.arg(0))?;
+    let path = unix_path_bytes(globals, lfp.arg(0), false)?;
     let sun = sockaddr_un_from_path(&path);
     let fd = cloexec_socket(libc::AF_UNIX, libc::SOCK_STREAM, 0, true);
     if fd < 0 {
@@ -2338,6 +2345,214 @@ mod tests {
             res << probe.call { a.recvmsg }
             res << probe.call { Socket.tcp_server_loop("127.0.0.1", 0) { } }
             [s, u, a, b].each(&:close)
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn recv_nonblock_and_msg_nonblock_paths() {
+        run_test_once(
+            r#"
+            require "socket"
+            res = []
+            a, b = UNIXSocket.pair
+            # would-block: exception and exception: false forms
+            res << (begin; b.recv_nonblock(4); rescue IO::WaitReadable; :raised; end)
+            res << b.recv_nonblock(4, exception: false)
+            res << (begin; b.recvmsg_nonblock(4); rescue IO::WaitReadable; :raised; end)
+            res << b.recvmsg_nonblock(4, exception: false)
+            # data present: outbuf form and plain form
+            a.send("hi", 0)
+            buf = +"xxxx"
+            res << b.recv_nonblock(2, 0, buf)
+            res << buf
+            a.sendmsg_nonblock("yo")
+            data, ai, _fl = b.recvmsg_nonblock(2)
+            res << [data, ai.class.to_s]
+            a.close; b.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn sendmsg_nonblock_error_paths() {
+        run_test_once(
+            r#"
+            require "socket"
+            s = Socket.new(:INET, :DGRAM)
+            res = []
+            res << (begin; s.sendmsg_nonblock("x"); rescue Errno::EDESTADDRREQ; :dest_req; end)
+            res << (begin; s.send("x", 0); rescue Errno::EDESTADDRREQ; :dest_req; end)
+            s.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn udp_send_forms_and_connect() {
+        run_test_once(
+            r#"
+            require "socket"
+            srv = UDPSocket.new
+            srv.bind("127.0.0.1", 0)
+            port = srv.addr[1]
+            c = UDPSocket.new
+            res = []
+            # 3-arg packed-sockaddr form
+            res << c.send("aa", 0, Socket.pack_sockaddr_in(port, "127.0.0.1"))
+            res << srv.recvfrom(2).first
+            # connected 2-arg form
+            c.connect("127.0.0.1", port)
+            res << c.send("bb", 0)
+            res << srv.recvfrom(2).first
+            # send with Addrinfo destination via BasicSocket#send wrapper
+            res << c.send("cc", 0, srv.connect_address)
+            res << srv.recvfrom(2).first
+            c.close; srv.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn socket_pair_and_for_fd_and_sysaccept() {
+        run_test_once(
+            r#"
+            require "socket"
+            res = []
+            x, y = Socket.pair(:UNIX, :STREAM)
+            x.send("pp", 0)
+            res << y.recv(2)
+            res << [x.class.to_s, y.class.to_s]
+            x.close; y.close
+            u, v = UNIXSocket.pair(:DGRAM)
+            u.send("qq", 0)
+            res << v.recv(2)
+            u.close; v.close
+            # sysaccept returns a raw fd; wrap it back with for_fd
+            srv = TCPServer.new("127.0.0.1", 0)
+            port = srv.addr[1]
+            t = Thread.new { TCPSocket.new("127.0.0.1", port) }
+            fd = srv.sysaccept
+            res << fd.is_a?(Integer)
+            conn = Socket.for_fd(fd)
+            res << conn.class.to_s
+            k = t.join.value
+            k.write("zz")
+            res << conn.recv(2)
+            conn.close; k.close; srv.close
+            res
+            "#,
+        );
+        run_test_once(
+            r#"
+            require "socket"
+            require "tmpdir"
+            path = File.join(Dir.mktmpdir, "sa.sock")
+            srv = UNIXServer.new(path)
+            t = Thread.new { UNIXSocket.new(path) }
+            fd = srv.sysaccept
+            k = t.join.value
+            res = [fd.is_a?(Integer)]
+            sock = Socket.new(:INET, :STREAM)
+            sock.setsockopt(:SOCKET, :REUSEADDR, true)
+            sock.bind(Socket.pack_sockaddr_in(0, "127.0.0.1"))
+            sock.listen(1)
+            port = sock.local_address.ip_port
+            t2 = Thread.new { TCPSocket.new("127.0.0.1", port) }
+            fd2, ai = sock.sysaccept
+            k2 = t2.join.value
+            res << [fd2.is_a?(Integer), ai.class.to_s, ai.ip_address]
+            IO.for_fd(fd).close rescue nil
+            IO.for_fd(fd2).close rescue nil
+            k.close; k2.close; srv.close; sock.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn sockaddr_error_paths_and_unix_helpers() {
+        run_test_once(
+            r#"
+            require "socket"
+            require "tmpdir"
+            res = []
+            # pack allows NUL (abstract addresses); UNIXSocket.new rejects it.
+            res << Socket.pack_sockaddr_un("a\0b").bytes.first(6)
+            res << (begin; UNIXSocket.new("a\0b"); rescue ArgumentError; :nul; end)
+            res << (begin; Socket.pack_sockaddr_un("x" * 200); rescue ArgumentError; :too_long; end)
+            res << (begin; Socket.unpack_sockaddr_un(Socket.pack_sockaddr_in(1, "127.0.0.1")); rescue ArgumentError; :bad_family; end)
+            res << (begin; UNIXSocket.new(123); rescue TypeError; :not_str; end)
+            path = File.join(Dir.mktmpdir, "h.sock")
+            srv = UNIXServer.new(path)
+            t = Thread.new { srv.accept.close }
+            k = UNIXSocket.open(path) { |s| s.addr[0] }
+            t.join
+            res << k
+            res << srv.addr[0]
+            res << (srv.path == path)
+            srv.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn generic_connect_refused_and_recvfrom_eof() {
+        run_test_once(
+            r#"
+            require "socket"
+            # Grab a free port, close the listener, then generic-connect to it.
+            s = TCPServer.new("127.0.0.1", 0)
+            port = s.addr[1]
+            s.close
+            res = []
+            c = Socket.new(:INET, :STREAM)
+            res << (begin
+              c.connect(Socket.pack_sockaddr_in(port, "127.0.0.1"))
+              :connected
+            rescue Errno::ECONNREFUSED
+              :refused
+            end)
+            c.close
+            # recvfrom/recvmsg on a peer-closed stream return nil (EOF).
+            a, b = UNIXSocket.pair
+            a.close
+            res << b.recvfrom(4).inspect
+            b.close
+            x, y = UNIXSocket.pair
+            x.close
+            res << y.recvmsg(4).inspect
+            y.close
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn address_helpers_and_argument_errors() {
+        run_test_once(
+            r#"
+            require "socket"
+            res = []
+            s = TCPServer.new("127.0.0.1", 0)
+            res << s.local_address.ip_address
+            res << (s.local_address.ip_port == s.addr[1])
+            res << s.getsockname.is_a?(String)
+            res << (begin; s.recv(-1); rescue ArgumentError; :neg; end)
+            t = Thread.new { c = s.accept; c.recv(4); c.close }
+            k = TCPSocket.new("127.0.0.1", s.addr[1])
+            res << (k.remote_address.ip_port == s.addr[1])
+            res << k.getpeername.is_a?(String)
+            ai = k.local_address
+            res << (begin; ai.unix_path; rescue SocketError; :not_unix; end)
+            k.send("done", 0)
+            t.join
+            k.close; s.close
             res
             "#,
         );

--- a/monoruby/src/builtins/socket.rs
+++ b/monoruby/src/builtins/socket.rs
@@ -152,6 +152,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(sock_id, "pack_sockaddr_un", pack_sockaddr_un, 1);
     globals.define_builtin_class_func(sock_id, "sockaddr_un", pack_sockaddr_un, 1);
     globals.define_builtin_class_func(sock_id, "unpack_sockaddr_un", unpack_sockaddr_un, 1);
+    globals.define_builtin_class_func(sock_id, "__sockaddr_family", sockaddr_family, 1);
     globals.define_builtin_class_func_with(sock_id, "pair", socket_pair, 2, 3, false);
     globals.define_builtin_class_func_with(sock_id, "socketpair", socket_pair, 2, 3, false);
 
@@ -1722,6 +1723,36 @@ fn unpack_sockaddr_in(_: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: Byt
         Value::integer(u16::from_be(sin.sin_port) as i64),
         Value::string(ip),
     ]))
+}
+
+///
+/// ### Socket.__sockaddr_family (stdlib/socket.rb internal)
+///
+/// - __sockaddr_family(sockaddr) -> Integer
+///
+/// The address family of packed sockaddr bytes, read through the
+/// platform's `struct sockaddr` layout — `sa_family` is a u16 at offset
+/// 0 on Linux but a u8 after `sa_len` on macOS/BSD, so Ruby-side
+/// `unpack` can't do this portably. Empty/short input yields AF_UNSPEC.
+#[monoruby_builtin]
+fn sockaddr_family(_: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let v = lfp.arg(0);
+    let bytes = v
+        .is_rstring_inner()
+        .ok_or_else(|| MonorubyErr::typeerr("sockaddr should be a String".to_string()))?
+        .as_bytes();
+    // SAFETY: sockaddr is plain-old-data; a short input only leaves the
+    // zeroed tail in place (family reads as AF_UNSPEC).
+    let sa: libc::sockaddr = unsafe {
+        let mut tmp: libc::sockaddr = std::mem::zeroed();
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            &mut tmp as *mut libc::sockaddr as *mut u8,
+            bytes.len().min(std::mem::size_of::<libc::sockaddr>()),
+        );
+        tmp
+    };
+    Ok(Value::integer(sa.sa_family as i64))
 }
 
 /// Longest path that fits `sun_path` with a trailing NUL.

--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -347,6 +347,15 @@ class Socket
 end
 
 class UDPSocket < IPSocket
+  # send(mesg, flags [, host, port] / [, sockaddr_to]) -> Integer
+  # Wraps the native primitive to accept an Addrinfo destination.
+  def send(mesg, flags, *rest)
+    if rest.length == 1 && rest[0].respond_to?(:to_sockaddr)
+      rest = [rest[0].to_sockaddr]
+    end
+    __udp_send_raw(mesg, flags, *rest)
+  end
+
   # UDPSocket#recvfrom_nonblock(maxlen, flags = 0, outbuf = nil, exception: true)
   #   -> [data, ["AF_INET", sender_port, sender_host, sender_host]]
   def recvfrom_nonblock(maxlen, flags = 0, _outbuf = nil, exception: true)

--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -485,8 +485,10 @@ class Addrinfo
   alias to_s to_sockaddr
 
   def afamily
-    # sa_family is a native-endian u16 at offset 0 on Linux.
-    @sockaddr.bytesize < 2 ? Socket::AF_UNSPEC : @sockaddr.unpack1("S")
+    # sa_family's offset/width is platform-dependent (Linux: u16 at 0;
+    # macOS/BSD: u8 after sa_len) — the native helper reads it through
+    # the real struct sockaddr layout.
+    Socket.__sockaddr_family(@sockaddr)
   end
   alias pfamily afamily
 

--- a/monoruby/stdlib/socket.rb
+++ b/monoruby/stdlib/socket.rb
@@ -1,13 +1,14 @@
 # Ruby-level remainder of the socket library for monoruby.
 #
-# The real TCP surface — BasicSocket < IO, IPSocket, TCPSocket, TCPServer,
-# Socket, Socket::Constants, SocketError — is implemented natively
-# (src/builtins/socket.rs): sockets are IO objects over the socket fd, so
-# the whole IO method set (read/gets/write/close/closed?/…, including the
-# green-thread blocking-IO emulation) applies to them by inheritance, and
-# accept/connect park the calling green thread on the scheduler's fd
-# poller. This file adds only pure-Ruby bookkeeping and the stubs for the
-# protocols that remain unsupported (UNIX domain, UDP).
+# The low-level surface — BasicSocket < IO, IPSocket, TCPSocket,
+# TCPServer, UDPSocket, UNIXSocket, UNIXServer, Socket — is implemented
+# natively (src/builtins/socket.rs): sockets are IO objects over the
+# socket fd, and every potentially blocking operation (accept/connect/
+# recv/send/recvfrom/recvmsg/sendmsg) parks the calling green thread on
+# the scheduler's fd poller, so `Thread#status` reports "sleep" while
+# blocked. This file wraps the raw natives (`__accept_raw`,
+# `__recvfrom_raw`, …) into the CRuby-shaped results (Addrinfo, address
+# arrays) and adds the pure-Ruby conveniences (server-loop helpers).
 
 class BasicSocket
   # monoruby always returns numeric addresses (as if
@@ -29,9 +30,117 @@ class BasicSocket
   def do_not_reverse_lookup=(v)
     @do_not_reverse_lookup = v
   end
+
+  def local_address
+    Addrinfo.new(__sockname_raw)
+  end
+
+  def remote_address
+    Addrinfo.new(__peername_raw)
+  end
+
+  def getsockname
+    __sockname_raw
+  end
+
+  def getpeername
+    __peername_raw
+  end
+
+  # The local address rewritten to something a client can connect to:
+  # a wildcard IP (0.0.0.0) becomes the loopback address.
+  def connect_address
+    ai = local_address
+    if ai.ipv4? && ai.ip_address == "0.0.0.0"
+      Addrinfo.new(Socket.pack_sockaddr_in(ai.ip_port, "127.0.0.1"))
+    else
+      ai
+    end
+  end
+
+  # send(mesg, flags, dest_sockaddr = nil) -> Integer
+  # Wraps the native primitive to accept an Addrinfo destination.
+  def send(mesg, flags, dest = nil)
+    dest = dest.to_sockaddr if dest.respond_to?(:to_sockaddr)
+    __send_raw(mesg, flags, dest)
+  end
+
+  # recvmsg(maxdatalen = nil, flags = 0, maxcontrollen = nil, opts = {})
+  #   -> [data, sender_addrinfo, rflags] | nil at stream EOF
+  # Ancillary data is not supported (no controls in the result).
+  def recvmsg(dlen = nil, flags = 0, _clen = nil, _opts = {})
+    raw = __recvmsg_raw(dlen || 65536, flags, true)
+    return nil if raw.nil?
+    data, sa, rflags = raw
+    [data, Addrinfo.new(sa, nil, __socktype), rflags]
+  end
+
+  def recvmsg_nonblock(dlen = nil, flags = 0, _clen = nil, _opts = {}, exception: true)
+    raw = begin
+      __recvmsg_raw(dlen || 65536, flags, false)
+    rescue IO::WaitReadable
+      raise if exception
+      return :wait_readable
+    end
+    return nil if raw.nil?
+    data, sa, rflags = raw
+    [data, Addrinfo.new(sa, nil, __socktype), rflags]
+  end
+
+  # sendmsg(mesg, flags = 0, dest_sockaddr = nil, *controls) -> Integer
+  def sendmsg(mesg, flags = 0, dest = nil, *_controls)
+    dest = dest.to_sockaddr if dest.respond_to?(:to_sockaddr)
+    __sendmsg_raw(mesg, flags, dest, true)
+  end
+
+  def sendmsg_nonblock(mesg, flags = 0, dest = nil, *_controls, exception: true)
+    dest = dest.to_sockaddr if dest.respond_to?(:to_sockaddr)
+    begin
+      __sendmsg_raw(mesg, flags, dest, false)
+    rescue IO::WaitWritable
+      raise if exception
+      :wait_writable
+    end
+  end
+
+  # The socket's own SO_TYPE, used to tag sender Addrinfos.
+  def __socktype
+    @__socktype ||= getsockopt(Socket::SOL_SOCKET, Socket::SO_TYPE)
+  end
+  private :__socktype
+end
+
+class IPSocket
+  # recvfrom(maxlen, flags = 0) -> [data, ["AF_INET", port, host, host]]
+  def recvfrom(maxlen, flags = 0)
+    raw = __recvfrom_raw(maxlen, flags, true)
+    return nil if raw.nil?
+    data, sa = raw
+    [data, Addrinfo.new(sa).__ip_addr_array]
+  end
 end
 
 class Socket
+  # recvfrom(maxlen, flags = 0) -> [data, Addrinfo] | nil at stream EOF
+  def recvfrom(maxlen, flags = 0)
+    raw = __recvfrom_raw(maxlen, flags, true)
+    return nil if raw.nil?
+    data, sa = raw
+    [data, Addrinfo.new(sa, nil, __socktype)]
+  end
+
+  # accept -> [Socket, Addrinfo]
+  def accept
+    sock, sa = __accept_raw(Socket)
+    [sock, Addrinfo.new(sa)]
+  end
+
+  # sysaccept -> [Integer, Addrinfo]
+  def sysaccept
+    fd, sa = __accept_raw(nil)
+    [fd, Addrinfo.new(sa)]
+  end
+
   # The high-level connect helper the net/* libraries use. Delegates to
   # the native TCPSocket; extra keywords accepted for compatibility
   # (resolv_timeout / fast_fallback are meaningless for a blocking
@@ -53,13 +162,183 @@ class Socket
     end
   end
 
-  def self.gethostname
-    require "etc" rescue nil
-    (Etc.uname[:nodename] rescue nil) || "localhost"
+  # One bound+listening IPv4 stream Socket (CRuby returns one socket per
+  # resolved address; monoruby resolves IPv4 only).
+  def self.tcp_server_sockets(host = nil, port)
+    sock = Socket.new(:INET, :STREAM)
+    sock.setsockopt(:SOCKET, :REUSEADDR, true)
+    sock.bind(Socket.pack_sockaddr_in(port || 0, host))
+    sock.listen(Socket::SOMAXCONN)
+    sockets = [sock]
+    if block_given?
+      begin
+        yield sockets
+      ensure
+        sockets.each { |s| s.close unless s.closed? }
+      end
+    else
+      sockets
+    end
   end
 
-  def self.getaddrinfo(*_)
-    []
+  # Accept connections on the listening sockets forever, yielding each
+  # connection as [Socket, Addrinfo]. Blocks (parks) in IO.select
+  # between connections.
+  #
+  # NOTE: the *_loop helpers below inline this instead of forwarding
+  # their block with `&b`: a directly-yielded block keeps `break`
+  # returning from the helper the user called, while a re-captured
+  # block would turn `break` into a proc-closure escape.
+  def self.accept_loop(*sockets)
+    sockets.flatten!
+    loop do
+      readable, = IO.select(sockets)
+      readable.each do |sock|
+        conn, addr = sock.accept
+        yield conn, addr
+      end
+    end
+  end
+
+  def self.tcp_server_loop(host = nil, port)
+    tcp_server_sockets(host, port) do |sockets|
+      loop do
+        readable, = IO.select(sockets)
+        readable.each do |sock|
+          conn, addr = sock.accept
+          yield conn, addr
+        end
+      end
+    end
+  end
+
+  # One bound IPv4 datagram Socket.
+  def self.udp_server_sockets(host = nil, port)
+    sock = Socket.new(:INET, :DGRAM)
+    sock.setsockopt(:SOCKET, :REUSEADDR, true)
+    sock.bind(Socket.pack_sockaddr_in(port || 0, host))
+    sockets = [sock]
+    if block_given?
+      begin
+        yield sockets
+      ensure
+        sockets.each { |s| s.close unless s.closed? }
+      end
+    else
+      sockets
+    end
+  end
+
+  # Receive datagrams forever, yielding [message, Socket::UDPSource].
+  def self.udp_server_loop_on(sockets)
+    loop do
+      readable, = IO.select(sockets)
+      readable.each do |sock|
+        msg, sender = sock.recvfrom(65536)
+        yield msg, UDPSource.new(sender, sock)
+      end
+    end
+  end
+
+  def self.udp_server_loop(host = nil, port)
+    udp_server_sockets(host, port) do |sockets|
+      loop do
+        readable, = IO.select(sockets)
+        readable.each do |sock|
+          msg, sender = sock.recvfrom(65536)
+          yield msg, UDPSource.new(sender, sock)
+        end
+      end
+    end
+  end
+
+  # Connect a UNIX-domain stream Socket to `path`.
+  def self.unix(path)
+    sock = Socket.new(:UNIX, :STREAM)
+    sock.connect(Socket.pack_sockaddr_un(path))
+    if block_given?
+      begin
+        yield sock
+      ensure
+        sock.close unless sock.closed?
+      end
+    else
+      sock
+    end
+  end
+
+  def self.unix_server_socket(path)
+    sock = Socket.new(:UNIX, :STREAM)
+    sock.bind(Socket.pack_sockaddr_un(path))
+    sock.listen(Socket::SOMAXCONN)
+    if block_given?
+      begin
+        yield sock
+      ensure
+        sock.close unless sock.closed?
+        begin
+          File.unlink(path)
+        rescue StandardError
+        end
+      end
+    else
+      sock
+    end
+  end
+
+  def self.unix_server_loop(path)
+    unix_server_socket(path) do |sock|
+      loop do
+        IO.select([sock])
+        conn, addr = sock.accept
+        yield conn, addr
+      end
+    end
+  end
+
+  # The reply handle yielded by udp_server_loop.
+  class UDPSource
+    attr_reader :remote_address
+
+    def initialize(remote_address, socket)
+      @remote_address = remote_address
+      @socket = socket
+    end
+
+    def reply(msg)
+      @socket.send(msg, 0, @remote_address.to_sockaddr)
+    end
+
+    def inspect
+      "#<Socket::UDPSource: #{@remote_address.inspect}>"
+    end
+  end
+
+  def self.gethostname
+    begin
+      require "etc"
+    rescue StandardError
+    end
+    begin
+      Etc.uname[:nodename]
+    rescue StandardError
+      nil
+    end || "localhost"
+  end
+
+  # Minimal getaddrinfo: numeric IPv4 resolution only (monoruby always
+  # behaves as do_not_reverse_lookup = true, so the canonical-name slot
+  # carries the numeric address, as CRuby does in that mode).
+  def self.getaddrinfo(host, service, _family = nil, socktype = nil,
+                       protocol = nil, _flags = nil, _reverse_lookup = nil)
+    port = case service
+           when nil then 0
+           when Integer then service
+           else service.to_s.to_i
+           end
+    ip = IPSocket.getaddress(host.nil? || host == "" ? "127.0.0.1" : host.to_s)
+    st = socktype.nil? || socktype == 0 ? Socket::SOCK_STREAM : socktype
+    [["AF_INET", port, ip, ip, Socket::PF_INET, st, protocol || 0]]
   end
 
   def self.ip_address_list
@@ -68,41 +347,190 @@ class Socket
 end
 
 class UDPSocket < IPSocket
-  # UDP is not implemented. Fail loudly at instantiation (see UNIXSocket
-  # below): a silent do-nothing socket lets code run on until it dies far
-  # from the cause.
-  def initialize(*)
-    raise SocketError, "UDP sockets are not supported in monoruby"
+  # UDPSocket#recvfrom_nonblock(maxlen, flags = 0, outbuf = nil, exception: true)
+  #   -> [data, ["AF_INET", sender_port, sender_host, sender_host]]
+  def recvfrom_nonblock(maxlen, flags = 0, _outbuf = nil, exception: true)
+    begin
+      data, sa = __recvfrom_raw(maxlen, flags, false)
+    rescue IO::WaitReadable
+      raise if exception
+      return :wait_readable
+    end
+    [data, Addrinfo.new(sa).__ip_addr_array]
   end
 end
 
 class UNIXSocket < BasicSocket
-  # Real UNIX-domain sockets are unsupported, but the path argument is
-  # validated like CRuby's (CVE-2018-8779): a NUL byte must raise
-  # ArgumentError *before* any bind/connect would happen. Valid paths
-  # fail with an explicit unsupported-feature error instead of a
-  # misleading NoMethodError.
-  def self.open(path, *rest, &blk)
-    new(path, *rest, &blk)
+  def self.open(path, &blk)
+    sock = new(path)
+    if blk
+      begin
+        blk.call(sock)
+      ensure
+        sock.close unless sock.closed?
+      end
+    else
+      sock
+    end
   end
 
-  def initialize(path, *)
-    path = path.to_path if path.respond_to?(:to_path)
-    path = path.to_str  if path.respond_to?(:to_str)
-    unless path.is_a?(String)
-      raise TypeError, "no implicit conversion of #{path.class} into String"
+  # recvfrom(maxlen, flags = 0) -> [data, ["AF_UNIX", path]]
+  def recvfrom(maxlen, flags = 0)
+    raw = __recvfrom_raw(maxlen, flags, true)
+    return nil if raw.nil?
+    data, sa = raw
+    path = if sa.empty?
+      ""
+    else
+      begin
+        Socket.unpack_sockaddr_un(sa)
+      rescue StandardError
+        ""
+      end
     end
-    if path.include?("\0")
-      raise ArgumentError, "path name contains null byte"
+    [data, ["AF_UNIX", path]]
+  end
+
+  def addr
+    ["AF_UNIX", path]
+  end
+
+  def peeraddr
+    sa = __peername_raw
+    path = begin
+      Socket.unpack_sockaddr_un(sa)
+    rescue StandardError
+      ""
     end
-    raise SocketError, "UNIX domain sockets are not supported in monoruby"
+    ["AF_UNIX", path]
   end
 end
-class UNIXServer < UNIXSocket; end
 
+class UNIXServer < UNIXSocket
+  def self.open(path, &blk)
+    sock = new(path)
+    if blk
+      begin
+        blk.call(sock)
+      ensure
+        sock.close unless sock.closed?
+      end
+    else
+      sock
+    end
+  end
+
+  # accept -> UNIXSocket
+  def accept
+    sock, _sa = __accept_raw(UNIXSocket)
+    sock
+  end
+
+  # sysaccept -> Integer
+  def sysaccept
+    fd, _sa = __accept_raw(nil)
+    fd
+  end
+end
+
+# A minimal Addrinfo over a packed sockaddr (AF_INET / AF_UNIX).
 class Addrinfo
-  def self.tcp(host, port); new; end
-  def self.udp(host, port); new; end
-  def ip_address; "0.0.0.0"; end
-  def ip_port; 0; end
+  attr_reader :socktype, :protocol
+
+  def initialize(sockaddr, _family = nil, socktype = nil, protocol = nil)
+    if sockaddr.is_a?(Array)
+      # ["AF_INET", port, host, numeric_host] / ["AF_UNIX", path]
+      case sockaddr[0]
+      when "AF_INET"
+        sockaddr = Socket.pack_sockaddr_in(sockaddr[1], sockaddr[3] || sockaddr[2])
+      when "AF_UNIX"
+        sockaddr = Socket.pack_sockaddr_un(sockaddr[1])
+      else
+        raise SocketError, "unknown address family: #{sockaddr[0]}"
+      end
+    end
+    @sockaddr = sockaddr.to_s.b
+    @socktype = socktype || 0
+    @protocol = protocol || 0
+  end
+
+  def self.ip(host)
+    new(Socket.pack_sockaddr_in(0, host))
+  end
+
+  def self.tcp(host, port)
+    new(Socket.pack_sockaddr_in(port, host))
+  end
+
+  def self.udp(host, port)
+    new(Socket.pack_sockaddr_in(port, host))
+  end
+
+  def self.unix(path)
+    new(Socket.pack_sockaddr_un(path))
+  end
+
+  def to_sockaddr
+    @sockaddr
+  end
+  alias to_s to_sockaddr
+
+  def afamily
+    # sa_family is a native-endian u16 at offset 0 on Linux.
+    @sockaddr.bytesize < 2 ? Socket::AF_UNSPEC : @sockaddr.unpack1("S")
+  end
+  alias pfamily afamily
+
+  def ip?
+    afamily == Socket::AF_INET || afamily == Socket::AF_INET6
+  end
+
+  def ipv4?
+    afamily == Socket::AF_INET
+  end
+
+  def ipv6?
+    afamily == Socket::AF_INET6
+  end
+
+  def unix?
+    afamily == Socket::AF_UNIX
+  end
+
+  def ip_address
+    raise SocketError, "need IPv4 or IPv6 address" unless ip?
+    Socket.unpack_sockaddr_in(@sockaddr)[1]
+  end
+
+  def ip_port
+    raise SocketError, "need IPv4 or IPv6 address" unless ip?
+    Socket.unpack_sockaddr_in(@sockaddr)[0]
+  end
+
+  def ip_unpack
+    raise SocketError, "need IPv4 or IPv6 address" unless ip?
+    port, addr = Socket.unpack_sockaddr_in(@sockaddr)
+    [addr, port]
+  end
+
+  def unix_path
+    raise SocketError, "need AF_UNIX address" unless unix?
+    Socket.unpack_sockaddr_un(@sockaddr)
+  end
+
+  # Internal: IPSocket#recvfrom-shaped address array.
+  def __ip_addr_array
+    port, addr = Socket.unpack_sockaddr_in(@sockaddr)
+    ["AF_INET", port, addr, addr]
+  end
+
+  def inspect
+    if unix?
+      "#<Addrinfo: #{unix_path} SOCK_STREAM>"
+    elsif ip?
+      "#<Addrinfo: #{ip_address}:#{ip_port}>"
+    else
+      "#<Addrinfo: (unknown)>"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements the missing blocking socket surface — UDP sockets, UNIX-domain sockets, and the message-level APIs (`recv`/`send`/`recvfrom`/`recvmsg`/`sendmsg`, generic `Socket#bind`/`connect`/`accept`, `sysaccept`, sockaddr pack/unpack, `Addrinfo`, and the `Socket.*_server_loop` helpers) — all on the existing `park_on_fd` blocking discipline, so a green thread blocked in any socket operation parks on the scheduler's fd poller and reports `Thread#status == "sleep"`.

That status contract is exactly what ruby/spec's `block_caller` matcher spins on: it `Thread.pass`es until the spawned thread's status becomes `"sleep"` (blocked) or terminates. The 24 `block_caller` examples across 16 `library/socket` spec files previously errored on unimplemented APIs, and two files (`tcp_server_loop_spec.rb`, `udp_server_loop_spec.rb`) hung to timeout: the fixture's `ServerLoopPortFinder.port` (`sleep 0.001 until @port`) spun forever after the server-loop thread died instantly on the missing `Socket.tcp_server_loop`.

## Native layer (`src/builtins/socket.rs`)

Every potentially blocking attempt is issued non-blocking (`MSG_DONTWAIT`, or an `O_NONBLOCK` listener fd) and a would-block result goes through a shared `park_retry` loop: poll point (signals / preemption / `Thread#kill`) → `park_on_fd` → retry, re-checking closed-ness each round so a cross-thread `close` wakes the parked thread into an `IOError` — the same discipline `TCPServer#accept` and `TCPSocket.new` already used.

- `BasicSocket#recv` / `recv_nonblock` / `send`, plus raw primitives (`__recvfrom_raw`, `__recvmsg_raw`, `__sendmsg_raw`, `__accept_raw`, `__sockname_raw`, `__peername_raw`) that the Ruby layer shapes into CRuby-style results
- Generic `Socket#bind` / `connect` (non-blocking connect parking on POLLOUT + `SO_ERROR`) / `listen`, `BasicSocket.for_fd`, `TCPServer#sysaccept`
- `UDPSocket` (`new`/`bind`/`connect`/`send` with all destination forms) and `UNIXSocket`/`UNIXServer` (`connect`, `bind`+`listen`, `pair`) replace the previous raising stubs; `Socket.pair`/`socketpair`
- `Socket.pack_sockaddr_in`/`un` + `unpack_*`
- A zero-byte `recvfrom(2)` on a stream socket surfaces as `nil` (CRuby's EOF shape); on a datagram socket it stays `""`

## Ruby layer (`stdlib/socket.rb`)

- `Addrinfo` backed by the packed sockaddr (`socktype`/`protocol` tags, `SocketError` from family-mismatched accessors), `local_address`/`remote_address`/`connect_address`, `getsockname`/`getpeername`, a minimal numeric-IPv4 `Socket.getaddrinfo`
- Per-class `recvfrom`/`recvmsg` wrappers; `sendmsg`/`sendmsg_nonblock` with `exception:`; `Addrinfo` destinations for `send`
- Server-loop helpers: `tcp/udp_server_sockets`, `accept_loop`, `tcp/udp/unix_server_loop`, `Socket.unix`, `Socket::UDPSource`

One subtlety: the `*_loop` helpers yield the user block **directly** instead of forwarding it with `&b`. A re-captured block turns `break` into a proc-closure escape — a `LocalJumpError` in the simple case, and a segfault through the ensure-unwind in the spec's fixture shape. The direct-yield structure keeps `break` returning from the helper the user called, matching CRuby. (The underlying VM behavior of `break` through a `&b`-forwarded block is worth a separate look.)

## Results

ruby/spec `library/socket` block_caller sweep (16 files, 45s kill-timeout per file):

- **13/16 files fully green; all 24 `block_caller` examples pass; zero hangs, zero crashes** (before: 2 files hung to timeout, most others errored within milliseconds)
- The remaining 4 failures/errors in 3 files are pre-existing gaps unrelated to sockets: `require "io/nonblock"` (LoadError), `Thread#backtrace` (unimplemented), and `IO#gets` with a binary separator

Tests: full suite passes (1919 lib tests, 0 failures), including 7 new socket tests — UDP roundtrip, generic `Socket` accept/connect, UNIX pair + `recvmsg`, UNIX server/client roundtrip, stream-EOF `nil`, sockaddr pack/unpack round-trips, and a `block_caller`-shaped test asserting that a thread blocked in `accept`/`recvfrom`/`recv`/`recvmsg`/`tcp_server_loop` reports `status == "sleep"` and can be reaped with `Thread#kill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ)_