### PR TITLE
regexp: port CRuby engine fixes (Onigmo) + surface compile warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onigmo-regex"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/onigmo-regex.git#e95fad2a5d75e078cd78ec7019ccdf516ab4a8f7"
+source = "git+https://github.com/sisshiki1969/onigmo-regex.git#4db1266bf96c2c99c94e84f63e5b3717f78638be"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/monoruby/src/builtins/regexp.rs
+++ b/monoruby/src/builtins/regexp.rs
@@ -133,6 +133,7 @@ fn regexp_initialize(
         vm.temp_push(a1);
     }
     let inner = build_regexp_inner(vm, globals, lfp)?;
+    vm.flush_compile_warnings(globals);
     *self_.as_regexp_inner_mut() = inner;
     vm.temp_clear(temp);
     Ok(Value::nil())
@@ -149,7 +150,11 @@ fn regexp_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     let class_id = lfp.self_val().as_class_id();
     if class_id == REGEXP_CLASS {
         // Fast path for the base class: build directly.
-        return Ok(Value::regexp(build_regexp_inner(vm, globals, lfp)?));
+        let inner = build_regexp_inner(vm, globals, lfp)?;
+        // Surface Onigmo compile-time diagnostics right away, like
+        // CRuby's rb_warn during Regexp.new.
+        vm.flush_compile_warnings(globals);
+        return Ok(Value::regexp(inner));
     }
     // A subclass: allocate an instance of it, then initialize. Root the
     // fresh instance across the construction below, which allocates (and
