### PR TITLE
perf(jit): emit object allocation as inline machine code (free list + bump)

### DIFF
--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -164,6 +164,23 @@ const ALLOC_SIZE: usize = PAGE_LEN * GCBOX_SIZE; // 2^18 = 256kb
 const MALLOC_THRESHOLD: usize = 256 * 1024;
 const MAX_PAGES: usize = 8192;
 
+/// Byte offset of the cell array inside a page, and the cell stride, so the
+/// JIT's inline bump fast path can compute a cell address as
+/// `current_page + PAGE_DATA_OFFSET + used_in_current * CELL_SIZE` — the
+/// same address `Page::get_cell` returns.
+pub(crate) const PAGE_DATA_OFFSET: usize = std::mem::offset_of!(Page<RValue>, data);
+pub(crate) const CELL_SIZE: usize = GCBOX_SIZE;
+/// The inline path scales the bump index with a shift.
+const _: () = assert!(CELL_SIZE.is_power_of_two());
+pub(crate) const CELL_SIZE_SHIFT: u32 = CELL_SIZE.trailing_zeros();
+
+/// Bump index at which the inline fast path must hand back to
+/// `Allocator::alloc`: at `THRESHOLD` the runtime sets the GC alloc flag and
+/// at `DATA_LEN` it starts a new page, neither of which is worth inlining
+/// (together they are 64 of every 4032 allocations). Anything below this is
+/// a plain bump.
+pub(crate) const BUMP_INLINE_LIMIT: usize = THRESHOLD;
+
 /// Hard cap on the number of minor (young-generation) collections between
 /// two major (full-heap) collections. This is only a safety bound — to
 /// rebuild the remembered set and bound floating old garbage even if the
