### PR TITLE
Add UncaughtThrowError#value

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -72,6 +72,7 @@ pub(super) fn init(globals: &mut Globals) {
         globals.define_builtin_exception_class("ArgumentError", ARGUMENTS_ERROR_CLASS, standarderr);
     let uncaught_throw = globals.define_class("UncaughtThrowError", argerr, OBJECT_CLASS);
     globals.define_builtin_func(uncaught_throw.id(), "tag", uncaught_throw_tag, 0);
+    globals.define_builtin_func(uncaught_throw.id(), "value", uncaught_throw_value, 0);
     globals.define_class("EncodingError", standarderr, OBJECT_CLASS);
     globals.define_builtin_exception_class("FiberError", FIBER_ERROR_CLASS, standarderr);
     let ioerr = globals.define_builtin_exception_class("IOError", IO_ERROR_CLASS, standarderr);
@@ -184,6 +185,21 @@ fn uncaught_throw_tag(
     Ok(globals
         .store
         .get_ivar(lfp.self_val(), IdentId::get_id("/tag"))
+        .unwrap_or_default())
+}
+
+/// `UncaughtThrowError#value` — the second argument passed to the
+/// uncaught `throw` (nil when omitted).
+#[monoruby_builtin]
+fn uncaught_throw_value(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    Ok(globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("/value"))
         .unwrap_or_default())
 }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3566,10 +3566,15 @@ fn throw_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
             .store
             .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("UncaughtThrowError"))
         {
-            let mut err = MonorubyErr::new(MonorubyErrKind::Other(klass.as_class_id()), msg);
-            // Surfaced as `UncaughtThrowError#tag`.
-            err.payload = Some((tag, "tag"));
-            return Err(err);
+            let class_id = klass.as_class_id();
+            // Build the exception object eagerly so it can carry both the
+            // tag and the thrown value (a single `payload` slot can't hold
+            // two). Surfaced as `UncaughtThrowError#tag` / `#value`; the
+            // `original` object keeps its ivars through `take_ex_obj`.
+            let exc = Value::new_exception_from(msg.clone(), class_id);
+            globals.store.set_ivar(exc, IdentId::get_id("/tag"), tag)?;
+            globals.store.set_ivar(exc, IdentId::get_id("/value"), value)?;
+            return Err(MonorubyErr::new(MonorubyErrKind::Other(class_id), msg).with_original(exc));
         }
         return Err(MonorubyErr::argumenterr(msg));
     }
@@ -5608,6 +5613,31 @@ mod tests {
           throw :nope
         rescue UncaughtThrowError => e
           [e.is_a?(ArgumentError), e.message]
+        end
+        "##,
+            // `#tag` / `#value` carry the throw arguments (value is nil
+            // when omitted).
+            r##"
+        begin
+          throw :nope, [1, 2]
+        rescue UncaughtThrowError => e
+          [e.tag, e.value]
+        end
+        "##,
+            r##"
+        begin
+          throw :nope
+        rescue UncaughtThrowError => e
+          e.value
+        end
+        "##,
+            // The tag object's identity is preserved.
+            r##"
+        o = Object.new
+        begin
+          throw o, 9
+        rescue UncaughtThrowError => e
+          [e.tag.equal?(o), e.value]
         end
         "##,
         ]);


### PR DESCRIPTION
## Summary

Adds `UncaughtThrowError#value`, surfacing `Kernel#throw`'s optional second argument (CRuby parity). Previously `#value` raised `NoMethodError` because the uncaught throw carried only the tag.

> Note: this was originally committed to the #1030 branch, but that PR was **squash-merged with only the refactor commit** — the `#value` commit (`2a8ad394`) was dropped. This re-lands it on top of the merged master.

## Changes
- `throw_` builds the `UncaughtThrowError` object eagerly (mirroring `no_method_error_with_args`) so it can hold both `/tag` and `/value` ivars via `with_original`; a single `payload` slot can't carry two values.
- Adds and registers the `#value` accessor (nil when the second `throw` arg is omitted). `#tag` now reads the eagerly-set ivar.
- Extends `catch_throw_uncaught` with `#tag`/`#value`/tag-identity cases.

## Testing
- `cargo build` clean; `cargo nextest run` — `catch_throw_uncaught`, `kernel_uncaught_throw` pass.
- CRuby parity verified: `#tag`/`#value`/`#message`, rescuability (`is_a?(ArgumentError)`), tag identity (`.equal?`), value-omitted → nil, and caught throws unaffected.
- Known cosmetic diff (pre-existing, out of scope): `instance_methods(false)` still omits `:to_s` — monoruby uses the inherited `Exception#to_s`, which produces identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
