### PR TITLE
ruby/spec: clear the core/{array,hash,file,filetest} residuals (13 → 3)

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -136,7 +136,18 @@ class Hash
     h
   end
 
-  def transform_keys(hash = nil, &block)
+  # CRuby's rb_to_hash_type: an explicitly passed mapping — nil included —
+  # goes through implicit `to_hash` conversion and raises TypeError when it
+  # has none. Only a genuinely absent argument means "no mapping".
+  private def __to_hash_type(obj)
+    h = Hash.try_convert(obj)
+    return h if h
+    name = obj.nil? ? "nil" : obj.equal?(true) ? "true" : obj.equal?(false) ? "false" : obj.class.to_s
+    raise TypeError, "no implicit conversion of #{name} into Hash"
+  end
+
+  def transform_keys(hash = (no_arg = true; nil), &block)
+    hash = __to_hash_type(hash) unless no_arg
     return to_enum(:transform_keys) { size } unless block || hash
     h = {}
     if hash
@@ -150,7 +161,8 @@ class Hash
     h
   end
 
-  def transform_keys!(hash = nil, &block)
+  def transform_keys!(hash = (no_arg = true; nil), &block)
+    hash = __to_hash_type(hash) unless no_arg
     return to_enum(:transform_keys!) { size } unless block || hash
     raise FrozenError.new("can't modify frozen Hash: #{inspect}", receiver: self) if frozen?
     # Snapshot the original pairs up front so a new key that collides with

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -269,7 +269,7 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     if lfp.try_arg(0).is_none() {
         // Array.new {} / Array#initialize {} — the block is ignored.
         if lfp.block().is_some() {
-            vm.ruby_warn(globals, "warning: given block not used")?;
+            vm.ruby_warn_caller(globals, "warning: given block not used")?;
         }
         self_val.clear();
         return Ok(self_val.into());
@@ -295,7 +295,7 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         }
         if let Some(inner) = from_array {
             if lfp.block().is_some() {
-                vm.ruby_warn(globals, "warning: given block not used")?;
+                vm.ruby_warn_caller(globals, "warning: given block not used")?;
             }
             *self_val = inner;
             return Ok(self_val.into());
@@ -315,11 +315,19 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     }
     if let Some(bh) = lfp.block() {
         if lfp.try_arg(1).is_some() {
-            vm.ruby_warn(globals, "warning: block supersedes default value argument")?;
+            vm.ruby_warn_caller(globals, "warning: block supersedes default value argument")?;
         }
-        let iter = (0..size).map(|i| Value::integer(i as i64));
-        let mut res = vm.invoke_block_map1(globals, bh, iter, size)?;
-        RValue::swap_kind(lfp.self_val().rvalue_mut(), res.rvalue_mut());
+        // Fill the receiver incrementally: a `break` in the block must
+        // leave the values produced so far in place (CRuby: `a.send(
+        // :initialize, 3) { break if i == 2; ... }` keeps ["0", "1"]),
+        // so building a detached result and swapping it in at the end
+        // would discard them.
+        self_val.clear();
+        let data = vm.get_block_data(globals, bh)?;
+        for i in 0..size {
+            let v = vm.invoke_block(globals, &data, &[Value::integer(i as i64)])?;
+            lfp.self_val().as_array().push(v);
+        }
     } else {
         let val = lfp.try_arg(1).unwrap_or_default();
         *self_val = ArrayInner::from(smallvec![val; size]);
@@ -2283,7 +2291,7 @@ fn fetch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     // Index out of bounds
     if let Some(bh) = lfp.block() {
         if lfp.try_arg(1).is_some() {
-            vm.ruby_warn(globals, "warning: block supersedes default value argument")?;
+            vm.ruby_warn_caller(globals, "warning: block supersedes default value argument")?;
         }
         let data = vm.get_block_data(globals, bh)?;
         let val = vm.invoke_block(globals, &data, &[lfp.arg(0)])?;
@@ -4019,6 +4027,32 @@ fn pack(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     rvalue::pack(vm, globals, &ary, &template, buffer)
 }
 
+/// Interpret the value `to_ary` (or `method_missing(:to_ary)`) produced.
+fn to_ary_result(v: &Value, result: Value, globals: &mut Globals) -> Result<Option<Array>> {
+    if let Some(ary) = result.try_array_ty() {
+        return Ok(Some(ary));
+    }
+    if result.is_nil() {
+        return Ok(None);
+    }
+    Err(MonorubyErr::cant_convert_error_ary(globals, *v, result))
+}
+
+/// The element-to-array probe of `Array#flatten`, following CRuby's
+/// `rb_check_funcall` protocol exactly (pinned by ruby/spec's
+/// respond_to?/respond_to_missing?/method_missing flatten examples):
+///
+/// 1. a *user-redefined* `respond_to?` gates everything — a false
+///    answer stops the conversion even when `to_ary` exists;
+/// 2. otherwise a defined `to_ary` is called;
+/// 3. with the default `respond_to?`, a *user-defined*
+///    `respond_to_missing?` gates the missing-dispatch: falsy means
+///    "not convertible" and `method_missing` is not consulted;
+/// 4. a *user-defined* `method_missing` is then consulted with
+///    `:to_ary`. A NoMethodError it raises for that name is re-raised
+///    when the object claimed to respond (CRuby check_funcall_failed:
+///    `rb_respond_to` true → re-raise) and otherwise means "not
+///    convertible".
 fn try_convert_to_array(
     v: &Value,
     vm: &mut Executor,
@@ -4027,32 +4061,95 @@ fn try_convert_to_array(
     if let Some(ary) = v.try_array_ty() {
         return Ok(Some(ary));
     }
-    // Check respond_to?(:to_ary, true) to respect respond_to_missing? protocol.
     let respond_to = IdentId::get_id("respond_to?");
-    let responds = match vm.invoke_method_inner(
+    let default_fid = |globals: &Globals, class: ClassId, name: IdentId| {
+        globals
+            .store
+            .check_method_for_class(class, name)
+            .and_then(|e| e.func_id())
+    };
+    let user_fid = |globals: &Globals, name: IdentId, class: ClassId| {
+        let fid = globals.check_method(*v, name)?;
+        (Some(fid) != default_fid(globals, class, name)).then_some(fid)
+    };
+
+    // respond: 1 = claimed to respond, 0 = refused, -1 = undetermined
+    let mut respond: i8 = -1;
+    // 1. A user-redefined respond_to? vetoes the whole probe.
+    if let Some(fid) = user_fid(globals, respond_to, OBJECT_CLASS) {
+        let responds = vm
+            .invoke_func_inner(
+                globals,
+                fid,
+                *v,
+                &[Value::symbol(IdentId::TO_ARY), Value::bool(true)],
+                None,
+                None,
+            )?
+            .as_bool();
+        if !responds {
+            return Ok(None);
+        }
+        respond = 1;
+    }
+    // 2. A defined to_ary is simply called.
+    if let Some(fid) = globals.check_method(*v, IdentId::TO_ARY) {
+        let result = vm.invoke_func_inner(globals, fid, *v, &[], None, None)?;
+        return to_ary_result(v, result, globals);
+    }
+    // 3. Default respond_to?: a user-defined respond_to_missing? gates
+    //    the missing-dispatch.
+    if respond < 0
+        && let Some(fid) = user_fid(globals, IdentId::RESPOND_TO_MISSING_, OBJECT_CLASS)
+    {
+        let responds = vm
+            .invoke_func_inner(
+                globals,
+                fid,
+                *v,
+                &[Value::symbol(IdentId::TO_ARY), Value::bool(true)],
+                None,
+                None,
+            )?
+            .as_bool();
+        if !responds {
+            return Ok(None);
+        }
+        respond = 1;
+    }
+    // 4. A user-defined method_missing is consulted with :to_ary.
+    let Some(fid) = user_fid(globals, IdentId::METHOD_MISSING, BASIC_OBJECT_CLASS) else {
+        if respond > 0 {
+            // claimed to respond (respond_to_missing? => true) but only
+            // the default method_missing exists: dispatch for real so
+            // the NoMethodError propagates (pinned by the
+            // respond_to_missing? flatten spec).
+            let result = vm.invoke_method_inner(globals, IdentId::TO_ARY, *v, &[], None, None)?;
+            return to_ary_result(v, result, globals);
+        }
+        return Ok(None);
+    };
+    match vm.invoke_func_inner(
         globals,
-        respond_to,
+        fid,
         *v,
-        &[Value::symbol(IdentId::TO_ARY), Value::bool(true)],
+        &[Value::symbol(IdentId::TO_ARY)],
         None,
         None,
     ) {
-        Ok(val) => val.as_bool(),
-        // BasicObject without respond_to? and without method_missing
-        Err(_) => return Ok(None),
-    };
-    if !responds {
-        return Ok(None);
+        Ok(result) => to_ary_result(v, result, globals),
+        Err(err)
+            if respond < 0
+                && matches!(
+                    &err.kind,
+                    MonorubyErrKind::NotMethod { name, .. }
+                        if name.is_none() || *name == Some(IdentId::TO_ARY)
+                ) =>
+        {
+            Ok(None)
+        }
+        Err(err) => Err(err),
     }
-    // Call to_ary via invoke_method_inner to support method_missing.
-    let result = vm.invoke_method_inner(globals, IdentId::TO_ARY, *v, &[], None, None)?;
-    if let Some(ary) = result.try_array_ty() {
-        return Ok(Some(ary));
-    }
-    if result.is_nil() {
-        return Ok(None);
-    }
-    Err(MonorubyErr::cant_convert_error_ary(globals, *v, result))
 }
 
 fn flatten_inner(
@@ -4181,7 +4278,17 @@ fn compact_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
 #[monoruby_builtin]
 fn shuffle_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let mut ary = lfp.self_val().as_array_mut(&globals.store)?;
-    ary.shuffle(&mut rand::rng());
+    // Fisher-Yates off the seeded global PRNG with CRuby's exact draw
+    // (`RAND_UPTO` = `rb_random_ulong_limited`), so a `srand(n)`-seeded
+    // shuffle produces CRuby's sequence. The `random:` keyword form is
+    // the same loop in Ruby (`Array#shuffle`), consuming `random.rand`
+    // identically.
+    let mut i = ary.len();
+    while i > 1 {
+        i -= 1;
+        let j = globals.random_ulong_limited(i as u64) as usize;
+        ary.swap(i, j);
+    }
     Ok(lfp.self_val())
 }
 

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -5103,6 +5103,135 @@ mod tests {
     }
 
     #[test]
+    /// Array#flatten's element probe follows CRuby's rb_check_funcall
+    /// protocol (respond_to? veto, respond_to_missing? gate, user
+    /// method_missing consult, NoMethodError re-raise rule).
+    #[test]
+    fn flatten_check_funcall_protocol() {
+        run_tests(&[
+            // plain BasicObject: no probe, not converted
+            "bo = BasicObject.new; [bo].flatten.equal?(nil); [[bo].flatten.size, [bo].flatten[0].equal?(bo)]",
+            // a user method_missing supplies to_ary
+            r##"
+            bo = BasicObject.new
+            def bo.method_missing(name, *) = [1, 2]
+            [bo].flatten
+            "##,
+            // a user respond_to? returning false vetoes even that
+            r##"
+            bo = BasicObject.new
+            def bo.method_missing(name, *) = [1, 2]
+            def bo.respond_to?(name, *) = false
+            r1 = [bo].flatten.size
+            def bo.respond_to?(name, *) = true
+            [r1, [bo].flatten]
+            "##,
+            // respond_to_missing? => false gates the missing-dispatch
+            r##"
+            o = Object.new
+            def o.respond_to_missing?(name, priv) = false
+            def o.method_missing(name, *) = [3]
+            [[o].flatten.size, [o].flatten[0].equal?(o)]
+            "##,
+            // respond_to_missing? => true + user method_missing converts
+            r##"
+            o = Object.new
+            def o.respond_to_missing?(name, priv) = true
+            def o.method_missing(name, *) = name == :to_ary ? [4, 5] : super
+            [o].flatten
+            "##,
+        ]);
+        // respond_to_missing? => true with only the default
+        // method_missing dispatches for real and raises NoMethodError
+        run_test_error(
+            r##"
+            o = Object.new
+            def o.respond_to_missing?(name, priv) = true
+            [o].flatten
+            "##,
+        );
+        // a to_ary that returns neither Array nor nil is a TypeError
+        run_test_error(
+            r##"
+            o = Object.new
+            def o.to_ary = 42
+            [o].flatten
+            "##,
+        );
+        // a to_ary returning nil means "not convertible"
+        run_test(
+            r##"
+            o = Object.new
+            def o.to_ary = nil
+            [[o].flatten.size, [o].flatten[0].equal?(o)]
+            "##,
+        );
+        // a user respond_to? => true with a real to_ary calls it
+        run_test(
+            r##"
+            o = Object.new
+            def o.respond_to?(name, *) = true
+            def o.to_ary = [7, 8]
+            [o].flatten
+            "##,
+        );
+        // a method_missing raising NoMethodError for :to_ary means
+        // "not convertible" when nothing claimed the object responds
+        run_test(
+            r##"
+            o = Object.new
+            def o.method_missing(name, *) = raise(NoMethodError.new("nope", name))
+            [[o].flatten.size, [o].flatten[0].equal?(o)]
+            "##,
+        );
+    }
+
+    /// Array.new with a block fills the receiver incrementally: break
+    /// keeps the values produced so far (and returns the break value).
+    #[test]
+    fn initialize_block_break() {
+        run_tests(&[
+            r##"
+            a = [1, 2, 3]
+            a.send(:initialize, 3) { |i| break if i == 2; i.to_s }
+            a
+            "##,
+            "Array.new(3) { break :bv }",
+            "Array.new(3) { |i| i * 2 }",
+        ]);
+    }
+
+    /// The sign of a Bignum comparator result is read natively — a
+    /// redefined Integer#<=> cannot interfere (rb_cmpint).
+    #[test]
+    fn sort_bignum_comparator() {
+        run_test(
+            r##"
+            class Integer
+              alias old_spaceship <=>
+              def <=>(other) = raise("no")
+            end
+            r = [1, 2, 5, 10, 7, -4, 12].sort { |n, m| (n - m) * (2 ** 200) }
+            class Integer
+              alias <=> old_spaceship
+            end
+            r
+            "##,
+        );
+    }
+
+    /// shuffle/sample draw from the seeded global PRNG with CRuby's
+    /// exact consumption, so srand-seeded runs match CRuby.
+    #[test]
+    fn shuffle_sample_srand() {
+        run_tests(&[
+            "srand(123); %w[a b c d e f g h i j k].shuffle",
+            "srand(123); a = (1..30).to_a; a.shuffle!; a",
+            "srand(7); [[1,2,3,4,5,6].sample, [1,2,3].sample]",
+            "%w[a b c].shuffle(random: Random.new(1))",
+        ]);
+    }
+
     fn zip_propagates_each_errors() {
         // Pulling from an `#each`-based argument stops on StopIteration —
         // that is exhaustion — but any *other* exception is the argument's

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -54,7 +54,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_funcs(ARRAY_CLASS, "inspect", &["to_s"], inspect, 0);
     globals.define_builtin_func(ARRAY_CLASS, "to_a", to_a, 0);
     globals.define_builtin_func(ARRAY_CLASS, "to_h", to_h, 0);
-    globals.define_builtin_func(ARRAY_CLASS, "hash", hash, 0);
+    let array_hash = globals.define_builtin_func(ARRAY_CLASS, "hash", hash, 0);
+    globals.store.set_array_hash_fid(array_hash);
     globals.define_builtin_func(ARRAY_CLASS, "+", add, 1);
     globals.define_builtin_func(ARRAY_CLASS, "-", sub, 1);
     globals.define_builtin_func(ARRAY_CLASS, "*", mul, 1);

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -925,7 +925,7 @@ fn chdir(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
                 Err(MonorubyErr::errno_with_msg(
                     &globals.store,
                     &err,
-                    &old_pwd.to_string_lossy(),
+                    &old_pwd,
                 ))
             }
         }

--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -137,6 +137,7 @@ pub(super) fn init(globals: &mut Globals) {
 
     globals.define_builtin_func_with(EXCEPTION_CLASS, "initialize", initialize, 0, 2, false);
     globals.define_builtin_func(EXCEPTION_CLASS, "message", message, 0);
+    globals.define_builtin_func(EXCEPTION_CLASS, "to_s", to_s, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "backtrace", backtrace, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "__raise_backtrace", raise_backtrace, 0);
     globals.define_builtin_func(EXCEPTION_CLASS, "set_backtrace", set_backtrace, 1);
@@ -481,6 +482,25 @@ fn message(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -
     // CRuby's `Exception#message` is `self.to_s`, so a subclass that
     // overrides `#to_s` changes the reported message too.
     vm.invoke_method_inner(globals, IdentId::TO_S, lfp.self_val(), &[], None, None)
+}
+
+///
+/// ### Exception#to_s
+///
+/// A message whose exact bytes are not valid UTF-8 (an Errno carrying a
+/// binary path) is materialized as an ASCII-8BIT string with the
+/// original bytes, like CRuby, which keeps the path's own bytes in the
+/// message.
+///
+/// [https://docs.ruby-lang.org/ja/latest/method/Exception/i/to_s.html]
+#[monoruby_builtin]
+fn to_s(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let ex = self_val.is_exception().unwrap();
+    if let Some(raw) = &ex.raw_message {
+        return Ok(Value::bytes(raw.clone()));
+    }
+    Ok(Value::string_from_str(ex.message()))
 }
 
 ///

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -3087,6 +3087,65 @@ fn file_realdirpath(
 mod tests {
     use crate::tests::*;
 
+    /// Errno messages keep a non-UTF-8 path's exact bytes as an
+    /// ASCII-8BIT string (CRuby keeps the path's own bytes).
+    #[test]
+    fn errno_message_binary_path() {
+        run_tests(&[
+            r##"
+            begin
+              File.stat("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.class.to_s, e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            r##"
+            begin
+              File.ftype("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.class.to_s, e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            r##"
+            begin
+              File.size("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            r##"
+            begin
+              File.mtime("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            // File.read / File.readlink funnel the same raw-path errnos
+            r##"
+            begin
+              File.read("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            r##"
+            begin
+              File.readlink("/missing\xE3E4".b)
+            rescue SystemCallError => e
+              [e.message.encoding.to_s, e.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+            // a plain UTF-8 path keeps the UTF-8 message
+            r##"
+            begin
+              File.stat("/missing_utf8_ぱす")
+            rescue SystemCallError => e
+              [e.message.encoding.to_s, e.message.include?("ぱす")]
+            end
+            "##,
+        ]);
+    }
+
     #[test]
     fn file_path_ops_preserve_encoding() {
         // basename/extname/split/join/path/absolute_path/expand_path

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -203,7 +203,7 @@ fn file_read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
                 &globals.store,
                 &err,
                 "rb_sysopen",
-                &filename_str,
+                &filename,
             ));
         }
     };
@@ -238,7 +238,7 @@ fn file_read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     };
     if offset > 0 {
         std::io::Seek::seek(&mut file, std::io::SeekFrom::Start(offset)).map_err(|err| {
-            MonorubyErr::errno_with_path(&globals.store, &err, "rb_io_read", &filename_str)
+            MonorubyErr::errno_with_path(&globals.store, &err, "rb_io_read", &filename)
         })?;
     }
     let mut contents = vec![];
@@ -251,7 +251,7 @@ fn file_read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
             &globals.store,
             &err,
             "rb_io_read",
-            &filename_str,
+            &filename,
         ));
     }
     // A sized read that hits EOF immediately reads as nil; sized reads
@@ -326,7 +326,7 @@ fn file_binread(
                 &globals.store,
                 &err,
                 "rb_sysopen",
-                &filename_str,
+                &filename,
             ));
         }
     };
@@ -1054,7 +1054,10 @@ fn check_realpath(
                 &globals.store,
                 &err,
                 "realpath_rec",
-                &String::from_utf8_lossy(resolved),
+                {
+                    use std::os::unix::ffi::OsStrExt;
+                    std::ffi::OsStr::from_bytes(resolved)
+                },
             )
         }
     };
@@ -2006,7 +2009,7 @@ fn file_size(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         SizeSource::Path(path) => {
             let path_str = path.to_string_lossy();
             let metadata = std::fs::metadata(&path).map_err(|e| {
-                MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_size", &path_str)
+                MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_size", &path)
             })?;
             Ok(Value::integer(metadata.len() as i64))
         }
@@ -2108,7 +2111,7 @@ fn ftype(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     let path = to_path(vm, globals, lfp.arg(0))?;
     let path_str = path.to_string_lossy();
     let metadata = std::fs::symlink_metadata(&path).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_ftype", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_ftype", &path)
     })?;
     let ft = metadata.file_type();
     let s = if ft.is_file() {
@@ -2347,7 +2350,7 @@ fn file_readlink(
     let path = to_path(vm, globals, lfp.arg(0))?;
     let path_str = path.to_string_lossy();
     let target = std::fs::read_link(&path).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_readlink", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_readlink", &path)
     })?;
     Ok(Value::string(conv_pathbuf(&target)))
 }
