### PR TITLE
Hash#each_key / #each_value: write them in Ruby

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -46,6 +46,44 @@ class Hash
 
   alias each_pair each
 
+  # Hash#each_key / Hash#each_value
+  # each_key {|key| block } -> self / each_value {|value| block } -> self
+  #
+  # In Ruby for the same reason as `each`: a hot call site specializes the
+  # method and inlines the block into the yield. The traversal is the same
+  # live positional walk — a delete during the block tombstones in place,
+  # so a deleted not-yet-visited entry is skipped (CRuby) — and the
+  # iteration reference makes adding a key raise.
+  def each_key
+    return to_enum(:each_key) { size } unless block_given?
+    guard = __iter_begin
+    begin
+      i = 0
+      while i < __entry_count
+        yield __key_at(i) if __live_at(i)
+        i += 1
+      end
+    ensure
+      __iter_end(guard)
+    end
+    self
+  end
+
+  def each_value
+    return to_enum(:each_value) { size } unless block_given?
+    guard = __iter_begin
+    begin
+      i = 0
+      while i < __entry_count
+        yield __value_at(i) if __live_at(i)
+        i += 1
+      end
+    ensure
+      __iter_end(guard)
+    end
+    self
+  end
+
   # Hash#to_h
   # to_h -> self
   # to_h {|key, value| block } -> Hash

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -1,3 +1,76 @@
+# ---------------------------------------------------------------------------
+# Pure-Ruby builtins, one file per class/module. Load order is significant:
+#  * everything up to `comparable` must not reference Comparable/Enumerable
+#    at load time (e.g. ObjectSpace::WeakMap deliberately skips its
+#    `include ::Enumerable` because the module is not defined yet);
+#  * `io_buffer` (IO::Buffer includes Comparable) loads after `comparable`;
+#  * the class files after `enumerable` may `include Enumerable`;
+#  * the spec-compat alias fixups inside each class file run when that file
+#    loads, after the natives and Ruby methods they re-point.
+# ---------------------------------------------------------------------------
+
+require_relative 'basic_object'
+require_relative 'kernel'
+require_relative 'object'
+require_relative 'class'
+require_relative 'regexp'
+require_relative 'exception'
+require_relative 'module'
+require_relative 'warning'
+require_relative 'process'
+require_relative 'file'
+require_relative 'thread'
+require_relative 'boolean'
+require_relative 'marshal'
+require_relative 'gc'
+require_relative 'object_space'
+require_relative 'io'
+require_relative 'encoding'
+
+# TOPLEVEL_BINDING is defined by the runtime (Executor::init): a Binding
+# over an empty, outer-less frame that the *main script* is then executed
+# in (Executor::exec_main_script), so it exposes exactly the main script's
+# locals — not this file's.
+
+require_relative 'comparable'
+require_relative 'io_buffer'
+require_relative 'data'
+
+require_relative 'enumerable'
+IO.include(Enumerable)
+require_relative 'arithmetic_sequence'
+require_relative 'numeric'
+require_relative 'integer'
+require_relative 'range'
+require_relative 'array'
+require_relative 'rational'
+require_relative 'complex'
+require_relative 'float'
+require_relative 'string'
+require_relative 'symbol'
+require_relative 'error'
+require_relative 'set'
+require_relative 'struct'
+require_relative 'monitor'
+require_relative 'enumerator'
+require_relative 'lazy'
+require_relative 'hash'
+require_relative 'file_stat'
+require_relative 'proc'
+require_relative 'method'
+require_relative 'dir'
+require_relative 'time'
+require_relative 'match_data'
+require_relative 'filetest'
+require_relative 'env'
+require_relative 'pathname_builtins'
+
+# RbConfig loads *after* the pure-Ruby builtins: the vendored rbconfig.rb
+# walks its CONFIG hash with `each_value` at module level, and Hash's
+# traversal methods (each/each_value/...) are defined in hash.rb rather
+# than in Rust so hot call sites can inline them. Everything in this
+# block uses only Rust-level natives (File, ENV, String), so deferring
+# it past the Ruby files loses nothing.
 require 'rbconfig'
 
 # The vendored `rbconfig.rb` (snapshotted from the build host's CRuby
@@ -179,72 +252,6 @@ RbConfig::CONFIG['sitearch']   = RUBY_PLATFORM
 RbConfig::CONFIG['target']     = "#{__host_cpu}-pc-#{__host_os}"
 RbConfig::CONFIG['host']       = "#{__host_cpu}-pc-#{__host_os}"
 
