### PR TITLE
Inline Hash#default= as machine code

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -50,7 +50,13 @@ pub(super) fn init(globals: &mut Globals) {
         0,
     );
     globals.define_builtin_func(HASH_CLASS, "default_proc=", default_proc_assign, 1);
-    globals.define_builtin_func(HASH_CLASS, "default=", default_assign, 1);
+    globals.define_builtin_inline_func(
+        HASH_CLASS,
+        "default=",
+        default_assign,
+        inline_gen2!(hash_default_assign),
+        1,
+    );
     globals.define_builtin_funcs(HASH_CLASS, "==", &["==="], eq, 1);
     globals.define_builtin_func(HASH_CLASS, "eql?", eql, 1);
     globals.define_builtin_func(HASH_CLASS, "hash", hash, 0);
@@ -932,6 +938,67 @@ fn index(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
             None,
         )
     }
+}
+
+/// `Hash#default=` with the frozen check already deopt-guarded by JIT code:
+/// runs the promotion / box-allocation cases the inline fast path cannot,
+/// then answers the assigned value (what `Hash#default=` returns).
+extern "C" fn hash_default_assign_extern(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    recv: Value,
+    val: Value,
+) -> Option<Value> {
+    match recv.as_hash().set_defalut_value(val, vm, globals) {
+        Ok(()) => Some(val),
+        Err(err) => {
+            vm.set_error(err);
+            None
+        }
+    }
+}
+
+///
+/// Inline `Hash#default=` as machine code.
+///
+/// The common shapes store in place: a boxed hash that already carries a
+/// default box gets its discriminant/payload overwritten (replacing a
+/// default proc exactly as `Hash#default=` does), and a nil assignment
+/// with no default box is a no-op. First-time non-nil defaults (box
+/// allocation, possibly inline→boxed promotion) go through the runtime
+/// call. The in-place store bypasses the builtin's frozen check, so a
+/// frozen receiver deopts to the interpreter to raise `FrozenError`.
+///
+fn hash_default_assign(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    _: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 {
+        return false;
+    }
+    let CallSiteInfo {
+        dst, args, recv, ..
+    } = *callsite;
+    state.load(ir, recv, GP::Rdi);
+    let deopt = ir.new_deopt(state);
+    ir.guard_frozen(deopt);
+    state.load(ir, args, GP::Rsi);
+    let using_fpr = state.get_using_fpr(ir);
+    ir.fpr_save(using_fpr);
+    ir.inline(move |r#gen, _, _, _| {
+        r#gen.emit_hash_default_assign(hash_default_assign_extern as *const () as u64)
+    });
+    ir.fpr_restore(using_fpr);
+    let error = ir.new_error(state);
+    ir.handle_error(error);
+    state.def_rax2acc(ir, dst);
+    true
 }
 
 fn hash_index(
@@ -4984,6 +5051,48 @@ mod tests {
     /// (`->(a, b, *c)` splits, `->(a, *b)` gets the pair whole). With an
     /// overridden `each`, values pass through unrepacked: a proc auto-splats
     /// a single-array yield, a strict lambda raises on it.
+    /// Inline `Hash#default=`: every shape the machine code splits on, hot
+    /// enough to compile. In-place overwrite of an existing default box
+    /// (including replacing a default *proc*, which `default=` clears),
+    /// nil assignments with and without a box (the no-box nil is an inline
+    /// no-op) on both representations, first-time defaults through the
+    /// runtime call (box allocation / inline→boxed promotion), the method's
+    /// return value, and a frozen receiver deopting to raise.
+    #[test]
+    fn hash_default_assign_inline() {
+        run_test(
+            r#"
+            def drive(n)
+              r = nil
+              n.times { r = yield }
+              r
+            end
+            res = []
+            h1 = Hash.new(0)
+            drive(30) { h1.default = 5 }
+            res << [h1.default, h1[:missing]]
+            h2 = Hash.new { |hh, k| :proc }
+            drive(30) { h2.default = 9 }
+            res << [h2.default, h2.default_proc, h2[:missing]]
+            h3 = Hash.new(3)
+            drive(30) { h3.default = nil }
+            res << [h3.default, h3[:missing]]
+            h4 = {a: 1}
+            drive(30) { h4.default = nil }
+            res << h4.default
+            h5 = {a: 1}
+            drive(30) { h5.default = 7 }
+            res << [h5.default, h5[:a], h5[:missing]]
+            h6 = {}
+            res << drive(30) { h6.send(:default=, 42) }
+            h7 = Hash.new(1)
+            h7.freeze
+            res << (drive(30) { h7.default = 2 } rescue $!.class.to_s)
+            res
+            "#,
+        );
+    }
+
     /// each_key / each_value (Ruby, builtins/hash.rb): the same live
     /// positional walk as `each`, yielding bare keys/values. Pinned to
     /// CRuby including the enumerator forms and deletes mid-iteration.

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -176,6 +176,66 @@ impl Codegen {
         );
     }
 
+    /// `Hash#default=`: hash in Rdi (x4), new default in Rsi (x3), result
+    /// (the assigned value) in Rax (x0). aarch64 twin of the x86
+    /// `emit_hash_default_assign`; see there for the shape split. The
+    /// receiver's un-frozen-ness is already deopt-guarded by the caller.
+    pub(crate) fn emit_hash_default_assign(&mut self, f: u64) {
+        let rdi = GP::Rdi.a64().0; // x4 (hash)
+        let rsi = GP::Rsi.a64().0; // x3 (new default)
+        let no_box = self.jit.label();
+        let slow = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
+        let boxed_rep = HASH_REP_BOXED as u32;
+        let slot = HASH_DEFAULT_OFFSET as u32;
+        let payload = HASH_DEFAULT_PAYLOAD_OFFSET as u32;
+        monoasm_arm64!(&mut self.jit,
+            ldrb w0, [x(rdi), #(ty_flags)];
+            mov x9, (HASH_REP_MASK as u64);
+            and x0, x0, x9;
+            cmp x0, #(boxed_rep);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &no_box); // inline: no default
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x(rdi), #(slot)];    // Option<Box<HashDefault>>: null = None
+            cmp x0, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &no_box);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (HASH_DEFAULT_TAG_VALUE as u64);
+            str x9, [x0];                 // discriminant := Value
+            str x(rsi), [x0, #(payload)];
+        );
+        // Write barrier: x4 (Rdi) = the hash (parent), x3 (Rsi) = the default.
+        self.emit_write_barrier(GP::Rdi, GP::Rsi);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(rsi);
+            b exit;
+        );
+        self.jit.bind_label(no_box);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, (NIL_VALUE as u64);
+            cmp x(rsi), x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &slow);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(NIL_VALUE as u32);
+            b exit;
+        );
+        self.jit.bind_label(slow);
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x(rdi);               // recv -> arg2 [val already in x3]
+            mov x0, x19;                  // vm
+            mov x1, x20;                  // globals
+            mov x9, (f);
+            str x30, [sp, #-16]!;
+            blr x9;
+            ldr x30, [sp], #16;
+        );
+        self.jit.bind_label(exit);
+    }
+
     /// `Hash#size`: entry count of the hash in `base`, fixnum-tagged into `dst`.
     /// aarch64 twin of the x86 `gen_hash_len_fixnum`.
     ///

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -114,6 +114,64 @@ impl Codegen {
         }
     }
 
