### PR TITLE
gc: make GC.compact a full-GC no-op instead of raising

### DIFF
--- a/monoruby/builtins/gc.rb
+++ b/monoruby/builtins/gc.rb
@@ -45,8 +45,18 @@ module GC
     @auto_compact = flag ? true : false
   end
 
+  # `compact` degrades to a full collection and reports that nothing
+  # moved, in CRuby's return shape (empty per-type tables). It must not
+  # raise: the idiomatic `GC.compact if GC.respond_to?(:compact)` guard
+  # passes here, so the call has to succeed.
   def self.compact
-    raise NotImplementedError, "GC.compact is not supported on this platform"
+    GC.start
+    { considered: {}, moved: {}, moved_up: {}, moved_down: {} }
+  end
+
+  # What the last (non-)compaction did — same shape as `compact`.
+  def self.latest_compact_info
+    { considered: {}, moved: {}, moved_up: {}, moved_down: {} }
   end
 
   # --- GC.config ----------------------------------------------------------

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -488,6 +488,16 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn gc_compact_is_a_full_gc_noop() {
+        // The `GC.compact if GC.respond_to?(:compact)` guard idiom must
+        // run the call, and the return keeps CRuby's shape (per-type
+        // tables, empty here because nothing ever moves).
+        run_test_once(r#"(GC.compact if GC.respond_to?(:compact)).class.to_s"#);
+        run_test_once(r#"GC.compact.keys"#);
+        run_test_once(r#"GC.latest_compact_info.keys"#);
+    }
+
+    #[test]
     fn gc_stat() {
         run_test("GC.stat.class");
         run_test("GC.stat.is_a?(Hash)");


### PR DESCRIPTION
## Summary

`GC.compact` raised `NotImplementedError`, which breaks the idiomatic guard

```ruby
GC.compact if GC.respond_to?(:compact)
```

— `respond_to?` answers `true`, so the guarded call must succeed. This crashed [khasinski/doom](https://github.com/khasinski/doom)'s `bench/benchmark.rb` on monoruby (found while benchmarking the DOOM renderer: monoruby 5.1 ms/frame vs CRuby 4.0.2+YJIT 11.1 ms/frame, framebuffer output pixel-identical).

## Change

The collector never moves objects, so `compact` now degrades to a **full collection** and reports that nothing moved, in CRuby's return shape (`{considered:, moved:, moved_up:, moved_down:}` with empty per-type tables). `GC.latest_compact_info` is added with the same shape. This matches the existing treatment of `GC.auto_compact` (round-trips a stored flag instead of erroring).

## Tests

- `run_test_once` comparisons against CRuby: the guard idiom returns a `Hash` in both, and `GC.compact.keys` / `GC.latest_compact_info.keys` agree (`[:considered, :moved, :moved_up, :moved_down]`)
- The unpatched upstream doom benchmark now runs to completion on monoruby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_