-# ---------------------------------------------------------------------------
-# Pure-Ruby builtins, one file per class/module. Load order is significant:
-#  * everything up to `comparable` must not reference Comparable/Enumerable
-#    at load time (e.g. ObjectSpace::WeakMap deliberately skips its
-#    `include ::Enumerable` because the module is not defined yet);
-#  * `io_buffer` (IO::Buffer includes Comparable) loads after `comparable`;
-#  * the class files after `enumerable` may `include Enumerable`;
-#  * the spec-compat alias fixups inside each class file run when that file
-#    loads, after the natives and Ruby methods they re-point.
-# ---------------------------------------------------------------------------
-
-require_relative 'basic_object'
-require_relative 'kernel'
-require_relative 'object'
-require_relative 'class'
-require_relative 'regexp'
-require_relative 'exception'
-require_relative 'module'
-require_relative 'warning'
-require_relative 'process'
-require_relative 'file'
-require_relative 'thread'
-require_relative 'boolean'
-require_relative 'marshal'
-require_relative 'gc'
-require_relative 'object_space'
-require_relative 'io'
-require_relative 'encoding'
-
-# TOPLEVEL_BINDING is defined by the runtime (Executor::init): a Binding
-# over an empty, outer-less frame that the *main script* is then executed
-# in (Executor::exec_main_script), so it exposes exactly the main script's
-# locals — not this file's.
-
-require_relative 'comparable'
-require_relative 'io_buffer'
-require_relative 'data'
-
-require_relative 'enumerable'
-IO.include(Enumerable)
-require_relative 'arithmetic_sequence'
-require_relative 'numeric'
-require_relative 'integer'
-require_relative 'range'
-require_relative 'array'
-require_relative 'rational'
-require_relative 'complex'
-require_relative 'float'
-require_relative 'string'
-require_relative 'symbol'
-require_relative 'error'
-require_relative 'set'
-require_relative 'struct'
-require_relative 'monitor'
-require_relative 'enumerator'
-require_relative 'lazy'
-require_relative 'hash'
-require_relative 'file_stat'
-require_relative 'proc'
-require_relative 'method'
-require_relative 'dir'
-require_relative 'time'
-require_relative 'match_data'
-require_relative 'filetest'
-require_relative 'env'
-require_relative 'pathname_builtins'
 
 # ARGF is implemented in Rust (builtins/argf.rs); only the
 # Enumerable mix-in has to wait until the module exists.

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -111,8 +111,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(HASH_CLASS, "delete", delete, 1);
     // collect/map: implemented in Ruby (builtins/hash.rb) for arity adaptation and subclass support
     globals.define_builtin_funcs(HASH_CLASS, "each", &["each_pair"], each, 0);
-    globals.define_builtin_func(HASH_CLASS, "each_key", each_key, 0);
-    globals.define_builtin_func(HASH_CLASS, "each_value", each_value, 0);
+    // each_key / each_value: implemented in Ruby (builtins/hash.rb) on the
+    // live positional walk, so a hot call site can inline both the method
+    // and the block (same reasoning as `each`).
     globals.define_builtin_funcs(HASH_CLASS, "select", &["filter"], select, 0);
     globals.define_builtin_funcs(HASH_CLASS, "select!", &["filter!"], select_, 0);
     globals.define_builtin_func(HASH_CLASS, "empty?", empty_, 0);
@@ -1434,57 +1435,6 @@ fn each(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> 
     for (k, v) in pairs {
         vm.invoke_block(globals, &data, &[Value::array2(k, v)])?;
     }
-    Ok(lfp.self_val())
-}
-
-///
-/// ### Hash#each_value
-///
-/// - each_value {|value| ... } -> self
-/// - each_value -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Hash/i/each_value.html]
-#[monoruby_builtin]
-fn each_value(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    pc: BytecodePtr,
-) -> Result<Value> {
-    let bh = match lfp.block() {
-        None => {
-            let id = IdentId::get_id("each_value");
-            return hash_to_sized_enum(vm, id, lfp, pc);
-        }
-        Some(block) => block,
-    };
-    let hash = lfp.self_val().as_hash();
-    let _iter_guard = hash.iter_guard();
-    let iter = hash.iter().map(|(_, v)| v);
-    vm.invoke_block_iter1(globals, bh, iter)?;
-    Ok(lfp.self_val())
-}
-
-///
-/// ### Hash#each_key
-///
-/// - each_key {|value| ... } -> self
-/// - each_key -> Enumerator
-///
-/// [https://docs.ruby-lang.org/ja/latest/method/Hash/i/each_key.html]
-#[monoruby_builtin]
-fn each_key(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
-    let bh = match lfp.block() {
-        None => {
-            let id = IdentId::get_id("each_key");
-            return hash_to_sized_enum(vm, id, lfp, pc);
-        }
-        Some(block) => block,
-    };
-    let hash = lfp.self_val().as_hash();
-    let _iter_guard = hash.iter_guard();
-    let iter = hash.iter().map(|(k, _)| k);
-    vm.invoke_block_iter1(globals, bh, iter)?;
     Ok(lfp.self_val())
 }
 