+    /// `Hash#default=`: hash in rdi, new default in rsi, result (the assigned
+    /// value — what `Hash#default=` returns) in rax.
+    ///
+    /// In-line shapes: a boxed hash that already carries a default box gets
+    /// its discriminant/payload overwritten in place (replacing a default
+    /// proc exactly as `Hash#default=` does) plus the write barrier; a nil
+    /// assignment with no default box is a no-op (no default and a nil
+    /// default are the same observable state). Everything else — a first
+    /// non-nil default (box allocation, possibly inline→boxed promotion) —
+    /// calls `f` = `hash_default_assign_extern(vm, globals, recv, val)`,
+    /// whose error edge is the caller's trailing HandleError. The receiver's
+    /// un-frozen-ness is already deopt-guarded by the caller.
+    pub(crate) fn emit_hash_default_assign(&mut self, f: u64) {
+        let no_box = self.jit.label();
+        let slow = self.jit.label();
+        let exit = self.jit.label();
+        let ty_flags = RVALUE_OFFSET_TY + 1;
+        let mask = HASH_REP_MASK as u64;
+        let boxed_rep = HASH_REP_BOXED as u64;
+        let slot = HASH_DEFAULT_OFFSET;
+        let payload = HASH_DEFAULT_PAYLOAD_OFFSET;
+        let tag_value = HASH_DEFAULT_TAG_VALUE as u64;
+        monoasm! { &mut self.jit,
+            movl rax, [rdi + (ty_flags)];
+            andl rax, (mask);
+            cmpl rax, (boxed_rep);
+            jne  no_box;                    // inline: never carries a default
+            movq rax, [rdi + (slot)];       // Option<Box<HashDefault>>: null = None
+            testq rax, rax;
+            jeq  no_box;
+            movq [rax], (tag_value);        // discriminant := Value
+            movq [rax + (payload)], rsi;
+        }
+        // Write barrier: rdi = the hash (parent), rsi = the stored default.
+        self.emit_write_barrier_rdi(GP::Rsi);
+        monoasm! { &mut self.jit,
+            movq rax, rsi;
+            jmp  exit;
+        no_box:
+            cmpq rsi, (NIL_VALUE);
+            jne  slow;
+            movq rax, (NIL_VALUE);
+        exit:
+        }
+        self.jit.select_page(1);
+        monoasm! { &mut self.jit,
+        slow:
+            movq rdx, rdi;                  // recv -> arg2
+            movq rcx, rsi;                  // val -> arg3
+            movq rdi, rbx;                  // vm
+            movq rsi, r12;                  // globals
+            movq rax, (f);
+            call rax;
+            jmp  exit;
+        }
+        self.jit.select_page(0);
+    }
+
     /// `Hash#size`: entry count of the hash in `base`, fixnum-tagged into `dst`.
     ///
     /// A small hash keeps its length in the header's representation bits; a


