### PR TITLE
perf(jit): fold trivial methods through `...` forwards; drop D1's dead sentinel

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -520,9 +520,10 @@ impl Codegen {
     ///   defaults.
     ///
     /// Statically-bound arity and a nil forwarded `**kwrest` are gate
-    /// invariants, so there is no length/kw guard and no fallback. Leaves
-    /// `x0 = NIL_VALUE` (the success sentinel the following `HandleError`
-    /// checks). Scratch: x9..x15 are reserved lowering temps (never GP-mapped);
+    /// invariants, so there is no length/kw guard and no fallback — nothing
+    /// here can fail, so no success sentinel is produced and the caller emits
+    /// no `HandleError`.
+    /// Scratch: x9..x15 are reserved lowering temps (never GP-mapped);
     /// x10 is used internally by `a64_frame_load/store` for large offsets, so
     /// the fixed temps below avoid it.
     pub(super) fn a64_set_arguments_forwarded_deferred(
@@ -611,7 +612,6 @@ impl Codegen {
                 );
             }
         }
-        monoasm_arm64!(&mut self.jit, mov x0, (NIL_VALUE as u64););
         true
     }
 

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -592,6 +592,8 @@ impl Codegen {
     ///
     /// ### out
     /// - rax: NIL_VALUE on success (non-zero), None(0) for error.
+    ///   The `deferred_src` (D1) path cannot fail, so it produces no
+    ///   sentinel at all — its caller emits no `HandleError`.
     ///
     /// ### destroy
     /// - caller save registers
@@ -684,9 +686,8 @@ impl Codegen {
                     movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * (lead_num + expected_len + j)) as i32)], 0;
                 }
             }
