### PR TITLE
JIT: inline String#<< byte appends and fast-path plain trailing-splat calls

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1098,7 +1098,7 @@ fn hash_get_or_key(
     state.load(ir, callsite.recv, GP::Rdx);
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
-    ir.inline(|r#gen, _, _, _| r#gen.emit_hash_index(hashgetorkey as *const () as u64));
+    ir.inline(|r#gen, _, _, _| r#gen.emit_call_2args(hashgetorkey as *const () as u64));
     ir.fpr_restore(using_fpr);
     let error = ir.new_error(state);
     ir.handle_error(error);
@@ -1631,7 +1631,7 @@ extern "C" fn hashindex(
 }
 
 /// `Hash#__get_or_key` for the JIT: same ABI as [`hashindex`], so the
-/// inliner reuses `emit_hash_index` with this address. One probe, the
+/// inliner reuses `emit_call_2args` with this address. One probe, the
 /// key itself on a miss, the default never consulted.
 extern "C" fn hashgetorkey(
     vm: &mut Executor,

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1045,7 +1045,7 @@ fn hash_index(
     state.load(ir, callsite.recv, GP::Rdx);
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
-    ir.inline(|r#gen, _, _, _| r#gen.emit_hash_index(hashindex as *const () as u64));
+    ir.inline(|r#gen, _, _, _| r#gen.emit_call_2args(hashindex as *const () as u64));
     ir.fpr_restore(using_fpr);
     let error = ir.new_error(state);
     ir.handle_error(error);

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -50,7 +50,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(STRING_CLASS, ">", gt, 1);
     globals.define_builtin_func(STRING_CLASS, "<=", le, 1);
     globals.define_builtin_func(STRING_CLASS, "<", lt, 1);
-    globals.define_builtin_func(STRING_CLASS, "<<", shl, 1);
+    globals.define_builtin_inline_func(STRING_CLASS, "<<", shl, inline_gen2!(string_shl_gen), 1);
     globals.define_builtin_func(STRING_CLASS, "%", rem, 1);
     globals.define_builtin_func(STRING_CLASS, "=~", match_, 1);
     globals.define_builtin_funcs_with(STRING_CLASS, "[]", &["slice"], index, 1, 2, false);
@@ -775,23 +775,32 @@ fn gt(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 /// [https://docs.ruby-lang.org/ja/latest/method/String/i/=3c=3c.html]
 #[monoruby_builtin]
 fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let mut self_ = lfp.self_val().as_string_mut(vm, globals)?;
-    if let Some(other) = lfp.arg(0).is_rstring() {
+    shl_inner(vm, globals, lfp.self_val(), lfp.arg(0))
+}
+
+fn shl_inner(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    mut recv: Value,
+    other_v: Value,
+) -> Result<Value> {
+    let mut self_ = recv.as_string_mut(vm, globals)?;
+    if let Some(other) = other_v.is_rstring() {
         self_.extend(&other, &globals.store)?;
-    } else if lfp.arg(0).try_fixnum().is_none() && lfp.arg(0).is_integer() {
+    } else if other_v.try_fixnum().is_none() && other_v.is_integer() {
         // `String#<<` / `#concat` treat any Integer as a codepoint; a
         // Bignum can never be a valid codepoint, so it is always out
         // of char range (CRuby: `RangeError "bignum out of char
         // range"`).
         return Err(MonorubyErr::rangeerr("bignum out of char range"));
-    } else if let Some(i) = lfp.arg(0).try_fixnum() {
+    } else if let Some(i) = other_v.try_fixnum() {
         let ch = match u32::try_from(i) {
             Ok(ch) => ch,
-            Err(_) => return Err(MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0))),
+            Err(_) => return Err(MonorubyErr::char_out_of_range(&globals.store, other_v)),
         };
         if self_.encoding().is_utf8_compatible() {
             let c = char::from_u32(ch)
-                .ok_or_else(|| MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0)))?;
+                .ok_or_else(|| MonorubyErr::char_out_of_range(&globals.store, other_v))?;
             let mut buf = [0u8; 4];
             let encoded = c.encode_utf8(&mut buf);
             self_.extend_from_slice_checked(encoded.as_bytes())?;
@@ -800,15 +809,71 @@ fn shl(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             if let Ok(b) = u8::try_from(ch) {
                 self_.extend_from_slice_checked(&[b])?;
             } else {
-                return Err(MonorubyErr::char_out_of_range(&globals.store, lfp.arg(0)));
+                return Err(MonorubyErr::char_out_of_range(&globals.store, other_v));
             }
         }
     } else {
-        // Try to_str coercion
-        let coerced = lfp.arg(0).coerce_to_rstring(vm, globals)?;
+        // Try to_str coercion. `#to_str` runs Ruby code: the JIT inliner
+        // calls in frameless (receiver only in a register/caller slot), so
+        // keep the receiver rooted across the call.
+        vm.temp_push(recv);
+        let coerced = other_v.coerce_to_rstring(vm, globals);
+        vm.temp_pop();
+        let coerced = coerced?;
         self_.extend(&coerced, &globals.store)?;
     }
     Ok(self_.into())
+}
+
+/// `String#<<` for the JIT inliner: the builtin's full semantics behind a
+/// bare `f(vm, globals, recv, arg)` call, so a hot `buff << byte` /
+/// `buff << str` skips the Ruby method frame entirely.
+extern "C" fn string_shl(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    recv: Value,
+    arg: Value,
+) -> Option<Value> {
+    match shl_inner(vm, globals, recv, arg) {
+        Ok(v) => Some(v),
+        Err(err) => {
+            vm.set_error(err);
+            None
+        }
+    }
+}
+
+/// Inline `String#<<`: a Fixnum byte appended by `emit_string_shl`'s inline
+/// store; every other shape falls back — inside the emitted code, with no
+/// deopt — to a direct `string_shl` call carrying the builtin's full
+/// semantics (String append, Integer codepoint encoding, `#to_str`
+/// coercion, frozen/chilled and range errors). No receiver-class
+/// restriction is needed: a String subclass resolves to the same builtin,
+/// and error cases surface through the ordinary HandleError path.
+fn string_shl_gen(
+    state: &mut AbstractState,
+    ir: &mut AsmIr,
+    _: &JitContext,
+    store: &Store,
+    callid: CallSiteId,
+    recv_class: ClassId,
+    _: Option<ClassId>,
+) -> bool {
+    let callsite = &store[callid];
+    if !callsite.is_simple() || callsite.pos_num != 1 {
+        return false;
+    }
+    state.load(ir, callsite.recv, GP::Rdi);
+    state.load(ir, callsite.args, GP::Rsi);
+    let using_fpr = state.get_using_fpr(ir);
+    ir.fpr_save(using_fpr);
+    ir.inline(|r#gen, _, _, _| r#gen.emit_string_shl(string_shl as *const () as u64));
+    ir.fpr_restore(using_fpr);
+    let error = ir.new_error(state);
+    ir.handle_error(error);
+    // both the inline store and the helper answer the receiver itself
+    state.def_reg2acc_class(ir, GP::Rax, callsite.dst, recv_class);
+    true
 }
 
 ///

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -159,19 +159,144 @@ impl Codegen {
         );
     }
 
-    /// Inlined `Hash#[]`: `hashindex(vm, globals, recv, key)`. The receiver is
-    /// already in Rdx (x2 == C arg2) and the key in Rcx (x1); move the key to
-    /// arg3 first (before x1 is overwritten by globals), then load vm/globals.
-    /// Result Value lands in Rax (x0); errors are checked by the trailing
-    /// HandleError. FP pool saved by the surrounding fpr_save/restore.
-    pub(crate) fn emit_hash_index(&mut self, hashindex: u64) {
+    /// `String#<<` with a Fixnum byte appended in line — the aarch64 twin
+    /// of x86 `emit_string_shl`. A byte 0..=127 appends into any encoding;
+    /// a byte with the high bit set only into ASCII-8BIT. A frozen/chilled
+    /// receiver, a shared (copy-on-write) or full buffer, and every
+    /// non-Fixnum or out-of-range argument falls back to `f` =
+    /// `string_shl(vm, globals, recv, arg)`, the builtin's full semantics
+    /// (errors via the trailing HandleError). Keeps the cached code-range
+    /// classification consistent with
+    /// `RStringInner::extend_from_slice_checked`.
+    ///
+    /// ### in
+    /// - Rdi (x4): receiver: String (class-guarded)
+    /// - Rsi (x3): argument: Value (unguarded)
+    ///
+    /// ### out
+    /// - Rax (x0): the receiver (`<<` returns self) / the helper's result
+    ///
+    /// ### destroy
+    /// - x0 (Rax), x1 (Rcx), x2 (Rdx), x3 (Rsi), x9
+    pub(crate) fn emit_string_shl(&mut self, f: u64) {
+        let fallback = self.jit.label();
+        let enc_ok = self.jit.label();
+        let heap = self.jit.label();
+        let stored = self.jit.label();
+        let keep_cr = self.jit.label();
+        let exit = self.jit.label();
         monoasm_arm64!(&mut self.jit,
-            mov x3, x1;           // key (Rcx) -> arg3   [recv already in x2 == Rdx]
+            // only a Fixnum byte inlines
+            mov x9, (1u64);
+            tst x3, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &fallback);
+        // frozen (0b010) or chilled (0b100) -> helper raises / warns
+        monoasm_arm64!(&mut self.jit,
+            ldrh w0, [x4, #(RVALUE_OFFSET_FLAG as u32)];
+            mov x9, (0b110u64);
+            tst x0, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &fallback);
+        monoasm_arm64!(&mut self.jit,
+            asr x2, x3, #(1);                                // untagged byte
+            // byte range 0..=255 (unsigned compare catches negatives)
+            cmp x2, #(0xff);
+        );
+        self.jit.bcond_label(monoasm::Cond::Hi, &fallback);
+        monoasm_arm64!(&mut self.jit,
+            cmp x2, #(0x7f);
+        );
+        self.jit.bcond_label(monoasm::Cond::Le, &enc_ok);
+        // high byte: raw append only into ASCII-8BIT (Ascii8 == 0)
+        monoasm_arm64!(&mut self.jit,
+            ldrb w0, [x4, #(crate::rvalue::STRING_TY_OFFSET as u32)];
+            cmp x0, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &fallback);
+        self.jit.bind_label(enc_ok);
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)]; // capa / shared tag
+            // shared (copy-on-write) buffer -> helper detaches
+            mov x9, (crate::rvalue::STRING_SHARED_TAG as u64);
+            cmp x0, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Eq, &fallback);
+        monoasm_arm64!(&mut self.jit,
+            cmp x0, #(STRING_INLINE_CAP as u32);
+        );
+        self.jit.bcond_label(monoasm::Cond::Gt, &heap);
+        // inline buffer: x0 is the length, STRING_INLINE_CAP the capacity
+        self.jit.bcond_label(monoasm::Cond::Eq, &fallback); // full -> helper spills
+        monoasm_arm64!(&mut self.jit,
+            add x1, x4, #(RVALUE_OFFSET_INLINE as u32);
+            add x1, x1, x0;
+            strb w2, [x1];
+            add x0, x0, #(1);
+            str x0, [x4, #(RVALUE_OFFSET_ARY_CAPA as u32)];
+            b stored;
+        );
+        self.jit.bind_label(heap);
+        // spilled buffer: x0 is the capacity, the length lives beside the
+        // pointer. A full buffer reallocates via the helper.
+        monoasm_arm64!(&mut self.jit,
+            ldr x1, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+            cmp x1, x0;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ge, &fallback);
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x4, #(RVALUE_OFFSET_HEAP_PTR as u32)];
+            add x0, x0, x1;
+            strb w2, [x0];
+            add x1, x1, #(1);
+            str x1, [x4, #(RVALUE_OFFSET_HEAP_LEN as u32)];
+        );
+        self.jit.bind_label(stored);
+        // code range: an ASCII byte keeps the cache; a high byte (ASCII-8BIT
+        // by the gate above) degrades it to Unknown.
+        monoasm_arm64!(&mut self.jit,
+            cmp x2, #(0x7f);
+        );
+        self.jit.bcond_label(monoasm::Cond::Le, &keep_cr);
+        monoasm_arm64!(&mut self.jit,
+            mov x9, #(crate::rvalue::CodeRange::Unknown as u32);
+            strb w9, [x4, #(crate::rvalue::STRING_CR_OFFSET as u32)];
+        );
+        self.jit.bind_label(keep_cr);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x4;                                      // String#<< returns self
+            b exit;
+        );
+        self.jit.bind_label(fallback);
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x4;           // recv -> arg2
+            // arg is already in x3 == C arg3
             mov x0, x19;          // vm (EXEC) -> arg0
             mov x1, x20;          // globals (GLOBALS) -> arg1
-            mov x9, (hashindex);
+            mov x9, (f);
             str x30, [sp, #-16]!; // save LR
-            blr x9;               // x0 = hashindex(vm, globals, recv, key)
+            blr x9;               // x0 = f(vm, globals, recv, arg)
+            ldr x30, [sp], #16;
+        );
+        self.jit.bind_label(exit);
+    }
+
+    /// Direct call of a two-value runtime helper `f(vm, globals, a, b)`,
+    /// skipping the Ruby method frame — the aarch64 twin of x86
+    /// `emit_call_2args`. `a` is already in Rdx (x2 == C arg2) and `b` in
+    /// Rcx (x1); move `b` to arg3 first (before x1 is overwritten by
+    /// globals), then load vm/globals. Result Value lands in Rax (x0);
+    /// errors are checked by the trailing HandleError. FP pool saved by the
+    /// surrounding fpr_save/restore. Used by the `Hash#[]` and `String#<<`
+    /// inliners.
+    pub(crate) fn emit_call_2args(&mut self, f: u64) {
+        monoasm_arm64!(&mut self.jit,
+            mov x3, x1;           // b (Rcx) -> arg3   [a already in x2 == Rdx]
+            mov x0, x19;          // vm (EXEC) -> arg0
+            mov x1, x20;          // globals (GLOBALS) -> arg1
+            mov x9, (f);
+            str x30, [sp, #-16]!; // save LR
+            blr x9;               // x0 = f(vm, globals, a, b)
             ldr x30, [sp], #16;
         );
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -103,13 +103,107 @@ impl Codegen {
         }
     }
 
-    /// `Hash#[]`: `hashindex(vm, globals, recv, key)`. recv in rdx, key in rcx.
-    /// Result Value in rax (errors via the trailing HandleError).
-    pub(crate) fn emit_hash_index(&mut self, hashindex: u64) {
+    /// `String#<<` with a Fixnum byte appended in line. A byte 0..=127
+    /// appends into any encoding (it is its own one-byte encode in every
+    /// ASCII-compatible receiver and the raw-byte append everywhere else —
+    /// exactly what the builtin does); a byte with the high bit set only
+    /// into ASCII-8BIT (other encodings multi-byte-encode or reject it). A
+    /// frozen/chilled receiver, a shared (copy-on-write) or full buffer,
+    /// and every non-Fixnum or out-of-range argument falls back to `f` =
+    /// `string_shl(vm, globals, recv, arg)`, the builtin's full semantics
+    /// (String append, `#to_str` coercion, warn-and-unchill, errors via the
+    /// trailing HandleError). Keeps the cached code-range classification
+    /// consistent with `RStringInner::extend_from_slice_checked`: an ASCII
+    /// byte preserves the cache, a high byte degrades it to Unknown.
+    ///
+    /// ### in
+    /// - rdi: receiver: String (class-guarded)
+    /// - rsi: argument: Value (unguarded)
+    ///
+    /// ### out
+    /// - rax: the receiver (`<<` returns self) / the helper's result
+    ///
+    /// ### destroy
+    /// - rax, rcx, rdx, rsi (+ caller-saved on the fallback call)
+    pub(crate) fn emit_string_shl(&mut self, f: u64) {
+        let fallback = self.jit.label();
+        let enc_ok = self.jit.label();
+        let heap = self.jit.label();
+        let stored = self.jit.label();
+        let keep_cr = self.jit.label();
+        let exit = self.jit.label();
+        monoasm! { &mut self.jit,
+            // only a Fixnum byte inlines
+            testq rsi, 1;
+            jz   fallback;
+            // frozen (0b010) or chilled (0b100) → helper raises / warns
+            testb [rdi + (RVALUE_OFFSET_FLAG)], (0b110);
+            jnz  fallback;
+            movq rdx, rsi;
+            sarq rdx, 1;
+            // byte range 0..=255 (unsigned compare catches negatives)
+            cmpq rdx, (0xff);
+            ja   fallback;
+            cmpq rdx, (0x7f);
+            jle  enc_ok;
+            // high byte: raw append only into ASCII-8BIT (Ascii8 == 0)
+            cmpb [rdi + (crate::rvalue::STRING_TY_OFFSET)], (0);
+            jne  fallback;
+        enc_ok:
+            movq rax, [rdi + (RVALUE_OFFSET_ARY_CAPA)];
+            // shared (copy-on-write) buffer → helper detaches
+            movq rcx, (crate::rvalue::STRING_SHARED_TAG);
+            cmpq rax, rcx;
+            jeq  fallback;
+            cmpq rax, (STRING_INLINE_CAP);
+            jgt  heap;
+            // inline buffer: rax is the length, STRING_INLINE_CAP the
+            // capacity; the `cmpq` above already set the full-buffer flags.
+            jeq  fallback;
+            lea  rcx, [rdi + (RVALUE_OFFSET_INLINE)];
+            movb [rcx + rax], rdx;
+            addq [rdi + (RVALUE_OFFSET_ARY_CAPA)], 1;
+            jmp  stored;
+        heap:
+            // spilled buffer: rax is the capacity, the length lives beside
+            // the pointer. A full buffer reallocates via the helper.
+            movq rcx, [rdi + (RVALUE_OFFSET_HEAP_LEN)];
+            cmpq rcx, rax;
+            jge  fallback;
+            movq rax, [rdi + (RVALUE_OFFSET_HEAP_PTR)];
+            movb [rax + rcx], rdx;
+            addq [rdi + (RVALUE_OFFSET_HEAP_LEN)], 1;
+        stored:
+            cmpq rdx, (0x7f);
+            jle  keep_cr;
+            movb [rdi + (crate::rvalue::STRING_CR_OFFSET)], (CodeRange::Unknown as u64);
+        keep_cr:
+            movq rax, rdi;
+        exit:
+        }
+        self.jit.select_page(1);
+        monoasm! { &mut self.jit,
+        fallback:
+            movq rdx, rdi;
+            movq rcx, rsi;
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (f);
+            call rax;
+            jmp  exit;
+        }
+        self.jit.select_page(0);
+    }
+
+    /// Direct call of a two-value runtime helper `f(vm, globals, a, b)`,
+    /// skipping the Ruby method frame: `a` in rdx, `b` in rcx. Result Value
+    /// in rax (errors via the trailing HandleError). Used by the `Hash#[]`
+    /// and `String#<<` inliners.
+    pub(crate) fn emit_call_2args(&mut self, f: u64) {
         monoasm! { &mut self.jit,
             movq rdi, rbx;
             movq rsi, r12;
-            movq rax, (hashindex);
+            movq rax, (f);
             call rax;
         }
     }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1491,6 +1491,42 @@ impl AbstractState {
             let error = ir.new_error(self);
             ir.push(AsmInst::SetArgumentsForwardedHelper { callid, callee_fid });
             ir.handle_error(error);
+        } else if !callsite.forwarding
+            && callsite.pos_num >= 1
+            && callsite.splat_pos.as_slice() == [callsite.pos_num - 1]
+            && !callsite.kw_may_exists()
+            && callee.no_keyword()
+            && callee.opt_num() == 0
+            && !callee.is_rest()
+            && callee.post_num() == 0
+            && !callee.single_arg_expand()
+            && callee.req_num() + 1 >= callsite.pos_num
+        {
+            // Plain trailing-splat call `g(x.., *ary)` into a req-only
+            // callee — `item_check(*node)`-style recursion is this shape on
+            // every call. The eager `SetArgumentsForwarded` lowering fits
+            // it exactly: if at run time the splat operand is an `Array` of
+            // exactly `req_num - lead_num` elements, the leading args and
+            // the elements copy straight into the callee frame; any other
+            // length or a non-Array operand (whose bind may coerce or
+            // raise) falls back to the generic runtime inside the emitted
+            // code. No keywords exist on either side (`kw_may_exists` /
+            // `no_keyword`), so no kw-rest guard is needed, and without
+            // keyword syntax at the call site no ruby2_keywords promotion
+            // can apply. A non-forwarding splat operand is an ordinary
+            // evaluated slot, so no deferred-rest handling applies either.
+            self.write_back_recv_and_callargs(ir, callsite);
+            let error = ir.new_error(self);
+            ir.push(AsmInst::SetArgumentsForwarded {
+                callid,
+                callee_fid,
+                recv: callsite.recv,
+                args: callsite.args,
+                lead_num: callsite.pos_num - 1,
+                kwrest_guard: None,
+                deferred_src: None,
+            });
+            ir.handle_error(error);
         } else {
             // Generic path. A forwarding call here (e.g. native callee
             // such as `Array.new`'s `o.__send__(:initialize, ...)`, or

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -33,7 +33,8 @@ pub use rational::{RationalFloorResult, RationalInner};
 pub use regexp::{Regexp, RegexpInner};
 pub(crate) use string::pack::*;
 pub use string::{
-    CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET, map_bytes_to_utf8,
+    CharByteIter, CodeRange, Encoding, RString, RStringInner, STRING_CR_OFFSET, STRING_TY_OFFSET,
+    map_bytes_to_utf8,
 };
 pub(crate) use string::{
     STRING_SHARED_TAG, check_string_not_modified, string_snapshot, string_substring,

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -831,6 +831,12 @@ pub fn map_bytes_to_utf8(bytes: &[u8]) -> String {
 pub const STRING_CR_OFFSET: usize =
     super::RVALUE_OFFSET_KIND + std::mem::offset_of!(RStringInner, cr);
 
+/// Byte offset of the encoding tag (`ty`) from the head of an `RValue`
+/// holding a String, for the JIT's inline `String#<<`. `Encoding` is
+/// `repr(u8)`, so its first byte is the discriminant (`Ascii8` == 0).
+pub const STRING_TY_OFFSET: usize =
+    super::RVALUE_OFFSET_KIND + std::mem::offset_of!(RStringInner, ty);
+
 impl std::ops::Deref for RStringInner {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
Two independent JIT optimizations closing the ruby-bench gaps against CRuby+YJIT that an investigation of `binarytrees` and `protoboeuf-encode` pinned down. Each addresses the single dominant cost of one benchmark; measured per stage (same batch, idle machine, WARMUP_ITRS=5 / MIN_BENCH_ITRS=10):

| stage | binarytrees | protoboeuf-encode |
|---|---|---|
| master | 237ms | 69ms |
| + String#<< inline | 233ms | **32ms** |
| + splat fast path | **118ms** | 32ms |
| CRuby+YJIT (reference) | 170ms | 32ms |

## 1. JIT-inline `String#<<` with an in-line Fixnum byte append

`protoboeuf-encode` performs ~1.8M `buff << byte` appends per pass; each went through the full builtin method frame (~24ns vs YJIT's effective ~5.5ns), which alone accounted for ~80% of the gap.

- `emit_string_shl` (x86_64 + aarch64): a Fixnum byte 0..=127 appends in line into any encoding (it is its own one-byte encode in every ASCII-compatible receiver and the raw-byte append everywhere else — exactly what the builtin does); 128..=255 in line into ASCII-8BIT only. Frozen/chilled receivers, shared (COW) or full buffers, and every non-Fixnum argument fall back **inside the emitted code — no deopt** — to a direct `string_shl(vm, globals, recv, arg)` call carrying the builtin's full semantics (String append, `#to_str` coercion, errors via HandleError). Code-range cache updates mirror `extend_from_slice_checked`.
- `shl_inner` is shared between the builtin and the helper, and roots the receiver across the `#to_str` coercion (the inliner calls in frameless).
- `emit_hash_index` is generalized to `emit_call_2args` (same code); the `String#<<` fallback and `Hash#[]` share the frame-skipping call shape.

## 2. Bind plain trailing-splat calls with the eager forwarded-args lowering

`item_check(*node)`-style recursion — `binarytrees`' hot path, 5.2M calls per iteration — always took the generic per-call runtime binder (CallSiteInfo re-parse, SmallVec copy, `fill_positional_args`), ~50ns per call where YJIT pays ~3ns.

The eager `SetArgumentsForwarded` lowering already does exactly the right thing for the materialized `...` forward — exact-length Array guard before any callee-frame write, direct element copy, in-code fallback to the generic binder for any other length or a non-Array operand — so this widens its front-end gate to admit the non-forwarding shape: single trailing splat, no keywords on either side (which is what makes ruby2_keywords promotion statically impossible), req-only callee, no single-arg-expand. A non-forwarding splat operand is an ordinary evaluated slot, so no deferred-rest (D1) handling applies. Both arches pick this up through the existing lowering.

## Verification

- Full test suite green (lib 2289 + integration; `cargo test --release`).
- `protoboeuf-encode` output SHA256-matches CRuby after 30 warmed iterations.
- Edge cases verified against CRuby through the JIT paths: COW-shared buffers, frozen (`FrozenError`) and chilled receivers, `RangeError`/bignum codepoints, UTF-8 multi-byte codepoints, inline→heap growth, CR-cache transitions; splat `ArgumentError` arity shapes, `to_a` coercion, falsy elements, lead args, non-trailing splats, block + splat combinations.
- aarch64 cross-checked (`cargo check --target aarch64-unknown-linux-gnu`).

A third change from the same investigation (a nil-tolerant receiver guard for `nil?` sites, worth another −15% on binarytrees) is deliberately **not** included: it touches how polymorphic call sites are guarded, and that deserves a designed approach rather than a special case. The remaining known gap of the same family is `left == nil`-style sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_