### PR TITLE
Hash: tombstone deletes during iteration; walk entries live (fixes #1095)

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -15,25 +15,27 @@ class Hash
   # in turn. A Rust builtin can never reach that, so its block pays a full
   # invocation per entry.
   #
-  # The three things the Rust implementation did that a bare index loop
-  # would lose are kept:
-  #
-  #   * the pairs are snapshotted first (`__pairs`) — deleting during
-  #     iteration is allowed and shifts the entry vector, so indexing the
-  #     live hash would skip the entry after each deletion;
-  #   * an iteration reference is held across the yields, which is what
-  #     makes *adding* a key during iteration raise;
-  #   * a single `[key, value]` array is yielded, so an arity-1 block
-  #     receives the pair (CRuby's `rb_yield(rb_assoc_new(k, v))`).
+  # Deleting during iteration is allowed and follows CRuby: while the
+  # traversal is live a delete tombstones its entry in place instead of
+  # compacting, so positions stay stable, a deleted not-yet-visited entry
+  # is not yielded, and deleting the current or a visited one skips
+  # nothing. An iteration reference is held across the yields, which is
+  # what makes *adding* a key during iteration raise; a single
+  # `[key, value]` array is yielded, so an arity-1 block receives the
+  # pair (CRuby's `rb_yield(rb_assoc_new(k, v))`).
   def each
     return to_enum(:each) { size } unless block_given?
-    pairs = __pairs
     guard = __iter_begin
     begin
+      # Walk the live entry vector by position. A delete during the loop
+      # tombstones its entry in place (positions stay stable, `__live_at`
+      # turns false for it), so a deleted not-yet-visited entry is skipped
+      # and deleting the current or an already-visited one skips nothing —
+      # CRuby's semantics. `__entry_count` is the raw bound, tombstones
+      # included; *adding* a key still raises, so it cannot grow mid-loop.
       i = 0
-      n = pairs.size
-      while i < n
-        yield pairs[i]
+      while i < __entry_count
+        yield [__key_at(i), __value_at(i)] if __live_at(i)
         i += 1
       end
     ensure
@@ -69,25 +71,25 @@ class Hash
     # `each` costs two block entries per pair — `each`'s own block and then
     # this method's `yield` — where one is enough. It also lets the pair be
     # yielded as two values, which is what `to_h` does anyway (unlike `each`,
-    # whose block receives a single `[k, v]`), so no array has to be splatted
-    # back apart at the yield.
+    # whose block receives a single `[k, v]`), so no array has to be built
+    # per element at all.
     #
-    # The traversal keeps what `each` guaranteed: the pairs are snapshotted,
-    # so deleting during the block still visits every entry, and an iteration
-    # reference is held so that *adding* a key raises. `ensure` balances the
-    # reference when the block raises or breaks.
-    pairs = __pairs
+    # The traversal is the same live positional walk as `each` — deleting
+    # during the block tombstones in place, so a deleted not-yet-visited
+    # entry is skipped (CRuby) — and an iteration reference is held so that
+    # *adding* a key raises. `ensure` balances the reference when the block
+    # raises or breaks.
     guard = __iter_begin
     begin
       i = 0
-      n = pairs.size
-      while i < n
-        e = pairs[i]
-        pair = yield e[0], e[1]
-        pair = pair.to_ary if !pair.is_a?(Array) && pair.respond_to?(:to_ary)
-        raise TypeError, "wrong element type #{pair.class} (expected array)" unless pair.is_a?(Array)
-        raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" unless pair.size == 2
-        h[pair[0]] = pair[1]
+      while i < __entry_count
+        if __live_at(i)
+          pair = yield __key_at(i), __value_at(i)
+          pair = pair.to_ary if !pair.is_a?(Array) && pair.respond_to?(:to_ary)
+          raise TypeError, "wrong element type #{pair.class} (expected array)" unless pair.is_a?(Array)
+          raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" unless pair.size == 2
+          h[pair[0]] = pair[1]
+        end
         i += 1
       end
     ensure

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -77,6 +77,27 @@ pub(super) fn init(globals: &mut Globals) {
         inline_gen2!(hash_value_at),
         1,
     );
+    // The raw entry-vector length (tombstones included) and the per-position
+    // liveness test — with `__key_at`/`__value_at`, the parts of the
+    // Ruby-level position-indexed traversal (`Hash#each`, builtins/hash.rb)
+    // that Ruby cannot express. A delete during iteration tombstones the
+    // entry in place (positions must stay stable under the walk), so the
+    // walk bounds itself with `__entry_count` and skips dead positions via
+    // `__live_at`.
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "__entry_count",
+        entry_count,
+        inline_gen2!(hash_entry_count),
+        0,
+    );
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "__live_at",
+        live_at,
+        inline_gen2!(hash_live_at),
+        1,
+    );
     // Internals of the Ruby-level `Hash#each` (builtins/hash.rb). `each`
     // lives in Ruby so that a `h.each { .. }` call site can inline both the
     // method and the block; these three are the parts that cannot.
@@ -958,6 +979,32 @@ fn value_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
 }
 
 ///
+/// ### Hash#__entry_count (internal)
+///
+/// The raw entry-vector length, tombstones included — the exclusive bound
+/// for a position-indexed walk. Equals `size` whenever no delete happened
+/// during a live traversal.
+///
+#[monoruby_builtin]
+fn entry_count(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let n = lfp.self_val().as_hash().entry_count();
+    Ok(Value::integer(n as i64))
+}
+
+///
+/// ### Hash#__live_at (internal)
+///
+/// `true` iff the `index`-th entry position exists and is not a tombstone
+/// (an entry deleted while a traversal was live). See `__entry_count`.
+///
+#[monoruby_builtin]
+fn live_at(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let idx = lfp.arg(0).coerce_to_i64(globals)?;
+    let live = idx >= 0 && lfp.self_val().as_hash().live_at(idx as usize);
+    Ok(Value::bool(live))
+}
+
+///
 /// ### Hash#__pairs (internal)
 ///
 /// A snapshot of the entries as `[[k, v], ...]`.
@@ -1129,8 +1176,65 @@ fn hash_size(
     };
     let dst = callsite.dst;
     state.load(ir, callsite.recv, GP::Rdi);
-    ir.hash_len_fixnum(GP::Rax, GP::Rdi, layout);
+    ir.hash_len_fixnum(GP::Rax, GP::Rdi, layout, true);
     state.def_reg2acc_fixnum(ir, GP::Rax, dst);
