### PR TITLE
darwin CI hang: malloc hard cap (abort with report) + death-proof heartbeat check run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,6 +173,15 @@ jobs:
         env:
           MONORUBY_MALLOC_HARD_LIMIT: 3G
           GH_TOKEN: ${{ github.token }}
+          # Experiment (2026-07-26): all three instrumented runner deaths
+          # struck inside the nextest phase at unrelated suite positions
+          # (tests #1438, #1360, #422) with memory healthy 30 s before —
+          # a fast ambient blow-up, not one culprit test. Default
+          # parallelism on the M1 runner is 3; halving it tests the
+          # parallel-interaction hypothesis and lowers peak pressure.
+          # A normal pass is ~11 min, so the ~+40% nextest time stays
+          # well under the 25-min attempt cap.
+          NEXTEST_TEST_THREADS: "2"
         with:
           timeout_minutes: 25
           max_attempts: 2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,12 @@ jobs:
           fail_ci_if_error: false
 
   darwin:
+    # checks: write lets the in-step heartbeat publish a `darwin-heartbeat`
+    # check run that SURVIVES runner death (see the Test step); contents:
+    # read is for checkout. Everything else needs no token.
+    permissions:
+      checks: write
+      contents: read
     # Native Apple Silicon (arm64-apple-darwin) runner. build.rs sets the `jit`
     # cfg on arm64 (only `jit_x86` is x86-only), so this builds and runs the
     # AArch64 JIT (AsmIR→A64 backend, asmir/compile_stub.rs) — instructions not
@@ -130,38 +136,74 @@ jobs:
       - name: Test (VM + AArch64 JIT, arm64-apple-darwin)
         # The arm64 JIT/runtime intermittently hangs by exhausting memory: the
         # macOS runner OOM-dies ("loses communication") before any stack can be
-        # captured, and when the runner dies the job's streamed logs become
-        # unavailable through the API as well — so past hangs left ZERO
-        # forensics. Guards, in order of importance:
+        # captured, and when the runner dies the job's streamed logs AND the
+        # artifact step are lost as well (confirmed 2026-07-26: a run with the
+        # in-log heartbeat still left zero forensics) — so past hangs left
+        # nothing. Guards, in order of importance:
+        #   * MONORUBY_MALLOC_HARD_LIMIT=3G (env below): monoruby's global
+        #     allocator aborts WITH a size report + backtrace the moment an
+        #     allocation would exceed 3 GB. Unlike any polling watchdog this
+        #     also catches a single multi-GB request, and nextest then names
+        #     the aborted test. This is the primary defense.
+        #   * a `darwin-heartbeat` check run updated every ~60 s from inside
+        #     the step (last log lines + memory trajectory + any watchdog
+        #     forensics). It lives on the GitHub side, so it SURVIVES runner
+        #     death — the progress log of record for silent hangs.
         #   * retry — cap each attempt at 25 min and retry once, so a clean
         #     hang fails fast (normal pass ~11 min) and the rerun recovers;
-        #   * a background memory watchdog that must fire BEFORE the runner
-        #     dies. It watches every monoruby AND ruby process (bin/test diffs
-        #     against CRuby and runs mspec, so the hog can be either side) and
-        #     additionally the system-wide free memory: it fires when one
-        #     process exceeds ~3 GB, the watched sum exceeds ~4 GB, or free
-        #     memory drops under ~700 MB while a watched process exists. On
-        #     firing it logs the last [phase] marker + the culprit's command
-        #     line, `sample`s its stack, and kills it (the retry recovers);
-        #   * a 30-second heartbeat line (elapsed / free memory / top process /
-        #     tail of the test log) so even a log truncated by runner death
-        #     shows how far the run got and how memory moved — this is the
-        #     "progress log" for otherwise-silent hangs;
-        #   * bin/test output is tee'd to $RUNNER_TEMP and uploaded as an
-        #     artifact even on failure (see the next step), which preserves the
-        #     full log of a timed-out attempt that the retry then recovered.
+        #   * a background memory watchdog: watches every monoruby AND ruby
+        #     process (bin/test diffs against CRuby and runs mspec) plus the
+        #     system-wide free memory; fires at >3 GB per process / >4 GB
+        #     watched sum / <700 MB free, logs the last [phase] marker + the
+        #     culprit's command line, `sample`s its stack, kills it;
+        #   * a 30-second heartbeat line in the streamed log, and bin/test
+        #     output tee'd to $RUNNER_TEMP + uploaded as an artifact when the
+        #     runner survives (preserves the log of a timed-out attempt that
+        #     the retry then recovered).
         # Per-test hangs inside the nextest phase are additionally named and
         # killed by .config/nextest.toml (slow-timeout terminate-after).
         # The manual .github/workflows/darwin-hang-debug.yml drives the same
         # idea in a loop for active reproduction.
         uses: nick-fields/retry@v3
