### PR TITLE
refactor(ast): give `__ENCODING__` its own `NodeKind::SourceEncoding`

### DIFF
--- a/monoruby/src/ast/node.rs
+++ b/monoruby/src/ast/node.rs
@@ -46,6 +46,17 @@ pub enum NodeKind {
 
     LocalVar(usize, String),
     Ident(String),
+    /// `__ENCODING__` — the pseudo-variable evaluating to the `Encoding`
+    /// object for the source file's encoding.
+    ///
+    /// Its two siblings, `__FILE__` and `__LINE__`, are folded to a
+    /// `String` / `Integer` literal at parse time. `__ENCODING__` cannot
+    /// be: an `Encoding` is a heap object with identity
+    /// (`__ENCODING__.equal?(Encoding::UTF_8)`), so bytecodegen loads it
+    /// as the constant `::Encoding::<NAME>` instead. It therefore needs a
+    /// node of its own rather than riding on `Ident`, which every other
+    /// consumer reads as a bare-identifier method call (vcall).
+    SourceEncoding,
     InstanceVar(String),
     GlobalVar(String),
     ClassVar(String),

--- a/monoruby/src/bytecodegen/defined.rs
+++ b/monoruby/src/bytecodegen/defined.rs
@@ -201,11 +201,9 @@ impl<'a> BytecodeGen<'a> {
                 }
                 self.check_defined(r, nil_label, ret, false)?;
             }
