### PR TITLE
Array#flat_map: root the accumulator (fixes the gc-stress CI abort)

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -425,6 +425,50 @@ proc/args/result/exception/joiners/pending/masks/last_status をマークする�
 起きないので、サスペンド中のどのスレッドのフレームも GC-complete
 (詳細は `doc/threads.md` §2・§3.4・§8)。
 
+### 8.1 ビルトインの一時値 — 素の `Vec<Value>` は**ルートではない**
+
+ルート走査は上記の列挙がすべてなので、Rust 側のローカル(`Vec<Value>`、
+`HashMap<_, Value>`、単なる `Value` 束など)は **GC からまったく見えない**。
+`vm.invoke_block` / `vm.invoke_method_inner` / `vm.invoke_proc` はいずれも
+任意の Ruby を走らせる = セーフポイントを跨ぐので、
+
+> **原則**: Ruby 呼び出しを跨いで生かしたい `Value` は、必ず `temp_stack`
+> (`temp_push` / `temp_array_new` + `temp_array_push` /
+> `temp_array_extend_from_slice` / `with_temp_scope`)に載せる。
+
+引数ベクタのように「組み立てた直後に 1 回だけ invoke へ渡す」用途は、
+その間にセーフポイントが無いので素の `Vec` で構わない。危険なのは
+**invoke をループで回しながら結果を貯めるアキュムレータ**である。
+
+`Executor` にはこの型の定型処理を安全側に閉じ込めたヘルパがある:
+
+| ヘルパ | 用途 |
+| --- | --- |
+| `invoke_block_iter1` | `each` 系(結果を捨てる) |
+| `invoke_block_iter1_rooted` | 同上。イテレート元を先に materialise してルート付けする |
+| `invoke_block_map1` | `map` 系(結果を 1 個ずつ push) |
+| `invoke_block_flat_map1` | `flat_map` 系(Array なら展開して push) |
+
+**実例(gc-stress CI の optcarrot abort)**: `Array#flat_map` は `#to_ary` 対応を足した際に
+`invoke_block_flat_map1` から素の `let mut res: Vec<Value>` に書き換えられ、
+ブロック呼び出しを跨いで貯めた要素がすべて未ルートになっていた。通常ビルドでは
+GC の閾値に届かず表面化しなかったが、`gc-stress`(毎セーフポイント収集)では
+optcarrot の `Palette.defacto_palette`(512 要素の `flat_map`)が返す Array が
+解放済み RValue で埋まり、次のマークで `DEAD RVALUE reached in mark` で abort した。
+再現は 9 行で足りる:
+
+```ruby
+src = [[1.0, 1.0, 1.0]] * 8
+res = src.flat_map { |rf, gf, bf| (0...64).map { |i| [i * rf, i * gf, i * bf] } }
+```
+
+診断のコツ: `RValue::mark` の DEAD 検出点で、(a) `Lfp::mark` 側に
+「いまマーク中のフレームの `func_id` とスロット番号」、(b) `RValue::mark` 側に
+「いま children を辿っている親 RValue」を thread-local で持たせて出力すると、
+*どのメソッドのどの一時値が壊れているか*が一発で分かる。今回は
+`func=Video#initialize(driver.rb:67) slot=2 / parent=Array(len=512)` まで出て、
+そこから `flat_map` に到達した。
+
 ---
 
 ## 9. スイープと空きページの回収

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -3172,18 +3172,34 @@ fn flat_map(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     let bh = lfp.expect_block()?;
     let elems: Vec<Value> = lfp.self_val().as_array().iter().copied().collect();
     let data = vm.get_block_data(globals, bh)?;
-    let mut res: Vec<Value> = Vec::with_capacity(elems.len());
+    // The accumulator has to be a *rooted* Ruby Array, not a Rust `Vec`:
+    // every `invoke_block` below is a safepoint, and values held only by
+    // an unrooted Vec would be swept out from under us (the gc-stress
+    // optcarrot abort).
+    vm.temp_array_new(elems.len());
+    let res = flat_map_inner(vm, globals, &data, elems);
+    let v = vm.temp_pop();
+    res?;
+    Ok(v)
+}
+
+fn flat_map_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    data: &ProcData,
+    elems: Vec<Value>,
+) -> Result<()> {
     for x in elems {
-        let r = vm.invoke_block(globals, &data, &[x])?;
+        let r = vm.invoke_block(globals, data, &[x])?;
         if let Some(a) = r.try_array_ty() {
-            res.extend(a.iter().copied());
+            vm.temp_array_extend_from_slice(&a);
         } else if globals.check_method(r, IdentId::TO_ARY).is_some() {
             // One level of `#to_ary` flattening, matching CRuby.
             let a = vm.invoke_method_inner(globals, IdentId::TO_ARY, r, &[], None, None)?;
             if let Some(arr) = a.try_array_ty() {
-                res.extend(arr.iter().copied());
+                vm.temp_array_extend_from_slice(&arr);
             } else if a.is_nil() {
-                res.push(r);
+                vm.temp_array_push(r);
             } else {
                 return Err(MonorubyErr::typeerr(format!(
                     "can't convert {} to Array ({}#to_ary gives {})",
@@ -3193,10 +3209,10 @@ fn flat_map(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
                 )));
             }
         } else {
-            res.push(r);
+            vm.temp_array_push(r);
         }
     }
-    Ok(Value::array_from_vec(res))
+    Ok(())
 }
 
 fn all_any_inner(
@@ -5118,6 +5134,26 @@ mod tests {
         [a.last(0), a.last(1), a.last(2), a.last(3), a.last(4)]
         "##,
         ]);
+    }
+
+    #[test]
+    fn flat_map_gc_safety() {
+        // Regression: the accumulator used to be an unrooted Rust `Vec`, so
+        // every value produced by the block was invisible to a GC triggered
+        // by a later iteration. Under `gc-stress` (a collection at every
+        // safepoint) the returned Array was full of freed RValues — this is
+        // the optcarrot palette build (`Palette.defacto_palette`) reduced.
+        run_test_once(
+            r##"
+        src = [[1.0, 1.0, 1.0], [1.0, 0.8, 0.81], [0.78, 0.94, 0.66], [0.79, 0.77, 0.63],
+               [0.82, 0.83, 1.12], [0.81, 0.71, 0.87], [0.68, 0.79, 0.79], [0.70, 0.70, 0.70]]
+        res = src.flat_map do |rf, gf, bf|
+          (0...64).map { |i| [(i * rf).floor, (i * gf).floor, (i * bf).floor] }
+        end
+        GC.start
+        [res.size, res.map { |a| a.sum }.sum]
+        "##,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The manual gc-stress workflow aborts in the optcarrot phase:

```
DEAD RVALUE reached in mark: 0x... meta=Metadata { ..., ty: Some(HASH), ... }
```

Bisecting showed this is **not a new regression**: it reproduces at `96c07601` (whose gc-stress run was green — that run predates #1085, which extended `GC_STRESS=1` to the benchmark/optcarrot phases, so optcarrot ran under per-safepoint stress for the first time only now).

## Root cause

`Array#flat_map` accumulated block results into a plain Rust `Vec<Value>`:

```rust
let mut res: Vec<Value> = Vec::with_capacity(elems.len());
for x in elems {
    let r = vm.invoke_block(globals, &data, &[x])?;  // safepoint every iteration
    res.extend(a.iter().copied());                   // invisible to the GC
}
Ok(Value::array_from_vec(res))
```

A bare `Vec<Value>` is not a GC root, and every `invoke_block` is a safepoint, so nothing produced by the block is reachable until the final `array_from_vec`. Any collection in between sweeps the accumulated values, and the returned Array is full of dangling pointers — the next mark phase hits a dead RValue and aborts.

The regression came in with the `#to_ary` handling (#931), which replaced the already-correct `Executor::invoke_block_flat_map1` (temp_stack-rooted) with the hand-rolled Vec. Normal builds rarely trigger a GC inside a single `flat_map`, so it stayed hidden; under gc-stress, optcarrot's `Palette.defacto_palette` (a 512-element `flat_map`) hits it deterministically.

Diagnosed by temporarily instrumenting `Lfp::mark` (func_id + slot of the frame being marked) and `RValue::mark` (parent RValue whose children are being walked), which pointed straight at `Video#initialize (driver.rb:67)` holding a 512-element Array with dead elements — the palette built by `flat_map`.

## Fix

Accumulate into a temp_stack-rooted Ruby Array (`temp_array_new` / `temp_array_push` / `temp_array_extend_from_slice`), keeping the `#to_ary` flattening behaviour intact.

Audited the rest of `builtins/` for the same shape: `Array#sort_by`, `Hash#sort` etc. already root their accumulators via `with_temp_scope`, and `Range#flat_map` still uses `invoke_block_flat_map1` — `Array#flat_map` was the only leak.

## Verification

- Minimal repro (9 lines, the palette build reduced) aborts before the fix, matches CRuby after.
- New regression test `flat_map_gc_safety`, verified to pass under `--features gc-stress`.
- optcarrot under a gc-stress build: previously aborted within minutes; now runs past the point of failure without crashing (full `--debug` run still in progress locally — it is hours-scale by design).
- `cargo test --release --lib`: 2263+120+86 passed, 0 failed.

## Docs

Adds `doc/gc.md` §8.1: why a bare `Vec<Value>` is not a root, which `invoke_block_*` helper to reach for, and how to instrument the mark phase to identify the offending frame/slot the next time a `DEAD RVALUE` abort shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_