### PR TITLE
fix(aarch64): revert off-stack JIT methods to VM on basic-op redefinition

### DIFF
--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -677,7 +677,28 @@ impl ISeqInfo {
         self.jit_entry.clear();
         self.jit_class_profile.clear();
         #[cfg(target_arch = "aarch64")]
-        self.jit_slot.clear();
+        {
+            // aarch64 has no entry-reversion pass (x86 reverts every compiled
+            // method entry to `vm_entry` via `apply_jmp_patch_address` in
+            // `set_bop_redefine`). Its compiled methods are instead reached
+            // through a heap-leaked dispatch slot (see `arch/aarch64/wrapper.rs`
+            // + `compile_patch`). Zero each tracked slot so an already-compiled
+            // method stops branching into its now-stale JIT body — which may
+            // have folded a basic-op result or inlined integer arithmetic that a
+            // BOP redefinition has invalidated — and falls back to the VM on its
+            // next call. The slots are plain data words read with `ldr`, so a
+            // bare store suffices; no I-cache maintenance is needed (that is only
+            // required when patching instructions).
+            for &slot_addr in self.jit_slot.values() {
+                // SAFETY: each value is a heap-leaked `u64` (a wrapper or
+                // class-guard-chain dispatch word) recorded by `set_jit_slot`;
+                // it is leaked for the process lifetime, so the pointer is always
+                // valid to write, and the write races nothing (method-table
+                // mutation is not a green-thread yield point).
+                unsafe { *(slot_addr as *mut u64) = 0 };
+            }
+            self.jit_slot.clear();
+        }
     }
 
     /// Record one warm-up sample of *self_class* for this iseq and report

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -87,6 +87,122 @@ fn redefine_test4() {
     );
 }
 
+// Regression: a basic-op redefinition must be observed by an *already
+// JIT-compiled* method that was **off the stack** at redefinition time.
+//
+// The pre-existing `redefine_test*` above only redefine `Integer#*` and use
+// `100 * 100`, a compile-time **fold**, while the redefining `class Integer`
+// body runs *inside* the warm-up loop (on-stack) — so they were satisfied on
+// aarch64 by the fold-only `CheckBOP` guard + on-stack `immediate_eviction`,
+// and never exercised the **non-fold** inline integer add of an off-stack
+// method. That path carries no per-op guard on either arch, so correctness
+// relies entirely on `set_bop_redefine` reverting every compiled method to the
+// VM: x86 rewrites each entry to `vm_entry`; aarch64 zeroes each method's
+// dispatch slot in `invalidate_jit_code`. Before slot-zeroing, aarch64 kept
+// dispatching an off-stack method into its stale JIT body and returned the
+// pre-redefinition result (e.g. `5 + 3 == 8` instead of the redefined `111`).
+//
+// `run_test` doubles as the guard: it evaluates the snippet 25× in one process
+// and `__assert`s run 1 (which JIT-compiles then redefines off-stack) against
+// later VM runs, so a divergence between the stale JIT body and the VM fails
+// the test.
+#[test]
+fn redefine_bop_offstack_nonfold() {
+    run_test(
+        r##"
+        def add_fold; 5 + 3; end
+        def add_dyn(a, b); a + b; end
+        res = []
+        50.times { add_fold; add_dyn(5, 3) }
+        class Integer
+          def +(o); 111; end
+        end
+        res << add_fold          # folded 5+3, must observe redefine -> 111
+        res << add_dyn(5, 3)     # non-fold inline add, off-stack -> 111
+        res
+        "##,
+    );
+}
+
+#[test]
+fn redefine_bop_offstack_ops() {
+    run_test(
+        r##"
+        def add_fold; 5 + 3; end
+        def mul_fold; 100 * 100; end
+        def sub_fold; 10 - 4; end
+        def add_dyn(a, b); a + b; end
+        def mul_dyn(a, b); a * b; end
+        def sub_dyn(a, b); a - b; end
+        res = []
+        50.times { add_fold; mul_fold; sub_fold; add_dyn(5,3); mul_dyn(100,100); sub_dyn(10,4) }
+        class Integer
+          def +(o); 111; end
+          def *(o); 222; end
+          def -(o); 333; end
+        end
+        res << add_fold << mul_fold << sub_fold
+        res << add_dyn(5,3) << mul_dyn(100,100) << sub_dyn(10,4)
+        res
+        "##,
+    );
+}
+
+// The dispatch slot is per receiver class: an inherited method compiled for
+// several subclasses builds a guard *chain* of slots (one HashMap entry each).
+// A BOP redefinition must zero **every** slot, not just the head class's.
+#[test]
+fn redefine_bop_polymorphic_chain() {
+    run_test(
+        r##"
+        class BopBase; def calc(a, b); a + b; end; end
+        class BopS1 < BopBase; end
+        class BopS2 < BopBase; end
+        s1 = BopS1.new
+        s2 = BopS2.new
+        50.times { s1.calc(5, 3); s2.calc(5, 3) }
+        class Integer
+          def +(o); 111; end
+        end
+        [s1.calc(5, 3), s2.calc(5, 3)]
+        "##,
+    );
+}
+
+// KNOWN, PRE-EXISTING, CROSS-ARCH BUG (bug B): an off-stack method that stays
+// VM-interpreted but has an OSR/loop-JIT'd hot loop keeps entering the stale
+// loop body after a basic-op redefinition. The compiled loop entry lives in the
+// bytecode (`BytecodePtr::write2`, `[pc-8]`) and `vm_loop_start` jumps to it
+// (`jmp rax` / `br x10`) with no `jit_invalidated`/class-version check, and
+// `set_bop_redefine` reverts method entries but never the OSR bytecode-PC
+// entries — on BOTH x86 and aarch64. Slot-zeroing (which fixed the method-JIT
+// twin, bug A) cannot reach these entries. Fixing this needs a cross-arch design
+// decision (revert every loop's `[pc-8]`, or guard the loop entry); until then
+// this miscompiles (`x * x` here reads the pre-redefinition product). Un-ignore
+// once OSR-entry invalidation lands.
+#[test]
+#[ignore = "bug B: off-stack OSR loop-JIT ignores BOP redefine (pre-existing, cross-arch)"]
+fn redefine_bop_offstack_osr_loop() {
+    run_test(
+        r##"
+        def osr_sum(x)
+          total = 0
+          i = 0
+          while i < 300
+            total = total + (x * x)
+            i = i + 1
+          end
+          total
+        end
+        osr_sum(7)
+        class Integer
+          def *(o); 1000; end
+        end
+        osr_sum(7)
+        "##,
+    );
+}
+
 // Regression for #730: a `class`/`module`/`class << obj` definition used
 // in *expression* position (its value feeds a surrounding operation)
 // must not clobber the accumulator that holds a live operand. Here `a`


