### PR TITLE
Easy-tier fixes for core/thread, signal, io ruby/spec failures

### DIFF
--- a/monoruby/builtins/io.rb
+++ b/monoruby/builtins/io.rb
@@ -151,3 +151,53 @@ class IO
     end
   end
 end
+
+class IO
+  # IO.write / IO.binwrite (File inherits both, as in CRuby).
+  #
+  # A given offset suppresses truncation: the file is opened
+  # write-create *without* TRUNC and seeked to the offset first.
+  # `:open_args` replaces every other option (the write mode must be
+  # given inside it — File.open's default read mode makes the write
+  # fail, matching CRuby); otherwise `:mode` (String or Integer),
+  # `:flags` (OR'd onto an Integer mode), `:perm` and the remaining
+  # options are forwarded to File.open.
+  def self.write(name, string, offset = nil, **opts)
+    __class_write(name, string, offset, false, opts)
+  end
+
+  def self.binwrite(name, string, offset = nil, **opts)
+    __class_write(name, string, offset, true, opts)
+  end
+
+  def self.__class_write(name, string, offset, binary, opts)
+    if (open_args = opts[:open_args])
+      f = File.open(name, *open_args)
+    else
+      opts = opts.dup
+      mode = opts.delete(:mode)
+      flags = opts.delete(:flags)
+      perm = opts.delete(:perm)
+      if mode.nil?
+        mode = File::WRONLY | File::CREAT
+        mode |= File::TRUNC unless offset
+        mode |= File::BINARY if binary
+        mode |= flags if flags
+      elsif flags && mode.is_a?(Integer)
+        mode |= flags
+      end
+      f = if opts.empty?
+        perm ? File.open(name, mode, perm) : File.open(name, mode)
+      else
+        perm ? File.open(name, mode, perm, **opts) : File.open(name, mode, **opts)
+      end
+    end
+    begin
+      f.seek(offset) if offset
+      f.write(string)
+    ensure
+      f.close
+    end
+  end
+  private_class_method :__class_write
+end

--- a/monoruby/builtins/thread.rb
+++ b/monoruby/builtins/thread.rb
@@ -29,7 +29,36 @@ class Thread
     @@ignore_deadlock = flag
   end
 
-  attr_accessor :name
+  # NOTE: every raise inside an *instance* method of Thread must be the
+  # explicit `Kernel.raise` — a bare `raise` dispatches on `self`, and
+  # `self` here is the receiver Thread, so it would silently become the
+  # asynchronous `Thread#raise` *into that thread* (queueing the
+  # exception there and returning nil to the caller) whenever the
+  # receiver is not the current thread.
+
+  attr_reader :name
+
+  # CRuby coerces the name with #to_str (TypeError otherwise), rejects
+  # embedded NULs, and allows nil to clear the name.
+  def name=(name)
+    unless name.nil?
+      unless name.is_a?(String)
+        if name.respond_to?(:to_str)
+          name = name.to_str
+          unless name.is_a?(String)
+            Kernel.raise TypeError,
+              "can't convert #{name.class} to String (#{name.class}#to_str gives #{name.class})"
+          end
+        else
+          Kernel.raise TypeError, "no implicit conversion of #{name.class} into String"
+        end
+      end
+      if name.include?("\0")
+        Kernel.raise ArgumentError, "string contains null byte"
+      end
+    end
+    @name = name
+  end
 
   # Reported when a thread dies with an unhandled exception (read by the
   # native finalizer). Falls back to the class-level default
@@ -114,7 +143,7 @@ class Thread
       if key.respond_to?(:to_str)
         key.to_str.to_sym
       else
-        raise TypeError, "#{key.inspect} is not a symbol nor a string"
+        Kernel.raise TypeError, "#{key.inspect} is not a symbol nor a string"
       end
     end
   end
@@ -126,7 +155,7 @@ class Thread
   end
 
   def []=(key, value)
-    raise FrozenError, "can't modify frozen thread locals" if frozen?
+    Kernel.raise FrozenError, "can't modify frozen thread locals" if frozen?
     (@fiber_locals ||= {})[__thread_key(key)] = value
   end
 
@@ -141,7 +170,7 @@ class Thread
 
   def fetch(key, *default)
     if default.size > 1
-      raise ArgumentError, "wrong number of arguments (given #{default.size + 1}, expected 1..2)"
+      Kernel.raise ArgumentError, "wrong number of arguments (given #{default.size + 1}, expected 1..2)"
     end
     k = __thread_key(key)
     if @fiber_locals && @fiber_locals.key?(k)
@@ -152,7 +181,7 @@ class Thread
     elsif !default.empty?
       default[0]
     else
-      raise KeyError.new("key not found: #{key.inspect}", receiver: self, key: key)
+      Kernel.raise KeyError.new("key not found: #{key.inspect}", receiver: self, key: key)
     end
   end
 
@@ -162,13 +191,16 @@ class Thread
   end
 
   def thread_variable_set(key, value)
-    raise FrozenError, "can't modify frozen thread locals" if frozen?
+    Kernel.raise FrozenError, "can't modify frozen thread locals" if frozen?
     (@thread_variables ||= {})[__thread_key(key)] = value
   end
 
   def thread_variable?(key)
+    # CRuby: assigning nil "removes" the variable as far as this
+    # predicate is concerned (the key itself stays listed in
+    # #thread_variables) — so test the value, not key presence.
     k = __thread_key(key)
-    !!(@thread_variables && @thread_variables.key?(k))
+    !!(@thread_variables && !@thread_variables[k].nil?)
   end
 
   def thread_variables
@@ -184,7 +216,7 @@ class Thread
   def priority=(value)
     unless value.is_a?(Integer)
       unless value.respond_to?(:to_int) && (value = value.to_int).is_a?(Integer)
-        raise TypeError, "no implicit conversion of #{value.class} into Integer"
+        Kernel.raise TypeError, "no implicit conversion of #{value.class} into Integer"
       end
     end
     # CRuby clamps the stored priority to -3..3.
@@ -200,6 +232,20 @@ class Thread
     alive? ? object_id : nil
   end
 
+  # True aliases (ruby/spec checks `instance_method(:terminate) ==
+  # instance_method(:kill)` and `method(:fork) == method(:start)`).
+  alias terminate kill
+  alias exit kill
+  class << self
+    alias fork start
+
+    # Thread has no allocator: instances are only created through
+    # Thread.new/start/fork (CRuby raises the same TypeError).
+    def allocate
+      Kernel.raise TypeError, "allocator undefined for Thread"
+    end
+  end
+
   # The object returned by `Process.detach`. Reaping one specific child via
   # `Process.wait2` is a *terminating* operation (unlike an arbitrary thread
   # body), so — unlike a general Thread, which defines no #join / #value —
@@ -211,7 +257,9 @@ class Thread
     # a Waiter is an inert shell around one specific child pid, so build
     # it via allocate.
     def self.new(pid)
-      w = allocate
+      # Not `allocate` — Thread.allocate deliberately raises TypeError
+      # (no user-visible allocator); the privileged spelling still works.
+      w = __builtin_allocate__
       w.__send__(:__init_waiter, pid)
       w
     end
@@ -635,6 +683,13 @@ class Thread
   end
 
   class Backtrace
