### PR TITLE
executor: give thread / fiber bodies their own $~ and $_ scope

### DIFF
--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -717,6 +717,47 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn fiber_svar_scope() {
+        // A `Fiber.new` body owns its `$~` / `$1`, like a thread body:
+        // nothing leaks in on entry, nothing leaks back on yield.
+        run_test(
+            r#"
+            "foo" =~ /(o+)/
+            r = []
+            f = Fiber.new do
+              r << ["initial", $1]
+              "zzz" =~ /(z+)/
+              r << ["after-match", $1]
+              Fiber.yield
+            end
+            f.resume
+            r << ["creator-after-resume", $1]
+            r
+            "#,
+        );
+        // Enumerator external iteration must NOT isolate: CRuby drives
+        // it with a C-function fiber (root_lep = NULL), so a match
+        // inside the block *is* visible to the caller after `next`.
+        run_test(
+            r#"
+            "foo" =~ /(o+)/
+            e = Enumerator.new { |y| "bb" =~ /(b+)/; y << 1; "cc" =~ /(c+)/; y << 2 }
+            a = (e.next; $1)
+            b = (e.next; $1)
+            [a, b]
+            "#,
+        );
+        // ... and neither does the plain block form (no fiber at all).
+        run_test(
+            r#"
+            "foo" =~ /(o+)/
+            Enumerator.new { |y| "dd" =~ /(d+)/; y << 1 }.each { }
+            $1
+            "#,
+        );
+    }
+
+    #[test]
     fn fiber_yield_multi_arg() {
         // `Fiber.yield(a, b, ...)` with >=2 args exercises the inlined
         // `emit_fiber_yield_value_array` (builds the yielded array from the

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -744,6 +744,50 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn thread_svar_scope_is_per_thread() {
+        // A thread body owns its `$~` / `$1` / `$_`: the spawner's
+        // values don't leak in, and the body's don't leak back out
+        // (CRuby gives the new context its own root svar container).
+        run_test(
+            r#"
+            "foo" =~ /(o+)/
+            r = []
+            t = Thread.new do
+              r << ["initial", $~.to_a, $1]
+              "bar" =~ /(a)/
+              r << ["after-match", $~.to_a, $1]
+              [1].each { "zzz" =~ /(z+)/ }
+              r << ["after-nested-block", $1]
+              r << ["in-method", (def __h; "q" =~ /(q)/; $1; end; __h)]
+              r << ["after-method-call", $1]
+            end
+            t.join
+            r << ["spawner-after-join", $~.to_a, $1]
+            r
+            "#,
+        );
+        // `$_` is scoped the same way (same container, index 1).
+        run_test(
+            r#"
+            $_ = "main"
+            t = Thread.new { $_ = "child"; $_ }
+            v = t.value
+            [v, $_]
+            "#,
+        );
+        // Two threads started from the *same* proc still get separate
+        // containers.
+        run_test(
+            r#"
+            body = proc { "x#{Thread.current[:n]}" =~ /(x\d)/; $1 }
+            a = Thread.new { Thread.current[:n] = 1; body.call }
+            b = Thread.new { Thread.current[:n] = 2; body.call }
+            [a.value, b.value].sort
+            "#,
+        );
+    }
+
+    #[test]
     fn thread_new_join_value() {
         run_test(r#"Thread.new { 42 }.value"#);
         run_test(

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -385,6 +385,12 @@ impl ProcData {
         self.func_id
     }
 
+    /// The frame this proc closes over — its LEP once resolved with
+    /// `Lfp::mfp`. `None` for procs with no captured environment.
+    pub(crate) fn outer(&self) -> Option<Lfp> {
+        self.outer
+    }
+
     pub(crate) fn from_proc(proc: &ProcInner) -> Self {
         Self {
             outer: proc.outer_lfp(),

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -162,6 +162,33 @@ pub struct Executor {
     /// actually borrows from this Value's buffer, so a stale stash can
     /// never mis-attribute a haystack — it only falls back to copying.
     sp_match_haystack: Option<Value>,
+    /// The LEP this execution context treats as *its own* svar scope
+    /// (CRuby's `ec->root_lep`).
+    ///
+    /// A green thread / fiber body runs a block whose LEP belongs to
+    /// the frame that *created* it — resolving `$~` / `$_` through
+    /// that LEP would share the spawner's container and leak matches
+    /// in both directions. CRuby sidesteps this by recording the
+    /// started proc's LEP here and, whenever an svar lookup lands on
+    /// exactly that LEP, using the context-owned [`root_svar`] instead
+    /// of the frame slot. Inner method frames are unaffected: they own
+    /// their own LEP, so they keep resolving frame-locally.
+    ///
+    /// `None` for the main thread (everything resolves frame-locally,
+    /// which is already correct as no other context shares its
+    /// frames) and for fibers that must stay *shared* with their
+    /// creator — see `FiberInner::svar_isolated` for why the
+    /// enumerator internals rely on that.
+    ///
+    /// [`root_svar`]: Self::root_svar
+    root_lep: Option<Lfp>,
+    /// The svar container (`[$~, $_]` Array) owned by this execution
+    /// context, used in place of the frame slot when a lookup resolves
+    /// to [`root_lep`]. Lazily created on first write, exactly like
+    /// the per-frame containers.
+    ///
+    /// [`root_lep`]: Self::root_lep
+    root_svar: Option<Value>,
     /// Stack of `break` barriers: the CFP at each synchronous
     /// thread-body invocation (`Thread#__invoke_body`). A `break`
     /// escaping a block must not resolve its defining frame *across*
@@ -265,6 +292,8 @@ impl std::default::Default for Executor {
             toplevel_visibility: Visibility::Private,
             sp_match_regex: None,
             sp_match_haystack: None,
+            root_lep: None,
+            root_svar: None,
             break_barriers: Vec::new(),
             temp_stack: vec![],
             method_missing_style: MethodMissingStyle::Plain,
@@ -337,6 +366,12 @@ impl alloc::GC<RValue> for Executor {
             v.mark(alloc);
         }
         if let Some(v) = self.sp_match_haystack {
+            v.mark(alloc);
+        }
+        // The context-owned `$~`/`$_` container (see `root_lep`): held
+        // only here, so it needs marking or a thread's / fiber's
+        // special variables would be collected while it is parked.
+        if let Some(v) = self.root_svar {
             v.mark(alloc);
         }
         // Deferred `MethodReturn` / `Throw` carry packed Values (return
@@ -3502,27 +3537,66 @@ impl Executor {
         Some(cfp.lfp().mfp())
     }
 
-    /// Read the svar container Array on the current MFP, if one has
-    /// been allocated. The slot starts as the zero sentinel (`None`)
-    /// and is lazily filled with a 2-element Array `[$~, $_]` the
-    /// first time either special variable is written.
-    fn svar_container(&self) -> Option<Value> {
-        self.current_mfp()?.svar()
+    /// Whether an svar lookup resolving to `mfp` must use this
+    /// context's own container instead of the frame slot — i.e. `mfp`
+    /// is the LEP the thread / fiber was started on. See
+    /// [`root_lep`](Self::root_lep).
+    fn is_root_svar_scope(&self, mfp: Lfp) -> bool {
+        self.root_lep == Some(mfp)
     }
 
-    /// Get the svar container on the current MFP, allocating a fresh
-    /// `[nil, nil]` Array (and storing it in `LFP_SVAR`) if absent.
-    /// Returns `None` only outside Ruby execution (no MFP).
+    /// Read the svar container for `mfp`: this context's own container
+    /// when `mfp` is the root LEP, otherwise the frame's `LFP_SVAR`
+    /// slot. `None` when nothing has been allocated yet — the slot
+    /// starts as the zero sentinel and is lazily filled with a
+    /// 2-element Array `[$~, $_]` on the first write.
+    fn svar_container_of(&self, mfp: Lfp) -> Option<Value> {
+        if self.is_root_svar_scope(mfp) {
+            self.root_svar
+        } else {
+            mfp.svar()
+        }
+    }
+
+    /// [`svar_container_of`](Self::svar_container_of), allocating a
+    /// fresh `[nil, nil]` container into the right home if absent.
+    fn svar_container_of_create(&mut self, mfp: Lfp) -> Value {
+        if let Some(v) = self.svar_container_of(mfp) {
+            return v;
+        }
+        let arr = Value::array2(Value::nil(), Value::nil());
+        if self.is_root_svar_scope(mfp) {
+            self.root_svar = Some(arr);
+        } else {
+            mfp.set_svar_slot_value(arr);
+        }
+        arr
+    }
+
+    /// Read the svar container Array for the current MFP, if one has
+    /// been allocated.
+    fn svar_container(&self) -> Option<Value> {
+        self.svar_container_of(self.current_mfp()?)
+    }
+
+    /// Get the svar container for the current MFP, allocating one if
+    /// absent. Returns `None` only outside Ruby execution (no MFP).
     fn svar_container_create(&mut self) -> Option<Value> {
         let mfp = self.current_mfp()?;
-        match mfp.svar() {
-            Some(v) => Some(v),
-            None => {
-                let arr = Value::array2(Value::nil(), Value::nil());
-                mfp.set_svar_slot_value(arr);
-                Some(arr)
-            }
-        }
+        Some(self.svar_container_of_create(mfp))
+    }
+
+    /// Enter a new *root* svar scope: the body about to run on this
+    /// (thread / fiber) context owns its `$~` / `$_` rather than
+    /// sharing the container of the frame that created the block.
+    ///
+    /// `lep` is the started proc's outer frame; passing `None` (or an
+    /// outer-less proc) leaves the context resolving frame-locally,
+    /// which is what the enumerator-internal fibers need in order to
+    /// keep sharing with their creator, as they do in CRuby.
+    pub(crate) fn enter_root_svar_scope(&mut self, lep: Option<Lfp>) {
+        self.root_lep = lep.map(|o| o.mfp());
+        self.root_svar = None;
     }
 
     /// Read the MatchData `Value` (`$~`) from the current MFP's svar
@@ -3685,14 +3759,7 @@ impl Executor {
             cfp = prev;
         }
         let mfp = cfp.lfp().mfp();
-        let c = match mfp.svar() {
-            Some(v) => v,
-            None => {
-                let arr = Value::array2(Value::nil(), Value::nil());
-                mfp.set_svar_slot_value(arr);
-                arr
-            }
-        };
+        let c = self.svar_container_of_create(mfp);
         c.as_array()[SVAR_LASTLINE] = val;
     }
 

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -1229,7 +1229,14 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
             let proc_data = ProcData::from_proc(inner.proc().unwrap());
             let args = inner.args();
             let (ptr, len) = (args.as_ptr(), args.len());
-            Entry::Invoke(proc_data, ptr, len, inner.handle() as *mut Executor)
+            // The body block's LEP belongs to the frame that spawned
+            // this thread; without claiming it as *this* context's
+            // root svar scope, `$~` / `$_` would be shared with the
+            // spawner in both directions (CRuby: `ec->root_lep`).
+            let root_lep = proc_data.outer();
+            let handle = inner.handle();
+            handle.enter_root_svar_scope(root_lep);
+            Entry::Invoke(proc_data, ptr, len, handle as *mut Executor)
         } else {
             inner.state = ThreadState::Runnable;
             let exec = inner.resume_exec.take().unwrap().as_ptr();

--- a/monoruby/src/value/rvalue/fiber.rs
+++ b/monoruby/src/value/rvalue/fiber.rs
@@ -9,8 +9,13 @@ impl Fiber {
         Self(val)
     }
 
+    /// A fiber driving enumerator external iteration. It deliberately
+    /// keeps sharing its creator's `$~` / `$_` — see
+    /// `FiberInner::svar_isolated`.
     pub(crate) fn from(proc: Proc) -> Self {
-        Fiber(Value::new_fiber(FiberInner::new(proc, 0, None)))
+        Fiber(Value::new_fiber(FiberInner::with_svar_isolation(
+            proc, 0, None, false,
+        )))
     }
 }
 
@@ -34,6 +39,19 @@ pub struct FiberInner {
     /// enumerator-internal fibers). Explicit Fiber API calls from another
     /// thread raise FiberError.
     owner_thread: u64,
+    /// Whether the body gets its own `$~` / `$_` scope instead of
+    /// sharing the container of the frame that created the block.
+    ///
+    /// `true` for `Fiber.new` (CRuby starts such a fiber with
+    /// `ec->root_lep` set to the proc's LEP, so matches inside it stay
+    /// inside). `false` for the enumerator-internal fibers: CRuby
+    /// drives external iteration with a *C-function* fiber, whose
+    /// `rb_vm_proc_local_ep` is NULL, so its svar lookups fall back to
+    /// the frame slot and a match inside an `Enumerator.new { ... }`
+    /// block *is* observable by the caller after `next`. monoruby
+    /// wraps the user's Ruby proc directly, so it has to opt out here
+    /// to keep that behaviour.
+    svar_isolated: bool,
 }
 
 const FIBER_STACK_SIZE: usize = 1024 * 256;
@@ -72,6 +90,17 @@ impl FiberInner {
         owner_thread: u64,
         thread_root: Option<std::ptr::NonNull<Executor>>,
     ) -> Self {
+        Self::with_svar_isolation(proc, owner_thread, thread_root, true)
+    }
+
+    /// [`new`](Self::new) with an explicit choice of svar scoping; see
+    /// [`svar_isolated`](Self::svar_isolated).
+    pub(crate) fn with_svar_isolation(
+        proc: Proc,
+        owner_thread: u64,
+        thread_root: Option<std::ptr::NonNull<Executor>>,
+        svar_isolated: bool,
+    ) -> Self {
         let mut vm = Executor::default();
         if let Some(root) = thread_root {
             vm.set_thread_root(root);
@@ -82,6 +111,7 @@ impl FiberInner {
             proc: Some(proc),
             stack: None,
             owner_thread,
+            svar_isolated,
         }
     }
 
@@ -92,6 +122,9 @@ impl FiberInner {
             proc: None,
             stack: None,
             owner_thread,
+            // A root fiber *is* its thread's root context; the thread
+            // entry already established the scope.
+            svar_isolated: false,
         }
     }
 
@@ -463,12 +496,17 @@ impl Fiber {
         resume_style: bool,
     ) -> Option<Value> {
         let proc = ProcData::from_proc(self.proc.as_ref().unwrap());
+        // A `Fiber.new` body owns its special variables (CRuby sets
+        // `ec->root_lep` to the proc's LEP when the fiber starts);
+        // enumerator-internal fibers opt out and stay shared.
+        let root_lep = if self.svar_isolated { proc.outer() } else { None };
         let invoker = match (self_val.is_some(), resume_style) {
             (true, _) => globals.invokers.fiber_with_self,
             (false, true) => globals.invokers.fiber,
             (false, false) => globals.invokers.fiber_transfer,
         };
         let handle = self.executor_mut();
+        handle.enter_root_svar_scope(root_lep);
         invoker(
             vm,
             globals,

--- a/spec/tags/language/predefined_tags.txt
+++ b/spec/tags/language/predefined_tags.txt
@@ -1,2 +1,1 @@
-fails:Predefined global $_ is Thread-local
 fails:$LOAD_PATH.resolve_feature_path returns what will be loaded without actual loading, .so file

--- a/spec/tags/language/regexp/back-references_tags.txt
+++ b/spec/tags/language/regexp/back-references_tags.txt
@@ -1,1 +1,0 @@
-fails:Regexps with back-references will not clobber capture variables across threads


### PR DESCRIPTION
## Summary

`$~` and `$_` already lived frame-locally on the LEP's `LFP_SVAR` slot, so **per-frame** scoping was correct. But a thread / fiber body runs a block whose LEP belongs to the frame that *created* it, so both special variables were shared with the spawner in both directions:

```ruby
"foo" =~ /(o+)/
Thread.new { p $1 }.join   # monoruby: "oo"    CRuby: nil
p $1                       # monoruby: leaked   CRuby: "oo"
```

## The CRuby rule

Verified empirically against `ruby` — svar resolution is one line:

```
svar(ec, lep) = (lep == ec.root_lep) ? ec.root_svar   # context-owned
                                     : lep.svar_slot   # frame-owned
```

Starting a thread / fiber records the started proc's LEP as `ec->root_lep` and gives the context a fresh `root_svar`. Inner method frames are unaffected — they own their LEP and keep resolving frame-locally.

## Changes

- **`Executor`** gains `root_lep` / `root_svar`. The three places that reach for a container (`svar_container`, `svar_container_create`, `set_last_read_line_in_caller`) now go through `svar_container_of{,_create}`, which pick the context-owned container when the resolved MFP is the root LEP.
- **`Executor::enter_root_svar_scope`** is called at the two body entries: the green-thread `Entry::Invoke` in `scheduler.rs` and `FiberInner::invoke_fiber_inner`.
- **GC**: `root_svar` is marked in `Executor::mark` (the per-thread/fiber `Executor` is already reached via `ThreadInner` / `FiberInner`).

**No codegen change was needed** — the VM and JIT only ever *write the zero sentinel* into `LFP_SVAR` on frame push, and route every read through the Rust accessors. (Confirmed by auditing all `LFP_SVAR` references across both backends.)

## Enumerator deliberately does not isolate

CRuby drives external iteration with a **C-function fiber**, whose `rb_vm_proc_local_ep` is `NULL`, so its lookups fall back to the frame slot — a match inside an `Enumerator.new { … }` block *is* visible to the caller after `next`:

```ruby
"foo" =~ /(o+)/
e = Enumerator.new { |y| "bb" =~ /(b+)/; y << 1 }
e.next; p $1      # CRuby: "bb"  (leaks, by construction)
```

monoruby wraps the user's Ruby proc directly in a fiber, so it would have started isolating here and diverged. `FiberInner` therefore carries an explicit `svar_isolated` flag — `true` for `Fiber.new`, `false` for `Fiber::from` (the enumerator path) — preserving CRuby's behaviour.

## Verification

Full matrix against CRuby, all now agreeing:

| case | before | after / CRuby |
|---|---|---|
| thread entry `$1` | `"oo"` (leaked in) | `nil` |
| thread body match / nested block / inner method | ✅ already correct | unchanged |
| spawner after `join` | `"zzz"` (leaked out) | `"oo"` |
| `Fiber.new` body & creator | leaked both ways | isolated |
| `Enumerator#next` / `#each` | leaks | **still leaks** ✅ |
| `$_` across threads | shared | isolated |
| two threads from one proc | shared | separate |

- Untags `$_ is Thread-local` and `will not clobber capture variables across threads`. **`language` is 0F / 0E with 5 tagged (was 7).**
- New differential tests: `thread_svar_scope_is_per_thread`, `fiber_svar_scope` (the latter pins the Enumerator non-isolation).
- No regressions: `core/{thread,fiber,enumerator,io,kernel,string}` spec counts are byte-identical to a master-built binary, and the `builtins::{thread,fiber,regexp,match_data}` cargo modules differ only by the two newly added passing tests. (The failures those modules show locally are pre-existing host-Ruby-3.3.6 artifacts and are green in CI.)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_