### PR TITLE
Kernel: easy/medium spec gaps — ===, extend, lambda, srand, Integer/String/Complex protocols, open/system/backtick, warn, loop, fork, at_exit $! (core/kernel 59F/33E → 9F/19E)

### DIFF
--- a/monoruby/builtins/kernel.rb
+++ b/monoruby/builtins/kernel.rb
@@ -93,9 +93,14 @@ module Kernel
       locs = caller_locations(1)
       if locs
         locs = locs.reject { |l| l.path&.start_with?("<internal:") }
-        if (loc = locs[uplevel])
-          str << "#{loc.path}:#{loc.lineno}: warning: "
-        end
+        loc = locs[uplevel]
+      end
+      # An uplevel beyond the stack still gets the bare "warning: "
+      # prefix (CRuby).
+      if loc
+        str << "#{loc.path}:#{loc.lineno}: warning: "
+      else
+        str << "warning: "
       end
     end
     messages.each do |m|
@@ -104,6 +109,14 @@ module Kernel
       str << "\n" unless s.end_with?("\n")
     end
 
+    # When self *is* the Warning module (a redefined Warning#warn calling
+    # `super`, or Warning's own use of Kernel#warn), write directly —
+    # dispatching Warning.warn again would recurse (CRuby behaves the
+    # same way).
+    if ::Warning.equal?(self)
+      $stderr.write(str)
+      return nil
+    end
     # Pass the category keyword, but fall back to a positional-only
     # call if Warning.warn was redefined without keyword support
     # (matches CRuby, and stays robust when Warning.warn is a mock).
@@ -180,14 +193,26 @@ end
 module Kernel
   module_function
 
-  def open(name, *args, &block)
+  def open(name, *args, **kw, &block)
     if name.respond_to?(:to_open)
-      name.to_open(*args, &block)
+      res = kw.empty? ? name.to_open(*args) : name.to_open(*args, **kw)
+      if block
+        begin
+          return yield res
+        ensure
+          res.close if res.respond_to?(:close)
+        end
+      end
+      res
     else
+      if args.size > 2
+        raise ArgumentError,
+              "wrong number of arguments (given #{1 + args.size}, expected 1..3)"
+      end
       name = name.to_path if name.respond_to?(:to_path)
       name = name.to_str if name.respond_to?(:to_str)
       raise TypeError, "no implicit conversion of #{name.class} into String" unless name.is_a?(String)
-      File.open(name, *args, &block)
+      File.open(name, *args, **kw, &block)
     end
   end
 
@@ -200,20 +225,29 @@ module Kernel
       return result if result.is_a?(::String)
       raise TypeError, "can't convert #{arg.class} to String (#{arg.class}#to_str gives #{result.class})"
     end
-    # CRuby's conversion honours a #respond_to? override and reports
-    # TypeError (not NoMethodError) when #to_s is missing entirely
-    # (e.g. on a BasicObject, where even #respond_to? is absent).
+    # CRuby's conversion (rb_check_funcall): a *user-defined*
+    # #respond_to? returning false suppresses the call, but with the
+    # default #respond_to? the conversion simply dispatches #to_s — so an
+    # undef'd #to_s still reaches a method_missing handler — and treats a
+    # NoMethodError as inconvertibility (TypeError, not NoMethodError).
     klass = begin
       arg.class
     rescue ::NoMethodError
       ::Object
     end
-    responds = begin
-      arg.respond_to?(:to_s)
-    rescue ::NoMethodError
+    custom_rt = begin
+      arg.method(:respond_to?).owner != ::Kernel
+    rescue ::NameError
       false
     end
-    raise TypeError, "can't convert #{klass} into String" unless responds
+    if custom_rt
+      responds = begin
+        arg.respond_to?(:to_s)
+      rescue ::NoMethodError
+        false
+      end
+      raise TypeError, "can't convert #{klass} into String" unless responds
+    end
     result = begin
       arg.to_s
     rescue ::NoMethodError
@@ -321,12 +355,17 @@ end
 # structured native frames (`Kernel.__caller_frames`), which carry the
 # load-time canonical path alongside the display path/label — string
 # parsing can't recover `absolute_path` after a chdir or file removal.
-def caller_locations(start = 1, length = nil)
-  frames = Kernel.__caller_frames(1)
-  locs = frames.map { |f| Thread::Backtrace::Location.new(f) }
-  # `Thread::Backtrace.__slice` implements the shared (start), (start,
-  # length) and (range) argument forms with Array#[] edge semantics.
-  Thread::Backtrace.__slice(locs, length.nil? ? [start] : [start, length])
+# A module function like `caller`: private instance method of Kernel,
+# public singleton.
+module Kernel
+  def caller_locations(start = 1, length = nil)
+    frames = Kernel.__caller_frames(1)
+    locs = frames.map { |f| Thread::Backtrace::Location.new(f) }
+    # `Thread::Backtrace.__slice` implements the shared (start), (start,
+    # length) and (range) argument forms with Array#[] edge semantics.
+    Thread::Backtrace.__slice(locs, length.nil? ? [start] : [start, length])
+  end
+  module_function :caller_locations
 end
 
 module Kernel
@@ -345,6 +384,14 @@ module Kernel
     raise ::NotImplementedError, "syscall() function is unimplemented on this machine"
   end
 
+  # `pp` lazily loads the 'pp' library, which redefines Kernel#pp; the
+  # re-dispatch below then reaches the real implementation (CRuby's
+  # bootstrap does the same).
+  def pp(*objs)
+    require "pp"
+    pp(*objs)
+  end
+
   # Console-input conveniences over ARGF (like Kernel#gets).
   def readline(*args)
     ARGF.readline(*args)
@@ -353,6 +400,19 @@ module Kernel
   def readlines(*args)
     ARGF.readlines(*args)
   end
+end
+
+module Kernel
+  # `set_trace_func`: monoruby has no line-event tracing hooks; accept and
+  # remember the handler so the method exists with CRuby's shape (private
+  # instance method / public module function). `nil` clears it.
+  def set_trace_func(handler)
+    unless handler.nil? || handler.respond_to?(:call)
+      raise TypeError, "trace_func needs to respond to call"
+    end
+    handler
+  end
+  module_function :set_trace_func
 end
 
 module Kernel

--- a/monoruby/builtins/object.rb
+++ b/monoruby/builtins/object.rb
@@ -16,10 +16,6 @@ class Object
   end
   alias yield_self then
 
-  def respond_to_missing?(method_name, include_private = false)
-    false
-  end
-
   def <=>(other)
     return 0 if equal?(other)
     # The `self == other` fallback would recurse infinitely when

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -167,7 +167,13 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 return Ok(v);
             }
             let a = v.as_array();
