### PR TITLE
Kernel#load(path, wrap): full CRuby semantics; Kernel#clone copies the singleton class (core/kernel/load_spec 1F/8E → 0F/0E)

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3345,7 +3345,18 @@ fn require_relative(
 #[monoruby_builtin]
 fn load_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let file_name = std::path::PathBuf::from(path_arg_to_string(vm, globals, lfp.arg(0))?);
-    let wrap = lfp.try_arg(1).map(|v| v.as_bool()).unwrap_or(false);
+    // `wrap` is either the module to load the file into, or — for any
+    // other truthy value — a fresh anonymous module (CRuby: a T_MODULE
+    // is used as-is, everything else truthy means `Module.new`; note a
+    // Class is *not* a T_MODULE and gets the anonymous module too).
+    let wrap_val = lfp.try_arg(1).unwrap_or_default();
+    let wrap = if let Some(module) = wrap_val.is_module() {
+        Some(module)
+    } else if wrap_val.as_bool() {
+        Some(globals.store.define_unnamed_module())
+    } else {
+        None
+    };
     vm.load(globals, &file_name, wrap)?;
     Ok(Value::bool(true))
 }
@@ -4978,6 +4989,16 @@ fn clone_val(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     // afterwards), so a hook may still initialise a to-be-frozen copy.
     copy.clear_frozen();
 
+    // Clone the receiver's singleton class too (CRuby's
+    // `rb_singleton_class_clone`): singleton methods and `extend`-ed
+    // modules carry over onto a *fresh* singleton class, so later
+    // `def copy.x` / `copy.extend(m)` don't bleed into the original.
+    // Root `copy` across the call — minting the singleton allocates.
+    let temp = vm.temp_len();
+    vm.temp_push(copy);
+    globals.store.clone_singleton_class(self_val, copy)?;
+    vm.temp_clear(temp);
+
     // Skip the no-op copy-hook dispatch when the class uses the default hooks
     // (see `dup` / `uses_default_copy_hooks`).
     let version = Globals::class_version();
@@ -5244,6 +5265,23 @@ fn initialize_clone(
         None,
         None,
     )
+}
+
+/// `main.to_s` / `main.inspect` — the top-level self prints as
+/// `"main"` via a *singleton* method (CRuby defines it with
+/// `rb_define_singleton_method(rb_vm_top_self(), ...)`), so
+/// `main.method(:to_s).owner == main.singleton_class` — and a copy of
+/// main (`Kernel#load` with `wrap`, `clone`) keeps it through its
+/// copied singleton class.
+#[monoruby_builtin]
+pub(crate) fn main_to_s(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let _ = lfp;
+    Ok(Value::string_from_str("main"))
 }
 
 ///
