### PR TITLE
gc-stress: make it opt-in via GC_STRESS=1, and apply it to every phase

### DIFF
--- a/.github/workflows/darwin-hang-debug.yml
+++ b/.github/workflows/darwin-hang-debug.yml
@@ -47,7 +47,6 @@ jobs:
       # Match the normal `darwin` job: no `gc-stress` on this runner.
       # It is now a true per-safepoint stress mode and only the Linux
       # `amd64` job runs it (see bin/test).
-      SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/.github/workflows/gc-stress.yml
+++ b/.github/workflows/gc-stress.yml
@@ -5,8 +5,8 @@
 # local across a Ruby re-entry is invisible to the mark phase and gets swept),
 # but it is far too slow to run on every push: on the `amd64` job, stacked on
 # top of llvm-cov instrumentation, it turned a ~10 min nextest phase into
-# ~100 min. So the automatic `Rust` workflow now sets `SKIP_GC_STRESS=1` on
-# both of its jobs, and the stress coverage lives here instead — dispatched by
+# ~100 min. `gc-stress` is therefore opt-in (`GC_STRESS=1`), nothing enables
+# it implicitly, and the stress coverage lives here instead — dispatched by
 # hand from the Actions tab (or `gh workflow run gc-stress.yml`).
 #
 # Run this when touching the GC, frame layout, argument binding, or any
@@ -27,7 +27,7 @@ on:
         options: [both, x86_64, aarch64]
         default: both
       scope:
-        description: "nextest = unit + integration tests under gc-stress. full = the whole bin/test scope (also benchmarks / optcarrot / ruby-spec, which build WITHOUT gc-stress)."
+        description: "nextest = unit + integration tests under gc-stress (~minutes). full = the whole bin/test scope — benchmarks, optcarrot and ruby/spec under gc-stress too, which takes HOURS."
         type: choice
         options: [nextest, full]
         default: nextest
@@ -78,9 +78,11 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.select.outputs.targets) }}
-    # Per-safepoint collection is slow by design; `full` on top of that is
-    # slower still. Well above any healthy run, well below a wedged one.
-    timeout-minutes: 240
+    # Per-safepoint collection is slow by design, and `full` now stresses the
+    # long-running phases too (optcarrot, ruby/spec) — hours, not minutes. 350
+    # is just under GitHub's 360-minute ceiling for hosted runners: high enough
+    # not to guillotine a healthy `full` run, and it still bounds a wedged one.
+    timeout-minutes: 350
     env:
       CARGO_TERM_COLOR: always
       # 20-min per-test cap instead of the default 10: under stress the
@@ -149,10 +151,11 @@ jobs:
           cargo nextest run "${args[@]}"
 
       # --- scope: full ------------------------------------------------------
-      # `bin/test` enables gc-stress for its nextest phase unless
-      # SKIP_GC_STRESS=1 (which is what the automatic workflow now sets), so
-      # simply NOT setting it here is what turns the stress on. SKIP_COV=1
-      # keeps llvm-cov out of the picture.
+      # GC_STRESS=1 turns the feature on for EVERY phase of `bin/test`, so the
+      # benchmark / optcarrot / ruby-bench / ruby-spec phases run under stress
+      # as well — that is the point of the manual run, since those phases are
+      # what exercise the JIT deepest. Expect hours. SKIP_COV=1 keeps llvm-cov
+      # out of the picture (it would only multiply the cost).
       - name: Clone optcarrot
         if: inputs.scope == 'full'
         run: git clone https://github.com/mame/optcarrot.git ../optcarrot
@@ -179,5 +182,6 @@ jobs:
       - name: bin/test under gc-stress
         if: inputs.scope == 'full'
         env:
+          GC_STRESS: "1"
           SKIP_COV: "1"
         run: bin/test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,16 +16,6 @@ jobs:
       # still beats a thrashing one), and having the limit set exercises the
       # cap's init + hot-path compare under the coverage run.
       MONORUBY_MALLOC_HARD_LIMIT: 6G
