### PR TITLE
bin/test: cap optcarrot at 10 frames under GC_STRESS=1

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -179,14 +179,28 @@ diff -s benchmark/mandel.ppm benchmark/mandel1.ppm
 diff -s benchmark/mandel.ppm benchmark/mandel2.ppm
 rm benchmark/*.ppm
 
+# Per-safepoint collection runs optcarrot at ~0.2 frames/min, so the
+# default 180 frames (`-b`) is a ~14-hour run — twice — and the first full
+# GC_STRESS=1 run of this phase sat in it for 4.6h until the job's
+# 350-minute timeout (the plb2 story again, one phase further down).
+# Shrink the run under stress instead of skipping it: 10 frames still
+# cross the JIT thresholds and the startup allocation storm that surfaced
+# the Array#flat_map unrooted-accumulator bug, and a trailing --frames
+# overrides the one baked into the -b shortcut. Both sides of the diff get
+# the same count, so the output comparison is unaffected.
+OPTCARROT_FRAMES=()
+if [ "$GC_STRESS_ON" = "1" ]; then
+  OPTCARROT_FRAMES=(--frames 10)
+fi
+
 phase "optcarrot (plain) — monoruby"
-$MONORUBY ../optcarrot/bin/optcarrot -b --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
-"${RUBY[@]}" ../optcarrot/bin/optcarrot -b --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
+$MONORUBY ../optcarrot/bin/optcarrot -b "${OPTCARROT_FRAMES[@]}" --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
+"${RUBY[@]}" ../optcarrot/bin/optcarrot -b "${OPTCARROT_FRAMES[@]}" --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
 diff -s monoruby.log ruby.log
 
 phase "optcarrot (--opt) — monoruby"
-$MONORUBY ../optcarrot/bin/optcarrot -b --opt --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
-"${RUBY[@]}" ../optcarrot/bin/optcarrot -b --opt --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
+$MONORUBY ../optcarrot/bin/optcarrot -b --opt "${OPTCARROT_FRAMES[@]}" --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > monoruby.log
+"${RUBY[@]}" ../optcarrot/bin/optcarrot -b --opt "${OPTCARROT_FRAMES[@]}" --debug ../optcarrot/examples/Lan_Master.nes | drop_last3 > ruby.log
 diff -s monoruby.log ruby.log
 rm *.log
 


### PR DESCRIPTION
## Problem

The first full `GC_STRESS=1` run to get past the `Array#flat_map` abort (#1093) still didn't finish ([run 31502313922](https://github.com/sisshiki1969/monoruby/actions/runs/31502313922)): both arch jobs were cancelled by the workflow's `timeout-minutes: 350`. The log shows why —

| Time | Phase | Result |
|---|---|---|
| 14:35–14:50 | nextest under gc-stress | 3088/3088 passed |
| 14:50–15:49 | app_fib / tarai / so_nbody / so_mandelbrot | all identical to CRuby |
| 15:49 | **optcarrot (plain)** starts | — |
| 20:25 | job cancelled | 350-minute timeout |

Per-safepoint collection runs optcarrot at ~0.2 frames/min (measured locally), so the default 180 frames (`-b`) is a ~14-hour run — and the phase runs twice (plain and `--opt`). The job spent 4.6 hours inside the first run and never reached `--opt`, ruby-bench, or ruby/spec. This is the plb2 timeout story again, one phase further down the script.

## Fix

Skipping optcarrot would defeat the point of the full scope (it exists to stress the JIT × GC interaction there), so shrink it instead: under `GC_STRESS=1`, append `--frames 10` to both optcarrot invocations. A trailing `--frames` overrides the 180 baked into the `-b` shortcut (verified against optcarrot's option parser). Ten frames still cross the JIT thresholds and the startup allocation storm that surfaced #1093, and fit in ~45 minutes per run, leaving budget for the downstream phases.

Both sides of the diff get the same frame count, so the output comparison is unaffected. The ordinary (non-stress) run still does the full 180 frames.

## Verification

- `bash -n bin/test` passes.
- At 10 frames, both `plain` and `--opt` output is byte-identical to CRuby (~100k debug lines diffed each).
- Time budget: 10 frames ≈ 45 min per run under gc-stress (from the local measurement of ~0.2 frames/min), so plain + `--opt` ≈ 1.5 h, comfortably inside the 350-minute cap alongside nextest (~15 min) and the benchmark phases (~1 h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_