### PR TITLE
jit: direct-copy argument path for simple generic yield sites (+50% on cold-caller iterator loops)

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -1203,6 +1203,7 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_yield(
         &mut self,
         callid: CallSiteId,
+        simple: bool,
         error: &DestLabel,
         evict: AsmEvict,
         evict_label: &DestLabel,
@@ -1213,7 +1214,11 @@ impl Codegen {
         // continuation frame is already reserved by the surrounding
         // fpr_save_cont, so no extra push here.
         let f_yield = runtime::get_yield_data as *const () as u64;
-        let f_args = runtime::jit_handle_arguments_no_block as *const () as u64;
+        let f_args = if simple {
+            runtime::jit_handle_arguments_no_block_for_yield as *const () as u64
+        } else {
+            runtime::jit_handle_arguments_no_block as *const () as u64
+        };
         // get_yield_data(vm, globals) -> x0 = outer Lfp, x1 = FuncId.
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -121,7 +121,12 @@ impl Codegen {
     /// - caller save registers
     /// - r15
     ///
-    pub(super) fn gen_yield(&mut self, callid: CallSiteId, error: &DestLabel) -> CodePtr {
+    pub(super) fn gen_yield(
+        &mut self,
+        callid: CallSiteId,
+        simple: bool,
+        error: &DestLabel,
+    ) -> CodePtr {
         self.get_proc_data();
         self.handle_error(&error);
         // rax <- outer, rdx <- FuncId
@@ -145,7 +150,11 @@ impl Codegen {
         monoasm! { &mut self.jit,
             movl r8, (callid.get()); // CallSiteId
         }
-        self.generic_handle_arguments(runtime::jit_handle_arguments_no_block);
+        self.generic_handle_arguments(if simple {
+            runtime::jit_handle_arguments_no_block_for_yield
+        } else {
+            runtime::jit_handle_arguments_no_block
+        });
         self.handle_error(error);
         self.call_funcdata()
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2232,11 +2232,12 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_yield(
         &mut self,
         callid: CallSiteId,
+        simple: bool,
         error: &DestLabel,
         evict: AsmEvict,
         evict_label: &DestLabel,
     ) -> bool {
-        let return_addr = self.gen_yield(callid, error);
+        let return_addr = self.gen_yield(callid, simple, error);
         self.set_deopt_with_return_addr(return_addr, evict, evict_label);
         true
     }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1576,6 +1576,9 @@ pub(super) enum AsmInst {
     },
     Yield {
         callid: CallSiteId,
+        /// Statically simple call site: plain positional args, so the
+        /// runtime argument transfer takes the direct-copy path.
+        simple: bool,
         error: AsmError,
         evict: AsmEvict,
     },

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -960,11 +960,12 @@ impl Codegen {
             // Generic `yield` (block target resolved at runtime). aarch64 builds
             // the block frame and calls the funcdata indirectly; the x86-only
             // return-address eviction patch is applied by the x86 emit_yield.
-            AsmInst::Yield { callid, error, evict } => {
+            AsmInst::Yield { callid, simple, error, evict } => {
                 let evict_label = labels[evict].clone();
                 let error = labels[error].clone();
                 self.encode_linst(LInst::Yield {
                     callid,
+                    simple,
                     error,
                     evict,
                     evict_label,
@@ -1451,8 +1452,8 @@ impl Codegen {
             LInst::EnsureEnd { loop_jit_spill_bytes } => {
                 self.emit_ensure_end(loop_jit_spill_bytes);
             }
-            LInst::Yield { callid, error, evict, evict_label } => {
-                self.emit_yield(callid, &error, evict, &evict_label);
+            LInst::Yield { callid, simple, error, evict, evict_label } => {
+                self.emit_yield(callid, simple, &error, evict, &evict_label);
             }
             LInst::Unreachable => {
                 self.emit_unreachable();

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1105,8 +1105,19 @@ impl AbstractState {
         ir.push(AsmInst::ContFramePc {
             call_site_pc: self.pc().as_ptr() as u64,
         });
+        // A statically simple call site (plain positional arguments) can
+        // hand the values to the block via the direct-copy path; the
+        // callee side stays dynamic (see
+        // `jit_handle_arguments_no_block_for_yield`).
+        let simple = callinfo.splat_pos.is_empty()
+            && callinfo.kw_args.is_empty()
+            && callinfo.hash_splat_pos.is_empty()
+            && !callinfo.forwarding
+            && callinfo.block_fid.is_none()
+            && callinfo.block_arg.is_none();
         ir.push(AsmInst::Yield {
             callid,
+            simple,
             error,
             evict,
         });

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -914,6 +914,7 @@ pub(in crate::codegen) enum LInst {
     },
     Yield {
         callid: CallSiteId,
+        simple: bool,
         error: DestLabel,
         evict: AsmEvict,
         evict_label: DestLabel,

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1202,6 +1202,52 @@ pub(super) extern "C" fn jit_handle_arguments_no_block(
     }
 }
 
+/// Argument transfer for a *simple* generic `yield` site (no splat, no
+/// keywords, no block argument — checked statically at JIT compile
+/// time): the positional values sit contiguously at the call site's
+/// argument slots, so they go through the direct `positional_simple`
+/// copy instead of the generic `CallSiteInfo` re-interpretation. The
+/// callee side stays fully dynamic — `positional_simple` /
+/// `fill_positional_args` handle block-style loose binding (nil-fill,
+/// dropped extras, single-Array auto-splat) and keyword defaults for
+/// whatever block turns up at runtime.
+pub(super) extern "C" fn jit_handle_arguments_no_block_for_yield(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    caller_lfp: Lfp,
+    callee_lfp: Lfp,
+    callid: CallSiteId,
+) -> Option<Value> {
+    let (args_slot, pos_num) = {
+        let cs = &globals.store[callid];
+        (cs.args, cs.pos_num)
+    };
+    let src = caller_lfp.register_ptr(args_slot) as *const Value;
+    // Exact-arity fixed-parameter callee (the overwhelmingly common
+    // `N.times { |i| … }` shape): a straight slot copy. `is_simple`
+    // excludes optional/rest/keyword/block params, so nothing needs
+    // nil-filling, expanding or dropping; single-Array auto-splat only
+    // applies when the block wants more values than it got, which the
+    // equality rules out.
+    let callee_fid = callee_lfp.func_id();
+    let info = &globals.store[callee_fid];
+    if info.meta().is_simple() && info.req_num() == pos_num {
+        let dst = callee_lfp.register_ptr(SlotId(1)) as *mut Option<Value>;
+        for i in 0..pos_num {
+            unsafe { *dst.sub(i) = Some(*src.sub(i)) };
+        }
+        return Some(Value::nil());
+    }
+    match set_frame_arguments_simple(vm, globals, callee_lfp, caller_lfp, callid, src, pos_num) {
+        Ok(_) => Some(Value::nil()),
+        Err(mut err) => {
+            err.push_internal_trace(callee_lfp.func_id());
+            vm.set_error(err);
+            None
+        }
+    }
+}
+
 pub(super) extern "C" fn jit_handle_arguments_no_block_for_send(
     vm: &mut Executor,
     globals: &mut Globals,

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -1914,3 +1914,43 @@ mod tests {
         run_test(r#"def m(a:); a; end; m(a: 5)"#);
     }
 }
+#[cfg(test)]
+mod fast_yield_tests {
+    use crate::tests::*;
+
+    #[test]
+    fn simple_yield_argument_shapes() {
+        // The simple-yield direct-copy path (jit_handle_arguments_no_
+        // block_for_yield) must agree with the generic path on every
+        // block binding rule. Each case iterates enough for the JIT to
+        // compile the yielding loop, and run_test compares the final
+        // values against CRuby.
+        run_tests(&[
+            // exact arity — the direct-copy fast path
+            r#"def a; s = 0; 200.times { |i| yield i }; s; end
+               acc = []; a { |x| acc << x }; [acc.size, acc.first, acc.last]"#,
+            // fewer args than params: nil-fill (loose block binding)
+            r#"acc = nil; def b; 100.times { yield 7 }; end
+               b { |x, y| acc = [x, y] }; acc"#,
+            // more args than params: extras dropped
+            r#"acc = nil; def c; 100.times { yield 1, 2, 3 }; end
+               c { |x, y| acc = [x, y] }; acc"#,
+            // single-Array auto-splat into a multi-param block
+            r#"acc = nil; def d; 100.times { yield [4, 5] }; end
+               d { |x, y| acc = [x, y] }; acc"#,
+            // single-param block keeps a passed Array whole
+            r#"acc = nil; def e; 100.times { yield [4, 5] }; end
+               e { |x| acc = x }; acc"#,
+            // optional / rest / keyword blocks stay on the flexible path
+            r#"acc = nil; def f; 100.times { yield 1 }; end
+               f { |x, y = 9| acc = [x, y] }; acc"#,
+            r#"acc = nil; def g; 100.times { yield 1, 2, 3 }; end
+               g { |x, *r| acc = [x, r] }; acc"#,
+            r#"acc = nil; def h; 100.times { yield 1 }; end
+               h { |x, k: 5| acc = [x, k] }; acc"#,
+            // zero-arg yield into a param-less block
+            r#"n = 0; def z; 300.times { yield }; end
+               z { n += 1 }; n"#,
+        ]);
+    }
+}

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -219,7 +219,7 @@ impl Meta {
     ///
     /// "simple" means that the function has no optional, rest, keyword, keyword rest, and block parameters.
     ///
-    fn is_simple(&self) -> bool {
+    pub(crate) fn is_simple(&self) -> bool {
         (self.kind & 0b1_0000) != 0
     }
 


### PR DESCRIPTION
## Summary

A generic `yield` (standalone / loop-JIT compilation, where the block target is resolved at runtime and per-call-site specialization can't apply) routed **every iteration** through the fully generic argument machinery: `set_frame_arguments` re-interpreting the `CallSiteInfo` (splat scan, keyword machinery), terminating in the ~100-instruction `fill_positional_args` — ~250 instructions per yield for a plain `|i|` block (callgrind, 5M-iteration `Integer#times`).

The **call-site side is static**, so this exploits it without assuming anything about the block's identity (per the discussion: block identity varies per call site, so no block-FuncId guards):

- `compile_yield` records a `simple` flag (no splat / keywords / hash-splat / block argument / forwarding), threaded through `AsmInst::Yield` → `LInst::Yield` to **both backends** (x86_64 / aarch64)
- a new runtime handler `jit_handle_arguments_no_block_for_yield` then selects per call:
  - **exact-arity fixed-parameter callee** (`Meta` `is_simple` bit + `req_num == pos_num` — the `N.times { |i| }` shape): a straight slot copy. Auto-splat can't apply, since it only triggers when the block wants more values than it got.
  - **anything else**: `set_frame_arguments_simple`, whose `positional_simple` / `fill_positional_args` terminal already implements the full block loose-binding rules (nil-fill, dropped extras, single-Array auto-splat, keyword defaults) for whatever block turns up.

## Measurements (A/B against master `58a1427`, same machine)

| | master | this PR |
|---|---|---|
| `30_000_000.times { \|i\| }` | 23.3 M iters/s | **35.0 M iters/s (+50%)** |
| `1.upto(30_000_000) { \|i\| }` | 22.7 M iters/s | **34.6 M iters/s (+52%)** |
| doom renderer (avg ms/frame) | 6.66–7.68 | 6.66–6.98 (noise) |

callgrind: the `set_frame_arguments` → `set_callee_frame_arguments` → `fill_positional_args` chain drops from ~250 instructions/yield to a ~30-instruction copy on the fast path. Hot-caller sites keep taking the existing specialized-yield inlining and are unaffected. The remaining per-yield cost is `get_yield_data` (block re-resolution, ~110 instructions) — hoisting it as a loop-invariant is noted as future work.

## Tests

- New cargo test drives **every block-binding rule** through JIT-compiled yielding loops, compared against CRuby 4.0.2: exact arity, nil-fill (fewer args), dropped extras, single-Array auto-splat, whole-Array to a single param, optional/rest/keyword blocks, zero-arg yield
- `cargo test --release`: all suites green
- ruby/spec `language` / `core/enumerable` / `core/array` / `core/integer` / `core/kernel`: failure counts identical to master (no regressions; core/integer 0F/0E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_