### PR TITLE
gc-stress: skip the plb2 benchmarks under GC_STRESS=1

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -38,6 +38,11 @@ RUBY=(ruby --yjit)
 # workloads quadratic-ish — a trivial 100K-allocation loop takes ~100 s — so
 # optcarrot and ruby/spec go from seconds to a long grind. A full
 # GC_STRESS=1 run is an hours-scale job, not something to sit and wait for.
+#
+# One phase is exempt: the plb2 benchmarks are skipped under GC_STRESS=1.
+# They are allocation-heavy enough that stress GC never finished them (see
+# the `plb2` phase below), and letting them run starves optcarrot and
+# ruby/spec of the job's time budget entirely.
 GC_STRESS_ON=0
 [ "${GC_STRESS:-0}" = "1" ] && GC_STRESS_ON=1
 
@@ -141,14 +146,24 @@ diff -s monoruby.log ruby.log
 #"${RUBY[@]}" benchmark/bf.rb > ruby.log
 #diff -s monoruby.log ruby.log
 
-phase "benchmarks: plb2 nqueen / sudoku"
-echo "checking plb2.."
-$MONORUBY benchmark/plb2/nqueen.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/nqueen.rb > ruby.log
-diff -s monoruby.log ruby.log
-$MONORUBY benchmark/plb2/sudoku.rb > monoruby.log
-"${RUBY[@]}" benchmark/plb2/sudoku.rb > ruby.log
-diff -s monoruby.log ruby.log
+# plb2 is the one phase per-safepoint collection cannot afford. nqueen runs
+# n=15 and allocates heavily, and stress GC is superlinear in live heap, so
+# the first full GC_STRESS=1 run sat here for 4h50m on both arches and was
+# killed by the job's 350-minute timeout — without ever reaching optcarrot or
+# ruby/spec, the phases the stress run exists to exercise. Skip it under
+# stress and spend that time downstream; the ordinary run still covers plb2.
+if [ "$GC_STRESS_ON" = "1" ]; then
+  phase "benchmarks: plb2 nqueen / sudoku [skipped: GC_STRESS=1]"
+else
+  phase "benchmarks: plb2 nqueen / sudoku"
+  echo "checking plb2.."
+  $MONORUBY benchmark/plb2/nqueen.rb > monoruby.log
+  "${RUBY[@]}" benchmark/plb2/nqueen.rb > ruby.log
+  diff -s monoruby.log ruby.log
+  $MONORUBY benchmark/plb2/sudoku.rb > monoruby.log
+  "${RUBY[@]}" benchmark/plb2/sudoku.rb > ruby.log
+  diff -s monoruby.log ruby.log
+fi
 #$MONORUBY benchmark/plb2/matmul.rb > monoruby.log
 #"${RUBY[@]}" benchmark/plb2/matmul.rb > ruby.log
 #diff -s monoruby.log ruby.log


### PR DESCRIPTION
The first full `GC_STRESS=1` run ([run #5](https://github.com/sisshiki1969/monoruby/actions/runs/31411803060)) reached the plb2 phase about an hour in and never left it: both arches sat there for **4h50m** and were cancelled by the job's 350-minute timeout, so optcarrot and ruby/spec — the phases a stress run exists to exercise — never ran at all.

Phase markers from that run, identical on both arches:

| phase | elapsed |
|---|---|
| nextest (unit + integration) | 10–15 min ✅ |
| benchmarks: app_fib / tarai / so_nbody | 45 min ✅ |
| **benchmarks: plb2 nqueen / sudoku** | **4h50m, cancelled** ⛔ |
| optcarrot / ruby-bench / ruby-spec | never reached |

plb2 nqueen runs `n=15` and allocates heavily, and per-safepoint collection is superlinear in live heap, so this is not a case of "slow but finishes": the three benchmarks before it took 8–19 minutes *each*, and plb2 was still going 15x later.

This gates that one phase on `GC_STRESS_ON` and spends the time downstream instead. The ordinary (non-stress) run is unchanged and still diffs plb2 against CRuby, so the only coverage lost is plb2-under-stress specifically.

The skip announces itself as a phase marker rather than vanishing, matching the script's existing rule that a bounded phase says what it dropped — a truncated log still shows it. The header comment claiming `GC_STRESS=1` applies to *every* phase is corrected to note the exception.

Verified the gate both ways (`GC_STRESS=0` runs plb2, `GC_STRESS=1` prints the skip marker); `bash -n` clean. No other phase is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_