### PR TITLE
kernel: __callee__ reports the dispatched alias, $~ crosses Ruby-level core builtins, sprintf %c honours the format encoding

### DIFF
--- a/monoruby/builtins/io.rb
+++ b/monoruby/builtins/io.rb
@@ -101,10 +101,18 @@ class IO
   # to_enum round-trip (a `chomp:` keyword would come back as a
   # positional Hash and be misparsed as a separator/limit).
   def __each_line(args, chomp)
-    # #gets implements the full (sep, limit, chomp:) semantics natively.
+    # CRuby's `each_line` reads through the internal `rb_io_getline`,
+    # which — unlike `IO#gets` — leaves `$_` alone. We drive `#gets`
+    # (it implements the full (sep, limit, chomp:) semantics natively),
+    # so put `$_` back after every read, while still letting the block
+    # assign it if it wants to.
+    saved = $_
     while (line = gets(*args, chomp: chomp))
+      $_ = saved
       yield line
+      saved = $_
     end
+    $_ = saved
     self
   end
   private :__each_line

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -1168,15 +1168,25 @@ fn print(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/printf.html]
 #[monoruby_builtin]
 fn printf(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let format_str = lfp.arg(0).coerce_to_string(vm, globals)?;
     let args = lfp.arg(1).as_array();
-
-    let buf = vm.format_by_args(globals, &format_str, &args)?;
+    // Format through the shared encoding negotiation so a binary or
+    // broken argument reaches the fd as its own bytes.
+    let fmt_inner = match lfp.arg(0).is_rstring_inner() {
+        Some(inner) => inner.clone(),
+        None => {
+            let s = lfp.arg(0).coerce_to_string(vm, globals)?;
+            RStringInner::from_encoding_scanned(s.as_bytes(), Encoding::Utf8)
+        }
+    };
+    let ctx = crate::executor::format::negotiate_format(&globals.store, &fmt_inner, &args)?;
+    let format_str = ctx.view_owned(&fmt_inner)?;
+    let out = vm.format_by_args(globals, &format_str, &args, ctx)?;
+    let buf = ctx.finish(&out).as_rstring_inner().as_bytes().to_vec();
     let mut done = 0;
     blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
         lfp.self_val()
             .as_io_inner_mut()
-            .write(buf.as_bytes(), &mut done, _store)
+            .write(&buf, &mut done, _store)
     })?;
 
     Ok(Value::nil())

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -220,10 +220,9 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     );
     globals.define_builtin_module_func(kernel_class, "__dir__", dir_, 0);
     globals.define_builtin_module_func(kernel_class, "__method__", method_, 0);
-    // `__callee__` differs from `__method__` only for aliased methods
-    // (it reports the called alias). monoruby does not track the
-    // call-site alias, so it shares `__method__`'s resolution.
-    globals.define_builtin_module_func(kernel_class, "__callee__", method_, 0);
+    // `__callee__` differs from `__method__` only for aliased methods:
+    // it reports the alias actually dispatched at the call site.
+    globals.define_builtin_module_func(kernel_class, "__callee__", callee_, 0);
     globals.define_builtin_module_func_with(kernel_class, "catch", catch_, 0, 1, false);
     globals.define_builtin_module_func_with(kernel_class, "throw", throw_, 1, 2, false);
     globals.define_builtin_func(kernel_class, "__assert", assert, 2);
@@ -1323,37 +1322,25 @@ fn format(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
     }
     let fmt_val = args[0];
-    let fmt = fmt_val.coerce_to_str(vm, globals)?;
     let arguments = &args[1..];
-    let result = vm.format_by_args(globals, &fmt, arguments)?;
-    // Negotiate the result encoding across the format String and every String
-    // argument (matching String#%): the compatible union wins (so the format's
-    // encoding is preserved, or widened to an argument's), and two
-    // ASCII-incompatible non-ASCII encodings raise Encoding::CompatibilityError.
+    // Negotiate the result encoding across the format String and every
+    // String argument (matching String#%): the compatible union wins (so
+    // the format's encoding is preserved, or widened to an argument's),
+    // and two ASCII-incompatible non-ASCII encodings raise
+    // Encoding::CompatibilityError.
     if let Some(fmt_inner) = fmt_val.is_rstring_inner() {
-        let mut result_inner = fmt_inner.clone();
-        for v in arguments {
-            if let Some(arg_inner) = v.is_rstring_inner() {
-                match result_inner.compatible_encoding(arg_inner) {
-                    Some(combined) if combined != result_inner.encoding() => {
-                        result_inner.set_encoding(combined);
-                    }
-                    Some(_) => {}
-                    None => {
-                        return Err(MonorubyErr::incompatible_encoding(
-                            &globals.store,
-                            result_inner.encoding(),
-                            arg_inner.encoding(),
-                        ));
-                    }
-                }
-            }
-        }
-        Ok(Value::string_from_inner(
-            RStringInner::from_encoding_scanned(result.as_bytes(), result_inner.encoding()),
-        ))
+        let ctx = crate::executor::format::negotiate_format(&globals.store, fmt_inner, arguments)?;
+        let fmt = ctx.view_owned(fmt_inner)?;
+        let result = vm.format_by_args(globals, &fmt, arguments, ctx)?;
+        Ok(ctx.finish(&result))
     } else {
-        Ok(Value::string(result))
+        // A non-String format (an object with `to_str`) has no encoding
+        // of its own; format its conversion as plain UTF-8.
+        let fmt = fmt_val.coerce_to_str(vm, globals)?;
+        let inner = RStringInner::from_encoding_scanned(fmt.as_bytes(), Encoding::Utf8);
+        let ctx = crate::executor::format::negotiate_format(&globals.store, &inner, arguments)?;
+        let result = vm.format_by_args(globals, &fmt, arguments, ctx)?;
+        Ok(ctx.finish(&result))
     }
 }
 
@@ -4271,16 +4258,12 @@ fn dir_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
 }
 
 ///
-/// Kernel.#__method__
+/// The innermost non-native caller frame — the Ruby frame that invoked
+/// `__method__` / `__callee__`. Builtin frames (`send` / `__send__` /
+/// `public_send`, `eval`, …) are skipped so `send("__method__")`
+/// reports the Ruby method that called `send`, not `send` itself.
 ///
-/// - __method__ -> Symbol | nil
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/__method__.html]
-#[monoruby_builtin]
-fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    // Skip native (builtin) caller frames such as `send`/`__send__`/
-    // `public_send` so that `send("__method__")` reports the Ruby method that
-    // invoked `send`, not `send` itself.
+fn calling_ruby_frame(vm: &Executor) -> Option<Cfp> {
     let mut cfp = vm.cfp().prev();
     while let Some(f) = cfp {
         if !f.lfp().meta().is_native() {
@@ -4288,25 +4271,129 @@ fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) 
         }
         cfp = f.prev();
     }
