### PR TITLE
Match CRuby's command-line warning gating for flip-flop and $;/$,

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1753,7 +1753,10 @@ fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let gvar_id = IdentId::get_id("$,");
         if let Some(v) = globals.get_gvar(gvar_id) {
             if !v.is_nil() {
-                vm.ruby_warn(globals, "warning: $, is set to non-nil value")?;
+                // `:deprecated`-category (silent unless
+                // `Warning[:deprecated]`), matching CRuby — see the
+                // `$;` warning in `String#split`.
+                vm.warn_deprecated(globals, "warning: $, is set to non-nil value")?;
             }
         }
     }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -2055,10 +2055,13 @@ fn split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         Some(v) if !v.is_nil() => resolve(vm, globals, v)?,
         _ => match globals.get_gvar(IdentId::get_id("$;")) {
             Some(fs) if !fs.is_nil() => {
-                // CRuby emits this as a `:deprecated` category warning
-                // that fires regardless of `$VERBOSE` (ruby/spec relies
-                // on it under `$VERBOSE = false`).
-                crate::value::emit_verbose_warning(vm, globals, "$; is set to non-nil value")?;
+                // CRuby emits this as a `:deprecated`-category warning:
+                // silent unless `Warning[:deprecated]` is enabled (mspec
+                // turns it on, so `split_spec`'s `should complain` still
+                // catches it; a fresh command-line subprocess like
+                // `-naF:` leaves it off, so autosplit stays quiet). Not
+                // gated on `$VERBOSE`.
+                vm.warn_deprecated(globals, "warning: $; is set to non-nil value")?;
                 resolve(vm, globals, fs)?
             }
             _ => SepKind::Awk,

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -690,6 +690,34 @@ impl Executor {
         Ok(())
     }
 
+    /// Emit a `:deprecated`-category warning. `msg` is printed verbatim
+    /// (include any `warning: ` prefix). Routed through
+    /// `Kernel#__warn_deprecated` so CRuby's gating applies: silent
+    /// unless `Warning[:deprecated]` is enabled — mspec turns it on, so
+    /// `should complain` still sees it, while a fresh command-line
+    /// subprocess (e.g. `-naF:` autosplit) leaves it off and stays quiet.
+    /// Silent during bootstrap, before the helper is defined.
+    pub(crate) fn warn_deprecated(&mut self, globals: &mut Globals, msg: &str) -> Result<()> {
+        let main = globals.main_object;
+        if globals
+            .store
+            .check_method(main, IdentId::get_id("__warn_deprecated"))
+            .is_none()
+        {
+            return Ok(());
+        }
+        let msg_val = Value::string(msg.to_string());
+        self.invoke_method_inner(
+            globals,
+            IdentId::get_id("__warn_deprecated"),
+            main,
+            &[msg_val],
+            None,
+            None,
+        )?;
+        Ok(())
+    }
+
     ///
     /// The `"file:line"` of the nearest Ruby (iseq) caller of the current
     /// native builtin frame.

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -905,6 +905,12 @@ fn main() {
         );
     }
 
+    // `-e`: mark the main script so the parser suppresses the flip-flop /
+    // condition-literal warnings for it (prism's `COMMAND_LINE_E` gate).
+    if !opts.exec.is_empty() {
+        parser::set_cli_e_script(path.clone());
+    }
+
     // Ruby prelude synthesized from the remaining switches; runs inside
     // the interpreter before `-r` requires and the script itself.
     let mut prelude = String::new();

--- a/monoruby/src/parser/mod.rs
+++ b/monoruby/src/parser/mod.rs
@@ -69,6 +69,33 @@ pub(crate) fn take_cli_source_encoding(path: &std::path::Path) -> Option<String>
     }
 }
 
