### PR TITLE
thread: fix Queue/SizedQueue/ConditionVariable ruby/spec failures

### DIFF
--- a/monoruby/builtins/thread.rb
+++ b/monoruby/builtins/thread.rb
@@ -493,7 +493,13 @@ class Thread
       begin
         timeout ? Kernel.sleep(timeout) : Thread.stop
       ensure
-        lock
+        # The re-acquire must complete even when a kill / Thread#raise
+        # arrives while parked waiting for the lock (CRuby re-acquires
+        # with mutex_lock_uninterruptible): a ConditionVariable#wait-er
+        # killed after being signaled still owns the mutex in its own
+        # ensure blocks. The deferred interrupt fires right after the
+        # lock is held.
+        Thread.__uninterruptible { lock }
       end
       (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round
     end
@@ -512,11 +518,29 @@ class Thread
     # StopIteration subclass (so `loop { q.pop }` ends cleanly on close);
     # a `raise ClosedQueueError` inside a `loop` block would be silently
     # eaten and turned into a nil return.
-    def initialize
+    def initialize(enum = nil)
       @items = []
       @closed = false
       @mutex = Mutex.new
       @cv_pop = ConditionVariable.new
+      unless enum.nil?
+        # CRuby's rb_convert_type protocol (to_a), messages included.
+        unless enum.respond_to?(:to_a)
+          raise TypeError, "can't convert #{enum.class} into Array"
+        end
+        ary = enum.to_a # a NoMethodError raised inside #to_a propagates
+        unless ary.is_a?(Array)
+          raise TypeError,
+                "can't convert #{enum.class} into Array (#{enum.class}#to_a gives #{ary.class})"
+        end
+        @items.concat(ary)
+      end
+    end
+
+    # Queue holds runtime synchronization state: freezing is rejected
+    # (CRuby raises regardless of receiver state).
+    def freeze
+      raise TypeError, "cannot freeze #{self}"
     end
 
     def push(item)
@@ -622,8 +646,7 @@ class Thread
 
   class SizedQueue < Queue
     def initialize(max)
-      max = max.to_int if !max.is_a?(Integer) && max.respond_to?(:to_int)
-      raise ArgumentError, "queue size must be positive" unless max.is_a?(Integer) && max > 0
+      max = __check_capacity(max)
       super()
       @max = max
       @cv_push = ConditionVariable.new
@@ -631,8 +654,28 @@ class Thread
 
     attr_reader :max
 
+    # CRuby's NUM2LONG semantics for the capacity: a non-Integer converts
+    # via #to_int (so 12.9 truncates to 12), anything inconvertible is a
+    # TypeError, and only then is positivity checked (ArgumentError).
+    def __check_capacity(v)
+      unless v.is_a?(Integer)
+        unless v.respond_to?(:to_int)
+          raise TypeError, "no implicit conversion of #{v.class} into Integer"
+        end
+        klass = v.class
+        v = v.to_int
+        unless v.is_a?(Integer)
+          raise TypeError,
+                "can't convert #{klass} to Integer (#{klass}#to_int gives #{v.class})"
+        end
+      end
+      raise ArgumentError, "queue size must be positive" unless v > 0
+      v
+    end
+    private :__check_capacity
+
     def max=(new_max)
-      raise ArgumentError, "queue size must be positive" unless new_max.is_a?(Integer) && new_max > 0
+      new_max = __check_capacity(new_max)
       @mutex.synchronize do
         grew = new_max > @max
         @max = new_max

--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -52,6 +52,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(THREAD_CLASS, "kill", thread_class_kill, 1);
     globals.define_builtin_class_func(THREAD_CLASS, "exit", thread_class_exit, 0);
     globals.define_builtin_class_func(THREAD_CLASS, "handle_interrupt", handle_interrupt, 1);
+    globals.define_builtin_class_func(THREAD_CLASS, "__uninterruptible", thread_uninterruptible, 0);
     globals.define_builtin_class_func_with(
         THREAD_CLASS,
         "pending_interrupt?",
@@ -132,6 +133,36 @@ fn handle_interrupt(
     // the delivered interrupt takes precedence over the block's own
     // exception (CRuby).
     scheduler::deliver_pending_now(vm, globals, cur, false)?;
+    res
+}
+
+///
+/// ### Thread.__uninterruptible { ... }
+///
+/// Internal: run the block with ALL asynchronous interrupts — including
+/// kill, which `handle_interrupt` cannot mask — deferred. Nothing is
+/// delivered at parks inside the block and a queued interrupt does not
+/// wake this thread (its ordinary wake source, e.g. `Mutex#unlock`'s
+/// permit, still does). Deferred interrupts fire at block exit, taking
+/// precedence over the block's own exception (as `handle_interrupt`).
+///
+/// The green-thread analogue of CRuby's `mutex_lock_uninterruptible`
+/// (the `rb_mutex_sleep` re-acquire): `Thread::Mutex#sleep` wraps its
+/// ensure-side `lock` in this so a `ConditionVariable#wait`er killed
+/// after being signaled still re-acquires the mutex before dying.
+#[monoruby_builtin]
+fn thread_uninterruptible(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let bh = lfp.expect_block()?;
+    let cur = scheduler::current_thread(vm);
+    scheduler::set_uninterruptible(cur, true);
+    let res = vm.invoke_block_once(globals, bh, &[]);
+    scheduler::set_uninterruptible(cur, false);
+    scheduler::deliver_pending_now(vm, globals, cur, true)?;
     res
 }
 

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -641,6 +641,13 @@ pub(crate) fn join(
 /// a thread. Kill is unmaskable. For a raise, the innermost mask entry
 /// whose class covers the exception's class wins; default `Immediate`.
 fn interrupt_timing(store: &Store, inner: &ThreadInner, int: &PendingInterrupt) -> InterruptTiming {
+    // A `Thread.__uninterruptible` section defers EVERYTHING, kill
+    // included: nothing is deliverable and nothing is wake-worthy until
+    // the section exits (where the deferred queue fires) — the
+    // `mutex_lock_uninterruptible` analogue.
+    if inner.uninterruptible > 0 {
+        return InterruptTiming::Never;
+    }
     let exc_class = match int {
         PendingInterrupt::Kill => return InterruptTiming::Immediate,
         PendingInterrupt::Raise(err) => err.class_id(),
@@ -791,6 +798,17 @@ pub(crate) fn pending_interrupt_p(store: &Store, thread: Value, filter: Option<M
 /// is delivered at resume.
 fn set_park_blocking(mut thread: Value, blocking: bool) {
     thread.as_thread_inner_mut().park_blocking = blocking;
+}
+
+/// Enter / leave a `Thread.__uninterruptible` section on `thread`
+/// (a depth counter, so nesting composes).
+pub(crate) fn set_uninterruptible(mut thread: Value, on: bool) {
+    let inner = thread.as_thread_inner_mut();
+    if on {
+        inner.uninterruptible += 1;
+    } else {
+        inner.uninterruptible -= 1;
+    }
 }
 
 /// Push / pop a `handle_interrupt` mask frame on the current thread.

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -71,6 +71,15 @@ pub struct ThreadInner {
     /// `Thread.handle_interrupt` mask stack (innermost last). Each frame
     /// is the `{Class => timing}` pairs of one handle_interrupt block.
     pub(crate) masks: Vec<Vec<(Value, InterruptTiming)>>,
+    /// Depth of `Thread.__uninterruptible` sections. While non-zero, ALL
+    /// asynchronous interrupts (including kill, which `handle_interrupt`
+    /// cannot mask) are deferred: nothing is delivered at parks and a
+    /// queued interrupt does not wake this thread. The green-thread
+    /// analogue of CRuby's `mutex_lock_uninterruptible` (the
+    /// `rb_mutex_sleep` re-acquire), used by `Thread::Mutex#sleep` so a
+    /// `ConditionVariable#wait`er killed after being signaled still
+    /// re-acquires the mutex before dying.
+    pub(crate) uninterruptible: u32,
     /// Whether the thread's current/last park was a *blocking* operation
     /// (sleep / join / fd wait / queue pop) as opposed to `Thread.pass`.
     /// Consulted when delivering a pending interrupt masked
@@ -175,6 +184,7 @@ impl ThreadInner {
             pending: Default::default(),
             killed: false,
             masks: vec![],
+            uninterruptible: 0,
             park_blocking: false,
             park_permit: false,
             last_status: None,
@@ -206,6 +216,7 @@ impl ThreadInner {
             pending: Default::default(),
             killed: false,
             masks: vec![],
+            uninterruptible: 0,
             park_blocking: false,
             park_permit: false,
             last_status: None,
@@ -229,6 +240,7 @@ impl ThreadInner {
             pending: Default::default(),
             killed: false,
             masks: vec![],
+            uninterruptible: 0,
             park_blocking: false,
             park_permit: false,
             last_status: None,


### PR DESCRIPTION
core/queue, core/sizedqueue and core/conditionvariable now pass clean (previously 5 failures + 9 errors across the three); core/mutex stays green.

- **`Queue.new(enumerable)`**: accept the optional initial-items argument (Ruby 3.1+) via the `to_a` conversion protocol — TypeError with CRuby's messages for inconvertible arguments and non-Array `to_a` results; a NoMethodError raised inside `to_a` propagates.
- **`Queue#freeze` / `SizedQueue#freeze`**: raise `TypeError` (`cannot freeze ...`) — a queue holds runtime synchronization state.
- **`SizedQueue.new` / `#max=`**: NUM2LONG semantics for the capacity — non-Integers convert via `to_int` (`12.9` truncates to `12`), inconvertible values raise TypeError (previously ArgumentError), positivity is checked after conversion.
- **`ConditionVariable#wait`**: a waiter killed after being signaled must re-acquire the mutex before dying. Added `Thread.__uninterruptible` — a scheduler-level deferral of *all* asynchronous interrupts, kill included (`handle_interrupt` cannot mask kill) — and wrapped `Mutex#sleep`'s ensure-side re-acquire in it: the green-thread analogue of CRuby's `mutex_lock_uninterruptible`, with the deferred interrupt firing as soon as the lock is held.

Full unit suite green (2122 lib tests + all integration binaries).

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_