### PR TITLE
jit: elide the Array allocation in [a, b].min / .max (3.1× microbench, ~18% on doom)

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) mod argf;
 mod arithmetic_sequence;
-mod array;
+pub(crate) mod array;
 mod binding;
 mod bool_class;
 mod class;

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2415,7 +2415,7 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/min.html]
 #[monoruby_builtin]
-fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+pub(crate) fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
     if ary.len() == 0 {
         return Ok(Value::nil());
@@ -2455,7 +2455,7 @@ fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/max.html]
 #[monoruby_builtin]
-fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+pub(crate) fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ary = lfp.self_val().as_array();
     if ary.len() == 0 {
         return Ok(Value::nil());
@@ -5088,6 +5088,73 @@ mod tests {
             r##"[[].sum, [].sum(0.0), [1, 2, 3].sum, [3, 5.5].sum, [2.5, 3.0].sum(0.0) {|e| e * e }, ["a", "b", "c"].sum("")]"##,
         );
         run_test_error("[Object.new].sum");
+    }
+
+    #[test]
+    fn array_literal_minmax_fusion() {
+        // The JIT fuses `[a, b].min`/`.max` into an allocation-free
+        // compare (see `try_fuse_array_minmax`); these run hot loops so
+        // the fused code path is what's being compared against CRuby.
+        run_test(
+            r#"
+            a, b, c = 3, 9, 5
+            f, g = 1.5, -2.5
+            s1, s2 = "abc", "abd"
+            r = nil
+            100.times do
+              r = [
+                [a, b].min, [b, a].min, [a, b].max, [b, a].max,
+                [a].min, [].min, [].max,
+                [f, g].min, [f, g].max, [a, f].min, [a, f].max,
+                [s1, s2].min, [s1, s2].max,
+                [a, b, c].min, [a, b, c].max,
+                [1.0, 1].min.class.to_s, [1, 1.0].max.class.to_s,
+              ]
+            end
+            r
+            "#,
+        );
+        // Incomparable elements raise; the error must fire from the
+        // fused path too.
+        run_test(
+            r#"
+            r = nil
+            100.times do
+              begin
+                [1, "x"].min
+              rescue ArgumentError
+                r = :raised
+              end
+            end
+            r
+            "#,
+        );
+        // Non-fusable shapes keep the normal builtin: a named receiver,
+        // a block, a splat.
+        run_test(
+            r#"
+            a, b = 3, 9
+            x = [b, a]
+            r = nil
+            100.times do
+              r = [x.min, x.max, [a, b].min { |p, q| q <=> p }, [*x, 1].min]
+            end
+            r
+            "#,
+        );
+        // Redefinition takes effect (class-version deopt).
+        run_test_once(
+            r#"
+            a, b = 3, 9
+            r = []
+            50.times { r << [a, b].min }
+            class Array
+              def min = :redefined
+            end
+            50.times { r << [a, b].min }
+            [r.first, r.last]
+            "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1618,6 +1618,40 @@ impl Codegen {
     }
 
     /// rax <- Hash literal via gen_hash(vm, globals, &slot[args], len).
+    /// x0 <- min/max of the `len` values at `args`, computed in place —
+    /// the fused, allocation-free `[a, b, …].min` / `.max`. Same call
+    /// shape as `emit_new_hash`.
+    pub(in crate::codegen::jitgen) fn emit_array_min_max(
+        &mut self,
+        args: SlotId,
+        len: u16,
+        min: bool,
+        using_fpr: UsingFpr,
+    ) -> bool {
+        let lfp = GP::R14.a64().0;
+        let off = args.0 as u32 * 8 + LFP_SELF as u32;
+        let f = if min {
+            runtime::opt_array_min as *const () as u64
+        } else {
+            runtime::opt_array_max as *const () as u64
+        };
+        self.emit_fpr_save(using_fpr, false);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;              // vm
+            mov x1, x20;              // globals
+        );
+        self.a64_addr_sub(2, lfp, off); // x2 = &slot[args]
+        monoasm_arm64!(&mut self.jit,
+            mov x3, (len as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.emit_fpr_restore(using_fpr, false);
+        true
+    }
+
     pub(in crate::codegen::jitgen) fn emit_new_hash(
         &mut self,
         args: SlotId,

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -68,6 +68,7 @@ impl Codegen {
             | AsmInst::StoreDynVar { .. }
             | AsmInst::CreateArray { .. }
             | AsmInst::NewArray { .. }
+            | AsmInst::ArrayMinMax { .. }
             | AsmInst::NewHash(..)
             | AsmInst::HashInsert { .. }
             | AsmInst::ArrayConcat { .. }
@@ -1126,6 +1127,33 @@ impl Codegen {
         using_fpr: UsingFpr,
     ) -> bool {
         self.new_hash(args, len, using_fpr);
+        true
+    }
+
+    /// rax <- min/max of the `len` values at `args`, computed in place —
+    /// the fused, allocation-free `[a, b, …].min` / `.max`.
+    pub(in crate::codegen::jitgen) fn emit_array_min_max(
+        &mut self,
+        args: SlotId,
+        len: u16,
+        min: bool,
+        using_fpr: UsingFpr,
+    ) -> bool {
+        let f = if min {
+            runtime::opt_array_min as usize
+        } else {
+            runtime::opt_array_max as usize
+        };
+        self.fpr_save(using_fpr);
+        monoasm!( &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            lea  rdx, [rbp - (rbp_local(args))];
+            movq rcx, (len as usize);
+            movq rax, (f);
+            call rax;
+        );
+        self.fpr_restore(using_fpr);
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -929,6 +929,15 @@ impl AsmIr {
         });
     }
 
+    pub(super) fn array_min_max(&mut self, using_fpr: UsingFpr, args: SlotId, len: u16, min: bool) {
+        self.push(AsmInst::ArrayMinMax {
+            args,
+            len,
+            min,
+            using_fpr,
+        });
+    }
+
     pub(super) fn new_hash(&mut self, using_fpr: UsingFpr, args: SlotId, len: usize) {
         self.push(AsmInst::NewHash(args, len, using_fpr));
     }
@@ -1907,6 +1916,14 @@ pub(super) enum AsmInst {
     ///
     /// - caller save registers
     ///
+    /// `[a, b, …].min` / `.max` fused: compare the literal's elements in
+    /// their slots, no Array allocated. See `try_fuse_array_minmax`.
+    ArrayMinMax {
+        args: SlotId,
+        len: u16,
+        min: bool,
+        using_fpr: UsingFpr,
+    },
     NewArray {
         callid: CallSiteId,
         /// `Some((args, len))` when the literal has no splat and `1 <= len <=

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -201,6 +201,9 @@ impl Codegen {
                 inline,
                 using_fpr,
             }),
+            AsmInst::ArrayMinMax { args, len, min, using_fpr } => {
+                self.encode_linst(LInst::ArrayMinMax { args, len, min, using_fpr })
+            }
             AsmInst::NewHash(args, len, using_fpr) => {
                 self.encode_linst(LInst::NewHash { args, len, using_fpr })
             }
@@ -1313,6 +1316,9 @@ impl Codegen {
                 using_fpr,
             } => {
                 self.emit_new_array(callid, inline, using_fpr);
+            }
+            LInst::ArrayMinMax { args, len, min, using_fpr } => {
+                self.emit_array_min_max(args, len, min, using_fpr);
             }
             LInst::NewHash { args, len, using_fpr } => {
                 self.emit_new_hash(args, len, using_fpr);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -157,6 +157,105 @@ impl<'a> JitContext<'a> {
         self.new_continue(end, next_bbid, state);
     }
 
+    /// CRuby's `opt_newarray_send` for min/max: fuse
+    /// `dst = [a, b, …]; res = dst.min` (an Array literal immediately
+    /// consumed by an argument-less, block-less `min`/`max` on a
+    /// temporary) into a single allocation-free compare over the
+    /// literal's element slots. Conditions:
+    ///
+    /// * the very next instruction (same basic block) is the consuming
+    ///   call, its receiver is this literal, and the literal lands in a
+    ///   temporary slot (a local could be re-read later);
+    /// * the literal has no splat;
+    /// * `Array#min` / `#max` still resolve to the builtins — anything
+    ///   else (including later redefinition, which bumps the guarded
+    ///   class version and deopts) takes the normal path.
+    ///
+    /// On success the consuming call's work is emitted here and the
+    /// call instruction itself is skipped via `fused_skip`.
+    fn try_fuse_array_minmax(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        bc_pos: BcIndex,
+        arr_dst: SlotId,
+        callid: CallSiteId,
+    ) -> bool {
+        let cs = &self.store[callid];
+        if !cs.splat_pos.is_empty() {
+            return false;
+        }
+        let (args, len) = (cs.args, cs.pos_num as u16);
+        // The literal must land in a temporary.
+        if (arr_dst.0 as usize) <= self.iseq().local_num() {
+            return false;
+        }
+        // The consuming call must be the next instruction of the same
+        // basic block.
+        let next_pos = bc_pos + 1;
+        if self.iseq().bb_info.is_bb_head(next_pos).is_some() {
+            return false;
+        }
+        let next_pc = self.get_pc(next_pos);
+        let TraceIr::MethodCall { callid: mcid, .. } = TraceIr::from_pc(next_pc, self.store)
+        else {
+            return false;
+        };
+        let mcs = &self.store[mcid];
+        let min_id = IdentId::get_id("min");
+        let max_id = IdentId::get_id("max");
+        let is_min = match mcs.name {
+            Some(name) if name == min_id => true,
+            Some(name) if name == max_id => false,
+            _ => return false,
+        };
+        if mcs.recv != arr_dst
+            || mcs.pos_num != 0
+            || !mcs.kw_args.is_empty()
+            || !mcs.hash_splat_pos.is_empty()
+            || mcs.block_fid.is_some()
+            || mcs.block_arg.is_some()
+        {
+            return false;
+        }
+        let call_dst = mcs.dst;
+        // `Array#min` / `#max` must still be the builtins.
+        let expected = if is_min {
+            crate::builtins::array::min as usize as u64
+        } else {
+            crate::builtins::array::max as usize as u64
+        };
+        let Some(fid) = self
+            .store
+            .check_method_for_class_with_version(
+                ARRAY_CLASS,
+                if is_min { min_id } else { max_id },
+                self.class_version(),
+            )
+            .and_then(|e| e.func_id())
+        else {
+            return false;
+        };
+        match self.store[fid].kind {
+            FuncKind::Builtin { abs_address } if abs_address == expected => {}
+            _ => return false,
+        }
+        // Emit: guarded by the class version (redefinition deopts), the
+        // compare can dispatch a user `<=>` (a side effect) and raise.
+        state.write_back_range(ir, args, len);
+        state.discard(call_dst);
+        state.discard(arr_dst);
+        self.guard_class_version(state, ir, true);
+        let using_fpr = state.get_using_fpr(ir);
+        let error = ir.new_error(state);
+        ir.array_min_max(using_fpr, args, len, is_min);
+        ir.handle_error(error);
+        state.def_rax2acc(ir, call_dst);
+        state.unset_side_effect_guard();
+        self.fused_skip = Some(next_pos);
+        true
+    }
+
     fn compile_instruction(
         &mut self,
         ir: &mut AsmIr,
@@ -164,6 +263,12 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         assert!(state.no_capture_guard());
+        // A fusing arm (e.g. `try_fuse_array_minmax`) already emitted this
+        // instruction's work together with its predecessor's.
+        if self.fused_skip == Some(bc_pos) {
+            self.fused_skip = None;
+            return Ok(CompileResult::Continue);
+        }
         let pc = self.get_pc(bc_pos);
         state.set_pc(pc);
         let trace_ir = TraceIr::from_pc(pc, self.store);
@@ -251,6 +356,9 @@ impl<'a> JitContext<'a> {
                 state.def_reg2acc_concrete_value(ir, GP::Rax, dst, val);
             }
             TraceIr::Array { dst, callid } => {
+                if self.try_fuse_array_minmax(state, ir, bc_pos, dst, callid) {
+                    return Ok(CompileResult::Continue);
+                }
                 let CallSiteInfo { args, pos_num, .. } = self.store[callid];
                 state.write_back_range(ir, args, pos_num as u16);
                 state.discard(dst);

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -621,6 +621,10 @@ impl JitStackFrame {
 pub(crate) struct JitContext<'a> {
     pub store: &'a Store,
     codegen_mode: bool,
+    /// Set by an instruction-fusing arm (`try_fuse_array_minmax`): the
+    /// bytecode position whose work was already emitted by its
+    /// predecessor, to be skipped by `compile_instruction`.
+    pub(super) fused_skip: Option<BcIndex>,
 
     ///
     /// Class version at compile time.
@@ -670,6 +674,7 @@ impl<'a> JitContext<'a> {
         Self {
             store,
             codegen_mode,
+            fused_skip: None,
             class_version,
             const_version,
             inline_method_cache: vec![],
@@ -685,6 +690,7 @@ impl<'a> JitContext<'a> {
         Self {
             store: self.store,
             codegen_mode: false,
+            fused_skip: None,
             class_version: self.class_version,
             const_version: self.const_version,
             inline_method_cache: vec![],

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -697,6 +697,12 @@ pub(in crate::codegen) enum LInst {
         inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     },
+    ArrayMinMax {
+        args: SlotId,
+        len: u16,
+        min: bool,
+        using_fpr: UsingFpr,
+    },
     NewHash {
         args: SlotId,
         len: usize,

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -608,6 +608,67 @@ pub(super) extern "C" fn gen_lambda(
     vm.generate_lambda(globals, func_id, pc).into()
 }
 
+/// `[a, b, …].min` / `.max` with the Array allocation elided: compare
+/// the literal's elements right in their stack slots (they descend from
+/// `src`, like `gen_hash`'s). The compare loop mirrors the builtin
+/// `Array#min` / `#max` exactly (`best <=> v`, replace on
+/// Greater/Less, ties keep the earlier element, incomparable pairs
+/// raise through `compare_values`), so the fused JIT path and the VM
+/// builtin are indistinguishable. An empty literal reads as nil.
+fn opt_array_minmax(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: *const Value,
+    len: usize,
+    is_min: bool,
+) -> Option<Value> {
+    if len == 0 {
+        return Some(Value::nil());
+    }
+    let replace_on = if is_min {
+        std::cmp::Ordering::Greater
+    } else {
+        std::cmp::Ordering::Less
+    };
+    let mut best = unsafe { *src };
+    for i in 1..len {
+        let v = unsafe { *src.sub(i) };
+        let ord = if let (Some(a), Some(b)) = (best.try_fixnum(), v.try_fixnum()) {
+            a.cmp(&b)
+        } else {
+            match vm.compare_values(globals, best, v) {
+                Ok(ord) => ord,
+                Err(err) => {
+                    vm.set_error(err);
+                    return None;
+                }
+            }
+        };
+        if ord == replace_on {
+            best = v;
+        }
+    }
+    Some(best)
+}
+
+pub(super) extern "C" fn opt_array_min(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: *const Value,
+    len: usize,
+) -> Option<Value> {
+    opt_array_minmax(vm, globals, src, len, true)
+}
+
+pub(super) extern "C" fn opt_array_max(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    src: *const Value,
+    len: usize,
+) -> Option<Value> {
+    opt_array_minmax(vm, globals, src, len, false)
+}
+
 pub(super) extern "C" fn gen_hash(
     vm: &mut Executor,
     globals: &mut Globals,


### PR DESCRIPTION
## Summary

CRuby's `opt_newarray_send` equivalent for `min`/`max`. An Array literal immediately consumed by an argument-less, block-less `min`/`max` on a temporary slot is fused at JIT compile time into a single **allocation-free compare over the literal's element slots** — no Array, no dynamic dispatch, no `compare_values` chain for Fixnums.

Profiling [khasinski/doom](https://github.com/khasinski/doom) showed this construct dominating monoruby's allocation gap vs CRuby: `[top[x], y1].min`-style clipping in per-column loops made monoruby allocate **20k arrays/frame** (CRuby: 2.7k, eliding via `opt_newarray_send`) and pushed 17k `compare_values` dispatches/frame — together ~8% of frame instructions plus the GC pressure.

## Design

- **`try_fuse_array_minmax`** (jitgen, arch-neutral): peepholes the `Array` instruction's successor within the basic block; the consuming call is then skipped via a `fused_skip` marker on `JitContext`. Fusion requires:
  - the very next instruction is the consuming `MethodCall`, receiver = this literal, and the literal lands in a **temporary** slot (a local could be re-read later);
  - no splat in the literal; no args/kw/block on the call;
  - `Array#min`/`#max` still resolve to the builtins (`FuncKind::Builtin` address compare), under the standard **class-version guard** — redefining `Array#min` deopts (verified by test).
- **Runtime compare loop** (`opt_array_min`/`opt_array_max`): mirrors the builtin `Array#min`/`#max` exactly (`best <=> v`, replace on Greater/Less, ties keep the earlier element, incomparable pairs raise through `compare_values`), plus a Fixnum fast path — so the fused JIT path and the VM builtin are indistinguishable, error messages included.
- **Lowering**: new `AsmInst::ArrayMinMax` follows `NewHash`'s `(vm, globals, src, len)` call shape, emitted on **both x86_64 and aarch64** via the shared LInst dispatcher.

The VM tier is unchanged (allocates as before) — hot loops are jitted, which is where the cost was.

## Measurements

| | before | after | CRuby 4.0.2+YJIT |
|---|---|---|---|
| `[a,b].min` (30M ops) | 32.8 M ops/s | **102.5 M ops/s (3.1×)** | 31.7 |
| `[a,b,c].min` | — | 87.2 M ops/s | 30.6 |
| allocations per call | 1 | **0** | 0 |
| doom renderer (A/B, same machine) | 7.3–8.1 ms/frame | **5.8–6.2 ms/frame (~18%)** | — |

doom framebuffer stays pixel-identical to CRuby on all four test viewpoints.

## Tests

- Hot-loop tests compared against CRuby: int/float/string/mixed elements, 0/1/3-element literals, ties keeping the first element (checked via class), incomparable-pair `ArgumentError` from the fused path
- Non-fusable shapes pinned (named receiver, block form, splat literal)
- **Redefinition test**: `class Array; def min = :redefined; end` mid-run takes effect via class-version deopt
- `cargo test --release`: all suites green; ruby/spec `core/array` / `core/enumerable` / `language`: counts identical to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_