### PR TITLE
Hash: add __key_at / __value_at index intrinsics, inlined to a C-ABI call

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -45,6 +45,24 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(HASH_CLASS, ">", gt, 1);
     globals.define_builtin_func(HASH_CLASS, ">=", ge, 1);
     globals.define_builtin_inline_func(HASH_CLASS, "[]", index, inline_gen2!(hash_index), 1);
+    // Positional entry access, used by Ruby-level iteration written as a
+    // `while` loop over indices instead of an `each` block. Internal: the
+    // index is a position in the hash's own entry order, which is not part of
+    // the public Ruby interface.
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "__key_at",
+        key_at,
+        inline_gen2!(hash_key_at),
+        1,
+    );
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "__value_at",
+        value_at,
+        inline_gen2!(hash_value_at),
+        1,
+    );
     globals.define_builtin_func(HASH_CLASS, "[]=", index_assign, 2);
     globals.define_builtin_func(HASH_CLASS, "clear", clear, 0);
     globals.define_builtin_func(HASH_CLASS, "replace", replace, 1);
@@ -887,6 +905,121 @@ fn hash_index(
     ir.handle_error(error);
     state.def_rax2acc(ir, callsite.dst);
     true
+}
+
+/// ### Hash#__key_at (internal)
+///
+/// The key of the `index`-th entry in insertion order, or `nil` when out of
+/// range. See `entry_at`.
+#[monoruby_builtin]
+fn key_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let idx = lfp.arg(0).coerce_to_i64(globals)?;
+    Ok(entry_component(lfp.self_val(), idx, true))
+}
+
+/// ### Hash#__value_at (internal)
+#[monoruby_builtin]
+fn value_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let idx = lfp.arg(0).coerce_to_i64(globals)?;
+    Ok(entry_component(lfp.self_val(), idx, false))
+}
+
+/// Shared by the builtin and the inlined C-ABI helper: a negative or
+/// out-of-range index is `nil` rather than an error, so a Ruby `while` loop
+/// can bound itself with `size` and never pay an error edge.
+fn entry_component(recv: Value, idx: i64, want_key: bool) -> Value {
+    if idx < 0 {
+        return Value::nil();
+    }
+    match recv.as_hash().entry_at(idx as usize) {
+        Some((k, v)) => {
+            if want_key {
+                k
+            } else {
+                v
+            }
+        }
+        None => Value::nil(),
+    }
+}
+
+extern "C" fn hash_key_at_extern(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    base: Value,
+    idx: Value,
+) -> Option<Value> {
+    // Only the Fixnum case is inlined; the guard in the generator keeps
+    // anything else on the generic path.
+    let i = idx.try_fixnum()?;
+    Some(entry_component(base, i, true))
+}
+
+extern "C" fn hash_value_at_extern(
+    _vm: &mut Executor,
+    _globals: &mut Globals,
+    base: Value,
+    idx: Value,
+) -> Option<Value> {
+    let i = idx.try_fixnum()?;
+    Some(entry_component(base, i, false))
+}
+
+/// Inline `Hash#__key_at` / `#__value_at` as a direct C-ABI call, reusing the
+/// `Hash#[]` call sequence (recv in Rdx, arg in Rcx, vm/globals loaded by the
+/// emitter). This skips method dispatch and the builtin trampoline while
+/// leaving the lookup itself in Rust.
+fn hash_entry_at_inline(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    store: &Store,
+    callid: CallSiteId,
+    f: u64,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 {
+        return false;
+    }
+    state.load(ir, callsite.args, GP::Rcx);
+    state.load(ir, callsite.recv, GP::Rdx);
+    let using_fpr = state.get_using_fpr(ir);
+    ir.fpr_save(using_fpr);
+    ir.inline(move |r#gen, _, _, _| r#gen.emit_hash_index(f));
+    ir.fpr_restore(using_fpr);
+    let error = ir.new_error(state);
+    ir.handle_error(error);
+    state.def_rax2acc(ir, callsite.dst);
+    true
+}
+
+fn hash_key_at(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    hash_entry_at_inline(state, ir, store, callid, hash_key_at_extern as *const () as u64)
+}
+
+fn hash_value_at(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    hash_entry_at_inline(
+        state,
+        ir,
+        store,
+        callid,
+        hash_value_at_extern as *const () as u64,
+    )
 }
 
 extern "C" fn hashindex(
@@ -4736,6 +4869,49 @@ mod tests {
             ENV.delete("MONORUBY_COV_FETCH")
             res
             "#,
+        );
+    }
+
+    #[test]
+    fn hash_entry_at_intrinsics() {
+        // `__key_at` / `__value_at` are monoruby-only, so the script computes
+        // the same value the other way round when they are absent — CRuby
+        // takes the `to_a` branch and the results must agree, which pins the
+        // intrinsics to CRuby's insertion order rather than to our own idea
+        // of it.
+        run_test(
+            r##"
+            def entries(h)
+              if h.respond_to?(:__key_at)
+                (0...h.size).map { |i| [h.__key_at(i), h.__value_at(i)] }
+              else
+                h.to_a
+              end
+            end
+            small = { a: 1, "b" => 2, 3 => :c }
+            big = {}
+            i = 0
+            while i < 100; big["k#{i}"] = i; i += 1; end
+            ident = {}
+            ident.compare_by_identity
+            x = "k"
+            y = "k"
+            ident[x] = 1
+            ident[y] = 2
+            [entries(small), entries(big).last, entries({}), entries(ident)]
+            "##,
+        );
+        // Out of range (and a negative index) is nil, so a `while` loop bounded
+        // by `size` never needs an error edge.
+        run_test(
+            r##"
+            h = { a: 1 }
+            if h.respond_to?(:__key_at)
+              [h.__key_at(1), h.__value_at(1), h.__key_at(-1), h.__value_at(-1)]
+            else
+              [nil, nil, nil, nil]
+            end
+            "##,
         );
     }
 }

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -524,6 +524,19 @@ impl<'a> HashRef<'a> {
         self.len() == 0
     }
 
