### PR TITLE
fix(aarch64): complete BOP-redefinition invalidation (OSR loops, on-stack callers, yields) and drop the fold CheckBOP

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1331,8 +1331,16 @@ impl Codegen {
         self.jit.set_writable();
         let dest = self.jit.get_label_address(deopt);
         // Byte displacement from the patch point to the deopt handler; both are
-        // 4-byte aligned, so imm26 = disp / 4 (B's range is ±128 MiB).
+        // 4-byte aligned, so imm26 = disp / 4 (B's range is ±128 MiB). In the
+        // intended use the evict handler sits in the same compilation unit as
+        // the call site, so the distance is tiny — assert the range so an
+        // out-of-range pair (a table-corruption symptom) panics instead of
+        // silently branching to a masked wrong target.
         let disp = dest - patch_point;
+        debug_assert!(
+            (-(1i64 << 27)..(1i64 << 27)).contains(&(disp as i64)),
+            "patch_return_to_deopt: B displacement out of imm26 range: {disp:#x}"
+        );
         let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
         let word = 0x1400_0000u32 | imm26;
         unsafe { (patch_point.as_ptr() as *mut u32).write(word) };
@@ -1360,6 +1368,10 @@ impl Codegen {
         self.jit.set_writable();
         let dest = self.jit.get_label_address(entry);
         let disp = dest - patch_point;
+        debug_assert!(
+            (-(1i64 << 27)..(1i64 << 27)).contains(&(disp as i64)),
+            "patch_call_to_entry: BL displacement out of imm26 range: {disp:#x}"
+        );
         let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
         let word = 0x9400_0000u32 | imm26;
         // SAFETY: `patch_point` is the 4-byte-aligned address of the `bl`

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -753,17 +753,18 @@ impl Codegen {
     /// Lower `Call` (the call itself): set the callee LFP, push a control
     /// frame, set PC, `blr` the callee codeptr, then restore the caller's
     /// cfp/lfp. Mirrors x86 `do_call` (set_lfp + push_frame + call + pop_frame)
-    /// and the VM invoker's `aftargs` sequence. The eviction-on-return
-    /// patching (`set_deopt_with_return_addr`) is x86-only (runtime branch
-    /// patching), so it is skipped — class-version changes are caught by
-    /// `GuardClassVersion` deopts instead.
+    /// and the VM invoker's `aftargs` sequence.
+    /// Returns the call's return address (the instruction after the `blr`,
+    /// i.e. pop_frame's first instruction) so `emit_call` can register it for
+    /// BOP-redefinition eviction (mirrors x86 `emit_call`'s
+    /// `get_current_address` after the `call`).
     pub(super) fn a64_do_call(
         &mut self,
         codeptr: CodePtr,
         is_iseq: bool,
         callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
-    ) {
+    ) -> CodePtr {
         let codeptr_addr = codeptr.as_ptr() as u64;
         // set_lfp + push_frame (EXEC=x19, LFP=x22).
         monoasm_arm64!(&mut self.jit,
@@ -792,12 +793,14 @@ impl Codegen {
             mov x10, (codeptr_addr);
             blr x10;                                 // result in x0
         );
+        let return_addr = self.jit.get_current_address();
         // pop_frame: restore caller cfp + lfp from x29 (== x86 rbp).
         monoasm_arm64!(&mut self.jit,
             sub x10, x29, #(BP_CFP as u32);
             str x10, [x19, #(EXECUTOR_CFP as u32)];
             ldur x22, [x29, #(-((BP_CFP + CFP_LFP) as i32))];
         );
+        return_addr
     }
 
     // ---- specialized (inlined) frame lowering (aarch64) -------------------
@@ -1081,12 +1084,17 @@ impl Codegen {
         );
     }
 
-    /// The call itself. aarch64 has no runtime branch patching, so the `evict`
-    /// return-address patch point is not registered (class-version guards cover
-    /// the staleness it would otherwise catch); the x86-only params are unused.
-    /// aarch64 always calls `codeptr` directly (no JIT-entry dispatch or
-    /// return-address patching — class-version guards cover invalidation), so
-    /// `jit_entry` / `evict` / `evict_label` are unused here.
+    /// The call itself. `jit_entry` is unused — aarch64 always calls `codeptr`
+    /// directly (no JIT-entry dispatch).
+    ///
+    /// Like x86, the call's return address is registered for BOP-redefinition
+    /// eviction: when a basic op is redefined *inside* the callee, the caller's
+    /// own compiled body (inline integer arithmetic, folds) is stale the moment
+    /// the callee returns, and the callee's entry guards cannot protect the
+    /// *caller*. `immediate_eviction` finds this frame's return address in
+    /// `return_addr_table` and overwrites the recorded patch point (bound by
+    /// the following `ImmediateEvict`, after the result store) with a `B evict`
+    /// so the frame deopts instead of resuming stale code.
     pub(in crate::codegen::jitgen) fn emit_call(
         &mut self,
         codeptr: CodePtr,
@@ -1094,10 +1102,11 @@ impl Codegen {
         callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
         _jit_entry: Option<DestLabel>,
-        _evict: AsmEvict,
-        _evict_label: &DestLabel,
+        evict: AsmEvict,
+        evict_label: &DestLabel,
     ) {
-        self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr);
+        let return_addr = self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr);
+        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
     }
 
     /// Keyword-rest fixup: if the `slot` is nil, replace it with a fresh empty
@@ -1130,16 +1139,23 @@ impl Codegen {
     /// Lower the generic `Yield` (block call whose target is resolved at runtime
     /// via `get_yield_data`). Mirrors x86 `gen_yield`: fetch the block's
     /// ProcData, build the callee block frame, massage arguments, then call the
-    /// block's funcdata indirectly. The eviction-on-return patching is x86-only
-    /// (runtime branch patching), so it is skipped — class-version guards cover
-    /// it. `error` catches a missing block, an argument error, or a callee
+    /// block's funcdata indirectly. Like every other machine-level call, the
+    /// block call's return address is registered for BOP-redefinition eviction
+    /// (see `emit_call`) — a yielded block can redefine a basic op, and the
+    /// yielding frame must then deopt on resume instead of running its stale
+    /// compiled continuation. Registering here also keeps the
+    /// `emit_immediate_evict` invariant that every `ImmediateEvict`'s evict id
+    /// was registered by its own site in the same block (AsmEvict ids restart
+    /// per block, so an unregistered producer would read a stale same-id entry
+    /// from `asm_return_addr_table` and hijack an unrelated site's patch
+    /// point). `error` catches a missing block, an argument error, or a callee
     /// raise. Bails on an out-of-range callee-frame offset.
     pub(in crate::codegen::jitgen) fn emit_yield(
         &mut self,
         callid: CallSiteId,
         error: &DestLabel,
-        _evict: AsmEvict,
-        _evict_label: &DestLabel,
+        evict: AsmEvict,
+        evict_label: &DestLabel,
     ) -> bool {
         // Closely mirrors the proven VM `a64_op_yield`. x25/x26 are callee-saved
         // and used by neither the JIT global set (x19-x23) nor JIT'd code, so
@@ -1218,12 +1234,16 @@ impl Codegen {
             ldr x21, [x26, #(FUNCDATA_PC as u32)];        // PC <- callee pc
             ldr x10, [x26, #(FUNCDATA_CODEPTR as u32)];
             blr x10;                                       // result in x0
+        );
+        let return_addr = self.jit.get_current_address();
+        monoasm_arm64!(&mut self.jit,
             sub x11, sp, #(RSP_CFP as u32);
             ldr x10, [x11];
             str x10, [x19, #(EXECUTOR_CFP as u32)];
             sub x10, x29, #((BP_CFP + CFP_LFP) as u32);
             ldr x22, [x10];
         );
+        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1808,22 +1808,26 @@ impl Codegen {
         self.a64_block_break(pc);
     }
 
-    /// Record this position (the return continuation of a specialized call) as
-    /// the return-address patch point for `evict`. On BOP redefinition,
-    /// `Codegen::immediate_eviction` overwrites the instruction here with a
-    /// `B deopt` so the stale specialized frame deopts on return. Mirrors x86.
+    /// Record this position (the return continuation of a call, after the
+    /// result store) as the return-address patch point for `evict`. On BOP
+    /// redefinition, `Codegen::immediate_eviction` overwrites the instruction
+    /// here with a `B deopt` so the stale frame deopts on return instead of
+    /// resuming its compiled body (whose inline integer arithmetic / folds
+    /// assume the builtin op). Mirrors x86.
     pub(in crate::codegen::jitgen) fn emit_immediate_evict(&mut self, evict: AsmEvict) {
-        // Only specialized calls register a return address on aarch64; normal
-        // calls (`emit_call`) ignore `evict` and rely on the callee's own entry
-        // guard rather than return-address patching. So an unregistered evict
-        // here is a normal call with nothing to patch — skip it. (On x86 every
-        // call registers, so the lookup always succeeds there.)
-        if let Some(&return_addr) = self.asm_return_addr_table.get(&evict) {
-            let patch_point = self.jit.get_current_address();
-            self.return_addr_table
-                .entry(return_addr)
-                .and_modify(|e| e.0 = Some(patch_point));
-        }
+        // Every `ImmediateEvict` producer (normal call, generic yield,
+        // specialized call/yield) registers its own return address in the same
+        // block, so the id ALWAYS resolves to the fresh same-block entry.
+        // `unwrap` (x86 parity) is load-bearing: AsmEvict ids restart per
+        // block and `asm_return_addr_table` is never cleared, so a producer
+        // that forgot to register would otherwise silently read a stale
+        // same-id entry from an earlier block and repoint an unrelated live
+        // call site's patch point — a miscompile. Panic loudly instead.
+        let return_addr = *self.asm_return_addr_table.get(&evict).unwrap();
+        let patch_point = self.jit.get_current_address();
+        self.return_addr_table
+            .entry(return_addr)
+            .and_modify(|e| e.0 = Some(patch_point));
     }
 
     /// Register a specialized call's return address so `immediate_eviction` can

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1534,6 +1534,17 @@ impl Codegen {
     /// instead of returning the fixnum result inline. Mirrors the x86
     /// `remove_vm_bop_optimization` in `vmgen.rs`.
     pub(in crate::codegen) fn remove_vm_bop_optimization(&mut self) {
+        // loop_start (14): swap in the no-opt handler (plain advance +
+        // dispatch, same shape as loop_end) so the VM stops entering compiled
+        // OSR loop bodies — and stops triggering new loop compiles — entirely.
+        // Without this, an off-stack method's `[pc+8]` still holds its stale
+        // loop codeptr (nothing reverts OSR entries; `invalidate_jit_code`
+        // only covers method dispatch slots), so a fresh frame's loop_start
+        // would branch straight into loop code whose folds / inline integer
+        // arithmetic assume the now-redefined basic op. Mirrors the x86
+        // `remove_vm_bop_optimization`'s `dispatch[14] = vm_loop_start_no_opt`.
+        self.dispatch[14] = self.a64_op_loop();
+
         let add = self.a64_op_binop(add_values_no_opt);
         let sub = self.a64_op_binop(sub_values_no_opt);
         let mul = self.a64_op_binop(mul_values_no_opt);

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -81,21 +81,20 @@ impl<'a> JitContext<'a> {
             }
             _ => match state.binop_type(lhs, rhs, ic) {
                 BinaryOpType::Integer(l, r) => {
-                    // A constant-fold bakes the result (e.g. `100 * 100` -> 10000)
-                    // assuming the builtin operator, with no runtime trace of the
-                    // op. Guard that assumption: emit `CheckBOP` *before* the fold
-                    // (so the deopt write-back still sees the operand literals
-                    // live) with the deopt PC at this op, so a later BOP
-                    // redefinition deopts and the interpreter re-runs the op
-                    // through the de-optimized VM handler. x86 recovers via the
-                    // class-version-guard recompile path, so gate this to the
-                    // aarch64 (no-recompile) build. Limited to the fold case: the
-                    // register fast-path keeps its operands at runtime, so it is
-                    // not worth a guard on every arithmetic op.
-                    #[cfg(target_arch = "aarch64")]
-                    if state.check_concrete_i64(l, r).is_some() {
-                        ir.check_bop(state);
-                    }
+                    // Both the constant fold (`100 * 100` -> 10000) and the
+                    // register fast-path's inline arithmetic assume the builtin
+                    // operator with no per-op runtime guard. A basic-op
+                    // redefinition is instead handled method-wide by
+                    // `set_bop_redefine`, identically on both arches: compiled
+                    // method entries are reverted (x86 `apply_jmp_patch_address`
+                    // to `vm_entry`; aarch64 dispatch-slot zeroing in
+                    // `invalidate_jit_code`), the VM's `loop_start` handler is
+                    // swapped for the no-opt one so stale OSR loop bodies are
+                    // never re-entered, and on-stack frames deopt on return via
+                    // `immediate_eviction`'s return-address patching (both
+                    // arches; see `emit_call`). A `def` executed *inside* JIT
+                    // code is caught by the `check_bop` after
+                    // `MethodDef`/`SingletonMethodDef`.
                     state.binop_integer(ir, kind, dst, l, r);
                     Ok(CompileResult::Continue)
                 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1890,6 +1890,17 @@ impl Executor {
         visibility: Visibility,
     ) -> Result<()> {
         globals.add_method(class_id, name, func_id, visibility);
+        // Evict stale on-stack JIT frames *after* the store mutation and
+        // *before* the `method_added` hook: if this definition redefined a
+        // basic op, `set_bop_redefine` has just set the flags, and every JIT
+        // frame currently on the stack (e.g. a caller whose inline integer
+        // arithmetic follows the call that led here) must deopt on return
+        // instead of resuming its compiled body — including inside the
+        // `method_added` callback, which runs arbitrary Ruby. This funnel
+        // covers every definition route (`def`, `Module#define_method`,
+        // `alias`); checking before the store mutation (as the `def` path
+        // used to) misses the very definition that sets the flags.
+        Codegen::check_bop_redefine(self.cfp());
         self.invoke_method_added(globals, class_id, name)
     }
 
@@ -1906,6 +1917,8 @@ impl Executor {
         original_name: IdentId,
     ) -> Result<()> {
         globals.add_method_with_original(class_id, name, func_id, visibility, original_name);
+        // BOP-redefinition eviction — see `add_method`.
+        Codegen::check_bop_redefine(self.cfp());
         self.invoke_method_added(globals, class_id, name)
     }
 
@@ -1918,6 +1931,8 @@ impl Executor {
         old_name: IdentId,
     ) -> Result<()> {
         globals.alias_method_for_class(class_id, new_name, old_name)?;
+        // BOP-redefinition eviction (`alias_method :+, :other`) — see `add_method`.
+        Codegen::check_bop_redefine(self.cfp());
         self.invoke_method_added(globals, class_id, new_name)
     }
 
@@ -2119,7 +2134,6 @@ impl Executor {
         if let Some(attached) = target.is_singleton() {
             attached.ensure_not_frozen(&globals.store)?;
         }
-        Codegen::check_bop_redefine(self.cfp());
         if cref.module_function {
             self.add_method(globals, class_id, name, func, Visibility::Private)?;
             self.add_singleton_method(globals, class_id, name, func, cref.visibility)?;
@@ -2144,6 +2158,8 @@ impl Executor {
             };
             self.add_method(globals, class_id, name, func, visibility)?;
         }
+        // BOP-redefinition eviction fires inside `add_method` (after the store
+        // mutation, before the `method_added` hook) — see the comment there.
         Ok(Value::nil())
     }
 }

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -169,19 +169,18 @@ fn redefine_bop_polymorphic_chain() {
     );
 }
 
-// KNOWN, PRE-EXISTING, CROSS-ARCH BUG (bug B): an off-stack method that stays
-// VM-interpreted but has an OSR/loop-JIT'd hot loop keeps entering the stale
-// loop body after a basic-op redefinition. The compiled loop entry lives in the
-// bytecode (`BytecodePtr::write2`, `[pc-8]`) and `vm_loop_start` jumps to it
-// (`jmp rax` / `br x10`) with no `jit_invalidated`/class-version check, and
-// `set_bop_redefine` reverts method entries but never the OSR bytecode-PC
-// entries — on BOTH x86 and aarch64. Slot-zeroing (which fixed the method-JIT
-// twin, bug A) cannot reach these entries. Fixing this needs a cross-arch design
-// decision (revert every loop's `[pc-8]`, or guard the loop entry); until then
-// this miscompiles (`x * x` here reads the pre-redefinition product). Un-ignore
-// once OSR-entry invalidation lands.
+// Regression (bug B): an off-stack method that stays VM-interpreted but has an
+// OSR/loop-JIT'd hot loop must not re-enter the stale loop body after a
+// basic-op redefinition. The compiled loop entry lives in the bytecode
+// (`BytecodePtr::write2`, `[pc+8]`) and the VM's `loop_start` handler branches
+// to it with no version check, and nothing reverts OSR bytecode-PC entries —
+// so the protection is the `remove_vm_bop_optimization` dispatch-table swap
+// that replaces `loop_start` with the no-opt handler (plain advance+dispatch),
+// making stale OSR entries unreachable. x86 always had that swap
+// (`dispatch[14] = vm_loop_start_no_opt`); the aarch64
+// `remove_vm_bop_optimization` was missing it, so `x * x` here kept returning
+// the pre-redefinition product (14700 instead of 300000).
 #[test]
-#[ignore = "bug B: off-stack OSR loop-JIT ignores BOP redefine (pre-existing, cross-arch)"]
 fn redefine_bop_offstack_osr_loop() {
     run_test(
         r##"
@@ -199,6 +198,150 @@ fn redefine_bop_offstack_osr_loop() {
           def *(o); 1000; end
         end
         osr_sum(7)
+        "##,
+    );
+}
+
+// Same, with a *folded* loop body (`7 * 7` bakes 49 at compile time with no
+// runtime trace). Historically this exact case was protected on aarch64 by a
+// compensating per-execution `CheckBOP` before every folded op; that guard is
+// now gone (the dispatch-table swap covers it method-wide), so this test pins
+// the fold variant against regressions in the swap.
+#[test]
+fn redefine_bop_offstack_osr_loop_fold() {
+    run_test(
+        r##"
+        def osr_fold_sum
+          total = 0
+          i = 0
+          while i < 300
+            total = total + (7 * 7)
+            i = i + 1
+          end
+          total
+        end
+        osr_fold_sum
+        class Integer
+          def *(o); 1000; end
+        end
+        osr_fold_sum
+        "##,
+    );
+}
+
+// Regression (bug C): an ON-STACK caller must not resume its stale compiled
+// body after a callee redefines a basic op. Two aarch64 gaps conspired here:
+// (1) `emit_call` did not register normal calls' return addresses, so
+// `immediate_eviction` could not patch the caller's return continuation
+// (x86 registers every call); (2) arch-neutral: the `check_bop_redefine`
+// eviction ran *before* the store mutation (and only on the `def` path), so
+// the very definition that set the BOP flags never triggered it — it only ran
+// on the *next* def, one redefinition too late. The eviction now fires inside
+// the `Executor::add_method` / `add_method_with_original` /
+// `alias_method_for_class` funnel (after the store mutation, before the
+// `method_added` hook), covering every definition route. With both fixed, the
+// caller deopts when the callee returns, and the redefined `+` is observed
+// (999, not the stale inline 8).
+#[test]
+fn redefine_bop_onstack_caller() {
+    run_test(
+        r##"
+        $flag = false
+        def maybe_redefine
+          if $flag
+            Integer.class_eval("def +(o); 999; end")
+          end
+          nil
+        end
+        def parent_dyn(a, b)
+          maybe_redefine
+          a + b        # non-fold inline add after the call
+        end
+        def parent_fold
+          maybe_redefine
+          5 + 3        # constant fold after the call
+        end
+        100.times { parent_dyn(5, 3); parent_fold }
+        $flag = true
+        [parent_dyn(5, 3), parent_fold]
+        "##,
+    );
+}
+
+// Same on-stack scenario reached through a GENERIC `yield` instead of a method
+// call: the yielded block redefines the basic op, and the yielding frame must
+// deopt on resume instead of running its stale compiled continuation. On
+// aarch64, `emit_yield` historically ignored its `evict` (only method calls /
+// specialized calls registered return addresses) — which both left
+// yield-suspended frames un-evictable AND broke `emit_immediate_evict`'s
+// same-block-registration invariant (AsmEvict ids restart per block; a generic
+// yield's `ImmediateEvict` would read a stale same-id entry from an earlier
+// block's call and hijack that unrelated call site's patch point). The fix
+// registers the yield's block-call return address exactly like x86.
+#[test]
+fn redefine_bop_onstack_yield() {
+    run_test(
+        r##"
+        def m_dyn(a, b)
+          yield
+          a + b
+        end
+        def m_fold
+          yield
+          5 + 3
+        end
+        100.times { m_dyn(5, 3) {}; m_fold {} }
+        r1 = m_dyn(5, 3) { Integer.class_eval("def +(o); 999; end") }
+        r2 = m_fold {}
+        [r1, r2]
+        "##,
+    );
+}
+
+// Same on-stack scenario, but the basic op is redefined WITHOUT the `def`
+// keyword: via `Module#define_method` and via `alias_method`. These set the
+// BOP flags through `insert_method` exactly like `def`, but historically only
+// the `def` bytecode path ran the eviction check — the funnel placement in
+// `Executor::add_method` / `alias_method_for_class` covers them.
+#[test]
+fn redefine_bop_onstack_caller_define_method_alias() {
+    run_test(
+        r##"
+        $flag = false
+        def maybe_redefine
+          if $flag
+            Integer.class_eval { define_method(:+) { |o| 999 } }
+          end
+          nil
+        end
+        def parent_dyn(a, b)
+          maybe_redefine
+          a + b
+        end
+        100.times { parent_dyn(5, 3) }
+        $flag = true
+        [parent_dyn(5, 3), parent_dyn(5, 3)]
+        "##,
+    );
+    run_test(
+        r##"
+        class Integer
+          def sub_impl(o); 777; end
+        end
+        $flag = false
+        def maybe_redefine
+          if $flag
+            Integer.class_eval { alias_method :-, :sub_impl }
+          end
+          nil
+        end
+        def parent_dyn(a, b)
+          maybe_redefine
+          a - b
+        end
+        100.times { parent_dyn(5, 3) }
+        $flag = true
+        [parent_dyn(5, 3), parent_dyn(5, 3)]
         "##,
     );
 }


### PR DESCRIPTION
Follow-up to #1003 (bug A, merged): closes every remaining path by which aarch64 JIT code could keep executing **stale inline integer arithmetic** (constant folds and the register fast path) after a basic operator (`Integer#+` etc.) was redefined — then removes the aarch64-only per-execution `CheckBOP` guard that partially compensated for those gaps. Folded constants now cost **zero runtime instructions** on aarch64, matching x86.

## The three fixes

### 1. OSR loops — one missing line ported from x86
`remove_vm_bop_optimization` (aarch64) had ported the binop/cmp/unop dispatch swaps but was **missing `dispatch[14]` (loop_start)**. x86 has always swapped it to the no-opt handler, making stale OSR loop entries unreachable after a redefine. On aarch64, a fresh frame's `loop_start` kept branching into the stale compiled loop:

```ruby
def osr_sum(x); total = 0; i = 0
  while i < 300; total = total + (x * x); i += 1; end
  total
end
osr_sum(7)                                  # OSR-compiles the loop
class Integer; def *(o); 1000; end; end
osr_sum(7)   # before: 14700 (stale)  after: 300000 (= CRuby)
```

The swap also stops post-redefine loop *compiles*, whose folds would bake stale semantics (the front-end's `binop_type` never consults BOP flags).

### 2. On-stack callers — three layers
- **aarch64**: `emit_call` ignored its `evict` → normal calls' return addresses were never registered → `immediate_eviction` couldn't patch a caller's return continuation. A JIT caller whose *callee* redefined `Integer#+` resumed its stale body (`a + b` → **8**, not 999). Now registers like x86.
- **arch-neutral (latent on x86 too)**: `check_bop_redefine` ran *before* `add_method` — the very definition that set the BOP flags never triggered eviction (one definition late), and the `Module#define_method` / `alias_method` routes never evicted at all. The check now lives in the `Executor::add_method` / `add_method_with_original` / `alias_method_for_class` **funnel** — after the store mutation, *before* the `method_added` hook — covering every definition route.
- **aarch64 generic `yield`** (found by adversarial review): `emit_yield` was the last call ignoring its `evict`. Besides leaving yield-suspended frames unevictable, it broke a subtle invariant: `AsmEvict` ids restart per basic block while `asm_return_addr_table` is never cleared, so a generic yield's `ImmediateEvict` lookup could hit a **stale same-id entry** and repoint an unrelated live call site's patch point (misexecution/crash on a later eviction). `emit_yield` now registers (x86 parity), `emit_immediate_evict` `unwrap`s so a future unregistered producer panics loudly instead of silently hijacking, and the aarch64 patchers gained imm26 range `debug_assert`s.

### 3. Drop the fold `CheckBOP` (audit item #7)
With #1003 + the above, every reach path is closed method-wide, so the compensating `#[cfg(target_arch="aarch64")] ir.check_bop` before constant-folded integer arithmetic is removed. The `check_bop` after `MethodDef`/`SingletonMethodDef` (def-inside-JIT) is **kept**.

## Tests

5 new + 1 un-ignored in `tests/redefine.rs`, all `run_test` (25× JIT-vs-VM `__assert` cross-check), each proven **non-vacuous** by neutering its fix → SIGABRT:
`redefine_bop_offstack_osr_loop` (un-ignored), `redefine_bop_offstack_osr_loop_fold`, `redefine_bop_onstack_caller`, `redefine_bop_onstack_caller_define_method_alias`, `redefine_bop_onstack_yield`. All arch-neutral, so Linux/x86-64 CI directly exercises the funnel reorder.

## Validation

- Full `cargo nextest run`: **2741/2741** (aarch64; one `signal_handling` failure in earlier runs was confirmed a parallel-load flake — 50 isolated/loaded runs green, subsequent full runs clean).
- `gc-stress` redefine: 13/13. Redefine suite re-verified after rebasing onto #1004/#1006.
- Adversarial multi-lens review (x86-impact / patch-mechanics / completeness): **GO** — x86 impact of the funnel reorder independently confirmed safe (no Ruby runs between flag-set and eviction; hooks run after eviction; patching idempotent; both `immediate_eviction` unwraps unreachable).
- Remaining residuals are **pre-existing x86-parity gaps**, not regressions (documented as follow-ups): `remove_method` / `Module#prepend` / `undef` / visibility flips never (or late) fire `set_bop_redefine`; fiber / parked-thread frames aren't evicted on either arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)