-      # No `gc-stress` on the automatic runs. Since it became a true stress
-      # mode (a collection at EVERY safepoint) it dominated this job: on top
-      # of llvm-cov instrumentation the nextest phase went from ~10 min to
-      # ~100 min, and the heaviest JIT warm-up tests kept crowding nextest's
-      # per-test cap. Every push paying that is not worth it.
-      # The stress coverage now lives in `.github/workflows/gc-stress.yml`,
-      # a manually dispatched workflow that runs the suite under `gc-stress`
-      # on BOTH x86-64 and aarch64 — run it when touching GC, frame layout,
-      # or rooting.
-      SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -107,14 +97,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
-      # Drop `gc-stress` (a collection at every safepoint). It was the single
-      # biggest multiplier in the run, and the M1 runner was finishing right
-      # at its per-attempt cap — three commits in a row passed only on the
-      # second attempt, and the fourth then exhausted both. The `amd64` job
-      # above now skips it for the same reason; stress coverage for both
-      # architectures lives in the manually dispatched
-      # `.github/workflows/gc-stress.yml`.
-      SKIP_GC_STRESS: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,11 +417,12 @@ bin/test
 `bin/test` does:
 
 1. `cargo llvm-cov nextest` with the stress features (`stress-spill-pool`, plus
-   `gc-stress` unless `SKIP_GC_STRESS=1` — **both** automatic CI jobs set it,
-   so pushes/PRs no longer pay the per-safepoint stress; see the manual
-   `gc-stress` workflow below)
-2. Builds a debug benchmark binary **without** `gc-stress` (true per-safepoint
-   stress would make the benchmark/optcarrot/spec phases take hours)
+   `gc-stress` only when `GC_STRESS=1` is exported — it is opt-in, so pushes
+   and PRs never pay the per-safepoint stress; see the manual `gc-stress`
+   workflow below)
+2. Builds a debug benchmark binary with the **same** feature list, so under
+   `GC_STRESS=1` the benchmark/optcarrot/spec phases are stressed too (that
+   run takes hours — it is a manual, deliberate exercise)
 3. Runs benchmark scripts and `diff`s output against CRuby
 4. Runs optcarrot and compares output
 5. Generates `lcov.info` coverage report
@@ -522,7 +523,8 @@ Do not add new nightly features without necessity; prefer stable alternatives wh
 
 File: `.github/workflows/rust.yml`
 
-Triggered on push/PR to `master`. Two jobs run, **both with `SKIP_GC_STRESS=1`**:
+Triggered on push/PR to `master`. Neither job sets `GC_STRESS`, so neither
+pays the per-safepoint stress:
 
 - **Linux/x86-64** (`ubuntu-latest`): install Ruby 4.0+, Rust nightly,
   `cargo-llvm-cov` + `cargo-nextest`, clone optcarrot / ruby-bench / ruby-spec,
@@ -544,8 +546,9 @@ touching the GC, frame layout, argument binding, or any builtin that creates a
 Value and then re-enters Ruby.
 
 Inputs: `arch` (`both` / `x86_64` / `aarch64`), `scope` (`nextest` = the unit +
-integration suite under stress, `full` = the whole `bin/test` scope),
-`test_filter` (a nextest `-E` expression), `no_fail_fast`.
+integration suite under stress, minutes; `full` = the whole `bin/test` scope
+with `GC_STRESS=1`, so benchmarks / optcarrot / ruby-spec are stressed too —
+**hours**), `test_filter` (a nextest `-E` expression), `no_fail_fast`.
 
 It runs on `ubuntu-latest` (x86-64) and `ubuntu-24.04-arm` (**native** arm64
 Linux — not qemu), and collects no coverage. On the arm64 runner the job
