### PR TITLE
core/kernel spec recovery: trace_var, public_method, caller/rand/Rational/Float/Array/String edges (144F/85E → 97F/54E)

### DIFF
--- a/monoruby/builtins/kernel.rb
+++ b/monoruby/builtins/kernel.rb
@@ -295,6 +295,14 @@ module Kernel
   end
 end
 
+# Fired by the runtime for `trace_var` String commands. `eval` reads
+# its caller's bytecode context, so it must be entered from a real Ruby
+# frame — the raw gvar-store runtime helper has no call-site pc to hang
+# the eval on.
+def __gvar_trace_eval(cmd)
+  eval(cmd)
+end
+
 # `caller` shares `caller_locations`' argument handling (Array#[] edge
 # semantics, Range forms, ArgumentError on negatives, #to_int coercion)
 # by going through the same `Thread::Backtrace.__slice` helper over the

--- a/monoruby/builtins/kernel.rb
+++ b/monoruby/builtins/kernel.rb
@@ -192,15 +192,35 @@ module Kernel
   end
 
   def String(arg)
-    return arg if arg.is_a?(::String)
-    if arg.respond_to?(:to_str)
+    # A BasicObject lacks #is_a?/#respond_to? entirely; every probe on
+    # `arg` is guarded so such objects fall through to the TypeError.
+    return arg if (arg.is_a?(::String) rescue false)
+    if (arg.respond_to?(:to_str) rescue false)
       result = arg.to_str
       return result if result.is_a?(::String)
       raise TypeError, "can't convert #{arg.class} to String (#{arg.class}#to_str gives #{result.class})"
     end
-    result = arg.to_s
+    # CRuby's conversion honours a #respond_to? override and reports
+    # TypeError (not NoMethodError) when #to_s is missing entirely
+    # (e.g. on a BasicObject, where even #respond_to? is absent).
+    klass = begin
+      arg.class
+    rescue ::NoMethodError
+      ::Object
+    end
+    responds = begin
+      arg.respond_to?(:to_s)
+    rescue ::NoMethodError
+      false
+    end
+    raise TypeError, "can't convert #{klass} into String" unless responds
+    result = begin
+      arg.to_s
+    rescue ::NoMethodError
+      raise TypeError, "can't convert #{klass} into String"
+    end
     unless result.is_a?(::String)
-      raise TypeError, "can't convert #{arg.class} to String (#{arg.class}#to_s gives #{result.class})"
+      raise TypeError, "can't convert #{klass} to String (#{klass}#to_s gives #{result.class})"
     end
     result
   end
@@ -299,6 +319,42 @@ def caller_locations(start = 1, length = nil)
   # `Thread::Backtrace.__slice` implements the shared (start), (start,
   # length) and (range) argument forms with Array#[] edge semantics.
   Thread::Backtrace.__slice(locs, length.nil? ? [start] : [start, length])
+end
+
+module Kernel
+  module_function
+
+  # `Kernel#select` is `IO.select` (CRuby defines it on Kernel too).
+  def select(*args)
+    IO.select(*args)
+  end
+
+  # CRuby defines Kernel#syscall on platforms that support it and makes
+  # it raise NotImplementedError elsewhere; monoruby never implements
+  # raw syscalls, but the method must exist (and be a private instance
+  # method / public module function).
+  def syscall(*)
+    raise ::NotImplementedError, "syscall() function is unimplemented on this machine"
+  end
+
+  # Console-input conveniences over ARGF (like Kernel#gets).
+  def readline(*args)
+    ARGF.readline(*args)
+  end
+
+  def readlines(*args)
+    ARGF.readlines(*args)
+  end
+end
+
+module Kernel
+  # `fail` is a true alias of `raise`: ruby/spec compares the
+  # UnboundMethod/Method objects for equality.
+  alias fail raise
+  private :fail
+  class << self
+    alias fail raise
+  end
 end
 
 module Kernel

--- a/monoruby/builtins/kernel.rb
+++ b/monoruby/builtins/kernel.rb
@@ -275,6 +275,20 @@ module Kernel
   end
 end
 
+# `caller` shares `caller_locations`' argument handling (Array#[] edge
+# semantics, Range forms, ArgumentError on negatives, #to_int coercion)
+# by going through the same `Thread::Backtrace.__slice` helper over the
+# structured frames' pre-rendered strings. Defined as a module function
+# so `Kernel.caller` gets the same semantics.
+module Kernel
+  def caller(start = 1, length = nil)
+    frames = Kernel.__caller_frames(1)
+    strs = frames.map { |f| f[0] }
+    Thread::Backtrace.__slice(strs, length.nil? ? [start] : [start, length])
+  end
+  module_function :caller
+end
+
 # `caller_locations` builds `Thread::Backtrace::Location`s from the
 # structured native frames (`Kernel.__caller_frames`), which carry the
 # load-time canonical path alongside the display path/label — string

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -2771,23 +2771,200 @@ fn rational_from_value(vm: &mut Executor, globals: &mut Globals, v: Value) -> Re
             }
             Ok(Value::rational_from_inner(RationalInner::from_f64(f)))
         }
+        // Strings go through the strict parser (`Rational("abc")` is an
+        // ArgumentError, not `String#to_r`'s permissive 0).
+        RV::String(b) => Ok(Value::rational_from_inner(rational_from_str(&b.to_str()?)?)),
         _ => {
-            // CRuby nurat_convert: try #to_r, then #to_int.
+            // CRuby nurat_convert: #to_r when present — a non-Rational
+            // result is an immediate TypeError, never a fallthrough —
+            // and #to_int only for objects with no #to_r at all. An
+            // exception raised inside #to_int surfaces as the TypeError.
             if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_r")) {
                 let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
                 if result.try_rational().is_some() {
                     return Ok(result);
                 }
+                return Err(bad_to_r_error(globals, v, result));
             }
             if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_int")) {
-                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
-                if let Some(i) = result.try_fixnum() {
+                if let Ok(result) = vm.invoke_func_inner(globals, func_id, v, &[], None, None)
+                    && let Some(i) = result.try_fixnum()
+                {
                     return Ok(Value::rational_from_inner(RationalInner::new(i, 1)));
                 }
+                return Err(rational_type_error(globals, v));
             }
             Err(rational_type_error(globals, v))
         }
     }
