### PR TITLE
hash: ar_table AR-mode + 3-pair small hashes embedded in the RValue cell

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -217,15 +217,18 @@ union Header { next: Option<NonNull<RValue>>, meta: Metadata }
 struct Metadata {          // rvalue.rs:2373
     flag:  u16,
     ty:    Option<ObjTy>,  // 1 バイト
-    _padding: u8,          // JIT の 2 バイト cmpw が隣接バイトを読むため 0 固定
+    ty_flags: u8,          // ObjTy 固有のメタデータ(HASH: 小ハッシュ表現ビット)
     class: Option<ClassId>,
 }
 ```
 
 - フリーリスト上のセルは `next`(次の空きセル)として解釈され、生存セルは `meta`。
-- `_padding` を 0 に固定するのは、JIT が型判定に `cmpw [ty]`(2 バイト)を使い
-  隣接バイトも読むため。したがって**世代別 GC の age は `ty` の隣ではなく
-  `flag` の上位バイトに置く**。
+- `ty_flags` は ObjTy 固有のメタデータバイト。JIT の型判定は両アーキテクチャとも
+  1 バイト読み(x86-64 `cmpb` / aarch64 `ldrb`)なので、隣接バイトが任意の値でも
+  問題ない。HASH オブジェクトはここにインライン表現のビット(hash.rs の
+  `HashFlags`)を置く。dup/リテラルコピー(`Header::newborn` /
+  `CellHeader::NewbornOf`)はこのバイトを保存する。世代別 GC の age は従来どおり
+  `flag` の上位バイトに置く。
 
 ### `flag: u16` のビット割り当て(`rvalue.rs:2447` 以降)
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2490,6 +2490,61 @@ fn keep_if(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 mod tests {
     use crate::tests::*;
 
+    #[test]
+    fn small_hash_linear_scan() {
+        // The ar_table-style fast path (HashContent::linear_lookup):
+        // immediate keys on <=8-entry tables answer by identity scan.
+        // Every rule it must preserve is pinned against CRuby here.
+        run_test_once(
+            r#"
+            r = []
+            h = { 1 => :a, 5 => :b, 9 => :c }
+            r << [h[1], h[9], h[7], h.key?(5), h.key?(7)]
+            h2 = { a: 1, nil => 3, true => 4, false => 5, 1.5 => 6 }
+            r << [h2[:a], h2[nil], h2[true], h2[false], h2[1.5], h2[:zz]]
+            # Fixnum and Float keys never alias (eql? distinguishes)
+            h3 = { 1 => :int, 1.0 => :float }
+            r << [h3[1], h3[1.0]]
+            # default value / default proc fire on a fast-path miss
+            h5 = Hash.new(:dflt); h5[3] = :x
+            r << [h5[3], h5[4]]
+            h6 = Hash.new { |_, k| "miss#{k}" }; h6[1] = :hit
+            r << [h6[1], h6[2]]
+            # compare_by_identity: same-content distinct strings differ
+            s1 = +"key"; s2 = +"key"
+            h7 = {}.compare_by_identity
+            h7[s1] = :one; h7[42] = :int
+            r << [h7[s1], h7[s2], h7[42]]
+            # growth across the boundary keeps hits and order; deletion
+            # back under it re-enables the scan
+            h8 = {}
+            (1..12).each { |i| h8[i] = i * 10 }
+            r << [h8[3], h8[11], h8.keys.first(3)]
+            (6..12).each { |i| h8.delete(i) }
+            r << [h8[3], h8[7], h8.size]
+            # NaN key: identity semantics (same flonum bits hit)
+            n = 0.0 / 0.0
+            h9 = { n => :nan }
+            r << [h9[n], h9[0.0 / 0.0]]
+            r
+            "#,
+        );
+        // Object keys keep the hashed path: #hash must still be
+        // consulted (a custom hash/eql? pair keeps working).
+        run_test_once(
+            r#"
+            class HKey
+              attr_reader :h
+              def initialize(h) = @h = h
+              def hash = @h
+              def eql?(o) = o.is_a?(HKey) && o.h == @h
+            end
+            k1 = HKey.new(42); k2 = HKey.new(42)
+            { k1 => :obj }[k2]
+            "#,
+        );
+    }
+
     /// Serializes ENV-mutating tests in this module. `setenv(3)` and
     /// `unsetenv(3)` are not thread-safe (they manipulate the process-
     /// wide `environ` array), so running ENV tests in parallel can race

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -3769,6 +3769,25 @@ mod tests {
         ]);
     }
 
+    /// `Hash#replace` transfers the compare_by_identity mode in both
+    /// directions — including for small (inline-representation) hashes,
+    /// whose mode bit lives in the header flags byte and must travel
+    /// with the replacement (ruby/spec core/hash/replace_spec.rb).
+    #[test]
+    fn hash_replace_compare_by_identity() {
+        run_tests(&[
+            "h = { a: 1, c: 3 }; \
+             h.replace({ b: 2, d: 4 }.compare_by_identity); \
+             h.compare_by_identity?",
+            "h = { a: 1, c: 3 }.compare_by_identity; \
+             h.replace(b: 2, d: 4); \
+             h.compare_by_identity?",
+            // identity lookups keep working through the transfer
+            "s = +'k'; src = {}.compare_by_identity; src[s] = 1; \
+             h = {}; h.replace(src); [h.compare_by_identity?, h[s], h[+'k']]",
+        ]);
+    }
+
     /// `h.default = x` inside `each` is legal (it does not change the key
     /// set) but forces a small hash out of its inline representation
     /// mid-iteration; the live iteration count must survive the move, so

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -211,9 +211,9 @@ fn initialize(
                 "wrong number of arguments (given 1, expected 0)",
             ));
         }
-        hash.set_defalut_proc(vm.generate_proc(globals, bh, pc)?);
+        hash.set_defalut_proc(vm.generate_proc(globals, bh, pc)?, vm, globals)?;
     } else {
-        hash.set_defalut_value(lfp.try_arg(0).unwrap_or_default());
+        hash.set_defalut_value(lfp.try_arg(0).unwrap_or_default(), vm, globals)?;
     }
     Ok(lfp.self_val())
 }
@@ -504,7 +504,7 @@ fn default_proc_assign(
     let arg = lfp.arg(0);
     if arg.is_nil() {
         let mut hash = lfp.self_val().as_hash();
-        hash.set_defalut_value(Value::nil());
+        hash.set_defalut_value(Value::nil(), vm, globals)?;
         return Ok(Value::nil());
     }
     // Coerce via :to_proc when arg is not already a Proc, mirroring CRuby.
@@ -537,7 +537,7 @@ fn default_proc_assign(
         }
     }
     let mut hash = lfp.self_val().as_hash();
-    hash.set_defalut_proc(proc);
+    hash.set_defalut_proc(proc, vm, globals)?;
     Ok(proc_val)
 }
 
