### PR TITLE
Fix break from a &b-forwarded block under a nested yield chain (#982)

### DIFF
--- a/monoruby/src/bytecodegen/method_call/arguments.rs
+++ b/monoruby/src/bytecodegen/method_call/arguments.rs
@@ -51,7 +51,7 @@ impl<'a> BytecodeGen<'a> {
         let (block_fid, block_arg) = if arglist.delegate_block {
             let (_, _, outer) = self.mother.clone();
             let block = self.push().into();
-            self.emit(BytecodeInst::BlockArgProxy(block, outer), loc);
+            self.emit_block_forward(block, outer, loc);
             (None, Some(block))
         } else {
             let block_arg = self.sp().into();
@@ -130,7 +130,7 @@ impl<'a> BytecodeGen<'a> {
         };
 
         let block = self.push().into();
-        self.emit(BytecodeInst::BlockArgProxy(block, outer), loc);
+        self.emit_block_forward(block, outer, loc);
 
         Ok(CallSite::new(
             name,
@@ -203,7 +203,7 @@ impl<'a> BytecodeGen<'a> {
         };
 
         let block = self.push().into();
-        self.emit(BytecodeInst::BlockArgProxy(block, outer), loc);
+        self.emit_block_forward(block, outer, loc);
 
         CallSite::new(
             None,
@@ -217,6 +217,34 @@ impl<'a> BytecodeGen<'a> {
             dst,
             true,
         )
+    }
+
+    ///
+    /// Emit the block handler of the method `outer` lexical levels up into
+    /// `dst`, to be passed on as the block argument of a call.
+    ///
+    /// A *proxy* handler encodes its home frame as a **dynamic** prev-cfp
+    /// hop count, but `BlockArgProxy` can only bump that count by a
+    /// statically known amount — it assumes every lexical level costs
+    /// exactly two frames (the block frame plus the method that `yield`ed
+    /// it). That holds only when each enclosing block is invoked by a
+    /// direct `yield` from the method it was passed to; as soon as the
+    /// block travels one more hop (a block re-yielded from inside another
+    /// literal block, issue #982) the forwarded handler resolves to an
+    /// unrelated frame, so `break` out of it reports a bogus
+    /// `LocalJumpError: break from proc-closure`.
+    ///
+    /// For `outer == 0` the home frame *is* the current frame, so the
+    /// static +1 is exact and the cheap proxy is kept. For `outer > 0`,
+    /// materialize the handler into a Proc with `BlockArg`, which locates
+    /// the home frame on the live cfp chain at run time.
+    ///
+    fn emit_block_forward(&mut self, dst: BcReg, outer: usize, loc: Loc) {
+        if outer == 0 {
+            self.emit(BytecodeInst::BlockArgProxy(dst, 0), loc);
+        } else {
+            self.emit(BytecodeInst::BlockArg(dst, outer), loc);
+        }
     }
 
     fn load_dynvar(&mut self, slot_id: SlotId, outer: usize, loc: Loc) -> BcReg {
@@ -331,7 +359,7 @@ impl<'a> BytecodeGen<'a> {
                     self.emit(BytecodeInst::LoadDynVar { dst, src, outer }, loc);
                 } else {
                     assert_eq!(Some(proc_local), self.outer_block_param_name(outer));
-                    self.emit(BytecodeInst::BlockArgProxy(dst, outer), loc);
+                    self.emit_block_forward(dst, outer, loc);
                 }
             }
             _ => {

--- a/monoruby/tests/break_proc.rs
+++ b/monoruby/tests/break_proc.rs
@@ -102,3 +102,68 @@ fn break_jit_tier() {
         "#,
     );
 }
+
+#[test]
+fn break_through_nested_yield_forwarding() {
+    // issue #982: `&b` forwarded from inside a block that is itself run
+    // through *another* literal block's `yield`. The forwarded block
+    // handler used to be re-based on a statically guessed cfp distance,
+    // which mis-identified the block's defining frame and turned the
+    // `break` into a bogus `LocalJumpError`.
+    run_test_once(
+        r#"
+        def base; yield :s; end
+        def relay; base { |s| yield(s) }; end
+        def inner; yield; end
+        res = []
+        def outer(&b); relay { |_s| inner(&b) }; end
+        res << (outer { break 3 })
+        res << (outer { 7 })
+        # class-hierarchy variant (ruby/spec's ServerLoopPortFinder shape)
+        class BaseH
+          def self.helper
+            yield [:sock]
+          ensure
+            :cleanup
+          end
+        end
+        class SubH < BaseH
+          def self.helper
+            super() { |s| yield(s) }
+          end
+        end
+        def accept_loop(_s); loop { yield :conn }; end
+        def server_loop(&b); SubH.helper { |s| accept_loop(s, &b) }; end
+        res << (server_loop { break :a })
+        # zsuper forwarding the block from inside a nested block
+        class P1
+          def m; yield :zs; end
+        end
+        class P2 < P1
+          def m; relay { |_s| super }; end
+        end
+        res << (P2.new.m { |x| break [:zsuper, x] })
+        # `...` forwarding from inside a nested block
+        def fwd_target(a, &b); inner(&b); end
+        def fwd(...); relay { |_s| fwd_target(...) }; end
+        res << (fwd(1) { break :fwd })
+        res
+        "#,
+    );
+}
+
+#[test]
+fn break_through_nested_yield_forwarding_jit() {
+    // Same shape, hot enough to be JIT-compiled.
+    run_test(
+        r#"
+        def base2; yield :s; end
+        def relay2; base2 { |s| yield(s) }; end
+        def inner2; yield; end
+        def outer_jit(&b); relay2 { |_s| inner2(&b) }; end
+        res = nil
+        50.times { res = outer_jit { break :jit } }
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
Fixes #982.

## Root cause

A *proxy* block handler (`(FuncId, depth)` packed in a Fixnum) encodes its home
frame as a **dynamic** prev-cfp hop count. `BlockArgProxy` re-based that count
by a **statically** guessed amount (`2 * outer + 1`, see the x86_64 / aarch64
lowerings), which assumes every lexical level costs exactly two frames — the
block frame plus the method that `yield`ed it.

That assumption holds only while each enclosing block is invoked by a direct
`yield` from the method it was passed to. One hop more — a block re-yielded from
inside *another* literal block — and the forwarded handler resolves to an
unrelated frame. The unwinder then reaches that frame, finds no call site
carrying this block literal, and reports a bogus
`LocalJumpError: break from proc-closure`. Through the pre-#981 socket
server-loop shape the same mis-resolution could escalate to a SIGSEGV.

The real distance depends on the run-time call chain, so no static correction
can be right.

## Fix

For `outer > 0`, emit `BlockArg` instead of `BlockArgProxy`:
`runtime::block_arg` locates the owner frame on the live cfp chain at run time
and materializes a Proc, so any number of forwarding / yield hops resolves
correctly. `outer == 0` (the home frame *is* the current frame, so the static
+1 is exact) keeps the cheap proxy — the hot `&b` forwarding path is unchanged.

`super` / zsuper / `...` forwarding go through the same helper
(`emit_block_forward`) and are fixed as well.

## Verification

- The issue's minimal repro and the `ServerLoopPortFinder` shape now match
  CRuby 4.0.2 (`3` / `:a`).
- New regression tests in `tests/break_proc.rs` cover the plain shape, the
  class-hierarchy shape, zsuper and `...` forwarding, plus a JIT-tier variant.
- Full `cargo test --release` green (0 failures).

The #981 workaround in `stdlib/socket.rb` is left as is; it is no longer
load-bearing but harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)