### PR DESCRIPTION
The last of the Hash default-slot accessors still going through a builtin call (#1090 inlined `default` / `default_proc` / `compare_by_identity?`).

## Fast paths, in line

* **Boxed hash with an existing default box**: overwrite the discriminant/payload in place — replacing a default *proc* exactly as `Hash#default=` does — followed by the generational **write barrier** (the hash may be old, the stored default young).
* **Nil assignment with no default box**: a no-op on either representation, since no default and a nil default are the same observable state.

A first non-nil default (box allocation, possibly an inline→boxed promotion) branches to a runtime helper whose error edge is the trailing HandleError. A **frozen receiver deopts** to the interpreter to raise `FrozenError` — the same discipline as `Array#<<`. Both architectures; the result register carries the assigned value, which is what `Hash#default=` returns.

## Measured (interleaved, medians)

The call itself: **82.1 → 55.6 ns** (in-place overwrite), **67.3 → 55.2 ns** (nil no-op) — the remainder is the surrounding call/loop scaffolding, so the inline saves ~25 ns per call. Downstream `Hash#to_h` paths that assign the default per conversion measure within noise: honest but modest.

## Verified

* Tests drive every shape hot: in-place overwrite, proc replacement (`default_proc` cleared), nil with/without a box on both representations, first-time defaults through the runtime call, the `send`-form return value, and the frozen raise — pinned to CRuby.
* Green under **gc-stress** (exercising the barrier path) and on aarch64 under qemu.
* Full suite green on x86-64 (3298 passed, 0 failed).

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_