### PR TITLE
enumerator: run #each on the caller's stack instead of a fiber

### DIFF
--- a/monoruby/builtins/enumerable.rb
+++ b/monoruby/builtins/enumerable.rb
@@ -120,7 +120,7 @@ module Enumerable
     return to_enum(:each_with_index, *args) { respond_to?(:size) ? size : nil } unless block_given?
     i = 0
     each(*args) do |*xs|
-      yield(xs.size == 1 ? xs[0] : xs, i)
+      yield(xs.empty? ? nil : xs.size == 1 ? xs[0] : xs, i)
       i += 1
     end
     self
@@ -215,7 +215,7 @@ module Enumerable
     res = []
     each do |*xs|
       break unless yield(*xs)
-      res << (xs.size == 1 ? xs[0] : xs)
+      res << (xs.empty? ? nil : xs.size == 1 ? xs[0] : xs)
     end
     res
   end
@@ -670,7 +670,10 @@ module Enumerable
   def to_a(*args)
     res = []
     self.each(*args) do |*ys|
-      res << (ys.size == 1 ? ys[0] : ys)
+      res << (ys.empty? ? nil : ys.size == 1 ? ys[0] : ys)
+      # CRuby's internal `collect_all` returns nil; a Generator source
+      # observes this as the value of `y.yield`.
+      nil
     end
     res
   end
@@ -684,7 +687,7 @@ module Enumerable
   def to_h(*args, &blk)
     h = {}
     self.each(*args) do |*xs|
-      x = xs.size == 1 ? xs[0] : xs
+      x = xs.empty? ? nil : xs.size == 1 ? xs[0] : xs
       pair = blk ? blk.call(*xs) : x
       unless pair.is_a?(Array)
         pair = pair.to_ary if pair.respond_to?(:to_ary)
@@ -926,7 +929,7 @@ module Enumerable
   def each_entry(*args)
     return to_enum(:each_entry, *args) { respond_to?(:size) ? size : nil } unless block_given?
     self.each(*args) do |*x|
-      yield(x.size == 1 ? x[0] : x)
+      yield(x.empty? ? nil : x.size == 1 ? x[0] : x)
     end
     self
   end
@@ -949,7 +952,7 @@ module Enumerable
       return to_enum(:cycle) { sz = respond_to?(:size) ? size : nil; sz.nil? ? nil : (sz == 0 ? 0 : Float::INFINITY) } unless block_given?
       cache = []
       each do |*xs|
-        x = xs.size == 1 ? xs[0] : xs
+        x = xs.empty? ? nil : xs.size == 1 ? xs[0] : xs
         cache << x
         yield x
       end
@@ -971,7 +974,7 @@ module Enumerable
       cache = []
       # First pass collects and yields simultaneously so `break` stops early.
       each do |*xs|
-        x = xs.size == 1 ? xs[0] : xs
+        x = xs.empty? ? nil : xs.size == 1 ? xs[0] : xs
         cache << x
         yield x
       end

--- a/monoruby/builtins/struct.rb
+++ b/monoruby/builtins/struct.rb
@@ -17,9 +17,19 @@ class Struct
   end
 
   # Yield [name, value] for each member.
-  def each_pair
+  def each_pair(&blk)
     return to_enum(:each_pair) { size } unless block_given?
-    members.each { |m| yield m, send(m) }
+    # CRuby yields `key, value` as two values only when the block can
+    # actually take two (`rb_block_pair_yield_optimizable`, i.e. min
+    # arity > 1); otherwise it yields a single `[key, value]` pair. That
+    # is what makes `s.each_pair { |k, v| }` and
+    # `s.each_pair.map { |pair| pair }` both behave correctly — the
+    # latter reaches here through Enumerable's internal `|*vs|` block.
+    if blk.arity > 1
+      members.each { |m| yield m, send(m) }
+    else
+      members.each { |m| yield [m, send(m)] }
+    end
     self
   end
 

