### PR TITLE
enumerator: run #with_index / #with_object without a fiber

### DIFF
--- a/monoruby/src/builtins/enumerator.rs
+++ b/monoruby/src/builtins/enumerator.rs
@@ -14,11 +14,11 @@ pub(super) fn init(globals: &mut Globals) {
         1,
         Effect::CAPTURE,
     );
+    globals.define_builtin_func_with(ENUMERATOR_CLASS, "with_index", with_index, 0, 1, false);
+    globals.define_builtin_func(ENUMERATOR_CLASS, "with_object", with_object, 1);
     globals.define_builtin_func(ENUMERATOR_CLASS, "next", next, 0);
     globals.define_builtin_func(ENUMERATOR_CLASS, "next_values", next_values, 0);
     globals.define_builtin_func_rest(ENUMERATOR_CLASS, "each", each);
-    globals.define_builtin_func_with(ENUMERATOR_CLASS, "with_index", with_index, 0, 1, false);
-    globals.define_builtin_func(ENUMERATOR_CLASS, "with_object", with_object, 1);
     globals.define_builtin_func(ENUMERATOR_CLASS, "peek", peek, 0);
     globals.define_builtin_func(ENUMERATOR_CLASS, "peek_values", peek_values, 0);
     globals.define_builtin_func(ENUMERATOR_CLASS, "rewind", rewind, 0);
@@ -197,7 +197,7 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 /// ### Enumerator#with_index
 ///
 /// - with_index(offset = 0) {|(*args), idx| ... } -> object
-/// - with_index(offset = 0) -> Enumeratorf
+/// - with_index(offset = 0) -> Enumerator
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerator/i/with_index.html]
 #[monoruby_builtin]
