### PR TITLE
GC: replace the module's stubs with the allocator's real numbers

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -493,10 +493,15 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
 
 | メソッド | 実装 | 挙動 |
 | --- | --- | --- |
-| `GC.start` | `request_gc(true)` | 次セーフポイントで**メジャー**収集を要求。引数(`full_mark:` 等)は互換のため受けるが無視(常に full)。インライン実行は危険なので即実行はしない。 |
+| `GC.start` | `builtins/gc.rb` + `__request_gc` | `request_gc(full_mark)` で収集を要求したあと、**ループ後方辺(セーフポイント)を跨いで `GC.count` が進むまで回る**ので、CRuby 同様に回収を終えてから返る。builtin の中で直接 `gc()` を呼べないのは、JIT 呼び出し元の生きたレジスタがセーフポイント以外では退避されておらずルート走査から見えないため。`full_mark: false` はマイナーを許す(強制しない)。 |
 | `GC.disable` / `GC.enable` | `Globals::gc_enable(false/true)` | GC の有効/無効を切り替え、直前の disable 状態を bool で返す。`GC_ENABLED`(§4 の malloc 経路が参照)も同期。 |
 | `GC.count` | `total_gc_counter` | 総 GC 回数。 |
-| `GC.stat` | `stat`(CRuby 互換キー) | `count` 等一部のキーだけが実カウンタに対応、他は 0 を返す。 |
+| `GC.stat` | `stat`(CRuby 4.0 のキー順) | ページ数・スロット数・累計確保/解放オブジェクト数・old 世代・malloc 量・フェーズ別時間まで実カウンタ。圧縮とファイナライザ、CRuby 固有の old malloc 会計だけが 0(概念が無いため)。 |
+| `GC.total_time` / `GC.measure_total_time` | `gc_time_ns` | `gc()` の実測ナノ秒。`measure_total_time = false` の間は計測自体を行わない(`GC::Profiler` が有効なら計測は続く)。 |
+| `GC.stress` | `Allocator::stress` | 収集の最後に poll フラグをトリガ帯へ戻すので、**以降すべてのセーフポイントで収集**する。CRuby の「確保ごと」は JIT が確保の高速路をインライン化する都合で再現できないが、ルート漏れの炙り出しという用途は同じ。 |
+| `GC.config` | `builtins/gc.rb` + `__allow_full_mark` | `:rgengc_allow_full_mark` は実ノブで、false の間 `decide_gc_kind` はメジャーを選ばない(明示的な `GC.start` は依然メジャーを強制する)。`:implementation` は読み取り専用。 |
+| `GC.auto_compact` / `GC.compact` | — | `NotImplementedError`。monoruby の収集器はオブジェクトを移動しないので、CRuby が圧縮非対応環境で返すのと同じ答えを返す。 |
+| `GC::Profiler` | `Allocator::profile` | 有効な間、収集ごとに `GcProfileRecord`(invoke time / 所要時間 / live バイト / ヒープ総バイト / 総スロット / メジャーか)を積む。`result` は CRuby と同じ表形式、`raw_data` は同じキー、`total_time` は秒の Float。 |
 
 コマンドラインでは `--no-gc` で GC を無効化できる。GC 無効時は `gc()` が即 return
 するため、`request_gc_if_malloc_over` は `GC_ENABLED` を見て要求自体をスキップする

--- a/monoruby/builtins/gc.rb
+++ b/monoruby/builtins/gc.rb
@@ -1,51 +1,61 @@
 module GC
-  # `GC.count` and `GC.start` are implemented in Rust (they read the
-  # allocator's collection counter / force a full collection).
+  # Most of the module is implemented in Rust (`src/builtins/gc.rs`),
+  # reading the allocator's own counters: `count`, `stat`, `total_time`,
+  # `measure_total_time`, `stress`, `enable` / `disable`, and the whole
+  # of `GC::Profiler`. What is left here needs either Ruby-level control
+  # flow (`start`) or is pure bookkeeping (`config`).
 
-  # --- boolean mode flags -------------------------------------------------
-  # monoruby has no stress mode, no auto-compaction and no time
-  # measurement, but the accessors round-trip a stored value so callers
-  # (and specs) can set and read them back.
-  @stress = false
-  @measure_total_time = false
-  @auto_compact = false
-
-  def self.stress
-    @stress
+  def self.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
+    before = count
+    __request_gc(full_mark)
+    # The collection runs at the next VM safepoint, never inside the
+    # builtin above: only at a safepoint are the JIT caller's live
+    # registers spilled where the root scan can find them. A loop
+    # back-edge *is* such a safepoint, so spin over one until the
+    # collection has happened and `GC.start` returns synchronously, the
+    # way CRuby's does.
+    #
+    # The trip count is bounded because the counter never moves while
+    # collection is disabled (`GC.disable`), which is also why this is a
+    # `while` and not a bare `until`.
+    spins = 0
+    while count == before && spins < 100
+      spins += 1
+    end
+    nil
   end
 
-  def self.stress=(flag)
-    @stress = flag
+  # Instance form (available via `obj.extend(GC)`).
+  def garbage_collect(full_mark: true, immediate_mark: true, immediate_sweep: true)
+    GC.start(full_mark: full_mark, immediate_mark: immediate_mark,
+             immediate_sweep: immediate_sweep)
   end
 
-  def self.measure_total_time
-    @measure_total_time
-  end
-
-  def self.measure_total_time=(flag)
-    @measure_total_time = flag
-  end
-
+  # monoruby's collector never moves an object, so there is no
+  # compaction to switch on. CRuby raises NotImplementedError from these
+  # on platforms whose GC cannot compact either, and callers already
+  # handle that — reporting a stored flag instead would claim a
+  # behaviour that does not exist.
   def self.auto_compact
-    @auto_compact
+    raise NotImplementedError, "GC.auto_compact is not supported on this platform"
   end
 
-  def self.auto_compact=(flag)
-    @auto_compact = flag
+  def self.auto_compact=(_flag)
+    raise NotImplementedError, "GC.auto_compact= is not supported on this platform"
   end
 
-  # Total time spent in GC, in nanoseconds. monoruby does not measure
-  # this, so report 0 (an Integer, never decreasing).
-  def self.total_time
-    0
+  def self.compact
+    raise NotImplementedError, "GC.compact is not supported on this platform"
   end
 
   # --- GC.config ----------------------------------------------------------