-    let Some(caller) = cfp else {
-        return Ok(Value::nil());
-    };
+    cfp
+}
+
+///
+/// Resolve the method (or `define_method` body) that lexically encloses
+/// `caller`, returning `(the frame that owns the method body, its name)`.
+/// `None` when the frame is not inside a method at all — `__method__`
+/// and `__callee__` both report `nil` there.
+///
+fn enclosing_method(store: &Store, caller: Cfp) -> Option<(Lfp, IdentId)> {
     let outer = caller.outermost_lfp();
     let fid = outer.func_id();
-    // `__method__` yields nil outside of a method body. A `define_method`
-    // body is a Proc-typed function (not `FuncType::Method`) but runs in a
-    // frame tagged `proc_method` and carries the installed method name, so
-    // accept those too.
-    if !globals.store[fid].is_method() && !outer.meta().is_proc_method() {
-        return Ok(Value::nil());
+    // A `define_method` body is a Proc-typed function (not
+    // `FuncType::Method`) but runs in a frame tagged `proc_method` and
+    // carries the installed method name, so accept those too.
+    if !store[fid].is_method() && !outer.meta().is_proc_method() {
+        return None;
     }
-    globals.store[fid]
-        .name()
-        // The main script's body carries the internal `/main` label (and,
-        // running inside TOPLEVEL_BINDING, a proc_method-tagged frame) —
-        // but the top level is not a method: report nil, as CRuby does.
-        .filter(|sym| *sym != IdentId::_MAIN)
-        .map_or(Ok(Value::nil()), |sym| Ok(Value::symbol(sym)))
+    // The main script's body carries the internal `/main` label (and,
+    // running inside TOPLEVEL_BINDING, a proc_method-tagged frame) —
+    // but the top level is not a method: report nil, as CRuby does.
+    let name = store[fid].name().filter(|sym| *sym != IdentId::_MAIN)?;
+    Some((outer, name))
+}
+
+///
+/// Kernel.#__method__
+///
+/// - __method__ -> Symbol | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/__method__.html]
+#[monoruby_builtin]
+fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let Some(caller) = calling_ruby_frame(vm) else {
+        return Ok(Value::nil());
+    };
+    match enclosing_method(&globals.store, caller) {
+        Some((_, name)) => Ok(Value::symbol(name)),
+        None => Ok(Value::nil()),
+    }
+}
+
+///
+/// The name the frame owning `method_lfp` was *called* by. Differs from
+/// the definition name only for an aliased method, which is exactly what
+/// `__callee__` must report.
+///
+/// The name is recovered from the call site rather than the frame: the
+/// caller saved its own pc into this frame's cont-frame slot, so the
+/// call site there names the alias that was dispatched. The VM saves
+/// the pc one word past the call instruction (at the inline-cache
+/// word), the JIT saves the instruction itself; both are covered by
+/// looking each candidate index up in the caller ISeq's `callsite_map`.
+///
+fn called_name(
+    store: &Store,
+    method_cfp: Cfp,
+    self_val: Value,
+    def_name: IdentId,
+) -> Option<IdentId> {
+    let caller = method_cfp.prev()?;
+    let iseq_id = store[caller.lfp().func_id()].is_iseq()?;
+    let info = &store[iseq_id];
+    let slot = method_cfp.caller_pc_slot();
+    if slot == 0 || slot as usize % std::mem::align_of::<Bytecode>() != 0 {
+        return None;
+    }
+    // A `MethodCall` occupies two words (the instruction and its
+    // inline cache), so exactly one of the two candidates can be a
+    // call-instruction index and `callsite_map` — which only holds
+    // real ones — tells them apart without decoding anything.
+    let size = std::mem::size_of::<Bytecode>();
+    let callid = [size, 0].into_iter().find_map(|back| {
+        let addr = (slot as usize).checked_sub(back)?;
+        // SAFETY: the pointer is never dereferenced — `contains_pc`
+        // only range-checks it against this ISeq's bytecode buffer so
+        // the derived index is meaningful.
+        let pc = unsafe { BytecodePtr::from_raw(addr as *mut Bytecode) }?;
+        if !info.contains_pc(pc) {
+            return None;
+        }
+        store.get_callsite_id(iseq_id, info.get_pc_index(Some(pc)))
+    })?;
+    // `super` has no name, and a dispatch that went through
+    // `method_missing` / `Method#call` / `send` / … names the
+    // trampoline rather than the frame we are standing in. Only trust
+    // the call-site name when the receiver really resolves it to an
+    // alias of this frame's method — `original_name` is the definition
+    // name every alias of it shares.
+    let name = store[callid].name?;
+    match store.check_method_for_class(self_val.class(), name) {
+        Some(entry) if entry.original_name() == def_name => Some(name),
+        _ => None,
+    }
+}
+
+///
+/// Kernel.#__callee__
+///
+/// - __callee__ -> Symbol | nil
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/__callee__.html]
+#[monoruby_builtin]
+fn callee_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let Some(caller) = calling_ruby_frame(vm) else {
+        return Ok(Value::nil());
+    };
+    let Some((outer, name)) = enclosing_method(&globals.store, caller) else {
+        return Ok(Value::nil());
+    };
+    // Walk out to the control frame that owns the method body — for a
+    // block, `caller` is the block's frame, several frames below.
+    let mut cfp = Some(caller);
+    while let Some(f) = cfp {
+        if f.lfp() == outer {
+            if let Some(called) = called_name(&globals.store, f, outer.self_val(), name) {
+                return Ok(Value::symbol(called));
+            }
+            break;
+        }
+        cfp = f.prev();
+    }
+    Ok(Value::symbol(name))
 }
 
 ///
@@ -6003,6 +6090,94 @@ mod tests {
         // in a normal method; nil outside any method.
         run_test_once(
             r##"(class MC; define_method(:dm){ [__method__, __callee__] }; def from_send; send "__method__"; end; def normal; __method__; end; end; o=MC.new; [o.dm, o.from_send, o.normal, (__method__)])"##,
+        );
+    }
+
+    #[test]
+    fn callee_reports_the_alias() {
+        // `__callee__` names the alias the call site dispatched, while
+        // `__method__` stays on the definition name — including from a
+        // block, from a `define_method` body, and through an alias of one.
+        run_test_once(
+            r##"
+            class CA
+              def f; [__method__, __callee__]; end
+              alias_method :g, :f
+              alias h f
+              def blk; (1..2).map { [__method__, __callee__] }; end
+              alias blk2 blk
+              define_method(:dm) { [__method__, __callee__] }
+              alias dm2 dm
+              def plain; helper; end
+              private def helper; [__method__, __callee__]; end
+            end
+            o = CA.new
+            [o.f, o.g, o.h, o.blk, o.blk2, o.dm, o.dm2, o.plain, [__method__, __callee__]]
+            "##,
+        );
+        // `method_missing` keeps its own name: the call site named a
+        // method that does not resolve to this frame's body.
+        run_test_once(
+            r##"
+            class CM
+              def method_missing(name, *) = [__method__, __callee__]
+              def respond_to_missing?(*) = true
+            end
+            CM.new.no_such_method
+            "##,
+        );
+    }
+
+    #[test]
+    fn regexp_match_crosses_ruby_level_builtins() {
+        // A `$~` set by a native method under a core builtin that
+        // monoruby happens to implement in Ruby (`Enumerable#map`,
+        // `#each_with_index`, …) must still be visible to the user
+        // block — CRuby implements those in C, and a C frame owns no
+        // `$~` scope.
+        run_test(
+            r##"
+            a = "wawa".to_enum(:scan, /./).map { $& }
+            b = []
+            "wawa".to_enum(:scan, /./).each { b << $& }
+            c = ["abc", "xyz"].grep(/b/)
+            d = $&
+            [a, b, c, d]
+            "##,
+        );
+    }
+
+    #[test]
+    fn sprintf_char_uses_the_format_encoding() {
+        // `%c` is CRuby's `rb_enc_uint_chr`: a Unicode scalar for a
+        // Unicode format string, the raw byte image of the character
+        // for every other encoding (9415601 == 0x8FABB1 is EUC-JP `é`).
+        run_test_once(
+            r##"
+            euc = "%c".dup.force_encoding("euc-jp")
+            r1 = sprintf(euc, 9415601)
+            r2 = euc % 9415601
+            r3 = sprintf("%c", 1286)
+            r4 = sprintf("%c", "ش")
+            e = begin; sprintf("%c".encode("ASCII"), 1286); rescue => ex; [ex.class, ex.message]; end
+            [r1.encoding.name, r1.bytes, r2.encoding.name, r2.bytes, r3.bytes, r4.bytes, e]
+            "##,
+        );
+    }
+
+    #[test]
+    fn sprintf_keeps_invalid_bytes() {
+        // CRuby does not substitute U+FFFD: the argument's bytes reach
+        // the result verbatim, which simply reports
+        // `valid_encoding? == false`.
+        run_test_once(
+            r##"
+            a = sprintf("good day %{invalid}", invalid: "\x80")
+            b = sprintf("good day %s", "\x80")
+            c = "good day %s" % "\x80"
+            [a.bytes, a.encoding.name, a.valid_encoding?,
+             b.bytes, b.valid_encoding?, c.bytes, c.valid_encoding?]
+            "##,
         );
     }
 

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -4320,10 +4320,13 @@ fn method_(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) 
 ///
 /// The name is recovered from the call site rather than the frame: the
 /// caller saved its own pc into this frame's cont-frame slot, so the