+    /// The `index`-th entry in insertion order, or `None` when out of range.
+    /// O(1) for every representation: the inline pairs and `RubyMap`'s entry
+    /// vector are both position-addressable. Used by the `__key_at` /
+    /// `__value_at` intrinsics so Ruby-level iteration can be a `while` loop
+    /// over indices instead of an `each` block.
+    pub(crate) fn entry_at(&self, index: usize) -> Option<(Value, Value)> {
+        match self.content() {
+            ContentRef::Inline(pairs) => pairs.get(index).copied(),
+            ContentRef::Map(m) => m.get_index(index).map(|(k, v)| (*k, *v)),
+            ContentRef::Ident(m) => m.get_index(index).map(|(k, v)| (k.0, *v)),
+        }
+    }
+
     pub fn is_compare_by_identity(&self) -> bool {
         if self.is_inline() {
             self.flags() & IDENT_BIT != 0
@@ -1374,6 +1387,11 @@ impl Hashmap {
 
     pub fn len(&self) -> usize {
         self.inner().len()
+    }
+
+    /// See [`HashRef::entry_at`].
+    pub(crate) fn entry_at(&self, index: usize) -> Option<(Value, Value)> {
+        self.inner().entry_at(index)
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Summary

Ruby-level builtins iterate with `each { ... yield ... }`, which costs **two block entries per element**: the block handed to `each`, then the user's block. Positional access lets that be a `while` loop over indices instead, leaving just the user's block — **one entry per element**.

```ruby
def to_h
  h = {}; i = 0; n = size
  while i < n
    pair = yield __key_at(i), __value_at(i)
    h[pair[0]] = pair[1]
    i += 1
  end
  h
end
```

`HashRef::entry_at` is O(1) for all three representations (the inline pairs and `RubyMap`'s entry vector are both position-addressable).

## Inlining

Both methods are registered with `define_builtin_inline_func`, so a JIT'd call site becomes a **direct C-ABI call** instead of going through method dispatch and the builtin trampoline.

The call sequence is the one `Hash#[]` already uses: `emit_hash_index` takes the target address as a parameter, so **both backends pick this up with no new arch-specific code** — the diff is two Rust files, nothing under `codegen/arch/`.

## Measurements (release build, `to_h`-shaped workload, ns/pair)

| | n=1,000 | n=100,000 |
|---|---|---|
| `each` + `yield` (current) | 177.1 / 185.6 | 312.5 / 294.8 |
| `while` + intrinsic | **138.7 / 127.4** | **250.6 / 232.4** |
| speedup | **~1.4x** | **~1.25x** |

No allocation either — contrast a `keys`-based Ruby `each`, which pays an Array plus N lookups and came out *slower* than the current code (500 vs 330 ns/pair at n=100000).

## What this does not reach, and why

A Rust `Hash#to_h` still beats both (~109 / ~199), because two intrinsic calls per pair remain. A per-element builtin call measured **13.3 ns** against **9.2–10.5 ns** for a block entry, so the win here comes from *halving the entries*, not from the call being cheap.

Closing the rest means lowering these to machine code. That needs the vendored `rubymap`'s `Bucket` / `IndexMapCore` pinned with `#[repr(C)]` (plus `offset_of!` assertions) before the JIT can hardcode offsets — Rust guarantees no layout today, so hardcoding would be unsound across compiler versions. Deliberately not attempted here.

For reference, an inlined-to-machine-code index (`Array#[]`) measures **3.2 ns**, so the headroom is real.

## Naming and testing

The index is a position in the hash's own entry order, not part of the public Ruby interface — hence the `__` prefix.

Since CRuby has no such methods, the test computes the same value via `to_a` when they are absent. CRuby therefore checks our ordering, rather than us asserting it against ourselves. Covered: mixed key types, the large (`Map`) representation, `compare_by_identity` (`IdentMap`), an empty hash, agreement with `each`'s order, and `nil` for out-of-range and negative indices.

Full suite: **3073/3073**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_