+        env:
+          MONORUBY_MALLOC_HARD_LIMIT: 3G
+          GH_TOKEN: ${{ github.token }}
         with:
           timeout_minutes: 25
           max_attempts: 2
           command: |
             set -o pipefail
             LOG="$RUNNER_TEMP/bin-test-attempt-$(date -u +%H%M%S).log"
+            FORENSICS="$RUNNER_TEMP/watchdog-forensics.log"
+            CR_ID_FILE="$RUNNER_TEMP/hb-checkrun-id"
             echo "attempt log: $LOG"
+            # Durable heartbeat: a neutral check run on the head commit,
+            # PATCHed with the latest progress. It survives runner death.
+            HB_SHA=$(jq -r '.pull_request.head.sha // .after // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+            HB_SHA=${HB_SHA:-$GITHUB_SHA}
+            hb_post() {
+              [ -n "${GH_TOKEN:-}" ] || return 0
+              if [ ! -s "$CR_ID_FILE" ]; then
+                curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/$GITHUB_REPOSITORY/check-runs" \
+                  -d "{\"name\":\"darwin-heartbeat\",\"head_sha\":\"$HB_SHA\",\"status\":\"completed\",\"conclusion\":\"neutral\"}" \
+                  | jq -r '.id // empty' > "$CR_ID_FILE" 2>/dev/null || true
+              fi
+              hbid=$(cat "$CR_ID_FILE" 2>/dev/null || true)
+              [ -n "$hbid" ] || return 0
+              { if [ -s "$FORENSICS" ]; then
+                  echo '### watchdog forensics'; echo '```'; tail -c 20000 "$FORENSICS"; echo '```'
+                fi
+                echo '### bin/test log tail'; echo '```'; tail -n 120 "$LOG" 2>/dev/null || true; echo '```'
+              } > "$RUNNER_TEMP/hb-body.md"
+              jq -n --arg s "$1" --rawfile t "$RUNNER_TEMP/hb-body.md" \
+                '{output:{title:"darwin bin/test heartbeat (survives runner death)",summary:$s,text:($t|.[0:60000])}}' \
+                | curl -sf -X PATCH -H "Authorization: Bearer $GH_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/repos/$GITHUB_REPOSITORY/check-runs/$hbid" \
+                    -d @- > /dev/null 2>&1 || true
+            }
             RSS_LIMIT_KB=3000000
             SUM_LIMIT_KB=4000000
             SYS_FREE_FLOOR_KB=700000
@@ -182,23 +224,30 @@ jobs:
                   '/Pages free/ {f=$3} /Pages inactive/ {i=$3} /Pages purgeable/ {p=$3} END {print (f+i+p)*16}')
                 if [ "${toprss:-0}" -gt "$RSS_LIMIT_KB" ] || [ "${sum:-0}" -gt "$SUM_LIMIT_KB" ] \
                    || { [ "${freekb:-999999999}" -lt "$SYS_FREE_FLOOR_KB" ] && [ "${toppid:-0}" -gt 0 ]; }; then
-                  echo "==================== MEMORY WATCHDOG fired @ $(date -u +%H:%M:%S) ===================="
-                  echo "sys_free_kb=$freekb sum_rss_kb=$sum top=$topcmd pid=$toppid rss_kb=$toprss"
-                  echo "(caps: per-proc=$RSS_LIMIT_KB sum=$SUM_LIMIT_KB sys-floor=$SYS_FREE_FLOOR_KB)"
-                  echo "---- last phase reached ----"; grep '^\[phase' "$LOG" 2>/dev/null | tail -1 || true
-                  echo "---- watched processes (pid rss_kb etime command) ----"
-                  ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }'
-                  echo "---- CULPRIT command line (pid $toppid) ----"; ps -p "$toppid" -o command= 2>/dev/null || true
-                  echo "---- sample pid $toppid (2s) ----"; /usr/bin/sample "$toppid" 2 2>&1 | sed -n '1,160p' || true
-                  echo "---- killing pid $toppid ----"; kill -9 "$toppid" 2>/dev/null || true
+                  { echo "==================== MEMORY WATCHDOG fired @ $(date -u +%H:%M:%S) ===================="
+                    echo "sys_free_kb=$freekb sum_rss_kb=$sum top=$topcmd pid=$toppid rss_kb=$toprss"
+                    echo "(caps: per-proc=$RSS_LIMIT_KB sum=$SUM_LIMIT_KB sys-floor=$SYS_FREE_FLOOR_KB)"
+                    echo "---- last phase reached ----"; grep '^\[phase' "$LOG" 2>/dev/null | tail -1 || true
+                    echo "---- watched processes (pid rss_kb etime command) ----"
+                    ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }'
+                    echo "---- CULPRIT command line (pid $toppid) ----"; ps -p "$toppid" -o command= 2>/dev/null || true
+                    echo "---- sample pid $toppid (2s) ----"; /usr/bin/sample "$toppid" 2 2>&1 | sed -n '1,160p' || true
+                    echo "---- killing pid $toppid ----"; kill -9 "$toppid" 2>/dev/null || true
+                  } 2>&1 | tee -a "$FORENSICS"
+                  hb_post "WATCHDOG FIRED $(date -u +%H:%M:%S): top=$topcmd rss_kb=${toprss:-0} sys_free_kb=${freekb:-?}"
                   sleep 8
                 fi
                 pass=$((pass+1))
                 if [ $((pass % 8)) -eq 0 ]; then