+/// Set for the main script when its source came from `-e` (prism's
+/// `PM_OPTIONS_COMMAND_LINE_E`). Like the loop wrap and source encoding
+/// above, it is armed for a single path (the `-e` script, which parses
+/// as `"-e"`) and consumed on first match. CRuby suppresses the
+/// "integer literal in flip-flop" and "regex literal in condition"
+/// parse warnings for `-e` scripts — those awk/sed-style conditions are
+/// idiomatic on the command line — but still emits them for files,
+/// `require`s, and `eval`s, so the flag must not leak past the main
+/// script.
+static CLI_E_SCRIPT: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Arm the `-e`-script marker for the main script at `path`.
+pub fn set_cli_e_script(path: PathBuf) {
+    *CLI_E_SCRIPT.lock().unwrap() = Some(path);
+}
+
+/// Consume the `-e`-script marker if `path` is the main script.
+pub(crate) fn take_cli_e_script(path: &std::path::Path) -> bool {
+    let mut guard = CLI_E_SCRIPT.lock().unwrap();
+    if matches!(&*guard, Some(p) if p == path) {
+        *guard = None;
+        true
+    } else {
+        false
+    }
+}
+
 /// Process-wide default for the `frozen_string_literal` pragma, set by
 /// the `--enable/--disable-frozen-string-literal` command-line flags.
 /// A per-file magic comment still wins. -1 = unset, 0 = false, 1 = true.

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -309,6 +309,11 @@ fn try_prism_inner(
     let cli_loop_wrap = super::take_cli_loop_wrap(&path);
     // `-K`: default source encoding for the main script.
     let cli_source_encoding = super::take_cli_source_encoding(&path);
+    // `-e`: prism's `PM_OPTIONS_COMMAND_LINE_E` suppresses the flip-flop /
+    // condition-literal parse warnings for command-line scripts. The
+    // vendored ruby-prism wrapper doesn't expose the `command_line`
+    // option, so we replicate the gate here when forwarding warnings.
+    let cli_e_script = super::take_cli_e_script(&path);
 
     let result = match options.as_ref() {
         Some(opts) => prism::parse_with_options(code, opts),
@@ -381,6 +386,15 @@ fn try_prism_inner(
         .warnings()
         .filter_map(|w| {
             let msg = w.message();
+            // `-e` scripts suppress the flip-flop / condition-literal
+            // warnings, exactly like CRuby's prism `COMMAND_LINE_E` gate
+            // (these are the idiomatic awk/sed `-ne`/`-pe` conditions).
+            if cli_e_script
+                && (msg == "integer literal in flip-flop"
+                    || msg == "regex literal in condition")
+            {
+                return None;
+            }
             let verbose_only = if msg == "END in method; use at_exit"
                 || msg == "integer literal in flip-flop"
                 || msg == "regex literal in condition"


### PR DESCRIPTION
## Summary

Fixes two independent warning-parity bugs that surfaced as noise in the ruby/spec `command_line` suite (`dash_e_spec`, `dash_upper_f_spec`, …): monoruby printed warnings CRuby suppresses in those contexts.

### 1. `integer literal in flip-flop` / `regex literal in condition` under `-e`

prism suppresses these two parse warnings for `-e` scripts (its `PM_OPTIONS_COMMAND_LINE_E` gate) — awk/sed-style `-ne`/`-pe` conditions like `2..3` are idiomatic on the command line — while still emitting them for files, `require`s, and `eval`s.

| context | CRuby | monoruby (before) |
|---|---|---|
| file / eval / require | warns | warns ✓ |
| `-e` script | **suppressed** | warns ✗ |

The vendored ruby-prism wrapper doesn't expose the `command_line` option, so monoruby forwarded these for every `-e` script. This replicates the gate on the monoruby side: arm a per-path `-e` marker (parallel to the existing `-n`/`-p` loop-wrap and `-K` source-encoding markers in `parser/mod.rs`) and drop those two warnings when it's set. Files/`eval`/`require` are unaffected.

### 2. `$; is set to non-nil value` (`String#split`) and `$, …` (`Array#join`)

These are `:deprecated`-category warnings in CRuby — silent unless `Warning[:deprecated]` is enabled (**not** gated on `$VERBOSE`). mspec turns `Warning[:deprecated]` on globally (`utils/warnings.rb`), so `split_spec`/`join_spec`'s `should complain` sees them; but `ruby_exe` subprocesses (e.g. `-naF:` autosplit) run fresh with it off, so CRuby stays quiet there.

monoruby emitted both **unconditionally**, spewing warnings in autosplit subprocesses. Both now route through a new `Executor::warn_deprecated` helper (→ `Kernel#__warn_deprecated` → `warn(category: :deprecated)`), matching CRuby's gating in both directions.

## Verification (vs CRuby 4.0.5, arm64-darwin)

- ruby/spec `command_line`: **32 files, 169 examples, 0 failures**
- ruby/spec `core/string/split_spec` (60 examples) + `core/array/join_spec` (20 examples): **0 failures** — the `should complain` tests still fire under mspec's `Warning[:deprecated]`
- `-e`/file/`eval` flip-flop + default-verbose `-naF:` autosplit now match CRuby exactly (stderr and stdout)
- monoruby unit tests: `predefined_gvar` + `command_line` (41) and split/join lib tests (26) pass; `parse_time_warnings` (eval-context flip-flop) still warns, confirming suppression is scoped to the `-e` main script

## Files

`parser/mod.rs`, `parser/prism_backend.rs`, `main.rs` (fix 1); `executor/op.rs`, `builtins/string.rs`, `builtins/array.rs` (fix 2). All arch-neutral — no codegen changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)