+}
+
+/// CRuby's rational-literal parser, shared by `Rational(String)`
+/// (strict) and `String#to_r` (permissive): optional whitespace,
+/// `[+-]? (digits[_digits]* (.digits?)? | .digits) ([eE][+-]?digits)?`,
+/// optionally `/` and an unsigned number of the same form. In strict
+/// mode any trailing garbage rejects the whole string (the caller
+/// raises ArgumentError); in permissive mode the longest valid prefix
+/// wins, backtracking over a half-consumed `/`, `.` or exponent
+/// (`"1/x".to_r == 1r`). Returns the unnormalized pair; a zero
+/// denominator (`"1/0"`) is the caller's ZeroDivisionError, and `None`
+/// means no number at all (permissive callers use 0).
+pub(crate) fn parse_rational_str(s: &str, strict: bool) -> Option<(num::BigInt, num::BigInt)> {
+    use num::BigInt;
+    struct P<'a> {
+        b: &'a [u8],
+        i: usize,
+    }
+    impl P<'_> {
+        fn peek(&self) -> Option<u8> {
+            self.b.get(self.i).copied()
+        }
+        fn peek2(&self) -> Option<u8> {
+            self.b.get(self.i + 1).copied()
+        }
+    }
+
+    fn digits(p: &mut P) -> Option<String> {
+        let mut out = String::new();
+        loop {
+            match p.peek() {
+                Some(c) if c.is_ascii_digit() => {
+                    out.push(c as char);
+                    p.i += 1;
+                }
+                // `_` only between digits (lookahead keeps `"1_x"`
+                // parseable as `1` + garbage).
+                Some(b'_')
+                    if !out.is_empty() && p.peek2().is_some_and(|c| c.is_ascii_digit()) =>
+                {
+                    p.i += 1;
+                }
+                _ => break,
+            }
+        }
+        if out.is_empty() { None } else { Some(out) }
+    }
+
+    fn number(p: &mut P, allow_sign: bool) -> Option<(BigInt, BigInt)> {
+        let start = p.i;
+        let neg = match p.peek() {
+            Some(b'+') if allow_sign => {
+                p.i += 1;
+                false
+            }
+            Some(b'-') if allow_sign => {
+                p.i += 1;
+                true
+            }
+            _ => false,
+        };
+        let int_part = digits(p);
+        let mut num: BigInt = match &int_part {
+            Some(d) => d.parse().ok()?,
+            None => BigInt::from(0),
+        };
+        let mut den = BigInt::from(1);
+        let mut have = int_part.is_some();
+        if p.peek() == Some(b'.') {
+            let dot = p.i;
+            p.i += 1;
+            match digits(p) {
+                Some(frac) => {
+                    let scale = BigInt::from(10).pow(frac.len() as u32);
+                    num = num * &scale + frac.parse::<BigInt>().ok()?;
+                    den *= scale;
+                    have = true;
+                }
+                // A trailing dot after digits (`"3."`) is allowed; a
+                // lone dot is not a number.
+                None if int_part.is_some() => {}
+                None => p.i = dot,
+            }
+        }
+        if !have {
+            p.i = start;
+            return None;
+        }
+        if matches!(p.peek(), Some(b'e') | Some(b'E')) {
+            let epos = p.i;
+            p.i += 1;
+            let eneg = match p.peek() {
+                Some(b'+') => {
+                    p.i += 1;
+                    false
+                }
+                Some(b'-') => {
+                    p.i += 1;
+                    true
+                }
+                _ => false,
+            };
+            match digits(&mut *p).and_then(|d| d.parse::<u32>().ok()) {
+                Some(e) => {
+                    let pw = BigInt::from(10).pow(e);
+                    if eneg {
+                        den *= pw;
+                    } else {
+                        num *= pw;
+                    }
+                }
+                // `"1e"` / `"1ex"`: the exponent is garbage.
+                None => p.i = epos,
+            }
+        }
+        if neg {
+            num = -num;
+        }
+        Some((num, den))
+    }
+
+    let s = s.trim();
+    let mut p = P { b: s.as_bytes(), i: 0 };
+    let (mut num, mut den) = number(&mut p, true)?;
+    if p.peek() == Some(b'/') {
+        let slash = p.i;
+        p.i += 1;
+        match number(&mut p, false) {
+            Some((dn, dd)) => {
+                num *= dd;
+                den *= dn;
+            }
+            // `"1/x"`: the slash itself is garbage.
+            None => p.i = slash,
+        }
+    }
+    if strict && p.i != p.b.len() {
+        return None;
+    }
+    Some((num, den))
+}
+
+/// Convert a strictly-parsed `Rational(String)` into a Value, raising
+/// CRuby's ArgumentError for garbage and ZeroDivisionError for a zero
+/// denominator.
+fn rational_from_str(s: &str) -> Result<RationalInner> {
+    use num::Zero;
+    match parse_rational_str(s, true) {
+        Some((num, den)) => {
+            if den.is_zero() {
+                return Err(MonorubyErr::divide_by_zero());
+            }
+            Ok(RationalInner::new(num, den))
+        }
+        None => Err(MonorubyErr::argumenterr(format!(
+            "invalid value for convert(): {s:?}"
+        ))),
+    }
+}
+
+/// The TypeError for a `#to_r` that returned a non-Rational
+/// (`can't convert X into Rational (X#to_r gives Y)`).
+fn bad_to_r_error(globals: &Globals, v: Value, result: Value) -> MonorubyErr {
+    let class = v.get_real_class_name(&globals.store);
+    MonorubyErr::typeerr(format!(
+        "can't convert {class} to Rational ({class}#to_r gives {})",
+        result.get_real_class_name(&globals.store)
+    ))
 }
 
 /// The `can't convert ... into Rational` TypeError: nil/true/false are
@@ -2834,20 +3011,28 @@ fn val_to_rational(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result
             }
             Ok(RationalInner::from_f64(f))
         }
+        // Strings go through the strict parser (`Rational("abc", 2)` is
+        // an ArgumentError, not `String#to_r`'s permissive 0).
+        RV::String(b) => rational_from_str(&b.to_str()?),
         _ => {
-            // CRuby nurat_convert: try #to_r, then #to_int — this is
-            // what lets Strings scale (`Rational("1/2", "2/3")`).
+            // CRuby nurat_convert: #to_r when present — a non-Rational
+            // result is an immediate TypeError, never a fallthrough —
+            // and #to_int only for objects with no #to_r at all. An
+            // exception raised inside #to_int surfaces as the TypeError.
             if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_r")) {
                 let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
                 if let Some(r) = result.try_rational() {
                     return Ok(r.clone());
                 }
+                return Err(bad_to_r_error(globals, v, result));
             }
             if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_int")) {
-                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
-                if let Some(i) = result.try_fixnum() {
+                if let Ok(result) = vm.invoke_func_inner(globals, func_id, v, &[], None, None)
+                    && let Some(i) = result.try_fixnum()
+                {
                     return Ok(RationalInner::new(i, 1));
                 }
+                return Err(rational_type_error(globals, v));
             }
             Err(rational_type_error(globals, v))
         }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -96,6 +96,8 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_module_func_rest(kernel_class, "format", format);
     globals.define_builtin_module_func_rest(kernel_class, "sprintf", format);
     globals.define_builtin_module_func_with(kernel_class, "rand", rand, 0, 1, false);
+    globals.define_builtin_module_func_with(kernel_class, "trace_var", trace_var, 1, 2, false);
+    globals.define_builtin_module_func_with(kernel_class, "untrace_var", untrace_var, 1, 2, false);
     globals.define_builtin_module_func_with_kw(
         kernel_class,
         "Integer",
@@ -316,6 +318,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         true,
     );
     globals.define_builtin_func(kernel_class, "method", method, 1);