--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -153,55 +153,43 @@ fn next_values(
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerator/i/each.html]
 #[monoruby_builtin]
 fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    fn each_inner(
-        vm: &mut Executor,
-        globals: &mut Globals,
-        mut internal: Fiber,
-        block_data: &ProcData,
-        self_val: Enumerator,
-    ) -> Result<Value> {
-        let mut res = Value::nil();
-        loop {
-            let v = internal.enum_yield_values(vm, globals, self_val, res)?;
-            if internal.is_terminated() {
-                return Ok(v);
-            }
-            let a = v.as_array();
-            // A zero-arg yield must invoke the block with no arguments —
-            // `peel()` on an empty args array would fabricate a nil.
-            res = if a.len() == 0 {
-                vm.invoke_block(globals, block_data, &[])?
-            } else {
-                vm.invoke_block(globals, block_data, &[a.peel()])?
-            };
-        }
-    }
     let self_val: Enumerator = match Enumerator::try_new(lfp.self_val()) {
         Some(e) => e,
         None => {
             return Err(MonorubyErr::typeerr("not an Enumerator"));
         }
     };
-    let data = if let Some(bh) = lfp.block() {
-        vm.get_block_data(globals, bh)?
-    } else {
+    let Some(bh) = lfp.block() else {
         return Ok(self_val.into());
     };
+
+    // Internal iteration: re-invoke the source method with the caller's
+    // own block, exactly as CRuby's `enumerator_block_call` does
+    // (`rb_block_call_kw(e->obj, e->meth, ...)`). Only external
+    // iteration (`#next` / `#peek`) needs to suspend the producer, and
+    // that is the one place a fiber is created — see `Enumerator::next`.
+    // Driving one here too would run the source on a separate stack,
+    // detaching it from the caller's backtrace and `ensure` unwinding.
 
     // Record the user block's arity so a predicate-consuming method
     // driven through its no-block enumerator (e.g. `Set#divide`, which
     // only receives the internal yielder proc as its block) can pick
     // the right mode from the real arity.
-    let blk_arity = data
+    let blk_arity = vm
+        .get_block_data(globals, bh)?
         .func_id()
         .map(|fid| globals[fid].arity())
         .unwrap_or(-1);
-    let internal = Fiber::from(self_val.proc);
-    vm.temp_push(internal.into());
     globals.push_enum_block_arity(blk_arity);
-    let res = each_inner(vm, globals, internal, &data, self_val);
+    let res = vm.invoke_method_inner(
+        globals,
+        self_val.method,
+        self_val.obj,
+        &self_val.args,
+        Some(bh),
+        self_val.kw_args,
+    );
     globals.pop_enum_block_arity();
-    vm.temp_pop();
     res
 }
 
