### PR TITLE
CI: bump the ruby/spec pin past the object_id-based frozen-string fixture

### DIFF
--- a/.github/workflows/darwin-hang-debug.yml
+++ b/.github/workflows/darwin-hang-debug.yml
@@ -69,7 +69,7 @@ jobs:
         run: git clone https://github.com/mame/optcarrot.git ../optcarrot
       - name: Clone ruby/spec and mspec (pinned)
         env:
-          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          SPEC_REV: 87b1631992bd00cf0c4934474766d54dad088191
           MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
         run: |
           git init ../spec

--- a/.github/workflows/gc-stress.yml
+++ b/.github/workflows/gc-stress.yml
@@ -163,7 +163,7 @@ jobs:
         if: inputs.scope == 'full'
         # Same pinned revisions as the automatic workflow — keep in sync.
         env:
-          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          SPEC_REV: 87b1631992bd00cf0c4934474766d54dad088191
           MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
         run: |
           git init ../spec

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
         # upstream spec that monoruby doesn't pass yet would fail the whole run.
         # Bump these SHAs deliberately when adopting newer specs.
         env:
-          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          SPEC_REV: 87b1631992bd00cf0c4934474766d54dad088191
           MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
         run: |
           git init ../spec
@@ -126,7 +126,7 @@ jobs:
         # Pinned to fixed commits so upstream ruby/spec changes can't break CI.
         # Keep these SHAs in sync with the `amd64` job above; bump deliberately.
         env:
-          SPEC_REV: baf5738ada1709afdbcf222c7609d3379b9d211d
+          SPEC_REV: 87b1631992bd00cf0c4934474766d54dad088191
           MSPEC_REV: dffcdf7d00612c13465983224203e457a30cf124
         run: |
           git init ../spec


### PR DESCRIPTION
## Problem

The first full-scope gc-stress run to get through optcarrot ([run 31552523169](https://github.com/sisshiki1969/monoruby/actions/runs/31552523169), after #1093 and #1099) failed at the very end, in ruby/spec `command_line`, identically on both arches. Everything before it was green — nextest 3095 passed, all benchmarks and both optcarrot runs `identical` to CRuby — and then:

```
The --disable-frozen-string-literal flag causes string literals to produce a different object each time FAILED
Expected "true" == "false"
```

## Root cause

At the pinned ruby/spec revision (`baf5738a`, 2026-06-04) the fixture is:

```ruby
ids = Array.new(2) { "abc".object_id }
p ids.first == ids.last
```

It keeps only the object_ids — the first `"abc"` is garbage by the time the second allocates. monoruby's `object_id` is the Value bits (the heap address), so under per-safepoint collection the freed slot is recycled for the second string and the two ids compare equal → `"true"`. CRuby 4 is immune only because its `object_id` has been a never-reused monotonic serial since 2.7. Ordinary runs never collect between the two block calls, which is why the automatic CI stays green on the same pin — this only surfaces under gc-stress.

Upstream ruby/spec has since rewritten the fixture to hold both strings and compare with `#equal?`, which tests what the spec actually means and is GC-safe:

```ruby
ids = Array.new(2) { "abc" }
p ids.first.equal? ids.last
```

## Change

Bump `SPEC_REV` to current upstream master (`87b16319`, 2026-07-26) in all three workflows that pin it — `rust.yml` (both jobs), `gc-stress.yml`, `darwin-hang-debug.yml` (the "keep in sync" pins). `MSPEC_REV` is unchanged.

## Verification (local, gc-stress build — the strictest consumer)

- Old fixture reproduces the CI failure deterministically (`true`); CRuby prints `false`.
- New fixture passes under gc-stress.
- All 22 ruby/spec categories that `bin/test` runs, at the new revision, under per-safepoint collection: `command_line` 175 examples and the other 21 categories 3,777 examples — **0 failures, 0 errors**, including the churn between the two pins (29 changed files, mostly aliased-method spec cleanups).

This closes out the third and last blocker for the full-scope gc-stress run (after the `Array#flat_map` rooting fix #1093 and the optcarrot frame cap #1099). Re-dispatching the gc-stress workflow with `scope=full` after this merges should now complete end to end.

A follow-up worth considering separately: making monoruby's `object_id` a CRuby-2.7+-style never-reused serial, so identity survives address recycling for code that stores ids across GC cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_