-                  printf '[hb %s +%ss] sys_free_kb=%s watched_sum_kb=%s top=%s(%sKB) tail: %s\n' \
+                  gtop=$(ps -Ao pid,rss,comm -m 2>/dev/null | awk 'NR==2 {n=split($3,a,"/"); print a[n]"("$2"KB)"}')
+                  hbline=$(printf '[hb %s +%ss] sys_free_kb=%s watched_sum_kb=%s top=%s(%sKB) global_top=%s tail: %s' \
                     "$(date -u +%H:%M:%S)" "$(( $(date +%s) - t0 ))" "${freekb:-?}" "$sum" \
-                    "$topcmd" "${toprss:-0}" \
-                    "$(tail -c 400 "$LOG" 2>/dev/null | tr '\n' ' ' | tail -c 160)"
+                    "$topcmd" "${toprss:-0}" "${gtop:--}" \
+                    "$(tail -c 400 "$LOG" 2>/dev/null | tr '\n' ' ' | tail -c 160)")
+                  echo "$hbline"
+                  if [ $((pass % 16)) -eq 0 ]; then
+                    hb_post "$hbline"
+                  fi
                 fi
                 sleep 4
               done ) &

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      # Backstop + coverage: a runaway allocation aborts with a report here
+      # too (the 16 GB Linux runner survives OOM better, but a named crash
+      # still beats a thrashing one), and having the limit set exercises the
+      # cap's init + hot-path compare under the coverage run.
+      MONORUBY_MALLOC_HARD_LIMIT: 6G
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,10 +197,14 @@ jobs:
               fi
               hbid=$(cat "$CR_ID_FILE" 2>/dev/null || true)
               [ -n "$hbid" ] || return 0
-              { if [ -s "$FORENSICS" ]; then
-                  echo '### watchdog forensics'; echo '```'; tail -c 20000 "$FORENSICS"; echo '```'
+              { echo '### in-flight monoruby/ruby processes (nextest passes the test name in argv)'
+                echo '```'
+                ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }' | head -30
+                echo '```'
+                if [ -s "$FORENSICS" ]; then
+                  echo '### watchdog forensics'; echo '```'; tail -c 18000 "$FORENSICS"; echo '```'
                 fi
-                echo '### bin/test log tail'; echo '```'; tail -n 120 "$LOG" 2>/dev/null || true; echo '```'
+                echo '### bin/test log tail'; echo '```'; tail -n 100 "$LOG" 2>/dev/null || true; echo '```'
               } > "$RUNNER_TEMP/hb-body.md"
               jq -n --arg s "$1" --rawfile t "$RUNNER_TEMP/hb-body.md" \
                 '{output:{title:"darwin bin/test heartbeat (survives runner death)",summary:$s,text:($t|.[0:60000])}}' \
