### PR TITLE
JIT: route literal keywords through pure forwarding trampolines (K1)

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -597,6 +597,7 @@ impl Codegen {
         lead_num: usize,
         src: SlotId,
         layout: ForwardedLayout,
+        kw_route: Option<(SlotId, Box<[Option<SlotId>]>)>,
     ) -> bool {
         // Fixed lowering temps (x9..x15 are never GP-mapped; x10 is the
         // internal scratch of `a64_frame_load/store`, so it is left free):
@@ -673,6 +674,26 @@ impl Codegen {
                     CLFP,
                     (LFP_ARG0 + 8 * (lead_num + expected_len + j) as i32) as u32,
                 );
+            }
+        }
+        // K1: routed literal keywords — copy each bound caller kw slot
+        // into the callee's kw register; 0-fill the absent optionals
+        // (their defaults run in the callee prologue, exactly as
+        // `ordinary_keyword` binds None).
+        if let Some((kw_reg_pos, route)) = &kw_route {
+            monoasm_arm64!(&mut self.jit, ldr x11, [x29];);
+            for (i, src) in route.iter().enumerate() {
+                let ofs = (LFP_SELF + 8 * (kw_reg_pos.0 as i32 + i as i32)) as u32;
+                match src {
+                    Some(slot) => {
+                        self.a64_frame_load(VAL, CALLER_FP, rbp_local(*slot) as u32);
+                        self.a64_frame_store(VAL, CLFP, ofs);
+                    }
+                    None => {
+                        monoasm_arm64!(&mut self.jit, mov x12, (0u64););
+                        self.a64_frame_store(VAL, CLFP, ofs);
+                    }
+                }
             }
         }
         true

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -370,6 +370,42 @@ impl Codegen {
         for (dst, src, len) in wb.forward_rest.clone() {
             self.a64_gen_forward_rest_materialize(dst, src, len);
         }
+        // K1: materialize deferred `**kwrest` Hashes after the rest
+        // arrays (each helper call may allocate; every not-yet-written
+        // deferred slot still physically holds the `nil` the caller
+        // stored, so the frame stays GC-consistent throughout).
+        for (dst, table) in wb.forward_kwrest.clone() {
+            self.a64_gen_forward_kwrest_materialize(dst, &table);
+        }
+    }
+
+    /// K1: rebuild a deferred `**kwrest` Hash from the caller's kw slots
+    /// for an interpreter resuming inside the trampoline frame. Twin of
+    /// x86 `gen_forward_kwrest_materialize`: the caller `Lfp` handed to
+    /// `correct_rest_kw` is derived from the caller frame pointer saved
+    /// at `[x29]` (`lfp == fp - RBP_LOCAL_FRAME` in every JIT frame).
+    fn a64_gen_forward_kwrest_materialize(&mut self, dst: SlotId, table: &[(IdentId, SlotId)]) {
+        let lfp = GP::R14.a64().0; // x22
+        let data = self.jit.const_align8();
+        for (name, slot) in table {
+            self.jit.const_i32(name.get() as i32);
+            self.jit.const_i32(slot.0 as i32);
+        }
+        self.jit.const_i32(0);
+        self.jit.const_i32(0);
+        let f = runtime::correct_rest_kw as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            ldr x1, [x29];                     // caller fp
+            mov x9, (RBP_LOCAL_FRAME as u64);
+            sub x1, x1, x9;                    // caller lfp
+            adr x0, data;                      // &table
+            str x30, [sp, #-16]!;              // save LR
+            mov x9, (f);
+            blr x9;                            // x0 = kwrest Hash
+            ldr x30, [sp], #16;                // restore LR
+            mov x12, x0;
+        );
+        self.a64_frame_store(12, lfp, conv(dst) as u32);
     }
 
     /// Rebuild a deferred `...` rest `Array` for an interpreter resuming inside
