### PR TITLE
tests: de-flake the thread sleep/interleave assertions

### DIFF
--- a/monoruby/src/builtins/thread.rs
+++ b/monoruby/src/builtins/thread.rs
@@ -928,7 +928,7 @@ mod tests {
             watcher = Thread.new do
               res = Thread.list.map { |th| th.backtrace.class.to_s }
             end
-            sleep 0.1
+            watcher.join
             res
             "#,
         );
@@ -977,14 +977,32 @@ mod tests {
 
     #[test]
     fn thread_sleep_interleaves_with_main() {
+        // The interleave is enforced by handshakes, not by racing two
+        // timers: the old shape (`sleep 0.05` in the thread vs `sleep
+        // 0.01` in main) flaked on loaded CI runners whenever either
+        // side overslept past the other, on the CRuby reference run as
+        // much as on monoruby. Reaching `status == "sleep"` proves the
+        // first leg ran and the thread is parked; `v << 2` lands while
+        // it sleeps (the property under test); `wakeup` resumes it
+        // deterministically.
         run_test_once(
             r#"
             v = []
-            t = Thread.new { v << 1; sleep 0.05; v << 3 }
-            sleep 0.01   # let t run its first leg
+            t = Thread.new { v << 1; sleep; v << 3 }
+            Thread.pass while t.status != "sleep"
             v << 2
+            t.wakeup
             t.join
             v
+            "#,
+        );
+        // A *timed* sleep expires on its own — no ordering asserted, so
+        // no load sensitivity: `join` waits however long the runner
+        // takes, and only the resumption is checked.
+        run_test_once(
+            r#"
+            t = Thread.new { sleep 0.01; :woke }
+            t.value
             "#,
         );
     }


### PR DESCRIPTION
`thread_sleep_interleaves_with_main` raced two timers — `sleep 0.05` in the thread against `sleep 0.01` in main — and asserted the resulting order. On a loaded CI runner either side can oversleep past the other, and **the CRuby reference run flakes exactly as easily as monoruby**: the recorded darwin failures were CRuby itself producing `[1, 3, 2]`.

## The fix: handshakes instead of durations

```ruby
v = []
t = Thread.new { v << 1; sleep; v << 3 }
Thread.pass while t.status != "sleep"   # first leg ran, thread parked
v << 2                                   # lands while t sleeps — the property under test
t.wakeup                                 # deterministic resume
t.join
v
```

* Reaching `status == "sleep"` proves the thread ran its first leg and parked (the busy-wait pattern `thread_status_and_pass` already uses).
* Timed-sleep expiry keeps its own coverage without any ordering assertion: a thread sleeps 0.01 and `value` merely proves it woke — `join` waits however long the runner takes.
* `thread_status_and_pass`'s watcher case had the same latent shape (main slept 0.1 and read a result the watcher was still free to be computing), so it now joins the watcher.

## Verified

* Both tests survive **40 consecutive runs plus 20 runs with every core saturated** by busy loops — the load profile that killed the old shape.
* Full suite green on x86-64 (3298 passed, 0 failed).

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_