@@ -2737,10 +2740,10 @@ fn file_time_attr(
     let path = to_path(vm, globals, lfp.arg(0))?;
     let path_str = path.to_string_lossy().to_string();
     let metadata = std::fs::metadata(&path).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path)
     })?;
     let t = f(&metadata).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_time", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_time", &path)
     })?;
     system_time_to_value(vm, globals, t)
 }
@@ -2797,7 +2800,7 @@ fn file_ctime(
     let path = to_path(vm, globals, lfp.arg(0))?;
     let path_str = path.to_string_lossy().to_string();
     let metadata = std::fs::metadata(&path).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path)
     })?;
     let secs = metadata.ctime();
     let nsec = metadata.ctime_nsec();
@@ -2824,7 +2827,7 @@ fn file_birthtime(
     let path = to_path(vm, globals, lfp.arg(0))?;
     let path_str = path.to_string_lossy().to_string();
     let metadata = std::fs::metadata(&path).map_err(|e| {
-        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path_str)
+        MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path)
     })?;
     match metadata.created() {
         Ok(t) => system_time_to_value(vm, globals, t),
@@ -2919,7 +2922,7 @@ fn build_stat(
     } else {
         std::fs::symlink_metadata(&path)
     }
-    .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path_str))?;
+    .map_err(|e| MonorubyErr::errno_with_path(&globals.store, &e, "rb_file_s_stat", &path))?;
     let stat_class = vm
         .get_qualified_constant(globals, OBJECT_CLASS, &["File", "Stat"])?
         .as_class();

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -4294,6 +4294,50 @@ mod tests {
     /// whose mode bit lives in the header flags byte and must travel
     /// with the replacement (ruby/spec core/hash/replace_spec.rb).
     #[test]
+    /// An explicitly passed mapping goes through implicit to_hash
+    /// conversion (TypeError for nil / non-hash); an absent one returns
+    /// the Enumerator.
+    #[test]
+    fn transform_keys_argument_validation() {
+        run_tests(&[
+            "{a: 1}.transform_keys.class.to_s",
+            "{a: 1, b: 2}.transform_keys({a: :A}) { |k| k.to_s }",
+            r##"
+            conv = Object.new
+            def conv.to_hash = { a: :z }
+            {a: 1}.transform_keys(conv)
+            "##,
+            "h = {a: 1, b: 2}; h.transform_keys!({a: :A}); h",
+        ]);
+        run_test_error("{a: 1}.transform_keys(nil)");
+        run_test_error("{a: 1}.transform_keys!(nil)");
+        run_test_error("{a: 1}.transform_keys(42)");
+    }
+
+    /// A singleton / redefined #hash on an Array or Hash key is
+    /// dispatched (exactly once per probe) instead of the native
+    /// structural digest; plain container keys stay native.
+    #[test]
+    fn container_key_hash_dispatch() {
+        run_tests(&[
+            r##"
+            calls = 0
+            k = ["x"]
+            k.define_singleton_method(:hash) { calls += 1; 0 }
+            h = {}
+            h[k] = 1
+            [h[k], calls >= 2, h.size]
+            "##,
+            // a plain Hash subclass inherits Hash#hash and digests
+            // structurally, so it works as a key interchangeably
+            r##"
+            sub = Class.new(Hash)
+            k = sub[[[:a, 1]]]
+            [k.hash == {a: 1}.hash, { {a: 1} => :x }[k]]
+            "##,
+        ]);
+    }
+
     fn hash_replace_compare_by_identity() {
         run_tests(&[
             "h = { a: 1, c: 3 }; \

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -59,7 +59,8 @@ pub(super) fn init(globals: &mut Globals) {
     );
     globals.define_builtin_funcs(HASH_CLASS, "==", &["==="], eq, 1);
     globals.define_builtin_func(HASH_CLASS, "eql?", eql, 1);
-    globals.define_builtin_func(HASH_CLASS, "hash", hash, 0);
+    let hash_hash = globals.define_builtin_func(HASH_CLASS, "hash", hash, 0);
+    globals.store.set_hash_hash_fid(hash_hash);
     globals.define_builtin_func(HASH_CLASS, "<", lt, 1);
     globals.define_builtin_func(HASH_CLASS, "<=", le, 1);
     globals.define_builtin_func(HASH_CLASS, ">", gt, 1);

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -2179,10 +2179,9 @@ fn env_fetch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         let hash = lfp.self_val().as_hash();
         let s = if let Some(bh) = lfp.block() {
             if lfp.try_arg(1).is_some() {
-                let warn_id = IdentId::get_id("warn");
-                let msg =
-                    Value::string_from_str("warning: block supersedes default value argument");
-                vm.invoke_method_inner(globals, warn_id, lfp.self_val(), &[msg], None, None)?;
+                // CRuby's rb_warn: caller-location prefix, straight to
+                // $stderr (not the overridable Kernel#warn).
+                vm.ruby_warn_caller(globals, "warning: block supersedes default value argument")?;
             }
             match hash.get(key, vm, globals)? {
                 Some(v) => v,

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -9374,7 +9374,97 @@ mod tests {
         ]);
     }
 
+    /// eval lexes a non-UTF-8 source in the string's own encoding
+    /// (via an injected magic comment), with line numbers unchanged.
     #[test]
+    fn eval_non_utf8_source() {
+        run_tests(&[
+            // Windows-31J source parses; the literal carries the encoding
+            // (note: a 'shift_jis'-tagged source is upgraded to
+            // Windows-31J by CRuby's parser — that alias rule is a
+            // separate, pre-existing nuance, so pin the canonical name)
+            r##"
+            src = "'\x87]'".dup.force_encoding('Windows-31J')
+            [eval(src).encoding.to_s, eval(src).bytesize]
+            "##,
+            // BINARY source with a high byte
+            r##"
+            s = eval("'\xE3'".b)
+            [s.encoding.to_s, s.bytes]
+            "##,
+            // line numbers are unshifted by the injection
+            r##"
+            src = "__LINE__".dup.force_encoding('Windows-31J')
+            [eval(src), eval("\n__LINE__".dup.force_encoding('Windows-31J')), eval("__LINE__", nil, "f", 7)]
+            "##,
+            // an explicit magic comment in the eval string wins untouched
+            r##"
+            eval("# encoding: us-ascii\n'x'.encoding.to_s")
+            "##,
+            // binding.eval takes the same path
+            r##"
+            binding.eval("'\xE3'".b).encoding.to_s
+            "##,
+        ]);
+    }
+
+    /// The seeded global PRNG draws exactly like CRuby for every
+    /// Kernel#rand shape (integer / Bignum / ranges / floats).
+    #[test]
+    fn kernel_rand_exact_streams() {
+        run_tests(&[
+            "srand(42); [rand, rand(100), rand(2**80), rand(5..10), rand(5...10)]",
+            "srand(42); [rand(1.0..2.0), rand(1.0...2.0), rand(0), rand(-7)]",
+            "srand(2**100 + 7); [rand(1000), rand]",
+            "srand(9); r1 = srand(11); [r1, rand(50)]",
+            "srand(3); Random.rand(50)",
+            "srand(3); Random.bytes(5).bytes",
+            "srand(3); Random.rand(2.5)",
+            // two-word (u64) limited draw
+            "srand(5); [rand(2**40), rand((2**35)..(2**36))]",
+            // generic endpoints: the span comes from end - start and the
+            // result round-trips through the endpoint's own #+
+            "srand(8); r = rand(Time.at(100)..Time.at(200)); [r.class.to_s, (100..200).include?(r.to_i)]",
+            // float-span generic endpoints
+            r##"
+            srand(8)
+            c = Class.new do
+              attr_reader :v
+              def initialize(v) = @v = v
+              def -(o) = @v - o.v
+              def +(f) = @v + f
+              def <=>(o) = @v <=> o.v
+            end
+            [rand(c.new(1.0)..c.new(2.0)).class.to_s]
+            "##,
+            // empty ranges give nil; float/zero shapes
+            "[rand(5..1), rand(2.0..1.0), rand(3.0...3.0), rand(2.0..2.0)]",
+            "srand(2); [rand(0), rand(-7.9.to_i), rand(1..1)]",
+        ]);
+        // the entropy-seeded path (srand with no argument) — value is
+        // nondeterministic, so only exercise it
+        run_test_no_result_check("srand; [rand, rand(10)].class");
+        run_test_no_result_check("Random.srand; Random.rand(10).class");
+    }
+
+    /// A re-raised Errno exception keeps its binary raw message.
+    #[test]
+    fn reraise_binary_errno_message() {
+        run_test(
+            r##"
+            begin
+              begin
+                File.stat("/missing\xE3E4".b)
+              rescue SystemCallError => e
+                raise e
+              end
+            rescue SystemCallError => e2
+              [e2.message.encoding.to_s, e2.message.include?("/missing\xE3E4".b)]
+            end
+            "##,
+        );
+    }
+
     fn kernel_raise_argument_matrix() {
         // The shared rb_make_exception surface: String-with-extra-arg
         // TypeError, custom backtraces (Array / single String / nil /

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1722,7 +1722,7 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // Drawn from the seeded global PRNG, so `srand(n)` makes the
     // sequence repeatable (CRuby: Kernel#rand shares Random::DEFAULT).
     let Some(arg0) = lfp.try_arg(0) else {
-        return Ok(Value::float(globals.random_gen()));
+        return Ok(Value::float(globals.random_float()));
     };
     if let Some(range) = arg0.is_range() {
         let start = range.start();
@@ -1734,8 +1734,8 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             if span <= 0 {
                 return Ok(Value::nil());
             }
-            let f: f64 = globals.random_gen();
-            return Ok(Value::integer(s + (f * span as f64) as i64));
+            let r = globals.random_ulong_limited(span as u64 - 1) as i64;
+            return Ok(Value::integer(s + r));
         }
         // Any Float endpoint makes the result a Float in [s, e).
         let to_f = |v: Value| v.try_float().or_else(|| v.try_fixnum().map(|i| i as f64));
@@ -1746,7 +1746,13 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             if e == s {
                 return Ok(Value::float(s));
             }
-            let f: f64 = globals.random_gen();
+            // an inclusive float range draws with CRuby's
+            // int_pair_to_real_inclusive mapping ([0, 1], both ends)
+            let f = if excl {
+                globals.random_float()
+            } else {
+                globals.random_float_inclusive()
+            };
             return Ok(Value::float(s + f * (e - s)));
         }
         // Generic endpoints (Time, custom numeric-ish objects): the
@@ -1764,8 +1770,7 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
             let f: f64 = if span == 0.0 {
                 0.0
             } else {
-                let f: f64 = globals.random_gen();
-                f * span
+                globals.random_float() * span
             };
             return vm.invoke_method_inner(globals, plus, start, &[Value::float(f)], None, None);
         }
@@ -1786,16 +1791,23 @@ fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         if span <= 0 {
             return Ok(Value::nil());
         }
-        let f: f64 = globals.random_gen();
-        let r = (f * span as f64) as i64;
+        let r = globals.random_ulong_limited(span as u64 - 1) as i64;
         return vm.invoke_method_inner(globals, plus, start, &[Value::integer(r)], None, None);
+    }
+    // A Bignum max draws through the multi-word path (CRuby rand_int).
+    if let RV::BigInt(b) = arg0.unpack() {
+        use num::Signed;
+        let b = b.abs();
+        if !b.is_zero() {
+            return Ok(globals.random_rand_int(&b));
+        }
     }
     let i = arg0.coerce_to_int_i64(vm, globals)?;
     if !i.is_zero() {
-        let f: f64 = globals.random_gen();
-        Ok(Value::integer((f * (i.abs() as f64)) as i64))
+        let r = globals.random_ulong_limited(i.unsigned_abs() - 1) as i64;
+        Ok(Value::integer(r))
     } else {
-        Ok(Value::float(globals.random_gen()))
+        Ok(Value::float(globals.random_float()))
     }
 }
 

--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -1,109 +1,8 @@
 use super::*;
+use crate::globals::prng::{
+    Mt, build_mt, digits_to_value, limited_rand, next_real, rand_int, to_le_digits,
+};
 use num::{Signed, Zero};
-
-/// Reference MT19937 (`mt19937ar`), the exact algorithm CRuby's
-/// `random.c` uses, so the generated stream is bit-identical to CRuby.
-#[derive(Clone, PartialEq, Eq, Hash)]
-struct Mt {
-    mt: [u32; 624],
-    mti: usize,
-}
-
-const MT_N: usize = 624;
-const MT_M: usize = 397;
-const MT_MATRIX_A: u32 = 0x9908_b0df;
-const MT_UPPER: u32 = 0x8000_0000;
-const MT_LOWER: u32 = 0x7fff_ffff;
-
-impl Mt {
-    fn init_genrand(seed: u32) -> Self {
-        let mut mt = [0u32; MT_N];
-        mt[0] = seed;
-        for i in 1..MT_N {
-            mt[i] = 1_812_433_253u32
-                .wrapping_mul(mt[i - 1] ^ (mt[i - 1] >> 30))
-                .wrapping_add(i as u32);
-        }
-        Self { mt, mti: MT_N }
-    }
-
-    fn new_with_key(key: &[u32]) -> Self {
-        let mut s = Self::init_genrand(19_650_218);
-        let mt = &mut s.mt;
-        let (mut i, mut j) = (1usize, 0usize);
-        let mut k = MT_N.max(key.len());
-        while k != 0 {
-            mt[i] = (mt[i]
-                ^ (mt[i - 1] ^ (mt[i - 1] >> 30)).wrapping_mul(1_664_525))
-            .wrapping_add(key[j])
-            .wrapping_add(j as u32);
-            i += 1;
-            j += 1;
-            if i >= MT_N {
-                mt[0] = mt[MT_N - 1];
-                i = 1;
-            }
-            if j >= key.len() {
-                j = 0;
-            }
-            k -= 1;
-        }
-        k = MT_N - 1;
-        while k != 0 {
-            mt[i] = (mt[i]
-                ^ (mt[i - 1] ^ (mt[i - 1] >> 30)).wrapping_mul(1_566_083_941))
-            .wrapping_sub(i as u32);
-            i += 1;
-            if i >= MT_N {
-                mt[0] = mt[MT_N - 1];
-                i = 1;
-            }
-            k -= 1;
-        }
-        mt[0] = 0x8000_0000;
-        s
-    }
-
-    fn next_u32(&mut self) -> u32 {
-        if self.mti >= MT_N {
-            let mt = &mut self.mt;
-            for kk in 0..MT_N - MT_M {
-                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
-                mt[kk] = mt[kk + MT_M] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
-            }
-            for kk in MT_N - MT_M..MT_N - 1 {
-                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
-                mt[kk] = mt[kk + MT_M - MT_N]
-                    ^ (y >> 1)
-                    ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
-            }
-            let y = (mt[MT_N - 1] & MT_UPPER) | (mt[0] & MT_LOWER);
-            mt[MT_N - 1] = mt[MT_M - 1] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
-            self.mti = 0;
-        }
-        let mut y = self.mt[self.mti];
-        self.mti += 1;
-        y ^= y >> 11;
-        y ^= (y << 7) & 0x9d2c_5680;
-        y ^= (y << 15) & 0xefc6_0000;
-        y ^= y >> 18;
-        y
-    }
-
-    /// CRuby `rb_rand_bytes`: little-endian 32-bit chunks; a trailing
-    /// partial word still consumes a full draw.
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut chunks = dest.chunks_exact_mut(4);
-        for c in &mut chunks {
-            c.copy_from_slice(&self.next_u32().to_le_bytes());
-        }
-        let rem = chunks.into_remainder();
-        if !rem.is_empty() {
-            let b = self.next_u32().to_le_bytes();
-            rem.copy_from_slice(&b[..rem.len()]);
-        }
-    }
-}
 
 //
 // Random class
