### PR TITLE
Refinements: honour a refinement of a basic operation

### DIFF
--- a/doc/bop_redefinition.md
+++ b/doc/bop_redefinition.md
@@ -544,7 +544,51 @@ iseq 単位にするには、捨てた iseq の `LoopStart` オペランドを�
   （エッジトリガ）、走査対象もその (op, class) に依存したフレームに絞る。
 - 効果: 「無関係な `Float#+` の再定義で fib が 24 倍遅くなる」が消える。
 
-### Step 3 — refinements の基本演算（#1066）
+### Step 3 — refinements の基本演算（#1066）— **実装済み**
+
+Step 1・2 を終えた時点で、残作業は**ペアを記録することだけ**だった。実験で
+確認できる: 意味を変えない再定義（`alias __p +; def +(o) = __p(o)`）で
+フラグ*だけ*を立てると、`refine Integer { def +(o) = 42 }` が VM・JIT とも
+CRuby と同じ 42 を返した。下流はすべて既に動いていた —
+`Executor::find_method` は refinement 対応、JIT は `assume_basic_op` が
+false を返して通常呼び出しへ降格し `jit_check_method` が
+`JitContext::refinements` の下で解決する。
+
+検知点は `refine` 側ではなく `insert_method` / `remove_method` に置いた。
+refinement のメソッドは refinement モジュール側の ClassId に入るので、
+`refined_class()` を引いて `(refined_class, name)` で照会する。この位置なら
+`def` / `define_method` / `alias` / `import_methods` を 1 箇所でカバーできる
+（Step 1 の「メソッド表を変更する全経路に検知点を置く」と同じ理由）。
+
+**必要だった前提修正 — ライブラリ境界。**
+`Executor::frame_refinements` は monoruby が Ruby で書いたコアライブラリの
+フレームを**透過**して呼び出し側スコープまで歩く。これは `&obj` の
+`to_proc` や補間の `to_s` のためで、CRuby がそれらを呼び出し側の iseq で
+行うのに対し monoruby は callee 側で行うため、透過しないと一致しない。
+
+ところが**演算子はその種の変換ではない**。`Array#map` 自身の `i += 1` は
+ライブラリのコードで、CRuby では C — どの refinement からも見えない。
+呼び出し側スコープで解決した結果、refine された `Integer#+` が 42 を返して
+`map` が 1 周で終了していた（`[1,2,3].map { |x| x*2 }` → `[2, nil, nil]`、
+`(1..3).sum` → 42）。
+
+そこで `find_method` が解決対象の**名前**で分岐するようにした:
+`BASIC_OP_DEFS` の演算子名ならライブラリ境界で歩みを止め
+（`Executor::basic_op_refinements`）、それ以外は従来どおり透過する。
+
+**残る不精度。** ペアの記録はプロセス全体なので、`refine` しただけで
+（`using` していないスコープでも）その演算子の inline を失う:
+
+| 条件 | `fib(29)`×3 |
+| --- | ---: |
+| baseline | 0.014 |
+| `refine(Integer) { def + }` 後 | 0.034 |
+
+精密版は `JitContext::assume_basic_op` に `self.refinements` を見せるだけで、
+「コンパイル中のスコープが refine していなければ inline 継続」にできる。
+VM 側の asm ガードは呼び出し地点の文脈を持たないグローバル語なので粗いまま。
+
+### Step 3 の当初計画（記録として保存）
 
 Step 2 の (op, class) ビットマスクができれば、#1066 が要求する
 「refinement セットごとの BOP ビットマスク」はその自然な拡張になる。

--- a/doc/refinements.md
+++ b/doc/refinements.md
@@ -26,11 +26,12 @@ this process contain a refinement at all". A program that never calls
 `refine` emits byte-identical machine code to the one that predates all of
 this — checked against an `emit-asm` baseline, not assumed.
 
