### PR TITLE
io: buffer in monoruby instead of relying on Rust's IO buffers

### DIFF
--- a/monoruby/builtins/io.rb
+++ b/monoruby/builtins/io.rb
@@ -27,22 +27,6 @@ class IO
     include IO::WaitWritable
   end
 
-  # The sync flag is per-object bookkeeping only: monoruby's writes are
-  # unbuffered, so semantically every IO behaves as if sync were on. The
-  # flag still round-trips through #sync= and defaults to true for the
-  # process's stderr (fd 2), matching CRuby.
-  def sync
-    raise IOError, "closed stream" if closed?
-    s = @sync
-    s.nil? ? fileno == 2 : s
-  end
-
-  def sync=(v)
-    raise IOError, "closed stream" if closed?
-    @sync = v ? true : false
-    v
-  end
-
   # CRuby's IO#putc: a String argument writes its first character, any
   # other argument is converted with #to_int and the low byte is written.
   def putc(ch)

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -8565,4 +8565,139 @@ mod tests {
             "##,
         );
     }
+
+    /// monoruby buffers IO itself (see `value/rvalue/io/buf.rs`), so the
+    /// points at which bytes actually reach the fd are observable. Each
+    /// case is compared against CRuby by the harness.
+    #[test]
+    fn io_write_buffering_points() {
+        // A buffered write is invisible until the buffer is flushed,
+        // and `#flush` / `#close` both push it out.
+        run_test_once(
+            r##"
+            path = "/tmp/mr_buf_points.txt"
+            res = []
+            f = File.open(path, "w")
+            f.write("abc")
+            res << File.size?(path)     # nil: still buffered
+            f.flush
+            res << File.size?(path)     # 3
+            f.write("de")
+            f.close
+            res << File.size?(path)     # 5: close flushes
+            res << File.read(path)
+            File.unlink(path)
+            res
+            "##,
+        );
+        // `sync = true` writes through; `#sync` round-trips.
+        run_test_once(
+            r##"
+            path = "/tmp/mr_buf_sync.txt"
+            res = []
+            f = File.open(path, "w")
+            res << f.sync
+            f.sync = true
+            res << f.sync
+            f.write("xyz")
+            res << File.size?(path)     # 3: written through
+            f.sync = false
+            res << f.sync
+            f.write("pq")
+            res << File.size?(path)     # still 3
+            f.close
+            res << File.size?(path)
+            File.unlink(path)
+            res
+            "##,
+        );
+        // A read through the same descriptor sees the pending write, and
+        // so does a positional read; seeking flushes first too.
+        run_test_once(
+            r##"
+            path = "/tmp/mr_buf_rw.txt"
+            res = []
+            f = File.open(path, "w+")
+            f.write("hello")
+            f.rewind
+            res << f.read              # "hello"
+            f.write("world")
+            res << f.pread(10, 0)      # "helloworld"
+            f.seek(0)
+            res << f.read
+            f.close
+            File.unlink(path)
+            res
+            "##,
+        );
+        // A write bigger than the 8KiB buffer goes straight out, and the
+        // content still comes back in order.
+        run_test_once(
+            r##"
+            path = "/tmp/mr_buf_big.txt"
+            f = File.open(path, "w")
+            f.write("head")
+            f.write("z" * 20000)
+            f.write("tail")
+            f.close
+            s = File.read(path)
+            res = [s.size, s[0, 4], s[-4, 4], s.count("z")]
+            File.unlink(path)
+            res
+            "##,
+        );
+    }
+
+    /// `#sync` defaults follow CRuby: only the process's stderr, a pipe's
+    /// write end, a socket and a popen stream start synchronized.
+    #[test]
+    fn io_sync_defaults() {
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            res = [$stdout.sync, $stderr.sync, $stdin.sync, r.sync, w.sync]
+            r.close
+            w.close
+            res
+            "##,
+        );
+        // A pipe's write end is synchronized, so the reader in the same
+        // process sees the bytes without an explicit flush.
+        run_test_once(
+            r##"
+            r, w = IO.pipe
+            w.write("through")
+            res = r.read(7)
+            r.close
+            w.close
+            res
+            "##,
+        );
+        run_test_once(
+            r##"
+            io = IO.popen("cat", "r+")
+            res = [io.sync]
+            io.close
+            res
+            "##,
+        );
+        // `#sync` / `#sync=` on a closed stream raise IOError.
+        run_test_error(r##"f = File.open("/tmp/mr_sync_closed.txt", "w"); f.close; f.sync"##);
+        run_test_error(r##"f = File.open("/tmp/mr_sync_closed2.txt", "w"); f.close; f.sync = true"##);
+    }
+
+    /// `Kernel#p` / `#print` and `$stdout.write` share one buffer, so
+    /// their output cannot be reordered against each other.
+    #[test]
+    fn stdout_writers_share_one_buffer() {
+        run_test_once(
+            r##"
+            $stdout.write("a")
+            print "b"
+            $stdout.write("c")
+            $stdout.flush
+            nil
+            "##,
+        );
+    }
 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -43,6 +43,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_CLASS, "close_write", close_write, 0);
     globals.define_builtin_func(IO_CLASS, "close_read", close_read, 0);
     globals.define_builtin_func(IO_CLASS, "closed?", closed_, 0);
+    globals.define_builtin_func(IO_CLASS, "sync", io_sync, 0);
     globals.define_builtin_func(IO_CLASS, "sync=", assign_sync, 1);
     globals.define_builtin_func_with(IO_CLASS, "seek", seek, 1, 2, false);
     globals.define_builtin_func_with(IO_CLASS, "read", read, 0, 2, false);
@@ -1000,7 +1001,7 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     blocking_io_region(vm, globals, lfp.self_val(), libc::POLLOUT, |_store| {
         lfp.self_val().as_io_inner_mut().write(&bytes, &mut done, _store)
     })?;
-    lfp.self_val().as_io_inner_mut().flush()?;
+    lfp.self_val().as_io_inner_mut().flush(&globals.store)?;
     Ok(lfp.self_val())
 }
 
@@ -1102,7 +1103,7 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     }
     // Flush after all writes
     let mut self_ = lfp.self_val();
-    self_.as_io_inner_mut().flush()?;
+    self_.as_io_inner_mut().flush(&globals.store)?;
     Ok(Value::nil())
 }
 
@@ -1199,9 +1200,9 @@ fn printf(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/flush.html]
 #[monoruby_builtin]
-fn flush(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+fn flush(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val();
-    self_.as_io_inner_mut().flush()?;
+    self_.as_io_inner_mut().flush(&globals.store)?;
 
     Ok(lfp.self_val())
 }
@@ -1575,7 +1576,7 @@ fn close(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     if lfp.self_val().as_io_inner().is_closed() {
         return Ok(Value::nil());
     }
-    let popen_result = lfp.self_val().as_io_inner_mut().close()?;
+    let popen_result = lfp.self_val().as_io_inner_mut().close(&globals.store)?;
     if let Some((exit_status, pid)) = popen_result {
         // Set $? (Process::Status) via Process::Status.new(exitstatus, pid)
         let status_class =
@@ -1603,7 +1604,7 @@ fn close(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn close_write(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
@@ -1626,7 +1627,7 @@ fn close_write(
             return Err(MonorubyErr::ioerr("closing non-duplex IO for writing"));
         }
         _ => {
-            io.close()?;
+            io.close(&globals.store)?;
         }
     }
     Ok(Value::nil())
@@ -1636,7 +1637,7 @@ fn close_write(
 #[monoruby_builtin]
 fn close_read(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
@@ -1658,7 +1659,7 @@ fn close_read(
             return Err(MonorubyErr::ioerr("closing non-duplex IO for reading"));
         }
         _ => {
-            io.close()?;
+            io.close(&globals.store)?;
         }
     }
     Ok(Value::nil())
@@ -1672,6 +1673,31 @@ fn closed_(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     Ok(Value::bool(lfp.self_val().as_io_inner().is_closed()))
 }
 
+///
+/// ### IO#sync
+///
+/// - sync -> bool
+///
+/// True when every write reaches the fd before returning. Defaults to
+/// true only for the process's stderr, as in CRuby. A TTY writes through
+/// regardless (CRuby's `FMODE_TTY`), which `#sync` does not report.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/sync.html]
+#[monoruby_builtin]
+fn io_sync(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    ensure_io_open(lfp.self_val())?;
+    Ok(Value::bool(lfp.self_val().as_io_inner().sync()))
+}
+
+///
+/// ### IO#sync=
+///
+/// - sync=(bool) -> bool
+///
+/// Changes the policy for *subsequent* writes; anything already buffered
+/// stays buffered until the next flush, matching CRuby.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/IO/i/sync=3d.html]
 #[monoruby_builtin]
 fn assign_sync(
     _vm: &mut Executor,
@@ -1680,6 +1706,8 @@ fn assign_sync(
     _: BytecodePtr,
 ) -> Result<Value> {
     ensure_io_open(lfp.self_val())?;
+    let sync = lfp.arg(0).as_bool();
+    lfp.self_val().as_io_inner_mut().set_sync(sync);
     Ok(lfp.arg(0))
 }
 
@@ -1966,7 +1994,7 @@ fn io_class_readlines(
             Ok(vm.temp_pop())
         })();
         // Close the fd now — leaving it to GC lets descriptors pile up.
-        let _ = io_val.as_io_inner_mut().close();
+        let _ = io_val.as_io_inner_mut().close(&globals.store);
         result
     })
 }
@@ -2151,7 +2179,7 @@ fn io_foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
             Ok(Value::nil())
         })();
         // Close the fd now — leaving it to GC lets descriptors pile up.
-        let _ = io_val.as_io_inner_mut().close();
+        let _ = io_val.as_io_inner_mut().close(&globals.store);
         result
     })
 }
@@ -2288,6 +2316,10 @@ fn io_pipe(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     };
     let mut read_io = make_end(vm, globals, fds[0], "r")?;
     let mut write_io = make_end(vm, globals, fds[1], "w")?;
+    // CRuby's `rb_io_s_pipe` marks the write end synchronous. It is not a
+    // nicety: both ends usually live in one process, so a buffered write
+    // would leave the reader blocked on data that never reaches the pipe.
+    write_io.as_io_inner_mut().set_sync(true);
 
     // The read end carries the requested (or default) encodings; the
     // write end carries none — `#initialize` with mode "w" already left
