### PR TITLE
gc-stress: force a collection at every safepoint (manual, both arches), and fix everything it caught

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,14 @@
 # on the slow macOS runner, and far below the 25-min attempt cap.
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+# The `amd64` CI job runs the suite with `gc-stress`, which collects at EVERY
+# safepoint; combined with llvm-cov instrumentation the heaviest JIT warm-up
+# tests legitimately run for several minutes, so the 10-min default cap has no
+# headroom left for the next one that grows. Give that job a 20-min cap: still
+# far below the job's own timeout, and a genuinely hung test is still named
+# rather than stalling the run. `bin/test` selects this profile via
+# NEXTEST_PROFILE when it enables `gc-stress`; unspecified keys inherit from
+# `profile.default`.
+[profile.gc-stress]
+slow-timeout = { period = "60s", terminate-after = 20 }

--- a/.github/workflows/darwin-hang-debug.yml
+++ b/.github/workflows/darwin-hang-debug.yml
@@ -44,6 +44,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
+      # Match the normal `darwin` job: no `gc-stress` on this runner.
+      # It is now a true per-safepoint stress mode and only the Linux
+      # `amd64` job runs it (see bin/test).
+      SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -79,8 +83,8 @@ jobs:
         run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
       - name: Pre-build test + benchmark binaries
         run: |
-          cargo nextest run --no-run --features stress-spill-pool,gc-stress
-          cargo build --bin monoruby --features stress-spill-pool,gc-stress
+          cargo nextest run --no-run --features stress-spill-pool
+          cargo build --bin monoruby --features stress-spill-pool
       - name: Loop bin/test under a memory watchdog (find the OOM culprit)
         env:
           ITERATIONS: ${{ github.event.inputs.iterations }}

--- a/.github/workflows/gc-stress.yml
+++ b/.github/workflows/gc-stress.yml
@@ -1,0 +1,183 @@
+# gc-stress — manual, both architectures.
+#
+# `gc-stress` forces a collection at EVERY safepoint, unconditionally. That is
+# the mode that finds unrooted-Value bugs (a fresh object held only by a Rust
+# local across a Ruby re-entry is invisible to the mark phase and gets swept),
+# but it is far too slow to run on every push: on the `amd64` job, stacked on
+# top of llvm-cov instrumentation, it turned a ~10 min nextest phase into
+# ~100 min. So the automatic `Rust` workflow now sets `SKIP_GC_STRESS=1` on
+# both of its jobs, and the stress coverage lives here instead — dispatched by
+# hand from the Actions tab (or `gh workflow run gc-stress.yml`).
+#
+# Run this when touching the GC, frame layout, argument binding, or any
+# builtin that creates a Value and then re-enters Ruby (`invoke_block`,
+# `#to_str`/`#to_ary` coercion, hash `eql?` dispatch, `warn`, ...).
+#
+# Unlike the automatic job this collects NO coverage: instrumentation is a
+# ~7.5x multiplier on top of the stress multiplier and adds nothing here —
+# codecov is fed by the `Rust` workflow.
+name: gc-stress (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: "Architectures to run"
+        type: choice
+        options: [both, x86_64, aarch64]
+        default: both
+      scope:
+        description: "nextest = unit + integration tests under gc-stress. full = the whole bin/test scope (also benchmarks / optcarrot / ruby-spec, which build WITHOUT gc-stress)."
+        type: choice
+        options: [nextest, full]
+        default: nextest
+      test_filter:
+        description: "Optional nextest filter expression, e.g. test(sort) or package(monoruby). Ignored when scope=full."
+        type: string
+        default: ""
+      no_fail_fast:
+        description: "Keep going after the first failure (report every failing test in one run)."
+        type: boolean
+        default: true
+
+jobs:
+  # Turn the `arch` choice into the matrix. The runner label travels with the
+  # architecture in the JSON rather than via `include:`, because an `include:`
+  # entry whose `arch` does not match the selected combination is APPENDED as
+  # a new job instead of being dropped — which would run aarch64 even when the
+  # user asked for x86_64 only.
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.pick.outputs.targets }}
+    steps:
+      - id: pick
+        env:
+          ARCH: ${{ inputs.arch }}
+        run: |
+          X86='{"arch":"x86_64","runner":"ubuntu-latest"}'
+          # GitHub-hosted native arm64 Linux runner (free for public repos).
+          # If this label is ever unavailable for the repo, `macos-latest` is
+          # the other native aarch64 option — but note it is
+          # aarch64-apple-darwin, and the darwin runner has a documented
+          # memory-fragility problem under long runs (see rust.yml).
+          ARM='{"arch":"aarch64","runner":"ubuntu-24.04-arm"}'
+          case "$ARCH" in
+            x86_64)  targets="[$X86]" ;;
+            aarch64) targets="[$ARM]" ;;
+            *)       targets="[$X86,$ARM]" ;;
+          esac
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "matrix: $targets"
+
+  stress:
+    needs: select
+    name: gc-stress (${{ matrix.target.arch }}, ${{ inputs.scope }})
+    runs-on: ${{ matrix.target.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.select.outputs.targets) }}
+    # Per-safepoint collection is slow by design; `full` on top of that is
+    # slower still. Well above any healthy run, well below a wedged one.
+    timeout-minutes: 240
+    env:
+      CARGO_TERM_COLOR: always
+      # 20-min per-test cap instead of the default 10: under stress the
+      # heaviest JIT warm-up tests legitimately run for minutes. A genuinely
+      # hung test is still terminated and named. (`bin/test` sets this itself
+      # for scope=full; setting it here too keeps both scopes consistent.)
+      NEXTEST_PROFILE: gc-stress
+      # A runaway allocation aborts with a size report + backtrace, and
+      # nextest then names the offending test, instead of the runner dying.
+      MONORUBY_MALLOC_HARD_LIMIT: 6G
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        # The test harness diffs monoruby's output against this CRuby.
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.2"
+      - name: Install bigdecimal (no longer a default gem since Ruby 3.4)
+        run: gem install bigdecimal --no-document
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+      - uses: taiki-e/install-action@nextest
+
+      - name: Neutralise the cross-compile config on native arm64
+        if: matrix.target.arch == 'aarch64'
+        # `.cargo/config.toml` pins `[target.aarch64-unknown-linux-gnu]` to the
+        # x86-64-host cross toolchain: linker `aarch64-linux-gnu-gcc` and
+        # runner `qemu-aarch64`. On a NATIVE arm64 runner that triple is the
+        # host, so cargo would apply both — linking with a compiler that is not
+        # installed and executing every test under qemu, which is precisely the
+        # combination `bin/test-aarch64` warns is unusable under gc-stress
+        # ("unit test だけで 4 時間級"). Environment variables win over
+        # config.toml, so override them here rather than editing the shared
+        # config. `env` is a no-op passthrough runner — cargo rejects an empty
+        # value ("invalid length 0, expected at least one element").
+        run: |
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=cc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=env" >> "$GITHUB_ENV"
+
+      - name: Show toolchain
+        run: |
+          echo "arch:   $(uname -m)"
+          rustc -vV
+          ruby --version
+          cargo nextest --version
+
+      # --- scope: nextest ---------------------------------------------------
+      - name: nextest under gc-stress
+        if: inputs.scope == 'nextest'
+        env:
+          # Via env, not `${{ }}` interpolation into the script: a dispatch
+          # input must never be pasted into a shell command.
+          TEST_FILTER: ${{ inputs.test_filter }}
+          NO_FAIL_FAST: ${{ inputs.no_fail_fast }}
+        run: |
+          set -o pipefail
+          args=(--features stress-spill-pool,gc-stress)
+          if [ "$NO_FAIL_FAST" = "true" ]; then
+            args+=(--no-fail-fast)
+          fi
+          if [ -n "$TEST_FILTER" ]; then
+            args+=(-E "$TEST_FILTER")
+          fi
+          echo "cargo nextest run ${args[*]}"
+          cargo nextest run "${args[@]}"
+
+      # --- scope: full ------------------------------------------------------
+      # `bin/test` enables gc-stress for its nextest phase unless
+      # SKIP_GC_STRESS=1 (which is what the automatic workflow now sets), so
+      # simply NOT setting it here is what turns the stress on. SKIP_COV=1
+      # keeps llvm-cov out of the picture.
+      - name: Clone optcarrot
+        if: inputs.scope == 'full'
+        run: git clone https://github.com/mame/optcarrot.git ../optcarrot
+      - name: Clone ruby/spec and mspec (pinned)
+        if: inputs.scope == 'full'
+        # Same pinned revisions as the automatic workflow — keep in sync.
+        env:
+          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
+        run: |
+          git init ../spec
+          git -C ../spec fetch --depth 1 https://github.com/ruby/spec.git "$SPEC_REV"
+          git -C ../spec checkout FETCH_HEAD
+          git init ../mspec
+          git -C ../mspec fetch --depth 1 https://github.com/ruby/mspec.git "$MSPEC_REV"
+          git -C ../mspec checkout FETCH_HEAD
+      - name: Clone ruby-bench
+        if: inputs.scope == 'full'
+        run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
+      - name: Install ruby-bench gem dependencies
+        if: inputs.scope == 'full'
+        # bin/ruby-bench-diff requires `erubi`.
+        run: gem install erubi --no-document
+      - name: bin/test under gc-stress
+        if: inputs.scope == 'full'
+        env:
+          SKIP_COV: "1"
+        run: bin/test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,16 @@ jobs:
       # still beats a thrashing one), and having the limit set exercises the
       # cap's init + hot-path compare under the coverage run.
       MONORUBY_MALLOC_HARD_LIMIT: 6G
+      # No `gc-stress` on the automatic runs. Since it became a true stress
+      # mode (a collection at EVERY safepoint) it dominated this job: on top
+      # of llvm-cov instrumentation the nextest phase went from ~10 min to
+      # ~100 min, and the heaviest JIT warm-up tests kept crowding nextest's
+      # per-test cap. Every push paying that is not worth it.
+      # The stress coverage now lives in `.github/workflows/gc-stress.yml`,
+      # a manually dispatched workflow that runs the suite under `gc-stress`
+      # on BOTH x86-64 and aarch64 — run it when touching GC, frame layout,
+      # or rooting.
+      SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -97,12 +107,13 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
-      # Drop `gc-stress` (a collection per allocation) on this runner only.
-      # It was the single biggest multiplier in the run, and the M1 runner
-      # was finishing right at its per-attempt cap — three commits in a row
-      # passed only on the second attempt, and the fourth then exhausted
-      # both. The Linux `amd64` job still runs with it, so every push
-      # still exercises the GC paths under stress.
+      # Drop `gc-stress` (a collection at every safepoint). It was the single
+      # biggest multiplier in the run, and the M1 runner was finishing right
+      # at its per-attempt cap — three commits in a row passed only on the
+      # second attempt, and the fourth then exhausted both. The `amd64` job
+      # above now skips it for the same reason; stress coverage for both
+      # architectures lives in the manually dispatched
+      # `.github/workflows/gc-stress.yml`.
       SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,7 +449,7 @@ All test helpers invoke CRuby via `ruby` in `PATH` and assert output equality.
 | `deopt`             | Log deoptimizations (implies `jit-log`, `dump-bc`, `dump-traceir`)     |
 | `gc-log`            | Log GC statistics at exit                                              |
 | `gc-debug`          | GC debug assertions                                                    |
-| `gc-stress`         | Start in `GC.stress` mode: GC at every safepoint (stress test)         |
+| `gc-stress`         | Force a GC at every safepoint, unconditionally (stress test)           |
 | `stress-spill-pool` | Shrink `PHYS_FPR_POOL` to 2 to stress the FP-register spill paths      |
 | `profile`           | Collect deopt/recompile statistics (implies `dump-bc`, `dump-traceir`) |
 | `perf`              | Emit perf-compatible symbol maps                                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,8 +417,9 @@ bin/test
 `bin/test` does:
 
 1. `cargo llvm-cov nextest` with the stress features (`stress-spill-pool`, plus
-   `gc-stress` unless `SKIP_GC_STRESS=1` — the darwin CI job sets it, so
-   `gc-stress` runs on x86-64 CI only)
+   `gc-stress` unless `SKIP_GC_STRESS=1` — **both** automatic CI jobs set it,
+   so pushes/PRs no longer pay the per-safepoint stress; see the manual
+   `gc-stress` workflow below)
 2. Builds a debug benchmark binary **without** `gc-stress` (true per-safepoint
    stress would make the benchmark/optcarrot/spec phases take hours)
 3. Runs benchmark scripts and `diff`s output against CRuby
@@ -521,7 +522,7 @@ Do not add new nightly features without necessity; prefer stable alternatives wh
 
 File: `.github/workflows/rust.yml`
 
-Triggered on push/PR to `master`. Two jobs run:
+Triggered on push/PR to `master`. Two jobs run, **both with `SKIP_GC_STRESS=1`**:
 
 - **Linux/x86-64** (`ubuntu-latest`): install Ruby 4.0+, Rust nightly,
   `cargo-llvm-cov` + `cargo-nextest`, clone optcarrot / ruby-bench / ruby-spec,
@@ -530,6 +531,28 @@ Triggered on push/PR to `master`. Two jobs run:
   runner exercising the VM + AArch64 JIT. Installs `bigdecimal`, `libffi` +
   `pkg-config` (Homebrew libffi is required on aarch64 macOS — see the
   target-specific dep block in `monoruby/Cargo.toml`), then runs the test scope.
+
+### Manual gc-stress workflow
+
+File: `.github/workflows/gc-stress.yml` — **`workflow_dispatch` only.**
+
+Per-safepoint collection is what finds unrooted-Value bugs, but it is far too
+slow for every push (stacked on llvm-cov it took the `amd64` nextest phase from
+~10 min to ~100 min), so it was moved out of the automatic runs. Dispatch this
+from the Actions tab — or `gh workflow run gc-stress.yml -f arch=both` — when
+touching the GC, frame layout, argument binding, or any builtin that creates a
+Value and then re-enters Ruby.
+
+Inputs: `arch` (`both` / `x86_64` / `aarch64`), `scope` (`nextest` = the unit +
+integration suite under stress, `full` = the whole `bin/test` scope),
+`test_filter` (a nextest `-E` expression), `no_fail_fast`.
+
+It runs on `ubuntu-latest` (x86-64) and `ubuntu-24.04-arm` (**native** arm64
+Linux — not qemu), and collects no coverage. On the arm64 runner the job
+overrides `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_{LINKER,RUNNER}` because
+`.cargo/config.toml` points that triple at the x86-64-host cross toolchain
+(`aarch64-linux-gnu-gcc` + `qemu-aarch64`), which would otherwise run every
+test under emulation.
 
 ---
 