### PR DESCRIPTION
## Summary

Fixes an **aarch64-only correctness bug**: an already-JIT-compiled method that is *off the stack* when a basic operator (e.g. `Integer#+`) is redefined kept dispatching into its stale JIT body and returned its **pre-redefinition** result.

Minimal repro (before this PR, on aarch64):
```ruby
def add_dyn(a, b); a + b; end
1000.times { add_dyn(5, 3) }          # method-JIT compiles add_dyn
class Integer; def +(o); 999; end; end # redefine Integer#+ (off-stack)
add_dyn(5, 3)                          # => 8  (WRONG; CRuby & VM say 999)
```

## Root cause

aarch64 reaches each compiled method through a heap-leaked **indirect dispatch slot** (the wrapper does `ldr x10,[slot]; cbnz x10, run_jit`). `ISeqInfo::invalidate_jit_code` (called on BOP redefinition via `set_bop_redefine`) only cleared the slot-address bookkeeping `HashMap` — it **never zeroed the slot memory**, so the wrapper kept branching into the invalidated code.

x86 avoids this by reverting every compiled method entry to `vm_entry` (`apply_jmp_patch_address`). aarch64 had no equivalent. The constant-**fold** case (`5 + 3`) was already covered on aarch64 by its `CheckBOP` guard; this bug is the **non-fold** inline arithmetic path, which carries no per-op guard on either arch and relies entirely on whole-method invalidation.

## Fix

Zero each tracked dispatch slot (the head class's slot **and** every polymorphic guard-chain `next_slot`) before clearing the HashMap, so an off-stack method falls back to the VM on its next call — parity with x86's entry reversion. The slots are plain data words (read via `ldr`), so a bare aligned store suffices with no I-cache maintenance.

## Why it's safe

Independently verified (adversarial multi-lens review):
- **Concurrency** — monoruby runs all Ruby on one OS thread (M:1 green threads); the slot's sole reader and the writer are the same thread, and method-table mutation is not a yield point → no data race. (The two background OS threads never touch slots/Store.)
- **Memory-safety** — every `jit_slot` value traces to a `Box::into_raw(Box::new(0u64))` site; 8-aligned, heap-leaked, never freed, non-aliasing, one-per-`ClassId` → the store is aligned/in-bounds/idempotent.
- **Completeness** — traced all fresh-entry reach paths; every indirect path (JIT→JIT calls, all invokers, `send`, VM re-dispatch) funnels back through the callee's zeroed slot because `funcdata.codeptr` is always the wrapper on aarch64.

## Tests

`tests/redefine.rs`:
- `redefine_bop_offstack_nonfold`, `redefine_bop_offstack_ops` (`+`/`*`/`-`), `redefine_bop_polymorphic_chain` — use `run_test`, whose 25× JIT-vs-VM `__assert` cross-check fails on divergence. Verified **non-vacuous** (they SIGABRT with the fix neutered).
- `redefine_bop_offstack_osr_loop` (`#[ignore]`d) — documents a **separate, pre-existing, cross-arch** gap: off-stack **OSR/loop-JIT** bodies, whose entries live in the bytecode PC and are entered by `vm_loop_start` with no version check, are reverted by *neither* arch. That's a follow-up (a symmetric fix that also unblocks removing the aarch64 `CheckBOP`).

## Validation

- Full `cargo nextest run`: **2736 passed, 2 skipped** (aarch64).
- `cargo nextest run --features gc-stress --test redefine`: **8 passed**.
- x86 is untouched (the change is entirely under `#[cfg(target_arch = "aarch64")]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)