@@ -376,11 +364,16 @@ fn rewind(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 #[monoruby_builtin]
 fn yielder_push(
     vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    vm.yield_fiber(Value::array1(lfp.arg(0)))
+    // `<<` takes exactly one value, so it always yields exactly one.
+    let self_val = lfp.self_val();
+    yielder_call(vm, globals, self_val, &[lfp.arg(0)])?;
+    // CRuby's `yielder_yield_push` returns the yielder so `y << 1 << 2`
+    // chains; the consumer block's value is only surfaced by `#yield`.
+    Ok(self_val)
 }
 
 ///
@@ -392,11 +385,35 @@ fn yielder_push(
 #[monoruby_builtin]
 fn yielder_yield(
     vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    vm.yield_fiber(lfp.arg(0))
+    // `yield` is rest-args and forwards them verbatim: `Enumerator#each`
+    // reproduces the source yield exactly, it does not pack.
+    //   `y.yield`      -> block called with no args
+    //   `y.yield 1, 2` -> block called with two args
+    // Packing into a single value (`rb_enum_values_pack`) is the job of
+    // the `Enumerable` methods that consume the yield, not of the
+    // yielder — see monoruby/builtins/enumerable.rb.
+    let args: Array = lfp.arg(0).as_array();
+    let args: Vec<Value> = args.iter().copied().collect();
+    yielder_call(vm, globals, lfp.self_val(), &args)
+}
+
+/// Hand `args` to the block of the `Generator#each` call this yielder
+/// belongs to. The index parked in the yielder's ivar selects the
+/// right block when generators are nested.
+fn yielder_call(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    yielder: Value,
+    args: &[Value],
+) -> Result<Value> {
+    let data = vm
+        .enum_yielder_block(yielder)
+        .ok_or_else(|| MonorubyErr::runtimeerr("yielder used outside its Generator#each"))?;
+    vm.invoke_block(globals, &data, args)
 }
 
 ///
@@ -429,31 +446,27 @@ fn generator_each(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    fn each_inner(
-        vm: &mut Executor,
-        globals: &mut Globals,
-        mut internal: Fiber,
-        block_data: &ProcData,
-    ) -> Result<Value> {
-        let yielder = Value::yielder_object();
-        loop {
-            let v = internal.generator_yield_values(vm, globals, yielder)?;
-            if internal.is_terminated() {
-                return Ok(v);
-            }
-            let a: Array = v.as_array();
-            vm.invoke_block(globals, block_data, &[a.peel()])?;
-        }
-    }
     let self_val = Generator::new(lfp.self_val());
+    // Run the generator body *directly* on the caller's stack, handing
+    // it a Yielder bound to this call's block — the same shape as
+    // CRuby's `generator_each` (`rb_proc_call` + `yielder_new`).
+    // Suspending the body is only needed for external iteration
+    // (`#next` / `#peek`), and that fiber is created by the enumerator,
+    // one level up; driving one here as well would nest a second fiber
+    // under every `#each`, cut the generator body off from the caller's
+    // backtrace and `ensure` handling, and cost two extra context
+    // switches per element.
     let data = vm.get_block_data(globals, lfp.expect_block()?)?;
-    let internal = self_val.create_internal();
-    vm.temp_push(internal.into());
-    let res = each_inner(vm, globals, internal, &data);
+    let yielder = Value::yielder_object();
+    vm.temp_push(yielder);
+    vm.push_enum_yielder_block(yielder, data);
+    let body = ProcData::from_proc(&self_val.body());
+    let res = vm.invoke_block(globals, &body, &[yielder]);
     vm.temp_pop();
-
+    vm.pop_enum_yielder_block();
     res
 }
+
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
@@ -469,6 +482,87 @@ mod tests {
             end
             [a.next, a.peek, a.peek, a.next, a.peek, a.next]
             "##,
+        );
+    }
+
+    #[test]
+    fn generator_each_runs_on_the_callers_stack() {
+        // `#each` must not push the generator body onto a fiber: it has
+        // to see the caller's frames and unwind through them.
+        // `ensure` in the body runs when the consumer block raises.
+        run_test(
+            r#"
+            log = []
+            begin
+              Enumerator.new { |y| begin; y << 1; ensure; log << :ensured; end }
+                        .each { |v| raise "boom" }
+            rescue => e
+              log << e.message
+            end
+            log
+            "#,
+        );
+        // The body is part of the caller's backtrace.
+        run_test(r#"Enumerator.new { |y| y << caller.empty? }.first"#);
+        // A body that yields the current fiber sees the caller's, so
+        // `Fiber.yield` is an error exactly as in CRuby (it used to hit
+        // the enumerator's private fiber and abort the process).
+        run_test(
+            r#"
+            begin
+              Enumerator.new { |y| Fiber.yield; y << 1 }.each { }
+            rescue FiberError => e
+              e.class.to_s
+            end
+            "#,
+        );
+        // `break` / exception propagation out of the consumer block.
+        run_test(r#"Enumerator.new { |y| y << 1; y << 2 }.each { |v| break v * 10 }"#);
+        run_test(
+            r#"(Enumerator.new { |y| raise "gen" }.each { }) rescue $!.message"#,
+        );
+    }
+
+    #[test]
+    fn generator_value_packing_and_yielder_returns() {
+        // `Enumerator#each` reproduces the source yield verbatim; the
+        // packing into one value is Enumerable's job.
+        run_test(r#"r = []; Enumerator.new { |y| y.yield }.each { |*a| r << a }; r"#);
+        run_test(r#"r = []; Enumerator.new { |y| y.yield :v }.each { |*a| r << a }; r"#);
+        run_test(r#"r = []; Enumerator.new { |y| y.yield 1, 2 }.each { |*a| r << a }; r"#);
+        run_test(r#"Enumerator.new { |y| y.yield }.each { |a| a }.nil?"#);
+        // rb_enum_values_pack, as seen through Enumerable consumers.
+        run_test(
+            r#"[Enumerator.new { |y| y.yield },
+                Enumerator.new { |y| y.yield :v },
+                Enumerator.new { |y| y.yield 1, 2 }].map { |e|
+                  a = nil; e.reject { false }.each { |*x| a = x }; a
+                }"#,
+        );
+        run_test(
+            r#"[Enumerator.new { |y| y.yield },
+                Enumerator.new { |y| y.yield 1, 2 }].map { |e| e.take_while { true } }"#,
+        );
+        // `#yield` returns the consumer block's value; `<<` returns the
+        // yielder so it chains.
+        run_test(r#"r = []; Enumerator.new { |y| r << y.yield(1) }.each { |v| :from_block }; r"#);
+        run_test(r#"Enumerator.new { |y| y << 1 << 2 }.to_a"#);
+        // Nested generators resolve to their own yielder.
+        run_test(
+            r#"Enumerator.new { |y|
+                 Enumerator.new { |z| z << [:inner, 9] }.each { |v| y << v }
+                 y << :outer
+               }.to_a"#,
+        );
+        // Struct#each_pair picks its yield shape from the block arity,
+        // which is what makes the enumerator form pack correctly.
+        run_test(
+            r#"S = Struct.new(:a, :b)
+               s = S.new(1, 2)
+               r = []
+               s.each_pair { |k, v| r << [k, v] }
+               s.each_pair { |x| r << x }
+               [r, s.each_pair.map { |v| v }, s.each_pair.to_a]"#,
         );
     }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -189,6 +189,20 @@ pub struct Executor {
     ///
     /// [`root_lep`]: Self::root_lep
     root_svar: Option<Value>,
+    /// Consumer blocks of the `Enumerator::Generator#each` calls
+    /// currently on this context's stack.
+    ///
+    /// `Generator#each` runs the generator body *directly* (CRuby does
+    /// the same: only external iteration needs a fiber), handing it a
+    /// fresh `Yielder`. `Yielder#<<` must then reach the block that
+    /// `#each` was given. The block is resolved once, up front, and
+    /// parked here keyed by the yielder object it belongs to, so
+    /// nesting (`Enumerator.new { |y| other.each { |v| y << v } }`)
+    /// resolves to the right one instead of whatever ran most recently.
+    /// Keying on the yielder rather than an ivar keeps the object's
+    /// `#inspect` free of monoruby-only internals (CRuby holds the
+    /// proc in a C struct).
+    enum_yielder_blocks: Vec<(Value, ProcData)>,
     /// Stack of `break` barriers: the CFP at each synchronous
     /// thread-body invocation (`Thread#__invoke_body`). A `break`
     /// escaping a block must not resolve its defining frame *across*
@@ -294,6 +308,7 @@ impl std::default::Default for Executor {
             sp_match_haystack: None,
             root_lep: None,
             root_svar: None,
+            enum_yielder_blocks: Vec::new(),
             break_barriers: Vec::new(),
             temp_stack: vec![],
             method_missing_style: MethodMissingStyle::Plain,
@@ -373,6 +388,15 @@ impl alloc::GC<RValue> for Executor {
         // special variables would be collected while it is parked.
         if let Some(v) = self.root_svar {
             v.mark(alloc);
+        }
+        // Generator consumer blocks close over their defining frame,
+        // which must survive for as long as the generator body can
+        // call back into it.
+        for (yielder, data) in &self.enum_yielder_blocks {
+            yielder.mark(alloc);
+            if let Some(outer) = data.outer() {
+                outer.mark(alloc);
+            }
         }
         // Deferred `MethodReturn` / `Throw` carry packed Values (return
         // value, throw tag/value) and an `Lfp`; keep them alive across
@@ -3597,6 +3621,27 @@ impl Executor {
     pub(crate) fn enter_root_svar_scope(&mut self, lep: Option<Lfp>) {
         self.root_lep = lep.map(|o| o.mfp());
         self.root_svar = None;
+    }
+
+    /// Park the consumer block of a `Generator#each` call, bound to the
+    /// `Yielder` handed to that call. See
+    /// [`enum_yielder_blocks`](Self::enum_yielder_blocks).
+    pub(crate) fn push_enum_yielder_block(&mut self, yielder: Value, data: ProcData) {
+        self.enum_yielder_blocks.push((yielder, data));
+    }
+
+    pub(crate) fn pop_enum_yielder_block(&mut self) {
+        self.enum_yielder_blocks.pop();
+    }
+
+    /// The consumer block `yielder` must call. Innermost first, so a
+    /// generator nested inside another finds its own.
+    pub(crate) fn enum_yielder_block(&self, yielder: Value) -> Option<ProcData> {
+        self.enum_yielder_blocks
+            .iter()
+            .rev()
+            .find(|(y, _)| y.id() == yielder.id())
+            .map(|(_, data)| data.clone())
     }
 
     /// Read the MatchData `Value` (`$~`) from the current MFP's svar

--- a/monoruby/src/value/rvalue/enumerator.rs
+++ b/monoruby/src/value/rvalue/enumerator.rs
@@ -170,6 +170,11 @@ impl Generator {
         assert_eq!(val.ty(), Some(ObjTy::GENERATOR));
         Self(val)
     }
+
+    /// The generator body (the block `Enumerator.new` was given).
+    pub(crate) fn body(&self) -> Proc {
+        self.proc
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

`Enumerator#each` drove the source through an internal fiber, and `Generator#each` spun up a **second one under it** — so every element of `Enumerator.new { … }.each { … }` paid two nested context switches each way.

CRuby only reaches for a fiber where it's unavoidable: **external iteration** (`#next` / `#peek`), which must suspend the producer between elements. Internal iteration is a plain call — `enumerator_block_call` does `rb_block_call(e->obj, e->meth, …)`, and `generator_each` does `rb_proc_call` with a `Yielder` bound to the block.

This aligns monoruby with that split.

## Changes

- **`Enumerator#each`** re-invokes the source method with the caller's own block. No fiber.
- **`Generator#each`** runs the generator body directly, handing it a `Yielder` bound to that call's block. The block is resolved once and parked on the executor **keyed by the yielder object**, so a generator nested inside another finds its own — and the yielder keeps a CRuby-shaped `#inspect`, with no bookkeeping ivar.
- **`#next` / `#peek` unchanged**: `enum_yielder` still drives the same fiber, which now reaches the body through the new `Generator#each` instead of a nested one.

Resulting fiber map matches CRuby exactly for everything measured (`each`/`map`/`to_a`/`size` → no fiber; `next`/`peek`/`next_values` → fiber).

## Behavioural fixes

All pre-existing on master, and **none covered by ruby/spec**:

| | before | after / CRuby |
|---|---|---|
| `ensure` in body when consumer raises | **skipped** (leaked open resources) | runs |
| `Fiber.yield` in body | **Rust panic → process abort** | `FiberError` |
| `caller` in body | truncated at the fiber stack | full |
| `Fiber.current` in `#each` | internal fiber | caller's |
| `y.yield 1, 2` to a `{ \|*a\| }` block | `[[1, 2]]` | `[1, 2]` |
| `y << 1 << 2` | didn't chain | chains (`<<` returns the yielder) |

Forwarding the yield verbatim is the correct split: packing is `rb_enum_values_pack`'s job, i.e. the Enumerable consumer's. Three fixes fall out of moving it there, each matching CRuby:

- the `Enumerable` helpers that pack a yield now map an **empty** yield to `nil` rather than `[]` (`take_while`, `to_a`, `to_h`, `each_entry`, `each_with_index`, `cycle`);
- `Enumerable#to_a`'s internal block returns `nil`, as CRuby's `collect_all` does — a generator observes it as the value of `y.yield`;
- `Struct#each_pair` picks its yield shape from the block's arity (CRuby's `rb_block_pair_yield_optimizable`), so `each_pair { |k, v| }` still gets two values while `each_pair.map { |pair| }` gets the pair.

## Performance

200 000 elements, same run:

| | master | this PR | CRuby |
|---|---|---|---|
| `Enumerator#each` | 52.9 ms | **8.5 ms** (6.2×) | 18.1 ms |
| `Enumerator#next` (50k) | 9.4 ms | 10.7 ms | 14.4 ms |
| `Array#each` | 5.5 ms | 5.5 ms | 7.1 ms |

## Regressions

None. `core/{enumerable,struct,array,hash,range,string,integer,io,kernel,set,comparable}` counts are **identical** to a master-built binary run side by side; `core/enumerator` improves by **2 failures and 1 error**. `language` stays 0F/0E. `builtins::{enumerator,struct,array,hash,fiber}` cargo modules match baseline apart from the two new passing tests.

New differential tests: `generator_each_runs_on_the_callers_stack` (ensure / backtrace / `FiberError` / break / raise) and `generator_value_packing_and_yielder_returns` (packing matrix, yielder return values, nesting, `Struct#each_pair` arity).

## Not in scope

`#with_index` / `#with_object` still drive a fiber — but **one, not two**. Converting them needs a stateful adapter block (the index/memo has to ride along with the consumer block); left for a follow-up.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_