@@ -8850,6 +8888,133 @@ mod tests {
             ::Module.prepend(mod_p)
             m = Module.new { extend self }
             m.singleton_methods
+            "##,
+        );
+    }
+
+    #[test]
+    fn kernel_load_wrap() {
+        // load(path, true): the file runs inside a fresh anonymous
+        // module — constants and top-level defs land there, self is a
+        // copy of main extended with it — and nothing leaks to Object
+        // or to the calling main.
+        run_test(
+            r##"
+            $probe = []
+            path = "/tmp/mrb_load_wrap_t1_#{Process.pid}.rb"
+            File.write(path, <<~'RUBY')
+              class LoadWrapSpecClass
+                $probe << String
+              end
+              LOAD_WRAP_TEST_CONST = 7
+              def load_wrap_test_meth = :meth
+              $probe << method(:load_wrap_test_meth).owner
+              $probe << self
+              $probe << load_wrap_test_meth
+            RUBY
+            r = load path, true
+            wrap_mod = $probe[1]
+            top = $probe[2]
+            res = [
+              r,
+              $probe[0] == String,
+              wrap_mod.instance_of?(Module), wrap_mod.name,
+              Object.const_defined?(:LOAD_WRAP_TEST_CONST),
+              Object.const_defined?(:LoadWrapSpecClass),
+              wrap_mod.const_defined?(:LOAD_WRAP_TEST_CONST),
+              top.to_s, top.equal?(self), top.instance_of?(Object),
+              top.method(:to_s).owner == top.singleton_class,
+              top.singleton_class.ancestors[1] == wrap_mod,
+              $probe[3],
+              (begin; send(:load_wrap_test_meth); :polluted; rescue NameError; :clean; end),
+            ]
+            File.delete(path)
+            res
+            "##,
+        );
+        // load(path, mod): the supplied module is the wrap scope; defs
+        // become private instance methods on it. A truthy non-Module
+        // (String, or a Class — not a T_MODULE) wraps in a fresh
+        // anonymous module instead.
+        run_test(
+            r##"
+            $probe = []
+            path = "/tmp/mrb_load_wrap_t2_#{Process.pid}.rb"
+            File.write(path, <<~'RUBY')
+              LOAD_WRAP_TEST_CONST = 7
+              def load_wrap_test_meth = :meth
+              $probe << method(:load_wrap_test_meth).owner
+            RUBY
+            mod = Module.new
+            load path, mod
+            res = [
+              $probe[0] == mod,
+              mod.const_defined?(:LOAD_WRAP_TEST_CONST),
+              mod::LOAD_WRAP_TEST_CONST,
+              mod.private_instance_methods.include?(:load_wrap_test_meth),
+              Object.new.extend(mod).send(:load_wrap_test_meth),
+            ]
+            $probe = []
+            load path, "truthy"
+            res << ($probe[0].instance_of?(Module) && $probe[0].name.nil?)
+            $probe = []
+            load path, Comparable
+            res << ($probe[0] == Comparable)
+            $probe = []
+            load path, Object
+            res << ($probe[0].instance_of?(Module) && $probe[0] != Object)
+            File.delete(path)
+            res
+            "##,
+        );
+    }
+
+    #[test]
+    fn kernel_clone_singleton_class() {
+        // clone gives the copy its *own* singleton class carrying the
+        // original's singleton methods and extended modules — later
+        // singleton defs / extends on either side don't bleed across.
+        run_test(
+            r##"
+            o = Object.new
+            def o.foo = 1
+            m = Module.new { def bar = 2 }
+            o.extend(m)
+            c = o.clone
+            def c.baz = 3
+            n = Module.new { def qux = 4 }
+            c.extend(n)
+            [
+              c.foo, c.bar, c.baz, c.qux,
+              o.respond_to?(:baz), o.respond_to?(:qux),
+              c.method(:foo).owner == c.singleton_class,
+              o.singleton_class.equal?(c.singleton_class),
+              c.singleton_class.ancestors.include?(m),
+              o.singleton_class.ancestors.include?(n),
+            ]
+            "##,
+        );
+        // dup, by contrast, drops the singleton class entirely.
+        run_test(
+            r##"
+            o = Object.new
+            def o.foo = 1
+            d = o.dup
+            [d.respond_to?(:foo), d.class == Object]
+            "##,
+        );
+        // main's to_s/inspect are singleton methods (owner is the
+        // singleton class), and survive cloning main.
+        run_test(
+            r##"
+            c = self.clone
+            [
+              to_s, inspect,
+              method(:to_s).owner == singleton_class,
+              method(:inspect).owner == singleton_class,
+              c.to_s, c.method(:to_s).owner == c.singleton_class,
+              c.equal?(self),
+            ]
             "##,
         );
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -696,6 +696,51 @@ impl Executor {
         }
     }
 
