### PR TITLE
Signals: carry the scheduler-entry depth across context switches (fixes #1071)

### DIFF
--- a/doc/signal.md
+++ b/doc/signal.md
@@ -125,6 +125,31 @@ ret
 `execute_gc` は**ハンドラ呼び出し中に CODEGEN 借用を保持しない**ので、trap ハンドラが
 その内部で JIT コンパイルや GC を起こしても自由に再入できる。
 
+### 4.1 配送ゲート(`scheduler::signal_delivery_ok`)
+
+すべての poll 地点で配送してよいわけではない。3 条件を満たす poll だけが drain する:
+
+1. **メインのグリーンスレッド上**であること(`current == main`)。CRuby と同じく、
+   非メインスレッド実行中に届いたシグナルはメインの次の poll まで保留される。
+2. スケジューラ自身の**機構(`machinery`)が走っていない**こと。
+3. スケジューラの**入口(`pass` / `sleep` / `join` / `terminate_all`)の中でない**こと。
+   これらの内側ではコンテキストが既にスイッチ用に保存されている(あるいは直後に
+   保存される)場合があり、その上に積んだ Ruby フレームは保存コンテキストの復帰時に
+   **もう一度**実行されてしまう。
+
+3 番目は `SCHED_CALL_DEPTH`(RAII ガード `SchedCall`)で数える。**この深度は
+コンテキストスイッチと一緒に持ち回らなければならない** — カウンタは OS スレッドの
+thread-local だが、ガードは各グリーンスレッドのスタック上にあり、park した
+スレッドは Rust フレームごと凍結されるのでガードが解放されないまま残る。
+`dispatch` は `machinery` と同じ区間で深度を退避・復元し、park 中の深度は
+`ThreadInner::sched_call_depth` に置く。
+
+> これを怠ると、`sleep` で park したスレッドが 1 本あるだけでカウンタが恒久的に
+> 1 以上に張り付き、以後 `Signal.trap` ハンドラが**二度と走らなくなる**。
+> `nil until flag` は無限に回り、次のブロッキング書き込みが内部マーカー
+> `__monoruby_signal_interrupt__`(§ マーカー)を RuntimeError として表に出す。
+> 回帰テスト: `process.rs` の `signal_delivered_while_another_thread_is_parked`。
+
 ---
 
 ## 5. signo → 既定例外(A4;`signo_to_error`)

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -2748,6 +2748,50 @@ mod new_api_tests {
     }
 
     #[test]
+    fn signal_delivered_while_another_thread_is_parked() {
+        // A trap handler on MAIN must still run while a second thread sits
+        // parked inside `sleep`. `sleep`/`pass`/`join` bump the
+        // scheduler-entry depth that gates signal delivery, and a parked
+        // thread keeps that guard alive on its own frozen stack — so the
+        // depth has to travel with the context switch. When it did not,
+        // one sleeping thread pinned the count above zero and no
+        // `Signal.trap` handler ever ran again: `nil until f` spun
+        // forever, and the next blocking write surfaced the internal
+        // `__monoruby_signal_interrupt__` marker as a RuntimeError.
+        //
+        // Forked, like the two tests above, so a starvation regression
+        // fails by timeout instead of wedging the harness.
+        run_test_once(
+            r#"
+            r, w = IO.pipe
+            pid = fork do
+              r.close
+              f = nil
+              Signal.trap(:TERM) { f = 1 }
+              Thread.new { sleep }          # parked, never joined
+              Process.kill(:TERM, Process.pid)
+              nil until f
+              w.write("handler-ran")        # must not raise
+              w.close
+              exit
+            end
+            w.close
+            got = nil
+            100.times do
+              break if (got = r.read_nonblock(64, exception: false)) && got != :wait_readable
+              sleep 0.1
+            end
+            if got.nil? || got == :wait_readable
+              Process.kill(:KILL, pid) rescue nil
+              got = "starved"
+            end
+            Process.wait(pid)
+            [got, $?.exitstatus]
+            "#,
+        );
+    }
+
+    #[test]
     fn process_kill_group_signal_forms() {
         // Signal-name parsing for the group forms ("-TERM", negative
         // Integer) plus the non-Int/String rejection. The actual group

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -176,10 +176,20 @@ pub(crate) fn mark(alloc: &mut crate::alloc::Allocator<RValue>) {
 
 thread_local! {
     /// Nesting depth of scheduler entry points (`pass`, `sleep`, `join`,
-    /// `terminate_all`) on the current stack. Signal trap handlers must
-    /// not run at poll points inside these: the running context may
-    /// already be saved for a switch, and Ruby frames pushed on top of a
-    /// saved context are resumed AGAIN when it is restored.
+    /// `terminate_all`) on the CURRENTLY RUNNING green thread's stack.
+    /// Signal trap handlers must not run at poll points inside these: the
+    /// running context may already be saved for a switch, and Ruby frames
+    /// pushed on top of a saved context are resumed AGAIN when it is
+    /// restored.
+    ///
+    /// The counter lives on the OS thread but the guards live on green
+    /// thread stacks, which park with their Rust frames — and therefore
+    /// their guards — frozen. So it must be swapped for the resumed
+    /// thread's own saved depth across every context switch
+    /// (`swap_sched_call_depth`, bracketed in `dispatch` alongside
+    /// `machinery`). Without that swap a thread parked inside `sleep`
+    /// leaves the count permanently ≥ 1, and `signal_delivery_ok` below
+    /// never lets a `Signal.trap` handler run again.
     static SCHED_CALL_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
@@ -195,6 +205,12 @@ impl Drop for SchedCall {
     fn drop(&mut self) {
         SCHED_CALL_DEPTH.with(|d| d.set(d.get() - 1));
     }
+}
+
+/// Install `depth` as the running context's scheduler-entry depth and
+/// return the previous value. See `SCHED_CALL_DEPTH`.
+fn swap_sched_call_depth(depth: u32) -> u32 {
+    SCHED_CALL_DEPTH.with(|d| d.replace(depth))
 }
 
 /// Whether a poll point may run signal trap handlers here: only on the
@@ -1330,6 +1346,20 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
     // control is inside the resumed thread, `machinery` is cleared so
     // timeslice preemption can fire in its Ruby code; it is restored the
     // moment control returns to this (scheduler) context.
+    //
+    // `SCHED_CALL_DEPTH` is swapped over the same span. It counts the
+    // scheduler entry points on the RUNNING stack, and a parked thread
+    // keeps its guards alive on its own frozen stack, so the counter has
+    // to follow the switch: the resumed thread gets the depth it parked
+    // with (0 for one starting its body), and on the way back the
+    // scheduler context's own depth is restored. Leaving the counter
+    // alone would let one thread parked inside `sleep` pin it above zero
+    // for good, and `signal_delivery_ok` would refuse every trap handler
+    // from then on.
+    let saved_depth = swap_sched_call_depth(match &entry {
+        Entry::Invoke(..) => 0,
+        _ => thread.as_thread_inner().sched_call_depth,
+    });
     let ret = match entry {
         Entry::Invoke(proc_data, args, len, handle) => {
             let invoker = CODEGEN.with(|c| c.borrow().thread_invoker);
@@ -1363,6 +1393,7 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
             ret
         }
         Entry::Skip(err) => {
+            swap_sched_call_depth(saved_depth);
             finalize_unstarted(globals, thread, err);
             SCHEDULER.with(|s| {
                 let mut s = s.borrow_mut();
@@ -1372,6 +1403,7 @@ fn dispatch(globals: &mut Globals, mut thread: Value) -> Result<()> {
         }
     };
     // Control is back in the scheduler context.
+    thread.as_thread_inner_mut().sched_call_depth = swap_sched_call_depth(saved_depth);
     if thread.as_thread_inner().body_terminated() {
         finalize(globals, thread, ret);
     }

--- a/monoruby/src/value/rvalue/thread.rs
+++ b/monoruby/src/value/rvalue/thread.rs
@@ -97,6 +97,12 @@ pub struct ThreadInner {
     /// last child status per thread, so a fresh thread sees `nil` until
     /// it reaps a child of its own.
     pub(crate) last_status: Option<Value>,
+    /// This thread's own `SCHED_CALL_DEPTH` while it is not running.
+    /// The counter is a thread-local on the OS thread, but its RAII
+    /// guards sit on this green thread's stack and stay alive across a
+    /// park, so the scheduler swaps the counter through here at every
+    /// context switch. See `scheduler::SCHED_CALL_DEPTH`.
+    pub(crate) sched_call_depth: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -188,6 +194,7 @@ impl ThreadInner {
             park_blocking: false,
             park_permit: false,
             last_status: None,
+            sched_call_depth: 0,
         }
     }
 
@@ -220,6 +227,7 @@ impl ThreadInner {
             park_blocking: false,
             park_permit: false,
             last_status: None,
+            sched_call_depth: 0,
         }
     }
 
@@ -244,6 +252,7 @@ impl ThreadInner {
             park_blocking: false,
             park_permit: false,
             last_status: None,
+            sched_call_depth: 0,
         }
     }
 


### PR DESCRIPTION
Fixes #1071.

#1070 gated signal delivery on `SCHED_CALL_DEPTH`, a count of the scheduler
entry points (`pass` / `sleep` / `join` / `terminate_all`) on the stack, so a
trap handler never runs over a context that is about to be — or already is —
saved for a switch. The count was right; where it lived was not.

The counter is a thread-local on the OS thread, but its RAII guards sit on
**green thread stacks**, and a parked green thread keeps its Rust frames —
guards included — frozen until it resumes. One thread sleeping was therefore
enough to pin the count at 1 permanently, and from that moment
`signal_delivery_ok` refused every poll point: no `Signal.trap` handler ran
again for the life of the process.

```ruby
Thread.new { loop { sleep 0.05; Thread.pass } }   # any second thread
done = false
Signal.trap(:HUP) { done = true }
Process.kill :HUP, Process.pid
Thread.pass until done
STDOUT.puts "OK"
```

```
$ ruby t5.rb                           OK
$ monoruby t5.rb        (b6993516)     t5.rb:7:in '<main>': __monoruby_signal_interrupt__ (RuntimeError)
$ monoruby t5.rb        (beb556ae)     OK
$ monoruby t5.rb        (this branch)  OK
```

`nil until flag` spins without end, and the next blocking write surfaces the
internal `__monoruby_signal_interrupt__` marker to Ruby as a `RuntimeError` —
precisely the leak `globals/error.rs` names it to make unmistakable. Confirmed
deterministic, 5/5 runs per binary; dropping the `Thread.new` line makes every
build pass, so the second thread is the whole difference.

Diagnosed by instrumenting `signal_delivery_ok`: `depth=1 machinery=false
on_main=true`, 2.34M times. The depth was the only blocker.

## Fix

Make the depth per green thread. `dispatch` swaps it over the same span it
toggles `machinery`: the resumed thread gets the depth it parked with (0 when
starting a body), and the scheduler context's own depth comes back on the way
out. `ThreadInner::sched_call_depth` holds it while parked.

## ruby/spec

Three files went from passing to hanging under #1070 and pass again here:

| Spec file | `beb556ae` | `b6993516` | this branch |
|---|---|---|---|
| `core/exception/interrupt_spec.rb` | 5 examples | hangs | 5 examples, 0 failures |
| `core/exception/signal_exception_spec.rb` | 16 examples | hangs | 16 examples, 0 failures |
| `core/signal/trap_spec.rb` | 42 examples | hangs | 42 examples, 0 failures |

They hang only with mspec's `--timeout` watchdog running, because the watchdog
*is* the second thread:

```
$ mspec run              --target monoruby core/signal/trap_spec.rb   42 examples, 1s
$ mspec run --timeout 60 --target monoruby core/signal/trap_spec.rb   killed at 55s
```

`core/process/kill_spec.rb` passes 17/17 throughout — #1070 dropping its stale
`fails:` tags was correct and unrelated.

## Why this repo's dashboard never showed it

`spec-core.yml` runs core in 10-file batches under a 60s deadline and re-runs a
killed batch file by file, so a hang costs a few files and the total stays near
97%. [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/) runs the
whole group in **one** process under `timeout -k 5 1200`, where the hang ate the
budget and `stats.yml` was never written — `--- {}`, rendered as **0.0% Core
Library**.

Reproduced and re-measured locally with that exact invocation:

| | before | after |
|---|---|---|
| whole-core `mspec ci`, single process | killed at 1200s, no `stats.yml` | finishes in **339s** |
| reported | `--- {}` → 0.0% | 22874 examples, 347 failures, 219 errors → **97.53%** |

No change is needed on the rubyspec-stats side; the next scheduled run picks
this up.

## Testing

- `cargo test` — all 59 test binaries green.
- New regression test
  `builtins::process::…::signal_delivered_while_another_thread_is_parked`:
  a second thread parked in `sleep` (never joined) must not stop a trap handler
  on main. It forks, like the two `process_kill_from_thread_*` tests beside it,
  so a starvation regression fails by timeout instead of wedging the harness.
  Verified both directions — it reproduces the wedge on the parent commit
  (`"starved" != "handler-ran"`) and passes here.
- `doc/signal.md` gains §4.1 recording the three delivery-gate conditions, why
  the depth must travel with the context switch, and what breaks when it does
  not.

One unrelated flake to note honestly: a `cargo test` run hung once in the
fork-based process tests. It did not reproduce — two `--lib` runs and a full run
afterwards were clean — and it is not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_