### PR TITLE
gc: drop the REMEMBERED header bit; rename WB_PENDING to WB_ARMED

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+# Kill and NAME any test that hangs. After `period` a test is reported as
+# SLOW (with its name) in the live output — a heartbeat for the CI log; after
+# `terminate-after` x `period` (10 min) it is terminated and reported by name
+# instead of stalling the whole run. Background: the darwin CI runner
+# intermittently hangs / OOM-dies inside the nextest phase with no culprit
+# named (the 25-min attempt cap or the runner's death hid the test name).
+# 10 min is far above any legitimate single test, including under gc-stress
+# on the slow macOS runner, and far below the 25-min attempt cap.
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 10 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,46 +128,95 @@ jobs:
         run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
 
       - name: Test (VM + AArch64 JIT, arm64-apple-darwin)
-        # The arm64 JIT/runtime intermittently (~a few % of runs) hangs by
-        # exhausting memory: the macOS runner OOM-dies ("loses communication")
-        # before any stack can be captured, and on-demand reproduction under
-        # instrumentation has so far failed (nextest ×5 and full bin/test ×8
-        # both ran clean). Two guards:
-        #   * retry — cap each attempt at 25 min and retry once, so a hang fails
-        #     fast (normal pass ~11 min) and the rerun recovers automatically; and
-        #   * a background memory watchdog that NAMES the culprit the next time
-        #     the hang strikes a real run: it polls every monoruby process's RSS
-        #     and, when one exceeds ~4 GB (or the parallel sum exceeds ~5 GB),
-        #     logs that process's command line (the nextest test / benchmark /
-        #     spec it is running), `sample`s its stack, and kills it before the
-        #     runner dies. It only acts above 4 GB, so normal runs are
-        #     unaffected and the retry recovers the killed attempt.
+        # The arm64 JIT/runtime intermittently hangs by exhausting memory: the
+        # macOS runner OOM-dies ("loses communication") before any stack can be
+        # captured, and when the runner dies the job's streamed logs become
+        # unavailable through the API as well — so past hangs left ZERO
+        # forensics. Guards, in order of importance:
+        #   * retry — cap each attempt at 25 min and retry once, so a clean
+        #     hang fails fast (normal pass ~11 min) and the rerun recovers;
+        #   * a background memory watchdog that must fire BEFORE the runner
+        #     dies. It watches every monoruby AND ruby process (bin/test diffs
+        #     against CRuby and runs mspec, so the hog can be either side) and
+        #     additionally the system-wide free memory: it fires when one
+        #     process exceeds ~3 GB, the watched sum exceeds ~4 GB, or free
+        #     memory drops under ~700 MB while a watched process exists. On
+        #     firing it logs the last [phase] marker + the culprit's command
+        #     line, `sample`s its stack, and kills it (the retry recovers);
+        #   * a 30-second heartbeat line (elapsed / free memory / top process /
+        #     tail of the test log) so even a log truncated by runner death
+        #     shows how far the run got and how memory moved — this is the
+        #     "progress log" for otherwise-silent hangs;
+        #   * bin/test output is tee'd to $RUNNER_TEMP and uploaded as an
+        #     artifact even on failure (see the next step), which preserves the
+        #     full log of a timed-out attempt that the retry then recovered.
+        # Per-test hangs inside the nextest phase are additionally named and
+        # killed by .config/nextest.toml (slow-timeout terminate-after).
         # The manual .github/workflows/darwin-hang-debug.yml drives the same
-        # watchdog in a loop for active reproduction.
+        # idea in a loop for active reproduction.
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 25
           max_attempts: 2
           command: |
