### PR TITLE
perf(aarch64): guard-free slot dispatch for JIT method calls

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -754,6 +754,21 @@ impl Codegen {
     /// frame, set PC, `blr` the callee codeptr, then restore the caller's
     /// cfp/lfp. Mirrors x86 `do_call` (set_lfp + push_frame + call + pop_frame)
     /// and the VM invoker's `aftargs` sequence.
+    ///
+    /// With `jit_slot` (an iseq callee already compiled for the call site's
+    /// statically-guarded receiver class), the call dispatches through the
+    /// **guard-free slot**: `ldr` the current specialized entry from the heap
+    /// word and `blr` it directly, skipping the wrapper's counter logic and
+    /// the class-guard chain's redundant `self.class` re-check — the aarch64
+    /// analogue of x86's direct `call jit_entry`. `x21` (PC) is set to the
+    /// callee's bytecode base on the direct path too (not just the `cbz`
+    /// wrapper fallback): unlike x86 — whose bodies re-materialize `r13` from
+    /// baked immediates — aarch64 JIT bodies read the incoming `x21` at a few
+    /// VM-derived sites (see the inline comment), so the specialized entry
+    /// needs the same `x21` the wrapper path has always delivered. The `cbz`
+    /// fallback takes the plain wrapper `codeptr` when the slot was zeroed by
+    /// `invalidate_jit_code`.
+    ///
     /// Returns the call's return address (the instruction after the `blr`,
     /// i.e. pop_frame's first instruction) so `emit_call` can register it for
     /// BOP-redefinition eviction (mirrors x86 `emit_call`'s
@@ -764,6 +779,7 @@ impl Codegen {
         is_iseq: bool,
         callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
+        jit_slot: Option<u64>,
     ) -> CodePtr {
         let codeptr_addr = codeptr.as_ptr() as u64;
         // set_lfp + push_frame (EXEC=x19, LFP=x22).
@@ -775,24 +791,51 @@ impl Codegen {
             sub x22, sp, #(RSP_LOCAL_FRAME as u32);  // callee LFP
             stur x22, [sp, #(-((RSP_CFP + CFP_LFP) as i32))];  // new_cfp.lfp = LFP
         );
-        if is_iseq {
-            // iseq: PC <- callee pc (read by the VM tier / prologue).
-            if let Some(pc) = callee_pc {
-                let pc_ptr = pc.as_ptr() as u64;
-                monoasm_arm64!(&mut self.jit, mov x21, (pc_ptr););
-            }
+        if let Some(slot) = jit_slot {
+            // Guard-free dispatch (iseq callees only; the resolver never
+            // yields a slot for builtins). x21 (PC) is set on BOTH arms:
+            // unlike x86 — whose compiled bodies re-materialize r13 from baked
+            // immediates wherever they need a pc — aarch64 JIT bodies contain
+            // VM-derived sequences that *read* the incoming x21 (the
+            // `sub x3, x21, #16` call-site-pc computations in `emit_yield`,
+            // `object_send_inline` and `a64_jit_class_def_sub`), so a
+            // specialized entry must see the same x21 environment the wrapper
+            // path has always provided (x21 = callee bytecode base).
+            debug_assert!(is_iseq);
+            let do_call = self.jit.label();
+            let pc_ptr = callee_pc.unwrap().as_ptr() as u64;
+            monoasm_arm64!(&mut self.jit,
+                mov x21, (pc_ptr);
+                mov x9, (slot);
+                ldr x10, [x9];                       // current specialized entry
+                cbnz x10, do_call;
+                // Slot zeroed (BOP invalidation): fall back to the wrapper
+                // codeptr (its counter path branches to vm_entry, which also
+                // reads PC).
+                mov x10, (codeptr_addr);
+            do_call:
+                blr x10;                             // result in x0
+            );
         } else {
-            // builtin: x3 is the 4th C-arg = the `pc` parameter, which with-pc
-            // builtins use as the call-site bytecode pointer. The native-func
-            // wrapper passes x3 through untouched (mirrors x86 do_call setting
-            // rcx to the call-site bc ptr).
-            let cs = call_site_bc_ptr.as_ptr() as u64;
-            monoasm_arm64!(&mut self.jit, mov x3, (cs););
+            if is_iseq {
+                // iseq: PC <- callee pc (read by the VM tier / prologue).
+                if let Some(pc) = callee_pc {
+                    let pc_ptr = pc.as_ptr() as u64;
+                    monoasm_arm64!(&mut self.jit, mov x21, (pc_ptr););
+                }
+            } else {
+                // builtin: x3 is the 4th C-arg = the `pc` parameter, which with-pc
+                // builtins use as the call-site bytecode pointer. The native-func
+                // wrapper passes x3 through untouched (mirrors x86 do_call setting
+                // rcx to the call-site bc ptr).
+                let cs = call_site_bc_ptr.as_ptr() as u64;
+                monoasm_arm64!(&mut self.jit, mov x3, (cs););
+            }
+            monoasm_arm64!(&mut self.jit,
+                mov x10, (codeptr_addr);
+                blr x10;                             // result in x0
+            );
         }
-        monoasm_arm64!(&mut self.jit,
-            mov x10, (codeptr_addr);
-            blr x10;                                 // result in x0
-        );
         let return_addr = self.jit.get_current_address();
         // pop_frame: restore caller cfp + lfp from x29 (== x86 rbp).
         monoasm_arm64!(&mut self.jit,
@@ -1084,8 +1127,13 @@ impl Codegen {
         );
     }
 
-    /// The call itself. `jit_entry` is unused — aarch64 always calls `codeptr`
-    /// directly (no JIT-entry dispatch).
+    /// The call itself. `jit_entry` (an x86 `DestLabel`) is unused; the
+    /// aarch64 twin is `jit_slot` — the guard-free dispatch-slot address for a
+    /// callee already compiled for this call site's statically-guarded
+    /// receiver class. When present, `a64_do_call` dispatches through it,
+    /// skipping the wrapper's counter logic and redundant `self.class`
+    /// re-guard (see `a64_do_call`); otherwise it calls the wrapper `codeptr`
+    /// as before.
     ///
     /// Like x86, the call's return address is registered for BOP-redefinition
     /// eviction: when a basic op is redefined *inside* the callee, the caller's
@@ -1102,10 +1150,12 @@ impl Codegen {
         callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
         _jit_entry: Option<DestLabel>,
+        jit_slot: Option<u64>,
         evict: AsmEvict,
         evict_label: &DestLabel,
     ) {
-        let return_addr = self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr);
+        let return_addr =
+            self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr, jit_slot);
         self.set_deopt_with_return_addr(return_addr, evict, evict_label);
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -234,6 +234,8 @@ impl Codegen {
         callee_pc: Option<BytecodePtrBase>,
         call_site_bc_ptr: BytecodePtr,
         jit_entry: Option<DestLabel>,
+        // aarch64 guard-free dispatch slot; x86 dispatches via `jit_entry`.
+        _jit_slot: Option<u64>,
         evict: AsmEvict,
         evict_label: &DestLabel,
     ) {

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -367,6 +367,19 @@ impl Codegen {
         let guard_addr = self.jit.get_label_address(&guard).as_ptr() as u64;
         // SAFETY: `slot` is the dispatch word recorded by `compile_patch`.
         unsafe { *(slot as *mut u64) = guard_addr };
+        // Re-point the guard-free dispatch slot at the recompiled body so
+        // every JIT call site that dispatches through it (skipping the
+        // wrapper's re-guard) redirects too — the aarch64 analogue of x86
+        // repatching the `patch_point` jump. The slot exists whenever
+        // `compile_patch` compiled this (iseq, class) pair, which is a
+        // precondition for reaching the recompiler.
+        if let Some(guard_free) = globals.store[iseq_id].get_jit_guard_free_slot(self_class) {
+            let entry_addr = self.jit.get_label_address(&jit_entry).as_ptr() as u64;
+            // SAFETY: heap-leaked `u64` published by `compile_patch`; valid
+            // for the process lifetime, single-threaded write (see
+            // `invalidate_jit_code`).
+            unsafe { *(guard_free as *mut u64) = entry_addr };
+        }
         Some(())
     }
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -480,12 +480,24 @@ impl Codegen {
                 // x86 JIT-entry lookup (aarch64 ignores it; the lookup is a
                 // side-effect-free table read, so pre-resolving here is safe).
                 let jit_entry = is_iseq.and_then(|iseq| store[iseq].get_jit_entry(recv_class));
+                // aarch64 guard-free dispatch-slot lookup (x86 ignores it).
+                // `recv_class` is statically established at this call site
+                // (class-version + receiver guards precede every AsmInst::Call),
+                // which is exactly the precondition for skipping the wrapper's
+                // `self.class` re-guard — same soundness argument as x86's
+                // direct `call jit_entry`.
+                #[cfg(target_arch = "aarch64")]
+                let jit_slot =
+                    is_iseq.and_then(|iseq| store[iseq].get_jit_guard_free_slot(recv_class));
+                #[cfg(not(target_arch = "aarch64"))]
+                let jit_slot = None;
                 self.encode_linst(LInst::Call {
                     codeptr,
                     is_iseq: is_iseq.is_some(),
                     callee_pc,
                     call_site_bc_ptr: pc,
                     jit_entry,
+                    jit_slot,
                     evict,
                     evict_label,
                 });
@@ -1464,6 +1476,7 @@ impl Codegen {
                 callee_pc,
                 call_site_bc_ptr,
                 jit_entry,
+                jit_slot,
                 evict,
                 evict_label,
             } => {
@@ -1473,6 +1486,7 @@ impl Codegen {
                     callee_pc,
                     call_site_bc_ptr,
                     jit_entry,
+                    jit_slot,
                     evict,
                     &evict_label,
                 );

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -974,6 +974,12 @@ pub(in crate::codegen) enum LInst {
         call_site_bc_ptr: BytecodePtr,
         /// x86 JIT entry for this recv_class (`store[iseq].get_jit_entry`).
         jit_entry: Option<DestLabel>,
+        /// aarch64 guard-free dispatch-slot address for this recv_class
+        /// (`store[iseq].get_jit_guard_free_slot`): a heap word holding the
+        /// current specialized entry, letting the call skip the wrapper's
+        /// redundant `self.class` re-guard. `None` on x86 (which uses
+        /// `jit_entry` directly) and for uncompiled/unknown-class callees.
+        jit_slot: Option<u64>,
         evict: AsmEvict,
         evict_label: DestLabel,
     },

--- a/monoruby/src/codegen/patch.rs
+++ b/monoruby/src/codegen/patch.rs
@@ -72,6 +72,36 @@ impl Codegen {
         // `self_class`'s entry; `jit_compile_patch` passes the right one for
         // both the head class and chained classes).
         globals.store[iseq_id].set_jit_slot(self_class, slot.as_ptr() as u64);
+        // Publish the *guard-free* dispatch slot: a heap word holding the bare
+        // `jit_entry` address (past the wrapper counter logic and the
+        // class-guard chain). JIT call sites that statically know — and have
+        // already guarded — the receiver class dispatch through it, skipping
+        // the redundant re-guard (see `ISeqInfo::jit_guard_free_slot`).
+        // `recompile_method` re-points it; `invalidate_jit_code` zeroes it.
+        //
+        // ONE CELL PER (iseq, class), FOREVER: earlier-compiled callers bake
+        // the slot's *address* into their code, so a second `compile_patch`
+        // for the same pair (reachable when a whole-method recompile rebuilds
+        // the class-guard chain with a fresh empty `next_slot`, dropping the
+        // chained classes, which then re-warm through `jit_profile_patch`)
+        // must update the EXISTING word in place — allocating a fresh Box
+        // would orphan the baked one, making it invisible to both
+        // `invalidate_jit_code`'s zeroing and future recompiles' re-pointing
+        // (x86's twin invariant: it repatches its `patch_point` in place and
+        // panics on a double `add_jit_code`).
+        let entry_addr = self.jit.get_label_address(&jit_entry).as_ptr() as u64;
+        match globals.store[iseq_id].get_jit_guard_free_slot(self_class) {
+            Some(guard_free) => {
+                // SAFETY: heap-leaked `u64` published by an earlier
+                // `compile_patch`; valid for the process lifetime,
+                // single-threaded write (M:1 green threads).
+                unsafe { *(guard_free as *mut u64) = entry_addr };
+            }
+            None => {
+                let guard_free = Box::into_raw(Box::new(entry_addr)) as u64;
+                globals.store[iseq_id].set_jit_guard_free_slot(self_class, guard_free);
+            }
+        }
         Some(())
     }
 

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -174,6 +174,19 @@ pub struct ISeqInfo {
     /// (aarch64 installs JIT code via this slot, not x86 branch patching).
     #[cfg(target_arch = "aarch64")]
     pub(super) jit_slot: HashMap<ClassId, u64>,
+    /// aarch64 only: per-self-class address of the *guard-free* dispatch slot
+    /// — a heap-leaked `u64` holding the current specialized `jit_entry`
+    /// address (past the wrapper's counter logic and the class-guard chain).
+    /// JIT call sites whose receiver class is statically known (and already
+    /// guarded at the call site) dispatch through this slot, skipping the
+    /// wrapper's redundant `self.class` re-guard — the aarch64 analogue of
+    /// x86's direct `call` into the guard-free entry via its `patch_point`.
+    /// `compile_patch` publishes it, `recompile_method` re-points it at the
+    /// recompiled body (the analogue of x86 repatching `patch_point`), and
+    /// `invalidate_jit_code` zeroes it (callers then fall back to the wrapper
+    /// codeptr).
+    #[cfg(target_arch = "aarch64")]
+    pub(super) jit_guard_free_slot: HashMap<ClassId, u64>,
     /// Bounded per-self-class warm-up profile used to decide *which* receiver
     /// class is hot enough to specialize for. Without it, the first call that
     /// trips the global warm-up counter compiles for whatever class happens to
@@ -314,6 +327,8 @@ impl ISeqInfo {
             jit_entry: HashMap::default(),
             #[cfg(target_arch = "aarch64")]
             jit_slot: HashMap::default(),
+            #[cfg(target_arch = "aarch64")]
+            jit_guard_free_slot: HashMap::default(),
             jit_class_profile: Vec::new(),
             jit_invalidated: false,
             bb_info: BasicBlockInfo::default(),
@@ -634,6 +649,34 @@ impl ISeqInfo {
         self.jit_slot.get(&self_class).copied()
     }
 
+    /// aarch64 only: record the *guard-free* dispatch-slot address for a self
+    /// class (see `jit_guard_free_slot`). Called from `compile_patch` after
+    /// the specialized body is finalized — and only on the FIRST publish for
+    /// this class: callers bake the slot address into their code, so a
+    /// republish must update the existing word in place (`compile_patch` does
+    /// that), never insert a fresh one — an orphaned old cell would be
+    /// invisible to `invalidate_jit_code`'s zeroing and the recompiler's
+    /// re-pointing.
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn set_jit_guard_free_slot(&mut self, self_class: ClassId, slot: u64) {
+        let old = self.jit_guard_free_slot.insert(self_class, slot);
+        debug_assert!(
+            old.is_none(),
+            "guard-free slot republished for {self_class:?}: the old cell is now orphaned"
+        );
+    }
+
+    /// aarch64 only: the guard-free dispatch-slot address for a self class,
+    /// if compiled. `None` once invalidated (the slots are also zeroed then,
+    /// but new call-site lowering must stop resolving them entirely).
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn get_jit_guard_free_slot(&self, self_class: ClassId) -> Option<u64> {
+        if self.jit_invalidated {
+            return None;
+        }
+        self.jit_guard_free_slot.get(&self_class).copied()
+    }
+
     pub(crate) fn get_cache_map(
         &self,
         self_class: ClassId,
@@ -698,6 +741,16 @@ impl ISeqInfo {
                 unsafe { *(slot_addr as *mut u64) = 0 };
             }
             self.jit_slot.clear();
+            // Guard-free dispatch slots too: a zeroed slot makes the caller's
+            // `cbz` fallback take the wrapper codeptr (whose own dispatch word
+            // was just zeroed above → VM). Callers are themselves invalidated
+            // on the paths that matter, so this is defense in depth.
+            for &slot_addr in self.jit_guard_free_slot.values() {
+                // SAFETY: heap-leaked `u64` recorded by `set_jit_guard_free_slot`;
+                // same lifetime/race argument as `jit_slot` above.
+                unsafe { *(slot_addr as *mut u64) = 0 };
+            }
+            self.jit_guard_free_slot.clear();
         }
     }
 

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -378,3 +378,40 @@ fn class_def_in_expression_position_730() {
         "##,
     );
 }
+
+// Guard-free slot dispatch (aarch64) — a shared method dispatched through the
+// guard-free slot must stay correct across a whole-method recompile
+// (class-version bump) that RE-POINTS the slot at the recompiled body. Uses
+// chained receiver classes (A head, B chained) so both a head slot and a
+// chained-class slot participate, and avoids `+` entirely (`.times`/`<<`/
+// `.succ`) because `run_test` re-runs the snippet 25× in one process — a
+// mid-snippet `Integer#+` redefine would break loop counters on the re-runs.
+// (The BOP-zeroing + wrapper-fallback leg is covered by the redefine_bop_*
+// tests above, which already run with guard-free dispatch active.) On x86 this
+// is plain dispatch; on aarch64 it drives the jit_guard_free_slot machinery.
+#[test]
+fn guard_free_dispatch_across_recompile() {
+    run_test(
+        r##"
+        class Base
+          def helper(x); x.succ; end
+          def m(v); [helper(v), helper(v)]; end
+        end
+        class A < Base; end
+        class B < Base; end
+        a = A.new; b = B.new
+        res = 0
+        300.times { |i| res += a.m(i)[0]; res += b.m(i)[1] }   # compile m for A (head) + B (chained)
+        def caller(o)
+          r = []
+          50.times { |j| r << o.m(j) }
+          r.length
+        end
+        3.times { caller(a); caller(b) }                       # callers bake the guard-free slots
+        # class-version bumps drive whole-method recompiles that re-point the
+        # slots; every subsequent guard-free dispatch must reach the new body.
+        3.times { |k| eval("class Dummy#{k}; def zz; #{k}; end; end"); a.m(1); b.m(1) }
+        [res, caller(a), caller(b), a.m(5), b.m(7)]
+        "##,
+    );
+}


### PR DESCRIPTION
Final item from the aarch64/x86 JIT opt-parity audit (#1). When a JIT call site's callee iseq is already compiled for the call site's **statically-known, already-guarded** receiver class, aarch64 previously still `blr`'d the per-method wrapper — re-running its counter logic and the class-guard chain's redundant `self.class` re-check on every call. x86 avoids this by calling the guard-free specialized entry directly (via its repatchable `patch_point`). This ports the equivalent to aarch64 with an **indirect, updatable dispatch slot** (aarch64 reaches entries through heap words, not patchable branches).

## Mechanism

- `ISeqInfo::jit_guard_free_slot: HashMap<ClassId, u64>` (aarch64-only) holds, per `(iseq, recv_class)`, a heap-leaked word with the **current** specialized `jit_entry` address (past the wrapper counter + class-guard chain).
  - `compile_patch` publishes it; `recompile_method` **re-points it in place** (the analogue of x86 repatching `patch_point`), so callers redirect to the recompiled body; `invalidate_jit_code` **zeroes it** on BOP redefinition.
- The `AsmInst::Call` resolver hands the slot to `a64_do_call` only for iseq callees compiled for the call site's `recv_class`. The caller's unconditional class-version guard (`jitgen/compile/method_call.rs:171`) + receiver-class guard already establish `self == recv_class`, so skipping the wrapper's re-guard is sound (same argument as x86's direct call).
- `a64_do_call` emits `mov x9,(slot); ldr x10,[x9]; cbnz x10, do_call; <wrapper codeptr fallback>; do_call: blr x10`. With no slot resolved, the old wrapper path is byte-identical. x86 `emit_call` gains an ignored `_jit_slot` param.

## Two aarch64-specific subtleties (both caught pre-merge)

1. **x21 (PC) is set on the direct path too**, not just the fallback. x86 bodies re-materialize `r13` from baked immediates, but aarch64 JIT bodies *read* the incoming `x21` at a few VM-derived sites (`sub x3,x21,#16` in `emit_yield` / `object_send_inline` / `a64_jit_class_def_sub`), so a specialized entry must see the same `x21` the wrapper path always delivered.
2. **One slot cell per `(iseq, class)`, forever.** Callers bake the slot *address*, so a second `compile_patch` for the same pair — reachable when a whole-method recompile rebuilds the class-guard chain with a fresh empty `next_slot`, dropping chained classes that then re-warm — must **update the existing word in place**; a fresh `Box` would orphan the baked one (invisible to both zeroing and re-pointing). A `debug_assert` in `set_jit_guard_free_slot` enforces the invariant. *(This was the adversarial review's one real finding — fixed here.)*

## Perf (aarch64, release, interleaved reps)

- **optcarrot: consistently faster** (every rep after > before; ceiling ~+5%).
- app_fib / app_aobench / a cross-method-call microbenchmark: neutral.
- Inlined/specialized call paths are unaffected by design (they never lower to `AsmInst::Call`).

## Validation

- Full `cargo nextest run`: **2751/2751** (aarch64).
- `gc-stress` redefine+method_call: **134/134**.
- Test `guard_free_dispatch_across_recompile` (`tests/redefine.rs`) exercises the recompile/re-point path across chained receiver classes; the existing `redefine_bop_*` suite covers the BOP-zeroing + wrapper-fallback leg with guard-free dispatch active.
- Adversarial multi-lens review: resolution-condition & asm-mechanics lenses **SOUND**; the slot-lifecycle lens caught the orphaned-slot defect above (now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)