### PR TITLE
file/dir: byte-clean, encoding-preserving paths; fix core/{dir,file,filetest,signal} spec failures

### DIFF
--- a/monoruby/builtins/dir.rb
+++ b/monoruby/builtins/dir.rb
@@ -19,11 +19,36 @@ class Dir
     path = path.to_path if path.respond_to?(:to_path)
     path = path.to_str if path.respond_to?(:to_str)
     raise TypeError, "no implicit conversion of #{path.class} into String" unless path.is_a?(String)
-    raise Errno::ENOENT, "No such file or directory @ dir_initialize - #{path}" unless File.directory?(path)
     @path = path
-    @entries = Dir.entries(path)
+    # Every Dir holds a real O_DIRECTORY|O_CLOEXEC descriptor (like
+    # CRuby's DIR*): #fileno returns it, #close closes it at the
+    # close(2) level, and Dir.for_fd can share it.
+    @fd = Dir.__open_fd(path)
+    @entries = Dir.__entries_fd(@fd, encoding)
     @pos = 0
     @closed = false
+  end
+
+  # Wrap an existing directory file descriptor (no dup: closing this Dir
+  # closes the caller's fd, and a second close raises Errno::EBADF).
+  def self.for_fd(fd)
+    raise TypeError, "no implicit conversion of #{fd.class} into Integer" unless fd.is_a?(Integer)
+    dir = allocate
+    dir.__setup_fd(fd)
+    dir
+  end
+
+  def __setup_fd(fd)
+    @path = nil
+    @fd = fd
+    @entries = Dir.__entries_fd(fd, nil)
+    @pos = 0
+    @closed = false
+  end
+
+  def fileno
+    raise IOError, "closed directory" if @closed
+    @fd
   end
 
   def read
@@ -83,7 +108,9 @@ class Dir
   end
 
   def close
+    return nil if @closed
     @closed = true
+    Dir.__close_fd(@fd) if @fd
     nil
   end
 
@@ -98,7 +125,7 @@ class Dir
   end
 
   def self.children(path, encoding: nil)
-    entries(path).reject { |e| e == "." || e == ".." }
+    entries(path, encoding: encoding).reject { |e| e == "." || e == ".." }
   end
 
   def self.each_child(path, encoding: nil, &block)

--- a/monoruby/builtins/io.rb
+++ b/monoruby/builtins/io.rb
@@ -164,7 +164,15 @@ class IO
 
   def self.__class_write(name, string, offset, binary, opts)
     if (open_args = opts[:open_args])
-      f = File.open(name, *open_args)
+      # A trailing options Hash inside open_args is keyword-splatted:
+      # File.open takes at most 3 positional arguments (CRuby treats the
+      # trailing Hash of an open_args array as keyword options too).
+      if open_args.is_a?(Array) && open_args.last.is_a?(Hash)
+        *head, kw = open_args
+        f = File.open(name, *head, **kw)
+      else
+        f = File.open(name, *open_args)
+      end
     else
       opts = opts.dup
       mode = opts.delete(:mode)

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -96,6 +96,9 @@ fn read_entries_via_fd(
             libc::close(dup);
             return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "readdir"));
         }
+        // dup(2) shares the directory offset with the original fd (a
+        // previous full listing leaves it at EOF), so always start over.
+        libc::rewinddir(dirp);
         let mut names: Vec<Vec<u8>> = vec![];
         loop {
             let ent = libc::readdir(dirp);
@@ -1159,6 +1162,52 @@ fn chroot(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn dir_entries_encoding_keyword() {
+        // entries/foreach/children accept `encoding:` and tag names with
+        // it (default: external encoding); default_internal transcodes.
+        run_test_once(
+            r##"(d="/tmp/mono_de_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/a", ""); a=Dir.entries(d, encoding: "euc-jp").map { |e| e.encoding.name }.uniq; b=Dir.children(d, encoding: Encoding::ISO_8859_1).map { |e| e.encoding.name }.uniq; c=Dir.foreach(d, encoding: "iso-8859-1").to_a.map { |e| e.encoding.name }.uniq; names=[]; Dir.foreach(d, encoding: Encoding::ISO_8859_1) { |e| names << e.encoding.name }; e2=Dir.entries(d).map { |x| x.encoding.name }.uniq; File.unlink("#{d}/a"); Dir.rmdir(d); [a,b,c,names.uniq,e2])"##,
+        );
+    }
+
+    #[test]
+    fn dir_glob_encoding_and_flags_keyword() {
+        // Matches inherit the pattern's encoding; the flags: keyword is
+        // accepted and preferred over the positional argument.
+        run_test_once(
+            r##"(d="/tmp/mono_ge_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/.dot", ""); File.write("#{d}/plain", ""); a=Dir.glob("*", base: d).sort; b=Dir.glob("*", flags: File::FNM_DOTMATCH, base: d).sort; c=Dir.glob("*", :ignored, flags: File::FNM_DOTMATCH, base: d).sort; e2=Dir.glob("pl*".encode(Encoding::EUC_JP), base: d).map { |x| x.encoding.name }; f=Dir["pl*", base: d]; File.unlink("#{d}/.dot"); File.unlink("#{d}/plain"); Dir.rmdir(d); [a,b,c,e2,f])"##,
+        );
+    }
+
+    #[test]
+    fn dir_for_fd_shares_descriptor() {
+        // Dir.for_fd shares the fd (no dup): closing the original makes
+        // the wrapper's close(2) fail with CRuby's closedir EBADF; the
+        // wrapper lists the same entries and has a nil path.
+        run_test_once(
+            r##"(d="/tmp/mono_ff_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/x", ""); dir=Dir.open(d); a=dir.fileno.is_a?(Integer); dn=Dir.for_fd(dir.fileno); b=dn.to_a.sort; c=dn.path; dir.close; e2=(begin; dn.close; rescue => e; [e.class, e.message]; end); f=(begin; Dir.for_fd("x"); rescue => e; e.class; end); File.unlink("#{d}/x"); Dir.rmdir(d); [a,b,c,e2,f])"##,
+        );
+    }
+
+    #[test]
+    fn dir_pwd_binary_names() {
+        // mkdir/chdir/pwd round-trip raw non-ASCII bytes; pwd tags the
+        // result UTF-8 when it decodes.
+        run_test_once(
+            r##"(base="/tmp/mono_pwd_#{Process.pid}"; Dir.mkdir(base); name="#{base}/あ".dup.force_encoding(Encoding::BINARY); Dir.mkdir(name); r=Dir.chdir(name) { [Dir.pwd.encoding.name, Dir.pwd.force_encoding("binary") == name] }; Dir.rmdir(name); Dir.rmdir(base); r)"##,
+        );
+    }
+
+    #[test]
+    fn dir_chdir_restore_failure() {
+        // Dir.chdir's block form surfaces the Errno when the original
+        // directory vanished inside the block.
+        run_test_once(
+            r##"(d1="/tmp/mono_cr1_#{Process.pid}"; d2="/tmp/mono_cr2_#{Process.pid}"; Dir.mkdir(d1); Dir.mkdir(d2); r=(begin; Dir.chdir(d1) { Dir.chdir(d2) { Dir.unlink(d1) } }; rescue => e; e.class; end); Dir.rmdir(d2); r)"##,
+        );
+    }
 
     #[test]
     fn dir_methods_coverage() {

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -16,7 +16,7 @@ pub(super) fn init(globals: &mut Globals) {
         1,
         2,
         false,
-        &["base", "sort"],
+        &["base", "sort", "flags"],
         false,
     );
     globals.define_builtin_class_func_with_kw(
@@ -34,8 +34,26 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func_with(klass, "chdir", chdir, 0, 1, false);
     globals.define_builtin_class_func(klass, "exist?", exist, 1);
     globals.define_builtin_class_func_with(klass, "mkdir", mkdir, 1, 2, false);
-    globals.define_builtin_class_func_with(klass, "entries", entries, 1, 2, false);
-    globals.define_builtin_class_func_with(klass, "foreach", foreach, 1, 2, false);
+    globals.define_builtin_class_func_with_kw(
+        klass,
+        "entries",
+        entries,
+        1,
+        1,
+        false,
+        &["encoding"],
+        false,
+    );
+    globals.define_builtin_class_func_with_kw(
+        klass,
+        "foreach",
+        foreach,
+        1,
+        2,
+        false,
+        &["encoding"],
+        false,
+    );
     globals.define_builtin_class_funcs(klass, "rmdir", &["delete", "unlink"], rmdir, 1);
 
     // Methods that need libc syscalls or external state. The rest of Dir's
@@ -44,8 +62,62 @@ pub(super) fn init(globals: &mut Globals) {
     // Ruby ivars.
     globals.define_builtin_class_func(klass, "fchdir", fchdir, 1);
     globals.define_builtin_class_func(klass, "chroot", chroot, 1);
-    globals.define_builtin_func(klass, "fileno", dir_fileno, 0);
     globals.define_builtin_func_with(klass, "chdir", dir_inst_chdir, 0, 0, false);
+    // fd-backed internals for builtins/dir.rb: every Dir instance holds a
+    // real O_DIRECTORY descriptor so `fileno`, `Dir.for_fd`, and the
+    // close(2)-level double-close detection behave like CRuby's DIR*.
+    globals.define_builtin_class_func(klass, "__open_fd", dir_open_fd, 1);
+    globals.define_builtin_class_func(klass, "__close_fd", dir_close_fd, 1);
+    globals.define_builtin_class_func(klass, "__entries_fd", dir_entries_fd, 2);
+}
+
+/// Read a directory's entry names (including "." and "..") through a
+/// *duplicate* of `fd` so the caller's descriptor position/ownership is
+/// untouched, tagging each name with `enc` (or the default external
+/// encoding) and transcoding to the default internal encoding when set
+/// (entries whose bytes don't convert keep the external tag).
+fn read_entries_via_fd(
+    globals: &mut Globals,
+    fd: i32,
+    enc_obj: Option<Value>,
+) -> Result<Vec<Value>> {
+    // SAFETY: dup(2) then fdopendir(3); the DIR* takes ownership of the
+    // dup'd fd and is released with closedir below. readdir entries are
+    // copied out before the next readdir call.
+    unsafe {
+        let dup = libc::dup(fd);
+        if dup < 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "readdir"));
+        }
+        let dirp = libc::fdopendir(dup);
+        if dirp.is_null() {
+            let err = std::io::Error::last_os_error();
+            libc::close(dup);
+            return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "readdir"));
+        }
+        let mut names: Vec<Vec<u8>> = vec![];
+        loop {
+            let ent = libc::readdir(dirp);
+            if ent.is_null() {
+                break;
+            }
+            let name = std::ffi::CStr::from_ptr((*ent).d_name.as_ptr());
+            names.push(name.to_bytes().to_vec());
+        }
+        libc::closedir(dirp);
+        Ok(names
+            .into_iter()
+            .map(|n| super::io::tag_with_encs(globals, n, enc_obj, None))
+            .collect())
+    }
+}
+
+/// Resolve an `encoding:` keyword value (String name or Encoding
+/// object; nil/absent → None = default external).
+fn entries_enc_obj(globals: &Globals, v: Option<Value>) -> Option<Value> {
+    v.filter(|v| !v.is_nil())
+        .and_then(|v| super::io::arg_to_enc_obj(globals, v))
 }
 
 ///
@@ -55,20 +127,19 @@ pub(super) fn init(globals: &mut Globals) {
 /// Same as `Dir.entries` but excludes the `"."` and `".."` entries.
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/children.html]
-#[monoruby_builtin]
-fn children(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
+/// List a directory's entry names as raw byte vectors (no "." / "..").
+fn read_dir_names(globals: &Globals, path: &RString) -> Result<Vec<Vec<u8>>> {
+    use std::os::unix::ffi::OsStrExt;
+    let display = String::from_utf8_lossy(path.as_bytes()).to_string();
+    let dir = super::file::bytes_to_pathbuf(path.as_bytes());
     let mut result = vec![];
-    for entry in std::fs::read_dir(&path)
-        .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?
+    for entry in std::fs::read_dir(&dir)
+        .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &display))?
     {
-        let entry =
-            entry.map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?;
-        result.push(Value::string(
-            entry.file_name().to_string_lossy().to_string(),
-        ));
+        let entry = entry.map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &display))?;
+        result.push(entry.file_name().as_os_str().as_bytes().to_vec());
     }
-    Ok(Value::array_from_vec(result))
+    Ok(result)
 }
 
 ///
@@ -83,25 +154,35 @@ fn children(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/foreach.html]
 #[monoruby_builtin]
 fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    // The `encoding:` keyword lives in slot 2; the spare positional
+    // slot 1 carries it through an Enumerator replay (which passes
+    // positional arguments only).
+    let enc_val = lfp.try_arg(2).or_else(|| lfp.try_arg(1));
     // Without a block, return a (lazy, size-less) Enumerator that replays
     // `Dir.foreach(path)` when iterated — matching CRuby, which defers the
     // directory read (and any ENOENT) until enumeration.
     let Some(bh) = lfp.block() else {
         let method = IdentId::get_id("foreach");
-        return vm.generate_enumerator(method, lfp.self_val(), vec![lfp.arg(0)], pc);
+        let mut args = vec![lfp.arg(0)];
+        if let Some(e) = enc_val
+            && !e.is_nil()
+        {
+            args.push(e);
+        }
+        return vm.generate_enumerator(method, lfp.self_val(), args, pc);
     };