-            RSS_LIMIT_KB=4000000
-            SUM_LIMIT_KB=5000000
-            ( while true; do
-                snap=$(ps -Ao pid,rss,comm | awk 'NR>1 { n=split($3,a,"/"); b=a[n]; if (b ~ /^monoruby/) print $1, $2 }')
+            set -o pipefail
+            LOG="$RUNNER_TEMP/bin-test-attempt-$(date -u +%H%M%S).log"
+            echo "attempt log: $LOG"
+            RSS_LIMIT_KB=3000000
+            SUM_LIMIT_KB=4000000
+            SYS_FREE_FLOOR_KB=700000
+            ( t0=$(date +%s); pass=0
+              while true; do
+                snap=$(ps -Ao pid,rss,comm \
+                  | awk 'NR>1 { n=split($3,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print $1, $2, b }')
+                sum=0; toppid=0; toprss=0; topcmd=-
                 if [ -n "$snap" ]; then
                   sum=$(echo "$snap" | awk '{s+=$2} END{print s+0}')
-                  set -- $(echo "$snap" | awk '{if($2>m){m=$2;p=$1}} END{print p+0, m+0}')
-                  if [ "${2:-0}" -gt "$RSS_LIMIT_KB" ] || [ "${sum:-0}" -gt "$SUM_LIMIT_KB" ]; then
-                    echo "==================== MEMORY WATCHDOG fired @ $(date -u +%H:%M:%S) ===================="
-                    echo "sum_rss_kb=$sum top_pid=$1 top_rss_kb=$2 (caps: per-proc=$RSS_LIMIT_KB sum=$SUM_LIMIT_KB)"
-                    ps -Ao pid,rss,command | awk 'NR>1 { n=split($3,a,"/"); b=a[n]; if (b ~ /^monoruby/) print }'
-                    echo "---- CULPRIT command line (pid $1) ----"; ps -p "$1" -o command= 2>/dev/null || true
-                    echo "---- sample pid $1 (2s) ----"; /usr/bin/sample "$1" 2 2>&1 | sed -n '1,160p' || true
-                    echo "---- killing pid $1 ----"; kill -9 "$1" 2>/dev/null || true
-                  fi
+                  set -- $(echo "$snap" | awk '{if($2>m){m=$2;p=$1;c=$3}} END{print p+0, m+0, c}')
+                  toppid=$1; toprss=$2; topcmd=${3:--}
+                fi
+                # System-wide reclaimable memory (free+inactive+purgeable, 16 KB
+                # pages on Apple Silicon): the runner dies silently when this
+                # runs out, whichever process is responsible.
+                freekb=$(vm_stat | awk -F'[: .]+' \
+                  '/Pages free/ {f=$3} /Pages inactive/ {i=$3} /Pages purgeable/ {p=$3} END {print (f+i+p)*16}')
+                if [ "${toprss:-0}" -gt "$RSS_LIMIT_KB" ] || [ "${sum:-0}" -gt "$SUM_LIMIT_KB" ] \
+                   || { [ "${freekb:-999999999}" -lt "$SYS_FREE_FLOOR_KB" ] && [ "${toppid:-0}" -gt 0 ]; }; then
+                  echo "==================== MEMORY WATCHDOG fired @ $(date -u +%H:%M:%S) ===================="
+                  echo "sys_free_kb=$freekb sum_rss_kb=$sum top=$topcmd pid=$toppid rss_kb=$toprss"
+                  echo "(caps: per-proc=$RSS_LIMIT_KB sum=$SUM_LIMIT_KB sys-floor=$SYS_FREE_FLOOR_KB)"
+                  echo "---- last phase reached ----"; grep '^\[phase' "$LOG" 2>/dev/null | tail -1 || true
+                  echo "---- watched processes (pid rss_kb etime command) ----"
+                  ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }'
+                  echo "---- CULPRIT command line (pid $toppid) ----"; ps -p "$toppid" -o command= 2>/dev/null || true
+                  echo "---- sample pid $toppid (2s) ----"; /usr/bin/sample "$toppid" 2 2>&1 | sed -n '1,160p' || true
+                  echo "---- killing pid $toppid ----"; kill -9 "$toppid" 2>/dev/null || true
+                  sleep 8
+                fi
+                pass=$((pass+1))
+                if [ $((pass % 8)) -eq 0 ]; then
+                  printf '[hb %s +%ss] sys_free_kb=%s watched_sum_kb=%s top=%s(%sKB) tail: %s\n' \
+                    "$(date -u +%H:%M:%S)" "$(( $(date +%s) - t0 ))" "${freekb:-?}" "$sum" \
+                    "$topcmd" "${toprss:-0}" \
+                    "$(tail -c 400 "$LOG" 2>/dev/null | tr '\n' ' ' | tail -c 160)"
                 fi
                 sleep 4
               done ) &
             WATCHDOG_PID=$!
             trap 'kill "$WATCHDOG_PID" 2>/dev/null || true' EXIT
-            bin/test
+            bin/test 2>&1 | tee "$LOG"
+
+      - name: Upload darwin test logs (hang forensics)
+        # Preserves the tee'd bin/test log of every attempt — including a
+        # first attempt that hit the 25-min cap and was then recovered by the
+        # retry, whose hang would otherwise leave no trace in a green run.
+        # (If the runner itself dies, this step never runs; that case is
+        # covered by the watchdog killing the culprit first.)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-bin-test-logs-run${{ github.run_id }}-attempt${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bin-test-attempt-*.log
+          if-no-files-found: ignore
+          retention-days: 14
 

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -41,7 +41,7 @@ monoruby のガベージコレクタの**現行実装**を、コードに即し�
 コンパイルパイプライン全体における GC の位置づけは `CLAUDE.md` の
 "Custom GC (`alloc.rs`)" と本書を対応させて読むとよい。
 
