### PR TITLE
Fix two GC bugs and the object-construction path behind the bedcov gap

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -1,11 +1,20 @@
 class Array
   include Enumerable
 
-  def self.new(...)
-    o = allocate
-    o.__send__(:initialize, ...)
-    o
-  end
+  # NOTE: no `def self.new` here. It used to be defined as
+  # `o = allocate; o.__send__(:initialize, ...); o`, which predates the
+  # Ruby-level `Class#new`. That override is now both slower and less
+  # correct than inheriting `Class#new`:
+  #   * `__send__` is registered with rest + kwrest, so the forwarded
+  #     `initialize` call missed every JIT forwarding fast path and fell
+  #     back to the generic argument re-parse plus an eagerly
+  #     materialized rest Array per call (~8x slower than the inherited
+  #     trampoline, which reaches `Array#initialize` — 0/2 positionals,
+  #     no rest, no keywords — through the inline path); and
+  #   * it dispatched the *public* `allocate`, so a user-defined
+  #     `self.allocate` on an Array subclass was honoured. CRuby's
+  #     `Array.new` bypasses it, which is what `Class#new` does via
+  #     `__builtin_allocate__`.
 
   def sample(n = (no_n = true; nil), random: nil)
     if no_n

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2388,6 +2388,33 @@ fn partition(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 }
 
 fn sort_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, mut ary: Array) -> Result<Value> {
+    // The merge buffer must be scanned by the GC: while a merge is in
+    // flight it holds the only reference to one run's elements (their
+    // slots in `ary` have already been overwritten with merge output),
+    // and the comparator below runs Ruby, so a GC can happen right in
+    // that window. Back it with a `nil`-filled Array on the temp stack —
+    // every slot is then always a valid, markable Value, and the storage
+    // address is stable (the collector does not move objects).
+    let scratch_len = executor::op::merge_scratch_len(ary.len());
+    vm.with_temp_scope(|vm| {
+        let buf = if scratch_len == 0 {
+            std::ptr::null_mut()
+        } else {
+            let mut scratch = Array::new_from_vec(vec![Value::nil(); scratch_len]);
+            vm.temp_push(scratch.into());
+            scratch.as_mut_ptr()
+        };
+        sort_with_buf(vm, globals, lfp, ary, buf)
+    })
+}
+
+fn sort_with_buf(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    mut ary: Array,
+    buf: *mut Value,
+) -> Result<Value> {
     if let Some(bh) = lfp.block() {
         let data = vm.get_block_data(globals, bh)?;
         let f = |lhs: Value, rhs: Value| -> Result<std::cmp::Ordering> {
@@ -2420,9 +2447,9 @@ fn sort_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, mut ary: Array
                 _ => std::cmp::Ordering::Greater,
             })
         };
-        executor::op::sort_by(&mut ary, f)?;
+        executor::op::sort_by(&mut ary, buf, f)?;
     } else {
-        vm.sort(globals, &mut ary)?;
+        vm.sort(globals, &mut ary, buf)?;
     }
     Ok(ary.into())
 }
@@ -2437,9 +2464,11 @@ fn sort_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, mut ary: Array
 #[monoruby_builtin]
 fn sort_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     lfp.self_val().ensure_not_frozen(&globals.store)?;
-    // The receiver is the array we sort in place; it is already rooted
-    // through `lfp`, so the merge buffer used inside `sort_inner` only
-    // ever holds bit-copies of elements that the receiver still owns.
+    // NOTE: the receiver being rooted through `lfp` is NOT enough to keep
+    // the merge buffer's contents alive — `merge` overwrites the
+    // receiver's slots before the corresponding buffer entries are
+    // consumed, so during that window the buffer is their only reference.
+    // `sort_inner` therefore roots the buffer itself.
     let ary = lfp.self_val().as_array();
     sort_inner(vm, globals, lfp, ary)
 }
