### PR TITLE
Polymorphic call sites: complete VM detection, record a per-callsite PMC, nil-tolerant nil? guard

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -41,6 +41,7 @@ Two things to know before reading:
 | [`regalloc_separation.md`](regalloc_separation.md) | EN | design record | Separating the abstract interpreter from register allocation. The largest document here; the structural groundwork the LIR work builds on. |
 | [`arch_difference.md`](arch_difference.md) | EN | reference | How the x86-64 and aarch64 backends differ, `AsmInst` by `AsmInst`. Read before touching either. |
 | [`arg_forwarding_jit.md`](arg_forwarding_jit.md) | JA | design record | JIT strategy for `def f(a, ...) g(...) end`, staged, with the deopt-safety argument. |
+| [`polymorphic_call.md`](polymorphic_call.md) | JA | plan | Receiver-polymorphic call sites: why `x.nil?` / `x == nil` deopt on every nil receiver, the implemented nil-tolerant guard, and the design space (predicate generalization, PIC, page discipline) with measurements. |
 | [`bop_redefinition.md`](bop_redefinition.md) | JA | design record | What licenses inlining `1 + 2`, what happens when Ruby revokes it, and why the current all-or-nothing response is both too narrow (silently wrong answers) and too blunt (24× slower, permanently). Measured against CRuby. |
 | [`handoff_record_stream.md`](handoff_record_stream.md) | EN | plan / history | Handoff note for the record-driven lowering work; a summary of `regalloc_separation.md` §12–21 as of that branch. |
 

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -132,7 +132,7 @@ Object/Kernel から継承される述語群。`left == nil` の 885→489ms(§2
 
 コスト: 小。リスク: 生成器 flag の付け間違い。§3 の機構をそのまま使う。
 
-### 5.2 Polymorphic Inline Cache(N-way ディスパッチ)
+### 5.2 Polymorphic Inline Cache(N-way ディスパッチ)→ **採用方針。§7 の調査記録を参照**
 
 一般解。サイトごとに観測クラス列 (class, FuncId) を 2〜4 way まで持ち、
 線形比較チェーンで分岐、全ミスで deopt/再コンパイル。`BinCmp` の
@@ -140,15 +140,22 @@ Part B(`BecamePolymorphic` 再コンパイル)を method call 全般へ拡張す
 形が自然で、「初回は monomorphic でコンパイル → ミスが温まったら
 polymorphic 版へ再コンパイル」という既存のポリシーに乗る。
 
-論点:
+**方針決定(2026-08)**: VM が実行時に polymorphic を検出して
+バイトコードへ書き込む既存機構(`opcode_sub`)を土台に、
+`CallSiteInfo` に 4-way 程度の PMC を蓄積し JIT コンパイル時に利用する。
+`nil?` はこの一般機構で自然に扱える(§7.2)。`==` など二項演算子命令へ
+の適用可否は §7.3 の調査結果のとおり「検出機構は既にあり有効、
+ただしキャッシュがペア形で置き場所の追加が要る」。
 
-- **インライン生成器との併用**: way ごとに生成器を展開するか(コード
-  サイズ増)、polymorphic サイトは生成器を捨てて直接呼び出しに統一
-  するか。nil way だけ値比較特例(§3)を残す折衷が現実的。
+論点(§7 の調査で一部解決):
+
+- **インライン生成器との併用**: way ガード通過後はレシーバクラスが
+  確定するので、way ごとに生成器を適用しても ③ の unrefined-state
+  問題は起きない。ただし最小実装は「全 way が同一 FuncId のときだけ
+  生成器適用(`nil?` がこれ)、それ以外は way → 直接 FuncId 呼び出し」。
 - **abstract state**: way ごとに事後状態が異なる。合流で全 way の
   join を取る(≒ Value に落ちる)なら §5.3 の問題に帰着する。
-- 観測クラスの記録場所: 現行のインラインキャッシュは 1 エントリ。
-  deopt 側で「ガードを外したクラス」を蓄積する器が要る。
+  最小実装はチェーン全体を 1 命令として扱い、結果は Value で合流。
 
 ### 5.3 abstract state に union を持たせるか
 
@@ -180,20 +187,103 @@ refine しない state を広げるほど踏みやすくなる。選択肢:
   しない BasicObject 系レシーバ(`nil?` 呼び出しは NoMethodError に
   なるべき)で誤答する。クラスガードは第三クラスの安全網として残す。
 
-## 6. 提案する順序
+## 6. 提案する順序(§7 の方針決定で改訂)
 
-1. **§5.1 の最小一般化**(nil-safe flag + `==` / 述語群) — `== nil`
-   885→489ms の残り半分を回収。計測: §2 のマイクロベンチと
-   binarytrees。
-2. **§5.4-1 の page 二形態化の横展開** — §3.3 と同じパターンの機械的
-   適用。gc-stress full を再実行して検証。
-3. **§5.2 の PIC + BecamePolymorphic 拡張** — optcarrot 等、真に
-   多クラスなワークロードで設計・計測。§5.3(union 型)はその結果を
-   見てから判断。
+1. **VM 駆動 4-way PMC(メソッド呼び出し)** — §7.2 の実装点に沿って
+   `CallSiteInfo` に PMC を蓄積し、JIT が `_polymorphic` サイトで
+   ガードチェーンを発行する。`nil?` はこの一般機構に吸収され、§3 の
+   `GuardClassOrNil` 特例は「全 way 同一 FuncId の縮退形」として整理
+   し直す(または撤去する)。
+2. **§5.4-1 の page 二形態化の横展開** — way 分岐後のコード配置が
+   cold 側へ広がるため、PMC より先に済ませるのが安全。
+3. **二項演算子命令へのペア PMC 拡張** — §7.3。`== nil`
+   (現況 489ms vs YJIT 193ms)を計測基準にする。
 
-## 7. このブランチに含まれる実装
+## 7. 調査記録: VM 駆動 4-way PMC の実装点(2026-08)
+
+### 7.1 既存の検出機構(前提の確認)
+
+VM は **メソッド呼び出し・二項演算の両方で** polymorphic を実行時検出
+し、バイトコードの `opcode_sub` バイトに書き込む機構を既に持つ:
+
+- **メソッド呼び出し**(`vmgen/method_call.rs` slow_path):
+  インラインキャッシュ(バイトコード内の CACHED_CLASS / VERSION /
+  FUNCID、1 エントリ)が populated かつ receiver class 不一致のとき
+  `opcode_sub = 1`。直後に必ず `runtime::find_method(vm, globals,
+  callid, recv)` が呼ばれ、(class_for_ic, FuncId) を解決してキャッシュを
+  再タグ付けする。
+- **二項演算**(`vmgen.rs` `vm_save_binary_class`):
+  バイトコード内 IC に (lhs_class, rhs_class) の 1 ペアを保存し、
+  どちらかの変化を検出したら `opcode_sub = 1`。
+
+TraceIR はどちらも読み取り済みで、`BinCmp`/`BinCmpBr`/`BinOp` は
+`polymorphic` を **消費している**(単相 → ペアガード +
+recompile-on-miss(Part B)、多相 → ガードなし generic C-call +
+Eq/Ne は即値 fast path(Part C))。一方 `TraceIr::MethodCall` の
+`_polymorphic` は **未使用**(`compile.rs` で `_polymorphic: _`)。
+つまりメソッド呼び出し側は「検出はあるが JIT が利用していない」状態で、
+PMC 案はまさにこの穴を埋める。
+
+### 7.2 メソッド呼び出し側の実装点
+
+1. **記録**: `runtime::find_method` は `&mut Globals` と `CallSiteId` を
+   受けて解決結果 (cache_class, fid) を計算済みなので、ここで
+   `CallSiteInfo` に固定長 4-way の `(ClassId, FuncId)` 列を追記するのが
+   最小変更。既存の `class_for_ic`(Bool 統合)と `cacheable = false`
+   (frame-dependent super — class タグ 0 で毎回再解決)の扱いを
+   そのまま流用でき、cacheable でないサイトは PMC 対象外にマークする。
+   5 クラス目が観測されたら megamorphic フラグ(PMC 打ち切り、JIT は
+   ガードなし generic dispatch を選ぶ)。
+2. **消費**: `compile_method_call` で `_polymorphic` が真なら、単一
+   キャッシュではなく PMC を読み、way ごとの class 比較チェーンを発行:
+   - way ガード通過後はレシーバクラスが確定するので、既存の
+     monomorphic 経路(インライン生成器を含む)を way 内で再利用できる
+     余地がある。ただし最小実装は「way → FuncId 直接呼び出し、結果は
+     Value で合流」。
+   - **同一 FuncId の way は 1 経路に畳む**。`nil?` は全 way が
+     Kernel#nil? に解決されるため、畳んだ結果が §3 のガードレス値比較と
+     一致する — nil? 特例が一般機構の縮退形になる、というのがこの案の
+     利点。
+   - 全 way ミス: deopt(+ 観測が増えたら再コンパイル)か、その場で
+     generic dispatch へ落とすかは選択。Part B の単調再コンパイル
+     不変量(多相化は一方向)に合わせるなら後者。
+3. **無効化**: PMC エントリは class version guard の傘の下にある
+   (再定義で全サイト再コンパイル)ので、エントリ個別の無効化は不要。
+
+### 7.3 二項演算子命令(`==` ほか)への適用可否
+
+**有効。ただしキャッシュの形と置き場所が method call と異なる。**
+
+- 検出(`opcode_sub`)は §7.1 のとおり既にあり、多相サイトは現在
+  「ガードなし generic C-call」へ落ちている。`left == nil`
+  (left: Array/nil 二相)の実測 489ms(YJIT 193ms)の残りコストは
+  この generic C-call: Part C の即値 fast path は **両オペランドが
+  非 heap** のときだけ効くので、Array 側の呼び出しが毎回
+  `cmp_eq_values`(メソッド解決+実行)を払う。
+- binop の IC は (lhs_class, rhs_class) **ペア**で、バイトコード内の
+  8 バイト(2×u32)に 1 ペアしか置けない。4-way 化はバイトコード内では
+  無理なので、method call と同じくサイド構造に置く。置き場所の候補:
+  - binop サイトの一部は `IseqInfo::callsite_map`(bc_pos → CallSiteId)
+    で `CallSiteInfo` に到達できる(polymorphic 分岐が is_func_call
+    判定に既に使っている)。ペア PMC を `CallSiteInfo` に置くなら
+    これに乗るが、**全 binop 命令に callsite があるかは未確認**
+    (`get_callsite_id` は Option)。無いサイトには `IseqInfo` 側に
+    bc_pos キーのテーブルを足す。
+  - 記録タイミング: `vm_save_binary_class` はアセンブラ内でクラス保存
+    まで。ペア追記は set_poly 分岐(既に slow path)から Rust ヘルパを
+    呼ぶ形になる。generic C ヘルパ(`cmp_eq_values` 等)は pc を
+    受けない規約なので、記録はヘルパ側でなく VM 命令側で行う。
+- way 特化の価値: 第一段階は「ペアガード → FuncId 直接呼び出し」で
+  解決コストを消すだけでよい。第二段階として、組み込みが確定する
+  ペアには特化コードの余地がある(例: (Array, NilClass) の `==` は
+  Array#== が組み込みなら定数 false)。どちらが効くかは
+  `cmp_eq_values` の内部コスト内訳(解決 vs 本体実行)を測ってから
+  決める。
+
+## 8. このブランチに含まれる実装
 
 - `JIT: nil-tolerant receiver guard for nil? call sites` — §3.1/3.2。
+  §6-1 の一般機構が入った時点で縮退形として整理し直す予定。
 - `x86_64: make the Float-unbox guards page-tolerant` — §3.3。
 
 検証済み: フルスイート green(§3.3 修正後)、`Weird#nil?` 等の第三

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -53,7 +53,16 @@ if by == nil ...             # 同型の == バリアント
 - `== nil` が truthiness より 2.8 倍遅いのは、`==` サイトも同じ
   nil/非 nil 二相 deopt を踏んでいるからで、**未回収の最大候補**。
 
-## 3. 実装済みの第一歩: `nil?` サイトの nil 耐性ガード
+## 3. 第一歩として試作した `nil?` 専用の nil 耐性ガード(撤去済み)
+
+> **注**: この節の `GuardClassOrNil` 実装は一度ブランチに入れたが、
+> §7 の一般機構(観測クラス集合が単一 native FuncId に収束するサイトの
+> `GuardClassIn`)が `nil?` サイトも吸収するため、**PR からは撤去した**。
+> nil? は現在、集合ガード + 組み込み呼び出しとして扱われる。ガード後に
+> 値比較 1 命令へ畳む特化(このメモの元の §3 形)は、生成器の
+> nil 安全 flag(§5.1)とセットで将来の最適化として残る。§3.3 の
+> page 耐性修正だけは、集合ガードも同じ「state 未確定 → cold ブロックに
+> Float unbox」経路を踏むため**残している**。以下は設計記録。
 
 このブランチに含まれる(master 未マージ)。構成は 3 点:
 
@@ -363,9 +372,16 @@ StoreIndex(133)は全て `new_callsite` + `new_callsite_map_entry` で
 
 ## 8. このブランチに含まれる実装
 
-- `JIT: nil-tolerant receiver guard for nil? call sites` — §3.1/3.2。
-  §6-1 の一般機構が入った時点で縮退形として整理し直す予定。
 - `x86_64: make the Float-unbox guards page-tolerant` — §3.3。
+  集合ガード(下記)が受け手 state を未確定のまま残すために必要。
+- VM 検出の全命令完備(unop / Index / StoreIndex)— §7.4。
+- PMC の記録と profile ダンプ — §7.5。
+- **PMC 消費 v1**: 観測クラス集合が単一 **native** FuncId に収束する
+  method call サイトへの `GuardClassIn`(集合メンバーシップガード)+
+  通常呼び出し。FuncId は `jit_check_call` で再計算し PMC の保存値は
+  使わない。iseq ターゲットはレシーバクラス特殊化があるため対象外
+  (`polymorphic_call` テストが検出した制約)。`nil?` / `is_a?` /
+  `frozen?` 型の 4-way 多相サイトが deopt ゼロ・ほぼ単相速度になる。
 
-検証済み: フルスイート green(§3.3 修正後)、`Weird#nil?` 等の第三
-クラス・オーバーライドは CRuby と一致、binarytrees 118→100ms。
+検証済み: フルスイート green、`Weird#is_a?` 等の第三クラス・
+オーバーライドは CRuby と一致。

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -1,0 +1,200 @@
+# Polymorphic call サイトの最適化 — 設計メモ
+
+**Kind**: plan(第一歩の `nil?` 耐性ガードは実装済み・このブランチに同梱。
+一般化はここでの設計判断待ち)
+
+このメモは、ruby-bench の binarytrees / protoboeuf-encode 調査
+(String#`<<` インライン化・trailing-splat fast path は #1109 で master 入り)
+の過程で見つかった **レシーバ多相なコールサイトの deopt 問題** について、
+実測・実装済みの第一歩・残された設計空間をまとめたものである。
+
+---
+
+## 1. 現状のコールサイト設計と、その盲点
+
+JIT のメソッド呼び出しは **monomorphic 前提** で組み立てられている:
+
+1. VM がインラインキャッシュを温める(receiver class → FuncId)。
+2. JIT はキャッシュされた 1 クラスで **レシーバクラスガード** を発行し、
+   ガードの内側で FuncId を確定させ、インライン生成器
+   (`inline_info.get_inline`)か直接呼び出しへ落とす。
+3. ガード失敗は deopt。`BinCmp` サイトのみ、ミス回数が温まると
+   `RecompileReason::BecamePolymorphic` で「多相対応版」へ再コンパイル
+   する経路(Part B)がある。ふつうのメソッド呼び出しにはこれが無く、
+   **ガード失敗は永久に毎回 deopt** する。
+
+盲点は「nil との二相」である。Ruby の慣用句はレシーバが nil かもしれない
+場所でこそメソッドを呼ぶ:
+
+```ruby
+return 1 if left.nil?        # left は Array か nil(binarytrees の item_check)
+limit = to unless to.nil?    # to は Numeric か nil(numeric.rb の step)
+step ||= 1
+if by == nil ...             # 同型の == バリアント
+```
+
+このため `nil?` / `== nil` サイトは **設計上 50/50 で二相** になり、
+毎回 deopt が観測された。
+
+## 2. 実測(2026-08、x86-64 Linux、release)
+
+- binarytrees(#1109 適用後): `item_check` の `left.nil?` サイトで
+  **1 実行あたり 458 万回の deopt**(`profile` フィーチャで観測。
+  deopt ログは `POLYMORPHIC [NilClass]`)。
+- マイクロベンチ(2^16 ノードの木 ×40 周、YJIT 比):
+
+  | 変種 | monoruby(修正前) | 修正後(§3) | CRuby+YJIT |
+  |---|---|---|---|
+  | `left.nil?` | 353ms | **64ms** | 87ms |
+  | `left`(truthiness) | 317ms | 62ms | 90ms |
+  | `left == nil` | 885ms | **489ms(未対策)** | 193ms |
+
+- ベンチ全体: binarytrees 118ms → **100ms**(−15%)。
+- `== nil` が truthiness より 2.8 倍遅いのは、`==` サイトも同じ
+  nil/非 nil 二相 deopt を踏んでいるからで、**未回収の最大候補**。
+
+## 3. 実装済みの第一歩: `nil?` サイトの nil 耐性ガード
+
+このブランチに含まれる(master 未マージ)。構成は 3 点:
+
+### 3.1 `GuardClassOrNil`(AsmIR / LIR / 両アーキ lowering)
+
+「レシーバが nil なら通過、そうでなければ従来のクラスガード」。
+nil ケースは比較 1 回+分岐 1 回で、deopt と違い定常コストがほぼ無い。
+
+```
+cmp  recv, NIL_VALUE
+jeq  nil_ok
+<従来の guard_class(recv_class), 失敗は deopt>
+nil_ok:
+```
+
+### 3.2 フロントエンドのゲート(`compile_method_call`)
+
+適用条件(健全性の根拠ごと):
+
+- サイト名が `nil?`、simple、引数 0。
+- `recv_class != NIL_CLASS`(nil 単相なら従来ガードで十分)。
+- **`jit_check_call(NIL_CLASS, name)` の解決 FuncId が、キャッシュ
+  クラスでの解決 FuncId と一致**すること。これが健全性の核で、
+  「nil が来ても非 nil が来ても呼ぶべきメソッドは同一」をコンパイル時に
+  証明する。直前に発行済みの class version guard が再定義を無効化する。
+  `NilClass#nil?` だけが再定義されていれば一致せず、自動的に従来経路へ
+  戻る。第三のクラス(独自 `nil?` を持つ等)は従来どおり deopt して
+  正しくディスパッチされる。
+- ガード通過後、**abstract state は refine しない**(レシーバは
+  「nil か recv_class」なので、クラスを確定させたら嘘になる)。
+  未確定状態の `kernel_nil` 生成器は `recv == nil` の値比較
+  (`is_nil_to_bool`)を出すので、これがそのまま両ケースの正解になる。
+
+### 3.3 副作用: page 規律との衝突(修正済み、ただし全面解消ではない)
+
+state を refine しないことの下流コスト: `to.nil?` の後で `to` を Float
+として使うコード(numeric.rb `step`)では、Float unbox(ガード付き
+Value→f64)が **cold ブロック(page 1 に out-of-line 発行される基本
+ブロック)内** に現れるようになった。x86-64 バックエンドの多くの
+lowering は「hot(page 0)から呼ばれ、自分の cold スニペットを page 1 に
+置く」前提で `assert_eq!(0, get_page())` を持っており、ここで abort した
+(`numeric_step` テストで決定的に再現)。
+
+クラッシュ経路の `float_to_f64` / `float_val_to_f64` は、`guard_class` の
+fail ラッパが既にやっている二形態(**page 0 なら cold スニペットを
+page 1 へ、page 1 で発行中ならその場に inline 化して飛び越す**)に直して
+解消した。ただし同種の assert は `binary_op.rs` 等にも十数箇所残って
+おり、「refine しない state を広げる」設計はこの規律と面で衝突する
+(§5.4)。
+
+## 4. なぜ `nil?` に限定したか
+
+仕組み(FuncId 一致検証 + `GuardClassOrNil`)自体は名前非依存だが、
+ガード通過後に走る **インライン生成器の前提** が問題になる。生成器の
+多くは「ガード済み recv_class のレシーバ」を前提に書かれている
+(例: `Hash#[]` は `as_hash` へ直行)。nil が素通りすれば即クラッシュ
+なので、無条件の一般化は生成器全数の nil 安全性監査を要求する。
+`kernel_nil` は未確定状態で値比較を出すだけなので唯一安全と言い切れた。
+
+## 5. 設計空間(これから決めること)
+
+### 5.1 nil 耐性ガードの一般化 — 最小コストで `== nil` を回収する
+
+適用条件を「名前 = `nil?`」から次へ広げる:
+
+> `jit_check_call(NIL_CLASS, name) == func_id` **かつ**
+> (a) `func_id` にインライン生成器が無い、または
+> (b) 生成器が nil 安全(`InlineFuncInfo` に flag を追加)
+
+(a) が成り立つ場合、通常呼び出しは FuncId 直接ディスパッチなので
+レシーバが nil でも健全(フレーム構築・visibility はクラス非依存)。
+候補: `==`(NilClass は独自 `==` を持つため一致しないケースが多い点に
+注意 — 要確認)、`is_a?` / `kind_of?`、`respond_to?`、`frozen?` など
+Object/Kernel から継承される述語群。`left == nil` の 885→489ms(§2)が
+最初の回収目標。
+
+コスト: 小。リスク: 生成器 flag の付け間違い。§3 の機構をそのまま使う。
+
+### 5.2 Polymorphic Inline Cache(N-way ディスパッチ)
+
+一般解。サイトごとに観測クラス列 (class, FuncId) を 2〜4 way まで持ち、
+線形比較チェーンで分岐、全ミスで deopt/再コンパイル。`BinCmp` の
+Part B(`BecamePolymorphic` 再コンパイル)を method call 全般へ拡張する
+形が自然で、「初回は monomorphic でコンパイル → ミスが温まったら
+polymorphic 版へ再コンパイル」という既存のポリシーに乗る。
+
+論点:
+
+- **インライン生成器との併用**: way ごとに生成器を展開するか(コード
+  サイズ増)、polymorphic サイトは生成器を捨てて直接呼び出しに統一
+  するか。nil way だけ値比較特例(§3)を残す折衷が現実的。
+- **abstract state**: way ごとに事後状態が異なる。合流で全 way の
+  join を取る(≒ Value に落ちる)なら §5.3 の問題に帰着する。
+- 観測クラスの記録場所: 現行のインラインキャッシュは 1 エントリ。
+  deopt 側で「ガードを外したクラス」を蓄積する器が要る。
+
+### 5.3 abstract state に union を持たせるか
+
+現在の `Guarded` ラティスは単一クラス(+ Fixnum/Float 系の特例)。
+`nil?` 対応で「refine しない」を選んだが、`recv_class ∪ NilClass` の
+ような 2 要素 union を表現できれば、非 nil 側の下流(`unless to.nil?`
+の then 側など)は分岐条件から `recv_class` 単相へ **絞り直せる**。
+truthiness 分岐(`if x` / `unless x.nil?`)で nil を落とす flow-sensitive
+な絞り込みは、§5.1/5.2 のどちらを選んでも効く直交した改善。ただし
+ラティス拡張は merge/bridge 全体に波及するので、最も工数が大きい。
+
+### 5.4 page 規律の全面解消(前提整備)
+
+「cold ブロック内で page-1 スニペットを使う lowering が走り得る」は、
+refine しない state を広げるほど踏みやすくなる。選択肢:
+
+1. §3.3 の二形態化を、assert を持つ全 lowering(`binary_op.rs` ほか
+   十数箇所)へ横展開する。機械的だが確実。
+2. LIR 化(`doc/lir.md`)の進行に合わせ、cold スニペット配置を encoder
+   の責務にして assert 自体を消す。方向としては正しいが待ちが長い。
+
+§5.1 だけなら影響面は小さい(`==` 述語群の下流は Float unbox を含み
+にくい)が、§5.2/5.3 をやるなら 1. を先に済ませるべき。
+
+### 5.5 やらないと決めたこと
+
+- **ガード全廃(値比較のみで nil? を実装)**: 「どのクラスも `nil?` を
+  再定義していない」というグローバル性質が必要で、Kernel を include
+  しない BasicObject 系レシーバ(`nil?` 呼び出しは NoMethodError に
+  なるべき)で誤答する。クラスガードは第三クラスの安全網として残す。
+
+## 6. 提案する順序
+
+1. **§5.1 の最小一般化**(nil-safe flag + `==` / 述語群) — `== nil`
+   885→489ms の残り半分を回収。計測: §2 のマイクロベンチと
+   binarytrees。
+2. **§5.4-1 の page 二形態化の横展開** — §3.3 と同じパターンの機械的
+   適用。gc-stress full を再実行して検証。
+3. **§5.2 の PIC + BecamePolymorphic 拡張** — optcarrot 等、真に
+   多クラスなワークロードで設計・計測。§5.3(union 型)はその結果を
+   見てから判断。
+
+## 7. このブランチに含まれる実装
+
+- `JIT: nil-tolerant receiver guard for nil? call sites` — §3.1/3.2。
+- `x86_64: make the Float-unbox guards page-tolerant` — §3.3。
+
+検証済み: フルスイート green(§3.3 修正後)、`Weird#nil?` 等の第三
+クラス・オーバーライドは CRuby と一致、binarytrees 118→100ms。

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -319,6 +319,40 @@ StoreIndex(133)は全て `new_callsite` + `new_callsite_map_entry` で
   `_polymorphic` を配線済み。Index は binop と違い fixnum fast path を
   持たないため、検出は全実行に効く(遅延なし)。
 
+### 7.5 実装済み: PMC の記録と profile ダンプ(2026-08)
+
+記録側を実装した(JIT 消費は未着手)。設計:
+
+- **格納**: `CallSiteInfo::pmc: PolyCache`(`store.rs`)。最大
+  `PMC_WAYS = 4` エントリ `(recv, Option<arg>, Option<fid>, count)` +
+  megamorphic overflow カウンタ。キー形状は
+  **MethodCall / UnOp = レシーバのみ、BinOp / Cmp / Index /
+  StoreIndex = レシーバ + 第一引数**。
+- **記録点(すべて slow path のみ、定常状態のコストゼロ)**:
+  - MethodCall: `runtime::find_method`(単一エントリキャッシュのミス時に
+    呼ばれる)で `class_for_ic` と解決済み FuncId を記録。
+    `cacheable = false`(frame-dependent super)は記録しない。
+  - BinOp / Cmp / Index / StoreIndex: `vm_save_binary_class` /
+    `a64_save_binary_class` の「初回 population」と「poly 遷移」の 2 分岐
+    から `runtime::pmc_record_binary(vm, globals, pc)` を呼ぶ。クラスは
+    直前にバイトコード IC へ書いた値を pc から読み戻すので値渡し不要。
+    callsite は `cfp → iseq → get_pc_index → callsite_map` で解決
+    (record 分岐のみのコスト)。
+  - UnOp: 同様に `vm_save_lhs_class` / `a64_save_lhs_class` から
+    `pmc_record_unary`(レシーバのみ)。
+- **ダンプ**: `--features profile` の終了時統計(`Store::show_stats`)に
+  「polymorphic method cache」節を追加。サイト数サマリ
+  (recorded / polymorphic / megamorphic)と、slow-path 観測数順の
+  多相サイト top 40 を `class(/arg)(=resolved-func) xN` 形式で表示。
+  count は **slow-path 観測数**(fast path は記録しないので呼び出し
+  総数ではない)。
+- 実測例(gem 起動込みの小スクリプト): 3,984 サイト記録・35 多相・
+  13 megamorphic。`initialize` / `__builtin_allocate__`(overflow 196)や
+  Errno 網羅の `is_a?`(overflow 130)が megamorphic として正しく
+  弁別され、`nil?` は `Array=Kernel#nil? | NilClass=Kernel#nil? | …` と
+  全 way 同一 FuncId が観測できる — §7.2 の「同一 FuncId way の畳み込み」
+  の実データがそのまま得られる。
+
 ## 8. このブランチに含まれる実装
 
 - `JIT: nil-tolerant receiver guard for nil? call sites` — §3.1/3.2。

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -304,17 +304,20 @@ StoreIndex(133)は全て `new_callsite` + `new_callsite_map_entry` で
 - binop/cmp fast path の欠落は実質無害: fast path しか通らないサイトは
   単相で、多相サイトは必ず generic を通ってそこで検出される(最大
   1 実行遅れるだけ)。**binop/cmp は現状のまま PMC の前提を満たす**。
-- **unop は検出が完全に欠落**: `vm_save_lhs_class` は比較なし、
-  `TraceIr::UnOp` も `opcode_sub` を読まない。JIT は単相ガード+deopt
-  (`Not` は `call_unary_method`、算術 unop は class 分岐)なので、
-  `-x` の Integer/Float 交互や `!x` の nil/オブジェクト交互は `nil?` と
-  同型の deopt を起こし得る。対処: `vm_save_lhs_class` に
-  `vm_save_binary_class` と同じ比較+`opcode_sub = 1` を足す
-  (generic 側のみ、両アーキ)。
-- **Index/StoreIndex も検出なし**: クラス記録が VM 命令内でなく
-  ランタイムヘルパにあるため、検出はヘルパ側(Rust)で行い、
-  `opcode_sub` へ書き戻す pc を渡す改修になる。`x[i]` の Hash/Array
-  多相は実コードで普通に起きるので、PMC 展開の第二候補。
+- **unop の検出欠落 → 実装済み**(このブランチ): `vm_save_lhs_class` /
+  `a64_save_lhs_class` に `vm_save_binary_class` と同じ
+  「キャッシュ populated かつクラス変化 → `opcode_sub = 1`」を追加した
+  (generic 側のみ、両アーキ)。`TraceIr::UnOp` にも `_polymorphic` を
+  配線済み(JIT 消費は PMC 本実装で)。
+- **Index/StoreIndex の検出欠落 → 実装済み**(このブランチ): クラス
+  記録をランタイムヘルパから **VM 命令内の機械語へ移した**。binop と
+  同じ `[pc+8]`/`[pc+12]` レイアウトなので `vm_save_binary_class` /
+  `a64_save_binary_class` をそのまま流用でき、検出も同時に付く。
+  `get_index` / `set_index` は `ClassIdSlot` ポインタ引数(bit 0 に
+  is_func_call を折り込むハック)を廃止して素の `is_func_call` を
+  受ける形に単純化した。`TraceIr::Index` / `IndexAssign` にも
+  `_polymorphic` を配線済み。Index は binop と違い fixnum fast path を
+  持たないため、検出は全実行に効く(遅延なし)。
 
 ## 8. このブランチに含まれる実装
 

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -280,6 +280,42 @@ PMC 案はまさにこの穴を埋める。
   `cmp_eq_values` の内部コスト内訳(解決 vs 本体実行)を測ってから
   決める。
 
+### 7.4 検証結果: callsite 記録と poly 検出の全数確認(2026-08)
+
+**callsite 記録(`bytecodegen/encode.rs`)**: UnOp(121-124)/
+BinOp(160+)/ Cmp 両形(140-146, 150-156)/ Index(132)/
+StoreIndex(133)は全て `new_callsite` + `new_callsite_map_entry` で
+`CallSiteId` に到達できる。例外は **RescueTEq(157)のみ**(rescue 節
+マッチ専用、常にランタイムヘルパ経由で IC なし — PMC 対象外で問題ない)。
+`get_callsite_id` が `Option` なのはこの 1 命令のためで、ペア PMC を
+`CallSiteInfo` に置く設計は追加テーブルなしで成立する。
+
+**VM の poly 検出(x86_64 / aarch64 でミラーを確認)**:
+
+| 経路 | 保存 | `opcode_sub` 検出 |
+|---|---|---|
+| binop/cmp generic(`vm_generic_binop` → `vm_save_binary_class`) | ✓ | ✓ |
+| binop/cmp fixnum fast path(`vm_save_binary_integer`) | 上書きのみ | ✗(無害 — 下記) |
+| unop generic(`vm_generic_unop` → `vm_save_lhs_class`) | ✓ | **✗ 欠落** |
+| unop fixnum fast path(`vm_lhs_integer`) | 上書きのみ | ✗ |
+| Index / StoreIndex(`runtime::get_index`/`set_index` が ClassIdSlot へ無条件代入) | ✓ | **✗ 欠落** |
+| メソッド呼び出し slow path | ✓ | ✓ |
+
+- binop/cmp fast path の欠落は実質無害: fast path しか通らないサイトは
+  単相で、多相サイトは必ず generic を通ってそこで検出される(最大
+  1 実行遅れるだけ)。**binop/cmp は現状のまま PMC の前提を満たす**。
+- **unop は検出が完全に欠落**: `vm_save_lhs_class` は比較なし、
+  `TraceIr::UnOp` も `opcode_sub` を読まない。JIT は単相ガード+deopt
+  (`Not` は `call_unary_method`、算術 unop は class 分岐)なので、
+  `-x` の Integer/Float 交互や `!x` の nil/オブジェクト交互は `nil?` と
+  同型の deopt を起こし得る。対処: `vm_save_lhs_class` に
+  `vm_save_binary_class` と同じ比較+`opcode_sub = 1` を足す
+  (generic 側のみ、両アーキ)。
+- **Index/StoreIndex も検出なし**: クラス記録が VM 命令内でなく
+  ランタイムヘルパにあるため、検出はヘルパ側(Rust)で行い、
+  `opcode_sub` へ書き戻す pc を渡す改修になる。`x[i]` の Hash/Array
+  多相は実コードで普通に起きるので、PMC 展開の第二候補。
+
 ## 8. このブランチに含まれる実装
 
 - `JIT: nil-tolerant receiver guard for nil? call sites` — §3.1/3.2。

--- a/doc/polymorphic_call.md
+++ b/doc/polymorphic_call.md
@@ -334,10 +334,18 @@ StoreIndex(133)は全て `new_callsite` + `new_callsite_map_entry` で
     `cacheable = false`(frame-dependent super)は記録しない。
   - BinOp / Cmp / Index / StoreIndex: `vm_save_binary_class` /
     `a64_save_binary_class` の「初回 population」と「poly 遷移」の 2 分岐
-    から `runtime::pmc_record_binary(vm, globals, pc)` を呼ぶ。クラスは
-    直前にバイトコード IC へ書いた値を pc から読み戻すので値渡し不要。
-    callsite は `cfp → iseq → get_pc_index → callsite_map` で解決
+    から `runtime::pmc_record_binary(vm, globals, pc, old_lhs, old_rhs)`
+    を呼ぶ。新クラスは直前にバイトコード IC へ書いた値を pc から読み
+    戻し、**置き換えられた旧ペアも引数で渡して一緒に記録する**。
+    fixnum fast path(`vm_save_binary_integer`)は IC に無記録で
+    スタンプするため、displacement の瞬間がそのペアを PMC に残す唯一の
+    機会 — IC は実行とともに変化するので、これを取り逃すと IC を
+    通過したクラスが失われる。callsite は
+    `cfp → iseq → get_pc_index → callsite_map` で解決
     (record 分岐のみのコスト)。
+    なお「fast path のスタンプが一度も displace されずに終わった」
+    サイトはその 1 クラスが PMC に載らないが、IC 自体が生きている —
+    **消費側は IC の現内容と PMC の和集合を観測集合として扱う**こと。
   - UnOp: 同様に `vm_save_lhs_class` / `a64_save_lhs_class` から
     `pmc_record_unary`(レシーバのみ)。
 - **ダンプ**: `--features profile` の終了時統計(`Store::show_stats`)に

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -884,6 +884,31 @@ impl Codegen {
             LInst::GuardClass { reg, class, deopt } => {
                 self.a64_guard_class(reg, class, &deopt);
             }
+            // Class-set guard: membership chain built from the single-class
+            // guard — each class's check falls through on match (branch to
+            // ok) and moves to the next candidate on mismatch; the last
+            // candidate's mismatch is the real deopt.
+            LInst::GuardClassIn {
+                reg,
+                classes,
+                deopt,
+            } => {
+                let ok = self.jit.label();
+                let len = classes.len();
+                for (i, class) in classes.iter().enumerate() {
+                    if i + 1 < len {
+                        let next = self.jit.label();
+                        self.a64_guard_class(reg, *class, &next);
+                        monoasm_arm64!(&mut self.jit,
+                            b ok;
+                        );
+                        self.jit.bind_label(next);
+                    } else {
+                        self.a64_guard_class(reg, *class, &deopt);
+                    }
+                }
+                self.jit.bind_label(ok);
+            }
             // Type guard: deopt unless `reg` is an Array (immediate check, then
             // the RValue.ty byte).
             LInst::GuardArrayTy { reg, deopt } => {

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -554,22 +554,33 @@ impl Codegen {
         let p = self.jit.get_current_address();
         let raise = self.entry_raise.clone();
         monoasm_arm64!(&mut self.jit,
-            mov x0, x(EXEC.0);
-            mov x1, x(GLOBALS.0);
             ldrh x2, [x(PC.0), #(2)];  // base slot
-            // is_func_call = (base slot == self, slot 0): a literal `self[i]`
-            // reaches a private `#[]`; any other receiver enforces visibility.
-            cmp x2, #(0);
         );
-        self.jit.cset(X5, Cond::Eq); // x5 <- (base slot == 0)
         self.a64_slot_value(X2); // base
         monoasm_arm64!(&mut self.jit,
-            ldrh x3, [x(PC.0)];
+            mov x13, x2;               // keep base across the class save
+            ldrh x3, [x(PC.0)];        // idx slot
         );
         self.a64_slot_value(X3); // idx
         monoasm_arm64!(&mut self.jit,
-            add x4, x(PC.0), #(8);  // &cache (8-aligned)
-            orr x4, x4, x5;         // fold is_func_call into bit 0
+            mov x14, x3;               // keep idx
+        );
+        // Record (base, idx) classes into the inline cache and mark the site
+        // polymorphic on a class change — same machine-level bookkeeping as
+        // the binops, so the helper no longer needs the ClassIdSlot pointer.
+        self.a64_save_binary_class();
+        monoasm_arm64!(&mut self.jit,
+            // is_func_call = (base slot == self, slot 0): a literal `self[i]`
+            // reaches a private `#[]`; any other receiver enforces visibility.
+            ldrh x4, [x(PC.0), #(2)];
+            cmp x4, #(0);
+        );
+        self.jit.cset(X4, Cond::Eq); // x4 <- (base slot == 0)
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x13;               // base
+            mov x3, x14;               // idx
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
             mov x9, (runtime::get_index as *const () as u64);
             blr x9;
         );
@@ -583,26 +594,36 @@ impl Codegen {
         let p = self.jit.get_current_address();
         let raise = self.entry_raise.clone();
         monoasm_arm64!(&mut self.jit,
-            mov x0, x(EXEC.0);
-            mov x1, x(GLOBALS.0);
             ldrh x2, [x(PC.0), #(2)];  // base slot
-            // is_func_call = (base slot == self, slot 0): `self[i] = v` reaches
-            // a private `#[]=`; any other receiver enforces visibility.
-            cmp x2, #(0);
         );
-        self.jit.cset(X6, Cond::Eq); // x6 <- (base slot == 0)
         self.a64_slot_value(X2); // base
         monoasm_arm64!(&mut self.jit,
-            ldrh x3, [x(PC.0)];
+            mov x13, x2;               // keep base across the class save
+            ldrh x3, [x(PC.0)];        // idx slot
         );
         self.a64_slot_value(X3); // idx
+        monoasm_arm64!(&mut self.jit,
+            mov x14, x3;               // keep idx
+        );
+        // Record (base, idx) classes and mark polymorphic on change — see
+        // `a64_op_index`.
+        self.a64_save_binary_class();
         monoasm_arm64!(&mut self.jit,
             ldrh x4, [x(PC.0), #(4)];
         );
         self.a64_slot_value(X4); // src
         monoasm_arm64!(&mut self.jit,
-            add x5, x(PC.0), #(8);  // &cache (8-aligned)
-            orr x5, x5, x6;         // fold is_func_call into bit 0
+            // is_func_call = (base slot == self, slot 0): `self[i] = v` reaches
+            // a private `#[]=`; any other receiver enforces visibility.
+            ldrh x5, [x(PC.0), #(2)];
+            cmp x5, #(0);
+        );
+        self.jit.cset(X5, Cond::Eq); // x5 <- (base slot == 0)
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x13;               // base
+            mov x3, x14;               // idx
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
             mov x9, (runtime::set_index as *const () as u64);
             blr x9;
             cbz x0, raise;
@@ -1306,16 +1327,28 @@ impl Codegen {
     /// X13 (lhs) / X14 (rhs); `get_class` reads X0 only, so X13/X14 survive.
     /// Clobbers x0/x1/x2 and x10/x11/x12 and the link register.
     /// Record the unary operand's class into the UnOp inline cache (classid1
-    /// `[PC+8]`) so the JIT can type the site. Mirrors x86 `vm_save_lhs_class`.
+    /// `[PC+8]`) so the JIT can type the site, with the same polymorphic
+    /// detection as `a64_save_binary_class`: once the cache is populated, a
+    /// class change sets `opcode_sub` = 1. Mirrors x86 `vm_save_lhs_class`.
     /// Operand is the Value in x2. NB: `get_class` clobbers x1/x2 for
     /// immediate receivers, so callers must reload the operand afterwards.
-    /// Clobbers x0/x1/x2 and the link register.
+    /// Clobbers x0/x1/x2, x10/x11 and the link register.
     pub(in crate::codegen) fn a64_save_lhs_class(&mut self) {
         let get_class = self.get_class.clone();
+        let skip = self.jit.label();
         monoasm_arm64!(&mut self.jit,
+            ldr w10, [x(PC.0), #(8)]; // old classid1 (0 = cache empty)
             mov x0, x2;
             bl get_class;             // x0 = class(operand)
             str w0, [x(PC.0), #(8)];  // classid1
+            cbz w10, skip;
+            cmp w10, w0;
+        );
+        self.jit.bcond_label(Cond::Eq, &skip);
+        monoasm_arm64!(&mut self.jit,
+            mov x11, (1);
+            strb w11, [x(PC.0), #(7)]; // opcode_sub = 1 (polymorphic)
+            skip:
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1336,18 +1336,28 @@ impl Codegen {
     pub(in crate::codegen) fn a64_save_lhs_class(&mut self) {
         let get_class = self.get_class.clone();
         let skip = self.jit.label();
+        let record = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             ldr w10, [x(PC.0), #(8)]; // old classid1 (0 = cache empty)
             mov x0, x2;
             bl get_class;             // x0 = class(operand)
             str w0, [x(PC.0), #(8)];  // classid1
-            cbz w10, skip;
+            cbz w10, record;          // first population: record, no flag
             cmp w10, w0;
         );
         self.jit.bcond_label(Cond::Eq, &skip);
         monoasm_arm64!(&mut self.jit,
             mov x11, (1);
             strb w11, [x(PC.0), #(7)]; // opcode_sub = 1 (polymorphic)
+            record:
+            // Feed the call site's polymorphic method cache — population and
+            // transitions only. The operand (x2) is already documented as
+            // clobbered here; callers reload it afterwards.
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            mov x2, x(PC.0);           // the executing instruction
+            mov x9, (runtime::pmc_record_unary as *const () as u64);
+            blr x9;
             skip:
         );
     }
@@ -1356,6 +1366,7 @@ impl Codegen {
         let get_class = self.get_class.clone();
         let set_poly = self.jit.label();
         let skip = self.jit.label();
+        let record = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             // Read the previously-cached operand classes before overwriting
             // them (x10 = old classid1, x12 = old classid2; 0 = cache empty),
@@ -1374,7 +1385,7 @@ impl Codegen {
             // class changed, mark the site polymorphic (opcode_sub = 1, offset
             // +7) so the JIT emits a non-deoptimizing dispatch instead of a
             // monomorphic class guard.
-            cbz w10, skip;
+            cbz w10, record;            // first population: record, no flag
             ldr w11, [x(PC.0), #(8)];
             cmp w10, w11;
         );
@@ -1389,6 +1400,17 @@ impl Codegen {
             set_poly:
             mov x11, (1);
             strb w11, [x(PC.0), #(7)];  // opcode_sub = 1 (polymorphic)
+            record:
+            // Feed the call site's polymorphic method cache — population and
+            // transitions only, never the steady state. Preserve the operand
+            // Values in x13/x14 (the caller contract) across the C call.
+            stp x13, x14, [sp, #-16]!;
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            mov x2, x(PC.0);            // the executing instruction
+            mov x9, (runtime::pmc_record_binary as *const () as u64);
+            blr x9;
+            ldp x13, x14, [sp], #16;
             skip:
         );
     }

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1352,10 +1352,13 @@ impl Codegen {
             record:
             // Feed the call site's polymorphic method cache — population and
             // transitions only. The operand (x2) is already documented as
-            // clobbered here; callers reload it afterwards.
+            // clobbered here; callers reload it afterwards. The displaced
+            // class rides along in w10 so a class the fixnum fast path
+            // stamped (without recording) is captured on displacement.
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x2, x(PC.0);           // the executing instruction
+            mov x3, x10;               // displaced class (0 = empty)
             mov x9, (runtime::pmc_record_unary as *const () as u64);
             blr x9;
             skip:
@@ -1403,11 +1406,16 @@ impl Codegen {
             record:
             // Feed the call site's polymorphic method cache — population and
             // transitions only, never the steady state. Preserve the operand
-            // Values in x13/x14 (the caller contract) across the C call.
+            // Values in x13/x14 (the caller contract) across the C call. The
+            // displaced pair still sits in w10/w12 and rides along so classes
+            // the fixnum fast path stamped (without recording) are captured
+            // the moment they leave the inline cache.
             stp x13, x14, [sp, #-16]!;
             mov x0, x(EXEC.0);
             mov x1, x(GLOBALS.0);
             mov x2, x(PC.0);            // the executing instruction
+            mov x3, x10;                // displaced lhs class (0 = empty)
+            mov x4, x12;                // displaced rhs class
             mov x9, (runtime::pmc_record_binary as *const () as u64);
             blr x9;
             ldp x13, x14, [sp], #16;

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -54,6 +54,7 @@ impl Codegen {
             | AsmInst::CheckLocal(..)
             | AsmInst::OptCase { .. }
             | AsmInst::GuardClass(..)
+            | AsmInst::GuardClassIn(..)
             | AsmInst::Deopt(..)
             | AsmInst::HandleError(..)
             | AsmInst::CheckStack { .. }
@@ -595,6 +596,31 @@ impl Codegen {
             }
             // Type / class guards: deopt (jump to the side-exit) on a mismatch.
             LInst::GuardClass { reg, class, deopt } => self.guard_class(reg, class, &deopt),
+            LInst::GuardClassIn {
+                reg,
+                classes,
+                deopt,
+            } => {
+                // Membership chain built from the single-class guard: each
+                // class's check falls through on match (jump to ok) and
+                // branches to the next candidate on mismatch; the last
+                // candidate's mismatch is the real deopt.
+                let ok = self.jit.label();
+                let len = classes.len();
+                for (i, class) in classes.iter().enumerate() {
+                    if i + 1 < len {
+                        let next = self.jit.label();
+                        self.guard_class(reg, *class, &next);
+                        monoasm!( &mut self.jit,
+                            jmp ok;
+                        );
+                        self.jit.bind_label(next);
+                    } else {
+                        self.guard_class(reg, *class, &deopt);
+                    }
+                }
+                self.jit.bind_label(ok);
+            }
             LInst::GuardArrayTy { reg, deopt } => self.guard_array_ty(reg, &deopt),
             LInst::GuardFrozen { deopt } => self.guard_frozen(&deopt),
             // Constant-load base-class guard: deopt unless the accumulator equals

--- a/monoruby/src/codegen/arch/x86_64/guard.rs
+++ b/monoruby/src/codegen/arch/x86_64/guard.rs
@@ -337,14 +337,30 @@ impl Codegen {
             jnz l1;
         );
         self.float_val_to_f64(reg, dst, deopt);
-        assert_eq!(0, self.jit.get_page());
-        self.jit.select_page(1);
-        monoasm!( &mut self.jit,
-        l1:
-            movq rdi, R(reg as _);
-            jmp deopt;
-        );
-        self.jit.select_page(0);
+        // The fixnum bailout goes to the cold page when we are emitting hot
+        // code; when this conversion itself sits in cold (page-1) code — a
+        // block whose receiver stayed polymorphic, e.g. behind a
+        // nil-tolerant guard — it is emitted in line instead, jumped over
+        // by the fall-through (same dual shape as `guard_class`'s
+        // fail-wrapper).
+        if self.jit.get_page() == 0 {
+            self.jit.select_page(1);
+            monoasm!( &mut self.jit,
+            l1:
+                movq rdi, R(reg as _);
+                jmp deopt;
+            );
+            self.jit.select_page(0);
+        } else {
+            let skip = self.jit.label();
+            monoasm!( &mut self.jit,
+                jmp skip;
+            l1:
+                movq rdi, R(reg as _);
+                jmp deopt;
+            skip:
+            );
+        }
     }
 
     /*///
@@ -433,15 +449,30 @@ impl Codegen {
         exit:
         }
 
-        assert_eq!(0, self.jit.get_page());
-        self.jit.select_page(1);
-        self.jit.bind_label(heap);
-        self.guard_rvalue(reg, FLOAT_CLASS, side_exit);
-        monoasm! {&mut self.jit,
-            movq xmm(dst), [R(r) + (RVALUE_OFFSET_KIND)];
-            jmp  exit;
+        // Heap-Float load: on the cold page when emitting hot code, in line
+        // (jumped over by the fall-through) when this conversion itself is
+        // already in cold page-1 code — same dual shape as `float_to_f64`.
+        if self.jit.get_page() == 0 {
+            self.jit.select_page(1);
+            self.jit.bind_label(heap);
+            self.guard_rvalue(reg, FLOAT_CLASS, side_exit);
+            monoasm! {&mut self.jit,
+                movq xmm(dst), [R(r) + (RVALUE_OFFSET_KIND)];
+                jmp  exit;
+            }
+            self.jit.select_page(0);
+        } else {
+            let skip = self.jit.label();
+            monoasm! {&mut self.jit,
+                jmp  skip;
+            }
+            self.jit.bind_label(heap);
+            self.guard_rvalue(reg, FLOAT_CLASS, side_exit);
+            monoasm! {&mut self.jit,
+                movq xmm(dst), [R(r) + (RVALUE_OFFSET_KIND)];
+            }
+            self.jit.bind_label(skip);
         }
-        self.jit.select_page(0);
     }
 
     ///

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -514,21 +514,35 @@ impl Codegen {
     /// - rdi: Value
     ///
     /// ### destroy
-    /// - rax, r8
+    /// - rax, r8 (+ caller-saved except rdi on the record branch)
     ///
     fn vm_save_lhs_class(&mut self) {
         let get_class = self.get_class.clone();
         let skip = self.jit.label();
+        let record = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
             // r8 <- cached class (0 if the inline cache is empty)
             movl  r8, [r13 - 8];
             movl  [r13 - 8], rax;
             testq r8, r8;
-            jeq   skip;
+            jeq   record;      // first population: record without the flag
             cmpl  r8, rax;
             jeq   skip;
             movb  [r13 + (OPCODE_SUB)], 1;
+        record:
+            // Feed the call site's polymorphic method cache — population and
+            // transitions only, see `vm_save_binary_class`. The caller keeps
+            // the operand Value in rdi; preserve it (rax as padding).
+            pushq rdi;
+            pushq rax;
+            movq rdi, rbx;
+            movq rsi, r12;
+            lea  rdx, [r13 - 16];
+            movq rax, (runtime::pmc_record_unary);
+            call rax;
+            popq rax;
+            popq rdi;
         skip:
         };
     }
@@ -541,12 +555,13 @@ impl Codegen {
     /// - rsi: Value
     ///
     /// ### destroy
-    /// - rax
+    /// - rax, r8, r9 (+ caller-saved except rdi/rsi/r15 on the record branch)
     ///
     fn vm_save_binary_class(&mut self) {
         let get_class = self.get_class.clone();
         let skip = self.jit.label();
         let set_poly = self.jit.label();
+        let record = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
             // r8 <- cached lhs class (0 if the inline cache is empty)
@@ -566,7 +581,7 @@ impl Codegen {
             // non-deoptimizing dispatch instead of a monomorphic
             // class guard.
             testq r8, r8;
-            jeq   skip;
+            jeq   record;      // first population: record without the flag
             cmpl  r8, [r13 - 8];
             jne   set_poly;
             cmpl  r9, [r13 - 4];
@@ -574,6 +589,25 @@ impl Codegen {
             jmp   skip;
         set_poly:
             movb  [r13 + (OPCODE_SUB)], 1;
+        record:
+            // Feed the call site's polymorphic method cache. Population and
+            // transitions only — the steady state never gets here — so the
+            // C call is off every hot path. The caller contract keeps the
+            // operand Values in rdi/rsi (and vm_index_assign's src in r15);
+            // preserve them across the call, rcx as alignment padding.
+            pushq rdi;
+            pushq rsi;
+            pushq r15;
+            pushq rcx;
+            movq rdi, rbx;
+            movq rsi, r12;
+            lea  rdx, [r13 - 16];  // r13 = next instruction; the cache is ours
+            movq rax, (runtime::pmc_record_binary);
+            call rax;
+            popq rcx;
+            popq r15;
+            popq rsi;
+            popq rdi;
         skip:
         };
     }

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -504,11 +504,32 @@ impl Codegen {
     /// ### out
     /// - rax: ClassId
     ///
+    ///
+    /// Save the class of the unary operand in the inline cache, with the
+    /// same polymorphic detection as `vm_save_binary_class`: once the cache
+    /// is populated, a class change marks the site polymorphic via
+    /// opcode_sub.
+    ///
+    /// ### in
+    /// - rdi: Value
+    ///
+    /// ### destroy
+    /// - rax, r8
+    ///
     fn vm_save_lhs_class(&mut self) {
         let get_class = self.get_class.clone();
+        let skip = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
+            // r8 <- cached class (0 if the inline cache is empty)
+            movl  r8, [r13 - 8];
             movl  [r13 - 8], rax;
+            testq r8, r8;
+            jeq   skip;
+            cmpl  r8, rax;
+            jeq   skip;
+            movb  [r13 + (OPCODE_SUB)], 1;
+        skip:
         };
     }
 
@@ -989,24 +1010,25 @@ impl Codegen {
     fn vm_index(&mut self) -> CodePtr {
         let label = self.jit.get_current_address();
         self.fetch3();
+        self.vm_get_slot_value(GP::Rdi); // base: Value
+        self.vm_get_slot_value(GP::Rsi); // idx: Value
+        // Record (base, idx) classes into the inline cache and mark the
+        // site polymorphic on a class change — same machine-level
+        // bookkeeping as the binops, so the helper no longer needs the
+        // ClassIdSlot pointer.
+        self.vm_save_binary_class();
         // is_func_call = (base slot == self, slot 0): a literal `self[i]`
         // reaches a private `#[]`; any other receiver enforces visibility.
-        // rdi still holds the base *slot* here, before it becomes a value.
-        // The bit rides in `class_slot`'s low bit (8-aligned → free).
+        // The base slot is the `:2` bytecode operand at [r13 - 14].
         monoasm! { &mut self.jit,
-            xorq rax, rax;
-            testq rdi, rdi;
-            seteq rax;     // rax <- (base slot == 0)
-        };
-        self.vm_get_slot_value(GP::Rdi);
-        self.vm_get_slot_value(GP::Rsi);
-        monoasm! { &mut self.jit,
+            movzxw rax, [r13 - 14];
+            xorq r8, r8;
+            testq rax, rax;
+            seteq r8;
             movq rdx, rdi; // base: Value
             movq rcx, rsi; // idx: Value
             movq rdi, rbx; // &mut Interp
             movq rsi, r12; // &mut Globals
-            lea  r8, [r13 - 8]; // &mut ClassIdSlot
-            orq  r8, rax;  // fold is_func_call into bit 0
             movq rax, (runtime::get_index);
             call rax;
         };
@@ -1019,25 +1041,24 @@ impl Codegen {
     fn vm_index_assign(&mut self) -> CodePtr {
         let label = self.jit.get_current_address();
         self.fetch3();
+        self.vm_get_slot_value(GP::R15); // src: Value
+        self.vm_get_slot_value(GP::Rdi); // base: Value
+        self.vm_get_slot_value(GP::Rsi); // idx: Value
+        // Record (base, idx) classes and mark polymorphic on change — see
+        // `vm_index`. Destroys rax/r8/r9 only; r15 (src) survives.
+        self.vm_save_binary_class();
         // is_func_call = (base slot == self, slot 0): `self[i] = v` reaches a
-        // private `#[]=`. rdi still holds the base *slot* here. The bit rides
-        // in `class_slot`'s low bit (8-aligned → free).
+        // private `#[]=`. The base slot is the `:2` operand at [r13 - 14].
         monoasm! { &mut self.jit,
-            xorq rax, rax;
-            testq rdi, rdi;
-            seteq rax;     // rax <- (base slot == 0)
-        };
-        self.vm_get_slot_value(GP::R15);
-        self.vm_get_slot_value(GP::Rdi);
-        self.vm_get_slot_value(GP::Rsi);
-        monoasm! { &mut self.jit,
+            movzxw rax, [r13 - 14];
+            xorq r9, r9;
+            testq rax, rax;
+            seteq r9;
             movq rdx, rdi; // base: Value
             movq rcx, rsi; // idx: Value
             movq r8, r15;  // src: Value
             movq rdi, rbx; // &mut Interp
             movq rsi, r12; // &mut Globals
-            lea  r9, [r13 - 8]; // &mut ClassIdSlot
-            orq  r9, rax;  // fold is_func_call into bit 0
             movq rax, (runtime::set_index);
             call rax;
         };

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -533,12 +533,15 @@ impl Codegen {
         record:
             // Feed the call site's polymorphic method cache — population and
             // transitions only, see `vm_save_binary_class`. The caller keeps
-            // the operand Value in rdi; preserve it (rax as padding).
+            // the operand Value in rdi; preserve it (rax as padding). The
+            // displaced class rides along in r8 so a class the fixnum fast
+            // path stamped (without recording) is captured on displacement.
             pushq rdi;
             pushq rax;
             movq rdi, rbx;
             movq rsi, r12;
             lea  rdx, [r13 - 16];
+            movq rcx, r8;          // displaced class (0 = cache was empty)
             movq rax, (runtime::pmc_record_unary);
             call rax;
             popq rax;
@@ -594,7 +597,10 @@ impl Codegen {
             // transitions only — the steady state never gets here — so the
             // C call is off every hot path. The caller contract keeps the
             // operand Values in rdi/rsi (and vm_index_assign's src in r15);
-            // preserve them across the call, rcx as alignment padding.
+            // preserve them across the call, rcx as alignment padding. The
+            // displaced pair still sits in r8/r9 and rides along so classes
+            // the fixnum fast path stamped (without recording) are captured
+            // the moment they leave the inline cache.
             pushq rdi;
             pushq rsi;
             pushq r15;
@@ -602,6 +608,8 @@ impl Codegen {
             movq rdi, rbx;
             movq rsi, r12;
             lea  rdx, [r13 - 16];  // r13 = next instruction; the cache is ours
+            movq rcx, r8;          // displaced lhs class (0 = cache was empty)
+            movq r8, r9;           // displaced rhs class
             movq rax, (runtime::pmc_record_binary);
             call rax;
             popq rcx;

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1369,6 +1369,12 @@ pub(super) enum AsmInst {
     /// - R(*reg*): Value
     ///
     GuardClass(GP, ClassId, AsmDeopt),
+    /// Class-set guard: pass when R(*reg*)'s runtime class is any of the
+    /// listed classes, deopt otherwise. For polymorphic call sites whose
+    /// observed receiver classes (PMC ∪ inline cache) all re-resolve to one
+    /// `FuncId` at compile time — the whole set shares a single target, so
+    /// one membership guard replaces the per-class deopt.
+    GuardClassIn(GP, Box<[ClassId]>, AsmDeopt),
     GuardArrayTy(GP, AsmDeopt),
     GuardCapture(AsmDeopt),
 

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -123,6 +123,16 @@ impl Codegen {
                     deopt,
                 });
             }
+            // Class-set guard: any listed class passes, everything else
+            // deopts.
+            AsmInst::GuardClassIn(r, classes, deopt) => {
+                let deopt = labels[deopt].clone();
+                self.encode_linst(LInst::GuardClassIn {
+                    reg: r,
+                    classes,
+                    deopt,
+                });
+            }
             // Unconditional jump to a side-exit (deopt) label.
             AsmInst::Deopt(deopt) => self.encode_linst(LInst::Deopt {
                 deopt: labels[deopt].clone(),

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -511,7 +511,7 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
 
-            TraceIr::UnOp { kind, dst, src, ic } => {
+            TraceIr::UnOp { kind, dst, src, ic, _polymorphic: _ } => {
                 let class = if let Some(class) = state.class(src) {
                     Some(class)
                 } else {
@@ -653,12 +653,14 @@ impl<'a> JitContext<'a> {
                 base,
                 idx,
                 class: ic,
+                _polymorphic: _,
             } => return self.index(state, ir, base, idx, ic, bc_pos),
             TraceIr::IndexAssign {
                 base,
                 idx,
                 src,
                 class: ic,
+                _polymorphic: _,
             } => {
                 assert_eq!(idx.0 + 1, src.0);
                 return self.index_assign(state, ir, base, idx, src, ic, bc_pos);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -107,6 +107,70 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// The "polymorphic but single-target" test: collect the receiver
+    /// classes the VM observed at this call site (its polymorphic method
+    /// cache plus the current inline-cache class — the PMC alone can miss a
+    /// pair the fixnum fast path stamped and never displaced), and answer
+    /// the set when **every** class re-resolves the called name to
+    /// `func_id`. Resolution is re-computed per class with `jit_check_call`
+    /// under the already-emitted class version guard; the FuncId the PMC
+    /// recorded is deliberately not trusted (it may predate a
+    /// redefinition). A megamorphic site (PMC overflow) has an incomplete
+    /// observation set, so it never qualifies; nor does a class whose
+    /// resolution's visibility would block this call site.
+    ///
+    /// The classes are ordered most-observed-first so the emitted
+    /// membership chain tests the hottest class first.
+    ///
+    /// Restricted to **native (builtin) targets**: a shared FuncId is only
+    /// a shared *implementation* for those. An ISeq target's JIT code is
+    /// specialized on the receiver class (its internal `self` dispatch —
+    /// `def g = f` resolving `f` per subclass — is baked in), an attr
+    /// accessor's ivar slot is class-layout-dependent, and a Struct
+    /// reader's slot index is per-class, so for all of them the set's
+    /// members must not funnel into one compiled body.
+    ///
+    fn pmc_same_target_classes(
+        &mut self,
+        callid: CallSiteId,
+        recv_class: ClassId,
+        func_id: FuncId,
+    ) -> Option<Box<[ClassId]>> {
+        if !matches!(self.store[func_id].kind, FuncKind::Builtin { .. }) {
+            return None;
+        }
+        let callsite = &self.store[callid];
+        let name = callsite.name?;
+        let pmc = &callsite.pmc;
+        if pmc.overflow() != 0 {
+            return None;
+        }
+        let mut classes: Vec<(ClassId, u32)> = pmc
+            .entries()
+            .iter()
+            .map(|e| (e.recv, e.count))
+            .collect();
+        if !classes.iter().any(|(c, _)| *c == recv_class) {
+            classes.push((recv_class, 0));
+        }
+        if classes.len() < 2 {
+            // Monomorphic — the ordinary single-class guard is strictly
+            // better (it refines the state for the inliners downstream).
+            return None;
+        }
+        classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
+        let mut set = Vec::with_capacity(classes.len());
+        for (class, _) in classes {
+            let (fid, visibility) = self.jit_check_call(class, Some(name))?;
+            if fid != func_id || self.jit_visibility_blocks(callid, visibility) {
+                return None;
+            }
+            set.push(class);
+        }
+        Some(set.into_boxed_slice())
+    }
+
+    ///
     /// Compile TraceIr::MethodCall with inline method cache info.
     ///
     /// *visibility* is the resolved method's visibility, obtained together with
@@ -176,25 +240,50 @@ impl<'a> JitContext<'a> {
         self.guard_class_version(state, ir, true);
 
         // receiver class guard
+        //
+        // When the class-set guard below is taken, the receiver's class is
+        // NOT statically refined (it may be any member of the set), so the
+        // inline generators — which assume a single `recv_class` receiver —
+        // must be skipped for this compile.
+        let mut same_target_set_guarded = false;
         if state.class(recv) != Some(recv_class) {
-            // Specialized JIT recompiles via an idx, not a position;
-            // keep it on the plain deopt path (no Part B there).
-            let use_recompile = recompile_on_recv_miss
-                && !matches!(self.jit_type(), JitType::Specialized { .. });
-            let deopt = if use_recompile {
-                ir.new_recompile_deopt(
-                    state,
-                    RecompileReason::BecamePolymorphic,
-                    self.position(),
-                )
+            if !recompile_on_recv_miss
+                && let Some(classes) = self.pmc_same_target_classes(callid, recv_class, func_id)
+            {
+                // The site is polymorphic, but every receiver class the VM
+                // observed (PMC ∪ the inline cache) re-resolves — at compile
+                // time, `jit_check_call` per class, never the PMC's stored
+                // FuncId — to this very `func_id` (`Kernel#nil?`-,
+                // `Kernel#is_a?`-style sites). One membership guard over the
+                // observed set replaces the single-class guard that deopted
+                // on every off-class receiver; an unobserved class still
+                // deopts, and a redefinition recompiles via the class
+                // version guard above.
+                let deopt = ir.new_deopt(state);
+                state.load(ir, recv, GP::Rdi);
+                ir.push(AsmInst::GuardClassIn(GP::Rdi, classes, deopt));
+                same_target_set_guarded = true;
             } else {
-                ir.new_deopt(state)
-            };
-            state.load(ir, recv, GP::Rdi);
-            state.guard_class(ir, recv, GP::Rdi, recv_class, deopt);
+                // Specialized JIT recompiles via an idx, not a position;
+                // keep it on the plain deopt path (no Part B there).
+                let use_recompile = recompile_on_recv_miss
+                    && !matches!(self.jit_type(), JitType::Specialized { .. });
+                let deopt = if use_recompile {
+                    ir.new_recompile_deopt(
+                        state,
+                        RecompileReason::BecamePolymorphic,
+                        self.position(),
+                    )
+                } else {
+                    ir.new_deopt(state)
+                };
+                state.load(ir, recv, GP::Rdi);
+                state.guard_class(ir, recv, GP::Rdi, recv_class, deopt);
+            }
         }
 
-        if callsite.block_fid.is_none()
+        if !same_target_set_guarded
+            && callsite.block_fid.is_none()
             && let Some(info) = self.store.inline_info.get_inline(func_id)
         {
             match info {
@@ -1552,6 +1641,38 @@ mod tests {
     /// the forwarded count is statically known per specialization, so the
     /// fill layout (copied slots + None-filled optionals running their
     /// defaults) is a compile-time constant. Cover under-, exactly-, and
+    /// Polymorphic-but-single-target call sites: every observed receiver
+    /// class re-resolves the name to one FuncId (`Kernel#is_a?` /
+    /// `Kernel#frozen?`), so the JIT emits a class-set membership guard
+    /// instead of a single-class guard that would deopt on 3 of every 4
+    /// receivers. Covers: the set guard's hit path for each member class,
+    /// a third class with a *different* resolution arriving after warmup
+    /// (must deopt and dispatch its override), and nil/bool members.
+    #[test]
+    fn polymorphic_same_target() {
+        run_test(
+            r#"
+            def check(x) = x.is_a?(Integer)
+            def fro(x) = x.frozen?
+            vals = [[1, 2], nil, "s", { a: 1 }]
+            res = []
+            c = 0
+            f = 0
+            200.times do |i|
+                c += 1 if check(vals[i % 4])
+                f += 1 if fro(vals[i % 4])
+            end
+            res << c << f
+            class WeirdIsA
+              def is_a?(k) = "custom"
+            end
+            res << check(WeirdIsA.new)
+            res << check(7) << check(nil) << check(false)
+            res
+            "#,
+        );
+    }
+
     /// over-supplied optionals (the last vetoes the deferral and takes
     /// the eager helper path, raising ArgumentError like CRuby), plus a
     /// default expression with a side effect (must run only when the

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1673,6 +1673,45 @@ mod tests {
         );
     }
 
+    /// A megamorphic site (a fifth distinct receiver class overflows the
+    /// 4-way PMC) must NOT take the same-target set guard — the observation
+    /// set is incomplete, so `pmc_same_target_classes` rejects it and the
+    /// site keeps the ordinary single-class guard. Also exercises the PMC
+    /// overflow counter itself, and a float-typed branch behind a
+    /// polymorphic `nil?` (the receiver state stays unrefined after the set
+    /// guard, so the Float conversions downstream must still be correct).
+    #[test]
+    fn polymorphic_megamorphic_and_float() {
+        run_test(
+            r#"
+            def check(x) = x.nil?
+            def step_like(limit, by)
+              acc = 0.0
+              unless limit.nil?
+                acc += limit * 2.0
+              end
+              unless by.nil?
+                acc += by + 1.5
+              end
+              acc
+            end
+            vals = [[1, 2], nil, "s", { a: 1 }, :sym, 7, 2.5, false]
+            c = 0
+            r = 0.0
+            200.times do |i|
+              c += 1 if check(vals[i % 8])
+              case i % 4
+              when 0 then r += step_like(2.5, nil)
+              when 1 then r += step_like(nil, 3.5)
+              when 2 then r += step_like(1.5, 0.5)
+              when 3 then r += step_like(nil, nil)
+              end
+            end
+            [c, r]
+            "#,
+        );
+    }
+
     /// over-supplied optionals (the last vetoes the deferral and takes
     /// the eager helper path, raising ArgumentError like CRuby), plus a
     /// default expression with a side effect (must run only when the

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -430,6 +430,13 @@ pub(in crate::codegen) enum LInst {
         class: ClassId,
         deopt: DestLabel,
     },
+    /// Class-set guard: pass when `reg`'s runtime class is any of `classes`,
+    /// branch to `deopt` otherwise.
+    GuardClassIn {
+        reg: GP,
+        classes: Box<[ClassId]>,
+        deopt: DestLabel,
+    },
     /// Type guard: deopt unless `reg` holds an `Array`.
     GuardArrayTy {
         reg: GP,

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -163,6 +163,10 @@ pub(crate) enum TraceIr {
         dst: SlotId,
         src: SlotId,
         ic: Option<ClassId>,
+        /// The VM observed operand-class variance at this site
+        /// (`opcode_sub`). Not yet consumed by the JIT — reserved for the
+        /// polymorphic-cache lowering (see `doc/polymorphic_call.md`).
+        _polymorphic: bool,
     },
 
     BinOp {
@@ -202,12 +206,17 @@ pub(crate) enum TraceIr {
         base: SlotId,
         idx: SlotId,
         class: Option<(ClassId, ClassId)>, // (base_class, idx_class)
+        /// The VM observed operand-class variance at this site
+        /// (`opcode_sub`) — see `UnOp::_polymorphic`.
+        _polymorphic: bool,
     },
     IndexAssign {
         base: SlotId,
         idx: SlotId,
         src: SlotId,
         class: Option<(ClassId, ClassId)>, // (base_class, idx_class)
+        /// See `UnOp::_polymorphic`.
+        _polymorphic: bool,
     },
     MethodCall {
         _polymorphic: bool,
@@ -570,6 +579,7 @@ impl TraceIr {
                         dst,
                         src,
                         ic: pc.classid1(),
+                        _polymorphic: pc.opcode_sub() == 1,
                     }
                 }
                 130 => TraceIr::InlineCache,
@@ -584,6 +594,7 @@ impl TraceIr {
                     } else {
                         None
                     },
+                    _polymorphic: pc.opcode_sub() == 1,
                 },
                 133 => TraceIr::IndexAssign {
                     base: SlotId::new(op2_w2),
@@ -596,6 +607,7 @@ impl TraceIr {
                     } else {
                         None
                     },
+                    _polymorphic: pc.opcode_sub() == 1,
                 },
                 140..=146 => {
                     let kind = CmpKind::from(opcode - 140);
@@ -919,6 +931,7 @@ impl TraceIr {
                 base,
                 idx,
                 class,
+                _polymorphic: _,
             } => {
                 let op1 = format!("{:?} = {:?}.[{:?}]", dst, base, idx);
                 fmt(store, op1, class)
@@ -928,6 +941,7 @@ impl TraceIr {
                 idx,
                 src,
                 class,
+                _polymorphic: _,
             } => {
                 let op1 = format!("{:?}:.[{:?}:] = {:?}", base, idx, src,);
                 fmt(store, op1, class)
@@ -1000,6 +1014,7 @@ impl TraceIr {
                 dst,
                 src,
                 ic: src_class,
+                _polymorphic: _,
             } => {
                 let op1 = format!("{:?} = {}{:?}", dst, kind, src);
                 format!("{:36} [{}]", op1, store.debug_class_name(src_class),)

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -68,7 +68,47 @@ pub(super) extern "C" fn find_method(
             ic_class
         }
     };
+    // Feed the call site's polymorphic method cache: this slow path runs
+    // exactly when the single-entry bytecode cache missed, so the PMC
+    // accumulates the receiver classes a polymorphic site cycles through
+    // (and one entry for a monomorphic site's first execution).
+    if let Some(f) = fid {
+        globals.store[callid].pmc.record(cache_class, None, Some(f));
+    }
     ((cache_class.u32() as u64) << 32) | fid.map_or(0, |f| f.get()) as u64
+}
+
+///
+/// Feed a pair-keyed call site's polymorphic method cache from the VM.
+///
+/// Called by `vm_save_binary_class` (both arches) — which BinOp / Cmp /
+/// Index / StoreIndex all share — on cache population and on every
+/// polymorphic transition, never on the steady-state path. The operand
+/// classes were just stored into the bytecode inline cache, so they are
+/// read back from `pc` (the *executing* instruction) instead of being
+/// passed by value.
+///
+pub(super) extern "C" fn pmc_record_binary(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr) {
+    pmc_record_from_pc(vm, globals, pc, true);
+}
+
+/// Unary twin of [`pmc_record_binary`], fed by `vm_save_lhs_class`:
+/// records the receiver class only.
+pub(super) extern "C" fn pmc_record_unary(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr) {
+    pmc_record_from_pc(vm, globals, pc, false);
+}
+
+fn pmc_record_from_pc(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr, binary: bool) {
+    let iseq_id = globals.store[vm.cfp().lfp().func_id()].as_iseq();
+    let bc_pos = globals.store[iseq_id].get_pc_index(Some(pc));
+    // Every binop/unop/cmp/Index/StoreIndex records a callsite; the lone
+    // exception (RescueTEq) never reaches the recording branches.
+    let Some(callid) = globals.store.get_callsite_id(iseq_id, bc_pos) else {
+        return;
+    };
+    let Some(recv) = pc.classid1() else { return };
+    let arg = if binary { pc.classid2() } else { None };
+    globals.store[callid].pmc.record(recv, arg, None);
 }
 
 /// CRuby's Ruby-3.4 "unused block" warning: calling a method with a

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -83,22 +83,49 @@ pub(super) extern "C" fn find_method(
 ///
 /// Called by `vm_save_binary_class` (both arches) — which BinOp / Cmp /
 /// Index / StoreIndex all share — on cache population and on every
-/// polymorphic transition, never on the steady-state path. The operand
-/// classes were just stored into the bytecode inline cache, so they are
-/// read back from `pc` (the *executing* instruction) instead of being
-/// passed by value.
+/// polymorphic transition, never on the steady-state path. The new
+/// operand classes were just stored into the bytecode inline cache, so
+/// they are read back from `pc` (the *executing* instruction);
+/// `old_lhs`/`old_rhs` carry the pair this transition displaced (0 =
+/// the cache was empty). The displaced pair is recorded too: the fixnum
+/// fast path stamps `Integer`/`Integer` into the IC without recording,
+/// so the moment it is displaced is that pair's only chance to reach the
+/// PMC — without this, classes that pass through the ever-changing IC
+/// would be lost to it.
 ///
-pub(super) extern "C" fn pmc_record_binary(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr) {
-    pmc_record_from_pc(vm, globals, pc, true);
+pub(super) extern "C" fn pmc_record_binary(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    pc: BytecodePtr,
+    old_lhs: u32,
+    old_rhs: u32,
+) {
+    let displaced = match (ClassId::from(old_lhs), ClassId::from(old_rhs)) {
+        (Some(l), r @ Some(_)) => Some((l, r)),
+        _ => None,
+    };
+    pmc_record_from_pc(vm, globals, pc, true, displaced);
 }
 
 /// Unary twin of [`pmc_record_binary`], fed by `vm_save_lhs_class`:
-/// records the receiver class only.
-pub(super) extern "C" fn pmc_record_unary(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr) {
-    pmc_record_from_pc(vm, globals, pc, false);
+/// records the receiver class only (`old_recv` = the displaced one).
+pub(super) extern "C" fn pmc_record_unary(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    pc: BytecodePtr,
+    old_recv: u32,
+) {
+    let displaced = ClassId::from(old_recv).map(|c| (c, None));
+    pmc_record_from_pc(vm, globals, pc, false, displaced);
 }
 
-fn pmc_record_from_pc(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr, binary: bool) {
+fn pmc_record_from_pc(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    pc: BytecodePtr,
+    binary: bool,
+    displaced: Option<(ClassId, Option<ClassId>)>,
+) {
     let iseq_id = globals.store[vm.cfp().lfp().func_id()].as_iseq();
     let bc_pos = globals.store[iseq_id].get_pc_index(Some(pc));
     // Every binop/unop/cmp/Index/StoreIndex records a callsite; the lone
@@ -106,6 +133,9 @@ fn pmc_record_from_pc(vm: &mut Executor, globals: &mut Globals, pc: BytecodePtr,
     let Some(callid) = globals.store.get_callsite_id(iseq_id, bc_pos) else {
         return;
     };
+    if let Some((recv, arg)) = displaced {
+        globals.store[callid].pmc.record(recv, arg, None);
+    }
     let Some(recv) = pc.classid1() else { return };
     let arg = if binary { pc.classid2() } else { None };
     globals.store[callid].pmc.record(recv, arg, None);

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1386,12 +1386,6 @@ pub(super) extern "C" fn jit_handle_arguments_no_block_for_send_splat(
     }
 }
 
-#[repr(C)]
-pub(super) struct ClassIdSlot {
-    base: ClassId,
-    idx: ClassId,
-}
-
 thread_local! {
     /// Cached `ClassId` of `Enumerator::ArithmeticSequence`. The
     /// class is defined in Ruby (`monoruby/builtins/enumerable.rb`)
@@ -1455,7 +1449,7 @@ pub(crate) fn is_arithmetic_sequence(globals: &Globals, v: Value) -> bool {
 ///
 /// - base: Value
 /// - index: Value
-/// - class_slot: &mut ClassIdSlot
+/// - is_func_call: non-zero for a literal `self[i]`
 ///
 /// ### out
 ///
@@ -1467,20 +1461,16 @@ pub(super) extern "C" fn get_index(
     globals: &mut Globals,
     base: Value,
     index: Value,
-    // Bit 0 carries `is_func_call`: the VM sets it when the base operand is
-    // slot 0 (a literal `self[i]`), which reaches a private `#[]`; it is clear
-    // for any other receiver, which enforces visibility. The slot lives
-    // 8-aligned in the bytecode stream, so bit 0 is free. Only consulted on
-    // the user-class fallback below — Array/Hash slice with no visibility gate.
-    class_slot: *mut ClassIdSlot,
+    // Non-zero when the base operand is slot 0 (a literal `self[i]`), which
+    // reaches a private `#[]`; zero for any other receiver, which enforces
+    // visibility. Only consulted on the user-class fallback below —
+    // Array/Hash slice with no visibility gate. The operand classes are
+    // recorded into the inline cache (with polymorphic detection) by the
+    // VM's `vm_save_binary_class` before this call, not here.
+    is_func_call: usize,
 ) -> Option<Value> {
-    let is_func_call = (class_slot as usize) & 1 != 0;
-    // SAFETY: the VM passes `&ClassIdSlot | is_func_call`; clearing bit 0
-    // restores the original 8-aligned slot pointer.
-    let class_slot = unsafe { &mut *(((class_slot as usize) & !1) as *mut ClassIdSlot) };
+    let is_func_call = is_func_call != 0;
     let base_classid = base.class();
-    class_slot.base = base_classid;
-    class_slot.idx = index.class();
     // `Array#[]` / `Hash#[]` below bypass method lookup, so they are only
     // sound while those are still the builtins. Unlike the dispatch-table
     // ops there is no `_no_opt` twin to swap in here — this helper *is* the
@@ -1609,17 +1599,14 @@ pub(super) extern "C" fn set_index(
     base: Value,
     index: Value,
     src: Value,
-    // Bit 0 carries `is_func_call` — see `get_index`. `self[i] = v` reaches a
-    // private `#[]=`; any other receiver enforces visibility.
-    class_slot: *mut ClassIdSlot,
+    // Non-zero when the base operand is slot 0 — see `get_index`.
+    // `self[i] = v` reaches a private `#[]=`; any other receiver enforces
+    // visibility. The operand classes are recorded into the inline cache by
+    // the VM's `vm_save_binary_class` before this call, not here.
+    is_func_call: usize,
 ) -> Option<Value> {
-    let is_func_call = (class_slot as usize) & 1 != 0;
-    // SAFETY: the VM passes `&ClassIdSlot | is_func_call`; clearing bit 0
-    // restores the original 8-aligned slot pointer.
-    let class_slot = unsafe { &mut *(((class_slot as usize) & !1) as *mut ClassIdSlot) };
+    let is_func_call = is_func_call != 0;
     let base_classid = base.class();
-    class_slot.base = base_classid;
-    class_slot.idx = index.class();
     if base_classid == ARRAY_CLASS
         && let Some(idx) = index.try_fixnum()
         // See `get_index`: this branch answers `Array#[]=` without a lookup.
@@ -1627,7 +1614,6 @@ pub(super) extern "C" fn set_index(
             .store
             .basic_op_redefined_for(base_classid, IdentId::_INDEX_ASSIGN)
     {
-        class_slot.idx = INTEGER_CLASS;
         if base.is_frozen() {
             vm.set_error(MonorubyErr::cant_modify_frozen(&globals.store, base));
             return None;

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1037,6 +1037,7 @@ impl Store {
             forwarding,
             bypass_visibility,
             vcall,
+            pmc: PolyCache::default(),
         });
         id
     }
@@ -1429,6 +1430,65 @@ impl Store {
                 );
             }
         }
+
+        eprintln!();
+        let recorded = self
+            .callsite_info
+            .iter()
+            .filter(|cs| !cs.pmc.entries().is_empty())
+            .count();
+        let poly: Vec<_> = self
+            .callsite_info
+            .iter()
+            .filter(|cs| cs.pmc.is_polymorphic())
+            .collect();
+        let mega = poly.iter().filter(|cs| cs.pmc.overflow() != 0).count();
+        eprintln!(
+            "polymorphic method cache: {} sites recorded, {} polymorphic, {} megamorphic",
+            recorded,
+            poly.len(),
+            mega
+        );
+        eprintln!("polymorphic sites (top 40 by slow-path observations)");
+        eprintln!(
+            " CallId  {:20} {:10} ways [class(/arg-class)(=func) xobservations]",
+            "name", "overflow"
+        );
+        eprintln!(
+            "------------------------------------------------------------------------------------------------------------------------"
+        );
+        let mut poly = poly;
+        poly.sort_unstable_by_key(|cs| {
+            std::cmp::Reverse(cs.pmc.entries().iter().map(|e| e.count as u64).sum::<u64>())
+        });
+        for cs in poly.into_iter().take(40) {
+            let name = cs
+                .name
+                .map_or_else(|| "<super>".to_string(), |n| n.to_string());
+            let ways = cs
+                .pmc
+                .entries()
+                .iter()
+                .map(|e| {
+                    let mut s = self.debug_class_name(e.recv);
+                    if let Some(arg) = e.arg {
+                        s += &format!("/{}", self.debug_class_name(arg));
+                    }
+                    if let Some(fid) = e.fid {
+                        s += &format!("={}", self.func_description(fid));
+                    }
+                    format!("{s} x{}", e.count)
+                })
+                .collect::<Vec<_>>()
+                .join(" | ");
+            eprintln!(
+                "({:6}) {:20} {:10} {}",
+                cs.id.get(),
+                name,
+                cs.pmc.overflow(),
+                ways
+            );
+        }
     }
 }
 
@@ -1818,6 +1878,80 @@ impl ConstSiteInfo {
 #[repr(transparent)]
 pub struct ConstSiteId(pub u32);
 
+/// Number of ways a call site's polymorphic method cache keeps before it
+/// counts further keys as megamorphic overflow.
+pub const PMC_WAYS: usize = 4;
+
+/// One observed key of a call site's polymorphic method cache.
+#[derive(Debug, Clone)]
+pub struct PolyCacheEntry {
+    /// The receiver's class (`class_for_ic`-unified for method calls, so
+    /// `true`/`false` share a way when their method is unified).
+    pub recv: ClassId,
+    /// The first argument's class — recorded for the pair-keyed sites
+    /// (BinOp / Cmp / Index / StoreIndex), `None` for method calls and
+    /// unary operators.
+    pub arg: Option<ClassId>,
+    /// The resolved method — method-call sites only; the operator/index
+    /// sites re-resolve from the class at JIT compile time.
+    pub fid: Option<FuncId>,
+    /// How many times the slow path (re-)observed this key. Not a call
+    /// count: the fast paths never record, so steady-state monomorphic
+    /// traffic does not bump this.
+    pub count: u32,
+}
+
+/// Polymorphic method cache of a call site: the receiver(-pair) classes
+/// the VM observed on its slow paths, up to [`PMC_WAYS`] of them.
+/// Recording-only for now — the JIT does not consume it yet (see
+/// `doc/polymorphic_call.md` §7); dump it with the `profile` feature.
+#[derive(Debug, Clone, Default)]
+pub struct PolyCache {
+    entries: Vec<PolyCacheEntry>,
+    /// Recordings that arrived with a fifth distinct key: the site is
+    /// megamorphic and a consumer should give up on way dispatch.
+    overflow: u32,
+}
+
+impl PolyCache {
+    pub fn record(&mut self, recv: ClassId, arg: Option<ClassId>, fid: Option<FuncId>) {
+        for e in self.entries.iter_mut() {
+            if e.recv == recv && e.arg == arg {
+                e.count += 1;
+                if fid.is_some() {
+                    // A later resolution wins: a redefinition changed the
+                    // target while the key stayed the same.
+                    e.fid = fid;
+                }
+                return;
+            }
+        }
+        if self.entries.len() < PMC_WAYS {
+            self.entries.push(PolyCacheEntry {
+                recv,
+                arg,
+                fid,
+                count: 1,
+            });
+        } else {
+            self.overflow += 1;
+        }
+    }
+
+    pub fn entries(&self) -> &[PolyCacheEntry] {
+        &self.entries
+    }
+
+    pub fn overflow(&self) -> u32 {
+        self.overflow
+    }
+
+    /// Two or more ways (or an overflow) were observed.
+    pub fn is_polymorphic(&self) -> bool {
+        self.entries.len() >= 2 || self.overflow != 0
+    }
+}
+
 /// Infomation for a call site.
 #[derive(Debug, Clone)]
 pub struct CallSiteInfo {
@@ -1860,6 +1994,9 @@ pub struct CallSiteInfo {
     /// parens): a failed lookup raises NameError instead of
     /// NoMethodError.
     pub(crate) vcall: bool,
+    /// Polymorphic method cache — the receiver(-pair) classes the VM
+    /// observed at this site. See [`PolyCache`].
+    pub pmc: PolyCache,
 }
 
 impl CallSiteInfo {


### PR DESCRIPTION
Groundwork for polymorphic-call-site optimization, following the direction in the new design memo `doc/polymorphic_call.md`: use the VM's run-time polymorphism detection (`opcode_sub`) to accumulate a ~4-way polymorphic method cache in `CallSiteInfo`, for the JIT to consume at compile time. This PR ships the detection completion and the **recording side** (no JIT consumption yet), plus the `nil?` guard fix from the original investigation.

## VM detection completed across every operator instruction

The VM already marked polymorphic method-call and binop/cmp sites via `opcode_sub`; unops and Index/StoreIndex did not participate. Now they do, at the machine-code level on both arches:

- `vm_save_lhs_class` / `a64_save_lhs_class` (unops) gain the same populated-and-changed → `opcode_sub = 1` bookkeeping as the binops.
- `vm_index` / `vm_index_assign` record (base, idx) classes with `vm_save_binary_class` itself — the IC layout is identical to the binops' — so detection comes for free and `get_index` / `set_index` drop the `ClassIdSlot` pointer argument (and its bit-0 `is_func_call` fold; the flag is now a plain argument). The `self[i]` → private `#[]` visibility path is preserved and tested.
- `TraceIr::{UnOp, Index, IndexAssign}` now carry the (reserved) `_polymorphic` bit like `MethodCall` does.

Survey results recorded in the memo: every binop/unop/cmp/Index/StoreIndex opcode records a `CallSiteId` (`RescueTEq` is the sole, deliberate exception), so the PMC needs no side table.

## Per-callsite polymorphic method cache (recording only)

`CallSiteInfo::pmc: PolyCache` — up to 4 ways of `(recv_class, Option<arg_class>, Option<FuncId>, count)` plus a megamorphic overflow counter. Key shape: **receiver only** for method calls and unops, **receiver + first argument** for BinOp/Cmp/Index/StoreIndex.

Recording happens **only on IC population and polymorphic transitions** — the steady state and all JIT-compiled code never pay anything:

- Method calls: in `runtime::find_method` (runs exactly on IC misses), with the `class_for_ic` bool-unification and the resolved `FuncId`; frame-dependent `super` (uncacheable) is excluded.
- Operator/index sites: the recording branches of `vm_save_binary_class` / `vm_save_lhs_class` call a helper that resolves the callsite via `cfp → iseq → callsite_map` and reads the just-stored classes back from the bytecode IC. **The displaced pair is recorded too**: the fixnum fast path stamps `Integer`/`Integer` into the IC without recording, so displacement is that pair's only chance to reach the PMC (a never-displaced stamp still lives in the IC; consumers must treat IC ∪ PMC as the observed set — noted in the memo).

`--features profile` prints the PMC at exit: summary (sites recorded / polymorphic / megamorphic) and the top polymorphic sites as `class(/arg)(=resolved-func) xobservations`. On optcarrot (180 frames): 5,419 sites recorded, **46 polymorphic (0.9%)**, 12 megamorphic — the APU `Pulse`/`Triangle`/`Noise` `active?`/`update_freq` sites emerge as clean 2–3-way candidates whose ways resolve to *different* FuncIds, matching the deopt statistics, while Errno-sweep `is_a?`/`<` and `initialize`/`__builtin_allocate__` are correctly flagged megamorphic.

## nil-tolerant receiver guard for `nil?` sites

From the original binarytrees investigation: a `nil?` site is nil/non-nil polymorphic by design, and the receiver class guard deopted on every nil receiver (4.58M deopts per run). When NilClass provably resolves the name to the same `FuncId` as the cached class (class-version-guarded), the new `GuardClassOrNil` lets nil through; the `nil?` inliner's value test covers both halves, and any third class still deopts. binarytrees 118ms → 100ms (CRuby+YJIT: 170ms). The memo slates this special case for re-derivation as the "all ways share one FuncId" degenerate form of the PMC dispatch once consumption lands.

Landing this exposed a latent x86-64 backend constraint: cold (page-1) blocks could not contain Float-unbox guards (`assert_eq!(0, get_page())`). `float_to_f64` / `float_val_to_f64` now emit their cold snippets in line when already on the cold page, the same dual shape `guard_class`'s fail-wrapper uses.

## Verification

- Full test suite on this tree (master `24dfae61` merged): **3,325 passed, 0 failed**.
- aarch64 cross-checked; all VM changes implemented on both arches.
- Behavior parity with CRuby verified for: unop polymorphism (Integer/Float/BigInt/custom `-@`, `!` over mixed truthiness), Index/StoreIndex polymorphism (Hash/Array/String/custom `[]`/`[]=`), `self[i]` / `self[i] = v` reaching private `#[]`/`#[]=`, `nil?` overrides on third classes, and displaced fast-path pair capture.
- optcarrot 180 frames runs correctly under the profile build (fps ~148, checksum matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_