### PR TITLE
perf(aarch64): recompile on class-version / polymorphic-flip guard miss instead of deopting forever

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -423,6 +423,63 @@ impl Codegen {
     /// write-back reads it (d8-d15 are callee-saved); x19-x23 are AAPCS64
     /// callee-saved so the VM globals survive. `global_idx` is the resolved
     /// `specialized_base + idx` slot in `specialized_info`.
+    /// Emit an (uncounted) call to the non-specialized recompiler:
+    /// `jit_recompile_loop(vm, globals, lfp, pc, reason)` when `position` is a
+    /// loop-header pc, else `jit_recompile_method(vm, globals, lfp, reason)`.
+    /// Twin of `a64_call_recompile_specialized`. The caller-saved d2-d7 FP pool
+    /// and x5-x8 GP pool (R8-R11) are saved around the `blr` because the deopt
+    /// write-back that follows reads both (x19-x23 / d8-d15 / x19-x28 are
+    /// callee-saved). Leaves the `Option<Value>` result in x0 — x0 == 0 means
+    /// the recompile panicked and set a FatalError.
+    pub(super) fn a64_call_recompile(
+        &mut self,
+        position: Option<BytecodePtr>,
+        reason: RecompileReason,
+    ) {
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(80);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            stp x5, x6, [sp, #(48)];      // GP pool (R8-R11), read by the deopt write-back
+            stp x7, x8, [sp, #(64)];
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, x22;                  // lfp
+        );
+        let f = if let Some(pc) = position {
+            let pc_ptr = pc.as_ptr() as u64;
+            monoasm_arm64!(&mut self.jit,
+                mov x3, (pc_ptr);         // loop pc
+                mov x4, (reason as u64);
+            );
+            crate::codegen::compiler::jit_recompile_loop as *const () as u64
+        } else {
+            monoasm_arm64!(&mut self.jit,
+                mov x3, (reason as u64);
+            );
+            crate::codegen::compiler::jit_recompile_method as *const () as u64
+        };
+        monoasm_arm64!(&mut self.jit,
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                       // -> Option<Value>: None (x0 == 0) = panic
+            ldr x30, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            ldp x5, x6, [sp, #(48)];
+            ldp x7, x8, [sp, #(64)];
+            add sp, sp, #(80);
+        );
+    }
+
     pub(super) fn a64_call_recompile_specialized(&mut self, global_idx: usize, reason: RecompileReason) {
         let f = crate::codegen::compiler::jit_recompile_specialized as *const () as u64;
         monoasm_arm64!(&mut self.jit,

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1156,8 +1156,7 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, ldr x30, [sp], #16;);
                 self.a64_fpr_save(dst, 0, base); // result d0 -> dst
             }
-            // Cold side-exit (deopt) handler blocks. aarch64 has no recompiler,
-            // so Evict / RecompileDeopt collapse to a plain deopt.
+            // Cold side-exit handler blocks. Deopt / Evict re-enter the VM.
             LInst::SideExit {
                 kind,
                 pc,
@@ -1166,10 +1165,26 @@ impl Codegen {
                 loop_jit_spill_bytes,
                 base,
             } => match kind {
-                LSideExitKind::Deopt
-                | LSideExitKind::Evict
-                | LSideExitKind::RecompileDeopt { .. } => {
+                LSideExitKind::Deopt | LSideExitKind::Evict => {
                     self.a64_gen_deopt(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+                // A monomorphically-compiled site (e.g. a `BinCmp`) whose
+                // receiver-class guard missed because it went polymorphic.
+                // Route the miss through the same counter-gated recompiler the
+                // main-body `AsmInst::RecompileDeopt` / `GuardClassVersionSpecialized`
+                // use, so the site re-JITs to the guard-free (polymorphic) path
+                // instead of deopting to the VM on every off-class receiver
+                // forever. `emit_recompile_deopt` runs the recompile once (or
+                // falls straight through while the counter is unexhausted),
+                // branching to `deopt_body` to resume in the interpreter, or to
+                // `error_body` if the recompile itself raised a FatalError.
+                LSideExitKind::RecompileDeopt { reason, position } => {
+                    let deopt_body = self.jit.label();
+                    let error_body = self.jit.label();
+                    self.jit.bind_label(entry);
+                    self.emit_recompile_deopt(position, &deopt_body, Some(&error_body), reason);
+                    self.a64_gen_deopt(pc, &wb, deopt_body, loop_jit_spill_bytes, base);
+                    self.a64_gen_handle_error(pc, &wb, error_body, loop_jit_spill_bytes, base);
                 }
                 LSideExitKind::Error => {
                     self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base)
@@ -1832,11 +1847,33 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_guard_class_version(
         &mut self,
         _class_version: DestLabel,
-        _position: Option<BytecodePtr>,
+        position: Option<BytecodePtr>,
         _with_recovery: bool,
         deopt: DestLabel,
     ) {
-        self.a64_guard_class_version(&deopt);
+        // On a class-version miss, recompile (loop → `jit_recompile_loop`,
+        // method → `jit_recompile_method`) then resume via the deopt side exit,
+        // instead of deopting to the VM forever: `insert_method` bumps the
+        // global class version on any `def`, so without this a hot JIT'd method
+        // is stranded in the interpreter for the rest of the process after any
+        // unrelated method definition. Mirrors x86 `guard_class_version` and the
+        // aarch64 `GuardClassVersionSpecialized` twin; no counter — the
+        // recompile bakes in the new version, so the guard won't re-fire. The
+        // cheap x86 `with_recovery` path (an in-place inline-cache re-bake that
+        // resumes in JIT without recompiling) is not ported —
+        // `jit_recompile_method_with_recovery` is x86-only — so `_with_recovery`
+        // is ignored and this always full-recompiles. On a recompile panic the
+        // helper leaves a FatalError set and x0 == 0; we still branch to the
+        // deopt, which resumes at the guarded call where the interpreter
+        // propagates the fatal (matching the specialized twin).
+        let miss = self.jit.label();
+        let done = self.jit.label();
+        self.a64_guard_class_version(&miss); // version mismatch -> miss
+        monoasm_arm64!(&mut self.jit, b done;); // match -> continue in JIT
+        self.jit.bind_label(miss);
+        self.a64_call_recompile(position, RecompileReason::ClassVersionGuardFailed);
+        monoasm_arm64!(&mut self.jit, b deopt;); // recompiled -> resume via deopt
+        self.jit.bind_label(done);
     }
 
     /// Recompile-or-deopt point. Counter-gates a one-shot recompile, then falls

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3457,3 +3457,54 @@ fn trivial_method_wrapper_dispatch() {
         "#,
     );
 }
+
+#[test]
+fn recompile_on_polymorphic_comparison_flip() {
+    // A comparison compiled while monomorphic (one receiver class) that later
+    // sees another class: the receiver-class-guard miss must re-JIT the site to
+    // the guard-free polymorphic path (RecompileReason::BecamePolymorphic) and
+    // keep producing correct results — not deopt to the VM on every off-class
+    // receiver forever (the aarch64 bug where the RecompileDeopt side-exit
+    // collapsed to a plain deopt). Exercises the recompile write-back on both
+    // backends.
+    run_test(
+        r#"
+        class A; def ==(o); "A==#{o}"; end; end
+        class B; def ==(o); "B==#{o}"; end; end
+        def cmp(x); x == 5; end
+        a = A.new; b = B.new
+        res = []
+        i = 0
+        while i < 2000; cmp(a); i += 1; end   # warm monomorphic (A)
+        j = 0
+        while j < 30                           # polymorphic -> recompile to guard-free
+          res << cmp(a) << cmp(b)
+          j += 1
+        end
+        res.uniq.sort
+        "#,
+    );
+}
+
+#[test]
+fn recompile_hot_method_after_class_version_bump() {
+    // A hot JIT'd method whose body makes a cached method call carries a
+    // class-version guard. Any `def` bumps the global class version; the guard
+    // then misses and the method must RECOMPILE (RecompileReason::
+    // ClassVersionGuardFailed) rather than deopt to the interpreter for the
+    // rest of the process (the aarch64 permanent-strand bug). Verify results
+    // stay correct across the bump.
+    run_test(
+        r#"
+        class Lib; def twice(n); n + n; end; end
+        $lib = Lib.new
+        def work(n); $lib.twice(n) + 1; end
+        s = 0
+        i = 0
+        while i < 3000; s += work(i); i += 1; end   # warm -> method JIT
+        class Other; def noop; end; end              # bump class version
+        while i < 6000; s += work(i); i += 1; end    # keep calling across the bump
+        s
+        "#,
+    );
+}


### PR DESCRIPTION
Two cold guard-miss side-exits plain-deopted to the VM on aarch64 where x86 recompiles, stranding hot JIT'd code in the interpreter. Both are now routed through the aarch64 recompiler that **already existed** (used by `GuardClassVersionSpecialized` and the main-body `AsmInst::RecompileDeopt`) — this is the highest-ROI item from the backend optimization-asymmetry audit.

## Fixes

**Monomorphic-comparison polymorphic flip** — a `==`/`<=>`/`<`… site compiled while monomorphic (one receiver class) that later sees another class. Its receiver-class-guard miss target is a `RecompileDeoptimize` side-exit, which aarch64 was *bucketing with a plain `Deopt`* (dropping `reason`+`position`). It now re-JITs the site to the guard-free polymorphic path (`emit_recompile_deopt`, counter-gated) instead of deopting on every off-class receiver — which for method-JITs was permanent. The `LSideExitKind::RecompileDeopt` arm reuses the existing recompiler and adds a FatalError-on-recompile-panic raise path.

**Class-version-guard miss** — `emit_guard_class_version` was discarding `position`/`with_recovery` and plain-deopting. `insert_method` bumps the global class version on *any* `def`, so a hot method carrying an inline-cache class-version guard was stranded in the VM for the rest of the process after any unrelated method definition. It now recompiles (baking the new version, so no counter is needed — mirrors x86 `guard_class_version` and the aarch64 `GuardClassVersionSpecialized` twin) via a new `a64_call_recompile` helper (the `jit_recompile_method`/`jit_recompile_loop` twin of `a64_call_recompile_specialized`).

The x86 `with_recovery` cheap in-place inline-cache re-bake (resume-in-JIT without a full recompile) is **not** ported — `jit_recompile_method_with_recovery` is x86-only — so `_with_recovery` is ignored and aarch64 always full-recompiles. That still closes the permanent-strand failure mode.

## Verification

- deopt-feature JIT log now shows `recompile (ClassVersionGuardFailed)` after a class-version bump and `recompile (BecamePolymorphic)` after a poly-flip, where **before neither ever recompiled**.
- Correct vs CRuby under `--features gc-stress`, including the x5-x8-save `require "set"` / `require "bigdecimal"` corruption case the recompile-call save guards against.
- Full `cargo nextest`: **2731 passed, 1 skipped** (2729 + 2 new tests: `recompile_on_polymorphic_comparison_flip`, `recompile_hot_method_after_class_version_bump`).

Follow-up (out of scope): once a BOP-version recompile lands the same way, the aarch64-only compensating `CheckBOP` on constant-folded integer arithmetic can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)