### PR TITLE
IO.popen extensions, Thread construction protocol, real IO#dup, exact sized reads

### DIFF
--- a/monoruby/builtins/thread.rb
+++ b/monoruby/builtins/thread.rb
@@ -86,11 +86,11 @@ class Thread
   def to_s
     st = status
     st = "dead" unless st
-    if (n = @name)
-      "#<Thread:#{format('0x%016x', object_id << 1)}@#{n} #{st}>"
-    else
-      "#<Thread:#{format('0x%016x', object_id << 1)} #{st}>"
-    end
+    s = +"#<Thread:#{format('0x%016x', object_id << 1)}"
+    s << "@#{@name}" if @name
+    s << " #{@__spawn_location}" if @__spawn_location
+    s << " #{st}>"
+    s
   end
   alias inspect to_s
 
@@ -150,23 +150,48 @@ class Thread
   end
   private :__thread_key
 
+  # Fiber-locals genuinely belong to the *fiber* (CRuby): reads/writes
+  # key a per-fiber table. At a thread's root context (no explicit
+  # Fiber) the table is keyed under :root; reading another thread
+  # resolves its root table, which is where a plain thread body's
+  # locals live.
+  def __fiber_local_table(create)
+    fk = Fiber.__current_fiber || :root
+    all = @fiber_locals
+    if all.nil?
+      return nil unless create
+      all = @fiber_locals = {}
+    end
+    t = all[fk]
+    if t.nil?
+      return nil unless create
+      t = all[fk] = {}
+    end
+    t
+  end
+  private :__fiber_local_table
+
   def [](key)
     k = __thread_key(key)
-    @fiber_locals && @fiber_locals[k]
+    t = __fiber_local_table(false)
+    t && t[k]
   end
 
   def []=(key, value)
     Kernel.raise FrozenError, "can't modify frozen thread locals" if frozen?
-    (@fiber_locals ||= {})[__thread_key(key)] = value
+    k = __thread_key(key)
+    __fiber_local_table(true)[k] = value
   end
 
   def key?(key)
     k = __thread_key(key)
-    !!(@fiber_locals && @fiber_locals.key?(k))
+    t = __fiber_local_table(false)
+    !!(t && t.key?(k))
   end
 
   def keys
-    @fiber_locals ? @fiber_locals.keys : []
+    t = __fiber_local_table(false)
+    t ? t.keys : []
   end
 
   def fetch(key, *default)
@@ -174,8 +199,9 @@ class Thread
       Kernel.raise ArgumentError, "wrong number of arguments (given #{default.size + 1}, expected 1..2)"
     end
     k = __thread_key(key)
-    if @fiber_locals && @fiber_locals.key?(k)
-      @fiber_locals[k]
+    t = __fiber_local_table(false)
+    if t && t.key?(k)
+      t[k]
     elsif block_given?
       warn "warning: block supersedes default value argument" unless default.empty?
       yield(key)

--- a/monoruby/builtins/thread.rb
+++ b/monoruby/builtins/thread.rb
@@ -156,7 +156,15 @@ class Thread
   # resolves its root table, which is where a plain thread body's
   # locals live.
   def __fiber_local_table(create)
-    fk = Fiber.__current_fiber || :root
+    # The caller's fiber only keys accesses to the *current* thread's
+    # locals; another thread's locals resolve through its root table
+    # (its own current fiber — the root, for any parked plain thread —
+    # is not observable from outside).
+    fk = if equal?(Thread.current)
+      Fiber.__current_fiber || :root
+    else
+      :root
+    end
     all = @fiber_locals
     if all.nil?
       return nil unless create

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -4842,8 +4842,7 @@ mod tests {
     }
 
     #[test]
