### PR TITLE
perf(aarch64): JIT opt-parity — trivial wrapper, Fiber.yield offset, Int<<lit fold (+x86 shift bugfix)

### DIFF
--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -127,12 +127,6 @@ fn fiber_yield_inline(
     let CallSiteInfo {
         args, pos_num, dst, ..
     } = *callsite;
-    // aarch64 reaches the args via `sub x0, lfp, #conv(args)` (bounded
-    // immediate); bail to the slow path on an out-of-range frame.
-    #[cfg(target_arch = "aarch64")]
-    if pos_num > 1 && jitgen::conv(args) as u32 > 4095 {
-        return false;
-    }
     // `Fiber.yield` suspends this fiber: control returns to the resumer
     // and arbitrary code (including GCs) runs while this frame stays live
     // on the fiber's stack. Unlike a normal call, the inlined yield does
@@ -180,6 +174,35 @@ fn resume(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn fiber_yield_multi_arg() {
+        // `Fiber.yield(a, b, ...)` with >=2 args exercises the inlined
+        // `emit_fiber_yield_value_array` (builds the yielded array from the
+        // arg slots). Warm the fiber body so the yield JIT-compiles; the >=2
+        // arg array-build path (aarch64 addresses the arg slots through a
+        // scratch register for any frame offset) must match CRuby.
+        run_test(
+            r#"
+            def run
+              out = []
+              50.times do |k|
+                f = Fiber.new do
+                  a = Fiber.yield(k, k + 1)
+                  b = Fiber.yield(k + 2, k + 3, k + 4)
+                  [a, b]
+                end
+                out << f.resume
+                out << f.resume(100)
+                out << f.resume(200)
+              end
+              out
+            end
+            run
+            "#,
+        );
+    }
+
     #[test]
     fn fiber_error() {
         run_test_error("Fiber.yield");

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -1020,18 +1020,15 @@ fn integer_shl(
         // Variable shift amount.
         state.load_fixnum(ir, args, GP::Rcx);
         let deopt = ir.new_deopt(state);
-        // x86 has a literal-lhs fast path (`gen_shl_lhs_imm`) that folds the
-        // overflow guard to a constant `lzcnt`; aarch64's shift-back overflow
-        // check gains nothing from a constant lhs (recv is already in Rdi), so
-        // it uses `gen_shl` for both cases.
-        #[cfg(target_arch = "x86_64")]
+        // Literal-lhs fast path (`gen_shl_lhs_imm`, both backends): the
+        // left-shift overflow bound is the literal's `leading_zeros()`, a
+        // compile-time constant, so the runtime shift-back overflow check
+        // folds to a single constant compare.
         if let Some(lhs) = state.is_fixnum_literal(recv) {
             ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl_lhs_imm(lhs.get(), &labels[deopt]));
         } else {
             ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
         }
-        #[cfg(target_arch = "aarch64")]
-        ir.inline(move |r#gen, _, labels, _| r#gen.gen_shl(&labels[deopt]));
     }
     state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
     true

--- a/monoruby/src/codegen/arch/aarch64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/binary_op.rs
@@ -227,6 +227,53 @@ impl Codegen {
         self.jit.bind_label(cont);
     }
 
+    /// `<literal_int> << <variable>` fast path. Mirrors x86 `gen_shl_lhs_imm`:
+    /// the left-shift overflow bound is the literal's `leading_zeros()`, a
+    /// compile-time constant, so the runtime shift-back overflow test (`sub` /
+    /// `lsl` / `asr` / `cmp`) of the generic `gen_shl` collapses to a single
+    /// `cmp x1, #lzcnt; b.gt deopt` (which also subsumes the `cmp #64` bound).
+    /// The tagged lhs is already in x4 (recv); the shift amount is in x1.
+    pub(crate) fn gen_shl_lhs_imm(&mut self, lhs: i64, deopt: &DestLabel) {
+        let shr = self.jit.label();
+        let after = self.jit.label();
+        let under = self.jit.label();
+        let cont = self.jit.label();
+        let deopt = deopt.clone();
+        let lhs = Value::check_fixnum(lhs).unwrap();
+        let lzcnt = lhs.id().leading_zeros();
+        monoasm_arm64!(&mut self.jit,
+            asr x1, x1, #1;            // untag shift amount
+            cmp x1, #0;
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &shr); // negative -> right shift
+        // Overflow bound: the tagged lhs's top bit sits at position
+        // `63 - lzcnt`, so shifting `2n` left sets the sign bit once
+        // `k >= lzcnt` — deopt there (the x86 `gen_shl_lhs_imm` uses `jgt`
+        // here, which is an off-by-one that lets `lit << lzcnt` overflow
+        // silently; `b.ge` is the correct bound).
+        monoasm_arm64!(&mut self.jit, cmp x1, #(lzcnt);); // baked overflow bound
+        self.jit.bcond_label(monoasm::Cond::Ge, &deopt); // shift >= lzcnt -> overflow
+        monoasm_arm64!(&mut self.jit,
+            sub x4, x4, #1;           // strip tag -> 2n
+            lsl x4, x4, x1;           // 2n << k (statically bounded, no shift-back check)
+        );
+        self.jit.bind_label(after.clone());
+        monoasm_arm64!(&mut self.jit,
+            mov x9, #1;
+            orr x4, x4, x9;           // re-tag fixnum
+            b cont;
+        );
+        // right shift by -k (cold)
+        self.jit.bind_label(shr);
+        monoasm_arm64!(&mut self.jit, neg x1, x1; cmp x1, #64;);
+        self.jit.bcond_label(monoasm::Cond::Ge, &under);
+        monoasm_arm64!(&mut self.jit, asr x4, x4, x1; b after;);
+        // right shift by >= 64 (cold): 0 if lhs >= 0, else -1
+        self.jit.bind_label(under);
+        self.a64_shift_under(&after);
+        self.jit.bind_label(cont);
+    }
+
     /// Shared cold tail for a shift-right by >= 64 bits: the tagged lhs is in
     /// Rdi (x4); leave 0 (Value 0) for a non-negative lhs or -1 (Value -1) for a
     /// negative one, then branch to `after` (which re-tags). Mirrors x86

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -11,10 +11,13 @@ impl Codegen {
     }
 
     /// `Fiber.yield(*args)` with ≥2 args: build the args array, leaving it in
-    /// Rsi (x3). `args_off` is `conv(args)`; bounded by the caller.
+    /// Rsi (x3). `args_off` is `conv(args)`; any frame offset is addressable
+    /// (large offsets materialize through a scratch register via `a64_addr_sub`,
+    /// so the caller never has to bail).
     pub(crate) fn emit_fiber_yield_value_array(&mut self, args_off: usize, pos_num: usize) {
+        let lfp = GP::R14.a64().0; // x22
+        self.a64_addr_sub(0, lfp, args_off as u32); // x0 = &args (lfp - conv)
         monoasm_arm64!(&mut self.jit,
-            sub x0, x22, #(args_off as u32);   // &args (lfp - conv)
             mov x1, (pos_num);
             mov x9, (crate::runtime::create_array as *const () as u64);
             str x30, [sp, #-16]!;

--- a/monoruby/src/codegen/arch/aarch64/wrapper.rs
+++ b/monoruby/src/codegen/arch/aarch64/wrapper.rs
@@ -18,7 +18,26 @@ impl Codegen {
             entry:
         );
         match &globals.store[fid].kind {
-            FuncKind::ISeq(_) => {
+            FuncKind::ISeq(iseq) => match globals.store[*iseq].hint {
+                // Trivial methods: return the constant / self immediately with
+                // no frame creation or bytecode execution (mirrors x86
+                // `gen_wrapper`). Reached from the VM tier, invokers
+                // (send / Method#call / block yields), and non-foldable
+                // polymorphic JIT sites; foldable JIT'd call sites already
+                // const-fold the hint in the front-end.
+                ISeqHint::ConstReturn(imm) => {
+                    monoasm_arm64!(&mut self.jit,
+                        mov x0, (imm.id());
+                        ret;
+                    );
+                }
+                ISeqHint::SelfReturn => {
+                    monoasm_arm64!(&mut self.jit,
+                        ldur x0, [x(LFP.0), #(-(LFP_SELF as i32))];
+                        ret;
+                    );
+                }
+                ISeqHint::Normal => {
                 let vm_entry = self.vm_entry();
                 // JIT trigger (Phase 3a/3b). Per-method JIT-entry slot + call
                 // counter (both heap-leaked so their absolute addresses are
@@ -84,6 +103,7 @@ impl Codegen {
                     run_jit:
                         br x10;                  // tail-call the JIT code
                     );
+                }
                 }
             }
             FuncKind::Builtin { abs_address } => {

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -757,7 +757,11 @@ impl Codegen {
             sarq rcx, 1;
             js shr;
             cmpq rcx, (lzcnt);
-            jgt deopt;
+            // The tagged lhs's top bit sits at `63 - lzcnt`, so shifting `2n`
+            // left sets the sign bit once `k >= lzcnt` — deopt there. (Was
+            // `jgt`, an off-by-one that let `lit << lzcnt` overflow silently;
+            // e.g. `5 << 60` yielded a wrapped negative instead of a Bignum.)
+            jge deopt;
             subq rdi, 1;
             salq rdi, rcx;
         after:

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -142,6 +142,26 @@ fn test_shift() {
 }
 
 #[test]
+fn shift_literal_lhs_overflow_boundary() {
+    // `<literal> << <variable>` uses the JIT literal-lhs fast path
+    // (`gen_shl_lhs_imm`), which bakes the left-shift overflow bound from the
+    // literal's `leading_zeros`. Regression: an off-by-one (`> lzcnt` instead
+    // of `>= lzcnt`) let `lit << lzcnt` overflow silently to a wrapped negative
+    // instead of promoting to a Bignum (e.g. `5 << 60`). Exercise the exact
+    // boundary across several literals and signs, on both backends.
+    run_test(
+        r#"
+        res = []
+        [0, 1, 2, 30, 31, 58, 59, 60, 61, 62, 63, 64, 100, -1, -30, -64].each do |k|
+          res << (1 << k) << (5 << k) << (255 << k) << (1000000 << k)
+          res << (-1 << k) << (-7 << k) << (0 << k)
+        end
+        res
+        "#,
+    );
+}
+
+#[test]
 fn test_assign_op() {
     run_tests(&[
         "a=3; a+=7; a",

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3417,3 +3417,43 @@ fn return_in_thread_and_class_block() {
         "#,
     );
 }
+
+#[test]
+fn trivial_method_wrapper_dispatch() {
+    // Const-return (`true`/`false`/`nil`/small-int-literal body) and
+    // self-return (`def m; self; end`) methods reached through the per-method
+    // *wrapper* — `send` / `Method#call` / a polymorphic (non-foldable) call
+    // site — must return the right value. The wrapper's trivial fast paths
+    // (x86 `gen_wrapper` ConstReturn/SelfReturn; the aarch64 twin) build no
+    // frame and run no bytecode, so a wrong register/offset would surface here.
+    run_test(
+        r#"
+        class A
+          def flag; true; end
+          def zero; 0; end
+          def big; 1_000_000; end
+          def nn; nil; end
+          def me; self; end
+        end
+        class B
+          def flag; false; end
+          def me; self; end
+        end
+        a = A.new; b = B.new
+        res = []
+        res << a.send(:flag) << a.send(:zero) << a.send(:big) << a.send(:nn).inspect
+        res << a.send(:me).equal?(a) << b.send(:flag)
+        res << a.method(:flag).call << a.method(:me).call.equal?(a)
+        objs = [a, b, a, b, a]
+        t = 0; s = 0
+        200.times do
+          objs.each do |o|
+            t += 1 if o.flag
+            s += 1 if o.me.equal?(o)
+          end
+        end
+        res << t << s
+        res
+        "#,
+    );
+}


### PR DESCRIPTION
Closes three low-impact x86-vs-aarch64 JIT optimization asymmetries surfaced by the backend audit. All verified against CRuby; each ships a regression test that runs on **both** backends.

## Fixes

**Trivial-method wrapper** — aarch64 `gen_wrapper` now honours the ISeq hint like x86: `ConstReturn` returns the constant, `SelfReturn` returns `[lfp - self]`, both in two instructions with no frame and no bytecode. Previously aarch64 built a full VM frame and interpreted the (trivial) body for every such method reached through the wrapper (`send` / `Method#call` / non-foldable polymorphic sites).

**`Fiber.yield` with ≥2 args** — `emit_fiber_yield_value_array` now addresses the argument slots through `a64_addr_sub` (scratch-register materialization) for any frame offset, so the inlined yield no longer *bails to a full method call* when `conv(args) > 4095`. Drops the aarch64-only bail in `fiber.rs`.

**`<literal> << <variable>`** — aarch64 gains `gen_shl_lhs_imm`, folding the left-shift overflow guard to a single `cmp #lzcnt` (the literal's `leading_zeros`) instead of the generic runtime shift-back check; the dispatch in `builtins/numeric/integer.rs` is now arch-neutral (was `#[cfg]`-split).

## Bonus: latent x86 correctness bug fixed

Porting the shift fold surfaced an off-by-one in **both** backends' `gen_shl_lhs_imm`: the overflow boundary is `>= lzcnt`, not `> lzcnt` (the tagged lhs's top bit sits at `63 - lzcnt`, so `lit << lzcnt` sets the sign bit). `5 << 60` returned a wrapped negative instead of a Bignum. Fixed on x86 (`jgt`→`jge`) and implemented correctly on aarch64 (`b.ge`). Caught by `shift_literal_lhs_overflow_boundary` (which fails on unpatched x86 too).

## Verification

- Full `cargo nextest`: **2729 passed, 1 skipped** (2726 + the 3 new tests).
- New tests: `trivial_method_wrapper_dispatch`, `fiber_yield_multi_arg`, `shift_literal_lhs_overflow_boundary`.

Remaining backend-audit items (follow-ups, not in this PR): #4 eager `...`-forwarding inline copy, #8 BigNum `guard_class2`, and the higher-value #2/#3 — wiring the cold class-version / polymorphic-flip guard-miss side-exits to the aarch64 recompiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)