### PR TITLE
Hash#to_h: iterate the entries directly instead of going through each

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -26,13 +26,34 @@ class Hash
       return h
     end
     h = {}
-    self.each {|k, v|
-      pair = yield k, v
-      pair = pair.to_ary if !pair.is_a?(Array) && pair.respond_to?(:to_ary)
-      raise TypeError, "wrong element type #{pair.class} (expected array)" unless pair.is_a?(Array)
-      raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" unless pair.size == 2
-      h[pair[0]] = pair[1]
-    }
+    # Iterate the entries here rather than through `each`. Going through
+    # `each` costs two block entries per pair — `each`'s own block and then
+    # this method's `yield` — where one is enough. It also lets the pair be
+    # yielded as two values, which is what `to_h` does anyway (unlike `each`,
+    # whose block receives a single `[k, v]`), so no array has to be splatted
+    # back apart at the yield.
+    #
+    # The traversal keeps what `each` guaranteed: the pairs are snapshotted,
+    # so deleting during the block still visits every entry, and an iteration
+    # reference is held so that *adding* a key raises. `ensure` balances the
+    # reference when the block raises or breaks.
+    pairs = __pairs
+    guard = __iter_begin
+    begin
+      i = 0
+      n = pairs.size
+      while i < n
+        e = pairs[i]
+        pair = yield e[0], e[1]
+        pair = pair.to_ary if !pair.is_a?(Array) && pair.respond_to?(:to_ary)
+        raise TypeError, "wrong element type #{pair.class} (expected array)" unless pair.is_a?(Array)
+        raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" unless pair.size == 2
+        h[pair[0]] = pair[1]
+        i += 1
+      end
+    ensure
+      __iter_end(guard)
+    end
     h
   end
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -63,6 +63,12 @@ pub(super) fn init(globals: &mut Globals) {
         inline_gen2!(hash_value_at),
         1,
     );
+    // Internals of the Ruby-level `Hash#each` (builtins/hash.rb). `each`
+    // lives in Ruby so that a `h.each { .. }` call site can inline both the
+    // method and the block; these three are the parts that cannot.
+    globals.define_builtin_func(HASH_CLASS, "__pairs", pairs, 0);
+    globals.define_builtin_func(HASH_CLASS, "__iter_begin", iter_begin, 0);
+    globals.define_builtin_func(HASH_CLASS, "__iter_end", iter_end, 1);
     globals.define_builtin_func(HASH_CLASS, "[]=", index_assign, 2);
     globals.define_builtin_func(HASH_CLASS, "clear", clear, 0);
     globals.define_builtin_func(HASH_CLASS, "replace", replace, 1);
@@ -929,6 +935,51 @@ fn key_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 fn value_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let idx = lfp.arg(0).coerce_to_i64(globals)?;
     Ok(entry_component(lfp.self_val(), idx, false))