@@ -585,5 +608,5 @@ run `bin/refresh-prism-vendored` (rebuilds and force-pushes
 3. **Ruby in PATH**: Tests compare output against a system `ruby` binary matching the vendored pin (`4.0.2`, see `vendor/ruby-stdlib/.ruby-version`). Ensure Ruby is installed and the binary is accessible.
 4. **optcarrot**: The full CI test requires optcarrot cloned at `../optcarrot` relative to the repo root.
 5. **Library path**: `build.rs` does **not** invoke a host `ruby` for `$LOAD_PATH` / `RUBY_VERSION` (those come from the vendored snapshot). Host-installed *non-default* gems are discovered at run time by `src/ruby_probe.rs`, which invokes a host `ruby` once if present and caches `~/.monoruby/{library_path,gem_path}`. If no host Ruby is found, those caches stay empty and a warning is printed at startup, but the vendored stdlib still loads from the per-version install root (`~/.monoruby/v<version>/lib`).
-6. **gc-stress in tests**: The `bin/test` script runs the nextest phase with `--features gc-stress` to catch GC bugs. Since the true-stress restoration this means a collection at **every safepoint** — the test binary is drastically slower than a normal debug build, and long-running workloads (benchmarks, optcarrot, ruby/spec) are deliberately built without it.
+6. **gc-stress in tests**: `bin/test` runs the nextest phase with `--features gc-stress` (unless `SKIP_GC_STRESS=1`) to catch GC bugs. Since the true-stress restoration this means a collection at **every safepoint** — the test binary is drastically slower than a normal debug build, and long-running workloads (benchmarks, optcarrot, ruby/spec) are deliberately built without it. Both automatic CI jobs now skip it; run the manual `gc-stress` workflow instead. Tests whose loop counts exist only to reach the JIT thresholds should shrink them under `cfg!(feature = "gc-stress")` (see `tests/method_call.rs`) — otherwise they blow past nextest's per-test cap.
 7. **Thread-local CODEGEN**: The JIT compiler is a thread-local singleton. Do not attempt to use it across threads.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,9 +416,12 @@ bin/test
 
 `bin/test` does:
 
-1. `cargo llvm-cov nextest` with all debug features enabled
-2. Builds a debug binary with `gc-stress`
-3. Runs benchmark scripts and `diff`s output against CRuby 3.4.1
+1. `cargo llvm-cov nextest` with the stress features (`stress-spill-pool`, plus
+   `gc-stress` unless `SKIP_GC_STRESS=1` — the darwin CI job sets it, so
+   `gc-stress` runs on x86-64 CI only)
+2. Builds a debug benchmark binary **without** `gc-stress` (true per-safepoint
+   stress would make the benchmark/optcarrot/spec phases take hours)
+3. Runs benchmark scripts and `diff`s output against CRuby
 4. Runs optcarrot and compares output
 5. Generates `lcov.info` coverage report
 
@@ -446,7 +449,7 @@ All test helpers invoke CRuby via `ruby` in `PATH` and assert output equality.
 | `deopt`             | Log deoptimizations (implies `jit-log`, `dump-bc`, `dump-traceir`)     |
 | `gc-log`            | Log GC statistics at exit                                              |
 | `gc-debug`          | GC debug assertions                                                    |
-| `gc-stress`         | GC on every allocation (stress test)                                   |
+| `gc-stress`         | Start in `GC.stress` mode: GC at every safepoint (stress test)         |
 | `stress-spill-pool` | Shrink `PHYS_FPR_POOL` to 2 to stress the FP-register spill paths      |
 | `profile`           | Collect deopt/recompile statistics (implies `dump-bc`, `dump-traceir`) |
 | `perf`              | Emit perf-compatible symbol maps                                       |
@@ -582,5 +585,5 @@ run `bin/refresh-prism-vendored` (rebuilds and force-pushes
 3. **Ruby in PATH**: Tests compare output against a system `ruby` binary matching the vendored pin (`4.0.2`, see `vendor/ruby-stdlib/.ruby-version`). Ensure Ruby is installed and the binary is accessible.
 4. **optcarrot**: The full CI test requires optcarrot cloned at `../optcarrot` relative to the repo root.
 5. **Library path**: `build.rs` does **not** invoke a host `ruby` for `$LOAD_PATH` / `RUBY_VERSION` (those come from the vendored snapshot). Host-installed *non-default* gems are discovered at run time by `src/ruby_probe.rs`, which invokes a host `ruby` once if present and caches `~/.monoruby/{library_path,gem_path}`. If no host Ruby is found, those caches stay empty and a warning is printed at startup, but the vendored stdlib still loads from the per-version install root (`~/.monoruby/v<version>/lib`).
-6. **gc-stress in tests**: The `bin/test` script builds with `--features gc-stress` to catch GC bugs; this makes the binary much slower than a normal debug build.
+6. **gc-stress in tests**: The `bin/test` script runs the nextest phase with `--features gc-stress` to catch GC bugs. Since the true-stress restoration this means a collection at **every safepoint** — the test binary is drastically slower than a normal debug build, and long-running workloads (benchmarks, optcarrot, ruby/spec) are deliberately built without it.
 7. **Thread-local CODEGEN**: The JIT compiler is a thread-local singleton. Do not attempt to use it across threads.

--- a/bin/test
+++ b/bin/test
@@ -33,6 +33,11 @@ RUBY=(ruby --yjit)
 NEXTEST_FEATURE_LIST=stress-spill-pool
 if [ "${SKIP_GC_STRESS:-0}" != "1" ]; then
   NEXTEST_FEATURE_LIST="$NEXTEST_FEATURE_LIST,gc-stress"
+  # Per-safepoint collection makes the heaviest JIT warm-up tests take minutes,
+  # so use the `gc-stress` nextest profile (a 20-min per-test cap instead of
+  # 10). Selected by env var rather than `--profile`, which `cargo llvm-cov`
+  # would consume as the *cargo* profile.
+  export NEXTEST_PROFILE=gc-stress
 fi
 NEXTEST_FEATURES=(--features "$NEXTEST_FEATURE_LIST")
 BENCH_FEATURES=(--features stress-spill-pool)

--- a/bin/test
+++ b/bin/test
@@ -21,16 +21,21 @@ RUBY=(ruby --yjit)
 # there — no pool allocation happens, which sidesteps the macOS-runner
 # `optcarrot --opt` divergence that the (non-empty) aarch64 pool path used to hit.
 #
-# SKIP_GC_STRESS=1 drops `gc-stress` (a collection per allocation) while
-# keeping the spill stress. The `darwin` job sets it: that runner was
-# finishing right at its per-attempt cap, and `gc-stress` is the single
-# biggest multiplier in the run. The Linux `amd64` job still runs with it,
-# so the GC paths stay covered on every push.
-STRESS_FEATURE_LIST=stress-spill-pool
+# `gc-stress` is now a true stress mode: the binary starts in `GC.stress`
+# and collects at EVERY safepoint. That is affordable for the unit/
+# integration tests (small snippets), but makes long-running workloads
+# quadratic-ish (a trivial 100K-allocation loop takes ~100 s), so the
+# benchmark / optcarrot / ruby-bench / ruby-spec phases build WITHOUT it
+# and keep only the spill stress. SKIP_GC_STRESS=1 drops `gc-stress` from
+# the nextest phase too; the `darwin` job sets it so the M1 runner stays
+# under its per-attempt cap. The Linux `amd64` job runs with it, so the
+# GC paths stay stress-covered on every push.
+NEXTEST_FEATURE_LIST=stress-spill-pool
 if [ "${SKIP_GC_STRESS:-0}" != "1" ]; then
-  STRESS_FEATURE_LIST="$STRESS_FEATURE_LIST,gc-stress"
+  NEXTEST_FEATURE_LIST="$NEXTEST_FEATURE_LIST,gc-stress"
 fi
-STRESS_FEATURES=(--features "$STRESS_FEATURE_LIST")
+NEXTEST_FEATURES=(--features "$NEXTEST_FEATURE_LIST")
+BENCH_FEATURES=(--features stress-spill-pool)
 
 # Coverage wrappers. SKIP_COV=1 runs the whole script without llvm-cov
 # instrumentation and uploads nothing. Used by the arm64 macOS `darwin` job:
@@ -93,11 +98,13 @@ fi
 
 phase "nextest (unit + integration tests)"
 cov_clean
-cov_nextest "${STRESS_FEATURES[@]}"
+cov_nextest "${NEXTEST_FEATURES[@]}"
 
-# Rebuild the benchmark binary with the stress features (x86-64 only).
+# Rebuild the benchmark binary WITHOUT `gc-stress` (see the feature-list
+# comment above): under true per-safepoint stress the benchmark/optcarrot/
+# spec phases would take hours. The feature change recompiles the lib once.
 phase "build benchmark binary"
-cov_build "${STRESS_FEATURES[@]}"
+cov_build "${BENCH_FEATURES[@]}"
 
 phase "benchmarks: app_fib / tarai / so_nbody"
 $MONORUBY benchmark/app_fib.rb > monoruby.log 2> /dev/null

--- a/bin/test
+++ b/bin/test
@@ -22,14 +22,19 @@ RUBY=(ruby --yjit)
 # `optcarrot --opt` divergence that the (non-empty) aarch64 pool path used to hit.
 #
 # `gc-stress` is now a true stress mode: the binary starts in `GC.stress`
-# and collects at EVERY safepoint. That is affordable for the unit/
-# integration tests (small snippets), but makes long-running workloads
+# and collects at EVERY safepoint. That makes long-running workloads
 # quadratic-ish (a trivial 100K-allocation loop takes ~100 s), so the
 # benchmark / optcarrot / ruby-bench / ruby-spec phases build WITHOUT it
 # and keep only the spill stress. SKIP_GC_STRESS=1 drops `gc-stress` from
-# the nextest phase too; the `darwin` job sets it so the M1 runner stays
-# under its per-attempt cap. The Linux `amd64` job runs with it, so the
-# GC paths stay stress-covered on every push.
+# the nextest phase too.
+#
+# BOTH automatic CI jobs now set SKIP_GC_STRESS=1: even limited to the
+# nextest phase the stress dominated the run (~10 min -> ~100 min on the
+# coverage-instrumented `amd64` job, and the M1 `darwin` runner was
+# finishing right at its per-attempt cap). Stress coverage for x86-64 AND
+# aarch64 lives in .github/workflows/gc-stress.yml, dispatched by hand.
+# A local `bin/test` still stress-tests by default — export
+# SKIP_GC_STRESS=1 if you want the fast path.
 NEXTEST_FEATURE_LIST=stress-spill-pool
 if [ "${SKIP_GC_STRESS:-0}" != "1" ]; then
   NEXTEST_FEATURE_LIST="$NEXTEST_FEATURE_LIST,gc-stress"

--- a/bin/test-aarch64
+++ b/bin/test-aarch64
@@ -19,8 +19,10 @@
 #                 optcarrot) と ruby/spec をスキップ
 #   SKIP_COV=1    cargo llvm-cov を経由せず素の cargo test/nextest を使う
 #                 (CI でカバレッジを集めないとき)
-#   STRESS=1      gc-stress / stress-spill-pool も付ける。
-#                 qemu-user では unit test だけで 4 時間級になるので注意。
+#   STRESS=1      gc-stress / stress-spill-pool も付ける。gc-stress は
+#                 真のストレスモード (毎セーフポイント GC) になったため、
+#                 qemu-user では unit test だけでも非現実的な時間になる。
+#                 実機 aarch64 での利用を想定。
 #   THREADS=N     `cargo test -- --test-threads=N` (既定: テストごとに既定)
 #
 # 実機 aarch64 ホストでは:

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -515,7 +515,7 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
 | --- | --- |
 | `gc-log` | 終了時に GC 統計を出力(old 数の実 popcount 等)。 |
 | `gc-debug` | GC 中の各種アサート・ダンプ。`old_count` と実 popcount の一致検証など。 |
-| `gc-stress` | **毎回のアロケーションで GC** を走らせる(`bin/test` が使用)。世代別のバリア/remembered set 漏れを最も強く炙り出す。 |
+| `gc-stress` | 起動時から `GC.stress` 相当: **毎セーフポイントで GC** を走らせる(`bin/test` の nextest フェーズが使用。CI では x86-64 のみ)。世代別のバリア/remembered set 漏れを最も強く炙り出す。 |
 | `gc-verify` | マイナー GC 後に独立フル再マークで健全性検証(§6.5)。 |
 
 環境変数 `MONORUBY_MALLOC_HARD_LIMIT`(例 `3G`。K/M/G サフィックス可)を設定すると、

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -515,7 +515,7 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
 | --- | --- |
 | `gc-log` | 終了時に GC 統計を出力(old 数の実 popcount 等)。 |
 | `gc-debug` | GC 中の各種アサート・ダンプ。`old_count` と実 popcount の一致検証など。 |
-| `gc-stress` | 起動時から `GC.stress` 相当: **毎セーフポイントで GC** を走らせる(`bin/test` の nextest フェーズが使用。CI では x86-64 のみ)。世代別のバリア/remembered set 漏れを最も強く炙り出す。 |
+| `gc-stress` | **毎セーフポイントで無条件に強制 GC**(実行時 `GC.stress` フラグとは独立。`execute_gc` が常に収集し、GC レーンを常時再アーム)。`bin/test` の nextest フェーズが使用(CI では x86-64 のみ)。世代別のバリア/remembered set 漏れや、Rust ローカルに保持したままの未ルート `Value` を最も強く炙り出す。 |
 | `gc-verify` | マイナー GC 後に独立フル再マークで健全性検証(§6.5)。 |
 
 環境変数 `MONORUBY_MALLOC_HARD_LIMIT`(例 `3G`。K/M/G サフィックス可)を設定すると、

--- a/docs/src/garbage-collection.md
+++ b/docs/src/garbage-collection.md
@@ -38,7 +38,7 @@ Safepoint polls (`compare alloc_flag; conditionally call gc`) are emitted at **c
 | `--no-gc` CLI flag | Disable GC for the process |
 | `GC.count` / `GC.stat` | Collection counters / CRuby-compatible stats |
 
-Debugging Cargo features: `gc-log` (stats at exit), `gc-debug` (assertions), `gc-stress` (collect on every allocation — used by `bin/test` in CI), `gc-verify` (independent re-mark verification after each minor GC).
+Debugging Cargo features: `gc-log` (stats at exit), `gc-debug` (assertions), `gc-stress` (start in `GC.stress` mode and collect at every safepoint — used by `bin/test`'s nextest phase on x86-64 CI), `gc-verify` (independent re-mark verification after each minor GC).
 
 ## Further reading
 

--- a/docs/src/garbage-collection.md
+++ b/docs/src/garbage-collection.md
@@ -38,7 +38,7 @@ Safepoint polls (`compare alloc_flag; conditionally call gc`) are emitted at **c
 | `--no-gc` CLI flag | Disable GC for the process |
 | `GC.count` / `GC.stat` | Collection counters / CRuby-compatible stats |
 
-Debugging Cargo features: `gc-log` (stats at exit), `gc-debug` (assertions), `gc-stress` (start in `GC.stress` mode and collect at every safepoint — used by `bin/test`'s nextest phase on x86-64 CI), `gc-verify` (independent re-mark verification after each minor GC).
+Debugging Cargo features: `gc-log` (stats at exit), `gc-debug` (assertions), `gc-stress` (force a collection at every safepoint, unconditionally — used by `bin/test`'s nextest phase on x86-64 CI), `gc-verify` (independent re-mark verification after each minor GC).
 
 ## Further reading
 

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -719,7 +719,11 @@ impl<T: GCBox> Allocator<T> {
             total_freed_pages: 0,
             profile_enabled: false,
             profile: Vec::new(),
-            stress: false,
+            // `gc-stress` builds start in `GC.stress` mode: the jit_module
+            // poll-word initializer arms the GC lane at startup, and the
+            // end-of-collection re-arm below keeps every safepoint
+            // collecting from then on.
+            stress: cfg!(feature = "gc-stress"),
             allow_full_mark: true,
         }
     }

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -168,10 +168,17 @@ pub(crate) fn set_gc_enabled(enabled: bool) {
     GC_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
-/// Set by `GC.start` so the next safepoint collection is a Major (full)
-/// one — running a collection inline from a builtin is unsafe, so
-/// `GC.start` asks for one at the next poll via [`request_gc`].
-static GC_FORCE_MAJOR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    /// Set by `GC.start` so the next safepoint collection is a Major
+    /// (full) one — running a collection inline from a builtin is
+    /// unsafe, so `GC.start` asks for one at the next poll via
+    /// [`request_gc`]. Thread-local like the allocator itself: each
+    /// test thread runs its own interpreter, and a process-global flag
+    /// let one thread's `GC.start` turn another thread's next
+    /// collection into a Major (observable through
+    /// `GC.stat(:major_gc_count)` — deterministic under `gc-stress`).
+    static GC_FORCE_MAJOR: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 /// Live bytes in tracked `malloc` buffers (`GC.stat`'s
 /// `malloc_increase_bytes`).
@@ -193,7 +200,7 @@ pub(crate) fn malloc_gc_threshold() -> usize {
 /// safe to call from inside a builtin.
 pub(crate) fn request_gc(force_major: bool) {
     if force_major {
-        GC_FORCE_MAJOR.store(true, Ordering::Relaxed);
+        GC_FORCE_MAJOR.with(|f| f.set(true));
     }
     crate::poll_flag::set_gc();
 }
@@ -1180,7 +1187,7 @@ impl<T: GCBox> Allocator<T> {
             return;
         }
         // A pending `GC.start` request forces a Major collection.
-        let kind = if GC_FORCE_MAJOR.swap(false, Ordering::Relaxed) || all_major_forced() {
+        let kind = if GC_FORCE_MAJOR.with(|f| f.replace(false)) || all_major_forced() {
             GcKind::Major
         } else {
             self.decide_gc_kind()

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -719,11 +719,12 @@ impl<T: GCBox> Allocator<T> {
             total_freed_pages: 0,
             profile_enabled: false,
             profile: Vec::new(),
-            // `gc-stress` builds start in `GC.stress` mode: the jit_module
-            // poll-word initializer arms the GC lane at startup, and the
-            // end-of-collection re-arm below keeps every safepoint
-            // collecting from then on.
-            stress: cfg!(feature = "gc-stress"),
+            // Note: `gc-stress` builds do NOT set this — the runtime
+            // `GC.stress` flag keeps CRuby-identical semantics. The
+            // feature forces a collection at every safepoint directly in
+            // `execute_gc` (see poll_flag::StressRearm), independent of
+            // this flag.
+            stress: false,
             allow_full_mark: true,
         }
     }

--- a/monoruby/src/builtins/argf.rs
+++ b/monoruby/src/builtins/argf.rs
@@ -228,8 +228,15 @@ fn force_stream(vm: &mut Executor, globals: &mut Globals, argf: Value) -> Result
                     stdin_value(globals)
                 } else {
                     let f = open_file(vm, globals, name)?;
-                    inplace_redirect(vm, globals, argf, name)?;
-                    f
+                    // The fresh File lives only in this Rust local while
+                    // `inplace_redirect` re-enters Ruby (`close`,
+                    // `File.open`) — root it until it lands in
+                    // `inner.current` below.
+                    vm.with_temp_scope(|vm| {
+                        vm.temp_push(f);
+                        inplace_redirect(vm, globals, argf, name)?;
+                        Ok(f)
+                    })?
                 };
                 let inner = expect_inner(argf)?;
                 inner.state = ArgfState::Reading;

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -837,10 +837,15 @@ fn and(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn or(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut lhs = Array::new_from_vec(lfp.self_val().as_array().to_vec());
-    let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
-    lhs.extend(rhs.iter().cloned());
-    lhs.uniq(vm, globals)?;
-    Ok(lhs.as_val())
+    // Root the fresh copy across `#to_ary` and `uniq`'s Ruby
+    // `hash`/`eql?` dispatches, like `Array#&` above.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(lhs.into());
+        let rhs = lfp.arg(0).coerce_to_array(vm, globals)?;
+        lhs.extend(rhs.iter().cloned());
+        lhs.uniq(vm, globals)?;
+        Ok(lhs.as_val())
+    })
 }
 
 ///
@@ -3663,30 +3668,34 @@ fn rotate(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[monoruby_builtin]
 fn product(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs = lfp.self_val().as_array();
-    let mut lists = vec![];
-    for rhs in lfp.arg(0).as_array().into_iter() {
-        lists.push(rhs.coerce_to_array(vm, globals)?);
-    }
-    // Check total product size to avoid memory exhaustion.
-    let mut total: usize = lhs.len();
-    for l in &lists {
-        total = total
-            .checked_mul(l.len())
-            .ok_or_else(|| MonorubyErr::rangeerr("too big to product"))?;
-        if total > 1_000_000 {
-            return Err(MonorubyErr::rangeerr("too big to product"));
+    // `#to_ary` may hand back fresh Arrays that only this Rust Vec (and
+    // later the lazy iterator) reference; root each across the remaining
+    // coercions and the block calls below.
+    vm.with_temp_scope(|vm| {
+        let mut lists = vec![];
+        for rhs in lfp.arg(0).as_array().into_iter() {
+            let list = rhs.coerce_to_array(vm, globals)?;
+            vm.temp_push(list.into());
+            lists.push(list);
         }
-    }
-    let iter = product_inner(lhs, lists);
-    if let Some(bh) = lfp.block() {
-        //let ary = Array::new_from_vec(v);
-        //vm.temp_push(ary.into());
-        vm.invoke_block_iter1(globals, bh, iter)?;
-        //vm.temp_pop();
-        Ok(lfp.self_val())
-    } else {
-        Ok(Value::array_from_iter(iter))
-    }
+        // Check total product size to avoid memory exhaustion.
+        let mut total: usize = lhs.len();
+        for l in &lists {
+            total = total
+                .checked_mul(l.len())
+                .ok_or_else(|| MonorubyErr::rangeerr("too big to product"))?;
+            if total > 1_000_000 {
+                return Err(MonorubyErr::rangeerr("too big to product"));
+            }
+        }
+        let iter = product_inner(lhs, lists);
+        if let Some(bh) = lfp.block() {
+            vm.invoke_block_iter1(globals, bh, iter)?;
+            Ok(lfp.self_val())
+        } else {
+            Ok(Value::array_from_iter(iter))
+        }
+    })
 }
 
 fn product_inner(lhs: Array, rhs: Vec<Array>) -> impl Iterator<Item = Value> {
@@ -3722,12 +3731,17 @@ fn product_inner(lhs: Array, rhs: Vec<Array>) -> impl Iterator<Item = Value> {
 #[monoruby_builtin]
 fn union(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut ary = Array::new_from_vec(lfp.self_val().as_array().to_vec());
-    for rhs in lfp.arg(0).as_array().into_iter() {
-        let rhs = rhs.coerce_to_array(vm, globals)?;
-        ary.extend(rhs.into_iter().cloned());
-    }
-    ary.uniq(vm, globals)?;
-    Ok(ary.into())
+    // Root the accumulator across `#to_ary` and `uniq`'s Ruby
+    // `hash`/`eql?` dispatches, like `Array#intersection`.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(ary.into());
+        for rhs in lfp.arg(0).as_array().into_iter() {
+            let rhs = rhs.coerce_to_array(vm, globals)?;
+            ary.extend(rhs.into_iter().cloned());
+        }
+        ary.uniq(vm, globals)?;
+        Ok(ary.into())
+    })
 }
 
 ///
@@ -3739,24 +3753,32 @@ fn union(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 #[monoruby_builtin]
 fn difference(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs_v = lfp.self_val();
-    let others: Vec<_> = lfp
-        .arg(0)
-        .as_array()
-        .iter()
-        .map(|v| v.coerce_to_array(vm, globals))
-        .collect::<Result<Vec<_>>>()?;
-    let mut v = vec![];
-    'outer: for lhs in lhs_v.as_array().iter() {
-        for other in &others {
-            for rhs in other.iter() {
-                if lhs.eql(rhs, vm, globals)? {
-                    continue 'outer;
+    // `#to_ary` may hand back fresh Arrays referenced only by this Rust
+    // Vec; root each across the later coercions and `eql?` dispatches.
+    vm.with_temp_scope(|vm| {
+        let others: Vec<_> = lfp
+            .arg(0)
+            .as_array()
+            .iter()
+            .map(|v| {
+                let a = v.coerce_to_array(vm, globals)?;
+                vm.temp_push(a.into());
+                Ok(a)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut v = vec![];
+        'outer: for lhs in lhs_v.as_array().iter() {
+            for other in &others {
+                for rhs in other.iter() {
+                    if lhs.eql(rhs, vm, globals)? {
+                        continue 'outer;
+                    }
                 }
             }
+            v.push(*lhs);
         }
-        v.push(*lhs);
-    }
-    Ok(Value::array_from_vec(v))
+        Ok(Value::array_from_vec(v))
+    })
 }
 
 ///
@@ -3811,14 +3833,20 @@ fn intersection(
 #[monoruby_builtin]
 fn intersect_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let lhs = lfp.self_val().as_array();
-    for rhs in lfp.arg(0).coerce_to_array(vm, globals)?.iter().cloned() {
-        for lhs in lhs.iter().cloned() {
-            if lhs.eql(&rhs, vm, globals)? {
-                return Ok(Value::bool(true));
+    let rhs_ary = lfp.arg(0).coerce_to_array(vm, globals)?;
+    // A fresh `#to_ary` result is referenced only by this Rust local;
+    // root it across the `eql?` dispatches below.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(rhs_ary.into());
+        for rhs in rhs_ary.iter().cloned() {
+            for lhs in lhs.iter().cloned() {
+                if lhs.eql(&rhs, vm, globals)? {
+                    return Ok(Value::bool(true));
+                }
             }
         }
-    }
-    Ok(Value::bool(false))
+        Ok(Value::bool(false))
+    })
 }
 
 ///
@@ -3835,8 +3863,13 @@ fn uniq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     match lfp.block() {
         None => {
             let mut ary = Array::new_from_vec(lfp.self_val().as_array().to_vec());
-            ary.uniq(vm, globals)?;
-            Ok(ary.into())
+            // Root the fresh copy across `uniq`'s Ruby `hash`/`eql?`
+            // dispatches.
+            vm.with_temp_scope(|vm| {
+                vm.temp_push(ary.into());
+                ary.uniq(vm, globals)?;
+                Ok(ary.into())
+            })
         }
         Some(bh) => vm.with_temp_scope(|vm| {
             let data = vm.get_block_data(globals, bh)?;

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -4392,13 +4392,23 @@ mod tests {
         // GC skips scanning it, and all of its elements are swept while
         // still reachable — a later read then trips `Dead object`. The
         // allocation churn after the build is what forces that minor GC.
-        run_test_once(
+        //
+        // The large sizes exist only to trigger that GC organically in a
+        // normal build; under gc-stress every safepoint already collects,
+        // and marking a 300k-element array per safepoint would take >10min
+        // on CI, so the stress build uses a small workload instead.
+        let (build, churn) = if cfg!(feature = "gc-stress") {
+            (2_000, 1_000)
+        } else {
+            (300_000, 200_000)
+        };
+        run_test_once(&format!(
             r#"
-            a = Array.new(300_000) { |i| [i % 1000] }
-            200_000.times { [1] }
-            a.map { |x| x[0] }.sum
-            "#,
-        );
+            a = Array.new({build}) {{ |i| [i % 1000] }}
+            {churn}.times {{ [1] }}
+            a.map {{ |x| x[0] }}.sum
+            "#
+        ));
     }
 
     #[test]
@@ -4407,14 +4417,23 @@ mod tests {
         // elements while `merge` overwrites their slots in the receiver,
         // and the comparator can allocate (and thus GC) right in that
         // window — so the buffer itself has to be GC-visible.
-        run_test_once(
+        //
+        // As above: the large size makes a GC land in that window by
+        // chance in a normal build, while under gc-stress every safepoint
+        // collects anyway and a large sort would run for >10min on CI.
+        let n = if cfg!(feature = "gc-stress") {
+            2_000
+        } else {
+            200_000
+        };
+        run_test_once(&format!(
             r#"
             a = []
-            200_000.times { |i| a << [(i * 7919) % 1000] }
-            a.sort! { |x, y| [x[0]] <=> [y[0]] }
+            {n}.times {{ |i| a << [(i * 7919) % 1000] }}
+            a.sort! {{ |x, y| [x[0]] <=> [y[0]] }}
             [a.size, a.first[0], a.last[0]]
-            "#,
-        );
+            "#
+        ));
     }
 
     #[test]

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -184,10 +184,17 @@ fn foreach(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
         .map(|n| super::io::tag_with_encs(globals, n, enc_obj, None))
         .collect();
     let p = vm.get_block_data(globals, bh)?;
-    for name in entries {
-        vm.invoke_block(globals, &p, &[name])?;
-    }
-    Ok(Value::nil())
+    // Root the not-yet-yielded name strings: the block body reaches
+    // safepoints, and a bare Rust `Vec<Value>` is invisible to the GC
+    // mark phase (caught by the true `gc-stress` mode).
+    vm.with_temp_scope(|vm| {
+        vm.temp_array_new(entries.len());
+        vm.temp_array_extend_from_slice(&entries);
+        for name in entries {
+            vm.invoke_block(globals, &p, &[name])?;
+        }
+        Ok(Value::nil())
+    })
 }
 
 ///

--- a/monoruby/src/builtins/encoding.rs
+++ b/monoruby/src/builtins/encoding.rs
@@ -2140,21 +2140,6 @@ fn converter_new(
         ));
     }
     validate_converter_pair(src, dst, &globals.store)?;
-    let class = lfp.self_val();
-    let obj = Value::object(class.as_class_id());
-    // Stash the encodings as their canonical *names* so
-    // `encoding_value` and `try_from_str` can round-trip without
-    // a separate Encoding-to-id table.
-    let _ = globals.store.set_ivar(
-        obj,
-        IdentId::get_id(CONVERTER_SRC_IVAR),
-        Value::string_from_str(src.name()),
-    );
-    let _ = globals.store.set_ivar(
-        obj,
-        IdentId::get_id(CONVERTER_DST_IVAR),
-        Value::string_from_str(dst.name()),
-    );
     // Options Hash (`replace:` kwargs / `**opts` / trailing Hash).
     // With `kw_rest=true` the collected kwargs Hash is delivered in
     // the slot after the positional args (index 3 here); a literal
@@ -2168,6 +2153,7 @@ fn converter_new(
     // `INVALID_REPLACE` / `UNDEF_REPLACE` bitmask) or
     // `invalid:`/`undef: :replace` kwargs.
     let mut flags: i64 = 0;
+    let mut replace_inner: Option<crate::value::RStringInner> = None;
     if let Some(n) = lfp.try_arg(2).and_then(|v| v.try_fixnum()) {
         if n & 0x0000_0002 != 0 {
             flags |= CONVERTER_FLAG_INVALID_REPLACE;
@@ -2207,7 +2193,11 @@ fn converter_new(
                 if !rep.is_nil() {
                     // CRuby coerces via `#to_str`; a non-String
                     // return or an object without `#to_str`
-                    // (true/false/Integer) raises TypeError.
+                    // (true/false/Integer) raises TypeError. This
+                    // re-enters Ruby, so it runs BEFORE the converter
+                    // object exists — holding the fresh object in a
+                    // Rust local across `#to_str` left it invisible
+                    // to the GC (caught by true `gc-stress`).
                     let s = if let Some(st) = rep.is_str() {
                         st.to_string()
                     } else {
@@ -2215,14 +2205,33 @@ fn converter_new(
                     };
                     let mut inner = crate::value::RStringInner::from_string_scanned(s);
                     inner.set_encoding(dst);
-                    let _ = globals.store.set_ivar(
-                        obj,
-                        IdentId::get_id(CONVERTER_REPLACE_IVAR),
-                        Value::string_from_inner(inner),
-                    );
+                    replace_inner = Some(inner);
                 }
             }
         }
+    }
+    let class = lfp.self_val();
+    let obj = Value::object(class.as_class_id());
+    // Stash the encodings as their canonical *names* so
+    // `encoding_value` and `try_from_str` can round-trip without
+    // a separate Encoding-to-id table. `set_ivar` never re-enters
+    // Ruby, so `obj` needs no temp-stack rooting here.
+    let _ = globals.store.set_ivar(
+        obj,
+        IdentId::get_id(CONVERTER_SRC_IVAR),
+        Value::string_from_str(src.name()),
+    );
+    let _ = globals.store.set_ivar(
+        obj,
+        IdentId::get_id(CONVERTER_DST_IVAR),
+        Value::string_from_str(dst.name()),
+    );
+    if let Some(inner) = replace_inner {
+        let _ = globals.store.set_ivar(
+            obj,
+            IdentId::get_id(CONVERTER_REPLACE_IVAR),
+            Value::string_from_inner(inner),
+        );
     }
     if flags != 0 {
         let _ = globals.store.set_ivar(

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -611,8 +611,10 @@ fn exception_method(
     if arg.id() == self_v.id() {
         return Ok(self_v);
     }
-    let mut new_exc = self_v.dup();
+    // Coerce first: `#to_s` re-enters Ruby, and the dup would live only
+    // in a Rust local across it.
     let msg = arg.coerce_to_string(vm, globals)?;
+    let mut new_exc = self_v.dup();
     new_exc.is_exception_mut().unwrap().set_message(msg);
     Ok(new_exc)
 }

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -1362,33 +1362,47 @@ fn open_impl(
             effective_autoclose,
         );
         let res = Value::new_io_with_class(io_inner, FILE_CLASS);
-        let mode_for_enc = lfp
-            .try_arg(1)
-            .and_then(|a| a.is_str().map(|s| s.to_string()))
-            .unwrap_or_else(|| {
-                match (readable, writable) {
-                    (true, true) => "r+",
-                    (false, true) => "w",
-                    _ => "r",
+        // The fresh File is referenced only by this Rust local while
+        // `init_io_encodings` / `ruby_warn` re-enter Ruby — root it.
+        return vm.with_temp_scope(|vm| {
+            vm.temp_push(res);
+            let mode_for_enc = lfp
+                .try_arg(1)
+                .and_then(|a| a.is_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| {
+                    match (readable, writable) {
+                        (true, true) => "r+",
+                        (false, true) => "w",
+                        _ => "r",
+                    }
+                    .to_string()
+                });
+            super::io::init_io_encodings(
+                vm,
+                globals,
+                lfp,
+                res,
+                &mode_for_enc,
+                readable,
+                1..3,
+                kw_hash,
+            )?;
+            if let Some(bh) = lfp.block() {
+                if is_new {
+                    vm.ruby_warn(
+                        globals,
+                        "warning: File::new() does not take block; use File::open() instead",
+                    )?;
+                    return Ok(res);
                 }
-                .to_string()
-            });
-        super::io::init_io_encodings(vm, globals, lfp, res, &mode_for_enc, readable, 1..3, kw_hash)?;
-        if let Some(bh) = lfp.block() {
-            if is_new {
-                vm.ruby_warn(
-                    globals,
-                    "warning: File::new() does not take block; use File::open() instead",
-                )?;
-                return Ok(res);
+                let r = vm.invoke_block_once(globals, bh, &[res]);
+                // Match CRuby File.open(...) {|io| ... }: close at block exit.
+                // Holding the underlying fd open across blocks defeats `flock`
+                // (rubygems' open_with_flock relies on this) and leaks fds.
+                return block_close(vm, globals, res, r);
             }
-            let r = vm.invoke_block_once(globals, bh, &[res]);
-            // Match CRuby File.open(...) {|io| ... }: close at block exit.
-            // Holding the underlying fd open across blocks defeats `flock`
-            // (rubygems' open_with_flock relies on this) and leaks fds.
-            return block_close(vm, globals, res, r);
-        }
-        return Ok(res);
+            Ok(res)
+        });
     }
 
     // Resolve the open mode into open(2) flags. Precedence (CRuby):
@@ -1515,20 +1529,25 @@ fn open_impl(
         readable,
         writable,
     );
-    super::io::init_io_encodings(vm, globals, lfp, res, &mode, readable, 1..3, kw_hash)?;
-    if let Some(bh) = lfp.block() {
-        if is_new {
-            vm.ruby_warn(
-                globals,
-                "warning: File::new() does not take block; use File::open() instead",
-            )?;
-            return Ok(res);
+    // The fresh File is referenced only by this Rust local while
+    // `init_io_encodings` / `ruby_warn` re-enter Ruby — root it.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(res);
+        super::io::init_io_encodings(vm, globals, lfp, res, &mode, readable, 1..3, kw_hash)?;
+        if let Some(bh) = lfp.block() {
+            if is_new {
+                vm.ruby_warn(
+                    globals,
+                    "warning: File::new() does not take block; use File::open() instead",
+                )?;
+                return Ok(res);
+            }
+            let r = vm.invoke_block_once(globals, bh, &[res]);
+            // CRuby File.open(...) {|io| ... } closes the file at block exit.
+            return block_close(vm, globals, res, r);
         }
-        let r = vm.invoke_block_once(globals, bh, &[res]);
-        // CRuby File.open(...) {|io| ... } closes the file at block exit.
-        return block_close(vm, globals, res, r);
-    }
-    Ok(res)
+        Ok(res)
+    })
 }
 
 ///

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -4285,4 +4285,61 @@ mod tests {
             "#,
         );
     }
+
+    /// `File.new` / `File.open` given a raw file descriptor. The fresh File
+    /// is reachable only from a Rust local while `init_io_encodings` and
+    /// the `File::new() does not take block` warning re-enter Ruby, which
+    /// is what the rooting guards. Also covers the encoding-mode default
+    /// derived from the fd's access mode when no String mode is passed.
+    #[test]
+    fn file_from_fd_modes_and_block() {
+        run_test_once(
+            r#"
+            path = "/tmp/mono_cov_file_fd_#{Process.pid}"
+            begin
+              File.write(path, "hello")
+              # Read-only fd, no mode argument -> "r".
+              f = File.new(IO.sysopen(path, "r"))
+              a = [f.class, f.read]
+              f.close
+              # Write-only fd -> "w"; read-write fd -> "r+".
+              f = File.new(IO.sysopen(path, "w"))
+              b = f.class
+              f.close
+              f = File.new(IO.sysopen(path, "r+"))
+              c = f.class
+              f.close
+              # File.open(fd) with a block closes the File at block exit.
+              d = File.open(IO.sysopen(path, "r")) { |io| io.read }
+              # File.new(fd) with a block warns and ignores the block.
+              f = File.new(IO.sysopen(path, "r")) { |io| :never_called }
+              e = [f.class, f.read]
+              f.close
+              [a, b, c, d, e]
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
+
+    /// `File.new(path)` given a block warns and ignores it, returning the
+    /// open File (the block form is `File.open`).
+    #[test]
+    fn file_new_with_block_warns() {
+        run_test_once(
+            r#"
+            path = "/tmp/mono_cov_file_new_#{Process.pid}"
+            begin
+              File.write(path, "hello")
+              f = File.new(path, "r") { |io| :never_called }
+              res = [f.class, f.read]
+              f.close
+              res
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -668,20 +668,29 @@ mod tests {
     fn gc_config_suppresses_self_chosen_major() {
         // With full marking off the collector only ever picks a minor
         // collection; an explicit `GC.start` still forces a major.
-        run_test_once(
+        //
+        // The big loop exists to organically drive collections in a normal
+        // build; under gc-stress every safepoint collects already, and the
+        // full-size loop runs for >5min on CI.
+        let n = if cfg!(feature = "gc-stress") {
+            5_000
+        } else {
+            200_000
+        };
+        run_test_once(&format!(
             r##"
             GC.config(rgengc_allow_full_mark: false)
             begin
               major = GC.stat(:major_gc_count)
-              200000.times { Object.new }
+              {n}.times {{ Object.new }}
               a = GC.stat(:major_gc_count) == major
               GC.start
               [a, GC.stat(:major_gc_count) > major]
             ensure
               GC.config(rgengc_allow_full_mark: true)
             end
-            "##,
-        );
+            "##
+        ));
     }
 
     #[test]

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4619,4 +4619,84 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn hash_sort_with_comparator_block() {
+        // `Hash#sort` with a block sorts the freshly built [k, v] pair
+        // Arrays with a Ruby comparator — the pairs live only in a Rust
+        // Vec while that block runs, which is what the rooting covers.
+        // All three comparator outcomes (<0, >0 and 0) are exercised.
+        run_test(
+            r#"
+            h = { "b" => 2, "a" => 1, "c" => 3 }
+            [
+              h.sort { |x, y| x[0] <=> y[0] },
+              h.sort { |x, y| y[1] <=> x[1] },
+              h.sort { |x, y| 0 },
+            ]
+            "#,
+        );
+        // A comparator that raises propagates the error out of the sort.
+        run_test(
+            r#"
+            h = { "b" => 2, "a" => 1 }
+            begin
+              h.sort { |x, y| raise ArgumentError, "boom" }
+            rescue ArgumentError => e
+              [e.class, e.message]
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn hash_to_h_with_block() {
+        // `Hash#to_h` with a block accumulates the block's fresh return
+        // Arrays into a new Hash; a return value that is not a 2-element
+        // Array is a TypeError / ArgumentError.
+        run_test(
+            r#"
+            h = { a: 1, b: 2 }
+            [
+              h.to_h { |k, v| [k.to_s, v * 10] },
+              h.to_h { |k, v| [v, k] },
+              {}.to_h { |k, v| [k, v] },
+              h.to_h,
+            ]
+            "#,
+        );
+        run_test(
+            r#"
+            h = { a: 1 }
+            [
+              (begin; h.to_h { |k, v| [1, 2, 3] }; rescue => e; e.class; end),
+              (begin; h.to_h { |k, v| 5 }; rescue => e; e.class; end),
+            ]
+            "#,
+        );
+    }
+
+    #[test]
+    fn env_fetch_default_block_and_missing() {
+        // `ENV.fetch` coerces the key to a fresh String and keeps it alive
+        // across the `warn` call and the Ruby dispatches inside `get`.
+        // Covers all four outcomes: hit, default argument, block, and the
+        // block-supersedes-default warning path.
+        run_test(
+            r#"
+            ENV["MONORUBY_COV_FETCH"] = "hit"
+            res = [
+              ENV.fetch("MONORUBY_COV_FETCH"),
+              ENV.fetch("MONORUBY_COV_ABSENT", "dflt"),
+              ENV.fetch("MONORUBY_COV_FETCH", "dflt"),
+              ENV.fetch("MONORUBY_COV_ABSENT") { |k| "blk:#{k}" },
+              ENV.fetch("MONORUBY_COV_FETCH") { |k| "blk:#{k}" },
+              ENV.fetch("MONORUBY_COV_ABSENT", "dflt") { |k| "block wins" },
+              (begin; ENV.fetch("MONORUBY_COV_ABSENT"); rescue KeyError => e; e.class; end),
+            ]
+            ENV.delete("MONORUBY_COV_FETCH")
+            res
+            "#,
+        );
+    }
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1398,33 +1398,40 @@ fn reject_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
 #[monoruby_builtin]
 fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let hash = lfp.self_val().as_hash();
-    let mut pairs: Vec<Value> = hash
-        .iter()
-        .map(|(k, v)| Value::array2(k, v))
-        .collect();
     if let Some(bh) = lfp.block() {
+        let mut pairs: Vec<Value> = hash
+            .iter()
+            .map(|(k, v)| Value::array2(k, v))
+            .collect();
         let data = vm.get_block_data(globals, bh)?;
-        // Stable sort with a comparator block.
-        let mut err: Option<MonorubyErr> = None;
-        pairs.sort_by(|a, b| {
-            if err.is_some() {
-                return std::cmp::Ordering::Equal;
-            }
-            match vm.invoke_block(globals, &data, &[*a, *b]) {
-                Ok(r) => match r.try_fixnum() {
-                    Some(n) if n < 0 => std::cmp::Ordering::Less,
-                    Some(n) if n > 0 => std::cmp::Ordering::Greater,
-                    _ => std::cmp::Ordering::Equal,
-                },
-                Err(e) => {
-                    err = Some(e);
-                    std::cmp::Ordering::Equal
+        // Root the pending pair Arrays: the comparator block runs
+        // arbitrary Ruby while they live only in this Rust Vec.
+        vm.with_temp_scope(|vm| {
+            vm.temp_array_new(pairs.len());
+            vm.temp_array_extend_from_slice(&pairs);
+            // Stable sort with a comparator block.
+            let mut err: Option<MonorubyErr> = None;
+            pairs.sort_by(|a, b| {
+                if err.is_some() {
+                    return std::cmp::Ordering::Equal;
                 }
+                match vm.invoke_block(globals, &data, &[*a, *b]) {
+                    Ok(r) => match r.try_fixnum() {
+                        Some(n) if n < 0 => std::cmp::Ordering::Less,
+                        Some(n) if n > 0 => std::cmp::Ordering::Greater,
+                        _ => std::cmp::Ordering::Equal,
+                    },
+                    Err(e) => {
+                        err = Some(e);
+                        std::cmp::Ordering::Equal
+                    }
+                }
+            });
+            if let Some(e) = err {
+                return Err(e);
             }
-        });
-        if let Some(e) = err {
-            return Err(e);
-        }
+            Ok(Value::array_from_vec(pairs))
+        })
     } else {
         let mut keys = hash.keys();
         // Root the merge buffer (see `Array::sort_inner`): the hash keeps
@@ -1441,12 +1448,19 @@ fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             };
             vm.sort(globals, &mut keys, buf)
         })?;
-        pairs = keys
-            .iter()
-            .map(|&k| Value::array2(k, hash.get(k, vm, globals).unwrap().unwrap()))
-            .collect();
+        // Each fresh pair must survive the Ruby `hash`/`eql?` dispatch
+        // inside `hash.get` for the following keys — accumulate into a
+        // rooted Array instead of a bare Rust Vec.
+        vm.with_temp_scope(|vm| {
+            vm.temp_array_new(keys.len());
+            let idx = vm.temp_len() - 1;
+            for &k in keys.iter() {
+                let v = hash.get(k, vm, globals)?.unwrap();
+                vm.temp_array_push(Value::array2(k, v));
+            }
+            Ok(vm.temp_at(idx))
+        })
     }
-    Ok(Value::array_from_vec(pairs))
 }
 
 ///
@@ -1512,6 +1526,12 @@ fn invert(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 #[monoruby_builtin]
 fn merge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut h = lfp.self_val().dup().as_hash();
+    // The dup is a fresh Hash referenced only by this Rust local; root it
+    // across `#to_hash`, the block calls, and the Ruby `hash`/`eql?`
+    // dispatches inside get/insert (contrast `merge!`, where `h` is the
+    // frame-rooted receiver).
+    vm.with_temp_scope(|vm| {
+    vm.temp_push(h.into());
     if let Some(block) = lfp.block() {
         let data = vm.get_block_data(globals, block)?;
         for arg in lfp.arg(0).as_array().iter() {
@@ -1535,6 +1555,7 @@ fn merge(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     }
 
     Ok(h.into())
+    })
 }
 
 ///
@@ -1654,18 +1675,24 @@ fn to_h(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         let data = vm.get_block_data(globals, bh)?;
         let hash = lfp.self_val().as_hash();
         let pairs: Vec<(Value, Value)> = hash.iter().collect();
-        let mut new_map = RubyMap::default();
-        for (k, v) in pairs {
-            let result = vm.invoke_block(globals, &data, &[k, v])?;
-            let arr = result.expect_array_ty(globals)?;
-            if arr.len() != 2 {
-                return Err(MonorubyErr::typeerr(
-                    "wrong element type (expected array with 2 elements)",
-                ));
+        // Accumulate into a rooted Ruby Hash (not a bare Rust RubyMap):
+        // the entries come from the block's fresh return Arrays and must
+        // survive the following block calls.
+        vm.with_temp_scope(|vm| {
+            vm.temp_push(Value::hash(RubyMap::default()));
+            let map_idx = vm.temp_len() - 1;
+            for (k, v) in pairs {
+                let result = vm.invoke_block(globals, &data, &[k, v])?;
+                let arr = result.expect_array_ty(globals)?;
+                if arr.len() != 2 {
+                    return Err(MonorubyErr::typeerr(
+                        "wrong element type (expected array with 2 elements)",
+                    ));
+                }
+                vm.temp_at(map_idx).as_hash().insert(arr[0], arr[1], vm, globals)?;
             }
-            new_map.insert(arr[0], arr[1], vm, globals)?;
-        }
-        Ok(Value::hash(new_map))
+            Ok(vm.temp_at(map_idx))
+        })
     } else {
         Ok(lfp.self_val())
     }
@@ -1722,35 +1749,41 @@ fn env_fetch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         let s = arg0.coerce_to_str(vm, globals)?;
         Value::string(s)
     };
-    let hash = lfp.self_val().as_hash();
-    let s = if let Some(bh) = lfp.block() {
-        if lfp.try_arg(1).is_some() {
-            let warn_id = IdentId::get_id("warn");
-            let msg = Value::string_from_str("warning: block supersedes default value argument");
-            vm.invoke_method_inner(globals, warn_id, lfp.self_val(), &[msg], None, None)?;
-        }
-        match hash.get(key, vm, globals)? {
-            Some(v) => v,
-            None => vm.invoke_block_once(globals, bh, &[key])?,
-        }
-    } else if let Some(arg1) = lfp.try_arg(1) {
-        match hash.get(key, vm, globals)? {
-            Some(v) => v,
-            None => arg1,
-        }
-    } else {
-        match hash.get(key, vm, globals)? {
-            Some(v) => v,
-            None => {
-                return Err(MonorubyErr::keyerr_with(
-                    format!("key not found: {}", key.inspect(&globals.store)),
-                    lfp.self_val(),
-                    key,
-                ));
+    // A coerced key is a fresh String referenced only by this Rust local;
+    // root it across the `warn` call and the Ruby dispatches in `get`.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(key);
+        let hash = lfp.self_val().as_hash();
+        let s = if let Some(bh) = lfp.block() {
+            if lfp.try_arg(1).is_some() {
+                let warn_id = IdentId::get_id("warn");
+                let msg =
+                    Value::string_from_str("warning: block supersedes default value argument");
+                vm.invoke_method_inner(globals, warn_id, lfp.self_val(), &[msg], None, None)?;
             }
-        }
-    };
-    Ok(s)
+            match hash.get(key, vm, globals)? {
+                Some(v) => v,
+                None => vm.invoke_block_once(globals, bh, &[key])?,
+            }
+        } else if let Some(arg1) = lfp.try_arg(1) {
+            match hash.get(key, vm, globals)? {
+                Some(v) => v,
+                None => arg1,
+            }
+        } else {
+            match hash.get(key, vm, globals)? {
+                Some(v) => v,
+                None => {
+                    return Err(MonorubyErr::keyerr_with(
+                        format!("key not found: {}", key.inspect(&globals.store)),
+                        lfp.self_val(),
+                        key,
+                    ));
+                }
+            }
+        };
+        Ok(s)
+    })
 }
 
 ///
@@ -1779,7 +1812,12 @@ fn env_to_hash(
         let data = vm.get_block_data(globals, bh)?;
         let hash = lfp.self_val().as_hash();
         let pairs: Vec<(Value, Value)> = hash.iter().collect();
-        let mut new_map = RubyMap::default();
+        // Accumulate into a rooted Ruby Hash (not a bare Rust RubyMap):
+        // the entries come from the block's fresh return Arrays and must
+        // survive the following block calls.
+        return vm.with_temp_scope(|vm| {
+        vm.temp_push(Value::hash(RubyMap::default()));
+        let map_idx = vm.temp_len() - 1;
         for (k, v) in pairs {
             let result = vm.invoke_block(globals, &data, &[k, v])?;
             // CRuby coerces the block's return value to an Array *only* via
@@ -1810,9 +1848,10 @@ fn env_to_hash(
                     arr.len(),
                 )));
             }
-            new_map.insert(arr[0], arr[1], vm, globals)?;
+            vm.temp_at(map_idx).as_hash().insert(arr[0], arr[1], vm, globals)?;
         }
-        return Ok(Value::hash(new_map));
+        Ok(vm.temp_at(map_idx))
+        });
     }
     let inner = lfp.self_val().as_hashmap_inner().clone_inner();
     Ok(Value::hash_from_inner(inner))
@@ -1955,22 +1994,28 @@ fn env_delete(
     let key_val = lfp.arg(0);
     let key = coerce_env_string(key_val, vm, globals)?;
     let key_v = Value::string(key.clone());
-    let removed = lfp.self_val().as_hash().remove(key_v, vm, globals)?;
+    // `key_v` is a fresh String referenced only by this Rust local; root
+    // it across the Ruby dispatches in `remove` (it is passed to the
+    // block afterwards).
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(key_v);
+        let removed = lfp.self_val().as_hash().remove(key_v, vm, globals)?;
 
-    let c_key = std::ffi::CString::new(key.as_bytes())
-        .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
-    // SAFETY: `c_key` is a NUL-terminated C string whose storage outlives
-    // this call. `unsetenv` is a no-op if the variable is not set.
-    unsafe {
-        libc::unsetenv(c_key.as_ptr());
-    }
+        let c_key = std::ffi::CString::new(key.as_bytes())
+            .map_err(|_| MonorubyErr::argumenterr("bare \\0 in env"))?;
+        // SAFETY: `c_key` is a NUL-terminated C string whose storage outlives
+        // this call. `unsetenv` is a no-op if the variable is not set.
+        unsafe {
+            libc::unsetenv(c_key.as_ptr());
+        }
 
-    if removed.is_none()
-        && let Some(bh) = lfp.block()
-    {
-        return vm.invoke_block_once(globals, bh, &[key_v]);
-    }
-    Ok(removed.unwrap_or_default())
+        if removed.is_none()
+            && let Some(bh) = lfp.block()
+        {
+            return vm.invoke_block_once(globals, bh, &[key_v]);
+        }
+        Ok(removed.unwrap_or_default())
+    })
 }
 
 ///
@@ -2232,9 +2277,18 @@ fn env_merge_bang(
 
             if let Some(ref data) = block_data {
                 let key_v = Value::string(key.clone());
-                if let Some(old_v) = lfp.self_val().as_hash().get(key_v, vm, globals)? {
-                    let new_v = Value::string(value.clone());
-                    let result = vm.invoke_block(globals, data, &[key_v, old_v, new_v])?;
+                // `key_v` must survive the Ruby dispatches inside `get`
+                // — it is passed to the block afterwards.
+                let result = vm.with_temp_scope(|vm| {
+                    vm.temp_push(key_v);
+                    if let Some(old_v) = lfp.self_val().as_hash().get(key_v, vm, globals)? {
+                        let new_v = Value::string(value.clone());
+                        Ok(Some(vm.invoke_block(globals, data, &[key_v, old_v, new_v])?))
+                    } else {
+                        Ok(None)
+                    }
+                })?;
+                if let Some(result) = result {
                     value = coerce_env_string(result, vm, globals)?;
                 }
             }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4637,9 +4637,11 @@ mod tests {
             "#,
         );
         // A comparator that raises propagates the error out of the sort.
+        // Enough pairs that the sort keeps asking after the first raise, so
+        // the "an error is already pending" short-circuit is taken too.
         run_test(
             r#"
-            h = { "b" => 2, "a" => 1 }
+            h = { "d" => 4, "b" => 2, "a" => 1, "c" => 3, "e" => 5 }
             begin
               h.sort { |x, y| raise ArgumentError, "boom" }
             rescue ArgumentError => e
@@ -4651,9 +4653,13 @@ mod tests {
 
     #[test]
     fn hash_to_h_with_block() {
-        // `Hash#to_h` with a block accumulates the block's fresh return
-        // Arrays into a new Hash; a return value that is not a 2-element
-        // Array is a TypeError / ArgumentError.
+        // NOTE: this exercises the *Ruby-level* `Hash#to_h` in
+        // `monoruby/builtins/hash.rb`, which reopens `class Hash` at startup
+        // and shadows the Rust builtin registered here. (`Hash.instance_method
+        // (:to_h).source_location` is `["<internal:hash>", 11]`.) The Rust
+        // `to_h` block branch is therefore not reachable from Ruby.
+        // A block return that is not a 2-element Array is a TypeError /
+        // ArgumentError, matching CRuby.
         run_test(
             r#"
             h = { a: 1, b: 2 }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -2596,27 +2596,37 @@ fn io_popen(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     if let Some(bh) = lfp.block() {
         let data = vm.get_block_data(globals, bh)?;
         let res = vm.invoke_block(globals, &data, &[io_val]);
-        let mut io_close = io_val;
-        if let Ok(Some((exit_status, pid))) = io_close.as_io_inner_mut().close(&globals.store) {
-            if let Ok(status_class) =
-                vm.get_qualified_constant(globals, OBJECT_CLASS, &["Process", "Status"])
+        // Root the block's return value (and the IO) across the
+        // Process::Status construction below, which re-enters Ruby while
+        // both live only in Rust locals.
+        vm.with_temp_scope(|vm| {
+            if let Ok(v) = res {
+                vm.temp_push(v);
+            }
+            vm.temp_push(io_val);
+            let mut io_close = io_val;
+            if let Ok(Some((exit_status, pid))) = io_close.as_io_inner_mut().close(&globals.store)
             {
-                if let Ok(status_obj) = vm.invoke_method_inner(
-                    globals,
-                    IdentId::NEW,
-                    status_class,
-                    &[
-                        Value::integer(exit_status as i64),
-                        Value::integer(pid as i64),
-                    ],
-                    None,
-                    None,
-                ) {
-                    crate::scheduler::set_last_status(vm, status_obj);
+                if let Ok(status_class) =
+                    vm.get_qualified_constant(globals, OBJECT_CLASS, &["Process", "Status"])
+                {
+                    if let Ok(status_obj) = vm.invoke_method_inner(
+                        globals,
+                        IdentId::NEW,
+                        status_class,
+                        &[
+                            Value::integer(exit_status as i64),
+                            Value::integer(pid as i64),
+                        ],
+                        None,
+                        None,
+                    ) {
+                        crate::scheduler::set_last_status(vm, status_obj);
+                    }
                 }
             }
-        }
-        res
+            res
+        })
     } else {
         Ok(io_val)
     }

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -180,17 +180,23 @@ pub(super) fn init(globals: &mut Globals) {
 fn io_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let class = lfp.self_val().as_class_id();
     let obj = Value::new_io_with_class(IoInner::closed(None), class);
-    io_init_from_fd(vm, globals, lfp, obj)?;
-    if lfp.block().is_some() {
-        // CRuby warns through rb_warn; route via Kernel#warn so the
-        // Ruby-level $stderr (which specs capture) receives it.
-        let msg = Value::string_from_str(
-            "warning: IO::new() does not take block; use IO::open() instead",
-        );
-        let main = globals.main_object;
-        let _ = vm.invoke_method_inner(globals, IdentId::get_id("warn"), main, &[msg], None, None);
-    }
-    Ok(obj)
+    // Root the fresh IO across `io_init_from_fd` / `warn`, which re-enter
+    // Ruby while it lives only in this Rust local.
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(obj);
+        io_init_from_fd(vm, globals, lfp, obj)?;
+        if lfp.block().is_some() {
+            // CRuby warns through rb_warn; route via Kernel#warn so the
+            // Ruby-level $stderr (which specs capture) receives it.
+            let msg = Value::string_from_str(
+                "warning: IO::new() does not take block; use IO::open() instead",
+            );
+            let main = globals.main_object;
+            let _ =
+                vm.invoke_method_inner(globals, IdentId::get_id("warn"), main, &[msg], None, None);
+        }
+        Ok(obj)
+    })
 }
 
 ///
@@ -1039,21 +1045,29 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // CRuby's rb_io_puts: a real Array recurses; any other non-String is
     // first offered `#to_ary` (an Array result recurses, `nil` falls back
     // to `#to_s`, anything else is the usual conversion TypeError).
+    // The collector rides on the VM temp stack (the last entry, a rooted
+    // Array): elements can be freshly created (`"[...]"` markers) or come
+    // from a `#to_ary` result that nothing else references, and they must
+    // survive the later `#to_ary` / `#to_s` / `#write` re-entries.
     fn decompose(
         vm: &mut Executor,
         globals: &mut Globals,
-        collector: &mut Vec<Value>,
+        root_idx: usize,
         val: Value,
         seen: &mut Vec<u64>,
     ) -> Result<()> {
         if let Some(ary) = val.try_array_ty() {
             let id = val.id();
             if seen.contains(&id) {
-                collector.push(Value::string("[...]".to_string()));
+                let marker = Value::string("[...]".to_string());
+                vm.temp_at(root_idx).as_array().push(marker);
             } else {
                 seen.push(id);
-                for v in ary.iter() {
-                    decompose(vm, globals, collector, *v, seen)?;
+                for i in 0..ary.len() {
+                    // Re-read each element: the recursion can run Ruby
+                    // that mutates `ary`.
+                    let Some(v) = ary.get(i).copied() else { break };
+                    decompose(vm, globals, root_idx, v, seen)?;
                 }
                 seen.pop();
             }
@@ -1068,7 +1082,11 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             let converted =
                 vm.invoke_method_inner(globals, IdentId::get_id("to_ary"), val, &[], None, None)?;
             if converted.try_array_ty().is_some() {
-                return decompose(vm, globals, collector, converted, seen);
+                // Root the fresh `#to_ary` result while its elements are
+                // walked (nested `#to_ary`s can run Ruby in between).
+                // The push is rolled back by `with_temp_scope` below.
+                vm.temp_push(converted);
+                return decompose(vm, globals, root_idx, converted, seen);
             }
             if !converted.is_nil() {
                 return Err(MonorubyErr::typeerr(format!(
@@ -1079,55 +1097,66 @@ fn puts(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 )));
             }
         }
-        collector.push(val);
+        vm.temp_at(root_idx).as_array().push(val);
         Ok(())
     }
-    let mut collector = Vec::new();
-    let mut seen = Vec::new();
-    let args = lfp.arg(0).as_array();
-    let no_args = args.is_empty();
-    for v in args.iter().cloned() {
-        decompose(vm, globals, &mut collector, v, &mut seen)?;
-    }
-
-    let self_val = lfp.self_val();
-    let write_id = IdentId::get_id("write");
-    if no_args {
-        // puts with no args writes a newline. (An empty *array* argument
-        // decomposes to nothing and writes nothing — only the genuinely
-        // argument-less call gets the bare newline.)
-        let newline = Value::string_from_str("\n");
-        vm.invoke_method_inner(globals, write_id, self_val, &[newline], None, None)?;
-    } else {
-        for v in collector {
-            let s = if v.is_nil() {
-                String::new()
-            } else if let Some(rs) = v.is_rstring() {
-                String::from_utf8_lossy(rs.as_bytes()).into_owned()
-            } else {
-                // Stringify through the value's (possibly Ruby-defined)
-                // `to_s`, matching CRuby's `rb_obj_as_string`; fall back
-                // to the Rust-side formatter when `to_s` misbehaves.
-                let sv =
-                    vm.invoke_method_inner(globals, IdentId::get_id("to_s"), v, &[], None, None)?;
-                match sv.is_rstring() {
-                    Some(rs) => String::from_utf8_lossy(rs.as_bytes()).into_owned(),
-                    None => v.to_s(globals),
-                }
-            };
-            let needs_newline = !s.ends_with('\n');
-            let write_str = if needs_newline {
-                Value::string(s + "\n")
-            } else {
-                Value::string(s)
-            };
-            vm.invoke_method_inner(globals, write_id, self_val, &[write_str], None, None)?;
+    vm.with_temp_scope(|vm| {
+        let mut seen = Vec::new();
+        let args = lfp.arg(0).as_array();
+        let no_args = args.is_empty();
+        vm.temp_array_new(None);
+        let root_idx = vm.temp_len() - 1;
+        for v in args.iter().cloned() {
+            decompose(vm, globals, root_idx, v, &mut seen)?;
         }
-    }
-    // Flush after all writes
-    let mut self_ = lfp.self_val();
-    self_.as_io_inner_mut().flush(&globals.store)?;
-    Ok(Value::nil())
+
+        let self_val = lfp.self_val();
+        let write_id = IdentId::get_id("write");
+        if no_args {
+            // puts with no args writes a newline. (An empty *array* argument
+            // decomposes to nothing and writes nothing — only the genuinely
+            // argument-less call gets the bare newline.)
+            let newline = Value::string_from_str("\n");
+            vm.invoke_method_inner(globals, write_id, self_val, &[newline], None, None)?;
+        } else {
+            let len = vm.temp_at(root_idx).as_array().len();
+            for i in 0..len {
+                let v = vm.temp_at(root_idx).as_array()[i];
+                let s = if v.is_nil() {
+                    String::new()
+                } else if let Some(rs) = v.is_rstring() {
+                    String::from_utf8_lossy(rs.as_bytes()).into_owned()
+                } else {
+                    // Stringify through the value's (possibly Ruby-defined)
+                    // `to_s`, matching CRuby's `rb_obj_as_string`; fall back
+                    // to the Rust-side formatter when `to_s` misbehaves.
+                    let sv = vm.invoke_method_inner(
+                        globals,
+                        IdentId::get_id("to_s"),
+                        v,
+                        &[],
+                        None,
+                        None,
+                    )?;
+                    match sv.is_rstring() {
+                        Some(rs) => String::from_utf8_lossy(rs.as_bytes()).into_owned(),
+                        None => v.to_s(globals),
+                    }
+                };
+                let needs_newline = !s.ends_with('\n');
+                let write_str = if needs_newline {
+                    Value::string(s + "\n")
+                } else {
+                    Value::string(s)
+                };
+                vm.invoke_method_inner(globals, write_id, self_val, &[write_str], None, None)?;
+            }
+        }
+        // Flush after all writes
+        let mut self_ = lfp.self_val();
+        self_.as_io_inner_mut().flush(&globals.store)?;
+        Ok(Value::nil())
+    })
 }
 
 ///
@@ -2306,7 +2335,12 @@ fn io_pipe(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         Ok(obj)
     };
     let mut read_io = make_end(vm, globals, fds[0], "r")?;
+    // `read_io` lives only in this Rust local while the second
+    // `#initialize` (and later the block) runs Ruby — root both ends.
+    vm.with_temp_scope(|vm| {
+    vm.temp_push(read_io);
     let mut write_io = make_end(vm, globals, fds[1], "w")?;
+    vm.temp_push(write_io);
     // CRuby's `rb_io_s_pipe` marks the write end synchronous. It is not a
     // nicety: both ends usually live in one process, so a buffered write
     // would leave the reader blocked on data that never reaches the pipe.
@@ -2334,6 +2368,7 @@ fn io_pipe(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
         }
         None => Ok(Value::array2(read_io, write_io)),
     }
+    })
 }
 
 /// ### IO.popen

--- a/monoruby/src/builtins/io.rs
+++ b/monoruby/src/builtins/io.rs
@@ -8830,4 +8830,57 @@ mod tests {
             "##,
         );
     }
+
+    /// `IO.new` given a block warns and ignores it (the block form is
+    /// `IO.open`), returning the fresh IO. The IO is only reachable from a
+    /// Rust local while `io_init_from_fd` and the `warn` dispatch re-enter
+    /// Ruby, which is what the rooting guards.
+    #[test]
+    fn io_new_with_block_warns_and_returns_io() {
+        run_test_once(
+            r##"
+            path = "/tmp/mono_cov_io_new_#{Process.pid}"
+            begin
+              File.write(path, "hello\n")
+              fd = IO.sysopen(path, "r")
+              io = IO.new(fd, "r") { |x| :never_called }
+              res = [io.class, io.read]
+              io.close
+              res
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "##,
+        );
+    }
+
+    /// `IO#puts` stringifies each decomposed element: `nil` writes an empty
+    /// line, and an object whose `to_s` returns a non-String falls back to
+    /// the Rust-side formatter (CRuby's `rb_any_to_s`). Both write through
+    /// the rooted collector Array.
+    #[test]
+    fn puts_stringifies_nil_and_bad_to_s() {
+        run_test_once(
+            r##"
+            path = "/tmp/mono_cov_puts_#{Process.pid}"
+            begin
+              class BadToS
+                def to_s; 42; end
+              end
+              File.open(path, "w") do |f|
+                f.puts nil
+                f.puts [nil, nil]
+                f.puts "plain"
+                f.puts BadToS.new
+              end
+              lines = File.readlines(path)
+              # The BadToS line renders as an address-bearing default
+              # `to_s`, so compare only its shape.
+              [lines.size, lines[0, 4], lines[4].start_with?("#<BadToS")]
+            ensure
+              File.unlink(path) rescue nil
+            end
+            "##,
+        );
+    }
 }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1065,10 +1065,14 @@ pub(crate) fn make_exception_error(
             let cargs: Vec<Value> = msg_arg.into_iter().collect();
             let ex =
                 vm.invoke_method_inner(globals, IdentId::NEW, klass.as_val(), &cargs, None, None)?;
-            apply_backtrace(vm, globals, ex, bt_arg)?;
-            let mut err = MonorubyErr::new_from_exception(ex.is_exception().unwrap());
-            fix_system_exit_status(globals, &mut err, ex);
-            return apply_cause(globals, err.with_original(ex), Some(ex), cause_kwarg);
+            // Root the fresh exception across `#set_backtrace` (Ruby).
+            return vm.with_temp_scope(|vm| {
+                vm.temp_push(ex);
+                apply_backtrace(vm, globals, ex, bt_arg)?;
+                let mut err = MonorubyErr::new_from_exception(ex.is_exception().unwrap());
+                fix_system_exit_status(globals, &mut err, ex);
+                apply_cause(globals, err.with_original(ex), Some(ex), cause_kwarg)
+            });
         }
         return Err(MonorubyErr::typeerr("exception class/object expected"));
     }
@@ -1093,9 +1097,13 @@ pub(crate) fn make_exception_error(
         let result = vm.invoke_method_inner(globals, exception_id, a0, &cargs, None, None)?;
         match result.is_exception() {
             Some(ex) => {
-                apply_backtrace(vm, globals, result, bt_arg)?;
-                let err = MonorubyErr::new_from_exception(ex).with_original(result);
-                return apply_cause(globals, err, Some(result), cause_kwarg);
+                // Root the `#exception` result across `#set_backtrace`.
+                return vm.with_temp_scope(|vm| {
+                    vm.temp_push(result);
+                    apply_backtrace(vm, globals, result, bt_arg)?;
+                    let err = MonorubyErr::new_from_exception(ex).with_original(result);
+                    apply_cause(globals, err, Some(result), cause_kwarg)
+                });
             }
             None => return Err(MonorubyErr::typeerr("exception object expected")),
         }

--- a/monoruby/src/builtins/marshal.rs
+++ b/monoruby/src/builtins/marshal.rs
@@ -127,7 +127,14 @@ fn load(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let mut cursor = MarshalReader::new(&data[2..]);
     cursor.freeze = freeze;
     cursor.proc = proc;
-    cursor.read_value(vm, globals)
+    // Root the reader's object link table for the whole load: it is the
+    // only reference to most partially-reconstructed values while
+    // `_load` / `marshal_load` / the load proc run Ruby.
+    let objects = cursor.objects;
+    vm.with_temp_scope(|vm| {
+        vm.temp_push(objects.into());
+        cursor.read_value(vm, globals)
+    })
 }
 
 // ============================================================
@@ -139,8 +146,12 @@ struct MarshalReader<'a> {
     pos: usize,
     /// Symbol table for back-references (';' tag)
     symbols: Vec<IdentId>,
-    /// Object table for back-references ('@' tag)
-    objects: Vec<Value>,
+    /// Object table for back-references ('@' tag). A Ruby Array (not a
+    /// Rust Vec) so `load` can root the whole link table on the VM temp
+    /// stack: reconstruction re-enters Ruby (`_load`, `marshal_load`,
+    /// `set_backtrace`, hash inserts), and every partially-built object
+    /// in here must survive those collections.
+    objects: Array,
     /// `Marshal.load(.., freeze: true)`: deep-freeze reconstructed values.
     freeze: bool,
     /// `Marshal.load(src, proc)`: called with each reconstructed value.
@@ -157,7 +168,7 @@ impl<'a> MarshalReader<'a> {
             data,
             pos: 0,
             symbols: Vec::new(),
-            objects: Vec::new(),
+            objects: Array::new_empty(),
             freeze: false,
             proc: None,
             building: std::collections::HashSet::new(),
@@ -665,6 +676,11 @@ impl<'a> MarshalReader<'a> {
             .map(|f| f as *const () == crate::default_alloc_func as *const ())
             .unwrap_or(true);
         let obj = Value::object(module.id());
+        // Register the (still-empty) instance right away: the rooted
+        // link table keeps the fresh object alive across the ivar
+        // `read_value`s below, and a self-reference resolves to the
+        // instance rather than nil.
+        self.objects[obj_idx] = obj;
         // Read instance variables.
         let mut ivars: Vec<(IdentId, Value)> = Vec::with_capacity(ivar_count);
         for _ in 0..ivar_count {
@@ -1046,6 +1062,9 @@ impl<'a> MarshalReader<'a> {
         }
         let class_id = module.id();
         let mut instance = Value::struct_object(class_id, member_count);
+        // Register right away: the rooted link table keeps the fresh
+        // instance alive across the member `read_value`s below.
+        self.objects[obj_idx] = instance;
         for i in 0..member_count {
             let member_sym = self.read_symbol(vm, globals)?;
             let val = self.read_value(vm, globals)?;

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -557,6 +557,11 @@ fn attr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     let visi = vm.context_visibility();
     let args = lfp.arg(0).as_array();
     let mut ary = Array::new_empty();
+    // Root the fresh result Array: the warning and the
+    // `#to_str`/`#to_sym` coercions below re-enter Ruby while it lives
+    // only in this Rust local.
+    vm.with_temp_scope(|vm| {
+    vm.temp_push(ary.into());
 
     // Detect the legacy `attr(name, true|false)` form.
     let legacy_writable = if args.len() == 2 {
@@ -602,6 +607,7 @@ fn attr(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         }
     }
     Ok(ary.into())
+    })
 }
 
 ///

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -435,13 +435,16 @@ fn fdiv(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         }
     }
     let fdiv_id = IdentId::get_id("fdiv");
+    // Extract each result to an f64 *before* the next dispatch: a heap
+    // Float held only in a Rust local would not survive the GC a
+    // (possibly redefined) `fdiv` can trigger.
     let re = vm.invoke_method_inner(globals, fdiv_id, c.re().get(), &[other], None, None)?;
-    let im = vm.invoke_method_inner(globals, fdiv_id, c.im().get(), &[other], None, None)?;
     let re_f = match re.unpack() {
         RV::Float(f) => f,
         RV::Fixnum(i) => i as f64,
         _ => return Err(MonorubyErr::typeerr("fdiv did not return Float")),
     };
+    let im = vm.invoke_method_inner(globals, fdiv_id, c.im().get(), &[other], None, None)?;
     let im_f = match im.unpack() {
         RV::Float(f) => f,
         RV::Fixnum(i) => i as f64,
@@ -457,22 +460,35 @@ fn fdiv(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 fn numerator(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let c = self_val.as_complex();
-    let d = complex_denominator(vm, globals, c)?;
-    let num_id = IdentId::get_id("numerator");
-    let div_id = IdentId::_DIV;
-    let mul_id = IdentId::_MUL;
-    let den_id = IdentId::get_id("denominator");
-    let re_num = vm.invoke_method_inner(globals, num_id, c.re().get(), &[], None, None)?;
-    let re_den = vm.invoke_method_inner(globals, den_id, c.re().get(), &[], None, None)?;
-    let im_num = vm.invoke_method_inner(globals, num_id, c.im().get(), &[], None, None)?;
-    let im_den = vm.invoke_method_inner(globals, den_id, c.im().get(), &[], None, None)?;
-    let re_scale = vm.invoke_method_inner(globals, div_id, d, &[re_den], None, None)?;
-    let im_scale = vm.invoke_method_inner(globals, div_id, d, &[im_den], None, None)?;
-    let re = vm.invoke_method_inner(globals, mul_id, re_num, &[re_scale], None, None)?;
-    let im = vm.invoke_method_inner(globals, mul_id, im_num, &[im_scale], None, None)?;
-    let re_r = Real::try_from(globals, re)?;
-    let im_r = Real::try_from(globals, im)?;
-    Ok(Value::complex(re_r, im_r))
+    // Every intermediate can be a heap numeric (Bignum/Rational) that
+    // only these Rust locals reference across the following dispatches —
+    // keep each rooted for the duration.
+    vm.with_temp_scope(|vm| {
+        let d = complex_denominator(vm, globals, c)?;
+        vm.temp_push(d);
+        let num_id = IdentId::get_id("numerator");
+        let div_id = IdentId::_DIV;
+        let mul_id = IdentId::_MUL;
+        let den_id = IdentId::get_id("denominator");
+        let re_num = vm.invoke_method_inner(globals, num_id, c.re().get(), &[], None, None)?;
+        vm.temp_push(re_num);
+        let re_den = vm.invoke_method_inner(globals, den_id, c.re().get(), &[], None, None)?;
+        vm.temp_push(re_den);
+        let im_num = vm.invoke_method_inner(globals, num_id, c.im().get(), &[], None, None)?;
+        vm.temp_push(im_num);
+        let im_den = vm.invoke_method_inner(globals, den_id, c.im().get(), &[], None, None)?;
+        vm.temp_push(im_den);
+        let re_scale = vm.invoke_method_inner(globals, div_id, d, &[re_den], None, None)?;
+        vm.temp_push(re_scale);
+        let im_scale = vm.invoke_method_inner(globals, div_id, d, &[im_den], None, None)?;
+        vm.temp_push(im_scale);
+        let re = vm.invoke_method_inner(globals, mul_id, re_num, &[re_scale], None, None)?;
+        vm.temp_push(re);
+        let im = vm.invoke_method_inner(globals, mul_id, im_num, &[im_scale], None, None)?;
+        let re_r = Real::try_from(globals, re)?;
+        let im_r = Real::try_from(globals, im)?;
+        Ok(Value::complex(re_r, im_r))
+    })
 }
 
 ///
@@ -617,11 +633,16 @@ fn neg_op(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let self_val = lfp.self_val();
     let c = self_val.as_complex();
     let neg_id = IdentId::_UMINUS;
-    let re = vm.invoke_method_inner(globals, neg_id, c.re().get(), &[], None, None)?;
-    let im = vm.invoke_method_inner(globals, neg_id, c.im().get(), &[], None, None)?;
-    let re_r = Real::try_from(globals, re)?;
-    let im_r = Real::try_from(globals, im)?;
-    Ok(Value::complex(re_r, im_r))
+    // `re` can be a heap numeric only this Rust local references while
+    // the second `-@` dispatch runs — root it.
+    vm.with_temp_scope(|vm| {
+        let re = vm.invoke_method_inner(globals, neg_id, c.re().get(), &[], None, None)?;
+        vm.temp_push(re);
+        let im = vm.invoke_method_inner(globals, neg_id, c.im().get(), &[], None, None)?;
+        let re_r = Real::try_from(globals, re)?;
+        let im_r = Real::try_from(globals, im)?;
+        Ok(Value::complex(re_r, im_r))
+    })
 }
 
 /// Format a Complex following CRuby's `nucomp_to_s` / `nucomp_inspect`.

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -1357,4 +1357,32 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn complex_numerator_denominator() {
+        // `numerator` scales both components onto the common denominator
+        // (`denominator` = lcm of the parts'), dispatching `numerator` /
+        // `denominator` / `/` / `*` on each part. Every intermediate can be
+        // a heap numeric (Rational/Bignum) that only a Rust local holds
+        // across the next dispatch, which is what the rooting guards.
+        run_tests(&[
+            // Integer components: denominator 1, numerator == self.
+            "Complex(1, 2).numerator.to_s",
+            "Complex(1, 2).denominator",
+            // Rational components with different denominators.
+            "Complex(Rational(1, 2), Rational(2, 3)).numerator.to_s",
+            "Complex(Rational(1, 2), Rational(2, 3)).denominator",
+            // Mixed Rational / Integer.
+            "Complex(Rational(3, 4), 5).numerator.to_s",
+            "Complex(Rational(3, 4), 5).denominator",
+            "Complex(7, Rational(5, 6)).numerator.to_s",
+            // Negative and zero components.
+            "Complex(Rational(-1, 3), Rational(1, 6)).numerator.to_s",
+            "Complex(0, Rational(1, 2)).numerator.to_s",
+            // Bignum components: the intermediates are heap Integers.
+            "Complex(10**30, 3).numerator.to_s",
+            "Complex(Rational(10**30, 7), Rational(1, 3)).numerator.to_s",
+            "Complex(Rational(10**30, 7), Rational(1, 3)).denominator",
+        ]);
+    }
 }

--- a/monoruby/src/builtins/numeric/complex.rs
+++ b/monoruby/src/builtins/numeric/complex.rs
@@ -819,53 +819,82 @@ fn div(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     };
 
     // Complex / Complex: Smith's algorithm using `quo` on the components.
+    // Every intermediate can be a heap numeric (Rational/Bignum) that
+    // only a Rust local references while the next `quo`/`*`/`+` dispatch
+    // runs Ruby — root each until the components are extracted.
     if let Some(o) = other.try_complex() {
         let (b_re, b_im) = (o.re().get(), o.im().get());
         let one = Value::integer(1);
-        let abs_re = f_abs(vm, globals, b_re)?;
-        let abs_im = f_abs(vm, globals, b_im)?;
-        let (mut x, mut y);
-        if f_gt(vm, globals, abs_re, abs_im)? {
-            // r = b_im / b_re ; n = b_re * (1 + r*r)
-            let r = f_quo(vm, globals, b_im, b_re)?;
-            let rr = f_mul(vm, globals, r, r)?;
-            let one_plus = f_add(vm, globals, one, rr)?;
-            let n = f_mul(vm, globals, b_re, one_plus)?;
-            // x = (a_re + a_im*r) / n ; y = (a_im - a_re*r) / n
-            let aim_r = f_mul(vm, globals, a_im, r)?;
-            let num_x = f_add(vm, globals, a_re, aim_r)?;
-            let are_r = f_mul(vm, globals, a_re, r)?;
-            let num_y = f_sub(vm, globals, a_im, are_r)?;
-            x = f_quo(vm, globals, num_x, n)?;
-            y = f_quo(vm, globals, num_y, n)?;
-        } else {
-            // r = b_re / b_im ; n = b_im * (1 + r*r)
-            let r = f_quo(vm, globals, b_re, b_im)?;
-            let rr = f_mul(vm, globals, r, r)?;
-            let one_plus = f_add(vm, globals, one, rr)?;
-            let n = f_mul(vm, globals, b_im, one_plus)?;
-            // x = (a_re*r + a_im) / n ; y = (a_im*r - a_re) / n
-            let are_r = f_mul(vm, globals, a_re, r)?;
-            let num_x = f_add(vm, globals, are_r, a_im)?;
-            let aim_r = f_mul(vm, globals, a_im, r)?;
-            let num_y = f_sub(vm, globals, aim_r, a_re)?;
-            x = f_quo(vm, globals, num_x, n)?;
-            y = f_quo(vm, globals, num_y, n)?;
-        }
-        x = rational_canonicalize(x);
-        y = rational_canonicalize(y);
-        let re_r = Real::try_from(globals, x)?;
-        let im_r = Real::try_from(globals, y)?;
-        return Ok(Value::complex(re_r, im_r));
+        return vm.with_temp_scope(|vm| {
+            let abs_re = f_abs(vm, globals, b_re)?;
+            vm.temp_push(abs_re);
+            let abs_im = f_abs(vm, globals, b_im)?;
+            vm.temp_push(abs_im);
+            let (mut x, mut y);
+            if f_gt(vm, globals, abs_re, abs_im)? {
+                // r = b_im / b_re ; n = b_re * (1 + r*r)
+                let r = f_quo(vm, globals, b_im, b_re)?;
+                vm.temp_push(r);
+                let rr = f_mul(vm, globals, r, r)?;
+                vm.temp_push(rr);
+                let one_plus = f_add(vm, globals, one, rr)?;
+                vm.temp_push(one_plus);
+                let n = f_mul(vm, globals, b_re, one_plus)?;
+                vm.temp_push(n);
+                // x = (a_re + a_im*r) / n ; y = (a_im - a_re*r) / n
+                let aim_r = f_mul(vm, globals, a_im, r)?;
+                vm.temp_push(aim_r);
+                let num_x = f_add(vm, globals, a_re, aim_r)?;
+                vm.temp_push(num_x);
+                let are_r = f_mul(vm, globals, a_re, r)?;
+                vm.temp_push(are_r);
+                let num_y = f_sub(vm, globals, a_im, are_r)?;
+                vm.temp_push(num_y);
+                x = f_quo(vm, globals, num_x, n)?;
+                vm.temp_push(x);
+                y = f_quo(vm, globals, num_y, n)?;
+            } else {
+                // r = b_re / b_im ; n = b_im * (1 + r*r)
+                let r = f_quo(vm, globals, b_re, b_im)?;
+                vm.temp_push(r);
+                let rr = f_mul(vm, globals, r, r)?;
+                vm.temp_push(rr);
+                let one_plus = f_add(vm, globals, one, rr)?;
+                vm.temp_push(one_plus);
+                let n = f_mul(vm, globals, b_im, one_plus)?;
+                vm.temp_push(n);
+                // x = (a_re*r + a_im) / n ; y = (a_im*r - a_re) / n
+                let are_r = f_mul(vm, globals, a_re, r)?;
+                vm.temp_push(are_r);
+                let num_x = f_add(vm, globals, are_r, a_im)?;
+                vm.temp_push(num_x);
+                let aim_r = f_mul(vm, globals, a_im, r)?;
+                vm.temp_push(aim_r);
+                let num_y = f_sub(vm, globals, aim_r, a_re)?;
+                vm.temp_push(num_y);
+                x = f_quo(vm, globals, num_x, n)?;
+                vm.temp_push(x);
+                y = f_quo(vm, globals, num_y, n)?;
+            }
+            x = rational_canonicalize(x);
+            y = rational_canonicalize(y);
+            let re_r = Real::try_from(globals, x)?;
+            let im_r = Real::try_from(globals, y)?;
+            Ok(Value::complex(re_r, im_r))
+        });
     }
 
-    // Complex / real: divide each component by the real divisor.
+    // Complex / real: divide each component by the real divisor. `x`
+    // must survive the second `quo` dispatch — root it.
     if is_real_divisor(vm, globals, other)? {
-        let x = rational_canonicalize(f_quo(vm, globals, a_re, other)?);
-        let y = rational_canonicalize(f_quo(vm, globals, a_im, other)?);
-        let re_r = Real::try_from(globals, x)?;
-        let im_r = Real::try_from(globals, y)?;
-        return Ok(Value::complex(re_r, im_r));
+        return vm.with_temp_scope(|vm| {
+            let x = rational_canonicalize(f_quo(vm, globals, a_re, other)?);
+            vm.temp_push(x);
+            let y = rational_canonicalize(f_quo(vm, globals, a_im, other)?);
+            let re_r = Real::try_from(globals, x)?;
+            let im_r = Real::try_from(globals, y)?;
+            Ok(Value::complex(re_r, im_r))
+        });
     }
 
     // Otherwise fall back to the coerce protocol (`rb_num_coerce_bin`). The

--- a/monoruby/src/builtins/process.rs
+++ b/monoruby/src/builtins/process.rs
@@ -1454,7 +1454,12 @@ fn process_warmup(_vm: &mut Executor, _globals: &mut Globals, _lfp: Lfp, _: Byte
 /// when there are no children. `$?` is left at the last reaped child.
 #[monoruby_builtin]
 fn process_waitall(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut pairs: Vec<Value> = vec![];
+    // Accumulate into a rooted Array: each [pid, status] pair must
+    // survive the next iteration's Process::Status construction (Ruby
+    // re-entry) — a bare Rust Vec left them invisible to the GC.
+    vm.with_temp_scope(|vm| {
+    vm.temp_array_new(None);
+    let pairs_idx = vm.temp_len() - 1;
     loop {
         let mut status: i32 = 0;
         // SAFETY: waitpid is a POSIX system call.
@@ -1485,12 +1490,11 @@ fn process_waitall(vm: &mut Executor, globals: &mut Globals, _lfp: Lfp, _: Bytec
             None,
         )?;
         crate::scheduler::set_last_status(vm, status_obj);
-        pairs.push(Value::array_from_vec(vec![
-            Value::integer(ret as i64),
-            status_obj,
-        ]));
+        let pair = Value::array_from_vec(vec![Value::integer(ret as i64), status_obj]);
+        vm.temp_at(pairs_idx).as_array().push(pair);
     }
-    Ok(Value::array_from_vec(pairs))
+    Ok(vm.temp_at(pairs_idx))
+    })
 }
 
 ///

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -987,6 +987,10 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                     None,
                 )?
                 .as_array();
+            // The `to_a` result is referenced only by this Rust local
+            // while the comparator block runs — root it.
+            vm.with_temp_scope(|vm| {
+            vm.temp_push(arr.into());
             for v in arr.iter() {
                 let v = *v;
                 let mn = match min_val {
@@ -1031,6 +1035,7 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 min_val.unwrap_or_else(Value::nil),
                 max_val.unwrap_or_else(Value::nil),
             ]))
+            })
         }
     } else {
         // No block: compute min and max directly

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -1369,18 +1369,24 @@ fn divide(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -
         // Arity-1 mode: classify and return set of sets
         let mut groups: std::collections::HashMap<u64, Vec<Value>> = std::collections::HashMap::new();
         let mut group_order: Vec<u64> = Vec::new();
-        for k in &keys {
-            let classification = vm.invoke_block(globals, &data, &[*k])?;
-            let key = classification.id() as u64;
-            if !groups.contains_key(&key) {
-                group_order.push(key);
-            }
-            groups.entry(key).or_default().push(*k);
-        }
-        let result_set = new_empty_set();
-        // Root `result_set` and each freshly-built `subset` across the GC that
-        // `set_from_iter` / `insert` can trigger (see `classify`).
+        // The whole grouping runs inside one temp scope: each
+        // classification value is kept rooted so its identity (`id()`,
+        // the group key) can't be recycled by a GC for a later,
+        // different classification — under per-safepoint stress a freed
+        // result's address is reused almost immediately.
         vm.with_temp_scope(|vm| {
+            for k in &keys {
+                let classification = vm.invoke_block(globals, &data, &[*k])?;
+                vm.temp_push(classification);
+                let key = classification.id() as u64;
+                if !groups.contains_key(&key) {
+                    group_order.push(key);
+                }
+                groups.entry(key).or_default().push(*k);
+            }
+            let result_set = new_empty_set();
+            // Root `result_set` and each freshly-built `subset` across the GC
+            // that `set_from_iter` / `insert` can trigger (see `classify`).
             vm.temp_push(result_set);
             for key in group_order {
                 if let Some(elems) = groups.remove(&key) {

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -355,9 +355,11 @@ fn uplus(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn add(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     // CRuby `String#+` always returns a plain String, even for a String
     // subclass receiver — so build a fresh String rather than `dup`ing
-    // (which would carry over the receiver's class).
-    let mut self_ = Value::string_from_inner(lfp.self_val().as_rstring_inner().clone());
+    // (which would carry over the receiver's class). Coerce first:
+    // `#to_str` re-enters Ruby, and the fresh copy would live only in a
+    // Rust local across it.
     let other = lfp.arg(0).coerce_to_rstring(vm, globals)?;
+    let mut self_ = Value::string_from_inner(lfp.self_val().as_rstring_inner().clone());
     self_
         .as_rstring_inner_mut()
         .extend(&other, &globals.store)?;

--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -601,6 +601,13 @@ struct BytecodeGen<'a> {
     exception_table: Vec<ExceptionEntry>,
     /// Merge info.
     merge_info: HashMap<Label, (Option<BcTemp>, Vec<MergeSourceInfo>)>,
+    /// Slot range (arg-area indices) of destructured-parameter locals
+    /// (`|(a, b)|`). These sit in the argument area, but no caller ever
+    /// writes them — the prologue `expand` instructions do, *after* the
+    /// callee-entry GC poll — so `init_method` must nil-fill them or the
+    /// poll's root scan reads stack garbage. Computed from the actual
+    /// `DestructureInfo` targets in `compile()`.
+    destructed_args: std::ops::Range<usize>,
 }
 
 impl<'a> std::ops::Index<Label> for BytecodeGen<'a> {
@@ -649,6 +656,7 @@ impl<'a> BytecodeGen<'a> {
 
             exception_table: vec![],
             merge_info: HashMap::default(),
+            destructed_args: 0..0,
         };
         if let Some(lvc) = binding {
             assert!(params.args_names.is_empty());
@@ -697,6 +705,15 @@ impl<'a> BytecodeGen<'a> {
             rest_pos,
         } in info.destruct_info
         {
+            // Record the union of the expand targets so `replace_init`
+            // can have `init_method` nil-fill them (see `destructed_args`).
+            let start = self.destructed_args.start.min(dst);
+            let end = self.destructed_args.end.max(dst + len);
+            self.destructed_args = if self.destructed_args.is_empty() {
+                dst..dst + len
+            } else {
+                start..end
+            };
             self.gen_expand_array(src, dst, len, rest_pos);
         }
         // A trivial-method hint (`ConstReturn` / `SelfReturn`) makes the
@@ -1972,7 +1989,7 @@ impl<'a> BytecodeGen<'a> {
     }
 
     fn replace_init(&mut self, params: &ParamsInfo) {
-        let fninfo = FnInitInfo::new(self.total_reg_num(), params);
+        let fninfo = FnInitInfo::new(self.total_reg_num(), params, self.destructed_args.clone());
         self.ir[0] = (BytecodeInst::InitMethod(fninfo), Loc::default());
     }
 }

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -642,7 +642,14 @@ impl<'a> BytecodeGen<'a> {
                 let op3 = self.slot_id(&src);
                 Bytecode::from(enc_www(149, op1.0, op2, op3.0))
             }
-            BytecodeInst::InitMethod(fn_info) => Bytecode::from(enc_www_fn_info(172, &fn_info)),
+            BytecodeInst::InitMethod(fn_info) => {
+                // Second word (low u32): destructured-param slot range —
+                // `destruct_start` in the low u16, `destruct_len` above it.
+                // Read back by `TraceIr` decode and the VM's `vm_init`.
+                let destruct =
+                    ((fn_info.destruct_len as u32) << 16) | (fn_info.destruct_start as u32);
+                Bytecode::from_u32(enc_www_fn_info(172, &fn_info), destruct)
+            }
             BytecodeInst::ExpandArray(src, dst, len, rest_pos) => {
                 let op1 = self.slot_id(&src);
                 let op2 = self.slot_id(&dst);

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -326,6 +326,14 @@ pub(crate) struct FnInitInfo {
     pub arg_num: usize,
     /// stack offset (in 16 bytes unit) for local frame.
     pub stack_offset: usize,
+    /// First arg-area slot of the destructured-parameter locals
+    /// (`|(a, b)|`), and their count. These slots are inside the
+    /// argument area (so the `arg_num..reg_num` nil-fill misses them)
+    /// but no caller writes them — the prologue `expand` instructions
+    /// do, *after* the callee-entry GC poll — so the init must nil-fill
+    /// them too or the poll's root scan reads stack garbage.
+    pub destruct_start: usize,
+    pub destruct_len: usize,
 }
 
 impl std::fmt::Debug for FnInitInfo {
@@ -341,7 +349,11 @@ impl std::fmt::Debug for FnInitInfo {
 }
 
 impl FnInitInfo {
-    pub(super) fn new(total_reg_num: usize, params: &ParamsInfo) -> Self {
+    pub(super) fn new(
+        total_reg_num: usize,
+        params: &ParamsInfo,
+        destructed_args: std::ops::Range<usize>,
+    ) -> Self {
         let reg_num = total_reg_num - 1;
         let arg_num = params.args_names.len();
         let stack_offset = (reg_num * 8 + (RSP_LOCAL_FRAME + LFP_ARG0) as usize + 31) / 16;
@@ -349,6 +361,8 @@ impl FnInitInfo {
             reg_num,
             arg_num,
             stack_offset,
+            destruct_start: destructed_args.start,
+            destruct_len: destructed_args.len(),
         }
     }
 }

--- a/monoruby/src/codegen/arch/aarch64/compile/init_method.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/init_method.rs
@@ -20,10 +20,18 @@ impl Codegen {
         );
         self.a64_sp_sub(prologue_bytes as u32);
         let clear_len = info.reg_num - info.arg_num;
-        if clear_len > 0 {
+        if clear_len > 0 || info.destruct_len > 0 {
             monoasm_arm64!(&mut self.jit, mov x9, (NIL_VALUE););
             for i in 0..clear_len {
                 let off = (info.arg_num + i) as u32 * 8 + LFP_ARG0 as u32;
+                self.a64_frame_store(9, lfp, off);
+            }
+            // Destructured block params (`|(a, b)|`): inside the argument
+            // area (missed by the loop above) and written only by the
+            // `expand`s after entry — nil-fill them so the entry GC poll
+            // never marks stack garbage. Mirrors x86 `init_func`.
+            for i in 0..info.destruct_len {
+                let off = (info.destruct_start + i) as u32 * 8 + LFP_ARG0 as u32;
                 self.a64_frame_store(9, lfp, off);
             }
         }

--- a/monoruby/src/codegen/arch/aarch64/vmgen/init_method.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen/init_method.rs
@@ -10,6 +10,8 @@ impl Codegen {
         let p = self.jit.get_current_address();
         let skip = self.jit.label();
         let loop_ = self.jit.label();
+        let dskip = self.jit.label();
+        let dloop = self.jit.label();
         // allocate stack: sp -= stack_offset * 16
         monoasm_arm64!(&mut self.jit,
             ldrh x10, [x(PC.0)];
@@ -28,6 +30,24 @@ impl Codegen {
             ldrb x13, [x10];
             tbnz x13, #(7), skip;  // on_heap
             tbnz x13, #(3), skip;  // invalidated
+        // Destructured-parameter slots (`|(a, b)|`): inside the argument
+        // area (missed by the arg_num..reg_num fill below), written only
+        // by the `expand`s after entry — nil-fill them so the entry GC
+        // poll never marks stack garbage. Range rides in the second
+        // instruction word: start at `[PC+8]`, len at `[PC+10]`.
+            ldrh x12, [x(PC.0), #(10)];  // destruct_len
+            cbz x12, dskip;
+            ldrh x11, [x(PC.0), #(8)];   // destruct_start
+            neg x11, x11;
+            add x11, x(LFP.0), x11, lsl #(3);
+            sub x11, x11, #(LFP_ARG0 as u32);  // &slot[destruct_start]
+            mov x14, (NIL_VALUE);
+            dloop:
+            str x14, [x11];
+            sub x11, x11, #(8);
+            sub x12, x12, #(1);
+            cbnz x12, dloop;
+            dskip:
         // count = reg_num - arg_num
             ldrh x15, [x(PC.0), #(4)];  // reg_num
             ldrh x11, [x(PC.0), #(2)];  // arg_num

--- a/monoruby/src/codegen/arch/x86_64/compile/init_method.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/init_method.rs
@@ -41,6 +41,15 @@ impl Codegen {
                 );
             }
         }
+        // Destructured block params (`|(a, b)|`): their slots are inside
+        // the argument area, so the loop above misses them, and no caller
+        // writes them — the `expand`s after entry do. Nil-fill them so
+        // the callee-entry GC poll never marks stack garbage.
+        for i in 0..fn_info.destruct_len {
+            monoasm!( &mut self.jit,
+                movq [rbp - (RBP_LOCAL_FRAME + (fn_info.destruct_start + i) as i32 * 8 + LFP_ARG0)], (NIL_VALUE);
+            );
+        }
         self.jit.bind_label(l1);
     }
 }

--- a/monoruby/src/codegen/arch/x86_64/vmgen/init_method.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen/init_method.rs
@@ -24,6 +24,7 @@ impl Codegen {
         let label = self.jit.get_current_address();
         self.vm_init_func();
         self.fill_nil();
+        self.fill_destruct();
         // Callee-entry GC/preempt poll. This is the one point every call
         // path funnels through — including the Rust invokers
         // (`invoke_method` / `invoke_block`), which have no call-site
@@ -81,6 +82,38 @@ impl Codegen {
         l0:
             movq [r15 + rax * 8], (NIL_VALUE);
             subq rax, 1;
+            jne  l0;
+        l1:
+        };
+    }
+
+    ///
+    /// Fill NIL_VALUE to the destructured-parameter slots (`|(a, b)|`).
+    ///
+    /// They live inside the argument area (so `fill_nil` misses them),
+    /// and no caller writes them — the `expand` instructions after entry
+    /// do — so without this the callee-entry GC poll marks stack garbage.
+    /// The slot range rides in the instruction's second word:
+    /// `destruct_start` at `[r13 - 8]`, `destruct_len` at `[r13 - 6]`.
+    ///
+    /// ### destroy
+    /// - rax, rdi
+    ///
+    fn fill_destruct(&mut self) {
+        let l0 = self.jit.label();
+        let l1 = self.jit.label();
+        self.jit.branch_if_captured(&l1);
+        monoasm! { &mut self.jit,
+            movzxw rdi, [r13 - 6];  // destruct_len
+            testq rdi, rdi;
+            jz   l1;
+            movzxw rax, [r13 - 8];  // destruct_start
+            negq rax;
+            lea  rax, [r14 + rax * 8 - (LFP_ARG0)];  // &slot[destruct_start]
+        l0:
+            movq [rax], (NIL_VALUE);
+            subq rax, 8;
+            subq rdi, 1;
             jne  l0;
         l1:
         };

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2088,7 +2088,16 @@ mod tests {
     /// refinement. Expected result: `1249925000.0`.
     #[test]
     fn test_fpr_swap_mixed_refinement() {
-        run_test(
+        // Loop JIT compiles at 15 iterations in test mode, so a small n
+        // still exercises the swap path; under gc-stress every safepoint
+        // collects and run_test's 25 warm-up runs of a 100k-iteration
+        // loop would flirt with the CI timeout.
+        let n = if cfg!(feature = "gc-stress") {
+            2_000
+        } else {
+            100_000
+        };
+        run_test(&format!(
             r###"
         def f(n)
           x = 0.0
@@ -2103,9 +2112,9 @@ mod tests {
           end
           x
         end
-        f(100000)
-        "###,
-        );
+        f({n})
+        "###
+        ));
     }
 
     /// §15.5: a loop-carried float enters a loop JIT from the VM as a boxed

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -705,6 +705,8 @@ impl TraceIr {
                     reg_num: op1_w1 as usize,
                     arg_num: op2_w2 as usize,
                     stack_offset: op3_w3 as usize,
+                    destruct_start: (op2 as u16) as usize,
+                    destruct_len: ((op2 >> 16) as u16) as usize,
                 }),
                 173 => TraceIr::ExpandArray {
                     src: SlotId::new(op1_w1),

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -1166,6 +1166,13 @@ fn handle_keyword(
         if any_keyword_passed(globals, caller, caller_lfp)? {
             return Err(MonorubyErr::argumenterr("no keywords accepted"));
         }
+        // `**nil` still reserves a kwrest argument slot that nothing
+        // else writes (it binds no local); store a real Value or the
+        // callee-entry GC poll marks stack garbage. Mirrors
+        // `handle_keyword_simple` / the forwarding fast path.
+        if let Some(kwr) = globals[callee].kw_rest() {
+            unsafe { *callee_lfp.register_ptr(kwr) = Some(Value::nil()) };
+        }
         return Ok(());
     }
     let mut unknowns = ordinary_keyword(globals, callee, caller, callee_lfp, caller_lfp)?;

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3131,36 +3131,41 @@ impl Executor {
         let kw = if cs_kw_len == 0 {
             None
         } else {
-            let mut map = HashmapInner::default();
-            for (k, offset) in cs_kw_args.into_iter() {
-                map.insert(
-                    Value::symbol(k),
-                    lfp.register(cs_kw_pos + offset).unwrap(),
-                    self,
-                    globals,
-                )
-                .unwrap();
-            }
-            // Merge hash splat arguments into the keyword hash. `**obj`
-            // accepts any #to_hash-convertible object (implicit
-            // conversion), not just a Hash.
-            for pos in cs_hash_splat_pos.iter() {
-                if let Some(v) = lfp.register(*pos) {
-                    if !v.is_nil() {
-                        let hash = match v.coerce_to_hash(self, globals) {
-                            Ok(h) => h,
-                            Err(err) => {
-                                self.set_error(err);
-                                return None;
+            // Build the kwargs into a rooted Ruby Hash (not a bare Rust
+            // `HashmapInner`): `insert` / `#to_hash` re-enter Ruby, and a
+            // fresh `#to_hash` result plus the half-built map must
+            // survive those collections.
+            let res = self.with_temp_scope(|vm| {
+                vm.temp_push(Value::hash_from_inner(HashmapInner::default()));
+                let map_idx = vm.temp_len() - 1;
+                for (k, offset) in cs_kw_args.into_iter() {
+                    let key = Value::symbol(k);
+                    let val = lfp.register(cs_kw_pos + offset).unwrap();
+                    vm.temp_at(map_idx).as_hash().insert(key, val, vm, globals)?;
+                }
+                // Merge hash splat arguments into the keyword hash. `**obj`
+                // accepts any #to_hash-convertible object (implicit
+                // conversion), not just a Hash.
+                for pos in cs_hash_splat_pos.iter() {
+                    if let Some(v) = lfp.register(*pos) {
+                        if !v.is_nil() {
+                            let hash = v.coerce_to_hash(vm, globals)?;
+                            vm.temp_push(hash.into());
+                            for (k, v) in hash.iter() {
+                                vm.temp_at(map_idx).as_hash().insert(k, v, vm, globals)?;
                             }
-                        };
-                        for (k, v) in hash.iter() {
-                            map.insert(k, v, self, globals).unwrap();
                         }
                     }
                 }
+                Ok(vm.temp_at(map_idx).as_hash())
+            });
+            match res {
+                Ok(h) => Some(h),
+                Err(err) => {
+                    self.set_error(err);
+                    return None;
+                }
             }
-            Some(Value::hash_from_inner(map).as_hash())
         };
         // method_missing should always be callable regardless of visibility.
         // In Ruby, method_missing is conventionally private, but the VM must
@@ -4629,6 +4634,12 @@ pub(crate) extern "C" fn execute_gc(
     // hang watchdog's countdown (no-op unless armed). See
     // doc/signal.md B+.
     crate::watchdog::poll();
+    // `gc-stress`: force a collection at EVERY safepoint, unconditionally
+    // — independent of the runtime `GC.stress` flag and of how this poll
+    // was triggered. The guard re-arms the GC lane on every exit path, so
+    // the poll word never rests at zero and no poll skips this function.
+    #[cfg(feature = "gc-stress")]
+    let _stress_rearm = crate::poll_flag::StressRearm;
     // Consume the PREEMPT lane first: whether this poll wants a
     // collection, a timeslice switch, or both is decided lane by lane —
     // a pure preempt tick never runs a spurious full GC. See
@@ -4698,7 +4709,7 @@ pub(crate) extern "C" fn execute_gc(
             }
         }
     }
-    if crate::poll_flag::gc_requested() && !deferred_signal {
+    if (cfg!(feature = "gc-stress") || crate::poll_flag::gc_requested()) && !deferred_signal {
         // Forensics (`MONORUBY_GC_BREAK=N`): dump the trigger context of GC
         // #N — who called into the collector, from which executor, and what
         // the scheduler state was — right before that collection runs.

--- a/monoruby/src/executor/op/binary_ops.rs
+++ b/monoruby/src/executor/op/binary_ops.rs
@@ -101,7 +101,12 @@ fn complex_real_op(
     let (re, im) = (c.re().get(), c.im().get());
     let new_re = vm.invoke_method_simple(globals, op, re, &[rhs])?;
     let new_im = if op == IdentId::_MUL {
-        vm.invoke_method_simple(globals, op, im, &[rhs])?
+        // `new_re` can be a fresh heap numeric only this Rust local
+        // references while the imaginary-part dispatch runs — root it.
+        vm.with_temp_scope(|vm| {
+            vm.temp_push(new_re);
+            vm.invoke_method_simple(globals, op, im, &[rhs])
+        })?
     } else {
         im
     };

--- a/monoruby/src/globals/gvar.rs
+++ b/monoruby/src/globals/gvar.rs
@@ -551,9 +551,16 @@ fn write_special_check(
         // still reaches this check, so match it too for the error
         // message's sake.
         "$/" | "$-0" => {
-            let val = frozen_string_or_nil(&n, val)?;
+            // Type-check, then warn, then copy — in that order:
+            // `__warn_deprecated` runs Ruby, and the fresh frozen copy
+            // would live only in a Rust local across it (its cell was
+            // collected under gc-stress, leaving `$/` dangling). `val`
+            // itself is safe: it is rooted by the caller's frame.
+            if !val.is_nil() && val.is_rstring_inner().is_none() {
+                return Err(MonorubyErr::typeerr(format!("value of {n} must be String")));
+            }
             warn_deprecated_separator(vm, globals, &n, val);
-            Ok(val)
+            frozen_string_or_nil(&n, val)
         }
         // Output record / field separators: String or nil, stored
         // as-is (CRuby does not copy these).

--- a/monoruby/src/poll_flag.rs
+++ b/monoruby/src/poll_flag.rs
@@ -146,6 +146,19 @@ pub(crate) fn gc_requested() -> bool {
     with_flag(|f| f.load(Ordering::Relaxed) & GC_LANE_MASK != 0).unwrap_or(true)
 }
 
+/// `gc-stress` builds force a collection at every safepoint. This guard
+/// re-arms the GC lane on drop, so `execute_gc` leaves the poll word
+/// non-zero on every exit path (normal, deferred, or error) and the next
+/// poll takes the slow path again.
+#[cfg(feature = "gc-stress")]
+pub(crate) struct StressRearm;
+#[cfg(feature = "gc-stress")]
+impl Drop for StressRearm {
+    fn drop(&mut self) {
+        set_gc();
+    }
+}
+
 /// Arm the preempt lane from the owning thread (stress mode re-arm; the
 /// timer thread writes through its own registered address in preempt.rs).
 pub(crate) fn set_preempt() {

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3484,23 +3484,29 @@ fn recompile_on_polymorphic_comparison_flip() {
     // receiver forever (the aarch64 bug where the RecompileDeopt side-exit
     // collapsed to a plain deopt). Exercises the recompile write-back on both
     // backends.
-    run_test(
+    //
+    // The warm-up loop only has to clear the test-mode JIT thresholds (5 calls
+    // / 15 loop iterations); 2000 iterations x25 runs cost 162s on the
+    // coverage-instrumented CI runner once gc-stress collects at every
+    // safepoint, so the stress build warms up with 100 instead.
+    let warm = if cfg!(feature = "gc-stress") { 100 } else { 2000 };
+    run_test(&format!(
         r#"
-        class A; def ==(o); "A==#{o}"; end; end
-        class B; def ==(o); "B==#{o}"; end; end
+        class A; def ==(o); "A==#{{o}}"; end; end
+        class B; def ==(o); "B==#{{o}}"; end; end
         def cmp(x); x == 5; end
         a = A.new; b = B.new
         res = []
         i = 0
-        while i < 2000; cmp(a); i += 1; end   # warm monomorphic (A)
+        while i < {warm}; cmp(a); i += 1; end   # warm monomorphic (A)
         j = 0
         while j < 30                           # polymorphic -> recompile to guard-free
           res << cmp(a) << cmp(b)
           j += 1
         end
         res.uniq.sort
-        "#,
-    );
+        "#
+    ));
 }
 
 #[test]
@@ -3511,19 +3517,30 @@ fn recompile_hot_method_after_class_version_bump() {
     // ClassVersionGuardFailed) rather than deopt to the interpreter for the
     // rest of the process (the aarch64 permanent-strand bug). Verify results
     // stay correct across the bump.
-    run_test(
+    //
+    // 3000 warm-up + 3000 post-bump iterations x25 runs took 373s on the
+    // coverage-instrumented CI runner under gc-stress (a collection at every
+    // safepoint). 100 iterations on each side of the bump still clears the
+    // test-mode thresholds (5 calls / 15 loop iterations) with room to spare,
+    // so the method is JIT'd before the bump and re-JIT'd after it.
+    let (warm, total) = if cfg!(feature = "gc-stress") {
+        (100, 200)
+    } else {
+        (3000, 6000)
+    };
+    run_test(&format!(
         r#"
         class Lib; def twice(n); n + n; end; end
         $lib = Lib.new
         def work(n); $lib.twice(n) + 1; end
         s = 0
         i = 0
-        while i < 3000; s += work(i); i += 1; end   # warm -> method JIT
+        while i < {warm}; s += work(i); i += 1; end   # warm -> method JIT
         class Other; def noop; end; end              # bump class version
-        while i < 6000; s += work(i); i += 1; end    # keep calling across the bump
+        while i < {total}; s += work(i); i += 1; end    # keep calling across the bump
         s
-        "#,
-    );
+        "#
+    ));
 }
 
 #[test]
@@ -3535,7 +3552,16 @@ fn eager_forwarding_into_req_only_callee() {
     // calling the runtime helper; any guard miss (keyword forwarded, wrong
     // length) still falls back to the helper and matches CRuby — including the
     // ArgumentError on an arity mismatch.
-    run_test(
+    //
+    // The loop only exists to get the four trampolines JIT-compiled, and it
+    // allocates a fresh `C` plus a forwarding rest array every iteration. Under
+    // gc-stress (a collection at every safepoint) 3000 iterations x25 runs blew
+    // past nextest's 600s timeout on the coverage-instrumented CI runner — the
+    // outputs still matched, it was just too slow. 100 iterations still clears
+    // the test-mode thresholds (5 calls / 15 loop iterations) several times
+    // over, so every trampoline is still compiled before the checks below.
+    let n = if cfg!(feature = "gc-stress") { 100 } else { 3000 };
+    run_test(&format!(
         r##"
         def a0; 42; end
         def a1(x); x * 10; end
@@ -3543,21 +3569,21 @@ fn eager_forwarding_into_req_only_callee() {
         def f0(...); a0(...); end
         def f1(...); a1(...); end
         def f5(...); a5(...); end
-        def kw_target(a, b); "#{a}/#{b}"; end
+        def kw_target(a, b); "#{{a}}/#{{b}}"; end
         def fkw(...); kw_target(...); end
-        class P; def greet(a, b); "#{a}:#{b}"; end; end
+        class P; def greet(a, b); "#{{a}}:#{{b}}"; end; end
         class C < P; def greet(...); super(...); end; end
         res = []
         i = 0
-        while i < 3000
+        while i < {n}
           f0; f1(i); f5(i, i, i, i, i); C.new.greet(i, i)
           i += 1
         end
         res << f0 << f1(9) << f5(1, 2, 3, 4, 5) << fkw(1, 2) << C.new.greet(7, 8)
         res << (begin; f5(1, 2); rescue ArgumentError; "argerr"; end)
         res
-        "##,
-    );
+        "##
+    ));
 }
 
 #[test]
@@ -3567,7 +3593,13 @@ fn jit_integer_method_with_bignum_receiver() {
     // a BigNum straight to the VM (`a64_guard_class2`) instead of the
     // miss/profile-patch chain — results must stay correct across interleaved
     // fixnum and BigNum receivers.
-    run_test(
+    //
+    // As with the neighbouring recompile tests, the fixnum warm-up loop only
+    // has to reach the test-mode JIT thresholds (5 calls / 15 loop iterations);
+    // 3000 iterations x25 runs cost 320s on the coverage-instrumented CI runner
+    // under gc-stress, so the stress build warms up with 100.
+    let warm = if cfg!(feature = "gc-stress") { 100 } else { 3000 };
+    run_test(&format!(
         r#"
         class Integer
           def dbl; self * 2; end
@@ -3575,15 +3607,15 @@ fn jit_integer_method_with_bignum_receiver() {
         end
         s = 0
         i = 0
-        while i < 3000; s += i.dbl + i.add5(3); i += 1; end
+        while i < {warm}; s += i.dbl + i.add5(3); i += 1; end
         big = 10 ** 40
         res = []
         [5, big, big + 1, 7, big * big, 9, -8, -big].each do |n|
           res << n.dbl << n.add5(100)
         end
         [s, res]
-        "#,
-    );
+        "#
+    ));
 }
 
 #[test]

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -1384,13 +1384,19 @@ fn block_optional() {
 
 #[test]
 fn nested_blockargproxy() {
+    // Under gc-stress every safepoint collects, so the 10^4-yield nest (x25
+    // runs) blows past nextest's 600s CI timeout. 3^3 outer iterations with
+    // the innermost loop kept at 10 still JIT-compiles every frame and
+    // exercises the same BlockArgProxy forwarding chain.
+    let n = if cfg!(feature = "gc-stress") { 3 } else { 10 };
     run_test_with_prelude(
         r#"
         $x = 0
         g { 42 }
         $x
         "#,
-        r#"
+        &format!(
+            r#"
         def e
           10.times do
             $x += yield
@@ -1398,19 +1404,20 @@ fn nested_blockargproxy() {
         end
 
         def f(&q)
-          10.times do
+          {n}.times do
             e(&q)
           end
         end
 
         def g(&p)
-          10.times do
-            10.times do
+          {n}.times do
+            {n}.times do
               f(&p)
             end
           end
         end
-        "#,
+        "#
+        ),
     );
 }
 
@@ -3575,7 +3582,13 @@ fn object_send_inline() {
     // block, keywords, class method, arity errors, NoMethodError, and a varying
     // method name (LFU symbol-cache promotion), all hammered to trigger the
     // inline generator. Must match CRuby.
-    run_test(
+    //
+    // Under gc-stress every safepoint collects and 50k iterations (x25 runs)
+    // exceed nextest's 600s CI timeout; 500 iterations still clear the JIT
+    // thresholds (5 calls / 15 loop iters in test mode) and the LFU
+    // symbol-cache promotion the loop exists to provoke.
+    let n = if cfg!(feature = "gc-stress") { 500 } else { 50000 };
+    run_test(&format!(
         r##"
         class C
           def m0; "m0"; end
@@ -3589,19 +3602,19 @@ fn object_send_inline() {
         end
         c = C.new
         res = []
-        50000.times do
+        {n}.times do
           c.send(:m0); c.send(:m1, 5); c.__send__(:m6, 1,2,3,4,5,6)
           c.send(:rest, 1, 2, 3); c.send(:opt, 10)
         end
         res << c.send(:m0) << c.send(:m1, 42) << c.__send__(:m6, 1,2,3,4,5,6)
         res << c.send("m0") << c.send(:rest) << c.send(:rest, 1, 2, 3, 4)
         res << c.send(:opt, 10) << c.send(:opt, 10, 20)
-        res << c.send(:blk) { 777 } << c.send(:kw, a: 9, b: 4)
+        res << c.send(:blk) {{ 777 }} << c.send(:kw, a: 9, b: 4)
         res << c.send(*[:m1, 88]) << C.send(:smeth, 8)
         res << (c.send(:opt) rescue "argerr")
         res << (c.send(:nope, 1) rescue $!.class.name)
-        [:m0, :m1, :rest].each { |m| res << (m == :m1 ? c.send(m, 7) : c.send(m)) }
+        [:m0, :m1, :rest].each {{ |m| res << (m == :m1 ? c.send(m, 7) : c.send(m)) }}
         res
-        "##,
-    );
+        "##
+    ));
 }

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -2935,12 +2935,22 @@ fn method_call_on_fresh_class_each_iteration() {
     // each time. The JIT must not compile a specialization per singleton class
     // (the per-class warm-up profiler keeps these one-shot classes out of the
     // compiler). Correctness must be unaffected regardless.
+    //
+    // Each iteration leaks a class into the mark set, so under gc-stress (a
+    // collection at every safepoint) the cost is quadratic: 300 iterations
+    // x25 runs took 131s locally, the slowest test in the stress suite and
+    // close enough to nextest's 600s timeout to matter on the slower,
+    // coverage-instrumented CI runner. 40 fresh singleton classes still take
+    // the call site far past the warm-up threshold (5 calls in test mode).
+    let n = if cfg!(feature = "gc-stress") { 40 } else { 300 };
     run_test_with_prelude(
-        r##"
+        &format!(
+            r##"
         res = 0
-        300.times { res += Class.new.tag }
+        {n}.times {{ res += Class.new.tag }}
         res
-        "##,
+        "##
+        ),
         r##"
         class Object
           def tag = 7

--- a/monoruby/tests/signal_handling.rs
+++ b/monoruby/tests/signal_handling.rs
@@ -120,25 +120,27 @@ fn fork_child_signal_death_is_observable() {
 
 #[test]
 fn sleep_is_interrupted_by_signals() {
-    // A trap firing mid-sleep interrupts the nanosleep promptly; the whole
-    // script must finish far sooner than the requested 30s sleep.
-    let start = std::time::Instant::now();
+    // A trap firing mid-sleep interrupts the nanosleep promptly, rather than
+    // being deferred to the safepoint after the full 30s elapses. Printing
+    // "wake" alone does not prove that — a trap drained *after* an
+    // uninterrupted `sleep 30` raises the same RuntimeError — so the script
+    // times its own sleep with CLOCK_MONOTONIC. Measuring in-script (instead
+    // of wall-clocking the child from here) keeps the bound independent of
+    // process startup, which under gc-stress + coverage instrumentation costs
+    // ~35s on its own and swamped the old 10s outer budget.
     let out = monoruby(
         r##"Signal.trap("ALRM") { raise "wake" }
            pid = fork { sleep 0.2; Process.kill :ALRM, Process.ppid }
+           t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
            begin
              sleep 30
              puts :overslept
            rescue RuntimeError => e
              puts e.message
            end
+           puts((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t) < 10)
            Process.wait(pid)"##,
     );
-    assert_eq!(stdout(&out), "wake\n");
+    assert_eq!(stdout(&out), "wake\ntrue\n");
     assert!(out.status.success());
-    assert!(
-        start.elapsed() < std::time::Duration::from_secs(10),
-        "sleep was not interrupted (took {:?})",
-        start.elapsed()
-    );
 }


### PR DESCRIPTION
## Summary

Restores `gc-stress` as a **true stress mode**: under the feature, `execute_gc` runs a collection at **every safepoint, unconditionally** — independent of the runtime `GC.stress` flag (which keeps CRuby-identical semantics), with a drop guard re-arming the GC lane on every exit path so no poll ever takes the fast path. Verified: a 100K-allocation script now runs **258,721** collections (previously 11 — the feature had been inert since the `&gt;= 8` page band was introduced, its only effect being the initial poll-word value).

## CI scope: manual, both architectures

Per-safepoint collection is what finds the bugs below, but it is far too slow to run on every push: on the coverage-instrumented `amd64` job it took the nextest phase from ~10 min to ~100 min, and the heaviest JIT warm-up tests kept crowding nextest's per-test cap (one run died on a 600 s timeout with output that matched CRuby — it was purely too slow).

- **Automatic workflow (`rust.yml`)**: both jobs now set `SKIP_GC_STRESS=1`. Measured effect on `amd64`: **50 min → 15.6 min** (and 117 min for the run that timed out).
- **New manual workflow (`.github/workflows/gc-stress.yml`)**: `workflow_dispatch` only, running the suite under `gc-stress` on **x86-64 (`ubuntu-latest`) and aarch64 (`ubuntu-24.04-arm`, native — not qemu)**. Inputs: `arch` (both/x86_64/aarch64), `scope` (`nextest` / `full`), `test_filter`, `no_fail_fast`. No coverage — instrumentation is a ~7.5x multiplier that adds nothing to a stress hunt.
  - On the arm64 runner the job overrides `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_{LINKER,RUNNER}`: `.cargo/config.toml` pins that triple to the x86-64-host cross toolchain (`aarch64-linux-gnu-gcc` + `qemu-aarch64`), and on a native arm64 host the triple *is* the host, so cargo would otherwise link with a missing compiler and run every test under emulation — the combination `bin/test-aarch64` already warns is unusable under stress.
- `bin/test` still applies `gc-stress` to the **nextest phase only**; the benchmark / optcarrot / ruby-bench / ruby-spec binary builds with `stress-spill-pool` alone. A local `bin/test` stress-tests by default.
- Tests whose loop counts exist only to reach the JIT thresholds now shrink them under `cfg!(feature = "gc-stress")`, and `.config/nextest.toml` gains a `gc-stress` profile with a 20-min per-test cap (selected via `NEXTEST_PROFILE`, because `cargo llvm-cov` would eat `--profile` as the *cargo* profile).

## What deterministic per-safepoint GC caught (all fixed here)

Two frame-layout bugs where the callee-entry GC poll marked raw stack garbage as Values:

1. **Destructured block parameters** (`|(a, b)|`): their slots sit in the argument area, so the `arg_num..reg_num` nil-fill skipped them, and nothing writes them until the `expand` instructions *after* the entry poll. The destructure-slot range now rides in the previously-unused second word of the `init_method` bytecode and is nil-filled by all four backends (VM + JIT × x86-64 + aarch64).
2. **`**nil` kwrest slot**: the keyword-forbidding definition reserves a kwrest argument slot but binds no local, and `handle_keyword`&#39;s forbid branch never wrote it (SEGV via `def m(a, **nil)`).

A family of ~35 &#34;unrooted fresh Value across Ruby re-entry&#34; bugs in builtins — an object freshly created in Rust, held only in a Rust local or `Vec` while `invoke_block` / `#to_str` / `#to_ary` / hash-`eql?` dispatch runs Ruby, is invisible to the mark phase and gets swept. Confirmed-crashing sites included `Dir.foreach`, `Encoding::Converter.new`, `File.open`, `ENV.to_h`, `IO.popen` (block result), `Enumerator` chains, `Complex#/` (Smith&#39;s algorithm intermediates), `Process.waitall` (corrupted pair list), and the `$/` setter (the frozen copy died across the deprecation warning, leaving `$/` dangling). A subagent audit swept `builtins/` for the same pattern and the fixes cover `Array#|/#union/#difference/#uniq/#product/#intersect?`, `Hash#sort/#merge/#to_h`, `ENV.fetch/.delete/.merge!`, `IO#puts`/`IO.pipe`/`IO.new`, `Range#minmax`, `Module#attr`, `Exception#exception`, `String#+`, `Kernel#raise`, ARGF stream switching, `Set#divide` (classification identity could be recycled mid-grouping, corrupting groups), `Complex#numerator/#fdiv/#-@`, `complex_real_op`, `method_missing` kwarg packing, and `Marshal.load` — whose whole object link table is now a rooted Ruby Array instead of a bare `Vec`.

One test-only race made deterministic by stress and fixed for real: `GC_FORCE_MAJOR` (the `GC.start` &#34;next collection is a Major&#34; latch) was process-global while the allocator is thread-local, so one test thread&#39;s `GC.start` could inject a Major into another thread&#39;s `GC.stat(:major_gc_count)`. It is now thread-local.

## Coverage

Eight tests were added for rooting paths the suite never reached (patch coverage 86.05% → 96.68%), the largest being `Complex#numerator`, whose body was never executed at all: also `Hash#sort` with a comparator block, `ENV.fetch`, `File.new`/`File.open` from a raw fd, the `File.new`/`IO.new` block warnings, and `IO#puts` stringification.

Two notes from that work:

- The Rust `Hash#to_h` block branch is **shadowed dead code**: `monoruby/builtins/hash.rb` reopens `class Hash` at startup and defines `to_h` in Ruby (`Hash.instance_method(:to_h).source_location` is `["<internal:hash>", 11]`), so the rooting added there is unreachable from Ruby. Left in place; flagged for a separate decision.
- The remaining 25 uncovered lines are structurally unreachable rather than untested: 15 are that shadowed `to_h`, 4 are `cfg!(feature = "gc-stress")` arms whose opposite side is dead in any single build, 5 are `?`-propagation lines on calls that succeeded, and 3 are a `set_error` path needing a key whose `hash` method raises.

## Found but not fixed here

`Hash#sort` with a block honours only Fixnum comparator returns — `Float`/`Bignum` comparators are silently ignored (producing an **unsorted** result with no error) and `nil` skips CRuby's `ArgumentError`. `Array#sort` handles all three correctly, so this diverges from CRuby *and* from the sibling implementation. This PR only reindents that code, so it is pre-existing: filed as #1076.

## Verification

- Full suite under forced `gc-stress`: **3046/3046 passed** locally in 562 s with zero SLOW (&gt;60 s) markers; slowest test 20 s
- Full suite without the feature: 3054/3054 passed (no behavior change in normal builds)
- Differential vs CRuby (plain build): `app_fib`, `tarai`, `so_mandelbrot` (JIT and `--no-jit`) — byte-identical
- aarch64: `cargo check` clean; the destructure / `**nil` / enumerator-chain regression cases all pass under qemu with the aarch64 `gc-stress` build (the new A64 `init_method` fill paths exercised directly)
- Docs updated: CLAUDE.md, doc/gc.md, docs/src/garbage-collection.md, bin/test comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_