-            res = vm.invoke_block(globals, block_data, &[a.peel()])?;
+            // A zero-arg yield must invoke the block with no arguments —
+            // `peel()` on an empty args array would fabricate a nil.
+            res = if a.len() == 0 {
+                vm.invoke_block(globals, block_data, &[])?
+            } else {
+                vm.invoke_block(globals, block_data, &[a.peel()])?
+            };
         }
     }
     let self_val: Enumerator = match Enumerator::try_new(lfp.self_val()) {

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1031,6 +1031,28 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             )));
         }
     };
+    // Creation permissions: the positional Integer after the mode, or a
+    // `:perm` entry in a trailing options Hash (both CRuby forms; only
+    // applied when the open creates the file).
+    let mut perm: Option<u32> = None;
+    if let Some(arg2) = lfp.try_arg(2)
+        && let Some(n) = arg2.try_fixnum()
+    {
+        perm = Some(n as u32);
+    }
+    for i in 1..4 {
+        if let Some(arg) = lfp.try_arg(i)
+            && let Some(h) = arg.try_hash_ty()
+            && let Some(m) = h.get(Value::symbol(IdentId::get_id("perm")), vm, globals)?
+            && let Some(n) = m.try_fixnum()
+        {
+            perm = Some(n as u32);
+        }
+    }
+    if let Some(p) = perm {
+        use std::os::unix::fs::OpenOptionsExt;
+        opt.mode(p);
+    }
     let path = to_path_str(vm, globals, lfp.arg(0))?;
     // A FIFO's open(2) blocks in the kernel until the peer end appears;
     // opening it inline through std would freeze every green thread (and

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -573,7 +573,7 @@ fn enc_by_name(globals: &Globals, name: &str) -> Option<Value> {
 }
 
 /// `Encoding.default_external` object (UTF-8 if unset).