-**Known gaps.** A refinement of a *basic operation* (`Integer#+` and the
-other dispatch-table fast paths) is not seen, in either tier — §6.7. And
-one refinement cell per iseq means a *block* that runs `using` and
-executes more than once bases on the previous execution's set
-(`ISeqInfo::refinements`, §7.2 option C).
+**Known gaps.** One refinement cell per iseq means a *block* that runs
+`using` and executes more than once bases on the previous execution's set
+(`ISeqInfo::refinements`, §7.2 option C). Refinements of *basic operations*
+are now honoured in both tiers (§6.7), but coarsely: `refine`-ing one costs
+that operator's inline path process-wide, not only in the scopes that
+activate it.
 
 ---
 
@@ -487,15 +488,38 @@ and taking the global basic-op cliff. With `refined_names` it is neither:
   honest comparison — and because the JIT, which is where the time
   actually goes, keeps per-scope precision via the gate above.
 
-> **Update.** Neither half of this shipped: a refinement of a basic
-> operation is still unseen by both tiers. The reason turned out to be
-> upstream of refinements — the basic-op mechanism itself carries a single
-> process-wide "something was redefined" bit and covers only 10 of the
-> operators the two tiers inline, so there is nothing per-`(op, class)` for
-> a per-scope set to extend. `doc/bop_redefinition.md` measures that and
-> sets out the order: give basic ops `(op, class)` granularity and full
-> coverage first, then a refinement set's own bitmask is a natural
-> extension of it. Done in the other order, the design has to be redone.
+> **Update.** The order this called for was followed —
+> `doc/bop_redefinition.md` gave basic ops `(op, class)` granularity, full
+> coverage and per-iseq JIT invalidation first — and once that was in
+> place, honouring a refinement of a basic operation turned out to need
+> almost nothing beyond *marking the pair*. `insert_method` /
+> `remove_method` ask `refined_class()` for the class the refinement
+> refines and mark `(that class, name)`; both tiers then stop answering it
+> without a lookup, and the dispatch they fall back to was already
+> refinement-aware. `refine Integer { def +(o) = 42 }` now yields 42 in the
+> VM and in JIT-compiled code.
+>
+> Two things that fix did *not* buy:
+>
+> - **Per-scope precision.** Marking the pair is process-wide, so
+>   `refine`-ing `Integer#+` costs the inline path in every scope, not only
+>   the ones that `using` it (`fib(29)` 0.014 → 0.034). The precise version
+>   is the gate this section originally described, and it is now a small
+>   change: `JitContext::assume_basic_op` already takes `(class, op)` and
+>   the context already carries the set id, so the JIT can keep inlining
+>   wherever the compiling scope does not refine the operator. The VM's
+>   asm guard is a global word with no call-site context and stays coarse.
+> - **The inline-generator half**, which is still ungated.
+>
+> One boundary had to be drawn to make any of this correct — see
+> `Executor::basic_op_refinements`. monoruby writes part of its core
+> library in Ruby where CRuby uses C, and those frames are transparent to
+> refinements so that `&obj` / interpolation, which monoruby converts in
+> the callee and CRuby in the caller, reach the user's scope. An operator
+> is never such a conversion: `Array#map`'s own `i += 1` is library code,
+> C in CRuby and invisible to any refinement. Resolving it against the
+> caller ended the loop after one iteration. So operator names stop the
+> walk at the library boundary and everything else still walks out.
 
 ### 6.8 The remaining pieces
 

--- a/monoruby/src/builtins/module.rs
+++ b/monoruby/src/builtins/module.rs
@@ -6446,6 +6446,76 @@ mod tests {
         );
     }
 
