### PR TITLE
zip: propagate exceptions raised by the argument's #each (fixes #1080)

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1796,7 +1796,15 @@ fn zip(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
                         .invoke_method_inner(globals, next_id, enum_val, &[], None, None)
                     {
                         Ok(val) => vm.temp_array_push(val),
-                        Err(_) => break, // StopIteration — enumerator exhausted
+                        // Only exhaustion ends the pull. Anything else is
+                        // the argument's own `each` failing and must reach
+                        // the caller: swallowing it silently padded the row
+                        // with nils instead of raising, so a GC-induced
+                        // failure showed up as wrong data rather than an
+                        // error (and `[1,2].zip(o)` with a raising `o.each`
+                        // returned [[1,nil],[2,nil]] where CRuby raises).
+                        Err(err) if err.is_stop_iteration(&globals.store) => break,
+                        Err(err) => return Err(err),
                     }
                 }
                 let inner = vm.temp_pop();
@@ -5016,6 +5024,37 @@ mod tests {
         ]);
         // zip raises TypeError for non-enumerable
         run_test_error(r##"[1, 2].zip(42)"##);
+    }
+
+    #[test]
+    fn zip_propagates_each_errors() {
+        // Pulling from an `#each`-based argument stops on StopIteration —
+        // that is exhaustion — but any *other* exception is the argument's
+        // own `each` failing and must reach the caller. Swallowing it padded
+        // the row with nils and returned silently wrong data instead of
+        // raising, which also disguised an unrelated GC failure as a bad
+        // result rather than an error.
+        run_test(
+            r##"
+            o = Object.new
+            def o.each; raise "boom"; end
+            begin; [1, 2].zip(o); rescue => e; [e.class, e.message]; end
+            "##,
+        );
+        // ...including when it raises part-way through the iteration.
+        run_test(
+            r##"
+            o = Object.new
+            def o.each; yield 1; raise ArgumentError, "mid"; end
+            begin; [1, 2].zip(o); rescue => e; [e.class, e.message]; end
+            "##,
+        );
+        // NOTE: a StopIteration raised by the argument's own `each` is still
+        // mistaken for exhaustion here, because the pull goes through
+        // `Enumerator#next` and monoruby's end-of-iteration signal is the
+        // same exception. CRuby collects with `each` + `break` instead, so
+        // it propagates that too. Not asserted, so this test does not pin
+        // the divergent behaviour; tracked separately.
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Array#zip` pulls from a non-Array argument with `to_enum` + `#next` and treated **any** error as end-of-iteration:

```rust
Err(_) => break, // StopIteration — enumerator exhausted
```

So an exception raised by the argument's own `each` was discarded and the row padded with `nil` — the caller got silently wrong data instead of the exception. Break only on `StopIteration` (`MonorubyErr::is_stop_iteration`, the same predicate `Kernel#loop` uses) and propagate everything else.

| | CRuby 4.0.2 | Before | After |
|---|---|---|---|
| `each` raises immediately | `[RuntimeError, "boom"]` | `[[1, nil], [2, nil]]` | `[RuntimeError, "boom"]` |
| `each` raises part-way | `[ArgumentError, "mid"]` | `[[1, 1], [2, nil]]` | `[ArgumentError, "mid"]` |

Architecture-independent — it reproduces on a plain x86-64 build with no stress features.

## Known remaining divergence

CRuby propagates a `StopIteration` raised by the argument's `each` too:

```ruby
o = Object.new
def o.each; yield 1; raise StopIteration; end
[1, 2, 3].zip(o)
#=> CRuby: raises StopIteration
#=> monoruby: [[1, 1], [2, nil], [3, nil]]
```

`rb_ary_zip` does not use `Enumerator#next` at all: it collects with `each` plus `rb_iter_break` once it has enough items, so *every* exception propagates and early termination is a `break` rather than an exception. monoruby's pull loop cannot tell the enumerator's own end-of-iteration signal apart from a user-raised `StopIteration`, since both arrive as the same exception from `#next`.

Fixing that means collecting via `each` + break (matching `rb_ary_zip`), which also drops the fiber machinery from this path — a larger change, left out here. The new test deliberately does **not** assert the current behaviour for that case, so nothing pins the divergence; it is described in a comment and tracked in #1080.

## Why this was worth separating out

This is what made #1079 (an AArch64 JIT/GC bug) present as silently wrong data rather than an error: `[1, 2].zip(10.upto(Float::INFINITY))` returned `[[1, nil], [2, nil]]` under `gc-stress` on aarch64 because the underlying failure was swallowed here. With this fix the aarch64 case still reproduces, but the class of "silent nils" is gone.

## Verification

- Both fixed cases byte-identical to CRuby 4.0.2.
- Full suite: **3057/3057 passed**.
- Regression test added (`zip_propagates_each_errors`), using `run_test` so the messages are pinned against CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_