@@ -2305,8 +2337,8 @@ fn io_pipe(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
             let r = vm.invoke_block_once(globals, bh, &[read_io, write_io]);
             // Both ends close at block exit (idempotent for ends the
             // block already closed), success or raise.
-            let _ = read_io.as_io_inner_mut().close();
-            let _ = write_io.as_io_inner_mut().close();
+            let _ = read_io.as_io_inner_mut().close(&globals.store);
+            let _ = write_io.as_io_inner_mut().close(&globals.store);
             r
         }
         None => Ok(Value::array2(read_io, write_io)),
@@ -2539,7 +2571,7 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         let data = vm.get_block_data(globals, bh)?;
         let res = vm.invoke_block(globals, &data, &[io_val]);
         let mut io_close = io_val;
-        if let Ok(Some((exit_status, pid))) = io_close.as_io_inner_mut().close() {
+        if let Ok(Some((exit_status, pid))) = io_close.as_io_inner_mut().close(&globals.store) {
             if let Ok(status_class) =
                 vm.get_qualified_constant(globals, OBJECT_CLASS, &["Process", "Status"])
             {
@@ -2768,10 +2800,10 @@ fn io_reopen_io(globals: &mut Globals, self_: Value, other: Value) -> Result<Val
     };
     // Flush both write sides before re-pointing the descriptor.
     if self_.as_io_inner().is_writable() {
-        self_.as_io_inner_mut().flush()?;
+        self_.as_io_inner_mut().flush(&globals.store)?;
     }
     if other.as_io_inner().is_writable() {
-        other.as_io_inner_mut().flush()?;
+        other.as_io_inner_mut().flush(&globals.store)?;
     }
     let fd1 = self_.as_io_inner().fileno()?;
     let fd2 = other.as_io_inner().fileno()?;
@@ -2878,7 +2910,7 @@ fn io_reopen_path(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<
     })?;
     if was_open {
         if self_.as_io_inner().is_writable() {
-            self_.as_io_inner_mut().flush()?;
+            self_.as_io_inner_mut().flush(&globals.store)?;
         }
         let fd1 = self_.as_io_inner().fileno()?;
         let tmpfd = std::os::fd::AsRawFd::as_raw_fd(&file);
@@ -3572,8 +3604,8 @@ fn io_path(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/fsync.html]
 #[monoruby_builtin]
-fn io_fsync(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let ret = lfp.self_val().as_io_inner_mut().fsync(false)?;
+fn io_fsync(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ret = lfp.self_val().as_io_inner_mut().fsync(false, &globals.store)?;
     Ok(Value::integer(ret as i64))
 }
 
@@ -3585,11 +3617,11 @@ fn io_fsync(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr
 #[monoruby_builtin]
 fn io_fdatasync(
     _vm: &mut Executor,
-    _globals: &mut Globals,
+    globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let ret = lfp.self_val().as_io_inner_mut().fsync(true)?;
+    let ret = lfp.self_val().as_io_inner_mut().fsync(true, &globals.store)?;
     Ok(Value::integer(ret as i64))
 }
 
@@ -3730,6 +3762,10 @@ fn io_pread(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
         _ => None,
     };
     lfp.self_val().as_io_inner().ensure_readable()?;
+    // A positional read goes to the fd directly, so anything still sitting
+    // in the write buffer has to land first or `pread` reads stale bytes
+    // (CRuby flushes via `rb_io_check_char_readable`).
+    lfp.self_val().as_io_inner_mut().flush(&globals.store)?;
 
     // maxlen == 0: return "" (or the buffer unchanged) without
     // touching the file — the offset is ignored even if out of range.
@@ -3789,7 +3825,7 @@ fn io_pwrite(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     lfp.self_val().as_io_inner().ensure_writable()?;
     // Flush any buffered writes so the file offset/content the OS sees
     // is consistent before the positional write.
-    lfp.self_val().as_io_inner_mut().flush()?;
+    lfp.self_val().as_io_inner_mut().flush(&globals.store)?;
     let fd = lfp.self_val().as_io_inner().fileno()?;
     // SAFETY: fd is valid, bytes is a valid buffer of `bytes.len()`.
     let n = unsafe {
@@ -4496,7 +4532,7 @@ fn set_encoding_by_bom(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let mut self_ = lfp.self_val();
+    let self_ = lfp.self_val();
     if !self_.as_io_inner().is_readable() {
         return Ok(Value::nil());
     }
@@ -5236,7 +5272,7 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                     blocking_io_region(vm, globals, vv, libc::POLLOUT, |_store| {
                         vv.as_io_inner_mut().write(chunk, &mut done, _store)
                     })?;
-                    vv.as_io_inner_mut().flush()
+                    vv.as_io_inner_mut().flush(&globals.store)
                 }
                 _ => unreachable!(),
             }
@@ -5352,10 +5388,10 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
     // Close only the endpoints this call opened (path forms); IO
     // arguments are left open, per CRuby.
     if let Some(mut v) = src_io_owned {
-        let _ = v.as_io_inner_mut().close();
+        let _ = v.as_io_inner_mut().close(&globals.store);
     }
     if let Some(mut v) = dst_io_owned {
-        let _ = v.as_io_inner_mut().close();
+        let _ = v.as_io_inner_mut().close(&globals.store);
     }
     Ok(Value::integer(result? as i64))
 }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1,6 +1,5 @@
 use crate::ast::{BlockInfo, Loc, LvarCollector, Node, ParamKind, SourceInfoRef};
-use std::io::{BufWriter, Stdout, stdout};
-use std::io::{Read, Write};
+use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU8;
@@ -194,8 +193,6 @@ pub struct Globals {
     pub no_jit: bool,
     /// suppress loading gem.
     pub no_gems: bool,
-    /// stdout.
-    stdout: BufWriter<Stdout>,
     /// library directries.
     load_path: Value,
     /// standard PRNG
@@ -491,7 +488,6 @@ impl Globals {
             gvars: GvarTable::new(),
             no_jit,
             no_gems,
-            stdout: BufWriter::new(stdout()),
             load_path: Value::array_empty(),
             random: Box::new(Prng::new()),
             loaded_features,
@@ -841,7 +837,7 @@ impl Globals {
         // runs the ensure clauses of its current fiber chain (never of
         // suspended fibers) on the way out.
         crate::scheduler::terminate_all(&mut executor, self);
-        let _ = self.flush_stdout();
+        crate::rvalue::io::flush_std_streams();
         #[cfg(any(feature = "profile", feature = "jit-log"))]
         self.show_stats();
         #[cfg(feature = "gc-log")]
@@ -1097,26 +1093,26 @@ impl Globals {
         })
     }
 
+    /// Push monoruby's own stdout buffer out to the kernel.
+    ///
+    /// `Kernel#p` / `#print` and `$stdout.write` share that one buffer, so
+    /// their output can never be reordered relative to each other — which
+    /// a second, Rust-side writer over the same fd would allow.
     pub fn flush_stdout(&mut self) -> Result<()> {
-        self.stdout
-            .flush()
-            .map_err(|e| MonorubyErr::runtimeerr(format!("flush: {}", e)))
+        crate::rvalue::io::flush_stdout(&self.store)
     }
 
     pub fn write_stdout(&mut self, bytes: &[u8]) -> Result<()> {
-        self.stdout
-            .write_all(bytes)
-            .map_err(|e| MonorubyErr::runtimeerr(format!("write: {}", e)))
+        crate::rvalue::io::write_stdout(bytes, &self.store)
     }
 
     pub fn print_value(&mut self, val: Value) -> Result<()> {
         if let Some(s) = val.is_rstring() {
-            self.stdout.write_all(&s)
+            crate::rvalue::io::write_stdout(&s, &self.store)
         } else {
             let v = val.to_s(&self.store).into_bytes();
-            self.stdout.write_all(&v)
+            crate::rvalue::io::write_stdout(&v, &self.store)
         }
-        .map_err(|e| MonorubyErr::runtimeerr(format!("write: {}", e)))
     }
 
     // Handling global variables.

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -269,9 +269,14 @@ pub struct ClassInfo {
     ///
     constant_locations: HashMap<IdentId, (String, u32)>,
     ///
-    /// class variable table.
+    /// class variable table (insertion-ordered).
     ///
-    class_variables: Option<HashMap<IdentId, Value>>,
+    /// Ordered because `Module#class_variables` reports definition order
+    /// in CRuby. A plain `HashMap` made the order depend on how the
+    /// names happened to hash, i.e. on unrelated interning done earlier
+    /// in the process.
+    ///
+    class_variables: Option<indexmap::IndexMap<IdentId, Value>>,
     ///
     /// instance variable table (insertion-ordered).
     ///
@@ -666,7 +671,7 @@ impl ClassInfo {
         if let Some(cv) = &mut self.class_variables {
             cv.insert(name, val);
         } else {
-            let mut cv = HashMap::default();
+            let mut cv = indexmap::IndexMap::default();
             cv.insert(name, val);
             self.class_variables = Some(cv);
         }
@@ -677,7 +682,9 @@ impl ClassInfo {
     }
 
     pub(crate) fn remove_cvar(&mut self, name: IdentId) -> Option<Value> {
-        self.class_variables.as_mut()?.remove(&name)
+        // `shift_remove`, not `swap_remove`: removing one class variable
+        // must not reorder the rest.
+        self.class_variables.as_mut()?.shift_remove(&name)
     }
 
     fn cvar_names(&self) -> Vec<IdentId> {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -49,7 +49,7 @@ mod enumerator;
 mod exception;
 mod fiber;
 mod hash;
-mod io;
+pub(crate) mod io;
 mod io_buffer;
 mod ivar_table;
 mod match_data;

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -529,17 +529,6 @@ impl IoInner {
         res.map_err(|e| drain_err(e, store))
     }
 
-    /// Bytes accepted from Ruby but not yet handed to the kernel.
-    pub fn buffered_write_len(&self) -> usize {
-        match self {
-            Self::Stdout => stdout_buf().buffered_len(),
-            Self::Stderr => stderr_buf().buffered_len(),
-            Self::File(file) => file.wbuf.borrow().buffered_len(),
-            Self::Popen(p) => p.writer.as_ref().map(|w| w.buffered_len()).unwrap_or(0),
-            Self::Stdin | Self::Closed(..) => 0,
-        }
-    }
-
     /// `IO#sync`.
     pub fn sync(&self) -> bool {
         match self {

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -1,14 +1,95 @@
+mod buf;
+
 use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
-    io::{BufRead, IsTerminal, Read, Seek, SeekFrom, Write},
+    io::{BufRead, IsTerminal, Read, Seek, SeekFrom},
     mem::ManuallyDrop,
     os::fd::{AsRawFd, FromRawFd, IntoRawFd},
     os::unix::process::ExitStatusExt,
     rc::Rc,
+    sync::{LazyLock, Mutex, MutexGuard},
 };
 
+use buf::{DrainErr, IoReader, IoWriter, StdFd, WriteBuf};
+
 use super::*;
+
+/// monoruby's own buffers for the three standard descriptors.
+///
+/// Process-global rather than per-`IO`-object: `$stdout` / `STDOUT` and
+/// any other IO naming fd 1 must share one buffer, or their output
+/// interleaves in the wrong order. A `Mutex` rather than a `thread_local!`
+/// for the same reason across the test harness, which runs one
+/// interpreter per OS thread over the same standard descriptors. Ruby
+/// `Thread`s are green threads multiplexed on one OS thread, so this is
+/// uncontended in normal use, and the guard is never held across a
+/// context switch (each call locks, works, and returns).
+static STDIN_BUF: LazyLock<Mutex<IoReader<StdFd>>> =
+    LazyLock::new(|| Mutex::new(IoReader::new(StdFd::new(0))));
+static STDOUT_BUF: LazyLock<Mutex<IoWriter<StdFd>>> = LazyLock::new(|| {
+    let fd = StdFd::new(1);
+    // CRuby: `$stdout.sync` is false, on a TTY as well — a TTY instead
+    // writes through via `FMODE_TTY`.
+    let tty = fd.is_terminal();
+    Mutex::new(IoWriter::new(fd, false, tty))
+});
+static STDERR_BUF: LazyLock<Mutex<IoWriter<StdFd>>> = LazyLock::new(|| {
+    let fd = StdFd::new(2);
+    let tty = fd.is_terminal();
+    // CRuby: `$stderr.sync` is true.
+    Mutex::new(IoWriter::new(fd, true, tty))
+});
+
+fn stdin_buf() -> MutexGuard<'static, IoReader<StdFd>> {
+    STDIN_BUF.lock().unwrap()
+}
+
+pub(crate) fn stdout_buf() -> MutexGuard<'static, IoWriter<StdFd>> {
+    STDOUT_BUF.lock().unwrap()
+}
+
+fn stderr_buf() -> MutexGuard<'static, IoWriter<StdFd>> {
+    STDERR_BUF.lock().unwrap()
+}
+
+/// Push the standard streams' buffers out to the kernel. Called at
+/// interpreter exit, where there is no longer anywhere to report a
+/// failure to.
+pub fn flush_std_streams() {
+    let _ = stdout_buf().drain(&signal_pending);
+    let _ = stderr_buf().drain(&signal_pending);
+}
+
+/// Append to monoruby's stdout buffer, flushing per the stream's policy.
+/// Used by `Kernel#p` / `#print`, which write to the process's stdout
+/// without going through a Ruby `IO` object — sharing the one buffer
+/// keeps their output ordered against `$stdout.write`.
+pub fn write_stdout(bytes: &[u8], store: &Store) -> Result<()> {
+    let mut progress = 0;
+    stdout_buf()
+        .write(bytes, &mut progress, &signal_pending)
+        .map_err(|e| drain_err(e, store))
+}
+
+pub fn flush_stdout(store: &Store) -> Result<()> {
+    stdout_buf()
+        .drain(&signal_pending)
+        .map_err(|e| drain_err(e, store))
+}
+
+/// Map a stalled drain to the internal marker / error the IO builtins
+/// expect. Bytes the kernel took are already out of the buffer, so the
+/// builtin's retry resumes without duplicating output.
+fn drain_err(e: DrainErr, store: &Store) -> MonorubyErr {
+    match e {
+        DrainErr::Signal => MonorubyErr::signal_interrupt(),
+        DrainErr::WouldBlock => MonorubyErr::would_block_interrupt(),
+        // Surface the OS error as the matching Errno::* (e.g. Errno::EPIPE
+        // on a closed pipe -- SIGPIPE is ignored at startup, as in CRuby).
+        DrainErr::Io(e) => MonorubyErr::errno_plain(store, &e),
+    }
+}
 
 thread_local! {
     /// File descriptors currently *owned* (autoclose = true) by a live
@@ -242,7 +323,7 @@ fn read_until_step(
 /// only the bytes already sitting in the internal buffer are taken;
 /// otherwise `fill_buf` may block once to fetch more.
 fn read_partial_chunk<T: Read>(
-    reader: &mut std::io::BufReader<T>,
+    reader: &mut IoReader<T>,
     need: usize,
     no_block: bool,
 ) -> Result<Vec<u8>> {
@@ -298,7 +379,7 @@ fn utf8_missing_bytes(buf: &[u8]) -> usize {
 
 #[derive(Debug)]
 pub struct FileDescriptor {
-    reader: ManuallyDrop<std::io::BufReader<std::fs::File>>,
+    reader: ManuallyDrop<IoReader<std::fs::File>>,
     name: String,
     /// Whether `name` is a real filesystem path (surfaced via `IO#path`).
     /// `false` for placeholder names like `fd 3`/`pipe` created from a raw
@@ -321,6 +402,26 @@ pub struct FileDescriptor {
     /// the underlying reader on the next read. Stored in read order (front
     /// = next byte out); each unget splices its bytes at the front.
     pushback: RefCell<Vec<u8>>,
+    /// monoruby's own write buffer over the *same* descriptor the reader
+    /// owns (a `"r+"` file is read and written through one fd). Held
+    /// behind a `RefCell` because writes reach here through `&self` —
+    /// `&std::fs::File` is itself a `Write`, so no unique borrow of the
+    /// descriptor is needed.
+    wbuf: RefCell<WriteBuf>,
+}
+
+impl FileDescriptor {
+    /// Push this descriptor's write buffer out to the fd. Writes go
+    /// through `&std::fs::File`, so no unique borrow of the reader is
+    /// needed and a buffered write can be flushed from a `&self` path.
+    fn drain_wbuf(&self) -> std::result::Result<(), DrainErr> {
+        let mut wbuf = self.wbuf.borrow_mut();
+        if wbuf.buffered_len() == 0 {
+            return Ok(());
+        }
+        let mut sink: &std::fs::File = self.reader.get_ref();
+        wbuf.drain(&mut sink, &signal_pending)
+    }
 }
 
 impl Drop for FileDescriptor {
@@ -331,7 +432,7 @@ impl Drop for FileDescriptor {
         // be accessed.
         let reader = unsafe { ManuallyDrop::take(&mut self.reader) };
         if self.autoclose.get() {
-            // Normal case: dropping the `BufReader<File>` closes the fd via
+            // Normal case: dropping the `IoReader<File>` closes the fd via
             // `OwnedFd::drop`. This descriptor was the owner; release the
             // fd from the owned-fd set (before the number can be reused).
             unregister_owned_fd(fd);
@@ -347,8 +448,8 @@ impl Drop for FileDescriptor {
 #[derive(Debug)]
 pub struct PopenDescriptor {
     child: std::process::Child,
-    pub(crate) reader: Option<std::io::BufReader<std::process::ChildStdout>>,
-    pub(crate) writer: Option<std::process::ChildStdin>,
+    pub(crate) reader: Option<IoReader<std::process::ChildStdout>>,
+    pub(crate) writer: Option<IoWriter<std::process::ChildStdin>>,
     /// See `FileDescriptor::pushback`.
     pushback: RefCell<Vec<u8>>,
 }
@@ -406,24 +507,66 @@ impl std::fmt::Display for IoInner {
 }
 
 impl IoInner {
-    pub fn flush(&mut self) -> Result<()> {
+    /// Push whatever monoruby has buffered out to the kernel.
+    ///
+    /// Only monoruby's own buffers are involved — there is no `fsync`
+    /// here, matching CRuby's `IO#flush` (`IO#fsync` is separate).
+    pub fn flush(&mut self, store: &Store) -> Result<()> {
         let res = match self {
             Self::Stdin => return Ok(()),
-            Self::Stdout => std::io::stdout().flush(),
-            Self::Stderr => std::io::stderr().flush(),
-            Self::File(file) => file.reader.get_ref().flush(),
+            Self::Stdout => stdout_buf().drain(&signal_pending),
+            Self::Stderr => stderr_buf().drain(&signal_pending),
+            Self::File(file) => file.drain_wbuf(),
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
-                if let Some(ref mut writer) = popen.writer {
-                    writer
-                        .flush()
-                        .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
+                match popen.writer {
+                    Some(ref mut writer) => writer.drain(&signal_pending),
+                    None => return Ok(()),
                 }
-                return Ok(());
             }
             Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
         };
-        res.map_err(|err| MonorubyErr::runtimeerr(err.to_string()))
+        res.map_err(|e| drain_err(e, store))
+    }
+
+    /// Bytes accepted from Ruby but not yet handed to the kernel.
+    pub fn buffered_write_len(&self) -> usize {
+        match self {
+            Self::Stdout => stdout_buf().buffered_len(),
+            Self::Stderr => stderr_buf().buffered_len(),
+            Self::File(file) => file.wbuf.borrow().buffered_len(),
+            Self::Popen(p) => p.writer.as_ref().map(|w| w.buffered_len()).unwrap_or(0),
+            Self::Stdin | Self::Closed(..) => 0,
+        }
+    }
+
+    /// `IO#sync`.
+    pub fn sync(&self) -> bool {
+        match self {
+            Self::Stdout => stdout_buf().sync(),
+            Self::Stderr => stderr_buf().sync(),
+            Self::File(file) => file.wbuf.borrow().sync(),
+            Self::Popen(p) => p.writer.as_ref().map(|w| w.sync()).unwrap_or(false),
+            // A read-only stream has no write buffer to bypass; CRuby
+            // reports false.
+            Self::Stdin | Self::Closed(..) => false,
+        }
+    }
+
+    /// `IO#sync=`. Turning it on does not itself flush — CRuby only
+    /// changes the policy for subsequent writes.
+    pub fn set_sync(&mut self, sync: bool) {
+        match self {
+            Self::Stdout => stdout_buf().set_sync(sync),
+            Self::Stderr => stderr_buf().set_sync(sync),
+            Self::File(file) => file.wbuf.borrow_mut().set_sync(sync),
+            Self::Popen(p) => {
+                if let Some(w) = Rc::get_mut(p).unwrap().writer.as_mut() {
+                    w.set_sync(sync)
+                }
+            }
+            Self::Stdin | Self::Closed(..) => {}
+        }
     }
 
     pub fn is_closed(&self) -> bool {
@@ -476,9 +619,14 @@ impl IoInner {
     /// otherwise. `raw_wait_status` is the POSIX `wait(2)` status word, so
     /// callers (and `Process::Status`) can distinguish exit code, signal
     /// termination, and core-dump state.
-    pub fn close(&mut self) -> Result<Option<(i32, u32)>> {
+    pub fn close(&mut self, store: &Store) -> Result<Option<(i32, u32)>> {
         if self.is_closed() {
             return Err(MonorubyErr::ioerr("closed stream"));
+        }
+        // Anything still buffered has to reach the fd before it goes away
+        // (CRuby's `finish_writeconv` / `io_fflush` in `rb_io_close`).
+        if self.is_writable() {
+            self.flush(store)?;
         }
         let popen_result = if let Self::Popen(popen) = self {
             let popen = Rc::get_mut(popen).unwrap();
@@ -519,14 +667,16 @@ impl IoInner {
 
     pub(super) fn file(file: std::fs::File, name: String, readable: bool, writable: bool) -> Self {
         register_owned_fd(file.as_raw_fd());
+        let is_tty = file.is_terminal();
         Self::File(Rc::new(FileDescriptor {
-            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
+            reader: ManuallyDrop::new(IoReader::new(file)),
             name,
             has_path: true,
             readable,
             writable,
             autoclose: Cell::new(true),
             pushback: RefCell::new(Vec::new()),
+            wbuf: RefCell::new(WriteBuf::new(false, is_tty)),
         }))
     }
 
@@ -535,20 +685,26 @@ impl IoInner {
     /// always opened read/write; `name` only feeds `Display`/inspect.
     pub(super) fn socket(file: std::fs::File, name: String) -> Self {
         register_owned_fd(file.as_raw_fd());
+        let is_tty = file.is_terminal();
+        // CRuby marks sockets synchronized (`rb_io_synchronized`).
+        let sync = true;
         Self::File(Rc::new(FileDescriptor {
-            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
+            reader: ManuallyDrop::new(IoReader::new(file)),
             name,
             has_path: false,
             readable: true,
             writable: true,
             autoclose: Cell::new(true),
             pushback: RefCell::new(Vec::new()),
+            wbuf: RefCell::new(WriteBuf::new(sync, is_tty)),
         }))
     }
 
     pub(crate) fn popen(mut child: std::process::Child) -> Self {
-        let reader = child.stdout.take().map(std::io::BufReader::new);
-        let writer = child.stdin.take();
+        let reader = child.stdout.take().map(IoReader::new);
+        // Never a TTY; synchronized, as CRuby's `IO.popen` is — the child
+        // is waiting on the other end of this pipe.
+        let writer = child.stdin.take().map(|w| IoWriter::new(w, true, false));
         Self::Popen(Rc::new(PopenDescriptor {
             child,
             reader,
@@ -580,86 +736,71 @@ impl IoInner {
         // SAFETY: fd is a valid file descriptor obtained from pipe() or an
         // already-open descriptor supplied to `IO.new`.
         let file = unsafe { std::fs::File::from_raw_fd(fd) };
+        let is_tty = file.is_terminal();
         if autoclose {
             register_owned_fd(fd);
         }
         Self::File(Rc::new(FileDescriptor {
-            reader: ManuallyDrop::new(std::io::BufReader::new(file)),
+            reader: ManuallyDrop::new(IoReader::new(file)),
             name,
             has_path,
             readable,
             writable,
             autoclose: Cell::new(autoclose),
             pushback: RefCell::new(Vec::new()),
+            wbuf: RefCell::new(WriteBuf::new(false, is_tty)),
         }))
     }
 
-    /// Write all of `data[*progress..]`, advancing `*progress` past every
-    /// byte accepted by the kernel (fixing silent short writes on pipes).
+    /// Accept `data[*progress..]` into this stream's buffer, then push
+    /// the buffer to the kernel if the stream writes through (`sync` or a
+    /// TTY) or the buffer is full.
     ///
     /// Signal-interruptible: a bare `EINTR` is retried, while `EINTR`
     /// with a pending signal surfaces the internal signal-interrupt
-    /// marker. Because `*progress` records exactly what was flushed, the
-    /// builtin's `blocking_region` retry after a `Signal.trap` handler
-    /// resumes mid-buffer without duplicating output.
+    /// marker. `*progress` records what has been *accepted*, and the
+    /// buffer itself records what the kernel has taken, so the builtin's
+    /// `blocking_region` retry after a `Signal.trap` handler (or after an
+    /// `EAGAIN` park) resumes exactly where it stopped and never
+    /// duplicates output.
     pub fn write(&mut self, data: &[u8], progress: &mut usize, store: &Store) -> Result<()> {
         self.ensure_writable()?;
-        fn write_all(
-            writer: &mut impl Write,
-            data: &[u8],
-            progress: &mut usize,
-            store: &Store,
-        ) -> Result<()> {
-            while *progress < data.len() {
-                // A blocking pipe write that already transferred bytes
-                // returns the partial count on a signal instead of EINTR,
-                // and a signal can also land while we are in userspace
-                // between chunks; either way the pending bit is set and
-                // re-entering write(2) would block unkillably. Check
-                // before every kernel entry.
-                if signal_pending() {
-                    return Err(MonorubyErr::signal_interrupt());
-                }
-                match writer.write(&data[*progress..]) {
-                    Ok(0) => return Err(MonorubyErr::ioerr("write returned 0")),
-                    Ok(n) => *progress += n,
-                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
-                        if signal_pending() {
-                            return Err(MonorubyErr::signal_interrupt());
-                        }
-                    }
-                    // EAGAIN on an fd the green-thread scheduler put in
-                    // non-blocking mode: `*progress` records what was
-                    // flushed, so the restart after the fd-readiness park
-                    // resumes mid-buffer without duplicating output.
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        return Err(MonorubyErr::would_block_interrupt());
-                    }
-                    // Surface the OS error as the matching Errno::* (e.g.
-                    // Errno::EPIPE on a closed pipe — SIGPIPE is ignored
-                    // at startup, as in CRuby).
-                    Err(e) => return Err(MonorubyErr::errno_plain(store, &e)),
-                }
+        let res = match self {
+            Self::Stdout => stdout_buf().write(data, progress, &signal_pending),
+            Self::Stderr => stderr_buf().write(data, progress, &signal_pending),
+            Self::File(file) => {
+                let mut wbuf = file.wbuf.borrow_mut();
+                let mut sink: &std::fs::File = file.reader.get_ref();
+                wbuf.write(&mut sink, data, progress, &signal_pending)
             }
-            Ok(())
-        }
-        match self {
-            Self::Stdout => write_all(&mut std::io::stdout(), data, progress, store),
-            Self::Stderr => write_all(&mut std::io::stderr(), data, progress, store),
-            Self::File(file) => write_all(
-                Rc::get_mut(file).unwrap().reader.get_mut(),
-                data,
-                progress,
-                store,
-            ),
             Self::Popen(popen) => {
                 let popen = Rc::get_mut(popen).unwrap();
                 // `ensure_writable` guaranteed the writer is present.
                 let writer = popen.writer.as_mut().unwrap();
-                write_all(writer, data, progress, store)
+                writer.write(data, progress, &signal_pending)
             }
             // `ensure_writable` already rejected non-writable streams.
             Self::Stdin | Self::Closed(..) => unreachable!(),
+        };
+        res.map_err(|e| drain_err(e, store))
+    }
+
+    /// Push out anything a *write* left buffered before reading or
+    /// repositioning.
+    ///
+    /// A `File` reads and writes through one descriptor, so a pending
+    /// write has to reach the fd first — otherwise the read returns stale
+    /// content and the file offset is wrong. CRuby does the same
+    /// (`io_fflush` ahead of `io_fillbuf` / `io_seek`). A `Popen` needs
+    /// nothing: the child's stdin and stdout are separate descriptors.
+    fn flush_wbuf_before_read(&self) -> Result<()> {
+        match self {
+            Self::File(file) => file.drain_wbuf().map_err(|e| match e {
+                DrainErr::Signal => MonorubyErr::signal_interrupt(),
+                DrainErr::WouldBlock => MonorubyErr::would_block_interrupt(),
+                DrainErr::Io(e) => MonorubyErr::ioerr(e.to_string()),
+            }),
+            _ => Ok(()),
         }
     }
 
@@ -671,6 +812,7 @@ impl IoInner {
             return true;
         }
         match self {
+            Self::Stdin => !stdin_buf().buffer().is_empty(),
             Self::File(f) => !f.reader.buffer().is_empty(),
             Self::Popen(p) => p
                 .reader
@@ -799,6 +941,7 @@ impl IoInner {
     }
 
     fn read_underlying(&mut self, length: Option<usize>, exact: bool) -> Result<Vec<u8>> {
+        self.flush_wbuf_before_read()?;
         // On a restartable interrupt (`Interrupted`/`WouldBlock` out of the
         // read helpers), bytes already consumed from the fd are pushed back
         // so that the retried read (after a `Signal.trap` handler ran, or
@@ -823,9 +966,9 @@ impl IoInner {
             Self::Stdin => {
                 let mut buf = vec![];
                 let res = if let Some(length) = length {
-                    read_upto(&mut std::io::stdin(), length, &mut buf)
+                    read_upto(&mut *stdin_buf(), length, &mut buf)
                 } else {
-                    read_all(&mut std::io::stdin(), &mut buf)
+                    read_all(&mut *stdin_buf(), &mut buf)
                 };
                 match res {
                     Ok(()) => Ok(buf),
@@ -909,6 +1052,7 @@ impl IoInner {
     /// Returns an empty `Vec` only at end of file (the caller raises
     /// `EOFError`).
     pub fn sysread(&mut self, maxlen: usize) -> Result<Vec<u8>> {
+        self.flush_wbuf_before_read()?;
         use std::io::{Seek, SeekFrom};
         let mut out = if self.pushback_len() > 0 {
             self.take_pushback(Some(maxlen))
@@ -925,8 +1069,10 @@ impl IoInner {
                 return Err(MonorubyErr::ioerr("not opened for reading"));
             }
             Self::Stdin => {
+                // `sysread` bypasses the buffer (CRuby raises if anything
+                // is buffered; monoruby just reads the fd directly).
                 let mut buf = vec![0u8; need];
-                let n = read_step(&mut std::io::stdin(), &mut buf)
+                let n = read_step(stdin_buf().get_mut(), &mut buf)
                     .map_err(|e| map_read_err(e, MonorubyErr::runtimeerr))?;
                 buf.truncate(n);
                 buf
@@ -1005,6 +1151,7 @@ impl IoInner {
     /// `O_NONBLOCK` and issues one raw `read(2)`. Reports `WouldBlock`
     /// on `EAGAIN`/`EWOULDBLOCK` and `Eof` on a 0-byte read.
     pub fn read_nonblock(&mut self, maxlen: usize, store: &Store) -> Result<NonblockRead> {
+        self.flush_wbuf_before_read()?;
         if self.pushback_len() > 0 {
             return Ok(NonblockRead::Data(self.take_pushback(Some(maxlen))));
         }
@@ -1071,6 +1218,7 @@ impl IoInner {
     /// buffered bytes are returned) and unlike `read` it never blocks
     /// to fill the whole `maxlen`. An empty result signals EOF.
     pub fn readpartial(&mut self, maxlen: usize) -> Result<Vec<u8>> {
+        self.flush_wbuf_before_read()?;
         // Drain ungetc pushback first. When pushback supplied any
         // bytes, we must not block for more — only append bytes that
         // are *already* buffered (CRuby returns the available data).
@@ -1091,12 +1239,8 @@ impl IoInner {
             }
             Self::Stdin => {
                 if !had_pushback {
-                    let mut buf = vec![0u8; need];
-                    let n = std::io::stdin()
-                        .read(&mut buf)
-                        .map_err(|e| MonorubyErr::ioerr(e.to_string()))?;
-                    buf.truncate(n);
-                    out.extend(buf);
+                    let chunk = read_partial_chunk(&mut stdin_buf(), need, false)?;
+                    out.extend(chunk);
                 }
             }
             Self::File(file) => {
@@ -1128,6 +1272,7 @@ impl IoInner {
 
     /// Read one `\n`-terminated line as raw bytes (pushback-aware).
     pub fn read_line_bytes(&mut self) -> Result<Option<Vec<u8>>> {
+        self.flush_wbuf_before_read()?;
         if self.pushback_len() > 0 {
             let cell = self.pushback_cell().unwrap();
             let nl = cell.borrow().iter().position(|&b| b == b'\n');
@@ -1166,7 +1311,7 @@ impl IoInner {
         };
         let size = match self {
             Self::Closed(..) => return Err(MonorubyErr::ioerr("closed stream")),
-            Self::Stdin => read_until_step(&mut std::io::stdin().lock(), b'\n', &mut buf)
+            Self::Stdin => read_until_step(&mut *stdin_buf(), b'\n', &mut buf)
                 .map_err(|e| map_read_err(e, MonorubyErr::runtimeerr))?,
             Self::Stdout => return Err(MonorubyErr::argumenterr("can't read from $stdin")),
             Self::Stderr => return Err(MonorubyErr::argumenterr("can't read from $stderr")),
@@ -1398,7 +1543,7 @@ impl IoInner {
                 return Ok(stdin.as_raw_fd());
             }
             if let Some(ref writer) = popen.writer {
-                return Ok(writer.as_raw_fd());
+                return Ok(writer.get_ref().as_raw_fd());
             }
         }
         self.fileno()
@@ -1412,6 +1557,7 @@ impl IoInner {
     pub fn seek(&mut self, offset: i64, whence: i32) -> std::io::Result<u64> {
         const EINVAL: i32 = 22;
         const ESPIPE: i32 = 29;
+        const EINTR: i32 = 4;
         let seek_from = match whence {
             0 => {
                 if offset < 0 {
@@ -1424,7 +1570,17 @@ impl IoInner {
             _ => return Err(std::io::Error::from_raw_os_error(EINVAL)),
         };
         match self {
-            Self::File(file) => Rc::get_mut(file).unwrap().reader.seek(seek_from),
+            Self::File(file) => {
+                // A pending write has to land before the offset moves,
+                // or it would be written at the *new* position.
+                if let Err(e) = file.drain_wbuf() {
+                    return Err(match e {
+                        DrainErr::Io(e) => e,
+                        _ => std::io::Error::from_raw_os_error(EINTR),
+                    });
+                }
+                Rc::get_mut(file).unwrap().reader.seek(seek_from)
+            }
             Self::Closed(..) => Err(std::io::Error::from_raw_os_error(9)), // EBADF
             _ => Err(std::io::Error::from_raw_os_error(ESPIPE)),
         }
@@ -1432,9 +1588,9 @@ impl IoInner {
 
     pub fn isatty(&self) -> bool {
         match self {
-            Self::Stdin => std::io::stdin().is_terminal(),
-            Self::Stdout => std::io::stdout().is_terminal(),
-            Self::Stderr => std::io::stderr().is_terminal(),
+            Self::Stdin => stdin_buf().get_ref().is_terminal(),
+            Self::Stdout => stdout_buf().get_ref().is_terminal(),
+            Self::Stderr => stderr_buf().get_ref().is_terminal(),
             Self::File(_) | Self::Popen(_) | Self::Closed(..) => false,
         }
     }
@@ -1466,8 +1622,8 @@ impl IoInner {
     /// asks the kernel to flush to permanent storage. `data_only` selects
     /// `fdatasync(2)` (skip metadata) over `fsync(2)`. Returns `0` on
     /// success (matching CRuby), `IOError` on a closed stream.
-    pub fn fsync(&mut self, data_only: bool) -> Result<i32> {
-        self.flush()?;
+    pub fn fsync(&mut self, data_only: bool, store: &Store) -> Result<i32> {
+        self.flush(store)?;
         let fd = self.fileno()?;
         // `fdatasync(2)` is Linux/POSIX-realtime; macOS doesn't ship it
         // (the closest equivalent is `fcntl(fd, F_FULLFSYNC)`, which is

--- a/monoruby/src/value/rvalue/io/buf.rs
+++ b/monoruby/src/value/rvalue/io/buf.rs
@@ -1,0 +1,433 @@
+//! monoruby's own IO buffering.
+//!
+//! Ruby IO deliberately does **not** use Rust's buffering types
+//! (`std::io::BufReader`, the `LineWriter` inside `std::io::Stdout`) nor
+//! the `std::io::{stdin, stdout, stderr}` handles, because their policy
+//! is not Ruby's:
+//!
+//! * `std::io::Stdout` is line buffered, so it flushes at every newline
+//!   even when stdout is a file. CRuby buffers fully there and only
+//!   writes at capacity, `#flush`, `#close`, or exit.
+//! * `std::io::Stderr` is unbuffered with no way to turn buffering on.
+//! * Neither honours `IO#sync=`, and neither exposes how much is
+//!   buffered — which the green-thread scheduler needs in order to skip
+//!   an fd-readiness park when a read can already be satisfied.
+//!
+//! The buffers here are monoruby's own and implement CRuby's policy
+//! (`io_binwrite` in CRuby's io.c): a write goes straight to the fd when
+//! the stream is `sync` or is a TTY (CRuby's `FMODE_SYNC | FMODE_TTY`),
+//! and is otherwise accumulated up to [`IO_BUF_CAPA`].
+//!
+//! The std `Read` / `BufRead` / `Seek` *traits* are implemented so the
+//! signal-aware helpers in the parent module stay generic; none of std's
+//! buffering *types* are involved.
+
+use std::io::{BufRead, Read, Seek, SeekFrom, Write};
+use std::mem::ManuallyDrop;
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+/// Capacity of both the read and the write buffer. Matches CRuby's
+/// `IO_WBUF_CAPA_MIN`.
+pub(crate) const IO_BUF_CAPA: usize = 8192;
+
+// ---------------------------------------------------------------------
+// standard descriptors
+// ---------------------------------------------------------------------
+
+/// One of the process's standard descriptors (0/1/2), used *instead of*
+/// `std::io::{stdin, stdout, stderr}` so that no buffering happens
+/// outside monoruby's own.
+///
+/// The fd is borrowed: the `File` is wrapped in `ManuallyDrop`, so
+/// dropping this never closes a standard descriptor.
+pub(crate) struct StdFd(ManuallyDrop<std::fs::File>);
+
+impl StdFd {
+    /// # Safety-relevant invariant
+    /// `fd` must be one of the process's standard descriptors, which stay
+    /// open for its whole lifetime.
+    pub(crate) fn new(fd: RawFd) -> Self {
+        // SAFETY: fd 0/1/2 are open for the process's lifetime, and the
+        // `File` never closes them (`ManuallyDrop`, no `Drop` impl below).
+        Self(ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(fd) }))
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        use std::io::IsTerminal;
+        self.0.is_terminal()
+    }
+}
+
+impl std::fmt::Debug for StdFd {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "StdFd({})", self.0.as_raw_fd())
+    }
+}
+
+impl AsRawFd for StdFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl Read for StdFd {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&*self.0).read(buf)
+    }
+}
+
+impl Write for StdFd {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        (&*self.0).write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Nothing is held back below this point: the bytes are already in
+        // the kernel.
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// read side
+// ---------------------------------------------------------------------
+
+/// Refill-on-demand read buffer.
+pub(crate) struct IoReader<T> {
+    inner: T,
+    buf: Box<[u8]>,
+    /// `buf[pos..cap]` has been read from the fd but not yet consumed.
+    pos: usize,
+    cap: usize,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for IoReader<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("IoReader")
+            .field("inner", &self.inner)
+            .field("buffered", &(self.cap - self.pos))
+            .finish()
+    }
+}
+
+impl<T> IoReader<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            buf: vec![0u8; IO_BUF_CAPA].into_boxed_slice(),
+            pos: 0,
+            cap: 0,
+        }
+    }
+
+    /// Bytes read from the fd but not yet consumed.
+    pub(crate) fn buffer(&self) -> &[u8] {
+        &self.buf[self.pos..self.cap]
+    }
+
+    pub(crate) fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    pub(crate) fn into_inner(self) -> T {
+        self.inner
+    }
+
+    fn discard_buffer(&mut self) {
+        self.pos = 0;
+        self.cap = 0;
+    }
+}
+
+impl<T: Read> Read for IoReader<T> {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        // With nothing buffered and a request at least as large as the
+        // buffer, read straight into the caller's slice: buffering here
+        // would only add a copy.
+        if self.pos == self.cap && out.len() >= self.buf.len() {
+            self.discard_buffer();
+            return self.inner.read(out);
+        }
+        let n = {
+            let avail = self.fill_buf()?;
+            let n = avail.len().min(out.len());
+            out[..n].copy_from_slice(&avail[..n]);
+            n
+        };
+        self.consume(n);
+        Ok(n)
+    }
+}
+
+impl<T: Read> std::io::BufRead for IoReader<T> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if self.pos >= self.cap {
+            // The buffer is spent, so refilling cannot lose anything. On
+            // error `pos`/`cap` are left as they are (both meaning
+            // "empty"), so a retry simply reads again.
+            self.cap = self.inner.read(&mut self.buf)?;
+            self.pos = 0;
+        }
+        Ok(&self.buf[self.pos..self.cap])
+    }
+
+    fn consume(&mut self, n: usize) {
+        self.pos = (self.pos + n).min(self.cap);
+    }
+}
+
+impl<T: Seek> Seek for IoReader<T> {
+    /// Seeking is relative to the *logical* position — the one Ruby sees —
+    /// which is behind the fd's position by however much is still sitting
+    /// in the buffer. A relative seek therefore folds that remainder in,
+    /// and every seek drops the buffer.
+    ///
+    /// `seek(SeekFrom::Current(0))` is consequently both "report the
+    /// logical position" and "rewind the fd to it", which is what the
+    /// unbuffered read/write paths rely on before touching the fd
+    /// directly.
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let result = if let SeekFrom::Current(n) = pos {
+            let remainder = (self.cap - self.pos) as i64;
+            match n.checked_sub(remainder) {
+                Some(offset) => self.inner.seek(SeekFrom::Current(offset))?,
+                None => {
+                    // `n - remainder` overflowed: undo the read-ahead
+                    // first, then apply `n` from there.
+                    self.inner.seek(SeekFrom::Current(-remainder))?;
+                    self.discard_buffer();
+                    self.inner.seek(SeekFrom::Current(n))?
+                }
+            }
+        } else {
+            self.inner.seek(pos)?
+        };
+        self.discard_buffer();
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------
+// write side
+// ---------------------------------------------------------------------
+
+/// Why a buffer drain stopped early. Bytes already accepted by the kernel
+/// have been removed from the buffer, so a retry resumes exactly where it
+/// left off and never duplicates output.
+pub(crate) enum DrainErr {
+    /// A signal is pending: the caller must unwind to a VM poll point (to
+    /// run the Ruby handler) and retry.
+    Signal,
+    /// `EAGAIN` on an fd the green-thread scheduler put in non-blocking
+    /// mode: the caller parks until the fd is writable, then retries.
+    WouldBlock,
+    Io(std::io::Error),
+}
+
+/// Write buffer implementing CRuby's `io_binwrite` policy.
+///
+/// Holds no sink: a `File` opened `"r+"` is read *and* written through
+/// the same descriptor, which the read buffer already owns, so the sink
+/// is supplied per call.
+pub(crate) struct WriteBuf {
+    buf: Vec<u8>,
+    /// `IO#sync`. When set, every write reaches the fd before returning.
+    sync: bool,
+    /// Whether the stream is a TTY. CRuby writes through on a TTY exactly
+    /// as it does for `sync` (`FMODE_SYNC | FMODE_TTY` in `io_binwrite`),
+    /// so a prompt without a trailing newline still appears.
+    tty: bool,
+}
+
+impl std::fmt::Debug for WriteBuf {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("WriteBuf")
+            .field("buffered", &self.buf.len())
+            .field("sync", &self.sync)
+            .field("tty", &self.tty)
+            .finish()
+    }
+}
+
+impl WriteBuf {
+    pub(crate) fn new(sync: bool, tty: bool) -> Self {
+        Self {
+            buf: Vec::new(),
+            sync,
+            tty,
+        }
+    }
+
+    pub(crate) fn sync(&self) -> bool {
+        self.sync
+    }
+
+    pub(crate) fn set_sync(&mut self, sync: bool) {
+        self.sync = sync;
+    }
+
+    /// Bytes accepted from Ruby but not yet handed to the kernel.
+    pub(crate) fn buffered_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Whether writes bypass the buffer entirely.
+    pub(crate) fn writes_through(&self) -> bool {
+        self.sync || self.tty
+    }
+
+    /// Hand the buffer to the kernel, `write(2)` at a time.
+    ///
+    /// `signal_pending` is polled before every kernel entry: a signal that
+    /// arrived while we were in userspace sets no `EINTR`, and entering a
+    /// blocking write with it already pending would block unkillably.
+    pub(crate) fn drain(
+        &mut self,
+        sink: &mut impl Write,
+        signal_pending: &dyn Fn() -> bool,
+    ) -> std::result::Result<(), DrainErr> {
+        let mut written = 0usize;
+        let res = loop {
+            if written >= self.buf.len() {
+                break Ok(());
+            }
+            if signal_pending() {
+                break Err(DrainErr::Signal);
+            }
+            match sink.write(&self.buf[written..]) {
+                Ok(0) => break Err(DrainErr::Io(std::io::Error::other("write returned 0"))),
+                Ok(n) => written += n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    // A bare EINTR with no Ruby-visible signal pending is
+                    // just a restart; anything else has to reach a poll
+                    // point.
+                    if signal_pending() {
+                        break Err(DrainErr::Signal);
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    break Err(DrainErr::WouldBlock);
+                }
+                Err(e) => break Err(DrainErr::Io(e)),
+            }
+        };
+        // Drop exactly what the kernel took, whichever way the loop ended,
+        // so a retry neither duplicates nor loses bytes.
+        self.buf.drain(..written);
+        res
+    }
+
+    /// Accept `data[*progress..]` per this stream's policy.
+    ///
+    /// A write-through stream (`sync`, or a TTY) never touches the buffer:
+    /// CRuby's `io_binwrite` hands the bytes straight to `write(2)`, so a
+    /// failure leaves nothing behind for a later `#flush` or `#close` to
+    /// re-raise — which is what a broken pipe depends on. `*progress`
+    /// records what the kernel took, so a restart after a signal or an
+    /// `EAGAIN` park resumes mid-buffer without duplicating output.
+    ///
+    /// Otherwise the bytes are accumulated and only handed over once the
+    /// buffer reaches [`IO_BUF_CAPA`].
+    pub(crate) fn write(
+        &mut self,
+        sink: &mut impl Write,
+        data: &[u8],
+        progress: &mut usize,
+        signal_pending: &dyn Fn() -> bool,
+    ) -> std::result::Result<(), DrainErr> {
+        if self.writes_through() {
+            // Anything a previous buffered phase left behind goes first,
+            // or the output would be reordered.
+            self.drain(sink, signal_pending)?;
+            while *progress < data.len() {
+                if signal_pending() {
+                    return Err(DrainErr::Signal);
+                }
+                match sink.write(&data[*progress..]) {
+                    Ok(0) => return Err(DrainErr::Io(std::io::Error::other("write returned 0"))),
+                    Ok(n) => *progress += n,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        if signal_pending() {
+                            return Err(DrainErr::Signal);
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        return Err(DrainErr::WouldBlock);
+                    }
+                    Err(e) => return Err(DrainErr::Io(e)),
+                }
+            }
+            return Ok(());
+        }
+        self.buf.extend_from_slice(&data[*progress..]);
+        *progress = data.len();
+        if self.buf.len() >= IO_BUF_CAPA {
+            self.drain(sink, signal_pending)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A [`WriteBuf`] paired with the sink it owns — the standard
+/// descriptors and a child's stdin, which are write-only.
+pub(crate) struct IoWriter<T> {
+    inner: T,
+    buf: WriteBuf,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for IoWriter<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("IoWriter")
+            .field("inner", &self.inner)
+            .field("buf", &self.buf)
+            .finish()
+    }
+}
+
+impl<T> IoWriter<T> {
+    pub(crate) fn new(inner: T, sync: bool, tty: bool) -> Self {
+        Self {
+            inner,
+            buf: WriteBuf::new(sync, tty),
+        }
+    }
+
+    pub(crate) fn sync(&self) -> bool {
+        self.buf.sync()
+    }
+
+    pub(crate) fn set_sync(&mut self, sync: bool) {
+        self.buf.set_sync(sync);
+    }
+
+    pub(crate) fn buffered_len(&self) -> usize {
+        self.buf.buffered_len()
+    }
+
+    pub(crate) fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+}
+
+impl<T: Write> IoWriter<T> {
+    pub(crate) fn drain(
+        &mut self,
+        signal_pending: &dyn Fn() -> bool,
+    ) -> std::result::Result<(), DrainErr> {
+        self.buf.drain(&mut self.inner, signal_pending)
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        data: &[u8],
+        progress: &mut usize,
+        signal_pending: &dyn Fn() -> bool,
+    ) -> std::result::Result<(), DrainErr> {
+        self.buf.write(&mut self.inner, data, progress, signal_pending)
+    }
+}

--- a/monoruby/src/value/rvalue/io/buf.rs
+++ b/monoruby/src/value/rvalue/io/buf.rs
@@ -448,3 +448,349 @@ impl<T: Write> IoWriter<T> {
         self.buf.write(&mut self.inner, data, progress, signal_pending)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sink that records everything written and can be told to fail the
+    /// next `write` with a chosen error, or to accept only `chunk` bytes
+    /// at a time (short writes, as a pipe does).
+    #[derive(Default, Debug)]
+    struct MockSink {
+        written: Vec<u8>,
+        chunk: Option<usize>,
+        fail_with: Vec<std::io::ErrorKind>,
+        calls: usize,
+    }
+
+    impl Write for MockSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.calls += 1;
+            if !self.fail_with.is_empty() {
+                return Err(self.fail_with.remove(0).into());
+            }
+            let n = self.chunk.map_or(buf.len(), |c| c.min(buf.len()));
+            self.written.extend_from_slice(&buf[..n]);
+            Ok(n)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn never() -> impl Fn() -> bool {
+        || false
+    }
+
+    fn write_all(w: &mut WriteBuf, sink: &mut MockSink, data: &[u8]) {
+        let mut progress = 0;
+        w.write(sink, data, &mut progress, &never()).ok().unwrap();
+        assert_eq!(progress, data.len());
+    }
+
+    // ---------------------------------------------------------------
+    // write side
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn buffered_write_holds_until_capacity() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink::default();
+        write_all(&mut w, &mut sink, b"hello");
+        // Nothing reaches the sink yet.
+        assert_eq!(w.buffered_len(), 5);
+        assert!(sink.written.is_empty());
+        w.drain(&mut sink, &never()).ok().unwrap();
+        assert_eq!(sink.written, b"hello");
+        assert_eq!(w.buffered_len(), 0);
+    }
+
+    #[test]
+    fn buffered_write_spills_at_capacity() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink::default();
+        // Just under capacity stays buffered...
+        let small = vec![b'a'; IO_BUF_CAPA - 1];
+        write_all(&mut w, &mut sink, &small);
+        assert!(sink.written.is_empty());
+        // ...and the byte that would fill it pushes everything out.
+        write_all(&mut w, &mut sink, b"b");
+        assert_eq!(sink.written.len(), IO_BUF_CAPA);
+        assert_eq!(w.buffered_len(), 0);
+    }
+
+    #[test]
+    fn write_larger_than_buffer_goes_direct() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink::default();
+        write_all(&mut w, &mut sink, b"pending");
+        let big = vec![b'z'; IO_BUF_CAPA * 2];
+        write_all(&mut w, &mut sink, &big);
+        // The buffered prefix is flushed first, so ordering holds, and
+        // the large write is not copied through the buffer.
+        assert_eq!(&sink.written[..7], b"pending");
+        assert_eq!(sink.written.len(), 7 + big.len());
+        assert_eq!(w.buffered_len(), 0);
+    }
+
+    #[test]
+    fn sync_and_tty_write_through() {
+        for (sync, tty) in [(true, false), (false, true)] {
+            let mut w = WriteBuf::new(sync, tty);
+            assert!(w.writes_through());
+            let mut sink = MockSink::default();
+            write_all(&mut w, &mut sink, b"now");
+            assert_eq!(sink.written, b"now");
+            assert_eq!(w.buffered_len(), 0);
+        }
+    }
+
+    #[test]
+    fn set_sync_flushes_the_buffered_prefix_on_the_next_write() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink::default();
+        write_all(&mut w, &mut sink, b"buffered");
+        assert!(!w.sync());
+        w.set_sync(true);
+        assert!(w.sync());
+        write_all(&mut w, &mut sink, b"-through");
+        assert_eq!(sink.written, b"buffered-through");
+    }
+
+    #[test]
+    fn short_writes_are_retried_until_everything_is_out() {
+        let mut w = WriteBuf::new(true, false);
+        let mut sink = MockSink {
+            chunk: Some(3),
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"0123456789");
+        assert_eq!(sink.written, b"0123456789");
+        assert!(sink.calls >= 4);
+    }
+
+    #[test]
+    fn bare_eintr_is_retried() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink {
+            fail_with: vec![std::io::ErrorKind::Interrupted],
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"x");
+        // No signal is pending, so the EINTR is just a restart.
+        w.drain(&mut sink, &never()).ok().unwrap();
+        assert_eq!(sink.written, b"x");
+    }
+
+    #[test]
+    fn a_pending_signal_stops_the_drain_and_keeps_the_rest() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink {
+            chunk: Some(2),
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"abcdef");
+        // Signal pending from the start: nothing is written, everything
+        // stays buffered for the retry.
+        let err = w.drain(&mut sink, &|| true).err().unwrap();
+        assert!(matches!(err, DrainErr::Signal));
+        assert_eq!(w.buffered_len(), 6);
+        assert!(sink.written.is_empty());
+        // The retry, with no signal pending, completes it.
+        w.drain(&mut sink, &never()).ok().unwrap();
+        assert_eq!(sink.written, b"abcdef");
+    }
+
+    #[test]
+    fn would_block_keeps_only_what_the_kernel_refused() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink::default();
+        write_all(&mut w, &mut sink, b"abcdef");
+        sink.chunk = Some(2);
+        sink.fail_with = vec![];
+        // First `write(2)` takes 2 bytes, the second reports EAGAIN.
+        let mut sink = MockSink {
+            chunk: Some(2),
+            fail_with: vec![],
+            ..Default::default()
+        };
+        w.drain(&mut sink, &never()).ok().unwrap();
+        assert_eq!(sink.written, b"abcdef");
+
+        // Now a sink that refuses outright.
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink {
+            fail_with: vec![std::io::ErrorKind::WouldBlock],
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"xy");
+        let err = w.drain(&mut sink, &never()).err().unwrap();
+        assert!(matches!(err, DrainErr::WouldBlock));
+        assert_eq!(w.buffered_len(), 2);
+    }
+
+    #[test]
+    fn a_hard_error_surfaces_and_a_zero_write_is_an_error() {
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink {
+            fail_with: vec![std::io::ErrorKind::BrokenPipe],
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"x");
+        assert!(matches!(
+            w.drain(&mut sink, &never()).err().unwrap(),
+            DrainErr::Io(_)
+        ));
+
+        let mut w = WriteBuf::new(false, false);
+        let mut sink = MockSink {
+            chunk: Some(0),
+            ..Default::default()
+        };
+        write_all(&mut w, &mut sink, b"x");
+        assert!(matches!(
+            w.drain(&mut sink, &never()).err().unwrap(),
+            DrainErr::Io(_)
+        ));
+    }
+
+    #[test]
+    fn write_through_failure_leaves_nothing_buffered() {
+        // A broken pipe must not strand the bytes: a later `#flush` or
+        // `#close` would raise EPIPE all over again.
+        let mut w = WriteBuf::new(true, false);
+        let mut sink = MockSink {
+            fail_with: vec![std::io::ErrorKind::BrokenPipe],
+            ..Default::default()
+        };
+        let mut progress = 0;
+        let err = w.write(&mut sink, b"gone", &mut progress, &never()).err().unwrap();
+        assert!(matches!(err, DrainErr::Io(_)));
+        assert_eq!(w.buffered_len(), 0);
+        assert_eq!(progress, 0);
+    }
+
+    #[test]
+    fn io_writer_pairs_the_buffer_with_its_sink() {
+        let mut w = IoWriter::new(MockSink::default(), false, false);
+        let mut progress = 0;
+        w.write(b"pair", &mut progress, &never()).ok().unwrap();
+        assert_eq!(w.buffered_len(), 4);
+        assert!(!w.sync());
+        w.set_sync(true);
+        assert!(w.sync());
+        w.drain(&never()).ok().unwrap();
+        assert_eq!(w.get_ref().written, b"pair");
+    }
+
+    // ---------------------------------------------------------------
+    // read side
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn reader_refills_on_demand_and_reports_what_it_holds() {
+        let data: Vec<u8> = (0..100u8).collect();
+        let mut r = IoReader::new(std::io::Cursor::new(data.clone()));
+        assert!(r.buffer().is_empty());
+        let mut out = [0u8; 10];
+        assert_eq!(r.read(&mut out).unwrap(), 10);
+        assert_eq!(out, data[..10]);
+        // One refill pulled everything; the rest is buffered.
+        assert_eq!(r.buffer().len(), 90);
+        let mut rest = Vec::new();
+        r.read_to_end(&mut rest).unwrap();
+        assert_eq!(rest, data[10..]);
+        assert_eq!(r.read(&mut out).unwrap(), 0);
+    }
+
+    #[test]
+    fn a_request_at_least_as_large_as_the_buffer_bypasses_it() {
+        let data = vec![7u8; IO_BUF_CAPA * 2];
+        let mut r = IoReader::new(std::io::Cursor::new(data.clone()));
+        let mut out = vec![0u8; IO_BUF_CAPA * 2];
+        let n = r.read(&mut out).unwrap();
+        assert_eq!(n, data.len());
+        assert!(r.buffer().is_empty());
+    }
+
+    #[test]
+    fn fill_buf_and_consume_walk_the_buffer() {
+        let mut r = IoReader::new(std::io::Cursor::new(b"abcdef".to_vec()));
+        assert_eq!(r.fill_buf().unwrap(), b"abcdef");
+        r.consume(2);
+        assert_eq!(r.buffer(), b"cdef");
+        // Over-consuming saturates rather than running past the buffer.
+        r.consume(100);
+        assert!(r.buffer().is_empty());
+        assert_eq!(r.fill_buf().unwrap(), b"");
+    }
+
+    #[test]
+    fn seek_is_relative_to_the_logical_position() {
+        let data: Vec<u8> = (0..50u8).collect();
+        let mut r = IoReader::new(std::io::Cursor::new(data));
+        let mut out = [0u8; 4];
+        r.read(&mut out).unwrap(); // logical position 4, fd at 50
+        assert_eq!(r.buffer().len(), 46);
+        // `Current(0)` reports the logical position and drops the buffer.
+        assert_eq!(r.seek(SeekFrom::Current(0)).unwrap(), 4);
+        assert!(r.buffer().is_empty());
+        r.read(&mut out).unwrap();
+        assert_eq!(out, [4, 5, 6, 7]);
+        // Absolute and relative seeks both discard the read-ahead.
+        assert_eq!(r.seek(SeekFrom::Start(10)).unwrap(), 10);
+        r.read(&mut out).unwrap();
+        assert_eq!(out, [10, 11, 12, 13]);
+        assert_eq!(r.seek(SeekFrom::Current(-4)).unwrap(), 10);
+        assert_eq!(r.seek(SeekFrom::End(-1)).unwrap(), 49);
+    }
+
+    /// The `Debug` impls are diagnostics, but they read the buffer state
+    /// through the same accessors the hot paths use — a wrong field here
+    /// is a wrong field everywhere.
+    #[test]
+    fn debug_reports_the_buffer_state() {
+        let mut r = IoReader::new(std::io::Cursor::new(b"abcdef".to_vec()));
+        let mut out = [0u8; 2];
+        r.read(&mut out).unwrap();
+        assert!(format!("{r:?}").contains("buffered: 4"));
+
+        let mut w = IoWriter::new(MockSink::default(), true, false);
+        let mut progress = 0;
+        w.write(b"xyz", &mut progress, &never()).ok().unwrap();
+        let s = format!("{w:?}");
+        assert!(s.contains("sync: true"), "{s}");
+        assert!(s.contains("buffered: 0"), "{s}");
+
+        // A standard descriptor reports its fd, and reads/writes reach it
+        // without going through `std::io::stdout()`.
+        let devnull = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+        let fd = devnull.as_raw_fd();
+        let mut std_fd = StdFd::new(fd);
+        assert_eq!(std_fd.as_raw_fd(), fd);
+        assert_eq!(format!("{std_fd:?}"), format!("StdFd({fd})"));
+        assert_eq!(std_fd.write(b"discarded").unwrap(), 9);
+        std_fd.flush().unwrap();
+        // `StdFd` borrows: dropping it must not close the descriptor.
+        drop(std_fd);
+        assert_eq!((&devnull).write(b"still open").unwrap(), 10);
+
+        let zero_file = std::fs::File::open("/dev/zero").unwrap();
+        let mut zero = StdFd::new(zero_file.as_raw_fd());
+        let mut buf = [1u8; 4];
+        assert_eq!(zero.read(&mut buf).unwrap(), 4);
+        assert_eq!(buf, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn accessors_reach_the_wrapped_stream() {
+        let mut r = IoReader::new(std::io::Cursor::new(b"xy".to_vec()));
+        assert_eq!(r.get_ref().position(), 0);
+        r.get_mut().set_position(1);
+        assert_eq!(r.into_inner().position(), 1);
+    }
+}

--- a/monoruby/src/value/rvalue/io/buf.rs
+++ b/monoruby/src/value/rvalue/io/buf.rs
@@ -325,12 +325,18 @@ impl WriteBuf {
     /// A write-through stream (`sync`, or a TTY) never touches the buffer:
     /// CRuby's `io_binwrite` hands the bytes straight to `write(2)`, so a
     /// failure leaves nothing behind for a later `#flush` or `#close` to
-    /// re-raise — which is what a broken pipe depends on. `*progress`
-    /// records what the kernel took, so a restart after a signal or an
-    /// `EAGAIN` park resumes mid-buffer without duplicating output.
+    /// re-raise — which is what a broken pipe depends on.
     ///
-    /// Otherwise the bytes are accumulated and only handed over once the
-    /// buffer reaches [`IO_BUF_CAPA`].
+    /// Otherwise the bytes are accumulated, *unless* they would not fit
+    /// alongside what is already buffered: then the buffer is drained and
+    /// the data goes straight to the kernel, exactly as CRuby does
+    /// (`fptr->wbuf.capa <= fptr->wbuf.len + len`). Copying a 64 KiB
+    /// write through an 8 KiB buffer would cost more than it saves.
+    ///
+    /// `*progress` records what has been accepted — bytes copied into the
+    /// buffer, or bytes the kernel took — so a restart after a signal or
+    /// an `EAGAIN` park resumes exactly where it stopped and never
+    /// duplicates output.
     pub(crate) fn write(
         &mut self,
         sink: &mut impl Write,
@@ -338,38 +344,49 @@ impl WriteBuf {
         progress: &mut usize,
         signal_pending: &dyn Fn() -> bool,
     ) -> std::result::Result<(), DrainErr> {
-        if self.writes_through() {
-            // Anything a previous buffered phase left behind goes first,
-            // or the output would be reordered.
-            self.drain(sink, signal_pending)?;
-            while *progress < data.len() {
+        if !self.writes_through() && self.buf.len() + (data.len() - *progress) < IO_BUF_CAPA {
+            self.buf.extend_from_slice(&data[*progress..]);
+            *progress = data.len();
+            return Ok(());
+        }
+        // Anything a previous buffered phase left behind goes first, or
+        // the output would be reordered.
+        self.drain(sink, signal_pending)?;
+        write_direct(sink, data, progress, signal_pending)
+    }
+}
+
+/// `write(2)` until `data[*progress..]` is gone, polling `signal_pending`
+/// before every kernel entry (a signal delivered while we were in
+/// userspace sets no `EINTR`, and entering a blocking write with it
+/// already pending would block unkillably).
+fn write_direct(
+    sink: &mut impl Write,
+    data: &[u8],
+    progress: &mut usize,
+    signal_pending: &dyn Fn() -> bool,
+) -> std::result::Result<(), DrainErr> {
+    while *progress < data.len() {
+        if signal_pending() {
+            return Err(DrainErr::Signal);
+        }
+        match sink.write(&data[*progress..]) {
+            Ok(0) => return Err(DrainErr::Io(std::io::Error::other("write returned 0"))),
+            Ok(n) => *progress += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                // A bare EINTR with no Ruby-visible signal pending is just
+                // a restart; anything else has to reach a poll point.
                 if signal_pending() {
                     return Err(DrainErr::Signal);
                 }
-                match sink.write(&data[*progress..]) {
-                    Ok(0) => return Err(DrainErr::Io(std::io::Error::other("write returned 0"))),
-                    Ok(n) => *progress += n,
-                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
-                        if signal_pending() {
-                            return Err(DrainErr::Signal);
-                        }
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        return Err(DrainErr::WouldBlock);
-                    }
-                    Err(e) => return Err(DrainErr::Io(e)),
-                }
             }
-            return Ok(());
-        }
-        self.buf.extend_from_slice(&data[*progress..]);
-        *progress = data.len();
-        if self.buf.len() >= IO_BUF_CAPA {
-            self.drain(sink, signal_pending)
-        } else {
-            Ok(())
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                return Err(DrainErr::WouldBlock);
+            }
+            Err(e) => return Err(DrainErr::Io(e)),
         }
     }
+    Ok(())
 }
 
 /// A [`WriteBuf`] paired with the sink it owns — the standard


### PR DESCRIPTION
## Why

Ruby IO was buffered by whatever Rust's std happened to do, and std's policy is not Ruby's:

* `std::io::Stdout` is a `LineWriter`, so it flushed at every newline **even when stdout was a file** — CRuby buffers fully there and only writes at capacity, `#flush`, `#close` or exit.
* `std::io::Stderr` is unbuffered with no way to turn buffering on.
* Neither honours `IO#sync=`, so `builtins/io.rb`'s `#sync` was per-object bookkeeping that changed nothing.
* Regular files were written *unbuffered* (one `write(2)` per `IO#write`), the opposite of CRuby.
* Nothing exposed how much was buffered, so `has_buffered_data` — which lets the green-thread scheduler skip an fd-readiness park — always answered `false` for stdin.

There were also two buffers over fd 1: `Globals::stdout` (a `BufWriter`, used by `Kernel#p` / `#print`) and `std::io::stdout()` (used by `$stdout.write`).

Observable, all now matching CRuby 4.0.2:

| | before | after |
| --- | --- | --- |
| stdout redirected to a file, `write("…\n")` | flushed immediately | held until capacity / flush / exit |
| `$stdout.sync = true`, `write` without a newline | invisible until exit | written through |
| TTY, `write` without a newline | stuck in the `LineWriter` | written through |
| `f.write("abc")` on a File | on disk immediately | buffered until flush / close |
| `IO#sync` defaults | ivar only | stdout false, stderr true, pipe-write / socket / popen true |

## What

New `monoruby/src/value/rvalue/io/buf.rs`:

* **`StdFd`** — fd 0/1/2 borrowed through a `ManuallyDrop<File>`, so `read(2)`/`write(2)` go direct and `std::io::{stdin, stdout, stderr}` are never used.
* **`IoReader<T>`** — refill-on-demand read buffer. It implements the std `Read` / `BufRead` / `Seek` *traits* so the signal-aware helpers in the parent module stay generic, but none of std's buffering *types* are involved.
* **`WriteBuf` / `IoWriter<T>`** — CRuby's `io_binwrite` policy. `sync` or a TTY (CRuby's `FMODE_SYNC | FMODE_TTY`) writes through, bypassing the buffer entirely — so a failed write on a broken pipe leaves nothing behind for a later `#flush` or `#close` to re-raise. Data too large to fit alongside what is buffered also goes direct, rather than being copied through an 8 KiB buffer.

The three standard streams share one process-global buffer each (`Mutex`, uncontended: Ruby `Thread`s are green threads on one OS thread), so `$stdout.write` and `Kernel#p` / `#print` can no longer be reordered against each other. `Globals::stdout` is gone.

`IO#sync` / `#sync=` became native and now drive the real flag; pending writes are flushed before a read, a `seek`, a `pread` and a `close`, since a File reads and writes through one descriptor.

The `class_variables` commit is fallout, not scope creep: `Module#class_variables` walked a `HashMap`, so the order it reported depended on which names had been interned earlier in the process. Interning a few new method names for the IO work flipped `core/module/class_variables_spec.rb`. It now uses the `IndexMap` already used for `ivar_names`, so the order is the definition order CRuby reports.

## Performance

200k–300k ops, best of 3, vs master and CRuby 4.0.2:

| case | size | before | after | CRuby | after/before |
| --- | --- | --- | --- | --- | --- |
| file write | 1 B | 197.1 ms | **78.8 ms** | 62.8 ms | **2.50x** |
| file write | 16 B | 197.0 ms | **80.6 ms** | 61.3 ms | **2.45x** |
| file write | 256 B | 163.3 ms | **83.3 ms** | 73.9 ms | **1.96x** |
| file write | 4 KB | 127.2 ms | 135.4 ms | 106.8 ms | 0.94x |
| file write | 64 KB | 66.0 ms | 77.2 ms | 70.8 ms | 0.85x |
| stdout write | 256 B | 45.5 ms | **34.3 ms** | 49.4 ms | 1.32x |
| stdout write | 4 KB | 31.5 ms | **19.1 ms** | 22.4 ms | 1.65x |
| stdout write | 64 KB | 23.5 ms | **8.9 ms** | 2.4 ms | **2.65x** |
| file read | 1 B … 64 KB | — | — | — | 0.95–1.02x |
| gets / getc | — | — | — | — | 0.96x / 0.93x |

Small writes gain 2.0–2.5x (they used to be one syscall each). Reads are unchanged, as expected — the new reader refills 8 KiB on demand exactly as `BufReader` did.

The first version of the write buffer made 64 KiB writes **2.3x slower** (62.8 → 143.8 ms) by copying them through the 8 KiB buffer; the direct-write path in the third commit brought that to 77.2 ms and 64 KiB `$stdout` writes to 8.9 ms. Writes to `/dev/null`, which isolate the IO path from the filesystem, confirm no large-size regression: 64 B 1.48x, 1 KB 1.22x, 4 KB–256 KB 0.90–1.04x.

## Testing

* `cargo test`: 2078 passed, 0 failed (under Ruby 4.0.2, matching `vendor/ruby-stdlib/.ruby-version`).
* ruby/spec against a master-built baseline: **no new failures anywhere**; `core/io` improves by one (`IO#flush on a pipe raises Errno::EPIPE if sync=false and the read end is closed`) and `core/module` by one (`Module#class_variables returns the correct class variables when inherit is given`). All 57 `core/*` categories swept.
* Differential checks against CRuby for each behaviour in the table above, plus `w+` write-then-read, flush/close ordering, and `sync` defaults per stream kind.

One thing worth flagging: buffering pipe writes deadlocked the spec suite until the write end was marked `sync`, since both ends usually live in one process. CRuby marks it in `rb_io_s_pipe` for the same reason; sockets and `IO.popen` are likewise synchronized here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_