+    true
+}
+
+///
+/// Inline `Hash#__entry_count` as machine code: the raw entry-vector length,
+/// tombstones included — the exclusive bound for a position-indexed walk.
+/// Identical to `Hash#size` except that the tombstone count is not
+/// subtracted.
+///
+fn hash_entry_count(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() {
+        return false;
+    }
+    let Some(layout) = hash_entries_layout() else {
+        return false;
+    };
+    let dst = callsite.dst;
+    state.load(ir, callsite.recv, GP::Rdi);
+    ir.hash_len_fixnum(GP::Rax, GP::Rdi, layout, false);
+    state.def_reg2acc_fixnum(ir, GP::Rax, dst);
+    true
+}
+
+///
+/// Inline `Hash#__live_at` as machine code: Ruby `true` iff the position is
+/// in range and the entry is not a tombstone. Total by construction, like
+/// `__key_at` — no call, no error edge.
+///
+fn hash_live_at(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    idx_class: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 || idx_class != Some(INTEGER_CLASS) {
+        return false;
+    }
+    let Some(layout) = hash_entries_layout() else {
+        return false;
+    };
+    state.load_fixnum(ir, callsite.args, GP::Rcx);
+    state.load(ir, callsite.recv, GP::Rdx);
+    ir.hash_live_at(layout);
+    state.def_rax2acc(ir, callsite.dst);
     true
 }
 