@@ -245,14 +249,15 @@ jobs:
                 pass=$((pass+1))
                 if [ $((pass % 8)) -eq 0 ]; then
                   gtop=$(ps -Ao pid,rss,comm -m 2>/dev/null | awk 'NR==2 {n=split($3,a,"/"); print a[n]"("$2"KB)"}')
-                  hbline=$(printf '[hb %s +%ss] sys_free_kb=%s watched_sum_kb=%s top=%s(%sKB) global_top=%s tail: %s' \
-                    "$(date -u +%H:%M:%S)" "$(( $(date +%s) - t0 ))" "${freekb:-?}" "$sum" \
+                  diskfree=$(df -k / 2>/dev/null | awk 'NR==2 {print $4}')
+                  hbline=$(printf '[hb %s +%ss] sys_free_kb=%s disk_free_kb=%s watched_sum_kb=%s top=%s(%sKB) global_top=%s tail: %s' \
+                    "$(date -u +%H:%M:%S)" "$(( $(date +%s) - t0 ))" "${freekb:-?}" "${diskfree:-?}" "$sum" \
                     "$topcmd" "${toprss:-0}" "${gtop:--}" \
                     "$(tail -c 400 "$LOG" 2>/dev/null | tr '\n' ' ' | tail -c 160)")
                   echo "$hbline"
-                  if [ $((pass % 16)) -eq 0 ]; then
-                    hb_post "$hbline"
-                  fi
+                  # Death leaves at most ~30 s of blind window; the posted
+                  # body names the tests in flight via their argv.
+                  hb_post "$hbline"
                 fi
                 sleep 4
               done ) &

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -513,6 +513,14 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
 | `gc-stress` | **毎回のアロケーションで GC** を走らせる(`bin/test` が使用)。世代別のバリア/remembered set 漏れを最も強く炙り出す。 |
 | `gc-verify` | マイナー GC 後に独立フル再マークで健全性検証(§6.5)。 |
 
+環境変数 `MONORUBY_MALLOC_HARD_LIMIT`(例 `3G`。K/M/G サフィックス可)を設定すると、
+malloc 総量がこれを超える確保が要求された瞬間に、要求サイズとバックトレースを
+stderr へ出力して abort する(`alloc.rs` の `malloc_hard_limit`)。OOM でマシン/
+ランナーごと死んでログが失われる環境(darwin CI)で、暴走アロケーションを
+「名前付きで診断可能なクラッシュ」に変換するための装置。ポーリング型の監視では
+捕捉できない単発の巨大確保も、アロケータ内の同期チェックなので確実に捕まる。
+未設定なら無効(コストは relaxed load 1 回)。
+
 ---
 
 ## 14. まとめ

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -8,6 +8,18 @@ pub struct RurubyAlloc;
 
 unsafe impl GlobalAlloc for RurubyAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Optional hard cap (MONORUBY_MALLOC_HARD_LIMIT): abort with a
+        // report instead of letting a runaway allocation OOM-kill the
+        // machine. Checked against layout.size() itself too, so even a
+        // single multi-GB request (which a polling watchdog can never
+        // catch in time) trips it. Costs one relaxed load when disabled.
+        let limit = malloc_hard_limit();
+        if limit != 0 && !MALLOC_ABORTING.load(Ordering::Relaxed) {
+            let projected = MALLOC_AMOUNT.load(Ordering::Relaxed) + layout.size();
+            if projected > limit {
+                malloc_hard_limit_abort(layout.size(), projected, limit);
+            }
+        }
         // Only object-scale buffers count toward the malloc-driven GC trigger;
         // huge one-shot reservations are skipped (see `MALLOC_TRACK_LIMIT`).
         // The same size test gates `dealloc`, so accounting stays symmetric
@@ -47,6 +59,73 @@ const MALLOC_TRACK_LIMIT: usize = 64 * 1024 * 1024;
 /// only by GC-arena (`RValue`) pressure — a `String#<<` loop allocates almost
 /// no `RValue`s yet can balloon malloc memory unboundedly.
 pub static MALLOC_AMOUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Optional hard ceiling on malloc'd memory, set via the
