### PR TITLE
Inline Hash#default / #default_proc / #compare_by_identity? / Kernel#instance_of?

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -33,8 +33,22 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(HASH_CLASS, "ruby2_keywords_hash?", ruby2_keywords_hash_p, 1);
 
     globals.define_private_builtin_func_with(HASH_CLASS, "initialize", initialize, 0, 1, false);
-    globals.define_builtin_func_with(HASH_CLASS, "default", default, 0, 1, false);
-    globals.define_builtin_func(HASH_CLASS, "default_proc", default_proc, 0);
+    globals.define_builtin_inline_func_with(
+        HASH_CLASS,
+        "default",
+        default,
+        inline_gen2!(hash_default_value),
+        0,
+        1,
+        false,
+    );
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "default_proc",
+        default_proc,
+        inline_gen2!(hash_default_proc),
+        0,
+    );
     globals.define_builtin_func(HASH_CLASS, "default_proc=", default_proc_assign, 1);
     globals.define_builtin_func(HASH_CLASS, "default=", default_assign, 1);
     globals.define_builtin_funcs(HASH_CLASS, "==", &["==="], eq, 1);
@@ -118,7 +132,13 @@ pub(super) fn init(globals: &mut Globals) {
         &[],
         false,
     );
-    globals.define_builtin_func(HASH_CLASS, "compare_by_identity?", compare_by_identity_, 0);
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "compare_by_identity?",
+        compare_by_identity_,
+        inline_gen2!(hash_compare_by_identity),
+        0,
+    );
     globals.define_builtin_func_rest(HASH_CLASS, "values_at", values_at);
     globals.define_builtin_func_rest(HASH_CLASS, "dig", dig);
     globals.define_builtin_func(HASH_CLASS, "to_h", to_h, 0);
@@ -948,6 +968,91 @@ fn entry_component(recv: Value, idx: i64, want_key: bool) -> Value {
         }
         None => Value::nil(),
     }
+}
+
+///
+/// Shared shape of the three zero-argument accessor inliners.
+///
+/// A block is rejected for all three: `compare_by_identity?` raises on one,
+/// and for the other two a block is so unusual that keeping the generic path
+/// is not worth a separate rule. `Hash#default` also takes an optional key —
+/// that form invokes the default proc, so only the zero-argument call inlines.
+///
+fn hash_accessor_callsite(store: &Store, callid: CallSiteId) -> Option<&CallSiteInfo> {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 0 || callsite.block_fid.is_some() {
+        return None;
+    }
+    Some(callsite)
+}
+
+///
+/// Inline `Hash#compare_by_identity?` as machine code.
+///
+fn hash_compare_by_identity(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let Some(callsite) = hash_accessor_callsite(store, callid) else {
+        return false;
+    };
+    let (recv, dst) = (callsite.recv, callsite.dst);
+    state.load(ir, recv, GP::Rdi);
+    ir.hash_compare_by_identity(GP::Rax, GP::Rdi);
+    state.def_rax2acc(ir, dst);
+    true
+}
+
+///
+/// Inline `Hash#default` (the zero-argument form) as machine code.
+///
+fn hash_default_value(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    hash_default_inline(state, ir, store, callid, false)
+}
+
+///
+/// Inline `Hash#default_proc` as machine code.
+///
+fn hash_default_proc(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    hash_default_inline(state, ir, store, callid, true)
+}
+
+fn hash_default_inline(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    store: &Store,
+    callid: CallSiteId,
+    want_proc: bool,
+) -> bool {
+    let Some(callsite) = hash_accessor_callsite(store, callid) else {
+        return false;
+    };
+    let (recv, dst) = (callsite.recv, callsite.dst);
+    state.load(ir, recv, GP::Rdi);
+    ir.hash_default(GP::Rax, GP::Rdi, want_proc);
+    state.def_rax2acc(ir, dst);
+    true
 }
 
 ///