-            monoasm! { &mut self.jit,
-                movq rax, (NIL_VALUE);
-            }
+            // No success sentinel: nothing above can fail, and the caller
+            // emits no `HandleError` for D1.
             return;
         }
         let fallback = self.jit.label();

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -311,22 +311,53 @@ impl<'a> JitContext<'a> {
                 // accepts kwargs — required-kw-missing and unknown-kw
                 // would silently fold otherwise. Restrict folding to the
                 // "neither side touches kwargs" case to avoid that.
-                if self.store.is_simple_call(func_id, callid)
+                let simple_fold = self.store.is_simple_call(func_id, callid)
                     && self.store[func_id].no_keyword()
-                    && !callsite.kw_may_exists()
-                {
-                    match self.store[iseq].hint {
+                    && !callsite.kw_may_exists();
+                // A `...`-forwarding call site never satisfies
+                // `is_simple_call` (its splat and hash-splat disqualify it),
+                // so the fold above never sees the
+                // `o.__builtin_initialize__(...)` inside the Ruby
+                // `Class#new` — i.e. the overwhelmingly common
+                // `def initialize(x); end`. When the frame's forwarded `...`
+                // rest was deferred (D1) the argument shape is a
+                // compile-time constant, which is all the fold needs; see
+                // `forwarded_trivial_pos_num`.
+                let forwarded_fold = !simple_fold
+                    && self
+                        .forwarded_trivial_pos_num(state, callsite)
+                        .is_some_and(|n| {
+                            let callee = &self.store[func_id];
+                            callee.no_keyword()
+                                && !callee.single_arg_expand()
+                                && callee.positional_arity_ok(n)
+                        });
+                if simple_fold || forwarded_fold {
+                    let folded = match self.store[iseq].hint {
                         ISeqHint::ConstReturn(v) => {
                             state.def_C(dst, v);
-                            return Ok(CompileResult::Continue);
+                            true
                         }
                         ISeqHint::SelfReturn => {
                             if let Some(dst) = dst {
                                 state.copy_slot(ir, callsite.recv, dst);
                             }
-                            return Ok(CompileResult::Continue);
+                            true
                         }
-                        ISeqHint::Normal => {}
+                        ISeqHint::Normal => false,
+                    };
+                    if folded {
+                        if forwarded_fold {
+                            // Eliding the call *is* the forwarding consume:
+                            // no one reads the rest `Array`, so keep the
+                            // caller-side `create_array` skip on (without
+                            // this the producer would materialize an Array
+                            // nothing ever looks at). Deopt side exits still
+                            // rebuild it from the frame's D1 annotation,
+                            // which is left in place.
+                            ir.set_deferred_rest();
+                        }
+                        return Ok(CompileResult::Continue);
                     }
                 }
                 // Use `is_C_immediate` here, not `is_C`: heap-resident
@@ -396,6 +427,48 @@ impl<'a> JitContext<'a> {
         state.send(ir, &self.store, callid, fid, recv_class, outer_lfp);
 
         Ok(CompileResult::Continue)
+    }
+
+    ///
+    /// The statically-known positional-argument count of a `...`-forwarding
+    /// call site, or `None` when the shape is not a compile-time constant.
+    ///
+    /// This is the trivial-method fold's (`ISeqHint`) entry for forwarding
+    /// call sites, which `is_simple_call` rejects out of hand. It leans
+    /// entirely on the D1 deferral annotation: `forward_rest_deferral` only
+    /// annotates a *pure forwarding trampoline* (`def f(...) = g(...)`,
+    /// single basic block) whose own caller passes no keywords and no `&blk`
+    /// through a simple (splat-free) call site. So for an annotated frame:
+    ///
+    /// * the forwarded positional count is exactly the caller's `pos_num`
+    ///   (`len` below), and
+    /// * `f`'s `**kwrest` local is statically nil — the `...` forward's
+    ///   hash-splat contributes no keywords, which is what lets the fold
+    ///   ignore `kw_may_exists` (true here only because of that nil splat).
+    ///
+    /// The consuming site must therefore add no keyword of its own
+    /// (`def f(...) = g(k: 1, ...)`) and no second hash-splat
+    /// (`def f(...) = g(**h, ...)`), and its only splat must be the trailing
+    /// `...` rest. The *callee*-side conditions (no keyword surface, arity
+    /// binds without `ArgumentError`) are checked by the caller of this fn.
+    ///
+    fn forwarded_trivial_pos_num(
+        &self,
+        state: &AbstractState,
+        callsite: &CallSiteInfo,
+    ) -> Option<usize> {
+        if !callsite.forwarding || callsite.pos_num == 0 {
+            return None;
+        }
+        if callsite.splat_pos.as_slice() != [callsite.pos_num - 1]
+            || !callsite.kw_args.is_empty()
+            || callsite.hash_splat_pos.len() != 1
+        {
+            return None;
+        }
+        let lead_num = callsite.pos_num - 1;
+        let (_, len) = state.deferred_rest_src(callsite.args + lead_num)?;
+        Some(lead_num + len as usize)
     }
 
     ///
@@ -1284,19 +1357,13 @@ impl AbstractState {
                 }
             };
             self.write_back_recv_and_callargs(ir, callsite);
-            let error = ir.new_error(self);
-            if deferred_src.is_none()
-                && (callee.opt_num() != 0 || callee.is_rest() || !callee.no_keyword())
-            {
-                // Eager (the `...` Array really was materialized): the
-                // bind length is only known at run time, so anything but
-                // a plain req-only callee — optional params, a `*rest`
-                // to size, or a `**kwrest` slot to initialize — keeps the
-                // proven specialized runtime helper. The inline fast path
-                // below guards on an exact length and would have to
-                // re-derive all of that at run time.
-                ir.push(AsmInst::SetArgumentsForwardedHelper { callid, callee_fid });
-            } else {
+            if deferred_src.is_some() {
+                // D1 cannot fail: the gate proved the fill layout is a
+                // compile-time constant, so the lowering has no length
+                // guard, no fallback, and no call that can raise. Emit it
+                // without an error side exit — a `HandleError` here would
+                // test a constant-`nil` sentinel against a handler nothing
+                // can ever branch to.
                 ir.push(AsmInst::SetArgumentsForwarded {
                     callid,
                     callee_fid,
@@ -1306,8 +1373,30 @@ impl AbstractState {
                     kwrest_guard,
                     deferred_src,
                 });
+            } else {
+                let error = ir.new_error(self);
+                if callee.opt_num() != 0 || callee.is_rest() || !callee.no_keyword() {
+                    // Eager (the `...` Array really was materialized): the
+                    // bind length is only known at run time, so anything but
+                    // a plain req-only callee — optional params, a `*rest`
+                    // to size, or a `**kwrest` slot to initialize — keeps the
+                    // proven specialized runtime helper. The inline fast path
+                    // below guards on an exact length and would have to
+                    // re-derive all of that at run time.
+                    ir.push(AsmInst::SetArgumentsForwardedHelper { callid, callee_fid });
+                } else {
+                    ir.push(AsmInst::SetArgumentsForwarded {
+                        callid,
+                        callee_fid,
+                        recv,
+                        args,
+                        lead_num,
+                        kwrest_guard,
+                        deferred_src,
+                    });
+                }
+                ir.handle_error(error);
             }
-            ir.handle_error(error);
         } else if callsite.forwarding
             && callsite.splat_pos.len() == 1
             && callsite.splat_pos[0] < callsite.pos_num
@@ -1398,6 +1487,77 @@ mod tests {
             res << (begin; fs(1, 2, 3); rescue ArgumentError => e; e.message; end)
             res << fs(1)
             res << $effects.size
+            res
+            "#,
+        );
+    }
+
+    /// Trivial-method (`ISeqHint`) fold through a `...` forward. The Ruby
+    /// `Class#new` reaches `initialize` via `o.__builtin_initialize__(...)`,
+    /// a forwarding call site `is_simple_call` always rejects — so the fold
+    /// applies only once the D1 deferral makes the forwarded argument shape
+    /// a compile-time constant. Covers what the fold must NOT swallow:
+    /// arity and keyword errors still raise, an impure default still runs,
+    /// and a real `initialize` still executes.
+    #[test]
+    fn trivial_initialize_folded() {
+        run_test(
+            r#"
+            $effects = []
+            class Fold
+              def initialize(x); end
+            end
+            class FoldRest
+              def initialize(*a); end
+            end
+            class FoldOpt
+              def initialize(x, y = 1); end
+            end
+            class Impure
+              def initialize(x = ($effects << :d; 1)); end
+            end
+            class Real
+              def initialize(x); @x = x; end
+              attr_reader :x
+            end
+            res = []
+            r = []; 100.times {|i| r << Fold.new(i).class }; res << r.uniq
+            r = []; 100.times {|i| r << FoldRest.new(i, i, i).class }; res << r.uniq
+            r = []; 100.times {|i| r << FoldOpt.new(i).class }; res << r.uniq
+            r = []; 100.times {|i| r << Impure.new.class }; res << r.uniq
+            r = []; 100.times {|i| r << Real.new(i).x }; res << r.last
+            res << (begin; Fold.new; rescue ArgumentError => e; e.class; end)
+            res << (begin; Fold.new(1, 2); rescue ArgumentError => e; e.class; end)
+            res << (begin; Fold.new(1, k: 2); rescue ArgumentError => e; e.class; end)
+            res << Fold.new(1) { :blk }.class
+            res << $effects.size
+            res
+            "#,
+        );
+    }
+
+    /// The same fold on a plain `def f(...) = g(...)` trampoline (not just
+    /// the `Class#new` shape), and the invalidation path: once a folded
+    /// callee is redefined with a body that has a side effect, the compiled
+    /// caller must stop folding and run it.
+    #[test]
+    fn trivial_forwarded_fold_and_redefine() {
+        run_test(
+            r#"
+            $log = []
+            def g(x) = 42
+            def f(...) = g(...)
+            res = []
+            r = []; 100.times {|i| r << f(i) }; res << r.uniq
+            class Re
+              def initialize(x); end
+            end
+            100.times {|i| Re.new(i) }
+            class Re
+              def initialize(x); $log << x; end
+            end
+            Re.new(7)
+            res << $log
             res
             "#,
         );

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1454,6 +1454,21 @@ impl FuncInfo {
         let max = self.max_positional_args();
         min <= pos_num && pos_num <= max
     }
+
+    ///
+    /// Whether `pos_num` positional arguments bind to this function's
+    /// positional parameters without raising `ArgumentError`. A block-style
+    /// callee never raises on arity (surplus args are dropped, missing ones
+    /// bound to nil).
+    ///
+    pub(crate) fn positional_arity_ok(&self, pos_num: usize) -> bool {
+        self.is_block_style()
+            || if self.is_rest() {
+                pos_num >= self.min_positional_args()
+            } else {
+                self.positional_within_range(pos_num)
+            }
+    }
 }
 
 impl Store {
@@ -1503,14 +1518,7 @@ impl Store {
                 return false;
             }
         }
-        !callsite.has_splat()
-            && !callsite.has_hash_splat()
-            && (info.is_block_style()
-                || if info.is_rest() {
-                    pos_num >= info.min_positional_args()
-                } else {
-                    info.positional_within_range(pos_num)
-                })
+        !callsite.has_splat() && !callsite.has_hash_splat() && info.positional_arity_ok(pos_num)
     }
 
     ///


### PR DESCRIPTION
Two related cleanups on the D1 forwarding-rest path.

## 1. Trivial-method fold for forwarding call sites

`ISeqHint::ConstReturn` / `SelfReturn` let the JIT replace a call to a trivial method with its constant result, but the fold was gated on `is_simple_call`, which rejects **every** forwarding call site (its splat and hash-splat disqualify it). The Ruby `Class#new` reaches `initialize` via `o.__builtin_initialize__(...)`, so the overwhelmingly common `def initialize(x); end` never reached the fold — it got a full specialized compile with a frame prologue whose entire body returns nil:

```
:00005 _ = %3.initialize(*%1,**%2,&%4)   POLYMORPHIC [C] FuncId(...)
  ... frame setup ...
  call ...

>>> [2] ISeqId(...) <C#initialize>
  push rbp / mov rbp,rsp / sub rsp,0x70
  movabs rax,0x4 / leave / ret
```

When the frame's forwarded `...` rest was deferred (D1), the argument shape is already a compile-time constant — which is all the fold needs. `forwarded_trivial_pos_num` leans entirely on that annotation: `forward_rest_deferral` only annotates a pure forwarding trampoline whose own caller passes no keywords and no `&blk` through a simple (splat-free) call site, so the forwarded positional count is the caller's `pos_num` and the forwarded `**kwrest` is statically nil. The callee must still accept that many positionals without an `ArgumentError` (`positional_arity_ok`, extracted from `is_simple_call`'s tail) and have no keyword surface, so arity/keyword errors keep raising.

Folding *is* the forwarding consume, so it sets `deferred_rest` — without that the producer would materialize a rest `Array` nothing ever reads.

Result for `C.new(x)` with `def initialize(x); end`:

- the call and its frame emit **zero instructions**
- `C#initialize`'s specialized compile is no longer generated at all
- `Class#new` shrinks **457 → 304 bytes**
- the caller still skips `create_array` (D1 preserved)
- `20_000_000.times { |i| C.new(i) }`: 0.669s → 0.604s (**~-10%**, release, interleaved A/B medians)

## 2. Drop D1's dead success sentinel

The D1 lowering ended with a `NIL_VALUE` sentinel that the caller's unconditional `HandleError` tested:

```
movabs rax,0x4
test   rax,rax
je     <error>
```

D1 has no length guard, no fallback, and no call that can raise, so this was a comparison against a compile-time constant plus a branch to a handler nothing can reach. Worse, `ir.new_error()` emits its error side-exit handler (write-back stub) whether or not anything branches to it, so every such call site carried a dead handler on the cold page. Both backends drop the sentinel and the front-end skips the error label. The eager (non-D1) path genuinely can raise and keeps its `HandleError`.

## Testing

- `cargo test --lib`: 1953 passed / 0 failed
- New: `trivial_initialize_folded`, `trivial_forwarded_fold_and_redefine` — cover what must **not** be folded (arity mismatch and keyword still raise `ArgumentError`, impure parameter defaults still run, a real `initialize` still executes), plus `*rest`/optional callees, a block-passing call, and redefinition after the fold (class-version invalidation).
- Verified the emitted code with `--features emit-asm`.

⚠️ aarch64 was not compile-checked: `cargo check --target aarch64-unknown-linux-gnu` fails in this environment on libffi's cross build (unrelated to this change). The aarch64 diff is one removed `mov x0, NIL_VALUE` plus doc comments; the fold itself is in the arch-neutral front-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)