### PR TITLE
regexp: native-encoding byte matching for non-UTF-8 subjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onigmo-regex"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/onigmo-regex.git#9fdfb990d610fad2214e79b9ea9f7ca23bd07736"
+source = "git+https://github.com/sisshiki1969/onigmo-regex.git#e95fad2a5d75e078cd78ec7019ccdf516ab4a8f7"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/monoruby/src/builtins/match_data.rs
+++ b/monoruby/src/builtins/match_data.rs
@@ -346,8 +346,8 @@ fn offset(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let idx = resolve_capture_index(vm, globals, &m, lfp.arg(0))?;
     match m.pos(idx) {
         Some((start, end)) => {
-            let s = m.string()[..start].chars().count() as i64;
-            let e = m.string()[..end].chars().count() as i64;
+            let s = m.char_count_upto(start) as i64;
+            let e = m.char_count_upto(end) as i64;
             Ok(Value::array_from_vec(vec![Value::integer(s), Value::integer(e)]))
         }
         None => Ok(Value::array_from_vec(vec![Value::nil(), Value::nil()])),
@@ -787,7 +787,7 @@ fn match_begin(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
     let idx = resolve_capture_index(vm, globals, &m, lfp.arg(0))?;
     match m.pos(idx) {
         Some((start, _)) => {
-            let char_offset = m.string()[..start].chars().count();
+            let char_offset = m.char_count_upto(start);
             Ok(Value::integer(char_offset as i64))
         }
         None => Ok(Value::nil()),
@@ -809,7 +809,7 @@ fn match_end(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     let idx = resolve_capture_index(vm, globals, &m, lfp.arg(0))?;
     match m.pos(idx) {
         Some((_, end_pos)) => {
-            let char_offset = m.string()[..end_pos].chars().count();
+            let char_offset = m.char_count_upto(end_pos);
             Ok(Value::integer(char_offset as i64))
         }
         None => Ok(Value::nil()),

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -2556,4 +2556,33 @@ mod tests {
                [m.string.bytes, m.string.encoding.to_s, m.string.frozen?]"#,
         );
     }
+
+    #[test]
+    fn regexp_match_iso8859_variants() {
+        // Every ISO-8859-N Onigmo codec: single high byte is one char,
+        // so `/./` (compiled in the subject's encoding) matches exactly
+        // that byte. Exercises each arm of onigmo_encoding_for.
+        run_test(
+            r#"%w[ISO-8859-1 ISO-8859-2 ISO-8859-3 ISO-8859-4 ISO-8859-5
+                 ISO-8859-6 ISO-8859-7 ISO-8859-8 ISO-8859-9 ISO-8859-10
+                 ISO-8859-11 ISO-8859-13 ISO-8859-14 ISO-8859-15 ISO-8859-16]
+                .map do |name|
+                  enc = Encoding.find(name)
+                  s = "\341z".dup.force_encoding(enc)
+                  m = Regexp.new(".".dup.force_encoding(enc)).match(s)
+                  [name, m[0].bytes, m[0].encoding == enc]
+                end"#,
+        );
+        // Single-byte NamedByte encodings mapped to native Onigmo
+        // codecs (KOI8 / Windows-125x family).
+        run_test(
+            r#"%w[KOI8-R KOI8-U Windows-1250 Windows-1251 Windows-1252
+                 Windows-1253 Windows-1254 Windows-1257].map do |name|
+                  enc = Encoding.find(name)
+                  s = "\341z".dup.force_encoding(enc)
+                  m = Regexp.new(".".dup.force_encoding(enc)).match(s)
+                  [name, m[0].bytes, m[0].encoding == enc]
+                end"#,
+        );
+    }
 }

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -2497,4 +2497,63 @@ mod tests {
         // A modifier combined with `i`, and with a leading empty fragment.
         run_test(r#"x = "Z"; (/#{x}/i =~ "qzq")"#);
     }
+
+    #[test]
+    fn regexp_match_native_encoding() {
+        // Windows-31J subject: "\xC3\xA9" is TWO single-byte chars in
+        // Windows-31J (0xC3 is not a lead byte) even though the same
+        // bytes are one char ("é") as UTF-8. `/./s` must match one
+        // byte, and the capture must carry the subject's encoding —
+        // exercises the native-encoding byte-match path
+        // (`captures_bytes_from_pos` / `from_captures_bytes`).
+        run_test(
+            r#"m = /./s.match("\303\251".dup.force_encoding(Encoding::Windows_31J))
+               [m[0].bytes, m[0].encoding.to_s, m.pre_match.bytes, m.post_match.bytes]"#,
+        );
+        // Interpolated form (spec: "with interpolation" / "and /o").
+        run_test(
+            r#"m = /#{/./}/s.match("\303\251".dup.force_encoding(Encoding::Windows_31J))
+               m.to_a.map(&:bytes)"#,
+        );
+        // EUC-JP: 0xA4A2 ("あ") is one 2-byte char; `/./e` matches both bytes.
+        run_test(
+            r#"m = /./e.match("\244\242".dup.force_encoding(Encoding::EUC_JP))
+               [m[0].bytes, m[0].encoding.to_s]"#,
+        );
+        // ISO-8859-1: every byte is one char.
+        run_test(
+            r#"s = "\351x".dup.force_encoding(Encoding::ISO_8859_1)
+               m = Regexp.new(".".dup.force_encoding(Encoding::ISO_8859_1)).match(s)
+               [m[0].bytes, m[0].encoding.to_s, m.post_match.bytes]"#,
+        );
+        // Capture groups + named backrefs still work on the native path.
+        run_test(
+            r#"s = "\303\251\303".dup.force_encoding(Encoding::Windows_31J)
+               m = /(.)(.)/s.match(s)
+               [m[1].bytes, m[2].bytes, m.to_a.size, $~[0].bytes, $1.bytes]"#,
+        );
+        // `pos` argument: char offset converts to byte offset under the
+        // subject's encoding.
+        run_test(
+            r#"s = "\303\251\303".dup.force_encoding(Encoding::Windows_31J)
+               m = /./s.match(s, 2)
+               [m[0].bytes, m.begin(0)]"#,
+        );
+        // No match on the native path clears $~ and returns nil.
+        run_test(
+            r#"s = "\303".dup.force_encoding(Encoding::Windows_31J)
+               [/z/s.match(s), $~]"#,
+        );
+        // Pure 7-bit subject stays equivalent regardless of path.
+        run_test(
+            r#"m = /b./s.match("abc".dup.force_encoding(Encoding::Windows_31J))
+               [m[0], m[0].encoding.to_s]"#,
+        );
+        // MatchData#string snapshot preserves the original bytes/encoding.
+        run_test(
+            r#"s = "\303\251".dup.force_encoding(Encoding::Windows_31J)
+               m = /./s.match(s)
+               [m.string.bytes, m.string.encoding.to_s, m.string.frozen?]"#,
+        );
+    }
 }

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -1130,6 +1130,47 @@ fn rmatch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     }
     check_subject_match_encoding(&globals.store, &regex, arg0)?;
     warn_binary_regexp_match(vm, globals, &regex, arg0);
+    // Subject declared in a non-UTF-8 encoding Onigmo has a native
+    // codec for: compile the source under that codec and match the
+    // raw bytes, so char boundaries follow the subject's *declared*
+    // encoding (e.g. `/./s` on Windows-31J "\xC3\xA9" matches one
+    // byte, even though those bytes happen to be valid UTF-8 too).
+    // Pure 7-bit content decodes identically either way; keep it on
+    // the fast zero-copy UTF-8 path.
+    if let Some(rs) = arg0.is_rstring()
+        && rs.code_range() != CodeRange::SevenBit
+        && let Some(native_enc) = RegexpInner::onigmo_encoding_for(rs.encoding())
+    {
+        let byte_pos = if let Some(pos) = lfp.try_arg(1) {
+            match conv_index(pos.coerce_to_int_i64(vm, globals)?, rs.char_length()) {
+                // Convert char index -> byte offset by walking char
+                // boundaries under the native encoding.
+                Some(cp) => rs.iter_char_bytes().take(cp).map(|c| c.len()).sum(),
+                None => return Ok(Value::nil()),
+            }
+        } else {
+            0
+        };
+        vm.set_match_regex(self_);
+        let bytes = arg0.as_rstring_inner().as_bytes();
+        let md = if let Some(captures) =
+            regex.captures_bytes_from_pos(bytes, arg0, native_enc, byte_pos, vm)?
+        {
+            Value::new_matchdata_bytes(&captures, arg0, regex)
+        } else {
+            Value::nil()
+        };
+        if !md.is_nil() {
+            vm.set_backref(md);
+        }
+        if let Some(bh) = lfp.block() {
+            if md.is_nil() {
+                return Ok(Value::nil());
+            }
+            return vm.invoke_block_once(globals, bh, &[md]);
+        }
+        return Ok(md);
+    }
     // Borrow the subject's bytes directly (and stash the Value for
     // the zero-copy MatchData snapshot) when it is a UTF-8 String;
     // Symbols and non-UTF-8 subjects fall back to the owned

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3611,6 +3611,25 @@ impl Executor {
         self.sp_match_regex = None;
     }
 
+    /// As [`save_capture_special_variables`], for byte-oriented
+    /// matches against non-UTF-8 subjects. `haystack` is the String
+    /// Value whose raw bytes the byte offsets in `captures` index.
+    pub(crate) fn save_capture_special_variables_bytes(
+        &mut self,
+        captures: &onigmo_regex::CapturesBytes,
+        haystack: Value,
+    ) {
+        let mut md = MatchDataInner::from_captures_bytes(captures, haystack);
+        if let Some(regex_val) = self.sp_match_regex
+            && let Some(regex) = regex_val.is_regex()
+        {
+            md = md.with_regex(regex);
+        }
+        let md_val = RValue::new_match_data_from_inner(md).pack();
+        self.set_backref(md_val);
+        self.sp_match_regex = None;
+    }
+
     /// `$_` reader — the last line read by `gets` / `readline` in the
     /// current scope (frame-local, like `$~`). `nil` when unset.
     pub(crate) fn get_last_read_line(&self) -> Value {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1451,6 +1451,20 @@ impl Value {
         .pack()
     }
 
+    /// `new_matchdata_snap` for byte-oriented matches on non-UTF-8
+    /// subjects (`Regex::captures_bytes`). `heystack` is the subject
+    /// String Value whose raw bytes the capture offsets index.
+    pub(crate) fn new_matchdata_bytes(
+        captures: &onigmo_regex::CapturesBytes,
+        heystack: Value,
+        regex: Regexp,
+    ) -> Self {
+        RValue::new_match_data_from_inner(
+            MatchDataInner::from_captures_bytes(captures, heystack).with_regex(regex),
+        )
+        .pack()
+    }
+
     pub(crate) fn unpack(&self) -> RV<'_> {
         if let Some(i) = self.try_fixnum() {
             RV::Fixnum(i)

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -178,6 +178,25 @@ impl MatchDataInner {
         decode_span(self.matches[pos])
     }
 
+    /// Number of characters in the haystack before byte offset
+    /// `byte_off`, counted under the haystack's *declared encoding*
+    /// (`MatchData#begin` / `#end` / `#offset` semantics). Walks the
+    /// encoding-aware char iterator, so Windows-31J / EUC-JP subjects
+    /// stored by the byte-match path count correctly.
+    pub fn char_count_upto(&self, byte_off: usize) -> usize {
+        let rs = self.heystack.as_rstring_inner();
+        let mut n = 0;
+        let mut consumed = 0;
+        for c in rs.iter_char_bytes() {
+            if consumed >= byte_off {
+                break;
+            }
+            consumed += c.len();
+            n += 1;
+        }
+        n
+    }
+
     /// Matched bytes for capture `pos`. Slices the haystack on
     /// **byte** boundaries (always safe) — required for binary
     /// (`/n`) regexps whose onigmo byte offsets land mid-UTF-8 of

--- a/monoruby/src/value/rvalue/match_data.rs
+++ b/monoruby/src/value/rvalue/match_data.rs
@@ -1,5 +1,6 @@
 use super::*;
 use smallvec::SmallVec;
+use std::borrow::Cow;
 
 /// Byte span of one capture group, `(start, end)`.
 ///
@@ -105,6 +106,29 @@ impl MatchDataInner {
         Self::from_captures_snap(captures, heystack, None)
     }
 
+    /// Build from a byte-oriented match (`Regex::captures_bytes`)
+    /// against a non-UTF-8 subject. `heystack` must be the exact
+    /// String Value the match ran over — its raw bytes are the
+    /// coordinate system of the byte offsets in `captures`. The
+    /// snapshot is a CoW substring of the whole subject, so the
+    /// stored bytes and encoding are the subject's own (no lossy
+    /// UTF-8 round-trip).
+    pub fn from_captures_bytes(captures: &onigmo_regex::CapturesBytes, heystack: Value) -> Self {
+        let len = heystack.as_rstring_inner().as_bytes().len();
+        assert!(
+            len < u32::MAX as usize,
+            "match subject longer than 4GiB is not supported"
+        );
+        let matches = (0..captures.len())
+            .map(|i| encode_span(captures.pos(i)))
+            .collect();
+        MatchDataInner {
+            regex: None,
+            heystack: string_substring(heystack, 0, len),
+            matches,
+        }
+    }
+
     /// Builder helper: attach a `Regexp` to a freshly-constructed
     /// `MatchDataInner`. Used when reconstructing a `MatchData`
     /// from `Executor`'s special-variable stash so named-capture
@@ -132,11 +156,13 @@ impl MatchDataInner {
         self.heystack.as_rstring_inner().as_bytes()
     }
 
-    pub fn string(&self) -> &str {
-        // SAFETY: every constructor receives the haystack as `&str`
-        // and the snapshot preserves those exact bytes (shared view or
-        // copy), so the content is valid UTF-8.
-        unsafe { std::str::from_utf8_unchecked(self.heystack_bytes()) }
+    pub fn string(&self) -> Cow<'_, str> {
+        // &str-based constructors always store valid UTF-8 (borrowed
+        // fast path); `from_captures_bytes` may store non-UTF-8
+        // subject bytes, for which char-count consumers get a lossy
+        // view. Byte-precise consumers should use `at()` /
+        // `string_value()` instead.
+        String::from_utf8_lossy(self.heystack_bytes())
     }
 
     /// The stored haystack snapshot as a String `Value`.

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -777,6 +777,22 @@ impl RegexpInner {
                 16 => OnigmoEncoding::ISO_8859_16,
                 _ => return None,
             },
+            // Single-byte NamedByte encodings with an Onigmo codec.
+            // Multi-byte ones (Big5, GB18030, EUC-KR/TW, ...) are left
+            // out: monoruby's char iteration treats NamedByte subjects
+            // as one char per byte, which would disagree with Onigmo's
+            // multi-byte char boundaries in MatchData offsets.
+            E::NamedByte(_) => match enc.name() {
+                "KOI8-R" => OnigmoEncoding::KOI8_R,
+                "KOI8-U" => OnigmoEncoding::KOI8_U,
+                "Windows-1250" => OnigmoEncoding::Windows_1250,
+                "Windows-1251" => OnigmoEncoding::Windows_1251,
+                "Windows-1252" => OnigmoEncoding::Windows_1252,
+                "Windows-1253" => OnigmoEncoding::Windows_1253,
+                "Windows-1254" => OnigmoEncoding::Windows_1254,
+                "Windows-1257" => OnigmoEncoding::Windows_1257,
+                _ => return None,
+            },
             _ => None?,
         })
     }

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -749,6 +749,87 @@ impl RegexpInner {
         self.regex.captures_iter(given)
     }
 