+    # Maximum backtrace length set by --backtrace-limit, or -1 when the
+    # option was not given (CRuby). The runtime exposes the raw option
+    # (nil when unset) as Kernel.__backtrace_limit.
+    def self.limit
+      Kernel.__backtrace_limit || -1
+    end
+
     class Location
       def initialize(frame)
         @frame = frame.to_s

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -3612,4 +3612,26 @@ mod tests {
             "#,
         );
     }
+
+
+    #[test]
+    fn file_open_integer_flags_no_truncate() {
+        // WRONLY|CREAT without TRUNC must not truncate an existing
+        // file; bare WRONLY opens an existing file without creating.
+        run_test_once(
+            r#"
+            path = "/tmp/monoruby_test_flags_#{Process.pid}_#{rand(100000)}"
+            begin
+              File.write(path, "hello")
+              File.open(path, File::WRONLY | File::CREAT) { |f| f.write("A") }
+              a = File.read(path)
+              File.open(path, File::WRONLY) { |f| f.write("B") }
+              b = File.read(path)
+              [a, b]
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::path::Path;
 use std::{
     fs::File,
-    io::{Seek, SeekFrom, Write},
+    io::{Seek, SeekFrom},
 };
 
 //
@@ -27,20 +27,13 @@ pub(super) fn init(globals: &mut Globals) {
     // arity opening alone closes a 25-strong cluster in
     // `core/kernel` (mspec's `before :each` writes a fixture file
     // with `perm: 0o700`).
-    globals.define_builtin_class_func_with_kw(
-        file, "write", file_write, 2, 3, false,
-        &["mode", "perm", "encoding"], false,
-    );
-    globals.define_builtin_class_func_with(file, "binwrite", file_binwrite, 2, 3, false);
+    // File.write / File.binwrite are inherited from IO (implemented in
+    // Ruby, builtins/io.rb) — CRuby defines them on IO too.
     globals.define_builtin_class_func_with(file, "read", file_read, 1, 4, false);
     globals.define_builtin_class_func_with(file, "binread", file_binread, 1, 3, false);
 
     // IO class methods that share semantics with File.* class methods.
-    globals.define_builtin_class_func_with_kw(
-        IO_CLASS, "write", file_write, 2, 3, false,
-        &["mode", "perm", "encoding"], false,
-    );
-    globals.define_builtin_class_func_with(IO_CLASS, "binwrite", file_binwrite, 2, 3, false);
+    // (IO.write / IO.binwrite live in builtins/io.rb.)
     globals.define_builtin_class_func_with(IO_CLASS, "binread", file_binread, 1, 3, false);
     globals.define_builtin_class_func(IO_CLASS, "try_convert", io_try_convert, 1);
     globals.define_builtin_class_func_rest(file, "join", file_join);
@@ -184,52 +177,6 @@ pub(super) fn init(globals: &mut Globals) {
     );
 }
 
-///
-/// ### File.write
-/// - write(path, string, opt={}) -> Integer
-/// - [NOT SUPPORTED] write(path, string, offset=nil, opt={}) -> Integer
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/s/write.html]
-#[monoruby_builtin]
-fn file_write(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let name = lfp.arg(0).coerce_to_string(vm, globals)?;
-    let mut file = match File::create(&name) {
-        Ok(file) => file,
-        Err(err) => {
-            return Err(MonorubyErr::errno_with_path(
-                &globals.store,
-                &err,
-                "rb_sysopen",
-                &name,
-            ));
-        }
-    };
-    let val = lfp.arg(1);
-    let len = if let Some(s) = val.is_rstring() {
-        if let Err(err) = file.write_all(&s) {
-            return Err(MonorubyErr::errno_with_path(
-                &globals.store,
-                &err,
-                "rb_io_write",
-                &name,
-            ));
-        };
-        s.len()
-    } else {
-        let v = val.to_s(&globals.store).into_bytes();
-        if let Err(err) = file.write_all(&v) {
-            return Err(MonorubyErr::errno_with_path(
-                &globals.store,
-                &err,
-                "rb_io_write",
-                &name,
-            ));
-        };
-        v.len()
-    };
-
-    Ok(Value::integer(len as i64))
-}
 
 ///
 /// ### IO.read
@@ -355,87 +302,6 @@ fn file_binread(
     }
 }
 
-///
-/// ### IO.binwrite / File.binwrite
-/// - binwrite(path, string, offset = nil) -> Integer
-///
-/// Writes `string` to the file at `path` in binary mode and returns the
-/// number of bytes written. With no `offset`, the file is created if missing
-/// and truncated to the length of `string`. With an `offset`, the file is
-/// created if missing but **not** truncated; bytes are written starting at
-/// `offset`.
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/IO/s/binwrite.html]
-#[monoruby_builtin]
-fn file_binwrite(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let name = lfp.arg(0).coerce_to_string(vm, globals)?;
-    let val = lfp.arg(1);
-    let bytes = if let Some(s) = val.is_rstring() {
-        s.to_vec()
-    } else {
-        val.to_s(&globals.store).into_bytes()
-    };
-    let offset = if let Some(arg2) = lfp.try_arg(2)
-        && !arg2.is_nil()
-    {
-        Some(arg2.coerce_to_int_i64(vm, globals)?)
-    } else {
-        None
-    };
-    let mut file = match offset {
-        None => match File::create(&name) {
-            Ok(f) => f,
-            Err(err) => {
-                return Err(MonorubyErr::errno_with_path(
-                    &globals.store,
-                    &err,
-                    "rb_sysopen",
-                    &name,
-                ));
-            }
-        },
-        Some(off) => {
-            let mut f = match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .open(&name)
-            {
-                Ok(f) => f,
-                Err(err) => {
-                    return Err(MonorubyErr::errno_with_path(
-                        &globals.store,
-                        &err,
-                        "rb_sysopen",
-                        &name,
-                    ));
-                }
-            };
-            if let Err(err) = f.seek(SeekFrom::Start(off as u64)) {
-                return Err(MonorubyErr::errno_with_path(
-                    &globals.store,
-                    &err,
-                    "rb_io_seek",
-                    &name,
-                ));
-            }
-            f
-        }
-    };
-    if let Err(err) = file.write_all(&bytes) {
-        return Err(MonorubyErr::errno_with_path(
-            &globals.store,
-            &err,
-            "rb_io_write",
-            &name,
-        ));
-    }
-    Ok(Value::integer(bytes.len() as i64))
-}
 
 ///
 /// ### IO.try_convert
