### PR TITLE
Async Thread#raise protocol, kill "aborting" status, raise keyword separation

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -374,7 +374,11 @@ fn exception_new(
     _: BytecodePtr,
 ) -> Result<Value> {
     let class_id = lfp.self_val().expect_class(globals)?.id();
-    let obj = Value::new_exception_from("".to_string(), class_id);
+    // Seed the message with the class name (CRuby's default when the
+    // mesg field is never assigned): a subclass `initialize` that
+    // doesn't call super must still report `klass.to_s` from
+    // `#message`.
+    let obj = Value::new_exception_from(class_id.get_name(globals), class_id);
 
     vm.invoke_method_inner(
         globals,

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -70,7 +70,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         3,
         false,
         &["cause"],
-        false,
+        true,
     );
     // CRuby aliases `fail` to the same `rb_f_raise` callback (variadic).
     // Use the identical signature so `cause:` ends up at the same
@@ -83,7 +83,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         3,
         false,
         &["cause"],
-        false,
+        true,
     );
     globals.define_builtin_module_inline_func(
         kernel_class,
@@ -963,11 +963,31 @@ fn fix_system_exit_status(globals: &mut Globals, err: &mut MonorubyErr, ex: Valu
 #[monoruby_builtin]
 fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // `cause:` kwarg is at slot 3 (positional_max=3 for the shared
-    // raise/fail trampoline). CRuby: passing `cause:` with no
-    // positional arguments raises `ArgumentError "only cause is given
-    // with no arguments"`.
+    // raise/fail trampoline); leftover keywords (kw_rest) land in slot
+    // 4. CRuby extracts only `cause:` from genuine keywords — any
+    // remaining keywords act as a trailing positional Hash (the
+    // message), per https://bugs.ruby-lang.org/issues/8257#note-36
+    // (`raise(data_error, data: 42)`).
     let cause_kwarg = lfp.try_arg(3);
-    if lfp.try_arg(0).is_none() {
+    let kw_rest = lfp
+        .try_arg(4)
+        .filter(|v| v.try_hash_ty().is_some_and(|h| h.len() != 0));
+    let mut args = vec![];
+    if let Some(a0) = lfp.try_arg(0) {
+        args.push(a0);
+        if let Some(a1) = lfp.try_arg(1) {
+            args.push(a1);
+            if let Some(a2) = lfp.try_arg(2) {
+                args.push(a2);
+            }
+        }
+    }
+    if let Some(kw) = kw_rest {
+        args.push(kw);
+    }
+    if args.is_empty() {
+        // CRuby: passing `cause:` with no positional arguments raises
+        // `ArgumentError "only cause is given with no arguments"`.
         if cause_kwarg.is_some() {
             return Err(MonorubyErr::argumenterr(
                 "only cause is given with no arguments",
@@ -980,13 +1000,6 @@ fn raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             return Err(err.with_original(ex));
         } else {
             return Err(MonorubyErr::runtimeerr(""));
-        }
-    }
-    let mut args = vec![lfp.arg(0)];
-    if let Some(a1) = lfp.try_arg(1) {
-        args.push(a1);
-        if let Some(a2) = lfp.try_arg(2) {
-            args.push(a2);
         }
     }
     Err(make_exception_error(vm, globals, &args, cause_kwarg)?)
@@ -1030,12 +1043,14 @@ pub(crate) fn make_exception_error(
         Ok(())
     }
     let a0 = args[0];
-    let msg_arg = args.get(1).copied().filter(|v| v.try_hash_ty().is_none());
-    // A nil backtrace means "keep the runtime capture".
-    let bt_arg = args
-        .get(2)
-        .copied()
-        .filter(|v| !v.is_nil() && v.try_hash_ty().is_none());
+    // A Hash is a legitimate message (`raise(data_error, {data: 42})`
+    // constructs via `data_error.exception({data: 42})`); keyword
+    // separation happens in the callers, never here.
+    let msg_arg = args.get(1).copied();
+    // A nil backtrace means "keep the runtime capture"; anything else
+    // goes through `#set_backtrace` dispatch, whose own validation
+    // raises the CRuby-matching TypeError for bad types.
+    let bt_arg = args.get(2).copied().filter(|v| !v.is_nil());
     if a0.is_exception().is_some() {
         // A message override makes CRuby return a *new* exception via
         // `exc.exception(msg)`, so identity is not preserved.
@@ -1055,6 +1070,16 @@ pub(crate) fn make_exception_error(
             return Err(MonorubyErr::typeerr("exception object expected"));
         };
         let mut err = MonorubyErr::new_from_exception(ex);
+        // `set_backtrace(nil)` cleared the stored backtrace: this raise
+        // captures a *fresh* one, so don't drag the object's stale
+        // trace along (take_ex_obj re-installs the new capture).
+        if globals
+            .store
+            .get_ivar(obj, IdentId::get_id("/backtrace"))
+            .is_some_and(|v| v.is_nil())
+        {
+            err.trace.clear();
+        }
         fix_system_exit_status(globals, &mut err, obj);
         return apply_cause(globals, err.with_original(obj), Some(obj), cause_kwarg);
     }
@@ -1138,7 +1163,7 @@ fn apply_cause(
 }
 
 /// Whether `target` appears in the `#cause` chain reachable from `start`.
-fn cause_chain_contains(globals: &Globals, start: Value, target: Value) -> bool {
+pub(crate) fn cause_chain_contains(globals: &Globals, start: Value, target: Value) -> bool {
     let cause_id = IdentId::get_id("/cause");
     let mut cur = start;
     loop {
@@ -7447,5 +7472,62 @@ mod tests {
         // Array's builtin `initialize_copy` (alias of replace) keeps dup a
         // shallow, independent copy.
         run_test(r#"a = [1, 2, 3]; b = a.dup; b << 4; [a, b]"#);
+    }
+
+    #[test]
+    fn raise_keyword_separation_and_message_forms() {
+        run_tests(&[
+            // A Hash message constructs through the class, both as a
+            // positional hash and as folded-back leftover keywords
+            // (CRuby extracts only `cause:` from genuine keywords).
+            r#"de = Class.new(StandardError) { attr_reader :data; def initialize(d); @data = d; end }
+               begin; raise(de, {data: 42}); rescue Exception => e; [e.class.equal?(de), e.data]; end"#,
+            r#"de = Class.new(StandardError) { attr_reader :data; def initialize(d); @data = d; end }
+               begin; raise(de, data: 42); rescue Exception => e; [e.class.equal?(de), e.data]; end"#,
+            // A positional `{cause: ...}` hash is a message argument —
+            // and a String followed by a message is a TypeError.
+            r#"begin; raise("message", {cause: RuntimeError.new}); rescue TypeError => e; e.message; end"#,
+            // Only an exception class: zero-arg construction, message
+            // defaults to the class name even when the subclass
+            // initialize never calls super.
+            r#"k = Class.new(Exception) { def initialize; end }
+               begin; raise(k); rescue Exception => e; e.message == k.to_s; end"#,
+            // Genuine `cause:` keyword still works, alone it is an
+            // ArgumentError.
+            r#"begin; raise("m", cause: RuntimeError.new("c")); rescue => e; [e.message, e.cause.message]; end"#,
+            r#"begin; raise(cause: RuntimeError.new); rescue ArgumentError => e; e.message; end"#,
+        ]);
+    }
+
+    #[test]
+    fn raise_reraise_backtrace_and_cause_cycle() {
+        run_tests(&[
+            // `set_backtrace(nil)` + re-raise captures a fresh
+            // backtrace at the new raise site.
+            r#"begin; raise "x"; rescue => e; end
+               e.set_backtrace(nil)
+               begin; raise e; rescue => r; end
+               [r.equal?(e), r.backtrace.class.to_s, r.backtrace.empty?]"#,
+            // Re-raising an exception that already sits in `$!`'s cause
+            // chain must not chain implicitly (no cycle).
+            r#"
+            out = []
+            e1 = nil
+            begin
+              begin
+                raise "Error 1"
+              rescue => e1
+                begin
+                  raise "Error 2"
+                rescue => e2
+                  out << e1.cause.nil? << (e2.cause == e1)
+                  raise e1
+                end
+              end
+            rescue => e
+              out << e.equal?(e1) << e.cause.nil?
+            end
+            out"#,
+        ]);
     }
 }

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -45,7 +45,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(THREAD_CLASS, "wakeup", thread_wakeup, 0);
     globals.define_builtin_func(THREAD_CLASS, "__wakeup_permit", thread_wakeup_permit, 0);
     globals.define_builtin_func(THREAD_CLASS, "run", thread_run, 0);
-    globals.define_builtin_func_rest(THREAD_CLASS, "raise", thread_raise);
+    globals.define_builtin_func_with_kw(THREAD_CLASS, "raise", thread_raise, 0, 3, false, &["cause"], true);
     globals.define_builtin_func(THREAD_CLASS, "kill", thread_kill, 0);
     globals.define_builtin_func(THREAD_CLASS, "exit", thread_kill, 0);
     globals.define_builtin_func(THREAD_CLASS, "terminate", thread_kill, 0);
@@ -122,7 +122,7 @@ fn handle_interrupt(
     scheduler::push_interrupt_mask(vm, mask);
     // Entry delivery point (non-blocking): a pending interrupt the new
     // mask allows fires before the block runs.
-    let res = match scheduler::deliver_pending_now(globals, cur, false) {
+    let res = match scheduler::deliver_pending_now(vm, globals, cur, false) {
         Err(err) => Err(err),
         Ok(()) => vm.invoke_block_once(globals, bh, &[]),
     };
@@ -131,7 +131,7 @@ fn handle_interrupt(
     // mask deferred fire here — even when the block itself raised, and
     // the delivered interrupt takes precedence over the block's own
     // exception (CRuby).
-    scheduler::deliver_pending_now(globals, cur, false)?;
+    scheduler::deliver_pending_now(vm, globals, cur, false)?;
     res
 }
 
@@ -192,31 +192,18 @@ fn pending_interrupt_p(
     )))
 }
 
-/// Build the exception for a `Thread#raise` from its rest-args (CRuby's
+/// Build the exception for a `Thread#raise` (CRuby's
 /// `rb_make_exception`, shared with `Kernel#raise`): no args -> a fresh
 /// `RuntimeError` with an empty message (NOT Kernel#raise's `$!`
 /// re-raise); otherwise exception object / class / String / duck-typed
-/// `#exception`, with optional message-override, backtrace, and a
-/// trailing `cause:` keyword hash.
+/// `#exception`, with optional message-override, backtrace, and the
+/// `cause:` keyword.
 fn build_async_error(
     vm: &mut Executor,
     globals: &mut Globals,
     args: &[Value],
+    cause_kwarg: Option<Value>,
 ) -> Result<MonorubyErr> {
-    // Rest-args calling convention: a trailing `{cause: ...}` hash is
-    // the keyword argument.
-    let (args, cause_kwarg) = match args.last() {
-        Some(last) => match last.try_hash_ty() {
-            Some(h) if h.len() == 1 => {
-                match h.get(Value::symbol_from_str("cause"), vm, globals)? {
-                    Some(c) => (&args[..args.len() - 1], Some(c)),
-                    None => (args, None),
-                }
-            }
-            _ => (args, None),
-        },
-        None => (args, None),
-    };
     if args.is_empty() {
         if cause_kwarg.is_some() {
             return Err(MonorubyErr::argumenterr(
@@ -240,8 +227,44 @@ fn build_async_error(
 /// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/raise.html]
 #[monoruby_builtin]
 fn thread_raise(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let args = lfp.arg(0).as_array().to_vec();
-    let err = build_async_error(vm, globals, &args)?;
+    // Same keyword layout as Kernel#raise: `cause:` at slot 3,
+    // leftover keywords (kw_rest, slot 4) act as a trailing positional
+    // Hash — while a literal positional `{cause: ...}` stays a
+    // positional message argument (and TypeErrors after a String),
+    // matching CRuby's keyword separation.
+    let cause_kwarg = lfp.try_arg(3);
+    let kw_rest = lfp
+        .try_arg(4)
+        .filter(|v| v.try_hash_ty().is_some_and(|h| h.len() != 0));
+    let mut args = vec![];
+    if let Some(a0) = lfp.try_arg(0) {
+        args.push(a0);
+        if let Some(a1) = lfp.try_arg(1) {
+            args.push(a1);
+            if let Some(a2) = lfp.try_arg(2) {
+                args.push(a2);
+            }
+        }
+    }
+    if let Some(kw) = kw_rest {
+        args.push(kw);
+    }
+    let mut err = build_async_error(vm, globals, &args, cause_kwarg)?;
+    // The cause comes from the *calling* context: with no explicit
+    // `cause:`, the caller's `$!` (or its absence) is pinned here so
+    // delivery in the target never picks up the target's own `$!`
+    // (CRuby captures the cause in `rb_threadptr_raise`).
+    if cause_kwarg.is_none() && err.explicit_cause.is_none() {
+        let errinfo = vm.errinfo();
+        let cause = if errinfo.is_exception().is_some()
+            && err.original.map(|o| o.id()) != Some(errinfo.id())
+        {
+            errinfo
+        } else {
+            Value::nil()
+        };
+        err.explicit_cause = Some(cause);
+    }
     scheduler::interrupt(vm, globals, lfp.self_val(), PendingInterrupt::Raise(err))?;
     Ok(Value::nil())
 }
@@ -539,8 +562,8 @@ fn thread_value(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodeP
 ///
 /// ### Thread#status
 ///
-/// "run" | "sleep" | false (normal termination) | nil (terminated with
-/// exception).
+/// "run" | "sleep" | "aborting" | false (normal termination) | nil
+/// (terminated with exception).
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Thread/i/status.html]
 #[monoruby_builtin]
@@ -556,7 +579,17 @@ fn thread_status(vm: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             }
         }
         ThreadState::Sleeping | ThreadState::Joining | ThreadState::IoWaiting => {
+            // A killed thread parked inside its ensure clauses still
+            // reports "sleep" (CRuby: the sleep state wins over
+            // to_kill), and so does one whose kill is queued but not
+            // yet delivered.
             Value::string_from_str("sleep")
+        }
+        // Running with the kill delivered — the unrescuable unwind is
+        // executing ensure clauses — reports "aborting" (CRuby's
+        // to_kill flag).
+        ThreadState::Created | ThreadState::Runnable if inner.killed => {
+            Value::string_from_str("aborting")
         }
         ThreadState::Created | ThreadState::Runnable => {
             // The current thread reports "run"; queued-but-not-yet-run
@@ -1950,6 +1983,90 @@ mod tests {
             t.thread_variable_set(:b, false)
             [t.thread_variable?(:a), t.thread_variable?(:b), t.thread_variables, t.thread_variable_get(:a)]
             "#,
+        );
+    }
+
+    #[test]
+    fn thread_raise_async_protocol() {
+        // Async Thread#raise argument protocol: Hash messages, the
+        // caller-context cause, and the two-sided #exception dispatch
+        // (once in the caller with the message, once in the target
+        // with no arguments).
+        run_test_once(
+            r#"
+            r = []
+            de = Class.new(StandardError) { attr_reader :data; def initialize(d); @data = d; end }
+            t = Thread.new { Thread.current.report_on_exception = false; sleep }
+            Thread.pass until t.stop?
+            t.raise(de, {data: 42})
+            begin; t.join; rescue Exception => e; r << [e.class.equal?(de), e.data]; end
+            t2 = Thread.new { Thread.current.report_on_exception = false; sleep }
+            Thread.pass until t2.stop?
+            begin
+              raise "ctx"
+            rescue => ctx
+              t2.raise(RuntimeError, "async")
+            end
+            begin; t2.join; rescue => e; r << [e.message, e.cause && e.cause.message]; end
+            cls = Class.new(Exception) do
+              attr_accessor :log
+              def initialize(*a); @log = []; super; end
+              def exception(*a); @log << [Thread.current == Thread.main, a]; super; end
+            end
+            exc = cls.new
+            t3 = Thread.new { Thread.current.report_on_exception = false; begin; sleep; rescue Exception => e; e; end }
+            Thread.pass until t3.stop?
+            t3.raise exc, "both"
+            v = t3.value
+            r << [exc.log, v.class.equal?(cls), v.message, v.equal?(exc)]
+            r
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_kill_aborting_status() {
+        // A killed thread reports "aborting" from inside its ensure
+        // clauses while running, and false once dead; a queued kill on
+        // a parked thread still reports "sleep" from outside.
+        run_test_once(
+            r#"
+            r = []
+            q = []
+            t = Thread.new { begin; q << 1; sleep; ensure; q << Thread.current.status; end }
+            Thread.pass until t.stop?
+            r << t.status
+            t.kill
+            t.join
+            r << q.last << t.status
+            r
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_report_on_exception_format() {
+        // The report goes through the (replaceable) $stderr in regular
+        // backtrace order: header line mirroring Thread#inspect, then
+        // `frame: message (Class)`, then `	from frame` lines. Only
+        // structural properties are compared — frame labels differ
+        // from CRuby's in block-nesting detail.
+        run_test_once(
+            r##"
+            require 'stringio'
+            orig = $stderr
+            $stderr = StringIO.new
+            t = Thread.new { Thread.pass; raise "boom" }
+            begin; t.join; rescue; end
+            Thread.pass
+            s = $stderr.string
+            $stderr = orig
+            lines = s.lines
+            [lines[0].include?(" terminated with exception (report_on_exception is true):"),
+             lines[0].start_with?("#<Thread:0x"),
+             (lines[1] =~ /:\d+:in '/ ? true : false),
+             lines[1].include?("boom (RuntimeError)")]
+            "##,
         );
     }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1229,12 +1229,32 @@ impl Executor {
         // Re-raise of an existing exception object (`raise exc`): return
         // that object so its identity and instance variables are
         // preserved. CRuby only assigns a backtrace if the exception
-        // doesn't have one yet, so fill the trace in only when empty.
+        // doesn't have one yet, so fill the trace in only when empty —
+        // where "empty" includes an explicit `set_backtrace(nil)`,
+        // which clears the stored backtrace so the new raise
+        // re-captures one at its own location.
         if let Some(mut orig) = err.original {
+            let bt_id = IdentId::get_id("/backtrace");
+            let cleared = globals
+                .store
+                .get_ivar(orig, bt_id)
+                .is_some_and(|v| v.is_nil());
             if let Some(ex) = orig.is_exception_mut() {
-                if ex.trace.is_empty() {
+                if ex.trace.is_empty() || cleared {
                     ex.trace = err.take_trace();
                 }
+            }
+            if cleared {
+                // Replace the memoized nil (which would shadow the
+                // fresh capture in `Exception#backtrace`) with the
+                // rendered new trace.
+                let traces: Vec<String> = orig.is_exception().unwrap().trace_location(globals);
+                let fresh = if traces.is_empty() {
+                    Value::nil()
+                } else {
+                    Value::array_from_iter(traces.into_iter().map(Value::string))
+                };
+                let _ = globals.store.set_ivar(orig, bt_id, fresh);
             }
             return self.chain_cause(globals, orig, explicit_cause);
         }
@@ -1408,7 +1428,14 @@ impl Executor {
         }
         if globals.store.get_ivar(v, cause_id).is_none() {
             let active = self.errinfo;
-            if !active.is_nil() && active.id() != v.id() {
+            // No implicit chaining onto an exception that already sits
+            // in `$!`'s own cause chain — re-raising `e1` while
+            // rescuing an `e2` whose cause is `e1` must not create a
+            // cycle (CRuby leaves `e1.cause` nil).
+            if !active.is_nil()
+                && active.id() != v.id()
+                && !crate::builtins::kernel::cause_chain_contains(globals, active, v)
+            {
                 let _ = globals.store.set_ivar(v, cause_id, active);
             }
         }

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -385,7 +385,7 @@ pub(crate) fn sleep(
     // A pending interrupt allowed at blocking points fires *instead of*
     // parking (also the case where it was queued while running).
     let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
-    deliver_pending_now(globals, cur0, true)?;
+    deliver_pending_now(vm, globals, cur0, true)?;
     set_park_blocking(cur0, true);
     // Consume a park permit armed by a wakeup that raced this park (see
     // `ThreadInner::park_permit`): return immediately instead of
@@ -411,7 +411,7 @@ pub(crate) fn sleep(
         });
         scheduler_run(vm, globals)?;
         flush_pending_reports(vm, globals);
-        take_main_pending(globals, true)?;
+        take_main_pending(vm, globals, true)?;
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -420,7 +420,7 @@ pub(crate) fn sleep(
             s.sleepers.push((deadline, cur));
             cur
         });
-        park_switch(vm, cur)?;
+        park_switch(vm, globals, cur)?;
     }
     Ok(start.elapsed())
 }
@@ -432,7 +432,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
     // `Thread.pass` is a delivery point for `:immediate` interrupts but
     // NOT for `:on_blocking` ones (it is not a blocking call).
     let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
-    deliver_pending_now(globals, cur0, false)?;
+    deliver_pending_now(vm, globals, cur0, false)?;
     set_park_blocking(cur0, false);
     if is_current_main() {
         // Dispatch the threads that are ready *now* (not the ones they
@@ -483,7 +483,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
         });
         result?;
         flush_pending_reports(vm, globals);
-        take_main_pending(globals, false)
+        take_main_pending(vm, globals, false)
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -492,7 +492,7 @@ pub(crate) fn pass(vm: &mut Executor, globals: &mut Globals) -> Result<()> {
             s.ready.push_back(cur);
             cur
         });
-        park_switch(vm, cur)
+        park_switch(vm, globals, cur)
     }
 }
 
@@ -515,7 +515,7 @@ pub(crate) fn join(
     let deadline = timeout.map(|d| Instant::now() + d);
     loop {
         flush_pending_reports(vm, globals);
-        deliver_pending_now(globals, cur, true)?;
+        deliver_pending_now(vm, globals, cur, true)?;
         set_park_blocking(cur, true);
         if target.as_thread_inner().is_dead() {
             return Ok(true);
@@ -537,7 +537,7 @@ pub(crate) fn join(
                 }
             });
             scheduler_run(vm, globals)?;
-            take_main_pending(globals, true)?;
+            take_main_pending(vm, globals, true)?;
         } else {
             SCHEDULER.with(|s| {
                 let mut s = s.borrow_mut();
@@ -549,7 +549,7 @@ pub(crate) fn join(
                     s.sleepers.push((deadline, cur));
                 }
             });
-            park_switch(vm, cur)?;
+            park_switch(vm, globals, cur)?;
         }
     }
 }
@@ -626,6 +626,7 @@ fn take_pending_as_error(mut thread: Value, idx: usize) -> Option<MonorubyErr> {
 /// boundaries). Called at every park entry and at handle_interrupt
 /// entry/exit.
 pub(crate) fn deliver_pending_now(
+    vm: &mut Executor,
     globals: &mut Globals,
     thread: Value,
     at_blocking: bool,
@@ -640,9 +641,43 @@ pub(crate) fn deliver_pending_now(
             t.as_thread_inner_mut().killed = false;
             return Err(MonorubyErr::new(MonorubyErrKind::SystemExit(0), "exit"));
         }
-        return Err(err);
+        return Err(finalize_delivered_raise(vm, globals, err));
     }
     Ok(())
+}
+
+/// Target-side half of CRuby's `Thread#raise` protocol: delivery runs
+/// the queued exception object through `#exception` (no arguments)
+/// *in the receiving thread's context* — `rb_make_exception` executes
+/// once in the caller (with the message) and once here, so a user
+/// override observes both calls, and the delivered object is the
+/// second call's result. Errors carry the caller-pinned `cause:`
+/// across. Kills and message-only raises (no original object) pass
+/// through unchanged.
+fn finalize_delivered_raise(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    err: MonorubyErr,
+) -> MonorubyErr {
+    let Some(obj) = err.original else {
+        return err;
+    };
+    if obj.is_exception().is_none() {
+        return err;
+    }
+    match vm.invoke_method_inner(globals, IdentId::get_id("exception"), obj, &[], None, None) {
+        Ok(result) => match result.is_exception() {
+            Some(ex) => {
+                let mut new_err = MonorubyErr::new_from_exception(ex).with_original(result);
+                new_err.explicit_cause = err.explicit_cause;
+                new_err
+            }
+            None => MonorubyErr::typeerr("exception object expected"),
+        },
+        // A raising `#exception` override: its error is what the
+        // target sees.
+        Err(e) => e,
+    }
 }
 
 /// Whether `thread` has a queued pending interrupt (optionally filtered
@@ -705,7 +740,7 @@ pub(crate) fn interrupt(
         // false), everything else stays queued for a later delivery
         // point.
         target.as_thread_inner_mut().pending.push_back(int);
-        return deliver_pending_now(globals, target, false);
+        return deliver_pending_now(vm, globals, target, false);
     }
     if target.as_thread_inner().is_dead() {
         // CRuby: killing a dead thread is a no-op; raising into one is
@@ -748,10 +783,10 @@ fn kill_unwind_error() -> MonorubyErr {
 
 /// Deliver a pending interrupt queued for the *main* thread. Called
 /// after the scheduler returns control to a main-thread park.
-fn take_main_pending(globals: &mut Globals, at_blocking: bool) -> Result<()> {
+fn take_main_pending(vm: &mut Executor, globals: &mut Globals, at_blocking: bool) -> Result<()> {
     let main = SCHEDULER.with(|s| s.borrow().main.unwrap());
     // The handle_interrupt mask still applies at this delivery point.
-    deliver_pending_now(globals, main, at_blocking)
+    deliver_pending_now(vm, globals, main, at_blocking)
 }
 
 /// Park the current thread until `fd` reports one of `events` (or the
@@ -776,7 +811,7 @@ pub(crate) fn wait_fds(
 ) -> Result<()> {
     ensure_main(vm);
     let cur0 = SCHEDULER.with(|s| s.borrow().current.unwrap());
-    deliver_pending_now(globals, cur0, true)?;
+    deliver_pending_now(vm, globals, cur0, true)?;
     set_park_blocking(cur0, true);
     if is_current_main() {
         SCHEDULER.with(|s| {
@@ -794,7 +829,7 @@ pub(crate) fn wait_fds(
         unregister_io_waiter(SCHEDULER.with(|s| s.borrow().main.unwrap()));
         result?;
         flush_pending_reports(vm, globals);
-        take_main_pending(globals, true)
+        take_main_pending(vm, globals, true)
     } else {
         let cur = SCHEDULER.with(|s| {
             let mut s = s.borrow_mut();
@@ -808,7 +843,7 @@ pub(crate) fn wait_fds(
             }
             cur
         });
-        let result = park_switch(vm, cur);
+        let result = park_switch(vm, globals, cur);
         unregister_io_waiter(cur);
         result
     }
@@ -822,14 +857,20 @@ fn unregister_io_waiter(thread: Value) {
 
 /// Park the current green thread: record the context to resume, then
 /// switch to the scheduler. Returns when the scheduler resumes us.
-fn park_switch(vm: &mut Executor, mut cur: Value) -> Result<()> {
+fn park_switch(vm: &mut Executor, globals: &mut Globals, mut cur: Value) -> Result<()> {
     cur.as_thread_inner_mut().resume_exec = Some(std::ptr::NonNull::from(&mut *vm));
     let switch = CODEGEN.with(|c| c.borrow().switch_to_scheduler);
     match switch(vm as *mut _, Value::nil()) {
         Some(_) => Ok(()),
-        // Reserved for asynchronous interrupt injection (Thread#raise /
-        // #kill): a resume that sets an error instead of a value.
-        None => Err(vm.take_error()),
+        // Asynchronous interrupt injection (Thread#raise / #kill): a
+        // resume that sets an error instead of a value. `dispatch` set
+        // the error from machinery context, where Ruby must not run —
+        // the target-side `#exception` re-dispatch happens here, on
+        // this (the receiving) thread's own stack.
+        None => {
+            let err = vm.take_error();
+            Err(finalize_delivered_raise(vm, globals, err))
+        }
     }
 }
 
@@ -1292,7 +1333,35 @@ fn queue_exception_report(globals: &mut Globals, thread: Value) {
         match &inner.exception {
             None => return,
             Some(err) if matches!(err.kind(), MonorubyErrKind::SystemExit(_)) => return,
-            Some(err) => format!("{} ({})", err.message(), err.class_name(&globals.store)),
+            Some(err) => {
+                // Regular backtrace order (CRuby `rb_error_write` with
+                // the non-highlighted, non-reversed layout): the
+                // innermost frame heads the message line, the rest
+                // follow as `\tfrom` lines.
+                let head = format!("{} ({})", err.message(), err.class_name(&globals.store));
+                let frames: Vec<String> = err
+                    .trace
+                    .iter()
+                    .map(|(source_loc, fid)| {
+                        if let Some((loc, source)) = source_loc {
+                            globals.store.location(*fid, source, *loc)
+                        } else {
+                            globals.store.internal_location(fid.unwrap())
+                        }
+                    })
+                    .collect();
+                match frames.split_first() {
+                    None => head,
+                    Some((first, rest)) => {
+                        let mut text = format!("{first}: {head}");
+                        for f in rest {
+                            text.push_str("\n\tfrom ");
+                            text.push_str(f);
+                        }
+                        text
+                    }
+                }
+            }
         }
     };
     let ivar = IdentId::get_id("@report_on_exception");
@@ -1314,18 +1383,28 @@ fn queue_exception_report(globals: &mut Globals, thread: Value) {
     if !report {
         return;
     }
-    // The header mirrors Thread#inspect (`#<Thread:0xADDR[@name] run>`)
-    // without calling it — the spec matchers key on the `Thread` word and
-    // interpolate `t.inspect` taken while the thread was running.
+    // The header mirrors Thread#inspect
+    // (`#<Thread:0xADDR[@name][ file:line] run>`) without calling it —
+    // the spec matchers interpolate `t.inspect` taken while the thread
+    // was running, so every inspect component (including the spawn
+    // location) must round-trip.
     let name = globals
         .store
         .get_ivar(thread, IdentId::get_id("@name"))
         .and_then(|v| v.is_str().map(|s| format!("@{s}")))
         .unwrap_or_default();
+    let location = globals
+        .store
+        .get_ivar(thread, IdentId::get_id("@__spawn_location"))
+        .and_then(|v| v.is_str().map(|s| format!(" {s}")))
+        .unwrap_or_default();
+    // `object_id << 1`, exactly as the Ruby-side `Thread#to_s` prints
+    // the address.
     let text = format!(
-        "#<Thread:0x{:016x}{} run> terminated with exception (report_on_exception is true):\n{}\n",
-        thread.id(),
+        "#<Thread:0x{:016x}{}{} run> terminated with exception (report_on_exception is true):\n{}\n",
+        thread.id() << 1,
         name,
+        location,
         exc
     );
     SCHEDULER.with(|s| s.borrow_mut().pending_reports.push(text));


### PR DESCRIPTION
## Summary

Completes the asynchronous `Thread#raise` / `#kill` semantics on top of the scheduler's existing pending-interrupt machinery (queue, park-point delivery, `handle_interrupt` masks, unrescuable kill unwind, `abort_on_exception` forwarding — all already green), and fixes the shared `Kernel#raise` argument protocol both paths use.

### Kernel#raise / #fail and Thread#raise argument protocol

`Thread#raise` is re-registered with the same `cause:` + kw_rest keyword layout as `Kernel#raise` (previously rest-args, which cannot distinguish keywords from a positional hash):

- **Keyword separation matches CRuby**: only a genuine `cause:` keyword is extracted; leftover keywords act as a trailing positional Hash (`raise(data_error, data: 42)` constructs through the class — [Bug #8257]), a literal positional `{cause: ...}` stays a message argument (and raises `TypeError` after a String message), and Hash messages are no longer silently dropped by `make_exception_error`.
- **`raise(klass)`** constructs with no arguments, and the message defaults to the class name even when a subclass `initialize` never calls super (`Exception.new` seeds the class name).
- **Re-raise after `set_backtrace(nil)`** captures a fresh backtrace at the new raise site instead of keeping a nil/stale one.
- **Implicit cause chaining** skips an exception that already sits in `$!`'s cause chain — re-raising `e1` while rescuing an `e2` whose cause is `e1` leaves `e1.cause` nil (no cycle).

### Async delivery semantics

- **Caller-context cause**: with no explicit `cause:`, the caller's `$!` (or its absence) is pinned at queue time, so delivery never picks up the target thread's own `$!`.
- **CRuby's two-sided `#exception` protocol**: the argument list runs through `#exception` once in the caller (with the message) and once more at delivery in the *receiving thread's* context (no arguments) — implemented in `deliver_pending_now` for park-entry delivery and in `park_switch` for wake-from-park delivery, where the receiving thread's stack and `Thread.current` are live (the scheduler's `dispatch` sets the error from machinery context, where Ruby must not run).

### Thread#status "aborting"

A killed thread running its ensure clauses reports `"aborting"` (CRuby's to_kill flag); one parked inside its ensure still reports `"sleep"`, as does a queued-but-undelivered kill on a sleeping thread.

### report_on_exception format

The report renders in regular backtrace order — the innermost frame heads the `frame: message (Class)` line, remaining frames follow as `\tfrom` lines — and the header now mirrors `Thread#inspect` exactly (`object_id << 1` address and the spawn location), which the spec matchers interpolate verbatim.

## Testing

- core/thread + core/kernel/raise: **55F / 7E → 29F / 1E**. Every remaining failure is the `Thread::Backtrace::Location` structured-frame backlog (plus its two `Thread#to_s` and one report-label dependents).
- core/fiber and core/exception are **unchanged against master** (verified by running both spec sets against a master-built binary — identical failure counts).
- Full lib suite passes: **2010 tests**, including five new differential test groups (`raise_keyword_separation_and_message_forms`, `raise_reraise_backtrace_and_cause_cycle`, `thread_raise_async_protocol`, `thread_kill_aborting_status`, `thread_report_on_exception_format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_