### PR TITLE
Add mdBook documentation site published to gh-pages /docs/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "doc/**"
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  MDBOOK_VERSION: v0.5.4
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          mkdir -p "$RUNNER_TEMP/mdbook"
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar xz -C "$RUNNER_TEMP/mdbook"
+          echo "$RUNNER_TEMP/mdbook" >> "$GITHUB_PATH"
+
+      - name: Build book
+        run: bash docs/build.sh
+
+      - name: Publish to gh-pages /docs/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          GH_PAGES_DIR="$RUNNER_TEMP/gh-pages"
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages > /dev/null 2>&1; then
+            git clone --depth 1 --branch gh-pages "$REPO_URL" "$GH_PAGES_DIR"
+          else
+            mkdir -p "$GH_PAGES_DIR"
+            git -C "$GH_PAGES_DIR" init -b gh-pages
+            git -C "$GH_PAGES_DIR" remote add origin "$REPO_URL"
+          fi
+
+          rm -rf "$GH_PAGES_DIR/docs"
+          cp -r docs/book "$GH_PAGES_DIR/docs"
+
+          cd "$GH_PAGES_DIR"
+          git add -A docs
+          if git diff --cached --quiet; then
+            echo "No docs changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: publish from ${GITHUB_SHA}"
+
+          # bench/spec workflows also push to gh-pages; rebase-and-retry on races
+          for i in 0 1 2 3 4; do
+            if git push -u origin gh-pages; then
+              break
+            fi
+            git pull --rebase origin gh-pages || true
+            sleep $((2 ** i))
+          done

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+book/
+src/design/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "monoruby"
+description = "Documentation for monoruby — a Ruby implementation with a JIT compiler, written in Rust"
+authors = ["sisshiki1969 and contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+site-url = "/monoruby/docs/"
+git-repository-url = "https://github.com/sisshiki1969/monoruby"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Build the documentation book (output: docs/book/).
+#
+# The "Design Documents" section of the book is sourced from ../doc at build
+# time: this script copies doc/*.md and the diagrams into src/design/ (which
+# is gitignored) and then runs `mdbook build`. Planning/handoff memos are
+# excluded. If a new design document is added to doc/, list it in
+# src/SUMMARY.md to give it a chapter.
+set -eu
+cd "$(dirname "$0")"
+
+rm -rf src/design
+mkdir -p src/design
+cp ../doc/*.md src/design/
+cp ../doc/*.svg ../doc/*.png src/design/
+rm -f src/design/handoff_record_stream.md src/design/plan-activerecord.md
+
+mdbook build

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,38 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# Architecture
+
+- [Architecture Overview](architecture-overview.md)
+- [Value Representation](value-representation.md)
+- [JIT Compiler](jit-compiler.md)
+- [Garbage Collection](garbage-collection.md)
+- [Threads and Fibers](threads-and-fibers.md)
+- [Stack Frames and Method Calls](stack-frames-and-method-calls.md)
+- [Exception Handling](exception-handling.md)
+- [aarch64 Backend](aarch64-backend.md)
+
+# Design Documents
+
+- [Stub code for JIT'ed code](design/jit.md)
+- [Unified low-level IR (LIR)](design/lir.md)
+- [Separating the abstract interpreter from register allocation](design/regalloc_separation.md)
+- [Inline asm functions](design/inline.md)
+- [JIT argument forwarding (Japanese)](design/arg_forwarding_jit.md)
+- [x86-64 / aarch64 JIT backend differences](design/arch_difference.md)
+- [GC — mechanism and implementation (Japanese)](design/gc.md)
+- [Thread / Fiber / non-blocking IO / preemption (Japanese)](design/threads.md)
+- [Thread / Fiber state transition diagrams (Japanese)](design/scheduler_state_diagram.md)
+- [Safepoints (Japanese)](design/safepoint.md)
+- [Signal handling (Japanese)](design/signal.md)
+- [Exception handling — mechanism and CRuby contrast](design/exception_handling.md)
+- [Stack layout for the interpreter / JIT'ed code](design/stack_frame.md)
+- [Method argument processing (Japanese)](design/method_args.md)
+- [Native (builtin) function registration](design/native_func.md)
+- [CREF — Class / Constant Reference](design/cref.md)
+- [super resolution via the caller PC (Japanese)](design/super_resolution.md)
+- [Per-encoding character iteration design](design/encoding_char_iteration_design.md)
+- [C extension support — design notes (Japanese)](design/c_extention.md)
+- [ruby/spec hang countermeasures (Japanese)](design/ruby_spec_skip_tags.md)
+- [Progress summary (April 2025 – April 2026)](design/progress_2025-2026.md)

--- a/docs/src/aarch64-backend.md
+++ b/docs/src/aarch64-backend.md
@@ -1,0 +1,39 @@
+monoruby runs natively on **aarch64** — macOS on Apple Silicon is fully supported (VM tier + JIT), and CI runs on GitHub's Apple Silicon runners. The aarch64 backend was ported in mid-2026 and lowers the **complete** instruction set: it never declines a compilation. This page is an overview; the detailed comparison is [`doc/arch_difference.md`](design/arch_difference.md).
+
+## How the backends are organized
+
+```
+codegen/jitgen/                 arch-neutral front-end: bytecode → TraceIR → AsmIR
+codegen/jitgen/asmir/           arch-neutral lowering dispatcher (compile_asmir → LIR)
+codegen/arch/x86_64/            x86-64 backend: VM tier, invokers, wrappers, encode_linst
+codegen/arch/aarch64/           aarch64 backend: same structure, mirrored file layout
+```
+
+Everything above machine-code emission is shared. The arch-neutral dispatcher lowers each `AsmInst` either through common code paths built on small per-arch emission primitives (`emit_reg_move`, `emit_guard_class`, `emit_integer_binop`, …) or into arch-neutral **LIR**, which each architecture encodes with its own `encode_linst` (selected by `cfg(target_arch)`, no dynamic dispatch). Machine code is emitted with the [monoasm](https://github.com/sisshiki1969/monoasm) dynamic assembler, which provides both `monoasm!` (x86-64) and `monoasm_arm64!` DSLs.
+
+## Full coverage — no bail
+
+Historically the aarch64 port could "bail" (fall back to the VM) on instructions it didn't yet support — almost always because an offset didn't fit AArch64's 12-bit immediate encodings. Today every `AsmInst` and every side exit is lowered: displacements that fit are folded into `ldur`/`stur`/scaled `ldr`/`str`, and larger frame/field/sp offsets are **materialized through reserved scratch registers** (`x9`/`x10`). The `bool` "decline" return still present in some lowering signatures is vestigial.
+
+## Register mapping
+
+| Role | x86-64 | aarch64 |
+| --- | --- | --- |
+| `&mut Executor` | `rbx` | `x19` |
+| `&mut Globals` | `r12` | `x20` |
+| Program counter | `r13` | `x21` |
+| Local frame pointer (LFP) | `r14` | `x22` |
+| (former accumulator slot) | `r15` | `x23` |
+| Scratch for lowering temps | — | `x9`–`x15` |
+
+The C-call ABIs differ (arguments in `rdi/rsi/rdx/…` vs `x0..x7`), so call-argument lowering shuffles into the ABI registers explicitly rather than using a 1:1 map.
+
+## Remaining differences
+
+Correctness and instruction coverage are identical across the two backends; the few remaining asymmetries only affect *transition costs* around recompilation (e.g. how a class-version guard miss recovers: x86-64 patches and recompiles in place in some paths where aarch64 deopts and re-JITs via warm-up counters). These are catalogued, with rationale, in [`doc/arch_difference.md`](design/arch_difference.md).
+
+## Building and testing on aarch64
+
+- On Apple Silicon macOS, a normal `cargo build` produces a native binary (Homebrew `libffi` + `pkg-config` are required — see the target-specific dependency block in `monoruby/Cargo.toml`).
+- From an x86-64 Linux host, `bin/setup-aarch64-cross` sets up a cross toolchain and `bin/test-aarch64` runs the test suite under emulation.
+- CI runs the full test scope natively on `macos-latest` (Apple Silicon) for every push and pull request.

--- a/docs/src/architecture-overview.md
+++ b/docs/src/architecture-overview.md
@@ -1,0 +1,91 @@
+monoruby is a Ruby implementation written from scratch in Rust, featuring a register-based bytecode VM and a just-in-time (JIT) compiler. It has no dependency on CRuby or any other Ruby runtime. This page gives a bird's-eye view of the system; each section links to a dedicated chapter and to the detailed design documents (rendered in the "Design Documents" section of this book, sourced from the repository's [`doc/`](https://github.com/sisshiki1969/monoruby/tree/master/doc) directory).
+
+## Compilation pipeline
+
+```
+Ruby source
+    │
+    ▼
+prism (ruby-prism)      prism syntax tree — the official Ruby parser
+    │
+    ▼
+parser/ + ast/          monoruby AST
+    │
+    ▼
+bytecodegen/            register-based bytecode
+    │
+    ▼
+Executor (VM)           interpreted execution, machine-code VM tier
+    │  when hot (≥20 calls / ≥100 loop iterations)
+    ▼
+JIT: TraceIR            type-annotated IR built from inline-cache feedback
+    │
+    ▼
+JIT: AsmIR              register-allocated, arch-neutral assembly IR
+    │
+    ▼
+codegen/arch/<arch>     AsmIR → machine code (x86-64 / aarch64 backends)
+    │
+    ▼
+monoasm                 self-made dynamic assembler
+    │
+    ▼
+Native machine code
+```
+
+Ruby source is parsed by [prism](https://github.com/ruby/prism) (consumed as the `ruby-prism` crate) and converted into monoruby's own AST. The AST is compiled into register-based bytecode, which the VM executes. Hot methods (≥ 20 calls) and hot loops (≥ 100 iterations) are handed to the JIT, which uses runtime type feedback to produce specialized machine code, falling back to the VM through deoptimization when its assumptions are invalidated. See [JIT Compiler](jit-compiler.md) for details.
+
+## Execution tiers
+
+- **VM tier** — the bytecode executor. Its dispatch loop and operation handlers are themselves emitted as machine code through monoasm (per target architecture), rather than being a Rust `match` loop.
+- **JIT tier** — specialized machine code per method / loop, guarded by type and class-version checks. Both x86-64 and aarch64 lower the full instruction set; see [aarch64 Backend](aarch64-backend.md).
+
+## Major subsystems
+
+| Subsystem | Chapter | Design documents |
+| --- | --- | --- |
+| Value representation (64-bit tagged union) | [Value Representation](value-representation.md) | — |
+| JIT compiler (TraceIR / AsmIR / register allocation) | [JIT Compiler](jit-compiler.md) | [`jit.md`](design/jit.md), [`lir.md`](design/lir.md), [`regalloc_separation.md`](design/regalloc_separation.md) |
+| Garbage collection (generational mark-and-sweep) | [Garbage Collection](garbage-collection.md) | [`gc.md`](design/gc.md) |
+| Green threads and fibers | [Threads and Fibers](threads-and-fibers.md) | [`threads.md`](design/threads.md) |
+| Stack frames and method calls | [Stack Frames and Method Calls](stack-frames-and-method-calls.md) | [`stack_frame.md`](design/stack_frame.md), [`method_args.md`](design/method_args.md) |
+| Exception handling | [Exception Handling](exception-handling.md) | [`exception_handling.md`](design/exception_handling.md) |
+| aarch64 (Apple Silicon) backend | [aarch64 Backend](aarch64-backend.md) | [`arch_difference.md`](design/arch_difference.md) |
+
+## Source layout
+
+```
+monoruby/                   workspace root
+├── monoruby/src/
+│   ├── parser/, ast/       prism → monoruby-AST bridge, AST definitions
+│   ├── bytecodegen/        AST → register-based bytecode
+│   ├── executor/           bytecode interpreter (VM), frames, operator dispatch
+│   ├── codegen/            JIT compiler
+│   │   ├── jitgen/         bytecode → TraceIR → AsmIR (arch-neutral front-end)
+│   │   └── arch/           per-arch backends: x86_64/ and aarch64/
+│   ├── value.rs, value/    Value type and heap objects (RValue)
+│   ├── alloc.rs            garbage collector
+│   ├── globals/            global interpreter state, function/class tables
+│   └── builtins/           built-in Ruby classes implemented in Rust
+├── monoruby/builtins/      built-in library code written in Ruby
+├── monoruby_attr/          proc macros (#[monoruby_builtin], …)
+├── rubymap/, hashbrown/    order-preserving hash map for Ruby Hash
+└── doc/                    detailed design documents
+```
+
+## Key global registers (JIT / VM tier)
+
+On x86-64, JIT-compiled code keeps interpreter state in fixed registers (the aarch64 backend uses an equivalent fixed assignment):
+
+| Register | Holds |
+| --- | --- |
+| `rbx` | `&mut Executor` |
+| `r12` | `&mut Globals` |
+| `r13` | program counter |
+| `r14` | local frame pointer (LFP) |
+
+## Further reading
+
+- [Build and Install](https://github.com/sisshiki1969/monoruby/wiki/Build-and-Install) — how to build and run monoruby
+- [Build options for performance tuning](https://github.com/sisshiki1969/monoruby/wiki/Build-options-for-performance-tuning) — bytecode / TraceIR / assembly dumps
+- [`doc/` directory](https://github.com/sisshiki1969/monoruby/tree/master/doc) — the full set of design documents, including C-extension design notes, encoding design, and progress notes

--- a/docs/src/exception-handling.md
+++ b/docs/src/exception-handling.md
@@ -1,0 +1,30 @@
+monoruby's exception machinery is built around **laziness**: at `raise` time it stores the minimum needed to unwind, and defers every expensive step — building the Ruby exception object, walking callers, formatting strings — until (and unless) something actually asks for it. This page is an overview; the full design document, including a detailed contrast with CRuby, is [`doc/exception_handling.md`](design/exception_handling.md).
+
+## In-flight errors
+
+While an exception is propagating it is **not a Ruby object** but a Rust struct, `MonorubyErr`, stored in the executor. Its kind covers both real exceptions (`TypeError`, `NameError`, `ArgumentError`, …, plus `Other(ClassId)` for user classes) and **control-flow pseudo-exceptions**: `MethodReturn` (non-local `return`), `BlockBreak`, `Throw` (`Kernel#throw`), `Retry`, and `Redo`. Both families share one unwinder, mirroring how CRuby routes `break`/`return` through its `THROW_DATA` tags.
+
+## Unwinding
+
+The unwinder runs once per frame. For each interpreted frame it:
+
+1. Dispatches control-flow kinds first — `return`/`break`/`throw`/`retry`/`redo` are resolved **before** any backtrace capture, so non-local control flow never pays for a backtrace or allocates an exception object.
+2. Records the frame's source location into the incremental trace (frames are being destroyed, so this is the only chance).
+3. Consults the function's **exception table** for the innermost region covering the current pc, yielding a rescue target, an ensure target, and the slot for the error value. Rescue jumps materialize the exception object and set `$!`; ensure jumps *defer* the in-flight unwind, resuming it when the ensure body finishes (a new exception raised inside `ensure` supersedes the deferred one).
+4. Otherwise returns the error to the caller frame and repeats.
+
+`$!` is scoped per rescue region: its previous value is saved on region entry and restored on exit, so nested and non-local exits observe CRuby's semantics.
+
+## Lazy backtraces
+
+Backtrace cost is split into three deferred stages: frames between raise and rescue are captured incrementally during unwinding; frames *above* the rescuer are filled in only at the catch point (the last moment the stack is coherent), by walking each caller's saved call-site pc — the same mechanism behind `Kernel#caller`; and formatting into strings happens only when `Exception#backtrace` is first called, then is memoized. CRuby, by contrast, captures the full backtrace eagerly at raise time. The practical result: `rescue`-based control flow in hot code is far cheaper than in CRuby, and `StopIteration` under `Kernel#loop` is caught at the Rust level with near-zero cost.
+
+## Exception objects
+
+The Ruby exception object is created only at a catch point or at top level. Re-raising an exception object preserves its identity; implicit `cause` chaining from `$!` and the explicit `raise ..., cause:` keyword follow CRuby's rules. Class-specific payloads (`LoadError#path`, `SystemExit#status`, `NoMethodError#name`/`#receiver`, …) ride along as hidden instance variables.
+
+Native builtins participate through a simple protocol: a builtin returns a `Result<Value>`, and on error the `#[monoruby_builtin]` wrapper stores the `MonorubyErr` in the executor and returns a sentinel that routes into the same unwinder.
+
+## Further reading
+
+- [`doc/exception_handling.md`](design/exception_handling.md) — full mechanism, exception-table format, `$!` restoration, ensure deferral, and the CRuby (`catch_table` / `THROW_DATA`) comparison

--- a/docs/src/garbage-collection.md
+++ b/docs/src/garbage-collection.md
@@ -1,0 +1,46 @@
+monoruby has its own garbage collector: a **non-moving, single-threaded, stop-the-world, generational mark-and-sweep** collector, modeled on CRuby's RGenGC. This page is an overview; the full design document is [`doc/gc.md`](design/gc.md), and the implementation lives in [`monoruby/src/alloc.rs`](https://github.com/sisshiki1969/monoruby/blob/master/monoruby/src/alloc.rs).
+
+## Heap layout
+
+- All heap objects (`RValue`) are exactly **64 bytes**. Memory comes from a single 2 GB virtual arena reserved up front, carved into **256 KB pages** of 4032 cells each.
+- Mark bits and old bits are stored **outside** the object cells, as per-page bitmaps. A pointer's page is found with a single address mask, so bitmap lookup is O(1).
+- Objects **never move**, so raw `*const RValue` pointers stay valid across collections.
+- Allocation pops from a free list when possible, otherwise bump-allocates in the current page. The JIT inlines this free-list fast path directly into compiled code.
+
+## Generational collection
+
+Minor collections trace only young objects; old objects are assumed live and their mark bits are seeded from the old bitmap.
+
+- Objects of promotable types (Object, String, Array, Hash, Bignum, Float, Struct) age by one on each minor GC they survive; at **age 3** they are promoted to the old generation.
+- **Write barrier**: when a reference is stored into an old object, a single header-bit test decides whether the object must enter the **remembered set**, whose old→young edges are traced during minor GCs. The JIT emits the barrier inline; bulk operations (`Array#concat`, …) use a bulk variant.
+- A **major** (full) collection runs when the old-object count crosses an adaptive threshold or after 64 consecutive minors; it clears all generation state and retraces everything. `GC.start` always forces a major.
+
+![Object state transitions](design/gc_state_transitions.svg)
+
+The write-barrier / remembered-set interaction (including why a minor GC without the barrier would sweep live objects) is illustrated in [`doc/gc_write_barrier.svg`](design/gc_write_barrier.svg).
+
+## GC triggers and safepoints
+
+Collections are requested by setting a single per-thread `alloc_flag`, and *performed* only at **safepoints**:
+
+- **Allocation pressure** — every ~8 filled pages trips the flag.
+- **malloc pressure** — a custom `#[global_allocator]` tracks off-heap allocation (String/Array backing stores etc.) and requests a GC when it outgrows an adaptive threshold, so heavy malloc traffic can't outrun the heap-cell trigger.
+- **Explicit** — `GC.start`.
+
+Safepoint polls (`compare alloc_flag; conditionally call gc`) are emitted at **callee entry and loop back-edges** in both the VM tier and JIT code. The same poll also drives green-thread preemption and pending-signal delivery (see [Threads and Fibers](threads-and-fibers.md)). Rooting is **precise**: roots are explicitly enumerated — the executor's frame chain, temporary-value stack, the green-thread scheduler's thread registry, pending exceptions, and global state — never conservatively scanned off the machine stack; JIT code spills live registers before a safepoint call.
+
+## Controlling the GC
+
+| Control | Effect |
+| --- | --- |
+| `GC.start` | Force a full (major) collection |
+| `GC.enable` / `GC.disable` | Toggle collection at runtime |
+| `--no-gc` CLI flag | Disable GC for the process |
+| `GC.count` / `GC.stat` | Collection counters / CRuby-compatible stats |
+
+Debugging Cargo features: `gc-log` (stats at exit), `gc-debug` (assertions), `gc-stress` (collect on every allocation — used by `bin/test` in CI), `gc-verify` (independent re-mark verification after each minor GC).
+
+## Further reading
+
+- [`doc/gc.md`](design/gc.md) — full design document (heap layout, bitmaps, aging/promotion, remembered-set self-cleaning, heap-escaped frame reclamation)
+- [`doc/safepoint.md`](design/safepoint.md) — the safepoint / poll-flag mechanism shared by GC, preemption, and signals

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,16 @@
+# monoruby
+
+[monoruby](https://github.com/sisshiki1969/monoruby) is a Ruby implementation written from scratch in Rust, featuring a register-based bytecode VM and a just-in-time (JIT) compiler for x86-64 and aarch64 (Apple Silicon). It is fast — comparable to CRuby with YJIT/ZJIT on many benchmarks — and has no dependency on any other Ruby runtime.
+
+This site documents monoruby's internals.
+
+- The **Architecture** section contains overview pages: start with the [Architecture Overview](architecture-overview.md).
+- The **Design Documents** section renders the full design documents from the repository's [`doc/`](https://github.com/sisshiki1969/monoruby/tree/master/doc) directory (some are written in Japanese, as marked).
+
+## Related resources
+
+- [README](https://github.com/sisshiki1969/monoruby#readme) — features, installation, monthly changelog
+- [Build and Install](https://github.com/sisshiki1969/monoruby/wiki/Build-and-Install) — build instructions (wiki)
+- [Benchmark results](https://sisshiki1969.github.io/monoruby/bench/) — continuously updated yjit-bench comparison
+- [ruby/spec dashboard](https://sisshiki1969.github.io/monoruby/spec/) — spec compliance for this repository
+- [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/) — daily ruby/spec pass rates across Ruby implementations

--- a/docs/src/jit-compiler.md
+++ b/docs/src/jit-compiler.md
@@ -1,0 +1,52 @@
+monoruby executes bytecode in the VM until code gets hot, then compiles it to specialized machine code. This page is an overview; the detailed documents are [`doc/jit.md`](design/jit.md) (stub/bridge code), [`doc/lir.md`](design/lir.md) (the low-level IR), [`doc/regalloc_separation.md`](design/regalloc_separation.md) (register allocation), and [`doc/inline.md`](design/inline.md) (inline builtins).
+
+## When compilation triggers
+
+- **Method JIT** — after ≥ 20 calls (`COUNT_START_COMPILE`; 5 in test mode)
+- **Loop JIT** — after ≥ 100 iterations of a loop (`COUNT_LOOP_START_COMPILE`; 15 in test mode), compiling the enclosing method from the loop entry
+
+Each function starts with a small *wrapper* that decrements a counter and falls through to the VM until the counter expires, then triggers compilation and patches itself.
+
+## IR pipeline
+
+```
+bytecode ──abstract interpretation──▶ TraceIR ──▶ AsmIR ──▶ LIR ──▶ machine code (monoasm)
+                (type feedback from inline caches)        (per-arch encoder)
+```
+
+- **TraceIR** — bytecode annotated with type information gathered from the VM tier's inline caches.
+- **AsmIR** (`AsmInst`) — arch-neutral, register-allocated assembly IR produced by an abstract interpreter that tracks, per slot, whether a value lives on the stack, in a floating-point register (unboxed `f64`), both, or is a compile-time constant (`LinkMode`).
+- **LIR** (`LInst`) — arch-neutral machine-level ops with offsets and labels resolved; the single seam where bytes are emitted. Each architecture implements one `encode_linst` (see [aarch64 Backend](aarch64-backend.md)).
+
+## Specialization and inline caches
+
+Compiled code is specialized **per receiver class**. The method entry is a chain of self-class guard stubs: each guard tests the receiver's class and jumps to the machine code compiled for that class; a miss falls through to the next guard or to the VM. Method calls inside JIT code are resolved through inline caches and guarded by a **class-version** check, so redefining a method invalidates dependent code. Small hot builtins (`Array#[]`, `Integer` arithmetic, `Math.sqrt`, `Object#is_a?`, `Struct` accessors, `Class#new`, `Fiber.yield`, …) are inlined directly by generator functions that can both consult the abstract state (folding results at compile time when types are proven) and emit code; a failed inline attempt rolls back cleanly and falls back to a normal call. Monomorphic methods can additionally be **specialized inline** — the callee's frame is inlined into the caller.
+
+## Deoptimization and recompilation
+
+JIT code is speculative. Guards — receiver class, class version, array type, frozen state, fixnum overflow, basic-operator (BOP) redefinition, frame capture — branch to **side exits** that write register-resident values back to the frame and resume in the VM at the equivalent program point. Repeated deopts trigger **recompilation** with the newly observed classes (e.g. polymorphic call sites, `method_missing` dispatch, newly resolved constants/ivars). Deopt logging is available with the `deopt` Cargo feature, recompile/deopt statistics with `profile`.
+
+## Register allocation
+
+- **Floating point** — virtual FP registers (`VirtFPReg`) allocated greedily over the physical pool (14 xmm registers on x86-64), with automatic **spill-to-stack** when the pool is exhausted; loop entries specialize float-typed slots so hot numeric loops keep values unboxed in registers.
+- **General purpose** — a per-basic-block local GP register allocator keeps boxed values (notably Fixnums) in a small pool of scratch registers within a block, eliding redundant fixnum guards, and flushes the pool at calls and GC safepoints (pool registers are not GC roots).
+
+The long-form design discussion — separating type inference from placement, the retirement of the dedicated accumulator register, and measured results — is in [`doc/regalloc_separation.md`](design/regalloc_separation.md) and [`doc/lir.md`](design/lir.md).
+
+## Argument forwarding (D1)
+
+`def f(...)` forwarding is compiled as an opaque pipe: for simple callees the rest-Array / keyword-Hash allocation is elided entirely and arguments are copied (or lazily deferred) straight from the caller's frame, with deopt-safe lazy materialization if a side exit or frame capture ever needs the real objects. See [`doc/arg_forwarding_jit.md`](design/arg_forwarding_jit.md).
+
+## Observing the JIT
+
+| Cargo feature | Output |
+| --- | --- |
+| `dump-bc` / `emit-bc` | bytecode |
+| `dump-traceir` | TraceIR |
+| `emit-asm` | generated assembly |
+| `jit-log` / `jit-debug` | compilation events / detailed debug |
+| `deopt` | deoptimization log |
+| `profile` | deopt & recompile statistics |
+| `perf` | perf-compatible symbol maps |
+
+The JIT is always built in; disable it at runtime with `--no-jit`. See [Build options for performance tuning](https://github.com/sisshiki1969/monoruby/wiki/Build-options-for-performance-tuning) for example output.

--- a/docs/src/stack-frames-and-method-calls.md
+++ b/docs/src/stack-frames-and-method-calls.md
@@ -1,0 +1,33 @@
+This page describes how monoruby lays out call frames and processes method arguments. Details: [`doc/stack_frame.md`](design/stack_frame.md), [`doc/method_args.md`](design/method_args.md), [`doc/cref.md`](design/cref.md), [`doc/super_resolution.md`](design/super_resolution.md).
+
+## Frame layout
+
+Each Ruby-level call pushes three contiguous regions on the native stack (growing downward):
+
+- **Continuation frame** — the caller's saved `lfp`, `pc`, return address, and `rbp`. The saved call-site pc is also what powers lazy backtraces, `Kernel#caller`, and `super` resolution.
+- **Control frame (CFP)** — `prev cfp` and `lfp`; the executor's `cfp` chain links all active frames.
+- **Local frame (LFP)** — the Ruby-visible part: `outer` (for blocks: the enclosing frame), `meta`, `block`, `self`, then the argument/local slots `arg0, arg1, …`.
+
+The bytecode interpreter and JIT code share a fixed register ABI on x86-64 (the aarch64 backend uses an equivalent assignment): `rbx` = `&mut Executor`, `r12` = `&mut Globals`, `r13` = pc, `r14` = lfp.
+
+Frames captured by blocks, Procs, or Bindings are **promoted to the heap lazily** — only when the capture actually escapes — and heap frames are reclaimed by the GC once unreachable.
+
+## Argument processing
+
+Formal parameters occupy frame slots in a fixed order: `required | optional | rest | keyword | block | destructured-children`. At call time the **caller** copies positional arguments into the callee frame, expanding splats, gathering overflow into `rest`, filling missing slots with `nil`/none-markers, and checking arity. Keyword arguments are then assigned by name, with surplus keywords gathered into the keyword-rest slot; if the callee accepts no keywords at all, trailing keywords are packed into a Hash and passed as one extra positional argument. Blocks additionally auto-splat a single Array argument when they take multiple parameters. The **callee prologue** (`InitMethod`) then links the frame, homes arguments, nil-fills the remaining slots — and runs the safepoint poll. Destructuring and optional-parameter default initializers are compiled as ordinary bytecode at the top of the method body.
+
+Built-in (native) methods declare their arity and keyword names at registration time (e.g. `define_builtin_func_with_kw(..., min, max, rest, kw)`), and receive their arguments in the same fixed slot order via `Lfp`. The `#[monoruby_builtin]` proc macro wraps a Rust `fn(vm, globals, lfp) -> Result<Value>` into the VM's calling convention, converting errors into the VM's error protocol (`vm.set_error`).
+
+## Lexical scope (CREF)
+
+Where `def`, constant lookup, and visibility land is decided by monoruby's CREF model — a compact 16-byte `Cref` struct kept on a VM-wide stack, distinguishing the *definition* context (used by `def`) from the *lexical* context (used by `module`/`class` nesting and unqualified constants). This is monoruby's counterpart to CRuby's per-frame `rb_cref_t` chain; [`doc/cref.md`](design/cref.md) contrasts the two models in depth, including how `class_eval` / `instance_eval` / `Kernel#eval` push their scopes.
+
+## `super` resolution
+
+CRuby frames carry a callable-method-entry that tells `super` both the method name to search and where in the ancestor chain to continue. monoruby frames carry only a `FuncId`, so `super` **reconstructs** that information from the caller pc saved in the continuation frame: it recovers the call site's opcode and call-site info, derives the originally-called name (correct across `alias` and multi-name `define_method`), and counts how many times the running body occurs in the ancestor chain so a method aliased into several places supers past the right occurrence. See [`doc/super_resolution.md`](design/super_resolution.md).
+
+## Further reading
+
+- [`doc/stack_frame.md`](design/stack_frame.md) — exact slot offsets, pre-call vs post-prologue layouts
+- [`doc/method_args.md`](design/method_args.md) — caller/callee argument-processing responsibilities
+- [`doc/native_func.md`](design/native_func.md) — builtin registration and argument slots

--- a/docs/src/threads-and-fibers.md
+++ b/docs/src/threads-and-fibers.md
@@ -1,0 +1,43 @@
+monoruby implements **M:1 green threads**: all Ruby `Thread`s are multiplexed onto a single OS thread that runs the VM. There is no parallel Ruby execution (and no GVL — there is simply one VM-running OS thread); short-lived helper OS threads exist only for blocking-syscall offload and the preemption timer, and they never touch the Ruby heap. This page is an overview; the full design document is [`doc/threads.md`](design/threads.md).
+
+## Scheduler
+
+The scheduler (`monoruby/src/scheduler.rs`) is a per-OS-thread singleton. Its event loop runs **on the main thread's stack**: main enters it as an ordinary function call when it parks, and returns from it when main becomes runnable again; green threads never call the loop themselves — they switch into its saved context. The scheduler tracks live threads (a GC root), a FIFO run queue, sleepers with deadlines, and fd waiters. When idle it `poll(2)`s the waited fds or sleeps to the nearest deadline; if no thread can ever run again it raises a fatal deadlock error.
+
+Context switching reuses the Fiber stack-switching machinery (`rsp` exchange): each thread gets its own 256 KiB stack with a guard page and its own `Executor`.
+
+## Cooperative and preemptive switching
+
+Switching is hybrid:
+
+- **Cooperative** — at blocking points: `sleep`, `Thread.stop`, `#join`, `Thread.pass`, blocking IO, and synchronization-primitive waits.
+- **Preemptive** — a dedicated timer OS thread ticks every **10 ms** (spawned only while ≥ 2 threads are live) and arms the shared poll flag, which acts as if the running thread called `Thread.pass` at its next safepoint. `MONORUBY_NO_PREEMPT=1` disables it; `MONORUBY_PREEMPT_STRESS=1` switches at every poll site.
+
+Both kinds of switch happen **only at VM safepoints** — the same callee-entry / loop-back-edge polls used by the GC (see [Garbage Collection](garbage-collection.md) and [`doc/safepoint.md`](design/safepoint.md)) — so a suspended thread's frames are always in a GC-complete state. A consequence: Rust builtins are atomic with respect to other threads (like C functions under CRuby's GVL), but sequences of pure-Ruby statements can interleave, so Ruby code must use locks for compound state transitions.
+
+## Blocking IO
+
+Blocking-IO builtins go through a common wrapper that checks buffered data, probes readiness with a zero-timeout poll, and otherwise **parks the thread on the scheduler's fd poller** instead of blocking the process. While other threads are live, fds are temporarily set to non-blocking so that a mid-operation would-block parks and resumes without data loss. `IO.select`, non-blocking TCP `connect`, and `accept` retry-loops are integrated with the same poller. The only truly blocking syscalls (`flock`, FIFO `open`) are offloaded to short-lived native helper threads that signal completion through a self-pipe registered with the poller.
+
+## Synchronization primitives and interrupts
+
+`Mutex`, `Queue`, `SizedQueue`, and `ConditionVariable` are implemented **in Ruby** (in `builtins/startup.rb`), relying on safepoint-free straight-line test-and-set plus a *park permit* mechanism that closes the classic lost-wakeup race. Locks abandoned by a dead thread are reclaimed by the next acquirer, and `Mutex#owned?` is per-Fiber.
+
+`Thread#kill` / `#raise` are queued and delivered by the scheduler: a parked target is woken and unwinds **from its exact blocking point** (running `ensure` blocks); a running target is caught by preemption at its next safepoint, so even busy loops are killable. `Thread.handle_interrupt` masking is honored at mask boundaries.
+
+## Fibers
+
+Threads are built on Fiber's stack switching, but the two remain distinct: Fibers form an asymmetric resume/yield chain within a thread, while the scheduler schedules threads only. A green thread may park while deep inside a nested Fiber and be resumed exactly there. Signal handling uses the same deferred safepoint model — see [`doc/signal.md`](design/signal.md).
+
+## State diagrams
+
+![Thread state transitions](design/thread_state_diagram.svg)
+
+![Fiber state transitions](design/fiber_state_diagram.svg)
+
+## Further reading
+
+- [`doc/threads.md`](design/threads.md) — full design document (scheduler internals, preemption, IO parking, sync primitives, kill/raise delivery)
+- [`doc/scheduler_state_diagram.md`](design/scheduler_state_diagram.md) — the state diagrams with commentary
+- [`doc/safepoint.md`](design/safepoint.md) — the unified GC / preemption / signal poll mechanism
+- [`doc/signal.md`](design/signal.md) — async-signal-safe handlers and deferred delivery

--- a/docs/src/value-representation.md
+++ b/docs/src/value-representation.md
@@ -1,0 +1,40 @@
+A monoruby `Value` is a 64-bit non-zero integer (`NonZeroU64`) using a **tagged-union** scheme: the lower 3 bits encode the kind of value. It is *not* NaN-boxing. Because `Value` is always a single machine word, values can live directly in VM registers, JIT machine registers, and GC-scanned stack slots.
+
+## Dispatch on the lower 3 bits
+
+| Lower bits (`& 0b111`) | Kind |
+| --- | --- |
+| `???????1` (bit 0 = 1) | **Fixnum** — integer stored in bits 63:1 as i63 (`value >> 1`) |
+| `??????10` (bits 1:0 = `10`) | **Flonum** — double-precision float encoded inline (bit-rotated) |
+| `?????000` (bits 2:0 = `000`) | **Heap pointer** — raw pointer to a GC-managed `RValue` |
+| other (bit 2 = 1, bits 1:0 ≠ `10`) | **Other immediate** — `nil` / `true` / `false` / Symbol |
+
+`is_packed_value()` tests `bits & 0b0111 != 0`; if true, the value is an immediate and `try_rvalue()` returns `None`. If false, the bits are a valid `*const RValue` pointer (RValues are 8-byte aligned, so their low 3 bits are always zero).
+
+## Immediate tag constants
+
+| Constant | Hex | Binary | Meaning |
+| --- | --- | --- | --- |
+| `NIL_VALUE` | `0x04` | `0000_0100` | `nil` |
+| `FALSE_VALUE` | `0x14` | `0001_0100` | `false` |
+| `TRUE_VALUE` | `0x1c` | `0001_1100` | `true` |
+| `TAG_SYMBOL` | `0x0c` | `0000_1100` | Symbol (`IdentId` packed in the upper 32 bits) |
+
+`FLOAT_ZERO` (`(0b1000 << 60) | 0b10`) is the flonum encoding of `0.0`.
+
+## Consequences
+
+- **Fixnum** covers 63-bit signed integers. Integer results that overflow i63 are promoted to heap-allocated Bignum objects (backed by `BigInt`).
+- **Flonum** covers most doubles; floats whose exponent falls outside the encodable range are heap-allocated as `RValue`s of class `Float`.
+- `nil` / `false` are the only falsy values, and both have bit patterns distinguishable with a single mask — which the JIT exploits for cheap truthiness tests.
+- Equality on immediates (Fixnum, Symbol, `nil`, `true`, `false`) is plain 64-bit comparison.
+
+## Heap values: `RValue`
+
+Everything that is not an immediate lives on the GC heap as an `RValue` (defined under `monoruby/src/value/rvalue/`): Strings, Arrays, Hashes, objects with instance variables, Bignums, non-flonum Floats, Ranges, Procs, Fibers, and so on. `RValue`s are allocated from the GC's page-based arena and carry the object's class, flags (including the generational-GC age bits), and kind-specific payload. See [Garbage Collection](garbage-collection.md).
+
+## Relevant source
+
+- [`monoruby/src/value.rs`](https://github.com/sisshiki1969/monoruby/blob/master/monoruby/src/value.rs) — the `Value` type and tag scheme
+- [`monoruby/src/value/numeric.rs`](https://github.com/sisshiki1969/monoruby/blob/master/monoruby/src/value/numeric.rs) — Fixnum / Flonum / BigInt helpers
+- [`monoruby/src/value/rvalue/`](https://github.com/sisshiki1969/monoruby/tree/master/monoruby/src/value/rvalue) — heap object representation


### PR DESCRIPTION
## Summary

Adds an mdBook-based documentation site, published to the project portal at https://sisshiki1969.github.io/monoruby/docs/ after merge.

- **`docs/`** — the book source, kept on master so documentation changes go through normal PR review:
  - **Architecture** section: eight new English overview pages — Architecture Overview, Value Representation, JIT Compiler, Garbage Collection, Threads and Fibers, Stack Frames and Method Calls, Exception Handling, aarch64 Backend. Each is a standalone overview that links into the full design documents.
  - **Design Documents** section: renders the existing `doc/*.md` documents (21 of them; planning/handoff memos excluded). They are copied in at build time by `docs/build.sh`, so `doc/` remains the single source of truth. Japanese documents are marked in the table of contents. The state-transition SVG diagrams render inline.
- **`.github/workflows/docs.yml`** — builds the book with mdBook v0.5.4 on pushes to master touching `doc/` or `docs/` (plus `workflow_dispatch`), and publishes it to the `gh-pages` branch under `/docs/`, following the same `GITHUB_TOKEN` clone-commit-push pattern as the bench and spec workflows, with rebase-and-retry against concurrent gh-pages pushes.

## Verification

- Built locally with mdBook v0.5.4: chapter cross-links, links into the design documents (`.md` → `.html` rewriting), and the SVG diagram embeds all resolve correctly in the generated HTML.
- Only `docs/` and one new workflow are added; no interpreter code is touched.

## Note

The gh-pages root landing page (`index.html`) does not yet link to `/docs/` — that file lives on the `gh-pages` branch and can be updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM2d5Ykdwp3zUDgbivNRjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM2d5Ykdwp3zUDgbivNRjL)_