### PR TITLE
integer: implement #upto/#downto in pure Ruby — 5× faster short spans, allocation-free

### DIFF
--- a/monoruby/builtins/integer.rb
+++ b/monoruby/builtins/integer.rb
@@ -27,23 +27,33 @@ class Integer
     self
   end
 
-  alias __upto upto
-  alias __downto downto
-
-  def upto(limit, &block)
-    if block
-      __upto(limit, &block)
-    else
-      to_enum(:__upto, limit) { self <= limit ? limit - self + 1 : 0 }
+  # Pure Ruby, like #times above: the JIT compiles the while loop per
+  # call site with the yield lowered to a near-direct block call, which
+  # beats a native loop crossing the Rust->block invoker boundary every
+  # iteration for the common short spans (and allocates nothing — a
+  # `&block` parameter would materialize a Proc per call).
+  def upto(limit)
+    unless block_given?
+      return to_enum(:upto, limit) { self <= limit ? limit - self + 1 : 0 }
     end
+    i = self
+    while i <= limit
+      yield i
+      i += 1
+    end
+    self
   end
 
-  def downto(limit, &block)
-    if block
-      __downto(limit, &block)
-    else
-      to_enum(:__downto, limit) { self >= limit ? self - limit + 1 : 0 }
+  def downto(limit)
+    unless block_given?
+      return to_enum(:downto, limit) { self >= limit ? self - limit + 1 : 0 }
     end
+    i = self
+    while i >= limit
+      yield i
+      i -= 1
+    end
+    self
   end
 
   def negative?

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -21,8 +21,6 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         inline_gen2!(integer_succ),
         0,
     );
-    globals.define_builtin_func(INTEGER_CLASS, "upto", upto, 1);
-    globals.define_builtin_func(INTEGER_CLASS, "downto", downto, 1);
     globals.define_builtin_inline_func(INTEGER_CLASS, "to_f", to_f, inline_gen2!(integer_tof), 0);
     globals.define_basic_op(INTEGER_CLASS, "+", add, 1);
     globals.define_basic_op(INTEGER_CLASS, "-", sub, 1);
@@ -88,150 +86,6 @@ pub(super) fn init(globals: &mut Globals, numeric: Module) {
         &["half"],
         false,
     );
-}
-
-struct PosStep {
-    cur: i64,
-    limit: i64,
-    step: i64, // must be > 0
-}
-
-impl Iterator for PosStep {
-    type Item = Value;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.cur > self.limit {
-            None
-        } else {
-            let v = Value::integer(self.cur);
-            self.cur += self.step;
-            Some(v)
-        }
-    }
-}
-
-struct NegStep {
-    cur: i64,
-    limit: i64,
-    step: i64, // must be < 0
-}
-
-impl Iterator for NegStep {
-    type Item = Value;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.limit > self.cur {
-            None
-        } else {
-            let v = Value::integer(self.cur);
-            self.cur += self.step;
-            Some(v)
-        }
-    }
-}
-
-///
-/// ### Integer#upto
-///
-/// - upto(max) {|n| ... } -> Integer
-/// - upto(max) -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/upto.html]
-#[monoruby_builtin]
-fn upto(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    let cur = lfp.self_val().expect_integer(globals)?;
-    let limit = if let Some(f) = lfp.arg(0).try_float() {
-        if f.is_nan() {
-            return Ok(lfp.self_val());
-        }
-        f.floor() as i64
-    } else {
-        match lfp.arg(0).coerce_to_int_i64(vm, globals) {
-            Ok(v) => v,
-            Err(_) => return Err(MonorubyErr::argumenterr(format!("bad value for range"))),
-        }
-    };
-    let bh = match lfp.block() {
-        None => {
-            let id = IdentId::get_id("upto");
-            // Size hint: `stop - start + 1` if `stop >= start`, else 0.
-            let size = if limit >= cur {
-                Value::integer(limit - cur + 1)
-            } else {
-                Value::integer(0)
-            };
-            return vm.generate_enumerator_with_size(
-                id,
-                lfp.self_val(),
-                lfp.iter().collect(),
-                pc,
-                Some(size),
-            );
-        }
-        Some(block) => block,
-    };
-    if cur > limit {
-        return Ok(lfp.self_val());
-    }
-
-    let iter = PosStep {
-        cur,
-        limit,
-        step: 1,
-    };
-    vm.invoke_block_iter1(globals, bh, iter)?;
-    Ok(lfp.self_val())
-}
-
-///
-/// ### Integer#downto
-///
-/// - downto(min) {|n| ... } -> self
-/// - downto(min) -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Integer/i/downto.html]
-#[monoruby_builtin]
-fn downto(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    let cur = lfp.self_val().expect_integer(globals)?;
-    let limit = if let Some(f) = lfp.arg(0).try_float() {
-        if f.is_nan() {
-            return Ok(lfp.self_val());
-        }
-        f.ceil() as i64
-    } else {
-        match lfp.arg(0).coerce_to_int_i64(vm, globals) {
-            Ok(v) => v,
-            Err(_) => return Err(MonorubyErr::argumenterr(format!("bad value for range"))),
-        }
-    };
-    let bh = match lfp.block() {
-        None => {
-            let id = IdentId::get_id("downto");
-            // Size hint: `start - stop + 1` if `start >= stop`, else 0.
-            let size = if cur >= limit {
-                Value::integer(cur - limit + 1)
-            } else {
-                Value::integer(0)
-            };
-            return vm.generate_enumerator_with_size(
-                id,
-                lfp.self_val(),
-                lfp.iter().collect(),
-                pc,
-                Some(size),
-            );
-        }
-        Some(block) => block,
-    };
-    if cur < limit {
-        return Ok(lfp.self_val());
-    }
-
-    let iter = NegStep {
-        cur,
-        limit,
-        step: -1,
-    };
-    vm.invoke_block_iter1(globals, bh, iter)?;
-    Ok(lfp.self_val())
 }
 
 /// ### Integer#chr