-    #[test]
-    fn encode_binary_source_undefined_conversion() {
+        fn encode_binary_source_undefined_conversion() {
         // BINARY with an 8-bit byte -> real codec: CRuby's
         // UndefinedConversionError, direct and pivot message forms.
         run_test_once(
@@ -4851,6 +4850,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn converter_streaming_state() {
         // primitive_convert error reporting: errinfo tuples, read-again
         // buffering (putback), last_error objects with byte attributes.

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1309,7 +1309,7 @@ fn to_path(vm: &mut Executor, globals: &mut Globals, file: Value) -> Result<std:
     Ok(path)
 }
 
-fn to_path_str(vm: &mut Executor, globals: &mut Globals, val: Value) -> Result<String> {
+pub(super) fn to_path_str(vm: &mut Executor, globals: &mut Globals, val: Value) -> Result<String> {
     Ok(val
         .coerce_to_path_rstring(vm, globals)?
         .to_str()?

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -5862,9 +5862,7 @@ mod tests {
     // macOS. CRuby comparison still runs once for output parity.
 
     #[test]
-    #[test]
-    #[test]
-    fn io_dup_ioctl_and_exact_reads() {
+        fn io_dup_ioctl_and_exact_reads() {
         // #dup wraps a dup(2)'d fd (distinct fileno, shared offset,
         // cloexec+autoclose set, IOError after close / on closed source);
         // sized reads consume the fd exactly, so syswrite lands at the
@@ -5894,6 +5892,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn io_popen_argv_env_opts_forms() {
         // Array form [env, cmd, arg..., exec_opts], outside env hash,
         // chdir: (String and #to_path), subclass instantiation, and
@@ -5917,6 +5916,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn io_popen_read_stdout() {
         run_test_once(
             r#"

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -63,6 +63,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_CLASS, "pid", io_pid, 0);
     globals.define_builtin_funcs(IO_CLASS, "fileno", &["to_i"], io_fileno, 0);
     globals.define_builtin_func_with(IO_CLASS, "fcntl", io_fcntl, 1, 2, false);
+    globals.define_builtin_func_with(IO_CLASS, "ioctl", io_ioctl, 1, 2, false);
+    globals.define_builtin_func(IO_CLASS, "initialize_copy", io_initialize_copy, 1);
     globals.define_builtin_func(IO_CLASS, "to_io", io_to_io, 0);
     globals.define_builtin_func_with(IO_CLASS, "write", io_write_method, 0, 0, true);
     globals.define_builtin_func_with(IO_CLASS, "syswrite", io_syswrite, 1, 1, false);
@@ -2600,6 +2602,77 @@ fn io_fcntl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "fcntl"));
     }
     Ok(Value::integer(ret as i64))
+}
+
+///
+/// ### IO#ioctl
+/// - ioctl(cmd, arg = 0) -> Integer
+///
+/// Thin wrapper over ioctl(2) with an integer argument (the
+/// memory-backed String forms are not supported). Raises `IOError` on a
+/// closed stream and the matching `Errno::*` (e.g. `Errno::ENOTTY`) on
+/// syscall failure.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/ioctl.html]
+#[monoruby_builtin]
+fn io_ioctl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let fd = self_.as_io_inner().fileno()?;
+    let cmd = lfp.arg(0).coerce_to_int_i64(vm, globals)?;
+    let arg = match lfp.try_arg(1) {
+        Some(v) if !v.is_nil() => v.coerce_to_int_i64(vm, globals)?,
+        _ => 0,
+    };
+    // SAFETY: ioctl(2) with an integer third argument; no memory is
+    // passed, so there are no aliasing concerns.
+    let ret = unsafe { libc::ioctl(fd, cmd as libc::c_ulong, arg as libc::c_long) };
+    if ret == -1 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "ioctl"));
+    }
+    Ok(Value::integer(ret as i64))
+}
+
+///
+/// ### IO#initialize_copy (the #dup / #clone hook)
+///
+/// A duplicated IO wraps a dup(2) of the descriptor: a distinct fd
+/// sharing the open file description (offset, status flags) with the
+/// original, close-on-exec and autoclose both set (CRuby). Raises
+/// IOError when the source is closed.
+#[monoruby_builtin]
+fn io_initialize_copy(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let mut self_ = lfp.self_val();
+    let other = lfp.arg(0);
+    let fd = other.as_io_inner().fileno()?;
+    // SAFETY: dup(2) of a validated fd.
+    let newfd = unsafe { libc::dup(fd) };
+    if newfd == -1 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "dup"));
+    }
+    // SAFETY: setting FD_CLOEXEC on the fd we just created.
+    unsafe { libc::fcntl(newfd, libc::F_SETFD, libc::FD_CLOEXEC) };
+    let (readable, writable) = {
+        let inner = other.as_io_inner();
+        (inner.is_readable(), inner.is_writable())
+    };
+    let path = other.as_io_inner().path();
+    let has_path = path.is_some();
+    *self_.as_io_inner_mut() = IoInner::from_raw_fd_autoclose(
+        newfd,
+        path.unwrap_or_default(),
+        has_path,
+        readable,
+        writable,
+        true,
+    );
+    Ok(self_)
 }
 
 ///