+/// `MONORUBY_MALLOC_HARD_LIMIT` environment variable (bytes, with an
+/// optional K/M/G suffix, e.g. `3G`; unset/unparsable = disabled, returns
+/// 0). When an allocation would push the live tracked total past the
+/// limit, the process prints the requested size plus a backtrace and
+/// aborts — converting a runaway allocation into a *diagnosable, named*
+/// crash before the OS kills the whole machine. Motivated by the darwin
+/// CI runner (7 GB RAM), whose OOM death destroys every log and artifact:
+/// a polling memory watchdog can never catch a single multi-GB request in
+/// time, but this check sees each allocation synchronously. The GC
+/// arena's up-front reservation and monoasm's JIT pages call
+/// `System.alloc` directly (or exceed `MALLOC_TRACK_LIMIT`), mirroring
+/// what `MALLOC_AMOUNT` tracks, so only real buffer growth counts —
+/// though a single oversized request trips the cap regardless via
+/// `layout.size()`.
+fn malloc_hard_limit() -> usize {
+    // usize::MAX = "not initialized yet". Initialization reads the
+    // environment, which itself allocates; IN_INIT makes those nested
+    // allocations skip the cap instead of recursing unboundedly (and
+    // OnceLock::get_or_init would deadlock on such reentrancy).
+    static LIMIT: AtomicUsize = AtomicUsize::new(usize::MAX);
+    static IN_INIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    let v = LIMIT.load(Ordering::Relaxed);
+    if v != usize::MAX {
+        return v;
+    }
+    if IN_INIT.swap(true, Ordering::Relaxed) {
+        // Nested allocation during init (or a racing thread): treat as
+        // unlimited for this one call; LIMIT is stored momentarily.
+        return 0;
+    }
+    let parsed = std::env::var("MONORUBY_MALLOC_HARD_LIMIT")
+        .ok()
+        .and_then(|s| parse_byte_size(s.trim()))
+        .unwrap_or(0);
+    LIMIT.store(parsed, Ordering::Relaxed);
+    parsed
+}
+
+/// `"123"`, `"512K"`, `"64M"`, `"3G"` → bytes. Anything else → None.
+fn parse_byte_size(s: &str) -> Option<usize> {
+    let (num, mult) = match s.as_bytes().last()? {
+        b'k' | b'K' => (&s[..s.len() - 1], 1usize << 10),
+        b'm' | b'M' => (&s[..s.len() - 1], 1 << 20),
+        b'g' | b'G' => (&s[..s.len() - 1], 1 << 30),
+        _ => (s, 1),
+    };
+    num.parse::<usize>().ok()?.checked_mul(mult)
+}
+
+/// Set for the duration of the hard-limit crash report, so the report's
+/// own allocations (eprintln formatting, backtrace capture) bypass the
+/// cap instead of re-tripping it and aborting mid-report.
+static MALLOC_ABORTING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cold]
+fn malloc_hard_limit_abort(size: usize, projected: usize, limit: usize) -> ! {
+    MALLOC_ABORTING.store(true, Ordering::SeqCst);
+    eprintln!(
+        "monoruby: MONORUBY_MALLOC_HARD_LIMIT exceeded: \
+         requested {size} B (live tracked total would be {projected} B, limit {limit} B) — aborting"
+    );
+    eprintln!("{}", std::backtrace::Backtrace::force_capture());
+    std::process::abort();
+}
 
 /// Address (as `usize`; `0` until the VM registers it) of the JIT/VM
 /// allocation flag — the same `u32` the GC-arena path nudges. Stored

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -110,6 +110,32 @@ fn parse_byte_size(s: &str) -> Option<usize> {
     num.parse::<usize>().ok()?.checked_mul(mult)
 }
 
