### PR TITLE
Complete core/exception specs: C frames in backtraces, top-level report, exit-time thread termination

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1443,6 +1443,80 @@ fn is_transparent_native_frame(globals: &Globals, func_id: FuncId) -> bool {
         || (owner == METHOD_CLASS && matches!(name.as_str(), "call" | "===" | "[]"))
 }
 
+/// The call site of the native frame `cfp`: the file/line of the pc its
+/// Ruby caller saved into `cfp`'s cont-frame slot when it made the call
+/// (see `collect_backtrace` for the slot mechanics). `None` when the
+/// caller isn't a resolvable iseq (invoker boundary, nested native
+/// dispatch).
+pub(crate) fn native_call_site(
+    globals: &Globals,
+    cfp: crate::executor::Cfp,
+) -> Option<(crate::ast::Loc, crate::ast::SourceInfoRef)> {
+    let prev = cfp.prev()?;
+    let iseq = globals.store[prev.lfp().func_id()].is_iseq()?;
+    let info = &globals.store[iseq];
+    let slot = cfp.caller_pc_slot();
+    if slot == 0 || slot % 8 != 0 {
+        return None;
+    }
+    // SAFETY: validated against the bytecode span below.
+    let pc = unsafe { crate::bytecode::BytecodePtr::from_raw(slot as *mut _)? };
+    if !info.contains_pc(pc) {
+        return None;
+    }
+    let idx = info.get_pc_index(Some(pc)).to_usize();
+    Some((info.sourcemap[idx], info.sourceinfo.clone()))
+}
+
+/// Whether a native frame is the raise machinery itself. CRuby's
+/// backtraces never show `Kernel#raise` / `Kernel#fail` — the raised
+/// exception is attributed to the Ruby frame that called them.
+fn is_raise_like(globals: &Globals, func_id: FuncId) -> bool {
+    let info = &globals.store[func_id];
+    info.is_iseq().is_none()
+        && info.name().is_some_and(|n| {
+            let n = n.get_name();
+            n == "raise" || n == "fail"
+        })
+}
+
+/// Attach the native frame `fid` to `err`'s backtrace as the error
+/// leaves a builtin, the way CRuby records C frames: rendered at the
+/// *call site* (`-e:1:in 'Array#fetch'`), both for errors originating
+/// inside the builtin and for errors propagating through it (a block it
+/// invoked raised). Invocation trampolines (`Proc#call`, `Method#call`)
+/// and the raise machinery (`Kernel#raise`) stay invisible, and the
+/// internal scheduler markers are never decorated (they are consumed
+/// before they surface).
+pub(crate) fn push_builtin_trace(
+    vm: &Executor,
+    globals: &Globals,
+    err: &mut MonorubyErr,
+    fid: FuncId,
+) {
+    if err.is_signal_interrupt() || err.is_would_block_interrupt() {
+        return;
+    }
+    if is_transparent_native_frame(globals, fid) {
+        return;
+    }
+    // Never for a fresh raise, and never for a re-raise (`raise e`)
+    // either — CRuby's backtraces never contain the raise machinery.
+    if is_raise_like(globals, fid) {
+        return;
+    }
+    let originating = err.trace().is_empty();
+    match native_call_site(globals, vm.cfp()) {
+        Some((loc, source)) => err.push_trace(loc, source, fid),
+        // With no resolvable call site an originating error keeps the
+        // Ruby caller as its innermost frame (a bare `<internal>` header
+        // would be worse); a propagating error keeps the established
+        // `<internal>` entry.
+        None if !originating => err.push_internal_trace(fid),
+        None => {}
+    }
+}
+
 /// Walk a frame chain from `cfp` outward, rendering CRuby-style
 /// backtrace strings (`file:line:in 'label'`). `level` frames are
 /// skipped first, at most `length` (when given) are collected, and the