@@ -608,5 +611,5 @@ run `bin/refresh-prism-vendored` (rebuilds and force-pushes
 3. **Ruby in PATH**: Tests compare output against a system `ruby` binary matching the vendored pin (`4.0.2`, see `vendor/ruby-stdlib/.ruby-version`). Ensure Ruby is installed and the binary is accessible.
 4. **optcarrot**: The full CI test requires optcarrot cloned at `../optcarrot` relative to the repo root.
 5. **Library path**: `build.rs` does **not** invoke a host `ruby` for `$LOAD_PATH` / `RUBY_VERSION` (those come from the vendored snapshot). Host-installed *non-default* gems are discovered at run time by `src/ruby_probe.rs`, which invokes a host `ruby` once if present and caches `~/.monoruby/{library_path,gem_path}`. If no host Ruby is found, those caches stay empty and a warning is printed at startup, but the vendored stdlib still loads from the per-version install root (`~/.monoruby/v<version>/lib`).
-6. **gc-stress in tests**: `bin/test` runs the nextest phase with `--features gc-stress` (unless `SKIP_GC_STRESS=1`) to catch GC bugs. Since the true-stress restoration this means a collection at **every safepoint** — the test binary is drastically slower than a normal debug build, and long-running workloads (benchmarks, optcarrot, ruby/spec) are deliberately built without it. Both automatic CI jobs now skip it; run the manual `gc-stress` workflow instead. Tests whose loop counts exist only to reach the JIT thresholds should shrink them under `cfg!(feature = "gc-stress")` (see `tests/method_call.rs`) — otherwise they blow past nextest's per-test cap.
+6. **gc-stress in tests**: `gc-stress` is **opt-in** — `export GC_STRESS=1` before `bin/test` and it applies to **every** phase (nextest *and* the benchmark binary, so optcarrot / ruby-spec are stressed too). Since the true-stress restoration this means a collection at **every safepoint**, so a `GC_STRESS=1` run of the full scope is an hours-scale job. Nothing enables it implicitly, so the automatic CI never pays it; run the manual `gc-stress` workflow instead. Tests whose loop counts exist only to reach the JIT thresholds should shrink them under `cfg!(feature = "gc-stress")` (see `tests/method_call.rs`) — otherwise they blow past nextest's per-test cap.
 7. **Thread-local CODEGEN**: The JIT compiler is a thread-local singleton. Do not attempt to use it across threads.

--- a/bin/test
+++ b/bin/test
@@ -21,31 +21,39 @@ RUBY=(ruby --yjit)
 # there — no pool allocation happens, which sidesteps the macOS-runner
 # `optcarrot --opt` divergence that the (non-empty) aarch64 pool path used to hit.
 #
-# `gc-stress` is now a true stress mode: the binary starts in `GC.stress`
-# and collects at EVERY safepoint. That makes long-running workloads
-# quadratic-ish (a trivial 100K-allocation loop takes ~100 s), so the
-# benchmark / optcarrot / ruby-bench / ruby-spec phases build WITHOUT it
-# and keep only the spill stress. SKIP_GC_STRESS=1 drops `gc-stress` from
-# the nextest phase too.
+# `gc-stress` is a true stress mode: the binary starts in `GC.stress` and
+# collects at EVERY safepoint. It is **opt-in** — export GC_STRESS=1 to turn
+# it on. Nothing enables it implicitly, so the automatic CI workflow needs no
+# opt-out; the manual .github/workflows/gc-stress.yml sets it.
 #
-# BOTH automatic CI jobs now set SKIP_GC_STRESS=1: even limited to the
-# nextest phase the stress dominated the run (~10 min -> ~100 min on the
-# coverage-instrumented `amd64` job, and the M1 `darwin` runner was
-# finishing right at its per-attempt cap). Stress coverage for x86-64 AND
-# aarch64 lives in .github/workflows/gc-stress.yml, dispatched by hand.
-# A local `bin/test` still stress-tests by default — export
-# SKIP_GC_STRESS=1 if you want the fast path.
-NEXTEST_FEATURE_LIST=stress-spill-pool
-if [ "${SKIP_GC_STRESS:-0}" != "1" ]; then
-  NEXTEST_FEATURE_LIST="$NEXTEST_FEATURE_LIST,gc-stress"
+# GC_STRESS=1 applies the feature to EVERY phase, not just nextest: the
+# benchmark binary is built with it too, so the benchmark / optcarrot /
+# ruby-bench / ruby-spec phases run under stress as well. That is the whole
+# point of a manual stress run — those phases are what exercise the JIT
+# deepest, and restricting the stress to the unit tests left the JIT x GC
+# interaction there unchecked (see #1079, an AArch64 JIT/GC bug that a unit
+# test happened to catch first).
+#
+# Be aware what that costs: per-safepoint collection makes long-running
+# workloads quadratic-ish — a trivial 100K-allocation loop takes ~100 s — so
+# optcarrot and ruby/spec go from seconds to a long grind. A full
+# GC_STRESS=1 run is an hours-scale job, not something to sit and wait for.
+GC_STRESS_ON=0
+[ "${GC_STRESS:-0}" = "1" ] && GC_STRESS_ON=1
+
+FEATURE_LIST=stress-spill-pool
+if [ "$GC_STRESS_ON" = "1" ]; then
+  FEATURE_LIST="$FEATURE_LIST,gc-stress"
   # Per-safepoint collection makes the heaviest JIT warm-up tests take minutes,
   # so use the `gc-stress` nextest profile (a 20-min per-test cap instead of
   # 10). Selected by env var rather than `--profile`, which `cargo llvm-cov`
   # would consume as the *cargo* profile.
   export NEXTEST_PROFILE=gc-stress
 fi
-NEXTEST_FEATURES=(--features "$NEXTEST_FEATURE_LIST")
-BENCH_FEATURES=(--features stress-spill-pool)
+NEXTEST_FEATURES=(--features "$FEATURE_LIST")
+# Same list as nextest: under GC_STRESS=1 the long-running phases are stressed
+# too, otherwise both are just the spill stress and no rebuild is needed.
+BENCH_FEATURES=(--features "$FEATURE_LIST")
 
 # Coverage wrappers. SKIP_COV=1 runs the whole script without llvm-cov
 # instrumentation and uploads nothing. Used by the arm64 macOS `darwin` job:
@@ -110,9 +118,11 @@ phase "nextest (unit + integration tests)"
 cov_clean
 cov_nextest "${NEXTEST_FEATURES[@]}"
 
-# Rebuild the benchmark binary WITHOUT `gc-stress` (see the feature-list
-# comment above): under true per-safepoint stress the benchmark/optcarrot/
-# spec phases would take hours. The feature change recompiles the lib once.
+# Build the binary the remaining phases run. It uses the same feature list as
+# nextest (see above), so under GC_STRESS=1 the benchmark / optcarrot /
+# ruby-bench / ruby-spec phases are stressed too — expect them to take hours
+# rather than seconds. Without GC_STRESS the lists are identical, so cargo
+# reuses the nextest build instead of recompiling the lib.
 phase "build benchmark binary"
 cov_build "${BENCH_FEATURES[@]}"
 


### PR DESCRIPTION
## Apply the stress to the whole run

`bin/test` deliberately rebuilt the benchmark binary **without** `gc-stress`, so the benchmark / optcarrot / ruby-bench / ruby-spec phases never ran under stress — only the unit and integration tests did.

That made a `scope=full` manual run say far less than it looked like it did. In the last one, optcarrot finished in **22 seconds**, which is impossible under per-safepoint collection (a trivial 100K-allocation loop takes ~100 s). Those phases are the ones that exercise the JIT deepest, and #1079 was an AArch64 JIT/GC bug that a unit test only happened to catch first — so leaving them unstressed left the most interesting surface unchecked.

The benchmark binary now uses the same feature list as nextest.

## Flip the switch to opt-in

`SKIP_GC_STRESS=1` meant the default was on and every caller that did not want it had to say so — backwards once both CI jobs and (now) the long phases are involved.

`GC_STRESS=1` turns it on for everything; nothing enables it implicitly. The automatic workflow loses its opt-out env entirely, the manual workflow sets `GC_STRESS` for its `full` scope, and a plain local `bin/test` is now the fast path.

| | before | after |
|---|---|---|
| default | gc-stress **on** | **off** |
| enable | (implicit) | `GC_STRESS=1` |
| scope | nextest only | **every phase** |
| automatic CI | `SKIP_GC_STRESS=1` set explicitly | nothing to set |

## The cost is real

A full `GC_STRESS=1` run is an **hours-scale** job, not minutes. The manual workflow's job timeout goes to 350 minutes (just under GitHub's 360-minute ceiling for hosted runners) and the `scope` input says so in its description.

## Verification

- No `SKIP_GC_STRESS` references remain anywhere (`bin/`, `.github/`, docs).
- All three workflow YAMLs parse; `bin/test` passes `bash -n`.
- The feature-selection branch checked both ways: unset → `stress-spill-pool` + default nextest profile; `GC_STRESS=1` → `stress-spill-pool,gc-stress` + the `gc-stress` profile.
- Docs updated (CLAUDE.md: `bin/test` phase list, CI section, gotcha #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_