-オブジェクトの状態遷移(世代間の移動と OLD / WB_PENDING / REMEMBERED / age
+オブジェクトの状態遷移(世代間の移動と OLD / WB_ARMED / age
 各フラグの変化)を 1 枚にまとめた図が
 [gc_state_transitions.svg](gc_state_transitions.svg) にある(§6・§7 の図解版)。
 
@@ -236,18 +236,21 @@ struct Metadata {          // rvalue.rs:2373
 | 2 | `0b0000_0100` | CHILLED(`Symbol#to_s` 由来の準 frozen 文字列) |
 | 3 | `0b0000_1000` | **OLD**(old 世代へ昇格済み) |
 | 4 | `0b0001_0000` | WB_UNPROTECTED(shady 用に予約。現状**未使用** — §7.3) |
-| 5 | `0b0010_0000` | **REMEMBERED**(remembered set に登録済み) |
-| 6 | `0b0100_0000` | **WB_PENDING / armed**(old かつ未 remembered = 書き込みバリアの slow path 対象) |
+| 5 | `0b0010_0000` | 空き(旧 REMEMBERED。「remembered set 登録済み」は専用ビットではなく **`OLD ∧ ¬WB_ARMED` で導出**する) |
+| 6 | `0b0100_0000` | **WB_ARMED**(old かつ未 remembered = 書き込みバリアの slow path 対象) |
 | 7 | `0b1000_0000` | CHILLED_LITERAL(リテラル由来の chilled 文字列;警告文言の出し分け用) |
 | 8..15 | 上位バイト | **age**(生存回数;`RGENGC_OLD_AGE` で昇格。上位バイトは age 専用 — 下位バイトのフラグはここに置かないこと) |
 
-新規オブジェクトは `flag == 1` なので、OLD / REMEMBERED / WB_PENDING はすべて 0
+新規オブジェクトは `flag == 1` なので、OLD / WB_ARMED はともに 0
 (= young・バリア対象外)、age は 0 から始まる。
 
-`arm_barrier`(WB_PENDING を立て REMEMBERED を落とす)と
-`enter_remembered`(REMEMBERED を立て WB_PENDING を落とす)は、この 2 ビットを
-**排他**に保つ。書き込みバリアの高速パスがこの 1 ビット(WB_PENDING)テストだけで
-済むのはこの排他性による。
+old オブジェクトの 2 状態は WB_ARMED 1 ビットで表す:
+**armed = OLD ∧ WB_ARMED**、**remembered = OLD ∧ ¬WB_ARMED**。
+remembered set の実体(列挙)は `Allocator::remembered`(Vec)であり、ヘッダ側は
+バリアの高速パスが見る WB_ARMED だけを持つ。`arm_barrier`(WB_ARMED を立てる)と
+`enter_remembered`(WB_ARMED を落とす)は単一ビットの反転で、
+書き込みバリアの高速パスはこの 1 ビット(WB_ARMED)テストだけで済む。
+「OLD=0 なのに WB_ARMED=1」は発生しない不正状態である。
 
 ---
 
@@ -329,13 +332,13 @@ minor GC / 完全な minor GC の 3 通りでのマーク走査の比較と、�
 
 ```rust
 pub(crate) fn write_barrier(&mut self, child: Value) {
-    if self.is_wb_pending() && !child.is_packed_value() {
+    if self.is_wb_armed() && !child.is_packed_value() {
         self.enter_remembered_set();
     }
 }
 ```
 
-- **高速パスはヘッダ 1 ビットのテスト**(`is_wb_pending` = WB_PENDING ビット)。
+- **高速パスはヘッダ 1 ビットのテスト**(`is_wb_armed` = WB_ARMED ビット)。
   young オブジェクトも、既に remembered な old オブジェクトも、このビットが 0 なので
   即 return(アロケータに触れない)。
 - 子の世代は見ない(old→old を覚える過剰近似は無害)。即値(`is_packed_value`)は除外。
@@ -353,14 +356,16 @@ pub(crate) fn write_barrier(&mut self, child: Value) {
 
 ```
 young(flag=1) ──[age>=3 で昇格]──▶ old
-   昇格時に young 子あり ─▶ enter_remembered (REMEMBERED=1, WB_PENDING=0) ── remembered set 登録
-   昇格時に young 子なし ─▶ arm_barrier      (WB_PENDING=1, REMEMBERED=0) ── 以後の young ストアを待つ
-   armed な old に young ストア ─▶ write_barrier ─▶ enter_remembered_set ── set 登録 + WB_PENDING=0
+   昇格時に young 子あり ─▶ enter_remembered (WB_ARMED=0) ── remembered set 登録
+   昇格時に young 子なし ─▶ arm_barrier      (WB_ARMED=1) ── 以後の young ストアを待つ
+   armed な old に young ストア ─▶ write_barrier ─▶ enter_remembered_set ── set 登録 + WB_ARMED=0
    minor 走査で young 子が消えた remembered ─▶ arm_barrier に戻す(自己クリーニング)
 ```
 
-REMEMBERED と WB_PENDING は常に排他。remembered set の大きさは「生きた old→young 辺の
-数」に比例し続ける(かつて young 子を持っていた全昇格オブジェクトには比例しない)。
+生きている old については「WB_ARMED=0 ⇔ `Allocator::remembered` に登録済み」が
+不変条件(専用の REMEMBERED ビットは持たない — §5)。remembered set の大きさは
+「生きた old→young 辺の数」に比例し続ける(かつて young 子を持っていた全昇格
+オブジェクトには比例しない)。
 
 ### 7.3 昇格可能性(`is_promotable`, `rvalue.rs:918`)
 

--- a/doc/gc_state_transitions.svg
+++ b/doc/gc_state_transitions.svg
@@ -22,7 +22,7 @@
 
   <!-- title -->
   <text x="700" y="52" text-anchor="middle" font-size="32" font-weight="bold" fill="#0f172a">monoruby Generational GC — Object State Transitions</text>
-  <text x="700" y="84" text-anchor="middle" font-size="17" fill="#64748b">Flags: OLD = promoted · WB_PENDING = barrier armed · REMEMBERED = in remembered set · age = survivals</text>
+  <text x="700" y="84" text-anchor="middle" font-size="17" fill="#64748b">Flags: OLD = promoted · WB_ARMED = barrier armed · age = survivals · "remembered" is derived: OLD &amp; !WB_ARMED</text>
 
   <!-- major GC demote (OLD -> YOUNG) -->
   <path d="M 1090 208 C 1090 95, 305 95, 305 208" fill="none" stroke="#be123c" stroke-width="2.5" stroke-dasharray="8 5" marker-end="url(#arwR)"/>
@@ -32,7 +32,7 @@
   <!-- YOUNG -->
   <rect x="70" y="210" width="470" height="300" rx="14" fill="#eff6ff" stroke="#3b82f6" stroke-width="2.5"/>
   <text x="305" y="248" text-anchor="middle" font-size="20" font-weight="bold" fill="#1d4ed8">YOUNG (old_bit = 0)</text>
-  <text x="305" y="284" text-anchor="middle" font-size="17" fill="#0f172a">OLD = 0 / WB_PENDING = 0 / REMEMBERED = 0</text>
+  <text x="305" y="284" text-anchor="middle" font-size="17" fill="#0f172a">OLD = 0 / WB_ARMED = 0</text>
   <text x="305" y="314" text-anchor="middle" font-size="17" fill="#0f172a">age = 0 – 2</text>
   <text x="305" y="350" text-anchor="middle" font-size="15.5" fill="#3b82f6">scanned &amp; swept by every GC (minor and major)</text>
 
@@ -51,14 +51,14 @@
 
   <!-- promotion: YOUNG -> OLD/armed -->
   <text x="560" y="300" font-size="15.5" font-weight="bold" fill="#0f172a">age = 3 → promote: OLD ← 1</text>
-  <text x="560" y="322" font-size="15" fill="#b45309">no young child → WB_PENDING ← 1</text>
+  <text x="560" y="322" font-size="15" fill="#b45309">no young child → WB_ARMED ← 1</text>
   <line x1="540" y1="350" x2="856" y2="375" stroke="#b45309" stroke-width="2.5" marker-end="url(#arwA)"/>
 
   <!-- promotion: YOUNG -> OLD/remembered -->
   <line x1="540" y1="470" x2="856" y2="630" stroke="#15803d" stroke-width="2.5" marker-end="url(#arwG)"/>
   <text x="548" y="644" font-size="15.5" font-weight="bold" fill="#0f172a">age = 3 → promote: OLD ← 1</text>
-  <text x="548" y="668" font-size="15" fill="#15803d">young child → REMEMBERED ← 1</text>
-  <text x="548" y="690" font-size="14.5" fill="#15803d">(remember-on-promote → push to set)</text>
+  <text x="548" y="668" font-size="15" fill="#15803d">young child → pushed to the set</text>
+  <text x="548" y="690" font-size="14.5" fill="#15803d">(remember-on-promote, WB_ARMED ← 0)</text>
 
   <!-- OLD container -->
   <rect x="830" y="210" width="520" height="560" rx="14" fill="#fffbeb" stroke="#d97706" stroke-width="2.5"/>
@@ -68,26 +68,26 @@
   <!-- OLD / armed -->
   <rect x="860" y="295" width="460" height="140" rx="10" fill="#ffffff" stroke="#b45309" stroke-width="2"/>
   <text x="1090" y="327" text-anchor="middle" font-size="19" font-weight="bold" fill="#7c2d12">old / armed — barrier watching</text>
-  <text x="1090" y="357" text-anchor="middle" font-size="16.5" fill="#0f172a">OLD = 1 / WB_PENDING = 1 / REMEMBERED = 0</text>
+  <text x="1090" y="357" text-anchor="middle" font-size="16.5" fill="#0f172a">OLD = 1 / WB_ARMED = 1</text>
   <text x="1090" y="385" text-anchor="middle" font-size="15" fill="#475569">not in the remembered set</text>
   <text x="1090" y="410" text-anchor="middle" font-size="14.5" fill="#64748b">steady state: no young children</text>
 
   <!-- armed -> remembered -->
   <line x1="920" y1="435" x2="920" y2="586" stroke="#7c2d12" stroke-width="2.5" marker-end="url(#arw)"/>
   <text x="950" y="468" font-size="15.5" font-weight="bold" fill="#7c2d12">↓ young stored → write barrier fires</text>
-  <text x="950" y="491" font-size="15" fill="#7c2d12">WB_PENDING → 0, REMEMBERED → 1</text>
+  <text x="950" y="491" font-size="15" fill="#7c2d12">WB_ARMED → 0</text>
   <text x="950" y="512" font-size="15" fill="#7c2d12">pushed to the remembered set</text>
 
   <!-- remembered -> armed -->
   <line x1="1290" y1="586" x2="1290" y2="437" stroke="#15803d" stroke-width="2.5" marker-end="url(#arwG)"/>
   <text x="950" y="540" font-size="15.5" font-weight="bold" fill="#15803d">↑ minor GC: young children gone</text>
-  <text x="950" y="562" font-size="15" fill="#15803d">REMEMBERED → 0, WB_PENDING → 1</text>
+  <text x="950" y="562" font-size="15" fill="#15803d">WB_ARMED → 1</text>
   <text x="950" y="583" font-size="15" fill="#15803d">dropped from the set</text>
 
   <!-- OLD / remembered -->
   <rect x="860" y="590" width="460" height="155" rx="10" fill="#ffffff" stroke="#15803d" stroke-width="2"/>
   <text x="1090" y="622" text-anchor="middle" font-size="19" font-weight="bold" fill="#14532d">old / remembered — has old→young edges</text>
-  <text x="1090" y="652" text-anchor="middle" font-size="16.5" fill="#0f172a">OLD = 1 / WB_PENDING = 0 / REMEMBERED = 1</text>
+  <text x="1090" y="652" text-anchor="middle" font-size="16.5" fill="#0f172a">OLD = 1 / WB_ARMED = 0</text>
   <text x="1090" y="680" text-anchor="middle" font-size="15" fill="#475569">in the remembered set</text>
   <text x="1090" y="706" text-anchor="middle" font-size="15" fill="#15803d">minor GC scans only its children</text>
 

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -258,7 +258,9 @@ pub trait GCBox: PartialEq {
 
     ///
     /// Mark this object as recorded in the remembered set (clears the
-    /// armed flag). Used when it is added to the set.
+    /// WB_ARMED flag; an old object with WB_ARMED clear *is*
+    /// "remembered" — there is no separate bit). Used when it is added
+    /// to the set.
     ///
     fn enter_remembered(&mut self);
 
@@ -910,7 +912,7 @@ impl<T: GCBox> Allocator<T> {
                 // Every object is demoted and re-aged from scratch, so the
                 // remembered set is rebuilt by this cycle's `apply_aging`.
                 // (Demoted objects are young again — fully scanned — so
-                // their now-stale armed/remembered header bits are
+                // their now-stale OLD/WB_ARMED header bits are
                 // harmless until re-promotion resets them.)
                 self.remembered.clear();
             }

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -48,7 +48,7 @@ mod variables;
 ///
 extern "C" fn jit_write_barrier(parent: *mut RValue) {
     // SAFETY: `parent` is the live `&RValue` the store wrote into. The
-    // inline fast path has already checked it is `wb_pending` with a heap
+    // inline fast path has already checked it is `wb_armed` with a heap
     // child, so `write_barrier_bulk` records it in the remembered set.
     unsafe { (*parent).write_barrier_bulk() };
 }

--- a/monoruby/src/codegen/arch/aarch64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/variables.rs
@@ -159,9 +159,9 @@ impl Codegen {
         let p = parent.a64().0;
         let c = child.a64().0;
         monoasm_arm64!(&mut self.jit,
-            // barrier armed?  (WB_PENDING = flag bit 6 = old & not remembered)
+            // barrier armed?  (WB_ARMED = flag bit 6 = old & not remembered)
             ldrb w9, [x(p), #(RVALUE_OFFSET_FLAG as u32)];
-            tbz x9, #(6), skip;        // WB_PENDING clear -> skip
+            tbz x9, #(6), skip;        // WB_ARMED clear -> skip
             // child immediate?  (heap pointers have the low 3 bits clear)
             mov x9, (0b111);
             and x9, x(c), x9;

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -179,7 +179,7 @@ impl Codegen {
 ///
 extern "C" fn jit_write_barrier(parent: *mut RValue) {
     // SAFETY: `parent` is the live `&RValue` the store wrote into. The
-    // inline fast path has already checked it is `wb_pending` with a heap
+    // inline fast path has already checked it is `wb_armed` with a heap
     // child, so `write_barrier_bulk` records it in the remembered set.
     unsafe { (*parent).write_barrier_bulk() };
 }
@@ -200,7 +200,7 @@ impl Codegen {
     pub(super) fn emit_write_barrier_rdi(&mut self, child: GP) {
         let skip = self.jit.label();
         monoasm! { &mut self.jit,
-            // barrier armed?  (WB_PENDING = flag bit 6 = old & not remembered)
+            // barrier armed?  (WB_ARMED = flag bit 6 = old & not remembered)
             // Young objects and already-remembered old objects both have it
             // clear, so the common case skips after this single test.
             testb [rdi + (RVALUE_OFFSET_FLAG as i32)], 0x40;

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1101,12 +1101,12 @@ impl RValue {
 
     /// Old object that is not (yet) in the remembered set — a young store
     /// to it must take the barrier slow path.
-    pub(crate) fn is_wb_pending(&self) -> bool {
-        self.header.is_wb_pending()
+    pub(crate) fn is_wb_armed(&self) -> bool {
+        self.header.is_wb_armed()
     }
 
-    /// Record `self` in the remembered set: flip its state to "remembered"
-    /// (clears the armed flag) and append it to the allocator's set.
+    /// Record `self` in the remembered set: disarm the barrier (clear
+    /// WB_ARMED) and append it to the allocator's set.
     fn enter_remembered_set(&mut self) {
         self.header.enter_remembered();
         crate::alloc::ALLOC
@@ -1118,12 +1118,12 @@ impl RValue {
     ///
     /// Call *after* storing `child` into a reference-typed field of
     /// `self` (an ivar, an array/hash element, a struct slot, …). If
-    /// `self` is old and not yet remembered (`is_wb_pending`) and `child`
+    /// `self` is old and not yet remembered (`is_wb_armed`) and `child`
     /// is a heap object, `self` is recorded in the remembered set so a
     /// subsequent minor GC can still reach `child` without scanning the
     /// whole old generation.
     ///
-    /// Fast path is a single header-bit test (`is_wb_pending`): young
+    /// Fast path is a single header-bit test (`is_wb_armed`): young
     /// objects *and* already-remembered old objects both return
     /// immediately without touching the allocator. We do not check the
     /// child's generation (remembering an old→old edge is a harmless
@@ -1132,7 +1132,7 @@ impl RValue {
     ///
     #[inline]
     pub(crate) fn write_barrier(&mut self, child: Value) {
-        if self.is_wb_pending() && !child.is_packed_value() {
+        if self.is_wb_armed() && !child.is_packed_value() {
             self.enter_remembered_set();
         }
     }
@@ -1145,7 +1145,7 @@ impl RValue {
     ///
     #[inline]
     pub(crate) fn write_barrier_bulk(&mut self) {
-        if self.is_wb_pending() {
+        if self.is_wb_armed() {
             self.enter_remembered_set();
         }
     }
@@ -2425,7 +2425,7 @@ impl Header {
 
     /// A copy of this header for a newborn object (`#dup` / `#clone` /
     /// literal instantiation): the generational-GC state — age (bits
-    /// 8..15), OLD, REMEMBERED, WB_PENDING — is reset so the copy starts
+    /// 8..15), OLD, WB_ARMED — is reset so the copy starts
     /// young and unbarriered, instead of inheriting the source's GC
     /// state without being registered in the page-side `old_bits` /
     /// remembered-set bookkeeping (issue #977). LIVE, WB_UNPROTECTED,
@@ -2478,15 +2478,17 @@ impl Header {
         unsafe { self.meta.flag |= 0b100 | CHILLED_LITERAL_BIT }
     }
 
-    // --- Generational GC flags (flag bits 3..5) ---
+    // --- Generational GC flags (flag bits 3, 4, 6) ---
     //
-    // bit3 `0b0_1000`  = OLD            (promoted to old generation)
-    // bit4 `0b1_0000`  = WB_UNPROTECTED (shady; never promoted)
-    // bit5 `0b10_0000` = REMEMBERED     (in the remembered set)
+    // bit3 `0b000_1000` = OLD            (promoted to old generation)
+    // bit4 `0b001_0000` = WB_UNPROTECTED (shady; never promoted)
+    // bit5 `0b010_0000` = (free — was REMEMBERED; "in the remembered
+    //                     set" is now derived as `OLD && !WB_ARMED`,
+    //                     and the set itself is `Allocator::remembered`)
+    // bit6 `0b100_0000` = WB_ARMED       (see `is_wb_armed`)
     //
-    // A freshly allocated object has `flag == 1`, so all three bits
-    // start clear (young, barrier-untracked, not remembered). See
-    // `doc/gc.md`.
+    // A freshly allocated object has `flag == 1`, so all these bits
+    // start clear (young, barrier-untracked). See `doc/gc.md`.
 
     #[allow(dead_code)]
     fn is_old(&self) -> bool {
@@ -2513,50 +2515,41 @@ impl Header {
         unsafe { self.meta.flag |= 0b1_0000 }
     }
 
-    #[allow(dead_code)]
-    fn is_remembered(&self) -> bool {
-        unsafe { self.meta.flag & 0b10_0000 != 0 }
-    }
-
-    #[allow(dead_code)]
-    fn set_remembered(&mut self) {
-        unsafe { self.meta.flag |= 0b10_0000 }
-    }
-
-    #[allow(dead_code)]
-    fn clear_remembered(&mut self) {
-        unsafe { self.meta.flag &= !0b10_0000 }
-    }
-
     ///
-    /// Generational GC write-barrier "armed" flag (bit 6): set iff the
-    /// object is old and *not* in the remembered set, i.e. a young store
-    /// to it must take the barrier slow path. Testing this single bit is
-    /// what makes the JIT/Rust barrier fast path one instruction — young
-    /// objects and already-remembered old objects both have it clear.
-    /// `arm_barrier` / `enter_remembered` keep it mutually exclusive with
-    /// `REMEMBERED`. See `doc/gc.md`.
+    /// Generational GC write-barrier "armed" flag (bit 6, WB_ARMED): set
+    /// iff the object is old and *not* in the remembered set, i.e. a
+    /// young store to it must take the barrier slow path. Testing this
+    /// single bit is what makes the JIT/Rust barrier fast path one
+    /// instruction — young objects and already-remembered old objects
+    /// both have it clear. There is no separate REMEMBERED bit:
+    /// membership in the remembered set is `OLD && !WB_ARMED` (the set
+    /// itself lives in `Allocator::remembered`), so `arm_barrier` /
+    /// `enter_remembered` are single-bit flips of this flag. See
+    /// `doc/gc.md`.
     ///
-    fn is_wb_pending(&self) -> bool {
+    fn is_wb_armed(&self) -> bool {
         unsafe { self.meta.flag & 0b100_0000 != 0 }
     }
 
-    /// Old, not remembered: arm the barrier (WB_PENDING set, REMEMBERED clear).
+    /// Old, not remembered: arm the barrier (set WB_ARMED). Also used to
+    /// re-arm when the object is dropped from the remembered set.
     fn arm_barrier(&mut self) {
-        unsafe { self.meta.flag = (self.meta.flag | 0b100_0000) & !0b10_0000 }
+        unsafe { self.meta.flag |= 0b100_0000 }
     }
 
-    /// Recorded in the remembered set (REMEMBERED set, WB_PENDING clear).
+    /// Recorded in the remembered set: disarm the barrier (clear
+    /// WB_ARMED; an old object with WB_ARMED clear *is* "remembered").
+    /// The clear is not always a no-op: an old object demoted by a major
+    /// GC keeps a stale WB_ARMED until re-promotion passes through here.
     fn enter_remembered(&mut self) {
-        unsafe { self.meta.flag = (self.meta.flag | 0b10_0000) & !0b100_0000 }
+        unsafe { self.meta.flag &= !0b100_0000 }
     }
 
     /// Generational GC age (number of collections survived), stored in
     /// the high byte of `flag` so the type byte's neighbour stays zero
     /// (see `Metadata::_padding`). The low byte holds the live/frozen/
-    /// chilled/OLD/REMEMBERED/WB_PENDING flags and is read by the write
-    /// barrier; age occupies bits 8..15, untouched by those byte-wide
-    /// flag tests.
+    /// chilled/OLD/WB_ARMED flags and is read by the write barrier; age
+    /// occupies bits 8..15, untouched by those byte-wide flag tests.
     fn age(&self) -> u8 {
         unsafe { (self.meta.flag >> 8) as u8 }
     }
@@ -2644,8 +2637,7 @@ mod header_flag_tests {
         let n = h.newborn();
         assert_eq!(n.age(), 0, "newborn inherited the age counter");
         assert!(!n.is_old(), "newborn inherited the OLD bit");
-        assert!(!n.is_remembered(), "newborn inherited REMEMBERED");
-        assert!(!n.is_wb_pending(), "newborn inherited WB_PENDING");
+        assert!(!n.is_wb_armed(), "newborn inherited WB_ARMED");
         assert!(n.is_live());
         assert!(n.is_frozen(), "newborn dropped the frozen bit");
         assert!(n.is_chilled(), "newborn dropped the chilled bit");
@@ -2655,6 +2647,23 @@ mod header_flag_tests {
         h.set_old();
         h.arm_barrier();
         let n = h.newborn();
-        assert!(!n.is_wb_pending(), "newborn born with the barrier armed");
+        assert!(!n.is_wb_armed(), "newborn born with the barrier armed");
+    }
+
+    // "In the remembered set" has no bit of its own: for an old object it
+    // is exactly `!WB_ARMED`, and `arm_barrier` / `enter_remembered` are
+    // single-bit flips of WB_ARMED.
+    #[test]
+    fn armed_and_remembered_are_one_bit() {
+        let mut h = string_header();
+        h.set_old();
+        h.arm_barrier();
+        assert!(h.is_wb_armed(), "promotion with no young child must arm");
+        h.enter_remembered();
+        assert!(!h.is_wb_armed(), "entering the set must disarm");
+        h.arm_barrier();
+        assert!(h.is_wb_armed(), "re-arming after set self-clean failed");
+        assert!(h.is_old(), "barrier flips must not touch OLD");
+        assert_eq!(h.age(), 0, "barrier flips must not touch the age");
     }
 }


### PR DESCRIPTION
## Summary

The `REMEMBERED` header flag (bit 5) was pure redundancy: the remembered set is enumerated from `Allocator::remembered`, and nothing ever read the header bit — its accessors were all `#[allow(dead_code)]`. This PR removes it and derives "in the remembered set" as **`OLD && !WB_ARMED`**, and renames `WB_PENDING` → **`WB_ARMED`** throughout.

### Changes

- **`rvalue.rs`**: remove `REMEMBERED` (bit 5 is now free) and its dead accessors; `arm_barrier` / `enter_remembered` become single-bit flips of `WB_ARMED`, so the two-bit exclusivity invariant disappears. `enter_remembered`'s clear is documented as not always a no-op (an old object demoted by a major GC keeps a stale `WB_ARMED` until same-cycle re-promotion passes through it). `is_wb_pending` → `is_wb_armed`.
- **Write-barrier fast path is unchanged**: still the single-bit test (`testb 0x40` on x86-64, `tbnz #6` on aarch64) inlined by both JIT backends — comment-only updates there.
- **State encoding**: young = `OLD=0`, armed = `OLD=1 ∧ WB_ARMED=1`, remembered = `OLD=1 ∧ WB_ARMED=0`. `OLD=0 ∧ WB_ARMED=1` is now an impossible state.
- **Docs**: `doc/gc.md` §5 bit table + §7.1/§7.2, and `doc/gc_state_transitions.svg` updated to the new flag names (render-checked). `doc/gc_write_barrier.svg` names no flags, so it is untouched.
- **Tests**: new `armed_and_remembered_are_one_bit` unit test (also checks the flips don't touch `OLD`/age); newborn-reset test updated.

### Verification

- `header_flag_tests`: 6/6 pass.
- CRuby-compared integration tests: `gc` filter 14 pass + `heap_frame_reclaim_correctness` pass. `gc_config` fails **identically on the unmodified baseline** (local-environment CRuby output parsing, unrelated to this change).
- Stress: a remembered-set cycle script (400 old holders × 20 rounds of young stores + ~40k allocations of churn per round, exercising armed → barrier → remembered → self-clean → re-armed) run on a `gc-stress + gc-verify + gc-debug` build, in both normal and `MONORUBY_GC_ALL_MAJOR=1` modes — results correct and identical to CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EScJjZq6bDW7vXkaZLaVb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EScJjZq6bDW7vXkaZLaVb7)_