@@ -2496,6 +2501,24 @@ mod tests {
         );
         // A modifier combined with `i`, and with a leading empty fragment.
         run_test(r#"x = "Z"; (/#{x}/i =~ "qzq")"#);
+    }
+
+    #[test]
+    fn regexp_nested_quantifier_not_reduced() {
+        // Bug #17341 semantics (ported into our Onigmo fork): a+?*
+        // behaves as (a+?)*; the match consumes all input.
+        run_test(r#"eval("/a+?*/").match("aa")[0]"#);
+        run_test(r#"eval("/a+?*/").match("")[0]"#);
+        run_test(r#"eval("/a+?+/").match("aa")[0]"#);
+        // The reduction-with-warning case still matches like CRuby.
+        run_test(r#"eval("/foo(A{0,1}+)Abar/").match("fooAAAbar").to_a"#);
+    }
+
+    #[test]
+    fn regexp_word_class_join_control() {
+        // CRuby >= 3.4: [[:word:]] / \p{Word} include Join_Control
+        // (U+200C/200D) per UTS #18; \w stays ASCII-only.
+        run_test(r#"["‌" =~ /[[:word:]]/, "‍" =~ /[[:word:]]/, "‌" =~ /\w/]"#);
     }
 
     #[test]

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -685,10 +685,17 @@ impl Executor {
     /// after compilation and before the compiled code runs.
     ///
     pub(crate) fn flush_compile_warnings(&mut self, globals: &mut Globals) {
-        if globals.store.compile_warnings.is_empty() {
+        // Onigmo compile-time diagnostics ("nested repeat operator ...
+        // was replaced with ...") are queued on a thread-local by
+        // `RegexpInner` (regexps also compile during bytecodegen,
+        // where no `Executor` is in reach) and join the same flush.
+        // They are plain rb_warn-level warnings (not verbose-only).
+        let regexp_warnings = crate::value::rvalue::RegexpInner::drain_pending_warnings();
+        if globals.store.compile_warnings.is_empty() && regexp_warnings.is_empty() {
             return;
         }
-        let msgs = std::mem::take(&mut globals.store.compile_warnings);
+        let mut msgs = std::mem::take(&mut globals.store.compile_warnings);
+        msgs.extend(regexp_warnings.into_iter().map(|m| (m, false)));
         // Verbose-level warnings (CRuby's `rb_warning`) print only when
         // `$VERBOSE` is exactly `true` at flush time.
         let verbose = globals

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -5,6 +5,31 @@ use std::sync::{LazyLock, RwLock};
 
 static REGEX_CACHE: LazyLock<RwLock<RegexCache>> = LazyLock::new(|| RwLock::new(RegexCache::new()));
 
+thread_local! {
+    /// Compile-time diagnostics Onigmo reported for regexps built
+    /// since the last [`RegexpInner::drain_pending_warnings`] call.
+    /// Compilation can happen with no `Executor` in reach (bytecodegen
+    /// compiles literals), so constructors queue here and the callers
+    /// that do own a vm (`Regexp.new`, the `eval` family) drain and
+    /// emit through the Ruby warning mechanism.
+    static PENDING_REGEXP_WARNINGS: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+fn queue_regexp_warnings(regex: &Regex) {
+    if regex.warnings().is_empty() {
+        return;
+    }
+    PENDING_REGEXP_WARNINGS.with(|w| {
+        let mut w = w.borrow_mut();
+        for msg in regex.warnings() {
+            // Onigmo's onig_syntax_warn already appends the offending
+            // pattern (`...: /<source>/`), so the message is complete.
+            w.push(format!("warning: {msg}"));
+        }
+    });
+}
+
 #[derive(Debug, Default)]
 struct RegexCache(HashMap<(String, u32, OnigmoEncoding), Arc<Regex>>);
 
@@ -571,6 +596,13 @@ fn utf8_char_len(b: u8) -> usize {
 impl RegexpInner {
 
     /// Create `RegexpInfo` from `escaped_str` escaping all meta characters.
+    /// Take (and clear) the compile-time diagnostics queued by regexp
+    /// constructions on this thread. Callers with an `Executor` should
+    /// forward each entry to `ruby_warn`.
+    pub fn drain_pending_warnings() -> Vec<String> {
+        PENDING_REGEXP_WARNINGS.with(|w| std::mem::take(&mut *w.borrow_mut()))
+    }
+
     pub fn from_escaped(text: &str) -> Result<Self> {
         RegexpInner::with_option_and_encoding(Self::escape(text), 0, OnigmoEncoding::UTF8)
     }
@@ -669,17 +701,24 @@ impl RegexpInner {
             .0
             .entry((reg_str.clone(), onigmo_option, encoding))
         {
-            std::collections::hash_map::Entry::Occupied(entry) => Ok(RegexpInner {
-                regex: entry.get().clone(),
-                source,
-                encoding,
-                declared_encoding,
-                fixed_encoding,
-                initialized: true,
-            }),
+            std::collections::hash_map::Entry::Occupied(entry) => {
+                // The cached Regex still carries its compile-time
+                // diagnostics; CRuby re-warns on every compile of the
+                // same pattern, so re-queue on cache hits too.
+                queue_regexp_warnings(entry.get());
+                Ok(RegexpInner {
+                    regex: entry.get().clone(),
+                    source,
+                    encoding,
+                    declared_encoding,
+                    fixed_encoding,
+                    initialized: true,
+                })
+            }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 match Regex::new_with_option_and_encoding(&reg_str, onigmo_option, encoding) {
                     Ok(regexp) => {
+                        queue_regexp_warnings(&regexp);
                         let regex = Arc::new(regexp);
                         entry.insert(regex.clone());
                         Ok(RegexpInner {

--- a/spec/tags/language/regexp/character_classes_tags.txt
+++ b/spec/tags/language/regexp/character_classes_tags.txt
@@ -1,1 +1,0 @@
-fails:Regexp with character classes matches Unicode join control characters with [[:word:]]

--- a/spec/tags/language/regexp/repetition_tags.txt
+++ b/spec/tags/language/regexp/repetition_tags.txt
@@ -1,2 +1,0 @@
-fails:Regexps with repetition does not treat {m,n}+ as possessive
-fails:Regexps with repetition supports nested quantifiers


### PR DESCRIPTION
## Summary

Fixes 3 of the 5 remaining `language/regexp` spec failures by porting two CRuby regex-engine divergences into our Onigmo fork and wiring Onigmo's compile-time diagnostics through to Ruby-level warnings. `mspec language --excl-tag fails` now runs **0F / 0E with 7 tagged** (was 10).

Depends on (already pushed):
- `sisshiki1969/Onigmo@a615b36` — cruby-compat port: **Bug #17341** `ReduceTypeTable` fix (`/a+?*/` behaves as `/(a+?)*/`) and **Join_Control (U+200C/200D) in `CR_Word`** (`[[:word:]]` / `\p{Word}` match join controls per UTS #18; Ruby's ASCII-only `\w` is unaffected).
- `sisshiki1969/onigmo-regex@4db1266` — collects Onigmo's warn-callback output per compile and exposes it as `Regex::warnings() -> &[String]`; bumps the Onigmo submodule to the above.

## monoruby changes

### Warning plumbing (`language/regexp/repetition` "does not treat {m,n}+ as possessive")

Onigmo emits "nested repeat operator '?' and '+' was replaced with '*' in regular expression: /src/" via `onig_syntax_warn` (the message already carries the offending pattern). CRuby routes it to `rb_warn`; monoruby previously dropped it.

- `RegexpInner` queues each compiled `Regex`'s `warnings()` on a thread-local — regexps also compile during **bytecodegen**, where no `Executor` is in reach. Cache hits re-queue from the cached `Arc<Regex>`, matching CRuby's warn-on-every-compile.
- `Executor::flush_compile_warnings` drains that queue into the **existing** compile-warning flush (rb_warn level, not verbose-gated), so the `eval` family and top-level runs emit with no new call sites. `Regexp.new` / `Regexp#initialize` flush immediately after building.

Verified byte-for-byte against CRuby:

```
$ monoruby -e 'eval %q{/foo(A{0,1}+)Abar/}'
warning: nested repeat operator '?' and '+' was replaced with '*' in regular expression: /foo(A{0,1}+)Abar/
```

### Tags removed (fixed by the engine port)

- `spec/tags/language/regexp/character_classes_tags.txt` — `[[:word:]]` now matches U+200C/U+200D
- `spec/tags/language/regexp/repetition_tags.txt` — `{m,n}+` warning + nested quantifiers both pass

### New differential tests

- `regexp_nested_quantifier_not_reduced` — `/a+?*/` family vs CRuby
- `regexp_word_class_join_control` — `[[:word:]]` / `\w` vs CRuby (needs host CRuby ≥ 4.0, which the project already requires)

## Remaining language/regexp gaps (out of scope, still tagged)

- back-references across threads (thread-local `$~` theme)
- `/o` (once) semantics (bytecodegen literal-caching theme)

## Test plan

- [x] `cargo test --lib builtins::regexp` — 35/35 (+2 new) locally
- [x] `mspec language --excl-tag fails -t monoruby` — 80 files, 2931 examples, 0F/0E, 7 tagged
- [ ] CI (amd64 / darwin) green with the pushed crate revs

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_