+    /// The `OnigmoEncoding` for a subject of Ruby encoding `enc`, or
+    /// `None` when Onigmo has no native codec (fall back to the
+    /// UTF-8-view path).
+    pub fn onigmo_encoding_for(enc: crate::value::Encoding) -> Option<OnigmoEncoding> {
+        use crate::value::Encoding as E;
+        Some(match enc {
+            E::EucJp => OnigmoEncoding::EUC_JP,
+            // Ruby treats Shift_JIS / Windows-31J as one codec family;
+            // Windows_31J is the superset CRuby actually pins for /s.
+            E::Sjis(_) => OnigmoEncoding::Windows_31J,
+            E::Iso8859(n) => match n {
+                1 => OnigmoEncoding::ISO_8859_1,
+                2 => OnigmoEncoding::ISO_8859_2,
+                3 => OnigmoEncoding::ISO_8859_3,
+                4 => OnigmoEncoding::ISO_8859_4,
+                5 => OnigmoEncoding::ISO_8859_5,
+                6 => OnigmoEncoding::ISO_8859_6,
+                7 => OnigmoEncoding::ISO_8859_7,
+                8 => OnigmoEncoding::ISO_8859_8,
+                9 => OnigmoEncoding::ISO_8859_9,
+                10 => OnigmoEncoding::ISO_8859_10,
+                11 => OnigmoEncoding::ISO_8859_11,
+                13 => OnigmoEncoding::ISO_8859_13,
+                14 => OnigmoEncoding::ISO_8859_14,
+                15 => OnigmoEncoding::ISO_8859_15,
+                16 => OnigmoEncoding::ISO_8859_16,
+                _ => return None,
+            },
+            _ => None?,
+        })
+    }
+
+    /// Compile (with caching) the *source bytes* of this regex under
+    /// `enc` for a native-encoding byte match. The regular
+    /// [`REGEX_CACHE`] is keyed on the UTF-8-view pattern; native
+    /// compiles use the raw source bytes, so they get their own cache.
+    fn native_regex(&self, enc: OnigmoEncoding) -> Result<Arc<Regex>> {
+        static NATIVE_CACHE: LazyLock<RwLock<HashMap<(Vec<u8>, u32, OnigmoEncoding), Arc<Regex>>>> =
+            LazyLock::new(|| RwLock::new(HashMap::default()));
+        let option = self.regex.option();
+        let key = (self.source.to_vec(), option, enc);
+        if let Some(re) = NATIVE_CACHE.read().unwrap().get(&key) {
+            return Ok(re.clone());
+        }
+        match Regex::new_bytes_with_encoding(&self.source, option, enc) {
+            Ok(re) => {
+                let re = Arc::new(re);
+                NATIVE_CACHE.write().unwrap().insert(key, re.clone());
+                Ok(re)
+            }
+            Err(err) => Err(MonorubyErr::regexerr(err.to_string())),
+        }
+    }
+
+    /// Byte-oriented match against a non-UTF-8 subject. `given` must
+    /// be `given_value`'s raw bytes (the coordinate system for the
+    /// resulting MatchData), and `enc` the Onigmo codec matching the
+    /// subject's Ruby encoding. Saves `$~` exactly like
+    /// [`captures_from_pos`](Self::captures_from_pos).
+    pub fn captures_bytes_from_pos<'a>(
+        &self,
+        given: &'a [u8],
+        given_value: Value,
+        enc: OnigmoEncoding,
+        pos: usize,
+        vm: &mut Executor,
+    ) -> Result<Option<onigmo_regex::CapturesBytes<'a>>> {
+        let native = self.native_regex(enc)?;
+        match native.captures_bytes_from_pos(given, pos) {
+            Ok(res) => {
+                if let Some(captures) = &res {
+                    vm.save_capture_special_variables_bytes(captures, given_value);
+                } else {
+                    vm.clear_capture_special_variables();
+                }
+                Ok(res)
+            }
+            Err(err) => Err(MonorubyErr::regexerr(format!("Capture failed. {:?}", err))),
+        }
+    }
+
     /// Find the leftmost-first match for `given`.
     /// Returns `Match`s.
     pub fn find_one<'a>(