@@ -2717,6 +2753,7 @@ impl Codegen {
                 lead_num,
                 kwrest_guard,
                 deferred_src,
+                kw_route,
             } => {
                 let offset = store[callee_fid].get_offset();
                 // D1 source-routed: the whole bind is a compile-time
@@ -2725,8 +2762,12 @@ impl Codegen {
                     Some((src, len)) => {
                         let layout = store[callee_fid]
                             .forwarded_deferred_layout(lead_num, len as usize);
+                        // K1: pair the routed caller slots with the
+                        // callee's kw register base.
+                        let kw_route =
+                            kw_route.map(|route| (store[callee_fid].kw_reg_pos(), route));
                         self.a64_set_arguments_forwarded_deferred(
-                            offset, recv, args, lead_num, src, layout,
+                            offset, recv, args, lead_num, src, layout, kw_route,
                         )
                     }
                     // Eager (rest Array materialized): the callee is req-only
@@ -2735,6 +2776,10 @@ impl Codegen {
                     // fixed req count minus the leading args. Inline the
                     // array-copy fast path with a helper fallback.
                     None => {
+                        // The eager path never routes keywords (a
+                        // kw-declaring callee is only admitted with an
+                        // active deferral).
+                        assert!(kw_route.is_none());
                         let expected_len = store[callee_fid].req_num() - lead_num;
                         self.a64_set_arguments_forwarded_eager(
                             callid,

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -680,6 +680,7 @@ impl Codegen {
         recv: SlotId,
         kwrest_guard: Option<SlotId>,
         deferred_src: Option<(SlotId, u16)>,
+        kw_route: Option<(SlotId, Box<[Option<SlotId>]>)>,
     ) {
         if let Some((src, _len)) = deferred_src {
             let layout = layout.expect("a source-routed forward always carries its layout");
@@ -756,10 +757,32 @@ impl Codegen {
                     movq [rsp - (RSP_LOCAL_FRAME + LFP_ARG0 + (8 * (lead_num + expected_len + j)) as i32)], 0;
                 }
             }
+            // K1: routed literal keywords — copy each bound caller kw
+            // slot straight into the callee's kw register (rcx still
+            // holds the caller rbp), 0-fill the absent optionals (their
+            // defaults run in the callee prologue, exactly as
+            // `ordinary_keyword` binds None).
+            if let Some((kw_reg_pos, route)) = &kw_route {
+                for (i, src) in route.iter().enumerate() {
+                    let ofs = RSP_LOCAL_FRAME + LFP_SELF + 8 * (kw_reg_pos.0 as i32 + i as i32);
+                    match src {
+                        Some(slot) => monoasm! { &mut self.jit,
+                            movq rax, [rcx - (rbp_local(*slot))];
+                            movq [rsp - (ofs)], rax;
+                        },
+                        None => monoasm! { &mut self.jit,
+                            movq [rsp - (ofs)], 0;
+                        },
+                    }
+                }
+            }
             // No success sentinel: nothing above can fail, and the caller
-            // emits no `HandleError` for D1.
+            // emits no `HandleError` for D1/K1.
             return;
         }
+        // The eager path never routes keywords (a kw-declaring callee is
+        // only admitted with an active deferral).
+        assert!(kw_route.is_none());
         let fallback = self.jit.label();
         let heap = self.jit.label();
         let got = self.jit.label();

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -212,6 +212,7 @@ impl Codegen {
                 lead_num,
                 kwrest_guard,
                 deferred_src,
+                kw_route,
             } => {
                 let offset = store[callee_fid].get_offset();
                 // D1 source-routed: the whole bind is a compile-time
@@ -225,6 +226,10 @@ impl Codegen {
                     Some(l) => l.from_src,
                     None => store[callee_fid].req_num() - lead_num,
                 };
+                // K1: pair the routed caller slots with the callee's kw
+                // register base.
+                let kw_route =
+                    kw_route.map(|route| (store[callee_fid].kw_reg_pos(), route));
                 self.jit_set_arguments_forwarded(
                     callid,
                     callee_fid,
@@ -236,6 +241,7 @@ impl Codegen {
                     recv,
                     kwrest_guard,
                     deferred_src,
+                    kw_route,
                 );
             }
         }

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -156,6 +156,13 @@ pub(crate) struct WriteBack {
     /// frame copy) reads the rest local, so the array must be built
     /// here from the source slots and stored into `dst`.
     forward_rest: Vec<(SlotId, SlotId, u16)>,
+    /// Deferred forwarding-kwrest materialization (K1). Each entry
+    /// `(dst, [(name, caller slot)])`: the `**kwrest` slot `dst` of a
+    /// forwarding-trampoline frame was *not* materialized as a Hash on
+    /// the fast path (the caller passed only literal keywords, routed
+    /// straight to the forwarded callee); a side exit rebuilds the Hash
+    /// from the caller's kw slots via `correct_rest_kw`.
+    forward_kwrest: Vec<(SlotId, Box<[(IdentId, SlotId)]>)>,
 }
 
 impl Hash for WriteBack {
@@ -182,6 +189,13 @@ impl Hash for WriteBack {
             src.hash(state);
             len.hash(state);
         }
+        for (dst, table) in &self.forward_kwrest {
+            dst.hash(state);
+            for (name, slot) in table.iter() {
+                name.hash(state);
+                slot.hash(state);
+            }
+        }
     }
 }
 
@@ -206,6 +220,9 @@ impl std::fmt::Debug for WriteBack {
         for (dst, src, len) in &self.forward_rest {
             s.push_str(&format!(" fwdrest[{:?};{}]->{:?}", src, len, dst));
         }
+        for (dst, table) in &self.forward_kwrest {
+            s.push_str(&format!(" fwdkwrest[{:?}]->{:?}", table, dst));
+        }
         write!(f, "WriteBack({})", s)
     }
 }
@@ -217,6 +234,7 @@ impl WriteBack {
         void: Vec<SlotId>,
         gp: Vec<(GP, SlotId)>,
         forward_rest: Vec<(SlotId, SlotId, u16)>,
+        forward_kwrest: Vec<(SlotId, Box<[(IdentId, SlotId)]>)>,
     ) -> Self {
         Self {
             fpr,
@@ -224,6 +242,7 @@ impl WriteBack {
             void,
             gp,
             forward_rest,
+            forward_kwrest,
         }
     }
 }
@@ -939,6 +958,37 @@ impl JitModule {
         // addressed `r14`-relative like every other deopt restore.
         for (dst, src, len) in wb.forward_rest.clone() {
             self.gen_forward_rest_materialize(dst, src, len);
+        }
+        // K1: materialize deferred `**kwrest` Hashes after the rest
+        // arrays (each helper call may allocate; every not-yet-written
+        // deferred slot still physically holds the `nil` the caller
+        // stored, so the frame stays GC-consistent throughout).
+        for (dst, table) in wb.forward_kwrest.clone() {
+            self.gen_forward_kwrest_materialize(dst, &table);
+        }
+    }
+
+    /// K1: rebuild a deferred `**kwrest` Hash from the caller's kw
+    /// slots and store it into `dst` (the trampoline's kwrest local).
+    /// Same caller addressing as `gen_forward_rest_materialize`; the
+    /// caller `Lfp` handed to `correct_rest_kw` is derived from the
+    /// saved caller rbp (`lfp == rbp - RBP_LOCAL_FRAME` in every JIT
+    /// frame).
+    fn gen_forward_kwrest_materialize(&mut self, dst: SlotId, table: &[(IdentId, SlotId)]) {
+        let data = self.const_align8();
+        for (name, slot) in table {
+            self.const_i32(name.get() as i32);
+            self.const_i32(slot.0 as i32);
+        }
+        self.const_i32(0);
+        self.const_i32(0);
+        monoasm! { self,
+            movq rsi, [rbp];
+            subq rsi, (RBP_LOCAL_FRAME);
+            lea  rdi, [rip + data];
+            movq rax, (runtime::correct_rest_kw);
+            call rax;
+            movq [r14 - (conv(dst))], rax;
         }
     }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1558,6 +1558,13 @@ pub(super) enum AsmInst {
         /// guarding `f`'s rest `Array`. No fallback (the structural gate
         /// guarantees exact arity and a nil forwarded `**kwrest`).
         deferred_src: Option<(SlotId, u16)>,
+        /// K1: per-callee-kw-param caller source slots when the
+        /// trampoline's deferred literal keywords statically bind to the
+        /// callee's declaration. `route[i]` is the caller slot feeding
+        /// callee kw param `i` (at `kw_reg_pos() + i`), or `None` for an
+        /// absent optional keyword (0-filled; the callee prologue runs
+        /// its default). Only ever `Some` together with `deferred_src`.
+        kw_route: Option<Box<[Option<SlotId>]>>,
     },
 
     ///

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1291,6 +1291,48 @@ impl AbstractState {
     ///
     /// Set positional and keyword arguments for callee.
     ///
+    /// K1: the per-callee-kw-param caller source slots when this frame's
+    /// deferred literal keywords statically bind to `callee`'s keyword
+    /// declaration: every passed name declared, every required name
+    /// passed, and no `**kwrest` on the callee (a leftover hash would
+    /// need building). `route[i]` feeds callee kw param `i` (at
+    /// `kw_reg_pos() + i`); `None` 0-fills an absent optional keyword so
+    /// the callee prologue runs its default.
+    fn kw_forward_route(
+        &self,
+        _callsite: &CallSiteInfo,
+        callee: &FuncInfo,
+    ) -> Option<Box<[Option<SlotId>]>> {
+        let df = self.deferred_forward_info()?;
+        if callee.kw_rest().is_some() {
+            return None;
+        }
+        let kw_names = callee.kw_names();
+        let Some((_, kw_pos, names)) = df.kw.as_ref() else {
+            // The caller passed no keywords at all: routable iff every
+            // callee keyword is optional — an all-None route 0-fills
+            // them so their defaults run. (A required keyword must
+            // raise, which only the generic path does.)
+            if (0..kw_names.len()).any(|i| callee.kw_is_required(i)) {
+                return None;
+            }
+            return Some(vec![None; kw_names.len()].into_boxed_slice());
+        };
+        if !names.iter().all(|n| kw_names.contains(n)) {
+            return None;
+        }
+        let route: Box<[Option<SlotId>]> = kw_names
+            .iter()
+            .map(|pn| names.iter().position(|n| n == pn).map(|idx| *kw_pos + idx))
+            .collect();
+        for (i, r) in route.iter().enumerate() {
+            if callee.kw_is_required(i) && r.is_none() {
+                return None;
+            }
+        }
+        Some(route)
+    }
+
     fn set_arguments(
         &mut self,
         store: &Store,
@@ -1418,7 +1460,20 @@ impl AbstractState {
             // fill kw rest param.
             if let Some(kw_rest) = callee.kw_rest() {
                 let ofs = stack_offset - (LFP_SELF + kw_rest.0 as i32 * 8);
-                self.fetch_kwrest_for_callee(ir, rest_kw, ofs);
+                if defer_rest && !rest_kw.is_empty() {
+                    // K1: the specialized trampoline body source-routed
+                    // these literal keywords straight from our slots;
+                    // store the same GC-safe `nil` the deferred rest
+                    // gets. Spill the kw window first so it is
+                    // memory-resident for the routed reads and for a
+                    // deopt-time Hash rebuild (`forward_kwrest`
+                    // write-back), exactly as the deferred rest spills
+                    // its positional window.
+                    self.write_back_range(ir, kw_pos, kw_num as u16);
+                    ir.u64torsp_offset(NIL_VALUE, ofs);
+                } else {
+                    self.fetch_kwrest_for_callee(ir, rest_kw, ofs);
+                }
             }
 
             ir.reg_add(GP::Rsp, stack_offset);
@@ -1466,7 +1521,15 @@ impl AbstractState {
             // what preserves ruby2_keywords (see `forwarded_fast_path_ok`
             // in runtime/args.rs, which this mirrors); a `...` forward
             // always carries the `**kwrest` hash-splat.
-            && (callee.no_keyword() || (callee.kw_names().is_empty() && callsite.kw_may_exists()))
+            //
+            // K1: a callee that *declares* keywords is also allowed when
+            // the frame's deferred literal keywords statically bind to
+            // that declaration (`kw_forward_route`); the deferred match
+            // below couples the routing with the rest source-routing.
+            && (callee.no_keyword()
+                || (callee.kw_names().is_empty() && callsite.kw_may_exists())
+                || (callsite.kw_may_exists()
+                    && self.kw_forward_route(callsite, callee).is_some()))
             // A block-style callee auto-splats a lone Array argument
             // (`single_arg_expand`); the direct fills below do not model
             // that, so leave those to the generic path — matching the
@@ -1492,6 +1555,24 @@ impl AbstractState {
             let args = callsite.args;
             let lead_num = callsite.pos_num - 1;
             let kwrest_guard = callsite.hash_splat_pos.first().copied();
+            // K1: the deferred literal keywords' static binding to the
+            // callee declaration (None when the frame defers no keywords
+            // or they don't bind; the arm gate only admits a
+            // kw-declaring callee in the bound case).
+            let kw_route = self.kw_forward_route(callsite, callee);
+            // A deferral carrying keywords routes them together with the
+            // rest window or not at all: the routed reads go straight to
+            // the caller frame, which is only sound while the caller-side
+            // skip (one flag covers the array and the hash) is in force.
+            // The routed keywords must come through this callsite's own
+            // `**kwrest` hash-splat slot.
+            let deferred_kw_ok =
+                match self.deferred_forward_info().and_then(|df| df.kw.as_ref()) {
+                    None => true,
+                    Some((kwrest_local, _, _)) => {
+                        kw_route.is_some() && kwrest_guard == Some(*kwrest_local)
+                    }
+                };
             // D1: if `f`'s `...` rest array was deferred at frame entry,
             // route the copy straight from the caller's source slots.
             // Only when the forwarded arity statically binds to `g`'s
@@ -1514,7 +1595,8 @@ impl AbstractState {
                         let n = lead_num + len as usize;
                         callee.req_num() <= n
                             && (callee.is_rest() || n <= callee.reqopt_num())
-                    } && kwrest_guard.is_some() =>
+                    } && kwrest_guard.is_some()
+                        && deferred_kw_ok =>
                 {
                     ir.set_deferred_rest();
                     Some((src, len))
@@ -1523,7 +1605,7 @@ impl AbstractState {
                     // Not source-routed (slot/arity/kwrest mismatch):
                     // this forwarding consume reads `f`'s rest slot as a
                     // real `Array`, so veto the caller-side skip.
-                    if self.deferred_rest_tuple().is_some() {
+                    if self.deferred_forward_info().is_some() {
                         ir.set_needs_rest_array();
                     }
                     None
@@ -1531,7 +1613,7 @@ impl AbstractState {
             };
             self.write_back_recv_and_callargs(ir, callsite);
             if deferred_src.is_some() {
-                // D1 cannot fail: the gate proved the fill layout is a
+                // D1/K1 cannot fail: the gate proved the fill layout is a
                 // compile-time constant, so the lowering has no length
                 // guard, no fallback, and no call that can raise. Emit it
                 // without an error side exit — a `HandleError` here would
@@ -1545,7 +1627,15 @@ impl AbstractState {
                     lead_num,
                     kwrest_guard,
                     deferred_src,
+                    kw_route,
                 });
+            } else if !callee.kw_names().is_empty() {
+                // K1 admitted a kw-declaring callee but the deferral did
+                // not activate: the keywords live in the real kwrest
+                // Hash, which only the generic path binds.
+                let error = ir.new_error(self);
+                ir.push(AsmInst::SetArguments { callid, callee_fid });
+                ir.handle_error(error);
             } else {
                 let error = ir.new_error(self);
                 if callee.opt_num() != 0 || callee.is_rest() || !callee.no_keyword() {
@@ -1566,6 +1656,7 @@ impl AbstractState {
                         lead_num,
                         kwrest_guard,
                         deferred_src,
+                        kw_route: None,
                     });
                 }
                 ir.handle_error(error);
@@ -1608,7 +1699,7 @@ impl AbstractState {
             // taking the generic path.
             // Array-path forwarding consume (callee with opt/post/rest):
             // it reads `f`'s rest slot as a real `Array`.
-            if self.deferred_rest_tuple().is_some() {
+            if self.deferred_forward_info().is_some() {
                 ir.set_needs_rest_array();
             }
             self.write_back_recv_and_callargs(ir, callsite);
@@ -1649,6 +1740,7 @@ impl AbstractState {
                 lead_num: callsite.pos_num - 1,
                 kwrest_guard: None,
                 deferred_src: None,
+                kw_route: None,
             });
             ir.handle_error(error);
         } else {
@@ -1657,7 +1749,7 @@ impl AbstractState {
             // a leading-arg forward like `File.read(@path, ...)`) reads
             // `f`'s rest slot as a real `Array` via the runtime
             // `jit_generic_set_arguments`, so veto the skip.
-            if callsite.forwarding && self.deferred_rest_tuple().is_some() {
+            if callsite.forwarding && self.deferred_forward_info().is_some() {
                 ir.set_needs_rest_array();
             }
             self.write_back_recv_and_callargs(ir, callsite);

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -20,6 +20,26 @@ pub(crate) struct SpecializedId(pub(super) usize);
 /// `base` is the immutable value snapshotted at frame creation. The
 /// difference is what the Loop-JIT-side rsp bump consumes.
 ///
+///
+/// D1/K1 forwarding-deferral record for a specialized pure trampoline
+/// frame (`def f(...) = g(...)`): the caller's positional window that
+/// backs `f`'s un-materialized `...` rest `Array`, plus — when the
+/// caller passes literal keywords — the caller's kw window that backs
+/// `f`'s un-materialized `**kwrest` Hash (K1).
+///
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DeferredForward {
+    /// `f`'s synthetic rest local slot.
+    pub rest_local: SlotId,
+    /// Caller-frame base of the positional source window.
+    pub src: SlotId,
+    /// Positional source count.
+    pub len: u16,
+    /// K1: `(f's **kwrest local, caller kw base, names in slot order)` —
+    /// `names[i]`'s value lives at caller slot `kw_pos + i`.
+    pub kw: Option<(SlotId, SlotId, Box<[IdentId]>)>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct FrameSizes {
     pub(super) total: usize,
@@ -1260,7 +1280,7 @@ impl<'a> JitContext<'a> {
     /// that saved caller `rbp`), `len` its positional count,
     /// `rest_local` `f`'s synthetic rest local slot.
     ///
-    pub(super) fn forward_rest_deferral(&self) -> Option<(SlotId, SlotId, u16)> {
+    pub(super) fn forward_rest_deferral(&self) -> Option<DeferredForward> {
         // D1 deferred-rest is lowered on both backends now: the side-exit
         // `forward_rest` materialize (`gen_forward_rest_materialize` /
         // `a64_gen_forward_rest_materialize`) and the `SetArgumentsForwarded`
@@ -1279,14 +1299,38 @@ impl<'a> JitContext<'a> {
             return None;
         }
         let cs = &self.store[cid];
-        if cs.kw_may_exists() || cs.block_arg.is_some() {
+        // K1: literal keywords at the caller defer alongside the rest —
+        // recorded here as (f's `**kwrest` local, the caller's kw base,
+        // the names in slot order) and either source-routed into the
+        // forwarded callee's declared kw params by the consume or vetoed
+        // as a whole (`needs_rest_array`). A `**hash` splat stays on the
+        // generic path: its keys are dynamic.
+        if !cs.hash_splat_pos.is_empty() || cs.block_arg.is_some() {
             return None;
         }
+        let kw = if cs.kw_args.is_empty() {
+            None
+        } else {
+            // `def f(...)` always declares `**kwrest`.
+            let kwrest_local = self.store[fid].kw_rest()?;
+            // kw_args maps name -> offset from kw_pos; record names in
+            // offset order so `names[i]` lives at `kw_pos + i`.
+            let mut names = vec![IdentId::get_id(""); cs.kw_args.len()];
+            for (name, i) in &cs.kw_args {
+                names[*i] = *name;
+            }
+            Some((kwrest_local, cs.kw_pos, names.into_boxed_slice()))
+        };
         // `pos_num == 0` (e.g. `NoArg.new` through the Ruby `Class#new`)
         // defers to an *empty* source range: the consume copies nothing
         // and the side-exit materialization (`create_array` with len 0)
         // rebuilds `[]` without touching the source pointer.
-        Some((rest_local, cs.args, cs.pos_num as u16))
+        Some(DeferredForward {
+            rest_local,
+            src: cs.args,
+            len: cs.pos_num as u16,
+            kw,
+        })
     }
 
     pub(super) fn position(&self) -> Option<BytecodePtr> {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::codegen::jitgen::context::DeferredForward;
 
 ///
 /// §5 stage 3c-i — the register-allocation **policy** seam.
@@ -257,8 +258,8 @@ pub(crate) struct SlotState {
     /// merge despite living in the cloned `SlotState`.
     pub(in crate::codegen::jitgen) gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile,
     local_num: usize,
-    /// D1 forwarding-rest deferral (transient annotation; see the consumers).
-    deferred_rest: Option<(SlotId, SlotId, u16)>,
+    /// D1/K1 forwarding deferral (transient annotation; see the consumers).
+    deferred_forward: Option<DeferredForward>,
     /// §27.3 Stage-2a: the loop-carried float set `L` for the enclosing loop —
     /// slots that are `F`/`Sf` at the loop back-edge (so they round-trip the
     /// loop). Populated at the loop-entry merge from the fixpoint's back-edge
@@ -297,7 +298,7 @@ impl SlotState {
             fpr_alloc: FprAllocator::new(),
             gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile::new(),
             local_num,
-            deferred_rest: None,
+            deferred_forward: None,
             loop_carried: std::collections::HashSet::new(),
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
@@ -354,8 +355,8 @@ impl SlotState {
         // spurious `C(nil)` write-back can clobber that array. The
         // annotation only routes the consumer and adds the deopt
         // materialization while live.
-        if let Some((dst, src, len)) = cc.forward_rest_deferral() {
-            ctx.deferred_rest = Some((dst, src, len));
+        if let Some(df) = cc.forward_rest_deferral() {
+            ctx.deferred_forward = Some(df);
         }
         ctx
     }
@@ -502,17 +503,17 @@ impl SlotState {
         &self,
         slot: SlotId,
     ) -> Option<(SlotId, u16)> {
-        match self.deferred_rest {
-            Some((dst, src, len)) if dst == slot => Some((src, len)),
+        match &self.deferred_forward {
+            Some(df) if df.rest_local == slot => Some((df.src, df.len)),
             _ => None,
         }
     }
 
-    /// D1: the frame's `(dst, src, len)` deferral annotation, if any.
-    /// Used by array-path forwarding consumers to veto the caller-side
-    /// `create_array` skip (`set_needs_rest_array`).
-    pub(in crate::codegen::jitgen) fn deferred_rest_tuple(&self) -> Option<(SlotId, SlotId, u16)> {
-        self.deferred_rest
+    /// D1/K1: the frame's deferral annotation, if any. Used by
+    /// forwarding consumers to source-route or to veto the caller-side
+    /// skip (`set_needs_rest_array`).
+    pub(in crate::codegen::jitgen) fn deferred_forward_info(&self) -> Option<&DeferredForward> {
+        self.deferred_forward.as_ref()
     }
 
     pub(super) fn is_used(&self, slot: SlotId) -> &IsUsed {
@@ -1362,7 +1363,27 @@ impl AbstractFrame {
     }
 
     fn wb_forward_rest(&self) -> Vec<(SlotId, SlotId, u16)> {
-        self.deferred_rest.into_iter().collect()
+        self.deferred_forward
+            .iter()
+            .map(|df| (df.rest_local, df.src, df.len))
+            .collect()
+    }
+
+    /// K1: the deferred `**kwrest` materialization entries —
+    /// `(f's kwrest local, [(name, caller slot)])`.
+    fn wb_forward_kwrest(&self) -> Vec<(SlotId, Box<[(IdentId, SlotId)]>)> {
+        self.deferred_forward
+            .iter()
+            .filter_map(|df| {
+                let (dst, kw_pos, names) = df.kw.as_ref()?;
+                let table = names
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| (*name, *kw_pos + i))
+                    .collect();
+                Some((*dst, table))
+            })
+            .collect()
     }
 
     pub(super) fn get_gc_write_back(&self) -> WriteBack {
@@ -1379,7 +1400,7 @@ impl AbstractFrame {
         // registers themselves survive the collection — `exec_gc` preserves the
         // caller-saved set). Empty without the feature.
         let gp = self.gp_regfile.dirty_residents();
-        WriteBack::new(vec![], literal, void, gp, vec![])
+        WriteBack::new(vec![], literal, void, gp, vec![], vec![])
     }
 
     pub(crate) fn get_write_back(&self) -> WriteBack {
@@ -1390,7 +1411,14 @@ impl AbstractFrame {
         // register) so a deopt resuming in the VM reads them from their stack
         // home. Empty without the feature.
         let gp = self.gp_regfile.dirty_residents();
-        WriteBack::new(fpr, literal, vec![], gp, self.wb_forward_rest())
+        WriteBack::new(
+            fpr,
+            literal,
+            vec![],
+            gp,
+            self.wb_forward_rest(),
+            self.wb_forward_kwrest(),
+        )
     }
 
     fn fpr_swap(&mut self, l: FPReg, r: FPReg) {

--- a/monoruby/tests/kwargs_forward.rs
+++ b/monoruby/tests/kwargs_forward.rs
@@ -1,0 +1,169 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// K1: literal keyword arguments at a `X.new(...)`-style call site are
+// source-routed through the pure forwarding trampoline (`Class#new`'s
+// `def new(...)`) straight into the callee's declared keyword
+// parameters, skipping the `**kwrest` Hash round trip. These tests pin
+// the routed fast path, its static-veto fallbacks, and the deopt
+// materialization against CRuby.
+
+#[test]
+fn new_with_literal_kwargs() {
+    run_test(
+        r#"
+        class Node
+          attr_reader :pos, :name, :dirs, :sels, :file, :src
+          def initialize(pos: nil, name: "d", dirs: [], sels: nil, file: nil, src: :none)
+            @pos = pos; @name = name; @dirs = dirs
+            @sels = sels; @file = file; @src = src
+          end
+        end
+        r = []
+        30.times do |i|
+          n = Node.new(pos: i, name: "x#{i}", sels: [i])
+          r << [n.pos, n.name, n.dirs, n.sels, n.file, n.src]
+        end
+        30.times do |i|
+          n = Node.new
+          m = Node.new(src: i, pos: 0)
+          r << [n.pos, n.src, m.src, m.pos]
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_with_positionals_and_required() {
+    run_test(
+        r#"
+        class Mix
+          attr_reader :v
+          def initialize(x, y = 7, k: :k, j: nil) = @v = [x, y, k, j]
+        end
+        class Req
+          attr_reader :v
+          def initialize(a:, b: 2) = @v = [a, b]
+        end
+        r = []
+        30.times do |i|
+          r << Mix.new(i, k: i).v << Mix.new(i, 2, k: 3, j: 4).v << Mix.new(i).v
+          r << Req.new(a: i).v << Req.new(b: i, a: -1).v
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_error_cases_stay_generic() {
+    // Missing required / unknown keyword must still raise ArgumentError
+    // (the static veto keeps these on the generic runtime path).
+    run_test(
+        r#"
+        class Req
+          def initialize(a:, b: 2) = @x = [a, b]
+        end
+        r = []
+        30.times do
+          begin
+            Req.new(b: 1)
+          rescue ArgumentError => e
+            r << e.message
+          end
+          begin
+            Req.new(a: 1, z: 9)
+          rescue ArgumentError => e
+            r << e.message
+          end
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_kwrest_callee_vetoed() {
+    // A callee with `**rest` collects the leftovers — not routable, must
+    // keep last-one-wins Hash semantics via the generic path.
+    run_test(
+        r#"
+        class KwR
+          attr_reader :h
+          def initialize(a: 1, **h) = @h = [a, h]
+        end
+        r = []
+        30.times do |i|
+          r << KwR.new(a: i, z: 9, w: i).h << KwR.new.h
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_hash_splat_vetoed() {
+    // `X.new(**h)` carries a dynamic hash-splat: no deferral, generic
+    // path, same results.
+    run_test(
+        r#"
+        class N
+          attr_reader :v
+          def initialize(a: 0, b: 1) = @v = [a, b]
+        end
+        r = []
+        h = {a: 5, b: 6}
+        30.times do |i|
+          r << N.new(**h).v << N.new(a: i, **{b: i}).v
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_redefinition_deopt() {
+    // Redefining initialize mid-loop invalidates the specialized
+    // trampoline; the transition (deopt + recompile) must keep binding
+    // the routed keywords correctly.
+    run_test_once(
+        r#"
+        class D
+          attr_reader :v
+          def initialize(k: 0) = @v = k
+        end
+        r = []
+        40.times do |i|
+          r << D.new(k: i).v
+          if i == 25
+            class D
+              def initialize(k: 0) = @v = k + 100
+            end
+          end
+        end
+        r
+        "#,
+    );
+}
+
+#[test]
+fn new_kwargs_heap_values_gc() {
+    // Routed keyword values are heap objects; the deferral window (nil
+    // kwrest, values only in caller slots) must keep them alive across
+    // the callee-entry GC poll.
+    run_test(
+        r#"
+        class H
+          attr_reader :a, :b
+          def initialize(a: nil, b: nil) = (@a = a; @b = b)
+        end
+        r = 0
+        200.times do |i|
+          o = H.new(a: "s#{i}" * 10, b: [i, i + 1])
+          r += o.a.size + o.b.sum
+        end
+        r
+        "#,
+    );
+}


### PR DESCRIPTION
## Summary

`X.new(k: v, …)` paid a full keyword round trip: the outer call site materialized a `**kwrest` Hash for the Ruby `Class#new` trampoline (`def new(...)`), and the forwarded `initialize` unpacked it again through the generic runtime binding (`handle_keyword`) — per-name map lookups, SipHash, and a Hash allocation on every construction. 1M six-keyword `new`s: **826ms vs CRuby's 216ms**, even though a *direct* kwarg call was already 2.4× **faster** than CRuby (the simple-call JIT path binds keywords statically). This is the dominant remaining cost in ruby-bench **graphql**, whose parser builds every AST node with 5–7 kwargs through `Nodes::X.new`.

## How: extend the D1 rest deferral to keywords (K1)

When a specialized pure forwarding trampoline's caller passes only **literal** keywords, the kwrest Hash is deferred exactly like the rest Array:

- the caller spills its kw window and stores `nil` into the trampoline's kwrest slot (one flag pair covers array and hash — both defer together or not at all);
- the forwarding consume routes each keyword **straight from the caller's frame slots** into the callee's declared kw registers (via the saved caller frame pointer, like D1's positional window); absent optionals are 0-filled so the callee prologue runs their defaults;
- a kw-less deferral also routes into a kw-declaring callee when every keyword is optional (all-None route), so plain `X.new` with a kw-defaulted `initialize` takes the fast path too.

**Statically unroutable shapes veto the deferral** and keep the generic path with its exact errors: an undeclared keyword (unknown-keyword ArgumentError), a missing required keyword, a callee `**kwrest` (leftover collection), or a dynamic `**hash` splat at the outer site.

**Deopt**: a side exit inside the deferral window rebuilds the kwrest Hash from the caller's kw slots via the existing `correct_rest_kw` helper (caller `Lfp` derived from the saved caller frame pointer), mirroring the rest-array materialization; `WriteBack` carries the `(dst, name→slot)` table. Lowered on x86_64 and aarch64.

## Results

| microbench (1M calls) | CRuby | before | after |
|---|---|---|---|
| `X.new(6 kwargs)` | 216ms | 826ms | **71ms (11.6×)** |
| `X.new` (kw-defaulted initialize) | 136ms | 238ms | **44ms** |
| direct kwarg call (unchanged) | 135ms | 56ms | 56ms |

ruby-bench **graphql**: 0.14s → **0.09s** (CRuby 0.078s — the gap is now ~1.2×, from 3.6× at the start of this series). tinygql unchanged (0.46s, faster than CRuby's 0.65s).

## Verification

- `cargo nextest run --no-fail-fast`: **3141 / 3141 passed**
- New `tests/kwargs_forward.rs` (all vs CRuby): the routed path, positional+kw mix, required kws, every veto (unknown kw, missing required, callee `**kwrest`, outer `**splat`), mid-loop `initialize` redefinition (deopt transition), and heap-object keyword values across the deferral window — **also all passing under `gc-stress`** (a collection at every safepoint exercises the nil-kwrest window's GC consistency)
- ruby/spec `language/keyword_arguments` + `language/def` + `core/basicobject`: 267 examples, 0 failures
- aarch64: `cargo check --target aarch64-unknown-linux-gnu` clean; both lowerings implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_