@@ -983,14 +849,19 @@ pub(super) fn mode_string_from_flags(flags: i64) -> String {
     match access {
         // RDONLY
         0 => "r".to_string(),
-        // WRONLY
+        // WRONLY. `WRONLY|CREAT` *without* `TRUNC` has no public mode
+        // string; the internal spellings "w-" (write+create) / "-w"
+        // (write only) keep it lossless — `IO.write` with an offset
+        // depends on the file NOT being truncated.
         1 => {
             if append {
                 "a".to_string()
-            } else if trunc || create {
+            } else if trunc {
                 "w".to_string()
+            } else if create {
+                "w-".to_string()
             } else {
-                "w".to_string()
+                "-w".to_string()
             }
         }
         // RDWR
@@ -1136,13 +1007,17 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let mode_base = mode.split(':').next().unwrap().replace('b', "");
     let (readable, writable) = match mode_base.as_str() {
         "r" => (true, false),
-        "w" | "a" => (false, true),
+        "w" | "a" | "w-" | "-w" => (false, true),
         "r+" | "+r" | "w+" | "+w" | "a+" | "+a" => (true, true),
         _ => (true, false),
     };
     let opt = match mode_base.as_str() {
         "r" => opt.read(true),
         "w" => opt.write(true).create(true).truncate(true),
+        // Internal spellings (mode_string_from_flags): write+create
+        // without truncation, and bare write-only.
+        "w-" => opt.write(true).create(true),
+        "-w" => opt.write(true),
         "a" => opt.write(true).create(true).append(true),
         "r+" | "+r" => opt.read(true).write(true),
         "w+" | "+w" => opt.read(true).write(true).create(true).truncate(true),
@@ -1168,6 +1043,8 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let flags = match mode_base.as_str() {
             "r" => libc::O_RDONLY,
             "w" => libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
+            "w-" => libc::O_WRONLY | libc::O_CREAT,
+            "-w" => libc::O_WRONLY,
             "a" => libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
             "r+" | "+r" => libc::O_RDWR,
             "w+" | "+w" => libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC,
@@ -1236,8 +1113,8 @@ fn write(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         };
         count += bytes.len() as i64;
         let mut done = 0;
-        super::io::blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, || {
-            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+        super::io::blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
+            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done, _store)
         })?;
     }
     Ok(Value::integer(count))

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -7604,4 +7604,62 @@ mod tests {
             "##,
         );
     }
+
+
+    #[test]
+    fn io_puts_to_ary_edge_cases() {
+        // #to_ary returning a non-Array non-nil is the conversion
+        // TypeError; nil falls back to #to_s; a self-referencing Array
+        // renders as "[...]".
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            bad = Object.new
+            def bad.to_ary; 42; end
+            a = begin; w.puts(bad); rescue TypeError => e; e.message; end
+            nilly = Object.new
+            def nilly.to_ary; nil; end
+            def nilly.to_s; "N"; end
+            w.puts(nilly)
+            circ = ["a"]; circ << circ
+            w.puts(circ)
+            w.close
+            [a, r.read]
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_fcntl_error_paths() {
+        // An invalid fcntl command surfaces the OS Errno; an explicit
+        // nil arg is treated as 0.
+        run_test_once(
+            r##"
+            require 'fcntl'
+            File.open("/tmp") do |f|
+              a = begin; f.fcntl(-1); rescue SystemCallError => e; e.class.to_s; end
+              [a, f.fcntl(Fcntl::F_GETFD, nil) >= 0]
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_print_writes_nil_lastline_with_rs() {
+        // Argument-less print with a nil $_ still writes $\ (via
+        // Kernel#print delegating the explicit lastline down).
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            begin
+              $\ = "!"
+              w.print
+            ensure
+              $\ = nil
+            end
+            w.close
+            r.read
+            "##,
+        );
+    }
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -62,6 +62,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func_rest(IO_CLASS, "popen", io_popen);
     globals.define_builtin_func(IO_CLASS, "pid", io_pid, 0);
     globals.define_builtin_funcs(IO_CLASS, "fileno", &["to_i"], io_fileno, 0);
+    globals.define_builtin_func_with(IO_CLASS, "fcntl", io_fcntl, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "to_io", io_to_io, 0);
     globals.define_builtin_func_with(IO_CLASS, "write", io_write_method, 0, 0, true);
     globals.define_builtin_func_with(IO_CLASS, "syswrite", io_syswrite, 1, 1, false);
@@ -278,7 +279,14 @@ pub(super) fn io_init_from_fd(
                 Some(v.coerce_to_string(vm, globals)?)
             } else {
                 let flags = v.coerce_to_int_i64(vm, globals)?;
-                Some(super::file::mode_string_from_flags(flags))
+                let m = super::file::mode_string_from_flags(flags);
+                // The internal no-truncate spellings ("w-"/"-w") only
+                // affect File-open truncation; wrapping an existing fd
+                // never truncates, so they mean plain write-only here.
+                Some(match m.as_str() {
+                    "w-" | "-w" => "w".to_string(),
+                    _ => m,
+                })
             }
         }
     };
@@ -877,8 +885,8 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
         vm.to_s(globals, lfp.arg(0))?.into_bytes()
     };
     let mut done = 0;
-    blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, || {
-        lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+    blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
+        lfp.self_val().as_io_inner_mut().write(&bytes, &mut done, _store)
     })?;
     lfp.self_val().as_io_inner_mut().flush()?;
     Ok(lfp.self_val())