+  # `:rgengc_allow_full_mark` is a real knob: with it off, the collector
+  # only ever chooses a minor collection on its own (an explicit
+  # `GC.start` still forces a full one).
   def self.config(*args)
-    @config ||= { implementation: "default", rgengc_allow_full_mark: true }
-    return @config.dup if args.empty?
+    return __config if args.empty?
     arg = args[0]
-    return @config.dup if arg.nil?
+    return __config if arg.nil?
     unless arg.is_a?(Hash)
       raise ArgumentError, "GC.config requires a Hash argument"
     end
@@ -53,53 +63,26 @@ module GC
     if arg.key?(:implementation)
       raise ArgumentError, 'Attempting to set read-only key "Implementation"'
     end
-    # Update known knobs (coercing arbitrary truthy/falsey values to a
-    # boolean, as MRI does); unknown keys are ignored.
-    arg.each do |k, v|
-      next unless @config.key?(k)
-      @config[k] = v ? true : false
+    # Known knobs take any truthy/falsey value (as MRI does); unknown
+    # keys are ignored.
+    if arg.key?(:rgengc_allow_full_mark)
+      self.__allow_full_mark = arg[:rgengc_allow_full_mark] ? true : false
     end
-    @config.dup
+    __config
   end
 
-  # Instance form (available via `obj.extend(GC)`); always returns nil.
-  def garbage_collect(full_mark: true, immediate_mark: true, immediate_sweep: true)
-    GC.start
-    nil
+  # Key order matches CRuby's, so `p GC.config` reads the same.
+  def self.__config
+    { rgengc_allow_full_mark: __allow_full_mark, implementation: "default" }
   end
+  private_class_method :__config
 
   module Profiler
-    @enabled = false
-
-    def self.enabled?
-      @enabled
-    end
-
-    def self.enable
-      @enabled = true
-      nil
-    end
-
-    def self.disable
-      @enabled = false
-      nil
-    end
-
-    def self.clear
-      nil
-    end
-
-    def self.result
-      ""
-    end
-
+    # `enabled?` / `enable` / `disable` / `clear` / `result` /
+    # `raw_data` / `total_time` are implemented in Rust.
     def self.report(out = $stdout)
       out.print(result)
       nil
-    end
-
-    def self.total_time
-      0.0
     end
   end
 end

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -153,11 +153,23 @@ fn malloc_hard_limit_abort(size: usize, projected: usize, limit: usize) -> ! {
     std::process::abort();
 }
 