@@ -5790,6 +5863,37 @@ mod tests {
 
     #[test]
     #[test]
+    #[test]
+    fn io_dup_ioctl_and_exact_reads() {
+        // #dup wraps a dup(2)'d fd (distinct fileno, shared offset,
+        // cloexec+autoclose set, IOError after close / on closed source);
+        // sized reads consume the fd exactly, so syswrite lands at the
+        // logical position; ioctl surfaces ENOTTY on a regular file and
+        // IOError on a closed stream.
+        run_test_once(
+            r##"
+            path = "/tmp/monoruby_test_iodup_#{Process.pid}_#{rand(100000)}"
+            File.write(path, "0123456789")
+            r = []
+            File.open(path) do |f|
+              g = f.dup
+              r << [g.fileno != f.fileno, g.autoclose?, g.close_on_exec?]
+              f.read(3)
+              r << g.read(3)
+              g.close
+              r << (begin; g.read(1); rescue IOError => e; e.message; end)
+            end
+            io = File.open(path); io.close
+            r << (begin; io.dup; rescue IOError => e; e.message; end)
+            File.open(path, "r+") { |f| f.read(2); f.syswrite("XY") }
+            r << File.read(path)
+            File.open(path) { |f| r << (begin; f.ioctl(0x5401); rescue SystemCallError => e; e.class.to_s; end) }
+            r << (begin; io.ioctl(1); rescue IOError => e; e.message; end)
+            r
+            "##,
+        );
+    }
+
     fn io_popen_argv_env_opts_forms() {
         // Array form [env, cmd, arg..., exec_opts], outside env hash,
         // chdir: (String and #to_path), subclass instantiation, and

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -2335,8 +2335,22 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
             v.to_s(globals).into()
         }
     }
+    // CRuby's Array form is `[env, cmd, arg1, ..., exec_opts]`: a leading
+    // Hash inside the Array is the environment, a trailing Hash the exec
+    // options.
+    let mut array_opts: Option<Value> = None;
     let (mut command, cmd_name) = if let Some(ary) = cmd_val.try_array_ty() {
-        let parts: Vec<std::ffi::OsString> = ary.iter().map(|v| arg_os(*v, globals)).collect();
+        let mut elems: Vec<Value> = ary.iter().cloned().collect();
+        if elems.first().is_some_and(|v| v.try_hash_ty().is_some()) {
+            let h = elems.remove(0);
+            if env_hash.is_none() {
+                env_hash = Some(h);
+            }
+        }
+        if elems.len() > 1 && elems.last().is_some_and(|v| v.try_hash_ty().is_some()) {
+            array_opts = elems.pop();
+        }
+        let parts: Vec<std::ffi::OsString> = elems.iter().map(|v| arg_os(*v, globals)).collect();
         if parts.is_empty() {
             return Err(MonorubyErr::argumenterr("popen: empty command array"));
         }
@@ -2407,11 +2421,15 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         command.stdout(Stdio::inherit());
     }
 
-    // Handle err: [:child, :out] option to redirect stderr to stdout
+    // Process the exec-option hashes: the Array-trailing one and the
+    // positional/keyword one both apply.
     let mut stderr_to_stdout = false;