-    let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?.to_str()?.to_string();
-    let mut names = vec![".".to_string(), "..".to_string()];
-    for entry in std::fs::read_dir(&path)
-        .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?
-    {
-        let entry =
-            entry.map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?;
-        names.push(entry.file_name().to_string_lossy().to_string());
-    }
+    let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &path)?;
+    let enc_obj = entries_enc_obj(globals, enc_val);
+    let mut names: Vec<Vec<u8>> = vec![b".".to_vec(), b"..".to_vec()];
+    names.extend(read_dir_names(globals, &path)?);
+    let entries: Vec<Value> = names
+        .into_iter()
+        .map(|n| super::io::tag_with_encs(globals, n, enc_obj, None))
+        .collect();
     let p = vm.get_block_data(globals, bh)?;
-    for name in names {
-        vm.invoke_block(globals, &p, &[Value::string(name)])?;
+    for name in entries {
+        vm.invoke_block(globals, &p, &[name])?;
     }
     Ok(Value::nil())
 }
@@ -112,14 +193,13 @@ fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/rmdir.html]
 #[monoruby_builtin]
 fn rmdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = lfp
-        .arg(0)
-        .coerce_to_path_rstring(vm, globals)?
-        .to_str()?
-        .to_string();
+    let rs = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &rs)?;
+    let path = super::file::bytes_to_pathbuf(rs.as_bytes());
+    let display = path.to_string_lossy().to_string();
     std::fs::remove_dir(&path).map_err(|e| {
         let desc = errno_description(&e);
-        MonorubyErr::from_io_err(globals, &e, format!("{} @ dir_s_rmdir - {}", desc, path))
+        MonorubyErr::from_io_err(globals, &e, format!("{} @ dir_s_rmdir - {}", desc, display))
     })?;
     Ok(Value::integer(0))
 }
@@ -132,11 +212,10 @@ fn rmdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/mkdir.html]
 #[monoruby_builtin]
 fn mkdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = lfp
-        .arg(0)
-        .coerce_to_path_rstring(vm, globals)?
-        .to_str()?
-        .to_string();
+    let rs = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &rs)?;
+    let path = super::file::bytes_to_pathbuf(rs.as_bytes());
+    let display = path.to_string_lossy().to_string();
     let mode = if let Some(m) = lfp.try_arg(1) {
         m.coerce_to_int_i64(vm, globals)? as u32
     } else {
@@ -149,7 +228,7 @@ fn mkdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             Err(MonorubyErr::from_io_err(
                 globals,
                 &e,
-                format!("{} @ dir_s_mkdir - {}", desc, path),
+                format!("{} @ dir_s_mkdir - {}", desc, display),
             ))
         }
     }