@@ -892,32 +900,66 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/puts.html]
 #[monoruby_builtin]
 fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    fn decompose(collector: &mut Vec<Value>, val: Value, seen: &mut Vec<u64>) {
-        match val.try_array_ty() {
-            Some(ary) => {
-                let id = val.id();
-                if seen.contains(&id) {
-                    collector.push(Value::string("[...]".to_string()));
-                } else {
-                    seen.push(id);
-                    ary.iter().for_each(|v| decompose(collector, *v, seen));
-                    seen.pop();
+    // CRuby's rb_io_puts: a real Array recurses; any other non-String is
+    // first offered `#to_ary` (an Array result recurses, `nil` falls back
+    // to `#to_s`, anything else is the usual conversion TypeError).
+    fn decompose(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        collector: &mut Vec<Value>,
+        val: Value,
+        seen: &mut Vec<u64>,
+    ) -> Result<()> {
+        if let Some(ary) = val.try_array_ty() {
+            let id = val.id();
+            if seen.contains(&id) {
+                collector.push(Value::string("[...]".to_string()));
+            } else {
+                seen.push(id);
+                for v in ary.iter() {
+                    decompose(vm, globals, collector, *v, seen)?;
                 }
+                seen.pop();
             }
-            None => collector.push(val),
+            return Ok(());
         }
+        if val.is_rstring().is_none()
+            && globals
+                .store
+                .check_method(val, IdentId::get_id("to_ary"))
+                .is_some()
+        {
+            let converted =
+                vm.invoke_method_inner(globals, IdentId::get_id("to_ary"), val, &[], None, None)?;
+            if converted.try_array_ty().is_some() {
+                return decompose(vm, globals, collector, converted, seen);
+            }
+            if !converted.is_nil() {
+                return Err(MonorubyErr::typeerr(format!(
+                    "can't convert {} to Array ({}#to_ary gives {})",
+                    val.get_real_class_name(&globals.store),
+                    val.get_real_class_name(&globals.store),
+                    converted.get_real_class_name(&globals.store)
+                )));
+            }
+        }
+        collector.push(val);
+        Ok(())
     }
     let mut collector = Vec::new();
     let mut seen = Vec::new();
     let args = lfp.arg(0).as_array();
+    let no_args = args.is_empty();
     for v in args.iter().cloned() {
-        decompose(&mut collector, v, &mut seen);
+        decompose(vm, globals, &mut collector, v, &mut seen)?;
     }
 
     let self_val = lfp.self_val();
     let write_id = IdentId::get_id("write");
-    if collector.is_empty() {
-        // puts with no args writes a newline
+    if no_args {
+        // puts with no args writes a newline. (An empty *array* argument
+        // decomposes to nothing and writes nothing — only the genuinely
+        // argument-less call gets the bare newline.)
         let newline = Value::string_from_str("\n");
         vm.invoke_method_inner(globals, write_id, self_val, &[newline], None, None)?;
     } else {
@@ -962,14 +1004,46 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn print(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let write_id = IdentId::get_id("write");
-    for v in lfp.arg(0).as_array().iter().cloned() {
-        let str_val = if v.is_rstring().is_some() {
-            v
+    // Each object goes through `#to_s` (never `#to_str`); the output
+    // field separator `$,` goes between objects and the output record
+    // separator `$\` is appended, both only when non-nil (CRuby).
+    let to_str_val = |vm: &mut Executor, globals: &mut Globals, v: Value| -> Result<Value> {
+        if v.is_rstring().is_some() {
+            Ok(v)
         } else {
             let s = vm.to_s(globals, v)?;
-            Value::string(s)
-        };
-        vm.invoke_method_inner(globals, write_id, self_val, &[str_val], None, None)?;
+            Ok(Value::string(s))
+        }
+    };
+    let sep = globals
+        .get_gvar(IdentId::get_id("$,"))
+        .filter(|v| !v.is_nil());
+    let rs = globals
+        .get_gvar(IdentId::get_id("$\\"))
+        .filter(|v| !v.is_nil());
+    let args = lfp.arg(0).as_array();
+    if args.is_empty() {
+        // `print` with no arguments writes `$_` (the caller's frame-local
+        // last-read line; resolved past this native frame). A nil `$_`
+        // still writes `$\`.
+        let lastline = vm.get_last_read_line();
+        if !lastline.is_nil() {
+            let sv = to_str_val(vm, globals, lastline)?;
+            vm.invoke_method_inner(globals, write_id, self_val, &[sv], None, None)?;
+        }
+    } else {
+        for (i, v) in args.iter().cloned().enumerate() {
+            if i > 0 && let Some(sep) = sep {
+                let sv = to_str_val(vm, globals, sep)?;
+                vm.invoke_method_inner(globals, write_id, self_val, &[sv], None, None)?;
+            }
+            let str_val = to_str_val(vm, globals, v)?;
+            vm.invoke_method_inner(globals, write_id, self_val, &[str_val], None, None)?;
+        }
+    }
+    if let Some(rs) = rs {
+        let sv = to_str_val(vm, globals, rs)?;
+        vm.invoke_method_inner(globals, write_id, self_val, &[sv], None, None)?;
     }
     Ok(Value::nil())
 }
@@ -987,10 +1061,10 @@ fn printf(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 
     let buf = vm.format_by_args(globals, &format_str, &args)?;
     let mut done = 0;
-    blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, || {
+    blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
         lfp.self_val()
             .as_io_inner_mut()
-            .write(buf.as_bytes(), &mut done)
+            .write(buf.as_bytes(), &mut done, _store)
     })?;
 
     Ok(Value::nil())
@@ -1183,7 +1257,7 @@ pub(crate) fn blocking_io_region<T>(
     globals: &mut Globals,
     io: Value,
     events: i16,
-    mut f: impl FnMut() -> Result<T>,
+    mut f: impl FnMut(&Store) -> Result<T>,
 ) -> Result<T> {
     loop {
         // Entry parking (wait for readiness *before* attempting the
@@ -1228,7 +1302,7 @@ pub(crate) fn blocking_io_region<T>(
         } else {
             None
         };
-        let res = f();
+        let res = f(&globals.store);
         // Restore the fd's blocking mode *before* parking: while this
         // thread is parked, other green threads (or a spawned child) may
         // use the same fd and must see it in its original mode.
@@ -1299,7 +1373,7 @@ fn gets_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Valu
     let (sep, limit, chomp) = getline_args(vm, globals, lfp, 2)?;
     let self_ = lfp.self_val();
     let complete_utf8 = io_completes_utf8(globals, self_);
-    let line = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let line = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val()
             .as_io_inner_mut()
             .getline(sep.as_deref(), limit, complete_utf8)
@@ -1553,7 +1627,7 @@ fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         lfp.self_val().as_io_inner().ensure_readable()?;
         Vec::new()
     } else {
-        blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+        blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
             lfp.self_val().as_io_inner_mut().read(length)
         })?
     };
@@ -1732,7 +1806,7 @@ fn io_class_readlines(
         vm.temp_push(io_val);
         vm.temp_array_new(None);
         let result = (|| {
-            while let Some(mut buf) = blocking_io_region(vm, globals, io_val, libc::POLLIN, || {
+            while let Some(mut buf) = blocking_io_region(vm, globals, io_val, libc::POLLIN, |_store| {
                 io_val
                     .as_io_inner_mut()
                     .getline(sep.as_deref(), limit, complete_utf8)
@@ -1910,7 +1984,7 @@ fn io_foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
         vm.temp_push(io_val);
         let mut lineno = 0i64;
         let result = (|| {
-            while let Some(mut buf) = blocking_io_region(vm, globals, io_val, libc::POLLIN, || {
+            while let Some(mut buf) = blocking_io_region(vm, globals, io_val, libc::POLLIN, |_store| {
                 io_val
                     .as_io_inner_mut()
                     .getline(sep.as_deref(), limit, complete_utf8)
@@ -2304,6 +2378,34 @@ fn io_fileno(
 }
 
 ///
+/// ### IO#fcntl
+/// - fcntl(cmd, arg = 0) -> Integer
+///
+/// Thin wrapper over fcntl(2). `arg` must be an Integer (the String
+/// forms some exotic commands take are not supported). Raises `IOError`
+/// on a closed stream and the matching `Errno::*` on syscall failure.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/fcntl.html]
+#[monoruby_builtin]
+fn io_fcntl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let fd = self_.as_io_inner().fileno()?;
+    let cmd = lfp.arg(0).coerce_to_int_i64(vm, globals)? as i32;
+    let arg = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => v.coerce_to_int_i64(vm, globals)?,
+        _ => 0,
+    };
+    // SAFETY: fcntl(2) with an integer third argument; no memory is
+    // passed, so there are no aliasing concerns.
+    let ret = unsafe { libc::fcntl(fd, cmd, arg as libc::c_long) };
+    if ret == -1 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "fcntl"));
+    }
+    Ok(Value::integer(ret as i64))
+}
+
+///
 /// ### IO#to_io
 /// - to_io -> self
 ///
@@ -2340,7 +2442,7 @@ fn io_readlines(
     let self_ = lfp.self_val();
     let complete_utf8 = io_completes_utf8(globals, self_);
     let mut lines = Vec::new();
-    while let Some(mut buf) = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    while let Some(mut buf) = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val()
             .as_io_inner_mut()
             .getline(sep.as_deref(), limit, complete_utf8)
@@ -2588,7 +2690,7 @@ fn io_eof_(
         return Ok(Value::bool(false));
     }
     // Read 1 byte; if empty, we're at EOF.
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val().as_io_inner_mut().read(Some(1))
     })?;
     let io = self_.as_io_inner_mut();
@@ -2621,7 +2723,7 @@ fn io_getbyte(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val().as_io_inner_mut().read(Some(1))
     })?;
     if buf.is_empty() {
@@ -2743,7 +2845,7 @@ fn io_getc(
     let self_ = lfp.self_val();
     let ext_obj = read_io_encoding(globals, self_, false);
     let ext = enc_obj_to_enum(globals, ext_obj).unwrap_or(crate::value::Encoding::Utf8);
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         read_one_char_enc(lfp.self_val().as_io_inner_mut(), ext)
     })?;
     if buf.is_empty() {
@@ -3013,8 +3115,8 @@ fn io_write_method(
         };
         total += bytes.len() as i64;
         let mut done = 0;
-        blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, || {
-            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done)
+        blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
+            lfp.self_val().as_io_inner_mut().write(&bytes, &mut done, _store)
         })?;
     }
     Ok(Value::integer(total))
@@ -3209,7 +3311,7 @@ fn io_sysread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
             None => Value::string_from_vec(vec![]),
         });
     }
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val().as_io_inner_mut().sysread(maxlen as usize)
     })?;
     if buf.is_empty() {
@@ -3268,7 +3370,7 @@ fn io_readpartial(
             None => Value::string_from_vec(vec![]),
         });
     }
-    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val().as_io_inner_mut().readpartial(maxlen as usize)
     })?;
     if buf.is_empty() {
@@ -3890,7 +3992,7 @@ fn set_encoding_by_bom(
     }
     // Read up to 4 bytes — enough to disambiguate every BOM (and to
     // tell UTF-16LE from UTF-32LE, which share the FF FE prefix).
-    let head = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, || {
+    let head = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
         lfp.self_val().as_io_inner_mut().read(Some(4))
     })?;
     let (consume, enc_name): (usize, &str) = match head.first() {
@@ -4573,8 +4675,8 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                     // immediately — Rust's stdout is block-buffered).
                     let mut vv = *v;
                     let mut done = 0;
-                    blocking_io_region(vm, globals, vv, libc::POLLOUT, || {
-                        vv.as_io_inner_mut().write(chunk, &mut done)
+                    blocking_io_region(vm, globals, vv, libc::POLLOUT, |_store| {
+                        vv.as_io_inner_mut().write(chunk, &mut done, _store)
                     })?;
                     vv.as_io_inner_mut().flush()
                 }
@@ -4630,7 +4732,7 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                         break;
                     }
                     let mut vv = *v;
-                    let chunk = blocking_io_region(vm, globals, vv, libc::POLLIN, || {
+                    let chunk = blocking_io_region(vm, globals, vv, libc::POLLIN, |_store| {
                         vv.as_io_inner_mut().readpartial(want)
                     })?;
                     if chunk.is_empty() {
@@ -7388,6 +7490,118 @@ mod tests {
             w.close
             res
             "#,
+        );
+    }
+
+
+    #[test]
+    fn io_puts_to_ary_protocol() {
+        // A non-String object is offered #to_ary first; an empty Array
+        // writes nothing (only the argument-less call writes "\n").
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            w.puts([])
+            w.puts
+            o = Object.new
+            def o.to_ary; ["x", [1, [2]]]; end
+            w.puts(o)
+            n = Object.new
+            def n.to_s; "S"; end
+            w.puts(n)
+            w.close
+            r.read
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_print_field_and_record_separators() {
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            begin
+              $, = "-"
+              $\ = "!"
+              w.print("a", "b")
+              $, = nil
+              $\ = nil
+              o = Object.new
+              def o.to_s; "OBJ"; end
+              w.print(o)
+            ensure
+              $, = nil
+              $\ = nil
+            end
+            w.close
+            r.read
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_class_write_options() {
+        run_test_once(
+            r##"
+            path = "/tmp/monoruby_test_iowrite_#{Process.pid}_#{rand(100000)}"
+            r = []
+            begin
+              r << IO.write(path, "hello")
+              # An offset suppresses truncation.
+              r << IO.write(path, "AB", 1)
+              r << File.read(path)
+              r << IO.binwrite(path, "zz", 3)
+              r << File.read(path)
+              r << (begin; IO.write(path, "hi", mode: "r"); rescue IOError => e; e.message; end)
+              r << IO.write(path, "hi", 2, mode: "r", open_args: ["w"])
+              r << File.read(path).bytes
+              r << (begin; IO.write(path, "hi", open_args: [{binmode: true}]); rescue IOError => e; e.message; end)
+              r << IO.write(path, "x", flags: File::CREAT | File::WRONLY | File::TRUNC)
+              r << IO.write(path, 123, mode: "a")
+              r << File.read(path)
+            ensure
+              File.unlink(path) rescue nil
+            end
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_write_closed_pipe_epipe() {
+        // SIGPIPE is ignored at startup; a write to a closed pipe
+        // surfaces Errno::EPIPE instead of killing the process.
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            r.close
+            begin
+              w.write("x")
+              :no_error
+            rescue Errno::EPIPE => e
+              e.class.to_s
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_fcntl_and_nonblock_stub() {
+        run_test_once(
+            r##"
+            require 'fcntl'
+            require 'io/nonblock'
+            res = []
+            File.open("/tmp") { |f| res << (f.fcntl(Fcntl::F_GETFD) >= 0) }
+            r, w = IO.pipe
+            r.nonblock = false
+            res << r.nonblock?
+            r.nonblock(true) { res << r.nonblock? }
+            res << r.nonblock?
+            f = File.open("/tmp"); f.close
+            res << (begin; f.fcntl(Fcntl::F_GETFL); rescue IOError => e; e.message; end)
+            res
+            "##,
         );
     }
 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -816,13 +816,11 @@ fn print(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let print_id = IdentId::get_id("print");
     if args.len() == 0 {
         // `print` with no arguments writes `$_` (the caller's
-        // frame-local last-read line). A `nil` `$_` prints nothing.
-        // `vm.get_last_read_line` resolves the LEP past this native
-        // frame, so it sees the Ruby caller's `$_`, not print's own.
+        // frame-local last-read line). `vm.get_last_read_line` resolves
+        // the LEP past this native frame, so it sees the Ruby caller's
+        // `$_`, not print's own. Passed down explicitly (a nil `$_`
+        // prints as "") so `IO#print` still appends `$\`.
         let lastline = vm.get_last_read_line();
-        if lastline.is_nil() {
-            return Ok(Value::nil());
-        }
         vm.invoke_method_inner(globals, print_id, stdout, &[lastline], None, None)?;
     } else {
         let argvec: Vec<Value> = args.iter().cloned().collect();

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1268,6 +1268,25 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn signal_trap_exit_dispositions() {
+        // nil / IGNORE clear the EXIT hook like DEFAULT; a handler set
+        // and left in place survives a GC (the hook is a root).
+        run_test_once(
+            r#"
+            a = Signal.trap(:EXIT, proc { })
+            b = Signal.trap(:EXIT, nil)
+            c = Signal.trap(:EXIT, 'IGNORE')
+            Signal.trap(:EXIT, proc { })
+            GC.start
+            d = Signal.trap(:EXIT, 'DEFAULT').is_a?(Proc)
+            [a, b.is_a?(Proc), c, d]
+            "#,
+        );
+        run_test_error(r#"Signal.trap(:EXIT)"#);
+    }
+
+    #[test]
     fn signal_trap_reserved_signal() {
         // SIGKILL / SIGSTOP cannot be trapped.
         run_test_error("Signal.trap(:KILL) { }");

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1018,6 +1018,26 @@ pub(super) fn signal_trap(
     pc: BytecodePtr,
 ) -> Result<Value> {
     let signo = trap_signo(vm, globals, lfp.arg(0))?;
+    if signo == 0 {
+        // The EXIT pseudo-signal: not a signal at all but an exit hook,
+        // run before the `at_exit` handlers (see run_exit_handlers).
+        use signal_table::SignalDisposition;
+        let new_disp = if let Some(cmd) = lfp.try_arg(1) {
+            command_disposition(cmd)?
+        } else if let Some(bh) = lfp.block() {
+            SignalDisposition::Handler(vm.generate_proc(globals, bh, pc)?.into())
+        } else {
+            return Err(MonorubyErr::argumenterr(
+                "tried to create Proc object without a block",
+            ));
+        };
+        let prev = globals.exit_trap_handler.take();
+        if let SignalDisposition::Handler(v) = new_disp {
+            globals.exit_trap_handler = Some(v);
+        }
+        // A never-trapped EXIT reports nil (CRuby).
+        return Ok(prev.unwrap_or_default());
+    }
     if signal_table::is_uncatchable(signo) {
         // KILL / STOP: the kernel forbids catching these.
         return Err(MonorubyErr::argumenterr("Signal already used by VM or OS"));
@@ -1228,6 +1248,23 @@ mod tests {
     #[test]
     fn signal_trap_unsupported_signal() {
         run_test_error(r#"Signal.trap("NO_SUCH_SIGNAL") { }"#);
+    }
+
+    #[test]
+    #[test]
+    fn signal_trap_exit_pseudo_signal() {
+        // EXIT is an exit hook, not a signal: trapping it succeeds, a
+        // never-trapped EXIT reports nil, re-trapping reports the
+        // previous handler, and "DEFAULT" unsets it.
+        run_test_once(
+            r#"
+            a = Signal.trap(:EXIT, proc { })
+            b = Signal.trap('EXIT') { }
+            c = Signal.trap(:EXIT, 'DEFAULT')
+            d = Signal.trap(:EXIT, 'DEFAULT')
+            [a, b.is_a?(Proc), c.is_a?(Proc), d]
+            "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -22,8 +22,10 @@ pub(super) fn init(globals: &mut Globals) {
     globals.store[THREAD_CLASS].set_alloc_func(thread_alloc_func);
 
     globals.define_builtin_class_func_rest(THREAD_CLASS, "new", thread_new);
-    globals.define_builtin_class_func_rest(THREAD_CLASS, "start", thread_new);
-    globals.define_builtin_class_func_rest(THREAD_CLASS, "fork", thread_new);
+    globals.define_builtin_class_func_rest(THREAD_CLASS, "start", thread_start);
+    // `fork` is re-pointed at `start` as a true alias in builtins/thread.rb
+    // (ruby/spec checks `Thread.method(:fork) == Thread.method(:start)`).
+    globals.define_builtin_class_func_rest(THREAD_CLASS, "fork", thread_start);
     globals.define_builtin_class_func(THREAD_CLASS, "current", thread_current, 0);
     globals.define_builtin_class_func(THREAD_CLASS, "main", thread_main, 0);
     globals.define_builtin_class_func(THREAD_CLASS, "pass", thread_pass, 0);
@@ -324,6 +326,25 @@ fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
     // `thread` is reachable via the scheduler registry.
     scheduler::pass(vm, globals)?;
     Ok(thread)
+}
+
+/// `Thread.start` / `Thread.fork`: same as `Thread.new`, but a missing
+/// block is an `ArgumentError` ("tried to create Proc object without a
+/// block") rather than `Thread.new`'s `ThreadError` (CRuby).
+#[monoruby_builtin]
+fn thread_start(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    if lfp.block().is_none() {
+        return Err(MonorubyErr::argumenterr(
+            "tried to create Proc object without a block",
+        ));
+    }
+    // `#[monoruby_builtin]` renames the Result-returning body to `__<name>`.
+    __thread_new(vm, globals, lfp, pc)
 }
 
 ///
@@ -1730,6 +1751,59 @@ mod tests {
               [a, b]
             end
             t.value
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_cross_thread_raise_stays_in_caller() {
+        // A raise inside a Ruby-implemented Thread instance method must
+        // surface in the *caller*, not be queued into the receiver thread
+        // (a bare `raise` there would dispatch to the async Thread#raise
+        // since `self` is the receiver Thread — see builtins/thread.rb).
+        run_test_once(
+            r##"
+            q = Thread::Queue.new
+            th = Thread.new { q.pop }
+            r = []
+            begin; th.thread_variable_get(123); rescue TypeError => e; r << e.message; end
+            begin; th.fetch(:cat); rescue KeyError => e; r << e.class.to_s; end
+            begin; th.priority = Object.new; rescue TypeError => e; r << e.message; end
+            begin; th.name = 123; rescue TypeError => e; r << e.message; end
+            begin; th.name = "a\0b"; rescue ArgumentError => e; r << e.message; end
+            q.push(nil); th.join
+            r << th.status.inspect
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn thread_aliases_and_limits() {
+        run_test(
+            r#"[Thread.instance_method(:terminate) == Thread.instance_method(:kill),
+                Thread.instance_method(:exit) == Thread.instance_method(:kill),
+                Thread.method(:fork) == Thread.method(:start),
+                Thread::Backtrace.limit]"#,
+        );
+        // Thread.allocate: allocator undefined (TypeError); Thread.start
+        // without a block: ArgumentError (unlike Thread.new's ThreadError).
+        run_test_error(r#"Thread.allocate"#);
+        run_test_error(r#"Thread.start"#);
+        run_test_error(r#"Thread.new"#);
+    }
+
+    #[test]
+    fn thread_variable_set_nil_removes() {
+        // Assigning nil makes thread_variable? false while the key stays
+        // listed in #thread_variables (CRuby); false is a real value.
+        run_test_once(
+            r#"
+            t = Thread.new {}.join
+            t.thread_variable_set(:a, 1)
+            t.thread_variable_set(:a, nil)
+            t.thread_variable_set(:b, false)
+            [t.thread_variable?(:a), t.thread_variable?(:b), t.thread_variables, t.thread_variable_get(:a)]
             "#,
         );
     }

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1071,6 +1071,14 @@ impl Codegen {
             }
         }
 
+        // CRuby ignores SIGPIPE at startup so a write(2) to a closed pipe
+        // surfaces as `Errno::EPIPE` instead of killing the process. The
+        // recorded disposition (globals.rs) is `Ignore { from_nil: true }`,
+        // which is what `Signal.trap("PIPE", ...)` reports as nil.
+        if !codegen.install_signal_ignore(libc::SIGPIPE) {
+            panic!("Failed to ignore SIGPIPE");
+        }
+
         #[cfg(feature = "perf")]
         codegen.perf_info(pair, "monoruby-vm");
 

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -621,6 +621,12 @@ impl Executor {
     ///   the process fail with status 1 (unless a `SystemExit` chose a
     ///   status explicitly).
     pub(crate) fn run_exit_handlers(&mut self, globals: &mut Globals) -> Option<i32> {
+        // The `Signal.trap(:EXIT)` handler runs before the at_exit
+        // handlers (CRuby order). Pushing it last makes the LIFO pop
+        // below run it first, with identical error semantics.
+        if let Some(handler) = globals.exit_trap_handler.take() {
+            globals.at_exit_handlers.push(handler);
+        }
         if globals.at_exit_handlers.is_empty() && globals.finalizers.is_empty() {
             return None;
         }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -227,6 +227,10 @@ pub struct Globals {
     /// signal runs a Ruby `Proc`, is ignored, or lowers to the default
     /// exception. See doc/signal.md A7.
     pub(crate) signal_handlers: Vec<crate::codegen::signal_table::SignalDisposition>,
+    /// The `Signal.trap(:EXIT, ...)` handler, if any. EXIT is a
+    /// pseudo-signal: the handler is not a signal disposition but an
+    /// exit hook, run *before* the `at_exit` handlers (CRuby order).
+    pub(crate) exit_trap_handler: Option<Value>,
     /// `Kernel#at_exit` handler Procs, run in LIFO order at program
     /// termination. Held here as GC roots: they are reachable only from
     /// this table yet must survive until the program exits.
@@ -281,6 +285,9 @@ impl alloc::GC<RValue> for Globals {
         // roots: nothing else references them, yet they must survive until
         // they run at program termination.
         for v in &self.at_exit_handlers {
+            v.mark(alloc);
+        }
+        if let Some(v) = &self.exit_trap_handler {
             v.mark(alloc);
         }
         for (_, v) in &self.finalizers {
@@ -465,10 +472,15 @@ impl Globals {
                 for &signo in signal_table::POSIX_SIGNALS {
                     v[signo as usize] = SignalDisposition::Default;
                 }
+                // SIGPIPE is ignored at startup (writes surface
+                // Errno::EPIPE instead of killing the process, as in
+                // CRuby); trap reports the never-trapped state as nil.
+                v[libc::SIGPIPE as usize] = SignalDisposition::Ignore { from_nil: true };
                 v
             },
             invokers,
             enum_block_arity: Vec::new(),
+            exit_trap_handler: None,
             at_exit_handlers: Vec::new(),
             finalizers: Vec::new(),
             #[cfg(feature = "profile")]

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -602,13 +602,13 @@ impl IoInner {
     /// marker. Because `*progress` records exactly what was flushed, the
     /// builtin's `blocking_region` retry after a `Signal.trap` handler
     /// resumes mid-buffer without duplicating output.
-    pub fn write(&mut self, data: &[u8], progress: &mut usize) -> Result<()> {
+    pub fn write(&mut self, data: &[u8], progress: &mut usize, store: &Store) -> Result<()> {
         self.ensure_writable()?;
         fn write_all(
             writer: &mut impl Write,
             data: &[u8],
             progress: &mut usize,
-            map: impl Fn(String) -> MonorubyErr,
+            store: &Store,
         ) -> Result<()> {
             while *progress < data.len() {
                 // A blocking pipe write that already transferred bytes
@@ -621,7 +621,7 @@ impl IoInner {
                     return Err(MonorubyErr::signal_interrupt());
                 }
                 match writer.write(&data[*progress..]) {
-                    Ok(0) => return Err(map("write returned 0".to_string())),
+                    Ok(0) => return Err(MonorubyErr::ioerr("write returned 0")),
                     Ok(n) => *progress += n,
                     Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
                         if signal_pending() {
@@ -635,35 +635,28 @@ impl IoInner {
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         return Err(MonorubyErr::would_block_interrupt());
                     }
-                    Err(e) => return Err(map(e.to_string())),
+                    // Surface the OS error as the matching Errno::* (e.g.
+                    // Errno::EPIPE on a closed pipe — SIGPIPE is ignored
+                    // at startup, as in CRuby).
+                    Err(e) => return Err(MonorubyErr::errno_plain(store, &e)),
                 }
             }
             Ok(())
         }
         match self {
-            Self::Stdout => write_all(
-                &mut std::io::stdout(),
-                data,
-                progress,
-                MonorubyErr::rangeerr,
-            ),
-            Self::Stderr => write_all(
-                &mut std::io::stderr(),
-                data,
-                progress,
-                MonorubyErr::rangeerr,
-            ),
+            Self::Stdout => write_all(&mut std::io::stdout(), data, progress, store),
+            Self::Stderr => write_all(&mut std::io::stderr(), data, progress, store),
             Self::File(file) => write_all(
                 Rc::get_mut(file).unwrap().reader.get_mut(),
                 data,
                 progress,
-                MonorubyErr::rangeerr,
+                store,
             ),
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
                 // `ensure_writable` guaranteed the writer is present.
                 let writer = popen.writer.as_mut().unwrap();
-                write_all(writer, data, progress, MonorubyErr::ioerr)
+                write_all(writer, data, progress, store)
             }
             // `ensure_writable` already rejected non-writable streams.
             Self::Stdin | Self::Closed(..) => unreachable!(),

--- a/monoruby/stdlib/fcntl.rb
+++ b/monoruby/stdlib/fcntl.rb
@@ -4,37 +4,60 @@
 #
 # CRuby ships this as a C extension that only defines the Fcntl constant
 # module; the actual work happens through `IO#fcntl` (a monoruby
-# builtin). The values are the Linux/x86-64 ones, matching the vendored
-# platform.
+# builtin). The fcntl command numbers and open flags differ between
+# Linux and Darwin, so branch on the runtime platform (monoruby runs on
+# both). `O_NONBLOCK` in particular is 0o4000 on Linux but 0x0004 on
+# Darwin — using the wrong bit makes `io/nonblock` silently ineffective.
 module Fcntl
   F_DUPFD  = 0
   F_GETFD  = 1
   F_SETFD  = 2
   F_GETFL  = 3
   F_SETFL  = 4
-  F_GETLK  = 5
-  F_SETLK  = 6
-  F_SETLKW = 7
 
   FD_CLOEXEC = 1
-
-  F_RDLCK = 0
-  F_WRLCK = 1
-  F_UNLCK = 2
 
   O_RDONLY   = 0
   O_WRONLY   = 1
   O_RDWR     = 2
   O_ACCMODE  = 3
-  O_CREAT    = 64
-  O_EXCL     = 128
-  O_NOCTTY   = 256
-  O_TRUNC    = 512
-  O_APPEND   = 1024
-  O_NONBLOCK = 2048
-  O_NDELAY   = O_NONBLOCK
 
-  F_DUPFD_CLOEXEC = 1030
+  if RUBY_PLATFORM.include?('darwin')
+    F_GETLK  = 7
+    F_SETLK  = 8
+    F_SETLKW = 9
+
+    F_RDLCK = 1
+    F_WRLCK = 3
+    F_UNLCK = 2
+
+    O_NONBLOCK = 0x0004
+    O_APPEND   = 0x0008
+    O_CREAT    = 0x0200
+    O_TRUNC    = 0x0400
+    O_EXCL     = 0x0800
+    O_NOCTTY   = 0x20000
+
+    F_DUPFD_CLOEXEC = 67
+  else
+    F_GETLK  = 5
+    F_SETLK  = 6
+    F_SETLKW = 7
+
+    F_RDLCK = 0
+    F_WRLCK = 1
+    F_UNLCK = 2
+
+    O_NONBLOCK = 0o4000
+    O_APPEND   = 0o2000
+    O_CREAT    = 0o100
+    O_TRUNC    = 0o1000
+    O_EXCL     = 0o200
+    O_NOCTTY   = 0o400
+
+    F_DUPFD_CLOEXEC = 1030
+  end
+  O_NDELAY = O_NONBLOCK
 
   VERSION = "1.2.0"
 end

--- a/monoruby/stdlib/fcntl.rb
+++ b/monoruby/stdlib/fcntl.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# `fcntl` stub for monoruby.
+#
+# CRuby ships this as a C extension that only defines the Fcntl constant
+# module; the actual work happens through `IO#fcntl` (a monoruby
+# builtin). The values are the Linux/x86-64 ones, matching the vendored
+# platform.
+module Fcntl
+  F_DUPFD  = 0
+  F_GETFD  = 1
+  F_SETFD  = 2
+  F_GETFL  = 3
+  F_SETFL  = 4
+  F_GETLK  = 5
+  F_SETLK  = 6
+  F_SETLKW = 7
+
+  FD_CLOEXEC = 1
+
+  F_RDLCK = 0
+  F_WRLCK = 1
+  F_UNLCK = 2
+
+  O_RDONLY   = 0
+  O_WRONLY   = 1
+  O_RDWR     = 2
+  O_ACCMODE  = 3
+  O_CREAT    = 64
+  O_EXCL     = 128
+  O_NOCTTY   = 256
+  O_TRUNC    = 512
+  O_APPEND   = 1024
+  O_NONBLOCK = 2048
+  O_NDELAY   = O_NONBLOCK
+
+  F_DUPFD_CLOEXEC = 1030
+
+  VERSION = "1.2.0"
+end

--- a/monoruby/stdlib/io/nonblock.rb
+++ b/monoruby/stdlib/io/nonblock.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+#
+# `io/nonblock` stub for monoruby: the O_NONBLOCK accessors CRuby ships
+# as a C extension, expressed over the `IO#fcntl` builtin.
+require 'fcntl'
+
+class IO
+  # Whether the underlying file descriptor has O_NONBLOCK set.
+  def nonblock?
+    (fcntl(Fcntl::F_GETFL) & Fcntl::O_NONBLOCK) != 0
+  end
+
+  # Set or clear O_NONBLOCK on the underlying file descriptor.
+  def nonblock=(flag)
+    flags = fcntl(Fcntl::F_GETFL)
+    if flag
+      fcntl(Fcntl::F_SETFL, flags | Fcntl::O_NONBLOCK)
+    else
+      fcntl(Fcntl::F_SETFL, flags & ~Fcntl::O_NONBLOCK)
+    end
+    flag
+  end
+
+  # With a block: set O_NONBLOCK to `nonblock` for the duration of the
+  # block, restoring the previous state afterwards. Without a block:
+  # set it and return self.
+  def nonblock(nonblock = true)
+    if block_given?
+      prev = nonblock?
+      begin
+        self.nonblock = nonblock
+        yield self
+      ensure
+        begin
+          self.nonblock = prev
+        rescue IOError, SystemCallError
+          # The IO may have been closed inside the block.
+        end
+      end
+    else
+      self.nonblock = nonblock
+      self
+    end
+  end
+end


### PR DESCRIPTION
# Summary

First tranche of fixes from the core/thread + core/signal + core/io ruby/spec triage: the low-difficulty cluster. Results:

| group | before | after |
|---|---|---|
| core/signal | 4F / 0E | **0F / 0E (fully green)** |
| core/thread | 70F / 55E | **51F / 51E** (23 examples recovered) |
| core/io | 77F / 44E | 74F / 52E (**29 pre-existing failures recovered**; see note) |
| core/file / core/dir | — | no regressions (file −1 failure) |

core/io note: `require 'fcntl'` / `require 'io/nonblock'` used to LoadError (they resolved to the host CRuby's native-extension paths), killing `reopen_spec` and the nonblock examples wholesale. With the stubs added, those files now load and ~34 examples for the still-unimplemented `IO#reopen` become visible — the raw totals hide that pre-existing failures went 121 → 92.

## Thread

- **Fix a monoruby-specific trap**: a bare `raise` inside a Ruby-implemented Thread *instance* method dispatches on `self` — the receiver Thread — and silently becomes the asynchronous `Thread#raise` *into that thread* (queueing the exception there and returning nil to the caller) whenever the receiver is not the current thread. CRuby never hits this because its equivalents are C functions. Every raise in `builtins/thread.rb` instance methods is now the explicit `Kernel.raise`, with a warning comment at the top of the class. This alone recovers the `thread_variable_*` / `fetch` / `priority=` validation examples.
- `Thread#name=` coerces via `#to_str` (TypeError otherwise) and rejects embedded NULs (ArgumentError); nil clears the name.
- `thread_variable?` tests the *value*: assigning nil reads as unset while the key stays listed in `#thread_variables` (probed against CRuby 4.0.2; `false` is a real value).
- `terminate` / `exit` are true aliases of `kill`, `fork` of `start` (ruby/spec checks method identity); `Thread.allocate` raises TypeError (`Thread::Waiter` now allocates through the privileged `__builtin_allocate__`); `Thread.start`/`fork` without a block raise ArgumentError while `Thread.new` keeps ThreadError (CRuby's split); `Thread::Backtrace.limit` returns the `--backtrace-limit` value or −1.

## Signal

- The **EXIT pseudo-signal** is accepted by `Signal.trap`: the handler is an exit hook run *before* the `at_exit` handlers (injected at the LIFO front in `run_exit_handlers`, so error semantics are identical), unset by `'DEFAULT'`; a never-trapped EXIT reports nil.
- **SIGPIPE is ignored at startup** (as in CRuby): writes to closed pipes now surface `Errno::EPIPE` instead of killing the process, and the initial trap state for PIPE reports nil (`Signal.trap('PIPE', 'SYSTEM_DEFAULT')` → nil, then the process dies signal-terminated as the spec requires). Children spawned via `std::process::Command` get default dispositions, so subprocesses are unaffected.

## IO

- `IoInner::write` maps OS errors to the matching `Errno::*` (it previously produced a placeholder `RangeError`); `blocking_io_region` now lends `&Store` to its closure to make the errno lookup possible.
- New `IO#fcntl(cmd, arg = 0)` builtin (fcntl(2)); pure-Ruby stdlib stubs for `fcntl` (the constants module) and `io/nonblock` (`nonblock?` / `nonblock=` / `nonblock` with block-restore), following the existing `io/wait` stub pattern.
- `IO#puts` follows the `#to_ary` conversion protocol and writes nothing for an empty Array (only the argument-less call writes a newline).
- `IO#print` emits `$,` between objects and appends `$\`, converts via `#to_s` only, and the argument-less form writes `$_`; `Kernel#print` reuses that path so `$\` still applies when `$_` is nil.
- `IO.write` / `IO.binwrite` move to Ruby (`builtins/io.rb`; File inherits them, as in CRuby): an offset suppresses truncation, `:open_args` replaces every other option (the write mode must be inside it — File.open's default read mode makes the write fail, matching CRuby), `:mode` / `:flags` / `:perm` and remaining options forward to `File.open`, data is `#to_s`-coerced, and a readonly mode raises IOError. The old native path silently ignored the options and **truncated even with an offset**.
- Fix the lossy integer-flags → mode-string conversion behind that bug: `WRONLY|CREAT` without `TRUNC` no longer truncates (internal `"w-"` / `"-w"` spellings, handled by the open path and the FIFO branch); wrapping an existing fd via `IO.new` maps them back to plain write-only since fd wrapping never truncates.

Performance note (asked during review of this work): `IO.write` is a one-shot open→write→close API, so the Ruby wrapper's cost is dominated by syscalls — measured ~30µs/call vs CRuby's ~10µs, with the same ~3× ratio on `File.open`+write+close, i.e. the gap lives in the shared open path, not the Ruby layer. `Kernel#puts` does not go through it (it uses the native instance `IO#write`, ~0.85µs/call).

## Validation

- Full lib suite: **1982 / 1982 green**.
- ruby/spec re-run: numbers above; core/file and core/dir confirmed regression-free by title-level diff.
- 9 new unit tests cover the cross-thread raise fix, the aliases/limits, thread-variable nil semantics, `trap(:EXIT)`, the puts/print protocol, `IO.write` options, EPIPE on closed pipes, and the fcntl / io-nonblock stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_