+            // `__ENCODING__` is a pseudo-variable, always defined.
+            NodeKind::SourceEncoding => return Ok(()),
             NodeKind::Ident(name) => {
-                // `__ENCODING__` is a pseudo-variable, always defined.
-                if name == "__ENCODING__" {
-                    return Ok(());
-                }
                 let name = IdentId::get_id_from_string(name);
                 self.emit(
                     BytecodeInst::DefinedMethod {
@@ -427,9 +425,8 @@ fn defined_str(node: &Node) -> &'static str {
                 "expression"
             }
         }
-        // `__ENCODING__` is a pseudo-variable (parsed as a bare Ident),
-        // not a method call.
-        NodeKind::Ident(name) if name == "__ENCODING__" => "expression",
+        // `__ENCODING__` is a pseudo-variable, not a method call.
+        NodeKind::SourceEncoding => "expression",
         NodeKind::BinOp(..)
         | NodeKind::FuncCall { .. }
         | NodeKind::MethodCall { .. }

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -315,6 +315,22 @@ impl<'a> BytecodeGen<'a> {
                 let name = IdentId::get_id_from_string(name);
                 self.emit_load_cvar(dst.into(), name, loc);
             }
+            // `__ENCODING__` — evaluate to the source-encoding `Encoding`
+            // object. Load it as the constant `::Encoding::<NAME>` (rather
+            // than a baked literal) so it keeps object identity with the
+            // registered `Encoding` singleton.
+            NodeKind::SourceEncoding => {
+                let const_name =
+                    crate::builtins::encoding::encoding_constant_name(self.source_encoding());
+                self.emit_load_const(
+                    Some(dst),
+                    None,
+                    true,
+                    const_name.to_string(),
+                    vec!["Encoding".to_string()],
+                    loc,
+                );
+            }
             NodeKind::MethodCall {
                 box receiver,
                 method,
@@ -340,9 +356,7 @@ impl<'a> BytecodeGen<'a> {
                 let method = IdentId::get_id_from_string(method);
                 self.gen_method_call(method, None, arglist, safe_nav, false, UseMode2::Store(dst), loc)?;
             }
-            // `__ENCODING__` is a bare `Ident` that is *not* a call; keep it on
-            // the generic path so the read arm in `gen_expr_inner` handles it.
-            NodeKind::Ident(method) if method != "__ENCODING__" => {
+            NodeKind::Ident(method) => {
                 // A bare-identifier vcall (`a = foo`). Store straight into `dst`
                 // instead of landing in a temp and moving.
                 let method = IdentId::get_id_from_string(method);
@@ -445,10 +459,10 @@ impl<'a> BytecodeGen<'a> {
                 | NodeKind::Rational(..)
                 | NodeKind::RImaginary(..)
                 | NodeKind::String(_)
-                | NodeKind::EncodedString(..) => return Ok(()),
+                | NodeKind::EncodedString(..)
                 // `__ENCODING__` is a pure pseudo-variable; in void
                 // context it has no effect.
-                NodeKind::Ident(name) if name == "__ENCODING__" => return Ok(()),
+                | NodeKind::SourceEncoding => return Ok(()),
                 _ => {}
             }
         }
@@ -478,26 +492,10 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::Const { .. }
             | NodeKind::InstanceVar(_)
             | NodeKind::ClassVar(_)
-            | NodeKind::GlobalVar(_) => {
+            | NodeKind::GlobalVar(_)
+            | NodeKind::SourceEncoding => {
                 let ret = self.push().into();
                 self.gen_store_expr(ret, expr)?;
-            }
-            // `__ENCODING__` — parsed as a bare `Ident`; evaluate to the
-            // source-encoding `Encoding` object. Load it as the constant
-            // `::Encoding::<NAME>` (rather than a baked literal) so it keeps
-            // object identity with the registered `Encoding` singleton.
-            NodeKind::Ident(method) if method == "__ENCODING__" => {
-                let ret = self.push().into();
-                let const_name =
-                    crate::builtins::encoding::encoding_constant_name(self.source_encoding());
-                self.emit_load_const(
-                    Some(ret),
-                    None,
-                    true,
-                    const_name.to_string(),
-                    vec!["Encoding".to_string()],
-                    loc,
-                );
             }
             NodeKind::BinOp(op, box lhs, box rhs) => {
                 self.gen_binop(op, lhs, rhs, use_mode, loc)?;
@@ -2399,5 +2397,13 @@ mod tests {
         run_test(r#"__ENCODING__.equal?(Encoding::UTF_8)"#);
         // Void context is a no-op.
         run_test(r#"__ENCODING__; 42"#);
+        // Store position inside a method / block: `SourceEncoding` is not a
+        // call, so it must not take the vcall path.
+        run_test(r#"def g; e = __ENCODING__; e.name; end; g"#);
+        run_test(r#"-> { e = __ENCODING__; e.name }.call"#);
+        run_test(r#"r = nil; 3.times { r = __ENCODING__ }; r.equal?(Encoding::UTF_8)"#);
+        // `defined?` reports a pseudo-variable, never a method.
+        run_test(r#"defined?(!__ENCODING__)"#);
+        run_test(r#"defined?(__ENCODING__.name)"#);
     }
 }

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -332,6 +332,7 @@ impl<'a> BytecodeGen<'a> {
             | NodeKind::EncodedString(..)
             | NodeKind::Symbol(_)
             | NodeKind::Ident(_)
+            | NodeKind::SourceEncoding
             | NodeKind::InstanceVar(_)
             | NodeKind::GlobalVar(_)
             | NodeKind::ClassVar(_)

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -1822,11 +1822,13 @@ impl<'pr> Lowerer<'pr> {
                 }
             }
             prism::Node::SourceEncodingNode { .. } => {
-                // ruruby parses `__ENCODING__` as a bare identifier
-                // (`NodeKind::Ident("__ENCODING__")`) which bytecodegen
-                // turns into a method call resolved at runtime.
+                // `__ENCODING__` — unlike its `__FILE__` / `__LINE__`
+                // siblings above it cannot be folded to a literal (the
+                // `Encoding` object has identity), so it keeps its own
+                // node kind and bytecodegen loads the corresponding
+                // `::Encoding::<NAME>` constant.
                 Node {
-                    kind: NodeKind::Ident("__ENCODING__".to_string()),
+                    kind: NodeKind::SourceEncoding,
                     loc,
                 }
             }


### PR DESCRIPTION
Follow-up to #1014.

## Problem

`__ENCODING__` was lowered to `NodeKind::Ident("__ENCODING__")`, a leftover from the ruruby parser:

```rust
prism::Node::SourceEncodingNode { .. } => {
    // ruruby parses `__ENCODING__` as a bare identifier
    // (`NodeKind::Ident("__ENCODING__")`) which bytecodegen
    // turns into a method call resolved at runtime.
    Node { kind: NodeKind::Ident("__ENCODING__".to_string()), loc }
}
```

But `Ident` means *"bare-identifier method call (vcall)"* to every consumer, and `__ENCODING__` is not a call — it is a pseudo-variable that bytecodegen resolves to the `::Encoding::<NAME>` constant. So every consumer had to re-discriminate it by string comparison, and any consumer that forgot would silently compile it into a vcall to a method named `__ENCODING__`:

- `gen_expr_inner`, twice — once to make void context a no-op, once for the actual constant load
- `gen_store_expr`, which had to *exclude* it from the vcall arm
- `check_defined` and `defined_str` in `defined.rs`

Its `__FILE__` / `__LINE__` siblings need no such node because they fold to a `String` / `Integer` literal at parse time. `__ENCODING__` cannot: an `Encoding` is a heap object with identity, so `__ENCODING__.equal?(Encoding::UTF_8)` must hold.

## Change

Give it a dedicated `NodeKind::SourceEncoding` variant and let the type system route it. All five string comparisons are gone, the constant load moves into `gen_store_expr` (the canonical "evaluate into dst" path), and the two `gen_expr_inner` arms collapse into the existing literal-group patterns.

As a side effect `e = __ENCODING__` now stores directly rather than via a temp, since it no longer has to dodge the vcall arm added in #1014:

```
-    :00001 [03] %2 = ::Encoding::UTF_8
-    :00002 [03] %1 = %2
+    :00001 [02] %1 = ::Encoding::UTF_8
```

## Verification

Behavior is unchanged.

- Full `cargo test --no-fail-fast` suite passes.
- New regression tests cover the store, block, and `defined?` positions the node split touches.
- Output verified to match CRuby for `__ENCODING__` in every expression position — value / `.name` / identity with `Encoding::UTF_8`, store into a local, inside a method / lambda / block, array and hash elements, argument position, ternary condition, void context, `defined?(__ENCODING__)`, `defined?(!__ENCODING__)`, `defined?(__ENCODING__.name)` — under UTF-8, `# encoding: euc-jp`, and `# encoding: ascii-8bit` sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)