@@ -5121,6 +5226,79 @@ mod tests {
               i += 1
             end
             out
+            "##,
+        );
+    }
+
+    /// The zero-argument accessors are emitted as machine code, so drive
+    /// each through a hot call site and pin every combination to CRuby.
+    /// `default` and `default_proc` read the same slot and differ only in
+    /// which discriminant they accept — the crossed cases (a value default
+    /// asked for its proc, and vice versa) are the ones that would break if
+    /// the discriminants were transposed.
+    #[test]
+    fn hash_default_accessors_jit() {
+        run_test(
+            r##"
+            def probe(h)
+              [h.default, h.default_proc.class, h.compare_by_identity?]
+            end
+
+            plain = {}
+            valued = Hash.new(7)
+            proced = Hash.new { |hash, key| hash[key] = key.to_s }
+            ident = {}
+            ident.compare_by_identity
+            big_ident = {}
+            big_ident.compare_by_identity
+            i = 0
+            while i < 10; big_ident[i.to_s] = i; i += 1; end
+            valued_big = Hash.new(:d)
+            i = 0
+            while i < 10; valued_big[i] = i; i += 1; end
+
+            out = []
+            n = 0
+            while n < 30
+              out << probe(plain)
+              out << probe(valued)
+              out << probe(proced)
+              out << probe(ident)
+              out << probe(big_ident)
+              out << probe(valued_big)
+              n += 1
+            end
+            out.uniq
+            "##,
+        );
+        // The one-argument form invokes the default proc, so it must keep
+        // using the generic path rather than the inlined reader.
+        run_test(
+            r##"
+            h = Hash.new { |hash, key| "made:#{key}" }
+            v = Hash.new(3)
+            r = []
+            i = 0
+            while i < 30
+              r = [h.default(:k), v.default(:k), h.default, v.default]
+              i += 1
+            end
+            r
+            "##,
+        );
+        // A block makes `compare_by_identity?` raise (a monoruby-specific
+        // restriction, so this is not compared against CRuby). The call site
+        // is compiled hot first, which is exactly when the inliner could
+        // wrongly swallow the block.
+        run_test_error(
+            r##"
+            h = {}
+            i = 0
+            while i < 300
+              h.compare_by_identity?
+              i += 1
+            end
+            h.compare_by_identity? { 1 }
             "##,
         );
     }

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -312,7 +312,13 @@ pub(super) fn init(globals: &mut Globals) -> Module {
     globals.define_builtin_func(kernel_class, "singleton_class", singleton_class, 0);
     globals.define_builtin_func(kernel_class, "to_s", to_s, 0);
     globals.define_builtin_func(kernel_class, "inspect", inspect, 0);
-    globals.define_builtin_func(kernel_class, "instance_of?", instance_of, 1);
+    globals.define_builtin_inline_func(
+        kernel_class,
+        "instance_of?",
+        instance_of,
+        inline_gen2!(kernel_instance_of),
+        1,
+    );
     globals.define_builtin_func(kernel_class, "instance_variable_defined?", iv_defined, 1);
     globals.define_builtin_func(kernel_class, "instance_variable_set", iv_set, 2);
     globals.define_builtin_func(kernel_class, "instance_variable_get", iv_get, 1);
@@ -5401,6 +5407,41 @@ fn instance_of(
     Ok(Value::bool(b))
 }
 
+/// `instance_of?` compares the receiver's *real* class — singleton and
+/// iclass links skipped — against the argument. Both sides are known at
+/// compile time whenever the argument is a class literal: the receiver-class
+/// guard upstream pins `recv_class` exactly, so the whole call folds to a
+/// constant and emits nothing at all.
+fn kernel_instance_of(
+    state: &mut AbstractState,
+    _ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    let CallSiteInfo { args, dst, .. } = *callsite;
+    // Anything that is not a concrete class/module literal — including a
+    // literal of the wrong type, which must raise TypeError — falls back.
+    let Some(target) = state.is_class_or_module_literal(args) else {
+        return false;
+    };
+    // Synthetic classes (e.g. BOOL_CLASS) have no backing Module object.
+    let Some(recv_module) = store[recv_class].try_get_module() else {
+        return false;
+    };
+    let result = recv_module.get_real_class().id() == target.id();
+    if let Some(dst) = dst {
+        state.def_C(dst, Immediate::bool(result));
+    }
+    true
+}
+
 ///
 /// ### Kernel#method
 ///
@@ -7958,6 +7999,51 @@ mod tests {
         run_test_error("Complex(:x, 0)");
         run_test_error("Complex(:x, 0, exception: false)");
         run_test_error(r#"Complex("1@")"#);
+    }
+
+    /// The fold answers from the receiver's *real* class, so a singleton
+    /// (`def o.x`) must not change the result, a subclass must not count as
+    /// its parent, and a module must never match. A non-literal argument has
+    /// to keep the generic path, where a non-class argument still raises.
+    #[test]
+    fn object_instance_of_jit() {
+        run_test(
+            r##"
+            class C; end
+            class D < C; end
+            o = C.new
+            def o.only_mine; end
+
+            r = nil
+            i = 0
+            while i < 30
+              r = [o.instance_of?(C), o.instance_of?(D),
+                   D.new.instance_of?(D), D.new.instance_of?(C),
+                   1.instance_of?(Integer), 1.instance_of?(Numeric),
+                   "s".instance_of?(String), nil.instance_of?(NilClass),
+                   :s.instance_of?(Symbol), o.instance_of?(Comparable)]
+              i += 1
+            end
+            r
+            "##,
+        );
+        // Argument not known at compile time: the generic path must still
+        // answer correctly, and still raise for a non-class argument.
+        run_test(
+            r##"
+            class C; end
+            o = C.new
+            klasses = [C, String, Object]
+            r = []
+            i = 0
+            while i < 30
+              r = klasses.map { |k| o.instance_of?(k) }
+              i += 1
+            end
+            r << (begin; o.instance_of?(3); rescue TypeError; :typeerr; end)
+            r
+            "##,
+        );
     }
 
     #[test]

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -211,6 +211,96 @@ impl Codegen {
         );
     }
 
+    /// `Hash#compare_by_identity?`: hash in `base`, Ruby bool into `dst`.
+    /// aarch64 twin of the x86 `gen_hash_compare_by_identity`.
+    ///
+    /// Both representations reduce to one bit — a `ty_flags` bit while inline,
+    /// and the boxed `HashContent` discriminant (0 = Map, 1 = IdentMap) — so
+    /// masking bit 0 of either answers it without a comparison.
+    ///
+    /// ### destroy
+    /// - x9
+    pub(crate) fn gen_hash_compare_by_identity(&mut self, dst: GP, base: GP) {
+        let (d, b) = (dst.a64().0, base.a64().0);
+        let inline_case = self.jit.label();
+        let tag_ready = self.jit.label();
+        let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
+        let boxed_rep = HASH_REP_BOXED as u32;
+        let ident_shift = HASH_INLINE_IDENT_BIT.trailing_zeros();
+        let content = HASH_CONTENT_OFFSET as u32;
+        monoasm_arm64!(&mut self.jit,
+            ldrb w(d), [x(b), #(ty_flags)];
+            mov x9, (HASH_REP_MASK as u64);
+            and x9, x(d), x9;
+            cmp x9, #(boxed_rep);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &inline_case);
+        monoasm_arm64!(&mut self.jit,
+            ldr x(d), [x(b), #(content)];    // 0 = Map, 1 = IdentMap
+            b tag_ready;
+        inline_case:
+            lsr x(d), x(d), #(ident_shift);
+        tag_ready:
+            // isolate bit 0, then 0/1 -> false/true (0x14 / 0x1c)
+            lsl x(d), x(d), #(63);
+            lsr x(d), x(d), #(63);
+            lsl x(d), x(d), #(3);
+            add x(d), x(d), #(FALSE_VALUE as u32);
+        );
+    }
+
+    /// `Hash#default` (`want_proc == false`) / `#default_proc`: hash in `base`,
+    /// result Value into `dst`. aarch64 twin of the x86 `gen_hash_default`.
+    ///
+    /// An inline hash never carries a default, a null slot means none is set,
+    /// and the other discriminant belongs to the sibling accessor — all three
+    /// answer `nil`, matching the builtins' `unwrap_or_default`.
+    ///
+    /// ### destroy
+    /// - x9
+    pub(crate) fn gen_hash_default(&mut self, dst: GP, base: GP, want_proc: bool) {
+        let (d, b) = (dst.a64().0, base.a64().0);
+        let nil_case = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
+        let boxed_rep = HASH_REP_BOXED as u32;
+        let slot = HASH_DEFAULT_OFFSET as u32;
+        let payload = HASH_DEFAULT_PAYLOAD_OFFSET as u32;
+        let want_tag = (if want_proc {
+            HASH_DEFAULT_TAG_PROC
+        } else {
+            HASH_DEFAULT_TAG_VALUE
+        }) as u64;
+        // Isolate the representation bits with a shift pair rather than a
+        // mask register: `base` is still live, so `dst` must not be borrowed
+        // as scratch here.
+        let rep_bits = HASH_REP_MASK.count_ones();
+        monoasm_arm64!(&mut self.jit,
+            ldrb w9, [x(b), #(ty_flags)];
+            lsl x9, x9, #(64 - rep_bits);
+            lsr x9, x9, #(64 - rep_bits);
+            cmp x9, #(boxed_rep);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &nil_case);
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x(b), #(slot)];         // Option<Box<HashDefault>>: null = None
+            cmp x9, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &nil_case);
+        monoasm_arm64!(&mut self.jit,
+            ldr x(d), [x9];                  // discriminant
+            cmp x(d), #(want_tag as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &nil_case);
+        monoasm_arm64!(&mut self.jit,
+            ldr x(d), [x9, #(payload)];
+            b exit;
+        nil_case:
+            mov x(d), #(NIL_VALUE);
+        exit:
+        );
+    }
+
     /// `Hash#__key_at` / `#__value_at`: hash in Rdx (x2), fixnum index in Rcx
     /// (x1), result Value in Rax (x0). aarch64 twin of the x86
     /// `gen_hash_entry_at`.

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -143,6 +143,84 @@ impl Codegen {
         }
     }
 
+    /// `Hash#compare_by_identity?`: hash in `base`, Ruby bool into `dst`.
+    ///
+    /// Both representations reduce to one bit, so no comparison is needed:
+    /// inline keeps it as a `ty_flags` bit, and the boxed `HashContent`
+    /// discriminant is 0 for `Map` and 1 for `IdentMap`, so masking bit 0 of
+    /// either gives the answer. `(b << 3) | FALSE_VALUE` then turns 0/1 into
+    /// `false`/`true`.
+    ///
+    /// ### destroy
+    /// - rsi
+    pub(crate) fn gen_hash_compare_by_identity(&mut self, dst: GP, base: GP) {
+        let (d, b) = (dst as u64, base as u64);
+        let inline_case = self.jit.label();
+        let tag_ready = self.jit.label();
+        let ty_flags = RVALUE_OFFSET_TY + 1;
+        let mask = HASH_REP_MASK as u64;
+        let boxed_rep = HASH_REP_BOXED as u64;
+        let ident_shift = HASH_INLINE_IDENT_BIT.trailing_zeros() as u64;
+        let content = HASH_CONTENT_OFFSET;
+        monoasm! { &mut self.jit,
+            movl R(d), [R(b) + (ty_flags)];
+            movq rsi, R(d);
+            andl rsi, (mask);
+            cmpl rsi, (boxed_rep);
+            jne  inline_case;
+            movq R(d), [R(b) + (content)];   // 0 = Map, 1 = IdentMap
+            jmp  tag_ready;
+        inline_case:
+            shrq R(d), (ident_shift);
+        tag_ready:
+            andl R(d), (1);
+            shlq R(d), 3;
+            orq  R(d), (FALSE_VALUE);
+        }
+    }
+
+    /// `Hash#default` (`want_proc == false`) / `#default_proc`: hash in `base`,
+    /// result Value into `dst`.
+    ///
+    /// An inline hash never carries a default, a null slot means none is set,
+    /// and the other discriminant belongs to the sibling accessor — all three
+    /// answer `nil`, matching the builtins' `unwrap_or_default`.
+    ///
+    /// ### destroy
+    /// - rsi
+    pub(crate) fn gen_hash_default(&mut self, dst: GP, base: GP, want_proc: bool) {
+        let (d, b) = (dst as u64, base as u64);
+        let nil_case = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = RVALUE_OFFSET_TY + 1;
+        let mask = HASH_REP_MASK as u64;
+        let boxed_rep = HASH_REP_BOXED as u64;
+        let slot = HASH_DEFAULT_OFFSET;
+        let payload = HASH_DEFAULT_PAYLOAD_OFFSET;
+        let want_tag = if want_proc {
+            HASH_DEFAULT_TAG_PROC
+        } else {
+            HASH_DEFAULT_TAG_VALUE
+        };
+        monoasm! { &mut self.jit,
+            movl rsi, [R(b) + (ty_flags)];
+            andl rsi, (mask);
+            cmpl rsi, (boxed_rep);
+            jne  nil_case;
+            movq rsi, [R(b) + (slot)];       // Option<Box<HashDefault>>: null = None
+            testq rsi, rsi;
+            jeq  nil_case;
+            movq R(d), [rsi];                // discriminant
+            cmpq R(d), (want_tag);
+            jne  nil_case;
+            movq R(d), [rsi + (payload)];
+            jmp  exit;
+        nil_case:
+            movq R(d), (NIL_VALUE);
+        exit:
+        }
+    }
+
     /// `Hash#__key_at` / `#__value_at`: hash in rdx, fixnum index in rcx,
     /// result Value in rax.
     ///

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -175,6 +175,8 @@ impl Codegen {
             | AsmInst::StringLenFixnum { .. }
             | AsmInst::HashLenFixnum { .. }
             | AsmInst::HashEntryAt { .. }
+            | AsmInst::HashCompareByIdentity { .. }
+            | AsmInst::HashDefault { .. }
             | AsmInst::IsNilToBool { .. }
             | AsmInst::NotToBool { .. }
             | AsmInst::MathSqrt { .. }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1015,6 +1015,24 @@ impl AsmIr {
         self.inst.push(AsmInst::HashLenFixnum { dst, base, layout });
     }
 
+    /// Emit `dst <- Hash#compare_by_identity?` for the hash in `base`.
+    /// Typed alternative to the out-of-line call. `dst` must differ from `base`.
+    pub(crate) fn hash_compare_by_identity(&mut self, dst: GP, base: GP) {
+        debug_assert_ne!(dst, base);
+        self.inst.push(AsmInst::HashCompareByIdentity { dst, base });
+    }
+
+    /// Emit `dst <- Hash#default` / `#default_proc` for the hash in `base`.
+    /// Typed alternative to the out-of-line call. `dst` must differ from `base`.
+    pub(crate) fn hash_default(&mut self, dst: GP, base: GP, want_proc: bool) {
+        debug_assert_ne!(dst, base);
+        self.inst.push(AsmInst::HashDefault {
+            dst,
+            base,
+            want_proc,
+        });
+    }
+
     /// Emit `Rax <- Hash#__key_at(Rcx)` / `#__value_at(Rcx)` for the hash in
     /// `Rdx`. Typed alternative to the out-of-line C-ABI call.
     pub(crate) fn hash_entry_at(&mut self, want_key: bool, layout: rubymap::EntriesLayout) {
@@ -1669,6 +1687,27 @@ pub(super) enum AsmInst {
         dst: GP,
         base: GP,
         layout: rubymap::EntriesLayout,
+    },
+    /// `dst <- Hash#compare_by_identity?` for the hash in `base`, as a Ruby bool.
+    ///
+    /// The flag has two homes: a `ty_flags` bit while the hash is inline, and
+    /// the `HashContent` discriminant once it is boxed. `dst` and `base` must
+    /// differ — `base` is still live when `dst` is first written.
+    HashCompareByIdentity {
+        dst: GP,
+        base: GP,
+    },
+    /// `dst <- Hash#default` (`want_proc == false`) or `Hash#default_proc` for
+    /// the hash in `base`.
+    ///
+    /// Both read one `Option<Box<HashDefault>>` slot and differ only in which
+    /// discriminant they accept; a null slot, the other discriminant, or an
+    /// inline hash (which never carries a default) all answer `nil`, which is
+    /// what the builtins produce via `unwrap_or_default`.
+    HashDefault {
+        dst: GP,
+        base: GP,
+        want_proc: bool,
     },
     /// `Rax <- Hash#__key_at(Rcx)` / `Hash#__value_at(Rcx)` for the hash in `Rdx`,
     /// with the index arriving as a fixnum `Value`.

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1087,6 +1087,20 @@ impl Codegen {
                     cg.gen_hash_len_fixnum(dst, base, layout);
                 });
             }
+            AsmInst::HashCompareByIdentity { dst, base } => {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.gen_hash_compare_by_identity(dst, base);
+                });
+            }
+            AsmInst::HashDefault {
+                dst,
+                base,
+                want_proc,
+            } => {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.gen_hash_default(dst, base, want_proc);
+                });
+            }
             AsmInst::HashEntryAt { want_key, layout } => {
                 self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
                     cg.gen_hash_entry_at(want_key, layout);

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -76,6 +76,20 @@ pub const HASH_INLINE_VALUE_OFFSET: usize = std::mem::offset_of!((Value, Value),
 pub const HASH_CONTENT_OFFSET: usize = RVALUE_OFFSET_KIND + std::mem::offset_of!(BoxedHash, content);
 pub const HASH_CONTENT_MAP_OFFSET: usize = HASH_CONTENT_OFFSET + std::mem::size_of::<usize>();
 
+/// `HashContent`'s discriminant: the boxed hash is identity-keyed iff the word
+/// at [`HASH_CONTENT_OFFSET`] equals this.
+pub const HASH_CONTENT_TAG_IDENT: usize = 1;
+
+/// The inline representation's identity-mode bit within the `ty_flags` byte.
+/// (The boxed form uses the `HashContent` discriminant instead.)
+pub const HASH_INLINE_IDENT_BIT: u8 = IDENT_BIT;
+
+/// The boxed default slot, addressed from the start of the `RValue`. It holds
+/// an `Option<Box<HashDefault>>`, so the word is null exactly when no default
+/// is set; otherwise it points at a discriminant followed by the payload.
+pub const HASH_DEFAULT_OFFSET: usize = RVALUE_OFFSET_KIND + std::mem::offset_of!(BoxedHash, default);
+pub const HASH_DEFAULT_PAYLOAD_OFFSET: usize = std::mem::size_of::<usize>();
+
 /// The entry-storage layout shared by both boxed forms.
 ///
 /// Returns `None` when the two instantiations disagree, or when
@@ -175,10 +189,20 @@ enum HashContent {
 }
 
 #[derive(Debug, Clone)]
+/// `repr(C, usize)` for the same reason as [`HashContent`]: the JIT reads the
+/// discriminant at offset 0 and the payload at [`HASH_DEFAULT_PAYLOAD_OFFSET`],
+/// and `offset_of!` cannot reach into a `repr(Rust)` enum variant. Both
+/// variants carry exactly one `Value`-shaped word (`Proc` is a newtype over
+/// `Value`), so the payload is read the same way for either tag.
+#[repr(C, usize)]
 enum HashDefault {
     Value(Value),
     Proc(Proc),
 }
+
+/// Discriminant values of [`HashDefault`], as generated code sees them.
+pub const HASH_DEFAULT_TAG_VALUE: usize = 0;
+pub const HASH_DEFAULT_TAG_PROC: usize = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct HashId(usize);
@@ -2186,5 +2210,108 @@ mod tests {
                 assert_eq!(unsafe { raw_entry_at(v, i) }, h.entry_at(i), "n={n} i={i}");
             }
         }
+    }
+
+    /// Read `compare_by_identity?` the way generated code does.
+    unsafe fn raw_compare_by_identity(v: Value) -> bool {
+        unsafe {
+            let p = v.rvalue() as *const RValue as *const u8;
+            let flags = p.add(RVALUE_OFFSET_TY + 1).read();
+            if flags & HASH_REP_MASK != HASH_REP_BOXED {
+                flags & HASH_INLINE_IDENT_BIT != 0
+            } else {
+                p.add(HASH_CONTENT_OFFSET).cast::<usize>().read() == HASH_CONTENT_TAG_IDENT
+            }
+        }
+    }
+
+    /// Read `default` (`want_proc == false`) or `default_proc` the way
+    /// generated code does. An inline hash never carries a default, and a
+    /// mismatched discriminant answers nil — exactly what the builtins do
+    /// via `unwrap_or_default`.
+    unsafe fn raw_default(v: Value, want_proc: bool) -> Value {
+        unsafe {
+            let p = v.rvalue() as *const RValue as *const u8;
+            if p.add(RVALUE_OFFSET_TY + 1).read() & HASH_REP_MASK != HASH_REP_BOXED {
+                return Value::nil();
+            }
+            let d = p.add(HASH_DEFAULT_OFFSET).cast::<*const u8>().read();
+            if d.is_null() {
+                return Value::nil();
+            }
+            let want = if want_proc {
+                HASH_DEFAULT_TAG_PROC
+            } else {
+                HASH_DEFAULT_TAG_VALUE
+            };
+            if d.cast::<usize>().read() != want {
+                return Value::nil();
+            }
+            d.add(HASH_DEFAULT_PAYLOAD_OFFSET).cast::<Value>().read()
+        }
+    }
+
+    /// The identity flag has two homes — a `ty_flags` bit while inline, the
+    /// `HashContent` discriminant once boxed — so check both sides of the
+    /// promotion against the safe API.
+    #[test]
+    fn jit_layout_matches_compare_by_identity() {
+        let mut globals = Globals::new_test();
+        let e = &mut Executor::default();
+        let g = &mut globals;
+        for ident in [false, true] {
+            for n in [0usize, 1, 3, 4, 10] {
+                let mut inner = HashmapInner::default();
+                inner.set_compare_by_identity_empty(ident).unwrap();
+                for i in 0..n {
+                    inner
+                        .insert(Value::integer(i as i64), Value::integer(i as i64), e, g)
+                        .unwrap();
+                }
+                let v = Value::hash_from_inner(inner);
+                assert_eq!(
+                    unsafe { raw_compare_by_identity(v) },
+                    v.as_hash().is_compare_by_identity(),
+                    "ident={ident} n={n}"
+                );
+            }
+        }
+    }
+
+    /// `Hash#default` / `#default_proc` read the same `Option<Box<..>>` slot
+    /// and differ only in which discriminant they accept, so both are pinned
+    /// here for the no-default and value-default cases. The default-proc case
+    /// needs a real `Proc` and is covered from Ruby
+    /// (`builtins::hash::tests::hash_default_accessors_jit`).
+    #[test]
+    fn jit_layout_matches_default() {
+        let mut globals = Globals::new_test();
+        let g = &mut globals;
+        let _ = &g;
+
+        // No default: nil from both, in either representation.
+        for n in [0usize, 4] {
+            let mut inner = HashmapInner::default();
+            let e = &mut Executor::default();
+            for i in 0..n {
+                inner
+                    .insert(Value::integer(i as i64), Value::integer(i as i64), e, g)
+                    .unwrap();
+            }
+            let v = Value::hash_from_inner(inner);
+            assert!(unsafe { raw_default(v, false) }.is_nil(), "n={n}");
+            assert!(unsafe { raw_default(v, true) }.is_nil(), "n={n}");
+        }
+
+        // Value default: `default` returns it, `default_proc` stays nil.
+        let d = Value::integer(42);
+        let inner = HashmapInner::new_with_default(RubyMap::new(), d);
+        let v = Value::hash_from_inner(inner);
+        assert_eq!(unsafe { raw_default(v, false) }, d);
+        assert_eq!(
+            unsafe { raw_default(v, false) },
+            v.as_hash().default_value().unwrap()
+        );
+        assert!(unsafe { raw_default(v, true) }.is_nil());
     }
 }


### PR DESCRIPTION
These four are the constant-cost tail of any Ruby-level builtin written around them. `Hash#to_h`'s no-block path calls all four, and **none of them could ever be specialized**: the JIT only specializes `FuncKind::ISeq` callees, so a Rust builtin never even reaches that gate — the only way to remove its call is an inline generator.

## Effect on the generated code

`Hash#to_h` compiled for a Hash subclass, per TraceIR operation:

| operation | before | after |
|---|---|---|
| `instance_of?(Hash)` | 29 insns, 1 call | **0, 0** — folded away |
| the branch consuming it | 5 insns | **0** |
| `compare_by_identity?` | 30 insns, 1 call | 13, **0** |
| `default_proc` | 30 insns, 1 call | 18, **0** |
| `default` | 31 insns, 1 call | 15, **0** |
| **whole method** | **311 insns** | **220 insns** |

The no-block path drops from 6 calls to 3 — the survivors are the hash allocation, `each`, and `default=`.

## Measured (x86-64 release, 5 runs, median, first discarded)

The harness has a ~65 ns floor per iteration, so the delta is the signal:

| case | before | after | delta |
|---|---:|---:|---:|
| `instance_of?(Hash)` | 83.2 | 68.6 | **−14.6 ns** |
| `default` | 73.4 | 66.2 | −7.2 |
| `default_proc` | 72.8 | 68.2 | −4.6 |
| `compare_by_identity?` | 72.8 | 70.2 | −2.6 |
| `to_h`, plain Hash | 90.2 | 72.2 | **−18.1 (1.25x)** |
| `to_h`, subclass n=0 | 247.4 | 206.4 | **−41.0 (1.20x)** |

This is constant cost, so it shows up at small sizes and is amortized away at large ones — `to_h` on a 1000-entry hash is unchanged, since there the per-element `each` loop dominates.

## How each one works

`instance_of?` needs no code at all. The receiver-class guard upstream pins `recv_class` exactly, so when the argument is a class literal the answer is known at compile time; it folds to a constant exactly as `is_a?` already does. It answers from the receiver's *real* class, so a singleton class must not change the result — covered by a test.

The other three read one bit or one slot:

* `compare_by_identity?` keeps the flag in a `ty_flags` bit while the hash is inline and in the `HashContent` discriminant once boxed. Both are bit 0 of their word, so masking answers it without a comparison.
* `default` and `default_proc` read the same `Option<Box<HashDefault>>` slot and differ only in which discriminant they accept. A null slot, the other discriminant, or an inline hash (which never carries a default) all answer `nil` — what the builtins produce via `unwrap_or_default`.

`HashDefault` becomes `repr(C, usize)` for the same reason `HashContent` did in #1088: `offset_of!` cannot reach into a `repr(Rust)` enum variant. As there, the offsets are validated by tests that read through them and compare against the safe API, on both sides of the inline→boxed promotion.

## Boundaries kept

`Hash#default` inlines only its zero-argument form — the one-argument form invokes the default proc. A block keeps all three on the generic path, which is what preserves `compare_by_identity?`'s existing raise on a block (a monoruby-specific restriction, so that case is asserted with `run_test_error` rather than against CRuby). A non-literal argument to `instance_of?` falls back to the generic call, where a non-class argument still raises `TypeError`.

Full suite green (3289 passed, 0 failed); the new tests also pass on aarch64 under qemu.