### PR TITLE
JIT: inline the yield auto-splat; Hash#each in Ruby; Hash#map block-shape dispatch

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -5,6 +5,45 @@ class Hash
     self
   end
 
+  # Hash#each / Hash#each_pair
+  # each {|key, value| block } -> self
+  # each -> Enumerator
+  #
+  # Written in Ruby, not Rust, so that a `h.each { .. }` call site can
+  # inline it: the JIT only specializes `FuncKind::ISeq` callees, and
+  # specializing `each` is what lets the block be inlined into the `yield`
+  # in turn. A Rust builtin can never reach that, so its block pays a full
+  # invocation per entry.
+  #
+  # The three things the Rust implementation did that a bare index loop
+  # would lose are kept:
+  #
+  #   * the pairs are snapshotted first (`__pairs`) — deleting during
+  #     iteration is allowed and shifts the entry vector, so indexing the
+  #     live hash would skip the entry after each deletion;
+  #   * an iteration reference is held across the yields, which is what
+  #     makes *adding* a key during iteration raise;
+  #   * a single `[key, value]` array is yielded, so an arity-1 block
+  #     receives the pair (CRuby's `rb_yield(rb_assoc_new(k, v))`).
+  def each
+    return to_enum(:each) { size } unless block_given?
+    pairs = __pairs
+    guard = __iter_begin
+    begin
+      i = 0
+      n = pairs.size
+      while i < n
+        yield pairs[i]
+        i += 1
+      end
+    ensure
+      __iter_end(guard)
+    end
+    self
+  end
+
+  alias each_pair each
+
   # Hash#to_h
   # to_h -> self
   # to_h {|key, value| block } -> Hash

--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -227,20 +227,38 @@ class Hash
   def map(&blk)
     return to_enum(:map) { size } unless blk
     result = []
-    # Capture every value `each` yields. A plain Hash yields a single
-    # [k, v] pair, but a subclass may override `each` to `yield k, v` as
-    # two separate values (or `yield [k, v]` as one) — normalise both.
-    # An arity-1 block/proc sees the element as-is (the pair for a plain
-    # Hash, the first value for a two-value yield); anything else has the
-    # pair splatted, so a strict arity-2 block/Method receives k and v
-    # (matches CRuby rb_yield_values2 / the enumerable map specs).
-    each do |*vs|
-      if blk.arity == 1
-        result << blk.call(vs[0])
+    if method(:each).owner == ::Hash
+      # Own `each` — not overridden by a subclass or a singleton method —
+      # so every element is exactly one [k, v] pair, and the arity dispatch
+      # can happen once out here, leaving plain blocks in the loops. That
+      # matters for speed: a `|*vs|` rest parameter disqualifies a block
+      # from the specialized-yield fast path (simple parameter lists are
+      # bound in line by the JIT; rest params take the generic runtime
+      # binding on every element).
+      #
+      # Whether the pair is passed whole or split in two follows CRuby
+      # (each_pair_i_fast / rb_block_pair_yield_optimizable), where procs
+      # and lambdas differ: a proc is split whenever it can take more than
+      # one positional argument (`{ |a, *b| }` splits, bare `{ |*a| }`
+      # receives the pair whole), a lambda — including a Symbol proc —
+      # only when it *requires* at least two (`->(a, b, *c)` splits,
+      # `->(a, *b)` receives the pair whole).
+      ar = blk.arity
+      wide = blk.lambda? ? (ar >= 2 || ar <= -3) : (ar > 1 || ar < -1)
+      if wide
+        each { |k, v| result << yield(k, v) }
       else
-        pair = vs.size == 1 ? vs[0] : vs
-        result << blk.call(*pair)
+        each { |pair| result << yield(pair) }
       end
+    else
+      # Overridden `each`: pass whatever it yields straight through —
+      # CRuby's Enumerable#map does no repacking. A proc auto-splats a
+      # single-array yield across its parameters as any proc call would;
+      # a lambda receives it as one argument and may raise. (The previous
+      # arity-based normalization here re-split the element for every
+      # non-arity-1 block, which wrongly let `->(k, v)` accept a
+      # single-array yield and handed `{ |*a| }` the pair pre-splatted.)
+      each { |*vs| result << blk.call(*vs) }
     end
     result
   end

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4922,6 +4922,63 @@ mod tests {
         ]);
     }
 
