### PR TITLE
spec: tag currently-failing language specs as fails

### DIFF
--- a/spec/tags/language/pattern_matching_tags.txt
+++ b/spec/tags/language/pattern_matching_tags.txt
@@ -1,0 +1,3 @@
+fails:Pattern matching refinements are used for #deconstruct
+fails:Pattern matching refinements are used for #deconstruct_keys
+fails:Pattern matching refinements are used for #=== in constant pattern

--- a/spec/tags/language/predefined_tags.txt
+++ b/spec/tags/language/predefined_tags.txt
@@ -1,0 +1,2 @@
+fails:Predefined global $_ is Thread-local
+fails:$LOAD_PATH.resolve_feature_path returns what will be loaded without actual loading, .so file

--- a/spec/tags/language/regexp/back-references_tags.txt
+++ b/spec/tags/language/regexp/back-references_tags.txt
@@ -1,0 +1,1 @@
+fails:Regexps with back-references will not clobber capture variables across threads

--- a/spec/tags/language/regexp/character_classes_tags.txt
+++ b/spec/tags/language/regexp/character_classes_tags.txt
@@ -1,0 +1,1 @@
+fails:Regexp with character classes matches Unicode join control characters with [[:word:]]

--- a/spec/tags/language/regexp/encoding_tags.txt
+++ b/spec/tags/language/regexp/encoding_tags.txt
@@ -1,0 +1,3 @@
+fails:Regexps with encoding modifiers supports /s (Windows_31J encoding)
+fails:Regexps with encoding modifiers supports /s (Windows_31J encoding) with interpolation
+fails:Regexps with encoding modifiers supports /s (Windows_31J encoding) with interpolation and /o

--- a/spec/tags/language/regexp/modifiers_tags.txt
+++ b/spec/tags/language/regexp/modifiers_tags.txt
@@ -1,0 +1,1 @@
+fails:Regexps with modifiers supports /o (once)

--- a/spec/tags/language/regexp/repetition_tags.txt
+++ b/spec/tags/language/regexp/repetition_tags.txt
@@ -1,0 +1,2 @@
+fails:Regexps with repetition does not treat {m,n}+ as possessive
+fails:Regexps with repetition supports nested quantifiers


### PR DESCRIPTION
## What

Add `spec/tags/language/` with the 13 currently-failing examples from ruby/spec's `language/` group tagged as `fails`, so the group runs cleanly under monoruby.

Motivated by [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/) showing "Language 0.0% of 2930" for `monoruby dev`. Locally the picture is actually much better — a clean `mspec language` runs at ~99.6% (2913/2931 passing) — but the 13 real gaps below are worth tracking as tags either way.

## Investigation

```
$ mspec language -t monoruby -f s
80 files, 2931 examples, 5517 expectations, 15 failures, 3 errors, 0 tagged
```

Of the 15 failures, 5 were host-env noise, not real bugs: `source_encoding_spec` (4) and `END_spec` "The END keyword runs all handlers even if some raise exceptions" (1) all read `Kernel.warn` output and assert it's empty, but monoruby's startup prints `Warning: failed to read library path file: "/root/.monoruby/library_path". Ruby may not be installed.` when no host Ruby was ever probed. Touching that cache path suppresses the warning and drops those 5 to genuine passes:

```
$ touch ~/.monoruby/library_path ~/.monoruby/gem_path
$ mspec tag language -t monoruby
80 files, 2931 examples, 10 failures, 3 errors, 0 tagged
```

Leaving 13 real failures — the ones tagged here.

## Tags added

```
spec/tags/language/pattern_matching_tags.txt              (3 fails)
    fails:Pattern matching refinements are used for #deconstruct
    fails:Pattern matching refinements are used for #deconstruct_keys
    fails:Pattern matching refinements are used for #=== in constant pattern

spec/tags/language/predefined_tags.txt                    (2 fails)
    fails:Predefined global $_ is Thread-local
    fails:$LOAD_PATH.resolve_feature_path returns what will be loaded without actual loading, .so file

spec/tags/language/regexp/back-references_tags.txt        (1 fail)
spec/tags/language/regexp/character_classes_tags.txt      (1 fail)
spec/tags/language/regexp/encoding_tags.txt               (3 fails)
spec/tags/language/regexp/modifiers_tags.txt              (1 fail)
spec/tags/language/regexp/repetition_tags.txt             (2 fails)
```

## Verification

```
$ mspec language --excl-tag fails -t monoruby -f s
80 files, 2931 examples, 5501 expectations, 0 failures, 0 errors, 13 tagged
```

## Notes

- The 0.0% figure on rubyspec-stats does not reproduce locally; something in that pipeline (a different monoruby build? a wrapper that suppresses stdout?) is presumably at fault too. This PR at least gets the tag tree in shape so the eventual fix on either side lands on top of a clean baseline.
- No parser / codegen change; only new `spec/tags/language/**` files.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_