@@ -5034,6 +4984,27 @@ mod tests {
     /// (`->(a, b, *c)` splits, `->(a, *b)` gets the pair whole). With an
     /// overridden `each`, values pass through unrepacked: a proc auto-splats
     /// a single-array yield, a strict lambda raises on it.
+    /// each_key / each_value (Ruby, builtins/hash.rb): the same live
+    /// positional walk as `each`, yielding bare keys/values. Pinned to
+    /// CRuby including the enumerator forms and deletes mid-iteration.
+    #[test]
+    fn hash_each_key_value() {
+        run_tests(&[
+            r#"acc = []; r = {a: 1, b: 2, c: 3}.each_key { |k| acc << k }; [acc, r.class]"#,
+            r#"acc = []; r = {a: 1, b: 2, c: 3}.each_value { |v| acc << v }; [acc, r.class]"#,
+            r#"e = {a: 1, b: 2}.each_key; [e.class, e.size, e.to_a]"#,
+            r#"e = {a: 1, b: 2}.each_value; [e.class, e.size, e.to_a]"#,
+            // A multi-param block sees the bare key (no pair, no splat).
+            r#"acc = []; {a: 1}.each_key { |k, v| acc << [k, v] }; acc"#,
+            // Deleting a not-yet-visited key mid-walk skips it (#1095 discipline).
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each_key { |k| h.delete(:e); acc << k }; [acc, h.keys]"#,
+            r#"h = {a:1, b:2, c:3, d:4, e:5, f:6, g:7}; acc = []; h.each_value { |v| h.delete(:e); acc << v }; [acc, h.keys]"#,
+            // Adding raises; empty hash yields nothing.
+            r#"h = {a: 1}; (h.each_key { h[:new] = 1 } rescue $!.class.to_s)"#,
+            r#"n = 0; {}.each_key { n += 1 }; n"#,
+        ]);
+    }
+
     /// Deleting during iteration follows CRuby (#1095): while a traversal
     /// is live a delete tombstones its entry in place — the index table
     /// drops it, the walk's positions stay stable — so a deleted


### PR DESCRIPTION
The same conversion as `Hash#each` (#1094), riding the live positional walk #1096 built (`__entry_count` / `__live_at` / `__key_at` / `__value_at`): a hot call site now specializes the method and inlines the block into the yield, and the delete-during-iteration semantics become exactly `each`'s — a deleted not-yet-visited entry is skipped, adding a key raises. The #1095 discipline is now uniform across `each` / `each_pair` / `each_key` / `each_value` / `to_h`.

This also retires the one place still iterating the live rubymap buckets while user code could mutate them: the Rust implementations held `hash.iter()` across the block invocations, so a mid-block delete (tombstoning since #1096) mutated bucket contents under the iterator's shared borrow. The Ruby walk touches entries only through the position-indexed intrinsics, which re-read per element.

**Performance is neutral rather than a win**, reported for honesty: the Rust versions' pre-resolved block loop (`invoke_block_iter1`) was already tight, and unlike `each` there is no per-element pair Array whose allocation the rewrite could drop. Interleaved, ns/elem: n=1000 `each_key` 7.2 → 8.3, `each_value` 7.8 → 9.0; n=10 15.1 → 17.7 / 15.4 → 17.9. The value here is the semantics and one less Rust iteration path to keep sound, not speed.

**Loading order**: the vendored `rbconfig.rb` walks its CONFIG hash with `each_value` at module level, so `require 'rbconfig'` (and the RbConfig patch block after it) moves below the pure-Ruby builtin requires in `startup.rb`. The block only uses Rust-level natives (File, ENV, String), so deferring it past the Ruby files loses nothing; `hash.rb` itself cannot move above `enumerable` (its `include Enumerable` needs the module defined first).

## Verified

* Tests pin both methods to CRuby: traversal order and `self` return, sized Enumerator forms, a multi-param block receiving the bare key, deletes mid-iteration on both methods, the add-raises rule, and the empty hash. Green under **gc-stress** and on aarch64 under qemu.
* A 14-case gate script diffed against CRuby (including nested iteration, break-then-reuse, inline-representation deletes, and subclasses), all matching.
* Full suite green on x86-64 (3294 passed, 0 failed) — including the startup-order change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_