@@ -258,7 +337,15 @@ enum PathComponent {
 #[monoruby_builtin]
 fn glob(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let pat_val = lfp.arg(0);
-    let flags = lfp.try_arg(1).and_then(|v| v.try_fixnum()).unwrap_or(0);
+    // `flags:` keyword wins over the positional flags argument
+    // (core/dir/glob_spec.rb "prefers the keyword argument").
+    let flags = if let Some(f) = lfp.try_arg(4)
+        && !f.is_nil()
+    {
+        f.coerce_to_int_i64(vm, globals)?
+    } else {
+        lfp.try_arg(1).and_then(|v| v.try_fixnum()).unwrap_or(0)
+    };
     let base = if let Some(base) = lfp.try_arg(2)
         && !base.is_nil()
     {
@@ -277,25 +364,19 @@ fn glob(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // single-String form ("nul-separated glob pattern is deprecated")
     // and the Array form ("path name contains null byte"), matching
     // CRuby.
-    let patterns: Vec<String> = if pat_val.is_array_ty() {
+    let patterns: Vec<(String, crate::value::Encoding)> = if pat_val.is_array_ty() {
         pat_val
             .as_array_inner()
             .iter()
             .map(|v| {
-                let s = v
-                    .coerce_to_path_rstring_allow_nul(vm, globals)?
-                    .to_str()?
-                    .to_string();
-                reject_array_pattern_nul(&s)?;
+                let s = glob_pattern(vm, globals, *v)?;
+                reject_array_pattern_nul(&s.0)?;
                 Ok(s)
             })
             .collect::<Result<_>>()?
     } else {
-        let s = pat_val
-            .coerce_to_path_rstring_allow_nul(vm, globals)?
-            .to_str()?
-            .to_string();
-        reject_single_pattern_nul(&s)?;
+        let s = glob_pattern(vm, globals, pat_val)?;
+        reject_single_pattern_nul(&s.0)?;
         vec![s]
     };
 
@@ -343,17 +424,14 @@ fn glob2(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     // (single-String NUL message); with several it behaves like the
     // Array form.
     let single = pat_val.len() == 1;
-    let patterns: Vec<String> = pat_val
+    let patterns: Vec<(String, crate::value::Encoding)> = pat_val
         .iter()
         .map(|v| {
-            let s = v
-                .coerce_to_path_rstring_allow_nul(vm, globals)?
-                .to_str()?
-                .to_string();
+            let s = glob_pattern(vm, globals, *v)?;
             if single {
-                reject_single_pattern_nul(&s)?;
+                reject_single_pattern_nul(&s.0)?;
             } else {
-                reject_array_pattern_nul(&s)?;
+                reject_array_pattern_nul(&s.0)?;
             }
             Ok(s)
         })
@@ -402,15 +480,35 @@ fn reject_array_pattern_nul(s: &str) -> Result<()> {
     Ok(())
 }
 
+/// Coerce one glob pattern, keeping its encoding for the result tags.
+/// An ASCII-incompatible pattern encoding raises CRuby's
+/// `Encoding::CompatibilityError` ("… UTF-16BE and US-ASCII").
+fn glob_pattern(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    v: Value,
+) -> Result<(String, crate::value::Encoding)> {
+    let rs = v.coerce_to_path_rstring_allow_nul(vm, globals)?;
+    let enc = rs.encoding();
+    if !enc.is_ascii_compatible() {
+        return Err(MonorubyErr::incompatible_encoding(
+            &globals.store,
+            enc,
+            crate::value::Encoding::UsAscii,
+        ));
+    }
+    Ok((rs.to_str()?.to_string(), enc))
+}
+
 fn glob_impl(
-    patterns: Vec<String>,
+    patterns: Vec<(String, crate::value::Encoding)>,
     flags: i64,
     base: Option<String>,
     sort: bool,
 ) -> Result<Vec<RStringInner>> {
     let noescape = flags & FNM_NOESCAPE != 0;
     let mut all_matches = vec![];
-    for pattern_str in &patterns {
+    for (pattern_str, enc) in &patterns {
         // Brace alternations expand first, in source order, and each
         // expansion contributes its own (individually sorted) result
         // group — duplicates across groups are kept (CRuby:
@@ -421,13 +519,15 @@ fn glob_impl(
             if sort {
                 matches.sort();
             }
-            all_matches.extend(matches);
+            // Matches inherit the pattern's encoding (glob_spec.rb
+            // "preserves the encoding of the path").
+            all_matches
+                .extend(matches.into_iter().map(|m| {
+                    RStringInner::from_encoding(m.as_bytes(), *enc)
+                }));
         }
     }
-    Ok(all_matches
-        .into_iter()
-        .map(RStringInner::from_string)
-        .collect())
+    Ok(all_matches)
 }
 
 /// Parse one (brace-free) glob pattern string and append matches.
@@ -750,11 +850,16 @@ fn home(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/getwd.html]
 #[monoruby_builtin]
 fn pwd(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Value> {
-    let pwd = std::env::current_dir()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
-    Ok(Value::string(pwd))
+    let cwd = std::env::current_dir().unwrap();
+    let bytes = super::file::pathbuf_bytes(&cwd);
+    // The cwd is reported in the filesystem (UTF-8) encoding; raw bytes
+    // that don't decode fall back to BINARY (core/dir/pwd_spec.rb).
+    let enc = if std::str::from_utf8(bytes).is_ok() {
+        crate::value::Encoding::Utf8
+    } else {
+        crate::value::Encoding::Ascii8
+    };
+    Ok(super::file::path_value(bytes, enc))
 }
 
 ///
@@ -768,27 +873,51 @@ fn pwd(_: &mut Executor, _: &mut Globals, _: Lfp, _: BytecodePtr) -> Result<Valu
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/chdir.html]
 #[monoruby_builtin]
 fn chdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = if let Some(path) = lfp.try_arg(0) {
-        path.coerce_to_path_rstring(vm, globals)?.to_str()?.to_string()
+    let (path, path_val) = if let Some(path) = lfp.try_arg(0) {
+        let rs = path.coerce_to_path_rstring(vm, globals)?;
+        super::file::check_path_encoding(globals, &rs)?;
+        let enc = rs.encoding();
+        (
+            super::file::bytes_to_pathbuf(rs.as_bytes()),
+            super::file::path_value(rs.as_bytes(), enc),
+        )
     } else {
-        dirs::home_dir().unwrap().to_string_lossy().to_string()
+        let home = dirs::home_dir().unwrap();
+        let v = super::file::path_value(
+            super::file::pathbuf_bytes(&home),
+            crate::value::Encoding::Utf8,
+        );
+        (home, v)
     };
+    let display = path.to_string_lossy().to_string();
     if let Some(bh) = lfp.block() {
         let data = vm.get_block_data(globals, bh)?;
         let old_pwd = std::env::current_dir().unwrap();
         match std::env::set_current_dir(&path) {
             Ok(_) => {}
             Err(err) => {
-                return Err(MonorubyErr::errno_with_msg(&globals.store, &err, &path));
+                return Err(MonorubyErr::errno_with_msg(&globals.store, &err, &display));
             }
         }
-        let path = Value::string(path);
-        let res = vm.invoke_block(globals, &data, &[path]);
-        let _ = std::env::set_current_dir(old_pwd);
-        res
+        let res = vm.invoke_block(globals, &data, &[path_val]);
+        // Restoring the original directory can itself fail (it may have
+        // been removed inside the block); CRuby surfaces that Errno
+        // (core/dir/chdir_spec.rb "raises an Errno::ENOENT if the
+        // original directory no longer exists").
+        match std::env::set_current_dir(&old_pwd) {
+            Ok(_) => res,
+            Err(err) => {
+                res?;
+                Err(MonorubyErr::errno_with_msg(
+                    &globals.store,
+                    &err,
+                    &old_pwd.to_string_lossy(),
+                ))
+            }
+        }
     } else {
         std::env::set_current_dir(&path)
-            .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?;
+            .map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &display))?;
         Ok(Value::integer(0))
     }
 }
@@ -803,12 +932,9 @@ fn chdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/exist=3f.html]
 #[monoruby_builtin]
 fn exist(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path_str = lfp
-        .arg(0)
-        .coerce_to_path_rstring(vm, globals)?
-        .to_str()?
-        .to_string();
-    let path = std::path::Path::new(&path_str);
+    let rs = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &rs)?;
+    let path = super::file::bytes_to_pathbuf(rs.as_bytes());
     Ok(Value::bool(path.is_dir()))
 }
 
@@ -823,24 +949,85 @@ fn exist(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 /// [https://docs.ruby-lang.org/ja/latest/method/Dir/s/entries.html]
 #[monoruby_builtin]
 fn entries(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let path = lfp
-        .arg(0)
-        .coerce_to_path_rstring(vm, globals)?
-        .to_str()?
-        .to_string();
-    let mut result = vec![
-        Value::string(".".to_string()),
-        Value::string("..".to_string()),
-    ];
-    for entry in
-        std::fs::read_dir(&path).map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?
-    {
-        let entry = entry.map_err(|e| MonorubyErr::errno_with_msg(&globals.store, &e, &path))?;
-        result.push(Value::string(
-            entry.file_name().to_string_lossy().to_string(),
+    let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &path)?;
+    let enc_obj = entries_enc_obj(globals, lfp.try_arg(1));
+    let mut names: Vec<Vec<u8>> = vec![b".".to_vec(), b"..".to_vec()];
+    names.extend(read_dir_names(globals, &path)?);
+    let result: Vec<Value> = names
+        .into_iter()
+        .map(|n| super::io::tag_with_encs(globals, n, enc_obj, None))
+        .collect();
+    Ok(Value::array_from_vec(result))
+}
+
+///
+/// ### Dir.__open_fd (internal)
+///
+/// Open `path` with `O_RDONLY|O_DIRECTORY|O_CLOEXEC` and return the fd.
+/// Backs `Dir#initialize` in builtins/dir.rb.
+#[monoruby_builtin]
+fn dir_open_fd(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let path = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
+    super::file::check_path_encoding(globals, &path)?;
+    if path.as_bytes().contains(&0) {
+        return Err(MonorubyErr::argumenterr("path name contains null byte"));
+    }
+    let display = String::from_utf8_lossy(path.as_bytes()).to_string();
+    let c = std::ffi::CString::new(path.as_bytes().to_vec()).unwrap();
+    // SAFETY: open(2) with a NUL-terminated path; the fd's ownership moves
+    // to the Ruby-side Dir object (closed via Dir.__close_fd).
+    let fd = unsafe {
+        libc::open(
+            c.as_ptr(),
+            libc::O_DIRECTORY | libc::O_RDONLY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_path(
+            &globals.store,
+            &err,
+            "dir_initialize",
+            &display,
         ));
     }
-    Ok(Value::array_from_vec(result))
+    Ok(Value::integer(fd as i64))
+}
+
+///
+/// ### Dir.__close_fd (internal)
+///
+/// close(2) a directory fd, surfacing failures the way CRuby's
+/// `closedir` does (`Errno::EBADF: Bad file descriptor - closedir`).
+#[monoruby_builtin]
+fn dir_close_fd(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let fd = lfp.arg(0).coerce_to_int_i64(vm, globals)? as i32;
+    // SAFETY: close(2); an invalid fd is reported via errno, not UB.
+    let rc = unsafe { libc::close(fd) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "closedir"));
+    }
+    Ok(Value::nil())
+}
+
+///
+/// ### Dir.__entries_fd (internal)
+///
+/// Entry names (including "." and "..") of the directory open at `fd`,
+/// tagged/transcoded per the optional `encoding` argument.
+#[monoruby_builtin]
+fn dir_entries_fd(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let fd = lfp.arg(0).coerce_to_int_i64(vm, globals)? as i32;
+    let enc_obj = entries_enc_obj(globals, Some(lfp.arg(1)));
+    let entries = read_entries_via_fd(globals, fd, enc_obj)?;
+    Ok(Value::array_from_vec(entries))
 }
 
 /// Read the `@path` ivar set by Ruby-side `Dir#initialize`.
@@ -901,42 +1088,6 @@ fn dir_inst_chdir(
         return result;
     }
     Ok(Value::integer(0))
-}
-
-///
-/// ### Dir#fileno
-/// - fileno -> Integer
-///
-/// Returns a file descriptor for the directory by opening it with
-/// `O_DIRECTORY`. monoruby does not currently keep a `DIR *` open per Dir
-/// instance, so each call opens a fresh descriptor — comparing two `fileno`
-/// values from the same Dir will give the same number for the same path.
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Dir/i/fileno.html]
-#[monoruby_builtin]
-fn dir_fileno(
-    _vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    let self_ = lfp.self_val();
-    dir_check_closed(globals, self_)?;
-    let path = dir_path_ivar(globals, self_)?;
-    let c = std::ffi::CString::new(path.as_bytes())
-        .map_err(|_| MonorubyErr::argumenterr("path contains NUL byte"))?;
-    // SAFETY: O_DIRECTORY | O_RDONLY is a POSIX-defined open mode.
-    let fd = unsafe { libc::open(c.as_ptr(), libc::O_DIRECTORY | libc::O_RDONLY) };
-    if fd < 0 {
-        let err = std::io::Error::last_os_error();
-        return Err(MonorubyErr::errno_with_path(
-            &globals.store,
-            &err,
-            "rb_dir_s_fileno",
-            &path,
-        ));
-    }
-    Ok(Value::integer(fd as i64))
 }
 
 ///

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::path::Path;
 use std::{
     fs::File,
     io::{Seek, SeekFrom},
@@ -43,9 +42,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(file, "extname", file_extname, 1);
     globals.define_builtin_class_func(file, "path", file_path, 1);
     globals.define_builtin_class_func_with(file, "realpath", realpath, 1, 2, false);
-    globals.define_builtin_class_func_with(file, "open", open, 1, 4, false);
-    globals.define_builtin_class_func_with(file, "new", open, 1, 4, false);
-    globals.define_builtin_class_func_with(IO_CLASS, "open", open, 1, 4, false);
+    globals.define_builtin_class_func_with_kw(file, "open", open, 1, 3, false, OPEN_KW, true);
+    globals.define_builtin_class_func_with_kw(file, "new", file_new, 1, 3, false, OPEN_KW, true);
+    globals.define_builtin_class_func_with_kw(IO_CLASS, "open", open, 1, 3, false, OPEN_KW, true);
 
     globals.define_builtin_class_func(file, "directory?", directory_, 1);
     globals.define_builtin_module_func(file_test, "directory?", directory_, 1);
@@ -437,7 +436,7 @@ fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     fn flatten(
         vm: &mut Executor,
         globals: &mut Globals,
-        parts: &mut Vec<String>,
+        parts: &mut Vec<(Vec<u8>, crate::value::Encoding)>,
         val: Value,
         seen: &mut Vec<u64>,
     ) -> Result<()> {
@@ -446,7 +445,7 @@ fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                 // An empty array argument joins as a single empty component,
                 // so `File.join([], [])` == "/" (core/file/join_spec.rb).
                 if ainfo.len() == 0 {
-                    parts.push(String::new());
+                    parts.push((Vec::new(), crate::value::Encoding::Utf8));
                     return Ok(());
                 }
                 let id = val.id();
@@ -461,11 +460,10 @@ fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
             }
             None => {
                 let s = val.coerce_to_path_rstring_allow_nul(vm, globals)?;
-                let s = s.to_str()?.to_string();
                 if s.as_bytes().contains(&0) {
                     return Err(MonorubyErr::argumenterr("string contains null byte"));
                 }
-                parts.push(s);
+                parts.push((s.as_bytes().to_vec(), s.encoding()));
             }
         }
         Ok(())
@@ -480,24 +478,30 @@ fn file_join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     // separators and drops the left part's trailing ones ("usr//" + "/bin" ->
     // "usr/bin", "usr/" + "//bin" -> "usr//bin"); when exactly one side has one
     // it is reused; when neither does a "/" is inserted.
-    let mut path = String::new();
-    for (i, part) in parts.iter().enumerate() {
+    let mut path: Vec<u8> = Vec::new();
+    // The joined result carries the first non-UTF-8 component's encoding
+    // (join_spec.rb "preserves the encoding of the path").
+    let mut enc = crate::value::Encoding::Utf8;
+    for (i, (part, part_enc)) in parts.iter().enumerate() {
+        if enc == crate::value::Encoding::Utf8 && *part_enc != crate::value::Encoding::Utf8 {
+            enc = *part_enc;
+        }
         if i == 0 {
-            path.push_str(part);
+            path.extend_from_slice(part);
             continue;
         }
-        let left_sep = path.ends_with('/');
-        let right_sep = part.starts_with('/');
+        let left_sep = path.last() == Some(&b'/');
+        let right_sep = part.first() == Some(&b'/');
         if left_sep && right_sep {
-            while path.ends_with('/') {
+            while path.last() == Some(&b'/') {
                 path.pop();
             }
         } else if !left_sep && !right_sep {
-            path.push('/');
+            path.push(b'/');
         }
-        path.push_str(part);
+        path.extend_from_slice(part);
     }
-    Ok(Value::string(path))
+    Ok(path_value(&path, enc))
 }
 
 ///
@@ -513,36 +517,139 @@ fn file_expand_path(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let current_dir = match std::env::current_dir() {
-        Ok(dir) => dir,
-        Err(err) => {
-            return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "."));
-        }
-    };
-    let arg0 = to_path(vm, globals, lfp.arg(0))?;
-    let path = if let Some(arg1) = lfp.try_arg(1)
+    // CRuby converts the result to the filesystem encoding; with an
+    // ASCII-incompatible default_external this is impossible up front.
+    let de = super::io::enc_default_external_obj(globals);
+    if let Some(e) = super::io::enc_obj_to_enum(globals, de)
+        && !e.is_ascii_compatible()
+    {
+        return Err(MonorubyErr::encoding_compatibility_error_with_store(
+            &globals.store,
+            format!("incompatible character encodings: UTF-8 and {}", e.name()),
+        ));
+    }
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = rs.encoding();
+    let dfl: Option<Vec<u8>> = if let Some(arg1) = lfp.try_arg(1)
         && !arg1.is_nil()
     {
-        let mut path = to_path(vm, globals, arg1)?;
-        path.push(arg0);
-        path
+        Some(to_path_rstring(vm, globals, arg1)?.as_bytes().to_vec())
     } else {
-        arg0
+        None
     };
+    let res = expand_path_bytes(rs.as_bytes(), dfl.as_deref())?;
+    Ok(path_value(&res, enc))
+}
 
-    let mut res_path = std::path::PathBuf::new();
-    res_path.push(current_dir);
+/// Expand `path` into an absolute byte path against `dfl` (both may
+/// start with `~`/`~user`), mirroring CRuby's `rb_file_expand_path`:
+/// `.`/`..` are collapsed lexically, interior slash runs are squeezed,
+/// and the leading slash run of the absolute prefix is preserved
+/// verbatim (`////some/path` stays as written).
+fn expand_path_bytes(path: &[u8], dfl: Option<&[u8]>) -> Result<Vec<u8>> {
+    if path.first() == Some(&b'~') {
+        let (home, rest) = if path.len() == 1 || path[1] == b'/' {
+            (expand_home_dir()?, &path[1..])
+        } else {
+            let end = path.iter().position(|&b| b == b'/').unwrap_or(path.len());
+            (user_home_dir(&path[1..end])?, &path[end..])
+        };
+        if home.first() != Some(&b'/') {
+            return Err(MonorubyErr::argumenterr("non-absolute home"));
+        }
+        let mut joined = home;
+        joined.extend_from_slice(rest);
+        Ok(normalize_abs_bytes(&joined))
+    } else if path.first() == Some(&b'/') {
+        Ok(normalize_abs_bytes(path))
+    } else {
+        let mut base = match dfl {
+            Some(d) => expand_path_bytes(d, None)?,
+            None => cwd_bytes()?,
+        };
+        if base.last() != Some(&b'/') {
+            base.push(b'/');
+        }
+        base.extend_from_slice(path);
+        Ok(normalize_abs_bytes(&base))
+    }
+}
 
-    extend(&mut res_path, path)?;
+/// Current working directory as raw bytes.
+fn cwd_bytes() -> Result<Vec<u8>> {
+    match std::env::current_dir() {
+        Ok(dir) => Ok(pathbuf_bytes(&dir).to_vec()),
+        Err(err) => Err(MonorubyErr::runtimeerr(format!(
+            "failed to get current directory: {err}"
+        ))),
+    }
+}
 
-    #[cfg(windows)]
-    let res_path = PathBuf::from(
-        std::env::var("HOMEDRIVE")
-            .or_else(|_| Err(RubyError::internal("Failed to get home drive.")))?,
-    )
-    .join(res_path);
+/// `$HOME` (must be set and non-empty; falls back to the passwd entry
+/// when unset — CRuby raises "non-absolute home" for a set-but-empty or
+/// relative HOME later, in the caller's absolute check).
+fn expand_home_dir() -> Result<Vec<u8>> {
+    use std::os::unix::ffi::OsStrExt;
+    match std::env::var_os("HOME") {
+        Some(h) if !h.is_empty() => Ok(h.as_bytes().to_vec()),
+        Some(_) => Err(MonorubyErr::argumenterr("non-absolute home")),
+        None => {
+            // SAFETY: getpwuid returns a pointer to a static passwd entry
+            // (or null); pw_dir is read immediately before any other libc
+            // call could clobber the buffer.
+            unsafe {
+                let pw = libc::getpwuid(libc::getuid());
+                if pw.is_null() {
+                    return Err(MonorubyErr::argumenterr("couldn't find HOME environment -- expanding `~'"));
+                }
+                Ok(std::ffi::CStr::from_ptr((*pw).pw_dir).to_bytes().to_vec())
+            }
+        }
+    }
+}
 
-    Ok(Value::string(conv_pathbuf(&res_path)))
+/// Home directory of the named user (for `~user` expansion).
+fn user_home_dir(user: &[u8]) -> Result<Vec<u8>> {
+    let display = String::from_utf8_lossy(user).to_string();
+    let c_user = std::ffi::CString::new(user)
+        .map_err(|_| MonorubyErr::argumenterr("user name contains null byte"))?;
+    // SAFETY: getpwnam reads the passwd DB for the NUL-terminated name and
+    // returns a pointer into a static buffer (or null when unknown); pw_dir
+    // is copied out immediately.
+    unsafe {
+        let pw = libc::getpwnam(c_user.as_ptr());
+        if pw.is_null() {
+            return Err(MonorubyErr::argumenterr(format!(
+                "user {display} doesn't exist"
+            )));
+        }
+        Ok(std::ffi::CStr::from_ptr((*pw).pw_dir).to_bytes().to_vec())
+    }
+}
+
+/// Lexically normalize an absolute byte path: squeeze interior slash
+/// runs, drop `.`, collapse `..` (never above root), and keep the
+/// leading run of slashes exactly as written.
+fn normalize_abs_bytes(bytes: &[u8]) -> Vec<u8> {
+    let lead = bytes.iter().take_while(|&&b| b == b'/').count().max(1);
+    let mut comps: Vec<&[u8]> = vec![];
+    for c in bytes[lead.min(bytes.len())..].split(|&b| b == b'/') {
+        match c {
+            b"" | b"." => {}
+            b".." => {
+                comps.pop();
+            }
+            c => comps.push(c),
+        }
+    }
+    let mut out = vec![b'/'; lead];
+    for (i, c) in comps.iter().enumerate() {
+        if i > 0 {
+            out.push(b'/');
+        }
+        out.extend_from_slice(c);
+    }
+    out
 }
 
 ///
@@ -580,43 +687,42 @@ fn file_basename(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let filename = lfp.arg(0).coerce_to_path_rstring(vm, globals)?;
-    let suffix = if let Some(arg1) = lfp.try_arg(1) {
-        let s = arg1.coerce_to_string(vm, globals)?;
+    let filename = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = filename.encoding();
+    let suffix: Option<Vec<u8>> = if let Some(arg1) = lfp.try_arg(1) {
+        let s = arg1.coerce_to_rstring(vm, globals)?;
         if s.is_empty() {
             None
         } else {
-            Some(s.to_string())
+            Some(s.as_bytes().to_vec())
         }
     } else {
         None
     };
     if filename.is_empty() {
-        return Ok(Value::string_from_str(""));
+        return Ok(path_value(b"", enc));
     }
-    let filename = filename.to_str()?.to_string();
-    let basename = if let Some(s) = filename.split('/').rev().find(|s| !s.is_empty()) {
-        s
-    } else {
-        "/"
-    };
+    let basename: &[u8] = filename
+        .as_bytes()
+        .split(|&b| b == b'/')
+        .rev()
+        .find(|s| !s.is_empty())
+        .unwrap_or(b"/");
     if let Some(suffix) = suffix {
-        if suffix == ".*" {
+        if suffix == b".*" {
             // CRuby treats the ".*" suffix specially: strip the last
             // extension (a '.' that is not the leading char, so
             // dotfiles like ".bashrc" are preserved).
-            if let Some(pos) = basename.rfind('.') {
+            if let Some(pos) = basename.iter().rposition(|&b| b == b'.') {
                 if pos > 0 {
-                    return Ok(Value::string_from_str(&basename[..pos]));
+                    return Ok(path_value(&basename[..pos], enc));
                 }
             }
         } else if basename.ends_with(&suffix) {
-            return Ok(Value::string_from_str(
-                &basename[..basename.len() - suffix.len()],
-            ));
+            return Ok(path_value(&basename[..basename.len() - suffix.len()], enc));
         }
     }
-    Ok(Value::string_from_str(basename))
+    Ok(path_value(basename, enc))
 }
 
 ///
@@ -690,25 +796,30 @@ fn file_extname(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let filename = to_path_str(vm, globals, lfp.arg(0))?;
+    let filename = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = filename.encoding();
     // Work on the final path component; an extension is the part after the
     // last dot, but a basename that is nothing but dots ("...", "..") or
     // starts with its only dot (".profile") has no extension.
-    let base = filename.rsplit('/').next().unwrap_or("");
-    let extname = match base.rfind('.') {
+    let base: &[u8] = filename
+        .as_bytes()
+        .rsplit(|&b| b == b'/')
+        .next()
+        .unwrap_or(b"");
+    let extname: &[u8] = match base.iter().rposition(|&b| b == b'.') {
         // No extension when nothing but dots precedes the last dot:
         // ".profile" / ".." / "...a" → "".
-        Some(pos) if !base[..pos].is_empty() && !base[..pos].bytes().all(|b| b == b'.') => {
+        Some(pos) if !base[..pos].is_empty() && !base[..pos].iter().all(|&b| b == b'.') => {
             if pos + 1 < base.len() {
-                base[pos..].to_string()
+                &base[pos..]
             } else {
                 // Trailing dot: "foo." → "." on non-Windows CRuby.
-                ".".to_string()
+                b"."
             }
         }
-        _ => "".to_string(),
+        _ => b"",
     };
-    Ok(Value::string(extname))
+    Ok(path_value(extname, enc))
 }
 
 ///
@@ -844,7 +955,8 @@ fn flock_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/path.html]
 #[monoruby_builtin]
 fn file_path(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(Value::string(to_path_str(vm, globals, lfp.arg(0))?))
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    Ok(path_value(rs.as_bytes(), rs.encoding()))
 }
 
 ///
@@ -854,43 +966,154 @@ fn file_path(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/realpath.html]
 #[monoruby_builtin]
 fn realpath(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut pathname = if let Some(arg1) = lfp.try_arg(1) {
-        let path_str = to_path_str(vm, globals, arg1)?;
-        let path = std::path::PathBuf::from(&path_str);
-        match path.canonicalize() {
-            Ok(path) => path,
-            Err(err) => {
-                return Err(MonorubyErr::errno_with_path(
-                    &globals.store,
-                    &err,
-                    "rb_file_s_realpath",
-                    &path_str,
-                ));
-            }
-        }
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = rs.encoding();
+    let base: Option<Vec<u8>> = if let Some(arg1) = lfp.try_arg(1)
+        && !arg1.is_nil()
+    {
+        Some(to_path_rstring(vm, globals, arg1)?.as_bytes().to_vec())
     } else {
-        match std::env::current_dir() {
-            Ok(path) => path,
-            Err(err) => {
-                return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "."));
+        None
+    };
+    let resolved = check_realpath(
+        globals,
+        rs.as_bytes(),
+        base.as_deref(),
+        true,
+        "rb_check_realpath_internal",
+    )?;
+    Ok(resolved_path_value(globals, resolved, enc, true))
+}
+
+/// Tag a resolved (filesystem / UTF-8) path with the path argument's
+/// encoding: converted when possible; when the conversion fails,
+/// `File.realpath` *forces* the argument's encoding onto the raw bytes
+/// while `File.realdirpath` keeps the resolved UTF-8 tag (CRuby's
+/// realpath specs distinguish the two).
+fn resolved_path_value(
+    globals: &Globals,
+    bytes: Vec<u8>,
+    enc: crate::value::Encoding,
+    force: bool,
+) -> Value {
+    use crate::value::Encoding as E;
+    if enc == E::Utf8 {
+        return path_value(&bytes, E::Utf8);
+    }
+    let topts = super::encoding::TranscodeOpts::default();
+    match super::encoding::transcode_bytes_with_opts(&bytes, E::Utf8, enc, &topts, &globals.store) {
+        Ok(b) => path_value(&b, enc),
+        Err(_) if force => path_value(&bytes, enc),
+        Err(_) => path_value(&bytes, E::Utf8),
+    }
+}
+
+/// Resolve `path` (absolutized against `base` / the cwd) component-wise
+/// the way CRuby's `rb_check_realpath` does: each component is
+/// `lstat`ed, symlinks are followed (raising `ELOOP` after too many
+/// hops), and `..` collapses the resolved prefix *lexically* — so
+/// `dir/file/../` resolves to `dir` without an `ENOTDIR`. With
+/// `strict_last` false (File.realdirpath) the final component may be
+/// absent; everything else must exist.
+fn check_realpath(
+    globals: &Globals,
+    path: &[u8],
+    base: Option<&[u8]>,
+    strict_last: bool,
+    op: &str,
+) -> Result<Vec<u8>> {
+    use std::collections::VecDeque;
+    fn push_front_components(queue: &mut VecDeque<Vec<u8>>, bytes: &[u8]) {
+        for c in bytes.split(|&b| b == b'/').rev() {
+            if !c.is_empty() {
+                queue.push_front(c.to_vec());
             }
         }
-    };
-    pathname.push(std::path::PathBuf::from(to_path_str(
-        vm,
-        globals,
-        lfp.arg(0),
-    )?));
-    let pathname_str = pathname.to_string_lossy().to_string();
-    match pathname.canonicalize() {
-        Ok(file) => Ok(Value::string(file.to_string_lossy().to_string())),
-        Err(err) => Err(MonorubyErr::errno_with_path(
-            &globals.store,
-            &err,
-            "rb_file_s_realpath",
-            &pathname_str,
-        )),
     }
+    if path.is_empty() {
+        let err = std::io::Error::from_raw_os_error(libc::ENOENT);
+        return Err(MonorubyErr::errno_with_path(&globals.store, &err, op, ""));
+    }
+    let mut queue: VecDeque<Vec<u8>> = VecDeque::new();
+    push_front_components(&mut queue, path);
+    if path.first() != Some(&b'/') {
+        let abs_base: Vec<u8> = match base {
+            Some(b) if b.first() == Some(&b'/') => b.to_vec(),
+            Some(b) => {
+                let mut cur = cwd_bytes()?;
+                cur.push(b'/');
+                cur.extend_from_slice(b);
+                cur
+            }
+            None => cwd_bytes()?,
+        };
+        push_front_components(&mut queue, &abs_base);
+    }
+
+    let errno_err = |raw: i32, at: &[u8]| {
+        let err = std::io::Error::from_raw_os_error(raw);
+        MonorubyErr::errno_with_path(&globals.store, &err, op, &String::from_utf8_lossy(at))
+    };
+
+    let mut resolved: Vec<u8> = Vec::new();
+    let mut links = 0usize;
+    while let Some(comp) = queue.pop_front() {
+        if comp == b"." {
+            continue;
+        }
+        if comp == b".." {
+            while let Some(b) = resolved.pop() {
+                if b == b'/' {
+                    break;
+                }
+            }
+            continue;
+        }
+        let prev_len = resolved.len();
+        resolved.push(b'/');
+        resolved.extend_from_slice(&comp);
+        match std::fs::symlink_metadata(bytes_to_pathbuf(&resolved)) {
+            Ok(md) if md.file_type().is_symlink() => {
+                links += 1;
+                if links > 40 {
+                    return Err(errno_err(libc::ELOOP, &resolved));
+                }
+                let target = std::fs::read_link(bytes_to_pathbuf(&resolved))
+                    .map_err(|e| {
+                        MonorubyErr::errno_with_path(
+                            &globals.store,
+                            &e,
+                            op,
+                            &String::from_utf8_lossy(&resolved),
+                        )
+                    })?;
+                let tb = pathbuf_bytes(&target).to_vec();
+                resolved.truncate(prev_len);
+                if tb.first() == Some(&b'/') {
+                    resolved.clear();
+                }
+                push_front_components(&mut queue, &tb);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                let missing_last_ok = !strict_last
+                    && queue.is_empty()
+                    && e.kind() == std::io::ErrorKind::NotFound;
+                if !missing_last_ok {
+                    return Err(MonorubyErr::errno_with_path(
+                        &globals.store,
+                        &e,
+                        op,
+                        &String::from_utf8_lossy(&resolved),
+                    ));
+                }
+            }
+        }
+    }
+    if resolved.is_empty() {
+        resolved.push(b'/');
+    }
+    Ok(resolved)
 }
 
 ///
@@ -971,8 +1194,113 @@ pub(super) fn block_close(
     }
 }
 
+/// Keyword parameters accepted by `File.open` / `File.new` / `IO.open`.
+/// Their slots start right after the 3 positional parameters (path,
+/// mode, perm); the kw_rest Hash (transcode options and other extras
+/// monoruby accepts but does not implement) sits after them.
+pub(super) const OPEN_KW: &[&str] = &[
+    "flags",
+    "mode",
+    "perm",
+    "encoding",
+    "external_encoding",
+    "internal_encoding",
+    "textmode",
+    "binmode",
+    "autoclose",
+    "path",
+    "newline",
+    "invalid",
+    "undef",
+    "replace",
+    "fallback",
+    "xml",
+];
+
+/// A named `OPEN_KW` keyword's value (absent or nil → `None`).
+fn open_kw(lfp: Lfp, name: &str) -> Option<Value> {
+    let i = OPEN_KW.iter().position(|n| *n == name)?;
+    lfp.try_arg(3 + i).filter(|v| !v.is_nil())
+}
+
+/// Collect the named keyword slots (+ any kw_rest extras) back into an
+/// options Hash so the shared IO option readers (`io_open_opts`,
+/// `init_io_encodings`) see keyword and positional-Hash call forms
+/// uniformly.
+fn open_kw_hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<Option<Value>> {
+    let mut map = RubyMap::default();
+    let mut any = false;
+    for (i, name) in OPEN_KW.iter().enumerate() {
+        if let Some(v) = lfp.try_arg(3 + i) {
+            map.insert(Value::symbol(IdentId::get_id(name)), v, vm, globals)?;
+            any = true;
+        }
+    }
+    if let Some(rest) = lfp.try_arg(3 + OPEN_KW.len())
+        && rest.try_hash_ty().is_some()
+    {
+        for (k, v) in rest.as_hash().iter() {
+            map.insert(k, v, vm, globals)?;
+            any = true;
+        }
+    }
+    Ok(if any { Some(Value::hash(map)) } else { None })
+}
+
+/// Translate a mode string ("r", "wb+", "wx", …; a ":enc" suffix is
+/// ignored here) into open(2) flags + the binmode marker. Unknown or
+/// misplaced letters raise CRuby's "invalid access mode" ArgumentError
+/// (the 'x' creation guard is only valid with 'w').
+fn oflags_from_mode_string(mode: &str) -> Result<(i64, bool)> {
+    let base = mode.split(':').next().unwrap_or("");
+    let invalid = || MonorubyErr::argumenterr(format!("invalid access mode {base}"));
+    let mut it = base.chars();
+    let first = it.next();
+    let mut oflags: i64 = match first {
+        Some('r') => libc::O_RDONLY as i64,
+        Some('w') => (libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC) as i64,
+        Some('a') => (libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND) as i64,
+        _ => return Err(invalid()),
+    };
+    let mut binmode = false;
+    for c in it {
+        match c {
+            'b' => binmode = true,
+            't' => {}
+            '+' => {
+                oflags = (oflags & !(libc::O_ACCMODE as i64)) | libc::O_RDWR as i64;
+            }
+            'x' => {
+                if first != Some('w') {
+                    return Err(invalid());
+                }
+                oflags |= libc::O_EXCL as i64;
+            }
+            _ => return Err(invalid()),
+        }
+    }
+    Ok((oflags, binmode))
+}
+
 #[monoruby_builtin]
 fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    open_impl(vm, globals, lfp, false)
+}
+
+/// `File.new` — same as `File.open` except a given block is *not*
+/// called (CRuby warns and returns the File).
+#[monoruby_builtin]
+fn file_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    open_impl(vm, globals, lfp, true)
+}
+
+fn open_impl(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    is_new: bool,
+) -> Result<Value> {
+    let kw_hash = open_kw_hash(vm, globals, lfp)?;
     // If the first argument is an Integer, treat it as a file descriptor.
     if let Some(fd) = lfp.arg(0).try_fixnum() {
         let fd_i32 = fd as i32;
@@ -987,12 +1315,26 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 &format!("fd {}", fd),
             ));
         }
+        // Creation-only flags make no sense on an already-open fd;
+        // CRuby surfaces this as Errno::EINVAL (core/file/new_spec.rb
+        // "can't alter mode or permissions when opening a file").
+        if let Some(n) = lfp.try_arg(1).and_then(|v| v.try_fixnum())
+            && n & ((libc::O_CREAT | libc::O_TRUNC | libc::O_EXCL) as i64) != 0
+        {
+            let err = std::io::Error::from_raw_os_error(libc::EINVAL);
+            return Err(MonorubyErr::errno_with_msg(
+                &globals.store,
+                &err,
+                &format!("fd {}", fd),
+            ));
+        }
         // Scan trailing args for an options Hash and pick up `:path`
         // (display name) and `:autoclose` (fd ownership) — required by
         // patterns like `File.new(io.fileno, autoclose: false, path: "")`
         // (logger/log_device.rb feature-detection code) where the caller
         // explicitly disclaims ownership of the borrowed fd.
-        let (name, has_path, autoclose) = super::io::io_open_opts(vm, globals, lfp, 1..4, fd)?;
+        let (name, has_path, autoclose) =
+            super::io::io_open_opts(vm, globals, lfp, 1..3, fd, kw_hash)?;
         let (readable, writable) = super::io::fd_rw_mode(fd_i32);
         // If another monoruby IO already owns this fd, borrow it (autoclose
         // = false) instead of creating a second closing `OwnedFd`, which
@@ -1021,8 +1363,15 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 }
                 .to_string()
             });
