### PR TITLE
perf(aarch64): route BigNum receivers straight to vm_entry in the class-guard stub

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/guard.rs
+++ b/monoruby/src/codegen/arch/aarch64/guard.rs
@@ -62,6 +62,37 @@ impl Codegen {
         true
     }
 
+    /// Method-entry variant of [`a64_guard_class`] for the class-guard stub:
+    /// identical except a heap `Integer` (BigNum) receiver is routed straight to
+    /// `vm_entry` — the JIT body is compiled for fixnum `Integer` and can't run
+    /// a BigNum — instead of falling into the guard-miss / profile-patch chain
+    /// (which would keep re-compiling a specialization that rejects it anyway).
+    /// Mirrors x86 `guard_class2`. Only `INTEGER_CLASS` differs from
+    /// `a64_guard_class`: a heap `Float` is still handled by the Float JIT body,
+    /// so `FLOAT_CLASS` and every other class delegate unchanged.
+    pub(in crate::codegen) fn a64_guard_class2(
+        &mut self,
+        reg: GP,
+        class_id: ClassId,
+        fail: &DestLabel,
+    ) {
+        if class_id == INTEGER_CLASS {
+            let r = reg.a64().0;
+            let vm_entry = self.vm_entry();
+            let exit = self.jit.label();
+            monoasm_arm64!(&mut self.jit,
+                tbnz x(r), #(0), exit;   // fixnum -> JIT body
+            );
+            self.a64_guard_rvalue(r, INTEGER_CLASS, fail); // heap non-Integer -> miss
+            monoasm_arm64!(&mut self.jit,
+                b vm_entry;              // heap Integer (BigNum) -> VM
+            );
+            self.jit.bind_label(exit);
+        } else {
+            self.a64_guard_class(reg, class_id, fail);
+        }
+    }
+
     /// Heap-object class guard: branch to `fail` unless `reg` is a heap pointer
     /// (low 3 bits zero) whose RValue class equals `class_id`. Mirrors x86
     /// `guard_rvalue`.

--- a/monoruby/src/codegen/arch/aarch64/wrapper.rs
+++ b/monoruby/src/codegen/arch/aarch64/wrapper.rs
@@ -201,10 +201,12 @@ impl Codegen {
         let next_counter = Box::into_raw(Box::new(COUNT_RECOMPILE_ARECV_CLASS)) as u64;
         monoasm_arm64!(&mut self.jit,
             guard:
-            ldur x0, [x(LFP.0), #(-(LFP_SELF as i32))];  // self (GP::Rax == x0; a64_guard_class uses x9/x10)
+            ldur x0, [x(LFP.0), #(-(LFP_SELF as i32))];  // self (GP::Rax == x0; the guard uses x9/x10)
         );
-        // self.class != self_class -> miss
-        self.a64_guard_class(GP::Rax, self_class, &miss);
+        // self.class != self_class -> miss; a heap Integer (BigNum) receiver is
+        // routed straight to vm_entry by `a64_guard_class2` rather than the miss
+        // chain (the JIT body only handles fixnum Integer).
+        self.a64_guard_class2(GP::Rax, self_class, &miss);
         monoasm_arm64!(&mut self.jit,
             b jit_entry;             // matched -> tail-call the JIT code
         miss:

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3542,3 +3542,29 @@ fn eager_forwarding_into_req_only_callee() {
         "##,
     );
 }
+
+#[test]
+fn jit_integer_method_with_bignum_receiver() {
+    // A user-defined `Integer` method JIT-compiled for fixnum receivers, then
+    // called with heap-Integer (BigNum) receivers. The class-guard stub routes
+    // a BigNum straight to the VM (`a64_guard_class2`) instead of the
+    // miss/profile-patch chain — results must stay correct across interleaved
+    // fixnum and BigNum receivers.
+    run_test(
+        r#"
+        class Integer
+          def dbl; self * 2; end
+          def add5(x); self + x; end
+        end
+        s = 0
+        i = 0
+        while i < 3000; s += i.dbl + i.add5(3); i += 1; end
+        big = 10 ** 40
+        res = []
+        [5, big, big + 1, 7, big * big, 9, -8, -big].each do |n|
+          res << n.dbl << n.add5(100)
+        end
+        [s, res]
+        "#,
+    );
+}


### PR DESCRIPTION
x86's monomorphic class-guard stub (`guard_class2`) dispatches a Fixnum receiver to the JIT body but a heap `Integer` (BigNum) directly to `vm_entry` in one hop. aarch64's stub used the plain `a64_guard_class`, whose `INTEGER_CLASS` arm is fixnum-only (`tbz bit0`), so a BigNum receiver *failed the entry guard and fell into the miss path* — chain-link check, a countdown that eventually calls `jit_profile_patch` to compile a specialization that **again** rejects BigNum — before settling on `vm_entry`, with periodic redundant recompiles.

## Fix

Adds `a64_guard_class2` (used only by `a64_gen_class_guard_stub`): for `INTEGER_CLASS`, a fixnum goes to the JIT body, a heap `Integer` is routed to `vm_entry`, and a non-Integer still misses. Every other class — including `Float`, whose heap values the JIT body handles fine — delegates to `a64_guard_class` unchanged, and the *inline* recv-class guards keep their fixnum-only semantics (a BigNum there must still deopt). Mirrors x86 `guard_class2`.

## Verification

- Interleaved fixnum + BigNum (and negative-BigNum) receivers on JIT'd user `Integer` methods match CRuby, including under `--features gc-stress` (the heap-class read is memory-sensitive).
- A 5000-iteration BigNum-receiver loop now drives **zero** extra compiles of the method (1 initial fixnum JIT, 0 recompiles) where before it churned the profile-patch / recompile path.
- Full `cargo nextest`: **2733 passed, 1 skipped** (+ new `jit_integer_method_with_bignum_receiver`).

Remaining audit items are the two hardest, both blocked on aarch64's lack of runtime branch patching: #1 direct-dispatch to the specialized JIT entry, and #5 `Object#send` inlining (the last x86-only `inline_gen!`). (#7 — dropping the compensating `CheckBOP` — is deferred pending a dedicated BOP-redefine invalidation design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)