+#[cfg(test)]
+mod malloc_limit_tests {
+    use super::parse_byte_size;
+
+    #[test]
+    fn parses_plain_and_suffixed_sizes() {
+        assert_eq!(parse_byte_size("123"), Some(123));
+        assert_eq!(parse_byte_size("512K"), Some(512 << 10));
+        assert_eq!(parse_byte_size("512k"), Some(512 << 10));
+        assert_eq!(parse_byte_size("64M"), Some(64 << 20));
+        assert_eq!(parse_byte_size("64m"), Some(64 << 20));
+        assert_eq!(parse_byte_size("3G"), Some(3usize << 30));
+        assert_eq!(parse_byte_size("3g"), Some(3usize << 30));
+    }
+
+    #[test]
+    fn rejects_garbage_and_overflow() {
+        assert_eq!(parse_byte_size(""), None);
+        assert_eq!(parse_byte_size("abc"), None);
+        assert_eq!(parse_byte_size("G"), None);
+        assert_eq!(parse_byte_size("12x"), None);
+        // numeric part parses, multiplication overflows
+        assert_eq!(parse_byte_size("99999999999999999G"), None);
+    }
+}
+
 /// Set for the duration of the hard-limit crash report, so the report's
 /// own allocations (eprintln formatting, backtrace capture) bypass the
 /// cap instead of re-tripping it and aborting mid-report.
@@ -117,6 +143,7 @@ static MALLOC_ABORTING: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 #[cold]
+#[coverage(off)] // crash handler: aborts the process, uncoverable in-test
 fn malloc_hard_limit_abort(size: usize, projected: usize, limit: usize) -> ! {
     MALLOC_ABORTING.store(true, Ordering::SeqCst);
     eprintln!(


### PR DESCRIPTION
## Background

The darwin job's intermittent hang ends with the macOS runner OOM-dying ("lost communication"). A 2026-07-26 incident on PR #1007 proved that in-runner forensics **cannot survive this**: the run already contained the in-log heartbeat + widened watchdog + `if: always()` artifact upload (#1005), yet the runner's death erased the streamed step log (API returns 404) and prevented the artifact step from ever running — zero data, again. A 4-second polling watchdog also can never catch a *single* multi-GB allocation, which is the leading hypothesis for a blow-up fast enough to kill the runner between polls (and would explain why it never reproduces on a local Mac with more RAM).

Two escalations, in order of importance:

## 1. `MONORUBY_MALLOC_HARD_LIMIT` — abort with a report instead of OOM-dying (`alloc.rs`)

Env-gated hard cap in `RurubyAlloc::alloc` (bytes; `K`/`M`/`G` suffix accepted). When an allocation would push the live tracked total past the limit, monoruby prints the requested size + a backtrace to stderr and aborts. Because the check is synchronous in the allocator, it catches even a one-shot giant request (`layout.size()` is counted regardless of the `MALLOC_TRACK_LIMIT` exclusion), and under nextest the aborted test is reported **by name** — the culprit identification every past incident has lacked.

- Reentrancy-safe init (reading the env var itself allocates) and a `MALLOC_ABORTING` flag so the report's own allocations bypass the cap instead of aborting mid-report.
- Disabled = one relaxed atomic load per allocation; nothing else changes.
- Verified locally: a single 768 MB request aborts under a 200 MB limit; a 10 MB-string growth loop aborts at a 1 GB limit naming the requesting size; runs without the variable (and under-limit workloads) are unaffected. `gc` / `header_flag` test filters pass (the `gc_config` failure is a pre-existing local-environment issue, identical on the unmodified baseline).
- The darwin job sets `MONORUBY_MALLOC_HARD_LIMIT=3G` (runner has 7 GB; a normal suite stays well under 1 GB; monoasm's one-shot 768 MB JIT reservation passes).
- Documented in `doc/gc.md` §13.

## 2. Death-proof progress log: `darwin-heartbeat` check run (`rust.yml`)

The step now creates a neutral `darwin-heartbeat` check run on the head commit and PATCHes it every ~60 s with the latest heartbeat line (elapsed / free memory / watched RSS / global top-RSS process), the `bin/test` log tail, and any watchdog forensics — and immediately when the watchdog fires. The data lives on the GitHub side, so **the last update before a runner death survives**, bounding the blind window to ~60 s. Fail-soft when the token lacks `checks: write` (fork PRs); the job declares `permissions: checks: write, contents: read`.

The in-log 30 s heartbeat additionally reports the global top-RSS process, in case the hog is outside the monoruby/ruby watch set (e.g. rustc).

YAML validated and the embedded shell passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EScJjZq6bDW7vXkaZLaVb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EScJjZq6bDW7vXkaZLaVb7)_