### PR TITLE
Interpret comparator block results like CRuby's rb_cmpint (fixes #1076)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2439,11 +2439,7 @@ pub(crate) fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         let mut min = ary[0];
         for v in &ary[1..] {
             let block_res = vm.invoke_block(globals, &data, &[*v, min])?;
-            if block_res.is_nil() {
-                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-            }
-            let res = block_res.coerce_to_int_i64(vm, globals)?;
-            if res < 0 {
+            if vm.cmpint(globals, block_res, *v, min)? == std::cmp::Ordering::Less {
                 min = *v;
             }
         }
@@ -2479,11 +2475,7 @@ pub(crate) fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         let mut max = ary[0];
         for v in &ary[1..] {
             let block_res = vm.invoke_block(globals, &data, &[*v, max])?;
-            if block_res.is_nil() {
-                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-            }
-            let res = block_res.coerce_to_int_i64(vm, globals)?;
-            if res > 0 {
+            if vm.cmpint(globals, block_res, *v, max)? == std::cmp::Ordering::Greater {
                 max = *v;
             }
         }
@@ -2518,17 +2510,11 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         let data = vm.get_block_data(globals, bh)?;
         for v in &ary[1..] {
             let r_min = vm.invoke_block(globals, &data, &[*v, min])?;
-            if r_min.is_nil() {
-                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-            }
-            if r_min.coerce_to_int_i64(vm, globals)? < 0 {
+            if vm.cmpint(globals, r_min, *v, min)? == std::cmp::Ordering::Less {
                 min = *v;
             }
             let r_max = vm.invoke_block(globals, &data, &[*v, max])?;
-            if r_max.is_nil() {
-                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-            }
-            if r_max.coerce_to_int_i64(vm, globals)? > 0 {
+            if vm.cmpint(globals, r_max, *v, max)? == std::cmp::Ordering::Greater {
                 max = *v;
             }
         }
@@ -2624,33 +2610,7 @@ fn sort_with_buf(
         let data = vm.get_block_data(globals, bh)?;
         let f = |lhs: Value, rhs: Value| -> Result<std::cmp::Ordering> {
             let block_res = vm.invoke_block(globals, &data, &[lhs, rhs])?;
-            if block_res.is_nil() {
-                return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-            }
-            // Try to use <=> with 0 for non-Integer results
-            let res = match block_res.try_fixnum() {
-                Some(i) => i,
-                None => {
-                    // Try coercing via <=> with 0
-                    let cmp = vm.invoke_method_inner(
-                        globals,
-                        IdentId::_CMP,
-                        block_res,
-                        &[Value::integer(0)],
-                        None,
-                        None,
-                    )?;
-                    if cmp.is_nil() {
-                        return Err(MonorubyErr::argumenterr("comparison of elements failed"));
-                    }
-                    cmp.coerce_to_int_i64(vm, globals)?
-                }
-            };
-            Ok(match res {
-                0 => std::cmp::Ordering::Equal,
-                res if res < 0 => std::cmp::Ordering::Less,
-                _ => std::cmp::Ordering::Greater,
-            })
+            vm.cmpint(globals, block_res, lhs, rhs)
         };
         executor::op::sort_by(&mut ary, buf, f)?;
     } else {
@@ -7233,5 +7193,35 @@ mod tests {
             // No initial value and an empty receiver yields nil.
             r#"[].inject { |s, e| s + e }"#,
         ]);
+    }
+
+    #[test]
+    fn sort_min_max_non_integer_comparator() {
+        // Companion to #1076: `sort` / `min` / `max` / `minmax` all route a
+        // comparator block's result through the same `rb_cmpint` rules, so a
+        // Float, Bignum or Rational comparator sorts correctly...
+        run_test(
+            r#"
+            a = [3, 1, 2]
+            [
+              a.sort { |x, y| (x <=> y) * 1.0 },
+              a.sort { |x, y| (x <=> y) * (10 ** 20) },
+              a.min { |x, y| (x <=> y) * 1.0 },
+              a.max { |x, y| (x <=> y) * 1.0 },
+              a.minmax { |x, y| Rational(x <=> y, 3) },
+            ]
+            "#,
+        );
+        // ...and an incomparable result raises with CRuby's wording: `nil`
+        // names the two elements' classes, while a non-numeric result names
+        // itself against the 0 it was compared with.
+        run_test(
+            r#"
+            a = [[1], [2]]
+            f = ->(m) { begin; a.send(m) { |x, y| nil }; rescue => e; [e.class, e.message]; end }
+            g = ->(m) { begin; a.send(m) { |x, y| "z" }; rescue => e; [e.class, e.message]; end }
+            [:sort, :min, :max, :minmax].map { |m| [f.(m), g.(m)] }
+            "#,
+        );
     }
 }

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1415,12 +1415,14 @@ fn sort(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
                 if err.is_some() {
                     return std::cmp::Ordering::Equal;
                 }
-                match vm.invoke_block(globals, &data, &[*a, *b]) {
-                    Ok(r) => match r.try_fixnum() {
-                        Some(n) if n < 0 => std::cmp::Ordering::Less,
-                        Some(n) if n > 0 => std::cmp::Ordering::Greater,
-                        _ => std::cmp::Ordering::Equal,
-                    },
+                // Interpret the block's result exactly as `Array#sort` does:
+                // an Integer's sign, a non-Integer via its own `<=>` against
+                // 0, and `nil` as "not comparable" (ArgumentError).
+                match vm
+                    .invoke_block(globals, &data, &[*a, *b])
+                    .and_then(|r| vm.cmpint(globals, r, *a, *b))
+                {
+                    Ok(ord) => ord,
                     Err(e) => {
                         err = Some(e);
                         std::cmp::Ordering::Equal
@@ -4647,6 +4649,37 @@ mod tests {
             rescue ArgumentError => e
               [e.class, e.message]
             end
+            "#,
+        );
+    }
+
+    #[test]
+    fn hash_sort_non_integer_comparator() {
+        // Regression for #1076: `Hash#sort` used to honour only Fixnum
+        // comparator results and silently treat everything else as "equal",
+        // so a Float or Bignum comparator returned an UNSORTED array with no
+        // error and a `nil` comparator swallowed CRuby's ArgumentError. It
+        // now follows `rb_cmpint` like `Array#sort`: an Integer's sign, any
+        // other object via its own `<=>` against 0, and `nil` as an error.
+        run_test(
+            r#"
+            h = { "b" => 2, "a" => 1, "c" => 3 }
+            [
+              h.sort { |x, y| (x[1] <=> y[1]) * 1.0 },            # Float
+              h.sort { |x, y| (x[1] <=> y[1]) * (10 ** 20) },     # Bignum
+              h.sort { |x, y| Rational(x[1] <=> y[1], 3) },       # Rational
+            ]
+            "#,
+        );
+        // `nil` names the two elements; a non-numeric result names itself
+        // against the 0 it was compared with — both exactly as CRuby does.
+        run_test(
+            r#"
+            h = { "b" => 2, "a" => 1, "c" => 3 }
+            [
+              (begin; h.sort { |x, y| nil }; rescue => e; [e.class, e.message]; end),
+              (begin; h.sort { |x, y| "z" }; rescue => e; [e.class, e.message]; end),
+            ]
             "#,
         );
     }

--- a/monoruby/src/executor/op/sort.rs
+++ b/monoruby/src/executor/op/sort.rs
@@ -41,6 +41,65 @@ impl Executor {
         };
         merge_sort(vec, buf, is_less)
     }
+
+    ///
+    /// Interpret a comparator block's return value as an ordering, following
+    /// CRuby's `rb_cmpint`.
+    ///
+    /// An Integer gives its sign directly; `nil` means the two elements are
+    /// not comparable; anything else is asked to compare *itself* against 0,
+    /// so a `Float`, `Bignum` or `Rational` comparator works the way CRuby's
+    /// does. `lhs`/`rhs` are the elements being compared and are only used to
+    /// name the operands in the error.
+    ///
+    /// Every caller that runs a user comparator block must go through this:
+    /// `Hash#sort` used to interpret only `Fixnum` and silently collapse
+    /// everything else to "equal", which returned an unsorted result with no
+    /// error for a `Float`/`Bignum` comparator and swallowed the
+    /// `ArgumentError` for `nil` (#1076).
+    ///
+    pub(crate) fn cmpint(
+        &mut self,
+        globals: &mut Globals,
+        res: Value,
+        lhs: Value,
+        rhs: Value,
+    ) -> Result<std::cmp::Ordering> {
+        if res.is_nil() {
+            return Err(cmperr(&globals.store, lhs, rhs));
+        }
+        let i = match res.try_fixnum() {
+            Some(i) => i,
+            None => {
+                let zero = Value::integer(0);
+                let cmp =
+                    self.invoke_method_inner(globals, IdentId::_CMP, res, &[zero], None, None)?;
+                if cmp.is_nil() {
+                    // CRuby reaches the same place through `res > 0`, and
+                    // names the comparator's own result: e.g. a String
+                    // comparator gives "comparison of String with 0 failed".
+                    return Err(cmperr(&globals.store, res, zero));
+                }
+                cmp.coerce_to_int_i64(self, globals)?
+            }
+        };
+        Ok(i.cmp(&0))
+    }
+}
+
+///
+/// CRuby's `rb_cmperr`: the receiver is named by class, and the argument by
+/// `inspect` when it is an immediate or a Float — so `0` reads as `0` rather
+/// than `Integer` — and by class otherwise.
+///
+pub(crate) fn cmperr(store: &Store, x: Value, y: Value) -> MonorubyErr {
+    let x_name = x.get_real_class_name(store);
+    let y_name = if y.is_packed_value() || matches!(y.unpack(), RV::Float(_)) {
+        y.inspect(store)
+    } else {
+        y.get_real_class_name(store)
+    };
+    MonorubyErr::argumenterr(format!("comparison of {x_name} with {y_name} failed"))
 }
 
 ///


### PR DESCRIPTION
## Summary

`Hash#sort` with a block honoured only **Fixnum** comparator results. Anything else — `Float`, `Bignum`, `nil` — fell into a catch-all arm that collapsed to `Ordering::Equal`, so a `Float` or `Bignum` comparator returned an **unsorted** array with no error at all, and a `nil` comparator silently skipped the `ArgumentError` CRuby raises.

```rust
Ok(r) => match r.try_fixnum() {
    Some(n) if n < 0 => Ordering::Less,
    Some(n) if n > 0 => Ordering::Greater,
    _ => Ordering::Equal,          // <- Float / Bignum / nil all land here
},
```

The cause was duplication: `Array#sort` already had the right logic, written out inline a second time. Rather than copy it a third time, this extracts it as `Executor::cmpint` (CRuby's `rb_cmpint`) and routes every comparator-block caller through it, so the two cannot drift apart again.

## Also closes the message gap noted in the issue

That turned out to be the same defect, not a separate cosmetic one. `Array#min` / `#max` / `#minmax` rejected `nil` but pushed anything else straight into `coerce_to_int_i64`, raising `TypeError` where CRuby raises `ArgumentError` for e.g. a String comparator — and they reported a generic `"comparison of elements failed"` instead of naming the operands.

`cmperr` now follows CRuby's `rb_cmperr`: the receiver by class, the argument by `inspect` when it is an immediate or a `Float` and by class otherwise. So `nil` reports `"comparison of Array with Array failed"`, and a String comparator reports `"comparison of String with 0 failed"` — the latter because CRuby reaches the error through `res > 0`, naming the comparator's own result rather than the elements.

## Before / after (all vs CRuby 4.0.2)

| Case | Before | After (= CRuby) |
|---|---|---|
| `h.sort { Float }` | unsorted, no error | sorts correctly |
| `h.sort { Bignum }` | unsorted, no error | sorts correctly |
| `h.sort { nil }` | unsorted, no error | `ArgumentError: comparison of Array with Array failed` |
| `h.sort { "z" }` | unsorted, no error | `ArgumentError: comparison of String with 0 failed` |
| `[[1],[2]].min { nil }` | `comparison of elements failed` | `comparison of Array with Array failed` |
| `[[1],[2]].min { "z" }` | `TypeError` | `ArgumentError: comparison of String with 0 failed` |

## Verification

- The issue's reproduction plus `Rational`, `String`, `0` and raising comparators, across `sort` / `min` / `max` / `minmax` on both `Hash` and `Array`: **21/21 cases byte-identical to CRuby 4.0.2**, error messages included.
- Full suite: **3058/3058 passed**.
- Two regression tests added (`hash_sort_non_integer_comparator`, `sort_min_max_non_integer_comparator`). Both use `run_test`, so they pin the messages against CRuby too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_