--- a/spec/tags/language/regexp/encoding_tags.txt
+++ b/spec/tags/language/regexp/encoding_tags.txt
@@ -1,3 +1,0 @@
-fails:Regexps with encoding modifiers supports /s (Windows_31J encoding)
-fails:Regexps with encoding modifiers supports /s (Windows_31J encoding) with interpolation
-fails:Regexps with encoding modifiers supports /s (Windows_31J encoding) with interpolation and /o


### PR DESCRIPTION
## Summary

Wire monoruby up to the newly-merged `onigmo-regex` encoding expansion (`e95fad2a`), so `Regexp#match` on a subject declared in a non-UTF-8 encoding with a native Onigmo codec — **Windows-31J / Shift_JIS, EUC-JP, ISO-8859-1..16** — compiles the pattern under that codec and matches the subject's **raw bytes**.

Fixes the three remaining `language/regexp/encoding_spec.rb` failures (F5–F7 from the language-group audit): `supports /s (Windows_31J encoding)`, `+ interpolation`, `+ interpolation and /o`.

## Why the old path was wrong

Non-UTF-8 subjects went through `String::from_utf8_lossy`, which rewrites the byte layout. Windows-31J `"\xC3\xA9"` is **two** 1-byte characters in its declared encoding — but those same bytes are also valid UTF-8 (`"é"`, one char). The lossy view made `/./s` match both bytes as one character; CRuby matches exactly one byte (`"\xC3"`).