-        super::io::init_io_encodings(vm, globals, lfp, res, &mode_for_enc, readable, 1..4)?;
+        super::io::init_io_encodings(vm, globals, lfp, res, &mode_for_enc, readable, 1..3, kw_hash)?;
         if let Some(bh) = lfp.block() {
+            if is_new {
+                vm.ruby_warn(
+                    globals,
+                    "warning: File::new() does not take block; use File::open() instead",
+                )?;
+                return Ok(res);
+            }
             let r = vm.invoke_block_once(globals, bh, &[res]);
             // Match CRuby File.open(...) {|io| ... }: close at block exit.
             // Holding the underlying fd open across blocks defeats `flock`
@@ -1032,123 +1381,92 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         return Ok(res);
     }
 
-    // Resolve the open mode. Each later position overrides the earlier one
-    // when it provides an explicit `:mode` (matching CRuby's option-Hash
-    // precedence): trailing options Hash > explicit mode arg > default "r".
-    let mut mode = "r".to_string();
-    if let Some(arg1) = lfp.try_arg(1) {
-        if arg1.is_nil() {
-            // explicit nil => keep default
-        } else if let Some(n) = arg1.try_fixnum() {
-            mode = mode_string_from_flags(n);
-        } else if arg1.is_rstring().is_some() {
-            mode = arg1.coerce_to_string(vm, globals)?;
-        } else if let Some(h) = arg1.try_hash_ty() {
-            if let Some(m) =
-                h.get(Value::symbol(IdentId::get_id("mode")), vm, globals)?
+    // Resolve the open mode into open(2) flags. Precedence (CRuby):
+    // `mode:` keyword > positional mode arg (String / Integer / Hash
+    // with `:mode`) > default "r". A `flags:` keyword ORs extra bits on
+    // top of either form.
+    let mut mode_val: Option<Value> = None;
+    if let Some(arg1) = lfp.try_arg(1)
+        && !arg1.is_nil()
+    {
+        if let Some(h) = arg1.try_hash_ty() {
+            if let Some(m) = h.get(Value::symbol(IdentId::get_id("mode")), vm, globals)?
                 && !m.is_nil()
             {
-                if let Some(n) = m.try_fixnum() {
-                    mode = mode_string_from_flags(n);
-                } else {
-                    mode = m.coerce_to_string(vm, globals)?;
-                }
+                mode_val = Some(m);
             }
+        } else {
+            mode_val = Some(arg1);
         }
     }
-    // Look at later args (perm, opts) for a Hash with :mode.
-    for i in 2..4 {
-        if let Some(arg) = lfp.try_arg(i)
-            && let Some(h) = arg.try_hash_ty()
-            && let Some(m) = h.get(Value::symbol(IdentId::get_id("mode")), vm, globals)?
-            && !m.is_nil()
-        {
+    if let Some(m) = open_kw(lfp, "mode") {
+        mode_val = Some(m);
+    }
+    // `mode` (the string form) also drives the encoding suffix parsing
+    // in init_io_encodings, so keep a string spelling alongside the
+    // flag bits.
+    let (mut oflags, mut binmode, mode) = match mode_val {
+        None => (libc::O_RDONLY as i64, false, "r".to_string()),
+        Some(m) => {
             if let Some(n) = m.try_fixnum() {
-                mode = mode_string_from_flags(n);
+                (n, false, mode_string_from_flags(n))
             } else {
-                mode = m.coerce_to_string(vm, globals)?;
+                let s = m.coerce_to_string(vm, globals)?;
+                let (f, b) = oflags_from_mode_string(&s)?;
+                (f, b, s)
             }
         }
+    };
+    if let Some(f) = open_kw(lfp, "flags") {
+        oflags |= f.coerce_to_int_i64(vm, globals)?;
     }
-    let mut opt = File::options();
-    // Strip encoding suffix (e.g. ":UTF-8") and normalize the mode string:
-    // remove 'b' (binary) flag since it has no effect on Unix.
-    let mode_base = mode.split(':').next().unwrap().replace('b', "");
-    let (readable, writable) = match mode_base.as_str() {
-        "r" => (true, false),
-        "w" | "a" | "w-" | "-w" => (false, true),
-        "r+" | "+r" | "w+" | "+w" | "a+" | "+a" => (true, true),
-        _ => (true, false),
-    };
-    let opt = match mode_base.as_str() {
-        "r" => opt.read(true),
-        "w" => opt.write(true).create(true).truncate(true),
-        // Internal spellings (mode_string_from_flags): write+create
-        // without truncation, and bare write-only.
-        "w-" => opt.write(true).create(true),
-        "-w" => opt.write(true),
-        "a" => opt.write(true).create(true).append(true),
-        "r+" | "+r" => opt.read(true).write(true),
-        "w+" | "+w" => opt.read(true).write(true).create(true).truncate(true),
-        "a+" | "+a" => opt.read(true).write(true).create(true).append(true),
-        _ => {
-            return Err(MonorubyErr::argumenterr(format!(
-                "Invalid access mode {}",
-                mode
-            )));
-        }
-    };
+    if open_kw(lfp, "binmode").is_some_and(|v| v.as_bool()) {
+        binmode = true;
+    }
+    // CRuby rejects newline decorators on a binary-mode stream.
+    if binmode && open_kw(lfp, "newline").is_some() {
+        return Err(MonorubyErr::argumenterr("newline decorator with binary mode"));
+    }
+    let access = (oflags as i32) & libc::O_ACCMODE;
+    let readable = access == libc::O_RDONLY || access == libc::O_RDWR;
+    let writable = access == libc::O_WRONLY || access == libc::O_RDWR;
     // Creation permissions: the positional Integer after the mode, or a
-    // `:perm` entry in a trailing options Hash (both CRuby forms; only
-    // applied when the open creates the file).
-    let mut perm: Option<u32> = None;
+    // `perm:` keyword (only applied when the open creates the file).
+    let mut perm: i64 = 0o666;
     if let Some(arg2) = lfp.try_arg(2)
         && let Some(n) = arg2.try_fixnum()
     {
-        perm = Some(n as u32);
+        perm = n;
     }
-    for i in 1..4 {
-        if let Some(arg) = lfp.try_arg(i)
-            && let Some(h) = arg.try_hash_ty()
-            && let Some(m) = h.get(Value::symbol(IdentId::get_id("perm")), vm, globals)?
-            && let Some(n) = m.try_fixnum()
-        {
-            perm = Some(n as u32);
-        }
+    if let Some(p) = open_kw(lfp, "perm")
+        && let Some(n) = p.try_fixnum()
+    {
+        perm = n;
     }
-    if let Some(p) = perm {
-        use std::os::unix::fs::OpenOptionsExt;
-        opt.mode(p);
-    }
-    let path = to_path_str(vm, globals, lfp.arg(0))?;
+    let path_rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let path_bytes = path_rs.as_bytes().to_vec();
+    let path = String::from_utf8_lossy(&path_bytes).to_string();
+    // NUL bytes were rejected by to_path_rstring, so this cannot fail.
+    let cpath = std::ffi::CString::new(path_bytes.clone())
+        .map_err(|_| MonorubyErr::argumenterr("path name contains null byte"))?;
+    let open_flags = (oflags as i32) | libc::O_CLOEXEC;
     // A FIFO's open(2) blocks in the kernel until the peer end appears;
-    // opening it inline through std would freeze every green thread (and
-    // the process). Detect the FIFO up front and run the blocking open on
+    // opening it inline would freeze every green thread (and the
+    // process). Detect the FIFO up front and run the blocking open on
     // a native worker instead, parking only this thread
     // (doc/threads.md §9). A TOCTOU miss here just falls back to
     // the previous inline behavior.
-    let is_fifo = std::fs::metadata(&path)
+    let is_fifo = std::fs::metadata(bytes_to_pathbuf(&path_bytes))
         .map(|m| std::os::unix::fs::FileTypeExt::is_fifo(&m.file_type()))
         .unwrap_or(false);
-    let file = if is_fifo && let Ok(cpath) = std::ffi::CString::new(path.as_str()) {
-        let flags = match mode_base.as_str() {
-            "r" => libc::O_RDONLY,
-            "w" => libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
-            "w-" => libc::O_WRONLY | libc::O_CREAT,
-            "-w" => libc::O_WRONLY,
-            "a" => libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
-            "r+" | "+r" => libc::O_RDWR,
-            "w+" | "+w" => libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC,
-            "a+" | "+a" => libc::O_RDWR | libc::O_CREAT | libc::O_APPEND,
-            _ => unreachable!(),
-        } | libc::O_CLOEXEC;
+    let file = if is_fifo {
         let comp = crate::native_pool::run_blocking(
             vm,
             globals,
             crate::native_pool::NativeOp::Open {
                 path: cpath,
-                flags,
-                mode: 0o666,
+                flags: open_flags,
+                mode: perm as u32,
             },
         )?;
         if comp.ret < 0 {
@@ -1164,21 +1482,38 @@ fn open(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         // transfers to the File here.
         unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(comp.ret as i32) }
     } else {
-        match opt.open(&path) {
-            Ok(file) => file,
-            Err(err) => {
-                return Err(MonorubyErr::errno_with_path(
-                    &globals.store,
-                    &err,
-                    "rb_sysopen",
-                    &path,
-                ));
-            }
+        // SAFETY: open(2) with a NUL-terminated path; the returned fd (when
+        // valid) is owned by the File constructed below.
+        let fd = unsafe { libc::open(cpath.as_ptr(), open_flags, perm as libc::c_uint) };
+        if fd < 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(MonorubyErr::errno_with_path(
+                &globals.store,
+                &err,
+                "rb_sysopen",
+                &path,
+            ));
         }
+        // SAFETY: `fd` is a fresh descriptor from open(2); ownership
+        // transfers to the File here.
+        unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(fd) }
     };
-    let res = Value::new_file(file, path, readable, writable);
-    super::io::init_io_encodings(vm, globals, lfp, res, &mode, readable, 1..4)?;
+    let res = Value::new_file(
+        file,
+        path,
+        Some((path_bytes.clone(), path_rs.encoding())),
+        readable,
+        writable,
+    );
+    super::io::init_io_encodings(vm, globals, lfp, res, &mode, readable, 1..3, kw_hash)?;
     if let Some(bh) = lfp.block() {
+        if is_new {
+            vm.ruby_warn(
+                globals,
+                "warning: File::new() does not take block; use File::open() instead",
+            )?;
+            return Ok(res);
+        }
         let r = vm.invoke_block_once(globals, bh, &[res]);
         // CRuby File.open(...) {|io| ... } closes the file at block exit.
         return block_close(vm, globals, res, r);
@@ -1293,14 +1628,15 @@ fn absolute_path(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let file_name = to_path_str(vm, globals, lfp.arg(0))?;
-    if Path::new(&file_name).is_absolute() {
-        return Ok(Value::string(file_name));
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = rs.encoding();
+    if rs.as_bytes().first() == Some(&b'/') {
+        return Ok(path_value(rs.as_bytes(), enc));
     }
     let base = if let Some(arg1) = lfp.try_arg(1)
         && !arg1.is_nil()
     {
-        std::path::PathBuf::from(to_path_str(vm, globals, arg1)?)
+        bytes_to_pathbuf(to_path_rstring(vm, globals, arg1)?.as_bytes())
     } else {
         match std::env::current_dir() {
             Ok(dir) => dir,
@@ -1308,8 +1644,8 @@ fn absolute_path(
         }
     };
     let mut result = base;
-    result.push(&file_name);
-    Ok(Value::string(conv_pathbuf(&result)))
+    result.push(bytes_to_pathbuf(rs.as_bytes()));
+    Ok(path_value(pathbuf_bytes(&result), enc))
 }
 
 ///
@@ -1335,76 +1671,107 @@ fn absolute_path_(
 /// [https://docs.ruby-lang.org/ja/latest/method/File/s/split.html]
 #[monoruby_builtin]
 fn file_split(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let filename = to_path(vm, globals, lfp.arg(0))?;
-    let mut dir = match filename.parent() {
-        Some(ostr) => conv_pathbuf(ostr),
-        None => "".to_string(),
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = rs.encoding();
+    let filename = normalize_pathbuf(rs.as_bytes());
+    let dir: Vec<u8> = match filename.parent() {
+        Some(p) if !pathbuf_bytes(p).is_empty() => pathbuf_bytes(p).to_vec(),
+        _ => b".".to_vec(),
     };
-    if dir.is_empty() {
-        dir = ".".to_string();
-    }
-    let base = match filename.file_name() {
-        Some(ostr) => ostr.to_string_lossy().to_string(),
+    let base: Vec<u8> = match filename.file_name() {
+        Some(ostr) => {
+            use std::os::unix::ffi::OsStrExt;
+            ostr.as_bytes().to_vec()
+        }
         None => {
             if filename.as_os_str() == "/" {
-                "/".to_string()
+                b"/".to_vec()
             } else {
-                "".to_string()
+                Vec::new()
             }
         }
     };
-    Ok(Value::array2(Value::string(dir), Value::string(base)))
+    Ok(Value::array2(path_value(&dir, enc), path_value(&base, enc)))
 }
 
 // Utils
 
-fn extend(path: &mut std::path::PathBuf, extend: std::path::PathBuf) -> Result<()> {
-    for elem in extend.components() {
-        match elem {
-            std::path::Component::CurDir => {}
-            std::path::Component::Normal(comp) if comp == "~" => {
-                path.clear();
-                let home_dir = match dirs::home_dir() {
-                    Some(dir) => dir,
-                    None => {
-                        return Err(MonorubyErr::runtimeerr("Failed to get home directory."));
-                    }
-                };
-                path.push(home_dir);
-            }
-            std::path::Component::Normal(comp) => path.push(comp),
-            std::path::Component::ParentDir => {
-                path.pop();
-            }
-            std::path::Component::RootDir => {
-                path.clear();
-                path.push(std::path::Component::RootDir);
-            }
-            _ => {}
-        };
-    }
-    Ok(())
-}
-
 /// Convert `file` to PathBuf.
 fn to_path(vm: &mut Executor, globals: &mut Globals, file: Value) -> Result<std::path::PathBuf> {
-    let file = to_path_str(vm, globals, file)?;
+    let file = to_path_rstring(vm, globals, file)?;
+    Ok(normalize_pathbuf(file.as_bytes()))
+}
+
+/// Lexically normalize raw path bytes into a `PathBuf`, collapsing
+/// `name/..` pairs.
+fn normalize_pathbuf(bytes: &[u8]) -> std::path::PathBuf {
     let mut path = std::path::PathBuf::new();
-    for p in std::path::PathBuf::from(file).iter() {
+    for p in bytes_to_pathbuf(bytes).iter() {
         if p == ".." && path.file_name().is_some() {
             path.pop();
         } else {
             path.push(p);
         };
     }
-    Ok(path)
+    path
+}
+
+/// Coerce `val` to a path String, keeping the raw bytes and the encoding
+/// tag. Mirrors CRuby's `rb_get_path`: NUL bytes raise ArgumentError and
+/// an ASCII-incompatible encoding raises `Encoding::CompatibilityError`.
+pub(super) fn to_path_rstring(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    val: Value,
+) -> Result<RString> {
+    // Check the encoding before the NUL-byte scan: a UTF-16/32 path is a
+    // CompatibilityError even though its bytes contain NULs.
+    let rs = val.coerce_to_path_rstring_allow_nul(vm, globals)?;
+    check_path_encoding(globals, &rs)?;
+    if rs.as_bytes().contains(&0) {
+        return Err(MonorubyErr::argumenterr("path name contains null byte"));
+    }
+    Ok(rs)
+}
+
+/// Reject ASCII-incompatible path encodings (UTF-16/32, ISO-2022-JP)
+/// with CRuby's `Encoding::CompatibilityError` message.
+pub(super) fn check_path_encoding(globals: &Globals, rs: &RString) -> Result<()> {
+    let enc = rs.encoding();
+    if !enc.is_ascii_compatible() {
+        return Err(MonorubyErr::encoding_compatibility_error_with_store(
+            &globals.store,
+            format!(
+                "path name must be ASCII-compatible ({}): \"{}\"",
+                enc.name(),
+                rs.inspect().trim_matches('"'),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Build a `PathBuf` from raw path bytes (no UTF-8 requirement on Unix).
+pub(super) fn bytes_to_pathbuf(bytes: &[u8]) -> std::path::PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    std::path::PathBuf::from(std::ffi::OsStr::from_bytes(bytes))
+}
+
+/// The raw bytes of a `Path`.
+pub(super) fn pathbuf_bytes(path: &std::path::Path) -> &[u8] {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes()
+}
+
+/// Build a path result String from raw bytes tagged with `enc` — the
+/// encoding of the originating path argument, which CRuby's path
+/// operations preserve in their results.
+pub(super) fn path_value(bytes: &[u8], enc: crate::value::Encoding) -> Value {
+    Value::string_from_inner(RStringInner::from_encoding(bytes, enc))
 }
 
 pub(super) fn to_path_str(vm: &mut Executor, globals: &mut Globals, val: Value) -> Result<String> {
-    Ok(val
-        .coerce_to_path_rstring(vm, globals)?
-        .to_str()?
-        .to_string())
+    Ok(to_path_rstring(vm, globals, val)?.to_str()?.to_string())
 }
 
 #[cfg(not(windows))]
@@ -2671,51 +3038,17 @@ fn file_realdirpath(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
-    let path_str = to_path_str(vm, globals, lfp.arg(0))?;
-    let mut joined = if Path::new(&path_str).is_absolute() {
-        std::path::PathBuf::from(&path_str)
+    let rs = to_path_rstring(vm, globals, lfp.arg(0))?;
+    let enc = rs.encoding();
+    let base: Option<Vec<u8>> = if let Some(arg1) = lfp.try_arg(1)
+        && !arg1.is_nil()
+    {
+        Some(to_path_rstring(vm, globals, arg1)?.as_bytes().to_vec())
     } else {
-        let base = if let Some(arg1) = lfp.try_arg(1)
-            && !arg1.is_nil()
-        {
-            std::path::PathBuf::from(to_path_str(vm, globals, arg1)?)
-        } else {
-            std::env::current_dir().map_err(|e| {
-                MonorubyErr::errno_with_msg(&globals.store, &e, ".")
-            })?
-        };
-        let mut p = base;
-        p.push(&path_str);
-        p
+        None
     };
-    // If the full path exists, canonicalize it and we're done.
-    if let Ok(canon) = joined.canonicalize() {
-        return Ok(Value::string(conv_pathbuf(&canon)));
-    }
-    // Otherwise canonicalize the parent directory and append the basename.
-    let basename = match joined.file_name() {
-        Some(n) => n.to_owned(),
-        None => {
-            return Err(MonorubyErr::errno_with_path(
-                &globals.store,
-                &std::io::Error::from_raw_os_error(libc::ENOENT),
-                "rb_file_s_realdirpath",
-                &joined.to_string_lossy(),
-            ));
-        }
-    };
-    joined.pop();
-    let parent = joined.canonicalize().map_err(|e| {
-        MonorubyErr::errno_with_path(
-            &globals.store,
-            &e,
-            "rb_file_s_realdirpath",
-            &joined.to_string_lossy(),
-        )
-    })?;
-    let mut out = parent;
-    out.push(basename);
-    Ok(Value::string(conv_pathbuf(&out)))
+    let resolved = check_realpath(globals, rs.as_bytes(), base.as_deref(), false, "realpath_rec")?;
+    Ok(resolved_path_value(globals, resolved, enc, false))
 }
 
 #[cfg(test)]

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -975,13 +975,7 @@ fn realpath(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     } else {
         None
     };
-    let resolved = check_realpath(
-        globals,
-        rs.as_bytes(),
-        base.as_deref(),
-        true,
-        "rb_check_realpath_internal",
-    )?;
+    let resolved = check_realpath(globals, rs.as_bytes(), base.as_deref(), true)?;
     Ok(resolved_path_value(globals, resolved, enc, true))
 }
 
@@ -1015,12 +1009,16 @@ fn resolved_path_value(
 /// `dir/file/../` resolves to `dir` without an `ENOTDIR`. With
 /// `strict_last` false (File.realdirpath) the final component may be
 /// absent; everything else must exist.
+///
+/// Error spelling follows CRuby: strict-mode ENOENT/ELOOP report the
+/// path *as given* (base-joined) under `rb_check_realpath_internal`
+/// (CRuby's native realpath(3) path); every other failure reports the
+/// resolved-so-far prefix under `realpath_rec` (the emulation).
 fn check_realpath(
     globals: &Globals,
     path: &[u8],
     base: Option<&[u8]>,
     strict_last: bool,
-    op: &str,
 ) -> Result<Vec<u8>> {
     use std::collections::VecDeque;
     fn push_front_components(queue: &mut VecDeque<Vec<u8>>, bytes: &[u8]) {
@@ -1030,9 +1028,38 @@ fn check_realpath(
             }
         }
     }
+    // The user-facing path for strict-mode native-style errors: the
+    // argument as written, prefixed by the base when one was given and
+    // the argument is relative.
+    let given_display = {
+        let arg = String::from_utf8_lossy(path).to_string();
+        match base {
+            Some(b) if path.first() != Some(&b'/') => {
+                format!("{}/{}", String::from_utf8_lossy(b), arg)
+            }
+            _ => arg,
+        }
+    };
+    let raise = |raw: i32, resolved: &[u8]| {
+        let err = std::io::Error::from_raw_os_error(raw);
+        if strict_last && matches!(raw, libc::ENOENT | libc::ELOOP) {
+            MonorubyErr::errno_with_path(
+                &globals.store,
+                &err,
+                "rb_check_realpath_internal",
+                &given_display,
+            )
+        } else {
+            MonorubyErr::errno_with_path(
+                &globals.store,
+                &err,
+                "realpath_rec",
+                &String::from_utf8_lossy(resolved),
+            )
+        }
+    };
     if path.is_empty() {
-        let err = std::io::Error::from_raw_os_error(libc::ENOENT);
-        return Err(MonorubyErr::errno_with_path(&globals.store, &err, op, ""));
+        return Err(raise(libc::ENOENT, b""));
     }
     let mut queue: VecDeque<Vec<u8>> = VecDeque::new();
     push_front_components(&mut queue, path);
@@ -1049,11 +1076,6 @@ fn check_realpath(
         };
         push_front_components(&mut queue, &abs_base);
     }
-
-    let errno_err = |raw: i32, at: &[u8]| {
-        let err = std::io::Error::from_raw_os_error(raw);
-        MonorubyErr::errno_with_path(&globals.store, &err, op, &String::from_utf8_lossy(at))
-    };
 
     let mut resolved: Vec<u8> = Vec::new();
     let mut links = 0usize;
@@ -1076,17 +1098,10 @@ fn check_realpath(
             Ok(md) if md.file_type().is_symlink() => {
                 links += 1;
                 if links > 40 {
-                    return Err(errno_err(libc::ELOOP, &resolved));
+                    return Err(raise(libc::ELOOP, &resolved));
                 }
                 let target = std::fs::read_link(bytes_to_pathbuf(&resolved))
-                    .map_err(|e| {
-                        MonorubyErr::errno_with_path(
-                            &globals.store,
-                            &e,
-                            op,
-                            &String::from_utf8_lossy(&resolved),
-                        )
-                    })?;
+                    .map_err(|e| raise(e.raw_os_error().unwrap_or(libc::EIO), &resolved))?;
                 let tb = pathbuf_bytes(&target).to_vec();
                 resolved.truncate(prev_len);
                 if tb.first() == Some(&b'/') {
@@ -1100,12 +1115,7 @@ fn check_realpath(
                     && queue.is_empty()
                     && e.kind() == std::io::ErrorKind::NotFound;
                 if !missing_last_ok {
-                    return Err(MonorubyErr::errno_with_path(
-                        &globals.store,
-                        &e,
-                        op,
-                        &String::from_utf8_lossy(&resolved),
-                    ));
+                    return Err(raise(e.raw_os_error().unwrap_or(libc::EIO), &resolved));
                 }
             }
         }
@@ -1315,18 +1325,18 @@ fn open_impl(
                 &format!("fd {}", fd),
             ));
         }
-        // Creation-only flags make no sense on an already-open fd;
-        // CRuby surfaces this as Errno::EINVAL (core/file/new_spec.rb
-        // "can't alter mode or permissions when opening a file").
-        if let Some(n) = lfp.try_arg(1).and_then(|v| v.try_fixnum())
-            && n & ((libc::O_CREAT | libc::O_TRUNC | libc::O_EXCL) as i64) != 0
-        {
-            let err = std::io::Error::from_raw_os_error(libc::EINVAL);
-            return Err(MonorubyErr::errno_with_msg(
-                &globals.store,
-                &err,
-                &format!("fd {}", fd),
-            ));
+        // An integer mode cannot change an already-open fd's access mode;
+        // CRuby surfaces the mismatch as Errno::EINVAL
+        // (core/file/new_spec.rb "can't alter mode or permissions when
+        // opening a file").
+        if let Some(n) = lfp.try_arg(1).and_then(|v| v.try_fixnum()) {
+            let want = (n as i32) & libc::O_ACCMODE;
+            // SAFETY: fcntl(F_GETFL) on the fd validated above.
+            let cur = unsafe { libc::fcntl(fd_i32, libc::F_GETFL) };
+            if cur != -1 && (cur & libc::O_ACCMODE) != want {
+                let err = std::io::Error::from_raw_os_error(libc::EINVAL);
+                return Err(MonorubyErr::errno_plain(&globals.store, &err));
+            }
         }
         // Scan trailing args for an options Hash and pick up `:path`
         // (display name) and `:autoclose` (fd ownership) — required by
@@ -3047,13 +3057,124 @@ fn file_realdirpath(
     } else {
         None
     };
-    let resolved = check_realpath(globals, rs.as_bytes(), base.as_deref(), false, "realpath_rec")?;
+    let resolved = check_realpath(globals, rs.as_bytes(), base.as_deref(), false)?;
     Ok(resolved_path_value(globals, resolved, enc, false))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    #[test]
+    fn file_path_ops_preserve_encoding() {
+        // basename/extname/split/join/path/absolute_path/expand_path
+        // preserve the path argument's encoding in their results.
+        run_test_once(
+            r##"(p="/foo/bar.baz".encode(Encoding::EUC_JP); [File.basename(p).encoding.name, File.basename(p, ".baz").encoding.name, File.basename(p, ".*"), File.extname(p).encoding.name, File.split(p).map { |x| x.encoding.name }, File.join(p, "q").encoding.name, File.path(p).encoding.name, File.absolute_path(p).encoding.name, File.expand_path("./a".encode(Encoding::Windows_1251)).encoding.name, File.expand_path(p).encoding.name])"##,
+        );
+    }
+
+    #[test]
+    fn file_path_ops_reject_ascii_incompatible() {
+        // UTF-16/32 path arguments raise Encoding::CompatibilityError
+        // (before the NUL-byte scan — UTF-32 "ab" contains NULs).
+        run_test_once(
+            r##"(f = ->(x) { begin; x.call; rescue => e; e.class; end }; [f.(-> { File.basename("/foo/bar".encode(Encoding::UTF_16LE)) }), f.(-> { File.path("ab".encode(Encoding::UTF_32BE)) }), f.(-> { File.extname("a.b".encode(Encoding::UTF_16BE)) }), f.(-> { Dir.glob("nope*".encode(Encoding::UTF_16BE)) }), (begin; Dir.glob("x*".encode(Encoding::UTF_16BE)); rescue => e; e.message; end)])"##,
+        );
+    }
+
+    #[test]
+    fn file_expand_path_slashes_and_tilde() {
+        // Leading slash runs survive verbatim, interior runs squeeze,
+        // ~user expands via getpwnam, mid-path ~ stays literal.
+        run_test_once(
+            r##"[File.expand_path("////some/path"), File.expand_path("//some/path"), File.expand_path("/some////path"), File.expand_path("/a/./b/../c//d/"), File.expand_path("~root/x"), File.expand_path("/~root/a"), File.expand_path("a", "/"), File.expand_path("../../bin", "/tmp/x"), (begin; File.expand_path("~no_such_user_zzq"); rescue => e; [e.class, e.message]; end)]"##,
+        );
+    }
+
+    #[test]
+    fn file_realpath_component_resolution() {
+        // dir/file/../ resolves lexically (no ENOTDIR); a missing
+        // intermediate component reports CRuby's realpath error message;
+        // a self-referential symlink is ELOOP.
+        run_test_once(
+            r##"(d="/tmp/mono_rp_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/file", ""); a=(File.realpath("#{d}/file/../")==d); b=(begin; File.realpath("/no_such_dir_zzq/x"); rescue => e; [e.class, e.message]; end); File.symlink("#{d}/self", "#{d}/self"); c=(begin; File.realpath("#{d}/self"); rescue => e; e.class; end); c2=(begin; File.realdirpath("#{d}/self"); rescue => e; e.class; end); File.unlink("#{d}/self"); File.unlink("#{d}/file"); Dir.rmdir(d); [a,b,c,c2])"##,
+        );
+    }
+
+    #[test]
+    fn file_realdirpath_dangling_symlinks() {
+        // The final component may be absent; a dangling symlink resolves
+        // to its (absent) target; a missing intermediate dir is ENOENT.
+        run_test_once(
+            r##"(d="/tmp/mono_rdp_#{Process.pid}"; Dir.mkdir(d); a=(File.realdirpath("#{d}/missing") == "#{d}/missing"); File.symlink("#{d}/absent_file", "#{d}/link"); b=(File.realdirpath("#{d}/link") == "#{d}/absent_file"); c=(begin; File.realdirpath("#{d}/no_dir/file"); rescue => e; [e.class, e.message.sub(d, "")]; end); File.unlink("#{d}/link"); Dir.rmdir(d); [a, b, c])"##,
+        );
+    }
+
+    #[test]
+    fn file_realpath_result_encoding() {
+        // Resolved paths convert to the argument's encoding; realpath
+        // forces it when the conversion fails, realdirpath keeps UTF-8.
+        run_test_once(
+            r##"(d="/tmp/mono_rpe_あ_#{Process.pid}"; Dir.mkdir(d); a=File.realpath(".".encode(Encoding::ISO_8859_1), d).encoding.name; b=File.realdirpath(".".encode(Encoding::ISO_8859_1), d).encoding.name; c=File.realpath(d.encode(Encoding::EUC_JP)).encoding.name rescue c=$!.class; Dir.rmdir(d); [a, b])"##,
+        );
+    }
+
+    #[test]
+    fn file_open_integer_modes() {
+        // Integer modes keep their creation bits: CREAT creates,
+        // CREAT|EXCL raises EEXIST, TRUNC truncates a read-only open,
+        // WRONLY|APPEND appends without truncating.
+        run_test_once(
+            r##"(f="/tmp/mono_om_#{Process.pid}"; a=File.open(f, File::CREAT) { |x| x.class }; b=(begin; File.open(f, File::CREAT|File::EXCL); rescue => e; e.class; end); File.write(f, "hello\n"); File.open(f, File::WRONLY|File::APPEND) { |x| x.write("more\n") }; c=File.read(f); d=File.open(f, File::TRUNC) { |x| x.gets }; e2=File.read(f); File.delete(f); [a,b,c,d,e2])"##,
+        );
+    }
+
+    #[test]
+    fn file_open_mode_string_x_flag_and_errors() {
+        // 'wx' maps to O_EXCL; 'rx'/'ax'/unknown modes raise CRuby's
+        // lowercase "invalid access mode"; 4 positional args raise the
+        // arity error.
+        run_test_once(
+            r##"(f="/tmp/mono_x_#{Process.pid}"; a=File.open(f, "wx") { |x| x.write("c") }; b=File.read(f); c=(begin; File.open(f, "wx"); rescue => e; e.class; end); d=(begin; File.open(f, "rx"); rescue => e; [e.class, e.message]; end); e2=(begin; File.open(f, "ax"); rescue => e; e.message; end); g=(begin; File.open(f, "fake"); rescue => e; e.message; end); h=(begin; File.open(f, "w", 0o644, "extra"); rescue => e; [e.class, e.message]; end); File.delete(f); [a,b,c,d,e2,g,h])"##,
+        );
+    }
+
+    #[test]
+    fn file_open_keyword_options() {
+        // mode:/flags:/perm: keywords; flags: ORs onto both string and
+        // integer modes; binmode+newline is rejected.
+        run_test_once(
+            r##"(f="/tmp/mono_kw_#{Process.pid}"; File.write(f, ""); a=(begin; File.open(f, "w", flags: File::EXCL) {}; rescue => e; e.class; end); b=(begin; File.open(f, File::WRONLY|File::CREAT, flags: File::EXCL) {}; rescue => e; e.class; end); c=File.open(f, mode: "r") { |x| x.class }; d=(begin; File.open(f, "rb", newline: :universal) {}; rescue => e; [e.class, e.message]; end); File.delete(f); g="/tmp/mono_kw2_#{Process.pid}"; File.open(g, "w", perm: 0o600) {}; h=format("%o", File.stat(g).mode & 0o7777); File.delete(g); [a,b,c,d,h])"##,
+        );
+    }
+
+    #[test]
+    fn file_new_ignores_block_and_fd_creation_flags() {
+        // File.new never yields a given block (returns the File), and
+        // creation flags on an existing fd raise Errno::EINVAL.
+        run_test_once(
+            r##"(f="/tmp/mono_nb_#{Process.pid}"; fh=File.new(f, "w") { raise "block called" }; a=fh.class; fh.close; b=File.exist?(f); io=File.new(f); c=(begin; File.new(io.fileno, File::CREAT|File::TRUNC|File::WRONLY); rescue => e; [e.class, e.message]; end); c2=File.new(io.fileno, File::TRUNC, autoclose: false).class; io.close; File.delete(f); [a,b,c,c2])"##,
+        );
+    }
+
+    #[test]
+    fn file_to_path_preserves_open_encoding() {
+        // IO#path/#to_path reproduce the exact path argument, including
+        // its encoding tag.
+        run_test_once(
+            r##"(f="/tmp/mono_tpe_#{Process.pid}"; File.write(f, ""); io=File.new(f.encode(Encoding::EUC_JP)); a=[io.to_path.encoding.name, io.path == f]; io.close; File.delete(f); a)"##,
+        );
+    }
+
+    #[test]
+    fn io_write_open_args_option() {
+        // IO.write's :open_args — a trailing Hash inside the array is
+        // keyword-splatted into File.open.
+        run_test_once(
+            r##"(f="/tmp/mono_oa_#{Process.pid}"; n=IO.write(f, "hi", open_args: ["w", nil, {encoding: "UTF-8"}]); r=File.read(f); File.delete(f); [n, r])"##,
+        );
+    }
 
     #[test]
     fn file_to_path_coercion() {

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -504,14 +504,17 @@ pub(super) fn io_open_opts(
     lfp: Lfp,
     range: std::ops::Range<usize>,
     fd: i64,
+    extra: Option<Value>,
 ) -> Result<(String, bool, bool)> {
     let mut autoclose = true;
     let mut name = format!("fd {}", fd);
     let mut has_path = false;
-    for i in range {
-        if let Some(arg) = lfp.try_arg(i)
-            && let Some(h) = arg.try_hash_ty()
-        {
+    let candidates = range
+        .filter_map(|i| lfp.try_arg(i))
+        .chain(extra)
+        .collect::<Vec<_>>();
+    for arg in candidates {
+        if let Some(h) = arg.try_hash_ty() {
             if let Some(v) = h.get(Value::symbol(IdentId::get_id("autoclose")), vm, globals)? {
                 autoclose = v.as_bool();
             }
@@ -647,7 +650,7 @@ fn coerce_enc_arg(vm: &mut Executor, globals: &mut Globals, v: Value) -> Result<
 
 /// Argument `Value` -> Encoding object: an `Encoding` is taken as-is, a
 /// String is resolved by name; anything else (incl. `nil`) -> `None`.
-fn arg_to_enc_obj(globals: &Globals, v: Value) -> Option<Value> {
+pub(super) fn arg_to_enc_obj(globals: &Globals, v: Value) -> Option<Value> {
     if v.is_nil() {
         return None;
     }
@@ -778,6 +781,7 @@ fn parse_open_encodings(
     lfp: Lfp,
     opt_range: std::ops::Range<usize>,
     mode: &str,
+    extra: Option<Value>,
 ) -> Result<(Option<Value>, Option<Value>, bool, bool)> {
     let base = mode.split(':').next().unwrap_or("");
     let binmode = base.contains('b');
@@ -794,8 +798,11 @@ fn parse_open_encodings(
     let mut ext = mext.and_then(|s| enc_by_name(globals, s));
     let mut int = mint.and_then(|s| enc_by_name(globals, s));
 
-    for i in opt_range {
-        let Some(arg) = lfp.try_arg(i) else { continue };
+    let candidates = opt_range
+        .filter_map(|i| lfp.try_arg(i))
+        .chain(extra)
+        .collect::<Vec<_>>();
+    for arg in candidates {
         let Some(h) = arg.try_hash_ty() else { continue };
         if let Some(v) = h.get(Value::symbol(IdentId::get_id("encoding")), vm, globals)?
             && !v.is_nil()
@@ -933,8 +940,10 @@ pub(super) fn init_io_encodings(
     mode: &str,
     readable: bool,
     opt_range: std::ops::Range<usize>,
+    extra: Option<Value>,
 ) -> Result<()> {
-    let (ext, int, binmode, bom) = parse_open_encodings(vm, globals, lfp, opt_range, mode)?;
+    let (ext, int, binmode, bom) =
+        parse_open_encodings(vm, globals, lfp, opt_range, mode, extra)?;
     // The stream's write-ability decides whether a missing external
     // encoding tracks default_external (read-only) or stays nil.
     let base = mode.split(':').next().unwrap_or("");
@@ -1961,7 +1970,7 @@ fn io_class_readlines(
     let file = std::fs::File::open(&path)
         .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_sysopen", &path))?;
     let complete_utf8 = ext_completes_utf8(globals, ext_obj);
-    let mut io_val = Value::new_file(file, path, true, false);
+    let mut io_val = Value::new_file(file, path, None, true, false);
     vm.with_temp_scope(|vm| {
         // Root the transient File IO (and the result lines) across the
         // per-line allocations below.
@@ -2133,7 +2142,7 @@ fn io_foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePt
     let file = std::fs::File::open(&path)
         .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_sysopen", &path))?;
     let complete_utf8 = ext_completes_utf8(globals, ext_obj);
-    let mut io_val = Value::new_file(file, path, true, false);
+    let mut io_val = Value::new_file(file, path, None, true, false);
     vm.with_temp_scope(|vm| {
         // Root the transient File IO across the block calls below.
         vm.temp_push(io_val);
@@ -3567,7 +3576,11 @@ fn io_lineno_set(
 /// [https://docs.ruby-lang.org/ja/latest/method/IO/i/path.html]
 #[monoruby_builtin]
 fn io_path(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    Ok(match lfp.self_val().as_io_inner().path() {
+    let io = lfp.self_val();
+    if let Some((bytes, enc)) = io.as_io_inner().path_raw() {
+        return Ok(super::file::path_value(bytes, *enc));
+    }
+    Ok(match io.as_io_inner().path() {
         Some(p) => Value::string(p),
         None => Value::nil(),
     })
@@ -4591,7 +4604,7 @@ pub(super) fn enc_obj_to_enum(globals: &Globals, v: Value) -> Option<crate::valu
 /// `Encoding.default_external`), transcoding external -> internal when
 /// an internal encoding is set and differs and the external is not
 /// BINARY. Used by the `IO.readlines` / `IO.foreach` class methods.
-fn tag_with_encs(
+pub(super) fn tag_with_encs(
     globals: &mut Globals,
     bytes: Vec<u8>,
     ext_obj: Option<Value>,
@@ -5186,7 +5199,7 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         Src::Path(p) => {
             let file = std::fs::File::open(p)
                 .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_sysopen", p))?;
-            let v = Value::new_file(file, p.clone(), true, false);
+            let v = Value::new_file(file, p.clone(), None, true, false);
             src_io_owned = Some(v);
             Some(v)
         }
@@ -5202,7 +5215,7 @@ fn io_copy_stream(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
                 .truncate(true)
                 .open(p)
                 .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_sysopen", p))?;
-            let v = Value::new_file(file, p.clone(), false, true);
+            let v = Value::new_file(file, p.clone(), None, false, true);
             dst_io_owned = Some(v);
             Some(v)
         }

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1096,6 +1096,15 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn signal_trap_negative_name() {
+        // A leading '-' is rejected with a dedicated message, before the
+        // signal-table lookup.
+        run_test_once(
+            r##"[(begin; Signal.trap("-HUP") {}; rescue => e; [e.class, e.message]; end), (begin; Signal.trap(:"-INT") {}; rescue => e; e.message; end)]"##,
+        );
+    }
+
+    #[test]
     fn process() {
         run_test_no_result_check("Process.clock_gettime Process::CLOCK_MONOTONIC, :nanosecond");
         run_test_no_result_check("Process.clock_gettime Process::CLOCK_MONOTONIC");

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -948,6 +948,13 @@ fn trap_signo(vm: &mut Executor, globals: &mut Globals, arg: Value) -> Result<i3
             arg.get_real_class_name(&globals.store)
         )));
     };
+    // CRuby rejects a leading '-' with a dedicated message before the
+    // signal-table lookup (core/signal/trap_spec.rb).
+    if name.starts_with('-') {
+        return Err(MonorubyErr::argumenterr(format!(
+            "negative signal name: {name}"
+        )));
+    }
     signal_name_to_number(&name).ok_or_else(|| {
         MonorubyErr::argumenterr(format!(
             "unsupported signal 'SIG{}'",

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -720,7 +720,7 @@ impl Executor {
         {
             use std::io::Seek;
             let _ = file.seek(std::io::SeekFrom::Start(offset as u64));
-            let data = Value::new_file(file, path.to_string_lossy().into_owned(), true, false);
+            let data = Value::new_file(file, path.to_string_lossy().into_owned(), None, true, false);
             globals.set_constant_by_str(OBJECT_CLASS, "DATA", data);
         }
     }

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1284,10 +1284,11 @@ impl Value {
     pub(crate) fn new_file(
         file: std::fs::File,
         name: String,
+        path_raw: Option<(Vec<u8>, crate::value::Encoding)>,
         readable: bool,
         writable: bool,
     ) -> Self {
-        RValue::new_file(file, name, readable, writable).pack()
+        RValue::new_file(file, name, path_raw, readable, writable).pack()
     }
 
     pub(crate) fn new_socket(file: std::fs::File, name: String, class_id: ClassId) -> Self {

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1975,10 +1975,11 @@ impl RValue {
     pub(super) fn new_file(
         file: std::fs::File,
         name: String,
+        path_raw: Option<(Vec<u8>, crate::value::Encoding)>,
         readable: bool,
         writable: bool,
     ) -> Self {
-        let inner = IoInner::file(file, name, readable, writable);
+        let inner = IoInner::file(file, name, path_raw, readable, writable);
         RValue {
             header: Header::new(FILE_CLASS, ObjTy::IO),
             kind: ObjKind::io(inner),

--- a/monoruby/src/value/rvalue/io.rs
+++ b/monoruby/src/value/rvalue/io.rs
@@ -406,6 +406,10 @@ fn utf8_missing_bytes(buf: &[u8]) -> usize {
 pub struct FileDescriptor {
     reader: ManuallyDrop<IoReader<std::fs::File>>,
     name: String,
+    /// The path as originally passed to `File.open`/`File.new`: raw
+    /// bytes plus the argument's encoding tag, so `IO#path`/`#to_path`
+    /// can reproduce it exactly (`name` is its lossy display form).
+    path_raw: Option<(Vec<u8>, crate::value::Encoding)>,
     /// Whether `name` is a real filesystem path (surfaced via `IO#path`).
     /// `false` for placeholder names like `fd 3`/`pipe` created from a raw
     /// fd without an explicit `path:` option — CRuby's `IO#path` is `nil`
@@ -859,12 +863,19 @@ impl IoInner {
         Self::with_kind(IoKind::Stderr)
     }
 
-    pub(super) fn file(file: std::fs::File, name: String, readable: bool, writable: bool) -> Self {
+    pub(super) fn file(
+        file: std::fs::File,
+        name: String,
+        path_raw: Option<(Vec<u8>, crate::value::Encoding)>,
+        readable: bool,
+        writable: bool,
+    ) -> Self {
         register_owned_fd(file.as_raw_fd());
         let is_tty = file.is_terminal();
         Self::with_kind(IoKind::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(IoReader::new(file)),
             name,
+            path_raw,
             has_path: true,
             readable,
             writable,
@@ -885,6 +896,7 @@ impl IoInner {
         Self::with_kind(IoKind::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(IoReader::new(file)),
             name,
+            path_raw: None,
             has_path: false,
             readable: true,
             writable: true,
@@ -937,6 +949,7 @@ impl IoInner {
         Self::with_kind(IoKind::File(Rc::new(FileDescriptor {
             reader: ManuallyDrop::new(IoReader::new(file)),
             name,
+            path_raw: None,
             has_path,
             readable,
             writable,
@@ -1809,6 +1822,16 @@ impl IoInner {
             IoKind::File(file) if file.has_path => Some(file.name.clone()),
             IoKind::Closed(p) => p.as_deref().cloned(),
             IoKind::File(_) | IoKind::Popen(_) => None,
+        }
+    }
+
+    /// The exact path bytes + encoding as passed at open time, when the
+    /// stream was opened from a path (`IO#path` preserves the argument's
+    /// encoding — core/file/to_path_spec.rb).
+    pub fn path_raw(&self) -> Option<&(Vec<u8>, crate::value::Encoding)> {
+        match &self.kind {
+            IoKind::File(file) if file.has_path => file.path_raw.as_ref(),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Fixes 63 of the 66 remaining ruby/spec failures across the four categories:

| category | before | after |
|---|---|---|
| core/dir | 15 failures + 3 errors | **0** |
| core/file | 32 failures + 14 errors | **0 failures + 3 errors** |
| core/filetest | 0 | 0 |
| core/signal | 1 error | **0** |

## Path handling (the root cause behind ~30 specs)

- Paths now flow as **raw bytes** end-to-end (`OsStr` on Unix) instead of through `RStringInner::to_str`, which escaped non-UTF-8 bytes as literal `\xHH` text — `Dir.mkdir`/`chdir`/`pwd` with binary names literally created directories named `\xE3\x81\x82` on disk.
- New `to_path_rstring` mirrors CRuby's `rb_get_path`: `#to_path`/`#to_str` coercion, `Encoding::CompatibilityError` for ASCII-incompatible path encodings (checked **before** the NUL scan, so UTF-16/32 paths report the right error), then the NUL-byte rejection.
- `basename` / `extname` / `join` / `split` / `path` / `absolute_path` / `expand_path` / `realpath` / `realdirpath` / `File#path` / `File#to_path` preserve the path argument's encoding in their results. `File.open` threads the original bytes + encoding tag into the `FileDescriptor` (`path_raw`) so `#to_path` can reproduce it exactly.

## File.expand_path (rewritten byte-wise)

- Leading slash runs are preserved verbatim (`////some/path`), interior runs squeezed.
- `~user` expands via `getpwnam` (unknown user → `ArgumentError: user X doesn't exist`); `~` honours `HOME` with CRuby's `"non-absolute home"` for empty/relative values and falls back to the passwd entry when unset; a mid-path `~` is left alone.
- An ASCII-incompatible `Encoding.default_external` raises `Encoding::CompatibilityError`.

## File.realpath / File.realdirpath

Replaced the `canonicalize()`-based implementation with a component-wise resolver modeled on CRuby's `rb_check_realpath`: each component is `lstat`ed, symlinks are followed with an ELOOP hop limit, and `..` collapses the resolved prefix lexically — so `dir/file/../` resolves to `dir` instead of `ENOTDIR`. `realdirpath` allows only the final component to be absent (dangling symlinks resolve to their target path; a missing intermediate directory is still `ENOENT`). Result encoding follows CRuby's split behavior: converted to the argument's encoding, with `realpath` *forcing* it on conversion failure while `realdirpath` keeps the resolved UTF-8 tag.

## File.open / File.new

- Modes resolve to open(2) flags directly, so integer modes stop losing bits: `File::CREAT` creates, `CREAT|EXCL` raises `EEXIST`, bare `TRUNC` truncates a read-only open. The `'x'` mode-string flag maps to `O_EXCL` (`"wx"`), and `"rx"`/`"ax"`/unknown modes raise `invalid access mode …` (now lowercase, matching CRuby).
- Registered with 3 positional parameters + real keywords (`mode`, `flags`, `perm`, encodings, …): `flags:` ORs onto either mode form, a 4th positional argument raises CRuby's `wrong number of arguments (given 4, expected 1..3)`, and `binmode` + `newline:` raises `newline decorator with binary mode`.
- `File.new` no longer invokes a given block (warns `File::new() does not take block; use File::open() instead`), and opening an existing fd with creation flags raises `Errno::EINVAL`.
- `IO.write`'s `:open_args` splats a trailing Hash as keywords to fit the new 3-positional signature.

## Dir

- Every Dir instance now holds a real `O_DIRECTORY|O_CLOEXEC` descriptor (via internal `Dir.__open_fd` / `__close_fd` / `__entries_fd`): `#fileno` returns it (close-on-exec spec), `Dir.for_fd` shares it, and `#close` surfaces close(2) errors (`Bad file descriptor - closedir` on the double-close spec).
- `Dir.entries` / `foreach` / `children` accept `encoding:`; entries are tagged with it (default: external encoding) and transcoded to the default internal encoding when set, keeping the external tag for names that don't convert (the SHIFT_JIS/UTF-8 mixed-entries spec).
- `Dir.glob` / `Dir[]`: results inherit the pattern's encoding, an ASCII-incompatible pattern raises `Encoding::CompatibilityError`, and glob accepts the `flags:` keyword (preferred over the positional argument).
- `Dir.pwd` returns raw bytes tagged UTF-8 (BINARY when not valid UTF-8); `Dir.chdir` propagates the restore failure when the original directory vanished inside the block.

## Signal

`Signal.trap("-HUP")` raises `ArgumentError: negative signal name: -HUP`.

## Remaining 3 (out of scope, structural)

- `File.utime`/`lutime` far-future `Time.at(1<<44)` (2 errors): monoruby's Time is chrono-backed, whose `DateTime` caps at year ±262143; representing year ~559444 needs a Time representation redesign.
- `File.stat` raw path bytes inside the exception message (1 error): `MonorubyErr`/`ExceptionInner` messages are Rust `String`s (valid UTF-8 only), so raw non-UTF-8 path bytes can't be embedded without reworking the error plumbing.

## Verification

- `cargo test` full suite green (2128 lib tests + all integration tests, exit 0).
- One collateral regression found and fixed during verification (`IO.write` `:open_args`, core/io 21→20 errors); the remaining core/io and core/kernel failures show no signatures of this change (no arity/unknown-keyword/access-mode fallout) and match the pre-existing feature-gap list (BOM reads, `set_encoding`, popen, IO::Buffer…).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_