### PR TITLE
JIT: inline-allocate the empty Array literal []

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1604,7 +1604,7 @@ impl Codegen {
         );
     }
 
-    /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
+    /// Inline allocation of a small (`0..=ARRAY_INLINE_CAPA`) no-splat array
     /// literal: pop a recycled cell from the GC free list and initialise it
     /// directly as an inline-storage Array, falling back to the runtime
     /// `gen_array` when the free list is empty. See the x86_64

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1124,7 +1124,7 @@ impl Codegen {
         }
     }
 
-    /// Inline allocation of a small (`1..=ARRAY_INLINE_CAPA`) no-splat array
+    /// Inline allocation of a small (`0..=ARRAY_INLINE_CAPA`) no-splat array
     /// literal: pop a recycled cell from the GC free list and initialise it
     /// directly as an inline-storage Array, with no runtime call. When the
     /// free list is empty, fall back to the runtime `gen_array` (which also

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2041,10 +2041,11 @@ pub(super) enum AsmInst {
     },
     NewArray {
         callid: CallSiteId,
-        /// `Some((args, len))` when the literal has no splat and `1 <= len <=
-        /// ARRAY_INLINE_CAPA`, enabling the JIT inline free-list fast path
-        /// (elements live in consecutive slots starting at `args`). `None`
-        /// falls back to the runtime `gen_array` call.
+        /// `Some((args, len))` when the literal has no splat and `len <=
+        /// ARRAY_INLINE_CAPA` (0 = the empty literal `[]`), enabling the JIT
+        /// inline free-list fast path (elements live in consecutive slots
+        /// starting at `args`). `None` falls back to the runtime `gen_array`
+        /// call.
         inline: Option<(SlotId, u16)>,
         using_fpr: UsingFpr,
     },

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -363,10 +363,11 @@ impl<'a> JitContext<'a> {
                 state.discard(dst);
                 let using_fpr = state.get_using_fpr(ir);
                 // A no-splat literal whose length fits the array's inline
-                // storage can be allocated inline from the free list, with no
-                // runtime call. Otherwise fall back to `gen_array`.
+                // storage (including the empty literal `[]`) can be allocated
+                // inline from the free list, with no runtime call. Otherwise
+                // fall back to `gen_array`.
                 let inline = if self.store[callid].splat_pos.is_empty()
-                    && (1..=ARRAY_INLINE_CAPA).contains(&pos_num)
+                    && pos_num <= ARRAY_INLINE_CAPA
                 {
                     Some((args, pos_num as u16))
                 } else {

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -270,6 +270,42 @@ fn literal_regexp_format() {
 }
 
 #[test]
+fn empty_array_literal() {
+    // `[]` is inline-allocated by the JIT (no runtime call) like other
+    // small no-splat literals. Every evaluation must yield a fresh,
+    // independent, unfrozen Array — mutations must not leak between
+    // iterations.
+    run_test(
+        r#"
+        res = []
+        20.times do |i|
+            a = []
+            a << i
+            res << a << a.size << a.class.to_s << a.frozen?
+        end
+        res
+        "#,
+    );
+    // Same via a hot method, plus identity: two evaluations are distinct
+    // objects, and the empty literal behaves like Array.new (capa = 0
+    // inline representation).
+    run_test(
+        r#"
+        def m = []
+        r = []
+        20.times do
+            a = m
+            b = m
+            r << a.equal?(b) << (a == b) << a.empty? << (a == Array.new)
+            a.push(1, 2, 3, 4, 5, 6)
+            r << a << b
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
 fn command_literal_frozen_argument() {
     // A non-interpolated command literal (`` `cmd` `` / `%x{...}`) passes its
     // command string to `Kernel#\`` FROZEN, matching CRuby (regardless of any


### PR DESCRIPTION
## Summary

The JIT's inline free-list fast path for no-splat Array literals was gated on `1..=ARRAY_INLINE_CAPA` elements, so the empty literal `[]` always fell back to the runtime `gen_array` call — making a hot `a = []` slower than `a = [x]`. This widens the gate to `0..=ARRAY_INLINE_CAPA`.

## Why this is safe with no backend changes

With `len = 0` the element-copy loop in `new_array_inline` simply vanishes: the emitted code writes the object header, `var_table = None`, and `capa = 0` — bit-for-bit the same cell image `ArrayInner::new()` (an inline `SmallVec` of length 0) produces. Both the x86_64 and aarch64 backends already handle this unchanged; only their doc comments are updated. The GC-safety argument is the array-literal one that already holds: a newborn object needs no write barrier and there is no safepoint between the free-list pop and field initialisation.

## Changes

- `jitgen/compile.rs` — widen the inline gate from `(1..=ARRAY_INLINE_CAPA)` to `pos_num <= ARRAY_INLINE_CAPA`
- `jitgen/asmir.rs`, `arch/{x86_64,aarch64}/compile/mod.rs` — comment updates only
- `tests/literal.rs` — new `empty_array_literal` test: a hot-loop and a hot-method `[]` must each yield a fresh, independent, unfrozen Array equal to `Array.new`, including a push past the inline capacity (spill transition), all compared against CRuby

## Benchmark

50M-iteration `a = []` loop (release, x86-64): median 0.648s → 0.603s (**~7% faster**). Modest because the empty case was already an early return inside `gen_array`; the win is the removed call/branch overhead, plus `[]` no longer being the one literal shape excluded from the inline path.

## Verification

- `cargo nextest run`: 3113 / 3113 passed
- New test passes standalone as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_