+    /// Whether Hash#map passes the [k, v] pair whole or split follows
+    /// CRuby's rb_block_pair_yield_optimizable, and procs and lambdas
+    /// differ: a proc splits whenever it can take more than one positional
+    /// (`{ |a, *b| }` splits, bare `{ |*a| }` gets the pair whole); a
+    /// lambda — Symbol procs included — only when it requires at least two
+    /// (`->(a, b, *c)` splits, `->(a, *b)` gets the pair whole). With an
+    /// overridden `each`, values pass through unrepacked: a proc auto-splats
+    /// a single-array yield, a strict lambda raises on it.
+    #[test]
+    fn hash_map_pair_split_rules() {
+        run_tests(&[
+            r#"h = {a: 1, b: 2}; h.map { |*a| a }"#,
+            r#"h = {a: 1, b: 2}; h.map(&->(*a) { a })"#,
+            r#"h = {a: 1, b: 2}; h.map { |a, *b| [a, b] }"#,
+            r#"h = {a: 1, b: 2}; h.map(&->(a, *b) { [a, b] })"#,
+            r#"h = {a: 1, b: 2}; h.map(&->(a, b, *c) { [a, b, c] })"#,
+            r#"h = {a: 1, b: 2}; h.map(&->(a, b = :d) { [a, b] })"#,
+            r#"h = {a: 1, b: 2}; h.map { |a, b = :d| [a, b] }"#,
+            r#"h = {a: 1, b: 2}; h.map(&:to_s)"#,
+            r#"h = {a: 1, b: 2}; h.map { |a, b, *c| [a, b, c] }"#,
+        ]);
+        // A singleton `each` on a plain Hash instance must take the
+        // pass-through path — `instance_of?(Hash)` cannot see it, which is
+        // why the dispatch checks `method(:each).owner`.
+        run_test_once(
+            r#"
+            hs = {a: 1, b: 2}
+            def hs.each; yield :s, :t; end
+            [hs.map { |k, v| [k, v] }, hs.map { |pair| pair }, hs.map { |*a| a }]
+            "#,
+        );
+        // Pass-through on an overridden each that yields a single array:
+        // the proc auto-splats it, the strict lambda gets it as ONE argument
+        // and raises.
+        run_test(
+            r#"
+            cls = Class.new(Hash) { def each; yield [:x, 9]; end }
+            h = cls.new
+            r1 = h.map { |k, v| [k, v] }
+            r2 = h.map { |*a| a }
+            r3 = (h.map(&->(k, v) { [k, v] }) rescue $!.class.to_s)
+            zero = Class.new(Hash) { def each; yield; end }.new.map { |*a| a }
+            [r1, r2, r3, zero]
+            "#,
+        );
+        // Subclass WITHOUT an each override still gets the fast path.
+        run_test(
+            r#"
+            cls = Class.new(Hash)
+            h = cls.new
+            h[:p] = 1
+            h[:q] = 2
+            [h.map { |k, v| [k, v] }, h.map { |pair| pair }, h.map { |*a| a }]
+            "#,
+        );
+    }
+
     #[test]
     fn hash_map_arity_and_subclass() {
         run_tests(&[

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -498,6 +498,69 @@ impl Codegen {
         true
     }
 
+    /// Lower `YieldArrayExpand`: block-style single-Array auto-splat with the
+    /// yielded value in Rdi (x4). aarch64 twin of the x86
+    /// `gen_yield_array_expand` — see there for the semantics.
+    ///
+    /// ### destroy
+    /// - x0 (Rax), x1 (Rcx), x2 (Rdx), x9, x10 (+ caller-save on the slow path)
+    pub(in crate::codegen::jitgen) fn gen_yield_array_expand(
+        &mut self,
+        callid: CallSiteId,
+        fid: FuncId,
+        req_num: usize,
+        offset: usize,
+    ) {
+        let slow = self.jit.label();
+        let done = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (0b111u64);
+            and x9, x4, x9;
+            cmp x9, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            ldrb w9, [x4, #(RVALUE_OFFSET_TY as u32)];
+            cmp x9, #(ObjTy::ARRAY.get() as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            // len -> x0, data ptr -> x1 (inline vs heap storage select)
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x0, #(ARRAY_INLINE_CAPA as u32);
+            csel x0, x9, x0, gt;
+            add x1, x4, #(RVALUE_OFFSET_INLINE as u32);
+            ldr x9, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            csel x1, x9, x1, gt;
+        );
+        for i in 0..req_num {
+            let fill_nil = self.jit.label();
+            let store = self.jit.label();
+            monoasm_arm64!(&mut self.jit,
+                cmp x0, #(i as u32);
+            );
+            self.jit.bcond_label(monoasm::Cond::Le, &fill_nil);
+            monoasm_arm64!(&mut self.jit,
+                ldr x2, [x1, #((8 * i) as u32)];
+                b store;
+            fill_nil:
+                mov x2, #(NIL_VALUE);
+            store:
+            );
+            // x10 <- &callee_slot(1 + i); x9 is a64_rsp_slot_addr's scratch.
+            self.a64_rsp_slot_addr(-((LFP_ARG0 + (8 * i) as i32)), 10);
+            monoasm_arm64!(&mut self.jit, str x2, [x10];);
+        }
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(NIL_VALUE);
+            b done;
+        slow:
+        );
+        self.a64_set_arguments(callid, fid, offset);
+        self.jit.bind_label(done);
+    }
+
     /// Lower the D1 source-routed `SetArgumentsForwarded` fast path (the
     /// deferred `...`-rest case). The trampoline `f`'s `...` rest `Array` was
     /// elided at frame entry, so the forwarded positionals are copied straight

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -160,6 +160,67 @@ impl Codegen {
     }
 
     ///
+    /// Lower `YieldArrayExpand`: block-style single-Array auto-splat with the
+    /// yielded value in `rdi`.
+    ///
+    /// When the value is an Array by ty — exactly the test the runtime's
+    /// `check_single_arg_expand` applies, so Array subclasses take the same
+    /// path — its elements fill the callee's `req_num` parameter slots
+    /// directly: nil past the end, extras dropped. The element loads are
+    /// branchy rather than `cmov`ed because a `cmov` memory operand always
+    /// reads, and an empty heap array's data pointer is dangling.
+    ///
+    /// Anything else branches to the same `jit_generic_set_arguments` call
+    /// the generic arm uses (its `#to_ary` coercion can run arbitrary Ruby),
+    /// so `rax` carries that helper's error signal; the fast path reports a
+    /// constant non-error for the shared `HandleError` that follows.
+    ///
+    /// ### destroy
+    /// - rax, rcx, rdx (+ caller-save on the slow path)
+    pub(in crate::codegen::jitgen) fn gen_yield_array_expand(
+        &mut self,
+        callid: CallSiteId,
+        fid: FuncId,
+        req_num: usize,
+        offset: usize,
+    ) {
+        let slow = self.jit.label();
+        let done = self.jit.label();
+        monoasm! { &mut self.jit,
+            testq rdi, (0b111);
+            jne  slow;
+            cmpb [rdi + (RVALUE_OFFSET_TY)], (ObjTy::ARRAY.get());
+            jne  slow;
+            // len -> rax, data ptr -> rcx (inline vs heap storage select)
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            lea  rcx, [rdi + (RVALUE_OFFSET_INLINE)];
+            cmpq rax, (ARRAY_INLINE_CAPA);
+            cmovgtq rax, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            cmovgtq rcx, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+        }
+        for i in 0..req_num {
+            let fill_nil = self.jit.label();
+            let store = self.jit.label();
+            monoasm! { &mut self.jit,
+                cmpq rax, (i as i32);
+                jle  fill_nil;
+                movq rdx, [rcx + ((8 * i) as i32)];
+                jmp  store;
+            fill_nil:
+                movq rdx, (NIL_VALUE);
+            store:
+                movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * i) as i32)], rdx;
+            }
+        }
+        monoasm! { &mut self.jit,
+            movq rax, (NIL_VALUE);
+            jmp  done;
+        slow:
+        }
+        self.jit_set_arguments(callid, fid, offset);
+        self.jit.bind_label(done);
+    }
+
     /// Set up a callee method frame for send.
     ///
     /// ### destroy

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -161,6 +161,7 @@ impl Codegen {
             | AsmInst::Yield { .. }
             | AsmInst::MethodRetSpecialized { .. }
             | AsmInst::BlockBreakSpecialized { .. }
+            | AsmInst::YieldArrayExpand { .. }
             | AsmInst::SetupYieldFrame { .. }
             | AsmInst::SpecializedCall { .. }
             | AsmInst::SpecializedYield { .. }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1688,6 +1688,18 @@ pub(super) enum AsmInst {
         base: GP,
         layout: rubymap::EntriesLayout,
     },
+    /// Block-style single-Array auto-splat for a specialized `yield` of one
+    /// value into a plain multi-parameter block: with the value in `Rdi`,
+    /// fill the callee frame's `req_num` parameter slots from the Array's
+    /// elements (nil past the end, extras dropped). A non-Array value takes
+    /// the generic `SetArguments` runtime call instead, inside the same
+    /// lowering, so `Rax` carries the helper's error signal either way (the
+    /// fast path reports a constant non-error).
+    YieldArrayExpand {
+        callid: CallSiteId,
+        callee_fid: FuncId,
+        req_num: usize,
+    },
     /// `dst <- Hash#compare_by_identity?` for the hash in `base`, as a Ruby bool.
     ///
     /// The flag has two homes: a `ty_flags` bit while the hash is inline, and

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1019,6 +1019,16 @@ impl Codegen {
             }
             // Specialized `yield`: build the block frame, then branch into the
             // inlined block entry (no patch point).
+            AsmInst::YieldArrayExpand {
+                callid,
+                callee_fid,
+                req_num,
+            } => {
+                let offset = store[callee_fid].get_offset();
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.gen_yield_array_expand(callid, callee_fid, req_num, offset);
+                });
+            }
             AsmInst::SetupYieldFrame { meta, outer } => {
                 self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
                     cg.setup_yield_frame(meta, outer);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1298,6 +1298,39 @@ impl AbstractState {
             }
 
             ir.reg_add(GP::Rsp, stack_offset);
+        } else if callsite.pos_num == 1
+            && callee.single_arg_expand()
+            && callee.meta().is_simple()
+            && callee.post_num() == 0
+            && !callsite.has_splat()
+            && !callsite.has_hash_splat()
+            && !callsite.kw_may_exists()
+            && callsite.block_arg.is_none()
+        {
+            // `yield v` into a plain multi-parameter block (`h.each { |k, v| .. }`
+            // receiving one `[k, v]` pair): block-style single-Array auto-splat.
+            // `single_arg_expand` makes `is_simple_call` false, so without this
+            // arm every such yield pays the generic runtime-call binding — and
+            // this is the argument shape every `each`-style Ruby builtin yields
+            // on every element.
+            //
+            // The lowering peels the by-far-common case in line: when the value
+            // is an Array (by ty, as the runtime's `check_single_arg_expand`
+            // decides it), its elements fill the parameters directly —
+            // nil-filled past the end, extras dropped, block-style loose
+            // binding. Anything else — a non-Array (whose `#to_ary` may run
+            // arbitrary code) — branches to the same generic runtime helper the
+            // arm below uses, so semantics never depend on the fast path.
+            let req_num = callee.req_num();
+            self.write_back_recv_and_callargs(ir, callsite);
+            self.load(ir, callsite.args, GP::Rdi);
+            let error = ir.new_error(self);
+            ir.push(AsmInst::YieldArrayExpand {
+                callid,
+                callee_fid,
+                req_num,
+            });
+            ir.handle_error(error);
         } else if callsite.forwarding
             && callsite.pos_num >= 1
             && callsite.splat_pos.as_slice() == [callsite.pos_num - 1]