+    /// A refinement of a basic operation has to reach both tiers. Both the
+    /// VM's assembly and the JIT answer `Integer#+` without a lookup, so
+    /// `refine` has to invalidate that fast path the same way a redefinition
+    /// does; the dispatch it falls back to is already refinement-aware.
+    /// #1066.
+    #[test]
+    fn refinement_of_a_basic_operation_is_honored() {
+        run_test_once(
+            r#"
+            module BopPlus
+              refine(Integer) { def +(o); 42; end }
+            end
+            inner = Module.new do
+              using BopPlus
+              def self.direct; 1 + 1; end
+              def self.viajit(a, b); a + b; end
+            end
+            i = 0
+            while i < 200      # past the JIT thresholds
+              inner.viajit(1, 1)
+              i = i.succ
+            end
+            [inner.direct, inner.viajit(1, 1), 1 + 1]
+            "#,
+        );
+    }
+
+    /// The library's own arithmetic is not the user's scope. monoruby writes
+    /// `Array#map` and friends in Ruby, where CRuby uses C — and a C frame
+    /// carries no cref, so a refinement of `Integer#+` must not reach the
+    /// `i += 1` those bodies loop on. Before the fix `map` ended after one
+    /// iteration.
+    #[test]
+    fn refinement_of_a_basic_operation_does_not_leak_into_ruby_builtins() {
+        run_test_once(
+            r#"
+            module BopLeak
+              refine(Integer) { def +(o); 42; end }
+            end
+            inner = Module.new do
+              using BopLeak
+              def self.run
+                [[1, 2, 3].map { |x| x * 2 }, (1..3).sum, [1, 2, 3].sum, 1 + 1]
+              end
+            end
+            inner.run
+            "#,
+        );
+    }
+
+    /// The same boundary for a protocol dispatch: interpolation runs in the
+    /// user's own iseq and sees the refinement, while `Array#join` reaching
+    /// for `to_s` from inside the library does not. CRuby draws the line in
+    /// exactly this place because `join` is C.
+    #[test]
+    fn refinement_stops_at_the_ruby_implemented_builtin_boundary() {
+        run_test_once(
+            r##"
+            module BopToS
+              refine(Integer) { def to_s; "REFINED"; end }
+            end
+            inner = Module.new do
+              using BopToS
+              def self.run; ["#{1}", [1].join, [1].to_s, 1.to_s]; end
+            end
+            inner.run
+            "##,
+        );
+    }
+
     #[test]
     fn using_gathers_refinements_of_ancestors() {
         // `using M` activates what M's *included* modules refine too.

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -2414,10 +2414,47 @@ impl Executor {
             // wrote against, so a protocol dispatch made from inside one
             // — `#to_proc` for a `&obj` argument, `#to_s` behind
             // interpolation — must keep walking out to the caller's
-            // scope. The same frames are already transparent to `$~`.
+            // scope. CRuby performs those conversions in the caller's own
+            // iseq; monoruby performs them inside the callee, and walking
+            // out is what makes the two agree. The same frames are already
+            // transparent to `$~`.
+            //
+            // The library's *own* operations are the opposite case, and
+            // `lexical_frame_refinements` handles them.
             if !globals.store[fid].meta().is_svar_transparent()
                 && let Some(iseq) = globals.store[fid].is_iseq()
             {
+                return globals.store.iseq_refinements(iseq);
+            }
+            cfp = c.prev();
+        }
+        RefinementSetId::EMPTY
+    }
+
+    ///
+    /// The set for a *basic operation* resolved from the current frame.
+    ///
+    /// Same walk as [`Self::current_refinements`] except that monoruby's
+    /// Ruby-written core library ends it instead of being walked through.
+    /// The two cases the transparency serves pull in opposite directions:
+    ///
+    /// - `&obj` / interpolation convert in the callee here where CRuby
+    ///   converts in the caller, so those must reach the caller's scope.
+    /// - `Array#map`'s own `i += 1` is the library's code, and in CRuby it
+    ///   is C — invisible to any refinement. Reaching the caller's scope
+    ///   there let a refined `Integer#+` end the loop after one iteration.
+    ///
+    /// An operator is never a conversion performed on the caller's behalf,
+    /// so the operator paths ask this instead. See #1066.
+    ///
+    pub(crate) fn basic_op_refinements(&self, globals: &Globals) -> RefinementSetId {
+        let mut cfp = self.cfp;
+        while let Some(c) = cfp {
+            let fid = c.lfp().func_id();
+            if globals.store[fid].meta().is_svar_transparent() {
+                return RefinementSetId::EMPTY;
+            }
+            if let Some(iseq) = globals.store[fid].is_iseq() {
                 return globals.store.iseq_refinements(iseq);
             }
             cfp = c.prev();
@@ -2917,8 +2954,18 @@ impl Executor {
         // The resolved method depends on the *caller's* scope once
         // refinements are in play. `EMPTY` — every scope in a program
         // that never refines anything — takes the same path as before.
+        //
+        // An operator is resolved against the scope that *wrote* it, which
+        // is not the same walk: monoruby's Ruby-written core library must
+        // not pick up a caller's refinement of `Integer#+` for its own
+        // `i += 1`, while a conversion it performs for the caller (`&obj`,
+        // interpolation) must. See `Self::basic_op_refinements`.
         let set = if globals.store.refinements().is_active() {
-            self.current_refinements(globals)
+            if globals.store.is_basic_op_name(func_name) {
+                self.basic_op_refinements(globals)
+            } else {
+                self.current_refinements(globals)
+            }
         } else {
             RefinementSetId::EMPTY
         };

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -400,6 +400,11 @@ impl Store {
         self.basic_ops.redefined_pair(class_id, name)
     }
 
+    /// Whether `name` is one of the operators with a lookup-free fast path.
+    pub(crate) fn is_basic_op_name(&self, name: IdentId) -> bool {
+        self.basic_ops.is_basic_op_name(name)
+    }
+
     #[cfg(feature = "emit-bc")]
     pub(super) fn functions(&self) -> &[FuncInfo] {
         self.functions.functions()

--- a/monoruby/src/globals/store/basic_op.rs
+++ b/monoruby/src/globals/store/basic_op.rs
@@ -113,6 +113,11 @@ pub(crate) const BASIC_OP_DEFS: &[(ClassId, &str)] = &[
 /// Interned [`BASIC_OP_DEFS`], plus the bootstrap latch.
 pub(crate) struct BasicOpTable {
     set: HashSet<(ClassId, IdentId)>,
+    /// Just the *names* in [`BASIC_OP_DEFS`], any class. Used to tell an
+    /// operator apart from a conversion performed on the caller's behalf
+    /// when resolving under refinements — see
+    /// `Executor::basic_op_refinements`.
+    names: HashSet<IdentId>,
     /// False until the builtins — Rust *and* the Ruby ones in
     /// `builtins/*.rb` — have finished defining themselves. Their own
     /// definitions land in this very table, so an armed lookup during
@@ -136,6 +141,10 @@ impl BasicOpTable {
                 .iter()
                 .map(|(class_id, name)| (*class_id, IdentId::get_id(name)))
                 .collect(),
+            names: BASIC_OP_DEFS
+                .iter()
+                .map(|(_, name)| IdentId::get_id(name))
+                .collect(),
             armed: false,
             redefined: false,
             redefined_set: HashSet::default(),
@@ -151,6 +160,11 @@ impl BasicOpTable {
     /// Whether replacing `class_id#name` invalidates a fast path.
     pub(crate) fn contains(&self, class_id: ClassId, name: IdentId) -> bool {
         self.armed && self.set.contains(&(class_id, name))
+    }
+
+    /// Whether `name` is an operator some class gets a fast path for.
+    pub(crate) fn is_basic_op_name(&self, name: IdentId) -> bool {
+        self.names.contains(&name)
     }
 
     /// Record that `class_id#name` was replaced.

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2193,6 +2193,7 @@ impl Store {
         if self.basic_ops.contains(class_id, func_name) {
             self.set_bop_redefine(class_id, func_name);
         }
+        self.check_refined_basic_op(class_id, func_name);
         if self.classes[class_id].methods.remove(&func_name).is_none() {
             Err(MonorubyErr::nameerr(format!(
                 "method `{}' not defined in {}",
@@ -2429,6 +2430,32 @@ impl Store {
         // inherited), yet defining one shadows a fast path all the same.
         if self.basic_ops.contains(class_id, name) {
             self.set_bop_redefine(class_id, name);
+        }
+        self.check_refined_basic_op(class_id, name);
+    }
+
+    ///
+    /// A refinement of a basic operation invalidates the fast paths for it
+    /// just as a redefinition does.
+    ///
+    /// The method lands in the *refinement module*, so the pair to ask
+    /// about is `(the class it refines, name)` — `refine Integer { def + }`
+    /// inserts `+` into an anonymous module, not into `Integer`. Both tiers
+    /// then stop answering `Integer#+` without a lookup and dispatch
+    /// instead, and dispatch is already refinement-aware
+    /// (`Executor::find_method`, `JitContext::jit_check_method`), so the
+    /// refined scope gets the refined method and every other scope gets the
+    /// builtin.
+    ///
+    /// Reaching this from `insert_method` / `remove_method` — rather than
+    /// from `refine` itself — is what covers `def`, `define_method`,
+    /// `alias` and `Refinement#import_methods` in one place. See #1066.
+    ///
+    fn check_refined_basic_op(&mut self, class_id: ClassId, name: IdentId) {
+        if let Some(refined) = self.classes[class_id].refined_class()
+            && self.basic_ops.contains(refined, name)
+        {
+            self.set_bop_redefine(refined, name);
         }
     }
 


### PR DESCRIPTION
Fixes #1066.

```ruby
module IntPlus
  refine(Integer) { def +(other) = 42 }
end
using IntPlus

p 1 + 1                      # CRuby => 42, monoruby => 2
def viajit(a, b) = a + b
100.times { viajit(1, 1) }
p viajit(1, 1)               # CRuby => 42, monoruby => 2
```

Both tiers answer `Integer#+` without consulting the method table, and
neither guard knows anything about the call site's lexical scope.

## The fix is smaller than the issue expected

Almost all of the machinery landed with the basic-op work (#1077). Forcing
the flag on with a semantics-preserving redefinition — `alias __p +; def
+(o) = __p(o)` — was enough to make the repro above print `42` in **both**
tiers, because everything downstream is already refinement-aware:

- `Executor::find_method` resolves against the current scope's set;
- the JIT's `assume_basic_op` demotes a flagged operator to an ordinary
  call, which `jit_check_method` resolves under the compiling scope's set;
- `using` bumps the class version, so compiled bodies re-resolve.

So the only missing piece was **marking the pair**. That also retires the
issue's objection to reusing `bop_redefined_flags`: it was written when the
flag was one global latch, and granularity is now `(class, op)` with
per-iseq invalidation.

The mark is taken in `insert_method` / `remove_method` rather than in
`refine`. A refinement's methods land in the refinement module, so
`refined_class()` gives the class to look the pair up against. Sitting on
the mutation path is what covers `def`, `define_method`, `alias` and
`import_methods` at once — the same reason the redefinition check lives
there.

## The boundary that had to be drawn first

`frame_refinements` walks *through* monoruby's Ruby-written core library
out to the caller's scope. That is deliberate and load-bearing: `&obj`
conversion and interpolation happen in the callee here where CRuby does
them in the caller, so only walking out makes the two agree.

But an operator is never a conversion performed on the caller's behalf.
`Array#map`'s own `i += 1` is library code — C in CRuby, invisible to any
refinement. Resolving it against the caller made a refined `Integer#+`
return 42 and end the loop after one iteration:

```
[1,2,3].map { |x| x * 2 }   # => [2, nil, nil]
(1..3).sum                  # => 42
```

Operator names now stop the walk at the library boundary while everything
else still walks out. The split is on the name, tested once in
`find_method`, so every fallback path is covered by the same rule.

This was latent before: basic operators never dispatched, so nothing
reached the walk. Fixing #1066 without it would have broken `Array#map`
for any program refining `Integer#+`.

## Verification

Checked against CRuby 4.0.2:

| | CRuby | monoruby |
| --- | --- | --- |
| issue repro, VM and JIT | `42 42` | `42 42` |
| `[map, (1..3).sum, [1,2,3].sum, 1+1]` under a refined `+` | `[[2,4,6], 6, 6, 42]` | same |
| `["#{1}", [1].join, [1].to_s, 1.to_s]` under a refined `to_s` | `["REFINED", "1", "[1]", "REFINED"]` | same |

`cargo test` green across all 59 suites; aarch64 cross-check clean. Three
regression tests added, one per row above.

## Known imprecision

Marking the pair is process-wide, so refining an operator costs its inline
path in every scope rather than only the ones that `using` it — `fib(29)`
0.014 → 0.034. Recovering it is a contained follow-up: `assume_basic_op`
already takes `(class, op)` and `JitContext` already carries the set id, so
the JIT can keep inlining in scopes whose set does not refine the operator.
The VM's guard is a global word and stays coarse. Recorded in
`doc/refinements.md` §6.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_