### PR TITLE
spec-library: dashboard + monitor CI for ruby/spec library group

### DIFF
--- a/.github/portal/index.html
+++ b/.github/portal/index.html
@@ -101,6 +101,7 @@
   <a class="primary-blue" href="./bench/">Performance vs YJIT (x86-64) →</a>
   <a class="primary-blue" href="./bench-arm64/">Performance vs YJIT (aarch64) →</a>
   <a class="primary" href="./spec/">ruby/spec compliance dashboard →</a>
+  <a class="primary" href="./library/">ruby/spec library dashboard →</a>
   <a class="secondary" href="https://github.com/sisshiki1969/monoruby">GitHub</a>
 </nav>
 

--- a/.github/spec-library-pages/index.html
+++ b/.github/spec-library-pages/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>monoruby ruby/spec library history</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2em; max-width: 1100px; color: #1a1a1a; }
+  h1 { margin-bottom: 0.2em; }
+  .meta { color: #666; font-size: 0.9em; margin-bottom: 2em; }
+  section { margin-bottom: 3em; }
+  canvas { max-width: 100%; }
+  select { font-size: 1em; padding: 0.2em 0.5em; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.9em; }
+  th, td { padding: 4px 8px; border-bottom: 1px solid #eee; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { border-bottom: 2px solid #888; }
+  a { color: #1565c0; }
+  td a { text-decoration: none; }
+  td a:hover { text-decoration: underline; }
+  .range-control { margin-top: 1em; padding: 0.8em 0; border-top: 1px solid #eee; }
+  .range-control .dates { font-size: 0.85em; color: #555; margin-bottom: 0.8em; }
+  /* Single slider with two thumbs: two overlaid range inputs whose
+     tracks are transparent, sharing one visible track + fill. */
+  .dual-slider { position: relative; height: 24px; }
+  .dual-slider .track {
+    position: absolute; left: 0; right: 0; top: 10px; height: 4px;
+    background: #ddd; border-radius: 2px;
+  }
+  .dual-slider .fill {
+    position: absolute; top: 10px; height: 4px;
+    background: #1565c0; border-radius: 2px;
+  }
+  .dual-slider input[type=range] {
+    position: absolute; left: 0; top: 0; width: 100%; height: 24px;
+    margin: 0; background: none; pointer-events: none;
+    -webkit-appearance: none; appearance: none;
+  }
+  .dual-slider input[type=range]::-webkit-slider-runnable-track { background: none; border: none; }
+  .dual-slider input[type=range]::-moz-range-track { background: none; border: none; }
+  .dual-slider input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none; pointer-events: auto;
+    width: 16px; height: 16px; margin-top: -6px; border-radius: 50%;
+    background: #1565c0; border: 2px solid #fff; cursor: pointer;
+    box-shadow: 0 0 2px rgba(0,0,0,0.4);
+  }
+  .dual-slider input[type=range]::-moz-range-thumb {
+    pointer-events: auto; width: 16px; height: 16px; border-radius: 50%;
+    background: #1565c0; border: 2px solid #fff; cursor: pointer;
+  }
+</style>
+</head>
+<body>
+<h1>monoruby × ruby/spec library</h1>
+<div class="meta">
+  Pass rate history of <code>library/*</code> subcategories.
+  Source: <a href="data/history.csv">history.csv</a>,
+  <a href="data/history_total.csv">history_total.csv</a>,
+  <a href="latest.json">latest.json</a>.
+</div>
+
+<section>
+  <h2>Total pass rate over time</h2>
+  <canvas id="totalChart" height="120"></canvas>
+
+  <h2 style="margin-top:1.5em">Per-category pass rate over time</h2>
+  <label>Category: <select id="catSelect"></select></label>
+  <canvas id="catChart" height="120"></canvas>
+
+  <div class="range-control" id="rangeControl" hidden>
+    <div class="dates">
+      Showing <strong id="rangeFromLabel"></strong> &ndash; <strong id="rangeToLabel"></strong>
+    </div>
+    <div class="dual-slider">
+      <div class="track"></div>
+      <div class="fill" id="rangeFill"></div>
+      <input type="range" id="rangeFrom" min="0" max="0" value="0">
+      <input type="range" id="rangeTo"   min="0" max="0" value="0">
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>Latest snapshot</h2>
+  <div id="latestMeta" class="meta"></div>
+  <p class="meta">Click a benchmark name to open its <a href="https://github.com/ruby/spec/tree/master/library">ruby/spec</a> source directory.</p>
+  <div id="latestBarWrap" style="position: relative;"><canvas id="latestBar"></canvas></div>
+  <table id="latestTable">
+    <thead>
+      <tr><th>Category</th><th>Files</th><th>Examples</th><th>Pass</th><th>Failures</th><th>Errors</th><th>Pass rate</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</section>
+
+<section>
+  <h2>Timed-out spec files (latest run)</h2>
+  <p class="meta">
+    Spec files whose individual run exceeded the 60-second timeout and was
+    killed — typically hangs waiting on real thread concurrency. Their
+    examples are not included in the tallies above.
+    Source: <a href="data/timeouts.csv">timeouts.csv</a>,
+    <a href="data/history_timeouts.csv">history_timeouts.csv</a>.
+  </p>
+  <ul id="timeoutList"></ul>
+</section>
+
+<script>
+const SPEC_BASE = "https://github.com/ruby/spec/tree/master/library/";
+const specUrl = cat => SPEC_BASE + encodeURIComponent(cat);
+
+async function loadCsv(path) {
+  const res = await fetch(path + '?t=' + Date.now());
+  if (!res.ok) return [];
+  const text = (await res.text()).trim();
+  if (!text) return [];
+  const [header, ...rows] = text.split('\n');
+  const cols = header.split(',');
+  return rows.map(r => {
+    const vals = r.split(',');
+    const obj = {};
+    cols.forEach((c, i) => obj[c] = vals[i]);
+    return obj;
+  });
+}
+
+(async () => {
+  const total = await loadCsv('data/history_total.csv');
+  const hist = await loadCsv('data/history.csv');
+  const timeouts = await loadCsv('data/timeouts.csv');
+
+  // ------- Timed-out spec files (latest run) -------
+  {
+    const ul = document.getElementById('timeoutList');
+    if (!timeouts.length) {
+      const li = document.createElement('li');
+      li.textContent = 'none recorded';
+      li.style.color = '#666';
+      ul.appendChild(li);
+    } else {
+      for (const t of timeouts) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = 'https://github.com/ruby/spec/blob/master/' + t.file;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = t.file;
+        li.appendChild(a);
+        ul.appendChild(li);
+      }
+    }
+  }
+
+  // ------- shared date range over the run timestamps -------
+  const allStamps = [...new Set(total.map(r => r.timestamp))].sort();
+  let fromIdx = 0;
+  let toIdx = Math.max(0, allStamps.length - 1);
+  const inRange = ts => {
+    if (!allStamps.length) return true;
+    return ts >= allStamps[fromIdx] && ts <= allStamps[toIdx];
+  };
+
+  // Tooltip title that appends the commit hash for a row set.
+  const titleWithCommit = rowsRef => items => {
+    const r = rowsRef[items[0].dataIndex];
+    return r ? (r.timestamp + (r.commit ? '  @  ' + r.commit : '')) : '';
+  };
+
+  // ------- Total pass rate over time -------
+  let totalChart, totalRows = [];
+  function drawTotal() {
+    totalRows = total.filter(r => inRange(r.timestamp));
+    const cfg = {
+      type: 'line',
+      data: {
+        labels: totalRows.map(r => r.timestamp),
+        datasets: [{
+          label: 'Total pass rate (%)',
+          data: totalRows.map(r => parseFloat(r.pass_rate)),
+          borderColor: '#2e7d32',
+          backgroundColor: 'rgba(46,125,50,0.15)',
+          tension: 0.15,
+          fill: true,
+          pointRadius: 2
+        }]
+      },
+      options: {
+        scales: { y: { suggestedMin: 0, suggestedMax: 100 } },
+        plugins: { tooltip: { callbacks: { title: titleWithCommit(totalRows) } } }
+      }
+    };
+    if (totalChart) totalChart.destroy();
+    totalChart = new Chart(document.getElementById('totalChart'), cfg);
+  }
+
+  // ------- Per-category pass rate over time -------
+  const categories = [...new Set(hist.map(r => r.category))].sort();
+  const sel = document.getElementById('catSelect');
+  for (const c of categories) {
+    const opt = document.createElement('option');
+    opt.value = c; opt.textContent = c;
+    sel.appendChild(opt);
+  }
+
+  let catChart, catRows = [];
+  function drawCat(cat) {
+    catRows = hist.filter(r => r.category === cat && inRange(r.timestamp));
+    const cfg = {
+      type: 'line',
+      data: {
+        labels: catRows.map(r => r.timestamp),
+        datasets: [{
+          label: cat + ' pass rate (%)',
+          data: catRows.map(r => Math.max(0, parseFloat(r.pass_rate))),
+          borderColor: '#1565c0',
+          backgroundColor: 'rgba(21,101,192,0.15)',
+          tension: 0.15,
+          fill: true,
+          pointRadius: 2
+        }]
+      },
+      options: {
+        scales: { y: { suggestedMin: 0, suggestedMax: 100 } },
+        plugins: { tooltip: { callbacks: { title: titleWithCommit(catRows) } } }
+      }
+    };
+    if (catChart) catChart.destroy();
+    catChart = new Chart(document.getElementById('catChart'), cfg);
+  }
+
+  if (categories.length) {
+    sel.value = categories[0];
+    sel.addEventListener('change', e => drawCat(e.target.value));
+  }
+
+  // ------- date range slider (one slider, two thumbs) -------
+  if (allStamps.length > 1) {
+    const ctrl = document.getElementById('rangeControl');
+    const fromEl = document.getElementById('rangeFrom');
+    const toEl = document.getElementById('rangeTo');
+    const fromLbl = document.getElementById('rangeFromLabel');
+    const toLbl = document.getElementById('rangeToLabel');
+    const fillEl = document.getElementById('rangeFill');
+    ctrl.hidden = false;
+    const lastIdx = allStamps.length - 1;
+    fromEl.max = String(lastIdx);
+    toEl.max = String(lastIdx);
+    toEl.value = String(lastIdx);
+
+    const syncUi = () => {
+      fromLbl.textContent = allStamps[fromIdx];
+      toLbl.textContent = allStamps[toIdx];
+      // position the visible fill between the two thumbs
+      const lo = (fromIdx / lastIdx) * 100;
+      const hi = (toIdx / lastIdx) * 100;
+      fillEl.style.left = lo + '%';
+      fillEl.style.width = (hi - lo) + '%';
+      // keep both thumbs grabbable when they meet: raise the one that
+      // can still move inward.
+      fromEl.style.zIndex = fromIdx >= lastIdx ? 5 : 3;
+      toEl.style.zIndex = 4;
+    };
+    const onInput = (e) => {
+      let lo = parseInt(fromEl.value, 10);
+      let hi = parseInt(toEl.value, 10);
+      if (lo > hi) {                       // don't let thumbs cross
+        if (e.target === fromEl) { hi = lo; toEl.value = String(hi); }
+        else { lo = hi; fromEl.value = String(lo); }
+      }
+      fromIdx = lo;
+      toIdx = hi;
+      syncUi();
+      drawTotal();
+      drawCat(sel.value);
+    };
+    fromEl.addEventListener('input', onInput);
+    toEl.addEventListener('input', onInput);
+    syncUi();
+  }
+
+  if (total.length) drawTotal();
+  if (categories.length) drawCat(sel.value);
+
+  // ------- Latest snapshot -------
+  if (hist.length) {
+    const latestTs = hist[hist.length - 1].timestamp;
+    const latestSha = hist[hist.length - 1].commit;
+    const latest = hist.filter(r => r.timestamp === latestTs)
+                       .sort((a, b) => parseFloat(b.pass_rate) - parseFloat(a.pass_rate));
+    document.getElementById('latestMeta').textContent =
+      'snapshot: ' + latestTs + ' @ ' + latestSha;
+
+    const barColor = v => {
+      if (v >= 100) return '#2e7d32';
+      if (v >= 90)  return '#9ccc65';
+      if (v >= 70)  return '#fdd835';
+      return '#c62828';
+    };
+    document.getElementById('latestBarWrap').style.height =
+      Math.max(320, latest.length * 24) + 'px';
+
+    const latestBar = new Chart(document.getElementById('latestBar'), {
+      type: 'bar',
+      data: {
+        labels: latest.map(r => r.category),
+        datasets: [{
+          label: 'Pass rate (%)',
+          data: latest.map(r => parseFloat(r.pass_rate)),
+          backgroundColor: latest.map(r => barColor(parseFloat(r.pass_rate)))
+        }]
+      },
+      options: {
+        indexAxis: 'y',
+        maintainAspectRatio: false,
+        scales: {
+          x: { suggestedMin: 0, suggestedMax: 100 },
+          y: { ticks: { autoSkip: false, font: { size: 13 }, color: '#1565c0' } }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { afterLabel: () => 'click to open ruby/spec source' } }
+        },
+        onClick: (evt) => {
+          const idx = latestBar.scales.y.getValueForPixel(evt.y);
+          if (idx != null && idx >= 0 && idx < latest.length) {
+            window.open(specUrl(latest[idx].category), '_blank', 'noopener');
+          }
+        },
+        onHover: (evt) => {
+          evt.native.target.style.cursor = 'pointer';
+        }
+      }
+    });
+
+    const tbody = document.querySelector('#latestTable tbody');
+    for (const r of latest) {
+      const tr = document.createElement('tr');
+      for (const k of ['category','files','examples','pass','failures','errors','pass_rate']) {
+        const td = document.createElement('td');
+        if (k === 'category') {
+          const a = document.createElement('a');
+          a.href = specUrl(r.category);
+          a.target = '_blank';
+          a.rel = 'noopener';
+          a.textContent = r.category;
+          td.appendChild(a);
+        } else {
+          td.textContent = k === 'pass_rate' ? r[k] + '%' : r[k];
+        }
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+  }
+})();
+</script>
+</body>
+</html>

--- a/.github/workflows/spec-library.yml
+++ b/.github/workflows/spec-library.yml
@@ -1,0 +1,375 @@
+name: ruby/spec library monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
+  push:
+    branches: [master, preempt]
+    paths:
+      - 'monoruby/**'
+      - 'ruruby-parse/**'
+      - 'monoruby_attr/**'
+      - 'rubymap/**'
+      - 'Cargo.toml'
+      - '.github/workflows/spec-library.yml'
+      - '.github/spec-library-pages/**'
+      - '.github/portal/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  library-specs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.2"
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install monoruby (release)
+        run: RUSTFLAGS=-Cforce-frame-pointers cargo install --path monoruby --locked
+
+      - name: Clone ruby/spec and mspec
+        run: |
+          git clone --depth 1 https://github.com/ruby/spec.git ../spec
+          git clone --depth 1 https://github.com/ruby/mspec.git ../mspec
+
+      - name: Install spec tags
+        # mspec derives each spec's tag file as <spec-root>/tags/<path>,
+        # so the repo's tags (hanging / over-budget examples, see
+        # doc/ruby_spec_skip_tags.md) are copied into the checkout and
+        # excluded from the runs below via --excl-tag fails. Without
+        # this, every already-known hanging example re-times-out on
+        # every monitor run.
+        run: |
+          mkdir -p ../spec/tags
+          [ -d spec/tags ] && cp -R spec/tags/. ../spec/tags/ || true
+
+      - name: Run library specs per subcategory
+        id: run
+        working-directory: ../spec
+        shell: bash
+        run: |
+          # GitHub Actions' default `shell: bash` is `bash --noprofile --norc
+          # -eo pipefail`. We rely on grep-no-match returning non-zero (a
+          # category with zero summary lines is normal -- e.g. when every
+          # batch hits the 60s timeout), and on `[ test ] && cmd` patterns
+          # below; both would terminate the step under -e. Disable it.
+          set +e
+          set -uo pipefail
+          OUT="$GITHUB_WORKSPACE/spec-results"
+          mkdir -p "$OUT/logs"
+          REPORT="$OUT/report.md"
+          CSV="$OUT/report.csv"
+
+          {
+            echo "## ruby/spec library summary"
+            echo ""
+            echo "monoruby commit: \`$GITHUB_SHA\`"
+            echo ""
+            echo "| Category | Files | Examples | Pass | Failures | Errors | Pass rate |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+          } > "$REPORT"
+          echo "category,files,examples,pass,failures,errors,pass_rate" > "$CSV"
+
+          parse_log () {
+            local log="$1"
+            grep -aE '[0-9]+ examples?, ' "$log" || true
+          }
+          sum_field () {
+            parse_log "$1" \
+              | grep -oE "[0-9]+ $2" \
+              | grep -oE '[0-9]+' \
+              | awk '{s+=$1} END {print s+0}'
+          }
+
+          TIMEOUTS="$OUT/timeouts.csv"
+          echo "category,file" > "$TIMEOUTS"
+
+          # Run a batch of spec files under a hard deadline. `-k 5` matters:
+          # monoruby installs its own SIGTERM handler (deferred to a VM poll
+          # point), so a process stuck in a blocking read never dies to the
+          # plain TERM that `timeout` sends -- without the KILL escalation a
+          # single hung spec stalls the whole job until timeout-minutes.
+          # Exit 124 = killed by TERM, 137 = needed the KILL.
+          run_specs () {
+            timeout -k 5 60 ../mspec/bin/mspec "$@" --excl-tag fails -t monoruby -f s >> "$LOG" 2>&1
+            local rc=$?
+            [ $rc -eq 124 ] || [ $rc -eq 137 ]
+          }
+
+          # A killed batch prints no summary line, so none of its 10 files
+          # get tallied. Rerun them one by one: completing files are counted
+          # after all, and the hanging file(s) are pinned down and recorded.
+          run_batch () {
+            [ ${#BATCH[@]} -eq 0 ] && return
+            if run_specs "${BATCH[@]}"; then
+              echo "### batch timed out; rerunning ${#BATCH[@]} files individually" >> "$LOG"
+              local f
+              for f in "${BATCH[@]}"; do
+                if run_specs "$f"; then
+                  echo "$cat,$f" >> "$TIMEOUTS"
+                  echo "### TIMEOUT: $f" >> "$LOG"
+                fi
+              done
+            fi
+            BATCH=()
+          }
+
+          T_FILES=0; T_EX=0; T_FAIL=0; T_ERR=0
+
+          for cat in $(ls library/ | sort); do
+            SPECS=$(find "library/$cat" -name '*_spec.rb' 2>/dev/null | sort)
+            [ -z "$SPECS" ] && continue
+            FILE_COUNT=$(echo "$SPECS" | wc -l)
+            LOG="$OUT/logs/library_${cat}.log"
+            : > "$LOG"
+
+            BATCH=()
+            while IFS= read -r f; do
+              BATCH+=("$f")
+              [ ${#BATCH[@]} -ge 10 ] && run_batch
+            done <<< "$SPECS"
+            run_batch
+
+            EX=$(sum_field "$LOG" 'examples?')
+            FAIL=$(sum_field "$LOG" 'failures?')
+            ERR=$(sum_field "$LOG" 'errors?')
+            PASS=$((EX - FAIL - ERR))
+            [ "$PASS" -lt 0 ] && PASS=0
+            if [ "$EX" -gt 0 ] && [ "$PASS" -gt 0 ]; then
+              RATE=$(awk "BEGIN{printf \"%.1f\",($PASS/$EX)*100}")
+            else
+              RATE="0.0"
+            fi
+
+            echo "| $cat | $FILE_COUNT | $EX | $PASS | $FAIL | $ERR | ${RATE}% |" >> "$REPORT"
+            echo "$cat,$FILE_COUNT,$EX,$PASS,$FAIL,$ERR,$RATE" >> "$CSV"
+
+            T_FILES=$((T_FILES + FILE_COUNT))
+            T_EX=$((T_EX + EX))
+            T_FAIL=$((T_FAIL + FAIL))
+            T_ERR=$((T_ERR + ERR))
+          done
+
+          T_PASS=$((T_EX - T_FAIL - T_ERR))
+          [ "$T_PASS" -lt 0 ] && T_PASS=0
+          if [ "$T_EX" -gt 0 ] && [ "$T_PASS" -gt 0 ]; then
+            T_RATE=$(awk "BEGIN{printf \"%.2f\",($T_PASS/$T_EX)*100}")
+          else
+            T_RATE="0.00"
+          fi
+          echo "| **TOTAL** | **$T_FILES** | **$T_EX** | **$T_PASS** | **$T_FAIL** | **$T_ERR** | **${T_RATE}%** |" >> "$REPORT"
+
+          N_TIMEOUT=$(($(wc -l < "$TIMEOUTS") - 1))
+          if [ "$N_TIMEOUT" -gt 0 ]; then
+            {
+              echo ""
+              echo "### Timed-out spec files ($N_TIMEOUT)"
+              echo ""
+              echo "Killed after 60s; their examples are not included in the tallies above."
+              echo ""
+              tail -n +2 "$TIMEOUTS" | awk -F, '{print "- `" $2 "`"}'
+            } >> "$REPORT"
+          fi
+
+          cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "total_examples=$T_EX"
+            echo "total_pass=$T_PASS"
+            echo "total_fail=$T_FAIL"
+            echo "total_err=$T_ERR"
+            echo "total_rate=$T_RATE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Identify timed-out examples and update tags
+        id: bisect
+        shell: bash
+        run: |
+          set -uo pipefail
+          TIMEOUTS="$GITHUB_WORKSPACE/spec-results/timeouts.csv"
+          OUTCSV="$GITHUB_WORKSPACE/spec-results/timeout_culprits.csv"
+          N=$(($(wc -l < "$TIMEOUTS") - 1))
+          if [ "$N" -le 0 ]; then
+            echo "no timed-out files — nothing to bisect"
+            echo "n_tagged=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          .github/scripts/bisect-spec-timeouts.sh \
+            "$TIMEOUTS" \
+            "$(cd "$GITHUB_WORKSPACE/../spec" && pwd)" \
+            "$(cd "$GITHUB_WORKSPACE/../mspec" && pwd)/bin/mspec" \
+            monoruby \
+            "$GITHUB_WORKSPACE/spec/tags" \
+            "$OUTCSV"
+          {
+            echo ""
+            echo "### Timeout bisection"
+            echo ""
+            cat "${OUTCSV%.csv}.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open a PR for the new tags
+        if: steps.bisect.outputs.n_tagged != '' && steps.bisect.outputs.n_tagged != '0' && (github.event_name == 'schedule' || github.ref == 'refs/heads/master')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          BRANCH=auto/library-spec-timeout-tags
+          # A fixed branch keeps this idempotent: reruns before the PR
+          # merges regenerate the same tag set and force-push it, updating
+          # the existing PR instead of stacking new ones.
+          git checkout -B "$BRANCH"
+          git add spec/tags
+          git commit -m "spec: auto-tag hanging / over-budget examples
+
+          Added by the library monitor's timeout bisection
+          (.github/scripts/bisect-spec-timeouts.sh) for run
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+          for i in 1 2 3 4; do
+            git push -f -u origin "$BRANCH" && break
+            sleep $((2 ** i))
+          done
+
+          BODY_FILE="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "The library monitor detected spec files exceeding the 60s per-file budget and bisected them example-by-example ([run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}))."
+            echo ""
+            cat "$GITHUB_WORKSPACE/spec-results/timeout_culprits.md"
+            echo ""
+            echo "- \`hang\`: the example alone hit the ${EX_BUDGET:-60}s deadline (exit 124/137)."
+            echo "- \`slow\`: the example alone took ≥ ${SLOW_SECS:-30}s — it cannot share a 60s file budget."
+            echo "- \`cumulative-only\` rows (if any) were **not** tagged: no single culprit; the file needs a budget review instead."
+            echo ""
+            echo "Please review whether each culprit reflects a known limitation (see doc/ruby_spec_skip_tags.md) or a regression to fix instead of tagging."
+          } > "$BODY_FILE"
+          gh pr create --base master --head "$BRANCH" \
+            --title "spec: auto-tag hanging / over-budget examples (monitor bisection)" \
+            --body-file "$BODY_FILE" \
+            || gh pr edit "$BRANCH" --body-file "$BODY_FILE"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spec-library-results
+          path: spec-results/
+          retention-days: 30
+
+      - name: Publish history to gh-pages
+        if: github.event_name == 'schedule' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/preempt'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOTAL_EX: ${{ steps.run.outputs.total_examples }}
+          TOTAL_PASS: ${{ steps.run.outputs.total_pass }}
+          TOTAL_FAIL: ${{ steps.run.outputs.total_fail }}
+          TOTAL_ERR: ${{ steps.run.outputs.total_err }}
+          TOTAL_RATE: ${{ steps.run.outputs.total_rate }}
+        run: |
+          set -euo pipefail
+
+          GH_PAGES_DIR="$RUNNER_TEMP/gh-pages"
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages > /dev/null 2>&1; then
+            git clone --depth 1 --branch gh-pages "$REPO_URL" "$GH_PAGES_DIR"
+          else
+            mkdir -p "$GH_PAGES_DIR"
+            git -C "$GH_PAGES_DIR" init -b gh-pages
+            git -C "$GH_PAGES_DIR" remote add origin "$REPO_URL"
+          fi
+
+          cd "$GH_PAGES_DIR"
+
+          # master (and the weekly schedule, which runs on master) keeps the
+          # canonical library/ page; any other branch (e.g. preempt) gets its
+          # own page + history under library/<branch>/, so branch results never
+          # mix into master's trend data.
+          BRANCH="${GITHUB_REF_NAME}"
+          if [ "$BRANCH" = "master" ]; then
+            DEST=library
+          else
+            DEST="library/$BRANCH"
+          fi
+
+          mkdir -p "$DEST/data"
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+
+          if [ ! -f "$DEST/data/history.csv" ]; then
+            echo "timestamp,commit,category,files,examples,pass,failures,errors,pass_rate" > "$DEST/data/history.csv"
+          fi
+          if [ ! -f "$DEST/data/history_total.csv" ]; then
+            echo "timestamp,commit,examples,pass,failures,errors,pass_rate" > "$DEST/data/history_total.csv"
+          fi
+
+          tail -n +2 "$GITHUB_WORKSPACE/spec-results/report.csv" \
+            | awk -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" -F, 'BEGIN{OFS=","} {print ts,sha,$0}' \
+            >> "$DEST/data/history.csv"
+
+          echo "$TIMESTAMP,$SHORT_SHA,$TOTAL_EX,$TOTAL_PASS,$TOTAL_FAIL,$TOTAL_ERR,$TOTAL_RATE" \
+            >> "$DEST/data/history_total.csv"
+
+          # Latest run's timed-out spec files (shown on the site), plus a
+          # timestamped history of them.
+          if [ -f "$GITHUB_WORKSPACE/spec-results/timeouts.csv" ]; then
+            cp "$GITHUB_WORKSPACE/spec-results/timeouts.csv" "$DEST/data/timeouts.csv"
+          else
+            echo "category,file" > "$DEST/data/timeouts.csv"
+          fi
+          if [ ! -f "$DEST/data/history_timeouts.csv" ]; then
+            echo "timestamp,commit,category,file" > "$DEST/data/history_timeouts.csv"
+          fi
+          tail -n +2 "$DEST/data/timeouts.csv" \
+            | awk -v ts="$TIMESTAMP" -v sha="$SHORT_SHA" -F, 'BEGIN{OFS=","} {print ts,sha,$0}' \
+            >> "$DEST/data/history_timeouts.csv"
+
+          # The page fetches its CSVs by relative path (data/…), so the same
+          # index.html works from any directory depth. Branch pages get the
+          # branch name injected into the heading so they are not mistaken
+          # for master's dashboard.
+          cp "$GITHUB_WORKSPACE/.github/spec-library-pages/index.html" "$DEST/index.html"
+          if [ "$BRANCH" != "master" ]; then
+            sed -i "s|</h1>|</h1><p><strong>branch: ${BRANCH}</strong> — <a href=\"../\">master dashboard</a></p>|" "$DEST/index.html"
+          fi
+                    cat > "$DEST/latest.json" <<JSON
+          {"schemaVersion":1,"label":"ruby/spec library","message":"${TOTAL_RATE}%","color":"blue","timestamp":"${TIMESTAMP}","commit":"${SHORT_SHA}","branch":"${BRANCH}","examples":${TOTAL_EX},"pass":${TOTAL_PASS},"failures":${TOTAL_FAIL},"errors":${TOTAL_ERR}}
+          JSON
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "no changes to publish"
+          else
+            git commit -m "library-spec: ${TIMESTAMP} (${SHORT_SHA}, ${BRANCH}) ${TOTAL_RATE}%"
+            # With two publishing branches (master + preempt) concurrent
+            # runs can race on gh-pages; a plain re-push would fail every
+            # retry on non-fast-forward, so rebase onto the remote first.
+            for i in 1 2 3 4; do
+              if git push -u origin gh-pages; then
+                break
+              fi
+              sleep $((2 ** i))
+              git pull --rebase origin gh-pages || true
+            done
+          fi


### PR DESCRIPTION
## Summary

Add a `ruby/spec library` conformance dashboard alongside the existing `core` one. Everything is a parallel to `spec-core`; the code paths that already handled `core/*` were designed to be category-neutral, so the mirror is mostly copy + rename.

### Files added

- **`.github/workflows/spec-library.yml`** — parallel to `spec-core.yml`:
  - Iterates `library/<sub>` instead of `core/<sub>`.
  - Same per-file 60s budget, batch-of-10 with fallback single-file retry, bisection into auto-tags.
  - Publishes to `gh-pages/library/{data,index.html,latest.json}` on `master`, and `gh-pages/library/<branch>/` on non-master publishing branches.
  - Auto-tag PR branch is **`auto/library-spec-timeout-tags`** — separate from `auto/spec-timeout-tags` so the two monitors never race for the same head branch.
  - Artifact name is `spec-library-results`.
  - Path filter includes `.github/workflows/spec-library.yml`, `.github/spec-library-pages/**`, and `.github/portal/**`.
- **`.github/spec-library-pages/index.html`** — parallel to `spec-pages/index.html`:
  - Title and heading swapped to "library".
  - `SPEC_BASE` and the "click a benchmark name" link point at `https://github.com/ruby/spec/tree/master/library` — every category label / table row on the snapshot links to the matching library subdirectory in ruby/spec.
- **`.github/portal/index.html`** — new CTA `ruby/spec library dashboard →` immediately after the existing core dashboard button.

### Reused as-is

- **`.github/scripts/bisect-spec-timeouts.sh`** — the bisect script derives the tag file path from `dirname/basename` of each spec file (e.g. `library/csv/parse_spec.rb` → `spec/tags/library/csv/parse_tags.txt`), so it works unchanged for both groups.
- **`spec/tags/`** — the repo already tracks tags for both `core/` and `library/`; the "Install spec tags" step copies the whole tree into the checkout, so library tags are already picked up.

## Test plan

- [ ] After merge, `Run workflow` on `ruby/spec library monitor` and confirm it publishes to `gh-pages/library/`.
- [ ] Open **https://sisshiki1969.github.io/monoruby/library/** and confirm:
  - Total + Per-category over-time charts render (they'll be single-point after the first run).
  - Snapshot bar chart shows every `library/*` subcategory sorted by pass rate.
  - Clicking a category label / row opens the matching `ruby/spec/library/<name>` page.
- [ ] Portal at `https://sisshiki1969.github.io/monoruby/` now shows the new "ruby/spec library dashboard →" button (the portal republishes when the core workflow runs, since both filter on `.github/portal/**`).
- [ ] If timeouts occur, an `auto/library-spec-timeout-tags` PR is opened, independent from the core monitor's `auto/spec-timeout-tags` PR.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_