### PR TITLE
require/load/autoload: CRuby resolution rules, feature matching, caller-cbase autoload (4 spec files: 39F/26E → 3F/8E)

### DIFF
--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1133,7 +1133,7 @@ fn resolve_feature_path(
     _: BytecodePtr,
 ) -> Result<Value> {
     let file_name = to_path(vm, globals, lfp.arg(0))?;
-    match globals.search_lib(&file_name) {
+    match globals.search_lib(vm, &file_name) {
         Some(path) => {
             let ext = match path.extension().and_then(|s| s.to_str()) {
                 Some(ext) => Value::symbol_from_str(ext),

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3098,13 +3098,12 @@ fn kernel_array(
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/require.html]
 #[monoruby_builtin]
 fn require(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    // NOTE: `require` is intentionally left on `coerce_to_string`.
-    // It is intercepted by CRuby's rubygems `kernel_require.rb`
-    // shim, and routing the arg through `#to_path` here perturbs
-    // `$LOADED_FEATURES` bookkeeping in that shim. `require_relative`
-    // and `load` use the direct builtin path and do get the
-    // CRuby-accurate `#to_path`/`#to_str` coercion.
-    let feature = lfp.arg(0).coerce_to_string(vm, globals)?;
+    // The rubygems `kernel_require.rb` shim normally pre-converts the
+    // argument with `File.path`, so a String arrives here and the
+    // protocol below is a no-op — but with the shim absent (`--no-gems`
+    // / the test harness) the builtin itself must run the
+    // `#to_path`/`#to_str` chain.
+    let feature = path_arg_to_string(vm, globals, lfp.arg(0))?;
     let file_name = std::path::PathBuf::from(feature);
     let b = vm.require(globals, &file_name, false)?;
     Ok(Value::bool(b))
@@ -5908,6 +5907,63 @@ mod tests {
               res << e.path.include?("..")
               res << e.path.end_with?("/nope.rb")
             end
+            res << $mark
+            Dir.glob(File.join(dir, "*")) { |f| File.delete(f) rescue nil }
+            begin; Dir.rmdir(dir); rescue; end
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn require_path_protocol_edges() {
+        // The #to_path → #to_str chain (a non-String #to_path result is
+        // itself converted), tilde-expanded load, the circular-require
+        // verbose warning, and Kernel#autoload?'s inherit argument.
+        run_test_once(
+            r#"
+            dir = File.join(ENV["TMPDIR"] || "/tmp", "mrb_req_proto_#{Process.pid}")
+            Dir.mkdir(dir) unless File.exist?(dir)
+            $mark = []
+            path = File.join(dir, "proto_feat.rb")
+            File.write(path, "$mark << :proto\n")
+            circ = File.join(dir, "circ_feat.rb")
+            File.write(circ, "$mark << :circ\nrequire #{circ.inspect}\n")
+            res = []
+            # to_path returns a non-String that responds to to_str.
+            inner = Object.new
+            inner.define_singleton_method(:to_str) { path }
+            name = Object.new
+            name.define_singleton_method(:to_path) { inner }
+            res << require(name)
+            res << (File.path(name) == path)
+            # A chain whose to_str result is not a String raises.
+            bad_inner = Object.new
+            bad_inner.define_singleton_method(:to_str) { :nope }
+            bad = Object.new
+            bad.define_singleton_method(:to_path) { bad_inner }
+            res << (begin; File.path(bad); rescue TypeError; :te; end)
+            # load with a tilde path.
+            old_home = ENV["HOME"]
+            begin
+              ENV["HOME"] = dir
+              res << load("~/proto_feat.rb")
+            ensure
+              ENV["HOME"] = old_home
+            end
+            # Same-thread circular require: loads once, returns true,
+            # warns in verbose mode (stderr, invisible to the value
+            # comparison).
+            old_verbose = $VERBOSE
+            begin
+              $VERBOSE = true
+              res << require(circ)
+            ensure
+              $VERBOSE = old_verbose
+            end
+            # Kernel#autoload? accepts the inherit argument.
+            autoload :ProtoEdge, "proto_edge.rb"
+            res << autoload?(:ProtoEdge, false)
             res << $mark
             Dir.glob(File.join(dir, "*")) { |f| File.delete(f) rescue nil }
             begin; Dir.rmdir(dir); rescue; end

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -144,6 +144,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_module_func(kernel_class, "require_relative", require_relative, 1);
     globals.define_builtin_module_func_with(kernel_class, "load", load_, 1, 2, false);
     globals.define_builtin_module_func(kernel_class, "autoload", autoload, 2);
+    globals.define_builtin_module_func_with(kernel_class, "autoload?", autoload_query, 1, 2, false);
     globals.define_builtin_module_func_with_effect(
         kernel_class,
         "eval",
@@ -3155,7 +3156,9 @@ fn require_relative(
     file_name.pop();
     let feature = std::path::PathBuf::from(path_arg_to_string(vm, globals, lfp.arg(0))?);
     file_name.extend(&feature);
-    file_name.set_extension("rb");
+    // No extension munging here: the shared resolution appends `.rb`
+    // itself, and `require_relative "x.ext"` must mean `x.ext.rb`
+    // (set_extension would *replace* the foreign extension).
     let b = vm.require(globals, &file_name, true)?;
     Ok(Value::bool(b))
 }
@@ -3179,15 +3182,81 @@ fn load_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 ///
 /// - autoload(const_name, feature) -> nil
 ///
+/// Registers on the caller's cbase — the innermost runtime class
+/// context (class body, class_eval, instance_eval) when one is active,
+/// otherwise the calling method's lexical class: a method written in a
+/// module registers on that module, one written in a `Class.new` block
+/// on the anonymous class, and the top level on Object.
+///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/autoload.html]
 #[monoruby_builtin]
-fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let const_name = lfp.arg(0).expect_symbol_or_string(globals)?;
-    let feature = lfp.arg(1).coerce_to_string(vm, globals)?;
-    globals
-        .store
-        .set_constant_autoload(vm.context_class_id(), const_name, feature);
-    Ok(Value::nil())
+fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    let cbase = kernel_cbase(vm, globals);
+    let target = globals.store.get_module(cbase).as_val();
+    super::module::autoload_on(vm, globals, target, lfp.arg(0), lfp.arg(1), pc)
+}
+
+/// ### Kernel.#autoload?
+///
+/// - autoload?(const_name, inherit = true) -> String | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/autoload=3f.html]
+#[monoruby_builtin]
+fn autoload_query(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let cbase = kernel_cbase(vm, globals);
+    let name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let inherit = lfp.try_arg(1).is_none() || lfp.arg(1).as_bool();
+    let module = globals.store.get_module(cbase);
+    super::module::autoload_query_on(globals, module, name, inherit)
+}
+
+/// The caller's cbase for `Kernel#autoload` / `#autoload?`, mirroring
+/// `Executor::plain_def_definee`'s discrimination: a call from inside
+/// a *method* body uses the cref captured when that method's `def`
+/// executed (`nested_definee` — a method defined in a `Class.new`
+/// block reports the anonymous class, one written in a module reports
+/// that module), NOT the runtime cref, which may be a caller's
+/// `instance_eval` context leaking in through the shared stack (mspec
+/// runs every example under `instance_exec`). Any other caller (top
+/// level, class body, eval/instance_eval block) uses the runtime class
+/// context. Blocks resolve through their enclosing method
+/// (`outermost`).
+fn kernel_cbase(vm: &Executor, globals: &Globals) -> ClassId {
+    if let Some(caller) = vm.cfp().prev() {
+        let caller_lfp = caller.lfp();
+        let outer_lfp = caller_lfp.outermost().0;
+        let fid = outer_lfp.func_id();
+        let info = &globals.store[fid];
+        if (info.is_method() || info.meta().is_proc_method())
+            && let Some(iseq) = info.is_iseq()
+        {
+            let info = &globals.store[iseq];
+            if let Some(c) = info.nested_definee {
+                return c;
+            }
+            return info.lexical_context.last().copied().unwrap_or(OBJECT_CLASS);
+        }
+        // Block or top-level caller. A block invoked through the
+        // eval family has its `self` rebound away from its write
+        // site's — only then does the runtime cref apply; a plain
+        // `Proc#call` keeps the write-site cref (a lambda defined at
+        // the top level registers on Object no matter who calls it).
+        if caller_lfp.self_val().id() == outer_lfp.self_val().id()
+            && let Some(iseq) = info.is_iseq()
+        {
+            return globals.store[iseq]
+                .lexical_context
+                .last()
+                .copied()
+                .unwrap_or(OBJECT_CLASS);
+        }
+    }
+    vm.context_class_id()
 }
 
 ///
@@ -5783,6 +5852,106 @@ mod tests {
               e
             end
             [wrapped.message, wrapped.cause&.message, custom.backtrace]
+            "#,
+        );
+    }
+
+    #[test]
+    fn require_resolution_rules() {
+        // The `.rb`-appending candidate rule, tilde expansion, verbatim
+        // and suffix $LOADED_FEATURES matching, #to_path load-path
+        // entries, and LoadError path normalization — all differential
+        // against CRuby.
+        run_test_once(
+            r#"
+            dir = File.join(ENV["TMPDIR"] || "/tmp", "mrb_req_rules_#{Process.pid}")
+            Dir.mkdir(dir) unless File.exist?(dir)
+            $mark = []
+            File.write(File.join(dir, "feat"), "$mark << :bare\n")
+            File.write(File.join(dir, "feat.rb"), "$mark << :rb\n")
+            File.write(File.join(dir, "feat.ext"), "$mark << :ext\n")
+            File.write(File.join(dir, "feat.ext.rb"), "$mark << :extrb\n")
+            File.write(File.join(dir, "tilde_feat.rb"), "$mark << :tilde\n")
+            File.write(File.join(dir, "lp_feat.rb"), "$mark << :lp\n")
+            res = []
+            # `require "x"` / `require "x.ext"` load x.rb / x.ext.rb,
+            # never the bare or foreign-extensioned file.
+            res << require(File.join(dir, "feat"))
+            res << require(File.join(dir, "feat.ext"))
+            res << $mark
+            res << $LOADED_FEATURES.last(2).map { |f| File.basename(f) }
+            # Tilde expansion resolves against $HOME.
+            old_home = ENV["HOME"]
+            begin
+              ENV["HOME"] = dir
+              res << require("~/tilde_feat.rb")
+            ensure
+              ENV["HOME"] = old_home
+            end
+            # Verbatim stored relative entries and extensionless
+            # entries short-circuit to false.
+            $LOADED_FEATURES << "./phantom_xyz.rb"
+            res << require("./phantom_xyz.rb")
+            $LOADED_FEATURES << "phantom_bare"
+            res << require("phantom_bare")
+            # A #to_path object works as a $LOAD_PATH entry.
+            lp = Object.new
+            lp.define_singleton_method(:to_path) { dir }
+            $LOAD_PATH.unshift(lp)
+            res << require("lp_feat")
+            $LOAD_PATH.delete(lp)
+            # A missing require_relative reports the lexically-collapsed
+            # path.
+            begin
+              require_relative(File.join(dir, "sub", "..", "nope.rb"))
+            rescue LoadError => e
+              res << e.path.include?("..")
+              res << e.path.end_with?("/nope.rb")
+            end
+            res << $mark
+            Dir.glob(File.join(dir, "*")) { |f| File.delete(f) rescue nil }
+            begin; Dir.rmdir(dir); rescue; end
+            res
+            "#,
+        );
+    }
+
+    #[test]
+    fn kernel_autoload_cbase() {
+        // Kernel#autoload registers on the caller's cbase: the method's
+        // captured cref (anonymous class for a Class.new-defined
+        // method, the module for a module-defined method), Object for
+        // the top level and for a lambda defined there.
+        run_test_once(
+            r#"
+            cls = Class.new do
+              def go
+                autoload :Zxq, "bogus"
+                autoload? :Zxq
+              end
+            end
+            module MbCbaseSpec
+              def setup_auto(path)
+                autoload :Yxq, path
+              end
+            end
+            class MbCbaseIncluder
+              include MbCbaseSpec
+            end
+            MbCbaseIncluder.new.setup_auto("/tmp/yxq_#{Process.pid}.rb")
+            top_lambda = -> { autoload :Wxq, "wxq.rb"; autoload?(:Wxq) }
+            autoload :Vxq, "vxq.rb"
+            def chk_auto(c); autoload?(c); end
+            [
+              cls.new.go,
+              cls.autoload?(:Zxq),
+              MbCbaseSpec.autoload?(:Yxq).nil?,
+              MbCbaseIncluder.autoload?(:Yxq).nil?,
+              top_lambda.call,
+              Object.autoload?(:Wxq),
+              chk_auto(:Vxq),
+              Kernel.private_instance_methods(false).include?(:autoload?),
+            ]
             "#,
         );
     }

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -674,9 +674,22 @@ fn attr_writer(
 /// [https://docs.ruby-lang.org/ja/latest/method/Module/i/autoload.html]
 #[monoruby_builtin]
 fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    let const_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    autoload_on(vm, globals, lfp.self_val(), lfp.arg(0), lfp.arg(1), pc)
+}
+
+/// Shared body of `Module#autoload` and `Kernel#autoload` (the latter
+/// passes its caller's cbase as *target*).
+pub(super) fn autoload_on(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    target: Value,
+    name_arg: Value,
+    feature_arg: Value,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let const_name = name_arg.expect_symbol_or_string(globals)?;
     validate_constant_name(const_name)?;
-    let feature = lfp.arg(1).coerce_to_path_rstring(vm, globals)?;
+    let feature = feature_arg.coerce_to_path_rstring(vm, globals)?;
     let feature = feature.to_str()?.to_string();
     if feature.is_empty() {
         return Err(MonorubyErr::argumenterr("empty file name"));
@@ -684,8 +697,8 @@ fn autoload(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
     // CRuby raises a `FrozenError` *before* recording any autoload state so
     // that `frozen_module.autoload :Foo, ...` neither installs the entry
     // nor stores the constant name.
-    lfp.self_val().ensure_not_frozen(&globals.store)?;
-    let class_id = lfp.self_val().as_class_id();
+    target.ensure_not_frozen(&globals.store)?;
+    let class_id = target.as_class_id();
     // CRuby treats `autoload :Foo, path` as a no-op when `path` resolves
     // to a file that is already loaded (`$LOADED_FEATURES`) or is the
     // current `require`'s in-flight file. Mirrors `rb_autoload_str`'s
@@ -745,7 +758,18 @@ fn autoload_query(
 ) -> Result<Value> {
     let name = lfp.arg(0).expect_symbol_or_string(globals)?;
     let inherit = lfp.try_arg(1).is_none() || lfp.arg(1).as_bool();
-    let mut module = lfp.self_val().as_class();
+    autoload_query_on(globals, lfp.self_val().as_class(), name, inherit)
+}
+
+/// Shared body of `Module#autoload?` and `Kernel#autoload?` (the
+/// latter passes its caller's cbase).
+pub(super) fn autoload_query_on(
+    globals: &Globals,
+    module: Module,
+    name: IdentId,
+    inherit: bool,
+) -> Result<Value> {
+    let mut module = module;
     loop {
         if let Some(state) = globals.store.get_constant(module.id(), name) {
             match &state.kind {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -700,7 +700,7 @@ impl Executor {
         is_relative: bool,
     ) -> Result<bool> {
         let (file_body, canonicalized_path) = loop {
-            match globals.require_lib(file_name, is_relative)? {
+            match globals.require_lib(self, file_name, is_relative)? {
                 crate::globals::RequireLoad::Load(body, path) => break (body, path),
                 crate::globals::RequireLoad::AlreadyLoaded(path) => {
                     // The feature is registered — but its body may still
@@ -730,9 +730,30 @@ impl Executor {
                             globals.remove_loaded_feature(&path);
                             continue;
                         }
-                        // No loader, or a circular require on the
-                        // loading thread itself: already loaded.
-                        _ => return Ok(false),
+                        // A circular require on the loading thread
+                        // itself returns false; CRuby additionally
+                        // warns in verbose mode.
+                        Some(_) => {
+                            let verbose =
+                                GvarTable::get(self, globals, IdentId::get_id("$VERBOSE"));
+                            if verbose.as_bool() {
+                                let msg = format!(
+                                    "loading in progress, circular require considered harmful - {}",
+                                    path.display()
+                                );
+                                let _ = self.invoke_method_inner(
+                                    globals,
+                                    IdentId::get_id("warn"),
+                                    globals.main_object,
+                                    &[Value::string(msg)],
+                                    None,
+                                    None,
+                                );
+                            }
+                            return Ok(false);
+                        }
+                        // No loader: already loaded.
+                        None => return Ok(false),
                     }
                 }
             }
@@ -893,7 +914,7 @@ impl Executor {
             None
         };
 
-        let (file_body, path) = globals.find_for_load(file_name)?;
+        let (file_body, path) = globals.find_for_load(self, file_name)?;
         self.load_impl(globals, file_body, &path, wrap)?;
         Ok(())
     }

--- a/monoruby/src/executor/constants.rs
+++ b/monoruby/src/executor/constants.rs
@@ -73,7 +73,21 @@ impl Executor {
         #[cfg(feature = "dump-require")]
         eprintln!("{} > Autoload:{:?}", "  ".repeat(_level), name);
 
-        let res = self.require(globals, &feature, false);
+        // CRuby fires the autoload by *dispatching* `require` on the
+        // top-level main object (`rb_funcall(rb_vm_top_self(), ...)`),
+        // so a redefined/mocked `main.require` intercepts the load.
+        let res = {
+            let main = globals.main_object;
+            let feature_val = Value::string_from_str(&feature.to_string_lossy());
+            self.invoke_method_inner(
+                globals,
+                IdentId::get_id("require"),
+                main,
+                &[feature_val],
+                None,
+                None,
+            )
+        };
 
         #[cfg(feature = "dump-require")]
         eprintln!("{} < Autoload:{:?}", "  ".repeat(_level), name);

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -595,7 +595,14 @@ impl Globals {
                 .into_iter()
                 .map(|p| p.to_string_lossy().into_owned()),
         );
-        let list: Vec<_> = path_list.split('\n').map(|s| s.to_string()).collect();
+        // Skip blank lines (the cache file ends with a newline): an
+        // empty `$LOAD_PATH` entry would make bare `require`s resolve
+        // against the CWD, which CRuby forbids for security.
+        let list: Vec<_> = path_list
+            .split('\n')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
         globals.extend_load_path(list.iter().cloned());
 
         // set constants

--- a/monoruby/src/globals/require.rs
+++ b/monoruby/src/globals/require.rs
@@ -15,113 +15,242 @@ pub(crate) enum RequireLoad {
     AlreadyLoaded(std::path::PathBuf),
 }
 
+/// The candidate feature paths `require` may load for *path*, in
+/// CRuby's priority order. `require` never loads a file under its bare
+/// name unless it already ends in `.rb` or `.so`: both `require "x"`
+/// and `require "x.ext"` mean `x(.ext).rb` first, then the native
+/// variant (which monoruby serves from its stub tree).
+fn require_candidates(path: &std::path::Path) -> Vec<PathBuf> {
+    match path.extension().map(|e| e.as_bytes()) {
+        Some(b"rb") | Some(b"so") => vec![path.to_path_buf()],
+        _ => {
+            let s = path.as_os_str().to_string_lossy();
+            vec![PathBuf::from(format!("{s}.rb")), PathBuf::from(format!("{s}.so"))]
+        }
+    }
+}
+
+/// The canonical (symlink-resolved) form of a `$LOAD_PATH` directory,
+/// falling back to its lexically-normalized absolute form when the
+/// directory doesn't exist.
+fn canonical_dir_of(dir: &str) -> PathBuf {
+    canonical_dir_of_path(std::path::Path::new(dir))
+}
+
+fn canonical_dir_of_path(dir: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(dir).unwrap_or_else(|_| {
+        lexically_normalize(&std::path::absolute(dir).unwrap_or_else(|_| dir.to_path_buf()))
+    })
+}
+
+/// Expand a leading `~` to `$HOME` (CRuby's `require`/`load` shell
+/// expansion). Paths without the tilde come back unchanged.
+fn expand_tilde(path: &std::path::Path) -> PathBuf {
+    let s = path.as_os_str().as_bytes();
+    if s == b"~" || s.starts_with(b"~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut out = PathBuf::from(home);
+            if s.len() > 2 {
+                out.push(std::ffi::OsStr::from_bytes(&s[2..]));
+            }
+            return out;
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Whether the request already names a loadable form (`.rb` / `.so`) —
+/// such an as-given name matches `$LOADED_FEATURES` entries verbatim
+/// (including manually stored relative forms like `"./x.rb"`), whereas
+/// an extensionless request only falls back to its verbatim entry when
+/// resolution fails.
+fn has_loadable_ext(path: &std::path::Path) -> bool {
+    matches!(path.extension().map(|e| e.as_bytes()), Some(b"rb") | Some(b"so"))
+}
+
 impl Globals {
     ///
     /// Load external library.
     ///
     pub(crate) fn require_lib(
         &mut self,
+        vm: &mut Executor,
         file_name: &std::path::Path,
         is_relative: bool,
     ) -> Result<RequireLoad> {
+        let file_name = &expand_tilde(file_name);
         let path_str = file_name.to_string_lossy();
 
-        // Absolute path: try to load directly.
+        // Absolute path: try to load directly. Candidate-major order:
+        // the `.rb` verdict (loaded or loadable) is reached before the
+        // native variant is even considered, so a stored `x.so` entry
+        // doesn't block loading `x.rb` for an extensionless request.
         if path_str.starts_with('/') {
-            // Check if already loaded (with .rb or .so extension variants).
-            let mut file = PathBuf::from(file_name);
-            if file.extension().is_none() {
-                file.set_extension("rb");
-                if self.is_feature_loaded(&file) {
-                    return Ok(RequireLoad::AlreadyLoaded(file));
+            for cand in require_candidates(file_name) {
+                let canon = lexically_normalize(&cand);
+                if self.is_feature_loaded(&cand) || self.is_feature_loaded(&canon) {
+                    return Ok(RequireLoad::AlreadyLoaded(canon));
                 }
-                file.set_extension("so");
-                if self.is_feature_loaded(&file) {
-                    return Ok(RequireLoad::AlreadyLoaded(file));
-                }
-            } else if self.is_feature_loaded(&file) {
-                return Ok(RequireLoad::AlreadyLoaded(file));
-            }
-            // Try the file with its given extension first.
-            if file_name.is_file() {
-                return self.require_lib_file(file_name.into());
-            }
-            // Try appending .rb extension if none given.
-            if file_name.extension().is_none() {
-                let mut with_rb = PathBuf::from(file_name);
-                with_rb.set_extension("rb");
-                if with_rb.is_file() {
-                    return self.require_lib_file(with_rb);
-                }
-                let mut with_so = PathBuf::from(file_name);
-                with_so.set_extension("so");
-                if with_so.is_file() {
-                    return self.require_lib_file(with_so);
+                if canon.is_file() {
+                    return self.require_lib_file(canon);
                 }
             }
-            return Err(MonorubyErr::cant_load(None, file_name));
+            // The reported missing path is the lexically-normalized
+            // request: `require_relative "../x"` joins its caller's dir
+            // and CRuby reports (and stores in `LoadError#path`) the
+            // collapsed form.
+            return Err(MonorubyErr::cant_load(
+                None,
+                &lexically_normalize(file_name),
+            ));
         }
 
         // Relative path (starts with ./ or ../): resolve from CWD.
         if is_relative || path_str.starts_with("./") || path_str.starts_with("../") {
+            if has_loadable_ext(file_name) && self.is_feature_loaded(file_name) {
+                return Ok(RequireLoad::AlreadyLoaded(file_name.into()));
+            }
+            // Lexically collapse `..` segments (CRuby expand_path
+            // semantics): `bar/../x.rb` must resolve even when `bar`
+            // doesn't exist on disk.
             let resolved = if let Ok(cwd) = std::env::current_dir() {
-                cwd.join(file_name)
+                lexically_normalize(&cwd.join(file_name))
             } else {
                 file_name.into()
             };
-            if resolved.is_file() {
-                return self.require_lib_file(resolved);
+            for cand in require_candidates(&resolved) {
+                if cand.is_file() {
+                    return self.require_lib_file(cand);
+                }
             }
-            // Try with .rb and .so extensions.
-            if resolved.extension().is_none() {
-                let mut with_rb = resolved.clone();
-                with_rb.set_extension("rb");
-                if with_rb.is_file() {
-                    return self.require_lib_file(with_rb);
-                }
-                let mut with_so = resolved.clone();
-                with_so.set_extension("so");
-                if with_so.is_file() {
-                    return self.require_lib_file(with_so);
-                }
+            // An extensionless verbatim entry converts the miss to
+            // "already loaded" (require returns false).
+            if self.is_feature_loaded(file_name) {
+                return Ok(RequireLoad::AlreadyLoaded(file_name.into()));
             }
             return Err(MonorubyErr::cant_load(None, file_name));
         }
 
         // Bare path: check $LOADED_FEATURES, then search $LOAD_PATH.
         if !is_relative {
-            let mut file = PathBuf::from(file_name);
-            file.set_extension("rb");
-            if self.is_feature_loaded(&file) {
-                return Ok(RequireLoad::AlreadyLoaded(file));
+            // A verbatim stored entry under a loadable name — including
+            // non-canonical spellings like `"code/../code/x.rb"`.
+            if has_loadable_ext(file_name) && self.is_feature_loaded(file_name) {
+                return Ok(RequireLoad::AlreadyLoaded(file_name.into()));
             }
-            file.set_extension("so");
-            if self.is_feature_loaded(&file) {
-                return Ok(RequireLoad::AlreadyLoaded(file));
+            let entries = self.load_path_entries(vm);
+            // For feature matching, `$LOAD_PATH` directories compare in
+            // their canonical (symlink-resolved) form.
+            let canon_dirs: Vec<PathBuf> = entries.iter().map(|d| canonical_dir_of(d)).collect();
+            let bundler_priority = path_str == "bundler" || path_str.starts_with("bundler/");
+            for cand in require_candidates(file_name) {
+                if self.is_feature_loaded(&cand) {
+                    return Ok(RequireLoad::AlreadyLoaded(cand));
+                }
+                // CRuby's feature index: an entry ending in
+                // `/{candidate}` whose directory prefix is on the
+                // (canonicalized) load path counts as loaded — the
+                // `.rb` verdict is reached before the native pass, so
+                // a `.rb` loaded through any load-path dir blocks
+                // re-loading through another.
+                if let Some(hit) = self.feature_suffix_loaded(&cand, &canon_dirs) {
+                    return Ok(RequireLoad::AlreadyLoaded(hit));
+                }
+                if let Some(found) = self.search_candidate(&cand, &entries, bundler_priority) {
+                    return self.require_lib_file(found);
+                }
             }
-
-            if let Some(file) = self.search_lib(file_name) {
-                return self.require_lib_file(file);
+            // Resolution failed: an extensionless verbatim entry means
+            // "already loaded" (require returns false, not LoadError).
+            if self.is_feature_loaded(file_name) {
+                return Ok(RequireLoad::AlreadyLoaded(file_name.into()));
             }
         }
         Err(MonorubyErr::cant_load(None, file_name))
     }
 
-    pub(crate) fn search_lib(&mut self, file_name: &std::path::Path) -> Option<PathBuf> {
-        // Probe a single directory for `file_name`, applying the usual
-        // extension rules: an explicit extension must match exactly;
-        // otherwise try `.rb` then `.so`.
-        fn probe(dir: &std::path::Path, file_name: &std::path::Path) -> Option<PathBuf> {
-            let mut lib = dir.join(file_name);
-            if lib.extension().is_some() {
-                return lib.exists().then_some(lib);
+    /// `$LOAD_PATH` as strings: String entries verbatim, non-String
+    /// entries through the `#to_path` / `#to_str` protocol (CRuby's
+    /// `rb_get_path` per entry); unconvertible entries are skipped.
+    pub(crate) fn load_path_entries(&mut self, vm: &mut Executor) -> Vec<String> {
+        let raw: Vec<Value> = self.load_path.as_array().iter().copied().collect();
+        raw.into_iter()
+            .filter_map(|v| {
+                if let Some(s) = v.is_str() {
+                    return Some(s.to_string());
+                }
+                let pathed = if let Some(fid) = self.check_method(v, IdentId::get_id("to_path")) {
+                    vm.invoke_func_inner(self, fid, v, &[], None, None).ok()?
+                } else {
+                    v
+                };
+                if let Some(s) = pathed.is_str() {
+                    return Some(s.to_string());
+                }
+                let fid = self.check_method(pathed, IdentId::get_id("to_str"))?;
+                let s = vm.invoke_func_inner(self, fid, pathed, &[], None, None).ok()?;
+                Some(s.is_str()?.to_string())
+            })
+            .collect()
+    }
+
+    /// A `$LOADED_FEATURES` entry that ends in `/{cand}` and whose
+    /// directory prefix is one of the (canonicalized) load-path dirs.
+    fn feature_suffix_loaded(
+        &self,
+        cand: &std::path::Path,
+        canon_dirs: &[PathBuf],
+    ) -> Option<PathBuf> {
+        let suffix = format!("/{}", cand.display());
+        for v in self.loaded_features.as_array().iter() {
+            let Some(e) = v.is_str() else { continue };
+            if e.len() > suffix.len() && e.ends_with(&suffix) {
+                let prefix = &e[..e.len() - suffix.len()];
+                if canon_dirs
+                    .iter()
+                    .any(|d| d.as_os_str().as_bytes() == prefix.as_bytes())
+                {
+                    return Some(PathBuf::from(e));
+                }
             }
-            lib.set_extension("rb");
-            if lib.exists() {
-                return Some(lib);
+        }
+        None
+    }
+
+    pub(crate) fn search_lib(
+        &mut self,
+        vm: &mut Executor,
+        file_name: &std::path::Path,
+    ) -> Option<PathBuf> {
+        let entries = self.load_path_entries(vm);
+        let s = file_name.to_string_lossy();
+        let bundler_priority = s == "bundler" || s.starts_with("bundler/");
+        for cand in require_candidates(file_name) {
+            if let Some(p) = self.search_candidate(&cand, &entries, bundler_priority) {
+                return Some(p);
             }
-            lib.set_extension("so");
-            lib.exists().then_some(lib)
+        }
+        None
+    }
+
+    /// Search one concrete candidate (`x.rb` / `x.so` form) through the
+    /// stub pin, the host-bundler override, and `$LOAD_PATH`. The
+    /// returned path joins the *canonicalized* directory with the
+    /// candidate as given: CRuby resolves symlinks in the `$LOAD_PATH`
+    /// entry but never in the feature name, and that composite is what
+    /// lands in `$LOADED_FEATURES`.
+    fn search_candidate(
+        &mut self,
+        cand: &std::path::Path,
+        entries: &[String],
+        bundler_priority: bool,
+    ) -> Option<PathBuf> {
+        fn probe(dir: &std::path::Path, cand: &std::path::Path) -> Option<PathBuf> {
+            if dir.join(cand).exists() {
+                Some(canonical_dir_of_path(dir).join(cand))
+            } else {
+                None
+            }
         }
 
         // Pin monoruby's own C-extension replacement stubs ahead of
@@ -148,7 +277,7 @@ impl Globals {
         // is merely first), letting host activation shadow it consistently.
         let stub_root = install_root().join("stub");
         for dir in [stub_root.clone(), stub_root.join(ruby_platform())] {
-            if let Some(p) = probe(&dir, file_name) {
+            if let Some(p) = probe(&dir, cand) {
                 return Some(p);
             }
         }
@@ -168,32 +297,21 @@ impl Globals {
         // precedence here so the outcome no longer depends on activation
         // order. When the host has no bundler the normal loop below still
         // falls back to the vendored copy.
-        let is_bundler = {
-            let s = file_name.to_string_lossy();
-            s == "bundler" || s.starts_with("bundler/")
-        };
-        if is_bundler {
+        if bundler_priority {
             let vendored_lib = install_root().join("lib");
-            for lib in self.load_path.as_array().iter() {
-                let Some(lib) = lib.is_str() else {
-                    continue;
-                };
+            for lib in entries {
                 let path = std::path::Path::new(lib);
                 if path.starts_with(&vendored_lib) {
                     continue;
                 }
-                if let Some(p) = probe(path, file_name) {
+                if let Some(p) = probe(path, cand) {
                     return Some(p);
                 }
             }
         }
 
-        for lib in self.load_path.as_array().iter() {
-            let lib = match lib.is_str() {
-                Some(s) => s,
-                None => continue,
-            };
-            if let Some(p) = probe(std::path::Path::new(lib), file_name) {
+        for lib in entries {
+            if let Some(p) = probe(std::path::Path::new(lib), cand) {
                 return Some(p);
             }
         }
@@ -268,8 +386,10 @@ impl Globals {
     ///
     pub(crate) fn find_for_load(
         &mut self,
+        vm: &mut Executor,
         file_name: &std::path::Path,
     ) -> Result<(Vec<u8>, std::path::PathBuf)> {
+        let file_name = &expand_tilde(file_name);
         let path_str = file_name.to_string_lossy();
 
         // Absolute path: load directly. `__FILE__` (and
@@ -292,12 +412,9 @@ impl Globals {
             return Ok((body, resolved));
         }
 
-        // Bare filename: search $LOAD_PATH.
-        for lib in self.load_path.as_array().iter() {
-            let lib = match lib.is_str() {
-                Some(s) => s,
-                None => continue,
-            };
+        // Bare filename: search $LOAD_PATH (entries go through the
+        // #to_path / #to_str protocol).
+        for lib in self.load_path_entries(vm) {
             let lib = std::path::PathBuf::from(lib).join(file_name);
             if let Ok(res) = load_file(&lib) {
                 return Ok(res);

--- a/monoruby/src/value/coerce.rs
+++ b/monoruby/src/value/coerce.rs
@@ -16,6 +16,23 @@ fn coerce_to_rstring_inner(
             if let Some(s) = result.is_rstring() {
                 return Ok(s);
             }
+            // CRuby's `rb_get_path` chains: a non-String `#to_path`
+            // result is itself converted with `#to_str`.
+            if method == IdentId::TO_PATH
+                && let Some(fid2) = globals.check_method(result, IdentId::TO_STR)
+            {
+                let result2 = vm.invoke_func_inner(globals, fid2, result, &[], None, None)?;
+                if let Some(s) = result2.is_rstring() {
+                    return Ok(s);
+                }
+                return Err(MonorubyErr::cant_convert_error(
+                    globals,
+                    result,
+                    result2,
+                    "String",
+                    IdentId::TO_STR,
+                ));
+            }
             return Err(MonorubyErr::cant_convert_error(
                 globals, recv, result, "String", method,
             ));


### PR DESCRIPTION
## Summary

Recovers the require/load/autoload group of core/kernel specs, after a per-root-cause investigation of the ~65 failures in the group. The 4 spec files (require / require_relative / load / autoload) go from **39 failures / 26 errors to 3 / 8**, and the full core/kernel suite from **97 / 54 to 59 / 35**. Rebased on the current master (1165319).

## Resolution rules

- `require` follows CRuby's candidate rule: `require "x"` and `require "x.ext"` both mean `x(.ext).rb` first, then the native variant — a bare or foreign-extensioned file is never loaded as-is. The `.rb` pass sweeps the whole `$LOAD_PATH` before the native pass (a `.rb` in a later dir beats a C-extension in an earlier one). Also fixes `require_relative` clobbering foreign extensions (`set_extension` *replaced* `.ext`, so `require_relative "x.ext"` looked for `x.rb`).
- A leading `~` expands to `$HOME` for `require` and `load`, and the expansion is what lands in `$LOADED_FEATURES`.
- `require_relative`'s LoadError reports (and stores in `LoadError#path`) the lexically-collapsed path, and CWD-relative requires collapse `..` segments before the file test (a synthetic `bar/../x.rb` resolves even when `bar` doesn't exist on disk).
- Fixed the startup `$LOAD_PATH` picking up an **empty entry** from the library-path cache's trailing newline — an empty entry made bare requires resolve against the CWD, which CRuby forbids for security ([ruby-core:24155]). This alone explained the two "does not load … unless the current working directory is in $LOAD_PATH" failures.

## `$LOADED_FEATURES` matching (CRuby's feature index)

- Verbatim stored entries match the as-given request (`"./x.rb"`, `"../x.rb"`, non-canonical spellings); an extensionless stored entry converts a resolution miss into `false` instead of LoadError.
- An entry ending in `/{candidate}` whose directory prefix is on the canonicalized `$LOAD_PATH` counts as loaded — a feature loaded through one load-path dir isn't re-loaded through another, and the `.rb` verdict is reached before the native pass (a stored `x.so` doesn't block loading `x.rb`).
- Load-path search results join the *canonicalized* (symlink-resolved) directory with the candidate as given, matching CRuby's "canonicalizes the entry in `$LOAD_PATH` but not the filename passed to `#require`".
- In verbose mode a same-thread circular require now warns `loading in progress, circular require considered harmful` (built on the per-feature load-lock registry from #1028).

## `#to_path` protocol

- `rb_get_path` chaining: a non-String `#to_path` result is converted with `#to_str` — applied in the shared path coercion, so every path-taking API benefits.
- `$LOAD_PATH` entries go through `#to_path` / `#to_str` per lookup, for `require` and `load` alike.

## `Kernel#autoload` / `#autoload?`

- Previously a bare singleton shim (`autoload?` was missing entirely, breaking every `check_autoload` spec). Now full-featured private-instance/module functions sharing `Module#autoload`'s implementation — `#to_path` coercion, FrozenError before recording, already-loaded no-op, const_source_location recording — applied to the **caller's cbase**, mirroring `plain_def_definee`'s discrimination:
  - a method written in a module registers on that module (and is reachable from including classes),
  - a method defined in a `Class.new` block registers on the anonymous class (the captured `nested_definee` cref),
  - a top-level caller or a lambda defined at the top level registers on Object no matter who calls it,
  - eval-family blocks (self rebound away from the write site) use the runtime class context.

  The tricky case: mspec runs every example under `instance_exec`, whose runtime cref leaks into called methods through the shared cref stack — the method-body path must use the captured cref, not the stack top.
- The autoload now fires by *dispatching* `require` on the top-level main object (CRuby's `rb_funcall(rb_vm_top_self(), ...)`), so a redefined/mocked `main.require` intercepts the load.

## Remaining in the group (documented)

- `load(path, wrap)` (~9): needs wrap-module cref/self semantics (self as a main copy extended with the wrap module, top-level defs into it, constant fallback to Object) — a follow-up-sized change.
- Two environment-shaped specs: the provided-features list comparison and a C-extension `LoadError#path` edge.

## ruby/spec results

| Suite | before | after |
|---|---|---|
| require/require_relative/load/autoload specs | 39 failures / 26 errors | **3 failures / 8 errors** |
| core/kernel (full) | 97 failures / 54 errors | **59 failures / 35 errors** |
| core/exception | 0 failures | 0 failures |
| core/module | — | autoload failures are the pre-existing thread-visibility group only |

## Testing

- `cargo test` full suite green, including 2 new differential tests: `require_resolution_rules` (candidate rule, tilde, verbatim/suffix feature matching, `#to_path` load-path entries, LoadError normalization) and `kernel_autoload_cbase` (all four cbase shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_