## Changes

- **`Cargo.lock`** — `onigmo-regex 9fdfb990 → e95fad2a` (the `OnigmoEncoding` expansion + `new_bytes_with_encoding` / `captures_bytes` / `CapturesBytes` API).
- **`RegexpInner::onigmo_encoding_for`** — maps `value::Encoding` → `OnigmoEncoding` (`EucJp`, `Sjis(_) → Windows_31J` (CRuby's `/s` pin), `Iso8859(n)`); `None` for encodings Onigmo has no codec for (falls back to the existing path).
- **`RegexpInner::native_regex`** — compiles the regex **source bytes** under the subject codec, cached in a dedicated `(bytes, option, encoding)` map. The existing `REGEX_CACHE` keys on the UTF-8-view pattern so it can't be reused.
- **`RegexpInner::captures_bytes_from_pos`** — byte match + `$~` save via the new `Executor::save_capture_special_variables_bytes`.
- **`MatchDataInner::from_captures_bytes`** — snapshots the subject `Value` directly (CoW substring), so `$&`/`$1`… inherit the subject's true encoding, no lossy round-trip. `MatchDataInner::string` now returns `Cow<'_, str>` since the haystack may legitimately be non-UTF-8 (callers work unchanged through `Deref`).
- **`Regexp#match`** — takes the native path when the subject's code range isn't pure 7-bit ASCII and its encoding has a native codec. Pure-ASCII subjects stay on the zero-copy UTF-8 fast path. The `pos` argument converts char→byte offsets by walking `iter_char_bytes` under the native encoding.
- **`spec/tags/language/regexp/encoding_tags.txt`** removed — all 3 tagged examples pass now.

## Verification

```
$ mspec language/regexp/encoding_spec.rb -t monoruby
1 file, 32 examples, 35 expectations, 0 failures, 0 errors

$ mspec language -t monoruby            # untagged run
80 files, 2931 examples, 7 failures, 3 errors    # was 10 failures

$ mspec language --excl-tag fails -t monoruby    # with updated tags
80 files, 2931 examples, 0 failures, 0 errors, 10 tagged
```

Spot check:
```
> /./s.match("\303\251".dup.force_encoding(Encoding::Windows_31J)).to_a
=> [["\xC3", Windows-31J]]        # was ["\xC3\xA9"]
```

## Scope notes

- Only `Regexp#match` takes the native path in this PR. `=~`, `match?`, `String#gsub`-family etc. still use the lossy fallback for non-UTF-8 subjects — they can migrate to `captures_bytes` incrementally with the same building blocks.
- The full `cargo test` suite was still running at push time (it re-verifies every test 25× against CRuby and takes >10 min in this environment); language-group specs and the targeted encoding specs are verified above, and CI will run the full suite here.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_