@@ -549,14 +549,16 @@ fn default_proc_assign(
 /// [https://docs.ruby-lang.org/ja/latest/method/Hash/i/default=3d.html]
 #[monoruby_builtin]
 fn default_assign(
-    _: &mut Executor,
+    vm: &mut Executor,
     globals: &mut Globals,
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
     lfp.self_val().ensure_not_frozen(&globals.store)?;
     let default = lfp.arg(0);
-    lfp.self_val().as_hash().set_defalut_value(default);
+    lfp.self_val()
+        .as_hash()
+        .set_defalut_value(default, vm, globals)?;
     Ok(default)
 }
 
@@ -925,7 +927,7 @@ fn clear(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 fn replace(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut self_ = lfp.self_val().as_hash_mut(&globals.store)?;
     let arg = lfp.arg(0).coerce_to_hash(vm, globals)?;
-    self_.replace_inner(arg.inner().clone());
+    self_.replace_inner(arg.inner().clone_inner());
 
     Ok(lfp.self_val())
 }
@@ -966,7 +968,7 @@ fn clone(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     // Use the real class (skipping singleton/iclass) so that singleton
     // methods on the receiver do NOT show up on the clone.
     let class_id = lfp.self_val().real_class(&globals.store).id();
-    let inner = lfp.self_val().as_hashmap_inner().clone();
+    let inner = lfp.self_val().as_hashmap_inner().clone_inner();
     let mut v = Value::hash_from_inner(inner);
     if class_id != HASH_CLASS {
         v.change_class(class_id);
@@ -1812,7 +1814,7 @@ fn env_to_hash(
         }
         return Ok(Value::hash(new_map));
     }
-    let inner = lfp.self_val().as_hashmap_inner().clone();
+    let inner = lfp.self_val().as_hashmap_inner().clone_inner();
     Ok(Value::hash_from_inner(inner))
 }
 
@@ -2492,9 +2494,10 @@ mod tests {
 
     #[test]
     fn small_hash_linear_scan() {
-        // The ar_table-style fast path (HashContent::linear_lookup):
-        // immediate keys on <=8-entry tables answer by identity scan.
-        // Every rule it must preserve is pinned against CRuby here.
+        // The small-hash fast paths (rubymap's AR mode and the inline
+        // 2-pair representation in HashmapInner): immediate keys on small
+        // tables answer by identity scan. Every rule they must preserve
+        // is pinned against CRuby here.
         run_test_once(
             r#"
             r = []
@@ -3758,6 +3761,38 @@ mod tests {
             "h = {a: 1}; \
              begin; h.each { raise 'stop' }; rescue; end; \
              h[:b] = 2; h.keys.sort",
+            // Deep nesting on a small (inline) hash: the depth counter
+            // saturates and un-saturates soundly across many levels.
+            "h = {a: 1}; r = 0; \
+             h.each { h.each { h.each { h.each { h.each { r += 1 } } } } }; \
+             h[:b] = 2; [r, h.keys.sort]",
+        ]);
+    }
+
+    /// `h.default = x` inside `each` is legal (it does not change the key
+    /// set) but forces a small hash out of its inline representation
+    /// mid-iteration; the live iteration count must survive the move, so
+    /// a new-key insert still raises inside the block and mutation is
+    /// allowed again afterwards.
+    #[test]
+    fn hash_default_set_during_iteration() {
+        run_tests(&[
+            "h = {a: 1}; \
+             h.each { h.default = 5 }; \
+             h[:b] = 2; [h[:zz], h.keys.sort]",
+            r##"
+            h = {a: 1}
+            err = nil
+            h.each do
+              h.default = 5
+              begin
+                h[:new_key] = 1
+              rescue RuntimeError => e
+                err = e.message
+              end
+            end
+            [err, h[:miss], h.size]
+            "##,
         ]);
     }
 

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -634,7 +634,7 @@ impl<'a> MarshalReader<'a> {
         self.building.remove(&hash.id());
         if has_default {
             let default = self.read_value(vm, globals)?;
-            map.set_defalut_value(default);
+            map.set_defalut_value(default, vm, globals)?;
         }
         Ok(hash)
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -226,7 +226,7 @@ impl Codegen {
             // `val` must be an Array...
             testq rdx, 0b111;
             jnz  slow;
-            cmpw [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            cmpb [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
             jne  slow;
             // ...of exactly `len` elements. r8 <- its data.
             movq rax, [rdx + (RVALUE_OFFSET_ARY_CAPA)];

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -514,7 +514,7 @@ impl Codegen {
             movq rcx, [rbp - (rbp_local(args))];
             testq rcx, 0b111;
             jnz  exit;
-            cmpw [rcx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            cmpb [rcx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
             jne  exit;
             movq rax, [rcx + (RVALUE_OFFSET_ARY_CAPA)];
             cmpq rax, (ARRAY_INLINE_CAPA);
@@ -725,7 +725,7 @@ impl Codegen {
             movq rcx, [rbp - (rbp_local(rest_slot))];
             testq rcx, 0b111;
             jnz  fallback;
-            cmpw [rcx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            cmpb [rcx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
             jne  fallback;
             // rax = len, rsi = element base (inline vs heap)
             movq rax, [rcx + (RVALUE_OFFSET_ARY_CAPA)];

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2123,7 +2123,7 @@ impl Codegen {
         monoasm! { &mut self.jit,
             testq rdx, 0b111;                                   // immediate?
             jnz  slow;
-            cmpw [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            cmpb [rdx + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
             jne  slow;
             movq rax, [rdx + (RVALUE_OFFSET_ARY_CAPA)];
             cmpq rax, (ARRAY_INLINE_CAPA);

--- a/monoruby/src/codegen/arch/x86_64/guard.rs
+++ b/monoruby/src/codegen/arch/x86_64/guard.rs
@@ -276,7 +276,7 @@ impl Codegen {
         monoasm! { &mut self.jit,
             testq R(r as _), 0b111;
             jnz  label;
-            cmpw [R(r as _) + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            cmpb [R(r as _) + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
             jne  label;
         }
     }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -676,7 +676,7 @@ pub(super) extern "C" fn gen_hash(
     len: usize,
 ) -> Option<Value> {
     match gen_hash_inner(vm, globals, src, len) {
-        Ok(map) => Some(Value::hash(map)),
+        Ok(map) => Some(Value::hash_from_inner(map)),
         Err(err) => {
             vm.set_error(err);
             None
@@ -689,8 +689,11 @@ fn gen_hash_inner(
     globals: &mut Globals,
     src: *const Value,
     len: usize,
-) -> Result<RubyMap<Value, Value>> {
-    let mut map = RubyMap::default();
+) -> Result<crate::value::rvalue::HashmapInner> {
+    // Build the HashmapInner directly (not a RubyMap first) so a small
+    // literal with packed keys lands in the inline representation without
+    // ever touching the heap.
+    let mut map = crate::value::rvalue::HashmapInner::default();
     if len > 0 {
         let mut iter = unsafe { std::slice::from_raw_parts(src.sub(len * 2 - 1), len * 2) }
             .iter()

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -1445,7 +1445,7 @@ fn hash_splat_and_kw_rest(
                 if h.is_nil() {
                     continue;
                 }
-                let mut h = h.as_hashmap_inner().clone();
+                let mut h = h.as_hashmap_inner().clone_inner();
                 for name in kw_names.iter() {
                     let sym = Value::symbol(*name);
                     h.remove(sym, vm, globals)?;

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -494,7 +494,7 @@ impl RubyEql<Executor, Globals, MonorubyErr> for Value {
                                 lhs_id,
                                 rhs_id,
                                 || {
-                                    let r = lhs.as_hashmap().eql(rhs.as_hashmap(), vm, globals)?;
+                                    let r = lhs.as_hashmap().eql(&rhs.as_hashmap(), vm, globals)?;
                                     Ok(Value::bool(r))
                                 },
                                 Value::bool(true),
@@ -2568,7 +2568,7 @@ impl Value {
         Ok(self.as_hash())
     }
 
-    pub(crate) fn as_hashmap_inner(&self) -> &HashmapInner {
+    pub(crate) fn as_hashmap_inner(&self) -> HashRef<'_> {
         assert_eq!(ObjTy::HASH, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue contains a hash.
         unsafe { self.rvalue().as_hashmap() }
@@ -2610,7 +2610,7 @@ impl Value {
     /// `Hashmap` wrapper, whose `DerefMut`/inherent methods run the
     /// generational write barrier. This makes barrier bypass a type
     /// error rather than a code-review concern.
-    fn as_hashmap_inner_mut(&mut self) -> &mut HashmapInner {
+    fn as_hashmap_inner_mut(&mut self) -> HashRefMut<'_> {
         assert_eq!(ObjTy::HASH, self.rvalue().ty());
         // SAFETY: The assert ensures this RValue contains a hash.
         unsafe { self.rvalue_mut().as_hashmap_mut() }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -79,6 +79,9 @@ const CHILLED_LITERAL_BIT: u16 = 0b1000_0000;
 pub const NEWBORN_FLAG_MASK: u16 = 0b0001_0111 | CHILLED_LITERAL_BIT;
 pub const RVALUE_OFFSET_FLAG: usize = std::mem::offset_of!(RValue, header.meta.flag);
 pub const RVALUE_OFFSET_TY: usize = std::mem::offset_of!(RValue, header.meta.ty);
+// `ty_flags_ptr` addresses the per-type metadata byte as `ty` + 1.
+const _: () =
+    assert!(std::mem::offset_of!(RValue, header.meta.ty_flags) == RVALUE_OFFSET_TY + 1);
 pub const RVALUE_OFFSET_CLASS: usize = std::mem::offset_of!(RValue, header.meta.class);
 pub const RVALUE_OFFSET_VAR: usize = std::mem::offset_of!(RValue, var_table);
 pub const RVALUE_OFFSET_KIND: usize = std::mem::offset_of!(RValue, kind);
@@ -192,7 +195,10 @@ pub union ObjKind {
     range: ManuallyDrop<RangeInner>,
     exception: ManuallyDrop<Box<ExceptionInner>>,
     proc: ManuallyDrop<ProcInner>,
-    hash: ManuallyDrop<HashmapInner>,
+    /// The Hash payload. Its representation (inline pairs vs boxed map)
+    /// is discriminated by the header's `ty_flags` byte, not by the
+    /// payload itself — see `hash.rs`.
+    hash: ManuallyDrop<HashBody>,
     regexp: ManuallyDrop<RegexpInner>,
     io: ManuallyDrop<IoInner>,
     method: ManuallyDrop<MethodInner>,
@@ -330,30 +336,9 @@ impl ObjKind {
         }
     }
 
-    fn hash_from(map: RubyMap<Value, Value>) -> Self {
+    fn hash_body(body: HashBody) -> Self {
         Self {
-            hash: ManuallyDrop::new(HashmapInner::new(map)),
-        }
-    }
-
-    fn hash_with_default(default: Value) -> Self {
-        Self {
-            hash: ManuallyDrop::new(HashmapInner::new_with_default(RubyMap::default(), default)),
-        }
-    }
-
-    fn hash_with_default_proc(default_proc: Proc) -> Self {
-        Self {
-            hash: ManuallyDrop::new(HashmapInner::new_with_default_proc(
-                RubyMap::default(),
-                default_proc,
-            )),
-        }
-    }
-
-    fn hash_from_inner(inner: HashmapInner) -> Self {
-        Self {
-            hash: ManuallyDrop::new(inner),
+            hash: ManuallyDrop::new(body),
         }
     }
 
@@ -570,7 +555,7 @@ impl std::fmt::Debug for RValue {
                             ObjTy::RANGE => format!("{:?}", self.kind.range),
                             ObjTy::EXCEPTION => format!("{:?}", self.kind.exception),
                             ObjTy::PROC => format!("{:?}", self.kind.proc),
-                            ObjTy::HASH => format!("{:?}", self.kind.hash),
+                            ObjTy::HASH => format!("{:?}", self.as_hashmap()),
                             ObjTy::REGEXP => format!("{:?}", self.kind.regexp),
                             ObjTy::IO => format!("{:?}", self.kind.io),
                             ObjTy::METHOD => format!("{:?}", self.kind.method),
@@ -871,7 +856,10 @@ impl alloc::GCBox for RValue {
                 ObjTy::TIME => ManuallyDrop::drop(&mut self.kind.time),
                 ObjTy::ARRAY => ManuallyDrop::drop(&mut self.kind.array),
                 ObjTy::EXCEPTION => ManuallyDrop::drop(&mut self.kind.exception),
-                ObjTy::HASH => ManuallyDrop::drop(&mut self.kind.hash),
+                // The Hash payload's live union field is discriminated by
+                // the header flags byte: only the boxed form owns heap
+                // memory (inline pairs are plain Values).
+                ObjTy::HASH => drop_hash_body(self.header.ty_flags(), &mut self.kind.hash),
                 ObjTy::REGEXP => ManuallyDrop::drop(&mut self.kind.regexp),
                 ObjTy::FIBER => ManuallyDrop::drop(&mut self.kind.fiber),
                 ObjTy::THREAD => ManuallyDrop::drop(&mut self.kind.thread),
@@ -1097,6 +1085,18 @@ impl RValue {
 
     pub(crate) fn set_ty_flags(&mut self, flags: u8) {
         self.header.set_ty_flags(flags)
+    }
+
+    /// Raw pointer to the `ty_flags` byte, for the hash handles that
+    /// pair it with the payload (the iteration guard mutates its bits
+    /// through a shared borrow, `Cell`-style).
+    pub(crate) fn ty_flags_ptr(&self) -> std::ptr::NonNull<u8> {
+        // SAFETY: the byte after `ty` is `ty_flags` (checked below).
+        unsafe {
+            std::ptr::NonNull::new_unchecked(
+                (self as *const RValue as *mut u8).add(RVALUE_OFFSET_TY + 1),
+            )
+        }
     }
 
     pub(crate) fn is_frozen(&self) -> bool {
@@ -1442,6 +1442,11 @@ impl RValue {
         let mut header = self.header.newborn();
         // dup does not copy the frozen or chilled flag (clone does).
         unsafe { header.meta.flag &= !(0b110 | CHILLED_LITERAL_BIT) };
+        // A hash copy keeps its representation bits but not the source's
+        // ruby2_keywords flag or live iteration count.
+        if unsafe { self.try_ty() } == Some(ObjTy::HASH) {
+            header.set_ty_flags(hash::sanitize_dup_flags(header.ty_flags()));
+        }
         RValue {
             header,
             var_table: self.var_table.clone(),
@@ -1486,7 +1491,7 @@ impl RValue {
                             proc: self.kind.proc.clone(),
                         },
                         ObjTy::HASH => ObjKind {
-                            hash: self.kind.hash.clone(),
+                            hash: ManuallyDrop::new(self.as_hashmap().clone_body()),
                         },
                         ObjTy::REGEXP => ObjKind {
                             regexp: self.kind.regexp.clone(),
@@ -1528,7 +1533,12 @@ impl RValue {
 
     pub(super) fn clone_value(&self) -> Self {
         // clone keeps frozen / chilled, but not the source's GC state.
-        let header = self.header.newborn();
+        let mut header = self.header.newborn();
+        // A hash copy keeps its representation bits but not the source's
+        // ruby2_keywords flag or live iteration count.
+        if unsafe { self.try_ty() } == Some(ObjTy::HASH) {
+            header.set_ty_flags(hash::sanitize_dup_flags(header.ty_flags()));
+        }
         RValue {
             header,
             var_table: self.var_table.clone(),
@@ -1573,7 +1583,7 @@ impl RValue {
                             proc: self.kind.proc.clone(),
                         },
                         ObjTy::HASH => ObjKind {
-                            hash: self.kind.hash.clone(),
+                            hash: ManuallyDrop::new(self.as_hashmap().clone_body()),
                         },
                         ObjTy::REGEXP => ObjKind {
                             regexp: self.kind.regexp.clone(),
@@ -1862,39 +1872,43 @@ impl RValue {
         }
     }
 
-    pub(super) fn new_hash(map: RubyMap<Value, Value>) -> Self {
+    /// The Hash representation bits live in the header's `ty_flags`
+    /// byte; every Hash constructor funnels through here so flags and
+    /// payload are installed together.
+    fn new_hash_with_class(class_id: ClassId, inner: HashmapInner) -> Self {
+        let (flags, body) = inner.into_parts();
+        let mut header = Header::new(class_id, ObjTy::HASH);
+        header.set_ty_flags(flags);
         RValue {
-            header: Header::new(HASH_CLASS, ObjTy::HASH),
-            kind: ObjKind::hash_from(map),
+            header,
+            kind: ObjKind::hash_body(body),
             var_table: None,
         }
+    }
+
+    pub(super) fn new_hash(map: RubyMap<Value, Value>) -> Self {
+        Self::new_hash_with_class(HASH_CLASS, HashmapInner::new(map))
     }
 
     pub(super) fn new_hash_from_inner(inner: HashmapInner) -> Self {
-        RValue {
-            header: Header::new(HASH_CLASS, ObjTy::HASH),
-            kind: ObjKind::hash_from_inner(inner),
-            var_table: None,
-        }
+        Self::new_hash_with_class(HASH_CLASS, inner)
     }
 
     pub(super) fn new_hash_with_class_and_default(class_id: ClassId, default: Value) -> Self {
-        RValue {
-            header: Header::new(class_id, ObjTy::HASH),
-            kind: ObjKind::hash_with_default(default),
-            var_table: None,
-        }
+        Self::new_hash_with_class(
+            class_id,
+            HashmapInner::new_with_default(RubyMap::default(), default),
+        )
     }
 
     pub(super) fn new_hash_with_class_and_default_proc(
         class_id: ClassId,
         default_proc: Proc,
     ) -> Self {
-        RValue {
-            header: Header::new(class_id, ObjTy::HASH),
-            kind: ObjKind::hash_with_default_proc(default_proc),
-            var_table: None,
-        }
+        Self::new_hash_with_class(
+            class_id,
+            HashmapInner::new_with_default_proc(RubyMap::default(), default_proc),
+        )
     }
 
     pub(super) fn new_regexp(regexp: RegexpInner) -> Self {
@@ -2378,8 +2392,8 @@ impl RValue {
         unsafe { &self.kind.matchdata }
     }
 
-    pub(crate) unsafe fn as_hashmap(&self) -> &HashmapInner {
-        unsafe { &self.kind.hash }
+    pub(crate) unsafe fn as_hashmap(&self) -> HashRef<'_> {
+        unsafe { HashRef::from_rvalue(self) }
     }
 
     pub(crate) unsafe fn as_struct_inner(&self) -> &StructInner {
@@ -2390,8 +2404,8 @@ impl RValue {
         unsafe { &mut self.kind.struct_inner }
     }
 
-    pub(super) unsafe fn as_hashmap_mut(&mut self) -> &mut HashmapInner {
-        unsafe { &mut self.kind.hash }
+    pub(super) unsafe fn as_hashmap_mut(&mut self) -> HashRefMut<'_> {
+        unsafe { HashRefMut::from_rvalue(self) }
     }
 
     pub(super) unsafe fn as_regex(&self) -> &RegexpInner {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1089,6 +1089,16 @@ impl RValue {
         self.header.ty()
     }
 
+    /// The per-`ObjTy` metadata byte (see `Metadata::ty_flags`). For
+    /// HASH objects this holds the small-hash representation bits.
+    pub(crate) fn ty_flags(&self) -> u8 {
+        self.header.ty_flags()
+    }
+
+    pub(crate) fn set_ty_flags(&mut self, flags: u8) {
+        self.header.set_ty_flags(flags)
+    }
+
     pub(crate) fn is_frozen(&self) -> bool {
         self.header.is_frozen()
     }
@@ -2526,11 +2536,16 @@ union Header {
 struct Metadata {
     flag: u16,
     ty: Option<ObjTy>,
-    /// MUST stay zero: the JIT compares the type with a 2-byte `cmpw
-    /// [ty]` that also reads this adjacent byte (e.g. the Array check in
-    /// `object_send_splat_arg0`). The generational GC age therefore lives
-    /// in the high byte of `flag`, not here. See gc.md.
-    _padding: u8,
+    /// Per-`ObjTy` metadata byte. Zero for most types; a HASH object
+    /// keeps its small-hash representation bits here (see
+    /// `hash::HashFlags`), which frees the whole 48-byte payload for
+    /// three inline key-value pairs. All JIT type checks read `ty` with
+    /// 1-byte loads (x86-64 `cmpb`, aarch64 `ldrb`), so this byte may
+    /// hold arbitrary values. Copied verbatim by `Header::newborn` and
+    /// the JIT literal-copy path (`CellHeader::NewbornOf`) — dup/clone
+    /// preserve it — and rewritten wholesale when a freed cell is
+    /// reused.
+    ty_flags: u8,
     class: Option<ClassId>,
 }
 
@@ -2546,10 +2561,19 @@ impl Header {
             meta: Metadata {
                 flag: 1,
                 ty: Some(ty),
-                _padding: 0,
+                ty_flags: 0,
                 class: Some(class),
             },
         }
+    }
+
+    /// The per-`ObjTy` metadata byte (see `Metadata::ty_flags`).
+    fn ty_flags(&self) -> u8 {
+        unsafe { self.meta.ty_flags }
+    }
+
+    fn set_ty_flags(&mut self, flags: u8) {
+        self.meta.ty_flags = flags;
     }
 
     fn is_live(&self) -> bool {
@@ -2679,10 +2703,11 @@ impl Header {
     }
 
     /// Generational GC age (number of collections survived), stored in
-    /// the high byte of `flag` so the type byte's neighbour stays zero
-    /// (see `Metadata::_padding`). The low byte holds the live/frozen/
-    /// chilled/OLD/WB_ARMED flags and is read by the write barrier; age
-    /// occupies bits 8..15, untouched by those byte-wide flag tests.
+    /// the high byte of `flag` (the byte next to `ty` belongs to the
+    /// per-type metadata, `Metadata::ty_flags`). The low byte holds the
+    /// live/frozen/chilled/OLD/WB_ARMED flags and is read by the write
+    /// barrier; age occupies bits 8..15, untouched by those byte-wide
+    /// flag tests.
     fn age(&self) -> u8 {
         unsafe { (self.meta.flag >> 8) as u8 }
     }

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -1,36 +1,258 @@
 use super::*;
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 use std::ops::Deref;
+use std::ptr::NonNull;
 
-#[monoruby_object(write_barrier)]
-pub struct Hashmap(Value);
+//
+// ## Small-hash representation
+//
+// A Hash keeps its representation bits in the RValue header's per-type
+// metadata byte (`Metadata::ty_flags`), which frees the whole 48-byte
+// payload: small hashes with packed-immediate keys store up to
+// [`INLINE_CAP`] key-value pairs directly in the cell (`HashBody::inline`)
+// — no heap allocation at all — while everything else lives behind a
+// boxed [`BoxedHash`].
+//
+// Flags byte layout (HASH objects):
+//
+// | bits | meaning                                              |
+// |------|------------------------------------------------------|
+// | 0-2  | representation: 0..=3 = inline with that many pairs, |
+// |      | 7 = boxed (`HashBody::boxed` is live)                |
+// | 3    | ruby2_keywords flag                                  |
+// | 4-5  | inline iteration depth (saturating; boxed hashes     |
+// |      | count in `BoxedHash::iter_lev` instead)              |
+// | 6-7  | reserved (zero)                                      |
+//
+// A zeroed byte — the `Header::new` default — is a valid empty inline
+// hash, and dup/clone (`Header::newborn`) preserve the byte, so the
+// representation travels with the header while the payload is copied
+// alongside.
+//
 
-impl Hashmap {
-    pub(crate) fn new(val: Value) -> Self {
-        assert_eq!(val.ty(), Some(ObjTy::HASH));
-        Self(val)
+const REP_MASK: u8 = 0b0000_0111;
+const REP_BOXED: u8 = 7;
+const R2K_BIT: u8 = 0b0000_1000;
+const ITER_MASK: u8 = 0b0011_0000;
+const ITER_SHIFT: u8 = 4;
+const ITER_MAX: u8 = 3;
+
+/// Max pairs held inline: the full 48-byte payload.
+pub(crate) const INLINE_CAP: usize = 3;
+
+/// Is the boxed representation live for this flags byte?
+pub(super) fn flags_is_boxed(flags: u8) -> bool {
+    flags & REP_MASK == REP_BOXED
+}
+
+/// The flags a dup/clone of a hash must carry: the representation bits
+/// travel with the copied body, while the ruby2_keywords flag and any
+/// live iteration count belong to the source object only.
+pub(super) fn sanitize_dup_flags(flags: u8) -> u8 {
+    flags & REP_MASK
+}
+
+/// Drop the live content of `body` according to `flags` (the RValue
+/// sweep path for HASH cells).
+///
+/// # Safety
+/// `flags` must describe `body`, and the boxed content must not be used
+/// again afterwards.
+pub(super) unsafe fn drop_hash_body(flags: u8, body: &mut HashBody) {
+    if flags_is_boxed(flags) {
+        unsafe { ManuallyDrop::drop(&mut body.boxed) }
+    }
+}
+
+///
+/// The 48-byte Hash payload, discriminated by the header flags byte.
+///
+#[repr(C)]
+pub union HashBody {
+    /// Live while the flags byte says inline; only the first `len` pairs
+    /// are meaningful, the rest are nil-nil placeholders (kept
+    /// initialized so reading the whole array is always defined).
+    inline: [(Value, Value); INLINE_CAP],
+    boxed: ManuallyDrop<BoxedHash>,
+}
+
+const _: () = assert!(std::mem::size_of::<HashBody>() == 48);
+
+fn empty_pairs() -> [(Value, Value); INLINE_CAP] {
+    [(Value::nil(), Value::nil()); INLINE_CAP]
+}
+
+///
+/// The boxed form: a real map, the default value/proc, and an exact
+/// iteration counter.
+///
+pub(crate) struct BoxedHash {
+    content: HashContent,
+    /// The default value / default proc. `None` is the common
+    /// nil-default case.
+    default: Option<Box<HashDefault>>,
+    /// Active iteration count on this hash. Incremented while a
+    /// block-based traversal (each, each_pair, etc.) is in progress and
+    /// decremented when it finishes. Mutating operations consult this
+    /// via `check_iter` and raise `RuntimeError` when non-zero.
+    /// Corresponds to CRuby's `RHASH_ITER_LEV`. A `Cell` so a traversal
+    /// holding a shared borrow can still record its presence.
+    iter_lev: std::cell::Cell<u32>,
+}
+
+impl BoxedHash {
+    fn new(content: HashContent) -> Self {
+        BoxedHash {
+            content,
+            default: None,
+            iter_lev: std::cell::Cell::new(0),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum HashContent {
+    Map(Box<RubyMap<Value, Value>>),
+    IdentMap(Box<RubyMap<IdentKey, Value>>),
+}
+
+#[derive(Debug, Clone)]
+enum HashDefault {
+    Value(Value),
+    Proc(Proc),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HashId(usize);
+
+///
+/// An owned hash — the flags byte and the payload side by side. This is
+/// the form built on the Rust stack (keyword-hash assembly, builtins
+/// composing a result hash) and handed to [`Value::hash_from_inner`],
+/// which moves the payload into a fresh RValue and the flags into its
+/// header.
+///
+pub struct HashmapInner {
+    flags: u8,
+    body: HashBody,
+}
+
+impl std::default::Default for HashmapInner {
+    fn default() -> Self {
+        HashmapInner {
+            flags: 0,
+            body: HashBody {
+                inline: empty_pairs(),
+            },
+        }
+    }
+}
+
+impl Drop for HashmapInner {
+    fn drop(&mut self) {
+        if flags_is_boxed(self.flags) {
+            // SAFETY: the flags byte says the boxed field is live.
+            unsafe { ManuallyDrop::drop(&mut self.body.boxed) }
+        }
+    }
+}
+
+impl Clone for HashmapInner {
+    /// Clones the content but resets the iteration count and the
+    /// ruby2_keywords flag — a fresh copy is not being iterated, and
+    /// `Hash#dup` drops the r2k flag (as CRuby).
+    fn clone(&self) -> Self {
+        self.as_ref().clone_inner()
+    }
+}
+
+impl std::fmt::Debug for HashmapInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.as_ref().iter()).finish()
+    }
+}
+
+impl HashmapInner {
+    fn from_parts(flags: u8, body: HashBody) -> Self {
+        HashmapInner { flags, body }
     }
 
-    /// Get a reference to the inner HashmapInner.
-    pub(crate) fn inner(&self) -> &HashmapInner {
-        self.0.as_hashmap_inner()
+    /// Decompose without running `Drop` (ownership of the boxed content
+    /// moves to the caller along with the flags).
+    pub(super) fn into_parts(self) -> (u8, HashBody) {
+        let this = ManuallyDrop::new(self);
+        // SAFETY: `this` is never dropped; the body is moved out exactly once.
+        let body = unsafe { std::ptr::read(&this.body) };
+        (this.flags, body)
     }
 
-    pub fn index(&self, vm: &mut Executor, globals: &mut Globals, key: Value) -> Result<Value> {
-        if let Some(v) = self.get(key, vm, globals)? {
-            Ok(v)
-        } else {
-            match self.default {
-                HashDefault::Proc(proc) => vm.invoke_proc(globals, &proc, &[self.0, key]),
-                HashDefault::Value(v) => Ok(v),
-            }
+    pub(crate) fn as_ref(&self) -> HashRef<'_> {
+        HashRef {
+            flags: NonNull::from(&self.flags),
+            body: NonNull::from(&self.body),
+            _marker: PhantomData,
         }
     }
 
-    // Write-barrier-protected stores (shadow the `HashmapInner` methods
-    // reached via `Deref`, so existing call sites go through the
-    // generational write barrier). See `doc/gc.md`.
+    pub(crate) fn as_mut(&mut self) -> HashRefMut<'_> {
+        HashRefMut {
+            flags: NonNull::from(&mut self.flags),
+            body: NonNull::from(&mut self.body),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn new(map: RubyMap<Value, Value>) -> Self {
+        if map.len() <= INLINE_CAP && map.iter().all(|(k, _)| is_inline_key(*k)) {
+            let mut pairs = empty_pairs();
+            let mut len = 0u8;
+            for (k, v) in map.iter() {
+                pairs[len as usize] = (*k, *v);
+                len += 1;
+            }
+            Self::from_parts(len, HashBody { inline: pairs })
+        } else {
+            Self::from_parts(
+                REP_BOXED,
+                HashBody {
+                    boxed: ManuallyDrop::new(BoxedHash::new(HashContent::Map(Box::new(map)))),
+                },
+            )
+        }
+    }
+
+    fn new_boxed_with_default(map: RubyMap<Value, Value>, default: Option<HashDefault>) -> Self {
+        Self::from_parts(
+            REP_BOXED,
+            HashBody {
+                boxed: ManuallyDrop::new(BoxedHash {
+                    content: HashContent::Map(Box::new(map)),
+                    default: default.map(Box::new),
+                    iter_lev: std::cell::Cell::new(0),
+                }),
+            },
+        )
+    }
+
+    /// A hash with a default value. A non-nil default needs the boxed
+    /// form (the inline payload has no default slot), so this
+    /// constructs it directly — no promotion, hence no re-hashing.
+    pub fn new_with_default(map: RubyMap<Value, Value>, default: Value) -> Self {
+        if default.is_nil() {
+            Self::new(map)
+        } else {
+            Self::new_boxed_with_default(map, Some(HashDefault::Value(default)))
+        }
+    }
+
+    pub fn new_with_default_proc(map: RubyMap<Value, Value>, default_proc: Proc) -> Self {
+        Self::new_boxed_with_default(map, Some(HashDefault::Proc(default_proc)))
+    }
+
+    // Forwarders for the owned/builder form.
 
     pub fn insert(
         &mut self,
@@ -39,214 +261,343 @@ impl Hashmap {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<()> {
-        self.0.as_hashmap_inner_mut().insert(k, v, vm, globals)?;
-        self.0.write_barrier_bulk();
-        Ok(())
+        self.as_mut().insert(k, v, vm, globals)
     }
 
-    pub fn set_defalut_value(&mut self, default: Value) {
-        self.0.as_hashmap_inner_mut().set_defalut_value(default);
-        self.0.write_barrier(default);
+    pub fn remove(
+        &mut self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<Value>> {
+        self.as_mut().remove(k, vm, globals)
     }
 
-    pub fn set_defalut_proc(&mut self, default_proc: Proc) {
-        self.0.as_hashmap_inner_mut().set_defalut_proc(default_proc);
-        self.0.write_barrier_bulk();
+    pub fn get(&self, k: Value, vm: &mut Executor, globals: &mut Globals) -> Result<Option<Value>> {
+        self.as_ref().get(k, vm, globals)
     }
 
-    /// Replace the whole content (`Hash#replace`). Bulk barrier: the new
-    /// content may reference young objects.
-    pub fn replace_inner(&mut self, inner: HashmapInner) {
-        *self.0.as_hashmap_inner_mut() = inner;
-        self.0.write_barrier_bulk();
-    }
-
-    /// Set / clear the ruby2_keywords flag (a plain bool — no GC edge,
-    /// so no write barrier is needed).
     pub(crate) fn set_ruby2_keywords_flag(&mut self) {
-        self.0.as_hashmap_inner_mut().set_ruby2_keywords_flag();
+        self.as_mut().set_ruby2_keywords_flag()
     }
 
     pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
-        self.0.as_hashmap_inner_mut().unset_ruby2_keywords_flag();
+        self.as_mut().unset_ruby2_keywords_flag()
     }
-}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct HashId(usize);
-
-#[derive(Debug, Clone)]
-enum HashDefault {
-    Value(Value),
-    Proc(Proc),
-}
-
-impl std::default::Default for HashDefault {
-    fn default() -> Self {
-        HashDefault::Value(Value::nil())
+    pub(crate) fn ruby2_keywords_flag(&self) -> bool {
+        self.as_ref().ruby2_keywords_flag()
     }
-}
 
-#[derive(Debug, Default)]
-pub struct HashmapInner {
-    default: HashDefault,
-    content: HashContent,
-    /// Active iteration count on this hash. Incremented while a block-based
-    /// traversal (each, each_pair, each_key, etc.) is in progress and
-    /// decremented when it finishes. Mutating operations consult this via
-    /// [`Self::check_iter`] and raise `RuntimeError` when non-zero.
-    ///
-    /// Corresponds to CRuby's `RHASH_ITER_LEV`. Wrapped in `Cell` so that
-    /// a traversal holding a shared borrow of the hash (for iteration) can
-    /// still record its presence here.
-    iter_lev: std::cell::Cell<u32>,
-    /// CRuby's Hash ruby2_keywords flag: set on the hash a
-    /// `ruby2_keywords`-marked method packs its keywords into (and by
-    /// `Hash.ruby2_keywords_hash`). A later `*args` splat whose final
-    /// element carries this flag turns it back into keywords at
-    /// dispatch. Cleared by `clone` (`Hash#dup` drops the flag, as
-    /// CRuby; `Hash.ruby2_keywords_hash` re-sets it on its dup).
-    r2k: bool,
-}
+    pub fn defalut_value(&self) -> Option<Value> {
+        self.as_ref().defalut_value()
+    }
 
-impl Clone for HashmapInner {
-    /// Clones the default and content but resets `iter_lev` to 0 — a fresh
-    /// copy is not being iterated, regardless of the original's state.
-    fn clone(&self) -> Self {
-        HashmapInner {
-            default: self.default.clone(),
-            content: self.content.clone(),
-            iter_lev: std::cell::Cell::new(0),
-            r2k: false,
-        }
+    pub(crate) fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.as_ref().is_empty()
+    }
+
+    pub(crate) fn keys(&self) -> Vec<Value> {
+        self.as_ref().keys()
+    }
+
+    pub(crate) fn values(&self) -> Vec<Value> {
+        self.as_ref().values()
+    }
+
+    pub(crate) fn iter(&self) -> Iter<'_> {
+        self.as_ref().iter()
+    }
+
+    pub fn compare_by_identity(&mut self, vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+        self.as_mut().compare_by_identity(vm, globals)
+    }
+
+    pub fn set_compare_by_identity_empty(&mut self, ident: bool) -> Result<()> {
+        self.as_mut().set_compare_by_identity_empty(ident)
+    }
+
+    pub fn is_compare_by_identity(&self) -> bool {
+        self.as_ref().is_compare_by_identity()
+    }
+
+    pub fn clear(&mut self) -> Result<()> {
+        self.as_mut().clear()
+    }
+
+    pub fn shift(
+        &mut self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<(Value, Value)>> {
+        self.as_mut().shift(vm, globals)
+    }
+
+    pub fn contains_key(
+        &self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<bool> {
+        self.as_ref().contains_key(k, vm, globals)
     }
 }
 
 impl RubyEql<Executor, Globals, MonorubyErr> for HashmapInner {
-    // This type of equality is used for comparison for keys of Hash.
     fn eql(&self, other: &Self, vm: &mut Executor, globals: &mut Globals) -> Result<bool> {
-        self.content.eql(&other.content, vm, globals)
+        self.as_ref().eql(&other.as_ref(), vm, globals)
     }
 }
 
-impl std::ops::Deref for HashmapInner {
-    type Target = HashContent;
-    fn deref(&self) -> &Self::Target {
-        &self.content
+impl RubyHash<Executor, Globals, MonorubyErr> for HashmapInner {
+    fn ruby_hash<H: std::hash::Hasher>(
+        &self,
+        state: &mut H,
+        e: &mut Executor,
+        g: &mut Globals,
+    ) -> Result<()> {
+        self.as_ref().ruby_hash(state, e, g)
     }
 }
 
-impl std::ops::DerefMut for HashmapInner {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.content
-    }
+/// Can `k` be stored inline? Only packed immediates: their identity *is*
+/// their content, so equality is bit comparison and the digest
+/// recomputed at probe time can never disagree with an insert-time one
+/// (heap keys — even strings — can be mutated, and a boxed map's
+/// insert-time digest going stale is exactly the behavior `Hash#rehash`
+/// exists for; that protocol stays with the boxed representation).
+fn is_inline_key(k: Value) -> bool {
+    k.is_packed_value()
 }
 
-impl HashmapInner {
+/// A tag-resolved view of the content, so read paths can match on the
+/// representation without touching the union directly.
+enum ContentRef<'a> {
+    Inline(&'a [(Value, Value)]),
+    Map(&'a RubyMap<Value, Value>),
+    Ident(&'a RubyMap<IdentKey, Value>),
+}
+
+///
+/// A borrowed hash: the header flags byte and the payload, paired. The
+/// flags pointer is kept raw (not `&u8`) because the iteration guard
+/// mutates the inline iteration bits through a shared borrow, in the
+/// same interior-mutability style the boxed form's `Cell` counter uses.
+///
+#[derive(Clone, Copy)]
+pub struct HashRef<'a> {
+    flags: NonNull<u8>,
+    body: NonNull<HashBody>,
+    _marker: PhantomData<&'a RValue>,
+}
+
+///
+/// An exclusively borrowed hash; grants the mutating operations.
+///
+pub struct HashRefMut<'a> {
+    flags: NonNull<u8>,
+    body: NonNull<HashBody>,
+    _marker: PhantomData<&'a mut RValue>,
+}
+
+impl<'a> HashRef<'a> {
+    /// Borrow the hash stored in `rv`.
     ///
-    /// Generational GC: does this hash reference any young (non-old) heap
-    /// object — among its keys, values, or default value/proc? Used for
-    /// the remember-on-promote decision (the `default` field is private to
-    /// this module, hence this helper). See `doc/gc.md`.
-    ///
-    pub(crate) fn young_child_exists(&self, alloc: &alloc::Allocator<RValue>) -> bool {
-        fn is_young(v: Value, alloc: &alloc::Allocator<RValue>) -> bool {
-            v.try_rvalue().is_some_and(|rv| !alloc.is_old(rv))
-        }
-        match self.default {
-            HashDefault::Proc(p) => {
-                if is_young(p.into(), alloc) {
-                    return true;
-                }
-            }
-            HashDefault::Value(v) => {
-                if is_young(v, alloc) {
-                    return true;
-                }
+    /// # Safety
+    /// `rv` must be a live HASH object.
+    pub(super) unsafe fn from_rvalue(rv: &'a RValue) -> Self {
+        unsafe {
+            HashRef {
+                flags: rv.ty_flags_ptr(),
+                body: NonNull::from(&*rv.kind.hash),
+                _marker: PhantomData,
             }
         }
-        self.content
+    }
+
+    fn flags(&self) -> u8 {
+        // SAFETY: the pointee outlives 'a.
+        unsafe { *self.flags.as_ref() }
+    }
+
+    fn body(&self) -> &'a HashBody {
+        // SAFETY: the pointee outlives 'a.
+        unsafe { self.body.as_ref() }
+    }
+
+    fn is_inline(&self) -> bool {
+        !flags_is_boxed(self.flags())
+    }
+
+    fn inline_len(&self) -> usize {
+        debug_assert!(self.is_inline());
+        (self.flags() & REP_MASK) as usize
+    }
+
+    fn inline_pairs(&self) -> &'a [(Value, Value)] {
+        let len = self.inline_len();
+        // SAFETY: rep is inline; len ≤ INLINE_CAP and the array is
+        // always fully initialized.
+        unsafe { &self.body().inline[..len] }
+    }
+
+    fn boxed(&self) -> &'a BoxedHash {
+        debug_assert!(!self.is_inline());
+        // SAFETY: rep is boxed.
+        unsafe { &self.body().boxed }
+    }
+
+    fn content(&self) -> ContentRef<'a> {
+        if self.is_inline() {
+            ContentRef::Inline(self.inline_pairs())
+        } else {
+            match &self.boxed().content {
+                HashContent::Map(m) => ContentRef::Map(m),
+                HashContent::IdentMap(m) => ContentRef::Ident(m),
+            }
+        }
+    }
+
+    fn default_ref(&self) -> Option<&'a HashDefault> {
+        if self.is_inline() {
+            None
+        } else {
+            self.boxed().default.as_deref()
+        }
+    }
+
+    fn id(&self) -> HashId {
+        HashId(self.body.as_ptr() as usize)
+    }
+
+    /// Position of packed key `k` among the inline pairs. Packed values
+    /// are eql? iff their bits are equal (`Value::eql`'s immediate arm),
+    /// so this scan is exactly a map's digest-probe + eql? for these
+    /// keys. Heap keys can never match a packed key.
+    fn inline_pos_packed(&self, k: Value) -> Option<usize> {
+        if !k.is_packed_value() {
+            return None;
+        }
+        self.inline_pairs()
             .iter()
-            .any(|(k, v)| is_young(k, alloc) || is_young(v, alloc))
+            .position(|(ek, _)| ek.id() == k.id())
     }
-}
 
-impl alloc::GC<RValue> for HashmapInner {
-    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
-        match self.default {
-            HashDefault::Proc(p) => p.mark(alloc),
-            HashDefault::Value(v) => v.mark(alloc),
-        }
-        for (k, v) in self.content.iter() {
-            k.mark(alloc);
-            v.mark(alloc);
-        }
-    }
-}
-
-impl HashmapInner {
-    pub fn new(map: RubyMap<Value, Value>) -> Self {
-        HashmapInner {
-            default: HashDefault::default(),
-            content: HashContent::new(map),
-            iter_lev: std::cell::Cell::new(0),
-            r2k: false,
+    /// Position of `k` among the inline pairs, observing the same
+    /// `#hash` protocol a boxed-map lookup would: a heap probe is hashed
+    /// exactly once (dispatching a user-defined `#hash` and propagating
+    /// its errors) even though it can never be eql? to a packed key.
+    fn inline_pos(
+        &self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<usize>> {
+        if k.is_packed_value() {
+            Ok(self
+                .inline_pairs()
+                .iter()
+                .position(|(ek, _)| ek.id() == k.id()))
+        } else {
+            k.calculate_hash(vm, globals)?;
+            Ok(None)
         }
     }
 
-    pub fn new_with_default(map: RubyMap<Value, Value>, default: Value) -> Self {
-        HashmapInner {
-            default: HashDefault::Value(default),
-            content: HashContent::new(map),
-            iter_lev: std::cell::Cell::new(0),
-            r2k: false,
+    pub(crate) fn len(&self) -> usize {
+        match self.content() {
+            ContentRef::Inline(pairs) => pairs.len(),
+            ContentRef::Map(m) => m.len(),
+            ContentRef::Ident(m) => m.len(),
         }
     }
 
-    pub fn new_with_default_proc(map: RubyMap<Value, Value>, default_proc: Proc) -> Self {
-        HashmapInner {
-            default: HashDefault::Proc(default_proc),
-            content: HashContent::new(map),
-            iter_lev: std::cell::Cell::new(0),
-            r2k: false,
-        }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
-    /// CRuby's Hash ruby2_keywords flag (see the field doc).
+    pub fn is_compare_by_identity(&self) -> bool {
+        matches!(self.content(), ContentRef::Ident(_))
+    }
+
     pub(crate) fn ruby2_keywords_flag(&self) -> bool {
-        self.r2k
-    }
-
-    pub(crate) fn set_ruby2_keywords_flag(&mut self) {
-        self.r2k = true;
-    }
-
-    pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
-        self.r2k = false;
+        self.flags() & R2K_BIT != 0
     }
 
     pub fn defalut_value(&self) -> Option<Value> {
-        if let HashDefault::Value(v) = self.default {
-            Some(v)
-        } else {
-            None
+        match self.default_ref() {
+            None => Some(Value::nil()),
+            Some(HashDefault::Value(v)) => Some(*v),
+            Some(HashDefault::Proc(_)) => None,
         }
     }
 
     pub fn defalut_proc(&self) -> Option<Proc> {
-        if let HashDefault::Proc(p) = self.default {
-            Some(p)
+        if let Some(HashDefault::Proc(p)) = self.default_ref() {
+            Some(*p)
         } else {
             None
         }
     }
 
-    pub fn set_defalut_value(&mut self, default: Value) {
-        self.default = HashDefault::Value(default);
+    /// The hash's default *value* (`Hash.new(x)`), if one is set and it
+    /// is a plain value rather than a default proc. Returns `None` for
+    /// the nil default or a default proc.
+    pub fn default_value(&self) -> Option<Value> {
+        match self.default_ref() {
+            Some(HashDefault::Value(v)) if !v.is_nil() => Some(*v),
+            _ => None,
+        }
     }
 
-    pub fn set_defalut_proc(&mut self, default_proc: Proc) {
-        self.default = HashDefault::Proc(default_proc);
+    pub fn get(&self, k: Value, vm: &mut Executor, globals: &mut Globals) -> Result<Option<Value>> {
+        Ok(match self.content() {
+            ContentRef::Inline(pairs) => self.inline_pos(k, vm, globals)?.map(|i| pairs[i].1),
+            ContentRef::Map(m) => m.get(&k, vm, globals)?.copied(),
+            ContentRef::Ident(m) => m.get(&IdentKey(k), vm, globals)?.copied(),
+        })
+    }
+
+    pub(crate) fn contains_key(
+        &self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<bool> {
+        match self.content() {
+            ContentRef::Inline(_) => Ok(self.inline_pos(k, vm, globals)?.is_some()),
+            ContentRef::Map(m) => m.contains_key(&k, vm, globals),
+            ContentRef::Ident(m) => m.contains_key(&IdentKey(k), vm, globals),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> Iter<'a> {
+        match self.content() {
+            ContentRef::Inline(pairs) => Iter::Inline(pairs.iter()),
+            ContentRef::Map(m) => Iter::Map(m.iter()),
+            ContentRef::Ident(m) => Iter::IdentMap(m.iter()),
+        }
+    }
+
+    pub(crate) fn keys(&self) -> Vec<Value> {
+        self.iter().map(|(k, _)| k).collect()
+    }
+
+    pub(crate) fn values(&self) -> Vec<Value> {
+        self.iter().map(|(_, v)| v).collect()
+    }
+
+    /// Is a traversal currently in progress on this hash?
+    fn iter_active(&self) -> bool {
+        if self.is_inline() {
+            self.flags() & ITER_MASK != 0
+        } else {
+            self.boxed().iter_lev.get() > 0
+        }
     }
 
     /// Raise `RuntimeError` if a traversal is currently in progress on
@@ -256,7 +607,7 @@ impl HashmapInner {
     /// matching CRuby, where `h.each { h[existing] = v }` is allowed but
     /// `h.each { h[new] = v }` or `h.each { h.delete(k) }` raises.
     pub fn check_iter(&self) -> Result<()> {
-        if self.iter_lev.get() > 0 {
+        if self.iter_active() {
             Err(MonorubyErr::runtimeerr(
                 "can't modify hash during iteration",
             ))
@@ -265,124 +616,88 @@ impl HashmapInner {
         }
     }
 
-    /// Start a traversal: returns an RAII guard that decrements `iter_lev`
-    /// when dropped. Takes `&self` (not `&mut`) so the hash can be iterated
-    /// concurrently with the guard being alive.
-    pub fn iter_guard(&self) -> IterGuard<'_> {
-        self.iter_lev.set(self.iter_lev.get() + 1);
-        IterGuard { inner: self }
-    }
-
-    fn id(&self) -> HashId {
-        HashId(self as *const _ as usize)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match &self.content {
-            HashContent::Map(box map) => map.is_empty(),
-            HashContent::IdentMap(box map) => map.is_empty(),
-        }
-    }
-
-    pub fn is_compare_by_identity(&self) -> bool {
-        matches!(&self.content, HashContent::IdentMap(_))
-    }
-
-    /// The hash's default *value* (`Hash.new(x)`), if one is set and it is
-    /// a plain value rather than a default proc. Returns `None` for the
-    /// nil default or a default proc.
-    pub fn default_value(&self) -> Option<Value> {
-        match self.default {
-            HashDefault::Value(v) if !v.is_nil() => Some(v),
-            _ => None,
-        }
-    }
-
-    pub fn get(&self, v: Value, vm: &mut Executor, globals: &mut Globals) -> Result<Option<Value>> {
-        Ok(match &self.content {
-            HashContent::Map(box map) => map.get(&v, vm, globals)?.copied(),
-            HashContent::IdentMap(box map) => map.get(&IdentKey(v), vm, globals)?.copied(),
-        })
-    }
-
-    pub fn remove(
-        &mut self,
-        k: Value,
-        vm: &mut Executor,
-        globals: &mut Globals,
-    ) -> Result<Option<Value>> {
-        // Removing a key during iteration is explicitly allowed — CRuby
-        // behaves the same way (see ruby/spec core/hash/delete_spec.rb
-        // "allows removing a key while iterating").
-        Ok(match &mut self.content {
-            HashContent::Map(map) => map.shift_remove(&k, vm, globals)?,
-            HashContent::IdentMap(map) => map.shift_remove(&IdentKey(k), vm, globals)?,
-        })
-    }
-
-    pub fn insert(
-        &mut self,
-        k: Value,
-        v: Value,
-        vm: &mut Executor,
-        globals: &mut Globals,
-    ) -> Result<()> {
-        if self.iter_lev.get() > 0 && !self.content.contains_key(k, vm, globals)? {
-            return Err(MonorubyErr::runtimeerr(
-                "can't add a new key into hash during iteration",
-            ));
-        }
-        self.content.insert(k, v, vm, globals)
-    }
-
-    pub fn clear(&mut self) -> Result<()> {
-        self.check_iter()?;
-        self.content.clear();
-        Ok(())
-    }
-
-    pub fn shift(
-        &mut self,
-        vm: &mut Executor,
-        globals: &mut Globals,
-    ) -> Result<Option<(Value, Value)>> {
-        // Shifting an entry during iteration is allowed, like `delete` — CRuby
-        // permits `h.each { h.shift }` (see ruby/spec core/hash/shift_spec.rb
-        // "allows shifting entries while iterating"). Only *adding* a key is
-        // rejected mid-iteration.
-        self.content.shift(vm, globals)
-    }
-
-    pub fn compare_by_identity(
-        &mut self,
-        vm: &mut Executor,
-        globals: &mut Globals,
-    ) -> Result<()> {
-        self.check_iter()?;
-        self.content.compare_by_identity(vm, globals)
-    }
-
-    /// Set the key-comparison mode of an empty hash, in either direction.
-    /// See `HashContent::set_compare_by_identity_empty`.
-    pub fn set_compare_by_identity_empty(&mut self, ident: bool) -> Result<()> {
-        self.check_iter()?;
-        self.content.set_compare_by_identity_empty(ident);
-        Ok(())
-    }
-
-    /*pub fn entry_and_modify<F>(&mut self, k: Value, f: F)
-    where
-        F: FnOnce(&mut Value),
-    {
-        match &mut self.content {
-            HashContent::Map(map) => {
-                map.entry(HashKey(k)).and_modify(f);
+    /// Start a traversal: returns an RAII guard that decrements the
+    /// iteration count when dropped. Takes `&self` (not `&mut`) so the
+    /// hash can be iterated concurrently with the guard being alive.
+    ///
+    /// Inline hashes track the depth in two header-flag bits; if a
+    /// pathological nesting exceeds that range the extra guards become
+    /// no-ops — the hash simply stays marked as iterating until the
+    /// tracked (outer) guards unwind, which keeps the "no new keys
+    /// while iterating" rule sound for the usual LIFO guard order.
+    pub fn iter_guard(&self) -> IterGuard<'a> {
+        let real = if self.is_inline() {
+            let flags = self.flags();
+            let depth = (flags & ITER_MASK) >> ITER_SHIFT;
+            if depth < ITER_MAX {
+                let new = (flags & !ITER_MASK) | ((depth + 1) << ITER_SHIFT);
+                // SAFETY: interior mutation of the iteration bits through
+                // the shared borrow — the inline analogue of the boxed
+                // form's `Cell` counter. No other bits change.
+                unsafe { *self.flags.as_ptr() = new };
+                true
+            } else {
+                false
             }
-            HashContent::IdentMap(map) => {
-                map.entry(IdentKey(k)).and_modify(f);
+        } else {
+            let lev = &self.boxed().iter_lev;
+            lev.set(lev.get() + 1);
+            true
+        };
+        IterGuard { h: *self, real }
+    }
+
+    /// A detached copy of this hash: content cloned, iteration count and
+    /// ruby2_keywords flag reset (`Hash#dup` semantics for the flag).
+    pub(crate) fn clone_inner(&self) -> HashmapInner {
+        HashmapInner::from_parts(sanitize_dup_flags(self.flags()), self.clone_body())
+    }
+
+    /// Clone just the payload (for `dup`/`clone`, which copy the header
+    /// — and with it the representation bits — separately).
+    pub(super) fn clone_body(&self) -> HashBody {
+        if self.is_inline() {
+            HashBody {
+                // SAFETY: rep is inline; the pair array is Copy.
+                inline: unsafe { self.body().inline },
+            }
+        } else {
+            let b = self.boxed();
+            HashBody {
+                boxed: ManuallyDrop::new(BoxedHash {
+                    content: b.content.clone(),
+                    default: b.default.clone(),
+                    iter_lev: std::cell::Cell::new(0),
+                }),
             }
         }
-    }*/
+    }
+
+    ///
+    /// Generational GC: does this hash reference any young (non-old)
+    /// heap object — among its keys, values, or default value/proc?
+    /// Used for the remember-on-promote decision. See `doc/gc.md`.
+    ///
+    pub(crate) fn young_child_exists(&self, alloc: &alloc::Allocator<RValue>) -> bool {
+        fn is_young(v: Value, alloc: &alloc::Allocator<RValue>) -> bool {
+            v.try_rvalue().is_some_and(|rv| !alloc.is_old(rv))
+        }
+        match self.default_ref() {
+            Some(HashDefault::Proc(p)) => {
+                if is_young((*p).into(), alloc) {
+                    return true;
+                }
+            }
+            Some(HashDefault::Value(v)) => {
+                if is_young(*v, alloc) {
+                    return true;
+                }
+            }
+            None => {}
+        }
+        self.iter()
+            .any(|(k, v)| is_young(k, alloc) || is_young(v, alloc))
+    }
 
     pub fn debug(&self, store: &Store) -> String {
         match self.len() {
@@ -450,47 +765,63 @@ impl HashmapInner {
     }
 }
 
-/// RAII guard returned from [`HashmapInner::iter_guard`].
-///
-/// While alive it represents a single layer of active iteration; dropping it
-/// (normal return or unwinding via `Result::Err`) decrements `iter_lev`.
-pub struct IterGuard<'a> {
-    inner: &'a HashmapInner,
-}
-
-impl Drop for IterGuard<'_> {
-    fn drop(&mut self) {
-        self.inner.iter_lev.set(self.inner.iter_lev.get() - 1);
+impl std::fmt::Debug for HashRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum HashContent {
-    Map(Box<RubyMap<Value, Value>>),
-    IdentMap(Box<RubyMap<IdentKey, Value>>),
-}
-
-impl std::default::Default for HashContent {
-    fn default() -> Self {
-        HashContent::Map(Box::new(RubyMap::default()))
+impl RubyEql<Executor, Globals, MonorubyErr> for HashRef<'_> {
+    // This type of equality is used for comparison for keys of Hash.
+    fn eql(&self, other: &Self, vm: &mut Executor, globals: &mut Globals) -> Result<bool> {
+        match (self.content(), other.content()) {
+            // A hash and an identity-compared hash never compare equal.
+            (ContentRef::Ident(m1), ContentRef::Ident(m2)) => m1.eql(m2, vm, globals),
+            (ContentRef::Ident(_), _) | (_, ContentRef::Ident(_)) => Ok(false),
+            // Both eql?-keyed: representation (inline vs boxed) must not
+            // matter, so compare pairwise through `get` — the same probe
+            // protocol RubyMap::eql uses.
+            _ => {
+                if self.len() != other.len() {
+                    return Ok(false);
+                }
+                for (k, v) in self.iter() {
+                    match other.get(k, vm, globals)? {
+                        None => return Ok(false),
+                        Some(ov) => {
+                            if !v.eql(&ov, vm, globals)? {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                }
+                Ok(true)
+            }
+        }
     }
 }
 
-impl RubyHash<Executor, Globals, MonorubyErr> for HashContent {
+impl RubyHash<Executor, Globals, MonorubyErr> for HashRef<'_> {
     fn ruby_hash<H: std::hash::Hasher>(
         &self,
         state: &mut H,
         e: &mut Executor,
         g: &mut Globals,
     ) -> Result<()> {
-        match self {
-            HashContent::Map(h) => {
+        match self.content() {
+            ContentRef::Inline(pairs) => {
+                for (key, val) in pairs {
+                    key.ruby_hash(state, e, g)?;
+                    val.ruby_hash(state, e, g)?;
+                }
+            }
+            ContentRef::Map(h) => {
                 for (key, val) in h.iter() {
                     key.ruby_hash(state, e, g)?;
                     val.ruby_hash(state, e, g)?;
                 }
             }
-            HashContent::IdentMap(h) => {
+            ContentRef::Ident(h) => {
                 for (key, val) in h.iter() {
                     key.ruby_hash(state, e, g)?;
                     val.ruby_hash(state, e, g)?;
@@ -501,15 +832,412 @@ impl RubyHash<Executor, Globals, MonorubyErr> for HashContent {
     }
 }
 
-impl RubyEql<Executor, Globals, MonorubyErr> for HashContent {
-    // This type of equality is used for comparison for keys of Hash.
-    fn eql(&self, other: &Self, vm: &mut Executor, globals: &mut Globals) -> Result<bool> {
-        match (self, other) {
-            (HashContent::Map(map1), HashContent::Map(map2)) => map1.eql(map2, vm, globals),
-            (HashContent::IdentMap(map1), HashContent::IdentMap(map2)) => {
-                map1.eql(map2, vm, globals)
+impl alloc::GC<RValue> for HashRef<'_> {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        match self.default_ref() {
+            Some(HashDefault::Proc(p)) => p.mark(alloc),
+            Some(HashDefault::Value(v)) => v.mark(alloc),
+            None => {}
+        }
+        for (k, v) in self.iter() {
+            k.mark(alloc);
+            v.mark(alloc);
+        }
+    }
+}
+
+impl<'a> HashRefMut<'a> {
+    /// Borrow the hash stored in `rv` exclusively.
+    ///
+    /// # Safety
+    /// `rv` must be a live HASH object.
+    pub(super) unsafe fn from_rvalue(rv: &'a mut RValue) -> Self {
+        unsafe {
+            HashRefMut {
+                flags: rv.ty_flags_ptr(),
+                body: NonNull::from(&mut *rv.kind.hash),
+                _marker: PhantomData,
             }
-            _ => Ok(false),
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> HashRef<'_> {
+        HashRef {
+            flags: self.flags,
+            body: self.body,
+            _marker: PhantomData,
+        }
+    }
+
+    fn flags(&self) -> u8 {
+        unsafe { *self.flags.as_ref() }
+    }
+
+    fn set_flags(&mut self, flags: u8) {
+        unsafe { *self.flags.as_mut() = flags }
+    }
+
+    fn set_rep(&mut self, rep: u8) {
+        let f = self.flags();
+        self.set_flags((f & !REP_MASK) | rep);
+    }
+
+    fn body_mut(&mut self) -> &mut HashBody {
+        unsafe { self.body.as_mut() }
+    }
+
+    fn is_inline(&self) -> bool {
+        !flags_is_boxed(self.flags())
+    }
+
+    fn inline_len(&self) -> usize {
+        self.as_ref().inline_len()
+    }
+
+    fn boxed_mut(&mut self) -> &mut BoxedHash {
+        debug_assert!(!self.is_inline());
+        // SAFETY: rep is boxed.
+        unsafe { &mut self.body_mut().boxed }
+    }
+
+    /// Replace the body wholesale, dropping the previous boxed content
+    /// if any, and set the representation bits to match.
+    fn install(&mut self, rep: u8, body: HashBody) {
+        if !self.is_inline() {
+            // SAFETY: rep says the boxed field is live; it is not
+            // touched again before the overwrite below.
+            unsafe { ManuallyDrop::drop(&mut self.body_mut().boxed) }
+        }
+        *self.body_mut() = body;
+        self.set_rep(rep);
+    }
+
+    /// Move an inline hash into its boxed form (the 4th pair, a heap
+    /// key, a default, or `compare_by_identity` arrived). Re-inserting
+    /// packed keys hashes them natively — no Ruby code runs. The live
+    /// iteration depth (header bits) migrates into the exact counter.
+    fn promote(&mut self, ident: bool, vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+        debug_assert!(self.is_inline());
+        let flags = self.flags();
+        let iter_depth = ((flags & ITER_MASK) >> ITER_SHIFT) as u32;
+        let content = if ident {
+            let mut map = RubyMap::default();
+            for (k, v) in self.as_ref().inline_pairs() {
+                map.insert(IdentKey(*k), *v, vm, globals)?;
+            }
+            HashContent::IdentMap(Box::new(map))
+        } else {
+            let mut map = RubyMap::default();
+            for (k, v) in self.as_ref().inline_pairs() {
+                map.insert(*k, *v, vm, globals)?;
+            }
+            HashContent::Map(Box::new(map))
+        };
+        let boxed = BoxedHash {
+            content,
+            default: None,
+            iter_lev: std::cell::Cell::new(iter_depth),
+        };
+        *self.body_mut() = HashBody {
+            boxed: ManuallyDrop::new(boxed),
+        };
+        // rep := boxed, iteration bits cleared (now tracked in iter_lev)
+        self.set_flags((flags & R2K_BIT) | REP_BOXED);
+        Ok(())
+    }
+
+    pub fn insert(
+        &mut self,
+        k: Value,
+        v: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        if self.as_ref().iter_active() && !self.as_ref().contains_key(k, vm, globals)? {
+            return Err(MonorubyErr::runtimeerr(
+                "can't add a new key into hash during iteration",
+            ));
+        }
+        if self.is_inline() {
+            let len = self.inline_len();
+            if let Some(i) = self.as_ref().inline_pos_packed(k) {
+                // SAFETY: rep is inline; i < len.
+                unsafe { self.body_mut().inline[i].1 = v };
+            } else if is_inline_key(k) && len < INLINE_CAP {
+                // SAFETY: rep is inline; the slot exists (len < CAP).
+                unsafe { self.body_mut().inline[len] = (k, v) };
+                self.set_rep(len as u8 + 1);
+            } else {
+                // 4th pair or heap key: move to the boxed map. A heap
+                // key's user-defined #hash is observed (once) by the map
+                // insert, matching the boxed-representation protocol.
+                self.promote(false, vm, globals)?;
+                match &mut self.boxed_mut().content {
+                    HashContent::Map(m) => m.insert(k, v, vm, globals)?,
+                    HashContent::IdentMap(_) => unreachable!(),
+                };
+            }
+            return Ok(());
+        }
+        match &mut self.boxed_mut().content {
+            HashContent::Map(m) => {
+                m.insert(k, v, vm, globals)?;
+            }
+            HashContent::IdentMap(m) => {
+                m.insert(IdentKey(k), v, vm, globals)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn remove(
+        &mut self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<Value>> {
+        // Removing a key during iteration is explicitly allowed — CRuby
+        // behaves the same way (see ruby/spec core/hash/delete_spec.rb
+        // "allows removing a key while iterating").
+        if self.is_inline() {
+            return Ok(match self.as_ref().inline_pos(k, vm, globals)? {
+                Some(i) => Some(self.inline_remove_at(i)),
+                None => None,
+            });
+        }
+        match &mut self.boxed_mut().content {
+            HashContent::Map(m) => m.shift_remove(&k, vm, globals),
+            HashContent::IdentMap(m) => m.shift_remove(&IdentKey(k), vm, globals),
+        }
+    }
+
+    /// Remove the inline pair at `i`, closing the gap (insertion order
+    /// is preserved, like the boxed map's `shift_remove`).
+    fn inline_remove_at(&mut self, i: usize) -> Value {
+        let len = self.inline_len();
+        debug_assert!(i < len);
+        // SAFETY: rep is inline; indices stay within the always-initialized array.
+        unsafe {
+            let v = self.body_mut().inline[i].1;
+            for j in i..len - 1 {
+                self.body_mut().inline[j] = self.body_mut().inline[j + 1];
+            }
+            self.body_mut().inline[len - 1] = (Value::nil(), Value::nil());
+            self.set_rep(len as u8 - 1);
+            v
+        }
+    }
+
+    pub fn clear(&mut self) -> Result<()> {
+        self.as_ref().check_iter()?;
+        if self.is_inline() {
+            self.install(
+                0,
+                HashBody {
+                    inline: empty_pairs(),
+                },
+            );
+        } else if matches!(self.boxed_mut().content, HashContent::IdentMap(_)) {
+            // An identity-compared hash must stay identity-compared, so
+            // it keeps its boxed map. (The default also survives, as in
+            // CRuby: `clear` does not touch it.)
+            match &mut self.boxed_mut().content {
+                HashContent::IdentMap(m) => m.clear(),
+                HashContent::Map(_) => unreachable!(),
+            }
+        } else if self.boxed_mut().default.is_some() {
+            // A default keeps the hash boxed; just empty the map.
+            match &mut self.boxed_mut().content {
+                HashContent::Map(m) => m.clear(),
+                HashContent::IdentMap(_) => unreachable!(),
+            }
+        } else {
+            // Give the boxed storage back — an emptied, default-less
+            // hash is small again by definition.
+            self.install(
+                0,
+                HashBody {
+                    inline: empty_pairs(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub fn shift(
+        &mut self,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<Option<(Value, Value)>> {
+        // Shifting an entry during iteration is allowed, like `delete` —
+        // CRuby permits `h.each { h.shift }`. Only *adding* a key is
+        // rejected mid-iteration.
+        if self.as_ref().len() == 0 {
+            return Ok(None);
+        }
+        if self.is_inline() {
+            // SAFETY: rep is inline; len > 0 was checked above.
+            let k = unsafe { self.body_mut().inline[0].0 };
+            let v = self.inline_remove_at(0);
+            return Ok(Some((k, v)));
+        }
+        match &mut self.boxed_mut().content {
+            HashContent::Map(m) => m
+                .shift_remove_index(0, vm, globals)
+                .map(|opt| opt.map(|(k, v)| (k, v))),
+            HashContent::IdentMap(m) => m
+                .shift_remove_index(0, vm, globals)
+                .map(|opt| opt.map(|(k, v)| (k.0, v))),
+        }
+    }
+
+    /// Set the default value. A non-nil default needs the boxed form
+    /// (the inline payload has no default slot), so setting one on an
+    /// inline hash promotes it — that re-hashes the packed keys
+    /// natively, no Ruby code runs.
+    pub fn set_defalut_value(
+        &mut self,
+        default: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        // A nil default is indistinguishable from no default.
+        if default.is_nil() {
+            if !self.is_inline() {
+                self.boxed_mut().default = None;
+            }
+            return Ok(());
+        }
+        if self.is_inline() {
+            self.promote(false, vm, globals)?;
+        }
+        self.boxed_mut().default = Some(Box::new(HashDefault::Value(default)));
+        Ok(())
+    }
+
+    pub fn set_defalut_proc(
+        &mut self,
+        default_proc: Proc,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        if self.is_inline() {
+            self.promote(false, vm, globals)?;
+        }
+        self.boxed_mut().default = Some(Box::new(HashDefault::Proc(default_proc)));
+        Ok(())
+    }
+
+    pub(crate) fn set_ruby2_keywords_flag(&mut self) {
+        let f = self.flags();
+        self.set_flags(f | R2K_BIT);
+    }
+
+    pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
+        let f = self.flags();
+        self.set_flags(f & !R2K_BIT);
+    }
+
+    pub fn compare_by_identity(&mut self, vm: &mut Executor, globals: &mut Globals) -> Result<()> {
+        self.as_ref().check_iter()?;
+        if self.is_inline() {
+            return self.promote(true, vm, globals);
+        }
+        if let HashContent::Map(m) = &self.boxed_mut().content {
+            let mut new_map = RubyMap::default();
+            for (k, v) in m.iter() {
+                new_map.insert(IdentKey(*k), *v, vm, globals)?;
+            }
+            self.boxed_mut().content = HashContent::IdentMap(Box::new(new_map));
+        }
+        Ok(())
+    }
+
+    ///
+    /// Set the key-comparison mode of an **empty** hash, in either
+    /// direction.
+    ///
+    /// This is the primitive behind CRuby's `rb_hash_replace`, which
+    /// adopts the source hash's comparison mode wholesale — including
+    /// turning identity comparison *off*, which `compare_by_identity` (a
+    /// one-way door) cannot do. Turning it off on a populated map would
+    /// have to merge keys that are `eql?` but not identical, silently
+    /// dropping entries; requiring an empty map keeps the primitive
+    /// lossless. Callers that rebuild a container (`Set#replace` /
+    /// `#map!` / `#flatten!`) clear it first anyway.
+    ///
+    pub fn set_compare_by_identity_empty(&mut self, ident: bool) -> Result<()> {
+        self.as_ref().check_iter()?;
+        assert_eq!(
+            0,
+            self.as_ref().len(),
+            "the map must be empty to change its mode"
+        );
+        if ident {
+            if !self.as_ref().is_compare_by_identity() {
+                let default = if self.is_inline() {
+                    None
+                } else {
+                    self.boxed_mut().default.take()
+                };
+                self.install(
+                    REP_BOXED,
+                    HashBody {
+                        boxed: ManuallyDrop::new(BoxedHash {
+                            content: HashContent::IdentMap(Box::new(RubyMap::default())),
+                            default,
+                            iter_lev: std::cell::Cell::new(0),
+                        }),
+                    },
+                );
+            }
+        } else if self.as_ref().is_compare_by_identity() {
+            let default = self.boxed_mut().default.take();
+            if default.is_some() {
+                self.boxed_mut().default = default;
+                self.boxed_mut().content = HashContent::Map(Box::new(RubyMap::default()));
+            } else {
+                self.install(
+                    0,
+                    HashBody {
+                        inline: empty_pairs(),
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// RAII guard returned from [`HashRef::iter_guard`].
+///
+/// While alive it represents a single layer of active iteration;
+/// dropping it (normal return or unwinding via `Result::Err`) decrements
+/// the count — wherever it currently lives: a hash promoted mid-guard
+/// (e.g. `h.each { h.default = x }`) migrated its depth into the boxed
+/// counter, and the drop follows the representation.
+pub struct IterGuard<'a> {
+    h: HashRef<'a>,
+    /// False for a guard that saturated the inline depth bits and was
+    /// admitted as a no-op (see `iter_guard`).
+    real: bool,
+}
+
+impl Drop for IterGuard<'_> {
+    fn drop(&mut self) {
+        if !self.real {
+            return;
+        }
+        if self.h.is_inline() {
+            let flags = self.h.flags();
+            let depth = (flags & ITER_MASK) >> ITER_SHIFT;
+            debug_assert!(depth > 0);
+            let new = (flags & !ITER_MASK) | ((depth - 1) << ITER_SHIFT);
+            // SAFETY: see `iter_guard`.
+            unsafe { *self.h.flags.as_ptr() = new };
+        } else {
+            let lev = &self.h.boxed().iter_lev;
+            lev.set(lev.get() - 1);
         }
     }
 }
@@ -544,234 +1272,263 @@ impl RubyEql<Executor, Globals, MonorubyErr> for IdentKey {
     }
 }
 
-pub enum MonorubyHashIntoIter {
-    Map(rubymap::map::IntoIter<Value, Value>),
-    IdentMap(rubymap::map::IntoIter<IdentKey, Value>),
+pub enum Iter<'a> {
+    Inline(std::slice::Iter<'a, (Value, Value)>),
+    Map(rubymap::map::Iter<'a, Value, Value>),
+    IdentMap(rubymap::map::Iter<'a, IdentKey, Value>),
 }
 
-impl MonorubyHashIntoIter {
-    fn new(hash: HashContent) -> MonorubyHashIntoIter {
-        match hash {
-            HashContent::Map(map) => MonorubyHashIntoIter::Map(map.into_iter()),
-            HashContent::IdentMap(map) => MonorubyHashIntoIter::IdentMap(map.into_iter()),
-        }
-    }
-}
-
-impl Iterator for MonorubyHashIntoIter {
+impl Iterator for Iter<'_> {
     type Item = (Value, Value);
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            MonorubyHashIntoIter::Map(map) => map.next().map(|(k, v)| (k, v)),
-            MonorubyHashIntoIter::IdentMap(map) => map.next().map(|(k, v)| (k.0, v)),
+            Iter::Inline(pairs) => pairs.next().copied(),
+            Iter::Map(map) => map.next().map(|(k, v)| (*k, *v)),
+            Iter::IdentMap(map) => map.next().map(|(k, v)| (k.0, *v)),
         }
     }
 }
-macro_rules! define_iter {
-    ($($trait:ident),*) => {
-        $(
-            pub enum $trait<'a> {
-                Map(rubymap::map::$trait<'a, Value, Value>),
-                IdentMap(rubymap::map::$trait<'a, IdentKey, Value>),
-            }
-        )*
-    };
-}
 
-define_iter!(Iter, IterMut);
+///
+/// The Hash object handle: a `Value` known to be `ObjTy::HASH`.
+///
+/// Mutating methods run the generational write barrier; read methods
+/// forward to [`HashRef`].
+///
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy)]
+pub struct Hashmap(Value);
 
-macro_rules! define_iter_new {
-    ($ty1: ident, $ty2: ty, $method: ident) => {
-        impl<'a> $ty1<'a> {
-            fn new(hash: $ty2) -> $ty1<'_> {
-                match hash {
-                    HashContent::Map(map) => $ty1::Map(map.$method()),
-                    HashContent::IdentMap(map) => $ty1::IdentMap(map.$method()),
-                }
-            }
-        }
-    };
-}
-
-define_iter_new!(Iter, &HashContent, iter);
-define_iter_new!(IterMut, &mut HashContent, iter_mut);
-
-macro_rules! define_iterator {
-    ($ty2:ident) => {
-        impl<'a> Iterator for $ty2<'a> {
-            type Item = (Value, Value);
-            fn next(&mut self) -> Option<Self::Item> {
-                match self {
-                    $ty2::Map(map) => map.next().map(|(k, v)| (*k, *v)),
-                    $ty2::IdentMap(map) => map.next().map(|(k, v)| (k.0, *v)),
-                }
-            }
-        }
-    };
-}
-
-define_iterator!(Iter);
-define_iterator!(IterMut);
-
-macro_rules! define_into_iterator {
-    ($ty1:ty, $ty2:ident) => {
-        impl<'a> IntoIterator for $ty1 {
-            type Item = (Value, Value);
-            type IntoIter = $ty2<'a>;
-            fn into_iter(self) -> $ty2<'a> {
-                $ty2::new(self)
-            }
-        }
-    };
-}
-
-define_into_iterator!(&'a HashContent, Iter);
-define_into_iterator!(&'a mut HashContent, IterMut);
-
-impl IntoIterator for HashContent {
-    type Item = (Value, Value);
-    type IntoIter = MonorubyHashIntoIter;
-
-    fn into_iter(self) -> MonorubyHashIntoIter {
-        MonorubyHashIntoIter::new(self)
+impl std::convert::From<Hashmap> for Value {
+    fn from(h: Hashmap) -> Value {
+        h.0
     }
 }
 
-impl HashContent {
-    pub(crate) fn new(map: RubyMap<Value, Value>) -> Self {
-        HashContent::Map(Box::new(map))
+impl alloc::GC<RValue> for Hashmap {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        self.0.mark(alloc)
+    }
+}
+
+impl Hashmap {
+    pub(crate) fn new(val: Value) -> Self {
+        assert_eq!(val.ty(), Some(ObjTy::HASH));
+        Self(val)
     }
 
-    pub(crate) fn iter(&self) -> Iter<'_> {
-        Iter::new(self)
+    pub fn new_unchecked(val: Value) -> Self {
+        Self(val)
     }
 
-    pub(crate) fn len(&self) -> usize {
-        match self {
-            HashContent::Map(box map) => map.len(),
-            HashContent::IdentMap(box map) => map.len(),
+    pub fn as_ptr(self) -> *mut RValue {
+        self.0.id() as _
+    }
+
+    pub fn as_val(self) -> Value {
+        self.0
+    }
+
+    /// Borrow the content.
+    pub(crate) fn inner(&self) -> HashRef<'_> {
+        self.0.as_hashmap_inner()
+    }
+
+    pub fn index(&self, vm: &mut Executor, globals: &mut Globals, key: Value) -> Result<Value> {
+        if let Some(v) = self.get(key, vm, globals)? {
+            Ok(v)
+        } else if let Some(proc) = self.inner().defalut_proc() {
+            vm.invoke_proc(globals, &proc, &[self.0, key])
+        } else {
+            Ok(self.inner().defalut_value().unwrap_or_default())
         }
     }
 
-    pub(crate) fn clear(&mut self) {
-        match self {
-            HashContent::Map(box map) => map.clear(),
-            HashContent::IdentMap(box map) => map.clear(),
-        }
+    pub fn get(&self, k: Value, vm: &mut Executor, globals: &mut Globals) -> Result<Option<Value>> {
+        self.inner().get(k, vm, globals)
     }
 
-    pub(crate) fn insert(
+    pub fn contains_key(
+        &self,
+        k: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<bool> {
+        self.inner().contains_key(k, vm, globals)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner().is_empty()
+    }
+
+    pub fn iter(&self) -> Iter<'_> {
+        self.inner().iter()
+    }
+
+    pub fn keys(&self) -> Vec<Value> {
+        self.inner().keys()
+    }
+
+    pub fn values(&self) -> Vec<Value> {
+        self.inner().values()
+    }
+
+    pub fn is_compare_by_identity(&self) -> bool {
+        self.inner().is_compare_by_identity()
+    }
+
+    pub fn defalut_value(&self) -> Option<Value> {
+        self.inner().defalut_value()
+    }
+
+    pub fn defalut_proc(&self) -> Option<Proc> {
+        self.inner().defalut_proc()
+    }
+
+    pub fn default_value(&self) -> Option<Value> {
+        self.inner().default_value()
+    }
+
+    pub fn check_iter(&self) -> Result<()> {
+        self.inner().check_iter()
+    }
+
+    pub fn iter_guard(&self) -> IterGuard<'_> {
+        self.inner().iter_guard()
+    }
+
+    pub fn debug(&self, store: &Store) -> String {
+        self.inner().debug(store)
+    }
+
+    pub fn to_s(&self, store: &Store, self_id: u64) -> String {
+        self.inner().to_s(store, self_id)
+    }
+
+    pub fn inspect_inner(&self, store: &Store, set: &mut HashSet<u64>) -> String {
+        self.inner().inspect_inner(store, set)
+    }
+
+    pub(crate) fn ruby2_keywords_flag(&self) -> bool {
+        self.inner().ruby2_keywords_flag()
+    }
+
+    fn id(&self) -> HashId {
+        self.inner().id()
+    }
+
+    // Write-barrier-protected stores.
+
+    pub fn insert(
         &mut self,
         k: Value,
         v: Value,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<()> {
-        match self {
-            HashContent::Map(box map) => map.insert(k, v, vm, globals)?,
-            HashContent::IdentMap(box map) => map.insert(IdentKey(k), v, vm, globals)?,
-        };
+        self.0.as_hashmap_inner_mut().insert(k, v, vm, globals)?;
+        self.0.write_barrier_bulk();
         Ok(())
     }
 
-    /*pub(crate) fn remove(&mut self, k: Value) -> Option<Value> {
-        match self {
-            HashInfo::Map(map) => map.remove(&HashKey(k)),
-            HashInfo::IdentMap(map) => map.remove(&IdentKey(k)),
-        }
-    }*/
-
-    pub(crate) fn contains_key(
-        &self,
+    pub fn remove(
+        &mut self,
         k: Value,
         vm: &mut Executor,
         globals: &mut Globals,
-    ) -> Result<bool> {
-        match self {
-            HashContent::Map(map) => map.contains_key(&k, vm, globals),
-            HashContent::IdentMap(map) => map.contains_key(&IdentKey(k), vm, globals),
-        }
+    ) -> Result<Option<Value>> {
+        self.0.as_hashmap_inner_mut().remove(k, vm, globals)
     }
 
-    pub(crate) fn keys(&self) -> Vec<Value> {
-        match self {
-            HashContent::Map(map) => map.keys().map(|x| *x).collect(),
-            HashContent::IdentMap(map) => map.keys().map(|x| x.0).collect(),
-        }
+    pub fn clear(&mut self) -> Result<()> {
+        self.0.as_hashmap_inner_mut().clear()
     }
 
-    pub(crate) fn values(&self) -> Vec<Value> {
-        match self {
-            HashContent::Map(map) => map.values().cloned().collect(),
-            HashContent::IdentMap(map) => map.values().cloned().collect(),
-        }
-    }
-
-    pub(crate) fn shift(
+    pub fn shift(
         &mut self,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Option<(Value, Value)>> {
-        if self.len() == 0 {
-            return Ok(None);
-        }
-        match self {
-            HashContent::Map(box map) => map
-                .shift_remove_index(0, vm, globals)
-                .map(|opt| opt.map(|(k, v)| (k, v))),
-            HashContent::IdentMap(box map) => map
-                .shift_remove_index(0, vm, globals)
-                .map(|opt| opt.map(|(k, v)| (k.0, v))),
-        }
+        self.0.as_hashmap_inner_mut().shift(vm, globals)
     }
 
-    pub(crate) fn compare_by_identity(
+    pub fn compare_by_identity(
         &mut self,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<()> {
-        match self {
-            HashContent::Map(box map) => {
-                let mut new_map = RubyMap::default();
-                for (k, v) in map.iter() {
-                    new_map.insert(IdentKey(*k), *v, vm, globals)?;
-                }
-                *self = HashContent::IdentMap(Box::new(new_map));
-            }
-            HashContent::IdentMap(_) => {}
-        }
+        self.0
+            .as_hashmap_inner_mut()
+            .compare_by_identity(vm, globals)?;
+        self.0.write_barrier_bulk();
         Ok(())
     }
 
-    ///
-    /// Set the key-comparison mode of an **empty** map, in either direction.
-    ///
-    /// This is the primitive behind CRuby's `rb_hash_replace`, which adopts
-    /// the source hash's comparison mode wholesale — including turning
-    /// identity comparison *off*, which `compare_by_identity` (a one-way
-    /// door, like `Hash#compare_by_identity`) cannot do. Turning it off on a
-    /// populated map would have to merge keys that are `eql?` but not
-    /// identical, silently dropping entries; requiring an empty map keeps
-    /// the primitive lossless. Callers that rebuild a container (`Set#replace`
-    /// / `#map!` / `#flatten!`) clear it first anyway.
-    ///
-    pub(crate) fn set_compare_by_identity_empty(&mut self, ident: bool) {
-        assert_eq!(0, self.len(), "the map must be empty to change its mode");
-        match (&self, ident) {
-            (HashContent::Map(_), true) => {
-                *self = HashContent::IdentMap(Box::new(RubyMap::default()));
-            }
-            (HashContent::IdentMap(_), false) => {
-                *self = HashContent::Map(Box::new(RubyMap::default()));
-            }
-            _ => {}
-        }
+    pub fn set_compare_by_identity_empty(&mut self, ident: bool) -> Result<()> {
+        self.0.as_hashmap_inner_mut().set_compare_by_identity_empty(ident)
+    }
+
+    pub fn set_defalut_value(
+        &mut self,
+        default: Value,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        self.0
+            .as_hashmap_inner_mut()
+            .set_defalut_value(default, vm, globals)?;
+        self.0.write_barrier(default);
+        Ok(())
+    }
+
+    pub fn set_defalut_proc(
+        &mut self,
+        default_proc: Proc,
+        vm: &mut Executor,
+        globals: &mut Globals,
+    ) -> Result<()> {
+        self.0
+            .as_hashmap_inner_mut()
+            .set_defalut_proc(default_proc, vm, globals)?;
+        self.0.write_barrier_bulk();
+        Ok(())
+    }
+
+    /// Replace the whole content (`Hash#replace`). Bulk barrier: the new
+    /// content may reference young objects.
+    pub fn replace_inner(&mut self, inner: HashmapInner) {
+        let (flags, body) = inner.into_parts();
+        let mut m = self.0.as_hashmap_inner_mut();
+        // keep the receiver's iteration state out of it: replace is a
+        // key-set change and is rejected during iteration by callers.
+        m.install(flags & REP_MASK, body);
+        let f = m.flags();
+        m.set_flags((f & !R2K_BIT) | (flags & R2K_BIT));
+        self.0.write_barrier_bulk();
+    }
+
+    /// Set / clear the ruby2_keywords flag (a plain bit — no GC edge,
+    /// so no write barrier is needed).
+    pub(crate) fn set_ruby2_keywords_flag(&mut self) {
+        self.0.as_hashmap_inner_mut().set_ruby2_keywords_flag();
+    }
+
+    pub(crate) fn unset_ruby2_keywords_flag(&mut self) {
+        self.0.as_hashmap_inner_mut().unset_ruby2_keywords_flag();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rep_of(h: &HashmapInner) -> u8 {
+        h.flags & REP_MASK
+    }
 
     #[test]
     fn hash0() {
@@ -807,5 +1564,320 @@ mod tests {
         assert_eq!(vec![Value::integer(5), Value::integer(7)], map.keys());
         assert_eq!(vec![Value::float(5.7), Value::float(42.5)], map.values());
         assert_eq!(2, map.len())
+    }
+
+    /// Exercise the inline representation end to end: stay inline for
+    /// three packed-key pairs, promote on the 4th pair and on a heap
+    /// key, and keep every operation's result identical across the
+    /// transition.
+    #[test]
+    fn hash_inline() {
+        let mut globals = Globals::new_test();
+        let e = &mut Executor::default();
+        let g = &mut globals;
+
+        let mut h = HashmapInner::default();
+        assert!(h.is_empty());
+        assert_eq!(0, rep_of(&h));
+
+        // fill the three inline slots
+        h.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        h.insert(Value::integer(2), Value::integer(20), e, g).unwrap();
+        h.insert(Value::integer(3), Value::integer(30), e, g).unwrap();
+        assert_eq!(3, rep_of(&h));
+        assert_eq!(3, h.len());
+        // in-place update does not promote
+        h.insert(Value::integer(2), Value::integer(21), e, g).unwrap();
+        assert_eq!(3, rep_of(&h));
+        assert_eq!(
+            Some(Value::integer(21)),
+            h.get(Value::integer(2), e, g).unwrap()
+        );
+        assert_eq!(None, h.get(Value::integer(9), e, g).unwrap());
+        // a heap probe misses without promoting
+        assert_eq!(None, h.get(Value::string_from_str("k"), e, g).unwrap());
+        assert!(h.contains_key(Value::integer(1), e, g).unwrap());
+        assert!(!h.contains_key(Value::string_from_str("k"), e, g).unwrap());
+
+        // remove keeps order and reopens an inline slot
+        assert_eq!(
+            Some(Value::integer(10)),
+            h.remove(Value::integer(1), e, g).unwrap()
+        );
+        assert_eq!(2, h.len());
+        assert_eq!(None, h.remove(Value::integer(1), e, g).unwrap());
+        h.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        assert_eq!(
+            vec![Value::integer(2), Value::integer(3), Value::integer(1)],
+            h.keys()
+        );
+
+        // 4th pair promotes to the boxed map with entries preserved
+        h.insert(Value::integer(4), Value::integer(40), e, g).unwrap();
+        assert_eq!(REP_BOXED, rep_of(&h));
+        assert_eq!(4, h.len());
+        assert_eq!(
+            vec![
+                Value::integer(2),
+                Value::integer(3),
+                Value::integer(1),
+                Value::integer(4)
+            ],
+            h.keys()
+        );
+        assert_eq!(
+            Some(Value::integer(21)),
+            h.get(Value::integer(2), e, g).unwrap()
+        );
+
+        // a heap (String) key promotes even when a slot is free
+        let mut h2 = HashmapInner::default();
+        h2.insert(Value::string_from_str("a"), Value::integer(1), e, g)
+            .unwrap();
+        assert_eq!(REP_BOXED, rep_of(&h2));
+        assert_eq!(
+            Some(Value::integer(1)),
+            h2.get(Value::string_from_str("a"), e, g).unwrap()
+        );
+
+        // inline and boxed hashes with the same entries are eql and hash
+        // equal
+        let mut inline = HashmapInner::default();
+        inline.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        let mut boxed = HashmapInner::default();
+        boxed.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        for i in 8..11 {
+            boxed
+                .insert(Value::integer(i), Value::integer(i), e, g)
+                .unwrap();
+        }
+        assert_eq!(REP_BOXED, rep_of(&boxed));
+        for i in 8..11 {
+            boxed.remove(Value::integer(i), e, g).unwrap();
+        }
+        assert!(inline.eql(&boxed, e, g).unwrap());
+        assert!(boxed.eql(&inline, e, g).unwrap());
+        let digest = |m: &HashmapInner, e: &mut Executor, g: &mut Globals| {
+            let mut s = crate::value::seeded_hasher();
+            m.ruby_hash(&mut s, e, g).unwrap();
+            std::hash::Hasher::finish(&s)
+        };
+        assert_eq!(digest(&inline, e, g), digest(&boxed, e, g));
+
+        // shift walks the inline pairs in insertion order
+        let mut s = HashmapInner::default();
+        s.insert(Value::symbol_from_str("x"), Value::integer(1), e, g)
+            .unwrap();
+        s.insert(Value::symbol_from_str("y"), Value::integer(2), e, g)
+            .unwrap();
+        assert_eq!(
+            Some((Value::symbol_from_str("x"), Value::integer(1))),
+            s.shift(e, g).unwrap()
+        );
+        assert_eq!(
+            Some((Value::symbol_from_str("y"), Value::integer(2))),
+            s.shift(e, g).unwrap()
+        );
+        assert_eq!(None, s.shift(e, g).unwrap());
+
+        // clear returns a boxed, default-less hash to the inline form
+        let mut c = HashmapInner::default();
+        for i in 0..5 {
+            c.insert(Value::integer(i), Value::integer(i), e, g).unwrap();
+        }
+        assert_eq!(REP_BOXED, rep_of(&c));
+        c.clear().unwrap();
+        assert_eq!(0, rep_of(&c));
+        assert!(c.is_empty());
+        c.insert(Value::integer(1), Value::integer(1), e, g).unwrap();
+        assert_eq!(1, rep_of(&c));
+
+        // compare_by_identity promotes an inline hash to an ident map
+        let mut ident = HashmapInner::default();
+        ident
+            .insert(Value::integer(1), Value::integer(10), e, g)
+            .unwrap();
+        ident.compare_by_identity(e, g).unwrap();
+        assert!(ident.is_compare_by_identity());
+        assert_eq!(
+            Some(Value::integer(10)),
+            ident.get(Value::integer(1), e, g).unwrap()
+        );
+        // ... and clear keeps the identity mode
+        ident.clear().unwrap();
+        assert!(ident.is_compare_by_identity());
+        // switching an empty hash's mode goes both ways
+        ident.set_compare_by_identity_empty(false).unwrap();
+        assert!(!ident.is_compare_by_identity());
+        assert_eq!(0, rep_of(&ident));
+        ident.set_compare_by_identity_empty(true).unwrap();
+        assert!(ident.is_compare_by_identity());
+
+        // clone of an inline hash stays inline and is independent
+        let mut orig = HashmapInner::default();
+        orig.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        let mut copy = orig.clone();
+        assert_eq!(1, rep_of(&copy));
+        copy.insert(Value::integer(2), Value::integer(20), e, g).unwrap();
+        assert_eq!(1, orig.len());
+        assert_eq!(2, copy.len());
+
+        // HashmapInner::new converts a small packed-key map to inline
+        let mut small = RubyMap::default();
+        small
+            .insert(Value::integer(1), Value::integer(10), e, g)
+            .unwrap();
+        let conv = HashmapInner::new(small);
+        assert_eq!(1, rep_of(&conv));
+        assert_eq!(1, conv.len());
+        let mut with_heap_key = RubyMap::default();
+        with_heap_key
+            .insert(Value::string_from_str("a"), Value::integer(1), e, g)
+            .unwrap();
+        let conv = HashmapInner::new(with_heap_key);
+        assert_eq!(REP_BOXED, rep_of(&conv));
+        assert_eq!(1, conv.len());
+    }
+
+    /// The identity-keyed arms, the default plumbing (a default forces
+    /// the boxed form), and the iteration guard across representations.
+    #[test]
+    fn hash_ident_and_defaults() {
+        let mut globals = Globals::new_test();
+        let e = &mut Executor::default();
+        let g = &mut globals;
+
+        // identity-keyed: full method surface
+        let mut h = HashmapInner::default();
+        h.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        h.compare_by_identity(e, g).unwrap();
+        h.insert(Value::integer(2), Value::integer(20), e, g).unwrap();
+        assert!(h.contains_key(Value::integer(1), e, g).unwrap());
+        assert!(!h.contains_key(Value::integer(3), e, g).unwrap());
+        assert_eq!(2, h.len());
+        assert_eq!(vec![Value::integer(1), Value::integer(2)], h.keys());
+        assert_eq!(vec![Value::integer(10), Value::integer(20)], h.values());
+        assert_eq!(
+            Some((Value::integer(1), Value::integer(10))),
+            h.shift(e, g).unwrap()
+        );
+        assert_eq!(
+            Some(Value::integer(20)),
+            h.remove(Value::integer(2), e, g).unwrap()
+        );
+        assert_eq!(None, h.remove(Value::integer(2), e, g).unwrap());
+
+        // ident-vs-ident eql, ident-vs-eql-keyed is always false, and
+        // the ident ruby_hash arm digests by id
+        let mut i1 = HashmapInner::default();
+        i1.compare_by_identity(e, g).unwrap();
+        i1.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        let i2 = i1.clone();
+        assert!(i2.is_compare_by_identity());
+        assert!(i1.eql(&i2, e, g).unwrap());
+        let mut plain = HashmapInner::default();
+        plain.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        assert!(!i1.eql(&plain, e, g).unwrap());
+        assert!(!plain.eql(&i1, e, g).unwrap());
+        let mut s = crate::value::seeded_hasher();
+        i1.ruby_hash(&mut s, e, g).unwrap();
+
+        // eql: length mismatch and value mismatch
+        let mut short = HashmapInner::default();
+        short.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        let mut long = short.clone();
+        long.insert(Value::integer(2), Value::integer(20), e, g).unwrap();
+        assert!(!short.eql(&long, e, g).unwrap());
+        let mut diff = HashmapInner::default();
+        diff.insert(Value::integer(1), Value::integer(99), e, g).unwrap();
+        assert!(!short.eql(&diff, e, g).unwrap());
+
+        // an emptied boxed map can switch to identity mode
+        let mut m = RubyMap::default();
+        m.insert(Value::string_from_str("k"), Value::integer(1), e, g)
+            .unwrap();
+        let mut boxed = HashmapInner::new(m);
+        boxed.remove(Value::string_from_str("k"), e, g).unwrap();
+        boxed.set_compare_by_identity_empty(true).unwrap();
+        assert!(boxed.is_compare_by_identity());
+        // Map-arm shift
+        let mut m2 = RubyMap::default();
+        m2.insert(Value::string_from_str("k"), Value::integer(1), e, g)
+            .unwrap();
+        let mut boxed2 = HashmapInner::new(m2);
+        let (sk, sv) = boxed2.shift(e, g).unwrap().unwrap();
+        assert_eq!(Value::integer(1), sv);
+        assert!(sk.eql(&Value::string_from_str("k"), e, g).unwrap());
+
+        // defaults: nil normalizes to no box; a real default forces the
+        // boxed representation and round-trips
+        let mut d = HashmapInner::default();
+        assert_eq!(Some(Value::nil()), d.defalut_value());
+        assert_eq!(None, d.as_ref().default_value());
+        d.insert(Value::integer(1), Value::integer(2), e, g).unwrap();
+        assert_eq!(1, rep_of(&d));
+        d.as_mut().set_defalut_value(Value::nil(), e, g).unwrap();
+        assert_eq!(1, rep_of(&d)); // nil default keeps it inline
+        d.as_mut().set_defalut_value(Value::integer(42), e, g).unwrap();
+        assert_eq!(REP_BOXED, rep_of(&d)); // a real default boxes
+        assert_eq!(Some(Value::integer(42)), d.defalut_value());
+        assert_eq!(Some(Value::integer(42)), d.as_ref().default_value());
+        assert_eq!(
+            Some(Value::integer(2)),
+            d.get(Value::integer(1), e, g).unwrap()
+        );
+        d.as_mut().set_defalut_value(Value::nil(), e, g).unwrap();
+        assert_eq!(Some(Value::nil()), d.defalut_value());
+        assert!(d.as_ref().defalut_proc().is_none());
+        let dm = HashmapInner::new_with_default(RubyMap::default(), Value::integer(7));
+        assert_eq!(REP_BOXED, rep_of(&dm));
+        assert_eq!(Some(Value::integer(7)), dm.defalut_value());
+
+        // r2k flag travels in the flags byte and is dropped by clone
+        let mut r = HashmapInner::default();
+        r.set_ruby2_keywords_flag();
+        assert!(r.ruby2_keywords_flag());
+        assert!(!r.clone().ruby2_keywords_flag());
+        r.unset_ruby2_keywords_flag();
+        assert!(!r.ruby2_keywords_flag());
+
+        // iteration guard: inline bits count up and down, and inserting
+        // a new key mid-iteration fails while updating an existing one
+        // succeeds
+        let mut it = HashmapInner::default();
+        it.insert(Value::integer(1), Value::integer(1), e, g).unwrap();
+        {
+            let r = it.as_ref();
+            let _g1 = r.iter_guard();
+            let _g2 = r.iter_guard();
+            assert!(r.check_iter().is_err());
+        }
+        assert!(it.as_ref().check_iter().is_ok());
+        {
+            let r = it.as_ref();
+            let _g1 = r.iter_guard();
+            // 3 real guards + 1 saturated no-op guard
+            let _g2 = r.iter_guard();
+            let _g3 = r.iter_guard();
+            let _g4 = r.iter_guard();
+        }
+        assert!(it.as_ref().check_iter().is_ok());
+        // (promotion while a guard is live — `h.each { h.default = x }` —
+        // needs two aliases of the same cell and is covered by the
+        // Ruby-level test `hash_default_set_during_iteration`.)
+        it.as_mut()
+            .set_defalut_value(Value::integer(5), e, g)
+            .unwrap();
+        assert_eq!(REP_BOXED, rep_of(&it));
+        assert_eq!(
+            Some(Value::integer(1)),
+            it.get(Value::integer(1), e, g).unwrap()
+        );
+        assert!(it.as_ref().check_iter().is_ok());
+
+        // Debug walks the pairs
+        let mut dbg = HashmapInner::default();
+        dbg.insert(Value::integer(1), Value::integer(2), e, g).unwrap();
+        assert!(!format!("{dbg:?}").is_empty());
     }
 }

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -39,6 +39,12 @@ const R2K_BIT: u8 = 0b0000_1000;
 const ITER_MASK: u8 = 0b0011_0000;
 const ITER_SHIFT: u8 = 4;
 const ITER_MAX: u8 = 3;
+/// The *inline* hash is identity-keyed (`compare_by_identity`).
+/// Identity probing is a pure id scan — no hashing, no Ruby code, and
+/// an id can never go stale — so an identity-keyed inline hash may hold
+/// *any* keys, heap ones included. The boxed form does not use this
+/// bit; there the `HashContent` variant (Map vs IdentMap) is the truth.
+const IDENT_BIT: u8 = 0b0100_0000;
 
 /// Max pairs held inline: the full 48-byte payload.
 pub(crate) const INLINE_CAP: usize = 3;
@@ -48,11 +54,12 @@ pub(super) fn flags_is_boxed(flags: u8) -> bool {
     flags & REP_MASK == REP_BOXED
 }
 
-/// The flags a dup/clone of a hash must carry: the representation bits
-/// travel with the copied body, while the ruby2_keywords flag and any
-/// live iteration count belong to the source object only.
+/// The flags a dup/clone of a hash must carry: the representation and
+/// identity-mode bits travel with the copied body, while the
+/// ruby2_keywords flag and any live iteration count belong to the
+/// source object only.
 pub(super) fn sanitize_dup_flags(flags: u8) -> u8 {
-    flags & REP_MASK
+    flags & (REP_MASK | IDENT_BIT)
 }
 
 /// Drop the live content of `body` according to `flags` (the RValue
@@ -474,12 +481,20 @@ impl<'a> HashRef<'a> {
         HashId(self.body.as_ptr() as usize)
     }
 
-    /// Position of packed key `k` among the inline pairs. Packed values
-    /// are eql? iff their bits are equal (`Value::eql`'s immediate arm),
-    /// so this scan is exactly a map's digest-probe + eql? for these
-    /// keys. Heap keys can never match a packed key.
-    fn inline_pos_packed(&self, k: Value) -> Option<usize> {
-        if !k.is_packed_value() {
+    /// Is this an identity-keyed *inline* hash?
+    fn is_ident_inline(&self) -> bool {
+        self.is_inline() && self.flags() & IDENT_BIT != 0
+    }
+
+    /// Position of `k` among the inline pairs when no `#hash` dispatch
+    /// can be observable: an identity-keyed hash compares ids for any
+    /// key, and in an eql?-keyed hash only a packed probe can match
+    /// (packed values are eql? iff their bits are equal — `Value::eql`'s
+    /// immediate arm — so the id scan is exactly a map's digest-probe +
+    /// eql? for them). An eql?-keyed heap probe returns `None`; whether
+    /// its `#hash` must be observed is the caller's business.
+    fn inline_pos_noobs(&self, k: Value) -> Option<usize> {
+        if !self.is_ident_inline() && !k.is_packed_value() {
             return None;
         }
         self.inline_pairs()
@@ -488,20 +503,19 @@ impl<'a> HashRef<'a> {
     }
 
     /// Position of `k` among the inline pairs, observing the same
-    /// `#hash` protocol a boxed-map lookup would: a heap probe is hashed
-    /// exactly once (dispatching a user-defined `#hash` and propagating
-    /// its errors) even though it can never be eql? to a packed key.
+    /// `#hash` protocol a boxed-map lookup would: an eql?-keyed heap
+    /// probe is hashed exactly once (dispatching a user-defined `#hash`
+    /// and propagating its errors) even though it can never be eql? to a
+    /// packed key. Identity-keyed lookups never hash (matching the
+    /// IdentKey map, which digests ids natively).
     fn inline_pos(
         &self,
         k: Value,
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Option<usize>> {
-        if k.is_packed_value() {
-            Ok(self
-                .inline_pairs()
-                .iter()
-                .position(|(ek, _)| ek.id() == k.id()))
+        if self.is_ident_inline() || k.is_packed_value() {
+            Ok(self.inline_pos_noobs(k))
         } else {
             k.calculate_hash(vm, globals)?;
             Ok(None)
@@ -521,7 +535,11 @@ impl<'a> HashRef<'a> {
     }
 
     pub fn is_compare_by_identity(&self) -> bool {
-        matches!(self.content(), ContentRef::Ident(_))
+        if self.is_inline() {
+            self.flags() & IDENT_BIT != 0
+        } else {
+            matches!(self.content(), ContentRef::Ident(_))
+        }
     }
 
     pub(crate) fn ruby2_keywords_flag(&self) -> bool {
@@ -774,30 +792,28 @@ impl std::fmt::Debug for HashRef<'_> {
 impl RubyEql<Executor, Globals, MonorubyErr> for HashRef<'_> {
     // This type of equality is used for comparison for keys of Hash.
     fn eql(&self, other: &Self, vm: &mut Executor, globals: &mut Globals) -> Result<bool> {
-        match (self.content(), other.content()) {
-            // A hash and an identity-compared hash never compare equal.
-            (ContentRef::Ident(m1), ContentRef::Ident(m2)) => m1.eql(m2, vm, globals),
-            (ContentRef::Ident(_), _) | (_, ContentRef::Ident(_)) => Ok(false),
-            // Both eql?-keyed: representation (inline vs boxed) must not
-            // matter, so compare pairwise through `get` — the same probe
-            // protocol RubyMap::eql uses.
-            _ => {
-                if self.len() != other.len() {
-                    return Ok(false);
-                }
-                for (k, v) in self.iter() {
-                    match other.get(k, vm, globals)? {
-                        None => return Ok(false),
-                        Some(ov) => {
-                            if !v.eql(&ov, vm, globals)? {
-                                return Ok(false);
-                            }
-                        }
+        // A hash and an identity-compared hash never compare equal.
+        if self.is_compare_by_identity() != other.is_compare_by_identity() {
+            return Ok(false);
+        }
+        // Same mode: representation (inline vs boxed) must not matter,
+        // so compare pairwise through `get` — the same probe protocol
+        // RubyMap::eql uses (which for identity hashes is native id
+        // digesting/comparison on both sides).
+        if self.len() != other.len() {
+            return Ok(false);
+        }
+        for (k, v) in self.iter() {
+            match other.get(k, vm, globals)? {
+                None => return Ok(false),
+                Some(ov) => {
+                    if !v.eql(&ov, vm, globals)? {
+                        return Ok(false);
                     }
                 }
-                Ok(true)
             }
         }
+        Ok(true)
     }
 }
 
@@ -810,9 +826,18 @@ impl RubyHash<Executor, Globals, MonorubyErr> for HashRef<'_> {
     ) -> Result<()> {
         match self.content() {
             ContentRef::Inline(pairs) => {
-                for (key, val) in pairs {
-                    key.ruby_hash(state, e, g)?;
-                    val.ruby_hash(state, e, g)?;
+                if self.is_ident_inline() {
+                    // digest keys by id, matching `IdentKey::ruby_hash`
+                    // so inline and boxed identity hashes digest alike
+                    for (key, val) in pairs {
+                        key.id().hash(state);
+                        val.ruby_hash(state, e, g)?;
+                    }
+                } else {
+                    for (key, val) in pairs {
+                        key.ruby_hash(state, e, g)?;
+                        val.ruby_hash(state, e, g)?;
+                    }
                 }
             }
             ContentRef::Map(h) => {
@@ -960,21 +985,26 @@ impl<'a> HashRefMut<'a> {
         }
         if self.is_inline() {
             let len = self.inline_len();
-            if let Some(i) = self.as_ref().inline_pos_packed(k) {
+            let ident = self.as_ref().is_ident_inline();
+            if let Some(i) = self.as_ref().inline_pos_noobs(k) {
                 // SAFETY: rep is inline; i < len.
                 unsafe { self.body_mut().inline[i].1 = v };
-            } else if is_inline_key(k) && len < INLINE_CAP {
+            } else if (ident || is_inline_key(k)) && len < INLINE_CAP {
+                // An identity-keyed inline hash accepts any key (id
+                // probing never goes stale); an eql?-keyed one only
+                // packed immediates.
                 // SAFETY: rep is inline; the slot exists (len < CAP).
                 unsafe { self.body_mut().inline[len] = (k, v) };
                 self.set_rep(len as u8 + 1);
             } else {
-                // 4th pair or heap key: move to the boxed map. A heap
-                // key's user-defined #hash is observed (once) by the map
-                // insert, matching the boxed-representation protocol.
-                self.promote(false, vm, globals)?;
+                // 4th pair — or, in eql? mode, a heap key: move to the
+                // boxed map. An eql?-keyed heap key's user-defined
+                // #hash is observed (once) by the map insert, matching
+                // the boxed-representation protocol.
+                self.promote(ident, vm, globals)?;
                 match &mut self.boxed_mut().content {
                     HashContent::Map(m) => m.insert(k, v, vm, globals)?,
-                    HashContent::IdentMap(_) => unreachable!(),
+                    HashContent::IdentMap(m) => m.insert(IdentKey(k), v, vm, globals)?,
                 };
             }
             return Ok(());
@@ -1031,35 +1061,37 @@ impl<'a> HashRefMut<'a> {
     pub fn clear(&mut self) -> Result<()> {
         self.as_ref().check_iter()?;
         if self.is_inline() {
+            // Keep the mode bit: a cleared identity hash stays
+            // identity-compared.
             self.install(
                 0,
                 HashBody {
                     inline: empty_pairs(),
                 },
             );
-        } else if matches!(self.boxed_mut().content, HashContent::IdentMap(_)) {
-            // An identity-compared hash must stay identity-compared, so
-            // it keeps its boxed map. (The default also survives, as in
-            // CRuby: `clear` does not touch it.)
-            match &mut self.boxed_mut().content {
-                HashContent::IdentMap(m) => m.clear(),
-                HashContent::Map(_) => unreachable!(),
-            }
         } else if self.boxed_mut().default.is_some() {
-            // A default keeps the hash boxed; just empty the map.
+            // A default keeps the hash boxed; just empty the map (the
+            // default itself survives, as in CRuby: `clear` does not
+            // touch it).
             match &mut self.boxed_mut().content {
                 HashContent::Map(m) => m.clear(),
-                HashContent::IdentMap(_) => unreachable!(),
+                HashContent::IdentMap(m) => m.clear(),
             }
         } else {
             // Give the boxed storage back — an emptied, default-less
-            // hash is small again by definition.
+            // hash is small again by definition. An identity-compared
+            // hash keeps its mode via the inline mode bit.
+            let ident = matches!(self.boxed_mut().content, HashContent::IdentMap(_));
             self.install(
                 0,
                 HashBody {
                     inline: empty_pairs(),
                 },
             );
+            if ident {
+                let f = self.flags();
+                self.set_flags(f | IDENT_BIT);
+            }
         }
         Ok(())
     }
@@ -1109,7 +1141,8 @@ impl<'a> HashRefMut<'a> {
             return Ok(());
         }
         if self.is_inline() {
-            self.promote(false, vm, globals)?;
+            let ident = self.as_ref().is_ident_inline();
+            self.promote(ident, vm, globals)?;
         }
         self.boxed_mut().default = Some(Box::new(HashDefault::Value(default)));
         Ok(())
@@ -1122,7 +1155,8 @@ impl<'a> HashRefMut<'a> {
         globals: &mut Globals,
     ) -> Result<()> {
         if self.is_inline() {
-            self.promote(false, vm, globals)?;
+            let ident = self.as_ref().is_ident_inline();
+            self.promote(ident, vm, globals)?;
         }
         self.boxed_mut().default = Some(Box::new(HashDefault::Proc(default_proc)));
         Ok(())
@@ -1141,7 +1175,12 @@ impl<'a> HashRefMut<'a> {
     pub fn compare_by_identity(&mut self, vm: &mut Executor, globals: &mut Globals) -> Result<()> {
         self.as_ref().check_iter()?;
         if self.is_inline() {
-            return self.promote(true, vm, globals);
+            // Just flip the mode bit: the existing keys are packed
+            // immediates, for which eql? and identity coincide, so the
+            // pairs stay valid verbatim — and the hash stays inline.
+            let f = self.flags();
+            self.set_flags(f | IDENT_BIT);
+            return Ok(());
         }
         if let HashContent::Map(m) = &self.boxed_mut().content {
             let mut new_map = RubyMap::default();
@@ -1174,27 +1213,18 @@ impl<'a> HashRefMut<'a> {
             "the map must be empty to change its mode"
         );
         if ident {
-            if !self.as_ref().is_compare_by_identity() {
-                let default = if self.is_inline() {
-                    None
-                } else {
-                    self.boxed_mut().default.take()
-                };
-                self.install(
-                    REP_BOXED,
-                    HashBody {
-                        boxed: ManuallyDrop::new(BoxedHash {
-                            content: HashContent::IdentMap(Box::new(RubyMap::default())),
-                            default,
-                            iter_lev: std::cell::Cell::new(0),
-                        }),
-                    },
-                );
+            if self.is_inline() {
+                // stays inline: the empty pair array serves both modes
+                let f = self.flags();
+                self.set_flags(f | IDENT_BIT);
+            } else if !self.as_ref().is_compare_by_identity() {
+                self.boxed_mut().content = HashContent::IdentMap(Box::new(RubyMap::default()));
             }
+        } else if self.is_inline() {
+            let f = self.flags();
+            self.set_flags(f & !IDENT_BIT);
         } else if self.as_ref().is_compare_by_identity() {
-            let default = self.boxed_mut().default.take();
-            if default.is_some() {
-                self.boxed_mut().default = default;
+            if self.boxed_mut().default.is_some() {
                 self.boxed_mut().content = HashContent::Map(Box::new(RubyMap::default()));
             } else {
                 self.install(
@@ -1498,16 +1528,17 @@ impl Hashmap {
         Ok(())
     }
 
-    /// Replace the whole content (`Hash#replace`). Bulk barrier: the new
-    /// content may reference young objects.
+    /// Replace the whole content (`Hash#replace`). The source's
+    /// representation, identity-mode, and r2k bits replace the
+    /// receiver's (`Hash#replace` transfers the compare_by_identity
+    /// flag in both directions). Bulk barrier: the new content may
+    /// reference young objects.
     pub fn replace_inner(&mut self, inner: HashmapInner) {
         let (flags, body) = inner.into_parts();
         let mut m = self.0.as_hashmap_inner_mut();
-        // keep the receiver's iteration state out of it: replace is a
-        // key-set change and is rejected during iteration by callers.
         m.install(flags & REP_MASK, body);
         let f = m.flags();
-        m.set_flags((f & !R2K_BIT) | (flags & R2K_BIT));
+        m.set_flags((f & !(IDENT_BIT | R2K_BIT)) | (flags & (IDENT_BIT | R2K_BIT)));
         self.0.write_barrier_bulk();
     }
 
@@ -1879,5 +1910,109 @@ mod tests {
         let mut dbg = HashmapInner::default();
         dbg.insert(Value::integer(1), Value::integer(2), e, g).unwrap();
         assert!(!format!("{dbg:?}").is_empty());
+    }
+
+    /// Identity-keyed hashes use the inline representation too: the mode
+    /// bit lives in the flags byte, id probing accepts heap keys, and
+    /// the boxed transitions preserve the mode in both directions.
+    #[test]
+    fn hash_ident_inline() {
+        let mut globals = Globals::new_test();
+        let e = &mut Executor::default();
+        let g = &mut globals;
+
+        // compare_by_identity on a populated inline hash stays inline
+        let mut h = HashmapInner::default();
+        h.insert(Value::integer(1), Value::integer(10), e, g).unwrap();
+        h.compare_by_identity(e, g).unwrap();
+        assert!(h.is_compare_by_identity());
+        assert!(rep_of(&h) != REP_BOXED);
+
+        // heap keys go inline under identity mode; same-content distinct
+        // strings are distinct keys, and re-probing with the same object
+        // hits
+        let s1 = Value::string_from_str("key");
+        let s2 = Value::string_from_str("key");
+        h.insert(s1, Value::integer(100), e, g).unwrap();
+        assert!(rep_of(&h) != REP_BOXED);
+        assert_eq!(2, h.len());
+        assert_eq!(Some(Value::integer(100)), h.get(s1, e, g).unwrap());
+        assert_eq!(None, h.get(s2, e, g).unwrap());
+        assert!(h.contains_key(s1, e, g).unwrap());
+        assert!(!h.contains_key(s2, e, g).unwrap());
+        assert_eq!(Some(Value::integer(100)), h.remove(s1, e, g).unwrap());
+        h.insert(s1, Value::integer(100), e, g).unwrap();
+
+        // the 4th pair promotes to the boxed IdentMap with identical
+        // behavior
+        h.insert(s2, Value::integer(200), e, g).unwrap();
+        h.insert(Value::integer(9), Value::integer(90), e, g).unwrap();
+        assert_eq!(REP_BOXED, rep_of(&h));
+        assert!(h.is_compare_by_identity());
+        assert_eq!(4, h.len());
+        assert_eq!(Some(Value::integer(100)), h.get(s1, e, g).unwrap());
+        assert_eq!(Some(Value::integer(200)), h.get(s2, e, g).unwrap());
+
+        // clear demotes a default-less boxed ident hash back to inline,
+        // keeping the mode
+        h.clear().unwrap();
+        assert!(rep_of(&h) != REP_BOXED);
+        assert!(h.is_compare_by_identity());
+        h.insert(s1, Value::integer(1), e, g).unwrap();
+        assert!(rep_of(&h) != REP_BOXED);
+
+        // inline-ident and boxed-ident with the same entries are eql and
+        // digest alike; ident never equals eql?-keyed
+        let mut inline_i = HashmapInner::default();
+        inline_i.compare_by_identity(e, g).unwrap();
+        inline_i.insert(s1, Value::integer(1), e, g).unwrap();
+        let mut boxed_i = HashmapInner::default();
+        boxed_i.compare_by_identity(e, g).unwrap();
+        boxed_i.insert(s1, Value::integer(1), e, g).unwrap();
+        for i in 0..3 {
+            boxed_i
+                .insert(Value::integer(i), Value::integer(i), e, g)
+                .unwrap();
+        }
+        assert_eq!(REP_BOXED, rep_of(&boxed_i));
+        for i in 0..3 {
+            boxed_i.remove(Value::integer(i), e, g).unwrap();
+        }
+        assert!(inline_i.eql(&boxed_i, e, g).unwrap());
+        assert!(boxed_i.eql(&inline_i, e, g).unwrap());
+        let digest = |m: &HashmapInner, e: &mut Executor, g: &mut Globals| {
+            let mut s = crate::value::seeded_hasher();
+            m.ruby_hash(&mut s, e, g).unwrap();
+            std::hash::Hasher::finish(&s)
+        };
+        assert_eq!(digest(&inline_i, e, g), digest(&boxed_i, e, g));
+
+        // clone keeps the identity mode (and the inline representation)
+        let copy = inline_i.clone();
+        assert!(copy.is_compare_by_identity());
+        assert!(rep_of(&copy) != REP_BOXED);
+        assert_eq!(Some(Value::integer(1)), copy.get(s1, e, g).unwrap());
+
+        // a default still forces boxing, into an IdentMap
+        let mut di = HashmapInner::default();
+        di.compare_by_identity(e, g).unwrap();
+        di.insert(s1, Value::integer(1), e, g).unwrap();
+        di.as_mut()
+            .set_defalut_value(Value::integer(7), e, g)
+            .unwrap();
+        assert_eq!(REP_BOXED, rep_of(&di));
+        assert!(di.is_compare_by_identity());
+        assert_eq!(Some(Value::integer(1)), di.get(s1, e, g).unwrap());
+        assert_eq!(Some(Value::integer(7)), di.defalut_value());
+
+        // shift preserves insertion order across the mode
+        let mut sh = HashmapInner::default();
+        sh.compare_by_identity(e, g).unwrap();
+        sh.insert(s1, Value::integer(1), e, g).unwrap();
+        sh.insert(s2, Value::integer(2), e, g).unwrap();
+        let (k, v) = sh.shift(e, g).unwrap().unwrap();
+        assert_eq!((s1.id(), Value::integer(1)), (k.id(), v));
+        let (k, v) = sh.shift(e, g).unwrap().unwrap();
+        assert_eq!((s2.id(), Value::integer(2)), (k.id(), v));
     }
 }

--- a/rubymap/src/map.rs
+++ b/rubymap/src/map.rs
@@ -1246,6 +1246,9 @@ impl<K, V, E, G, R, S> RubyMap<K, V, E, G, R, S> {
     ///
     /// Computes in **O(1)** time.
     pub fn get_index_entry(&mut self, index: usize) -> Option<IndexedEntry<'_, K, V, E, G, R>> {
+        // IndexedEntry holds live references into the indices table;
+        // promote a linear map first (see IndexMapCore::ensure_indexed).
+        self.core.ensure_indexed();
         if index >= self.len() {
             return None;
         }

--- a/rubymap/src/map/core.rs
+++ b/rubymap/src/map/core.rs
@@ -32,6 +32,19 @@ pub use entry::{Entry, IndexedEntry, OccupiedEntry, VacantEntry};
 pub(crate) struct IndexMapCore<K, V, E, G, R> {
     /// indices mapping from the entry hash to its index.
     indices: Indices<E, G, R>,
+    /// CRuby's ar_table idea: while the map stays at or below
+    /// [`AR_MAX`] entries, `indices` is left unbuilt (empty, no
+    /// allocation) and lookups scan `entries` linearly, comparing the
+    /// stored hash first and `eql` only on a hash match — the same
+    /// probe/eql pattern as the indexed path, so nothing observable
+    /// changes. The first insert taking the map past `AR_MAX` (or an
+    /// operation that needs the table, e.g. the `Entry` API) promotes
+    /// via [`Self::ensure_indexed`]; promotion is one-way except
+    /// `clear`, which resets to linear.
+    ///
+    /// Invariants: `linear` ⇒ `indices.is_empty()`;
+    /// `!linear` ⇒ `indices.len() == entries.len()`.
+    linear: bool,
     /// entries is a dense vec maintaining entry order.
     entries: Entries<K, V>,
 }
@@ -123,6 +136,7 @@ where
     }
 
     fn clone_from(&mut self, other: &Self) {
+        self.linear = other.linear;
         self.indices.clone_from(&other.indices);
         if self.entries.capacity() < other.entries.len() {
             // If we must resize, match the indices capacity.
@@ -160,6 +174,10 @@ impl<K, V, E, G, R> crate::Entries for IndexMapCore<K, V, E, G, R> {
     }
 }
 
+/// Entry count up to which the indices table is left unbuilt (see the
+/// `linear` field). Matches CRuby's `RHASH_AR_TABLE_MAX_SIZE`.
+const AR_MAX: usize = 8;
+
 impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     /// The maximum capacity before the `entries` allocation would exceed `isize::MAX`.
     const MAX_ENTRIES_CAPACITY: usize = (isize::MAX as usize) / mem::size_of::<Bucket<K, V>>();
@@ -169,6 +187,7 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         IndexMapCore {
             indices: Indices::new(),
             entries: Vec::new(),
+            linear: true,
         }
     }
 
@@ -179,25 +198,73 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
 
     #[inline]
     pub(crate) fn with_capacity(n: usize) -> Self {
-        IndexMapCore {
-            indices: Indices::with_capacity(n),
-            entries: Vec::with_capacity(n),
+        // A small-capacity map starts linear: the indices allocation is
+        // deferred until (if ever) it outgrows `AR_MAX`.
+        if n <= AR_MAX {
+            IndexMapCore {
+                indices: Indices::new(),
+                entries: Vec::with_capacity(n),
+                linear: true,
+            }
+        } else {
+            IndexMapCore {
+                indices: Indices::with_capacity(n),
+                entries: Vec::with_capacity(n),
+                linear: false,
+            }
         }
     }
 
     #[inline]
     pub(crate) fn len(&self) -> usize {
-        self.indices.len()
+        self.entries.len()
     }
 
     #[inline]
     pub(crate) fn capacity(&self) -> usize {
-        Ord::min(self.indices.capacity(), self.entries.capacity())
+        if self.linear {
+            self.entries.capacity()
+        } else {
+            Ord::min(self.indices.capacity(), self.entries.capacity())
+        }
+    }
+
+    /// Build the indices table from `entries` and leave linear mode.
+    /// Idempotent; the entry hashes were computed at insertion time, so
+    /// no key is re-hashed.
+    pub(super) fn ensure_indexed(&mut self) {
+        if self.linear {
+            self.indices
+                .reserve(self.entries.len(), get_hash(&self.entries));
+            insert_bulk_no_grow(&mut self.indices, &self.entries);
+            self.linear = false;
+        }
+    }
+
+    /// Linear-mode lookup: stored-hash compare first, `eql` only on a
+    /// hash match — the indexed path's exact probe pattern.
+    fn linear_find<Q>(
+        &self,
+        hash: HashValue,
+        key: &Q,
+        e: &mut E,
+        g: &mut G,
+    ) -> Result<Option<usize>, R>
+    where
+        Q: ?Sized + Equivalent<K, E, G, R>,
+    {
+        for (i, entry) in self.entries.iter().enumerate() {
+            if entry.hash == hash && key.equivalent(&entry.key, e, g)? {
+                return Ok(Some(i));
+            }
+        }
+        Ok(None)
     }
 
     pub(crate) fn clear(&mut self) {
         self.indices.clear();
         self.entries.clear();
+        self.linear = true;
     }
 
     pub(crate) fn truncate(&mut self, len: usize, e: &mut E, g: &mut G) -> Result<(), R> {
@@ -234,13 +301,35 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         self.erase_indices(at, self.entries.len(), e, g)?;
         let entries = self.entries.split_off(at);
 
+        if self.linear {
+            return Ok(Self {
+                indices: Indices::new(),
+                entries,
+                linear: true,
+            });
+        }
         let mut indices = Indices::with_capacity(entries.len());
         insert_bulk_no_grow(&mut indices, &entries);
-        Ok(Self { indices, entries })
+        Ok(Self {
+            indices,
+            entries,
+            linear: false,
+        })
     }
 
     /// Reserve capacity for `additional` more key-value pairs.
     pub(crate) fn reserve(&mut self, additional: usize) {
+        // A reservation that must outgrow linear mode builds the table
+        // up front (so the bulk insert that follows doesn't pay a
+        // per-insert promotion check); a small one stays linear.
+        if self.linear {
+            if self.entries.len() + additional > AR_MAX {
+                self.ensure_indexed();
+            } else {
+                self.entries.reserve(additional);
+                return;
+            }
+        }
         self.indices.reserve(additional, get_hash(&self.entries));
         // Only grow entries if necessary, since we also round up capacity.
         if additional > self.entries.capacity() - self.entries.len() {
@@ -250,22 +339,34 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
 
     /// Reserve capacity for `additional` more key-value pairs, without over-allocating.
     pub(crate) fn reserve_exact(&mut self, additional: usize) {
+        if self.linear {
+            if self.entries.len() + additional > AR_MAX {
+                self.ensure_indexed();
+            } else {
+                self.entries.reserve_exact(additional);
+                return;
+            }
+        }
         self.indices.reserve(additional, get_hash(&self.entries));
         self.entries.reserve_exact(additional);
     }
 
     /// Shrink the capacity of the map with a lower bound
     pub(crate) fn shrink_to(&mut self, min_capacity: usize) {
-        self.indices
-            .shrink_to(min_capacity, get_hash(&self.entries));
+        if !self.linear {
+            self.indices
+                .shrink_to(min_capacity, get_hash(&self.entries));
+        }
         self.entries.shrink_to(min_capacity);
     }
 
     /// Remove the last key-value pair
     pub(crate) fn pop(&mut self, e: &mut E, g: &mut G) -> Result<Option<(K, V)>, R> {
         Ok(if let Some(entry) = self.entries.pop() {
-            let last = self.entries.len();
-            erase_index(&mut self.indices, entry.hash, last, e, g)?;
+            if !self.linear {
+                let last = self.entries.len();
+                erase_index(&mut self.indices, entry.hash, last, e, g)?;
+            }
             Some((entry.key, entry.value))
         } else {
             None
@@ -283,6 +384,9 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         Q: ?Sized + Equivalent<K, E, G, R>,
     {
+        if self.linear {
+            return self.linear_find(hash, key, e, g);
+        }
         let eq = equivalent(key, &self.entries);
         Ok(self.indices.find(hash.get(), eq, e, g)?.copied())
     }
@@ -309,6 +413,18 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         K: RubyEql<E, G, R>,
     {
+        if self.linear {
+            if let Some(i) = self.linear_find(hash, &key, e, g)? {
+                return Ok((i, Some(mem::replace(&mut self.entries[i].value, value))));
+            }
+            if self.entries.len() < AR_MAX {
+                let i = self.entries.len();
+                self.push_entry(hash, key, value);
+                return Ok((i, None));
+            }
+            // Crossing AR_MAX: build the table once, then fall through.
+            self.ensure_indexed();
+        }
         let eq = equivalent(&key, &self.entries);
         let hasher = get_hash(&self.entries);
         match self.indices.entry(hash.get(), eq, hasher, e, g)? {
@@ -336,6 +452,19 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         I: ruby_traits::RubySymEql,
         K: Borrow<I> + From<I>,
     {
+        if self.linear {
+            for (i, entry) in self.entries.iter().enumerate() {
+                if entry.hash == hash && SymEquivalent::equivalent(&key, entry.key.borrow()) {
+                    return (i, Some(mem::replace(&mut self.entries[i].value, value)));
+                }
+            }
+            if self.entries.len() < AR_MAX {
+                let i = self.entries.len();
+                self.push_entry(hash, K::from(key), value);
+                return (i, None);
+            }
+            self.ensure_indexed();
+        }
         let eq = sym_equivalent(&key, &self.entries);
         let hasher = get_hash(&self.entries);
         match self.indices.entry_sym(hash.get(), eq, hasher) {
@@ -365,6 +494,7 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         K: RubyEql<E, G, R>,
     {
+        self.ensure_indexed();
         let eq = equivalent(&key, &self.entries);
         let hasher = get_hash(&self.entries);
         match self.indices.entry(hash.get(), eq, hasher, e, g)? {
@@ -398,6 +528,15 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         Q: ?Sized + Equivalent<K, E, G, R>,
     {
+        if self.linear {
+            return Ok(match self.linear_find(hash, key, e, g)? {
+                Some(index) => {
+                    let entry = self.entries.remove(index);
+                    Some((index, entry.key, entry.value))
+                }
+                None => None,
+            });
+        }
         let eq = equivalent(key, &self.entries);
         Ok(match self.indices.find_entry(hash.get(), eq, e, g)? {
             Ok(entry) => {
@@ -417,6 +556,14 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         e: &mut E,
         g: &mut G,
     ) -> Result<Option<(K, V)>, R> {
+        if self.linear {
+            return Ok(if index < self.entries.len() {
+                let entry = self.entries.remove(index);
+                Some((entry.key, entry.value))
+            } else {
+                None
+            });
+        }
         self.borrow_mut().shift_remove_index(index, e, g)
     }
 
@@ -429,6 +576,17 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         e: &mut E,
         g: &mut G,
     ) -> Result<(), R> {
+        if self.linear {
+            // Pure entry rotation; there are no indices to fix up.
+            let _ = &self.entries[from];
+            let _ = &self.entries[to];
+            if from < to {
+                self.entries[from..=to].rotate_left(1);
+            } else {
+                self.entries[to..=from].rotate_right(1);
+            }
+            return Ok(());
+        }
         self.borrow_mut().move_index(from, to, e, g)
     }
 
@@ -443,6 +601,15 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         Q: ?Sized + Equivalent<K, E, G, R>,
     {
+        if self.linear {
+            return Ok(match self.linear_find(hash, key, e, g)? {
+                Some(index) => {
+                    let entry = self.entries.swap_remove(index);
+                    Some((index, entry.key, entry.value))
+                }
+                None => None,
+            });
+        }
         let eq = equivalent(key, &self.entries);
         Ok(match self.indices.find_entry(hash.get(), eq, e, g)? {
             Ok(entry) => {
@@ -462,6 +629,14 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         e: &mut E,
         g: &mut G,
     ) -> Result<Option<(K, V)>, R> {
+        if self.linear {
+            return Ok(if index < self.entries.len() {
+                let entry = self.entries.swap_remove(index);
+                Some((entry.key, entry.value))
+            } else {
+                None
+            });
+        }
         self.borrow_mut().swap_remove_index(index, e, g)
     }
 
@@ -470,6 +645,10 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     /// All of these items should still be at their original location in `entries`.
     /// This is used by `drain`, which will let `Vec::drain` do the work on `entries`.
     fn erase_indices(&mut self, start: usize, end: usize, e: &mut E, g: &mut G) -> Result<(), R> {
+        if self.linear {
+            // No table to fix up; the caller adjusts `entries` itself.
+            return Ok(());
+        }
         let (init, shifted_entries) = self.entries.split_at(end);
         let (start_entries, erased_entries) = init.split_at(start);
 
@@ -522,12 +701,16 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     {
         self.entries
             .retain_mut(|entry| keep(&mut entry.key, &mut entry.value));
-        if self.entries.len() < self.indices.len() {
+        if !self.linear && self.entries.len() < self.indices.len() {
             self.rebuild_hash_table();
         }
     }
 
     fn rebuild_hash_table(&mut self) {
+        if self.linear {
+            debug_assert!(self.indices.is_empty());
+            return;
+        }
         self.indices.clear();
         insert_bulk_no_grow(&mut self.indices, &self.entries);
     }
@@ -553,7 +736,10 @@ fn reserve_entries<K, V, E, G, R>(
     // Use a soft-limit on the maximum capacity, but if the caller explicitly
     // requested more, do it and let them have the resulting panic.
     let try_capacity = try_capacity.min(IndexMapCore::<K, V, E, G, R>::MAX_ENTRIES_CAPACITY);
-    let try_add = try_capacity - entries.len();
+    // In linear mode the indices table has capacity 0, so the sync-up
+    // target can sit below the current length; saturate instead of
+    // underflowing (try_add == 0 then falls through to reserve_exact).
+    let try_add = try_capacity.saturating_sub(entries.len());
     if try_add > additional && entries.try_reserve_exact(try_add).is_ok() {
         return;
     }

--- a/rubymap/src/map/core/entry.rs
+++ b/rubymap/src/map/core/entry.rs
@@ -14,6 +14,10 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
     where
         K: RubyEql<E, G, R>,
     {
+        // The Entry API hands out live references into the indices
+        // table; promote a linear map instead of teaching every entry
+        // flavour about both modes.
+        self.ensure_indexed();
         let entries = &mut self.entries;
         let eq = equivalent(&key, entries);
         Ok(match self.indices.find_entry(hash.get(), eq, e, g)? {

--- a/rubymap/src/map/tests.rs
+++ b/rubymap/src/map/tests.rs
@@ -1508,3 +1508,135 @@ fn disjoint_indices_mut_fail_duplicate() {
         Err(crate::GetDisjointMutError::OverlappingIndices)
     );
 }
+
+/// Exercise every linear-mode (ar_table) arm of `IndexMapCore` through
+/// the public API: small maps never build the indices table, the 9th
+/// insert promotes, and every mutation flavour works in both modes.
+#[test]
+fn linear_mode_small_maps() {
+    let mut e = E;
+    let mut g = G;
+
+    // Linear insert / update / lookup, then promotion at the 9th key.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..8 {
+        assert_eq!(map.insert(i, i * 10, &mut e, &mut g).unwrap(), None);
+    }
+    assert_eq!(map.insert(3, 333, &mut e, &mut g).unwrap(), Some(30)); // linear replace
+    assert_eq!(map.get(&3, &mut e, &mut g).unwrap(), Some(&333));
+    assert_eq!(map.get(&99, &mut e, &mut g).unwrap(), None); // linear miss
+    assert_eq!(map.insert(8, 80, &mut e, &mut g).unwrap(), None); // promotes
+    assert_eq!(map.len(), 9);
+    for i in 0..9 {
+        assert!(map.get(&i, &mut e, &mut g).unwrap().is_some());
+    }
+
+    // Linear removals: by key (shift + swap), by index, and pop.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..6 {
+        map.insert(i, i, &mut e, &mut g).unwrap();
+    }
+    assert_eq!(map.shift_remove(&2, &mut e, &mut g).unwrap(), Some(2));
+    assert_eq!(map.shift_remove(&42, &mut e, &mut g).unwrap(), None);
+    assert_eq!(map.swap_remove(&0, &mut e, &mut g).unwrap(), Some(0));
+    assert_eq!(map.swap_remove(&42, &mut e, &mut g).unwrap(), None);
+    assert_eq!(map.pop(&mut e, &mut g).unwrap(), Some((4, 4)));
+    let keys: Vec<i32> = map.keys().copied().collect();
+    assert_eq!(keys, vec![5, 1, 3]);
+
+    // Order maintenance while linear: move_index both directions,
+    // reverse, retain, truncate.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..5 {
+        map.insert(i, i, &mut e, &mut g).unwrap();
+    }
+    map.move_index(0, 3, &mut e, &mut g).unwrap();
+    map.move_index(3, 1, &mut e, &mut g).unwrap();
+    map.reverse();
+    map.retain(|k, _| *k != 2);
+    map.truncate(3, &mut e, &mut g).unwrap();
+    assert_eq!(map.len(), 3);
+    assert_eq!(map.get(&2, &mut e, &mut g).unwrap(), None);
+
+    // drain / split_off on a linear map keep both halves working.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..6 {
+        map.insert(i, i, &mut e, &mut g).unwrap();
+    }
+    let drained: Vec<(i32, i32)> = map.drain(0..2, &mut e, &mut g).unwrap().collect();
+    assert_eq!(drained, vec![(0, 0), (1, 1)]);
+    let tail = map.split_off(2, &mut e, &mut g).unwrap();
+    assert_eq!(map.len(), 2);
+    assert_eq!(tail.len(), 2);
+    assert_eq!(tail.get(&5, &mut e, &mut g).unwrap(), Some(&5));
+
+    // clear resets to linear; reserve past AR_MAX promotes eagerly,
+    // a small reserve/reserve_exact/shrink_to stays linear.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    map.insert(1, 1, &mut e, &mut g).unwrap();
+    map.reserve(2);
+    map.reserve_exact(2);
+    map.shrink_to(0);
+    assert_eq!(map.get(&1, &mut e, &mut g).unwrap(), Some(&1));
+    map.reserve(64); // promotes
+    map.insert(2, 2, &mut e, &mut g).unwrap();
+    assert_eq!(map.len(), 2);
+    map.clear();
+    map.insert(7, 7, &mut e, &mut g).unwrap();
+    assert_eq!(map.get(&7, &mut e, &mut g).unwrap(), Some(&7));
+    let mut map2: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    map2.reserve_exact(64); // promotes the exact flavour too
+    map2.insert(1, 1, &mut e, &mut g).unwrap();
+    assert_eq!(map2.len(), 1);
+
+    // with_capacity: small stays table-free, large pre-builds.
+    let small: RubyMap<i32, i32, E, G, ()> = RubyMap::with_capacity(4);
+    assert_eq!(small.len(), 0);
+    let mut large: RubyMap<i32, i32, E, G, ()> = RubyMap::with_capacity(32);
+    large.insert(1, 1, &mut e, &mut g).unwrap();
+    assert_eq!(large.get(&1, &mut e, &mut g).unwrap(), Some(&1));
+
+    // clone of a linear map stays consistent.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    map.insert(1, 10, &mut e, &mut g).unwrap();
+    let clone = map.clone();
+    assert_eq!(clone.get(&1, &mut e, &mut g).unwrap(), Some(&10));
+
+    // Entry / IndexedEntry APIs promote a linear map and stay correct.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    map.insert(1, 10, &mut e, &mut g).unwrap();
+    *map.entry(2, &mut e, &mut g).unwrap().or_insert(20) += 1;
+    assert_eq!(map.get(&2, &mut e, &mut g).unwrap(), Some(&21));
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..3 {
+        map.insert(i, i, &mut e, &mut g).unwrap();
+    }
+    let entry = map.get_index_entry(1).unwrap();
+    assert_eq!(*entry.key(), 1);
+
+    // Index-based removals on a linear map.
+    let mut map: RubyMap<i32, i32, E, G, ()> = RubyMap::new();
+    for i in 0..5 {
+        map.insert(i, i, &mut e, &mut g).unwrap();
+    }
+    assert_eq!(map.shift_remove_index(1, &mut e, &mut g).unwrap(), Some((1, 1)));
+    assert_eq!(map.swap_remove_index(0, &mut e, &mut g).unwrap(), Some((0, 0)));
+    assert_eq!(map.shift_remove_index(99, &mut e, &mut g).unwrap(), None);
+    assert_eq!(map.swap_remove_index(99, &mut e, &mut g).unwrap(), None);
+    let keys: Vec<i32> = map.keys().copied().collect();
+    assert_eq!(keys, vec![4, 2, 3]);
+}
+
+/// Symbol-keyed maps take the `insert_full_sym` linear arm: replace,
+/// promote past AR_MAX, and lookup.
+#[test]
+fn linear_mode_sym_maps() {
+    let mut map: RubyMap<Value, i32, E, G, ()> = RubyMap::new();
+    for i in 0..8 {
+        assert_eq!(map.insert_sym(Symbol(i), i), None);
+    }
+    assert_eq!(map.insert_sym(Symbol(3), 333), Some(3)); // linear replace
+    assert_eq!(map.insert_sym(Symbol(8), 8), None); // promotes
+    assert_eq!(map.len(), 9);
+    assert_eq!(map.insert_sym(Symbol(8), 88), Some(8)); // indexed replace
+}


### PR DESCRIPTION
## Summary

Four stacked layers of CRuby's small-hash strategy:

1. **AR mode in `rubymap`** — while a map stays at ≤ 8 entries, the hash-index table is never built; lookups and mutations operate on the ordered entry list alone, and the first insert past `AR_MAX` promotes once. Key hashing is untouched and its cost accepted — entries store their hashes and the linear probe compares the stored hash before `eql`, exactly like the indexed probe, so the observable `#hash`/`#eql?` pattern is identical.
2. **JIT `ty` guards go byte-wide** — the five x86-64 `cmpw [RVALUE_OFFSET_TY]` Array guards read the adjacent header byte, forcing it to zero. They become `cmpb` (aarch64 already did all five mirrored checks with 1-byte `ldrb`, proving the wide compare carried no semantics; dropping the 16-bit immediate also removes an x86 LCP decode stall). The freed byte becomes `ty_flags`: a per-ObjTy metadata byte, preserved by dup/clone and the JIT literal-copy path.
3. **Three inline pairs in the RValue cell** — the Hash representation bits move into `ty_flags` (bits 0-2: inline pair count 0..=3 or boxed; bit 3: ruby2_keywords; bits 4-5: inline iteration depth), freeing the **entire 48-byte payload** for three key-value pairs. Everything else lives behind a boxed `{content, default, iter_lev}`. `{}` and ≤3-pair packed-key hashes allocate **nothing beyond the RValue cell**, like CRuby's RHASH-embedded ar_table.
4. **`compare_by_identity` in the flags byte too (bit 6)** — identity probing is a pure id scan (no hashing, no Ruby code, ids never go stale), so an identity-keyed inline hash may hold **any** keys, heap ones included. `compare_by_identity` on an inline hash just flips the bit (packed keys' `eql?` and identity coincide), `clear` demotes a default-less boxed identity hash back to inline with its mode intact, and `Hash#replace` transfers the mode bits in both directions (pinned by ruby/spec's replace specs and a new cargo test).

## Inline-representation rules

- An eql?-keyed hash stays inline only while every key is a **packed immediate** (Fixnum / Flonum / Symbol / nil / true / false): their identity *is* their content, so a recomputed digest can never go stale — the `Hash#rehash` mutable-key protocol stays with the boxed maps, which heap keys promote to. Identity-keyed inline hashes take any keys.
- Lookup observability matches the boxed map exactly: an eql?-keyed heap probe's `#hash` is dispatched **once** (errors propagate); identity lookups never hash, matching the IdentKey map.
- Promotion on the 4th pair, an eql?-mode heap key, or a non-nil default (`default=` mid-iteration migrates the live iteration depth into the boxed counter — covered by a dedicated test); `clear` returns a default-less boxed hash to the inline form.
- Borrowed access pairs the header byte with the payload via new `HashRef`/`HashRefMut` handles; `HashmapInner` remains the owned/builder form (`{flags, body}`), so stack-construction sites are unchanged and `gen_hash` builds literals with zero intermediate allocation.

## Measurements (master `8277332` vs this PR, A/B interleaved)

**Memory — malloc bytes per hash (`GC.stat[:malloc_increase_bytes]`; CRuby = 0 for all):**

| hash | master | this PR |
|---|---|---|
| `{}` literal | 30 | **0** |
| 1–3 entries (int/sym keys) | 54–55 | **0** |
| ≤3-entry `compare_by_identity` (any keys) | 55 | **0** |
| small heap-key eql? hash (boxed) | 55 | 11 |

**Speed:**

| benchmark | master | this PR | Δ | YJIT ref |
|---|---|---|---|---|
| literal `{1=>1,2=>2}` | 4.2 M ops/s | **25.2** | **×6.0** | 15.3 |
| `{}` + 3 inserts | 2.7 | **14.2** | **×5.3** | 9.0 |
| delete+insert cycle (sz=3) | 10.6 | **35.0** | **×3.3** | 18.6 |
| lookup, 1–3 entries (hit/miss) | ~30 | **104–126** | **×4** | — |
| identity-hash 2-entry hit | 37 | **83–89** | **×2.3** | — |
| literal, 5 entries (AR mode) | 2.3 | 2.9 | +26% | 17.2 |
| literal, 8 entries (AR mode) | 1.4 | 1.9 | +36% | 18.7 |
| `{}` + 9 inserts (promote) | 1.0 | 1.1 | +10% | 1.8 |
| lookup, ≥ 4 entries | ~29–31 | ~28–31 | ±0 | — |
| String-key 4-entry hit | 34 | 33 | −4% | — |
| iteration (sz 8 / 64) | — | — | ±0 | — |

**Macro:** optcarrot 262 → 276 fps (**+5%**, identical checksum); app_fib / binarytrees / quick_sort neutral.

## Tests

- Full monoruby suite under the CI-equivalent profile (`gc-stress` + `stress-spill-pool`): **3147+ passed, 0 failed** (run single-threaded; the parallel-mode `tests/method_call.rs` SIGABRT reproduces identically on master and is pre-existing — invisible in CI because nextest isolates processes)
- Unit tests drive both inline modes end to end (promotion on 4th pair / heap key / default, cross-representation `eql` + `#hash` digest equality for both eql? and identity modes, shift/clear/ident transitions in both directions, clone independence, r2k and identity bits in the flags byte, saturating iteration-depth bits) plus Ruby-level tests for deep guard nesting, `default=` during `each`, and `Hash#replace` mode transfer
- 10-case semantics script byte-identical to CRuby 4.0.2
- `core/hash` / `core/set` specs: no change vs master (the two remaining core/hash issues — a mock-count spec and a prism multibyte-eval error — reproduce identically on master). The 3-pair head passed the **full 60-category ruby/spec sweep vs master with zero regressions** (only nondeterministic thread expectation counts differ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM