### PR TITLE
core/set: propagate compare_by_identity per CRuby 4.0; fix bin/spec target

### DIFF
--- a/bin/spec
+++ b/bin/spec
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -e
 
-RUSTFLAGS=-Cforce-frame-pointers cargo install --path monoruby
+cargo install --path monoruby
+MONORUBY="${MONORUBY:-$(command -v monoruby)}"
 
 # Run ruby/spec with instrumented binary for coverage
 if [ -d "../spec" ] && [ -d "../mspec" ]; then
   echo "Running ruby/spec for coverage..."
   cd ../spec
-  for cat in basicobject true false nil integer float comparable math builtin_constants class numeric rational struct systemexit method unboundmethod; do
+  for cat in basicobject true false nil integer float comparable math builtin_constants class numeric rational struct systemexit method unboundmethod set; do
     echo "=== core/$cat ==="
     ../mspec/bin/mspec core/$cat -t "$MONORUBY"
   done

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -101,6 +101,20 @@ fn new_empty_set() -> Value {
     Value::hash_with_class_and_default(SET_CLASS, Value::nil())
 }
 
+/// Create a new empty Set that compares its members the same way `model`
+/// does.
+///
+/// The mode is set while the set is still empty, so every subsequent insert
+/// already uses the right comparison — flipping it afterwards would rehash
+/// (and merge) elements that were meant to stay distinct.
+fn new_empty_set_like(model: Value) -> Result<Value> {
+    let set = new_empty_set();
+    if model.as_hash().is_compare_by_identity() {
+        set.as_hash().set_compare_by_identity_empty(true)?;
+    }
+    Ok(set)
+}
+
 /// Create a Set from an iterator of values.
 fn set_from_iter(
     iter: impl Iterator<Item = Value>,
@@ -450,8 +464,20 @@ fn subtract(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     self_val.ensure_not_frozen(&globals.store)?;
-    let elems = enum_to_vec(vm, globals, lfp.arg(0))?;
+    let arg = lfp.arg(0);
+    // Replacing with a Set adopts *its* comparison mode, in both directions
+    // — CRuby implements this as `rb_hash_replace`, which copies the source
+    // hash wholesale. Any other Enumerable leaves `self`'s mode alone.
+    let ident = if is_set(arg, &globals.store) {
+        Some(arg.as_hash().is_compare_by_identity())
+    } else {
+        None
+    };
+    let elems = enum_to_vec(vm, globals, arg)?;
     self_val.as_hash().clear()?;
+    if let Some(ident) = ident {
+        self_val.as_hash().set_compare_by_identity_empty(ident)?;
+    }
     for elem in elems {
         self_val
             .as_hash().insert(elem, Value::bool(true), vm, globals)?;
@@ -476,13 +502,17 @@ fn intersection(
     let self_val = lfp.self_val();
     let self_inner = self_val.as_hashmap_inner();
     let other_elems = enum_to_vec(vm, globals, lfp.arg(0))?;
-    // Build a temp hash for the other side
-    let other = new_empty_set();
+    // Build a temp hash for the other side. It compares like `self` does, so
+    // the membership tests below follow `self`'s rule — CRuby probes the
+    // enum's elements against `self`'s own hash.
+    let other = new_empty_set_like(self_val)?;
     for elem in other_elems {
         other
             .as_hash().insert(elem, Value::bool(true), vm, globals)?;
     }
     let other_inner = other.as_hashmap_inner();
+    // `&` alone builds a *plain* result: CRuby allocates a fresh Set here
+    // rather than duplicating `self` (see `new_empty_set_like` at `-` / `^`).
     let result = new_empty_set();
     for (k, _) in self_inner.iter() {
         if other_inner.contains_key(k, vm, globals)? {
@@ -505,7 +535,9 @@ fn intersection(
 fn union_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_keys = set_keys(lfp.self_val());
     let other_elems = enum_to_vec(vm, globals, lfp.arg(0))?;
-    let result = new_empty_set();
+    // CRuby builds `|` by duplicating `self` and merging the enum into it, so
+    // the result keeps `self`'s comparison mode (and the merge follows it).
+    let result = new_empty_set_like(lfp.self_val())?;
     for k in self_keys {
         result
             .as_hash().insert(k, Value::bool(true), vm, globals)?;
@@ -529,13 +561,16 @@ fn difference(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     let self_val = lfp.self_val();
     let self_inner = self_val.as_hashmap_inner();
     let other_elems = enum_to_vec(vm, globals, lfp.arg(0))?;
-    let other = new_empty_set();
+    // CRuby builds `-` by duplicating `self` and deleting the enum's elements
+    // from it: the result keeps `self`'s comparison mode, and so do the
+    // deletions (hence the `_like` temp probed below).
+    let other = new_empty_set_like(self_val)?;
     for elem in other_elems {
         other
             .as_hash().insert(elem, Value::bool(true), vm, globals)?;
     }
     let other_inner = other.as_hashmap_inner();
-    let result = new_empty_set();
+    let result = new_empty_set_like(self_val)?;
     for (k, _) in self_inner.iter() {
         if !other_inner.contains_key(k, vm, globals)? {
             result
@@ -561,13 +596,15 @@ fn symmetric_difference(
     let self_val = lfp.self_val();
     let self_inner = self_val.as_hashmap_inner();
     let other_elems = enum_to_vec(vm, globals, lfp.arg(0))?;
-    let other = new_empty_set();
+    // Both halves of the symmetric difference are probed with `self`'s
+    // comparison mode, and the result keeps it (as CRuby's `^` does).
+    let other = new_empty_set_like(self_val)?;
     for elem in other_elems {
         other
             .as_hash().insert(elem, Value::bool(true), vm, globals)?;
     }
     let other_inner = other.as_hashmap_inner();
-    let result = new_empty_set();
+    let result = new_empty_set_like(self_val)?;
     for (k, _) in self_inner.iter() {
         if !other_inner.contains_key(k, vm, globals)? {
             result
@@ -1034,6 +1071,9 @@ fn collect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
         let new_elems_idx = vm.temp_len() - 1;
         let self_val = lfp.self_val();
         self_val.as_hash().clear()?;
+        // CRuby rebuilds `self` from a freshly allocated (plain) Set, so the
+        // mapped elements are compared by `eql?` and the flag is dropped.
+        self_val.as_hash().set_compare_by_identity_empty(false)?;
         let n = vm.temp_at(new_elems_idx).as_array().len();
         for i in 0..n {
             let elem = vm.temp_at(new_elems_idx).as_array()[i];
@@ -1104,9 +1144,12 @@ fn flatten_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     let mut seen = std::collections::HashSet::new();
     seen.insert(self_val.id());
     flatten_set_into(&mut result, self_val, vm, globals, &mut seen)?;
-    // Replace self's contents
+    // Replace self's contents. As with `map!`, CRuby swaps in the freshly
+    // built (plain) Set, so the flag is dropped — but only on this path: an
+    // already-flat Set returned early above and keeps its flag.
     let self_val = lfp.self_val();
     self_val.as_hash().clear()?;
+    self_val.as_hash().set_compare_by_identity_empty(false)?;
     let new_keys = set_keys(result);
     for k in new_keys {
         self_val
@@ -1670,6 +1713,44 @@ mod tests {
             // persists across dup / clone.
             r#"(s=Set.new; s.compare_by_identity; [s.dup.compare_by_identity?, s.clone.compare_by_identity?])"#,
             r#"(s=Set.new; s.compare_by_identity?)"#,
+        ]);
+    }
+
+    /// Which Set operations carry the `compare_by_identity` flag over to
+    /// their result, and which drop it. CRuby's rule is "the flag follows
+    /// the hash that gets copied": `|` / `-` / `^` duplicate `self`, so they
+    /// keep it (and compare the operand's elements by identity too), while
+    /// `&` / `flatten` allocate a fresh plain Set. The in-place `map!` /
+    /// `flatten!` / `replace` swap in a freshly built hash, so they take
+    /// *its* flag — which is how `replace` can turn identity comparison off.
+    #[test]
+    fn compare_by_identity_propagation() {
+        run_tests(&[
+            // Binary operators: `|` / `-` / `^` retain, `&` does not.
+            r#"(s=Set[1,2,3,4].compare_by_identity; [(s|Set[3,4,5]).compare_by_identity?,
+                (s-Set[3,4]).compare_by_identity?, (s^Set[3,4,5]).compare_by_identity?,
+                (s&Set[3,4]).compare_by_identity?])"#,
+            // ... and their element comparison follows `self`, so two equal
+            // but distinct Strings stay distinct.
+            r#"(a="x".dup; b="x".dup; s=Set.new.compare_by_identity; s<<a;
+                [(s-[b]).size, (s-[a]).size, (s|[b]).size, (s^[b]).size, (s&[b]).size])"#,
+            // A plain Set keeps comparing by value through the same ops.
+            r#"(a="x".dup; b="x".dup; s=Set.new; s<<a;
+                [(s-[b]).size, (s|[b]).size, (s^[b]).size, (s&[b]).size])"#,
+            // flatten always returns a plain Set; flatten! drops the flag
+            // only when something was actually flattened.
+            r#"Set[1,2,Set[3,4]].compare_by_identity.flatten.compare_by_identity?"#,
+            r#"(s=Set[1,2,Set[3,4]].compare_by_identity; s.flatten!; s.compare_by_identity?)"#,
+            r#"(s=Set[1,2].compare_by_identity; s.flatten!; s.compare_by_identity?)"#,
+            // map! drops it; merge / subtract keep it.
+            r#"(s=Set[1,2,3].compare_by_identity; s.map!{|x| x*2}; [s.compare_by_identity?, s.to_a.sort])"#,
+            r#"(s=Set[1,2].compare_by_identity; s.merge([3]); s.compare_by_identity?)"#,
+            r#"(s=Set[1,2].compare_by_identity; s.subtract([2]); s.compare_by_identity?)"#,
+            // replace adopts the argument's flag when it is a Set, in both
+            // directions, and leaves it alone for any other Enumerable.
+            r#"(s=Set[:a].compare_by_identity; s.replace(Set[1,2]); s.compare_by_identity?)"#,
+            r#"(s=Set[:a]; s.replace(Set[1,2].compare_by_identity); s.compare_by_identity?)"#,
+            r#"(s=Set[:a].compare_by_identity; s.replace([1,2]); [s.compare_by_identity?, s.to_a])"#,
         ]);
     }
 

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -362,6 +362,14 @@ impl HashmapInner {
         self.content.compare_by_identity(vm, globals)
     }
 
+    /// Set the key-comparison mode of an empty hash, in either direction.
+    /// See `HashContent::set_compare_by_identity_empty`.
+    pub fn set_compare_by_identity_empty(&mut self, ident: bool) -> Result<()> {
+        self.check_iter()?;
+        self.content.set_compare_by_identity_empty(ident);
+        Ok(())
+    }
+
     /*pub fn entry_and_modify<F>(&mut self, k: Value, f: F)
     where
         F: FnOnce(&mut Value),
@@ -733,6 +741,31 @@ impl HashContent {
             HashContent::IdentMap(_) => {}
         }
         Ok(())
+    }
+
+    ///
+    /// Set the key-comparison mode of an **empty** map, in either direction.
+    ///
+    /// This is the primitive behind CRuby's `rb_hash_replace`, which adopts
+    /// the source hash's comparison mode wholesale — including turning
+    /// identity comparison *off*, which `compare_by_identity` (a one-way
+    /// door, like `Hash#compare_by_identity`) cannot do. Turning it off on a
+    /// populated map would have to merge keys that are `eql?` but not
+    /// identical, silently dropping entries; requiring an empty map keeps
+    /// the primitive lossless. Callers that rebuild a container (`Set#replace`
+    /// / `#map!` / `#flatten!`) clear it first anyway.
+    ///
+    pub(crate) fn set_compare_by_identity_empty(&mut self, ident: bool) {
+        assert_eq!(0, self.len(), "the map must be empty to change its mode");
+        match (&self, ident) {
+            (HashContent::Map(_), true) => {
+                *self = HashContent::IdentMap(Box::new(RubyMap::default()));
+            }
+            (HashContent::IdentMap(_), false) => {
+                *self = HashContent::Map(Box::new(RubyMap::default()));
+            }
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
ruby/spec added `compare_by_identity` propagation checks for Set on 2026-07-14 ([ruby/spec bb3e38bac](https://github.com/ruby/spec/commit/bb3e38bac290459ff29e44aed475f062981f835b), 16 new examples across 10 files), and `core/set` failed 6 of them. The propagation was never implemented beyond `#dup` / `#clone` — nothing tested it until now.

## The rule

CRuby's is "the flag follows the hash that gets copied":

| op | flag | element comparison |
|---|---|---|
| `\|` / `-` / `^` | retains self's | self's |
| `&` | plain (fresh Set) | self's |
| `flatten` | plain | — |
| `flatten!` | dropped iff something was flattened | — |
| `map!` | dropped | — |
| `merge` / `subtract` | retains | self's |
| `replace(Set)` | adopts the argument's | — |
| `replace(other Enumerable)` | unchanged | — |

## What was wrong

- **`\|` / `-` / `^`**: results came from `new_empty_set()` (always plain) and the membership probes ran against a plain temp set, so a `compare_by_identity` Set silently fell back to `eql?`. `^` was worse: one direction probed the plain temp and the other the identity `self`, mixing both rules within one operation.
- **`&`**: the plain result is correct (CRuby allocates a fresh Set here), but the probe must still use `self`'s comparison.
- **`map!` / `flatten!` / `replace`**: these rebuild in place with `clear()` + insert, and `HashContent::clear()` keeps the `IdentMap` variant — so the flag survived where CRuby drops it. `replace` must additionally adopt the argument's flag when the argument is a Set.

Beyond the flag, this fixes real element-level divergence:

```ruby
a = "x".dup; b = "x".dup           # eql? but not equal?
s = Set.new.compare_by_identity; s << a
(s - [b]).to_a   # was []  → now ["x"]   (CRuby: ["x"])
(s | [b]).size   # was 1   → now 2       (CRuby: 2)
(s ^ [b]).size   # was 1   → now 2       (CRuby: 2)
(s & [b]).size   # was 1   → now 0       (CRuby: 0)
```

## New primitive

Turning identity comparison *off* needed something that did not exist — `compare_by_identity` is a one-way door, as `Hash#compare_by_identity` is. `HashContent::set_compare_by_identity_empty(bool)` goes both ways but asserts the map is empty: flipping it off on a populated map would have to merge keys that are `eql?` but not identical, silently dropping entries. Every caller clears first, so the restriction costs nothing and keeps the primitive lossless.

`new_empty_set_like(model)` sets the mode while the set is still empty, so every insert uses the right comparison from the start — flipping afterwards would rehash and merge elements meant to stay distinct.

## bin/spec was testing CRuby

`bin/spec` never assigned `MONORUBY`, so `-t "$MONORUBY"` passed an empty target; mspec then ran `mspec-run` through its own `#!/usr/bin/env ruby` shebang — against the host CRuby, not monoruby. That is why it reported everything green while `bin/test` (which does set `MONORUBY`) showed the failures. It now points at the binary its own `cargo install` produces, and `set` is added to its category list.

## Testing

- `core/set`: **6 failures → 0** (57 files, 175 examples, 373 expectations)
- All 20 spec categories from `bin/test` diffed against a pre-change binary: `core/set` is the only difference; the other 19 are byte-identical, including `core/hash` and `core/enumerable` (whose pre-existing failures are unchanged).
- `cargo test --lib`: 1954 passed / 0 failed
- New `compare_by_identity_propagation` test covering the whole flag matrix and the element-comparison semantics, for both identity and plain Sets.

Not covered: other set predicates (`disjoint?`, `intersect?`, `subset?`, …) may use the same plain-temp-set pattern. They are outside the spec's scope and unverified, so this PR leaves them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)