-    if let Some(opts) = opts_hash {
-        let err_key = Value::symbol_from_str("err");
-        if let Ok(Some(err_val)) = opts.as_hash().get(err_key, vm, globals) {
+    let mut ext_obj: Option<Value> = None;
+    let mut int_obj: Option<Value> = None;
+    for opts in [array_opts, opts_hash].into_iter().flatten() {
+        let h = opts.as_hash();
+        // err: [:child, :out] redirects the child's stderr to its stdout.
+        if let Ok(Some(err_val)) = h.get(Value::symbol_from_str("err"), vm, globals) {
             if let Some(ary) = err_val.try_array_ty() {
                 if ary.len() == 2
                     && ary[0].try_symbol_or_string() == Some(IdentId::get_id("child"))
@@ -2420,6 +2438,51 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
                     stderr_to_stdout = true;
                 }
             }
+        }
+        // chdir: the child's working directory (String / #to_path / #to_str).
+        if let Some(dir) = h.get(Value::symbol_from_str("chdir"), vm, globals)?
+            && !dir.is_nil()
+        {
+            let path = super::file::to_path_str(vm, globals, dir)?;
+            command.current_dir(path);
+        }
+        // encoding options for the read end.
+        if let Some(v) = h.get(Value::symbol(IdentId::get_id("encoding")), vm, globals)?
+            && !v.is_nil()
+        {
+            if let Some(sv) = v.is_str() {
+                let mut parts = sv.split(':');
+                ext_obj = parts
+                    .next()
+                    .filter(|x| !x.is_empty())
+                    .and_then(|x| enc_by_name(globals, x));
+                int_obj = parts
+                    .next()
+                    .filter(|x| !x.is_empty())
+                    .and_then(|x| enc_by_name(globals, x));
+            } else {
+                ext_obj = arg_to_enc_obj(globals, v);
+            }
+        }
+        if let Some(v) = h.get(Value::symbol(IdentId::get_id("external_encoding")), vm, globals)?
+            && !v.is_nil()
+        {
+            ext_obj = arg_to_enc_obj(globals, v);
+        }
+        if let Some(v) = h.get(Value::symbol(IdentId::get_id("internal_encoding")), vm, globals)?
+            && !v.is_nil()
+        {
+            int_obj = arg_to_enc_obj(globals, v);
+        }
+    }
+    // Mode-string encoding suffix ("r:ext:int") — explicit options win.
+    {
+        let (me, mi) = mode_encoding_names(&mode);
+        if ext_obj.is_none() {
+            ext_obj = me.and_then(|e| enc_by_name(globals, e));
+        }
+        if int_obj.is_none() {
+            int_obj = mi.and_then(|i| enc_by_name(globals, i));
         }
     }
     if stderr_to_stdout {
@@ -2438,7 +2501,17 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         .spawn()
         .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_f_spawn", &cmd_name))?;
 
-    let io_val = Value::new_io(IoInner::popen(child));
+    // Instantiate as the receiver class (a subclass' popen yields the
+    // subclass), and install the resolved encodings on the read end.
+    let class_id = lfp.self_val().as_class_id();
+    let io_val = Value::new_io_with_class(IoInner::popen(child), class_id);
+    {
+        let de = enc_default_external_obj(globals);
+        let di = enc_default_internal_obj(globals);
+        let (slot, i) =
+            resolve_io_encodings(globals, ext_obj, int_obj, false, readable, !readable, de, di);
+        store_io_encodings(globals, io_val, slot, i);
+    }
 
     if let Some(bh) = lfp.block() {
         let data = vm.get_block_data(globals, bh)?;
@@ -5716,6 +5789,30 @@ mod tests {
     // macOS. CRuby comparison still runs once for output parity.
 
     #[test]
+    #[test]
+    fn io_popen_argv_env_opts_forms() {
+        // Array form [env, cmd, arg..., exec_opts], outside env hash,
+        // chdir: (String and #to_path), subclass instantiation, and
+        // encoding options on the read end.
+        run_test_once(
+            r##"
+            r = []
+            IO.popen([{"PV" => "pv"}, "sh", "-c", "echo $PV"]) { |io| r << io.read }
+            IO.popen([{"PV" => "pv2"}, "sh", "-c", "echo $PV 1>&2", {err: [:child, :out]}], "r") { |io| r << io.read }
+            IO.popen({"PV" => "pv3"}, ["sh", "-c", "echo $PV"], "r") { |io| r << io.read }
+            IO.popen(["pwd"], "r", chdir: "/tmp") { |io| r << io.read }
+            o = Object.new
+            def o.to_path; "/tmp"; end
+            IO.popen(["pwd"], chdir: o) { |io| r << io.read }
+            myio = Class.new(IO)
+            r << (myio.popen("echo sub") { |io| io.class == myio })
+            IO.popen("echo enc", external_encoding: "iso-8859-1") { |io| r << io.read.encoding.name }
+            IO.popen("echo enc2", "r:utf-8:iso-8859-1") { |io| r << [io.external_encoding.name, io.internal_encoding.name] }
+            r
+            "##,
+        );
+    }
+
     fn io_popen_read_stdout() {
         run_test_once(
             r#"

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -2994,7 +2994,7 @@ fn io_getbyte(
     _: BytecodePtr,
 ) -> Result<Value> {
     let buf = blocking_io_region(vm, globals, lfp.self_val(), libc::POLLIN, |_store| {
-        lfp.self_val().as_io_inner_mut().read(Some(1))
+        lfp.self_val().as_io_inner_mut().read_buffered(Some(1))
     })?;
     if buf.is_empty() {
         Ok(Value::nil())
@@ -3008,7 +3008,7 @@ fn io_getbyte(
 /// sequence is not valid UTF-8 (matching CRuby's invalid-byte behavior in
 /// binary-mode reads, which is what monoruby uses everywhere).
 fn read_one_char(io: &mut IoInner) -> Result<Vec<u8>> {
-    let first = io.read(Some(1))?;
+    let first = io.read_buffered(Some(1))?;
     if first.is_empty() {
         return Ok(vec![]);
     }
@@ -3039,7 +3039,7 @@ fn read_one_char(io: &mut IoInner) -> Result<Vec<u8>> {
 /// push the partial character bytes back so the retried getc re-reads a
 /// whole character.
 fn read_more_char_bytes(io: &mut IoInner, acc: &[u8], total: usize) -> Result<Vec<u8>> {
-    match io.read(Some(total - acc.len())) {
+    match io.read_buffered(Some(total - acc.len())) {
         Err(err) => {
             if err.is_signal_interrupt() && !acc.is_empty() {
                 let _ = io.unget(acc);
@@ -3080,7 +3080,7 @@ fn read_one_char_enc(io: &mut IoInner, enc: crate::value::Encoding) -> Result<Ve
     if enc == crate::value::Encoding::Utf8 {
         return read_one_char(io);
     }
-    let first = io.read(Some(1))?;
+    let first = io.read_buffered(Some(1))?;
     if first.is_empty() {
         return Ok(vec![]);
     }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -7126,8 +7126,7 @@ mod tests {
     }
 
     #[test]
-    #[test]
-    fn kernel_raise_argument_matrix() {
+        fn kernel_raise_argument_matrix() {
         // The shared rb_make_exception surface: String-with-extra-arg
         // TypeError, custom backtraces (Array / single String / nil /
         // invalid), message override through #exception, duck-typed
@@ -7175,6 +7174,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn kernel_raise_class() {
         run_test_error("raise ArgumentError");
         run_test_error(r#"raise TypeError, "custom""#);

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1251,8 +1251,7 @@ mod tests {
     }
 
     #[test]
-    #[test]
-    fn signal_trap_exit_pseudo_signal() {
+        fn signal_trap_exit_pseudo_signal() {
         // EXIT is an exit hook, not a signal: trapping it succeeds, a
         // never-trapped EXIT reports nil, re-trapping reports the
         // previous handler, and "DEFAULT" unsets it.
@@ -1268,8 +1267,7 @@ mod tests {
     }
 
     #[test]
-    #[test]
-    fn signal_trap_exit_dispositions() {
+        fn signal_trap_exit_dispositions() {
         // nil / IGNORE clear the EXIT hook like DEFAULT; a handler set
         // and left in place survives a GC (the hook is a root).
         run_test_once(

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -22,6 +22,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.store[THREAD_CLASS].set_alloc_func(thread_alloc_func);
 
     globals.define_builtin_class_func_rest(THREAD_CLASS, "new", thread_new);
+    globals.define_builtin_func_rest(THREAD_CLASS, "initialize", thread_initialize);
     globals.define_builtin_class_func_rest(THREAD_CLASS, "start", thread_start);
     // `fork` is re-pointed at `start` as a true alias in builtins/thread.rb
     // (ruby/spec checks `Thread.method(:fork) == Thread.method(:start)`).
@@ -310,7 +311,47 @@ pub(crate) extern "C" fn thread_alloc_func(class_id: ClassId, _: &mut Globals) -
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Thread/s/new.html]
 #[monoruby_builtin]
-fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _pc: BytecodePtr) -> Result<Value> {
+    // Two-phase construction (CRuby): allocate an uninitialized shell,
+    // dispatch #initialize (a subclass override runs and must reach the
+    // native initialize below via super), then verify it did.
+    let class_id = lfp.self_val().as_class_id();
+    let obj = Value::new_thread(class_id, ThreadInner::shell());
+    let args: Vec<Value> = lfp.arg(0).as_array().to_vec();
+    vm.invoke_method_inner(
+        globals,
+        IdentId::get_id("initialize"),
+        obj,
+        &args,
+        lfp.block(),
+        None,
+    )?;
+    // Note: not a state check — the body may already have run to
+    // completion (Dead) during the eager first slice.
+    if obj.as_thread_inner().is_uninitialized_shell() {
+        return Err(MonorubyErr::threaderr(
+            &globals.store,
+            "uninitialized thread - check 'Thread#initialize'",
+        ));
+    }
+    Ok(obj)
+}
+
+///
+/// ### Thread#initialize
+///
+/// The queueing half of `Thread.new`: requires a block (ThreadError
+/// otherwise), refuses a live or already-initialized receiver, then
+/// installs the body and queues the green thread. Records the block's
+/// definition site for `#to_s` (CRuby shows `file:line` there).
+#[monoruby_builtin]
+fn thread_initialize(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let mut self_ = lfp.self_val();
     let bh = match lfp.block() {
         Some(bh) => bh,
         None => {
@@ -320,16 +361,31 @@ fn thread_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
             ));
         }
     };
+    if !self_.as_thread_inner().is_uninitialized_shell() {
+        return Err(MonorubyErr::threaderr(
+            &globals.store,
+            "already initialized thread",
+        ));
+    }
     let proc = vm.generate_proc(globals, bh, pc)?;
+    // The block's definition site, shown by Thread#to_s (CRuby).
+    if let Some(iseq) = globals.store.resolve_iseq(proc.func_id()) {
+        let info = &globals.store[iseq];
+        let path = info.sourceinfo.short_file_name().to_string();
+        let line = info.sourceinfo.get_line(&info.loc);
+        let loc = Value::string(format!("{path}:{line}"));
+        let _ = globals
+            .store
+            .set_ivar(self_, IdentId::get_id("@__spawn_location"), loc);
+    }
     let args = lfp.arg(0).as_array().to_vec();
-    let class_id = lfp.self_val().as_class_id();
-    let thread = Value::new_thread(class_id, ThreadInner::new(proc, args));
-    scheduler::spawn(vm, thread);
-    // The eager first slice must keep `thread` (and this frame's Values)
-    // rooted: `pass` is a scheduler entry (GC-safe park point), and
-    // `thread` is reachable via the scheduler registry.
+    *self_.as_thread_inner_mut() = ThreadInner::new(proc, args);
+    scheduler::spawn(vm, self_);
+    // The eager first slice must keep `self_` (and this frame's Values)
+    // rooted: `pass` is a scheduler entry (GC-safe park point), and the
+    // thread is reachable via the scheduler registry.
     scheduler::pass(vm, globals)?;
-    Ok(thread)
+    Ok(self_)
 }
 
 /// `Thread.start` / `Thread.fork`: same as `Thread.new`, but a missing
@@ -342,13 +398,33 @@ fn thread_start(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    if lfp.block().is_none() {
-        return Err(MonorubyErr::argumenterr(
-            "tried to create Proc object without a block",
-        ));
+    let bh = match lfp.block() {
+        Some(bh) => bh,
+        None => {
+            return Err(MonorubyErr::argumenterr(
+                "tried to create Proc object without a block",
+            ));
+        }
+    };
+    // Unlike Thread.new, CRuby's Thread.start does NOT call #initialize:
+    // construct and queue directly.
+    let proc = vm.generate_proc(globals, bh, pc)?;
+    let class_id = lfp.self_val().as_class_id();
+    let args = lfp.arg(0).as_array().to_vec();
+    let mut thread = Value::new_thread(class_id, ThreadInner::new(proc.clone(), args));
+    if let Some(iseq) = globals.store.resolve_iseq(proc.func_id()) {
+        let info = &globals.store[iseq];
+        let path = info.sourceinfo.short_file_name().to_string();
+        let line = info.sourceinfo.get_line(&info.loc);
+        let loc = Value::string(format!("{path}:{line}"));
+        let _ = globals
+            .store
+            .set_ivar(thread, IdentId::get_id("@__spawn_location"), loc);
     }
-    // `#[monoruby_builtin]` renames the Result-returning body to `__<name>`.
-    __thread_new(vm, globals, lfp, pc)
+    let _ = &mut thread;
+    scheduler::spawn(vm, thread);
+    scheduler::pass(vm, globals)?;
+    Ok(thread)
 }
 
 ///
@@ -1761,6 +1837,38 @@ mod tests {
 
     #[test]
     #[test]
+    #[test]
+    fn thread_new_initialize_protocol() {
+        // Thread.new dispatches #initialize (subclass overrides run and
+        // must reach super); missing super or block raise ThreadError;
+        // re-initializing a live thread raises; Thread#to_s carries the
+        // block's file:line; fiber-locals are per-fiber.
+        run_test_once(
+            r##"
+            r = []
+            arr = []
+            sub = Class.new(Thread) do
+              def initialize(a); a << :init; super() { a << :body }; end
+            end
+            st = sub.new(arr); st.join
+            r << arr << (st.class == sub)
+            noinit = Class.new(Thread) { def initialize; end }
+            r << (begin; noinit.new; rescue ThreadError; :uninitialized; end)
+            r << (begin; Thread.new; rescue ThreadError => e; e.message; end)
+            q = Thread::Queue.new
+            th = Thread.new { q.pop }
+            r << (begin; th.instance_eval { initialize {} }; rescue ThreadError; :already; end)
+            q.push(nil); th.join
+            r << !!(Thread.new {}.tap(&:join).to_s =~ /\A#<Thread:0x[0-9a-f]+ .*:\d+ (run|dead)>\z/)
+            Thread.current[:fl] = 1
+            f = Fiber.new { Thread.current[:fl] = 2; Thread.current[:fl] }
+            r << f.resume
+            r << Thread.current[:fl]
+            r
+            "##,
+        );
+    }
+
     fn thread_raise_same_thread_matrix() {
         run_test_once(
             r##"

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -1836,9 +1836,7 @@ mod tests {
     }
 
     #[test]
-    #[test]
-    #[test]
-    fn thread_new_initialize_protocol() {
+        fn thread_new_initialize_protocol() {
         // Thread.new dispatches #initialize (subclass overrides run and
         // must reach super); missing super or block raise ThreadError;
         // re-initializing a live thread raises; Thread#to_s carries the
@@ -1869,6 +1867,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn thread_raise_same_thread_matrix() {
         run_test_once(
             r##"
@@ -1891,6 +1890,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn thread_cross_thread_raise_stays_in_caller() {
         // A raise inside a Ruby-implemented Thread instance method must
         // surface in the *caller*, not be queued into the receiver thread
@@ -1920,6 +1920,16 @@ mod tests {
                 Thread.instance_method(:exit) == Thread.instance_method(:kill),
                 Thread.method(:fork) == Thread.method(:start),
                 Thread::Backtrace.limit]"#,
+        );
+        // Thread.start / .fork queue the body directly (no #initialize)
+        // and forward arguments; to_s carries the spawn site.
+        run_test_once(
+            r#"
+            a = Thread.start(1, 2) { |x, y| x + y }.value
+            b = Thread.fork { :forked }.value
+            c = !!(Thread.start {}.tap(&:join).to_s =~ /:\d+ (run|dead)>\z/)
+            [a, b, c]
+            "#,
         );
         // Thread.allocate: allocator undefined (TypeError); Thread.start
         // without a block: ArgumentError (unlike Thread.new's ThreadError).

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -736,6 +736,19 @@ impl IoInner {
     }
 
     pub fn read(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
+        self.read_impl(length, true)
+    }
+
+    /// Like [`Self::read`], but a sized read may fill the BufReader's
+    /// page from the fd (the classic buffered behavior). The
+    /// character-oriented readers (getc/getbyte) use this — CRuby
+    /// buffers those, which the `#ungetc` + `#readpartial` interplay
+    /// observes — while `IO#read(n)` consumes the fd exactly.
+    pub fn read_buffered(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
+        self.read_impl(length, false)
+    }
+
+    fn read_impl(&mut self, length: Option<usize>, exact: bool) -> Result<Vec<u8>> {
         if self.pushback_len() > 0 {
             match length {
                 Some(0) => return Ok(vec![]),
@@ -745,15 +758,15 @@ impl IoInner {
                 Some(n) => {
                     let out = self.take_pushback(None);
                     let need = n - out.len();
-                    return self.read_more_preserving(out, Some(need));
+                    return self.read_more_preserving(out, Some(need), exact);
                 }
                 None => {
                     let out = self.take_pushback(None);
-                    return self.read_more_preserving(out, None);
+                    return self.read_more_preserving(out, None, exact);
                 }
             }
         }
-        self.read_underlying(length)
+        self.read_underlying(length, exact)
     }
 
     /// Extend already-drained pushback bytes (`out`) with an underlying
@@ -763,8 +776,13 @@ impl IoInner {
     /// bytes. (`read_underlying` has already pushed back its own partial
     /// data at that point; ungetting `out` afterwards splices it in front,
     /// preserving stream order.)
-    fn read_more_preserving(&mut self, mut out: Vec<u8>, length: Option<usize>) -> Result<Vec<u8>> {
-        match self.read_underlying(length) {
+    fn read_more_preserving(
+        &mut self,
+        mut out: Vec<u8>,
+        length: Option<usize>,
+        exact: bool,
+    ) -> Result<Vec<u8>> {
+        match self.read_underlying(length, exact) {
             Ok(chunk) => {
                 out.extend_from_slice(&chunk);
                 Ok(out)
@@ -780,7 +798,7 @@ impl IoInner {
         }
     }
 
-    fn read_underlying(&mut self, length: Option<usize>) -> Result<Vec<u8>> {
+    fn read_underlying(&mut self, length: Option<usize>, exact: bool) -> Result<Vec<u8>> {
         // On a restartable interrupt (`Interrupted`/`WouldBlock` out of the
         // read helpers), bytes already consumed from the fd are pushed back
         // so that the retried read (after a `Signal.trap` handler ran, or
@@ -824,22 +842,27 @@ impl IoInner {
                 let reader = &mut *file.reader;
                 let mut buf = vec![];
                 let res = if let Some(length) = length {
-                    // A sized read takes exactly `length` bytes: drain what
-                    // the BufReader already holds, then read the remainder
-                    // from the fd directly. Letting the BufReader fill its
-                    // 8K buffer here would advance the fd far past the
-                    // logical position, which `#syswrite`, `#dup` (shared
-                    // file offset) and write-after-read positioning all
-                    // observe (CRuby reads exactly `length` too).
-                    let avail = reader.buffer().len().min(length);
-                    if avail > 0 {
-                        buf.extend_from_slice(&reader.buffer()[..avail]);
-                        reader.consume(avail);
-                    }
-                    if buf.len() < length {
-                        read_upto(reader.get_mut(), length, &mut buf)
+                    if exact {
+                        // A sized read takes exactly `length` bytes: drain
+                        // what the BufReader already holds, then read the
+                        // remainder from the fd directly. Letting the
+                        // BufReader fill its 8K buffer here would advance
+                        // the fd far past the logical position, which
+                        // `#syswrite`, `#dup` (shared file offset) and
+                        // write-after-read positioning all observe (CRuby
+                        // reads exactly `length` too).
+                        let avail = reader.buffer().len().min(length);
+                        if avail > 0 {
+                            buf.extend_from_slice(&reader.buffer()[..avail]);
+                            reader.consume(avail);
+                        }
+                        if buf.len() < length {
+                            read_upto(reader.get_mut(), length, &mut buf)
+                        } else {
+                            Ok(())
+                        }
                     } else {
-                        Ok(())
+                        read_upto(reader, length, &mut buf)
                     }
                 } else {
                     read_all(reader, &mut buf)

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -824,7 +824,23 @@ impl IoInner {
                 let reader = &mut *file.reader;
                 let mut buf = vec![];
                 let res = if let Some(length) = length {
-                    read_upto(reader, length, &mut buf)
+                    // A sized read takes exactly `length` bytes: drain what
+                    // the BufReader already holds, then read the remainder
+                    // from the fd directly. Letting the BufReader fill its
+                    // 8K buffer here would advance the fd far past the
+                    // logical position, which `#syswrite`, `#dup` (shared
+                    // file offset) and write-after-read positioning all
+                    // observe (CRuby reads exactly `length` too).
+                    let avail = reader.buffer().len().min(length);
+                    if avail > 0 {
+                        buf.extend_from_slice(&reader.buffer()[..avail]);
+                        reader.consume(avail);
+                    }
+                    if buf.len() < length {
+                        read_upto(reader.get_mut(), length, &mut buf)
+                    } else {
+                        Ok(())
+                    }
                 } else {
                     read_all(reader, &mut buf)
                 };

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -226,6 +226,16 @@ impl ThreadInner {
         }
     }
 
+    /// Whether this is an inert, never-initialized shell (as produced by
+    /// the allocator) — `Thread#initialize` refuses anything else.
+    pub(crate) fn is_uninitialized_shell(&self) -> bool {
+        self.handle.is_none()
+            && self.proc.is_none()
+            && self.state == ThreadState::Dead
+            && self.result.is_none()
+            && self.exception.is_none()
+    }
+
     //pub(crate) fn is_main(&self) -> bool {
     //    self.handle.is_none() && self.proc.is_none() && self.state != ThreadState::Dead
     //}


### PR DESCRIPTION
# Summary

Third tranche from the core/thread + core/io triage: the remaining medium-difficulty clusters, on top of #1022. Results:

| group | before (post-#1022) | after |
|---|---|---|
| core/io | 50F / 53E | **33F / 45E** (25 examples recovered) |
| core/thread | 45F / 9E | **41F / 7E** (6 examples recovered) |
| core/file | 28F / 17E | 27F / 17E (−1) |
| core/string | — | unchanged (regression-free) |

## IO.popen extensions (`d97244b`)

- The Array form accepts CRuby's full `[env, cmd, arg1, ..., exec_opts]` shape: a leading Hash inside the Array is the environment, a trailing Hash the exec options (merged with the positional/keyword options hash).
- `chdir:` sets the child's working directory (String / `#to_path` / `#to_str`).
- `popen` on an IO subclass instantiates that subclass.
- Encoding options apply to the read end (`encoding:` / `external_encoding:` / `internal_encoding:` and the `"r:ext:int"` mode suffix), resolved through the shared open-encoding machinery. (The `"-"` fork form remains out of scope.)

## Thread construction protocol (`d97244b`)

- `Thread.new` is two-phase, as in CRuby: allocate an uninitialized shell, dispatch `#initialize` (subclass overrides run and must reach the new native `Thread#initialize` via `super` — it requires a block, refuses an already-initialized receiver, and queues the body), then raise `ThreadError` "uninitialized thread" if super was never reached. The check is shell-identity, not thread state — the body may already have *finished* during the eager first slice. `Thread.start`/`fork` construct directly without `#initialize` (CRuby).
- `Thread#to_s` includes the block's definition site (`file:line`), captured from the proc's iseq at queue time.
- Fiber-locals (`[]`/`[]=`/`key?`/`keys`/`fetch`) are keyed per-fiber (`:root` at a thread's root context), so a Fiber's writes are invisible outside it; accesses to *another* thread resolve through its root table (a fiber writing `t[:k]` into a parked thread lands where `t`'s body reads it).

## Real IO#dup, exact sized reads, IO#ioctl (`d5ae2f8`, `8533377`)

- `IO#initialize_copy` (the `#dup`/`#clone` hook) wraps a **dup(2)** of the descriptor: a distinct fd sharing the open file description (offset, status flags), close-on-exec and autoclose both set, IOError on a closed source. This also fixes a crash: the previous `#dup` shallow-copied the `IoInner` and shared the `FileDescriptor` Rc, so a read through either copy **panicked** on `Rc::get_mut`.
- Sized reads (`IO#read(n)`) consume the fd *exactly*: the BufReader's existing buffer is drained first and the remainder is read from the fd directly, instead of slurping an 8K page. The fd position therefore matches the logical position, which `IO#syswrite`, the dup'd-fd shared offset, and write-after-read positioning all observe (CRuby reads exactly n as well). Character-oriented readers (`getc`/`getbyte` and the multi-byte char path) deliberately keep the buffered fill — CRuby buffers those, which the `ungetc` + `readpartial` interplay observes.
- `IO#ioctl(cmd, arg = 0)`: ioctl(2) with an integer argument — `Errno::ENOTTY` etc. on failure, IOError on a closed stream.

## Validation

- Full lib suite: **1999 / 1999 green**.
- Spec re-run after the initial pass surfaced 4 regressions (readpartial-after-ungetc, cross-thread fiber-locals from a fiber); both root causes fixed in `8533377` and re-verified title-level regression-free.
- 4 new differential unit tests: the popen argv/env/opts forms, the Thread initialize protocol (incl. per-fiber locals and `to_s` location), and the dup/ioctl/exact-read cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_