@@ -4930,6 +5034,48 @@ mod tests {
     /// (`->(a, b, *c)` splits, `->(a, *b)` gets the pair whole). With an
     /// overridden `each`, values pass through unrepacked: a proc auto-splats
     /// a single-array yield, a strict lambda raises on it.
+    /// Deleting during iteration follows CRuby (#1095): while a traversal
+    /// is live a delete tombstones its entry in place — the index table
+    /// drops it, the walk's positions stay stable — so a deleted
+    /// not-yet-visited entry is not yielded, deleting the current or a
+    /// visited entry skips nothing, and `size`/`keys`/`inspect`/`dup`
+    /// observed mid-walk never see the dead entry. Compaction is lazy: the
+    /// next mutation outside an iteration (or a clone) sweeps the
+    /// tombstones. Exercised on both representations — an inline hash
+    /// promotes to boxed on the first mid-iteration delete — plus identity
+    /// hashes and `shift`.
+    #[test]
+    fn hash_delete_during_iteration() {
+        run_tests(&[
+            // Not-yet-visited: skipped (boxed).
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each { |k, v| h.delete(:e) if k == :b; acc << k }; [acc, h.keys, h.size]"#,
+            // Current key: nothing skipped.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each { |k, v| h.delete(k); acc << k }; [acc, h.keys, h.empty?]"#,
+            // Already-visited key: nothing skipped.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each { |k, v| h.delete(:a) if k == :c; acc << k }; [acc, h.keys]"#,
+            // Everything deleted up front: only the current entry yields.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each { |k, v| h.keys.each { |x| h.delete(x) }; acc << k }; [acc, h.keys, h.size]"#,
+            // Inline representation: promotes to boxed mid-iteration.
+            r#"h = {a:1, b:2, c:3}; acc = []; h.each { |k, v| h.delete(:b); acc << k }; [acc, h.keys, h.size]"#,
+            // Live size mid-walk, and update of an existing key stays legal.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each { |k, v| h.delete(:e) if k == :a; acc << h.size; h[:b] = 99 }; [acc.first, h[:b]]"#,
+            // Re-adding a deleted key is adding a new key: raises.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; (h.each { |k, v| h.delete(:e); h[:e] = 5 } rescue $!.class.to_s)"#,
+            // shift during iteration tombstones the first live entry.
+            r#"h = {a:1, b:2, c:3}; acc = []; h.each { |k, v| h.shift; acc << k }; [acc, h.keys]"#,
+            // Observers mid-window: keys/inspect/dup never see the dead entry,
+            // and the dup is independently mutable (compacted copy).
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; r = nil; h.each { |k, v| h.delete(:e) if k == :a; r = [h.keys, h.inspect, h.dup.size] if k == :b }; r"#,
+            // Identity hash: same discipline through the IdentMap path.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6}.compare_by_identity; acc = []; h.each { |k, v| h.delete(:e); acc << k }; [acc, h.keys]"#,
+            // Break leaves tombstones; the next mutation compacts and the
+            // hash is fully usable.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; h.each { |k, v| h.delete(:e); break }; h[:new] = 1; h.delete(:a); [h.keys, h.size]"#,
+            // to_h's block form shares the walk.
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; r = h.to_h { |k, v| h.delete(:e); [k, v] }; [r.keys, h.keys]"#,
+        ]);
+    }
+
     #[test]
     fn hash_map_pair_split_rules() {
         run_tests(&[

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -186,13 +186,24 @@ impl Codegen {
     ///
     /// ### destroy
     /// - x9
-    pub(crate) fn gen_hash_len_fixnum(&mut self, dst: GP, base: GP, layout: rubymap::EntriesLayout) {
+    /// `sub_dead` additionally subtracts the boxed tombstone count
+    /// (`HASH_DEAD_OFFSET`) — the live size for `Hash#size`. Without it the
+    /// raw entry-vector length is produced (`__entry_count`), the exclusive
+    /// bound for a position-indexed walk.
+    pub(crate) fn gen_hash_len_fixnum(
+        &mut self,
+        dst: GP,
+        base: GP,
+        layout: rubymap::EntriesLayout,
+        sub_dead: bool,
+    ) {
         let (d, b) = (dst.a64().0, base.a64().0);
         let tag = self.jit.label();
         let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
         let boxed_rep = HASH_REP_BOXED as u32;
         let map_ptr = HASH_CONTENT_MAP_OFFSET as u32;
         let len_off = layout.len_offset as u32;
+        let dead_off = HASH_DEAD_OFFSET as u32;
         monoasm_arm64!(&mut self.jit,
             ldrb w(d), [x(b), #(ty_flags)];
             mov x9, (HASH_REP_MASK as u64);
@@ -200,10 +211,20 @@ impl Codegen {
             cmp x(d), #(boxed_rep);
         );
         self.jit.bcond_label(monoasm::Cond::Ne, &tag);
+        if sub_dead {
+            monoasm_arm64!(&mut self.jit,
+                ldr w9, [x(b), #(dead_off)];
+            );
+        }
         monoasm_arm64!(&mut self.jit,
             ldr x(d), [x(b), #(map_ptr)];
             ldr x(d), [x(d), #(len_off)];
         );
+        if sub_dead {
+            monoasm_arm64!(&mut self.jit,
+                sub x(d), x(d), x9;
+            );
+        }
         self.jit.bind_label(tag);
         monoasm_arm64!(&mut self.jit,
             lsl x(d), x(d), #1;
@@ -331,6 +352,7 @@ impl Codegen {
         } else {
             layout.value_offset
         }) as u32;
+        let key_field = layout.key_offset as u32;
         monoasm_arm64!(&mut self.jit,
             asr x1, x1, #(1);                 // untag the index
             mov x0, #(NIL_VALUE);             // nil unless a path below overwrites it
@@ -366,7 +388,81 @@ impl Codegen {
             mul x1, x1, x9;
             ldr x9, [x4, #(ptr_off)];
             add x1, x1, x9;
+            // A tombstoned entry answers nil like an out-of-range index —
+            // the sentinel key must never surface as a Ruby value, and
+            // user code may probe any position directly.
+            ldr x3, [x1, #(key_field)];
+            mov x9, (crate::rvalue::HASH_TOMBSTONE_KEY);
+            cmp x3, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &exit);
+        monoasm_arm64!(&mut self.jit,
             ldr x0, [x1, #(bucket_field)];
+        exit:
+        );
+    }
+
+    /// `Hash#__live_at`: hash in Rdx (x2), fixnum index in Rcx (x1), Ruby
+    /// bool in Rax (x0) — `true` iff the position is in range and the entry
+    /// is not a tombstone. aarch64 twin of the x86 `gen_hash_live_at`.
+    /// Total by construction, like `__key_at`.
+    ///
+    /// ### destroy
+    /// - x0 (Rax), x1 (Rcx), x3 (Rsi), x4 (Rdi), x9
+    pub(crate) fn gen_hash_live_at(&mut self, layout: rubymap::EntriesLayout) {
+        let boxed = self.jit.label();
+        let dead = self.jit.label();
+        let live = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
+        let boxed_rep = HASH_REP_BOXED as u32;
+        let map_ptr = HASH_CONTENT_MAP_OFFSET as u32;
+        let len_off = layout.len_offset as u32;
+        let ptr_off = layout.ptr_offset as u32;
+        let bucket_size = layout.bucket_size as u64;
+        let key_off = layout.key_offset as u32;
+        monoasm_arm64!(&mut self.jit,
+            asr x1, x1, #(1);                 // untag the index
+            cmp x1, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Lt, &dead); // negative -> false
+        monoasm_arm64!(&mut self.jit,
+            ldrb w3, [x2, #(ty_flags)];
+            mov x9, (HASH_REP_MASK as u64);
+            and x3, x3, x9;                   // representation bits
+            cmp x3, #(boxed_rep);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &boxed);
+        // Inline: the representation bits double as the length, and an
+        // inline hash never holds a tombstone — in range means live.
+        monoasm_arm64!(&mut self.jit,
+            cmp x3, x1;                       // len vs idx
+        );
+        self.jit.bcond_label(monoasm::Cond::Hi, &live); // len > idx -> live
+        monoasm_arm64!(&mut self.jit,
+            b dead;
+        boxed:
+            ldr x4, [x2, #(map_ptr)];
+            ldr x9, [x4, #(len_off)];
+            cmp x9, x1;                       // len vs idx
+        );
+        self.jit.bcond_label(monoasm::Cond::Ls, &dead);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (bucket_size);
+            mul x1, x1, x9;
+            ldr x9, [x4, #(ptr_off)];
+            add x1, x1, x9;
+            ldr x3, [x1, #(key_off)];
+            mov x9, (crate::rvalue::HASH_TOMBSTONE_KEY);
+            cmp x3, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &dead);
+        self.jit.bind_label(live);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(TRUE_VALUE as u32);
+            b exit;
+        dead:
+            mov x0, #(FALSE_VALUE as u32);
         exit:
         );
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -120,7 +120,17 @@ impl Codegen {
     /// boxed one keeps it in the entry vector. The boxed length hangs off a
     /// pointer that is only a pointer on that side of the branch, so unlike
     /// `Array#size` this cannot be a speculative load plus `cmov`.
-    pub(crate) fn gen_hash_len_fixnum(&mut self, dst: GP, base: GP, layout: rubymap::EntriesLayout) {
+    /// `sub_dead` additionally subtracts the boxed tombstone count
+    /// (`HASH_DEAD_OFFSET`) — the live size for `Hash#size`. Without it the
+    /// raw entry-vector length is produced (`__entry_count`), the exclusive
+    /// bound for a position-indexed walk. Destroys rsi when `sub_dead`.
+    pub(crate) fn gen_hash_len_fixnum(
+        &mut self,
+        dst: GP,
+        base: GP,
+        layout: rubymap::EntriesLayout,
+        sub_dead: bool,
+    ) {
         let (d, b) = (dst as u64, base as u64);
         let tag = self.jit.label();
         let ty_flags = RVALUE_OFFSET_TY + 1;
@@ -128,6 +138,7 @@ impl Codegen {
         let boxed_rep = HASH_REP_BOXED as u64;
         let map_ptr = HASH_CONTENT_MAP_OFFSET;
         let len_off = layout.len_offset;
+        let dead_off = HASH_DEAD_OFFSET;
         monoasm! { &mut self.jit,
             // The representation bits live in the low byte of ty_flags; the
             // 32-bit load stays inside the header and `andl` clears the rest.
@@ -135,8 +146,22 @@ impl Codegen {
             andl R(d), (mask);
             cmpl R(d), (boxed_rep);
             jne  tag;
+        }
+        if sub_dead {
+            monoasm! { &mut self.jit,
+                movl rsi, [R(b) + (dead_off)];
+            }
+        }
+        monoasm! { &mut self.jit,
             movq R(d), [R(b) + (map_ptr)];
             movq R(d), [R(d) + (len_off)];
+        }
+        if sub_dead {
+            monoasm! { &mut self.jit,
+                subq R(d), rsi;
+            }
+        }
+        monoasm! { &mut self.jit,
         tag:
             salq R(d), 1;
             orq  R(d), 1;
@@ -249,6 +274,7 @@ impl Codegen {
         } else {
             layout.value_offset
         };
+        let key_field = layout.key_offset;
         monoasm! { &mut self.jit,
             // nil unless one of the paths below overwrites it.
             movq rax, (NIL_VALUE);
@@ -273,7 +299,60 @@ impl Codegen {
             movq rsi, (bucket_size);
             imul rcx, rsi;
             addq rcx, [rdi + (ptr_off)];
+            // A tombstoned entry answers nil like an out-of-range index —
+            // the sentinel key must never surface as a Ruby value, and
+            // user code may probe any position directly.
+            movq rsi, [rcx + (key_field)];
+            cmpq rsi, (crate::rvalue::HASH_TOMBSTONE_KEY);
+            jeq  exit;
             movq rax, [rcx + (bucket_field)];
+        exit:
+        }
+    }
+
+    /// `Hash#__live_at`: hash in rdx, fixnum index in rcx, Ruby bool in rax —
+    /// `true` iff the position is in range and the entry is not a tombstone.
+    /// Total by construction, like `__key_at`. rsi and rdi are scratch.
+    pub(crate) fn gen_hash_live_at(&mut self, layout: rubymap::EntriesLayout) {
+        let boxed = self.jit.label();
+        let dead = self.jit.label();
+        let live = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = RVALUE_OFFSET_TY + 1;
+        let mask = HASH_REP_MASK as u64;
+        let boxed_rep = HASH_REP_BOXED as u64;
+        let map_ptr = HASH_CONTENT_MAP_OFFSET;
+        let len_off = layout.len_offset;
+        let ptr_off = layout.ptr_offset;
+        let bucket_size = layout.bucket_size;
+        let key_off = layout.key_offset;
+        monoasm! { &mut self.jit,
+            sarq rcx, 1;                  // untag the index
+            js   dead;                    // negative → false
+            movl rsi, [rdx + (ty_flags)];
+            andl rsi, (mask);
+            cmpl rsi, (boxed_rep);
+            jeq  boxed;
+            // Inline: the representation bits double as the length, and an
+            // inline hash never holds a tombstone — in range means live.
+            cmpq rcx, rsi;
+            jb   live;
+            jmp  dead;
+        boxed:
+            movq rdi, [rdx + (map_ptr)];
+            cmpq rcx, [rdi + (len_off)];
+            jae  dead;
+            movq rsi, (bucket_size);
+            imul rcx, rsi;
+            addq rcx, [rdi + (ptr_off)];
+            movq rsi, [rcx + (key_off)];
+            cmpq rsi, (crate::rvalue::HASH_TOMBSTONE_KEY);
+            jeq  dead;
+        live:
+            movq rax, (TRUE_VALUE);
+            jmp  exit;
+        dead:
+            movq rax, (FALSE_VALUE);
         exit:
         }
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -176,6 +176,7 @@ impl Codegen {
             | AsmInst::StringLenFixnum { .. }
             | AsmInst::HashLenFixnum { .. }
             | AsmInst::HashEntryAt { .. }
+            | AsmInst::HashLiveAt { .. }
             | AsmInst::HashCompareByIdentity { .. }
             | AsmInst::HashDefault { .. }
             | AsmInst::IsNilToBool { .. }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1010,9 +1010,30 @@ impl AsmIr {
     }
 
     /// Emit `dst <- fixnum(Hash#size)`: the fixnum-tagged entry count of the
-    /// hash receiver in `base`. Typed alternative to `inline` for `Hash#size`.
-    pub(crate) fn hash_len_fixnum(&mut self, dst: GP, base: GP, layout: rubymap::EntriesLayout) {
-        self.inst.push(AsmInst::HashLenFixnum { dst, base, layout });
+    /// hash receiver in `base`. `sub_dead` subtracts the tombstone count
+    /// (true for the user-facing `Hash#size`; false for `__entry_count`,
+    /// whose walk needs the raw entry-vector length, tombstones included).
+    /// Typed alternative to `inline`.
+    pub(crate) fn hash_len_fixnum(
+        &mut self,
+        dst: GP,
+        base: GP,
+        layout: rubymap::EntriesLayout,
+        sub_dead: bool,
+    ) {
+        self.inst.push(AsmInst::HashLenFixnum {
+            dst,
+            base,
+            layout,
+            sub_dead,
+        });
+    }
+
+    /// Emit `Rax <- Hash#__live_at(Rcx)` for the hash in `Rdx`: Ruby `true`
+    /// when the entry at that position exists and is not tombstoned. Typed
+    /// alternative to the out-of-line C-ABI call.
+    pub(crate) fn hash_live_at(&mut self, layout: rubymap::EntriesLayout) {
+        self.inst.push(AsmInst::HashLiveAt { layout });
     }
 
     /// Emit `dst <- Hash#compare_by_identity?` for the hash in `base`.
@@ -1687,6 +1708,9 @@ pub(super) enum AsmInst {
         dst: GP,
         base: GP,
         layout: rubymap::EntriesLayout,
+        /// Subtract the tombstone count: true for `Hash#size`, false for
+        /// the raw `__entry_count`.
+        sub_dead: bool,
     },
     /// Block-style single-Array auto-splat for a specialized `yield` of one
     /// value into a plain multi-parameter block: with the value in `Rdi`,
@@ -1729,6 +1753,13 @@ pub(super) enum AsmInst {
     /// intrinsics exist for need no error edge and no generic fallback.
     HashEntryAt {
         want_key: bool,
+        layout: rubymap::EntriesLayout,
+    },
+    /// `Rax <- Hash#__live_at(Rcx)` for the hash in `Rdx`, with the index
+    /// arriving as a fixnum `Value`: Ruby `true` when the position is in
+    /// range and the entry is not a tombstone, else `false`. Total by
+    /// construction, like `HashEntryAt` — no error edge, no fallback.
+    HashLiveAt {
         layout: rubymap::EntriesLayout,
     },
     /// `dst <- (src == nil) ? true : false` as a Ruby bool `Value` (`Object#nil?`).

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1092,9 +1092,14 @@ impl Codegen {
             }
             // The hash intrinsics branch on the representation, so they are
             // emitted per arch rather than as straight-line LIR.
-            AsmInst::HashLenFixnum { dst, base, layout } => {
+            AsmInst::HashLenFixnum {
+                dst,
+                base,
+                layout,
+                sub_dead,
+            } => {
                 self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
-                    cg.gen_hash_len_fixnum(dst, base, layout);
+                    cg.gen_hash_len_fixnum(dst, base, layout, sub_dead);
                 });
             }
             AsmInst::HashCompareByIdentity { dst, base } => {
@@ -1114,6 +1119,11 @@ impl Codegen {
             AsmInst::HashEntryAt { want_key, layout } => {
                 self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
                     cg.gen_hash_entry_at(want_key, layout);
+                });
+            }
+            AsmInst::HashLiveAt { layout } => {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
+                    cg.gen_hash_live_at(layout);
                 });
             }
             // Typed bool predicates (replace `emit_kernel_nil` / `emit_object_not`).

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -39,6 +39,24 @@ const R2K_BIT: u8 = 0b0000_1000;
 const ITER_MASK: u8 = 0b0011_0000;
 const ITER_SHIFT: u8 = 4;
 const ITER_MAX: u8 = 3;
+
+/// The key bits marking a tombstoned (deleted-during-iteration) entry in a
+/// boxed hash's entry vector.
+///
+/// `0b0010_0100` is not a value any live `Value` can carry: bit 0 is clear
+/// (not a Fixnum), bits 1:0 are `00` (not a Flonum), bits 2:0 are not `000`
+/// (not a heap pointer), and the low byte is not `TAG_SYMBOL` — while bit 2
+/// being set still classifies it as a *packed* value, so the GC never tries
+/// to dereference it. Entries carrying this key are dead: the index table
+/// no longer references them (`rubymap::tombstone_remove`), every iterator
+/// filters them, and the `__live_at` intrinsic reports them false. The next
+/// mutating operation outside an iteration compacts them away
+/// ([`HashRefMut::compact_if_dirty`]).
+pub const HASH_TOMBSTONE_KEY: u64 = 0b0010_0100;
+
+fn tombstone_key() -> Value {
+    Value::from_u64(HASH_TOMBSTONE_KEY)
+}
 /// The *inline* hash is identity-keyed (`compare_by_identity`).
 /// Identity probing is a pure id scan — no hashing, no Ruby code, and
 /// an id can never go stale — so an identity-keyed inline hash may hold
@@ -89,6 +107,12 @@ pub const HASH_INLINE_IDENT_BIT: u8 = IDENT_BIT;
 /// is set; otherwise it points at a discriminant followed by the payload.
 pub const HASH_DEFAULT_OFFSET: usize = RVALUE_OFFSET_KIND + std::mem::offset_of!(BoxedHash, default);
 pub const HASH_DEFAULT_PAYLOAD_OFFSET: usize = std::mem::size_of::<usize>();
+
+/// The boxed tombstone count (a `Cell<u32>`), addressed from the start of the
+/// `RValue`. `Hash#size` in machine code subtracts this from the raw entry
+/// length; it is zero except while a traversal that deleted keys is live (or
+/// until the next mutation compacts).
+pub const HASH_DEAD_OFFSET: usize = RVALUE_OFFSET_KIND + std::mem::offset_of!(BoxedHash, dead);
 
 /// The entry-storage layout shared by both boxed forms.
 ///
@@ -164,6 +188,15 @@ pub(crate) struct BoxedHash {
     /// Corresponds to CRuby's `RHASH_ITER_LEV`. A `Cell` so a traversal
     /// holding a shared borrow can still record its presence.
     iter_lev: std::cell::Cell<u32>,
+    /// Tombstoned entries currently sitting in the entry vector: a delete
+    /// while `iter_lev > 0` cannot compact (positions must stay stable
+    /// under the live traversal), so the entry stays in place with its key
+    /// overwritten by [`HASH_TOMBSTONE_KEY`] and this count goes up. The
+    /// live size is the entry count minus this; the next mutating
+    /// operation outside an iteration compacts and resets it. A `Cell`
+    /// because `Hash#delete` reaches here through the same shared-borrow
+    /// discipline as `iter_lev`.
+    dead: std::cell::Cell<u32>,
 }
 
 impl BoxedHash {
@@ -172,6 +205,7 @@ impl BoxedHash {
             content,
             default: None,
             iter_lev: std::cell::Cell::new(0),
+            dead: std::cell::Cell::new(0),
         }
     }
 }
@@ -311,6 +345,7 @@ impl HashmapInner {
                     content: HashContent::Map(Box::new(map)),
                     default: default.map(Box::new),
                     iter_lev: std::cell::Cell::new(0),
+                    dead: std::cell::Cell::new(0),
                 }),
             },
         )
@@ -584,7 +619,29 @@ impl<'a> HashRef<'a> {
         }
     }
 
+    /// Tombstoned entries currently in the boxed entry vector (zero for the
+    /// inline representation, which never tombstones — a delete during
+    /// iteration promotes to boxed first).
+    fn dead_count(&self) -> usize {
+        if self.is_inline() {
+            0
+        } else {
+            self.boxed().dead.get() as usize
+        }
+    }
+
     pub(crate) fn len(&self) -> usize {
+        match self.content() {
+            ContentRef::Inline(pairs) => pairs.len(),
+            ContentRef::Map(m) => m.len() - self.dead_count(),
+            ContentRef::Ident(m) => m.len() - self.dead_count(),
+        }
+    }
+
+    /// The raw entry-vector length, tombstones included — the exclusive
+    /// upper bound for a position-indexed walk (`__entry_count`). Equals
+    /// [`Self::len`] whenever no tombstones are outstanding.
+    pub(crate) fn entry_count(&self) -> usize {
         match self.content() {
             ContentRef::Inline(pairs) => pairs.len(),
             ContentRef::Map(m) => m.len(),
@@ -592,11 +649,28 @@ impl<'a> HashRef<'a> {
         }
     }
 
+    /// Is the `index`-th entry live — in range and not a tombstone? The
+    /// `__live_at` intrinsic; a position-indexed walk asks this before
+    /// touching `entry_at`.
+    pub(crate) fn live_at(&self, index: usize) -> bool {
+        match self.content() {
+            ContentRef::Inline(pairs) => index < pairs.len(),
+            ContentRef::Map(m) => m
+                .get_index(index)
+                .is_some_and(|(k, _)| k.id() != HASH_TOMBSTONE_KEY),
+            ContentRef::Ident(m) => m
+                .get_index(index)
+                .is_some_and(|(k, _)| k.0.id() != HASH_TOMBSTONE_KEY),
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// The `index`-th entry in insertion order, or `None` when out of range.
+    /// The `index`-th entry in insertion order, or `None` when out of range
+    /// **or tombstoned** — the sentinel key must never surface as a Ruby
+    /// value, so a dead entry answers like an out-of-range one.
     /// O(1) for every representation: the inline pairs and `RubyMap`'s entry
     /// vector are both position-addressable. Used by the `__key_at` /
     /// `__value_at` intrinsics so Ruby-level iteration can be a `while` loop
@@ -604,8 +678,14 @@ impl<'a> HashRef<'a> {
     pub(crate) fn entry_at(&self, index: usize) -> Option<(Value, Value)> {
         match self.content() {
             ContentRef::Inline(pairs) => pairs.get(index).copied(),
-            ContentRef::Map(m) => m.get_index(index).map(|(k, v)| (*k, *v)),
-            ContentRef::Ident(m) => m.get_index(index).map(|(k, v)| (k.0, *v)),
+            ContentRef::Map(m) => m
+                .get_index(index)
+                .filter(|(k, _)| k.id() != HASH_TOMBSTONE_KEY)
+                .map(|(k, v)| (*k, *v)),
+            ContentRef::Ident(m) => m
+                .get_index(index)
+                .filter(|(k, _)| k.0.id() != HASH_TOMBSTONE_KEY)
+                .map(|(k, v)| (k.0, *v)),
         }
     }
 
@@ -788,11 +868,26 @@ impl<'a> HashRef<'a> {
             }
         } else {
             let b = self.boxed();
+            let mut content = b.content.clone();
+            // A copy is not being iterated, so it owes no position
+            // stability: drop any tombstones now rather than carrying the
+            // dead count over.
+            if b.dead.get() > 0 {
+                match &mut content {
+                    HashContent::Map(m) => {
+                        m.compact_tombstones(|k| k.id() == HASH_TOMBSTONE_KEY)
+                    }
+                    HashContent::IdentMap(m) => {
+                        m.compact_tombstones(|k| k.0.id() == HASH_TOMBSTONE_KEY)
+                    }
+                }
+            }
             HashBody {
                 boxed: ManuallyDrop::new(BoxedHash {
-                    content: b.content.clone(),
+                    content,
                     default: b.default.clone(),
                     iter_lev: std::cell::Cell::new(0),
+                    dead: std::cell::Cell::new(0),
                 }),
             }
         }
@@ -1069,6 +1164,7 @@ impl<'a> HashRefMut<'a> {
             content,
             default: None,
             iter_lev: std::cell::Cell::new(iter_depth),
+            dead: std::cell::Cell::new(0),
         };
         *self.body_mut() = HashBody {
             boxed: ManuallyDrop::new(boxed),
@@ -1085,6 +1181,14 @@ impl<'a> HashRefMut<'a> {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<()> {
+        // Stale tombstones must go before an insert: growing the index
+        // table re-inserts every raw bucket, which would resurrect them.
+        // (During iteration the new-key check below raises first, and an
+        // existing-key update touches no bucket positions, so tombstones
+        // can only be stale — no traversal live — when this compacts.)
+        if !self.as_ref().iter_active() {
+            self.compact_if_dirty();
+        }
         if self.as_ref().iter_active() && !self.as_ref().contains_key(k, vm, globals)? {
             return Err(MonorubyErr::runtimeerr(
                 "can't add a new key into hash during iteration",
@@ -1127,6 +1231,29 @@ impl<'a> HashRefMut<'a> {
         Ok(())
     }
 
+    /// Compact any tombstones left by a finished (or broken-out-of)
+    /// traversal. Must run before any operation that walks or rebuilds the
+    /// raw buckets as if all were live — insertion (whose index-table
+    /// growth re-inserts every bucket), `compare_by_identity`'s rebuild —
+    /// and is called from every such `&mut` entry point. Never called with
+    /// a traversal live: the callers either raise on iteration first or
+    /// take the tombstoning branch instead.
+    fn compact_if_dirty(&mut self) {
+        if self.is_inline() {
+            return;
+        }
+        let b = self.boxed_mut();
+        if b.dead.get() == 0 {
+            return;
+        }
+        debug_assert_eq!(b.iter_lev.get(), 0);
+        match &mut b.content {
+            HashContent::Map(m) => m.compact_tombstones(|k| k.id() == HASH_TOMBSTONE_KEY),
+            HashContent::IdentMap(m) => m.compact_tombstones(|k| k.0.id() == HASH_TOMBSTONE_KEY),
+        }
+        b.dead.set(0);
+    }
+
     pub fn remove(
         &mut self,
         k: Value,
@@ -1135,13 +1262,48 @@ impl<'a> HashRefMut<'a> {
     ) -> Result<Option<Value>> {
         // Removing a key during iteration is explicitly allowed — CRuby
         // behaves the same way (see ruby/spec core/hash/delete_spec.rb
-        // "allows removing a key while iterating").
+        // "allows removing a key while iterating") — but the traversal is
+        // walking the entries by position, so the entry cannot be compacted
+        // out from under it. Instead it is tombstoned in place: dropped
+        // from the index table, key overwritten with the sentinel, so the
+        // walk sees a dead slot (skipped via `__live_at`) and every
+        // position it has yet to visit stays put. CRuby semantics follow:
+        // a deleted not-yet-visited entry is not yielded, and deleting a
+        // visited (or the current) one skips nothing. The inline form
+        // cannot hold a dead slot, so it promotes to boxed first (its
+        // iteration depth migrates with it).
+        if self.as_ref().iter_active() {
+            if self.is_inline() {
+                let ident = self.as_ref().is_compare_by_identity();
+                self.promote(ident, vm, globals)?;
+            }
+            let removed = match &mut self.boxed_mut().content {
+                HashContent::Map(m) => m
+                    .tombstone_remove(&k, tombstone_key(), Value::nil(), vm, globals)?
+                    .map(|(_, _, v)| v),
+                HashContent::IdentMap(m) => m
+                    .tombstone_remove(
+                        &IdentKey(k),
+                        IdentKey(tombstone_key()),
+                        Value::nil(),
+                        vm,
+                        globals,
+                    )?
+                    .map(|(_, _, v)| v),
+            };
+            if removed.is_some() {
+                let dead = &self.boxed_mut().dead;
+                dead.set(dead.get() + 1);
+            }
+            return Ok(removed);
+        }
         if self.is_inline() {
             return Ok(match self.as_ref().inline_pos(k, vm, globals)? {
                 Some(i) => Some(self.inline_remove_at(i)),
                 None => None,
             });
         }
+        self.compact_if_dirty();
         match &mut self.boxed_mut().content {
             HashContent::Map(m) => m.shift_remove(&k, vm, globals),
             HashContent::IdentMap(m) => m.shift_remove(&IdentKey(k), vm, globals),
@@ -1179,11 +1341,13 @@ impl<'a> HashRefMut<'a> {
         } else if self.boxed_mut().default.is_some() {
             // A default keeps the hash boxed; just empty the map (the
             // default itself survives, as in CRuby: `clear` does not
-            // touch it).
+            // touch it). Any stale tombstones vanish with the entries, so
+            // the dead count resets alongside.
             match &mut self.boxed_mut().content {
                 HashContent::Map(m) => m.clear(),
                 HashContent::IdentMap(m) => m.clear(),
             }
+            self.boxed_mut().dead.set(0);
         } else {
             // Give the boxed storage back — an emptied, default-less
             // hash is small again by definition. An identity-compared
@@ -1214,12 +1378,44 @@ impl<'a> HashRefMut<'a> {
         if self.as_ref().len() == 0 {
             return Ok(None);
         }
+        if self.as_ref().iter_active() {
+            // Same discipline as `remove` during iteration: tombstone the
+            // first *live* entry so positions stay stable under the
+            // traversal.
+            if self.is_inline() {
+                let ident = self.as_ref().is_compare_by_identity();
+                self.promote(ident, vm, globals)?;
+            }
+            let first_live = (0..self.as_ref().entry_count())
+                .find(|&i| self.as_ref().live_at(i))
+                .expect("len > 0 implies a live entry");
+            let removed = match &mut self.boxed_mut().content {
+                HashContent::Map(m) => m
+                    .tombstone_index(first_live, tombstone_key(), Value::nil(), vm, globals)?,
+                HashContent::IdentMap(m) => m
+                    .tombstone_index(
+                        first_live,
+                        IdentKey(tombstone_key()),
+                        Value::nil(),
+                        vm,
+                        globals,
+                    )?
+                    .map(|(k, v)| (k.0, v)),
+            };
+            debug_assert!(removed.is_some());
+            if removed.is_some() {
+                let dead = &self.boxed_mut().dead;
+                dead.set(dead.get() + 1);
+            }
+            return Ok(removed);
+        }
         if self.is_inline() {
             // SAFETY: rep is inline; len > 0 was checked above.
             let k = unsafe { self.body_mut().inline[0].0 };
             let v = self.inline_remove_at(0);
             return Ok(Some((k, v)));
         }
+        self.compact_if_dirty();
         match &mut self.boxed_mut().content {
             HashContent::Map(m) => m
                 .shift_remove_index(0, vm, globals)
@@ -1281,6 +1477,9 @@ impl<'a> HashRefMut<'a> {
 
     pub fn compare_by_identity(&mut self, vm: &mut Executor, globals: &mut Globals) -> Result<()> {
         self.as_ref().check_iter()?;
+        // The rebuild below walks the raw buckets; stale tombstones must
+        // not come along.
+        self.compact_if_dirty();
         if self.is_inline() {
             // Just flip the mode bit: the existing keys are packed
             // immediates, for which eql? and identity coincide, so the
@@ -1405,10 +1604,19 @@ pub enum Iter<'a> {
 impl Iterator for Iter<'_> {
     type Item = (Value, Value);
     fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Iter::Inline(pairs) => pairs.next().copied(),
-            Iter::Map(map) => map.next().map(|(k, v)| (*k, *v)),
-            Iter::IdentMap(map) => map.next().map(|(k, v)| (k.0, *v)),
+        // Tombstoned entries are dead: skip them so no caller — user-facing
+        // iteration, GC marking, `keys`/`values`, `inspect` — can observe
+        // the sentinel key.
+        loop {
+            let next = match self {
+                Iter::Inline(pairs) => pairs.next().copied(),
+                Iter::Map(map) => map.next().map(|(k, v)| (*k, *v)),
+                Iter::IdentMap(map) => map.next().map(|(k, v)| (k.0, *v)),
+            };
+            match next {
+                Some((k, _)) if k.id() == HASH_TOMBSTONE_KEY => continue,
+                other => return other,
+            }
         }
     }
 }
@@ -1483,6 +1691,16 @@ impl Hashmap {
     /// See [`HashRef::entry_at`].
     pub(crate) fn entry_at(&self, index: usize) -> Option<(Value, Value)> {
         self.inner().entry_at(index)
+    }
+
+    /// See [`HashRef::entry_count`].
+    pub(crate) fn entry_count(&self) -> usize {
+        self.inner().entry_count()
+    }
+
+    /// See [`HashRef::live_at`].
+    pub(crate) fn live_at(&self, index: usize) -> bool {
+        self.inner().live_at(index)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/rubymap/src/map.rs
+++ b/rubymap/src/map.rs
@@ -927,6 +927,50 @@ where
         }
     }
 
+    /// Remove `key` from the index table only, leaving its entry in place
+    /// overwritten with `dead_key`/`dead_value`, so entry positions stay
+    /// stable for a traversal walking them by index. See
+    /// `IndexMapCore::tombstone_remove_full` (map/core.rs) for the
+    /// contract; compact with [`Self::compact_tombstones`] when the
+    /// traversal window closes.
+    pub fn tombstone_remove<Q>(
+        &mut self,
+        key: &Q,
+        dead_key: K,
+        dead_value: V,
+        e: &mut E,
+        g: &mut G,
+    ) -> Result<Option<(usize, K, V)>, R>
+    where
+        Q: ?Sized + RubyHash<E, G, R> + Equivalent<K, E, G, R>,
+    {
+        if self.is_empty() {
+            return Ok(None);
+        }
+        let hash = self.hash(key, e, g)?;
+        self.core
+            .tombstone_remove_full(hash, key, dead_key, dead_value, e, g)
+    }
+
+    /// [`Self::tombstone_remove`] for a caller-chosen entry position.
+    pub fn tombstone_index(
+        &mut self,
+        index: usize,
+        dead_key: K,
+        dead_value: V,
+        e: &mut E,
+        g: &mut G,
+    ) -> Result<Option<(K, V)>, R> {
+        self.core.tombstone_index(index, dead_key, dead_value, e, g)
+    }
+
+    /// Drop every entry whose key `is_dead` and rebuild the index table
+    /// over the survivors.
+    pub fn compact_tombstones(&mut self, is_dead: impl Fn(&K) -> bool) {
+        self.core.compact_tombstones(is_dead)
+    }
+
+
     /// Remove the key-value pair equivalent to `key` and return
     /// its value.
     ///

--- a/rubymap/src/map/core.rs
+++ b/rubymap/src/map/core.rs
@@ -526,6 +526,85 @@ impl<K, V, E, G, R> IndexMapCore<K, V, E, G, R> {
         }
     }
 
+    /// Remove `key` from the *index table only*, leaving its bucket in
+    /// place overwritten with the caller's tombstone key/value. Entry
+    /// positions therefore stay stable — nothing shifts — which is what a
+    /// traversal that is concurrently walking the entries by index needs.
+    ///
+    /// The map is promoted to indexed form first: linear lookups scan the
+    /// entry vector directly and would otherwise have to know how to skip
+    /// dead buckets. Once indexed, lookups can only reach a bucket through
+    /// `indices`, which no longer references the dead one, so neither the
+    /// tombstone key nor its stale cached hash is ever consulted. The
+    /// caller owns the other half of the bargain: while tombstones exist it
+    /// must not trigger anything that walks the raw buckets as live entries
+    /// (insertion/rehash — barred during Ruby iteration anyway — or the
+    /// plain iterators, which the caller is expected to filter).
+    ///
+    /// Returns the displaced `(index, key, value)`; the caller is expected
+    /// to compact with [`Self::compact_tombstones`] when the traversal
+    /// window closes.
+    pub(crate) fn tombstone_remove_full<Q>(
+        &mut self,
+        hash: HashValue,
+        key: &Q,
+        dead_key: K,
+        dead_value: V,
+        e: &mut E,
+        g: &mut G,
+    ) -> Result<Option<(usize, K, V)>, R>
+    where
+        Q: ?Sized + Equivalent<K, E, G, R>,
+    {
+        self.ensure_indexed();
+        let eq = equivalent(key, &self.entries);
+        Ok(match self.indices.find_entry(hash.get(), eq, e, g)? {
+            Ok(entry) => {
+                let (index, _) = entry.remove();
+                let bucket = &mut self.entries[index];
+                let key = std::mem::replace(&mut bucket.key, dead_key);
+                let value = std::mem::replace(&mut bucket.value, dead_value);
+                Some((index, key, value))
+            }
+            Err(_) => None,
+        })
+    }
+
+    /// [`Self::tombstone_remove_full`] for a caller-chosen entry position
+    /// (`Hash#shift` tombstoning the first live entry). Same contract.
+    pub(crate) fn tombstone_index(
+        &mut self,
+        index: usize,
+        dead_key: K,
+        dead_value: V,
+        e: &mut E,
+        g: &mut G,
+    ) -> Result<Option<(K, V)>, R> {
+        if index >= self.entries.len() {
+            return Ok(None);
+        }
+        self.ensure_indexed();
+        let hash = self.entries[index].hash;
+        erase_index(&mut self.indices, hash, index, e, g)?;
+        let bucket = &mut self.entries[index];
+        let key = std::mem::replace(&mut bucket.key, dead_key);
+        let value = std::mem::replace(&mut bucket.value, dead_value);
+        Ok(Some((key, value)))
+    }
+
+    /// Drop every bucket whose key `is_dead` and rebuild the index table
+    /// over the survivors. Closes a tombstone window opened by the
+    /// `tombstone_*` methods; positions compact back to dense entry order.
+    pub(crate) fn compact_tombstones(&mut self, is_dead: impl Fn(&K) -> bool) {
+        self.entries.retain(|b| !is_dead(&b.key));
+        if !self.linear {
+            self.indices.clear();
+            self.indices
+                .reserve(self.entries.len(), get_hash(&self.entries));
+            insert_bulk_no_grow(&mut self.indices, &self.entries);
+        }
+    }
+
     /// Remove an entry by shifting all entries that follow it
     pub(crate) fn shift_remove_full<Q>(
         &mut self,


### PR DESCRIPTION
Fixes #1095: deleting a **not-yet-visited** key during Hash iteration diverged from CRuby — the Ruby-level `each` walked a `__pairs` snapshot, so an entry deleted mid-loop was still yielded. The snapshot existed because `Hash#delete` compacts the entry vector (`shift_remove`), which would shift unvisited entries under a live positional walk. This PR removes the snapshot's reason to exist, then removes the snapshot.

## Tombstones: delete without compacting while a traversal is live

Deletion during a live traversal (`iter_lev > 0`) now **tombstones instead of compacting**, the same idea as CRuby's `st_table` deferring reclamation under `iter_lev`:

* rubymap grows `tombstone_remove` / `tombstone_index` / `compact_tombstones`: the entry leaves the **index table** but stays in the entry vector, key overwritten with a sentinel, value released to nil. The map is promoted to indexed form first, so a lookup can only reach a bucket through the index table — the sentinel key and its stale cached hash are never consulted.
* The sentinel (`HASH_TOMBSTONE_KEY = 0b0010_0100`) is not a bit pattern any live `Value` can carry — not a Fixnum, Flonum, heap pointer, nil/true/false, or Symbol — yet still reads as a *packed* immediate, so the GC never dereferences it.
* The boxed hash counts tombstones in a new `dead` field (packed into `BoxedHash`'s existing padding — the 48-byte payload budget is untouched). `len` subtracts it; every iterator filters the sentinel; `clone` compacts the copy. The **inline representation never holds a tombstone** — a mid-iteration delete promotes to boxed first, migrating the iteration depth exactly as promotion already did.
* **Compaction is lazy**: the next mutating operation outside a traversal (insert, delete, shift, `compare_by_identity`) sweeps tombstones and rebuilds the index table. The iteration-end path keeps its shared borrow, and resurrection is impossible — index-table growth rehashes only live indices, and the bulk rebuild runs only from compaction itself.

CRuby's semantics fall out: a deleted not-yet-visited entry is skipped, deleting the current or an already-visited entry skips nothing, re-adding a deleted key raises ("new key"), and `size` / `keys` / `inspect` / `dup` / `==` observed mid-walk never see the dead entry. `Hash#shift` during iteration tombstones the first *live* entry.

## `each` / `to_h`: live positional walk

With positions stable under deletion, `each` and `to_h` drop the snapshot for a live walk bounded by `__entry_count` (raw length, tombstones included) and guarded by `__live_at` — both new intrinsics emitted as machine code on **both architectures** next to `__key_at`/`__value_at`. Those two now answer nil for a tombstoned position, so the sentinel can never surface through a direct probe either; `Hash#size`'s machine code subtracts the dead count.

Dropping the snapshot also drops its up-front allocations — a measured win on top of the semantics fix (interleaved builds, medians, ns/elem, n=1000, vs current master):

| case | master | this PR | |
|---|---:|---:|---:|
| `each` | 42.5 | **30.7** | 1.4x |
| `any?` / `all?` / `count` | ~67 | **~54** | 1.2x |
| `map { \|k, v\| }` | 98.9 | **82.4** | 1.2x |
| `to_h` block form | ~187 | **~157** | 1.2x |

## Verified

* A 30-case gate script diffed against CRuby, all matching: the delete matrix (future/current/past/all-at-once, first/mid/last positions), inline and boxed representations (inline promotes mid-iteration), identity hashes, default-proc hashes, `shift` during iteration, mid-window observers (`size`/`keys`/`values`/`inspect`/`dup`/`==`/`to_a`), nested iteration on the same hash, break/raise leaving tombstones then full reuse, `to_h`'s shared walk, `delete_if`/`reject!`/`keep_if`, `each_key`/`each_value` with deletes, and `GC.start` while tombstones are live.
* The same matrix is pinned as a `run_tests` suite (`hash_delete_during_iteration`); it and the `to_h` tests pass under **gc-stress**.
* Full suite green on x86-64 (3293 passed, 0 failed). aarch64 under qemu: the new-machine-code tests (`hash_delete_during_iteration`, `hash_entry_at`) and the full hash filter (153) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_