-fn enc_default_external_obj(globals: &mut Globals) -> Value {
+pub(super) fn enc_default_external_obj(globals: &mut Globals) -> Value {
     if let Some(v) = globals.get_gvar(IdentId::get_id("$DEFAULT_EXTERNAL"))
         && !v.is_nil()
     {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -11,6 +11,18 @@ use std::{io::Write, mem::transmute};
 // Kernel module
 //
 
+/// Define the `-n` / `-p` loop companions (`Kernel#chomp` / `#chop`),
+/// which exist only when the CLI armed the implicit `while gets` wrap.
+pub fn define_loop_mode_builtins(globals: &mut Globals) {
+    let kernel_class = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Kernel"))
+        .unwrap()
+        .as_class_id();
+    globals.define_builtin_module_func_with(kernel_class, "chomp", chomp, 0, 1, false);
+    globals.define_builtin_module_func(kernel_class, "chop", chop, 0);
+}
+
 pub(super) fn init(globals: &mut Globals) -> Module {
     let klass = globals.define_toplevel_module("Kernel");
     let kernel_class = klass.id();
@@ -154,7 +166,16 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         false,
         Effect::EVAL,
     );
-    globals.define_builtin_module_func_with(kernel_class, "system", system, 1, 1, true);
+    globals.define_builtin_module_func_with_kw(
+        kernel_class,
+        "system",
+        system,
+        1,
+        1,
+        true,
+        &["exception"],
+        false,
+    );
     globals.define_builtin_module_func_rest(kernel_class, "exec", exec);
     globals.define_builtin_module_func_rest(kernel_class, "spawn", spawn);
     globals.define_builtin_module_func(kernel_class, "`", command, 1);
@@ -218,8 +239,8 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     );
     globals.define_builtin_func(kernel_class, "__backtrace_limit", backtrace_limit, 0);
     globals.define_builtin_func(kernel_class, "__caller_frames", caller_frames, 1);
-    globals.define_builtin_module_func_with(kernel_class, "chomp", chomp, 0, 1, false);
-    globals.define_builtin_module_func(kernel_class, "chop", chop, 0);
+    // `chomp` / `chop` are only defined under `-n` / `-p`
+    // (`define_loop_mode_builtins`, called from the CLI driver).
     globals.define_builtin_func(
         kernel_class,
         "__enum_yield",
@@ -255,7 +276,16 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     let init_copy_fid =
         globals.define_private_builtin_func(kernel_class, "initialize_copy", initialize_copy, 1);
     let init_clone_fid =
-        globals.define_private_builtin_func(kernel_class, "initialize_clone", initialize_clone, 1);
+        globals.define_private_builtin_func_with_kw(
+            kernel_class,
+            "initialize_clone",
+            initialize_clone,
+            1,
+            1,
+            false,
+            &["freeze"],
+            false,
+        );
     let init_dup_fid =
         globals.define_private_builtin_func(kernel_class, "initialize_dup", initialize_clone, 1);
     globals
@@ -658,6 +688,30 @@ fn read_record(
 
 #[monoruby_builtin]
 fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // CRuby's `Kernel#gets` is `ARGF.gets` — dispatched, so a singleton
+    // stub on the ARGF object intercepts it (`$_` is still set here: the
+    // stub runs in its own frame and could not reach the caller's
+    // frame-local `$_`). Without an override, use the raw record reader
+    // directly, which also maintains `$.`.
+    if let Some(argf) = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ARGF"))
+    {
+        let gets_id = IdentId::get_id("gets");
+        if let Ok((fid, _, owner)) = globals.find_method_for_object(argf, gets_id)
+            && owner != argf.real_class(&globals.store).id()
+        {
+            let res = vm.invoke_func_inner(globals, fid, argf, &[], None, None)?;
+            vm.set_last_read_line(res);
+            return Ok(res);
+        }
+    }
+    argf_gets_raw(vm, globals)
+}
+
+/// The raw ARGV/stdin record reader backing `Kernel#gets`: honours `$/`,
+/// advances `$.`, and sets `$_`.
+fn argf_gets_raw(vm: &mut Executor, globals: &mut Globals) -> Result<Value> {
     // Honour the input record separator `$/` (set by the `-0`
     // command-line switch or by assignment): nil slurps the whole
     // input, "" is paragraph mode, any other string reads up to and
@@ -871,6 +925,16 @@ fn proc(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
 #[monoruby_builtin]
 fn lambda(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
     if let Some(bh) = lfp.block() {
+        // A non-literal block (`lambda(&pr)`): CRuby refuses to promote
+        // an ordinary proc, and passes an existing lambda through.
+        if let Some(p) = bh.try_proc() {
+            if globals.store[p.func_id()].meta().is_block_style() {
+                return Err(MonorubyErr::argumenterr(
+                    "the lambda method requires a literal block",
+                ));
+            }
+            return Ok(p.into());
+        }
         let func_id = bh.func_id();
         globals.store[func_id].set_method_style();
         let p = vm.generate_proc(globals, bh, pc)?;
@@ -941,10 +1005,23 @@ fn loop_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) ->
             // for an empty `loop {}` body.
             Ok(_) => {}
             Err(err) => {
-                // `loop` swallows StopIteration and any user subclass of it, and
-                // re-raises everything else (including control-flow signals).
+                // `loop` swallows StopIteration and any user subclass of it
+                // — evaluating to the iterator's return value
+                // (`StopIteration#result`) — and re-raises everything else
+                // (including control-flow signals).
                 return if err.is_stop_iteration(&globals.store) {
-                    Ok(Value::nil())
+                    let result = err
+                        .payload
+                        .as_ref()
+                        .filter(|(_, key)| *key == "result")
+                        .map(|(v, _)| *v)
+                        .or_else(|| {
+                            err.original.and_then(|obj| {
+                                globals.store.get_ivar(obj, IdentId::get_id("/result"))
+                            })
+                        })
+                        .unwrap_or_default();
+                    Ok(result)
                 } else {
                     Err(err)
                 };
@@ -1984,6 +2061,17 @@ fn kernel_integer_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> R
     } else {
         None
     };
+    if base.is_some() && !matches!(arg0.unpack(), RV::String(_)) {
+        // With an explicit base only Strings (and #to_str convertibles,
+        // handled below) are acceptable.
+        if let Some(func_id) = globals.check_method(arg0, IdentId::TO_STR) {
+            let result = vm.invoke_func_inner(globals, func_id, arg0, &[], None, None)?;
+            if let Some(s) = result.is_str() {
+                return parse_kernel_integer(s, base.unwrap_or(0));
+            }
+        }
+        return Err(MonorubyErr::argumenterr("base specified for non string value"));
+    }
     match arg0.unpack() {
         RV::Fixnum(num) => return Ok(Value::integer(num)),
         RV::BigInt(num) => return Ok(Value::bigint(num.clone())),
@@ -1997,7 +2085,13 @@ fn kernel_integer_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> R
                     if num < 0.0 { "-Infinity" } else { "Infinity" },
                 ));
             }
-            return Ok(Value::integer(num.trunc() as i64));
+            let t = num.trunc();
+            if t >= i64::MIN as f64 && t <= i64::MAX as f64 {
+                return Ok(Value::integer(t as i64));
+            }
+            // Out of Fixnum range: exact conversion through BigInt.
+            use num::bigint::ToBigInt;
+            return Ok(Value::bigint(t.to_bigint().unwrap()));
         }
         RV::String(b) => {
             let s = b.check_utf8()?;
@@ -2013,6 +2107,14 @@ fn kernel_integer_inner(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> R
             RV::Fixnum(i) => return Ok(Value::integer(i)),
             RV::BigInt(b) => return Ok(Value::bigint(b.clone())),
             _ => {}
+        }
+    }
+    // Then #to_str (an object convertible to a String parses like one) —
+    // preferred over #to_i (CRuby).
+    if let Some(func_id) = globals.check_method(arg0, IdentId::TO_STR) {
+        let result = vm.invoke_func_inner(globals, func_id, arg0, &[], None, None)?;
+        if let Some(s) = result.is_str() {
+            return parse_kernel_integer(s, 0);
         }
     }
     // Try to_i coercion as a fallback
@@ -2420,6 +2522,30 @@ fn kernel_complex(
     // first argument paired with a *Numeric* second argument always raises
     // (`Complex(:sym, 0, exception: false)` -> TypeError "not a real").
     if let Some(i) = arg1 {
+        // A non-real numeric component (a Complex, or a Numeric whose
+        // `real?` is false) composes arithmetically through dispatch:
+        // `n1 + n2 * Complex(0, 1)` (CRuby).
+        let re_realness = numeric_is_real(vm, globals, arg0)?;
+        let im_realness = numeric_is_real(vm, globals, i)?;
+        if re_realness == Some(false) || im_realness == Some(false) {
+            let unit = Value::complex(Real::from(0i64), Real::from(1i64));
+            let prod = vm.invoke_method_inner(
+                globals,
+                IdentId::get_id("*"),
+                i,
+                &[unit],
+                None,
+                None,
+            )?;
+            return vm.invoke_method_inner(
+                globals,
+                IdentId::get_id("+"),
+                arg0,
+                &[prod],
+                None,
+                None,
+            );
+        }
         let im = match real_for_complex(vm, globals, i)? {
             Some(i) => i,
             None => {
@@ -2431,11 +2557,27 @@ fn kernel_complex(
         };
         let re = match real_for_complex(vm, globals, arg0)? {
             Some(r) => r,
-            None => return Err(MonorubyErr::typeerr("not a real")),
+            None => {
+                // A non-numeric *String* component is swallowable with
+                // `exception: false`; a non-String non-numeric first
+                // argument always raises (CRuby).
+                if !exception && matches!(arg0.unpack(), RV::String(_)) {
+                    return Ok(Value::nil());
+                }
+                return Err(MonorubyErr::typeerr("not a real"));
+            }
         };
         return Ok(Value::complex(re, im));
     }
 
+    // A single Complex — or a Numeric that says it is not real — passes
+    // through unchanged (CRuby).
+    if arg0.try_complex().is_some() {
+        return Ok(arg0);
+    }
+    if numeric_is_real(vm, globals, arg0)? == Some(false) {
+        return Ok(arg0);
+    }
     let r = match real_for_complex(vm, globals, arg0)? {
         Some(r) => r,
         None => {
@@ -2458,6 +2600,38 @@ fn kernel_complex(
         }
     };
     Ok(Value::complex(r, Real::zero()))
+}
+
+/// Whether `v` is a real number: `Some(true)` for the standard reals,
+/// `Some(false)` for a Complex or a Numeric whose dispatched `#real?` is
+/// falsy, `None` when `v` is not numeric at all (so no `#real?` is sent to
+/// arbitrary objects).
+fn numeric_is_real(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<Option<bool>> {
+    match v.unpack() {
+        RV::Fixnum(_) | RV::BigInt(_) | RV::Float(_) => Ok(Some(true)),
+        _ if v.try_rational().is_some() => Ok(Some(true)),
+        _ if v.try_complex().is_some() => Ok(Some(false)),
+        _ => {
+            let numeric_id = IdentId::get_id("Numeric");
+            if let Some(numeric) = globals
+                .store
+                .get_constant_noautoload(OBJECT_CLASS, numeric_id)
+                .map(|c| c.as_class_id())
+                && v.is_kind_of(&globals.store, numeric)
+            {
+                let res = vm.invoke_method_inner(
+                    globals,
+                    IdentId::get_id("real?"),
+                    v,
+                    &[],
+                    None,
+                    None,
+                )?;
+                return Ok(Some(res.as_bool()));
+            }
+            Ok(None)
+        }
+    }
 }
 
 /// Convert `v` into a `Real` suitable for a Complex component, returning
@@ -3321,7 +3495,10 @@ fn eval(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
         // the surrounding class/module body. Mirrors CRuby's
         // `rb_vm_cref_dup_without_refinements`.
         let pushed = vm.push_eval_cref();
-        let res = vm.invoke_block(globals, &proc, &[]);
+        // `self` inside the eval is the *receiver* of the eval call — for
+        // the ordinary private spelling that is the caller's self, but
+        // `Kernel.eval("self")` evaluates with self == Kernel (CRuby).
+        let res = vm.invoke_block_with_self(globals, &proc, lfp.self_val(), &[]);
         vm.pop_eval_cref(pushed);
         res
     }
@@ -3374,15 +3551,36 @@ pub(super) fn prepare_command_arg(input: &str) -> (String, Vec<String>) {
 fn system(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use std::process::Command;
     let arg0 = lfp.arg(0);
-    let (program, mut args) = prepare_command_arg(&arg0.coerce_to_str(vm, globals)?);
+    // `exception: true` turns the nil/false results into raises (CRuby).
+    let exception = lfp.try_arg(2).is_some_and(|v| v.as_bool());
+    let cmd_str = arg0.coerce_to_str(vm, globals)?;
+    let (program, mut args) = prepare_command_arg(&cmd_str);
     if let Some(arg1) = lfp.try_arg(1) {
         for v in arg1.as_array().iter() {
             args.push(v.coerce_to_string(vm, globals)?);
         }
     }
-    let mut child = match Command::new(program).args(&args).spawn() {
+    let mut child = match Command::new(&program).args(&args).spawn() {
         Ok(child) => child,
-        Err(_) => return Ok(Value::nil()),
+        // ENOEXEC (an executable file without a shebang that isn't a
+        // binary): retry through `sh`, like execvp-era shells and CRuby.
+        Err(err) if err.raw_os_error() == Some(libc::ENOEXEC) => {
+            match Command::new("/bin/sh").arg(&program).args(&args).spawn() {
+                Ok(child) => child,
+                Err(_) => return Ok(Value::nil()),
+            }
+        }
+        Err(err) => {
+            if exception {
+                // e.g. Errno::ENOENT: "No such file or directory - cmd"
+                return Err(MonorubyErr::from_io_err(
+                    &globals.store,
+                    &err,
+                    format!("{} - {}", errno_description(&err), cmd_str),
+                ));
+            }
+            return Ok(Value::nil());
+        }
     };
     let pid = child.id();
     let status = match child.wait() {
@@ -3408,6 +3606,17 @@ fn system(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 crate::scheduler::set_last_status(vm, status_obj);
             }
         }
+    }
+    if exception && !status.success() {
+        use std::os::unix::process::ExitStatusExt;
+        let detail = match (status.code(), status.signal()) {
+            (Some(code), _) => format!("exit {code}"),
+            (None, Some(sig)) => format!("signal {sig}"),
+            _ => "unknown status".to_string(),
+        };
+        return Err(MonorubyErr::runtimeerr(format!(
+            "Command failed with {detail}: {cmd_str}"
+        )));
     }
     Ok(Value::bool(status.success()))
 }
@@ -3520,7 +3729,10 @@ fn fork(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         return Err(MonorubyErr::runtimeerr("fork failed"));
     }
     if pid == 0 {
-        // Child process
+        // Child process: only the forking thread exists here — the other
+        // green threads' state belongs to the parent (CRuby marks them
+        // dead).
+        crate::scheduler::fork_child_reset_threads(vm);
         if let Some(bh) = lfp.block() {
             let data = vm.get_block_data(globals, bh)?;
             match vm.invoke_block(globals, &data, &[]) {
@@ -3685,13 +3897,41 @@ pub(super) fn spawn(
 fn command(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use std::os::unix::process::ExitStatusExt;
     let arg0 = lfp.arg(0);
-    let (program, args) = prepare_command_arg(&arg0.coerce_to_string(vm, globals)?);
-    let child = std::process::Command::new(program)
-        .args(&args)
+    let rs = arg0.coerce_to_rstring(vm, globals)?;
+    let bytes = rs.as_bytes().to_vec();
+    // A command with invalid UTF-8 bytes still runs: hand the raw bytes to
+    // the shell (CRuby passes the byte string through unmodified).
+    let mut builder = match std::str::from_utf8(&bytes) {
+        Ok(s) => {
+            let (program, args) = prepare_command_arg(s);
+            let mut c = std::process::Command::new(program);
+            c.args(&args);
+            c
+        }
+        Err(_) => {
+            use std::os::unix::ffi::OsStrExt;
+            let mut c = std::process::Command::new("sh");
+            c.arg("-c").arg(std::ffi::OsStr::from_bytes(&bytes));
+            c
+        }
+    };
+    let child = builder
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .map_err(|err| MonorubyErr::runtimeerr(format!("{}", err)))?;
+        .map_err(|err| {
+            // e.g. Errno::ENOENT for a nonexistent command (the direct-exec
+            // path; the shell path reports through the exit status instead).
+            MonorubyErr::from_io_err(
+                &globals.store,
+                &err,
+                format!(
+                    "{} - {}",
+                    errno_description(&err),
+                    String::from_utf8_lossy(&bytes)
+                ),
+            )
+        })?;
     let pid = child.id();
     match child.wait_with_output() {
         Ok(output) => {
@@ -3714,7 +3954,14 @@ fn command(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
                     crate::scheduler::set_last_status(vm, status_obj);
                 }
             }
-            Ok(Value::string_from_vec(output.stdout))
+            // The captured output is tagged with the default external
+            // encoding (CRuby).
+            let mut s = Value::string_from_vec(output.stdout);
+            let ext_obj = super::io::enc_default_external_obj(globals);
+            if let Some(enc) = super::io::enc_obj_to_enum(globals, ext_obj) {
+                s.as_rstring_inner_mut().set_encoding(enc);
+            }
+            Ok(s)
         }
         Err(err) => Err(MonorubyErr::runtimeerr(format!("{}", err))),
     }
@@ -4516,6 +4763,16 @@ fn extend(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
     }
     let self_val = lfp.self_val();
+    // Reject non-Modules up front (CRuby checks the whole argument list
+    // before extending anything).
+    for v in args.iter() {
+        if v.is_module().is_none() {
+            return Err(MonorubyErr::typeerr(format!(
+                "wrong argument type {} (expected Module)",
+                v.get_real_class_name(&globals.store)
+            )));
+        }
+    }
     for v in args.iter().cloned().rev() {
         vm.invoke_method_inner(globals, IdentId::EXTEND_OBJECT, v, &[self_val], None, None)?;
         vm.invoke_method_inner(globals, IdentId::EXTENDED, v, &[self_val], None, None)?;
@@ -5262,7 +5519,10 @@ fn instance_of(
 #[monoruby_builtin]
 fn method(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let receiver = lfp.self_val();
-    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    // The name accepts Symbols, Strings, and #to_str convertibles; an
+    // error raised by the conversion (e.g. a NoMethodError from #to_str)
+    // propagates as-is.
+    let method_name = lfp.arg(0).coerce_to_symbol_or_string(vm, globals)?;
     method_object_impl(vm, globals, receiver, method_name, false)
 }
 
@@ -5284,7 +5544,7 @@ fn public_method(
     _: BytecodePtr,
 ) -> Result<Value> {
     let receiver = lfp.self_val();
-    let method_name = lfp.arg(0).expect_symbol_or_string(globals)?;
+    let method_name = lfp.arg(0).coerce_to_symbol_or_string(vm, globals)?;
     method_object_impl(vm, globals, receiver, method_name, true)
 }
 
@@ -5398,6 +5658,13 @@ fn singleton_class(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    // A frozen String can never be given a singleton class (CRuby,
+    // observable with deduplicated `"..."` literals under
+    // frozen-string-literal).
+    let recv = lfp.self_val();
+    if recv.is_rstring().is_some() && recv.is_frozen() {
+        return Err(MonorubyErr::typeerr("can't define singleton"));
+    }
     let s = lfp.self_val().get_singleton(&mut globals.store)?;
     // MRI's `rb_singleton_class`: for a Class receiver, the exposed
     // eigenclass is made to belong to its *own* eigenclass — building
@@ -8425,6 +8692,166 @@ mod tests {
         ]);
         run_test_error(r#"Hash(1)"#);
         run_test_error(r#"Hash("str")"#);
+    }
+
+    #[test]
+    fn kernel_easy_edges_2026_07() {
+        // Object#===: identity wins even when == / equal? lie.
+        run_test(
+            r##"
+            k = Class.new { def ==(o); false; end; def equal?(o); false; end }
+            a = k.new
+            [a === a, a === k.new]
+            "##,
+        );
+        // Kernel#extend rejects non-Modules (and classes).
+        run_test_error("Object.new.extend(String)");
+        run_test_error("Object.new.extend(42)");
+        // lambda(&proc) is refused; lambda(&lambda) passes through.
+        run_test_error("lambda(&proc {})");
+        run_test("l = lambda { 5 }; lambda(&l).call");
+        // Frozen String has no singleton class.
+        run_test_error(r##""frozen-str".freeze.singleton_class"##);
+        run_test(r##""mutable-str".dup.singleton_class.class.to_s"##);
+        // Kernel#method with a #to_str name; conversion errors propagate.
+        run_test(
+            r##"
+            key = Object.new
+            def key.to_str = "upcase"
+            "abc".method(key).call
+            "##,
+        );
+        run_test_error("[].method(Object.new)");
+        // initialize_clone accepts freeze: (returns the receiver).
+        run_test(
+            r##"
+            a = "a"
+            a.send(:initialize_clone, "b", freeze: true).equal?(a)
+            "##,
+        );
+        // respond_to_missing? is a Kernel instance method.
+        run_test("Object.instance_method(:respond_to_missing?).owner.to_s");
+        // chop/chomp exist only under -n; caller_locations/set_trace_func
+        // have module-function shape.
+        run_test(
+            r##"
+            [Kernel.private_instance_methods(false).include?(:chop),
+             Kernel.private_instance_methods(false).include?(:chomp),
+             Kernel.private_instance_methods(false).include?(:caller_locations),
+             Kernel.private_instance_methods(false).include?(:set_trace_func),
+             Kernel.respond_to?(:caller_locations),
+             Kernel.respond_to?(:set_trace_func)]
+            "##,
+        );
+    }
+
+    #[test]
+    fn kernel_integer_srand_edges() {
+        // Integer(): #to_str wins over #to_i; base demands string-likes;
+        // huge Floats convert exactly.
+        run_test(
+            r##"
+            o = Object.new
+            def o.to_str = "42"
+            def o.to_i = 7
+            Integer(o)
+            "##,
+        );
+        run_test_error("Integer(98, 15)");
+        run_test("Integer(2.0 ** 100)");
+        // srand echoes the previous seed exactly (Bignum included) and
+        // coerces via #to_int.
+        run_test(
+            r##"
+            srand(2 ** 79 + 3)
+            prev = srand(1)
+            o = Object.new
+            def o.to_int = 5
+            srand(o)
+            [prev, srand]
+            "##,
+        );
+        // system(exception: true): Errno::ENOENT for a missing command,
+        // RuntimeError for a failing one.
+        run_test_error(r##"system("monoruby_no_such_cmd_xyz", exception: true)"##);
+        run_test_error(r##"system("false", exception: true)"##);
+        // Backtick: nonexistent command raises Errno::ENOENT.
+        run_test_error("`monoruby_no_such_cmd_xyz`");
+    }
+
+    #[test]
+    fn kernel_complex_protocol_edges() {
+        run_test_with_prelude(
+            r#"
+            n1 = UnrealNum.new(1)
+            n2 = UnrealNum.new(2)
+            c = Complex(n1, n2)
+            single = Complex(UnrealNum.new(9))
+            [c.class.to_s, c.real, c.imaginary, single.value]
+        "#,
+            r#"
+            class UnrealNum < Numeric
+                attr_reader :value
+                def initialize(v) = @value = v
+                def real? = false
+                def *(o) = UnrealNum.new(@value * 10)
+                def +(o) = (o.is_a?(UnrealNum) ? @value + o.value : @value)
+                def coerce(o) = [UnrealNum.new(o), self]
+            end
+        "#,
+        );
+        run_test("c = Complex(1, 2); Complex(c).equal?(c)");
+        run_test(r##"[Complex("a", "b", exception: false), Complex("a", 0, exception: false)]"##);
+    }
+
+    #[test]
+    fn kernel_loop_open_eval_edges() {
+        // loop: enumerator form yields no args; StopIteration#result is
+        // loop's value.
+        run_test(
+            r##"
+            e = loop
+            cnt = 0
+            got = nil
+            e.each { |*args| got = args; cnt += 1; break if cnt >= 3 }
+            enum = Enumerator.new { |y| y << 1; y << 2; :stopped }
+            res = loop { enum.next }
+            [e.class.to_s, got, cnt, res]
+            "##,
+        );
+        // open: positional-arity check and the #to_open protocol.
+        run_test_error(r##"open("/dev/null", "r", 0o666, {flags: 0})"##);
+        run_test(
+            r##"
+            obj = Object.new
+            def obj.to_open(*a, **kw) = [a, kw]
+            got = nil
+            r = open(obj, 1, 2, x: "y") { |v| got = v; :blk }
+            [r, got]
+            "##,
+        );
+        // Kernel.eval evaluates with the receiver as self.
+        run_test(r##"Kernel.eval("self").to_s"##);
+        // eval SyntaxError messages embed file:line.
+        run_test_once(
+            r##"
+            begin
+              eval("if true", nil, "speccing.rb", 88)
+            rescue SyntaxError => e
+              e.message =~ /speccing\.rb:88:/ ? true : false
+            end
+            "##,
+        );
+        // singleton_methods stops at the first ordinary class (a module
+        // prepended to Module must not leak in).
+        run_test_once(
+            r##"
+            mod_p = Module.new { def mspec_test_prepended_probe; end }
+            ::Module.prepend(mod_p)
+            m = Module.new { extend self }
+            m.singleton_methods
+            "##,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -347,12 +347,17 @@ fn ne(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     Ok(Value::bool(!res))
 }
 
-/// Default `Object#===` — delegates to `==` so that subclasses which
+/// Default `Object#===` — identical objects compare true without consulting
+/// `==` (CRuby's `rb_equal` fast path, observable when `==`/`equal?` are
+/// overridden to lie), otherwise delegates to `==` so that subclasses which
 /// override `==` get consistent `case` behaviour.
 #[monoruby_builtin]
 fn case_eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let other = lfp.arg(0);
+    if self_val.id() == other.id() {
+        return Ok(Value::bool(true));
+    }
     vm.invoke_method_inner(globals, IdentId::_EQ, self_val, &[other], None, None)
 }
 

--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -389,36 +389,59 @@ fn inst_eq(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/Random/s/srand.html]
 #[monoruby_builtin]
 fn random_srand(
-    _vm: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let old_seed = globals.random_seed();
-    let new_seed = if lfp.try_arg(0).is_none() {
-        None
-    } else {
-        match lfp.arg(0).unpack() {
-            RV::Fixnum(i) => Some(i),
-            RV::BigInt(b) => Some(b.to_i64().unwrap_or_else(|| {
-                // Truncate BigInt to i64 by taking its low 64 bits.
-                use num::bigint::Sign;
-                let (sign, digits) = b.to_u64_digits();
-                let low = digits.first().copied().unwrap_or(0) as i64;
-                if sign == Sign::Minus { low.wrapping_neg() } else { low }
-            })),
-            RV::Float(f) => Some(f.trunc() as i64),
-            _ => {
+    // The previous seed is echoed back *exactly* as given (a Bignum seed
+    // returns that Bignum), so the reported value is kept as a Value.
+    let old_seed = globals.random_seed_value();
+    let arg = match lfp.try_arg(0) {
+        None => {
+            globals.random_init(None);
+            return Ok(old_seed);
+        }
+        Some(v) => {
+            // Coerce non-Integers through #to_int (CRuby).
+            if v.try_fixnum().is_some() || matches!(v.unpack(), RV::BigInt(_)) {
+                v
+            } else if let Some(fid) = globals.check_method(v, IdentId::TO_INT) {
+                let res = vm.invoke_func_inner(globals, fid, v, &[], None, None)?;
+                if res.try_fixnum().is_none() && !matches!(res.unpack(), RV::BigInt(_)) {
+                    return Err(MonorubyErr::no_implicit_conversion(
+                        &globals.store,
+                        v,
+                        INTEGER_CLASS,
+                    ));
+                }
+                res
+            } else {
                 return Err(MonorubyErr::no_implicit_conversion(
                     &globals.store,
-                    lfp.arg(0),
+                    v,
                     INTEGER_CLASS,
                 ));
             }
         }
     };
-    globals.random_init(new_seed);
-    Ok(Value::integer(old_seed as i64))
+    // Feed the Mersenne Twister the low bits; report the exact Integer.
+    let mt_seed = match arg.unpack() {
+        RV::Fixnum(i) => i,
+        RV::BigInt(b) => {
+            use num::bigint::Sign;
+            let (sign, digits) = b.to_u64_digits();
+            let low = digits.first().copied().unwrap_or(0) as i64;
+            if sign == Sign::Minus {
+                low.wrapping_neg()
+            } else {
+                low
+            }
+        }
+        _ => unreachable!(),
+    };
+    globals.random_init_with(mt_seed, arg);
+    Ok(old_seed)
 }
 
 ///

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -220,6 +220,8 @@ pub struct Globals {
     /// The fiber scheduler installed by `Fiber.set_scheduler` (monoruby
     /// keeps one per process — fibers are M:1 on the main native thread).
     pub(crate) fiber_scheduler: Option<Value>,
+    /// The exact Integer the next `srand` reports as the previous seed.
+    pub(crate) random_seed_obj: Value,
     /// Every root Fiber object ever materialized (`Fiber.current` at a
     /// thread's root context). A GC triggered while an ordinary fiber runs
     /// marks only the *running* executor, so a root Fiber cached on a
@@ -304,6 +306,7 @@ impl alloc::GC<RValue> for Globals {
         for v in &self.root_fiber_objs {
             v.mark(alloc);
         }
+        self.random_seed_obj.mark(alloc);
         self.symbol_names.values().for_each(|v| v.mark(alloc));
         // Trap handler Procs are GC roots: they are reachable only from
         // this table, yet may be invoked at any future poll point.
@@ -495,6 +498,7 @@ impl Globals {
             loading_features: std::collections::HashMap::default(),
             gvar_traces: std::collections::HashMap::default(),
             fiber_scheduler: None,
+            random_seed_obj: Value::integer(0),
             root_fiber_objs: vec![],
             symbol_names: HashMap::default(),
             unused_block_warned: std::collections::HashSet::default(),
@@ -574,7 +578,7 @@ impl Globals {
                 crate::builtins::proc::proc_curry_body
             )
         );
-        globals.random.init_with_seed(None);
+        globals.random_init(None);
         gvar::init_builtin_gvars(&mut globals);
         crate::builtins::init_builtins(&mut globals);
         globals
@@ -784,7 +788,22 @@ impl Globals {
         // exception — CRuby runs both on any normal-ish termination.
         // `Kernel#exit!` / `Process.exit!` bypass this by calling
         // `std::process::exit` directly and never returning here.
+        //
+        // The script's uncaught exception is visible to the handlers as
+        // `$!` (CRuby: at_exit blocks inspect the dying exception). The
+        // unwind-time `$!` is restored afterwards — the top-level report
+        // re-materializes the exception and derives its implicit cause
+        // from it, so the handler-time materialization must not replace it.
+        let unwind_errinfo = executor.errinfo();
+        if let Err(err) = &res
+            && !matches!(err.kind(), MonorubyErrKind::SystemExit(_))
+        {
+            executor.set_error(err.clone());
+            let err_val = executor.take_ex_obj(self);
+            executor.set_errinfo(err_val);
+        }
         let handler_status = executor.run_exit_handlers(self);
+        executor.set_errinfo(unwind_errinfo);
         // CRuby kills the remaining threads *after* the `at_exit`
         // handlers and *before* the uncaught-exception report: each
         // runs the ensure clauses of its current fiber chain (never of
@@ -1366,12 +1385,27 @@ impl Globals {
 
 // Random generator
 impl Globals {
+    /// The exact Integer `srand` reports as the previous seed: the last
+    /// explicitly given seed Value, or the system-initialized one.
+    pub(crate) fn random_seed_value(&self) -> Value {
+        self.random_seed_obj
+    }
+
+    /// Re-seed the global PRNG with an explicit seed: `mt_seed` feeds the
+    /// Mersenne Twister (low bits), `exact` is what the next `srand`
+    /// reports back.
+    pub(crate) fn random_init_with(&mut self, mt_seed: i64, exact: Value) {
+        self.random.init_with_seed(Some(mt_seed));
+        self.random_seed_obj = exact;
+    }
+
     pub(crate) fn random_seed(&self) -> i32 {
         self.random.seed
     }
 
     pub(crate) fn random_init(&mut self, seed: Option<i64>) {
-        self.random.init_with_seed(seed)
+        let used = self.random.init_with_seed(seed);
+        self.random_seed_obj = Value::integer(used);
     }
 
     pub(crate) fn random_gen<T>(&mut self) -> T

--- a/monoruby/src/globals/prng.rs
+++ b/monoruby/src/globals/prng.rs
@@ -4,7 +4,9 @@ use rand_mt::Mt;
 pub struct Prng {
     /// standard PRNG
     pub random: Mt,
-    /// random seed,
+    /// random seed (the low 32 bits actually fed to the Mersenne
+    /// Twister; `Kernel#srand`'s exact Integer echo is kept separately
+    /// as a Value on `Globals`).
     pub seed: i32,
 }
 
@@ -15,19 +17,23 @@ impl Prng {
         Self { random, seed }
     }
 
-    pub fn init_with_seed(&mut self, seed: Option<i64>) {
+    /// Seed the PRNG. With `None`, draws a fresh nonnegative seed from OS
+    /// entropy and returns it (CRuby reports the system-initialized seed
+    /// as a nonnegative Integer).
+    pub fn init_with_seed(&mut self, seed: Option<i64>) -> i64 {
         let new_seed = match seed {
             None => {
                 let mut new_seed = [0u8; 4];
                 if let Err(err) = getrandom::fill(&mut new_seed) {
                     panic!("from_entropy failed: {}", err);
                 }
-                i32::from_ne_bytes(new_seed)
+                (u32::from_ne_bytes(new_seed) & 0x7fff_ffff) as i32
             }
             Some(seed) => seed as i32,
         };
         self.seed = new_seed;
         self.random = Mt::new(new_seed as u32);
+        new_seed as i64
     }
 
     pub fn random<T>(&mut self) -> T

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -1342,6 +1342,14 @@ impl ClassInfoTable {
         let mut module = self.get_module(class_id);
         let mut exclude = HashSet::default();
         loop {
+            // Collecting singleton methods stops at the first ordinary
+            // class on the chain (`Object` for plain objects, `Class` /
+            // `Module` for class/module receivers): everything past it is
+            // instance-method territory — including modules prepended to
+            // `Module` itself, which must not surface here.
+            if only_singleton && module.is_singleton().is_none() && !module.is_iclass() {
+                break;
+            }
             if !only_singleton || module.is_singleton().is_some() || module.is_iclass() {
                 for (name, entry) in &self[module.id()].methods {
                     // Closer ancestor wins: skip names already resolved

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -65,6 +65,7 @@ mod watchdog;
 
 pub(crate) use crate::codegen::runtime::ProcData;
 pub(crate) use bytecode::*;
+pub use builtins::kernel::define_loop_mode_builtins;
 pub use bytecodegen::bytecode_compile_script;
 #[cfg(target_arch = "x86_64")]
 pub(crate) use codegen::jitgen::JitContext;

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -895,6 +895,8 @@ fn main() {
     // main script's parse (consumed by path match, so `require`d files
     // are unaffected).
     if opts.loop_mode != LoopMode::None {
+        // `Kernel#chomp` / `#chop` exist only under `-n` / `-p` (CRuby).
+        monoruby::define_loop_mode_builtins(&mut globals);
         parser::set_cli_loop_wrap(
             path.clone(),
             parser::CliLoopWrap {

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -366,8 +366,15 @@ fn try_prism_inner(
 
     if let Some(diag) = result.errors().next() {
         let loc = location_to_loc(&diag.location());
+        // CRuby embeds the location in the SyntaxError *message* itself
+        // ("file:line: syntax error, ..."), and callers regex on it.
+        let line = source_info.get_line(&loc);
+        let file = crate::globals::display_path(&source_info);
         return Err(MonorubyErr::parse(crate::ast::ParseErr {
-            kind: crate::ast::ParseErrKind::SyntaxError(format!("prism: {}", diag.message())),
+            kind: crate::ast::ParseErrKind::SyntaxError(format!(
+                "{file}:{line}: prism: {}",
+                diag.message()
+            )),
             loc,
             source_info,
         }));

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -281,6 +281,22 @@ pub(crate) fn thread_list(vm: &mut Executor) -> Vec<Value> {
     SCHEDULER.with(|s| s.borrow().threads.clone())
 }
 
+/// After `fork`, only the forking thread survives in the child: mark
+/// every other registered thread dead (CRuby's fork semantics — their
+/// native contexts belong to the parent).
+pub(crate) fn fork_child_reset_threads(vm: &mut Executor) {
+    let cur = SCHEDULER.with(|s| s.borrow().current);
+    let _ = vm;
+    SCHEDULER.with(|s| {
+        let threads = s.borrow().threads.clone();
+        for mut t in threads {
+            if Some(t) != cur {
+                t.as_thread_inner_mut().mark_dead_for_fork();
+            }
+        }
+    });
+}
+
 /// Whether a live (not dead) thread with the given object id exists.
 /// Used by the `require` load lock to detect a stale loading marker
 /// left by a thread that died without unwinding.

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -257,6 +257,13 @@ impl ThreadInner {
         self.state == ThreadState::Dead
     }
 
+    /// Mark this thread dead without unwinding it — used in a fork child,
+    /// where the parent's other threads do not exist.
+    pub(crate) fn mark_dead_for_fork(&mut self) {
+        self.state = ThreadState::Dead;
+        self.killed = true;
+    }
+
     pub(crate) fn proc(&self) -> Option<&Proc> {
         self.proc.as_ref()
     }

--- a/monoruby/tests/command_line.rs
+++ b/monoruby/tests/command_line.rs
@@ -122,10 +122,18 @@ fn dash_zero_record_separator() {
 
 #[test]
 fn kernel_chomp_and_chop() {
-    let out = run(monoruby().args(["-e", "$_ = \"ab\\n\"; chomp; print $_, \"|\"; $_ = \"xyz\"; chop; puts $_"]));
+    // chomp/chop are only defined under -n / -p.
+    let out = run_with_stdin(
+        monoruby().args(["-n", "-e", "chomp; print $_, \"|\"; $_ = \"xyz\"; chop; puts $_"]),
+        "ab\n",
+    );
     assert_eq!(String::from_utf8_lossy(&out.stdout), "ab|xy\n");
-    // chomp with nil $_ is a TypeError.
+    // Without a loop switch they don't exist at all.
     let out = run(monoruby().args(["-e", "chomp"]));
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("NameError"));
+    // chomp with nil $_ (BEGIN runs before the first gets) is a TypeError.
+    let out = run_with_stdin(monoruby().args(["-n", "-e", "BEGIN { chomp }"]), "");
     assert_eq!(out.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&out.stderr).contains("TypeError"));
 }


### PR DESCRIPTION
# Summary

Works through the remaining core/kernel failures (excluding refinements, per request) from the cheapest up: **core/kernel 2231 examples, 59F/33E → 9F/19E** (64 specs fixed). Rebased on current master (d8658eb).

# Method-shape / precondition fixes

- `Object#===`: identity short-circuits before dispatching `==` (CRuby's `rb_equal` fast path, observable when `==`/`equal?` lie).
- `Kernel#extend` validates every argument is a Module before extending anything (TypeError).
- `Kernel#lambda(&pr)`: a non-lambda proc raises ArgumentError; an existing lambda passes through — previously the proc's underlying function was mutated into method style.
- `Kernel#method` / `#public_method` accept `#to_str`-convertible names; conversion errors (e.g. NoMethodError from `#to_str`) propagate as themselves.
- `Kernel#singleton_class` raises TypeError for a frozen String.
- `initialize_clone` accepts the `freeze:` keyword.
- `respond_to_missing?` lives only on Kernel; `caller_locations` and a `set_trace_func` stub get CRuby's module-function shape (private instance / public singleton); `chop` / `chomp` exist only under `-n` / `-p`, registered from the CLI driver.
- `singleton_methods` stops at the first ordinary class on the singleton chain, so modules prepended to `Module` itself no longer leak into a module's singleton methods.

# Conversion protocols

- `Kernel#Integer`: `#to_int` → `#to_str` → `#to_i` coercion order; "base specified for non string value" ArgumentError for an explicit base with a non-String; huge Floats convert exactly through BigInt instead of saturating at i64.
- `Kernel#String`: CRuby's `check_funcall` semantics — a user-defined `respond_to?` returning false suppresses the call, but with the default `respond_to?` the conversion dispatches `#to_s` (so an undef'd `to_s` still reaches `method_missing`), and a NoMethodError means TypeError.
- `Kernel#Complex`: non-real numeric components (a Complex, or a Numeric whose dispatched `#real?` is false) compose as `n1 + n2 * Complex(0, 1)` through `*`/`+` dispatch; a single Complex or non-real Numeric passes through unchanged; non-numeric String components swallow under `exception: false`.
- `Kernel#srand`: the previous seed is echoed back exactly as given (Bignum included — the seed is kept as a Value on Globals, with the low bits feeding the Mersenne Twister), the system-initialized seed is nonnegative, and seeds coerce via `#to_int`.

# Subprocess & IO edges

- `Kernel#system`: `exception: true` raises `Errno::*` on spawn failure and RuntimeError on non-zero exit; ENOEXEC (an executable text file without a shebang) retries through `sh`.
- Kernel backtick: a missing command raises `Errno::ENOENT`; a command string with invalid UTF-8 is handed to the shell as raw bytes; the captured output is tagged with `Encoding.default_external`.
- `Kernel#open`: 1..3 positional arity enforced with keywords kept separate; the `#to_open` protocol forwards keywords and yields `to_open`'s result to a block (guarded `#close` afterwards).
- `File.open` now applies creation permissions (positional Integer or `perm:`) — `IO.write(..., perm: 0o700)` produced 0644 files before, which is what broke the `system` sh-fallback spec.
- `Kernel#gets` dispatches `ARGF.gets` when it has been overridden (so stubs intercept it, with `$_` still set in the caller), keeping the raw `$_`/`$.` record reader otherwise.

# Runtime / reporting

- `Kernel#loop`: the block-less form returns an Enumerator that yields **no** arguments (the enumerator bridge fabricated a `nil` for zero-arg yields), and StopIteration ends the loop with its `#result` as the value.
- `Kernel#warn`: when self is the Warning module (including a redefined `Warning#warn` calling `super`) the message is written directly, fixing the infinite recursion; an out-of-range `uplevel:` still gets the bare `"warning: "` prefix.
- `Kernel#fork`: the child marks every other green thread dead.
- at_exit handlers observe the dying exception as `$!`; the unwind-time `$!` is restored afterwards so the top-level report's implicit cause chain is unchanged (caught by core/exception during development).
- `Kernel#pp` lazily requires `pp` and re-dispatches.
- `Kernel.eval` evaluates with the receiver as self (`Kernel.eval("self")` → Kernel); the ordinary private spelling is unaffected.
- SyntaxError messages embed `file:line:` like CRuby, so eval callers can regex on the position.

# Remaining (documented, out of scope here)

load(path, wrap) ×9, eval refinements ×2 (excluded per request), eval anonymous-parameter forwarding ×4 / magic-comment edges ×2 / binding-self ×3 / LocalJumpError, `to_enum` `$~` propagation, `__callee__` through aliases, `extend`-self-include method-cache case, two environment-shaped require cases, sprintf `%c` encoding ×3.

# Testing

- core/kernel 59F/33E → 9F/19E (re-verified after the rebase)
- CI categories (basicobject … command_line, exception, thread, fiber) at their baselines; core/module / core/proc / core/objectspace / core/enumerator verified **identical to a master-built binary**
- Full unit suite passes (2047 tests), including four new differential test batches covering the changed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_