### PR TITLE
Implement IO#reopen (IO form and path form)

### DIFF
--- a/monoruby/builtins/file.rb
+++ b/monoruby/builtins/file.rb
@@ -5,23 +5,27 @@ module File::Constants
   FNM_DOTMATCH = 4
   FNM_CASEFOLD = 8
   FNM_EXTGLOB = 16
-  # Open(2) flags and flock(2) operations (Linux values), mirrored on
-  # File itself below via `include File::Constants` in CRuby; monoruby
-  # historically defined them directly on File, so keep both in sync.
-  RDONLY   = 0
-  WRONLY   = 1
-  RDWR     = 2
-  APPEND   = 1024
-  CREAT    = 64
-  EXCL     = 128
-  TRUNC    = 512
-  NOCTTY   = 256
-  NONBLOCK = 2048
-  DSYNC    = 4096
-  SYNC     = 1052672
-  RSYNC    = 1052672
-  DIRECT   = 16384
-  NOFOLLOW = 131072
+  # Open(2) flags and flock(2) operations, mirrored on File itself
+  # below via `include File::Constants` in CRuby; monoruby historically
+  # defined them directly on File, so keep both in sync. The values
+  # come from the libc-backed IO:: constants so they match the running
+  # platform's kernel bits — Linux and Darwin disagree on almost every
+  # one (e.g. O_APPEND is 0o2000 on Linux but 0x8 on Darwin), and
+  # comparisons against fcntl(F_GETFL) results depend on this.
+  RDONLY   = IO::RDONLY
+  WRONLY   = IO::WRONLY
+  RDWR     = IO::RDWR
+  APPEND   = IO::APPEND
+  CREAT    = IO::CREAT
+  EXCL     = IO::EXCL
+  TRUNC    = IO::TRUNC
+  NOCTTY   = IO::NOCTTY
+  NONBLOCK = IO::NONBLOCK
+  DSYNC    = IO::DSYNC
+  SYNC     = IO::SYNC
+  RSYNC    = IO::RSYNC if defined?(IO::RSYNC)
+  DIRECT   = IO::DIRECT if defined?(IO::DIRECT)
+  NOFOLLOW = IO::NOFOLLOW
   # No-op outside Windows; defined for source compatibility (CRuby).
   SHARE_DELETE = 0
   BINARY   = 0
@@ -43,20 +47,20 @@ class File
   NULL = "/dev/null"
   BINARY = 0
 
-  RDONLY   = 0
-  WRONLY   = 1
-  RDWR     = 2
-  APPEND   = 1024
-  CREAT    = 64
-  EXCL     = 128
-  TRUNC    = 512
-  NOCTTY   = 256
-  NONBLOCK = 2048
-  DSYNC    = 4096
-  SYNC     = 1052672
-  RSYNC    = 1052672
-  DIRECT   = 16384
-  NOFOLLOW = 131072
+  RDONLY   = IO::RDONLY
+  WRONLY   = IO::WRONLY
+  RDWR     = IO::RDWR
+  APPEND   = IO::APPEND
+  CREAT    = IO::CREAT
+  EXCL     = IO::EXCL
+  TRUNC    = IO::TRUNC
+  NOCTTY   = IO::NOCTTY
+  NONBLOCK = IO::NONBLOCK
+  DSYNC    = IO::DSYNC
+  SYNC     = IO::SYNC
+  RSYNC    = IO::RSYNC if defined?(IO::RSYNC)
+  DIRECT   = IO::DIRECT if defined?(IO::DIRECT)
+  NOFOLLOW = IO::NOFOLLOW
   SHARE_DELETE = 0
   LOCK_SH  = 1
   LOCK_EX  = 2

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -834,14 +834,16 @@ fn realpath(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/new.html]
 /// Translate a CRuby-style flags integer (e.g. `File::WRONLY | File::CREAT`)