-/// Address (as `usize`; `0` until the VM registers it) of the JIT/VM
-/// allocation flag — the same `u32` the GC-arena path nudges. Stored
-/// globally so `RurubyAlloc::alloc` can request a GC without reaching into
-/// the (non-reentrant) thread-local `Allocator`.
-static MALLOC_GC_FLAG_ADDR: AtomicUsize = AtomicUsize::new(0);
+thread_local! {
+    /// Address (as `usize`; `0` until the VM registers it) of the JIT/VM
+    /// allocation flag — the same `u32` the GC-arena path nudges. Kept
+    /// beside the thread-local `Allocator` it belongs to (a `Cell<usize>`
+    /// with a `const` initialiser, so reading it allocates nothing and
+    /// runs no destructor: `RurubyAlloc::alloc` reaches it from inside
+    /// the global allocator, where the non-reentrant `ALLOC` itself is
+    /// off limits).
+    ///
+    /// Per-thread rather than global because each VM thread has its own
+    /// heap and its own flag; a process-wide slot would let one thread's
+    /// `GC.start` nudge another thread's flag, and its own request would
+    /// then never fire. Only the interpreter's own thread has a
+    /// registered flag, so allocations on helper threads (preempt timer,
+    /// fd poller) simply request nothing.
+    static MALLOC_GC_FLAG_ADDR: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// `MALLOC_AMOUNT` ceiling above which a GC is requested. Recomputed after
 /// each GC from the post-collection live amount (see `Allocator::gc`).
@@ -180,6 +192,18 @@ pub(crate) fn set_gc_enabled(enabled: bool) {
 /// `GC.start` asks for one at the next poll via [`request_gc`].
 static GC_FORCE_MAJOR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// Live bytes in tracked `malloc` buffers (`GC.stat`'s
+/// `malloc_increase_bytes`).
+pub(crate) fn malloc_amount() -> usize {
+    MALLOC_AMOUNT.load(Ordering::Relaxed)
+}
+
+/// The `malloc_amount` ceiling that triggers the next collection
+/// (`GC.stat`'s `malloc_increase_bytes_limit`).
+pub(crate) fn malloc_gc_threshold() -> usize {
+    MALLOC_GC_THRESHOLD.load(Ordering::Relaxed)
+}
+
 /// Request a garbage collection at the next VM safepoint (`GC.start`).
 ///
 /// Only nudges the JIT/VM alloc flag into its trigger band (and, when
@@ -197,7 +221,7 @@ pub(crate) fn request_gc(force_major: bool) {
 /// preempt bit or a value already in the band. Atomic because the preempt
 /// timer ORs its bit into the same word from another OS thread.
 fn nudge_flag() {
-    let addr = MALLOC_GC_FLAG_ADDR.load(Ordering::Relaxed);
+    let addr = MALLOC_GC_FLAG_ADDR.try_with(|a| a.get()).unwrap_or(0);
     if addr == 0 {
         return;
     }
@@ -248,7 +272,7 @@ fn request_gc_if_malloc_over(total: usize) {
 
 /// Register the VM allocation-flag address with the malloc-trigger path.
 pub(crate) fn set_malloc_gc_flag_addr(addr: *mut u32) {
-    MALLOC_GC_FLAG_ADDR.store(addr as usize, Ordering::Relaxed);
+    let _ = MALLOC_GC_FLAG_ADDR.try_with(|a| a.set(addr as usize));
 }
 
 thread_local!(
@@ -498,6 +522,59 @@ pub struct Allocator<T> {
     free_log_pos: usize,
     /// `GcKind` of the collection currently sweeping (forensics tag).
     current_kind: u8,
+    /// Reference instant for `GcProfileRecord::invoke_time`, taken when
+    /// the allocator is created (as close to process start as monoruby
+    /// gets). CRuby measures its profiler's "Invoke Time" the same way.
+    epoch: std::time::Instant,
+    /// Wall-clock time spent inside `gc()`, split by phase. Accumulated
+    /// only while `measure_time` is set — that is CRuby's
+    /// `GC.measure_total_time`, which is on by default.
+    gc_time_ns: u64,
+    mark_time_ns: u64,
+    sweep_time_ns: u64,
+    /// `GC.measure_total_time`.
+    measure_time: bool,
+    /// Objects reclaimed by every sweep so far (`GC.stat`'s
+    /// `total_freed_objects`).
+    total_freed_objects: usize,
+    /// Pages ever put into service, and pages ever salvaged back into
+    /// `free_pages`. Both monotonic, as CRuby's counterparts are.
+    total_allocated_pages: usize,
+    total_freed_pages: usize,
+    /// `GC::Profiler`: whether to append a record per collection, and
+    /// the records collected so far.
+    profile_enabled: bool,
+    profile: Vec<GcProfileRecord>,
+    /// `GC.stress`: re-arm the poll flag at the end of every collection
+    /// so the next safepoint collects again.
+    stress: bool,
+    /// `GC.config[:rgengc_allow_full_mark]`. When false, `decide_gc_kind`
+    /// never chooses a major collection on its own; an explicit
+    /// `GC.start` still forces one.
+    allow_full_mark: bool,
+}
+
+///
+/// One collection's profile, recorded while `GC::Profiler` is enabled.
+/// The field set mirrors what CRuby's `GC::Profiler.raw_data` reports.
+///
+#[derive(Debug, Clone, Copy)]
+pub struct GcProfileRecord {
+    /// Seconds from the allocator's epoch to the start of this
+    /// collection (`GC_INVOKE_TIME`).
+    pub invoke_time: f64,
+    /// Nanoseconds spent in this collection (`GC_TIME`).
+    pub gc_time_ns: u64,
+    /// Bytes held by live objects after the collection (`HEAP_USE_SIZE`).
+    pub heap_use_size: usize,
+    /// Bytes of heap the collector owns (`HEAP_TOTAL_SIZE`).
+    pub heap_total_size: usize,
+    /// Slots in that heap (`HEAP_TOTAL_OBJECTS`).
+    pub heap_total_objects: usize,
+    /// Whether this was a major (full-heap) collection. CRuby reports
+    /// `GC_IS_MARKED`, which is true for every non-lazy collection; for
+    /// monoruby the major/minor distinction is the informative bit.
+    pub major: bool,
 }
 
 /// Whether `MONORUBY_GC_FREE_LOG=1` forensics are enabled (cached).
@@ -674,6 +751,19 @@ impl<T: GCBox> Allocator<T> {
             free_log: Vec::new(),
             free_log_pos: 0,
             current_kind: 0,
+            epoch: std::time::Instant::now(),
+            gc_time_ns: 0,
+            mark_time_ns: 0,
+            sweep_time_ns: 0,
+            measure_time: true,
+            total_freed_objects: 0,
+            // The first page is in service from the start.
+            total_allocated_pages: 1,
+            total_freed_pages: 0,
+            profile_enabled: false,
+            profile: Vec::new(),
+            stress: false,
+            allow_full_mark: true,
         }
     }
 
@@ -889,6 +979,128 @@ impl<T: GCBox> Allocator<T> {
     }
 
     ///
+    /// Pages currently in service: the filled ones plus the page bump
+    /// allocation is carving out of.
+    ///
+    pub fn page_count(&self) -> usize {
+        self.pages.len() + 1
+    }
+
+    /// Pages salvaged by a previous sweep and waiting to be reused
+    /// (CRuby's `heap_empty_pages`).
+    pub fn empty_page_count(&self) -> usize {
+        self.free_pages.len()
+    }
+
+    /// Object slots the in-service pages hold in total.
+    pub fn available_slots(&self) -> usize {
+        self.page_count() * DATA_LEN
+    }
+
+    /// Slots that can still be handed out without putting another page
+    /// into service: the free list plus the tail of the current page.
+    pub fn allocatable_slots(&self) -> usize {
+        self.free_list_count + (DATA_LEN - self.used_in_current)
+    }
+
+    /// Bytes one object slot occupies.
+    pub const fn slot_size() -> usize {
+        GCBOX_SIZE
+    }
+
+    /// Objects reclaimed by every sweep so far.
+    pub fn total_freed(&self) -> usize {
+        self.total_freed_objects
+    }
+
+    /// Pages ever put into service / ever salvaged back.
+    pub fn total_allocated_pages(&self) -> usize {
+        self.total_allocated_pages
+    }
+
+    pub fn total_freed_pages(&self) -> usize {
+        self.total_freed_pages
+    }
+
+    /// Old-generation objects, and the threshold at which their growth
+    /// forces the next major collection.
+    pub fn old_count(&self) -> usize {
+        self.old_count
+    }
+
+    pub fn old_objects_limit(&self) -> usize {
+        self.old_major_threshold
+    }
+
+    /// Old-generation objects currently in the remembered set (they hold
+    /// a reference into the young generation).
+    pub fn remembered_count(&self) -> usize {
+        self.remembered.len()
+    }
+
+    /// Total / mark-phase / sweep-phase nanoseconds spent collecting.
+    /// Zero while `GC.measure_total_time` is off.
+    pub fn gc_time_ns(&self) -> u64 {
+        self.gc_time_ns
+    }
+
+    pub fn mark_time_ns(&self) -> u64 {
+        self.mark_time_ns
+    }
+
+    pub fn sweep_time_ns(&self) -> u64 {
+        self.sweep_time_ns
+    }
+
+    /// `GC.measure_total_time`.
+    pub fn measure_time(&self) -> bool {
+        self.measure_time
+    }
+
+    pub fn set_measure_time(&mut self, flag: bool) {
+        self.measure_time = flag;
+    }
+
+    /// `GC.stress`. Turning it on arms the poll flag immediately, so the
+    /// next safepoint collects without waiting for allocation pressure.
+    pub fn stress(&self) -> bool {
+        self.stress
+    }
+
+    pub fn set_stress(&mut self, flag: bool) {
+        self.stress = flag;
+        if flag {
+            nudge_flag();
+        }
+    }
+
+    /// `GC.config[:rgengc_allow_full_mark]`.
+    pub fn allow_full_mark(&self) -> bool {
+        self.allow_full_mark
+    }
+
+    pub fn set_allow_full_mark(&mut self, flag: bool) {
+        self.allow_full_mark = flag;
+    }
+
+    /// `GC::Profiler` state and the records collected so far.
+    pub fn profile_enabled(&self) -> bool {
+        self.profile_enabled
+    }
+
+    pub fn set_profile_enabled(&mut self, flag: bool) {
+        self.profile_enabled = flag;
+    }
+
+    pub fn profile_records(&self) -> &[GcProfileRecord] {
+        &self.profile
+    }
+
+    pub fn clear_profile(&mut self) {
+        self.profile.clear();
+    }
+
+    ///
     /// Returns the number of old-generation objects (popcount of every
     /// page's `old_bits`). Confirms that promotion is taking effect, and
     /// cross-checks the incrementally maintained `old_count` field.
@@ -943,10 +1155,13 @@ impl<T: GCBox> Allocator<T> {
             // Allocate new page.
             self.used_in_current = 1;
             self.pages.push(self.current_page);
-            self.current_page = self
-                .free_pages
-                .pop_front()
-                .unwrap_or_else(|| self.new_page());
+            self.current_page = match self.free_pages.pop_front() {
+                Some(page) => page,
+                None => {
+                    self.total_allocated_pages += 1;
+                    self.new_page()
+                }
+            };
             // A page entering service must start with a zeroed
             // old-generation bitmap: fresh arena pages are uninitialised,
             // and salvaged pages may carry stale old bits. This keeps a
@@ -992,6 +1207,12 @@ impl<T: GCBox> Allocator<T> {
     /// caught by the triggers above.
     ///
     fn decide_gc_kind(&self) -> GcKind {
+        // `GC.config[:rgengc_allow_full_mark] = false` takes the major
+        // collection off the table entirely; only an explicit `GC.start`
+        // can still force one.
+        if !self.allow_full_mark {
+            return GcKind::Minor;
+        }
         if self.old_count >= self.old_major_threshold
             || self.minors_since_major >= MAX_MINORS_PER_MAJOR
         {
@@ -1011,6 +1232,14 @@ impl<T: GCBox> Allocator<T> {
         } else {
             self.decide_gc_kind()
         };
+        // Timing is off unless somebody is reading it: `GC.total_time`
+        // (via `measure_total_time`) or `GC::Profiler`.
+        let clock = (self.measure_time || self.profile_enabled).then(|| {
+            (
+                self.epoch.elapsed().as_secs_f64(),
+                std::time::Instant::now(),
+            )
+        });
         self.total_gc_counter += 1;
         self.current_kind = match kind {
             GcKind::Minor => 0,
@@ -1095,6 +1324,7 @@ impl<T: GCBox> Allocator<T> {
         // Drop dead entries from the remembered set before sweep frees
         // them: keep only objects still marked this cycle.
         self.filter_remembered();
+        let mark_elapsed = clock.map(|(_, t)| t.elapsed());
         self.salvage_empty_pages();
         self.sweep();
         if has_heap_frames {
@@ -1116,6 +1346,31 @@ impl<T: GCBox> Allocator<T> {
             eprintln!("free list: {}", self.free_list_count);
         }
         self.unset_alloc_flag();
+        if let Some((invoke_time, started)) = clock {
+            let total = started.elapsed().as_nanos() as u64;
+            let mark = mark_elapsed.map_or(0, |d| d.as_nanos() as u64).min(total);
+            if self.measure_time {
+                self.gc_time_ns += total;
+                self.mark_time_ns += mark;
+                self.sweep_time_ns += total - mark;
+            }
+            if self.profile_enabled {
+                let pages = self.page_count();
+                self.profile.push(GcProfileRecord {
+                    invoke_time,
+                    gc_time_ns: total,
+                    heap_use_size: self.mark_counter * GCBOX_SIZE,
+                    heap_total_size: pages * DATA_LEN * GCBOX_SIZE,
+                    heap_total_objects: pages * DATA_LEN,
+                    major: kind == GcKind::Major,
+                });
+            }
+        }
+        // `GC.stress`: lift the poll flag straight back into its trigger
+        // band so the very next safepoint collects again.
+        if self.stress {
+            nudge_flag();
+        }
         let malloced = MALLOC_AMOUNT.load(std::sync::atomic::Ordering::SeqCst);
         // Allow malloc to grow by half the live amount (at least
         // MALLOC_THRESHOLD) before the next GC. Additive-only growth would
@@ -1393,6 +1648,7 @@ impl<T: GCBox> Allocator<T> {
                     let mut page = self.pages.remove(len - i - 1);
                     page.as_mut().drop_inner_cells();
                     self.free_pages.push_back(page);
+                    self.total_freed_pages += 1;
                     #[cfg(feature = "gc-debug")]
                     eprintln!("salvage: {:?}", page);
                 }
@@ -1467,6 +1723,10 @@ impl<T: GCBox> Allocator<T> {
         }
 
         self.free = anchor.next();
+        // Cells that were already on the free list are swept again (the
+        // sweep is idempotent), so they appear in both counts: what this
+        // collection actually reclaimed is the growth of the list.
+        self.total_freed_objects += c.saturating_sub(self.free_list_count);
         self.free_list_count = c;
         if let Some(log) = log {
             let gc = self.total_gc_counter as u32;

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -10,24 +10,50 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_module_func(klass, "enable", enable, 0);
     globals.define_builtin_module_func(klass, "disable", disable, 0);
     globals.define_builtin_module_func(klass, "count", count, 0);
-    globals.define_builtin_module_func_rest(klass, "start", start);
+    globals.define_builtin_module_func(klass, "total_time", total_time, 0);
+    globals.define_builtin_module_func(klass, "measure_total_time", measure_total_time, 0);
+    globals.define_builtin_module_func(klass, "measure_total_time=", set_measure_total_time, 1);
+    globals.define_builtin_module_func(klass, "stress", stress, 0);
+    globals.define_builtin_module_func(klass, "stress=", set_stress, 1);
+    // Internals the Ruby-level `GC.start` / `GC.config` in
+    // `builtins/gc.rb` drive; see there for why they are split.
+    globals.define_builtin_module_func(klass, "__request_gc", request_gc, 1);
+    globals.define_builtin_module_func(klass, "__allow_full_mark", allow_full_mark, 0);
+    globals.define_builtin_module_func(klass, "__allow_full_mark=", set_allow_full_mark, 1);
+
+    let profiler = globals
+        .define_module_with_identid(IdentId::get_id("Profiler"), klass)
+        .id();
+    globals.define_builtin_module_func(profiler, "enabled?", profiler_enabled, 0);
+    globals.define_builtin_module_func(profiler, "enable", profiler_enable, 0);
+    globals.define_builtin_module_func(profiler, "disable", profiler_disable, 0);
+    globals.define_builtin_module_func(profiler, "clear", profiler_clear, 0);
+    globals.define_builtin_module_func(profiler, "result", profiler_result, 0);
+    globals.define_builtin_module_func(profiler, "total_time", profiler_total_time, 0);
+    globals.define_builtin_module_func(profiler, "raw_data", profiler_raw_data, 0);
 }
 
-/// The `GC.stat` keys, in CRuby order. Only a handful map to real
-/// allocator counters (see [`stat_value`]); the rest are reported as 0
-/// because monoruby's mark-and-sweep collector has no equivalent.
+/// The `GC.stat` keys, in CRuby 4.0 order.
+///
+/// Everything monoruby's collector actually has an answer for is a real
+/// allocator counter (see [`stat_value`]). The rest — compaction and
+/// finalizer bookkeeping, and CRuby's separate old-generation malloc
+/// accounting — is reported as 0 because monoruby has no equivalent
+/// concept, not because the number is unavailable.
 const STAT_KEYS: &[&str] = &[
     "count",
+    "time",
+    "marking_time",
+    "sweeping_time",
     "heap_allocated_pages",
-    "heap_sorted_length",
-    "heap_allocatable_pages",
+    "heap_empty_pages",
+    "heap_allocatable_slots",
     "heap_available_slots",
     "heap_live_slots",
     "heap_free_slots",
     "heap_final_slots",
     "heap_marked_slots",
     "heap_eden_pages",
-    "heap_tomb_pages",
     "total_allocated_pages",
     "total_freed_pages",
     "total_allocated_objects",
@@ -36,6 +62,9 @@ const STAT_KEYS: &[&str] = &[
     "malloc_increase_bytes_limit",
     "minor_gc_count",
     "major_gc_count",
+    "compact_count",
+    "read_barrier_faults",
+    "total_moved_objects",
     "remembered_wb_unprotected_objects",
     "remembered_wb_unprotected_objects_limit",
     "old_objects",
@@ -44,20 +73,43 @@ const STAT_KEYS: &[&str] = &[
     "oldmalloc_increase_bytes_limit",
 ];
 
-/// Value of a `GC.stat` key. Returns `None` for keys we don't recognise
-/// (so `GC.stat(:bogus)` can raise), real allocator counters for the
-/// keys we track, and 0 for the remaining known-but-unsupported keys.
+/// Value of a `GC.stat` key. `None` for keys we don't recognise, so
+/// `GC.stat(:bogus)` can raise.
 fn stat_value(name: &str) -> Option<i64> {
     crate::alloc::ALLOC.with(|alloc| {
         let alloc = alloc.borrow();
         Some(match name {
             "count" => alloc.total_gc_counter() as i64,
-            "minor_gc_count" => alloc.minor_gc_count() as i64,
-            "major_gc_count" => alloc.major_gc_count() as i64,
-            "total_allocated_objects" => alloc.total_allocated() as i64,
+            // CRuby reports the three timers in milliseconds.
+            "time" => (alloc.gc_time_ns() / 1_000_000) as i64,
+            "marking_time" => (alloc.mark_time_ns() / 1_000_000) as i64,
+            "sweeping_time" => (alloc.sweep_time_ns() / 1_000_000) as i64,
+            "heap_allocated_pages" | "heap_eden_pages" => alloc.page_count() as i64,
+            "heap_empty_pages" => alloc.empty_page_count() as i64,
+            "heap_allocatable_slots" => alloc.allocatable_slots() as i64,
+            "heap_available_slots" => alloc.available_slots() as i64,
             "heap_live_slots" | "heap_marked_slots" => alloc.live_count() as i64,
             "heap_free_slots" => alloc.free_count() as i64,
-            _ if STAT_KEYS.contains(&name) => 0,
+            "total_allocated_pages" => alloc.total_allocated_pages() as i64,
+            "total_freed_pages" => alloc.total_freed_pages() as i64,
+            "total_allocated_objects" => alloc.total_allocated() as i64,
+            "total_freed_objects" => alloc.total_freed() as i64,
+            "malloc_increase_bytes" => crate::alloc::malloc_amount() as i64,
+            "malloc_increase_bytes_limit" => crate::alloc::malloc_gc_threshold() as i64,
+            "minor_gc_count" => alloc.minor_gc_count() as i64,
+            "major_gc_count" => alloc.major_gc_count() as i64,
+            "remembered_wb_unprotected_objects" => alloc.remembered_count() as i64,
+            "old_objects" => alloc.old_count() as i64,
+            "old_objects_limit" => alloc.old_objects_limit() as i64,
+            // No finalizers, no compaction, no separate old-gen malloc
+            // accounting.
+            "heap_final_slots"
+            | "compact_count"
+            | "read_barrier_faults"
+            | "total_moved_objects"
+            | "remembered_wb_unprotected_objects_limit"
+            | "oldmalloc_increase_bytes"
+            | "oldmalloc_increase_bytes_limit" => 0,
             _ => return None,
         })
     })
@@ -126,21 +178,280 @@ fn count(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) 
 }
 
 ///
-/// ### GC.start
+/// Internal: ask for a collection at the next VM safepoint.
 ///
-/// - start(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
-///
-/// Force a garbage collection. The keyword arguments are accepted for
-/// compatibility but ignored — `GC.start` always runs a full collection.
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/start.html]
+/// Running one inline here would be unsafe — only at a safepoint are the
+/// JIT caller's live registers spilled where the root scan can see them
+/// — so `GC.start` (Ruby side, `builtins/gc.rb`) requests here and then
+/// crosses a safepoint before returning. A truthy `full_mark` forces the
+/// pending collection to be a major one; otherwise the collector picks
+/// minor or major as usual.
 #[monoruby_builtin]
-fn start(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    // Running a collection inline here is unsafe (the JIT caller's live
-    // registers aren't spilled for the GC root scan), so request a full
-    // collection at the next VM safepoint, where registers are saved.
-    crate::alloc::request_gc(true);
+fn request_gc(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    crate::alloc::request_gc(lfp.arg(0).as_bool());
     Ok(Value::nil())
+}
+
+///
+/// ### GC.total_time
+///
+/// - total_time -> Integer
+///
+/// Nanoseconds spent collecting so far. Frozen while
+/// `GC.measure_total_time` is false.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/total_time.html]
+#[monoruby_builtin]
+fn total_time(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ns = crate::alloc::ALLOC.with(|alloc| alloc.borrow().gc_time_ns());
+    Ok(Value::integer(ns as i64))
+}
+
+///
+/// ### GC.measure_total_time
+///
+/// - measure_total_time -> bool
+/// - measure_total_time=(flag) -> flag
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/measure_total_time.html]
+#[monoruby_builtin]
+fn measure_total_time(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let flag = crate::alloc::ALLOC.with(|alloc| alloc.borrow().measure_time());
+    Ok(Value::bool(flag))
+}
+
+#[monoruby_builtin]
+fn set_measure_total_time(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let flag = lfp.arg(0).as_bool();
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().set_measure_time(flag));
+    Ok(lfp.arg(0))
+}
+
+///
+/// ### GC.stress
+///
+/// - stress -> bool
+/// - stress=(flag) -> flag
+///
+/// With stress on, every VM safepoint collects: the poll flag is put
+/// back into its trigger band at the end of each collection. CRuby
+/// collects once per *allocation*; monoruby cannot, because the JIT
+/// inlines the allocation fast path, but collecting at every safepoint
+/// shakes out missing roots the same way.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC/s/stress.html]
+#[monoruby_builtin]
+fn stress(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let flag = crate::alloc::ALLOC.with(|alloc| alloc.borrow().stress());
+    Ok(Value::bool(flag))
+}
+
+#[monoruby_builtin]
+fn set_stress(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let flag = lfp.arg(0).as_bool();
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().set_stress(flag));
+    Ok(lfp.arg(0))
+}
+
+///
+/// Internal: `GC.config[:rgengc_allow_full_mark]` accessors. Off means
+/// `decide_gc_kind` never picks a major collection on its own.
+#[monoruby_builtin]
+fn allow_full_mark(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let flag = crate::alloc::ALLOC.with(|alloc| alloc.borrow().allow_full_mark());
+    Ok(Value::bool(flag))
+}
+
+#[monoruby_builtin]
+fn set_allow_full_mark(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let flag = lfp.arg(0).as_bool();
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().set_allow_full_mark(flag));
+    Ok(lfp.arg(0))
+}
+
+//
+// GC::Profiler
+//
+
+#[monoruby_builtin]
+fn profiler_enabled(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let flag = crate::alloc::ALLOC.with(|alloc| alloc.borrow().profile_enabled());
+    Ok(Value::bool(flag))
+}
+
+#[monoruby_builtin]
+fn profiler_enable(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().set_profile_enabled(true));
+    Ok(Value::nil())
+}
+
+#[monoruby_builtin]
+fn profiler_disable(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().set_profile_enabled(false));
+    Ok(Value::nil())
+}
+
+#[monoruby_builtin]
+fn profiler_clear(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    crate::alloc::ALLOC.with(|alloc| alloc.borrow_mut().clear_profile());
+    Ok(Value::nil())
+}
+
+///
+/// ### GC::Profiler.result
+///
+/// - result -> String
+///
+/// The collected records in CRuby's report layout.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC=3a=3aProfiler/s/result.html]
+#[monoruby_builtin]
+fn profiler_result(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let s = crate::alloc::ALLOC.with(|alloc| {
+        let alloc = alloc.borrow();
+        let records = alloc.profile_records();
+        // CRuby reports nothing at all unless the profiler is running
+        // and has something to show.
+        if !alloc.profile_enabled() || records.is_empty() {
+            return String::new();
+        }
+        // The header counts every collection the process has run (CRuby
+        // prints `GC.count` here); the rows are the ones recorded since
+        // the profiler was enabled.
+        let mut s = format!("GC {} invokes.\n", alloc.total_gc_counter());
+        s += "Index    Invoke Time(sec)       Use Size(byte)     Total Size(byte)         Total Object                    GC Time(ms)\n";
+        for (i, r) in records.iter().enumerate() {
+            s += &format!(
+                "{:5} {:19.3} {:20} {:20} {:20} {:30.20}\n",
+                i + 1,
+                r.invoke_time,
+                r.heap_use_size,
+                r.heap_total_size,
+                r.heap_total_objects,
+                r.gc_time_ns as f64 / 1_000_000.0,
+            );
+        }
+        s
+    });
+    Ok(Value::string(s))
+}
+
+///
+/// ### GC::Profiler.total_time
+///
+/// - total_time -> Float
+///
+/// Seconds spent in the collections the profiler recorded.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC=3a=3aProfiler/s/total_time.html]
+#[monoruby_builtin]
+fn profiler_total_time(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let secs = crate::alloc::ALLOC.with(|alloc| {
+        alloc
+            .borrow()
+            .profile_records()
+            .iter()
+            .map(|r| r.gc_time_ns as f64)
+            .sum::<f64>()
+            / 1_000_000_000.0
+    });
+    Ok(Value::float(secs))
+}
+
+///
+/// ### GC::Profiler.raw_data
+///
+/// - raw_data -> [Hash] | nil
+///
+/// One Hash per recorded collection; `nil` while the profiler is off.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/GC=3a=3aProfiler/s/raw_data.html]
+#[monoruby_builtin]
+fn profiler_raw_data(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    _lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let (enabled, records) = crate::alloc::ALLOC.with(|alloc| {
+        let alloc = alloc.borrow();
+        (alloc.profile_enabled(), alloc.profile_records().to_vec())
+    });
+    if !enabled {
+        return Ok(Value::nil());
+    }
+    let mut ary = vec![];
+    for r in records {
+        let mut inner = HashmapInner::default();
+        let mut put = |k: &str, v: Value| -> Result<()> {
+            inner.insert(Value::symbol_from_str(k), v, vm, globals)?;
+            Ok(())
+        };
+        put("GC_TIME", Value::float(r.gc_time_ns as f64 / 1e9))?;
+        put("GC_INVOKE_TIME", Value::float(r.invoke_time))?;
+        put("HEAP_USE_SIZE", Value::integer(r.heap_use_size as i64))?;
+        put("HEAP_TOTAL_SIZE", Value::integer(r.heap_total_size as i64))?;
+        put(
+            "HEAP_TOTAL_OBJECTS",
+            Value::integer(r.heap_total_objects as i64),
+        )?;
+        // monoruby never collects lazily, so every recorded cycle marked;
+        // the informative bit is whether it was a full-heap one.
+        put("GC_IS_MARKED", Value::bool(true))?;
+        put("MAJOR_GC", Value::bool(r.major))?;
+        ary.push(Value::hash_from_inner(inner));
+    }
+    Ok(Value::array_from_vec(ary))
 }
 
 ///
@@ -213,17 +524,114 @@ mod tests {
     }
 
     #[test]
-    fn gc_mode_flags() {
-        // Explicit set/read round-trips (default-independent: CRuby's
-        // default for these knobs is build/platform-specific).
-        run_test("GC.stress = true; r = GC.stress; GC.stress = false; [r, GC.stress]");
-        run_test(
-            "GC.measure_total_time = true; a = GC.measure_total_time; \
-             GC.measure_total_time = false; b = GC.measure_total_time; [a, b]",
+    fn gc_stat_is_consistent() {
+        // The counters describe one heap, so they have to agree with
+        // each other — that is what makes them worth reporting.
+        run_test_once(
+            r##"
+            GC.start
+            s = GC.stat
+            [
+              s[:heap_live_slots] <= s[:heap_available_slots],
+              s[:heap_free_slots] <= s[:heap_available_slots],
+              s[:heap_allocatable_slots] <= s[:heap_available_slots],
+              s[:total_allocated_objects] >= s[:total_freed_objects],
+              s[:total_allocated_pages] >= s[:total_freed_pages],
+              s[:count] == s[:minor_gc_count] + s[:major_gc_count],
+              s[:major_gc_count] > 0,
+              s[:heap_allocated_pages] > 0,
+              s[:heap_available_slots] > 0,
+              s[:old_objects] <= s[:heap_live_slots],
+              s[:malloc_increase_bytes_limit] > 0,
+              s[:time] >= s[:marking_time],
+              s[:time] >= s[:sweeping_time],
+              s.values.all? { |v| v.is_a?(Integer) && v >= 0 },
+            ]
+            "##,
         );
-        run_test("GC.total_time.is_a?(Integer)");
-        // `auto_compact=` may raise NotImplementedError on some platforms.
-        run_test("(GC.auto_compact = false rescue nil); [true, false].include?(GC.auto_compact)");
+    }
+
+    #[test]
+    fn gc_start_is_synchronous() {
+        // `GC.start` must have collected by the time it returns, with no
+        // loop of the caller's own to reach a safepoint.
+        run_test_once(
+            r##"
+            before = GC.count
+            GC.start
+            after = GC.count
+            major = GC.stat(:major_gc_count)
+            GC.start
+            [after > before, GC.stat(:major_gc_count) > major]
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_start_full_mark_selects_the_kind() {
+        // `full_mark: false` asks for a young-generation collection; the
+        // default asks for a full one.
+        run_test_once(
+            r##"
+            minor = GC.stat(:minor_gc_count)
+            major = GC.stat(:major_gc_count)
+            GC.start(full_mark: false)
+            a = [GC.stat(:minor_gc_count) > minor, GC.stat(:major_gc_count) == major]
+            major = GC.stat(:major_gc_count)
+            GC.start
+            [a, GC.stat(:major_gc_count) > major]
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_time_measurement() {
+        // `GC.total_time` is nanoseconds and only moves while
+        // `measure_total_time` is on.
+        run_test_once(
+            r##"
+            GC.measure_total_time = false
+            frozen = GC.total_time
+            GC.start
+            a = GC.total_time == frozen
+            GC.measure_total_time = true
+            before = GC.total_time
+            GC.start
+            b = GC.total_time > before
+            [GC.total_time.is_a?(Integer), a, b, GC.measure_total_time]
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_stress_collects() {
+        // Stress mode collects far more often than allocation pressure
+        // alone would.
+        run_test_once(
+            r##"
+            GC.stress = false
+            before = GC.count
+            GC.stress = true
+            100.times { Object.new }
+            grew = GC.count - before
+            GC.stress = false
+            [GC.stress, grew > 10]
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_auto_compact_is_unsupported() {
+        // monoruby never moves an object, so both accessors raise —
+        // exactly as CRuby does where its GC cannot compact. Written so
+        // the answer is the same on both.
+        run_test_once(
+            r##"
+            r = begin; GC.auto_compact; rescue NotImplementedError; false; end
+            w = begin; GC.auto_compact = false; rescue NotImplementedError; false; end
+            [[true, false].include?(r), [true, false].include?(w)]
+            "##,
+        );
     }
 
     #[test]
@@ -233,6 +641,42 @@ mod tests {
         run_test("GC.config({}) == GC.config");
         run_test("GC.config(nil) == GC.config");
         run_test("(GC.config(implementation: \"x\") rescue $!.class)");
+        // `:rgengc_allow_full_mark` round-trips, unknown keys are ignored
+        // and the value is coerced to a boolean.
+        run_test_once(
+            r##"
+            was = GC.config[:rgengc_allow_full_mark]
+            begin
+              a = GC.config(rgengc_allow_full_mark: nil)[:rgengc_allow_full_mark]
+              b = GC.config[:rgengc_allow_full_mark]
+              c = GC.config(rgengc_allow_full_mark: 1.23)[:rgengc_allow_full_mark]
+              d = GC.config(foo: "bar")[:rgengc_allow_full_mark]
+              [a, b, c, d]
+            ensure
+              GC.config(rgengc_allow_full_mark: was)
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_config_suppresses_self_chosen_major() {
+        // With full marking off the collector only ever picks a minor
+        // collection; an explicit `GC.start` still forces a major.
+        run_test_once(
+            r##"
+            GC.config(rgengc_allow_full_mark: false)
+            begin
+              major = GC.stat(:major_gc_count)
+              200000.times { Object.new }
+              a = GC.stat(:major_gc_count) == major
+              GC.start
+              [a, GC.stat(:major_gc_count) > major]
+            ensure
+              GC.config(rgengc_allow_full_mark: true)
+            end
+            "##,
+        );
     }
 
     #[test]
@@ -249,5 +693,45 @@ mod tests {
         run_test("GC::Profiler.result.is_a?(String)");
         run_test("GC::Profiler.total_time.is_a?(Float)");
         run_test("GC::Profiler.clear");
+    }
+
+    #[test]
+    fn gc_profiler_records_each_collection() {
+        // One record per collection while enabled, none once cleared or
+        // disabled, and `raw_data` carries the per-cycle numbers.
+        run_test_once(
+            r##"
+            GC::Profiler.clear
+            GC::Profiler.enable
+            begin
+              GC.start
+              GC.start
+              data = GC::Profiler.raw_data
+              # The header counts every collection the process ran, so
+              # only its shape is comparable across implementations.
+              head = GC::Profiler.result.lines[0]
+              header = head.start_with?("GC ") && head.end_with?(" invokes.\n")
+              keys = data[0].keys.sort
+              ok = data.all? do |r|
+                r[:GC_TIME].is_a?(Float) && r[:GC_TIME] >= 0 &&
+                  r[:GC_INVOKE_TIME].is_a?(Float) &&
+                  r[:HEAP_USE_SIZE] <= r[:HEAP_TOTAL_SIZE] &&
+                  r[:HEAP_TOTAL_OBJECTS] > 0
+              end
+              total = GC::Profiler.total_time
+              GC::Profiler.clear
+              [data.size >= 2, ok, header, keys.include?(:GC_TIME),
+               total.is_a?(Float), total >= 0, GC::Profiler.result.lines[0]]
+            ensure
+              GC::Profiler.disable
+              GC::Profiler.clear
+            end
+            "##,
+        );
+    }
+
+    #[test]
+    fn gc_profiler_raw_data_is_nil_when_disabled() {
+        run_test_once("GC::Profiler.disable; GC::Profiler.raw_data");
     }
 }

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -322,7 +322,7 @@ impl MonorubyErr {
             MonorubyErrKind::NotMethod { .. } => "NoMethodError",
             MonorubyErrKind::Arguments => "ArgumentError",
             MonorubyErrKind::Syntax => "SyntaxError",
-            MonorubyErrKind::Unimplemented => "RuntimeError",
+            MonorubyErrKind::Unimplemented => "NotImplementedError",
             MonorubyErrKind::Name(..) => "NameError",
             MonorubyErrKind::DivideByZero => "ZeroDivisionError",
             MonorubyErrKind::LocalJump => "LocalJumpError",


### PR DESCRIPTION
`builtins/gc.rb` stood in for most of the `GC` module with round-tripped ivars: `stress`, `measure_total_time` and `auto_compact` stored a flag nobody read, `total_time` answered 0, `config` was a private Hash, and `GC::Profiler` was a set of no-ops. `GC.stat` reported six real counters and zero for everything else. All of it now comes from the collector.

## New bookkeeping in the allocator

The module needed profile data monoruby was not collecting, so `Allocator` grows:

- wall-clock time per collection, split into mark and sweep phases (measured only when somebody is reading it — `GC.measure_total_time` or `GC::Profiler`);
- objects reclaimed per sweep, taken as the growth of the free list so the sweep's hot loop pays nothing;
- pages ever put into service and ever salvaged back;
- a `GcProfileRecord` per cycle while `GC::Profiler` is enabled.

## Stubs → implementations

| method | before | after |
| --- | --- | --- |
| `GC.stat` | 6 real counters, 0 for the rest | CRuby 4.0's key list, answered with real page / slot / object / old-generation / malloc / phase-time counters |
| `GC.total_time` | `0` | measured nanoseconds |
| `GC.measure_total_time` | stored ivar | actually gates the measurement |
| `GC.stress` | stored ivar | collects at every safepoint |
| `GC.config` | private Hash | `:rgengc_allow_full_mark` suppresses self-chosen major collections |
| `GC.auto_compact` / `GC.compact` | stored ivar | `NotImplementedError` |
| `GC::Profiler` (all) | no-ops | real records; `result` reproduces CRuby's table, `raw_data` its key set, `total_time` its Float seconds |

Compaction, finalizers and CRuby's separate old-generation malloc accounting stay 0 in `GC.stat` — monoruby has no such concept, which is a different thing from the number being unavailable.

`GC.stress` deserves a note: CRuby collects once per *allocation*, which monoruby cannot do because the JIT inlines the allocation fast path. Re-arming the poll flag at the end of each cycle collects at every safepoint instead — far more often than allocation pressure would, and it shakes out missing roots the same way.

`GC.auto_compact` raising is the honest answer rather than a regression: the collector never moves an object, and `NotImplementedError` is exactly what CRuby returns where its own GC cannot compact. `core/gc/auto_compact_spec.rb` already handles it (it skips).

## `GC.start` is now synchronous

This is what `core/gc/stat_spec.rb`'s two failures were about. They read `GC.count` immediately after `GC.start`, with no loop of their own to reach a safepoint — and `GC.start` only *requested* a collection.

It cannot collect inline: only at a safepoint are the JIT caller's live registers spilled where the root scan can see them. So it now requests and then spins across a loop back-edge — which *is* a safepoint — until the collection has run, bounded because the counter never moves while collection is disabled. `full_mark: false` asks for a minor collection instead of being ignored.

(`core/gc/count_spec.rb` passed all along precisely because it loops itself.)

## Two fixes that fell out

- **The poll-flag address was a process-global holding a per-thread address.** With more than one VM thread, one thread's `GC.start` armed another thread's flag while its own request never fired. It is now thread-local, beside the allocator it belongs to. This is also what made the new tests fail under `cargo test`'s parallelism.
- **An uncaught `NotImplementedError` was reported as `RuntimeError`** — `MonorubyErrKind::Unimplemented` named the wrong class in `class_name`. The exception object itself was always right; only the top-level report was wrong.

## Testing

- `core/gc`: **2 failures → 0** (41 examples).
- Unit tests green; the GC suite goes from 8 to 17 tests, covering `GC.stat`'s internal consistency, `GC.start`'s synchrony and `full_mark:`, the measurement gate, stress actually collecting, the config knob suppressing majors, and the profiler's record contents.
- ruby/spec sweep over `core/{gc,kernel,string,enumerable,array,hash,enumerator,io,file,thread,objectspace,exception,module,method,proc,range,struct}` — 1145 files, 16010 examples: **2 newly passing, 0 regressions**.

`doc/gc.md` §12 is rewritten to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_