@@ -207,52 +207,30 @@ fn with_index(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    fn with_index_inner(
-        vm: &mut Executor,
-        globals: &mut Globals,
-        mut internal: Fiber,
-        block_data: &ProcData,
-        mut count: Value,
-        self_val: Enumerator,
-    ) -> Result<Value> {
-        let mut res = Value::nil();
-        loop {
-            let v = internal.enum_yield_values(vm, globals, self_val, res)?;
-            if internal.is_terminated() {
-                return Ok(v);
-            }
-            let a = v.as_array();
-            res = vm.invoke_block(globals, block_data, &[a.peel(), count])?;
-            match count.unpack() {
-                RV::Fixnum(i) => count = Value::integer(i + 1),
-                RV::BigInt(i) => count = Value::bigint(i + 1),
-                _ => unreachable!(),
-            }
-        }
-    }
-    let count = if lfp.try_arg(0).is_none() {
-        Value::integer(0)
-    } else {
-        match lfp.arg(0).unpack() {
-            RV::Fixnum(_) | RV::BigInt(_) => lfp.arg(0),
+    let offset = match lfp.try_arg(0) {
+        // CRuby: `NIL_P(memo) ? 0 : rb_to_int(memo)` — an explicit nil
+        // means 0, a Float truncates, anything else goes through #to_int.
+        None => Value::integer(0),
+        Some(v) if v.is_nil() => Value::integer(0),
+        Some(v) => match v.unpack() {
+            RV::Fixnum(_) | RV::BigInt(_) => v,
             RV::Float(f) => Value::integer(f as i64),
-            _ => Value::integer(lfp.arg(0).coerce_to_int_i64(vm, globals)?),
-        }
+            _ => Value::integer(v.coerce_to_int_i64(vm, globals)?),
+        },
     };
     let self_val = Enumerator::new(lfp.self_val());
-
-    let id = IdentId::get_id("with_index");
-    let data = if let Some(bh) = lfp.block() {
-        vm.get_block_data(globals, bh)?
-    } else {
-        return vm.generate_enumerator(id, lfp.self_val(), vec![], pc);
+    let Some(bh) = lfp.block() else {
+        // The offset is part of the enumerator's replayed arguments —
+        // `e.with_index(5).to_a` must start at 5.
+        return vm.generate_enumerator_with_size(
+            IdentId::get_id("with_index"),
+            lfp.self_val(),
+            vec![offset],
+            pc,
+            self_val.size(),
+        );
     };
-
-    let internal = Fiber::from(self_val.proc);
-    vm.temp_push(internal.into());
-    let res = with_index_inner(vm, globals, internal, &data, count, self_val);
-    vm.temp_pop();
-    res
+    enum_adapter_call(vm, globals, self_val, bh, offset, WITH_INDEX_ADAPTER_FUNCID, pc)
 }
 
 ///
@@ -260,11 +238,6 @@ fn with_index(
 ///
 /// - with_object(memo) {|(*args), memo| ... } -> memo
 /// - with_object(memo) -> Enumerator
-///
-/// Yields each element from the underlying enumeration together with
-/// the same `memo` object. With a block, returns `memo` after all
-/// elements have been yielded. Without a block, returns a fresh
-/// Enumerator that yields `[element, memo]` pairs.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Enumerator/i/with_object.html]
 #[monoruby_builtin]
@@ -274,37 +247,58 @@ fn with_object(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    fn with_object_inner(
-        vm: &mut Executor,
-        globals: &mut Globals,
-        mut internal: Fiber,
-        block_data: &ProcData,
-        memo: Value,
-        self_val: Enumerator,
-    ) -> Result<Value> {
-        let mut res = Value::nil();
-        loop {
-            let v = internal.enum_yield_values(vm, globals, self_val, res)?;
-            if internal.is_terminated() {
-                // CRuby returns the memo (not the underlying each's
-                // return value) when iteration completes.
-                return Ok(memo);
-            }
-            let a = v.as_array();
-            res = vm.invoke_block(globals, block_data, &[a.peel(), memo])?;
-        }
-    }
     let memo = lfp.arg(0);
     let self_val = Enumerator::new(lfp.self_val());
-    let id = IdentId::get_id("with_object");
-    let data = if let Some(bh) = lfp.block() {
-        vm.get_block_data(globals, bh)?
-    } else {
-        return vm.generate_enumerator(id, lfp.self_val(), vec![memo], pc);
+    let Some(bh) = lfp.block() else {
+        return vm.generate_enumerator_with_size(
+            IdentId::get_id("with_object"),
+            lfp.self_val(),
+            vec![memo],
+            pc,
+            self_val.size(),
+        );
     };
-    let internal = Fiber::from(self_val.proc);
-    vm.temp_push(internal.into());
-    let res = with_object_inner(vm, globals, internal, &data, memo, self_val);
+    enum_adapter_call(vm, globals, self_val, bh, memo, WITH_OBJECT_ADAPTER_FUNCID, pc)?;
+    // CRuby returns the memo, not the source's return value.
+    Ok(memo)
+}
+
+/// Run the enumerator's source with a *native* adapter block
+/// (`adapter_fid`) that carries `state` and forwards to the user's
+/// block — CRuby's `enumerator_block_call(obj, enumerator_with_index_i,
+/// memo)` shape. No fiber: only external iteration needs to suspend the
+/// producer.
+///
+/// `state` rides on the adapter proc's `outer_lfp` self as a
+/// single-element Array (mutable, so `#with_index` can bump its
+/// counter); that same Array keys the user block parked on the
+/// executor, which keeps nesting correct.
+fn enum_adapter_call(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    self_val: Enumerator,
+    bh: BlockHandler,
+    state: Value,
+    adapter_fid: FuncId,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    let data = vm.get_block_data(globals, bh)?;
+    let state = Value::array1(state);
+    vm.temp_push(state);
+    let outer = Lfp::dummy_heap_frame_with_self(state);
+    let adapter: Value = Proc::from_outer(outer, adapter_fid, pc).into();
+    vm.temp_push(adapter);
+    vm.push_adapter_block(state, data);
+    let res = vm.invoke_method_inner(
+        globals,
+        self_val.method,
+        self_val.obj,
+        &self_val.args,
+        Some(BlockHandler::new(adapter)),
+        self_val.kw_args,
+    );
+    vm.pop_adapter_block();
+    vm.temp_pop();
     vm.temp_pop();
     res
 }
@@ -411,7 +405,7 @@ fn yielder_call(
     args: &[Value],
 ) -> Result<Value> {
     let data = vm
-        .enum_yielder_block(yielder)
+        .adapter_block(yielder)
         .ok_or_else(|| MonorubyErr::runtimeerr("yielder used outside its Generator#each"))?;
     vm.invoke_block(globals, &data, args)
 }
@@ -459,11 +453,11 @@ fn generator_each(
     let data = vm.get_block_data(globals, lfp.expect_block()?)?;
     let yielder = Value::yielder_object();
     vm.temp_push(yielder);
-    vm.push_enum_yielder_block(yielder, data);
+    vm.push_adapter_block(yielder, data);
     let body = ProcData::from_proc(&self_val.body());
     let res = vm.invoke_block(globals, &body, &[yielder]);
     vm.temp_pop();
-    vm.pop_enum_yielder_block();
+    vm.pop_adapter_block();
     res
 }
 
@@ -482,6 +476,67 @@ mod tests {
             end
             [a.next, a.peek, a.peek, a.next, a.peek, a.next]
             "##,
+        );
+    }
+
+    #[test]
+    fn with_index_and_with_object_run_without_a_fiber() {
+        // Return values: `#with_index` gives back the source's, whereas
+        // `#with_object` gives back the memo.
+        run_test(r#"[1, 2].each.with_index { |v, i| }"#);
+        run_test(r#"[1, 2].each.with_object(:m) { |v, m| }"#);
+        run_test(r#"[1, 2, 3].each.with_object([]) { |v, m| m << v * 2 }"#);
+        // Offset handling: default, explicit, nil (== 0), Float
+        // (truncated), and a #to_int-able object.
+        run_test(r#"r = []; [1, 2].each.with_index { |v, i| r << [v, i] }; r"#);
+        run_test(r#"r = []; [1, 2].each.with_index(5) { |v, i| r << [v, i] }; r"#);
+        run_test(r#"r = []; [1, 2].each.with_index(nil) { |v, i| r << [v, i] }; r"#);
+        run_test(r#"r = []; [1, 2].each.with_index(2.9) { |v, i| r << [v, i] }; r"#);
+        run_test(
+            r#"o = Object.new
+               def o.to_int; 3; end
+               r = []; [1, 2].each.with_index(o) { |v, i| r << [v, i] }; r"#,
+        );
+        // The blockless form keeps the offset / memo and the source size.
+        run_test(r#"[1, 2].each.with_index(5).to_a"#);
+        run_test(r#"[1, 2].each.with_object(:m).to_a"#);
+        run_test(r#"[[1, 2].each.with_index.size, [1, 2].each.with_object(:m).size]"#);
+        // Source yields are packed the way rb_enum_values_pack does.
+        run_test(
+            r#"[Enumerator.new { |y| y.yield },
+                Enumerator.new { |y| y.yield :v },
+                Enumerator.new { |y| y.yield 1, 2 }].map { |e|
+                  r = []; e.with_index { |v, i| r << [v, i] }; r
+                }"#,
+        );
+        run_test(r#"r = []; ({a: 1, b: 2}).each.with_index { |v, i| r << [v, i] }; r"#);
+        // `break` leaves the enumerator method with the block's value.
+        run_test(r#"[1, 2, 3].each.with_index { |v, i| break [v, i] if i == 1 }"#);
+        run_test(r#"[1, 2, 3].each.with_object(:m) { |v, m| break v if v == 2 }"#);
+        // Running the source on the caller's stack (no fiber) means its
+        // `ensure` fires and its frames are on the backtrace.
+        run_test(
+            r#"
+            log = []
+            begin
+              Enumerator.new { |y| begin; y << 1; ensure; log << :ensured; end }
+                        .with_index { |v, i| raise "boom" }
+            rescue => e
+              log << e.message
+            end
+            log
+            "#,
+        );
+        run_test(
+            r#"r = []; Enumerator.new { |y| y << caller.empty? }.with_index { |v, i| r << v }; r"#,
+        );
+        // Nested enumerator calls keep their own state.
+        run_test(
+            r#"out = []
+               [10, 20].each.with_index do |a, i|
+                 [1, 2].each.with_index(100) { |b, j| out << [a, i, b, j] }
+               end
+               out"#,
         );
     }
 

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -192,17 +192,20 @@ pub struct Executor {
     /// Consumer blocks of the `Enumerator::Generator#each` calls
     /// currently on this context's stack.
     ///
-    /// `Generator#each` runs the generator body *directly* (CRuby does
-    /// the same: only external iteration needs a fiber), handing it a
-    /// fresh `Yielder`. `Yielder#<<` must then reach the block that
-    /// `#each` was given. The block is resolved once, up front, and
-    /// parked here keyed by the yielder object it belongs to, so
-    /// nesting (`Enumerator.new { |y| other.each { |v| y << v } }`)
-    /// resolves to the right one instead of whatever ran most recently.
-    /// Keying on the yielder rather than an ivar keeps the object's
-    /// `#inspect` free of monoruby-only internals (CRuby holds the
-    /// proc in a C struct).
-    enum_yielder_blocks: Vec<(Value, ProcData)>,
+    /// Consumer blocks of the enumerator calls currently on this
+    /// context's stack, keyed by the object that stands for the call.
+    ///
+    /// Used wherever a *native* block has to reach the Ruby block its
+    /// enclosing enumerator method was given, because the enumerator
+    /// method runs the source directly rather than through a fiber:
+    /// `Generator#each` keys on the `Yielder` it hands the body, and
+    /// `#with_index` / `#with_object` key on their state Array. Both
+    /// resolve innermost-first, so nesting
+    /// (`Enumerator.new { |y| other.each { |v| y << v } }`) finds the
+    /// right block instead of whatever ran most recently. Keying on an
+    /// object rather than an ivar keeps `#inspect` free of
+    /// monoruby-only internals (CRuby holds these in C structs).
+    adapter_blocks: Vec<(Value, ProcData)>,
     /// Stack of `break` barriers: the CFP at each synchronous
     /// thread-body invocation (`Thread#__invoke_body`). A `break`
     /// escaping a block must not resolve its defining frame *across*
@@ -308,7 +311,7 @@ impl std::default::Default for Executor {
             sp_match_haystack: None,
             root_lep: None,
             root_svar: None,
-            enum_yielder_blocks: Vec::new(),
+            adapter_blocks: Vec::new(),
             break_barriers: Vec::new(),
             temp_stack: vec![],
             method_missing_style: MethodMissingStyle::Plain,
@@ -392,8 +395,8 @@ impl alloc::GC<RValue> for Executor {
         // Generator consumer blocks close over their defining frame,
         // which must survive for as long as the generator body can
         // call back into it.
-        for (yielder, data) in &self.enum_yielder_blocks {
-            yielder.mark(alloc);
+        for (key, data) in &self.adapter_blocks {
+            key.mark(alloc);
             if let Some(outer) = data.outer() {
                 outer.mark(alloc);
             }
@@ -3695,24 +3698,23 @@ impl Executor {
         self.root_svar = None;
     }
 
-    /// Park the consumer block of a `Generator#each` call, bound to the
-    /// `Yielder` handed to that call. See
-    /// [`enum_yielder_blocks`](Self::enum_yielder_blocks).
-    pub(crate) fn push_enum_yielder_block(&mut self, yielder: Value, data: ProcData) {
-        self.enum_yielder_blocks.push((yielder, data));
+    /// Park a consumer block, bound to the object that stands for the
+    /// enumerator call. See [`adapter_blocks`](Self::adapter_blocks).
+    pub(crate) fn push_adapter_block(&mut self, key: Value, data: ProcData) {
+        self.adapter_blocks.push((key, data));
     }
 
-    pub(crate) fn pop_enum_yielder_block(&mut self) {
-        self.enum_yielder_blocks.pop();
+    pub(crate) fn pop_adapter_block(&mut self) {
+        self.adapter_blocks.pop();
     }
 
-    /// The consumer block `yielder` must call. Innermost first, so a
-    /// generator nested inside another finds its own.
-    pub(crate) fn enum_yielder_block(&self, yielder: Value) -> Option<ProcData> {
-        self.enum_yielder_blocks
+    /// The consumer block bound to `key`. Innermost first, so a nested
+    /// enumerator call finds its own.
+    pub(crate) fn adapter_block(&self, key: Value) -> Option<ProcData> {
+        self.adapter_blocks
             .iter()
             .rev()
-            .find(|(y, _)| y.id() == yielder.id())
+            .find(|(k, _)| k.id() == key.id())
             .map(|(_, data)| data.clone())
     }
 

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -578,6 +578,22 @@ impl Globals {
                 crate::builtins::proc::proc_curry_body
             )
         );
+        assert_eq!(
+            WITH_INDEX_ADAPTER_FUNCID,
+            globals.define_builtin_func_rest(
+                OBJECT_CLASS,
+                "",
+                with_index_adapter
+            )
+        );
+        assert_eq!(
+            WITH_OBJECT_ADAPTER_FUNCID,
+            globals.define_builtin_func_rest(
+                OBJECT_CLASS,
+                "",
+                with_object_adapter
+            )
+        );
         globals.random_init(None);
         gvar::init_builtin_gvars(&mut globals);
         crate::builtins::init_builtins(&mut globals);

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -429,6 +429,70 @@ pub(crate) const METHOD_TO_PROC_BODY_FUNCID: FuncId = FuncId::new(4);
 ///
 pub(crate) const PROC_CURRY_BODY_FUNCID: FuncId = FuncId::new(5);
 
+///
+/// Block body for `Enumerator#with_index`.
+///
+/// Mirrors CRuby's `enumerator_with_index_i`: it is the block handed to
+/// the *source* method, so the source runs on the caller's stack with
+/// no fiber. `outer_lfp`'s self is a one-element Array holding the
+/// running index; the consumer block is parked on the executor keyed by
+/// that same Array (see `Executor::adapter_block`). Each call packs the
+/// source yield (`rb_enum_values_pack`) and yields `(packed, index)`.
+///
+pub(crate) const WITH_INDEX_ADAPTER_FUNCID: FuncId = FuncId::new(6);
+
+///
+/// Block body for `Enumerator#with_object`; as
+/// [`WITH_INDEX_ADAPTER_FUNCID`] but the state Array holds the memo,
+/// which is passed unchanged to every call.
+///
+pub(crate) const WITH_OBJECT_ADAPTER_FUNCID: FuncId = FuncId::new(7);
+
+/// Pack a source yield the way CRuby's `rb_enum_values_pack` does:
+/// nothing -> nil, one value -> itself, several -> an Array.
+fn pack_source_yield(lfp: Lfp) -> Value {
+    let args: Array = lfp.arg(0).as_array();
+    args.peel()
+}
+
+#[monoruby_builtin]
+pub(crate) fn with_index_adapter(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let state = lfp.self_val();
+    let packed = pack_source_yield(lfp);
+    let data = vm
+        .adapter_block(state)
+        .ok_or_else(|| MonorubyErr::runtimeerr("with_index adapter lost its block"))?;
+    let mut arr = state.as_array();
+    let idx = arr[0];
+    arr[0] = match idx.unpack() {
+        RV::Fixnum(i) => Value::integer(i + 1),
+        RV::BigInt(i) => Value::bigint(i + 1),
+        _ => return Err(MonorubyErr::runtimeerr("with_index counter is not an Integer")),
+    };
+    vm.invoke_block(globals, &data, &[packed, idx])
+}
+
+#[monoruby_builtin]
+pub(crate) fn with_object_adapter(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let state = lfp.self_val();
+    let packed = pack_source_yield(lfp);
+    let data = vm
+        .adapter_block(state)
+        .ok_or_else(|| MonorubyErr::runtimeerr("with_object adapter lost its block"))?;
+    let memo = state.as_array()[0];
+    vm.invoke_block(globals, &data, &[packed, memo])
+}
+
 #[monoruby_builtin]
 pub(crate) fn enum_yielder(
     vm: &mut Executor,


### PR DESCRIPTION
## Summary

Follow-up to #1041. `#with_index` / `#with_object` were the last internal-iteration paths still driving the source through a fiber.

CRuby runs them as a plain call — `enumerator_with_index` is `enumerator_block_call(obj, enumerator_with_index_i, memo)`, where the adapter is a C function carrying the counter — and reserves fibers for external iteration (`#next` / `#peek`), which genuinely has to suspend the producer.

## Approach

`enum_adapter_call` invokes the source method with a proc over a **native adapter block** (`with_index_adapter` / `with_object_adapter`), whose `outer_lfp` self is a one-element Array holding the state (running index, or memo). The user's block is parked on the executor **keyed by that same Array**, reusing the mechanism `Generator#each` already uses for its `Yielder` — so nesting resolves each call to its own block:

```ruby
a.each.with_index { b.each.with_index(100) { } }   # each level keeps its own counter
```

The keyed stack is renamed `enum_yielder_blocks` → `adapter_blocks` now that it has two users. The adapters pack the source yield exactly as `rb_enum_values_pack` does (nothing → `nil`, one value → itself, several → an `Array`) and yield `(packed, state)`.

An earlier draft implemented these in Ruby (`enumerator.rb`). It was correct and much simpler, but the per-element `|*args|` rest-array allocation and extra Ruby frames ate the entire fiber saving (31.9 → 30.9 ms). The native adapter is what actually buys the speed, and it's what CRuby does.

## Behavioural fixes

Four divergences, all pre-existing on master:

| | before | after / CRuby |
|---|---|---|
| generator `ensure` when consumer raises | **skipped** | runs |
| generator frames in `caller` | hidden by the fiber | present |
| `e.with_index(5).to_a` | starts at **0** (argument dropped) | starts at 5 |
| `e.with_index.size` / `with_object(m).size` | `nil` | source's size |
| `with_index(nil)` | **TypeError** | `0` (CRuby's `rb_to_int`) |
| `with_index(2.9)` blockless | offset ignored | truncated to 2 |

## Performance

200 000 elements:

| | master | this PR | CRuby |
|---|---|---|---|
| `each.with_index` | 31.3 ms | **14.0 ms** | 12.8 ms |
| `each.with_object` | 32.2 ms | **13.7 ms** | 9.5 ms |
| `map.with_index` | 36.0 ms | **15.3 ms** | 11.5 ms |
| `each_with_index` | 15.0 ms | 17.2 ms | 12.4 ms |
| `#next` | unchanged | unchanged | — |

## Result

Every internal-iteration entry point is now fiber-free, matching CRuby's split exactly:

```
each / map / with_index / with_object / to_a / size  → no fiber
next / peek / next_values                            → fiber
```

## Regressions

None. `core/{enumerable,array,hash,range,struct,string,integer,set,io,kernel}` counts are identical to a master-built binary run side by side; `core/enumerator` improves by **5 failures and 1 error**. `builtins::{array,hash,set}` cargo failures match baseline exactly (pre-existing host-Ruby artifacts); `builtins::enumerator` is 17/17 with the new test.

New differential test `with_index_and_with_object_run_without_a_fiber` covers return values, the offset matrix (default / explicit / nil / Float / `#to_int`), the blockless form incl. `size`, packing of zero/single/multi yields, `break`, generator `ensure` + `caller`, and nesting.

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_