### PR TITLE
array: collect zip arguments with each + break, not Enumerator#next

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -647,4 +647,22 @@ class Array
     end
     result
   end
+
+  # Pull up to +n+ leading items from +obj+ for Array#zip — CRuby's
+  # `rb_ary_zip` / `take_items` protocol: collect with `each` and stop
+  # early with a plain `break`. Unlike an `Enumerator#next` pull there is
+  # no fiber in the path, and every exception the argument's `each`
+  # raises — StopIteration included — reaches the caller instead of
+  # being mistaken for end-of-iteration (issue #1080). A multi-value
+  # yield packs into an Array, a single value stays bare, matching what
+  # `#next` used to return.
+  private def __zip_pull(obj, n)
+    buf = []
+    return buf if n == 0
+    obj.each do |*x|
+      buf << (x.size <= 1 ? x[0] : x)
+      break if buf.size >= n
+    end
+    buf
+  end
 end

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1774,42 +1774,34 @@ fn zip(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
     let self_ary = lfp.self_val().as_array();
     let self_len = self_ary.len();
     let each_id = IdentId::EACH;
-    let to_enum_id = IdentId::get_id("to_enum");
-    let next_id = IdentId::get_id("next");
+    let zip_pull_id = IdentId::get_id("__zip_pull");
 
     vm.with_temp_scope(|vm| {
         // Phase 1: stash each converted argument as a GC-rooted Array on the
-        // temp_stack at offsets [base..base + n_args]. This protects values
-        // pulled from enumerators (which are freshly allocated by `#next` and
-        // would otherwise be unreachable across the next Ruby callback).
+        // temp_stack at offsets [base..base + n_args].
         let base = vm.temp_len();
         for a in lfp.arg(0).as_array().iter() {
             if let Ok(ary) = a.coerce_to_array(vm, globals) {
                 vm.temp_push(ary.into());
             } else if globals.check_method(*a, each_id).is_some() {
-                let enum_val =
-                    vm.invoke_method_inner(globals, to_enum_id, *a, &[], None, None)?;
-                vm.temp_push(enum_val);
-                vm.temp_array_new(Some(self_len));
-                for _ in 0..self_len {
-                    match vm
-                        .invoke_method_inner(globals, next_id, enum_val, &[], None, None)
-                    {
-                        Ok(val) => vm.temp_array_push(val),
-                        // Only exhaustion ends the pull. Anything else is
-                        // the argument's own `each` failing and must reach
-                        // the caller: swallowing it silently padded the row
-                        // with nils instead of raising, so a GC-induced
-                        // failure showed up as wrong data rather than an
-                        // error (and `[1,2].zip(o)` with a raising `o.each`
-                        // returned [[1,nil],[2,nil]] where CRuby raises).
-                        Err(err) if err.is_stop_iteration(&globals.store) => break,
-                        Err(err) => return Err(err),
-                    }
-                }
-                let inner = vm.temp_pop();
-                vm.temp_pop(); // discard enum_val
-                vm.temp_push(inner);
+                // Collect with `each` + break (`Array#__zip_pull`,
+                // CRuby's rb_ary_zip / take_items protocol) rather than
+                // `to_enum` + `next`: no fiber in the path, and every
+                // exception the argument's `each` raises — StopIteration
+                // included — reaches the caller. An Enumerator-based
+                // pull cannot make that distinction, because a
+                // user-raised StopIteration and the enumerator's own
+                // end-of-iteration signal arrive as the same exception
+                // from `#next` (issue #1080).
+                let pulled = vm.invoke_method_inner(
+                    globals,
+                    zip_pull_id,
+                    lfp.self_val(),
+                    &[*a, Value::integer(self_len as i64)],
+                    None,
+                    None,
+                )?;
+                vm.temp_push(pulled);
             } else {
                 return Err(MonorubyErr::typeerr(format!(
                     "wrong argument type {} (must respond to :each)",
@@ -5009,12 +5001,27 @@ mod tests {
             begin; [1, 2].zip(o); rescue => e; [e.class, e.message]; end
             "##,
         );
-        // NOTE: a StopIteration raised by the argument's own `each` is still
-        // mistaken for exhaustion here, because the pull goes through
-        // `Enumerator#next` and monoruby's end-of-iteration signal is the
-        // same exception. CRuby collects with `each` + `break` instead, so
-        // it propagates that too. Not asserted, so this test does not pin
-        // the divergent behaviour; tracked separately.
+        // A StopIteration raised by the argument's own `each` propagates
+        // too: the pull collects with `each` + break (CRuby's rb_ary_zip
+        // protocol), so there is no Enumerator end-of-iteration signal to
+        // confuse it with.
+        run_test(
+            r##"
+            o = Object.new
+            def o.each; yield 1; raise StopIteration; end
+            begin; [1, 2, 3].zip(o); rescue => e; [e.class, e.message]; end
+            "##,
+        );
+        // Multi-value yields pack into an Array element, single values
+        // stay bare, and an empty self never invokes `each` at all.
+        run_tests(&[
+            r##"
+            o = Object.new
+            def o.each; yield 1, 2; yield 3; end
+            [10, 20].zip(o)
+            "##,
+            r##"[].zip(1.step)"##,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1066,7 +1066,10 @@ pub(crate) fn make_exception_error(
     }
     if let Some(klass) = a0.is_class() {
         if klass.id() == STOP_ITERATION_CLASS && msg_arg.is_none() && bt_arg.is_none() {
-            let err = MonorubyErr::stopiterationerr("".to_string());
+            // Fast path skipping the exception-object allocation; the
+            // message still defaults to the class name like
+            // `Exception#message` would.
+            let err = MonorubyErr::stopiterationerr("StopIteration".to_string());
             return apply_cause(globals, err, None, cause_kwarg);
         } else if klass.is_exception() {
             let cargs: Vec<Value> = msg_arg.into_iter().collect();


### PR DESCRIPTION
## Summary

Closes #1080 — the remaining divergence: a `StopIteration` raised by a zip argument's own `each` was still mistaken for end-of-iteration, because the pull went through `to_enum` + `Enumerator#next` and monoruby's exhaustion signal is the same exception.

## Changes

- **Collect with `each` + break** (CRuby's `rb_ary_zip` / `take_items` protocol): a new private Ruby helper `Array#__zip_pull(obj, n)` iterates the argument's `each` and stops with a plain `break` once `n` items arrived. Early termination is no longer an exception, so **every** exception the argument's `each` raises — `StopIteration` included — reaches the caller, and the fiber machinery drops out of this path entirely. The Rust side of `zip` calls the helper and keeps the result GC-rooted on the temp stack; the `TypeError` for non-enumerable arguments is unchanged.
- Semantics preserved from the `#next`-based pull: a multi-value yield packs into an Array element, a single value stays bare, and an empty receiver never invokes `each` at all (CRuby: `[].zip(1.step)` → `[]`).
- **`raise StopIteration` message fix** (found by the new test): the bare-class fast path in `Kernel#raise` produced an exception with an *empty* message; it now defaults to `"StopIteration"` like `Exception#message` does.

## Behavior

```ruby
o = Object.new
def o.each; yield 1; raise StopIteration; end
[1, 2, 3].zip(o)
# before: [[1, 1], [2, nil], [3, nil]]   (silently wrong data)
# after:  raises StopIteration            (matches CRuby)
```

## Verification

- The issue's full reproduction matrix (immediate raise / mid-iteration raise / user-raised `StopIteration` / multi-value yield / empty receiver / infinite enumerator) is **byte-identical to CRuby 4.0.2**
- `zip_propagates_each_errors` extended to pin the `StopIteration` propagation, multi-yield packing, and empty-self cases (the old NOTE about the divergence is gone)
- Full monoruby lib suite: 2266 passed, 0 failed
- ruby/spec: `core/array/zip_spec.rb`, `core/kernel/loop_spec.rb`, `core/enumerator` (452 examples) — 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_