@@ -2854,6 +2708,49 @@ mod tests {
     #[test]
     fn try_convert_error_message() {
         run_test_error(r#"class C; def to_int; "str"; end; end; Integer.try_convert(C.new)"#);
+    }
+
+    #[test]
+    fn upto_downto_pure_ruby_semantics() {
+        // The pure-Ruby implementation must keep every edge CRuby has:
+        // Float limits, empty spans, self return, comparison failures
+        // (message included), enumerator size behaviour, the
+        // Fixnum->Bignum crossing, and allocation-free block calls.
+        run_test_once(
+            r#"
+            r = []
+            r << 1.upto(3).to_a
+            r << 5.downto(3).to_a
+            r << 1.upto(2.5).to_a
+            r << 5.downto(2.5).to_a
+            r << 3.upto(1).to_a
+            r << 1.downto(3).to_a
+            r << (1.upto(3) { }).equal?(1)
+            r << (5.downto(3) { }).equal?(5)
+            r << (begin; 1.upto("x") { }; rescue ArgumentError => e; e.message; end)
+            r << (begin; 1.downto("x") { }; rescue ArgumentError => e; e.message; end)
+            r << 1.upto(5).size
+            r << 5.downto(1).size
+            r << 1.upto(3).inspect.include?("upto")
+            big = 2**62
+            r << (big - 1).upto(big + 1).to_a.size
+            r << (big + 1).downto(big - 1).to_a.size
+            r << 1.upto(3).each_slice(2).to_a
+            r
+            "#,
+        );
+        // A short span with a block allocates nothing (the old wrapper
+        // materialized one Proc per call through its `&block`).
+        run_test_no_result_check(
+            r#"
+            3.upto(9) { }   # warm caches
+            before = GC.stat[:total_allocated_objects]
+            1000.times { 3.upto(9) { } }
+            allocs = GC.stat[:total_allocated_objects] - before
+            raise "upto allocates: #{allocs}" if allocs > 50
+            :ok
+            "#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Integer#upto`/`#downto` were three layers: a Rust builtin (`PosStep`/`NegStep` native loops), an `alias __upto upto` saving it, and a Ruby wrapper taking `&block` — which **materialized one Proc per call** (10,001 allocations per 10,000 calls; found while profiling [khasinski/doom](https://github.com/khasinski/doom), whose renderer calls `upto` inside per-column loops).

This replaces all three with a single pure-Ruby `while`/`yield` implementation — the same shape `Integer#times` already uses.

## Measurements (release build)

| | before | after |
|---|---|---|
| `3.upto(9) { }` × 3M calls | 1.7 M calls/s | **9.3 M calls/s (5.4×)** |
| same, Rust loop called directly (no wrapper) | 6.0 M calls/s | — |
| CRuby 4.0.2 + YJIT reference | 2.9 M calls/s | — |
| allocations / 10,000 calls | 10,001 | **2** |
| `1.upto(30_000_000)` iteration rate | 70 M iters/s | 23 M iters/s |

The pure-Ruby version beats even the direct Rust loop on short spans because the JIT compiles the method per call site with the `yield` lowered close to a direct block call, while a native loop crosses the Rust→block-invoker boundary every iteration. Long spans are the one regression (crossover ≈ 17 iterations); real long-distance loops are written as `while`/`times`, and short spans dominate real code.

Bonus fix: `1.upto(3).inspect` no longer leaks the internal name (was `#<Enumerator: 1:__upto(3)>`, now `1:upto(3)` like CRuby).

## Semantics

Pinned against CRuby 4.0.2 in a new cargo test: Float limits (`1.upto(2.5)` → `[1, 2]`), empty spans, `self` return, `ArgumentError` message on incomparable limits, `Enumerator#size` raising for bad limits, the Fixnum→Bignum crossing, `each_slice` composition, plus an allocation-free regression check.

## Tests

- `cargo test --release`: all suites green (existing `upto_with_float` / `downto_upto_bad_arg` / `upto_downto_non_numeric_size` tests pass unchanged)
- ruby/spec `core/integer`: 598 examples, **0 failures, 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_