### PR TITLE
Binding frame chaining and import_methods entry-kind checks (fixes #1067, #1068)

### DIFF
--- a/doc/ruby_spec_skip_tags.md
+++ b/doc/ruby_spec_skip_tags.md
@@ -274,6 +274,23 @@ Mutex/Queue/Thread の状態）を残し、*後続*ファイルをハングさ�
   保たれる。これにより `core/io`（103ファイル / 1483 example）・`core/file`・
   `core/kernel` がカテゴリ一括実行で crash せず完走するようになった。
 
+## 実装前提の非互換による tags（恒久・非ハング）
+
+原則（tags はハング専用、セマンティクス差は統計に出す）の唯一の例外として、
+**spec の前提がこの処理系上で成立し得ない** example をタグ化している。
+「いずれ直すべき差」ではなく、直すことが誤りになる類のもの。
+
+- `core/refinement/import_methods_tags.txt` — `raises ArgumentError when
+  importing methods from C extension`: この spec は「C 拡張のメソッドは
+  import できない」ことを検証するために、CRuby では確実に C 実装である
+  `Zlib` を素材に選んでいる。monoruby の `Zlib` は Ruby 実装
+  （`stdlib/zlib.rb`）なので import は**正しく成功**し、raise しないのが
+  正直な挙動。ガード自体（native builtin・attr アクセサ・
+  `define_method`+block・`alias` エントリ・可視性 shadow の拒否）は
+  実装済みで、`module.rs` のユニットテストが CRuby と突き合わせている。
+  Zlib が C 実装でなくなる限りこの example は恒久に成立しないため、
+  ハングではないが tag で除外する。
+
 ## グリーンスレッド導入後のタイムアウト tags（2026-07 追加 → 撤去済み）
 
 > **2026-07 更新**: 以下の 5 タグ（+ `kernel/exit`）は、タイムスライス・

--- a/monoruby/src/builtins/binding.rs
+++ b/monoruby/src/builtins/binding.rs
@@ -566,6 +566,67 @@ mod tests {
     }
 
     #[test]
+    fn binding_dup_shares_storage_but_not_new_names() {
+        // core/binding/dup_spec.rb "retains original binding variables but
+        // the list is distinct": an eval-introduced local lives in the
+        // frame it was born in and is reached through the outer chain, so
+        // a dup'd Binding writes the SAME storage — while a name
+        // introduced through one Binding does not become visible through
+        // the other. Copying the locals into a fresh frame per eval (the
+        // pre-#1067 scheme) got the second half right and the first half
+        // wrong.
+        run_test(
+            r#"
+            def m
+              binding
+            end
+            bind1 = m
+            eval "a = 1", bind1
+            bind2 = bind1.dup
+            eval("a = 2", bind2)
+            leak = begin
+              eval("b = 3", bind2)
+              eval("b", bind1)
+            rescue NameError
+              :not_leaked
+            end
+            [eval("a", bind1), eval("a", bind2), eval("b", bind2), leak,
+             bind1.local_variables.sort, bind2.local_variables.sort]
+            "#,
+        );
+        // The same sharing through local_variable_set on an
+        // eval-introduced (not method-frame) local.
+        run_test(
+            r#"
+            def m
+              binding
+            end
+            b1 = m
+            b1.local_variable_set(:z, 10)
+            b2 = b1.dup
+            b2.local_variable_set(:z, 20)
+            [b1.local_variable_get(:z), b2.local_variable_get(:z)]
+            "#,
+        );
+        // Chained evals: later evals see earlier evals' locals through
+        // the chain, and assignment updates in place. The binding comes
+        // from a method, not toplevel — the harness wraps the snippet in
+        // its own toplevel locals, which a toplevel binding would report.
+        run_test(
+            r#"
+            def m
+              binding
+            end
+            b = m
+            eval("x = 1", b)
+            eval("y = x + 1", b)
+            eval("x = y * 2", b)
+            [eval("[x, y]", b), b.local_variables.sort]
+            "#,
+        );
+    }
+
+    #[test]
     fn binding_new() {
         run_test(
             r#"

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -3189,15 +3189,26 @@ fn import_methods(
             );
             emit_stderr_warning(vm, globals, &msg);
         }
-        for (name, func_id, visi) in globals.store[*module].own_method_entries() {
-            let Some(func_id) = func_id else { continue };
-            if globals.store[func_id].is_iseq().is_none() {
+        for (name, entry) in globals.store[*module].own_method_table() {
+            let Some(func_id) = entry.func_id() else {
+                continue;
+            };
+            // Only genuinely `def`-defined bodies can be imported. CRuby
+            // requires the entry itself to be VM_METHOD_TYPE_ISEQ, so an
+            // `alias` entry or a visibility re-declaration of an inherited
+            // method (`private :inherited`) raises even though the body it
+            // leads to is written in Ruby — while `define_method(name,
+            // method_obj)` re-registers the original ISEQ and imports.
+            if globals.store[func_id].is_iseq().is_none()
+                || entry.is_alias()
+                || entry.is_visibility_shadow()
+            {
                 return Err(MonorubyErr::argumenterr(format!(
                     "Can't import method which is not defined with Ruby code: {}#{name}",
                     globals.store.get_class_name(*module)
                 )));
             }
-            imports.push((name, func_id, visi));
+            imports.push((*name, func_id, entry.visibility()));
         }
         for (name, func_id, visi) in imports {
             globals.add_method(refinement, name, func_id, visi);
@@ -6648,6 +6659,50 @@ mod tests {
               end
             end
             out
+            "#,
+        );
+    }
+
+    #[test]
+    fn refinement_import_methods_requires_def_defined_bodies() {
+        // CRuby's check is on the method-entry TYPE, not on where the body
+        // ultimately came from: an `alias` entry (either form) and a
+        // visibility re-declaration of an inherited method raise even
+        // though the body they lead to is plain Ruby, while
+        // `define_method(name, method_obj)` re-registers the original
+        // ISEQ and imports. `define_method` with a block, accessors and
+        // native methods raise. Each rejecting module carries ONLY the
+        // offending entry — a raise mid-module leaves earlier entries of
+        // that module imported in CRuby, and this must not depend on
+        // method-table iteration order.
+        run_test(
+            r#"
+            probe = lambda do |src|
+              begin
+                Module.new { refine(String) { import_methods src } }
+                :imported
+              rescue ArgumentError => e
+                # The message names the module by its inspect (an address
+                # for anonymous modules); keep only the stable tail.
+                "ArgumentError: ##{e.message.split('#').last}"
+              end
+            end
+            base = Module.new { def rm; 1; end }
+            [
+              probe.call(Module.new { def ok; 1; end }),
+              probe.call(Module.new { include base; private :rm }),
+              probe.call(Module.new { define_method(:dm) { 1 } }),
+              probe.call(Module.new { define_method(:dm2, base.instance_method(:rm)) }),
+              probe.call(Module.new { attr_reader :foo }),
+              probe.call(Module.new { def s; 1; end; alias_method :am, :s }.tap { |m| m.send(:remove_method, :s) }),
+              probe.call(Module.new { def s; 1; end; alias kw s }.tap { |m| m.send(:remove_method, :s) }),
+            ]
+            "#,
+        );
+        // Math's methods are native in both implementations.
+        run_test_error(
+            r#"
+            Module.new { refine(String) { import_methods Math } }
             "#,
         );
     }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2641,7 +2641,7 @@ impl Executor {
         visibility: Visibility,
         original_name: IdentId,
     ) -> Result<()> {
-        globals.add_method_with_original(class_id, name, func_id, visibility, original_name);
+        globals.add_method_with_original(class_id, name, func_id, visibility, original_name, false);
         // BOP-redefinition eviction — see `add_method`.
         Codegen::check_bop_redefine(self.cfp());
         self.invoke_method_added(globals, class_id, name, Some(func_id))

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BlockInfo, Loc, LvarCollector, Node, ParamKind, SourceInfoRef};
+use crate::ast::{BlockInfo, Loc, Node, ParamKind, SourceInfoRef};
 use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
@@ -1064,30 +1064,29 @@ impl Globals {
     ) -> Result<Option<usize>> {
         let line_offset = lineno - 1;
         let outer_fid = binding.outer_fid();
-        let outer = match self.store[outer_fid].is_iseq() {
-            Some(iseq) => iseq,
-            None => {
-                return Err(MonorubyErr::runtimeerr(
-                    "eval with binding requires a Ruby method context",
-                ));
-            }
+        if self.store[outer_fid].is_iseq().is_none() {
+            return Err(MonorubyErr::runtimeerr(
+                "eval with binding requires a Ruby method context",
+            ));
+        }
+        // The scope this eval body compiles under. A binding that has
+        // already hosted an eval carries its own frame; new code compiles
+        // as a CHILD of that frame's iseq, so the locals earlier evals
+        // introduced resolve through the outer chain (depth >= 1) into the
+        // frame they were born in. They must NOT be re-declared as the new
+        // fid's own locals: that came with a value copy into a fresh frame,
+        // and any other Binding sharing the old frame (`#dup`) kept seeing
+        // the stale copy (#1067).
+        let outer = match binding.func_id() {
+            Some(fid) => self.store[fid].as_iseq(),
+            None => self.store[outer_fid].as_iseq(),
         };
         let external_context = self.store.scoped_locals(outer);
-
-        let context = if let Some(fid) = binding.func_id() {
-            let mut lvar = LvarCollector::new();
-            for (name, _) in &self.store.iseq(fid).locals {
-                lvar.insert(&name.get_name());
-            }
-            Some(lvar)
-        } else {
-            None
-        };
 
         let (fid, data_offset) = match crate::parser::parse_program_binding(
             code,
             path,
-            context.clone(),
+            None,
             Some(&external_context),
             line_offset,
             src_encoding,
@@ -1096,7 +1095,7 @@ impl Globals {
             Ok(res) => {
                 let data_offset = res.data_offset;
                 let res =
-                    bytecodegen::bytecode_compile_eval(self, res, outer, Loc::default(), context);
+                    bytecodegen::bytecode_compile_eval(self, res, outer, Loc::default(), None);
                 #[cfg(feature = "emit-bc")]
                 self.dump_bc();
                 res.map(|fid| (fid, data_offset))
@@ -1194,23 +1193,23 @@ impl Globals {
     }
 
     ///
-    /// Create new heap binding frame with *fid* and *self_val*.
+    /// Create a new heap frame for *fid* and chain it onto *binding*.
     ///
-    /// local variables are copied from *binding_lfp* if any.
-    ///
+    /// The frame's outer is the binding's current frame — or the captured
+    /// caller frame for a binding that has not hosted an eval yet. Locals
+    /// are NOT copied: earlier evals' locals stay in the frame they were
+    /// born in and are reached through the outer chain, so every Binding
+    /// sharing those frames (`#dup` / `#clone` copies the pointer) reads
+    /// and writes the same storage (#1067). Only the locals this fid
+    /// itself declares live in the new frame.
     fn new_binding_frame(&mut self, fid: FuncId, self_val: Value, mut binding: Binding) {
         let meta = self.store[fid].meta();
         let mut lfp = Lfp::heap_frame(self_val, meta);
-        lfp.set_outer(Some(binding.outer_lfp()));
-        if let Some(binding_lfp) = binding.binding() {
-            let locals_len = self.locals_len(binding_lfp.func_id());
-            for i in SlotId(1)..SlotId(1) + locals_len {
-                let v = binding_lfp.register(i);
-                // SAFETY: Setting register values during frame initialization.
-                // The slot index is within bounds (1..locals_len).
-                unsafe { lfp.set_register(i, v) }
-            }
-        }
+        let outer = match binding.binding() {
+            Some(prev) => prev,
+            None => binding.outer_lfp(),
+        };
+        lfp.set_outer(Some(outer));
         binding.set_inner(lfp);
     }
 

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -955,7 +955,14 @@ impl Globals {
         } else {
             visibility
         };
-        self.add_method_with_original(class_id, new_name, func_id, forced_visibility, original_name);
+        self.add_method_with_original(
+            class_id,
+            new_name,
+            func_id,
+            forced_visibility,
+            original_name,
+            true,
+        );
         Ok(())
     }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -35,6 +35,13 @@ pub(crate) struct MethodTableEntry {
     /// not a definition — `super` resolution must not treat the class
     /// as a position of the method body (`Store::body_dispatched_by`).
     visibility_shadow: bool,
+    /// Created by `alias_method` / the `alias` keyword. `original_name`
+    /// cannot stand in for this: `define_method(name, method_obj)` also
+    /// records the source's name there, yet CRuby treats it as an
+    /// ordinary ISEQ definition while an alias entry is its own method
+    /// type (`VM_METHOD_TYPE_ALIAS`) — which `Refinement#import_methods`
+    /// refuses even when the aliased body is written in Ruby.
+    is_alias: bool,
 }
 
 impl MethodTableEntry {
@@ -60,6 +67,10 @@ impl MethodTableEntry {
 
     pub fn is_visibility_shadow(&self) -> bool {
         self.visibility_shadow
+    }
+
+    pub fn is_alias(&self) -> bool {
+        self.is_alias
     }
 
     pub fn is_public(&self) -> bool {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -706,6 +706,13 @@ impl ClassInfo {
             .collect()
     }
 
+    /// Own-method entries with their full table records — for callers
+    /// that need the alias / visibility-shadow flags, not just the fid
+    /// (`Refinement#import_methods`).
+    pub(crate) fn own_method_table(&self) -> impl Iterator<Item = (&IdentId, &MethodTableEntry)> {
+        self.methods.iter()
+    }
+
     /// Returns true if the constant `name` defined on this class/module is
     /// marked as private. Constants are public by default. Returns false if
     /// the constant is not defined on this class.
@@ -2066,7 +2073,7 @@ impl Store {
         func_id: FuncId,
         visibility: Visibility,
     ) {
-        self.add_method_inner(class_id, name, func_id, visibility, false, name)
+        self.add_method_inner(class_id, name, func_id, visibility, false, name, false)
     }
 
     ///
@@ -2082,8 +2089,9 @@ impl Store {
         func_id: FuncId,
         visibility: Visibility,
         original_name: IdentId,
+        is_alias: bool,
     ) {
-        self.add_method_inner(class_id, name, func_id, visibility, false, original_name)
+        self.add_method_inner(class_id, name, func_id, visibility, false, original_name, is_alias)
     }
 
     ///
@@ -2098,7 +2106,7 @@ impl Store {
         func_id: FuncId,
         visibility: Visibility,
     ) {
-        self.add_method_inner(class_id, name, func_id, visibility, true, name)
+        self.add_method_inner(class_id, name, func_id, visibility, true, name, false)
     }
 
     ///
@@ -2114,6 +2122,7 @@ impl Store {
         visibility: Visibility,
         is_basic_op: bool,
         original_name: IdentId,
+        is_alias: bool,
     ) {
         self[func_id].set_owner_class(owner);
         // Defining into a refinement module puts `name` on the list the
@@ -2133,6 +2142,7 @@ impl Store {
                 is_basic_op,
                 original_name,
                 visibility_shadow: false,
+                is_alias,
             },
         );
         #[cfg(feature = "perf")]
@@ -2164,6 +2174,7 @@ impl Store {
                 is_basic_op: false,
                 original_name: name,
                 visibility_shadow: false,
+                is_alias: false,
             },
         );
     }
@@ -2388,6 +2399,7 @@ impl Store {
                             is_basic_op: false,
                             original_name,
                             visibility_shadow: true,
+                            is_alias: false,
                         },
                     );
                 }

--- a/spec/tags/core/refinement/import_methods_tags.txt
+++ b/spec/tags/core/refinement/import_methods_tags.txt
@@ -1,0 +1,1 @@
+fails:Refinement#import_methods when methods are not defined in Ruby code raises ArgumentError when importing methods from C extension


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. Binding: chain eval frames instead of copying them (#1067)

Every eval against a Binding used to re-declare the binding's accumulated
locals as the new eval fid's own slots, allocate a fresh heap frame sized for
them, and copy the values across. The copy is where sharing died: `Binding#dup`
copies the frame *pointer*, so the original and the dup agreed on storage only
until the next eval on either side replaced one side's frame with a private
copy. `core/binding/dup_spec.rb`'s "retains original binding variables but the
list is distinct" failed on exactly that.

Now it chains, the way CRuby's env chain does. An eval on a binding compiles as
a child of the binding's current eval iseq (or of the captured method iseq the
first time), so locals born in earlier evals resolve through the outer chain —
depth ≥ 1 — into the frame they were born in, and only the locals the new code
itself declares live in its frame. `new_binding_frame` sets the new frame's
outer to the binding's previous frame and copies nothing.

The spec's other half falls out of the same structure: a name introduced
through one Binding lives in a frame the sibling's chain does not contain, so
it neither resolves (NameError) nor appears in the sibling's
`local_variables`. The per-iseq static outer chain *is* the per-Binding
variable list — no separate name table to maintain. The existing frame walk in
`local_variable_get/set/defined?` already searched the outer chain, so those
share storage too.

- `core/binding`: **98 examples, 0 failures** (was 1 failure).
- `core/{kernel,proc,main,binding}` failure set is **byte-identical** to
  master's — the one fixed example is the whole diff.
- Differential tests against CRuby 4.0.2: dup-then-eval in both orders, clone,
  chained evals, a lambda capturing an eval-born local, nested eval,
  `local_variable_set` on eval-born locals — all byte-identical output,
  NameError backtraces included.

Named trade-off (in the commit message too): a binding kept alive across many
evals now holds one frame per eval, and lookup cost grows with chain depth.
CRuby's env chains have the same shape; collapsing local-less eval frames is a
possible follow-up if a REPL workload ever surfaces it.

## 2. import_methods: reject alias and shadow entries; tag the Zlib premise (#1068)

`Refinement#import_methods` already refused methods without a Ruby body.
Measured against CRuby 4.0.2, the guard was short in two places — both entry
**kinds**, not body kinds, because CRuby's check is on the method entry's type:

| entry | CRuby | monoruby before |
|---|---|---|
| `alias_method` / `alias` of a Ruby method | raises (`VM_METHOD_TYPE_ALIAS`) | imported |
| `private :inherited` visibility re-declaration | raises (`VM_METHOD_TYPE_ZSUPER`) | imported |
| `define_method(name, method_obj)` | **imports** (re-registers the ISEQ) | imports ✓ |

The third row pins the discriminator: `define_method`-from-Method records the
source's name in `original_name` exactly like an alias does, so
`original_name != name` cannot be the alias test. `MethodTableEntry` gains an
`is_alias` flag instead, set only at the one point both alias forms funnel
through (`Globals::alias_method_for_class`); the shadow case rides the
existing `visibility_shadow` flag.

The remaining spec failure is a premise mismatch, not a missing guard, and is
tagged rather than papered over: `import_methods_spec.rb` verifies C-extension
rejection by importing `Zlib`, chosen because in CRuby it is reliably C.
monoruby's Zlib is written in Ruby (`stdlib/zlib.rb`), so importing it
genuinely succeeds — raising there would be wrong. Tagged in
`spec/tags/core/refinement/import_methods_tags.txt`; the tags-are-for-hangs-only
policy gets its one documented exception in `doc/ruby_spec_skip_tags.md`
(a spec premise that cannot hold on this implementation, permanently).

- `core/refinement` under `mspec ci`: 25 examples, 0 failures, 0 errors,
  1 tagged.
- `core/module` (alias-heavy) failure set byte-identical to master's.
- New unit test probes all seven entry kinds through one lambda against
  CRuby's verdicts; each rejecting module carries only the offending entry so
  the outcome cannot depend on method-table iteration order.

## Testing

- `cargo test` — all 59 test binaries green, re-run after merging current
  `master` (#1073's safepoint-poll restructuring is merged in; clean merge,
  no conflicts).
- ruby/spec categories touched: binding 98/98, refinement 25/25 (1 tagged),
  kernel/proc/main/module failure sets unchanged vs master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_