-/// into the mode string monoruby's open path understands. The bits map to:
-/// access mode in the low 2 bits (RDONLY=0/WRONLY=1/RDWR=2), `O_CREAT`=0o100,
-/// `O_TRUNC`=0o1000, `O_APPEND`=0o2000. Other flags (EXCL, NONBLOCK, …) pass
-/// through silently — `open` handles their effect via mode-string semantics.
+/// into the mode string monoruby's open path understands: access mode in
+/// the low 2 bits (RDONLY=0/WRONLY=1/RDWR=2) plus the platform's
+/// `O_CREAT`/`O_TRUNC`/`O_APPEND` bits — `File::*` mirrors the libc-backed
+/// `IO::*` constants, and Linux and Darwin disagree on every one of these.
+/// Other flags (EXCL, NONBLOCK, …) pass through silently — `open` handles
+/// their effect via mode-string semantics.
 pub(super) fn mode_string_from_flags(flags: i64) -> String {
-    const O_CREAT: i64 = 0o100;
-    const O_TRUNC: i64 = 0o1000;
-    const O_APPEND: i64 = 0o2000;
+    const O_CREAT: i64 = libc::O_CREAT as i64;
+    const O_TRUNC: i64 = libc::O_TRUNC as i64;
+    const O_APPEND: i64 = libc::O_APPEND as i64;
     let access = flags & 0b11;
     let create = flags & O_CREAT != 0;
     let trunc = flags & O_TRUNC != 0;

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -150,6 +150,15 @@ pub(super) fn init(globals: &mut Globals) {
     globals.set_constant_by_str(IO_CLASS, "NOCTTY", Value::integer(libc::O_NOCTTY as i64));
     globals.set_constant_by_str(IO_CLASS, "NONBLOCK", Value::integer(libc::O_NONBLOCK as i64));
     globals.set_constant_by_str(IO_CLASS, "SYNC", Value::integer(libc::O_SYNC as i64));
+    globals.set_constant_by_str(IO_CLASS, "DSYNC", Value::integer(libc::O_DSYNC as i64));
+    globals.set_constant_by_str(IO_CLASS, "NOFOLLOW", Value::integer(libc::O_NOFOLLOW as i64));
+    // Linux-only bits — absent from Darwin's open(2) (and from CRuby
+    // on Darwin, which defines these constants only `#ifdef O_*`).
+    #[cfg(target_os = "linux")]
+    {
+        globals.set_constant_by_str(IO_CLASS, "RSYNC", Value::integer(libc::O_RSYNC as i64));
+        globals.set_constant_by_str(IO_CLASS, "DIRECT", Value::integer(libc::O_DIRECT as i64));
+    }
     // (IO::SEEK_SET / SEEK_CUR / SEEK_END are already defined elsewhere
     //  in startup; do not re-define here.)
     let stdin = Value::new_io_stdin();
@@ -6235,6 +6244,52 @@ mod tests {
             io.print "new data"; io.flush; io.close
             r << [File.read(e1), File.read(e2)]
             File.delete(a, b, c, d, e1, e2)
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_reopen_path_modes() {
+        // Explicit mode variants of the path form: "r+"/"w+"/"a+"
+        // string modes, an integer-flags mode, the invalid-mode
+        // ArgumentError, and mode inference from an "r+" receiver.
+        run_test_once(
+            r##"
+            base = "/tmp/monoruby_test_reopenm_#{Process.pid}_#{rand(100000)}"
+            a = base + "_a"; b = base + "_b"
+            File.write(a, "aaaa"); File.write(b, "bbbb")
+            r = []
+            # "r+": read/write, no truncation, positioned at 0
+            io = File.open(a); io.reopen(b, "r+")
+            r << io.read(2); io.print "XX"; io.flush; io.close
+            r << File.read(b)
+            # "w+": truncates
+            File.write(b, "bbbb")
+            io = File.open(a); io.reopen(b, "w+")
+            r << [io.read, File.read(b).bytesize]
+            io.close
+            # "a+": appends
+            File.write(b, "bb")
+            io = File.open(a); io.reopen(b, "a+")
+            io.print "cc"; io.flush
+            r << File.read(b)
+            io.close
+            # integer flags mode (WRONLY|CREAT|TRUNC == "w")
+            File.write(b, "bbbb")
+            io = File.open(a); io.reopen(b, File::WRONLY | File::CREAT | File::TRUNC)
+            io.print "ii"; io.flush; io.close
+            r << File.read(b)
+            # invalid mode string
+            io = File.open(a)
+            r << (begin; io.reopen(b, "z"); rescue ArgumentError => e; e.class.to_s; end)
+            io.close
+            # mode inference from an "r+" receiver: no truncation
+            File.write(b, "keep")
+            io = File.open(a, "r+"); io.reopen(b)
+            r << [io.read, File.read(b)]
+            io.close
+            File.delete(a, b)
             r
             "##,
         );

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -65,6 +65,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(IO_CLASS, "fcntl", io_fcntl, 1, 2, false);
     globals.define_builtin_func_with(IO_CLASS, "ioctl", io_ioctl, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "initialize_copy", io_initialize_copy, 1);
+    globals.define_builtin_func_with(IO_CLASS, "reopen", io_reopen, 1, 2, false);
     globals.define_builtin_func(IO_CLASS, "to_io", io_to_io, 0);
     globals.define_builtin_func_with(IO_CLASS, "write", io_write_method, 0, 0, true);
     globals.define_builtin_func_with(IO_CLASS, "syswrite", io_syswrite, 1, 1, false);
@@ -2673,6 +2674,249 @@ fn io_initialize_copy(
         true,
     );
     Ok(self_)
+}
+
+///
+/// ### IO#reopen
+/// - reopen(io) -> self
+/// - reopen(path, mode = <receiver's current mode>) -> self
+///
+/// Re-associates the receiver with another stream. The IO form
+/// `dup2(2)`s the other stream's fd onto the receiver's fd number
+/// (sharing the open file description, hence the position) and the
+/// receiver takes on the other IO's class/path/mode; the path form
+/// has `freopen(3)` semantics — the receiver's fd number is
+/// re-pointed at a fresh open of `path`, positioned at 0.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/reopen.html]
+#[monoruby_builtin]
+fn io_reopen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let arg0 = lfp.arg(0);
+    let is_io = |v: Value| v.try_rvalue().is_some_and(|rv| rv.ty() == ObjTy::IO);
+    if lfp.try_arg(1).is_none() {
+        // IO form. A real IO argument is used as-is — CRuby's
+        // rb_io_check_io short-circuits on T_FILE without calling
+        // #to_io (the reopen spec pins this down). Other objects
+        // convert via #to_io when they respond; a wrong-typed result
+        // raises TypeError. Objects with neither fall through to the
+        // path form (#to_path / #to_str coercion).
+        if is_io(arg0) {
+            return io_reopen_io(globals, lfp.self_val(), arg0);
+        }
+        if let Some(fid) = globals.check_method(arg0, IdentId::get_id("to_io")) {
+            let conv = vm.invoke_func_inner(globals, fid, arg0, &[], None, None)?;
+            if !is_io(conv) {
+                // CRuby's conversion error spells this "to IO", not
+                // the generic coercion helper's "into", and names the
+                // real class (not a singleton).
+                let class = globals.store.get_class_name(arg0.real_class(&globals.store).id());
+                let gives = globals.store.get_class_name(conv.real_class(&globals.store).id());
+                return Err(MonorubyErr::typeerr(format!(
+                    "can't convert {class} to IO ({class}#to_io gives {gives})"
+                )));
+            }
+            return io_reopen_io(globals, lfp.self_val(), conv);
+        }
+    }
+    io_reopen_path(vm, globals, lfp)
+}
+
+/// `IO#reopen(other_io)`: `dup2(2)` the other stream's fd onto the
+/// receiver's fd number and adopt the other IO's mode, path, and
+/// class.
+fn io_reopen_io(globals: &mut Globals, self_: Value, other: Value) -> Result<Value> {
+    let mut self_ = self_;
+    let mut other = other;
+    ensure_io_open(other)?;
+    ensure_io_open(self_)?;
+    if self_.id() == other.id() {
+        return Ok(self_);
+    }
+    // Logical position of the other stream (fd offset minus its
+    // buffered lookahead / pushback), captured before the fd surgery.
+    // CRuby's io_reopen seeks both streams there afterwards so the
+    // shared description continues from the *visible* position, not
+    // from wherever buffered readahead left the fd.
+    let other_pos = if other.as_io_inner().is_readable() {
+        let pb = other.as_io_inner().pushback_len() as i64;
+        other
+            .as_io_inner_mut()
+            .seek(0, 1)
+            .ok()
+            .map(|p| (p as i64 - pb).max(0))
+    } else {
+        None
+    };
+    // Flush both write sides before re-pointing the descriptor.
+    if self_.as_io_inner().is_writable() {
+        self_.as_io_inner_mut().flush()?;
+    }
+    if other.as_io_inner().is_writable() {
+        other.as_io_inner_mut().flush()?;
+    }
+    let fd1 = self_.as_io_inner().fileno()?;
+    let fd2 = other.as_io_inner().fileno()?;
+    if fd1 != fd2 {
+        // SAFETY: dup2 of two validated open fds — atomically closes
+        // the receiver's old description and re-points its fd number.
+        if unsafe { libc::dup2(fd2, fd1) } == -1 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "dup2"));
+        }
+        if fd1 > 2 {
+            // CRuby resets close-on-exec to true on non-STDIO fds
+            // (dup2 always clears it).
+            // SAFETY: setting FD_CLOEXEC on the fd we just dup2'ed.
+            unsafe { libc::fcntl(fd1, libc::F_SETFD, libc::FD_CLOEXEC) };
+        }
+    }
+    let (readable, writable) = {
+        let o = other.as_io_inner();
+        (o.is_readable(), o.is_writable())
+    };
+    rebuild_reopened_inner(&mut self_, fd1, other.as_io_inner().path(), readable, writable);
+    if let Some(pos) = other_pos {
+        // Both fds now share one description; seeking re-syncs the
+        // kernel offset to the logical position and drops both sides'
+        // stale read buffers.
+        let _ = self_.as_io_inner_mut().seek(pos, 0);
+        let _ = other.as_io_inner_mut().seek(pos, 0);
+    }
+    // The receiver takes on the other IO's (real) class — CRuby's
+    // RBASIC_SET_CLASS in io_reopen; `@io.reopen(file).should.instance_of?(File)`.
+    let real = other.real_class(&globals.store).id();
+    if self_.class() != real {
+        self_.change_class(real);
+    }
+    Ok(self_)
+}
+
+/// `IO#reopen(path, mode)`: freopen(3) semantics. Opens `path` and
+/// re-points the receiver's fd number at it (or installs a fresh fd
+/// when the receiver is closed — allowed for the path form).
+fn io_reopen_path(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Value> {
+    let mut self_ = lfp.self_val();
+    let path = super::file::to_path_str(vm, globals, lfp.arg(0))?;
+    let was_open = !self_.as_io_inner().is_closed();
+    // Resolve the mode: an explicit argument wins; otherwise
+    // reconstruct it from the receiver's current state (CRuby reuses
+    // fptr->mode). F_GETFL recovers O_APPEND, which monoruby's inner
+    // doesn't store; write-only non-append receivers are treated as
+    // "w" (create + truncate), matching the common `File.open(_, "w")`
+    // origin.
+    let mode_base = if let Some(m) = lfp.try_arg(1) {
+        let mode = if let Some(n) = m.try_fixnum() {
+            super::file::mode_string_from_flags(n)
+        } else {
+            m.coerce_to_string(vm, globals)?
+        };
+        mode.split(':').next().unwrap().replace('b', "")
+    } else {
+        let (readable, writable) = {
+            let i = self_.as_io_inner();
+            (i.is_readable(), i.is_writable())
+        };
+        let append = if was_open {
+            let fd = self_.as_io_inner().fileno()?;
+            // SAFETY: F_GETFL on the receiver's open fd; reads no memory.
+            unsafe { libc::fcntl(fd, libc::F_GETFL) & libc::O_APPEND != 0 }
+        } else {
+            false
+        };
+        match (readable, writable, append) {
+            (true, false, _) | (false, false, _) => "r".to_string(),
+            (false, true, true) => "a".to_string(),
+            (false, true, false) => "w".to_string(),
+            (true, true, true) => "a+".to_string(),
+            (true, true, false) => "r+".to_string(),
+        }
+    };
+    let (readable, writable) = match mode_base.as_str() {
+        "r" => (true, false),
+        "w" | "a" | "w-" | "-w" => (false, true),
+        "r+" | "+r" | "w+" | "+w" | "a+" | "+a" => (true, true),
+        _ => {
+            return Err(MonorubyErr::argumenterr(format!(
+                "invalid access mode {mode_base}"
+            )));
+        }
+    };
+    let mut opt = std::fs::OpenOptions::new();
+    match mode_base.as_str() {
+        "r" => opt.read(true),
+        "w" => opt.write(true).create(true).truncate(true),
+        "w-" => opt.write(true).create(true),
+        "-w" => opt.write(true),
+        "a" => opt.write(true).create(true).append(true),
+        "r+" | "+r" => opt.read(true).write(true),
+        "w+" | "+w" => opt.read(true).write(true).create(true).truncate(true),
+        "a+" | "+a" => opt.read(true).write(true).create(true).append(true),
+        _ => unreachable!(),
+    };
+    std::os::unix::fs::OpenOptionsExt::custom_flags(&mut opt, libc::O_CLOEXEC);
+    let file = opt.open(&path).map_err(|e| {
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_sysopen", &path)
+    })?;
+    if was_open {
+        if self_.as_io_inner().is_writable() {
+            self_.as_io_inner_mut().flush()?;
+        }
+        let fd1 = self_.as_io_inner().fileno()?;
+        let tmpfd = std::os::fd::AsRawFd::as_raw_fd(&file);
+        if fd1 != tmpfd {
+            // SAFETY: dup2 onto the receiver's own open fd number;
+            // `file` (tmpfd) is closed when it drops below.
+            if unsafe { libc::dup2(tmpfd, fd1) } == -1 {
+                let err = std::io::Error::last_os_error();
+                return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "dup2"));
+            }
+        }
+        if fd1 > 2 {
+            // SAFETY: setting FD_CLOEXEC on the receiver's fd.
+            unsafe { libc::fcntl(fd1, libc::F_SETFD, libc::FD_CLOEXEC) };
+        }
+        rebuild_reopened_inner(&mut self_, fd1, Some(path), readable, writable);
+    } else {
+        // Closed receiver: adopt the fresh fd directly.
+        let fd = std::os::fd::IntoRawFd::into_raw_fd(file);
+        *self_.as_io_inner_mut() =
+            IoInner::from_raw_fd_autoclose(fd, path, true, readable, writable, true);
+    }
+    Ok(self_)
+}
+
+/// Swap the receiver's `IoInner` for a fresh wrapper of `fd` (new
+/// buffer, no pushback, new mode/path) without disturbing fd-close
+/// responsibility. Only File-backed receivers are rebuilt: the stdio
+/// singletons keep their variant (their writes go through the process
+/// fd, which dup2 already re-pointed — the redirection works without
+/// touching the wrapper), and popen wrappers keep their child
+/// bookkeeping.
+fn rebuild_reopened_inner(
+    self_: &mut Value,
+    fd: i32,
+    path: Option<String>,
+    readable: bool,
+    writable: bool,
+) {
+    let inner = self_.as_io_inner_mut();
+    if !matches!(inner, IoInner::File(_)) {
+        return;
+    }
+    let was_autoclose = inner.is_autoclose();
+    // Release the old wrapper's claim on the fd number without closing
+    // it (the number now holds the new description); the new wrapper
+    // re-registers ownership if it had it.
+    inner.set_autoclose(false);
+    let has_path = path.is_some();
+    *inner = IoInner::from_raw_fd_autoclose(
+        fd,
+        path.unwrap_or_default(),
+        has_path,
+        readable,
+        writable,
+        was_autoclose,
+    );
 }
 
 ///