+}
+
+///
+/// ### Hash#__pairs (internal)
+///
+/// A snapshot of the entries as `[[k, v], ...]`.
+///
+/// `each` yields from this rather than indexing the live hash: deleting
+/// during iteration is explicitly allowed, and it shifts the entry vector,
+/// so an index-based traversal would skip the entry after each deletion.
+/// Snapshotting also means a key whose `#hash` no longer matches its stored
+/// slot (`Hash#rehash`, mutable keys) is still yielded.
+///
+#[monoruby_builtin]
+fn pairs(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let hash = lfp.self_val().as_hash();
+    Ok(Value::array_from_iter(
+        hash.iter().map(|(k, v)| Value::array2(k, v)),
+    ))
+}
+
+///
+/// ### Hash#__iter_begin (internal)
+///
+/// Take an iteration reference, so that adding a new key while `each` is
+/// running raises the way CRuby does. Returns whether the reference was
+/// actually recorded — the inline representation saturates its two depth
+/// bits — and that answer must be handed back to `__iter_end`.
+///
+#[monoruby_builtin]
+fn iter_begin(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(lfp.self_val().as_hash().iter_incr()))
+}
+
+///
+/// ### Hash#__iter_end (internal)
+///
+/// Release the reference taken by `__iter_begin`, whose result must be
+/// passed back here. Called from an `ensure`, so a block that raises or
+/// breaks still balances the count.
+///
+#[monoruby_builtin]
+fn iter_end(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    lfp.self_val().as_hash().iter_decr(lfp.arg(0).as_bool());
+    Ok(Value::nil())
 }
 
 /// Shared by the builtin and the inlined C-ABI helper: a negative or

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -695,7 +695,19 @@ impl<'a> HashRef<'a> {
     /// tracked (outer) guards unwind, which keeps the "no new keys
     /// while iterating" rule sound for the usual LIFO guard order.
     pub fn iter_guard(&self) -> IterGuard<'a> {
-        let real = if self.is_inline() {
+        let real = self.iter_incr();
+        IterGuard { h: *self, real }
+    }
+
+    ///
+    /// Take one iteration reference, returning whether it was actually
+    /// recorded. The inline representation holds the depth in two flag
+    /// bits, so a deeply nested traversal saturates and is admitted as a
+    /// no-op — the caller must pass that answer back to [`Self::iter_decr`]
+    /// rather than assume a decrement is owed.
+    ///
+    pub fn iter_incr(&self) -> bool {
+        if self.is_inline() {
             let flags = self.flags();
             let depth = (flags & ITER_MASK) >> ITER_SHIFT;
             if depth < ITER_MAX {
@@ -712,8 +724,28 @@ impl<'a> HashRef<'a> {
             let lev = &self.boxed().iter_lev;
             lev.set(lev.get() + 1);
             true
-        };
-        IterGuard { h: *self, real }
+        }
+    }
+
+    ///
+    /// Release an iteration reference taken by [`Self::iter_incr`]. `real`
+    /// must be that call's return value.
+    ///
+    pub fn iter_decr(&self, real: bool) {
+        if !real {
+            return;
+        }
+        if self.is_inline() {
+            let flags = self.flags();
+            let depth = (flags & ITER_MASK) >> ITER_SHIFT;
+            debug_assert!(depth > 0);
+            let new = (flags & !ITER_MASK) | ((depth - 1) << ITER_SHIFT);
+            // SAFETY: see `iter_incr`.
+            unsafe { *self.flags.as_ptr() = new };
+        } else {
+            let lev = &self.boxed().iter_lev;
+            lev.set(lev.get() - 1);
+        }
     }
 
     /// A detached copy of this hash: content cloned, iteration count and
@@ -1306,20 +1338,7 @@ pub struct IterGuard<'a> {
 
 impl Drop for IterGuard<'_> {
     fn drop(&mut self) {
-        if !self.real {
-            return;
-        }
-        if self.h.is_inline() {
-            let flags = self.h.flags();
-            let depth = (flags & ITER_MASK) >> ITER_SHIFT;
-            debug_assert!(depth > 0);
-            let new = (flags & !ITER_MASK) | ((depth - 1) << ITER_SHIFT);
-            // SAFETY: see `iter_guard`.
-            unsafe { *self.h.flags.as_ptr() = new };
-        } else {
-            let lev = &self.h.boxed().iter_lev;
-            lev.set(lev.get() - 1);
-        }
+        self.h.iter_decr(self.real);
     }
 }
 
@@ -1480,6 +1499,16 @@ impl Hashmap {
 
     pub fn iter_guard(&self) -> IterGuard<'_> {
         self.inner().iter_guard()
+    }
+
+    /// See [`HashRef::iter_incr`].
+    pub fn iter_incr(&self) -> bool {
+        self.inner().iter_incr()
+    }
+
+    /// See [`HashRef::iter_decr`].
+    pub fn iter_decr(&self, real: bool) {
+        self.inner().iter_decr(real)
     }
 
     pub fn debug(&self, store: &Store) -> String {


### PR DESCRIPTION
The block form went through `each`, so every pair paid **two block entries** — `each`'s own block, and then this method's `yield` inside it — where one is enough. Iterating here removes the outer one.

It also lets the pair be yielded as **two values**. `to_h` yields two (an arity-1 block sees the key), unlike `each`, whose block receives a single `[k, v]`:

```ruby
{a: 1}.to_h { |x| p x }   # => :a        (two values yielded)
{a: 1}.each { |x| p x }   # => [:a, 1]   (one pair yielded)
```

So going through `each` meant packing a pair only to splat it apart again at the yield — and that splat is expensive. At the same yield site a two-parameter block costs about **2.8x** a one-parameter one (117.0 vs 41.4 ns/elem), which is what this avoids.

## Measured

Both builds interleaved — six alternating rounds, first dropped, medians. Sequential runs on a loaded machine drift enough to invent 2–5x differences that are not there, so the A/B is interleaved deliberately:

| case | before | after | |
|---|---:|---:|---:|
| `to_h { }` n=3 | 203.9 | **151.4** | 1.35x |
| `to_h { }` n=100 | 255.9 | **186.5** | 1.37x |
| `to_h { }` n=1000 | 245.1 | **164.8** | 1.49x |

Everything else measures the same before and after, which is the control — the no-block paths (plain and subclass) and the `each` / `dup` / `map` reference points are all untouched by this change and all read unchanged.

Against CRuby the block form goes from ~1.33x its time to **~1.08x**, and 0.27x at n=3 where CRuby's per-call block setup dominates.

## Semantics kept

The traversal keeps everything `each` guaranteed, via three new internal builtins:

* **`__pairs`** snapshots the entries, so deleting during the block still visits every entry — CRuby allows that, and indexing the live hash would skip the entry after each deletion.
* **`__iter_begin` / `__iter_end`** hold an iteration reference across the yields, which is what makes *adding* a key raise. `IterGuard` is split into `iter_incr`/`iter_decr` for this; the inline representation saturates its two depth bits, so whether the reference was really taken has to travel back to `__iter_end`, and `ensure` balances it when the block raises or breaks.

The pair validation (`to_ary` coercion, the `Array` check, the length check) is unchanged.

Verified against CRuby: the yield shape, the add-during-iteration `RuntimeError` and its message, and delete-during-iteration visiting every entry. Full suite green (3285 passed, 0 failed).

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_