+    ///
+    /// Execute a script like [`Self::exec_script`], but inside *wrap*
+    /// when one is given (`Kernel#load(path, wrap)`): the file's
+    /// lexical scope is the wrap module — so unqualified constants
+    /// created at its top level land there, not on `Object` — and
+    /// `self` is a fresh copy of *main* (singleton class included)
+    /// extended with the module, mirroring CRuby's
+    /// `rb_obj_clone(top_self)` + `rb_extend_object`.
+    ///
+    fn exec_script_with_wrap(
+        &mut self,
+        globals: &mut Globals,
+        code: impl Into<Vec<u8>>,
+        path: &std::path::Path,
+        wrap: Option<Module>,
+    ) -> Result<Value> {
+        let Some(wrap) = wrap else {
+            return self.exec_script(globals, code, path);
+        };
+        let res = crate::parser::parse_program(code, path)?;
+        let fid = bytecodegen::bytecode_compile_script(globals, res)?;
+        self.flush_compile_warnings(globals);
+        if let Some(iseq) = globals.store.iseq_mut(fid) {
+            iseq.lexical_context = vec![wrap.id()];
+        }
+        let main_object = globals.main_object;
+        let top_self = self.invoke_method_inner(
+            globals,
+            IdentId::get_id("clone"),
+            main_object,
+            &[],
+            None,
+            None,
+        )?;
+        self.invoke_method_inner(
+            globals,
+            IdentId::get_id("extend"),
+            top_self,
+            &[wrap.as_val()],
+            None,
+            None,
+        )?;
+        self.eval_toplevel_with_self(globals, fid, top_self)
+    }
+
     fn exec_script_inner(
         &mut self,
         globals: &mut Globals,
@@ -757,15 +802,29 @@ impl Executor {
     /// *main* object is set to *self*.
     ///
     pub fn eval_toplevel(&mut self, globals: &mut Globals, func_id: FuncId) -> Result<Value> {
+        let main_object = globals.main_object;
+        self.eval_toplevel_with_self(globals, func_id, main_object)
+    }
+
+    ///
+    /// Execute a top level method with an explicit `self` — used by
+    /// `Kernel#load(path, wrap)`, where `self` is a copy of *main*
+    /// extended with the wrap module rather than *main* itself.
+    ///
+    fn eval_toplevel_with_self(
+        &mut self,
+        globals: &mut Globals,
+        func_id: FuncId,
+        self_val: Value,
+    ) -> Result<Value> {
         #[cfg(feature = "emit-bc")]
         globals.dump_bc();
 
-        let main_object = globals.main_object;
         let res = (globals.invokers.method)(
             self,
             globals,
             func_id,
-            main_object,
+            self_val,
             ([]).as_ptr(),
             0,
             None,
@@ -994,20 +1053,16 @@ impl Executor {
     ///
     /// Kernel#load — always (re-)executes the file, never checks loaded_features.
     ///
-    /// When `r#priv` is true the file should run inside an anonymous module;
+    /// With a wrap module the file runs inside it: constants and
+    /// top-level `def`s land in the module instead of `Object`, and
+    /// `self` is a copy of *main* extended with the module.
     ///
     pub fn load(
         &mut self,
         globals: &mut Globals,
         file_name: &std::path::Path,
-        r#priv: bool,
+        wrap: Option<Module>,
     ) -> Result<()> {
-        let wrap = if r#priv {
-            Some(globals.define_toplevel_module(""))
-        } else {
-            None
-        };
-
         let (file_body, path) = globals.find_for_load(self, file_name)?;
         self.load_impl(globals, file_body, &path, wrap)?;
         Ok(())
@@ -1027,10 +1082,15 @@ impl Executor {
 
         self.enter_class_context();
         if let Some(wrap) = wrap {
-            self.push_class_context(wrap.id());
+            // Wrapped load: the runtime cref makes the wrap module the
+            // definee for top-level `def`s, with *private* default
+            // visibility (matching top-level defs on Object — CRuby's
+            // load-wrap defs become private instance methods of the
+            // module).
+            self.push_wrap_class_context(wrap.id());
         }
         self.loading_paths.push(path.to_path_buf());
-        let res = self.exec_script(globals, file_body, path);
+        let res = self.exec_script_with_wrap(globals, file_body, path, wrap);
         self.loading_paths.pop();
         self.exit_class_context();
 
@@ -1064,6 +1124,18 @@ impl Executor {
             .last_mut()
             .unwrap()
             .push(Cref::new(class_id, false, Visibility::Public));
+    }
+
+    /// Like [`Self::push_class_context`], but with *private* default
+    /// visibility: the cref for a wrapped load (`Kernel#load(path,
+    /// wrap)`), whose top-level `def`s become private instance methods
+    /// of the wrap module — the same default a top-level `def` gets on
+    /// `Object`.
+    pub(crate) fn push_wrap_class_context(&mut self, class_id: ClassId) {
+        self.lexical_class
+            .last_mut()
+            .unwrap()
+            .push(Cref::new(class_id, false, Visibility::Private));
     }
 
     /// Runtime-only push used by `class_eval` / `module_eval` /

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -585,6 +585,22 @@ impl Globals {
             .store
             .set_ivar(main_object, IdentId::_NAME, Value::string_from_str("main"))
             .unwrap();
+        // CRuby defines main's `to_s`/`inspect` as *singleton* methods
+        // (`method(:to_s).owner == main.singleton_class`), and copies of
+        // main (`clone`, `Kernel#load` with `wrap`) keep them through the
+        // copied singleton class.
+        globals.define_builtin_singleton_func(
+            main_object,
+            "to_s",
+            crate::builtins::kernel::main_to_s,
+            0,
+        );
+        globals.define_builtin_singleton_func(
+            main_object,
+            "inspect",
+            crate::builtins::kernel::main_to_s,
+            0,
+        );
 
         // Load library path. Resolution chain mirrors the GEM_PATH
         // chain above; the runtime probe that may have just populated

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -1664,6 +1664,63 @@ impl ClassInfoTable {
         class_obj.as_class()
     }
 
+    /// `Kernel#clone`'s singleton-class copy (CRuby's
+    /// `rb_singleton_class_clone_and_attach`): when *original* has a
+    /// singleton class, give *copy* its own fresh singleton class with the
+    /// same method/constant/class-variable tables and the same `extend`-ed
+    /// modules. Without this the two objects share one singleton class, and
+    /// `def copy.x` / `copy.extend(m)` after the clone bleed into the
+    /// original (and vice versa).
+    ///
+    /// The caller must keep *copy* rooted: minting the singleton class and
+    /// its iclasses allocates.
+    pub(crate) fn clone_singleton_class(&mut self, original: Value, mut copy: Value) -> Result<()> {
+        let org_sc = self[original.class()].get_module();
+        if org_sc.is_singleton().is_none() {
+            return Ok(());
+        }
+        // `clone_value` copied the class field verbatim, so the copy still
+        // points at the *original's* singleton. Re-attach it to the real
+        // class first so `get_singleton` mints a fresh one.
+        let real = org_sc.get_real_class();
+        copy.change_class(real.id());
+        let mut new_sc = self.get_singleton(copy)?;
+        let org_info = &self[org_sc.id()];
+        let mut methods = org_info.methods.clone();
+        // Entries stamp their defining class as `owner` (surfaced by
+        // `Method#owner`); on the copied table that must be the *new*
+        // singleton, as it is in CRuby.
+        for entry in methods.values_mut() {
+            if entry.owner == org_sc.id() {
+                entry.owner = new_sc.id();
+            }
+        }
+        let constants = org_info.constants.clone();
+        let constant_locations = org_info.constant_locations.clone();
+        let class_variables = org_info.class_variables.clone();
+        let new_info = &mut self[new_sc.id()];
+        new_info.methods = methods;
+        new_info.constants = constants;
+        new_info.constant_locations = constant_locations;
+        new_info.class_variables = class_variables;
+        // Replicate `extend`-ed modules (iclasses on the original
+        // singleton's superclass chain) in the same order; `include_module`
+        // prepends, so walk nearest-to-furthest and re-include in reverse.
+        let mut included: Vec<ClassId> = vec![];
+        let mut cur = org_sc.superclass();
+        while let Some(sc) = cur
+            && sc.is_iclass()
+        {
+            included.push(sc.id());
+            cur = sc.superclass();
+        }
+        for mod_id in included.into_iter().rev() {
+            let module = self.get_module(mod_id);
+            let _ = new_sc.include_module(module);
+        }
+        Ok(())
+    }
+
     pub(crate) fn define_struct_class(
         &mut self,
         name: Option<IdentId>,


### PR DESCRIPTION
## Summary

Implements the `wrap` argument of `Kernel#load` with CRuby semantics, and fixes two underlying gaps that the wrap specs exposed: `Kernel#clone` sharing the receiver's singleton class, and `main`'s `to_s`/`inspect` not being singleton methods.

`core/kernel/load_spec.rb` goes from 1 failure / 8 errors to **0F/0E** (52 examples clean); `core/kernel` overall goes from 9F/19E to **8F/11E**.

## `Kernel#load(path, wrap)`

`wrap` resolution now matches CRuby: a `Module` is used as the wrap scope directly; any other truthy value mints a fresh anonymous module (a `Class` is not a `T_MODULE`, so it also gets the anonymous module). The wrapped file then runs with:

- **The wrap module as its lexical scope.** The scope is stamped onto the script iseq's `lexical_context`, so unqualified constant assignment at the file's top level lands in the module instead of `Object`. Previously `CONST = 1` in a wrapped file leaked to `Object` (and warned "already initialized constant" on a second load).
- **Top-level `def`s as private instance methods of the module.** A new `push_wrap_class_context` pushes the runtime cref with private default visibility, mirroring the private default a top-level `def` gets on `Object`.
- **`self` as a copy of `main` extended with the module** — CRuby's `rb_obj_clone(top_self)` + `rb_extend_object`. The file can call the top-level methods it defines, while the caller's real `main` is left untouched.

`Executor::load` now takes `Option<Module>` rather than a bool, and `eval_toplevel` gained a sibling that runs a top-level iseq with an explicit `self`.

## Supporting fixes

**`Kernel#clone` now clones the singleton class** (CRuby's `rb_singleton_class_clone`). The copy gets its own fresh singleton class carrying the original's singleton methods — re-owned so `Method#owner` reports the new singleton — and its `extend`-ed modules. Before this, both objects shared one singleton class, so `def copy.x` or `copy.extend(m)` after a clone bled into the original (and vice versa):

```ruby
o = Object.new
def o.foo = 1
c = o.clone
def c.baz = 3
o.respond_to?(:baz)   # was true, now false
```

**`main`'s `to_s`/`inspect` are now genuine singleton methods** on the main object, as CRuby defines them with `rb_define_singleton_method`. So `method(:to_s).owner == main.singleton_class` holds, and clones of `main` keep them through the copied singleton class.

## Testing

- `core/kernel/load_spec.rb`: 52 examples, 0 failures, 0 errors (was 1F/8E)
- `core/kernel`: 9F/19E → 8F/11E
- No change against a binary built from this PR's merge base in `core/{method, unboundmethod, module, objectspace, basicobject, class, thread, fiber, exception, struct, set, proc, enumerator, marshal}`
- Full unit suite green: 3070 tests, 0 failures
- Two new tests (`kernel_load_wrap`, `kernel_clone_singleton_class`) also pass under `gc-stress`
- Behaviour verified against CRuby by differential probes for every `wrap` form (`true`, a `Module`, a `String`, a `Class`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_