### PR TITLE
JIT-inline the hot Array/Integer operations optcarrot spends its time in

### DIFF
--- a/doc/optcarrot_opt_profile.md
+++ b/doc/optcarrot_opt_profile.md
@@ -1,0 +1,283 @@
+# optcarrot `--opt` プロファイル調査と高速化ロードマップ
+
+`bin/optcarrot --opt`（`--opt-ppu=all --opt-cpu=all`）を対象に、どこで時間を
+使っているかを `perf` と `--features profile` で測り、追加すべき最適化を洗い
+出した記録。調査日 2026-07-31 / 2026-08-01。調査の出発点は `ba8e5599`、
+最終的な A/B は `111d1895`（PR のマージベース）に対して取り直したもの。
+
+計測機は x86-64 / Linux。数値は `--frames 3000` を 9 回走らせた中央値
+（`--frames 180` の既定計測は分散が大きいので、定常状態の比較にはフレーム数を
+増やしたものを使う）。
+
+---
+
+## 1. 出発点
+
+| 実装 | fps (`--opt`, 180 frames) |
+|------|--------------------------:|
+| CRuby 4.0.1 | 約 114 |
+| CRuby 4.0.1 + YJIT | 約 153 |
+| monoruby (`ba8e5599`) | 約 460〜494 (3000 frames 中央値) |
+| monoruby (`111d1895`) | 486.5 (3000 frames 中央値) |
+
+## 2. 時間の内訳
+
+`perf record -F 4999 -g --call-graph=fp` の結果を大づかみに分類すると:
+
+| 区分 | 割合 |
+|------|-----:|
+| JIT が吐いたコード本体 | 約 40 % |
+| **JIT コードから呼び出す Rust 側 builtin / runtime** | **約 30 %** |
+| JIT コンパイル自身（`AbstractState::join` ほか） | 約 8 % |
+| GC / malloc / memmove | 約 2 % |
+
+つまり「JIT の出すコードが遅い」のではなく、**ホットループが 1 命令ごとに
+Rust の関数呼び出しへ抜けている**のが最大の損失だった。individual な内訳
+（改善前）:
+
+| シンボル | 自己時間 | 呼び出し元 |
+|----------|--------:|-----------|
+| `Array::push` (← `ary_shl`) | 10.0 % | `@output_pixels << …` ×8 連鎖 |
+| `builtins::numeric::integer::index` | 3.9 % | `data[8]`, `@_a[6]`（CPU のビット取り出し） |
+| `builtins::array::rotate_` | 3.6 % | `@bg_pixels.rotate!(8)` |
+| `runtime::expand_array` | 3.0 % | 多重代入 `a, b = …` |
+| `Array::set_index2` + `index_assign` | 4.3 % | `@bg_pixels[@scroll_xfine, 8] = …` |
+| `Value::unpack` | 2.2 % | 上記 builtin の中 |
+| `Encoding::classify` (← `$1`) | 1.3 % | `--opt` のソース書き換え（起動時） |
+
+### `--opt` の起動コスト
+
+`--frames` を振って外挿すると、定常状態は約 2.2 ms/frame、**固定コストが約
+1.3 s**。optcarrot の `--opt` は起動時に Ruby ソースを生成・正規表現で書き換え
+るため、そのぶんが丸ごと乗る。`fps` の数値自体には影響しないが、
+`Encoding::classify` / `match_at` はここに属する。
+
+---
+
+## 3. 実施した最適化
+
+### 3.1 `Integer#[nth]` の JIT インライン化
+
+`data[8]` のようなビット取り出しが builtin 呼び出しになっていた。レシーバは
+`INTEGER_CLASS` ガード（= `Guarded::Fixnum`）で Fixnum が確定しているので、
+`nth` が定数なら 3 命令で済む。
+
+Fixnum の表現は `2n+1` なので、`n` のビット `nth` はタグ付き値のビット
+`nth+1` にある。算術右シフト `nth` でちょうどビット 1 に落ち、これは Fixnum
+タグが求める位置そのもの:
+
+```asm
+sarq rdi, (nth.min(63))   ; nth>=63 は符号ビット複製で正しい答えになる
+andq rdi, 2
+orq  rdi, 1
+```
+
+負の `nth` は常に 0、両辺リテラルなら定数畳み込み。`[nth, len]` / Range 形式は
+従来どおり generic path。x86-64 / aarch64 双方に実装
+（`gen_bit_index_imm`）。
+
+**効果: 中央値 492 → 510 fps（+4 %）**、`integer::index` は 3.9 % → 0.7 %、
+`Value::unpack` は 2.2 % → 0.7 % に低下。
+
+### 3.2 `Array#<<` の真のインライン化
+
+`Array#<<` は `define_builtin_inline_func` に登録されてはいたが、
+`emit_array_shl` の中身は `movq rax, (f); call rax;` ——つまり
+「generic dispatch を飛ばした直接呼び出し」でしかなく、`Array::push` 本体
+（プロローグ／エピローグ + `SmallVec` の inline/heap 判定 + 書き込みバリア）は
+毎回実行されていた。optcarrot の生成コードは
+
+```ruby
+@output_pixels << @output_color[pixel0] << … << @output_color[pixel7]
+```
+
+を 1 フレームあたり 61440 回実行するため、これが単独で最大のホットスポット。
+
+`ArrayInner` は `SmallVec<[Value; 5]>` で、レイアウトは
+
+- `capacity > 5` ⇔ spill 済み
+- inline のときは `capacity` フィールドが**そのまま長さ**、容量は 5 固定
+- spill 済みなら `heap_ptr` / `heap_len` が別フィールド
+
+なので、どちらの residency でも「2 ロード + 1 ストア + 長さ加算」で追記できる。
+容量いっぱいのとき（`capacity` 回に 1 回、償却的にごく稀）だけ `ary_shl` に
+落として再確保させる。x86-64 / aarch64 双方に実装。
+
+**副産物として凍結チェックのバグを修正**: `ary_shl` は `Array::push` を直接
+呼ぶだけで frozen を見ていなかったため、JIT 化された `a << v` は凍結配列に
+書き込めてしまっていた。
+
+```ruby
+def go(a, v) = a << v
+300.times { |i| go([], i) }      # JIT を温める
+go([1].freeze, 2)                # CRuby: FrozenError / 修正前 monoruby: 素通り
+```
+
+インライン化されたストアは `Array::push` を経由しないので、インライン生成側で
+`ir.guard_frozen(deopt)` を張り、凍結時はインタプリタへ deopt して正しく
+`FrozenError` を上げるようにした。
+
+**効果: 中央値 510 → 590 fps。`Array::push` / `ary_shl` はプロファイルから
+完全に消滅。**
+
+### 3.3 `Array#rotate!`
+
+`rotate_` の自己時間の **約 48 % が `i % ary_len` の 32bit `div`** だった
+（`@bg_pixels.rotate!(8)` は 16 要素配列に対する回転で、剰余は常に恒等）。
+除算は数十サイクルかかる一方、回転量が配列長未満という圧倒的多数のケースでは
+剰余は `|cnt|` そのものなので、範囲内なら除算を飛ばす `wrap_rotate_count` を
+入れた。`Array#rotate` も同じ。
+
+ついでに `(-i) % ary_len` が `i == i64::MIN` でオーバーフローする既存の穴も
+塞いだ（先に剰余を取ってから符号を反転する）。
+
+さらに JIT インライン生成を追加し、レシーバのクラスガード + `guard_frozen` の
+あと `ary_rotate_(ary, i64)` を直接呼ぶようにした（generic dispatch と
+`coerce_to_int_i64` が消える）。
+
+### 3.4 `expand_array`（多重代入）
+
+`AsmInst::ExpandArray` は常に `runtime::expand_array` を呼んでいた。`rest` なし
+で `src` がすでに Array、かつ要素数が足りているケース——多重代入の圧倒的多数
+——は `#to_ary` も nil 埋めも起きない単なる代入列なので、`len <= 8` のときは
+`is_array_ty` チェック + 長さ確認 + 定数回のロード／ストアに展開し、外れた場合
+だけ従来の runtime 呼び出しへ落ちるようにした。
+
+### 3.5 `Array#[]=` の slice 形式
+
+`array_index_assign` のインライン生成は `pos_num != 2` を弾いており、3 引数形式
+（`@bg_pixels[@scroll_xfine, 8] = @bg_pattern_lut[@bg_pattern]`）が丸ごと
+generic dispatch に落ちていた。`set_index2` は `try_array_ty` → `copy_within`
+→ `resize` → `copy_from_slice` と一般形を通るが、エミュレータの内側ループが
+書くのは「同じ長さの並びを配列の内側で置き換える」形だけ——**要素の増減も
+移動もない、ただのコピー**。
+
+そこで `len` をコンパイル時リテラルから取り、残り（`other` が Array であること、
+`other.len() == len`、`0 <= start` かつ `start + len <= self.len()`）を実行時に
+チェックして `len` 個コピーする。外れたもの（伸縮する splice、負のインデックス、
+Array でない右辺、自己代入）はすべて `set_array_slice` に落ちて builtin と同じ
+意味論を再現する。
+
+> **落とし穴**: 最初 `state.is_fixnum(start)` でゲートしたら optcarrot では
+> 一度も発火しなかった。`@scroll_xfine` は ivar から読んだ値で、抽象状態は
+> Fixnum と**証明できていない**（`Guarded::Value`）ためである。`load_fixnum` は
+> どのみちガードを張るので、「Integer 以外だと*証明されて*いない限り許可」と
+> いう弱い述語 `may_be_fixnum` を足してゲートし直した。これで発火するようになり、
+> 単独で 645 → 799 fps を稼いだ。
+
+### 3.6 合計
+
+段階ごとの寄与（`ba8e5599` を基準に測ったもの）:
+
+| | fps (中央値, 3000 frames) |
+|---|---:|
+| `ba8e5599` | 460〜494（run 間で振れる） |
+| + `Integer#[]` + `Array#<<` | 590.4 |
+| + `rotate!` + `expand_array` + `[]=` slice | 779.0 |
+
+最終的な A/B は PR のマージベース `111d1895` に対して取り直した:
+
+| | fps (中央値, 3000 frames) |
+|---|---:|
+| `111d1895` | 486.5 |
+| + 本変更 | **775.6** |
+
+**+59.4 %**。180 frames の既定計測では CRuby ≈ 135〜141 / YJIT ≈ 157〜158
+に対し `111d1895` が 498〜528、本変更で **854〜900 fps**。
+checksum は全 run で一致（60838）。
+
+改善後プロファイルでは JIT が吐いたコードが全体の約 70 % を占め、
+`Array::push` / `ary_shl` / `integer::index` / `set_index2` / `index_assign` /
+`expand_array` / `coerce_to_int_i64` / `SmallVec::resize` はいずれも上位から
+消えた。
+
+検証: `cargo test --release` 3073 件 pass / 0 fail、`--features gc-stress` の
+lib テスト 2253 件 pass / 0 fail。加えて各最適化について、境界・エラー・凍結・
+GC 書き込みバリアを突く Ruby スクリプトを release と gc-stress の両ビルドで
+CRuby と差分比較（`Array#<<` の inline/spill/成長境界/自己追記、slice 代入の
+伸縮・負インデックス・非 Array 右辺・自己代入・`to_ary` 強制、`rotate!` の
+巨大/負/`to_int` 引数、`expand_array` の 1〜9 要素・`*rest`・`to_ary`）。
+
+> **注意**: aarch64 側の実装はクロスコンパイラ (`gcc-aarch64-linux-gnu`) が
+> 手元になく **型チェックできていない**。monoasm の arm64 命令定義と既存の
+> aarch64 コードに照らした目視レビューのみ。CI の macOS arm64 ジョブが初回の
+> ビルド検証になる。
+
+---
+
+## 4. 残っている改善余地
+
+改善後プロファイル（`--frames 4000`）の、JIT コード外の上位:
+
+| 対象 | 割合 | 内容 |
+|------|-----:|------|
+| `Array#rotate!` の実作業 | 3.3 % | `ary_rotate_` 1.7 + `ptr_rotate` 1.6 |
+| `Encoding::classify` + `match_at` | 1.8 % | `--opt` の起動時ソース書き換え |
+| JIT コンパイル自身 | 約 2 % | `AbstractState::join` 1.0 ほか |
+
+### 4.1 `Array#rotate!` の回転そのもの
+
+除算は消えたが、`core::slice::rotate::ptr_rotate`（三段リバース／ジャグリング
+の汎用実装）は残っている。`@bg_pixels` のような 16 要素固定の小配列なら、
+スタック上のテンポラリにコピーして戻すだけの特殊化のほうが速い。
+
+### 4.2 `$1` 取得時のコードレンジ再走査
+
+`get_match_nth` → `RStringInner::propagated_cr` → `Encoding::classify` が
+1.7 %。`propagated_cr` は親の `code_range()` が `Unknown` だと O(N) の再分類に
+落ちる。親文字列を生成した時点（リテラル、`String#+`、`gsub` の結果など）で
+コードレンジを確定させておけば、`$1` ごとの再走査がなくなる。`fps` には効かな
+いが `--opt` の 1.3 s の起動時間には効く。
+
+### 4.3 JIT コンパイル時間 / 再コンパイル
+
+`--features profile` の `jit recompile stats` で、巨大な生成メソッド
+`run` が `RecompileReason::NotCached` で **CPU 側 16 回・PPU 側 6 回**
+再コンパイルされている。数千の呼び出しサイトを持つメソッドでは、
+「まだ暖まっていない 1 サイト」のたびに全体を捨てて再コンパイルすることになる。
+
+- 冷たいサイトだけを遅延コンパイルする（サイド出口スタブ方式）
+- あるいは一定数のサイトが暖まるまでコンパイルを遅らせる
+
+のどちらかで、起動 1.3 s と定常 2.5 % の双方が縮む見込み。
+
+### 4.4 多相インラインキャッシュ (PIC)
+
+`jit class guard failed stats` を見ると `APU::Oscillator#poke_3` などの
+スーパークラス共有メソッドが `Pulse` / `Noise` / `Triangle` の 3 クラスで
+呼ばれ、単相ガードのミス→ deopt になっている。JIT コード内に 2〜4 way の
+PIC を持たせれば deopt を避けられる。
+
+### 4.5 Ruby メソッドのインライン展開条件の緩和
+
+現在 `specialized_iseq`（callee の iseq を呼び出し側に展開）が起動する条件は
+`is_simple_call` かつ **レシーバか引数のどれかがコンパイル時即値**、または
+`...` フォワーディングのとき。APU のように「レシーバは ivar から読んだ
+オブジェクトだが、インラインキャッシュ上はクラスが単相」という典型的な
+ケースは対象外になっている。
+
+「単相 かつ callee の iseq が小さい（バイトコード N 命令未満）」を追加条件に
+すれば、`Oscillator#active?` のような薄いメソッドを取り込める。機構
+（`JitType::Specialized`、`specialize_level` による深さ制限）はすでにあるので、
+ゲートの緩和とサイズヒューリスティクスの追加が主な作業になる。
+
+---
+
+## 5. 調べ方の再現手順
+
+```sh
+# プロファイル
+cargo build --release --features perf
+perf record -F 4999 -g --call-graph=fp -o oc.data \
+  target/release/monoruby ../optcarrot/bin/optcarrot -b --opt --frames 3000 \
+  ../optcarrot/examples/Lan_Master.nes
+perf report -i oc.data --no-children -g none --stdio   # 自己時間の一覧
+perf report -i oc.data --no-children --stdio -S <symbol>  # 呼び出し元
+
+# deopt / 再コンパイル / メソッドキャッシュ統計
+cargo build --release --features profile
+target/release/monoruby ../optcarrot/bin/optcarrot -b --opt --frames 500 \
+  ../optcarrot/examples/Lan_Master.nes 2> prof.txt
+
+# A/B は必ずインターリーブして中央値を取る（単発は ±20 % 振れる）
+```

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1456,13 +1456,15 @@ fn array_slice_assign(
 /// The out-of-line half of `array_slice_assign`: `ary[start, len] = val` with
 /// the full builtin semantics. Mirrors the 3-argument branch of
 /// [`index_assign`]; the receiver's class and unfrozen-ness are already
-/// guarded by the JIT, but everything else (index normalization, the negative
-/// length error, `#to_ary`) still has to happen here.
+/// guarded by the JIT, and `len` comes from the literal `array_slice_assign`
+/// bounded to `0..=MAX_INLINE_SLICE` (so the builtin's negative-length error
+/// cannot arise here), but everything else — index normalization, `#to_ary` —
+/// still has to happen.
 ///
 extern "C" fn set_array_slice(
     base: Value,
     start: i64,
-    len: i64,
+    len: usize,
     val: Value,
     vm: &mut Executor,
     globals: &mut Globals,
@@ -1470,15 +1472,12 @@ extern "C" fn set_array_slice(
     fn inner(
         base: Value,
         mut start: i64,
-        len: i64,
+        len: usize,
         val: Value,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Value> {
         let mut ary = base.as_array();
-        if len < 0 {
-            return Err(MonorubyErr::indexerr(format!("negative length ({})", len)));
-        }
         if start < 0 {
             start += ary.len() as i64;
             if start < 0 {
@@ -1492,7 +1491,7 @@ extern "C" fn set_array_slice(
         } else {
             val
         };
-        ary.set_index2(start as usize, len as usize, val)
+        ary.set_index2(start as usize, len, val)
     }
     inner(base, start, len, val, vm, globals)
         .map_err(|err| vm.set_error(err))
@@ -6177,6 +6176,171 @@ mod tests {
         [a.slice!(2), a]
         "##,
         ]);
+    }
+
+    /// `Array#<<` is JIT-inlined by `array_shl` / `emit_array_shl`: an append
+    /// with spare capacity becomes a two-load / one-store sequence, in both
+    /// the inline (`SmallVec`) and spilled residencies, and only a full buffer
+    /// calls `ary_shl` to reallocate. A splat call site is not `simple` and
+    /// keeps the generic path; a frozen receiver must deopt so the interpreter
+    /// can raise (the inline store bypasses `Array::push`'s caller, which is
+    /// where the check lives).
+    #[test]
+    fn shl_jit_inline() {
+        run_test(
+            r##"
+        def app(a, v) = a << v
+        def app_blk(a, v, &b) = a.<<(v, &b)
+        50.times { app([], 1); app_blk([], 1) }
+        res = []
+        # Grows out of the inline buffer, spills, then reallocates repeatedly.
+        a = []
+        20.times { |i| app(a, i) }
+        res << a
+        # Already spilled, with spare capacity: `<<` returns the receiver.
+        b = [0, 1, 2, 3, 4, 5]
+        res << (app(b, 6).object_id == b.object_id)
+        res << b
+        # Heap children go through the write barrier.
+        c = []
+        6.times { |i| app(c, [i, "s#{i}"]) }
+        res << c
+        res << app_blk([0, 1], 2)
+        begin
+          app([1, 2].freeze, 3)
+        rescue => e
+          res << e.class
+        end
+        res
+        "##,
+        );
+    }
+
+    /// `Array#rotate!` is JIT-inlined by `array_rotate_`: the call site drops
+    /// generic dispatch and `coerce_to_int_i64`, and `ary_rotate_` /
+    /// `wrap_rotate_count` skip the `%` when the count is already in range.
+    /// Covers both arities, all four `wrap_rotate_count` branches, the empty
+    /// receiver, and the shapes that stay generic (a splat call site, a
+    /// non-Integer count) plus the frozen deopt.
+    #[test]
+    fn rotate_jit_inline() {
+        run_test(
+            r##"
+        class Cnt; def to_int = 2; end
+        def rot0(a) = a.rotate!
+        def rot(a, n) = a.rotate!(n)
+        def rot_splat(a, args) = a.rotate!(*args)
+        def rot_obj(a, n) = a.rotate!(n)
+        50.times do
+          rot0([1, 2, 3]); rot([1, 2, 3], 2); rot([1, 2, 3], -2); rot([1, 2, 3], 0)
+          rot_splat([1, 2, 3], [2]); rot_obj([1, 2, 3], Cnt.new)
+        end
+        res = []
+        res << rot([0, 1, 2, 3, 4, 5, 6, 7], 3)     # 0 < cnt < len
+        res << rot([0, 1, 2, 3], 4)                 # cnt == len
+        res << rot([0, 1, 2, 3], 10)                # cnt > len
+        res << rot([0, 1, 2, 3, 4, 5, 6, 7], -3)    # -len < cnt < 0
+        res << rot([0, 1, 2, 3], -10)               # cnt < -len
+        res << rot([0, 1, 2, 3], -4611686018427387904)
+        res << rot([0, 1, 2, 3], 0)
+        res << rot([], 5)                           # empty receiver
+        res << rot0([1, 2, 3, 4])
+        res << rot0([])
+        res << rot_splat([0, 1, 2, 3], [2])
+        res << rot_obj([0, 1, 2, 3], Cnt.new)
+        a = [1, 2, 3]
+        res << (rot(a, 1).object_id == a.object_id)
+        begin
+          rot([1, 2].freeze, 1)
+        rescue => e
+          res << e.class
+        end
+        res
+        "##,
+        );
+    }
+
+    /// The slice form `ary[start, len] = other` is JIT-inlined by
+    /// `array_slice_assign` when `len` is a literal in `0..=8`: an in-bounds
+    /// replacement by an equally long `Array` is a plain copy. Covers the
+    /// inline copy in all four buffer combinations (inline/spilled × source,
+    /// receiver), and every run-time condition that has to fall back to
+    /// `set_array_slice` — a negative start (in and out of range), a
+    /// non-`Array` right-hand side, one that answers `#to_ary`, a length
+    /// mismatch, a run that reaches past the end, and self-assignment —
+    /// plus the compile-time refusals (a start proven non-Integer, a
+    /// non-literal or out-of-range length, a splat call site).
+    #[test]
+    fn index_assign_slice_jit_inline() {
+        run_test(
+            r##"
+        class ToAry; def to_ary = [:x, :y, :z, :w]; end
+        def sl0(a, i, v) = a[i, 0] = v
+        def sl1(a, i, v) = a[i, 1] = v
+        def sl4(a, i, v) = a[i, 4] = v
+        def sl6(a, i, v) = a[i, 6] = v
+        def sl_var(a, i, n, v) = a[i, n] = v      # `len` is not a literal
+        def sl_wide(a, i, v) = a[i, 20] = v       # `len` > the unroll bound
+        def sl_float(a, v) = a[1.5, 2] = v        # start proven non-Integer
+        def sl_splat(a, args) = a.[]=(*args)      # not a `simple` call site
+        def sl_arity(a, v) = a[1, 2, 3] = v       # neither the 2- nor 3-arg form
+        def sl_range(a, r, v) = a[r] = v          # 2-arg form, index not an Integer
+        50.times do
+          sl_range([1, 2, 3], 0..1, [0])
+          sl0([1], 0, []); sl1([1], 0, [0]); sl4([1, 2, 3, 4], 0, [0, 0, 0, 0])
+          sl6([1, 2, 3, 4, 5, 6], 0, [0, 0, 0, 0, 0, 0])
+          sl_var([1, 2], 0, 1, [0]); sl_wide([1, 2], 0, [0])
+          sl_float([1, 2, 3], [0]); sl_splat([1, 2, 3], [0, 1, [0]])
+          begin; sl_arity([1, 2], 0); rescue ArgumentError; end
+        end
+        res = []
+        # --- the inline copy ---
+        res << (a = [0, 1, 2]; sl1(a, 1, [:a]); a)                     # inline/inline
+        res << (a = [*0..9]; sl4(a, 2, [:a, :b, :c, :d]); a)           # spilled/inline
+        res << (a = [*0..9]; sl6(a, 1, [*:a..:f]); a)                  # spilled/spilled
+        res << (a = [0, 1, 2]; sl0(a, 1, []); a)                       # zero-length
+        res << (a = [*0..9]; sl4(a, 6, [:a, :b, :c, :d]); a)           # ends exactly at len
+        # --- run-time fall-backs into `set_array_slice` ---
+        res << (a = [*0..9]; sl4(a, -5, [:a, :b, :c, :d]); a)          # negative start
+        res << (a = [*0..9]; sl4(a, 0, [:a, :b]); a)                   # shorter -> shrinks
+        res << (a = [*0..9]; sl4(a, 0, [*:a..:f]); a)                  # longer -> grows
+        res << (a = [*0..9]; sl4(a, 8, [:a, :b, :c, :d]); a)           # runs past the end
+        res << (a = [*0..9]; sl4(a, 20, [:a, :b, :c, :d]); a)          # start past the end
+        res << (a = [*0..9]; sl4(a, 2, 42); a)                         # not an Array
+        res << (a = [*0..9]; sl4(a, 2, ToAry.new); a)                  # answers #to_ary
+        res << (a = [*0..9]; sl4(a, 2, nil); a)
+        res << (a = [*0..7]; sl4(a, 2, a); a)                          # self-assignment
+        res << (a = [0, 1, 2]; sl4(a, 0, [:a, :b, :c, :d]); a)         # inline receiver grows
+        begin
+          sl4([*0..9], -100, [:a, :b, :c, :d])
+        rescue => e
+          res << e.class
+        end
+        begin
+          sl4([*0..9].freeze, 0, [:a, :b, :c, :d])
+        rescue => e
+          res << e.class
+        end
+        # --- shapes that never reach the inline path ---
+        res << (a = [*0..9]; sl_var(a, 1, 3, [:a, :b, :c]); a)
+        res << (a = [*0..9]; sl_wide(a, 1, [:a]); a)
+        res << (a = [*0..9]; sl_float(a, [:a, :b]); a)
+        res << (a = [*0..9]; sl_splat(a, [1, 2, [:a, :b]]); a)
+        res << (a = [*0..9]; sl_range(a, 2..5, [:a, :b]); a)
+        begin
+          sl_arity([*0..9], 0)
+        rescue => e
+          res << e.class
+        end
+        begin
+          a = [*0..9]
+          a[1, -1] = [:a]
+        rescue => e
+          res << e.class
+        end
+        res
+        "##,
+        );
     }
 
     #[test]

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -128,7 +128,15 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(ARRAY_CLASS, "reverse", reverse, 0);
     globals.define_builtin_func(ARRAY_CLASS, "reverse!", reverse_, 0);
     globals.define_builtin_func(ARRAY_CLASS, "transpose", transpose, 0);
-    globals.define_builtin_func_with(ARRAY_CLASS, "rotate!", rotate_, 0, 1, false);
+    globals.define_builtin_inline_func_with(
+        ARRAY_CLASS,
+        "rotate!",
+        rotate_,
+        inline_gen2!(array_rotate_),
+        0,
+        1,
+        false,
+    );
     globals.define_builtin_func_with(ARRAY_CLASS, "rotate", rotate, 0, 1, false);
     globals.define_builtin_func_rest(ARRAY_CLASS, "product", product);
 
@@ -930,10 +938,72 @@ fn array_shl(
         dst, args, recv, ..
     } = *callsite;
     state.load(ir, recv, GP::Rdi);
+    // `emit_array_shl`'s inline store bypasses `Array::push`, which never
+    // checked frozen-ness itself — a frozen receiver has to leave JIT code
+    // so the interpreter can raise `FrozenError`.
+    let deopt = ir.new_deopt(state);
+    ir.guard_frozen(deopt);
     state.load(ir, args, GP::Rsi);
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
     ir.inline(move |r#gen, _, _, _| r#gen.emit_array_shl(ary_shl as *const () as u64));
+    ir.fpr_restore(using_fpr);
+    state.def_reg2acc_class(ir, GP::Rax, dst, recv_class);
+    true
+}
+
+///
+/// `Array#rotate!` with the count already narrowed to an `i64` — the body
+/// `rotate_` runs once its argument handling is done. Called directly from
+/// JIT code, which has proven the receiver is an unfrozen `Array` and the
+/// count a Fixnum, so none of `rotate_`'s coercion / frozen / arity work is
+/// needed.
+///
+extern "C" fn ary_rotate_(mut ary: Array, count: i64) -> Value {
+    let ary_len = ary.len() as i64;
+    if ary_len != 0 {
+        if count > 0 {
+            ary.rotate_left(wrap_rotate_count(count, ary_len));
+        } else {
+            ary.rotate_right(wrap_rotate_count(count, ary_len));
+        }
+    }
+    ary.into()
+}
+
+fn array_rotate_(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+    arg_class: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num > 1 {
+        return false;
+    }
+    // `arg_class` is only fed for 1-positional-argument sites, which is
+    // exactly the form we narrow; the 0-argument form rotates by 1.
+    let has_arg = callsite.pos_num == 1;
+    if has_arg && arg_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+    state.load(ir, recv, GP::Rdi);
+    let deopt = ir.new_deopt(state);
+    ir.guard_frozen(deopt);
+    if has_arg {
+        state.load_fixnum(ir, args, GP::Rsi);
+    }
+    let using_fpr = state.get_using_fpr(ir);
+    ir.fpr_save(using_fpr);
+    ir.inline(move |r#gen, _, _, _| {
+        r#gen.emit_array_rotate_(ary_rotate_ as *const () as u64, has_arg)
+    });
     ir.fpr_restore(using_fpr);
     state.def_reg2acc_class(ir, GP::Rax, dst, recv_class);
     true
@@ -1294,15 +1364,139 @@ fn array_index_assign(
     idx_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
-    if !callsite.is_simple() || callsite.pos_num != 2 || idx_class != Some(INTEGER_CLASS) {
+    if !callsite.is_simple() {
         return false;
     }
+    match callsite.pos_num {
+        2 => {
+            if idx_class != Some(INTEGER_CLASS) {
+                return false;
+            }
+            let CallSiteInfo {
+                recv, args, dst, ..
+            } = *callsite;
+            assert!(dst.is_none());
+            state.array_integer_index_assign(ir, store, args + 1usize, recv, args);
+            true
+        }
+        3 => array_slice_assign(state, ir, store, callid),
+        _ => false,
+    }
+}
+
+///
+/// JIT-inline the *slice* form `ary[start, len] = other`.
+///
+/// The generic `index_assign` path costs two `coerce_to_int_i64`s, a
+/// `#to_ary` probe and `ArrayInner::set_index2`'s full resize/`copy_within`
+/// dance. But the overwhelmingly common shape — the one emulator inner loops
+/// write, e.g. `@bg_pixels[@scroll_xfine, 8] = @bg_pattern_lut[…]` — replaces
+/// a run with an equally long one *inside* the array, which is a plain copy:
+/// nothing moves, nothing resizes, no element is dropped or added.
+///
+/// So the inline path takes `len` from a compile-time literal and checks the
+/// rest at run time (`other` is an `Array`, `other.len() == len`,
+/// `0 <= start` and `start + len <= self.len()`), copying `len` values when
+/// they all hold. Anything else — a growing/shrinking splice, a negative
+/// index, a non-Array right-hand side — falls into `set_array_slice`, which
+/// reproduces the builtin exactly.
+///
+fn array_slice_assign(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    store: &Store,
+    callid: CallSiteId,
+) -> bool {
+    /// Beyond this the unrolled copy stops paying for the call it replaces.
+    const MAX_INLINE_SLICE: i64 = 8;
+    let callsite = &store[callid];
     let CallSiteInfo {
         recv, args, dst, ..
     } = *callsite;
     assert!(dst.is_none());
-    state.array_integer_index_assign(ir, store, args + 1usize, recv, args);
+    let start = args;
+    let count = args + 1usize;
+    let src = args + 2usize;
+    // `idx_class` is only fed for 1-positional-argument sites, so gate on the
+    // abstract state directly. The weak predicate is deliberate: the common
+    // `ary[ivar, 8] = …` reads its start straight out of an instance variable,
+    // which the state has not narrowed to Fixnum, and `load_fixnum`'s own
+    // guard covers it. Only a slot *proven* to hold something else (a Float,
+    // a Range) is refused, since that guard would deopt every time.
+    if !state.may_be_fixnum(start) {
+        return false;
+    }
+    // `len` must be a literal: it is what the copy is unrolled by.
+    let Some(len) = state.is_fixnum_literal(count) else {
+        return false;
+    };
+    let len = len.get();
+    if !(0..=MAX_INLINE_SLICE).contains(&len) {
+        return false;
+    }
+    let len = len as usize;
+
+    state.load(ir, recv, GP::Rdi);
+    let deopt = ir.new_deopt(state);
+    ir.guard_frozen(deopt);
+    state.load_fixnum(ir, start, GP::Rsi);
+    state.load(ir, src, GP::Rdx);
+    let using_fpr = state.get_using_fpr(ir);
+    let error = ir.new_error(state);
+    ir.fpr_save(using_fpr);
+    ir.inline(move |r#gen, _, _, _| {
+        r#gen.emit_array_slice_assign(set_array_slice as *const () as u64, len)
+    });
+    ir.fpr_restore(using_fpr);
+    ir.handle_error(error);
     true
+}
+
+///
+/// The out-of-line half of `array_slice_assign`: `ary[start, len] = val` with
+/// the full builtin semantics. Mirrors the 3-argument branch of
+/// [`index_assign`]; the receiver's class and unfrozen-ness are already
+/// guarded by the JIT, but everything else (index normalization, the negative
+/// length error, `#to_ary`) still has to happen here.
+///
+extern "C" fn set_array_slice(
+    base: Value,
+    start: i64,
+    len: i64,
+    val: Value,
+    vm: &mut Executor,
+    globals: &mut Globals,
+) -> Option<Value> {
+    fn inner(
+        base: Value,
+        mut start: i64,
+        len: i64,
+        val: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Value> {
+        let mut ary = base.as_array();
+        if len < 0 {
+            return Err(MonorubyErr::indexerr(format!("negative length ({})", len)));
+        }
+        if start < 0 {
+            start += ary.len() as i64;
+            if start < 0 {
+                return Err(MonorubyErr::index_too_small(start - ary.len() as i64, 0));
+            }
+        }
+        let val = if val.try_array_ty().is_some() {
+            val
+        } else if let Some(fid) = globals.check_method(val, IdentId::TO_ARY) {
+            vm.invoke_func_inner(globals, fid, val, &[], None, None)?
+        } else {
+            val
+        };
+        ary.set_index2(start as usize, len as usize, val)
+    }
+    inner(base, start, len, val, vm, globals)
+        .map_err(|err| vm.set_error(err))
+        .ok()
 }
 
 ///
@@ -3400,13 +3594,36 @@ fn rotate_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     let ary_len = ary.len() as i64;
     if ary_len == 0 {
     } else if i > 0 {
-        let i = i % ary_len;
-        ary.rotate_left(i as usize);
+        ary.rotate_left(wrap_rotate_count(i, ary_len));
     } else {
-        let i = (-i) % ary_len;
-        ary.rotate_right(i as usize);
+        // `-i` can overflow for `i == i64::MIN`; wrap first, then negate the
+        // (in-range) remainder.
+        ary.rotate_right(wrap_rotate_count(i, ary_len));
     };
     Ok(lfp.self_val())
+}
+
+///
+/// `|cnt| % ary_len` for a rotation count, skipping the division when `cnt`
+/// is already in range.
+///
+/// A hardware `div` costs tens of cycles and dominated `Array#rotate!` in
+/// profiles, yet the overwhelmingly common rotation is by less than the
+/// array's own length (`ary.rotate!(8)` on a 16-element array), where the
+/// remainder is `|cnt|` itself.
+///
+fn wrap_rotate_count(cnt: i64, ary_len: i64) -> usize {
+    debug_assert!(ary_len > 0);
+    if cnt >= 0 {
+        if cnt < ary_len { cnt } else { cnt % ary_len }
+    } else {
+        // `cnt % ary_len` is `-(|cnt| % ary_len)` in Rust (truncating), so
+        // negating the remainder gives `|cnt| % ary_len` without ever
+        // evaluating `-cnt` (which overflows at `i64::MIN`).
+        if cnt > -ary_len { -cnt } else { -(cnt % ary_len) }
+    }
+    .try_into()
+    .expect("wrapped rotation count is in 0..ary_len")
 }
 
 ///
@@ -3426,11 +3643,9 @@ fn rotate(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let ary_len = ary.len() as i64;
     if ary_len == 0 {
     } else if i > 0 {
-        let i = i % ary_len;
-        ary.rotate_left(i as usize);
+        ary.rotate_left(wrap_rotate_count(i, ary_len));
     } else {
-        let i = (-i) % ary_len;
-        ary.rotate_right(i as usize);
+        ary.rotate_right(wrap_rotate_count(i, ary_len));
     };
     Ok(ary.into())
 }

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -52,7 +52,15 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
     globals.define_builtin_func(INTEGER_CLASS, "<", lt, 1);
     globals.define_basic_op(INTEGER_CLASS, "!=", ne, 1);
     globals.define_builtin_func(INTEGER_CLASS, "<=>", cmp, 1);
-    globals.define_builtin_func_with(INTEGER_CLASS, "[]", index, 1, 2, false);
+    globals.define_builtin_inline_func_with(
+        INTEGER_CLASS,
+        "[]",
+        index,
+        inline_gen2!(integer_index),
+        1,
+        2,
+        false,
+    );
     globals.define_builtin_func(INTEGER_CLASS, "even?", even_, 0);
     globals.define_builtin_func(INTEGER_CLASS, "odd?", odd_, 0);
     globals.define_builtin_func(INTEGER_CLASS, "nonzero?", nonzero_, 0);
@@ -1333,6 +1341,60 @@ fn integer_bitxor(
         |r#gen, imm| r#gen.emit_bitxor_imm(imm),
         |r#gen| r#gen.emit_bitxor_rr(),
     )
+}
+
+///
+/// JIT-inline `Integer#[nth]`, the single-bit-extraction form, when `nth`
+/// is a compile-time fixnum literal. The receiver's `INTEGER_CLASS` guard
+/// has already proven Fixnum, so the whole method collapses to a
+/// shift/and/or triple (see `gen_bit_index_imm`) instead of a call into
+/// `index`, which pays a `Value::unpack` and a `coerce_to_int_i64` per bit.
+///
+/// Only the literal-`nth` shape is inlined: emulator-style bit tests
+/// (`data[7]`, `@_a[6]`) are overwhelmingly constant-indexed, and a
+/// variable `nth` would need the negative / out-of-range branches inline
+/// for no measured benefit.
+///
+fn integer_index(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    nth_class: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    // `self[nth, len]` / `self[range]` keep the generic path.
+    if !callsite.is_simple() || callsite.pos_num != 1 || nth_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+    let Some(nth) = state.is_fixnum_literal(args) else {
+        return false;
+    };
+    let nth = nth.get();
+
+    // A negative bit position always reads 0.
+    if nth < 0 {
+        state.def_C(dst, Immediate::check_fixnum(0).unwrap());
+        return true;
+    }
+
+    // Both operands concrete: fold.
+    if let Some(base) = state.is_fixnum_literal(recv) {
+        let bit = (base.get() >> nth.min(63)) & 1;
+        state.def_C(dst, Immediate::check_fixnum(bit).unwrap());
+        return true;
+    }
+
+    let nth = nth.min(63) as u8;
+    state.load(ir, recv, GP::Rdi);
+    ir.inline(move |r#gen, _, _, _| r#gen.gen_bit_index_imm(nth));
+    state.def_reg2acc_fixnum(ir, GP::Rdi, dst);
+    true
 }
 
 ///

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -2527,6 +2527,39 @@ mod tests {
         run_tests(&["0b11010[-2, 3]", "0b11010[1, 3]"]);
     }
 
+    /// `Integer#[nth]` with a literal `nth` is JIT-inlined by `integer_index`
+    /// down to `gen_bit_index_imm`'s shift/and/or triple. Covers the emitted
+    /// form, the two folds (negative `nth`, and a literal receiver as well),
+    /// the `nth >= 63` clamp, and every shape that has to stay on the generic
+    /// `index` builtin — a non-literal `nth`, the `self[nth, len]` form and a
+    /// splat call site. A Bignum receiver fails the call site's
+    /// `INTEGER_CLASS` guard (which the inline path relies on to prove
+    /// Fixnum) and must leave JIT'd code.
+    #[test]
+    fn integer_index_jit_inline() {
+        run_test(
+            r##"
+        def bits(n) = [n[0], n[1], n[5], n[62], n[63], n[64], n[100], n[-1], n[-70]]
+        # Both operands literal: folded away at compile time.
+        def folded = [0b1011010[0], 0b1011010[1], 0b1011010[3], (-1)[70], (-8)[2], 5[-1]]
+        # `nth` is not a literal -> the generic `Integer#[]`.
+        def var(n, i) = n[i]
+        # `self[nth, len]` is a different form -> generic too.
+        def two(n) = n[1, 3]
+        # A splat call site is not `simple`.
+        def splat(n, a) = n[*a]
+        50.times { bits(0); folded; var(0, 1); two(0); splat(0, [1]) }
+        res = []
+        [0, 1, -1, 255, -256, 4611686018427387903, -4611686018427387904,
+         2 ** 100, -(2 ** 100)].each do |n|
+          res << bits(n) << var(n, 3) << two(n) << splat(n, [4])
+        end
+        res << folded
+        res
+        "##,
+        );
+    }
+
     #[test]
     fn integer_index_endless_range() {
         run_tests(&[

--- a/monoruby/src/codegen/arch/aarch64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/binary_op.rs
@@ -121,6 +121,24 @@ impl Codegen {
         }
     }
 
+    /// Inlined `Integer#[nth]` (single-bit extraction) for a constant,
+    /// non-negative `nth`. Operand `2n+1` in Rdi (x4), result `2*bit+1`.
+    /// aarch64 twin of x86 `gen_bit_index_imm`: bit `nth` of `n` is bit
+    /// `nth + 1` of the tagged operand, so an arithmetic shift by `nth`
+    /// lands it in bit 1 — where the fixnum tag wants it. `nth >= 63`
+    /// clamps to 63 (sign replication), the correct answer for the bits
+    /// past the top of a 63-bit fixnum.
+    pub(crate) fn gen_bit_index_imm(&mut self, nth: u8) {
+        let rdi = GP::Rdi.a64().0; // x4
+        monoasm_arm64!(&mut self.jit,
+            asr x(rdi), x(rdi), #(nth.min(63) as u32);
+            mov x9, #(2);
+            and x(rdi), x(rdi), x9;
+            mov x9, #(1);
+            orr x(rdi), x(rdi), x9;
+        );
+    }
+
     /// Inlined `Integer#<<` by a constant shift amount, with a fixnum-overflow
     /// guard that deopts. Operand `2n+1` in Rdi (x4). aarch64 twin of x86
     /// `gen_shl_rhs_imm`. x86 uses `lzcnt` for the overflow test; monoasm has

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -283,11 +283,203 @@ impl Codegen {
         );
     }
 
-    /// Inlined `Array#<<`: `ary_shl(recv, arg)`. recv (Rdi/x4) -> arg0,
-    /// arg (Rsi/x3) -> arg1. Result Value in Rax (x0).
+    /// `Array#[]=` slice form, `recv[start, len] = val`. aarch64 twin of x86
+    /// `emit_array_slice_assign`; see there for which shape is inlined and
+    /// why. Cold blocks stay on this page (aarch64 b/b.cond cannot reach
+    /// monoasm's second page).
+    ///
+    /// ### in
+    /// - Rdi (x4): receiver: Array (class- and frozen-guarded)
+    /// - Rsi (x3): start: Fixnum (tagged)
+    /// - Rdx (x2): val: Value
+    ///
+    /// ### out
+    /// - Rax (x0): non-null on success (the caller's `handle_error` checks it)
+    ///
+    pub(crate) fn emit_array_slice_assign(&mut self, f: u64, len: usize) {
+        let rdi = GP::Rdi.a64().0; // x4  receiver
+        let rsi = GP::Rsi.a64().0; // x3  start
+        let rdx = GP::Rdx.a64().0; // x2  val
+        let slow = self.jit.label();
+        let src_heap = self.jit.label();
+        let src_ready = self.jit.label();
+        let dst_heap = self.jit.label();
+        let dst_ready = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            asr x(rsi), x(rsi), #(1u32);       // untag start
+            tbnz x(rsi), #(63), slow;          // negative: let the callee wrap it
+            // A self-assignment would copy a buffer over itself; hand it to
+            // the callee, which snapshots the source first.
+            cmp x(rdi), x(rdx);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &slow);
+        monoasm_arm64!(&mut self.jit,
+            // `val` must be an Array...
+            mov x9, (0b111);
+            and x9, x(rdx), x9;
+            cbnz x9, slow;
+            ldrb w9, [x(rdx), #(RVALUE_OFFSET_TY as u32)];
+            cmp x9, #(ObjTy::ARRAY.get() as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            // ...of exactly `len` elements. x11 <- its data.
+            ldr x9, [x(rdx), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x9, #(ARRAY_INLINE_CAPA as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &src_heap);
+        monoasm_arm64!(&mut self.jit,
+            cmp x9, #(len as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            add x11, x(rdx), #(RVALUE_OFFSET_INLINE as u32);
+        );
+        self.jit.bind_label(src_ready.clone());
+        monoasm_arm64!(&mut self.jit,
+            // x9 <- the receiver's length, x12 <- its data.
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x9, #(ARRAY_INLINE_CAPA as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &dst_heap);
+        monoasm_arm64!(&mut self.jit,
+            add x12, x(rdi), #(RVALUE_OFFSET_INLINE as u32);
+        );
+        self.jit.bind_label(dst_ready.clone());
+        monoasm_arm64!(&mut self.jit,
+            // The replaced run must lie inside the receiver.
+            add x10, x(rsi), #(len as u32);
+            cmp x10, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &slow);
+        monoasm_arm64!(&mut self.jit,
+            add x12, x12, x(rsi), lsl #3;      // &recv[start]
+        );
+        for i in 0..len {
+            let disp = (i * 8) as u32;
+            monoasm_arm64!(&mut self.jit,
+                ldr x9, [x11, #(disp)];
+                str x9, [x12, #(disp)];
+            );
+        }
+        // Several children stored at once: remember the receiver wholesale.
+        self.emit_write_barrier_bulk(GP::Rdi);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdx);                    // `[]=` evaluates to the value
+            b exit;
+        );
+        self.jit.bind_label(src_heap);
+        monoasm_arm64!(&mut self.jit,
+            ldr x10, [x(rdx), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x10, #(len as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            ldr x11, [x(rdx), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            b src_ready;
+        );
+        self.jit.bind_label(dst_heap);
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(rdi), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            ldr x12, [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            b dst_ready;
+        );
+        self.jit.bind_label(slow);
+        // set_array_slice(base, start, len, val, vm, globals). Source regs at
+        // entry: base=x4, start=x3, val=x2. Reorder into the C ABI args
+        // without clobbering a still-needed source.
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // base  -> arg0  (x4 free after this)
+            mov x1, x(rsi);       // start -> arg1  (x3 free after this)
+            mov x3, x(rdx);       // val   -> arg3  (x2 free after this)
+            mov x2, (len as u64); // len   -> arg2
+            mov x4, x19;          // vm      -> arg4
+            mov x5, x20;          // globals -> arg5
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.jit.bind_label(exit);
+    }
+
+    /// `Array#rotate!`: `ary_rotate_(recv, count)`. recv (Rdi/x4) -> arg0;
+    /// the count arrives tagged in Rsi (x3) — or is the implicit `1` — and
+    /// the callee takes a plain `i64`. Result Value in Rax (x0).
+    pub(crate) fn emit_array_rotate_(&mut self, f: u64, has_arg: bool) {
+        let rdi = GP::Rdi.a64().0; // x4
+        let rsi = GP::Rsi.a64().0; // x3
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);       // recv -> arg0
+        );
+        if has_arg {
+            monoasm_arm64!(&mut self.jit, asr x1, x(rsi), #(1u32););
+        } else {
+            monoasm_arm64!(&mut self.jit, mov x1, #(1););
+        }
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+    }
+
+    /// `Array#<<` — append, with the no-grow case emitted inline. aarch64
+    /// twin of x86 `emit_array_shl`; see there for why the receiver's
+    /// `SmallVec` residency decides which pair of fields holds the length.
+    /// Cold blocks are laid out inline rather than on page 1 (aarch64
+    /// b/b.cond cannot reach it — see `array_index`).
+    ///
+    /// ### in
+    /// - Rdi (x4): receiver: Array
+    /// - Rsi (x3): value: Value
+    ///
+    /// ### out
+    /// - Rax (x0): receiver: Array (`<<` returns self)
+    ///
     pub(crate) fn emit_array_shl(&mut self, f: u64) {
         let rdi = GP::Rdi.a64().0; // x4
         let rsi = GP::Rsi.a64().0; // x3
+        let heap = self.jit.label();
+        let grow = self.jit.label();
+        let stored = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x(rdi), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x0, #(ARRAY_INLINE_CAPA as u32);
+            b.gt heap;
+            // Inline buffer: x0 is the length, ARRAY_INLINE_CAPA the capacity.
+            b.eq grow;
+            add x9, x(rdi), x0, lsl #3;
+            str x(rsi), [x9, #(RVALUE_OFFSET_INLINE as u32)];
+            add x0, x0, #(1);
+            str x0, [x(rdi), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            b stored;
+        );
+        self.jit.bind_label(heap);
+        monoasm_arm64!(&mut self.jit,
+            // Spilled buffer: x0 is the capacity, the length lives beside
+            // the pointer.
+            ldr x10, [x(rdi), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x10, x0;
+            b.ge grow;
+            ldr x11, [x(rdi), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            add x9, x11, x10, lsl #3;
+            str x(rsi), [x9];
+            add x10, x10, #(1);
+            str x10, [x(rdi), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+        );
+        self.jit.bind_label(stored);
+        // Write barrier: x4 (Rdi) = the array (parent), x3 (Rsi) = appended value.
+        self.emit_write_barrier(GP::Rdi, GP::Rsi);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rdi);
+            b exit;
+        );
+        self.jit.bind_label(grow);
+        // Buffer full: let `ary_shl` reallocate (and run its own barrier).
         monoasm_arm64!(&mut self.jit,
             mov x0, x(rdi);       // recv -> arg0
             mov x1, x(rsi);       // arg  -> arg1
@@ -296,6 +488,7 @@ impl Codegen {
             blr x9;
             ldr x30, [sp], #16;
         );
+        self.jit.bind_label(exit);
     }
 
     /// `Integer#succ` / `#next`: fixnum in Rdi (x4); tagged `+1` is `+2` on the

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2206,6 +2206,9 @@ impl Codegen {
         let lfp = GP::R14.a64().0; // x22
         let off = dst.0 as u32 * 8 + LFP_SELF as u32;
         let f = runtime::expand_array as *const () as u64;
+        // The fast path (when emitted) falls through to the runtime call
+        // below on `slow`, and jumps past it on success.
+        let fast = self.expand_array_fast_path(off, len, rest_pos);
         self.emit_fpr_save(using_fpr, false);
         // x2 already holds `src` (GP::Rdx). Fill the remaining C-args.
         // x19 = EXEC (&mut Executor), x20 = GLOBALS (&mut Globals).
@@ -2223,7 +2226,88 @@ impl Codegen {
             ldr x30, [sp], #16;
         );
         self.emit_fpr_restore(using_fpr, false);
+        if let Some(exit) = fast {
+            self.jit.bind_label(exit);
+        }
         true
+    }
+
+    ///
+    /// aarch64 twin of the x86 `expand_array_fast_path`: when `src` (x2) is
+    /// already an `Array` holding at least `len` elements, destructuring is
+    /// just `len` moves onto the destination slots. `off` is the byte
+    /// displacement of `dst` below the LFP; slot `dst.0 + i` sits a further
+    /// `i * 8` below. Cold blocks stay on this page (aarch64 b/b.cond cannot
+    /// reach monoasm's second page).
+    ///
+    /// Returns the `exit` label the caller must bind after the runtime call
+    /// (which doubles as the fall-through `slow` target), or `None` when no
+    /// fast path was emitted.
+    ///
+    fn expand_array_fast_path(
+        &mut self,
+        off: u32,
+        len: usize,
+        rest_pos: Option<usize>,
+    ) -> Option<DestLabel> {
+        const MAX_INLINE_EXPAND: usize = 8;
+        if rest_pos.is_some() || len == 0 || len > MAX_INLINE_EXPAND {
+            return None;
+        }
+        let src = GP::Rdx.a64().0; // x2
+        let lfp = GP::R14.a64().0; // x22
+        let heap = self.jit.label();
+        let copy = self.jit.label();
+        let slow = self.jit.label();
+        let exit = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (0b111);
+            and x9, x(src), x9;
+            cbnz x9, slow;                                  // immediate -> slow
+            ldrb w9, [x(src), #(RVALUE_OFFSET_TY as u32)];
+            cmp x9, #(ObjTy::ARRAY.get() as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(src), #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            cmp x9, #(ARRAY_INLINE_CAPA as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &heap);
+        // Inline buffer: x9 is the length, the elements follow in place.
+        monoasm_arm64!(&mut self.jit,
+            cmp x9, #(len as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &slow);
+        monoasm_arm64!(&mut self.jit,
+            add x11, x(src), #(RVALUE_OFFSET_INLINE as u32);
+        );
+        self.jit.bind_label(copy.clone());
+        for i in 0..len {
+            let src_disp = (i * 8) as u32;
+            monoasm_arm64!(&mut self.jit, ldr x9, [x11, #(src_disp)];);
+            self.a64_frame_store(9, lfp, off + (i * 8) as u32);
+        }
+        monoasm_arm64!(&mut self.jit,
+            // Non-null x0: `expand_array` signals errors with a null return,
+            // and the caller's `handle_error` checks it.
+            mov x0, #(1);
+            b exit;
+        );
+        self.jit.bind_label(heap);
+        // Spilled buffer: x9 is the capacity, the length lives beside the
+        // pointer.
+        monoasm_arm64!(&mut self.jit,
+            ldr x10, [x(src), #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x10, #(len as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &slow);
+        monoasm_arm64!(&mut self.jit,
+            ldr x11, [x(src), #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            b copy;
+        );
+        // The runtime call the caller emits next *is* the slow path.
+        self.jit.bind_label(slow);
+        Some(exit)
     }
 
     // ---- exception / non-local control flow -------------------------------

--- a/monoruby/src/codegen/arch/aarch64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/variables.rs
@@ -167,9 +167,36 @@ impl Codegen {
             and x9, x(c), x9;
             cbnz x9, skip;             // immediate child -> skip
         );
-        // Slow path: save the caller-saved regs the JIT may have live, pass the
-        // parent in the C-ABI arg0 (x0), and call. `x(p)` is untouched by the
-        // saves, so it still holds the parent when read into x0.
+        self.a64_write_barrier_call(p);
+        self.jit.bind_label(skip);
+    }
+
+    ///
+    /// The bulk variant of [`Self::emit_write_barrier`], for an inline store
+    /// that wrote *several* children (an array slice copy). Checking each one
+    /// is not worth it, so an armed parent is remembered regardless of what
+    /// was stored — the same safe over-approximation
+    /// `RValue::write_barrier_bulk` makes. aarch64 twin of x86
+    /// `emit_write_barrier_bulk_rdi`.
+    ///
+    pub(in crate::codegen::jitgen) fn emit_write_barrier_bulk(&mut self, parent: GP) {
+        let skip = self.jit.label();
+        let p = parent.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            ldrb w9, [x(p), #(RVALUE_OFFSET_FLAG as u32)];
+            tbz x9, #(6), skip;        // WB_ARMED clear -> skip
+        );
+        self.a64_write_barrier_call(p);
+        self.jit.bind_label(skip);
+    }
+
+    ///
+    /// The write barrier's out-of-line half: save the caller-saved regs the
+    /// JIT may have live, pass the parent in the C-ABI arg0 (x0), and call.
+    /// `x(p)` is untouched by the saves, so it still holds the parent when
+    /// read into x0.
+    ///
+    fn a64_write_barrier_call(&mut self, p: u32) {
         let f = jit_write_barrier as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             sub sp, sp, #(144);
@@ -214,7 +241,6 @@ impl Codegen {
             ldr x0, [sp, #(0)];
             add sp, sp, #(144);
         );
-        self.jit.bind_label(skip);
     }
 
     /// Store `src` into a heap-spilled instance variable of the object in rdi

--- a/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/binary_op.rs
@@ -692,6 +692,24 @@ impl Codegen {
     }
 
     ///
+    /// Inlined `Integer#[nth]` (single-bit extraction) for a constant,
+    /// non-negative `nth`. Operand `2n+1` in rdi, result `2*bit+1` in rdi.
+    ///
+    /// Bit `nth` of `n` sits at bit `nth + 1` of the tagged `2n+1`, so an
+    /// arithmetic shift by `nth` lands it in bit 1 — exactly where the
+    /// fixnum tagging wants it. `nth >= 63` is clamped to 63, which
+    /// replicates the sign bit and gives the correct answer for the
+    /// out-of-range bits of a 63-bit fixnum.
+    ///
+    pub(crate) fn gen_bit_index_imm(&mut self, nth: u8) {
+        monoasm! { &mut self.jit,
+            sarq rdi, (nth.min(63));
+            andq rdi, 2;
+            orq  rdi, 1;
+        }
+    }
+
+    ///
     /// gen code for shift-left of integer.
     ///
     /// ### in

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -131,8 +131,173 @@ impl Codegen {
         }
     }
 
-    /// `Array#<<`: `ary_shl(recv, arg)`. recv in rdi, arg in rsi → rax.
+    /// `Array#<<` — append, with the no-grow case emitted inline.
+    ///
+    /// The receiver's class *and* its unfrozen-ness are already guarded by
+    /// the caller, so the only thing separating an append from a store is
+    /// spare capacity. `ArrayInner` is a `SmallVec<[Value; 5]>`, whose
+    /// `capacity` field doubles as the length while the buffer is still
+    /// inline (`capacity <= ARRAY_INLINE_CAPA` ⇔ not spilled), so both
+    /// residencies get a two-load / one-store fast path. Only a full
+    /// buffer — one append in `capacity` of them, amortized — falls
+    /// through to `ary_shl` to reallocate.
+    ///
+    /// ### in
+    /// - rdi: receiver: Array
+    /// - rsi: value: Value
+    ///
+    /// ### out
+    /// - rax: receiver: Array (`<<` returns self)
+    ///
     pub(crate) fn emit_array_shl(&mut self, f: u64) {
+        let heap = self.jit.label();
+        let grow = self.jit.label();
+        let stored = self.jit.label();
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            cmpq rax, (ARRAY_INLINE_CAPA);
+            jgt  heap;
+            // Inline buffer: rax is the length, ARRAY_INLINE_CAPA the capacity.
+            // The `cmpq` above already set the flags for the full-buffer test.
+            jeq  grow;
+            movq [rdi + rax * 8 + (RVALUE_OFFSET_INLINE)], rsi;
+            addq [rdi + (RVALUE_OFFSET_ARY_CAPA)], 1;
+        stored:
+        }
+        // Write barrier: rdi = the array (parent), rsi = the appended value.
+        self.emit_write_barrier_rdi(GP::Rsi);
+        monoasm! { &mut self.jit,
+            movq rax, rdi;
+        exit:
+        }
+
+        self.jit.select_page(1);
+        monoasm! { &mut self.jit,
+        heap:
+            // Spilled buffer: rax is the capacity, the length lives beside
+            // the pointer.
+            movq rcx, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            cmpq rcx, rax;
+            jge  grow;
+            movq rdx, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+            movq [rdx + rcx * 8], rsi;
+            addq [rdi + (RVALUE_OFFSET_HEAP_LEN)], 1;
+            jmp  stored;
+        grow:
+            // Buffer full: let `ary_shl` reallocate (and run its own barrier).
+            movq rax, (f);
+            call rax;
+            jmp  exit;
+        }
+        self.jit.select_page(0);
+    }
+
+    /// `Array#[]=` slice form, `recv[start, len] = val`, with the
+    /// same-length in-bounds replacement emitted inline.
+    ///
+    /// See `array_slice_assign` for why that shape is worth singling out: it
+    /// neither grows nor shrinks the receiver, so it is a straight copy of
+    /// `len` values. Everything else calls `f` (`set_array_slice`), which
+    /// reproduces the builtin.
+    ///
+    /// ### in
+    /// - rdi: receiver: Array (class- and frozen-guarded)
+    /// - rsi: start: Fixnum (tagged)
+    /// - rdx: val: Value
+    ///
+    /// ### out
+    /// - rax: non-null on success (the caller's `handle_error` checks it)
+    ///
+    pub(crate) fn emit_array_slice_assign(&mut self, f: u64, len: usize) {
+        let slow = self.jit.label();
+        let src_heap = self.jit.label();
+        let src_ready = self.jit.label();
+        let dst_heap = self.jit.label();
+        let dst_ready = self.jit.label();
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            sarq rsi, 1;                 // untag start
+            js   slow;                   // negative start: let the callee wrap it
+            // A self-assignment would copy a buffer over itself; hand it to
+            // the callee, which snapshots the source first.
+            cmpq rdi, rdx;
+            jeq  slow;
+            // `val` must be an Array...
+            testq rdx, 0b111;
+            jnz  slow;
+            cmpw [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            jne  slow;
+            // ...of exactly `len` elements. r8 <- its data.
+            movq rax, [rdx + (RVALUE_OFFSET_ARY_CAPA)];
+            cmpq rax, (ARRAY_INLINE_CAPA);
+            jgt  src_heap;
+            cmpq rax, (len);
+            jne  slow;
+            lea  r8, [rdx + (RVALUE_OFFSET_INLINE)];
+        src_ready:
+            // rax <- the receiver's length, r9 <- its data.
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            cmpq rax, (ARRAY_INLINE_CAPA);
+            jgt  dst_heap;
+            lea  r9, [rdi + (RVALUE_OFFSET_INLINE)];
+        dst_ready:
+            // The replaced run must lie inside the receiver.
+            movq rcx, rsi;
+            addq rcx, (len);
+            cmpq rcx, rax;
+            jgt  slow;
+        }
+        for i in 0..len {
+            let disp = (i * 8) as i32;
+            monoasm! { &mut self.jit,
+                movq rax, [r8 + (disp)];
+                movq [r9 + rsi * 8 + (disp)], rax;
+            }
+        }
+        // Several children stored at once: remember the receiver wholesale.
+        self.emit_write_barrier_bulk_rdi();
+        monoasm! { &mut self.jit,
+            movq rax, rdx;               // `[]=` evaluates to the assigned value
+            jmp  exit;
+        }
+
+        self.jit.select_page(1);
+        monoasm! { &mut self.jit,
+        src_heap:
+            movq rcx, [rdx + (RVALUE_OFFSET_HEAP_LEN)];
+            cmpq rcx, (len);
+            jne  slow;
+            movq r8, [rdx + (RVALUE_OFFSET_HEAP_PTR)];
+            jmp  src_ready;
+        dst_heap:
+            movq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            movq r9, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+            jmp  dst_ready;
+        slow:
+            // set_array_slice(base, start, len, val, vm, globals).
+            // rdi = base and rsi = start are already in place.
+            movq rcx, rdx;               // val  -> arg3
+            movq rdx, (len);             // len  -> arg2
+            movq r8, rbx;                // vm
+            movq r9, r12;                // globals
+            movq rax, (f);
+            call rax;
+            jmp  exit;
+        }
+        self.jit.select_page(0);
+        self.jit.bind_label(exit);
+    }
+
+    /// `Array#rotate!`: `ary_rotate_(recv, count)`. recv in rdi; the count
+    /// arrives tagged in rsi (or is the implicit `1`), and the callee takes a
+    /// plain `i64`. → rax.
+    pub(crate) fn emit_array_rotate_(&mut self, f: u64, has_arg: bool) {
+        if has_arg {
+            monoasm! { &mut self.jit, sarq rsi, 1; }
+        } else {
+            monoasm! { &mut self.jit, movq rsi, 1; }
+        }
         monoasm! { &mut self.jit,
             movq rax, (f);
             call rax;

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2012,6 +2012,9 @@ impl Codegen {
         } else {
             0
         };
+        // The fast path (when emitted) falls through to the runtime call
+        // below on `slow`, and jumps past it on success.
+        let fast = self.expand_array_fast_path(dst, len, rest_pos);
         self.fpr_save(using_fpr);
         // `src` is already in rdx (loaded by the caller). Args:
         // rdi = &mut Executor, rsi = &mut Globals, rdx = src, rcx = &dst,
@@ -2026,7 +2029,87 @@ impl Codegen {
             call rax;
         );
         self.fpr_restore(using_fpr);
+        if let Some(exit) = fast {
+            self.jit.bind_label(exit);
+        }
         true
+    }
+
+    ///
+    /// The no-`#to_ary`, no-rest fast path of `AsmInst::ExpandArray`: when
+    /// `src` (rdx) is already an `Array` holding at least `len` elements,
+    /// destructuring is just `len` moves onto the destination slots — no
+    /// `respond_to?`/`#to_ary` dispatch, no nil padding, nothing that can
+    /// raise. Everything else jumps to `slow` (the full `runtime::expand_array`
+    /// call, which re-derives its own view of `src`).
+    ///
+    /// Returns the `exit` label the caller must bind after the runtime call
+    /// (which doubles as the fall-through `slow` target), or `None` when no
+    /// fast path was emitted and the runtime call stands alone as before.
+    ///
+    /// A `rest_pos` site (`a, *b = …`) allocates the rest `Array`, so it stays
+    /// on the runtime path, as do wide destructurings whose unrolled copy
+    /// would outweigh the call it replaces.
+    ///
+    fn expand_array_fast_path(
+        &mut self,
+        dst: SlotId,
+        len: usize,
+        rest_pos: Option<usize>,
+    ) -> Option<DestLabel> {
+        const MAX_INLINE_EXPAND: usize = 8;
+        if rest_pos.is_some() || len == 0 || len > MAX_INLINE_EXPAND {
+            return None;
+        }
+        let heap = self.jit.label();
+        let copy = self.jit.label();
+        let slow = self.jit.label();
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            testq rdx, 0b111;                                   // immediate?
+            jnz  slow;
+            cmpw [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            jne  slow;
+            movq rax, [rdx + (RVALUE_OFFSET_ARY_CAPA)];
+            cmpq rax, (ARRAY_INLINE_CAPA);
+            jgt  heap;
+            // Inline buffer: rax is the length, the elements follow in place.
+            cmpq rax, (len);
+            jlt  slow;
+            lea  rcx, [rdx + (RVALUE_OFFSET_INLINE)];
+        copy:
+        }
+        // `dst` descends: slot `dst.0 + i` sits `i * 8` below `&dst`.
+        for i in 0..len {
+            let src_disp = (i * 8) as i32;
+            let dst_disp = rbp_local(dst) + (i * 8) as i32;
+            monoasm! { &mut self.jit,
+                movq rax, [rcx + (src_disp)];
+                movq [rbp - (dst_disp)], rax;
+            }
+        }
+        monoasm! { &mut self.jit,
+            // Non-null rax: `expand_array` signals errors with a null return,
+            // and the caller's `handle_error` checks it.
+            movq rax, 1;
+            jmp  exit;
+        }
+
+        self.jit.select_page(1);
+        monoasm! { &mut self.jit,
+        heap:
+            // Spilled buffer: rax is the capacity, the length lives beside
+            // the pointer.
+            movq rcx, [rdx + (RVALUE_OFFSET_HEAP_LEN)];
+            cmpq rcx, (len);
+            jlt  slow;
+            movq rcx, [rdx + (RVALUE_OFFSET_HEAP_PTR)];
+            jmp  copy;
+        }
+        self.jit.select_page(0);
+        // The runtime call the caller emits next *is* the slow path.
+        self.jit.bind_label(slow);
+        Some(exit)
     }
 
     // ---- method definition (the former per-arch arms, verbatim) ----

--- a/monoruby/src/codegen/arch/x86_64/compile/variables.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/variables.rs
@@ -222,6 +222,32 @@ impl Codegen {
         skip:
         }
     }
+
+    ///
+    /// The bulk variant of [`Self::emit_write_barrier_rdi`], for an inline
+    /// store that wrote *several* children (an array slice copy). Checking
+    /// each one is not worth it, so an armed parent is remembered regardless
+    /// of what was stored — the same safe over-approximation
+    /// `RValue::write_barrier_bulk` makes. Parent in rdi.
+    ///
+    pub(super) fn emit_write_barrier_bulk_rdi(&mut self) {
+        let skip = self.jit.label();
+        monoasm! { &mut self.jit,
+            testb [rdi + (RVALUE_OFFSET_FLAG as i32)], 0x40;
+            jz   skip;
+        }
+        self.save_registers();
+        monoasm! { &mut self.jit,
+            movq [rsp + 176], rax;          // save rax (save_registers skips it)
+            movq rax, (jit_write_barrier);
+            call rax;
+            movq rax, [rsp + 176];
+        }
+        self.restore_registers();
+        monoasm! { &mut self.jit,
+        skip:
+        }
+    }
 }
 
 impl Codegen {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1064,6 +1064,21 @@ impl SlotState {
         b
     }
 
+    ///
+    /// True when *slot* is not *proven* to hold a non-Integer — i.e. a Fixnum
+    /// guard on it may plausibly succeed.
+    ///
+    /// The stricter [`Self::is_fixnum`] is the right gate for folds that must
+    /// be free; this one is for inline paths that emit a guard anyway and only
+    /// want to avoid the pathological case of guarding a slot the abstract
+    /// state already knows is (say) a Float or a Range, where the guard would
+    /// deopt on every execution. A slot the state simply hasn't narrowed
+    /// (`Guarded::Value` — e.g. a value just read out of an ivar) passes.
+    ///
+    pub fn may_be_fixnum(&self, slot: SlotId) -> bool {
+        !matches!(self.guarded(slot).class(), Some(class) if class != INTEGER_CLASS)
+    }
+
     pub fn is_float(&self, slot: SlotId) -> bool {
         let b = self.guarded(slot) == Guarded::Float;
         match self.mode(slot) {


### PR DESCRIPTION
## What

`perf` on `optcarrot --opt` showed **~30% of the run inside Rust builtins called *from* JIT code**, not in the JIT's own output — the emulator inner loops leave compiled code once per elementary operation. Five of those calls accounted for most of it, and each collapses to a handful of instructions once the JIT's existing guards are taken into account.

| | before | what it was |
|---|---:|---|
| `Array::push` (← `ary_shl`) | 10.0% + 2.9% | `@output_pixels << … << …` ×8, 61440×/frame |
| `Array#[]=` slice form | 4.3% + resize/coerce | `@bg_pixels[@scroll_xfine, 8] = @bg_pattern_lut[…]` |
| `integer::index` | 3.9% + 2.2% (`Value::unpack`) | `data[8]`, `@_a[6]` — CPU bit tests |
| `array::rotate_` | 3.6% | `@bg_pixels.rotate!(8)` |
| `runtime::expand_array` | 3.0% | `a, b = …` |

## How

- **`Integer#[nth]`** — the receiver's `INTEGER_CLASS` guard already proves Fixnum, so a literal `nth` is `sar`/`and`/`or`. Bit `nth` of `n` sits at bit `nth+1` of the tagged `2n+1`, so the shift lands it exactly where the fixnum tag wants it.
- **`Array#<<`** — was *registered* as an inline builtin, but `emit_array_shl` only emitted `call`. `ArrayInner` is a `SmallVec<[Value; 5]>` whose `capacity` field doubles as the length while inline, so both residencies get a two-load/one-store append; only a full buffer falls through to `ary_shl` to reallocate.
- **`Array#rotate!`** — **48% of its self time was the `i % ary_len` `div`**, yet the common rotation is by less than the array's own length, where the remainder is `|cnt|`. Skip the division in range, plus an inline generator so the call drops generic dispatch and `coerce_to_int_i64`.
- **`expand_array`** — a rest-less destructuring of an already-long-enough Array cannot dispatch `#to_ary`, pad with nil, or raise. Unrolled for `len <= 8`.
- **`Array#[]=` slice form** — `array_index_assign` bailed on `pos_num != 2`, so the 3-arg form went through `set_index2`'s full resize/`copy_within` path. The shape inner loops actually write replaces a run with an equally long one *inside* the array — a plain copy. `len` comes from a literal, the rest is checked at run time, and anything else falls back to `set_array_slice`.

## Two fixes that fell out

- **JIT'd `a << v` could write to a frozen array.** `ary_shl` called `Array::push` directly and never checked frozen-ness, so once the method was JIT'd the check was simply absent:
  ```ruby
  def go(a, v) = a << v
  300.times { |i| go([], i) }   # warm the JIT
  go([1].freeze, 2)             # CRuby: FrozenError / before: silently succeeded
  ```
  The inline store bypasses `Array::push` too, so the generator now guards frozen and deopts.
- `Array#rotate!(i64::MIN)` overflowed on `-i`; wrap first, then negate.

## A gotcha worth knowing about

The slice assign first gated on `state.is_fixnum(start)` and **never fired** in optcarrot: `@scroll_xfine` is read from an ivar, which the abstract state has not narrowed to Fixnum (`Guarded::Value`). Since `load_fixnum` emits a guard anyway, the new `may_be_fixnum` refuses only a slot *proven* to hold something else. That one predicate was worth 645 → 799 fps on its own — the same blind spot may be costing other inline generators.

## Numbers

optcarrot `--opt`, 3000 frames, median of 9 interleaved runs against the merge base, checksums identical across every run:

| | fps |
|---|---:|
| `111d1895` (merge base) | 486.5 |
| this branch | **775.6 (+59%)** |

At the default 180 frames: **854–900 fps** where the merge base gets 498–528, against CRuby 135–141 and YJIT 157–158.

`set_index2`, `index_assign`, `expand_array`, `coerce_to_int_i64`, `SmallVec::resize`, `Array::push` and `integer::index` are all gone from the profile's top entries; JIT output is now ~70% of the run. `doc/optcarrot_opt_profile.md` records the full investigation and what is left (small-array `ptr_rotate`, JIT recompilation of the giant generated `run`, PIC, relaxing the method-specialization gate).

## Testing

- `cargo test --release` — 3073 pass / 0 fail
- `cargo test --features gc-stress --lib` — 2253 pass / 0 fail
- Per-optimization scripts diffed against CRuby on **both** the release and gc-stress builds, covering inline/spill boundaries, array growth, self-assignment, frozen receivers, `to_ary`/`to_int` coercion, negative and out-of-range indices, and heap children through the write barrier.

## ⚠️ aarch64 is not compile-checked

There is no cross-toolchain on the dev machine and monoasm gates its arm64 encoder on `target_arch`, so the aarch64 halves were reviewed against monoasm's instruction definitions and the existing backend but **never fed to rustc**. The macOS arm64 CI job is the first real build. `emit_array_slice_assign`'s C-ABI register shuffle is the spot most worth a careful look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)