@@ -141,39 +40,6 @@ fn ivar_cnt() -> IdentId {
     IdentId::get_id("/random_cnt")
 }
 
-/// Little-endian `u32` words of `|seed|` (`init_by_array` key). Zero -> `[0]`.
-fn seed_words(seed: Value) -> Vec<u32> {
-    let big = match seed.unpack() {
-        RV::Fixnum(i) => num::BigInt::from(i),
-        RV::BigInt(b) => b.clone(),
-        _ => num::BigInt::from(0),
-    };
-    let (_, bytes) = big.abs().to_bytes_le();
-    let mut words: Vec<u32> = bytes
-        .chunks(4)
-        .map(|c| {
-            let mut w = [0u8; 4];
-            w[..c.len()].copy_from_slice(c);
-            u32::from_le_bytes(w)
-        })
-        .collect();
-    if words.is_empty() {
-        words.push(0);
-    }
-    words
-}
-
-fn build_mt(seed: Value) -> Mt {
-    // CRuby `rand_init`: a single-word seed uses `init_genrand`;
-    // multi-word seeds use `init_by_array`.
-    let words = seed_words(seed);
-    if words.len() <= 1 {
-        Mt::init_genrand(words[0])
-    } else {
-        Mt::new_with_key(&words)
-    }
-}
-
 fn load_state(globals: &Globals, self_: Value) -> (Value, u64) {
     let seed = globals
         .store
@@ -193,92 +59,6 @@ fn mt_at(seed: Value, cnt: u64) -> Mt {
         mt.next_u32();
     }
     mt
-}
-
-/// CRuby `genrand_real` (53-bit, two draws).
-fn next_real(mt: &mut Mt, cnt: &mut u64) -> f64 {
-    let a = (mt.next_u32() >> 5) as f64;
-    let b = (mt.next_u32() >> 6) as f64;
-    *cnt += 2;
-    (a * 67108864.0 + b) * (1.0 / 9007199254740992.0)
-}
-
-fn make_mask(mut x: u32) -> u32 {
-    x |= x >> 1;
-    x |= x >> 2;
-    x |= x >> 4;
-    x |= x >> 8;
-    x |= x >> 16;
-    x
-}
-
-/// CRuby `limited_big_rand`: uniform integer in `[0, limit]` where
-/// `limit` is given as little-endian `u32` digits. Returns the same.
-fn limited_rand(mt: &mut Mt, cnt: &mut u64, limit: &[u32]) -> Vec<u32> {
-    let len = limit.len();
-    loop {
-        let mut mask = 0u32;
-        let mut boundary = true;
-        let mut digits = vec![0u32; len];
-        let mut retry = false;
-        for i in (0..len).rev() {
-            let lim = limit[i];
-            mask = if mask != 0 { 0xffff_ffff } else { make_mask(lim) };
-            let rnd = if mask != 0 {
-                let r = mt.next_u32() & mask;
-                *cnt += 1;
-                if boundary {
-                    if lim < r {
-                        retry = true;
-                        break;
-                    }
-                    if r < lim {
-                        boundary = false;
-                    }
-                }
-                r
-            } else {
-                0
-            };
-            digits[i] = rnd;
-        }
-        if !retry {
-            return digits;
-        }
-    }
-}
-
-/// Little-endian `u32` digits of a non-negative integer Value.
-fn to_le_digits(big: &num::BigInt) -> Vec<u32> {
-    let (_, bytes) = big.to_bytes_le();
-    let mut d: Vec<u32> = bytes
-        .chunks(4)
-        .map(|c| {
-            let mut w = [0u8; 4];
-            w[..c.len()].copy_from_slice(c);
-            u32::from_le_bytes(w)
-        })
-        .collect();
-    if d.is_empty() {
-        d.push(0);
-    }
-    d
-}
-
-fn digits_to_value(digits: &[u32]) -> Value {
-    let mut bytes = Vec::with_capacity(digits.len() * 4);
-    for w in digits {
-        bytes.extend_from_slice(&w.to_le_bytes());
-    }
-    let big = num::BigInt::from_bytes_le(num::bigint::Sign::Plus, &bytes);
-    Value::bigint(big)
-}
-
-/// `rand(max)` for an integer `max` (> 0): uniform in `[0, max)`.
-fn rand_int(mt: &mut Mt, cnt: &mut u64, max: &num::BigInt) -> Value {
-    let limit = max - 1u32;
-    let digits = limited_rand(mt, cnt, &to_le_digits(&limit));
-    digits_to_value(&digits)
 }
 
 fn random_seed_value() -> Value {
@@ -425,22 +205,9 @@ fn random_srand(
             }
         }
     };