@@ -673,6 +690,27 @@ impl<T: GCBox> Allocator<T> {
     ///
     pub(crate) fn total_allocated_addr(&self) -> *mut usize {
         &self.total_allocated_objects as *const _ as *mut usize
+    }
+
+    ///
+    /// Address of `self.current_page`, the page bump allocation is carving
+    /// cells out of. A `PageRef` is a non-null pointer, so reading it as
+    /// `*mut usize` yields the page address. Exposed (with
+    /// `used_in_current_addr`) so the JIT can inline the bump fast path;
+    /// the free list alone is not enough, because a workload whose objects
+    /// stay live never refills it.
+    ///
+    pub(crate) fn current_page_addr(&self) -> *mut usize {
+        &self.current_page as *const _ as *mut usize
+    }
+
+    ///
+    /// Address of `self.used_in_current`, the bump index into
+    /// `current_page`. Incremented by the inline fast path exactly as
+    /// `alloc` does.
+    ///
+    pub(crate) fn used_in_current_addr(&self) -> *mut usize {
+        &self.used_in_current as *const _ as *mut usize
     }
 
     ///

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -65,10 +65,34 @@ pub(super) fn gen_class_allocate_inline(
     let deopt = ir.new_deopt(state);
     ir.guard_value_identity(self_module.as_val(), deopt);
 
+    // A plain object (the inherited `default_alloc_func`) is just a
+    // header plus `OBJECT_INLINE_IVAR` nil slots, so it can be built
+    // inline from the GC free list with no call at all. Two compile-time
+    // conditions:
+    //
+    // * the class must actually use the default allocator — every class
+    //   with its own `alloc_func` (Array, Hash, String, Range, Struct, …)
+    //   builds a different payload and keeps the call;
+    // * its ivar count must fit the inline slots — beyond that
+    //   `default_alloc_func` pre-sizes the spilled ivar table, which
+    //   needs a malloc.
+    //
+    // The ivar check is a pure optimization gate, not a correctness one:
+    // `var_table: None` is valid for any object (that is what
+    // `RValue::new_object` itself stores) and the table grows on demand,
+    // so a class that gains ivars after this compile stays correct — it
+    // merely loses the pre-sizing until the code is recompiled.
+    let inline_object = std::ptr::fn_addr_eq(alloc_func, crate::default_alloc_func as AllocFunc)
+        && store[class_id].ivar_len() <= OBJECT_INLINE_IVAR;
+
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
     ir.inline(move |r#gen, _, _, _| {
-        r#gen.emit_class_allocate(class_id.u32(), alloc_func as *const () as u64)
+        r#gen.emit_class_allocate(
+            class_id.u32(),
+            alloc_func as *const () as u64,
+            inline_object,
+        )
     });
     ir.fpr_restore(using_fpr);
     // The allocator produces an instance of exactly `class_id`. Record

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -65,34 +65,39 @@ pub(super) fn gen_class_allocate_inline(
     let deopt = ir.new_deopt(state);
     ir.guard_value_identity(self_module.as_val(), deopt);
 
-    // A plain object (the inherited `default_alloc_func`) is just a
-    // header plus `OBJECT_INLINE_IVAR` nil slots, so it can be built
-    // inline from the GC free list with no call at all. Two compile-time
-    // conditions:
+    // Both stock allocators produce a payload small enough to write with
+    // a few stores, so for them the call is replaced by an inline
+    // allocation. Any class with its own `alloc_func` (Array, Hash,
+    // String, Range, IO, …) builds something else and keeps the call.
     //
-    // * the class must actually use the default allocator — every class
-    //   with its own `alloc_func` (Array, Hash, String, Range, Struct, …)
-    //   builds a different payload and keeps the call;
-    // * its ivar count must fit the inline slots — beyond that
-    //   `default_alloc_func` pre-sizes the spilled ivar table, which
-    //   needs a malloc.
-    //
-    // The ivar check is a pure optimization gate, not a correctness one:
-    // `var_table: None` is valid for any object (that is what
-    // `RValue::new_object` itself stores) and the table grows on demand,
-    // so a class that gains ivars after this compile stays correct — it
-    // merely loses the pre-sizing until the code is recompiled.
-    let inline_object = std::ptr::fn_addr_eq(alloc_func, crate::default_alloc_func as AllocFunc)
-        && store[class_id].ivar_len() <= OBJECT_INLINE_IVAR;
+    // * `default_alloc_func` — a plain object: header plus
+    //   `OBJECT_INLINE_IVAR` nil slots. Requires the class's ivar count to
+    //   fit those slots, because beyond them the allocator pre-sizes the
+    //   spilled ivar table, which needs a malloc. That check is a pure
+    //   optimization gate, not a correctness one: `var_table: None` is
+    //   valid for any object (it is what `RValue::new_object` stores) and
+    //   the table grows on demand, so a class that gains ivars after this
+    //   compile stays correct — it merely loses the pre-sizing.
+    // * `struct_alloc_func` — a `Struct` subclass instance: header plus
+    //   `len` nil slots. The member count is baked here so the per-
+    //   allocation `/members` class-chain walk disappears; only structs
+    //   that fit `STRUCT_INLINE_SLOTS` qualify, so the inline/heap choice
+    //   in the slot layout can never be mis-encoded.
+    let inline_alloc = if std::ptr::fn_addr_eq(alloc_func, crate::default_alloc_func as AllocFunc)
+        && store[class_id].ivar_len() <= OBJECT_INLINE_IVAR
+    {
+        Some(InlineAlloc::Object)
+    } else if std::ptr::fn_addr_eq(alloc_func, crate::struct_alloc_func as AllocFunc) {
+        let len = crate::struct_members_len(store, class_id);
+        (len <= STRUCT_INLINE_SLOTS).then_some(InlineAlloc::Struct(len as u16))
+    } else {
+        None
+    };
 
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
     ir.inline(move |r#gen, _, _, _| {
-        r#gen.emit_class_allocate(
-            class_id.u32(),
-            alloc_func as *const () as u64,
-            inline_object,
-        )
+        r#gen.emit_class_allocate(class_id.u32(), alloc_func as *const () as u64, inline_alloc)
     });
     ir.fpr_restore(using_fpr);
     // The allocator produces an instance of exactly `class_id`. Record

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -614,6 +614,11 @@ pub struct Codegen {
     alloc_free_head_addr: *mut usize,
     alloc_free_count_addr: *mut usize,
     alloc_total_addr: *mut usize,
+    /// Bump-allocation state (`current_page` / `used_in_current`), so the
+    /// inline path also covers a heap that is still growing — where the
+    /// free list stays empty and every allocation would otherwise call out.
+    alloc_used_addr: *mut usize,
+    alloc_page_addr: *mut usize,
 
     compilation_unit: Vec<CompilationUnitInfo>,
 
@@ -968,6 +973,8 @@ impl Codegen {
             alloc_free_head_addr: std::ptr::null_mut(),
             alloc_free_count_addr: std::ptr::null_mut(),
             alloc_total_addr: std::ptr::null_mut(),
+            alloc_used_addr: std::ptr::null_mut(),
+            alloc_page_addr: std::ptr::null_mut(),
             compilation_unit: Vec::new(),
             return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
@@ -1046,6 +1053,8 @@ impl Codegen {
             codegen.alloc_free_head_addr = alloc.free_list_head_addr();
             codegen.alloc_free_count_addr = alloc.free_list_count_addr();
             codegen.alloc_total_addr = alloc.total_allocated_addr();
+            codegen.alloc_used_addr = alloc.used_in_current_addr();
+            codegen.alloc_page_addr = alloc.current_page_addr();
         });
 
         codegen

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -594,6 +594,43 @@ struct CompilationUnitInfo {
 }
 
 ///
+/// What `Class#allocate` may build inline instead of calling the class's
+/// `alloc_func`. Decided at compile time by `gen_class_allocate_inline`,
+/// which knows the receiver class exactly (it is identity-guarded), and
+/// consumed by each backend's `emit_class_allocate`.
+///
+/// Both payloads are small enough to write with a handful of stores, so the
+/// call disappears entirely — the cell itself comes from `emit_alloc_cell`.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InlineAlloc {
+    /// A plain object (`default_alloc_func`): header, `var_table = None`,
+    /// and `OBJECT_INLINE_IVAR` nil ivar slots.
+    Object,
+    /// A `Struct` subclass instance (`struct_alloc_func`) with `len`
+    /// members, all nil. Only used when `len <= STRUCT_INLINE_SLOTS`, so
+    /// the slots live inline and no heap buffer is needed.
+    Struct(u16),
+}
+
+///
+/// Where an inline allocation's 8-byte object header comes from.
+///
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CellHeader {
+    /// A header known at compile time: a fresh object of a statically
+    /// known class and type.
+    Imm(u64),
+    /// `Header::newborn()` of the template object at this address — its
+    /// header word with the generational-GC state masked off
+    /// (`NEWBORN_FLAG_MASK`). Used by literal instantiation, where the
+    /// copy inherits the template's class, type and frozen/chilled bits
+    /// but must start young. Read at run time rather than baked, so a
+    /// template whose bits change later can never desync the copies.
+    NewbornOf(u64),
+}
+
+///
 /// Machine code generator
 ///
 pub struct Codegen {

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -180,7 +180,51 @@ impl Codegen {
     /// (a u32) and the resolved allocator pointer are embedded as constants;
     /// arg0 = class_id, arg1 = globals (GLOBALS/x20). Result Value in Rax (x0).
     /// FP pool saved by the surrounding fpr_save.
-    pub(crate) fn emit_class_allocate(&mut self, class_id: u32, alloc_func: u64) {
+    ///
+    /// With `inline_object` (a plain object produced by
+    /// `default_alloc_func`, with no spilled ivar table), the whole
+    /// allocation is emitted here instead: pop a cell from the GC free list
+    /// and write the header, `var_table = None` and `OBJECT_INLINE_IVAR`
+    /// nil slots — which is the entire payload of `RValue::new_object`.
+    /// An empty free list falls back to the call.
+    pub(crate) fn emit_class_allocate(
+        &mut self,
+        class_id: u32,
+        alloc_func: u64,
+        inline_object: bool,
+    ) {
+        if inline_object && !self.alloc_free_head_addr.is_null() {
+            let rax = GP::Rax.a64().0; // x0 (result)
+            let slow = self.jit.label();
+            let cont = self.jit.label();
+            // 8-byte object header: flag=1 (live) | ty=OBJECT<<16 | class<<32.
+            let header: u64 =
+                ((class_id as u64) << 32) | ((ObjTy::OBJECT.get() as u64) << 16) | 1;
+            self.emit_alloc_cell(header, &slow);
+            monoasm_arm64!(&mut self.jit,
+                mov x12, #0;
+                str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
+            );
+            // `ObjKind::object()` == `[None; OBJECT_INLINE_IVAR]` at the
+            // head of the `kind` union (the same `RVALUE_OFFSET_KIND +
+            // ivarid * 8` addressing the ivar emitters use), and `None`
+            // for `Option<Value>` is a zero word.
+            for k in 0..OBJECT_INLINE_IVAR {
+                let off = RVALUE_OFFSET_KIND as u32 + (k as u32) * 8;
+                monoasm_arm64!(&mut self.jit,
+                    str x12, [x(rax), #(off)];
+                );
+            }
+            monoasm_arm64!(&mut self.jit, b cont;);
+            self.jit.bind_label(slow);
+            self.class_allocate_call(class_id, alloc_func);
+            self.jit.bind_label(cont);
+        } else {
+            self.class_allocate_call(class_id, alloc_func);
+        }
+    }
+
+    fn class_allocate_call(&mut self, class_id: u32, alloc_func: u64) {
         monoasm_arm64!(&mut self.jit,
             mov x0, (class_id as u64); // class_id -> arg0 (low 32 bits read)
             mov x1, x20;               // globals -> arg1

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -181,47 +181,68 @@ impl Codegen {
     /// arg0 = class_id, arg1 = globals (GLOBALS/x20). Result Value in Rax (x0).
     /// FP pool saved by the surrounding fpr_save.
     ///
-    /// With `inline_object` (a plain object produced by
-    /// `default_alloc_func`, with no spilled ivar table), the whole
-    /// allocation is emitted here instead: pop a cell from the GC free list
-    /// and write the header, `var_table = None` and `OBJECT_INLINE_IVAR`
-    /// nil slots — which is the entire payload of `RValue::new_object`.
-    /// An empty free list falls back to the call.
+    /// With an `inline` payload the whole allocation is emitted here
+    /// instead: pop a cell (`emit_alloc_cell`) and write exactly what the
+    /// stock allocator would have produced. The runtime call is kept as the
+    /// fallback for the page-boundary cases.
     pub(crate) fn emit_class_allocate(
         &mut self,
         class_id: u32,
         alloc_func: u64,
-        inline_object: bool,
+        inline: Option<InlineAlloc>,
     ) {
-        if inline_object && !self.alloc_free_head_addr.is_null() {
-            let rax = GP::Rax.a64().0; // x0 (result)
-            let slow = self.jit.label();
-            let cont = self.jit.label();
-            // 8-byte object header: flag=1 (live) | ty=OBJECT<<16 | class<<32.
-            let header: u64 =
-                ((class_id as u64) << 32) | ((ObjTy::OBJECT.get() as u64) << 16) | 1;
-            self.emit_alloc_cell(header, &slow);
-            monoasm_arm64!(&mut self.jit,
-                mov x12, #0;
-                str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
-            );
+        let Some(inline) = inline.filter(|_| !self.alloc_free_head_addr.is_null()) else {
+            self.class_allocate_call(class_id, alloc_func);
+            return;
+        };
+        let rax = GP::Rax.a64().0; // x0 (result)
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        // 8-byte object header: flag=1 (live) | ty<<16 | class<<32.
+        let ty = match inline {
+            InlineAlloc::Object => ObjTy::OBJECT,
+            InlineAlloc::Struct(_) => ObjTy::STRUCT,
+        };
+        let header: u64 = ((class_id as u64) << 32) | ((ty.get() as u64) << 16) | 1;
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
+        monoasm_arm64!(&mut self.jit,
+            mov x12, #0;
+            str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
+        );
+        match inline {
             // `ObjKind::object()` == `[None; OBJECT_INLINE_IVAR]` at the
             // head of the `kind` union (the same `RVALUE_OFFSET_KIND +
             // ivarid * 8` addressing the ivar emitters use), and `None`
             // for `Option<Value>` is a zero word.
-            for k in 0..OBJECT_INLINE_IVAR {
-                let off = RVALUE_OFFSET_KIND as u32 + (k as u32) * 8;
-                monoasm_arm64!(&mut self.jit,
-                    str x12, [x(rax), #(off)];
-                );
+            InlineAlloc::Object => {
+                for k in 0..OBJECT_INLINE_IVAR {
+                    let off = RVALUE_OFFSET_KIND as u32 + (k as u32) * 8;
+                    monoasm_arm64!(&mut self.jit,
+                        str x12, [x(rax), #(off)];
+                    );
+                }
             }
-            monoasm_arm64!(&mut self.jit, b cont;);
-            self.jit.bind_label(slow);
-            self.class_allocate_call(class_id, alloc_func);
-            self.jit.bind_label(cont);
-        } else {
-            self.class_allocate_call(class_id, alloc_func);
+            // `StructInner::new(len)` == a `SmallVec` holding `len` nils:
+            // the smallvec's capacity field doubles as the inline length,
+            // and slots past `len` stay untouched, exactly as in Rust.
+            InlineAlloc::Struct(len) => {
+                monoasm_arm64!(&mut self.jit,
+                    mov x12, (len as u64);
+                    str x12, [x(rax), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+                    mov x12, (NIL_VALUE);
+                );
+                for k in 0..len {
+                    let off = RVALUE_OFFSET_INLINE as u32 + (k as u32) * 8;
+                    monoasm_arm64!(&mut self.jit,
+                        str x12, [x(rax), #(off)];
+                    );
+                }
+            }
         }
+        monoasm_arm64!(&mut self.jit, b cont;);
+        self.jit.bind_label(slow);
+        self.class_allocate_call(class_id, alloc_func);
+        self.jit.bind_label(cont);
     }
 
     fn class_allocate_call(&mut self, class_id: u32, alloc_func: u64) {

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -527,12 +527,12 @@ impl Codegen {
     /// the fixed temps below avoid it.
     pub(super) fn a64_set_arguments_forwarded_deferred(
         &mut self,
+        offset: usize,
         recv: SlotId,
         args: SlotId,
         lead_num: usize,
-        expected_len: usize,
-        none_fill: usize,
         src: SlotId,
+        layout: ForwardedLayout,
     ) -> bool {
         // Fixed lowering temps (x9..x15 are never GP-mapped; x10 is the
         // internal scratch of `a64_frame_load/store`, so it is left free):
@@ -543,9 +543,47 @@ impl Codegen {
         const VAL: u32 = 12;
         const CALLER_FP: u32 = 11;
         let lfp = GP::R14.a64().0; // x22: f's own LFP
+        let expected_len = layout.from_src;
+        // A `*rest` callee gets its `Array` built straight off the
+        // caller's slots (the elements are a contiguous tail of the
+        // forwarded window — see `forwarded_deferred_layout`). Emitted
+        // *first*, before any callee slot is written and before `x13` is
+        // taken: the call clobbers the x9..x15 temps and its LR push
+        // would otherwise land in the frame under construction. `sp` is
+        // lowered past the whole callee frame for the duration, as the
+        // helper path does. GC-safe for the same reason the side-exit
+        // materialization is: every element is still live in the
+        // caller's frame slots, which are scanned.
+        if let Some(rest) = layout.rest {
+            monoasm_arm64!(&mut self.jit,
+                str x30, [sp, #-16]!;                 // save LR
+                ldr x11, [x29];                       // caller frame pointer
+                mov x9, (rbp_local(src + rest.src_offset) as u64);
+                sub x0, x11, x9;                      // highest-address element
+                mov x1, (rest.len as u64);
+            );
+            self.a64_sp_sub(offset as u32);
+            monoasm_arm64!(&mut self.jit,
+                mov x9, (crate::runtime::create_array as *const () as u64);
+                blr x9;
+            );
+            self.a64_sp_add(offset as u32);
+            monoasm_arm64!(&mut self.jit,
+                ldr x30, [sp], #16;                   // restore LR
+                sub x13, sp, #(RSP_LOCAL_FRAME as u32);
+                mov x12, x0;
+            );
+            self.a64_frame_store(VAL, CLFP, (LFP_ARG0 + 8 * rest.pos as i32) as u32);
+        }
         monoasm_arm64!(&mut self.jit,
             sub x13, sp, #(RSP_LOCAL_FRAME as u32);
         );
+        // A bare `**kwrest` gets `nil` — "no keyword arguments" everywhere
+        // downstream, matching the runtime's `store_empty_kw_rest`.
+        if let Some(kw_rest) = layout.kw_rest {
+            monoasm_arm64!(&mut self.jit, mov x12, (NIL_VALUE as u64););
+            self.a64_frame_store(VAL, CLFP, (LFP_SELF + 8 * kw_rest.0 as i32) as u32);
+        }
         // self <- f's own recv slot
         self.a64_frame_load(VAL, lfp, conv(recv) as u32);
         self.a64_frame_store(VAL, CLFP, LFP_SELF as u32);
@@ -563,9 +601,9 @@ impl Codegen {
             }
         }
         // None-fill the statically-uncovered trailing optionals (0 sentinel)
-        if none_fill != 0 {
+        if layout.none_fill != 0 {
             monoasm_arm64!(&mut self.jit, mov x12, (0u64););
-            for j in 0..none_fill {
+            for j in 0..layout.none_fill {
                 self.a64_frame_store(
                     VAL,
                     CLFP,

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1488,7 +1488,7 @@ impl Codegen {
     ///
     /// #### destroy
     /// - x9, x11, x12
-    pub(crate) fn emit_alloc_cell(&mut self, header: u64, slow: &DestLabel) {
+    pub(crate) fn emit_alloc_cell(&mut self, header: CellHeader, slow: &DestLabel) {
         let rax = GP::Rax.a64().0; // x0 (result)
         let free_head = self.alloc_free_head_addr as u64;
         let free_count = self.alloc_free_count_addr as u64;
@@ -1540,7 +1540,23 @@ impl Codegen {
             ldr x12, [x9];
             add x12, x12, #1;
             str x12, [x9];
-            mov x11, (header);
+        );
+        match header {
+            CellHeader::Imm(h) => monoasm_arm64!(&mut self.jit,
+                mov x11, (h);
+            ),
+            CellHeader::NewbornOf(src) => {
+                // Keep class/type (the upper 48 bits) and the non-GC flags.
+                let mask: u64 = !0xffffu64 | NEWBORN_FLAG_MASK as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x11, (src);
+                    ldr x11, [x11];
+                    mov x12, (mask);
+                    and x11, x11, x12;
+                );
+            }
+        }
+        monoasm_arm64!(&mut self.jit,
             str x11, [x(rax)];         // header (offset 0); overwrites the free link
         );
     }
@@ -1565,7 +1581,7 @@ impl Codegen {
         // 8-byte object header: flag=1 | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
         let header: u64 =
             ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
-        self.emit_alloc_cell(header, &slow);
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
         monoasm_arm64!(&mut self.jit,
             mov x12, #0;
             str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
@@ -1761,11 +1777,49 @@ impl Codegen {
 
     /// rax <- a deep copy of literal `v` (a fresh mutable object per
     /// evaluation). Mirrors x86 `deepcopy_literal`.
+    ///
+    /// A short all-immediate Array literal (`[1, 2]` and friends, which
+    /// `bytecodegen` bakes as a constant rather than compiling to
+    /// `NewArray`) is copied inline: its deep copy is just a header, the
+    /// inline length, and the element words. Everything else calls
+    /// `value_deep_copy`.
     pub(in crate::codegen::jitgen) fn emit_deep_copy_lit(
         &mut self,
         v: Value,
         using_fpr: UsingFpr,
     ) -> bool {
+        if let Some(elems) = v
+            .inline_copyable_array()
+            .filter(|_| !self.alloc_free_head_addr.is_null())
+        {
+            let rax = GP::Rax.a64().0; // x0 (result)
+            let slow = self.jit.label();
+            let cont = self.jit.label();
+            self.emit_alloc_cell(CellHeader::NewbornOf(v.id()), &slow);
+            monoasm_arm64!(&mut self.jit,
+                mov x12, #0;
+                str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
+                mov x12, (elems.len() as u64);
+                str x12, [x(rax), #(RVALUE_OFFSET_ARY_CAPA as u32)]; // inline length
+            );
+            for (k, e) in elems.iter().enumerate() {
+                let off = RVALUE_OFFSET_INLINE as u32 + (k as u32) * 8;
+                monoasm_arm64!(&mut self.jit,
+                    mov x12, (e.id());
+                    str x12, [x(rax), #(off)];
+                );
+            }
+            monoasm_arm64!(&mut self.jit, b cont;);
+            self.jit.bind_label(slow);
+            self.deep_copy_lit_call(v, using_fpr);
+            self.jit.bind_label(cont);
+            return true;
+        }
+        self.deep_copy_lit_call(v, using_fpr);
+        true
+    }
+
+    fn deep_copy_lit_call(&mut self, v: Value, using_fpr: UsingFpr) {
         let imm = v.id();
         let f = Value::value_deep_copy as *const () as u64;
         self.emit_fpr_save(using_fpr, false);
@@ -1777,7 +1831,6 @@ impl Codegen {
             ldr x30, [sp], #16;
         );
         self.emit_fpr_restore(using_fpr, false);
-        true
     }
 
     // ---- floating-point transfer primitives (aarch64) ---------------------

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -10,6 +10,7 @@
 //! vestigial. See `doc/aarch64-jitgen-plan.md`.
 
 use super::*;
+use crate::alloc::{BUMP_INLINE_LIMIT, CELL_SIZE_SHIFT, PAGE_DATA_OFFSET};
 use crate::codegen::jitgen::asmir::ArrayIndexKind;
 use crate::codegen::jitgen::asmir::compile_shared::{
     extend_ivar, set_array_integer_index, set_ivar, unreachable,
@@ -1469,6 +1470,81 @@ impl Codegen {
         self.emit_fpr_restore(using_fpr, false);
     }
 
+    /// Inline GC-cell allocation, shared by every inline constructor (array
+    /// literals, plain objects). Mirrors `Allocator::alloc`'s two fast
+    /// paths — pop a recycled cell from the free list, else bump-allocate
+    /// out of the current page — and writes the 8-byte object header,
+    /// leaving `var_table` and the type-specific body to the caller.
+    ///
+    /// Jumps to `slow` only where the runtime does real work: at
+    /// `BUMP_INLINE_LIMIT` the allocator sets the GC alloc flag and starts a
+    /// new page. The caller must emit a runtime fallback there.
+    ///
+    /// Callers must first check that `alloc_free_head_addr` is non-null (the
+    /// allocator addresses are captured once at `Codegen::new`).
+    ///
+    /// #### out
+    /// - x0 (Rax): the fresh cell, header already stored
+    ///
+    /// #### destroy
+    /// - x9, x11, x12
+    pub(crate) fn emit_alloc_cell(&mut self, header: u64, slow: &DestLabel) {
+        let rax = GP::Rax.a64().0; // x0 (result)
+        let free_head = self.alloc_free_head_addr as u64;
+        let free_count = self.alloc_free_count_addr as u64;
+        let total = self.alloc_total_addr as u64;
+        let used = self.alloc_used_addr as u64;
+        let page = self.alloc_page_addr as u64;
+        let bump = self.jit.label();
+        let done = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (free_head);
+            ldr x(rax), [x9];          // rax = free-list head (cell ptr, or 0 = None)
+            cbz x(rax), bump;
+            ldr x12, [x(rax)];         // x12 = (*cell).header.next (free link @ offset 0)
+            str x12, [x9];             // free = next
+            mov x9, (free_count);
+            ldr x12, [x9];
+            sub x12, x12, #1;
+            str x12, [x9];
+            b done;
+        );
+        self.jit.bind_label(bump.clone());
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (used);
+            ldr x12, [x9];             // x12 = used_in_current
+            mov x11, (BUMP_INLINE_LIMIT as u64);
+            cmp x12, x11;
+        );
+        // alloc-flag / new-page territory: hand back to the runtime.
+        self.jit.bcond_label(monoasm::Cond::Hs, slow);
+        monoasm_arm64!(&mut self.jit,
+            mov x11, (page);
+            ldr x(rax), [x11];         // rax = current page
+            lsl x11, x12, #(CELL_SIZE_SHIFT);
+            add x(rax), x(rax), x11;   // + used_in_current * CELL_SIZE
+        );
+        if PAGE_DATA_OFFSET != 0 {
+            monoasm_arm64!(&mut self.jit,
+                mov x11, (PAGE_DATA_OFFSET as u64);
+                add x(rax), x(rax), x11;
+            );
+        }
+        monoasm_arm64!(&mut self.jit,
+            add x12, x12, #1;
+            str x12, [x9];             // used_in_current += 1
+        );
+        self.jit.bind_label(done.clone());
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (total);
+            ldr x12, [x9];
+            add x12, x12, #1;
+            str x12, [x9];
+            mov x11, (header);
+            str x11, [x(rax)];         // header (offset 0); overwrites the free link
+        );
+    }
+
     /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
     /// literal: pop a recycled cell from the GC free list and initialise it
     /// directly as an inline-storage Array, falling back to the runtime
@@ -1486,28 +1562,11 @@ impl Codegen {
         let lfp = GP::R14.a64().0; // x22
         let slow = self.jit.label();
         let cont = self.jit.label();
-        let free_head = self.alloc_free_head_addr as u64;
-        let free_count = self.alloc_free_count_addr as u64;
-        let total = self.alloc_total_addr as u64;
         // 8-byte object header: flag=1 | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
         let header: u64 =
             ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
+        self.emit_alloc_cell(header, &slow);
         monoasm_arm64!(&mut self.jit,
-            mov x9, (free_head);
-            ldr x(rax), [x9];          // rax = free-list head (cell ptr, or 0 = None)
-            cbz x(rax), slow;
-            ldr x12, [x(rax)];         // x12 = (*cell).header.next (free link @ offset 0)
-            str x12, [x9];             // free = next
-            mov x9, (free_count);
-            ldr x12, [x9];
-            sub x12, x12, #1;
-            str x12, [x9];
-            mov x9, (total);
-            ldr x12, [x9];
-            add x12, x12, #1;
-            str x12, [x9];
-            mov x11, (header);
-            str x11, [x(rax)];                              // header (offset 0)
             mov x12, #0;
             str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
             mov x12, (len as u64);

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2330,15 +2330,14 @@ impl Codegen {
                 deferred_src,
             } => {
                 let offset = store[callee_fid].get_offset();
-                // D1 source-routed: the forwarded count is the statically
-                // known caller arg count; missing optional slots are
-                // None-filled (gate guarantees req <= lead+len <= reqopt).
+                // D1 source-routed: the whole bind is a compile-time
+                // constant (see `forwarded_deferred_layout`).
                 return match deferred_src {
                     Some((src, len)) => {
-                        let n = len as usize;
-                        let none_fill = store[callee_fid].reqopt_num() - lead_num - n;
+                        let layout = store[callee_fid]
+                            .forwarded_deferred_layout(lead_num, len as usize);
                         self.a64_set_arguments_forwarded_deferred(
-                            recv, args, lead_num, n, none_fill, src,
+                            offset, recv, args, lead_num, src, layout,
                         )
                     }
                     // Eager (rest Array materialized): the callee is req-only

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -141,48 +141,67 @@ impl Codegen {
 
     /// `Class#allocate`: `alloc_func(class_id, globals)` → rax.
     ///
-    /// With `inline_object` (a plain object produced by
-    /// `default_alloc_func`, with no spilled ivar table), the whole
-    /// allocation is emitted here instead: pop a cell from the GC free list
-    /// and write the header, `var_table = None` and `OBJECT_INLINE_IVAR`
-    /// nil slots — which is the entire payload of `RValue::new_object`.
-    /// An empty free list falls back to the call.
+    /// With an `inline` payload the whole allocation is emitted here
+    /// instead: pop a cell (`emit_alloc_cell`) and write exactly what the
+    /// stock allocator would have produced. The runtime call is kept as the
+    /// fallback for the page-boundary cases.
     pub(crate) fn emit_class_allocate(
         &mut self,
         class_id: u32,
         alloc_func: u64,
-        inline_object: bool,
+        inline: Option<InlineAlloc>,
     ) {
-        if inline_object && !self.alloc_free_head_addr.is_null() {
-            let slow = self.jit.label();
-            let cont = self.jit.label();
-            // 8-byte object header: flag=1 (live) | ty=OBJECT<<16 | class<<32.
-            let header: u64 =
-                ((class_id as u64) << 32) | ((ObjTy::OBJECT.get() as u64) << 16) | 1;
-            self.emit_alloc_cell(header, &slow);
-            monoasm! { &mut self.jit,
-                movq [rax + (RVALUE_OFFSET_VAR)], 0;  // var_table = None
-            }
+        let Some(inline) = inline.filter(|_| !self.alloc_free_head_addr.is_null()) else {
+            self.class_allocate_call(class_id, alloc_func);
+            return;
+        };
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        // 8-byte object header: flag=1 (live) | ty<<16 | class<<32.
+        let ty = match inline {
+            InlineAlloc::Object => ObjTy::OBJECT,
+            InlineAlloc::Struct(_) => ObjTy::STRUCT,
+        };
+        let header: u64 = ((class_id as u64) << 32) | ((ty.get() as u64) << 16) | 1;
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
+        monoasm! { &mut self.jit,
+            movq [rax + (RVALUE_OFFSET_VAR)], 0;  // var_table = None
+        }
+        match inline {
             // `ObjKind::object()` == `[None; OBJECT_INLINE_IVAR]` at the
             // head of the `kind` union (the same `RVALUE_OFFSET_KIND +
             // ivarid * 8` addressing the ivar emitters use), and `None`
             // for `Option<Value>` is a zero word.
-            for k in 0..OBJECT_INLINE_IVAR {
-                let off = RVALUE_OFFSET_KIND as i32 + (k as i32) * 8;
-                monoasm! { &mut self.jit,
-                    movq [rax + (off)], 0;
+            InlineAlloc::Object => {
+                for k in 0..OBJECT_INLINE_IVAR {
+                    let off = RVALUE_OFFSET_KIND as i32 + (k as i32) * 8;
+                    monoasm! { &mut self.jit,
+                        movq [rax + (off)], 0;
+                    }
                 }
             }
-            monoasm! { &mut self.jit,
-                jmp  cont;
-            slow:
+            // `StructInner::new(len)` == a `SmallVec` holding `len` nils:
+            // the smallvec's capacity field doubles as the inline length,
+            // and slots past `len` stay untouched, exactly as in Rust.
+            InlineAlloc::Struct(len) => {
+                monoasm! { &mut self.jit,
+                    movq [rax + (RVALUE_OFFSET_ARY_CAPA)], (len as i32);
+                }
+                for k in 0..len {
+                    let off = RVALUE_OFFSET_INLINE as i32 + (k as i32) * 8;
+                    monoasm! { &mut self.jit,
+                        movq [rax + (off)], (NIL_VALUE as i32);
+                    }
+                }
             }
-            self.class_allocate_call(class_id, alloc_func);
-            monoasm! { &mut self.jit,
-            cont:
-            }
-        } else {
-            self.class_allocate_call(class_id, alloc_func);
+        }
+        monoasm! { &mut self.jit,
+            jmp  cont;
+        slow:
+        }
+        self.class_allocate_call(class_id, alloc_func);
+        monoasm! { &mut self.jit,
+        cont:
         }
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -140,7 +140,53 @@ impl Codegen {
     }
 
     /// `Class#allocate`: `alloc_func(class_id, globals)` → rax.
-    pub(crate) fn emit_class_allocate(&mut self, class_id: u32, alloc_func: u64) {
+    ///
+    /// With `inline_object` (a plain object produced by
+    /// `default_alloc_func`, with no spilled ivar table), the whole
+    /// allocation is emitted here instead: pop a cell from the GC free list
+    /// and write the header, `var_table = None` and `OBJECT_INLINE_IVAR`
+    /// nil slots — which is the entire payload of `RValue::new_object`.
+    /// An empty free list falls back to the call.
+    pub(crate) fn emit_class_allocate(
+        &mut self,
+        class_id: u32,
+        alloc_func: u64,
+        inline_object: bool,
+    ) {
+        if inline_object && !self.alloc_free_head_addr.is_null() {
+            let slow = self.jit.label();
+            let cont = self.jit.label();
+            // 8-byte object header: flag=1 (live) | ty=OBJECT<<16 | class<<32.
+            let header: u64 =
+                ((class_id as u64) << 32) | ((ObjTy::OBJECT.get() as u64) << 16) | 1;
+            self.emit_alloc_cell(header, &slow);
+            monoasm! { &mut self.jit,
+                movq [rax + (RVALUE_OFFSET_VAR)], 0;  // var_table = None
+            }
+            // `ObjKind::object()` == `[None; OBJECT_INLINE_IVAR]` at the
+            // head of the `kind` union (the same `RVALUE_OFFSET_KIND +
+            // ivarid * 8` addressing the ivar emitters use), and `None`
+            // for `Option<Value>` is a zero word.
+            for k in 0..OBJECT_INLINE_IVAR {
+                let off = RVALUE_OFFSET_KIND as i32 + (k as i32) * 8;
+                monoasm! { &mut self.jit,
+                    movq [rax + (off)], 0;
+                }
+            }
+            monoasm! { &mut self.jit,
+                jmp  cont;
+            slow:
+            }
+            self.class_allocate_call(class_id, alloc_func);
+            monoasm! { &mut self.jit,
+            cont:
+            }
+        } else {
+            self.class_allocate_call(class_id, alloc_func);
+        }
+    }
+
+    fn class_allocate_call(&mut self, class_id: u32, alloc_func: u64) {
         monoasm! { &mut self.jit,
             movl rdi, (class_id);
             movq rsi, r12;

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -602,12 +602,13 @@ impl Codegen {
         args: SlotId,
         lead_num: usize,
         expected_len: usize,
-        none_fill: usize,
+        layout: Option<ForwardedLayout>,
         recv: SlotId,
         kwrest_guard: Option<SlotId>,
         deferred_src: Option<(SlotId, u16)>,
     ) {
         if let Some((src, _len)) = deferred_src {
+            let layout = layout.expect("a source-routed forward always carries its layout");
             // D1: the `...` rest `Array` was deferred. `recv` and the
             // `lead_num` leading args are `f`'s own slots (`f`'s rbp).
             // The forwarded positionals come from the *caller* frame:
@@ -621,6 +622,42 @@ impl Codegen {
             // covered by the forwarded args) get `None` (0), exactly as
             // `fill_positional_args` writes for an absent optional — the
             // callee prologue's `CheckLocal` then runs the defaults.
+            //
+            // A `*rest` callee gets its `Array` built straight off the
+            // caller's slots, with no intermediate: the elements are a
+            // contiguous tail of the forwarded window (see
+            // `forwarded_deferred_layout`), which is exactly the shape
+            // `create_array` consumes. It is emitted *first*, before any
+            // callee slot is written, so the call cannot disturb the
+            // frame under construction: `rsp` is lowered past the whole
+            // callee frame for the duration (as `jit_set_arguments`
+            // does), and nothing of the frame exists yet anyway. It is
+            // GC-safe for the same reason the side-exit materialization
+            // (`gen_forward_rest_materialize`) is: every element is
+            // still live in the caller's frame slots, which are on the
+            // control-frame chain and scanned.
+            if let Some(rest) = layout.rest {
+                let elem0 = rbp_local(src + rest.src_offset);
+                monoasm! { &mut self.jit,
+                    movq rcx, [rbp];            // caller rbp
+                    lea  rdi, [rcx - (elem0)];  // highest-address element
+                    movq rsi, (rest.len);
+                    subq rsp, (offset);
+                    movq rax, (runtime::create_array);
+                    call rax;
+                    addq rsp, (offset);
+                    movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * rest.pos as usize) as i32)], rax;
+                }
+            }
+            // A bare `**kwrest` gets `nil` — "no keyword arguments"
+            // everywhere downstream, matching the runtime's
+            // `store_empty_kw_rest`.
+            if let Some(kw_rest) = layout.kw_rest {
+                monoasm! { &mut self.jit,
+                    movq rax, (NIL_VALUE);
+                    movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF + (8 * kw_rest.0 as usize) as i32)], rax;
+                }
+            }
             monoasm! { &mut self.jit,
                 movq rax, [rbp - (rbp_local(recv))];
                 movq [rsp - (RSP_LOCAL_FRAME + LFP_SELF)], rax;
@@ -640,7 +677,7 @@ impl Codegen {
                     movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * (lead_num + j)) as i32)], rax;
                 }
             }
-            for j in 0..none_fill {
+            for j in 0..layout.none_fill {
                 monoasm! { &mut self.jit,
                     movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * (lead_num + expected_len + j)) as i32)], 0;
                 }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -997,7 +997,7 @@ impl Codegen {
     ///
     /// #### destroy
     /// - rdi, rcx
-    pub(crate) fn emit_alloc_cell(&mut self, header: u64, slow: &DestLabel) {
+    pub(crate) fn emit_alloc_cell(&mut self, header: CellHeader, slow: &DestLabel) {
         let free_head = self.alloc_free_head_addr as u64;
         let free_count = self.alloc_free_count_addr as u64;
         let total = self.alloc_total_addr as u64;
@@ -1035,7 +1035,23 @@ impl Codegen {
         done:
             movq rdi, (total);
             addq [rdi], 1;
-            movq rdi, (header);
+        }
+        match header {
+            CellHeader::Imm(h) => monoasm! { &mut self.jit,
+                movq rdi, (h);
+            },
+            CellHeader::NewbornOf(src) => {
+                // Keep class/type (the upper 48 bits) and the non-GC flags.
+                let mask: u64 = !0xffffu64 | NEWBORN_FLAG_MASK as u64;
+                monoasm! { &mut self.jit,
+                    movq rdi, (src);
+                    movq rdi, [rdi];
+                    movq rcx, (mask);
+                    andq rdi, rcx;
+                }
+            }
+        }
+        monoasm! { &mut self.jit,
             movq [rax + (RVALUE_OFFSET_FLAG)], rdi;   // header (offset 0); overwrites the free link
         }
     }
@@ -1064,7 +1080,7 @@ impl Codegen {
         // 8-byte object header: flag=1 (live) | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
         let header: u64 =
             ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
-        self.emit_alloc_cell(header, &slow);
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
         monoasm! { &mut self.jit,
             movq [rax + (RVALUE_OFFSET_VAR)], 0;      // var_table = None
             movq [rax + (RVALUE_OFFSET_ARY_CAPA)], (len as i32);  // inline length (capa == len <= 5)
@@ -1174,12 +1190,46 @@ impl Codegen {
     }
 
     /// rax <- a deep copy of literal `v` (fresh mutable object per evaluation).
+    ///
+    /// A short all-immediate Array literal (`[1, 2]` and friends, which
+    /// `bytecodegen` bakes as a constant rather than compiling to
+    /// `NewArray`) is copied inline: its deep copy is just a header, the
+    /// inline length, and the element words. Everything else calls
+    /// `value_deep_copy`.
     pub(in crate::codegen::jitgen) fn emit_deep_copy_lit(
         &mut self,
         v: Value,
         using_fpr: UsingFpr,
     ) -> bool {
+        let Some(elems) = v
+            .inline_copyable_array()
+            .filter(|_| !self.alloc_free_head_addr.is_null())
+        else {
+            self.deepcopy_literal(v, using_fpr);
+            return true;
+        };
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        self.emit_alloc_cell(CellHeader::NewbornOf(v.id()), &slow);
+        monoasm! { &mut self.jit,
+            movq [rax + (RVALUE_OFFSET_VAR)], 0;  // var_table = None
+            movq [rax + (RVALUE_OFFSET_ARY_CAPA)], (elems.len() as i32);  // inline length
+        }
+        for (k, e) in elems.iter().enumerate() {
+            let off = RVALUE_OFFSET_INLINE as i32 + (k as i32) * 8;
+            monoasm! { &mut self.jit,
+                movq rcx, (e.id());
+                movq [rax + (off)], rcx;
+            }
+        }
+        monoasm! { &mut self.jit,
+            jmp  cont;
+        slow:
+        }
         self.deepcopy_literal(v, using_fpr);
+        monoasm! { &mut self.jit,
+        cont:
+        }
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -10,6 +10,7 @@ mod init_method;
 mod method_call;
 mod variables;
 
+use crate::alloc::{BUMP_INLINE_LIMIT, CELL_SIZE_SHIFT, PAGE_DATA_OFFSET};
 use super::compile_shared::{extend_ivar, unreachable};
 use crate::codegen::jitgen::lir::{LAluOp, LCond, LInst, LMem, LOperand, LReg, LSideExitKind};
 
@@ -978,6 +979,67 @@ impl Codegen {
         true
     }
 
+    /// Inline GC-cell allocation, shared by every inline constructor (array
+    /// literals, plain objects). Mirrors `Allocator::alloc`'s two fast
+    /// paths — pop a recycled cell from the free list, else bump-allocate
+    /// out of the current page — and writes the 8-byte object header,
+    /// leaving `var_table` and the type-specific body to the caller.
+    ///
+    /// Jumps to `slow` only where the runtime does real work: at
+    /// `BUMP_INLINE_LIMIT` the allocator sets the GC alloc flag and starts a
+    /// new page. The caller must emit a runtime fallback there.
+    ///
+    /// Callers must first check that `alloc_free_head_addr` is non-null (the
+    /// allocator addresses are captured once at `Codegen::new`).
+    ///
+    /// #### out
+    /// - rax: the fresh cell, header already stored
+    ///
+    /// #### destroy
+    /// - rdi, rcx
+    pub(crate) fn emit_alloc_cell(&mut self, header: u64, slow: &DestLabel) {
+        let free_head = self.alloc_free_head_addr as u64;
+        let free_count = self.alloc_free_count_addr as u64;
+        let total = self.alloc_total_addr as u64;
+        let used = self.alloc_used_addr as u64;
+        let page = self.alloc_page_addr as u64;
+        let bump = self.jit.label();
+        let done = self.jit.label();
+        monoasm! { &mut self.jit,
+            movq rdi, (free_head);
+            movq rax, [rdi];          // rax = free-list head (cell ptr, or 0 = None)
+            testq rax, rax;
+            jz   bump;
+            movq rcx, [rax];          // rcx = (*cell).header.next (free link @ offset 0)
+            movq [rdi], rcx;          // free = next
+            movq rdi, (free_count);
+            subq [rdi], 1;
+            jmp  done;
+        bump:
+            movq rdi, (used);
+            movq rcx, [rdi];          // rcx = used_in_current
+            cmpq rcx, (BUMP_INLINE_LIMIT);
+            jae  slow;                // alloc-flag / new-page territory
+            movq rax, (page);
+            movq rax, [rax];          // rax = current page
+            shlq rcx, (CELL_SIZE_SHIFT);
+            addq rax, rcx;            // + used_in_current * CELL_SIZE
+        }
+        if PAGE_DATA_OFFSET != 0 {
+            monoasm! { &mut self.jit,
+                addq rax, (PAGE_DATA_OFFSET);
+            }
+        }
+        monoasm! { &mut self.jit,
+            addq [rdi], 1;            // used_in_current += 1
+        done:
+            movq rdi, (total);
+            addq [rdi], 1;
+            movq rdi, (header);
+            movq [rax + (RVALUE_OFFSET_FLAG)], rdi;   // header (offset 0); overwrites the free link
+        }
+    }
+
     /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
     /// literal: pop a recycled cell from the GC free list and initialise it
     /// directly as an inline-storage Array, with no runtime call. When the
@@ -999,25 +1061,11 @@ impl Codegen {
     ) {
         let slow = self.jit.label();
         let cont = self.jit.label();
-        let free_head = self.alloc_free_head_addr as u64;
-        let free_count = self.alloc_free_count_addr as u64;
-        let total = self.alloc_total_addr as u64;
         // 8-byte object header: flag=1 (live) | ty=ARRAY<<16 | class=ARRAY_CLASS<<32.
         let header: u64 =
             ((ARRAY_CLASS.u32() as u64) << 32) | ((ObjTy::ARRAY.get() as u64) << 16) | 1;
+        self.emit_alloc_cell(header, &slow);
         monoasm! { &mut self.jit,
-            movq rdi, (free_head);
-            movq rax, [rdi];          // rax = free-list head (cell ptr, or 0 = None)
-            testq rax, rax;
-            jz   slow;
-            movq rcx, [rax];          // rcx = (*cell).header.next (free link @ offset 0)
-            movq [rdi], rcx;          // free = next
-            movq rdi, (free_count);
-            subq [rdi], 1;
-            movq rdi, (total);
-            addq [rdi], 1;
-            movq rdi, (header);
-            movq [rax + (RVALUE_OFFSET_FLAG)], rdi;   // header (offset 0); overwrites the free link
             movq [rax + (RVALUE_OFFSET_VAR)], 0;      // var_table = None
             movq [rax + (RVALUE_OFFSET_ARY_CAPA)], (len as i32);  // inline length (capa == len <= 5)
         }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -201,16 +201,16 @@ impl Codegen {
                 deferred_src,
             } => {
                 let offset = store[callee_fid].get_offset();
-                // D1 source-routed: the forwarded count is the statically
-                // known caller arg count; missing optional slots are
-                // None-filled (gate guarantees req <= lead+len <= reqopt).
-                // Eager: gate guarantees a req-only callee with
-                // req_num() >= lead_num, so the length guard is exact.
-                let (expected_len, none_fill) = if let Some((_, len)) = deferred_src {
-                    let n = len as usize;
-                    (n, store[callee_fid].reqopt_num() - lead_num - n)
-                } else {
-                    (store[callee_fid].req_num() - lead_num, 0)
+                // D1 source-routed: the whole bind is a compile-time
+                // constant (see `forwarded_deferred_layout`). Eager: the
+                // gate guarantees a plain req-only callee with
+                // `req_num() >= lead_num`, so the length guard is exact.
+                let layout = deferred_src.map(|(_, len)| {
+                    store[callee_fid].forwarded_deferred_layout(lead_num, len as usize)
+                });
+                let expected_len = match &layout {
+                    Some(l) => l.from_src,
+                    None => store[callee_fid].req_num() - lead_num,
                 };
                 self.jit_set_arguments_forwarded(
                     callid,
@@ -219,7 +219,7 @@ impl Codegen {
                     args,
                     lead_num,
                     expected_len,
-                    none_fill,
+                    layout,
                     recv,
                     kwrest_guard,
                     deferred_src,

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1212,10 +1212,24 @@ impl AbstractState {
         } else if callsite.forwarding
             && callsite.pos_num >= 1
             && callsite.splat_pos.as_slice() == [callsite.pos_num - 1]
-            && callee.no_keyword()
-            && !callee.is_rest()
             && callee.post_num() == 0
             && callee.reqopt_num() + 1 >= callsite.pos_num
+            // A bare `**kwrest` is fine — the lowering stores `nil` into
+            // that slot, exactly as the runtime's `store_empty_kw_rest`
+            // does. Requiring the call site to carry keyword syntax is
+            // what preserves ruby2_keywords (see `forwarded_fast_path_ok`
+            // in runtime/args.rs, which this mirrors); a `...` forward
+            // always carries the `**kwrest` hash-splat.
+            && (callee.no_keyword() || (callee.kw_names().is_empty() && callsite.kw_may_exists()))
+            // A block-style callee auto-splats a lone Array argument
+            // (`single_arg_expand`); the direct fills below do not model
+            // that, so leave those to the generic path — matching the
+            // runtime's own fast-path gate.
+            && !callee.single_arg_expand()
+            // An *implicit* rest (`|a,|`) does not accept extra args, so
+            // the "surplus goes to the rest" reasoning below needs an
+            // explicit `*rest`.
+            && (!callee.is_rest() || callee.is_explicit_rest())
         {
             // Forwarding `g(x.., ...)` where `g` takes only required (and
             // possibly optional) positionals and the only splat is the
@@ -1235,11 +1249,13 @@ impl AbstractState {
             // D1: if `f`'s `...` rest array was deferred at frame entry,
             // route the copy straight from the caller's source slots.
             // Only when the forwarded arity statically binds to `g`'s
-            // positional params — `req <= lead+len <= req+opt` with no
-            // post/rest, so the fill layout (copied slots + None-filled
-            // optionals, whose defaults the callee prologue then runs) is
-            // a compile-time constant and no `ArgumentError`-shaped case
-            // remains — and only for the `g(*rest, **kwrest, &blk)`
+            // positional params — `req <= lead+len`, no post, and the
+            // surplus over `req+opt` either absorbed by an explicit
+            // `*rest` or absent — so the whole fill layout (copied slots,
+            // None-filled optionals whose defaults the callee prologue
+            // runs, and the rest `Array`'s contiguous source window) is a
+            // compile-time constant and no `ArgumentError`-shaped case
+            // remains. Also only for the `g(*rest, **kwrest, &blk)`
             // trampoline shape (`kwrest_guard.is_some()`; the structural
             // gate guarantees no kw reaches `f`, so the forwarded
             // `**kwrest` is nil). `ir.set_deferred_rest` makes the
@@ -1250,7 +1266,8 @@ impl AbstractState {
                 Some((src, len))
                     if {
                         let n = lead_num + len as usize;
-                        callee.req_num() <= n && n <= callee.reqopt_num()
+                        callee.req_num() <= n
+                            && (callee.is_rest() || n <= callee.reqopt_num())
                     } && kwrest_guard.is_some() =>
                 {
                     ir.set_deferred_rest();
@@ -1268,11 +1285,16 @@ impl AbstractState {
             };
             self.write_back_recv_and_callargs(ir, callsite);
             let error = ir.new_error(self);
-            if deferred_src.is_none() && callee.opt_num() != 0 {
-                // Eager Array into an optional-taking callee: the bind
-                // length is only known at run time — keep the proven
-                // specialized runtime helper (same as before this branch
-                // accepted optional callees).
+            if deferred_src.is_none()
+                && (callee.opt_num() != 0 || callee.is_rest() || !callee.no_keyword())
+            {
+                // Eager (the `...` Array really was materialized): the
+                // bind length is only known at run time, so anything but
+                // a plain req-only callee — optional params, a `*rest`
+                // to size, or a `**kwrest` slot to initialize — keeps the
+                // proven specialized runtime helper. The inline fast path
+                // below guards on an exact length and would have to
+                // re-derive all of that at run time.
                 ir.push(AsmInst::SetArgumentsForwardedHelper { callid, callee_fid });
             } else {
                 ir.push(AsmInst::SetArgumentsForwarded {
@@ -1420,6 +1442,59 @@ mod tests {
               i += 1
             end
             res
+            "#,
+        );
+    }
+
+    /// D1 forwarding-rest deferral into a `*rest` / bare-`**kwrest`
+    /// callee: the rest `Array` is built directly from the caller's
+    /// slots (single `create_array`, no intermediate) and the kwrest
+    /// slot is nil-initialized. Cover empty/short/long binds, leading
+    /// args, opt+rest mixes, arity errors, and the freshness of the
+    /// built Array (mutating one result must not affect another call).
+    #[test]
+    fn forwarded_rest_callee() {
+        run_test(
+            r#"
+            def r0(*a) = [:r0, a]
+            def r1(x, *a) = [:r1, x, a]
+            def ro(x, y = :dy, *a) = [:ro, x, y, a]
+            def rk(*a, **k) = [:rk, a, k]
+            def f0(...) = r0(...)
+            def f1(...) = r1(...)
+            def fo(...) = ro(...)
+            def fk(...) = rk(...)
+            def lead(x, ...) = ro(x, ...)
+            def cap(*a) = a
+            def fc(...) = cap(...)
+            res = []
+            res << f0() << f0(1, 2, 3)
+            res << f1(1) << f1(1, 2, 3)
+            res << fo(1) << fo(1, 2) << fo(1, 2, 3, 4)
+            res << fk() << fk(1, 2)
+            res << lead(:L) << lead(:L, 1, 2, 3)
+            res << (begin; f1(); rescue ArgumentError => e; e.message; end)
+            x = fc(1, 2); y = fc(1, 2); x << 3
+            res << x << y
+            res
+            "#,
+        );
+    }
+
+    /// The motivating shape: Struct construction through the Ruby
+    /// `Class#new` — `Struct#initialize` is a rest + kwrest native.
+    #[test]
+    fn forwarded_struct_rest_native() {
+        run_test_with_prelude(
+            r#"
+            res = []
+            100.times { res = [S.new(1, 2).to_a, S.new(1).to_a, K.new(x: 5).x] }
+            res << (begin; S.new(1, 2, 3); rescue ArgumentError => e; e.message; end)
+            res
+            "#,
+            r#"
+            S = Struct.new(:a, :b)
+            K = Struct.new(:x, keyword_init: true)
             "#,
         );
     }

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -352,14 +352,26 @@ pub extern "C" fn default_alloc_func(class_id: ClassId, globals: &mut crate::Glo
 /// `allocate` before `Struct.new` finished initialising the subclass)
 /// we fall back to a zero-length slot vector.
 pub extern "C" fn struct_alloc_func(class_id: ClassId, globals: &mut crate::Globals) -> Value {
-    use crate::IdentId;
     use crate::value::Value;
-    // Walk the class chain looking for `/members` (set on the immediate
-    // subclass produced by `Struct.new(...)`, not propagated to deeper
-    // descendants like `Class.new(MyStruct)`).
-    let mut cls = globals.store[class_id].get_module();
-    let len = loop {
-        if let Some(m) = globals.store.get_ivar(cls.as_val(), IdentId::get_id("/members"))
+    let len = struct_members_len(&globals.store, class_id);
+    Value::struct_object(class_id, len)
+}
+
+/// Number of members of the `Struct` subclass `class_id`, i.e. the length of
+/// the `/members` array found by walking the class chain (it is set on the
+/// immediate subclass produced by `Struct.new(...)` and not propagated to
+/// deeper descendants like `Class.new(MyStruct)`). Zero when there is none.
+///
+/// Shared by `struct_alloc_func` and by the JIT, which bakes the count into
+/// an inline allocation instead of repeating this walk on every
+/// construction. Baking is sound for the same reason the struct
+/// reader/writer wrappers may bake a slot index and an inline/heap choice:
+/// a `Struct` subclass's shape is fixed when `Struct.new(...)` creates it.
+pub fn struct_members_len(store: &super::Store, class_id: ClassId) -> usize {
+    use crate::IdentId;
+    let mut cls = store[class_id].get_module();
+    loop {
+        if let Some(m) = store.get_ivar(cls.as_val(), IdentId::get_id("/members"))
             && let Some(arr) = m.try_array_ty()
         {
             break arr.len();
@@ -368,8 +380,7 @@ pub extern "C" fn struct_alloc_func(class_id: ClassId, globals: &mut crate::Glob
             Some(s) => cls = s,
             None => break 0,
         }
-    };
-    Value::struct_object(class_id, len)
+    }
 }
 
 impl alloc::GC<RValue> for ClassInfo {

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -794,6 +794,39 @@ struct FuncExt {
     wrapper: Option<(monoasm::CodePtr, usize, monoasm::CodePtr, usize)>,
 }
 
+///
+/// The callee's `*rest` `Array` in a D1 source-routed forwarding call:
+/// build it from `len` values starting at the caller's argument slot
+/// `src + src_offset`, and store it in positional slot `pos`.
+///
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RestBuild {
+    /// Rest-parameter index among the callee's positional params.
+    pub pos: u16,
+    /// Offset into the caller's forwarded argument window.
+    pub src_offset: usize,
+    /// Number of elements (0 for an empty rest).
+    pub len: usize,
+}
+
+///
+/// Static callee-frame layout of a D1 source-routed forwarding call.
+/// See `FuncInfo::forwarded_deferred_layout`.
+///
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ForwardedLayout {
+    /// Values copied from the caller's slots into req/opt slots (the
+    /// `lead_num` leading args fill the positions before these).
+    pub from_src: usize,
+    /// Trailing optional slots left uncovered; they get the `None`
+    /// sentinel so the callee prologue runs their default expressions.
+    pub none_fill: usize,
+    /// The callee's `*rest`, when it declares one.
+    pub rest: Option<RestBuild>,
+    /// The callee's bare `**kwrest` slot, initialized to `nil`.
+    pub kw_rest: Option<SlotId>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct FuncInfo {
     /// function data.
@@ -1199,6 +1232,44 @@ impl FuncInfo {
 
     pub(crate) fn rest_pos(&self) -> Option<u16> {
         self.ext.params.is_rest()
+    }
+
+    ///
+    /// Static callee-frame layout for a D1 source-routed forwarding call
+    /// (`def f(...) = g(...)` whose `...` rest was deferred).
+    ///
+    /// `lead_num` ordinary leading args sit in `f`'s own slots and
+    /// `len` forwarded positionals in the *caller's* argument slots, so
+    /// the total positional count `n = lead_num + len` is a compile-time
+    /// constant and the whole bind is static. The gate in
+    /// `jitgen/compile/method_call.rs` guarantees `req <= n`, no post
+    /// params, `reqopt >= lead_num`, and — when `n > reqopt` — an
+    /// explicit `*rest` to absorb the surplus.
+    ///
+    /// Because the leading args always occupy the first positions and
+    /// are always consumed by req/opt (`reqopt >= lead_num`), the values
+    /// that land in the rest `Array` are exactly a *contiguous* tail of
+    /// the caller's source slots — which is what lets the backends build
+    /// it with a single `create_array` straight off the caller frame,
+    /// with no intermediate.
+    ///
+    pub(crate) fn forwarded_deferred_layout(&self, lead_num: usize, len: usize) -> ForwardedLayout {
+        let n = lead_num + len;
+        let reqopt = self.reqopt_num();
+        // Values bound to req/opt slots; the surplus (if any) goes to `*rest`.
+        let bound = n.min(reqopt);
+        ForwardedLayout {
+            from_src: bound - lead_num,
+            none_fill: reqopt - bound,
+            rest: self
+                .rest_pos()
+                .map(|pos| RestBuild {
+                    pos,
+                    src_offset: bound - lead_num,
+                    len: n - bound,
+                }),
+            kw_rest: self.kw_rest(),
+        }
     }
 
     pub(crate) fn is_block_style(&self) -> bool {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -2432,6 +2432,12 @@ impl Value {
         unsafe { self.rvalue_mut().as_array_mut() }
     }
 
+    /// See `RValue::inline_copyable_array`: the elements of a literal the
+    /// JIT can copy inline instead of calling `value_deep_copy`.
+    pub(crate) fn inline_copyable_array(&self) -> Option<Vec<Value>> {
+        self.try_rvalue()?.inline_copyable_array()
+    }
+
     pub(crate) fn try_array_ty(&self) -> Option<Array> {
         let rv = self.try_rvalue()?;
         match rv.ty() {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -76,6 +76,17 @@ pub const RVALUE_OFFSET_INLINE: usize = RVALUE_OFFSET_KIND + smallvec::OFFSET_IN
 pub const RVALUE_OFFSET_HEAP_PTR: usize = RVALUE_OFFSET_KIND + smallvec::OFFSET_HEAP_PTR;
 pub const RVALUE_OFFSET_HEAP_LEN: usize = RVALUE_OFFSET_KIND + smallvec::OFFSET_HEAP_LEN;
 
+/// The JIT addresses an `ObjTy::OBJECT`'s inline ivar slots as
+/// `RVALUE_OFFSET_KIND + 8 * i` (see the ivar load/store emitters and the
+/// inline `Class#allocate`, which nil-fills all of them). Note this is
+/// `RVALUE_OFFSET_KIND`, *not* `RVALUE_OFFSET_INLINE` — the latter is the
+/// smallvec payload used by Array/Struct slots. Sound only while all
+/// `OBJECT_INLINE_IVAR` slots stay inside the cell: a layout change that
+/// grew `kind`'s prefix would silently write past the object, so pin it
+/// here rather than in one backend.
+const _: () =
+    assert!(RVALUE_OFFSET_KIND + OBJECT_INLINE_IVAR * 8 <= std::mem::size_of::<RValue>());
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ObjTy(std::num::NonZeroU8);
 

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -66,6 +66,11 @@ pub const OBJECT_INLINE_IVAR: usize = 6;
 /// `set_age` overwrites wholesale (issue #975: this bit previously sat
 /// on bit 8 and corrupted / was corrupted by the age counter).
 const CHILLED_LITERAL_BIT: u16 = 0b1000_0000;
+/// Flag bits a newborn copy inherits from its source (see
+/// `Header::newborn`): everything except the generational-GC state. Shared
+/// with the JIT, whose inline literal copy masks the template's header word
+/// with exactly this, so the two cannot drift apart.
+pub const NEWBORN_FLAG_MASK: u16 = 0b0001_0111 | CHILLED_LITERAL_BIT;
 pub const RVALUE_OFFSET_FLAG: usize = std::mem::offset_of!(RValue, header.meta.flag);
 pub const RVALUE_OFFSET_TY: usize = std::mem::offset_of!(RValue, header.meta.ty);
 pub const RVALUE_OFFSET_CLASS: usize = std::mem::offset_of!(RValue, header.meta.class);
@@ -1188,6 +1193,33 @@ impl RValue {
             .ivar_names()
             .filter_map(|(name, id)| self.get_ivar_by_ivarid(*id).map(|v| (*name, v)))
             .collect()
+    }
+
+    ///
+    /// The elements of a literal template that the JIT may copy inline
+    /// instead of calling `Value::value_deep_copy`, or `None` when the
+    /// literal needs the general deep copy.
+    ///
+    /// Qualifying literals are short Arrays — short enough that the copy's
+    /// slots live inline, so no heap buffer is needed — whose elements are
+    /// all immediates. `Value::deep_copy` is the identity on an immediate,
+    /// so for those a deep copy is a plain word copy. A template carrying
+    /// instance variables is excluded, since the copy must clone them.
+    ///
+    /// The elements are safe to bake into machine code: they are
+    /// immediates (never GC pointers), and the template itself is owned by
+    /// the bytecode and never mutated.
+    ///
+    pub(crate) fn inline_copyable_array(&self) -> Option<Vec<Value>> {
+        if self.ty() != ObjTy::ARRAY || self.var_table.is_some() {
+            return None;
+        }
+        // SAFETY: the type check above proves the `array` variant is active.
+        let ary = unsafe { &self.kind.array };
+        if ary.len() > ARRAY_INLINE_CAPA || ary.iter().any(|e| e.try_rvalue().is_some()) {
+            return None;
+        }
+        Some(ary.iter().copied().collect())
     }
 
     pub(crate) fn get_ivar_by_ivarid(&self, id: IvarId) -> Option<Value> {
@@ -2444,7 +2476,7 @@ impl Header {
     /// itself.
     fn newborn(&self) -> Header {
         let mut header = *self;
-        unsafe { header.meta.flag &= 0b0001_0111 | CHILLED_LITERAL_BIT };
+        unsafe { header.meta.flag &= NEWBORN_FLAG_MASK };
         header
     }
 


### PR DESCRIPTION
## Summary

Object creation no longer calls out to the runtime allocator on its hot path. The free-list pop that small Array literals already used is generalized into a shared emitter, extended with the **bump-allocation** case, and reused by plain objects, `Struct` instances, and const array literals.

Two commits:

* **`7c85910`** — extract `emit_alloc_cell`, add the bump path, inline `Class#allocate` for plain objects.
* **`4ce6dc4`** — inline `Struct` allocation and small const array literals.

## What is now emitted inline

`emit_alloc_cell` (both backends) mirrors `Allocator::alloc`'s two fast paths — pop a recycled cell from the free list, else bump out of the current page — and writes the 8-byte header. Callers fill in the type-specific body:

| caller | payload | gate |
|---|---|---|
| Array literal | inline length + element words | existing, no splat, `len <= ARRAY_INLINE_CAPA` |
| `Class#allocate` | `var_table = None` + `OBJECT_INLINE_IVAR` nil slots | `default_alloc_func` and `ivar_len() <= 6` |
| `Class#allocate` (Struct) | inline length + `len` nil slots | `struct_alloc_func` and `len <= STRUCT_INLINE_SLOTS` |
| const array literal | inline length + baked immediate elements | short Array of immediates, no ivars |

The runtime call survives only where it does real work: at `BUMP_INLINE_LIMIT` the allocator sets the GC alloc flag and starts a new page (together 64 of every 4032 allocations).

**The bump case is the point.** A free-list-only inline does nothing for a workload whose objects stay live — the free list is refilled by sweeping, so a growing heap never has one. That is exactly the shape of the construction-heavy benchmarks.

## Notes on the individual gates

* **Plain objects** — the `ivar_len() <= 6` check is an optimization gate, not a correctness one: `var_table: None` is valid for any object (it is what `RValue::new_object` stores) and the table grows on demand, so a class that gains ivars after the compile stays correct.
* **Structs** — `struct_alloc_func` walked the class chain looking up `/members` on *every* construction just to learn the slot count. That is hoisted to compile time via a new `struct_members_len` helper shared with the allocator, so the two cannot drift. Baking the count is sound for the same reason the struct reader/writer wrappers already bake a slot index and an inline/heap choice: a Struct subclass's shape is fixed when `Struct.new(...)` creates it.
* **Const array literals** — `[1, 2]` never reaches `TraceIr::Array`; bytecodegen compiles an all-literal array to a baked constant plus a `value_deep_copy` call, so the existing `NewArray` inlining never applied. When the elements are all immediates (deep copy is the identity on those) and the template has no ivars, the copy is a plain word copy. Its header comes from the new `CellHeader::NewbornOf`, which loads the template's header **at run time** and masks it with `NEWBORN_FLAG_MASK` — the same constant `Header::newborn` now uses — so the copy inherits class, type and the frozen/chilled bits while starting young, with no compile-time assumption about bits that could change later. Nested or heap-element literals (`[[1],[2]]`, `["a"]`) keep the general deep copy.

A const assertion in `rvalue.rs` now pins the fact that an object's inline ivar slots are addressed from `RVALUE_OFFSET_KIND` (not `RVALUE_OFFSET_INLINE`, which is the smallvec payload used by Array/Struct slots) and that all of them fit inside the cell. It caught a real mistake while this was being written.

## Performance (2M iterations, interleaved A/B, min of 3)

| case | before | after |
|---|---|---|
| `[1, 2]` const literal | 0.176s | **0.082s (−53%)** |
| `S4.new(1,2)` (4-member Struct) | 0.378s | **0.286s (−24%)** |
| `[i, 2]` literal | 0.106s | 0.083s (−19%) |
| `Object.new` | 0.125s | 0.107s (−14%) |
| `Foo.new(1)` (1 ivar) | 0.122s | 0.106s (−13%) |
| `Wide.new` (7 ivars, spills) | 0.258s | unchanged (excluded by design) |

bedcov's construction phases improve by about what the micros predict (~0.09s per 2M constructions), which is only a few percent of that benchmark — its remaining gap is no longer in allocation.

## Correctness

* Output verified **identical to CRuby** under both the JIT and `--no-jit` for: copy independence and mutation, freezing one copy not affecting the next, nested/heap-element literals, empty and over-capacity arrays, over-capacity structs, `Struct` subclasses, `keyword_init:`, `allocate` directly, `S[...]`, and arity errors.
* GC safety: a freshly allocated young object needs no write barrier for its children, and there is no safepoint between the cell being taken and its body being written, so a partially built object is never observed by a collection. `gc-stress` is unaffected by inlining, since it drives collection from the alloc flag at safepoints rather than from `Allocator::alloc`. The inline paths keep `free_list_count` / `total_allocated_objects` in sync with the runtime path.
* Full suite green on both commits: `cargo test -p monoruby --features stress-spill-pool,gc-stress` (lib + all integration targets + doc-tests), plus `cargo check` for `aarch64-unknown-linux-gnu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUZQEe27QVvkLPCgq9oHcJ)_