--- a/monoruby/src/codegen/runtime/args.rs
+++ b/monoruby/src/codegen/runtime/args.rs
@@ -1598,6 +1598,123 @@ fn invoker_arguments_inner(
 mod tests {
     use crate::tests::*;
 
+    /// The inlined block-style single-Array auto-splat (`YieldArrayExpand`):
+    /// a hot specialized `yield` of one value into a plain multi-parameter
+    /// block fills the parameters from the Array in machine code. Every
+    /// shape the fill has to get right is driven through one hot call site
+    /// per case and pinned to CRuby: exact length, short (nil-fill), empty
+    /// (whose heap data pointer may be dangling — the bounds check must keep
+    /// it unread), long (extras dropped), inline vs heap storage, and a
+    /// three-parameter block.
+    #[test]
+    fn yield_array_expand_jit() {
+        run_test(
+            r#"
+            def drive(a)
+              acc = []
+              a.each_with_yield { |k, v| acc << [k, v] }
+              acc
+            end
+            class Array
+              def each_with_yield
+                i = 0
+                n = size
+                while i < n
+                  yield self[i]
+                  i += 1
+                end
+                self
+              end
+            end
+            exact = [[1, 2], [:a, :b]]
+            short = [[1], []]
+            long  = [[1, 2, 3, 4]]
+            heap  = [(1..10).to_a]          # > inline capacity
+            out = []
+            n = 0
+            while n < 30
+              out = [drive(exact), drive(short), drive(long), drive(heap)]
+              n += 1
+            end
+            out
+            "#,
+        );
+        // Three parameters, same machinery.
+        run_test(
+            r#"
+            def drive3(a)
+              acc = []
+              a.each_with_yield3 { |x, y, z| acc << [x, y, z] }
+              acc
+            end
+            class Array
+              def each_with_yield3
+                i = 0
+                n = size
+                while i < n
+                  yield self[i]
+                  i += 1
+                end
+                self
+              end
+            end
+            r = nil
+            n = 0
+            while n < 30
+              r = drive3([[1, 2, 3], [1, 2], [1], [], [1, 2, 3, 4, 5]])
+              n += 1
+            end
+            r
+            "#,
+        );
+    }
+
+    /// The values the inline fast path must NOT swallow: a non-Array scalar
+    /// (first param takes it, rest nil), a `#to_ary` respondent (whose
+    /// coercion runs Ruby code), and an Array subclass (splatted directly,
+    /// `#to_ary` NOT consulted). One call site sees all of them interleaved
+    /// with plain Arrays, so the compiled fast path and its slow branch are
+    /// both exercised in a single unit.
+    #[test]
+    fn yield_array_expand_jit_slow_paths() {
+        run_test(
+            r#"
+            def drive(a)
+              acc = []
+              a.each_with_yield { |k, v| acc << [k, v] }
+              acc
+            end
+            class Array
+              def each_with_yield
+                i = 0
+                n = size
+                while i < n
+                  yield self[i]
+                  i += 1
+                end
+                self
+              end
+            end
+            class Pairish
+              def initialize(k, v); @k = k; @v = v; end
+              def to_ary; [@k, @v]; end
+            end
+            class MyArray < Array; end
+
+            sub = MyArray.new
+            sub << :s1 << :s2 << :s3
+            mixed = [[1, 2], :scalar, Pairish.new(:pk, :pv), sub, nil, 4.5]
+            out = nil
+            n = 0
+            while n < 30
+              out = drive(mixed)
+              n += 1
+            end
+            out
+            "#,
+        );
+    }
+
     #[test]
     fn lazy_forwarding() {
         // The lazy `(...)`-forwarding convention: a flat call into a pure


### PR DESCRIPTION
Three commits in dependency order — each builds on the one before.

## 1. Inline the block-style single-Array auto-splat at specialized yields

`yield v` into a plain multi-parameter block — the shape every `each`-style Ruby builtin produces on every element (`h.each { |k, v| .. }` receiving one `[k, v]` pair) — could never take the specialized yield's inline argument binding: `single_arg_expand` makes `is_simple_call` false, so each element paid a generic runtime-call binding. At a hot specialized yield that was **59 instructions and 3 calls per element**, and measured **2.8x** the cost of the same yield into a one-parameter block (117.0 vs 41.4 ns/elem).

The new `YieldArrayExpand` lowering peels the by-far-common case in line: when the value is an Array by ty — exactly the test the runtime's `check_single_arg_expand` applies, so Array subclasses take the same path — its elements fill the parameter slots directly, nil past the end, extras dropped. The element loads are branchy rather than `cmov`ed because a `cmov` memory operand always reads, and an **empty heap array's data pointer is dangling**. Anything else — a non-Array, whose `#to_ary` may run arbitrary Ruby — branches to the same generic runtime helper the arm previously used, so semantics never depend on the fast path.

The arm is gated on a plain callee (`Meta::is_simple`, no post params) and a plain call site (no splat, no keywords, no block argument); everything else keeps the generic path unchanged. After the change the arity gap is gone: **29.8 vs 29.1 ns/elem**.

## 2. Hash#each in Ruby

With the splat inlined, the reason to keep `each` in Rust inverts: as a `FuncKind::Builtin` callee the JIT can never specialize it, so every block invocation went through the generic block-call machinery. In Ruby, a hot `h.each { .. }` call site specializes `each` and inlines the block into the yield. (A first attempt at this predates this PR and was abandoned: without commit 1 it measured **1.9x slower** than the Rust `each`, the auto-splat being the entire regression.)

The implementation is the one #1091 already built the internals for: `__pairs` snapshots the entries so deleting during iteration still visits every entry, `__iter_begin`/`__iter_end` hold the iteration reference that makes adding a key raise (balanced by `ensure` on raise/break), and a single `[key, value]` array is yielded so an arity-1 block receives the pair — the shape whose splat commit 1 makes free.

## 3. Hash#map: dispatch on the block shape once, not per element

`map` alone missed the wins: its normalization block took a `|*vs|` rest parameter, which disqualifies a block from the inline binding, so every element still paid the generic path. When `each` is Hash's own (`method(:each).owner == ::Hash` — a singleton `def h.each` must not take this path, and `instance_of?` cannot see one), the block-shape dispatch now happens once outside the loop and the loops use plain blocks.

Whether the pair is passed whole or split follows CRuby's `rb_block_pair_yield_optimizable`, where **procs and lambdas differ**: a proc splits whenever it can take more than one positional (`{ |a, *b| }` splits, bare `{ |*a| }` receives the pair whole); a lambda — Symbol procs included — only when it *requires* at least two (`->(a, b, *c)` splits, `->(a, *b)` receives the pair whole). The old normalization got the narrow cases wrong (`{ |*a| }` saw the pair pre-splatted; `h.map(&:to_s)` stringified the value with the key as radix) — **pre-existing divergences from CRuby**, pinned here by probing CRuby case by case. With an overridden `each`, values now pass through unrepacked — CRuby's `Enumerable#map` does no repacking (a proc auto-splats a single-array yield; a strict `->(k, v)` receives it as one argument and raises); the old re-splitting diverged here too.

## Measured (interleaved builds, six alternating rounds, first dropped, medians)

Against master, ns/elem at n=1000:

| case | master | this PR | |
|---|---:|---:|---:|
| `each` | 74.4 | **30.0** | 2.5x |
| `any?` | 133.4 | **44.5** | 3.0x |
| `all?` | 135.2 | **46.7** | 2.9x |
| `count` | 135.1 | **46.5** | 2.9x |
| `map { \|k, v\| }` | 274.4 | **63.3** | 4.3x |
| `map { \|pair\| }` | 177.1 | **64.8** | 2.7x |
| `to_h` subclass path | 151.8 | **109.2** | 1.4x |

Controls — `to_h` plain and block paths, `dup` — measure unchanged. Against CRuby, `Hash#each` goes from **1.24x slower to 1.45x faster** (0.69x its time at n=1000, interleaved).

## Verified

* Splat tests drive every fill shape through hot call sites and pin them to CRuby: exact/short/empty/long arrays (empty is the dangling-pointer case the bounds check must keep unread), inline vs heap storage, a three-parameter block, and a mixed call site interleaving Arrays with a scalar, a `#to_ary` respondent, an Array subclass, nil, and a Float. Targeted tests also pass under **gc-stress**.
* `map` tests pin the pair-split rules (proc vs lambda vs Symbol proc, at every arity boundary), the singleton-each and overridden-each pass-through cases (including the lambda ArgumentError), and the no-override subclass fast path to CRuby.
* Full suite green on x86-64 (3292 passed, 0 failed). aarch64 under qemu: the splat tests and the full hash suite pass (commit 3 is pure Ruby, covered by the same suite).
* `each` semantics pinned against CRuby: delete/shift during iteration, adding raises, nested iteration, `break` releases the guard, no-block returns a sized Enumerator.

Related: the pre-existing snapshot-iteration divergence from CRuby (deleting a not-yet-visited key during iteration) is documented in #1095 — this PR preserves master's behavior there.