-/// call site there names the alias that was dispatched. The VM saves
-/// the pc one word past the call instruction (at the inline-cache
-/// word), the JIT saves the instruction itself; both are covered by
-/// looking each candidate index up in the caller ISeq's `callsite_map`.
+/// call site there names the alias that was dispatched.
+///
+/// A by-name dispatcher (`send` / `Method#call`) is deliberately *not*
+/// followed: it names its target at run time, and under the JIT — which
+/// inlines `send` without a cont-frame pc — that name is not reachable
+/// from here at all. Reporting it only in the interpreter would make
+/// `__callee__` depend on whether the caller happens to be compiled.
 ///
 fn called_name(
     store: &Store,
@@ -4333,17 +4336,35 @@ fn called_name(
 ) -> Option<IdentId> {
     let caller = method_cfp.prev()?;
     let iseq_id = store[caller.lfp().func_id()].is_iseq()?;
+    let name = store[call_site_id(store, iseq_id, method_cfp)?].name?;
+    // `super` has no name, and a dispatch that went through
+    // `method_missing` / `send` / `Method#call` / … names the
+    // trampoline rather than the frame we are standing in. Only trust
+    // the call-site name when the receiver really resolves it to an
+    // alias of this frame's method — `original_name` is the definition
+    // name every alias of it shares.
+    match store.check_method_for_class(self_val.class(), name) {
+        Some(entry) if entry.original_name() == def_name => Some(name),
+        _ => None,
+    }
+}
+
+///
+/// The call site in `iseq_id` that entered `method_cfp`. The VM saves
+/// the pc one word past the call instruction (at the inline-cache
+/// word), the JIT saves the instruction itself; a `MethodCall` occupies
+/// both words, so exactly one of the two candidates can be a
+/// call-instruction index and the ISeq's `callsite_map` — which only
+/// holds real ones — tells them apart without decoding anything.
+///
+fn call_site_id(store: &Store, iseq_id: ISeqId, method_cfp: Cfp) -> Option<CallSiteId> {
     let info = &store[iseq_id];
     let slot = method_cfp.caller_pc_slot();
     if slot == 0 || slot as usize % std::mem::align_of::<Bytecode>() != 0 {
         return None;
     }
-    // A `MethodCall` occupies two words (the instruction and its
-    // inline cache), so exactly one of the two candidates can be a
-    // call-instruction index and `callsite_map` — which only holds
-    // real ones — tells them apart without decoding anything.
     let size = std::mem::size_of::<Bytecode>();
-    let callid = [size, 0].into_iter().find_map(|back| {
+    [size, 0].into_iter().find_map(|back| {
         let addr = (slot as usize).checked_sub(back)?;
         // SAFETY: the pointer is never dereferenced — `contains_pc`
         // only range-checks it against this ISeq's bytecode buffer so
@@ -4353,18 +4374,7 @@ fn called_name(
             return None;
         }
         store.get_callsite_id(iseq_id, info.get_pc_index(Some(pc)))
-    })?;
-    // `super` has no name, and a dispatch that went through
-    // `method_missing` / `Method#call` / `send` / … names the
-    // trampoline rather than the frame we are standing in. Only trust
-    // the call-site name when the receiver really resolves it to an
-    // alias of this frame's method — `original_name` is the definition
-    // name every alias of it shares.
-    let name = store[callid].name?;
-    match store.check_method_for_class(self_val.class(), name) {
-        Some(entry) if entry.original_name() == def_name => Some(name),
-        _ => None,
-    }
+    })
 }
 
 ///
@@ -6111,8 +6121,16 @@ mod tests {
               def plain; helper; end
               private def helper; [__method__, __callee__]; end
             end
+            # Dispatched from a native frame (`send`) or from `super`,
+            # the call site names something other than this frame's
+            # method, so the definition name stands.
+            class CB < CA
+              def f; super; end
+              alias sup f
+            end
             o = CA.new
-            [o.f, o.g, o.h, o.blk, o.blk2, o.dm, o.dm2, o.plain, [__method__, __callee__]]
+            [o.f, o.g, o.h, o.blk, o.blk2, o.dm, o.dm2, o.plain,
+             CB.new.sup, [__method__, __callee__]]
             "##,
         );
         // `method_missing` keeps its own name: the call site named a
@@ -6177,6 +6195,83 @@ mod tests {
             c = "good day %s" % "\x80"
             [a.bytes, a.encoding.name, a.valid_encoding?,
              b.bytes, b.valid_encoding?, c.bytes, c.valid_encoding?]
+            "##,
+        );
+    }
+
+    #[test]
+    fn sprintf_char_across_encodings() {
+        // Every non-Unicode `%c` reads its Integer as the character's
+        // own byte image; the two error kinds follow CRuby (a
+        // single-byte encoding's code space overflows with RangeError,
+        // an ill-formed byte image is an `ArgumentError`).
+        run_test_once(
+            r##"
+            def c(enc, v)
+              begin
+                ("%c".dup.force_encoding(enc) % v).bytes
+              rescue => e
+                [e.class, e.message]
+              end
+            end
+            [
+              # single-byte encodings: the character *is* the byte
+              c("ASCII-8BIT", 0xFF), c("ISO-8859-1", 0xE9), c("Windows-1252", 0x80),
+              c("US-ASCII", 0x41), c("US-ASCII", 0x80),
+              c("ASCII-8BIT", 0x100), c("ISO-8859-1", 0x100), c("US-ASCII", 1286),
+              # Shift_JIS: bare byte, half-width kana, two-byte char
+              c("Shift_JIS", 0x41), c("Shift_JIS", 0xB1), c("Shift_JIS", 0x82A0),
+              c("Shift_JIS", 0xE0), c("Shift_JIS", 0x1234), c("Shift_JIS", 0x10000),
+              # EUC-JP: ASCII, SS2 kana, JIS X 0208, SS3 (JIS X 0212)
+              c("EUC-JP", 0x41), c("EUC-JP", 0x8EB1), c("EUC-JP", 0xA4A2),
+              c("EUC-JP", 0x8FA1A1), c("EUC-JP", 0x80), c("EUC-JP", 0x12345678),
+              # negative is never a character, in any encoding
+              c("UTF-8", -1), c("ASCII-8BIT", -1), c("UTF-8", 0x110000),
+              # a String argument gives its whole leading character
+              ("%c".dup.force_encoding("Shift_JIS") % "\x82\xA0".dup.force_encoding("Shift_JIS")).bytes,
+              ("%c".dup.force_encoding("EUC-JP") % "\xA4\xA2".dup.force_encoding("EUC-JP")).bytes,
+              # non-Integer, non-String goes through #to_int
+              sprintf("%c", 65.9), sprintf("%c", ""),
+            ]
+            "##,
+        );
+    }
+
+    #[test]
+    fn sprintf_rejects_ascii_incompatible_format() {
+        // The directives themselves cannot be spelled in an
+        // ASCII-incompatible encoding, so CRuby rejects the format
+        // String before reading any specifier.
+        run_test_once(
+            r##"
+            ["UTF-16BE", "UTF-16LE", "UTF-32BE", "ISO-2022-JP", "UTF-7"].map do |enc|
+              begin
+                "%s".dup.force_encoding(enc) % "x"
+              rescue => e
+                e.class.to_s
+              end
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn format_and_printf_accept_a_to_str_format() {
+        // A format object that is not a String is converted with
+        // #to_str and formatted as plain UTF-8 — for `Kernel#format`
+        // and for `IO#printf`, which writes the negotiated bytes.
+        run_test_once(
+            r##"
+            class Fmt
+              def to_str = "to_str: %i/%c"
+            end
+            path = "/tmp/monoruby_printf_to_str_#{Process.pid}"
+            begin
+              File.open(path, "w") { |f| f.printf(Fmt.new, 42, 0x41) }
+              [format(Fmt.new, 42, 0x41), File.binread(path)]
+            ensure
+              File.unlink(path) if File.exist?(path)
+            end
             "##,
         );
     }

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -847,40 +847,15 @@ fn rem(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     } else {
         vec![arg]
     };
-    // Negotiate the result encoding before formatting: start from
-    // the format string's encoding and fold each String/Symbol
-    // argument's encoding via `compatible_encoding`. Incompatible
-    // pairs raise `Encoding::CompatibilityError` (CRuby semantics).
-    let mut result_inner = self_.as_rstring_inner().clone();
-    for v in &arguments {
-        if let Some(arg_inner) = v.is_rstring_inner() {
-            if let Some(combined) = result_inner.compatible_encoding(&arg_inner) {
-                if combined != result_inner.encoding() {
-                    result_inner.set_encoding(combined);
-                }
-            } else {
-                return Err(MonorubyErr::incompatible_encoding(
-                    &globals.store,
-                    result_inner.encoding(),
-                    arg_inner.encoding(),
-                ));
-            }
-        }
-    }
-    let result_enc = result_inner.encoding();
-    // The formatter runs in `&str` space; a byte-oriented format
-    // string goes through the byte↔U+00XX surrogate view, and `%s`
-    // arguments do the same inside `format_by_args`, so the output
-    // is decoded back to raw bytes when the negotiated result
-    // encoding is byte-oriented.
-    let fmt_view = self_.as_rstring_inner().regex_view()?.into_owned();
-    let format_str = vm.format_by_args(globals, &fmt_view, &arguments)?;
-    let out = if result_enc.is_byte_oriented() && !format_str.is_ascii() {
-        RStringInner::from_mapped_utf8(&format_str, result_enc)
-    } else {
-        RStringInner::from_encoding_scanned(format_str.as_bytes(), result_enc)
-    };
-    Ok(Value::string_from_inner(out))
+    // The formatter runs in `&str` space; `FormatCtx` carries the
+    // negotiated result encoding and, when raw bytes must survive the
+    // round trip, puts the whole run into the byte↔U+00XX surrogate
+    // view that `FormatCtx::finish` decodes again.
+    let fmt_inner = self_.as_rstring_inner();
+    let ctx = crate::executor::format::negotiate_format(&globals.store, fmt_inner, &arguments)?;
+    let fmt_view = ctx.view_owned(fmt_inner)?;
+    let format_str = vm.format_by_args(globals, &fmt_view, &arguments, ctx)?;
+    Ok(ctx.finish(&format_str))
 }
 
 ///

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3625,9 +3625,19 @@ impl Executor {
     /// that frame's lexical `outer` chain to the method frame (so a
     /// match performed inside a block updates the enclosing method's
     /// `$~`). Returns `None` outside Ruby execution (no CFP set).
+    ///
+    /// Core builtins monoruby writes in Ruby (`builtins/*.rb`) are
+    /// skipped for the same reason: CRuby implements those same
+    /// methods in C, so `"wawa".to_enum(:scan, /./).map { $& }` must
+    /// see the match `scan` performed even though monoruby's
+    /// `Enumerable#map` is a Ruby frame standing between the two.
     fn current_mfp(&self) -> Option<Lfp> {
         let mut cfp = self.cfp?;
-        while cfp.lfp().meta().is_native() {
+        while {
+            let lfp = cfp.lfp();
+            let meta = lfp.meta();
+            meta.is_native() || meta.is_svar_transparent()
+        } {
             cfp = cfp.prev()?;
         }
         Some(cfp.lfp().mfp())

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::value::IntegerBase;
-use crate::value::rvalue::{Encoding, RStringInner, map_bytes_to_utf8};
+use crate::value::rvalue::{
+    Encoding, RStringInner, eucjp_char_width, map_bytes_to_utf8, sjis_char_width,
+};
 use num::Signed;
 
 ///
@@ -64,6 +66,14 @@ pub(crate) fn negotiate_format(
     fmt: &RStringInner,
     arguments: &[Value],
 ) -> Result<FormatCtx> {
+    // A format String that cannot hold ASCII cannot hold the directives
+    // either; CRuby rejects it before reading a single specifier.
+    if !fmt.encoding().is_ascii_compatible() {
+        return Err(MonorubyErr::encoding_compatibility_error_with_store(
+            store,
+            format!("ASCII incompatible encoding: {}", fmt.encoding().name()),
+        ));
+    }
     let mut result_inner = fmt.clone();
     let mut broken = !fmt.is_valid_encoding();
     for v in arguments {
@@ -105,10 +115,12 @@ pub(crate) fn negotiate_format(
     let enc = result_inner.encoding();
     Ok(FormatCtx {
         enc,
-        // `!is_ascii_compatible` catches the UTF-16 / UTF-32 family,
-        // whose bytes are no more `&str`-shaped than a byte-oriented
-        // encoding's.
-        byte_space: enc.is_byte_oriented() || !enc.is_ascii_compatible() || broken,
+        // US-ASCII joins the byte-oriented encodings because `%c` can
+        // put a high byte into a US-ASCII result (onigmo's `%c` code
+        // space for it is the full byte range). Everything else that
+        // stays US-ASCII is 7-bit, for which the surrogate view is the
+        // identity, so this costs nothing.
+        byte_space: enc.is_byte_oriented() || enc == Encoding::UsAscii || broken,
     })
 }
 
@@ -117,94 +129,87 @@ pub(crate) fn negotiate_format(
 /// denotes in `enc`. Unicode encodings read `code` as a Unicode scalar;
 /// every other encoding reads it as the big-endian byte image of the
 /// character itself, so `9415601` (`0x8FABB1`) is the EUC-JP three-byte
-/// sequence for `é`. `None` when `enc` cannot represent it — the caller
-/// raises `RangeError`.
+/// sequence for `é`.
 ///
-fn encode_codepoint(code: u32, enc: Encoding) -> Option<Vec<u8>> {
+/// The two error kinds follow CRuby: a value that simply overflows a
+/// single-byte encoding's code space is a `RangeError`, everything else
+/// that is not a character in `enc` — a negative value, a Unicode scalar
+/// past `U+10FFFF`, an ill-formed EUC-JP / Shift_JIS byte image — is an
+/// `ArgumentError: invalid character`.
+///
+fn encode_codepoint(code: i64, enc: Encoding) -> Result<Vec<u8>> {
     fn be_bytes(code: u32) -> Vec<u8> {
         if code <= 0xFF {
             vec![code as u8]
         } else if code <= 0xFFFF {
             vec![(code >> 8) as u8, code as u8]
-        } else if code <= 0xFF_FFFF {
-            vec![(code >> 16) as u8, (code >> 8) as u8, code as u8]
         } else {
-            vec![
-                (code >> 24) as u8,
-                (code >> 16) as u8,
-                (code >> 8) as u8,
-                code as u8,
-            ]
+            vec![(code >> 16) as u8, (code >> 8) as u8, code as u8]
         }
     }
-    /// A single EUC-JP character: ASCII, half-width katakana (`8E xx`),
-    /// JIS X 0208 (two bytes in `A1..FE`) or JIS X 0212 (`8F` + two).
+    /// Onigmo's EUC-JP `code_to_mbclen` plus its trailing-byte check:
+    /// ASCII stands alone, and every byte of a multibyte image (SS2
+    /// `8E xx`, JIS X 0208 `hi lo`, SS3 `8F hi lo`) must have its high
+    /// bit set. Wider than the *decoder*'s notion of a valid character
+    /// — `8E FF` has no JIS X 0201 meaning but `%c` still emits it.
     fn valid_euc_jp(b: &[u8]) -> bool {
         match b {
             [c] => *c <= 0x7F,
-            [0x8E, c] => (0xA1..=0xDF).contains(c),
-            [hi, lo] => (0xA1..=0xFE).contains(hi) && (0xA1..=0xFE).contains(lo),
-            [0x8F, hi, lo] => (0xA1..=0xFE).contains(hi) && (0xA1..=0xFE).contains(lo),
-            _ => false,
+            [rest @ ..] => rest.iter().all(|c| *c >= 0x80),
         }
     }
+    /// Onigmo's Shift_JIS `code_to_mbclen`: a lone byte must not be a
+    /// double-byte lead, and a two-byte image is judged by its trail
+    /// byte alone (the lead goes unchecked, so `01 40` is accepted).
     fn valid_sjis(b: &[u8]) -> bool {
         match b {
-            [c] => *c <= 0x7F || (0xA1..=0xDF).contains(c),
-            [hi, lo] => {
-                ((0x81..=0x9F).contains(hi) || (0xE0..=0xFC).contains(hi))
-                    && ((0x40..=0x7E).contains(lo) || (0x80..=0xFC).contains(lo))
-            }
+            [c] => !matches!(c, 0x81..=0x9F | 0xE0..=0xFC),
+            [_, lo] => matches!(lo, 0x40..=0x7E | 0x80..=0xFC),
             _ => false,
         }
     }
+    let invalid = || MonorubyErr::argumenterr("invalid character");
+    let Ok(code) = u32::try_from(code) else {
+        return Err(invalid());
+    };
     match enc {
+        // CRuby also emits the CESU-style three-byte form for a lone
+        // surrogate (`%c` % 0xD800), producing a broken String; we
+        // reject those instead.
         Encoding::Utf8 => {
-            let c = char::from_u32(code)?;
+            let c = char::from_u32(code).ok_or_else(invalid)?;
             let mut buf = [0u8; 4];
-            Some(c.encode_utf8(&mut buf).as_bytes().to_vec())
+            Ok(c.encode_utf8(&mut buf).as_bytes().to_vec())
         }
-        Encoding::Utf16Le | Encoding::Utf16Be => {
-            let c = char::from_u32(code)?;
-            let mut buf = [0u16; 2];
-            let units = c.encode_utf16(&mut buf);
-            Some(
-                units
-                    .iter()
-                    .flat_map(|u| {
-                        if enc == Encoding::Utf16Le {
-                            u.to_le_bytes()
-                        } else {
-                            u.to_be_bytes()
-                        }
-                    })
-                    .collect(),
-            )
-        }
-        Encoding::Utf32Le | Encoding::Utf32Be => {
-            let c = char::from_u32(code)?;
-            let u = c as u32;
-            Some(if enc == Encoding::Utf32Le {
-                u.to_le_bytes().to_vec()
-            } else {
-                u.to_be_bytes().to_vec()
-            })
-        }
-        Encoding::UsAscii => (code <= 0x7F).then(|| vec![code as u8]),
         Encoding::EucJp => {
             let bytes = be_bytes(code);
-            valid_euc_jp(&bytes).then_some(bytes)
+            if code > 0xFF_FFFF || !valid_euc_jp(&bytes) {
+                return Err(invalid());
+            }
+            Ok(bytes)
         }
         Encoding::Sjis(_) => {
             let bytes = be_bytes(code);
-            valid_sjis(&bytes).then_some(bytes)
+            if code > 0xFFFF || !valid_sjis(&bytes) {
+                return Err(invalid());
+            }
+            Ok(bytes)
         }
-        // Single-byte / uncodec'd encodings: the character *is* the byte.
+        // Single-byte encodings — including US-ASCII, whose `%c` code
+        // space onigmo takes as the full byte range: the character *is*
+        // the byte, and anything wider overflows it.
         Encoding::Ascii8
+        | Encoding::UsAscii
         | Encoding::Iso8859(_)
-        | Encoding::Iso2022Jp
-        | Encoding::Other(_)
-        | Encoding::NamedByte(_) => (code <= 0xFF).then(|| vec![code as u8]),
+        | Encoding::NamedByte(_) => {
+            if code > 0xFF {
+                return Err(MonorubyErr::rangeerr(format!("{code} out of char range")));
+            }
+            Ok(vec![code as u8])
+        }
+        // ASCII-incompatible encodings never reach here: `sprintf` on
+        // such a format String raises before any specifier is read.
+        _ => Err(invalid()),
     }
 }
 
@@ -220,10 +225,7 @@ fn format_char(
     ctx: FormatCtx,
 ) -> Result<String> {
     if let RV::Fixnum(i) = val.unpack() {
-        let bytes = u32::try_from(i)
-            .ok()
-            .and_then(|code| encode_codepoint(code, ctx.enc))
-            .ok_or_else(|| MonorubyErr::rangeerr(format!("{i} out of char range")))?;
+        let bytes = encode_codepoint(i, ctx.enc)?;
         return Ok(if ctx.byte_space {
             map_bytes_to_utf8(&bytes)
         } else {
@@ -233,10 +235,19 @@ fn format_char(
         });
     }
     if let Some(inner) = val.is_rstring_inner() {
-        // Take the first character of the argument's own view, so a
-        // byte-oriented or broken String contributes its leading byte
+        // Take the argument's leading character *in its own encoding*,
+        // so a byte-oriented or broken String contributes whole bytes
         // instead of raising on the UTF-8 check.
         let view = ctx.view(&inner)?;
+        if ctx.byte_space {
+            let width = match inner.encoding() {
+                Encoding::EucJp => eucjp_char_width(inner.as_bytes()),
+                Encoding::Sjis(_) => sjis_char_width(inner.as_bytes()),
+                _ => None,
+            }
+            .unwrap_or(1);
+            return Ok(view.chars().take(width).collect());
+        }
         return Ok(match view.chars().next() {
             Some(c) => c.to_string(),
             None => String::new(),

--- a/monoruby/src/executor/format.rs
+++ b/monoruby/src/executor/format.rs
@@ -1,6 +1,252 @@
 use super::*;
 use crate::value::IntegerBase;
+use crate::value::rvalue::{Encoding, RStringInner, map_bytes_to_utf8};
 use num::Signed;
+
+///
+/// How a `sprintf` run treats text: the encoding the result String is
+/// tagged with, and whether the run happens in the byte↔U+00XX
+/// surrogate space (see [`RStringInner::regex_view`]).
+///
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FormatCtx {
+    /// Negotiated encoding of the result String.
+    enc: Encoding,
+    /// Every String taking part is viewed as one `char` per byte
+    /// ([`map_bytes_to_utf8`]) and the finished text is decoded back
+    /// with [`RStringInner::from_mapped_utf8`]. Needed whenever raw
+    /// bytes must survive the `&str`-space formatter: a byte-oriented
+    /// result encoding, or a participant whose bytes are not valid
+    /// UTF-8 (CRuby formats `"%s" % "\x80"` into a result that simply
+    /// reports `valid_encoding? == false`, it does not substitute
+    /// U+FFFD).
+    byte_space: bool,
+}
+
+impl FormatCtx {
+    /// A `&str`-space view of `s` for this run.
+    fn view<'a>(&self, s: &'a RStringInner) -> Result<std::borrow::Cow<'a, str>> {
+        if self.byte_space {
+            Ok(std::borrow::Cow::Owned(map_bytes_to_utf8(s.as_bytes())))
+        } else {
+            s.regex_view()
+        }
+    }
+
+    /// [`Self::view`] as an owned `String` (the format string itself,
+    /// which the formatter iterates by `char`).
+    pub(crate) fn view_owned(&self, s: &RStringInner) -> Result<String> {
+        self.view(s).map(|v| v.into_owned())
+    }
+
+    /// Turn finished format text back into a String value, undoing the
+    /// surrogate view when the run used one.
+    pub(crate) fn finish(&self, s: &str) -> Value {
+        let inner = if self.byte_space && !s.is_ascii() {
+            RStringInner::from_mapped_utf8(s, self.enc)
+        } else {
+            RStringInner::from_encoding_scanned(s.as_bytes(), self.enc)
+        };
+        Value::string_from_inner(inner)
+    }
+}
+
+///
+/// Negotiate the result encoding for `fmt % arguments`: start from the
+/// format String's encoding and fold in each String argument's via
+/// `compatible_encoding`, raising `Encoding::CompatibilityError` on an
+/// incompatible pair (CRuby semantics). Also decides whether the run
+/// needs byte space, for which the values of a trailing named-reference
+/// Hash count too — they reach the output just like positional ones.
+///
+pub(crate) fn negotiate_format(
+    store: &Store,
+    fmt: &RStringInner,
+    arguments: &[Value],
+) -> Result<FormatCtx> {
+    let mut result_inner = fmt.clone();
+    let mut broken = !fmt.is_valid_encoding();
+    for v in arguments {
+        let Some(inner) = v.is_rstring_inner() else {
+            continue;
+        };
+        if !inner.is_valid_encoding() {
+            broken = true;
+        }
+        match result_inner.compatible_encoding(&inner) {
+            Some(combined) => {
+                if combined != result_inner.encoding() {
+                    result_inner.set_encoding(combined);
+                }
+            }
+            None => {
+                return Err(MonorubyErr::incompatible_encoding(
+                    store,
+                    result_inner.encoding(),
+                    inner.encoding(),
+                ));
+            }
+        }
+    }
+    // `%{name}` / `%<name>spec` read their values from a trailing Hash.
+    // They only inform the byte-space decision here: folding them into
+    // the encoding negotiation as well would be closer to CRuby, but
+    // would also start raising `CompatibilityError` for pairs monoruby
+    // has always accepted.
+    if let Some(hash) = arguments.last().and_then(|v| v.try_hash_ty()) {
+        for (_, v) in hash.iter() {
+            if let Some(inner) = v.is_rstring_inner()
+                && !inner.is_valid_encoding()
+            {
+                broken = true;
+            }
+        }
+    }
+    let enc = result_inner.encoding();
+    Ok(FormatCtx {
+        enc,
+        // `!is_ascii_compatible` catches the UTF-16 / UTF-32 family,
+        // whose bytes are no more `&str`-shaped than a byte-oriented
+        // encoding's.
+        byte_space: enc.is_byte_oriented() || !enc.is_ascii_compatible() || broken,
+    })
+}
+
+///
+/// CRuby's `rb_enc_uint_chr`: the raw bytes of the character `code`
+/// denotes in `enc`. Unicode encodings read `code` as a Unicode scalar;
+/// every other encoding reads it as the big-endian byte image of the
+/// character itself, so `9415601` (`0x8FABB1`) is the EUC-JP three-byte
+/// sequence for `é`. `None` when `enc` cannot represent it — the caller
+/// raises `RangeError`.
+///
+fn encode_codepoint(code: u32, enc: Encoding) -> Option<Vec<u8>> {
+    fn be_bytes(code: u32) -> Vec<u8> {
+        if code <= 0xFF {
+            vec![code as u8]
+        } else if code <= 0xFFFF {
+            vec![(code >> 8) as u8, code as u8]
+        } else if code <= 0xFF_FFFF {
+            vec![(code >> 16) as u8, (code >> 8) as u8, code as u8]
+        } else {
+            vec![
+                (code >> 24) as u8,
+                (code >> 16) as u8,
+                (code >> 8) as u8,
+                code as u8,
+            ]
+        }
+    }
+    /// A single EUC-JP character: ASCII, half-width katakana (`8E xx`),
+    /// JIS X 0208 (two bytes in `A1..FE`) or JIS X 0212 (`8F` + two).
+    fn valid_euc_jp(b: &[u8]) -> bool {
+        match b {
+            [c] => *c <= 0x7F,
+            [0x8E, c] => (0xA1..=0xDF).contains(c),
+            [hi, lo] => (0xA1..=0xFE).contains(hi) && (0xA1..=0xFE).contains(lo),
+            [0x8F, hi, lo] => (0xA1..=0xFE).contains(hi) && (0xA1..=0xFE).contains(lo),
+            _ => false,
+        }
+    }
+    fn valid_sjis(b: &[u8]) -> bool {
+        match b {
+            [c] => *c <= 0x7F || (0xA1..=0xDF).contains(c),
+            [hi, lo] => {
+                ((0x81..=0x9F).contains(hi) || (0xE0..=0xFC).contains(hi))
+                    && ((0x40..=0x7E).contains(lo) || (0x80..=0xFC).contains(lo))
+            }
+            _ => false,
+        }
+    }
+    match enc {
+        Encoding::Utf8 => {
+            let c = char::from_u32(code)?;
+            let mut buf = [0u8; 4];
+            Some(c.encode_utf8(&mut buf).as_bytes().to_vec())
+        }
+        Encoding::Utf16Le | Encoding::Utf16Be => {
+            let c = char::from_u32(code)?;
+            let mut buf = [0u16; 2];
+            let units = c.encode_utf16(&mut buf);
+            Some(
+                units
+                    .iter()
+                    .flat_map(|u| {
+                        if enc == Encoding::Utf16Le {
+                            u.to_le_bytes()
+                        } else {
+                            u.to_be_bytes()
+                        }
+                    })
+                    .collect(),
+            )
+        }
+        Encoding::Utf32Le | Encoding::Utf32Be => {
+            let c = char::from_u32(code)?;
+            let u = c as u32;
+            Some(if enc == Encoding::Utf32Le {
+                u.to_le_bytes().to_vec()
+            } else {
+                u.to_be_bytes().to_vec()
+            })
+        }
+        Encoding::UsAscii => (code <= 0x7F).then(|| vec![code as u8]),
+        Encoding::EucJp => {
+            let bytes = be_bytes(code);
+            valid_euc_jp(&bytes).then_some(bytes)
+        }
+        Encoding::Sjis(_) => {
+            let bytes = be_bytes(code);
+            valid_sjis(&bytes).then_some(bytes)
+        }
+        // Single-byte / uncodec'd encodings: the character *is* the byte.
+        Encoding::Ascii8
+        | Encoding::Iso8859(_)
+        | Encoding::Iso2022Jp
+        | Encoding::Other(_)
+        | Encoding::NamedByte(_) => (code <= 0xFF).then(|| vec![code as u8]),
+    }
+}
+
+///
+/// `%c`: one character in the result encoding. An Integer goes through
+/// [`encode_codepoint`]; anything else contributes its first character
+/// (a String directly, other objects via `to_int` / `to_str`).
+///
+fn format_char(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    val: Value,
+    ctx: FormatCtx,
+) -> Result<String> {
+    if let RV::Fixnum(i) = val.unpack() {
+        let bytes = u32::try_from(i)
+            .ok()
+            .and_then(|code| encode_codepoint(code, ctx.enc))
+            .ok_or_else(|| MonorubyErr::rangeerr(format!("{i} out of char range")))?;
+        return Ok(if ctx.byte_space {
+            map_bytes_to_utf8(&bytes)
+        } else {
+            // Outside byte space `enc` is UTF-8 or US-ASCII, so the
+            // bytes `encode_codepoint` produced are valid UTF-8.
+            String::from_utf8_lossy(&bytes).into_owned()
+        });
+    }
+    if let Some(inner) = val.is_rstring_inner() {
+        // Take the first character of the argument's own view, so a
+        // byte-oriented or broken String contributes its leading byte
+        // instead of raising on the UTF-8 check.
+        let view = ctx.view(&inner)?;
+        return Ok(match view.chars().next() {
+            Some(c) => c.to_string(),
+            None => String::new(),
+        });
+    }
+    Ok(match val.coerce_to_char(vm, globals)? {
+        Some(c) => c.to_string(),
+        None => String::new(),
+    })
+}
 
 /// Apply integer precision: pad digits with leading zeros to at
 /// least `prec` digits. Special-case: precision 0 with value 0
@@ -548,6 +794,7 @@ impl Executor {
         globals: &mut Globals,
         self_str: &str,
         arguments: &[Value],
+        ctx: FormatCtx,
     ) -> Result<String> {
         let mut arg_no = 0;
         // Track whether the format string has used a numbered (`N$`)
@@ -975,7 +1222,18 @@ impl Executor {
                 let key_val = Value::symbol_from_str(&key);
                 let val =
                     hash_lookup_or_keyerror(self, globals, &hash, key_val, key.as_str(), '{')?;
-                let mut s = val.coerce_to_s(self, globals)?;
+                // A String value goes through the run's view so its raw
+                // bytes survive (`%{k}` with a binary or broken value),
+                // exactly like `%s` below.
+                let mut s = match val.is_rstring_inner() {
+                    Some(inner) => match ctx.view(&inner) {
+                        Ok(v) => v.into_owned(),
+                        // Broken bytes outside byte space: keep the old
+                        // lossy render rather than raising.
+                        Err(_) => val.coerce_to_s(self, globals)?,
+                    },
+                    None => val.coerce_to_s(self, globals)?,
+                };
                 if let Some(prec) = precision {
                     if s.chars().count() > prec {
                         s = s.chars().take(prec).collect();
@@ -1047,10 +1305,7 @@ impl Executor {
             // Specifier
             let format = match ch {
                 'c' => {
-                    let s = match val.coerce_to_char(self, globals)? {
-                        Some(c) => format!("{}", c),
-                        None => String::new(),
-                    };
+                    let s = format_char(self, globals, val, ctx)?;
                     apply_width(&s, width, minus_flag, ' ')
                 }
                 's' => {
@@ -1060,14 +1315,13 @@ impl Executor {
                     // CRuby raises `NoMethodError`. Don't fall back
                     // to the C-level inspect.
                     //
-                    // String arguments go through `regex_view` so a
-                    // byte-oriented 8-bit string contributes its
-                    // bytes as U+00XX surrogates (decoded again by
-                    // `String#%` when the result encoding is
-                    // byte-oriented) instead of being lossily
+                    // String arguments go through the run's view so a
+                    // byte-oriented or broken 8-bit string contributes
+                    // its bytes as U+00XX surrogates (decoded again by
+                    // `FormatCtx::finish`) instead of being lossily
                     // re-rendered with U+FFFD.
                     let mut s = if let Some(inner) = val.is_rstring_inner() {
-                        match inner.regex_view() {
+                        match ctx.view(&inner) {
                             Ok(v) => v.into_owned(),
                             // Broken UTF-8: keep the old lossy render
                             // instead of raising.
@@ -1077,7 +1331,7 @@ impl Executor {
                         let result =
                             self.invoke_func_inner(globals, func_id, val, &[], None, None)?;
                         if let Some(inner) = result.is_rstring_inner() {
-                            match inner.regex_view() {
+                            match ctx.view(&inner) {
                                 Ok(v) => v.into_owned(),
                                 Err(_) => result.to_s(&globals.store),
                             }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -575,6 +575,18 @@ impl Store {
     }
 }
 
+thread_local! {
+    static BUILTINS_DIR: std::path::PathBuf = crate::globals::install_root().join("builtins");
+}
+
+/// True for sources shipped in the interpreter's own `builtins/`
+/// bootstrap tree — the core methods monoruby implements in Ruby but
+/// CRuby implements in C. Their frames are `$~` / `$_`-transparent
+/// (see `Meta::set_svar_transparent`).
+fn is_internal_source(source: &SourceInfoRef) -> bool {
+    BUILTINS_DIR.with(|dir| source.path.starts_with(dir))
+}
+
 /// CRuby-style display path for backtrace strings: sources shipped in
 /// the interpreter's own `builtins/` bootstrap tree render as
 /// `<internal:NAME>` (CRuby's prelude-style frames — `Kernel#tap`
@@ -582,10 +594,6 @@ impl Store {
 /// else renders as loaded. `Location#absolute_path` is nil for the
 /// internal form.
 pub(crate) fn display_path(source: &SourceInfoRef) -> std::borrow::Cow<'_, str> {
-    thread_local! {
-        static BUILTINS_DIR: std::path::PathBuf =
-            crate::globals::install_root().join("builtins");
-    }
     let internal = BUILTINS_DIR.with(|dir| {
         source.path.strip_prefix(dir).ok().map(|rest| {
             format!(
@@ -642,6 +650,7 @@ impl Store {
     ) -> Result<FuncId> {
         let func_id = self.functions.next_func_id();
         self.functions.add_compile_info(compile_info);
+        let internal = is_internal_source(&sourceinfo);
         let mut info = ISeqInfo::new_method(
             func_id,
             self.next_iseq_id(),
@@ -658,7 +667,10 @@ impl Store {
         // propagates the flag onto those).
         info.in_singleton_lexical = is_singleton;
         let iseq = self.new_iseq(info);
-        let info = FuncInfo::new_classdef_iseq(name, func_id, iseq);
+        let mut info = FuncInfo::new_classdef_iseq(name, func_id, iseq);
+        if internal {
+            info.set_svar_transparent();
+        }
         self.functions.info.push(info);
         Ok(func_id)
     }
@@ -674,6 +686,7 @@ impl Store {
         let func_id = self.functions.next_func_id();
         let params_info = compile_info.params.clone();
         self.functions.add_compile_info(compile_info);
+        let internal = is_internal_source(&sourceinfo);
         let info = ISeqInfo::new_method(
             func_id,
             self.next_iseq_id(),
@@ -683,7 +696,10 @@ impl Store {
             sourceinfo,
         );
         let iseq = self.new_iseq(info);
-        let info = FuncInfo::new_method_iseq(name, func_id, iseq, params_info, top_level);
+        let mut info = FuncInfo::new_method_iseq(name, func_id, iseq, params_info, top_level);
+        if internal {
+            info.set_svar_transparent();
+        }
         self.functions.info.push(info);
         Ok(func_id)
     }
@@ -701,10 +717,14 @@ impl Store {
         let func_id = self.functions.next_func_id();
         let params_info = compile_info.params.clone();
         self.functions.add_compile_info(compile_info);
+        let internal = is_internal_source(&sourceinfo);
         let info =
             ISeqInfo::new_block(func_id, mother, outer, params_info.clone(), loc, sourceinfo);
         let iseq = self.new_iseq(info);
-        let info = FuncInfo::new_block_iseq(func_id, iseq, params_info, is_block_style);
+        let mut info = FuncInfo::new_block_iseq(func_id, iseq, params_info, is_block_style);
+        if internal {
+            info.set_svar_transparent();
+        }
         self.functions.info.push(info);
         Ok(func_id)
     }

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -120,6 +120,9 @@ pub struct Meta {
     reg_num: u16,
     mode: u8,
     /// bit 7:  0:on_stack 1:on_heap
+    /// bit 6:  1:svar-transparent frame (a core builtin written in
+    ///         Ruby; it stands in for a CRuby C function, which owns
+    ///         no `$~` / `$_` scope — see `Executor::current_mfp`)
     /// bit 5:  1:proc-method frame (ISeq body wrapped as a method via
     ///         `Module#define_method`; a set `MethodReturn` must be
     ///         absorbed at this frame so `return` has lambda-like
@@ -246,6 +249,22 @@ impl Meta {
 
     pub fn is_native(&self) -> bool {
         (self.kind & 0b10) != 0
+    }
+
+    /// Mark this frame as owning no `$~` / `$_` scope. Set for the
+    /// core builtins monoruby implements in Ruby (`builtins/*.rb`):
+    /// CRuby implements the same methods in C, and a C frame is
+    /// skipped by `vm_svar_lep`, so a match performed under one of
+    /// them lands in the *caller's* container. Without this, a
+    /// `$~` set inside e.g. `Enumerable#map`'s `each` call would be
+    /// invisible to the user block map yields to.
+    fn set_svar_transparent(&mut self) {
+        self.kind |= 0b0100_0000
+    }
+
+    /// See [`Self::set_svar_transparent`].
+    pub(crate) fn is_svar_transparent(&self) -> bool {
+        (self.kind & 0b0100_0000) != 0
     }
 
     pub fn on_stack(&self) -> bool {
@@ -1149,6 +1168,12 @@ impl FuncInfo {
     /// boundary even when the JIT inlines the call.
     pub(crate) fn set_proc_method(&mut self) {
         self.data.meta.set_proc_method();
+    }
+
+    /// Mark this function's frames as owning no `$~` / `$_` scope.
+    /// See [`Meta::set_svar_transparent`].
+    pub(crate) fn set_svar_transparent(&mut self) {
+        self.data.meta.set_svar_transparent();
     }
 
     ///


### PR DESCRIPTION
Three of the remaining ruby/spec gaps in `core/kernel`.

## `__callee__` reports the dispatched alias

`__callee__` shared `__method__`'s resolution, so an aliased method reported its *definition* name (`:f` where CRuby says `:g`).

The dispatched name now comes from the call site: the caller saved its pc into the callee's cont-frame slot, and the caller ISeq's `callsite_map` turns that index back into the `CallSiteInfo` whose `name` is the alias. The VM saves the pc one word past the call instruction (at the inline-cache word) and the JIT saves the instruction itself, so both candidate indices are looked up — a `MethodCall` occupies two words, so at most one of them can be a call-instruction position, which makes the choice unambiguous without decoding any opcode.

The name is only trusted when the receiver really resolves it to an alias of this frame's method (matching `MethodTableEntry::original_name`), so a dispatch that went through `method_missing` / `send` / `Method#call` still falls back to the definition name rather than naming the trampoline. An aliased `define_method` body (`alias dm2 dm`) now matches CRuby too.

## `$~` crosses core builtins monoruby writes in Ruby

`"wawa".to_enum(:scan, /./).map { $& }` returned `[nil, nil, nil, nil]`. The culprit was `Enumerable#map`: CRuby implements it in C and `vm_svar_lep` skips C frames, so the `$~` that `String#scan` sets lands in the *user's* frame. monoruby implements it in Ruby, so the Ruby frame owned the `$~` scope and the user block never saw the match.

Core methods loaded from `builtins/*.rb` are now marked svar-transparent — a new `Meta` bit, set from the source path when the ISeq function is created — and `Executor::current_mfp` skips those frames exactly as it already skips native ones.

One consequence needed fixing: `IO#each_line` drives `IO#gets`, which (unlike CRuby's internal `rb_io_getline`) does set `$_`. With the frame now transparent that write became visible to the caller, so `__each_line` restores `$_` around each read while still letting the block assign it.

This also recovers `Enumerable#grep_v sets $~ in the block` and `String#partition ... sets global vars if regexp used`.

## sprintf `%c` honours the format encoding

`%c` always read its Integer argument as a Unicode scalar. It is CRuby's `rb_enc_uint_chr`: a Unicode scalar only for Unicode encodings, and the raw big-endian byte image of the character itself for every other one — `9415601` (`0x8FABB1`) is the EUC-JP three-byte sequence for `é` — raising `RangeError` when the encoding cannot represent it (`"%c".encode("ASCII") % 1286`).

Encoding negotiation for `Kernel#sprintf`, `String#%` and `IO#printf` was duplicated three ways; it now goes through one `FormatCtx`, which additionally puts the whole run into the byte↔U+00XX surrogate space whenever raw bytes must survive the `&str`-space formatter. That is what lets an argument with invalid bytes reach the result verbatim (`sprintf("%s", "\x80").valid_encoding? == false`) instead of being re-rendered with U+FFFD.

## Results

`core/kernel/{__callee__,to_enum,sprintf}_spec.rb` and `core/string/modulo_spec.rb` gain 8 examples:

| spec | before | after |
| --- | --- | --- |
| `Kernel#__callee__` | 1F | 0F |
| `Kernel#to_enum` | 1F | 0F |
| `Kernel#sprintf` | 2F/1E | 0F/1E |
| `String#%` | 1F/1E | 0F/1E |
| `Enumerable#grep_v` / `String#partition` (`$~`) | 2F | 0F |

The one remaining `%c` example (`uses the encoding of the format string to interpret codepoints`) is **not** a sprintf problem: the `%c` output is byte-identical to CRuby (`[143, 171, 177]`, EUC-JP), but the spec's own expectation `"é".encode(Encoding::EUC_JP)` raises `Encoding::UndefinedConversionError`. `encoding_rs`' EUC-JP encoder is the WHATWG one and has no JIS X 0212 (`0x8F`-prefixed) coverage; adding it means importing a JIS X 0212 table, which is out of scope here.

## Testing

- Full unit suite green (2061 lib tests + the integration binaries, 0 failures). The 4 new tests also pass under `--features gc-stress`.
- ruby/spec sweep over `core/{kernel,string,regexp,matchdata,enumerable,array,hash,enumerator,io,file,thread,encoding,symbol,integer,method,proc,module,binding,struct,range}` — 1268 files, 17596 examples: **8 newly passing, 0 regressions**. (`Module#autoload (concurrently) ...` flips in ~half of repeated runs on both the base and this branch; it is a pre-existing race, unrelated to these changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_