### PR TITLE
Safepoint poll rework: one process-global word, four byte lanes, zero-test poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ monoruby/                   # Workspace root
 │   │   │   └── prism_backend.rs # Drives the `ruby-prism` crate
 │   │   ├── ast/            # monoruby AST (node, lvar_collector, source_info, error)
 │   │   ├── alloc.rs        # Custom GC allocator (mark-and-sweep)
+│   │   ├── poll_flag.rs    # Safepoint poll word (GC/preempt/signal byte lanes)
 │   │   ├── id_table.rs     # Interned identifier table (IdentId)
 │   │   ├── value.rs        # Value type (tagged-union, 64-bit, NonZeroU64)
 │   │   ├── value/

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -74,7 +74,7 @@ thread_local! { pub static ALLOC: RefCell<Allocator<RValue>> }   // alloc.rs
 | `promoting` | マーク中に昇格候補を収集するか(実マーク中のみ true) |
 | `aging` | 今サイクルで生存した昇格候補(マーク後に加齢) |
 | `remembered` | remembered set(old→young 参照を持つ old オブジェクト) |
-| `alloc_flag` | GC 起動フラグ(`u32`)のアドレス |
+| `pages_since_gc` | 前回の収集以降に `THRESHOLD` まで充填したページ数(8 で GC レーンを立てる) |
 | `heap_frames` | ヒープに退避したフレームバッファの登録表(§9) |
 
 ### 2.2 アリーナとページ
@@ -84,7 +84,7 @@ const SIZE: usize        = 64;
 const GCBOX_SIZE: usize  = size_of::<RValue>();          // 64
 const PAGE_LEN: usize    = 64 * SIZE;                     // 4096 セル/ページ
 const DATA_LEN: usize    = 64 * (SIZE - 1);               // 4032 データセル
-const THRESHOLD: usize   = 64 * (SIZE - 2);               // 3968(alloc_flag を立てる位置)
+const THRESHOLD: usize   = 64 * (SIZE - 2);               // 3968(ページ圧力を数える位置)
 const ALLOC_SIZE: usize  = PAGE_LEN * GCBOX_SIZE;         // 262144 = 256KB
 const MAX_PAGES: usize   = 8192;
 ```
@@ -119,8 +119,8 @@ mark-external 方式なので、生存中のオブジェクト内容を汚さな
 1. **フリーリスト**が空でなければそこから 1 セル pop(`self.free`)。直前の GC で
    スイープされたセルの再利用。
 2. 空でなければ**現ページのバンプ割り当て**。
-   - `used_in_current == THRESHOLD`(3968)に達したら `set_alloc_flag()` で
-     `alloc_flag += 1`(GC を要求;§4)。
+   - `used_in_current == THRESHOLD`(3968)に達したら `on_page_pressure()` で
+     `pages_since_gc += 1`、8 ページ目で poll ワードの GC レーンを立てる(GC を要求;§4)。
    - `used_in_current == DATA_LEN`(4032)でページ満杯 → `free_pages` から再利用、
      なければ `new_page()` で新規ページ。新ページは `clear_old_bits()` で
      old ビットマップを 0 初期化(マイナー GC のシード整合性のため)。
@@ -144,37 +144,32 @@ GC は「アロケーションの延長で即実行」はしない。JIT の生�
 まま GC ルート走査に入るのは危険なため、**フラグを立てて次のセーフポイントで
 実行**する。
 
-### 4.1 起動フラグ `alloc_flag`(`u32`)
+### 4.1 poll ワードの GC レーン(`poll_flag.rs`)
 
-VM/JIT が参照する単一の `u32`。**8 以上(ベース値)でトリガ帯**。これを立てる経路:
+VM/JIT が参照する poll ワード(`u32`、8bit×4 レーン。全体像は `doc/safepoint.md` §3)の
+**byte 0 が GC レーン**。これを立てる経路:
 
-| 経路 | 実装 | フラグ操作 |
+| 経路 | 実装 | 操作 |
 | --- | --- | --- |
-| ページ充填 | `set_alloc_flag`(`alloc.rs:681`) | ほぼ満杯ページごとに `+= 1`(約 8 ページで 8 に到達) |
-| malloc 圧(§8) | `request_gc_if_malloc_over`(`alloc.rs:123`) | 8 未満なら `8` を書く |
-| `GC.start` | `request_gc(true)`(`alloc.rs:84`) | 8 未満なら `8` を書く + メジャー強制 |
-| シグナル配送 | シグナルハンドラ(`jit_module.rs`) | `+= 10`(`doc/signal.md`) |
-| プリエンプト tick | タイマ OS スレッド(`preempt.rs`) | `\|= 1 << 30`(`PREEMPT_BIT`;`doc/threads.md` §8) |
+| ページ圧力 | `on_page_pressure`(`alloc.rs`) | `pages_since_gc` が 8 に達したら `set_gc()` |
+| malloc 圧(§8) | `request_gc_if_malloc_over` | `set_gc()` |
+| `GC.start` | `request_gc(true)` | `set_gc()` + メジャー強制 |
+| `GC.stress` | `set_stress(true)` / 各収集の末尾 | `set_gc()`(再武装) |
 
-「8 未満のときだけ 8 を書く」ことで、ページ充填の累積値やシグナルの `+10` を
-踏み潰さず、ちょうど 1 回の収集を要求する。
-
-> **この `u32` はプリエンプションの poll フラグと同一の語**である(`doc/threads.md` §8)。
-> タイマ OS スレッドが上位ビット `PREEMPT_BIT`(= `1 << 30`。ビット 31 でないのは
-> x86-64 poll `cmpl …; jge` が**符号付き**比較で、ビット 31 だと負値に読めて発火しないため)を
-> 立てる。別スレッドから書くのでフラグアクセスはすべてアトミックになった。GC 判定は
-> **ベース値**(プリエンプトビットを剥がした値)が `>= 8` かどうかで行うので、純粋な
-> プリエンプト tick が偽の full GC を起こすことはない(§4.3 手順 2)。GC 完了後の
-> `unset_alloc_flag`(`alloc.rs:694`)は `fetch_and(PREEMPT_BIT)` でベース帯だけ落とし、
-> 並行して立ったプリエンプトビットは保存する。
+すべて冪等な `fetch_or` で、シグナル(SIGNAL レーン)・プリエンプト(PREEMPT レーン)とは
+byte が分かれているため互いを踏み潰す競合は原理的にない。GC 判定は GC レーン単体で行うので、
+純粋なプリエンプト tick やシグナル到着が偽の full GC を起こすことはない(§4.3 手順 2)。
+収集の完了時は `ack_gc_request`(`alloc.rs`)が **GC レーンの byte だけ**を落とし、
+`pages_since_gc` を 0 に戻す(並行して立った他レーンは保存される)。`--no-gc` 時の
+空収集も同じ経路で要求を無効化するため、レーンが立ちっぱなしで poll が空回りすることはない。
 
 ### 4.2 poll のコード生成
 
 `execute_gc_inner`(`codegen/arch/x86_64/jit_module.rs:255`)が poll を出力:
 
 ```asm
-cmpl [rip + alloc_flag], 8
-jge  gc          ; フラグ >= 8 なら収集パスへ
+cmpl [rip + poll_flag], 0
+jne  gc          ; いずれかのレーンが立っていれば slow path へ
 exit:
 ; gc: (別ページ)
 ;   write_back(生きたレジスタを退避)
@@ -187,21 +182,23 @@ exit:
 この poll は**呼び出し先エントリ(callee entry)とループのバックエッジ**という
 セーフポイントで実行される(`vm_execute_gc`;`vmgen/init_method.rs` / `vm_loop_start` ほか。
 call-site には poll を置かない — `doc/threads.md` §8.3)。aarch64 backend も
-同等のフラグ比較を出力する。
+同等のゼロ判定(`ldr; cbz`)を出力する。
 
 ### 4.3 `execute_gc`(`executor.rs:3743`)
 
 セーフポイントから呼ばれる `extern "C"` 関数。順に:
 
 1. `watchdog::poll()` — ハングウォッチドッグのカウントダウンをリセット。
-2. `preempt::consume_poll_flag()` で**プリエンプトビットを剥がし**、`(ベース値, プリエンプトか)`
-   を得る(§4.1 の注)。以降の GC 判定はベース値で行う。
-3. **保留シグナルの処理** — `pending_signals` ビットマップを drain し、最小番号の
-   シグナルを `Signal.trap` ハンドラ呼び出し / 既定例外(SIGINT ⇒ `Interrupt` 等)に
-   変換(`doc/signal.md`)。
-4. **ベース値が `>= 8` のときだけ** GC 本体を実行:`parent_fiber` を辿って
+2. `poll_flag::consume_preempt()` で **PREEMPT レーンを消費**する。GC 判定は GC レーンで
+   独立に行う(§4.1)。
+3. **保留シグナルの処理** — SIGNAL レーンをクリアしてから `PENDING_SIGNALS` ビットマップを
+   drain し、最小番号のシグナルを `Signal.trap` ハンドラ呼び出し / 既定例外(SIGINT ⇒
+   `Interrupt` 等)に変換(`doc/signal.md`)。
+4. **GC レーンが立っているときだけ** GC 本体を実行:`parent_fiber` を辿って
    **ルート Executor(最上位ファイバ)**へ行き、
    `ALLOC.with(|a| a.borrow_mut().gc(&Root { globals, executor }))`。
+   drain できなかった保留シグナルがある poll では収集を次の poll へ延期する
+   (`doc/signal.md` §4.1)。
 5. プリエンプトビットが立っていて `scheduler::preempt_ok()` なら `scheduler::pass`
    (タイムスライス切替。`doc/threads.md` §8.4)。
 
@@ -482,8 +479,8 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
   無視すると閾値が GB 級に張り付き、通常の String/Array/Hash 成長で永遠に GC が
   発火しなくなる。同じ判定で `dealloc` も gate するので `MALLOC_AMOUNT` は
   アンダーフローしない。
-- `request_gc_if_malloc_over`(`alloc.rs:123`)が `MALLOC_AMOUNT >= MALLOC_GC_THRESHOLD`
-  で `alloc_flag` を 8 に持ち上げる(GC 要求;割り当てフリーで安全)。
+- `request_gc_if_malloc_over`(`alloc.rs`)が `MALLOC_AMOUNT >= MALLOC_GC_THRESHOLD`
+  で poll ワードの GC レーンを立てる(GC 要求;割り当てフリーで安全)。
 - 閾値 `MALLOC_GC_THRESHOLD` は各 GC 後に
   `malloced + max(malloced/2, MALLOC_THRESHOLD)` へ再設定(`alloc.rs:986`)。
   加算のみだと巨大ヒープでも 256KB ごとに GC してしまうので、乗算項で比例させる。
@@ -536,10 +533,10 @@ stderr へ出力して abort する(`alloc.rs` の `malloc_hard_limit`)。OOM �
 - monoruby の GC は **非移動・単一スレッド・stop-the-world の世代別 mark & sweep**。
 - 256KB ページ + マーク/old の 2 枚のビットマップ(mark-external)で、非移動と
   世代別を両立。ページはアドレスマスクで O(1) 逆引き。
-- 割り当てはフリーリスト → バンプ。閾値到達で `alloc_flag` を立て、**次のセーフ
-  ポイント**で `execute_gc` が同期収集する(JIT レジスタ退避のため即実行はしない)。
+- 割り当てはフリーリスト → バンプ。ページ圧力の閾値到達で poll ワードの GC レーンを立て、
+  **次のセーフポイント**で `execute_gc` が同期収集する(JIT レジスタ退避のため即実行はしない)。
 - 世代別の心臓部は、**3 回生存で昇格(aging)**・**適応的メジャー閾値**・
   **1 ビット高速パスの書き込みバリア + remembered set(自己クリーニング付き)**。
   マイナーは old をシードマークして young + old→young 辺だけを辿る。
-- 外部 malloc 圧・シグナル・`GC.start` も同じ `alloc_flag` 経由で同一のセーフ
-  ポイント収集に集約される。
+- 外部 malloc 圧・シグナル・`GC.start` も同じ poll ワード経由で同一のセーフ
+  ポイント収集に集約される(レーン分割は `poll_flag.rs` / `doc/safepoint.md` §3)。

