### PR TITLE
kernel: hold ARGV and the ARGF binding in Globals, off the gets hot path

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -619,12 +619,11 @@ enum ArgfSource {
 
 static ARGF_SOURCE: std::sync::Mutex<ArgfSource> = std::sync::Mutex::new(ArgfSource::Uninit);
 
-/// Shift the next file name off `ARGV`, if any.
+/// Shift the next file name off the program-argument array, if any.
+/// Reads it straight off `Globals` — the same object `ARGV` and `$*`
+/// name — rather than looking the constant back up.
 fn shift_argv(globals: &mut Globals) -> Option<String> {
-    let argv = globals
-        .store
-        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ARGV"))?;
-    let mut ary = argv.try_array_ty()?;
+    let mut ary = globals.argv().try_array_ty()?;
     if ary.is_empty() {
         return None;
     }
@@ -685,6 +684,41 @@ fn read_record(
     }
 }
 
+/// The ARGF object `Kernel#gets` reads from. Resolved from the `ARGF`
+/// constant the first time it is needed and then bound for good: CRuby
+/// holds its `argf` object in a C global, so reassigning the constant
+/// never redirects `gets`. Binding it also keeps a constant lookup out
+/// of the `while gets` / `-n` / `-p` hot loop.
+pub(crate) fn argf_object(globals: &mut Globals) -> Option<Value> {
+    if let Some(argf) = globals.argf {
+        return Some(argf);
+    }
+    let argf = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ARGF"))?;
+    globals.argf = Some(argf);
+    Some(argf)
+}
+
+/// The `FuncId` of a `gets` *overriding* `ARGFClass#gets` on the ARGF
+/// object, if one is installed (mspec does this with singleton stubs).
+/// The answer is memoised against the global class version, so the
+/// method lookup runs again only after a method is (re)defined.
+fn argf_gets_override(globals: &mut Globals, argf: Value) -> Option<FuncId> {
+    let version = Globals::class_version();
+    if let Some((cached_version, fid)) = globals.argf_gets
+        && cached_version == version
+    {
+        return fid;
+    }
+    let fid = match globals.find_method_for_object(argf, IdentId::get_id("gets")) {
+        Ok((fid, _, owner)) if owner != argf.real_class(&globals.store).id() => Some(fid),
+        _ => None,
+    };
+    globals.argf_gets = Some((version, fid));
+    fid
+}
+
 #[monoruby_builtin]
 fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // CRuby's `Kernel#gets` is `ARGF.gets` — dispatched, so a singleton
@@ -692,18 +726,12 @@ fn gets(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> 
     // stub runs in its own frame and could not reach the caller's
     // frame-local `$_`). Without an override, use the raw record reader
     // directly, which also maintains `$.`.
-    if let Some(argf) = globals
-        .store
-        .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("ARGF"))
+    if let Some(argf) = argf_object(globals)
+        && let Some(fid) = argf_gets_override(globals, argf)
     {
-        let gets_id = IdentId::get_id("gets");
-        if let Ok((fid, _, owner)) = globals.find_method_for_object(argf, gets_id)
-            && owner != argf.real_class(&globals.store).id()
-        {
-            let res = vm.invoke_func_inner(globals, fid, argf, &[], None, None)?;
-            vm.set_last_read_line(res);
-            return Ok(res);
-        }
+        let res = vm.invoke_func_inner(globals, fid, argf, &[], None, None)?;
+        vm.set_last_read_line(res);
+        return Ok(res);
     }
     argf_gets_raw(vm, globals)
 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -9390,6 +9390,56 @@ mod tests {
     }
 
     #[test]
+    fn argv_argf_specials() {
+        // `$*` and `$<` read through Globals-backed hooks and are
+        // read-only; a singleton `gets` on ARGF intercepts `Kernel#gets`
+        // (called twice to also hit the class-version-memoised probe).
+        run_test_once(
+            r#"
+            r = []
+            r << $*
+            r << $*.equal?(ARGV)
+            r << defined?($<)
+            r << $<.to_s
+            r << $<.equal?(ARGF)
+            r << (begin; $* = []; rescue NameError => e; e.message; end)
+            r << (begin; $< = nil; rescue NameError => e; e.message; end)
+            def ARGF.gets; "stubbed"; end
+            r << gets
+            r << gets
+            r
+            "#,
+        );
+    }
+
+    #[test]
+    fn kernel_gets_argv_files() {
+        // Real (un-stubbed) `Kernel#gets`: file names pushed onto ARGV
+        // are shifted off and read in order, `$.` advances, and end of
+        // input reads as nil. Keeps `gets` off stdin, so it cannot hang.
+        run_test_once(
+            r#"
+            require 'tmpdir'
+            f = File.join(Dir.tmpdir, "kgets_#{Process.pid}.txt")
+            File.write(f, "a\nb\n")
+            begin
+              ARGV << f
+              r = []
+              r << gets
+              r << $.
+              r << gets
+              r << gets
+              r << $.
+              r << ARGV
+              r
+            ensure
+              File.unlink(f) rescue nil
+            end
+            "#,
+        );
+    }
+
+    #[test]
     fn argf_basic_shape() {
         run_test_no_result_check(
             r#"

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -265,6 +265,25 @@ pub struct Globals {
     /// runs finalizers only at exit, never asynchronously at GC time,
     /// which the spec explicitly permits.
     pub(crate) finalizers: Vec<(u64, Value)>,
+    /// The program-argument array: the single object behind the `ARGV`
+    /// constant, `$*`, and the file-name queue that `ARGF` and
+    /// `Kernel#gets` consume. CRuby keeps it in a C global (`rb_argv`)
+    /// rather than reading the constant back, so reassigning `ARGV`
+    /// redirects neither; holding it here does the same, and lets `gets`
+    /// reach the queue without a constant lookup per stream switch.
+    argv: Value,
+    /// The ARGF object `Kernel#gets` reads from, resolved from the
+    /// `ARGF` constant on first use and then bound for the process's
+    /// lifetime. CRuby binds its `argf` object at startup, so
+    /// reassigning the `ARGF` constant never redirects `gets` — and
+    /// binding it once keeps the constant lookup out of the `gets` hot
+    /// loop (`while gets`, `-n`/`-p`).
+    pub(crate) argf: Option<Value>,
+    /// Memoised answer to "does the ARGF object carry a `gets` that
+    /// overrides `ARGFClass#gets`?" — mspec installs such singleton
+    /// stubs. Keyed on the global class version, so defining or
+    /// redefining any method invalidates it.
+    pub(crate) argf_gets: Option<(u32, Option<FuncId>)>,
     /// stats for deoptimization
     #[cfg(feature = "profile")]
     deopt_stats: HashMap<(FuncId, bytecodegen::BcIndex), usize>,
@@ -308,6 +327,13 @@ impl alloc::GC<RValue> for Globals {
             v.mark(alloc);
         }
         self.random_seed_obj.mark(alloc);
+        // The argv array and the bound ARGF object outlive any
+        // reassignment of the `ARGV` / `ARGF` constants, so from then on
+        // they are reachable only from here.
+        self.argv.mark(alloc);
+        if let Some(v) = &self.argf {
+            v.mark(alloc);
+        }
         self.symbol_names.values().for_each(|v| v.mark(alloc));
         // Trap handler Procs are GC roots: they are reachable only from
         // this table, yet may be invoked at any future poll point.
@@ -524,6 +550,9 @@ impl Globals {
             exit_trap_handler: None,
             at_exit_handlers: Vec::new(),
             finalizers: Vec::new(),
+            argv: Value::array_empty(),
+            argf: None,
+            argf_gets: None,
             #[cfg(feature = "profile")]
             deopt_stats: HashMap::default(),
             #[cfg(feature = "profile")]
@@ -598,6 +627,9 @@ impl Globals {
         globals.random_init(None);
         gvar::init_builtin_gvars(&mut globals);
         crate::builtins::init_builtins(&mut globals);
+        // `ARGV` exists from the start — empty until the CLI fills it
+        // in — and names the same array as `$*` and the ARGF queue.
+        globals.set_argv(globals.argv());
         globals
             .store
             .set_ivar(main_object, IdentId::_NAME, Value::string_from_str("main"))
@@ -1413,6 +1445,23 @@ impl Globals {
                     .insert((func_id, class_id, *reason), 1);
             }
         };
+    }
+}
+
+// Program arguments (`ARGV` / `$*` / the ARGF file queue)
+impl Globals {
+    /// The program-argument array. Both the `ARGV` constant and `$*`
+    /// name this same object, and `ARGF` / `Kernel#gets` shift the file
+    /// names to read off its front.
+    pub fn argv(&self) -> Value {
+        self.argv
+    }
+
+    /// Install the program-argument array, re-pointing the `ARGV`
+    /// constant at it. `$*` needs no update: it reads through a hook.
+    pub fn set_argv(&mut self, argv: Value) {
+        self.argv = argv;
+        self.set_constant_by_str(OBJECT_CLASS, "ARGV", argv);
     }
 }
 

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -730,6 +730,21 @@ pub fn init_builtin_gvars(globals: &mut Globals) {
     }
     globals.define_hooked_variable(IdentId::get_id("$?"), get_last_status, None);
 
+    // `$*` — the program arguments, the very same array as `ARGV`.
+    // Read-only, like CRuby: the array itself is mutable (`$*.shift`),
+    // but the variable cannot be rebound to another object.
+    fn get_argv(_vm: &mut Executor, globals: &mut Globals, _name: IdentId) -> Option<Value> {
+        Some(globals.argv())
+    }
+    globals.define_hooked_variable(IdentId::get_id("$*"), get_argv, None);
+
+    // `$<` — the ARGF object, read-only. The same binding `Kernel#gets`
+    // uses; reassigning the `ARGF` constant does not redirect it.
+    fn get_argf(_vm: &mut Executor, globals: &mut Globals, _name: IdentId) -> Option<Value> {
+        crate::builtins::kernel::argf_object(globals)
+    }
+    globals.define_hooked_variable(IdentId::get_id("$<"), get_argf, None);
+
     globals.define_hooked_variable(IdentId::get_id("$!"), get_errinfo, None);
     globals.define_hooked_variable(
         IdentId::get_id(crate::globals::ERRINFO_INTERNAL_GVAR),

--- a/monoruby/src/main.rs
+++ b/monoruby/src/main.rs
@@ -869,9 +869,11 @@ fn main() {
         }
     }
 
-    let argv = Value::array_from_iter(prog_args.iter().map(|s| Value::string(lossy(s))));
-    globals.set_constant_by_str(OBJECT_CLASS, "ARGV", argv);
-    globals.set_gvar(monoruby::IdentId::get_id("$*"), argv);
+    // Installs the array as `ARGV`; `$*` and the ARGF file queue read
+    // the same object straight off `Globals`.
+    globals.set_argv(Value::array_from_iter(
+        prog_args.iter().map(|s| Value::string(lossy(s))),
+    ));
 
     if opts.ast {
         dump_ast(&code);


### PR DESCRIPTION
## Summary

`Kernel#gets` performed two constant-table lookups per call: fetching the `ARGF` constant to probe for a `gets` override (mspec installs singleton stubs), and fetching `ARGV` inside `shift_argv`. callgrind showed the `Executor::get_constant*` + `IdentId::get_id` chain at ~9% inclusive of a `while gets` loop.

This follows CRuby's design, where both objects live in C globals (`rb_argv`, `argf`) rather than being read back from the constant table:

- **`Globals::argv`** — the program-argument array is now owned by `Globals`. The CLI installs it via `Globals::set_argv`, which also points the `ARGV` constant at it. `ARGV`, `$*`, and the ARGF file queue all name this same object, and `shift_argv` consumes the queue directly off `Globals` with no constant lookup.
- **`$*`** is now a read-only hooked gvar reading the field. Previously it was a plain writable `Simple` entry, so `$* = []` silently succeeded — CRuby raises `NameError: $* is a read-only variable`.
- **`Globals::argf`** — the ARGF object is bound once on first use. The "does ARGF carry a `gets` override?" answer is memoised keyed on the global class version, so the method probe reruns only after a method (re)definition. Matching CRuby, reassigning the `ARGV`/`ARGF` constants no longer redirects `Kernel#gets` (verified identical against CRuby 4.0.2).
- **`$<`** is now defined (read-only, returns the bound ARGF object). Previously `defined?($<)` was `nil` where CRuby reports `"global-variable"`.

Both objects are marked from `Globals::mark`: after a constant reassignment they are reachable only from these fields.

## Behavior verified against CRuby 4.0.2

```ruby
$* = []                          # NameError: $* is a read-only variable  (was: silently ok)
$< = nil                         # NameError: $< is a read-only variable
defined?($<)                     # "global-variable"                      (was: nil)
$<.equal?(ARGF)                  # true
$*.equal?(ARGV)                  # true
$*.shift                         # mutates ARGV (same object)
Object.const_set(:ARGV, [...])   # does NOT redirect Kernel#gets (CRuby-identical)
def ARGF.gets; ...; end          # singleton override still intercepts Kernel#gets
class << ARGF; remove_method :gets; end  # falls back to the raw reader again
```

## Performance

`while gets` over a 300k-line / 11 MB file (best of 5):

| | before | after | CRuby 4.0.2 |
|---|---|---|---|
| `while gets` | 0.18s | 0.16–0.17s | 0.12s |
| `-n -e 'nil'` | — | 0.17s | 0.14s |

callgrind: the `gets` subtree drops from 6.60% → 4.96% inclusive; constant lookups no longer appear in the profile (remaining hot spots are string allocation and malloc/free).

## Tests

- `cargo test --release`: all suites green (2101 lib tests + integration suites, 0 failed)
- ruby/spec `core/argf`: unchanged (31F/46E, all pre-existing stub gaps: `each_byte`/`seek`/`read_nonblock` etc.)
- ruby/spec `language/predefined`: 1 pre-existing unrelated failure (`resolve_feature_path` `.so`), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_