### PR TITLE
process: validate exec options before the point of no return

### DIFF
--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -3510,6 +3510,32 @@ pub(super) fn exec(
 ) -> Result<Value> {
     use std::ffi::CString;
     let args = lfp.arg(0).as_array();
+    // Validate exec-option types *before* the point of no return: CRuby
+    // checks the options hash up front, so e.g.
+    // `Process.exec("true", unsetenv_others: 1)` raises ArgumentError
+    // instead of replacing the process. The ruby/spec
+    // "Process.exec options validation" examples call exec in-process
+    // and count on the raise happening first — without it the whole
+    // test runner is silently replaced by the exec'd command.
+    for v in args.iter() {
+        if let Some(h) = v.try_hash_ty() {
+            for (k, val) in h.iter() {
+                if let Some(sym) = k.try_symbol() {
+                    let name = format!("{sym}");
+                    if (name == "unsetenv_others" || name == "close_others")
+                        && !(val.is_nil()
+                            || val == Value::bool(true)
+                            || val == Value::bool(false))
+                    {
+                        return Err(MonorubyErr::argumenterr(format!(
+                            "expected true or false as {name}: {}",
+                            val.inspect(&globals.store)
+                        )));
+                    }
+                }
+            }
+        }
+    }
     // Filter out trailing Hash arguments (keyword args like close_others:)
     let str_args: Vec<String> = args
         .iter()
@@ -3596,7 +3622,7 @@ pub(super) fn exec(
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Kernel/m/fork.html]
 #[monoruby_builtin]
-fn fork(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+pub(super) fn fork(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // SAFETY: fork() is a POSIX system call. We call it in a single-threaded context.
     let pid = unsafe { libc::fork() };
     if pid < 0 {

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -17,7 +17,11 @@ pub(super) fn init(globals: &mut Globals) {
     let object_class = globals.store.object_class();
     globals.define_class("Tms", object_class, klass);
     globals.define_builtin_module_func(klass, "pid", pid, 0);
-    globals.define_builtin_module_func(klass, "fork", process_fork, 0);
+    // Share Kernel#fork's implementation: it resets the green-thread
+    // scheduler in the child and maps an uncaught SystemExit /
+    // SignalException in the block to the right process exit, which the
+    // old Process-local copy did not.
+    globals.define_builtin_module_func(klass, "fork", crate::builtins::kernel::fork, 0);
     globals.define_builtin_module_func(klass, "times", times, 0);
     globals.define_builtin_module_func_with(klass, "clock_gettime", clock_gettime, 1, 2, false);
     globals.define_builtin_module_func_with(klass, "exit!", process_exit_bang, 0, 1, false);
@@ -288,41 +292,6 @@ fn process_setrlimit(
         ));
     }
     Ok(Value::nil())
-}
-
-///
-/// ### Process.#fork
-///
-/// - fork -> Integer | nil
-/// - fork { ... } -> Integer | nil
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Process/m/fork.html]
-#[monoruby_builtin]
-fn process_fork(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    // SAFETY: fork() is a POSIX system call. We call it in a single-threaded context.
-    let pid = unsafe { libc::fork() };
-    if pid < 0 {
-        return Err(MonorubyErr::runtimeerr("fork failed"));
-    }
-    if pid == 0 {
-        // Child process
-        if let Some(bh) = lfp.block() {
-            let data = vm.get_block_data(globals, bh)?;
-            match vm.invoke_block(globals, &data, &[]) {
-                Ok(_) => std::process::exit(0),
-                Err(_) => std::process::exit(1),
-            }
-        }
-        Ok(Value::nil())
-    } else {
-        // Parent process
-        Ok(Value::integer(pid as i64))
-    }
 }
 
 ///
@@ -1629,6 +1598,23 @@ mod tests {
         // an ArgumentError, not an abort.
         run_test_error(r#"Process.exec("ls\0", "-la")"#);
         run_test_error(r#"Process.exec("ls", "-l\0a")"#);
+    }
+
+    /// Boolean exec options must be validated *before* the exec — a bad
+    /// value has to raise ArgumentError in-process instead of replacing
+    /// the caller with the exec'd command. (The ruby/spec
+    /// "Process.exec options validation" examples exec `true`
+    /// in-process; without the early raise the whole test runner is
+    /// silently replaced, which is exactly how the rubyspec-stats CI's
+    /// core stats.yml ended up empty.)
+    #[test]
+    fn process_exec_option_validation() {
+        run_tests(&[
+            r#"begin; Process.exec("true", unsetenv_others: 1); rescue ArgumentError => e; e.message; end"#,
+            r#"begin; Process.exec("true", unsetenv_others: "true"); rescue ArgumentError => e; e.message; end"#,
+            r#"begin; Process.exec("true", close_others: 1); rescue ArgumentError => e; e.message; end"#,
+            r#"begin; exec("true", close_others: "x"); rescue ArgumentError => e; e.message; end"#,
+        ]);
     }
 
     /// `Process.exec`/`abort`/`exit` are also reachable as Module


### PR DESCRIPTION
## Summary

Fixes the rubyspec-stats CI's core step producing an **empty `stats.yml`** (the published site showed monoruby's Core column as 0 passing).

## Root cause

`Kernel#exec` / `Process.exec` silently discarded the options hash and exec'd anyway. ruby/spec's recently added **"Process.exec options validation"** examples call

```ruby
Process.exec("true", unsetenv_others: 1)
```

**in-process**, counting on CRuby's up-front `ArgumentError`. Without the early raise, the whole mspec runner was replaced by `/bin/true`, which explains every symptom of the CI failure:

- exit code **0** (that's `/bin/true`'s status — no error annotation in GHA)
- ~58s wall time that looks like a normal completion (the killer spec sits late in `core/process`)
- an **empty `stats.yml`** — mspec's `YamlFormatter` truncates the output file at startup and only writes in `finish`, which was never reached
- the last visible log lines being the `map_fd.rb` / `rubyexe.rb` fixture noise from the immediately preceding `Process.exec` examples

The failure never reproduced with `core/process` alone on older ruby/spec checkouts because the "options validation" describe block is a recent upstream addition; the stats CI clones ruby/spec fresh.

(The originally suspected `Thread.new { Process.exit }` / SystemExit-propagation path was investigated first and is **not** the culprit — the forwarding works and the exit specs pass as-is, so no tags are needed.)

## Changes

- **`Kernel#exec` / `Process.exec`**: validate the boolean options (`unsetenv_others`, `close_others`) *before* the exec and raise `ArgumentError: expected true or false as <name>: <value>` with CRuby's exact message.
- **`Process.fork`**: fold the Process-local copy into `Kernel#fork`'s implementation. The copy did not reset the green-thread scheduler in the child, did not map an uncaught `SystemExit` / `SignalException` in the block to the right process exit, and its blockless child inherited the parent's scheduler state wholesale.
- New pinning test `process_exec_option_validation` (compares messages against CRuby, raising before any exec happens).

## Verification

- Minimal repro now raises and survives, with a CRuby-identical message
- **`mspec ci --timeout 60 --format yaml` over the whole of `core` (fresh ruby/spec master + this repo's spec/tags) runs to completion with a populated 404 KB `stats.yml`** — `examples: 22932, expectations: 102199, failures: 498, errors: 494` — where it previously died silently at "Process.exec options validation" with a 0-byte file
- `core/process/exec_spec.rb` runs all 24 examples to completion
- Unit tests: `builtins::process` (44) and `builtins::kernel` fork/exec/system/spawn (167) all green

After merging, a `workflow_dispatch` of rubyspec-stats' `ci.yml` should populate `monoruby/core.yml` with real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_