### PR TITLE
StringScanner: allocation-free match registers, lazy string materialization

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,9 +91,9 @@ jobs:
     runs-on: macos-latest
     # Backstop: if a hung attempt somehow escapes the per-attempt cap on the
     # Test step below, GitHub cancels the job cleanly here (2 attempts x
-    # 35 min + setup/clone overhead) rather than letting the runner die with
+    # 50 min + setup/clone overhead) rather than letting the runner die with
     # "lost communication".
-    timeout-minutes: 95
+    timeout-minutes: 110
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
@@ -154,8 +154,11 @@ jobs:
         #     the step (last log lines + memory trajectory + any watchdog
         #     forensics). It lives on the GitHub side, so it SURVIVES runner
         #     death — the progress log of record for silent hangs.
-        #   * retry — cap each attempt at 35 min and retry once, so a clean
-        #     hang fails fast (normal pass ~11 min) and the rerun recovers;
+        #   * retry — cap each attempt at 50 min and retry once, so a clean
+        #     hang fails fast and the rerun recovers. (The cap was 35 min
+        #     when a normal pass was ~11 min; the bin-test scope has since
+        #     grown to ~34 min on this runner, and 2026-08-14 both attempts
+        #     of a healthy run timed out mid-spec — no hang, just budget.)
         #   * a background memory watchdog: watches every monoruby AND ruby
         #     process (bin/test diffs against CRuby and runs mspec) plus the
         #     system-wide free memory; fires at >3 GB per process / >4 GB
@@ -183,7 +186,7 @@ jobs:
           # well under the attempt cap.
           NEXTEST_TEST_THREADS: "2"
         with:
-          timeout_minutes: 35
+          timeout_minutes: 50
           max_attempts: 2
           command: |
             set -o pipefail

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3285,19 +3285,28 @@ fn string_match(
 ///
 /// ### String#__strscan_match (monoruby internal)
 ///
-/// - __strscan_match(regexp, byte_pos) -> MatchData | nil
+/// - __strscan_match(regexp, byte_pos) -> Integer | Array | nil
 ///
-/// Match `regexp` against the byte suffix of self starting at
-/// `byte_pos`, backing the pure-Ruby `StringScanner`'s ASCII fast path
-/// (`stdlib/strscan.rb`). The engine sees only the suffix, so `\A` and
-/// `^` anchor at the scan position — CRuby strscan's default
-/// (`fixed_anchor: false`) semantics — and the MatchData's offsets are
-/// relative to it, exactly like the byteslice-based fallback path, but
-/// with no copy: the suffix is a borrowed view and the MatchData's
-/// haystack snapshot resolves to a zero-copy CoW substring of self
-/// (`Executor::resolve_haystack`). Out-of-range or non-char-boundary
-/// positions return nil; the caller's `ascii_only?` gate makes every
-/// in-range byte position a boundary.
+/// Allocation-lean scanning primitive backing the pure-Ruby
+/// `StringScanner` (`stdlib/strscan.rb`): match `regexp` against the
+/// byte suffix of self starting at `byte_pos` and hand back only the
+/// match registers. No MatchData is built and `$~` is NOT set — like
+/// CRuby's C strscan, which keeps its registers inside the scanner and
+/// leaves the special variables alone.
+///
+/// The engine sees only the suffix, so `\A` and `^` anchor at the scan
+/// position (CRuby strscan's default `fixed_anchor: false` semantics).
+/// Returns
+/// - nil — no match;
+/// - an Integer — the byte end of a whole-match starting at offset 0
+///   with no capture groups (the common lexer case — the value is a
+///   packed Fixnum, so a hit allocates nothing);
+/// - an Array `[b0, e0, b1, e1, …]` of byte offsets relative to
+///   `byte_pos` (nil pairs for unmatched groups) otherwise.
+///
+/// Out-of-range or non-char-boundary positions return nil; the
+/// caller's `ascii_only?` gate makes every in-range byte position a
+/// boundary.
 #[monoruby_builtin]
 fn string_strscan_match(
     vm: &mut Executor,
@@ -3316,9 +3325,32 @@ fn string_strscan_match(
     let Some(sub) = given.get(byte_pos..) else {
         return Ok(Value::nil());
     };
-    // Enable zero-copy MatchData/$~ haystack snapshots (CoW).
-    vm.set_match_haystack(self_);
-    RegexpInner::match_one(vm, globals, re, sub, lfp.block(), 0)
+    let Some(caps) = re.captures_from_pos_no_save(sub, 0)? else {
+        return Ok(Value::nil());
+    };
+    if caps.len() == 1 {
+        // Group-less pattern: a single Fixnum carries the whole
+        // register set when the match starts at the scan position
+        // (always true for the `\A`-anchored scan family).
+        let m = caps.get(0).unwrap();
+        if m.start() == 0 {
+            return Ok(Value::integer(m.end() as i64));
+        }
+    }
+    let mut spans = Vec::with_capacity(caps.len() * 2);
+    for m in caps.iter() {
+        match m {
+            Some(m) => {
+                spans.push(Value::integer(m.start() as i64));
+                spans.push(Value::integer(m.end() as i64));
+            }
+            None => {
+                spans.push(Value::nil());
+                spans.push(Value::nil());
+            }
+        }
+    }
+    Ok(Value::array_from_vec(spans))
 }
 
 ///

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1391,6 +1391,19 @@ impl RegexpInner {
         }
     }
 
+    /// `captures_from_pos` without touching `$~`/`$1..` — the raw match
+    /// for scanning primitives that must not update the special
+    /// variables (CRuby's C strscan keeps its registers to itself).
+    pub(crate) fn captures_from_pos_no_save<'a>(
+        &self,
+        given: &'a str,
+        pos: usize,
+    ) -> Result<Option<Captures<'a>>> {
+        self.regex
+            .captures_from_pos(given, pos)
+            .map_err(|err| MonorubyErr::regexerr(format!("Capture failed. {:?}", err)))
+    }
+
     /// Like `match_one` but returns only a boolean and does NOT set `$~`.
     pub(crate) fn match_pred(
         re: &RegexpInner,

--- a/monoruby/stdlib/strscan.rb
+++ b/monoruby/stdlib/strscan.rb
@@ -4,13 +4,22 @@
 # Provides a simple lexical scanning interface for strings.
 #
 # Note: pos is always a byte offset, consistent with CRuby's StringScanner.
+#
+# Like CRuby's C strscan, the scanner keeps its match registers to
+# itself: a scan stores only byte offsets (via the allocation-lean
+# `String#__strscan_match` primitive on the ASCII fast path — a plain
+# Fixnum for group-less patterns), never builds a MatchData, and leaves
+# `$~` untouched. The accessors (`matched`, `[]`, `captures`, …)
+# materialize strings lazily from the registers. Non-ASCII subjects fall
+# back to a copied rest-slice matched with `String#match`, whose
+# MatchData then backs the same accessors.
 
 class StringScanner
   def initialize(str)
     @str = str.is_a?(String) ? str : str.to_s
     @pos = 0
-    @match = nil
     @prev_pos = 0
+    _clear_match
   end
 
   attr_reader :pos
@@ -29,7 +38,7 @@ class StringScanner
   def string=(str)
     @str = str
     @pos = 0
-    @match = nil
+    _clear_match
   end
 
   def concat(str)
@@ -40,13 +49,13 @@ class StringScanner
 
   def reset
     @pos = 0
-    @match = nil
+    _clear_match
     self
   end
 
   def terminate
     @pos = @str.bytesize
-    @match = nil
+    _clear_match
     self
   end
   alias clear terminate
@@ -70,39 +79,39 @@ class StringScanner
   # --- Scanning methods ---
 
   def scan(pattern)
-    _match_at_pos(pattern, true, true)
-  end
-
-  def scan_until(pattern)
-    _match_forward(pattern, true, true)
+    len = _match_len_at_pos(pattern, true)
+    len ? @str.byteslice(@pos - len, len) : nil
   end
 
   def skip(pattern)
-    result = _match_at_pos(pattern, true, false)
-    result ? result.bytesize : nil
-  end
-
-  def skip_until(pattern)
-    result = _match_forward(pattern, true, false)
-    result ? @pos - @prev_pos : nil
+    _match_len_at_pos(pattern, true)
   end
 
   def match?(pattern)
-    result = _match_at_pos(pattern, false, false)
-    result ? result.bytesize : nil
+    _match_len_at_pos(pattern, false)
   end
 
   def check(pattern)
-    _match_at_pos(pattern, false, true)
+    len = _match_len_at_pos(pattern, false)
+    len ? @str.byteslice(@pos, len) : nil
+  end
+
+  def scan_until(pattern)
+    end_pos = _match_forward_end(pattern, true)
+    end_pos ? @str.byteslice(@prev_pos, end_pos) : nil
+  end
+
+  def skip_until(pattern)
+    _match_forward_end(pattern, true)
   end
 
   def check_until(pattern)
-    _match_forward(pattern, false, true)
+    end_pos = _match_forward_end(pattern, false)
+    end_pos ? @str.byteslice(@pos, end_pos) : nil
   end
 
   def exist?(pattern)
-    _match_forward(pattern, false, false)
-    @match ? @match.end(0) : nil
+    _match_forward_end(pattern, false)
   end
 
   def peek(len)
@@ -115,7 +124,10 @@ class StringScanner
     ch = @str.byteslice(@pos, 1)
     @prev_pos = @pos
     @pos += 1
-    @match = nil
+    # A successful getch records the char as the whole match (CRuby).
+    _clear_match
+    @match_spans = @match_end = ch.bytesize
+    @match_begin = 0
     ch
   end
 
@@ -124,42 +136,88 @@ class StringScanner
     byte = @str.byteslice(@pos, 1)
     @prev_pos = @pos
     @pos += 1
-    @match = nil
+    _clear_match
+    @match_spans = @match_end = 1
+    @match_begin = 0
     byte
   end
   alias getbyte get_byte
 
   def unscan
-    raise "unscan failed: previous match record not exist" unless @match
+    raise "unscan failed: previous match record not exist" unless matched?
     @pos = @prev_pos
-    @match = nil
+    _clear_match
     self
   end
 
   # --- Match data ---
+  #
+  # On the register (spans) path, @match_begin/@match_end are byte
+  # offsets of the whole match relative to the scan origin (@prev_pos),
+  # and group contents are byteslices of @str. On the fallback path the
+  # stored MatchData answers instead.
 
   def matched
-    @match ? @match[0] : nil
+    if @match_spans
+      @str.byteslice(@prev_pos + @match_begin, @match_end - @match_begin)
+    elsif @match_md
+      @match_md[0]
+    end
   end
 
   def matched?
-    !@match.nil?
+    !(@match_spans.nil? && @match_md.nil?)
   end
 
   def matched_size
-    @match ? @match[0].bytesize : nil
+    if @match_spans
+      @match_end - @match_begin
+    elsif @match_md
+      @match_md[0].bytesize
+    end
   end
 
   def [](n)
-    @match ? @match[n] : nil
+    if @match_spans
+      if n.is_a?(Integer)
+        count = _group_count
+        n += count if n < 0
+        return nil if n < 0 || n >= count
+        if Integer === @match_spans
+          matched # count == 1, so n == 0: the whole match
+        else
+          b = @match_spans[2 * n]
+          b ? @str.byteslice(@prev_pos + b, @match_spans[2 * n + 1] - b) : nil
+        end
+      elsif n.is_a?(String) || n.is_a?(Symbol)
+        name = n.to_s
+        idx = @match_re && @match_re.named_captures[name]&.last
+        raise IndexError, "undefined group name reference: #{name}" unless idx
+        self[idx]
+      elsif n.respond_to?(:to_int)
+        self[n.to_int]
+      else
+        raise TypeError, "no implicit conversion of #{n.class} into Integer"
+      end
+    elsif @match_md
+      @match_md[n]
+    end
   end
 
   def pre_match
-    @match ? @str.byteslice(0, @pos - @match[0].bytesize) : nil
+    if @match_spans
+      @str.byteslice(0, @prev_pos + @match_begin)
+    elsif @match_md
+      @str.byteslice(0, @pos - @match_md[0].bytesize)
+    end
   end
 
   def post_match
-    @match ? @str.byteslice(@pos..-1) : nil
+    if @match_spans
+      @str.byteslice(@prev_pos + @match_end..-1)
+    elsif @match_md
+      @str.byteslice(@pos..-1)
+    end
   end
 
   # --- Misc ---
@@ -174,19 +232,21 @@ class StringScanner
   end
 
   def size
-    @match ? @match.size : nil
+    if @match_spans
+      _group_count
+    elsif @match_md
+      @match_md.size
+    end
   end
 
   def captures
-    return nil unless @match
-    result = []
-    (1...@match.size).each { |i| result << @match[i] }
-    result
+    return nil unless matched?
+    (1..._group_total).map { |i| self[i] }
   end
 
   def values_at(*indices)
-    return nil unless @match
-    indices.map { |i| @match[i] }
+    return nil unless matched?
+    indices.map { |i| self[i] }
   end
 
   def inspect
@@ -219,6 +279,19 @@ class StringScanner
 
   private
 
+  def _clear_match
+    @match_spans = @match_md = @match_re = @match_begin = @match_end = nil
+  end
+
+  def _group_count
+    Integer === @match_spans ? 1 : @match_spans.size / 2
+  end
+
+  # Group count across both representations (for `captures`).
+  def _group_total
+    @match_spans ? _group_count : @match_md.size
+  end
+
   # Both match paths hand the engine only the rest of the string, so
   # `\A` anchors at the scan position — CRuby strscan's default
   # (fixed_anchor: false) semantics.
@@ -232,55 +305,83 @@ class StringScanner
     end
   end
 
-  # Match `pattern` against the rest of the string. The MatchData's
-  # offsets are relative to the scan position on both paths.
+  # Match the anchored form of `pattern` at the scan position and store
+  # the registers. Returns the byte length of the match, or nil.
   #
   # ASCII-only content (an O(1) check on the cached code range; byte and
-  # char offsets coincide) uses the zero-copy `__strscan_match`
-  # primitive, which matches against the byte suffix in place and
-  # snapshots the haystack as a CoW substring. Everything else copies
-  # the rest, exactly as before.
-  def _match_rest(pattern)
-    if @str.ascii_only?
-      @str.__strscan_match(pattern, @pos)
-    else
-      rest_str = @str.byteslice(@pos..-1)
-      rest_str&.match(pattern)
-    end
-  end
-
-  def _match_at_pos(pattern, advance, return_string)
+  # char offsets coincide) matches the byte suffix in place via
+  # `__strscan_match` — a group-less hit costs no allocation at all.
+  # Everything else copies the rest and matches it, as before.
+  def _match_len_at_pos(pattern, advance)
     anchored = _anchored(pattern)
     @prev_pos = @pos
-    m = _match_rest(anchored)
-    if m
-      @match = m
-      matched_str = m[0]
-      @pos += matched_str.bytesize if advance
-      matched_str
+    if @str.ascii_only?
+      spans = @str.__strscan_match(anchored, @pos)
+      @match_md = nil
+      unless spans
+        @match_spans = @match_re = @match_begin = @match_end = nil
+        return nil
+      end
+      @match_spans = spans
+      @match_re = anchored
+      @match_begin = 0
+      len = @match_end = (Integer === spans ? spans : spans[1])
     else
-      @match = nil
-      nil
+      rest_str = @str.byteslice(@pos..-1)
+      m = rest_str&.match(anchored)
+      @match_spans = @match_re = nil
+      @match_md = m
+      unless m
+        @match_begin = @match_end = nil
+        return nil
+      end
+      @match_begin = 0
+      len = @match_end = m[0].bytesize
     end
+    @pos += len if advance
+    len
   end
 
-  def _match_forward(pattern, advance, return_string)
+  # Search `pattern` in the rest of the string and store the registers.
+  # Returns the byte offset of the match END relative to the scan
+  # position (== the number of bytes an advancing variant consumes), or
+  # nil.
+  def _match_forward_end(pattern, advance)
     if pattern.is_a?(String)
       PLAIN_STR.clear if PLAIN_STR.size > CACHE_LIMIT
       pattern = PLAIN_STR[pattern] ||= Regexp.new(Regexp.escape(pattern))
     end
     @prev_pos = @pos
-    m = _match_rest(pattern)
-    if m
-      @match = m
-      end_pos = m.end(0) # relative to the scan position
-      if advance
-        @pos += end_pos
+    if @str.ascii_only?
+      spans = @str.__strscan_match(pattern, @pos)
+      @match_md = nil
+      unless spans
+        @match_spans = @match_re = @match_begin = @match_end = nil
+        return nil
       end
-      return_string ? @str.byteslice(@prev_pos, end_pos) : true
+      @match_spans = spans
+      @match_re = pattern
+      if Integer === spans
+        @match_begin = 0
+        end_pos = @match_end = spans
+      else
+        @match_begin = spans[0]
+        end_pos = @match_end = spans[1]
+      end
     else
-      @match = nil
-      nil
+      rest_str = @str.byteslice(@pos..-1)
+      m = rest_str&.match(pattern)
+      @match_spans = @match_re = nil
+      @match_md = m
+      unless m
+        @match_begin = @match_end = nil
+        return nil
+      end
+      end_pos = m.end(0)
+      @match_begin = end_pos - m[0].bytesize
+      @match_end = end_pos
     end
+    @pos += end_pos if advance
+    end_pos
   end
 end

--- a/monoruby/tests/strscan.rs
+++ b/monoruby/tests/strscan.rs
@@ -107,6 +107,33 @@ fn strscan_repeated_scan_hot_loop() {
 }
 
 #[test]
+fn strscan_register_accessors() {
+    // The register (spans) representation must answer every accessor —
+    // named groups, negative indices, getch registers, pre/post_match in
+    // the regular-expression sense — identically to CRuby's C strscan.
+    run_test_once(
+        r#"
+        require "strscan"
+        r = []
+        s = StringScanner.new("Fri Dec 12 1975 14:39")
+        r << s.scan(/(\w+)(?<mon>\s\w+)?/) << s[0] << s[1] << s[:mon] << s["mon"] << s[-1] << s[9]
+        r << s.size << s.captures << s.matched << s.matched_size << s.pre_match << s.post_match
+        begin; s[:nope]; rescue IndexError => e; r << e.class.to_s; end
+        r << s.check_until(/\d+/) << s.pre_match << s.post_match << s.matched << s.pos
+        r << s.scan_until(/12/) << s.pre_match << s.post_match << s.pos
+        r << s.getch << s.matched << s[0] << s.matched_size
+        r << s.skip(/\s*(19)(75)\s*/) << s[1] << s[2] << s.captures << s.matched
+        s2 = StringScanner.new("a b")
+        r << s2.exist?(/b/) << s2.pos << s2.skip_until(/b/) << s2.pos
+        s3 = StringScanner.new("test")
+        r << s3.scan(/(t)(e)(x)?(s)/) << s3[3] << s3.captures << s3.values_at(0, 4, -1, 3)
+        r << s3.unscan.pos
+        r
+        "#,
+    );
+}
+
+#[test]
 fn string_match_position_boundaries() {
     // String#match clamps past-the-end positions to the end (a zero-width
     // pattern still matches there); String#match? rejects them instead.


### PR DESCRIPTION
## Summary

Follow-up to #1112. Scanning still built a MatchData + a CoW haystack snapshot + the matched substring (and updated `$~`) on every hit — roughly 3 heap objects per scan — even for `skip`/`match?` callers that only need a byte count. CRuby's C strscan allocates none of that: it keeps its registers inside the scanner and leaves the special variables alone. This PR makes monoruby's scanner do the same.

## Changes

**`String#__strscan_match`** now returns raw match registers and does NOT set `$~`:

- a plain **Fixnum** end offset for a group-less match starting at the scan position — the common lexer case, so a `skip` hit allocates **nothing**;
- an Array of byte spans (`[b0, e0, b1, e1, …]`, nil pairs for unmatched groups) otherwise;
- nil on a miss.

**`stdlib/strscan.rb`** stores the registers and materializes strings lazily:

- `scan`/`check` byteslice the match on demand; `skip`/`match?` return the length straight from the registers.
- `matched` / `[]` / `captures` / `values_at` / `matched_size` / `size` / `pre_match` / `post_match` all derive from the spans. Named-group lookup resolves via `Regexp#named_captures` (unknown names raise `IndexError`), indices coerce via `to_int` (a `Range` raises `TypeError`), and `getch`/`get_byte` now record the returned char as the whole match — all matching CRuby.
- `pre_match`/`post_match` are computed from the match's own span, so the non-advancing family (`check`/`check_until`/`exist?`) reports them in the regular-expression sense, like CRuby.
- The non-ASCII fallback keeps the copied-rest MatchData path unchanged.

## Results

- `StringScanner#skip` microbench (2M skips): **791ms → 375ms** (CRuby 201ms; the gap shrinks from 3.9× to 1.9×)
- ruby-bench **tinygql**: 0.65s → **0.46s** — now **1.4× faster than CRuby** (0.65s)
- ruby-bench **graphql**: 0.17s → **0.14s** (CRuby 0.078s)

## Verification

- `cargo nextest run`: full suite green (includes a new `strscan_register_accessors` test comparing named groups, negative indices, getch registers, and pre/post_match against CRuby's C strscan)
- ruby/spec `library/stringscanner` + `core/string/match_spec` + `core/regexp`: **11 fewer failures than master**, zero new — the newly passing examples include `match?`'s last-match visibility, `pre_match`/`post_match` in the regular-expression sense, `[]`'s `to_int` coercion and `TypeError` on Range, and `scan(//)` at EOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_