--- a/doc/safepoint.md
+++ b/doc/safepoint.md
@@ -12,7 +12,7 @@ GC(`doc/gc.md`)・タイムスライスプリエンプション(`doc/threads.md`
 | poll のコード生成(x86-64) | `codegen/arch/x86_64/jit_module.rs`(`execute_gc_inner`) / `vmgen/init_method.rs`(`vm_init`) / `vmgen.rs`(`vm_loop_start`) |
 | poll のコード生成(aarch64) | `codegen/arch/aarch64/codegen.rs`(`a64_vm_execute_gc`) / `vmgen.rs` |
 | セーフポイント本体 | `executor.rs`(`execute_gc`) |
-| poll フラグ | `alloc.rs`(`alloc_flag` / `set_alloc_flag` / `unset_alloc_flag`) / `preempt.rs`(`PREEMPT_BIT` / `consume_poll_flag`) |
+| poll ワード | `poll_flag.rs`(レーン定義・set/clear/consume) / `alloc.rs`(ページ圧力・`ack_gc_request`) / `preempt.rs`(タイマ) |
 | JIT tier の poll IR | `codegen/jitgen/asmir.rs`(`AsmInst::ExecGc`) / `codegen/jitgen/compile.rs` |
 
 ---
@@ -20,7 +20,7 @@ GC(`doc/gc.md`)・タイムスライスプリエンプション(`doc/threads.md`
 ## 1. セーフポイントとは何か
 
 セーフポイントとは、実行中のインタプリタが**フレームを完全に整合した(GC-complete な)状態
-にしたうえで poll フラグを検査する**地点である。フラグがトリガ帯に立っていれば、その場で
+にしたうえで poll ワードを検査する**地点である。いずれかのレーンが立っていれば、その場で
 `execute_gc`(`executor.rs`)を呼び、以下のいずれか(または複数)を行う:
 
 - **GC**: マーク&スイープ(`doc/gc.md`)。
@@ -54,24 +54,25 @@ GC(`doc/gc.md`)・タイムスライスプリエンプション(`doc/threads.md`
 
 ---
 
-## 3. poll フラグ `alloc_flag`(`u32`)
+## 3. poll ワード(`poll_flag.rs`、`u32`)
 
-VM/JIT が参照する単一の `u32`。3 イベントすべてがこの 1 語を共有する。**ベース値(下位)が
-8 以上でトリガ帯**、上位ビット `PREEMPT_BIT` がプリエンプト要求。
+VM/JIT が参照する単一の `u32`。3 イベントすべてがこの 1 語を共有し、**8bit×4 のレーン**に
+分割される。poll は**ワード全体のゼロ判定 1 個**(非ゼロ = いずれかのレーンが立っている)。
 
-| 書き手 | 操作 | 意味 |
-| --- | --- | --- |
-| ページ充填 | `set_alloc_flag`:`+= 1` | ほぼ満杯ページごと(約 8 ページで 8 に到達)→ GC |
-| malloc 圧 / `GC.start` | `>= 8` 帯へ持ち上げ | 外部バッファ圧・明示 GC → GC |
-| シグナルハンドラ | `+= 10` | 保留シグナル配送 |
-| プリエンプトタイマ | `\|= 1 << 30`(`PREEMPT_BIT`) | タイムスライス切替 |
+| byte | レーン | 立てる側 | 落とす側 |
+| --- | --- | --- | --- |
+| 0 | GC | ページ圧力(8 ページで `set_gc`)/ malloc 圧 / `GC.start` / `GC.stress` 再武装 | 収集完了(`ack_gc_request`。`--no-gc` の空収集も同様) |
+| 1 | PREEMPT | プリエンプトタイマ(別 OS スレッド)/ stress 再武装 | poll 入口の `consume_preempt` |
+| 2 | SIGNAL | シグナルハンドラ(async-signal 文脈) | ビットマップを drain した poll(main 配送時) |
+| 3 | 予備 | — | — |
 
-- **ビット 30** であってビット 31 ではない: x86-64 poll は `cmpl …; jge`(符号付き比較)なので、
-  ビット 31 だと負値に読めて発火しない。
-- タイマは別 OS スレッドから書くので、フラグアクセスはすべてアトミック。GC 後の
-  `unset_alloc_flag` は `fetch_and(PREEMPT_BIT)` でベース帯だけ落とし、並行して立った
-  プリエンプトビットは保存する。
-- 詳細な相互作用は `doc/gc.md` §4.1、`doc/threads.md` §8.2 を参照。
+- 全書き込みは**冪等なアトミック演算**(`fetch_or` で set、`fetch_and` で自レーンの byte のみ
+  clear)。別スレッド・async-signal 文脈からの書き込みが互いのレーンを失わせることはない。
+- ページ圧力の「8 ページ」カウンタはアロケータ内部(`pages_since_gc`)にあり、poll ワード自体は
+  算術を持たない(旧設計はページ充填 `+=1`・シグナル `+=10`・`>= 8` トリガ帯を 1 語に重畳し、
+  符号付き比較の都合で PREEMPT がビット 30 に制限されていた)。
+- 詳細な相互作用は `poll_flag.rs` のモジュールドキュメント、`doc/gc.md` §4.1、
+  `doc/threads.md` §8.2 を参照。
 
 ---
 
@@ -120,8 +121,8 @@ native(非 Ruby)の callee には entry poll がないが、任意の非有界�
 `execute_gc_inner`(`jit_module.rs`)が出力する。ホットパスは 1 比較 + fall-through:
 
 ```asm
-    cmpl [rip + alloc_flag], 8
-    jge  gc          ; ベース値 >= 8(またはプリエンプトビット)なら収集パスへ
+    cmpl [rip + poll_flag], 0
+    jne  gc          ; いずれかのレーンが立っていれば slow path へ
 exit:
     ; --- 別ページ ---
 gc:
@@ -132,7 +133,7 @@ gc:
     jmp  error        ; None(=例外/シグナル/割り込み)なら伝播
 ```
 
-- **fall-through が最頻ケース**(フラグ未武装)で、収集本体は `select_page(1)` の別ページに
+- **fall-through が最頻ケース**(全レーン未武装)で、収集本体は `select_page(1)` の別ページに
   置いてホットパスの I-cache を汚さない。
 - `exec_gc` は `execute_gc` を呼ぶスタブ。戻り値 `Some` を `rax != 0`、`None` を `rax == 0` として
   分岐する。
@@ -142,10 +143,9 @@ gc:
 `a64_vm_execute_gc`(`codegen.rs`)が対称に出力する:
 
 ```asm
-    mov x10, alloc_flag_addr
+    mov x10, poll_flag_addr
     ldr w11, [x10]
-    cmp x11, #8
-    b.lt skip
+    cbz x11, skip
     bl  gc
 skip:
 ```
@@ -185,15 +185,17 @@ poll でフラグが立っていたら、収集本体に入る**前**に、レ�
 
 1. **`watchdog::poll()`** — poll 到達はインタプリタの進捗なので、ハングウォッチドッグの
    カウントダウンをリセット(`doc/signal.md`)。
-2. **`preempt::consume_poll_flag()`** — プリエンプトビットを剥がし `(ベース値, プリエンプトか)`
-   を得る。以降の GC 判定はベース値で行う(純プリエンプト tick で偽の full GC を起こさない)。
-   フラグ未登録なら防御的に `(8, false)`。
-3. **保留シグナルの drain** — `PENDING_SIGNALS` ビットマップを取り、最小番号のシグナルを
-   `Signal.trap` ハンドラ呼び出し / 既定例外(SIGINT ⇒ `Interrupt` 等)に変換。エラーを
-   立てて `None` を返しうる。
-4. **GC(ベース値 `>= 8` のときだけ)** — `parent_fiber` を辿ってルート Executor へ行き、
+2. **`poll_flag::consume_preempt()`** — PREEMPT レーンを消費する。GC 判定は GC レーンで
+   独立に行う(純プリエンプト tick で偽の full GC を起こさない)。ワード未登録なら
+   防御的に「GC 要求あり」とみなす。
+3. **保留シグナルの drain** — SIGNAL レーンをクリアしてから `PENDING_SIGNALS` ビットマップを
+   取り、最小番号のシグナルを `Signal.trap` ハンドラ呼び出し / 既定例外(SIGINT ⇒
+   `Interrupt` 等)に変換。エラーを立てて `None` を返しうる。配送が main にゲートされ
+   drain できない poll では SIGNAL レーンを残し(main の wakeup 維持)、GC も次の poll へ
+   延期する(`doc/signal.md` §4.1)。
+4. **GC(GC レーンが立っているときだけ)** — `parent_fiber` を辿ってルート Executor へ行き、
    `ALLOC.borrow_mut().gc(&Root { globals, executor })`。
-5. **`preempt::stress_renudge()`** — stress モードでは切替の**前に**フラグを再武装し、
+5. **`preempt::stress_renudge()`** — stress モードでは切替の**前に**レーンを再武装し、
    切替先スレッドも poll するようにする。
 6. **プリエンプション** — `preempt && scheduler::preempt_ok()` のとき `scheduler::pass`。
    `Err`(このスレッドへ配送された kill/raise)は `set_error` + `None` で浮上させる。

--- a/doc/signal.md
+++ b/doc/signal.md
@@ -29,16 +29,18 @@ monoruby の POSIX シグナル処理の**現行実装**を、コードに即し
 シグナルハンドラは async-signal 文脈で走るため、そこでは Rust のアロケータ・`RefCell`・
 libc 呼び出しに触れられない。そこで **2 段階**にする:
 
-1. **記録(async-signal 文脈)**: ハンドラスタブは、プロセスグローバルなビットマップに
-   自分のビットを OR し、poll フラグ(`alloc_flag`)を `+= 10` して即 `ret`。メモリの
-   ADD と OR だけで、Rust には一切入らない。
+1. **記録(async-signal 文脈)**: Rust ハンドラ(`signal_table::signal_handler`)が、
+   プロセスグローバルなビットマップに自分のビットを `fetch_or` し、poll ワード
+   (`poll_flag.rs`)の SIGNAL レーンを `fetch_or` して即 return。lock-free な
+   アトミック演算 2 つだけ(ロックなし・確保なし・TLS なし)。
 2. **配送(セーフポイント)**: 次に VM/JIT がセーフポイント(callee-entry / ループ
    バックエッジ、`doc/safepoint.md` §4)へ到達すると `execute_gc`(`executor.rs`)が
    ビットマップを drain し、最小番号のシグナルを Ruby 例外 / `Signal.trap` ハンドラ呼び出しに
    変換する。
 
-この構造により、シグナルは GC・プリエンプションと同一の `alloc_flag`・同一の poll・
-同一の `execute_gc` を共有する。`+= 10` はトリガ帯(`>= 8`)を確実に踏むためのナッジ。
+この構造により、シグナルは GC・プリエンプションと同一の poll ワード・同一の poll・
+同一の `execute_gc` を共有する。ワードは 8bit×4 のレーン(GC / PREEMPT / SIGNAL / 予備)に
+分割されており、poll はワード全体のゼロ判定 1 個(`poll_flag.rs` 参照)。
 
 ---
 
@@ -51,45 +53,47 @@ pub(crate) static PENDING_SIGNALS: AtomicU32 = AtomicU32::new(0);
 - **プロセスグローバル**な `AtomicU32`。ビット `n` = シグナル `n+1`(SIGINT=2 ⇒ bit1)。
 - プロセスグローバルにする理由: `sigaction` はプロセス全体に効くので、`Codegen` ごとに
   ビットマップを分けると、2 個目の `Codegen` がハンドラを自分のビットマップへ向け直した際に
-  シグナルを取りこぼす。1 枚のグローバルにすれば、記録側(スタブ)と drain 側が
+  シグナルを取りこぼす。1 枚のグローバルにすれば、記録側(ハンドラ)と drain 側が
   どの `Codegen` がインストールしたかによらず一致する。
-- `pending_signals_addr()` — スタブに焼き込む絶対アドレス。
 - `take_pending_signals()` — `swap(0, Relaxed)` でアトミックに drain。
 - `lowest_pending_signo(bitmap)` — `bitmap.trailing_zeros() + 1`。**最小番号の signo が優先**
   (§6)。1 回の drain で配送するのは 1 シグナルだけ。
 
-### ハンドラスタブ(A2 の一部;`signal_handler_for`)
+### Rust ハンドラ(A2;`signal_table::signal_handler`)
 
-x86-64(`jit_module.rs`)が出力する内容そのもの:
+`sa_handler` 形式で `sigaction(2)` される単一の `extern "C" fn(signo: i32)`:
 
-```asm
-addl [rip + alloc_flag], 10   ; 次の poll を必ず発火させる
-movq rax, (ps_addr)
-orl  [rax], (bit)             ; PENDING_SIGNALS に自分のビットを OR
-ret
+```rust
+pub(crate) extern "C" fn signal_handler(signo: i32) {
+    if (1..=32).contains(&signo) {
+        PENDING_SIGNALS.fetch_or(1 << (signo - 1) as u32, Ordering::Relaxed);
+    }
+    crate::poll_flag::set_signal_from_handler(); // SIGNAL レーンを fetch_or
+}
 ```
 
-- **Rust を呼ばない**。メモリの ADD と OR、そして `ret` のみ。`rax` はシグナルハンドラの
-  C ABI で caller-saved。
-- RMW は **LOCK 前置しない**(async-signal 文脈では `ldxr/stxr` 相当が使えない)。ネストした
-  シグナルで増分/ビットを稀に取りこぼしうるが無害(次の poll が拾う)。
-- aarch64(`jit_module.rs`)も対称。ただし alloc_flag のアドレス取得法が異なる
-  (x86 は rip 相対、aarch64 はラベルアドレス)。
+**async-signal-safe な理由**: 本体は lock-free な relaxed アトミック演算 2 つだけ。
+ロックなし・確保なし・TLS なし・libc 呼び出しなし。poll ワードのアドレスは
+`poll_flag.rs` のプロセスグローバルなレジストリ(`AtomicUsize`、最後に登録した
+`Codegen` が勝つ — `sigaction` のプロセスワイド性と対応)から取得する。
 
-**async-signal-safe な理由**: 静的に既知の絶対アドレスへのロード/ストアと `ret` だけ。
-ロックなし・確保なし・libc 呼び出しなし・再入 Rust なし。
+かつては signo ごとに JIT asm スタブ(`addl [alloc_flag], 10; orl [pending], bit`)を
+事前生成していたが、(1) lock なし RMW がプリエンプトタイマの `fetch_or` と競合して
+どちらかの更新を失いうる、(2) インストール元 `Codegen` の解放後にシグナルが来ると
+解放済み JIT メモリを実行する、という 2 つの欠陥があり、Rust ハンドラ+アトミック演算に
+置き換えた。
 
 ---
 
 ## 3. sigaction のインストール(A3)
 
-`codegen.rs` の `sigaction_to` / `install_signal_stub` がプロセスワイドに `libc::sigaction` する。
+`codegen.rs` の `sigaction_to` / `install_signal_handler` がプロセスワイドに `libc::sigaction` する。
 
 - **`SA_RESTART` を付けない**(`flags = 0`)。これは意図的(§8)。シグナルがブロッキング
   syscall を EINTR で中断させ、インタプリタを poll 地点へ到達させるため。
-- **スタブ事前生成(A2)**: `Codegen::new` 時に `TRAPPABLE_SIGNALS` 全てのスタブを
-  `signal_stubs: HashMap<i32, CodePtr>` に用意する。ゆえに実行時の trap は `sigaction(2)`
-  だけで済み、稼働中のバッファに JIT コード生成を行わない。
+- ハンドラは全 signo 共通の Rust 関数(§2)なので事前生成物はなく、実行時の trap は
+  `sigaction(2)` だけで済む(稼働中のバッファに JIT コード生成を行わない、という
+  旧スタブ方式の利点はそのまま)。`install_signal_handler` は `is_trappable` で守られる。
 - **デフォルトインストール**: 起動時に `POSIX_SIGNALS`(HUP, INT, QUIT, ALRM, TERM,
   USR1, USR2)へ自動で `sigaction`。CHLD/CONT/WINCH/TSTP や PIPE は既定では張らない。
   ウォッチドッグが armed のとき(§9)は SIGALRM をスキップしてハンドラを奪わない。
@@ -108,8 +112,10 @@ ret
 `execute_gc`(`executor.rs`)がセーフポイントで実行する処理のうち、シグナル部分:
 
 1. `watchdog::poll()`(§9)。
-2. `preempt::consume_poll_flag()` でプリエンプトビットを剥がす。
-3. **シグナル drain**: `take_pending_signals()` → `lowest_pending_signo()`。signo があれば
+2. `poll_flag::consume_preempt()` で PREEMPT レーンを消費する。
+3. **シグナル drain**: SIGNAL レーンをクリアしてから `take_pending_signals()` →
+   `lowest_pending_signo()`(クリア→drain の順序: 間に届いたシグナルはレーンとビットを
+   立て直すので余分な poll 1 回で済む。逆順はビットの arming を失いうる)。signo があれば
    `globals.signal_disposition(signo)` で分岐:
    - `Handler(handler)` → `arg = Value::integer(signo)`、`#call` を `invoke_method_inner` で
      呼ぶ。`Err` なら `set_error` + `return None`。
@@ -118,7 +124,7 @@ ret
      `set_error(err); return None`。マップ外は何もしない。
    - 同じ drain 窓に複数立っていても**最小 signo だけ**配送し、残りは捨てる
      (CRuby も coalesce したシグナルの全配送を保証しない)。
-4. GC 本体(ベース値 `>= 8` のとき)。
+4. GC 本体(GC レーンが立っているとき)。
 5. プリエンプション(`scheduler::pass`)。
 
 **シグナル配送は GC・プリエンプションより前**に同じ poll 内で行われる。
@@ -279,12 +285,13 @@ thread-local だが、ガードは各グリーンスレッドのスタック上�
 
 ## 9. スレッド / スケジューラとの関係
 
-- **どのスレッドが変換するか**: poll 地点(`execute_gc`)に到達したスレッド。シグナルは
-  main ではなく**ポーリングしたスレッド**で変換される(`doc/threads.md` §10 の既知の制限。
-  CRuby は main へ配送)。
-- poll フラグは GC の `alloc_flag` と同一の `u32`。書き手はページ充填 `+=1`、
-  **シグナルスタブ `+=10`**、malloc/`GC.start` の `>=8` 持ち上げ、プリエンプトタイマ
-  `|= 1<<30`(`doc/threads.md` §8.2 / `doc/gc.md` §4.1)。
+- **どのスレッドが変換するか**: main グリーンスレッド(§4.1 の配送ゲート、CRuby と同じ)。
+  非 main スレッドの poll ではビットマップと SIGNAL レーンが残り、main の次の poll が配送する。
+- poll ワードは GC・プリエンプションと共有の `u32` で、8bit×4 のレーンに分割
+  (`poll_flag.rs`)。書き手はアリーナのページ圧力 / malloc / `GC.start`(GC レーン)、
+  **シグナルハンドラ(SIGNAL レーン)**、プリエンプトタイマ(PREEMPT レーン)。
+  全書き込みは冪等なアトミック `fetch_or`/`fetch_and`(`doc/threads.md` §8.2 /
+  `doc/gc.md` §4.1)。
 - グリーンスレッドをまたぐブロッキング IO はスケジューラの fd ポーラで park する。
   シグナルによる EINTR が待機を起こし poll 地点を通すので、他スレッドが park していても
   シグナル応答性が保たれる。
@@ -305,12 +312,12 @@ thread-local だが、ガードは各グリーンスレッドのスタック上�
 
 ## 11. まとめ
 
-- シグナルは async-signal 文脈で**ビットを立てて `alloc_flag` をナッジするだけ**、実配送は
+- シグナルは async-signal 文脈で**ビットマップと SIGNAL レーンを立てるだけ**、実配送は
   次のセーフポイント(`doc/safepoint.md`)で `execute_gc` が行う遅延モデル。GC・
-  プリエンプションと poll・フラグ・入口関数を完全に共有する。
+  プリエンプションと poll・ワード・入口関数を完全に共有する。
 - ビットマップ・trap テーブルはプロセス/インタプリタ単位で、trap ハンドラは GC ルート。
 - `SA_RESTART` を意図的に外し、ブロッキング IO は `signal_interrupt` マーカー経由で
   EINTR を poll 地点へ運ぶ(SIGTERM 応答性の担保)。
-- 最小 signo 優先(A6)、SIGINT→`Interrupt`(A4)、`Signal.trap`(A7)、スタブ事前生成(A2)、
+- 最小 signo 優先(A6)、SIGINT→`Interrupt`(A4)、`Signal.trap`(A7)、共通 Rust ハンドラ(A2)、
   デフォルトインストール(A3)、ハングウォッチドッグ(B+)。
 - 捕捉されない SignalException は同じシグナルで自死し、親に正しいシグナル死を見せる。

--- a/doc/threads.md
+++ b/doc/threads.md
@@ -136,7 +136,7 @@ flushing_reports: flush_pending_reports の再入ラッチ
 ループのインスタンスは常に高々 1 つ)。
 
 `SCHED_RSP` は **OS スレッドごと**(`thread_local` の `Cell<u64>`)。各 OS スレッドの
-`Codegen` が自分のスロットのアドレスをスタブに焼き込む(alloc_flag と同じ構図)。
+`Codegen` が自分のスロットのアドレスをスタブに焼き込む(poll ワードと同じ構図)。
 テストハーネスのように複数のインタプリタが別 OS スレッドで並走しても衝突しない。
 
 ### 3.2 コンテキストスイッチのスタブ(×2 アーキ)
@@ -354,26 +354,26 @@ fd を持たない旧 `blocking_region` は全サイトが `blocking_io_region` 
   走る(`on_thread_count(live)` が `live >= 2` で起動、`live < 2` で停止)。単独スレッドの
   プログラムはタイマを 1 本も生やさずコストゼロ。
 - `MONORUBY_NO_PREEMPT` / `MONORUBY_PREEMPT_STRESS` が設定されているとタイマは起動しない。
-- 毎 tick、`flag_addr` の mutex を取ってから poll フラグに `fetch_or(PREEMPT_BIT)`。
+- 毎 tick、`flag_addr` の mutex を取ってから poll ワードの PREEMPT レーンを `fetch_or`。
   `Codegen::drop`(`codegen_dropped`)が同じ mutex 下で `flag_addr` を 0 に落とすので、
   タイマが解放済み JIT メモリを触ることはない(マルチインタプリタのテストハーネス対策)。
 
-### 8.2 フラグプロトコル
+### 8.2 レーンプロトコル
 
-poll フラグは **GC の `alloc_flag` と同じ 1 つの `u32`**。複数の書き手がいる:
+poll ワードは **GC・シグナルと同じ 1 つの `u32`** で、8bit×4 のレーンに分割される
+(全体像は `poll_flag.rs` / `doc/safepoint.md` §3):
 
-| 書き手 | 操作 |
-|---|---|
-| RValue アリーナ(ページ充填) | `+= 1` |
-| シグナルスタブ | `+= 10` |
-| malloc トリガ / `GC.start` | `>= 8` 帯へ持ち上げ |
-| プリエンプトタイマ | `\|= 1 << 30`(`PREEMPT_BIT`) |
+| byte | レーン | 書き手 |
+|---|---|---|
+| 0 | GC | アリーナのページ圧力 / malloc トリガ / `GC.start` |
+| 1 | PREEMPT | プリエンプトタイマ |
+| 2 | SIGNAL | シグナルハンドラ |
 
-- **ビット 30**であってビット 31 ではない: x86-64 の poll は `cmpl [rip+alloc_flag], 8; jge`
-  という**符号付き**比較なので、ビット 31 だと負値に読めて発火しない。
-- タイマは別 OS スレッドから書くので、フラグアクセスはすべてアトミック
-  (タイマ `fetch_or`、GC 後の `unset_alloc_flag` は `fetch_and(PREEMPT_BIT)` で
-  ベース帯だけ落として並行設定されたプリエンプトビットを**保存**する)。
+- 全書き込みは冪等なアトミック `fetch_or` / 自レーン byte のみの `fetch_and` clear。
+  タイマ(別 OS スレッド)とシグナルハンドラ(async-signal 文脈)が同じ語に書いても、
+  レーンが byte で分かれているため互いの更新を失わない。
+- poll はワード全体の**ゼロ判定**(`cmpl …, 0; jne` / `ldr; cbz`)なので符号の罠もない
+  (旧設計は符号付き `jge` の都合で PREEMPT がビット 30 に制限されていた)。
 
 ### 8.3 poll 配置
 
@@ -398,12 +398,12 @@ poll フラグは **GC の `alloc_flag` と同じ 1 つの `u32`**。複数の�
 セーフポイントから呼ばれる `execute_gc`(executor.rs)の順序:
 
 1. `watchdog::poll()`。
-2. `let (flag_base, preempt) = preempt::consume_poll_flag();` — プリエンプトビットを剥がし、
-   `(ベース値, プリエンプトか)` を返す(フラグ未登録なら防御的に `(8, false)`)。
+2. `let preempt = poll_flag::consume_preempt() || preempt::stress();` — PREEMPT レーンを
+   消費する。
 3. 保留シグナルを drain(エラーを立てて `None` を返しうる)。
-4. `flag_base >= 8` のときだけ実際に GC(純プリエンプト tick はベースが 8 未満なので
+4. GC レーンが立っているときだけ実際に GC(純プリエンプト tick は GC レーンに触れないので
    スキップ = 偽の full GC を起こさない)。
-5. `stress_renudge()` — stress モードでは切替の**前に**フラグを再武装し、切替先スレッドも
+5. `stress_renudge()` — stress モードでは切替の**前に**レーンを再武装し、切替先スレッドも
    poll するようにする。
 6. `if preempt && scheduler::preempt_ok() { scheduler::pass(vm, globals)? }`。
    `pass` の `Err`(kill/raise がこのスレッドに配送された)は `set_error` + `None` で浮上。

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -153,33 +153,14 @@ fn malloc_hard_limit_abort(size: usize, projected: usize, limit: usize) -> ! {
     std::process::abort();
 }
 
-thread_local! {
-    /// Address (as `usize`; `0` until the VM registers it) of the JIT/VM
-    /// allocation flag — the same `u32` the GC-arena path nudges. Kept
-    /// beside the thread-local `Allocator` it belongs to (a `Cell<usize>`
-    /// with a `const` initialiser, so reading it allocates nothing and
-    /// runs no destructor: `RurubyAlloc::alloc` reaches it from inside
-    /// the global allocator, where the non-reentrant `ALLOC` itself is
-    /// off limits).
-    ///
-    /// Per-thread rather than global because each VM thread has its own
-    /// heap and its own flag; a process-wide slot would let one thread's
-    /// `GC.start` nudge another thread's flag, and its own request would
-    /// then never fire. Only the interpreter's own thread has a
-    /// registered flag, so allocations on helper threads (preempt timer,
-    /// fd poller) simply request nothing.
-    static MALLOC_GC_FLAG_ADDR: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
-
 /// `MALLOC_AMOUNT` ceiling above which a GC is requested. Recomputed after
 /// each GC from the post-collection live amount (see `Allocator::gc`).
 static MALLOC_GC_THRESHOLD: AtomicUsize = AtomicUsize::new(MALLOC_THRESHOLD);
 
 /// Mirror of `Allocator::gc_enabled`, readable from the global allocator
 /// without touching the (non-reentrant) thread-local `Allocator`. When GC is
-/// disabled (`--no-gc`), `gc()` early-returns without clearing the alloc flag,
-/// so requesting a collection would leave the flag stuck in the trigger band
-/// and spin the safepoint poll. Skip the request entirely in that case.
+/// disabled (`--no-gc`), `gc()` voids the request instead of collecting;
+/// skipping the request here just avoids even that no-op poll.
 static GC_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
 
 /// Keep `GC_ENABLED` in step with `Allocator::gc_enabled` (see `Globals::gc_enable`).
@@ -206,35 +187,15 @@ pub(crate) fn malloc_gc_threshold() -> usize {
 
 /// Request a garbage collection at the next VM safepoint (`GC.start`).
 ///
-/// Only nudges the JIT/VM alloc flag into its trigger band (and, when
-/// `force_major`, records that the pending collection must be Major); the
-/// actual collection runs from the safepoint poll where live registers
-/// are spilled, so this is safe to call from inside a builtin.
+/// Only arms the poll word's GC lane (and, when `force_major`, records
+/// that the pending collection must be Major); the actual collection runs
+/// from the safepoint poll where live registers are spilled, so this is
+/// safe to call from inside a builtin.
 pub(crate) fn request_gc(force_major: bool) {
     if force_major {
         GC_FORCE_MAJOR.store(true, Ordering::Relaxed);
     }
-    nudge_flag();
-}
-
-/// Lift the poll flag into its `>= 8` trigger band without disturbing the
-/// preempt bit or a value already in the band. Atomic because the preempt
-/// timer ORs its bit into the same word from another OS thread.
-fn nudge_flag() {
-    let addr = MALLOC_GC_FLAG_ADDR.try_with(|a| a.get()).unwrap_or(0);
-    if addr == 0 {
-        return;
-    }
-    // SAFETY: `addr` is the registered JIT alloc-flag location, valid for
-    // the VM thread's lifetime.
-    let flag = unsafe { &*(addr as *const std::sync::atomic::AtomicU32) };
-    let _ = flag.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-        if v & !crate::preempt::PREEMPT_BIT >= 8 {
-            None
-        } else {
-            Some(v | 8)
-        }
-    });
+    crate::poll_flag::set_gc();
 }
 
 /// Request a GC at the next VM safepoint when live malloc has crossed the
@@ -256,23 +217,10 @@ fn request_gc_if_malloc_over(total: usize) {
     if !GC_ENABLED.load(Ordering::Relaxed) {
         return;
     }
-    // The VM/JIT GC poll fires when this `u32` is `>= 8`: the GC-arena path
-    // bumps it `+= 1` per nearly-full page (so ~8 pages of `RValue`s trips
-    // it), and the signal handler adds 10. To actually request a GC we must
-    // therefore lift it to the `>= 8` trigger band — writing a small value
-    // like `1` only joins the page-fill accumulation and is effectively a
-    // no-op. `nudge_flag` ORs `8` in only when the flag (preempt bit aside)
-    // is below the band, so we request exactly one collection, never stomp a
-    // value already in the trigger/signal range, and never climb unboundedly
-    // while we sit over threshold. Racing the async signal handler is
-    // harmless: a signal's delivery rides the separate `pending_signals`
-    // bitmap, so the poll still fires and `execute_gc` still drains it.
-    nudge_flag();
-}
-
-/// Register the VM allocation-flag address with the malloc-trigger path.
-pub(crate) fn set_malloc_gc_flag_addr(addr: *mut u32) {
-    let _ = MALLOC_GC_FLAG_ADDR.try_with(|a| a.set(addr as usize));
+    // Idempotent lane set: staying over threshold across many mallocs
+    // re-arms the same request, never anything unbounded. Racing the async
+    // signal handler is harmless too — the lanes are separate bytes.
+    crate::poll_flag::set_gc();
 }
 
 thread_local!(
@@ -284,6 +232,11 @@ const GCBOX_SIZE: usize = std::mem::size_of::<RValue>();
 const PAGE_LEN: usize = 64 * SIZE;
 const DATA_LEN: usize = 64 * (SIZE - 1);
 const THRESHOLD: usize = 64 * (SIZE - 2);
+
+/// Pages filling to `THRESHOLD` before the arena requests a collection
+/// (~8 pages ≈ 32K `RValue`s between GCs, matching the old `>= 8` poll
+/// band that accumulated `+1` per page).
+const PAGES_PER_GC_TRIGGER: u32 = 8;
 const ALLOC_SIZE: usize = PAGE_LEN * GCBOX_SIZE; // 2^18 = 256kb
 const MALLOC_THRESHOLD: usize = 256 * 1024;
 const MAX_PAGES: usize = 8192;
@@ -498,8 +451,12 @@ pub struct Allocator<T> {
     /// `OLD` yet), so the barrier is currently inert. See
     /// `doc/gc.md`.
     remembered: Vec<std::ptr::NonNull<T>>,
-    /// Flag for GC timing.
-    alloc_flag: Option<*mut u32>,
+    /// Arena pressure toward the next GC request: pages that filled to
+    /// `THRESHOLD` since the last collection. At [`PAGES_PER_GC_TRIGGER`]
+    /// the poll word's GC lane is armed; a completed collection resets
+    /// this (`ack_gc_request`). The counter lives here — the poll word
+    /// itself carries no arithmetic, only lane bits.
+    pages_since_gc: u32,
     /// Flag whether GC is enabled or not.
     pub gc_enabled: bool,
     /// Registry of promoted heap frames (`Box<[u64]>` buffers that
@@ -745,7 +702,7 @@ impl<T: GCBox> Allocator<T> {
             promoting: false,
             aging: Vec::new(),
             remembered: Vec::new(),
-            alloc_flag: None,
+            pages_since_gc: 0,
             gc_enabled: true,
             heap_frames: std::collections::HashMap::default(),
             free_log: Vec::new(),
@@ -845,16 +802,6 @@ impl<T: GCBox> Allocator<T> {
     }
 
     ///
-    /// Set address of allocation flag.
-    ///
-    pub(crate) fn set_alloc_flag_address(&mut self, address: *mut u32) {
-        self.alloc_flag = Some(address);
-        // Let the global allocator reach the same flag for malloc-driven
-        // GC requests.
-        set_malloc_gc_flag_addr(address);
-    }
-
-    ///
     /// Address of the free-list head (`self.free`), exposed so the JIT can
     /// inline the free-list allocation fast path (pop a recycled cell)
     /// without a runtime call. `self.free` is `Option<NonNull<T>>`, which is
@@ -906,27 +853,25 @@ impl<T: GCBox> Allocator<T> {
     }
 
     ///
-    /// Set allocation flag.
+    /// A page just filled to `THRESHOLD`: accumulate arena pressure and
+    /// arm the poll word's GC lane once enough pages have filled since
+    /// the last collection.
     ///
-    fn set_alloc_flag(&self) {
-        if let Some(flag) = self.alloc_flag {
-            // SAFETY: registered poll-flag location; atomic because the
-            // preempt timer ORs a bit into the same word from another
-            // OS thread.
-            unsafe { &*(flag as *const std::sync::atomic::AtomicU32) }
-                .fetch_add(1, Ordering::Relaxed);
+    fn on_page_pressure(&mut self) {
+        self.pages_since_gc += 1;
+        if self.pages_since_gc >= PAGES_PER_GC_TRIGGER {
+            crate::poll_flag::set_gc();
         }
     }
 
     ///
-    /// Unset allocation flag (keeping a concurrently-set preempt bit).
+    /// A collection answered (or, with GC disabled, voided) the pending
+    /// request: clear the GC lane and restart the arena-pressure count.
+    /// Other lanes (preempt tick, pending signal) are untouched.
     ///
-    fn unset_alloc_flag(&self) {
-        if let Some(flag) = self.alloc_flag {
-            // SAFETY: as in `set_alloc_flag`.
-            unsafe { &*(flag as *const std::sync::atomic::AtomicU32) }
-                .fetch_and(crate::preempt::PREEMPT_BIT, Ordering::Relaxed);
-        }
+    fn ack_gc_request(&mut self) {
+        self.pages_since_gc = 0;
+        crate::poll_flag::clear_gc();
     }
 
     ///
@@ -1061,7 +1006,7 @@ impl<T: GCBox> Allocator<T> {
         self.measure_time = flag;
     }
 
-    /// `GC.stress`. Turning it on arms the poll flag immediately, so the
+    /// `GC.stress`. Turning it on arms the GC lane immediately, so the
     /// next safepoint collects without waiting for allocation pressure.
     pub fn stress(&self) -> bool {
         self.stress
@@ -1070,7 +1015,7 @@ impl<T: GCBox> Allocator<T> {
     pub fn set_stress(&mut self, flag: bool) {
         self.stress = flag;
         if flag {
-            nudge_flag();
+            crate::poll_flag::set_gc();
         }
     }
 
@@ -1173,7 +1118,7 @@ impl<T: GCBox> Allocator<T> {
         } else {
             // Bump allocation.
             if self.used_in_current == THRESHOLD {
-                self.set_alloc_flag();
+                self.on_page_pressure();
             }
             let ptr = unsafe { self.current_page.as_ref().get_cell(self.used_in_current) };
             self.used_in_current += 1;
@@ -1224,6 +1169,9 @@ impl<T: GCBox> Allocator<T> {
 
     pub(crate) fn gc(&mut self, root: &impl GCRoot<T>) {
         if !self.gc_enabled {
+            // Void the request (`--no-gc`): leaving the GC lane armed
+            // would send every subsequent safepoint through this no-op.
+            self.ack_gc_request();
             return;
         }
         // A pending `GC.start` request forces a Major collection.
@@ -1345,7 +1293,7 @@ impl<T: GCBox> Allocator<T> {
             assert_eq!(self.free_list_count, self.check_free_list());
             eprintln!("free list: {}", self.free_list_count);
         }
-        self.unset_alloc_flag();
+        self.ack_gc_request();
         if let Some((invoke_time, started)) = clock {
             let total = started.elapsed().as_nanos() as u64;
             let mark = mark_elapsed.map_or(0, |d| d.as_nanos() as u64).min(total);
@@ -1366,10 +1314,10 @@ impl<T: GCBox> Allocator<T> {
                 });
             }
         }
-        // `GC.stress`: lift the poll flag straight back into its trigger
-        // band so the very next safepoint collects again.
+        // `GC.stress`: re-arm the GC lane so the very next safepoint
+        // collects again.
         if self.stress {
-            nudge_flag();
+            crate::poll_flag::set_gc();
         }
         let malloced = MALLOC_AMOUNT.load(std::sync::atomic::Ordering::SeqCst);
         // Allow malloc to grow by half the live amount (at least

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1317,7 +1317,7 @@ pub(super) fn signal_trap(
     let installed = crate::codegen::CODEGEN.with(|codegen| {
         let codegen = codegen.borrow();
         match new_disp {
-            SignalDisposition::Handler(_) => codegen.install_signal_stub(signo),
+            SignalDisposition::Handler(_) => codegen.install_signal_handler(signo),
             SignalDisposition::Ignore { .. } => codegen.install_signal_ignore(signo),
             SignalDisposition::Default => codegen.install_signal_default(signo),
             SignalDisposition::SystemDefault => codegen.install_signal_system_default(signo),

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -432,7 +432,9 @@ pub struct JitModule {
     pub(crate) jit: JitMemory,
     class_version: DestLabel,
     const_version: DestLabel,
-    alloc_flag: DestLabel,
+    /// The safepoint poll word (see poll_flag.rs for the lane protocol).
+    /// JIT data so the VM/JIT poll sites can address it rip-relative.
+    poll_flag: DestLabel,
     ///
     /// Raise error.
     ///
@@ -635,11 +637,6 @@ pub(crate) enum CellHeader {
 ///
 pub struct Codegen {
     pub(crate) jit: JitModule,
-    /// Pre-generated async-signal-safe asm stub for every signal in
-    /// `signal_table::TRAPPABLE_SIGNALS`, keyed by signo. Generated once
-    /// at `Codegen::new`; `Signal.trap` looks up the stub here and
-    /// `sigaction(2)`s it at trap time. See doc/signal.md A7.
-    signal_stubs: HashMap<i32, CodePtr>,
     class_version_addr: *mut u32,
     const_version_addr: *mut u64,
 
@@ -852,9 +849,13 @@ pub(crate) struct VmHandlers {
 
 impl Drop for Codegen {
     fn drop(&mut self) {
-        // The poll flag lives in this Codegen's JIT memory and the
-        // preempt timer writes to it from another OS thread: detach it
-        // before the memory is freed. See preempt.rs.
+        // The poll word lives in this Codegen's JIT memory and is written
+        // by the preempt timer (another OS thread) and the signal handler
+        // (async context): detach it everywhere before the memory is
+        // freed. See preempt.rs and poll_flag.rs.
+        let label = self.poll_flag.clone();
+        let addr = self.jit.get_label_address(&label).as_ptr() as *mut u32;
+        crate::poll_flag::unregister(addr);
         crate::preempt::codegen_dropped();
     }
 }
@@ -1012,7 +1013,6 @@ impl Codegen {
 
         let mut codegen = Self {
             jit,
-            signal_stubs: HashMap::default(),
             class_version_addr,
             const_version_addr,
             alloc_free_head_addr: std::ptr::null_mut(),
@@ -1051,17 +1051,6 @@ impl Codegen {
             jit_compile_time: std::time::Duration::default(),
         };
         codegen.construct_vm();
-        // Pre-generate an async-signal-safe stub for every signal we
-        // permit trapping (signal_table::TRAPPABLE_SIGNALS). Doing it all
-        // up front means `Signal.trap` only has to sigaction(2) at trap
-        // time — no JIT codegen on a live buffer. SIGSEGV/SIGBUS/SIGFPE/
-        // SIGILL/SIGABRT are deliberately absent: those are genuine
-        // programming errors and are left to the kernel's core-dump path.
-        // See doc/signal.md A2/A7.
-        for &signo in signal_table::TRAPPABLE_SIGNALS {
-            let codeptr = codegen.signal_handler_for(signo);
-            codegen.signal_stubs.insert(signo, codeptr);
-        }
         codegen.jit.finalize();
 
         // Only the default-install set (POSIX_SIGNALS, i.e. SIGINT) is
@@ -1076,7 +1065,7 @@ impl Codegen {
             if signo == libc::SIGALRM && crate::watchdog::armed() {
                 continue;
             }
-            if !codegen.install_signal_stub(signo) {
+            if !codegen.install_signal_handler(signo) {
                 panic!("Failed to set signal handler for signo {signo}");
             }
         }
@@ -1095,13 +1084,14 @@ impl Codegen {
         let info = codegen.get_wrapper_info(pair);
         codegen.vm_code_position = (Some(info.0), info.1, Some(info.2), info.3);
 
-        let address = codegen.jit.get_label_address(&codegen.alloc_flag).as_ptr() as *mut u32;
-        // The preempt timer nudges the same flag from its own OS thread;
-        // register it (detached again in `Codegen::drop`).
+        let address = codegen.jit.get_label_address(&codegen.poll_flag).as_ptr() as *mut u32;
+        // Register the poll word: the owning-thread + signal-handler
+        // registries (poll_flag.rs) and the preempt timer's mutex-guarded
+        // copy (preempt.rs). All detached again in `Codegen::drop`.
+        crate::poll_flag::register(address);
         crate::preempt::register_flag(address);
         alloc::ALLOC.with(|alloc| {
-            let mut alloc = alloc.borrow_mut();
-            alloc.set_alloc_flag_address(address);
+            let alloc = alloc.borrow_mut();
             // Capture the allocator's free-list state addresses for the JIT
             // inline-allocation fast path (stable thread-local; see the
             // Codegen field docs).
@@ -1145,17 +1135,12 @@ impl Codegen {
         CompilationUnitId(id)
     }
 
-    pub(crate) fn signal_handler_for(&mut self, signo: i32) -> CodePtr {
-        self.jit.signal_handler_for(self.alloc_flag.clone(), signo)
-    }
-
     /// `sigaction(2)` `signo` to `handler` with `flags`. Returns true on
     /// success. The handler must be either one of the libc `SIG_*`
-    /// sentinels or a pointer to a stub from `signal_stubs`.
+    /// sentinels or `signal_table::signal_handler`.
     unsafe fn sigaction_to(signo: i32, handler: libc::sighandler_t, flags: i32) -> bool {
         // SAFETY: caller passes a valid signo and a handler that is
-        // either a libc sentinel or a stable code pointer into the JIT
-        // buffer (which lives for the process lifetime).
+        // either a libc sentinel or the process-lifetime Rust handler.
         unsafe {
             let mut sa: libc::sigaction = std::mem::zeroed();
             sa.sa_sigaction = handler;
@@ -1165,14 +1150,14 @@ impl Codegen {
         }
     }
 
-    /// Arm `signo` with its pre-generated async-signal-safe stub so the
-    /// next poll point observes the pending bit. Returns false if no
-    /// stub was generated for `signo` (i.e. it is not trappable) or the
+    /// Arm `signo` with the async-signal-safe Rust handler
+    /// (`signal_table::signal_handler`) so the next poll point observes
+    /// the pending bit. Returns false if `signo` is not trappable or the
     /// syscall failed.
-    pub(crate) fn install_signal_stub(&self, signo: i32) -> bool {
-        let Some(codeptr) = self.signal_stubs.get(&signo) else {
+    pub(crate) fn install_signal_handler(&self, signo: i32) -> bool {
+        if !signal_table::is_trappable(signo) {
             return false;
-        };
+        }
         // No SA_RESTART, deliberately (like CRuby): a signal must EINTR a
         // blocking syscall so the interpreter can reach a poll point and
         // convert the pending signal. With SA_RESTART, a read(2) that has
@@ -1180,9 +1165,23 @@ impl Codegen {
         // a process blocked on an idle pipe can never be terminated by
         // SIGTERM. The blocking primitives (value/rvalue/io.rs, sleep,
         // waitpid, select) all retry bare EINTRs themselves.
-        // SAFETY: codeptr is a stable pointer into the finalized JIT
-        // buffer.
-        unsafe { Self::sigaction_to(signo, codeptr.as_ptr() as libc::sighandler_t, 0) }
+        // SAFETY: the handler is a plain `extern "C" fn(i32)` living in
+        // the executable for the process lifetime.
+        let ok = unsafe {
+            Self::sigaction_to(
+                signo,
+                signal_table::signal_handler as *const () as usize as libc::sighandler_t,
+                0,
+            )
+        };
+        if ok {
+            // sigaction is process-wide, so this interpreter now owns
+            // signal handling: point the handler's poll-word registry at
+            // it too (crucial after fork / in parallel-test processes —
+            // see `adopt_signal_registry`).
+            crate::poll_flag::adopt_signal_registry();
+        }
+        ok
     }
 
     /// Set `signo` to `SIG_IGN` (silently discard).
@@ -1191,12 +1190,12 @@ impl Codegen {
         unsafe { Self::sigaction_to(signo, libc::SIG_IGN, 0) }
     }
 
-    /// Restore `signo` to monoruby's default disposition: re-arm the stub
-    /// for default-installed signals (so SIGINT keeps raising `Interrupt`),
-    /// otherwise revert to the kernel `SIG_DFL`.
+    /// Restore `signo` to monoruby's default disposition: re-arm the
+    /// handler for default-installed signals (so SIGINT keeps raising
+    /// `Interrupt`), otherwise revert to the kernel `SIG_DFL`.
     pub(crate) fn install_signal_default(&self, signo: i32) -> bool {
         if signal_table::is_default_installed(signo) {
-            self.install_signal_stub(signo)
+            self.install_signal_handler(signo)
         } else {
             // SAFETY: SIG_DFL is always a valid disposition.
             unsafe { Self::sigaction_to(signo, libc::SIG_DFL, 0) }
@@ -1205,9 +1204,9 @@ impl Codegen {
 
     /// Set `signo` to the OS default disposition (`SIG_DFL`)
     /// unconditionally — the `"SYSTEM_DEFAULT"` trap command. Unlike
-    /// `install_signal_default`, this does *not* re-arm monoruby's stub
-    /// for the default-installed set: the caller explicitly wants the
-    /// kernel's behaviour.
+    /// `install_signal_default`, this does *not* re-arm monoruby's
+    /// handler for the default-installed set: the caller explicitly wants
+    /// the kernel's behaviour.
     pub(crate) fn install_signal_system_default(&self, signo: i32) -> bool {
         // SAFETY: SIG_DFL is always a valid disposition.
         unsafe { Self::sigaction_to(signo, libc::SIG_DFL, 0) }

--- a/monoruby/src/codegen/arch/aarch64/codegen.rs
+++ b/monoruby/src/codegen/arch/aarch64/codegen.rs
@@ -155,20 +155,17 @@ impl Codegen {
         );
     }
 
-    /// VM-side GC/signal poll. If `alloc_flag >= 8` (the signal handler nudges
-    /// it by 10), call `exec_gc` which drains pending signals + runs GC. The
-    /// hot path is two loads, a compare, and a fall-through branch.
+    /// VM-side safepoint poll. If any lane of the poll word is set (GC
+    /// request, preempt tick, pending signal — see poll_flag.rs), call
+    /// `exec_gc`. The hot path is a load and a fall-through `cbz`.
     pub(in crate::codegen) fn a64_vm_execute_gc(&mut self) {
         let gc = self.exec_gc.clone();
         let skip = self.jit.label();
-        let af_addr = self.jit.get_label_address(&self.alloc_flag).as_ptr() as u64;
+        let pf_addr = self.jit.get_label_address(&self.poll_flag).as_ptr() as u64;
         monoasm_arm64!(&mut self.jit,
-            mov x10, (af_addr);
-            ldr w11, [x10];
-            cmp x11, #(8);
-        );
-        self.jit.bcond_label(Cond::Lt, &skip);
-        monoasm_arm64!(&mut self.jit,
+            mov x10, (pf_addr);
+            ldr w11, [x10];       // zero-extends into x11
+            cbz x11, skip;
             bl gc;
             skip:
         );

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1373,11 +1373,12 @@ impl Codegen {
         true
     }
 
-    /// GC safepoint: if alloc_flag >= 8 (signal/gc-stress nudge), write back
-    /// live values, run execute_gc(vm, globals), and on error jump to the error
-    /// handler. The GC path is laid out inline but skipped on the common path.
-    /// Bails (`false`) like `emit_check_stack`. `base` is unused on aarch64.
-    /// Mirrors x86 `jit_execute_gc`.
+    /// Safepoint poll: if any lane of the poll word is set (GC request,
+    /// preempt tick, pending signal — see poll_flag.rs), write back live
+    /// values, run execute_gc(vm, globals), and on error jump to the error
+    /// handler. The slow path is laid out inline but skipped on the common
+    /// path. Bails (`false`) like `emit_check_stack`. `base` is unused on
+    /// aarch64. Mirrors x86 `jit_execute_gc`.
     pub(in crate::codegen::jitgen) fn emit_exec_gc(
         &mut self,
         write_back: WriteBack,
@@ -1386,16 +1387,15 @@ impl Codegen {
     ) -> bool {
         let error = error.clone();
         let skip = self.jit.label();
-        let af_addr = self
+        let pf_addr = self
             .jit
-            .get_label_address(&self.alloc_flag.clone())
+            .get_label_address(&self.poll_flag.clone())
             .as_ptr() as u64;
         monoasm_arm64!(&mut self.jit,
-            mov x9, (af_addr);
-            ldr w9, [x9];
-            cmp x9, #(8u32);
+            mov x9, (pf_addr);
+            ldr w9, [x9];         // zero-extends into x9
+            cbz x9, skip;         // all lanes clear -> no poll
         );
-        self.jit.bcond_label(monoasm::Cond::Lt, &skip); // < 8 -> no GC
         self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::executor::execute_gc as *const () as u64;
         // Preserve the GP-alloc pool (x5-x8 = GP::R8-R11) across the call. They

--- a/monoruby/src/codegen/arch/aarch64/jit_module.rs
+++ b/monoruby/src/codegen/arch/aarch64/jit_module.rs
@@ -116,7 +116,13 @@ impl JitModule {
         let class_version = jit.data_i32(1);
         let bop_redefined_flags = jit.data_i32(0);
         let const_version = jit.data_i64(1);
-        let alloc_flag = jit.data_i32(if cfg!(feature = "gc-stress") { 1 } else { 0 });
+        // The poll word (poll_flag.rs). Under `gc-stress` the GC lane
+        // starts armed so the very first safepoint collects.
+        let poll_flag = jit.data_i32(if cfg!(feature = "gc-stress") {
+            crate::poll_flag::GC_LANE as i32
+        } else {
+            0
+        });
         let entry_raise = jit.label();
         let entry_panic = jit.label();
         let exec_gc = jit.label();
@@ -137,7 +143,7 @@ impl JitModule {
             jit,
             class_version,
             const_version,
-            alloc_flag,
+            poll_flag,
             entry_raise,
             exec_gc,
             f64_to_val,
@@ -169,53 +175,4 @@ impl JitModule {
         j
     }
 
-    // --- invokers / entry points ---
-    /// Real `method_invoker` for the simple case (0 args, no kw): set up the
-    /// Ruby frame and call into `vm_entry`, then return the result to Rust.
-    /// AAPCS64 in: x0 exec, x1 globals, x2 funcid, x3 self, x4 args, x5 len,
-    /// x6 block, x7 hashmap. The frame offsets match x86 because aarch64's
-    /// `stp fp,lr` (16B at vm_entry) equals x86's `call`(8B)+`push rbp`(8B).
-    /// TODO(aarch64): argument copying (assumes 0 args) + stack-overflow check.
-    /// Invoker prologue: save callee-saved globals + fp/lr + X25/X26, then set
-    /// EXEC=x0, GLOBALS=x1.
-    /// Per-signal async-signal-safe stub. Mirrors the x86 version
-    /// (`addl [alloc_flag], 10; orl [pending_signals], (bit); ret`). The
-    /// handler nudges `alloc_flag` (so the next GC poll notices the signal)
-    /// and OR-sets the signal bit into `pending_signals`. `signo` is folded
-    /// into the immediate bit at codegen time, so the running handler does
-    /// only memory ops and returns.
-    ///
-    /// The RMW isn't atomic (no ldxr/stxr — these would be illegal at this
-    /// level inside async-signal context too), so a nested signal during the
-    /// sequence may lose an increment / a bit. The x86 version has the same
-    /// property (no LOCK prefix); the lossy case is rare and harmless — the
-    /// next allocation poll picks it up.
-    pub(crate) fn signal_handler_for(
-        &mut self,
-        alloc_flag: DestLabel,
-        signo: i32,
-    ) -> CodePtr {
-        debug_assert!((1..=32).contains(&signo));
-        let bit: u64 = 1u64 << (signo - 1);
-        let af_addr = self.jit.get_label_address(&alloc_flag).as_ptr() as u64;
-        // Process-global bitmap (see signal_table.rs): recording and
-        // polling agree even when several Codegens exist.
-        let ps_addr = crate::codegen::signal_table::pending_signals_addr();
-        let p = self.jit.get_current_address();
-        monoasm_arm64!(&mut self.jit,
-            // alloc_flag += 10  (32-bit RMW)
-            mov x0, (af_addr);
-            ldr w1, [x0];
-            add x1, x1, #10;
-            str w1, [x0];
-            // pending_signals |= bit  (32-bit RMW)
-            mov x0, (ps_addr);
-            ldr w1, [x0];
-            mov x2, (bit);
-            orr x1, x1, x2;
-            str w1, [x0];
-            ret;
-        );
-        p
-    }
 }

--- a/monoruby/src/codegen/arch/x86_64/jit_module.rs
+++ b/monoruby/src/codegen/arch/x86_64/jit_module.rs
@@ -1,5 +1,5 @@
 //! x86-64 `JitModule` asm methods: VM construction primitives, frame
-//! setup, register save/restore, GC poll, and the per-signal stub.
+//! setup, register save/restore, and the safepoint poll.
 //!
 //! Counterpart of `arch/aarch64/jit_module.rs`. These are inherent
 //! `impl JitModule` methods on the arch-neutral `JitModule` defined in
@@ -15,7 +15,13 @@ impl JitModule {
         let class_version = jit.data_i32(1);
         let bop_redefined_flags = jit.data_i32(0);
         let const_version = jit.data_i64(1);
-        let alloc_flag = jit.data_i32(if cfg!(feature = "gc-stress") { 1 } else { 0 });
+        // The poll word (poll_flag.rs). Under `gc-stress` the GC lane
+        // starts armed so the very first safepoint collects.
+        let poll_flag = jit.data_i32(if cfg!(feature = "gc-stress") {
+            crate::poll_flag::GC_LANE as i32
+        } else {
+            0
+        });
         let entry_raise = jit.label();
         let entry_panic = jit.label();
         let exec_gc = jit.label();
@@ -38,7 +44,7 @@ impl JitModule {
             jit,
             class_version,
             const_version,
-            alloc_flag,
+            poll_flag,
             entry_raise,
             exec_gc,
             f64_to_val,
@@ -257,14 +263,16 @@ impl JitModule {
         error: &DestLabel,
         write_back: impl FnOnce(&mut Self),
     ) {
-        let alloc_flag = self.alloc_flag.clone();
+        let poll_flag = self.poll_flag.clone();
         let gc = self.jit.label();
         let exit = self.jit.label();
         let exec_gc = self.exec_gc.clone();
         assert_eq!(0, self.jit.get_page());
+        // Any armed lane (GC / preempt / signal) sends the poll through
+        // `execute_gc`; the hot path is one fused compare-and-branch.
         monoasm! { &mut self.jit,
-            cmpl [rip + alloc_flag], 8;
-            jge  gc;
+            cmpl [rip + poll_flag], 0;
+            jne  gc;
         exit:
         };
         self.jit.select_page(1);
@@ -279,36 +287,6 @@ impl JitModule {
         self.jit.select_page(0);
     }
 
-    /// Emit a per-signal asm stub. Each stub OR-sets its own bit into
-    /// the process-global `signal_table::PENDING_SIGNALS` bitmap and
-    /// nudges `alloc_flag` so the next GC poll in `execute_gc` notices
-    /// the signal and converts it to a Ruby exception. `signo` is the
-    /// POSIX signal number (1..32).
-    ///
-    /// The handler runs in async-signal context; the only operations
-    /// performed are a memory OR and an ADD, both async-signal-safe on
-    /// x86-64, and rax is caller-saved under the C ABI a signal handler
-    /// is invoked with. No call into Rust. The bitmap is a process
-    /// global (its absolute address is baked in) so the recording side
-    /// and the polling side agree even when several `Codegen`s exist
-    /// (each re-`sigaction`s process-wide; see signal_table.rs).
-    pub(crate) fn signal_handler_for(
-        &mut self,
-        alloc_flag: DestLabel,
-        signo: i32,
-    ) -> CodePtr {
-        debug_assert!((1..=32).contains(&signo));
-        let bit: i32 = 1 << (signo - 1);
-        let ps_addr = crate::codegen::signal_table::pending_signals_addr();
-        let codeptr = self.jit.get_current_address();
-        monoasm! { &mut self.jit,
-            addl [rip + alloc_flag], 10;
-            movq rax, (ps_addr);
-            orl  [rax], (bit);
-            ret;
-        }
-        codeptr
-    }
     ///
     /// Save caller-save registers (except rax) in stack.
     ///

--- a/monoruby/src/codegen/signal_table.rs
+++ b/monoruby/src/codegen/signal_table.rs
@@ -15,8 +15,8 @@ use crate::{MonorubyErr, Value};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Process-global bitmap of pending Unix signals — bit `n` corresponds
-/// to signal `n + 1` (SIGINT = 2 ⇒ bit 1). Written from the per-signal
-/// asm stubs (`signal_handler_for`), drained at poll time.
+/// to signal `n + 1` (SIGINT = 2 ⇒ bit 1). Written by [`signal_handler`],
+/// drained at poll time.
 ///
 /// This is deliberately a *process* global, not per-`Codegen` JIT data:
 /// POSIX signals are process-wide, and `sigaction` is process-wide. With
@@ -28,9 +28,22 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// which Codegen installed the handler.
 pub(crate) static PENDING_SIGNALS: AtomicU32 = AtomicU32::new(0);
 
-/// Absolute address of `PENDING_SIGNALS`, baked into the asm stubs.
-pub(crate) fn pending_signals_addr() -> u64 {
-    &PENDING_SIGNALS as *const AtomicU32 as u64
+/// The process's signal handler, installed via `sigaction(2)` for every
+/// armed signal (`sa_handler` style, so the kernel passes the signo).
+///
+/// Runs in async-signal context: the entire body is two lock-free relaxed
+/// atomic ops — record the signo in the pending bitmap, then arm the poll
+/// word's SIGNAL lane so the next safepoint drains it. No locks, no
+/// allocation, no TLS. This replaces the old per-signo JIT asm stubs,
+/// whose unsynchronized read-modify-write (`addl` without `lock`) could
+/// race the preempt timer's `fetch_or` on the same word and lose one of
+/// the two updates — and which turned into a call into freed JIT memory
+/// if a signal arrived after the installing `Codegen` was dropped.
+pub(crate) extern "C" fn signal_handler(signo: i32) {
+    if (1..=32).contains(&signo) {
+        PENDING_SIGNALS.fetch_or(1 << (signo - 1) as u32, Ordering::Relaxed);
+    }
+    crate::poll_flag::set_signal_from_handler();
 }
 
 /// Atomically drain the pending-signal bitmap.

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -4629,11 +4629,11 @@ pub(crate) extern "C" fn execute_gc(
     // hang watchdog's countdown (no-op unless armed). See
     // doc/signal.md B+.
     crate::watchdog::poll();
-    // Strip the preempt bit off the poll flag first: `(base, preempt)`
-    // decides below whether this poll wants a collection (`base >= 8`), a
-    // timeslice switch, or both. A pure preempt tick must not run a
-    // spurious full GC. See preempt.rs for the flag protocol.
-    let (flag_base, preempt) = crate::preempt::consume_poll_flag();
+    // Consume the PREEMPT lane first: whether this poll wants a
+    // collection, a timeslice switch, or both is decided lane by lane —
+    // a pure preempt tick never runs a spurious full GC. See
+    // poll_flag.rs for the lane protocol.
+    let preempt = crate::poll_flag::consume_preempt() || crate::preempt::stress();
     let current_exec = executor as *mut Executor;
     // Drain the pending-signal bitmap. The lowest-numbered pending signal
     // is consumed; any others observed in the same drain are dropped on
@@ -4646,25 +4646,28 @@ pub(crate) extern "C" fn execute_gc(
     // the MAIN green thread, matching CRuby: a signal arriving while a
     // non-main thread runs stays pending until main's next poll point.
     let pending = if crate::scheduler::signal_delivery_ok() {
+        // Clear the SIGNAL lane *before* draining: a signal landing in
+        // between re-arms both, costing one spurious poll; the reverse
+        // order could drop the arming of a bit this drain never saw.
+        crate::poll_flag::clear_signal();
         crate::codegen::signal_table::take_pending_signals()
     } else {
         // The signal stays pending for the main thread (or for a poll
-        // outside the scheduler machinery); `deferred_signal` below keeps
-        // this poll from consuming the flag arming, so main still wakes.
+        // outside the scheduler machinery). The SIGNAL lane is left
+        // armed, which keeps the poll word non-zero: main still wakes
+        // (an allocation-free `nil until flag` spin on main polls only
+        // while the word is non-zero).
         0
     };
     // A pending signal this poll may not drain (delivery is gated to the
-    // main thread outside scheduler entry points). Two things follow:
-    // - The collection is skipped for this poll. Running the GC here has
-    //   been observed to corrupt live state (a heap frame freed while a
-    //   pending-signal drain is still owed to main manifests as a wedged
-    //   process at exit, spinning in a swept frame — see the regression
-    //   tests around `process_kill_from_thread`); deferring the
-    //   collection to the next ungated poll is always safe, since the
-    //   poll flag is left armed (only a completed `gc()` resets it).
-    // - That armed flag doubles as main's wakeup: an allocation-free
-    //   `nil until flag` spin on main polls only while the flag is up,
-    //   so clearing it here would swallow the handler forever.
+    // main thread outside scheduler entry points): skip the collection
+    // for this poll. Running the GC here has been observed to corrupt
+    // live state (a heap frame freed while a pending-signal drain is
+    // still owed to main manifests as a wedged process at exit, spinning
+    // in a swept frame — see the regression tests around
+    // `process_kill_from_thread`); deferring the collection to the next
+    // ungated poll is always safe, since the GC lane stays armed (only a
+    // completed collection clears it).
     let deferred_signal = pending == 0 && crate::codegen::signal_table::has_pending_signals();
     if let Some(signo) = crate::codegen::signal_table::lowest_pending_signo(pending) {
         use crate::codegen::signal_table::{self, SignalDisposition};
@@ -4695,7 +4698,7 @@ pub(crate) extern "C" fn execute_gc(
             }
         }
     }
-    if flag_base >= 8 && !deferred_signal {
+    if crate::poll_flag::gc_requested() && !deferred_signal {
         // Forensics (`MONORUBY_GC_BREAK=N`): dump the trigger context of GC
         // #N — who called into the collector, from which executor, and what
         // the scheduler state was — right before that collection runs.

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -56,6 +56,7 @@ mod globals;
 mod id_table;
 mod native_pool;
 pub mod parser;
+mod poll_flag;
 mod preempt;
 mod ruby_probe;
 mod scheduler;

--- a/monoruby/src/poll_flag.rs
+++ b/monoruby/src/poll_flag.rs
@@ -1,0 +1,224 @@
+//! The safepoint poll word and its lane protocol.
+//!
+//! One process-global 32-bit word, living in JIT data memory so the VM and
+//! JIT can poll it at every method call and loop back-edge with a single
+//! zero test (`cmpl [rip + flag], 0; jne` on x86-64, `ldr; cbnz` on
+//! aarch64). Any non-zero value means "reach `execute_gc`"; *what* the
+//! poll should do there is encoded in independent byte lanes:
+//!
+//! | byte | lane      | set by                                   | cleared by |
+//! |------|-----------|------------------------------------------|------------|
+//! | 0    | `GC`      | arena page pressure, the malloc trigger, `GC.start`, `GC.stress` re-arm | the collection that answers it (`Allocator::ack_gc_request`) |
+//! | 1    | `PREEMPT` | the preempt timer (another OS thread), stress re-arm | [`consume_preempt`] at poll entry |
+//! | 2    | `SIGNAL`  | the signal handler (async-signal context) | the poll that drains `PENDING_SIGNALS` (main-thread delivery) |
+//! | 3    | reserved  |                                          |            |
+//!
+//! Every writer uses an idempotent atomic op — `fetch_or` to set a lane,
+//! `fetch_and` to clear exactly its own byte — so concurrent writers can
+//! never lose each other's lanes. (The predecessor design packed a
+//! page-fill counter, a `+10` signal nudge, and a preempt bit into one
+//! arithmetic `>= 8` band; the signal handler's non-atomic `addl` could
+//! race the timer thread's `fetch_or` and drop one of the two updates.)
+//!
+//! Lane-clear ownership is what makes the protocol compose:
+//! - The `GC` lane survives a poll that *defers* its collection (a pending
+//!   signal it may not drain — see `execute_gc`), because only a completed
+//!   (or `--no-gc`-skipped) collection clears it.
+//! - The `SIGNAL` lane survives non-main polls, keeping the word non-zero
+//!   until the main thread drains the pending bitmap — this is also what
+//!   keeps an allocation-free `nil until flag` spin on main polling.
+//! - A signal arriving *during* a collection survives the GC-lane clear
+//!   (the old design wiped the whole word at GC end, delaying delivery
+//!   until the next unrelated nudge).
+//!
+//! ## Storage and registration
+//!
+//! The word itself is `JitModule`'s `poll_flag` data slot (it must be
+//! rip-relative-addressable from JIT code, so it cannot be a Rust static).
+//! `Codegen::new` registers its address here; `Codegen::drop` unregisters
+//! it. Two views exist:
+//! - a thread-local address for the owning interpreter thread (the VM,
+//!   the allocator, and `execute_gc` all run there);
+//! - a process-global address for the signal handler, which can run on
+//!   any OS thread. Multiple `Codegen`s (test threads) overwrite it
+//!   last-registration-wins, mirroring how `sigaction` itself is
+//!   process-wide. The preempt timer keeps its own mutex-guarded copy
+//!   (see preempt.rs) because it must exclude teardown, which an atomic
+//!   pointer alone cannot.
+
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+/// Set-value and whole-byte clear mask of the GC lane (byte 0). The set
+/// value doubles as the `data_i32` initializer under `gc-stress`.
+pub(crate) const GC_LANE: u32 = 0x0000_0001;
+const GC_LANE_MASK: u32 = 0x0000_00ff;
+/// Timeslice-preemption lane (byte 1).
+pub(crate) const PREEMPT_LANE: u32 = 0x0000_0100;
+const PREEMPT_LANE_MASK: u32 = 0x0000_ff00;
+/// Pending-signal lane (byte 2).
+pub(crate) const SIGNAL_LANE: u32 = 0x0001_0000;
+const SIGNAL_LANE_MASK: u32 = 0x00ff_0000;
+
+thread_local! {
+    /// This interpreter thread's poll word (0 = none registered), like
+    /// `ALLOC` / `CODEGEN`: each test thread runs its own interpreter, and
+    /// per-thread addressing keeps one thread's `GC.start` from arming
+    /// another thread's word. A `Cell<usize>` with a `const` initializer:
+    /// reading it allocates nothing and runs no destructor, because
+    /// [`set_gc`] is reached from *inside the global allocator* (the
+    /// malloc-threshold trigger), where the non-reentrant `ALLOC` — and
+    /// any allocating TLS — is off limits.
+    static FLAG_ADDR: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// The poll word the *signal handler* targets. Process-global because
+/// `sigaction` is: whichever `Codegen` registered last owns the process's
+/// signal handlers, so it also owns this slot.
+static SIGNAL_FLAG_ADDR: AtomicUsize = AtomicUsize::new(0);
+
+/// Register the interpreter's poll-word address (from `Codegen::new`).
+pub(crate) fn register(addr: *mut u32) {
+    FLAG_ADDR.with(|a| a.set(addr as usize));
+    SIGNAL_FLAG_ADDR.store(addr as usize, Ordering::Release);
+}
+
+/// Signal handlers were just `sigaction`ed to point at this interpreter
+/// (e.g. `Signal.trap`): make the handler-side registry follow, so the
+/// SIGNAL lane lands in *this* interpreter's word. This mirrors the old
+/// per-`Codegen` stub table, where re-arming a signal re-baked the
+/// calling interpreter's own flag address — without it, a forked child
+/// (or a parallel test interpreter) that traps a signal would have the
+/// lane armed on whichever interpreter happened to register last, and
+/// its own allocation-free `nil until flag` spin would starve.
+pub(crate) fn adopt_signal_registry() {
+    let addr = FLAG_ADDR.try_with(|a| a.get()).unwrap_or(0);
+    if addr != 0 {
+        SIGNAL_FLAG_ADDR.store(addr, Ordering::Release);
+    }
+}
+
+/// `Codegen` is being dropped: detach `addr` wherever it is still
+/// registered, so neither this thread nor the signal handler can write
+/// into freed JIT memory. A later registration by another `Codegen` is
+/// left untouched (compare-exchange).
+pub(crate) fn unregister(addr: *mut u32) {
+    // `try_with`: thread-local teardown order is unspecified.
+    let _ = FLAG_ADDR.try_with(|a| {
+        if a.get() == addr as usize {
+            a.set(0);
+        }
+    });
+    let _ = SIGNAL_FLAG_ADDR.compare_exchange(
+        addr as usize,
+        0,
+        Ordering::AcqRel,
+        Ordering::Relaxed,
+    );
+}
+
+/// Run `f` on this thread's poll word, or return `None` if no interpreter
+/// is registered on this thread.
+fn with_flag<R>(f: impl FnOnce(&AtomicU32) -> R) -> Option<R> {
+    let addr = FLAG_ADDR.try_with(|a| a.get()).unwrap_or(0);
+    if addr == 0 {
+        return None;
+    }
+    // SAFETY: owning-thread access — the word is JIT data in this
+    // thread's `Codegen`, alive for as long as this thread executes
+    // Ruby code (unregistered in `Codegen::drop` before it is freed).
+    Some(f(unsafe { &*(addr as *const AtomicU32) }))
+}
+
+/// Request a collection at the next safepoint.
+pub(crate) fn set_gc() {
+    with_flag(|f| f.fetch_or(GC_LANE, Ordering::Relaxed));
+}
+
+/// A collection answered (or `--no-gc` voided) the pending request.
+pub(crate) fn clear_gc() {
+    with_flag(|f| f.fetch_and(!GC_LANE_MASK, Ordering::Relaxed));
+}
+
+/// Whether a collection is currently requested. Defensive default when no
+/// flag is registered on this thread: `true`, so a direct `execute_gc`
+/// call still collects (the pre-lane behavior).
+pub(crate) fn gc_requested() -> bool {
+    with_flag(|f| f.load(Ordering::Relaxed) & GC_LANE_MASK != 0).unwrap_or(true)
+}
+
+/// Arm the preempt lane from the owning thread (stress mode re-arm; the
+/// timer thread writes through its own registered address in preempt.rs).
+pub(crate) fn set_preempt() {
+    with_flag(|f| f.fetch_or(PREEMPT_LANE, Ordering::Relaxed));
+}
+
+/// Consume the preempt lane at poll entry: report whether a timeslice
+/// tick was pending and clear it.
+pub(crate) fn consume_preempt() -> bool {
+    with_flag(|f| {
+        if f.load(Ordering::Relaxed) & PREEMPT_LANE_MASK != 0 {
+            f.fetch_and(!PREEMPT_LANE_MASK, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    })
+    .unwrap_or(false)
+}
+
+/// The poll is about to drain `PENDING_SIGNALS`: clear the signal lane
+/// *first*, then drain. A signal landing in between re-sets the lane and
+/// its bitmap bit, costing one spurious poll; the reverse order could
+/// clear the arming of a bit the drain never saw and lose its wakeup.
+pub(crate) fn clear_signal() {
+    with_flag(|f| f.fetch_and(!SIGNAL_LANE_MASK, Ordering::Relaxed));
+}
+
+/// Arm the signal lane from the signal handler. Async-signal-safe: one
+/// relaxed load of the registry and one lock-free `fetch_or`, no locks,
+/// no allocation. No-op when no interpreter is registered (the pending
+/// bit in `PENDING_SIGNALS` still records the signal).
+pub(crate) fn set_signal_from_handler() {
+    let addr = SIGNAL_FLAG_ADDR.load(Ordering::Acquire);
+    if addr != 0 {
+        // SAFETY: non-zero only between a `Codegen`'s registration and
+        // its `unregister` in `Codegen::drop`, so the word is live JIT
+        // data. (A handler racing the drop itself is a pre-existing
+        // teardown hazard the old asm stubs had in a worse form: they
+        // *executed from* the freed JIT buffer.)
+        unsafe { &*(addr as *const AtomicU32) }.fetch_or(SIGNAL_LANE, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lane ops on a locally registered word: each lane sets and clears
+    /// only its own byte, and the zero test is exactly "any lane set".
+    /// (The handler-side path targets the process-global registry, which
+    /// other test threads' interpreters also use, so it is exercised via
+    /// the word directly here.)
+    #[test]
+    fn lanes_are_independent() {
+        let word = AtomicU32::new(0);
+        register(word.as_ptr());
+        set_gc();
+        set_preempt();
+        assert!(gc_requested());
+        assert!(consume_preempt());
+        // The preempt consume left the GC lane alone.
+        assert!(gc_requested());
+        assert!(!consume_preempt());
+        clear_gc();
+        assert!(!gc_requested());
+        word.fetch_or(SIGNAL_LANE, Ordering::Relaxed);
+        assert_ne!(word.load(Ordering::Relaxed), 0);
+        clear_signal();
+        assert_eq!(word.load(Ordering::Relaxed), 0);
+        unregister(word.as_ptr());
+        // Unregistered defensive defaults.
+        assert!(gc_requested());
+        assert!(!consume_preempt());
+    }
+}

--- a/monoruby/src/preempt.rs
+++ b/monoruby/src/preempt.rs
@@ -1,30 +1,19 @@
 //! Phase-1 preemptive scheduling for the M:1 green-thread runtime.
 //!
-//! A dedicated timer OS thread "nudges" the interpreter's GC poll flag
-//! every [`TICK`] while two or more green threads are alive. The VM and
-//! JIT already poll that flag (`>= 8` calls `execute_gc`) at every
-//! method call and loop back-edge, so the nudge makes the running
-//! thread reach `execute_gc`, which consumes the request and calls
-//! `scheduler::pass` — i.e. preemption is exactly "as if every thread
-//! called `Thread.pass` at its next safepoint", reusing the existing
-//! cooperative switching machinery unchanged: no new context-switch
-//! paths and zero codegen changes.
+//! A dedicated timer OS thread arms the poll word's PREEMPT lane every
+//! [`TICK`] while two or more green threads are alive. The VM and JIT
+//! poll that word (any non-zero lane calls `execute_gc`) at every method
+//! call and loop back-edge, so the tick makes the running thread reach
+//! `execute_gc`, which consumes the lane and calls `scheduler::pass` —
+//! i.e. preemption is exactly "as if every thread called `Thread.pass`
+//! at its next safepoint", reusing the existing cooperative switching
+//! machinery unchanged: no new context-switch paths and zero codegen
+//! changes.
 //!
-//! ## The flag protocol
-//!
-//! The poll flag is a `u32` in JIT memory, shared by several writers:
-//! - the RValue-arena path adds `+1` per nearly-full page,
-//! - the signal stubs add `+10`,
-//! - `request_gc` / the malloc trigger lift it into the `>= 8` band,
-//! - the preempt timer ORs in [`PREEMPT_BIT`].
-//!
-//! [`consume_poll_flag`] (top of `execute_gc`) strips `PREEMPT_BIT` and
-//! reports `(base, preempt)`: a collection is wanted only when
-//! `base >= 8`, so a pure preempt tick never triggers a spurious full
-//! GC, and page-fill accumulation below the trigger band is preserved.
-//! `PREEMPT_BIT` is bit 30, not 31: the x86-64 poll is `cmpl ...; jge`
-//! (a *signed* compare), so bit 31 would read as negative and the poll
-//! would never fire.
+//! The lane protocol (who sets/clears which byte of the word) lives in
+//! poll_flag.rs; `execute_gc` consumes the PREEMPT lane through
+//! [`crate::poll_flag::consume_preempt`]. This module owns only the
+//! timer thread and the stress switches.
 //!
 //! ## Lifetime safety
 //!
@@ -32,14 +21,16 @@
 //! by this thread's `Codegen`. `flag_addr` is behind a mutex: the timer
 //! locks it around every write, and [`codegen_dropped`] (called from
 //! `Codegen::drop`) zeroes it under the same lock before the memory is
-//! freed — after that the timer can never dereference it again.
+//! freed — after that the timer can never dereference it again. (This is
+//! why the timer does not use poll_flag.rs's registries: excluding
+//! teardown needs the lock.)
 //!
 //! ## Env switches
 //!
 //! - `MONORUBY_NO_PREEMPT=1` — never start the timer (cooperative-only,
 //!   for debugging and bisection).
 //! - `MONORUBY_PREEMPT_STRESS=1` — treat *every* poll-site visit as a
-//!   preempt request and re-arm the flag after each poll, so every
+//!   preempt request and re-arm the lane after each poll, so every
 //!   safepoint performs a switch attempt: the deterministic torture
 //!   mode, the scheduling analog of `gc-stress`.
 
@@ -47,8 +38,7 @@ use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
-/// See the module doc: bit 30, not 31 (the x86-64 poll compare is signed).
-pub(crate) const PREEMPT_BIT: u32 = 1 << 30;
+use crate::poll_flag::PREEMPT_LANE;
 
 /// Timeslice; the same order of magnitude as CRuby's thread quantum.
 const TICK: std::time::Duration = std::time::Duration::from_millis(10);
@@ -56,7 +46,7 @@ const TICK: std::time::Duration = std::time::Duration::from_millis(10);
 struct Shared {
     /// Tells the timer thread to exit at its next tick.
     stop: AtomicBool,
-    /// Address of this interpreter's poll flag (0 = detached). The mutex
+    /// Address of this interpreter's poll word (0 = detached). The mutex
     /// makes timer writes and detachment mutually exclusive, so the
     /// timer can never write into freed JIT memory.
     flag_addr: Mutex<usize>,
@@ -88,15 +78,15 @@ pub(crate) fn stress() -> bool {
     *ON.get_or_init(|| std::env::var_os("MONORUBY_PREEMPT_STRESS").is_some())
 }
 
-/// Register the interpreter's poll-flag address (from `Codegen` init).
+/// Register the interpreter's poll-word address (from `Codegen` init).
 pub(crate) fn register_flag(addr: *mut u32) {
     STATE.with(|st| {
         *st.borrow().shared.flag_addr.lock().unwrap() = addr as usize;
     });
     if stress() {
         // Arm the very first poll; `stress_renudge` re-arms after each one.
-        // SAFETY: `addr` is the live poll flag just registered.
-        unsafe { &*(addr as *const AtomicU32) }.fetch_or(PREEMPT_BIT, Ordering::Relaxed);
+        // SAFETY: `addr` is the live poll word just registered.
+        unsafe { &*(addr as *const AtomicU32) }.fetch_or(PREEMPT_LANE, Ordering::Relaxed);
     }
 }
 
@@ -149,46 +139,15 @@ fn timer_loop(shared: Arc<Shared>) {
             // SAFETY: non-zero only while the owning `Codegen` is alive;
             // the lock excludes concurrent detachment.
             let flag = unsafe { &*(*addr as *const AtomicU32) };
-            flag.fetch_or(PREEMPT_BIT, Ordering::Relaxed);
+            flag.fetch_or(PREEMPT_LANE, Ordering::Relaxed);
         }
     }
 }
 
-/// Consume the poll flag at `execute_gc` entry: strip `PREEMPT_BIT` and
-/// return `(base, preempt)`. `base >= 8` means an actual GC request
-/// (page-fill accumulation, malloc trigger, `GC.start`, or a signal
-/// stub's `+10`); a pure preempt tick leaves `base` below the band.
-pub(crate) fn consume_poll_flag() -> (u32, bool) {
-    STATE.with(|st| {
-        let st = st.borrow();
-        let addr = *st.shared.flag_addr.lock().unwrap();
-        if addr == 0 {
-            // Defensive: a direct `execute_gc` call with no registered
-            // flag behaves exactly as before this module existed.
-            return (8, false);
-        }
-        // SAFETY: this is the owning interpreter thread — the flag (JIT
-        // memory in this thread's `Codegen`) is alive while it executes.
-        let flag = unsafe { &*(addr as *const AtomicU32) };
-        let v = flag.load(Ordering::Relaxed);
-        let preempt = v & PREEMPT_BIT != 0;
-        if preempt {
-            flag.fetch_and(!PREEMPT_BIT, Ordering::Relaxed);
-        }
-        (v & !PREEMPT_BIT, preempt || stress())
-    })
-}
-
-/// Stress mode: re-arm the flag so the very next poll site fires again.
+/// Stress mode: re-arm the lane so the very next poll site fires again.
 pub(crate) fn stress_renudge() {
     if !stress() {
         return;
     }
-    STATE.with(|st| {
-        let addr = *st.borrow().shared.flag_addr.lock().unwrap();
-        if addr != 0 {
-            // SAFETY: owning-thread access, as in `consume_poll_flag`.
-            unsafe { &*(addr as *const AtomicU32) }.fetch_or(PREEMPT_BIT, Ordering::Relaxed);
-        }
-    });
+    crate::poll_flag::set_preempt();
 }

--- a/monoruby/src/scheduler.rs
+++ b/monoruby/src/scheduler.rs
@@ -56,7 +56,7 @@ thread_local! {
     /// terminates. One slot per OS thread: the interpreter (scheduler,
     /// allocator, JIT) is per-OS-thread, and each OS thread's `Codegen`
     /// bakes *its own* slot address into its stubs — exactly like the
-    /// alloc_flag. A process-global slot would be corrupted when several
+    /// poll word. A process-global slot would be corrupted when several
     /// interpreters run on different OS threads (the test harness).
     static SCHED_RSP: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }


### PR DESCRIPTION
## Summary

Implements the poll-flag restructuring discussed for SafePoint: the poll word stays a single process-global `u32` (per-thread storage was evaluated and rejected for the M:1 runtime), split into four 8-bit lanes — **GC / PREEMPT / SIGNAL / reserved** — with the VM/JIT poll reduced to a plain zero test. New module: `poll_flag.rs`, which owns the lane protocol and both registries (owning-thread TLS + a process-global slot for the signal handler).

## What the old encoding cost us

The previous `alloc_flag` packed four meanings into one word arithmetically: page-fill `+= 1`, a signal `+= 10` nudge, a `>= 8` trigger band, and a preempt bit pinned to **bit 30** because the x86-64 poll used a *signed* `jge`. Beyond the scattered invariants, this had three real defects, all fixed by the lane design:

1. **Lost-update race**: the signal stub's un-`lock`ed `addl` (and the aarch64 `ldr/add/str`) could race the preempt timer's `fetch_or` from another OS thread and drop one of the two updates. Every writer is now an idempotent atomic `fetch_or`, and every clear touches only its own byte.
2. **Freed-JIT-memory hazard**: the per-signo asm stubs lived in the installing `Codegen`'s JIT buffer; a signal after that `Codegen` dropped executed freed memory. The stubs are replaced by a single Rust `extern "C"` handler (two lock-free relaxed atomics — async-signal-safe), and `Codegen::drop` unregisters the word everywhere first.
3. **Swallowed signal wakeup**: a signal arriving *during* a collection had its nudge wiped by the end-of-GC full-word reset, delaying delivery until the next unrelated nudge. The SIGNAL lane now survives the GC-lane clear.

## Design points

- The 8-pages-per-GC policy moves into the allocator (`pages_since_gc`); the poll word carries no arithmetic. Behavior is preserved (verified identical GC counts/stats on an allocation-heavy workload before/after).
- The #1070 defer-GC-at-gated-polls rule is now expressed directly: the GC lane simply stays armed across a deferred poll, and the SIGNAL lane doubles as main's wakeup for the allocation-free `nil until f` spin.
- `Signal.trap` re-points the handler-side registry at the calling interpreter (`adopt_signal_registry`), preserving the old per-`Codegen` stub semantics for forked children and parallel test interpreters (caught by `process_kill_from_thread_*` running under parallel `cargo test`).
- With `--no-gc`, a voided request now clears the GC lane instead of leaving every subsequent safepoint spinning through the slow path.
- aarch64's poll gets one instruction shorter (`ldr; cbz` vs `ldr; cmp #8; b.ge`), and bit 31 is usable again since the zero test has no sign trap.
- Docs updated: `safepoint.md`, `gc.md`, `signal.md`, `threads.md`.

## A finding, deliberately *not* changed here

While verifying, I measured that the `gc-stress` cargo feature is effectively inert today: a 370K-allocation workload runs only **11 GCs** (pure page-pressure cadence) — the feature's sole effect is the initial flag value, which lost its meaning when the `>= 8` band was introduced. The `bin/test` comment calling it "a collection per allocation" reflects an older implementation. This PR preserves the current observed behavior (initial GC lane armed). Restoring true per-safepoint stress would be a one-liner (`stress: cfg!(feature = "gc-stress")` in `Allocator::new`) but would multiply CI runtime, so it's left as a separate decision.

## Verification

- Full suite: 2227 passed / 0 failed (x86-64)
- Differential vs CRuby: `app_fib`, `so_mandelbrot` (JIT and `--no-jit`) — identical output on both x86-64 and aarch64 (qemu)
- Signal/thread/GC batches: `process_kill` (11), `signal` (28), `trap` (7), `gc` (26), `thread` (51), `preempt` (3) — all green, including the #1070 exit-hang regressions
- Stress modes: `MONORUBY_PREEMPT_STRESS=1` and runtime `GC.stress` smokes pass on both arches; `gc-stress` build shows byte-identical GC statistics to the pre-refactor build
- `cargo check --target aarch64-unknown-linux-gnu` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_