### PR TITLE
perf(bytecodegen): store vcall/super/yield results straight into the lvalue

### DIFF
--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -340,6 +340,28 @@ impl<'a> BytecodeGen<'a> {
                 let method = IdentId::get_id_from_string(method);
                 self.gen_method_call(method, None, arglist, safe_nav, false, UseMode2::Store(dst), loc)?;
             }
+            // `__ENCODING__` is a bare `Ident` that is *not* a call; keep it on
+            // the generic path so the read arm in `gen_expr_inner` handles it.
+            NodeKind::Ident(method) if method != "__ENCODING__" => {
+                // A bare-identifier vcall (`a = foo`). Store straight into `dst`
+                // instead of landing in a temp and moving.
+                let method = IdentId::get_id_from_string(method);
+                self.gen_method_call(
+                    method,
+                    None,
+                    ArgList::default(),
+                    false,
+                    true,
+                    UseMode2::Store(dst),
+                    loc,
+                )?;
+            }
+            NodeKind::Super(arglist) => {
+                self.gen_super(arglist.map(|arglist| *arglist), UseMode2::Store(dst), loc)?;
+            }
+            NodeKind::Yield(box arglist) => {
+                self.gen_yield(arglist, UseMode2::Store(dst), loc)?;
+            }
             NodeKind::Return(box val) => {
                 if self.return_escapes() {
                     return self.gen_method_return(val, UseMode2::Store(dst));


### PR DESCRIPTION
## Problem

`a = foo` — a **bare-identifier call** (no receiver, no arguments, no parens) assigned to a local variable — compiled to a redundant temp round-trip:

```
:00001 [03] %2 = %0.foo()
:00003 [03] %1 = %2
```

## Cause

Call forms that carry an explicit receiver or arglist — `foo()`, `foo(1)`, `self.foo` — already lowered to a direct store, because `gen_store_expr` handles `MethodCall` / `FuncCall` by passing `UseMode2::Store(dst)` down to `gen_method_call`.

A bare call, however, reaches bytecodegen as `NodeKind::Ident`, for which `gen_store_expr` had no arm, so it fell through to the generic `push_expr` + `mov` tail.

## Change

Add the missing arm, plus the two sibling node kinds with the same gap — `Super` and `Yield` — whose emitters (`gen_super` / `gen_yield`) already accept `UseMode2::Store`.

`__ENCODING__` also arrives as a bare `Ident`, but it is a constant load rather than a call, so it is guarded and stays on the generic path.

```
-    :00001 [03] %2 = %0.foo()
-    :00003 [03] %1 = %2
+    :00001 [02] %1 = %0.foo()
```

This saves one instruction and one temp register per bare-call assignment. Register allocation only — no semantic change. `vcall: true` is preserved, so a failed bare-identifier lookup still raises `NameError` rather than `NoMethodError`.

## Verification

- Full `cargo test --no-fail-fast` suite passes (1954 lib tests + all integration tests).
- Output verified to match CRuby for:
  - dst aliasing a parameter slot: `def m(x, ...) x = super end`
  - zsuper / explicit-arg super / block forwarding
  - `a = yield v` storing the yielded result into a local
  - a 200-iteration loop, exercising the JIT-warmed path
  - a failed vcall lookup raising `NameError`
  - `e = __ENCODING__`
- Release build output for `benchmark/app_fib.rb` and `benchmark/so_nbody.rb` matches CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)