@@ -5887,6 +6131,110 @@ mod tests {
             r << File.read(path)
             File.open(path) { |f| r << (begin; f.ioctl(0x5401); rescue SystemCallError => e; e.class.to_s; end) }
             r << (begin; io.ioctl(1); rescue IOError => e; e.message; end)
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_reopen_with_io() {
+        // IO form: dup2 semantics — shared position, class/path
+        // adoption, EOF reset, write redirection, error cases, #to_io
+        // conversion, and the same-object no-op.
+        run_test_once(
+            r##"
+            base = "/tmp/monoruby_test_reopen_#{Process.pid}_#{rand(100000)}"
+            a = base + "_a"; b = base + "_b"
+            File.write(a, "Line 1\nLine 2\n"); File.write(b, "Other 1\nOther 2\n")
+            r = []
+            # position of the other stream is adopted
+            io = File.open(a); other = File.open(b)
+            other.gets
+            r << [io.reopen(other).equal?(io), io.gets, io.class.to_s, io.path == other.path]
+            io.close; other.close
+            # from the beginning when the other stream is unread; EOF resets
+            io = File.open(a); other = File.open(b)
+            io.read
+            r << [io.eof?, io.reopen(other).eof?, io.gets]
+            io.close; other.close
+            # write redirection
+            w1 = base + "_w1"; w2 = base + "_w2"
+            io = File.open(w1, "w"); other = File.open(w2, "w")
+            io.print "one"; io.reopen(other); io.print "two"; io.flush
+            io.close; (other.close rescue nil)
+            r << [File.read(w1), File.read(w2)]
+            # closed argument / closed receiver raise IOError
+            closed = File.open(a); closed.close
+            io = File.open(a)
+            r << (begin; io.reopen(closed); rescue IOError => e; e.message; end)
+            io.close
+            r << (begin; io.reopen(File.open(b)); rescue IOError => e; e.message; end)
+            # to_io conversion; wrong-typed result is a TypeError
+            conv = Object.new
+            other = File.open(b)
+            conv.define_singleton_method(:to_io) { other }
+            io = File.open(a)
+            r << [io.reopen(conv).class.to_s, io.gets]
+            io.close; other.close
+            bad = Object.new
+            bad.define_singleton_method(:to_io) { "nope" }
+            io = File.open(a)
+            r << (begin; io.reopen(bad); rescue TypeError => e; e.message; end)
+            # same-object reopen is a no-op
+            r << io.reopen(io).equal?(io)
+            io.close
+            File.delete(a, b, w1, w2)
+            r
+            "##,
+        );
+    }
+
+    #[test]
+    fn io_reopen_with_path() {
+        // Path form: freopen semantics — rewind to 0, path update,
+        // mode inference from the receiver (w/a create, r -> ENOENT),
+        // explicit mode flags (append) pass through, #to_path
+        // coercion, closed receivers allowed, close-on-exec reset.
+        run_test_once(
+            r##"
+            require 'fcntl'
+            base = "/tmp/monoruby_test_reopenp_#{Process.pid}_#{rand(100000)}"
+            a = base + "_a"; b = base + "_b"; c = base + "_c"; d = base + "_d"
+            File.write(a, "Line 1\nLine 2\n"); File.write(b, "Other 1\n")
+            r = []
+            io = File.open(a); io.gets
+            io.reopen(b)
+            r << [io.gets, File.basename(io.path) == File.basename(b)]
+            io.close
+            # closed receiver with explicit mode reopens fine
+            io = File.open(a); io.close
+            io.reopen(a, "r")
+            r << [io.closed?, io.gets]
+            io.close
+            # to_path coercion
+            pth = Object.new
+            pth.define_singleton_method(:to_path) { b }
+            io = File.open(a); io.reopen(pth); r << io.gets; io.close
+            # mode inference: write-mode receivers create the target
+            io = File.open(c, "w"); io.reopen(d); r << File.exist?(d); io.close
+            io = File.open(c, "a"); File.delete(d); io.reopen(d); r << File.exist?(d); io.close
+            # read-mode receiver + missing file -> ENOENT
+            io = File.open(a)
+            r << (begin; io.reopen(base + "_missing"); rescue Errno::ENOENT => e; e.class.to_s; end)
+            io.close
+            # explicit "ab" passes O_APPEND through; original data intact
+            io = File.open(a); io.reopen(c, "ab")
+            r << ((io.fcntl(Fcntl::F_GETFL) & File::APPEND) == File::APPEND)
+            io.close
+            # write flushed before switching; cloexec reset to true
+            e1 = base + "_e1"; e2 = base + "_e2"
+            io = File.open(e1, "w"); io.print "original data"
+            io.close_on_exec = false
+            io.reopen(e2)
+            r << io.close_on_exec?
+            io.print "new data"; io.flush; io.close
+            r << [File.read(e1), File.read(e2)]
+            File.delete(a, b, c, d, e1, e2)
             r
             "##,
         );


### PR DESCRIPTION
## Summary

`IO#reopen` was missing entirely — `core/io/reopen_spec.rb` sat at 6 failures / 27 errors. This PR implements both forms following CRuby's `io_reopen` / `rb_io_reopen`.

### IO form — `io.reopen(other_io)`

- A real IO argument is used **as-is**; `#to_io` is only dispatched for non-IO objects (CRuby's `rb_io_check_io` short-circuit, pinned by the spec's "does not call #to_io" example). A non-IO conversion result raises `TypeError` naming the real class.
- The other stream's **logical position** (fd offset minus buffered lookahead and `ungetc` pushback) is captured first; both write sides are flushed; then `dup2(2)` re-points the receiver's fd number at the other stream's open file description. Both streams are seeked to the captured position afterwards, so the shared description continues from the *visible* position rather than the buffered-readahead offset ("reads from the current position of the other IO's stream").
- The receiver adopts the other IO's mode, `path`, and **real class** (`@io.reopen(file).should.instance_of?(File)`), resets EOF/pushback via a fresh buffer wrapper, and close-on-exec is reset to `true` on non-STDIO fds.
- Closed receivers and closed arguments raise `IOError`; `io.reopen(io)` is a no-op.

### Path form — `io.reopen(path, mode = <current mode>)`

- `freopen(3)` semantics: the path (via `#to_path` / `#to_str`) is opened and `dup2`'ed onto the receiver's fd number, positioned at 0.
- Mode: an explicit string / integer-flags argument wins; otherwise it is reconstructed from the receiver's state — `F_GETFL` recovers `O_APPEND` (which the inner doesn't store), and write-only non-append receivers reopen as `"w"`. Net effect: write-mode receivers **create** a missing target, read-mode receivers surface `Errno::ENOENT`, and `"ab"`'s `O_APPEND` is observable via `fcntl` — all as specced.
- A **closed receiver is allowed** for the path form and simply adopts the fresh fd.

### fd-ownership plumbing

The wrapper swap preserves fd-close responsibility: the old `FileDescriptor` releases the fd *number* without closing it (`set_autoclose(false)`), and the new wrapper re-registers ownership. Stdio singletons keep their `IoInner` variant — `dup2` alone performs the redirection, so `STDOUT.reopen(path)` affects subsequent `exec`/`system` — and popen wrappers keep their child bookkeeping.

## Testing

- **`core/io/reopen_spec.rb`: all 28 examples green** (was 6F / 27E).
- core/io overall: 33F / 45E → **27F / 15E**, no regressions.
- A differential probe covering position sharing, class/path adoption, EOF reset, write redirection, error cases, `#to_io`/`#to_path` protocols, mode inference, and cloexec reset is **byte-identical with CRuby 4.0.2**.
- Full lib suite passes: **2004 tests**, including two new differential test groups (`io_reopen_with_io`, `io_reopen_with_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_