@@ -5053,6 +5127,97 @@ mod tests {
         // private default respond_to_missing?.
         run_test_once(
             r##"(a=Kernel.instance_method(:format)==Kernel.instance_method(:sprintf); b=Kernel.method(:format)==Kernel.method(:sprintf); c=Kernel.private_method_defined?(:respond_to_missing?); e2=format("%03d", 7); [a,b,c,e2])"##,
+        );
+    }
+
+    #[test]
+    fn native_frame_in_backtrace() {
+        // An exception raised inside a builtin carries the C frame,
+        // rendered at its call site, as the innermost backtrace entry
+        // (CRuby: `-e:1:in 'Array#fetch'`); the raise machinery itself
+        // never appears — neither for a fresh raise nor a re-raise.
+        run_test(
+            r#"
+            res = []
+            begin
+              [1].fetch(5)
+            rescue => e
+              res << e.backtrace.first.include?("in 'Array#fetch'")
+              res << e.backtrace.any? { |f| f.include?("Kernel#raise") }
+            end
+            begin
+              begin
+                raise ArgumentError, "x"
+              rescue => e2
+                raise e2
+              end
+            rescue => e3
+              res << e3.backtrace.any? { |f| f.include?("Kernel#raise") }
+            end
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn top_level_cause_and_custom_backtrace() {
+        // The implicit `$!` cause chain and an explicitly stored string
+        // backtrace, observed through the exception object (the same
+        // data the top-level report prints).
+        run_test(
+            r#"
+            wrapped = begin
+              begin
+                raise "the cause"
+              rescue
+                raise "wrapped"
+              end
+            rescue => e
+              e
+            end
+            custom = begin
+              raise RuntimeError, "foo", ["/dir/foo.rb:10:in `raising'", "/dir/bar.rb:20:in `caller'"]
+            rescue => e
+              e
+            end
+            [wrapped.message, wrapped.cause&.message, custom.backtrace]
+            "#,
+        );
+    }
+
+    #[test]
+    fn concurrent_require_blocks_second_thread() {
+        // CRuby's per-feature load lock: a second thread requiring a
+        // feature whose body is still executing on another thread
+        // blocks until that load finishes, then returns false.
+        run_test_once(
+            r#"
+            dir = ENV["TMPDIR"] || "/tmp"
+            path = File.join(dir, "mrb_conc_req_#{Process.pid}.rb")
+            File.write(path, <<~RUBY)
+              $conc_order << :body_pre
+              Thread.pass until $conc_t2_started
+              50.times { Thread.pass }
+              $conc_order << :body_post
+            RUBY
+            $conc_order = []
+            $conc_t2_started = false
+            r1 = r2 = t2 = nil
+            t1 = Thread.new do
+              Thread.pass until t2
+              r1 = require(path)
+            end
+            t2 = Thread.new do
+              Thread.pass until $conc_order.include?(:body_pre)
+              $conc_t2_started = true
+              r2 = require(path)
+              $conc_order << :t2_done
+            end
+            t1.join
+            t2.join
+            begin; File.delete(path); rescue; end
+            [r1, r2, $conc_order]
+            "#,
         );
     }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -5154,7 +5154,107 @@ mod tests {
             rescue => e3
               res << e3.backtrace.any? { |f| f.include?("Kernel#raise") }
             end
+            begin
+              [3, 1].sort { |a, b| raise "s" }
+            rescue => e4
+              res << e4.backtrace.any? { |f| f.include?("Array#sort") }
+            end
             res
+            "#,
+        );
+    }
+
+    #[test]
+    fn exit_kills_threads_with_current_fiber_ensure() {
+        // At interpreter exit the remaining threads are killed: the
+        // ensure of each thread's *current* fiber chain runs (to
+        // stderr, invisible to the differential comparison), suspended
+        // fibers are never resumed, and the process still finishes
+        // normally.
+        run_test_once(
+            r#"
+            r = false
+            t = Thread.new do
+              f = Fiber.new do
+                begin
+                  Fiber.yield
+                ensure
+                  STDERR.puts "suspended fiber ensure"
+                end
+              end
+              f.resume
+              begin
+                r = true
+                sleep
+              ensure
+                STDERR.puts "current fiber ensure"
+              end
+            end
+            Thread.pass until r && t.stop?
+            :done
+            "#,
+        );
+    }
+
+    #[test]
+    fn top_level_report_cause_chain_and_custom_backtrace() {
+        // Uncaught exceptions at top level are materialized (running
+        // the implicit `$!` cause chaining) and reported with the
+        // whole #cause chain, each entry with its own backtrace.
+        run_test_error(
+            r#"
+            def raise_cause
+              raise "the cause"
+            end
+            def raise_wrapped
+              raise "wrapped"
+            end
+            begin
+              raise_cause
+            rescue
+              raise_wrapped
+            end
+            "#,
+        );
+        // A stored string backtrace becomes the report's header and
+        // `\tfrom` lines.
+        run_test_error(
+            r#"raise RuntimeError, "foo", ["/dir/foo.rb:10:in 'f'", "/dir/bar.rb:20:in 'g'"]"#,
+        );
+        // A cause carrying its own stored string backtrace.
+        run_test_error(
+            r#"
+            c = RuntimeError.new("the cause")
+            c.set_backtrace(["/dir/cause.rb:1:in 'c'"])
+            raise "wrapped", cause: c
+            "#,
+        );
+    }
+
+    #[test]
+    fn thread_report_prints_cause_and_custom_backtrace() {
+        // The uncaught-exception report (exercised here through
+        // report_on_exception) prints the #cause chain and honours a
+        // stored string backtrace. Output goes to stderr; the
+        // differential comparison only sees the :ok result.
+        run_test_once(
+            r#"
+            chained = begin
+              begin
+                raise "the cause"
+              rescue
+                raise "wrapped"
+              end
+            rescue => e
+              e
+            end
+            custom = RuntimeError.new("custom")
+            custom.set_backtrace(["/dir/foo.rb:10:in 'f'", "/dir/bar.rb:20:in 'g'"])
+            t1 = Thread.new { raise chained }
+            Thread.pass while t1.alive?
+            t2 = Thread.new { raise custom }
+            Thread.pass while t2.alive?
+            :ok
             "#,
         );
     }

--- a/monoruby/src/codegen/jit_module.rs
+++ b/monoruby/src/codegen/jit_module.rs
@@ -279,7 +279,11 @@ pub(super) extern "C" fn handle_error(
             {
                 return ErrorReturn::return_err();
             }
-            vm.push_internal_error_location(meta.func_id());
+            // Render this native frame at its call site (CRuby's C-frame
+            // form); invocation trampolines stay invisible.
+            let mut err = vm.take_error();
+            crate::builtins::kernel::push_builtin_trace(vm, globals, &mut err, meta.func_id());
+            vm.set_error(err);
         }
         _ => unreachable!(),
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -699,9 +699,49 @@ impl Executor {
         file_name: &std::path::Path,
         is_relative: bool,
     ) -> Result<bool> {
-        if let Some((file_body, canonicalized_path)) =
-            globals.require_lib(file_name, is_relative)?
+        let (file_body, canonicalized_path) = loop {
+            match globals.require_lib(file_name, is_relative)? {
+                crate::globals::RequireLoad::Load(body, path) => break (body, path),
+                crate::globals::RequireLoad::AlreadyLoaded(path) => {
+                    // The feature is registered — but its body may still
+                    // be running on another thread (features register
+                    // before executing). CRuby's per-feature load lock:
+                    // block until the first loader finishes, then
+                    // return false; if it failed, retry the load
+                    // ourselves. Parked here, this thread reports
+                    // `stop?` with a backtrace inside `Kernel#require`,
+                    // which the concurrent-require specs poll for.
+                    match globals.loading_features.get(&path) {
+                        Some(&loader)
+                            if loader != crate::scheduler::current_thread(self).id() =>
+                        {
+                            if crate::scheduler::thread_alive_by_id(loader) {
+                                crate::scheduler::sleep(
+                                    self,
+                                    globals,
+                                    Some(std::time::Duration::from_millis(1)),
+                                )?;
+                                continue;
+                            }
+                            // Stale marker: the loader died without
+                            // unwinding (bug path). Clear it and retry
+                            // the load ourselves.
+                            globals.loading_features.remove(&path);
+                            globals.remove_loaded_feature(&path);
+                            continue;
+                        }
+                        // No loader, or a circular require on the
+                        // loading thread itself: already loaded.
+                        _ => return Ok(false),
+                    }
+                }
+            }
+        };
         {
+            let loader = crate::scheduler::current_thread(self).id();
+            globals
+                .loading_features
+                .insert(canonicalized_path.clone(), loader);
             // Find every autoload-registered constant whose `feature`
             // resolves to the file we're about to execute. CRuby's
             // direct-require-of-an-autoload-target case flips those
@@ -720,6 +760,10 @@ impl Executor {
                     .set_autoload_state(*class_id, *name, AutoloadState::Loading);
             }
             let res = self.load_impl(globals, file_body, &canonicalized_path, None);
+            // The lock only needs to cover the body: waiters woken from
+            // here on see either the registered feature (success) or a
+            // retriable miss (failure removed it just below).
+            globals.loading_features.remove(&canonicalized_path);
             match res {
                 Ok(()) => {
                     // require body finished. Any `matching` slot still
@@ -829,8 +873,6 @@ impl Executor {
                 );
             }
             Ok(true)
-        } else {
-            Ok(false)
         }
     }
 

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -20,6 +20,7 @@ pub use error::*;
 pub use gvar::*;
 use prng::*;
 pub use require::{load_file, read_source_file};
+pub(crate) use require::RequireLoad;
 pub use store::*;
 
 pub static WARNING: std::sync::LazyLock<AtomicU8> = std::sync::LazyLock::new(|| AtomicU8::new(0u8));
@@ -204,6 +205,13 @@ pub struct Globals {
     /// dedup tracking. Membership checks scan the array linearly,
     /// which is fine because `require` is not on a hot path.
     pub(crate) loaded_features: Value,
+    /// Features whose `require` body is currently executing, keyed by
+    /// the canonical path registered in `$LOADED_FEATURES`, with the
+    /// loading green thread's object id. A second thread requiring the
+    /// same feature blocks until the entry clears (CRuby's per-feature
+    /// load lock); the id is only compared / liveness-checked, never
+    /// dereferenced, so the map needs no GC marking.
+    pub(crate) loading_features: std::collections::HashMap<std::path::PathBuf, u64>,
     /// cache for Symbol#name (frozen strings keyed by IdentId).
     pub(crate) symbol_names: HashMap<IdentId, Value>,
     /// Dedup table for the Ruby-3.4 "block may be ignored" warning.
@@ -460,6 +468,7 @@ impl Globals {
             load_path: Value::array_empty(),
             random: Box::new(Prng::new()),
             loaded_features,
+            loading_features: std::collections::HashMap::default(),
             symbol_names: HashMap::default(),
             unused_block_warned: std::collections::HashSet::default(),
             // signo runs 1..=32; index by signo directly (slot 0 unused).
@@ -742,6 +751,11 @@ impl Globals {
         // `Kernel#exit!` / `Process.exit!` bypass this by calling
         // `std::process::exit` directly and never returning here.
         let handler_status = executor.run_exit_handlers(self);
+        // CRuby kills the remaining threads *after* the `at_exit`
+        // handlers and *before* the uncaught-exception report: each
+        // runs the ensure clauses of its current fiber chain (never of
+        // suspended fibers) on the way out.
+        crate::scheduler::terminate_all(&mut executor, self);
         let _ = self.flush_stdout();
         #[cfg(any(feature = "profile", feature = "jit-log"))]
         self.show_stats();
@@ -760,6 +774,32 @@ impl Globals {
                 eprintln!("active pages:            {}", alloc.pages_len());
             });
         }
+        // Materialize an uncaught exception into its Ruby object while
+        // the executor is still alive: this runs the implicit `$!`
+        // cause chaining and hangs the object off the returned error
+        // (`original`), so the top-level report can show a custom
+        // string backtrace and walk the `#cause` chain. Control-flow
+        // pseudo-errors and `SystemExit` keep their dedicated handling
+        // in `main::handle_error`. Nothing Ruby-level runs after this
+        // point, so the object can't be collected out from under the
+        // report.
+        let res = match res {
+            Err(err)
+                if !matches!(
+                    err.kind(),
+                    MonorubyErrKind::SystemExit(_)
+                        | MonorubyErrKind::MethodReturn(..)
+                        | MonorubyErrKind::BlockBreak(..)
+                ) =>
+            {
+                executor.set_error(err);
+                let obj = executor.take_ex_obj(self);
+                let err = MonorubyErr::new_from_exception(obj.is_exception().unwrap())
+                    .with_original(obj);
+                Err(err)
+            }
+            other => other,
+        };
         // An exit status chosen by the handlers themselves (a
         // `SystemExit` raised in one, or status 1 after an uncaught
         // handler exception) overrides the script's own. The script's

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -12,6 +12,58 @@ pub(crate) const WOULD_BLOCK_INTERRUPT_MSG: &str = "__monoruby_would_block_inter
 
 use super::*;
 
+/// The string backtrace stored on an exception object (`/backtrace`
+/// ivar: installed by `#set_backtrace` / the third `raise` argument, or
+/// memoized by `Exception#backtrace`). `None` when absent, cleared, or
+/// not an array of strings.
+fn backtrace_strings(store: &Store, obj: Value) -> Option<Vec<String>> {
+    let bt = store.get_ivar(obj, IdentId::get_id("/backtrace"))?;
+    let arr = bt.try_array_ty()?;
+    let v: Vec<String> = arr
+        .iter()
+        .filter_map(|e| e.is_str().map(|s| s.to_string()))
+        .collect();
+    if v.is_empty() { None } else { Some(v) }
+}
+
+/// Print a report from pre-rendered backtrace strings: the first entry
+/// is the header location, the rest `\tfrom` lines (honouring
+/// `--backtrace-limit=N`).
+fn show_string_backtrace(bt: &[String], error_message: &str) {
+    eprintln!("{}: {error_message}", bt[0]);
+    let rest = &bt[1..];
+    let limit = crate::globals::backtrace_limit().unwrap_or(usize::MAX);
+    for (i, line) in rest.iter().enumerate() {
+        if i >= limit {
+            eprintln!("\t ... {} levels...", rest.len() - i);
+            break;
+        }
+        eprintln!("\tfrom {line}");
+    }
+}
+
+/// Print `trace`'s caller frames (everything after the header entry) as
+/// `\tfrom <location>` lines, honouring `--backtrace-limit=N`: after N
+/// frames the rest collapse into `\t ... K levels...`.
+fn show_trace_rest(store: &Store, trace: &[(Option<(Loc, SourceInfoRef)>, Option<FuncId>)]) {
+    if trace.len() <= 1 {
+        return;
+    }
+    let rest = &trace[1..];
+    let limit = crate::globals::backtrace_limit().unwrap_or(usize::MAX);
+    for (i, (source_loc, func_id)) in rest.iter().enumerate() {
+        if i >= limit {
+            eprintln!("\t ... {} levels...", rest.len() - i);
+            break;
+        }
+        if let Some((loc, source)) = source_loc {
+            eprintln!("\tfrom {}", store.location(*func_id, source, *loc));
+        } else {
+            eprintln!("\tfrom {}", store.internal_location(func_id.unwrap()))
+        }
+    }
+}
+
 ///
 /// Exception information which is stored in *Executor*.
 ///
@@ -175,28 +227,61 @@ impl MonorubyErr {
     }
 
     pub fn show_error_message_and_all_loc(&self, store: &Store) {
-        self.show_error_message_and_loc(store);
-        if self.trace.len() > 1 {
-            // CRuby prints each caller frame as `\tfrom <location>`,
-            // honouring `--backtrace-limit=N`: after N frames the rest
-            // collapse into `\t ... K levels...`.
-            let rest = &self.trace[1..];
-            let limit = crate::globals::backtrace_limit().unwrap_or(usize::MAX);
-            for (i, (source_loc, func_id)) in rest.iter().enumerate() {
-                if i >= limit {
-                    eprintln!("\t ... {} levels...", rest.len() - i);
-                    break;
-                }
-                if let Some((loc, source)) = source_loc {
-                    eprintln!("\tfrom {}", store.location(func_id.clone(), source, *loc));
-                } else {
-                    eprintln!("\tfrom {}", store.internal_location(func_id.unwrap()))
-                }
-            }
+        // A string backtrace installed via `raise ..., bt` /
+        // `#set_backtrace` replaces the runtime capture in CRuby's
+        // report: its first entry becomes the header location.
+        if let Some(obj) = self.original
+            && let Some(bt) = backtrace_strings(store, obj)
+        {
+            show_string_backtrace(&bt, &self.get_error_message(store));
+        } else {
+            self.show_error_message_and_loc(store);
+            show_trace_rest(store, &self.trace);
+        }
+        // CRuby follows the report with the exception's whole `#cause`
+        // chain, each entry with its own backtrace. The chain only
+        // exists on a materialized exception object (`original` — set
+        // for every uncaught exception at top level).
+        if let Some(obj) = self.original {
+            self.show_cause_chain(store, obj);
         }
     }
 
-    pub fn show_error_message_and_loc(&self, store: &Store) -> bool {
+    /// Print the `#cause` chain hanging off `obj` (already-printed
+    /// exception), one `header + from-lines` block per cause.
+    fn show_cause_chain(&self, store: &Store, obj: Value) {
+        let cause_id = IdentId::get_id("/cause");
+        let mut seen = vec![obj.id()];
+        let mut cur = obj;
+        while let Some(cause) = store.get_ivar(cur, cause_id) {
+            if cause.is_nil() || seen.contains(&cause.id()) {
+                break;
+            }
+            seen.push(cause.id());
+            let Some(inner) = cause.is_exception() else {
+                break;
+            };
+            let msg = format!("{} ({})", inner.message(), cause.get_real_class_name(store));
+            if let Some(bt) = backtrace_strings(store, cause) {
+                show_string_backtrace(&bt, &msg);
+            } else {
+                let trace = inner.trace();
+                match trace.first() {
+                    Some((Some((loc, source)), func_id)) => {
+                        eprintln!("{}: {msg}", store.location(*func_id, source, *loc));
+                    }
+                    Some((None, Some(fid))) => {
+                        eprintln!("{}: {msg}", store.internal_location(*fid));
+                    }
+                    _ => eprintln!("{msg}"),
+                }
+                show_trace_rest(store, trace);
+            }
+            cur = cause;
+        }
+    }
+
+    fn show_error_message_and_loc(&self, store: &Store) -> bool {
         let mut loc_flag = false;
         if let Some((source_loc, func_id)) = self.trace.first() {
             let error_message = self.get_error_message(store);

--- a/monoruby/src/globals/require.rs
+++ b/monoruby/src/globals/require.rs
@@ -2,6 +2,19 @@ use std::os::unix::ffi::OsStrExt;
 
 use super::*;
 
+/// What `Globals::require_lib` resolved a `require` argument to.
+pub(crate) enum RequireLoad {
+    /// Not yet loaded: execute this body, registered in
+    /// `$LOADED_FEATURES` under the given canonical path.
+    Load(Vec<u8>, std::path::PathBuf),
+    /// Already present in `$LOADED_FEATURES` under this path — which
+    /// includes a load still *in progress* on another thread (features
+    /// register before their body runs); `Executor::require` uses the
+    /// path to consult the loading registry and block until the first
+    /// loader finishes (CRuby's per-feature load lock).
+    AlreadyLoaded(std::path::PathBuf),
+}
+
 impl Globals {
     ///
     /// Load external library.
@@ -10,7 +23,7 @@ impl Globals {
         &mut self,
         file_name: &std::path::Path,
         is_relative: bool,
-    ) -> Result<Option<(Vec<u8>, std::path::PathBuf)>> {
+    ) -> Result<RequireLoad> {
         let path_str = file_name.to_string_lossy();
 
         // Absolute path: try to load directly.
@@ -20,14 +33,14 @@ impl Globals {
             if file.extension().is_none() {
                 file.set_extension("rb");
                 if self.is_feature_loaded(&file) {
-                    return Ok(None);
+                    return Ok(RequireLoad::AlreadyLoaded(file));
                 }
                 file.set_extension("so");
                 if self.is_feature_loaded(&file) {
-                    return Ok(None);
+                    return Ok(RequireLoad::AlreadyLoaded(file));
                 }
             } else if self.is_feature_loaded(&file) {
-                return Ok(None);
+                return Ok(RequireLoad::AlreadyLoaded(file));
             }
             // Try the file with its given extension first.
             if file_name.is_file() {
@@ -80,11 +93,11 @@ impl Globals {
             let mut file = PathBuf::from(file_name);
             file.set_extension("rb");
             if self.is_feature_loaded(&file) {
-                return Ok(None);
+                return Ok(RequireLoad::AlreadyLoaded(file));
             }
             file.set_extension("so");
             if self.is_feature_loaded(&file) {
-                return Ok(None);
+                return Ok(RequireLoad::AlreadyLoaded(file));
             }
 
             if let Some(file) = self.search_lib(file_name) {
@@ -195,10 +208,7 @@ impl Globals {
     ///
     /// When an error occured in loading, returns Err.
     ///
-    fn require_lib_file(
-        &mut self,
-        path: std::path::PathBuf,
-    ) -> Result<Option<(Vec<u8>, std::path::PathBuf)>> {
+    fn require_lib_file(&mut self, path: std::path::PathBuf) -> Result<RequireLoad> {
         // CRuby stores the path as passed to `require`, not its
         // symlink-resolved form. `Path::canonicalize` resolves every
         // symlink (e.g. on macOS where `/tmp` is a symlink to
@@ -214,7 +224,7 @@ impl Globals {
             &std::path::absolute(&path).unwrap_or_else(|_| path.clone()),
         );
         if self.is_feature_loaded(&canonicalized_path) {
-            return Ok(None);
+            return Ok(RequireLoad::AlreadyLoaded(canonicalized_path));
         }
         let (file_body, _resolved) = if let Some(b"so") = canonicalized_path.extension().map(|s| s.as_bytes()) {
             let monoruby_lib = install_root().join("lib");
@@ -242,7 +252,7 @@ impl Globals {
         // match the entry we added or the cleanup silently misses (on
         // macOS `/var/folders/..`→`/private/var/folders/..` symlinks the
         // two diverge, leaving a failed require un-retriable).
-        Ok(Some((file_body, canonicalized_path)))
+        Ok(RequireLoad::Load(file_body, canonicalized_path))
     }
 
     ///

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -281,6 +281,18 @@ pub(crate) fn thread_list(vm: &mut Executor) -> Vec<Value> {
     SCHEDULER.with(|s| s.borrow().threads.clone())
 }
 
+/// Whether a live (not dead) thread with the given object id exists.
+/// Used by the `require` load lock to detect a stale loading marker
+/// left by a thread that died without unwinding.
+pub(crate) fn thread_alive_by_id(id: u64) -> bool {
+    SCHEDULER.with(|s| {
+        s.borrow()
+            .threads
+            .iter()
+            .any(|t| t.id() == id && !t.as_thread_inner().is_dead())
+    })
+}
+
 /// Whether any *other* live thread exists (i.e. whether blocking
 /// operations must go through the scheduler instead of really blocking).
 pub(crate) fn has_other_live_threads() -> bool {
@@ -423,6 +435,61 @@ pub(crate) fn sleep(
         park_switch(vm, globals, cur)?;
     }
     Ok(start.elapsed())
+}
+
+/// Terminate every live thread except main at process exit, the way
+/// CRuby's `rb_thread_terminate_all` does after the `at_exit` handlers:
+/// each thread is killed — an unrescuable unwind that runs the ensure
+/// clauses of its *current* fiber chain only; suspended fibers are
+/// never resumed — and the scheduler runs until they have all unwound.
+/// `handle_interrupt` masks are bypassed: the process is ending, so
+/// there is no later delivery point to defer to.
+pub(crate) fn terminate_all(vm: &mut Executor, globals: &mut Globals) {
+    ensure_main(vm);
+    if !is_current_main() {
+        return;
+    }
+    let targets: Vec<Value> = SCHEDULER.with(|s| {
+        let s = s.borrow();
+        s.threads
+            .iter()
+            .copied()
+            .filter(|t| Some(*t) != s.main && !t.as_thread_inner().is_dead())
+            .collect()
+    });
+    if targets.is_empty() {
+        return;
+    }
+    for mut t in targets.iter().copied() {
+        t.as_thread_inner_mut()
+            .pending
+            .push_back(PendingInterrupt::Kill);
+    }
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        for mut t in targets.iter().copied() {
+            let inner = t.as_thread_inner_mut();
+            if matches!(
+                inner.state(),
+                ThreadState::Sleeping | ThreadState::Joining | ThreadState::IoWaiting
+            ) {
+                inner.state = ThreadState::Runnable;
+                s.ready.push_back(t);
+            }
+        }
+    });
+    // Bounded: a thread that refuses to die (spinning in its ensure,
+    // never reaching a delivery point) must not wedge the process exit.
+    for _ in 0..10_000 {
+        if targets.iter().all(|t| t.as_thread_inner().is_dead()) {
+            break;
+        }
+        // An error delivered to the main thread here has nowhere to go —
+        // the script is already over.
+        if pass(vm, globals).is_err() {
+            let _ = vm.take_error();
+        }
+    }
 }
 
 /// `Thread.pass`: give every currently runnable thread a chance to run.

--- a/monoruby_attr/src/lib.rs
+++ b/monoruby_attr/src/lib.rs
@@ -30,13 +30,13 @@ pub fn monoruby_builtin(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     if let MonorubyErrKind::MethodReturn(val, target_lfp) = err.kind() && lfp == *target_lfp {
                         return Some(*val);
                     }
-                    // Only add builtin trace for errors propagating through
-                    // this function (trace already has entries), not for errors
-                    // originating here like Kernel#raise (trace is empty).
-                    if !err.trace().is_empty() {
-                        let fid = lfp.func_id();
-                        err.push_internal_trace(fid);
-                    }
+                    // Attach this builtin's frame to the backtrace, rendered
+                    // at its call site the way CRuby records C frames — for
+                    // errors originating here (`Array#fetch` raising
+                    // IndexError) and errors propagating through (a block
+                    // this builtin invoked raised). The helper hides the
+                    // raise machinery and invocation trampolines.
+                    crate::builtins::kernel::push_builtin_trace(vm, globals, &mut err, lfp.func_id());
                     vm.set_error(err);
                     None
                 }


### PR DESCRIPTION
## Summary

Fixes all five remaining core/exception failures — **the suite is now green (0 failures / 0 errors)** — plus a concurrent-require hang that made the full core/kernel suite unrunnable.

## Native (C) frames in exception backtraces

- An error leaving a builtin now records the builtin's frame, rendered at its **call site**, the way CRuby records C frames (`-e:1:in 'Array#fetch': index 5 outside of array bounds`), via a shared `push_builtin_trace` helper used by both the `#[monoruby_builtin]` trampoline and the VM unwinding path (`handle_error`'s builtin branch).
- The raise machinery (`Kernel#raise` / `#fail`) never appears — neither for a fresh raise nor a re-raise (`raise e`); `Proc#call` / `Method#call` invocation trampolines stay invisible; the internal scheduler markers are never decorated.
- An uncaught `Interrupt` at a parked builtin now reports the interrupted C frame plus the `from -e:1:in '<main>'` line, satisfying `interrupt_spec.rb`'s "shows the backtrace and has a signaled exit status".

## Top-level exception report

- An uncaught exception is materialized into its Ruby object while the executor is still alive (running the implicit `$!` cause chaining), and the report then prints the whole **`#cause` chain**, each entry with its own backtrace — CRuby's format:
  ```
  file:5:in 'Object#raise_wrapped': wrapped (RuntimeError)
  	from file:10:in '<main>'
  file:2:in 'Object#raise_cause': the cause (RuntimeError)
  	from file:8:in '<main>'
  ```
- A custom string backtrace (`raise Klass, msg, bt` / `#set_backtrace`) replaces the runtime capture in the report: its first entry becomes the header location, the rest render as `\tfrom` lines.

## Exit-time thread termination (`scheduler::terminate_all`)

After the `at_exit` handlers and before the uncaught-exception report, every live thread is killed like CRuby's `rb_thread_terminate_all`: the unrescuable kill unwind runs the ensure clauses of each thread's **current fiber chain only** — suspended fibers are never resumed. Both `thread_fiber_ensure*.rb` fixtures now print exactly `current fiber ensure` and exit 0.

## Concurrent require — CRuby's per-feature load lock

While verifying, the full core/kernel suite turned out to **hang forever** in the `Kernel#require (concurrently)` specs (pre-existing on master; stale spec processes were left spinning at ~100% CPU because `timeout` only kills the mspec wrapper). Implemented the lock:

- `require_lib` now distinguishes "load this body" from "already registered" (`RequireLoad` enum), and `Executor::require` blocks a second thread requiring a feature whose body is still executing on another thread until that load finishes (then returns `false`), retrying the load itself if the first loader failed. The parked waiter reports `stop?` with a `Kernel#require` backtrace, which the specs poll for.
- The full core/kernel suite now completes (~7s, 2231 examples), and all four "(concurrently)" specs pass.

## ruby/spec results

| Suite | master | this PR |
|---|---|---|
| core/exception | 5 failures | **0 failures / 0 errors** |
| core/kernel (full) | hangs forever | completes: 144 failures / 87 errors |
| core/thread | 1 failure (known, Enumerator-bound) | 1 failure (unchanged) |
| core/kernel caller/warn/raise/eval subset | 18 failures / 8 errors | unchanged |
| core/io | 27 failures / 15 errors | unchanged |
| core/file | 27 failures / 14 errors | unchanged |

Known remaining difference: errors raised by VM-inlined operators (e.g. `1/0` → `Integer#/`) still attribute to the caller frame — only builtin-function frames are recorded so far.

## Testing

- `cargo test` full suite green (2018 lib tests + integration tests, exit 0).
- New differential tests (vs CRuby): `native_frame_in_backtrace` (C frame present, raise machinery absent, re-raise case), `top_level_cause_and_custom_backtrace`, `concurrent_require_blocks_second_thread`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_