-    // Feed the Mersenne Twister the low bits; report the exact Integer.
-    let mt_seed = match arg.unpack() {
-        RV::Fixnum(i) => i,
-        RV::BigInt(b) => {
-            use num::bigint::Sign;
-            let (sign, digits) = b.to_u64_digits();
-            let low = digits.first().copied().unwrap_or(0) as i64;
-            if sign == Sign::Minus {
-                low.wrapping_neg()
-            } else {
-                low
-            }
-        }
-        _ => unreachable!(),
-    };
-    globals.random_init_with(mt_seed, arg);
+    // Every word of the seed feeds the Mersenne Twister (CRuby
+    // rand_init); the exact Integer is reported back by the next srand.
+    globals.random_init_with(arg);
     Ok(old_seed)
 }
 
@@ -578,7 +345,7 @@ fn inst_rand_op(
 fn rand_with_arg(globals: &mut Globals, arg: Option<Value>) -> Result<Value> {
     let arg = match arg {
         Some(v) => v,
-        None => return Ok(Value::float(globals.random_gen())),
+        None => return Ok(Value::float(globals.random_float())),
     };
     if let Some(max) = arg.try_fixnum() {
         if max <= 0 {
@@ -587,8 +354,7 @@ fn rand_with_arg(globals: &mut Globals, arg: Option<Value>) -> Result<Value> {
                 max
             )));
         }
-        let f: f64 = globals.random_gen();
-        Ok(Value::integer((f * max as f64) as i64))
+        Ok(globals.random_rand_int(&num::BigInt::from(max)))
     } else if let Some(max) = arg.try_float() {
         if max < 0.0 {
             return Err(MonorubyErr::argumenterr(format!(
@@ -596,7 +362,7 @@ fn rand_with_arg(globals: &mut Globals, arg: Option<Value>) -> Result<Value> {
                 max
             )));
         }
-        let f: f64 = globals.random_gen();
+        let f = globals.random_float();
         if max == 0.0 {
             Ok(Value::float(f))
         } else {
@@ -716,12 +482,10 @@ fn random_bytes_inner(vm: &mut Executor, globals: &mut Globals, size_arg: Value)
     } else {
         size as usize
     };
-    let pack_size = (size + 7) & !7;
-    let mut v = vec![0; pack_size];
-    for chunk in v.as_chunks_mut().0 {
-        *chunk = globals.random_gen::<[u8; 8]>();
-    }
-    v.truncate(size);
+    // CRuby `rb_rand_bytes`: little-endian 32-bit words off the default
+    // PRNG, a trailing partial word consuming a full draw.
+    let mut v = vec![0; size];
+    globals.random_fill_bytes(&mut v);
     Ok(Value::bytes(v))
 }
 

--- a/monoruby/src/executor/op/sort.rs
+++ b/monoruby/src/executor/op/sort.rs
@@ -71,6 +71,16 @@ impl Executor {
         let i = match res.try_fixnum() {
             Some(i) => i,
             None => {
+                // A Bignum's sign is read directly, like CRuby's rb_cmpint:
+                // no method dispatch, so a redefined Integer#<=> (or #>)
+                // cannot interfere with sorting by huge differences.
+                if let RV::BigInt(b) = res.unpack() {
+                    return Ok(match b.sign() {
+                        num::bigint::Sign::Minus => std::cmp::Ordering::Less,
+                        num::bigint::Sign::NoSign => std::cmp::Ordering::Equal,
+                        num::bigint::Sign::Plus => std::cmp::Ordering::Greater,
+                    });
+                }
                 let zero = Value::integer(0);
                 let cmp =
                     self.invoke_method_inner(globals, IdentId::_CMP, res, &[zero], None, None)?;

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -10,7 +10,7 @@ mod dump;
 mod error;
 mod gvar;
 pub(crate) mod method;
-mod prng;
+pub(crate) mod prng;
 mod require;
 mod store;
 #[cfg(any(feature = "deopt", feature = "profile"))]
@@ -1493,28 +1493,48 @@ impl Globals {
         self.random_seed_obj
     }
 
-    /// Re-seed the global PRNG with an explicit seed: `mt_seed` feeds the
-    /// Mersenne Twister (low bits), `exact` is what the next `srand`
-    /// reports back.
-    pub(crate) fn random_init_with(&mut self, mt_seed: i64, exact: Value) {
-        self.random.init_with_seed(Some(mt_seed));
+    /// Re-seed the global PRNG with an explicit Integer seed. Every word
+    /// of the seed feeds the Mersenne Twister (CRuby `rand_init`);
+    /// `exact` is also what the next `srand` reports back.
+    pub(crate) fn random_init_with(&mut self, exact: Value) {
+        self.random.seed_value(exact);
         self.random_seed_obj = exact;
     }
 
-    //pub(crate) fn random_seed(&self) -> i32 {
-    //    self.random.seed
-    //}
-
     pub(crate) fn random_init(&mut self, seed: Option<i64>) {
-        let used = self.random.init_with_seed(seed);
-        self.random_seed_obj = Value::integer(used);
+        match seed {
+            Some(s) => self.random_init_with(Value::integer(s)),
+            None => {
+                let used = self.random.seed_entropy();
+                self.random_seed_obj = Value::integer(used);
+            }
+        }
     }
 
-    pub(crate) fn random_gen<T>(&mut self) -> T
-    where
-        rand::distr::StandardUniform: rand::prelude::Distribution<T>,
-    {
-        self.random.random()
+    /// Uniform Float in `[0, 1)` (CRuby `genrand_real`, 53-bit).
+    pub(crate) fn random_float(&mut self) -> f64 {
+        self.random.next_real()
+    }
+
+    /// Uniform Float in `[0, 1]`, both ends included (CRuby
+    /// `int_pair_to_real_inclusive` — inclusive float-range `rand`).
+    pub(crate) fn random_float_inclusive(&mut self) -> f64 {
+        self.random.next_real_inclusive()
+    }
+
+    /// Uniform integer in `[0, max]` (CRuby `rb_random_ulong_limited` —
+    /// the draw `Array#shuffle` / `#sample` and integer `rand` use).
+    pub(crate) fn random_ulong_limited(&mut self, max: u64) -> u64 {
+        self.random.ulong_limited(max)
+    }
+
+    /// `rand(max)` for a positive integer `max`: uniform in `[0, max)`.
+    pub(crate) fn random_rand_int(&mut self, max: &num::BigInt) -> Value {
+        self.random.rand_int(max)
+    }
+
+    pub(crate) fn random_fill_bytes(&mut self, dest: &mut [u8]) {
+        self.random.fill_bytes(dest)
     }
 }
 

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -87,6 +87,12 @@ pub struct MonorubyErr {
     /// → `#exit_value` / `#reason`; for `StopIteration` the
     /// iterator return value + `"result"` → `#result`.
     pub(crate) payload: Option<(Value, &'static str)>,
+    /// The exact message bytes when they are not valid UTF-8 — e.g. an
+    /// Errno message carrying a binary path. `message` then holds the
+    /// lossy rendering for Rust-side display, while `Exception#to_s`
+    /// materializes these bytes as an ASCII-8BIT string (CRuby keeps
+    /// the path's own bytes in the message).
+    pub(crate) raw_message: Option<Vec<u8>>,
 }
 
 impl MonorubyErr {
@@ -98,6 +104,7 @@ impl MonorubyErr {
             original: None,
             explicit_cause: None,
             payload: None,
+            raw_message: None,
         }
     }
 
@@ -112,6 +119,7 @@ impl MonorubyErr {
             original: None,
             explicit_cause: None,
             payload: None,
+            raw_message: ex.raw_message.clone(),
         }
     }
 
@@ -136,6 +144,7 @@ impl MonorubyErr {
             trace: vec![(Some((loc, sourceinfo)), func_id)],
             original: None,
             explicit_cause: None,
+            raw_message: None,
             payload: None,
         }
     }
@@ -1239,21 +1248,41 @@ impl MonorubyErr {
         store: &Store,
         err: &std::io::Error,
         syscall: &str,
-        path: &str,
+        path: impl AsRef<std::ffi::OsStr>,
     ) -> MonorubyErr {
         let desc = errno_description(err);
-        let msg = format!("{} @ {} - {}", desc, syscall, path);
-        Self::from_io_err(store, err, msg)
+        let path = path.as_ref();
+        let msg = format!("{} @ {} - {}", desc, syscall, path.to_string_lossy());
+        let mut e = Self::from_io_err(store, err, msg);
+        let bytes = path.as_encoded_bytes();
+        if std::str::from_utf8(bytes).is_err() {
+            let mut raw = format!("{} @ {} - ", desc, syscall).into_bytes();
+            raw.extend_from_slice(bytes);
+            e.raw_message = Some(raw);
+        }
+        e
     }
 
     /// Create an Errno exception from a `std::io::Error` with just a path (no syscall name).
     ///
     /// Formats the message to match CRuby: `"<description> - <path>"`
     /// For example: `"No such file or directory - /path/to/file"`
-    pub(crate) fn errno_with_msg(store: &Store, err: &std::io::Error, path: &str) -> MonorubyErr {
+    pub(crate) fn errno_with_msg(
+        store: &Store,
+        err: &std::io::Error,
+        path: impl AsRef<std::ffi::OsStr>,
+    ) -> MonorubyErr {
         let desc = errno_description(err);
-        let msg = format!("{} - {}", desc, path);
-        Self::from_io_err(store, err, msg)
+        let path = path.as_ref();
+        let msg = format!("{} - {}", desc, path.to_string_lossy());
+        let mut e = Self::from_io_err(store, err, msg);
+        let bytes = path.as_encoded_bytes();
+        if std::str::from_utf8(bytes).is_err() {
+            let mut raw = format!("{} - ", desc).into_bytes();
+            raw.extend_from_slice(bytes);
+            e.raw_message = Some(raw);
+        }
+        e
     }
 
     /// Errno exception whose message is the bare strerror description

--- a/monoruby/src/globals/prng.rs
+++ b/monoruby/src/globals/prng.rs
@@ -1,45 +1,307 @@
-use rand::Rng;
-use rand_mt::Mt;
+use crate::*;
 
+//
+// Reference MT19937 (`mt19937ar`), the exact algorithm CRuby's
+// `random.c` uses, so every stream drawn here — the seeded global PRNG
+// behind `Kernel#srand` / `#rand` / `Array#shuffle` as well as `Random`
+// instances (`builtins/random.rs` reuses these helpers) — is
+// bit-identical to CRuby's.
+//
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct Mt {
+    mt: [u32; 624],
+    mti: usize,
+}
+
+const MT_N: usize = 624;
+const MT_M: usize = 397;
+const MT_MATRIX_A: u32 = 0x9908_b0df;
+const MT_UPPER: u32 = 0x8000_0000;
+const MT_LOWER: u32 = 0x7fff_ffff;
+
+impl Mt {
+    pub(crate) fn init_genrand(seed: u32) -> Self {
+        let mut mt = [0u32; MT_N];
+        mt[0] = seed;
+        for i in 1..MT_N {
+            mt[i] = 1_812_433_253u32
+                .wrapping_mul(mt[i - 1] ^ (mt[i - 1] >> 30))
+                .wrapping_add(i as u32);
+        }
+        Self { mt, mti: MT_N }
+    }
+
+    pub(crate) fn new_with_key(key: &[u32]) -> Self {
+        let mut s = Self::init_genrand(19_650_218);
+        let mt = &mut s.mt;
+        let (mut i, mut j) = (1usize, 0usize);
+        let mut k = MT_N.max(key.len());
+        while k != 0 {
+            mt[i] = (mt[i] ^ (mt[i - 1] ^ (mt[i - 1] >> 30)).wrapping_mul(1_664_525))
+                .wrapping_add(key[j])
+                .wrapping_add(j as u32);
+            i += 1;
+            j += 1;
+            if i >= MT_N {
+                mt[0] = mt[MT_N - 1];
+                i = 1;
+            }
+            if j >= key.len() {
+                j = 0;
+            }
+            k -= 1;
+        }
+        k = MT_N - 1;
+        while k != 0 {
+            mt[i] = (mt[i] ^ (mt[i - 1] ^ (mt[i - 1] >> 30)).wrapping_mul(1_566_083_941))
+                .wrapping_sub(i as u32);
+            i += 1;
+            if i >= MT_N {
+                mt[0] = mt[MT_N - 1];
+                i = 1;
+            }
+            k -= 1;
+        }
+        mt[0] = 0x8000_0000;
+        s
+    }
+
+    pub(crate) fn next_u32(&mut self) -> u32 {
+        if self.mti >= MT_N {
+            let mt = &mut self.mt;
+            for kk in 0..MT_N - MT_M {
+                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
+                mt[kk] = mt[kk + MT_M] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+            }
+            for kk in MT_N - MT_M..MT_N - 1 {
+                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
+                mt[kk] =
+                    mt[kk + MT_M - MT_N] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+            }
+            let y = (mt[MT_N - 1] & MT_UPPER) | (mt[0] & MT_LOWER);
+            mt[MT_N - 1] = mt[MT_M - 1] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+            self.mti = 0;
+        }
+        let mut y = self.mt[self.mti];
+        self.mti += 1;
+        y ^= y >> 11;
+        y ^= (y << 7) & 0x9d2c_5680;
+        y ^= (y << 15) & 0xefc6_0000;
+        y ^= y >> 18;
+        y
+    }
+
+    /// CRuby `rb_rand_bytes`: little-endian 32-bit chunks; a trailing
+    /// partial word still consumes a full draw.
+    pub(crate) fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let mut chunks = dest.chunks_exact_mut(4);
+        for c in &mut chunks {
+            c.copy_from_slice(&self.next_u32().to_le_bytes());
+        }
+        let rem = chunks.into_remainder();
+        if !rem.is_empty() {
+            let b = self.next_u32().to_le_bytes();
+            rem.copy_from_slice(&b[..rem.len()]);
+        }
+    }
+}
+
+/// Little-endian `u32` words of `|seed|` (`init_by_array` key). Zero -> `[0]`.
+pub(crate) fn seed_words(seed: Value) -> Vec<u32> {
+    use num::Signed;
+    let big = match seed.unpack() {
+        RV::Fixnum(i) => num::BigInt::from(i),
+        RV::BigInt(b) => b.clone(),
+        _ => num::BigInt::from(0),
+    };
+    let (_, bytes) = big.abs().to_bytes_le();
+    let mut words: Vec<u32> = bytes
+        .chunks(4)
+        .map(|c| {
+            let mut w = [0u8; 4];
+            w[..c.len()].copy_from_slice(c);
+            u32::from_le_bytes(w)
+        })
+        .collect();
+    if words.is_empty() {
+        words.push(0);
+    }
+    words
+}
+
+/// CRuby `rand_init`: a single-word seed uses `init_genrand`;
+/// multi-word seeds use `init_by_array`.
+pub(crate) fn build_mt(seed: Value) -> Mt {
+    let words = seed_words(seed);
+    if words.len() <= 1 {
+        Mt::init_genrand(words[0])
+    } else {
+        Mt::new_with_key(&words)
+    }
+}
+
+/// CRuby `genrand_real` (53-bit, two draws).
+pub(crate) fn next_real(mt: &mut Mt, cnt: &mut u64) -> f64 {
+    let a = (mt.next_u32() >> 5) as f64;
+    let b = (mt.next_u32() >> 6) as f64;
+    *cnt += 2;
+    (a * 67108864.0 + b) * (1.0 / 9007199254740992.0)
+}
+
+fn make_mask(mut x: u32) -> u32 {
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    x
+}
+
+/// CRuby `limited_big_rand`: uniform integer in `[0, limit]` where
+/// `limit` is given as little-endian `u32` digits. Returns the same.
+pub(crate) fn limited_rand(mt: &mut Mt, cnt: &mut u64, limit: &[u32]) -> Vec<u32> {
+    let len = limit.len();
+    loop {
+        let mut mask = 0u32;
+        let mut boundary = true;
+        let mut digits = vec![0u32; len];
+        let mut retry = false;
+        for i in (0..len).rev() {
+            let lim = limit[i];
+            mask = if mask != 0 { 0xffff_ffff } else { make_mask(lim) };
+            let rnd = if mask != 0 {
+                let r = mt.next_u32() & mask;
+                *cnt += 1;
+                if boundary {
+                    if lim < r {
+                        retry = true;
+                        break;
+                    }
+                    if r < lim {
+                        boundary = false;
+                    }
+                }
+                r
+            } else {
+                0
+            };
+            digits[i] = rnd;
+        }
+        if !retry {
+            return digits;
+        }
+    }
+}
+
+/// Little-endian `u32` digits of a non-negative integer.
+pub(crate) fn to_le_digits(big: &num::BigInt) -> Vec<u32> {
+    let (_, bytes) = big.to_bytes_le();
+    let mut d: Vec<u32> = bytes
+        .chunks(4)
+        .map(|c| {
+            let mut w = [0u8; 4];
+            w[..c.len()].copy_from_slice(c);
+            u32::from_le_bytes(w)
+        })
+        .collect();
+    if d.is_empty() {
+        d.push(0);
+    }
+    d
+}
+
+pub(crate) fn digits_to_value(digits: &[u32]) -> Value {
+    let mut bytes = Vec::with_capacity(digits.len() * 4);
+    for w in digits {
+        bytes.extend_from_slice(&w.to_le_bytes());
+    }
+    let big = num::BigInt::from_bytes_le(num::bigint::Sign::Plus, &bytes);
+    Value::bigint(big)
+}
+
+/// `rand(max)` for an integer `max` (> 0): uniform in `[0, max)`.
+pub(crate) fn rand_int(mt: &mut Mt, cnt: &mut u64, max: &num::BigInt) -> Value {
+    let limit = max - 1u32;
+    let digits = limited_rand(mt, cnt, &to_le_digits(&limit));
+    digits_to_value(&digits)
+}
+
+///
+/// The seeded global PRNG behind `Kernel#srand` / `#rand`,
+/// `Random.rand`, `Random.bytes` and the default paths of
+/// `Array#shuffle` / `#sample`. CRuby models this as `Random::DEFAULT`;
+/// keeping the stream and its consumption identical to CRuby makes
+/// `srand(n)`-seeded sequences (and specs pinning them) reproducible.
+///
 pub struct Prng {
-    /// standard PRNG
-    pub random: Mt,
-    /// random seed (the low 32 bits actually fed to the Mersenne
-    /// Twister; `Kernel#srand`'s exact Integer echo is kept separately
-    /// as a Value on `Globals`).
-    pub seed: i32,
+    mt: Mt,
 }
 
 impl Prng {
     pub fn new() -> Self {
-        let seed = 0;
-        let random = Mt::new(seed as u32);
-        Self { random, seed }
+        Self {
+            mt: Mt::init_genrand(0),
+        }
     }
 
-    /// Seed the PRNG. With `None`, draws a fresh nonnegative seed from OS
-    /// entropy and returns it (CRuby reports the system-initialized seed
-    /// as a nonnegative Integer).
-    pub fn init_with_seed(&mut self, seed: Option<i64>) -> i64 {
-        let new_seed = match seed {
-            None => {
-                let mut new_seed = [0u8; 4];
-                if let Err(err) = getrandom::fill(&mut new_seed) {
-                    panic!("from_entropy failed: {}", err);
-                }
-                (u32::from_ne_bytes(new_seed) & 0x7fff_ffff) as i32
-            }
-            Some(seed) => seed as i32,
-        };
-        self.seed = new_seed;
-        self.random = Mt::new(new_seed as u32);
-        new_seed as i64
+    /// Seed with the full integer Value (CRuby `rand_init` feeds every
+    /// word of the seed, not just the low bits).
+    pub(crate) fn seed_value(&mut self, seed: Value) {
+        self.mt = build_mt(seed);
     }
 
-    pub fn random<T>(&mut self) -> T
-    where
-        rand::distr::StandardUniform: rand::prelude::Distribution<T>,
-    {
-        self.random.random()
+    /// Draw a fresh nonnegative seed from OS entropy, seed with it, and
+    /// return it (CRuby reports the system-initialized seed).
+    pub(crate) fn seed_entropy(&mut self) -> i64 {
+        let mut buf = [0u8; 4];
+        if let Err(err) = getrandom::fill(&mut buf) {
+            panic!("from_entropy failed: {}", err);
+        }
+        let seed = (u32::from_ne_bytes(buf) & 0x7fff_ffff) as i64;
+        self.seed_value(Value::integer(seed));
+        seed
+    }
+
+    /// CRuby `genrand_real`: uniform Float in `[0, 1)`.
+    pub(crate) fn next_real(&mut self) -> f64 {
+        let mut cnt = 0;
+        next_real(&mut self.mt, &mut cnt)
+    }
+
+    /// CRuby `int_pair_to_real_inclusive`: uniform Float in `[0, 1]`
+    /// (both ends included), two draws — the mapping an *inclusive*
+    /// float-range `rand` uses.
+    pub(crate) fn next_real_inclusive(&mut self) -> f64 {
+        let a = self.mt.next_u32() as u128;
+        let b = self.mt.next_u32() as u128;
+        let x = (a << 32) | b;
+        let m = (1u128 << 53) | 1;
+        let r = ((x * m) >> 64) as u64;
+        (r as f64) * (1.0 / 9007199254740992.0)
+    }
+
+    /// CRuby `rb_random_ulong_limited`: uniform integer in `[0, max]`.
+    pub(crate) fn ulong_limited(&mut self, max: u64) -> u64 {
+        if max == 0 {
+            return 0;
+        }
+        let mut cnt = 0;
+        let limit = [(max & 0xffff_ffff) as u32, (max >> 32) as u32];
+        let limit: &[u32] = if limit[1] == 0 { &limit[..1] } else { &limit };
+        let digits = limited_rand(&mut self.mt, &mut cnt, limit);
+        let lo = digits.first().copied().unwrap_or(0) as u64;
+        let hi = digits.get(1).copied().unwrap_or(0) as u64;
+        lo | (hi << 32)
+    }
+
+    /// `rand(max)` for a positive integer `max`: uniform in `[0, max)`.
+    pub(crate) fn rand_int(&mut self, max: &num::BigInt) -> Value {
+        let mut cnt = 0;
+        rand_int(&mut self.mt, &mut cnt, max)
+    }
+
+    pub(crate) fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.mt.fill_bytes(dest)
     }
 }

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -100,6 +100,8 @@ pub struct Store {
     /// one?" and compute the digest inline instead of dispatching. See
     /// `doc/bop_redefinition.md`.
     kernel_hash_fid: Option<FuncId>,
+    array_hash_fid: Option<FuncId>,
+    hash_hash_fid: Option<FuncId>,
     /// ISeq info.
     pub(crate) iseqs: Vec<ISeqInfo>,
     /// class table.
@@ -256,6 +258,8 @@ impl Store {
             functions: function::Funcs::default(),
             basic_ops: basic_op::BasicOpTable::new(),
             kernel_hash_fid: None,
+            array_hash_fid: None,
+            hash_hash_fid: None,
             iseqs: vec![],
             constsite_info: vec![],
             callsite_info: vec![],
@@ -398,6 +402,35 @@ impl Store {
     /// Record the builtin `Kernel#hash`. Called once, at bootstrap.
     pub(crate) fn set_kernel_hash_fid(&mut self, fid: FuncId) {
         self.kernel_hash_fid = Some(fid);
+    }
+
+    pub(crate) fn set_array_hash_fid(&mut self, fid: FuncId) {
+        self.array_hash_fid = Some(fid);
+    }
+
+    pub(crate) fn set_hash_hash_fid(&mut self, fid: FuncId) {
+        self.hash_hash_fid = Some(fid);
+    }
+
+    ///
+    /// Whether the Array / Hash `obj` still resolves `:hash` to its
+    /// builtin structural implementation, so the native digest may be
+    /// used without a dispatch. A singleton (mock), a subclass override,
+    /// or a monkey-patched `#hash` makes this false and the caller
+    /// dispatches instead — the mock-count specs pin exactly one `#hash`
+    /// call per probe. Like `has_builtin_identity_hash`, the probe
+    /// behind `check_method` is cached on the class version.
+    ///
+    pub(crate) fn has_builtin_container_hash(&self, obj: Value, ty: ObjTy) -> bool {
+        let builtin = match ty {
+            ObjTy::ARRAY => self.array_hash_fid,
+            ObjTy::HASH => self.hash_hash_fid,
+            _ => return false,
+        };
+        match (builtin, self.check_method(obj, IdentId::HASH)) {
+            (Some(builtin), Some(found)) => builtin == found,
+            _ => false,
+        }
     }
 
     ///

--- a/monoruby/src/parser/prism_backend.rs
+++ b/monoruby/src/parser/prism_backend.rs
@@ -57,25 +57,50 @@ pub(super) fn parse_program(code: Vec<u8>, path: PathBuf) -> Result<ParseResult,
 }
 
 pub(super) fn parse_program_eval(
-    code: Vec<u8>,
+    mut code: Vec<u8>,
     path: PathBuf,
     extern_context: Option<&ExternalContext>,
-    line_offset: i64,
+    mut line_offset: i64,
     default_encoding: Option<String>,
 ) -> Result<ParseResult, MonorubyErr> {
+    inject_encoding_comment(&mut code, &default_encoding, &mut line_offset);
     let options = build_prism_options(extern_context, None, line_offset);
     try_prism_inner(&code, path, Some(options), None, line_offset, default_encoding, false)
 }
 
+/// CRuby lexes an eval source in the string's *own* encoding. The
+/// vendored ruby-prism wrapper does not expose
+/// `pm_options_encoding_set`, but prism honours a `# encoding:` magic
+/// comment natively, so a non-UTF-8 eval source that doesn't carry its
+/// own directive gets one injected — with the line option shifted so
+/// every reported line number stays where CRuby puts it.
+fn inject_encoding_comment(
+    code: &mut Vec<u8>,
+    default_encoding: &Option<String>,
+    line_offset: &mut i64,
+) {
+    let Some(enc) = default_encoding else { return };
+    if enc.eq_ignore_ascii_case("UTF-8") || enc.eq_ignore_ascii_case("US-ASCII") {
+        return;
+    }
+    if detect_source_encoding(code).is_some() {
+        return;
+    }
+    let header = format!("# encoding: {enc}\n");
+    code.splice(0..0, header.into_bytes());
+    *line_offset -= 1;
+}
+
 pub(super) fn parse_program_binding(
-    code: Vec<u8>,
+    mut code: Vec<u8>,
     path: PathBuf,
     context: Option<LvarCollector>,
     extern_context: Option<&ExternalContext>,
-    line_offset: i64,
+    mut line_offset: i64,
     default_encoding: Option<String>,
     main_script: bool,
 ) -> Result<ParseResult, MonorubyErr> {
+    inject_encoding_comment(&mut code, &default_encoding, &mut line_offset);
     let options = build_prism_options(extern_context, context.as_ref(), line_offset);
     try_prism_inner(
         &code,
@@ -101,7 +126,7 @@ fn build_prism_options(
     // Prism's `line` is 1-indexed. monoruby tracks an offset
     // (`lineno - 1`) at the call sites in `globals.rs`, so the
     // wire-format we want is `line_offset + 1`.
-    let line = line_offset.saturating_add(1).clamp(1, i32::MAX as i64) as i32;
+    let line = line_offset.saturating_add(1).clamp(0, i32::MAX as i64) as i32;
 
     let mut scopes: Vec<prism::Scope> = Vec::new();
 

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -391,15 +391,18 @@ impl RubyHash<Executor, Globals, MonorubyErr> for Value {
                     ObjTy::BIGNUM => lhs.as_bignum().hash(state),
                     ObjTy::FLOAT => lhs.as_float().to_bits().hash(state),
                     ObjTy::STRING => lhs.as_rstring().hash(state),
-                    // Only a *true* Array / Hash uses the native
-                    // structural hash. `Set` is `ObjTy::HASH` with class
-                    // `Set` and a Ruby-level, order-independent
-                    // `Set#hash` (and a Hash subclass may override
-                    // `#hash`); those fall through to the Ruby `#hash`
-                    // dispatch in the `_` arm so e.g. `Set[1,3]` and
-                    // `Set[3,1]` hash equal and compare as set members.
-                    ObjTy::ARRAY | ObjTy::HASH
-                        if lhs.ty() == ObjTy::ARRAY || lhs.class() == HASH_CLASS =>
+                    // The native structural hash applies only while the
+                    // object's `:hash` still resolves to the builtin
+                    // identity `Kernel#hash` (a class-version-cached
+                    // probe): a singleton/mock or monkey-patched `#hash`
+                    // on an Array or Hash key must be dispatched — the
+                    // mock-count specs pin exactly one `#hash` call per
+                    // probe. `Set` (`ObjTy::HASH` with a Ruby-level,
+                    // order-independent `Set#hash`) falls through the
+                    // same way, so e.g. `Set[1,3]` and `Set[3,1]` hash
+                    // equal and compare as set members.
+                    ty @ (ObjTy::ARRAY | ObjTy::HASH)
+                        if g.store.has_builtin_container_hash(*self, ty) =>
                     {
                         let id = self.id();
                         let is_recursive =


### PR DESCRIPTION
## Summary

Works through the remaining ruby/spec failures in core/array, core/hash, core/file and core/filetest (fresh ruby/spec master), from a classified survey of all 13 residual items. **core/array (2898 examples) and core/filetest now pass clean**; core/hash and core/file are down to the two known representation-level items (non-UTF-8 symbol bytes, Time range).

## Commits

### `random: one CRuby-exact Mersenne Twister for the global PRNG`

The global PRNG behind `Kernel#srand` / `#rand` / `Random.rand` / `Random.bytes` was a `rand_mt::Mt` seeded with the seed's low 32 bits and drawn through rand's generic f64 distribution — none of its streams matched CRuby, and `Array#shuffle!` didn't even use it (it drew from the OS thread RNG, ignoring `srand` entirely). The reference MT19937 that `Random` instances already carried moves into `globals::prng` and both RNGs now share one machinery:

- seeding feeds **every word** of the seed (CRuby `rand_init`: `init_genrand` / `init_by_array`)
- `Kernel#rand` draws exactly like CRuby: `rb_random_ulong_limited` for integer maxima and integer ranges (no float-scaling bias), 53-bit `genrand_real` for floats, `int_pair_to_real_inclusive` for *inclusive* float ranges, and the multi-word `rand_int` path for Bignum maxima (`rand(2**80)` raised RangeError before)
- `Random.bytes` follows `rb_rand_bytes`' little-endian word protocol

Result: `srand(42)`-seeded `rand` / `rand(n)` / `rand(bignum)` / `rand(range)` / `shuffle` / `sample` / `Random.rand` / `Random.bytes` streams are **bit-identical to CRuby 4.0.2**.

### `ruby/spec conformance: array/hash/file fixes from the residual sweep`

- `Hash#transform_keys(!)`: an explicitly passed mapping — nil included — goes through implicit `to_hash` conversion and raises TypeError (CRuby `rb_to_hash_type`); only an absent argument returns the Enumerator
- `Array#initialize` with a block fills the receiver incrementally, so a `break` keeps the values produced so far
- the sort comparator interpreter reads a Bignum result's sign directly like `rb_cmpint` — a redefined `Integer#<=>` can't interfere with `sort { (n-m) * 2**200 }`
- `Array#shuffle!` runs Fisher-Yates off the seeded global PRNG with CRuby's `RAND_UPTO` draw; `srand(123); ary.shuffle` reproduces CRuby's sequence
- `Array#flatten`'s element probe follows `rb_check_funcall` exactly: a user-redefined `respond_to?` gates everything, a user-defined `respond_to_missing?` gates the missing-dispatch, a user-defined `method_missing` is consulted with `:to_ary`, and a NoMethodError it raises is re-raised only when the object claimed to respond
- Errno messages keep a non-UTF-8 path's exact bytes: `MonorubyErr` grows a `raw_message` and `Exception#to_s` (now a real method on Exception, as in CRuby) materializes it as an ASCII-8BIT string, so `File.stat(binary_path)`'s ENOENT message contains the path verbatim
- the "given block not used" / "block supersedes default value argument" warnings carry the caller's `file:line:` prefix (`rb_warn`)

### `hash: dispatch a redefined #hash on Array / Hash keys`

`Value::ruby_hash` used the native structural digest for every true Array, so a singleton `#hash` on an Array key (ruby/spec's mock in "Hash#[]= stores unequal keys that hash to the same value") was never called. The native arm is now gated on the key still resolving `:hash` to its builtin structural implementation (`Array#hash` / `Hash#hash` FuncIds recorded at registration, probe cached on the class version); a singleton, subclass override or monkey-patch dispatches instead, observing exactly one `#hash` call per probe. A plain Hash subclass now also digests structurally (inheriting `Hash#hash`, as CRuby) instead of falling back to the identity hash.

### `eval: lex a non-UTF-8 source in its own encoding`

monoruby fed eval strings to prism as-is; prism assumes UTF-8 and rejected e.g. a Windows-31J source with "invalid multibyte character". The vendored ruby-prism wrapper doesn't expose `pm_options_encoding_set`, but prism honours a `# encoding:` magic comment natively (non-UTF-8 *files* already parse through exactly that), so `parse_program_eval` / `parse_program_binding` inject one for a non-UTF-8 eval source without its own directive and shift the prism line option by one — `eval("__LINE__")`, explicit lineno arguments and SyntaxError locations all stay where CRuby puts them.

## Remaining (tracked, representation-level)

- core/hash 1 F: the sjis inspect round-trip — the interned symbol table stores identifiers as UTF-8 Rust strings, which lossily converts non-UTF-8 symbol literals; needs byte-preserving symbols
- core/file 2 E: `Time.at(1<<44)` (year ~559444) exceeds the chrono-backed Time range (±262143 years); needs a wider internal representation

## Verification

- Full monoruby lib suite green at every step (2273 tests)
- Final sweep: core/array **0F 0E** (2898 examples), core/filetest **0F 0E**, core/hash 1F (above), core/file 2E (above)
- No collateral change in core/set, core/random, core/kernel (rand/srand/loop — 18k expectations in rand_spec), core/enumerator, core/exception, core/file/stat, language (all observed diffs bisected to pre-existing master behavior)
- RNG streams compared against CRuby 4.0.2 output byte-for-byte across srand/shuffle/rand-variants/Random.rand/Random.bytes/sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_