@@ -4072,6 +4101,67 @@ fn insert(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn array_new_via_class_new() {
+        // `Array` no longer overrides `self.new`; it inherits the Ruby
+        // `Class#new`. Cover every argument form, the error cases, and —
+        // the semantic difference from the old override, which dispatched
+        // the public `allocate` — that a subclass's `allocate` override is
+        // NOT called (CRuby bypasses it in `Array.new`).
+        run_test(
+            r#"
+            class MyA < Array
+              def self.allocate; $called = true; super; end
+            end
+            $called = false
+            res = []
+            res << Array.new
+            res << Array.new(3)
+            res << Array.new(3, :x)
+            res << Array.new(3) { |i| i * 2 }
+            res << (begin; Array.new(-1); rescue ArgumentError => e; e.message; end)
+            res << (begin; Array.new(1, 2, 3); rescue ArgumentError => e; e.message; end)
+            a = MyA.new(2, :z)
+            res << [a.class.to_s, a.to_a, $called]
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn array_new_with_block_write_barrier() {
+        // `Array#initialize`'s block form installs every element at once
+        // by swapping the payload of the (already rooted, and therefore
+        // possibly promoted-and-armed) receiver. Without a write barrier
+        // on that swap the array never enters the remembered set, a minor
+        // GC skips scanning it, and all of its elements are swept while
+        // still reachable — a later read then trips `Dead object`. The
+        // allocation churn after the build is what forces that minor GC.
+        run_test_once(
+            r#"
+            a = Array.new(300_000) { |i| [i % 1000] }
+            200_000.times { [1] }
+            a.map { |x| x[0] }.sum
+            "#,
+        );
+    }
+
+    #[test]
+    fn sort_bang_rooted_merge_buffer() {
+        // `sort!`'s merge buffer holds the only reference to one run's
+        // elements while `merge` overwrites their slots in the receiver,
+        // and the comparator can allocate (and thus GC) right in that
+        // window — so the buffer itself has to be GC-visible.
+        run_test_once(
+            r#"
+            a = []
+            200_000.times { |i| a << [(i * 7919) % 1000] }
+            a.sort! { |x, y| [x[0]] <=> [y[0]] }
+            [a.size, a.first[0], a.last[0]]
+            "#,
+        );
+    }
 
     #[test]
     fn array_literal_chunked() {

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1425,7 +1425,20 @@ fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         }
     } else {
         let mut keys = hash.keys();
-        vm.sort(globals, &mut keys)?;
+        // Root the merge buffer (see `Array::sort_inner`): the hash keeps
+        // the keys alive, but a user-defined `<=>` may mutate the hash
+        // mid-sort, and the buffer would then be their only reference.
+        let scratch_len = executor::op::merge_scratch_len(keys.len());
+        vm.with_temp_scope(|vm| {
+            let buf = if scratch_len == 0 {
+                std::ptr::null_mut()
+            } else {
+                let mut scratch = Array::new_from_vec(vec![Value::nil(); scratch_len]);
+                vm.temp_push(scratch.into());
+                scratch.as_mut_ptr()
+            };
+            vm.sort(globals, &mut keys, buf)
+        })?;
         pairs = keys
             .iter()
             .map(|&k| Value::array2(k, hash.get(k, vm, globals).unwrap().unwrap()))

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1289,7 +1289,8 @@ impl AbstractState {
         } else if callsite.forwarding
             && callsite.splat_pos.len() == 1
             && callsite.splat_pos[0] < callsite.pos_num
-            && callee.no_keyword()
+            && (callee.no_keyword()
+                || (callee.kw_names().is_empty() && callsite.kw_may_exists()))
         {
             // Forwarding with a single splat at any position — `g(x.., ...)`
             // (trailing) or implicit `super` of a `def m(a,*r,z)` method
@@ -1300,6 +1301,27 @@ impl AbstractState {
             // subtle kw case to the proven generic. Native callees share
             // the same callee-frame protocol (rest natives get their rest
             // Array materialized by the same `fill_positional_args`).
+            //
+            // A callee whose only keyword surface is a bare `**kwrest`
+            // (no declared keyword names) is admitted too, *provided the
+            // call site itself carries keyword syntax*: the helper's
+            // runtime core then checks whether keywords are actually
+            // being forwarded and stores `nil` into the kwrest slot when
+            // they are not — the same value the generic path would
+            // write. `Struct#initialize` is exactly this shape (rest +
+            // kwrest, for `keyword_init:`) and a `...` forward always
+            // carries the `**kwrest` hash-splat, so this is what keeps
+            // `S.new(...)` off the generic re-parse.
+            //
+            // The `kw_may_exists()` requirement is what keeps
+            // ruby2_keywords correct: promotion of a flagged trailing
+            // Hash into the callee's keywords only happens when the call
+            // site passes no keywords of its own (`r2k_promote` in
+            // `set_callee_frame_arguments`), and the fast path does not
+            // implement it. Forwarding call sites without keyword syntax
+            // — `ruby2_keywords def t(*args); super; end`, or a
+            // delegating block's `target(*args, **kwargs)` — must keep
+            // taking the generic path.
             // Array-path forwarding consume (callee with opt/post/rest):
             // it reads `f`'s rest slot as a real `Array`.
             if self.deferred_rest_tuple().is_some() {

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -46,16 +46,16 @@ pub(crate) fn set_frame_arguments(
         if cs.forwarding {
             if cs.splat_pos.len() == 1
                 && cs.splat_pos[0] < cs.pos_num
-                && globals[callee_fid].no_keyword()
+                && forwarded_fast_path_ok(&globals.store[callee_fid], cs)
             {
                 return forwarded_set_arguments_core(
                     vm, globals, callid, callee_lfp, callee_fid, caller_lfp,
                 );
             }
-            // Shapes outside the direct gate (keyword-taking callee,
-            // extra user splats as in `g(*a, ...)`) still need any
-            // pending lazy marker materialized before the generic
-            // machinery interprets the splat slots.
+            // Shapes outside the direct gate (callee with *named*
+            // keyword parameters, extra user splats as in `g(*a, ...)`)
+            // still need any pending lazy marker materialized before the
+            // generic machinery interprets the splat slots.
             materialize_lazy_at_callsite(vm, globals, callid, caller_lfp);
         }
     }
@@ -254,7 +254,7 @@ pub(crate) fn resolve_lazy_forwarding(
         });
     if allow_direct
         && kw_empty
-        && globals[callee_fid].no_keyword()
+        && forwarded_fast_path_ok(&globals.store[callee_fid], &globals[callid])
         && !globals[callee_fid].single_arg_expand()
     {
         lazy_forward_fill(
@@ -307,7 +307,52 @@ fn lazy_forward_fill(
         buf.push(unsafe { *args_ptr.sub(i) });
     }
     let dst = callee_lfp.register_ptr(SlotId(1));
-    fill_positional_args1(dst, &globals.store[callee_fid], &buf)
+    fill_positional_args1(dst, &globals.store[callee_fid], &buf)?;
+    store_empty_kw_rest(globals, callee_lfp, callee_fid);
+    Ok(())
+}
+
+///
+/// Whether a forwarding call site may take the direct positional build
+/// instead of the generic `set_callee_frame_arguments` re-parse.
+///
+/// A keyword-less callee always may. A callee whose only keyword surface
+/// is a bare `**kwrest` may too — `store_empty_kw_rest` initializes that
+/// slot — but only when the call site itself carries keyword syntax.
+/// That last condition is what preserves ruby2_keywords: promotion of a
+/// flagged trailing Hash into the callee's keywords is gated on the call
+/// site passing no keywords of its own (`r2k_promote`), and the direct
+/// build does not implement it. In practice the shapes this excludes are
+/// `ruby2_keywords def m(*args); super; end` and delegating blocks,
+/// while the `...` forward — which always carries the `**kwrest`
+/// hash-splat — stays on the fast path.
+///
+/// Mirrors the JIT-side gate in `jitgen/compile/method_call.rs`.
+///
+#[inline]
+fn forwarded_fast_path_ok(callee: &FuncInfo, cs: &CallSiteInfo) -> bool {
+    callee.no_keyword() || (callee.kw_names().is_empty() && cs.kw_may_exists())
+}
+
+///
+/// Initialize the callee's `**kwrest` slot for a forwarded call that
+/// carries no keywords.
+///
+/// The positional fast paths above write only positional slots, so a
+/// callee that declares a bare `**kwrest` (no named keywords — the gate
+/// rejects those) would otherwise be left with an uninitialized slot.
+/// `nil` is what the generic path's `handle_keyword_simple` stores for a
+/// keyword-less call, and it means "no keyword arguments" everywhere
+/// downstream: an iseq callee's prologue turns it into `{}` via
+/// `CheckKwRest`, and natives that declare a kwrest already have to
+/// tolerate it (e.g. `Struct#initialize` filters its kwrest argument on
+/// `try_hash_ty()` + non-empty, treating `nil` and `{}` alike).
+///
+#[inline]
+fn store_empty_kw_rest(globals: &Globals, callee_lfp: Lfp, callee_fid: FuncId) {
+    if let Some(rest) = globals[callee_fid].kw_rest() {
+        unsafe { *callee_lfp.register_ptr(rest) = Some(Value::nil()) };
+    }
 }
 
 ///
@@ -464,7 +509,10 @@ fn forwarded_set_arguments_core(
             })
         });
 
-    if kw_empty && !globals[callee_fid].single_arg_expand() {
+    if kw_empty
+        && forwarded_fast_path_ok(&globals.store[callee_fid], cs)
+        && !globals[callee_fid].single_arg_expand()
+    {
         let pos_args = cs.pos_num;
         // gate guarantees exactly one splat; `sp` is its position (the
         // `...`/`*rest` slot). It is trailing for `g(x.., ...)` but is
@@ -512,7 +560,9 @@ fn forwarded_set_arguments_core(
             buf.push(unsafe { *args_ptr.sub(i) });
         }
         let dst = callee_lfp.register_ptr(SlotId(1));
-        fill_positional_args1(dst, &globals.store[callee_fid], &buf)
+        fill_positional_args1(dst, &globals.store[callee_fid], &buf)?;
+        store_empty_kw_rest(globals, callee_lfp, callee_fid);
+        Ok(())
     } else {
         // keywords actually forwarded: defer to the proven generic path
         // (materializing any pending lazy marker first).
@@ -1648,6 +1698,61 @@ mod tests {
             res << (begin; Object.new(1); rescue ArgumentError => e; e.message; end)
             res << (begin; NoArg.new(k: 1); rescue ArgumentError => e; e.class.to_s; end)
             res << Object.instance_method(:initialize).owner.to_s
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn forwarded_bare_kwrest_callee() {
+        // A callee whose only keyword surface is a bare `**kwrest` (no
+        // declared keyword names) is admitted to the forwarding fast
+        // path; the kwrest slot must still be initialized. An iseq
+        // callee sees `{}` (its prologue's `CheckKwRest` turns the
+        // stored nil into an empty Hash), and forwarded keywords must
+        // still arrive intact.
+        run_test(
+            r#"
+            class K; def initialize(*a, **kw); @a = a; @kw = kw; end
+                     attr_reader :a, :kw; end
+            class F; def initialize(x, **kw); @x = x; @kw = kw; end
+                     attr_reader :x, :kw; end
+            def fwd(...) = K.new(...)
+            res = []
+            o = K.new;            res << [o.a, o.kw]
+            o = K.new(1, 2);      res << [o.a, o.kw]
+            o = K.new(1, x: 3);   res << [o.a, o.kw]
+            o = fwd(5, y: 6);     res << [o.a, o.kw]
+            o = fwd;              res << [o.a, o.kw]
+            o = F.new(7);         res << [o.x, o.kw]
+            o = F.new(7, z: 8);   res << [o.x, o.kw]
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn forwarded_struct_construction() {
+        // `Struct#initialize` is a native registered with rest + kwrest
+        // (for `keyword_init:`), which used to disqualify it from every
+        // forwarding fast path. It now takes the specialized helper, so
+        // exercise the shapes that path has to get right.
+        run_test(
+            r#"
+            S = Struct.new(:a, :b)
+            K = Struct.new(:x, keyword_init: true)
+            U = Struct.new(:v) do
+              def initialize(v); super(v * 2); end
+            end
+            res = []
+            res << S.new(1, 2).to_a
+            res << S.new(1).to_a
+            res << S[3, 4].to_a
+            res << K.new(x: 9).x
+            res << K[x: 8].x
+            res << U.new(21).v
+            res << (begin; S.new(1, 2, 3); rescue ArgumentError => e; e.message; end)
+            res << S.new(1, 2).frozen?
             res
             "#,
         );

--- a/monoruby/src/executor/op/sort.rs
+++ b/monoruby/src/executor/op/sort.rs
@@ -1,22 +1,54 @@
 use super::*;
 
+/// Slices of up to this length get sorted using insertion sort, which
+/// needs no merge buffer.
+const MAX_INSERTION: usize = 20;
+
+///
+/// Number of scratch `Value` slots `merge_sort` needs to sort `len`
+/// elements; 0 when insertion sort covers it.
+///
+/// The caller owns the scratch buffer because it must be **GC-visible**:
+/// during a merge the buffer holds the only reference to the elements of
+/// one run (their slots in the receiver have already been overwritten by
+/// merge output), and the comparator runs arbitrary Ruby — and therefore
+/// may trigger a GC — between the copy-in and the copy-out. A plain
+/// Rust `Vec<Value>` is not scanned by the collector, so those elements
+/// were swept and the sort resumed on dangling pointers. Callers back
+/// the buffer with a `nil`-filled Array kept on the temp stack (every
+/// slot then always holds a valid, markable `Value`).
+///
+pub(crate) fn merge_scratch_len(len: usize) -> usize {
+    if len <= MAX_INSERTION { 0 } else { len / 2 }
+}
+
 impl Executor {
     ///
     /// Execute merge sort for Vec of *Value*s with `<=>`.
     ///
-    pub(crate) fn sort(&mut self, globals: &mut Globals, vec: &mut [Value]) -> Result<()> {
+    /// `buf` must point to at least `merge_scratch_len(vec.len())`
+    /// initialized, GC-rooted `Value`s (may be null when that is 0).
+    ///
+    pub(crate) fn sort(
+        &mut self,
+        globals: &mut Globals,
+        vec: &mut [Value],
+        buf: *mut Value,
+    ) -> Result<()> {
         let is_less = |a: Value, b: Value| {
             let ord = Executor::compare_values(self, globals, a, b)?;
             Result::Ok(ord == std::cmp::Ordering::Less)
         };
-        merge_sort(vec, is_less)
+        merge_sort(vec, buf, is_less)
     }
 }
 
 ///
 /// Execute merge sort for Vec of *Value*s with `compare`.
 ///
-pub(crate) fn sort_by<F>(vec: &mut [Value], mut compare: F) -> Result<()>
+/// See `Executor::sort` for the `buf` contract.
+///
+pub(crate) fn sort_by<F>(vec: &mut [Value], buf: *mut Value, mut compare: F) -> Result<()>
 where
     F: FnMut(Value, Value) -> Result<std::cmp::Ordering>,
 {
@@ -24,15 +56,13 @@ where
         let ord = compare(a, b)?;
         Result::Ok(ord == std::cmp::Ordering::Less)
     };
-    merge_sort(vec, f)
+    merge_sort(vec, buf, f)
 }
 
-fn merge_sort<F>(v: &mut [Value], mut is_less: F) -> Result<()>
+fn merge_sort<F>(v: &mut [Value], buf: *mut Value, mut is_less: F) -> Result<()>
 where
     F: FnMut(Value, Value) -> Result<bool>,
 {
-    // Slices of up to this length get sorted using insertion sort.
-    const MAX_INSERTION: usize = 20;
     // Very short runs are extended using insertion sort to span at least this many elements.
     const MIN_RUN: usize = 10;
 
@@ -48,7 +78,7 @@ where
         return Ok(());
     }
 
-    let mut buf = Vec::with_capacity(len / 2);
+    debug_assert!(!buf.is_null());
     let mut runs = vec![];
     let mut end = len;
     while end > 0 {
@@ -95,7 +125,7 @@ where
             merge(
                 &mut v[left.start..right.start + right.len],
                 left.len,
-                buf.as_mut_ptr(),
+                buf,
                 &mut is_less,
             )?;
             runs[r] = Run {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -571,8 +571,24 @@ impl PartialEq for RValue {
 }
 
 impl RValue {
+    ///
+    /// Exchange the payloads (and hence the child references) of two
+    /// objects.
+    ///
+    /// Both objects end up owning a child set they did not have before,
+    /// so both need the write barrier: either one may be an OLD object
+    /// that was armed while childless (`apply_aging` takes the
+    /// `arm_barrier` branch when `young_child_exists()` is false), and a
+    /// minor GC seeds OLD objects as already-marked and never scans them
+    /// unless they are in the remembered set. `Array#initialize`'s block
+    /// form hits exactly that: the receiver is allocated empty, stays
+    /// rooted across the whole block loop (so it ages into OLD), and then
+    /// receives every element at once through this swap.
+    ///
     pub fn swap_kind(&mut self, other: &mut Self) {
         std::mem::swap(&mut self.kind, &mut other.kind);
+        self.write_barrier_bulk();
+        other.write_barrier_bulk();
     }
 
     pub(crate) fn debug(&self, store: &Store) -> String {


### PR DESCRIPTION
# Why

Investigating why `benchmark/plb2/bedcov.rb` trails CRuby+YJIT showed the gap is **entirely object construction**, not the algorithm. Phase breakdown (1M intervals, same box):

| phase | monoruby (before) | YJIT | |
|---|---|---|---|
| gen — 2M `Interval.new` | 3.28s | 1.28s | construction-bound |
| index — sort + ~1.5M `Interval.new` | 2.03s | 0.71s | construction-bound |
| **query — no construction (75% of runtime)** | **11.93s** | **12.24s** | **at parity** |

Component micro-benchmarks confirm everything else is at parity or faster: `splitmix32` 0.270s vs 0.311s, the `for` loop 0.004s vs 0.059s, `a[i]=` 0.007s vs 0.064s (per 2M).

Two independent, pre-existing GC bugs surfaced while building those micro-benchmarks; both are fixed here too.

# Construction: the forwarding fast-path gate was too strict

Construction runs through the Ruby `Class#new` trampoline, whose `o.__builtin_initialize__(...)` is a forwarding call site. Both fast branches in `set_arguments` were gated on `callee.no_keyword()`, so a callee declaring a bare `**kwrest` fell all the way back to the generic `SetArguments` path — which also vetoes the D1 deferral and therefore materializes the `...` rest Array on *every* call. Per 2M constructions, before:

| callee shape | branch | time |
|---|---|---|
| fixed-arity iseq `initialize` | inline | 0.061s |
| rest iseq `initialize` | helper | 0.219s |
| rest + `**kw` iseq | generic | 0.613s |
| fixed + `**kw` iseq | generic | 0.626s |
| **`Struct#initialize`** | **generic** | **0.894s** |

`Struct#initialize` is registered rest + kwrest (for `keyword_init:`), so every Struct construction took the slowest path — even though a `...` forward supplies no keywords at all.

Callees whose only keyword surface is a bare `**kwrest` are now admitted to the helper branch, with the runtime core initializing that slot via `store_empty_kw_rest` (writes `nil` — what `handle_keyword_simple` already stores for a keyword-less call, and what every consumer reads as "no keyword arguments": an iseq callee's prologue turns it into `{}` via `CheckKwRest`, and natives declaring a kwrest already tolerate it — `Struct#initialize` filters on `try_hash_ty()` + non-empty, treating `nil` and `{}` alike). Callees with *named* keywords still take the generic path.

The relaxation additionally requires the call site to carry keyword syntax (`kw_may_exists()`), which is what keeps **ruby2_keywords** correct: promotion of a flagged trailing Hash into the callee's keywords only happens when the call site passes none of its own (`r2k_promote`), and the direct build does not implement it. A `...` forward always carries the `**kwrest` hash-splat and stays on the fast path, while `ruby2_keywords def m(*args); super; end` and delegating blocks keep taking the generic one. `tests/ruby2_keywords.rs` covers both shapes (it caught this during development).

# `Array.new` never reached the trampoline

`builtins/array.rb` overrode `self.new` as `o = allocate; o.__send__(:initialize, ...)`, predating the Ruby `Class#new`. `__send__` is registered rest + kwrest, so this hit the generic path too. Removing the override is both faster and more correct: it also dispatched the **public** `allocate`, so a subclass's `self.allocate` override was honoured, where CRuby's `Array.new` bypasses it (the inherited `Class#new` uses `__builtin_allocate__`).

# GC bug A: missing write barrier in `Array#initialize`'s block form

`Array#initialize` installs every element at once by swapping the receiver's payload, and `RValue::swap_kind` was a bare `mem::swap` with no barrier. The receiver is allocated empty and stays rooted across the whole block loop, so it ages into OLD and gets *armed* while still childless; the swap then gives it a million young children without entering the remembered set, and the next minor GC — which seeds OLD objects as marked and does not scan them — sweeps every element.

```ruby
a = Array.new(1_000_000) { |i| [(i * 7919) % 1000] }
a.sort_by! { |x| x[0] }     # => abort: Dead object
```

Confirmed generational first: the repro passes under `MONORUBY_GC_ALL_MAJOR=1`. Fixed by barriering both sides in `swap_kind` (it moves children in both directions).

# GC bug B: unrooted merge buffer in `sort!`

`merge_sort` kept its merge buffer in a plain `Vec<Value>`, which the collector does not scan. During a merge that buffer holds the **only** reference to one run's elements — their slots in the receiver have already been overwritten with merge output — and the comparator runs arbitrary Ruby in exactly that window:

```ruby
a.sort! { |x, y| [x[0]] <=> [y[0]] }   # 1M elements => abort: Dead object
```

The buffer is now handed in by the caller, backed by a `nil`-filled Array kept on the temp stack, so every slot is always a valid, markable Value (`Array#sort_by!` already used this pattern). The comment claiming the buffer only holds elements the receiver still owns was exactly wrong and is corrected. `Hash#sort`'s path gets the same treatment: the hash keeps the keys alive today, but a user-defined `<=>` may mutate it mid-sort.

(My first hypothesis that `sort_by!` was at fault was wrong — it is correctly temp-rooted and merely supplied the allocation churn. bedcov itself uses `Array.new(n)` without a block, so it was never at risk from bug A.)

# Results

| benchmark (2M iterations) | before | after |
|---|---|---|
| `S.new(1)` (Struct) | 0.894s | **0.395s** |
| `Array.new(4)` | 0.830s | **0.277s** |
| rest + `**kw` iseq | 0.613s | 0.336s |
| fixed + `**kw` iseq | 0.626s | 0.362s |
| `Plain.new(1)` (unchanged) | 0.060s | 0.060s |

bedcov: gen 3.28s → **2.08s**, index 2.03s → **1.72s**, query unchanged at ~12.3s (it constructs nothing). End-to-end vs YJIT: ~1.35x → **~1.15x**.

# Tests

* Full suite green — lib **and** integration targets, `--features stress-spill-pool,gc-stress`.
* Five regression tests added: `array_new_via_class_new` (all argument forms, error cases, and the subclass-`allocate` semantics), `array_new_with_block_write_barrier`, `sort_bang_rooted_merge_buffer`, `forwarded_bare_kwrest_callee`, `forwarded_struct_construction`.
* **Both GC tests were verified to actually catch their bugs** — with the fix reverted, each aborts with `Dead object`.
* Semantics diffed against CRuby for Struct/Data construction, `__send__` forwarding, kwrest edge cases (`**{}`, empty-vs-nil observability), `Array.new` forms, and sort correctness.

# Follow-ups (not in this PR)

* Struct construction still materializes one rest Array (0.395s vs 0.060s for a plain class). Closing that needs D1 source-routing extended to rest callees, or a dedicated `FuncKind::StructInitialize` lowered to direct slot stores like the existing `StructReader`/`StructWriter`.
* Relaxing the **inline** branch (1) the same way would move fixed-arity + `**kwrest` callees from 0.362s toward 0.061s, but requires storing nil into the callee's kwrest slot in both backends' asm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ)_