### PR TITLE
aarch64: preserve the caller-saved FP pool across the GC safepoint (fixes #1079)

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1400,18 +1400,35 @@ impl Codegen {
         );
         self.a64_gen_write_back_for_deopt(&write_back, base);
         let f = crate::executor::execute_gc as *const () as u64;
-        // Preserve the GP-alloc pool (x5-x8 = GP::R8-R11) across the call. They
-        // are AAPCS64 caller-saved and hold live pool Values. The
-        // write-back above spills them to their frame homes for GC marking, but
-        // the post-GC code keeps reading the *registers* (e.g. a pool-resident
-        // call receiver), so they must survive `execute_gc`. x86 preserves
-        // r8-r11 the same way in its `exec_gc` stub (save/restore_registers).
+        // Preserve the caller-saved halves of BOTH allocation pools across the
+        // call: the GP pool (x5-x8 = GP::R8-R11) and the FP pool (d2-d7).
+        // Both are AAPCS64 caller-saved and hold live pool values, and the
+        // write-back above only spills them to their frame homes for GC
+        // marking — the post-GC code keeps reading the *registers* (e.g. a
+        // pool-resident call receiver, or an unboxed float operand), so they
+        // must survive `execute_gc`. d8-d15 / x19-x28 are callee-saved, so the
+        // Rust callee preserves those itself.
+        //
+        // x86 preserves the equivalent registers in its `exec_gc` stub:
+        // `save_registers`/`restore_registers` cover r8-r11 *and* xmm2-xmm15.
+        // Omitting the d2-d7 half here let `execute_gc` clobber a live unboxed
+        // float, so e.g. `10.upto(Float::INFINITY)`'s enumerator saw a garbage
+        // limit and terminated immediately (#1079) — the same failure the
+        // recompile path below already guards against with the identical save.
+        //
         // The GC is mark-and-sweep (non-moving), so a heap value the write-back
         // kept alive is not relocated and restoring the raw register value is
         // correct (Fixnum immediates are trivially fine for the same reason).
         monoasm_arm64!(&mut self.jit,
-            stp x5, x6, [sp, #-16]!;
-            stp x7, x8, [sp, #-16]!;
+            sub sp, sp, #(80);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            stp x5, x6, [sp, #(48)];
+            stp x7, x8, [sp, #(64)];
         );
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;
@@ -1422,8 +1439,15 @@ impl Codegen {
             ldr x30, [sp], #16;
         );
         monoasm_arm64!(&mut self.jit,
-            ldp x7, x8, [sp], #16;
-            ldp x5, x6, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            ldp x5, x6, [sp, #(48)];
+            ldp x7, x8, [sp, #(64)];
+            add sp, sp, #(80);
         );
         monoasm_arm64!(&mut self.jit,
             cbz x0, error;             // None -> error


### PR DESCRIPTION
## Summary

The JIT's GC safepoint on aarch64 (`emit_exec_gc`) called `execute_gc` while saving only the caller-saved **GP** pool (`x5`-`x8`). The FP pool's caller-saved half, **`d2`-`d7`**, was left live across the call — and under AAPCS64 those are volatile, so the Rust callee was free to clobber them, and did.

The write-back before the poll spills those registers to their frame homes *for GC marking*, but the post-GC code keeps reading the **registers**, so a live unboxed float came back as garbage.

Concretely: `10.upto(Float::INFINITY)`'s producer fiber compared against a clobbered limit, decided it was already exceeded, and ran to completion — so the enumerator reported `StopIteration` on its first `#next`. Through `Array#zip` that surfaced as `[[1, nil], [2, nil]]`, which is how it was first noticed.

## This is a missing half, not a design choice

- **x86-64 already does it.** Its `exec_gc` stub's `save_registers` / `restore_registers` cover `r8`-`r11` **and `xmm2`-`xmm15`** — the whole FP pool.
- **The recompile path in this very file already does it**, saving `d2`-`d7` alongside `x5`-`x8`. Its comment records the same class of failure from when the *GP* half was missing there ("`require "set"`/`"bigdecimal"` corruption") and points at "the twin save in `a64_gen_exec_gc`". Only the GP half was ever added to `emit_exec_gc`.

The fix mirrors the recompile path's save/restore exactly. `d8`-`d15` and `x19`-`x28` are callee-saved, so the Rust callee preserves those itself.

This accounts for every condition observed while bisecting: aarch64 only (x86 saves its xmms), JIT only (the VM keeps floats in memory), `gc-stress` only (the call has to actually happen), and `Float` only — a `Fixnum` limit is an immediate and a `Bignum` limit is never unboxed, and both were unaffected.

## Verification — the blast radius was much wider than `zip`

Same 107-test batch (`test(zip) or test(float) or test(enumerator) or test(fiber)`), aarch64 under qemu with `--features stress-spill-pool,gc-stress`, `--no-fail-fast` both times:

| | Baseline (master) | With the fix |
|---|---|---|
| passed | 98 | **106** |
| failed | **8** | **0** |
| timed out | 1 | 1 |

The eight baseline failures:

```
SIGABRT  builtins::array::tests::zip                     <- the reported CI failure
SIGABRT  builtins::numeric::integer::tests::upto_with_float
SIGABRT  codegen::jitgen::state::slot::tests::test_join_float_register_disagreement
SIGABRT  codegen::jitgen::state::slot::tests::test_join_float_register_three_way
FAIL     codegen::jitgen::state::slot::tests::test_loop_carried_float_kept_unboxed
FAIL     builtins::fiber::tests::fiber_raise_kill_edges
FAIL     builtins::fiber::tests::fiber_transfer_basic
FAIL     builtins::fiber::tests::fiber_storage
```

All eight pass with the fix. Most are float-register tests — `zip` was one symptom of a broader breakage that the manual `gc-stress` run never saw, because it fail-fasted on `zip` (test 3 of the batch) before reaching the others.

Also verified with the fix: the minimal reproduction, a six-way limit-type matrix (`Float::INFINITY` / `1e18` / Fixnum / Bignum / endless Range / Array enumerator), and the original `zip` reproduction — all previously failing, all now clean.

### The one remaining timeout is environmental

`builtins::enumerator::tests::with_index_and_with_object_run_without_a_fiber` times out in **both** runs — 603 s baseline, 601 s fixed — against nextest's 600 s cap. That is qemu emulation overhead, not a code failure; on the native `ubuntu-24.04-arm` runner the manual workflow uses, it should be well inside the cap.

### x86-64

Unaffected: the changed file is `target_arch`-gated and is not compiled on x86-64. 59 float/`zip` tests re-run there anyway — all pass.

## Note

`gc-verify` *not* firing was the decisive clue: nothing reachable was being freed, which ruled out a missed-root/sweep hypothesis and redirected the search to register clobbering.

This bug is also a data point for including aarch64 in the manual `gc-stress` workflow — it is invisible on x86-64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_