### PR TITLE
JIT: inline-allocate small Hash literals

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1678,12 +1678,23 @@ impl Codegen {
         true
     }
 
+    /// x0 <- Hash literal from the `len` key/value slots at `args`.
     pub(in crate::codegen::jitgen) fn emit_new_hash(
         &mut self,
         args: SlotId,
         len: usize,
         using_fpr: UsingFpr,
     ) -> bool {
+        if len <= HASH_INLINE_CAP && !self.alloc_free_head_addr.is_null() {
+            self.new_hash_inline(args, len, using_fpr);
+        } else {
+            self.new_hash_runtime(args, len, using_fpr);
+        }
+        true
+    }
+
+    /// x0 <- Hash literal via gen_hash(vm, globals, &slot[args], len).
+    fn new_hash_runtime(&mut self, args: SlotId, len: usize, using_fpr: UsingFpr) {
         let lfp = GP::R14.a64().0;
         let off = args.0 as u32 * 8 + LFP_SELF as u32;
         let f = runtime::gen_hash as *const () as u64;
@@ -1701,7 +1712,83 @@ impl Codegen {
             ldr x30, [sp], #16;
         );
         self.emit_fpr_restore(using_fpr, false);
-        true
+    }
+
+    /// Inline allocation of a small (`0..=HASH_INLINE_CAP` pairs) Hash
+    /// literal: pop a recycled cell from the GC free list and initialise it
+    /// directly as an inline-representation Hash, with no runtime call.
+    /// Fast-path conditions and the correctness argument (packed distinct
+    /// keys — eql? is bit equality, no observable `#hash`; nil-nil
+    /// placeholder pairs; young object needs no write barrier; no GC
+    /// safepoint mid-build) are documented on the x86_64
+    /// `new_hash_inline`; anything else falls back to `gen_hash`.
+    fn new_hash_inline(&mut self, args: SlotId, len: usize, using_fpr: UsingFpr) {
+        let rax = GP::Rax.a64().0; // x0 (result)
+        let lfp = GP::R14.a64().0; // x22
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        if len > 0 {
+            // x9 = packed-value mask (`Value::is_packed_value`: heap iff
+            // (bits & 0b111) == 0; monoasm's `and` is register-only).
+            monoasm_arm64!(&mut self.jit,
+                mov x9, #7;
+            );
+            for i in 0..len {
+                let key = SlotId(args.0 + 2 * i as u16);
+                self.a64_frame_load(12, lfp, conv(key) as u32);
+                monoasm_arm64!(&mut self.jit,
+                    and x11, x12, x9;
+                    cbz x11, slow;
+                );
+            }
+            for j in 1..len {
+                for i in 0..j {
+                    let ki = SlotId(args.0 + 2 * i as u16);
+                    let kj = SlotId(args.0 + 2 * j as u16);
+                    self.a64_frame_load(11, lfp, conv(ki) as u32);
+                    self.a64_frame_load(12, lfp, conv(kj) as u32);
+                    monoasm_arm64!(&mut self.jit,
+                        cmp x11, x12;
+                    );
+                    self.jit.bcond_label(monoasm::Cond::Eq, &slow);
+                }
+            }
+        }
+        // 8-byte object header: flag=1 | ty=HASH<<16 | rep(len)<<24 |
+        // class=HASH_CLASS<<32 (the ty_flags byte holds the inline
+        // representation bits: pair count, eql?-keyed).
+        let header: u64 = ((HASH_CLASS.u32() as u64) << 32)
+            | ((len as u64) << 24)
+            | ((ObjTy::HASH.get() as u64) << 16)
+            | 1;
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
+        monoasm_arm64!(&mut self.jit,
+            mov x12, #0;
+            str x12, [x(rax), #(RVALUE_OFFSET_VAR as u32)]; // var_table = None
+        );
+        for i in 0..HASH_INLINE_CAP {
+            let pair = HASH_INLINE_PAIRS_OFFSET + i * HASH_INLINE_PAIR_STRIDE;
+            let key_off = (pair + HASH_INLINE_KEY_OFFSET) as u32;
+            let val_off = (pair + HASH_INLINE_VALUE_OFFSET) as u32;
+            if i < len {
+                let key = SlotId(args.0 + 2 * i as u16);
+                let val = SlotId(args.0 + 2 * i as u16 + 1);
+                self.a64_frame_load(12, lfp, conv(key) as u32);
+                self.a64_field_store(12, rax, key_off);
+                self.a64_frame_load(12, lfp, conv(val) as u32);
+                self.a64_field_store(12, rax, val_off);
+            } else {
+                monoasm_arm64!(&mut self.jit,
+                    mov x12, (NIL_VALUE as u64);
+                );
+                self.a64_field_store(12, rax, key_off);
+                self.a64_field_store(12, rax, val_off);
+            }
+        }
+        monoasm_arm64!(&mut self.jit, b cont;);
+        self.jit.bind_label(slow);
+        self.new_hash_runtime(args, len, using_fpr);
+        self.jit.bind_label(cont);
     }
 
     /// rax <- the Hash in `hash` after inserting the `len` key/value pairs

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1178,8 +1178,97 @@ impl Codegen {
         len: usize,
         using_fpr: UsingFpr,
     ) -> bool {
-        self.new_hash(args, len, using_fpr);
+        if len <= HASH_INLINE_CAP && !self.alloc_free_head_addr.is_null() {
+            self.new_hash_inline(args, len, using_fpr);
+        } else {
+            self.new_hash(args, len, using_fpr);
+        }
         true
+    }
+
+    /// Inline allocation of a small (`0..=HASH_INLINE_CAP` pairs) Hash
+    /// literal: pop a recycled cell from the GC free list and initialise it
+    /// directly as an inline-representation Hash, with no runtime call.
+    ///
+    /// The fast path requires every key to be a packed immediate — for
+    /// those eql? is exactly bit equality and no `#hash` dispatch is
+    /// observable (see `is_inline_key`) — and the keys to be pairwise
+    /// distinct (a duplicate needs last-wins overwrite). Anything else
+    /// (heap keys with their `frozen_hash_key` and user-`#hash` protocol,
+    /// duplicates, an empty free list) falls back to the runtime
+    /// `gen_hash`, which the following `handle_error` already covers; on
+    /// the fast path no error is possible.
+    ///
+    /// The pairs have been written back to consecutive slots (key0, val0,
+    /// key1, …) starting at `args` (see `TraceIr::Hash`). Unused inline
+    /// pairs are written nil-nil, per the `HashBody::inline` contract that
+    /// the whole payload stays initialised. A freshly allocated young Hash
+    /// needs no write barrier and there is no GC safepoint between the
+    /// free-list pop and the field initialisation (same argument as
+    /// `new_array_inline`).
+    fn new_hash_inline(&mut self, args: SlotId, len: usize, using_fpr: UsingFpr) {
+        let slow = self.jit.label();
+        let cont = self.jit.label();
+        for i in 0..len {
+            let key = SlotId(args.0 + 2 * i as u16);
+            // Heap iff (bits & 0b111) == 0 (`Value::is_packed_value`).
+            monoasm! { &mut self.jit,
+                movq rax, [rbp - (rbp_local(key))];
+                andq rax, 0b111;
+                jz   slow;
+            }
+        }
+        for j in 1..len {
+            for i in 0..j {
+                let ki = SlotId(args.0 + 2 * i as u16);
+                let kj = SlotId(args.0 + 2 * j as u16);
+                monoasm! { &mut self.jit,
+                    movq rax, [rbp - (rbp_local(ki))];
+                    cmpq rax, [rbp - (rbp_local(kj))];
+                    jeq  slow;
+                }
+            }
+        }
+        // 8-byte object header: flag=1 (live) | ty=HASH<<16 | rep<<24 |
+        // class=HASH_CLASS<<32. The ty_flags byte (bits 24-31) carries the
+        // inline representation: rep = pair count, eql?-keyed, no live
+        // iteration, no ruby2_keywords.
+        let header: u64 = ((HASH_CLASS.u32() as u64) << 32)
+            | ((len as u64) << 24)
+            | ((ObjTy::HASH.get() as u64) << 16)
+            | 1;
+        self.emit_alloc_cell(CellHeader::Imm(header), &slow);
+        monoasm! { &mut self.jit,
+            movq [rax + (RVALUE_OFFSET_VAR)], 0;      // var_table = None
+        }
+        for i in 0..HASH_INLINE_CAP {
+            let pair = HASH_INLINE_PAIRS_OFFSET + i * HASH_INLINE_PAIR_STRIDE;
+            let key_off = (pair + HASH_INLINE_KEY_OFFSET) as i32;
+            let val_off = (pair + HASH_INLINE_VALUE_OFFSET) as i32;
+            if i < len {
+                let key = SlotId(args.0 + 2 * i as u16);
+                let val = SlotId(args.0 + 2 * i as u16 + 1);
+                monoasm! { &mut self.jit,
+                    movq rcx, [rbp - (rbp_local(key))];
+                    movq [rax + (key_off)], rcx;
+                    movq rcx, [rbp - (rbp_local(val))];
+                    movq [rax + (val_off)], rcx;
+                }
+            } else {
+                monoasm! { &mut self.jit,
+                    movq [rax + (key_off)], (NIL_VALUE);
+                    movq [rax + (val_off)], (NIL_VALUE);
+                }
+            }
+        }
+        monoasm! { &mut self.jit,
+            jmp  cont;
+        slow:
+        }
+        self.new_hash(args, len, using_fpr);
+        monoasm! { &mut self.jit,
+        cont:
+        }
     }
 
     /// rax <- min/max of the `len` values at `args`, computed in place —

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2050,7 +2050,10 @@ pub(super) enum AsmInst {
         using_fpr: UsingFpr,
     },
     ///
-    /// Create a new Hash object and store it to *rax*
+    /// Create a new Hash object and store it to *rax*. The backends
+    /// inline-allocate a literal of `0..=HASH_INLINE_CAP` pairs (guarded at
+    /// runtime on packed, pairwise-distinct keys) and fall back to the
+    /// `gen_hash` runtime call otherwise.
     ///
     NewHash(SlotId, usize, UsingFpr),
     ///

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -80,6 +80,10 @@ pub(crate) const INLINE_CAP: usize = 3;
 pub const HASH_REP_MASK: u8 = REP_MASK;
 pub const HASH_REP_BOXED: u8 = REP_BOXED;
 
+/// Max pairs the inline representation holds — the gate for the JIT's
+/// inline-allocated Hash literal fast path.
+pub const HASH_INLINE_CAP: usize = INLINE_CAP;
+
 /// The inline pair array, addressed from the start of the `RValue`.
 pub const HASH_INLINE_PAIRS_OFFSET: usize = RVALUE_OFFSET_KIND;
 pub const HASH_INLINE_PAIR_STRIDE: usize = std::mem::size_of::<(Value, Value)>();

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -306,6 +306,74 @@ fn empty_array_literal() {
 }
 
 #[test]
+fn small_hash_literal() {
+    // `{}` and 1..=3-pair literals with packed keys are inline-allocated
+    // by the JIT; every evaluation must yield a fresh, independent,
+    // unfrozen Hash with insertion order preserved.
+    run_test(
+        r#"
+        res = []
+        20.times do |i|
+            h = {}
+            h[:k] = i
+            g = {a: 1, b: i}
+            res << h << h.size << g << g.keys << g.values << g.frozen? << (h == {k: i})
+        end
+        res
+        "#,
+    );
+    // Growth past the inline capacity (promotion to the boxed map),
+    // reads on a literal-built hash, and independence of two evaluations.
+    run_test(
+        r#"
+        def m(i) = {a: i, b: 2, c: 3}
+        r = []
+        20.times do |i|
+            h = m(i)
+            x = m(-1)
+            h[:d] = 4
+            h[:e] = 5
+            r << h.size << h.keys << h[:a] << x.size << h.equal?(x)
+        end
+        r
+        "#,
+    );
+    // Runtime-duplicate keys (undetectable at bytecode-gen time) must
+    // take the fallback and keep last-wins semantics; flonum and mixed
+    // packed key kinds stay on the fast path.
+    run_test(
+        r#"
+        x = 1
+        r = []
+        20.times do |i|
+            d = {x => :a, 1 => :b, i => :c}
+            f = {1.5 => 1, 2.5 => i}
+            m = {nil => 1, true => 2, :sym => i}
+            r << d << d.size << f << m << m[true]
+        end
+        r
+        "#,
+    );
+    // Heap (String) keys fall back to the runtime path, which dups and
+    // freezes the key (`frozen_hash_key`), exactly like the interpreter.
+    // An inline-allocated `{}` must also interoperate with `default=`
+    // (which promotes to the boxed representation).
+    run_test(
+        r#"
+        r = []
+        20.times do |i|
+            s = "k#{i % 2}"
+            h = {s => i, "lit" => 1}
+            e = {}
+            e.default = i
+            r << h << h.keys.map(&:frozen?) << h[s] << e[:missing] << e.size
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
 fn command_literal_frozen_argument() {
     // A non-interpolated command literal (`` `cmd` `` / `%x{...}`) passes its
     // command string to `Kernel#\`` FROZEN, matching CRuby (regardless of any


### PR DESCRIPTION
## Summary

Hash literals had no JIT fast path at all — `{}` and `{a: 1}` alike went through the `gen_hash` runtime call, which builds a `HashmapInner` with a per-pair `insert` (compact check, iteration check, linear probe) and then allocates the cell. This PR inline-allocates a literal of `0..=HASH_INLINE_CAP` (3) pairs in machine code, the Hash counterpart of the Array literal inline path (#1106), on both x86_64 and aarch64.

## How

The Hash inline representation (up to 3 pairs in the 48-byte cell payload, representation bits in the header's `ty_flags` byte) makes this a plain cell initialisation:

- **Runtime guards first** (skipped for `{}`): every key must be a **packed immediate** — for those `eql?` is exactly bit equality and no `#hash` dispatch is observable (`is_inline_key`'s own correctness argument) — and the keys must be **pairwise distinct** (a duplicate needs last-wins overwrite). At most 3 packed tests + 3 compares.
- **Then** `emit_alloc_cell` with the header immediate carrying `rep = len` in the `ty_flags` byte — the representation costs zero extra instructions — followed by `var_table = None`, the pairs copied from their slots, and nil-nil placeholders in the unused pairs (the `HashBody::inline` contract that the whole payload stays initialised).
- **Fallback** to the existing `gen_hash` call for heap keys (their `frozen_hash_key` dup+freeze and user-`#hash` protocol), runtime-duplicate keys, and free-list exhaustion / bump-limit. The existing `handle_error` after `NewHash` still covers the slow path; the fast path cannot raise.

GC safety is the `new_array_inline` argument unchanged: a newborn object needs no write barrier and there is no safepoint between the free-list pop and field initialisation.

`HASH_INLINE_CAP` is newly exported from `hash.rs` alongside the other JIT layout constants. No IR changes: `TraceIr::Hash` carries no splat (splatted literals compile to `merge!` calls), so each backend decides inline eligibility from `len` alone.

## Benchmark

20M-iteration loops (release, x86-64):

| literal | master | this PR | speedup |
|---|---|---|---|
| `h = {}` | 0.58–0.62s | 0.26s | **~2.3×** |
| `h = {a: 1, b: 2, c: i}` | 0.99–1.05s | 0.27s | **~3.7×** |

## Tests

New `small_hash_literal` in `tests/literal.rs` (all compared against CRuby, JIT-warmed):

- `{}` / 2-pair literals in a hot loop: fresh, independent, unfrozen, insertion order preserved
- growth past the inline capacity (promotion to the boxed map) and object identity across evaluations
- **runtime-duplicate keys** (undetectable at bytecode-gen time) taking the fallback with last-wins semantics; flonum / nil / true / symbol keys on the fast path
- String keys falling back (keys dup'd + frozen like the interpreter) and an inline-allocated `{}` interoperating with `default=` (boxed promotion)

## Verification

- `cargo nextest run`: 3114 / 3114 passed
- ruby/spec `core/hash`: 562 examples, the single failure (`inspect` under a changed `Encoding.default_external`) reproduces identically on master — pre-existing, unrelated
- aarch64 backend type-checked via `cargo check --target aarch64-unknown-linux-gnu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_