### PR TITLE
bytecodegen: fix panic on the no-index assignment `a[] = v`

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -1755,11 +1755,19 @@ impl<'a> BytecodeGen<'a> {
                     self.push(); // register for src.
                     LvalueKind::Index { base, index }
                 } else {
+                    // Everything else — two or more indices, *and* the empty
+                    // index list `a[] = v` — lowers to an ordinary `[]=` call
+                    // of `num` indices followed by the assigned value. `num`
+                    // counts only the indices, so `a[] = v` is a one-argument
+                    // `[]=` (which `Array`/`Hash` reject at run time with
+                    // ArgumentError, and a user-defined `def []=(*a)` accepts).
                     let base = self.eval_index_base(base)?;
-                    let index1 = self.push_expr(index[0].clone())?;
+                    // Take the argument base *before* pushing, so it is right
+                    // even when there are no index expressions to push.
+                    let index1 = self.sp();
                     let num = index.len();
-                    for i in 1..index.len() {
-                        self.push_expr(index[i].clone())?;
+                    for i in index {
+                        self.push_expr(i.clone())?;
                     }
                     self.push(); // register for src.
                     LvalueKind::Index2 { base, index1, num }
@@ -2110,5 +2118,58 @@ mod tests {
         run_test_error(r#"->(a = a + 1) { a }.call"#);
         run_test(r#"def m(a = a); a; end; m"#);
         run_test(r#"def f(x, y = x, z = y + 1); [x, y, z]; end; f(3)"#);
+    }
+
+    /// Issue #1047: the empty index list `a[] = v` shares the l-value arm
+    /// written for two-or-more indices, which indexed `index[0]`
+    /// unconditionally and panicked in bytecodegen — taking the whole file
+    /// down before it ran, even for an `a[] = v` under `if false`.
+    ///
+    /// `a[] = v` is a one-argument `[]=` call: `Array` / `Hash` reject it at
+    /// run time, a `def []=(*a)` accepts it.
+    #[test]
+    fn empty_index_assign() {
+        run_test_error(r#"a = [1, 2]; a[] = 9"#);
+        run_test_error(r#"h = {}; h[] = 9"#);
+        run_test_error(r#"a = [1, 2]; a[] += 1"#);
+        // Compiles even when never executed.
+        run_test(r#"res = :ok; if false; a = [1, 2]; a[] = 9; end; res"#);
+        run_test_with_prelude(
+            r#"c = C.new; c[] = 9; c.log"#,
+            r#"class C
+                 def initialize; @log = []; end
+                 def []=(*a); @log << a; end
+                 def [](*a); @log << [:get, a]; @log.size; end
+                 attr_reader :log
+               end"#,
+        );
+        // `[]` getter + `[]=` setter, and the index list still being empty
+        // after the op-assign rewrite.
+        run_test_with_prelude(
+            r#"c = C.new; c[] += 1; c.log"#,
+            r#"class C
+                 def initialize; @log = []; end
+                 def []=(*a); @log << a; end
+                 def [](*a); @log << [:get, a]; @log.size; end
+                 attr_reader :log
+               end"#,
+        );
+        // Multiple assignment, and a mix with a non-empty index.
+        run_test_with_prelude(
+            r#"c = C.new; c[], c[1] = :x, :y; c.log"#,
+            r#"class C
+                 def initialize; @log = []; end
+                 def []=(*a); @log << a; end
+                 attr_reader :log
+               end"#,
+        );
+        // A private `#[]=` reached through a literal `self` base.
+        run_test_with_prelude(
+            r#"E.new.go"#,
+            r#"class E
+                 def []=(*a); @v = a; end
+                 def go; self[] = 42; @v; end
+               end"#,
+        );
     }
 }


### PR DESCRIPTION
Fixes #1047

## Cause

The `NodeKind::Index` l-value arm dispatches on `index.len()`: one index takes the fast `StoreIndex` path, everything else falls through to an `else` written for two or more — which read `index[0]` unconditionally. An *empty* index list landed there too and panicked with `index out of bounds: the len is 0 but the index is 0`. Because it fires while compiling, the whole file died before running: even an `a[] = v` under `if false` took the process down.

## Fix

Take the argument base with `sp()` *before* pushing the index expressions, so it is correct when there are none. `Index2`'s `num` counts only the indices, so `num == 0` already means a one-argument `[]=` and the existing emit path (`CallSite::simple(_INDEX_ASSIGN, num + 1, …)`) handles it unchanged. The loop also drops the `1..len` + `index[0]` split in favour of iterating the whole list, which is what made the empty case special in the first place.

## Behaviour

All matching CRuby 4.0.2:

```ruby
a = [1, 2]; a[] = 9    # ArgumentError: wrong number of arguments (given 1, expected 2..3)
h = {};     h[] = 9    # ArgumentError: wrong number of arguments (given 1, expected 2)
class C; def []=(*a); p a; end; end
C.new[] = 9            # [9]
a = [1, 2]; a[] += 1   # ArgumentError from the `[]` getter (given 0, expected 1..2)
a = [1, 2]; a[], b = 1, 2
if false; a = [1, 2]; a[] = 9; end   # compiles, no longer kills the file
```

## Testing

* New `bytecodegen::tests::empty_index_assign` covering every l-value form from the issue, plus the op-assign getter path, multiple assignment mixing empty and non-empty indices, and a private `#[]=` reached through a literal `self` base.
* Manually checked the JIT path (200-iteration hot loops of `d[] = 1` and `e[] += 1`) and that the existing forms `a[0] =`, `a[0, 2] =`, `a[1, 1] =`, `a[*idx] =` are unaffected — all identical to CRuby.
* `cargo test`: 2066 passed, 0 failed (under Ruby 4.0.2, matching `vendor/ruby-stdlib/.ruby-version`).
* ruby/spec vs the master baseline: `core/array` 5F/1E, `core/hash` 1F/1E, `language` 2F/3E — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_