+    globals.define_builtin_func(kernel_class, "public_method", public_method, 1);
     globals.define_builtin_func(kernel_class, "singleton_method", singleton_method, 1);
     globals.define_builtin_func_with(
         kernel_class,
@@ -1744,30 +1747,161 @@ fn instance_ty(
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/rand.html]
 #[monoruby_builtin]
 fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let i = if let Some(arg0) = lfp.try_arg(0) {
-        if let Some(range) = arg0.is_range() {
-            let start = range.start();
-            let end = range.end();
-            let start = start.coerce_to_int_i64(vm, globals)?;
-            let end = end.coerce_to_int_i64(vm, globals)?;
-            if start > end {
+    // Drawn from the seeded global PRNG, so `srand(n)` makes the
+    // sequence repeatable (CRuby: Kernel#rand shares Random::DEFAULT).
+    let Some(arg0) = lfp.try_arg(0) else {
+        return Ok(Value::float(globals.random_gen()));
+    };
+    if let Some(range) = arg0.is_range() {
+        let start = range.start();
+        let end = range.end();
+        let excl = range.exclude_end();
+        // Both endpoints Integer: an Integer in the range (nil when empty).
+        if let (Some(s), Some(e)) = (start.try_fixnum(), end.try_fixnum()) {
+            let span = e - s + if excl { 0 } else { 1 };
+            if span <= 0 {
                 return Ok(Value::nil());
             }
-            return Ok(Value::integer(
-                (rand::random::<f64>() * (end - start) as f64 + start as f64) as i64,
-            ));
+            let f: f64 = globals.random_gen();
+            return Ok(Value::integer(s + (f * span as f64) as i64));
         }
-        arg0.coerce_to_int_i64(vm, globals)?
-    } else {
-        0i64
-    };
-    if !i.is_zero() {
-        Ok(Value::integer(
-            (rand::random::<f64>() * (i.abs() as f64)) as i64,
-        ))
-    } else {
-        Ok(Value::float(rand::random()))
+        // Any Float endpoint makes the result a Float in [s, e).
+        let to_f = |v: Value| v.try_float().or_else(|| v.try_fixnum().map(|i| i as f64));
+        if let (Some(s), Some(e)) = (to_f(start), to_f(end)) {
+            if e < s || (excl && e <= s) {
+                return Ok(Value::nil());
+            }
+            if e == s {
+                return Ok(Value::float(s));
+            }
+            let f: f64 = globals.random_gen();
+            return Ok(Value::float(s + f * (e - s)));
+        }
+        // Generic endpoints (Time, custom numeric-ish objects): the
+        // span comes from `end - start`; a Float span picks a real
+        // offset, an Integer-ish span (`#to_int`) an integral one, and
+        // the result is `start + offset` so the endpoint type
+        // round-trips through its own `#+`.
+        let minus = IdentId::get_id("-");
+        let plus = IdentId::get_id("+");
+        let span_val = vm.invoke_method_inner(globals, minus, end, &[start], None, None)?;
+        if let Some(span) = span_val.try_float() {
+            if span < 0.0 {
+                return Ok(Value::nil());
+            }
+            let f: f64 = if span == 0.0 {
+                0.0
+            } else {
+                let f: f64 = globals.random_gen();
+                f * span
+            };
+            return vm.invoke_method_inner(globals, plus, start, &[Value::float(f)], None, None);
+        }
+        let span_int = if let Some(i) = span_val.try_fixnum() {
+            i
+        } else {
+            let coerced = vm.invoke_method_inner(
+                globals,
+                IdentId::get_id("to_int"),
+                span_val,
+                &[],
+                None,
+                None,
+            )?;
+            coerced.coerce_to_int_i64(vm, globals)?
+        };
+        let span = span_int + if excl { 0 } else { 1 };
+        if span <= 0 {
+            return Ok(Value::nil());
+        }
+        let f: f64 = globals.random_gen();
+        let r = (f * span as f64) as i64;
+        return vm.invoke_method_inner(globals, plus, start, &[Value::integer(r)], None, None);
     }
+    let i = arg0.coerce_to_int_i64(vm, globals)?;
+    if !i.is_zero() {
+        let f: f64 = globals.random_gen();
+        Ok(Value::integer((f * (i.abs() as f64)) as i64))
+    } else {
+        Ok(Value::float(globals.random_gen()))
+    }
+}
+
+///
+/// ### Kernel.#trace_var
+///
+/// - trace_var(varname, hook) -> nil
+/// - trace_var(varname) { |new_val| ... } -> nil
+///
+/// Registers a hook (Proc or String command) fired after each
+/// assignment to the named global variable.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/trace_var.html]
+#[monoruby_builtin]
+fn trace_var(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let name = gvar_trace_name(globals, lfp.arg(0))?;
+    let cmd: Value = if let Some(bh) = lfp.block() {
+        vm.generate_proc(globals, bh, pc)?.into()
+    } else {
+        match lfp.try_arg(1) {
+            Some(v) if !v.is_nil() => v,
+            _ => {
+                return Err(MonorubyErr::argumenterr(
+                    "tried to create Proc object without a block",
+                ));
+            }
+        }
+    };
+    globals.gvar_traces.entry(name).or_default().push(cmd);
+    Ok(Value::nil())
+}
+
+///
+/// ### Kernel.#untrace_var
+///
+/// - untrace_var(varname, hook = nil) -> Array | nil
+///
+/// Removes the named global variable's trace hooks: all of them
+/// (returning the removed commands) when `hook` is nil, otherwise just
+/// the given one.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/untrace_var.html]
+#[monoruby_builtin]
+fn untrace_var(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let name = gvar_trace_name(globals, lfp.arg(0))?;
+    match lfp.try_arg(1).filter(|v| !v.is_nil()) {
+        None => {
+            let removed = globals.gvar_traces.remove(&name).unwrap_or_default();
+            Ok(Value::array_from_vec(removed))
+        }
+        Some(cmd) => {
+            if let Some(cmds) = globals.gvar_traces.get_mut(&name)
+                && let Some(pos) = cmds.iter().position(|c| c.id() == cmd.id())
+            {
+                cmds.remove(pos);
+                return Ok(Value::array_from_vec(vec![cmd]));
+            }
+            Ok(Value::nil())
+        }
+    }
+}
+
+/// Coerce a `trace_var`/`untrace_var` variable name (Symbol or String)
+/// and require the `$` prefix.
+fn gvar_trace_name(globals: &mut Globals, v: Value) -> Result<IdentId> {
+    let name = v.expect_symbol_or_string(globals)?;
+    let s = name.get_name();
+    if !s.starts_with('$') {
+        return Err(MonorubyErr::nameerr(format!(
+            "'{s}' is not allowed as a global variable name"
+        )));
+    }
+    Ok(name)
 }
 
 ///
@@ -2558,50 +2692,115 @@ fn kernel_rational_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> 
     let a = lfp.arg(0);
     if let Some(b) = lfp.try_arg(1) {
         // Two-argument form: Rational(a, b)
-        let ar = val_to_rational(globals, a)?;
-        let br = val_to_rational(globals, b)?;
+        if a.is_nil() || b.is_nil() {
+            return Err(rational_type_error(
+                globals,
+                if a.is_nil() { a } else { b },
+            ));
+        }
+        // A Complex with non-zero imaginary part in either slot falls
+        // back to real division (CRuby nurat_convert), producing the
+        // Complex quotient; an exactly-real Complex contributes its
+        // real part.
+        if (a.try_complex().is_some() && complex_exact_real(a).is_none())
+            || (b.try_complex().is_some() && complex_exact_real(b).is_none())
+        {
+            return vm.invoke_method_inner(globals, IdentId::get_id("/"), a, &[b], None, None);
+        }
+        let a = complex_exact_real(a).unwrap_or(a);
+        let b = complex_exact_real(b).unwrap_or(b);
+        let ar = val_to_rational(vm, globals, a)?;
+        let br = val_to_rational(vm, globals, b)?;
         Ok(Value::rational_from_inner(ar.div(&br)?))
     } else {
-        // One-argument form: Rational(a)
-        if let Some(r) = a.try_rational() {
-            return Ok(Value::rational_from_inner(r.clone()));
+        rational_from_value(vm, globals, a)
+    }
+}
+
+/// One-argument `Kernel#Rational` conversion.
+fn rational_from_value(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<Value> {
+    if let Some(r) = v.try_rational() {
+        return Ok(Value::rational_from_inner(r.clone()));
+    }
+    if v.is_nil() {
+        return Err(rational_type_error(globals, v));
+    }
+    if let Some(c) = v.try_complex() {
+        return match complex_exact_real(v) {
+            Some(re) => rational_from_value(vm, globals, re),
+            None => Err(MonorubyErr::rangeerr(format!(
+                "can't convert {} into Rational",
+                c.to_s_str(&globals.store)
+            ))),
+        };
+    }
+    match v.unpack() {
+        RV::Fixnum(i) => Ok(Value::rational_from_inner(RationalInner::new(i, 1))),
+        RV::BigInt(b) => Ok(Value::rational_from_inner(RationalInner::new(b.clone(), 1))),
+        RV::Float(f) => {
+            if f.is_nan() {
+                return Err(MonorubyErr::rangeerr("can't convert NaN into Rational"));
+            }
+            if f.is_infinite() {
+                return Err(MonorubyErr::rangeerr(
+                    "can't convert Infinity into Rational",
+                ));
+            }
+            Ok(Value::rational_from_inner(RationalInner::from_f64(f)))
         }
-        match a.unpack() {
-            RV::Fixnum(i) => Ok(Value::rational_from_inner(RationalInner::new(i, 1))),
-            RV::BigInt(b) => Ok(Value::rational_from_inner(RationalInner::new(b.clone(), 1))),
-            RV::Float(f) => {
-                if f.is_nan() {
-                    return Err(MonorubyErr::rangeerr("can't convert NaN into Rational"));
+        _ => {
+            // CRuby nurat_convert: try #to_r, then #to_int.
+            if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_r")) {
+                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
+                if result.try_rational().is_some() {
+                    return Ok(result);
                 }
-                if f.is_infinite() {
-                    return Err(MonorubyErr::rangeerr(
-                        "can't convert Infinity into Rational",
-                    ));
-                }
-                Ok(Value::rational_from_inner(RationalInner::from_f64(f)))
             }
-            _ => {
-                // Try to_r coercion
-                let to_r_id = IdentId::get_id("to_r");
-                if let Some(func_id) = globals.check_method(a, to_r_id) {
-                    let result = vm.invoke_func_inner(globals, func_id, a, &[], None, None)?;
-                    if result.try_rational().is_some() {
-                        return Ok(result);
-                    }
+            if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_int")) {
+                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
+                if let Some(i) = result.try_fixnum() {
+                    return Ok(Value::rational_from_inner(RationalInner::new(i, 1)));
                 }
-                Err(MonorubyErr::typeerr(format!(
-                    "can't convert {} into Rational",
-                    a.get_real_class_name(&globals.store)
-                )))
             }
+            Err(rational_type_error(globals, v))
         }
     }
 }
 
+/// The `can't convert ... into Rational` TypeError: nil/true/false are
+/// echoed literally (CRuby's conversion-error convention), everything
+/// else by class name.
+fn rational_type_error(globals: &Globals, v: Value) -> MonorubyErr {
+    let name = if v.is_nil() {
+        "nil".to_string()
+    } else if v == Value::bool(true) {
+        "true".to_string()
+    } else if v == Value::bool(false) {
+        "false".to_string()
+    } else {
+        v.get_real_class_name(&globals.store)
+    };
+    MonorubyErr::typeerr(format!("can't convert {name} into Rational"))
+}
+
+/// `Some(real_part)` when *v* is a Complex whose imaginary part is
+/// exactly zero.
+fn complex_exact_real(v: Value) -> Option<Value> {
+    let c = v.try_complex()?;
+    if c.im().is_zero() {
+        Some(c.re().get())
+    } else {
+        None
+    }
+}
+
 /// Convert a Value to RationalInner for Kernel#Rational two-arg form.
-fn val_to_rational(globals: &mut Globals, v: Value) -> Result<RationalInner> {
+fn val_to_rational(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<RationalInner> {
     if let Some(r) = v.try_rational() {
         return Ok(r.clone());
+    }
+    if v.is_nil() {
+        return Err(rational_type_error(globals, v));
     }
     match v.unpack() {
         RV::Fixnum(i) => Ok(RationalInner::new(i, 1)),
@@ -2612,10 +2811,23 @@ fn val_to_rational(globals: &mut Globals, v: Value) -> Result<RationalInner> {
             }
             Ok(RationalInner::from_f64(f))
         }
-        _ => Err(MonorubyErr::typeerr(format!(
-            "can't convert {} into Rational",
-            v.get_real_class_name(&globals.store)
-        ))),
+        _ => {
+            // CRuby nurat_convert: try #to_r, then #to_int — this is
+            // what lets Strings scale (`Rational("1/2", "2/3")`).
+            if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_r")) {
+                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
+                if let Some(r) = result.try_rational() {
+                    return Ok(r.clone());
+                }
+            }
+            if let Some(func_id) = globals.check_method(v, IdentId::get_id("to_int")) {
+                let result = vm.invoke_func_inner(globals, func_id, v, &[], None, None)?;
+                if let Some(i) = result.try_fixnum() {
+                    return Ok(RationalInner::new(i, 1));
+                }
+            }
+            Err(rational_type_error(globals, v))
+        }
     }
 }
 
@@ -4726,8 +4938,40 @@ fn instance_of(
 fn method(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
     let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    method_object_impl(vm, globals, receiver, method_name, false)
+}
+
+///
+/// ### Kernel#public_method
+///
+/// - public_method(name) -> Method
+///
+/// Like `Kernel#method`, restricted to public methods: a private or
+/// protected method raises NameError, and the `respond_to_missing?`
+/// fallback is consulted with `include_private = false`.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Object/i/public_method.html]
+#[monoruby_builtin]
+fn public_method(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let receiver = lfp.self_val();
+    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    method_object_impl(vm, globals, receiver, method_name, true)
+}
+
+fn method_object_impl(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    receiver: Value,
+    method_name: IdentId,
+    public_only: bool,
+) -> Result<Value> {
     match globals.find_method_for_object(receiver, method_name) {
-        Ok((func_id, _, owner)) => {
+        Ok((func_id, visi, owner)) if !public_only || visi == Visibility::Public => {
             let original_name = globals
                 .store
                 .original_name_by_class_id(receiver.class(), method_name);
@@ -4739,15 +4983,15 @@ fn method(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 original_name,
             ))
         }
-        Err(err) => {
-            // CRuby: if `receiver.respond_to_missing?(name, true)` is truthy,
-            // return a Method that proxies to `method_missing`.
+        found => {
+            // CRuby: if `receiver.respond_to_missing?(name, include_private)`
+            // is truthy, return a Method that proxies to `method_missing`.
             if let Some(rtm_fid) = globals.check_method(receiver, IdentId::RESPOND_TO_MISSING_) {
                 let responds = vm.invoke_func_inner(
                     globals,
                     rtm_fid,
                     receiver,
-                    &[Value::symbol(method_name), Value::bool(true)],
+                    &[Value::symbol(method_name), Value::bool(!public_only)],
                     None,
                     None,
                 )?;
@@ -4762,7 +5006,15 @@ fn method(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                     ));
                 }
             }
-            Err(err)
+            match found {
+                // A non-public method under `public_method`.
+                Ok(_) => Err(MonorubyErr::method_not_found(
+                    &globals.store,
+                    method_name,
+                    receiver,
+                )),
+                Err(err) => Err(err),
+            }
         }
     }
 }
@@ -5329,6 +5581,130 @@ mod tests {
             t2.join
             begin; File.delete(path); rescue; end
             [r1, r2, $conc_order]
+            "#,
+        );
+    }
+
+    #[test]
+    fn caller_argument_edges() {
+        // Array#[] edge semantics, Range forms, ArgumentError on
+        // negatives, and #to_int coercion — shared with caller_locations
+        // via Thread::Backtrace.__slice.
+        run_test(
+            r#"
+            def lvl2
+              [
+                caller(1, nil).size,
+                caller(100),
+                (begin; caller(-1); rescue ArgumentError => e; e.message; end),
+                (begin; caller(1, -1); rescue ArgumentError => e; e.message; end),
+                caller(1..-1) == caller(1),
+                caller(1..) == caller(1),
+              ]
+            end
+            def lvl1; lvl2; end
+            lvl1
+            "#,
+        );
+    }
+
+    #[test]
+    fn trace_var_untrace_var() {
+        run_test_once(
+            r#"
+            res = []
+            trace_var(:$tv_spec) { |v| res << [:block, v] }
+            $tv_spec = 1
+            p1 = proc { |v| res << [:proc, v] }
+            trace_var(:$tv_spec, p1)
+            $tv_spec = 2
+            res << (untrace_var(:$tv_spec, p1) == [p1])
+            $tv_spec = 3
+            res << untrace_var(:$tv_spec).size
+            $tv_spec = 4
+            trace_var(:$tv_spec2, "$tv_spec_extra = :fired")
+            $tv_spec2 = 1
+            res << $tv_spec_extra
+            res << (begin; trace_var(:$tv_spec3); rescue ArgumentError; :argerr; end)
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn rand_range_forms() {
+        // Float endpoints yield Floats, empty ranges nil, degenerate
+        // ranges their endpoint; seeded sequences repeat.
+        run_test_once(
+            r#"
+            srand(42)
+            a = rand
+            srand(42)
+            [
+              rand == a,
+              rand(3.5..6.5).is_a?(Float),
+              rand(4..6.5).is_a?(Float),
+              rand(3.5...6).is_a?(Float),
+              rand(4..6).is_a?(Integer),
+              rand(1.0..1.0),
+              rand(42..42),
+              rand(1..0),
+              rand(1.0...1.0),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn kernel_rational_conversions() {
+        run_test(
+            r#"
+            [
+              (begin; Rational(nil); rescue TypeError => e; e.message; end),
+              (begin; Rational(1, nil); rescue TypeError => e; e.message; end),
+              Rational(nil, exception: false),
+              Rational("1/2", "2/3").to_s,
+              Rational(Complex(3, 0), 2).to_s,
+              (begin; Rational(Complex(1, 2)); rescue RangeError => e; e.message; end),
+              (o = Object.new; def o.to_int; 7; end; Rational(o).to_s),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn public_method_visibility() {
+        run_test(
+            r#"
+            class PubMethSpec
+              def pub; :pub; end
+              private def priv; :priv; end
+              protected def prot; :prot; end
+            end
+            o = PubMethSpec.new
+            [
+              o.public_method(:pub).call,
+              o.public_method(:pub).class.to_s,
+              (begin; o.public_method(:priv); rescue NameError; :priv_err; end),
+              (begin; o.public_method(:prot); rescue NameError; :prot_err; end),
+              (begin; o.public_method(:nope); rescue NameError; :missing_err; end),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn sprintf_malformed_format() {
+        run_test(
+            r#"
+            fmts = ["%\n", " % ", "%.\n3f", "hello %1$"]
+            fmts.map do |f|
+              begin
+                sprintf(f, "foo")
+              rescue ArgumentError => e
+                e.message[/malformed format string/] || e.message
+              end
+            end
             "#,
         );
     }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -96,6 +96,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_module_func_rest(kernel_class, "format", format);
     globals.define_builtin_module_func_rest(kernel_class, "sprintf", format);
     globals.define_builtin_module_func_with(kernel_class, "rand", rand, 0, 1, false);
+    globals.define_builtin_module_func(kernel_class, "global_variables", global_variables, 0);
     globals.define_builtin_module_func_with(kernel_class, "trace_var", trace_var, 1, 2, false);
     globals.define_builtin_module_func_with(kernel_class, "untrace_var", untrace_var, 1, 2, false);
     globals.define_builtin_module_func_with_kw(
@@ -981,7 +982,7 @@ fn fix_system_exit_status(globals: &mut Globals, err: &mut MonorubyErr, ex: Valu
             .get_ivar(ex, IdentId::get_id("/status"))
             .and_then(|v| v.try_fixnum())
             .unwrap_or(0);
-        err.kind = MonorubyErrKind::SystemExit(status as u8);
+        err.kind = MonorubyErrKind::SystemExit(status);
     }
 }
 
@@ -1828,6 +1829,25 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 }
 
 ///
+/// ### Kernel.#global_variables
+///
+/// - global_variables -> [Symbol]
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/global_variables.html]
+#[monoruby_builtin]
+fn global_variables(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let names = globals.gvars.names();
+    Ok(Value::array_from_iter(
+        names.into_iter().map(Value::symbol),
+    ))
+}
+
+///
 /// ### Kernel.#trace_var
 ///
 /// - trace_var(varname, hook) -> nil
@@ -2323,7 +2343,9 @@ fn kernel_float_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Res
     match arg0.unpack() {
         RV::Fixnum(num) => return Ok(Value::float(num as f64)),
         RV::BigInt(num) => return Ok(Value::float(num.to_f64().unwrap())),
-        RV::Float(num) => return Ok(Value::float(num)),
+        // Return the argument itself: `Float(nan).equal?(nan)` holds in
+        // CRuby (identity is preserved for Float inputs).
+        RV::Float(_) => return Ok(arg0),
         RV::String(b) => {
             let s = b.to_str()?;
             return parse_kernel_float(&s);
@@ -2331,11 +2353,12 @@ fn kernel_float_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Res
         _ => {}
     };
     // Try to_f coercion. CRuby requires `#to_f` to return a Float; an
-    // Integer (or anything else) is a TypeError.
+    // Integer (or anything else) is a TypeError. The result object is
+    // returned as-is (identity preserved).
     if let Some(func_id) = globals.check_method(arg0, IdentId::TO_F) {
         let result = vm.invoke_func_inner(globals, func_id, arg0, &[], None, None)?;
         match result.unpack() {
-            RV::Float(f) => return Ok(Value::float(f)),
+            RV::Float(_) => return Ok(result),
             _ => {
                 return Err(MonorubyErr::cant_convert_error_f(globals, arg0, result));
             }
@@ -2853,11 +2876,19 @@ fn kernel_array(
         if result.is_array_ty() {
             return Ok(result);
         }
-        return Err(MonorubyErr::cant_convert_error_ary(globals, arg, result));
-    } else if let Some(func_id) = globals.check_method(arg, IdentId::TO_A) {
+        // A nil #to_ary falls through to the #to_a protocol (CRuby).
+        if !result.is_nil() {
+            return Err(MonorubyErr::cant_convert_error_ary(globals, arg, result));
+        }
+    }
+    if let Some(func_id) = globals.check_method(arg, IdentId::TO_A) {
         let result = vm.invoke_func_inner(globals, func_id, arg, &[], None, None)?;
         if result.is_array_ty() {
             return Ok(result);
+        }
+        // A nil #to_a wraps the argument itself (CRuby).
+        if result.is_nil() {
+            return Ok(Value::array1(arg));
         }
         return Err(MonorubyErr::typeerr(format!(
             "can't convert {} into Array ({}#to_a gives {})",
@@ -3441,6 +3472,27 @@ fn command(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 ///
 /// - sleep -> Integer
 /// - sleep(sec) -> Integer
+/// Coerce a `sleep` duration: numerics via `#to_f` semantics, any
+/// other object through `#divmod(1)` (CRuby `rb_time_interval` — the
+/// quotient plus remainder is the interval in seconds).
+fn sleep_duration(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<f64> {
+    let numeric = v.try_fixnum().is_some()
+        || v.is_float()
+        || v.try_rational().is_some()
+        || matches!(v.unpack(), RV::BigInt(_));
+    if !numeric && let Some(fid) = globals.check_method(v, IdentId::get_id("divmod")) {
+        let res = vm.invoke_func_inner(globals, fid, v, &[Value::integer(1)], None, None)?;
+        if let Some(arr) = res.try_array_ty()
+            && arr.len() == 2
+        {
+            let q = arr[0].coerce_to_f64(vm, globals)?;
+            let r = arr[1].coerce_to_f64(vm, globals)?;
+            return Ok(q + r);
+        }
+    }
+    v.coerce_to_f64(vm, globals)
+}
+
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/sleep.html]
 #[monoruby_builtin]
@@ -3452,7 +3504,7 @@ fn sleep(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     if crate::scheduler::has_other_live_threads() {
         let dur = match lfp.try_arg(0) {
             Some(sec) => {
-                let sec = sec.coerce_to_f64(vm, globals)?;
+                let sec = sleep_duration(vm, globals, sec)?;
                 if sec.is_nan() || sec < 0.0 {
                     return Err(MonorubyErr::argumenterr(
                         "time interval must not be negative or NaN",
@@ -3466,7 +3518,7 @@ fn sleep(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         return Ok(Value::integer(elapsed.as_secs() as i64));
     }
     if let Some(sec) = lfp.try_arg(0) {
-        let sec = sec.coerce_to_f64(vm, globals)?;
+        let sec = sleep_duration(vm, globals, sec)?;
         if sec.is_nan() || sec < 0.0 {
             return Err(MonorubyErr::argumenterr(
                 "time interval must not be negative or NaN",
@@ -3593,7 +3645,7 @@ pub(super) fn exit(
         0
     };
     Err(MonorubyErr::new(
-        MonorubyErrKind::SystemExit(status as u8),
+        MonorubyErrKind::SystemExit(status),
         "exit",
     ))
 }
@@ -4628,14 +4680,15 @@ fn initialize_copy(
     if orig.id() == self_val.id() {
         return Ok(self_val);
     }
+    if self_val.is_frozen() {
+        return Err(MonorubyErr::cant_modify_frozen(&globals.store, self_val));
+    }
     if self_val.real_class(globals).id() != orig.real_class(globals).id()
         || self_val.ty() != orig.ty()
     {
-        return Err(MonorubyErr::typeerr(format!(
-            "initialize_copy should take same class object self:{} original:{}",
-            self_val.class().get_name(globals),
-            orig.class().get_name(globals)
-        )));
+        return Err(MonorubyErr::typeerr(
+            "initialize_copy should take same class object",
+        ));
     }
     Ok(self_val)
 }
@@ -5581,6 +5634,44 @@ mod tests {
             t2.join
             begin; File.delete(path); rescue; end
             [r1, r2, $conc_order]
+            "#,
+        );
+    }
+
+    #[test]
+    fn kernel_conversion_and_misc_edges() {
+        run_test(
+            r#"
+            nan = 0.0 / 0.0
+            inf = 1.0 / 0.0
+            to_ary_nil = Object.new
+            def to_ary_nil.to_ary; nil; end
+            def to_ary_nil.to_a; [1, 2]; end
+            to_a_nil = Object.new
+            def to_a_nil.to_a; nil; end
+            no_to_s = Object.new
+            def no_to_s.respond_to?(name, priv = false); false; end
+            frozen = Object.new.freeze
+            divmod_obj = Object.new
+            def divmod_obj.divmod(*); [0, 0.001]; end
+            [
+              Float(nan).equal?(nan),
+              Float(inf).equal?(inf),
+              (begin; exit(-65536); rescue SystemExit => e; e.status; end),
+              (begin; exit(-2.2); rescue SystemExit => e; e.status; end),
+              Array(to_ary_nil),
+              Array(to_a_nil) == [to_a_nil],
+              (begin; String(BasicObject.new); rescue TypeError; :ts_err; end),
+              (begin; String(no_to_s); rescue TypeError; :rtp_err; end),
+              (begin; frozen.send(:initialize_copy, Object.new); rescue FrozenError; :frozen_err; end),
+              global_variables.include?(:$stdout),
+              Kernel.instance_method(:fail) == Kernel.instance_method(:raise),
+              Kernel.method(:fail) == Kernel.method(:raise),
+              sleep(divmod_obj) >= 0,
+              Kernel.private_instance_methods(false).include?(:syscall),
+              Kernel.public_methods(false).include?(:select),
+              Kernel.private_instance_methods(false).include?(:readline),
+            ]
             "#,
         );
     }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -5824,6 +5824,67 @@ mod tests {
     }
 
     #[test]
+    fn rand_generic_endpoints() {
+        // Custom numeric-ish endpoints round-trip through their own
+        // #-/#+ (Integer-span via #to_int, Float-span directly), and
+        // Time ranges yield Times.
+        run_test_once(
+            r#"
+            cri = Struct.new(:value) do
+              def to_int; value; end
+              def <=>(o); to_int <=> o.to_int; end
+              def -(o); self.class.new(to_int - o.to_int); end
+              def +(o); self.class.new(to_int + o.to_int); end
+            end
+            crf = Struct.new(:value) do
+              def to_f; value; end
+              def <=>(o); to_f <=> o.to_f; end
+              def -(o); to_f - o.to_f; end
+              def +(o); self.class.new(to_f + o.to_f); end
+            end
+            i = rand(cri.new(1)..cri.new(42))
+            f = rand(crf.new(1.0)..crf.new(42.0))
+            t = Time.now
+            [
+              i.instance_of?(cri),
+              (1..42).include?(i.value),
+              f.instance_of?(crf),
+              f.value >= 1.0 && f.value <= 42.0,
+              rand(t..t).instance_of?(Time),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn rational_string_forms() {
+        run_test(
+            r#"
+            bad_to_int = Object.new
+            def bad_to_int.to_int; raise NoMethodError; end
+            [
+              Rational(".52"), Rational("10e2"), Rational("1.5e-2"), Rational("3."),
+              Rational("1_000_0"), Rational("+2/4"), Rational("  -19.1/3  "),
+              (begin; Rational("1/-2"); rescue ArgumentError => e; e.message; end),
+              (begin; Rational("1/0"); rescue ZeroDivisionError; :zde; end),
+              (begin; Rational("1_"); rescue ArgumentError; :ae; end),
+              (begin; Rational("1/x"); rescue ArgumentError; :ae2; end),
+              ".52".to_r, "1_x".to_r, "1/x".to_r, "-19.1/3".to_r, "abc".to_r,
+              "1e-2".to_r, "9.5e".to_r, "3.".to_r, "21/06".to_r, "".to_r,
+              Rational(:sym, exception: false),
+              Rational("abc", exception: false),
+              (begin; Rational(bad_to_int); rescue TypeError; :tie; end),
+              Rational(bad_to_int, exception: false),
+              # Complex results decomposed — the differential harness
+              # can't parse Complex literals from CRuby's output.
+              (c = Rational(1, Complex(1, 2)); [c.class.to_s, c.real, c.imaginary]),
+              Rational(Complex(2, 0), Complex(4, 0)),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
     fn kernel_conversion_and_misc_edges() {
         run_test(
             r#"
@@ -5973,7 +6034,7 @@ mod tests {
     fn sprintf_malformed_format() {
         run_test(
             r#"
-            fmts = ["%\n", " % ", "%.\n3f", "hello %1$"]
+            fmts = ["%\n", " % ", "%.\n3f", "%.3\nf", "%\0", "hello %1$", "%v", "% \n"]
             fmts.map do |f|
               begin
                 sprintf(f, "foo")

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -5063,24 +5063,21 @@ fn parse_real(s: f64) -> Real {
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/to_r.html]
 #[monoruby_builtin]
-fn to_r(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn to_r(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    use num::Zero;
     let self_ = lfp.self_val();
     let s = self_.expect_str(globals)?;
-    let (num, den) = parse_rational(s);
-    // Call Kernel#Rational to create the Rational object
-    let rational_id = IdentId::get_id("Rational");
-    let main_obj = globals.main_object;
-    let func_id = globals
-        .check_method(main_obj, rational_id)
-        .ok_or_else(|| MonorubyErr::runtimeerr("Rational method not found"))?;
-    vm.invoke_func_inner(
-        globals,
-        func_id,
-        main_obj,
-        &[Value::integer(num), Value::integer(den)],
-        None,
-        None,
-    )
+    // The shared rational-literal parser in permissive mode: the
+    // longest valid prefix wins, garbage-only strings yield 0.
+    match crate::builtins::kernel::parse_rational_str(s, false) {
+        Some((num, den)) => {
+            if den.is_zero() {
+                return Err(MonorubyErr::divide_by_zero());
+            }
+            Ok(Value::rational_from_inner(RationalInner::new(num, den)))
+        }
+        None => Ok(Value::rational_from_inner(RationalInner::new(0, 1))),
+    }
 }
 
 /// Parse a string as a complex number, returning (real, imaginary) as f64.
@@ -5151,86 +5148,6 @@ fn parse_f64_simple(s: &str) -> f64 {
         return 0.0;
     }
     s.parse::<f64>().unwrap_or(0.0)
-}
-
-/// Parse a string as a rational number, returning (numerator, denominator).
-fn parse_rational(s: &str) -> (i64, i64) {
-    let s = s.trim();
-    if s.is_empty() {
-        return (0, 1);
-    }
-
-    // Try "a/b" format
-    if let Some(pos) = s.find('/') {
-        let num_str = &s[..pos];
-        let den_str = &s[pos + 1..];
-        let num = parse_rational_int(num_str);
-        let den = parse_rational_int(den_str);
-        if den == 0 {
-            return (0, 1);
-        }
-        return (num, den);
-    }
-
-    // Try decimal format "0.5" -> 1/2
-    if let Some(pos) = s.find('.') {
-        let int_part = &s[..pos];
-        let frac_part = &s[pos + 1..];
-        // Count decimal digits (stop at first non-digit)
-        let frac_digits: String = frac_part
-            .chars()
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
-        let dec_places = frac_digits.len();
-        if dec_places == 0 {
-            let num = parse_rational_int(int_part);
-            return (num, 1);
-        }
-        let int_val = parse_rational_int(int_part);
-        let frac_val: i64 = frac_digits.parse().unwrap_or(0);
-        let den = 10i64.pow(dec_places as u32);
-        let negative = s.starts_with('-');
-        let num = if negative {
-            int_val * den - frac_val
-        } else {
-            int_val * den + frac_val
-        };
-        // Simplify
-        let g = gcd_u64(num.unsigned_abs(), den as u64) as i64;
-        return (num / g, den / g);
-    }
-
-    // Plain integer
-    let num = parse_rational_int(s);
-    (num, 1)
-}
-
-fn parse_rational_int(s: &str) -> i64 {
-    let s = s.trim();
-    if s.is_empty() {
-        return 0;
-    }
-    // Parse leading integer, stop at first non-digit (after optional sign)
-    let mut chars = s.chars().peekable();
-    let negative = if chars.peek() == Some(&'-') {
-        chars.next();
-        true
-    } else if chars.peek() == Some(&'+') {
-        chars.next();
-        false
-    } else {
-        false
-    };
-    let digits: String = chars.take_while(|c| c.is_ascii_digit()).collect();
-    if digits.is_empty() {
-        return 0;
-    }
-    let val: i64 = digits.parse().unwrap_or(0);
-    if negative { -val } else { val }
-}
-
-fn gcd_u64(a: u64, b: u64) -> u64 {
-    if b == 0 { a } else { gcd_u64(b, a % b) }
 }
 
 ///

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -690,7 +690,7 @@ impl Executor {
 
             if i >= flen {
                 return Err(MonorubyErr::argumenterr(
-                    "Invalid termination of format string",
+                    "malformed format string",
                 ));
             }
             let mut ch = fchars[i];
@@ -713,7 +713,7 @@ impl Executor {
                 i += 1;
                 if i >= flen {
                     return Err(MonorubyErr::argumenterr(
-                        "Invalid termination of format string",
+                        "malformed format string",
                     ));
                 }
                 ch = fchars[i];
@@ -731,7 +731,7 @@ impl Executor {
                         named_val = Some(v);
                         if i >= flen {
                             return Err(MonorubyErr::argumenterr(
-                                "Invalid termination of format string",
+                                "malformed format string",
                             ));
                         }
                         ch = fchars[i];
@@ -750,7 +750,7 @@ impl Executor {
                     positional_arg = Some(arguments[num - 1]);
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -803,7 +803,7 @@ impl Executor {
                 }
                 if i >= flen {
                     return Err(MonorubyErr::argumenterr(
-                        "Invalid termination of format string",
+                        "malformed format string",
                     ));
                 }
                 ch = fchars[i];
@@ -816,7 +816,7 @@ impl Executor {
                     i += 1;
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -836,7 +836,7 @@ impl Executor {
                     named_val = Some(v);
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -850,7 +850,7 @@ impl Executor {
                 i += 1;
                 if i >= flen {
                     return Err(MonorubyErr::argumenterr(
-                        "Invalid termination of format string",
+                        "malformed format string",
                     ));
                 }
                 ch = fchars[i];
@@ -886,7 +886,7 @@ impl Executor {
                     }
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -900,7 +900,7 @@ impl Executor {
                         i += 1;
                         if i >= flen {
                             return Err(MonorubyErr::argumenterr(
-                                "Invalid termination of format string",
+                                "malformed format string",
                             ));
                         }
                         ch = fchars[i];
@@ -919,7 +919,7 @@ impl Executor {
                     positional_arg = Some(arguments[num - 1]);
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -939,7 +939,7 @@ impl Executor {
                     named_val = Some(v);
                     if i >= flen {
                         return Err(MonorubyErr::argumenterr(
-                            "Invalid termination of format string",
+                            "malformed format string",
                         ));
                     }
                     ch = fchars[i];
@@ -998,6 +998,36 @@ impl Executor {
                 return Err(MonorubyErr::argumenterr(
                     "numbered/unnumbered reference is mixed with named",
                 ));
+            }
+            // CRuby validates the conversion character *before* demanding
+            // an argument for it: `sprintf("%\n")` is malformed even with
+            // no arguments left. Unprintable characters get the bare
+            // message, printable ones are echoed (`… - %v`).
+            if !matches!(
+                ch,
+                'c' | 's'
+                    | 'p'
+                    | 'd'
+                    | 'i'
+                    | 'u'
+                    | 'b'
+                    | 'B'
+                    | 'o'
+                    | 'x'
+                    | 'X'
+                    | 'f'
+                    | 'e'
+                    | 'E'
+                    | 'g'
+                    | 'G'
+                    | 'a'
+                    | 'A'
+            ) {
+                return Err(MonorubyErr::argumenterr(if ch.is_ascii_graphic() {
+                    format!("malformed format string - %{ch}")
+                } else {
+                    "malformed format string".to_string()
+                }));
             }
             // Determine val: positional, named, or sequential
             let val = if let Some(v) = positional_arg {

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -212,6 +212,9 @@ pub struct Globals {
     /// load lock); the id is only compared / liveness-checked, never
     /// dereferenced, so the map needs no GC marking.
     pub(crate) loading_features: std::collections::HashMap<std::path::PathBuf, u64>,
+    /// `Kernel#trace_var` hooks: per global-variable name, the commands
+    /// (Procs or Strings) fired after each Ruby-level assignment.
+    pub(crate) gvar_traces: std::collections::HashMap<IdentId, Vec<Value>>,
     /// cache for Symbol#name (frozen strings keyed by IdentId).
     pub(crate) symbol_names: HashMap<IdentId, Value>,
     /// Dedup table for the Ruby-3.4 "block may be ignored" warning.
@@ -281,6 +284,10 @@ impl alloc::GC<RValue> for Globals {
         self.loaded_features.mark(alloc);
         self.store.mark(alloc);
         self.gvars.mark_values(|v| v.mark(alloc));
+        self.gvar_traces
+            .values()
+            .flatten()
+            .for_each(|v| v.mark(alloc));
         self.symbol_names.values().for_each(|v| v.mark(alloc));
         // Trap handler Procs are GC roots: they are reachable only from
         // this table, yet may be invoked at any future poll point.
@@ -469,6 +476,7 @@ impl Globals {
             random: Box::new(Prng::new()),
             loaded_features,
             loading_features: std::collections::HashMap::default(),
+            gvar_traces: std::collections::HashMap::default(),
             symbol_names: HashMap::default(),
             unused_block_warned: std::collections::HashSet::default(),
             // signo runs 1..=32; index by signo directly (slot 0 unused).

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -821,7 +821,7 @@ impl Globals {
                     err.show_error_message_and_all_loc(&self.store);
                 }
                 Err(MonorubyErr::new(
-                    MonorubyErrKind::SystemExit(status as u8),
+                    MonorubyErrKind::SystemExit(status as i64),
                     "exit",
                 ))
             }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -1315,7 +1315,7 @@ pub enum MonorubyErrKind {
     Key(Option<(Value, Value)>),
     Fiber,
     StopIteration,
-    SystemExit(u8),
+    SystemExit(i64),
     Other(ClassId),
     MethodReturn(Value, Lfp),
     /// `break` escaping a block: carries the break value, the block's

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -252,6 +252,12 @@ impl GvarTable {
         Ok(())
     }
 
+    /// Every registered global-variable name (Simple, Alias, or
+    /// Hooked), for `Kernel#global_variables`.
+    pub(crate) fn names(&self) -> Vec<IdentId> {
+        self.index.keys().copied().collect()
+    }
+
     /// Returns `true` if `name` has any entry — Simple, Alias, or Hooked.
     /// Used by the gvar unit tests as a cheap "is the name registered"
     /// probe; runtime `defined?` evaluation goes through

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -222,16 +222,34 @@ impl GvarTable {
         match &mut globals.gvars.entries[id.index()] {
             GvarEntry::Simple(slot) => {
                 *slot = val;
-                Ok(())
             }
             GvarEntry::Alias(_) => unreachable!("resolve() follows aliases"),
             GvarEntry::Hooked { setter, .. } => match *setter {
-                Some(setter) => setter(vm, globals, name, val),
-                None => Err(MonorubyErr::nameerr(format!(
-                    "{name} is a read-only variable"
-                ))),
+                Some(setter) => setter(vm, globals, name, val)?,
+                None => {
+                    return Err(MonorubyErr::nameerr(format!(
+                        "{name} is a read-only variable"
+                    )));
+                }
             },
         }
+        // `Kernel#trace_var` hooks fire after the store, newest first
+        // (CRuby prepends each registration): a Proc command is called
+        // with the assigned value, a String command is eval'ed.
+        if let Some(cmds) = globals.gvar_traces.get(&name) {
+            let cmds = cmds.clone();
+            let call = IdentId::get_id("call");
+            let eval = IdentId::get_id("eval");
+            for cmd in cmds.into_iter().rev() {
+                if cmd.is_str().is_some() {
+                    let main = globals.main_object;
+                    vm.invoke_method_inner(globals, eval, main, &[cmd], None, None)?;
+                } else {
+                    vm.invoke_method_inner(globals, call, cmd, &[val], None, None)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Returns `true` if `name` has any entry — Simple, Alias, or Hooked.

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -235,15 +235,18 @@ impl GvarTable {
         }
         // `Kernel#trace_var` hooks fire after the store, newest first
         // (CRuby prepends each registration): a Proc command is called
-        // with the assigned value, a String command is eval'ed.
+        // with the assigned value, a String command is eval'ed — via
+        // the `__gvar_trace_eval` Ruby shim, NOT the eval builtin
+        // directly: `eval` reads its caller's bytecode pc, which this
+        // runtime helper doesn't have.
         if let Some(cmds) = globals.gvar_traces.get(&name) {
             let cmds = cmds.clone();
             let call = IdentId::get_id("call");
-            let eval = IdentId::get_id("eval");
+            let eval_shim = IdentId::get_id("__gvar_trace_eval");
             for cmd in cmds.into_iter().rev() {
                 if cmd.is_str().is_some() {
                     let main = globals.main_object;
-                    vm.invoke_method_inner(globals, eval, main, &[cmd], None, None)?;
+                    vm.invoke_method_inner(globals, eval_shim, main, &[cmd], None, None)?;
                 } else {
                     vm.invoke_method_inner(globals, call, cmd, &[val], None, None)?;
                 }


### PR DESCRIPTION
## Summary

Two batches of core/kernel spec fixes, picked by effort-to-impact after bucketing the full suite's failures per method. The full core/kernel suite (runnable since #1028 fixed the concurrent-require hang) goes from **144 failures / 85 errors to 97 / 54** — about a third of the failures resolved.

## Batch 1 — new APIs and argument semantics

- **`Kernel#trace_var` / `#untrace_var`** (was undefined): global-variable assignment hooks, fired newest-first from the single `GvarTable::set` choke point (VM and JIT both funnel through it). Proc and String (eval'ed) commands; `untrace_var` returns the removed commands.
- **`Kernel#public_method`** (was undefined): `Kernel#method` restricted to public visibility, sharing one implementation — NameError on private/protected methods, and the `respond_to_missing?` fallback consulted with `include_private = false`.
- **`Kernel#caller`**: rebuilt on the structured frames' pre-rendered strings through `Thread::Backtrace.__slice`, so it shares `caller_locations`' argument semantics — Range forms (beginless/endless/negative-end), ArgumentError on negative start/length, explicit nil length, `#to_int` coercion, and Array#[] edge cases (out-of-range → nil). Defined as a module function so `Kernel.caller` matches.
- **`Kernel#rand`**: draws from the seeded global PRNG (`srand` makes sequences repeatable — it previously used an unseeded thread RNG), Float-endpoint ranges yield Floats, empty ranges nil, degenerate ranges their endpoint, and generic endpoints (Time, custom numerics) round-trip through `end - start` / `start + offset`.
- **`Kernel#Rational`**: nil raises TypeError with CRuby's literal echo (`can't convert nil into Rational`), the two-arg form gains `#to_r` / `#to_int` fallbacks (String scaling), exactly-real Complexes contribute their real part, non-real Complexes fall back to division or RangeError echoing the value (`can't convert 1+2i into Rational`), and `exception: false` now yields nil for these.
- **`sprintf` / `printf`**: conversion characters are validated before demanding an argument (`sprintf("%\n")` is malformed even with no arguments left), and truncated/malformed specifiers report CRuby's `malformed format string` (echoing printable characters only).

## Batch 2 — conversions, exit status, method presence

- **`Kernel#Float`** preserves identity for Float inputs and `#to_f` results (`Float(nan).equal?(nan)` holds).
- **`SystemExit`** carries the full Integer status — the kind stored a `u8`, so `exit(-2**16)` reported status 0 and `exit(-2.2)` reported 254. The process still exits with the OS-truncated value.
- **`Kernel#Array`** follows CRuby's nil protocol: a nil `#to_ary` falls through to `#to_a`, a nil `#to_a` wraps the argument.
- **`Kernel#String`** raises TypeError (not NoMethodError) when `#to_s` is missing or `#respond_to?` denies it; every probe is guarded so `BasicObject` instances reach the TypeError too.
- **`Kernel#initialize_copy`** checks the receiver's frozen state (FrozenError) and reports CRuby's exact TypeError message.
- **`Kernel#global_variables`** implemented (was undefined).
- **`Kernel#select`** (delegates to `IO.select`), **`#syscall`** (NotImplementedError), **`#readline` / `#readlines`** (over ARGF) defined as module functions, fixing the private-instance/public-singleton presence specs.
- **`fail`** is a true alias of `raise` on both the instance and singleton sides (ruby/spec compares the Method objects).
- **`Kernel#sleep`** accepts any object responding to `#divmod` (CRuby's `rb_time_interval` protocol).

## ruby/spec results

| Suite | before | after |
|---|---|---|
| core/kernel (full) | 144 failures / 85 errors | **97 failures / 54 errors** |
| core/exception | 0 failures | 0 failures |
| core/thread | 1 failure (known) | 1 failure |
| core/io | 27 failures / 15 errors | unchanged |
| core/file | 27 failures / 14 errors | 27 failures / 12 errors |

Largest remaining buckets: require/load/autoload (~52, load-path semantics), eval (12, bindings/refinements), Complex mocks, warn edge cases.

## Testing

- `cargo test` full suite green, including 8 new differential tests: `caller_argument_edges`, `trace_var_untrace_var`, `rand_range_forms`, `kernel_rational_conversions`, `public_method_visibility`, `sprintf_malformed_format`, `kernel_conversion_and_misc_edges`, plus the existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_